### PR TITLE
feat(apple-music): Complete Apple Music support (Epic 17)

### DIFF
--- a/custom_components/beatify/playlists/eurovision-winners.json
+++ b/custom_components/beatify/playlists/eurovision-winners.json
@@ -7,137 +7,245 @@
       "uri": "spotify:track:3ijeTyo5ggRvM0DTfZflBB",
       "artist": "Lys Assia",
       "title": "Refrain",
-      "chart_info": {"eurovision_position": 1, "country": "Switzerland"},
+      "chart_info": {
+        "eurovision_position": 1,
+        "country": "Switzerland"
+      },
       "certifications": [],
-      "awards": ["Eurovision Winner 1956"],
-      "awards_de": ["Eurovision-Sieger 1956"],
-      "awards_es": ["Ganador de Eurovision 1956"],
+      "awards": [
+        "Eurovision Winner 1956"
+      ],
+      "awards_de": [
+        "Eurovision-Sieger 1956"
+      ],
+      "awards_es": [
+        "Ganador de Eurovision 1956"
+      ],
       "fun_fact": "Refrain won the very first Eurovision Song Contest held in Lugano, Switzerland. Lys Assia was the only competitor from Switzerland and won with a simple, elegant performance. The 1956 contest had no public voting system - only jury votes counted.",
       "fun_fact_de": "Refrain gewann den allerersten Eurovision Song Contest in Lugano, Schweiz. Lys Assia war die einzige Vertreterin der Schweiz und siegte mit einer schlichten, eleganten Darbietung. Beim Wettbewerb 1956 gab es noch keine offentliche Abstimmung - nur die Jury-Stimmen zahlten.",
-      "fun_fact_es": "Refrain gano el primer Festival de Eurovision celebrado en Lugano, Suiza. Lys Assia era la unica representante de Suiza y triunfo con una actuacion sencilla y elegante. El concurso de 1956 no tenia sistema de votacion publica - solo contaban los votos del jurado."
+      "fun_fact_es": "Refrain gano el primer Festival de Eurovision celebrado en Lugano, Suiza. Lys Assia era la unica representante de Suiza y triunfo con una actuacion sencilla y elegante. El concurso de 1956 no tenia sistema de votacion publica - solo contaban los votos del jurado.",
+      "uri_apple_music": "applemusic://track/254285129"
     },
     {
       "year": 1957,
       "uri": "spotify:track:1I9fugKDEYETuxJME3aesv",
       "artist": "Corry Brokken",
       "title": "Net Als Toen",
-      "chart_info": {"eurovision_position": 1, "eurovision_points": 31, "country": "Netherlands"},
+      "chart_info": {
+        "eurovision_position": 1,
+        "eurovision_points": 31,
+        "country": "Netherlands"
+      },
       "certifications": [],
-      "awards": ["Eurovision Winner 1957"],
-      "awards_de": ["Eurovision-Sieger 1957"],
-      "awards_es": ["Ganador de Eurovision 1957"],
+      "awards": [
+        "Eurovision Winner 1957"
+      ],
+      "awards_de": [
+        "Eurovision-Sieger 1957"
+      ],
+      "awards_es": [
+        "Ganador de Eurovision 1957"
+      ],
       "fun_fact": "Net Als Toen (Just Like Then) gave the Netherlands their first Eurovision victory. Corry Brokken had previously competed in 1956, placing seventh. She remains one of few artists to win after a previous Eurovision appearance.",
       "fun_fact_de": "Net Als Toen (Genau wie damals) bescherte den Niederlanden ihren ersten Eurovision-Sieg. Corry Brokken hatte bereits 1956 teilgenommen und den siebten Platz belegt. Sie gehort zu den wenigen Kunstlern, die nach einer fruheren Eurovision-Teilnahme gewonnen haben.",
-      "fun_fact_es": "Net Als Toen (Igual que entonces) dio a los Paises Bajos su primera victoria en Eurovision. Corry Brokken habia competido previamente en 1956, quedando en septimo lugar. Sigue siendo una de las pocas artistas en ganar tras una participacion anterior en Eurovision."
+      "fun_fact_es": "Net Als Toen (Igual que entonces) dio a los Paises Bajos su primera victoria en Eurovision. Corry Brokken habia competido previamente en 1956, quedando en septimo lugar. Sigue siendo una de las pocas artistas en ganar tras una participacion anterior en Eurovision.",
+      "uri_apple_music": "applemusic://track/986305357"
     },
     {
       "year": 1958,
       "uri": "spotify:track:3W05oiilHd4xRcLb66N51o",
       "artist": "Andre Claveau",
       "title": "Dors mon amour",
-      "chart_info": {"eurovision_position": 1, "eurovision_points": 27, "country": "France"},
+      "chart_info": {
+        "eurovision_position": 1,
+        "eurovision_points": 27,
+        "country": "France"
+      },
       "certifications": [],
-      "awards": ["Eurovision Winner 1958"],
-      "awards_de": ["Eurovision-Sieger 1958"],
-      "awards_es": ["Ganador de Eurovision 1958"],
+      "awards": [
+        "Eurovision Winner 1958"
+      ],
+      "awards_de": [
+        "Eurovision-Sieger 1958"
+      ],
+      "awards_es": [
+        "Ganador de Eurovision 1958"
+      ],
       "fun_fact": "Dors mon amour (Sleep My Love) was a gentle lullaby that won France their first Eurovision title. Andre Claveau was already a well-established French chansonnier before his victory, known for his smooth vocal style.",
       "fun_fact_de": "Dors mon amour (Schlaf, meine Liebe) war ein sanftes Schlaflied, das Frankreich seinen ersten Eurovision-Titel brachte. Andre Claveau war bereits vor seinem Sieg ein etablierter franzosischer Chansonnier, bekannt fur seinen samtigen Gesangsstil.",
-      "fun_fact_es": "Dors mon amour (Duerme, mi amor) fue una suave cancion de cuna que dio a Francia su primer titulo en Eurovision. Andre Claveau ya era un reconocido cantante de chanson frances antes de su victoria, conocido por su estilo vocal aterciopelado."
+      "fun_fact_es": "Dors mon amour (Duerme, mi amor) fue una suave cancion de cuna que dio a Francia su primer titulo en Eurovision. Andre Claveau ya era un reconocido cantante de chanson frances antes de su victoria, conocido por su estilo vocal aterciopelado.",
+      "uri_apple_music": "applemusic://track/794472283"
     },
     {
       "year": 1959,
       "uri": "spotify:track:6fQfOgajFEdUTOvAQNoinK",
       "artist": "Teddy Scholten",
       "title": "Een Beetje",
-      "chart_info": {"eurovision_position": 1, "eurovision_points": 21, "country": "Netherlands"},
+      "chart_info": {
+        "eurovision_position": 1,
+        "eurovision_points": 21,
+        "country": "Netherlands"
+      },
       "certifications": [],
-      "awards": ["Eurovision Winner 1959"],
-      "awards_de": ["Eurovision-Sieger 1959"],
-      "awards_es": ["Ganador de Eurovision 1959"],
+      "awards": [
+        "Eurovision Winner 1959"
+      ],
+      "awards_de": [
+        "Eurovision-Sieger 1959"
+      ],
+      "awards_es": [
+        "Ganador de Eurovision 1959"
+      ],
       "fun_fact": "Een Beetje (A Little Bit) became a surprise international hit, reaching the charts in multiple countries. Teddy Scholten's playful performance gave the Netherlands their second Eurovision victory in three years.",
       "fun_fact_de": "Een Beetje (Ein bisschen) wurde uberraschend ein internationaler Hit und erreichte die Charts in mehreren Landern. Teddy Scholtens verspielte Darbietung brachte den Niederlanden ihren zweiten Eurovision-Sieg innerhalb von drei Jahren.",
-      "fun_fact_es": "Een Beetje (Un poquito) se convirtio en un exito internacional inesperado, llegando a las listas de varios paises. La alegre actuacion de Teddy Scholten dio a los Paises Bajos su segunda victoria en Eurovision en tres anos."
+      "fun_fact_es": "Een Beetje (Un poquito) se convirtio en un exito internacional inesperado, llegando a las listas de varios paises. La alegre actuacion de Teddy Scholten dio a los Paises Bajos su segunda victoria en Eurovision en tres anos.",
+      "uri_apple_music": "applemusic://track/420371297"
     },
     {
       "year": 1960,
       "uri": "spotify:track:2ExzWeo5f3FL9pn61hhOJp",
       "artist": "Jacqueline Boyer",
       "title": "Tom Pillibi",
-      "chart_info": {"eurovision_position": 1, "eurovision_points": 32, "country": "France"},
+      "chart_info": {
+        "eurovision_position": 1,
+        "eurovision_points": 32,
+        "country": "France"
+      },
       "certifications": [],
-      "awards": ["Eurovision Winner 1960"],
-      "awards_de": ["Eurovision-Sieger 1960"],
-      "awards_es": ["Ganador de Eurovision 1960"],
+      "awards": [
+        "Eurovision Winner 1960"
+      ],
+      "awards_de": [
+        "Eurovision-Sieger 1960"
+      ],
+      "awards_es": [
+        "Ganador de Eurovision 1960"
+      ],
       "fun_fact": "Tom Pillibi tells the story of a charming liar who makes up fantastic tales. Jacqueline Boyer was only 18 years old when she won, and her mother Lucienne Boyer was also a famous French singer.",
       "fun_fact_de": "Tom Pillibi erzahlt die Geschichte eines charmanten Lugners, der fantastische Geschichten erfindet. Jacqueline Boyer war erst 18 Jahre alt, als sie gewann, und ihre Mutter Lucienne Boyer war ebenfalls eine beruhmte franzosische Sangerin.",
-      "fun_fact_es": "Tom Pillibi cuenta la historia de un mentiroso encantador que inventa relatos fantasticos. Jacqueline Boyer tenia solo 18 anos cuando gano, y su madre Lucienne Boyer tambien era una famosa cantante francesa."
+      "fun_fact_es": "Tom Pillibi cuenta la historia de un mentiroso encantador que inventa relatos fantasticos. Jacqueline Boyer tenia solo 18 anos cuando gano, y su madre Lucienne Boyer tambien era una famosa cantante francesa.",
+      "uri_apple_music": "applemusic://track/1484516430"
     },
     {
       "year": 1961,
       "uri": "spotify:track:35PWl4T8d2U3a5AboajXXw",
       "artist": "Jean-Claude Pascal",
       "title": "Nous les amoureux",
-      "chart_info": {"eurovision_position": 1, "eurovision_points": 31, "country": "Luxembourg"},
+      "chart_info": {
+        "eurovision_position": 1,
+        "eurovision_points": 31,
+        "country": "Luxembourg"
+      },
       "certifications": [],
-      "awards": ["Eurovision Winner 1961"],
-      "awards_de": ["Eurovision-Sieger 1961"],
-      "awards_es": ["Ganador de Eurovision 1961"],
+      "awards": [
+        "Eurovision Winner 1961"
+      ],
+      "awards_de": [
+        "Eurovision-Sieger 1961"
+      ],
+      "awards_es": [
+        "Ganador de Eurovision 1961"
+      ],
       "fun_fact": "Nous les amoureux (We the Lovers) was Luxembourg's first Eurovision victory. Jean-Claude Pascal was primarily known as a film actor before his singing career. The song's theme of forbidden love resonated with audiences across Europe.",
       "fun_fact_de": "Nous les amoureux (Wir Liebenden) war Luxemburgs erster Eurovision-Sieg. Jean-Claude Pascal war vor seiner Gesangskarriere hauptsachlich als Filmschauspieler bekannt. Das Thema der verbotenen Liebe fand beim Publikum in ganz Europa Anklang.",
-      "fun_fact_es": "Nous les amoureux (Nosotros los enamorados) fue la primera victoria de Luxemburgo en Eurovision. Jean-Claude Pascal era conocido principalmente como actor de cine antes de su carrera musical. El tema del amor prohibido resono con el publico de toda Europa."
+      "fun_fact_es": "Nous les amoureux (Nosotros los enamorados) fue la primera victoria de Luxemburgo en Eurovision. Jean-Claude Pascal era conocido principalmente como actor de cine antes de su carrera musical. El tema del amor prohibido resono con el publico de toda Europa.",
+      "uri_apple_music": "applemusic://track/695906718"
     },
     {
       "year": 1962,
       "uri": "spotify:track:64EE5jxbZLyb2SElNSyuUD",
       "artist": "Isabelle Aubret",
       "title": "Un premier amour",
-      "chart_info": {"eurovision_position": 1, "eurovision_points": 26, "country": "France"},
+      "chart_info": {
+        "eurovision_position": 1,
+        "eurovision_points": 26,
+        "country": "France"
+      },
       "certifications": [],
-      "awards": ["Eurovision Winner 1962"],
-      "awards_de": ["Eurovision-Sieger 1962"],
-      "awards_es": ["Ganador de Eurovision 1962"],
+      "awards": [
+        "Eurovision Winner 1962"
+      ],
+      "awards_de": [
+        "Eurovision-Sieger 1962"
+      ],
+      "awards_es": [
+        "Ganador de Eurovision 1962"
+      ],
       "fun_fact": "Un premier amour (A First Love) secured France's third Eurovision victory. Isabelle Aubret survived a near-fatal car accident in 1963 but made a remarkable comeback. She represented France again in 1968, finishing third.",
       "fun_fact_de": "Un premier amour (Eine erste Liebe) sicherte Frankreich seinen dritten Eurovision-Sieg. Isabelle Aubret uberlebte 1963 einen beinahe todlichen Autounfall, feierte aber ein bemerkenswertes Comeback. 1968 vertrat sie Frankreich erneut und belegte den dritten Platz.",
-      "fun_fact_es": "Un premier amour (Un primer amor) aseguro la tercera victoria de Francia en Eurovision. Isabelle Aubret sobrevivio a un accidente de coche casi mortal en 1963, pero hizo un regreso extraordinario. Represento a Francia nuevamente en 1968, quedando tercera."
+      "fun_fact_es": "Un premier amour (Un primer amor) aseguro la tercera victoria de Francia en Eurovision. Isabelle Aubret sobrevivio a un accidente de coche casi mortal en 1963, pero hizo un regreso extraordinario. Represento a Francia nuevamente en 1968, quedando tercera.",
+      "uri_apple_music": "applemusic://track/1682977904"
     },
     {
       "year": 1963,
       "uri": "spotify:track:1oIVUqdVUFouSa6xsSN5aM",
       "artist": "Grethe Ingmann;Jorgen Ingmann",
       "title": "Dansevise",
-      "chart_info": {"eurovision_position": 1, "eurovision_points": 42, "country": "Denmark"},
+      "chart_info": {
+        "eurovision_position": 1,
+        "eurovision_points": 42,
+        "country": "Denmark"
+      },
       "certifications": [],
-      "awards": ["Eurovision Winner 1963"],
-      "awards_de": ["Eurovision-Sieger 1963"],
-      "awards_es": ["Ganador de Eurovision 1963"],
+      "awards": [
+        "Eurovision Winner 1963"
+      ],
+      "awards_de": [
+        "Eurovision-Sieger 1963"
+      ],
+      "awards_es": [
+        "Ganador de Eurovision 1963"
+      ],
       "fun_fact": "Dansevise (Dancing Ballad) gave Denmark their first and only Eurovision victory for 37 years. Grethe and Jorgen Ingmann were a married couple, and Jorgen was already internationally known for his guitar instrumental 'Apache'.",
       "fun_fact_de": "Dansevise (Tanzballade) bescherte Danemark seinen ersten und fur 37 Jahre einzigen Eurovision-Sieg. Grethe und Jorgen Ingmann waren ein Ehepaar, und Jorgen war bereits international bekannt fur sein Gitarreninstrumental 'Apache'.",
-      "fun_fact_es": "Dansevise (Balada de baile) dio a Dinamarca su primera y unica victoria en Eurovision durante 37 anos. Grethe y Jorgen Ingmann eran un matrimonio, y Jorgen ya era conocido internacionalmente por su instrumental de guitarra 'Apache'."
+      "fun_fact_es": "Dansevise (Balada de baile) dio a Dinamarca su primera y unica victoria en Eurovision durante 37 anos. Grethe y Jorgen Ingmann eran un matrimonio, y Jorgen ya era conocido internacionalmente por su instrumental de guitarra 'Apache'.",
+      "uri_apple_music": "applemusic://track/1235564140"
     },
     {
       "year": 1964,
       "uri": "spotify:track:07rZol7bEXJSUHIcwah0eq",
       "artist": "Gigliola Cinquetti",
       "title": "Non ho l'eta (Per amarti)",
-      "chart_info": {"eurovision_position": 1, "eurovision_points": 49, "country": "Italy"},
+      "chart_info": {
+        "eurovision_position": 1,
+        "eurovision_points": 49,
+        "country": "Italy"
+      },
       "certifications": [],
-      "awards": ["Eurovision Winner 1964"],
-      "awards_de": ["Eurovision-Sieger 1964"],
-      "awards_es": ["Ganador de Eurovision 1964"],
+      "awards": [
+        "Eurovision Winner 1964"
+      ],
+      "awards_de": [
+        "Eurovision-Sieger 1964"
+      ],
+      "awards_es": [
+        "Ganador de Eurovision 1964"
+      ],
       "fun_fact": "Non ho l'eta (I'm Not Old Enough) was performed by 16-year-old Gigliola Cinquetti, one of the youngest ever Eurovision winners. The song became a massive international hit and is considered one of Eurovision's greatest winning songs.",
       "fun_fact_de": "Non ho l'eta (Ich bin nicht alt genug) wurde von der 16-jahrigen Gigliola Cinquetti vorgetragen, einer der jungsten Eurovision-Siegerinnen uberhaupt. Das Lied wurde ein riesiger internationaler Hit und gilt als eines der grossten Eurovision-Siegerlieder.",
-      "fun_fact_es": "Non ho l'eta (No tengo edad) fue interpretada por Gigliola Cinquetti de 16 anos, una de las ganadoras mas jovenes de Eurovision. La cancion se convirtio en un gran exito internacional y se considera una de las mejores canciones ganadoras de Eurovision."
+      "fun_fact_es": "Non ho l'eta (No tengo edad) fue interpretada por Gigliola Cinquetti de 16 anos, una de las ganadoras mas jovenes de Eurovision. La cancion se convirtio en un gran exito internacional y se considera una de las mejores canciones ganadoras de Eurovision.",
+      "uri_apple_music": "applemusic://track/297960817"
     },
     {
       "year": 1965,
       "uri": "spotify:track:68jKFhKRqnatqtLYIiz3c1",
       "artist": "France Gall",
       "title": "Poupee de cire poupee de son",
-      "chart_info": {"eurovision_position": 1, "eurovision_points": 32, "country": "Luxembourg"},
+      "chart_info": {
+        "eurovision_position": 1,
+        "eurovision_points": 32,
+        "country": "Luxembourg"
+      },
       "certifications": [],
-      "awards": ["Eurovision Winner 1965"],
-      "awards_de": ["Eurovision-Sieger 1965"],
-      "awards_es": ["Ganador de Eurovision 1965"],
+      "awards": [
+        "Eurovision Winner 1965"
+      ],
+      "awards_de": [
+        "Eurovision-Sieger 1965"
+      ],
+      "awards_es": [
+        "Ganador de Eurovision 1965"
+      ],
       "fun_fact": "Poupee de cire, poupee de son (Wax Doll, Rag Doll) was written by legendary French songwriter Serge Gainsbourg. France Gall was only 17 and reportedly unaware of the song's double meanings. It became a defining ye-ye pop classic.",
       "fun_fact_de": "Poupee de cire, poupee de son (Wachspuppe, Stoffpuppe) wurde vom legendaren franzosischen Liedermacher Serge Gainsbourg geschrieben. France Gall war erst 17 und wusste angeblich nichts von den Doppeldeutigkeiten des Liedes. Es wurde zu einem pragenden Ye-Ye-Pop-Klassiker.",
       "fun_fact_es": "Poupee de cire, poupee de son (Muneca de cera, muneca de trapo) fue escrita por el legendario compositor frances Serge Gainsbourg. France Gall tenia solo 17 anos y supuestamente desconocia los dobles sentidos de la cancion. Se convirtio en un clasico definitivo del pop ye-ye."
@@ -147,179 +255,327 @@
       "uri": "spotify:track:07MEgnJdMyU2vNjOMskxSu",
       "artist": "Udo Jurgens",
       "title": "Merci Cherie",
-      "chart_info": {"eurovision_position": 1, "eurovision_points": 31, "country": "Austria"},
+      "chart_info": {
+        "eurovision_position": 1,
+        "eurovision_points": 31,
+        "country": "Austria"
+      },
       "certifications": [],
-      "awards": ["Eurovision Winner 1966"],
-      "awards_de": ["Eurovision-Sieger 1966"],
-      "awards_es": ["Ganador de Eurovision 1966"],
+      "awards": [
+        "Eurovision Winner 1966"
+      ],
+      "awards_de": [
+        "Eurovision-Sieger 1966"
+      ],
+      "awards_es": [
+        "Ganador de Eurovision 1966"
+      ],
       "fun_fact": "Merci Cherie was Austria's first Eurovision victory. Udo Jurgens had competed twice before (1964, 1965) before finally winning. He became one of Europe's most successful artists, selling over 100 million records worldwide.",
       "fun_fact_de": "Merci Cherie war Osterreichs erster Eurovision-Sieg. Udo Jurgens hatte zweimal zuvor teilgenommen (1964, 1965), bevor er endlich gewann. Er wurde einer der erfolgreichsten Kunstler Europas mit uber 100 Millionen verkauften Tonträgern weltweit.",
-      "fun_fact_es": "Merci Cherie fue la primera victoria de Austria en Eurovision. Udo Jurgens habia competido dos veces antes (1964, 1965) antes de finalmente ganar. Se convirtio en uno de los artistas mas exitosos de Europa, vendiendo mas de 100 millones de discos en todo el mundo."
+      "fun_fact_es": "Merci Cherie fue la primera victoria de Austria en Eurovision. Udo Jurgens habia competido dos veces antes (1964, 1965) antes de finalmente ganar. Se convirtio en uno de los artistas mas exitosos de Europa, vendiendo mas de 100 millones de discos en todo el mundo.",
+      "uri_apple_music": "applemusic://track/924201291"
     },
     {
       "year": 1967,
       "uri": "spotify:track:7f5w4aiYgVZrp9w4bNaBLu",
       "artist": "Sandie Shaw",
       "title": "Puppet On A String",
-      "chart_info": {"eurovision_position": 1, "eurovision_points": 47, "country": "United Kingdom"},
+      "chart_info": {
+        "eurovision_position": 1,
+        "eurovision_points": 47,
+        "country": "United Kingdom"
+      },
       "certifications": [],
-      "awards": ["Eurovision Winner 1967"],
-      "awards_de": ["Eurovision-Sieger 1967"],
-      "awards_es": ["Ganador de Eurovision 1967"],
+      "awards": [
+        "Eurovision Winner 1967"
+      ],
+      "awards_de": [
+        "Eurovision-Sieger 1967"
+      ],
+      "awards_es": [
+        "Ganador de Eurovision 1967"
+      ],
       "fun_fact": "Puppet On A String gave the UK their first Eurovision victory. Sandie Shaw famously performed barefoot, which became her trademark. She reportedly disliked the song but it became one of the biggest hits of 1967.",
       "fun_fact_de": "Puppet On A String brachte dem Vereinigten Konigreich seinen ersten Eurovision-Sieg. Sandie Shaw trat beruhmt barfuss auf, was zu ihrem Markenzeichen wurde. Sie mochte das Lied angeblich nicht, aber es wurde einer der grossten Hits von 1967.",
-      "fun_fact_es": "Puppet On A String dio al Reino Unido su primera victoria en Eurovision. Sandie Shaw actuo famosamente descalza, lo que se convirtio en su sello distintivo. Segun se dice, no le gustaba la cancion, pero se convirtio en uno de los mayores exitos de 1967."
+      "fun_fact_es": "Puppet On A String dio al Reino Unido su primera victoria en Eurovision. Sandie Shaw actuo famosamente descalza, lo que se convirtio en su sello distintivo. Segun se dice, no le gustaba la cancion, pero se convirtio en uno de los mayores exitos de 1967.",
+      "uri_apple_music": "applemusic://track/1467380894"
     },
     {
       "year": 1968,
       "uri": "spotify:track:1ApXNkjfjxkSDoezO8Kh8g",
       "artist": "Massiel",
       "title": "La, La, La",
-      "chart_info": {"eurovision_position": 1, "eurovision_points": 29, "country": "Spain"},
+      "chart_info": {
+        "eurovision_position": 1,
+        "eurovision_points": 29,
+        "country": "Spain"
+      },
       "certifications": [],
-      "awards": ["Eurovision Winner 1968"],
-      "awards_de": ["Eurovision-Sieger 1968"],
-      "awards_es": ["Ganador de Eurovision 1968"],
+      "awards": [
+        "Eurovision Winner 1968"
+      ],
+      "awards_de": [
+        "Eurovision-Sieger 1968"
+      ],
+      "awards_es": [
+        "Ganador de Eurovision 1968"
+      ],
       "fun_fact": "La, La, La won Spain's first Eurovision by just one point over Cliff Richard's 'Congratulations'. Massiel replaced the original singer Joan Manuel Serrat just days before the contest after he refused to sing in Spanish instead of Catalan.",
       "fun_fact_de": "La, La, La gewann Spaniens ersten Eurovision-Sieg mit nur einem Punkt Vorsprung vor Cliff Richards 'Congratulations'. Massiel ersetzte den ursprunglichen Sanger Joan Manuel Serrat nur wenige Tage vor dem Wettbewerb, nachdem dieser sich geweigert hatte, auf Spanisch statt auf Katalanisch zu singen.",
-      "fun_fact_es": "La, La, La gano el primer Eurovision de Espana por solo un punto sobre 'Congratulations' de Cliff Richard. Massiel reemplazo al cantante original Joan Manuel Serrat pocos dias antes del concurso despues de que este se negara a cantar en espanol en lugar de catalan."
+      "fun_fact_es": "La, La, La gano el primer Eurovision de Espana por solo un punto sobre 'Congratulations' de Cliff Richard. Massiel reemplazo al cantante original Joan Manuel Serrat pocos dias antes del concurso despues de que este se negara a cantar en espanol en lugar de catalan.",
+      "uri_apple_music": "applemusic://track/1344881200"
     },
     {
       "year": 1969,
       "uri": "spotify:track:31VRNSB6FA4KP7TOkW3k3A",
       "artist": "Lenny Kuhr",
       "title": "De Troubadour",
-      "chart_info": {"eurovision_position": 1, "eurovision_points": 18, "country": "Netherlands"},
+      "chart_info": {
+        "eurovision_position": 1,
+        "eurovision_points": 18,
+        "country": "Netherlands"
+      },
       "certifications": [],
-      "awards": ["Eurovision Winner 1969 (4-way tie)"],
-      "awards_de": ["Eurovision-Sieger 1969 (Vierfacher Gleichstand)"],
-      "awards_es": ["Ganador de Eurovision 1969 (Empate a cuatro)"],
+      "awards": [
+        "Eurovision Winner 1969 (4-way tie)"
+      ],
+      "awards_de": [
+        "Eurovision-Sieger 1969 (Vierfacher Gleichstand)"
+      ],
+      "awards_es": [
+        "Ganador de Eurovision 1969 (Empate a cuatro)"
+      ],
       "fun_fact": "De Troubadour was part of Eurovision's only four-way tie in history. The Netherlands, France, Spain, and UK all shared first place with 18 points each. This controversial result led to rule changes to prevent future ties.",
       "fun_fact_de": "De Troubadour war Teil des einzigen vierfachen Gleichstands in der Eurovision-Geschichte. Die Niederlande, Frankreich, Spanien und das Vereinigte Konigreich teilten sich mit jeweils 18 Punkten den ersten Platz. Dieses umstrittene Ergebnis fuhrte zu Regelanderungen, um zukunftige Gleichstande zu verhindern.",
-      "fun_fact_es": "De Troubadour fue parte del unico empate a cuatro en la historia de Eurovision. Paises Bajos, Francia, Espana y Reino Unido compartieron el primer lugar con 18 puntos cada uno. Este resultado controversial llevo a cambios en las reglas para evitar futuros empates."
+      "fun_fact_es": "De Troubadour fue parte del unico empate a cuatro en la historia de Eurovision. Paises Bajos, Francia, Espana y Reino Unido compartieron el primer lugar con 18 puntos cada uno. Este resultado controversial llevo a cambios en las reglas para evitar futuros empates.",
+      "uri_apple_music": "applemusic://track/1442813455"
     },
     {
       "year": 1969,
       "uri": "spotify:track:0vaRIQTdMIEnXjhWlVS95p",
       "artist": "Lulu",
       "title": "Boom Bang a Bang",
-      "chart_info": {"eurovision_position": 1, "eurovision_points": 18, "country": "United Kingdom"},
+      "chart_info": {
+        "eurovision_position": 1,
+        "eurovision_points": 18,
+        "country": "United Kingdom"
+      },
       "certifications": [],
-      "awards": ["Eurovision Winner 1969 (4-way tie)"],
-      "awards_de": ["Eurovision-Sieger 1969 (Vierfacher Gleichstand)"],
-      "awards_es": ["Ganador de Eurovision 1969 (Empate a cuatro)"],
+      "awards": [
+        "Eurovision Winner 1969 (4-way tie)"
+      ],
+      "awards_de": [
+        "Eurovision-Sieger 1969 (Vierfacher Gleichstand)"
+      ],
+      "awards_es": [
+        "Ganador de Eurovision 1969 (Empate a cuatro)"
+      ],
       "fun_fact": "Boom Bang a Bang was one of four joint winners in 1969. Scottish singer Lulu was already famous for 'Shout' and 'To Sir with Love'. The upbeat, catchy song became a UK chart success despite the shared victory.",
       "fun_fact_de": "Boom Bang a Bang war einer von vier gemeinsamen Siegern 1969. Die schottische Sangerin Lulu war bereits beruhmt fur 'Shout' und 'To Sir with Love'. Das frohliche, eingangige Lied wurde trotz des geteilten Sieges ein Charterfolg in Grossbritannien.",
-      "fun_fact_es": "Boom Bang a Bang fue una de las cuatro canciones ganadoras conjuntas en 1969. La cantante escocesa Lulu ya era famosa por 'Shout' y 'To Sir with Love'. La cancion alegre y pegadiza se convirtio en un exito en las listas del Reino Unido a pesar de la victoria compartida."
+      "fun_fact_es": "Boom Bang a Bang fue una de las cuatro canciones ganadoras conjuntas en 1969. La cantante escocesa Lulu ya era famosa por 'Shout' y 'To Sir with Love'. La cancion alegre y pegadiza se convirtio en un exito en las listas del Reino Unido a pesar de la victoria compartida.",
+      "uri_apple_music": "applemusic://track/1323002159"
     },
     {
       "year": 1969,
       "uri": "spotify:track:059G9tpE3kl6wz3kiddaN0",
       "artist": "Salome",
       "title": "Vivo Cantando",
-      "chart_info": {"eurovision_position": 1, "eurovision_points": 18, "country": "Spain"},
+      "chart_info": {
+        "eurovision_position": 1,
+        "eurovision_points": 18,
+        "country": "Spain"
+      },
       "certifications": [],
-      "awards": ["Eurovision Winner 1969 (4-way tie)"],
-      "awards_de": ["Eurovision-Sieger 1969 (Vierfacher Gleichstand)"],
-      "awards_es": ["Ganador de Eurovision 1969 (Empate a cuatro)"],
+      "awards": [
+        "Eurovision Winner 1969 (4-way tie)"
+      ],
+      "awards_de": [
+        "Eurovision-Sieger 1969 (Vierfacher Gleichstand)"
+      ],
+      "awards_es": [
+        "Ganador de Eurovision 1969 (Empate a cuatro)"
+      ],
       "fun_fact": "Vivo Cantando (I Live Singing) gave Spain a joint victory in 1969. Salome's powerful vocals and dramatic performance style made her a star across the Spanish-speaking world. She went on to have a successful recording career.",
       "fun_fact_de": "Vivo Cantando (Ich lebe singend) brachte Spanien 1969 einen geteilten Sieg. Salomes kraftvolle Stimme und ihr dramatischer Auftritt machten sie zu einem Star in der spanischsprachigen Welt. Sie hatte anschliessend eine erfolgreiche Karriere als Sangerin.",
-      "fun_fact_es": "Vivo Cantando dio a Espana una victoria compartida en 1969. La poderosa voz de Salome y su dramatico estilo de actuacion la convirtieron en una estrella en todo el mundo hispanohablante. Continuo teniendo una exitosa carrera discografica."
+      "fun_fact_es": "Vivo Cantando dio a Espana una victoria compartida en 1969. La poderosa voz de Salome y su dramatico estilo de actuacion la convirtieron en una estrella en todo el mundo hispanohablante. Continuo teniendo una exitosa carrera discografica.",
+      "uri_apple_music": "applemusic://track/175107275"
     },
     {
       "year": 1969,
       "uri": "spotify:track:1XNnJeGSYasJctGndU8mCu",
       "artist": "Frida Boccara",
       "title": "Un jour, un enfant",
-      "chart_info": {"eurovision_position": 1, "eurovision_points": 18, "country": "France"},
+      "chart_info": {
+        "eurovision_position": 1,
+        "eurovision_points": 18,
+        "country": "France"
+      },
       "certifications": [],
-      "awards": ["Eurovision Winner 1969 (4-way tie)"],
-      "awards_de": ["Eurovision-Sieger 1969 (Vierfacher Gleichstand)"],
-      "awards_es": ["Ganador de Eurovision 1969 (Empate a cuatro)"],
+      "awards": [
+        "Eurovision Winner 1969 (4-way tie)"
+      ],
+      "awards_de": [
+        "Eurovision-Sieger 1969 (Vierfacher Gleichstand)"
+      ],
+      "awards_es": [
+        "Ganador de Eurovision 1969 (Empate a cuatro)"
+      ],
       "fun_fact": "Un jour, un enfant (One Day, A Child) completed the historic four-way tie of 1969. Frida Boccara was born in Morocco and became one of France's most respected chanteuses. Her emotional ballad stood out among the tied winners.",
       "fun_fact_de": "Un jour, un enfant (Eines Tages, ein Kind) vervollstandigte den historischen vierfachen Gleichstand von 1969. Frida Boccara wurde in Marokko geboren und wurde eine der angesehensten franzosischen Chansonsangerinnen. Ihre gefuhlvolle Ballade stach unter den punktgleichen Siegern hervor.",
-      "fun_fact_es": "Un jour, un enfant (Un dia, un nino) completo el historico empate a cuatro de 1969. Frida Boccara nacio en Marruecos y se convirtio en una de las cantantes de chanson mas respetadas de Francia. Su emotiva balada destaco entre los ganadores empatados."
+      "fun_fact_es": "Un jour, un enfant (Un dia, un nino) completo el historico empate a cuatro de 1969. Frida Boccara nacio en Marruecos y se convirtio en una de las cantantes de chanson mas respetadas de Francia. Su emotiva balada destaco entre los ganadores empatados.",
+      "uri_apple_music": "applemusic://track/1243859629"
     },
     {
       "year": 1970,
       "uri": "spotify:track:2kwAhlh7BDsJkES19zaYqs",
       "artist": "Dana",
       "title": "All Kinds Of Everything",
-      "chart_info": {"eurovision_position": 1, "eurovision_points": 32, "country": "Ireland"},
+      "chart_info": {
+        "eurovision_position": 1,
+        "eurovision_points": 32,
+        "country": "Ireland"
+      },
       "certifications": [],
-      "awards": ["Eurovision Winner 1970"],
-      "awards_de": ["Eurovision-Sieger 1970"],
-      "awards_es": ["Ganador de Eurovision 1970"],
+      "awards": [
+        "Eurovision Winner 1970"
+      ],
+      "awards_de": [
+        "Eurovision-Sieger 1970"
+      ],
+      "awards_es": [
+        "Ganador de Eurovision 1970"
+      ],
       "fun_fact": "All Kinds Of Everything launched Ireland's Eurovision dominance. Dana was only 18 and still a schoolgirl when she won. The gentle song topped charts across Europe and she later became a member of the European Parliament.",
       "fun_fact_de": "All Kinds Of Everything leitete Irlands Eurovision-Dominanz ein. Dana war erst 18 und noch Schulerin, als sie gewann. Das sanfte Lied fuhrte die Charts in ganz Europa an und sie wurde spater Mitglied des Europaischen Parlaments.",
-      "fun_fact_es": "All Kinds Of Everything inicio el dominio de Irlanda en Eurovision. Dana tenia solo 18 anos y aun era estudiante cuando gano. La suave cancion encabezo las listas de toda Europa y mas tarde se convirtio en miembro del Parlamento Europeo."
+      "fun_fact_es": "All Kinds Of Everything inicio el dominio de Irlanda en Eurovision. Dana tenia solo 18 anos y aun era estudiante cuando gano. La suave cancion encabezo las listas de toda Europa y mas tarde se convirtio en miembro del Parlamento Europeo.",
+      "uri_apple_music": "applemusic://track/1078014787"
     },
     {
       "year": 1971,
       "uri": "spotify:track:15mVQWoiwjwXrs5LBybM0A",
       "artist": "Severine",
       "title": "Un Banc, Un Arbre, Une Rue",
-      "chart_info": {"eurovision_position": 1, "eurovision_points": 128, "country": "Monaco"},
+      "chart_info": {
+        "eurovision_position": 1,
+        "eurovision_points": 128,
+        "country": "Monaco"
+      },
       "certifications": [],
-      "awards": ["Eurovision Winner 1971"],
-      "awards_de": ["Eurovision-Sieger 1971"],
-      "awards_es": ["Ganador de Eurovision 1971"],
+      "awards": [
+        "Eurovision Winner 1971"
+      ],
+      "awards_de": [
+        "Eurovision-Sieger 1971"
+      ],
+      "awards_es": [
+        "Ganador de Eurovision 1971"
+      ],
       "fun_fact": "Un Banc, Un Arbre, Une Rue (A Bench, A Tree, A Street) gave Monaco their only Eurovision victory. Severine was actually French and the song was written by Yves Dessca. The win came at the same contest where new voting rules were introduced.",
       "fun_fact_de": "Un Banc, Un Arbre, Une Rue (Eine Bank, ein Baum, eine Strasse) brachte Monaco seinen einzigen Eurovision-Sieg. Severine war eigentlich Franzosin und das Lied wurde von Yves Dessca geschrieben. Der Sieg kam bei demselben Wettbewerb, bei dem neue Abstimmungsregeln eingefuhrt wurden.",
-      "fun_fact_es": "Un Banc, Un Arbre, Une Rue (Un banco, un arbol, una calle) dio a Monaco su unica victoria en Eurovision. Severine era en realidad francesa y la cancion fue escrita por Yves Dessca. La victoria llego en el mismo concurso donde se introdujeron nuevas reglas de votacion."
+      "fun_fact_es": "Un Banc, Un Arbre, Une Rue (Un banco, un arbol, una calle) dio a Monaco su unica victoria en Eurovision. Severine era en realidad francesa y la cancion fue escrita por Yves Dessca. La victoria llego en el mismo concurso donde se introdujeron nuevas reglas de votacion.",
+      "uri_apple_music": "applemusic://track/104660824"
     },
     {
       "year": 1972,
       "uri": "spotify:track:13tx9je0ftBgu6BKpsQDo4",
       "artist": "Vicky Leandros",
       "title": "Apres toi",
-      "chart_info": {"eurovision_position": 1, "eurovision_points": 128, "country": "Luxembourg"},
+      "chart_info": {
+        "eurovision_position": 1,
+        "eurovision_points": 128,
+        "country": "Luxembourg"
+      },
       "certifications": [],
-      "awards": ["Eurovision Winner 1972"],
-      "awards_de": ["Eurovision-Sieger 1972"],
-      "awards_es": ["Ganador de Eurovision 1972"],
+      "awards": [
+        "Eurovision Winner 1972"
+      ],
+      "awards_de": [
+        "Eurovision-Sieger 1972"
+      ],
+      "awards_es": [
+        "Ganador de Eurovision 1972"
+      ],
       "fun_fact": "Apres toi (After You) is considered one of Eurovision's most beautiful winning songs. Greek-German singer Vicky Leandros had previously represented Luxembourg in 1967. The song became a massive hit across Europe in multiple language versions.",
       "fun_fact_de": "Apres toi (Nach dir) gilt als eines der schonsten Eurovision-Siegerlieder. Die griechisch-deutsche Sangerin Vicky Leandros hatte Luxemburg bereits 1967 vertreten. Das Lied wurde in mehreren Sprachversionen ein Riesenhit in ganz Europa.",
-      "fun_fact_es": "Apres toi (Despues de ti) se considera una de las canciones ganadoras mas hermosas de Eurovision. La cantante greco-alemana Vicky Leandros habia representado previamente a Luxemburgo en 1967. La cancion se convirtio en un gran exito en toda Europa en multiples versiones idiomaticas."
+      "fun_fact_es": "Apres toi (Despues de ti) se considera una de las canciones ganadoras mas hermosas de Eurovision. La cantante greco-alemana Vicky Leandros habia representado previamente a Luxemburgo en 1967. La cancion se convirtio en un gran exito en toda Europa en multiples versiones idiomaticas.",
+      "uri_apple_music": "applemusic://track/1442450412"
     },
     {
       "year": 1973,
       "uri": "spotify:track:3682WlWtLmx44QNpB6Py4X",
       "artist": "Anne-Marie David",
       "title": "Tu te reconnaitras",
-      "chart_info": {"eurovision_position": 1, "eurovision_points": 129, "country": "Luxembourg"},
+      "chart_info": {
+        "eurovision_position": 1,
+        "eurovision_points": 129,
+        "country": "Luxembourg"
+      },
       "certifications": [],
-      "awards": ["Eurovision Winner 1973"],
-      "awards_de": ["Eurovision-Sieger 1973"],
-      "awards_es": ["Ganador de Eurovision 1973"],
+      "awards": [
+        "Eurovision Winner 1973"
+      ],
+      "awards_de": [
+        "Eurovision-Sieger 1973"
+      ],
+      "awards_es": [
+        "Ganador de Eurovision 1973"
+      ],
       "fun_fact": "Tu te reconnaitras (You Will Recognize Yourself) was Luxembourg's fourth win in 12 years. Anne-Marie David represented France at Eurovision in 1979, making her one of few artists to compete for two different countries.",
       "fun_fact_de": "Tu te reconnaitras (Du wirst dich wiedererkennen) war Luxemburgs vierter Sieg in 12 Jahren. Anne-Marie David vertrat Frankreich beim Eurovision 1979, was sie zu einer der wenigen Kunstlerinnen macht, die fur zwei verschiedene Lander angetreten sind.",
-      "fun_fact_es": "Tu te reconnaitras (Te reconoceras) fue la cuarta victoria de Luxemburgo en 12 anos. Anne-Marie David represento a Francia en Eurovision 1979, convirtiendola en una de las pocas artistas en competir por dos paises diferentes."
+      "fun_fact_es": "Tu te reconnaitras (Te reconoceras) fue la cuarta victoria de Luxemburgo en 12 anos. Anne-Marie David represento a Francia en Eurovision 1979, convirtiendola en una de las pocas artistas en competir por dos paises diferentes.",
+      "uri_apple_music": "applemusic://track/1230500284"
     },
     {
       "year": 1974,
       "uri": "spotify:track:1CsuK5dlnWAkWhffeteqH3",
       "artist": "ABBA",
       "title": "Waterloo",
-      "chart_info": {"eurovision_position": 1, "eurovision_points": 24, "country": "Sweden"},
-      "certifications": ["Gold (US)", "Platinum (UK)"],
-      "awards": ["Eurovision Winner 1974", "Best Eurovision Song Ever (2005 poll)"],
-      "awards_de": ["Eurovision-Sieger 1974", "Bester Eurovision-Song aller Zeiten (Umfrage 2005)"],
-      "awards_es": ["Ganador de Eurovision 1974", "Mejor cancion de Eurovision de todos los tiempos (encuesta 2005)"],
+      "chart_info": {
+        "eurovision_position": 1,
+        "eurovision_points": 24,
+        "country": "Sweden"
+      },
+      "certifications": [
+        "Gold (US)",
+        "Platinum (UK)"
+      ],
+      "awards": [
+        "Eurovision Winner 1974",
+        "Best Eurovision Song Ever (2005 poll)"
+      ],
+      "awards_de": [
+        "Eurovision-Sieger 1974",
+        "Bester Eurovision-Song aller Zeiten (Umfrage 2005)"
+      ],
+      "awards_es": [
+        "Ganador de Eurovision 1974",
+        "Mejor cancion de Eurovision de todos los tiempos (encuesta 2005)"
+      ],
       "fun_fact": "Waterloo launched ABBA to global superstardom and is considered the greatest Eurovision song ever. The UK jury gave them zero points, yet they won anyway. In 2005, it was voted the best Eurovision song of all time in a 50th anniversary poll.",
       "fun_fact_de": "Waterloo machte ABBA zu globalen Superstars und gilt als der grosste Eurovision-Song aller Zeiten. Die britische Jury gab ihnen null Punkte, dennoch gewannen sie. 2005 wurde es in einer Umfrage zum 50-jahrigen Jubilaum zum besten Eurovision-Song aller Zeiten gewahlt.",
-      "fun_fact_es": "Waterloo lanzo a ABBA al estrellato mundial y se considera la mejor cancion de Eurovision de todos los tiempos. El jurado del Reino Unido les dio cero puntos, pero aun asi ganaron. En 2005, fue votada como la mejor cancion de Eurovision en una encuesta del 50 aniversario."
+      "fun_fact_es": "Waterloo lanzo a ABBA al estrellato mundial y se considera la mejor cancion de Eurovision de todos los tiempos. El jurado del Reino Unido les dio cero puntos, pero aun asi ganaron. En 2005, fue votada como la mejor cancion de Eurovision en una encuesta del 50 aniversario.",
+      "uri_apple_music": "applemusic://track/1440861750"
     },
     {
       "year": 1975,
       "uri": "spotify:track:4ARCWS3l327M1YulCf74Uu",
       "artist": "Teach In",
       "title": "Ding-A-Dong",
-      "chart_info": {"eurovision_position": 1, "eurovision_points": 152, "country": "Netherlands"},
+      "chart_info": {
+        "eurovision_position": 1,
+        "eurovision_points": 152,
+        "country": "Netherlands"
+      },
       "certifications": [],
-      "awards": ["Eurovision Winner 1975"],
-      "awards_de": ["Eurovision-Sieger 1975"],
-      "awards_es": ["Ganador de Eurovision 1975"],
+      "awards": [
+        "Eurovision Winner 1975"
+      ],
+      "awards_de": [
+        "Eurovision-Sieger 1975"
+      ],
+      "awards_es": [
+        "Ganador de Eurovision 1975"
+      ],
       "fun_fact": "Ding-A-Dong gave the Netherlands their fourth Eurovision victory. The catchy pop song faced tough competition in a year featuring many strong entries. Teach-In had a brief international career following their win.",
       "fun_fact_de": "Ding-A-Dong brachte den Niederlanden ihren vierten Eurovision-Sieg. Der eingangige Popsong hatte harte Konkurrenz in einem Jahr mit vielen starken Beitragen. Teach-In hatte nach ihrem Sieg eine kurze internationale Karriere.",
       "fun_fact_es": "Ding-A-Dong dio a los Paises Bajos su cuarta victoria en Eurovision. La pegadiza cancion pop enfrento dura competencia en un ano con muchas entradas fuertes. Teach-In tuvo una breve carrera internacional tras su victoria."
@@ -329,39 +585,71 @@
       "uri": "spotify:track:0E19RAvUkhjMM0rdICkidE",
       "artist": "Brotherhood of Man",
       "title": "Save Your Kisses For Me",
-      "chart_info": {"eurovision_position": 1, "eurovision_points": 164, "country": "United Kingdom"},
+      "chart_info": {
+        "eurovision_position": 1,
+        "eurovision_points": 164,
+        "country": "United Kingdom"
+      },
       "certifications": [],
-      "awards": ["Eurovision Winner 1976"],
-      "awards_de": ["Eurovision-Sieger 1976"],
-      "awards_es": ["Ganador de Eurovision 1976"],
+      "awards": [
+        "Eurovision Winner 1976"
+      ],
+      "awards_de": [
+        "Eurovision-Sieger 1976"
+      ],
+      "awards_es": [
+        "Ganador de Eurovision 1976"
+      ],
       "fun_fact": "Save Your Kisses For Me was the UK's third Eurovision victory and became one of the best-selling singles of 1976 worldwide. The song appears to be about romantic love but reveals at the end it's about a three-year-old daughter.",
       "fun_fact_de": "Save Your Kisses For Me war der dritte Eurovision-Sieg des Vereinigten Konigreichs und wurde eine der meistverkauften Singles des Jahres 1976 weltweit. Das Lied scheint von romantischer Liebe zu handeln, enthullt aber am Ende, dass es um eine dreijahrige Tochter geht.",
-      "fun_fact_es": "Save Your Kisses For Me fue la tercera victoria del Reino Unido en Eurovision y se convirtio en uno de los sencillos mas vendidos de 1976 en todo el mundo. La cancion parece tratar sobre amor romantico, pero al final revela que es sobre una hija de tres anos."
+      "fun_fact_es": "Save Your Kisses For Me fue la tercera victoria del Reino Unido en Eurovision y se convirtio en uno de los sencillos mas vendidos de 1976 en todo el mundo. La cancion parece tratar sobre amor romantico, pero al final revela que es sobre una hija de tres anos.",
+      "uri_apple_music": "applemusic://track/286882661"
     },
     {
       "year": 1977,
       "uri": "spotify:track:7Hy0CZtFcREucLDXB5jp6m",
       "artist": "Marie Myriam",
       "title": "L'oiseau et l'enfant",
-      "chart_info": {"eurovision_position": 1, "eurovision_points": 136, "country": "France"},
+      "chart_info": {
+        "eurovision_position": 1,
+        "eurovision_points": 136,
+        "country": "France"
+      },
       "certifications": [],
-      "awards": ["Eurovision Winner 1977"],
-      "awards_de": ["Eurovision-Sieger 1977"],
-      "awards_es": ["Ganador de Eurovision 1977"],
+      "awards": [
+        "Eurovision Winner 1977"
+      ],
+      "awards_de": [
+        "Eurovision-Sieger 1977"
+      ],
+      "awards_es": [
+        "Ganador de Eurovision 1977"
+      ],
       "fun_fact": "L'oiseau et l'enfant (The Bird and the Child) remains France's last Eurovision victory to date. Marie Myriam's soaring vocals made the song a classic. France has since had the longest drought of any former winning country.",
       "fun_fact_de": "L'oiseau et l'enfant (Der Vogel und das Kind) ist bis heute Frankreichs letzter Eurovision-Sieg. Marie Myriams kraftvolle Stimme machte das Lied zu einem Klassiker. Frankreich hat seitdem die langste Durststrecke aller ehemaligen Siegerlander.",
-      "fun_fact_es": "L'oiseau et l'enfant (El pajaro y el nino) sigue siendo la ultima victoria de Francia en Eurovision hasta la fecha. La voz elevada de Marie Myriam convirtio la cancion en un clasico. Desde entonces, Francia ha tenido la sequia mas larga de cualquier pais ganador anterior."
+      "fun_fact_es": "L'oiseau et l'enfant (El pajaro y el nino) sigue siendo la ultima victoria de Francia en Eurovision hasta la fecha. La voz elevada de Marie Myriam convirtio la cancion en un clasico. Desde entonces, Francia ha tenido la sequia mas larga de cualquier pais ganador anterior.",
+      "uri_apple_music": "applemusic://track/1222623640"
     },
     {
       "year": 1978,
       "uri": "spotify:track:1njC0GQXuhxnplvR9DK6NZ",
       "artist": "Izhar Cohen",
       "title": "A-Ba-Ni-Bi",
-      "chart_info": {"eurovision_position": 1, "eurovision_points": 157, "country": "Israel"},
+      "chart_info": {
+        "eurovision_position": 1,
+        "eurovision_points": 157,
+        "country": "Israel"
+      },
       "certifications": [],
-      "awards": ["Eurovision Winner 1978"],
-      "awards_de": ["Eurovision-Sieger 1978"],
-      "awards_es": ["Ganador de Eurovision 1978"],
+      "awards": [
+        "Eurovision Winner 1978"
+      ],
+      "awards_de": [
+        "Eurovision-Sieger 1978"
+      ],
+      "awards_es": [
+        "Ganador de Eurovision 1978"
+      ],
       "fun_fact": "A-Ba-Ni-Bi was Israel's first Eurovision victory and used a Hebrew children's language game in its lyrics. Izhar Cohen and the Alphabeta performed with high energy choreography that was groundbreaking for the era.",
       "fun_fact_de": "A-Ba-Ni-Bi war Israels erster Eurovision-Sieg und verwendete ein hebraisches Kindersprachspiel in seinen Texten. Izhar Cohen und die Alphabeta traten mit einer energiegeladenen Choreografie auf, die fur die damalige Zeit bahnbrechend war.",
       "fun_fact_es": "A-Ba-Ni-Bi fue la primera victoria de Israel en Eurovision y utilizo un juego linguistico infantil hebreo en sus letras. Izhar Cohen y Alphabeta actuaron con una coreografia de alta energia que fue revolucionaria para la epoca."
@@ -371,179 +659,321 @@
       "uri": "spotify:track:557ZG0nAvOppPxR3e1DP42",
       "artist": "Gali Atari",
       "title": "Hallelujah",
-      "chart_info": {"eurovision_position": 1, "eurovision_points": 125, "country": "Israel"},
+      "chart_info": {
+        "eurovision_position": 1,
+        "eurovision_points": 125,
+        "country": "Israel"
+      },
       "certifications": [],
-      "awards": ["Eurovision Winner 1979"],
-      "awards_de": ["Eurovision-Sieger 1979"],
-      "awards_es": ["Ganador de Eurovision 1979"],
+      "awards": [
+        "Eurovision Winner 1979"
+      ],
+      "awards_de": [
+        "Eurovision-Sieger 1979"
+      ],
+      "awards_es": [
+        "Ganador de Eurovision 1979"
+      ],
       "fun_fact": "Hallelujah gave Israel back-to-back victories. Performed by Gali Atari with Milk and Honey, the song's message of peace resonated deeply during tense Middle East times. Israel hosted Eurovision 1979 in Jerusalem following their 1978 win.",
       "fun_fact_de": "Hallelujah bescherte Israel zwei aufeinanderfolgende Siege. Aufgefuhrt von Gali Atari mit Milk and Honey, fand die Friedensbotschaft des Liedes in den angespannten Zeiten im Nahen Osten grossen Anklang. Israel richtete nach seinem Sieg 1978 den Eurovision 1979 in Jerusalem aus.",
-      "fun_fact_es": "Hallelujah dio a Israel victorias consecutivas. Interpretada por Gali Atari con Milk and Honey, el mensaje de paz de la cancion resono profundamente durante los tiempos tensos en Oriente Medio. Israel fue anfitrion de Eurovision 1979 en Jerusalen tras su victoria en 1978."
+      "fun_fact_es": "Hallelujah dio a Israel victorias consecutivas. Interpretada por Gali Atari con Milk and Honey, el mensaje de paz de la cancion resono profundamente durante los tiempos tensos en Oriente Medio. Israel fue anfitrion de Eurovision 1979 en Jerusalen tras su victoria en 1978.",
+      "uri_apple_music": "applemusic://track/1724997885"
     },
     {
       "year": 1980,
       "uri": "spotify:track:2VPyWgAjdIRlMvk4XQCO44",
       "artist": "Johnny Logan",
       "title": "What's Another Year",
-      "chart_info": {"eurovision_position": 1, "eurovision_points": 143, "country": "Ireland"},
+      "chart_info": {
+        "eurovision_position": 1,
+        "eurovision_points": 143,
+        "country": "Ireland"
+      },
       "certifications": [],
-      "awards": ["Eurovision Winner 1980"],
-      "awards_de": ["Eurovision-Sieger 1980"],
-      "awards_es": ["Ganador de Eurovision 1980"],
+      "awards": [
+        "Eurovision Winner 1980"
+      ],
+      "awards_de": [
+        "Eurovision-Sieger 1980"
+      ],
+      "awards_es": [
+        "Ganador de Eurovision 1980"
+      ],
       "fun_fact": "What's Another Year began Johnny Logan's legendary Eurovision career. He would win again in 1987 as a performer and 1992 as a songwriter, making him the only person to win Eurovision three times. He's known as 'Mr. Eurovision'.",
       "fun_fact_de": "What's Another Year begann Johnny Logans legendare Eurovision-Karriere. Er wurde 1987 als Interpret und 1992 als Songwriter erneut gewinnen, was ihn zur einzigen Person macht, die den Eurovision dreimal gewonnen hat. Er ist als 'Mr. Eurovision' bekannt.",
-      "fun_fact_es": "What's Another Year inicio la legendaria carrera de Johnny Logan en Eurovision. Ganaria nuevamente en 1987 como interprete y en 1992 como compositor, convirtiendolo en la unica persona en ganar Eurovision tres veces. Se le conoce como 'Mr. Eurovision'."
+      "fun_fact_es": "What's Another Year inicio la legendaria carrera de Johnny Logan en Eurovision. Ganaria nuevamente en 1987 como interprete y en 1992 como compositor, convirtiendolo en la unica persona en ganar Eurovision tres veces. Se le conoce como 'Mr. Eurovision'.",
+      "uri_apple_music": "applemusic://track/735689364"
     },
     {
       "year": 1981,
       "uri": "spotify:track:5tK13ThQnZJF1YOVjQ0FAx",
       "artist": "Bucks Fizz",
       "title": "Making Your Mind Up",
-      "chart_info": {"eurovision_position": 1, "eurovision_points": 136, "country": "United Kingdom"},
+      "chart_info": {
+        "eurovision_position": 1,
+        "eurovision_points": 136,
+        "country": "United Kingdom"
+      },
       "certifications": [],
-      "awards": ["Eurovision Winner 1981"],
-      "awards_de": ["Eurovision-Sieger 1981"],
-      "awards_es": ["Ganador de Eurovision 1981"],
+      "awards": [
+        "Eurovision Winner 1981"
+      ],
+      "awards_de": [
+        "Eurovision-Sieger 1981"
+      ],
+      "awards_es": [
+        "Ganador de Eurovision 1981"
+      ],
       "fun_fact": "Making Your Mind Up is famous for the skirt-ripping routine where the men tore off the women's skirts to reveal shorter ones underneath. This moment became one of Eurovision's most iconic performances and boosted Bucks Fizz to stardom.",
       "fun_fact_de": "Making Your Mind Up ist beruhmt fur die Rock-Abreiss-Routine, bei der die Manner den Frauen die Rocke abrissen und darunter kurzere enthullten. Dieser Moment wurde zu einer der ikonischsten Eurovision-Darbietungen und machte Bucks Fizz zu Stars.",
-      "fun_fact_es": "Making Your Mind Up es famosa por la rutina de arrancar las faldas donde los hombres arrancaban las faldas de las mujeres para revelar otras mas cortas debajo. Este momento se convirtio en una de las actuaciones mas iconicas de Eurovision e impulso a Bucks Fizz al estrellato."
+      "fun_fact_es": "Making Your Mind Up es famosa por la rutina de arrancar las faldas donde los hombres arrancaban las faldas de las mujeres para revelar otras mas cortas debajo. Este momento se convirtio en una de las actuaciones mas iconicas de Eurovision e impulso a Bucks Fizz al estrellato.",
+      "uri_apple_music": "applemusic://track/250583272"
     },
     {
       "year": 1982,
       "uri": "spotify:track:7JZHsMxhcaRKug5kA0DmDE",
       "artist": "Nicole",
       "title": "Ein bisschen Frieden",
-      "chart_info": {"eurovision_position": 1, "eurovision_points": 161, "country": "Germany"},
+      "chart_info": {
+        "eurovision_position": 1,
+        "eurovision_points": 161,
+        "country": "Germany"
+      },
       "certifications": [],
-      "awards": ["Eurovision Winner 1982"],
-      "awards_de": ["Eurovision-Sieger 1982"],
-      "awards_es": ["Ganador de Eurovision 1982"],
+      "awards": [
+        "Eurovision Winner 1982"
+      ],
+      "awards_de": [
+        "Eurovision-Sieger 1982"
+      ],
+      "awards_es": [
+        "Ganador de Eurovision 1982"
+      ],
       "fun_fact": "Ein bisschen Frieden (A Little Peace) was Germany's first Eurovision victory and topped charts across Europe. The anti-war ballad resonated during Cold War tensions. Nicole was only 17 and performed with a simple, heartfelt presentation.",
       "fun_fact_de": "Ein bisschen Frieden war Deutschlands erster Eurovision-Sieg und fuhrte die Charts in ganz Europa an. Die Antikriegsballade fand wahrend der Spannungen des Kalten Krieges grossen Anklang. Nicole war erst 17 und trat mit einer schlichten, herzlichen Darbietung auf.",
-      "fun_fact_es": "Ein bisschen Frieden (Un poco de paz) fue la primera victoria de Alemania en Eurovision y encabezo las listas de toda Europa. La balada antibélica resono durante las tensiones de la Guerra Fria. Nicole tenia solo 17 anos y actuo con una presentacion sencilla y sincera."
+      "fun_fact_es": "Ein bisschen Frieden (Un poco de paz) fue la primera victoria de Alemania en Eurovision y encabezo las listas de toda Europa. La balada antibélica resono durante las tensiones de la Guerra Fria. Nicole tenia solo 17 anos y actuo con una presentacion sencilla y sincera.",
+      "uri_apple_music": "applemusic://track/274740408"
     },
     {
       "year": 1983,
       "uri": "spotify:track:0u8AjgsFdyKA1rAca57GC4",
       "artist": "Corinne Hermes",
       "title": "Si la vie est cadeau",
-      "chart_info": {"eurovision_position": 1, "eurovision_points": 142, "country": "Luxembourg"},
+      "chart_info": {
+        "eurovision_position": 1,
+        "eurovision_points": 142,
+        "country": "Luxembourg"
+      },
       "certifications": [],
-      "awards": ["Eurovision Winner 1983"],
-      "awards_de": ["Eurovision-Sieger 1983"],
-      "awards_es": ["Ganador de Eurovision 1983"],
+      "awards": [
+        "Eurovision Winner 1983"
+      ],
+      "awards_de": [
+        "Eurovision-Sieger 1983"
+      ],
+      "awards_es": [
+        "Ganador de Eurovision 1983"
+      ],
       "fun_fact": "Si la vie est cadeau (If Life Is a Gift) gave Luxembourg their fifth and final Eurovision victory. The power ballad showcased Corinne Hermes' impressive vocal range. Luxembourg withdrew from Eurovision in 1994 and hasn't returned since.",
       "fun_fact_de": "Si la vie est cadeau (Wenn das Leben ein Geschenk ist) brachte Luxemburg seinen funften und letzten Eurovision-Sieg. Die kraftvolle Ballade zeigte Corinne Hermes' beeindruckenden Stimmumfang. Luxemburg zog sich 1994 vom Eurovision zuruck und ist seitdem nicht zuruckgekehrt.",
-      "fun_fact_es": "Si la vie est cadeau (Si la vida es un regalo) dio a Luxemburgo su quinta y ultima victoria en Eurovision. La poderosa balada mostro el impresionante rango vocal de Corinne Hermes. Luxemburgo se retiro de Eurovision en 1994 y no ha regresado desde entonces."
+      "fun_fact_es": "Si la vie est cadeau (Si la vida es un regalo) dio a Luxemburgo su quinta y ultima victoria en Eurovision. La poderosa balada mostro el impresionante rango vocal de Corinne Hermes. Luxemburgo se retiro de Eurovision en 1994 y no ha regresado desde entonces.",
+      "uri_apple_music": "applemusic://track/1568840214"
     },
     {
       "year": 1984,
       "uri": "spotify:track:4NzirQ4BrNkVaPEla2ipG4",
       "artist": "Herreys",
       "title": "Diggiloo Diggiley",
-      "chart_info": {"eurovision_position": 1, "eurovision_points": 145, "country": "Sweden"},
+      "chart_info": {
+        "eurovision_position": 1,
+        "eurovision_points": 145,
+        "country": "Sweden"
+      },
       "certifications": [],
-      "awards": ["Eurovision Winner 1984"],
-      "awards_de": ["Eurovision-Sieger 1984"],
-      "awards_es": ["Ganador de Eurovision 1984"],
+      "awards": [
+        "Eurovision Winner 1984"
+      ],
+      "awards_de": [
+        "Eurovision-Sieger 1984"
+      ],
+      "awards_es": [
+        "Ganador de Eurovision 1984"
+      ],
       "fun_fact": "Diggi-Loo Diggi-Ley was performed by three brothers in shiny gold boots that became their trademark. The upbeat Eurodisco song gave Sweden their second victory after ABBA. The Herreys' energetic choreography defined 80s Eurovision style.",
       "fun_fact_de": "Diggi-Loo Diggi-Ley wurde von drei Brudern in glanzenden goldenen Stiefeln aufgefuhrt, die zu ihrem Markenzeichen wurden. Der frohliche Eurodisco-Song brachte Schweden nach ABBA seinen zweiten Sieg. Die energiegeladene Choreografie der Herreys pragte den Eurovision-Stil der 80er Jahre.",
-      "fun_fact_es": "Diggi-Loo Diggi-Ley fue interpretada por tres hermanos con brillantes botas doradas que se convirtieron en su marca distintiva. La alegre cancion eurodisco dio a Suecia su segunda victoria despues de ABBA. La energetica coreografia de los Herreys definio el estilo de Eurovision de los anos 80."
+      "fun_fact_es": "Diggi-Loo Diggi-Ley fue interpretada por tres hermanos con brillantes botas doradas que se convirtieron en su marca distintiva. La alegre cancion eurodisco dio a Suecia su segunda victoria despues de ABBA. La energetica coreografia de los Herreys definio el estilo de Eurovision de los anos 80.",
+      "uri_apple_music": "applemusic://track/440309422"
     },
     {
       "year": 1985,
       "uri": "spotify:track:0LmEzNrxk0lecRm8X58jiC",
       "artist": "Bobbysocks",
       "title": "La det swinge",
-      "chart_info": {"eurovision_position": 1, "eurovision_points": 123, "country": "Norway"},
+      "chart_info": {
+        "eurovision_position": 1,
+        "eurovision_points": 123,
+        "country": "Norway"
+      },
       "certifications": [],
-      "awards": ["Eurovision Winner 1985"],
-      "awards_de": ["Eurovision-Sieger 1985"],
-      "awards_es": ["Ganador de Eurovision 1985"],
+      "awards": [
+        "Eurovision Winner 1985"
+      ],
+      "awards_de": [
+        "Eurovision-Sieger 1985"
+      ],
+      "awards_es": [
+        "Ganador de Eurovision 1985"
+      ],
       "fun_fact": "La det swinge (Let It Swing) ended Norway's notorious streak of poor Eurovision results with their first-ever victory. The Norwegian female duo Bobbysocks broke through with an energetic pop-rock performance that charmed voters across Europe.",
       "fun_fact_de": "La det swinge (Lass es schwingen) beendete Norwegens beruchtigte Serie schlechter Eurovision-Ergebnisse mit ihrem allerersten Sieg. Das norwegische Frauen-Duo Bobbysocks schaffte den Durchbruch mit einer energiegeladenen Pop-Rock-Darbietung, die Wahler in ganz Europa begeisterte.",
-      "fun_fact_es": "La det swinge (Dejalo balancearse) termino con la notoria racha de malos resultados de Noruega en Eurovision con su primera victoria. El duo femenino noruego Bobbysocks triunfo con una energetica actuacion de pop-rock que encanto a los votantes de toda Europa."
+      "fun_fact_es": "La det swinge (Dejalo balancearse) termino con la notoria racha de malos resultados de Noruega en Eurovision con su primera victoria. El duo femenino noruego Bobbysocks triunfo con una energetica actuacion de pop-rock que encanto a los votantes de toda Europa.",
+      "uri_apple_music": "applemusic://track/876486003"
     },
     {
       "year": 1986,
       "uri": "spotify:track:0Kr57gzJjexm8TF0l0JPLD",
       "artist": "Sandra Kim",
       "title": "J'aime la vie",
-      "chart_info": {"eurovision_position": 1, "eurovision_points": 176, "country": "Belgium"},
+      "chart_info": {
+        "eurovision_position": 1,
+        "eurovision_points": 176,
+        "country": "Belgium"
+      },
       "certifications": [],
-      "awards": ["Eurovision Winner 1986"],
-      "awards_de": ["Eurovision-Sieger 1986"],
-      "awards_es": ["Ganador de Eurovision 1986"],
+      "awards": [
+        "Eurovision Winner 1986"
+      ],
+      "awards_de": [
+        "Eurovision-Sieger 1986"
+      ],
+      "awards_es": [
+        "Ganador de Eurovision 1986"
+      ],
       "fun_fact": "J'aime la vie (I Love Life) remains Belgium's only Eurovision victory. Sandra Kim claimed to be 15 but was actually only 13, making her the youngest ever Eurovision winner. The truth only emerged after her victory.",
       "fun_fact_de": "J'aime la vie (Ich liebe das Leben) bleibt Belgiens einziger Eurovision-Sieg. Sandra Kim behauptete, 15 zu sein, war aber tatsachlich erst 13, was sie zur jungsten Eurovision-Siegerin aller Zeiten macht. Die Wahrheit kam erst nach ihrem Sieg ans Licht.",
-      "fun_fact_es": "J'aime la vie (Amo la vida) sigue siendo la unica victoria de Belgica en Eurovision. Sandra Kim afirmaba tener 15 anos pero en realidad tenia solo 13, convirtiendola en la ganadora mas joven de Eurovision. La verdad solo surgio despues de su victoria."
+      "fun_fact_es": "J'aime la vie (Amo la vida) sigue siendo la unica victoria de Belgica en Eurovision. Sandra Kim afirmaba tener 15 anos pero en realidad tenia solo 13, convirtiendola en la ganadora mas joven de Eurovision. La verdad solo surgio despues de su victoria.",
+      "uri_apple_music": "applemusic://track/775105607"
     },
     {
       "year": 1987,
       "uri": "spotify:track:3wAfLEy1KQjpmbZdBrAW1U",
       "artist": "Johnny Logan",
       "title": "Hold Me Now",
-      "chart_info": {"eurovision_position": 1, "eurovision_points": 172, "country": "Ireland"},
+      "chart_info": {
+        "eurovision_position": 1,
+        "eurovision_points": 172,
+        "country": "Ireland"
+      },
       "certifications": [],
-      "awards": ["Eurovision Winner 1987"],
-      "awards_de": ["Eurovision-Sieger 1987"],
-      "awards_es": ["Ganador de Eurovision 1987"],
+      "awards": [
+        "Eurovision Winner 1987"
+      ],
+      "awards_de": [
+        "Eurovision-Sieger 1987"
+      ],
+      "awards_es": [
+        "Ganador de Eurovision 1987"
+      ],
       "fun_fact": "Hold Me Now made Johnny Logan the first artist to win Eurovision twice as a performer. He wrote this power ballad himself, unlike his 1980 entry. Logan would win a third time in 1992 as songwriter for Linda Martin's 'Why Me?'.",
       "fun_fact_de": "Hold Me Now machte Johnny Logan zum ersten Kunstler, der den Eurovision zweimal als Interpret gewann. Er schrieb diese kraftvolle Ballade selbst, im Gegensatz zu seinem Beitrag von 1980. Logan wurde 1992 als Songwriter fur Linda Martins 'Why Me?' ein drittes Mal gewinnen.",
-      "fun_fact_es": "Hold Me Now convirtio a Johnny Logan en el primer artista en ganar Eurovision dos veces como interprete. El mismo escribio esta poderosa balada, a diferencia de su entrada de 1980. Logan ganaria por tercera vez en 1992 como compositor de 'Why Me?' de Linda Martin."
+      "fun_fact_es": "Hold Me Now convirtio a Johnny Logan en el primer artista en ganar Eurovision dos veces como interprete. El mismo escribio esta poderosa balada, a diferencia de su entrada de 1980. Logan ganaria por tercera vez en 1992 como compositor de 'Why Me?' de Linda Martin.",
+      "uri_apple_music": "applemusic://track/429802667"
     },
     {
       "year": 1988,
       "uri": "spotify:track:0Kv4i96E41jbULmUajBYOe",
       "artist": "Celine Dion",
       "title": "Ne partez pas sans moi",
-      "chart_info": {"eurovision_position": 1, "eurovision_points": 137, "country": "Switzerland"},
+      "chart_info": {
+        "eurovision_position": 1,
+        "eurovision_points": 137,
+        "country": "Switzerland"
+      },
       "certifications": [],
-      "awards": ["Eurovision Winner 1988"],
-      "awards_de": ["Eurovision-Sieger 1988"],
-      "awards_es": ["Ganador de Eurovision 1988"],
+      "awards": [
+        "Eurovision Winner 1988"
+      ],
+      "awards_de": [
+        "Eurovision-Sieger 1988"
+      ],
+      "awards_es": [
+        "Ganador de Eurovision 1988"
+      ],
       "fun_fact": "Ne partez pas sans moi (Don't Leave Without Me) launched Celine Dion to European fame. She won by just one point in a nail-biting finish. Dion represented Switzerland because Canadian artists weren't eligible for their own country.",
       "fun_fact_de": "Ne partez pas sans moi (Geht nicht ohne mich) machte Celine Dion in Europa beruhmt. Sie gewann mit nur einem Punkt Vorsprung in einem nervenaufreibenden Finale. Dion vertrat die Schweiz, weil kanadische Kunstler fur ihr eigenes Land nicht teilnahmeberechtigt waren.",
-      "fun_fact_es": "Ne partez pas sans moi (No se vayan sin mi) lanzo a Celine Dion a la fama europea. Gano por solo un punto en un final de infarto. Dion represento a Suiza porque los artistas canadienses no eran elegibles para su propio pais."
+      "fun_fact_es": "Ne partez pas sans moi (No se vayan sin mi) lanzo a Celine Dion a la fama europea. Gano por solo un punto en un final de infarto. Dion represento a Suiza porque los artistas canadienses no eran elegibles para su propio pais.",
+      "uri_apple_music": "applemusic://track/253634992"
     },
     {
       "year": 1989,
       "uri": "spotify:track:2WXogQGOO7qo2hlHyzpwhg",
       "artist": "Riva",
       "title": "Rock Me",
-      "chart_info": {"eurovision_position": 1, "eurovision_points": 137, "country": "Yugoslavia"},
+      "chart_info": {
+        "eurovision_position": 1,
+        "eurovision_points": 137,
+        "country": "Yugoslavia"
+      },
       "certifications": [],
-      "awards": ["Eurovision Winner 1989"],
-      "awards_de": ["Eurovision-Sieger 1989"],
-      "awards_es": ["Ganador de Eurovision 1989"],
+      "awards": [
+        "Eurovision Winner 1989"
+      ],
+      "awards_de": [
+        "Eurovision-Sieger 1989"
+      ],
+      "awards_es": [
+        "Ganador de Eurovision 1989"
+      ],
       "fun_fact": "Rock Me was Yugoslavia's only Eurovision victory before the country dissolved. The Croatian band Riva performed with infectious energy. Tragically, the breakup of Yugoslavia meant no unified country could celebrate this historic win for long.",
       "fun_fact_de": "Rock Me war Jugoslawiens einziger Eurovision-Sieg, bevor das Land zerbrach. Die kroatische Band Riva trat mit ansteckender Energie auf. Tragischerweise bedeutete der Zerfall Jugoslawiens, dass kein vereintes Land diesen historischen Sieg lange feiern konnte.",
-      "fun_fact_es": "Rock Me fue la unica victoria de Yugoslavia en Eurovision antes de que el pais se disolviera. La banda croata Riva actuo con energia contagiosa. Tragicamente, la disolucion de Yugoslavia significo que ningun pais unificado pudo celebrar esta victoria historica por mucho tiempo."
+      "fun_fact_es": "Rock Me fue la unica victoria de Yugoslavia en Eurovision antes de que el pais se disolviera. La banda croata Riva actuo con energia contagiosa. Tragicamente, la disolucion de Yugoslavia significo que ningun pais unificado pudo celebrar esta victoria historica por mucho tiempo.",
+      "uri_apple_music": "applemusic://track/504583865"
     },
     {
       "year": 1990,
       "uri": "spotify:track:44noNMO0iv87Tds7dwcpQU",
       "artist": "Toto Cutugno",
       "title": "Insieme: 1992",
-      "chart_info": {"eurovision_position": 1, "eurovision_points": 149, "country": "Italy"},
+      "chart_info": {
+        "eurovision_position": 1,
+        "eurovision_points": 149,
+        "country": "Italy"
+      },
       "certifications": [],
-      "awards": ["Eurovision Winner 1990"],
-      "awards_de": ["Eurovision-Sieger 1990"],
-      "awards_es": ["Ganador de Eurovision 1990"],
+      "awards": [
+        "Eurovision Winner 1990"
+      ],
+      "awards_de": [
+        "Eurovision-Sieger 1990"
+      ],
+      "awards_es": [
+        "Ganador de Eurovision 1990"
+      ],
       "fun_fact": "Insieme: 1992 (Together: 1992) celebrated European unity ahead of the EU single market. Toto Cutugno had competed at Eurovision many times before finally winning. The song became an anthem for European integration during a pivotal historical moment.",
       "fun_fact_de": "Insieme: 1992 (Zusammen: 1992) feierte die europaische Einheit im Vorfeld des EU-Binnenmarktes. Toto Cutugno hatte viele Male am Eurovision teilgenommen, bevor er schliesslich gewann. Das Lied wurde wahrend eines entscheidenden historischen Moments zu einer Hymne fur die europaische Integration.",
-      "fun_fact_es": "Insieme: 1992 (Juntos: 1992) celebro la unidad europea antes del mercado unico de la UE. Toto Cutugno habia competido en Eurovision muchas veces antes de finalmente ganar. La cancion se convirtio en un himno para la integracion europea durante un momento historico crucial."
+      "fun_fact_es": "Insieme: 1992 (Juntos: 1992) celebro la unidad europea antes del mercado unico de la UE. Toto Cutugno habia competido en Eurovision muchas veces antes de finalmente ganar. La cancion se convirtio en un himno para la integracion europea durante un momento historico crucial.",
+      "uri_apple_music": "applemusic://track/1329254875"
     },
     {
       "year": 1991,
       "uri": "spotify:track:5I6eq9wK0SOkeUWEPHqD39",
       "artist": "Carola",
       "title": "Fangad av en stormvind",
-      "chart_info": {"eurovision_position": 1, "eurovision_points": 146, "country": "Sweden"},
+      "chart_info": {
+        "eurovision_position": 1,
+        "eurovision_points": 146,
+        "country": "Sweden"
+      },
       "certifications": [],
-      "awards": ["Eurovision Winner 1991"],
-      "awards_de": ["Eurovision-Sieger 1991"],
-      "awards_es": ["Ganador de Eurovision 1991"],
+      "awards": [
+        "Eurovision Winner 1991"
+      ],
+      "awards_de": [
+        "Eurovision-Sieger 1991"
+      ],
+      "awards_es": [
+        "Ganador de Eurovision 1991"
+      ],
       "fun_fact": "Fangad av en stormvind (Captured by a Lovestorm) won in a contest held in Rome. Carola had previously represented Sweden in 1983. The dramatic ballad showcased Sweden's knack for producing Eurovision winners.",
       "fun_fact_de": "Fangad av en stormvind (Gefangen von einem Liebessturm) gewann bei einem Wettbewerb in Rom. Carola hatte Schweden bereits 1983 vertreten. Die dramatische Ballade zeigte Schwedens Talent, Eurovision-Sieger hervorzubringen.",
       "fun_fact_es": "Fangad av en stormvind (Atrapada por una tormenta de amor) gano en un concurso celebrado en Roma. Carola habia representado previamente a Suecia en 1983. La dramatica balada demostro la habilidad de Suecia para producir ganadores de Eurovision."
@@ -553,11 +983,21 @@
       "uri": "spotify:track:3Y81Q8dLI74Mgi1wbXvscv",
       "artist": "Linda Martin",
       "title": "Why Me?",
-      "chart_info": {"eurovision_position": 1, "eurovision_points": 155, "country": "Ireland"},
+      "chart_info": {
+        "eurovision_position": 1,
+        "eurovision_points": 155,
+        "country": "Ireland"
+      },
       "certifications": [],
-      "awards": ["Eurovision Winner 1992"],
-      "awards_de": ["Eurovision-Sieger 1992"],
-      "awards_es": ["Ganador de Eurovision 1992"],
+      "awards": [
+        "Eurovision Winner 1992"
+      ],
+      "awards_de": [
+        "Eurovision-Sieger 1992"
+      ],
+      "awards_es": [
+        "Ganador de Eurovision 1992"
+      ],
       "fun_fact": "Why Me? was written by Johnny Logan, giving him his third Eurovision victory (this time as songwriter). Linda Martin had previously competed in 1984. This began Ireland's unprecedented streak of four consecutive wins.",
       "fun_fact_de": "Why Me? wurde von Johnny Logan geschrieben, was ihm seinen dritten Eurovision-Sieg bescherte (diesmal als Songwriter). Linda Martin hatte bereits 1984 teilgenommen. Dies begann Irlands beispiellose Serie von vier aufeinanderfolgenden Siegen.",
       "fun_fact_es": "Why Me? fue escrita por Johnny Logan, dandole su tercera victoria en Eurovision (esta vez como compositor). Linda Martin habia competido previamente en 1984. Esto inicio la racha sin precedentes de Irlanda de cuatro victorias consecutivas."
@@ -567,39 +1007,71 @@
       "uri": "spotify:track:7LBBL20GLOtjBJwxgVmzPK",
       "artist": "Niamh Kavanagh",
       "title": "In Your Eyes",
-      "chart_info": {"eurovision_position": 1, "eurovision_points": 187, "country": "Ireland"},
+      "chart_info": {
+        "eurovision_position": 1,
+        "eurovision_points": 187,
+        "country": "Ireland"
+      },
       "certifications": [],
-      "awards": ["Eurovision Winner 1993"],
-      "awards_de": ["Eurovision-Sieger 1993"],
-      "awards_es": ["Ganador de Eurovision 1993"],
+      "awards": [
+        "Eurovision Winner 1993"
+      ],
+      "awards_de": [
+        "Eurovision-Sieger 1993"
+      ],
+      "awards_es": [
+        "Ganador de Eurovision 1993"
+      ],
       "fun_fact": "In Your Eyes extended Ireland's winning streak to two consecutive years. Niamh Kavanagh's powerful vocals earned the highest points total to that date. She returned to Eurovision in 2010, representing Ireland again.",
       "fun_fact_de": "In Your Eyes verlangerte Irlands Siegesserie auf zwei aufeinanderfolgende Jahre. Niamh Kavanaghs kraftvolle Stimme erzielte die bis dahin hochste Punktzahl. Sie kehrte 2010 zum Eurovision zuruck und vertrat erneut Irland.",
-      "fun_fact_es": "In Your Eyes extendio la racha ganadora de Irlanda a dos anos consecutivos. La poderosa voz de Niamh Kavanagh obtuvo la puntuacion mas alta hasta esa fecha. Regreso a Eurovision en 2010, representando nuevamente a Irlanda."
+      "fun_fact_es": "In Your Eyes extendio la racha ganadora de Irlanda a dos anos consecutivos. La poderosa voz de Niamh Kavanagh obtuvo la puntuacion mas alta hasta esa fecha. Regreso a Eurovision en 2010, representando nuevamente a Irlanda.",
+      "uri_apple_music": "applemusic://track/348924038"
     },
     {
       "year": 1994,
       "uri": "spotify:track:4qVX2nHuFlVNp6AOVrDBGb",
       "artist": "Paul Harrington;Charlie McGettigan",
       "title": "Rock 'n' Roll Kids",
-      "chart_info": {"eurovision_position": 1, "eurovision_points": 226, "country": "Ireland"},
+      "chart_info": {
+        "eurovision_position": 1,
+        "eurovision_points": 226,
+        "country": "Ireland"
+      },
       "certifications": [],
-      "awards": ["Eurovision Winner 1994"],
-      "awards_de": ["Eurovision-Sieger 1994"],
-      "awards_es": ["Ganador de Eurovision 1994"],
+      "awards": [
+        "Eurovision Winner 1994"
+      ],
+      "awards_de": [
+        "Eurovision-Sieger 1994"
+      ],
+      "awards_es": [
+        "Ganador de Eurovision 1994"
+      ],
       "fun_fact": "Rock 'n' Roll Kids was Ireland's third consecutive victory. The nostalgic duet about childhood dreams broke the points record. This contest also featured the interval act 'Riverdance', which became a global phenomenon.",
       "fun_fact_de": "Rock 'n' Roll Kids war Irlands dritter aufeinanderfolgender Sieg. Das nostalgische Duett uber Kindheitstraume brach den Punkterekord. Bei diesem Wettbewerb gab es auch die Pausenshow 'Riverdance', die zu einem weltweiten Phanomen wurde.",
-      "fun_fact_es": "Rock 'n' Roll Kids fue la tercera victoria consecutiva de Irlanda. El dueto nostalgico sobre suenos de infancia rompio el record de puntos. Este concurso tambien presento el espectaculo de intermedio 'Riverdance', que se convirtio en un fenomeno global."
+      "fun_fact_es": "Rock 'n' Roll Kids fue la tercera victoria consecutiva de Irlanda. El dueto nostalgico sobre suenos de infancia rompio el record de puntos. Este concurso tambien presento el espectaculo de intermedio 'Riverdance', que se convirtio en un fenomeno global.",
+      "uri_apple_music": "applemusic://track/212118856"
     },
     {
       "year": 1995,
       "uri": "spotify:track:4zHzxmGa8ywcOBBvPvnYcp",
       "artist": "Rolf Lovland;Secret Garden",
       "title": "Nocturne",
-      "chart_info": {"eurovision_position": 1, "eurovision_points": 148, "country": "Norway"},
+      "chart_info": {
+        "eurovision_position": 1,
+        "eurovision_points": 148,
+        "country": "Norway"
+      },
       "certifications": [],
-      "awards": ["Eurovision Winner 1995"],
-      "awards_de": ["Eurovision-Sieger 1995"],
-      "awards_es": ["Ganador de Eurovision 1995"],
+      "awards": [
+        "Eurovision Winner 1995"
+      ],
+      "awards_de": [
+        "Eurovision-Sieger 1995"
+      ],
+      "awards_es": [
+        "Ganador de Eurovision 1995"
+      ],
       "fun_fact": "Nocturne is the only mostly instrumental song to win Eurovision, featuring just 24 words of lyrics. Secret Garden's haunting violin melody captivated Europe. The Norwegian-Irish duo proved Eurovision wasn't just about catchy pop songs.",
       "fun_fact_de": "Nocturne ist das einzige uberwiegend instrumentale Lied, das den Eurovision gewann, mit nur 24 Wortern Text. Secret Gardens eindringliche Violinmelodie faszinierte Europa. Das norwegisch-irische Duo bewies, dass Eurovision nicht nur eingangige Popsongs bedeutet.",
       "fun_fact_es": "Nocturne es la unica cancion mayoritariamente instrumental en ganar Eurovision, con solo 24 palabras de letra. La cautivadora melodia de violin de Secret Garden fascino a Europa. El duo noruego-irlandes demostro que Eurovision no se trataba solo de canciones pop pegadizas."
@@ -609,39 +1081,71 @@
       "uri": "spotify:track:6SA7BxY6zh5SaxUBp3tCtb",
       "artist": "Eimear Quinn",
       "title": "The Voice",
-      "chart_info": {"eurovision_position": 1, "eurovision_points": 162, "country": "Ireland"},
+      "chart_info": {
+        "eurovision_position": 1,
+        "eurovision_points": 162,
+        "country": "Ireland"
+      },
       "certifications": [],
-      "awards": ["Eurovision Winner 1996"],
-      "awards_de": ["Eurovision-Sieger 1996"],
-      "awards_es": ["Ganador de Eurovision 1996"],
+      "awards": [
+        "Eurovision Winner 1996"
+      ],
+      "awards_de": [
+        "Eurovision-Sieger 1996"
+      ],
+      "awards_es": [
+        "Ganador de Eurovision 1996"
+      ],
       "fun_fact": "The Voice gave Ireland their record-breaking seventh Eurovision victory (fourth in five years). Eimear Quinn's ethereal Celtic performance continued Ireland's dominance. No country has won Eurovision more times than Ireland.",
       "fun_fact_de": "The Voice brachte Irland seinen rekordverdachtigen siebten Eurovision-Sieg (den vierten in funf Jahren). Eimear Quinns atherische keltische Darbietung setzte Irlands Dominanz fort. Kein Land hat den Eurovision ofter gewonnen als Irland.",
-      "fun_fact_es": "The Voice dio a Irlanda su septima victoria record en Eurovision (la cuarta en cinco anos). La eterea actuacion celta de Eimear Quinn continuo el dominio de Irlanda. Ningun pais ha ganado Eurovision mas veces que Irlanda."
+      "fun_fact_es": "The Voice dio a Irlanda su septima victoria record en Eurovision (la cuarta en cinco anos). La eterea actuacion celta de Eimear Quinn continuo el dominio de Irlanda. Ningun pais ha ganado Eurovision mas veces que Irlanda.",
+      "uri_apple_music": "applemusic://track/74409108"
     },
     {
       "year": 1997,
       "uri": "spotify:track:3QzYNbqWxef2iBsRWUyCUc",
       "artist": "Katrina & The Waves",
       "title": "Love Shine a Light",
-      "chart_info": {"eurovision_position": 1, "eurovision_points": 227, "country": "United Kingdom"},
+      "chart_info": {
+        "eurovision_position": 1,
+        "eurovision_points": 227,
+        "country": "United Kingdom"
+      },
       "certifications": [],
-      "awards": ["Eurovision Winner 1997"],
-      "awards_de": ["Eurovision-Sieger 1997"],
-      "awards_es": ["Ganador de Eurovision 1997"],
+      "awards": [
+        "Eurovision Winner 1997"
+      ],
+      "awards_de": [
+        "Eurovision-Sieger 1997"
+      ],
+      "awards_es": [
+        "Ganador de Eurovision 1997"
+      ],
       "fun_fact": "Love Shine a Light was the UK's fifth and most recent Eurovision victory. Katrina & The Waves won by the largest margin ever at that time, with 70 points ahead of second place. Katrina Leskanich was already famous for 'Walking on Sunshine'.",
       "fun_fact_de": "Love Shine a Light war der funfte und jungste Eurovision-Sieg des Vereinigten Konigreichs. Katrina & The Waves gewannen mit dem grossten Vorsprung aller Zeiten, 70 Punkte vor dem zweiten Platz. Katrina Leskanich war bereits beruhmt durch 'Walking on Sunshine'.",
-      "fun_fact_es": "Love Shine a Light fue la quinta y mas reciente victoria del Reino Unido en Eurovision. Katrina & The Waves ganaron con el mayor margen de la historia hasta ese momento, 70 puntos por delante del segundo lugar. Katrina Leskanich ya era famosa por 'Walking on Sunshine'."
+      "fun_fact_es": "Love Shine a Light fue la quinta y mas reciente victoria del Reino Unido en Eurovision. Katrina & The Waves ganaron con el mayor margen de la historia hasta ese momento, 70 puntos por delante del segundo lugar. Katrina Leskanich ya era famosa por 'Walking on Sunshine'.",
+      "uri_apple_music": "applemusic://track/1438446169"
     },
     {
       "year": 1998,
       "uri": "spotify:track:2v2SuFiCqmxqlqRyonSycx",
       "artist": "Dana International",
       "title": "Diva",
-      "chart_info": {"eurovision_position": 1, "eurovision_points": 172, "country": "Israel"},
+      "chart_info": {
+        "eurovision_position": 1,
+        "eurovision_points": 172,
+        "country": "Israel"
+      },
       "certifications": [],
-      "awards": ["Eurovision Winner 1998"],
-      "awards_de": ["Eurovision-Sieger 1998"],
-      "awards_es": ["Ganador de Eurovision 1998"],
+      "awards": [
+        "Eurovision Winner 1998"
+      ],
+      "awards_de": [
+        "Eurovision-Sieger 1998"
+      ],
+      "awards_es": [
+        "Ganador de Eurovision 1998"
+      ],
       "fun_fact": "Diva made history as Dana International became the first transgender winner of Eurovision. Her victory was controversial in some quarters but celebrated as a milestone for LGBTQ+ representation. The song became a global dance hit.",
       "fun_fact_de": "Diva schrieb Geschichte, als Dana International die erste transsexuelle Siegerin des Eurovision wurde. Ihr Sieg war in manchen Kreisen umstritten, wurde aber als Meilenstein fur die LGBTQ+-Reprasentation gefeiert. Das Lied wurde ein weltweiter Dance-Hit.",
       "fun_fact_es": "Diva hizo historia cuando Dana International se convirtio en la primera ganadora transgenero de Eurovision. Su victoria fue controvertida en algunos sectores pero celebrada como un hito para la representacion LGBTQ+. La cancion se convirtio en un exito de baile mundial."
@@ -651,39 +1155,71 @@
       "uri": "spotify:track:4omWhsNIPxarzpBgMsWBmB",
       "artist": "Charlotte Perrelli",
       "title": "Take Me to Your Heaven",
-      "chart_info": {"eurovision_position": 1, "eurovision_points": 163, "country": "Sweden"},
+      "chart_info": {
+        "eurovision_position": 1,
+        "eurovision_points": 163,
+        "country": "Sweden"
+      },
       "certifications": [],
-      "awards": ["Eurovision Winner 1999"],
-      "awards_de": ["Eurovision-Sieger 1999"],
-      "awards_es": ["Ganador de Eurovision 1999"],
+      "awards": [
+        "Eurovision Winner 1999"
+      ],
+      "awards_de": [
+        "Eurovision-Sieger 1999"
+      ],
+      "awards_es": [
+        "Ganador de Eurovision 1999"
+      ],
       "fun_fact": "Take Me to Your Heaven was Sweden's fourth Eurovision victory. Charlotte Nilsson (later Perrelli) performed a classic Scandinavian pop song. She returned to Eurovision in 2008 with 'Hero', finishing 18th.",
       "fun_fact_de": "Take Me to Your Heaven war Schwedens vierter Eurovision-Sieg. Charlotte Nilsson (spater Perrelli) trug einen klassischen skandinavischen Popsong vor. Sie kehrte 2008 mit 'Hero' zum Eurovision zuruck und belegte den 18. Platz.",
-      "fun_fact_es": "Take Me to Your Heaven fue la cuarta victoria de Suecia en Eurovision. Charlotte Nilsson (luego Perrelli) interpreto una clasica cancion pop escandinava. Regreso a Eurovision en 2008 con 'Hero', quedando en el puesto 18."
+      "fun_fact_es": "Take Me to Your Heaven fue la cuarta victoria de Suecia en Eurovision. Charlotte Nilsson (luego Perrelli) interpreto una clasica cancion pop escandinava. Regreso a Eurovision en 2008 con 'Hero', quedando en el puesto 18.",
+      "uri_apple_music": "applemusic://track/1477474325"
     },
     {
       "year": 2000,
       "uri": "spotify:track:4v2RaPHSsTvNkggw3RqyeT",
       "artist": "Olsen Brothers",
       "title": "Fly on the Wings of Love",
-      "chart_info": {"eurovision_position": 1, "eurovision_points": 195, "country": "Denmark"},
+      "chart_info": {
+        "eurovision_position": 1,
+        "eurovision_points": 195,
+        "country": "Denmark"
+      },
       "certifications": [],
-      "awards": ["Eurovision Winner 2000"],
-      "awards_de": ["Eurovision-Sieger 2000"],
-      "awards_es": ["Ganador de Eurovision 2000"],
+      "awards": [
+        "Eurovision Winner 2000"
+      ],
+      "awards_de": [
+        "Eurovision-Sieger 2000"
+      ],
+      "awards_es": [
+        "Ganador de Eurovision 2000"
+      ],
       "fun_fact": "Fly on the Wings of Love ended Denmark's 37-year Eurovision drought since 1963. The Olsen Brothers (Jorgen and Niels) were veteran musicians in their 50s when they won. Their victory proved age was no barrier to Eurovision success.",
       "fun_fact_de": "Fly on the Wings of Love beendete Danemarks 37-jahrige Eurovision-Durststrecke seit 1963. Die Olsen Brothers (Jorgen und Niels) waren erfahrene Musiker in ihren 50ern, als sie gewannen. Ihr Sieg bewies, dass das Alter kein Hindernis fur den Eurovision-Erfolg ist.",
-      "fun_fact_es": "Fly on the Wings of Love termino con la sequia de 37 anos de Dinamarca en Eurovision desde 1963. Los hermanos Olsen (Jorgen y Niels) eran musicos veteranos en sus 50 anos cuando ganaron. Su victoria demostro que la edad no era una barrera para el exito en Eurovision."
+      "fun_fact_es": "Fly on the Wings of Love termino con la sequia de 37 anos de Dinamarca en Eurovision desde 1963. Los hermanos Olsen (Jorgen y Niels) eran musicos veteranos en sus 50 anos cuando ganaron. Su victoria demostro que la edad no era una barrera para el exito en Eurovision.",
+      "uri_apple_music": "applemusic://track/690981282"
     },
     {
       "year": 2001,
       "uri": "spotify:track:3h5mWmIOf44J2AzSfZ1pbN",
       "artist": "Tanel Padar;Dave Benton",
       "title": "Everybody",
-      "chart_info": {"eurovision_position": 1, "eurovision_points": 198, "country": "Estonia"},
+      "chart_info": {
+        "eurovision_position": 1,
+        "eurovision_points": 198,
+        "country": "Estonia"
+      },
       "certifications": [],
-      "awards": ["Eurovision Winner 2001"],
-      "awards_de": ["Eurovision-Sieger 2001"],
-      "awards_es": ["Ganador de Eurovision 2001"],
+      "awards": [
+        "Eurovision Winner 2001"
+      ],
+      "awards_de": [
+        "Eurovision-Sieger 2001"
+      ],
+      "awards_es": [
+        "Ganador de Eurovision 2001"
+      ],
       "fun_fact": "Everybody was Estonia's first Eurovision victory and the first for any former Soviet republic. Dave Benton became the oldest winner at 50 and the first Black performer to win. Estonia went from debut in 1994 to champions in just seven years.",
       "fun_fact_de": "Everybody war Estlands erster Eurovision-Sieg und der erste fur eine ehemalige Sowjetrepublik. Dave Benton wurde mit 50 Jahren der alteste Sieger und der erste schwarze Kunstler, der gewann. Estland entwickelte sich vom Debut 1994 zum Champion in nur sieben Jahren.",
       "fun_fact_es": "Everybody fue la primera victoria de Estonia en Eurovision y la primera para cualquier antigua republica sovietica. Dave Benton se convirtio en el ganador mas viejo a los 50 anos y el primer interprete negro en ganar. Estonia paso del debut en 1994 a campeones en solo siete anos."
@@ -693,81 +1229,146 @@
       "uri": "spotify:track:70tFqMdkFXCPeirRaLAKKM",
       "artist": "Marie N",
       "title": "I Wanna",
-      "chart_info": {"eurovision_position": 1, "eurovision_points": 176, "country": "Latvia"},
+      "chart_info": {
+        "eurovision_position": 1,
+        "eurovision_points": 176,
+        "country": "Latvia"
+      },
       "certifications": [],
-      "awards": ["Eurovision Winner 2002"],
-      "awards_de": ["Eurovision-Sieger 2002"],
-      "awards_es": ["Ganador de Eurovision 2002"],
+      "awards": [
+        "Eurovision Winner 2002"
+      ],
+      "awards_de": [
+        "Eurovision-Sieger 2002"
+      ],
+      "awards_es": [
+        "Ganador de Eurovision 2002"
+      ],
       "fun_fact": "I Wanna gave Latvia their first Eurovision victory at only their third attempt. Marie N's sultry performance and costume changes during the song created a memorable spectacle. Latvia hosted Eurovision 2003 in Riga.",
       "fun_fact_de": "I Wanna brachte Lettland bei erst seinem dritten Versuch den ersten Eurovision-Sieg. Marie Ns verfuhrerische Darbietung und Kostumwechsel wahrend des Liedes schufen ein unvergessliches Spektakel. Lettland richtete 2003 den Eurovision in Riga aus.",
-      "fun_fact_es": "I Wanna dio a Letonia su primera victoria en Eurovision en solo su tercer intento. La sensual actuacion de Marie N y los cambios de vestuario durante la cancion crearon un espectaculo memorable. Letonia fue anfitrion de Eurovision 2003 en Riga."
+      "fun_fact_es": "I Wanna dio a Letonia su primera victoria en Eurovision en solo su tercer intento. La sensual actuacion de Marie N y los cambios de vestuario durante la cancion crearon un espectaculo memorable. Letonia fue anfitrion de Eurovision 2003 en Riga.",
+      "uri_apple_music": "applemusic://track/260662904"
     },
     {
       "year": 2003,
       "uri": "spotify:track:5I8ENb7zzrbYLwhGESY9CF",
       "artist": "Sertab Erener",
       "title": "Every Way That I Can",
-      "chart_info": {"eurovision_position": 1, "eurovision_points": 167, "country": "Turkey"},
+      "chart_info": {
+        "eurovision_position": 1,
+        "eurovision_points": 167,
+        "country": "Turkey"
+      },
       "certifications": [],
-      "awards": ["Eurovision Winner 2003"],
-      "awards_de": ["Eurovision-Sieger 2003"],
-      "awards_es": ["Ganador de Eurovision 2003"],
+      "awards": [
+        "Eurovision Winner 2003"
+      ],
+      "awards_de": [
+        "Eurovision-Sieger 2003"
+      ],
+      "awards_es": [
+        "Ganador de Eurovision 2003"
+      ],
       "fun_fact": "Everyway That I Can was Turkey's first and only Eurovision victory. Sertab Erener's belly dancing and Turkish-influenced pop sound brought something new to the contest. The song featured backing dancers and elaborate choreography.",
       "fun_fact_de": "Everyway That I Can war der erste und einzige Eurovision-Sieg der Turkei. Sertab Ereners Bauchtanz und turkisch beeinflusster Pop brachten etwas Neues in den Wettbewerb. Das Lied enthielt Backgroundtanzer und aufwendige Choreografie.",
-      "fun_fact_es": "Everyway That I Can fue la primera y unica victoria de Turquia en Eurovision. La danza del vientre de Sertab Erener y el sonido pop con influencia turca trajeron algo nuevo al concurso. La cancion presento bailarines de apoyo y una elaborada coreografia."
+      "fun_fact_es": "Everyway That I Can fue la primera y unica victoria de Turquia en Eurovision. La danza del vientre de Sertab Erener y el sonido pop con influencia turca trajeron algo nuevo al concurso. La cancion presento bailarines de apoyo y una elaborada coreografia.",
+      "uri_apple_music": "applemusic://track/400705407"
     },
     {
       "year": 2004,
       "uri": "spotify:track:1Lav2Z3RKu71MJLIjQz4dQ",
       "artist": "Ruslana",
       "title": "Wild Dances",
-      "chart_info": {"eurovision_position": 1, "eurovision_points": 280, "country": "Ukraine"},
+      "chart_info": {
+        "eurovision_position": 1,
+        "eurovision_points": 280,
+        "country": "Ukraine"
+      },
       "certifications": [],
-      "awards": ["Eurovision Winner 2004"],
-      "awards_de": ["Eurovision-Sieger 2004"],
-      "awards_es": ["Ganador de Eurovision 2004"],
+      "awards": [
+        "Eurovision Winner 2004"
+      ],
+      "awards_de": [
+        "Eurovision-Sieger 2004"
+      ],
+      "awards_es": [
+        "Ganador de Eurovision 2004"
+      ],
       "fun_fact": "Wild Dances was Ukraine's first Eurovision victory and featured Hutsul folk music elements from the Carpathian Mountains. Ruslana's high-energy performance with fire and tribal dancing was revolutionary. She later became a prominent activist during Ukraine's political upheavals.",
       "fun_fact_de": "Wild Dances war der erste Eurovision-Sieg der Ukraine und enthielt Hutsul-Volksmusik-Elemente aus den Karpaten. Ruslanas energiegeladene Darbietung mit Feuer und Stammestanzen war revolutionar. Sie wurde spater wahrend der politischen Umwalzungen in der Ukraine zu einer prominenten Aktivistin.",
-      "fun_fact_es": "Wild Dances fue la primera victoria de Ucrania en Eurovision y presento elementos de musica folclorica hutsul de los Montes Carpatos. La actuacion de alta energia de Ruslana con fuego y danzas tribales fue revolucionaria. Mas tarde se convirtio en una activista prominente durante las convulsiones politicas de Ucrania."
+      "fun_fact_es": "Wild Dances fue la primera victoria de Ucrania en Eurovision y presento elementos de musica folclorica hutsul de los Montes Carpatos. La actuacion de alta energia de Ruslana con fuego y danzas tribales fue revolucionaria. Mas tarde se convirtio en una activista prominente durante las convulsiones politicas de Ucrania.",
+      "uri_apple_music": "applemusic://track/724020692"
     },
     {
       "year": 2005,
       "uri": "spotify:track:6LkCvCc9oFoLDv4DLhzTox",
       "artist": "Helena Paparizou",
       "title": "My Number One",
-      "chart_info": {"eurovision_position": 1, "eurovision_points": 230, "country": "Greece"},
+      "chart_info": {
+        "eurovision_position": 1,
+        "eurovision_points": 230,
+        "country": "Greece"
+      },
       "certifications": [],
-      "awards": ["Eurovision Winner 2005"],
-      "awards_de": ["Eurovision-Sieger 2005"],
-      "awards_es": ["Ganador de Eurovision 2005"],
+      "awards": [
+        "Eurovision Winner 2005"
+      ],
+      "awards_de": [
+        "Eurovision-Sieger 2005"
+      ],
+      "awards_es": [
+        "Ganador de Eurovision 2005"
+      ],
       "fun_fact": "My Number One was Greece's first Eurovision victory after decades of participation. Helena Paparizou's Greek-Swedish background and polished pop performance captivated voters. She previously competed in 2001 as part of the duo Antique.",
       "fun_fact_de": "My Number One war Griechenlands erster Eurovision-Sieg nach Jahrzehnten der Teilnahme. Helena Paparizous griechisch-schwedischer Hintergrund und ihre ausgefeilte Pop-Darbietung begeisterten die Wahler. Sie hatte 2001 als Teil des Duos Antique teilgenommen.",
-      "fun_fact_es": "My Number One fue la primera victoria de Grecia en Eurovision despues de decadas de participacion. El trasfondo greco-sueco de Helena Paparizou y su pulida actuacion pop cautivaron a los votantes. Previamente habia competido en 2001 como parte del duo Antique."
+      "fun_fact_es": "My Number One fue la primera victoria de Grecia en Eurovision despues de decadas de participacion. El trasfondo greco-sueco de Helena Paparizou y su pulida actuacion pop cautivaron a los votantes. Previamente habia competido en 2001 como parte del duo Antique.",
+      "uri_apple_music": "applemusic://track/299636095"
     },
     {
       "year": 2006,
       "uri": "spotify:track:7BxBHNoIqiybZHlbeqMmvP",
       "artist": "Lordi",
       "title": "Hard Rock Hallelujah",
-      "chart_info": {"eurovision_position": 1, "eurovision_points": 292, "country": "Finland"},
+      "chart_info": {
+        "eurovision_position": 1,
+        "eurovision_points": 292,
+        "country": "Finland"
+      },
       "certifications": [],
-      "awards": ["Eurovision Winner 2006"],
-      "awards_de": ["Eurovision-Sieger 2006"],
-      "awards_es": ["Ganador de Eurovision 2006"],
+      "awards": [
+        "Eurovision Winner 2006"
+      ],
+      "awards_de": [
+        "Eurovision-Sieger 2006"
+      ],
+      "awards_es": [
+        "Ganador de Eurovision 2006"
+      ],
       "fun_fact": "Hard Rock Hallelujah shocked Eurovision with Finnish monster-costumed heavy metal winning the contest. Lordi's theatrical rock performance proved Eurovision could embrace all genres. Finland had never won before despite competing since 1961.",
       "fun_fact_de": "Hard Rock Hallelujah schockierte den Eurovision, als finnischer Heavy Metal in Monsterkostumen den Wettbewerb gewann. Lordis theatralische Rock-Darbietung bewies, dass der Eurovision alle Genres umfassen kann. Finnland hatte trotz Teilnahme seit 1961 noch nie gewonnen.",
-      "fun_fact_es": "Hard Rock Hallelujah sorprendio a Eurovision cuando el heavy metal finlandes con disfraces de monstruos gano el concurso. La teatral actuacion de rock de Lordi demostro que Eurovision podia abrazar todos los generos. Finlandia nunca habia ganado a pesar de competir desde 1961."
+      "fun_fact_es": "Hard Rock Hallelujah sorprendio a Eurovision cuando el heavy metal finlandes con disfraces de monstruos gano el concurso. La teatral actuacion de rock de Lordi demostro que Eurovision podia abrazar todos los generos. Finlandia nunca habia ganado a pesar de competir desde 1961.",
+      "uri_apple_music": "applemusic://track/389516413"
     },
     {
       "year": 2007,
       "uri": "spotify:track:1ue71r2sNUvl4LSqvgVVcZ",
       "artist": "Marija Serifovic",
       "title": "Molitva",
-      "chart_info": {"eurovision_position": 1, "eurovision_points": 268, "country": "Serbia"},
+      "chart_info": {
+        "eurovision_position": 1,
+        "eurovision_points": 268,
+        "country": "Serbia"
+      },
       "certifications": [],
-      "awards": ["Eurovision Winner 2007"],
-      "awards_de": ["Eurovision-Sieger 2007"],
-      "awards_es": ["Ganador de Eurovision 2007"],
+      "awards": [
+        "Eurovision Winner 2007"
+      ],
+      "awards_de": [
+        "Eurovision-Sieger 2007"
+      ],
+      "awards_es": [
+        "Ganador de Eurovision 2007"
+      ],
       "fun_fact": "Molitva (Prayer) was Serbia's first entry and first victory as an independent nation after Yugoslavia's dissolution. Marija Serifovic's emotional ballad, performed entirely in Serbian, won overwhelmingly. The powerful song needed no gimmicks.",
       "fun_fact_de": "Molitva (Gebet) war Serbiens erster Beitrag und erster Sieg als unabhangige Nation nach der Auflosung Jugoslawiens. Marija Serifovics emotionale Ballade, ganz auf Serbisch vorgetragen, gewann uberwaltigend. Das kraftvolle Lied brauchte keine Gimmicks.",
       "fun_fact_es": "Molitva (Oracion) fue la primera entrada y primera victoria de Serbia como nacion independiente despues de la disolucion de Yugoslavia. La emotiva balada de Marija Serifovic, interpretada enteramente en serbio, gano de manera abrumadora. La poderosa cancion no necesito trucos."
@@ -777,53 +1378,96 @@
       "uri": "spotify:track:3tYLiiS9VlIXWaB677KJjQ",
       "artist": "Dima Bilan",
       "title": "Believe",
-      "chart_info": {"eurovision_position": 1, "eurovision_points": 272, "country": "Russia"},
+      "chart_info": {
+        "eurovision_position": 1,
+        "eurovision_points": 272,
+        "country": "Russia"
+      },
       "certifications": [],
-      "awards": ["Eurovision Winner 2008"],
-      "awards_de": ["Eurovision-Sieger 2008"],
-      "awards_es": ["Ganador de Eurovision 2008"],
+      "awards": [
+        "Eurovision Winner 2008"
+      ],
+      "awards_de": [
+        "Eurovision-Sieger 2008"
+      ],
+      "awards_es": [
+        "Ganador de Eurovision 2008"
+      ],
       "fun_fact": "Believe gave Russia their first and only Eurovision victory. Dima Bilan performed with Hungarian violinist Edvin Marton and an Olympic ice skater on stage. He had finished second in 2006, making 2008 his redemption year.",
       "fun_fact_de": "Believe brachte Russland seinen ersten und einzigen Eurovision-Sieg. Dima Bilan trat mit dem ungarischen Geiger Edvin Marton und einem olympischen Eislaufer auf der Buhne auf. Er war 2006 Zweiter geworden, was 2008 zu seinem Jahr der Rehabilitation machte.",
-      "fun_fact_es": "Believe dio a Rusia su primera y unica victoria en Eurovision. Dima Bilan actuo con el violinista hungaro Edvin Marton y un patinador olimpico sobre hielo en el escenario. Habia quedado segundo en 2006, haciendo de 2008 su ano de redencion."
+      "fun_fact_es": "Believe dio a Rusia su primera y unica victoria en Eurovision. Dima Bilan actuo con el violinista hungaro Edvin Marton y un patinador olimpico sobre hielo en el escenario. Habia quedado segundo en 2006, haciendo de 2008 su ano de redencion.",
+      "uri_apple_music": "applemusic://track/1859966612"
     },
     {
       "year": 2009,
       "uri": "spotify:track:2kWAsHovOITGRmAwXoWoJE",
       "artist": "Alexander Rybak",
       "title": "Fairytale",
-      "chart_info": {"eurovision_position": 1, "eurovision_points": 387, "country": "Norway"},
+      "chart_info": {
+        "eurovision_position": 1,
+        "eurovision_points": 387,
+        "country": "Norway"
+      },
       "certifications": [],
-      "awards": ["Eurovision Winner 2009"],
-      "awards_de": ["Eurovision-Sieger 2009"],
-      "awards_es": ["Ganador de Eurovision 2009"],
+      "awards": [
+        "Eurovision Winner 2009"
+      ],
+      "awards_de": [
+        "Eurovision-Sieger 2009"
+      ],
+      "awards_es": [
+        "Ganador de Eurovision 2009"
+      ],
       "fun_fact": "Fairytale won with 387 points, the highest score ever achieved at the time under the voting system. Alexander Rybak's folk-pop song and violin playing charmed all of Europe. The Belarusian-Norwegian performer was just 22 years old.",
       "fun_fact_de": "Fairytale gewann mit 387 Punkten, der hochsten jemals erreichten Punktzahl unter dem damaligen Abstimmungssystem. Alexander Rybaks Folk-Pop-Lied und Geigenspiel bezauberten ganz Europa. Der weissrussisch-norwegische Kunstler war erst 22 Jahre alt.",
-      "fun_fact_es": "Fairytale gano con 387 puntos, la puntuacion mas alta jamas alcanzada bajo el sistema de votacion de entonces. La cancion folk-pop de Alexander Rybak y su violin encantaron a toda Europa. El interprete bielorruso-noruego tenia solo 22 anos."
+      "fun_fact_es": "Fairytale gano con 387 puntos, la puntuacion mas alta jamas alcanzada bajo el sistema de votacion de entonces. La cancion folk-pop de Alexander Rybak y su violin encantaron a toda Europa. El interprete bielorruso-noruego tenia solo 22 anos.",
+      "uri_apple_music": "applemusic://track/1438988564"
     },
     {
       "year": 2010,
       "uri": "spotify:track:6V3OVnS8A0P2I7j5e7YRBb",
       "artist": "Lena",
       "title": "Satellite",
-      "chart_info": {"eurovision_position": 1, "eurovision_points": 246, "country": "Germany"},
+      "chart_info": {
+        "eurovision_position": 1,
+        "eurovision_points": 246,
+        "country": "Germany"
+      },
       "certifications": [],
-      "awards": ["Eurovision Winner 2010"],
-      "awards_de": ["Eurovision-Sieger 2010"],
-      "awards_es": ["Ganador de Eurovision 2010"],
+      "awards": [
+        "Eurovision Winner 2010"
+      ],
+      "awards_de": [
+        "Eurovision-Sieger 2010"
+      ],
+      "awards_es": [
+        "Ganador de Eurovision 2010"
+      ],
       "fun_fact": "Satellite gave Germany their second Eurovision victory and first since 1982. Lena Meyer-Landrut's quirky, charming performance captured hearts across Europe. She was discovered through the German TV show 'Unser Star fur Oslo'.",
       "fun_fact_de": "Satellite brachte Deutschland seinen zweiten Eurovision-Sieg und den ersten seit 1982. Lena Meyer-Landruts schrullige, charmante Darbietung eroberte die Herzen in ganz Europa. Sie wurde durch die deutsche TV-Show 'Unser Star fur Oslo' entdeckt.",
-      "fun_fact_es": "Satellite dio a Alemania su segunda victoria en Eurovision y la primera desde 1982. La peculiar y encantadora actuacion de Lena Meyer-Landrut conquisto corazones en toda Europa. Fue descubierta a traves del programa de television aleman 'Unser Star fur Oslo'."
+      "fun_fact_es": "Satellite dio a Alemania su segunda victoria en Eurovision y la primera desde 1982. La peculiar y encantadora actuacion de Lena Meyer-Landrut conquisto corazones en toda Europa. Fue descubierta a traves del programa de television aleman 'Unser Star fur Oslo'.",
+      "uri_apple_music": "applemusic://track/1445293252"
     },
     {
       "year": 2011,
       "uri": "spotify:track:5UoNgkMxD3JbWGFW9hmQAg",
       "artist": "Ell/Nikki",
       "title": "Running Scared",
-      "chart_info": {"eurovision_position": 1, "eurovision_points": 221, "country": "Azerbaijan"},
+      "chart_info": {
+        "eurovision_position": 1,
+        "eurovision_points": 221,
+        "country": "Azerbaijan"
+      },
       "certifications": [],
-      "awards": ["Eurovision Winner 2011"],
-      "awards_de": ["Eurovision-Sieger 2011"],
-      "awards_es": ["Ganador de Eurovision 2011"],
+      "awards": [
+        "Eurovision Winner 2011"
+      ],
+      "awards_de": [
+        "Eurovision-Sieger 2011"
+      ],
+      "awards_es": [
+        "Ganador de Eurovision 2011"
+      ],
       "fun_fact": "Running Scared was Azerbaijan's first Eurovision victory after debuting only in 2008. The romantic duet by Ell and Nikki narrowly beat Italy. The win led Azerbaijan to host Eurovision 2012 in their specially-built Crystal Hall.",
       "fun_fact_de": "Running Scared war Aserbaidschans erster Eurovision-Sieg nach dem Debut erst 2008. Das romantische Duett von Ell und Nikki schlug Italien knapp. Der Sieg fuhrte dazu, dass Aserbaidschan den Eurovision 2012 in seiner eigens erbauten Crystal Hall ausrichtete.",
       "fun_fact_es": "Running Scared fue la primera victoria de Azerbaiyan en Eurovision despues de debutar apenas en 2008. El romantico duo de Ell y Nikki vencio a Italia por poco. La victoria llevo a Azerbaiyan a ser anfitrion de Eurovision 2012 en su Crystal Hall especialmente construido."
@@ -833,182 +1477,327 @@
       "uri": "spotify:track:1xN7BpTAWnZkuSLOtRP6Qc",
       "artist": "Loreen",
       "title": "Euphoria",
-      "chart_info": {"eurovision_position": 1, "eurovision_points": 372, "country": "Sweden"},
+      "chart_info": {
+        "eurovision_position": 1,
+        "eurovision_points": 372,
+        "country": "Sweden"
+      },
       "certifications": [],
-      "awards": ["Eurovision Winner 2012"],
-      "awards_de": ["Eurovision-Sieger 2012"],
-      "awards_es": ["Ganador de Eurovision 2012"],
+      "awards": [
+        "Eurovision Winner 2012"
+      ],
+      "awards_de": [
+        "Eurovision-Sieger 2012"
+      ],
+      "awards_es": [
+        "Ganador de Eurovision 2012"
+      ],
       "fun_fact": "Euphoria is considered one of Eurovision's greatest winning songs ever. Loreen received first place votes from 18 countries - a record. The haunting dance track topped charts worldwide and has over 300 million Spotify streams.",
       "fun_fact_de": "Euphoria gilt als eines der grossten Eurovision-Siegerlieder aller Zeiten. Loreen erhielt von 18 Landern den ersten Platz - ein Rekord. Der eindringliche Dance-Track fuhrte weltweit die Charts an und hat uber 300 Millionen Spotify-Streams.",
-      "fun_fact_es": "Euphoria se considera una de las mejores canciones ganadoras de Eurovision de todos los tiempos. Loreen recibio votos de primer lugar de 18 paises - un record. La cautivadora pista de baile encabezo las listas en todo el mundo y tiene mas de 300 millones de reproducciones en Spotify."
+      "fun_fact_es": "Euphoria se considera una de las mejores canciones ganadoras de Eurovision de todos los tiempos. Loreen recibio votos de primer lugar de 18 paises - un record. La cautivadora pista de baile encabezo las listas en todo el mundo y tiene mas de 300 millones de reproducciones en Spotify.",
+      "uri_apple_music": "applemusic://track/534019647"
     },
     {
       "year": 2013,
       "uri": "spotify:track:3yRwgprKX3If2zcuGfKFBu",
       "artist": "Emmelie de Forest",
       "title": "Only Teardrops",
-      "chart_info": {"eurovision_position": 1, "eurovision_points": 281, "country": "Denmark"},
+      "chart_info": {
+        "eurovision_position": 1,
+        "eurovision_points": 281,
+        "country": "Denmark"
+      },
       "certifications": [],
-      "awards": ["Eurovision Winner 2013"],
-      "awards_de": ["Eurovision-Sieger 2013"],
-      "awards_es": ["Ganador de Eurovision 2013"],
+      "awards": [
+        "Eurovision Winner 2013"
+      ],
+      "awards_de": [
+        "Eurovision-Sieger 2013"
+      ],
+      "awards_es": [
+        "Ganador de Eurovision 2013"
+      ],
       "fun_fact": "Only Teardrops gave Denmark their third Eurovision victory. Emmelie de Forest's ethereal folk-pop performance featured barefoot dancing and tin whistle. The song's message about letting go of pain resonated with viewers across Europe.",
       "fun_fact_de": "Only Teardrops brachte Danemark seinen dritten Eurovision-Sieg. Emmelie de Forests atherische Folk-Pop-Darbietung enthielt barfussiges Tanzen und Blechflote. Die Botschaft des Liedes uber das Loslassen von Schmerz fand bei den Zuschauern in ganz Europa Anklang.",
-      "fun_fact_es": "Only Teardrops dio a Dinamarca su tercera victoria en Eurovision. La eterea actuacion folk-pop de Emmelie de Forest incluyo baile descalzo y flauta de hojalata. El mensaje de la cancion sobre dejar ir el dolor resono con los espectadores de toda Europa."
+      "fun_fact_es": "Only Teardrops dio a Dinamarca su tercera victoria en Eurovision. La eterea actuacion folk-pop de Emmelie de Forest incluyo baile descalzo y flauta de hojalata. El mensaje de la cancion sobre dejar ir el dolor resono con los espectadores de toda Europa.",
+      "uri_apple_music": "applemusic://track/643675723"
     },
     {
       "year": 2014,
       "uri": "spotify:track:1ijX03QOR6a1wI322HifSV",
       "artist": "Conchita Wurst",
       "title": "Rise Like a Phoenix",
-      "chart_info": {"eurovision_position": 1, "eurovision_points": 290, "country": "Austria"},
+      "chart_info": {
+        "eurovision_position": 1,
+        "eurovision_points": 290,
+        "country": "Austria"
+      },
       "certifications": [],
-      "awards": ["Eurovision Winner 2014"],
-      "awards_de": ["Eurovision-Sieger 2014"],
-      "awards_es": ["Ganador de Eurovision 2014"],
+      "awards": [
+        "Eurovision Winner 2014"
+      ],
+      "awards_de": [
+        "Eurovision-Sieger 2014"
+      ],
+      "awards_es": [
+        "Ganador de Eurovision 2014"
+      ],
       "fun_fact": "Rise Like a Phoenix made Conchita Wurst (drag persona of Tom Neuwirth) a global icon and LGBTQ+ symbol. The bearded drag queen's powerful ballad was Austria's second win. She performed without backup dancers - the first winner to do so since 1970.",
       "fun_fact_de": "Rise Like a Phoenix machte Conchita Wurst (Drag-Persona von Tom Neuwirth) zu einer globalen Ikone und einem LGBTQ+-Symbol. Die kraftvolle Ballade der bartigen Drag Queen war Osterreichs zweiter Sieg. Sie trat ohne Backgroundtanzer auf - der erste Sieger seit 1970, der das tat.",
-      "fun_fact_es": "Rise Like a Phoenix convirtio a Conchita Wurst (personaje drag de Tom Neuwirth) en un icono global y simbolo LGBTQ+. La poderosa balada de la drag queen con barba fue la segunda victoria de Austria. Actuo sin bailarines de apoyo - la primera ganadora en hacerlo desde 1970."
+      "fun_fact_es": "Rise Like a Phoenix convirtio a Conchita Wurst (personaje drag de Tom Neuwirth) en un icono global y simbolo LGBTQ+. La poderosa balada de la drag queen con barba fue la segunda victoria de Austria. Actuo sin bailarines de apoyo - la primera ganadora en hacerlo desde 1970.",
+      "uri_apple_music": "applemusic://track/844169216"
     },
     {
       "year": 2015,
       "uri": "spotify:track:33lbkEAr4M93uGWveuCPCf",
       "artist": "Mans Zelmerlow",
       "title": "Heroes",
-      "chart_info": {"eurovision_position": 1, "eurovision_points": 365, "country": "Sweden"},
+      "chart_info": {
+        "eurovision_position": 1,
+        "eurovision_points": 365,
+        "country": "Sweden"
+      },
       "certifications": [],
-      "awards": ["Eurovision Winner 2015"],
-      "awards_de": ["Eurovision-Sieger 2015"],
-      "awards_es": ["Ganador de Eurovision 2015"],
+      "awards": [
+        "Eurovision Winner 2015"
+      ],
+      "awards_de": [
+        "Eurovision-Sieger 2015"
+      ],
+      "awards_es": [
+        "Ganador de Eurovision 2015"
+      ],
       "fun_fact": "Heroes featured groundbreaking visual effects with animated stick figures interacting with the performer live on stage. Mans Zelmerlow's performance revolutionized Eurovision staging. The technology used cost over one million euros to develop.",
       "fun_fact_de": "Heroes enthielt bahnbrechende visuelle Effekte mit animierten Strichmännchen, die live auf der Buhne mit dem Kunstler interagierten. Mans Zelmerlows Darbietung revolutionierte die Eurovision-Buhnengestaltung. Die verwendete Technologie kostete uber eine Million Euro in der Entwicklung.",
-      "fun_fact_es": "Heroes presento efectos visuales revolucionarios con figuras de palitos animadas interactuando con el interprete en vivo en el escenario. La actuacion de Mans Zelmerlow revoluciono la puesta en escena de Eurovision. La tecnologia utilizada costo mas de un millon de euros desarrollar."
+      "fun_fact_es": "Heroes presento efectos visuales revolucionarios con figuras de palitos animadas interactuando con el interprete en vivo en el escenario. La actuacion de Mans Zelmerlow revoluciono la puesta en escena de Eurovision. La tecnologia utilizada costo mas de un millon de euros desarrollar.",
+      "uri_apple_music": "applemusic://track/968817858"
     },
     {
       "year": 2016,
       "uri": "spotify:track:2nxTpjhxLXeyBOxYnRnT76",
       "artist": "Jamala",
       "title": "1944",
-      "chart_info": {"eurovision_position": 1, "eurovision_points": 534, "country": "Ukraine"},
+      "chart_info": {
+        "eurovision_position": 1,
+        "eurovision_points": 534,
+        "country": "Ukraine"
+      },
       "certifications": [],
-      "awards": ["Eurovision Winner 2016"],
-      "awards_de": ["Eurovision-Sieger 2016"],
-      "awards_es": ["Ganador de Eurovision 2016"],
+      "awards": [
+        "Eurovision Winner 2016"
+      ],
+      "awards_de": [
+        "Eurovision-Sieger 2016"
+      ],
+      "awards_es": [
+        "Ganador de Eurovision 2016"
+      ],
       "fun_fact": "1944 told the story of Stalin's deportation of Crimean Tatars, including Jamala's great-grandmother. The politically charged song won controversially amid Russia-Ukraine tensions. It remains one of Eurovision's most powerful and emotional winning entries.",
       "fun_fact_de": "1944 erzahlte die Geschichte von Stalins Deportation der Krimtataren, einschliesslich Jamalas Urgrossmutter. Das politisch aufgeladene Lied gewann umstritten inmitten russisch-ukrainischer Spannungen. Es bleibt einer der kraftvollsten und emotionalsten Siegerbeitrage des Eurovision.",
-      "fun_fact_es": "1944 conto la historia de la deportacion de los tartaros de Crimea por Stalin, incluyendo a la bisabuela de Jamala. La cancion cargada politicamente gano de manera controvertida en medio de las tensiones entre Rusia y Ucrania. Sigue siendo una de las entradas ganadoras mas poderosas y emotivas de Eurovision."
+      "fun_fact_es": "1944 conto la historia de la deportacion de los tartaros de Crimea por Stalin, incluyendo a la bisabuela de Jamala. La cancion cargada politicamente gano de manera controvertida en medio de las tensiones entre Rusia y Ucrania. Sigue siendo una de las entradas ganadoras mas poderosas y emotivas de Eurovision.",
+      "uri_apple_music": "applemusic://track/1664506710"
     },
     {
       "year": 2017,
       "uri": "spotify:track:3UjSOJ00E1eLMcayBm827Q",
       "artist": "Salvador Sobral",
       "title": "Amar Pelos Dois",
-      "chart_info": {"eurovision_position": 1, "eurovision_points": 758, "country": "Portugal"},
+      "chart_info": {
+        "eurovision_position": 1,
+        "eurovision_points": 758,
+        "country": "Portugal"
+      },
       "certifications": [],
-      "awards": ["Eurovision Winner 2017"],
-      "awards_de": ["Eurovision-Sieger 2017"],
-      "awards_es": ["Ganador de Eurovision 2017"],
+      "awards": [
+        "Eurovision Winner 2017"
+      ],
+      "awards_de": [
+        "Eurovision-Sieger 2017"
+      ],
+      "awards_es": [
+        "Ganador de Eurovision 2017"
+      ],
       "fun_fact": "Amar Pelos Dois (Love for Both of Us) won with 758 points - the highest score ever in Eurovision history. Salvador Sobral's intimate jazz ballad, written by his sister Luisa, broke all records. He performed awaiting a heart transplant, which he received months later.",
       "fun_fact_de": "Amar Pelos Dois (Liebe fur uns beide) gewann mit 758 Punkten - die hochste Punktzahl in der Eurovision-Geschichte uberhaupt. Salvador Sobrals intime Jazzballade, geschrieben von seiner Schwester Luisa, brach alle Rekorde. Er trat auf, wahrend er auf eine Herztransplantation wartete, die er Monate spater erhielt.",
-      "fun_fact_es": "Amar Pelos Dois (Amor por los dos) gano con 758 puntos - la puntuacion mas alta en la historia de Eurovision. La intima balada de jazz de Salvador Sobral, escrita por su hermana Luisa, rompio todos los records. Actuo esperando un trasplante de corazon, que recibio meses despues."
+      "fun_fact_es": "Amar Pelos Dois (Amor por los dos) gano con 758 puntos - la puntuacion mas alta en la historia de Eurovision. La intima balada de jazz de Salvador Sobral, escrita por su hermana Luisa, rompio todos los records. Actuo esperando un trasplante de corazon, que recibio meses despues.",
+      "uri_apple_music": "applemusic://track/1812636468"
     },
     {
       "year": 2018,
       "uri": "spotify:track:7vuTcvFnvlqWlWb4u60nvY",
       "artist": "Netta",
       "title": "Toy",
-      "chart_info": {"eurovision_position": 1, "eurovision_points": 529, "country": "Israel"},
+      "chart_info": {
+        "eurovision_position": 1,
+        "eurovision_points": 529,
+        "country": "Israel"
+      },
       "certifications": [],
-      "awards": ["Eurovision Winner 2018"],
-      "awards_de": ["Eurovision-Sieger 2018"],
-      "awards_es": ["Ganador de Eurovision 2018"],
+      "awards": [
+        "Eurovision Winner 2018"
+      ],
+      "awards_de": [
+        "Eurovision-Sieger 2018"
+      ],
+      "awards_es": [
+        "Ganador de Eurovision 2018"
+      ],
       "fun_fact": "Toy's chicken sounds and loop-pedal performance made it unforgettable. Netta Barzilai's empowerment anthem with its 'I'm not your toy' message resonated with the #MeToo movement. The quirky electronic track divided opinions but won decisively.",
       "fun_fact_de": "Toys Huhnergerausche und Loop-Pedal-Darbietung machten es unvergesslich. Netta Barzilais Empowerment-Hymne mit ihrer 'Ich bin nicht dein Spielzeug'-Botschaft fand Anklang bei der #MeToo-Bewegung. Der schrullige elektronische Track spaltete die Meinungen, gewann aber entscheidend.",
-      "fun_fact_es": "Los sonidos de gallina de Toy y la actuacion con pedal de loop la hicieron inolvidable. El himno de empoderamiento de Netta Barzilai con su mensaje 'No soy tu juguete' resono con el movimiento #MeToo. La peculiar pista electronica dividio opiniones pero gano de manera decisiva."
+      "fun_fact_es": "Los sonidos de gallina de Toy y la actuacion con pedal de loop la hicieron inolvidable. El himno de empoderamiento de Netta Barzilai con su mensaje 'No soy tu juguete' resono con el movimiento #MeToo. La peculiar pista electronica dividio opiniones pero gano de manera decisiva.",
+      "uri_apple_music": "applemusic://track/1518643036"
     },
     {
       "year": 2019,
       "uri": "spotify:track:1Xi84slp6FryDSCbzq4UCD",
       "artist": "Duncan Laurence",
       "title": "Arcade",
-      "chart_info": {"eurovision_position": 1, "eurovision_points": 498, "country": "Netherlands"},
-      "certifications": ["4x Platinum (US)"],
-      "awards": ["Eurovision Winner 2019"],
-      "awards_de": ["Eurovision-Sieger 2019"],
-      "awards_es": ["Ganador de Eurovision 2019"],
+      "chart_info": {
+        "eurovision_position": 1,
+        "eurovision_points": 498,
+        "country": "Netherlands"
+      },
+      "certifications": [
+        "4x Platinum (US)"
+      ],
+      "awards": [
+        "Eurovision Winner 2019"
+      ],
+      "awards_de": [
+        "Eurovision-Sieger 2019"
+      ],
+      "awards_es": [
+        "Ganador de Eurovision 2019"
+      ],
       "fun_fact": "Arcade became the biggest post-Eurovision hit in history after going viral on TikTok in 2021, two years after winning. The emotional piano ballad about lost love has over 1 billion streams. It gave the Netherlands their fifth Eurovision victory.",
       "fun_fact_de": "Arcade wurde der grosste Post-Eurovision-Hit der Geschichte, nachdem es 2021 auf TikTok viral ging, zwei Jahre nach dem Sieg. Die emotionale Klavierballade uber verlorene Liebe hat uber 1 Milliarde Streams. Sie brachte den Niederlanden ihren funften Eurovision-Sieg.",
-      "fun_fact_es": "Arcade se convirtio en el mayor exito post-Eurovision de la historia despues de volverse viral en TikTok en 2021, dos anos despues de ganar. La emotiva balada de piano sobre el amor perdido tiene mas de mil millones de reproducciones. Dio a los Paises Bajos su quinta victoria en Eurovision."
+      "fun_fact_es": "Arcade se convirtio en el mayor exito post-Eurovision de la historia despues de volverse viral en TikTok en 2021, dos anos despues de ganar. La emotiva balada de piano sobre el amor perdido tiene mas de mil millones de reproducciones. Dio a los Paises Bajos su quinta victoria en Eurovision.",
+      "uri_apple_music": "applemusic://track/1455090089"
     },
     {
       "year": 2021,
       "uri": "spotify:track:1lWWoec2z1j88GRblI5anV",
       "artist": "Maneskin",
       "title": "ZITTI E BUONI",
-      "chart_info": {"eurovision_position": 1, "eurovision_points": 524, "country": "Italy"},
+      "chart_info": {
+        "eurovision_position": 1,
+        "eurovision_points": 524,
+        "country": "Italy"
+      },
       "certifications": [],
-      "awards": ["Eurovision Winner 2021"],
-      "awards_de": ["Eurovision-Sieger 2021"],
-      "awards_es": ["Ganador de Eurovision 2021"],
+      "awards": [
+        "Eurovision Winner 2021"
+      ],
+      "awards_de": [
+        "Eurovision-Sieger 2021"
+      ],
+      "awards_es": [
+        "Ganador de Eurovision 2021"
+      ],
       "fun_fact": "ZITTI E BUONI (Shut Up and Behave) was the first rock song to win Eurovision since Lordi in 2006. Maneskin went on to become global superstars, topping charts worldwide and performing at major festivals. Frontman Damiano faced false drug allegations that were quickly disproven.",
       "fun_fact_de": "ZITTI E BUONI (Halt die Klappe und benimm dich) war das erste Rocklied, das den Eurovision seit Lordi 2006 gewann. Maneskin wurden zu globalen Superstars, fuhrten weltweit die Charts an und traten auf grossen Festivals auf. Frontmann Damiano sah sich falschen Drogenvorwurfen gegenuber, die schnell widerlegt wurden.",
-      "fun_fact_es": "ZITTI E BUONI (Callense y comportense) fue la primera cancion de rock en ganar Eurovision desde Lordi en 2006. Maneskin se convirtieron en superestrellas globales, encabezando listas en todo el mundo y actuando en festivales importantes. El vocalista Damiano enfrento falsas acusaciones de drogas que fueron rapidamente desmentidas."
+      "fun_fact_es": "ZITTI E BUONI (Callense y comportense) fue la primera cancion de rock en ganar Eurovision desde Lordi en 2006. Maneskin se convirtieron en superestrellas globales, encabezando listas en todo el mundo y actuando en festivales importantes. El vocalista Damiano enfrento falsas acusaciones de drogas que fueron rapidamente desmentidas.",
+      "uri_apple_music": "applemusic://track/1554925274"
     },
     {
       "year": 2022,
       "uri": "spotify:track:2vHzOWRKYPLu8umRPIFuOq",
       "artist": "Kalush Orchestra",
       "title": "Stefania",
-      "chart_info": {"eurovision_position": 1, "eurovision_points": 631, "country": "Ukraine"},
+      "chart_info": {
+        "eurovision_position": 1,
+        "eurovision_points": 631,
+        "country": "Ukraine"
+      },
       "certifications": [],
-      "awards": ["Eurovision Winner 2022"],
-      "awards_de": ["Eurovision-Sieger 2022"],
-      "awards_es": ["Ganador de Eurovision 2022"],
+      "awards": [
+        "Eurovision Winner 2022"
+      ],
+      "awards_de": [
+        "Eurovision-Sieger 2022"
+      ],
+      "awards_es": [
+        "Ganador de Eurovision 2022"
+      ],
       "fun_fact": "Stefania won Eurovision during Russia's invasion of Ukraine, with band members returning to fight after the contest. Originally written about frontman Oleh Psiuk's mother, the lyrics took on new meaning about the motherland. It received overwhelming public votes as solidarity with Ukraine.",
       "fun_fact_de": "Stefania gewann den Eurovision wahrend Russlands Invasion in der Ukraine, wobei Bandmitglieder nach dem Wettbewerb zuruckkehrten, um zu kampfen. Ursprunglich uber die Mutter von Frontmann Oleh Psiuk geschrieben, bekamen die Texte eine neue Bedeutung uber das Vaterland. Es erhielt uberwältigende offentliche Stimmen als Solidaritat mit der Ukraine.",
-      "fun_fact_es": "Stefania gano Eurovision durante la invasion rusa de Ucrania, con los miembros de la banda regresando a luchar despues del concurso. Originalmente escrita sobre la madre del vocalista Oleh Psiuk, la letra adquirio un nuevo significado sobre la patria. Recibio una abrumadora votacion publica como solidaridad con Ucrania."
+      "fun_fact_es": "Stefania gano Eurovision durante la invasion rusa de Ucrania, con los miembros de la banda regresando a luchar despues del concurso. Originalmente escrita sobre la madre del vocalista Oleh Psiuk, la letra adquirio un nuevo significado sobre la patria. Recibio una abrumadora votacion publica como solidaridad con Ucrania.",
+      "uri_apple_music": "applemusic://track/1614859013"
     },
     {
       "year": 2023,
       "uri": "spotify:track:1DmW5Ep6ywYwxc2HMT5BG6",
       "artist": "Loreen",
       "title": "Tattoo",
-      "chart_info": {"eurovision_position": 1, "eurovision_points": 583, "country": "Sweden"},
+      "chart_info": {
+        "eurovision_position": 1,
+        "eurovision_points": 583,
+        "country": "Sweden"
+      },
       "certifications": [],
-      "awards": ["Eurovision Winner 2023"],
-      "awards_de": ["Eurovision-Sieger 2023"],
-      "awards_es": ["Ganador de Eurovision 2023"],
+      "awards": [
+        "Eurovision Winner 2023"
+      ],
+      "awards_de": [
+        "Eurovision-Sieger 2023"
+      ],
+      "awards_es": [
+        "Ganador de Eurovision 2023"
+      ],
       "fun_fact": "Tattoo made Loreen only the second artist ever to win Eurovision twice (after Johnny Logan). Her haunting performance 11 years after 'Euphoria' proved lightning can strike twice. Sweden tied with Ireland for most Eurovision wins with seven victories.",
       "fun_fact_de": "Tattoo machte Loreen zur erst zweiten Kunstlerin uberhaupt, die den Eurovision zweimal gewann (nach Johnny Logan). Ihre eindringliche Darbietung 11 Jahre nach 'Euphoria' bewies, dass der Blitz zweimal einschlagen kann. Schweden zog mit Irland bei den meisten Eurovision-Siegen mit sieben Siegen gleich.",
-      "fun_fact_es": "Tattoo hizo de Loreen solo la segunda artista en ganar Eurovision dos veces (despues de Johnny Logan). Su cautivadora actuacion 11 anos despues de 'Euphoria' demostro que el rayo puede caer dos veces. Suecia empato con Irlanda en la mayoria de victorias de Eurovision con siete triunfos."
+      "fun_fact_es": "Tattoo hizo de Loreen solo la segunda artista en ganar Eurovision dos veces (despues de Johnny Logan). Su cautivadora actuacion 11 anos despues de 'Euphoria' demostro que el rayo puede caer dos veces. Suecia empato con Irlanda en la mayoria de victorias de Eurovision con siete triunfos.",
+      "uri_apple_music": "applemusic://track/1672056675"
     },
     {
       "year": 2024,
       "uri": "spotify:track:1EjIXKhNHI00ZLMRpS8iz8",
       "artist": "Nemo",
       "title": "The Code",
-      "chart_info": {"eurovision_position": 1, "eurovision_points": 591, "country": "Switzerland"},
+      "chart_info": {
+        "eurovision_position": 1,
+        "eurovision_points": 591,
+        "country": "Switzerland"
+      },
       "certifications": [],
-      "awards": ["Eurovision Winner 2024"],
-      "awards_de": ["Eurovision-Sieger 2024"],
-      "awards_es": ["Ganador de Eurovision 2024"],
+      "awards": [
+        "Eurovision Winner 2024"
+      ],
+      "awards_de": [
+        "Eurovision-Sieger 2024"
+      ],
+      "awards_es": [
+        "Ganador de Eurovision 2024"
+      ],
       "fun_fact": "The Code made history as Nemo became the first non-binary artist to win Eurovision. The theatrical performance combined opera, rap, and drum and bass. Switzerland's third victory came in a controversial contest held in Malmo, Sweden.",
       "fun_fact_de": "The Code schrieb Geschichte, als Nemo die erste nicht-binare Person wurde, die den Eurovision gewann. Die theatralische Darbietung kombinierte Oper, Rap und Drum and Bass. Die Schweiz errang ihren dritten Sieg bei einem umstrittenen Wettbewerb in Malmo, Schweden.",
-      "fun_fact_es": "The Code hizo historia cuando Nemo se convirtio en la primera persona no binaria en ganar Eurovision. La teatral actuacion combino opera, rap y drum and bass. La tercera victoria de Suiza llego en un controvertido concurso celebrado en Malmo, Suecia."
+      "fun_fact_es": "The Code hizo historia cuando Nemo se convirtio en la primera persona no binaria en ganar Eurovision. La teatral actuacion combino opera, rap y drum and bass. La tercera victoria de Suiza llego en un controvertido concurso celebrado en Malmo, Suecia.",
+      "uri_apple_music": "applemusic://track/1730730673"
     },
     {
       "year": 2025,
       "uri": "spotify:track:321yySUTzRXUbzkRTeTzDB",
       "artist": "JJ",
       "title": "Wasted Love",
-      "chart_info": {"eurovision_position": 1, "eurovision_points": 436, "country": "Austria"},
+      "chart_info": {
+        "eurovision_position": 1,
+        "eurovision_points": 436,
+        "country": "Austria"
+      },
       "certifications": [],
-      "awards": ["Eurovision Winner 2025"],
-      "awards_de": ["Eurovision-Sieger 2025"],
-      "awards_es": ["Ganador de Eurovision 2025"],
+      "awards": [
+        "Eurovision Winner 2025"
+      ],
+      "awards_de": [
+        "Eurovision-Sieger 2025"
+      ],
+      "awards_es": [
+        "Ganador de Eurovision 2025"
+      ],
       "fun_fact": "Wasted Love showcased JJ's extraordinary countertenor opera voice in a song that builds from orchestral swells to a club finish. Johannes Pietsch, who performs at the Vienna State Opera, won jury support from 8 countries giving him douze points. Austria will host Eurovision 2026.",
       "fun_fact_de": "Wasted Love prasentierte JJs aussergewohnliche Countertenor-Opernstimme in einem Lied, das von orchestralen Schwellungen zu einem Club-Finish aufbaut. Johannes Pietsch, der an der Wiener Staatsoper auftritt, gewann die Jury-Unterstutzung von 8 Landern, die ihm die Hochstwertung gaben. Osterreich wird den Eurovision 2026 ausrichten.",
-      "fun_fact_es": "Wasted Love mostro la extraordinaria voz de contratenor operistico de JJ en una cancion que crece desde crescendos orquestales hasta un final de club. Johannes Pietsch, quien actua en la Opera Estatal de Viena, gano el apoyo del jurado de 8 paises dandole la maxima puntuacion. Austria sera anfitrion de Eurovision 2026."
+      "fun_fact_es": "Wasted Love mostro la extraordinaria voz de contratenor operistico de JJ en una cancion que crece desde crescendos orquestales hasta un final de club. Johannes Pietsch, quien actua en la Opera Estatal de Viena, gano el apoyo del jurado de 8 paises dandole la maxima puntuacion. Austria sera anfitrion de Eurovision 2026.",
+      "uri_apple_music": "applemusic://track/1797320660"
     }
   ]
 }

--- a/custom_components/beatify/playlists/greatest-hits-of-all-time.json
+++ b/custom_components/beatify/playlists/greatest-hits-of-all-time.json
@@ -26,7 +26,8 @@
       ],
       "awards_es": [
         "Salón de la Fama del Grammy (2004)"
-      ]
+      ],
+      "uri_apple_music": "applemusic://track/1440650711"
     },
     {
       "year": 1982,
@@ -43,7 +44,8 @@
       "awards": [],
       "fun_fact": "Africa was written by TOTO's David Paich about a man who has never been to Africa but romanticizes the continent. The distinctive keyboard intro was inspired by a documentary about African wildlife. The song has experienced multiple viral revivals decades after release.",
       "fun_fact_de": "Africa wurde von TOTOs David Paich über einen Mann geschrieben, der noch nie in Afrika war, aber den Kontinent romantisiert. Das markante Keyboard-Intro wurde von einer Dokumentation über afrikanische Tierwelt inspiriert. Der Song erlebte Jahrzehnte nach seiner Veröffentlichung mehrere virale Revivals.",
-      "fun_fact_es": "Africa fue escrita por David Paich de TOTO sobre un hombre que nunca ha estado en África pero que romantiza el continente. La distintiva introducción de teclado fue inspirada por un documental sobre la vida salvaje africana. La canción ha experimentado múltiples resurgimientos virales décadas después de su lanzamiento."
+      "fun_fact_es": "Africa fue escrita por David Paich de TOTO sobre un hombre que nunca ha estado en África pero que romantiza el continente. La distintiva introducción de teclado fue inspirada por un documental sobre la vida salvaje africana. La canción ha experimentado múltiples resurgimientos virales décadas después de su lanzamiento.",
+      "uri_apple_music": "applemusic://track/185717604"
     },
     {
       "year": 1997,
@@ -60,7 +62,8 @@
       "awards": [],
       "fun_fact": "Angels was written by Robbie Williams and Guy Chambers in just 25 minutes at Chambers' home. It became the song most requested at British funerals for years. Williams has said it's about his belief in guardian angels and the connection between people.",
       "fun_fact_de": "Angels wurde von Robbie Williams und Guy Chambers in nur 25 Minuten in Chambers' Haus geschrieben. Es wurde jahrelang der meistgewünschte Song bei britischen Beerdigungen. Williams hat gesagt, es handelt von seinem Glauben an Schutzengel und die Verbindung zwischen Menschen.",
-      "fun_fact_es": "Angels fue escrita por Robbie Williams y Guy Chambers en solo 25 minutos en la casa de Chambers. Se convirtió en la canción más solicitada en funerales británicos durante años. Williams ha dicho que trata sobre su creencia en los ángeles guardianes y la conexión entre las personas."
+      "fun_fact_es": "Angels fue escrita por Robbie Williams y Guy Chambers en solo 25 minutos en la casa de Chambers. Se convirtió en la canción más solicitada en funerales británicos durante años. Williams ha dicho que trata sobre su creencia en los ángeles guardianes y la conexión entre las personas.",
+      "uri_apple_music": "applemusic://track/725818406"
     },
     {
       "year": 1980,
@@ -78,7 +81,8 @@
       "awards": [],
       "fun_fact": "Back In Black was recorded as a tribute to late AC/DC frontman Bon Scott, who died in February 1980. The album of the same name became one of the best-selling records in history. Brian Johnson was selected as Scott's replacement just weeks before recording began.",
       "fun_fact_de": "Back In Black wurde als Tribut an den verstorbenen AC/DC-Frontmann Bon Scott aufgenommen, der im Februar 1980 starb. Das gleichnamige Album wurde zu einer der meistverkauften Platten der Geschichte. Brian Johnson wurde nur wenige Wochen vor Aufnahmebeginn als Scotts Nachfolger ausgewählt.",
-      "fun_fact_es": "Back In Black fue grabada como tributo al fallecido vocalista de AC/DC Bon Scott, quien murió en febrero de 1980. El álbum del mismo nombre se convirtió en uno de los discos más vendidos de la historia. Brian Johnson fue seleccionado como reemplazo de Scott solo semanas antes de comenzar la grabación."
+      "fun_fact_es": "Back In Black fue grabada como tributo al fallecido vocalista de AC/DC Bon Scott, quien murió en febrero de 1980. El álbum del mismo nombre se convirtió en uno de los discos más vendidos de la historia. Brian Johnson fue seleccionado como reemplazo de Scott solo semanas antes de comenzar la grabación.",
+      "uri_apple_music": "applemusic://track/574050602"
     },
     {
       "year": 1982,
@@ -103,7 +107,8 @@
       ],
       "awards_es": [
         "Grammy - Mejor Interpretación Vocal Pop Masculina (1984)"
-      ]
+      ],
+      "uri_apple_music": "applemusic://track/269573303"
     },
     {
       "year": 1984,
@@ -119,7 +124,8 @@
       "awards": [],
       "fun_fact": "Leonard Cohen wrote approximately 80 draft verses of Hallelujah over five years before settling on the final version. The song was initially ignored but gained fame through Jeff Buckley's 1994 cover. Cohen reportedly worked on verses while sitting in his underwear at hotels.",
       "fun_fact_de": "Leonard Cohen schrieb über fünf Jahre hinweg etwa 80 Entwürfe von Hallelujah-Strophen, bevor er sich für die endgültige Version entschied. Der Song wurde zunächst ignoriert, erlangte aber durch Jeff Buckleys Cover von 1994 Berühmtheit. Cohen arbeitete Berichten zufolge in Unterwäsche an den Strophen in Hotels.",
-      "fun_fact_es": "Leonard Cohen escribió aproximadamente 80 borradores de versos de Hallelujah durante cinco años antes de decidirse por la versión final. La canción fue inicialmente ignorada pero ganó fama a través de la versión de Jeff Buckley de 1994. Según los informes, Cohen trabajaba en los versos sentado en ropa interior en hoteles."
+      "fun_fact_es": "Leonard Cohen escribió aproximadamente 80 borradores de versos de Hallelujah durante cinco años antes de decidirse por la versión final. La canción fue inicialmente ignorada pero ganó fama a través de la versión de Jeff Buckley de 1994. Según los informes, Cohen trabajaba en los versos sentado en ropa interior en hoteles.",
+      "uri_apple_music": "applemusic://track/192678693"
     },
     {
       "year": 1970,
@@ -136,7 +142,8 @@
       "awards": [],
       "fun_fact": "Father and Son features Cat Stevens singing both parts—the father in a deeper voice and the son in a higher register. It was originally written for a musical called Revolussia that was never produced. The song has become an anthem for generational understanding worldwide.",
       "fun_fact_de": "Father and Son zeigt Cat Stevens, der beide Rollen singt – den Vater mit tieferer Stimme und den Sohn in höherer Lage. Es wurde ursprünglich für ein Musical namens Revolussia geschrieben, das nie produziert wurde. Der Song ist weltweit zu einer Hymne für generationsübergreifendes Verständnis geworden.",
-      "fun_fact_es": "Father and Son presenta a Cat Stevens cantando ambas partes: el padre con una voz más grave y el hijo en un registro más alto. Fue escrita originalmente para un musical llamado Revolussia que nunca se produjo. La canción se ha convertido en un himno mundial para el entendimiento generacional."
+      "fun_fact_es": "Father and Son presenta a Cat Stevens cantando ambas partes: el padre con una voz más grave y el hijo en un registro más alto. Fue escrita originalmente para un musical llamado Revolussia que nunca se produjo. La canción se ha convertido en un himno mundial para el entendimiento generacional.",
+      "uri_apple_music": "applemusic://track/1535559786"
     },
     {
       "year": 1968,
@@ -162,7 +169,8 @@
       ],
       "awards_es": [
         "Salón de la Fama del Grammy (2001)"
-      ]
+      ],
+      "uri_apple_music": "applemusic://track/1440834224"
     },
     {
       "year": 1984,
@@ -179,7 +187,8 @@
       "awards": [],
       "fun_fact": "Summer of '69 is not about the year 1969—Bryan Adams was only 9 years old then. Adams has confirmed the title refers to the sexual position. The song captures the nostalgic feeling of youthful summers and first bands, becoming a rock radio staple worldwide.",
       "fun_fact_de": "Summer of '69 handelt nicht vom Jahr 1969 – Bryan Adams war damals erst 9 Jahre alt. Adams hat bestätigt, dass sich der Titel auf die Sexstellung bezieht. Der Song fängt das nostalgische Gefühl jugendlicher Sommer und erster Bands ein und wurde weltweit zu einem Rock-Radio-Klassiker.",
-      "fun_fact_es": "Summer of '69 no trata sobre el año 1969: Bryan Adams tenía solo 9 años entonces. Adams ha confirmado que el título se refiere a la posición sexual. La canción captura el sentimiento nostálgico de los veranos juveniles y las primeras bandas, convirtiéndose en un clásico de la radio rock mundial."
+      "fun_fact_es": "Summer of '69 no trata sobre el año 1969: Bryan Adams tenía solo 9 años entonces. Adams ha confirmado que el título se refiere a la posición sexual. La canción captura el sentimiento nostálgico de los veranos juveniles y las primeras bandas, convirtiéndose en un clásico de la radio rock mundial.",
+      "uri_apple_music": "applemusic://track/1440823965"
     },
     {
       "year": 1970,
@@ -207,7 +216,8 @@
       "awards_es": [
         "Salón de la Fama del Grammy (2004)",
         "Grammy - Mejor Banda Sonora Original (1971)"
-      ]
+      ],
+      "uri_apple_music": "applemusic://track/402154219"
     },
     {
       "year": 1979,
@@ -232,7 +242,8 @@
       ],
       "awards_es": [
         "Salón de la Fama del Grammy (2020)"
-      ]
+      ],
+      "uri_apple_music": "applemusic://track/574044008"
     },
     {
       "year": 1976,
@@ -260,7 +271,8 @@
       "awards_es": [
         "Grammy - Grabación del Año (1978)",
         "Salón de la Fama del Grammy (2003)"
-      ]
+      ],
+      "uri_apple_music": "applemusic://track/635770202"
     },
     {
       "year": 1980,
@@ -285,7 +297,8 @@
       ],
       "awards_es": [
         "Premio American Music (1981)"
-      ]
+      ],
+      "uri_apple_music": "applemusic://track/1440650719"
     },
     {
       "year": 1982,
@@ -313,7 +326,8 @@
       "awards_es": [
         "Grammy - Grabación del Año (1984)",
         "Grammy - Mejor Interpretación Vocal Rock Masculina (1984)"
-      ]
+      ],
+      "uri_apple_music": "applemusic://track/269573341"
     },
     {
       "year": 1970,
@@ -330,7 +344,8 @@
       "awards": [],
       "fun_fact": "Immigrant Song was inspired by Led Zeppelin's 1970 concert in Iceland. Robert Plant's distinctive war cry was meant to evoke Viking raiders. The band initially resisted releasing it as a single, preferring to keep their music on albums only, but relented due to demand.",
       "fun_fact_de": "Immigrant Song wurde durch Led Zeppelins Konzert in Island 1970 inspiriert. Robert Plants markanter Kampfschrei sollte Wikingerüberfälle heraufbeschwören. Die Band widersetzte sich zunächst einer Veröffentlichung als Single und bevorzugte es, ihre Musik nur auf Alben zu belassen, gab aber aufgrund der Nachfrage nach.",
-      "fun_fact_es": "Immigrant Song fue inspirada por el concierto de Led Zeppelin en Islandia en 1970. El distintivo grito de guerra de Robert Plant pretendía evocar a los invasores vikingos. La banda inicialmente se resistió a lanzarla como sencillo, prefiriendo mantener su música solo en álbumes, pero cedió debido a la demanda."
+      "fun_fact_es": "Immigrant Song fue inspirada por el concierto de Led Zeppelin en Islandia en 1970. El distintivo grito de guerra de Robert Plant pretendía evocar a los invasores vikingos. La banda inicialmente se resistió a lanzarla como sencillo, prefiriendo mantener su música solo en álbumes, pero cedió debido a la demanda.",
+      "uri_apple_music": "applemusic://track/580708280"
     },
     {
       "year": 1972,
@@ -355,7 +370,8 @@
       ],
       "awards_es": [
         "Salón de la Fama del Grammy (1998)"
-      ]
+      ],
+      "uri_apple_music": "applemusic://track/1652668538"
     },
     {
       "year": 1982,
@@ -380,7 +396,8 @@
       ],
       "awards_es": [
         "Grammy - Mejor Interpretación Rock (1983)"
-      ]
+      ],
+      "uri_apple_music": "applemusic://track/254685026"
     },
     {
       "year": 1990,
@@ -397,7 +414,8 @@
       "awards": [],
       "fun_fact": "Thunderstruck's opening guitar riff took Angus Young so long to perfect that he developed arm cramps during recording. The technique involves rapid-fire hammer-ons and pull-offs on one string. The song has become AC/DC's most-played track at sporting events globally.",
       "fun_fact_de": "Thunderstrucks Eröffnungsriff brauchte so lange zur Perfektionierung, dass Angus Young während der Aufnahmen Armkrämpfe bekam. Die Technik beinhaltet schnelle Hammer-ons und Pull-offs auf einer Saite. Der Song ist weltweit der meistgespielte AC/DC-Track bei Sportveranstaltungen geworden.",
-      "fun_fact_es": "El riff de apertura de Thunderstruck tomó tanto tiempo para perfeccionar que Angus Young desarrolló calambres en el brazo durante la grabación. La técnica involucra hammer-ons y pull-offs rápidos en una sola cuerda. La canción se ha convertido en la pista más reproducida de AC/DC en eventos deportivos a nivel mundial."
+      "fun_fact_es": "El riff de apertura de Thunderstruck tomó tanto tiempo para perfeccionar que Angus Young desarrolló calambres en el brazo durante la grabación. La técnica involucra hammer-ons y pull-offs rápidos en una sola cuerda. La canción se ha convertido en la pista más reproducida de AC/DC en eventos deportivos a nivel mundial.",
+      "uri_apple_music": "applemusic://track/575998661"
     },
     {
       "year": 1972,
@@ -422,7 +440,8 @@
       ],
       "awards_es": [
         "Salón de la Fama del Grammy (2023)"
-      ]
+      ],
+      "uri_apple_music": "applemusic://track/1099335223"
     },
     {
       "year": 1977,
@@ -447,7 +466,8 @@
       ],
       "awards_es": [
         "Grammy - Mejor Interpretación Vocal Pop (1979)"
-      ]
+      ],
+      "uri_apple_music": "applemusic://track/1445668462"
     },
     {
       "year": 1977,
@@ -472,7 +492,8 @@
       ],
       "awards_es": [
         "Salón de la Fama del Grammy (2009)"
-      ]
+      ],
+      "uri_apple_music": "applemusic://track/1440651281"
     },
     {
       "year": 1985,
@@ -497,7 +518,8 @@
       ],
       "awards_es": [
         "MTV VMA - Mejor Artista Nuevo (1986)"
-      ]
+      ],
+      "uri_apple_music": "applemusic://track/1035413072"
     },
     {
       "year": 1976,
@@ -514,7 +536,8 @@
       "awards": [],
       "fun_fact": "T.N.T. was written about Angus Young's explosive energy on stage and his tendency to blow up amplifiers. The song became AC/DC's concert opener for years. Originally released only in Australia, it became an international hit when the band gained global recognition.",
       "fun_fact_de": "T.N.T. wurde über Angus Youngs explosive Energie auf der Bühne und seine Tendenz, Verstärker zu sprengen, geschrieben. Der Song wurde jahrelang AC/DCs Konzertopener. Ursprünglich nur in Australien veröffentlicht, wurde er ein internationaler Hit, als die Band weltweite Anerkennung erlangte.",
-      "fun_fact_es": "T.N.T. fue escrita sobre la energía explosiva de Angus Young en el escenario y su tendencia a hacer explotar amplificadores. La canción se convirtió en la canción de apertura de conciertos de AC/DC durante años. Originalmente lanzada solo en Australia, se convirtió en un éxito internacional cuando la banda ganó reconocimiento global."
+      "fun_fact_es": "T.N.T. fue escrita sobre la energía explosiva de Angus Young en el escenario y su tendencia a hacer explotar amplificadores. La canción se convirtió en la canción de apertura de conciertos de AC/DC durante años. Originalmente lanzada solo en Australia, se convirtió en un éxito internacional cuando la banda ganó reconocimiento global.",
+      "uri_apple_music": "applemusic://track/574124824"
     },
     {
       "year": 1965,
@@ -542,7 +565,8 @@
       "awards_es": [
         "Premio Ivor Novello (1966)",
         "Salón de la Fama del Grammy (1997)"
-      ]
+      ],
+      "uri_apple_music": "applemusic://track/1441164805"
     },
     {
       "year": 1983,
@@ -567,7 +591,8 @@
       ],
       "awards_es": [
         "MTV VMA - Mejor Artista Nuevo (1984)"
-      ]
+      ],
+      "uri_apple_music": "applemusic://track/255966421"
     },
     {
       "year": 2000,
@@ -584,7 +609,8 @@
       "awards": [],
       "fun_fact": "It's My Life marked Bon Jovi's successful comeback after a five-year hiatus. The song was written to appeal to both longtime fans and a new generation. It has been certified platinum multiple times and became a defining rock anthem of the early 2000s across the globe.",
       "fun_fact_de": "It's My Life markierte Bon Jovis erfolgreiches Comeback nach einer fünfjährigen Pause. Der Song wurde geschrieben, um sowohl langjährige Fans als auch eine neue Generation anzusprechen. Er wurde mehrfach mit Platin ausgezeichnet und wurde weltweit zu einer prägenden Rock-Hymne der frühen 2000er.",
-      "fun_fact_es": "It's My Life marcó el exitoso regreso de Bon Jovi después de un paréntesis de cinco años. La canción fue escrita para atraer tanto a los fans de siempre como a una nueva generación. Ha sido certificada platino múltiples veces y se convirtió en un himno de rock definitorio de principios de los 2000 en todo el mundo."
+      "fun_fact_es": "It's My Life marcó el exitoso regreso de Bon Jovi después de un paréntesis de cinco años. La canción fue escrita para atraer tanto a los fans de siempre como a una nueva generación. Ha sido certificada platino múltiples veces y se convirtió en un himno de rock definitorio de principios de los 2000 en todo el mundo.",
+      "uri_apple_music": "applemusic://track/1440677670"
     },
     {
       "year": 1984,
@@ -601,7 +627,8 @@
       "awards": [],
       "fun_fact": "Wake Me Up Before You Go-Go was inspired by a note left by Andrew Ridgeley for his parents. The double 'go-go' came from a scribbling error. George Michael wrote the song in just a few hours, and it became Wham!'s biggest international hit, reaching number one globally.",
       "fun_fact_de": "Wake Me Up Before You Go-Go wurde durch eine Notiz inspiriert, die Andrew Ridgeley für seine Eltern hinterließ. Das doppelte 'go-go' entstand durch einen Schreibfehler. George Michael schrieb den Song in nur wenigen Stunden, und er wurde Wham!s größter internationaler Hit mit Nummer-eins-Platzierungen weltweit.",
-      "fun_fact_es": "Wake Me Up Before You Go-Go fue inspirada por una nota que Andrew Ridgeley dejó a sus padres. El doble 'go-go' vino de un error de escritura. George Michael escribió la canción en solo unas horas, y se convirtió en el mayor éxito internacional de Wham!, alcanzando el número uno a nivel mundial."
+      "fun_fact_es": "Wake Me Up Before You Go-Go fue inspirada por una nota que Andrew Ridgeley dejó a sus padres. El doble 'go-go' vino de un error de escritura. George Michael escribió la canción en solo unas horas, y se convirtió en el mayor éxito internacional de Wham!, alcanzando el número uno a nivel mundial.",
+      "uri_apple_music": "applemusic://track/1466274459"
     },
     {
       "year": 1977,
@@ -626,7 +653,8 @@
       ],
       "awards_es": [
         "Salón de la Fama del Grammy (2009)"
-      ]
+      ],
+      "uri_apple_music": "applemusic://track/1440651216"
     },
     {
       "year": 1990,
@@ -643,7 +671,8 @@
       "awards": [],
       "fun_fact": "Wind of Change was written about the fall of the Berlin Wall and the end of the Cold War. The Scorpions' Klaus Meine wrote it after visiting Moscow during glasnost. It became an anthem for German reunification and has sold over 14 million copies, symbolizing hope and freedom.",
       "fun_fact_de": "Wind of Change wurde über den Fall der Berliner Mauer und das Ende des Kalten Krieges geschrieben. Scorpions' Klaus Meine schrieb ihn nach einem Besuch in Moskau während der Glasnost. Er wurde zu einer Hymne der deutschen Wiedervereinigung und hat über 14 Millionen Exemplare verkauft, als Symbol für Hoffnung und Freiheit.",
-      "fun_fact_es": "Wind of Change fue escrita sobre la caída del Muro de Berlín y el fin de la Guerra Fría. Klaus Meine de los Scorpions la escribió después de visitar Moscú durante la glasnost. Se convirtió en un himno de la reunificación alemana y ha vendido más de 14 millones de copias, simbolizando esperanza y libertad."
+      "fun_fact_es": "Wind of Change fue escrita sobre la caída del Muro de Berlín y el fin de la Guerra Fría. Klaus Meine de los Scorpions la escribió después de visitar Moscú durante la glasnost. Se convirtió en un himno de la reunificación alemana y ha vendido más de 14 millones de copias, simbolizando esperanza y libertad.",
+      "uri_apple_music": "applemusic://track/1438813154"
     },
     {
       "year": 1995,
@@ -661,7 +690,8 @@
       "awards": [],
       "fun_fact": "Wonderwall was inspired by Noel Gallagher's then-girlfriend Meg Mathews, though he later said it was about an 'imaginary friend' who'll save you. The title comes from a George Harrison album. It's one of the most-played songs on streaming platforms and a karaoke staple worldwide.",
       "fun_fact_de": "Wonderwall wurde von Noel Gallaghers damaliger Freundin Meg Mathews inspiriert, obwohl er später sagte, es gehe um einen 'imaginären Freund', der einen rettet. Der Titel stammt von einem George-Harrison-Album. Er ist einer der meistgestreamten Songs und ein Karaoke-Klassiker weltweit.",
-      "fun_fact_es": "Wonderwall fue inspirada por la entonces novia de Noel Gallagher, Meg Mathews, aunque luego dijo que era sobre un 'amigo imaginario' que te salvará. El título viene de un álbum de George Harrison. Es una de las canciones más reproducidas en plataformas de streaming y un clásico del karaoke en todo el mundo."
+      "fun_fact_es": "Wonderwall fue inspirada por la entonces novia de Noel Gallagher, Meg Mathews, aunque luego dijo que era sobre un 'amigo imaginario' que te salvará. El título viene de un álbum de George Harrison. Es una de las canciones más reproducidas en plataformas de streaming y un clásico del karaoke en todo el mundo.",
+      "uri_apple_music": "applemusic://track/1517447333"
     },
     {
       "year": 1961,
@@ -678,7 +708,8 @@
       "awards": [],
       "fun_fact": "Can't Help Falling in Love was adapted from the 18th-century French song 'Plaisir d'Amour.' Elvis Presley performed it at the end of his concerts for years. It was featured in the film Blue Hawaii and has been covered by over 500 artists, becoming a wedding favorite.",
       "fun_fact_de": "Can't Help Falling in Love wurde aus dem französischen Lied 'Plaisir d'Amour' aus dem 18. Jahrhundert adaptiert. Elvis Presley spielte es jahrelang am Ende seiner Konzerte. Es war im Film Blue Hawaii zu sehen und wurde von über 500 Künstlern gecovert – ein Favorit bei Hochzeiten.",
-      "fun_fact_es": "Can't Help Falling in Love fue adaptada de la canción francesa del siglo XVIII 'Plaisir d'Amour'. Elvis Presley la interpretó al final de sus conciertos durante años. Apareció en la película Blue Hawaii y ha sido versionada por más de 500 artistas, convirtiéndose en una favorita de bodas."
+      "fun_fact_es": "Can't Help Falling in Love fue adaptada de la canción francesa del siglo XVIII 'Plaisir d'Amour'. Elvis Presley la interpretó al final de sus conciertos durante años. Apareció en la película Blue Hawaii y ha sido versionada por más de 500 artistas, convirtiéndose en una favorita de bodas.",
+      "uri_apple_music": "applemusic://track/949550091"
     },
     {
       "year": 1984,
@@ -695,7 +726,8 @@
       "awards": [],
       "fun_fact": "Forever Young became a Cold War anthem about nuclear annihilation and the desire to live fully despite uncertainty. Alphaville's Marian Gold wrote two versions—one slow and one uptempo—and couldn't decide which to release, so both appeared on the album. It's now a graduation staple.",
       "fun_fact_de": "Forever Young wurde zu einer Hymne des Kalten Krieges über nukleare Vernichtung und den Wunsch, trotz Ungewissheit voll zu leben. Alphavilles Marian Gold schrieb zwei Versionen – eine langsame und eine schnelle – und konnte sich nicht entscheiden, welche er veröffentlichen sollte, also erschienen beide auf dem Album. Heute ist es ein Abschlussfeier-Klassiker.",
-      "fun_fact_es": "Forever Young se convirtió en un himno de la Guerra Fría sobre la aniquilación nuclear y el deseo de vivir plenamente a pesar de la incertidumbre. Marian Gold de Alphaville escribió dos versiones, una lenta y otra rápida, y no podía decidir cuál lanzar, así que ambas aparecieron en el álbum. Ahora es un clásico de graduación."
+      "fun_fact_es": "Forever Young se convirtió en un himno de la Guerra Fría sobre la aniquilación nuclear y el deseo de vivir plenamente a pesar de la incertidumbre. Marian Gold de Alphaville escribió dos versiones, una lenta y otra rápida, y no podía decidir cuál lanzar, así que ambas aparecieron en el álbum. Ahora es un clásico de graduación.",
+      "uri_apple_music": "applemusic://track/73255043"
     },
     {
       "year": 1969,
@@ -720,7 +752,8 @@
       ],
       "awards_es": [
         "Salón de la Fama del Grammy (2017)"
-      ]
+      ],
+      "uri_apple_music": "applemusic://track/1422721989"
     },
     {
       "year": 1962,
@@ -745,7 +778,8 @@
       ],
       "awards_es": [
         "Salón de la Fama del Grammy (1999)"
-      ]
+      ],
+      "uri_apple_music": "applemusic://track/1632466975"
     },
     {
       "year": 1968,
@@ -770,7 +804,8 @@
       ],
       "awards_es": [
         "Salón de la Fama del Grammy (1999)"
-      ]
+      ],
+      "uri_apple_music": "applemusic://track/1440787254"
     },
     {
       "year": 1969,
@@ -795,7 +830,8 @@
       ],
       "awards_es": [
         "Salón de la Fama del Grammy (1999)"
-      ]
+      ],
+      "uri_apple_music": "applemusic://track/1471434343"
     },
     {
       "year": 1971,
@@ -812,7 +848,8 @@
       "awards": [],
       "fun_fact": "Take Me Home, Country Roads was written about West Virginia by two songwriters who had never visited the state. John Denver added final touches and made it his signature song. It became the official state anthem of West Virginia in 2014, beloved by fans worldwide.",
       "fun_fact_de": "Take Me Home, Country Roads wurde über West Virginia von zwei Songwritern geschrieben, die den Staat nie besucht hatten. John Denver fügte die letzten Details hinzu und machte ihn zu seinem Erkennungslied. Er wurde 2014 zur offiziellen Staatshymne von West Virginia – von Fans weltweit geliebt.",
-      "fun_fact_es": "Take Me Home, Country Roads fue escrita sobre Virginia Occidental por dos compositores que nunca habían visitado el estado. John Denver añadió los toques finales y la convirtió en su canción insignia. Se convirtió en el himno oficial del estado de Virginia Occidental en 2014, amada por fans de todo el mundo."
+      "fun_fact_es": "Take Me Home, Country Roads fue escrita sobre Virginia Occidental por dos compositores que nunca habían visitado el estado. John Denver añadió los toques finales y la convirtió en su canción insignia. Se convirtió en el himno oficial del estado de Virginia Occidental en 2014, amada por fans de todo el mundo.",
+      "uri_apple_music": "applemusic://track/1482520559"
     },
     {
       "year": 1985,
@@ -840,7 +877,8 @@
       "awards_es": [
         "Grammy - Grabación del Año (1986)",
         "Grammy - Canción del Año (1986)"
-      ]
+      ],
+      "uri_apple_music": "applemusic://track/41737859"
     },
     {
       "year": 1975,
@@ -857,7 +895,8 @@
       "awards": [],
       "fun_fact": "Mamma Mia launched a global phenomenon including a stage musical and two films. ABBA's Benny Andersson wrote the distinctive keyboard hook. The song's title and lyrics play with the Italian exclamation. It was ABBA's first UK number one and helped establish them internationally.",
       "fun_fact_de": "Mamma Mia löste ein weltweites Phänomen aus, einschließlich eines Bühnenmusicals und zweier Filme. ABBAs Benny Andersson schrieb den markanten Keyboard-Hook. Der Songtitel und die Texte spielen mit dem italienischen Ausruf. Es war ABBAs erste UK-Nummer-eins und half, sie international zu etablieren.",
-      "fun_fact_es": "Mamma Mia lanzó un fenómeno global que incluye un musical de teatro y dos películas. Benny Andersson de ABBA escribió el distintivo gancho de teclado. El título y la letra de la canción juegan con la exclamación italiana. Fue el primer número uno de ABBA en el Reino Unido y ayudó a establecerlos internacionalmente."
+      "fun_fact_es": "Mamma Mia lanzó un fenómeno global que incluye un musical de teatro y dos películas. Benny Andersson de ABBA escribió el distintivo gancho de teclado. El título y la letra de la canción juegan con la exclamación italiana. Fue el primer número uno de ABBA en el Reino Unido y ayudó a establecerlos internacionalmente.",
+      "uri_apple_music": "applemusic://track/1440861294"
     },
     {
       "year": 1976,
@@ -874,7 +913,8 @@
       "awards": [],
       "fun_fact": "Sunny was originally written by Bobby Hebb in 1963 after the assassination of JFK and his brother's murder. Boney M.'s disco version became one of the biggest hits of 1976. The song has been covered over 300 times, making it one of the most-recorded songs in history.",
       "fun_fact_de": "Sunny wurde ursprünglich 1963 von Bobby Hebb nach der Ermordung JFKs und dem Mord an seinem Bruder geschrieben. Boney M.s Disco-Version wurde einer der größten Hits von 1976. Der Song wurde über 300 Mal gecovert und ist damit einer der meistaufgenommenen Songs der Geschichte.",
-      "fun_fact_es": "Sunny fue escrita originalmente por Bobby Hebb en 1963 después del asesinato de JFK y el asesinato de su hermano. La versión disco de Boney M. se convirtió en uno de los mayores éxitos de 1976. La canción ha sido versionada más de 300 veces, convirtiéndola en una de las canciones más grabadas de la historia."
+      "fun_fact_es": "Sunny fue escrita originalmente por Bobby Hebb en 1963 después del asesinato de JFK y el asesinato de su hermano. La versión disco de Boney M. se convirtió en uno de los mayores éxitos de 1976. La canción ha sido versionada más de 300 veces, convirtiéndola en una de las canciones más grabadas de la historia.",
+      "uri_apple_music": "applemusic://track/220385946"
     },
     {
       "year": 1995,
@@ -891,7 +931,8 @@
       "awards": [],
       "fun_fact": "Lemon Tree was written by Fools Garden's Peter Freudenthaler about a boring Sunday afternoon spent staring at a lemon tree picture. The German band became one-hit wonders internationally but remain popular in Europe. The song's upbeat melody contrasts with its melancholic lyrics.",
       "fun_fact_de": "Lemon Tree wurde von Fools Gardens Peter Freudenthaler über einen langweiligen Sonntagnachmittag geschrieben, an dem er ein Zitronenbaum-Bild anstarrte. Die deutsche Band wurde international zu One-Hit-Wondern, blieb aber in Europa beliebt. Die fröhliche Melodie des Songs steht im Kontrast zu seinen melancholischen Texten.",
-      "fun_fact_es": "Lemon Tree fue escrita por Peter Freudenthaler de Fools Garden sobre una aburrida tarde de domingo pasada mirando una imagen de un limonero. La banda alemana se convirtió en éxitos de un solo tema internacionalmente pero sigue siendo popular en Europa. La melodía alegre de la canción contrasta con su letra melancólica."
+      "fun_fact_es": "Lemon Tree fue escrita por Peter Freudenthaler de Fools Garden sobre una aburrida tarde de domingo pasada mirando una imagen de un limonero. La banda alemana se convirtió en éxitos de un solo tema internacionalmente pero sigue siendo popular en Europa. La melodía alegre de la canción contrasta con su letra melancólica.",
+      "uri_apple_music": "applemusic://track/1642728104"
     },
     {
       "year": 1988,
@@ -919,7 +960,8 @@
       "awards_es": [
         "Grammy - Grabación del Año (1989)",
         "Grammy - Canción del Año (1989)"
-      ]
+      ],
+      "uri_apple_music": "applemusic://track/724862378"
     },
     {
       "year": 1974,
@@ -944,7 +986,8 @@
       ],
       "awards_es": [
         "Ganador de Eurovisión (1974)"
-      ]
+      ],
+      "uri_apple_music": "applemusic://track/1440861750"
     },
     {
       "year": 1978,
@@ -961,7 +1004,8 @@
       "awards": [],
       "fun_fact": "YMCA was written by Jacques Morali after he visited a YMCA in New York and found it a great place for young people to hang out. The Village People song became a gay anthem and disco classic. The famous arm movements were invented by audience members, not choreographed.",
       "fun_fact_de": "YMCA wurde von Jacques Morali geschrieben, nachdem er ein YMCA in New York besucht hatte und es als großartigen Ort für junge Leute fand. Der Village People-Song wurde zu einer Schwulenhymne und einem Disco-Klassiker. Die berühmten Armbewegungen wurden vom Publikum erfunden, nicht choreografiert.",
-      "fun_fact_es": "YMCA fue escrita por Jacques Morali después de visitar un YMCA en Nueva York y encontrarlo un gran lugar para los jóvenes. La canción de Village People se convirtió en un himno gay y un clásico del disco. Los famosos movimientos de brazos fueron inventados por el público, no coreografiados."
+      "fun_fact_es": "YMCA fue escrita por Jacques Morali después de visitar un YMCA en Nueva York y encontrarlo un gran lugar para los jóvenes. La canción de Village People se convirtió en un himno gay y un clásico del disco. Los famosos movimientos de brazos fueron inventados por el público, no coreografiados.",
+      "uri_apple_music": "applemusic://track/1443926626"
     },
     {
       "year": 1978,
@@ -978,7 +1022,8 @@
       "awards": [],
       "fun_fact": "September's opening line 'Do you remember the 21st night of September?' refers to no specific event—songwriter Allee Willis chose it purely for the sound. Maurice White confirmed there's no special meaning. The song has become an essential party anthem for over four decades now.",
       "fun_fact_de": "Septembers Eröffnungszeile 'Erinnerst du dich an die 21. Nacht im September?' bezieht sich auf kein bestimmtes Ereignis – Songwriterin Allee Willis wählte es rein wegen des Klangs. Maurice White bestätigte, dass es keine besondere Bedeutung gibt. Der Song ist seit über vier Jahrzehnten eine unverzichtbare Party-Hymne.",
-      "fun_fact_es": "La línea inicial de September '¿Recuerdas la noche del 21 de septiembre?' no se refiere a ningún evento específico: la compositora Allee Willis la eligió puramente por el sonido. Maurice White confirmó que no hay un significado especial. La canción se ha convertido en un himno esencial de fiestas por más de cuatro décadas."
+      "fun_fact_es": "La línea inicial de September '¿Recuerdas la noche del 21 de septiembre?' no se refiere a ningún evento específico: la compositora Allee Willis la eligió puramente por el sonido. Maurice White confirmó que no hay un significado especial. La canción se ha convertido en un himno esencial de fiestas por más de cuatro décadas.",
+      "uri_apple_music": "applemusic://track/1456623340"
     },
     {
       "year": 1999,
@@ -995,7 +1040,8 @@
       "awards": [],
       "fun_fact": "Mambo No. 5 originally was a 1949 Cuban instrumental. Lou Bega added lyrics listing women's names, which were supposedly real girlfriends. The song became a global phenomenon, topping charts in over 10 countries. Bega reportedly made $6 million from this single alone worldwide.",
       "fun_fact_de": "Mambo No. 5 war ursprünglich ein kubanisches Instrumental von 1949. Lou Bega fügte Texte mit Frauennamen hinzu, die angeblich echte Freundinnen waren. Der Song wurde ein weltweites Phänomen und führte die Charts in über 10 Ländern an. Bega verdiente Berichten zufolge allein mit dieser Single 6 Millionen Dollar weltweit.",
-      "fun_fact_es": "Mambo No. 5 fue originalmente un instrumental cubano de 1949. Lou Bega añadió letras con nombres de mujeres, que supuestamente eran novias reales. La canción se convirtió en un fenómeno global, encabezando las listas en más de 10 países. Según los informes, Bega ganó 6 millones de dólares solo con este sencillo a nivel mundial."
+      "fun_fact_es": "Mambo No. 5 fue originalmente un instrumental cubano de 1949. Lou Bega añadió letras con nombres de mujeres, que supuestamente eran novias reales. La canción se convirtió en un fenómeno global, encabezando las listas en más de 10 países. Según los informes, Bega ganó 6 millones de dólares solo con este sencillo a nivel mundial.",
+      "uri_apple_music": "applemusic://track/1322068804"
     },
     {
       "year": 1974,
@@ -1012,7 +1058,8 @@
       "awards": [],
       "fun_fact": "Sweet Home Alabama was written as a response to Neil Young's critical songs about the American South. Despite the perceived feud, Young and Lynyrd Skynyrd were actually friends. The song became an anthem for Southern pride and is still played at Alabama Crimson Tide football games.",
       "fun_fact_de": "Sweet Home Alabama wurde als Antwort auf Neil Youngs kritische Songs über den amerikanischen Süden geschrieben. Trotz der vermeintlichen Fehde waren Young und Lynyrd Skynyrd eigentlich Freunde. Der Song wurde zu einer Hymne des Südstaaten-Stolzes und wird noch heute bei Alabama Crimson Tide Football-Spielen gespielt.",
-      "fun_fact_es": "Sweet Home Alabama fue escrita como respuesta a las canciones críticas de Neil Young sobre el sur estadounidense. A pesar de la supuesta rivalidad, Young y Lynyrd Skynyrd eran en realidad amigos. La canción se convirtió en un himno del orgullo sureño y todavía se toca en los partidos de fútbol americano de Alabama Crimson Tide."
+      "fun_fact_es": "Sweet Home Alabama fue escrita como respuesta a las canciones críticas de Neil Young sobre el sur estadounidense. A pesar de la supuesta rivalidad, Young y Lynyrd Skynyrd eran en realidad amigos. La canción se convirtió en un himno del orgullo sureño y todavía se toca en los partidos de fútbol americano de Alabama Crimson Tide.",
+      "uri_apple_music": "applemusic://track/1413948381"
     },
     {
       "year": 1976,
@@ -1029,7 +1076,8 @@
       "awards": [],
       "fun_fact": "Daddy Cool was one of Boney M.'s first major hits, featuring Frank Farian's production techniques that later caused controversy. The song's infectious rhythm made it a disco staple. Farian would later admit to using session singers on some recordings, but Daddy Cool showcased the group's talent.",
       "fun_fact_de": "Daddy Cool war einer von Boney M.s ersten großen Hits mit Frank Farians Produktionstechniken, die später Kontroversen auslösten. Der ansteckende Rhythmus des Songs machte ihn zu einem Disco-Klassiker. Farian gab später zu, bei einigen Aufnahmen Session-Sänger verwendet zu haben, aber Daddy Cool zeigte das Talent der Gruppe.",
-      "fun_fact_es": "Daddy Cool fue uno de los primeros grandes éxitos de Boney M., presentando las técnicas de producción de Frank Farian que más tarde causaron controversia. El ritmo contagioso de la canción la convirtió en un clásico del disco. Farian luego admitiría usar cantantes de sesión en algunas grabaciones, pero Daddy Cool mostró el talento del grupo."
+      "fun_fact_es": "Daddy Cool fue uno de los primeros grandes éxitos de Boney M., presentando las técnicas de producción de Frank Farian que más tarde causaron controversia. El ritmo contagioso de la canción la convirtió en un clásico del disco. Farian luego admitiría usar cantantes de sesión en algunas grabaciones, pero Daddy Cool mostró el talento del grupo.",
+      "uri_apple_music": "applemusic://track/824787060"
     },
     {
       "year": 1986,
@@ -1046,7 +1094,8 @@
       "awards": [],
       "fun_fact": "The Final Countdown was written about space travel and leaving Earth behind. The iconic synthesizer intro has made it one of the most recognized riffs in rock history. Europe's Joey Tempest was inspired by David Bowie's 'Space Oddity.' The song is played at countless sporting events today.",
       "fun_fact_de": "The Final Countdown wurde über Raumfahrt und das Verlassen der Erde geschrieben. Das ikonische Synthesizer-Intro hat es zu einem der bekanntesten Riffs der Rockgeschichte gemacht. Europes Joey Tempest wurde von David Bowies 'Space Oddity' inspiriert. Der Song wird heute bei unzähligen Sportveranstaltungen gespielt.",
-      "fun_fact_es": "The Final Countdown fue escrita sobre viajes espaciales y dejar la Tierra atrás. La icónica introducción de sintetizador la ha convertido en uno de los riffs más reconocidos en la historia del rock. Joey Tempest de Europe se inspiró en 'Space Oddity' de David Bowie. La canción se toca en innumerables eventos deportivos hoy en día."
+      "fun_fact_es": "The Final Countdown fue escrita sobre viajes espaciales y dejar la Tierra atrás. La icónica introducción de sintetizador la ha convertido en uno de los riffs más reconocidos en la historia del rock. Joey Tempest de Europe se inspiró en 'Space Oddity' de David Bowie. La canción se toca en innumerables eventos deportivos hoy en día.",
+      "uri_apple_music": "applemusic://track/355893426"
     },
     {
       "year": 1981,
@@ -1063,7 +1112,8 @@
       "awards": [],
       "fun_fact": "I Love Rock 'n' Roll was originally recorded by Arrows in 1975. Joan Jett saw them perform it on British TV and became obsessed with the song. Her version became one of the biggest hits of the early 1980s and defined her career as the queen of rock and roll attitude.",
       "fun_fact_de": "I Love Rock 'n' Roll wurde ursprünglich 1975 von Arrows aufgenommen. Joan Jett sah sie den Song im britischen Fernsehen spielen und war besessen davon. Ihre Version wurde einer der größten Hits der frühen 1980er und definierte ihre Karriere als Königin der Rock-and-Roll-Attitüde.",
-      "fun_fact_es": "I Love Rock 'n' Roll fue grabada originalmente por Arrows en 1975. Joan Jett los vio interpretarla en la televisión británica y quedó obsesionada con la canción. Su versión se convirtió en uno de los mayores éxitos de principios de los 80 y definió su carrera como la reina de la actitud del rock and roll."
+      "fun_fact_es": "I Love Rock 'n' Roll fue grabada originalmente por Arrows en 1975. Joan Jett los vio interpretarla en la televisión británica y quedó obsesionada con la canción. Su versión se convirtió en uno de los mayores éxitos de principios de los 80 y definió su carrera como la reina de la actitud del rock and roll.",
+      "uri_apple_music": "applemusic://track/1434145184"
     },
     {
       "year": 1984,
@@ -1080,7 +1130,8 @@
       "awards": [],
       "fun_fact": "Jump was the first Van Halen song to feature David Lee Roth's idea of using synthesizers prominently. Eddie Van Halen actually disliked the keyboard riff initially. The song's optimistic message about taking risks made it an instant anthem and Van Halen's biggest commercial success.",
       "fun_fact_de": "Jump war der erste Van-Halen-Song, bei dem David Lee Roths Idee umgesetzt wurde, Synthesizer prominent einzusetzen. Eddie Van Halen mochte das Keyboard-Riff anfangs nicht. Die optimistische Botschaft des Songs über das Eingehen von Risiken machte ihn sofort zur Hymne und Van Halens größtem kommerziellen Erfolg.",
-      "fun_fact_es": "Jump fue la primera canción de Van Halen que presentó la idea de David Lee Roth de usar sintetizadores de manera prominente. Eddie Van Halen en realidad no le gustaba el riff de teclado inicialmente. El mensaje optimista de la canción sobre tomar riesgos la convirtió en un himno instantáneo y el mayor éxito comercial de Van Halen."
+      "fun_fact_es": "Jump fue la primera canción de Van Halen que presentó la idea de David Lee Roth de usar sintetizadores de manera prominente. Eddie Van Halen en realidad no le gustaba el riff de teclado inicialmente. El mensaje optimista de la canción sobre tomar riesgos la convirtió en un himno instantáneo y el mayor éxito comercial de Van Halen.",
+      "uri_apple_music": "applemusic://track/976832495"
     },
     {
       "year": 1982,
@@ -1097,7 +1148,8 @@
       "awards": [],
       "fun_fact": "It's Raining Men was originally offered to Donna Summer, who rejected it for being too risqué. The Weather Girls turned it into a disco anthem that has endured as a camp classic. Songwriters Paul Jabara and Paul Shaffer wrote it as a humorous celebration of female desire.",
       "fun_fact_de": "It's Raining Men wurde ursprünglich Donna Summer angeboten, die es als zu gewagt ablehnte. The Weather Girls machten daraus eine Disco-Hymne, die als Camp-Klassiker überdauert hat. Die Songwriter Paul Jabara und Paul Shaffer schrieben es als humorvolle Feier weiblichen Begehrens.",
-      "fun_fact_es": "It's Raining Men fue ofrecida originalmente a Donna Summer, quien la rechazó por considerarla demasiado atrevida. The Weather Girls la convirtieron en un himno disco que ha perdurado como un clásico camp. Los compositores Paul Jabara y Paul Shaffer la escribieron como una celebración humorística del deseo femenino."
+      "fun_fact_es": "It's Raining Men fue ofrecida originalmente a Donna Summer, quien la rechazó por considerarla demasiado atrevida. The Weather Girls la convirtieron en un himno disco que ha perdurado como un clásico camp. Los compositores Paul Jabara y Paul Shaffer la escribieron como una celebración humorística del deseo femenino.",
+      "uri_apple_music": "applemusic://track/1005688002"
     },
     {
       "year": 1982,
@@ -1114,7 +1166,8 @@
       "awards": [],
       "fun_fact": "Should I Stay or Should I Go was written by Mick Jones about his relationship with Ellen Foley. The Spanish backing vocals were recorded by the band without understanding what they were singing. The song gained renewed fame in the Netflix series 'Stranger Things' decades later.",
       "fun_fact_de": "Should I Stay or Should I Go wurde von Mick Jones über seine Beziehung mit Ellen Foley geschrieben. Die spanischen Background-Vocals wurden von der Band aufgenommen, ohne zu verstehen, was sie sangen. Der Song gewann Jahrzehnte später durch die Netflix-Serie 'Stranger Things' erneute Berühmtheit.",
-      "fun_fact_es": "Should I Stay or Should I Go fue escrita por Mick Jones sobre su relación con Ellen Foley. Los coros en español fueron grabados por la banda sin entender lo que estaban cantando. La canción ganó renovada fama en la serie de Netflix 'Stranger Things' décadas después."
+      "fun_fact_es": "Should I Stay or Should I Go fue escrita por Mick Jones sobre su relación con Ellen Foley. Los coros en español fueron grabados por la banda sin entender lo que estaban cantando. La canción ganó renovada fama en la serie de Netflix 'Stranger Things' décadas después.",
+      "uri_apple_music": "applemusic://track/688796842"
     },
     {
       "year": 1980,
@@ -1131,7 +1184,8 @@
       "awards": [],
       "fun_fact": "Super Trouper was named after the follow-spot lights used at concerts. ABBA wrote it during the peak of their fame when they felt exhausted by touring. The opening line 'I was sick and tired of everything' reflected their genuine feelings at the time despite worldwide success.",
       "fun_fact_de": "Super Trouper wurde nach den Verfolgungsscheinwerfern benannt, die bei Konzerten verwendet werden. ABBA schrieb ihn auf dem Höhepunkt ihres Ruhms, als sie sich vom Touren erschöpft fühlten. Die Eröffnungszeile 'I was sick and tired of everything' spiegelte trotz weltweiten Erfolgs ihre echten Gefühle zu dieser Zeit wider.",
-      "fun_fact_es": "Super Trouper fue nombrada por los focos de seguimiento usados en conciertos. ABBA la escribió en la cima de su fama cuando se sentían agotados de las giras. La línea inicial 'I was sick and tired of everything' reflejaba sus sentimientos genuinos en ese momento a pesar del éxito mundial."
+      "fun_fact_es": "Super Trouper fue nombrada por los focos de seguimiento usados en conciertos. ABBA la escribió en la cima de su fama cuando se sentían agotados de las giras. La línea inicial 'I was sick and tired of everything' reflejaba sus sentimientos genuinos en ese momento a pesar del éxito mundial.",
+      "uri_apple_music": "applemusic://track/1440816845"
     },
     {
       "year": 1985,
@@ -1148,7 +1202,8 @@
       "awards": [],
       "fun_fact": "Walking on Sunshine was rejected by multiple labels before finally being released. The song's relentless optimism has made it one of the most-licensed tracks in advertising history. Katrina Leskanich said she was actually going through a rough time when she recorded the joyful song.",
       "fun_fact_de": "Walking on Sunshine wurde von mehreren Labels abgelehnt, bevor es endlich veröffentlicht wurde. Der unermüdliche Optimismus des Songs hat ihn zu einem der meistlizenzierten Tracks in der Werbegeschichte gemacht. Katrina Leskanich sagte, sie durchlebte tatsächlich eine schwere Zeit, als sie den fröhlichen Song aufnahm.",
-      "fun_fact_es": "Walking on Sunshine fue rechazada por múltiples sellos antes de ser finalmente lanzada. El optimismo implacable de la canción la ha convertido en una de las pistas más licenciadas en la historia de la publicidad. Katrina Leskanich dijo que en realidad estaba pasando por un momento difícil cuando grabó la alegre canción."
+      "fun_fact_es": "Walking on Sunshine fue rechazada por múltiples sellos antes de ser finalmente lanzada. El optimismo implacable de la canción la ha convertido en una de las pistas más licenciadas en la historia de la publicidad. Katrina Leskanich dijo que en realidad estaba pasando por un momento difícil cuando grabó la alegre canción.",
+      "uri_apple_music": "applemusic://track/724739482"
     },
     {
       "year": 1976,
@@ -1165,7 +1220,8 @@
       "awards": [],
       "fun_fact": "Somebody to Love was Queen's tribute to gospel music, featuring over 100 vocal overdubs. Freddie Mercury was inspired by Aretha Franklin's gospel-influenced performances. The song showcases Queen's incredible harmonies and Mercury's four-octave vocal range at its absolute finest.",
       "fun_fact_de": "Somebody to Love war Queens Hommage an Gospel-Musik mit über 100 Gesangs-Overdubs. Freddie Mercury wurde von Aretha Franklins Gospel-beeinflussten Auftritten inspiriert. Der Song zeigt Queens unglaubliche Harmonien und Mercurys Vier-Oktaven-Stimmumfang in absoluter Perfektion.",
-      "fun_fact_es": "Somebody to Love fue el tributo de Queen a la música gospel, con más de 100 sobregrabaciones vocales. Freddie Mercury se inspiró en las interpretaciones influenciadas por el gospel de Aretha Franklin. La canción muestra las increíbles armonías de Queen y el rango vocal de cuatro octavas de Mercury en su máxima expresión."
+      "fun_fact_es": "Somebody to Love fue el tributo de Queen a la música gospel, con más de 100 sobregrabaciones vocales. Freddie Mercury se inspiró en las interpretaciones influenciadas por el gospel de Aretha Franklin. La canción muestra las increíbles armonías de Queen y el rango vocal de cuatro octavas de Mercury en su máxima expresión.",
+      "uri_apple_music": "applemusic://track/1440651012"
     },
     {
       "year": 1967,
@@ -1196,7 +1252,8 @@
         "Grammy - Mejor Grabación de R&B (1968)",
         "Grammy - Mejor Interpretación Vocal de R&B (1968)",
         "Salón de la Fama del Grammy (1998)"
-      ]
+      ],
+      "uri_apple_music": "applemusic://track/937107838"
     },
     {
       "year": 1982,
@@ -1221,7 +1278,8 @@
       ],
       "awards_es": [
         "Grammy - Grabación del Año (1983)"
-      ]
+      ],
+      "uri_apple_music": "applemusic://track/185716601"
     },
     {
       "year": 1976,
@@ -1247,7 +1305,8 @@
       ],
       "awards_es": [
         "Salón de la Fama del Grammy (2015)"
-      ]
+      ],
+      "uri_apple_music": "applemusic://track/1422648513"
     },
     {
       "year": 1978,
@@ -1264,7 +1323,8 @@
       "awards": [],
       "fun_fact": "Don't Stop Me Now was written by Freddie Mercury during a particularly hedonistic period of his life. Other band members initially disliked it for promoting excess. In 2020, a scientific study named it the 'happiest song ever' based on tempo, lyrics, and key. Mercury's favorite Queen song.",
       "fun_fact_de": "Don't Stop Me Now wurde von Freddie Mercury während einer besonders hedonistischen Phase seines Lebens geschrieben. Andere Bandmitglieder mochten es zunächst nicht, weil es Exzess förderte. 2020 nannte eine wissenschaftliche Studie es aufgrund von Tempo, Text und Tonart den 'glücklichsten Song aller Zeiten'. Mercurys Lieblings-Queen-Song.",
-      "fun_fact_es": "Don't Stop Me Now fue escrita por Freddie Mercury durante un período particularmente hedonista de su vida. Otros miembros de la banda inicialmente no les gustó porque promovía el exceso. En 2020, un estudio científico la nombró la 'canción más feliz de todos los tiempos' basándose en tempo, letra y tonalidad. La canción favorita de Queen de Mercury."
+      "fun_fact_es": "Don't Stop Me Now fue escrita por Freddie Mercury durante un período particularmente hedonista de su vida. Otros miembros de la banda inicialmente no les gustó porque promovía el exceso. En 2020, un estudio científico la nombró la 'canción más feliz de todos los tiempos' basándose en tempo, letra y tonalidad. La canción favorita de Queen de Mercury.",
+      "uri_apple_music": "applemusic://track/1440650733"
     },
     {
       "year": 1992,
@@ -1292,7 +1352,8 @@
       "awards_es": [
         "Grammy - Grabación del Año (1994)",
         "Grammy - Mejor Interpretación Vocal Pop (1994)"
-      ]
+      ],
+      "uri_apple_music": "applemusic://track/388151901"
     },
     {
       "year": 1963,
@@ -1317,7 +1378,8 @@
       ],
       "awards_es": [
         "Salón de la Fama del Grammy (2003)"
-      ]
+      ],
+      "uri_apple_music": "applemusic://track/716018776"
     },
     {
       "year": 1987,
@@ -1334,7 +1396,8 @@
       "awards": [],
       "fun_fact": "Smooth Criminal's distinctive lean was achieved by Michael Jackson using special patented shoes that locked into pegs on the stage floor. Jackson invented and patented this footwear technology. The song's music video was an 11-minute film featuring elaborate choreography and groundbreaking effects.",
       "fun_fact_de": "Smooth Criminals markante Neigung wurde von Michael Jackson mit speziell patentierten Schuhen erreicht, die sich in Stifte auf dem Bühnenboden einrasteten. Jackson erfand und patentierte diese Schuhtechnologie. Das Musikvideo war ein 11-minütiger Film mit aufwendiger Choreografie und bahnbrechenden Effekten.",
-      "fun_fact_es": "La distintiva inclinación de Smooth Criminal fue lograda por Michael Jackson usando zapatos especiales patentados que se enganchaban en clavijas en el suelo del escenario. Jackson inventó y patentó esta tecnología de calzado. El video musical fue una película de 11 minutos con coreografía elaborada y efectos revolucionarios."
+      "fun_fact_es": "La distintiva inclinación de Smooth Criminal fue lograda por Michael Jackson usando zapatos especiales patentados que se enganchaban en clavijas en el suelo del escenario. Jackson inventó y patentó esta tecnología de calzado. El video musical fue una película de 11 minutos con coreografía elaborada y efectos revolucionarios.",
+      "uri_apple_music": "applemusic://track/159294551"
     },
     {
       "year": 1982,
@@ -1351,7 +1414,8 @@
       "awards": [],
       "fun_fact": "I'm So Excited was originally released in 1982 but became a bigger hit when remixed and re-released in 1984. The Pointer Sisters wrote it about the excitement of romantic anticipation. It became a cultural touchstone through its appearance in the famous 'Saved by the Bell' caffeine pill episode.",
       "fun_fact_de": "I'm So Excited wurde ursprünglich 1982 veröffentlicht, wurde aber ein größerer Hit, als es 1984 remixed und neu veröffentlicht wurde. The Pointer Sisters schrieben es über die Aufregung romantischer Vorfreude. Es wurde durch seinen Auftritt in der berühmten 'Saved by the Bell'-Koffeinpillen-Folge zum Kulturgut.",
-      "fun_fact_es": "I'm So Excited fue lanzada originalmente en 1982 pero se convirtió en un éxito mayor cuando fue remezclada y relanzada en 1984. Las Pointer Sisters la escribieron sobre la emoción de la anticipación romántica. Se convirtió en un ícono cultural a través de su aparición en el famoso episodio de las pastillas de cafeína de 'Salvados por la Campana'."
+      "fun_fact_es": "I'm So Excited fue lanzada originalmente en 1982 pero se convirtió en un éxito mayor cuando fue remezclada y relanzada en 1984. Las Pointer Sisters la escribieron sobre la emoción de la anticipación romántica. Se convirtió en un ícono cultural a través de su aparición en el famoso episodio de las pastillas de cafeína de 'Salvados por la Campana'.",
+      "uri_apple_music": "applemusic://track/1223918849"
     },
     {
       "year": 1987,
@@ -1376,7 +1440,8 @@
       ],
       "awards_es": [
         "Grammy - Mejor Interpretación Vocal Pop (1988)"
-      ]
+      ],
+      "uri_apple_music": "applemusic://track/840431935"
     },
     {
       "year": 1983,
@@ -1393,7 +1458,8 @@
       "awards": [],
       "fun_fact": "Uptown Girl was written by Billy Joel about supermodel Elle Macpherson, though he later married Christie Brinkley who starred in the music video. The song was inspired by Frankie Valli and The Four Seasons' sound. It became one of Joel's biggest international hits, reaching number one in the UK.",
       "fun_fact_de": "Uptown Girl wurde von Billy Joel über das Supermodel Elle Macpherson geschrieben, obwohl er später Christie Brinkley heiratete, die im Musikvideo mitspielte. Der Song wurde vom Sound von Frankie Valli and The Four Seasons inspiriert. Er wurde einer von Joels größten internationalen Hits und erreichte Platz eins in Großbritannien.",
-      "fun_fact_es": "Uptown Girl fue escrita por Billy Joel sobre la supermodelo Elle Macpherson, aunque luego se casó con Christie Brinkley, quien apareció en el video musical. La canción fue inspirada por el sonido de Frankie Valli and The Four Seasons. Se convirtió en uno de los mayores éxitos internacionales de Joel, alcanzando el número uno en el Reino Unido."
+      "fun_fact_es": "Uptown Girl fue escrita por Billy Joel sobre la supermodelo Elle Macpherson, aunque luego se casó con Christie Brinkley, quien apareció en el video musical. La canción fue inspirada por el sonido de Frankie Valli and The Four Seasons. Se convirtió en uno de los mayores éxitos internacionales de Joel, alcanzando el número uno en el Reino Unido.",
+      "uri_apple_music": "applemusic://track/259814810"
     },
     {
       "year": 1976,
@@ -1435,7 +1501,8 @@
       ],
       "awards_es": [
         "Salón de la Fama del Grammy (2021)"
-      ]
+      ],
+      "uri_apple_music": "applemusic://track/160024096"
     },
     {
       "year": 1994,
@@ -1452,7 +1519,8 @@
       "awards": [],
       "fun_fact": "Zombie was written by Dolores O'Riordan after the 1993 IRA bombing in Warrington that killed two children. The Cranberries' most political song became a worldwide hit and anthem against violence. O'Riordan's distinctive yodel-like vocals made it instantly recognizable and emotionally powerful.",
       "fun_fact_de": "Zombie wurde von Dolores O'Riordan nach dem IRA-Bombenanschlag in Warrington 1993 geschrieben, bei dem zwei Kinder starben. Der politischste Song der Cranberries wurde ein weltweiter Hit und eine Hymne gegen Gewalt. O'Riordans markanter jodelartiger Gesang machte ihn sofort erkennbar und emotional kraftvoll.",
-      "fun_fact_es": "Zombie fue escrita por Dolores O'Riordan después del atentado del IRA en Warrington en 1993 que mató a dos niños. La canción más política de The Cranberries se convirtió en un éxito mundial y un himno contra la violencia. Las distintivas voces tipo yodel de O'Riordan la hicieron instantáneamente reconocible y emocionalmente poderosa."
+      "fun_fact_es": "Zombie fue escrita por Dolores O'Riordan después del atentado del IRA en Warrington en 1993 que mató a dos niños. La canción más política de The Cranberries se convirtió en un éxito mundial y un himno contra la violencia. Las distintivas voces tipo yodel de O'Riordan la hicieron instantáneamente reconocible y emocionalmente poderosa.",
+      "uri_apple_music": "applemusic://track/1828830887"
     },
     {
       "year": 1978,
@@ -1477,7 +1545,8 @@
       ],
       "awards_es": [
         "Grammy - Mejor Grabación Disco (1980)"
-      ]
+      ],
+      "uri_apple_music": "applemusic://track/1443818368"
     },
     {
       "year": 1978,
@@ -1494,7 +1563,8 @@
       "awards": [],
       "fun_fact": "Baker Street's iconic saxophone riff was played by Raphael Ravenscroft, who was reportedly paid only £27.50 for the session. He later claimed his royalty check bounced. Gerry Rafferty wrote the song about his frustration with the music industry and London's nightlife scene in the late 1970s.",
       "fun_fact_de": "Baker Streets ikonisches Saxophon-Riff wurde von Raphael Ravenscroft gespielt, der Berichten zufolge nur 27,50 Pfund für die Session bezahlt wurde. Er behauptete später, sein Tantiemenscheck sei geplatzt. Gerry Rafferty schrieb den Song über seine Frustration mit der Musikindustrie und Londons Nachtleben in den späten 1970ern.",
-      "fun_fact_es": "El icónico riff de saxofón de Baker Street fue tocado por Raphael Ravenscroft, quien supuestamente recibió solo 27,50 libras por la sesión. Más tarde afirmó que su cheque de regalías rebotó. Gerry Rafferty escribió la canción sobre su frustración con la industria musical y la vida nocturna de Londres a finales de los 70."
+      "fun_fact_es": "El icónico riff de saxofón de Baker Street fue tocado por Raphael Ravenscroft, quien supuestamente recibió solo 27,50 libras por la sesión. Más tarde afirmó que su cheque de regalías rebotó. Gerry Rafferty escribió la canción sobre su frustración con la industria musical y la vida nocturna de Londres a finales de los 70.",
+      "uri_apple_music": "applemusic://track/693606496"
     },
     {
       "year": 1979,
@@ -1511,7 +1581,8 @@
       "awards": [],
       "fun_fact": "Gimme! Gimme! Gimme! was originally an ABBA song that became the basis for Madonna's 'Hung Up' in 2005—the first time ABBA approved a sample of their work. The song's driving disco beat and desperate lyrics about loneliness created one of their most dramatic recordings ever produced.",
       "fun_fact_de": "Gimme! Gimme! Gimme! war ursprünglich ein ABBA-Song, der 2005 zur Grundlage für Madonnas 'Hung Up' wurde – das erste Mal, dass ABBA eine Sampling-Anfrage genehmigte. Der treibende Disco-Beat und die verzweifelten Texte über Einsamkeit schufen eine ihrer dramatischsten Aufnahmen überhaupt.",
-      "fun_fact_es": "Gimme! Gimme! Gimme! fue originalmente una canción de ABBA que se convirtió en la base de 'Hung Up' de Madonna en 2005, la primera vez que ABBA aprobó un sample de su trabajo. El ritmo disco impulsivo y las letras desesperadas sobre la soledad crearon una de sus grabaciones más dramáticas."
+      "fun_fact_es": "Gimme! Gimme! Gimme! fue originalmente una canción de ABBA que se convirtió en la base de 'Hung Up' de Madonna en 2005, la primera vez que ABBA aprobó un sample de su trabajo. El ritmo disco impulsivo y las letras desesperadas sobre la soledad crearon una de sus grabaciones más dramáticas.",
+      "uri_apple_music": "applemusic://track/1440817183"
     },
     {
       "year": 1982,
@@ -1539,7 +1610,8 @@
       "awards_es": [
         "Grammy - Mejor Interpretación Vocal de R&B (1984)",
         "Grammy - Mejor Canción de R&B (1984)"
-      ]
+      ],
+      "uri_apple_music": "applemusic://track/269573364"
     },
     {
       "year": 1983,
@@ -1556,7 +1628,8 @@
       "awards": [],
       "fun_fact": "Maniac was written for the film Flashdance about the story of a steel welder who dreams of becoming a ballet dancer. Michael Sembello originally wrote it about a serial killer but changed the lyrics for the film. The song perfectly captures the 80s workout and aerobics craze phenomenon.",
       "fun_fact_de": "Maniac wurde für den Film Flashdance über die Geschichte einer Stahlarbeiterin geschrieben, die davon träumt, Balletttänzerin zu werden. Michael Sembello schrieb es ursprünglich über einen Serienkiller, änderte aber die Texte für den Film. Der Song fängt das Workout- und Aerobic-Phänomen der 80er perfekt ein.",
-      "fun_fact_es": "Maniac fue escrita para la película Flashdance sobre la historia de una trabajadora del acero que sueña con convertirse en bailarina de ballet. Michael Sembello la escribió originalmente sobre un asesino en serie pero cambió la letra para la película. La canción captura perfectamente el fenómeno del ejercicio y aeróbicos de los 80."
+      "fun_fact_es": "Maniac fue escrita para la película Flashdance sobre la historia de una trabajadora del acero que sueña con convertirse en bailarina de ballet. Michael Sembello la escribió originalmente sobre un asesino en serie pero cambió la letra para la película. La canción captura perfectamente el fenómeno del ejercicio y aeróbicos de los 80.",
+      "uri_apple_music": "applemusic://track/1425259944"
     },
     {
       "year": 1978,
@@ -1573,7 +1646,8 @@
       "awards": [],
       "fun_fact": "Hold the Line was TOTO's debut single and showcased their exceptional musicianship. The band consisted of session musicians who had played on hundreds of hit records. The guitar riff and keyboard solo became instantly recognizable, establishing TOTO as a major force in rock music.",
       "fun_fact_de": "Hold the Line war TOTOs Debütsingle und zeigte ihre außergewöhnliche Musikalität. Die Band bestand aus Session-Musikern, die auf Hunderten von Hit-Platten gespielt hatten. Das Gitarrenriff und das Keyboard-Solo wurden sofort erkennbar und etablierten TOTO als bedeutende Kraft in der Rockmusik.",
-      "fun_fact_es": "Hold the Line fue el sencillo debut de TOTO y mostró su excepcional musicalidad. La banda estaba formada por músicos de sesión que habían tocado en cientos de discos exitosos. El riff de guitarra y el solo de teclado se volvieron instantáneamente reconocibles, estableciendo a TOTO como una fuerza importante en la música rock."
+      "fun_fact_es": "Hold the Line fue el sencillo debut de TOTO y mostró su excepcional musicalidad. La banda estaba formada por músicos de sesión que habían tocado en cientos de discos exitosos. El riff de guitarra y el solo de teclado se volvieron instantáneamente reconocibles, estableciendo a TOTO como una fuerza importante en la música rock.",
+      "uri_apple_music": "applemusic://track/198227598"
     },
     {
       "year": 1980,
@@ -1590,7 +1664,8 @@
       "awards": [],
       "fun_fact": "Celebration was written by Kool & The Gang's bassist and eunice to commemorate special occasions. The song has been played at countless parties, sports events, and celebrations since its release. It was used extensively during the hostages' return home from Iran in 1981, becoming an American anthem.",
       "fun_fact_de": "Celebration wurde von Kool & The Gangs Bassist geschrieben, um besondere Anlässe zu feiern. Der Song wurde seit seiner Veröffentlichung auf unzähligen Partys, Sportveranstaltungen und Feierlichkeiten gespielt. Er wurde während der Rückkehr der Geiseln aus dem Iran 1981 ausgiebig gespielt und wurde zu einer amerikanischen Hymne.",
-      "fun_fact_es": "Celebration fue escrita por el bajista de Kool & The Gang para conmemorar ocasiones especiales. La canción ha sido tocada en innumerables fiestas, eventos deportivos y celebraciones desde su lanzamiento. Fue usada extensivamente durante el regreso de los rehenes de Irán en 1981, convirtiéndose en un himno estadounidense."
+      "fun_fact_es": "Celebration fue escrita por el bajista de Kool & The Gang para conmemorar ocasiones especiales. La canción ha sido tocada en innumerables fiestas, eventos deportivos y celebraciones desde su lanzamiento. Fue usada extensivamente durante el regreso de los rehenes de Irán en 1981, convirtiéndose en un himno estadounidense.",
+      "uri_apple_music": "applemusic://track/1431062029"
     },
     {
       "year": 1994,
@@ -1607,7 +1682,8 @@
       "awards": [],
       "fun_fact": "Basket Case was written by Billie Joe Armstrong about his panic attacks and anxiety before he was diagnosed with panic disorder. Green Day recorded the song in their producer's living room. It became the anthem of 90s punk rock and helped define the pop-punk genre for a generation.",
       "fun_fact_de": "Basket Case wurde von Billie Joe Armstrong über seine Panikattacken und Angstzustände geschrieben, bevor er mit Panikstörung diagnostiziert wurde. Green Day nahm den Song im Wohnzimmer ihres Produzenten auf. Er wurde zur Hymne des 90er-Jahre-Punkrock und half, das Pop-Punk-Genre für eine Generation zu definieren.",
-      "fun_fact_es": "Basket Case fue escrita por Billie Joe Armstrong sobre sus ataques de pánico y ansiedad antes de que le diagnosticaran trastorno de pánico. Green Day grabó la canción en la sala de estar de su productor. Se convirtió en el himno del punk rock de los 90 y ayudó a definir el género pop-punk para una generación."
+      "fun_fact_es": "Basket Case fue escrita por Billie Joe Armstrong sobre sus ataques de pánico y ansiedad antes de que le diagnosticaran trastorno de pánico. Green Day grabó la canción en la sala de estar de su productor. Se convirtió en el himno del punk rock de los 90 y ayudó a definir el género pop-punk para una generación.",
+      "uri_apple_music": "applemusic://track/1160082180"
     },
     {
       "year": 1997,
@@ -1624,7 +1700,8 @@
       "awards": [],
       "fun_fact": "Everybody (Backstreet's Back) was released only internationally at first because the US label thought it was too cheesy. The horror-themed music video was inspired by Michael Jackson's 'Thriller.' The song became one of the Backstreet Boys' signature hits and a 90s pop culture milestone.",
       "fun_fact_de": "Everybody (Backstreet's Back) wurde zunächst nur international veröffentlicht, weil das US-Label es für zu kitschig hielt. Das Horror-Musikvideo wurde von Michael Jacksons 'Thriller' inspiriert. Der Song wurde einer der Signature-Hits der Backstreet Boys und ein Meilenstein der 90er-Popkultur.",
-      "fun_fact_es": "Everybody (Backstreet's Back) fue lanzada inicialmente solo internacionalmente porque el sello de EE.UU. pensó que era demasiado cursi. El video musical temático de terror fue inspirado por 'Thriller' de Michael Jackson. La canción se convirtió en uno de los éxitos insignia de los Backstreet Boys y un hito de la cultura pop de los 90."
+      "fun_fact_es": "Everybody (Backstreet's Back) fue lanzada inicialmente solo internacionalmente porque el sello de EE.UU. pensó que era demasiado cursi. El video musical temático de terror fue inspirado por 'Thriller' de Michael Jackson. La canción se convirtió en uno de los éxitos insignia de los Backstreet Boys y un hito de la cultura pop de los 90.",
+      "uri_apple_music": "applemusic://track/650117363"
     },
     {
       "year": 1998,
@@ -1641,7 +1718,8 @@
       "awards": [],
       "fun_fact": "Narcotic launched German band Liquido to international fame. The song's catchy guitar riff and straightforward lyrics about addiction made it an alternative rock staple of the late 1990s. It topped charts across Europe and remains a nostalgic favorite for fans of 90s rock music.",
       "fun_fact_de": "Narcotic brachte die deutsche Band Liquido zu internationalem Ruhm. Das eingängige Gitarrenriff und die direkten Texte über Sucht machten ihn zu einem Alternative-Rock-Klassiker der späten 1990er. Er führte die Charts in ganz Europa an und bleibt ein nostalgischer Favorit für Fans der 90er-Rockmusik.",
-      "fun_fact_es": "Narcotic lanzó a la banda alemana Liquido a la fama internacional. El pegadizo riff de guitarra y las letras directas sobre la adicción la convirtieron en un clásico del rock alternativo de finales de los 90. Encabezó las listas en toda Europa y sigue siendo un favorito nostálgico para los fans del rock de los 90."
+      "fun_fact_es": "Narcotic lanzó a la banda alemana Liquido a la fama internacional. El pegadizo riff de guitarra y las letras directas sobre la adicción la convirtieron en un clásico del rock alternativo de finales de los 90. Encabezó las listas en toda Europa y sigue siendo un favorito nostálgico para los fans del rock de los 90.",
+      "uri_apple_music": "applemusic://track/1015955379"
     },
     {
       "year": 1997,
@@ -1658,7 +1736,8 @@
       "awards": [],
       "fun_fact": "Bitter Sweet Symphony samples an orchestral version of The Rolling Stones' 'The Last Time.' Due to legal issues, the Verve lost all royalties to the Stones until 2019 when Jagger and Richards gave the rights back to Richard Ashcroft. The song defines 90s Britpop melancholy perfectly.",
       "fun_fact_de": "Bitter Sweet Symphony samplet eine Orchesterversion von The Rolling Stones' 'The Last Time'. Aufgrund rechtlicher Probleme verlor The Verve alle Tantiemen an die Stones, bis 2019 Jagger und Richards die Rechte an Richard Ashcroft zurückgaben. Der Song definiert die Melancholie des 90er-Britpop perfekt.",
-      "fun_fact_es": "Bitter Sweet Symphony samplea una versión orquestal de 'The Last Time' de los Rolling Stones. Debido a problemas legales, The Verve perdió todas las regalías a favor de los Stones hasta 2019, cuando Jagger y Richards devolvieron los derechos a Richard Ashcroft. La canción define perfectamente la melancolía del Britpop de los 90."
+      "fun_fact_es": "Bitter Sweet Symphony samplea una versión orquestal de 'The Last Time' de los Rolling Stones. Debido a problemas legales, The Verve perdió todas las regalías a favor de los Stones hasta 2019, cuando Jagger y Richards devolvieron los derechos a Richard Ashcroft. La canción define perfectamente la melancolía del Britpop de los 90.",
+      "uri_apple_music": "applemusic://track/1443258189"
     },
     {
       "year": 2005,
@@ -1675,7 +1754,8 @@
       "awards": [],
       "fun_fact": "Jerk It Out was used in the iPod commercial that helped launch it to international success. Swedish band Caesars had been together for years before this breakthrough. The high-energy garage rock song perfectly captured the early 2000s indie rock revival and became a party anthem.",
       "fun_fact_de": "Jerk It Out wurde in der iPod-Werbung verwendet, die half, ihn zum internationalen Erfolg zu führen. Die schwedische Band Caesars war jahrelang zusammen, bevor dieser Durchbruch kam. Der energiegeladene Garagen-Rock-Song fing das Indie-Rock-Revival der frühen 2000er perfekt ein und wurde zur Party-Hymne.",
-      "fun_fact_es": "Jerk It Out fue usada en el comercial del iPod que ayudó a lanzarla al éxito internacional. La banda sueca Caesars había estado juntos durante años antes de este avance. La canción de garage rock llena de energía capturó perfectamente el resurgimiento del indie rock de principios de los 2000 y se convirtió en un himno de fiestas."
+      "fun_fact_es": "Jerk It Out fue usada en el comercial del iPod que ayudó a lanzarla al éxito internacional. La banda sueca Caesars había estado juntos durante años antes de este avance. La canción de garage rock llena de energía capturó perfectamente el resurgimiento del indie rock de principios de los 2000 y se convirtió en un himno de fiestas.",
+      "uri_apple_music": "applemusic://track/699701391"
     },
     {
       "year": 1997,
@@ -1692,7 +1772,8 @@
       "awards": [],
       "fun_fact": "Let Me Entertain You was written by Robbie Williams and Guy Chambers as an anthemic statement of Williams' solo career. The song samples 'Rock DJ' elements and established his reputation as a showman. It became a concert opener for years and defined Williams' provocative stage persona.",
       "fun_fact_de": "Let Me Entertain You wurde von Robbie Williams und Guy Chambers als hymnenhaftes Statement für Williams' Solokarriere geschrieben. Der Song samplet 'Rock DJ'-Elemente und etablierte seinen Ruf als Showman. Er wurde jahrelang zum Konzertopener und definierte Williams' provokante Bühnenpersönlichkeit.",
-      "fun_fact_es": "Let Me Entertain You fue escrita por Robbie Williams y Guy Chambers como una declaración de himno de la carrera en solitario de Williams. La canción samplea elementos de 'Rock DJ' y estableció su reputación como showman. Se convirtió en la canción de apertura de conciertos durante años y definió la provocativa personalidad escénica de Williams."
+      "fun_fact_es": "Let Me Entertain You fue escrita por Robbie Williams y Guy Chambers como una declaración de himno de la carrera en solitario de Williams. La canción samplea elementos de 'Rock DJ' y estableció su reputación como showman. Se convirtió en la canción de apertura de conciertos durante años y definió la provocativa personalidad escénica de Williams.",
+      "uri_apple_music": "applemusic://track/727506226"
     },
     {
       "year": 1991,
@@ -1709,7 +1790,8 @@
       "awards": [],
       "fun_fact": "The Show Must Go On was recorded while Freddie Mercury was gravely ill with AIDS. Mercury reportedly drank vodka to numb his pain during recording, then delivered one of rock's most powerful vocal performances. Brian May said he didn't know how Mercury physically managed to sing it.",
       "fun_fact_de": "The Show Must Go On wurde aufgenommen, als Freddie Mercury schwer an AIDS erkrankt war. Mercury trank Berichten zufolge Wodka, um seine Schmerzen während der Aufnahme zu betäuben, und lieferte dann eine der kraftvollsten Gesangsdarbietungen des Rock ab. Brian May sagte, er wisse nicht, wie Mercury es physisch schaffte, zu singen.",
-      "fun_fact_es": "The Show Must Go On fue grabada mientras Freddie Mercury estaba gravemente enfermo de SIDA. Según los informes, Mercury bebió vodka para adormecer su dolor durante la grabación, luego entregó una de las interpretaciones vocales más poderosas del rock. Brian May dijo que no sabía cómo Mercury físicamente logró cantarla."
+      "fun_fact_es": "The Show Must Go On fue grabada mientras Freddie Mercury estaba gravemente enfermo de SIDA. Según los informes, Mercury bebió vodka para adormecer su dolor durante la grabación, luego entregó una de las interpretaciones vocales más poderosas del rock. Brian May dijo que no sabía cómo Mercury físicamente logró cantarla.",
+      "uri_apple_music": "applemusic://track/1440630994"
     },
     {
       "year": 1961,
@@ -1734,7 +1816,8 @@
       ],
       "awards_es": [
         "Grammy - Mejor Grabación de Rock and Roll (1962)"
-      ]
+      ],
+      "uri_apple_music": "applemusic://track/1443091056"
     },
     {
       "year": 1982,
@@ -1751,7 +1834,8 @@
       "awards": [],
       "fun_fact": "Under Pressure was created during an impromptu jam session between Queen and David Bowie. The famous bass line was played by John Deacon. Bowie and Mercury reportedly clashed over creative control, with each recording vocals separately. The song became a landmark collaboration in rock history.",
       "fun_fact_de": "Under Pressure entstand während einer spontanen Jam-Session zwischen Queen und David Bowie. Die berühmte Basslinie wurde von John Deacon gespielt. Bowie und Mercury gerieten Berichten zufolge über die kreative Kontrolle aneinander und nahmen ihre Gesangsstimmen getrennt auf. Der Song wurde zu einer wegweisenden Zusammenarbeit der Rockgeschichte.",
-      "fun_fact_es": "Under Pressure fue creada durante una sesión de jam improvisada entre Queen y David Bowie. La famosa línea de bajo fue tocada por John Deacon. Bowie y Mercury supuestamente chocaron por el control creativo, grabando cada uno sus voces por separado. La canción se convirtió en una colaboración histórica en la historia del rock."
+      "fun_fact_es": "Under Pressure fue creada durante una sesión de jam improvisada entre Queen y David Bowie. La famosa línea de bajo fue tocada por John Deacon. Bowie y Mercury supuestamente chocaron por el control creativo, grabando cada uno sus voces por separado. La canción se convirtió en una colaboración histórica en la historia del rock.",
+      "uri_apple_music": "applemusic://track/1440810475"
     },
     {
       "year": 1963,
@@ -1768,7 +1852,8 @@
       "awards": [],
       "fun_fact": "Twist and Shout was recorded last during The Beatles' marathon first album session. John Lennon's voice was nearly gone, giving the track its raw, raspy quality. The song was actually a cover, originally recorded by the Top Notes. The Beatles' version became definitive and iconic.",
       "fun_fact_de": "Twist and Shout wurde als letztes während der Marathon-Aufnahmesession zum ersten Beatles-Album aufgenommen. John Lennons Stimme war fast weg, was dem Track seine raue, heisere Qualität verlieh. Der Song war eigentlich ein Cover, ursprünglich von den Top Notes aufgenommen. Die Beatles-Version wurde zur definitiven und ikonischen Fassung.",
-      "fun_fact_es": "Twist and Shout fue grabada al final durante la maratónica sesión del primer álbum de The Beatles. La voz de John Lennon estaba casi perdida, dando a la pista su cualidad cruda y ronca. La canción era en realidad un cover, grabada originalmente por los Top Notes. La versión de los Beatles se convirtió en la definitiva e icónica."
+      "fun_fact_es": "Twist and Shout fue grabada al final durante la maratónica sesión del primer álbum de The Beatles. La voz de John Lennon estaba casi perdida, dando a la pista su cualidad cruda y ronca. La canción era en realidad un cover, grabada originalmente por los Top Notes. La versión de los Beatles se convirtió en la definitiva e icónica.",
+      "uri_apple_music": "applemusic://track/1441165136"
     },
     {
       "year": 1964,
@@ -1810,7 +1895,8 @@
       "awards": [],
       "fun_fact": "We Didn't Start the Fire lists 118 historical events and figures from 1949-1989. Billy Joel wrote it after a 21-year-old told him it was a boring time to grow up. Joel memorized all the lyrics by creating mental images and has said he hates performing it live because it's exhausting.",
       "fun_fact_de": "We Didn't Start the Fire listet 118 historische Ereignisse und Persönlichkeiten von 1949-1989 auf. Billy Joel schrieb es, nachdem ein 21-Jähriger ihm sagte, es sei eine langweilige Zeit zum Aufwachsen. Joel merkte sich alle Texte, indem er mentale Bilder erstellte, und hat gesagt, er hasst es, ihn live zu spielen, weil es erschöpfend ist.",
-      "fun_fact_es": "We Didn't Start the Fire enumera 118 eventos históricos y figuras de 1949-1989. Billy Joel la escribió después de que un joven de 21 años le dijera que era un momento aburrido para crecer. Joel memorizó toda la letra creando imágenes mentales y ha dicho que odia interpretarla en vivo porque es agotadora."
+      "fun_fact_es": "We Didn't Start the Fire enumera 118 eventos históricos y figuras de 1949-1989. Billy Joel la escribió después de que un joven de 21 años le dijera que era un momento aburrido para crecer. Joel memorizó toda la letra creando imágenes mentales y ha dicho que odia interpretarla en vivo porque es agotadora.",
+      "uri_apple_music": "applemusic://track/158816462"
     },
     {
       "year": 1973,
@@ -1827,7 +1913,8 @@
       "awards": [],
       "fun_fact": "Crocodile Rock was Elton John's first US number one single. It was written as a nostalgic tribute to 1950s rock and roll and the fictional dances of that era. The 'la la la' chorus was intentionally silly, capturing the innocent fun of early rock and roll dance hall culture.",
       "fun_fact_de": "Crocodile Rock war Elton Johns erste US-Nummer-eins-Single. Er wurde als nostalgische Hommage an den Rock and Roll der 1950er und die fiktiven Tänze dieser Ära geschrieben. Der 'la la la'-Refrain war absichtlich albern und fängt den unschuldigen Spaß der frühen Rock-and-Roll-Tanzhallenkultur ein.",
-      "fun_fact_es": "Crocodile Rock fue el primer sencillo número uno de Elton John en EE.UU. Fue escrita como un tributo nostálgico al rock and roll de los años 50 y los bailes ficticios de esa era. El coro 'la la la' era intencionalmente tonto, capturando la diversión inocente de la cultura de los salones de baile del rock and roll temprano."
+      "fun_fact_es": "Crocodile Rock fue el primer sencillo número uno de Elton John en EE.UU. Fue escrita como un tributo nostálgico al rock and roll de los años 50 y los bailes ficticios de esa era. El coro 'la la la' era intencionalmente tonto, capturando la diversión inocente de la cultura de los salones de baile del rock and roll temprano.",
+      "uri_apple_music": "applemusic://track/1440926343"
     },
     {
       "year": 1986,
@@ -1844,7 +1931,8 @@
       "awards": [],
       "fun_fact": "You Give Love a Bad Name was Bon Jovi's breakthrough hit that launched them to superstardom. The song was co-written with Desmond Child, who helped craft its massive arena rock sound. The opening a cappella scream became one of rock's most dramatic opening lines ever recorded.",
       "fun_fact_de": "You Give Love a Bad Name war Bon Jovis Durchbruchshit, der sie zum Superstarstatus katapultierte. Der Song wurde gemeinsam mit Desmond Child geschrieben, der half, seinen massiven Arena-Rock-Sound zu formen. Der a-cappella-Eröffnungsschrei wurde zu einer der dramatischsten Eröffnungszeilen, die je aufgenommen wurden.",
-      "fun_fact_es": "You Give Love a Bad Name fue el éxito revelación de Bon Jovi que los lanzó al estrellato. La canción fue coescrita con Desmond Child, quien ayudó a crear su masivo sonido de rock de arena. El grito a cappella de apertura se convirtió en una de las líneas de apertura más dramáticas jamás grabadas."
+      "fun_fact_es": "You Give Love a Bad Name fue el éxito revelación de Bon Jovi que los lanzó al estrellato. La canción fue coescrita con Desmond Child, quien ayudó a crear su masivo sonido de rock de arena. El grito a cappella de apertura se convirtió en una de las líneas de apertura más dramáticas jamás grabadas.",
+      "uri_apple_music": "applemusic://track/1422954999"
     },
     {
       "year": 1991,
@@ -1869,7 +1957,8 @@
       ],
       "awards_es": [
         "Salón de la Fama del Grammy (2017)"
-      ]
+      ],
+      "uri_apple_music": "applemusic://track/1440783625"
     },
     {
       "year": 1983,
@@ -1886,7 +1975,8 @@
       "awards": [],
       "fun_fact": "Girls Just Want to Have Fun was originally written by Robert Hazard as a song from a male perspective. Cyndi Lauper changed pronouns and the tone, transforming it into a feminist anthem. The colorful music video featured Lauper's real mother and helped establish MTV's visual culture.",
       "fun_fact_de": "Girls Just Want to Have Fun wurde ursprünglich von Robert Hazard aus männlicher Perspektive geschrieben. Cyndi Lauper änderte die Pronomen und den Ton und verwandelte ihn in eine feministische Hymne. Das bunte Musikvideo mit Laupers echter Mutter half, MTVs visuelle Kultur zu etablieren.",
-      "fun_fact_es": "Girls Just Want to Have Fun fue escrita originalmente por Robert Hazard desde una perspectiva masculina. Cyndi Lauper cambió los pronombres y el tono, transformándola en un himno feminista. El colorido video musical presentó a la madre real de Lauper y ayudó a establecer la cultura visual de MTV."
+      "fun_fact_es": "Girls Just Want to Have Fun fue escrita originalmente por Robert Hazard desde una perspectiva masculina. Cyndi Lauper cambió los pronombres y el tono, transformándola en un himno feminista. El colorido video musical presentó a la madre real de Lauper y ayudó a establecer la cultura visual de MTV.",
+      "uri_apple_music": "applemusic://track/400603693"
     },
     {
       "year": 1993,
@@ -1903,7 +1993,8 @@
       "awards": [],
       "fun_fact": "What Is Love was Haddaway's debut single and became a Eurodance classic. The song gained cult status through its use in the Saturday Night Live 'Night at the Roxbury' sketches. The head-bobbing dance move became iconic. Haddaway was genuinely asking a philosophical question about love.",
       "fun_fact_de": "What Is Love war Haddaways Debütsingle und wurde zu einem Eurodance-Klassiker. Der Song erlangte Kultstatus durch seine Verwendung in den Saturday Night Live 'Night at the Roxbury'-Sketchen. Die Kopfwackel-Tanzbewegung wurde ikonisch. Haddaway stellte aufrichtig eine philosophische Frage über die Liebe.",
-      "fun_fact_es": "What Is Love fue el sencillo debut de Haddaway y se convirtió en un clásico del Eurodance. La canción ganó estatus de culto a través de su uso en los sketches de Saturday Night Live 'Night at the Roxbury'. El movimiento de cabeza se volvió icónico. Haddaway estaba genuinamente haciendo una pregunta filosófica sobre el amor."
+      "fun_fact_es": "What Is Love fue el sencillo debut de Haddaway y se convirtió en un clásico del Eurodance. La canción ganó estatus de culto a través de su uso en los sketches de Saturday Night Live 'Night at the Roxbury'. El movimiento de cabeza se volvió icónico. Haddaway estaba genuinamente haciendo una pregunta filosófica sobre el amor.",
+      "uri_apple_music": "applemusic://track/1731384547"
     },
     {
       "year": 1987,
@@ -1920,7 +2011,8 @@
       "awards": [],
       "fun_fact": "Paradise City was inspired by Los Angeles and its promise of fame and fortune. The outro was recorded with the band playing live in the studio for 12 minutes straight. The song's epic length and guitar solos made it a perfect concert closer and one of Guns N' Roses' defining tracks.",
       "fun_fact_de": "Paradise City wurde von Los Angeles und seinem Versprechen von Ruhm und Reichtum inspiriert. Das Outro wurde aufgenommen, während die Band 12 Minuten lang live im Studio spielte. Die epische Länge und die Gitarrensoli des Songs machten ihn zu einem perfekten Konzertabschluss und einem der prägenden Tracks von Guns N' Roses.",
-      "fun_fact_es": "Paradise City fue inspirada por Los Ángeles y su promesa de fama y fortuna. El outro fue grabado con la banda tocando en vivo en el estudio durante 12 minutos seguidos. La duración épica de la canción y los solos de guitarra la hicieron un cierre de concierto perfecto y una de las canciones definitorias de Guns N' Roses."
+      "fun_fact_es": "Paradise City fue inspirada por Los Ángeles y su promesa de fama y fortuna. El outro fue grabado con la banda tocando en vivo en el estudio durante 12 minutos seguidos. La duración épica de la canción y los solos de guitarra la hicieron un cierre de concierto perfecto y una de las canciones definitorias de Guns N' Roses.",
+      "uri_apple_music": "applemusic://track/1377813298"
     },
     {
       "year": 1983,
@@ -1948,7 +2040,8 @@
       "awards_es": [
         "Grammy - Mejor Interpretación Vocal Pop (1984)",
         "Oscar - Mejor Canción Original (1984)"
-      ]
+      ],
+      "uri_apple_music": "applemusic://track/280711410"
     },
     {
       "year": 2002,
@@ -1965,7 +2058,8 @@
       "awards": [],
       "fun_fact": "Can't Stop features one of the most recognizable guitar riffs of the 2000s, played by John Frusciante. The song's funk-rock energy showcased Red Hot Chili Peppers at their peak. Chad Smith's drumming on this track is considered some of his best work with the band.",
       "fun_fact_de": "Can't Stop enthält eines der bekanntesten Gitarrenriffs der 2000er, gespielt von John Frusciante. Die Funk-Rock-Energie des Songs zeigte die Red Hot Chili Peppers auf ihrem Höhepunkt. Chad Smiths Schlagzeugspiel auf diesem Track gilt als eine seiner besten Arbeiten mit der Band.",
-      "fun_fact_es": "Can't Stop presenta uno de los riffs de guitarra más reconocibles de los 2000, tocado por John Frusciante. La energía funk-rock de la canción mostró a los Red Hot Chili Peppers en su mejor momento. La batería de Chad Smith en esta pista se considera uno de sus mejores trabajos con la banda."
+      "fun_fact_es": "Can't Stop presenta uno de los riffs de guitarra más reconocibles de los 2000, tocado por John Frusciante. La energía funk-rock de la canción mostró a los Red Hot Chili Peppers en su mejor momento. La batería de Chad Smith en esta pista se considera uno de sus mejores trabajos con la banda.",
+      "uri_apple_music": "applemusic://track/948438478"
     },
     {
       "year": 1999,
@@ -1982,7 +2076,8 @@
       "awards": [],
       "fun_fact": "I Want It That Way was written by Max Martin, who went on to become one of pop's most successful producers. Backstreet Boys admit the lyrics don't make complete grammatical sense, but Martin convinced them the emotion mattered more. It remains one of the best-selling singles of all time.",
       "fun_fact_de": "I Want It That Way wurde von Max Martin geschrieben, der zu einem der erfolgreichsten Pop-Produzenten werden sollte. Die Backstreet Boys geben zu, dass die Texte grammatikalisch nicht ganz sinnvoll sind, aber Martin überzeugte sie, dass die Emotion wichtiger ist. Er bleibt einer der meistverkauften Singles aller Zeiten.",
-      "fun_fact_es": "I Want It That Way fue escrita por Max Martin, quien se convertiría en uno de los productores pop más exitosos. Los Backstreet Boys admiten que la letra no tiene completo sentido gramatical, pero Martin los convenció de que la emoción importaba más. Sigue siendo uno de los sencillos más vendidos de todos los tiempos."
+      "fun_fact_es": "I Want It That Way fue escrita por Max Martin, quien se convertiría en uno de los productores pop más exitosos. Los Backstreet Boys admiten que la letra no tiene completo sentido gramatical, pero Martin los convenció de que la emoción importaba más. Sigue siendo uno de los sencillos más vendidos de todos los tiempos.",
+      "uri_apple_music": "applemusic://track/283567164"
     },
     {
       "year": 1986,
@@ -1999,7 +2094,8 @@
       "awards": [],
       "fun_fact": "Livin' on a Prayer tells the story of Tommy and Gina, working-class characters struggling to survive. Jon Bon Jovi initially disliked the song's talk-box effect but was convinced by producer. The song became one of the most-played rock anthems at sporting events and karaoke nights worldwide.",
       "fun_fact_de": "Livin' on a Prayer erzählt die Geschichte von Tommy und Gina, Arbeiterfiguren, die ums Überleben kämpfen. Jon Bon Jovi mochte den Talk-Box-Effekt des Songs anfangs nicht, wurde aber vom Produzenten überzeugt. Der Song wurde weltweit zu einer der meistgespielten Rock-Hymnen bei Sportveranstaltungen und Karaoke-Abenden.",
-      "fun_fact_es": "Livin' on a Prayer cuenta la historia de Tommy y Gina, personajes de clase trabajadora que luchan por sobrevivir. A Jon Bon Jovi inicialmente no le gustó el efecto de talk-box de la canción pero fue convencido por el productor. La canción se convirtió en uno de los himnos de rock más tocados en eventos deportivos y noches de karaoke en todo el mundo."
+      "fun_fact_es": "Livin' on a Prayer cuenta la historia de Tommy y Gina, personajes de clase trabajadora que luchan por sobrevivir. A Jon Bon Jovi inicialmente no le gustó el efecto de talk-box de la canción pero fue convencido por el productor. La canción se convirtió en uno de los himnos de rock más tocados en eventos deportivos y noches de karaoke en todo el mundo.",
+      "uri_apple_music": "applemusic://track/1422955211"
     },
     {
       "year": 1987,
@@ -2024,7 +2120,8 @@
       ],
       "awards_es": [
         "American Music Award - Sencillo Pop/Rock Favorito (1989)"
-      ]
+      ],
+      "uri_apple_music": "applemusic://track/1377826892"
     },
     {
       "year": 2000,
@@ -2041,7 +2138,8 @@
       "awards": [],
       "fun_fact": "In the End became Linkin Park's signature song and defined the nu-metal era. Mike Shinoda's rapping combined with Chester Bennington's singing created their distinctive sound. The song's themes of trying hard but ultimately failing resonated with millions of fans worldwide, becoming a generational anthem.",
       "fun_fact_de": "In the End wurde zu Linkin Parks Erkennungslied und definierte die Nu-Metal-Ära. Mike Shinodas Rap kombiniert mit Chester Benningtons Gesang schuf ihren unverwechselbaren Sound. Die Themen des Songs über hartes Bemühen, aber letztendliches Scheitern, sprachen Millionen von Fans weltweit an und wurde zu einer Generationenhymne.",
-      "fun_fact_es": "In the End se convirtió en la canción insignia de Linkin Park y definió la era del nu-metal. El rap de Mike Shinoda combinado con el canto de Chester Bennington creó su sonido distintivo. Los temas de la canción sobre esforzarse mucho pero finalmente fallar resonaron con millones de fans en todo el mundo, convirtiéndose en un himno generacional."
+      "fun_fact_es": "In the End se convirtió en la canción insignia de Linkin Park y definió la era del nu-metal. El rap de Mike Shinoda combinado con el canto de Chester Bennington creó su sonido distintivo. Los temas de la canción sobre esforzarse mucho pero finalmente fallar resonaron con millones de fans en todo el mundo, convirtiéndose en un himno generacional.",
+      "uri_apple_music": "applemusic://track/590431785"
     }
   ]
 }

--- a/custom_components/beatify/playlists/movies-100-greatest-themes.json
+++ b/custom_components/beatify/playlists/movies-100-greatest-themes.json
@@ -21,7 +21,8 @@
       "awards_es": [
         "Premio Oscar a la mejor banda sonora original (2001)",
         "Premio Grammy a la mejor banda sonora (2002)"
-      ]
+      ],
+      "uri_apple_music": "applemusic://track/1369922084"
     },
     {
       "year": 1962,
@@ -54,7 +55,8 @@
       "awards_es": [
         "Premio Oscar a la mejor banda sonora original (1997)",
         "Globo de Oro a la mejor banda sonora original (1998)"
-      ]
+      ],
+      "uri_apple_music": "applemusic://track/582727836"
     },
     {
       "year": 1977,
@@ -80,7 +82,8 @@
       "awards_es": [
         "Premio Oscar a la mejor banda sonora original (1977)",
         "Premio Grammy a la mejor banda sonora (1978)"
-      ]
+      ],
+      "uri_apple_music": "applemusic://track/1375814284"
     },
     {
       "year": 1977,
@@ -104,7 +107,8 @@
       ],
       "awards_es": [
         "Premio Grammy al album del ano (1979)"
-      ]
+      ],
+      "uri_apple_music": "applemusic://track/1445668462"
     },
     {
       "year": 1966,
@@ -119,7 +123,8 @@
       "certifications": [
         "Gold (US)"
       ],
-      "awards": []
+      "awards": [],
+      "uri_apple_music": "applemusic://track/715628797"
     },
     {
       "year": 1999,
@@ -137,7 +142,8 @@
       ],
       "awards_es": [
         "Premio Grammy a la mejor banda sonora (2000)"
-      ]
+      ],
+      "uri_apple_music": "applemusic://track/1437293431"
     },
     {
       "year": 1994,
@@ -147,7 +153,8 @@
       "fun_fact_es": "Alan Silvestri compuso el suave tema de piano de Forrest Gump para reflejar la vision inocente del personaje del mundo a traves de decadas de historia estadounidense.",
       "chart_info": {},
       "certifications": [],
-      "awards": []
+      "awards": [],
+      "uri_apple_music": "applemusic://track/203797501"
     },
     {
       "year": 1978,
@@ -162,7 +169,8 @@
       "certifications": [
         "Platinum (US)"
       ],
-      "awards": []
+      "awards": [],
+      "uri_apple_music": "applemusic://track/1687217340"
     },
     {
       "year": 1971,
@@ -209,7 +217,8 @@
       ],
       "awards_es": [
         "Premio Grammy a la mejor pieza instrumental (1964)"
-      ]
+      ],
+      "uri_apple_music": "applemusic://track/1732608881"
     },
     {
       "year": 2002,
@@ -219,7 +228,8 @@
       "fun_fact_es": "La banda sonora de El caso Bourne de John Powell fue pionera en el sonido moderno de peliculas de accion con ritmos impulsantes y elementos electronicos mezclados con orquesta.",
       "chart_info": {},
       "certifications": [],
-      "awards": []
+      "awards": [],
+      "uri_apple_music": "applemusic://track/1636991684"
     },
     {
       "year": 1972,
@@ -231,7 +241,8 @@
         "billboard_peak": 43
       },
       "certifications": [],
-      "awards": []
+      "awards": [],
+      "uri_apple_music": "applemusic://track/1440844677"
     },
     {
       "year": 1966,
@@ -257,7 +268,8 @@
       "awards_es": [
         "Premio Oscar a la mejor cancion original (1966)",
         "Premio Oscar a la mejor banda sonora original (1966)"
-      ]
+      ],
+      "uri_apple_music": "applemusic://track/209447357"
     },
     {
       "year": 1994,
@@ -280,7 +292,8 @@
       ],
       "awards_es": [
         "Globo de Oro a la mejor cancion original (1995)"
-      ]
+      ],
+      "uri_apple_music": "applemusic://track/1445732924"
     },
     {
       "year": 1976,
@@ -303,7 +316,8 @@
       ],
       "awards_es": [
         "Nominación al Óscar a la mejor canción original (1976)"
-      ]
+      ],
+      "uri_apple_music": "applemusic://track/1440832696"
     },
     {
       "year": 1965,
@@ -329,7 +343,8 @@
       "awards_es": [
         "Premio Oscar a la mejor banda sonora original (1965)",
         "Globo de Oro a la mejor banda sonora original (1966)"
-      ]
+      ],
+      "uri_apple_music": "applemusic://track/1455256248"
     },
     {
       "year": 1960,
@@ -355,7 +370,8 @@
         "weeks_on_chart": 8
       },
       "certifications": [],
-      "awards": []
+      "awards": [],
+      "uri_apple_music": "applemusic://track/1443666197"
     },
     {
       "year": 1983,
@@ -375,7 +391,8 @@
       "fun_fact_es": "La banda sonora de La milla verde de Thomas Newman utiliza piano suave y cuerdas para subrayar los temas de compasion y redencion sobrenatural de la pelicula.",
       "chart_info": {},
       "certifications": [],
-      "awards": []
+      "awards": [],
+      "uri_apple_music": "applemusic://track/373216432"
     },
     {
       "year": 2014,
@@ -393,7 +410,8 @@
       ],
       "awards_es": [
         "Nominacion al Grammy a la mejor banda sonora (2015)"
-      ]
+      ],
+      "uri_apple_music": "applemusic://track/1533984393"
     },
     {
       "year": 1967,
@@ -429,7 +447,8 @@
       "awards_es": [
         "Globo de Oro a la mejor banda sonora original (2016)",
         "BAFTA a la mejor musica de cine (2016)"
-      ]
+      ],
+      "uri_apple_music": "applemusic://track/1516405842"
     },
     {
       "year": 2007,
@@ -439,7 +458,8 @@
       "fun_fact_es": "La banda sonora de Beowulf de Alan Silvestri combina orquesta con elementos electronicos y coro para dar vida al antiguo poema epico.",
       "chart_info": {},
       "certifications": [],
-      "awards": []
+      "awards": [],
+      "uri_apple_music": "applemusic://track/268374723"
     },
     {
       "year": 1969,
@@ -469,7 +489,8 @@
       ],
       "awards_es": [
         "Palma de Oro en Cannes (1966)"
-      ]
+      ],
+      "uri_apple_music": "applemusic://track/546983101"
     },
     {
       "year": 2010,
@@ -479,7 +500,8 @@
       "fun_fact_es": "La banda sonora de Noche y dia de John Powell mezcla elementos de accion con comedia romantica, igualando el tono que mezcla generos de la pelicula.",
       "chart_info": {},
       "certifications": [],
-      "awards": []
+      "awards": [],
+      "uri_apple_music": "applemusic://track/1443410090"
     },
     {
       "year": 1995,
@@ -505,7 +527,8 @@
       "awards_es": [
         "Premio Oscar a la mejor cancion original (1995)",
         "Globo de Oro a la mejor cancion original (1995)"
-      ]
+      ],
+      "uri_apple_music": "applemusic://track/1440720182"
     },
     {
       "year": 1969,
@@ -528,7 +551,8 @@
       ],
       "awards_es": [
         "Premio Oscar a la mejor cancion original (1969)"
-      ]
+      ],
+      "uri_apple_music": "applemusic://track/1571097826"
     },
     {
       "year": 1969,
@@ -538,7 +562,8 @@
       "fun_fact_es": "The Pusher de Steppenwolf abre Easy Rider, estableciendo el tono contracultural. Las letras oscuras de la cancion contrastaban con la libertad de la carretera abierta.",
       "chart_info": {},
       "certifications": [],
-      "awards": []
+      "awards": [],
+      "uri_apple_music": "applemusic://track/1440860186"
     },
     {
       "year": 1969,
@@ -548,7 +573,8 @@
       "fun_fact_es": "El tema de Cowboy de medianoche de John Barry usa armonica para evocar la soledad urbana. La pelicula fue la unica con clasificacion X en ganar el Oscar a la mejor pelicula.",
       "chart_info": {},
       "certifications": [],
-      "awards": []
+      "awards": [],
+      "uri_apple_music": "applemusic://track/697397846"
     },
     {
       "year": 1975,
@@ -572,7 +598,8 @@
       "awards_es": [
         "Premio Oscar a la mejor banda sonora original (1975)",
         "Premio Grammy a la mejor banda sonora (1976)"
-      ]
+      ],
+      "uri_apple_music": "applemusic://track/1842229145"
     },
     {
       "year": 1978,
@@ -593,7 +620,8 @@
       "awards_es": [
         "Premio Oscar a la mejor banda sonora original (1978)",
         "Globo de Oro a la mejor banda sonora original (1979)"
-      ]
+      ],
+      "uri_apple_music": "applemusic://track/1443529354"
     },
     {
       "year": 1987,
@@ -639,7 +667,8 @@
       ],
       "awards_es": [
         "Nominacion al Oscar a la mejor cancion original (1995)"
-      ]
+      ],
+      "uri_apple_music": "applemusic://track/1440669784"
     },
     {
       "year": 1999,
@@ -649,7 +678,8 @@
       "fun_fact_es": "La banda sonora de Matrix de Don Davis mezcla orquesta con musica electronica para crear el distintivo paisaje sonoro de realidad digital de la pelicula.",
       "chart_info": {},
       "certifications": [],
-      "awards": []
+      "awards": [],
+      "uri_apple_music": "applemusic://track/1776050077"
     },
     {
       "year": 1962,
@@ -659,7 +689,8 @@
       "fun_fact_es": "Seventy Six Trombones de El hombre de la musica presenta una elaborada coreografia de banda de marcha. Robert Preston interpreto su papel de Broadway en la pelicula.",
       "chart_info": {},
       "certifications": [],
-      "awards": []
+      "awards": [],
+      "uri_apple_music": "applemusic://track/1514004194"
     },
     {
       "year": 2012,
@@ -669,7 +700,8 @@
       "fun_fact_es": "El tema de Los Vengadores de Alan Silvestri se ha convertido en la identidad musical del Universo Cinematografico de Marvel, apareciendo a lo largo de toda la franquicia.",
       "chart_info": {},
       "certifications": [],
-      "awards": []
+      "awards": [],
+      "uri_apple_music": "applemusic://track/1697155587"
     },
     {
       "year": 1996,
@@ -684,7 +716,8 @@
       "certifications": [
         "Gold (US)"
       ],
-      "awards": []
+      "awards": [],
+      "uri_apple_music": "applemusic://track/1444100762"
     },
     {
       "year": 1980,
@@ -726,7 +759,8 @@
       ],
       "awards_es": [
         "Nominacion al Oscar a la Mejor Banda Sonora Original (1990)"
-      ]
+      ],
+      "uri_apple_music": "applemusic://track/1049528540"
     },
     {
       "year": 1968,
@@ -765,7 +799,8 @@
       ],
       "awards_es": [
         "Nominacion al Oscar a la Mejor Banda Sonora Original (1981)"
-      ]
+      ],
+      "uri_apple_music": "applemusic://track/1400945114"
     },
     {
       "year": 1994,
@@ -778,7 +813,8 @@
         "weeks_on_chart": 13
       },
       "certifications": [],
-      "awards": []
+      "awards": [],
+      "uri_apple_music": "applemusic://track/1462308555"
     },
     {
       "year": 1964,
@@ -811,7 +847,8 @@
       ],
       "awards_es": [
         "Premio Oscar a la Mejor Pelicula (1965)"
-      ]
+      ],
+      "uri_apple_music": "applemusic://track/1550187917"
     },
     {
       "year": 1966,
@@ -821,7 +858,8 @@
       "fun_fact_es": "The Ecstasy of Gold suena durante la escena del cementerio en El Bueno, el Malo y el Feo. Metallica lo usa para abrir sus conciertos.",
       "chart_info": {},
       "certifications": [],
-      "awards": []
+      "awards": [],
+      "uri_apple_music": "applemusic://track/715630264"
     },
     {
       "year": 1970,
@@ -833,7 +871,8 @@
         "billboard_peak": 74
       },
       "certifications": [],
-      "awards": []
+      "awards": [],
+      "uri_apple_music": "applemusic://track/1743285349"
     },
     {
       "year": 1955,
@@ -898,7 +937,8 @@
       "awards_es": [
         "Premio Oscar a la Mejor Cancion Original (1961)",
         "Premio Grammy a la Grabacion del Ano (1962)"
-      ]
+      ],
+      "uri_apple_music": "applemusic://track/298421438"
     },
     {
       "year": 1994,
@@ -916,7 +956,8 @@
       ],
       "awards_es": [
         "Nominacion al Oscar a la Mejor Banda Sonora Original (1994)"
-      ]
+      ],
+      "uri_apple_music": "applemusic://track/331545686"
     },
     {
       "year": 2002,
@@ -926,7 +967,8 @@
       "fun_fact_es": "La Cancion de Gollum cierra Las Dos Torres. Las inquietantes voces de Emiliana Torrini capturan la tragedia del corrompido Smeagol.",
       "chart_info": {},
       "certifications": [],
-      "awards": []
+      "awards": [],
+      "uri_apple_music": "applemusic://track/297981337"
     },
     {
       "year": 2004,
@@ -936,7 +978,8 @@
       "fun_fact_es": "El tema de Spider-Man de Danny Elfman combina metales heroicos con su estilo peculiar caracteristico, definiendo el sonido de la trilogia de Sam Raimi.",
       "chart_info": {},
       "certifications": [],
-      "awards": []
+      "awards": [],
+      "uri_apple_music": "applemusic://track/186379179"
     },
     {
       "year": 1959,
@@ -971,7 +1014,8 @@
         "billboard_peak": 31
       },
       "certifications": [],
-      "awards": []
+      "awards": [],
+      "uri_apple_music": "applemusic://track/1521738030"
     },
     {
       "year": 1964,
@@ -981,7 +1025,8 @@
       "fun_fact_es": "Un Disparo en la Oscuridad fue la segunda pelicula de la Pantera Rosa. La partitura jazzistica de Henry Mancini realzo la comedia fisica de Peter Sellers.",
       "chart_info": {},
       "certifications": [],
-      "awards": []
+      "awards": [],
+      "uri_apple_music": "applemusic://track/298379578"
     },
     {
       "year": 1958,
@@ -1033,7 +1078,8 @@
       "awards_es": [
         "Premio Oscar a la Mejor Cancion Original (1976)",
         "Globo de Oro a la Mejor Cancion Original (1977)"
-      ]
+      ],
+      "uri_apple_music": "applemusic://track/192884975"
     },
     {
       "year": 1980,
@@ -1046,7 +1092,8 @@
         "uk_peak": 10
       },
       "certifications": [],
-      "awards": []
+      "awards": [],
+      "uri_apple_music": "applemusic://track/1440807379"
     },
     {
       "year": 1985,
@@ -1066,7 +1113,8 @@
       "fun_fact_es": "Sunrise, Sunset de El Violinista en el Tejado captura la alegria agridulce. La cancion se ha convertido en un clasico de las bodas judias en todo el mundo.",
       "chart_info": {},
       "certifications": [],
-      "awards": []
+      "awards": [],
+      "uri_apple_music": "applemusic://track/1240963025"
     },
     {
       "year": 1969,
@@ -1081,7 +1129,8 @@
       "certifications": [
         "Gold (UK)"
       ],
-      "awards": []
+      "awards": [],
+      "uri_apple_music": "applemusic://track/1657796080"
     },
     {
       "year": 1980,
@@ -1091,7 +1140,8 @@
       "fun_fact_es": "La banda sonora de Foxes de Giorgio Moroder presenta a Donna Summer y otros artistas de disco, capturando la escena de clubes de Los Angeles de finales de los 70.",
       "chart_info": {},
       "certifications": [],
-      "awards": []
+      "awards": [],
+      "uri_apple_music": "applemusic://track/1567146201"
     },
     {
       "year": 1968,
@@ -1101,7 +1151,8 @@
       "fun_fact_es": "La banda sonora de Bullitt de Lalo Schifrin fue pionera en el enfoque de jazz cool para peliculas de accion. La persecucion de autos no necesitaba musica en absoluto.",
       "chart_info": {},
       "certifications": [],
-      "awards": []
+      "awards": [],
+      "uri_apple_music": "applemusic://track/265721078"
     },
     {
       "year": 2019,
@@ -1111,7 +1162,8 @@
       "fun_fact_es": "La banda sonora de Erase una Vez en Hollywood presenta rarezas de los anos 60. Tarantino personalmente selecciono cada cancion.",
       "chart_info": {},
       "certifications": [],
-      "awards": []
+      "awards": [],
+      "uri_apple_music": "applemusic://track/1444009605"
     },
     {
       "year": 1983,
@@ -1131,7 +1183,8 @@
       ],
       "awards_es": [
         "BAFTA a la Mejor Musica de Pelicula (1983)"
-      ]
+      ],
+      "uri_apple_music": "applemusic://track/1500818278"
     },
     {
       "year": 1978,
@@ -1161,7 +1214,8 @@
       "fun_fact_es": "El tema de Hombres de Negro de Danny Elfman combina la tension de peliculas de espias con comedia de ciencia ficcion, igualando el tono irreverente de la pelicula.",
       "chart_info": {},
       "certifications": [],
-      "awards": []
+      "awards": [],
+      "uri_apple_music": "applemusic://track/157495883"
     },
     {
       "year": 2022,
@@ -1171,7 +1225,8 @@
       "fun_fact_es": "Elvis (2022) presenta a Austin Butler interpretando muchas canciones el mismo. La pelicula utiliza las grabaciones originales de Elvis para ciertas escenas.",
       "chart_info": {},
       "certifications": [],
-      "awards": []
+      "awards": [],
+      "uri_apple_music": "applemusic://track/1628655051"
     },
     {
       "year": 1960,
@@ -1205,7 +1260,8 @@
       "certifications": [
         "Gold (US)"
       ],
-      "awards": []
+      "awards": [],
+      "uri_apple_music": "applemusic://track/1681196890"
     },
     {
       "year": 1964,
@@ -1221,7 +1277,8 @@
       "certifications": [
         "Gold (US)"
       ],
-      "awards": []
+      "awards": [],
+      "uri_apple_music": "applemusic://track/696888851"
     },
     {
       "year": 1978,
@@ -1231,7 +1288,8 @@
       "fun_fact_es": "John Carpenter compuso el tema de Halloween el mismo en sintetizador. El simple motivo de piano en 5/4 costo casi nada de crear.",
       "chart_info": {},
       "certifications": [],
-      "awards": []
+      "awards": [],
+      "uri_apple_music": "applemusic://track/393996227"
     },
     {
       "year": 1942,
@@ -1244,7 +1302,8 @@
         "weeks_on_chart": 21
       },
       "certifications": [],
-      "awards": []
+      "awards": [],
+      "uri_apple_music": "applemusic://track/1455698341"
     },
     {
       "year": 2012,
@@ -1254,7 +1313,8 @@
       "fun_fact_es": "Django Sin Cadenas abre con el tema original de Django de 1966 de Luis Bacalov, conectando la pelicula de Tarantino con los Spaghetti Westerns.",
       "chart_info": {},
       "certifications": [],
-      "awards": []
+      "awards": [],
+      "uri_apple_music": "applemusic://track/1440874258"
     },
     {
       "year": 1996,
@@ -1264,7 +1324,8 @@
       "fun_fact_es": "La serie de peliculas Mision: Imposible continuo usando el tema de TV de Lalo Schifrin. Sigue siendo uno de los motivos de espias mas reconocibles.",
       "chart_info": {},
       "certifications": [],
-      "awards": []
+      "awards": [],
+      "uri_apple_music": "applemusic://track/1441032262"
     },
     {
       "year": 1968,
@@ -1302,7 +1363,8 @@
       "awards_es": [
         "Premio Óscar a la mejor banda sonora original (1960)",
         "Globo de Oro a la mejor banda sonora original (1961)"
-      ]
+      ],
+      "uri_apple_music": "applemusic://track/1719334913"
     },
     {
       "year": 1999,
@@ -1314,7 +1376,8 @@
         "billboard_peak": 63
       },
       "certifications": [],
-      "awards": []
+      "awards": [],
+      "uri_apple_music": "applemusic://track/1375814326"
     },
     {
       "year": 1939,
@@ -1332,7 +1395,8 @@
       ],
       "awards_es": [
         "Premio Óscar a la mejor banda sonora original (1939)"
-      ]
+      ],
+      "uri_apple_music": "applemusic://track/1454324974"
     },
     {
       "year": 1986,
@@ -1357,7 +1421,8 @@
       "fun_fact_es": "La muerte tenía un precio de Ennio Morricone presenta un reloj de bolsillo musical. La melodía tintineante se convierte en un elemento argumental de la película.",
       "chart_info": {},
       "certifications": [],
-      "awards": []
+      "awards": [],
+      "uri_apple_music": "applemusic://track/1718039376"
     },
     {
       "year": 1981,
@@ -1380,7 +1445,8 @@
       ],
       "awards_es": [
         "Premio Óscar a la mejor banda sonora original (1981)"
-      ]
+      ],
+      "uri_apple_music": "applemusic://track/1453156892"
     },
     {
       "year": 1984,
@@ -1403,7 +1469,8 @@
       ],
       "awards_es": [
         "Nominación al Óscar a la mejor canción original (1984)"
-      ]
+      ],
+      "uri_apple_music": "applemusic://track/1484413134"
     },
     {
       "year": 1973,
@@ -1440,7 +1507,8 @@
         "weeks_on_chart": 13
       },
       "certifications": [],
-      "awards": []
+      "awards": [],
+      "uri_apple_music": "applemusic://track/368555829"
     },
     {
       "year": 1958,
@@ -1450,7 +1518,8 @@
       "fun_fact_es": "La banda sonora de Vértigo de Bernard Herrmann usa cuerdas arremolinadas para reflejar la obsesión. Hitchcock la consideraba esencial para el efecto de la película.",
       "chart_info": {},
       "certifications": [],
-      "awards": []
+      "awards": [],
+      "uri_apple_music": "applemusic://track/600474544"
     },
     {
       "year": 1967,
@@ -1463,7 +1532,8 @@
         "weeks_on_chart": 8
       },
       "certifications": [],
-      "awards": []
+      "awards": [],
+      "uri_apple_music": "applemusic://track/1530113036"
     },
     {
       "year": 1982,
@@ -1484,7 +1554,8 @@
       "awards_es": [
         "Premio Óscar a la mejor banda sonora original (1982)",
         "Premio Grammy a la mejor banda sonora (1983)"
-      ]
+      ],
+      "uri_apple_music": "applemusic://track/347385520"
     },
     {
       "year": 1991,
@@ -1494,7 +1565,8 @@
       "fun_fact_es": "El tema de Terminator 2 de Brad Fiedel usa sonidos metálicos y sintetizadores para evocar tanto máquinas como latidos del corazón.",
       "chart_info": {},
       "certifications": [],
-      "awards": []
+      "awards": [],
+      "uri_apple_music": "applemusic://track/1440895540"
     },
     {
       "year": 1972,
@@ -1509,7 +1581,8 @@
       "certifications": [
         "Gold (US)"
       ],
-      "awards": []
+      "awards": [],
+      "uri_apple_music": "applemusic://track/40454154"
     },
     {
       "year": 1976,
@@ -1534,7 +1607,8 @@
       "fun_fact_es": "Gene Kelly interpretó Cantando bajo la lluvia estando enfermo con fiebre de 39,4 grados. Los charcos se mezclaron con leche para mayor visibilidad.",
       "chart_info": {},
       "certifications": [],
-      "awards": []
+      "awards": [],
+      "uri_apple_music": "applemusic://track/1455420758"
     },
     {
       "year": 2011,
@@ -1562,7 +1636,8 @@
       "fun_fact_es": "La banda sonora de La cosa de Ennio Morricone fue rechazada por John Carpenter, quien la encontró demasiado extraña. Ahora se considera un clásico.",
       "chart_info": {},
       "certifications": [],
-      "awards": []
+      "awards": [],
+      "uri_apple_music": "applemusic://track/1657233147"
     },
     {
       "year": 1982,
@@ -1584,7 +1659,8 @@
       "fun_fact_es": "El tema de Con la muerte en los talones de Bernard Herrmann es un fandango que impulsa el suspenso de la película. Hitchcock consideraba a Herrmann esencial.",
       "chart_info": {},
       "certifications": [],
-      "awards": []
+      "awards": [],
+      "uri_apple_music": "applemusic://track/1455885358"
     },
     {
       "year": 1939,
@@ -1607,7 +1683,8 @@
       ],
       "awards_es": [
         "Premio Óscar a la mejor canción original (1939)"
-      ]
+      ],
+      "uri_apple_music": "applemusic://track/1455918432"
     },
     {
       "year": 1982,
@@ -1620,7 +1697,8 @@
         "uk_peak": 26
       },
       "certifications": [],
-      "awards": []
+      "awards": [],
+      "uri_apple_music": "applemusic://track/1443427544"
     },
     {
       "year": 1968,
@@ -1650,7 +1728,8 @@
       "fun_fact_es": "La banda sonora de Psicosis de Bernard Herrmann usa solo cuerdas. Los violines estridentes de la escena de la ducha cambiaron la música de terror para siempre.",
       "chart_info": {},
       "certifications": [],
-      "awards": []
+      "awards": [],
+      "uri_apple_music": "applemusic://track/1440795713"
     },
     {
       "year": 1955,
@@ -1714,7 +1793,8 @@
       ],
       "awards_es": [
         "Premio Grammy a la mejor grabación instrumental (1975)"
-      ]
+      ],
+      "uri_apple_music": "applemusic://track/1443259735"
     },
     {
       "year": 1959,
@@ -1732,7 +1812,8 @@
       ],
       "awards_es": [
         "Premio Óscar a la mejor banda sonora original (1959)"
-      ]
+      ],
+      "uri_apple_music": "applemusic://track/1455700172"
     },
     {
       "year": 1992,
@@ -1763,7 +1844,8 @@
       ],
       "awards_es": [
         "Premio Óscar a la mejor banda sonora original (1962)"
-      ]
+      ],
+      "uri_apple_music": "applemusic://track/1663023916"
     },
     {
       "year": 1976,
@@ -1773,7 +1855,8 @@
       "fun_fact_es": "La banda sonora de Taxi Driver de Bernard Herrmann fue su última obra. Murió la noche después de completar las sesiones de grabación.",
       "chart_info": {},
       "certifications": [],
-      "awards": []
+      "awards": [],
+      "uri_apple_music": "applemusic://track/174892425"
     },
     {
       "year": 1964,
@@ -1783,7 +1866,8 @@
       "fun_fact_es": "El tema de Por un puñado de dólares de Ennio Morricone creó el sonido del spaghetti western. Los silbidos y chasquidos de látigo se volvieron icónicos.",
       "chart_info": {},
       "certifications": [],
-      "awards": []
+      "awards": [],
+      "uri_apple_music": "applemusic://track/1440831930"
     },
     {
       "year": 1971,
@@ -1796,7 +1880,8 @@
         "uk_peak": 38
       },
       "certifications": [],
-      "awards": []
+      "awards": [],
+      "uri_apple_music": "applemusic://track/1443116804"
     },
     {
       "year": 1979,
@@ -1806,7 +1891,8 @@
       "fun_fact_es": "La Cabalgata de las valquirias de Wagner en Apocalypse Now acompaña un ataque de helicópteros. Coppola hizo que la música clásica fuera aterradora.",
       "chart_info": {},
       "certifications": [],
-      "awards": []
+      "awards": [],
+      "uri_apple_music": "applemusic://track/927346120"
     },
     {
       "year": 1962,
@@ -1824,7 +1910,8 @@
       ],
       "awards_es": [
         "Nominación al Óscar a la mejor banda sonora original (1962)"
-      ]
+      ],
+      "uri_apple_music": "applemusic://track/1444004606"
     },
     {
       "year": 1980,
@@ -1841,7 +1928,8 @@
         "Platinum (US)",
         "Gold (UK)"
       ],
-      "awards": []
+      "awards": [],
+      "uri_apple_music": "applemusic://track/1440743615"
     },
     {
       "year": 1961,
@@ -1884,7 +1972,8 @@
       ],
       "awards_es": [
         "Nominación al Óscar a la mejor canción original (1967)"
-      ]
+      ],
+      "uri_apple_music": "applemusic://track/1442849462"
     },
     {
       "year": 1973,
@@ -1897,7 +1986,8 @@
         "weeks_on_chart": 14
       },
       "certifications": [],
-      "awards": []
+      "awards": [],
+      "uri_apple_music": "applemusic://track/459757919"
     },
     {
       "year": 1942,
@@ -1907,7 +1997,8 @@
       "fun_fact_es": "La banda sonora de Casablanca entrelaza música clásica, jazz y el himno francés La Marsellesa en una poderosa escena de bar.",
       "chart_info": {},
       "certifications": [],
-      "awards": []
+      "awards": [],
+      "uri_apple_music": "applemusic://track/1455697817"
     },
     {
       "year": 1979,
@@ -1925,7 +2016,8 @@
       ],
       "awards_es": [
         "Nominación al Óscar a la Mejor Banda Sonora Original (1979)"
-      ]
+      ],
+      "uri_apple_music": "applemusic://track/1440854590"
     },
     {
       "year": 1971,
@@ -1935,7 +2027,8 @@
       "fun_fact_es": "La obertura de La urraca ladrona de Rossini acompaña la ultraviolencia en La naranja mecánica. Las elecciones de música clásica de Kubrick se convirtieron en su sello distintivo.",
       "chart_info": {},
       "certifications": [],
-      "awards": []
+      "awards": [],
+      "uri_apple_music": "applemusic://track/904757640"
     },
     {
       "year": 1981,
@@ -1961,7 +2054,8 @@
       "awards_es": [
         "Óscar a la Mejor Canción Original (1981)",
         "Globo de Oro a la Mejor Canción Original (1982)"
-      ]
+      ],
+      "uri_apple_music": "applemusic://track/273426183"
     },
     {
       "year": 2000,
@@ -1982,7 +2076,8 @@
       "awards_es": [
         "Óscar a la Mejor Banda Sonora Original (2000)",
         "Globo de Oro a la Mejor Banda Sonora Original (2001)"
-      ]
+      ],
+      "uri_apple_music": "applemusic://track/1452552843"
     },
     {
       "year": 1995,
@@ -2000,7 +2095,8 @@
       ],
       "awards_es": [
         "Óscar a la Mejor Banda Sonora Original (1995)"
-      ]
+      ],
+      "uri_apple_music": "applemusic://track/1440773543"
     },
     {
       "year": 1954,
@@ -2018,7 +2114,8 @@
       ],
       "awards_es": [
         "Óscar a la Mejor Banda Sonora (1954)"
-      ]
+      ],
+      "uri_apple_music": "applemusic://track/1658406090"
     },
     {
       "year": 1968,
@@ -2028,7 +2125,8 @@
       "fun_fact_es": "La banda sonora de El planeta de los simios de Jerry Goldsmith utiliza instrumentos no convencionales como cuernos de carnero y cuencos de mezcla.",
       "chart_info": {},
       "certifications": [],
-      "awards": []
+      "awards": [],
+      "uri_apple_music": "applemusic://track/1443095011"
     },
     {
       "year": 1965,
@@ -2052,7 +2150,8 @@
       ],
       "awards_es": [
         "Nominación al Óscar a la Mejor Canción Original (1965)"
-      ]
+      ],
+      "uri_apple_music": "applemusic://track/1444091737"
     },
     {
       "year": 1957,
@@ -2079,7 +2178,8 @@
       "fun_fact_es": "La banda sonora de El resplandor de Wendy Carlos incluye versiones electrónicas de Berlioz y Bartók, creando una atmósfera inquietante.",
       "chart_info": {},
       "certifications": [],
-      "awards": []
+      "awards": [],
+      "uri_apple_music": "applemusic://track/1535496635"
     },
     {
       "year": 1969,
@@ -2089,7 +2189,8 @@
       "fun_fact_es": "La banda sonora de The Italian Job de Quincy Jones presenta On Days Like These de Matt Monro. La persecución en Mini Cooper de la película se volvió legendaria.",
       "chart_info": {},
       "certifications": [],
-      "awards": []
+      "awards": [],
+      "uri_apple_music": "applemusic://track/1802763015"
     },
     {
       "year": 1964,
@@ -2115,7 +2216,8 @@
       "awards_es": [
         "Óscar a la Mejor Banda Sonora Original (1964)",
         "Óscar a la Mejor Canción Original (1964)"
-      ]
+      ],
+      "uri_apple_music": "applemusic://track/1440796520"
     },
     {
       "year": 1965,
@@ -2132,7 +2234,8 @@
         "Gold (US)",
         "Gold (UK)"
       ],
-      "awards": []
+      "awards": [],
+      "uri_apple_music": "applemusic://track/1441164536"
     },
     {
       "year": 1985,
@@ -2148,7 +2251,8 @@
       "certifications": [
         "Gold (US)"
       ],
-      "awards": []
+      "awards": [],
+      "uri_apple_music": "applemusic://track/1443234133"
     },
     {
       "year": 1954,
@@ -2166,7 +2270,8 @@
       ],
       "awards_es": [
         "Óscar a la Mejor Banda Sonora Original (1954)"
-      ]
+      ],
+      "uri_apple_music": "applemusic://track/1816013634"
     },
     {
       "year": 1963,
@@ -2197,7 +2302,8 @@
       ],
       "awards_es": [
         "Premio Grammy a la Mejor Interpretación Instrumental (1963)"
-      ]
+      ],
+      "uri_apple_music": "applemusic://track/306820503"
     },
     {
       "year": 1991,
@@ -2238,7 +2344,8 @@
       "fun_fact_es": "La banda sonora de Harry el sucio de Lalo Schifrin usa jazz para capturar las calles ásperas de San Francisco. Clint Eastwood se convirtió en un ícono.",
       "chart_info": {},
       "certifications": [],
-      "awards": []
+      "awards": [],
+      "uri_apple_music": "applemusic://track/205808260"
     },
     {
       "year": 1955,
@@ -2269,7 +2376,8 @@
       ],
       "awards_es": [
         "Nominación al Óscar a la Mejor Banda Sonora Original (1977)"
-      ]
+      ],
+      "uri_apple_music": "applemusic://track/306664733"
     },
     {
       "year": 1959,
@@ -2304,7 +2412,8 @@
       "fun_fact_es": "Concerning Hobbits de Howard Shore captura la pacífica domesticidad de la Comarca. El tema suave usa silbato de hojalata y violín.",
       "chart_info": {},
       "certifications": [],
-      "awards": []
+      "awards": [],
+      "uri_apple_music": "applemusic://track/323714096"
     },
     {
       "year": 1971,
@@ -2337,7 +2446,8 @@
         "billboard_peak": 91
       },
       "certifications": [],
-      "awards": []
+      "awards": [],
+      "uri_apple_music": "applemusic://track/826934339"
     },
     {
       "year": 2007,
@@ -2349,7 +2459,8 @@
         "uk_peak": 39
       },
       "certifications": [],
-      "awards": []
+      "awards": [],
+      "uri_apple_music": "applemusic://track/1442889719"
     },
     {
       "year": 1973,
@@ -2373,7 +2484,8 @@
       ],
       "awards_es": [
         "Nominación al Óscar a la Mejor Canción Original (1973)"
-      ]
+      ],
+      "uri_apple_music": "applemusic://track/1440939414"
     },
     {
       "year": 1968,
@@ -2383,7 +2495,8 @@
       "fun_fact_es": "El hombre de la armónica de Hasta que llegó su hora cuenta una historia solo a través de la música. La melodía revela la historia del personaje.",
       "chart_info": {},
       "certifications": [],
-      "awards": []
+      "awards": [],
+      "uri_apple_music": "applemusic://track/1452655336"
     },
     {
       "year": 1999,
@@ -2393,7 +2506,8 @@
       "fun_fact_es": "La segunda pista de American Beauty de Thomas Newman captura el tedio suburbano. La banda sonora usa percusión y sonidos ambientales.",
       "chart_info": {},
       "certifications": [],
-      "awards": []
+      "awards": [],
+      "uri_apple_music": "applemusic://track/1437293471"
     },
     {
       "year": 1959,
@@ -2447,7 +2561,8 @@
         "Óscar a la Mejor Canción Original (1997)",
         "Globo de Oro a la Mejor Canción Original (1998)",
         "Premio Grammy a la Grabación del Año (1999)"
-      ]
+      ],
+      "uri_apple_music": "applemusic://track/507536740"
     },
     {
       "year": 1969,
@@ -2459,7 +2574,8 @@
         "uk_peak": 3
       },
       "certifications": [],
-      "awards": []
+      "awards": [],
+      "uri_apple_music": "applemusic://track/1584918493"
     },
     {
       "year": 1969,
@@ -2482,7 +2598,8 @@
       ],
       "awards_es": [
         "Premio Grammy a la Mejor Canción Contemporánea (1970)"
-      ]
+      ],
+      "uri_apple_music": "applemusic://track/714938680"
     },
     {
       "year": 1980,
@@ -2492,7 +2609,8 @@
       "fun_fact_es": "Fly Too High de Janis Ian apareció en Foxes. La película de maduración capturó las escenas punk y disco de Los Ángeles.",
       "chart_info": {},
       "certifications": [],
-      "awards": []
+      "awards": [],
+      "uri_apple_music": "applemusic://track/1550210611"
     },
     {
       "year": 1963,
@@ -2514,7 +2632,8 @@
       "fun_fact_es": "Qué bello es vivir fracasó inicialmente pero se convirtió en un clásico navideño a través de emisiones de televisión cuando sus derechos de autor expiraron.",
       "chart_info": {},
       "certifications": [],
-      "awards": []
+      "awards": [],
+      "uri_apple_music": "applemusic://track/1597777326"
     },
     {
       "year": 1942,

--- a/custom_components/beatify/playlists/schlager-klassiker.json
+++ b/custom_components/beatify/playlists/schlager-klassiker.json
@@ -8,9 +8,15 @@
       "fun_fact": "Ohne Dich (schlaf' ich heut Nacht nicht ein) was one of the biggest hits by Münchener Freiheit and became a classic of the Neue Deutsche Welle. This emotional ballad reached top positions on the German charts.",
       "fun_fact_de": "Ohne Dich (schlaf' ich heut Nacht nicht ein) war einer der größten Hits von Münchener Freiheit und wurde zum Klassiker der Neuen Deutschen Welle. Die emotionale Ballade erreichte Top-Positionen in den deutschen Charts.",
       "fun_fact_es": "Ohne Dich (schlaf' ich heut Nacht nicht ein) fue uno de los mayores éxitos de Münchener Freiheit y se convirtió en un clásico de la Nueva Ola Alemana. Esta emotiva balada alcanzó las primeras posiciones en las listas alemanas.",
-      "chart_info": {"german_peak": 2, "weeks_on_chart": 24},
-      "certifications": ["Gold (DE)"],
-      "awards": []
+      "chart_info": {
+        "german_peak": 2,
+        "weeks_on_chart": 24
+      },
+      "certifications": [
+        "Gold (DE)"
+      ],
+      "awards": [],
+      "uri_apple_music": "applemusic://track/209594066"
     },
     {
       "year": 1975,
@@ -18,11 +24,22 @@
       "fun_fact": "Vicky Leandros won the 1972 Eurovision Song Contest for Luxembourg with 'Après toi'. Ich liebe das Leben showcases her powerful voice and positive outlook on life, which made her a Schlager legend.",
       "fun_fact_de": "Vicky Leandros gewann 1972 den Eurovision Song Contest für Luxemburg mit 'Après toi'. Ich liebe das Leben zeigt ihre kraftvolle Stimme und positive Lebenseinstellung, die sie zur Schlager-Legende machte.",
       "fun_fact_es": "Vicky Leandros ganó el Festival de Eurovisión en 1972 representando a Luxemburgo con 'Après toi'. Ich liebe das Leben muestra su poderosa voz y actitud positiva ante la vida, que la convirtieron en una leyenda del Schlager.",
-      "chart_info": {"german_peak": 5},
-      "certifications": ["Gold (DE)"],
-      "awards": ["Eurovision Song Contest Winner (1972)"],
-      "awards_de": ["Gewinnerin des Eurovision Song Contest (1972)"],
-      "awards_es": ["Ganadora del Festival de Eurovisión (1972)"]
+      "chart_info": {
+        "german_peak": 5
+      },
+      "certifications": [
+        "Gold (DE)"
+      ],
+      "awards": [
+        "Eurovision Song Contest Winner (1972)"
+      ],
+      "awards_de": [
+        "Gewinnerin des Eurovision Song Contest (1972)"
+      ],
+      "awards_es": [
+        "Ganadora del Festival de Eurovisión (1972)"
+      ],
+      "uri_apple_music": "applemusic://track/1440923428"
     },
     {
       "year": 1993,
@@ -30,9 +47,15 @@
       "fun_fact": "Silbermond und Sternenfeuer was Michelle's breakthrough hit and made her one of the most successful German Schlager singers. This romantic song became a perennial favorite at parties.",
       "fun_fact_de": "Silbermond und Sternenfeuer war Michelles Durchbruchshit und machte sie zu einer der erfolgreichsten deutschen Schlagersängerinnen. Der romantische Song wurde zum Dauerbrenner auf Partys.",
       "fun_fact_es": "Silbermond und Sternenfeuer fue el éxito que lanzó a Michelle a la fama, convirtiéndola en una de las cantantes de Schlager más exitosas de Alemania. Esta romántica canción se convirtió en un clásico de las fiestas.",
-      "chart_info": {"german_peak": 8, "weeks_on_chart": 18},
-      "certifications": ["Gold (DE)"],
-      "awards": []
+      "chart_info": {
+        "german_peak": 8,
+        "weeks_on_chart": 18
+      },
+      "certifications": [
+        "Gold (DE)"
+      ],
+      "awards": [],
+      "uri_apple_music": "applemusic://track/403089252"
     },
     {
       "year": 1974,
@@ -40,11 +63,25 @@
       "fun_fact": "Griechischer Wein is Udo Jürgens' homage to Greek guest workers in Germany. The song became an unofficial anthem of integration and is still sung along at every party to this day.",
       "fun_fact_de": "Griechischer Wein ist Udo Jürgens' Hommage an griechische Gastarbeiter in Deutschland. Das Lied wurde zur inoffiziellen Hymne der Integration und wird bis heute auf jeder Party mitgesungen.",
       "fun_fact_es": "Griechischer Wein es el homenaje de Udo Jürgens a los trabajadores griegos en Alemania. La canción se convirtió en el himno no oficial de la integración y sigue siendo coreada en todas las fiestas.",
-      "chart_info": {"german_peak": 1, "weeks_on_chart": 32, "austrian_peak": 1},
-      "certifications": ["3x Platinum (DE)", "Platinum (AT)"],
-      "awards": ["Goldene Schallplatte (1974)"],
-      "awards_de": ["Goldene Schallplatte (1974)"],
-      "awards_es": ["Disco de Oro (1974)"]
+      "chart_info": {
+        "german_peak": 1,
+        "weeks_on_chart": 32,
+        "austrian_peak": 1
+      },
+      "certifications": [
+        "3x Platinum (DE)",
+        "Platinum (AT)"
+      ],
+      "awards": [
+        "Goldene Schallplatte (1974)"
+      ],
+      "awards_de": [
+        "Goldene Schallplatte (1974)"
+      ],
+      "awards_es": [
+        "Disco de Oro (1974)"
+      ],
+      "uri_apple_music": "applemusic://track/250875681"
     },
     {
       "year": 1984,
@@ -52,9 +89,15 @@
       "fun_fact": "1000 und 1 Nacht (Zoom!) by Klaus Lage became the soundtrack of an entire generation. The catchy chorus 'Tausendundeine Nacht' is one of the most recognizable in German music history.",
       "fun_fact_de": "1000 und 1 Nacht (Zoom!) von Klaus Lage wurde zum Soundtrack einer ganzen Generation. Der eingängige Refrain 'Tausendundeine Nacht' ist einer der bekanntesten der deutschen Musikgeschichte.",
       "fun_fact_es": "1000 und 1 Nacht (Zoom!) de Klaus Lage se convirtió en la banda sonora de toda una generación. El pegadizo estribillo 'Tausendundeine Nacht' es uno de los más reconocidos de la historia musical alemana.",
-      "chart_info": {"german_peak": 1, "weeks_on_chart": 28},
-      "certifications": ["Platinum (DE)"],
-      "awards": []
+      "chart_info": {
+        "german_peak": 1,
+        "weeks_on_chart": 28
+      },
+      "certifications": [
+        "Platinum (DE)"
+      ],
+      "awards": [],
+      "uri_apple_music": "applemusic://track/1719834135"
     },
     {
       "year": 1990,
@@ -62,11 +105,30 @@
       "fun_fact": "Verdammt, ich lieb' dich by Matthias Reim is one of the most-played German songs of all time. The 1990 original stayed at number 1 on the German charts for 16 weeks - a record!",
       "fun_fact_de": "Verdammt, ich lieb' dich von Matthias Reim ist einer der meistgespielten deutschen Songs aller Zeiten. Das Original von 1990 stand 16 Wochen auf Platz 1 der deutschen Charts – ein Rekord!",
       "fun_fact_es": "Verdammt, ich lieb' dich de Matthias Reim es una de las canciones alemanas más reproducidas de todos los tiempos. El original de 1990 estuvo 16 semanas en el número 1 de las listas alemanas – ¡un récord!",
-      "chart_info": {"german_peak": 1, "weeks_on_chart": 42, "austrian_peak": 1, "swiss_peak": 1},
-      "certifications": ["4x Platinum (DE)", "Platinum (AT)", "Platinum (CH)"],
-      "awards": ["Echo (1991)", "Goldene Stimmgabel (1991)"],
-      "awards_de": ["Echo (1991)", "Goldene Stimmgabel (1991)"],
-      "awards_es": ["Premio Echo (1991)", "Diapasón de Oro (1991)"]
+      "chart_info": {
+        "german_peak": 1,
+        "weeks_on_chart": 42,
+        "austrian_peak": 1,
+        "swiss_peak": 1
+      },
+      "certifications": [
+        "4x Platinum (DE)",
+        "Platinum (AT)",
+        "Platinum (CH)"
+      ],
+      "awards": [
+        "Echo (1991)",
+        "Goldene Stimmgabel (1991)"
+      ],
+      "awards_de": [
+        "Echo (1991)",
+        "Goldene Stimmgabel (1991)"
+      ],
+      "awards_es": [
+        "Premio Echo (1991)",
+        "Diapasón de Oro (1991)"
+      ],
+      "uri_apple_music": "applemusic://track/724238415"
     },
     {
       "year": 1995,
@@ -74,11 +136,23 @@
       "fun_fact": "Abenteuerland was PUR's biggest hit and became an anthem for dreamers and adventurers. The band from Bietigheim-Bissingen is one of the most successful German rock bands of all time.",
       "fun_fact_de": "Abenteuerland war PURs größter Hit und wurde zur Hymne für Träumer und Abenteurer. Die Band aus Bietigheim-Bissingen zählt zu den erfolgreichsten deutschen Rockbands überhaupt.",
       "fun_fact_es": "Abenteuerland fue el mayor éxito de PUR y se convirtió en el himno de soñadores y aventureros. La banda de Bietigheim-Bissingen es una de las bandas de rock alemanas más exitosas de todos los tiempos.",
-      "chart_info": {"german_peak": 2, "weeks_on_chart": 35},
-      "certifications": ["2x Platinum (DE)"],
-      "awards": ["Echo (1996)"],
-      "awards_de": ["Echo (1996)"],
-      "awards_es": ["Premio Echo (1996)"]
+      "chart_info": {
+        "german_peak": 2,
+        "weeks_on_chart": 35
+      },
+      "certifications": [
+        "2x Platinum (DE)"
+      ],
+      "awards": [
+        "Echo (1996)"
+      ],
+      "awards_de": [
+        "Echo (1996)"
+      ],
+      "awards_es": [
+        "Premio Echo (1996)"
+      ],
+      "uri_apple_music": "applemusic://track/1440856754"
     },
     {
       "year": 2013,
@@ -86,11 +160,36 @@
       "fun_fact": "Atemlos durch die Nacht made Helene Fischer an absolute superstar. The song has been streamed over 50 million times and is the most successful German Schlager of the 21st century.",
       "fun_fact_de": "Atemlos durch die Nacht machte Helene Fischer zum absoluten Superstar. Der Song wurde über 50 Millionen Mal gestreamt und ist der erfolgreichste deutsche Schlager des 21. Jahrhunderts.",
       "fun_fact_es": "Atemlos durch die Nacht convirtió a Helene Fischer en una auténtica superestrella. La canción ha sido reproducida más de 50 millones de veces y es el Schlager alemán más exitoso del siglo XXI.",
-      "chart_info": {"german_peak": 1, "weeks_on_chart": 104, "austrian_peak": 1, "swiss_peak": 1},
-      "certifications": ["Diamond (DE)", "4x Platinum (AT)", "3x Platinum (CH)"],
-      "awards": ["Echo (2014)", "Goldene Henne (2014)", "Bambi (2014)", "Goldene Kamera (2014)"],
-      "awards_de": ["Echo (2014)", "Goldene Henne (2014)", "Bambi (2014)", "Goldene Kamera (2014)"],
-      "awards_es": ["Premio Echo (2014)", "Gallina de Oro (2014)", "Premio Bambi (2014)", "Cámara de Oro (2014)"]
+      "chart_info": {
+        "german_peak": 1,
+        "weeks_on_chart": 104,
+        "austrian_peak": 1,
+        "swiss_peak": 1
+      },
+      "certifications": [
+        "Diamond (DE)",
+        "4x Platinum (AT)",
+        "3x Platinum (CH)"
+      ],
+      "awards": [
+        "Echo (2014)",
+        "Goldene Henne (2014)",
+        "Bambi (2014)",
+        "Goldene Kamera (2014)"
+      ],
+      "awards_de": [
+        "Echo (2014)",
+        "Goldene Henne (2014)",
+        "Bambi (2014)",
+        "Goldene Kamera (2014)"
+      ],
+      "awards_es": [
+        "Premio Echo (2014)",
+        "Gallina de Oro (2014)",
+        "Premio Bambi (2014)",
+        "Cámara de Oro (2014)"
+      ],
+      "uri_apple_music": "applemusic://track/1440818973"
     },
     {
       "year": 1982,
@@ -98,11 +197,25 @@
       "fun_fact": "Ich war noch niemals in New York is Udo Jürgens' ode to unfulfilled dreams. The song was later adapted into a successful musical that is performed worldwide.",
       "fun_fact_de": "Ich war noch niemals in New York ist Udo Jürgens' Ode an unerfüllte Träume. Das Lied wurde später zu einem erfolgreichen Musical adaptiert, das weltweit aufgeführt wird.",
       "fun_fact_es": "Ich war noch niemals in New York es la oda de Udo Jürgens a los sueños incumplidos. La canción fue adaptada posteriormente como un exitoso musical que se representa en todo el mundo.",
-      "chart_info": {"german_peak": 1, "weeks_on_chart": 26, "austrian_peak": 1},
-      "certifications": ["2x Platinum (DE)", "Platinum (AT)"],
-      "awards": ["Goldene Schallplatte (1982)"],
-      "awards_de": ["Goldene Schallplatte (1982)"],
-      "awards_es": ["Disco de Oro (1982)"]
+      "chart_info": {
+        "german_peak": 1,
+        "weeks_on_chart": 26,
+        "austrian_peak": 1
+      },
+      "certifications": [
+        "2x Platinum (DE)",
+        "Platinum (AT)"
+      ],
+      "awards": [
+        "Goldene Schallplatte (1982)"
+      ],
+      "awards_de": [
+        "Goldene Schallplatte (1982)"
+      ],
+      "awards_es": [
+        "Disco de Oro (1982)"
+      ],
+      "uri_apple_music": "applemusic://track/331872876"
     },
     {
       "year": 1972,
@@ -110,9 +223,15 @@
       "fun_fact": "Am Tag, als Conny Kramer starb was Juliane Werding's debut hit at just 16 years old. The song is based on the American song 'The Night They Drove Old Dixie Down' and became a huge success.",
       "fun_fact_de": "Am Tag, als Conny Kramer starb war Juliane Werdings Debüthit mit nur 16 Jahren. Das Lied basiert auf dem amerikanischen Song 'The Night They Drove Old Dixie Down' und wurde ein Riesenerfolg.",
       "fun_fact_es": "Am Tag, als Conny Kramer starb fue el éxito de debut de Juliane Werding con solo 16 años. La canción está basada en la canción estadounidense 'The Night They Drove Old Dixie Down' y fue un enorme éxito.",
-      "chart_info": {"german_peak": 1, "weeks_on_chart": 20},
-      "certifications": ["Gold (DE)"],
-      "awards": []
+      "chart_info": {
+        "german_peak": 1,
+        "weeks_on_chart": 20
+      },
+      "certifications": [
+        "Gold (DE)"
+      ],
+      "awards": [],
+      "uri_apple_music": "applemusic://track/915364976"
     },
     {
       "year": 1974,
@@ -120,11 +239,23 @@
       "fun_fact": "Über den Wolken by Reinhard Mey is one of the most famous German songs ever. Mey wrote it after his first solo flight, expressing the boundless freedom of flying.",
       "fun_fact_de": "Über den Wolken von Reinhard Mey ist eines der bekanntesten deutschen Lieder überhaupt. Mey schrieb es nach seinem ersten Alleinflug und drückt darin die grenzenlose Freiheit des Fliegens aus.",
       "fun_fact_es": "Über den Wolken de Reinhard Mey es una de las canciones alemanas más conocidas. Mey la escribió después de su primer vuelo en solitario, expresando la libertad infinita de volar.",
-      "chart_info": {"german_peak": 3, "weeks_on_chart": 18},
-      "certifications": ["Platinum (DE)"],
-      "awards": ["Deutscher Kleinkunstpreis"],
-      "awards_de": ["Deutscher Kleinkunstpreis"],
-      "awards_es": ["Premio Alemán de Cabaret"]
+      "chart_info": {
+        "german_peak": 3,
+        "weeks_on_chart": 18
+      },
+      "certifications": [
+        "Platinum (DE)"
+      ],
+      "awards": [
+        "Deutscher Kleinkunstpreis"
+      ],
+      "awards_de": [
+        "Deutscher Kleinkunstpreis"
+      ],
+      "awards_es": [
+        "Premio Alemán de Cabaret"
+      ],
+      "uri_apple_music": "applemusic://track/724003108"
     },
     {
       "year": 1977,
@@ -132,11 +263,23 @@
       "fun_fact": "Ti Amo made Howard Carpendale a superstar of German Schlager. The South African-born singer sold over 25 million records and filled the largest venues.",
       "fun_fact_de": "Ti Amo machte Howard Carpendale zum Superstar des deutschen Schlagers. Der in Südafrika geborene Sänger verkaufte über 25 Millionen Tonträger und füllte die größten Hallen.",
       "fun_fact_es": "Ti Amo convirtió a Howard Carpendale en la superestrella del Schlager alemán. El cantante nacido en Sudáfrica vendió más de 25 millones de discos y llenó los mayores estadios.",
-      "chart_info": {"german_peak": 1, "weeks_on_chart": 30},
-      "certifications": ["2x Platinum (DE)"],
-      "awards": ["Goldene Stimmgabel (1977)"],
-      "awards_de": ["Goldene Stimmgabel (1977)"],
-      "awards_es": ["Diapasón de Oro (1977)"]
+      "chart_info": {
+        "german_peak": 1,
+        "weeks_on_chart": 30
+      },
+      "certifications": [
+        "2x Platinum (DE)"
+      ],
+      "awards": [
+        "Goldene Stimmgabel (1977)"
+      ],
+      "awards_de": [
+        "Goldene Stimmgabel (1977)"
+      ],
+      "awards_es": [
+        "Diapasón de Oro (1977)"
+      ],
+      "uri_apple_music": "applemusic://track/713572059"
     },
     {
       "year": 1977,
@@ -144,9 +287,14 @@
       "fun_fact": "Guten Morgen Sonnenschein was sung by Nana Mouskouri and is a timeless feel-good song. The Greek singer is one of the most successful artists in the world, with over 300 million albums sold.",
       "fun_fact_de": "Guten Morgen Sonnenschein wurde von Nana Mouskouri gesungen und ist ein zeitloser Gute-Laune-Song. Die griechische Sängerin ist eine der erfolgreichsten Künstlerinnen der Welt mit über 300 Millionen verkauften Alben.",
       "fun_fact_es": "Guten Morgen Sonnenschein fue cantada por Nana Mouskouri y es una canción atemporal que levanta el ánimo. La cantante griega es una de las artistas más exitosas del mundo, con más de 300 millones de álbumes vendidos.",
-      "chart_info": {"german_peak": 5},
-      "certifications": ["Gold (DE)"],
-      "awards": []
+      "chart_info": {
+        "german_peak": 5
+      },
+      "certifications": [
+        "Gold (DE)"
+      ],
+      "awards": [],
+      "uri_apple_music": "applemusic://track/1442439783"
     },
     {
       "year": 1976,
@@ -154,9 +302,15 @@
       "fun_fact": "Aber bitte mit Sahne is Udo Jürgens' humorous hymn to the joy of life and the sweet life. The phrase has become a popular expression in the German language.",
       "fun_fact_de": "Aber bitte mit Sahne ist Udo Jürgens' humorvolle Hymne an die Lebensfreude und das süße Leben. Das Lied wurde zum geflügelten Wort in der deutschen Sprache.",
       "fun_fact_es": "Aber bitte mit Sahne es el himno humorístico de Udo Jürgens a la alegría de vivir y los placeres de la vida. La frase se ha convertido en una expresión popular en el idioma alemán.",
-      "chart_info": {"german_peak": 2, "weeks_on_chart": 22},
-      "certifications": ["Platinum (DE)"],
-      "awards": []
+      "chart_info": {
+        "german_peak": 2,
+        "weeks_on_chart": 22
+      },
+      "certifications": [
+        "Platinum (DE)"
+      ],
+      "awards": [],
+      "uri_apple_music": "applemusic://track/331872178"
     },
     {
       "year": 1975,
@@ -164,11 +318,23 @@
       "fun_fact": "Er gehört zu mir by Marianne Rosenberg became a classic and an anthem of self-assertion. Rosenberg is considered the 'Queen of Schlager' and has shaped the genre since the 1970s.",
       "fun_fact_de": "Er gehört zu mir von Marianne Rosenberg wurde zum Klassiker und zur Hymne der Selbstbehauptung. Rosenberg gilt als 'Queen of Schlager' und prägte das Genre seit den 1970ern.",
       "fun_fact_es": "Er gehört zu mir de Marianne Rosenberg se convirtió en un clásico y en el himno de la autoafirmación. Rosenberg es considerada la 'Reina del Schlager' y ha definido el género desde los años 70.",
-      "chart_info": {"german_peak": 1, "weeks_on_chart": 24},
-      "certifications": ["Platinum (DE)"],
-      "awards": ["Goldene Stimmgabel (1975)"],
-      "awards_de": ["Goldene Stimmgabel (1975)"],
-      "awards_es": ["Diapasón de Oro (1975)"]
+      "chart_info": {
+        "german_peak": 1,
+        "weeks_on_chart": 24
+      },
+      "certifications": [
+        "Platinum (DE)"
+      ],
+      "awards": [
+        "Goldene Stimmgabel (1975)"
+      ],
+      "awards_de": [
+        "Goldene Stimmgabel (1975)"
+      ],
+      "awards_es": [
+        "Diapasón de Oro (1975)"
+      ],
+      "uri_apple_music": "applemusic://track/703536400"
     },
     {
       "year": 1977,
@@ -176,9 +342,14 @@
       "fun_fact": "Tanze Samba mit mir by Tony Holiday brought South American flair to German Schlager. The catchy rhythm makes this song a perennial favorite on every dance floor.",
       "fun_fact_de": "Tanze Samba mit mir von Tony Holiday brachte südamerikanisches Flair in den deutschen Schlager. Der eingängige Rhythmus macht das Lied zum Dauerbrenner auf jeder Tanzfläche.",
       "fun_fact_es": "Tanze Samba mit mir de Tony Holiday trajo el sabor sudamericano al Schlager alemán. Su ritmo pegadizo convierte la canción en un éxito permanente en cualquier pista de baile.",
-      "chart_info": {"german_peak": 4},
-      "certifications": ["Gold (DE)"],
-      "awards": []
+      "chart_info": {
+        "german_peak": 4
+      },
+      "certifications": [
+        "Gold (DE)"
+      ],
+      "awards": [],
+      "uri_apple_music": "applemusic://track/1442330542"
     },
     {
       "year": 1992,
@@ -186,9 +357,15 @@
       "fun_fact": "Verlieben, verloren, vergessen, verzeih'n became Wolfgang Petry's signature song. The singer, nicknamed 'Wolle', is known for his high-energy live performances and loyal fans.",
       "fun_fact_de": "Verlieben, verloren, vergessen, verzeih'n wurde zu Wolfgang Petrys Erkennungsmelodie. Der 'Wolle' genannte Sänger ist bekannt für seine energiegeladenen Live-Auftritte und treuen Fans.",
       "fun_fact_es": "Verlieben, verloren, vergessen, verzeih'n se convirtió en la canción insignia de Wolfgang Petry. El cantante, conocido como 'Wolle', es famoso por sus enérgicas actuaciones en vivo y sus fieles seguidores.",
-      "chart_info": {"german_peak": 3, "weeks_on_chart": 28},
-      "certifications": ["Platinum (DE)"],
-      "awards": []
+      "chart_info": {
+        "german_peak": 3,
+        "weeks_on_chart": 28
+      },
+      "certifications": [
+        "Platinum (DE)"
+      ],
+      "awards": [],
+      "uri_apple_music": "applemusic://track/211407545"
     },
     {
       "year": 1965,
@@ -196,9 +373,15 @@
       "fun_fact": "Marmor, Stein und Eisen bricht by Drafi Deutscher is an eternal classic about everlasting love. The 1965 original is still played at weddings to this day.",
       "fun_fact_de": "Marmor, Stein und Eisen bricht von Drafi Deutscher ist ein ewiger Klassiker über unvergängliche Liebe. Das Original stammt von 1965 und wird bis heute auf Hochzeiten gespielt.",
       "fun_fact_es": "Marmor, Stein und Eisen bricht de Drafi Deutscher es un clásico eterno sobre el amor imperecedero. El original de 1965 sigue sonando en bodas hasta el día de hoy.",
-      "chart_info": {"german_peak": 1, "weeks_on_chart": 20},
-      "certifications": ["2x Platinum (DE)"],
-      "awards": []
+      "chart_info": {
+        "german_peak": 1,
+        "weeks_on_chart": 20
+      },
+      "certifications": [
+        "2x Platinum (DE)"
+      ],
+      "awards": [],
+      "uri_apple_music": "applemusic://track/40548009"
     },
     {
       "year": 1975,
@@ -206,9 +389,15 @@
       "fun_fact": "Ein ehrenwertes Haus by Udo Jürgens addresses bourgeois narrow-mindedness and prejudice. Jürgens was known for wrapping socially critical themes in catchy melodies.",
       "fun_fact_de": "Ein ehrenwertes Haus von Udo Jürgens thematisiert Spießbürgerlichkeit und Vorurteile. Jürgens war bekannt dafür, gesellschaftskritische Themen in eingängige Melodien zu verpacken.",
       "fun_fact_es": "Ein ehrenwertes Haus de Udo Jürgens aborda el conservadurismo pequeñoburgués y los prejuicios. Jürgens era conocido por envolver temas de crítica social en melodías pegadizas.",
-      "chart_info": {"german_peak": 4, "weeks_on_chart": 16},
-      "certifications": ["Gold (DE)"],
-      "awards": []
+      "chart_info": {
+        "german_peak": 4,
+        "weeks_on_chart": 16
+      },
+      "certifications": [
+        "Gold (DE)"
+      ],
+      "awards": [],
+      "uri_apple_music": "applemusic://track/331871942"
     },
     {
       "year": 1975,
@@ -216,9 +405,15 @@
       "fun_fact": "Wann wird's mal wieder richtig Sommer by Rudi Carrell became the anthem for everyone longing for summer. The Dutch entertainer was one of the most beloved show hosts on German television.",
       "fun_fact_de": "Wann wird's mal wieder richtig Sommer von Rudi Carrell wurde zur Hymne aller Sommersehnsucht. Der niederländische Entertainer war einer der beliebtesten Showmaster im deutschen Fernsehen.",
       "fun_fact_es": "Wann wird's mal wieder richtig Sommer de Rudi Carrell se convirtió en el himno de todos los que añoran el verano. El presentador neerlandés fue uno de los más queridos de la televisión alemana.",
-      "chart_info": {"german_peak": 1, "weeks_on_chart": 18},
-      "certifications": ["Gold (DE)"],
-      "awards": []
+      "chart_info": {
+        "german_peak": 1,
+        "weeks_on_chart": 18
+      },
+      "certifications": [
+        "Gold (DE)"
+      ],
+      "awards": [],
+      "uri_apple_music": "applemusic://track/1690144526"
     },
     {
       "year": 2007,
@@ -226,11 +421,30 @@
       "fun_fact": "Ein Stern (der deinen Namen trägt) by DJ Ötzi and Nik P. became a mega hit and conquered all of Europe. The song stayed at the top of the charts for weeks in several countries.",
       "fun_fact_de": "Ein Stern (der deinen Namen trägt) von DJ Ötzi und Nik P. wurde zum Mega-Hit und eroberte ganz Europa. Das Lied stand wochenlang an der Spitze der Charts in mehreren Ländern.",
       "fun_fact_es": "Ein Stern (der deinen Namen trägt) de DJ Ötzi y Nik P. se convirtió en un mega éxito que conquistó toda Europa. La canción estuvo en lo más alto de las listas durante semanas en varios países.",
-      "chart_info": {"german_peak": 1, "weeks_on_chart": 52, "austrian_peak": 1, "swiss_peak": 1},
-      "certifications": ["3x Platinum (DE)", "Diamond (AT)", "Platinum (CH)"],
-      "awards": ["Echo (2008)", "Amadeus Austrian Music Award (2008)"],
-      "awards_de": ["Echo (2008)", "Amadeus Austrian Music Award (2008)"],
-      "awards_es": ["Premio Echo (2008)", "Premio Amadeus de Música Austriaca (2008)"]
+      "chart_info": {
+        "german_peak": 1,
+        "weeks_on_chart": 52,
+        "austrian_peak": 1,
+        "swiss_peak": 1
+      },
+      "certifications": [
+        "3x Platinum (DE)",
+        "Diamond (AT)",
+        "Platinum (CH)"
+      ],
+      "awards": [
+        "Echo (2008)",
+        "Amadeus Austrian Music Award (2008)"
+      ],
+      "awards_de": [
+        "Echo (2008)",
+        "Amadeus Austrian Music Award (2008)"
+      ],
+      "awards_es": [
+        "Premio Echo (2008)",
+        "Premio Amadeus de Música Austriaca (2008)"
+      ],
+      "uri_apple_music": "applemusic://track/1444443840"
     },
     {
       "year": 1996,
@@ -238,9 +452,15 @@
       "fun_fact": "Weiß der Geier by Wolfgang Petry shows his rockier side. Petry is known for his sweat-drenched concerts and the incredible energy he radiates on stage.",
       "fun_fact_de": "Weiß der Geier von Wolfgang Petry zeigt seine rockige Seite. Petry ist bekannt für seine schweißnassen Konzerte und die unglaubliche Energie, die er auf der Bühne versprüht.",
       "fun_fact_es": "Weiß der Geier de Wolfgang Petry muestra su lado más rockero. Petry es conocido por sus conciertos sudorosos y la increíble energía que despliega en el escenario.",
-      "chart_info": {"german_peak": 6, "weeks_on_chart": 20},
-      "certifications": ["Gold (DE)"],
-      "awards": []
+      "chart_info": {
+        "german_peak": 6,
+        "weeks_on_chart": 20
+      },
+      "certifications": [
+        "Gold (DE)"
+      ],
+      "awards": [],
+      "uri_apple_music": "applemusic://track/1074872662"
     },
     {
       "year": 1983,
@@ -248,11 +468,23 @@
       "fun_fact": "Jenseits von Eden by Nino de Angelo became the singer's biggest hit. This dramatic song showcases his powerful voice and made him a star of the 1980s.",
       "fun_fact_de": "Jenseits von Eden von Nino de Angelo wurde zum größten Hit des Sängers. Das dramatische Lied zeigt seine kraftvolle Stimme und machte ihn zum Star der 1980er Jahre.",
       "fun_fact_es": "Jenseits von Eden de Nino de Angelo se convirtió en el mayor éxito del cantante. Esta dramática canción muestra su poderosa voz y lo convirtió en una estrella de los años 80.",
-      "chart_info": {"german_peak": 1, "weeks_on_chart": 26},
-      "certifications": ["Platinum (DE)"],
-      "awards": ["Goldene Stimmgabel (1984)"],
-      "awards_de": ["Goldene Stimmgabel (1984)"],
-      "awards_es": ["Diapasón de Oro (1984)"]
+      "chart_info": {
+        "german_peak": 1,
+        "weeks_on_chart": 26
+      },
+      "certifications": [
+        "Platinum (DE)"
+      ],
+      "awards": [
+        "Goldene Stimmgabel (1984)"
+      ],
+      "awards_de": [
+        "Goldene Stimmgabel (1984)"
+      ],
+      "awards_es": [
+        "Diapasón de Oro (1984)"
+      ],
+      "uri_apple_music": "applemusic://track/1453685670"
     },
     {
       "year": 1976,
@@ -260,9 +492,15 @@
       "fun_fact": "Anita by Costa Cordalis brought Greek temperament to German Schlager. The singer later became known to a new audience through reality TV.",
       "fun_fact_de": "Anita von Costa Cordalis brachte griechisches Temperament in den deutschen Schlager. Der Sänger wurde später auch durch Reality-TV einem neuen Publikum bekannt.",
       "fun_fact_es": "Anita de Costa Cordalis trajo el temperamento griego al Schlager alemán. El cantante se hizo conocido más tarde por una nueva audiencia a través de los reality shows.",
-      "chart_info": {"german_peak": 3, "weeks_on_chart": 18},
-      "certifications": ["Gold (DE)"],
-      "awards": []
+      "chart_info": {
+        "german_peak": 3,
+        "weeks_on_chart": 18
+      },
+      "certifications": [
+        "Gold (DE)"
+      ],
+      "awards": [],
+      "uri_apple_music": "applemusic://track/326422804"
     },
     {
       "year": 1991,
@@ -270,9 +508,15 @@
       "fun_fact": "Lena by Pur is an emotional ballad about love and loss. The band from Baden-Württemberg demonstrates their versatility between rock and emotional ballads.",
       "fun_fact_de": "Lena von Pur ist eine gefühlvolle Ballade über Liebe und Verlust. Die Band aus Baden-Württemberg beweist damit ihre Vielseitigkeit zwischen Rock und emotionalen Balladen.",
       "fun_fact_es": "Lena de Pur es una emotiva balada sobre el amor y la pérdida. La banda de Baden-Württemberg demuestra con ella su versatilidad entre el rock y las baladas emocionales.",
-      "chart_info": {"german_peak": 5, "weeks_on_chart": 22},
-      "certifications": ["Gold (DE)"],
-      "awards": []
+      "chart_info": {
+        "german_peak": 5,
+        "weeks_on_chart": 22
+      },
+      "certifications": [
+        "Gold (DE)"
+      ],
+      "awards": [],
+      "uri_apple_music": "applemusic://track/1530792637"
     },
     {
       "year": 1984,
@@ -280,9 +524,15 @@
       "fun_fact": "Hello Again by Howard Carpendale became one of his most famous songs. The song is often played at reunions and class meetings, moving generations to tears.",
       "fun_fact_de": "Hello Again von Howard Carpendale wurde zu einem seiner bekanntesten Lieder. Der Song wird oft bei Wiedersehen und Klassentreffen gespielt und rührt Generationen zu Tränen.",
       "fun_fact_es": "Hello Again de Howard Carpendale se convirtió en una de sus canciones más conocidas. La canción se toca a menudo en reencuentros y reuniones de clase, emocionando a generaciones hasta las lágrimas.",
-      "chart_info": {"german_peak": 2, "weeks_on_chart": 20},
-      "certifications": ["Platinum (DE)"],
-      "awards": []
+      "chart_info": {
+        "german_peak": 2,
+        "weeks_on_chart": 20
+      },
+      "certifications": [
+        "Platinum (DE)"
+      ],
+      "awards": [],
+      "uri_apple_music": "applemusic://track/724311867"
     },
     {
       "year": 1960,
@@ -290,9 +540,15 @@
       "fun_fact": "Itsy Bitsy Teenie Weenie Honolulu Strand Bikini was sung by Caterina Valente and is the German version of the American summer hit. This catchy tune is a must-have at every beach party.",
       "fun_fact_de": "Itsy Bitsy Teenie Weenie Honolulu Strand Bikini wurde von Caterina Valente gesungen und ist die deutsche Version des amerikanischen Sommerhits. Der Ohrwurm gehört zu jedem Strandfest.",
       "fun_fact_es": "Itsy Bitsy Teenie Weenie Honolulu Strand Bikini fue cantada por Caterina Valente y es la versión alemana del éxito veraniego estadounidense. Este pegadizo tema es imprescindible en cualquier fiesta playera.",
-      "chart_info": {"german_peak": 1, "weeks_on_chart": 16},
-      "certifications": ["Gold (DE)"],
-      "awards": []
+      "chart_info": {
+        "german_peak": 1,
+        "weeks_on_chart": 16
+      },
+      "certifications": [
+        "Gold (DE)"
+      ],
+      "awards": [],
+      "uri_apple_music": "applemusic://track/1653575754"
     },
     {
       "year": 1975,
@@ -300,9 +556,15 @@
       "fun_fact": "Wenn du denkst, du denkst, dann denkst du nur, du denkst by Juliane Werding is not just a tongue twister but also a philosophical hit about self-deception.",
       "fun_fact_de": "Wenn du denkst, du denkst, dann denkst du nur, du denkst von Juliane Werding ist nicht nur ein Zungenbrecher, sondern auch ein philosophischer Hit über Selbsttäuschung.",
       "fun_fact_es": "Wenn du denkst, du denkst, dann denkst du nur, du denkst de Juliane Werding no es solo un trabalenguas, sino también un éxito filosófico sobre el autoengaño.",
-      "chart_info": {"german_peak": 3, "weeks_on_chart": 18},
-      "certifications": ["Gold (DE)"],
-      "awards": []
+      "chart_info": {
+        "german_peak": 3,
+        "weeks_on_chart": 18
+      },
+      "certifications": [
+        "Gold (DE)"
+      ],
+      "awards": [],
+      "uri_apple_music": "applemusic://track/966556786"
     },
     {
       "year": 1976,
@@ -310,9 +572,15 @@
       "fun_fact": "Marleen by Marianne Rosenberg tells the story of a special woman. The song showcases Rosenberg's versatility between disco and classic Schlager.",
       "fun_fact_de": "Marleen von Marianne Rosenberg erzählt die Geschichte einer besonderen Frau. Der Song zeigt Rosenbergs Wandlungsfähigkeit zwischen Disco und klassischem Schlager.",
       "fun_fact_es": "Marleen de Marianne Rosenberg cuenta la historia de una mujer especial. La canción muestra la versatilidad de Rosenberg entre el disco y el Schlager clásico.",
-      "chart_info": {"german_peak": 2, "weeks_on_chart": 20},
-      "certifications": ["Gold (DE)"],
-      "awards": []
+      "chart_info": {
+        "german_peak": 2,
+        "weeks_on_chart": 20
+      },
+      "certifications": [
+        "Gold (DE)"
+      ],
+      "awards": [],
+      "uri_apple_music": "applemusic://track/316897793"
     },
     {
       "year": 2015,
@@ -320,11 +588,28 @@
       "fun_fact": "Hulapalu by Andreas Gabalier became a folk rock'n'roll hit and stadium anthem. The Austrian singer fills the largest arenas in the German-speaking world with his music.",
       "fun_fact_de": "Hulapalu von Andreas Gabalier wurde zum Volks-Rock'n'Roll-Hit und zur Stadion-Hymne. Der österreichische Sänger füllt mit seiner Musik die größten Arenen im deutschsprachigen Raum.",
       "fun_fact_es": "Hulapalu de Andreas Gabalier se convirtió en un éxito del rock'n'roll popular y en un himno de estadio. El cantante austríaco llena con su música los mayores estadios de habla alemana.",
-      "chart_info": {"german_peak": 3, "weeks_on_chart": 45, "austrian_peak": 1},
-      "certifications": ["2x Platinum (DE)", "Diamond (AT)"],
-      "awards": ["Amadeus Austrian Music Award (2015)", "Echo (2015)"],
-      "awards_de": ["Amadeus Austrian Music Award (2015)", "Echo (2015)"],
-      "awards_es": ["Premio Amadeus de Música Austriaca (2015)", "Premio Echo (2015)"]
+      "chart_info": {
+        "german_peak": 3,
+        "weeks_on_chart": 45,
+        "austrian_peak": 1
+      },
+      "certifications": [
+        "2x Platinum (DE)",
+        "Diamond (AT)"
+      ],
+      "awards": [
+        "Amadeus Austrian Music Award (2015)",
+        "Echo (2015)"
+      ],
+      "awards_de": [
+        "Amadeus Austrian Music Award (2015)",
+        "Echo (2015)"
+      ],
+      "awards_es": [
+        "Premio Amadeus de Música Austriaca (2015)",
+        "Premio Echo (2015)"
+      ],
+      "uri_apple_music": "applemusic://track/1442675084"
     },
     {
       "year": 1974,
@@ -332,9 +617,15 @@
       "fun_fact": "Tränen lügen nicht by Michael Holm is one of the most emotional ballads in German Schlager. The song has touched listeners' hearts for decades.",
       "fun_fact_de": "Tränen lügen nicht von Michael Holm ist eine der emotionalsten Balladen des deutschen Schlagers. Das Lied berührt seit Jahrzehnten die Herzen der Zuhörer.",
       "fun_fact_es": "Tränen lügen nicht de Michael Holm es una de las baladas más emotivas del Schlager alemán. La canción ha conmovido los corazones de los oyentes durante décadas.",
-      "chart_info": {"german_peak": 1, "weeks_on_chart": 22},
-      "certifications": ["Platinum (DE)"],
-      "awards": []
+      "chart_info": {
+        "german_peak": 1,
+        "weeks_on_chart": 22
+      },
+      "certifications": [
+        "Platinum (DE)"
+      ],
+      "awards": [],
+      "uri_apple_music": "applemusic://track/1029914710"
     },
     {
       "year": 1983,
@@ -342,11 +633,23 @@
       "fun_fact": "Wahnsinn by Wolfgang Petry is a party anthem that gets every dance floor jumping. Petry is known for his fans singing along for hours at his concerts.",
       "fun_fact_de": "Wahnsinn von Wolfgang Petry ist ein Partyknaller, der jede Tanzfläche zum Kochen bringt. Petry ist bekannt dafür, dass seine Fans bei Konzerten stundenlang mitsingen.",
       "fun_fact_es": "Wahnsinn de Wolfgang Petry es un éxito fiestero que hace hervir cualquier pista de baile. Petry es conocido porque sus fans cantan durante horas en sus conciertos.",
-      "chart_info": {"german_peak": 1, "weeks_on_chart": 30},
-      "certifications": ["2x Platinum (DE)"],
-      "awards": ["Goldene Stimmgabel (1983)"],
-      "awards_de": ["Goldene Stimmgabel (1983)"],
-      "awards_es": ["Diapasón de Oro (1983)"]
+      "chart_info": {
+        "german_peak": 1,
+        "weeks_on_chart": 30
+      },
+      "certifications": [
+        "2x Platinum (DE)"
+      ],
+      "awards": [
+        "Goldene Stimmgabel (1983)"
+      ],
+      "awards_de": [
+        "Goldene Stimmgabel (1983)"
+      ],
+      "awards_es": [
+        "Diapasón de Oro (1983)"
+      ],
+      "uri_apple_music": "applemusic://track/1074872657"
     },
     {
       "year": 1961,
@@ -354,9 +657,15 @@
       "fun_fact": "Schöner fremder Mann by Connie Francis was a big hit in Germany. The American singer recorded many of her hits in German and became a legend there.",
       "fun_fact_de": "Schöner fremder Mann von Connie Francis war ein großer Hit in Deutschland. Die amerikanische Sängerin sang viele ihrer Hits auch auf Deutsch und wurde hier zur Legende.",
       "fun_fact_es": "Schöner fremder Mann de Connie Francis fue un gran éxito en Alemania. La cantante estadounidense cantó muchos de sus éxitos también en alemán y se convirtió en una leyenda allí.",
-      "chart_info": {"german_peak": 1, "weeks_on_chart": 18},
-      "certifications": ["Gold (DE)"],
-      "awards": []
+      "chart_info": {
+        "german_peak": 1,
+        "weeks_on_chart": 18
+      },
+      "certifications": [
+        "Gold (DE)"
+      ],
+      "awards": [],
+      "uri_apple_music": "applemusic://track/1452867888"
     },
     {
       "year": 1980,
@@ -364,11 +673,23 @@
       "fun_fact": "Santa Maria by Roland Kaiser brought Latin feeling to German Schlager. Kaiser is known as the 'Emperor of Schlager' and still fills the largest venues to this day.",
       "fun_fact_de": "Santa Maria von Roland Kaiser brachte Latino-Feeling in den deutschen Schlager. Kaiser gilt als 'Kaiser des Schlagers' und füllt bis heute die größten Hallen.",
       "fun_fact_es": "Santa Maria de Roland Kaiser trajo el sentimiento latino al Schlager alemán. Kaiser es considerado el 'Emperador del Schlager' y sigue llenando los mayores estadios.",
-      "chart_info": {"german_peak": 1, "weeks_on_chart": 24},
-      "certifications": ["2x Platinum (DE)"],
-      "awards": ["Goldene Stimmgabel (1980)"],
-      "awards_de": ["Goldene Stimmgabel (1980)"],
-      "awards_es": ["Diapasón de Oro (1980)"]
+      "chart_info": {
+        "german_peak": 1,
+        "weeks_on_chart": 24
+      },
+      "certifications": [
+        "2x Platinum (DE)"
+      ],
+      "awards": [
+        "Goldene Stimmgabel (1980)"
+      ],
+      "awards_de": [
+        "Goldene Stimmgabel (1980)"
+      ],
+      "awards_es": [
+        "Diapasón de Oro (1980)"
+      ],
+      "uri_apple_music": "applemusic://track/634870211"
     },
     {
       "year": 1989,
@@ -376,8 +697,13 @@
       "fun_fact": "Lotosblume by Die Flippers combines Far Eastern romance with German Schlager. The band was successful for over 40 years and sold millions of records.",
       "fun_fact_de": "Lotosblume von Die Flippers verbindet fernöstliche Romantik mit deutschem Schlager. Die Band war über 40 Jahre erfolgreich und verkaufte Millionen von Tonträgern.",
       "fun_fact_es": "Lotosblume de Die Flippers combina el romanticismo oriental con el Schlager alemán. La banda tuvo éxito durante más de 40 años y vendió millones de discos.",
-      "chart_info": {"german_peak": 8, "weeks_on_chart": 16},
-      "certifications": ["Gold (DE)"],
+      "chart_info": {
+        "german_peak": 8,
+        "weeks_on_chart": 16
+      },
+      "certifications": [
+        "Gold (DE)"
+      ],
       "awards": []
     },
     {
@@ -386,9 +712,15 @@
       "fun_fact": "Fiesta Mexicana by Rex Gildo is a classic full of joie de vivre. The song brings Mexican flair to every party and is still played today.",
       "fun_fact_de": "Fiesta Mexicana von Rex Gildo ist ein Klassiker voller Lebensfreude. Der Song bringt mexikanisches Flair auf jede Party und wird bis heute gespielt.",
       "fun_fact_es": "Fiesta Mexicana de Rex Gildo es un clásico lleno de alegría de vivir. La canción aporta ambiente mexicano a cualquier fiesta y sigue sonando hasta hoy.",
-      "chart_info": {"german_peak": 1, "weeks_on_chart": 20},
-      "certifications": ["Platinum (DE)"],
-      "awards": []
+      "chart_info": {
+        "german_peak": 1,
+        "weeks_on_chart": 20
+      },
+      "certifications": [
+        "Platinum (DE)"
+      ],
+      "awards": [],
+      "uri_apple_music": "applemusic://track/402658123"
     },
     {
       "year": 1999,
@@ -396,9 +728,12 @@
       "fun_fact": "Aller Herren Länder by Heinz Rudolf Kunze shows the rockier side of German Schlager. Kunze is known for his poetic lyrics and critical observations.",
       "fun_fact_de": "Aller Herren Länder von Heinz Rudolf Kunze zeigt die rockige Seite des deutschen Schlagers. Kunze ist bekannt für seine poetischen Texte und kritischen Beobachtungen.",
       "fun_fact_es": "Aller Herren Länder de Heinz Rudolf Kunze muestra el lado más rockero del Schlager alemán. Kunze es conocido por sus letras poéticas y sus observaciones críticas.",
-      "chart_info": {"german_peak": 12},
+      "chart_info": {
+        "german_peak": 12
+      },
       "certifications": [],
-      "awards": []
+      "awards": [],
+      "uri_apple_music": "applemusic://track/79342257"
     },
     {
       "year": 1990,
@@ -406,9 +741,15 @@
       "fun_fact": "Ich hab' geträumt von dir was one of Matthias Reim's first major hits. The 1990 original established him as a major figure in German Schlager.",
       "fun_fact_de": "Ich hab' geträumt von dir war einer der ersten großen Hits von Matthias Reim. Das Original von 1990 etablierte ihn als feste Größe im deutschen Schlager.",
       "fun_fact_es": "Ich hab' geträumt von dir fue uno de los primeros grandes éxitos de Matthias Reim. El original de 1990 lo estableció como una figura destacada del Schlager alemán.",
-      "chart_info": {"german_peak": 5, "weeks_on_chart": 18},
-      "certifications": ["Gold (DE)"],
-      "awards": []
+      "chart_info": {
+        "german_peak": 5,
+        "weeks_on_chart": 18
+      },
+      "certifications": [
+        "Gold (DE)"
+      ],
+      "awards": [],
+      "uri_apple_music": "applemusic://track/1611040992"
     },
     {
       "year": 2014,
@@ -416,11 +757,23 @@
       "fun_fact": "Warum hast du nicht nein gesagt by Roland Kaiser and Maite Kelly became a modern Schlager duet classic. The chemistry between the two is palpable on stage.",
       "fun_fact_de": "Warum hast du nicht nein gesagt von Roland Kaiser und Maite Kelly wurde zum modernen Schlager-Duett-Klassiker. Die Chemie zwischen den beiden ist auf der Bühne spürbar.",
       "fun_fact_es": "Warum hast du nicht nein gesagt de Roland Kaiser y Maite Kelly se convirtió en un clásico moderno de los dúos del Schlager. La química entre ambos es palpable en el escenario.",
-      "chart_info": {"german_peak": 2, "weeks_on_chart": 48},
-      "certifications": ["2x Platinum (DE)"],
-      "awards": ["Goldene Henne (2015)"],
-      "awards_de": ["Goldene Henne (2015)"],
-      "awards_es": ["Gallina de Oro (2015)"]
+      "chart_info": {
+        "german_peak": 2,
+        "weeks_on_chart": 48
+      },
+      "certifications": [
+        "2x Platinum (DE)"
+      ],
+      "awards": [
+        "Goldene Henne (2015)"
+      ],
+      "awards_de": [
+        "Goldene Henne (2015)"
+      ],
+      "awards_es": [
+        "Gallina de Oro (2015)"
+      ],
+      "uri_apple_music": "applemusic://track/913150581"
     },
     {
       "year": 1975,
@@ -428,9 +781,15 @@
       "fun_fact": "Ich bin wie du by Marianne Rosenberg is a hymn to self-acceptance. Rosenberg has been singing for over 50 years and still captivates her audience.",
       "fun_fact_de": "Ich bin wie du von Marianne Rosenberg ist eine Hymne der Selbstakzeptanz. Rosenberg singt seit über 50 Jahren und begeistert immer noch ihr Publikum.",
       "fun_fact_es": "Ich bin wie du de Marianne Rosenberg es un himno a la autoaceptación. Rosenberg lleva más de 50 años cantando y sigue entusiasmando a su público.",
-      "chart_info": {"german_peak": 3, "weeks_on_chart": 16},
-      "certifications": ["Gold (DE)"],
-      "awards": []
+      "chart_info": {
+        "german_peak": 3,
+        "weeks_on_chart": 16
+      },
+      "certifications": [
+        "Gold (DE)"
+      ],
+      "awards": [],
+      "uri_apple_music": "applemusic://track/303883842"
     },
     {
       "year": 1993,
@@ -438,9 +797,15 @@
       "fun_fact": "Hör gut zu by Pur is a thoughtful ballad about communication. The band consistently manages to incorporate important themes into their music.",
       "fun_fact_de": "Hör gut zu von Pur ist eine nachdenkliche Ballade über Kommunikation. Die Band schafft es immer wieder, wichtige Themen in ihre Musik einzubauen.",
       "fun_fact_es": "Hör gut zu de Pur es una balada reflexiva sobre la comunicación. La banda logra una y otra vez incorporar temas importantes en su música.",
-      "chart_info": {"german_peak": 8, "weeks_on_chart": 14},
-      "certifications": ["Gold (DE)"],
-      "awards": []
+      "chart_info": {
+        "german_peak": 8,
+        "weeks_on_chart": 14
+      },
+      "certifications": [
+        "Gold (DE)"
+      ],
+      "awards": [],
+      "uri_apple_music": "applemusic://track/1440857163"
     },
     {
       "year": 1977,
@@ -448,9 +813,17 @@
       "fun_fact": "Mit 66 Jahren by Udo Jürgens is an optimistic hymn to growing older. Jürgens himself embodied this joy of life and performed until an advanced age.",
       "fun_fact_de": "Mit 66 Jahren von Udo Jürgens ist eine optimistische Hymne ans Älterwerden. Jürgens selbst lebte diese Lebensfreude vor und trat bis ins hohe Alter auf.",
       "fun_fact_es": "Mit 66 Jahren de Udo Jürgens es un himno optimista al envejecimiento. El propio Jürgens vivió esa alegría de vivir y actuó hasta una edad avanzada.",
-      "chart_info": {"german_peak": 1, "weeks_on_chart": 22, "austrian_peak": 1},
-      "certifications": ["Platinum (DE)", "Gold (AT)"],
-      "awards": []
+      "chart_info": {
+        "german_peak": 1,
+        "weeks_on_chart": 22,
+        "austrian_peak": 1
+      },
+      "certifications": [
+        "Platinum (DE)",
+        "Gold (AT)"
+      ],
+      "awards": [],
+      "uri_apple_music": "applemusic://track/207186284"
     },
     {
       "year": 2009,
@@ -458,11 +831,23 @@
       "fun_fact": "Ich will immer wieder... dieses Fieber spür'n showcases Helene Fischer's energy and stage presence. She is the most successful German artist of the present day.",
       "fun_fact_de": "Ich will immer wieder... dieses Fieber spür'n zeigt Helene Fischers Energie und Bühnenpräsenz. Sie ist die erfolgreichste deutsche Künstlerin der Gegenwart.",
       "fun_fact_es": "Ich will immer wieder... dieses Fieber spür'n muestra la energía y presencia escénica de Helene Fischer. Es la artista alemana más exitosa de la actualidad.",
-      "chart_info": {"german_peak": 4, "weeks_on_chart": 32},
-      "certifications": ["Platinum (DE)"],
-      "awards": ["Echo (2010)"],
-      "awards_de": ["Echo (2010)"],
-      "awards_es": ["Premio Echo (2010)"]
+      "chart_info": {
+        "german_peak": 4,
+        "weeks_on_chart": 32
+      },
+      "certifications": [
+        "Platinum (DE)"
+      ],
+      "awards": [
+        "Echo (2010)"
+      ],
+      "awards_de": [
+        "Echo (2010)"
+      ],
+      "awards_es": [
+        "Premio Echo (2010)"
+      ],
+      "uri_apple_music": "applemusic://track/1544489968"
     },
     {
       "year": 1972,
@@ -470,9 +855,15 @@
       "fun_fact": "Ein bisschen Spaß muss sein by Roberto Blanco has become a popular catchphrase. The Cuban-born entertainer brought Caribbean joie de vivre to Germany.",
       "fun_fact_de": "Ein bisschen Spaß muss sein von Roberto Blanco ist zum geflügelten Wort geworden. Der kubanischstämmige Entertainer brachte karibische Lebensfreude nach Deutschland.",
       "fun_fact_es": "Ein bisschen Spaß muss sein de Roberto Blanco se ha convertido en una frase hecha. El artista de origen cubano trajo la alegría caribeña a Alemania.",
-      "chart_info": {"german_peak": 2, "weeks_on_chart": 18},
-      "certifications": ["Gold (DE)"],
-      "awards": []
+      "chart_info": {
+        "german_peak": 2,
+        "weeks_on_chart": 18
+      },
+      "certifications": [
+        "Gold (DE)"
+      ],
+      "awards": [],
+      "uri_apple_music": "applemusic://track/915382195"
     },
     {
       "year": 1982,
@@ -480,11 +871,28 @@
       "fun_fact": "Ein bisschen Frieden by Nicole won the 1982 Eurovision Song Contest for Germany. It was Germany's first ESC victory and made Nicole a star.",
       "fun_fact_de": "Ein bisschen Frieden von Nicole gewann 1982 den Eurovision Song Contest für Deutschland. Es war der erste deutsche ESC-Sieg und machte Nicole zum Star.",
       "fun_fact_es": "Ein bisschen Frieden de Nicole ganó el Festival de Eurovisión para Alemania en 1982. Fue la primera victoria alemana en Eurovisión y convirtió a Nicole en una estrella.",
-      "chart_info": {"german_peak": 1, "weeks_on_chart": 28, "uk_peak": 1},
-      "certifications": ["2x Platinum (DE)", "Gold (UK)"],
-      "awards": ["Eurovision Song Contest Winner (1982)", "Goldene Stimmgabel (1982)"],
-      "awards_de": ["Gewinnerin des Eurovision Song Contest (1982)", "Goldene Stimmgabel (1982)"],
-      "awards_es": ["Ganadora del Festival de Eurovisión (1982)", "Diapasón de Oro (1982)"]
+      "chart_info": {
+        "german_peak": 1,
+        "weeks_on_chart": 28,
+        "uk_peak": 1
+      },
+      "certifications": [
+        "2x Platinum (DE)",
+        "Gold (UK)"
+      ],
+      "awards": [
+        "Eurovision Song Contest Winner (1982)",
+        "Goldene Stimmgabel (1982)"
+      ],
+      "awards_de": [
+        "Gewinnerin des Eurovision Song Contest (1982)",
+        "Goldene Stimmgabel (1982)"
+      ],
+      "awards_es": [
+        "Ganadora del Festival de Eurovisión (1982)",
+        "Diapasón de Oro (1982)"
+      ],
+      "uri_apple_music": "applemusic://track/274740408"
     },
     {
       "year": 1993,
@@ -492,9 +900,15 @@
       "fun_fact": "Indianer by Pur is a rock anthem about freedom and adventure. The band has been captivating audiences for over 40 years with German lyrics and rousing melodies.",
       "fun_fact_de": "Indianer von Pur ist eine rockige Hymne über Freiheit und Abenteuer. Die Band begeistert seit über 40 Jahren mit deutschen Texten und mitreißenden Melodien.",
       "fun_fact_es": "Indianer de Pur es un himno rockero sobre la libertad y la aventura. La banda lleva más de 40 años entusiasmando con letras en alemán y melodías contagiosas.",
-      "chart_info": {"german_peak": 4, "weeks_on_chart": 20},
-      "certifications": ["Gold (DE)"],
-      "awards": []
+      "chart_info": {
+        "german_peak": 4,
+        "weeks_on_chart": 20
+      },
+      "certifications": [
+        "Gold (DE)"
+      ],
+      "awards": [],
+      "uri_apple_music": "applemusic://track/1530792638"
     },
     {
       "year": 1971,
@@ -502,9 +916,15 @@
       "fun_fact": "Schön ist es auf der Welt zu sein by Roy Black and Anita is a timeless feel-good song. Roy Black was one of the biggest stars of the 1960s and 70s.",
       "fun_fact_de": "Schön ist es auf der Welt zu sein von Roy Black und Anita ist ein zeitloser Feelgood-Song. Roy Black war einer der größten Stars der 1960er und 70er Jahre.",
       "fun_fact_es": "Schön ist es auf der Welt zu sein de Roy Black y Anita es una canción atemporal que levanta el ánimo. Roy Black fue una de las mayores estrellas de los años 60 y 70.",
-      "chart_info": {"german_peak": 1, "weeks_on_chart": 20},
-      "certifications": ["Platinum (DE)"],
-      "awards": []
+      "chart_info": {
+        "german_peak": 1,
+        "weeks_on_chart": 20
+      },
+      "certifications": [
+        "Platinum (DE)"
+      ],
+      "awards": [],
+      "uri_apple_music": "applemusic://track/1443268695"
     },
     {
       "year": 2017,
@@ -512,9 +932,17 @@
       "fun_fact": "Herzbeben by Helene Fischer shows her evolution toward international pop. The song combines a modern sound with the emotionality of Schlager.",
       "fun_fact_de": "Herzbeben von Helene Fischer zeigt ihre Entwicklung zu internationalem Pop. Der Song verbindet modernen Sound mit der Emotionalität des Schlagers.",
       "fun_fact_es": "Herzbeben de Helene Fischer muestra su evolución hacia el pop internacional. La canción combina un sonido moderno con la emotividad del Schlager.",
-      "chart_info": {"german_peak": 1, "weeks_on_chart": 40, "austrian_peak": 1},
-      "certifications": ["2x Platinum (DE)", "Platinum (AT)"],
-      "awards": []
+      "chart_info": {
+        "german_peak": 1,
+        "weeks_on_chart": 40,
+        "austrian_peak": 1
+      },
+      "certifications": [
+        "2x Platinum (DE)",
+        "Platinum (AT)"
+      ],
+      "awards": [],
+      "uri_apple_music": "applemusic://track/1441541458"
     },
     {
       "year": 2018,
@@ -522,9 +950,15 @@
       "fun_fact": "Regenbogenfarben by Kerstin Ott and Helene Fischer became a duet hit. Ott became famous through 'Die immer lacht' and has become indispensable in modern Schlager.",
       "fun_fact_de": "Regenbogenfarben von Kerstin Ott und Helene Fischer wurde zum Duett-Hit. Ott wurde durch 'Die immer lacht' bekannt und ist aus dem modernen Schlager nicht mehr wegzudenken.",
       "fun_fact_es": "Regenbogenfarben de Kerstin Ott y Helene Fischer se convirtió en un éxito a dúo. Ott se hizo famosa con 'Die immer lacht' y es ya imprescindible en el Schlager moderno.",
-      "chart_info": {"german_peak": 2, "weeks_on_chart": 28},
-      "certifications": ["Platinum (DE)"],
-      "awards": []
+      "chart_info": {
+        "german_peak": 2,
+        "weeks_on_chart": 28
+      },
+      "certifications": [
+        "Platinum (DE)"
+      ],
+      "awards": [],
+      "uri_apple_music": "applemusic://track/1447386488"
     },
     {
       "year": 1973,
@@ -532,9 +966,15 @@
       "fun_fact": "Goodbye My Love Goodbye by Demis Roussos is an emotional farewell song. The Greek singer captivated millions of fans worldwide with his unmistakable voice.",
       "fun_fact_de": "Goodbye My Love Goodbye von Demis Roussos ist ein emotionaler Abschiedssong. Der griechische Sänger begeisterte mit seiner unverwechselbaren Stimme Millionen Fans weltweit.",
       "fun_fact_es": "Goodbye My Love Goodbye de Demis Roussos es una emotiva canción de despedida. El cantante griego conquistó a millones de fans en todo el mundo con su inconfundible voz.",
-      "chart_info": {"german_peak": 2, "weeks_on_chart": 22},
-      "certifications": ["Gold (DE)"],
-      "awards": []
+      "chart_info": {
+        "german_peak": 2,
+        "weeks_on_chart": 22
+      },
+      "certifications": [
+        "Gold (DE)"
+      ],
+      "awards": [],
+      "uri_apple_music": "applemusic://track/1443355536"
     },
     {
       "year": 1961,
@@ -542,9 +982,12 @@
       "fun_fact": "Zuckerpuppe (Aus der Bauchtanzgruppe) by Bill Ramsey is a humorous classic. Ramsey brought American swing humor to German Schlager.",
       "fun_fact_de": "Zuckerpuppe (Aus der Bauchtanzgruppe) von Bill Ramsey ist ein humorvoller Klassiker. Ramsey brachte amerikanischen Swing-Humor in den deutschen Schlager.",
       "fun_fact_es": "Zuckerpuppe (Aus der Bauchtanzgruppe) de Bill Ramsey es un clásico humorístico. Ramsey trajo el humor del swing estadounidense al Schlager alemán.",
-      "chart_info": {"german_peak": 5},
+      "chart_info": {
+        "german_peak": 5
+      },
       "certifications": [],
-      "awards": []
+      "awards": [],
+      "uri_apple_music": "applemusic://track/1443368139"
     },
     {
       "year": 1986,
@@ -552,9 +995,15 @@
       "fun_fact": "Stimmen im Wind by Juliane Werding shows her emotional side. Werding has been successful since the 1970s and has constantly evolved.",
       "fun_fact_de": "Stimmen im Wind von Juliane Werding zeigt ihre emotionale Seite. Werding ist seit den 1970ern erfolgreich und hat sich ständig weiterentwickelt.",
       "fun_fact_es": "Stimmen im Wind de Juliane Werding muestra su lado más emotivo. Werding ha sido exitosa desde los años 70 y ha evolucionado constantemente.",
-      "chart_info": {"german_peak": 6, "weeks_on_chart": 16},
-      "certifications": ["Gold (DE)"],
-      "awards": []
+      "chart_info": {
+        "german_peak": 6,
+        "weeks_on_chart": 16
+      },
+      "certifications": [
+        "Gold (DE)"
+      ],
+      "awards": [],
+      "uri_apple_music": "applemusic://track/915383380"
     },
     {
       "year": 1974,
@@ -562,9 +1011,15 @@
       "fun_fact": "Du kannst nicht immer 17 sein by Chris Roberts is a nostalgic hymn to youth. The song became the motto for everyone who stays young at heart.",
       "fun_fact_de": "Du kannst nicht immer 17 sein von Chris Roberts ist eine nostalgische Hymne an die Jugend. Der Song wurde zum Motto aller, die jung geblieben sind.",
       "fun_fact_es": "Du kannst nicht immer 17 sein de Chris Roberts es un himno nostálgico a la juventud. La canción se convirtió en el lema de todos los que se mantienen jóvenes de corazón.",
-      "chart_info": {"german_peak": 1, "weeks_on_chart": 18},
-      "certifications": ["Gold (DE)"],
-      "awards": []
+      "chart_info": {
+        "german_peak": 1,
+        "weeks_on_chart": 18
+      },
+      "certifications": [
+        "Gold (DE)"
+      ],
+      "awards": [],
+      "uri_apple_music": "applemusic://track/471542543"
     },
     {
       "year": 1972,
@@ -572,9 +1027,15 @@
       "fun_fact": "Eine neue Liebe ist wie ein neues Leben by Jürgen Marcus became an evergreen. This optimistic song has accompanied lovers for generations.",
       "fun_fact_de": "Eine neue Liebe ist wie ein neues Leben von Jürgen Marcus wurde zum Evergreen. Der optimistische Song begleitet Verliebte seit Generationen.",
       "fun_fact_es": "Eine neue Liebe ist wie ein neues Leben de Jürgen Marcus se convirtió en un clásico imperecedero. Esta optimista canción acompaña a los enamorados desde hace generaciones.",
-      "chart_info": {"german_peak": 1, "weeks_on_chart": 20},
-      "certifications": ["Gold (DE)"],
-      "awards": []
+      "chart_info": {
+        "german_peak": 1,
+        "weeks_on_chart": 20
+      },
+      "certifications": [
+        "Gold (DE)"
+      ],
+      "awards": [],
+      "uri_apple_music": "applemusic://track/453961321"
     },
     {
       "year": 2009,
@@ -582,9 +1043,12 @@
       "fun_fact": "Wir sagen danke schön by Die Flippers is a heartfelt anthem of thanks to their fans. The band said farewell after more than 40 years of a successful career.",
       "fun_fact_de": "Wir sagen danke schön von Die Flippers ist eine herzliche Dankeshymne an ihre Fans. Die Band verabschiedete sich nach über 40 Jahren erfolgreicher Karriere.",
       "fun_fact_es": "Wir sagen danke schön de Die Flippers es un emotivo himno de agradecimiento a sus fans. La banda se despidió después de más de 40 años de exitosa carrera.",
-      "chart_info": {"german_peak": 10},
+      "chart_info": {
+        "german_peak": 10
+      },
       "certifications": [],
-      "awards": []
+      "awards": [],
+      "uri_apple_music": "applemusic://track/1642332872"
     },
     {
       "year": 1976,
@@ -592,9 +1056,15 @@
       "fun_fact": "Ein Bett im Kornfeld by Jürgen Drews is the quintessential summer hit. Drews, the 'King of Mallorca', still sings it at every party to this day.",
       "fun_fact_de": "Ein Bett im Kornfeld von Jürgen Drews ist der Sommerhit schlechthin. Drews, der 'König von Mallorca', singt ihn bis heute auf jeder Party.",
       "fun_fact_es": "Ein Bett im Kornfeld de Jürgen Drews es el éxito veraniego por excelencia. Drews, el 'Rey de Mallorca', sigue cantándolo en todas las fiestas.",
-      "chart_info": {"german_peak": 1, "weeks_on_chart": 26},
-      "certifications": ["2x Platinum (DE)"],
-      "awards": []
+      "chart_info": {
+        "german_peak": 1,
+        "weeks_on_chart": 26
+      },
+      "certifications": [
+        "2x Platinum (DE)"
+      ],
+      "awards": [],
+      "uri_apple_music": "applemusic://track/293895098"
     },
     {
       "year": 2009,
@@ -602,9 +1072,15 @@
       "fun_fact": "1000 Träume weit (Tornero) by Anna-Maria Zimmermann became a party hit. The energetic singer has become indispensable in modern party Schlager.",
       "fun_fact_de": "1000 Träume weit (Tornero) von Anna-Maria Zimmermann wurde zum Party-Hit. Die energiegeladene Sängerin ist aus dem modernen Partyschlager nicht wegzudenken.",
       "fun_fact_es": "1000 Träume weit (Tornero) de Anna-Maria Zimmermann se convirtió en un éxito de fiesta. La enérgica cantante es imprescindible en el Schlager de fiesta moderno.",
-      "chart_info": {"german_peak": 8, "weeks_on_chart": 22},
-      "certifications": ["Gold (DE)"],
-      "awards": []
+      "chart_info": {
+        "german_peak": 8,
+        "weeks_on_chart": 22
+      },
+      "certifications": [
+        "Gold (DE)"
+      ],
+      "awards": [],
+      "uri_apple_music": "applemusic://track/716021745"
     },
     {
       "year": 1970,
@@ -612,11 +1088,23 @@
       "fun_fact": "Du by Peter Maffay was his breakthrough hit and made him a superstar. The title is listed in the Guinness Book as the best-selling single by a German artist.",
       "fun_fact_de": "Du von Peter Maffay war sein Durchbruchshit und machte ihn zum Superstar. Der Titel steht im Guinness-Buch als meistverkaufte Single eines deutschen Künstlers.",
       "fun_fact_es": "Du de Peter Maffay fue su éxito de lanzamiento y lo convirtió en superestrella. El título está en el Libro Guinness como el sencillo más vendido de un artista alemán.",
-      "chart_info": {"german_peak": 1, "weeks_on_chart": 30},
-      "certifications": ["3x Platinum (DE)"],
-      "awards": ["Goldene Schallplatte (1970)"],
-      "awards_de": ["Goldene Schallplatte (1970)"],
-      "awards_es": ["Disco de Oro (1970)"]
+      "chart_info": {
+        "german_peak": 1,
+        "weeks_on_chart": 30
+      },
+      "certifications": [
+        "3x Platinum (DE)"
+      ],
+      "awards": [
+        "Goldene Schallplatte (1970)"
+      ],
+      "awards_de": [
+        "Goldene Schallplatte (1970)"
+      ],
+      "awards_es": [
+        "Disco de Oro (1970)"
+      ],
+      "uri_apple_music": "applemusic://track/207071929"
     },
     {
       "year": 1969,
@@ -624,9 +1112,15 @@
       "fun_fact": "Mendocino by Michael Holm brought American flair to German Schlager. The song is about the longing for faraway places and adventures.",
       "fun_fact_de": "Mendocino von Michael Holm brachte amerikanisches Flair in den deutschen Schlager. Der Song handelt von der Sehnsucht nach fernen Orten und Abenteuern.",
       "fun_fact_es": "Mendocino de Michael Holm trajo el aire estadounidense al Schlager alemán. La canción trata sobre la añoranza de lugares lejanos y aventuras.",
-      "chart_info": {"german_peak": 1, "weeks_on_chart": 18},
-      "certifications": ["Gold (DE)"],
-      "awards": []
+      "chart_info": {
+        "german_peak": 1,
+        "weeks_on_chart": 18
+      },
+      "certifications": [
+        "Gold (DE)"
+      ],
+      "awards": [],
+      "uri_apple_music": "applemusic://track/304326426"
     },
     {
       "year": 1981,
@@ -634,8 +1128,13 @@
       "fun_fact": "Albany by Roger Whittaker showcases his distinctive voice and whistling talent. The British singer became an absolute fan favorite in Germany.",
       "fun_fact_de": "Albany von Roger Whittaker zeigt seine markante Stimme und sein Pfeiftalent. Der britische Sänger wurde in Deutschland zum absoluten Publikumsliebling.",
       "fun_fact_es": "Albany de Roger Whittaker muestra su distintiva voz y su talento para silbar. El cantante británico se convirtió en uno de los favoritos del público en Alemania.",
-      "chart_info": {"german_peak": 4, "weeks_on_chart": 16},
-      "certifications": ["Gold (DE)"],
+      "chart_info": {
+        "german_peak": 4,
+        "weeks_on_chart": 16
+      },
+      "certifications": [
+        "Gold (DE)"
+      ],
       "awards": []
     }
   ]

--- a/custom_components/beatify/services/media_player.py
+++ b/custom_components/beatify/services/media_player.py
@@ -22,8 +22,12 @@ def get_media_content_type(uri: str) -> str:
     content types. For example, Alexa devices return "Sorry, direct music
     streaming isn't supported" when using generic "music" type for Spotify URIs.
 
+    For Apple Music via Music Assistant, URIs use the "applemusic://" scheme.
+    Music Assistant handles the actual routing to Apple Music internally,
+    so the content type "music" is appropriate.
+
     Args:
-        uri: Media content URI (e.g., "spotify:track:xxx", "apple_music:track:xxx")
+        uri: Media content URI (e.g., "spotify:track:xxx", "applemusic://track/123")
 
     Returns:
         Provider-specific content type (e.g., "spotify") or default "music"
@@ -31,8 +35,8 @@ def get_media_content_type(uri: str) -> str:
     Examples:
         >>> get_media_content_type("spotify:track:abc123")
         'spotify'
-        >>> get_media_content_type("apple_music:track:xyz")
-        'apple_music'
+        >>> get_media_content_type("applemusic://track/123456789")
+        'music'
         >>> get_media_content_type("http://example.com/song.mp3")
         'music'
 

--- a/tests/unit/test_media_player_service.py
+++ b/tests/unit/test_media_player_service.py
@@ -253,8 +253,13 @@ class TestMediaContentTypeDetection:
         assert get_media_content_type("spotify:playlist:def456") == "spotify"
 
     def test_apple_music_uri_returns_apple_music_type(self):
-        """Apple Music URI returns 'apple_music' content type (future support)."""
+        """Apple Music URI returns 'apple_music' content type (legacy format)."""
         assert get_media_content_type("apple_music:track:abc123") == "apple_music"
+
+    def test_applemusic_via_music_assistant_returns_music_type(self):
+        """Apple Music via Music Assistant uses 'music' content type (Story 17.3)."""
+        # Music Assistant uses applemusic:// scheme, not apple_music: prefix
+        assert get_media_content_type("applemusic://track/1234567890") == "music"
 
     def test_tidal_uri_returns_tidal_type(self):
         """Tidal URI returns 'tidal' content type (future support)."""


### PR DESCRIPTION
## Summary

- **Story 17.3**: Dynamic URI selection based on selected music provider
- **Story 17.5**: Enriched all bundled playlists with Apple Music URIs

This PR completes Epic 17, enabling Apple Music subscribers to play Beatify using Music Assistant.

## Changes

### Backend (Story 17.3)
- Add `provider` field to game state
- Update media player service to select correct URI (Spotify vs Apple Music)
- Add unit tests for provider-aware playback

### Playlists (Story 17.5)
- `eurovision-winners.json` - Added Apple Music URIs
- `greatest-hits-of-all-time.json` - Added Apple Music URIs
- `movies-100-greatest-themes.json` - Added Apple Music URIs
- `schlager-klassiker.json` - Added Apple Music URIs

## Test plan
- [ ] Select Apple Music provider in admin page
- [ ] Start game with Music Assistant media player
- [ ] Verify songs play via Apple Music URIs
- [ ] Verify Spotify still works when Spotify provider selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)