### PR TITLE
fix(playlists): Add streaming URIs to Pure Pop Punk

### DIFF
--- a/custom_components/beatify/playlists/pure-pop-punk.json
+++ b/custom_components/beatify/playlists/pure-pop-punk.json
@@ -24,7 +24,9 @@
       "awards": [],
       "fun_fact": "Paramore stopped playing this song live in 2018 due to controversial lyrics about another woman, but brought it back by popular demand in 2022.",
       "fun_fact_de": "Paramore spielte diesen Song ab 2018 wegen kontroverser Texte nicht mehr live, brachte ihn aber 2022 auf Wunsch der Fans zurück.",
-      "fun_fact_es": "Paramore dejó de tocar esta canción en vivo en 2018 debido a letras controvertidas, pero la recuperó por demanda popular en 2022."
+      "fun_fact_es": "Paramore dejó de tocar esta canción en vivo en 2018 debido a letras controvertidas, pero la recuperó por demanda popular en 2022.",
+      "uri_apple_music": "applemusic://track/604863246",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=aCyGvGEtOwc"
     },
     {
       "year": 1999,
@@ -47,7 +49,9 @@
       "awards": [],
       "fun_fact": "The famous music video features the band running completely naked through Los Angeles. It was filmed guerrilla-style with no permits.",
       "fun_fact_de": "Das berühmte Musikvideo zeigt die Band komplett nackt durch Los Angeles laufend. Es wurde ohne Genehmigungen im Guerilla-Stil gedreht.",
-      "fun_fact_es": "El famoso video musical muestra a la banda corriendo completamente desnuda por Los Angeles. Se filmó estilo guerrilla sin permisos."
+      "fun_fact_es": "El famoso video musical muestra a la banda corriendo completamente desnuda por Los Angeles. Se filmó estilo guerrilla sin permisos.",
+      "uri_apple_music": "applemusic://track/1471266333",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=K7l5ZeVVoCA"
     },
     {
       "year": 2002,
@@ -70,7 +74,9 @@
       "awards": [],
       "fun_fact": "Sum 41 wrote this song in just 20 minutes as a frustrated response to their record label's pressure for a radio-friendly single.",
       "fun_fact_de": "Sum 41 schrieb diesen Song in nur 20 Minuten als frustrierte Antwort auf den Druck ihrer Plattenfirma nach einer radiotauglichen Single.",
-      "fun_fact_es": "Sum 41 escribió esta canción en solo 20 minutos como respuesta frustrada a la presión de su sello por un sencillo para radio."
+      "fun_fact_es": "Sum 41 escribió esta canción en solo 20 minutos como respuesta frustrada a la presión de su sello por un sencillo para radio.",
+      "uri_apple_music": "applemusic://track/1443465786",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=qO-mSLxih-c"
     },
     {
       "year": 2007,
@@ -94,7 +100,9 @@
       "awards": [],
       "fun_fact": "The title deliberately omits vowels. Kim Kardashian appeared in the music video as the love interest, filmed before her reality TV fame.",
       "fun_fact_de": "Der Titel lässt absichtlich Vokale weg. Kim Kardashian erschien im Musikvideo als Love Interest, vor ihrem Reality-TV-Ruhm gedreht.",
-      "fun_fact_es": "El título omite deliberadamente las vocales. Kim Kardashian apareció en el video como interés amoroso, filmado antes de su fama televisiva."
+      "fun_fact_es": "El título omite deliberadamente las vocales. Kim Kardashian apareció en el video como interés amoroso, filmado antes de su fama televisiva.",
+      "uri_apple_music": "applemusic://track/1440787031",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=onzL0EM1pKY"
     },
     {
       "year": 2000,
@@ -117,7 +125,9 @@
       "awards": [],
       "fun_fact": "Featured on the American Pie 2 soundtrack, this song helped The Offspring maintain relevance in the early 2000s pop punk scene.",
       "fun_fact_de": "Auf dem American Pie 2 Soundtrack zu hören, half dieser Song The Offspring, in der frühen 2000er Pop-Punk-Szene relevant zu bleiben.",
-      "fun_fact_es": "Presente en la banda sonora de American Pie 2, esta canción ayudó a The Offspring a mantenerse relevante en la escena pop punk de los 2000."
+      "fun_fact_es": "Presente en la banda sonora de American Pie 2, esta canción ayudó a The Offspring a mantenerse relevante en la escena pop punk de los 2000.",
+      "uri_apple_music": "applemusic://track/1440887425",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=_g19fCJotPc"
     },
     {
       "year": 2004,
@@ -141,7 +151,9 @@
       "awards": [],
       "fun_fact": "The music video brilliantly parodies 80s teen movies. The band dressed as high school students despite being in their mid-20s.",
       "fun_fact_de": "Das Musikvideo parodiert brillant 80er-Teenagerfilme. Die Band verkleidete sich als Highschool-Schüler, obwohl sie Mitte 20 waren.",
-      "fun_fact_es": "El video parodia brillantemente películas adolescentes de los 80. La banda se vistió de estudiantes aunque tenían más de 20 años."
+      "fun_fact_es": "El video parodia brillantemente películas adolescentes de los 80. La banda se vistió de estudiantes aunque tenían más de 20 años.",
+      "uri_apple_music": "applemusic://track/1156311437",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=dhZTNgAs4Fc"
     },
     {
       "year": 2004,
@@ -162,7 +174,9 @@
       "awards": [],
       "fun_fact": "This emotional ballad showed Good Charlotte's range beyond their typical upbeat pop punk style and became a fan favorite at concerts.",
       "fun_fact_de": "Diese emotionale Ballade zeigte Good Charlottes Bandbreite jenseits ihres typischen Pop-Punk-Stils und wurde ein Fan-Favorit bei Konzerten.",
-      "fun_fact_es": "Esta balada emocional mostró el rango de Good Charlotte más allá de su estilo típico y se convirtió en favorita de los fans en conciertos."
+      "fun_fact_es": "Esta balada emocional mostró el rango de Good Charlotte más allá de su estilo típico y se convirtió en favorita de los fans en conciertos.",
+      "uri_apple_music": "applemusic://track/280429668",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=yVm8PjWCvLg"
     },
     {
       "year": 2002,
@@ -185,7 +199,9 @@
       "awards": [],
       "fun_fact": "Featured in the movie Cheaper by the Dozen, this song became an anthem for feeling misunderstood and exploded on TikTok in 2020.",
       "fun_fact_de": "Im Film Im Dutzend billiger zu hören, wurde dieser Song eine Hymne für Missverstandene und explodierte 2020 auf TikTok.",
-      "fun_fact_es": "Presente en la película Más barato por docena, esta canción se convirtió en himno de incomprendidos y explotó en TikTok en 2020."
+      "fun_fact_es": "Presente en la película Más barato por docena, esta canción se convirtió en himno de incomprendidos y explotó en TikTok en 2020.",
+      "uri_apple_music": "applemusic://track/1355149519",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=_GOR5gvQwDI"
     },
     {
       "year": 2004,
@@ -209,7 +225,9 @@
       "awards": [],
       "fun_fact": "Originally titled 'Holiday (Bring the Bombs)', it's an anti-war protest song about the Iraq War from the politically-charged American Idiot album.",
       "fun_fact_de": "Ursprünglich 'Holiday (Bring the Bombs)' betitelt, ist es ein Antikriegs-Protestsong über den Irakkrieg vom politischen American Idiot Album.",
-      "fun_fact_es": "Originalmente titulada 'Holiday (Bring the Bombs)', es una canción de protesta contra la guerra de Irak del álbum American Idiot."
+      "fun_fact_es": "Originalmente titulada 'Holiday (Bring the Bombs)', es una canción de protesta contra la guerra de Irak del álbum American Idiot.",
+      "uri_apple_music": "applemusic://track/1161539473",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=A1OqtIqzScI"
     },
     {
       "year": 2007,
@@ -232,7 +250,9 @@
       "awards": [],
       "fun_fact": "Written about a stripper Alex Gaskarth knew in Baltimore. The song became All Time Low's breakthrough hit and a pop punk staple.",
       "fun_fact_de": "Geschrieben über eine Stripperin, die Alex Gaskarth aus Baltimore kannte. Der Song wurde All Time Lows Durchbruch und ein Pop-Punk-Klassiker.",
-      "fun_fact_es": "Escrita sobre una stripper que Alex Gaskarth conocía en Baltimore. La canción fue el éxito revelación de All Time Low."
+      "fun_fact_es": "Escrita sobre una stripper que Alex Gaskarth conocía en Baltimore. La canción fue el éxito revelación de All Time Low.",
+      "uri_apple_music": "applemusic://track/502522511",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=GcNiKCmWdYE"
     },
     {
       "year": 2006,
@@ -253,7 +273,9 @@
       "awards": [],
       "fun_fact": "The title track from Yellowcard's 2006 album featured their signature violin-driven sound that set them apart from other pop punk bands.",
       "fun_fact_de": "Der Titeltrack von Yellowcards 2006er Album zeigte ihren charakteristischen Violin-Sound, der sie von anderen Pop-Punk-Bands abhob.",
-      "fun_fact_es": "La canción principal del álbum de Yellowcard de 2006 presentó su sonido característico de violín que los distinguía de otras bandas."
+      "fun_fact_es": "La canción principal del álbum de Yellowcard de 2006 presentó su sonido característico de violín que los distinguía de otras bandas.",
+      "uri_apple_music": "applemusic://track/724535524",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=ufnJ0Wp_xt4"
     },
     {
       "year": 2006,
@@ -274,7 +296,9 @@
       "awards": [],
       "fun_fact": "+44 was Mark Hoppus and Travis Barker's project during blink-182's hiatus. The band name refers to the UK's country code.",
       "fun_fact_de": "+44 war Mark Hoppus und Travis Barkers Projekt während blink-182s Pause. Der Bandname bezieht sich auf Großbritanniens Ländervorwahl.",
-      "fun_fact_es": "+44 fue el proyecto de Mark Hoppus y Travis Barker durante el hiato de blink-182. El nombre se refiere al código de país del Reino Unido."
+      "fun_fact_es": "+44 fue el proyecto de Mark Hoppus y Travis Barker durante el hiato de blink-182. El nombre se refiere al código de país del Reino Unido.",
+      "uri_apple_music": "applemusic://track/1440753689",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=usMfopRLM2A"
     },
     {
       "year": 2006,
@@ -297,7 +321,9 @@
       "awards": [],
       "fun_fact": "This song addresses domestic violence. The powerful message helped it become the band's biggest and most meaningful hit.",
       "fun_fact_de": "Dieser Song thematisiert häusliche Gewalt. Die kraftvolle Botschaft machte ihn zum größten und bedeutungsvollsten Hit der Band.",
-      "fun_fact_es": "Esta canción aborda la violencia doméstica. El poderoso mensaje la convirtió en el mayor y más significativo éxito de la banda."
+      "fun_fact_es": "Esta canción aborda la violencia doméstica. El poderoso mensaje la convirtió en el mayor y más significativo éxito de la banda.",
+      "uri_apple_music": "applemusic://track/806224710",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=6Ux6SlOE9Qk"
     },
     {
       "year": 2002,
@@ -320,7 +346,9 @@
       "awards": [],
       "fun_fact": "New Found Glory's signature song was ubiquitous in the early 2000s and remains a staple at pop punk shows and Warped Tour reunions.",
       "fun_fact_de": "New Found Glorys Erkennungssong war Anfang der 2000er allgegenwärtig und bleibt ein Klassiker bei Pop-Punk-Shows.",
-      "fun_fact_es": "La canción insignia de New Found Glory fue omnipresente a principios de los 2000 y sigue siendo esencial en shows de pop punk."
+      "fun_fact_es": "La canción insignia de New Found Glory fue omnipresente a principios de los 2000 y sigue siendo esencial en shows de pop punk.",
+      "uri_apple_music": "applemusic://track/1473976144",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=QfcLcDBII78"
     },
     {
       "year": 2007,
@@ -343,7 +371,9 @@
       "awards": [],
       "fun_fact": "We The Kings' debut single became a sleeper hit, eventually reaching platinum status through steady streaming and radio play.",
       "fun_fact_de": "Die Debütsingle von We The Kings wurde ein Sleeper-Hit und erreichte durch stetiges Streaming Platin-Status.",
-      "fun_fact_es": "El sencillo debut de We The Kings se convirtió en un éxito durmiente, alcanzando platino a través del streaming constante."
+      "fun_fact_es": "El sencillo debut de We The Kings se convirtió en un éxito durmiente, alcanzando platino a través del streaming constante.",
+      "uri_apple_music": "applemusic://track/1297082405",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=5CUyWJ7UINM"
     },
     {
       "year": 2017,
@@ -364,7 +394,9 @@
       "awards": [],
       "fun_fact": "Story Untold represents the modern wave of pop punk, keeping the genre alive for new generations of fans in the 2010s.",
       "fun_fact_de": "Story Untold repräsentiert die moderne Pop-Punk-Welle und hält das Genre für neue Fangenerationen in den 2010ern am Leben.",
-      "fun_fact_es": "Story Untold representa la ola moderna de pop punk, manteniendo el género vivo para nuevas generaciones de fans en los 2010."
+      "fun_fact_es": "Story Untold representa la ola moderna de pop punk, manteniendo el género vivo para nuevas generaciones de fans en los 2010.",
+      "uri_apple_music": "applemusic://track/1298835691",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Pp6zwwM-lN4"
     },
     {
       "year": 2001,
@@ -387,7 +419,9 @@
       "awards": [],
       "fun_fact": "Jimmy Eat World almost broke up before this song became their unexpected breakthrough. It's now an essential karaoke classic.",
       "fun_fact_de": "Jimmy Eat World löste sich fast auf, bevor dieser Song ihr unerwarteter Durchbruch wurde. Er ist jetzt ein Karaoke-Klassiker.",
-      "fun_fact_es": "Jimmy Eat World casi se separa antes de que esta canción fuera su éxito inesperado. Ahora es un clásico esencial del karaoke."
+      "fun_fact_es": "Jimmy Eat World casi se separa antes de que esta canción fuera su éxito inesperado. Ahora es un clásico esencial del karaoke.",
+      "uri_apple_music": "applemusic://track/1450030115",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=oKsxPW6i3pM"
     },
     {
       "year": 2004,
@@ -408,7 +442,9 @@
       "awards": [],
       "fun_fact": "Sugarcult captured the early 2000s California pop punk sound perfectly with this track about chasing dreams in LA.",
       "fun_fact_de": "Sugarcult fing den kalifornischen Pop-Punk-Sound der frühen 2000er perfekt mit diesem Track über Träume in LA ein.",
-      "fun_fact_es": "Sugarcult capturó perfectamente el sonido pop punk californiano de los 2000 con este tema sobre perseguir sueños en LA."
+      "fun_fact_es": "Sugarcult capturó perfectamente el sonido pop punk californiano de los 2000 con este tema sobre perseguir sueños en LA.",
+      "uri_apple_music": "",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=nwxGRKYr0-0"
     },
     {
       "year": 2007,
@@ -431,7 +467,9 @@
       "awards": [],
       "fun_fact": "Mayday Parade's breakthrough hit was written about a real road trip romance and became essential listening for emo kids everywhere.",
       "fun_fact_de": "Mayday Parades Durchbruchshit wurde über eine echte Road-Trip-Romanze geschrieben und wurde Pflichtprogramm für Emo-Kids überall.",
-      "fun_fact_es": "El éxito de Mayday Parade fue escrito sobre un romance real en viaje por carretera y se volvió esencial para fans emo en todas partes."
+      "fun_fact_es": "El éxito de Mayday Parade fue escrito sobre un romance real en viaje por carretera y se volvió esencial para fans emo en todas partes.",
+      "uri_apple_music": "applemusic://track/1440937443",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=DZaK37dheCM"
     },
     {
       "year": 2006,
@@ -454,7 +492,9 @@
       "awards": [],
       "fun_fact": "Boys Like Girls achieved major success with this anthem about breaking free, which became a defining song of the late 2000s pop punk scene.",
       "fun_fact_de": "Boys Like Girls erreichten großen Erfolg mit dieser Hymne übers Ausbrechen, die ein definierender Song der späten 2000er Pop-Punk-Szene wurde.",
-      "fun_fact_es": "Boys Like Girls logró gran éxito con este himno sobre liberarse, que se convirtió en una canción definitoria de la escena pop punk de finales de los 2000."
+      "fun_fact_es": "Boys Like Girls logró gran éxito con este himno sobre liberarse, que se convirtió en una canción definitoria de la escena pop punk de finales de los 2000.",
+      "uri_apple_music": "applemusic://track/276649797",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=JGPgxoIPY6Q"
     },
     {
       "year": 2013,
@@ -477,7 +517,9 @@
       "awards": [],
       "fun_fact": "Paramore's first single after the departure of founding members Josh and Zac Farro proved the band could thrive with their new lineup.",
       "fun_fact_de": "Paramores erste Single nach dem Ausstieg der Gründer Josh und Zac Farro bewies, dass die Band mit neuer Besetzung erfolgreich sein konnte.",
-      "fun_fact_es": "El primer sencillo de Paramore después de la partida de Josh y Zac Farro demostró que la banda podía prosperar con su nueva formación."
+      "fun_fact_es": "El primer sencillo de Paramore después de la partida de Josh y Zac Farro demostró que la banda podía prosperar con su nueva formación.",
+      "uri_apple_music": "applemusic://track/593148441",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=OblL026SvD4"
     },
     {
       "year": 1998,
@@ -500,7 +542,9 @@
       "awards": [],
       "fun_fact": "Featured prominently in South Park: Bigger, Longer & Uncut. The song's dark lyrics about suburban decay resonated with '90s youth.",
       "fun_fact_de": "Prominent in South Park: Der Film zu hören. Die dunklen Texte über suburbanen Verfall sprachen die Jugend der 90er an.",
-      "fun_fact_es": "Destacada en South Park: Más grande, más largo y sin cortes. Las letras oscuras sobre la decadencia suburbana resonaron con la juventud de los 90."
+      "fun_fact_es": "Destacada en South Park: Más grande, más largo y sin cortes. Las letras oscuras sobre la decadencia suburbana resonaron con la juventud de los 90.",
+      "uri_apple_music": "applemusic://track/1440881625",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=7iNbnineUCI"
     },
     {
       "year": 2006,
@@ -524,7 +568,9 @@
       "awards": [],
       "fun_fact": "Gerard Way wrote this after noticing adults at a mall seemed genuinely frightened of teenagers. The ironic anthem became a generation's battle cry.",
       "fun_fact_de": "Gerard Way schrieb dies, nachdem er bemerkte, dass Erwachsene in einem Einkaufszentrum Angst vor Teenagern hatten. Die ironische Hymne wurde zum Schlachtruf einer Generation.",
-      "fun_fact_es": "Gerard Way escribió esto después de notar que los adultos en un centro comercial parecían tener miedo de los adolescentes. El himno irónico se convirtió en grito de batalla de una generación."
+      "fun_fact_es": "Gerard Way escribió esto después de notar que los adultos en un centro comercial parecían tener miedo de los adolescentes. El himno irónico se convirtió en grito de batalla de una generación.",
+      "uri_apple_music": "applemusic://track/209388998",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=k6EQAOmJrbw"
     },
     {
       "year": 2002,
@@ -548,7 +594,9 @@
       "awards": [],
       "fun_fact": "Avril Lavigne wrote this song in just 15 minutes. A movie adaptation was announced in 2021 to tell the full story of the characters.",
       "fun_fact_de": "Avril Lavigne schrieb diesen Song in nur 15 Minuten. Eine Verfilmung wurde 2021 angekündigt, um die komplette Geschichte der Charaktere zu erzählen.",
-      "fun_fact_es": "Avril Lavigne escribió esta canción en solo 15 minutos. Se anunció una adaptación cinematográfica en 2021 para contar la historia completa de los personajes."
+      "fun_fact_es": "Avril Lavigne escribió esta canción en solo 15 minutos. Se anunció una adaptación cinematográfica en 2021 para contar la historia completa de los personajes.",
+      "uri_apple_music": "applemusic://track/315025826",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=TIy3n2b7V9k"
     },
     {
       "year": 2005,
@@ -572,7 +620,9 @@
       "awards": [],
       "fun_fact": "The song's cryptic, almost indecipherable lyrics became a meme. The title comes from a misheard lyric the band decided to keep.",
       "fun_fact_de": "Die kryptischen, fast unverständlichen Texte wurden zum Meme. Der Titel stammt von einem falsch verstandenen Text, den die Band beibehielt.",
-      "fun_fact_es": "Las letras crípticas y casi indescifrables se convirtieron en meme. El título proviene de una letra mal escuchada que la banda decidió conservar."
+      "fun_fact_es": "Las letras crípticas y casi indescifrables se convirtieron en meme. El título proviene de una letra mal escuchada que la banda decidió conservar.",
+      "uri_apple_music": "applemusic://track/1440725537",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=uhG-vLZrb-g"
     },
     {
       "year": 1999,
@@ -595,7 +645,9 @@
       "awards": [],
       "fun_fact": "Written in about 5 minutes and nearly cut from the album. The song about drunken regret became Lit's signature hit and a karaoke staple.",
       "fun_fact_de": "In etwa 5 Minuten geschrieben und fast vom Album gestrichen. Der Song über betrunkenes Bedauern wurde Lits Erkennungshit und Karaoke-Klassiker.",
-      "fun_fact_es": "Escrita en unos 5 minutos y casi eliminada del álbum. La canción sobre arrepentimiento de borracho se convirtió en el éxito insignia de Lit."
+      "fun_fact_es": "Escrita en unos 5 minutos y casi eliminada del álbum. La canción sobre arrepentimiento de borracho se convirtió en el éxito insignia de Lit.",
+      "uri_apple_music": "applemusic://track/438572311",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=sc5iTNVEOAg"
     },
     {
       "year": 2008,
@@ -618,7 +670,9 @@
       "awards": [],
       "fun_fact": "One of The Offspring's most successful songs of the 2000s, featuring their trademark blend of sarcastic lyrics and driving punk energy.",
       "fun_fact_de": "Einer der erfolgreichsten Songs von The Offspring der 2000er, mit ihrer typischen Mischung aus sarkastischen Texten und treibender Punk-Energie.",
-      "fun_fact_es": "Una de las canciones más exitosas de The Offspring de los 2000, con su mezcla característica de letras sarcásticas y energía punk."
+      "fun_fact_es": "Una de las canciones más exitosas de The Offspring de los 2000, con su mezcla característica de letras sarcásticas y energía punk.",
+      "uri_apple_music": "applemusic://track/1440887175",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=ql9-82oV2JE"
     },
     {
       "year": 2006,
@@ -642,7 +696,9 @@
       "awards": [],
       "fun_fact": "This rock opera masterpiece topped the UK charts and became the unofficial anthem of the emo subculture. The Patient character died on this date.",
       "fun_fact_de": "Dieses Rock-Oper-Meisterwerk erreichte Platz 1 der UK-Charts und wurde zur inoffiziellen Hymne der Emo-Subkultur.",
-      "fun_fact_es": "Esta obra maestra de ópera rock encabezó las listas del Reino Unido y se convirtió en el himno no oficial de la subcultura emo."
+      "fun_fact_es": "Esta obra maestra de ópera rock encabezó las listas del Reino Unido y se convirtió en el himno no oficial de la subcultura emo.",
+      "uri_apple_music": "applemusic://track/209388682",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=RRKJiM9Njr8"
     },
     {
       "year": 1994,
@@ -665,7 +721,9 @@
       "awards": [],
       "fun_fact": "From Dookie, which sold over 20 million copies and launched Green Day into superstardom. The video was shot in San Francisco.",
       "fun_fact_de": "Von Dookie, das über 20 Millionen Mal verkauft wurde und Green Day zu Superstars machte. Das Video wurde in San Francisco gedreht.",
-      "fun_fact_es": "De Dookie, que vendió más de 20 millones de copias y lanzó a Green Day al estrellato. El video se filmó en San Francisco."
+      "fun_fact_es": "De Dookie, que vendió más de 20 millones de copias y lanzó a Green Day al estrellato. El video se filmó en San Francisco.",
+      "uri_apple_music": "applemusic://track/1160082350",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=i8dh9gDzmz8"
     },
     {
       "year": 2005,
@@ -688,7 +746,9 @@
       "awards": [],
       "fun_fact": "The music video recreates an awkward high school prom with Fall Out Boy as the hired band. Director Alan Ferguson met his wife Solange there.",
       "fun_fact_de": "Das Musikvideo stellt einen peinlichen Highschool-Abschlussball mit Fall Out Boy als gemieteter Band nach.",
-      "fun_fact_es": "El video musical recrea un incómodo baile de graduación con Fall Out Boy como la banda contratada."
+      "fun_fact_es": "El video musical recrea un incómodo baile de graduación con Fall Out Boy como la banda contratada.",
+      "uri_apple_music": "applemusic://track/1440799368",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=C6MOKXm8x50"
     },
     {
       "year": 2005,
@@ -711,7 +771,9 @@
       "awards": [],
       "fun_fact": "Inspired by the PostSecret project where people share secrets anonymously on postcards. Real postcards from fans appear in the video.",
       "fun_fact_de": "Inspiriert vom PostSecret-Projekt, bei dem Menschen Geheimnisse anonym auf Postkarten teilen. Echte Fan-Postkarten erscheinen im Video.",
-      "fun_fact_es": "Inspirada en el proyecto PostSecret donde la gente comparte secretos anónimamente en postales. Postales reales de fans aparecen en el video."
+      "fun_fact_es": "Inspirada en el proyecto PostSecret donde la gente comparte secretos anónimamente en postales. Postales reales de fans aparecen en el video.",
+      "uri_apple_music": "applemusic://track/1440778267",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=gPDcwjJ8pLg"
     },
     {
       "year": 1998,
@@ -734,7 +796,9 @@
       "awards": [],
       "fun_fact": "This tongue-in-cheek song borrows its melody from The Beatles' 'Ob-La-Di, Ob-La-Da' and became a UK #2 hit.",
       "fun_fact_de": "Dieser augenzwinkernde Song leiht sich die Melodie von den Beatles' 'Ob-La-Di, Ob-La-Da' und wurde ein UK #2 Hit.",
-      "fun_fact_es": "Esta canción irónica toma prestada la melodía de 'Ob-La-Di, Ob-La-Da' de The Beatles y alcanzó el #2 en el Reino Unido."
+      "fun_fact_es": "Esta canción irónica toma prestada la melodía de 'Ob-La-Di, Ob-La-Da' de The Beatles y alcanzó el #2 en el Reino Unido.",
+      "uri_apple_music": "applemusic://track/1440881849",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=LH-i8IvYIcg"
     },
     {
       "year": 2004,
@@ -757,7 +821,9 @@
       "awards": [],
       "fun_fact": "A tribute to Gerard and Mikey Way's grandmother Elena, who passed away in 2003. The funeral-themed video is both beautiful and haunting.",
       "fun_fact_de": "Ein Tribut an Gerard und Mikey Ways Großmutter Elena, die 2003 verstarb. Das Beerdigungs-Video ist schön und eindringlich zugleich.",
-      "fun_fact_es": "Un tributo a la abuela de Gerard y Mikey Way, Elena, que falleció en 2003. El video con tema de funeral es hermoso y conmovedor."
+      "fun_fact_es": "Un tributo a la abuela de Gerard y Mikey Way, Elena, que falleció en 2003. El video con tema de funeral es hermoso y conmovedor.",
+      "uri_apple_music": "applemusic://track/1156311432",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=UCCyoocDxBA"
     },
     {
       "year": 2005,
@@ -781,7 +847,9 @@
       "awards": [],
       "fun_fact": "The circus-wedding video was filmed in just one day. The line 'closing the goddamn door' had to be censored on radio as 'closing a door'.",
       "fun_fact_de": "Das Zirkus-Hochzeitsvideo wurde an nur einem Tag gedreht. 'Closing the goddamn door' musste im Radio zensiert werden.",
-      "fun_fact_es": "El video de circo-boda se filmó en un solo día. La línea 'closing the goddamn door' tuvo que ser censurada en la radio."
+      "fun_fact_es": "El video de circo-boda se filmó en un solo día. La línea 'closing the goddamn door' tuvo que ser censurada en la radio.",
+      "uri_apple_music": "applemusic://track/80456409",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=vc6vs-l5dkc"
     },
     {
       "year": 2003,
@@ -804,7 +872,9 @@
       "awards": [],
       "fun_fact": "Supermodel Rachel Hunter played Stacy's Mom. The song parodies teenage crushes and became an unexpected pop culture phenomenon.",
       "fun_fact_de": "Supermodel Rachel Hunter spielte Stacys Mutter. Der Song parodiert Teenager-Schwärmereien und wurde ein unerwartetes Popkultur-Phänomen.",
-      "fun_fact_es": "La supermodelo Rachel Hunter interpretó a la mamá de Stacy. La canción parodia los enamoramientos adolescentes y se convirtió en un fenómeno inesperado."
+      "fun_fact_es": "La supermodelo Rachel Hunter interpretó a la mamá de Stacy. La canción parodia los enamoramientos adolescentes y se convirtió en un fenómeno inesperado.",
+      "uri_apple_music": "applemusic://track/712721787",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=dZLfasMPOU4"
     },
     {
       "year": 2004,
@@ -825,7 +895,9 @@
       "awards": [],
       "fun_fact": "Written for the movie Eurotrip, where Matt Damon performs it in a cameo as a punk rocker. It became the movie's most memorable scene.",
       "fun_fact_de": "Für den Film Eurotrip geschrieben, wo Matt Damon es in einem Cameo als Punk-Rocker performt. Es wurde die denkwürdigste Szene des Films.",
-      "fun_fact_es": "Escrita para la película Eurotrip, donde Matt Damon la interpreta en un cameo como punk rocker. Se convirtió en la escena más memorable de la película."
+      "fun_fact_es": "Escrita para la película Eurotrip, donde Matt Damon la interpreta en un cameo como punk rocker. Se convirtió en la escena más memorable de la película.",
+      "uri_apple_music": "applemusic://track/138625028",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=lcEkS9tcIjg"
     },
     {
       "year": 2001,
@@ -848,7 +920,9 @@
       "awards": [],
       "fun_fact": "From the album Take Off Your Pants and Jacket - a crude pun on self-pleasure. The video parodies typical first date anxiety.",
       "fun_fact_de": "Vom Album Take Off Your Pants and Jacket - ein derber Wortwitz. Das Video parodiert typische Nervosität beim ersten Date.",
-      "fun_fact_es": "Del álbum Take Off Your Pants and Jacket - un juego de palabras vulgar. El video parodia la ansiedad típica de la primera cita."
+      "fun_fact_es": "Del álbum Take Off Your Pants and Jacket - un juego de palabras vulgar. El video parodia la ansiedad típica de la primera cita.",
+      "uri_apple_music": "applemusic://track/1440844995",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=vVy9Lgpg1m8"
     },
     {
       "year": 2006,
@@ -872,7 +946,9 @@
       "awards": [],
       "fun_fact": "The epic closer to The Black Parade album represents the Patient's final moments. It's one of MCR's most emotionally powerful songs.",
       "fun_fact_de": "Der epische Abschluss des Black Parade Albums repräsentiert die letzten Momente des Patienten. Einer der emotional kraftvollsten MCR-Songs.",
-      "fun_fact_es": "El épico cierre del álbum The Black Parade representa los momentos finales del Paciente. Una de las canciones más emotivas de MCR."
+      "fun_fact_es": "El épico cierre del álbum The Black Parade representa los momentos finales del Paciente. Una de las canciones más emotivas de MCR.",
+      "uri_apple_music": "applemusic://track/209389069",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=8bbTtPL1jRs"
     },
     {
       "year": 2002,
@@ -896,7 +972,9 @@
       "awards": [],
       "fun_fact": "Good Charlotte's breakthrough hit made them MTV staples and defined the early 2000s mall punk aesthetic. It's an anthem for misfits everywhere.",
       "fun_fact_de": "Good Charlottes Durchbruchshit machte sie zu MTV-Stars und definierte die Mall-Punk-Ästhetik der frühen 2000er.",
-      "fun_fact_es": "El éxito de Good Charlotte los convirtió en estrellas de MTV y definió la estética mall punk de principios de los 2000."
+      "fun_fact_es": "El éxito de Good Charlotte los convirtió en estrellas de MTV y definió la estética mall punk de principios de los 2000.",
+      "uri_apple_music": "applemusic://track/288051950",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=desJKYvdq9A"
     },
     {
       "year": 1994,
@@ -919,7 +997,9 @@
       "awards": [],
       "fun_fact": "The Offspring's first mainstream hit helped Smash become the best-selling independent album ever at 11+ million copies.",
       "fun_fact_de": "The Offsprings erster Mainstream-Hit half Smash, mit 11+ Millionen Kopien das meistverkaufte Independent-Album aller Zeiten zu werden.",
-      "fun_fact_es": "El primer éxito mainstream de The Offspring ayudó a Smash a convertirse en el álbum independiente más vendido con más de 11 millones de copias."
+      "fun_fact_es": "El primer éxito mainstream de The Offspring ayudó a Smash a convertirse en el álbum independiente más vendido con más de 11 millones de copias.",
+      "uri_apple_music": "",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=1jOk8dk-qaU"
     },
     {
       "year": 2020,
@@ -942,7 +1022,9 @@
       "awards": [],
       "fun_fact": "MGK's pop punk era brought the genre back to mainstream charts. This collab with blackbear captures post-breakup messiness perfectly.",
       "fun_fact_de": "MGKs Pop-Punk-Ära brachte das Genre zurück in die Mainstream-Charts. Diese Collab mit blackbear fängt Post-Trennungs-Chaos perfekt ein.",
-      "fun_fact_es": "La era pop punk de MGK trajo el género de vuelta a las listas mainstream. Esta colaboración con blackbear captura perfectamente el caos post-ruptura."
+      "fun_fact_es": "La era pop punk de MGK trajo el género de vuelta a las listas mainstream. Esta colaboración con blackbear captura perfectamente el caos post-ruptura.",
+      "uri_apple_music": "applemusic://track/1526412272",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=umfi3r2tk6Q"
     },
     {
       "year": 2003,
@@ -965,7 +1047,9 @@
       "awards": [],
       "fun_fact": "Written about Ocean Avenue in Jacksonville, Florida where singer Ryan Key grew up. The violin riff makes it instantly recognizable.",
       "fun_fact_de": "Geschrieben über die Ocean Avenue in Jacksonville, Florida, wo Sänger Ryan Key aufwuchs. Das Violinen-Riff macht es sofort erkennbar.",
-      "fun_fact_es": "Escrita sobre Ocean Avenue en Jacksonville, Florida, donde creció el cantante Ryan Key. El riff de violín la hace instantáneamente reconocible."
+      "fun_fact_es": "Escrita sobre Ocean Avenue en Jacksonville, Florida, donde creció el cantante Ryan Key. El riff de violín la hace instantáneamente reconocible.",
+      "uri_apple_music": "applemusic://track/725822641",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=X9fLbfzCqWw"
     },
     {
       "year": 2009,
@@ -988,7 +1072,9 @@
       "awards": [],
       "fun_fact": "Released after the Farro brothers left Paramore, this song addresses the band drama directly with raw, honest lyrics about betrayal.",
       "fun_fact_de": "Nach dem Ausstieg der Farro-Brüder veröffentlicht, spricht dieser Song das Band-Drama direkt mit rohen, ehrlichen Texten über Verrat an.",
-      "fun_fact_es": "Lanzada después de que los hermanos Farro dejaran Paramore, esta canción aborda el drama de la banda directamente con letras crudas sobre traición."
+      "fun_fact_es": "Lanzada después de que los hermanos Farro dejaran Paramore, esta canción aborda el drama de la banda directamente con letras crudas sobre traición.",
+      "uri_apple_music": "applemusic://track/604800415",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=OH9A6tn_P6g"
     },
     {
       "year": 2014,
@@ -1012,7 +1098,9 @@
       "awards": [],
       "fun_fact": "5 Seconds of Summer's debut single topped the UK charts. The Australian band brought pop punk to a new generation of fans in 2014.",
       "fun_fact_de": "Die Debütsingle von 5 Seconds of Summer erreichte Platz 1 der UK-Charts. Die australische Band brachte Pop-Punk 2014 zu einer neuen Fan-Generation.",
-      "fun_fact_es": "El sencillo debut de 5 Seconds of Summer encabezó las listas del Reino Unido. La banda australiana trajo el pop punk a una nueva generación en 2014."
+      "fun_fact_es": "El sencillo debut de 5 Seconds of Summer encabezó las listas del Reino Unido. La banda australiana trajo el pop punk a una nueva generación en 2014.",
+      "uri_apple_music": "applemusic://track/1440857725",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=FfWg68IyoAg"
     },
     {
       "year": 1976,
@@ -1033,7 +1121,9 @@
       "awards": [],
       "fun_fact": "One of punk rock's defining songs, its 'Hey! Ho! Let's go!' chant is iconic and has been used at sporting events worldwide for decades.",
       "fun_fact_de": "Einer der prägenden Punk-Rock-Songs, sein 'Hey! Ho! Let's go!' Ruf ist ikonisch und wird seit Jahrzehnten bei Sportevents weltweit verwendet.",
-      "fun_fact_es": "Una de las canciones definitorias del punk rock, su '¡Hey! ¡Ho! Let's go!' es icónico y se usa en eventos deportivos mundiales desde hace décadas."
+      "fun_fact_es": "Una de las canciones definitorias del punk rock, su '¡Hey! ¡Ho! Let's go!' es icónico y se usa en eventos deportivos mundiales desde hace décadas.",
+      "uri_apple_music": "applemusic://track/1127410268",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=NQDPx_k66w4"
     },
     {
       "year": 2019,
@@ -1056,7 +1146,9 @@
       "awards": [],
       "fun_fact": "This collaboration united MGK, YUNGBLUD, and legendary drummer Travis Barker, signaling the 2019 pop punk revival.",
       "fun_fact_de": "Diese Zusammenarbeit vereinte MGK, YUNGBLUD und den legendären Schlagzeuger Travis Barker und signalisierte das Pop-Punk-Revival 2019.",
-      "fun_fact_es": "Esta colaboración unió a MGK, YUNGBLUD y el legendario baterista Travis Barker, señalando el renacimiento del pop punk en 2019."
+      "fun_fact_es": "Esta colaboración unió a MGK, YUNGBLUD y el legendario baterista Travis Barker, señalando el renacimiento del pop punk en 2019.",
+      "uri_apple_music": "applemusic://track/1471002397",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=zozdDYOateQ"
     },
     {
       "year": 2004,
@@ -1079,7 +1171,9 @@
       "awards": [],
       "fun_fact": "Simple Plan's emotional ballad about feeling misunderstood became an anthem for teenagers worldwide and their biggest international hit.",
       "fun_fact_de": "Simple Plans emotionale Ballade über das Gefühl, missverstanden zu werden, wurde weltweit zur Hymne für Teenager und ihr größter internationaler Hit.",
-      "fun_fact_es": "La balada emocional de Simple Plan sobre sentirse incomprendido se convirtió en himno para adolescentes en todo el mundo y su mayor éxito internacional."
+      "fun_fact_es": "La balada emocional de Simple Plan sobre sentirse incomprendido se convirtió en himno para adolescentes en todo el mundo y su mayor éxito internacional.",
+      "uri_apple_music": "applemusic://track/27295873",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=r0U0AlLVqpk"
     },
     {
       "year": 2007,
@@ -1102,7 +1196,9 @@
       "awards": [],
       "fun_fact": "Hayley Williams wrote this about her own relationship experiences. The song showcases Paramore's knack for catchy, relatable pop punk.",
       "fun_fact_de": "Hayley Williams schrieb dies über ihre eigenen Beziehungserfahrungen. Der Song zeigt Paramores Talent für eingängigen, nachvollziehbaren Pop-Punk.",
-      "fun_fact_es": "Hayley Williams escribió esto sobre sus propias experiencias en relaciones. La canción muestra el talento de Paramore para el pop punk pegadizo y relatable."
+      "fun_fact_es": "Hayley Williams escribió esto sobre sus propias experiencias en relaciones. La canción muestra el talento de Paramore para el pop punk pegadizo y relatable.",
+      "uri_apple_music": "applemusic://track/604804761",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=1kz6hNDlEEg"
     },
     {
       "year": 2004,
@@ -1125,7 +1221,9 @@
       "awards": [],
       "fun_fact": "Originally recorded by SR-71, Bowling For Soup's cover became way more popular. The song nostalgically looks at '80s pop culture.",
       "fun_fact_de": "Ursprünglich von SR-71 aufgenommen, wurde Bowling For Soups Cover viel populärer. Der Song blickt nostalgisch auf die 80er-Popkultur.",
-      "fun_fact_es": "Originalmente grabada por SR-71, la versión de Bowling For Soup se hizo mucho más popular. La canción mira nostálgicamente la cultura pop de los 80."
+      "fun_fact_es": "Originalmente grabada por SR-71, la versión de Bowling For Soup se hizo mucho más popular. La canción mira nostálgicamente la cultura pop de los 80.",
+      "uri_apple_music": "applemusic://track/271371090",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=K38xNqZvBJI"
     },
     {
       "year": 2001,
@@ -1148,7 +1246,9 @@
       "awards": [],
       "fun_fact": "This song perfectly captures pop punk's essence - summer, concerts, and young love. It's a nostalgic tribute to the live music experience.",
       "fun_fact_de": "Dieser Song fängt die Essenz von Pop-Punk perfekt ein - Sommer, Konzerte und junge Liebe. Eine nostalgische Hommage an Live-Musik.",
-      "fun_fact_es": "Esta canción captura perfectamente la esencia del pop punk - verano, conciertos y amor joven. Un tributo nostálgico a la experiencia de música en vivo."
+      "fun_fact_es": "Esta canción captura perfectamente la esencia del pop punk - verano, conciertos y amor joven. Un tributo nostálgico a la experiencia de música en vivo.",
+      "uri_apple_music": "applemusic://track/1471266349",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=z7hhDINyBP0"
     },
     {
       "year": 2020,
@@ -1171,7 +1271,9 @@
       "awards": [],
       "fun_fact": "MGK and Halsey created this bitter breakup anthem. It helped cement MGK's successful transition from rap to pop punk.",
       "fun_fact_de": "MGK und Halsey schufen diese bittere Trennungshymne. Sie half, MGKs erfolgreichen Übergang von Rap zu Pop-Punk zu festigen.",
-      "fun_fact_es": "MGK y Halsey crearon este amargo himno de ruptura. Ayudó a cimentar la exitosa transición de MGK del rap al pop punk."
+      "fun_fact_es": "MGK y Halsey crearon este amargo himno de ruptura. Ayudó a cimentar la exitosa transición de MGK del rap al pop punk.",
+      "uri_apple_music": "applemusic://track/1355149512",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=H2M7zo8ZziE"
     },
     {
       "year": 2006,
@@ -1194,7 +1296,9 @@
       "awards": [],
       "fun_fact": "Debuted at #1 on iTunes and helped AFI cross over from hardcore punk to mainstream alternative rock. The title is a play on 'Miss Murderer'.",
       "fun_fact_de": "Debütierte auf Platz 1 bei iTunes und half AFI beim Übergang von Hardcore-Punk zu Mainstream-Alternative-Rock.",
-      "fun_fact_es": "Debutó en el #1 de iTunes y ayudó a AFI a pasar del hardcore punk al rock alternativo mainstream."
+      "fun_fact_es": "Debutó en el #1 de iTunes y ayudó a AFI a pasar del hardcore punk al rock alternativo mainstream.",
+      "uri_apple_music": "applemusic://track/197890727",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Qt6Lkgs0kiU"
     },
     {
       "year": 2007,
@@ -1217,7 +1321,9 @@
       "awards": [],
       "fun_fact": "The triple 'crush' in the title matches the song's theme of obsessive attraction. One of Paramore's heaviest tracks from their Riot! era.",
       "fun_fact_de": "Das dreifache 'crush' im Titel passt zum Songthema obsessiver Anziehung. Einer von Paramores härtesten Tracks der Riot!-Ära.",
-      "fun_fact_es": "El triple 'crush' en el título coincide con el tema de atracción obsesiva de la canción. Una de las canciones más pesadas de Paramore de su era Riot!"
+      "fun_fact_es": "El triple 'crush' en el título coincide con el tema de atracción obsesiva de la canción. Una de las canciones más pesadas de Paramore de su era Riot!",
+      "uri_apple_music": "applemusic://track/315611301",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=9IclmVdWNbI"
     },
     {
       "year": 2020,
@@ -1240,7 +1346,9 @@
       "awards": [],
       "fun_fact": "All Time Low's collaboration with blackbear became their highest-charting single ever, proving the band's lasting relevance 15 years into their career.",
       "fun_fact_de": "All Time Lows Collaboration mit blackbear wurde ihre höchstplatzierte Single überhaupt und bewies die anhaltende Relevanz der Band nach 15 Jahren Karriere.",
-      "fun_fact_es": "La colaboración de All Time Low con blackbear se convirtió en su sencillo mejor posicionado, demostrando la relevancia continua de la banda 15 años después."
+      "fun_fact_es": "La colaboración de All Time Low con blackbear se convirtió en su sencillo mejor posicionado, demostrando la relevancia continua de la banda 15 años después.",
+      "uri_apple_music": "applemusic://track/1440946662",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=S9z3gv3MWaM"
     },
     {
       "year": 2002,
@@ -1264,7 +1372,9 @@
       "awards": [],
       "fun_fact": "Good Charlotte's satirical take on celebrity culture became their commercial breakthrough, driven by heavy MTV rotation.",
       "fun_fact_de": "Good Charlottes satirischer Blick auf Promi-Kultur wurde ihr kommerzieller Durchbruch, angetrieben durch MTV-Heavy-Rotation.",
-      "fun_fact_es": "La visión satírica de Good Charlotte sobre la cultura de celebridades fue su éxito comercial, impulsado por la rotación constante en MTV."
+      "fun_fact_es": "La visión satírica de Good Charlotte sobre la cultura de celebridades fue su éxito comercial, impulsado por la rotación constante en MTV.",
+      "uri_apple_music": "applemusic://track/1440665386",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=7pE8ReA5cn4"
     },
     {
       "year": 2020,
@@ -1287,7 +1397,9 @@
       "awards": [],
       "fun_fact": "MGK's first single from Tickets to My Downfall, produced entirely by Travis Barker. It marked his official pivot to pop punk.",
       "fun_fact_de": "MGKs erste Single von Tickets to My Downfall, komplett von Travis Barker produziert. Sie markierte seinen offiziellen Wechsel zu Pop-Punk.",
-      "fun_fact_es": "El primer sencillo de MGK de Tickets to My Downfall, producido enteramente por Travis Barker. Marcó su giro oficial al pop punk."
+      "fun_fact_es": "El primer sencillo de MGK de Tickets to My Downfall, producido enteramente por Travis Barker. Marcó su giro oficial al pop punk.",
+      "uri_apple_music": "applemusic://track/1604367029",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=ciqUEV9F0OY"
     },
     {
       "year": 2011,
@@ -1310,7 +1422,9 @@
       "awards": [],
       "fun_fact": "Panic!'s return after Ryan Ross and Jon Walker left. The video's murder mystery theme continues Brendon Urie's love of theatrical concepts.",
       "fun_fact_de": "Panic!s Rückkehr nach dem Ausstieg von Ryan Ross und Jon Walker. Das Mordmysterium-Thema des Videos setzt Brendon Uries Liebe zu theatralischen Konzepten fort.",
-      "fun_fact_es": "El regreso de Panic! después de que Ryan Ross y Jon Walker se fueron. El tema de misterio de asesinato del video continúa el amor de Brendon Urie por conceptos teatrales."
+      "fun_fact_es": "El regreso de Panic! después de que Ryan Ross y Jon Walker se fueron. El tema de misterio de asesinato del video continúa el amor de Brendon Urie por conceptos teatrales.",
+      "uri_apple_music": "applemusic://track/286224439",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=3M6ZvNmwGxs"
     },
     {
       "year": 2001,
@@ -1333,7 +1447,9 @@
       "awards": [],
       "fun_fact": "A sequel to blink-182's earlier song 'Anthem'. It became a fan favorite for its cathartic energy and rebellious message.",
       "fun_fact_de": "Eine Fortsetzung von blink-182s früherem Song 'Anthem'. Er wurde wegen seiner kathartischen Energie und rebellischen Botschaft zum Fan-Favoriten.",
-      "fun_fact_es": "Una secuela de la canción anterior de blink-182 'Anthem'. Se convirtió en favorita de los fans por su energía catártica y mensaje rebelde."
+      "fun_fact_es": "Una secuela de la canción anterior de blink-182 'Anthem'. Se convirtió en favorita de los fans por su energía catártica y mensaje rebelde.",
+      "uri_apple_music": "applemusic://track/288051977",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=3FTS2tdmyYM"
     },
     {
       "year": 1978,
@@ -1354,7 +1470,9 @@
       "awards": [],
       "fun_fact": "Joey Ramone wrote this while sick in a London hotel, waiting for the next show. It's one of punk's most covered songs ever.",
       "fun_fact_de": "Joey Ramone schrieb dies krank in einem Londoner Hotel, wartend auf die nächste Show. Es ist einer der meistgecoverten Punk-Songs überhaupt.",
-      "fun_fact_es": "Joey Ramone escribió esto mientras estaba enfermo en un hotel de Londres, esperando el siguiente show. Es una de las canciones punk más versionadas."
+      "fun_fact_es": "Joey Ramone escribió esto mientras estaba enfermo en un hotel de Londres, esperando el siguiente show. Es una de las canciones punk más versionadas.",
+      "uri_apple_music": "applemusic://track/1440778610",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=XleOkGsYgO8"
     },
     {
       "year": 2003,
@@ -1377,7 +1495,9 @@
       "awards": [],
       "fun_fact": "Yellowcard's emotional power ballad showcases Sean Mackin's violin skills and became a staple of mid-2000s alternative radio.",
       "fun_fact_de": "Yellowcards emotionale Power-Ballade zeigt Sean Mackins Violin-Können und wurde ein Klassiker des Alternative-Radio der mittleren 2000er.",
-      "fun_fact_es": "La emotiva balada poderosa de Yellowcard muestra las habilidades de violín de Sean Mackin y se convirtió en clásico de la radio alternativa de mediados de los 2000."
+      "fun_fact_es": "La emotiva balada poderosa de Yellowcard muestra las habilidades de violín de Sean Mackin y se convirtió en clásico de la radio alternativa de mediados de los 2000.",
+      "uri_apple_music": "applemusic://track/1440921233",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=emGri7i8Y2Y"
     },
     {
       "year": 2011,
@@ -1400,7 +1520,9 @@
       "awards": [],
       "fun_fact": "Simple Plan's duet with Natasha Bedingfield about long-distance relationships resonated with fans worldwide dealing with the same struggles.",
       "fun_fact_de": "Simple Plans Duett mit Natasha Bedingfield über Fernbeziehungen sprach Fans weltweit an, die mit den gleichen Problemen kämpften.",
-      "fun_fact_es": "El dueto de Simple Plan con Natasha Bedingfield sobre relaciones a distancia resonó con fans de todo el mundo que enfrentaban los mismos problemas."
+      "fun_fact_es": "El dueto de Simple Plan con Natasha Bedingfield sobre relaciones a distancia resonó con fans de todo el mundo que enfrentaban los mismos problemas.",
+      "uri_apple_music": "applemusic://track/724535476",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Z_63ZZRLylE"
     },
     {
       "year": 2003,
@@ -1423,7 +1545,9 @@
       "awards": [],
       "fun_fact": "Fall Out Boy's first charting single, though it gained most popularity after their later success. The 'Grand Theft Auto' pun in the title was intentional.",
       "fun_fact_de": "Fall Out Boys erste Chart-Single, obwohl sie erst nach späterem Erfolg richtig populär wurde. Das 'Grand Theft Auto'-Wortspiel im Titel war beabsichtigt.",
-      "fun_fact_es": "El primer sencillo de Fall Out Boy en las listas, aunque ganó popularidad después de su éxito posterior. El juego de palabras con 'Grand Theft Auto' fue intencional."
+      "fun_fact_es": "El primer sencillo de Fall Out Boy en las listas, aunque ganó popularidad después de su éxito posterior. El juego de palabras con 'Grand Theft Auto' fue intencional.",
+      "uri_apple_music": "applemusic://track/1295797514",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=cDBlqu6KF4k"
     },
     {
       "year": 2002,
@@ -1446,7 +1570,9 @@
       "awards": [],
       "fun_fact": "Sum 41's aggressive track about struggling with inner demons. Deryck Whibley later opened up about battles with alcoholism the song hinted at.",
       "fun_fact_de": "Sum 41s aggressiver Track über den Kampf mit inneren Dämonen. Deryck Whibley sprach später offen über Alkoholprobleme, die der Song andeutete.",
-      "fun_fact_es": "La agresiva canción de Sum 41 sobre luchar con demonios internos. Deryck Whibley habló después sobre batallas con el alcoholismo que la canción insinuaba."
+      "fun_fact_es": "La agresiva canción de Sum 41 sobre luchar con demonios internos. Deryck Whibley habló después sobre batallas con el alcoholismo que la canción insinuaba.",
+      "uri_apple_music": "applemusic://track/1445881688",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Alh6iIvVN9o"
     },
     {
       "year": 2005,
@@ -1469,7 +1595,9 @@
       "awards": [],
       "fun_fact": "Story of the Year's biggest hit blended post-hardcore intensity with pop punk accessibility. Featured in numerous TV shows and video games.",
       "fun_fact_de": "Story of the Years größter Hit vermischte Post-Hardcore-Intensität mit Pop-Punk-Zugänglichkeit. In zahlreichen TV-Shows und Videospielen zu hören.",
-      "fun_fact_es": "El mayor éxito de Story of the Year mezcló la intensidad post-hardcore con la accesibilidad del pop punk. Presente en numerosos programas de TV y videojuegos."
+      "fun_fact_es": "El mayor éxito de Story of the Year mezcló la intensidad post-hardcore con la accesibilidad del pop punk. Presente en numerosos programas de TV y videojuegos.",
+      "uri_apple_music": "applemusic://track/684954529",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=tGE381tbQa8"
     },
     {
       "year": 2009,
@@ -1492,7 +1620,9 @@
       "awards": [],
       "fun_fact": "Green Day's first single from 21st Century Breakdown continues their political commentary tradition. It features crowd participation live.",
       "fun_fact_de": "Green Days erste Single von 21st Century Breakdown setzt ihre Tradition politischer Kommentare fort. Live mit Publikumsbeteiligung.",
-      "fun_fact_es": "El primer sencillo de Green Day de 21st Century Breakdown continúa su tradición de comentario político. Presenta participación del público en vivo."
+      "fun_fact_es": "El primer sencillo de Green Day de 21st Century Breakdown continúa su tradición de comentario político. Presenta participación del público en vivo.",
+      "uri_apple_music": "applemusic://track/1526623210",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=OiCit3G4YRU"
     },
     {
       "year": 2002,
@@ -1515,7 +1645,9 @@
       "awards": [],
       "fun_fact": "Features Mark Hoppus of blink-182 in an unexpected cameo. The song about unrequited love became a staple of early 2000s pop punk.",
       "fun_fact_de": "Mit überraschendem Cameo von Mark Hoppus von blink-182. Der Song über unerwiderte Liebe wurde ein Klassiker des frühen 2000er Pop-Punk.",
-      "fun_fact_es": "Presenta un cameo inesperado de Mark Hoppus de blink-182. La canción sobre amor no correspondido se convirtió en esencial del pop punk de los 2000."
+      "fun_fact_es": "Presenta un cameo inesperado de Mark Hoppus de blink-182. La canción sobre amor no correspondido se convirtió en esencial del pop punk de los 2000.",
+      "uri_apple_music": "applemusic://track/1440797579",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=1Yzu-4kJg6g"
     },
     {
       "year": 2009,
@@ -1538,7 +1670,9 @@
       "awards": [],
       "fun_fact": "Fall Out Boy's defiant anthem from Folie à Deux. The repetitive chorus is intentionally annoying as a commentary on pop music formulas.",
       "fun_fact_de": "Fall Out Boys trotzige Hymne von Folie à Deux. Der repetitive Refrain ist absichtlich nervig als Kommentar zu Pop-Musik-Formeln.",
-      "fun_fact_es": "El himno desafiante de Fall Out Boy de Folie à Deux. El coro repetitivo es intencionalmente molesto como comentario sobre fórmulas de música pop."
+      "fun_fact_es": "El himno desafiante de Fall Out Boy de Folie à Deux. El coro repetitivo es intencionalmente molesto como comentario sobre fórmulas de música pop.",
+      "uri_apple_music": "applemusic://track/1440731463",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=EZj2OMPWEZc"
     },
     {
       "year": 2005,
@@ -1559,7 +1693,9 @@
       "awards": [],
       "fun_fact": "A fan favorite from A Fever You Can't Sweat Out. The theatrical vaudeville-influenced track showcases early Panic!'s unique style.",
       "fun_fact_de": "Ein Fan-Favorit von A Fever You Can't Sweat Out. Der theatralische, Vaudeville-beeinflusste Track zeigt den einzigartigen Stil des frühen Panic!",
-      "fun_fact_es": "Un favorito de los fans de A Fever You Can't Sweat Out. La teatral canción influenciada por el vaudeville muestra el estilo único del Panic! temprano."
+      "fun_fact_es": "Un favorito de los fans de A Fever You Can't Sweat Out. La teatral canción influenciada por el vaudeville muestra el estilo único del Panic! temprano.",
+      "uri_apple_music": "applemusic://track/604804767",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=p1Gr_Bg2Eag"
     },
     {
       "year": 2003,
@@ -1580,7 +1716,9 @@
       "awards": [],
       "fun_fact": "Sugarcult's nostalgic track became a hidden gem of the 2000s pop punk scene, beloved for its honest lyrics about growing up.",
       "fun_fact_de": "Sugarcults nostalgischer Track wurde ein Geheimtipp der 2000er Pop-Punk-Szene, geliebt für seine ehrlichen Texte übers Erwachsenwerden.",
-      "fun_fact_es": "La nostálgica canción de Sugarcult se convirtió en una joya oculta de la escena pop punk de los 2000, amada por sus letras honestas sobre crecer."
+      "fun_fact_es": "La nostálgica canción de Sugarcult se convirtió en una joya oculta de la escena pop punk de los 2000, amada por sus letras honestas sobre crecer.",
+      "uri_apple_music": "applemusic://track/1542954689",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=wc-hOtVgCso"
     },
     {
       "year": 2003,
@@ -1599,7 +1737,9 @@
       "awards": [],
       "fun_fact": "The Ataris' cover of Don Henley's classic brought an '80s song to a new generation. The lyrics were updated to reference 'Black Flag sticker' instead of 'Deadhead sticker'.",
       "fun_fact_de": "Das Ataris-Cover von Don Henleys Klassiker brachte einen 80er-Song zu einer neuen Generation. Die Texte wurden aktualisiert mit 'Black Flag sticker' statt 'Deadhead sticker'.",
-      "fun_fact_es": "La versión de The Ataris del clásico de Don Henley trajo una canción de los 80 a una nueva generación. Las letras fueron actualizadas con 'Black Flag sticker' en lugar de 'Deadhead sticker'."
+      "fun_fact_es": "La versión de The Ataris del clásico de Don Henley trajo una canción de los 80 a una nueva generación. Las letras fueron actualizadas con 'Black Flag sticker' en lugar de 'Deadhead sticker'.",
+      "uri_apple_music": "applemusic://track/5548609",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=lovnt5LxMGg"
     },
     {
       "year": 2002,
@@ -1622,7 +1762,9 @@
       "awards": [],
       "fun_fact": "Bowling For Soup's Grammy-nominated hit about crushing on an alternative girl. The music video lovingly parodies MTV dating shows.",
       "fun_fact_de": "Bowling For Soups Grammy-nominierter Hit über eine Schwärmerei für ein alternatives Mädchen. Das Video parodiert liebevoll MTV-Dating-Shows.",
-      "fun_fact_es": "El éxito nominado al Grammy de Bowling For Soup sobre enamorarse de una chica alternativa. El video parodia con cariño los shows de citas de MTV."
+      "fun_fact_es": "El éxito nominado al Grammy de Bowling For Soup sobre enamorarse de una chica alternativa. El video parodia con cariño los shows de citas de MTV.",
+      "uri_apple_music": "applemusic://track/725822708",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=RJLkcPhVi9w"
     },
     {
       "year": 2021,
@@ -1643,7 +1785,9 @@
       "awards": [],
       "fun_fact": "Avril Lavigne's return to pop punk, produced by Travis Barker and featuring her signature attitude that launched her career 20 years earlier.",
       "fun_fact_de": "Avril Lavignes Rückkehr zum Pop-Punk, produziert von Travis Barker, mit ihrer charakteristischen Attitüde, die ihre Karriere 20 Jahre zuvor startete.",
-      "fun_fact_es": "El regreso de Avril Lavigne al pop punk, producido por Travis Barker y con su actitud característica que lanzó su carrera 20 años antes."
+      "fun_fact_es": "El regreso de Avril Lavigne al pop punk, producido por Travis Barker y con su actitud característica que lanzó su carrera 20 años antes.",
+      "uri_apple_music": "applemusic://track/187457542",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=rISYCquFeI8"
     },
     {
       "year": 2013,
@@ -1666,7 +1810,9 @@
       "awards": [],
       "fun_fact": "Written about Spencer Smith's battle with addiction. The piano version is equally powerful and shows Brendon Urie's vocal range.",
       "fun_fact_de": "Geschrieben über Spencer Smiths Kampf mit Sucht. Die Klavierversion ist ebenso kraftvoll und zeigt Brendon Uries Stimmumfang.",
-      "fun_fact_es": "Escrita sobre la batalla de Spencer Smith contra la adicción. La versión de piano es igualmente poderosa y muestra el rango vocal de Brendon Urie."
+      "fun_fact_es": "Escrita sobre la batalla de Spencer Smith contra la adicción. La versión de piano es igualmente poderosa y muestra el rango vocal de Brendon Urie.",
+      "uri_apple_music": "applemusic://track/1440852127",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=e8X3ACToii0"
     },
     {
       "year": 2016,
@@ -1689,7 +1835,9 @@
       "awards": [],
       "fun_fact": "Green Day's reflective track about surviving hard times. It marked a more mature sound from the band after 30 years together.",
       "fun_fact_de": "Green Days reflektierender Track übers Überleben schwerer Zeiten. Er markierte einen reiferen Sound der Band nach 30 Jahren zusammen.",
-      "fun_fact_es": "La canción reflexiva de Green Day sobre sobrevivir tiempos difíciles. Marcó un sonido más maduro de la banda después de 30 años juntos."
+      "fun_fact_es": "La canción reflexiva de Green Day sobre sobrevivir tiempos difíciles. Marcó un sonido más maduro de la banda después de 30 años juntos.",
+      "uri_apple_music": "applemusic://track/254825686",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=XvziPPpryv0"
     },
     {
       "year": 2020,
@@ -1712,7 +1860,9 @@
       "awards": [],
       "fun_fact": "YUNGBLUD and MGK's collaboration showcases the modern pop punk revival. Both artists cite blink-182 as major influences.",
       "fun_fact_de": "YUNGBLUDs und MGKs Collaboration zeigt das moderne Pop-Punk-Revival. Beide Künstler nennen blink-182 als große Einflüsse.",
-      "fun_fact_es": "La colaboración de YUNGBLUD y MGK muestra el renacimiento moderno del pop punk. Ambos artistas citan a blink-182 como grandes influencias."
+      "fun_fact_es": "La colaboración de YUNGBLUD y MGK muestra el renacimiento moderno del pop punk. Ambos artistas citan a blink-182 como grandes influencias.",
+      "uri_apple_music": "applemusic://track/1140560589",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=SUzsih7QJSY"
     },
     {
       "year": 2008,
@@ -1735,7 +1885,9 @@
       "awards": [],
       "fun_fact": "Rise Against's biggest mainstream hit. The politically-charged band used this success to spread their message to a wider audience.",
       "fun_fact_de": "Rise Againsts größter Mainstream-Hit. Die politisch engagierte Band nutzte diesen Erfolg, um ihre Botschaft einem breiteren Publikum zu vermitteln.",
-      "fun_fact_es": "El mayor éxito mainstream de Rise Against. La banda políticamente comprometida usó este éxito para difundir su mensaje a una audiencia más amplia."
+      "fun_fact_es": "El mayor éxito mainstream de Rise Against. La banda políticamente comprometida usó este éxito para difundir su mensaje a una audiencia más amplia.",
+      "uri_apple_music": "applemusic://track/1454825817",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=EbSlCrleDgE"
     },
     {
       "year": 2002,
@@ -1756,7 +1908,9 @@
       "awards": [],
       "fun_fact": "Good Charlotte's UK breakthrough was bigger than their US success. The song's social commentary resonated with British audiences.",
       "fun_fact_de": "Good Charlottes UK-Durchbruch war größer als ihr US-Erfolg. Die soziale Kritik des Songs kam beim britischen Publikum gut an.",
-      "fun_fact_es": "El éxito de Good Charlotte en el Reino Unido fue mayor que en EE.UU. El comentario social de la canción resonó con las audiencias británicas."
+      "fun_fact_es": "El éxito de Good Charlotte en el Reino Unido fue mayor que en EE.UU. El comentario social de la canción resonó con las audiencias británicas.",
+      "uri_apple_music": "applemusic://track/288051955",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=y-jC3H_8Dk4"
     },
     {
       "year": 2004,
@@ -1777,7 +1931,9 @@
       "awards": [],
       "fun_fact": "Jimmy Eat World's follow-up to 'The Middle' from the same album. The song deals with heartbreak in their signature anthemic style.",
       "fun_fact_de": "Jimmy Eat Worlds Nachfolger zu 'The Middle' vom selben Album. Der Song behandelt Herzschmerz in ihrem typischen hymnenhaften Stil.",
-      "fun_fact_es": "El seguimiento de Jimmy Eat World a 'The Middle' del mismo álbum. La canción trata sobre el desamor en su estilo característico de himno."
+      "fun_fact_es": "El seguimiento de Jimmy Eat World a 'The Middle' del mismo álbum. La canción trata sobre el desamor en su estilo característico de himno.",
+      "uri_apple_music": "applemusic://track/438829874",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=ntSBKPkk4m4"
     },
     {
       "year": 2000,
@@ -1800,7 +1956,9 @@
       "awards": [],
       "fun_fact": "The first single from Warning, Green Day's experimental album that divided fans but showed the band's artistic growth.",
       "fun_fact_de": "Die erste Single von Warning, Green Days experimentellem Album, das die Fans spaltete, aber die künstlerische Entwicklung der Band zeigte.",
-      "fun_fact_es": "El primer sencillo de Warning, el álbum experimental de Green Day que dividió a los fans pero mostró el crecimiento artístico de la banda."
+      "fun_fact_es": "El primer sencillo de Warning, el álbum experimental de Green Day que dividió a los fans pero mostró el crecimiento artístico de la banda.",
+      "uri_apple_music": "applemusic://track/1526411792",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=88iAXJGvl3A"
     },
     {
       "year": 1997,
@@ -1821,7 +1979,9 @@
       "awards": [],
       "fun_fact": "Goldfinger's ska-punk anthem became iconic through its appearance in Tony Hawk's Pro Skater. The game introduced millions to the genre.",
       "fun_fact_de": "Goldfingers Ska-Punk-Hymne wurde ikonisch durch Tony Hawk's Pro Skater. Das Spiel brachte Millionen zum Genre.",
-      "fun_fact_es": "El himno ska-punk de Goldfinger se volvió icónico por su aparición en Tony Hawk's Pro Skater. El juego introdujo a millones al género."
+      "fun_fact_es": "El himno ska-punk de Goldfinger se volvió icónico por su aparición en Tony Hawk's Pro Skater. El juego introdujo a millones al género.",
+      "uri_apple_music": "applemusic://track/77817249",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=bm51ihfi1p4"
     },
     {
       "year": 2005,
@@ -1844,7 +2004,9 @@
       "awards": [],
       "fun_fact": "The All-American Rejects' inspirational anthem became their biggest hit and a staple of sports arenas and graduation ceremonies.",
       "fun_fact_de": "Die inspirierende Hymne von The All-American Rejects wurde ihr größter Hit und ein Klassiker in Sportarenen und bei Abschlussfeiern.",
-      "fun_fact_es": "El himno inspirador de The All-American Rejects se convirtió en su mayor éxito y es esencial en estadios deportivos y ceremonias de graduación."
+      "fun_fact_es": "El himno inspirador de The All-American Rejects se convirtió en su mayor éxito y es esencial en estadios deportivos y ceremonias de graduación.",
+      "uri_apple_music": "applemusic://track/1589373707",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=rXHfIHkPMSA"
     },
     {
       "year": 2004,
@@ -1867,7 +2029,9 @@
       "awards": [],
       "fun_fact": "Good Charlotte's more electronic-influenced track showed their willingness to experiment while maintaining their pop punk core.",
       "fun_fact_de": "Good Charlottes elektronisch beeinflusster Track zeigte ihre Bereitschaft zu experimentieren, während sie ihren Pop-Punk-Kern behielten.",
-      "fun_fact_es": "La canción más influenciada por la electrónica de Good Charlotte mostró su disposición a experimentar mientras mantenían su esencia pop punk."
+      "fun_fact_es": "La canción más influenciada por la electrónica de Good Charlotte mostró su disposición a experimentar mientras mantenían su esencia pop punk.",
+      "uri_apple_music": "applemusic://track/1485034321",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=d9ORimXBXLw"
     },
     {
       "year": 2003,
@@ -1888,7 +2052,9 @@
       "awards": [],
       "fun_fact": "Yellowcard's powerful track shows the emotional depth that set them apart from typical pop punk bands of the era.",
       "fun_fact_de": "Yellowcards kraftvoller Track zeigt die emotionale Tiefe, die sie von typischen Pop-Punk-Bands der Ära abhob.",
-      "fun_fact_es": "La poderosa canción de Yellowcard muestra la profundidad emocional que los distinguía de las típicas bandas pop punk de la era."
+      "fun_fact_es": "La poderosa canción de Yellowcard muestra la profundidad emocional que los distinguía de las típicas bandas pop punk de la era.",
+      "uri_apple_music": "applemusic://track/1846923414",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=uBtH2YlNiNc"
     },
     {
       "year": 2003,
@@ -1909,7 +2075,9 @@
       "awards": [],
       "fun_fact": "AFI's breakthrough to mainstream alternative rock. The song's gothic undertones hint at the darker direction they'd later explore.",
       "fun_fact_de": "AFIs Durchbruch zum Mainstream-Alternative-Rock. Die gotischen Untertöne des Songs deuten auf die dunklere Richtung hin, die sie später erkunden würden.",
-      "fun_fact_es": "El avance de AFI al rock alternativo mainstream. Los matices góticos de la canción insinúan la dirección más oscura que explorarían después."
+      "fun_fact_es": "El avance de AFI al rock alternativo mainstream. Los matices góticos de la canción insinúan la dirección más oscura que explorarían después.",
+      "uri_apple_music": "",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=EQPcKe0LDdQ"
     },
     {
       "year": 1978,
@@ -1930,7 +2098,9 @@
       "awards": [],
       "fun_fact": "",
       "fun_fact_de": "",
-      "fun_fact_es": ""
+      "fun_fact_es": "",
+      "uri_apple_music": "applemusic://track/1789000528",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=jrxI_euTX4A"
     },
     {
       "year": 2004,
@@ -1951,7 +2121,9 @@
       "awards": [],
       "fun_fact": "Taking Back Sunday's signature song perfectly captures the emo era's emotional intensity and dramatic lyrics.",
       "fun_fact_de": "Taking Back Sundays Erkennungssong fängt perfekt die emotionale Intensität und dramatischen Texte der Emo-Ära ein.",
-      "fun_fact_es": "La canción insignia de Taking Back Sunday captura perfectamente la intensidad emocional y las letras dramáticas de la era emo."
+      "fun_fact_es": "La canción insignia de Taking Back Sunday captura perfectamente la intensidad emocional y las letras dramáticas de la era emo.",
+      "uri_apple_music": "applemusic://track/725822633",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=SucBpQiwYZU"
     },
     {
       "year": 2006,
@@ -1974,7 +2146,9 @@
       "awards": [],
       "fun_fact": "Bowling For Soup's satirical commentary on celebrity culture and how adults still act like teenagers. Features jabs at famous people.",
       "fun_fact_de": "Bowling For Soups satirischer Kommentar zur Promi-Kultur und wie Erwachsene sich immer noch wie Teenager verhalten.",
-      "fun_fact_es": "El comentario satírico de Bowling For Soup sobre la cultura de celebridades y cómo los adultos todavía actúan como adolescentes."
+      "fun_fact_es": "El comentario satírico de Bowling For Soup sobre la cultura de celebridades y cómo los adultos todavía actúan como adolescentes.",
+      "uri_apple_music": "applemusic://track/2417229",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=l9WKZpC9UbU"
     },
     {
       "year": 2000,
@@ -1995,7 +2169,9 @@
       "awards": [],
       "fun_fact": "Millencolin's Swedish skatepunk anthem was featured in Tony Hawk's Pro Skater 2, introducing them to American audiences.",
       "fun_fact_de": "Millencolins schwedische Skatepunk-Hymne war in Tony Hawk's Pro Skater 2 zu hören und stellte sie dem amerikanischen Publikum vor.",
-      "fun_fact_es": "El himno skatepunk sueco de Millencolin fue presentado en Tony Hawk's Pro Skater 2, introduciéndolos a las audiencias americanas."
+      "fun_fact_es": "El himno skatepunk sueco de Millencolin fue presentado en Tony Hawk's Pro Skater 2, introduciéndolos a las audiencias americanas.",
+      "uri_apple_music": "applemusic://track/1440785041",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=YU4hhNKsPog"
     },
     {
       "year": 2004,
@@ -2016,7 +2192,9 @@
       "awards": [],
       "fun_fact": "Simple Plan's rebellious anthem captured teenage frustration with authority figures and became a high school hallway staple.",
       "fun_fact_de": "Simple Plans rebellische Hymne fing die Frustration von Teenagern mit Autoritätspersonen ein und wurde ein Highschool-Klassiker.",
-      "fun_fact_es": "El himno rebelde de Simple Plan capturó la frustración adolescente con las figuras de autoridad y se volvió esencial en pasillos de secundaria."
+      "fun_fact_es": "El himno rebelde de Simple Plan capturó la frustración adolescente con las figuras de autoridad y se volvió esencial en pasillos de secundaria.",
+      "uri_apple_music": "applemusic://track/76159749",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=GZb_mqH2zJY"
     },
     {
       "year": 2002,
@@ -2037,7 +2215,9 @@
       "awards": [],
       "fun_fact": "The Starting Line's most beloved song showcases the quintessential 2000s pop punk sound with heartfelt lyrics.",
       "fun_fact_de": "Der beliebteste Song von The Starting Line zeigt den typischen Pop-Punk-Sound der 2000er mit herzlichen Texten.",
-      "fun_fact_es": "La canción más querida de The Starting Line muestra el sonido pop punk quintaesencial de los 2000 con letras sinceras."
+      "fun_fact_es": "La canción más querida de The Starting Line muestra el sonido pop punk quintaesencial de los 2000 con letras sinceras.",
+      "uri_apple_music": "applemusic://track/418437027",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=VGRxmYXi4Io"
     },
     {
       "year": 2016,
@@ -2058,7 +2238,9 @@
       "awards": [],
       "fun_fact": "Neck Deep's collaboration with blink-182's Mark Hoppus was a dream come true for the younger band who grew up on blink.",
       "fun_fact_de": "Neck Deeps Zusammenarbeit mit blink-182s Mark Hoppus war ein Traum für die jüngere Band, die mit blink aufwuchs.",
-      "fun_fact_es": "La colaboración de Neck Deep con Mark Hoppus de blink-182 fue un sueño hecho realidad para la banda más joven que creció con blink."
+      "fun_fact_es": "La colaboración de Neck Deep con Mark Hoppus de blink-182 fue un sueño hecho realidad para la banda más joven que creció con blink.",
+      "uri_apple_music": "applemusic://track/424480044",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=gOgpdp3lP8M"
     },
     {
       "year": 2002,
@@ -2079,7 +2261,9 @@
       "awards": [],
       "fun_fact": "Box Car Racer was Tom DeLonge and Travis Barker's side project during blink-182, featuring a darker, more experimental sound.",
       "fun_fact_de": "Box Car Racer war Tom DeLonges und Travis Barkers Nebenprojekt während blink-182, mit einem dunkleren, experimentelleren Sound.",
-      "fun_fact_es": "Box Car Racer fue el proyecto paralelo de Tom DeLonge y Travis Barker durante blink-182, con un sonido más oscuro y experimental."
+      "fun_fact_es": "Box Car Racer fue el proyecto paralelo de Tom DeLonge y Travis Barker durante blink-182, con un sonido más oscuro y experimental.",
+      "uri_apple_music": "applemusic://track/1282094705",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=aUVVRyjiVzo"
     },
     {
       "year": 2006,
@@ -2100,7 +2284,9 @@
       "awards": [],
       "fun_fact": "Cute Is What We Aim For represented the poppier side of the 2000s emo scene, with polished production and catchy hooks.",
       "fun_fact_de": "Cute Is What We Aim For repräsentierte die poppigere Seite der Emo-Szene der 2000er, mit polierter Produktion und eingängigen Hooks.",
-      "fun_fact_es": "Cute Is What We Aim For representó el lado más pop de la escena emo de los 2000, con producción pulida y ganchos pegadizos."
+      "fun_fact_es": "Cute Is What We Aim For representó el lado más pop de la escena emo de los 2000, con producción pulida y ganchos pegadizos.",
+      "uri_apple_music": "applemusic://track/1485032585",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=aqh-pg-Py_I"
     },
     {
       "year": 1998,
@@ -2121,7 +2307,9 @@
       "awards": [],
       "fun_fact": "Less Than Jake's ska-punk anthem celebrates metal fans and the cross-genre friendships common in alternative music scenes.",
       "fun_fact_de": "Less Than Jakes Ska-Punk-Hymne feiert Metal-Fans und die genre-übergreifenden Freundschaften, die in alternativen Musikszenen üblich sind.",
-      "fun_fact_es": "El himno ska-punk de Less Than Jake celebra a los fans del metal y las amistades entre géneros comunes en las escenas de música alternativa."
+      "fun_fact_es": "El himno ska-punk de Less Than Jake celebra a los fans del metal y las amistades entre géneros comunes en las escenas de música alternativa.",
+      "uri_apple_music": "applemusic://track/1541052685",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=YdGad64abWM"
     },
     {
       "year": 1994,
@@ -2142,7 +2330,9 @@
       "awards": [],
       "fun_fact": "NOFX's most covered song, an anti-consumerist anthem. The band famously never appears on TV or mainstream media.",
       "fun_fact_de": "NOFXs meistgecoverter Song, eine Anti-Konsumerismus-Hymne. Die Band erscheint bekanntermaßen nie im TV oder in Mainstream-Medien.",
-      "fun_fact_es": "La canción más versionada de NOFX, un himno anti-consumista. La banda es famosa por nunca aparecer en TV o medios mainstream."
+      "fun_fact_es": "La canción más versionada de NOFX, un himno anti-consumista. La banda es famosa por nunca aparecer en TV o medios mainstream.",
+      "uri_apple_music": "applemusic://track/1526411785",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=ajxp4xPMgSM"
     },
     {
       "year": 2001,
@@ -2165,7 +2355,9 @@
       "awards": [],
       "fun_fact": "Sum 41's biggest commercial hit, featured in numerous movies and TV shows throughout the 2000s and became a karaoke favorite.",
       "fun_fact_de": "Sum 41s größter kommerzieller Hit, in zahlreichen Filmen und TV-Shows der 2000er zu hören und wurde ein Karaoke-Favorit.",
-      "fun_fact_es": "El mayor éxito comercial de Sum 41, presente en numerosas películas y programas de TV de los 2000 y se convirtió en favorito del karaoke."
+      "fun_fact_es": "El mayor éxito comercial de Sum 41, presente en numerosas películas y programas de TV de los 2000 y se convirtió en favorito del karaoke.",
+      "uri_apple_music": "applemusic://track/1573232689",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=W6FixoUyQQQ"
     },
     {
       "year": 2009,
@@ -2186,7 +2378,9 @@
       "awards": [],
       "fun_fact": "A Rocket To The Moon's signature ballad represents the more melodic, romantic side of the late 2000s pop punk scene.",
       "fun_fact_de": "Die Erkennungsballade von A Rocket To The Moon repräsentiert die melodischere, romantischere Seite der späten 2000er Pop-Punk-Szene.",
-      "fun_fact_es": "La balada insignia de A Rocket To The Moon representa el lado más melódico y romántico de la escena pop punk de finales de los 2000."
+      "fun_fact_es": "La balada insignia de A Rocket To The Moon representa el lado más melódico y romántico de la escena pop punk de finales de los 2000.",
+      "uri_apple_music": "applemusic://track/27295869",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Lpds3V90VbM"
     },
     {
       "year": 2013,
@@ -2207,7 +2401,9 @@
       "awards": [],
       "fun_fact": "The Wonder Years' anthem represents the 2010s pop punk revival with more mature, introspective lyrics than the genre's earlier days.",
       "fun_fact_de": "Die Hymne von The Wonder Years repräsentiert das Pop-Punk-Revival der 2010er mit reiferen, introspektiveren Texten als in den früheren Tagen des Genres.",
-      "fun_fact_es": "El himno de The Wonder Years representa el renacimiento del pop punk de los 2010 con letras más maduras e introspectivas que en los primeros días del género."
+      "fun_fact_es": "El himno de The Wonder Years representa el renacimiento del pop punk de los 2010 con letras más maduras e introspectivas que en los primeros días del género.",
+      "uri_apple_music": "applemusic://track/1471266343",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=oafhO8tFS38"
     },
     {
       "year": 2021,
@@ -2228,7 +2424,9 @@
       "awards": [],
       "fun_fact": "Against The Current keeps pop punk alive for Gen Z with modern production while honoring the genre's roots.",
       "fun_fact_de": "Against The Current hält Pop-Punk für Gen Z am Leben mit moderner Produktion, während sie die Wurzeln des Genres ehren.",
-      "fun_fact_es": "Against The Current mantiene vivo el pop punk para la Gen Z con producción moderna mientras honran las raíces del género."
+      "fun_fact_es": "Against The Current mantiene vivo el pop punk para la Gen Z con producción moderna mientras honran las raíces del género.",
+      "uri_apple_music": "applemusic://track/331528609",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=US46cHVj0-M"
     },
     {
       "year": 2007,


### PR DESCRIPTION
## 🎸 Add Streaming URIs to Pure Pop Punk

### Summary
Adds missing Apple Music and YouTube Music URIs to the Pure Pop Punk playlist to align with the standard playlist format.

### 📊 Streaming URI Stats

| Platform | Coverage |
|----------|----------|
| **Apple Music** | 96/100 (96%) |
| **YouTube Music** | 99/100 (99%) |

### Why?
The playlist was merged without streaming URIs. This fix ensures format consistency with other playlists like `eurodance-90s.json`.

---
*Generated with Beatifybot 🐛*