### PR TITLE
feat(playlists): Add tags for multi-category filtering

### DIFF
--- a/custom_components/beatify/playlists/80er-hits.json
+++ b/custom_components/beatify/playlists/80er-hits.json
@@ -1,6 +1,12 @@
 {
   "name": "80er Hits",
   "version": "1.0",
+  "tags": [
+    "1980s",
+    "pop",
+    "rock",
+    "international"
+  ],
   "songs": [
     {
       "year": 1975,

--- a/custom_components/beatify/playlists/90er-hits.json
+++ b/custom_components/beatify/playlists/90er-hits.json
@@ -1,6 +1,12 @@
 {
   "name": "90er Hits",
   "version": "1.0",
+  "tags": [
+    "1990s",
+    "pop",
+    "rock",
+    "international"
+  ],
   "songs": [
     {
       "year": 1991,

--- a/custom_components/beatify/playlists/eurodance-90s.json
+++ b/custom_components/beatify/playlists/eurodance-90s.json
@@ -1,6 +1,13 @@
 {
   "name": "Eurodance 90s 💥 Party Songs",
   "version": "1.0",
+  "tags": [
+    "1990s",
+    "eurodance",
+    "electronic",
+    "party",
+    "international"
+  ],
   "songs": [
     {
       "year": 1995,

--- a/custom_components/beatify/playlists/eurovision-winners.json
+++ b/custom_components/beatify/playlists/eurovision-winners.json
@@ -1,6 +1,12 @@
 {
   "name": "Eurovision Winners (1956-2025)",
   "version": "1.2",
+  "tags": [
+    "eurovision",
+    "contest",
+    "international",
+    "mixed"
+  ],
   "songs": [
     {
       "year": 1956,

--- a/custom_components/beatify/playlists/greatest-hits-of-all-time.json
+++ b/custom_components/beatify/playlists/greatest-hits-of-all-time.json
@@ -1,6 +1,12 @@
 {
   "name": "Greatest Hits of All Time",
   "version": "1.3",
+  "tags": [
+    "classics",
+    "top-hits",
+    "international",
+    "mixed"
+  ],
   "songs": [
     {
       "year": 1975,

--- a/custom_components/beatify/playlists/koelner-karneval.json
+++ b/custom_components/beatify/playlists/koelner-karneval.json
@@ -1,6 +1,12 @@
 {
   "name": "Kölner Karneval",
   "version": "1.0",
+  "tags": [
+    "german",
+    "carnival",
+    "party",
+    "schlager"
+  ],
   "songs": [
     {
       "year": 1971,

--- a/custom_components/beatify/playlists/movies-100-greatest-themes.json
+++ b/custom_components/beatify/playlists/movies-100-greatest-themes.json
@@ -1,6 +1,12 @@
 {
   "name": "Movie's Greatest Themes",
   "version": "1.2",
+  "tags": [
+    "movies",
+    "soundtrack",
+    "international",
+    "mixed"
+  ],
   "songs": [
     {
       "year": 2001,

--- a/custom_components/beatify/playlists/one-hit-wonders.json
+++ b/custom_components/beatify/playlists/one-hit-wonders.json
@@ -1,6 +1,12 @@
 {
   "name": "One-Hit Wonders",
   "version": "1.0",
+  "tags": [
+    "one-hit",
+    "classics",
+    "international",
+    "mixed"
+  ],
   "songs": [
     {
       "year": 1965,

--- a/custom_components/beatify/playlists/pure-pop-punk.json
+++ b/custom_components/beatify/playlists/pure-pop-punk.json
@@ -1,6 +1,12 @@
 {
   "name": "Pure Pop Punk 🎸",
   "version": "1.0",
+  "tags": [
+    "2000s",
+    "pop-punk",
+    "rock",
+    "international"
+  ],
   "songs": [
     {
       "year": 2007,

--- a/custom_components/beatify/playlists/schlager-klassiker.json
+++ b/custom_components/beatify/playlists/schlager-klassiker.json
@@ -1,6 +1,11 @@
 {
   "name": "German classics",
   "version": "1.2",
+  "tags": [
+    "german",
+    "schlager",
+    "classics"
+  ],
   "songs": [
     {
       "year": 1985,

--- a/custom_components/beatify/playlists/top-100-power-ballads.json
+++ b/custom_components/beatify/playlists/top-100-power-ballads.json
@@ -1,6 +1,13 @@
 {
   "name": "Top 100 Power Ballads",
   "version": "1.0",
+  "tags": [
+    "1980s",
+    "1990s",
+    "rock",
+    "ballads",
+    "international"
+  ],
   "songs": [
     {
       "year": 1998,

--- a/custom_components/beatify/playlists/yacht-rock.json
+++ b/custom_components/beatify/playlists/yacht-rock.json
@@ -1,6 +1,13 @@
 {
   "name": "Yacht Rock ⛵ Top 100 Songs",
   "version": "1.0",
+  "tags": [
+    "1970s",
+    "1980s",
+    "yacht-rock",
+    "soft-rock",
+    "international"
+  ],
   "songs": [
     {
       "year": 1978,


### PR DESCRIPTION
## Summary

Adds `tags` array to all 12 playlist JSON files, enabling future multi-category filtering in the Admin UI.

## Changes

Added `tags` field after `version` in each playlist:

```json
{
  "name": "80er Hits",
  "version": "1.0",
  "tags": ["1980s", "pop", "rock", "international"],
  "songs": [...]
}
```

## Playlist Tags

| Playlist | Tags |
|----------|------|
| 80er-hits | `1980s`, `pop`, `rock`, `international` |
| 90er-hits | `1990s`, `pop`, `rock`, `international` |
| eurodance-90s | `1990s`, `eurodance`, `electronic`, `party`, `international` |
| eurovision-winners | `eurovision`, `contest`, `international`, `mixed` |
| greatest-hits-of-all-time | `classics`, `top-hits`, `international`, `mixed` |
| koelner-karneval | `german`, `carnival`, `party`, `schlager` |
| movies-100-greatest-themes | `movies`, `soundtrack`, `international`, `mixed` |
| one-hit-wonders | `one-hit`, `classics`, `international`, `mixed` |
| pure-pop-punk | `2000s`, `pop-punk`, `rock`, `international` |
| schlager-klassiker | `german`, `schlager`, `classics` |
| top-100-power-ballads | `1980s`, `1990s`, `rock`, `ballads`, `international` |
| yacht-rock | `1970s`, `1980s`, `yacht-rock`, `soft-rock`, `international` |

## Tag Vocabulary

| Category | Tags |
|----------|------|
| **Decades** | `1970s`, `1980s`, `1990s`, `2000s`, `mixed` |
| **Genres** | `rock`, `pop`, `schlager`, `eurodance`, `electronic`, `pop-punk`, `ballads`, `soft-rock`, `yacht-rock`, `soundtrack` |
| **Regions** | `german`, `international` |
| **Themes** | `movies`, `carnival`, `eurovision`, `contest`, `party` |
| **Charts** | `classics`, `top-hits`, `one-hit` |

## Next Steps

- [ ] Backend: Parse and return tags in API response
- [ ] Frontend: Implement filter bar UI (see #70 for mockups)

## Related

Implements data layer for #70

---
*Created by Beatifybot 🐛*