### PR TITLE
feat(playlists): Motown and Soul Classics

### DIFF
--- a/custom_components/beatify/playlists/motown-soul-classics.json
+++ b/custom_components/beatify/playlists/motown-soul-classics.json
@@ -33,8 +33,8 @@
       "fun_fact": "One of the first Motown songs to address social issues, inspired by the 1967 Detroit riots. The distinctive opening was created using a primitive electronic oscillator.",
       "fun_fact_de": "Einer der ersten Motown-Songs mit sozialkritischem Inhalt, inspiriert von den Unruhen in Detroit 1967. Das markante Intro wurde mit einem primitiven elektronischen Oszillator erzeugt.",
       "fun_fact_es": "Una de las primeras canciones de Motown en abordar temas sociales, inspirada en los disturbios de Detroit de 1967. La distintiva introducción fue creada con un oscilador electrónico primitivo.",
-      "uri_apple_music": "",
-      "uri_youtube_music": ""
+      "uri_apple_music": "applemusic://track/1442909932",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=8Nlbj1t99m8"
     },
     {
       "year": 1968,
@@ -59,8 +59,8 @@
       "fun_fact": "Motown head Berry Gordy initially rejected Marvin's version, releasing Gladys Knight's version first. Marvin's version spent 7 weeks at #1 and became Motown's biggest-selling single at the time.",
       "fun_fact_de": "Motown-Chef Berry Gordy lehnte Marvins Version zunächst ab und veröffentlichte zuerst die Version von Gladys Knight. Marvins Version stand 7 Wochen auf Platz 1 und wurde Motowns meistverkaufte Single.",
       "fun_fact_es": "El jefe de Motown, Berry Gordy, rechazó inicialmente la versión de Marvin, publicando primero la de Gladys Knight. La versión de Marvin estuvo 7 semanas en el #1 y se convirtió en el sencillo más vendido de Motown.",
-      "uri_apple_music": "",
-      "uri_youtube_music": ""
+      "uri_apple_music": "applemusic://track/1444106658",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=cXWHpbpNdHE"
     },
     {
       "year": 1972,
@@ -87,8 +87,8 @@
       "fun_fact": "The full album version runs over 12 minutes with its iconic bass line. The Temptations initially hated the song because it referenced an absent father, which hit too close to home for some members.",
       "fun_fact_de": "Die vollständige Albumversion dauert über 12 Minuten mit ihrer ikonischen Basslinie. Die Temptations hassten den Song anfangs, weil er einen abwesenden Vater thematisierte – für einige Mitglieder ein zu persönliches Thema.",
       "fun_fact_es": "La versión completa del álbum dura más de 12 minutos con su icónica línea de bajo. Los Temptations odiaban la canción porque hacía referencia a un padre ausente, algo demasiado personal para algunos miembros.",
-      "uri_apple_music": "",
-      "uri_youtube_music": ""
+      "uri_apple_music": "applemusic://track/1442730461",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=IN1Y8kO-QKw"
     },
     {
       "year": 1978,
@@ -113,8 +113,8 @@
       "fun_fact": "Lionel Richie wrote it after watching his father dance with his mother at his parents' anniversary party. It was Motown's best-selling single in the UK at the time.",
       "fun_fact_de": "Lionel Richie schrieb den Song, nachdem er seinen Vater bei der Jubiläumsfeier seiner Eltern mit seiner Mutter tanzen sah. Es war Motowns meistverkaufte Single in Großbritannien.",
       "fun_fact_es": "Lionel Richie la escribió después de ver a su padre bailar con su madre en la fiesta de aniversario de sus padres. Fue el sencillo más vendido de Motown en el Reino Unido.",
-      "uri_apple_music": "",
-      "uri_youtube_music": ""
+      "uri_apple_music": "applemusic://track/1440842549",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=QFjvyeazAZs"
     },
     {
       "year": 1965,
@@ -137,8 +137,8 @@
       "fun_fact": "Widely regarded as one of the greatest songs ever written. John Lennon called Smokey Robinson 'America's greatest living poet.' The song was inducted into the Grammy Hall of Fame in 1998.",
       "fun_fact_de": "Weithin als einer der größten Songs aller Zeiten angesehen. John Lennon nannte Smokey Robinson 'Amerikas größten lebenden Dichter.' Der Song wurde 1998 in die Grammy Hall of Fame aufgenommen.",
       "fun_fact_es": "Ampliamente considerada una de las mejores canciones jamás escritas. John Lennon llamó a Smokey Robinson 'el mejor poeta vivo de América'. La canción fue incluida en el Grammy Hall of Fame en 1998.",
-      "uri_apple_music": "",
-      "uri_youtube_music": ""
+      "uri_apple_music": "applemusic://track/1475817730",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Yf2CB32jDYc"
     },
     {
       "year": 1961,
@@ -163,8 +163,8 @@
       "fun_fact": "Motown's first #1 pop hit. The Beatles covered it in 1963, and the Carpenters took their version to #1 in 1975, making it one of the few songs to reach #1 twice.",
       "fun_fact_de": "Motowns erster #1-Pop-Hit. Die Beatles coverten ihn 1963, und die Carpenters brachten ihre Version 1975 auf Platz 1 – einer der wenigen Songs, die zweimal die Spitze erreichten.",
       "fun_fact_es": "El primer #1 pop de Motown. Los Beatles la versionaron en 1963 y los Carpenters llevaron su versión al #1 en 1975, convirtiéndola en una de las pocas canciones en alcanzar el #1 dos veces.",
-      "uri_apple_music": "",
-      "uri_youtube_music": ""
+      "uri_apple_music": "applemusic://track/1444133527",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=UDZ6Zp_zGzg"
     },
     {
       "year": 1965,
@@ -189,8 +189,8 @@
       "fun_fact": "Written by the legendary Holland-Dozier-Holland team. It knocked the Rolling Stones' 'Satisfaction' out of the #1 spot. The song's title came from the writers' habit of calling people 'sugar pie' and 'honey bunch.'",
       "fun_fact_de": "Geschrieben vom legendären Holland-Dozier-Holland-Team. Es verdrängte 'Satisfaction' der Rolling Stones von Platz 1. Der Songtitel entstand aus der Gewohnheit der Autoren, Leute 'Sugar Pie' und 'Honey Bunch' zu nennen.",
       "fun_fact_es": "Escrita por el legendario equipo Holland-Dozier-Holland. Sacó a 'Satisfaction' de los Rolling Stones del #1. El título surgió de la costumbre de los compositores de llamar a la gente 'sugar pie' y 'honey bunch'.",
-      "uri_apple_music": "",
-      "uri_youtube_music": ""
+      "uri_apple_music": "applemusic://track/1443096422",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=EBA6z9sEzAo"
     },
     {
       "year": 1966,
@@ -213,8 +213,8 @@
       "fun_fact": "Jimmy was David Ruffin's older brother. This was originally written for The Spinners but given to Jimmy. It became a bigger UK hit on reissue in 1974, reaching #4.",
       "fun_fact_de": "Jimmy war der ältere Bruder von David Ruffin. Der Song war ursprünglich für The Spinners geschrieben, wurde aber Jimmy gegeben. In Großbritannien wurde er bei der Wiederveröffentlichung 1974 ein noch größerer Hit (#4).",
       "fun_fact_es": "Jimmy era el hermano mayor de David Ruffin. La canción fue escrita originalmente para The Spinners pero se la dieron a Jimmy. Fue un éxito aún mayor en el Reino Unido al reeditarse en 1974, alcanzando el #4.",
-      "uri_apple_music": "",
-      "uri_youtube_music": ""
+      "uri_apple_music": "applemusic://track/1443825634",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=cQywZYoGB1g"
     },
     {
       "year": 1964,
@@ -239,8 +239,8 @@
       "fun_fact": "Written by Marvin Gaye and William 'Mickey' Stevenson. Later became an anthem for civil rights and social change. David Bowie and Mick Jagger famously covered it for Live Aid in 1985.",
       "fun_fact_de": "Geschrieben von Marvin Gaye und William 'Mickey' Stevenson. Wurde später zur Hymne der Bürgerrechtsbewegung. David Bowie und Mick Jagger coverten ihn 1985 für Live Aid.",
       "fun_fact_es": "Escrita por Marvin Gaye y William 'Mickey' Stevenson. Se convirtió en un himno por los derechos civiles. David Bowie y Mick Jagger la versionaron para Live Aid en 1985.",
-      "uri_apple_music": "",
-      "uri_youtube_music": ""
+      "uri_apple_music": "applemusic://track/1444115709",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=M4p9qXIWN2Q"
     },
     {
       "year": 1972,
@@ -263,8 +263,8 @@
       "fun_fact": "Originally a country hit by Kris Kristofferson. Gladys Knight's soulful Motown rendition gave the song an entirely new dimension, showing how Motown could cross genre boundaries.",
       "fun_fact_de": "Ursprünglich ein Country-Hit von Kris Kristofferson. Gladys Knights gefühlvolle Motown-Version gab dem Song eine völlig neue Dimension und zeigte, wie Motown Genregrenzen überschreiten konnte.",
       "fun_fact_es": "Originalmente un éxito country de Kris Kristofferson. La versión soul de Gladys Knight le dio una dimensión completamente nueva, demostrando que Motown podía cruzar fronteras de género.",
-      "uri_apple_music": "",
-      "uri_youtube_music": ""
+      "uri_apple_music": "applemusic://track/1445361909",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=YFWsXTP5uao"
     },
     {
       "year": 1984,
@@ -289,8 +289,8 @@
       "fun_fact": "The iconic music video featured a blind student sculpting Lionel's face. The video won multiple MTV VMAs and became one of the most recognizable clips of the 1980s.",
       "fun_fact_de": "Im ikonischen Musikvideo modellierte eine blinde Studentin Lionels Gesicht. Das Video gewann mehrere MTV VMAs und wurde zu einem der bekanntesten Clips der 1980er.",
       "fun_fact_es": "El icónico video musical mostraba a una estudiante ciega esculpiendo el rostro de Lionel. El video ganó múltiples MTV VMAs y se convirtió en uno de los clips más reconocibles de los 80.",
-      "uri_apple_music": "",
-      "uri_youtube_music": ""
+      "uri_apple_music": "applemusic://track/1440783181",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=mHONNcZbwDY"
     },
     {
       "year": 1967,
@@ -313,8 +313,8 @@
       "fun_fact": "Written by husband-and-wife team Ashford & Simpson. Diana Ross later took a solo version to #1 in 1970. Tragically, Tammi Terrell collapsed into Marvin's arms during a concert in 1967 due to a brain tumor.",
       "fun_fact_de": "Geschrieben vom Ehepaar Ashford & Simpson. Diana Ross brachte 1970 eine Soloversion auf Platz 1. Tragischerweise brach Tammi Terrell 1967 bei einem Konzert aufgrund eines Hirntumors in Marvins Armen zusammen.",
       "fun_fact_es": "Escrita por el matrimonio Ashford & Simpson. Diana Ross llevó una versión en solitario al #1 en 1970. Trágicamente, Tammi Terrell se desplomó en los brazos de Marvin durante un concierto en 1967 debido a un tumor cerebral.",
-      "uri_apple_music": "",
-      "uri_youtube_music": ""
+      "uri_apple_music": "applemusic://track/1536018838",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=eu2gAqn4I2A"
     },
     {
       "year": 1966,
@@ -337,8 +337,8 @@
       "fun_fact": "Originally recorded by Marvin Gaye in 1964. Jr. Walker's saxophone-driven version added a grittier, funkier feel. James Taylor later had a hit with it in 1975.",
       "fun_fact_de": "Ursprünglich 1964 von Marvin Gaye aufgenommen. Jr. Walkers Saxophon-Version gab dem Song ein raueres, funkigeres Gefühl. James Taylor hatte 1975 ebenfalls einen Hit damit.",
       "fun_fact_es": "Originalmente grabada por Marvin Gaye en 1964. La versión de Jr. Walker con saxofón le dio un sonido más crudo y funky. James Taylor también tuvo un éxito con ella en 1975.",
-      "uri_apple_music": "",
-      "uri_youtube_music": ""
+      "uri_apple_music": "applemusic://track/1444098839",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=w7QEAykef7E"
     },
     {
       "year": 1964,
@@ -361,8 +361,8 @@
       "fun_fact": "Brenda Holloway was one of the first West Coast artists signed to Motown. She was discovered at a DJ convention in Los Angeles and was one of the opening acts on The Beatles' 1965 US tour.",
       "fun_fact_de": "Brenda Holloway war eine der ersten Westküsten-Künstlerinnen bei Motown. Sie wurde auf einer DJ-Messe in Los Angeles entdeckt und war Vorgruppe bei der US-Tour der Beatles 1965.",
       "fun_fact_es": "Brenda Holloway fue una de las primeras artistas de la costa oeste firmadas por Motown. Fue descubierta en una convención de DJs en Los Ángeles y teloneó a The Beatles en su gira por EE.UU. en 1965.",
-      "uri_apple_music": "",
-      "uri_youtube_music": ""
+      "uri_apple_music": "applemusic://track/1444216402",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=WW046NLTcUk"
     },
     {
       "year": 1975,
@@ -387,8 +387,8 @@
       "fun_fact": "Originally recorded in 1975 but released as a single in 1981 to capitalize on Michael's solo success. It reached #1 in the UK despite only peaking at #55 in the US.",
       "fun_fact_de": "Ursprünglich 1975 aufgenommen, aber erst 1981 als Single veröffentlicht, um von Michaels Soloerfolg zu profitieren. In Großbritannien erreichte er Platz 1, obwohl er in den USA nur auf Platz 55 kam.",
       "fun_fact_es": "Grabada originalmente en 1975 pero lanzada como sencillo en 1981 para aprovechar el éxito en solitario de Michael. Llegó al #1 en el Reino Unido aunque solo alcanzó el #55 en EE.UU.",
-      "uri_apple_music": "",
-      "uri_youtube_music": ""
+      "uri_apple_music": "applemusic://track/1471567182",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=TO_2iSKkzoQ"
     },
     {
       "year": 1975,
@@ -415,8 +415,8 @@
       "fun_fact": "Written for the film 'Mahogany' which also starred Diana Ross. It was nominated for an Academy Award for Best Original Song. The movie's tagline was 'Success is nothing without someone you love to share it with.'",
       "fun_fact_de": "Geschrieben für den Film 'Mahagoni', in dem Diana Ross auch die Hauptrolle spielte. Der Song war für den Oscar als bester Originalsong nominiert.",
       "fun_fact_es": "Escrita para la película 'Mahogany', protagonizada también por Diana Ross. Fue nominada al Oscar a Mejor Canción Original.",
-      "uri_apple_music": "",
-      "uri_youtube_music": ""
+      "uri_apple_music": "applemusic://track/1442975844",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=WhFqqVnwruI"
     },
     {
       "year": 1964,
@@ -441,8 +441,8 @@
       "fun_fact": "Written and produced by Smokey Robinson. Mary Wells became the first Motown artist to have a #1 pop hit. She left Motown shortly after at age 21, a decision she later regretted.",
       "fun_fact_de": "Geschrieben und produziert von Smokey Robinson. Mary Wells war die erste Motown-Künstlerin mit einem #1-Pop-Hit. Sie verließ Motown kurz darauf mit 21 Jahren – eine Entscheidung, die sie später bereute.",
       "fun_fact_es": "Escrita y producida por Smokey Robinson. Mary Wells fue la primera artista de Motown en tener un #1 pop. Dejó Motown poco después a los 21 años, una decisión que lamentó más tarde.",
-      "uri_apple_music": "",
-      "uri_youtube_music": ""
+      "uri_apple_music": "applemusic://track/1442912087",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=pqMFjBoFIFY"
     },
     {
       "year": 1971,
@@ -467,8 +467,8 @@
       "fun_fact": "Produced by Norman Whitfield, who originally recorded it with The Temptations as an 11-minute album track. The Undisputed Truth's shorter version became a bigger hit and a cultural touchstone about deception.",
       "fun_fact_de": "Produziert von Norman Whitfield, der den Song ursprünglich mit den Temptations als 11-minütigen Albumtrack aufnahm. Die kürzere Version der Undisputed Truth wurde ein größerer Hit und ein kultureller Maßstab über Täuschung.",
       "fun_fact_es": "Producida por Norman Whitfield, quien originalmente la grabó con The Temptations como un tema de 11 minutos. La versión más corta de The Undisputed Truth fue un éxito mayor y un referente cultural sobre el engaño.",
-      "uri_apple_music": "",
-      "uri_youtube_music": ""
+      "uri_apple_music": "applemusic://track/1442628301",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=zo1DxtI73SE"
     },
     {
       "year": 1965,
@@ -493,8 +493,8 @@
       "fun_fact": "The Supremes' fifth consecutive #1 hit, extending their incredible Holland-Dozier-Holland winning streak. The lush orchestral arrangement was a departure from their earlier pop sound, hinting at the sophistication to come.",
       "fun_fact_de": "Der fünfte aufeinanderfolgende #1-Hit der Supremes, der ihre unglaubliche Holland-Dozier-Holland-Erfolgsserie fortsetzte. Das üppige Orchesterarrangement war eine Abkehr von ihrem früheren Pop-Sound.",
       "fun_fact_es": "El quinto #1 consecutivo de The Supremes, extendiendo su increíble racha con Holland-Dozier-Holland. El lujoso arreglo orquestal fue un cambio respecto a su sonido pop anterior.",
-      "uri_apple_music": "",
-      "uri_youtube_music": ""
+      "uri_apple_music": "applemusic://track/1444118654",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=lNNdMLzJms0"
     },
     {
       "year": 1959,
@@ -517,8 +517,8 @@
       "fun_fact": "One of the very first Motown recordings and the label's first national hit. Co-written by Berry Gordy himself. The Beatles famously covered it, helping spread Motown's influence to the UK.",
       "fun_fact_de": "Eine der allerersten Motown-Aufnahmen und der erste nationale Hit des Labels. Co-geschrieben von Berry Gordy selbst. Die Beatles coverten den Song und trugen so Motowns Einfluss nach Großbritannien.",
       "fun_fact_es": "Una de las primeras grabaciones de Motown y el primer éxito nacional del sello. Co-escrita por el propio Berry Gordy. Los Beatles la versionaron, ayudando a difundir la influencia de Motown en el Reino Unido.",
-      "uri_apple_music": "",
-      "uri_youtube_music": ""
+      "uri_apple_music": "applemusic://track/1475817481",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=yeVx1C73o8k"
     },
     {
       "year": 1964,
@@ -543,8 +543,8 @@
       "fun_fact": "Written by Smokey Robinson and Ronald White of The Miracles. David Ruffin's lead vocal made it The Temptations' signature song. The iconic opening guitar riff was played by Robert White, one of Motown's Funk Brothers.",
       "fun_fact_de": "Geschrieben von Smokey Robinson und Ronald White von den Miracles. David Ruffins Leadgesang machte es zum Erkennungssong der Temptations. Das ikonische Gitarren-Riff spielte Robert White, einer der Funk Brothers.",
       "fun_fact_es": "Escrita por Smokey Robinson y Ronald White de The Miracles. La voz principal de David Ruffin la convirtió en la canción insignia de los Temptations. El icónico riff de guitarra fue tocado por Robert White, uno de los Funk Brothers.",
-      "uri_apple_music": "",
-      "uri_youtube_music": ""
+      "uri_apple_music": "applemusic://track/1423301921",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=y3KJ7d2qBoA"
     },
     {
       "year": 1964,
@@ -569,8 +569,8 @@
       "fun_fact": "The second of five consecutive #1 hits for The Supremes, tying The Beatles' record at the time. It was also #1 in the UK, making The Supremes the first Motown act to top the British charts.",
       "fun_fact_de": "Der zweite von fünf aufeinanderfolgenden #1-Hits der Supremes, womit sie den Rekord der Beatles einstellten. Auch in Großbritannien #1 – die Supremes waren der erste Motown-Act an der Spitze der britischen Charts.",
       "fun_fact_es": "El segundo de cinco #1 consecutivos de The Supremes, igualando el récord de The Beatles. También fue #1 en el Reino Unido, convirtiendo a The Supremes en el primer acto de Motown en liderar las listas británicas.",
-      "uri_apple_music": "",
-      "uri_youtube_music": ""
+      "uri_apple_music": "applemusic://track/1443150938",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=D6QF4sB40gU"
     },
     {
       "year": 1966,
@@ -595,8 +595,8 @@
       "fun_fact": "Considered Holland-Dozier-Holland's masterpiece. Levi Stubbs' passionate vocal was influenced by Bob Dylan's raw delivery. Phil Collins later covered it, reaching #19 in the US.",
       "fun_fact_de": "Gilt als Meisterwerk von Holland-Dozier-Holland. Levi Stubbs' leidenschaftlicher Gesang war von Bob Dylans rohem Vortragsstil beeinflusst. Phil Collins coverte den Song später und erreichte #19 in den USA.",
       "fun_fact_es": "Considerada la obra maestra de Holland-Dozier-Holland. La apasionada voz de Levi Stubbs fue influenciada por el estilo crudo de Bob Dylan. Phil Collins la versionó más tarde, alcanzando el #19 en EE.UU.",
-      "uri_apple_music": "",
-      "uri_youtube_music": ""
+      "uri_apple_music": "applemusic://track/1475818105",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=1v4twH9KbnU"
     },
     {
       "year": 1971,
@@ -623,8 +623,8 @@
       "fun_fact": "Berry Gordy called it 'the worst thing I ever heard' and refused to release it. Marvin threatened to never record again. The album of the same name is consistently ranked among the greatest albums of all time.",
       "fun_fact_de": "Berry Gordy nannte es 'das Schlimmste, was ich je gehört habe' und weigerte sich, es zu veröffentlichen. Marvin drohte, nie wieder aufzunehmen. Das gleichnamige Album zählt konstant zu den besten Alben aller Zeiten.",
       "fun_fact_es": "Berry Gordy lo llamó 'lo peor que he escuchado' y se negó a publicarlo. Marvin amenazó con no volver a grabar. El álbum homónimo es constantemente clasificado entre los mejores álbumes de todos los tiempos.",
-      "uri_apple_music": "",
-      "uri_youtube_music": ""
+      "uri_apple_music": "applemusic://track/1442022122",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=ApthDWoPMFQ"
     },
     {
       "year": 1967,
@@ -647,8 +647,8 @@
       "fun_fact": "Recorded in 1964 but not released until 1967. The song was written by Holland-Dozier-Holland and is about a woman pining for her boyfriend who is away. It became one of the Vandellas' signature songs.",
       "fun_fact_de": "1964 aufgenommen, aber erst 1967 veröffentlicht. Der Song wurde von Holland-Dozier-Holland geschrieben und handelt von einer Frau, die sich nach ihrem abwesenden Freund sehnt.",
       "fun_fact_es": "Grabada en 1964 pero no publicada hasta 1967. Escrita por Holland-Dozier-Holland, trata de una mujer que extraña a su novio ausente. Se convirtió en una de las canciones insignia de las Vandellas.",
-      "uri_apple_music": "",
-      "uri_youtube_music": ""
+      "uri_apple_music": "applemusic://track/1443753742",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=F1dRr6VypB8"
     },
     {
       "year": 1970,
@@ -673,8 +673,8 @@
       "fun_fact": "Knocked The Beatles' 'Let It Be' from the #1 position, symbolically marking a generational shift in pop music. Michael Jackson was just 11 years old when this topped the charts.",
       "fun_fact_de": "Verdrängte 'Let It Be' der Beatles von Platz 1 und markierte symbolisch einen Generationswechsel in der Popmusik. Michael Jackson war erst 11 Jahre alt, als der Song die Charts anführte.",
       "fun_fact_es": "Sacó a 'Let It Be' de The Beatles del #1, marcando simbólicamente un cambio generacional en la música pop. Michael Jackson tenía solo 11 años cuando lideró las listas.",
-      "uri_apple_music": "",
-      "uri_youtube_music": ""
+      "uri_apple_music": "applemusic://track/1440918277",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=niXNQ5dEcEA"
     },
     {
       "year": 1970,
@@ -699,8 +699,8 @@
       "fun_fact": "One of Gladys Knight's signature songs at Motown. She and The Pips were one of the label's most consistent hit-makers but often felt overshadowed by The Supremes and The Temptations.",
       "fun_fact_de": "Einer von Gladys Knights Erkennungssongs bei Motown. Sie und die Pips waren eine der konstantesten Hitmaschinen des Labels, fühlten sich aber oft von den Supremes und Temptations in den Schatten gestellt.",
       "fun_fact_es": "Una de las canciones insignia de Gladys Knight en Motown. Ella y los Pips fueron uno de los actos más consistentes del sello, pero a menudo se sentían eclipsados por The Supremes y The Temptations.",
-      "uri_apple_music": "",
-      "uri_youtube_music": ""
+      "uri_apple_music": "applemusic://track/1440919440",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=VeZfsXcMrBI"
     },
     {
       "year": 1964,
@@ -723,7 +723,7 @@
       "fun_fact": "Kim Weston was one of Motown's most versatile vocalists, best known for her duet 'It Takes Two' with Marvin Gaye. The Doobie Brothers later covered this song in 1975, reaching #11 on the Billboard Hot 100.",
       "fun_fact_de": "Kim Weston war eine der vielseitigsten Sängerinnen bei Motown, am bekanntesten für ihr Duett 'It Takes Two' mit Marvin Gaye. Die Doobie Brothers coverten diesen Song 1975 und erreichten #11 der Billboard Hot 100.",
       "fun_fact_es": "Kim Weston fue una de las vocalistas más versátiles de Motown, más conocida por su dueto 'It Takes Two' con Marvin Gaye. Los Doobie Brothers versionaron esta canción en 1975, alcanzando el #11 en Billboard Hot 100.",
-      "uri_apple_music": "",
+      "uri_apple_music": "applemusic://track/1443843981",
       "uri_youtube_music": ""
     },
     {
@@ -749,8 +749,8 @@
       "fun_fact": "Written by Norman Whitfield and Barrett Strong, this was one of Marvin Gaye's most joyful recordings. It reached #4 on the Billboard Hot 100 and became a Northern Soul dance floor favorite in the UK.",
       "fun_fact_de": "Geschrieben von Norman Whitfield und Barrett Strong, war dies eine von Marvin Gayes fröhlichsten Aufnahmen. Der Song erreichte #4 der Billboard Hot 100 und wurde ein Northern-Soul-Tanzflächen-Favorit in Großbritannien.",
       "fun_fact_es": "Escrita por Norman Whitfield y Barrett Strong, fue una de las grabaciones más alegres de Marvin Gaye. Alcanzó el #4 en Billboard Hot 100 y se convirtió en un favorito de las pistas de baile del Northern Soul en el Reino Unido.",
-      "uri_apple_music": "",
-      "uri_youtube_music": ""
+      "uri_apple_music": "applemusic://track/1452829547",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=fhSDOkettKo"
     },
     {
       "year": 1985,
@@ -777,8 +777,8 @@
       "fun_fact": "A tribute to Marvin Gaye and Jackie Wilson, both of whom died in 1984. It was the Commodores' biggest hit after Lionel Richie left the group and won the Grammy for Best R&B Performance.",
       "fun_fact_de": "Eine Hommage an Marvin Gaye und Jackie Wilson, die beide 1984 starben. Es war der größte Hit der Commodores nach Lionel Richies Abgang und gewann den Grammy für die beste R&B-Performance.",
       "fun_fact_es": "Un tributo a Marvin Gaye y Jackie Wilson, ambos fallecidos en 1984. Fue el mayor éxito de los Commodores después de que Lionel Richie dejara el grupo y ganó el Grammy a Mejor Interpretación R&B.",
-      "uri_apple_music": "",
-      "uri_youtube_music": ""
+      "uri_apple_music": "applemusic://track/1442252401",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=FrkEDe6Ljqs"
     },
     {
       "year": 1970,
@@ -803,8 +803,8 @@
       "fun_fact": "Originally an album track from 1967, it was released as a single in the UK first where it hit #1, then in the US where it also reached #1. Smokey wrote the lyrics to match a melody Stevie Wonder had composed.",
       "fun_fact_de": "Ursprünglich ein Albumtrack von 1967, wurde er zuerst in Großbritannien als Single veröffentlicht, wo er #1 erreichte, dann in den USA, wo er ebenfalls #1 wurde. Smokey schrieb den Text zu einer Melodie von Stevie Wonder.",
       "fun_fact_es": "Originalmente un tema de álbum de 1967, se lanzó primero como sencillo en el Reino Unido donde llegó al #1, y luego en EE.UU. donde también alcanzó el #1. Smokey escribió la letra para una melodía compuesta por Stevie Wonder.",
-      "uri_apple_music": "",
-      "uri_youtube_music": ""
+      "uri_apple_music": "applemusic://track/1447414676",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=51B55OQysj8"
     },
     {
       "year": 1970,
@@ -827,8 +827,8 @@
       "fun_fact": "Co-written by Stevie Wonder and produced by him as well. This was The Spinners' biggest hit during their Motown years before they moved to Atlantic Records and had even greater success.",
       "fun_fact_de": "Co-geschrieben und produziert von Stevie Wonder. Dies war der größte Hit der Spinners während ihrer Motown-Jahre, bevor sie zu Atlantic Records wechselten und noch größere Erfolge hatten.",
       "fun_fact_es": "Co-escrita y producida por Stevie Wonder. Fue el mayor éxito de The Spinners en sus años en Motown, antes de mudarse a Atlantic Records y tener éxitos aún mayores.",
-      "uri_apple_music": "",
-      "uri_youtube_music": ""
+      "uri_apple_music": "applemusic://track/1411666388",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=kDFFHLrzTDM"
     },
     {
       "year": 1966,
@@ -851,8 +851,8 @@
       "fun_fact": "Written by Holland-Dozier-Holland, this driving R&B track showcased Jr. Walker's raw saxophone style. The song was one of the grittier, more rock-influenced tracks in the Motown catalog.",
       "fun_fact_de": "Geschrieben von Holland-Dozier-Holland, zeigte dieser treibende R&B-Track Jr. Walkers rauen Saxophon-Stil. Der Song war einer der härteren, rockigeren Tracks im Motown-Katalog.",
       "fun_fact_es": "Escrita por Holland-Dozier-Holland, esta enérgica pista de R&B mostró el estilo crudo de saxofón de Jr. Walker. Fue una de las canciones más crudas e influenciadas por el rock del catálogo de Motown.",
-      "uri_apple_music": "",
-      "uri_youtube_music": ""
+      "uri_apple_music": "applemusic://track/1444098834",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=bjAdfZp8mWw"
     },
     {
       "year": 1977,
@@ -879,8 +879,8 @@
       "fun_fact": "Originally recorded by Harold Melvin & the Blue Notes. Thelma Houston's disco-infused version became her only #1 hit. She won the Grammy for Best R&B Female Vocal Performance for this recording.",
       "fun_fact_de": "Ursprünglich aufgenommen von Harold Melvin & the Blue Notes. Thelma Houstons Disco-Version wurde ihr einziger #1-Hit. Sie gewann den Grammy für die beste weibliche R&B-Gesangsleistung.",
       "fun_fact_es": "Originalmente grabada por Harold Melvin & the Blue Notes. La versión disco de Thelma Houston fue su único #1. Ganó el Grammy a Mejor Interpretación Vocal Femenina de R&B.",
-      "uri_apple_music": "",
-      "uri_youtube_music": ""
+      "uri_apple_music": "applemusic://track/259133290",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=8sAbzZjXLy8"
     },
     {
       "year": 1964,
@@ -903,8 +903,8 @@
       "fun_fact": "The Velvelettes were one of Motown's underrated girl groups from Kalamazoo, Michigan. They were discovered by Motown A&R man Mickey Stevenson and recorded several Northern Soul favorites.",
       "fun_fact_de": "Die Velvelettes waren eine der unterschätzten Girlgroups von Motown aus Kalamazoo, Michigan. Sie wurden von Motown-A&R-Mann Mickey Stevenson entdeckt und nahmen mehrere Northern-Soul-Favoriten auf.",
       "fun_fact_es": "The Velvelettes fueron uno de los grupos femeninos infravalorados de Motown, de Kalamazoo, Michigan. Fueron descubiertas por el A&R de Motown Mickey Stevenson y grabaron varios favoritos del Northern Soul.",
-      "uri_apple_music": "",
-      "uri_youtube_music": ""
+      "uri_apple_music": "applemusic://track/1447557853",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=w0OFTebIuUY"
     },
     {
       "year": 1975,
@@ -929,8 +929,8 @@
       "fun_fact": "The Miracles' biggest hit, but it came after Smokey Robinson had left the group. Billy Griffin took over as lead singer and brought a more modern funk-disco sound to the group.",
       "fun_fact_de": "Der größte Hit der Miracles, aber er kam erst nach Smokey Robinsons Abgang. Billy Griffin übernahm als Leadsänger und brachte einen moderneren Funk-Disco-Sound in die Gruppe.",
       "fun_fact_es": "El mayor éxito de The Miracles, pero llegó después de que Smokey Robinson dejara el grupo. Billy Griffin asumió como vocalista y trajo un sonido funk-disco más moderno al grupo.",
-      "uri_apple_music": "",
-      "uri_youtube_music": ""
+      "uri_apple_music": "applemusic://track/1471566080",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=hNAZxdyQFEY"
     },
     {
       "year": 1968,
@@ -957,7 +957,7 @@
       "fun_fact": "Written by Burt Bacharach and Hal David, this became one of Dionne Warwick's signature songs and won the Grammy for Best Contemporary Pop Vocal Performance. Though not a Motown recording, it appears in this Spotify playlist alongside the Motown classics.",
       "fun_fact_de": "Geschrieben von Burt Bacharach und Hal David, wurde dies einer von Dionne Warwicks Erkennungssongs und gewann den Grammy für die beste zeitgenössische Pop-Gesangsleistung. Obwohl keine Motown-Aufnahme, erscheint er in dieser Spotify-Playlist neben den Motown-Klassikern.",
       "fun_fact_es": "Escrita por Burt Bacharach y Hal David, se convirtió en una de las canciones insignia de Dionne Warwick y ganó el Grammy a Mejor Interpretación Vocal Pop Contemporánea. Aunque no es una grabación de Motown, aparece en esta playlist de Spotify junto a los clásicos de Motown.",
-      "uri_apple_music": "",
+      "uri_apple_music": "applemusic://track/1442238891",
       "uri_youtube_music": ""
     },
     {
@@ -983,8 +983,8 @@
       "fun_fact": "Minnie Riperton's iconic whistle-register vocal made this one of the most recognizable songs of the 1970s. Stevie Wonder co-produced the album and played keyboards. The birdsong heard in the recording was real, captured outside the studio.",
       "fun_fact_de": "Minnie Ripertons ikonischer Pfeifregister-Gesang machte dies zu einem der bekanntesten Songs der 1970er. Stevie Wonder co-produzierte das Album und spielte Keyboards. Der Vogelgesang in der Aufnahme war echt und wurde vor dem Studio eingefangen.",
       "fun_fact_es": "La icónica voz en registro de silbido de Minnie Riperton hizo de esta una de las canciones más reconocibles de los 70. Stevie Wonder co-produjo el álbum y tocó los teclados. El canto de pájaros en la grabación era real, capturado fuera del estudio.",
-      "uri_apple_music": "",
-      "uri_youtube_music": ""
+      "uri_apple_music": "applemusic://track/1444166661",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=OFCF0u-xc1Q"
     },
     {
       "year": 1979,
@@ -1009,8 +1009,8 @@
       "fun_fact": "From the movie 'Fast Break.' Syreeta Wright was Stevie Wonder's ex-wife and a talented songwriter in her own right. Billy Preston was known as the 'Fifth Beatle' for his work with The Beatles.",
       "fun_fact_de": "Aus dem Film 'Fast Break'. Syreeta Wright war Stevie Wonders Ex-Frau und eine talentierte Songwriterin. Billy Preston war als 'Fünfter Beatle' für seine Arbeit mit den Beatles bekannt.",
       "fun_fact_es": "De la película 'Fast Break'. Syreeta Wright era la ex esposa de Stevie Wonder y una talentosa compositora. Billy Preston era conocido como el 'Quinto Beatle' por su trabajo con The Beatles.",
-      "uri_apple_music": "",
-      "uri_youtube_music": ""
+      "uri_apple_music": "applemusic://track/1592733500",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=RlERDQepZqE"
     },
     {
       "year": 1972,
@@ -1035,8 +1035,8 @@
       "fun_fact": "A cover of Shep and the Limelites' 1961 doo-wop classic. It was Jermaine's first major solo hit while still a member of The Jackson 5. He stayed at Motown when his brothers left for Epic Records.",
       "fun_fact_de": "Ein Cover des Doo-Wop-Klassikers von Shep and the Limelites von 1961. Es war Jermaines erster großer Solo-Hit als Mitglied der Jackson 5. Er blieb bei Motown, als seine Brüder zu Epic Records wechselten.",
       "fun_fact_es": "Una versión del clásico doo-wop de Shep and the Limelites de 1961. Fue el primer gran éxito en solitario de Jermaine siendo aún miembro de los Jackson 5. Se quedó en Motown cuando sus hermanos se fueron a Epic Records.",
-      "uri_apple_music": "",
-      "uri_youtube_music": ""
+      "uri_apple_music": "applemusic://track/1440912319",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=uhNnlD3uNS0"
     },
     {
       "year": 1983,
@@ -1061,8 +1061,8 @@
       "fun_fact": "The 'African' chant in the song ('Tom bo li de say de moi ya') is actually made-up language. Lionel consulted with African students at his alma mater Tuskegee University for authentic-sounding syllables.",
       "fun_fact_de": "Der 'afrikanische' Gesang im Song ('Tom bo li de say de moi ya') ist tatsächlich eine erfundene Sprache. Lionel beriet sich mit afrikanischen Studenten seiner Alma Mater Tuskegee University für authentisch klingende Silben.",
       "fun_fact_es": "El canto 'africano' de la canción ('Tom bo li de say de moi ya') es en realidad un idioma inventado. Lionel consultó con estudiantes africanos de su alma mater, la Universidad Tuskegee, para lograr sílabas que sonaran auténticas.",
-      "uri_apple_music": "",
-      "uri_youtube_music": ""
+      "uri_apple_music": "applemusic://track/1440781676",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=nqAvFx3NxUM"
     },
     {
       "year": 1969,
@@ -1087,8 +1087,8 @@
       "fun_fact": "The Jackson 5's debut single and their first of four consecutive #1 hits. Michael was only 11 years old. The bass line, played by Wilton Felder, is considered one of the greatest in pop music history.",
       "fun_fact_de": "Die Debütsingle der Jackson 5 und ihr erster von vier aufeinanderfolgenden #1-Hits. Michael war erst 11 Jahre alt. Die Basslinie von Wilton Felder gilt als eine der größten in der Pop-Geschichte.",
       "fun_fact_es": "El sencillo debut de los Jackson 5 y el primero de cuatro #1 consecutivos. Michael tenía solo 11 años. La línea de bajo de Wilton Felder se considera una de las mejores de la historia del pop.",
-      "uri_apple_music": "",
-      "uri_youtube_music": ""
+      "uri_apple_music": "applemusic://track/1440912105",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=6NWhFo3B8Q0"
     },
     {
       "year": 1966,
@@ -1113,8 +1113,8 @@
       "fun_fact": "Phil Collins covered it in 1982 and also took it to #1. The song features the classic Holland-Dozier-Holland production with its driving beat and call-and-response vocals.",
       "fun_fact_de": "Phil Collins coverte den Song 1982 und brachte ihn ebenfalls auf Platz 1. Der Song zeigt die klassische Holland-Dozier-Holland-Produktion mit treibendem Beat und Call-and-Response-Gesang.",
       "fun_fact_es": "Phil Collins la versionó en 1982 y también la llevó al #1. La canción presenta la producción clásica de Holland-Dozier-Holland con su ritmo enérgico y voces de llamada y respuesta.",
-      "uri_apple_music": "",
-      "uri_youtube_music": ""
+      "uri_apple_music": "applemusic://track/1443094110",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=ovoBi3pXD_A"
     },
     {
       "year": 1966,
@@ -1137,8 +1137,8 @@
       "fun_fact": "Written by Holland-Dozier-Holland. It became a bigger hit in the UK on reissue in 1968 and again when Rod Stewart recorded a duet version with Ronald Isley in 1990.",
       "fun_fact_de": "Geschrieben von Holland-Dozier-Holland. In Großbritannien wurde er bei Wiederveröffentlichung 1968 ein größerer Hit und erneut, als Rod Stewart 1990 eine Duettversion mit Ronald Isley aufnahm.",
       "fun_fact_es": "Escrita por Holland-Dozier-Holland. Fue un éxito mayor en el Reino Unido al reeditarse en 1968 y de nuevo cuando Rod Stewart grabó un dueto con Ronald Isley en 1990.",
-      "uri_apple_music": "",
-      "uri_youtube_music": ""
+      "uri_apple_music": "applemusic://track/1444118296",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=M1xIQmTious"
     },
     {
       "year": 1968,
@@ -1161,8 +1161,8 @@
       "fun_fact": "A cover of Tim Hardin's folk classic, transformed into a soul masterpiece by Levi Stubbs' powerful vocal delivery. Bobby Darin's version had been a hit two years earlier.",
       "fun_fact_de": "Ein Cover von Tim Hardins Folk-Klassiker, verwandelt in ein Soul-Meisterwerk durch Levi Stubbs' kraftvollen Gesang. Bobby Darins Version war zwei Jahre zuvor ein Hit gewesen.",
       "fun_fact_es": "Una versión del clásico folk de Tim Hardin, transformada en una obra maestra del soul por la poderosa interpretación vocal de Levi Stubbs. La versión de Bobby Darin había sido un éxito dos años antes.",
-      "uri_apple_music": "",
-      "uri_youtube_music": ""
+      "uri_apple_music": "applemusic://track/1442427097",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=9gHztMbTGe0"
     },
     {
       "year": 1962,
@@ -1187,8 +1187,8 @@
       "fun_fact": "Originally written for The Temptations but they couldn't be found when it was time to record. It re-entered the charts in 1988 after being featured in the film 'Dirty Dancing.'",
       "fun_fact_de": "Ursprünglich für die Temptations geschrieben, die aber zum Aufnahmetermin nicht auffindbar waren. Der Song schaffte es 1988 erneut in die Charts, nachdem er im Film 'Dirty Dancing' verwendet wurde.",
       "fun_fact_es": "Originalmente escrita para los Temptations, pero no pudieron encontrarlos para la grabación. Volvió a las listas en 1988 tras aparecer en la película 'Dirty Dancing'.",
-      "uri_apple_music": "",
-      "uri_youtube_music": ""
+      "uri_apple_music": "applemusic://track/1572562126",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=ZiftWZnyzB4"
     },
     {
       "year": 1973,
@@ -1213,8 +1213,8 @@
       "fun_fact": "One of the most iconic love songs ever recorded. Marvin was inspired by meeting Janis Hunter, who would become his second wife. The opening notes are among the most recognizable in music history.",
       "fun_fact_de": "Einer der ikonischsten Liebessongs aller Zeiten. Marvin wurde inspiriert durch die Begegnung mit Janis Hunter, die seine zweite Frau wurde. Die Anfangstöne gehören zu den bekanntesten in der Musikgeschichte.",
       "fun_fact_es": "Una de las canciones de amor más icónicas jamás grabadas. Marvin se inspiró al conocer a Janis Hunter, quien se convertiría en su segunda esposa. Las notas iniciales son de las más reconocibles de la historia.",
-      "uri_apple_music": "",
-      "uri_youtube_music": ""
+      "uri_apple_music": "applemusic://track/1442361627",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=AqPBfbLoF_M"
     },
     {
       "year": 1981,
@@ -1241,8 +1241,8 @@
       "fun_fact": "Spent 9 weeks at #1, making it the most successful Motown single ever at the time. Written for Franco Zeffirelli's film of the same name. It was also nominated for an Academy Award.",
       "fun_fact_de": "Stand 9 Wochen auf Platz 1 und war damit die erfolgreichste Motown-Single aller Zeiten. Geschrieben für Franco Zeffirellis gleichnamigen Film. Wurde auch für den Oscar nominiert.",
       "fun_fact_es": "Estuvo 9 semanas en el #1, convirtiéndose en el sencillo más exitoso de Motown en su momento. Escrita para la película homónima de Franco Zeffirelli. También fue nominada al Oscar.",
-      "uri_apple_music": "",
-      "uri_youtube_music": ""
+      "uri_apple_music": "applemusic://track/1440783169",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=u4Vwe1i-b1M"
     },
     {
       "year": 1972,
@@ -1269,8 +1269,8 @@
       "fun_fact": "A love song about a pet rat, from the horror film 'Ben.' Michael was only 14 when it became his first solo #1 hit. It was nominated for an Academy Award for Best Original Song.",
       "fun_fact_de": "Ein Liebeslied über eine Ratte aus dem Horrorfilm 'Ben'. Michael war erst 14, als es sein erster Solo-#1-Hit wurde. Es war für den Oscar als bester Originalsong nominiert.",
       "fun_fact_es": "Una canción de amor sobre una rata mascota, de la película de terror 'Ben'. Michael tenía solo 14 años cuando se convirtió en su primer #1 en solitario. Fue nominada al Oscar a Mejor Canción Original.",
-      "uri_apple_music": "",
-      "uri_youtube_music": ""
+      "uri_apple_music": "applemusic://track/1443228831",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=i7TTSzfs2kw"
     },
     {
       "year": 1965,
@@ -1293,8 +1293,8 @@
       "fun_fact": "The Rolling Stones covered it on their 1982 live album 'Still Life.' The song perfectly captures the excitement of 1960s nightlife and became a Northern Soul dance floor favorite.",
       "fun_fact_de": "Die Rolling Stones coverten den Song auf ihrem 1982er Live-Album 'Still Life'. Der Song fängt die Aufregung des Nachtlebens der 1960er perfekt ein und wurde ein Favorit der Northern-Soul-Tanzflächen.",
       "fun_fact_es": "Los Rolling Stones la versionaron en su álbum en vivo de 1982 'Still Life'. La canción captura perfectamente la emoción de la vida nocturna de los 60 y se convirtió en un favorito de las pistas de baile del Northern Soul.",
-      "uri_apple_music": "",
-      "uri_youtube_music": ""
+      "uri_apple_music": "applemusic://track/1469577681",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=QBXoH53ObYo"
     },
     {
       "year": 1966,
@@ -1319,8 +1319,8 @@
       "fun_fact": "Vanilla Fudge turned it into a psychedelic rock epic, and Kim Wilde took it back to #1 in 1987. The song's urgent telephone-ring guitar riff was played by Funk Brothers guitarist Eddie Willis.",
       "fun_fact_de": "Vanilla Fudge verwandelten es in ein psychedelisches Rock-Epos, und Kim Wilde brachte es 1987 zurück auf Platz 1. Das drängende Telefon-Gitarrenriff spielte Funk-Brothers-Gitarrist Eddie Willis.",
       "fun_fact_es": "Vanilla Fudge la convirtió en una épica de rock psicodélico, y Kim Wilde la devolvió al #1 en 1987. El urgente riff de guitarra tipo timbre telefónico fue tocado por el guitarrista de Funk Brothers Eddie Willis.",
-      "uri_apple_music": "",
-      "uri_youtube_music": ""
+      "uri_apple_music": "applemusic://track/1443222812",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=pi00f6oiMu4"
     },
     {
       "year": 1965,
@@ -1343,8 +1343,8 @@
       "fun_fact": "Written by Holland-Dozier-Holland. The song was recorded partly on a Ford car assembly line at the River Rouge plant in Dearborn, Michigan, with the factory sounds providing a unique percussive backdrop.",
       "fun_fact_de": "Geschrieben von Holland-Dozier-Holland. Der Song wurde teilweise am Ford-Fließband im River-Rouge-Werk in Dearborn, Michigan, aufgenommen, wobei die Fabrikgeräusche eine einzigartige perkussive Kulisse boten.",
       "fun_fact_es": "Escrita por Holland-Dozier-Holland. La canción fue grabada parcialmente en una línea de ensamblaje de Ford en la planta River Rouge en Dearborn, Michigan, con los sonidos de la fábrica como fondo percusivo.",
-      "uri_apple_music": "",
-      "uri_youtube_music": ""
+      "uri_apple_music": "applemusic://track/1444115999",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=EexqF4tz-8U"
     },
     {
       "year": 1973,
@@ -1369,8 +1369,8 @@
       "fun_fact": "Eddie's biggest solo hit after leaving The Temptations. Its smooth falsetto and funky groove helped define the proto-disco sound. The single version fades out but the album version extends to over 8 minutes.",
       "fun_fact_de": "Eddies größter Solo-Hit nach dem Verlassen der Temptations. Sein sanftes Falsett und der funkige Groove halfen, den Proto-Disco-Sound zu definieren. Die Single blendet aus, die Albumversion dauert über 8 Minuten.",
       "fun_fact_es": "El mayor éxito en solitario de Eddie tras dejar los Temptations. Su suave falsete y groove funky ayudaron a definir el sonido proto-disco. La versión del sencillo se desvanece, pero la del álbum dura más de 8 minutos.",
-      "uri_apple_music": "",
-      "uri_youtube_music": ""
+      "uri_apple_music": "applemusic://track/1471566069",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=UjKwmlH0EJE"
     },
     {
       "year": 1962,
@@ -1393,8 +1393,8 @@
       "fun_fact": "Written by Marvin Gaye, who was then a session drummer at Motown. The phone number in the title was completely fictitious, but fans still tried calling it for years.",
       "fun_fact_de": "Geschrieben von Marvin Gaye, der damals Session-Drummer bei Motown war. Die Telefonnummer im Titel war komplett erfunden, aber Fans versuchten jahrelang, sie anzurufen.",
       "fun_fact_es": "Escrita por Marvin Gaye, quien entonces era baterista de sesión en Motown. El número de teléfono del título era completamente ficticio, pero los fans intentaron llamarlo durante años.",
-      "uri_apple_music": "",
-      "uri_youtube_music": ""
+      "uri_apple_music": "applemusic://track/1443811830",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Us18AUBM2RI"
     },
     {
       "year": 1969,
@@ -1417,8 +1417,8 @@
       "fun_fact": "David's first solo single after being fired from The Temptations for his diva behavior. The emotional title seemed to mirror his real-life situation of losing his place in the group.",
       "fun_fact_de": "Davids erste Solo-Single nach seinem Rauswurf bei den Temptations wegen seines Diva-Verhaltens. Der emotionale Titel schien seine reale Situation widerzuspiegeln.",
       "fun_fact_es": "El primer sencillo en solitario de David después de ser despedido de los Temptations por su comportamiento de diva. El emotivo título parecía reflejar su situación real de perder su lugar en el grupo.",
-      "uri_apple_music": "",
-      "uri_youtube_music": ""
+      "uri_apple_music": "applemusic://track/1444105844",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=yLJ7jk6YBw8"
     },
     {
       "year": 1981,
@@ -1443,8 +1443,8 @@
       "fun_fact": "Smokey's biggest solo hit and a massive #1 in the UK, kept from the US top spot only by 'Bette Davis Eyes.' It showed Smokey could thrive as a solo artist decades after co-founding Motown.",
       "fun_fact_de": "Smokeys größter Solo-Hit und eine massive #1 in Großbritannien, in den USA nur von 'Bette Davis Eyes' von Platz 1 ferngehalten. Es zeigte, dass Smokey Jahrzehnte nach der Motown-Gründung als Solokünstler bestehen konnte.",
       "fun_fact_es": "El mayor éxito en solitario de Smokey y un enorme #1 en el Reino Unido, solo impedido de alcanzar la cima en EE.UU. por 'Bette Davis Eyes'. Demostró que Smokey podía triunfar en solitario décadas después de cofundar Motown.",
-      "uri_apple_music": "",
-      "uri_youtube_music": ""
+      "uri_apple_music": "applemusic://track/1443067999",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=0P2a6aLDkkM"
     },
     {
       "year": 1985,
@@ -1469,8 +1469,8 @@
       "fun_fact": "Featured in the film 'The Last Dragon,' a martial arts-meets-Motown movie. DeBarge was a family group often compared to The Jacksons. El DeBarge's falsetto drew comparisons to a young Michael Jackson.",
       "fun_fact_de": "Im Film 'The Last Dragon' zu hören, einer Kampfkunst-trifft-Motown-Produktion. DeBarge war eine Familienband, oft mit den Jacksons verglichen. El DeBarges Falsett erinnerte an den jungen Michael Jackson.",
       "fun_fact_es": "Apareció en la película 'The Last Dragon', una producción de artes marciales y Motown. DeBarge era un grupo familiar frecuentemente comparado con los Jacksons. El falsete de El DeBarge recordaba al joven Michael Jackson.",
-      "uri_apple_music": "",
-      "uri_youtube_music": ""
+      "uri_apple_music": "applemusic://track/1443092508",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=cAQSZhazYk8"
     },
     {
       "year": 1981,
@@ -1495,8 +1495,8 @@
       "fun_fact": "MC Hammer sampled the bass line for 'U Can't Touch This,' which became a massive hit. Rick James initially sued but they settled and he received songwriting credit and royalties. The Temptations sang backup.",
       "fun_fact_de": "MC Hammer sampelte die Basslinie für 'U Can't Touch This'. Rick James klagte zunächst, aber sie einigten sich und er erhielt Songwriting-Credit und Tantiemen. Die Temptations sangen die Backing Vocals.",
       "fun_fact_es": "MC Hammer sampleó la línea de bajo para 'U Can't Touch This'. Rick James demandó inicialmente pero llegaron a un acuerdo y recibió crédito como compositor y regalías. Los Temptations cantaron los coros.",
-      "uri_apple_music": "",
-      "uri_youtube_music": ""
+      "uri_apple_music": "applemusic://track/1440805227",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=QYHxGBH6o4M"
     },
     {
       "year": 1984,
@@ -1519,8 +1519,8 @@
       "fun_fact": "Dennis Edwards was the lead singer of The Temptations. The song became a massive hip-hop sample source, used by 2Pac, Eric B. & Rakim, and many others. Siedah Garrett later co-wrote Michael Jackson's 'Man in the Mirror.'",
       "fun_fact_de": "Dennis Edwards war Leadsänger der Temptations. Der Song wurde eine bedeutende Hip-Hop-Sample-Quelle, verwendet von 2Pac, Eric B. & Rakim und vielen anderen. Siedah Garrett schrieb später Michael Jacksons 'Man in the Mirror' mit.",
       "fun_fact_es": "Dennis Edwards fue el vocalista de The Temptations. La canción se convirtió en una fuente de samples masiva para el hip-hop, utilizada por 2Pac, Eric B. & Rakim y muchos otros. Siedah Garrett co-escribió 'Man in the Mirror' de Michael Jackson.",
-      "uri_apple_music": "",
-      "uri_youtube_music": ""
+      "uri_apple_music": "applemusic://track/1490296342",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=CH3rx8LhrQo"
     },
     {
       "year": 1979,
@@ -1543,8 +1543,8 @@
       "fun_fact": "Originally a 1966 hit by The Elgins on Motown. Bonnie Pointer, who left The Pointer Sisters for a solo career on Motown, gave it a disco treatment that became her biggest solo hit.",
       "fun_fact_de": "Ursprünglich ein Hit von The Elgins aus dem Jahr 1966. Bonnie Pointer, die die Pointer Sisters für eine Solokarriere bei Motown verließ, gab dem Song ein Disco-Treatment und landete damit ihren größten Solo-Hit.",
       "fun_fact_es": "Originalmente un éxito de The Elgins de 1966. Bonnie Pointer, quien dejó las Pointer Sisters para una carrera en solitario en Motown, le dio un tratamiento disco que se convirtió en su mayor éxito.",
-      "uri_apple_music": "",
-      "uri_youtube_music": ""
+      "uri_apple_music": "applemusic://track/1430158363",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=owiYwYdjgM8"
     },
     {
       "year": 1967,
@@ -1567,8 +1567,8 @@
       "fun_fact": "Marvin's first major duet hit. Kim Weston left Motown shortly after, and Tammi Terrell became his most famous duet partner. The song was later covered by Rod Stewart and Tina Turner in 1990.",
       "fun_fact_de": "Marvins erster großer Duett-Hit. Kim Weston verließ Motown kurz darauf und Tammi Terrell wurde seine berühmteste Duett-Partnerin. Rod Stewart und Tina Turner coverten den Song 1990.",
       "fun_fact_es": "El primer gran éxito a dúo de Marvin. Kim Weston dejó Motown poco después y Tammi Terrell se convirtió en su compañera de dueto más famosa. Rod Stewart y Tina Turner la versionaron en 1990.",
-      "uri_apple_music": "",
-      "uri_youtube_music": ""
+      "uri_apple_music": "applemusic://track/1469581640",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=DVWH9InLMiA"
     },
     {
       "year": 1969,
@@ -1591,8 +1591,8 @@
       "fun_fact": "A massive hit in the UK's Northern Soul scene, reaching #5 on the UK charts. The Isley Brothers had a complicated relationship with Motown and eventually left for greater creative freedom at T-Neck Records.",
       "fun_fact_de": "Ein riesiger Hit in der britischen Northern-Soul-Szene, der Platz 5 der UK-Charts erreichte. Die Isley Brothers hatten ein kompliziertes Verhältnis zu Motown und gingen schließlich für mehr kreative Freiheit zu T-Neck Records.",
       "fun_fact_es": "Un gran éxito en la escena del Northern Soul británico, alcanzando el #5 en las listas del Reino Unido. Los Isley Brothers tuvieron una relación complicada con Motown y finalmente se fueron a T-Neck Records por mayor libertad creativa.",
-      "uri_apple_music": "",
-      "uri_youtube_music": ""
+      "uri_apple_music": "applemusic://track/1444126112",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=qTkt1j_y9JQ"
     },
     {
       "year": 1970,
@@ -1615,8 +1615,8 @@
       "fun_fact": "Diana's first solo single after leaving The Supremes. Written by Ashford & Simpson, it became her concert signature, with Diana walking into the audience to literally touch hands.",
       "fun_fact_de": "Dianas erste Solo-Single nach dem Verlassen der Supremes. Geschrieben von Ashford & Simpson, wurde es ihr Konzertsignatur-Song, bei dem Diana ins Publikum ging, um buchstäblich Hände zu berühren.",
       "fun_fact_es": "El primer sencillo en solitario de Diana tras dejar las Supremes. Escrita por Ashford & Simpson, se convirtió en su firma en conciertos, donde Diana caminaba entre el público para tocar las manos.",
-      "uri_apple_music": "",
-      "uri_youtube_music": ""
+      "uri_apple_music": "applemusic://track/1442551842",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=tCsSP33g75s"
     },
     {
       "year": 1983,
@@ -1641,8 +1641,8 @@
       "fun_fact": "From his self-titled debut album. Lionel wrote it as a love ballad to his first wife Brenda. The album produced three top-five hits and launched one of the most successful solo careers in pop history.",
       "fun_fact_de": "Von seinem selbstbetitelten Debütalbum. Lionel schrieb es als Liebesballade für seine erste Frau Brenda. Das Album produzierte drei Top-5-Hits und startete eine der erfolgreichsten Solokarrieren der Pop-Geschichte.",
       "fun_fact_es": "De su álbum debut homónimo. Lionel la escribió como balada de amor para su primera esposa Brenda. El álbum produjo tres éxitos en el top 5 y lanzó una de las carreras en solitario más exitosas de la historia del pop.",
-      "uri_apple_music": "",
-      "uri_youtube_music": ""
+      "uri_apple_music": "applemusic://track/1443202192",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=0353jrboqOc"
     },
     {
       "year": 1971,
@@ -1667,8 +1667,8 @@
       "fun_fact": "Michael's debut solo single while still a member of The Jackson 5. He was just 13 years old. The song showcased the emotional maturity that would define his legendary career.",
       "fun_fact_de": "Michaels Debüt-Solo-Single, während er noch Mitglied der Jackson 5 war. Er war erst 13 Jahre alt. Der Song zeigte die emotionale Reife, die seine legendäre Karriere definieren sollte.",
       "fun_fact_es": "El primer sencillo en solitario de Michael siendo aún miembro de los Jackson 5. Tenía solo 13 años. La canción mostró la madurez emocional que definiría su legendaria carrera.",
-      "uri_apple_music": "",
-      "uri_youtube_music": ""
+      "uri_apple_music": "applemusic://track/1471565643",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Y9cixo-iXAE"
     },
     {
       "year": 1967,
@@ -1691,8 +1691,8 @@
       "fun_fact": "Co-written by Smokey Robinson and Miracles guitarist Al Cleveland. The phrase came from a malapropism Cleveland used in conversation, saying 'I second that emotion' instead of 'motion.' Japan's version reached #1 in their charts.",
       "fun_fact_de": "Co-geschrieben von Smokey Robinson und Miracles-Gitarrist Al Cleveland. Der Ausdruck entstand aus einem Versprecher Clevelands, der 'I second that emotion' statt 'motion' sagte.",
       "fun_fact_es": "Co-escrita por Smokey Robinson y el guitarrista de los Miracles Al Cleveland. La frase surgió de un error de Cleveland, quien dijo 'I second that emotion' en vez de 'motion'.",
-      "uri_apple_music": "",
-      "uri_youtube_music": ""
+      "uri_apple_music": "applemusic://track/1447558979",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=u_4ghyswYAU"
     },
     {
       "year": 1970,
@@ -1717,8 +1717,8 @@
       "fun_fact": "Originally recorded by The Temptations but Motown feared the anti-war message would alienate their fans. Edwin Starr's intense version became a Vietnam-era protest anthem. 'War! What is it good for? Absolutely nothing!' became one of rock's most quoted lines.",
       "fun_fact_de": "Ursprünglich von den Temptations aufgenommen, aber Motown befürchtete, die Anti-Kriegs-Botschaft könnte Fans vergraulen. Edwin Starrs intensive Version wurde zur Protestsymne der Vietnam-Ära.",
       "fun_fact_es": "Originalmente grabada por The Temptations, pero Motown temía que el mensaje antibélico alienara a sus fans. La intensa versión de Edwin Starr se convirtió en un himno de protesta de la era de Vietnam.",
-      "uri_apple_music": "",
-      "uri_youtube_music": ""
+      "uri_apple_music": "applemusic://track/1454735131",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=yM71RwDtEE0"
     },
     {
       "year": 1966,
@@ -1741,8 +1741,8 @@
       "fun_fact": "Another Holland-Dozier-Holland masterpiece. The song's dramatic arrangement influenced the development of Northern Soul and was covered by artists from Rod Stewart to The Jackson 5.",
       "fun_fact_de": "Ein weiteres Meisterwerk von Holland-Dozier-Holland. Das dramatische Arrangement beeinflusste die Entwicklung des Northern Soul und wurde von Rod Stewart bis zu den Jackson 5 gecovert.",
       "fun_fact_es": "Otra obra maestra de Holland-Dozier-Holland. El dramático arreglo influyó en el desarrollo del Northern Soul y fue versionada por artistas desde Rod Stewart hasta los Jackson 5.",
-      "uri_apple_music": "",
-      "uri_youtube_music": ""
+      "uri_apple_music": "applemusic://track/1440912159",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=NhEuFW7l5c4"
     },
     {
       "year": 1964,
@@ -1765,8 +1765,8 @@
       "fun_fact": "The Spinners (also known as The Detroit Spinners in the UK) had limited success at Motown but later became one of the top soul groups of the 1970s after moving to Atlantic Records.",
       "fun_fact_de": "Die Spinners (in Großbritannien als Detroit Spinners bekannt) hatten bei Motown begrenzten Erfolg, wurden aber nach dem Wechsel zu Atlantic Records in den 1970ern eine der Top-Soul-Gruppen.",
       "fun_fact_es": "The Spinners (conocidos como Detroit Spinners en el Reino Unido) tuvieron éxito limitado en Motown pero se convirtieron en uno de los principales grupos soul de los 70 tras mudarse a Atlantic Records.",
-      "uri_apple_music": "",
-      "uri_youtube_music": ""
+      "uri_apple_music": "applemusic://track/1452829703",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=LYxjAXNNzQE"
     },
     {
       "year": 1964,
@@ -1791,8 +1791,8 @@
       "fun_fact": "The Supremes' third consecutive #1 hit, all written by Holland-Dozier-Holland. It was originally given to The Marvelettes before Berry Gordy decided The Supremes should record it.",
       "fun_fact_de": "Der dritte aufeinanderfolgende #1-Hit der Supremes, alle geschrieben von Holland-Dozier-Holland. Ursprünglich für die Marvelettes vorgesehen, bevor Berry Gordy entschied, dass die Supremes ihn aufnehmen sollten.",
       "fun_fact_es": "El tercer #1 consecutivo de las Supremes, todos escritos por Holland-Dozier-Holland. Originalmente fue asignada a las Marvelettes antes de que Berry Gordy decidiera que las Supremes debían grabarla.",
-      "uri_apple_music": "",
-      "uri_youtube_music": ""
+      "uri_apple_music": "applemusic://track/1475817718",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=NkH_dm9NkxQ"
     },
     {
       "year": 1972,
@@ -1815,8 +1815,8 @@
       "fun_fact": "Valerie Simpson was half of the legendary songwriting duo Ashford & Simpson, who wrote 'Ain't No Mountain High Enough' and many other Motown classics. Her solo work showcased her stunning vocal ability.",
       "fun_fact_de": "Valerie Simpson war die Hälfte des legendären Songwriting-Duos Ashford & Simpson, die 'Ain't No Mountain High Enough' und viele andere Motown-Klassiker schrieben. Ihr Solowerk zeigte ihre atemberaubende Gesangsfähigkeit.",
       "fun_fact_es": "Valerie Simpson era la mitad del legendario dúo de compositores Ashford & Simpson, quienes escribieron 'Ain't No Mountain High Enough' y muchos otros clásicos de Motown. Su trabajo en solitario mostró su impresionante habilidad vocal.",
-      "uri_apple_music": "",
-      "uri_youtube_music": ""
+      "uri_apple_music": "applemusic://track/1430157352",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=7T7utl7-ssk"
     },
     {
       "year": 1997,
@@ -1841,8 +1841,8 @@
       "fun_fact": "Boyz II Men signed to Motown in 1991, reviving the label's relevance in contemporary R&B. This song gave them their fourth #1 hit, produced by Jimmy Jam and Terry Lewis.",
       "fun_fact_de": "Boyz II Men unterschrieben 1991 bei Motown und belebten die Relevanz des Labels im zeitgenössischen R&B. Dieser Song bescherte ihnen ihren vierten #1-Hit, produziert von Jimmy Jam und Terry Lewis.",
       "fun_fact_es": "Boyz II Men firmaron con Motown en 1991, reviviendo la relevancia del sello en el R&B contemporáneo. Esta canción les dio su cuarto #1, producida por Jimmy Jam y Terry Lewis.",
-      "uri_apple_music": "",
-      "uri_youtube_music": ""
+      "uri_apple_music": "applemusic://track/1444047057",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=fUSOZAgl95A"
     },
     {
       "year": 1999,
@@ -1868,7 +1868,7 @@
       "fun_fact_de": "Brian McKnights größter Hit, veröffentlicht bei Motown Records. Er ist Multiinstrumentalist und spielt neun Instrumente. Der Song war einer der letzten großen Hits auf dem Motown-Label im 20. Jahrhundert.",
       "fun_fact_es": "El mayor éxito de Brian McKnight, publicado en Motown Records. Es multiinstrumentista y toca nueve instrumentos. La canción fue uno de los últimos grandes éxitos del sello Motown en el siglo XX.",
       "uri_apple_music": "",
-      "uri_youtube_music": ""
+      "uri_youtube_music": "https://music.youtube.com/watch?v=SN3m8sKyjYk"
     },
     {
       "year": 1985,
@@ -1894,7 +1894,7 @@
       "fun_fact_de": "Vom Album 'Glow', das Rick James' Vielseitigkeit zeigte, als er Funk mit weicheren R&B-Balladen kombinierte. Rick war auch dafür bekannt, Teena Marie bei Motown entdeckt und gefördert zu haben.",
       "fun_fact_es": "Del álbum 'Glow', que mostró la versatilidad de Rick James al equilibrar funk con baladas R&B más suaves. Rick también era conocido por descubrir y ser mentor de Teena Marie en Motown.",
       "uri_apple_music": "",
-      "uri_youtube_music": ""
+      "uri_youtube_music": "https://music.youtube.com/watch?v=BFe4BMgcSd0"
     },
     {
       "year": 1988,
@@ -1917,8 +1917,8 @@
       "fun_fact": "Gerald Alston was the lead singer of The Manhattans before launching his solo career on Motown. His smooth tenor voice was perfectly suited for romantic ballads in the quiet storm tradition.",
       "fun_fact_de": "Gerald Alston war Leadsänger der Manhattans, bevor er seine Solokarriere bei Motown startete. Seine sanfte Tenorstimme war perfekt geeignet für romantische Balladen in der Quiet-Storm-Tradition.",
       "fun_fact_es": "Gerald Alston fue el vocalista de The Manhattans antes de lanzar su carrera en solitario en Motown. Su suave voz de tenor era perfecta para baladas románticas en la tradición del quiet storm.",
-      "uri_apple_music": "",
-      "uri_youtube_music": ""
+      "uri_apple_music": "applemusic://track/1430161432",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=ULBACmcRES0"
     },
     {
       "year": 1969,
@@ -1943,8 +1943,8 @@
       "fun_fact": "Written and produced by Marvin Gaye, who also sang background vocals. The Originals were one of Motown's underappreciated groups who also served as backing vocalists for other Motown artists.",
       "fun_fact_de": "Geschrieben und produziert von Marvin Gaye, der auch die Hintergrundstimme sang. Die Originals waren eine der unterschätzten Gruppen von Motown, die auch als Backgroundsänger für andere Motown-Künstler dienten.",
       "fun_fact_es": "Escrita y producida por Marvin Gaye, quien también cantó los coros. The Originals fueron uno de los grupos infravalorados de Motown que también sirvieron como vocalistas de respaldo para otros artistas del sello.",
-      "uri_apple_music": "",
-      "uri_youtube_music": ""
+      "uri_apple_music": "applemusic://track/581217805",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Eucp9qqKG0o"
     },
     {
       "year": 1966,
@@ -1967,8 +1967,8 @@
       "fun_fact": "Written by Smokey Robinson, this was The Marvelettes' last major hit. The group struggled as Motown focused more attention on The Supremes, but their early recordings helped establish the Motown sound.",
       "fun_fact_de": "Geschrieben von Smokey Robinson, war dies der letzte große Hit der Marvelettes. Die Gruppe hatte es schwer, da Motown mehr Aufmerksamkeit auf die Supremes richtete.",
       "fun_fact_es": "Escrita por Smokey Robinson, fue el último gran éxito de las Marvelettes. El grupo tuvo dificultades cuando Motown centró más atención en las Supremes.",
-      "uri_apple_music": "",
-      "uri_youtube_music": ""
+      "uri_apple_music": "applemusic://track/1443813168",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=dABWW58dR6U"
     },
     {
       "year": 1962,
@@ -1991,8 +1991,8 @@
       "fun_fact": "The Beatles covered this on their 'With The Beatles' album, cementing the transatlantic connection between Motown and the British Invasion. John Lennon was a huge Smokey Robinson fan.",
       "fun_fact_de": "Die Beatles coverten diesen Song auf ihrem Album 'With The Beatles' und festigten die transatlantische Verbindung zwischen Motown und der British Invasion. John Lennon war ein großer Smokey-Robinson-Fan.",
       "fun_fact_es": "Los Beatles la versionaron en su álbum 'With The Beatles', cimentando la conexión transatlántica entre Motown y la invasión británica. John Lennon era un gran fan de Smokey Robinson.",
-      "uri_apple_music": "",
-      "uri_youtube_music": ""
+      "uri_apple_music": "applemusic://track/1442732378",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=xyC7QIKQLWU"
     },
     {
       "year": 1964,
@@ -2015,8 +2015,8 @@
       "fun_fact": "Co-written by Smokey Robinson and Bobby Rogers, this was The Temptations' first major hit with its clever string of similes. The Temptations re-recorded it with Hall & Oates in 1985, reaching #20 on the Billboard Hot 100.",
       "fun_fact_de": "Co-geschrieben von Smokey Robinson und Bobby Rogers, war dies der erste große Hit der Temptations mit seiner cleveren Reihe von Vergleichen. Die Temptations nahmen ihn 1985 mit Hall & Oates neu auf und erreichten #20.",
       "fun_fact_es": "Co-escrita por Smokey Robinson y Bobby Rogers, fue el primer gran éxito de los Temptations con su ingeniosa cadena de símiles. Los Temptations la regrabaron con Hall & Oates en 1985, alcanzando el #20.",
-      "uri_apple_music": "",
-      "uri_youtube_music": ""
+      "uri_apple_music": "applemusic://track/1452829685",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=GdIDUsMrmuY"
     },
     {
       "year": 1980,
@@ -2039,8 +2039,8 @@
       "fun_fact": "Teena Marie was one of Motown's few white artists. Rick James discovered her and she was initially marketed without showing her photo so listeners wouldn't know her race. She became known as the 'Ivory Queen of Soul.'",
       "fun_fact_de": "Teena Marie war eine der wenigen weißen Künstlerinnen bei Motown. Rick James entdeckte sie und sie wurde anfangs ohne Foto vermarktet, damit Hörer ihre Hautfarbe nicht kannten. Sie wurde als 'Ivory Queen of Soul' bekannt.",
       "fun_fact_es": "Teena Marie fue una de las pocas artistas blancas de Motown. Rick James la descubrió y fue comercializada inicialmente sin mostrar su foto para que los oyentes no supieran su raza. Fue conocida como la 'Reina de Marfil del Soul'.",
-      "uri_apple_music": "",
-      "uri_youtube_music": ""
+      "uri_apple_music": "applemusic://track/1430158374",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=m6DK8KFPDN8"
     },
     {
       "year": 1980,
@@ -2063,8 +2063,8 @@
       "fun_fact": "From the 'diana' album produced by Nile Rodgers and Bernard Edwards of Chic. The album was initially remixed by Motown without Diana's consent, causing a major controversy. 'My Old Piano' was a UK hit reaching #5.",
       "fun_fact_de": "Vom Album 'diana', produziert von Nile Rodgers und Bernard Edwards von Chic. Das Album wurde zunächst ohne Dianas Zustimmung von Motown remixt, was eine große Kontroverse auslöste. 'My Old Piano' erreichte #5 in Großbritannien.",
       "fun_fact_es": "Del álbum 'diana', producido por Nile Rodgers y Bernard Edwards de Chic. El álbum fue remezclado inicialmente por Motown sin el consentimiento de Diana, causando una gran controversia. 'My Old Piano' alcanzó el #5 en el Reino Unido.",
-      "uri_apple_music": "",
-      "uri_youtube_music": ""
+      "uri_apple_music": "applemusic://track/1452791802",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=dxFmU3_VlQM"
     },
     {
       "year": 1968,
@@ -2087,8 +2087,8 @@
       "fun_fact": "Written by Ashford & Simpson. It was one of the last songs Tammi Terrell recorded before her health declined from a brain tumor. Marvin was so devastated by her death in 1970 that he retreated from performing for years.",
       "fun_fact_de": "Geschrieben von Ashford & Simpson. Es war einer der letzten Songs, die Tammi Terrell vor ihrem gesundheitlichen Verfall durch einen Hirntumor aufnahm. Marvin war so erschüttert von ihrem Tod 1970, dass er sich jahrelang vom Auftreten zurückzog.",
       "fun_fact_es": "Escrita por Ashford & Simpson. Fue una de las últimas canciones que Tammi Terrell grabó antes de que su salud declinara por un tumor cerebral. Marvin quedó tan devastado por su muerte en 1970 que se retiró de actuar durante años.",
-      "uri_apple_music": "",
-      "uri_youtube_music": ""
+      "uri_apple_music": "applemusic://track/1426017466",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Jz_D-greh8Q"
     },
     {
       "year": 1971,
@@ -2113,8 +2113,8 @@
       "fun_fact": "Eddie Kendricks' last #1 hit with The Temptations before going solo. The dreamy, floating arrangement by Norman Whitfield was a dramatic contrast to the group's recent psychedelic funk direction.",
       "fun_fact_de": "Eddie Kendricks' letzter #1-Hit mit den Temptations vor seiner Solokarriere. Das verträumte, schwebende Arrangement von Norman Whitfield war ein dramatischer Kontrast zur jüngsten psychedelischen Funk-Richtung der Gruppe.",
       "fun_fact_es": "El último #1 de Eddie Kendricks con The Temptations antes de su carrera en solitario. El arreglo soñador y flotante de Norman Whitfield fue un contraste dramático con la reciente dirección de funk psicodélico del grupo.",
-      "uri_apple_music": "",
-      "uri_youtube_music": ""
+      "uri_apple_music": "applemusic://track/1443183041",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=WNnb1NfLrK4"
     },
     {
       "year": 1965,
@@ -2139,8 +2139,8 @@
       "fun_fact": "One of the greatest Burt Bacharach-Hal David compositions, Dionne Warwick's original 1964 version is considered definitive. Isaac Hayes later recorded a 12-minute epic version. Though not a Motown recording, it appears in this Spotify playlist.",
       "fun_fact_de": "Eine der größten Kompositionen von Burt Bacharach und Hal David. Dionne Warwicks Originalversion von 1964 gilt als die definitive Fassung. Isaac Hayes nahm später eine 12-minütige epische Version auf. Obwohl keine Motown-Aufnahme, erscheint sie in dieser Spotify-Playlist.",
       "fun_fact_es": "Una de las mejores composiciones de Burt Bacharach-Hal David, la versión original de Dionne Warwick de 1964 se considera definitiva. Isaac Hayes grabó más tarde una versión épica de 12 minutos. Aunque no es de Motown, aparece en esta playlist de Spotify.",
-      "uri_apple_music": "",
-      "uri_youtube_music": ""
+      "uri_apple_music": "applemusic://track/1446927022",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=boGPChaPo5Y"
     },
     {
       "year": 1979,
@@ -2165,8 +2165,8 @@
       "fun_fact": "Written by Lionel Richie in just five minutes on the back of a paper bag. It was the Commodores' second #1 pop hit after 'Three Times a Lady' and helped establish Lionel as a premier ballad writer.",
       "fun_fact_de": "Von Lionel Richie in nur fünf Minuten auf der Rückseite einer Papiertüte geschrieben. Es war der zweite #1-Pop-Hit der Commodores nach 'Three Times a Lady' und etablierte Lionel als erstklassigen Balladen-Autor.",
       "fun_fact_es": "Escrita por Lionel Richie en solo cinco minutos en el reverso de una bolsa de papel. Fue el segundo #1 pop de los Commodores después de 'Three Times a Lady' y estableció a Lionel como un escritor de baladas de primera.",
-      "uri_apple_music": "",
-      "uri_youtube_music": ""
+      "uri_apple_music": "applemusic://track/1440783371",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=gCjXXvb0AKk"
     },
     {
       "year": 1974,
@@ -2189,8 +2189,8 @@
       "fun_fact": "Originally a 1971 hit by The Stylistics. The Diana Ross and Marvin Gaye duet version was a bigger hit in the UK, reaching #5. Their duet album was actually assembled from separate recording sessions.",
       "fun_fact_de": "Ursprünglich ein Hit der Stylistics von 1971. Die Duettversion von Diana Ross und Marvin Gaye war in Großbritannien ein größerer Hit und erreichte #5. Ihr Duett-Album wurde tatsächlich aus separaten Aufnahme-Sessions zusammengestellt.",
       "fun_fact_es": "Originalmente un éxito de The Stylistics de 1971. La versión a dúo de Diana Ross y Marvin Gaye fue un éxito mayor en el Reino Unido, alcanzando el #5. Su álbum de duetos fue ensamblado a partir de sesiones de grabación separadas.",
-      "uri_apple_music": "",
-      "uri_youtube_music": ""
+      "uri_apple_music": "applemusic://track/1469579507",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Qr4IDzrXS-c"
     },
     {
       "year": 1970,
@@ -2215,8 +2215,8 @@
       "fun_fact": "The Jackson 5's fourth consecutive #1 hit and the best-selling single in Motown history at the time. Michael's mature vocal performance at age 12 astonished listeners. Mariah Carey later covered it, also reaching #1.",
       "fun_fact_de": "Der vierte aufeinanderfolgende #1-Hit der Jackson 5 und die meistverkaufte Single in der Geschichte von Motown. Michaels reifer Gesang mit 12 Jahren verblüffte die Zuhörer. Mariah Carey coverte den Song später und erreichte ebenfalls #1.",
       "fun_fact_es": "El cuarto #1 consecutivo de los Jackson 5 y el sencillo más vendido de la historia de Motown. La madura interpretación vocal de Michael a los 12 años asombró a los oyentes. Mariah Carey la versionó más tarde, también alcanzando el #1.",
-      "uri_apple_music": "",
-      "uri_youtube_music": ""
+      "uri_apple_music": "applemusic://track/1443186637",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=VRdG9vEJOKY"
     },
     {
       "year": 1964,
@@ -2239,8 +2239,8 @@
       "fun_fact": "Later covered by Bananarama in 1982, who turned it into a UK Top 5 hit. The Velvelettes were from Kalamazoo, Michigan and were one of Motown's most beloved but commercially underperforming girl groups.",
       "fun_fact_de": "Später 1982 von Bananarama gecovert, die daraus einen UK-Top-5-Hit machten. Die Velvelettes stammten aus Kalamazoo, Michigan und waren eine der beliebtesten, aber kommerziell weniger erfolgreichen Girlgroups von Motown.",
       "fun_fact_es": "Versionada por Bananarama en 1982, quienes la convirtieron en un éxito Top 5 en el Reino Unido. Las Velvelettes eran de Kalamazoo, Michigan y fueron uno de los grupos femeninos más queridos pero comercialmente menos exitosos de Motown.",
-      "uri_apple_music": "",
-      "uri_youtube_music": ""
+      "uri_apple_music": "applemusic://track/1452187494",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=PJxZ9C3EZaA"
     },
     {
       "year": 1962,
@@ -2263,8 +2263,8 @@
       "fun_fact": "Written and produced by Smokey Robinson, who crafted many of Mary Wells' biggest hits. Mary was Motown's first female star and helped establish the label's presence on the pop charts.",
       "fun_fact_de": "Geschrieben und produziert von Smokey Robinson, der viele von Mary Wells' größten Hits schuf. Mary war Motowns erster weiblicher Star und half, die Präsenz des Labels in den Pop-Charts zu etablieren.",
       "fun_fact_es": "Escrita y producida por Smokey Robinson, quien creó muchos de los mayores éxitos de Mary Wells. Mary fue la primera estrella femenina de Motown y ayudó a establecer la presencia del sello en las listas pop.",
-      "uri_apple_music": "",
-      "uri_youtube_music": ""
+      "uri_apple_music": "applemusic://track/1443906582",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=rzt9_c7cw5s"
     },
     {
       "year": 1968,
@@ -2287,8 +2287,8 @@
       "fun_fact": "One of Marvin Gaye's earliest hits, written by Holland-Dozier-Holland. The Rolling Stones covered it during their early career, helping spread the Motown sound to British rock audiences. The gospel-influenced call-and-response style defined early Motown.",
       "fun_fact_de": "Einer von Marvin Gayes frühesten Hits, geschrieben von Holland-Dozier-Holland. Die Rolling Stones coverten ihn in ihrer frühen Karriere und verbreiteten den Motown-Sound beim britischen Rock-Publikum. Der Gospel-beeinflusste Call-and-Response-Stil prägte das frühe Motown.",
       "fun_fact_es": "Uno de los primeros éxitos de Marvin Gaye, escrita por Holland-Dozier-Holland. Los Rolling Stones la versionaron al inicio de su carrera, ayudando a difundir el sonido Motown entre el público del rock británico. El estilo gospel de llamada y respuesta definió el Motown temprano.",
-      "uri_apple_music": "",
-      "uri_youtube_music": ""
+      "uri_apple_music": "applemusic://track/1455384527",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=-YdTLDQCVH4"
     },
     {
       "year": 1965,
@@ -2313,8 +2313,8 @@
       "fun_fact": "Jr. Walker's first and biggest hit, named after a popular dance. He was one of Motown's few instrumentalists to achieve major success as a frontman. The raw, honking saxophone defined the song's irresistible groove.",
       "fun_fact_de": "Jr. Walkers erster und größter Hit, benannt nach einem beliebten Tanz. Er war einer der wenigen Instrumentalisten bei Motown, die als Frontman großen Erfolg hatten. Das raue, schnarrende Saxophon definierte den unwiderstehlichen Groove des Songs.",
       "fun_fact_es": "El primer y mayor éxito de Jr. Walker, nombrado por un baile popular. Fue uno de los pocos instrumentistas de Motown en lograr gran éxito como líder. El saxofón crudo y estridente definió el irresistible groove de la canción.",
-      "uri_apple_music": "",
-      "uri_youtube_music": ""
+      "uri_apple_music": "applemusic://track/1611669451",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=6FgO2Hs4t_4"
     },
     {
       "year": 1963,
@@ -2339,8 +2339,8 @@
       "fun_fact": "Written by Holland-Dozier-Holland, it was the first Motown song to earn a Grammy nomination. Linda Ronstadt covered it in 1975 and also had a Top 5 hit. The song helped establish the Motown Sound.",
       "fun_fact_de": "Geschrieben von Holland-Dozier-Holland, war es der erste Motown-Song, der eine Grammy-Nominierung erhielt. Linda Ronstadt coverte ihn 1975 und landete ebenfalls einen Top-5-Hit.",
       "fun_fact_es": "Escrita por Holland-Dozier-Holland, fue la primera canción de Motown en obtener una nominación al Grammy. Linda Ronstadt la versionó en 1975 y también tuvo un éxito Top 5.",
-      "uri_apple_music": "",
-      "uri_youtube_music": ""
+      "uri_apple_music": "applemusic://track/1444017336",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=64w0UqTHGFg"
     },
     {
       "year": 1980,
@@ -2365,8 +2365,8 @@
       "fun_fact": "Written and produced by Stevie Wonder. Jermaine stayed at Motown when his brothers left for Epic Records because he had married Berry Gordy's daughter Hazel. This became his biggest solo hit at Motown.",
       "fun_fact_de": "Geschrieben und produziert von Stevie Wonder. Jermaine blieb bei Motown, als seine Brüder zu Epic Records wechselten, weil er Berry Gordys Tochter Hazel geheiratet hatte. Dies wurde sein größter Solo-Hit bei Motown.",
       "fun_fact_es": "Escrita y producida por Stevie Wonder. Jermaine se quedó en Motown cuando sus hermanos se fueron a Epic Records porque se había casado con Hazel, la hija de Berry Gordy. Este fue su mayor éxito en solitario en Motown.",
-      "uri_apple_music": "",
-      "uri_youtube_music": ""
+      "uri_apple_music": "applemusic://track/1471567104",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=uJjRWyqL7nA"
     },
     {
       "year": 1987,
@@ -2391,8 +2391,8 @@
       "fun_fact": "Yes, that Bruce Willis! The 'Die Hard' star released this cover of The Drifters' classic on Motown Records. His album 'The Return of Bruno' was a surprising commercial success, especially in Europe.",
       "fun_fact_de": "Ja, genau der Bruce Willis! Der 'Stirb langsam'-Star veröffentlichte dieses Cover des Drifters-Klassikers bei Motown Records. Sein Album 'The Return of Bruno' war ein überraschender kommerzieller Erfolg, besonders in Europa.",
       "fun_fact_es": "¡Sí, ese Bruce Willis! La estrella de 'Duro de Matar' lanzó esta versión del clásico de los Drifters en Motown Records. Su álbum 'The Return of Bruno' fue un sorprendente éxito comercial, especialmente en Europa.",
-      "uri_apple_music": "",
-      "uri_youtube_music": ""
+      "uri_apple_music": "applemusic://track/1442210829",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=en9ZWmt5UxI"
     },
     {
       "year": 1981,
@@ -2417,8 +2417,8 @@
       "fun_fact": "From the same album as 'Super Freak' (Street Songs). Rick James revitalized Motown's relevance in the early 1980s with his funk-punk style. The album sold over 3 million copies.",
       "fun_fact_de": "Vom gleichen Album wie 'Super Freak' (Street Songs). Rick James belebte Motowns Relevanz in den frühen 1980ern mit seinem Funk-Punk-Stil neu. Das Album verkaufte sich über 3 Millionen Mal.",
       "fun_fact_es": "Del mismo álbum que 'Super Freak' (Street Songs). Rick James revitalizó la relevancia de Motown a principios de los 80 con su estilo funk-punk. El álbum vendió más de 3 millones de copias.",
-      "uri_apple_music": "",
-      "uri_youtube_music": ""
+      "uri_apple_music": "applemusic://track/1440805217",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=1dNIQVYGXbM"
     },
     {
       "year": 1984,
@@ -2443,8 +2443,8 @@
       "fun_fact": "Rockwell was actually Berry Gordy's son, Kennedy Gordy, recording under a pseudonym. Michael Jackson sang the memorable chorus as a favor. The song became a Halloween staple and gained new popularity through internet memes.",
       "fun_fact_de": "Rockwell war tatsächlich Berry Gordys Sohn, Kennedy Gordy, der unter Pseudonym aufnahm. Michael Jackson sang den einprägsamen Refrain als Gefallen. Der Song wurde ein Halloween-Klassiker und gewann durch Internet-Memes neue Popularität.",
       "fun_fact_es": "Rockwell era en realidad el hijo de Berry Gordy, Kennedy Gordy, grabando bajo seudónimo. Michael Jackson cantó el memorable coro como un favor. La canción se convirtió en un clásico de Halloween y ganó nueva popularidad a través de memes de internet.",
-      "uri_apple_music": "",
-      "uri_youtube_music": ""
+      "uri_apple_music": "applemusic://track/1278579752",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=7YvAYIJSSZY"
     },
     {
       "year": 1991,
@@ -2469,8 +2469,8 @@
       "fun_fact": "Shanice was just 18 when this became a worldwide smash. It features a distinctive jazz flute solo. The song helped keep Motown relevant in the early 1990s new jack swing era.",
       "fun_fact_de": "Shanice war erst 18, als dies ein weltweiter Hit wurde. Es enthält ein markantes Jazz-Flöten-Solo. Der Song half, Motown in der frühen New-Jack-Swing-Ära der 1990er relevant zu halten.",
       "fun_fact_es": "Shanice tenía solo 18 años cuando este se convirtió en un éxito mundial. Presenta un distintivo solo de flauta jazz. La canción ayudó a mantener a Motown relevante en la era del new jack swing de los 90.",
-      "uri_apple_music": "",
-      "uri_youtube_music": ""
+      "uri_apple_music": "applemusic://track/1444166434",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=ysYyCElzB0A"
     },
     {
       "year": 1991,
@@ -2495,8 +2495,8 @@
       "fun_fact": "The group's debut single, produced by Dallas Austin. The title blends 'Motown' (their label) with 'Philly' (their hometown of Philadelphia). Michael Bivins of New Edition discovered and mentored the group.",
       "fun_fact_de": "Die Debütsingle der Gruppe, produziert von Dallas Austin. Der Titel verbindet 'Motown' (ihr Label) mit 'Philly' (ihre Heimatstadt Philadelphia). Michael Bivins von New Edition entdeckte und förderte die Gruppe.",
       "fun_fact_es": "El sencillo debut del grupo, producido por Dallas Austin. El título mezcla 'Motown' (su sello) con 'Philly' (su ciudad natal Philadelphia). Michael Bivins de New Edition descubrió y fue mentor del grupo.",
-      "uri_apple_music": "",
-      "uri_youtube_music": ""
+      "uri_apple_music": "applemusic://track/1444183110",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Rciee-oQLoI"
     },
     {
       "year": 1986,
@@ -2521,8 +2521,8 @@
       "fun_fact": "From the soundtrack of the movie 'Short Circuit.' El DeBarge's falsetto was often compared to a young Michael Jackson. The song was his biggest solo hit and one of Motown's last major pop crossover successes of the decade.",
       "fun_fact_de": "Vom Soundtrack des Films 'Nummer 5 lebt!'. El DeBarges Falsett wurde oft mit dem jungen Michael Jackson verglichen. Der Song war sein größter Solo-Hit und einer der letzten großen Pop-Crossover-Erfolge von Motown in diesem Jahrzehnt.",
       "fun_fact_es": "De la banda sonora de la película 'Cortocircuito'. El falsete de El DeBarge fue frecuentemente comparado con el del joven Michael Jackson. Fue su mayor éxito en solitario y uno de los últimos grandes éxitos pop crossover de Motown en la década.",
-      "uri_apple_music": "",
-      "uri_youtube_music": ""
+      "uri_apple_music": "applemusic://track/1443821020",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=F5V1nSUgYA4"
     },
     {
       "year": 1979,
@@ -2545,8 +2545,8 @@
       "fun_fact": "The second single from their duet album 'Billy Preston & Syreeta.' It showcased the musical chemistry between the 'Fifth Beatle' and Stevie Wonder's ex-wife. Syreeta also co-wrote Stevie's 'Signed, Sealed, Delivered.'",
       "fun_fact_de": "Die zweite Single von ihrem Duett-Album. Es zeigte die musikalische Chemie zwischen dem 'Fünften Beatle' und Stevie Wonders Ex-Frau. Syreeta schrieb auch Stevies 'Signed, Sealed, Delivered' mit.",
       "fun_fact_es": "El segundo sencillo de su álbum de duetos. Mostró la química musical entre el 'Quinto Beatle' y la ex esposa de Stevie Wonder. Syreeta también co-escribió 'Signed, Sealed, Delivered' de Stevie.",
-      "uri_apple_music": "",
-      "uri_youtube_music": ""
+      "uri_apple_music": "applemusic://track/1592733515",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=YXQzPRhjh_g"
     }
   ]
 }

--- a/scripts/enrich_playlists.py
+++ b/scripts/enrich_playlists.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""Enrich Beatify playlist JSON files with Apple Music and YouTube Music URIs.
+
+Uses the Odesli (song.link) API to look up cross-platform links from Spotify URIs.
+No API key required for basic usage.
+
+Usage:
+    python3 scripts/enrich_playlists.py [playlist.json ...]
+
+If no files are given, processes all JSON files in custom_components/beatify/playlists/.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+import time
+import urllib.parse
+import urllib.request
+from typing import Optional, Tuple
+
+ODESLI_ENDPOINT = "https://api.song.link/v1-alpha.1/links"
+REQUEST_DELAY = 0.15  # seconds between API calls (~6.6 req/s, well within limit)
+USER_COUNTRY = "DE"
+
+
+def spotify_uri_to_url(uri: str) -> Optional[str]:
+    """Convert 'spotify:track:ID' to 'https://open.spotify.com/track/ID'."""
+    match = re.match(r"spotify:track:(\w+)", uri)
+    if match:
+        return f"https://open.spotify.com/track/{match.group(1)}"
+    return None
+
+
+def fetch_odesli(spotify_url: str) -> Optional[dict]:
+    """Query the Odesli API and return the JSON response, or None on error."""
+    params = urllib.parse.urlencode({"url": spotify_url, "userCountry": USER_COUNTRY})
+    url = f"{ODESLI_ENDPOINT}?{params}"
+    req = urllib.request.Request(url, headers={"Accept": "application/json"})
+    try:
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            return json.loads(resp.read().decode())
+    except Exception as exc:
+        print(f"    ⚠  API error: {exc}")
+        return None
+
+
+def extract_apple_music_uri(data: dict) -> str:
+    """Extract Apple Music track ID → 'applemusic://track/<id>'."""
+    am = data.get("linksByPlatform", {}).get("appleMusic")
+    if not am:
+        return ""
+    # Primary: entityUniqueId "ITUNES_SONG::<id>"
+    entity_id = am.get("entityUniqueId", "")
+    match = re.search(r"ITUNES_SONG::(\d+)", entity_id)
+    if match:
+        return f"applemusic://track/{match.group(1)}"
+    # Fallback: parse ?i=<id> from the URL
+    url = am.get("url", "")
+    match = re.search(r"[?&]i=(\d+)", url)
+    if match:
+        return f"applemusic://track/{match.group(1)}"
+    return ""
+
+
+def extract_youtube_music_url(data: dict) -> str:
+    """Extract YouTube Music watch URL."""
+    yt = data.get("linksByPlatform", {}).get("youtubeMusic")
+    if not yt:
+        return ""
+    return yt.get("url", "")
+
+
+def process_playlist(filepath: str) -> Tuple[int, int, int, int]:
+    """Enrich a single playlist file. Returns (am_found, am_total, yt_found, yt_total)."""
+    print(f"\n📂 Processing: {os.path.basename(filepath)}")
+
+    with open(filepath, "r", encoding="utf-8") as f:
+        data = json.load(f)
+
+    songs = data.get("songs", [])
+    total = len(songs)
+    am_needed = 0
+    yt_needed = 0
+    am_found = 0
+    yt_found = 0
+    api_calls = 0
+
+    for i, song in enumerate(songs, 1):
+        need_am = not song.get("uri_apple_music")
+        need_yt = not song.get("uri_youtube_music")
+
+        if need_am:
+            am_needed += 1
+        if need_yt:
+            yt_needed += 1
+
+        if not need_am and not need_yt:
+            continue
+
+        artist = song.get("artist", "?")
+        title = song.get("title", "?")
+        uri = song.get("uri", "")
+        spotify_url = spotify_uri_to_url(uri)
+
+        if not spotify_url:
+            print(f"  [{i:3d}/{total}] ⏭  {artist} – {title} (no valid Spotify URI)")
+            continue
+
+        print(f"  [{i:3d}/{total}] 🔍 {artist} – {title}", end="", flush=True)
+
+        if api_calls > 0:
+            time.sleep(REQUEST_DELAY)
+
+        result = fetch_odesli(spotify_url)
+        api_calls += 1
+
+        if result is None:
+            print(" → ❌ API failed")
+            continue
+
+        parts = []
+        if need_am:
+            am_uri = extract_apple_music_uri(result)
+            if am_uri:
+                song["uri_apple_music"] = am_uri
+                am_found += 1
+                parts.append("🍎 ✓")
+            else:
+                parts.append("🍎 ✗")
+
+        if need_yt:
+            yt_url = extract_youtube_music_url(result)
+            if yt_url:
+                song["uri_youtube_music"] = yt_url
+                yt_found += 1
+                parts.append("🎵 ✓")
+            else:
+                parts.append("🎵 ✗")
+
+        print(f" → {' '.join(parts)}")
+
+        # Save periodically every 10 API calls
+        if api_calls % 10 == 0:
+            with open(filepath, "w", encoding="utf-8") as f:
+                json.dump(data, f, indent=2, ensure_ascii=False)
+                f.write("\n")
+
+    # Final save
+    with open(filepath, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2, ensure_ascii=False)
+        f.write("\n")
+
+    print(f"\n  ✅ Saved. Apple Music: {am_found}/{am_needed} enriched | YouTube Music: {yt_found}/{yt_needed} enriched")
+    return am_found, am_needed, yt_found, yt_needed
+
+
+def main():
+    if len(sys.argv) > 1:
+        files = sys.argv[1:]
+    else:
+        playlist_dir = os.path.join(
+            os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+            "custom_components", "beatify", "playlists",
+        )
+        files = sorted(
+            os.path.join(playlist_dir, f)
+            for f in os.listdir(playlist_dir)
+            if f.endswith(".json")
+        )
+
+    if not files:
+        print("No playlist files found.")
+        sys.exit(1)
+
+    total_am_found = total_am_needed = total_yt_found = total_yt_needed = 0
+
+    for filepath in files:
+        if not os.path.isfile(filepath):
+            print(f"⚠  File not found: {filepath}")
+            continue
+        am_f, am_n, yt_f, yt_n = process_playlist(filepath)
+        total_am_found += am_f
+        total_am_needed += am_n
+        total_yt_found += yt_f
+        total_yt_needed += yt_n
+
+    print(f"\n{'='*60}")
+    print(f"🏁 Done! Apple Music: {total_am_found}/{total_am_needed} | YouTube Music: {total_yt_found}/{total_yt_needed}")
+    print(f"{'='*60}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds **Motown & Soul Classics** playlist with 100 tracks spanning 1959-1999.

## Highlights
- 100 curated Motown & soul tracks with Spotify URIs
- Complete metadata: year, chart info, certifications, alt artists
- Fun facts in English, German, and Spanish
- Features legendary artists: Marvin Gaye, The Supremes, Stevie Wonder, The Temptations, Michael Jackson, and more

## Artists represented
Diana Ross & The Supremes, Marvin Gaye, The Temptations, Four Tops, Smokey Robinson & The Miracles, The Jackson 5, Michael Jackson, Lionel Richie, Commodores, Stevie Wonder, Gladys Knight & The Pips, Martha Reeves & The Vandellas, The Marvelettes, Rick James, Boyz II Men, and many more.

Apple Music and YouTube Music URIs pending enrichment.

Closes #73