### PR TITLE
feat(playlists): Disco & Funk Classics

### DIFF
--- a/custom_components/beatify/playlists/disco-funk-classics.json
+++ b/custom_components/beatify/playlists/disco-funk-classics.json
@@ -1,0 +1,1991 @@
+{
+  "name": "Disco & Funk Classics",
+  "version": "1.0",
+  "tags": [
+    "1970s",
+    "1980s",
+    "disco",
+    "funk",
+    "dance",
+    "international"
+  ],
+  "songs": [
+    {
+      "year": 1979,
+      "uri": "spotify:track:2rcmr9KH9yEvdKJVhXmLwG",
+      "artist": "Earth, Wind & Fire",
+      "alt_artists": [
+        "The Emotions",
+        "Kool & The Gang",
+        "The Commodores",
+        "KC & The Sunshine Band"
+      ],
+      "title": "Boogie Wonderland",
+      "chart_info": {
+        "billboard_peak": 6,
+        "uk_peak": 4,
+        "weeks_on_chart": 18
+      },
+      "certifications": [
+        "Gold (US)"
+      ],
+      "awards": [],
+      "fun_fact": "Written by Jon Lind and Allee Willis, who was inspired by the disco scene at Studio 54. The song features The Emotions on backing vocals and was used prominently in the film 'Happy Feet' decades later.",
+      "fun_fact_de": "Geschrieben von Jon Lind und Allee Willis, die sich von der Disco-Szene im Studio 54 inspirieren ließ. Der Song enthält Backing Vocals von The Emotions und wurde Jahrzehnte später prominent im Film 'Happy Feet' verwendet.",
+      "fun_fact_es": "Escrita por Jon Lind y Allee Willis, quien se inspiró en la escena disco del Studio 54. La canción presenta coros de The Emotions y se utilizó décadas después en la película 'Happy Feet'.",
+      "uri_apple_music": "applemusic://track/523223725",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=god7hAPv8f0"
+    },
+    {
+      "year": 1978,
+      "uri": "spotify:track:7K47w0YoH5wa118Fxhb0JO",
+      "artist": "CHIC",
+      "alt_artists": [
+        "Nile Rodgers",
+        "Sister Sledge",
+        "Kool & The Gang",
+        "Diana Ross"
+      ],
+      "title": "Le Freak",
+      "chart_info": {
+        "billboard_peak": 1,
+        "uk_peak": 7,
+        "weeks_on_chart": 22
+      },
+      "certifications": [
+        "2x Platinum (US)"
+      ],
+      "awards": [],
+      "fun_fact": "Originally titled 'Fuck Off' after Nile Rodgers and Bernard Edwards were denied entry to Studio 54. Atlantic Records' biggest-selling single ever at the time, it spent five weeks at #1 on the Billboard Hot 100.",
+      "fun_fact_de": "Ursprünglich 'Fuck Off' betitelt, nachdem Nile Rodgers und Bernard Edwards der Eintritt ins Studio 54 verwehrt wurde. Es war Atlantic Records' meistverkaufte Single und stand fünf Wochen auf Platz 1 der Billboard Hot 100.",
+      "fun_fact_es": "Originalmente titulada 'Fuck Off' después de que a Nile Rodgers y Bernard Edwards les negaran la entrada al Studio 54. Fue el sencillo más vendido de Atlantic Records, permaneciendo cinco semanas en el #1 del Billboard Hot 100.",
+      "uri_apple_music": "applemusic://track/847723715",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=aXgSHL7efKg"
+    },
+    {
+      "year": 1977,
+      "uri": "spotify:track:5cP52DlDN9yryuZVQDg3iq",
+      "artist": "Bee Gees",
+      "alt_artists": [
+        "Andy Gibb",
+        "Tavares",
+        "KC & The Sunshine Band",
+        "Village People"
+      ],
+      "title": "Stayin' Alive",
+      "chart_info": {
+        "billboard_peak": 1,
+        "uk_peak": 4,
+        "weeks_on_chart": 27
+      },
+      "certifications": [
+        "Platinum (US)"
+      ],
+      "awards": [],
+      "fun_fact": "The song's tempo of 104 BPM is the ideal rhythm for performing CPR chest compressions, and it's now used in medical training worldwide. It spent four weeks at #1 and became the signature song of the Saturday Night Fever era.",
+      "fun_fact_de": "Das Tempo von 104 BPM ist der ideale Rhythmus für Herz-Lungen-Wiederbelebung und wird heute weltweit in der medizinischen Ausbildung verwendet. Der Song war vier Wochen auf Platz 1 und wurde zum Erkennungssong der Saturday Night Fever-Ära.",
+      "fun_fact_es": "El tempo de 104 BPM es el ritmo ideal para realizar compresiones de RCP, y ahora se usa en formación médica en todo el mundo. Estuvo cuatro semanas en el #1 y se convirtió en la canción emblema de la era Saturday Night Fever.",
+      "uri_apple_music": "applemusic://track/1541946324",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Fa9n7GirhsI"
+    },
+    {
+      "year": 1982,
+      "uri": "spotify:track:5TgD3Wh5ZUZnUU4tmVvJbx",
+      "artist": "The Weather Girls",
+      "alt_artists": [
+        "Gloria Gaynor",
+        "Donna Summer",
+        "Martha Wash",
+        "Sylvester"
+      ],
+      "title": "It's Raining Men",
+      "chart_info": {
+        "billboard_peak": 46,
+        "uk_peak": 2,
+        "weeks_on_chart": 16
+      },
+      "certifications": [
+        "Gold (UK)"
+      ],
+      "awards": [],
+      "fun_fact": "Written by Paul Jabara and Paul Shaffer (of Late Show fame). Though it only reached #46 in the US, it became a massive hit in the UK and an enduring gay anthem. Geri Halliwell's 2001 cover topped the UK charts.",
+      "fun_fact_de": "Geschrieben von Paul Jabara und Paul Shaffer (bekannt aus der Late Show). Obwohl es in den USA nur Platz 46 erreichte, wurde es ein riesiger Hit in Großbritannien und eine zeitlose Gay-Hymne. Geri Halliwells Cover von 2001 erreichte Platz 1 in UK.",
+      "fun_fact_es": "Escrita por Paul Jabara y Paul Shaffer (famoso por el Late Show). Aunque solo llegó al #46 en EE.UU., fue un gran éxito en el Reino Unido y un himno gay perdurable. La versión de Geri Halliwell de 2001 llegó al #1 en el UK.",
+      "uri_apple_music": "applemusic://track/355893660",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=l5aZJBLAu1E"
+    },
+    {
+      "year": 1976,
+      "uri": "spotify:track:3WMbD1OyfKuwWDWMNbPQ4g",
+      "artist": "Boney M.",
+      "alt_artists": [
+        "Frank Farian",
+        "Village People",
+        "ABBA",
+        "Eruption"
+      ],
+      "title": "Daddy Cool",
+      "chart_info": {
+        "billboard_peak": 65,
+        "uk_peak": 6,
+        "weeks_on_chart": 13
+      },
+      "certifications": [
+        "Silver (UK)"
+      ],
+      "awards": [],
+      "fun_fact": "Created by producer Frank Farian, who later became infamous for the Milli Vanilli lip-syncing scandal. The male lead vocals on Boney M. records were actually performed by Farian himself, not the group's frontman Bobby Farrell.",
+      "fun_fact_de": "Produziert von Frank Farian, der später durch den Milli-Vanilli-Playback-Skandal berüchtigt wurde. Die männliche Hauptstimme auf Boney M.-Aufnahmen stammte tatsächlich von Farian selbst, nicht von Frontmann Bobby Farrell.",
+      "fun_fact_es": "Creada por el productor Frank Farian, quien luego se hizo infame por el escándalo de playback de Milli Vanilli. Las voces masculinas principales en los discos de Boney M. eran en realidad de Farian, no del frontman Bobby Farrell.",
+      "uri_apple_music": "applemusic://track/250734713",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=FYGTT7YhywA"
+    },
+    {
+      "year": 1980,
+      "uri": "spotify:track:6pc8xULSlsMdFB3OrqbvZ4",
+      "artist": "Kool & The Gang",
+      "alt_artists": [
+        "Earth, Wind & Fire",
+        "The Commodores",
+        "The Gap Band",
+        "Cameo"
+      ],
+      "title": "Celebration",
+      "chart_info": {
+        "billboard_peak": 1,
+        "uk_peak": 7,
+        "weeks_on_chart": 23
+      },
+      "certifications": [
+        "2x Platinum (US)"
+      ],
+      "awards": [],
+      "fun_fact": "Became the unofficial anthem of the 1981 release of the American hostages from Iran and has been a staple at celebrations worldwide ever since. It spent two weeks at #1 and is one of the most-played songs at weddings and sporting events.",
+      "fun_fact_de": "Wurde zur inoffiziellen Hymne der Freilassung der amerikanischen Geiseln aus dem Iran 1981 und ist seitdem bei Feiern weltweit ein Muss. Es war zwei Wochen auf Platz 1 und gehört zu den meistgespielten Songs bei Hochzeiten und Sportevents.",
+      "fun_fact_es": "Se convirtió en el himno no oficial de la liberación de los rehenes estadounidenses de Irán en 1981 y desde entonces es un clásico en celebraciones mundiales. Estuvo dos semanas en el #1 y es una de las canciones más tocadas en bodas y eventos deportivos.",
+      "uri_apple_music": "applemusic://track/1595570177",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=3GwjfUFyY6M"
+    },
+    {
+      "year": 1979,
+      "uri": "spotify:track:3XIEWK1V9n25PS9Vb6axj5",
+      "artist": "Patrick Hernandez",
+      "alt_artists": [
+        "Village People",
+        "Boney M.",
+        "Ottawan",
+        "Lipps Inc."
+      ],
+      "title": "Born to Be Alive",
+      "chart_info": {
+        "billboard_peak": 16,
+        "uk_peak": 10,
+        "weeks_on_chart": 14
+      },
+      "certifications": [
+        "Gold (France)"
+      ],
+      "awards": [],
+      "fun_fact": "This Belgian-French singer's one-hit wonder sold over 20 million copies worldwide. Madonna was once a backup dancer for Hernandez before she became famous. The song was originally recorded in 1978 but became a worldwide hit in 1979.",
+      "fun_fact_de": "Dieser belgisch-französische One-Hit-Wonder verkaufte über 20 Millionen Exemplare weltweit. Madonna war einst Backgroundtänzerin für Hernandez, bevor sie berühmt wurde. Der Song wurde 1978 aufgenommen, wurde aber erst 1979 ein Welthit.",
+      "fun_fact_es": "Este éxito único del cantante belga-francés vendió más de 20 millones de copias en todo el mundo. Madonna fue bailarina de respaldo de Hernandez antes de hacerse famosa. La canción se grabó en 1978 pero se convirtió en un éxito mundial en 1979.",
+      "uri_apple_music": "applemusic://track/1706359060",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=9UaJAnnipkY"
+    },
+    {
+      "year": 1976,
+      "uri": "spotify:track:2rgqPSIRAfaO2MGo9smdSX",
+      "artist": "ABBA",
+      "alt_artists": [
+        "Bee Gees",
+        "Boney M.",
+        "Donna Summer",
+        "Baccara"
+      ],
+      "title": "Dancing Queen",
+      "chart_info": {
+        "billboard_peak": 1,
+        "uk_peak": 1,
+        "weeks_on_chart": 20
+      },
+      "certifications": [
+        "Platinum (US)",
+        "Platinum (UK)"
+      ],
+      "awards": [],
+      "fun_fact": "ABBA's only US #1 hit, performed at the private pre-wedding gala for Sweden's King Carl XVI Gustaf and Queen Silvia in 1976. The opening piano was inspired by George McCrae's 'Rock Your Baby'. It's the most-streamed ABBA song on Spotify.",
+      "fun_fact_de": "ABBAs einzige US-Nummer-1, aufgeführt bei der privaten Vorhochzeitsgala für Schwedens König Carl XVI. Gustaf und Königin Silvia 1976. Das Intro-Piano wurde von George McCraes 'Rock Your Baby' inspiriert. Es ist der meistgestreamte ABBA-Song auf Spotify.",
+      "fun_fact_es": "El único #1 de ABBA en EE.UU., interpretada en la gala privada previa a la boda del Rey Carlos XVI Gustavo y la Reina Silvia de Suecia en 1976. El piano inicial fue inspirado por 'Rock Your Baby' de George McCrae. Es la canción más escuchada de ABBA en Spotify.",
+      "uri_apple_music": "applemusic://track/1440820267",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=xFrGuyw1V8s"
+    },
+    {
+      "year": 1984,
+      "uri": "spotify:track:2u8MGAiS2hBVE7GZzTZLQI",
+      "artist": "The Pointer Sisters",
+      "alt_artists": [
+        "Janet Jackson",
+        "Whitney Houston",
+        "Donna Summer",
+        "Tina Turner"
+      ],
+      "title": "I'm So Excited",
+      "chart_info": {
+        "billboard_peak": 9,
+        "uk_peak": 11,
+        "weeks_on_chart": 19
+      },
+      "certifications": [
+        "Gold (US)"
+      ],
+      "awards": [],
+      "fun_fact": "Originally released in 1982 and flopped, but was re-recorded with a faster tempo and re-released in 1984 to huge success. The song gained renewed fame from Jessie Spano's caffeine pill breakdown scene in 'Saved by the Bell'.",
+      "fun_fact_de": "Ursprünglich 1982 veröffentlicht und gefloppt, wurde der Song mit schnellerem Tempo neu aufgenommen und 1984 erfolgreich wiederveröffentlicht. Er erlangte neue Berühmtheit durch Jessie Spanos Koffeinpillen-Szene in 'Saved by the Bell'.",
+      "fun_fact_es": "Originalmente lanzada en 1982 sin éxito, fue regrabada con un tempo más rápido y relanzada en 1984 con gran éxito. La canción ganó nueva fama por la escena de las pastillas de cafeína de Jessie Spano en 'Salvados por la Campana'.",
+      "uri_apple_music": "applemusic://track/294037064",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=8iwBM_YB1sE"
+    },
+    {
+      "year": 1980,
+      "uri": "spotify:track:7723JnKU2R15Iv4T7OJrly",
+      "artist": "Lipps Inc.",
+      "alt_artists": [
+        "Donna Summer",
+        "Blondie",
+        "Patrick Hernandez",
+        "Village People"
+      ],
+      "title": "Funkytown",
+      "chart_info": {
+        "billboard_peak": 1,
+        "uk_peak": 2,
+        "weeks_on_chart": 20
+      },
+      "certifications": [
+        "Platinum (US)"
+      ],
+      "awards": [],
+      "fun_fact": "Steven Greenberg wrote it while living in Minneapolis, yearning to move to a more exciting music city like New York. The iconic synthesizer riff was created on a Moog and became one of the most recognizable electronic hooks in pop history.",
+      "fun_fact_de": "Steven Greenberg schrieb den Song in Minneapolis, wo er sich nach einer aufregenderen Musikstadt wie New York sehnte. Das ikonische Synthesizer-Riff wurde auf einem Moog erstellt und wurde zu einem der bekanntesten elektronischen Hooks der Popgeschichte.",
+      "fun_fact_es": "Steven Greenberg la escribió viviendo en Minneapolis, anhelando mudarse a una ciudad musical más emocionante como Nueva York. El icónico riff de sintetizador fue creado en un Moog y se convirtió en uno de los hooks electrónicos más reconocibles de la historia del pop.",
+      "uri_apple_music": "",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Z6dqIYKIBSU"
+    },
+    {
+      "year": 1979,
+      "uri": "spotify:track:2TjNlK2tNBxF8C8RIaK9Gb",
+      "artist": "ABBA",
+      "alt_artists": [
+        "Bee Gees",
+        "Boney M.",
+        "Donna Summer",
+        "Blondie"
+      ],
+      "title": "Gimme! Gimme! Gimme! (A Man After Midnight)",
+      "chart_info": {
+        "billboard_peak": 0,
+        "uk_peak": 3,
+        "weeks_on_chart": 12
+      },
+      "certifications": [
+        "Silver (UK)"
+      ],
+      "awards": [],
+      "fun_fact": "Never released as a single in the US but was a huge hit across Europe. Madonna sampled its distinctive riff for 'Hung Up' in 2005, making it the first ABBA song to be officially sampled. The music video was one of ABBA's most atmospheric.",
+      "fun_fact_de": "Wurde in den USA nie als Single veröffentlicht, war aber in Europa ein Riesenhit. Madonna sampelte das markante Riff für 'Hung Up' 2005 – das erste offiziell gesampelte ABBA-Stück. Das Musikvideo war eines der stimmungsvollsten von ABBA.",
+      "fun_fact_es": "Nunca se lanzó como sencillo en EE.UU. pero fue un gran éxito en Europa. Madonna sampleó su distintivo riff para 'Hung Up' en 2005, siendo la primera canción de ABBA oficialmente sampleada. El videoclip fue uno de los más atmosféricos de ABBA.",
+      "uri_apple_music": "applemusic://track/1440817183",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=XEjLoHdbVeE"
+    },
+    {
+      "year": 1978,
+      "uri": "spotify:track:0bfmfUQQ291rU0BUxc33u0",
+      "artist": "The Jacksons",
+      "alt_artists": [
+        "Michael Jackson",
+        "The Jackson 5",
+        "Stevie Wonder",
+        "Earth, Wind & Fire"
+      ],
+      "title": "Blame It on the Boogie",
+      "chart_info": {
+        "billboard_peak": 54,
+        "uk_peak": 8,
+        "weeks_on_chart": 11
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "Remarkably, this song was written by an English singer also named Mick Jackson (no relation). Both versions were released simultaneously, but The Jacksons' version became the definitive hit. It was their first single after leaving Motown for Epic Records.",
+      "fun_fact_de": "Bemerkenswerterweise wurde der Song von einem englischen Sänger namens Mick Jackson geschrieben (keine Verwandtschaft). Beide Versionen erschienen gleichzeitig, aber die Version der Jacksons wurde zum Hit. Es war ihre erste Single nach dem Wechsel von Motown zu Epic Records.",
+      "fun_fact_es": "Curiosamente, esta canción fue escrita por un cantante inglés también llamado Mick Jackson (sin parentesco). Ambas versiones se lanzaron simultáneamente, pero la de los Jacksons se convirtió en el éxito definitivo. Fue su primer sencillo tras dejar Motown por Epic Records.",
+      "uri_apple_music": "applemusic://track/604797533",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=nqxVMLVe62U"
+    },
+    {
+      "year": 1980,
+      "uri": "spotify:track:57Y3UccJEJqT8w8RWkUAz0",
+      "artist": "Diana Ross",
+      "alt_artists": [
+        "Donna Summer",
+        "Chaka Khan",
+        "Whitney Houston",
+        "Gloria Gaynor"
+      ],
+      "title": "Upside Down",
+      "chart_info": {
+        "billboard_peak": 1,
+        "uk_peak": 2,
+        "weeks_on_chart": 22
+      },
+      "certifications": [
+        "Platinum (US)"
+      ],
+      "awards": [],
+      "fun_fact": "Produced by CHIC's Nile Rodgers and Bernard Edwards, but Motown boss Berry Gordy remixed it against their wishes. Despite the controversy, it spent four weeks at #1 and became Diana Ross's biggest solo hit.",
+      "fun_fact_de": "Produziert von CHICs Nile Rodgers und Bernard Edwards, aber Motown-Chef Berry Gordy ließ es gegen ihren Willen neu abmischen. Trotz der Kontroverse stand es vier Wochen auf Platz 1 und wurde Diana Ross' größter Solo-Hit.",
+      "fun_fact_es": "Producida por Nile Rodgers y Bernard Edwards de CHIC, pero el jefe de Motown Berry Gordy la remezcló en contra de sus deseos. A pesar de la controversia, estuvo cuatro semanas en el #1 y se convirtió en el mayor éxito en solitario de Diana Ross.",
+      "uri_apple_music": "applemusic://track/1443160098",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=hDHW5wXBvLw"
+    },
+    {
+      "year": 1974,
+      "uri": "spotify:track:0DDgwlJDTQ6U3LPzUyvLu5",
+      "artist": "Gloria Gaynor",
+      "alt_artists": [
+        "Donna Summer",
+        "The Jackson 5",
+        "Diana Ross",
+        "Thelma Houston"
+      ],
+      "title": "Never Can Say Goodbye",
+      "chart_info": {
+        "billboard_peak": 9,
+        "uk_peak": 2,
+        "weeks_on_chart": 15
+      },
+      "certifications": [
+        "Gold (US)"
+      ],
+      "awards": [],
+      "fun_fact": "Gloria Gaynor's disco version of the Jackson 5 classic is widely considered the first true disco hit. It was part of a 19-minute medley on the album 'Never Can Say Goodbye', designed for non-stop dancing in clubs.",
+      "fun_fact_de": "Gloria Gaynors Disco-Version des Jackson-5-Klassikers gilt weithin als erster echter Disco-Hit. Er war Teil eines 19-minütigen Medleys auf dem Album 'Never Can Say Goodbye', das für Non-Stop-Tanzen in Clubs konzipiert war.",
+      "fun_fact_es": "La versión disco de Gloria Gaynor del clásico de los Jackson 5 se considera ampliamente como el primer verdadero éxito disco. Era parte de un medley de 19 minutos en el álbum 'Never Can Say Goodbye', diseñado para bailar sin parar en los clubs.",
+      "uri_apple_music": "",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=PvZbCxNu1PM"
+    },
+    {
+      "year": 1981,
+      "uri": "spotify:track:0PRodEMDFd6m58qg4GtqWA",
+      "artist": "Earth, Wind & Fire",
+      "alt_artists": [
+        "Kool & The Gang",
+        "The Commodores",
+        "Cameo",
+        "The Gap Band"
+      ],
+      "title": "Let's Groove",
+      "chart_info": {
+        "billboard_peak": 3,
+        "uk_peak": 3,
+        "weeks_on_chart": 21
+      },
+      "certifications": [
+        "Gold (US)"
+      ],
+      "awards": [],
+      "fun_fact": "Features one of the earliest uses of a vocoder in mainstream pop music. Maurice White and Wayne Vaughn wrote it, and the distinctive opening vocal effect was achieved using a Sennheiser vocoder, creating the robotic 'Let's groove tonight' intro.",
+      "fun_fact_de": "Enthält eine der frühesten Verwendungen eines Vocoders in der Mainstream-Popmusik. Maurice White und Wayne Vaughn schrieben den Song, und der markante Eröffnungseffekt wurde mit einem Sennheiser-Vocoder erzeugt.",
+      "fun_fact_es": "Presenta uno de los primeros usos del vocoder en la música pop mainstream. Maurice White y Wayne Vaughn la escribieron, y el distintivo efecto vocal de apertura se logró con un vocoder Sennheiser, creando la intro robótica.",
+      "uri_apple_music": "applemusic://track/523229275",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Lrle0x_DHBM"
+    },
+    {
+      "year": 1989,
+      "uri": "spotify:track:1ZtzjvhIcLoogzOpt4rKoa",
+      "artist": "Technotronic",
+      "alt_artists": [
+        "C+C Music Factory",
+        "Snap!",
+        "Black Box",
+        "Inner City"
+      ],
+      "title": "Pump Up the Jam",
+      "chart_info": {
+        "billboard_peak": 2,
+        "uk_peak": 2,
+        "weeks_on_chart": 20
+      },
+      "certifications": [
+        "Gold (US)",
+        "Gold (UK)"
+      ],
+      "awards": [],
+      "fun_fact": "The vocals were performed by Zairean-Belgian singer Ya Kid K, but model Felly was used in the music video instead, causing a controversy similar to Milli Vanilli. The Belgian production bridged disco-funk with emerging house music.",
+      "fun_fact_de": "Die Vocals stammten von der zairisch-belgischen Sängerin Ya Kid K, aber Model Felly wurde stattdessen im Musikvideo eingesetzt, was eine Kontroverse ähnlich Milli Vanilli auslöste. Die belgische Produktion verband Disco-Funk mit aufkommendem House.",
+      "fun_fact_es": "Las voces fueron interpretadas por la cantante zaireño-belga Ya Kid K, pero se usó a la modelo Felly en el video, causando una controversia similar a Milli Vanilli. La producción belga unió el disco-funk con el emergente house.",
+      "uri_apple_music": "applemusic://track/1444025178",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=9EcjWd-O4jI"
+    },
+    {
+      "year": 1981,
+      "uri": "spotify:track:27igFVa4ccGtNgwAPzRIix",
+      "artist": "Quincy Jones",
+      "alt_artists": [
+        "George Benson",
+        "Herbie Hancock",
+        "Michael Jackson",
+        "Stevie Wonder"
+      ],
+      "title": "Ai No Corrida",
+      "chart_info": {
+        "billboard_peak": 28,
+        "uk_peak": 14,
+        "weeks_on_chart": 10
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "Originally written and recorded by Chaz Jankel (of The Blockheads). The title references the controversial 1976 Japanese film 'In the Realm of the Senses'. Quincy Jones' version featured vocals by Dune and became a dancefloor staple.",
+      "fun_fact_de": "Ursprünglich von Chaz Jankel (von The Blockheads) geschrieben und aufgenommen. Der Titel bezieht sich auf den kontroversen japanischen Film 'Im Reich der Sinne' von 1976. Quincy Jones' Version mit Vocals von Dune wurde ein Dancefloor-Klassiker.",
+      "fun_fact_es": "Originalmente escrita y grabada por Chaz Jankel (de The Blockheads). El título hace referencia a la controvertida película japonesa 'El imperio de los sentidos' de 1976. La versión de Quincy Jones con voces de Dune se convirtió en un clásico de pista de baile.",
+      "uri_apple_music": "applemusic://track/1622737678",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=NVTVheyDY4s"
+    },
+    {
+      "year": 1982,
+      "uri": "spotify:track:7pwTNqKRrJlb0wd476AFO5",
+      "artist": "Marvin Gaye",
+      "alt_artists": [
+        "Stevie Wonder",
+        "Lionel Richie",
+        "Barry White",
+        "Al Green"
+      ],
+      "title": "Sexual Healing",
+      "chart_info": {
+        "billboard_peak": 3,
+        "uk_peak": 4,
+        "weeks_on_chart": 26
+      },
+      "certifications": [
+        "Platinum (US)"
+      ],
+      "awards": [
+        "Grammy Award for Best Male R&B Vocal Performance"
+      ],
+      "fun_fact": "Recorded in Ostend, Belgium, during Gaye's self-imposed exile from the US. It marked his comeback after years of personal turmoil and tax issues. The song won two Grammy Awards and was his last major hit before his tragic death in 1984.",
+      "fun_fact_de": "Aufgenommen in Ostende, Belgien, während Gayes selbstgewähltem Exil aus den USA. Es markierte sein Comeback nach Jahren persönlicher Probleme. Der Song gewann zwei Grammys und war sein letzter großer Hit vor seinem tragischen Tod 1984.",
+      "fun_fact_es": "Grabada en Ostende, Bélgica, durante el autoexilio de Gaye de EE.UU. Marcó su regreso tras años de problemas personales. La canción ganó dos Grammys y fue su último gran éxito antes de su trágica muerte en 1984.",
+      "uri_apple_music": "applemusic://track/158539332",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=rjlSiASsUIs"
+    },
+    {
+      "year": 1982,
+      "uri": "spotify:track:58QdD1OBMLWMiNLJus4xxU",
+      "artist": "Imagination",
+      "alt_artists": [
+        "Shalamar",
+        "Odyssey",
+        "Change",
+        "Loose Ends"
+      ],
+      "title": "Just an Illusion",
+      "chart_info": {
+        "billboard_peak": 0,
+        "uk_peak": 2,
+        "weeks_on_chart": 11
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "This British-based trio led by Leee John became known for their shirtless performances. The song was a massive hit across Europe but never charted in the US. Its dreamy synth-funk sound influenced many later electronic dance artists.",
+      "fun_fact_de": "Dieses britische Trio unter Führung von Leee John wurde für Auftritte ohne Oberteil bekannt. Der Song war ein Riesenhit in Europa, chartete aber nie in den USA. Sein verträumter Synth-Funk-Sound beeinflusste viele spätere Electronic-Dance-Künstler.",
+      "fun_fact_es": "Este trío británico liderado por Leee John se hizo conocido por sus actuaciones sin camiseta. La canción fue un gran éxito en Europa pero nunca entró en las listas de EE.UU. Su soñador sonido synth-funk influyó en muchos artistas de danza electrónica posteriores.",
+      "uri_apple_music": "applemusic://track/1741838959",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=uY4cVhXxW64"
+    },
+    {
+      "year": 1987,
+      "uri": "spotify:track:7Bc0S4rnNF06apWGfK2S3G",
+      "artist": "Whitney Houston",
+      "alt_artists": [
+        "Janet Jackson",
+        "Madonna",
+        "Diana Ross",
+        "Donna Summer"
+      ],
+      "title": "I Wanna Dance with Somebody",
+      "chart_info": {
+        "billboard_peak": 1,
+        "uk_peak": 1,
+        "weeks_on_chart": 22
+      },
+      "certifications": [
+        "Platinum (US)",
+        "Platinum (UK)"
+      ],
+      "awards": [
+        "Grammy Award for Best Female Pop Vocal Performance"
+      ],
+      "fun_fact": "Written by George Merrill and Shannon Rubicam, who also wrote Whitney's 'How Will I Know'. It spent two weeks at #1 and won the Grammy for Best Female Pop Vocal. The 2022 biopic about Whitney Houston was titled after this song.",
+      "fun_fact_de": "Geschrieben von George Merrill und Shannon Rubicam, die auch Whitneys 'How Will I Know' schrieben. Es war zwei Wochen auf Platz 1 und gewann den Grammy für Best Female Pop Vocal. Der Whitney-Houston-Film von 2022 wurde nach diesem Song benannt.",
+      "fun_fact_es": "Escrita por George Merrill y Shannon Rubicam, quienes también escribieron 'How Will I Know'. Estuvo dos semanas en el #1 y ganó el Grammy a la Mejor Interpretación Vocal Pop Femenina. La película biográfica de 2022 lleva el nombre de esta canción.",
+      "uri_apple_music": "applemusic://track/840431935",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=eH3giaIzONA"
+    },
+    {
+      "year": 1983,
+      "uri": "spotify:track:7sm3orGGwNFqmWFSPRl8eT",
+      "artist": "KC & The Sunshine Band",
+      "alt_artists": [
+        "Kool & The Gang",
+        "Earth, Wind & Fire",
+        "The Commodores",
+        "The Gap Band"
+      ],
+      "title": "Give It Up",
+      "chart_info": {
+        "billboard_peak": 18,
+        "uk_peak": 1,
+        "weeks_on_chart": 14
+      },
+      "certifications": [
+        "Gold (UK)"
+      ],
+      "awards": [],
+      "fun_fact": "After years of declining popularity in the US, this song gave KC a surprise #1 hit in the UK. Ironically, it only reached #18 in the US despite KC being an American artist. It marked a brief but triumphant comeback.",
+      "fun_fact_de": "Nach Jahren nachlassender Popularität in den USA bescherte dieser Song KC eine überraschende Nummer 1 in Großbritannien. Ironischerweise erreichte er in den USA nur Platz 18, obwohl KC ein amerikanischer Künstler ist.",
+      "fun_fact_es": "Después de años de popularidad decreciente en EE.UU., esta canción le dio a KC un sorpresivo #1 en el Reino Unido. Irónicamente, solo llegó al #18 en EE.UU. a pesar de ser KC un artista estadounidense.",
+      "uri_apple_music": "applemusic://track/1088537699",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=-AkxUirASIQ"
+    },
+    {
+      "year": 1983,
+      "uri": "spotify:track:4kjgGgDbNN4nR3OZYuRkUe",
+      "artist": "Lionel Richie",
+      "alt_artists": [
+        "Commodores",
+        "Stevie Wonder",
+        "Michael Jackson",
+        "Earth, Wind & Fire"
+      ],
+      "title": "All Night Long (All Night)",
+      "chart_info": {
+        "billboard_peak": 1,
+        "uk_peak": 2,
+        "weeks_on_chart": 25
+      },
+      "certifications": [
+        "2x Platinum (US)"
+      ],
+      "awards": [],
+      "fun_fact": "The multilingual lyrics include words from Caribbean, African, and completely made-up languages. Richie performed this at the 1984 LA Olympics closing ceremony. It spent four weeks at #1 and was one of the best-selling singles of 1983.",
+      "fun_fact_de": "Der mehrsprachige Text enthält Wörter aus karibischen, afrikanischen und völlig erfundenen Sprachen. Richie performte den Song bei der Abschlusszeremonie der Olympischen Spiele 1984 in LA. Er war vier Wochen auf Platz 1.",
+      "fun_fact_es": "Las letras multilingües incluyen palabras del Caribe, africanas y completamente inventadas. Richie interpretó esta canción en la ceremonia de clausura de los Juegos Olímpicos de LA 1984. Estuvo cuatro semanas en el #1.",
+      "uri_apple_music": "applemusic://track/1440781676",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=nqAvFx3NxUM"
+    },
+    {
+      "year": 1988,
+      "uri": "spotify:track:4wLs4GVQrC1obzAqnEMRQ4",
+      "artist": "Womack & Womack",
+      "alt_artists": [
+        "Soul II Soul",
+        "Lisa Stansfield",
+        "Alexander O'Neal",
+        "Luther Vandross"
+      ],
+      "title": "Teardrops",
+      "chart_info": {
+        "billboard_peak": 0,
+        "uk_peak": 3,
+        "weeks_on_chart": 14
+      },
+      "certifications": [
+        "Silver (UK)"
+      ],
+      "awards": [],
+      "fun_fact": "Cecil Womack was the brother of Bobby Womack, and Linda was the daughter of Sam Cooke. The song was a massive European hit but never charted in the US. It became a summer anthem in the UK and across Europe in 1988.",
+      "fun_fact_de": "Cecil Womack war der Bruder von Bobby Womack, und Linda war die Tochter von Sam Cooke. Der Song war ein riesiger europäischer Hit, chartete aber nie in den USA. Er wurde 1988 zum Sommerhit in Großbritannien und ganz Europa.",
+      "fun_fact_es": "Cecil Womack era hermano de Bobby Womack, y Linda era hija de Sam Cooke. La canción fue un gran éxito europeo pero nunca entró en las listas de EE.UU. Se convirtió en un himno veraniego en el Reino Unido y toda Europa en 1988.",
+      "uri_apple_music": "applemusic://track/1440670610",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=R8AOAap6_k4"
+    },
+    {
+      "year": 1978,
+      "uri": "spotify:track:79KIMUAkOLIREcEy859KSh",
+      "artist": "Earth, Wind & Fire",
+      "alt_artists": [
+        "Kool & The Gang",
+        "The Commodores",
+        "Stevie Wonder",
+        "The Gap Band"
+      ],
+      "title": "September",
+      "chart_info": {
+        "billboard_peak": 8,
+        "uk_peak": 3,
+        "weeks_on_chart": 18
+      },
+      "certifications": [
+        "Platinum (US)"
+      ],
+      "awards": [],
+      "fun_fact": "Co-writer Allee Willis chose the date 'the 21st night of September' simply because it sounded good, not for any special reason. The song has become a viral sensation every September 21st on social media, with millions of posts celebrating the date.",
+      "fun_fact_de": "Co-Autorin Allee Willis wählte das Datum 'die 21. Nacht im September' einfach weil es gut klang, ohne besonderen Grund. Der Song wird jedes Jahr am 21. September in den sozialen Medien mit Millionen Posts gefeiert.",
+      "fun_fact_es": "La coautora Allee Willis eligió la fecha 'la noche del 21 de septiembre' simplemente porque sonaba bien. La canción se ha convertido en una sensación viral cada 21 de septiembre en redes sociales, con millones de publicaciones celebrando la fecha.",
+      "uri_apple_music": "applemusic://track/1456446747",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Gs069dndIYk"
+    },
+    {
+      "year": 1979,
+      "uri": "spotify:track:42VCvYO7xY4jvvS93OKCZx",
+      "artist": "Kool & The Gang",
+      "alt_artists": [
+        "Earth, Wind & Fire",
+        "The Commodores",
+        "Chaka Khan",
+        "The Gap Band"
+      ],
+      "title": "Ladies Night",
+      "chart_info": {
+        "billboard_peak": 8,
+        "uk_peak": 9,
+        "weeks_on_chart": 16
+      },
+      "certifications": [
+        "Gold (US)"
+      ],
+      "awards": [],
+      "fun_fact": "Marked Kool & The Gang's transition from jazz-funk instrumentals to pop-funk vocals with the addition of singer James 'JT' Taylor. Producer Eumir Deodato helped reshape their sound, leading to a string of hits in the early 1980s.",
+      "fun_fact_de": "Markierte den Übergang von Kool & The Gang von Jazz-Funk-Instrumentals zu Pop-Funk-Vocals mit Sänger James 'JT' Taylor. Produzent Eumir Deodato half, ihren Sound neu zu gestalten, was zu einer Hit-Serie in den frühen 1980ern führte.",
+      "fun_fact_es": "Marcó la transición de Kool & The Gang del jazz-funk instrumental al pop-funk vocal con el cantante James 'JT' Taylor. El productor Eumir Deodato ayudó a remodelar su sonido, llevando a una serie de éxitos a principios de los 80.",
+      "uri_apple_music": "applemusic://track/1445227969",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=5JSGomGciTU"
+    },
+    {
+      "year": 1978,
+      "uri": "spotify:track:2M55R2A9IAhLdsCGFj8r8k",
+      "artist": "Chaka Khan",
+      "alt_artists": [
+        "Rufus",
+        "Diana Ross",
+        "Donna Summer",
+        "Whitney Houston"
+      ],
+      "title": "I'm Every Woman",
+      "chart_info": {
+        "billboard_peak": 21,
+        "uk_peak": 11,
+        "weeks_on_chart": 14
+      },
+      "certifications": [
+        "Gold (US)"
+      ],
+      "awards": [],
+      "fun_fact": "Written by Ashford & Simpson originally for Diana Ross, who turned it down. Whitney Houston's 1993 cover for 'The Bodyguard' soundtrack became even more famous. Chaka performed it at the 2024 Super Bowl halftime show tribute.",
+      "fun_fact_de": "Von Ashford & Simpson ursprünglich für Diana Ross geschrieben, die ablehnte. Whitney Houstons Cover von 1993 für den 'Bodyguard'-Soundtrack wurde noch berühmter. Chaka performte den Song bei der Super Bowl Halftime Show 2024.",
+      "fun_fact_es": "Escrita por Ashford & Simpson originalmente para Diana Ross, quien la rechazó. La versión de Whitney Houston de 1993 para 'El Guardaespaldas' se hizo aún más famosa. Chaka la interpretó en el show del medio tiempo del Super Bowl 2024.",
+      "uri_apple_music": "applemusic://track/281615481",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=DVDCNmdi7QI"
+    },
+    {
+      "year": 1975,
+      "uri": "spotify:track:6cHtnVvgIMqxIChRmraeTP",
+      "artist": "Gloria Gaynor",
+      "alt_artists": [
+        "Donna Summer",
+        "Diana Ross",
+        "Thelma Houston",
+        "Frankie Valli"
+      ],
+      "title": "Can't Take My Eyes Off You",
+      "chart_info": {
+        "billboard_peak": 0,
+        "uk_peak": 0,
+        "weeks_on_chart": 0
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "Gloria Gaynor's disco version of Frankie Valli's 1967 classic transformed a doo-wop ballad into a pulsing dancefloor anthem. The original by Frankie Valli reached #2 on the Billboard Hot 100 and has been covered by over 200 artists.",
+      "fun_fact_de": "Gloria Gaynors Disco-Version des Frankie-Valli-Klassikers von 1967 verwandelte eine Doo-Wop-Ballade in eine pulsierende Dancefloor-Hymne. Das Original von Frankie Valli erreichte Platz 2 der Billboard Hot 100 und wurde von über 200 Künstlern gecovert.",
+      "fun_fact_es": "La versión disco de Gloria Gaynor del clásico de Frankie Valli de 1967 transformó una balada doo-wop en un himno pulsante de pista de baile. El original de Frankie Valli llegó al #2 del Billboard Hot 100 y ha sido versionada por más de 200 artistas.",
+      "uri_apple_music": "applemusic://track/530072629",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=-R0EjDM5YFg"
+    },
+    {
+      "year": 1974,
+      "uri": "spotify:track:2shH36IytTvWBMMQi1KhNL",
+      "artist": "Barry White",
+      "alt_artists": [
+        "Isaac Hayes",
+        "Marvin Gaye",
+        "Luther Vandross",
+        "Teddy Pendergrass"
+      ],
+      "title": "You're the First, the Last, My Everything",
+      "chart_info": {
+        "billboard_peak": 2,
+        "uk_peak": 1,
+        "weeks_on_chart": 16
+      },
+      "certifications": [
+        "Gold (US)",
+        "Silver (UK)"
+      ],
+      "awards": [],
+      "fun_fact": "Originally written as a country song called 'You're My First, My Last, My Everything' in 1952. Barry White transformed it into a lush orchestral disco classic with his Love Unlimited Orchestra. It reached #1 in the UK and #2 in the US.",
+      "fun_fact_de": "Ursprünglich 1952 als Country-Song geschrieben. Barry White verwandelte ihn mit seinem Love Unlimited Orchestra in einen üppigen orchestralen Disco-Klassiker. Er erreichte Platz 1 in Großbritannien und Platz 2 in den USA.",
+      "fun_fact_es": "Originalmente escrita como canción country en 1952. Barry White la transformó en un lujoso clásico disco orquestal con su Love Unlimited Orchestra. Llegó al #1 en el Reino Unido y al #2 en EE.UU.",
+      "uri_apple_music": "applemusic://track/1428818295",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=rEbwl4J09yE"
+    },
+    {
+      "year": 1978,
+      "uri": "spotify:track:54OR1VDpfkBuOY5zZjhZAY",
+      "artist": "Village People",
+      "alt_artists": [
+        "Boney M.",
+        "Patrick Hernandez",
+        "Bee Gees",
+        "KC & The Sunshine Band"
+      ],
+      "title": "Y.M.C.A.",
+      "chart_info": {
+        "billboard_peak": 2,
+        "uk_peak": 1,
+        "weeks_on_chart": 20
+      },
+      "certifications": [
+        "Platinum (US)",
+        "Platinum (UK)"
+      ],
+      "awards": [],
+      "fun_fact": "Written by Jacques Morali and Victor Willis after Morali saw the YMCA sign while walking in New York. The famous arm gestures were invented by audience member Dick Clark during an American Bandstand performance. It's one of the most recognizable songs ever recorded.",
+      "fun_fact_de": "Geschrieben von Jacques Morali und Victor Willis, nachdem Morali das YMCA-Schild beim Spaziergang in New York sah. Die berühmten Armbewegungen wurden von Dick Clark während einer American-Bandstand-Aufführung erfunden. Es ist einer der bekanntesten Songs aller Zeiten.",
+      "fun_fact_es": "Escrita por Jacques Morali y Victor Willis después de que Morali viera el letrero YMCA paseando por Nueva York. Los famosos gestos con los brazos fueron inventados por Dick Clark durante una actuación en American Bandstand. Es una de las canciones más reconocibles jamás grabadas.",
+      "uri_apple_music": "",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=gj2LOqSugfw"
+    },
+    {
+      "year": 1982,
+      "uri": "spotify:track:6NSqiyQWIyZLouviktad9X",
+      "artist": "Indeep",
+      "alt_artists": [
+        "The Weather Girls",
+        "Imagination",
+        "Freeez",
+        "Shannon"
+      ],
+      "title": "Last Night a D.J. Saved My Life",
+      "chart_info": {
+        "billboard_peak": 10,
+        "uk_peak": 13,
+        "weeks_on_chart": 13
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "Considered the ultimate tribute to DJ culture and one of the most important songs about DJing ever written. The song has been sampled countless times and inspired a 2003 book of the same name about the history of the disc jockey.",
+      "fun_fact_de": "Gilt als ultimative Hommage an die DJ-Kultur und einer der wichtigsten Songs über DJing. Der Song wurde unzählige Male gesampelt und inspirierte ein gleichnamiges Buch von 2003 über die Geschichte der Discjockeys.",
+      "fun_fact_es": "Considerada el tributo definitivo a la cultura DJ y una de las canciones más importantes sobre DJing jamás escritas. Ha sido sampleada innumerables veces e inspiró un libro de 2003 del mismo nombre sobre la historia del disc jockey.",
+      "uri_apple_music": "applemusic://track/286849164",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=GtfZbj4J71A"
+    },
+    {
+      "year": 1978,
+      "uri": "spotify:track:7cv28LXcjAC3GsXbUvXKbX",
+      "artist": "Gloria Gaynor",
+      "alt_artists": [
+        "Donna Summer",
+        "Diana Ross",
+        "Thelma Houston",
+        "Sister Sledge"
+      ],
+      "title": "I Will Survive",
+      "chart_info": {
+        "billboard_peak": 1,
+        "uk_peak": 1,
+        "weeks_on_chart": 21
+      },
+      "certifications": [
+        "Platinum (US)",
+        "Gold (UK)"
+      ],
+      "awards": [
+        "Grammy Award for Best Disco Recording"
+      ],
+      "fun_fact": "Originally released as the B-side to 'Substitute'. DJs flipped the record and the song became a worldwide anthem of empowerment. It won the first and only Grammy for Best Disco Recording in 1980 and was inducted into the Library of Congress in 2016.",
+      "fun_fact_de": "Ursprünglich als B-Seite von 'Substitute' veröffentlicht. DJs drehten die Platte um und der Song wurde zur weltweiten Empowerment-Hymne. Er gewann 1980 den ersten und einzigen Grammy für Best Disco Recording und wurde 2016 in die Library of Congress aufgenommen.",
+      "fun_fact_es": "Originalmente lanzada como cara B de 'Substitute'. Los DJs dieron la vuelta al disco y la canción se convirtió en un himno mundial de empoderamiento. Ganó el primer y único Grammy a la Mejor Grabación Disco en 1980 y fue incluida en la Biblioteca del Congreso en 2016.",
+      "uri_apple_music": "applemusic://track/1443818368",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=6dYWe1c3OyU"
+    },
+    {
+      "year": 1984,
+      "uri": "spotify:track:59UwJzRHzH92UeXCZx2Kb6",
+      "artist": "Kool & The Gang",
+      "alt_artists": [
+        "Earth, Wind & Fire",
+        "The Commodores",
+        "Cameo",
+        "The Gap Band"
+      ],
+      "title": "Fresh",
+      "chart_info": {
+        "billboard_peak": 9,
+        "uk_peak": 11,
+        "weeks_on_chart": 16
+      },
+      "certifications": [
+        "Gold (US)"
+      ],
+      "awards": [],
+      "fun_fact": "From the album 'Emergency', this was one of four top-20 hits from that album alongside 'Cherish', 'Misled', and 'Emergency'. The song has become a favorite in TV commercials and was featured in the film 'Happy Gilmore'.",
+      "fun_fact_de": "Vom Album 'Emergency' war dies einer von vier Top-20-Hits neben 'Cherish', 'Misled' und 'Emergency'. Der Song wurde zum Favoriten für TV-Werbung und war im Film 'Happy Gilmore' zu hören.",
+      "fun_fact_es": "Del álbum 'Emergency', fue uno de cuatro éxitos top-20 junto con 'Cherish', 'Misled' y 'Emergency'. La canción se ha convertido en favorita de comerciales de TV y apareció en la película 'Happy Gilmore'.",
+      "uri_apple_music": "applemusic://track/1431065448",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=sTJ1XwGDcA4"
+    },
+    {
+      "year": 1983,
+      "uri": "spotify:track:2NHyfIeUIRucBcHhErA3pN",
+      "artist": "Oliver Cheatham",
+      "alt_artists": [
+        "Kool & The Gang",
+        "Patrice Rushen",
+        "Mtume",
+        "DeBarge"
+      ],
+      "title": "Get Down Saturday Night",
+      "chart_info": {
+        "billboard_peak": 38,
+        "uk_peak": 0,
+        "weeks_on_chart": 8
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "Though a modest hit on original release, the song experienced a massive revival in the 2000s when it was sampled by Room 5 for 'Make Luv' which hit #1 in the UK. Cheatham's smooth vocals became iconic in European club culture.",
+      "fun_fact_de": "Obwohl bei der Erstveröffentlichung nur ein bescheidener Hit, erlebte der Song in den 2000ern ein massives Revival, als Room 5 ihn für 'Make Luv' sampelte, das in UK Nummer 1 wurde. Cheathams Vocals wurden in der europäischen Clubkultur ikonisch.",
+      "fun_fact_es": "Aunque fue un éxito modesto en su lanzamiento, la canción experimentó un gran revival en los 2000 cuando Room 5 la sampleó para 'Make Luv', que llegó al #1 en UK. Las suaves voces de Cheatham se volvieron icónicas en la cultura de clubs europea.",
+      "uri_apple_music": "applemusic://track/1779019008",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=c29H75mLc-8"
+    },
+    {
+      "year": 1975,
+      "uri": "spotify:track:6q4WNR2hLjy57WkJ6kdUci",
+      "artist": "KC & The Sunshine Band",
+      "alt_artists": [
+        "Kool & The Gang",
+        "Earth, Wind & Fire",
+        "Wild Cherry",
+        "The Trammps"
+      ],
+      "title": "That's the Way (I Like It)",
+      "chart_info": {
+        "billboard_peak": 1,
+        "uk_peak": 4,
+        "weeks_on_chart": 16
+      },
+      "certifications": [
+        "Gold (US)"
+      ],
+      "awards": [],
+      "fun_fact": "KC & The Sunshine Band's second #1 hit, it established the Miami bass sound that influenced disco and later bass music. Harry Wayne Casey (KC) wrote and produced most of the band's hits alongside bassist Richard Finch in their own studio.",
+      "fun_fact_de": "Der zweite Nummer-1-Hit von KC & The Sunshine Band etablierte den Miami-Bass-Sound, der Disco und spätere Bass-Musik beeinflusste. Harry Wayne Casey (KC) schrieb und produzierte die meisten Hits der Band zusammen mit Bassist Richard Finch.",
+      "fun_fact_es": "El segundo #1 de KC & The Sunshine Band, estableció el sonido Miami bass que influyó en el disco y la música bass posterior. Harry Wayne Casey (KC) escribió y produjo la mayoría de los éxitos junto al bajista Richard Finch.",
+      "uri_apple_music": "applemusic://track/1039402934",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=aXxB2QN2IuY"
+    },
+    {
+      "year": 1980,
+      "uri": "spotify:track:7yBl8YmvcgwwYlazJcvowE",
+      "artist": "Irene Cara",
+      "alt_artists": [
+        "Donna Summer",
+        "Flashdance",
+        "Bonnie Tyler",
+        "Laura Branigan"
+      ],
+      "title": "Fame",
+      "chart_info": {
+        "billboard_peak": 4,
+        "uk_peak": 1,
+        "weeks_on_chart": 18
+      },
+      "certifications": [
+        "Gold (US)",
+        "Gold (UK)"
+      ],
+      "awards": [
+        "Academy Award Nomination for Best Original Song"
+      ],
+      "fun_fact": "Written by Michael Gore and Dean Pitchford for the 1980 film of the same name. Irene Cara also starred in the movie. The song inspired a TV series that ran from 1982-1987. Cara later won an Oscar for 'Flashdance... What a Feeling' in 1984.",
+      "fun_fact_de": "Geschrieben von Michael Gore und Dean Pitchford für den gleichnamigen Film von 1980. Irene Cara spielte auch im Film mit. Der Song inspirierte eine TV-Serie (1982-1987). Cara gewann später einen Oscar für 'Flashdance... What a Feeling' 1984.",
+      "fun_fact_es": "Escrita por Michael Gore y Dean Pitchford para la película de 1980 del mismo nombre. Irene Cara también actuó en la película. La canción inspiró una serie de TV (1982-1987). Cara ganó después un Oscar por 'Flashdance... What a Feeling' en 1984.",
+      "uri_apple_music": "applemusic://track/1454593961",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=uN1BS-L1vx8"
+    },
+    {
+      "year": 1980,
+      "uri": "spotify:track:62GYoGszQfROZswLee6W3O",
+      "artist": "George Benson",
+      "alt_artists": [
+        "Quincy Jones",
+        "Al Jarreau",
+        "Herbie Hancock",
+        "Grover Washington Jr."
+      ],
+      "title": "Give Me the Night",
+      "chart_info": {
+        "billboard_peak": 4,
+        "uk_peak": 7,
+        "weeks_on_chart": 18
+      },
+      "certifications": [
+        "Gold (US)"
+      ],
+      "awards": [
+        "Grammy Award for Best Male R&B Vocal Performance"
+      ],
+      "fun_fact": "Produced by Quincy Jones and written by Rod Temperton (who also wrote Michael Jackson's 'Thriller'). It blended jazz guitar virtuosity with disco-funk grooves, proving Benson could dominate both jazz and pop charts.",
+      "fun_fact_de": "Produziert von Quincy Jones und geschrieben von Rod Temperton (der auch Michael Jacksons 'Thriller' schrieb). Es verband Jazz-Gitarren-Virtuosität mit Disco-Funk-Grooves und bewies, dass Benson Jazz- und Pop-Charts dominieren konnte.",
+      "fun_fact_es": "Producida por Quincy Jones y escrita por Rod Temperton (quien también escribió 'Thriller' de Michael Jackson). Combinó el virtuosismo de guitarra jazz con grooves disco-funk, demostrando que Benson podía dominar las listas de jazz y pop.",
+      "uri_apple_music": "applemusic://track/358111274",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=FIF7wKJb2iU"
+    },
+    {
+      "year": 1976,
+      "uri": "spotify:track:3GXo1eWlT2flv4x01l5OTu",
+      "artist": "The Trammps",
+      "alt_artists": [
+        "KC & The Sunshine Band",
+        "Village People",
+        "Bee Gees",
+        "The O'Jays"
+      ],
+      "title": "Disco Inferno",
+      "chart_info": {
+        "billboard_peak": 11,
+        "uk_peak": 16,
+        "weeks_on_chart": 18
+      },
+      "certifications": [
+        "Gold (US)"
+      ],
+      "awards": [],
+      "fun_fact": "Originally a modest hit in 1976, but the Saturday Night Fever soundtrack in 1977 catapulted it to worldwide fame. The iconic 'Burn baby burn' chant became the rallying cry of the disco era. The full version runs over 10 minutes.",
+      "fun_fact_de": "Ursprünglich 1976 ein bescheidener Hit, aber der Saturday Night Fever-Soundtrack 1977 katapultierte ihn zu Weltruhm. Der ikonische 'Burn baby burn'-Ruf wurde zum Schlachtruf der Disco-Ära. Die Vollversion dauert über 10 Minuten.",
+      "fun_fact_es": "Originalmente un éxito modesto en 1976, pero la banda sonora de Saturday Night Fever en 1977 lo catapultó a la fama mundial. El icónico canto 'Burn baby burn' se convirtió en el grito de guerra de la era disco. La versión completa dura más de 10 minutos.",
+      "uri_apple_music": "applemusic://track/1121329085",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=pG8TyIEAqps"
+    },
+    {
+      "year": 1976,
+      "uri": "spotify:track:4T5Y25pWs2pVZVcFIqFuf8",
+      "artist": "Bee Gees",
+      "alt_artists": [
+        "Andy Gibb",
+        "KC & The Sunshine Band",
+        "The Trammps",
+        "Tavares"
+      ],
+      "title": "You Should Be Dancing",
+      "chart_info": {
+        "billboard_peak": 1,
+        "uk_peak": 5,
+        "weeks_on_chart": 17
+      },
+      "certifications": [
+        "Gold (US)"
+      ],
+      "awards": [],
+      "fun_fact": "The first Bee Gees song to feature Barry Gibb's iconic falsetto that would define the disco era. John Travolta used this song for his solo dance scene in Saturday Night Fever. It spent one week at #1 on the Billboard Hot 100.",
+      "fun_fact_de": "Der erste Bee-Gees-Song mit Barry Gibbs ikonischem Falsett, das die Disco-Ära prägen sollte. John Travolta nutzte diesen Song für seine Solo-Tanzszene in Saturday Night Fever. Er war eine Woche auf Platz 1 der Billboard Hot 100.",
+      "fun_fact_es": "La primera canción de los Bee Gees con el icónico falsete de Barry Gibb que definiría la era disco. John Travolta usó esta canción para su escena de baile en solitario en Saturday Night Fever. Estuvo una semana en el #1 del Billboard Hot 100.",
+      "uri_apple_music": "applemusic://track/1444171216",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=1sqE6P3XyiQ"
+    },
+    {
+      "year": 1979,
+      "uri": "spotify:track:2zMJN9JvDlvGP4jB03l1Bz",
+      "artist": "Donna Summer",
+      "alt_artists": [
+        "Gloria Gaynor",
+        "Diana Ross",
+        "Chaka Khan",
+        "Blondie"
+      ],
+      "title": "Hot Stuff",
+      "chart_info": {
+        "billboard_peak": 1,
+        "uk_peak": 11,
+        "weeks_on_chart": 22
+      },
+      "certifications": [
+        "Platinum (US)"
+      ],
+      "awards": [
+        "Grammy Award for Best Female Rock Vocal Performance"
+      ],
+      "fun_fact": "One of the first disco songs to incorporate rock guitar, featuring Jeff 'Skunk' Baxter of The Doobie Brothers. It spent three weeks at #1 and won the Grammy for Best Female Rock Vocal — a rare crossover achievement for a disco artist.",
+      "fun_fact_de": "Einer der ersten Disco-Songs mit Rock-Gitarre, mit Jeff 'Skunk' Baxter von den Doobie Brothers. Er war drei Wochen auf Platz 1 und gewann den Grammy für Best Female Rock Vocal — eine seltene Crossover-Leistung für eine Disco-Künstlerin.",
+      "fun_fact_es": "Una de las primeras canciones disco en incorporar guitarra rock, con Jeff 'Skunk' Baxter de The Doobie Brothers. Estuvo tres semanas en el #1 y ganó el Grammy a la Mejor Interpretación Vocal Rock Femenina — un raro logro crossover para una artista disco.",
+      "uri_apple_music": "applemusic://track/1425179373",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=nYMeJSehCe4"
+    },
+    {
+      "year": 1978,
+      "uri": "spotify:track:29RcVe2M9l8rHyWHffBmjf",
+      "artist": "Donna Summer",
+      "alt_artists": [
+        "Gloria Gaynor",
+        "Diana Ross",
+        "Irene Cara",
+        "Grace Jones"
+      ],
+      "title": "Last Dance",
+      "chart_info": {
+        "billboard_peak": 3,
+        "uk_peak": 51,
+        "weeks_on_chart": 15
+      },
+      "certifications": [
+        "Gold (US)"
+      ],
+      "awards": [
+        "Academy Award for Best Original Song",
+        "Golden Globe Award"
+      ],
+      "fun_fact": "Won the Academy Award for Best Original Song from the film 'Thank God It's Friday'. It uniquely starts as a slow ballad before exploding into a high-energy disco anthem — a structure that was revolutionary for disco at the time.",
+      "fun_fact_de": "Gewann den Oscar für den besten Originalsong aus dem Film 'Thank God It's Friday'. Er beginnt einzigartig als langsame Ballade, bevor er in eine Disco-Hymne explodiert — eine für Disco revolutionäre Struktur.",
+      "fun_fact_es": "Ganó el Oscar a la Mejor Canción Original de la película 'Thank God It's Friday'. Comienza como una balada lenta antes de explotar en un himno disco de alta energía — una estructura revolucionaria para el disco de la época.",
+      "uri_apple_music": "applemusic://track/1415204156",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=vqZY8P42pLo"
+    },
+    {
+      "year": 1975,
+      "uri": "spotify:track:4msPRe3NEDVL6dsBcE7AhL",
+      "artist": "KC & The Sunshine Band",
+      "alt_artists": [
+        "Bee Gees",
+        "The Trammps",
+        "Van McCoy",
+        "Silver Convention"
+      ],
+      "title": "Get Down Tonight",
+      "chart_info": {
+        "billboard_peak": 1,
+        "uk_peak": 21,
+        "weeks_on_chart": 18
+      },
+      "certifications": [
+        "Gold (US)"
+      ],
+      "awards": [],
+      "fun_fact": "KC & The Sunshine Band's first #1 hit, it defined the Miami Sound that blended funk, soul, and pop. Harry Wayne Casey and Richard Finch were staff songwriters at TK Records and wrote this at ages 23 and 21 respectively.",
+      "fun_fact_de": "Der erste Nummer-1-Hit von KC & The Sunshine Band definierte den Miami Sound, der Funk, Soul und Pop verband. Harry Wayne Casey und Richard Finch waren Songwriter bei TK Records und schrieben den Song mit 23 bzw. 21 Jahren.",
+      "fun_fact_es": "El primer #1 de KC & The Sunshine Band, definió el sonido Miami que combinaba funk, soul y pop. Harry Wayne Casey y Richard Finch eran compositores de TK Records y escribieron esto con 23 y 21 años respectivamente.",
+      "uri_apple_music": "applemusic://track/1039402935",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=BXIBEW5MLuU"
+    },
+    {
+      "year": 1981,
+      "uri": "spotify:track:1l74wt5cIjAq6vOinDPFgV",
+      "artist": "Rick James",
+      "alt_artists": [
+        "Prince",
+        "Parliament",
+        "Cameo",
+        "The Gap Band"
+      ],
+      "title": "Super Freak",
+      "chart_info": {
+        "billboard_peak": 16,
+        "uk_peak": 0,
+        "weeks_on_chart": 20
+      },
+      "certifications": [
+        "Gold (US)"
+      ],
+      "awards": [],
+      "fun_fact": "MC Hammer sampled the bass line for 'U Can't Touch This' in 1990, which became an even bigger hit. Rick James famously never received proper credit initially. The Temptations provided backup vocals on the original recording.",
+      "fun_fact_de": "MC Hammer sampelte die Basslinie für 'U Can't Touch This' 1990, was ein noch größerer Hit wurde. Rick James erhielt anfangs keine angemessene Anerkennung. Die Temptations lieferten Background-Vocals für die Originalaufnahme.",
+      "fun_fact_es": "MC Hammer sampleó la línea de bajo para 'U Can't Touch This' en 1990, que se convirtió en un éxito aún mayor. Rick James nunca recibió el crédito adecuado inicialmente. The Temptations proporcionaron coros en la grabación original.",
+      "uri_apple_music": "applemusic://track/1440805227",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=QYHxGBH6o4M"
+    },
+    {
+      "year": 1977,
+      "uri": "spotify:track:3Ya085SKwcdLQBdIBrbSqn",
+      "artist": "Baccara",
+      "alt_artists": [
+        "ABBA",
+        "Boney M.",
+        "Arabesque",
+        "Luisa Fernandez"
+      ],
+      "title": "Yes Sir, I Can Boogie",
+      "chart_info": {
+        "billboard_peak": 0,
+        "uk_peak": 1,
+        "weeks_on_chart": 16
+      },
+      "certifications": [
+        "Gold (UK)"
+      ],
+      "awards": [],
+      "fun_fact": "The best-selling single ever by a female duo, selling over 18 million copies worldwide. It was #1 in the UK and across Europe but was never released as a single in the US. It became Scotland's unofficial football anthem during Euro 2020.",
+      "fun_fact_de": "Die meistverkaufte Single eines weiblichen Duos mit über 18 Millionen verkauften Exemplaren weltweit. Nummer 1 in Großbritannien und ganz Europa, aber nie als Single in den USA veröffentlicht. Es wurde Schottlands inoffizielle Fußballhymne bei der Euro 2020.",
+      "fun_fact_es": "El sencillo más vendido de un dúo femenino, con más de 18 millones de copias vendidas. Fue #1 en el Reino Unido y toda Europa pero nunca se lanzó como sencillo en EE.UU. Se convirtió en el himno no oficial de fútbol de Escocia en la Euro 2020.",
+      "uri_apple_music": "applemusic://track/313627630",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=32wDFCM7iSI"
+    },
+    {
+      "year": 1977,
+      "uri": "spotify:track:4SMVEIfMusETeLhl7ptFUh",
+      "artist": "Boney M.",
+      "alt_artists": [
+        "Village People",
+        "ABBA",
+        "Eruption",
+        "Baccara"
+      ],
+      "title": "Ma Baker",
+      "chart_info": {
+        "billboard_peak": 0,
+        "uk_peak": 2,
+        "weeks_on_chart": 14
+      },
+      "certifications": [
+        "Silver (UK)"
+      ],
+      "awards": [],
+      "fun_fact": "Inspired by the true story of Ma Barker, the notorious American gangster mother of the 1930s. The song was #1 in Germany, France, and several other European countries. Producer Frank Farian later said it was one of his favorite Boney M. productions.",
+      "fun_fact_de": "Inspiriert von der wahren Geschichte der Ma Barker, der berüchtigten amerikanischen Gangster-Mutter der 1930er. Der Song war Nummer 1 in Deutschland, Frankreich und mehreren europäischen Ländern. Produzent Frank Farian sagte, es sei eine seiner Lieblings-Boney-M.-Produktionen.",
+      "fun_fact_es": "Inspirada en la historia real de Ma Barker, la notoria madre gánster estadounidense de los años 30. La canción fue #1 en Alemania, Francia y otros países europeos. El productor Frank Farian dijo que era una de sus producciones favoritas de Boney M.",
+      "uri_apple_music": "applemusic://track/402741465",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=9c5yPIQ3LQI"
+    },
+    {
+      "year": 1978,
+      "uri": "spotify:track:51VSKyT8XfhAscvagBB4bn",
+      "artist": "Boney M.",
+      "alt_artists": [
+        "Village People",
+        "ABBA",
+        "Eruption",
+        "Baccara"
+      ],
+      "title": "Rivers of Babylon",
+      "chart_info": {
+        "billboard_peak": 30,
+        "uk_peak": 1,
+        "weeks_on_chart": 40
+      },
+      "certifications": [
+        "Platinum (UK)"
+      ],
+      "awards": [],
+      "fun_fact": "Based on Psalm 137, it spent five weeks at #1 in the UK and is one of the best-selling singles of all time in Britain with over 2 million copies sold. The double A-side with 'Brown Girl in the Ring' remained on the UK charts for 40 weeks.",
+      "fun_fact_de": "Basierend auf Psalm 137, stand der Song fünf Wochen auf Platz 1 in Großbritannien und ist mit über 2 Millionen verkauften Exemplaren eine der meistverkauften Singles aller Zeiten in UK. Die Doppel-A-Seite mit 'Brown Girl in the Ring' blieb 40 Wochen in den UK-Charts.",
+      "fun_fact_es": "Basada en el Salmo 137, estuvo cinco semanas en el #1 en el Reino Unido y es uno de los sencillos más vendidos de la historia en Gran Bretaña con más de 2 millones de copias. El doble cara A con 'Brown Girl in the Ring' permaneció 40 semanas en las listas del UK.",
+      "uri_apple_music": "applemusic://track/355934187",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=l3QxT-w3WMo"
+    },
+    {
+      "year": 1985,
+      "uri": "spotify:track:5tdKaKLnC4SgtDZ6RlWeal",
+      "artist": "Whitney Houston",
+      "alt_artists": [
+        "Janet Jackson",
+        "Madonna",
+        "Diana Ross",
+        "Tina Turner"
+      ],
+      "title": "How Will I Know",
+      "chart_info": {
+        "billboard_peak": 1,
+        "uk_peak": 5,
+        "weeks_on_chart": 20
+      },
+      "certifications": [
+        "Gold (US)"
+      ],
+      "awards": [],
+      "fun_fact": "Originally written for Janet Jackson, who passed on it. The colorful, energetic music video showcased Whitney's charisma and helped establish MTV as a platform for Black pop artists. It was her third consecutive #1 hit in the US.",
+      "fun_fact_de": "Ursprünglich für Janet Jackson geschrieben, die ablehnte. Das farbenfrohe, energiegeladene Musikvideo zeigte Whitneys Charisma und half, MTV als Plattform für schwarze Pop-Künstler zu etablieren. Es war ihr dritter aufeinanderfolgender Nummer-1-Hit in den USA.",
+      "fun_fact_es": "Originalmente escrita para Janet Jackson, quien la rechazó. El colorido y energético videoclip mostró el carisma de Whitney y ayudó a establecer MTV como plataforma para artistas pop afroamericanos. Fue su tercer #1 consecutivo en EE.UU.",
+      "uri_apple_music": "applemusic://track/1784790781",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=lNwN0iHbos4"
+    },
+    {
+      "year": 1986,
+      "uri": "spotify:track:7y5oFt113JF0bnr4rKyLN8",
+      "artist": "Jermaine Stewart",
+      "alt_artists": [
+        "Stevie Wonder",
+        "Culture Club",
+        "Cameo",
+        "DeBarge"
+      ],
+      "title": "We Don't Have to Take Our Clothes Off",
+      "chart_info": {
+        "billboard_peak": 5,
+        "uk_peak": 2,
+        "weeks_on_chart": 17
+      },
+      "certifications": [
+        "Gold (US)"
+      ],
+      "awards": [],
+      "fun_fact": "Written by Narada Michael Walden and Preston Glass, this was Stewart's biggest hit. Before his solo career, he was a dancer on Soul Train and a backup dancer for Shalamar. Stewart tragically died of AIDS-related liver cancer in 1997 at age 39.",
+      "fun_fact_de": "Geschrieben von Narada Michael Walden und Preston Glass, war dies Stewarts größter Hit. Vor seiner Solokarriere war er Tänzer bei Soul Train und Backgroundtänzer für Shalamar. Stewart starb tragischerweise 1997 mit 39 Jahren an AIDS-bedingtem Leberkrebs.",
+      "fun_fact_es": "Escrita por Narada Michael Walden y Preston Glass, fue el mayor éxito de Stewart. Antes de su carrera solista, fue bailarín en Soul Train y bailarín de respaldo de Shalamar. Stewart murió trágicamente de cáncer de hígado relacionado con el SIDA en 1997 a los 39 años.",
+      "uri_apple_music": "applemusic://track/1445835984",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=HWZisnZ-RGE"
+    },
+    {
+      "year": 1985,
+      "uri": "spotify:track:6lOPbNUxDvkUkWpJLebgs7",
+      "artist": "Prince",
+      "alt_artists": [
+        "Rick James",
+        "Michael Jackson",
+        "Parliament",
+        "Cameo"
+      ],
+      "title": "Raspberry Beret",
+      "chart_info": {
+        "billboard_peak": 2,
+        "uk_peak": 25,
+        "weeks_on_chart": 16
+      },
+      "certifications": [
+        "Gold (US)"
+      ],
+      "awards": [],
+      "fun_fact": "The first single released by Prince and The Revolution from 'Around the World in a Day'. Prince recorded most of the album at his home studio in Chanhassen, Minnesota. The dreamy pop-funk sound marked a departure from the harder funk of 'Purple Rain'.",
+      "fun_fact_de": "Die erste Single von Prince and The Revolution vom Album 'Around the World in a Day'. Prince nahm das meiste in seinem Heimstudio in Chanhassen, Minnesota auf. Der verträumte Pop-Funk-Sound markierte eine Abkehr vom härteren Funk von 'Purple Rain'.",
+      "fun_fact_es": "El primer sencillo de Prince and The Revolution de 'Around the World in a Day'. Prince grabó la mayor parte en su estudio casero en Chanhassen, Minnesota. El soñador sonido pop-funk marcó un alejamiento del funk más duro de 'Purple Rain'.",
+      "uri_apple_music": "",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=mbi49VO_7ls"
+    },
+    {
+      "year": 1982,
+      "uri": "spotify:track:0zCNuyeXYbmxl6xlvkjvKi",
+      "artist": "Yazoo",
+      "alt_artists": [
+        "Depeche Mode",
+        "Soft Cell",
+        "Erasure",
+        "Bronski Beat"
+      ],
+      "title": "Don't Go",
+      "chart_info": {
+        "billboard_peak": 0,
+        "uk_peak": 3,
+        "weeks_on_chart": 11
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "Formed by Vince Clarke (who had just left Depeche Mode) and Alison Moyet. The duo was known as 'Yaz' in the US due to a trademark dispute. Clarke went on to form Erasure, while Moyet had a successful solo career. They only released two albums together.",
+      "fun_fact_de": "Gegründet von Vince Clarke (der gerade Depeche Mode verlassen hatte) und Alison Moyet. Das Duo war in den USA als 'Yaz' bekannt wegen eines Markenrechtsstreits. Clarke gründete später Erasure, Moyet hatte eine erfolgreiche Solokarriere. Sie veröffentlichten nur zwei Alben zusammen.",
+      "fun_fact_es": "Formado por Vince Clarke (que acababa de dejar Depeche Mode) y Alison Moyet. El dúo se conocía como 'Yaz' en EE.UU. por una disputa de marca. Clarke formó Erasure después, mientras Moyet tuvo una exitosa carrera en solitario. Solo lanzaron dos álbumes juntos.",
+      "uri_apple_music": "applemusic://track/1436832961",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=_sQGwDeambg"
+    },
+    {
+      "year": 1984,
+      "uri": "spotify:track:29uESWjogcfCbBVKb3eD8F",
+      "artist": "Rockwell",
+      "alt_artists": [
+        "Michael Jackson",
+        "Stevie Wonder",
+        "Rick James",
+        "DeBarge"
+      ],
+      "title": "Somebody's Watching Me",
+      "chart_info": {
+        "billboard_peak": 2,
+        "uk_peak": 6,
+        "weeks_on_chart": 18
+      },
+      "certifications": [
+        "Gold (US)"
+      ],
+      "awards": [],
+      "fun_fact": "Rockwell was actually Kennedy Gordy, son of Motown founder Berry Gordy. Michael Jackson sang the iconic chorus, and Jermaine Jackson provided additional vocals. Despite being Berry Gordy's son, Rockwell signed with Motown under a pseudonym to prove himself.",
+      "fun_fact_de": "Rockwell war eigentlich Kennedy Gordy, Sohn des Motown-Gründers Berry Gordy. Michael Jackson sang den ikonischen Refrain, und Jermaine Jackson lieferte zusätzliche Vocals. Trotz seiner Herkunft unterschrieb Rockwell unter Pseudonym bei Motown, um sich zu beweisen.",
+      "fun_fact_es": "Rockwell era en realidad Kennedy Gordy, hijo del fundador de Motown Berry Gordy. Michael Jackson cantó el icónico estribillo y Jermaine Jackson proporcionó voces adicionales. A pesar de ser hijo de Berry Gordy, Rockwell firmó con Motown bajo seudónimo para demostrar su valía.",
+      "uri_apple_music": "applemusic://track/1278579752",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=7YvAYIJSSZY"
+    },
+    {
+      "year": 1980,
+      "uri": "spotify:track:3SnGymj6ijE2iuUfWxLo1q",
+      "artist": "Diana Ross",
+      "alt_artists": [
+        "Donna Summer",
+        "Gloria Gaynor",
+        "Chaka Khan",
+        "Whitney Houston"
+      ],
+      "title": "I'm Coming Out",
+      "chart_info": {
+        "billboard_peak": 5,
+        "uk_peak": 13,
+        "weeks_on_chart": 18
+      },
+      "certifications": [
+        "Gold (US)"
+      ],
+      "awards": [],
+      "fun_fact": "Written by Nile Rodgers and Bernard Edwards of CHIC after seeing Diana Ross drag impersonators at a New York club. The song became an LGBTQ anthem, though Ross said she intended it as a declaration of artistic independence from Motown.",
+      "fun_fact_de": "Geschrieben von Nile Rodgers und Bernard Edwards von CHIC, nachdem sie Diana-Ross-Drag-Imitatoren in einem New Yorker Club gesehen hatten. Der Song wurde zur LGBTQ-Hymne, obwohl Ross sagte, er sei als Erklärung künstlerischer Unabhängigkeit von Motown gemeint.",
+      "fun_fact_es": "Escrita por Nile Rodgers y Bernard Edwards de CHIC después de ver imitadores drag de Diana Ross en un club de Nueva York. La canción se convirtió en un himno LGBTQ, aunque Ross dijo que pretendía ser una declaración de independencia artística de Motown.",
+      "uri_apple_music": "applemusic://track/1443160111",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Ms6gz5hpXBE"
+    },
+    {
+      "year": 1977,
+      "uri": "spotify:track:66wpCqkkM6MrxXSbfgmsrh",
+      "artist": "Bee Gees",
+      "alt_artists": [
+        "Andy Gibb",
+        "Tavares",
+        "KC & The Sunshine Band",
+        "The Trammps"
+      ],
+      "title": "Night Fever",
+      "chart_info": {
+        "billboard_peak": 1,
+        "uk_peak": 1,
+        "weeks_on_chart": 22
+      },
+      "certifications": [
+        "Platinum (US)",
+        "Platinum (UK)"
+      ],
+      "awards": [],
+      "fun_fact": "Spent eight consecutive weeks at #1 in the US, making it the Bee Gees' longest-running #1 hit. The Saturday Night Fever album spent 24 weeks at #1 and sold over 40 million copies, making it one of the best-selling soundtracks ever.",
+      "fun_fact_de": "Acht aufeinanderfolgende Wochen auf Platz 1 in den USA, damit der am längsten auf Platz 1 stehende Bee-Gees-Hit. Das Saturday Night Fever-Album war 24 Wochen auf Platz 1 mit über 40 Millionen verkauften Exemplaren.",
+      "fun_fact_es": "Estuvo ocho semanas consecutivas en el #1 en EE.UU., siendo el #1 más duradero de los Bee Gees. El álbum Saturday Night Fever estuvo 24 semanas en el #1 y vendió más de 40 millones de copias, convirtiéndose en una de las bandas sonoras más vendidas.",
+      "uri_apple_music": "applemusic://track/1445668465",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=e6GB04zeDeQ"
+    },
+    {
+      "year": 1976,
+      "uri": "spotify:track:1tJtx09XQnxaynZLOaTNfZ",
+      "artist": "Rose Royce",
+      "alt_artists": [
+        "The Commodores",
+        "Earth, Wind & Fire",
+        "Parliament",
+        "Rufus"
+      ],
+      "title": "Car Wash",
+      "chart_info": {
+        "billboard_peak": 1,
+        "uk_peak": 9,
+        "weeks_on_chart": 19
+      },
+      "certifications": [
+        "Gold (US)"
+      ],
+      "awards": [],
+      "fun_fact": "Written and produced by Norman Whitfield (famed Motown producer) for the 1976 comedy film of the same name. It spent one week at #1 and featured a funky clavinet riff that became instantly iconic. Christina Aguilera sampled it for a 2004 movie version.",
+      "fun_fact_de": "Geschrieben und produziert von Norman Whitfield (berühmter Motown-Produzent) für die gleichnamige Filmkomödie von 1976. Es war eine Woche auf Platz 1 mit einem funkigen Clavinet-Riff, das sofort ikonisch wurde.",
+      "fun_fact_es": "Escrita y producida por Norman Whitfield (famoso productor de Motown) para la comedia homónima de 1976. Estuvo una semana en el #1 y presentó un riff de clavinet funky que se volvió instantáneamente icónico.",
+      "uri_apple_music": "applemusic://track/216312896",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=PkxaunLybuM"
+    },
+    {
+      "year": 1978,
+      "uri": "spotify:track:26FOglnpqOEWUyspcbNYq6",
+      "artist": "Cheryl Lynn",
+      "alt_artists": [
+        "Donna Summer",
+        "Diana Ross",
+        "Sister Sledge",
+        "Chaka Khan"
+      ],
+      "title": "Got to Be Real",
+      "chart_info": {
+        "billboard_peak": 12,
+        "uk_peak": 0,
+        "weeks_on_chart": 16
+      },
+      "certifications": [
+        "Gold (US)"
+      ],
+      "awards": [],
+      "fun_fact": "Cheryl Lynn was discovered on 'The Gong Show' TV talent competition, where she won. Co-written with David Paich and David Foster (later of Toto and a legendary producer). The song became a staple of drag culture and LGBTQ celebrations.",
+      "fun_fact_de": "Cheryl Lynn wurde in der TV-Talentshow 'The Gong Show' entdeckt, die sie gewann. Mitgeschrieben mit David Paich und David Foster (später von Toto bzw. als legendärer Produzent). Der Song wurde zum Klassiker der Drag-Kultur und LGBTQ-Feiern.",
+      "fun_fact_es": "Cheryl Lynn fue descubierta en el concurso de TV 'The Gong Show', que ganó. Coescrita con David Paich y David Foster (luego de Toto y legendario productor). La canción se convirtió en un clásico de la cultura drag y celebraciones LGBTQ.",
+      "uri_apple_music": "applemusic://track/170497685",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=fI569nw0YUQ"
+    },
+    {
+      "year": 1980,
+      "uri": "spotify:track:3EG65y2LtxWjfydabHdItb",
+      "artist": "The Brothers Johnson",
+      "alt_artists": [
+        "Earth, Wind & Fire",
+        "Kool & The Gang",
+        "Quincy Jones",
+        "The Gap Band"
+      ],
+      "title": "Stomp!",
+      "chart_info": {
+        "billboard_peak": 7,
+        "uk_peak": 6,
+        "weeks_on_chart": 17
+      },
+      "certifications": [
+        "Gold (US)"
+      ],
+      "awards": [],
+      "fun_fact": "Produced by Quincy Jones, who was simultaneously working on Michael Jackson's 'Off the Wall'. The Brothers Johnson (George and Louis) were session musicians for Quincy Jones before launching their own career. The bass line is one of funk's most iconic.",
+      "fun_fact_de": "Produziert von Quincy Jones, der gleichzeitig an Michael Jacksons 'Off the Wall' arbeitete. Die Brothers Johnson (George und Louis) waren Session-Musiker für Quincy Jones, bevor sie ihre eigene Karriere starteten. Die Basslinie ist eine der ikonischsten des Funk.",
+      "fun_fact_es": "Producida por Quincy Jones, quien simultáneamente trabajaba en 'Off the Wall' de Michael Jackson. Los Brothers Johnson (George y Louis) eran músicos de sesión de Quincy Jones antes de lanzar su carrera. La línea de bajo es una de las más icónicas del funk.",
+      "uri_apple_music": "applemusic://track/1440897373",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=tPBDMihPRJA"
+    },
+    {
+      "year": 1979,
+      "uri": "spotify:track:5MuNxNox3zTanAFIO5KcTl",
+      "artist": "Sister Sledge",
+      "alt_artists": [
+        "CHIC",
+        "Donna Summer",
+        "Diana Ross",
+        "Kool & The Gang"
+      ],
+      "title": "He's the Greatest Dancer",
+      "chart_info": {
+        "billboard_peak": 9,
+        "uk_peak": 6,
+        "weeks_on_chart": 16
+      },
+      "certifications": [
+        "Gold (US)"
+      ],
+      "awards": [],
+      "fun_fact": "Written and produced by Nile Rodgers and Bernard Edwards of CHIC. Will Smith sampled it for 'Gettin' Jiggy wit It'. The four Sledge sisters were from Philadelphia, and this was from their breakthrough album 'We Are Family', entirely produced by CHIC.",
+      "fun_fact_de": "Geschrieben und produziert von Nile Rodgers und Bernard Edwards von CHIC. Will Smith sampelte es für 'Gettin' Jiggy wit It'. Die vier Sledge-Schwestern kamen aus Philadelphia, und dies war von ihrem Durchbruchsalbum 'We Are Family', komplett von CHIC produziert.",
+      "fun_fact_es": "Escrita y producida por Nile Rodgers y Bernard Edwards de CHIC. Will Smith la sampleó para 'Gettin' Jiggy wit It'. Las cuatro hermanas Sledge eran de Filadelfia, y esto era de su álbum de éxito 'We Are Family', producido íntegramente por CHIC.",
+      "uri_apple_music": "applemusic://track/333592942",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=fLLSwHaYk6k"
+    },
+    {
+      "year": 1978,
+      "uri": "spotify:track:67hbP9PFQZrb4XZc3TzB0s",
+      "artist": "Boney M.",
+      "alt_artists": [
+        "Village People",
+        "ABBA",
+        "Eruption",
+        "Genghis Khan"
+      ],
+      "title": "Rasputin",
+      "chart_info": {
+        "billboard_peak": 0,
+        "uk_peak": 2,
+        "weeks_on_chart": 14
+      },
+      "certifications": [
+        "Gold (UK)"
+      ],
+      "awards": [],
+      "fun_fact": "About the Russian mystic Grigori Rasputin, the song went massively viral on TikTok in 2020, introducing it to a new generation. The song was banned in the Soviet Union. Producer Frank Farian was fascinated by the historical figure's legendary reputation.",
+      "fun_fact_de": "Über den russischen Mystiker Grigori Rasputin ging der Song 2020 auf TikTok viral und erreichte eine neue Generation. Er war in der Sowjetunion verboten. Produzent Frank Farian war fasziniert vom legendären Ruf der historischen Figur.",
+      "fun_fact_es": "Sobre el místico ruso Grigori Rasputín, la canción se volvió masivamente viral en TikTok en 2020, presentándola a una nueva generación. La canción fue prohibida en la Unión Soviética. El productor Frank Farian estaba fascinado por la reputación legendaria del personaje histórico.",
+      "uri_apple_music": "applemusic://track/842661537",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=16y1AkoZkmQ"
+    },
+    {
+      "year": 1983,
+      "uri": "spotify:track:2NVpYQqdraEcQwqT7GhUkh",
+      "artist": "Chaka Khan",
+      "alt_artists": [
+        "Rufus",
+        "Prince",
+        "Earth, Wind & Fire",
+        "Kool & The Gang"
+      ],
+      "title": "Ain't Nobody",
+      "chart_info": {
+        "billboard_peak": 22,
+        "uk_peak": 8,
+        "weeks_on_chart": 14
+      },
+      "certifications": [
+        "Gold (US)"
+      ],
+      "awards": [
+        "Grammy Award for Best R&B Song"
+      ],
+      "fun_fact": "Recorded with Rufus, this was the band's final major hit. David 'Hawk' Wolinski wrote it in 15 minutes. The song has been covered and sampled extensively, most notably by Felix for a 1992 dance hit. It won the Grammy for Best R&B Song.",
+      "fun_fact_de": "Mit Rufus aufgenommen, war dies der letzte große Hit der Band. David 'Hawk' Wolinski schrieb ihn in 15 Minuten. Der Song wurde vielfach gecovert und gesampelt, am bekanntesten von Felix für einen Dance-Hit 1992. Er gewann den Grammy für Best R&B Song.",
+      "fun_fact_es": "Grabada con Rufus, fue el último gran éxito de la banda. David 'Hawk' Wolinski la escribió en 15 minutos. La canción ha sido versionada y sampleada extensamente, más notablemente por Felix para un éxito dance en 1992. Ganó el Grammy a la Mejor Canción R&B.",
+      "uri_apple_music": "applemusic://track/266611666",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=BNirQXe8HOA"
+    },
+    {
+      "year": 1976,
+      "uri": "spotify:track:3MFa9idQuY4iJLWsZl3tIQ",
+      "artist": "Candi Staton",
+      "alt_artists": [
+        "Gloria Gaynor",
+        "Donna Summer",
+        "Thelma Houston",
+        "Sister Sledge"
+      ],
+      "title": "Young Hearts Run Free",
+      "chart_info": {
+        "billboard_peak": 20,
+        "uk_peak": 2,
+        "weeks_on_chart": 14
+      },
+      "certifications": [
+        "Gold (UK)"
+      ],
+      "awards": [],
+      "fun_fact": "Written by David Crawford about Staton's abusive marriage. The song's message of liberation resonated deeply, making it a feminist anthem ahead of its time. It was featured prominently in Baz Luhrmann's 'Romeo + Juliet' (1996), introducing it to a new generation.",
+      "fun_fact_de": "Von David Crawford über Statons gewalttätige Ehe geschrieben. Die Botschaft der Befreiung machte den Song zu einer feministischen Hymne seiner Zeit. Er war prominent in Baz Luhrmanns 'Romeo + Juliet' (1996) zu hören und erreichte eine neue Generation.",
+      "fun_fact_es": "Escrita por David Crawford sobre el matrimonio abusivo de Staton. El mensaje de liberación resonó profundamente, convirtiéndola en un himno feminista adelantado a su tiempo. Apareció prominentemente en 'Romeo + Juliet' de Baz Luhrmann (1996), presentándola a una nueva generación.",
+      "uri_apple_music": "applemusic://track/40457861",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=wddgskIRVeg"
+    },
+    {
+      "year": 1977,
+      "uri": "spotify:track:6UjlpJhUqOQqv0hrb38IDI",
+      "artist": "The Emotions",
+      "alt_artists": [
+        "Earth, Wind & Fire",
+        "Sister Sledge",
+        "The Pointer Sisters",
+        "Chaka Khan"
+      ],
+      "title": "Best of My Love",
+      "chart_info": {
+        "billboard_peak": 1,
+        "uk_peak": 4,
+        "weeks_on_chart": 21
+      },
+      "certifications": [
+        "Gold (US)"
+      ],
+      "awards": [],
+      "fun_fact": "Written and produced by Maurice White of Earth, Wind & Fire, who also produced the group's album 'Rejoice'. It spent five weeks at #1 on the Hot 100. The three Hutchinson sisters had been performing together since childhood in Chicago's gospel scene.",
+      "fun_fact_de": "Geschrieben und produziert von Maurice White von Earth, Wind & Fire, der auch das Album 'Rejoice' der Gruppe produzierte. Es war fünf Wochen auf Platz 1 der Hot 100. Die drei Hutchinson-Schwestern traten seit ihrer Kindheit in Chicagos Gospel-Szene zusammen auf.",
+      "fun_fact_es": "Escrita y producida por Maurice White de Earth, Wind & Fire, quien también produjo el álbum 'Rejoice'. Estuvo cinco semanas en el #1 del Hot 100. Las tres hermanas Hutchinson actuaban juntas desde la infancia en la escena gospel de Chicago.",
+      "uri_apple_music": "applemusic://track/170522819",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=odh0DuMp780"
+    },
+    {
+      "year": 1977,
+      "uri": "spotify:track:3Hya20ZNnlLzGLCpzJR6bv",
+      "artist": "KC & The Sunshine Band",
+      "alt_artists": [
+        "Bee Gees",
+        "The Trammps",
+        "Village People",
+        "Kool & The Gang"
+      ],
+      "title": "I'm Your Boogie Man",
+      "chart_info": {
+        "billboard_peak": 1,
+        "uk_peak": 41,
+        "weeks_on_chart": 16
+      },
+      "certifications": [
+        "Gold (US)"
+      ],
+      "awards": [],
+      "fun_fact": "KC & The Sunshine Band's fifth and final #1 hit, it cemented their status as the kings of '70s disco. The band was one of the few white-fronted acts to top both the pop and R&B charts during the disco era, thanks to their authentic Miami soul-funk sound.",
+      "fun_fact_de": "Der fünfte und letzte Nummer-1-Hit von KC & The Sunshine Band festigte ihren Status als Könige des 70er-Disco. Die Band war eine der wenigen weiß geführten Acts, die während der Disco-Ära sowohl die Pop- als auch die R&B-Charts anführten.",
+      "fun_fact_es": "El quinto y último #1 de KC & The Sunshine Band, consolidó su estatus como los reyes del disco de los 70. La banda fue uno de los pocos actos liderados por blancos en liderar tanto las listas pop como R&B durante la era disco.",
+      "uri_apple_music": "applemusic://track/1858861535",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=HT0wGSbASZE"
+    },
+    {
+      "year": 1979,
+      "uri": "spotify:track:6120uJUyg6QDzaAJUosTx5",
+      "artist": "Amii Stewart",
+      "alt_artists": [
+        "Gloria Gaynor",
+        "Donna Summer",
+        "Anita Ward",
+        "Sister Sledge"
+      ],
+      "title": "Knock On Wood",
+      "chart_info": {
+        "billboard_peak": 1,
+        "uk_peak": 6,
+        "weeks_on_chart": 18
+      },
+      "certifications": [
+        "Gold (US)"
+      ],
+      "awards": [],
+      "fun_fact": "A disco reworking of Eddie Floyd's 1966 soul classic. Amii Stewart's version spent one week at #1 in the US and sold over a million copies. The original was co-written by Steve Cropper of Booker T. & the M.G.'s at Stax Records.",
+      "fun_fact_de": "Eine Disco-Neubearbeitung von Eddie Floyds Soul-Klassiker von 1966. Amii Stewarts Version war eine Woche auf Platz 1 in den USA und verkaufte über eine Million Exemplare. Das Original wurde von Steve Cropper von Booker T. & the M.G.'s bei Stax Records mitgeschrieben.",
+      "fun_fact_es": "Una reelaboración disco del clásico soul de Eddie Floyd de 1966. La versión de Amii Stewart estuvo una semana en el #1 en EE.UU. y vendió más de un millón de copias. El original fue coescrito por Steve Cropper de Booker T. & the M.G.'s en Stax Records.",
+      "uri_apple_music": "applemusic://track/428921412",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=XKuJUxGntRI"
+    },
+    {
+      "year": 1984,
+      "uri": "spotify:track:3L9ClO1W5KmebIXTrlKShF",
+      "artist": "The Pointer Sisters",
+      "alt_artists": [
+        "Whitney Houston",
+        "Janet Jackson",
+        "Tina Turner",
+        "Cyndi Lauper"
+      ],
+      "title": "Jump (For My Love)",
+      "chart_info": {
+        "billboard_peak": 3,
+        "uk_peak": 6,
+        "weeks_on_chart": 18
+      },
+      "certifications": [
+        "Gold (US)"
+      ],
+      "awards": [
+        "Grammy Award for Best Pop Performance by a Duo or Group"
+      ],
+      "fun_fact": "Written by Marti Sharron, Gary Skardina, and Stephen Mitchell. It won the Grammy for Best Pop Performance by a Duo or Group. The song gained renewed popularity when it was featured in the film 'Love Actually' (2003) and in Hugh Grant's famous dance scene.",
+      "fun_fact_de": "Geschrieben von Marti Sharron, Gary Skardina und Stephen Mitchell. Es gewann den Grammy für Best Pop Performance by a Duo or Group. Der Song erlangte neue Popularität durch den Film 'Tatsächlich... Liebe' (2003) und Hugh Grants berühmte Tanzszene.",
+      "fun_fact_es": "Escrita por Marti Sharron, Gary Skardina y Stephen Mitchell. Ganó el Grammy a la Mejor Interpretación Pop por Dúo o Grupo. La canción ganó nueva popularidad al aparecer en la película 'Love Actually' (2003) y en la famosa escena de baile de Hugh Grant.",
+      "uri_apple_music": "applemusic://track/1223786412",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=uyTVyCp7xrw"
+    },
+    {
+      "year": 1981,
+      "uri": "spotify:track:59BkBWQitTPgS1inzGfyI5",
+      "artist": "Stars On 45",
+      "alt_artists": [
+        "Jive Bunny",
+        "Boney M.",
+        "Village People",
+        "ABBA"
+      ],
+      "title": "Stars On 45",
+      "chart_info": {
+        "billboard_peak": 1,
+        "uk_peak": 2,
+        "weeks_on_chart": 16
+      },
+      "certifications": [
+        "Platinum (US)"
+      ],
+      "awards": [],
+      "fun_fact": "A medley of Beatles songs set to a disco beat, it spent one week at #1 in the US. Initially created as a bootleg in the Netherlands, it was quickly legitimized. The Beatles' management was not amused but couldn't stop its success.",
+      "fun_fact_de": "Ein Medley aus Beatles-Songs mit Disco-Beat war eine Woche auf Platz 1 in den USA. Ursprünglich als Bootleg in den Niederlanden entstanden, wurde es schnell legitimiert. Das Beatles-Management war not amused, konnte den Erfolg aber nicht aufhalten.",
+      "fun_fact_es": "Un medley de canciones de los Beatles con ritmo disco, estuvo una semana en el #1 en EE.UU. Inicialmente creado como bootleg en los Países Bajos, fue rápidamente legitimado. La dirección de los Beatles no estaba contenta pero no pudo detener su éxito.",
+      "uri_apple_music": "",
+      "uri_youtube_music": ""
+    },
+    {
+      "year": 1984,
+      "uri": "spotify:track:0FrCX7P2C2hcRTcuhjEvK4",
+      "artist": "Bronski Beat",
+      "alt_artists": [
+        "Yazoo",
+        "Erasure",
+        "Soft Cell",
+        "Pet Shop Boys"
+      ],
+      "title": "Smalltown Boy",
+      "chart_info": {
+        "billboard_peak": 48,
+        "uk_peak": 3,
+        "weeks_on_chart": 12
+      },
+      "certifications": [
+        "Silver (UK)"
+      ],
+      "awards": [],
+      "fun_fact": "One of the first openly gay pop songs to become a mainstream hit, telling the story of a young gay man forced to leave his hometown. Jimmy Somerville's distinctive falsetto became iconic. Somerville later co-founded The Communards and had a successful solo career.",
+      "fun_fact_de": "Einer der ersten offen schwulen Pop-Songs, der ein Mainstream-Hit wurde, über einen jungen schwulen Mann, der seine Heimatstadt verlassen muss. Jimmy Somervilles markantes Falsett wurde ikonisch. Somerville gründete später The Communards und hatte eine erfolgreiche Solokarriere.",
+      "fun_fact_es": "Una de las primeras canciones pop abiertamente gay en convertirse en éxito mainstream, contando la historia de un joven gay obligado a dejar su ciudad. El distintivo falsete de Jimmy Somerville se volvió icónico. Somerville cofundó The Communards y tuvo una exitosa carrera solista.",
+      "uri_apple_music": "applemusic://track/1434868877",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=a8dzSKRtctU"
+    },
+    {
+      "year": 1975,
+      "uri": "spotify:track:3GGcwG519BTMdvMeFy7meT",
+      "artist": "Labelle",
+      "alt_artists": [
+        "Patti LaBelle",
+        "Donna Summer",
+        "Gloria Gaynor",
+        "Chaka Khan"
+      ],
+      "title": "Lady Marmalade",
+      "chart_info": {
+        "billboard_peak": 1,
+        "uk_peak": 17,
+        "weeks_on_chart": 14
+      },
+      "certifications": [
+        "Gold (US)"
+      ],
+      "awards": [],
+      "fun_fact": "The famous French chorus 'Voulez-vous coucher avec moi ce soir' was considered scandalous in 1975. Written by Bob Crewe and Kenny Nolan about a New Orleans prostitute. The 2001 version by Christina Aguilera, Lil' Kim, Mýa, and Pink also hit #1.",
+      "fun_fact_de": "Der berühmte französische Refrain 'Voulez-vous coucher avec moi ce soir' galt 1975 als skandalös. Geschrieben von Bob Crewe und Kenny Nolan über eine Prostituierte in New Orleans. Die Version von 2001 mit Christina Aguilera, Lil' Kim, Mýa und Pink erreichte ebenfalls Platz 1.",
+      "fun_fact_es": "El famoso estribillo francés 'Voulez-vous coucher avec moi ce soir' se consideró escandaloso en 1975. Escrita por Bob Crewe y Kenny Nolan sobre una prostituta de Nueva Orleans. La versión de 2001 con Christina Aguilera, Lil' Kim, Mýa y Pink también llegó al #1.",
+      "uri_apple_music": "applemusic://track/1308524718",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Tw6HrI9e1K4"
+    },
+    {
+      "year": 1977,
+      "uri": "spotify:track:0OhpOmbSSSlNROas9zGP7N",
+      "artist": "Tavares",
+      "alt_artists": [
+        "Bee Gees",
+        "The Commodores",
+        "Earth, Wind & Fire",
+        "The O'Jays"
+      ],
+      "title": "More Than a Woman",
+      "chart_info": {
+        "billboard_peak": 32,
+        "uk_peak": 7,
+        "weeks_on_chart": 12
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "Written by the Bee Gees for the Saturday Night Fever soundtrack. Both the Bee Gees' own version and this Tavares version appeared in the film. The five Tavares brothers from Cape Verde, Massachusetts became one of the era's top vocal groups.",
+      "fun_fact_de": "Von den Bee Gees für den Saturday Night Fever-Soundtrack geschrieben. Sowohl die Bee-Gees-Version als auch diese Tavares-Version erschienen im Film. Die fünf Tavares-Brüder aus Cape Verde, Massachusetts wurden eine der Top-Vokalgruppen der Ära.",
+      "fun_fact_es": "Escrita por los Bee Gees para la banda sonora de Saturday Night Fever. Tanto la versión de los Bee Gees como esta de Tavares aparecieron en la película. Los cinco hermanos Tavares de Cape Verde, Massachusetts se convirtieron en uno de los mejores grupos vocales de la época.",
+      "uri_apple_music": "",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=D53HgCX1dR8"
+    },
+    {
+      "year": 1977,
+      "uri": "spotify:track:1jR4bgFyL3ut5ExAKDDNEZ",
+      "artist": "Odyssey",
+      "alt_artists": [
+        "Imagination",
+        "Shalamar",
+        "Change",
+        "D-Train"
+      ],
+      "title": "Native New Yorker",
+      "chart_info": {
+        "billboard_peak": 21,
+        "uk_peak": 5,
+        "weeks_on_chart": 14
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "Written by Sandy Linzer and Denny Randell, the song was originally offered to Frankie Valli. The trio Odyssey featured Filipina-American sisters Lillian and Louise Lopez alongside Tony Reynolds. It became a New York City anthem and is still played at city events.",
+      "fun_fact_de": "Von Sandy Linzer und Denny Randell geschrieben, wurde der Song ursprünglich Frankie Valli angeboten. Das Trio Odyssey bestand aus den philippinisch-amerikanischen Schwestern Lillian und Louise Lopez sowie Tony Reynolds. Es wurde zur New-York-Hymne.",
+      "fun_fact_es": "Escrita por Sandy Linzer y Denny Randell, la canción se ofreció originalmente a Frankie Valli. El trío Odyssey incluía a las hermanas filipino-americanas Lillian y Louise López junto con Tony Reynolds. Se convirtió en un himno de la ciudad de Nueva York.",
+      "uri_apple_music": "applemusic://track/411443154",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=dIw6xSvFz0c"
+    },
+    {
+      "year": 1977,
+      "uri": "spotify:track:6lN7g29oDwqBCptSrVtN0O",
+      "artist": "Commodores",
+      "alt_artists": [
+        "Earth, Wind & Fire",
+        "Kool & The Gang",
+        "The Gap Band",
+        "Parliament"
+      ],
+      "title": "Brick House",
+      "chart_info": {
+        "billboard_peak": 5,
+        "uk_peak": 32,
+        "weeks_on_chart": 17
+      },
+      "certifications": [
+        "Gold (US)"
+      ],
+      "awards": [],
+      "fun_fact": "Written by the entire band, with the opening bass line by Ronald LaPread becoming one of funk's most famous riffs. The song celebrates a confident woman and has become a staple at sporting events. Lionel Richie was still with the band when this was recorded.",
+      "fun_fact_de": "Von der gesamten Band geschrieben, mit der Eröffnungs-Basslinie von Ronald LaPread als einer der berühmtesten Funk-Riffs. Der Song feiert eine selbstbewusste Frau und ist bei Sportevents ein Muss. Lionel Richie war noch bei der Band, als dieser Song aufgenommen wurde.",
+      "fun_fact_es": "Escrita por toda la banda, con la línea de bajo inicial de Ronald LaPread convirtiéndose en uno de los riffs más famosos del funk. La canción celebra a una mujer segura y se ha convertido en un clásico en eventos deportivos. Lionel Richie aún estaba en la banda cuando se grabó.",
+      "uri_apple_music": "applemusic://track/1442972077",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=ZdJmXeod0RE"
+    },
+    {
+      "year": 1974,
+      "uri": "spotify:track:2EaxgHeQMOzaY8HcgP3VQ3",
+      "artist": "Average White Band",
+      "alt_artists": [
+        "Tower of Power",
+        "Earth, Wind & Fire",
+        "The Brothers Johnson",
+        "Kool & The Gang"
+      ],
+      "title": "Pick Up the Pieces",
+      "chart_info": {
+        "billboard_peak": 1,
+        "uk_peak": 6,
+        "weeks_on_chart": 18
+      },
+      "certifications": [
+        "Gold (US)"
+      ],
+      "awards": [],
+      "fun_fact": "This Scottish band's instrumental funk masterpiece spent one week at #1 in the US. Tragically, drummer Robbie McIntosh died of a heroin overdose at a party hosted by Cher shortly after the song's success. The iconic sax riff was played by Roger Ball.",
+      "fun_fact_de": "Das instrumentale Funk-Meisterwerk dieser schottischen Band war eine Woche auf Platz 1 in den USA. Tragischerweise starb Drummer Robbie McIntosh kurz nach dem Erfolg an einer Heroinüberdosis auf einer Party bei Cher. Das ikonische Saxophon-Riff spielte Roger Ball.",
+      "fun_fact_es": "La obra maestra instrumental funk de esta banda escocesa estuvo una semana en el #1 en EE.UU. Trágicamente, el baterista Robbie McIntosh murió de sobredosis de heroína en una fiesta organizada por Cher poco después del éxito. El icónico riff de saxo fue tocado por Roger Ball.",
+      "uri_apple_music": "applemusic://track/185816158",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=DyjlxsJEknc"
+    },
+    {
+      "year": 1979,
+      "uri": "spotify:track:0ZvLrvwzp0nBkfmtzL7XO1",
+      "artist": "Dan Hartman",
+      "alt_artists": [
+        "Patrick Cowley",
+        "Sylvester",
+        "The Trammps",
+        "Donna Summer"
+      ],
+      "title": "Relight My Fire",
+      "chart_info": {
+        "billboard_peak": 29,
+        "uk_peak": 0,
+        "weeks_on_chart": 10
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "Originally from the Edgar Winter Group, Hartman wrote this disco epic with its soaring vocals. Take That and Lulu's 1993 cover reached #1 in the UK. Hartman was also a prolific songwriter, writing 'Living in America' for James Brown. He died of AIDS in 1994.",
+      "fun_fact_de": "Ursprünglich von der Edgar Winter Group, schrieb Hartman dieses Disco-Epos mit seinen aufsteigenden Vocals. Das Cover von Take That und Lulu erreichte 1993 Platz 1 in UK. Hartman schrieb auch 'Living in America' für James Brown. Er starb 1994 an AIDS.",
+      "fun_fact_es": "Originalmente de la Edgar Winter Group, Hartman escribió esta épica disco con sus voces elevadas. La versión de Take That y Lulu de 1993 llegó al #1 en UK. Hartman también escribió 'Living in America' para James Brown. Murió de SIDA en 1994.",
+      "uri_apple_music": "applemusic://track/1372309830",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Bgew7_KeKWY"
+    },
+    {
+      "year": 1979,
+      "uri": "spotify:track:151LVGGcVL0RZJPBh1SIxn",
+      "artist": "Elton John",
+      "alt_artists": [
+        "Rod Stewart",
+        "David Bowie",
+        "Freddie Mercury",
+        "George Michael"
+      ],
+      "title": "Victim of Love",
+      "chart_info": {
+        "billboard_peak": 0,
+        "uk_peak": 0,
+        "weeks_on_chart": 0
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "Elton John's most controversial album — a full disco record produced by Pete Bellotte (Donna Summer's producer) with no input from longtime lyricist Bernie Taupin. It was poorly received at the time but has been reappraised as a bold artistic experiment.",
+      "fun_fact_de": "Elton Johns umstrittenstes Album — eine komplette Disco-Platte, produziert von Pete Bellotte (Donna Summers Produzent) ohne Beteiligung von Texter Bernie Taupin. Damals schlecht aufgenommen, wird es heute als mutiges künstlerisches Experiment neu bewertet.",
+      "fun_fact_es": "El álbum más controvertido de Elton John — un disco completo producido por Pete Bellotte (productor de Donna Summer) sin participación de su letrista Bernie Taupin. Mal recibido en su momento, hoy se revalora como un audaz experimento artístico.",
+      "uri_apple_music": "",
+      "uri_youtube_music": ""
+    },
+    {
+      "year": 1984,
+      "uri": "spotify:track:5xRaPHjgYoxOZjpwsDsbnp",
+      "artist": "Evelyn Thomas",
+      "alt_artists": [
+        "Donna Summer",
+        "Shannon",
+        "Hazell Dean",
+        "Dead or Alive"
+      ],
+      "title": "High Energy",
+      "chart_info": {
+        "billboard_peak": 85,
+        "uk_peak": 5,
+        "weeks_on_chart": 13
+      },
+      "certifications": [
+        "Silver (UK)"
+      ],
+      "awards": [],
+      "fun_fact": "Produced by Stock Aitken Waterman's Ian Levine, this Hi-NRG anthem became a defining track of the genre. The song was a massive hit in European clubs and helped define the Hi-NRG sound that would influence dance music throughout the 1980s.",
+      "fun_fact_de": "Produziert von Ian Levine, wurde diese Hi-NRG-Hymne zu einem Genre-definierenden Track. Der Song war ein Riesenhit in europäischen Clubs und half, den Hi-NRG-Sound zu definieren, der die Tanzmusik der 1980er Jahre beeinflusste.",
+      "fun_fact_es": "Producida por Ian Levine, este himno Hi-NRG se convirtió en un track definitorio del género. La canción fue un gran éxito en los clubs europeos y ayudó a definir el sonido Hi-NRG que influiría en la música dance de los años 80.",
+      "uri_apple_music": "applemusic://track/585427996",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=7G6S2YWOyCk"
+    },
+    {
+      "year": 1980,
+      "uri": "spotify:track:0MF3XV3L0oGokmU8qxYMba",
+      "artist": "Kelly Marie",
+      "alt_artists": [
+        "Ottawan",
+        "Boney M.",
+        "Anita Ward",
+        "Patrick Hernandez"
+      ],
+      "title": "Feels Like I'm in Love",
+      "chart_info": {
+        "billboard_peak": 0,
+        "uk_peak": 1,
+        "weeks_on_chart": 16
+      },
+      "certifications": [
+        "Silver (UK)"
+      ],
+      "awards": [],
+      "fun_fact": "Originally written by Mungo Jerry frontman Ray Dorset for Elvis Presley, who died before recording it. Kelly Marie's disco version spent two weeks at #1 in the UK but was never released in the US. It became one of the defining Euro-disco hits of 1980.",
+      "fun_fact_de": "Ursprünglich von Mungo-Jerry-Frontmann Ray Dorset für Elvis Presley geschrieben, der starb, bevor er es aufnehmen konnte. Kelly Maries Disco-Version war zwei Wochen auf Platz 1 in UK, wurde aber nie in den USA veröffentlicht. Einer der Euro-Disco-Hits von 1980.",
+      "fun_fact_es": "Originalmente escrita por el líder de Mungo Jerry, Ray Dorset, para Elvis Presley, quien murió antes de grabarla. La versión disco de Kelly Marie estuvo dos semanas en el #1 en UK pero nunca se lanzó en EE.UU. Se convirtió en uno de los éxitos euro-disco de 1980.",
+      "uri_apple_music": "",
+      "uri_youtube_music": ""
+    },
+    {
+      "year": 1981,
+      "uri": "spotify:track:3a5l5ngK3O7sprzL3FUoAs",
+      "artist": "Grace Jones",
+      "alt_artists": [
+        "Donna Summer",
+        "Diana Ross",
+        "Sly & The Family Stone",
+        "Blondie"
+      ],
+      "title": "Pull Up to the Bumper",
+      "chart_info": {
+        "billboard_peak": 0,
+        "uk_peak": 12,
+        "weeks_on_chart": 12
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "Co-written by Grace Jones, Kookoo Baya, and Dana Manno, with Sly Dunbar and Robbie Shakespeare providing the reggae-funk rhythm. The suggestive lyrics were controversial. Jones' Compass Point Studios sessions in Nassau, Bahamas, created a groundbreaking reggae-disco-funk fusion.",
+      "fun_fact_de": "Mitgeschrieben von Grace Jones, Kookoo Baya und Dana Manno, mit Sly Dunbar und Robbie Shakespeare am Reggae-Funk-Rhythmus. Die anzüglichen Texte waren kontrovers. Jones' Sessions in den Compass Point Studios auf Nassau schufen eine bahnbrechende Reggae-Disco-Funk-Fusion.",
+      "fun_fact_es": "Coescrita por Grace Jones, Kookoo Baya y Dana Manno, con Sly Dunbar y Robbie Shakespeare proporcionando el ritmo reggae-funk. Las letras sugerentes fueron controvertidas. Las sesiones de Jones en Compass Point Studios en Nassau crearon una fusión reggae-disco-funk revolucionaria.",
+      "uri_apple_music": "applemusic://track/1444048640",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Tc1IphRx1pk"
+    },
+    {
+      "year": 1983,
+      "uri": "spotify:track:4L9sdN5l6PvW3EZyP6sY7j",
+      "artist": "Gloria Gaynor",
+      "alt_artists": [
+        "Donna Summer",
+        "Shirley Bassey",
+        "Diana Ross",
+        "Barbra Streisand"
+      ],
+      "title": "I Am What I Am",
+      "chart_info": {
+        "billboard_peak": 82,
+        "uk_peak": 13,
+        "weeks_on_chart": 10
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "Originally from the Broadway musical 'La Cage aux Folles'. Gloria Gaynor's powerful disco version became a defining LGBTQ anthem, even more so than 'I Will Survive'. It's performed every year at Pride events worldwide and remains a statement of self-acceptance.",
+      "fun_fact_de": "Ursprünglich aus dem Broadway-Musical 'La Cage aux Folles'. Gloria Gaynors kraftvolle Disco-Version wurde zu einer LGBTQ-Hymne, noch mehr als 'I Will Survive'. Er wird jedes Jahr bei Pride-Events weltweit aufgeführt und bleibt ein Statement der Selbstakzeptanz.",
+      "fun_fact_es": "Originalmente del musical de Broadway 'La Cage aux Folles'. La poderosa versión disco de Gloria Gaynor se convirtió en un himno LGBTQ definitivo, incluso más que 'I Will Survive'. Se interpreta cada año en eventos del Orgullo en todo el mundo y sigue siendo una declaración de autoaceptación.",
+      "uri_apple_music": "applemusic://track/1810790226",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=zreTvtpTeoU"
+    }
+  ]
+}


### PR DESCRIPTION
Adds Disco & Funk Classics playlist with full metadata and streaming URIs.

## Stats
- **76 tracks** from the golden era of disco & funk (1974-1989)
- Spotify URIs: 76/76 (100%)
- Apple Music URIs: 68/76 (89%)
- YouTube Music URIs: 73/76 (96%)
- Fun facts in EN/DE/ES: 76/76 (100%)
- Chart info: 76/76 (100%)

## Curated from
Spotify playlist "Disco Classics (Top 100)" — filtered out non-classic modern tracks and duplicates.

Closes #74