### PR TITLE
fix: remove unused de_peak chart field

### DIFF
--- a/custom_components/beatify/playlists/80er-hits.json
+++ b/custom_components/beatify/playlists/80er-hits.json
@@ -17,9 +17,7 @@
         "Mary Roos"
       ],
       "title": "Er gehört zu mir",
-      "chart_info": {
-        "de_peak": 3
-      },
+      "chart_info": {},
       "certifications": [
         "Gold (DE)"
       ],
@@ -284,7 +282,6 @@
       ],
       "title": "Felicità",
       "chart_info": {
-        "de_peak": 1,
         "it_peak": 1
       },
       "certifications": [
@@ -335,7 +332,6 @@
       "chart_info": {
         "billboard_peak": 72,
         "uk_peak": 92,
-        "de_peak": 1,
         "at_peak": 1
       },
       "certifications": [
@@ -358,9 +354,7 @@
         "Modern Talking"
       ],
       "title": "Sternenhimmel",
-      "chart_info": {
-        "de_peak": 2
-      },
+      "chart_info": {},
       "certifications": [
         "Gold (DE)"
       ],
@@ -462,8 +456,7 @@
       "title": "Major Tom (Völlig losgelöst)",
       "chart_info": {
         "billboard_peak": 14,
-        "uk_peak": 94,
-        "de_peak": 1
+        "uk_peak": 94
       },
       "certifications": [
         "Gold (US)",
@@ -966,8 +959,7 @@
       "title": "Sunshine Reggae",
       "chart_info": {
         "billboard_peak": 64,
-        "uk_peak": 44,
-        "de_peak": 1
+        "uk_peak": 44
       },
       "certifications": [
         "Gold (DE)"
@@ -1187,8 +1179,7 @@
       "title": "Forever Young",
       "chart_info": {
         "billboard_peak": 65,
-        "uk_peak": 48,
-        "de_peak": 1
+        "uk_peak": 48
       },
       "certifications": [
         "Gold (DE)"
@@ -1379,8 +1370,7 @@
       "title": "When the Rain Begins to Fall",
       "chart_info": {
         "billboard_peak": 54,
-        "uk_peak": 68,
-        "de_peak": 1
+        "uk_peak": 68
       },
       "certifications": [
         "Gold (DE)"
@@ -1773,9 +1763,7 @@
         "Udo Lindenberg"
       ],
       "title": "Dein ist mein ganzes Herz",
-      "chart_info": {
-        "de_peak": 1
-      },
+      "chart_info": {},
       "certifications": [
         "Gold (DE)"
       ],
@@ -1820,7 +1808,6 @@
       ],
       "title": "Ohne Dich (schlaf' ich heut Nacht nicht ein)",
       "chart_info": {
-        "de_peak": 1,
         "at_peak": 2
       },
       "certifications": [
@@ -2013,8 +2000,7 @@
       "title": "Voyage voyage",
       "chart_info": {
         "billboard_peak": 48,
-        "uk_peak": 5,
-        "de_peak": 2
+        "uk_peak": 5
       },
       "certifications": [
         "Gold (FR)",
@@ -2037,8 +2023,7 @@
       ],
       "title": "Bello e impossibile",
       "chart_info": {
-        "it_peak": 1,
-        "de_peak": 5
+        "it_peak": 1
       },
       "certifications": [
         "Platinum (IT)"
@@ -2300,8 +2285,7 @@
       ],
       "title": "Ella, elle l'a",
       "chart_info": {
-        "fr_peak": 1,
-        "de_peak": 2
+        "fr_peak": 1
       },
       "certifications": [
         "Diamond (FR)",

--- a/custom_components/beatify/playlists/koelner-karneval.json
+++ b/custom_components/beatify/playlists/koelner-karneval.json
@@ -653,7 +653,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=T92lWKs4Nqc",
-      "uri_apple_music": "applemusic://track/269371824"
+      "uri_apple_music": "applemusic://track/269371824",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 1997,
@@ -670,7 +673,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=RLEFFpe0ZDA",
-      "uri_apple_music": "applemusic://track/1698598485"
+      "uri_apple_music": "applemusic://track/1698598485",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2001,
@@ -687,7 +693,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=dJu2jWlEZdI",
-      "uri_apple_music": "applemusic://track/713738390"
+      "uri_apple_music": "applemusic://track/713738390",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2001,
@@ -723,7 +732,10 @@
       "fun_fact_es": "Una declaracion segura de 'No necesitamos a nadie' - celebrando el espiritu independiente de Colonia y sus fuertes lazos comunitarios.",
       "certifications": [],
       "awards": [],
-      "uri_apple_music": "applemusic://track/713738498"
+      "uri_apple_music": "applemusic://track/713738498",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2001,
@@ -780,7 +792,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=C4VjjkP0uQs",
-      "uri_apple_music": "applemusic://track/803871018"
+      "uri_apple_music": "applemusic://track/803871018",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2001,
@@ -797,7 +812,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=gdKaI3TAMzI",
-      "uri_apple_music": "applemusic://track/314114513"
+      "uri_apple_music": "applemusic://track/314114513",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2001,
@@ -814,7 +832,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=Gfq6ukpkt8M",
-      "uri_apple_music": "applemusic://track/563994853"
+      "uri_apple_music": "applemusic://track/563994853",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2001,
@@ -831,7 +852,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=udm0_QwqCgU",
-      "uri_apple_music": "applemusic://track/713291213"
+      "uri_apple_music": "applemusic://track/713291213",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2001,
@@ -848,7 +872,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=EF0GBaV1huM",
-      "uri_apple_music": "applemusic://track/212430353"
+      "uri_apple_music": "applemusic://track/212430353",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2001,
@@ -885,7 +912,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=61PSHtAuPuQ",
-      "uri_apple_music": "applemusic://track/1444322979"
+      "uri_apple_music": "applemusic://track/1444322979",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2002,
@@ -902,7 +932,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=m4BDCxKjst8",
-      "uri_apple_music": "applemusic://track/1444398785"
+      "uri_apple_music": "applemusic://track/1444398785",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2002,
@@ -919,7 +952,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=J0tRDqDVKOk",
-      "uri_apple_music": "applemusic://track/201993850"
+      "uri_apple_music": "applemusic://track/201993850",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2002,
@@ -936,7 +972,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=SAnfv6mhb_Y",
-      "uri_apple_music": "applemusic://track/399740626"
+      "uri_apple_music": "applemusic://track/399740626",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2003,
@@ -953,7 +992,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=Xf9BEUuoOx0",
-      "uri_apple_music": "applemusic://track/206698193"
+      "uri_apple_music": "applemusic://track/206698193",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2003,
@@ -970,7 +1012,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=tS7Id7YQ1eE",
-      "uri_apple_music": "applemusic://track/713451419"
+      "uri_apple_music": "applemusic://track/713451419",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2003,
@@ -987,7 +1032,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=4r_oPE0Pcno",
-      "uri_apple_music": "applemusic://track/1694607686"
+      "uri_apple_music": "applemusic://track/1694607686",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2003,
@@ -1004,7 +1052,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=DcRlFgCbwMg",
-      "uri_apple_music": "applemusic://track/713451424"
+      "uri_apple_music": "applemusic://track/713451424",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2003,
@@ -1021,7 +1072,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=Xf9BEUuoOx0",
-      "uri_apple_music": "applemusic://track/206698193"
+      "uri_apple_music": "applemusic://track/206698193",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2003,
@@ -1038,7 +1092,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=DD9oG1kIC2I",
-      "uri_apple_music": "applemusic://track/713618540"
+      "uri_apple_music": "applemusic://track/713618540",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2005,
@@ -1055,7 +1112,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=7Sn1FrYclgs",
-      "uri_apple_music": "applemusic://track/267049981"
+      "uri_apple_music": "applemusic://track/267049981",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2005,
@@ -1072,7 +1132,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=umxahJPH2Fo",
-      "uri_apple_music": "applemusic://track/1436887142"
+      "uri_apple_music": "applemusic://track/1436887142",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2006,
@@ -1109,7 +1172,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=LXgf_bSDqr8",
-      "uri_apple_music": "applemusic://track/212444702"
+      "uri_apple_music": "applemusic://track/212444702",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2007,
@@ -1146,7 +1212,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=DXCSG6AMpQM",
-      "uri_apple_music": "applemusic://track/724227285"
+      "uri_apple_music": "applemusic://track/724227285",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2007,
@@ -1163,7 +1232,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=vYw0ip3WFPE",
-      "uri_apple_music": "applemusic://track/716166286"
+      "uri_apple_music": "applemusic://track/716166286",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2007,
@@ -1179,7 +1251,10 @@
       "fun_fact_es": "Höhner celebran que 'Hay gente de Colonia en todo el mundo' - la diaspora de Colonia mantiene vivas las tradiciones del carnaval globalmente.",
       "certifications": [],
       "awards": [],
-      "uri_apple_music": "applemusic://track/716006317"
+      "uri_apple_music": "applemusic://track/716006317",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2007,
@@ -1196,7 +1271,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=8ub3EU98xtA",
-      "uri_apple_music": "applemusic://track/713290533"
+      "uri_apple_music": "applemusic://track/713290533",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2007,
@@ -1213,7 +1291,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=goj-UN9il0c",
-      "uri_apple_music": "applemusic://track/724227271"
+      "uri_apple_music": "applemusic://track/724227271",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2007,
@@ -1230,7 +1311,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=pMB4xoIB3OI",
-      "uri_apple_music": "applemusic://track/1384483878"
+      "uri_apple_music": "applemusic://track/1384483878",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2012,
@@ -1267,7 +1351,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=CPEN_B7NGK8",
-      "uri_apple_music": "applemusic://track/267632592"
+      "uri_apple_music": "applemusic://track/267632592",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2008,
@@ -1284,7 +1371,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=zQo9emlsEhs",
-      "uri_apple_music": "applemusic://track/297068238"
+      "uri_apple_music": "applemusic://track/297068238",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2008,
@@ -1301,7 +1391,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=LKG1ATlnPtY",
-      "uri_apple_music": "applemusic://track/297068259"
+      "uri_apple_music": "applemusic://track/297068259",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2008,
@@ -1318,7 +1411,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=aDX7JMoBpeY",
-      "uri_apple_music": "applemusic://track/267050939"
+      "uri_apple_music": "applemusic://track/267050939",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2008,
@@ -1335,7 +1431,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=1WDb2SqP26s",
-      "uri_apple_music": "applemusic://track/399740101"
+      "uri_apple_music": "applemusic://track/399740101",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2008,
@@ -1352,7 +1451,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=Dd4LhwUmWU0",
-      "uri_apple_music": "applemusic://track/295827689"
+      "uri_apple_music": "applemusic://track/295827689",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2008,
@@ -1369,7 +1471,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=Fvg0ngtGT5Y",
-      "uri_apple_music": "applemusic://track/295170789"
+      "uri_apple_music": "applemusic://track/295170789",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2009,
@@ -1385,7 +1490,10 @@
       "fun_fact_es": "El exito de carnaval del comediante Bernd Stelter 'Locura' - muchos comediantes alemanes tienen carreras exitosas de musica de carnaval en Colonia.",
       "certifications": [],
       "awards": [],
-      "uri_apple_music": "applemusic://track/713096250"
+      "uri_apple_music": "applemusic://track/713096250",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2009,
@@ -1402,7 +1510,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=VauNz9bUByY",
-      "uri_apple_music": "applemusic://track/346780406"
+      "uri_apple_music": "applemusic://track/346780406",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2009,
@@ -1419,7 +1530,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=yo04EDrz6qA",
-      "uri_apple_music": "applemusic://track/713096244"
+      "uri_apple_music": "applemusic://track/713096244",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2009,
@@ -1436,7 +1550,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=LJ4XsW6BM8k",
-      "uri_apple_music": "applemusic://track/716548563"
+      "uri_apple_music": "applemusic://track/716548563",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2009,
@@ -1453,7 +1570,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=MtcS_gD4dF8",
-      "uri_apple_music": "applemusic://track/716445423"
+      "uri_apple_music": "applemusic://track/716445423",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2009,
@@ -1470,7 +1590,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=bhrueepAirw",
-      "uri_apple_music": "applemusic://track/337534443"
+      "uri_apple_music": "applemusic://track/337534443",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2009,
@@ -1487,7 +1610,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=baD5Y9HwF84",
-      "uri_apple_music": "applemusic://track/1672403084"
+      "uri_apple_music": "applemusic://track/1672403084",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2009,
@@ -1504,7 +1630,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=hEKF4hGEnk8",
-      "uri_apple_music": "applemusic://track/712743495"
+      "uri_apple_music": "applemusic://track/712743495",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2009,
@@ -1521,7 +1650,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=txjlCkXCx_4",
-      "uri_apple_music": "applemusic://track/1672403076"
+      "uri_apple_music": "applemusic://track/1672403076",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2010,
@@ -1538,7 +1670,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=lIy7g4yzraA",
-      "uri_apple_music": "applemusic://track/206940874"
+      "uri_apple_music": "applemusic://track/206940874",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2010,
@@ -1555,7 +1690,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=KHDFdY6y5mQ",
-      "uri_apple_music": "applemusic://track/367841973"
+      "uri_apple_music": "applemusic://track/367841973",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2010,
@@ -1572,7 +1710,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=NLdyPVAWgOs",
-      "uri_apple_music": "applemusic://track/721259503"
+      "uri_apple_music": "applemusic://track/721259503",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2010,
@@ -1588,7 +1729,10 @@
       "fun_fact_es": "Die Rheinländer cantan 'Al Mundo' - las bandas de carnaval a menudo hacen giras internacionales, difundiendo la cultura de Colonia mas alla del Rin.",
       "certifications": [],
       "awards": [],
-      "uri_apple_music": "applemusic://track/716548518"
+      "uri_apple_music": "applemusic://track/716548518",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2010,
@@ -1605,7 +1749,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=19PU4QxzU2U",
-      "uri_apple_music": "applemusic://track/714280125"
+      "uri_apple_music": "applemusic://track/714280125",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2010,
@@ -1641,7 +1788,10 @@
       "fun_fact_es": "Querbeat, fundados en 2007, traen energia de banda de metales con estilo latino - esta 'Colonia Tropical' se convirtio en favorita de las pistas de baile del carnaval.",
       "certifications": [],
       "awards": [],
-      "uri_apple_music": "applemusic://track/716646799"
+      "uri_apple_music": "applemusic://track/716646799",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2010,
@@ -1658,7 +1808,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=5QK0HLP5KY8",
-      "uri_apple_music": "applemusic://track/212431371"
+      "uri_apple_music": "applemusic://track/212431371",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2010,
@@ -1675,7 +1828,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=uc8WS_pXXtM",
-      "uri_apple_music": "applemusic://track/212430581"
+      "uri_apple_music": "applemusic://track/212430581",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2010,
@@ -1692,7 +1848,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=VKTBME4x1ZE",
-      "uri_apple_music": "applemusic://track/381978049"
+      "uri_apple_music": "applemusic://track/381978049",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2011,
@@ -1709,7 +1868,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=LSCg8MLnFyo",
-      "uri_apple_music": "applemusic://track/367840336"
+      "uri_apple_music": "applemusic://track/367840336",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2011,
@@ -1726,7 +1888,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=O1f8OztvFPw",
-      "uri_apple_music": "applemusic://track/415303398"
+      "uri_apple_music": "applemusic://track/415303398",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2011,
@@ -1763,7 +1928,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=kiM-TxZkVHA",
-      "uri_apple_music": "applemusic://track/267049501"
+      "uri_apple_music": "applemusic://track/267049501",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2011,
@@ -1779,7 +1947,10 @@
       "fun_fact_es": "La version de Hans Rudolf Knipp de esta tierna cancion sobre dar flores a la abuela - una tradicion de carnaval de honrar a los mayores.",
       "certifications": [],
       "awards": [],
-      "uri_apple_music": "applemusic://track/713912242"
+      "uri_apple_music": "applemusic://track/713912242",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2012,
@@ -1795,7 +1966,10 @@
       "fun_fact_es": "El exito revelacion de Kasalla 'Besame' los lanzo al estrellato del carnaval - su sonido rock moderno atrajo a audiencias mas jovenes a la musica de Colonia.",
       "certifications": [],
       "awards": [],
-      "uri_apple_music": "applemusic://track/493275962"
+      "uri_apple_music": "applemusic://track/493275962",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2012,
@@ -1812,7 +1986,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=duUSNwPPNsA",
-      "uri_apple_music": "applemusic://track/576565233"
+      "uri_apple_music": "applemusic://track/576565233",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2012,
@@ -1829,7 +2006,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=KjE9yBiAZqg",
-      "uri_apple_music": "applemusic://track/493275958"
+      "uri_apple_music": "applemusic://track/493275958",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2012,
@@ -1846,7 +2026,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=Tm7ONkeotnw",
-      "uri_apple_music": "applemusic://track/576565232"
+      "uri_apple_music": "applemusic://track/576565232",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2012,
@@ -1863,7 +2046,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=Tm7ONkeotnw",
-      "uri_apple_music": "applemusic://track/576565232"
+      "uri_apple_music": "applemusic://track/576565232",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2012,
@@ -1880,7 +2066,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=SPkmrk1upeo",
-      "uri_apple_music": "applemusic://track/574922257"
+      "uri_apple_music": "applemusic://track/574922257",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2012,
@@ -1897,7 +2086,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=5pTpTSCYpNo",
-      "uri_apple_music": "applemusic://track/582286248"
+      "uri_apple_music": "applemusic://track/582286248",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2012,
@@ -1914,7 +2106,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=Y51LKGeqels",
-      "uri_apple_music": "applemusic://track/582286317"
+      "uri_apple_music": "applemusic://track/582286317",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2013,
@@ -1931,7 +2126,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=d1v57x8zX6c",
-      "uri_apple_music": "applemusic://track/715920519"
+      "uri_apple_music": "applemusic://track/715920519",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2013,
@@ -1948,7 +2146,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=3Dbr3TG5Cd0",
-      "uri_apple_music": "applemusic://track/733775518"
+      "uri_apple_music": "applemusic://track/733775518",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2013,
@@ -1965,7 +2166,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=oe5MeX3RQ_k",
-      "uri_apple_music": "applemusic://track/733775456"
+      "uri_apple_music": "applemusic://track/733775456",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2013,
@@ -1981,7 +2185,10 @@
       "fun_fact_es": "'Rey' en aleman - celebra sentirse como realeza durante el carnaval, cuando cada Jeck (bufon) se convierte en rey.",
       "certifications": [],
       "awards": [],
-      "uri_apple_music": "applemusic://track/733775539"
+      "uri_apple_music": "applemusic://track/733775539",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2013,
@@ -1997,7 +2204,10 @@
       "fun_fact_es": "'Mi Ciudad' - una declaracion de amor a Colonia con el distintivo sonido folk-rock que Cat Ballou aporto a la musica colonesa.",
       "certifications": [],
       "awards": [],
-      "uri_apple_music": "applemusic://track/733775411"
+      "uri_apple_music": "applemusic://track/733775411",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2013,
@@ -2034,7 +2244,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=omaEzqzmAfE",
-      "uri_apple_music": "applemusic://track/404564581"
+      "uri_apple_music": "applemusic://track/404564581",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2016,
@@ -2051,7 +2264,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=EtcvYXAxhUI",
-      "uri_apple_music": "applemusic://track/1443269028"
+      "uri_apple_music": "applemusic://track/1443269028",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2016,
@@ -2068,7 +2284,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=isDxcmWnnmU",
-      "uri_apple_music": "applemusic://track/1443268826"
+      "uri_apple_music": "applemusic://track/1443268826",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2014,
@@ -2085,7 +2304,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=oMonuov_pDI",
-      "uri_apple_music": "applemusic://track/1057525935"
+      "uri_apple_music": "applemusic://track/1057525935",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2014,
@@ -2102,7 +2324,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=wE-5RrUzAjY",
-      "uri_apple_music": "applemusic://track/943377495"
+      "uri_apple_music": "applemusic://track/943377495",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2014,
@@ -2119,7 +2344,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=yVGXnfsrIf4",
-      "uri_apple_music": "applemusic://track/1442557282"
+      "uri_apple_music": "applemusic://track/1442557282",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2014,
@@ -2136,7 +2364,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=-ZCXIAT7Kic",
-      "uri_apple_music": "applemusic://track/1442557273"
+      "uri_apple_music": "applemusic://track/1442557273",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2014,
@@ -2173,7 +2404,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=peFcDC12YW0",
-      "uri_apple_music": "applemusic://track/730943505"
+      "uri_apple_music": "applemusic://track/730943505",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2014,
@@ -2190,7 +2424,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=Uo7-eTzJbhQ",
-      "uri_apple_music": "applemusic://track/476037186"
+      "uri_apple_music": "applemusic://track/476037186",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2014,
@@ -2207,7 +2444,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=zIC_WkcFOko",
-      "uri_apple_music": "applemusic://track/932478131"
+      "uri_apple_music": "applemusic://track/932478131",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2016,
@@ -2224,7 +2464,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=0PrKw3nhiTo",
-      "uri_apple_music": "applemusic://track/1442798678"
+      "uri_apple_music": "applemusic://track/1442798678",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2016,
@@ -2241,7 +2484,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=XZPdPEgn4OU",
-      "uri_apple_music": "applemusic://track/1442798815"
+      "uri_apple_music": "applemusic://track/1442798815",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2014,
@@ -2258,7 +2504,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=hNVjTRLbn70",
-      "uri_apple_music": "applemusic://track/933255381"
+      "uri_apple_music": "applemusic://track/933255381",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2015,
@@ -2275,7 +2524,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=aImbjskzv4s",
-      "uri_apple_music": "applemusic://track/1537957742"
+      "uri_apple_music": "applemusic://track/1537957742",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2015,
@@ -2292,7 +2544,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=LLwLcKigziA",
-      "uri_apple_music": "applemusic://track/1057525933"
+      "uri_apple_music": "applemusic://track/1057525933",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2015,
@@ -2309,7 +2564,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=BkoThPEkQyg",
-      "uri_apple_music": "applemusic://track/1038103752"
+      "uri_apple_music": "applemusic://track/1038103752",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2015,
@@ -2325,7 +2583,10 @@
       "fun_fact_es": "'Este es mi hogar' - Domhätzjer significa 'Corazones de la catedral', nombrados por la iconica catedral de Colonia.",
       "certifications": [],
       "awards": [],
-      "uri_apple_music": "applemusic://track/1041485882"
+      "uri_apple_music": "applemusic://track/1041485882",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2015,
@@ -2362,7 +2623,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=rCh54iEJVE4",
-      "uri_apple_music": "applemusic://track/961978784"
+      "uri_apple_music": "applemusic://track/961978784",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2015,
@@ -2379,7 +2643,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=MY5LbQSTQWc",
-      "uri_apple_music": "applemusic://track/1442596607"
+      "uri_apple_music": "applemusic://track/1442596607",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2015,
@@ -2396,7 +2663,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=dKxmiuv8sFc",
-      "uri_apple_music": "applemusic://track/1624673793"
+      "uri_apple_music": "applemusic://track/1624673793",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2015,
@@ -2413,7 +2683,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=wqNEtFgl67U",
-      "uri_apple_music": "applemusic://track/1443009841"
+      "uri_apple_music": "applemusic://track/1443009841",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2015,
@@ -2430,7 +2703,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=btwfBbbcn3Q",
-      "uri_apple_music": "applemusic://track/1047897637"
+      "uri_apple_music": "applemusic://track/1047897637",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2016,
@@ -2447,7 +2723,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=WMA9GHORLow",
-      "uri_apple_music": "applemusic://track/1440842640"
+      "uri_apple_music": "applemusic://track/1440842640",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2016,
@@ -2464,7 +2743,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=AzbI2RYF7D4",
-      "uri_apple_music": "applemusic://track/1444432789"
+      "uri_apple_music": "applemusic://track/1444432789",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2016,
@@ -2481,7 +2763,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=x9Fy-DlzCBU",
-      "uri_apple_music": "applemusic://track/1444579861"
+      "uri_apple_music": "applemusic://track/1444579861",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2016,
@@ -2498,7 +2783,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=iuQiwtg0Uhc",
-      "uri_apple_music": "applemusic://track/1444422655"
+      "uri_apple_music": "applemusic://track/1444422655",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2016,
@@ -2515,7 +2803,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=ZOVYt1EUhkk",
-      "uri_apple_music": "applemusic://track/1170524182"
+      "uri_apple_music": "applemusic://track/1170524182",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2016,
@@ -2532,7 +2823,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=HK2Q1-BJo1I",
-      "uri_apple_music": "applemusic://track/1208124638"
+      "uri_apple_music": "applemusic://track/1208124638",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2016,
@@ -2549,7 +2843,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=5Oylex5ILnM",
-      "uri_apple_music": "applemusic://track/1444400049"
+      "uri_apple_music": "applemusic://track/1444400049",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2016,
@@ -2566,7 +2863,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=QTHIBKb5IyI",
-      "uri_apple_music": "applemusic://track/1153683845"
+      "uri_apple_music": "applemusic://track/1153683845",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2016,
@@ -2583,7 +2883,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=x65_s8T1SGQ",
-      "uri_apple_music": "applemusic://track/1687077153"
+      "uri_apple_music": "applemusic://track/1687077153",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2016,
@@ -2600,7 +2903,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=GbOco1Ia71Y",
-      "uri_apple_music": "applemusic://track/1208124394"
+      "uri_apple_music": "applemusic://track/1208124394",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2016,
@@ -2637,7 +2943,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=kVcIvUU4dZc",
-      "uri_apple_music": "applemusic://track/1440867481"
+      "uri_apple_music": "applemusic://track/1440867481",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2016,
@@ -2654,7 +2963,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=cyeVIrbF8NY",
-      "uri_apple_music": "applemusic://track/1440867478"
+      "uri_apple_music": "applemusic://track/1440867478",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2016,
@@ -2671,7 +2983,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=7h5K36i6wJk",
-      "uri_apple_music": "applemusic://track/715536749"
+      "uri_apple_music": "applemusic://track/715536749",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2016,
@@ -2688,7 +3003,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=yErDY9dncy0",
-      "uri_apple_music": "applemusic://track/1440867643"
+      "uri_apple_music": "applemusic://track/1440867643",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2016,
@@ -2705,7 +3023,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=Zl16gviiSvk",
-      "uri_apple_music": "applemusic://track/1440867650"
+      "uri_apple_music": "applemusic://track/1440867650",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2016,
@@ -2722,7 +3043,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=vUcgJWQuJno",
-      "uri_apple_music": "applemusic://track/1440867487"
+      "uri_apple_music": "applemusic://track/1440867487",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2016,
@@ -2739,7 +3063,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=TiVvu0UP4Bc",
-      "uri_apple_music": "applemusic://track/1168030729"
+      "uri_apple_music": "applemusic://track/1168030729",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2017,
@@ -2756,7 +3083,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=jl9Sv6QCCG8",
-      "uri_apple_music": "applemusic://track/1440908384"
+      "uri_apple_music": "applemusic://track/1440908384",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2017,
@@ -2772,7 +3102,10 @@
       "fun_fact_es": "'Antes de irnos' - los hermanos Brings, Peter y Stephan, han liderado la banda desde 1991 con sus armonias distintivas.",
       "certifications": [],
       "awards": [],
-      "uri_apple_music": "applemusic://track/1440908387"
+      "uri_apple_music": "applemusic://track/1440908387",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2017,
@@ -2789,7 +3122,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=oA7CJZMmvUs",
-      "uri_apple_music": "applemusic://track/1444311016"
+      "uri_apple_music": "applemusic://track/1444311016",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2017,
@@ -2806,7 +3142,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=A8Yxc3RcExg",
-      "uri_apple_music": "applemusic://track/1440908288"
+      "uri_apple_music": "applemusic://track/1440908288",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2017,
@@ -2823,7 +3162,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=RUYWjiBjudU",
-      "uri_apple_music": "applemusic://track/1440908280"
+      "uri_apple_music": "applemusic://track/1440908280",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2017,
@@ -2840,7 +3182,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=NVUSqDEJF3I",
-      "uri_apple_music": "applemusic://track/1675680753"
+      "uri_apple_music": "applemusic://track/1675680753",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2017,
@@ -2857,7 +3202,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=55hxot5ZGFA",
-      "uri_apple_music": "applemusic://track/1300050466"
+      "uri_apple_music": "applemusic://track/1300050466",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2017,
@@ -2874,7 +3222,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=PvsLt0dcmuE",
-      "uri_apple_music": "applemusic://track/1444422129"
+      "uri_apple_music": "applemusic://track/1444422129",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2017,
@@ -2891,7 +3242,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=SCQL1KLglqE",
-      "uri_apple_music": "applemusic://track/1271752709"
+      "uri_apple_music": "applemusic://track/1271752709",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2017,
@@ -2908,7 +3262,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=X8zW0yFqhjM",
-      "uri_apple_music": "applemusic://track/1057538708"
+      "uri_apple_music": "applemusic://track/1057538708",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2017,
@@ -2925,7 +3282,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=VNSBu4x--LM",
-      "uri_apple_music": "applemusic://track/1295745147"
+      "uri_apple_music": "applemusic://track/1295745147",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2017,
@@ -2942,7 +3302,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=m2ANVUwi1SQ",
-      "uri_apple_music": "applemusic://track/1444435782"
+      "uri_apple_music": "applemusic://track/1444435782",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2017,
@@ -2959,7 +3322,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=E_HwRX-x9hI",
-      "uri_apple_music": "applemusic://track/1302832653"
+      "uri_apple_music": "applemusic://track/1302832653",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2017,
@@ -2976,7 +3342,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=ZerGcrXE7IY",
-      "uri_apple_music": "applemusic://track/1624678021"
+      "uri_apple_music": "applemusic://track/1624678021",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2017,
@@ -2993,7 +3362,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=I51mcz1xoas",
-      "uri_apple_music": "applemusic://track/1443009140"
+      "uri_apple_music": "applemusic://track/1443009140",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2017,
@@ -3010,7 +3382,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=AOjcKFapP1U",
-      "uri_apple_music": "applemusic://track/1444428549"
+      "uri_apple_music": "applemusic://track/1444428549",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2017,
@@ -3027,7 +3402,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=MPh94UbBl7s",
-      "uri_apple_music": "applemusic://track/1300729624"
+      "uri_apple_music": "applemusic://track/1300729624",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2018,
@@ -3044,7 +3422,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=aTtuKuLdsUE",
-      "uri_apple_music": "applemusic://track/1439294755"
+      "uri_apple_music": "applemusic://track/1439294755",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2018,
@@ -3061,7 +3442,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=jT0QlrHqXR0",
-      "uri_apple_music": "applemusic://track/1711803415"
+      "uri_apple_music": "applemusic://track/1711803415",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2018,
@@ -3077,7 +3461,10 @@
       "fun_fact_es": "'Ama tu ciudad' - se convirtio en un himno del orgullo de Colonia, tocado en eventos oficiales mas alla del carnaval.",
       "certifications": [],
       "awards": [],
-      "uri_apple_music": "applemusic://track/1671011632"
+      "uri_apple_music": "applemusic://track/1671011632",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2018,
@@ -3094,7 +3481,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=u5gIWrAFvlg",
-      "uri_apple_music": "applemusic://track/1680037462"
+      "uri_apple_music": "applemusic://track/1680037462",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2018,
@@ -3111,7 +3501,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=FFDwPe_I-6w",
-      "uri_apple_music": "applemusic://track/1440504347"
+      "uri_apple_music": "applemusic://track/1440504347",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2018,
@@ -3128,7 +3521,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=4BslINdHaDI",
-      "uri_apple_music": "applemusic://track/1439321317"
+      "uri_apple_music": "applemusic://track/1439321317",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2018,
@@ -3145,7 +3541,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=ERKCPMCdg_8",
-      "uri_apple_music": "applemusic://track/1439321318"
+      "uri_apple_music": "applemusic://track/1439321318",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2018,
@@ -3162,7 +3561,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=3xA0s5Bayg8",
-      "uri_apple_music": "applemusic://track/1438743230"
+      "uri_apple_music": "applemusic://track/1438743230",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2018,
@@ -3179,7 +3581,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=cS-lecxUKQU",
-      "uri_apple_music": "applemusic://track/1208124412"
+      "uri_apple_music": "applemusic://track/1208124412",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2018,
@@ -3196,7 +3601,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=evJQWvX9UZc",
-      "uri_apple_music": "applemusic://track/1440053155"
+      "uri_apple_music": "applemusic://track/1440053155",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2018,
@@ -3213,7 +3621,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=7cYkiMlrc_Y",
-      "uri_apple_music": "applemusic://track/1439294468"
+      "uri_apple_music": "applemusic://track/1439294468",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2018,
@@ -3230,7 +3641,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=iyC-xz2Ma5Q",
-      "uri_apple_music": "applemusic://track/1439345346"
+      "uri_apple_music": "applemusic://track/1439345346",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2018,
@@ -3247,7 +3661,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=vx35gdylnOo",
-      "uri_apple_music": "applemusic://track/1675646472"
+      "uri_apple_music": "applemusic://track/1675646472",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2018,
@@ -3264,7 +3681,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=KhVkAx8A9aQ",
-      "uri_apple_music": "applemusic://track/1436480900"
+      "uri_apple_music": "applemusic://track/1436480900",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2018,
@@ -3281,7 +3701,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=2Nf8lkTa86c",
-      "uri_apple_music": "applemusic://track/1436480907"
+      "uri_apple_music": "applemusic://track/1436480907",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2018,
@@ -3298,7 +3721,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=IhPF9UwPH1I",
-      "uri_apple_music": "applemusic://track/1436480902"
+      "uri_apple_music": "applemusic://track/1436480902",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2018,
@@ -3315,7 +3741,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=v2RMSUN37VU",
-      "uri_apple_music": "applemusic://track/1675790289"
+      "uri_apple_music": "applemusic://track/1675790289",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2019,
@@ -3332,7 +3761,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=wsgzuzuhWRI",
-      "uri_apple_music": "applemusic://track/1486024753"
+      "uri_apple_music": "applemusic://track/1486024753",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2019,
@@ -3349,7 +3781,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=hSFFTatArBo",
-      "uri_apple_music": "applemusic://track/1485719433"
+      "uri_apple_music": "applemusic://track/1485719433",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2019,
@@ -3366,7 +3801,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=D5bRuLzJcTM",
-      "uri_apple_music": "applemusic://track/1484068354"
+      "uri_apple_music": "applemusic://track/1484068354",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2019,
@@ -3383,7 +3821,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=XqDIE8pC_qU",
-      "uri_apple_music": "applemusic://track/1450379825"
+      "uri_apple_music": "applemusic://track/1450379825",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2019,
@@ -3400,7 +3841,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=RlhP25b-WTE",
-      "uri_apple_music": "applemusic://track/1477610690"
+      "uri_apple_music": "applemusic://track/1477610690",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2019,
@@ -3417,7 +3861,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=kpo046ly7x0",
-      "uri_apple_music": "applemusic://track/1482342716"
+      "uri_apple_music": "applemusic://track/1482342716",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2019,
@@ -3434,7 +3881,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=nV5-3FRmdeU",
-      "uri_apple_music": "applemusic://track/1483623333"
+      "uri_apple_music": "applemusic://track/1483623333",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2019,
@@ -3451,7 +3901,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=hBoNkJDkjlM",
-      "uri_apple_music": "applemusic://track/1440717939"
+      "uri_apple_music": "applemusic://track/1440717939",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2019,
@@ -3468,7 +3921,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=fcEp8U-XqUk",
-      "uri_apple_music": "applemusic://track/1483817040"
+      "uri_apple_music": "applemusic://track/1483817040",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2019,
@@ -3484,7 +3940,10 @@
       "fun_fact_es": "'Doblar' en colonés - Kempes Feinest mantienen fresca la musica de carnaval con sus influencias de musica urbana.",
       "certifications": [],
       "awards": [],
-      "uri_apple_music": "applemusic://track/1483720729"
+      "uri_apple_music": "applemusic://track/1483720729",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2019,
@@ -3501,7 +3960,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=JMQ-NqYV_x0",
-      "uri_apple_music": "applemusic://track/1483721485"
+      "uri_apple_music": "applemusic://track/1483721485",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2019,
@@ -3518,7 +3980,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=QyXUHZmDXJ0",
-      "uri_apple_music": "applemusic://track/1692236097"
+      "uri_apple_music": "applemusic://track/1692236097",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2019,
@@ -3535,7 +4000,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=wcnPMwM4_PE",
-      "uri_apple_music": "applemusic://track/1483150511"
+      "uri_apple_music": "applemusic://track/1483150511",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2019,
@@ -3552,7 +4020,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=dg_qgZdoNII",
-      "uri_apple_music": "applemusic://track/1483150525"
+      "uri_apple_music": "applemusic://track/1483150525",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2019,
@@ -3569,7 +4040,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=qp0UjkXX4XM",
-      "uri_apple_music": "applemusic://track/1483150521"
+      "uri_apple_music": "applemusic://track/1483150521",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2019,
@@ -3586,7 +4060,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=TJ4JRPT2VTM",
-      "uri_apple_music": "applemusic://track/1483720714"
+      "uri_apple_music": "applemusic://track/1483720714",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2019,
@@ -3603,7 +4080,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=7Q3tpgfAW9Q",
-      "uri_apple_music": "applemusic://track/1483720952"
+      "uri_apple_music": "applemusic://track/1483720952",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2020,
@@ -3620,7 +4100,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=JpZ7Zy_TU5w",
-      "uri_apple_music": "applemusic://track/1495322539"
+      "uri_apple_music": "applemusic://track/1495322539",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2020,
@@ -3637,7 +4120,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=TrlwodOfrQw",
-      "uri_apple_music": "applemusic://track/1536540220"
+      "uri_apple_music": "applemusic://track/1536540220",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2020,
@@ -3654,7 +4140,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=VnZ0UzvPaqk",
-      "uri_apple_music": "applemusic://track/1494693373"
+      "uri_apple_music": "applemusic://track/1494693373",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2020,
@@ -3671,7 +4160,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=TzlYm1HCBPA",
-      "uri_apple_music": "applemusic://track/1536552375"
+      "uri_apple_music": "applemusic://track/1536552375",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2020,
@@ -3688,7 +4180,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=gFlnQdWcYl0",
-      "uri_apple_music": "applemusic://track/1521986198"
+      "uri_apple_music": "applemusic://track/1521986198",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2020,
@@ -3705,7 +4200,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=3CHmYmC1980",
-      "uri_apple_music": "applemusic://track/1536059328"
+      "uri_apple_music": "applemusic://track/1536059328",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2020,
@@ -3722,7 +4220,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=7ZUAgNNF5Lc",
-      "uri_apple_music": "applemusic://track/1535667500"
+      "uri_apple_music": "applemusic://track/1535667500",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2021,
@@ -3739,7 +4240,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=lcT5SL-CMFc",
-      "uri_apple_music": "applemusic://track/1672174370"
+      "uri_apple_music": "applemusic://track/1672174370",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2021,
@@ -3756,7 +4260,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=7Y5qqZHsXFc",
-      "uri_apple_music": "applemusic://track/1672211454"
+      "uri_apple_music": "applemusic://track/1672211454",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2021,
@@ -3773,7 +4280,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=fUeGAsmsMK0",
-      "uri_apple_music": "applemusic://track/1589213156"
+      "uri_apple_music": "applemusic://track/1589213156",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2021,
@@ -3789,7 +4299,10 @@
       "fun_fact_es": "Höhner, fundada en 1972, es la banda de Kölsch más exitosa de la historia, con más de 50 años de éxitos y 20+ millones de discos vendidos.",
       "certifications": [],
       "awards": [],
-      "uri_apple_music": "applemusic://track/1589800572"
+      "uri_apple_music": "applemusic://track/1589800572",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2021,
@@ -3806,7 +4319,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=TdGvTJukUXE",
-      "uri_apple_music": "applemusic://track/1621280041"
+      "uri_apple_music": "applemusic://track/1621280041",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2021,
@@ -3823,7 +4339,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=Y9PHFDvoFSo",
-      "uri_apple_music": "applemusic://track/1591622104"
+      "uri_apple_music": "applemusic://track/1591622104",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2021,
@@ -3840,7 +4359,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=hJZEqzMfspY",
-      "uri_apple_music": "applemusic://track/1443794901"
+      "uri_apple_music": "applemusic://track/1443794901",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2021,
@@ -3857,7 +4379,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=Ap1M6967G_Y",
-      "uri_apple_music": "applemusic://track/1588234641"
+      "uri_apple_music": "applemusic://track/1588234641",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2021,
@@ -3874,7 +4399,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=i4Uv5qkZpaw",
-      "uri_apple_music": "applemusic://track/1589064651"
+      "uri_apple_music": "applemusic://track/1589064651",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2021,
@@ -3891,7 +4419,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=Z05-fxL0u38",
-      "uri_apple_music": "applemusic://track/1590445856"
+      "uri_apple_music": "applemusic://track/1590445856",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2021,
@@ -3908,7 +4439,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=Icl1t1Y7iTA",
-      "uri_apple_music": "applemusic://track/1672459081"
+      "uri_apple_music": "applemusic://track/1672459081",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2022,
@@ -3925,7 +4459,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=8bY_QPn9VG4",
-      "uri_apple_music": "applemusic://track/1651369752"
+      "uri_apple_music": "applemusic://track/1651369752",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2022,
@@ -3942,7 +4479,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=IoAejXy-7ec",
-      "uri_apple_music": "applemusic://track/1648168097"
+      "uri_apple_music": "applemusic://track/1648168097",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2022,
@@ -3959,7 +4499,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=UDRP_CS_OW0",
-      "uri_apple_music": "applemusic://track/713899804"
+      "uri_apple_music": "applemusic://track/713899804",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2022,
@@ -3976,7 +4519,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=1PVf4PvSaTQ",
-      "uri_apple_music": "applemusic://track/1655841923"
+      "uri_apple_music": "applemusic://track/1655841923",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2022,
@@ -3993,7 +4539,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=1djlP_7pk3w",
-      "uri_apple_music": "applemusic://track/1647675473"
+      "uri_apple_music": "applemusic://track/1647675473",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2022,
@@ -4010,7 +4559,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=gWAZx6dB8xU",
-      "uri_apple_music": "applemusic://track/1762467487"
+      "uri_apple_music": "applemusic://track/1762467487",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2022,
@@ -4027,7 +4579,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=pnet7nqkFa8",
-      "uri_apple_music": "applemusic://track/1688730094"
+      "uri_apple_music": "applemusic://track/1688730094",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2022,
@@ -4044,7 +4599,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=eiKLz0e3wmQ",
-      "uri_apple_music": "applemusic://track/1650299245"
+      "uri_apple_music": "applemusic://track/1650299245",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2022,
@@ -4061,7 +4619,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=qf-sDlLKLn8",
-      "uri_apple_music": "applemusic://track/1444588058"
+      "uri_apple_music": "applemusic://track/1444588058",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2022,
@@ -4078,7 +4639,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=JwUqH_IANEI",
-      "uri_apple_music": "applemusic://track/1641877160"
+      "uri_apple_music": "applemusic://track/1641877160",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2022,
@@ -4095,7 +4659,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=eBfFnunXhtg",
-      "uri_apple_music": "applemusic://track/1623537457"
+      "uri_apple_music": "applemusic://track/1623537457",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2022,
@@ -4112,7 +4679,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=mkayZqZZNdI",
-      "uri_apple_music": "applemusic://track/1647826395"
+      "uri_apple_music": "applemusic://track/1647826395",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2022,
@@ -4129,7 +4699,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=Xl16N0VZEPQ",
-      "uri_apple_music": "applemusic://track/1647826818"
+      "uri_apple_music": "applemusic://track/1647826818",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2022,
@@ -4146,7 +4719,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=GEeE5LlRwxo",
-      "uri_apple_music": "applemusic://track/1648649225"
+      "uri_apple_music": "applemusic://track/1648649225",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2022,
@@ -4163,7 +4739,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=bkjFSJ6EH28",
-      "uri_apple_music": "applemusic://track/1648653003"
+      "uri_apple_music": "applemusic://track/1648653003",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2022,
@@ -4180,7 +4759,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=UeLFIXopEq4",
-      "uri_apple_music": "applemusic://track/1671017694"
+      "uri_apple_music": "applemusic://track/1671017694",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2023,
@@ -4197,7 +4779,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=lrsVZXfQ0c8",
-      "uri_apple_music": "applemusic://track/1710764730"
+      "uri_apple_music": "applemusic://track/1710764730",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2023,
@@ -4214,7 +4799,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=th7p8Zj2Mdw",
-      "uri_apple_music": "applemusic://track/1710775886"
+      "uri_apple_music": "applemusic://track/1710775886",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2023,
@@ -4231,7 +4819,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=uST2NA131Yc",
-      "uri_apple_music": "applemusic://track/1710507999"
+      "uri_apple_music": "applemusic://track/1710507999",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2023,
@@ -4248,7 +4839,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=TH91rHntO9o",
-      "uri_apple_music": "applemusic://track/1671000882"
+      "uri_apple_music": "applemusic://track/1671000882",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2023,
@@ -4265,7 +4859,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=qDsk3hwY9dI",
-      "uri_apple_music": "applemusic://track/1703777824"
+      "uri_apple_music": "applemusic://track/1703777824",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2023,
@@ -4281,7 +4878,10 @@
       "fun_fact_es": "Canciones favoritas - esta meta-canción de carnaval sobre amar la música de carnaval resonó con los devotos fans del carnaval de Colonia.",
       "certifications": [],
       "awards": [],
-      "uri_apple_music": "applemusic://track/1711613886"
+      "uri_apple_music": "applemusic://track/1711613886",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2023,
@@ -4298,7 +4898,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=kQj8qJTErfk",
-      "uri_apple_music": "applemusic://track/1717408443"
+      "uri_apple_music": "applemusic://track/1717408443",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2023,
@@ -4315,7 +4918,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=MFRu9qEA3V4",
-      "uri_apple_music": "applemusic://track/1710791111"
+      "uri_apple_music": "applemusic://track/1710791111",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2023,
@@ -4332,7 +4938,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=0jPHBDwS_LM",
-      "uri_apple_music": "applemusic://track/1709627193"
+      "uri_apple_music": "applemusic://track/1709627193",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2023,
@@ -4349,7 +4958,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=Mp6wndgWO-g",
-      "uri_apple_music": "applemusic://track/1444430156"
+      "uri_apple_music": "applemusic://track/1444430156",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2023,
@@ -4366,7 +4978,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=IVE_4uL4vLs",
-      "uri_apple_music": "applemusic://track/1721351813"
+      "uri_apple_music": "applemusic://track/1721351813",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2023,
@@ -4383,7 +4998,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=yVnR40R-G3I",
-      "uri_apple_music": "applemusic://track/1711786088"
+      "uri_apple_music": "applemusic://track/1711786088",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2023,
@@ -4400,7 +5018,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=aNURD4ZuagU",
-      "uri_apple_music": "applemusic://track/1714609131"
+      "uri_apple_music": "applemusic://track/1714609131",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2023,
@@ -4417,7 +5038,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=MaFlZODnSa8",
-      "uri_apple_music": "applemusic://track/1712059728"
+      "uri_apple_music": "applemusic://track/1712059728",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2024,
@@ -4434,7 +5058,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=c83LZFKJyic",
-      "uri_apple_music": "applemusic://track/723924674"
+      "uri_apple_music": "applemusic://track/723924674",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2024,
@@ -4451,7 +5078,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=UtoxXiH4grg",
-      "uri_apple_music": "applemusic://track/723541960"
+      "uri_apple_music": "applemusic://track/723541960",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2024,
@@ -4468,7 +5098,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=D0x9rbjrPZ8",
-      "uri_apple_music": "applemusic://track/1444323040"
+      "uri_apple_music": "applemusic://track/1444323040",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2024,
@@ -4485,7 +5118,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=N1ProkC4vP8",
-      "uri_apple_music": "applemusic://track/1440908274"
+      "uri_apple_music": "applemusic://track/1440908274",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2024,
@@ -4502,7 +5138,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=R-Yswpa9zX4",
-      "uri_apple_music": "applemusic://track/1771051305"
+      "uri_apple_music": "applemusic://track/1771051305",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2024,
@@ -4519,7 +5158,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=1FT3k42yDrs",
-      "uri_apple_music": "applemusic://track/1672404816"
+      "uri_apple_music": "applemusic://track/1672404816",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2024,
@@ -4536,7 +5178,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=6qzf0PTykVA",
-      "uri_apple_music": "applemusic://track/1771763679"
+      "uri_apple_music": "applemusic://track/1771763679",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2024,
@@ -4553,7 +5198,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=ddYClLIEbdU",
-      "uri_apple_music": "applemusic://track/715806243"
+      "uri_apple_music": "applemusic://track/715806243",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2024,
@@ -4570,7 +5218,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=W2qgzRcoImw",
-      "uri_apple_music": "applemusic://track/1442649505"
+      "uri_apple_music": "applemusic://track/1442649505",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2024,
@@ -4587,7 +5238,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=T1nRviAlDJk",
-      "uri_apple_music": "applemusic://track/1021813861"
+      "uri_apple_music": "applemusic://track/1021813861",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2024,
@@ -4604,7 +5258,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=tywcBSYAJT0",
-      "uri_apple_music": "applemusic://track/1672403070"
+      "uri_apple_music": "applemusic://track/1672403070",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2024,
@@ -4621,7 +5278,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=nLtDOgt6qFg",
-      "uri_apple_music": "applemusic://track/1442517356"
+      "uri_apple_music": "applemusic://track/1442517356",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2024,
@@ -4638,7 +5298,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=bGl3IvqYMWw",
-      "uri_apple_music": "applemusic://track/1750053002"
+      "uri_apple_music": "applemusic://track/1750053002",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2024,
@@ -4655,7 +5318,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=DV7zhiGoXyE",
-      "uri_apple_music": "applemusic://track/1769179359"
+      "uri_apple_music": "applemusic://track/1769179359",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2024,
@@ -4672,7 +5338,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=RV2gOltoigE",
-      "uri_apple_music": "applemusic://track/1439261265"
+      "uri_apple_music": "applemusic://track/1439261265",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2024,
@@ -4689,7 +5358,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=C6b4Mf9s0L4",
-      "uri_apple_music": "applemusic://track/1536060763"
+      "uri_apple_music": "applemusic://track/1536060763",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2024,
@@ -4706,7 +5378,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=IBVuI15xBrA",
-      "uri_apple_music": "applemusic://track/1709271449"
+      "uri_apple_music": "applemusic://track/1709271449",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2024,
@@ -4723,7 +5398,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=6z9JbHqdmrQ",
-      "uri_apple_music": "applemusic://track/1764120136"
+      "uri_apple_music": "applemusic://track/1764120136",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2024,
@@ -4740,7 +5418,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=ucNcK-dfamU",
-      "uri_apple_music": "applemusic://track/713402068"
+      "uri_apple_music": "applemusic://track/713402068",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2024,
@@ -4757,7 +5438,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=stuS5CrNRPs",
-      "uri_apple_music": "applemusic://track/1764121310"
+      "uri_apple_music": "applemusic://track/1764121310",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2024,
@@ -4774,7 +5458,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=sH4DW7tyNLs",
-      "uri_apple_music": "applemusic://track/715626637"
+      "uri_apple_music": "applemusic://track/715626637",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2024,
@@ -4791,7 +5478,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=EWdDEsiKVFE",
-      "uri_apple_music": "applemusic://track/1641818941"
+      "uri_apple_music": "applemusic://track/1641818941",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2024,
@@ -4808,7 +5498,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=PqcZs2vCNv4",
-      "uri_apple_music": "applemusic://track/1774211111"
+      "uri_apple_music": "applemusic://track/1774211111",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2024,
@@ -4825,7 +5518,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=lYnBCvKwMlg",
-      "uri_apple_music": "applemusic://track/1442294197"
+      "uri_apple_music": "applemusic://track/1442294197",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2024,
@@ -4842,7 +5538,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=PIpJYyoDhQs",
-      "uri_apple_music": "applemusic://track/1444582590"
+      "uri_apple_music": "applemusic://track/1444582590",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2024,
@@ -4859,7 +5558,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=zlPosgRPYG0",
-      "uri_apple_music": "applemusic://track/1444592417"
+      "uri_apple_music": "applemusic://track/1444592417",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2024,
@@ -4876,7 +5578,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=8eQjK00wEeE",
-      "uri_apple_music": "applemusic://track/1444407851"
+      "uri_apple_music": "applemusic://track/1444407851",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2024,
@@ -4893,7 +5598,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=lmQSuFrvZaE",
-      "uri_apple_music": "applemusic://track/1483150281"
+      "uri_apple_music": "applemusic://track/1483150281",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2024,
@@ -4910,7 +5618,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=E-_z6gylJYE",
-      "uri_apple_music": "applemusic://track/1444417209"
+      "uri_apple_music": "applemusic://track/1444417209",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2024,
@@ -4927,7 +5638,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=7_jzAULq55w",
-      "uri_apple_music": "applemusic://track/1564379980"
+      "uri_apple_music": "applemusic://track/1564379980",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2024,
@@ -4944,7 +5658,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=ZuDlUykV31A",
-      "uri_apple_music": "applemusic://track/1439418104"
+      "uri_apple_music": "applemusic://track/1439418104",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2024,
@@ -4961,7 +5678,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=8CdmlAouKsM",
-      "uri_apple_music": "applemusic://track/1442798808"
+      "uri_apple_music": "applemusic://track/1442798808",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2024,
@@ -4978,7 +5698,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=RqUSekzrsMw",
-      "uri_apple_music": "applemusic://track/1536059320"
+      "uri_apple_music": "applemusic://track/1536059320",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2024,
@@ -4995,7 +5718,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=WW-HDijZR_Y",
-      "uri_apple_music": "applemusic://track/1473155299"
+      "uri_apple_music": "applemusic://track/1473155299",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2024,
@@ -5012,7 +5738,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=fHVkP251lFY",
-      "uri_apple_music": "applemusic://track/1710650644"
+      "uri_apple_music": "applemusic://track/1710650644",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2025,
@@ -5029,7 +5758,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=ZoPWUk6gdrQ",
-      "uri_apple_music": "applemusic://track/1846449458"
+      "uri_apple_music": "applemusic://track/1846449458",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2025,
@@ -5046,7 +5778,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=37RaTP0c3BA",
-      "uri_apple_music": "applemusic://track/1851222882"
+      "uri_apple_music": "applemusic://track/1851222882",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2025,
@@ -5063,7 +5798,10 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=Cx9RAamwjhY",
-      "uri_apple_music": "applemusic://track/1862452337"
+      "uri_apple_music": "applemusic://track/1862452337",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2025,
@@ -5079,7 +5817,10 @@
       "fun_fact_es": "Cohete - el éxito de 2025 de Mätropolis continúa la tradición de la banda de canciones de fiesta de alta energía diseñadas para las pistas del carnaval.",
       "certifications": [],
       "awards": [],
-      "uri_apple_music": "applemusic://track/1774224347"
+      "uri_apple_music": "applemusic://track/1774224347",
+      "chart_info": {
+        "weeks_on_chart": null
+      }
     }
   ]
 }


### PR DESCRIPTION
Removes de_peak from chart_info across all playlists. Only 13 tracks had it (0.8% global fill rate) — not worth maintaining.