### PR TITLE
fix: normalize Karneval chart_info + streaming URIs

### DIFF
--- a/custom_components/beatify/playlists/koelner-karneval.json
+++ b/custom_components/beatify/playlists/koelner-karneval.json
@@ -370,7 +370,8 @@
       "chart_info": {
         "german_peak": 63
       },
-      "uri_apple_music": "applemusic://track/724060568"
+      "uri_apple_music": "applemusic://track/724060568",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=cr9iyTX1Zqs"
     },
     {
       "year": 1991,
@@ -653,7 +654,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=T92lWKs4Nqc",
-      "uri_apple_music": "applemusic://track/269371824"
+      "uri_apple_music": "applemusic://track/269371824",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 1997,
@@ -670,7 +675,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=RLEFFpe0ZDA",
-      "uri_apple_music": "applemusic://track/1698598485"
+      "uri_apple_music": "applemusic://track/1698598485",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2001,
@@ -687,7 +696,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=dJu2jWlEZdI",
-      "uri_apple_music": "applemusic://track/713738390"
+      "uri_apple_music": "applemusic://track/713738390",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2001,
@@ -723,7 +736,11 @@
       "fun_fact_es": "Una declaracion segura de 'No necesitamos a nadie' - celebrando el espiritu independiente de Colonia y sus fuertes lazos comunitarios.",
       "certifications": [],
       "awards": [],
-      "uri_apple_music": "applemusic://track/713738498"
+      "uri_apple_music": "applemusic://track/713738498",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2001,
@@ -780,7 +797,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=C4VjjkP0uQs",
-      "uri_apple_music": "applemusic://track/803871018"
+      "uri_apple_music": "applemusic://track/803871018",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2001,
@@ -797,7 +818,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=gdKaI3TAMzI",
-      "uri_apple_music": "applemusic://track/314114513"
+      "uri_apple_music": "applemusic://track/314114513",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2001,
@@ -814,7 +839,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=Gfq6ukpkt8M",
-      "uri_apple_music": "applemusic://track/563994853"
+      "uri_apple_music": "applemusic://track/563994853",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2001,
@@ -831,7 +860,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=udm0_QwqCgU",
-      "uri_apple_music": "applemusic://track/713291213"
+      "uri_apple_music": "applemusic://track/713291213",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2001,
@@ -848,7 +881,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=EF0GBaV1huM",
-      "uri_apple_music": "applemusic://track/212430353"
+      "uri_apple_music": "applemusic://track/212430353",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2001,
@@ -885,7 +922,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=61PSHtAuPuQ",
-      "uri_apple_music": "applemusic://track/1444322979"
+      "uri_apple_music": "applemusic://track/1444322979",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2002,
@@ -902,7 +943,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=m4BDCxKjst8",
-      "uri_apple_music": "applemusic://track/1444398785"
+      "uri_apple_music": "applemusic://track/1444398785",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2002,
@@ -919,7 +964,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=J0tRDqDVKOk",
-      "uri_apple_music": "applemusic://track/201993850"
+      "uri_apple_music": "applemusic://track/201993850",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2002,
@@ -936,7 +985,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=SAnfv6mhb_Y",
-      "uri_apple_music": "applemusic://track/399740626"
+      "uri_apple_music": "applemusic://track/399740626",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2003,
@@ -953,7 +1006,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=Xf9BEUuoOx0",
-      "uri_apple_music": "applemusic://track/206698193"
+      "uri_apple_music": "applemusic://track/206698193",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2003,
@@ -970,7 +1027,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=tS7Id7YQ1eE",
-      "uri_apple_music": "applemusic://track/713451419"
+      "uri_apple_music": "applemusic://track/713451419",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2003,
@@ -987,7 +1048,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=4r_oPE0Pcno",
-      "uri_apple_music": "applemusic://track/1694607686"
+      "uri_apple_music": "applemusic://track/1694607686",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2003,
@@ -1004,7 +1069,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=DcRlFgCbwMg",
-      "uri_apple_music": "applemusic://track/713451424"
+      "uri_apple_music": "applemusic://track/713451424",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2003,
@@ -1021,7 +1090,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=Xf9BEUuoOx0",
-      "uri_apple_music": "applemusic://track/206698193"
+      "uri_apple_music": "applemusic://track/206698193",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2003,
@@ -1038,7 +1111,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=DD9oG1kIC2I",
-      "uri_apple_music": "applemusic://track/713618540"
+      "uri_apple_music": "applemusic://track/713618540",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2005,
@@ -1055,7 +1132,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=7Sn1FrYclgs",
-      "uri_apple_music": "applemusic://track/267049981"
+      "uri_apple_music": "applemusic://track/267049981",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2005,
@@ -1072,7 +1153,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=umxahJPH2Fo",
-      "uri_apple_music": "applemusic://track/1436887142"
+      "uri_apple_music": "applemusic://track/1436887142",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2006,
@@ -1109,7 +1194,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=LXgf_bSDqr8",
-      "uri_apple_music": "applemusic://track/212444702"
+      "uri_apple_music": "applemusic://track/212444702",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2007,
@@ -1146,7 +1235,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=DXCSG6AMpQM",
-      "uri_apple_music": "applemusic://track/724227285"
+      "uri_apple_music": "applemusic://track/724227285",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2007,
@@ -1163,7 +1256,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=vYw0ip3WFPE",
-      "uri_apple_music": "applemusic://track/716166286"
+      "uri_apple_music": "applemusic://track/716166286",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2007,
@@ -1179,7 +1276,11 @@
       "fun_fact_es": "Höhner celebran que 'Hay gente de Colonia en todo el mundo' - la diaspora de Colonia mantiene vivas las tradiciones del carnaval globalmente.",
       "certifications": [],
       "awards": [],
-      "uri_apple_music": "applemusic://track/716006317"
+      "uri_apple_music": "applemusic://track/716006317",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2007,
@@ -1196,7 +1297,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=8ub3EU98xtA",
-      "uri_apple_music": "applemusic://track/713290533"
+      "uri_apple_music": "applemusic://track/713290533",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2007,
@@ -1213,7 +1318,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=goj-UN9il0c",
-      "uri_apple_music": "applemusic://track/724227271"
+      "uri_apple_music": "applemusic://track/724227271",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2007,
@@ -1230,7 +1339,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=pMB4xoIB3OI",
-      "uri_apple_music": "applemusic://track/1384483878"
+      "uri_apple_music": "applemusic://track/1384483878",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2012,
@@ -1267,7 +1380,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=CPEN_B7NGK8",
-      "uri_apple_music": "applemusic://track/267632592"
+      "uri_apple_music": "applemusic://track/267632592",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2008,
@@ -1284,7 +1401,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=zQo9emlsEhs",
-      "uri_apple_music": "applemusic://track/297068238"
+      "uri_apple_music": "applemusic://track/297068238",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2008,
@@ -1301,7 +1422,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=LKG1ATlnPtY",
-      "uri_apple_music": "applemusic://track/297068259"
+      "uri_apple_music": "applemusic://track/297068259",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2008,
@@ -1318,7 +1443,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=aDX7JMoBpeY",
-      "uri_apple_music": "applemusic://track/267050939"
+      "uri_apple_music": "applemusic://track/267050939",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2008,
@@ -1335,7 +1464,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=1WDb2SqP26s",
-      "uri_apple_music": "applemusic://track/399740101"
+      "uri_apple_music": "applemusic://track/399740101",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2008,
@@ -1352,7 +1485,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=Dd4LhwUmWU0",
-      "uri_apple_music": "applemusic://track/295827689"
+      "uri_apple_music": "applemusic://track/295827689",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2008,
@@ -1369,7 +1506,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=Fvg0ngtGT5Y",
-      "uri_apple_music": "applemusic://track/295170789"
+      "uri_apple_music": "applemusic://track/295170789",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2009,
@@ -1385,7 +1526,11 @@
       "fun_fact_es": "El exito de carnaval del comediante Bernd Stelter 'Locura' - muchos comediantes alemanes tienen carreras exitosas de musica de carnaval en Colonia.",
       "certifications": [],
       "awards": [],
-      "uri_apple_music": "applemusic://track/713096250"
+      "uri_apple_music": "applemusic://track/713096250",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2009,
@@ -1402,7 +1547,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=VauNz9bUByY",
-      "uri_apple_music": "applemusic://track/346780406"
+      "uri_apple_music": "applemusic://track/346780406",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2009,
@@ -1419,7 +1568,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=yo04EDrz6qA",
-      "uri_apple_music": "applemusic://track/713096244"
+      "uri_apple_music": "applemusic://track/713096244",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2009,
@@ -1436,7 +1589,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=LJ4XsW6BM8k",
-      "uri_apple_music": "applemusic://track/716548563"
+      "uri_apple_music": "applemusic://track/716548563",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2009,
@@ -1453,7 +1610,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=MtcS_gD4dF8",
-      "uri_apple_music": "applemusic://track/716445423"
+      "uri_apple_music": "applemusic://track/716445423",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2009,
@@ -1470,7 +1631,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=bhrueepAirw",
-      "uri_apple_music": "applemusic://track/337534443"
+      "uri_apple_music": "applemusic://track/337534443",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2009,
@@ -1487,7 +1652,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=baD5Y9HwF84",
-      "uri_apple_music": "applemusic://track/1672403084"
+      "uri_apple_music": "applemusic://track/1672403084",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2009,
@@ -1504,7 +1673,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=hEKF4hGEnk8",
-      "uri_apple_music": "applemusic://track/712743495"
+      "uri_apple_music": "applemusic://track/712743495",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2009,
@@ -1521,7 +1694,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=txjlCkXCx_4",
-      "uri_apple_music": "applemusic://track/1672403076"
+      "uri_apple_music": "applemusic://track/1672403076",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2010,
@@ -1538,7 +1715,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=lIy7g4yzraA",
-      "uri_apple_music": "applemusic://track/206940874"
+      "uri_apple_music": "applemusic://track/206940874",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2010,
@@ -1555,7 +1736,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=KHDFdY6y5mQ",
-      "uri_apple_music": "applemusic://track/367841973"
+      "uri_apple_music": "applemusic://track/367841973",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2010,
@@ -1572,7 +1757,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=NLdyPVAWgOs",
-      "uri_apple_music": "applemusic://track/721259503"
+      "uri_apple_music": "applemusic://track/721259503",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2010,
@@ -1588,7 +1777,11 @@
       "fun_fact_es": "Die Rheinländer cantan 'Al Mundo' - las bandas de carnaval a menudo hacen giras internacionales, difundiendo la cultura de Colonia mas alla del Rin.",
       "certifications": [],
       "awards": [],
-      "uri_apple_music": "applemusic://track/716548518"
+      "uri_apple_music": "applemusic://track/716548518",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2010,
@@ -1605,7 +1798,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=19PU4QxzU2U",
-      "uri_apple_music": "applemusic://track/714280125"
+      "uri_apple_music": "applemusic://track/714280125",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2010,
@@ -1641,7 +1838,11 @@
       "fun_fact_es": "Querbeat, fundados en 2007, traen energia de banda de metales con estilo latino - esta 'Colonia Tropical' se convirtio en favorita de las pistas de baile del carnaval.",
       "certifications": [],
       "awards": [],
-      "uri_apple_music": "applemusic://track/716646799"
+      "uri_apple_music": "applemusic://track/716646799",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2010,
@@ -1658,7 +1859,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=5QK0HLP5KY8",
-      "uri_apple_music": "applemusic://track/212431371"
+      "uri_apple_music": "applemusic://track/212431371",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2010,
@@ -1675,7 +1880,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=uc8WS_pXXtM",
-      "uri_apple_music": "applemusic://track/212430581"
+      "uri_apple_music": "applemusic://track/212430581",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2010,
@@ -1692,7 +1901,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=VKTBME4x1ZE",
-      "uri_apple_music": "applemusic://track/381978049"
+      "uri_apple_music": "applemusic://track/381978049",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2011,
@@ -1709,7 +1922,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=LSCg8MLnFyo",
-      "uri_apple_music": "applemusic://track/367840336"
+      "uri_apple_music": "applemusic://track/367840336",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2011,
@@ -1726,7 +1943,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=O1f8OztvFPw",
-      "uri_apple_music": "applemusic://track/415303398"
+      "uri_apple_music": "applemusic://track/415303398",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2011,
@@ -1763,7 +1984,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=kiM-TxZkVHA",
-      "uri_apple_music": "applemusic://track/267049501"
+      "uri_apple_music": "applemusic://track/267049501",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2011,
@@ -1779,7 +2004,11 @@
       "fun_fact_es": "La version de Hans Rudolf Knipp de esta tierna cancion sobre dar flores a la abuela - una tradicion de carnaval de honrar a los mayores.",
       "certifications": [],
       "awards": [],
-      "uri_apple_music": "applemusic://track/713912242"
+      "uri_apple_music": "applemusic://track/713912242",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2012,
@@ -1795,7 +2024,11 @@
       "fun_fact_es": "El exito revelacion de Kasalla 'Besame' los lanzo al estrellato del carnaval - su sonido rock moderno atrajo a audiencias mas jovenes a la musica de Colonia.",
       "certifications": [],
       "awards": [],
-      "uri_apple_music": "applemusic://track/493275962"
+      "uri_apple_music": "applemusic://track/493275962",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2012,
@@ -1812,7 +2045,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=duUSNwPPNsA",
-      "uri_apple_music": "applemusic://track/576565233"
+      "uri_apple_music": "applemusic://track/576565233",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2012,
@@ -1829,7 +2066,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=KjE9yBiAZqg",
-      "uri_apple_music": "applemusic://track/493275958"
+      "uri_apple_music": "applemusic://track/493275958",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2012,
@@ -1846,7 +2087,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=Tm7ONkeotnw",
-      "uri_apple_music": "applemusic://track/576565232"
+      "uri_apple_music": "applemusic://track/576565232",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2012,
@@ -1863,7 +2108,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=Tm7ONkeotnw",
-      "uri_apple_music": "applemusic://track/576565232"
+      "uri_apple_music": "applemusic://track/576565232",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2012,
@@ -1880,7 +2129,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=SPkmrk1upeo",
-      "uri_apple_music": "applemusic://track/574922257"
+      "uri_apple_music": "applemusic://track/574922257",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2012,
@@ -1897,7 +2150,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=5pTpTSCYpNo",
-      "uri_apple_music": "applemusic://track/582286248"
+      "uri_apple_music": "applemusic://track/582286248",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2012,
@@ -1914,7 +2171,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=Y51LKGeqels",
-      "uri_apple_music": "applemusic://track/582286317"
+      "uri_apple_music": "applemusic://track/582286317",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2013,
@@ -1931,7 +2192,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=d1v57x8zX6c",
-      "uri_apple_music": "applemusic://track/715920519"
+      "uri_apple_music": "applemusic://track/715920519",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2013,
@@ -1948,7 +2213,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=3Dbr3TG5Cd0",
-      "uri_apple_music": "applemusic://track/733775518"
+      "uri_apple_music": "applemusic://track/733775518",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2013,
@@ -1965,7 +2234,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=oe5MeX3RQ_k",
-      "uri_apple_music": "applemusic://track/733775456"
+      "uri_apple_music": "applemusic://track/733775456",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2013,
@@ -1981,7 +2254,11 @@
       "fun_fact_es": "'Rey' en aleman - celebra sentirse como realeza durante el carnaval, cuando cada Jeck (bufon) se convierte en rey.",
       "certifications": [],
       "awards": [],
-      "uri_apple_music": "applemusic://track/733775539"
+      "uri_apple_music": "applemusic://track/733775539",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2013,
@@ -1997,7 +2274,11 @@
       "fun_fact_es": "'Mi Ciudad' - una declaracion de amor a Colonia con el distintivo sonido folk-rock que Cat Ballou aporto a la musica colonesa.",
       "certifications": [],
       "awards": [],
-      "uri_apple_music": "applemusic://track/733775411"
+      "uri_apple_music": "applemusic://track/733775411",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2013,
@@ -2034,7 +2315,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=omaEzqzmAfE",
-      "uri_apple_music": "applemusic://track/404564581"
+      "uri_apple_music": "applemusic://track/404564581",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2016,
@@ -2051,7 +2336,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=EtcvYXAxhUI",
-      "uri_apple_music": "applemusic://track/1443269028"
+      "uri_apple_music": "applemusic://track/1443269028",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2016,
@@ -2068,7 +2357,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=isDxcmWnnmU",
-      "uri_apple_music": "applemusic://track/1443268826"
+      "uri_apple_music": "applemusic://track/1443268826",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2014,
@@ -2085,7 +2378,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=oMonuov_pDI",
-      "uri_apple_music": "applemusic://track/1057525935"
+      "uri_apple_music": "applemusic://track/1057525935",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2014,
@@ -2102,7 +2399,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=wE-5RrUzAjY",
-      "uri_apple_music": "applemusic://track/943377495"
+      "uri_apple_music": "applemusic://track/943377495",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2014,
@@ -2119,7 +2420,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=yVGXnfsrIf4",
-      "uri_apple_music": "applemusic://track/1442557282"
+      "uri_apple_music": "applemusic://track/1442557282",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2014,
@@ -2136,7 +2441,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=-ZCXIAT7Kic",
-      "uri_apple_music": "applemusic://track/1442557273"
+      "uri_apple_music": "applemusic://track/1442557273",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2014,
@@ -2173,7 +2482,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=peFcDC12YW0",
-      "uri_apple_music": "applemusic://track/730943505"
+      "uri_apple_music": "applemusic://track/730943505",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2014,
@@ -2190,7 +2503,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=Uo7-eTzJbhQ",
-      "uri_apple_music": "applemusic://track/476037186"
+      "uri_apple_music": "applemusic://track/476037186",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2014,
@@ -2207,7 +2524,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=zIC_WkcFOko",
-      "uri_apple_music": "applemusic://track/932478131"
+      "uri_apple_music": "applemusic://track/932478131",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2016,
@@ -2224,7 +2545,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=0PrKw3nhiTo",
-      "uri_apple_music": "applemusic://track/1442798678"
+      "uri_apple_music": "applemusic://track/1442798678",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2016,
@@ -2241,7 +2566,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=XZPdPEgn4OU",
-      "uri_apple_music": "applemusic://track/1442798815"
+      "uri_apple_music": "applemusic://track/1442798815",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2014,
@@ -2258,7 +2587,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=hNVjTRLbn70",
-      "uri_apple_music": "applemusic://track/933255381"
+      "uri_apple_music": "applemusic://track/933255381",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2015,
@@ -2275,7 +2608,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=aImbjskzv4s",
-      "uri_apple_music": "applemusic://track/1537957742"
+      "uri_apple_music": "applemusic://track/1537957742",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2015,
@@ -2292,7 +2629,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=LLwLcKigziA",
-      "uri_apple_music": "applemusic://track/1057525933"
+      "uri_apple_music": "applemusic://track/1057525933",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2015,
@@ -2309,7 +2650,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=BkoThPEkQyg",
-      "uri_apple_music": "applemusic://track/1038103752"
+      "uri_apple_music": "applemusic://track/1038103752",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2015,
@@ -2325,7 +2670,12 @@
       "fun_fact_es": "'Este es mi hogar' - Domhätzjer significa 'Corazones de la catedral', nombrados por la iconica catedral de Colonia.",
       "certifications": [],
       "awards": [],
-      "uri_apple_music": "applemusic://track/1041485882"
+      "uri_apple_music": "applemusic://track/1041485882",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      },
+      "uri_youtube_music": "https://music.youtube.com/watch?v=bzXejmkCFU4"
     },
     {
       "year": 2015,
@@ -2362,7 +2712,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=rCh54iEJVE4",
-      "uri_apple_music": "applemusic://track/961978784"
+      "uri_apple_music": "applemusic://track/961978784",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2015,
@@ -2379,7 +2733,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=MY5LbQSTQWc",
-      "uri_apple_music": "applemusic://track/1442596607"
+      "uri_apple_music": "applemusic://track/1442596607",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2015,
@@ -2396,7 +2754,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=dKxmiuv8sFc",
-      "uri_apple_music": "applemusic://track/1624673793"
+      "uri_apple_music": "applemusic://track/1624673793",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2015,
@@ -2413,7 +2775,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=wqNEtFgl67U",
-      "uri_apple_music": "applemusic://track/1443009841"
+      "uri_apple_music": "applemusic://track/1443009841",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2015,
@@ -2430,7 +2796,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=btwfBbbcn3Q",
-      "uri_apple_music": "applemusic://track/1047897637"
+      "uri_apple_music": "applemusic://track/1047897637",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2016,
@@ -2447,7 +2817,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=WMA9GHORLow",
-      "uri_apple_music": "applemusic://track/1440842640"
+      "uri_apple_music": "applemusic://track/1440842640",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2016,
@@ -2464,7 +2838,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=AzbI2RYF7D4",
-      "uri_apple_music": "applemusic://track/1444432789"
+      "uri_apple_music": "applemusic://track/1444432789",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2016,
@@ -2481,7 +2859,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=x9Fy-DlzCBU",
-      "uri_apple_music": "applemusic://track/1444579861"
+      "uri_apple_music": "applemusic://track/1444579861",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2016,
@@ -2498,7 +2880,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=iuQiwtg0Uhc",
-      "uri_apple_music": "applemusic://track/1444422655"
+      "uri_apple_music": "applemusic://track/1444422655",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2016,
@@ -2515,7 +2901,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=ZOVYt1EUhkk",
-      "uri_apple_music": "applemusic://track/1170524182"
+      "uri_apple_music": "applemusic://track/1170524182",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2016,
@@ -2532,7 +2922,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=HK2Q1-BJo1I",
-      "uri_apple_music": "applemusic://track/1208124638"
+      "uri_apple_music": "applemusic://track/1208124638",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2016,
@@ -2549,7 +2943,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=5Oylex5ILnM",
-      "uri_apple_music": "applemusic://track/1444400049"
+      "uri_apple_music": "applemusic://track/1444400049",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2016,
@@ -2566,7 +2964,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=QTHIBKb5IyI",
-      "uri_apple_music": "applemusic://track/1153683845"
+      "uri_apple_music": "applemusic://track/1153683845",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2016,
@@ -2583,7 +2985,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=x65_s8T1SGQ",
-      "uri_apple_music": "applemusic://track/1687077153"
+      "uri_apple_music": "applemusic://track/1687077153",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2016,
@@ -2600,7 +3006,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=GbOco1Ia71Y",
-      "uri_apple_music": "applemusic://track/1208124394"
+      "uri_apple_music": "applemusic://track/1208124394",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2016,
@@ -2637,7 +3047,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=kVcIvUU4dZc",
-      "uri_apple_music": "applemusic://track/1440867481"
+      "uri_apple_music": "applemusic://track/1440867481",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2016,
@@ -2654,7 +3068,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=cyeVIrbF8NY",
-      "uri_apple_music": "applemusic://track/1440867478"
+      "uri_apple_music": "applemusic://track/1440867478",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2016,
@@ -2671,7 +3089,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=7h5K36i6wJk",
-      "uri_apple_music": "applemusic://track/715536749"
+      "uri_apple_music": "applemusic://track/715536749",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2016,
@@ -2688,7 +3110,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=yErDY9dncy0",
-      "uri_apple_music": "applemusic://track/1440867643"
+      "uri_apple_music": "applemusic://track/1440867643",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2016,
@@ -2705,7 +3131,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=Zl16gviiSvk",
-      "uri_apple_music": "applemusic://track/1440867650"
+      "uri_apple_music": "applemusic://track/1440867650",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2016,
@@ -2722,7 +3152,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=vUcgJWQuJno",
-      "uri_apple_music": "applemusic://track/1440867487"
+      "uri_apple_music": "applemusic://track/1440867487",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2016,
@@ -2739,7 +3173,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=TiVvu0UP4Bc",
-      "uri_apple_music": "applemusic://track/1168030729"
+      "uri_apple_music": "applemusic://track/1168030729",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2017,
@@ -2756,7 +3194,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=jl9Sv6QCCG8",
-      "uri_apple_music": "applemusic://track/1440908384"
+      "uri_apple_music": "applemusic://track/1440908384",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2017,
@@ -2772,7 +3214,12 @@
       "fun_fact_es": "'Antes de irnos' - los hermanos Brings, Peter y Stephan, han liderado la banda desde 1991 con sus armonias distintivas.",
       "certifications": [],
       "awards": [],
-      "uri_apple_music": "applemusic://track/1440908387"
+      "uri_apple_music": "applemusic://track/1440908387",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      },
+      "uri_youtube_music": "https://music.youtube.com/watch?v=d8Bpp1TfFTo"
     },
     {
       "year": 2017,
@@ -2789,7 +3236,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=oA7CJZMmvUs",
-      "uri_apple_music": "applemusic://track/1444311016"
+      "uri_apple_music": "applemusic://track/1444311016",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2017,
@@ -2806,7 +3257,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=A8Yxc3RcExg",
-      "uri_apple_music": "applemusic://track/1440908288"
+      "uri_apple_music": "applemusic://track/1440908288",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2017,
@@ -2823,7 +3278,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=RUYWjiBjudU",
-      "uri_apple_music": "applemusic://track/1440908280"
+      "uri_apple_music": "applemusic://track/1440908280",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2017,
@@ -2840,7 +3299,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=NVUSqDEJF3I",
-      "uri_apple_music": "applemusic://track/1675680753"
+      "uri_apple_music": "applemusic://track/1675680753",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2017,
@@ -2857,7 +3320,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=55hxot5ZGFA",
-      "uri_apple_music": "applemusic://track/1300050466"
+      "uri_apple_music": "applemusic://track/1300050466",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2017,
@@ -2874,7 +3341,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=PvsLt0dcmuE",
-      "uri_apple_music": "applemusic://track/1444422129"
+      "uri_apple_music": "applemusic://track/1444422129",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2017,
@@ -2891,7 +3362,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=SCQL1KLglqE",
-      "uri_apple_music": "applemusic://track/1271752709"
+      "uri_apple_music": "applemusic://track/1271752709",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2017,
@@ -2908,7 +3383,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=X8zW0yFqhjM",
-      "uri_apple_music": "applemusic://track/1057538708"
+      "uri_apple_music": "applemusic://track/1057538708",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2017,
@@ -2925,7 +3404,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=VNSBu4x--LM",
-      "uri_apple_music": "applemusic://track/1295745147"
+      "uri_apple_music": "applemusic://track/1295745147",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2017,
@@ -2942,7 +3425,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=m2ANVUwi1SQ",
-      "uri_apple_music": "applemusic://track/1444435782"
+      "uri_apple_music": "applemusic://track/1444435782",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2017,
@@ -2959,7 +3446,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=E_HwRX-x9hI",
-      "uri_apple_music": "applemusic://track/1302832653"
+      "uri_apple_music": "applemusic://track/1302832653",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2017,
@@ -2976,7 +3467,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=ZerGcrXE7IY",
-      "uri_apple_music": "applemusic://track/1624678021"
+      "uri_apple_music": "applemusic://track/1624678021",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2017,
@@ -2993,7 +3488,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=I51mcz1xoas",
-      "uri_apple_music": "applemusic://track/1443009140"
+      "uri_apple_music": "applemusic://track/1443009140",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2017,
@@ -3010,7 +3509,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=AOjcKFapP1U",
-      "uri_apple_music": "applemusic://track/1444428549"
+      "uri_apple_music": "applemusic://track/1444428549",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2017,
@@ -3027,7 +3530,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=MPh94UbBl7s",
-      "uri_apple_music": "applemusic://track/1300729624"
+      "uri_apple_music": "applemusic://track/1300729624",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2018,
@@ -3044,7 +3551,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=aTtuKuLdsUE",
-      "uri_apple_music": "applemusic://track/1439294755"
+      "uri_apple_music": "applemusic://track/1439294755",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2018,
@@ -3061,7 +3572,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=jT0QlrHqXR0",
-      "uri_apple_music": "applemusic://track/1711803415"
+      "uri_apple_music": "applemusic://track/1711803415",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2018,
@@ -3077,7 +3592,11 @@
       "fun_fact_es": "'Ama tu ciudad' - se convirtio en un himno del orgullo de Colonia, tocado en eventos oficiales mas alla del carnaval.",
       "certifications": [],
       "awards": [],
-      "uri_apple_music": "applemusic://track/1671011632"
+      "uri_apple_music": "applemusic://track/1671011632",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2018,
@@ -3094,7 +3613,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=u5gIWrAFvlg",
-      "uri_apple_music": "applemusic://track/1680037462"
+      "uri_apple_music": "applemusic://track/1680037462",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2018,
@@ -3111,7 +3634,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=FFDwPe_I-6w",
-      "uri_apple_music": "applemusic://track/1440504347"
+      "uri_apple_music": "applemusic://track/1440504347",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2018,
@@ -3128,7 +3655,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=4BslINdHaDI",
-      "uri_apple_music": "applemusic://track/1439321317"
+      "uri_apple_music": "applemusic://track/1439321317",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2018,
@@ -3145,7 +3676,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=ERKCPMCdg_8",
-      "uri_apple_music": "applemusic://track/1439321318"
+      "uri_apple_music": "applemusic://track/1439321318",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2018,
@@ -3162,7 +3697,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=3xA0s5Bayg8",
-      "uri_apple_music": "applemusic://track/1438743230"
+      "uri_apple_music": "applemusic://track/1438743230",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2018,
@@ -3179,7 +3718,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=cS-lecxUKQU",
-      "uri_apple_music": "applemusic://track/1208124412"
+      "uri_apple_music": "applemusic://track/1208124412",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2018,
@@ -3196,7 +3739,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=evJQWvX9UZc",
-      "uri_apple_music": "applemusic://track/1440053155"
+      "uri_apple_music": "applemusic://track/1440053155",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2018,
@@ -3213,7 +3760,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=7cYkiMlrc_Y",
-      "uri_apple_music": "applemusic://track/1439294468"
+      "uri_apple_music": "applemusic://track/1439294468",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2018,
@@ -3230,7 +3781,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=iyC-xz2Ma5Q",
-      "uri_apple_music": "applemusic://track/1439345346"
+      "uri_apple_music": "applemusic://track/1439345346",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2018,
@@ -3247,7 +3802,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=vx35gdylnOo",
-      "uri_apple_music": "applemusic://track/1675646472"
+      "uri_apple_music": "applemusic://track/1675646472",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2018,
@@ -3264,7 +3823,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=KhVkAx8A9aQ",
-      "uri_apple_music": "applemusic://track/1436480900"
+      "uri_apple_music": "applemusic://track/1436480900",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2018,
@@ -3281,7 +3844,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=2Nf8lkTa86c",
-      "uri_apple_music": "applemusic://track/1436480907"
+      "uri_apple_music": "applemusic://track/1436480907",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2018,
@@ -3298,7 +3865,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=IhPF9UwPH1I",
-      "uri_apple_music": "applemusic://track/1436480902"
+      "uri_apple_music": "applemusic://track/1436480902",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2018,
@@ -3315,7 +3886,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=v2RMSUN37VU",
-      "uri_apple_music": "applemusic://track/1675790289"
+      "uri_apple_music": "applemusic://track/1675790289",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2019,
@@ -3332,7 +3907,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=wsgzuzuhWRI",
-      "uri_apple_music": "applemusic://track/1486024753"
+      "uri_apple_music": "applemusic://track/1486024753",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2019,
@@ -3349,7 +3928,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=hSFFTatArBo",
-      "uri_apple_music": "applemusic://track/1485719433"
+      "uri_apple_music": "applemusic://track/1485719433",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2019,
@@ -3366,7 +3949,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=D5bRuLzJcTM",
-      "uri_apple_music": "applemusic://track/1484068354"
+      "uri_apple_music": "applemusic://track/1484068354",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2019,
@@ -3383,7 +3970,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=XqDIE8pC_qU",
-      "uri_apple_music": "applemusic://track/1450379825"
+      "uri_apple_music": "applemusic://track/1450379825",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2019,
@@ -3400,7 +3991,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=RlhP25b-WTE",
-      "uri_apple_music": "applemusic://track/1477610690"
+      "uri_apple_music": "applemusic://track/1477610690",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2019,
@@ -3417,7 +4012,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=kpo046ly7x0",
-      "uri_apple_music": "applemusic://track/1482342716"
+      "uri_apple_music": "applemusic://track/1482342716",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2019,
@@ -3434,7 +4033,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=nV5-3FRmdeU",
-      "uri_apple_music": "applemusic://track/1483623333"
+      "uri_apple_music": "applemusic://track/1483623333",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2019,
@@ -3451,7 +4054,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=hBoNkJDkjlM",
-      "uri_apple_music": "applemusic://track/1440717939"
+      "uri_apple_music": "applemusic://track/1440717939",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2019,
@@ -3468,7 +4075,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=fcEp8U-XqUk",
-      "uri_apple_music": "applemusic://track/1483817040"
+      "uri_apple_music": "applemusic://track/1483817040",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2019,
@@ -3484,7 +4095,11 @@
       "fun_fact_es": "'Doblar' en colonés - Kempes Feinest mantienen fresca la musica de carnaval con sus influencias de musica urbana.",
       "certifications": [],
       "awards": [],
-      "uri_apple_music": "applemusic://track/1483720729"
+      "uri_apple_music": "applemusic://track/1483720729",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2019,
@@ -3501,7 +4116,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=JMQ-NqYV_x0",
-      "uri_apple_music": "applemusic://track/1483721485"
+      "uri_apple_music": "applemusic://track/1483721485",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2019,
@@ -3518,7 +4137,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=QyXUHZmDXJ0",
-      "uri_apple_music": "applemusic://track/1692236097"
+      "uri_apple_music": "applemusic://track/1692236097",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2019,
@@ -3535,7 +4158,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=wcnPMwM4_PE",
-      "uri_apple_music": "applemusic://track/1483150511"
+      "uri_apple_music": "applemusic://track/1483150511",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2019,
@@ -3552,7 +4179,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=dg_qgZdoNII",
-      "uri_apple_music": "applemusic://track/1483150525"
+      "uri_apple_music": "applemusic://track/1483150525",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2019,
@@ -3569,7 +4200,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=qp0UjkXX4XM",
-      "uri_apple_music": "applemusic://track/1483150521"
+      "uri_apple_music": "applemusic://track/1483150521",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2019,
@@ -3586,7 +4221,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=TJ4JRPT2VTM",
-      "uri_apple_music": "applemusic://track/1483720714"
+      "uri_apple_music": "applemusic://track/1483720714",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2019,
@@ -3603,7 +4242,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=7Q3tpgfAW9Q",
-      "uri_apple_music": "applemusic://track/1483720952"
+      "uri_apple_music": "applemusic://track/1483720952",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2020,
@@ -3620,7 +4263,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=JpZ7Zy_TU5w",
-      "uri_apple_music": "applemusic://track/1495322539"
+      "uri_apple_music": "applemusic://track/1495322539",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2020,
@@ -3637,7 +4284,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=TrlwodOfrQw",
-      "uri_apple_music": "applemusic://track/1536540220"
+      "uri_apple_music": "applemusic://track/1536540220",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2020,
@@ -3654,7 +4305,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=VnZ0UzvPaqk",
-      "uri_apple_music": "applemusic://track/1494693373"
+      "uri_apple_music": "applemusic://track/1494693373",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2020,
@@ -3671,7 +4326,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=TzlYm1HCBPA",
-      "uri_apple_music": "applemusic://track/1536552375"
+      "uri_apple_music": "applemusic://track/1536552375",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2020,
@@ -3688,7 +4347,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=gFlnQdWcYl0",
-      "uri_apple_music": "applemusic://track/1521986198"
+      "uri_apple_music": "applemusic://track/1521986198",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2020,
@@ -3705,7 +4368,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=3CHmYmC1980",
-      "uri_apple_music": "applemusic://track/1536059328"
+      "uri_apple_music": "applemusic://track/1536059328",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2020,
@@ -3722,7 +4389,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=7ZUAgNNF5Lc",
-      "uri_apple_music": "applemusic://track/1535667500"
+      "uri_apple_music": "applemusic://track/1535667500",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2021,
@@ -3739,7 +4410,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=lcT5SL-CMFc",
-      "uri_apple_music": "applemusic://track/1672174370"
+      "uri_apple_music": "applemusic://track/1672174370",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2021,
@@ -3756,7 +4431,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=7Y5qqZHsXFc",
-      "uri_apple_music": "applemusic://track/1672211454"
+      "uri_apple_music": "applemusic://track/1672211454",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2021,
@@ -3773,7 +4452,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=fUeGAsmsMK0",
-      "uri_apple_music": "applemusic://track/1589213156"
+      "uri_apple_music": "applemusic://track/1589213156",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2021,
@@ -3789,7 +4472,12 @@
       "fun_fact_es": "Höhner, fundada en 1972, es la banda de Kölsch más exitosa de la historia, con más de 50 años de éxitos y 20+ millones de discos vendidos.",
       "certifications": [],
       "awards": [],
-      "uri_apple_music": "applemusic://track/1589800572"
+      "uri_apple_music": "applemusic://track/1589800572",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      },
+      "uri_youtube_music": "https://music.youtube.com/watch?v=38o4nqqmUyU"
     },
     {
       "year": 2021,
@@ -3806,7 +4494,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=TdGvTJukUXE",
-      "uri_apple_music": "applemusic://track/1621280041"
+      "uri_apple_music": "applemusic://track/1621280041",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2021,
@@ -3823,7 +4515,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=Y9PHFDvoFSo",
-      "uri_apple_music": "applemusic://track/1591622104"
+      "uri_apple_music": "applemusic://track/1591622104",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2021,
@@ -3840,7 +4536,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=hJZEqzMfspY",
-      "uri_apple_music": "applemusic://track/1443794901"
+      "uri_apple_music": "applemusic://track/1443794901",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2021,
@@ -3857,7 +4557,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=Ap1M6967G_Y",
-      "uri_apple_music": "applemusic://track/1588234641"
+      "uri_apple_music": "applemusic://track/1588234641",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2021,
@@ -3874,7 +4578,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=i4Uv5qkZpaw",
-      "uri_apple_music": "applemusic://track/1589064651"
+      "uri_apple_music": "applemusic://track/1589064651",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2021,
@@ -3891,7 +4599,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=Z05-fxL0u38",
-      "uri_apple_music": "applemusic://track/1590445856"
+      "uri_apple_music": "applemusic://track/1590445856",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2021,
@@ -3908,7 +4620,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=Icl1t1Y7iTA",
-      "uri_apple_music": "applemusic://track/1672459081"
+      "uri_apple_music": "applemusic://track/1672459081",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2022,
@@ -3925,7 +4641,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=8bY_QPn9VG4",
-      "uri_apple_music": "applemusic://track/1651369752"
+      "uri_apple_music": "applemusic://track/1651369752",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2022,
@@ -3942,7 +4662,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=IoAejXy-7ec",
-      "uri_apple_music": "applemusic://track/1648168097"
+      "uri_apple_music": "applemusic://track/1648168097",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2022,
@@ -3959,7 +4683,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=UDRP_CS_OW0",
-      "uri_apple_music": "applemusic://track/713899804"
+      "uri_apple_music": "applemusic://track/713899804",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2022,
@@ -3976,7 +4704,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=1PVf4PvSaTQ",
-      "uri_apple_music": "applemusic://track/1655841923"
+      "uri_apple_music": "applemusic://track/1655841923",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2022,
@@ -3993,7 +4725,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=1djlP_7pk3w",
-      "uri_apple_music": "applemusic://track/1647675473"
+      "uri_apple_music": "applemusic://track/1647675473",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2022,
@@ -4010,7 +4746,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=gWAZx6dB8xU",
-      "uri_apple_music": "applemusic://track/1762467487"
+      "uri_apple_music": "applemusic://track/1762467487",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2022,
@@ -4027,7 +4767,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=pnet7nqkFa8",
-      "uri_apple_music": "applemusic://track/1688730094"
+      "uri_apple_music": "applemusic://track/1688730094",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2022,
@@ -4044,7 +4788,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=eiKLz0e3wmQ",
-      "uri_apple_music": "applemusic://track/1650299245"
+      "uri_apple_music": "applemusic://track/1650299245",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2022,
@@ -4061,7 +4809,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=qf-sDlLKLn8",
-      "uri_apple_music": "applemusic://track/1444588058"
+      "uri_apple_music": "applemusic://track/1444588058",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2022,
@@ -4078,7 +4830,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=JwUqH_IANEI",
-      "uri_apple_music": "applemusic://track/1641877160"
+      "uri_apple_music": "applemusic://track/1641877160",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2022,
@@ -4095,7 +4851,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=eBfFnunXhtg",
-      "uri_apple_music": "applemusic://track/1623537457"
+      "uri_apple_music": "applemusic://track/1623537457",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2022,
@@ -4112,7 +4872,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=mkayZqZZNdI",
-      "uri_apple_music": "applemusic://track/1647826395"
+      "uri_apple_music": "applemusic://track/1647826395",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2022,
@@ -4129,7 +4893,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=Xl16N0VZEPQ",
-      "uri_apple_music": "applemusic://track/1647826818"
+      "uri_apple_music": "applemusic://track/1647826818",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2022,
@@ -4146,7 +4914,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=GEeE5LlRwxo",
-      "uri_apple_music": "applemusic://track/1648649225"
+      "uri_apple_music": "applemusic://track/1648649225",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2022,
@@ -4163,7 +4935,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=bkjFSJ6EH28",
-      "uri_apple_music": "applemusic://track/1648653003"
+      "uri_apple_music": "applemusic://track/1648653003",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2022,
@@ -4180,7 +4956,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=UeLFIXopEq4",
-      "uri_apple_music": "applemusic://track/1671017694"
+      "uri_apple_music": "applemusic://track/1671017694",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2023,
@@ -4197,7 +4977,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=lrsVZXfQ0c8",
-      "uri_apple_music": "applemusic://track/1710764730"
+      "uri_apple_music": "applemusic://track/1710764730",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2023,
@@ -4214,7 +4998,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=th7p8Zj2Mdw",
-      "uri_apple_music": "applemusic://track/1710775886"
+      "uri_apple_music": "applemusic://track/1710775886",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2023,
@@ -4231,7 +5019,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=uST2NA131Yc",
-      "uri_apple_music": "applemusic://track/1710507999"
+      "uri_apple_music": "applemusic://track/1710507999",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2023,
@@ -4248,7 +5040,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=TH91rHntO9o",
-      "uri_apple_music": "applemusic://track/1671000882"
+      "uri_apple_music": "applemusic://track/1671000882",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2023,
@@ -4265,7 +5061,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=qDsk3hwY9dI",
-      "uri_apple_music": "applemusic://track/1703777824"
+      "uri_apple_music": "applemusic://track/1703777824",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2023,
@@ -4281,7 +5081,11 @@
       "fun_fact_es": "Canciones favoritas - esta meta-canción de carnaval sobre amar la música de carnaval resonó con los devotos fans del carnaval de Colonia.",
       "certifications": [],
       "awards": [],
-      "uri_apple_music": "applemusic://track/1711613886"
+      "uri_apple_music": "applemusic://track/1711613886",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2023,
@@ -4298,7 +5102,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=kQj8qJTErfk",
-      "uri_apple_music": "applemusic://track/1717408443"
+      "uri_apple_music": "applemusic://track/1717408443",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2023,
@@ -4315,7 +5123,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=MFRu9qEA3V4",
-      "uri_apple_music": "applemusic://track/1710791111"
+      "uri_apple_music": "applemusic://track/1710791111",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2023,
@@ -4332,7 +5144,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=0jPHBDwS_LM",
-      "uri_apple_music": "applemusic://track/1709627193"
+      "uri_apple_music": "applemusic://track/1709627193",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2023,
@@ -4349,7 +5165,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=Mp6wndgWO-g",
-      "uri_apple_music": "applemusic://track/1444430156"
+      "uri_apple_music": "applemusic://track/1444430156",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2023,
@@ -4366,7 +5186,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=IVE_4uL4vLs",
-      "uri_apple_music": "applemusic://track/1721351813"
+      "uri_apple_music": "applemusic://track/1721351813",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2023,
@@ -4383,7 +5207,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=yVnR40R-G3I",
-      "uri_apple_music": "applemusic://track/1711786088"
+      "uri_apple_music": "applemusic://track/1711786088",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2023,
@@ -4400,7 +5228,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=aNURD4ZuagU",
-      "uri_apple_music": "applemusic://track/1714609131"
+      "uri_apple_music": "applemusic://track/1714609131",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2023,
@@ -4417,7 +5249,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=MaFlZODnSa8",
-      "uri_apple_music": "applemusic://track/1712059728"
+      "uri_apple_music": "applemusic://track/1712059728",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2024,
@@ -4434,7 +5270,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=c83LZFKJyic",
-      "uri_apple_music": "applemusic://track/723924674"
+      "uri_apple_music": "applemusic://track/723924674",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2024,
@@ -4451,7 +5291,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=UtoxXiH4grg",
-      "uri_apple_music": "applemusic://track/723541960"
+      "uri_apple_music": "applemusic://track/723541960",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2024,
@@ -4468,7 +5312,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=D0x9rbjrPZ8",
-      "uri_apple_music": "applemusic://track/1444323040"
+      "uri_apple_music": "applemusic://track/1444323040",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2024,
@@ -4485,7 +5333,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=N1ProkC4vP8",
-      "uri_apple_music": "applemusic://track/1440908274"
+      "uri_apple_music": "applemusic://track/1440908274",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2024,
@@ -4502,7 +5354,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=R-Yswpa9zX4",
-      "uri_apple_music": "applemusic://track/1771051305"
+      "uri_apple_music": "applemusic://track/1771051305",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2024,
@@ -4519,7 +5375,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=1FT3k42yDrs",
-      "uri_apple_music": "applemusic://track/1672404816"
+      "uri_apple_music": "applemusic://track/1672404816",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2024,
@@ -4536,7 +5396,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=6qzf0PTykVA",
-      "uri_apple_music": "applemusic://track/1771763679"
+      "uri_apple_music": "applemusic://track/1771763679",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2024,
@@ -4553,7 +5417,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=ddYClLIEbdU",
-      "uri_apple_music": "applemusic://track/715806243"
+      "uri_apple_music": "applemusic://track/715806243",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2024,
@@ -4570,7 +5438,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=W2qgzRcoImw",
-      "uri_apple_music": "applemusic://track/1442649505"
+      "uri_apple_music": "applemusic://track/1442649505",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2024,
@@ -4587,7 +5459,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=T1nRviAlDJk",
-      "uri_apple_music": "applemusic://track/1021813861"
+      "uri_apple_music": "applemusic://track/1021813861",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2024,
@@ -4604,7 +5480,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=tywcBSYAJT0",
-      "uri_apple_music": "applemusic://track/1672403070"
+      "uri_apple_music": "applemusic://track/1672403070",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2024,
@@ -4621,7 +5501,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=nLtDOgt6qFg",
-      "uri_apple_music": "applemusic://track/1442517356"
+      "uri_apple_music": "applemusic://track/1442517356",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2024,
@@ -4638,7 +5522,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=bGl3IvqYMWw",
-      "uri_apple_music": "applemusic://track/1750053002"
+      "uri_apple_music": "applemusic://track/1750053002",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2024,
@@ -4655,7 +5543,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=DV7zhiGoXyE",
-      "uri_apple_music": "applemusic://track/1769179359"
+      "uri_apple_music": "applemusic://track/1769179359",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2024,
@@ -4672,7 +5564,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=RV2gOltoigE",
-      "uri_apple_music": "applemusic://track/1439261265"
+      "uri_apple_music": "applemusic://track/1439261265",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2024,
@@ -4689,7 +5585,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=C6b4Mf9s0L4",
-      "uri_apple_music": "applemusic://track/1536060763"
+      "uri_apple_music": "applemusic://track/1536060763",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2024,
@@ -4706,7 +5606,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=IBVuI15xBrA",
-      "uri_apple_music": "applemusic://track/1709271449"
+      "uri_apple_music": "applemusic://track/1709271449",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2024,
@@ -4723,7 +5627,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=6z9JbHqdmrQ",
-      "uri_apple_music": "applemusic://track/1764120136"
+      "uri_apple_music": "applemusic://track/1764120136",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2024,
@@ -4740,7 +5648,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=ucNcK-dfamU",
-      "uri_apple_music": "applemusic://track/713402068"
+      "uri_apple_music": "applemusic://track/713402068",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2024,
@@ -4757,7 +5669,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=stuS5CrNRPs",
-      "uri_apple_music": "applemusic://track/1764121310"
+      "uri_apple_music": "applemusic://track/1764121310",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2024,
@@ -4774,7 +5690,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=sH4DW7tyNLs",
-      "uri_apple_music": "applemusic://track/715626637"
+      "uri_apple_music": "applemusic://track/715626637",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2024,
@@ -4791,7 +5711,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=EWdDEsiKVFE",
-      "uri_apple_music": "applemusic://track/1641818941"
+      "uri_apple_music": "applemusic://track/1641818941",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2024,
@@ -4808,7 +5732,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=PqcZs2vCNv4",
-      "uri_apple_music": "applemusic://track/1774211111"
+      "uri_apple_music": "applemusic://track/1774211111",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2024,
@@ -4825,7 +5753,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=lYnBCvKwMlg",
-      "uri_apple_music": "applemusic://track/1442294197"
+      "uri_apple_music": "applemusic://track/1442294197",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2024,
@@ -4842,7 +5774,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=PIpJYyoDhQs",
-      "uri_apple_music": "applemusic://track/1444582590"
+      "uri_apple_music": "applemusic://track/1444582590",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2024,
@@ -4859,7 +5795,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=zlPosgRPYG0",
-      "uri_apple_music": "applemusic://track/1444592417"
+      "uri_apple_music": "applemusic://track/1444592417",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2024,
@@ -4876,7 +5816,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=8eQjK00wEeE",
-      "uri_apple_music": "applemusic://track/1444407851"
+      "uri_apple_music": "applemusic://track/1444407851",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2024,
@@ -4893,7 +5837,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=lmQSuFrvZaE",
-      "uri_apple_music": "applemusic://track/1483150281"
+      "uri_apple_music": "applemusic://track/1483150281",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2024,
@@ -4910,7 +5858,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=E-_z6gylJYE",
-      "uri_apple_music": "applemusic://track/1444417209"
+      "uri_apple_music": "applemusic://track/1444417209",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2024,
@@ -4927,7 +5879,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=7_jzAULq55w",
-      "uri_apple_music": "applemusic://track/1564379980"
+      "uri_apple_music": "applemusic://track/1564379980",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2024,
@@ -4944,7 +5900,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=ZuDlUykV31A",
-      "uri_apple_music": "applemusic://track/1439418104"
+      "uri_apple_music": "applemusic://track/1439418104",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2024,
@@ -4961,7 +5921,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=8CdmlAouKsM",
-      "uri_apple_music": "applemusic://track/1442798808"
+      "uri_apple_music": "applemusic://track/1442798808",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2024,
@@ -4978,7 +5942,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=RqUSekzrsMw",
-      "uri_apple_music": "applemusic://track/1536059320"
+      "uri_apple_music": "applemusic://track/1536059320",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2024,
@@ -4995,7 +5963,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=WW-HDijZR_Y",
-      "uri_apple_music": "applemusic://track/1473155299"
+      "uri_apple_music": "applemusic://track/1473155299",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2024,
@@ -5012,7 +5984,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=fHVkP251lFY",
-      "uri_apple_music": "applemusic://track/1710650644"
+      "uri_apple_music": "applemusic://track/1710650644",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2025,
@@ -5029,7 +6005,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=ZoPWUk6gdrQ",
-      "uri_apple_music": "applemusic://track/1846449458"
+      "uri_apple_music": "applemusic://track/1846449458",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2025,
@@ -5046,7 +6026,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=37RaTP0c3BA",
-      "uri_apple_music": "applemusic://track/1851222882"
+      "uri_apple_music": "applemusic://track/1851222882",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2025,
@@ -5063,7 +6047,11 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=Cx9RAamwjhY",
-      "uri_apple_music": "applemusic://track/1862452337"
+      "uri_apple_music": "applemusic://track/1862452337",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     },
     {
       "year": 2025,
@@ -5079,7 +6067,11 @@
       "fun_fact_es": "Cohete - el éxito de 2025 de Mätropolis continúa la tradición de la banda de canciones de fiesta de alta energía diseñadas para las pistas del carnaval.",
       "certifications": [],
       "awards": [],
-      "uri_apple_music": "applemusic://track/1774224347"
+      "uri_apple_music": "applemusic://track/1774224347",
+      "chart_info": {
+        "de_peak": null,
+        "weeks_on_chart": null
+      }
     }
   ]
 }


### PR DESCRIPTION
Ensures all 291 tracks have chart_info key. Adds Apple Music and YouTube Music URIs via Odesli enrichment.