### PR TITLE
fix: enrich Movies & Power Ballads streaming URIs

### DIFF
--- a/custom_components/beatify/playlists/movies-100-greatest-themes.json
+++ b/custom_components/beatify/playlists/movies-100-greatest-themes.json
@@ -2559,7 +2559,8 @@
       "awards_es": [
         "Nominación al Óscar a la mejor canción original (1967)"
       ],
-      "uri_apple_music": "applemusic://track/1442849462"
+      "uri_apple_music": "applemusic://track/1442849462",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=6BH-Rxd-NBo"
     },
     {
       "year": 1973,
@@ -2577,7 +2578,8 @@
       },
       "certifications": [],
       "awards": [],
-      "uri_apple_music": "applemusic://track/459757919"
+      "uri_apple_music": "applemusic://track/459757919",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=cSs3mr3C4pA"
     },
     {
       "year": 1942,
@@ -2592,7 +2594,8 @@
       "chart_info": {},
       "certifications": [],
       "awards": [],
-      "uri_apple_music": "applemusic://track/1455697817"
+      "uri_apple_music": "applemusic://track/1455697817",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=FruwdlwW-k8"
     },
     {
       "year": 1979,
@@ -2615,7 +2618,8 @@
       "awards_es": [
         "Nominación al Óscar a la Mejor Banda Sonora Original (1979)"
       ],
-      "uri_apple_music": "applemusic://track/1440854590"
+      "uri_apple_music": "applemusic://track/1440854590",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=yc94TrMnwaw"
     },
     {
       "year": 1971,
@@ -2661,7 +2665,8 @@
         "Óscar a la Mejor Canción Original (1981)",
         "Globo de Oro a la Mejor Canción Original (1982)"
       ],
-      "uri_apple_music": "applemusic://track/273426183"
+      "uri_apple_music": "applemusic://track/273426183",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=wJ6zs2WSCjk"
     },
     {
       "year": 2000,
@@ -2710,7 +2715,8 @@
       "awards_es": [
         "Óscar a la Mejor Banda Sonora Original (1995)"
       ],
-      "uri_apple_music": "applemusic://track/1440773543"
+      "uri_apple_music": "applemusic://track/1440773543",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=gfHjh8KLURI"
     },
     {
       "year": 1954,
@@ -2748,7 +2754,8 @@
       "chart_info": {},
       "certifications": [],
       "awards": [],
-      "uri_apple_music": "applemusic://track/1443095011"
+      "uri_apple_music": "applemusic://track/1443095011",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=1ve6wEmeQDk"
     },
     {
       "year": 1965,
@@ -2777,7 +2784,8 @@
       "awards_es": [
         "Nominación al Óscar a la Mejor Canción Original (1965)"
       ],
-      "uri_apple_music": "applemusic://track/1444091737"
+      "uri_apple_music": "applemusic://track/1444091737",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=qQvIAs-nPSo"
     },
     {
       "year": 1957,
@@ -2798,7 +2806,8 @@
         "Gold (US)",
         "Gold (UK)"
       ],
-      "awards": []
+      "awards": [],
+      "uri_youtube_music": "https://music.youtube.com/watch?v=lbnClCGpTzs"
     },
     {
       "year": 1980,
@@ -2813,7 +2822,8 @@
       "chart_info": {},
       "certifications": [],
       "awards": [],
-      "uri_apple_music": "applemusic://track/1535496635"
+      "uri_apple_music": "applemusic://track/1535496635",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=UTGdnvpGHxU"
     },
     {
       "year": 1969,
@@ -2881,7 +2891,8 @@
         "Gold (UK)"
       ],
       "awards": [],
-      "uri_apple_music": "applemusic://track/1441164536"
+      "uri_apple_music": "applemusic://track/1441164536",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=MKUex3fci5c"
     },
     {
       "year": 1985,
@@ -2902,7 +2913,8 @@
         "Gold (US)"
       ],
       "awards": [],
-      "uri_apple_music": "applemusic://track/1443234133"
+      "uri_apple_music": "applemusic://track/1443234133",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=CdqoNKCCt7A"
     },
     {
       "year": 1954,
@@ -2925,7 +2937,8 @@
       "awards_es": [
         "Óscar a la Mejor Banda Sonora Original (1954)"
       ],
-      "uri_apple_music": "applemusic://track/1816013634"
+      "uri_apple_music": "applemusic://track/1816013634",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Q7sabA_J4SA"
     },
     {
       "year": 1963,
@@ -2939,7 +2952,9 @@
       "fun_fact_es": "La banda sonora de El mundo está loco, loco, loco de Ernest Gold coincide con la comedia maníaca de la película. La épica contó con todos los grandes comediantes.",
       "chart_info": {},
       "certifications": [],
-      "awards": []
+      "awards": [],
+      "uri_apple_music": "applemusic://track/285167010",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Gz4b7Ty5JjI"
     },
     {
       "year": 1962,
@@ -2965,7 +2980,8 @@
       "awards_es": [
         "Premio Grammy a la Mejor Interpretación Instrumental (1963)"
       ],
-      "uri_apple_music": "applemusic://track/306820503"
+      "uri_apple_music": "applemusic://track/306820503",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=EbI2nl3Duf8"
     },
     {
       "year": 1991,
@@ -2979,7 +2995,9 @@
       "fun_fact_es": "La banda sonora de El silencio de los corderos de Howard Shore crea temor psicológico. La música sutil nunca abruma el suspenso.",
       "chart_info": {},
       "certifications": [],
-      "awards": []
+      "awards": [],
+      "uri_apple_music": "applemusic://track/1443219466",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=oyyIcbb7lOE"
     },
     {
       "year": 1955,
@@ -3004,7 +3022,9 @@
       ],
       "awards_es": [
         "Óscar a la Mejor Banda Sonora (1955)"
-      ]
+      ],
+      "uri_apple_music": "applemusic://track/325855734",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=VpPKHI9N3Q0"
     },
     {
       "year": 1971,
@@ -3019,7 +3039,8 @@
       "chart_info": {},
       "certifications": [],
       "awards": [],
-      "uri_apple_music": "applemusic://track/205808260"
+      "uri_apple_music": "applemusic://track/205808260",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=YU6yAluDAkY"
     },
     {
       "year": 1955,
@@ -3033,7 +3054,8 @@
       "fun_fact_es": "La banda sonora de Rebelde sin causa de Leonard Rosenman fue revolucionaria por usar la disonancia para expresar la angustia adolescente.",
       "chart_info": {},
       "certifications": [],
-      "awards": []
+      "awards": [],
+      "uri_youtube_music": "https://music.youtube.com/watch?v=4V2WxyTtfII"
     },
     {
       "year": 1977,
@@ -3059,7 +3081,8 @@
       "awards_es": [
         "Nominación al Óscar a la Mejor Banda Sonora Original (1977)"
       ],
-      "uri_apple_music": "applemusic://track/306664733"
+      "uri_apple_music": "applemusic://track/306664733",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=W9pFv20Bhck"
     },
     {
       "year": 1959,
@@ -3073,7 +3096,8 @@
       "fun_fact_es": "La banda sonora de Con faldas y a lo loco captura el jazz de los años 1920. Sugar de Marilyn Monroe actúa con una banda femenina en pantalla.",
       "chart_info": {},
       "certifications": [],
-      "awards": []
+      "awards": [],
+      "uri_youtube_music": "https://music.youtube.com/watch?v=vMZfYZCVfqE"
     },
     {
       "year": 1978,
@@ -3107,7 +3131,8 @@
       "chart_info": {},
       "certifications": [],
       "awards": [],
-      "uri_apple_music": "applemusic://track/323714096"
+      "uri_apple_music": "applemusic://track/323714096",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=CL_3mlOPnGI"
     },
     {
       "year": 1971,
@@ -3132,7 +3157,8 @@
       ],
       "awards_es": [
         "Óscar a la Mejor Banda Sonora Original (1971)"
-      ]
+      ],
+      "uri_youtube_music": "https://music.youtube.com/watch?v=hxWpSmNDIZA"
     },
     {
       "year": 1961,
@@ -3149,7 +3175,8 @@
       },
       "certifications": [],
       "awards": [],
-      "uri_apple_music": "applemusic://track/826934339"
+      "uri_apple_music": "applemusic://track/826934339",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=esNgKybTSZQ"
     },
     {
       "year": 2007,
@@ -3166,7 +3193,8 @@
       },
       "certifications": [],
       "awards": [],
-      "uri_apple_music": "applemusic://track/1442889719"
+      "uri_apple_music": "applemusic://track/1442889719",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Wu_xMNZWyak"
     },
     {
       "year": 1973,
@@ -3195,7 +3223,8 @@
       "awards_es": [
         "Nominación al Óscar a la Mejor Canción Original (1973)"
       ],
-      "uri_apple_music": "applemusic://track/1440939414"
+      "uri_apple_music": "applemusic://track/1440939414",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=NR0UmZcf89E"
     },
     {
       "year": 1968,
@@ -3210,7 +3239,8 @@
       "chart_info": {},
       "certifications": [],
       "awards": [],
-      "uri_apple_music": "applemusic://track/1452655336"
+      "uri_apple_music": "applemusic://track/1452655336",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=qE5S9pUTGno"
     },
     {
       "year": 1999,
@@ -3225,7 +3255,8 @@
       "chart_info": {},
       "certifications": [],
       "awards": [],
-      "uri_apple_music": "applemusic://track/1437293471"
+      "uri_apple_music": "applemusic://track/1437293471",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=ucdz7A3s4Wc"
     },
     {
       "year": 1959,
@@ -3252,7 +3283,8 @@
       ],
       "awards_es": [
         "Premio Grammy a la Grabación del Año (1961)"
-      ]
+      ],
+      "uri_youtube_music": "https://music.youtube.com/watch?v=3ofmPuHBCCc"
     },
     {
       "year": 1997,
@@ -3288,7 +3320,8 @@
         "Globo de Oro a la Mejor Canción Original (1998)",
         "Premio Grammy a la Grabación del Año (1999)"
       ],
-      "uri_apple_music": "applemusic://track/507536740"
+      "uri_apple_music": "applemusic://track/507536740",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=MxtrIvQKNEQ"
     },
     {
       "year": 1969,
@@ -3305,7 +3338,8 @@
       },
       "certifications": [],
       "awards": [],
-      "uri_apple_music": "applemusic://track/1584918493"
+      "uri_apple_music": "applemusic://track/1584918493",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=SgVWFdDnSXQ"
     },
     {
       "year": 1969,
@@ -3333,7 +3367,8 @@
       "awards_es": [
         "Premio Grammy a la Mejor Canción Contemporánea (1970)"
       ],
-      "uri_apple_music": "applemusic://track/714938680"
+      "uri_apple_music": "applemusic://track/714938680",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=BFKDyVPkonc"
     },
     {
       "year": 1980,
@@ -3348,7 +3383,8 @@
       "chart_info": {},
       "certifications": [],
       "awards": [],
-      "uri_apple_music": "applemusic://track/1550210611"
+      "uri_apple_music": "applemusic://track/1550210611",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=H88biGPCMqg"
     },
     {
       "year": 1963,
@@ -3406,7 +3442,9 @@
       ],
       "awards_es": [
         "Óscar a la Mejor Canción Original (1942)"
-      ]
+      ],
+      "uri_apple_music": "applemusic://track/1772921827",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=DQdiNPe5ja0"
     },
     {
       "year": 1958,

--- a/custom_components/beatify/playlists/top-100-power-ballads.json
+++ b/custom_components/beatify/playlists/top-100-power-ballads.json
@@ -1062,7 +1062,7 @@
       "fun_fact": "Written by Diane Warren. The controversial music video was filmed on the USS Missouri with Cher wearing a revealing outfit, causing some networks to ban it.",
       "fun_fact_de": "[DE] Written by Diane Warren. The controversial music video was filmed on the USS Mis...",
       "fun_fact_es": "[ES] Written by Diane Warren. The controversial music video was filmed on the USS Mis...",
-      "uri_apple_music": "",
+      "uri_apple_music": "applemusic://track/1571969050",
       "uri_youtube_music": "https://music.youtube.com/watch?v=9n3A_-HRFfc"
     },
     {
@@ -1086,7 +1086,7 @@
       "fun_fact": "Def Leppard's only #1 hit in the US. The song took 4 years to complete as part of the Hysteria album, which was plagued by drummer Rick Allen's accident.",
       "fun_fact_de": "[DE] Def Leppard's only #1 hit in the US. The song took 4 years to complete as part o...",
       "fun_fact_es": "[ES] Def Leppard's only #1 hit in the US. The song took 4 years to complete as part o...",
-      "uri_apple_music": "",
+      "uri_apple_music": "applemusic://track/1643512302",
       "uri_youtube_music": "https://music.youtube.com/watch?v=W4XiSFyYRE8"
     },
     {
@@ -1134,7 +1134,7 @@
       "fun_fact": "Graham Russell wrote this in 10 minutes. The song's distinctive keyboard riff became an 80s soft rock signature and made Air Supply international stars.",
       "fun_fact_de": "[DE] Graham Russell wrote this in 10 minutes. The song's distinctive keyboard riff be...",
       "fun_fact_es": "[ES] Graham Russell wrote this in 10 minutes. The song's distinctive keyboard riff be...",
-      "uri_apple_music": "",
+      "uri_apple_music": "applemusic://track/1445843398",
       "uri_youtube_music": "https://music.youtube.com/watch?v=JWdZEumNRmI"
     },
     {
@@ -1180,7 +1180,7 @@
       "fun_fact": "Written for An Officer and a Gentleman, it won the Oscar for Best Original Song. Joe Cocker and Jennifer Warnes had to record their parts separately due to scheduling conflicts.",
       "fun_fact_de": "[DE] Written for An Officer and a Gentleman, it won the Oscar for Best Original Song....",
       "fun_fact_es": "[ES] Written for An Officer and a Gentleman, it won the Oscar for Best Original Song....",
-      "uri_apple_music": "",
+      "uri_apple_music": "applemusic://track/1088531479",
       "uri_youtube_music": "https://music.youtube.com/watch?v=bjrOcrisGyI"
     },
     {
@@ -1204,7 +1204,7 @@
       "fun_fact": "Based on Marc Cohn's first trip to Memphis, including his visit to Graceland. He was so moved by the experience that he wrote the song in one night.",
       "fun_fact_de": "[DE] Based on Marc Cohn's first trip to Memphis, including his visit to Graceland. He...",
       "fun_fact_es": "[ES] Based on Marc Cohn's first trip to Memphis, including his visit to Graceland. He...",
-      "uri_apple_music": "",
+      "uri_apple_music": "applemusic://track/1440648051",
       "uri_youtube_music": "https://music.youtube.com/watch?v=PgRafRp-P-o"
     },
     {
@@ -1253,7 +1253,7 @@
       "fun_fact": "Written for the 1988 Seoul Olympics. Albert Hammond and John Bettis crafted it specifically for Whitney's voice, and it became an anthem for athletes worldwide.",
       "fun_fact_de": "[DE] Written for the 1988 Seoul Olympics. Albert Hammond and John Bettis crafted it s...",
       "fun_fact_es": "[ES] Written for the 1988 Seoul Olympics. Albert Hammond and John Bettis crafted it s...",
-      "uri_apple_music": "",
+      "uri_apple_music": "applemusic://track/158580601",
       "uri_youtube_music": "https://music.youtube.com/watch?v=96aAx0kxVSA"
     },
     {
@@ -1323,7 +1323,7 @@
       "fun_fact": "The comeback single after a 3-year hiatus. Written by Backstreet Boys with Dan Muckala, it addressed their time apart and emotional journey.",
       "fun_fact_de": "[DE] The comeback single after a 3-year hiatus. Written by Backstreet Boys with Dan M...",
       "fun_fact_es": "[ES] The comeback single after a 3-year hiatus. Written by Backstreet Boys with Dan M...",
-      "uri_apple_music": "",
+      "uri_apple_music": "applemusic://track/724203469",
       "uri_youtube_music": "https://music.youtube.com/watch?v=WVe80iZtlYU"
     },
     {
@@ -1348,7 +1348,7 @@
       "fun_fact": "The epic 8-minute version was recorded live in one take at First Avenue in Minneapolis. Prince wrote it about the end of the world and seeking redemption through faith.",
       "fun_fact_de": "[DE] The epic 8-minute version was recorded live in one take at First Avenue in Minne...",
       "fun_fact_es": "[ES] The epic 8-minute version was recorded live in one take at First Avenue in Minne...",
-      "uri_apple_music": "",
+      "uri_apple_music": "applemusic://track/1445835626",
       "uri_youtube_music": "https://music.youtube.com/watch?v=TvnYmWpD_T8"
     },
     {
@@ -1395,7 +1395,7 @@
       "fun_fact": "Jani Lane wrote this ballad showcasing Warrant's softer side. It became an MTV staple and proved the band could deliver emotional depth beyond party anthems.",
       "fun_fact_de": "[DE] Jani Lane wrote this ballad showcasing Warrant's softer side. It became an MTV s...",
       "fun_fact_es": "[ES] Jani Lane wrote this ballad showcasing Warrant's softer side. It became an MTV s...",
-      "uri_apple_music": "",
+      "uri_apple_music": "applemusic://track/1217902077",
       "uri_youtube_music": "https://music.youtube.com/watch?v=DAX20LoVgxE"
     },
     {
@@ -1419,7 +1419,7 @@
       "fun_fact": "Features one of MTV's first narrative music videos with dance choreography. Pat Benatar was initially hesitant about the theatrical video concept.",
       "fun_fact_de": "[DE] Features one of MTV's first narrative music videos with dance choreography. Pat ...",
       "fun_fact_es": "[ES] Features one of MTV's first narrative music videos with dance choreography. Pat ...",
-      "uri_apple_music": "",
+      "uri_apple_music": "applemusic://track/447759252",
       "uri_youtube_music": "https://music.youtube.com/watch?v=IGVZOLV9SPo"
     },
     {
@@ -1441,7 +1441,7 @@
       "fun_fact": "A classic power ballad by Bad Company.",
       "fun_fact_de": "",
       "fun_fact_es": "",
-      "uri_apple_music": "",
+      "uri_apple_music": "applemusic://track/1440784502",
       "uri_youtube_music": "https://music.youtube.com/watch?v=OEPvv9pjIoQ"
     },
     {
@@ -1463,7 +1463,7 @@
       "fun_fact": "A classic power ballad by Tina Turner.",
       "fun_fact_de": "",
       "fun_fact_es": "",
-      "uri_apple_music": "",
+      "uri_apple_music": "applemusic://track/1644730834",
       "uri_youtube_music": "https://music.youtube.com/watch?v=HLBXAs2LO8k"
     },
     {
@@ -1533,7 +1533,7 @@
       "fun_fact": "British rock band Thunder's breakthrough hit. Danny Bowes' soulful vocals and Luke Morley's songwriting showed they could compete with American arena rock bands.",
       "fun_fact_de": "[DE] British rock band Thunder's breakthrough hit. Danny Bowes' soulful vocals and Lu...",
       "fun_fact_es": "[ES] British rock band Thunder's breakthrough hit. Danny Bowes' soulful vocals and Lu...",
-      "uri_apple_music": "",
+      "uri_apple_music": "applemusic://track/723425523",
       "uri_youtube_music": "https://music.youtube.com/watch?v=-IWAOPi4VCc"
     },
     {
@@ -1632,7 +1632,7 @@
       "fun_fact": "Named after the French horror film. Billy Idol wanted to show a vulnerable side different from his punk image. The whispered French vocals add to the haunting atmosphere.",
       "fun_fact_de": "[DE] Named after the French horror film. Billy Idol wanted to show a vulnerable side ...",
       "fun_fact_es": "[ES] Named after the French horror film. Billy Idol wanted to show a vulnerable side ...",
-      "uri_apple_music": "",
+      "uri_apple_music": "applemusic://track/217490782",
       "uri_youtube_music": "https://music.youtube.com/watch?v=9OFpfTd0EIs"
     },
     {
@@ -1704,7 +1704,7 @@
       "fun_fact": "Originally performed as a duet with Fred Durst at Woodstock '99. The raw emotional performance went viral and launched Staind's mainstream career.",
       "fun_fact_de": "[DE] Originally performed as a duet with Fred Durst at Woodstock '99. The raw emotion...",
       "fun_fact_es": "[ES] Originally performed as a duet with Fred Durst at Woodstock '99. The raw emotion...",
-      "uri_apple_music": "",
+      "uri_apple_music": "applemusic://track/355893546",
       "uri_youtube_music": "https://music.youtube.com/watch?v=mVQpfoqsY8Q"
     },
     {
@@ -1729,7 +1729,7 @@
       "fun_fact": "Spent 10 weeks at #2, blocked from #1 by Olivia Newton-John's 'Physical'. Mick Jones wrote it about his idealized vision of true love.",
       "fun_fact_de": "[DE] Spent 10 weeks at #2, blocked from #1 by Olivia Newton-John's 'Physical'. Mick J...",
       "fun_fact_es": "[ES] Spent 10 weeks at #2, blocked from #1 by Olivia Newton-John's 'Physical'. Mick J...",
-      "uri_apple_music": "",
+      "uri_apple_music": "applemusic://track/321975428",
       "uri_youtube_music": "https://music.youtube.com/watch?v=2dWmKSj5HjI"
     },
     {
@@ -1851,7 +1851,7 @@
       "fun_fact": "Daniel wrote this at age 17, asking existential questions about soulmates. He recorded early demos in his bedroom, launching the bedroom producer trend.",
       "fun_fact_de": "[DE] Daniel wrote this at age 17, asking existential questions about soulmates. He re...",
       "fun_fact_es": "[ES] Daniel wrote this at age 17, asking existential questions about soulmates. He re...",
-      "uri_apple_music": "",
+      "uri_apple_music": "applemusic://track/476986080",
       "uri_youtube_music": "https://music.youtube.com/watch?v=j6nevGNYTkA"
     },
     {
@@ -1895,7 +1895,7 @@
       "fun_fact": "Written about addiction struggles, it resonated deeply with the supergroup's members - former Guns N' Roses and Stone Temple Pilots musicians.",
       "fun_fact_de": "[DE] Written about addiction struggles, it resonated deeply with the supergroup's mem...",
       "fun_fact_es": "[ES] Written about addiction struggles, it resonated deeply with the supergroup's mem...",
-      "uri_apple_music": "",
+      "uri_apple_music": "applemusic://track/303178195",
       "uri_youtube_music": "https://music.youtube.com/watch?v=9JhsUFuqbCM"
     },
     {
@@ -1944,7 +1944,7 @@
       "fun_fact": "Written for the film Against All Odds. Phil Collins wrote and recorded it in a single day after watching a rough cut of the film. It won a Grammy.",
       "fun_fact_de": "[DE] Written for the film Against All Odds. Phil Collins wrote and recorded it in a s...",
       "fun_fact_es": "[ES] Written for the film Against All Odds. Phil Collins wrote and recorded it in a s...",
-      "uri_apple_music": "",
+      "uri_apple_music": "applemusic://track/1606706137",
       "uri_youtube_music": "https://music.youtube.com/watch?v=wuvtoyVi7vY"
     },
     {
@@ -1968,7 +1968,7 @@
       "fun_fact": "Written by Steven Tyler and Desmond Child about Tyler's daughter. The tender ballad showed Aerosmith's softer side during their commercial comeback.",
       "fun_fact_de": "[DE] Written by Steven Tyler and Desmond Child about Tyler's daughter. The tender bal...",
       "fun_fact_es": "[ES] Written by Steven Tyler and Desmond Child about Tyler's daughter. The tender bal...",
-      "uri_apple_music": "",
+      "uri_apple_music": "applemusic://track/1440823557",
       "uri_youtube_music": "https://music.youtube.com/watch?v=CBTOGVb_cQg"
     },
     {
@@ -1992,7 +1992,7 @@
       "fun_fact": "Originally recorded for the Adrenalize album but held back. It became a massive hit in the UK and showed Def Leppard could still deliver emotional ballads.",
       "fun_fact_de": "[DE] Originally recorded for the Adrenalize album but held back. It became a massive ...",
       "fun_fact_es": "[ES] Originally recorded for the Adrenalize album but held back. It became a massive ...",
-      "uri_apple_music": "",
+      "uri_apple_music": "applemusic://track/1434883426",
       "uri_youtube_music": "https://music.youtube.com/watch?v=d7ew_jIxLa8"
     },
     {
@@ -2016,7 +2016,7 @@
       "fun_fact": "Jonathan Cain wrote this on a tour bus, reflecting on how touring affects relationships. Steve Perry's emotional delivery made it a wedding song classic.",
       "fun_fact_de": "[DE] Jonathan Cain wrote this on a tour bus, reflecting on how touring affects relati...",
       "fun_fact_es": "[ES] Jonathan Cain wrote this on a tour bus, reflecting on how touring affects relati...",
-      "uri_apple_music": "",
+      "uri_apple_music": "applemusic://track/1109658204",
       "uri_youtube_music": "https://music.youtube.com/watch?v=OMD8hBsA-RI"
     },
     {
@@ -2038,7 +2038,7 @@
       "fun_fact": "Corey Taylor wrote this acoustic ballad for the Spider-Man soundtrack. It showed a vulnerable side of the Slipknot/Stone Sour frontman.",
       "fun_fact_de": "[DE] Corey Taylor wrote this acoustic ballad for the Spider-Man soundtrack. It showed...",
       "fun_fact_es": "[ES] Corey Taylor wrote this acoustic ballad for the Spider-Man soundtrack. It showed...",
-      "uri_apple_music": "",
+      "uri_apple_music": "applemusic://track/355893847",
       "uri_youtube_music": "https://music.youtube.com/watch?v=Q-pXD0FXLQ8"
     },
     {
@@ -2060,7 +2060,7 @@
       "fun_fact": "The only ballad on Black Sabbath's Vol. 4 album. Tony Iommi played piano for the first time on record, creating an unexpectedly tender moment in heavy metal.",
       "fun_fact_de": "[DE] The only ballad on Black Sabbath's Vol. 4 album. Tony Iommi played piano for the...",
       "fun_fact_es": "[ES] The only ballad on Black Sabbath's Vol. 4 album. Tony Iommi played piano for the...",
-      "uri_apple_music": "",
+      "uri_apple_music": "applemusic://track/696375679",
       "uri_youtube_music": "https://music.youtube.com/watch?v=_eBCxYVma1g"
     },
     {
@@ -2109,7 +2109,7 @@
       "fun_fact": "Written about a troubled youth. Sebastian Bach's powerful vocals and the song's narrative structure made it one of the defining late-80s power ballads.",
       "fun_fact_de": "[DE] Written about a troubled youth. Sebastian Bach's powerful vocals and the song's ...",
       "fun_fact_es": "[ES] Written about a troubled youth. Sebastian Bach's powerful vocals and the song's ...",
-      "uri_apple_music": "",
+      "uri_apple_music": "applemusic://track/693227789",
       "uri_youtube_music": "https://music.youtube.com/watch?v=Ghd2bkIadG4"
     },
     {
@@ -2158,7 +2158,7 @@
       "fun_fact": "The label insisted on Paul McCoy's male vocals, though Amy Lee originally wrote it as a solo. The song's unique rock/orchestral blend launched the genre.",
       "fun_fact_de": "[DE] The label insisted on Paul McCoy's male vocals, though Amy Lee originally wrote ...",
       "fun_fact_es": "[ES] The label insisted on Paul McCoy's male vocals, though Amy Lee originally wrote ...",
-      "uri_apple_music": "",
+      "uri_apple_music": "applemusic://track/727506102",
       "uri_youtube_music": "https://music.youtube.com/watch?v=3YxaaGgTQYM"
     },
     {
@@ -2202,7 +2202,7 @@
       "fun_fact": "A classic power ballad by Guns N' Roses.",
       "fun_fact_de": "",
       "fun_fact_es": "",
-      "uri_apple_music": "",
+      "uri_apple_music": "applemusic://track/1605606761",
       "uri_youtube_music": "https://music.youtube.com/watch?v=zRIbf6JqkNc"
     },
     {
@@ -2224,7 +2224,7 @@
       "fun_fact": "Co-written with Lou Reed. This uncharacteristic ballad appeared during KISS's experimental phase and showcased Paul Stanley's vulnerable vocal delivery.",
       "fun_fact_de": "[DE] Co-written with Lou Reed. This uncharacteristic ballad appeared during KISS's ex...",
       "fun_fact_es": "[ES] Co-written with Lou Reed. This uncharacteristic ballad appeared during KISS's ex...",
-      "uri_apple_music": "",
+      "uri_apple_music": "applemusic://track/977495542",
       "uri_youtube_music": "https://music.youtube.com/watch?v=A9SLgcNEpyM"
     },
     {
@@ -2248,7 +2248,7 @@
       "fun_fact": "Massive hit in Australia and Europe. The bagpipe-driven anthem became an unofficial Australian anthem and revitalized John Farnham's career.",
       "fun_fact_de": "[DE] Massive hit in Australia and Europe. The bagpipe-driven anthem became an unoffic...",
       "fun_fact_es": "[ES] Massive hit in Australia and Europe. The bagpipe-driven anthem became an unoffic...",
-      "uri_apple_music": "",
+      "uri_apple_music": "applemusic://track/525521084",
       "uri_youtube_music": "https://music.youtube.com/watch?v=tbkOZTSvrHs"
     },
     {
@@ -2272,7 +2272,7 @@
       "fun_fact": "Written by Sheriff members who regrouped as Alias. The song continued their power ballad success following Sheriff's 'When I'm With You'.",
       "fun_fact_de": "[DE] Written by Sheriff members who regrouped as Alias. The song continued their powe...",
       "fun_fact_es": "[ES] Written by Sheriff members who regrouped as Alias. The song continued their powe...",
-      "uri_apple_music": "",
+      "uri_apple_music": "applemusic://track/723338381",
       "uri_youtube_music": "https://music.youtube.com/watch?v=pjhrGPFaQoQ"
     },
     {
@@ -2297,7 +2297,7 @@
       "fun_fact": "Originally offered to several other artists who turned it down. Enrique recorded an English and Spanish version, with the English version becoming his signature song.",
       "fun_fact_de": "[DE] Originally offered to several other artists who turned it down. Enrique recorded...",
       "fun_fact_es": "[ES] Originally offered to several other artists who turned it down. Enrique recorded...",
-      "uri_apple_music": "",
+      "uri_apple_music": "applemusic://track/697410052",
       "uri_youtube_music": "https://music.youtube.com/watch?v=koJlIGDImiU"
     },
     {
@@ -2319,7 +2319,7 @@
       "fun_fact": "A classic power ballad by Firehouse.",
       "fun_fact_de": "",
       "fun_fact_es": "",
-      "uri_apple_music": "",
+      "uri_apple_music": "applemusic://track/1452924289",
       "uri_youtube_music": "https://music.youtube.com/watch?v=5ETENrv8cnU"
     },
     {
@@ -2343,7 +2343,7 @@
       "fun_fact": "Scott Stapp wrote this after learning he would become a father. It won the Grammy for Best Rock Song and became Creed's only #1 hit.",
       "fun_fact_de": "[DE] Scott Stapp wrote this after learning he would become a father. It won the Gramm...",
       "fun_fact_es": "[ES] Scott Stapp wrote this after learning he would become a father. It won the Gramm...",
-      "uri_apple_music": "",
+      "uri_apple_music": "applemusic://track/1716253895",
       "uri_youtube_music": "https://music.youtube.com/watch?v=99j0zLuNhi8"
     },
     {
@@ -2365,7 +2365,7 @@
       "fun_fact": "From Lita Ford's hit album 'Lita'. The former Runaways guitarist showed her range with power ballads alongside her harder rock material.",
       "fun_fact_de": "[DE] From Lita Ford's hit album 'Lita'. The former Runaways guitarist showed her rang...",
       "fun_fact_es": "[ES] From Lita Ford's hit album 'Lita'. The former Runaways guitarist showed her rang...",
-      "uri_apple_music": "",
+      "uri_apple_music": "applemusic://track/1423285054",
       "uri_youtube_music": "https://music.youtube.com/watch?v=rPX-JiTvDeY"
     },
     {
@@ -2389,7 +2389,7 @@
       "fun_fact": "Written by outside songwriters, which the band initially resisted. It became Cheap Trick's only #1 hit in the US, though they rarely play it live.",
       "fun_fact_de": "[DE] Written by outside songwriters, which the band initially resisted. It became Che...",
       "fun_fact_es": "[ES] Written by outside songwriters, which the band initially resisted. It became Che...",
-      "uri_apple_music": "",
+      "uri_apple_music": "applemusic://track/1445752097",
       "uri_youtube_music": "https://music.youtube.com/watch?v=2u6uXuT9pm4"
     }
   ]


### PR DESCRIPTION
Adds Apple Music and YouTube Music URIs via Odesli enrichment for Movies (162 tracks) and Power Ballads (99 tracks).

## Movies – 100 Greatest Themes (162 tracks)
- Apple Music: 119 → 126 (+7 new, now 77%)
- YouTube Music: 100 → 140 (+40 new, now 86%)

## Power Ballads (99 tracks)  
- Apple Music: 61 → 96 (+35 new, now 96%)
- YouTube Music: 99/99 (already complete)

Total URIs added: **82** (7+40 Apple Music/YouTube for Movies, 35 Apple Music for Ballads)