### PR TITLE
fix: Invalid Spotify URIs in Pure Pop Punk and 2000s Pop Anthems (#122)

### DIFF
--- a/custom_components/beatify/playlists/2000s-pop-anthems.json
+++ b/custom_components/beatify/playlists/2000s-pop-anthems.json
@@ -2761,7 +2761,7 @@
     },
     {
       "year": 2009,
-      "uri": "spotify:track:3GpbwCm3YxiYKBSI5brbG",
+      "uri": "spotify:track:3GpbwCm3YxiWDvy29Uo3vP",
       "artist": "Flo Rida, Kesha",
       "alt_artists": [
         "Pitbull",

--- a/custom_components/beatify/playlists/pure-pop-punk.json
+++ b/custom_components/beatify/playlists/pure-pop-punk.json
@@ -2436,7 +2436,7 @@
     },
     {
       "year": 2007,
-      "uri": "",
+      "uri": "spotify:track:5johpJIVjqU2Ki03DOA7Jr",
       "artist": "The Academy Is...",
       "alt_artists": [
         "Cobra Starship",


### PR DESCRIPTION
Fixes 2 invalid Spotify URIs flagged in the admin playlist selector:

| Playlist | Song | Issue | Fix |
|---|---|---|---|
| Pure Pop Punk | #100 The Academy Is... — About a Girl | Empty URI | `spotify:track:5johpJIVjqU2Ki03DOA7Jr` |
| 2000s Pop Anthems | #101 Flo Rida/Kesha — Right Round | Truncated 21-char ID | `spotify:track:3GpbwCm3YxiWDvy29Uo3vP` |

Both URIs verified via Odesli API lookup.

Closes #122