### PR TITLE
feat(#23): Add Intro Only Mode - random 10s intro rounds

### DIFF
--- a/custom_components/beatify/const.py
+++ b/custom_components/beatify/const.py
@@ -31,6 +31,12 @@ ARTIST_BONUS_POINTS = 5
 # Index 0 = fastest correct, index 1 = 2nd fastest, etc.
 MOVIE_BONUS_TIERS: list[int] = [5, 3, 1]
 
+# Intro mode constants (Issue #23)
+INTRO_DURATION_SECONDS = 10
+INTRO_ROUND_CHANCE = 0.20  # 20% chance per round
+INTRO_BONUS_TIERS: list[int] = [5, 3, 1]  # Same as movie bonus
+MIN_INTRO_BONUSES_FOR_AWARD = 1  # Minimum to qualify for superlative
+
 # Steal power-up constants (Story 15.3)
 STEAL_UNLOCK_STREAK = 3  # Consecutive correct answers to unlock steal
 MAX_STEALS_PER_GAME = 1  # Maximum number of steals allowed per game

--- a/custom_components/beatify/game/player.py
+++ b/custom_components/beatify/game/player.py
@@ -50,6 +50,10 @@ class PlayerSession:
     has_movie_guess: bool = False
     movie_bonus_total: int = 0  # Cumulative across rounds for superlative
 
+    # Intro mode bonus tracking (Issue #23)
+    intro_bonus: int = 0  # Per-round intro speed bonus
+    intro_speed_bonuses: int = 0  # Cumulative count for superlative
+
     # Betting tracking (Story 5.3)
     bet: bool = False
     bet_outcome: str | None = None  # "won", "lost", or None
@@ -107,6 +111,8 @@ class PlayerSession:
         # Reset movie quiz fields (Issue #28)
         self.movie_bonus = 0
         self.has_movie_guess = False
+        # Reset intro mode fields (Issue #23)
+        self.intro_bonus = 0
         # Reset bet fields (Story 5.3)
         self.bet = False
         self.bet_outcome = None
@@ -147,6 +153,12 @@ class PlayerSession:
         # Reset steal tracking
         self.steal_available = False
         self.steal_used = False
+
+        # Reset intro mode cumulative tracking (Issue #23)
+        self.intro_speed_bonuses = 0
+
+        # Reset movie bonus cumulative tracking (Issue #28)
+        self.movie_bonus_total = 0
 
         # Also reset round-level state
         self.reset_round()

--- a/custom_components/beatify/server/views.py
+++ b/custom_components/beatify/server/views.py
@@ -192,6 +192,7 @@ class StartGameView(HomeAssistantView):
         provider = body.get("provider", PROVIDER_DEFAULT)  # Story 17.2
         artist_challenge_enabled = body.get("artist_challenge_enabled", True)  # Story 20.7
         movie_quiz_enabled = body.get("movie_quiz_enabled", True)  # Issue #28
+        intro_mode_enabled = body.get("intro_mode_enabled", False)  # Issue #23
 
         # Validate difficulty (Story 14.1)
         valid_difficulties = (DIFFICULTY_EASY, DIFFICULTY_NORMAL, DIFFICULTY_HARD)
@@ -362,6 +363,7 @@ class StartGameView(HomeAssistantView):
             "platform": platform,
             "artist_challenge_enabled": artist_challenge_enabled,  # Story 20.7
             "movie_quiz_enabled": movie_quiz_enabled,  # Issue #28
+            "intro_mode_enabled": intro_mode_enabled,  # Issue #23
         }
         if round_duration is not None:
             create_kwargs["round_duration"] = round_duration

--- a/custom_components/beatify/www/admin.html
+++ b/custom_components/beatify/www/admin.html
@@ -171,6 +171,18 @@
                         <span class="toggle-switch-compact"></span>
                     </label>
                 </div>
+
+                <!-- Intro Mode - Inline toggle (Issue #23) -->
+                <div class="setting-row">
+                    <span class="setting-label">
+                        <span class="setting-icon" aria-hidden="true">⚡</span>
+                        <span data-i18n="admin.introMode">Intro Mode</span>
+                    </span>
+                    <label class="toggle-compact">
+                        <input type="checkbox" id="intro-mode-toggle">
+                        <span class="toggle-switch-compact"></span>
+                    </label>
+                </div>
             </div>
         </section>
 

--- a/custom_components/beatify/www/css/dashboard.css
+++ b/custom_components/beatify/www/css/dashboard.css
@@ -287,6 +287,9 @@
     background: var(--color-dark-surface);
     padding: var(--space-sm) var(--space-md);
     border-radius: var(--radius-md);
+    display: flex;
+    align-items: center;
+    gap: var(--space-md);
 }
 
 .dashboard-playing-content {

--- a/custom_components/beatify/www/css/styles.css
+++ b/custom_components/beatify/www/css/styles.css
@@ -3757,6 +3757,54 @@ body.theme-dark .admin-controls {
     animation: pulse 2s infinite;
 }
 
+/* Intro Round Badge (Issue #23) */
+.intro-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-xs);
+    padding: var(--space-xs) var(--space-md);
+    background: linear-gradient(135deg, #ffd700, #ff6b00);
+    color: #000;
+    border-radius: var(--radius-pill);
+    font-size: var(--font-size-sm);
+    font-weight: var(--font-weight-bold);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    animation: intro-pulse 1.5s ease-in-out infinite;
+    margin-bottom: var(--space-sm);
+}
+
+.intro-badge-icon {
+    font-size: var(--font-size-md);
+}
+
+.intro-badge--large {
+    font-size: var(--font-size-lg);
+    padding: var(--space-sm) var(--space-lg);
+    margin-left: var(--space-md);
+}
+
+.intro-badge--large .intro-badge-icon {
+    font-size: var(--font-size-xl);
+}
+
+.intro-badge--stopped {
+    background: linear-gradient(135deg, #666, #444);
+    color: var(--color-text-white);
+    animation: none;
+}
+
+@keyframes intro-pulse {
+    0%, 100% { transform: scale(1); opacity: 1; }
+    50% { transform: scale(1.05); opacity: 0.9; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .intro-badge {
+        animation: none;
+    }
+}
+
 /* Album Cover (compact, matches reveal size) */
 .album-cover-container {
     position: relative;

--- a/custom_components/beatify/www/dashboard.html
+++ b/custom_components/beatify/www/dashboard.html
@@ -83,6 +83,11 @@
             <!-- Round counter (top-right) -->
             <div class="dashboard-round-indicator">
                 <span data-i18n="game.roundLabel">Round</span> <span id="dashboard-current-round">1</span> <span data-i18n="game.ofLabel">of</span> <span id="dashboard-total-rounds">10</span>
+                <!-- Intro Round Badge (Issue #23) -->
+                <span id="dashboard-intro-badge" class="intro-badge intro-badge--large hidden">
+                    <span class="intro-badge-icon" aria-hidden="true">⚡</span>
+                    <span data-i18n="game.introRound">INTRO ROUND</span>
+                </span>
             </div>
 
             <div class="dashboard-playing-content">

--- a/custom_components/beatify/www/i18n/de.json
+++ b/custom_components/beatify/www/i18n/de.json
@@ -84,7 +84,9 @@
     "pausedHint": "Das Spiel geht weiter wenn der Gastgeber zurückkehrt",
     "difficultyEasy": "Leicht",
     "difficultyNormal": "Normal",
-    "difficultyHard": "Schwer"
+    "difficultyHard": "Schwer",
+    "introRound": "INTRO-RUNDE",
+    "introStopped": "Intro vorbei!"
   },
   "steal": {
     "available": "Klauen verfügbar!",
@@ -236,6 +238,8 @@
     "artistChallenge": "Künstler-Challenge",
     "enableArtistChallenge": "Künstler-Challenge aktivieren",
     "artistChallengeDesc": "Erster richtiger Tipp: +5 Pkt",
+    "introMode": "Intro-Modus",
+    "introModeHint": "~20% der Runden spielen nur 10 Sekunden",
     "gameSettings": "Spieleinstellungen",
     "language": "Sprache",
     "timer": "Timer",
@@ -431,11 +435,13 @@
     "risk_taker": "Zocker",
     "clutch_player": "Endspurt-König",
     "close_calls": "Knapp Daneben",
+    "intro_master": "Intro-Meister",
     "avgTime": "durchschn.",
     "streak": "in Folge",
     "bets": "Wetten",
     "points": "Pkt in letzten 3",
-    "closeGuesses": "knappe Tipps"
+    "closeGuesses": "knappe Tipps",
+    "intro_bonuses": "Intro-Boni"
   },
   "stats": {
     "firstGame": "Erstes Spiel! Maßstab gesetzt",

--- a/custom_components/beatify/www/i18n/en.json
+++ b/custom_components/beatify/www/i18n/en.json
@@ -84,7 +84,9 @@
     "pausedHint": "The game will resume when the host returns",
     "difficultyEasy": "Easy",
     "difficultyNormal": "Normal",
-    "difficultyHard": "Hard"
+    "difficultyHard": "Hard",
+    "introRound": "INTRO ROUND",
+    "introStopped": "Intro complete!"
   },
   "steal": {
     "available": "Steal Available!",
@@ -236,6 +238,8 @@
     "artistChallenge": "Artist Challenge",
     "enableArtistChallenge": "Enable Artist Challenge",
     "artistChallengeDesc": "First correct guess: +5 pts",
+    "introMode": "Intro Mode",
+    "introModeHint": "~20% of rounds play only 10 seconds",
     "gameSettings": "Game Settings",
     "language": "Language",
     "timer": "Timer",
@@ -431,11 +435,13 @@
     "risk_taker": "Risk Taker",
     "clutch_player": "Clutch Player",
     "close_calls": "Close Calls",
+    "intro_master": "Intro Master",
     "avgTime": "avg",
     "streak": "in a row",
     "bets": "bets",
     "points": "pts in final 3",
-    "closeGuesses": "close guesses"
+    "closeGuesses": "close guesses",
+    "intro_bonuses": "intro bonuses"
   },
   "stats": {
     "firstGame": "First game! Setting the benchmark",

--- a/custom_components/beatify/www/i18n/es.json
+++ b/custom_components/beatify/www/i18n/es.json
@@ -84,7 +84,9 @@
     "pausedHint": "El juego continuara cuando el anfitrion regrese",
     "difficultyEasy": "Facil",
     "difficultyNormal": "Normal",
-    "difficultyHard": "Dificil"
+    "difficultyHard": "Dificil",
+    "introRound": "RONDA INTRO",
+    "introStopped": "Intro completa!"
   },
   "steal": {
     "available": "Robo disponible!",
@@ -236,6 +238,8 @@
     "artistChallenge": "Desafío de Artista",
     "enableArtistChallenge": "Activar Desafío de Artista",
     "artistChallengeDesc": "Primera respuesta correcta: +5 pts",
+    "introMode": "Modo Intro",
+    "introModeHint": "~20% de las rondas reproducen solo 10 segundos",
     "gameSettings": "Configuracion del Juego",
     "language": "Idioma",
     "timer": "Temporizador",
@@ -431,11 +435,13 @@
     "risk_taker": "Apostador",
     "clutch_player": "Rey del final",
     "close_calls": "Por poco",
+    "intro_master": "Maestro del Intro",
     "avgTime": "promedio",
     "streak": "consecutivos",
     "bets": "apuestas",
     "points": "pts en ultimas 3",
-    "closeGuesses": "respuestas cercanas"
+    "closeGuesses": "respuestas cercanas",
+    "intro_bonuses": "bonos de intro"
   },
   "stats": {
     "firstGame": "Primer juego! Estableciendo el punto de referencia",

--- a/custom_components/beatify/www/i18n/fr.json
+++ b/custom_components/beatify/www/i18n/fr.json
@@ -84,7 +84,9 @@
     "pausedHint": "La partie reprendra quand l'hôte reviendra",
     "difficultyEasy": "Facile",
     "difficultyNormal": "Normal",
-    "difficultyHard": "Difficile"
+    "difficultyHard": "Difficile",
+    "introRound": "MANCHE INTRO",
+    "introStopped": "Intro terminée !"
   },
   "steal": {
     "available": "Vol disponible !",
@@ -236,6 +238,8 @@
     "artistChallenge": "Défi Artiste",
     "enableArtistChallenge": "Activer le Défi Artiste",
     "artistChallengeDesc": "Première bonne réponse : +5 pts",
+    "introMode": "Mode Intro",
+    "introModeHint": "~20% des manches ne jouent que 10 secondes",
     "gameSettings": "Paramètres du jeu",
     "language": "Langue",
     "timer": "Temps",
@@ -431,11 +435,13 @@
     "risk_taker": "Parieur",
     "clutch_player": "Roi du finish",
     "close_calls": "Tout juste",
+    "intro_master": "Maître de l'Intro",
     "avgTime": "moyenne",
     "streak": "d'affilée",
     "bets": "paris",
     "points": "pts sur les 3 dernières",
-    "closeGuesses": "réponses proches"
+    "closeGuesses": "réponses proches",
+    "intro_bonuses": "bonus d'intro"
   },
   "stats": {
     "firstGame": "Première partie ! On établit la référence",

--- a/custom_components/beatify/www/js/admin.js
+++ b/custom_components/beatify/www/js/admin.js
@@ -32,6 +32,9 @@ let hasMusicAssistant = false;
 // Artist Challenge state (Story 20.7)
 let artistChallengeEnabled = true;
 
+// Intro Mode state (Issue #23)
+let introModeEnabled = false;
+
 // Lobby state (Story 16.8)
 let previousLobbyPlayers = [];
 let lobbyPollingInterval = null;
@@ -240,6 +243,13 @@ function setupGameSettings() {
         saveGameSettings();
     });
 
+    // Intro Mode toggle (Issue #23)
+    document.getElementById('intro-mode-toggle')?.addEventListener('change', function() {
+        introModeEnabled = this.checked;
+        updateGameSettingsSummary();
+        saveGameSettings();
+    });
+
     // Provider chips (Music Service)
     document.querySelectorAll('.chip[data-provider]').forEach(chip => {
         chip.addEventListener('click', function() {
@@ -305,6 +315,13 @@ async function loadSavedSettings() {
                 if (toggle) toggle.checked = settings.artistChallenge;
             }
 
+            // Apply intro mode (Issue #23)
+            if (typeof settings.introMode === 'boolean') {
+                introModeEnabled = settings.introMode;
+                const introToggle = document.getElementById('intro-mode-toggle');
+                if (introToggle) introToggle.checked = settings.introMode;
+            }
+
             // Apply provider
             if (settings.provider) {
                 selectedProvider = settings.provider;
@@ -330,6 +347,7 @@ function saveGameSettings() {
             duration: selectedDuration,
             difficulty: selectedDifficulty,
             artistChallenge: artistChallengeEnabled,
+            introMode: introModeEnabled,  // Issue #23
             provider: selectedProvider
         };
         localStorage.setItem(STORAGE_GAME_SETTINGS, JSON.stringify(settings));
@@ -348,8 +366,9 @@ function updateGameSettingsSummary() {
     const difficultyLabels = { easy: 'Easy', normal: 'Normal', hard: 'Hard' };
     const langLabels = { en: 'EN', de: 'DE', es: 'ES' };
     const artistIcon = artistChallengeEnabled ? ' • 🎤' : '';
+    const introIcon = introModeEnabled ? ' • ⚡' : '';  // Issue #23
 
-    summary.textContent = `${difficultyLabels[selectedDifficulty] || 'Normal'} • ${selectedDuration}s • ${langLabels[selectedLanguage] || 'EN'}${artistIcon}`;
+    summary.textContent = `${difficultyLabels[selectedDifficulty] || 'Normal'} • ${selectedDuration}s • ${langLabels[selectedLanguage] || 'EN'}${artistIcon}${introIcon}`;
 }
 
 /**
@@ -1351,7 +1370,8 @@ async function startGame() {
                 round_duration: selectedDuration,  // Story 13.1
                 difficulty: selectedDifficulty,  // Story 14.1
                 provider: selectedProvider,  // Story 17.2
-                artist_challenge_enabled: artistChallengeEnabled  // Story 20.7
+                artist_challenge_enabled: artistChallengeEnabled,  // Story 20.7
+                intro_mode_enabled: introModeEnabled  // Issue #23
             })
         });
 

--- a/custom_components/beatify/www/js/dashboard.js
+++ b/custom_components/beatify/www/js/dashboard.js
@@ -349,6 +349,31 @@
         if (currentRound) currentRound.textContent = data.round || 1;
         if (totalRounds) totalRounds.textContent = data.total_rounds || 10;
 
+        // Issue #23: Show/hide intro round badge
+        var introBadge = document.getElementById('dashboard-intro-badge');
+        if (introBadge) {
+            if (data.is_intro_round) {
+                introBadge.classList.remove('hidden');
+                var badgeText = introBadge.querySelector('[data-i18n]');
+                if (data.intro_stopped) {
+                    introBadge.classList.add('intro-badge--stopped');
+                    if (badgeText) {
+                        badgeText.setAttribute('data-i18n', 'game.introStopped');
+                        badgeText.textContent = utils.t('game.introStopped') || 'Intro complete!';
+                    }
+                } else {
+                    introBadge.classList.remove('intro-badge--stopped');
+                    if (badgeText) {
+                        badgeText.setAttribute('data-i18n', 'game.introRound');
+                        badgeText.textContent = utils.t('game.introRound') || 'INTRO ROUND';
+                    }
+                }
+            } else {
+                introBadge.classList.add('hidden');
+                introBadge.classList.remove('intro-badge--stopped');
+            }
+        }
+
         // Update album art (blurred - AC 10.4.3)
         var albumArt = document.getElementById('dashboard-album-art');
         if (albumArt) {

--- a/custom_components/beatify/www/js/player.js
+++ b/custom_components/beatify/www/js/player.js
@@ -1911,6 +1911,32 @@
             }
         }
 
+        // Issue #23: Show/hide intro round badge
+        var introBadge = document.getElementById('intro-badge');
+        if (introBadge) {
+            if (data.is_intro_round) {
+                introBadge.classList.remove('hidden');
+                // Update badge text based on intro_stopped state
+                var badgeText = introBadge.querySelector('[data-i18n]');
+                if (data.intro_stopped) {
+                    introBadge.classList.add('intro-badge--stopped');
+                    if (badgeText) {
+                        badgeText.setAttribute('data-i18n', 'game.introStopped');
+                        badgeText.textContent = utils.t('game.introStopped') || 'Intro complete!';
+                    }
+                } else {
+                    introBadge.classList.remove('intro-badge--stopped');
+                    if (badgeText) {
+                        badgeText.setAttribute('data-i18n', 'game.introRound');
+                        badgeText.textContent = utils.t('game.introRound') || 'INTRO ROUND';
+                    }
+                }
+            } else {
+                introBadge.classList.add('hidden');
+                introBadge.classList.remove('intro-badge--stopped');
+            }
+        }
+
         // Update album cover
         var albumCover = document.getElementById('album-cover');
         var albumLoading = document.getElementById('album-loading');
@@ -3267,6 +3293,23 @@
         var totalEl = document.getElementById('reveal-total');
         if (roundEl) roundEl.textContent = data.round || 1;
         if (totalEl) totalEl.textContent = data.total_rounds || 10;
+
+        // Issue #23: Show/hide intro round badge during REVEAL
+        var introBadge = document.getElementById('intro-badge');
+        if (introBadge) {
+            if (data.is_intro_round) {
+                introBadge.classList.remove('hidden');
+                // During reveal, always show "stopped" state since intro is complete
+                introBadge.classList.add('intro-badge--stopped');
+                var badgeText = introBadge.querySelector('[data-i18n]');
+                if (badgeText) {
+                    badgeText.setAttribute('data-i18n', 'game.introStopped');
+                    badgeText.textContent = utils.t('game.introStopped') || 'Intro complete!';
+                }
+            } else {
+                introBadge.classList.add('hidden');
+            }
+        }
 
         // Update album cover
         var albumCover = document.getElementById('reveal-album-cover');

--- a/custom_components/beatify/www/player.html
+++ b/custom_components/beatify/www/player.html
@@ -187,6 +187,11 @@
                 <div id="last-round-banner" class="last-round-banner hidden" data-i18n="game.finalRound">
                     Final Round!
                 </div>
+                <!-- Intro Round Badge (Issue #23) -->
+                <div id="intro-badge" class="intro-badge hidden">
+                    <span class="intro-badge-icon" aria-hidden="true">⚡</span>
+                    <span data-i18n="game.introRound">INTRO ROUND</span>
+                </div>
 
                 <!-- Album Cover -->
                 <div class="album-cover-container">

--- a/tests/unit/test_intro_mode.py
+++ b/tests/unit/test_intro_mode.py
@@ -1,0 +1,568 @@
+"""Unit tests for Intro Mode feature (Issue #23)."""
+
+import asyncio
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.beatify.const import (
+    INTRO_BONUS_TIERS,
+    INTRO_DURATION_SECONDS,
+    INTRO_ROUND_CHANCE,
+    MIN_INTRO_BONUSES_FOR_AWARD,
+)
+from custom_components.beatify.game.player import PlayerSession
+from custom_components.beatify.game.state import GamePhase, GameState
+
+
+@pytest.fixture
+def mock_ws():
+    """Mock WebSocket connection."""
+    return MagicMock()
+
+
+@pytest.fixture
+def game_state():
+    """Create a GameState instance for testing."""
+    state = GameState()
+    return state
+
+
+@pytest.fixture
+def mock_media_player():
+    """Mock media player service."""
+    service = AsyncMock()
+    service.pause = AsyncMock()
+    service.play = AsyncMock()
+    service.play_song = AsyncMock()
+    return service
+
+
+# =============================================================================
+# TestIntroModeCreation - Game creation with intro mode
+# =============================================================================
+
+
+class TestIntroModeCreation:
+    """Tests for intro mode game creation (Issue #23)."""
+
+    def test_create_game_with_intro_mode_enabled(self, game_state):
+        """Verify intro_mode_enabled is stored when True."""
+        game_state.create_game(
+            playlists=["test.json"],
+            songs=[{"uri": "spotify:track:abc123", "year": 2020}],
+            media_player="media_player.test",
+            base_url="http://localhost",
+            intro_mode_enabled=True,
+        )
+
+        assert game_state.intro_mode_enabled is True
+
+    def test_create_game_intro_mode_default_off(self, game_state):
+        """Verify intro_mode_enabled defaults to False."""
+        game_state.create_game(
+            playlists=["test.json"],
+            songs=[{"uri": "spotify:track:abc123", "year": 2020}],
+            media_player="media_player.test",
+            base_url="http://localhost",
+        )
+
+        assert game_state.intro_mode_enabled is False
+
+    def test_create_game_initializes_intro_state(self, game_state):
+        """Verify all intro-related state is initialized on game creation."""
+        game_state.create_game(
+            playlists=["test.json"],
+            songs=[{"uri": "spotify:track:abc123", "year": 2020}],
+            media_player="media_player.test",
+            base_url="http://localhost",
+            intro_mode_enabled=True,
+        )
+
+        assert game_state.is_intro_round is False
+        assert game_state.intro_stopped is False
+        assert game_state._intro_round_start_time is None
+        assert game_state._intro_stop_task is None
+
+
+# =============================================================================
+# TestIntroRoundSelection - Random intro round selection
+# =============================================================================
+
+
+class TestIntroRoundSelection:
+    """Tests for random intro round selection (Issue #23)."""
+
+    def test_intro_round_never_when_disabled(self, game_state):
+        """Verify is_intro_round stays False when mode disabled."""
+        game_state.create_game(
+            playlists=["test.json"],
+            songs=[{"uri": "spotify:track:abc123", "year": 2020, "duration_ms": 180000}],
+            media_player="media_player.test",
+            base_url="http://localhost",
+            intro_mode_enabled=False,
+        )
+
+        # Even with random returning low value, should not trigger
+        with patch("random.random", return_value=0.01):
+            # Reset to simulate what start_round does
+            game_state.is_intro_round = False
+            if game_state.intro_mode_enabled:
+                import random
+                if random.random() < INTRO_ROUND_CHANCE:
+                    game_state.is_intro_round = True
+
+        assert game_state.is_intro_round is False
+
+    def test_intro_round_triggered_below_threshold(self, game_state):
+        """Verify intro round triggers when random() < INTRO_ROUND_CHANCE."""
+        game_state.create_game(
+            playlists=["test.json"],
+            songs=[{"uri": "spotify:track:abc123", "year": 2020, "duration_ms": 180000}],
+            media_player="media_player.test",
+            base_url="http://localhost",
+            intro_mode_enabled=True,
+        )
+
+        # Patch at module level where it's used
+        with patch("custom_components.beatify.game.state.random.random", return_value=0.10):
+            # Simulate what start_round does for intro detection
+            game_state.is_intro_round = False
+            if game_state.intro_mode_enabled:
+                import custom_components.beatify.game.state as state_module
+                if state_module.random.random() < INTRO_ROUND_CHANCE:
+                    song_duration_ms = 180000
+                    if song_duration_ms >= INTRO_DURATION_SECONDS * 1000:
+                        game_state.is_intro_round = True
+
+        assert game_state.is_intro_round is True
+
+    def test_intro_round_not_triggered_above_threshold(self, game_state):
+        """Verify no intro round when random() >= INTRO_ROUND_CHANCE."""
+        game_state.create_game(
+            playlists=["test.json"],
+            songs=[{"uri": "spotify:track:abc123", "year": 2020, "duration_ms": 180000}],
+            media_player="media_player.test",
+            base_url="http://localhost",
+            intro_mode_enabled=True,
+        )
+
+        with patch("custom_components.beatify.game.state.random.random", return_value=0.50):
+            game_state.is_intro_round = False
+            if game_state.intro_mode_enabled:
+                import custom_components.beatify.game.state as state_module
+                if state_module.random.random() < INTRO_ROUND_CHANCE:
+                    game_state.is_intro_round = True
+
+        assert game_state.is_intro_round is False
+
+    def test_short_song_skips_intro_mode(self, game_state):
+        """Verify songs <10s don't trigger intro mode (F4 fix)."""
+        game_state.create_game(
+            playlists=["test.json"],
+            songs=[{"uri": "spotify:track:abc123", "year": 2020, "duration_ms": 5000}],  # 5 seconds
+            media_player="media_player.test",
+            base_url="http://localhost",
+            intro_mode_enabled=True,
+        )
+
+        with patch("custom_components.beatify.game.state.random.random", return_value=0.10):
+            game_state.is_intro_round = False
+            if game_state.intro_mode_enabled:
+                import custom_components.beatify.game.state as state_module
+                if state_module.random.random() < INTRO_ROUND_CHANCE:
+                    song_duration_ms = 5000  # Short song
+                    if song_duration_ms >= INTRO_DURATION_SECONDS * 1000:
+                        game_state.is_intro_round = True
+
+        # Should NOT trigger because song is too short
+        assert game_state.is_intro_round is False
+
+
+# =============================================================================
+# TestIntroAutoStop - 10-second auto-pause
+# =============================================================================
+
+
+class TestIntroAutoStop:
+    """Tests for 10-second auto-pause (Issue #23)."""
+
+    @pytest.mark.asyncio
+    async def test_intro_auto_stop_pauses_playback(self, game_state, mock_media_player):
+        """Verify _intro_auto_stop calls pause on media player."""
+        game_state._media_player_service = mock_media_player
+        game_state.phase = GamePhase.PLAYING
+        game_state.intro_stopped = False
+        game_state._broadcast_state = AsyncMock()
+
+        # Call with 0 delay for immediate execution
+        await game_state._intro_auto_stop(0)
+
+        mock_media_player.pause.assert_called_once()
+        assert game_state.intro_stopped is True
+
+    @pytest.mark.asyncio
+    async def test_intro_auto_stop_broadcasts_state(self, game_state, mock_media_player):
+        """Verify state broadcast after intro stops."""
+        game_state._media_player_service = mock_media_player
+        game_state.phase = GamePhase.PLAYING
+        game_state.intro_stopped = False
+        game_state._broadcast_state = AsyncMock()
+
+        await game_state._intro_auto_stop(0)
+
+        game_state._broadcast_state.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_intro_auto_stop_does_not_pause_if_already_stopped(self, game_state, mock_media_player):
+        """Verify no double pause if intro already stopped."""
+        game_state._media_player_service = mock_media_player
+        game_state.phase = GamePhase.PLAYING
+        game_state.intro_stopped = True  # Already stopped
+        game_state._broadcast_state = AsyncMock()
+
+        await game_state._intro_auto_stop(0)
+
+        mock_media_player.pause.assert_not_called()
+
+    def test_cancel_intro_timer(self, game_state):
+        """Verify _cancel_intro_timer cancels the task."""
+        mock_task = MagicMock()
+        mock_task.done.return_value = False
+        game_state._intro_stop_task = mock_task
+
+        game_state._cancel_intro_timer()
+
+        mock_task.cancel.assert_called_once()
+        assert game_state._intro_stop_task is None
+
+    def test_cancel_intro_timer_no_task(self, game_state):
+        """Verify _cancel_intro_timer handles None task gracefully."""
+        game_state._intro_stop_task = None
+
+        # Should not raise
+        game_state._cancel_intro_timer()
+
+        assert game_state._intro_stop_task is None
+
+
+# =============================================================================
+# TestIntroSpeedBonus - Tiered speed bonus scoring
+# =============================================================================
+
+
+class TestIntroSpeedBonus:
+    """Tests for tiered speed bonus scoring (Issue #23)."""
+
+    def test_intro_bonus_tiers_constant(self):
+        """Verify INTRO_BONUS_TIERS matches expected values."""
+        assert INTRO_BONUS_TIERS == [5, 3, 1]
+
+    def test_intro_duration_constant(self):
+        """Verify INTRO_DURATION_SECONDS is 10."""
+        assert INTRO_DURATION_SECONDS == 10
+
+    def test_intro_round_chance_constant(self):
+        """Verify INTRO_ROUND_CHANCE is 0.20."""
+        assert INTRO_ROUND_CHANCE == 0.20
+
+    def test_first_submitter_gets_5_bonus(self, mock_ws):
+        """Verify fastest pre-cutoff submitter gets +5 bonus."""
+        # Setup: Create players with different submission times
+        player1 = PlayerSession(name="Alice", ws=mock_ws)
+        player2 = PlayerSession(name="Bob", ws=mock_ws)
+        player3 = PlayerSession(name="Charlie", ws=mock_ws)
+
+        # Simulate intro round timing
+        intro_start = 1000.0
+        intro_cutoff = intro_start + INTRO_DURATION_SECONDS
+
+        # Player 1 submits first (before cutoff)
+        player1.submission_time = intro_start + 3.0  # 3s after start
+        # Player 2 submits second (before cutoff)
+        player2.submission_time = intro_start + 5.0  # 5s after start
+        # Player 3 submits third (before cutoff)
+        player3.submission_time = intro_start + 8.0  # 8s after start
+
+        players = [player1, player2, player3]
+
+        # Calculate rank for player1 (should be 0 = first)
+        rank = len([
+            p for p in players
+            if p.submission_time is not None
+            and p.submission_time < intro_cutoff
+            and p.submission_time < player1.submission_time
+        ])
+
+        assert rank == 0  # First place
+        assert INTRO_BONUS_TIERS[rank] == 5  # Gets +5
+
+    def test_second_submitter_gets_3_bonus(self, mock_ws):
+        """Verify second fastest pre-cutoff submitter gets +3 bonus."""
+        player1 = PlayerSession(name="Alice", ws=mock_ws)
+        player2 = PlayerSession(name="Bob", ws=mock_ws)
+
+        intro_start = 1000.0
+        intro_cutoff = intro_start + INTRO_DURATION_SECONDS
+
+        player1.submission_time = intro_start + 3.0
+        player2.submission_time = intro_start + 5.0
+
+        players = [player1, player2]
+
+        # Calculate rank for player2 (should be 1 = second)
+        rank = len([
+            p for p in players
+            if p.submission_time is not None
+            and p.submission_time < intro_cutoff
+            and p.submission_time < player2.submission_time
+        ])
+
+        assert rank == 1  # Second place
+        assert INTRO_BONUS_TIERS[rank] == 3  # Gets +3
+
+    def test_third_submitter_gets_1_bonus(self, mock_ws):
+        """Verify third fastest pre-cutoff submitter gets +1 bonus."""
+        player1 = PlayerSession(name="Alice", ws=mock_ws)
+        player2 = PlayerSession(name="Bob", ws=mock_ws)
+        player3 = PlayerSession(name="Charlie", ws=mock_ws)
+
+        intro_start = 1000.0
+        intro_cutoff = intro_start + INTRO_DURATION_SECONDS
+
+        player1.submission_time = intro_start + 3.0
+        player2.submission_time = intro_start + 5.0
+        player3.submission_time = intro_start + 8.0
+
+        players = [player1, player2, player3]
+
+        # Calculate rank for player3 (should be 2 = third)
+        rank = len([
+            p for p in players
+            if p.submission_time is not None
+            and p.submission_time < intro_cutoff
+            and p.submission_time < player3.submission_time
+        ])
+
+        assert rank == 2  # Third place
+        assert INTRO_BONUS_TIERS[rank] == 1  # Gets +1
+
+    def test_submitter_after_cutoff_gets_no_bonus(self, mock_ws):
+        """Verify player submitting after 10s cutoff gets no bonus."""
+        player = PlayerSession(name="Alice", ws=mock_ws)
+
+        intro_start = 1000.0
+        intro_cutoff = intro_start + INTRO_DURATION_SECONDS
+
+        # Submit after cutoff
+        player.submission_time = intro_start + 12.0  # 12s after start
+
+        # Should not qualify for bonus
+        qualifies = (
+            player.submission_time is not None
+            and player.submission_time < intro_cutoff
+        )
+
+        assert qualifies is False
+
+
+# =============================================================================
+# TestIntroMasterSuperlative - Award calculation
+# =============================================================================
+
+
+class TestIntroMasterSuperlative:
+    """Tests for Intro Master award (Issue #23)."""
+
+    def test_min_intro_bonuses_constant(self):
+        """Verify MIN_INTRO_BONUSES_FOR_AWARD is 1."""
+        assert MIN_INTRO_BONUSES_FOR_AWARD == 1
+
+    def test_player_with_most_bonuses_wins(self, mock_ws):
+        """Verify player with most intro speed bonuses gets the award."""
+        player1 = PlayerSession(name="Alice", ws=mock_ws)
+        player2 = PlayerSession(name="Bob", ws=mock_ws)
+        player3 = PlayerSession(name="Charlie", ws=mock_ws)
+
+        player1.intro_speed_bonuses = 3
+        player2.intro_speed_bonuses = 5  # Winner
+        player3.intro_speed_bonuses = 2
+
+        players = [player1, player2, player3]
+
+        # Find winner (matching logic in calculate_superlatives)
+        candidates = [
+            (p, p.intro_speed_bonuses)
+            for p in players
+            if p.intro_speed_bonuses >= MIN_INTRO_BONUSES_FOR_AWARD
+        ]
+        winner = max(candidates, key=lambda x: x[1])
+
+        assert winner[0].name == "Bob"
+        assert winner[1] == 5
+
+    def test_no_award_if_no_qualifying_players(self, mock_ws):
+        """Verify no award when no players meet minimum threshold."""
+        player1 = PlayerSession(name="Alice", ws=mock_ws)
+        player1.intro_speed_bonuses = 0
+
+        players = [player1]
+
+        candidates = [
+            (p, p.intro_speed_bonuses)
+            for p in players
+            if p.intro_speed_bonuses >= MIN_INTRO_BONUSES_FOR_AWARD
+        ]
+
+        assert len(candidates) == 0
+
+
+# =============================================================================
+# TestIntroStateIntegration - State management and integration
+# =============================================================================
+
+
+class TestIntroStateIntegration:
+    """Tests for state management and integration (Issue #23)."""
+
+    def test_player_session_has_intro_fields(self, mock_ws):
+        """Verify PlayerSession has intro-related fields."""
+        player = PlayerSession(name="Alice", ws=mock_ws)
+
+        assert hasattr(player, "intro_bonus")
+        assert hasattr(player, "intro_speed_bonuses")
+        assert player.intro_bonus == 0
+        assert player.intro_speed_bonuses == 0
+
+    def test_player_reset_round_clears_intro_bonus(self, mock_ws):
+        """Verify reset_round clears intro_bonus but not intro_speed_bonuses."""
+        player = PlayerSession(name="Alice", ws=mock_ws)
+        player.intro_bonus = 5
+        player.intro_speed_bonuses = 3
+
+        player.reset_round()
+
+        assert player.intro_bonus == 0
+        assert player.intro_speed_bonuses == 3  # Cumulative, not reset
+
+    def test_player_reset_for_new_game_clears_all(self, mock_ws):
+        """Verify reset_for_new_game clears all intro tracking."""
+        player = PlayerSession(name="Alice", ws=mock_ws)
+        player.intro_bonus = 5
+        player.intro_speed_bonuses = 3
+
+        player.reset_for_new_game()
+
+        assert player.intro_bonus == 0
+        assert player.intro_speed_bonuses == 0
+
+    def test_get_state_includes_intro_fields(self, game_state):
+        """Verify get_state includes all intro fields."""
+        game_state.create_game(
+            playlists=["test.json"],
+            songs=[{"uri": "spotify:track:abc123", "year": 2020}],
+            media_player="media_player.test",
+            base_url="http://localhost",
+            intro_mode_enabled=True,
+        )
+        game_state.is_intro_round = True
+        game_state.intro_stopped = True
+
+        state = game_state.get_state()
+
+        assert state["intro_mode_enabled"] is True
+        assert state["is_intro_round"] is True
+        assert state["intro_stopped"] is True
+
+
+# =============================================================================
+# TestEdgeCases - Edge case tests
+# =============================================================================
+
+
+class TestEdgeCases:
+    """Edge case tests for intro mode (Issue #23)."""
+
+    @pytest.mark.asyncio
+    async def test_intro_auto_stop_handles_pause_error(self, game_state, mock_media_player):
+        """Verify graceful handling of media player pause errors."""
+        mock_media_player.pause = AsyncMock(side_effect=Exception("Network error"))
+        game_state._media_player_service = mock_media_player
+        game_state.phase = GamePhase.PLAYING
+        game_state.intro_stopped = False
+        game_state._broadcast_state = AsyncMock()
+
+        # Should not raise, just log warning
+        await game_state._intro_auto_stop(0)
+
+        # intro_stopped should still be set
+        assert game_state.intro_stopped is True
+
+    def test_all_players_submit_before_cutoff(self, mock_ws):
+        """Verify handling when all players submit before 10s."""
+        players = [
+            PlayerSession(name="Alice", ws=mock_ws),
+            PlayerSession(name="Bob", ws=mock_ws),
+            PlayerSession(name="Charlie", ws=mock_ws),
+        ]
+
+        intro_start = 1000.0
+        intro_cutoff = intro_start + INTRO_DURATION_SECONDS
+
+        # All submit before cutoff
+        players[0].submission_time = intro_start + 2.0
+        players[1].submission_time = intro_start + 4.0
+        players[2].submission_time = intro_start + 6.0
+
+        # All should qualify
+        qualifying = [
+            p for p in players
+            if p.submission_time and p.submission_time < intro_cutoff
+        ]
+
+        assert len(qualifying) == 3
+
+    def test_no_submissions_before_cutoff(self, mock_ws):
+        """Verify handling when no one submits before 10s."""
+        players = [
+            PlayerSession(name="Alice", ws=mock_ws),
+            PlayerSession(name="Bob", ws=mock_ws),
+        ]
+
+        intro_start = 1000.0
+        intro_cutoff = intro_start + INTRO_DURATION_SECONDS
+
+        # All submit after cutoff
+        players[0].submission_time = intro_start + 15.0
+        players[1].submission_time = intro_start + 20.0
+
+        # None should qualify
+        qualifying = [
+            p for p in players
+            if p.submission_time and p.submission_time < intro_cutoff
+        ]
+
+        assert len(qualifying) == 0
+
+    def test_player_with_none_submission_time(self, mock_ws):
+        """Verify handling of players with None submission_time (F5 fix)."""
+        players = [
+            PlayerSession(name="Alice", ws=mock_ws),
+            PlayerSession(name="Bob", ws=mock_ws),
+        ]
+
+        intro_start = 1000.0
+        intro_cutoff = intro_start + INTRO_DURATION_SECONDS
+
+        players[0].submission_time = intro_start + 5.0
+        players[1].submission_time = None  # Did not submit
+
+        # Only Alice should qualify
+        qualifying = [
+            p for p in players
+            if p.submission_time is not None and p.submission_time < intro_cutoff
+        ]
+
+        assert len(qualifying) == 1
+        assert qualifying[0].name == "Alice"


### PR DESCRIPTION
## Summary
- Adds optional "Intro Only Mode" game setting that creates ~20% random intro rounds
- During intro rounds, songs auto-pause after 10 seconds
- Tiered speed bonus (5/3/1 pts) rewards fast guessers who submit before the cutoff
- Full song resumes during reveal phase so players hear what they missed
- New "Intro Master" superlative for most intro speed bonuses earned

## Changes
- **Backend**: `const.py`, `state.py`, `player.py`, `views.py` - intro mode logic, scoring, superlative
- **Frontend**: Admin toggle, player/dashboard UI badges, CSS styling
- **i18n**: All 4 languages (EN/DE/ES/FR) with intro mode translations
- **Tests**: Unit tests for intro mode functionality

## Test plan
- [ ] Enable intro mode in admin settings
- [ ] Verify ~20% of rounds trigger intro mode (badge appears)
- [ ] Confirm song pauses after 10 seconds
- [ ] Submit answer before cutoff and verify speed bonus awarded
- [ ] Check reveal resumes full song playback
- [ ] Verify "Intro Master" superlative appears at game end

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)