### PR TITLE
feat(#143): Add Comeback King superlative 👑

### DIFF
--- a/custom_components/beatify/www/i18n/de.json
+++ b/custom_components/beatify/www/i18n/de.json
@@ -440,12 +440,14 @@
     "clutch_player": "Endspurt-König",
     "close_calls": "Knapp Daneben",
     "intro_master": "Intro-Meister",
+    "comeback_king": "Comeback-König",
     "avgTime": "durchschn.",
     "streak": "in Folge",
     "bets": "Wetten",
     "points": "Pkt in letzten 3",
     "closeGuesses": "knappe Tipps",
-    "intro_bonuses": "Intro-Boni"
+    "intro_bonuses": "Intro-Boni",
+    "improvement": "Verbesserung"
   },
   "stats": {
     "firstGame": "Erstes Spiel! Maßstab gesetzt",

--- a/custom_components/beatify/www/i18n/en.json
+++ b/custom_components/beatify/www/i18n/en.json
@@ -440,12 +440,14 @@
     "clutch_player": "Clutch Player",
     "close_calls": "Close Calls",
     "intro_master": "Intro Master",
+    "comeback_king": "Comeback King",
     "avgTime": "avg",
     "streak": "in a row",
     "bets": "bets",
     "points": "pts in final 3",
     "closeGuesses": "close guesses",
-    "intro_bonuses": "intro bonuses"
+    "intro_bonuses": "intro bonuses",
+    "improvement": "avg improvement"
   },
   "stats": {
     "firstGame": "First game! Setting the benchmark",

--- a/custom_components/beatify/www/i18n/es.json
+++ b/custom_components/beatify/www/i18n/es.json
@@ -440,12 +440,14 @@
     "clutch_player": "Rey del final",
     "close_calls": "Por poco",
     "intro_master": "Maestro del Intro",
+    "comeback_king": "Rey de la Remontada",
     "avgTime": "promedio",
     "streak": "consecutivos",
     "bets": "apuestas",
     "points": "pts en ultimas 3",
     "closeGuesses": "respuestas cercanas",
-    "intro_bonuses": "bonos de intro"
+    "intro_bonuses": "bonos de intro",
+    "improvement": "mejora promedio"
   },
   "stats": {
     "firstGame": "Primer juego! Estableciendo el punto de referencia",

--- a/custom_components/beatify/www/i18n/fr.json
+++ b/custom_components/beatify/www/i18n/fr.json
@@ -440,12 +440,14 @@
     "clutch_player": "Roi du finish",
     "close_calls": "Tout juste",
     "intro_master": "Maître de l'Intro",
+    "comeback_king": "Roi du Comeback",
     "avgTime": "moyenne",
     "streak": "d'affilée",
     "bets": "paris",
     "points": "pts sur les 3 dernières",
     "closeGuesses": "réponses proches",
-    "intro_bonuses": "bonus d'intro"
+    "intro_bonuses": "bonus d'intro",
+    "improvement": "amélioration moy."
   },
   "stats": {
     "firstGame": "Première partie ! On établit la référence",


### PR DESCRIPTION
## Summary
Adds a new **Comeback King** 👑 superlative that rewards the player who improved the most during a game.

Closes #143

## How it works
- Compares **first-half** vs **second-half** average round scores
- Player with the biggest positive improvement wins the award
- Minimum 6 rounds required (for meaningful halves)
- Minimum 2.0 avg improvement threshold (prevents trivial awards)

## Changes
| File | Change |
|------|--------|
| `const.py` | Added `MIN_ROUNDS_FOR_COMEBACK`, `MIN_COMEBACK_IMPROVEMENT` |
| `game/state.py` | Added comeback_king calculation in `calculate_superlatives()` |
| `i18n/en.json` | "Comeback King", "avg improvement" |
| `i18n/de.json` | "Comeback-König", "Verbesserung" |
| `i18n/es.json` | "Rey de la Remontada", "mejora promedio" |
| `i18n/fr.json` | "Roi du Comeback", "amélioration moy." |
| `test_game_state.py` | 3 new tests (happy path, min rounds, no improvement) |

## Why
Current superlatives reward consistency and peak performance, but nothing for the **comeback arc** — the most exciting story in any party game. This encourages players who fall behind early.

## Testing
- ✅ Code compiles
- ✅ 3 unit tests added
- ✅ Zero UI changes needed (superlatives render dynamically)
- ✅ Uses existing `round_scores` data — no new player fields