### PR TITLE
🎵 Add playlist: HITSTER 100% en español

### DIFF
--- a/custom_components/beatify/playlists/community/hitster-100-en-espanol.json
+++ b/custom_components/beatify/playlists/community/hitster-100-en-espanol.json
@@ -1,0 +1,2603 @@
+{
+  "name": "HITSTER 100% en español",
+  "version": "1.0",
+  "tags": [
+    "spanish",
+    "spain",
+    "latin",
+    "pop",
+    "rock",
+    "flamenco",
+    "multi-decade"
+  ],
+  "songs": [
+    {
+      "year": 1967,
+      "uri": "spotify:track:2Tif74q2v2BExCKlBdt1Cm",
+      "artist": "Patxi Andion",
+      "alt_artists": [
+        "Joan Manuel Serrat",
+        "Luis Eduardo Aute",
+        "Víctor Manuel"
+      ],
+      "title": "Una Dos Y Tres",
+      "chart_info": {
+        "billboard_peak": null,
+        "uk_peak": null,
+        "weeks_on_chart": null
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "Patxi Andión was a protest singer-songwriter icon during Spain's Franco era, using music for social commentary.",
+      "fun_fact_de": "Patxi Andión war eine Ikone der Protestlied-Bewegung während der Franco-Ära.",
+      "fun_fact_es": "Patxi Andión fue un icono de la canción protesta durante la era franquista.",
+      "fun_fact_fr": "Patxi Andión fut une icône de la chanson contestataire durant l'ère franquiste.",
+      "uri_apple_music": "applemusic://track/1438759692",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=UTomUsxKiLw",
+      "uri_tidal": "tidal://track/3631762"
+    },
+    {
+      "year": 2012,
+      "uri": "spotify:track:1suTz9wOBk6pF2OAAgKFve",
+      "artist": "Efecto Pasillo",
+      "alt_artists": [
+        "Taburete",
+        "Dvicio",
+        "Maldita Nerea"
+      ],
+      "title": "No importa que llueva",
+      "chart_info": {
+        "billboard_peak": null,
+        "uk_peak": null,
+        "weeks_on_chart": null
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "This Canarian band from Las Palmas became Spain's feel-good summer anthem kings — this track dominated Spanish radio in 2012.",
+      "fun_fact_de": "Diese kanarische Band aus Las Palmas wurde 2012 zum Inbegriff spanischer Sommerhits.",
+      "fun_fact_es": "Esta banda canaria de Las Palmas se convirtió en reina de los himnos veraniegos españoles en 2012.",
+      "fun_fact_fr": "Ce groupe canarien de Las Palmas est devenu le roi des hymnes estivaux espagnols en 2012.",
+      "uri_apple_music": "applemusic://track/1322695796",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=n9qU9kVc6jM",
+      "uri_tidal": "tidal://track/82198950"
+    },
+    {
+      "year": 2012,
+      "uri": "spotify:track:1kgBwPl0UUHz97Krp65zF4",
+      "artist": "Nancys Rubias",
+      "alt_artists": [
+        "Fangoria",
+        "Alaska y Dinarama",
+        "OBK"
+      ],
+      "title": "Me encanta - I Love It",
+      "chart_info": {
+        "billboard_peak": null,
+        "uk_peak": null,
+        "weeks_on_chart": null
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "Nancys Rubias is the project of Mario Vaquerizo, one of Spain's most colorful TV personalities and husband of Alaska from Fangoria.",
+      "fun_fact_de": "Nancys Rubias ist das Projekt von Mario Vaquerizo, Ehemann von Alaska (Fangoria) und einer der schillerndsten TV-Persönlichkeiten Spaniens.",
+      "fun_fact_es": "Nancys Rubias es el proyecto de Mario Vaquerizo, marido de Alaska (Fangoria) y una de las personalidades más coloridas de la TV española.",
+      "fun_fact_fr": "Nancys Rubias est le projet de Mario Vaquerizo, mari d'Alaska (Fangoria) et personnalité TV espagnole haute en couleur.",
+      "uri_apple_music": "applemusic://track/662768349",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=W2v72CID98M",
+      "uri_tidal": "tidal://track/20970603"
+    },
+    {
+      "year": 2017,
+      "uri": "spotify:track:6habFhsOp2NvshLv26DqMb",
+      "artist": "Luis Fonsi, Daddy Yankee",
+      "alt_artists": [
+        "Maluma",
+        "J Balvin",
+        "Enrique Iglesias",
+        "Shakira"
+      ],
+      "title": "Despacito",
+      "chart_info": {
+        "billboard_peak": null,
+        "uk_peak": null,
+        "weeks_on_chart": null
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "First Spanish-language song to reach #1 on the Billboard Hot 100 in 20+ years, with over 8 billion YouTube views — the most-viewed music video ever at its peak.",
+      "fun_fact_de": "Erster spanischsprachiger Song seit über 20 Jahren auf Platz 1 der Billboard Hot 100, mit über 8 Milliarden YouTube-Aufrufen.",
+      "fun_fact_es": "Primera canción en español en alcanzar el #1 del Billboard Hot 100 en más de 20 años, con más de 8 mil millones de reproducciones en YouTube.",
+      "fun_fact_fr": "Première chanson en espagnol au #1 du Billboard Hot 100 en plus de 20 ans, avec plus de 8 milliards de vues YouTube.",
+      "uri_apple_music": "applemusic://track/1445011795",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=kJQP7kiw5Fk",
+      "uri_tidal": "tidal://track/70587299"
+    },
+    {
+      "year": 1985,
+      "uri": "spotify:track:5hJ3UUZicnpl9DnBQFshUP",
+      "artist": "Los Chunguitos",
+      "alt_artists": [
+        "Los Chichos",
+        "Las Grecas",
+        "Rumba Tres",
+        "Peret"
+      ],
+      "title": "Ay Que Dolor",
+      "chart_info": {
+        "billboard_peak": null,
+        "uk_peak": null,
+        "weeks_on_chart": null
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "Twin brothers from Madrid's Vallecas district who pioneered 'rumba urbana' (flamenco-pop fusion), selling over 15 million records in Spain.",
+      "fun_fact_de": "Zwillingsbrüder aus Madrids Vallecas, Pioniere der 'Rumba Urbana' mit über 15 Millionen verkauften Platten.",
+      "fun_fact_es": "Hermanos gemelos del barrio madrileño de Vallecas, pioneros de la 'rumba urbana', con más de 15 millones de discos vendidos.",
+      "fun_fact_fr": "Frères jumeaux du quartier madrilène de Vallecas, pionniers de la 'rumba urbana', plus de 15 millions de disques vendus.",
+      "uri_apple_music": "applemusic://track/259103007",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=LPf92fBp2ZY",
+      "uri_tidal": "tidal://track/9289819"
+    },
+    {
+      "year": 1996,
+      "uri": "spotify:track:6Z8Q8zSG6xpIKAyH0Z77wb",
+      "artist": "Luz Casal",
+      "alt_artists": [
+        "Ana Belén",
+        "Rocío Dúrcal",
+        "Mónica Naranjo",
+        "Malú"
+      ],
+      "title": "Entre mis recuerdos",
+      "chart_info": {
+        "billboard_peak": null,
+        "uk_peak": null,
+        "weeks_on_chart": null
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "Luz Casal gained international fame when Pedro Almodóvar featured 'Piensa en mí' in 'High Heels' (1991), making her one of Spain's most celebrated female voices.",
+      "fun_fact_de": "Luz Casal wurde international bekannt durch Pedro Almodóvars Film 'High Heels' (1991) mit ihrem Song 'Piensa en mí'.",
+      "fun_fact_es": "Luz Casal alcanzó fama internacional cuando Almodóvar incluyó 'Piensa en mí' en 'Tacones lejanos' (1991).",
+      "fun_fact_fr": "Luz Casal est devenue célèbre quand Almodóvar a utilisé 'Piensa en mí' dans 'Talons aiguilles' (1991).",
+      "uri_apple_music": "applemusic://track/694098076",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=zUnOWCURe2M",
+      "uri_tidal": "tidal://track/40783594"
+    },
+    {
+      "year": 1978,
+      "uri": "spotify:track:7aKs8kWKKau0SDgaeyZMAX",
+      "artist": "Willie Colón, Rubén Blades",
+      "alt_artists": [
+        "Héctor Lavoe",
+        "Celia Cruz",
+        "Oscar D'León",
+        "Tito Puente"
+      ],
+      "title": "Pedro Navaja",
+      "chart_info": {
+        "billboard_peak": null,
+        "uk_peak": null,
+        "weeks_on_chart": null
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "Considered the greatest salsa song ever — a 7-minute crime narrative inspired by 'Mack the Knife', from 'Siembra', the best-selling salsa album of all time.",
+      "fun_fact_de": "Gilt als größter Salsa-Song aller Zeiten — 7-minütige Kriminalgeschichte vom meistverkauften Salsa-Album 'Siembra'.",
+      "fun_fact_es": "Considerada la mayor canción de salsa jamás escrita — narrativa criminal de 7 minutos del álbum 'Siembra', el más vendido de la salsa.",
+      "fun_fact_fr": "Considérée comme la plus grande chanson de salsa — récit criminel de 7 min tiré de 'Siembra', l'album de salsa le plus vendu.",
+      "uri_apple_music": "applemusic://track/1464957419",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=5LqnbAkqRYQ",
+      "uri_tidal": "tidal://track/60074360"
+    },
+    {
+      "year": 1970,
+      "uri": "spotify:track:61VeJ59zufLceZXb1SSVKu",
+      "artist": "Tony Ronald",
+      "alt_artists": [
+        "Raphael",
+        "Nino Bravo",
+        "Julio Iglesias",
+        "José Luis Perales"
+      ],
+      "title": "Help, áyudame",
+      "chart_info": {
+        "billboard_peak": null,
+        "uk_peak": null,
+        "weeks_on_chart": null
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "Dutch-born Tony Ronald became one of Spain's biggest pop stars. This Spanish adaptation of The Beatles' 'Help!' became a karaoke classic in Spain.",
+      "fun_fact_de": "Der in Holland geborene Tony Ronald wurde einer der größten Popstars Spaniens mit dieser spanischen Version von Beatles' 'Help!'.",
+      "fun_fact_es": "Tony Ronald, nacido en Holanda, se convirtió en estrella del pop español con esta adaptación de 'Help!' de The Beatles.",
+      "fun_fact_fr": "Né aux Pays-Bas, Tony Ronald est devenu star du pop espagnol avec cette adaptation de 'Help!' des Beatles.",
+      "uri_apple_music": "applemusic://track/1461480730",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=URRgBxPuuIw",
+      "uri_tidal": "tidal://track/343790"
+    },
+    {
+      "year": 2019,
+      "uri": "spotify:track:6Xk2u0r27AztzglwVUvohC",
+      "artist": "Suu",
+      "alt_artists": [
+        "Aitana",
+        "Amaia",
+        "Zahara",
+        "La Bien Querida"
+      ],
+      "title": "Eres un Temazo",
+      "chart_info": {
+        "billboard_peak": null,
+        "uk_peak": null,
+        "weeks_on_chart": null
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "Catalan indie-pop artist who went viral with this self-referential bop — a song about wanting to write a hit, which ironically became exactly that.",
+      "fun_fact_de": "Katalanische Indie-Pop-Künstlerin, die mit diesem Song über den Wunsch einen Hit zu schreiben viral ging — und ironischerweise genau das schaffte.",
+      "fun_fact_es": "Artista indie-pop catalana que se hizo viral con esta canción sobre querer escribir un hit que, irónicamente, se convirtió en uno.",
+      "fun_fact_fr": "Artiste indie-pop catalane devenue virale avec ce titre autoréférentiel sur l'envie d'écrire un tube — qui en est ironiquement devenu un.",
+      "uri_apple_music": "applemusic://track/1804701192",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=_I9Qpoi4yMQ",
+      "uri_tidal": "tidal://track/420279040"
+    },
+    {
+      "year": 1982,
+      "uri": "spotify:track:05fIQPYkn7kNqSPu2q9s1Q",
+      "artist": "Al Bano And Romina Power",
+      "alt_artists": [
+        "Ricchi e Poveri",
+        "Umberto Tozzi",
+        "Toto Cutugno",
+        "Raffaella Carrà"
+      ],
+      "title": "Felicidad",
+      "chart_info": {
+        "billboard_peak": null,
+        "uk_peak": null,
+        "weeks_on_chart": null
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "Italy's golden couple of pop (married 1970-1999). 'Felicidad' became the unofficial anthem of Spanish summer holidays in the 80s.",
+      "fun_fact_de": "Italiens goldenes Pop-Paar (1970-1999 verheiratet). 'Felicidad' wurde zur inoffiziellen Hymne spanischer Sommerferien der 80er.",
+      "fun_fact_es": "La pareja dorada del pop italiano (casados 1970-1999). 'Felicidad' se convirtió en himno oficioso de las vacaciones españolas de los 80.",
+      "fun_fact_fr": "Le couple en or du pop italien (mariés 1970-1999). 'Felicidad' est devenu l'hymne officieux des vacances d'été espagnoles des années 80.",
+      "uri_apple_music": "applemusic://track/1726909970",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=LAt_Ccb2bJI",
+      "uri_tidal": "tidal://track/519816"
+    },
+    {
+      "year": 1981,
+      "uri": "spotify:track:0loxOLrtuQBxkqdoTKTIj2",
+      "artist": "Manzanita",
+      "alt_artists": [
+        "Peret",
+        "Ketama",
+        "Los Chichos",
+        "Raimundo Amador"
+      ],
+      "title": "La Quiero A Morir",
+      "chart_info": {
+        "billboard_peak": null,
+        "uk_peak": null,
+        "weeks_on_chart": null
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "A Spanish flamenco-rumba cover of Francis Cabrel's 'Je l'aime à mourir' that became even more famous in Spain than the French original.",
+      "fun_fact_de": "Ein Flamenco-Rumba-Cover von Francis Cabrels 'Je l'aime à mourir', das in Spanien berühmter wurde als das französische Original.",
+      "fun_fact_es": "Versión flamenca de 'Je l'aime à mourir' de Francis Cabrel que se hizo más famosa en España que el original francés.",
+      "fun_fact_fr": "Reprise flamenco-rumba de 'Je l'aime à mourir' de Francis Cabrel, devenue plus célèbre en Espagne que l'original.",
+      "uri_apple_music": "applemusic://track/505148565",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=hHNGcwq3ml4",
+      "uri_tidal": "tidal://track/10912456"
+    },
+    {
+      "year": 2002,
+      "uri": "spotify:track:4twEyA6ivTMkCChphUztxX",
+      "artist": "Bustamante",
+      "alt_artists": [
+        "David Bisbal",
+        "Chenoa",
+        "Rosa López",
+        "Manuel Carrasco"
+      ],
+      "title": "Feliz",
+      "chart_info": {
+        "billboard_peak": null,
+        "uk_peak": null,
+        "weeks_on_chart": null
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "Rose to fame on 'Operación Triunfo' season 1 (2001), the most-watched TV show in Spanish history with 12+ million viewers at the finale.",
+      "fun_fact_de": "Wurde durch 'Operación Triunfo' Staffel 1 (2001) berühmt — die meistgesehene TV-Show der spanischen Geschichte.",
+      "fun_fact_es": "Saltó a la fama en 'Operación Triunfo' 1 (2001), el programa más visto de la historia de la TV española.",
+      "fun_fact_fr": "Devenu célèbre grâce à 'Operación Triunfo' saison 1 (2001), l'émission la plus regardée de l'histoire de la TV espagnole.",
+      "uri_apple_music": "applemusic://track/1443557151",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=WUXjoTtiSXg",
+      "uri_tidal": "tidal://track/34192115"
+    },
+    {
+      "year": 2021,
+      "uri": "spotify:track:5iF33sXejXwfTuidVHMll0",
+      "artist": "Carlos Vives, Ricky Martin",
+      "alt_artists": [
+        "Juanes",
+        "Alejandro Sanz",
+        "Maluma",
+        "Marc Anthony"
+      ],
+      "title": "Canción Bonita",
+      "chart_info": {
+        "billboard_peak": null,
+        "uk_peak": null,
+        "weeks_on_chart": null
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "A collaboration uniting Colombia's Vives with Puerto Rico's Ricky Martin — two Latin legends with 70+ combined years of career. A love letter to positivity during the pandemic.",
+      "fun_fact_de": "Vereinte Kolumbiens Vives mit Puerto Ricos Ricky Martin — zwei Legenden mit über 70 Jahren Karriere. Eine Liebeserklärung an die Positivität während der Pandemie.",
+      "fun_fact_es": "Unió al colombiano Vives con el puertorriqueño Ricky Martin — dos leyendas con más de 70 años de carrera combinados. Canto a la positividad durante la pandemia.",
+      "fun_fact_fr": "A réuni le Colombien Vives et le Portoricain Ricky Martin — deux légendes totalisant 70+ ans de carrière. Un hymne à la positivité pendant la pandémie.",
+      "uri_apple_music": "applemusic://track/1562714028",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=KIBeny5wq6M",
+      "uri_tidal": "tidal://track/179661758"
+    },
+    {
+      "year": 1981,
+      "uri": "spotify:track:04Xdk7F9HgyHBcAwO7KE3F",
+      "artist": "Ricchi E Poveri",
+      "alt_artists": [
+        "Al Bano And Romina Power",
+        "Umberto Tozzi",
+        "Toto Cutugno"
+      ],
+      "title": "Sera Porque Te Amo",
+      "chart_info": {
+        "billboard_peak": null,
+        "uk_peak": null,
+        "weeks_on_chart": null
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "Originally 'Sarà perché ti amo' in Italian, the Spanish version became a staple at Spanish weddings and verbenas for decades.",
+      "fun_fact_de": "Die spanische Version von 'Sarà perché ti amo' wurde jahrzehntelang zum Dauerbrenner auf spanischen Hochzeiten und Festen.",
+      "fun_fact_es": "La versión española de 'Sarà perché ti amo' lleva décadas siendo imprescindible en bodas y verbenas españolas.",
+      "fun_fact_fr": "La version espagnole de 'Sarà perché ti amo' est un incontournable des mariages et fêtes espagnoles depuis des décennies.",
+      "uri_apple_music": "applemusic://track/353035476",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=f37dgOF3I6o",
+      "uri_tidal": "tidal://track/20153650"
+    },
+    {
+      "year": 2022,
+      "uri": "spotify:track:5ww2BF9slyYgNOk37BlC4u",
+      "artist": "Manuel Turizo",
+      "alt_artists": [
+        "Romeo Santos",
+        "Prince Royce",
+        "Aventura",
+        "Ozuna"
+      ],
+      "title": "La Bachata",
+      "chart_info": {
+        "billboard_peak": null,
+        "uk_peak": null,
+        "weeks_on_chart": null
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "Despite its title, not traditional bachata but pop-urbano. Became the most-streamed Spanish-language song on Spotify in 2022 with 2+ billion streams.",
+      "fun_fact_de": "Trotz des Titels keine traditionelle Bachata, sondern Pop-Urbano. Meistgestreamter spanischsprachiger Song auf Spotify 2022 mit über 2 Milliarden Streams.",
+      "fun_fact_es": "A pesar del título, no es bachata tradicional sino pop urbano. Canción más reproducida en español en Spotify en 2022 con más de 2 mil millones de reproducciones.",
+      "fun_fact_fr": "Malgré son titre, pas de la bachata traditionnelle mais du pop-urbano. Chanson hispanophone la plus streamée sur Spotify en 2022 avec 2+ milliards d'écoutes.",
+      "uri_apple_music": "applemusic://track/1624563284",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=2w_nFl_87Sw",
+      "uri_tidal": "tidal://track/229552658"
+    },
+    {
+      "year": 2023,
+      "uri": "spotify:track:0Fd3900xH77g0ARXQjtYvV",
+      "artist": "DePol",
+      "alt_artists": [
+        "Beret",
+        "Pablo Alborán",
+        "Manuel Carrasco",
+        "Álvaro de Luna"
+      ],
+      "title": "Quién Diría",
+      "chart_info": {
+        "billboard_peak": null,
+        "uk_peak": null,
+        "weeks_on_chart": null
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "Went viral on TikTok — became one of Spain's biggest hits of 2023 despite DePol being virtually unknown months before release.",
+      "fun_fact_de": "Ging auf TikTok viral — wurde 2023 einer der größten Hits Spaniens, obwohl DePol Monate zuvor noch unbekannt war.",
+      "fun_fact_es": "Se hizo viral en TikTok — uno de los mayores éxitos de España en 2023 a pesar de ser desconocido meses antes.",
+      "fun_fact_fr": "Devenu viral sur TikTok — l'un des plus grands succès espagnols de 2023 alors que DePol était quasi inconnu quelques mois avant.",
+      "uri_apple_music": "applemusic://track/1619110608",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=PE7gYNK8gQg",
+      "uri_tidal": "tidal://track/421676922"
+    },
+    {
+      "year": 2004,
+      "uri": "spotify:track:2s7WJ9IRON5zalNbfFY1xa",
+      "artist": "David Bisbal",
+      "alt_artists": [
+        "Bustamante",
+        "Manuel Carrasco",
+        "Pablo Alborán",
+        "Antonio Orozco"
+      ],
+      "title": "Bulería",
+      "chart_info": {
+        "billboard_peak": null,
+        "uk_peak": null,
+        "weeks_on_chart": null
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "Operación Triunfo alumnus from Almería fused flamenco with pop. The title refers to bulería, the fastest and most passionate form of flamenco.",
+      "fun_fact_de": "OT-Absolvent aus Almería verschmolz Flamenco mit Pop. Der Titel bezieht sich auf Bulería, die schnellste und leidenschaftlichste Flamenco-Form.",
+      "fun_fact_es": "Ex alumno de OT de Almería que fusionó flamenco con pop. El título se refiere a la bulería, el palo más rápido y apasionado del flamenco.",
+      "fun_fact_fr": "Ancien d'OT originaire d'Almería, il a fusionné flamenco et pop. Le titre fait référence à la bulería, la forme la plus rapide du flamenco.",
+      "uri_apple_music": "applemusic://track/1443232792",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=vUqYEh5gJ_c",
+      "uri_tidal": "tidal://track/4019496"
+    },
+    {
+      "year": 2007,
+      "uri": "spotify:track:1NxFzOsXF3DXLH1xyon6vH",
+      "artist": "El Barrio",
+      "alt_artists": [
+        "Melendi",
+        "El Kanka",
+        "Estopa",
+        "Rosario"
+      ],
+      "title": "Quiereme",
+      "chart_info": {
+        "billboard_peak": null,
+        "uk_peak": null,
+        "weeks_on_chart": null
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "El Barrio from Cádiz pioneered a unique blend of flamenco, copla and pop — filling stadiums in Spain while remaining virtually unknown internationally.",
+      "fun_fact_de": "El Barrio aus Cádiz schuf eine einzigartige Mischung aus Flamenco, Copla und Pop — füllt Stadien in Spanien, international aber unbekannt.",
+      "fun_fact_es": "El Barrio, de Cádiz, creó una fusión única de flamenco, copla y pop — llena estadios en España pero es desconocido internacionalmente.",
+      "fun_fact_fr": "El Barrio, de Cadix, a créé un mélange unique de flamenco, copla et pop — remplit les stades en Espagne mais reste inconnu à l'international.",
+      "uri_apple_music": "applemusic://track/603228048",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=cxZGge2KKnY",
+      "uri_tidal": "tidal://track/31852101"
+    },
+    {
+      "year": 1997,
+      "uri": "spotify:track:6D3YqQ9dUA9LBOLw4CEUj1",
+      "artist": "Los Piratas",
+      "alt_artists": [
+        "Los Planetas",
+        "Australian Blonde",
+        "Dover",
+        "Extremoduro"
+      ],
+      "title": "Promesas que no valen nada",
+      "chart_info": {
+        "billboard_peak": null,
+        "uk_peak": null,
+        "weeks_on_chart": null
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "Los Piratas from Vigo were key figures in Spanish 90s indie rock. This was their crossover hit that brought alternative Spanish rock to mainstream radio.",
+      "fun_fact_de": "Los Piratas aus Vigo waren Schlüsselfiguren des spanischen 90er-Indie-Rock. Ihr Crossover-Hit brachte alternativen Rock ins Mainstream-Radio.",
+      "fun_fact_es": "Los Piratas de Vigo fueron figuras clave del indie rock español de los 90. Su éxito crossover que llevó el rock alternativo a la radio comercial.",
+      "fun_fact_fr": "Los Piratas de Vigo furent des figures clés du rock indie espagnol des années 90. Leur tube crossover qui a amené le rock alternatif sur les radios commerciales.",
+      "uri_apple_music": "applemusic://track/1268518529",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=hptUE57xH74",
+      "uri_tidal": "tidal://track/77145447"
+    },
+    {
+      "year": 1974,
+      "uri": "spotify:track:37f6dBsGwi5V9OOXI1KYe7",
+      "artist": "Las Grecas",
+      "alt_artists": [
+        "Los Chichos",
+        "Los Chunguitos",
+        "Lole y Manuel"
+      ],
+      "title": "Te Estoy Amando Locamente",
+      "chart_info": {
+        "billboard_peak": null,
+        "uk_peak": null,
+        "weeks_on_chart": null
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "Las Grecas were two Romani sisters from Madrid who fused flamenco with psychedelic rock in the 70s — decades ahead of their time. This was a #1 hit in Spain.",
+      "fun_fact_de": "Las Grecas waren zwei Roma-Schwestern aus Madrid, die in den 70ern Flamenco mit psychedelischem Rock verschmolzen — ihrer Zeit um Jahrzehnte voraus.",
+      "fun_fact_es": "Las Grecas eran dos hermanas gitanas de Madrid que fusionaron flamenco con rock psicodélico en los 70 — décadas adelantadas a su tiempo.",
+      "fun_fact_fr": "Las Grecas étaient deux sœurs gitanes de Madrid qui ont fusionné flamenco et rock psychédélique dans les années 70 — des décennies en avance.",
+      "uri_apple_music": "applemusic://track/1049532476",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=jmb3INqJq_Y",
+      "uri_tidal": "tidal://track/652183"
+    },
+    {
+      "year": 1981,
+      "uri": "spotify:track:5QfmCmdL4qnzqMz5Z0gvzV",
+      "artist": "Raffaella Carrà",
+      "alt_artists": [
+        "Al Bano And Romina Power",
+        "Ricchi e Poveri",
+        "Umberto Tozzi"
+      ],
+      "title": "Caliente, caliente",
+      "chart_info": {
+        "billboard_peak": null,
+        "uk_peak": null,
+        "weeks_on_chart": null
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "Italian queen of European pop TV who became a cultural icon in Spain. Her songs and dance moves defined an era of television entertainment across Southern Europe.",
+      "fun_fact_de": "Italienische Königin des europäischen Pop-TV, die in Spanien zur Kulturikone wurde. Ihre Songs und Tänze prägten eine Ära der TV-Unterhaltung.",
+      "fun_fact_es": "Reina italiana de la TV pop europea que se convirtió en icono cultural en España. Sus canciones y bailes definieron una era del entretenimiento televisivo.",
+      "fun_fact_fr": "Reine italienne de la TV pop européenne devenue icône culturelle en Espagne. Ses chansons et danses ont défini une ère du divertissement télévisé.",
+      "uri_apple_music": "applemusic://track/714544662",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=l3FrBFhZg28",
+      "uri_tidal": "tidal://track/3278048"
+    },
+    {
+      "year": 1967,
+      "uri": "spotify:track:59ZWNHCFaMoM1wOTlZ0E0k",
+      "artist": "Celia Cruz",
+      "alt_artists": [
+        "Tito Puente",
+        "Oscar D'León",
+        "La Lupe",
+        "Compay Segundo"
+      ],
+      "title": "Cuando Salí De Cuba",
+      "chart_info": {
+        "billboard_peak": null,
+        "uk_peak": null,
+        "weeks_on_chart": null
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "The 'Queen of Salsa' left Cuba in 1960 and never returned. This deeply personal song about exile became an anthem for the Cuban diaspora worldwide.",
+      "fun_fact_de": "Die 'Königin der Salsa' verließ Kuba 1960 und kehrte nie zurück. Dieser zutiefst persönliche Song über das Exil wurde zur Hymne der kubanischen Diaspora.",
+      "fun_fact_es": "La 'Reina de la Salsa' dejó Cuba en 1960 y nunca volvió. Esta canción profundamente personal sobre el exilio se convirtió en himno de la diáspora cubana.",
+      "fun_fact_fr": "La 'Reine de la Salsa' a quitté Cuba en 1960 sans jamais y retourner. Cette chanson sur l'exil est devenue l'hymne de la diaspora cubaine.",
+      "uri_apple_music": "applemusic://track/1464290953",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=usJVkRpLTvM",
+      "uri_tidal": "tidal://track/110223084"
+    },
+    {
+      "year": 1947,
+      "uri": "spotify:track:0lJ5GhkXTeVU4RVS81wgn4",
+      "artist": "Antonio Machín",
+      "alt_artists": [
+        "Beny Moré",
+        "Compay Segundo",
+        "Nat King Cole"
+      ],
+      "title": "Toda una Vida",
+      "chart_info": {
+        "billboard_peak": null,
+        "uk_peak": null,
+        "weeks_on_chart": null
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "Cuban-born Machín settled in Spain in 1939 and became one of the most popular singers in the country. 'Toda una Vida' remains one of the most-played boleros at Spanish celebrations.",
+      "fun_fact_de": "Der auf Kuba geborene Machín ließ sich 1939 in Spanien nieder und wurde einer der beliebtesten Sänger des Landes.",
+      "fun_fact_es": "Machín, nacido en Cuba, se estableció en España en 1939 y se convirtió en uno de los cantantes más populares del país.",
+      "fun_fact_fr": "Né à Cuba, Machín s'est installé en Espagne en 1939 et est devenu l'un des chanteurs les plus populaires du pays.",
+      "uri_apple_music": "applemusic://track/950732841",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=isKqhA76QTk",
+      "uri_tidal": "tidal://track/207189021"
+    },
+    {
+      "year": 1953,
+      "uri": "spotify:track:1JG27QjSUOvSnwkjqhTXMi",
+      "artist": "Beny Moré",
+      "alt_artists": [
+        "Compay Segundo",
+        "Antonio Machín",
+        "Celia Cruz",
+        "Tito Puente"
+      ],
+      "title": "Bonito y sabroso",
+      "chart_info": {
+        "billboard_peak": null,
+        "uk_peak": null,
+        "weeks_on_chart": null
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "Known as 'El Bárbaro del Ritmo', Beny Moré is considered the greatest Cuban musician of all time. He never learned to read music but could conduct a full orchestra by ear.",
+      "fun_fact_de": "Bekannt als 'El Bárbaro del Ritmo', gilt Beny Moré als größter kubanischer Musiker aller Zeiten. Er konnte keine Noten lesen, dirigierte aber ein ganzes Orchester nach Gehör.",
+      "fun_fact_es": "Conocido como 'El Bárbaro del Ritmo', Beny Moré es considerado el mayor músico cubano de la historia. Nunca aprendió a leer música pero dirigía una orquesta completa de oído.",
+      "fun_fact_fr": "Surnommé 'El Bárbaro del Ritmo', Beny Moré est considéré comme le plus grand musicien cubain. Il n'a jamais appris à lire la musique mais dirigeait un orchestre entier à l'oreille.",
+      "uri_apple_music": "applemusic://track/288069714",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=HhX5D50Ixqg",
+      "uri_tidal": "tidal://track/61597550"
+    },
+    {
+      "year": 1982,
+      "uri": "spotify:track:5iCaLR191eAHNxxlfKzK9f",
+      "artist": "María Jiménez",
+      "alt_artists": [
+        "Rocío Jurado",
+        "Lola Flores",
+        "Isabel Pantoja"
+      ],
+      "title": "Se acabó",
+      "chart_info": {
+        "billboard_peak": null,
+        "uk_peak": null,
+        "weeks_on_chart": null
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "María Jiménez was one of Spain's most passionate copla and pop singers, known for her powerful voice and dramatic stage presence rivaling Rocío Jurado.",
+      "fun_fact_de": "María Jiménez war eine der leidenschaftlichsten Copla- und Pop-Sängerinnen Spaniens mit einer dramatischen Bühnenpräsenz.",
+      "fun_fact_es": "María Jiménez fue una de las cantantes de copla y pop más apasionadas de España, con una presencia escénica dramática.",
+      "fun_fact_fr": "María Jiménez fut l'une des chanteuses de copla et pop les plus passionnées d'Espagne, avec une présence scénique dramatique.",
+      "uri_apple_music": "applemusic://track/154692713",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=4H-HdXzZgOA",
+      "uri_tidal": "tidal://track/35613298"
+    },
+    {
+      "year": 1977,
+      "uri": "spotify:track:7pIfwKV8EOPmJlConSHk2E",
+      "artist": "Miguel Bosé",
+      "alt_artists": [
+        "Raphael",
+        "Julio Iglesias",
+        "Camilo Sesto",
+        "Nino Bravo"
+      ],
+      "title": "Súper Supermán",
+      "chart_info": {
+        "billboard_peak": null,
+        "uk_peak": null,
+        "weeks_on_chart": null
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "Son of bullfighter Luis Miguel Dominguín and Italian actress Lucia Bosè. Miguel Bosé transcended Spanish pop to become a bilingual icon across Latin America and Europe.",
+      "fun_fact_de": "Sohn des Stierkämpfers Luis Miguel Dominguín und der italienischen Schauspielerin Lucia Bosè. Wurde zum zweisprachigen Pop-Icon in Lateinamerika und Europa.",
+      "fun_fact_es": "Hijo del torero Luis Miguel Dominguín y la actriz italiana Lucia Bosè. Trascendió el pop español para convertirse en icono bilingüe en Latinoamérica y Europa.",
+      "fun_fact_fr": "Fils du torero Luis Miguel Dominguín et de l'actrice italienne Lucia Bosè. A transcendé la pop espagnole pour devenir une icône bilingue en Amérique latine et Europe.",
+      "uri_apple_music": "applemusic://track/281268432",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=PJ92wvhp8y0",
+      "uri_tidal": "tidal://track/1839746"
+    },
+    {
+      "year": 1981,
+      "uri": "spotify:track:6nO69NbcCDLdSrVuml0Vb4",
+      "artist": "Julio Iglesias",
+      "alt_artists": [
+        "Miguel Bosé",
+        "Camilo Sesto",
+        "Raphael",
+        "José Luis Perales"
+      ],
+      "title": "Hey",
+      "chart_info": {
+        "billboard_peak": null,
+        "uk_peak": null,
+        "weeks_on_chart": null
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "Julio Iglesias holds a Guinness World Record as the best-selling Latin artist of all time with 300+ million records sold. He was also a professional footballer for Real Madrid's youth team before a car crash changed his path.",
+      "fun_fact_de": "Julio Iglesias hält den Guinness-Rekord als meistverkaufter Latin-Künstler mit über 300 Millionen Platten. Zuvor spielte er in Real Madrids Jugend.",
+      "fun_fact_es": "Julio Iglesias tiene el récord Guinness como artista latino más vendido con más de 300 millones de discos. Antes jugó en la cantera del Real Madrid.",
+      "fun_fact_fr": "Julio Iglesias détient le record Guinness d'artiste latin le plus vendu avec 300+ millions de disques. Il jouait au Real Madrid avant un accident.",
+      "uri_apple_music": "applemusic://track/250996960",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=F2vT9VyXOks",
+      "uri_tidal": "tidal://track/26905983"
+    },
+    {
+      "year": 1986,
+      "uri": "spotify:track:5BtNKZScq7gRDbcJ2FhIQb",
+      "artist": "Hombres G",
+      "alt_artists": [
+        "Los Nikis",
+        "Loquillo",
+        "Radio Futura",
+        "Alaska y Dinarama"
+      ],
+      "title": "El ataque de las chicas cocodrilo",
+      "chart_info": {
+        "billboard_peak": null,
+        "uk_peak": null,
+        "weeks_on_chart": null
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "Hombres G were Spain's answer to the British new wave movement. Led by David Summers (son of a famous guitarist), they filled stadiums with their catchy pop-rock and humorous lyrics.",
+      "fun_fact_de": "Hombres G waren Spaniens Antwort auf die britische New-Wave-Bewegung. Mit ihrem eingängigen Pop-Rock und humorvollen Texten füllten sie Stadien.",
+      "fun_fact_es": "Hombres G fueron la respuesta española al movimiento new wave británico. Con su pop-rock pegadizo y letras humorísticas llenaron estadios.",
+      "fun_fact_fr": "Hombres G furent la réponse espagnole au mouvement new wave britannique, remplissant les stades avec leur pop-rock accrocheur.",
+      "uri_apple_music": "applemusic://track/42231524",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=ET8Atukjvzk",
+      "uri_tidal": "tidal://track/323686"
+    },
+    {
+      "year": 2012,
+      "uri": "spotify:track:3quyxN3SapEsojxk1Uw10K",
+      "artist": "Conchita",
+      "alt_artists": [
+        "Aitana",
+        "Zahara",
+        "Rozalén",
+        "La Bien Querida"
+      ],
+      "title": "Puede Ser",
+      "chart_info": {
+        "billboard_peak": null,
+        "uk_peak": null,
+        "weeks_on_chart": null
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "Conchita (from OT 2007) crafted a unique indie-pop sound distinct from typical OT alumni, earning critical acclaim and a loyal cult following in Spain.",
+      "fun_fact_de": "Conchita (von OT 2007) schuf einen einzigartigen Indie-Pop-Sound, der sich von typischen OT-Absolventen abhob.",
+      "fun_fact_es": "Conchita (de OT 2007) creó un sonido indie-pop único diferente de los típicos ex OT, ganándose una fiel base de seguidores.",
+      "fun_fact_fr": "Conchita (d'OT 2007) a créé un son indie-pop unique, se démarquant des anciens d'OT typiques.",
+      "uri_apple_music": "applemusic://track/1523866781",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=SoDgagIYxC0",
+      "uri_tidal": "tidal://track/417266330"
+    },
+    {
+      "year": 1989,
+      "uri": "spotify:track:2wXyF3apEwRcwBMJkndksV",
+      "artist": "José Luis Perales",
+      "alt_artists": [
+        "Julio Iglesias",
+        "Camilo Sesto",
+        "Raphael",
+        "Nino Bravo"
+      ],
+      "title": "Me Llamas",
+      "chart_info": {
+        "billboard_peak": null,
+        "uk_peak": null,
+        "weeks_on_chart": null
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "One of Spain's most prolific songwriters with 700+ compositions. Perales wrote hits for Julio Iglesias and Rocío Dúrcal while maintaining his own hugely successful career.",
+      "fun_fact_de": "Einer der produktivsten Songwriter Spaniens mit über 700 Kompositionen. Schrieb Hits für Julio Iglesias und Rocío Dúrcal.",
+      "fun_fact_es": "Uno de los compositores más prolíficos de España con más de 700 composiciones. Escribió éxitos para Julio Iglesias y Rocío Dúrcal.",
+      "fun_fact_fr": "L'un des compositeurs les plus prolifiques d'Espagne avec 700+ compositions. A écrit des tubes pour Julio Iglesias et Rocío Dúrcal.",
+      "uri_apple_music": "applemusic://track/1259333866",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=HThwascSkzA",
+      "uri_tidal": "tidal://track/63615562"
+    },
+    {
+      "year": 1984,
+      "uri": "spotify:track:0WFatRyMXS4JVP9jSfO1Fe",
+      "artist": "Golpes Bajos",
+      "alt_artists": [
+        "Siniestro Total",
+        "Radio Futura",
+        "Gabinete Caligari",
+        "Nacha Pop"
+      ],
+      "title": "Malos Tiempos para la Lírica",
+      "chart_info": {
+        "billboard_peak": null,
+        "uk_peak": null,
+        "weeks_on_chart": null
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "One of the defining songs of 'La Movida Madrileña', Spain's explosive cultural movement after Franco's death. Golpes Bajos from Vigo brought Galician art-rock to the national stage.",
+      "fun_fact_de": "Einer der prägenden Songs der 'Movida Madrileña', Spaniens explosiver Kulturbewegung nach Francos Tod.",
+      "fun_fact_es": "Una de las canciones definitorias de La Movida Madrileña, el explosivo movimiento cultural español tras la muerte de Franco.",
+      "fun_fact_fr": "L'une des chansons phares de 'La Movida Madrileña', le mouvement culturel explosif espagnol après la mort de Franco.",
+      "uri_apple_music": "applemusic://track/873529482",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=xAYUO0QeqUk",
+      "uri_tidal": "tidal://track/29385967"
+    },
+    {
+      "year": 2004,
+      "uri": "spotify:track:30e3XyWpvUbKmHbLcRlsMt",
+      "artist": "Bebe",
+      "alt_artists": [
+        "Rosana",
+        "Luz Casal",
+        "Malú",
+        "Bebe"
+      ],
+      "title": "Siempre me quedará",
+      "chart_info": {
+        "billboard_peak": null,
+        "uk_peak": null,
+        "weeks_on_chart": null
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "Bebe (María Nieves Rebolledo) from Extremadura won a Latin Grammy for this track. Her raw, raspy voice and socially conscious lyrics made her a voice of her generation.",
+      "fun_fact_de": "Bebe aus Extremadura gewann einen Latin Grammy für diesen Track. Ihre raue Stimme und sozialkritischen Texte machten sie zur Stimme ihrer Generation.",
+      "fun_fact_es": "Bebe, de Extremadura, ganó un Latin Grammy por este tema. Su voz rasgada y letras de conciencia social la convirtieron en voz de su generación.",
+      "fun_fact_fr": "Bebe, d'Estrémadure, a remporté un Latin Grammy pour ce titre. Sa voix rauque et ses textes engagés en ont fait la voix de sa génération.",
+      "uri_apple_music": "applemusic://track/696023777",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=QsjAgjbMVWA",
+      "uri_tidal": "tidal://track/147679"
+    },
+    {
+      "year": 2015,
+      "uri": "spotify:track:3iHJm7dUroZYvbqrhobLZs",
+      "artist": "Joey Montana",
+      "alt_artists": [
+        "J Balvin",
+        "Maluma",
+        "Nicky Jam",
+        "Daddy Yankee"
+      ],
+      "title": "Picky",
+      "chart_info": {
+        "billboard_peak": null,
+        "uk_peak": null,
+        "weeks_on_chart": null
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "Panamanian reggaeton artist whose 'Picky' became an inescapable summer hit across Latin America and Spain, with a dance challenge that went viral before TikTok existed.",
+      "fun_fact_de": "Panamaischer Reggaeton-Künstler, dessen 'Picky' zum unausweichlichen Sommerhit in Lateinamerika und Spanien wurde.",
+      "fun_fact_es": "Artista panameño de reggaeton cuyo 'Picky' se convirtió en hit veraniego inevitable en Latinoamérica y España.",
+      "fun_fact_fr": "Artiste panaméen de reggaeton dont 'Picky' est devenu un tube estival incontournable en Amérique latine et Espagne.",
+      "uri_apple_music": "applemusic://track/1444616864",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=RqpKDkVzlqU",
+      "uri_tidal": "tidal://track/46785817"
+    },
+    {
+      "year": 2022,
+      "uri": "spotify:track:4tPL9PeVZY4c0jUPtSD5nx",
+      "artist": "ROSALÍA",
+      "alt_artists": [
+        "C. Tangana",
+        "Bad Gyal",
+        "Arca",
+        "Ms Nina"
+      ],
+      "title": "SAOKO",
+      "chart_info": {
+        "billboard_peak": null,
+        "uk_peak": null,
+        "weeks_on_chart": null
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "ROSALÍA from Barcelona revolutionized Spanish music by fusing flamenco with electronic and urban sounds. Her album 'Motomami' won Album of the Year at the 2023 Latin Grammys.",
+      "fun_fact_de": "ROSALÍA aus Barcelona revolutionierte die spanische Musik durch die Fusion von Flamenco mit elektronischen und urbanen Sounds.",
+      "fun_fact_es": "ROSALÍA de Barcelona revolucionó la música española fusionando flamenco con sonidos electrónicos y urbanos. 'Motomami' ganó Álbum del Año en los Latin Grammy 2023.",
+      "fun_fact_fr": "ROSALÍA de Barcelone a révolutionné la musique espagnole en fusionnant flamenco et sons électroniques/urbains. 'Motomami' a gagné l'Album de l'Année aux Latin Grammys 2023.",
+      "uri_apple_music": "applemusic://track/1654013499",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=ApNQX6fVWQ4",
+      "uri_tidal": "tidal://track/220809480"
+    },
+    {
+      "year": 2021,
+      "uri": "spotify:track:2FYGZDfsAnNsrm1gVbyKnG",
+      "artist": "Camilo",
+      "alt_artists": [
+        "Sebastián Yatra",
+        "Manuel Turizo",
+        "Maluma",
+        "Carlos Vives"
+      ],
+      "title": "KESI",
+      "chart_info": {
+        "billboard_peak": null,
+        "uk_peak": null,
+        "weeks_on_chart": null
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "Colombian Camilo Echeverry went from 'Factor X' contestant to global star. Married to Evaluna Montaner (daughter of Ricardo Montaner), their love story drives much of his music.",
+      "fun_fact_de": "Kolumbianer Camilo Echeverry wurde vom 'Factor X'-Teilnehmer zum Weltstar. Mit Evaluna Montaner verheiratet, inspiriert ihre Liebesgeschichte seine Musik.",
+      "fun_fact_es": "El colombiano Camilo Echeverry pasó de concursante de 'Factor X' a estrella global. Casado con Evaluna Montaner, su historia de amor inspira su música.",
+      "fun_fact_fr": "Le Colombien Camilo Echeverry est passé de candidat de 'Factor X' à star mondiale. Marié à Evaluna Montaner, leur histoire d'amour inspire sa musique.",
+      "uri_apple_music": "applemusic://track/1554206953",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=ZrUrwUwSHR0",
+      "uri_tidal": "tidal://track/175456722"
+    },
+    {
+      "year": 2022,
+      "uri": "spotify:track:42lpuSQmnLUM1ZXJVzIVOi",
+      "artist": "Lola Indigo, Manuel Turizo",
+      "alt_artists": [
+        "Aitana",
+        "Ana Mena",
+        "Bad Gyal",
+        "Becky G"
+      ],
+      "title": "1000COSAS",
+      "chart_info": {
+        "billboard_peak": null,
+        "uk_peak": null,
+        "weeks_on_chart": null
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "Lola Indigo (Mimi Doblas) finished second on OT 2017 but became arguably its biggest success — reinventing herself as Spain's leading urban-pop artist.",
+      "fun_fact_de": "Lola Indigo (Mimi Doblas) wurde Zweite bei OT 2017, aber wohl der größte Erfolg der Staffel — als Spaniens führende Urban-Pop-Künstlerin.",
+      "fun_fact_es": "Lola Indigo (Mimi Doblas) quedó segunda en OT 2017 pero se convirtió en su mayor éxito, reinventándose como artista urban-pop líder de España.",
+      "fun_fact_fr": "Lola Indigo (Mimi Doblas), deuxième d'OT 2017, est devenue son plus grand succès en se réinventant en artiste urban-pop leader d'Espagne.",
+      "uri_apple_music": "applemusic://track/1732994567",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=QdCTs5HZfhU",
+      "uri_tidal": "tidal://track/348323227"
+    },
+    {
+      "year": 1975,
+      "uri": "spotify:track:6xqQDwzjswlToEEHgvA3KM",
+      "artist": "Luis Eduardo Aute",
+      "alt_artists": [
+        "Joan Manuel Serrat",
+        "Joaquín Sabina",
+        "Patxi Andion",
+        "Silvio Rodríguez"
+      ],
+      "title": "Pasaba por Aqui",
+      "chart_info": {
+        "billboard_peak": null,
+        "uk_peak": null,
+        "weeks_on_chart": null
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "Aute was a Renaissance man — singer-songwriter, painter, sculptor, and filmmaker. He was one of Spain's most intellectual and poetic voices in popular music.",
+      "fun_fact_de": "Aute war ein Renaissancemensch — Liedermacher, Maler, Bildhauer und Filmemacher. Eine der intellektuellsten Stimmen der spanischen Musik.",
+      "fun_fact_es": "Aute fue un hombre del Renacimiento — cantautor, pintor, escultor y cineasta. Una de las voces más intelectuales y poéticas de la música popular española.",
+      "fun_fact_fr": "Aute était un homme de la Renaissance — auteur-compositeur, peintre, sculpteur et cinéaste. L'une des voix les plus intellectuelles de la musique populaire espagnole.",
+      "uri_apple_music": "applemusic://track/286589993",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=7gMQdACCRl4",
+      "uri_tidal": "tidal://track/2862037"
+    },
+    {
+      "year": 1984,
+      "uri": "spotify:track:6XhZIUzlCGABARgSgZby2v",
+      "artist": "Joaquín Sabina",
+      "alt_artists": [
+        "Luis Eduardo Aute",
+        "Joan Manuel Serrat",
+        "Alejandro Sanz",
+        "Andrés Calamaro"
+      ],
+      "title": "Por el Bulevar de los Sueños Rotos",
+      "chart_info": {
+        "billboard_peak": null,
+        "uk_peak": null,
+        "weeks_on_chart": null
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "Spain's greatest living songwriter — a chain-smoking bohemian poet who lived in exile in London during the Franco era and whose lyrics are studied in Spanish literature courses.",
+      "fun_fact_de": "Spaniens größter lebender Songwriter — ein kettenrauchender Bohème-Poet, der während der Franco-Ära im Londoner Exil lebte.",
+      "fun_fact_es": "El mayor compositor vivo de España — poeta bohemio que vivió exiliado en Londres durante el franquismo y cuyas letras se estudian en clases de literatura.",
+      "fun_fact_fr": "Le plus grand auteur-compositeur vivant d'Espagne — poète bohème exilé à Londres sous Franco, dont les textes sont étudiés en littérature.",
+      "uri_apple_music": "applemusic://track/1478351808",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=fyWjmlMK8Qg",
+      "uri_tidal": "tidal://track/30216368"
+    },
+    {
+      "year": 1988,
+      "uri": "spotify:track:7KcFlbQmzhVczGMor3Fhr9",
+      "artist": "Maria Del Monte",
+      "alt_artists": [
+        "Isabel Pantoja",
+        "Rocío Jurado",
+        "Lola Flores",
+        "Pastora Soler"
+      ],
+      "title": "Cántame",
+      "chart_info": {
+        "billboard_peak": null,
+        "uk_peak": null,
+        "weeks_on_chart": null
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "María del Monte shot to fame singing this at the 1988 Seville Spring Fair. She became one of Spain's most beloved sevillanas singers and a fixture of Andalusian culture.",
+      "fun_fact_de": "María del Monte wurde 1988 auf der Feria de Sevilla berühmt. Sie wurde zu einer der beliebtesten Sevillanas-Sängerinnen Spaniens.",
+      "fun_fact_es": "María del Monte saltó a la fama cantando esto en la Feria de Abril de 1988. Se convirtió en una de las cantantes de sevillanas más queridas de España.",
+      "fun_fact_fr": "María del Monte est devenue célèbre en chantant ceci à la Feria de Séville 1988, devenant l'une des chanteuses de sévillanes les plus aimées d'Espagne.",
+      "uri_apple_music": "applemusic://track/362776156",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=SMD-WzplZgE",
+      "uri_tidal": "tidal://track/3675378"
+    },
+    {
+      "year": 1992,
+      "uri": "spotify:track:035FANZcu4HK24hEIeI7bh",
+      "artist": "Jon Secada",
+      "alt_artists": [
+        "Luis Miguel",
+        "Alejandro Sanz",
+        "Ricardo Montaner",
+        "Cristian Castro"
+      ],
+      "title": "Otro Día Más Sin Verte",
+      "chart_info": {
+        "billboard_peak": null,
+        "uk_peak": null,
+        "weeks_on_chart": null
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "Cuban-American Jon Secada wrote and sang backing vocals for Gloria Estefan before launching a solo career. This Spanish version of 'Just Another Day' hit #1 in 30 countries.",
+      "fun_fact_de": "Der kubanisch-amerikanische Jon Secada schrieb für Gloria Estefan, bevor er solo durchstartete. Die spanische Version von 'Just Another Day' erreichte #1 in 30 Ländern.",
+      "fun_fact_es": "El cubanoamericano Jon Secada escribió para Gloria Estefan antes de su carrera solista. La versión española de 'Just Another Day' llegó al #1 en 30 países.",
+      "fun_fact_fr": "Le Cubano-Américain Jon Secada a écrit pour Gloria Estefan avant sa carrière solo. La version espagnole de 'Just Another Day' a atteint le #1 dans 30 pays.",
+      "uri_apple_music": "applemusic://track/723752149",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=zShPLJQDAFY",
+      "uri_tidal": "tidal://track/1385339"
+    },
+    {
+      "year": 1965,
+      "uri": "spotify:track:7i38EXhbFJjF5tGvTsJMmx",
+      "artist": "Jimmy Fontana",
+      "alt_artists": [
+        "Domenico Modugno",
+        "Nicola Di Bari",
+        "Adriano Celentano"
+      ],
+      "title": "El Mundo",
+      "chart_info": {
+        "billboard_peak": null,
+        "uk_peak": null,
+        "weeks_on_chart": null
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "Italian singer whose 'Il Mondo' became a global hit. The Spanish version became a karaoke staple across the Spanish-speaking world, covered by countless artists.",
+      "fun_fact_de": "Italienischer Sänger, dessen 'Il Mondo' ein Welthit wurde. Die spanische Version ist ein Karaoke-Klassiker in der gesamten spanischsprachigen Welt.",
+      "fun_fact_es": "Cantante italiano cuyo 'Il Mondo' fue un éxito mundial. La versión en español se convirtió en clásico de karaoke en todo el mundo hispano.",
+      "fun_fact_fr": "Chanteur italien dont 'Il Mondo' est devenu un succès mondial. La version espagnole est un classique du karaoké dans le monde hispanophone.",
+      "uri_apple_music": "applemusic://track/162276553",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=HFyCfFJC0no",
+      "uri_tidal": "tidal://track/100106555"
+    },
+    {
+      "year": 2006,
+      "uri": "spotify:track:2HCN2W2Y6GAfct0NWEtsk0",
+      "artist": "Melendi",
+      "alt_artists": [
+        "Estopa",
+        "El Barrio",
+        "El Kanka",
+        "Manu Chao"
+      ],
+      "title": "Un violinista en tu tejado",
+      "chart_info": {
+        "billboard_peak": null,
+        "uk_peak": null,
+        "weeks_on_chart": null
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "Asturian singer who blends rumba, pop and singer-songwriter traditions. Known for his witty, often humorous lyrics about everyday life and love gone wrong.",
+      "fun_fact_de": "Asturischer Sänger, der Rumba, Pop und Liedermacher-Tradition verbindet. Bekannt für seine witzigen Texte über Alltag und gescheiterte Liebe.",
+      "fun_fact_es": "Cantante asturiano que fusiona rumba, pop y cantautor. Conocido por sus letras ingeniosas y humorísticas sobre la vida cotidiana y amores fallidos.",
+      "fun_fact_fr": "Chanteur asturien mêlant rumba, pop et tradition d'auteur-compositeur. Connu pour ses textes spirituels sur le quotidien et les amours ratées.",
+      "uri_apple_music": "applemusic://track/701398502",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=eJbIMODHIdw",
+      "uri_tidal": "tidal://track/2428547"
+    },
+    {
+      "year": 1975,
+      "uri": "spotify:track:62sv8pbKqGwVeN4F20DSXM",
+      "artist": "Lorenzo Santamaría",
+      "alt_artists": [
+        "Nino Bravo",
+        "Camilo Sesto",
+        "Julio Iglesias",
+        "José Luis Perales"
+      ],
+      "title": "Para que no me olvides",
+      "chart_info": {
+        "billboard_peak": null,
+        "uk_peak": null,
+        "weeks_on_chart": null
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "Lorenzo Santamaría from Barcelona was one of Spain's biggest 70s pop stars. This romantic ballad became a wedding classic and is still one of the most-requested songs at Spanish celebrations.",
+      "fun_fact_de": "Lorenzo Santamaría aus Barcelona war einer der größten spanischen 70er-Popstars. Diese Ballade ist ein Hochzeitsklassiker.",
+      "fun_fact_es": "Lorenzo Santamaría de Barcelona fue una de las mayores estrellas del pop español de los 70. Esta balada romántica sigue siendo de las más pedidas en celebraciones.",
+      "fun_fact_fr": "Lorenzo Santamaría de Barcelone fut l'une des plus grandes stars du pop espagnol des années 70. Cette ballade reste très demandée lors des célébrations.",
+      "uri_apple_music": "applemusic://track/999776200",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Db0OpHeP1LM",
+      "uri_tidal": "tidal://track/80256694"
+    },
+    {
+      "year": 1977,
+      "uri": "spotify:track:17ZNANF0EA03icw5LpFSOF",
+      "artist": "Elsa Baeza",
+      "alt_artists": [
+        "Maria Del Monte",
+        "Massiel",
+        "Karina",
+        "Marisol"
+      ],
+      "title": "El Cristo de Palacagüina",
+      "chart_info": {
+        "billboard_peak": null,
+        "uk_peak": null,
+        "weeks_on_chart": null
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "A Spanish-language cover of a Nicaraguan revolutionary song by Carlos Mejía Godoy. Elsa Baeza's version brought Central American protest music to Spanish pop audiences.",
+      "fun_fact_de": "Ein spanischsprachiges Cover eines nicaraguanischen Revolutionslieds. Elsa Baezas Version brachte zentralamerikanische Protestmusik zum spanischen Pop-Publikum.",
+      "fun_fact_es": "Versión de una canción revolucionaria nicaragüense de Carlos Mejía Godoy. La versión de Elsa Baeza acercó la música de protesta centroamericana al público pop español.",
+      "fun_fact_fr": "Reprise d'une chanson révolutionnaire nicaraguayenne de Carlos Mejía Godoy. La version d'Elsa Baeza a apporté la musique contestataire centraméricaine au public pop espagnol.",
+      "uri_apple_music": "applemusic://track/157403623",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=ogxEVQjSmpQ",
+      "uri_tidal": "tidal://track/458935630"
+    },
+    {
+      "year": 1989,
+      "uri": "spotify:track:50xMqHj2hhLdgmLh0foksG",
+      "artist": "UN PINGUINO EN MI ASCENSOR",
+      "alt_artists": [
+        "Siniestro Total",
+        "Los Nikis",
+        "Hombres G",
+        "Loquillo"
+      ],
+      "title": "Espiando a mi vecina",
+      "chart_info": {
+        "billboard_peak": null,
+        "uk_peak": null,
+        "weeks_on_chart": null
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "One of the quirkiest bands from Spain's post-Movida era in the Basque Country. Their absurdist humor and catchy melodies made them indie legends in Spain.",
+      "fun_fact_de": "Eine der schrägsten Bands der Post-Movida-Ära im Baskenland. Ihr absurder Humor und eingängige Melodien machten sie zu Indie-Legenden.",
+      "fun_fact_es": "Una de las bandas más peculiares de la era post-Movida en el País Vasco. Su humor absurdo y melodías pegadizas los convirtieron en leyendas indie.",
+      "fun_fact_fr": "L'un des groupes les plus décalés de l'ère post-Movida au Pays Basque. Leur humour absurde en a fait des légendes indie en Espagne.",
+      "uri_apple_music": "applemusic://track/857799592",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=T1kLtZv9Sb4",
+      "uri_tidal": "tidal://track/186297"
+    },
+    {
+      "year": 2016,
+      "uri": "spotify:track:1XOqhF3MIzz6pzJzRpZo29",
+      "artist": "Blas Cantó",
+      "alt_artists": [
+        "Pablo Alborán",
+        "Manuel Carrasco",
+        "DePol",
+        "Antonio José"
+      ],
+      "title": "Él no soy yo",
+      "chart_info": {
+        "billboard_peak": null,
+        "uk_peak": null,
+        "weeks_on_chart": null
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "Blas Cantó went from boyband (Auryn) to solo career and was chosen to represent Spain at Eurovision 2020 and 2021. This ballad showcased his powerful voice.",
+      "fun_fact_de": "Blas Cantó ging von der Boyband Auryn zur Solokarriere und vertrat Spanien beim Eurovision 2020 und 2021.",
+      "fun_fact_es": "Blas Cantó pasó del grupo Auryn a carrera solista y fue elegido para representar a España en Eurovisión 2020 y 2021.",
+      "fun_fact_fr": "Blas Cantó est passé du boys band Auryn à une carrière solo et a représenté l'Espagne à l'Eurovision 2020 et 2021.",
+      "uri_apple_music": "applemusic://track/1421843539",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=yIg0uKHK8JU",
+      "uri_tidal": "tidal://track/85078851"
+    },
+    {
+      "year": 2004,
+      "uri": "spotify:track:38mCl4EuWhML4eaZPdNQ3a",
+      "artist": "Amaral",
+      "alt_artists": [
+        "La Oreja de Van Gogh",
+        "El Canto del Loco",
+        "Pereza",
+        "Dover"
+      ],
+      "title": "El universo sobre mí",
+      "chart_info": {
+        "billboard_peak": null,
+        "uk_peak": null,
+        "weeks_on_chart": null
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "Duo from Zaragoza (Eva Amaral + Juan Aguirre) who became Spain's most successful indie-rock band, filling arenas across the country. This track was a #1 hit.",
+      "fun_fact_de": "Duo aus Zaragoza (Eva Amaral + Juan Aguirre), erfolgreichste Indie-Rock-Band Spaniens, die landesweit Arenen füllte.",
+      "fun_fact_es": "Dúo de Zaragoza (Eva Amaral + Juan Aguirre), la banda indie-rock más exitosa de España, llenando recintos por todo el país.",
+      "fun_fact_fr": "Duo de Saragosse (Eva Amaral + Juan Aguirre), le groupe indie-rock le plus populaire d'Espagne, remplissant les arènes du pays.",
+      "uri_apple_music": "applemusic://track/726148732",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=d5alBzLbDNw",
+      "uri_tidal": "tidal://track/1404259"
+    },
+    {
+      "year": 1966,
+      "uri": "spotify:track:1jJn6iK6o2Vg7iUKHztRTk",
+      "artist": "Raphael",
+      "alt_artists": [
+        "Julio Iglesias",
+        "Camilo Sesto",
+        "Nino Bravo",
+        "Miguel Bosé"
+      ],
+      "title": "Yo soy aquél",
+      "chart_info": {
+        "billboard_peak": null,
+        "uk_peak": null,
+        "weeks_on_chart": null
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "Spain's Eurovision entry in 1966 (7th place). Raphael went on to become one of the greatest Spanish-language artists ever, with 60+ years of career and 50+ million records sold.",
+      "fun_fact_de": "Spaniens Eurovision-Beitrag 1966. Raphael wurde einer der größten spanischsprachigen Künstler mit über 60 Jahren Karriere und 50+ Millionen verkauften Platten.",
+      "fun_fact_es": "Representó a España en Eurovisión 1966. Raphael se convirtió en uno de los mayores artistas en español con más de 60 años de carrera y 50+ millones de discos.",
+      "fun_fact_fr": "Représentant l'Espagne à l'Eurovision 1966. Raphael est devenu l'un des plus grands artistes hispanophones avec 60+ ans de carrière et 50+ millions de disques.",
+      "uri_apple_music": "applemusic://track/693490632",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=TEwWrpebnkM",
+      "uri_tidal": "tidal://track/1487360"
+    },
+    {
+      "year": 1978,
+      "uri": "spotify:track:4H71d1kJ8DB8J4atO8fbBl",
+      "artist": "Los Chichos",
+      "alt_artists": [
+        "Los Chunguitos",
+        "Las Grecas",
+        "Rumba Tres",
+        "Los Calis"
+      ],
+      "title": "Son Ilusiones",
+      "chart_info": {
+        "billboard_peak": null,
+        "uk_peak": null,
+        "weeks_on_chart": null
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "Los Chichos from Vallecas are the undisputed kings of 'rumba flamenca'. Their raw, street-level sound became the soundtrack of working-class Spain in the late 70s and 80s.",
+      "fun_fact_de": "Los Chichos aus Vallecas sind die unbestrittenen Könige der 'Rumba Flamenca'. Ihr Sound wurde zum Soundtrack der spanischen Arbeiterklasse.",
+      "fun_fact_es": "Los Chichos de Vallecas son los reyes indiscutibles de la rumba flamenca. Su sonido se convirtió en la banda sonora de la España obrera.",
+      "fun_fact_fr": "Los Chichos de Vallecas sont les rois incontestés de la rumba flamenca. Leur son est devenu la bande-son de l'Espagne ouvrière.",
+      "uri_apple_music": "applemusic://track/1838116573",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=giAeZA6hQe8",
+      "uri_tidal": "tidal://track/45474653"
+    },
+    {
+      "year": 2021,
+      "uri": "spotify:track:0hGimYHmT1pttWUJF76L3J",
+      "artist": "Sebastian Yatra, Myke Towers",
+      "alt_artists": [
+        "Camilo",
+        "Maluma",
+        "Manuel Turizo",
+        "Rauw Alejandro"
+      ],
+      "title": "Pareja Del Año",
+      "chart_info": {
+        "billboard_peak": null,
+        "uk_peak": null,
+        "weeks_on_chart": null
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "Colombian Yatra and Puerto Rican Myke Towers created a romantic reggaeton hit that blurred the line between Latin pop and urban music, hitting #1 across Latin America.",
+      "fun_fact_de": "Der Kolumbianer Yatra und der Puertoricaner Myke Towers schufen einen romantischen Reggaeton-Hit, der Latin Pop und Urban Music verschmolz.",
+      "fun_fact_es": "El colombiano Yatra y el puertorriqueño Myke Towers crearon un hit de reggaetón romántico que difuminó la línea entre pop latino y música urbana.",
+      "fun_fact_fr": "Le Colombien Yatra et le Portoricain Myke Towers ont créé un hit reggaeton romantique brouillant la frontière entre pop latino et musique urbaine.",
+      "uri_apple_music": "applemusic://track/1561274161",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=SRm2Ch4oFWs",
+      "uri_tidal": "tidal://track/180009141"
+    },
+    {
+      "year": 1987,
+      "uri": "spotify:track:0UkXFKXVHe5YG7lke77CI1",
+      "artist": "El Norte",
+      "alt_artists": [
+        "Hombres G",
+        "Radio Futura",
+        "Duncan Dhu",
+        "Mecano"
+      ],
+      "title": "Entre Tu y Yo",
+      "chart_info": {
+        "billboard_peak": null,
+        "uk_peak": null,
+        "weeks_on_chart": null
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "Part of Spain's 80s 'techno-pop' wave alongside Mecano and Duncan Dhu. El Norte from Salamanca had a brief but intense career that produced several Spanish pop classics.",
+      "fun_fact_de": "Teil der spanischen 80er-Techno-Pop-Welle neben Mecano und Duncan Dhu. El Norte aus Salamanca hatte eine kurze aber intensive Karriere.",
+      "fun_fact_es": "Parte de la ola 'techno-pop' española de los 80 junto a Mecano y Duncan Dhu. El Norte de Salamanca tuvo una carrera breve pero intensa.",
+      "fun_fact_fr": "Partie de la vague 'techno-pop' espagnole des années 80 aux côtés de Mecano et Duncan Dhu. El Norte de Salamanque eut une carrière brève mais intense.",
+      "uri_apple_music": "applemusic://track/1280362581",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=TmvfrhXaW9E",
+      "uri_tidal": "tidal://track/53033205"
+    },
+    {
+      "year": 1985,
+      "uri": "spotify:track:61fbKInmWBIJQyUexcogQC",
+      "artist": "Rosendo",
+      "alt_artists": [
+        "Barricada",
+        "Extremoduro",
+        "Leño",
+        "Platero y Tú"
+      ],
+      "title": "Agradecido",
+      "chart_info": {
+        "billboard_peak": null,
+        "uk_peak": null,
+        "weeks_on_chart": null
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "Rosendo Mercado is the godfather of Spanish rock. Former frontman of Leño, he pioneered hard rock in Spain and maintained a 40+ year career as a solo artist.",
+      "fun_fact_de": "Rosendo Mercado ist der Pate des spanischen Rock. Ex-Frontmann von Leño, Pionier des Hard Rock in Spanien mit über 40 Jahren Solokarriere.",
+      "fun_fact_es": "Rosendo Mercado es el padrino del rock español. Ex líder de Leño, fue pionero del hard rock en España con más de 40 años de carrera solista.",
+      "fun_fact_fr": "Rosendo Mercado est le parrain du rock espagnol. Ex-leader de Leño, pionnier du hard rock en Espagne avec 40+ ans de carrière solo.",
+      "uri_apple_music": "applemusic://track/273928240",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=AOhiJQBYdF4",
+      "uri_tidal": "tidal://track/38055100"
+    },
+    {
+      "year": 1995,
+      "uri": "spotify:track:655JkvIwu2rDCaD1hPf04g",
+      "artist": "Raimundo Amador",
+      "alt_artists": [
+        "Pata Negra",
+        "Ketama",
+        "Manzanita",
+        "Tomatito"
+      ],
+      "title": "Ay Que Gustito Pa Mis Orejas",
+      "chart_info": {
+        "billboard_peak": null,
+        "uk_peak": null,
+        "weeks_on_chart": null
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "Raimundo Amador from Seville (ex-Pata Negra) is one of the most brilliant flamenco-blues guitarists ever, fusing flamenco with BB King-style blues like nobody else.",
+      "fun_fact_de": "Raimundo Amador aus Sevilla (ex-Pata Negra) ist einer der brillantesten Flamenco-Blues-Gitarristen, der Flamenco mit BB King-Blues verschmolz.",
+      "fun_fact_es": "Raimundo Amador de Sevilla (ex Pata Negra) es uno de los guitarristas flamenco-blues más brillantes, fusionando flamenco con blues estilo BB King.",
+      "fun_fact_fr": "Raimundo Amador de Séville (ex-Pata Negra) est l'un des plus brillants guitaristes flamenco-blues, fusionnant flamenco et blues à la BB King.",
+      "uri_apple_music": "applemusic://track/1537431985",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=ahetDyr7lAE",
+      "uri_tidal": "tidal://track/36302896"
+    },
+    {
+      "year": 2008,
+      "uri": "spotify:track:3zYohktAenCUDxxdPtFU6M",
+      "artist": "Pol 3.14",
+      "alt_artists": [
+        "Pablo Alborán",
+        "Antonio José",
+        "Beret",
+        "Manuel Carrasco"
+      ],
+      "title": "Lo Que no Ves",
+      "chart_info": {
+        "billboard_peak": null,
+        "uk_peak": null,
+        "weeks_on_chart": null
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "Pol 3.14 from Barcelona is a singer-songwriter who built his career through YouTube and live performances, representing a generation of Spanish artists who bypassed traditional labels.",
+      "fun_fact_de": "Pol 3.14 aus Barcelona baute seine Karriere über YouTube auf und repräsentiert eine Generation spanischer Künstler abseits traditioneller Labels.",
+      "fun_fact_es": "Pol 3.14 de Barcelona construyó su carrera a través de YouTube, representando una generación de artistas españoles que evitaron las discográficas tradicionales.",
+      "fun_fact_fr": "Pol 3.14 de Barcelone a construit sa carrière via YouTube, représentant une génération d'artistes espagnols contournant les labels traditionnels.",
+      "uri_apple_music": "applemusic://track/1840394612",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=JQqDOX5kRr0",
+      "uri_tidal": "tidal://track/461220656"
+    },
+    {
+      "year": 1982,
+      "uri": "spotify:track:7F5AYZAPcNE9rIpCCHFEeh",
+      "artist": "Los Calis",
+      "alt_artists": [
+        "Los Chichos",
+        "Los Chunguitos",
+        "Rumba Tres",
+        "Peret"
+      ],
+      "title": "Una paloma blanca",
+      "chart_info": {
+        "billboard_peak": null,
+        "uk_peak": null,
+        "weeks_on_chart": null
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "Not to be confused with the George Baker hit — Los Calis' version is a rumba flamenca classic from Madrid's Romani music scene that became a summer anthem in 80s Spain.",
+      "fun_fact_de": "Nicht zu verwechseln mit dem George Baker Hit — eine Rumba-Flamenca-Klassiker der Madrider Roma-Musikszene.",
+      "fun_fact_es": "No confundir con el éxito de George Baker — la versión de Los Calis es un clásico de rumba flamenca de la escena gitana madrileña.",
+      "fun_fact_fr": "À ne pas confondre avec le tube de George Baker — la version de Los Calis est un classique de rumba flamenca de la scène gitane madrilène.",
+      "uri_apple_music": "applemusic://track/669029704",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=oVgdvG1QDho",
+      "uri_tidal": "tidal://track/386385"
+    },
+    {
+      "year": 1985,
+      "uri": "spotify:track:6olopCEGYHL8U7jMRWBnJJ",
+      "artist": "Tino Casal",
+      "alt_artists": [
+        "Alaska y Dinarama",
+        "Aviador Dro",
+        "Gabinete Caligari",
+        "Parálisis Permanente"
+      ],
+      "title": "Champú de huevo",
+      "chart_info": {
+        "billboard_peak": null,
+        "uk_peak": null,
+        "weeks_on_chart": null
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "Tino Casal was the most flamboyant figure of 'La Movida Madrileña' — an Asturian glam-pop artist who died tragically in a car accident in 1991 at age 41.",
+      "fun_fact_de": "Tino Casal war die schillerndste Figur der 'Movida Madrileña' — ein asturischer Glam-Pop-Künstler, der 1991 mit 41 Jahren bei einem Autounfall starb.",
+      "fun_fact_es": "Tino Casal fue la figura más extravagante de La Movida Madrileña — artista asturiano de glam-pop que murió trágicamente en accidente de coche en 1991 con 41 años.",
+      "fun_fact_fr": "Tino Casal fut la figure la plus flamboyante de La Movida Madrileña — artiste glam-pop asturien mort tragiquement dans un accident en 1991 à 41 ans.",
+      "uri_apple_music": "applemusic://track/691545698",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=lr3hkcTqV2M",
+      "uri_tidal": "tidal://track/7760003"
+    },
+    {
+      "year": 1992,
+      "uri": "spotify:track:5AwsoZ2O4WeGxtq6dnGvAN",
+      "artist": "Zapato Veloz",
+      "alt_artists": [
+        "Boney M",
+        "Las Ketchup",
+        "Georgie Dann",
+        "Los Del Río"
+      ],
+      "title": "Tractor Amarillo",
+      "chart_info": {
+        "billboard_peak": null,
+        "uk_peak": null,
+        "weeks_on_chart": null
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "One of Spain's most iconic novelty songs — 'Yellow Tractor' became an inescapable one-hit wonder that still fills dance floors at Spanish village fiestas 30 years later.",
+      "fun_fact_de": "Einer der ikonischsten Partysongs Spaniens — 'Gelber Traktor' füllt noch 30 Jahre später die Tanzflächen bei Dorffesten.",
+      "fun_fact_es": "Una de las canciones festivas más icónicas de España — 'Tractor Amarillo' sigue llenando pistas de baile en fiestas de pueblo 30 años después.",
+      "fun_fact_fr": "L'une des chansons festives les plus iconiques d'Espagne — 'Tractor Amarillo' remplit encore les pistes de danse des fêtes de village 30 ans plus tard.",
+      "uri_apple_music": "applemusic://track/1315218782",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=62Z8vUIk9s8",
+      "uri_tidal": "tidal://track/81430657"
+    },
+    {
+      "year": 1995,
+      "uri": "spotify:track:0J1kzvBMKLUEsiF3Yx9nch",
+      "artist": "Heroes Del Silencio",
+      "alt_artists": [
+        "Extremoduro",
+        "Los Planetas",
+        "Barricada",
+        "Soda Stereo"
+      ],
+      "title": "Iberia sumergida",
+      "chart_info": {
+        "billboard_peak": null,
+        "uk_peak": null,
+        "weeks_on_chart": null
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "Zaragoza's Heroes del Silencio were Spain's biggest international rock band, selling 6+ million records globally. Led by Enrique Bunbury, they were massive in Latin America and Germany.",
+      "fun_fact_de": "Heroes del Silencio aus Zaragoza waren Spaniens größte internationale Rockband mit über 6 Millionen verkauften Platten weltweit, besonders in Lateinamerika und Deutschland.",
+      "fun_fact_es": "Heroes del Silencio de Zaragoza fueron la mayor banda de rock internacional de España, con más de 6 millones de discos vendidos, enormes en Latinoamérica y Alemania.",
+      "fun_fact_fr": "Heroes del Silencio de Saragosse furent le plus grand groupe de rock international d'Espagne, avec 6+ millions de disques vendus, énormes en Amérique latine et Allemagne.",
+      "uri_apple_music": "applemusic://track/699670267",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=QOBUw4IYI7U",
+      "uri_tidal": "tidal://track/256325331"
+    },
+    {
+      "year": 2023,
+      "uri": "spotify:track:4DorjfHssREi4THq5Aj95h",
+      "artist": "Ana Mena",
+      "alt_artists": [
+        "Aitana",
+        "Lola Indigo",
+        "Bad Gyal",
+        "Becky G"
+      ],
+      "title": "Música Ligera",
+      "chart_info": {
+        "billboard_peak": null,
+        "uk_peak": null,
+        "weeks_on_chart": null
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "Ana Mena from Málaga became a crossover star in Italy before breaking through in Spain. She holds the record for most weeks at #1 on Spain's Los40 chart by a female artist in recent years.",
+      "fun_fact_de": "Ana Mena aus Málaga wurde erst in Italien zum Star, bevor sie in Spanien durchbrach. Rekord für meiste Wochen auf #1 bei Los40.",
+      "fun_fact_es": "Ana Mena de Málaga triunfó primero en Italia antes de romper en España. Récord de semanas en el #1 de Los40 para una artista femenina.",
+      "fun_fact_fr": "Ana Mena de Málaga est devenue star en Italie avant de percer en Espagne. Record de semaines au #1 de Los40 pour une artiste féminine.",
+      "uri_apple_music": "applemusic://track/1677142421",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=K340m2VwhqE",
+      "uri_tidal": "tidal://track/204868811"
+    },
+    {
+      "year": 1986,
+      "uri": "spotify:track:128iWD7Q1rVvItX8HSdmLw",
+      "artist": "Los Toreros Muertos",
+      "alt_artists": [
+        "Hombres G",
+        "Los Nikis",
+        "Siniestro Total",
+        "Alaska y Dinarama"
+      ],
+      "title": "Mi Agüita Amarilla",
+      "chart_info": {
+        "billboard_peak": null,
+        "uk_peak": null,
+        "weeks_on_chart": null
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "One of the most irreverent bands of the Movida era. 'Mi Agüita Amarilla' (My Little Yellow Water) is exactly what you think it's about — and it was a massive hit anyway.",
+      "fun_fact_de": "Eine der respektlosesten Bands der Movida-Ära. 'Mi Agüita Amarilla' handelt genau davon, woran man denkt — und war trotzdem ein Riesenhit.",
+      "fun_fact_es": "Una de las bandas más irreverentes de la Movida. 'Mi Agüita Amarilla' trata exactamente de lo que imaginas — y aun así fue un éxito enorme.",
+      "fun_fact_fr": "L'un des groupes les plus irrévérencieux de la Movida. 'Mi Agüita Amarilla' parle exactement de ce que vous pensez — et ce fut un énorme succès.",
+      "uri_apple_music": "applemusic://track/964104426",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Jaf1yvWb1jw",
+      "uri_tidal": "tidal://track/34044126"
+    },
+    {
+      "year": 1935,
+      "uri": "spotify:track:2PKhVCRILDBc7HYSIT9v0u",
+      "artist": "Carlos Gardel",
+      "alt_artists": [
+        "Antonio Machín",
+        "Beny Moré",
+        "Julio Sosa",
+        "Roberto Goyeneche"
+      ],
+      "title": "Volver",
+      "chart_info": {
+        "billboard_peak": null,
+        "uk_peak": null,
+        "weeks_on_chart": null
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "The greatest tango singer of all time, Gardel died in a plane crash in 1935 at the peak of his fame. 'Volver' is Argentina's unofficial national anthem and his masterpiece.",
+      "fun_fact_de": "Der größte Tangosänger aller Zeiten, starb 1935 bei einem Flugzeugabsturz auf dem Höhepunkt seines Ruhms. 'Volver' ist Argentiniens inoffizielle Nationalhymne.",
+      "fun_fact_es": "El mayor cantante de tango de la historia, murió en un accidente aéreo en 1935. 'Volver' es el himno oficioso de Argentina y su obra maestra.",
+      "fun_fact_fr": "Le plus grand chanteur de tango de tous les temps, mort dans un accident d'avion en 1935. 'Volver' est l'hymne officieux de l'Argentine.",
+      "uri_apple_music": "applemusic://track/689435154",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=MCwtzp8b8uk",
+      "uri_tidal": "tidal://track/1549157"
+    },
+    {
+      "year": 1965,
+      "uri": "spotify:track:1lMuQJHBznRfq7GdQrIQN4",
+      "artist": "Conchita Velasco",
+      "alt_artists": [
+        "Marisol",
+        "Karina",
+        "Massiel",
+        "Rocío Dúrcal"
+      ],
+      "title": "Chica Ye Ye",
+      "chart_info": {
+        "billboard_peak": null,
+        "uk_peak": null,
+        "weeks_on_chart": null
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "Conchita Velasco became a symbol of the youthful Spanish pop revolution of the 60s. 'Chica Ye-Yé' from the film 'Historias de la televisión' defined a generation of young Spaniards.",
+      "fun_fact_de": "Conchita Velasco wurde zum Symbol der jugendlichen Pop-Revolution der 60er in Spanien.",
+      "fun_fact_es": "Conchita Velasco se convirtió en símbolo de la revolución pop juvenil española de los 60. 'Chica Ye-Yé' definió una generación.",
+      "fun_fact_fr": "Conchita Velasco devint le symbole de la révolution pop jeune des années 60 en Espagne. 'Chica Ye-Yé' a défini une génération.",
+      "uri_apple_music": "applemusic://track/160259544",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=L2SG1P86JCQ",
+      "uri_tidal": "tidal://track/225791006"
+    },
+    {
+      "year": 2024,
+      "uri": "spotify:track:2fYRXoal0ysbJJBUddCGDb",
+      "artist": "La Oreja de Van Gogh",
+      "alt_artists": [
+        "Amaral",
+        "El Canto del Loco",
+        "Pereza",
+        "Maldita Nerea"
+      ],
+      "title": "La Niña Que Llora en Tus Fiestas",
+      "chart_info": {
+        "billboard_peak": null,
+        "uk_peak": null,
+        "weeks_on_chart": null
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "LODVG from San Sebastián have been Spain's most consistent pop band for 25+ years. Originally fronted by Amaia Montero (now Leire Martínez), they've sold 10+ million records.",
+      "fun_fact_de": "LODVG aus San Sebastián sind seit über 25 Jahren Spaniens konstanteste Popband mit über 10 Millionen verkauften Platten.",
+      "fun_fact_es": "LODVG de San Sebastián llevan más de 25 años siendo la banda pop más constante de España con más de 10 millones de discos vendidos.",
+      "fun_fact_fr": "LODVG de Saint-Sébastien sont le groupe pop le plus constant d'Espagne depuis 25+ ans avec 10+ millions de disques vendus.",
+      "uri_apple_music": "applemusic://track/450460305",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=zAlsSqlxxyI",
+      "uri_tidal": "tidal://track/7623587"
+    },
+    {
+      "year": 1989,
+      "uri": "spotify:track:71bkiosdVssjMrVDbdeG7n",
+      "artist": "Burning",
+      "alt_artists": [
+        "Leño",
+        "Barón Rojo",
+        "Obús",
+        "Rosendo"
+      ],
+      "title": "Una Noche Sin Ti",
+      "chart_info": {
+        "billboard_peak": null,
+        "uk_peak": null,
+        "weeks_on_chart": null
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "Burning are the godfathers of Madrid rock — active since 1975, they're one of the longest-running rock bands in Spanish history with 40+ years of continuous touring.",
+      "fun_fact_de": "Burning sind die Paten des Madrider Rock — seit 1975 aktiv, eine der langlebigsten Rockbands der spanischen Geschichte.",
+      "fun_fact_es": "Burning son los padrinos del rock madrileño — activos desde 1975, una de las bandas de rock más longevas de la historia española.",
+      "fun_fact_fr": "Burning sont les parrains du rock madrilène — actifs depuis 1975, l'un des groupes de rock les plus durables de l'histoire espagnole.",
+      "uri_apple_music": "applemusic://track/1838219657",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=7ieJgYg1H78",
+      "uri_tidal": "tidal://track/2988373"
+    },
+    {
+      "year": 2014,
+      "uri": "spotify:track:6SPh662eEjHNNxs7v0xBX4",
+      "artist": "Osmani Garcia, Pitbull",
+      "alt_artists": [
+        "Daddy Yankee",
+        "Don Omar",
+        "Calle 13",
+        "Wisin y Yandel"
+      ],
+      "title": "El Taxi",
+      "chart_info": {
+        "billboard_peak": null,
+        "uk_peak": null,
+        "weeks_on_chart": null
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "Cuban reggaeton track that became a global viral phenomenon. The Pitbull remix made it inescapable on European dance floors in 2014-2015.",
+      "fun_fact_de": "Kubanischer Reggaeton-Track, der zum globalen viralen Phänomen wurde. Der Pitbull-Remix machte ihn 2014-2015 auf europäischen Tanzflächen unausweichlich.",
+      "fun_fact_es": "Tema de reggaetón cubano que se convirtió en fenómeno viral global. El remix con Pitbull lo hizo inevitable en las pistas europeas en 2014-2015.",
+      "fun_fact_fr": "Titre de reggaeton cubain devenu phénomène viral mondial. Le remix avec Pitbull l'a rendu incontournable sur les pistes européennes en 2014-2015.",
+      "uri_apple_music": "applemusic://track/844380593",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=qRp3-D3SMwI",
+      "uri_tidal": "tidal://track/27670428"
+    },
+    {
+      "year": 2014,
+      "uri": "spotify:track:0lTKqVmGitaJGRf1DzhaFV",
+      "artist": "Shakira, Carlinhos Brown",
+      "alt_artists": [
+        "Jennifer Lopez",
+        "Ricky Martin",
+        "Pitbull",
+        "Enrique Iglesias"
+      ],
+      "title": "La La La (Brasil 2014)",
+      "chart_info": {
+        "billboard_peak": null,
+        "uk_peak": null,
+        "weeks_on_chart": null
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "The official song of the 2014 FIFA World Cup in Brazil. Shakira became the only artist to perform at three consecutive World Cup ceremonies (2006, 2010, 2014).",
+      "fun_fact_de": "Offizieller Song der FIFA WM 2014 in Brasilien. Shakira wurde die einzige Künstlerin, die bei drei aufeinanderfolgenden WM-Zeremonien auftrat.",
+      "fun_fact_es": "Canción oficial del Mundial FIFA 2014 en Brasil. Shakira se convirtió en la única artista en actuar en tres ceremonias mundialistas consecutivas.",
+      "fun_fact_fr": "Chanson officielle de la Coupe du Monde FIFA 2014. Shakira est la seule artiste à s'être produite lors de trois cérémonies de Coupes du Monde consécutives.",
+      "uri_apple_music": "applemusic://track/825811735",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=-befR4wHsjQ",
+      "uri_tidal": "tidal://track/34913114"
+    },
+    {
+      "year": 1987,
+      "uri": "spotify:track:3YYaJCzQTkJ56nPO8FSeQP",
+      "artist": "Obus",
+      "alt_artists": [
+        "Barón Rojo",
+        "Ángeles del Infierno",
+        "Soziedad Alkoholika",
+        "Rosendo"
+      ],
+      "title": "Vamos Muy Bien",
+      "chart_info": {
+        "billboard_peak": null,
+        "uk_peak": null,
+        "weeks_on_chart": null
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "Obús were pioneers of Spanish heavy metal in the 80s. Part of the 'Rock Radikal Vasco' adjacent scene, they proved heavy metal could be sung effectively in Spanish.",
+      "fun_fact_de": "Obús waren Pioniere des spanischen Heavy Metal der 80er und bewiesen, dass Metal auf Spanisch funktioniert.",
+      "fun_fact_es": "Obús fueron pioneros del heavy metal español en los 80, demostrando que el metal se podía cantar eficazmente en español.",
+      "fun_fact_fr": "Obús furent des pionniers du heavy metal espagnol des années 80, prouvant que le metal pouvait être chanté efficacement en espagnol.",
+      "uri_apple_music": "applemusic://track/1807146809",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=uOF3iQfregw",
+      "uri_tidal": "tidal://track/525954"
+    },
+    {
+      "year": 2003,
+      "uri": "spotify:track:1qpbJ8GiPc706AfGqZAIei",
+      "artist": "Guaraná",
+      "alt_artists": [
+        "Pignoise",
+        "Pereza",
+        "El Canto del Loco",
+        "Maldita Nerea"
+      ],
+      "title": "En la Casa de Inés",
+      "chart_info": {
+        "billboard_peak": null,
+        "uk_peak": null,
+        "weeks_on_chart": null
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "Guaraná from Valencia scored one of Spain's catchiest pop-rock hits of the 2000s. The song became a ubiquitous radio staple and a sing-along anthem at live shows.",
+      "fun_fact_de": "Guaraná aus Valencia landeten einen der eingängigsten Pop-Rock-Hits der 2000er in Spanien.",
+      "fun_fact_es": "Guaraná de Valencia logró uno de los éxitos pop-rock más pegadizos de los 2000 en España.",
+      "fun_fact_fr": "Guaraná de Valence a signé l'un des tubes pop-rock les plus accrocheurs des années 2000 en Espagne.",
+      "uri_apple_music": "applemusic://track/507418902",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=sTthzVPDjak",
+      "uri_tidal": "tidal://track/81716276"
+    },
+    {
+      "year": 1993,
+      "uri": "spotify:track:6i2kn3iS5WKzsaYBdeHLIQ",
+      "artist": "Gloria Estefan",
+      "alt_artists": [
+        "Celia Cruz",
+        "Jon Secada",
+        "Shakira",
+        "Thalía"
+      ],
+      "title": "Con los Años Que Me Quedan",
+      "chart_info": {
+        "billboard_peak": null,
+        "uk_peak": null,
+        "weeks_on_chart": null
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "Cuban-American Gloria Estefan survived a devastating tour bus accident in 1990 that nearly left her paralyzed. Her comeback was one of music's greatest stories of resilience.",
+      "fun_fact_de": "Die kubanisch-amerikanische Gloria Estefan überlebte 1990 einen schweren Busunfall, der sie fast gelähmt hätte. Ihr Comeback war eine der größten Geschichten der Musikwelt.",
+      "fun_fact_es": "La cubanoamericana Gloria Estefan sobrevivió un devastador accidente de autobús en 1990. Su regreso fue una de las mayores historias de resiliencia de la música.",
+      "fun_fact_fr": "La Cubano-Américaine Gloria Estefan a survécu à un grave accident de bus en 1990. Son retour fut l'une des plus grandes histoires de résilience de la musique.",
+      "uri_apple_music": "applemusic://track/196407804",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=l6LjNOYvhMk",
+      "uri_tidal": "tidal://track/33950566"
+    },
+    {
+      "year": 1996,
+      "uri": "spotify:track:4YQ9WEYQG7fq0MAUYeB19Y",
+      "artist": "Extremoduro",
+      "alt_artists": [
+        "Heroes Del Silencio",
+        "Barricada",
+        "Platero y Tú",
+        "Marea"
+      ],
+      "title": "La vereda de la puerta de atrás",
+      "chart_info": {
+        "billboard_peak": null,
+        "uk_peak": null,
+        "weeks_on_chart": null
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "Robe Iniesta's Extremoduro from Plasencia (Extremadura) became Spain's most beloved underground rock band — selling out stadiums while never appearing on mainstream TV.",
+      "fun_fact_de": "Robe Iniestas Extremoduro aus Plasencia wurde Spaniens beliebteste Underground-Rockband — füllten Stadien ohne je im Mainstream-TV aufzutreten.",
+      "fun_fact_es": "Extremoduro de Robe Iniesta de Plasencia se convirtió en la banda underground más querida de España — llenaban estadios sin aparecer en TV.",
+      "fun_fact_fr": "Extremoduro de Robe Iniesta, de Plasencia, est devenu le groupe rock underground le plus aimé d'Espagne — remplissant les stades sans passer à la TV.",
+      "uri_apple_music": "applemusic://track/63836937",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=TLpDnHhHMfs",
+      "uri_tidal": "tidal://track/293515"
+    },
+    {
+      "year": 2017,
+      "uri": "spotify:track:5nenV4D7Yw2efQxItXOasH",
+      "artist": "El Kanka",
+      "alt_artists": [
+        "Melendi",
+        "Estopa",
+        "Rosana",
+        "Beret"
+      ],
+      "title": "Canela en Rama",
+      "chart_info": {
+        "billboard_peak": null,
+        "uk_peak": null,
+        "weeks_on_chart": null
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "El Kanka from Málaga built his career through social media and word-of-mouth, becoming one of Spain's most loved singer-songwriters without major label support.",
+      "fun_fact_de": "El Kanka aus Málaga baute seine Karriere über Social Media auf und wurde ohne Major-Label einer der beliebtesten Liedermacher Spaniens.",
+      "fun_fact_es": "El Kanka de Málaga construyó su carrera a través de las redes sociales, convirtiéndose en uno de los cantautores más queridos sin apoyo de grandes discográficas.",
+      "fun_fact_fr": "El Kanka de Málaga a construit sa carrière via les réseaux sociaux, devenant l'un des auteurs-compositeurs les plus aimés sans soutien de major.",
+      "uri_apple_music": "applemusic://track/1411538212",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=6rzbBs731L8",
+      "uri_tidal": "tidal://track/416269147"
+    },
+    {
+      "year": 1980,
+      "uri": "spotify:track:50xpsbiCVjCwEGSOAT697A",
+      "artist": "Loquillo",
+      "alt_artists": [
+        "Hombres G",
+        "Los Nikis",
+        "Radio Futura",
+        "Burning"
+      ],
+      "title": "El ritmo del garaje",
+      "chart_info": {
+        "billboard_peak": null,
+        "uk_peak": null,
+        "weeks_on_chart": null
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "Loquillo (José María Sanz) is Barcelona's rockabilly king — Spain's answer to Elvis meets The Clash. With Los Trogloditas, he's been a rock institution for 40+ years.",
+      "fun_fact_de": "Loquillo ist Barcelonas Rockabilly-König — Spaniens Antwort auf Elvis meets The Clash. Seit über 40 Jahren eine Rock-Institution.",
+      "fun_fact_es": "Loquillo es el rey del rockabilly de Barcelona — la respuesta española a Elvis meets The Clash. Una institución del rock durante más de 40 años.",
+      "fun_fact_fr": "Loquillo est le roi du rockabilly de Barcelone — la réponse espagnole à Elvis rencontre The Clash. Une institution du rock depuis 40+ ans.",
+      "uri_apple_music": "applemusic://track/339614691",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=B0YMoFwqkvY",
+      "uri_tidal": "tidal://track/5392801"
+    },
+    {
+      "year": 1988,
+      "uri": "spotify:track:4kJP8Z888wREJ8bRMWNMuk",
+      "artist": "Chiquetete",
+      "alt_artists": [
+        "El Fary",
+        "Los Chunguitos",
+        "Camarón",
+        "Niña Pastori"
+      ],
+      "title": "Esta Cobardía",
+      "chart_info": {
+        "billboard_peak": null,
+        "uk_peak": null,
+        "weeks_on_chart": null
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "Chiquetete from Seville was one of the great voices of flamenco-pop, known for his powerful vibrato and emotional intensity. A staple of Spanish variety TV shows in the 80s-90s.",
+      "fun_fact_de": "Chiquetete aus Sevilla war eine der großen Stimmen des Flamenco-Pop, bekannt für sein kraftvolles Vibrato und emotionale Intensität.",
+      "fun_fact_es": "Chiquetete de Sevilla fue una de las grandes voces del flamenco-pop, conocido por su potente vibrato e intensidad emocional.",
+      "fun_fact_fr": "Chiquetete de Séville fut l'une des grandes voix du flamenco-pop, connu pour son vibrato puissant et son intensité émotionnelle.",
+      "uri_apple_music": "applemusic://track/1449551728",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=V42RAxg0hjo",
+      "uri_tidal": "tidal://track/690085"
+    },
+    {
+      "year": 1970,
+      "uri": "spotify:track:4mXfHJAMHBFwq4MdQxne2L",
+      "artist": "Nino Bravo",
+      "alt_artists": [
+        "Raphael",
+        "Julio Iglesias",
+        "Camilo Sesto",
+        "José Luis Perales"
+      ],
+      "title": "Te Quiero, Te Quiero",
+      "chart_info": {
+        "billboard_peak": null,
+        "uk_peak": null,
+        "weeks_on_chart": null
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "Nino Bravo from Valencia died in a car crash at just 28 (1973), but his powerful tenor voice made him one of Spain's most legendary singers. His songs are still covered constantly.",
+      "fun_fact_de": "Nino Bravo aus Valencia starb mit nur 28 Jahren (1973) bei einem Autounfall, aber seine kraftvolle Tenorstimme machte ihn zu einer Legende.",
+      "fun_fact_es": "Nino Bravo de Valencia murió en accidente de coche con solo 28 años (1973), pero su potente voz de tenor lo convirtió en uno de los cantantes más legendarios de España.",
+      "fun_fact_fr": "Nino Bravo de Valence est mort dans un accident à seulement 28 ans (1973), mais sa puissante voix de ténor en a fait l'un des chanteurs les plus légendaires d'Espagne.",
+      "uri_apple_music": "applemusic://track/1442457085",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=mvHjgZJiA1g",
+      "uri_tidal": "tidal://track/37052753"
+    },
+    {
+      "year": 2005,
+      "uri": "spotify:track:020aPMXlwYFpPB7cI8Kuc1",
+      "artist": "Pignoise",
+      "alt_artists": [
+        "Pereza",
+        "El Canto del Loco",
+        "Maldita Nerea",
+        "Guaraná"
+      ],
+      "title": "Nada que perder",
+      "chart_info": {
+        "billboard_peak": null,
+        "uk_peak": null,
+        "weeks_on_chart": null
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "Named after a card game (pig nose), this Madrid pop-punk trio became one of Spain's most successful bands of the 2000s. Frontman Álvaro Benito is a former Real Madrid youth player.",
+      "fun_fact_de": "Nach einem Kartenspiel benannt, wurde dieses Madrider Pop-Punk-Trio eine der erfolgreichsten Bands Spaniens. Frontmann Álvaro Benito spielte in Real Madrids Jugend.",
+      "fun_fact_es": "Nombrados por un juego de cartas, este trío pop-punk madrileño fue una de las bandas más exitosas de los 2000. Álvaro Benito jugó en la cantera del Real Madrid.",
+      "fun_fact_fr": "Nommés d'après un jeu de cartes, ce trio pop-punk madrilène fut l'un des plus grands groupes des années 2000. Álvaro Benito jouait au Real Madrid.",
+      "uri_apple_music": "applemusic://track/151630092",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=b4YVijo8UFA",
+      "uri_tidal": "tidal://track/340902"
+    },
+    {
+      "year": 1950,
+      "uri": "spotify:track:7xT0YNKaOkvntYehrbRWen",
+      "artist": "Billos Caracas Boys",
+      "alt_artists": [
+        "Los Melódicos",
+        "Compay Segundo",
+        "Beny Moré",
+        "Celia Cruz"
+      ],
+      "title": "Se Va El Caimán",
+      "chart_info": {
+        "billboard_peak": null,
+        "uk_peak": null,
+        "weeks_on_chart": null
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "This Venezuelan-Dominican big band turned a Colombian folk song into a Latin dance standard. 'Se Va El Caimán' has been played at every Latin party for 70+ years.",
+      "fun_fact_de": "Diese venezolanisch-dominikanische Big Band machte ein kolumbianisches Volkslied zum Latin-Dance-Standard. Seit über 70 Jahren auf jeder lateinamerikanischen Party.",
+      "fun_fact_es": "Esta big band venezolano-dominicana convirtió una canción folclórica colombiana en un estándar del baile latino. Suena en cada fiesta latina desde hace más de 70 años.",
+      "fun_fact_fr": "Ce big band vénézuélo-dominicain a transformé un chant folklorique colombien en standard de danse latine. Joué à chaque fête latine depuis 70+ ans.",
+      "uri_apple_music": "applemusic://track/530174656",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=C6DKlyhQtSA",
+      "uri_tidal": "tidal://track/37191622"
+    },
+    {
+      "year": 1989,
+      "uri": "spotify:track:5ltBmvHslf7tplG5QfLmTt",
+      "artist": "Camaron De La Isla",
+      "alt_artists": [
+        "Paco de Lucía",
+        "Tomatito",
+        "Enrique Morente",
+        "Ketama"
+      ],
+      "title": "Soy Gitano",
+      "chart_info": {
+        "billboard_peak": null,
+        "uk_peak": null,
+        "weeks_on_chart": null
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "Camarón de la Isla is universally considered the greatest flamenco singer of all time. 'Soy Gitano' with the Royal Philharmonic Orchestra was a groundbreaking fusion of flamenco and symphonic music.",
+      "fun_fact_de": "Camarón de la Isla gilt als größter Flamenco-Sänger aller Zeiten. 'Soy Gitano' mit dem Royal Philharmonic Orchestra war eine bahnbrechende Fusion.",
+      "fun_fact_es": "Camarón de la Isla es considerado unánimemente el mayor cantaor flamenco de la historia. 'Soy Gitano' con la Royal Philharmonic fue una fusión revolucionaria.",
+      "fun_fact_fr": "Camarón de la Isla est universellement considéré comme le plus grand chanteur de flamenco. 'Soy Gitano' avec le Royal Philharmonic fut une fusion révolutionnaire.",
+      "uri_apple_music": "applemusic://track/1443635392",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=jhIIO4mELbs",
+      "uri_tidal": "tidal://track/3598038"
+    },
+    {
+      "year": 2021,
+      "uri": "spotify:track:0YSaKC66FGCWLxM9SoQA1f",
+      "artist": "C. Tangana, NATHY PELUSO",
+      "alt_artists": [
+        "ROSALÍA",
+        "Bad Gyal",
+        "Rels B",
+        "Dellafuente"
+      ],
+      "title": "Ateo",
+      "chart_info": {
+        "billboard_peak": null,
+        "uk_peak": null,
+        "weeks_on_chart": null
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "C. Tangana (Antón Álvarez) reinvented Spanish pop with 'El Madrileño' — mixing reggaeton, flamenco, and bossa nova. The 'Ateo' video in a cathedral caused national controversy.",
+      "fun_fact_de": "C. Tangana revolutionierte mit 'El Madrileño' den spanischen Pop. Das 'Ateo'-Video in einer Kathedrale sorgte für nationale Kontroverse.",
+      "fun_fact_es": "C. Tangana reinventó el pop español con 'El Madrileño'. El vídeo de 'Ateo' en una catedral causó polémica nacional.",
+      "fun_fact_fr": "C. Tangana a réinventé la pop espagnole avec 'El Madrileño'. Le clip d'Ateo' dans une cathédrale a causé une controverse nationale.",
+      "uri_apple_music": "applemusic://track/1588048905",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Y9WJOopLYBQ",
+      "uri_tidal": "tidal://track/199322248"
+    },
+    {
+      "year": 2002,
+      "uri": "spotify:track:3jkVN9ccFjs6HlZD4RtNC8",
+      "artist": "Paulina Rubio",
+      "alt_artists": [
+        "Thalía",
+        "Shakira",
+        "Gloria Trevi",
+        "Belinda"
+      ],
+      "title": "Causa Y Efecto",
+      "chart_info": {
+        "billboard_peak": null,
+        "uk_peak": null,
+        "weeks_on_chart": null
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "Mexico's 'Queen of Latin Pop' (ex-Timbiriche). Paulina Rubio was one of the first Latin artists to successfully cross over to the US pop market in the early 2000s.",
+      "fun_fact_de": "Mexikos 'Königin des Latin Pop' (ex-Timbiriche). Eine der ersten lateinamerikanischen Künstlerinnen, die in den USA erfolgreich wurden.",
+      "fun_fact_es": "La 'Reina del Pop Latino' de México (ex Timbiriche). Una de las primeras artistas latinas en cruzar exitosamente al mercado pop estadounidense.",
+      "fun_fact_fr": "La 'Reine du Pop Latin' du Mexique (ex-Timbiriche). L'une des premières artistes latines à percer sur le marché pop américain.",
+      "uri_apple_music": "applemusic://track/1452856259",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=PLLBHlGxFCA",
+      "uri_tidal": "tidal://track/8056799"
+    },
+    {
+      "year": 2000,
+      "uri": "spotify:track:7AdFxpPaZckmsSrQSjnmDq",
+      "artist": "Niña Pastori",
+      "alt_artists": [
+        "Rosario",
+        "Estrella Morente",
+        "Lola Flores",
+        "Niña de la Puebla"
+      ],
+      "title": "Cartita de Amor",
+      "chart_info": {
+        "billboard_peak": null,
+        "uk_peak": null,
+        "weeks_on_chart": null
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "Niña Pastori from Cádiz was discovered by Camarón de la Isla himself at age 5 and blessed by the maestro. She became one of the greatest female flamenco voices of her generation.",
+      "fun_fact_de": "Niña Pastori aus Cádiz wurde mit 5 Jahren von Camarón de la Isla selbst entdeckt und gesegnet.",
+      "fun_fact_es": "Niña Pastori de Cádiz fue descubierta por el propio Camarón de la Isla con 5 años. Se convirtió en una de las mayores voces flamencas femeninas.",
+      "fun_fact_fr": "Niña Pastori de Cadix a été découverte par Camarón de la Isla lui-même à 5 ans. Elle est devenue l'une des plus grandes voix féminines du flamenco.",
+      "uri_apple_music": "applemusic://track/276078076",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=HHhPsOF2j1c",
+      "uri_tidal": "tidal://track/60035550"
+    },
+    {
+      "year": 2021,
+      "uri": "spotify:track:5xiAfKzE3mbxYbOkUZPR11",
+      "artist": "Morat",
+      "alt_artists": [
+        "Dvicio",
+        "Taburete",
+        "Sebastián Yatra",
+        "Carlos Vives"
+      ],
+      "title": "A Dónde Vamos",
+      "chart_info": {
+        "billboard_peak": null,
+        "uk_peak": null,
+        "weeks_on_chart": null
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "Colombian band that became Spain's adopted sons — more popular in Spain than in Colombia. Their acoustic Latin pop sound resonated deeply with Spanish millennial audiences.",
+      "fun_fact_de": "Kolumbianische Band, die in Spanien populärer wurde als in Kolumbien. Ihr akustischer Latin-Pop traf den Nerv des spanischen Millennial-Publikums.",
+      "fun_fact_es": "Banda colombiana que se convirtió en hijos adoptivos de España — más populares en España que en Colombia.",
+      "fun_fact_fr": "Groupe colombien devenu les fils adoptifs de l'Espagne — plus populaires en Espagne qu'en Colombie.",
+      "uri_apple_music": "applemusic://track/1574879730",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=FO3Ks1J2A5w",
+      "uri_tidal": "tidal://track/120964882"
+    },
+    {
+      "year": 1996,
+      "uri": "spotify:track:0gdt218D74akk9AqMlbc45",
+      "artist": "Rosario",
+      "alt_artists": [
+        "Lola Flores",
+        "Ketama",
+        "Niña Pastori",
+        "Antonio Flores"
+      ],
+      "title": "Que Bonito",
+      "chart_info": {
+        "billboard_peak": null,
+        "uk_peak": null,
+        "weeks_on_chart": null
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "Rosario Flores — daughter of legends Lola Flores and El Pescaílla, sister of the late Antonio Flores. She merged flamenco with pop and became one of Spain's most iconic female artists.",
+      "fun_fact_de": "Rosario Flores — Tochter der Legenden Lola Flores und El Pescaílla. Sie verschmolz Flamenco mit Pop und wurde eine der ikonischsten Künstlerinnen Spaniens.",
+      "fun_fact_es": "Rosario Flores — hija de las leyendas Lola Flores y El Pescaílla. Fusionó flamenco con pop y se convirtió en una de las artistas más icónicas de España.",
+      "fun_fact_fr": "Rosario Flores — fille des légendes Lola Flores et El Pescaílla. Elle a fusionné flamenco et pop, devenant l'une des artistes les plus iconiques d'Espagne.",
+      "uri_apple_music": "applemusic://track/672554370",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=F1lf6kJzQWM",
+      "uri_tidal": "tidal://track/3007112"
+    },
+    {
+      "year": 1958,
+      "uri": "spotify:track:3Uht8v2qRF6sDNLSPhLQ2d",
+      "artist": "Sara Montiel",
+      "alt_artists": [
+        "Lola Flores",
+        "Imperio Argentina",
+        "Concha Piquer"
+      ],
+      "title": "Fumando Espero",
+      "chart_info": {
+        "billboard_peak": null,
+        "uk_peak": null,
+        "weeks_on_chart": null
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "Sara Montiel was Spain's first international film star, working in Hollywood alongside Gary Cooper and Burt Lancaster. 'Fumando Espero' became her iconic number, still imitated today.",
+      "fun_fact_de": "Sara Montiel war Spaniens erster internationaler Filmstar, arbeitete mit Gary Cooper und Burt Lancaster. 'Fumando Espero' ist ihre Ikonen-Nummer.",
+      "fun_fact_es": "Sara Montiel fue la primera estrella de cine internacional de España, trabajó con Gary Cooper y Burt Lancaster. 'Fumando Espero' es su número icónico.",
+      "fun_fact_fr": "Sara Montiel fut la première star de cinéma internationale d'Espagne, travaillant avec Gary Cooper et Burt Lancaster. 'Fumando Espero' reste son numéro iconique.",
+      "uri_apple_music": "applemusic://track/437565070",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=qqOdh7g7DCs",
+      "uri_tidal": "tidal://track/506029"
+    },
+    {
+      "year": 1984,
+      "uri": "spotify:track:671sG3ETDxC3L6qcGIrHRM",
+      "artist": "LOS NIKIS",
+      "alt_artists": [
+        "Siniestro Total",
+        "Los Toreros Muertos",
+        "Hombres G",
+        "Parálisis Permanente"
+      ],
+      "title": "El imperio contraataca",
+      "chart_info": {
+        "billboard_peak": null,
+        "uk_peak": null,
+        "weeks_on_chart": null
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "Los Nikis were Spain's Ramones — pioneers of Spanish punk-pop with humorous sci-fi and B-movie themed lyrics. Essential band of 'La Movida Madrileña'.",
+      "fun_fact_de": "Los Nikis waren Spaniens Ramones — Pioniere des spanischen Punk-Pop mit humorvollen Science-Fiction-Texten. Essenziell für La Movida.",
+      "fun_fact_es": "Los Nikis fueron los Ramones españoles — pioneros del punk-pop español con letras humorísticas de ciencia ficción. Esenciales en La Movida.",
+      "fun_fact_fr": "Los Nikis étaient les Ramones espagnols — pionniers du punk-pop espagnol avec des paroles humoristiques de science-fiction. Essentiels de La Movida.",
+      "uri_apple_music": "applemusic://track/110722294",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=71m3JuHKngY",
+      "uri_tidal": "tidal://track/2119322"
+    },
+    {
+      "year": 1998,
+      "uri": "spotify:track:1MO5KuLnSaY1dlkWGDjHkT",
+      "artist": "Camela",
+      "alt_artists": [
+        "Los Calis",
+        "Ángeles de Charli",
+        "El Arrebato",
+        "Andy y Lucas"
+      ],
+      "title": "Lagrimas De Amor",
+      "chart_info": {
+        "billboard_peak": null,
+        "uk_peak": null,
+        "weeks_on_chart": null
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "Camela are Spain's best-selling techno-flamenco duo with 8+ million records sold. Dismissed by critics but adored by millions — the ultimate guilty pleasure of Spanish music.",
+      "fun_fact_de": "Camela sind Spaniens meistverkauftes Techno-Flamenco-Duo mit über 8 Millionen verkauften Platten. Von Kritikern ignoriert, von Millionen geliebt.",
+      "fun_fact_es": "Camela son el dúo de tecno-flamenco más vendido de España con más de 8 millones de discos. Ignorados por la crítica pero adorados por millones.",
+      "fun_fact_fr": "Camela est le duo techno-flamenco le plus vendu d'Espagne avec 8+ millions de disques. Ignorés par la critique mais adorés par des millions.",
+      "uri_apple_music": "applemusic://track/483833736",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=DLm7rrCF7iU",
+      "uri_tidal": "tidal://track/11645466"
+    },
+    {
+      "year": 1988,
+      "uri": "spotify:track:1Y53CXQCPFejUPc0yOOc5f",
+      "artist": "Dinamita Pa Los Pollos",
+      "alt_artists": [
+        "Siniestro Total",
+        "Los Nikis",
+        "Kortatu",
+        "Eskorbuto"
+      ],
+      "title": "Pandilleros",
+      "chart_info": {
+        "billboard_peak": null,
+        "uk_peak": null,
+        "weeks_on_chart": null
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "Basque punk-rock band from Vitoria-Gasteiz who mixed punk energy with humor and social commentary. Part of the vibrant 'Rock Radikal Vasco' movement of the 80s.",
+      "fun_fact_de": "Baskische Punk-Rock-Band aus Vitoria-Gasteiz, Teil der lebhaften 'Rock Radikal Vasco'-Bewegung der 80er.",
+      "fun_fact_es": "Banda punk-rock vasca de Vitoria-Gasteiz, parte del vibrante movimiento 'Rock Radical Vasco' de los 80.",
+      "fun_fact_fr": "Groupe punk-rock basque de Vitoria-Gasteiz, partie du vibrant mouvement 'Rock Radical Vasco' des années 80.",
+      "uri_apple_music": "applemusic://track/521551606",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Dl5A9xBKCgw",
+      "uri_tidal": "tidal://track/90473142"
+    },
+    {
+      "year": 1977,
+      "uri": "spotify:track:0EzVGEyUB9HAXT1cQHwhqf",
+      "artist": "Carlos Mejia Godoy",
+      "alt_artists": [
+        "Elsa Baeza",
+        "Silvio Rodríguez",
+        "Pablo Milanés",
+        "Viglietti"
+      ],
+      "title": "Son tus Perjumenes Mujer",
+      "chart_info": {
+        "billboard_peak": null,
+        "uk_peak": null,
+        "weeks_on_chart": null
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "Nicaraguan singer-songwriter who wrote the anthem of the Sandinista revolution. His music blends folk, protest song and Central American rhythms in a way that resonated across the Spanish-speaking world.",
+      "fun_fact_de": "Nicaraguanischer Liedermacher, der die Hymne der sandinistischen Revolution schrieb. Seine Musik verbindet Folk und Protestlied.",
+      "fun_fact_es": "Cantautor nicaragüense que escribió el himno de la revolución sandinista. Su música fusiona folclore, canción protesta y ritmos centroamericanos.",
+      "fun_fact_fr": "Auteur-compositeur nicaraguayen qui a écrit l'hymne de la révolution sandiniste. Sa musique mêle folk, chanson contestataire et rythmes centraméricains.",
+      "uri_apple_music": "applemusic://track/299706392",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=cDtwkdFN9Ik",
+      "uri_tidal": "tidal://track/153082566"
+    },
+    {
+      "year": 1985,
+      "uri": "spotify:track:7wjQF9XTCrjvQZLeZBGMWs",
+      "artist": "Ana Belén",
+      "alt_artists": [
+        "Luz Casal",
+        "Rocío Dúrcal",
+        "Mocedades",
+        "María Jiménez"
+      ],
+      "title": "Derroche",
+      "chart_info": {
+        "billboard_peak": null,
+        "uk_peak": null,
+        "weeks_on_chart": null
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "Ana Belén is one of Spain's most celebrated singer-actresses. Married to songwriter Víctor Manuel, she was a key cultural figure in Spain's transition to democracy.",
+      "fun_fact_de": "Ana Belén ist eine der gefeiertsten Sängerinnen-Schauspielerinnen Spaniens. Eine Schlüsselfigur im Übergang zur Demokratie.",
+      "fun_fact_es": "Ana Belén es una de las cantantes-actrices más celebradas de España. Figura clave en la transición española a la democracia.",
+      "fun_fact_fr": "Ana Belén est l'une des chanteuses-actrices les plus célèbres d'Espagne. Figure clé de la transition démocratique espagnole.",
+      "uri_apple_music": "applemusic://track/280269117",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=hZI_gfVG6Sw",
+      "uri_tidal": "tidal://track/1840478"
+    },
+    {
+      "year": 2000,
+      "uri": "spotify:track:1dfyGDe87lHmmN8OMASyVa",
+      "artist": "Café Quijano",
+      "alt_artists": [
+        "Estopa",
+        "Melendi",
+        "Andy y Lucas",
+        "El Canto del Loco"
+      ],
+      "title": "La taberna del Buda",
+      "chart_info": {
+        "billboard_peak": null,
+        "uk_peak": null,
+        "weeks_on_chart": null
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "Three brothers from León who blended rumba, pop and bolero into a distinctive sound. 'La taberna del Buda' was one of Spain's biggest hits at the turn of the millennium.",
+      "fun_fact_de": "Drei Brüder aus León, die Rumba, Pop und Bolero verschmolzen. 'La taberna del Buda' war einer der größten Hits der Jahrtausendwende.",
+      "fun_fact_es": "Tres hermanos de León que fusionaron rumba, pop y bolero. 'La taberna del Buda' fue uno de los mayores éxitos del cambio de milenio en España.",
+      "fun_fact_fr": "Trois frères de León qui ont mélangé rumba, pop et boléro. 'La taberna del Buda' fut l'un des plus grands succès du tournant du millénaire.",
+      "uri_apple_music": "applemusic://track/256623726",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=K_mJ1NgqiSk",
+      "uri_tidal": "tidal://track/603876"
+    },
+    {
+      "year": 1996,
+      "uri": "spotify:track:5RsjTyHXCUPnWE7RyjSiIe",
+      "artist": "Rosana",
+      "alt_artists": [
+        "Luz Casal",
+        "Ana Belén",
+        "Bebe",
+        "Malú"
+      ],
+      "title": "Si tú no estas",
+      "chart_info": {
+        "billboard_peak": null,
+        "uk_peak": null,
+        "weeks_on_chart": null
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "Canarian singer-songwriter from Lanzarote who became a massive star across Latin America. 'Si tú no estás' was a pan-Hispanic hit that established her as a power ballad queen.",
+      "fun_fact_de": "Kanarische Liedermacherin aus Lanzarote, die in ganz Lateinamerika zum Star wurde.",
+      "fun_fact_es": "Cantautora canaria de Lanzarote que se convirtió en estrella en toda Latinoamérica. 'Si tú no estás' la estableció como reina de las power ballads.",
+      "fun_fact_fr": "Auteure-compositrice canarienne de Lanzarote devenue star en Amérique latine. 'Si tú no estás' l'a établie comme reine des power ballades.",
+      "uri_apple_music": "applemusic://track/258906537",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=sKoK3XnTd3g",
+      "uri_tidal": "tidal://track/4089916"
+    },
+    {
+      "year": 2005,
+      "uri": "spotify:track:73Bs0g0AbbUeQczbeUkyb0",
+      "artist": "La Casa Azul",
+      "alt_artists": [
+        "Los Planetas",
+        "El Canto del Loco",
+        "Maldita Nerea",
+        "Love of Lesbian"
+      ],
+      "title": "Podría Ser Peor",
+      "chart_info": {
+        "billboard_peak": null,
+        "uk_peak": null,
+        "weeks_on_chart": null
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "La Casa Azul is the one-man-band project of Guille Milkyway from Barcelona — Spain's answer to The Postal Service, blending indie-pop with 80s synth aesthetics.",
+      "fun_fact_de": "La Casa Azul ist das Ein-Mann-Projekt von Guille Milkyway aus Barcelona — Spaniens Antwort auf The Postal Service.",
+      "fun_fact_es": "La Casa Azul es el proyecto de Guille Milkyway de Barcelona — la respuesta española a The Postal Service, fusionando indie-pop con estética synth de los 80.",
+      "fun_fact_fr": "La Casa Azul est le projet solo de Guille Milkyway de Barcelone — la réponse espagnole à The Postal Service.",
+      "uri_apple_music": "applemusic://track/1166156257",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=XXzZ_Lz0XKg",
+      "uri_tidal": "tidal://track/418738787"
+    },
+    {
+      "year": 1996,
+      "uri": "spotify:track:40A11dg6RXzfDrwMrw5sED",
+      "artist": "Carlos Núñez",
+      "alt_artists": [
+        "Hevia",
+        "Luar Na Lubre",
+        "Milladoiro",
+        "The Chieftains"
+      ],
+      "title": "El Pozo De Aran",
+      "chart_info": {
+        "billboard_peak": null,
+        "uk_peak": null,
+        "weeks_on_chart": null
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "Galician bagpipe virtuoso who brought Celtic-Galician music to international audiences. His debut album 'A Brotherhood of Stars' sold over 1 million copies — unheard of for folk music.",
+      "fun_fact_de": "Galizischer Dudelsack-Virtuose, der keltisch-galizische Musik international bekannt machte. Sein Debüt verkaufte sich über 1 Million Mal.",
+      "fun_fact_es": "Virtuoso gallego de la gaita que llevó la música celta-gallega a audiencias internacionales. Su debut vendió más de 1 millón de copias.",
+      "fun_fact_fr": "Virtuose galicien de la cornemuse qui a fait connaître la musique celtique-galicienne au monde. Son premier album s'est vendu à plus d'1 million d'exemplaires.",
+      "uri_apple_music": "applemusic://track/1510024485",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=inN8ADUafr0",
+      "uri_tidal": "tidal://track/138832295"
+    },
+    {
+      "year": 1973,
+      "uri": "spotify:track:7CX6W4Mf98wMgX0izqRpAl",
+      "artist": "Mocedades",
+      "alt_artists": [
+        "Los Panchos",
+        "Julio Iglesias",
+        "Raphael",
+        "Nino Bravo"
+      ],
+      "title": "Tómame o Déjame",
+      "chart_info": {
+        "billboard_peak": null,
+        "uk_peak": null,
+        "weeks_on_chart": null
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "Mocedades from Bilbao represented Spain at Eurovision 1973 with 'Eres Tú', finishing 2nd. The song reached #9 on the US Billboard Hot 100 — Spain's best-ever showing in America.",
+      "fun_fact_de": "Mocedades aus Bilbao vertraten Spanien beim Eurovision 1973 mit 'Eres Tú' (Platz 2). Der Song erreichte Platz 9 der US Billboard Hot 100.",
+      "fun_fact_es": "Mocedades de Bilbao representaron a España en Eurovisión 1973 con 'Eres Tú' (2° puesto). La canción llegó al #9 del Billboard Hot 100.",
+      "fun_fact_fr": "Mocedades de Bilbao ont représenté l'Espagne à l'Eurovision 1973 avec 'Eres Tú' (2e). La chanson a atteint le #9 du Billboard Hot 100 américain.",
+      "uri_apple_music": "applemusic://track/1055226301",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=31NTBffoWWA",
+      "uri_tidal": "tidal://track/16777"
+    },
+    {
+      "year": 2002,
+      "uri": "spotify:track:7Eh2mdfhNMLRm7BFSS4uWU",
+      "artist": "Tamara",
+      "alt_artists": [
+        "Rosana",
+        "Paulina Rubio",
+        "Malú",
+        "Pastora Soler"
+      ],
+      "title": "Si No Te Hubieras Ido",
+      "chart_info": {
+        "billboard_peak": null,
+        "uk_peak": null,
+        "weeks_on_chart": null
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "Tamara from Pontevedra exploded onto the Spanish scene with her powerful voice. This Marco Antonio Solís cover became one of the biggest ballads in Spain in the early 2000s.",
+      "fun_fact_de": "Tamara aus Pontevedra eroberte die spanische Szene mit ihrer kraftvollen Stimme. Dieses Cover wurde einer der größten Balladen Spaniens der frühen 2000er.",
+      "fun_fact_es": "Tamara de Pontevedra irrumpió en la escena española con su potente voz. Esta versión se convirtió en una de las mayores baladas de los 2000.",
+      "fun_fact_fr": "Tamara de Pontevedra a explosé sur la scène espagnole avec sa voix puissante. Cette reprise est devenue l'une des plus grandes ballades des années 2000.",
+      "uri_apple_music": "applemusic://track/278948130",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=lCrZ3dgse2g",
+      "uri_tidal": "tidal://track/5862461"
+    },
+    {
+      "year": 1984,
+      "uri": "spotify:track:16ZSrvnyA13Cm55Ab9WkJP",
+      "artist": "Orquesta Mondragon",
+      "alt_artists": [
+        "Alaska y Dinarama",
+        "Gabinete Caligari",
+        "Radio Futura",
+        "Loquillo"
+      ],
+      "title": "Corazón de neón",
+      "chart_info": {
+        "billboard_peak": null,
+        "uk_peak": null,
+        "weeks_on_chart": null
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "Led by the theatrical Javier Gurruchaga, Orquesta Mondragón brought cabaret-rock showmanship to 'La Movida'. Their live shows were legendary multimedia spectacles.",
+      "fun_fact_de": "Angeführt vom theatralischen Javier Gurruchaga, brachte Orquesta Mondragón Kabarett-Rock-Showmanship in die Movida.",
+      "fun_fact_es": "Liderada por el teatral Javier Gurruchaga, Orquesta Mondragón llevó el espectáculo cabaret-rock a La Movida. Sus shows eran espectáculos multimedia legendarios.",
+      "fun_fact_fr": "Menée par le théâtral Javier Gurruchaga, Orquesta Mondragón a apporté le spectacle cabaret-rock à La Movida. Leurs shows étaient des spectacles multimédia légendaires.",
+      "uri_apple_music": "applemusic://track/1382199358",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=7cVGDkzNpwo",
+      "uri_tidal": "tidal://track/34307465"
+    },
+    {
+      "year": 2007,
+      "uri": "spotify:track:3I4rThw57SsVWFhZ81BwZv",
+      "artist": "Carlos Baute",
+      "alt_artists": [
+        "Chayanne",
+        "Luis Fonsi",
+        "Alejandro Sanz",
+        "Enrique Iglesias"
+      ],
+      "title": "Te regalo",
+      "chart_info": {
+        "billboard_peak": null,
+        "uk_peak": null,
+        "weeks_on_chart": null
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "Venezuelan heartthrob who became a massive star in Spain. Baute holds Spanish citizenship and is considered as much a Spanish artist as a Venezuelan one.",
+      "fun_fact_de": "Venezolanischer Schwarm, der in Spanien zum Star wurde. Baute hat die spanische Staatsbürgerschaft und gilt als spanischer wie venezolanischer Künstler.",
+      "fun_fact_es": "Galán venezolano que se convirtió en estrella en España. Baute tiene ciudadanía española y es considerado tanto artista español como venezolano.",
+      "fun_fact_fr": "Beau gosse vénézuélien devenu star en Espagne. Baute a la nationalité espagnole et est considéré comme artiste autant espagnol que vénézuélien.",
+      "uri_apple_music": "applemusic://track/76158627",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=YGrph6Era8A",
+      "uri_tidal": "tidal://track/175835"
+    },
+    {
+      "year": 1991,
+      "uri": "spotify:track:0qSlVX5N1OCTIjQhI6uc8F",
+      "artist": "Ray Heredia",
+      "alt_artists": [
+        "Ketama",
+        "Manzanita",
+        "Raimundo Amador",
+        "Camarón"
+      ],
+      "title": "Alegría de Vivir",
+      "chart_info": {
+        "billboard_peak": null,
+        "uk_peak": null,
+        "weeks_on_chart": null
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "Ray Heredia was a Romani musical genius from Madrid who fused flamenco, jazz and soul. He died of a drug overdose at just 24, leaving behind one brilliant album — 'Quien No Corre, Vuela'.",
+      "fun_fact_de": "Ray Heredia war ein Roma-Musikgenie aus Madrid, das Flamenco, Jazz und Soul verschmolz. Er starb mit nur 24 Jahren an einer Überdosis.",
+      "fun_fact_es": "Ray Heredia fue un genio musical gitano de Madrid que fusionó flamenco, jazz y soul. Murió de sobredosis con solo 24 años, dejando un álbum brillante.",
+      "fun_fact_fr": "Ray Heredia était un génie musical gitan de Madrid qui a fusionné flamenco, jazz et soul. Mort d'overdose à 24 ans, laissant un album brillant.",
+      "uri_apple_music": "applemusic://track/1793347154",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=lTFt_5CjkYs",
+      "uri_tidal": "tidal://track/29489663"
+    },
+    {
+      "year": 1993,
+      "uri": "spotify:track:5zAnoLd8d4ssifVCnSDrwG",
+      "artist": "El Fary",
+      "alt_artists": [
+        "Chiquetete",
+        "Los Chunguitos",
+        "Georgie Dann"
+      ],
+      "title": "El Toro Guapo",
+      "chart_info": {
+        "billboard_peak": null,
+        "uk_peak": null,
+        "weeks_on_chart": null
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "El Fary was beloved for his handlebar mustache and working-class Madrid humor. A folk singer and actor who became a national treasure.",
+      "fun_fact_de": "El Fary war berühmt für seinen Schnurrbart und verkörperte den Humor der Madrider Arbeiterklasse.",
+      "fun_fact_es": "El Fary era querido por su bigote y su humor castizo madrileño. Cantante y actor que se convirtió en tesoro nacional.",
+      "fun_fact_fr": "El Fary était adoré pour sa moustache et son humour populaire madrilène. Chanteur et acteur devenu trésor national.",
+      "uri_apple_music": "applemusic://track/1465983109",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=j9PjBhJLTc0",
+      "uri_tidal": "tidal://track/10925245"
+    },
+    {
+      "year": 1991,
+      "uri": "spotify:track:0fmgOwkb9AwgzXhYVSZRDs",
+      "artist": "Chimo Bayo",
+      "alt_artists": [
+        "Techno Valencia",
+        "Pont Aeri",
+        "DJ Sergio"
+      ],
+      "title": "Asi Me Gusta a Mi",
+      "chart_info": {
+        "billboard_peak": null,
+        "uk_peak": null,
+        "weeks_on_chart": null
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "Chimo Bayo was the king of 'bakalao', the Valencian rave scene that dominated Spanish nightlife in the early 90s.",
+      "fun_fact_de": "Chimo Bayo war der König des 'Bakalao', der valencianischen Rave-Szene der frühen 90er.",
+      "fun_fact_es": "Chimo Bayo fue el rey del 'bakalao', la escena rave valenciana que dominó la noche española a principios de los 90.",
+      "fun_fact_fr": "Chimo Bayo était le roi du 'bakalao', la scène rave valencienne qui dominait la nuit espagnole au début des années 90.",
+      "uri_apple_music": "applemusic://track/891670017",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=DwjEDNMqVTc",
+      "uri_tidal": "tidal://track/31639887"
+    },
+    {
+      "year": 1988,
+      "uri": "spotify:track:32SaRYYxS7SXjNNvIY9VBE",
+      "artist": "Georgie Dann",
+      "alt_artists": [
+        "El Fary",
+        "Los Del Río",
+        "Peret",
+        "Las Ketchup"
+      ],
+      "title": "La Barbacoa",
+      "chart_info": {
+        "billboard_peak": null,
+        "uk_peak": null,
+        "weeks_on_chart": null
+      },
+      "certifications": [],
+      "awards": [],
+      "fun_fact": "French-born Georgie Dann became the undisputed king of Spanish summer songs, releasing a new seasonal hit every year for decades.",
+      "fun_fact_de": "Der in Frankreich geborene Georgie Dann wurde zum König der spanischen Sommerhits.",
+      "fun_fact_es": "Georgie Dann, nacido en Francia, se convirtió en el rey indiscutible de las canciones del verano español.",
+      "fun_fact_fr": "Né en France, Georgie Dann est devenu le roi incontesté des tubes de l'été espagnol.",
+      "uri_apple_music": "applemusic://track/255678856",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=lTxGto9ADx0",
+      "uri_tidal": "tidal://track/505028"
+    }
+  ]
+}


### PR DESCRIPTION
## Playlist: HITSTER 100% en español

**Spotify source:** https://open.spotify.com/playlist/1DRXJOHj2G9ly41japRRUt

### Stats
- **100 songs** spanning **1935–2024**
- Genres: Pop, Rock, Flamenco, Latin, Indie, Rumba, Copla, Reggaeton
- Heavy Spain focus with some Latin American classics

### Enrichment ✅
- [x] Spotify URIs (100/100)
- [x] Apple Music URIs (100/100)
- [x] YouTube Music URIs (100/100)
- [x] Tidal URIs (100/100)
- [x] Fun facts EN/DE/ES/FR (100/100)
- [x] Alternative artists for guessing (100/100)
- [x] Release years (100/100)
- [ ] Chart info (not available without API)
- [ ] Certifications (not available without API)

### Overlap Analysis
Minimal overlap with existing playlists. Closest is **Fiesta Latina 90s** but that's 90s Latin dance vs. this being a multi-decade Spanish music history collection.

Closes #171