### PR TITLE
🔄 Bump Summer Party Anthems to v1.5

### DIFF
--- a/custom_components/beatify/playlists/summer-party-anthems.json
+++ b/custom_components/beatify/playlists/summer-party-anthems.json
@@ -1,6 +1,6 @@
 {
   "name": "100 Summer Anthems ☀️",
-  "version": "1.0",
+  "version": "1.5",
   "tags": [
     "party",
     "classics",


### PR DESCRIPTION
Version bump for Summer Party Anthems playlist to trigger update on existing installations. Includes the URI fix from #168 which was merged but never version-bumped, so existing installs still had the broken v1.0.

Ref #168