### PR TITLE
fix: French language validation, YEAR_MAX 2026, version bump (#185)

### DIFF
--- a/custom_components/beatify/const.py
+++ b/custom_components/beatify/const.py
@@ -15,7 +15,7 @@ LOBBY_DISCONNECT_GRACE_PERIOD = 5  # seconds before removing disconnected player
 
 # Year range for guesses
 YEAR_MIN = 1950
-YEAR_MAX = 2025
+YEAR_MAX = 2026
 
 # Volume control step (10%) - Story 6.4
 VOLUME_STEP = 0.1

--- a/custom_components/beatify/server/views.py
+++ b/custom_components/beatify/server/views.py
@@ -41,7 +41,7 @@ _LOGGER = logging.getLogger(__name__)
 # We avoid reading manifest.json at runtime because HA imports custom components
 # inside the event loop, and any file I/O (even at module level) triggers
 # blocking call warnings in HA 2026.2+.
-_VERSION = "2.5.1-rc.1"
+_VERSION = "2.6.0-dev"
 
 
 def _get_version() -> str:

--- a/custom_components/beatify/server/websocket.py
+++ b/custom_components/beatify/server/websocket.py
@@ -522,7 +522,7 @@ class BeatifyWebSocketHandler:
                     return
 
                 language = data.get("language", "en")
-                if language not in ("en", "de", "es"):
+                if language not in ("en", "de", "es", "fr"):
                     language = "en"  # Default to English for invalid codes
 
                 game_state.language = language


### PR DESCRIPTION
Closes #185

## Changes
- **websocket.py** — Added `fr` to language validation (was silently falling back to English)
- **const.py** — Updated `YEAR_MAX` from 2025 to 2026
- **views.py** — Updated `_VERSION` from `2.5.1-rc.1` to `2.6.0-dev`

3 one-line fixes, zero risk.