### PR TITLE
fix youtube music url with music assistant

### DIFF
--- a/custom_components/beatify/services/media_player.py
+++ b/custom_components/beatify/services/media_player.py
@@ -206,6 +206,10 @@ class MediaPlayerService:
             track_id = uri.removeprefix("tidal://track/")
             return f"https://tidal.com/browse/track/{track_id}"
 
+        if uri.startswith("https://music.youtube.com/watch?v="):
+            track_id = uri.removeprefix("https://music.youtube.com/watch?v=")
+            return f"ytmusic://track/{track_id}"
+
         # spotify:track:<id> and https:// URLs are passed through unchanged
         return uri
 


### PR DESCRIPTION
Hi,

I tried beatify with music assistant and youtube music setup in MA. It play the songs though. I dug around and found out, music assistant expects 'ytmusic://track/{track_id}` as URI instead of `https://music.youtube.com/watch?v={track_id}`. This small commit fixes this.