### PR TITLE
fix: auto-dismiss ended game when starting new game (Issue #204)

### DIFF
--- a/custom_components/beatify/server/views.py
+++ b/custom_components/beatify/server/views.py
@@ -166,10 +166,17 @@ class StartGameView(HomeAssistantView):
 
         # Check for existing game
         if game_state and game_state.game_id:
-            return web.json_response(
-                {"error": "GAME_ALREADY_STARTED", "message": "End current game first"},
-                status=409,
-            )
+            from custom_components.beatify.game.state import GamePhase  # noqa: PLC0415
+
+            if game_state.phase == GamePhase.END:
+                # Auto-dismiss ended game so admin can start a new one without
+                # having to manually click "Dismiss" first (Issue #204).
+                game_state.end_game()
+            else:
+                return web.json_response(
+                    {"error": "GAME_ALREADY_STARTED", "message": "End current game first"},
+                    status=409,
+                )
 
         try:
             body = await request.json()


### PR DESCRIPTION
## Summary

Fixes #204

## Root Cause

When a game ends naturally,  remains set (by design — so the admin can choose **Rematch** or **Dismiss**). The `/beatify/api/start-game` endpoint checked only for `game_id` being set, not the actual phase, causing it to reject new-game requests with `GAME_ALREADY_STARTED` (HTTP 409) even when the game was already in `END` phase.

**Flow that triggers the bug:**
1. Game finishes → phase = `END`, `game_id` still set ✅
2. Admin clicks **New Game** on end screen → redirected to `/beatify/admin`
3. Admin configures playlist/player → clicks **Start Game**
4. Backend sees `game_id` set → returns 409 ❌

## Fix

In `StartGameView.post()` (`server/views.py`): if the existing game is in `END` phase, automatically call `end_game()` (equivalent to Dismiss) before creating the new game.

```python
if game_state and game_state.game_id:
    if game_state.phase == GamePhase.END:
        # Auto-dismiss ended game so admin can start fresh (Issue #204)
        game_state.end_game()
    else:
        return web.json_response(
            {"error": "GAME_ALREADY_STARTED", "message": "End current game first"},
            status=409,
        )
```

## Testing
- Play a full game to completion
- Click **New Game** on the end screen
- Configure and start a new game → should work without errors
- **Rematch** flow is unaffected (goes through `rematch_game` action, not this endpoint)