### PR TITLE
feat: add GitHub Pages landing page with correct HACS deeplink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,6 @@ _bmad-output/
 .agentforce/
 .claude/
 scripts/
-docs/
 
 # ---- Duplicate deployed copy ----
 beatify/

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,209 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Beatify - Open-Source Music Trivia Quiz for Home Assistant</title>
+  <style>
+    :root {
+      --bg-primary: #0d1117;
+      --bg-secondary: #161b22;
+      --text-primary: #f0f6fc;
+      --text-secondary: #8b949e;
+      --accent: #58a6ff;
+      --accent-hover: #79b8ff;
+      --border: #30363d;
+    }
+
+    * {
+      margin: 0;
+      padding: 0;
+      box-sizing: border-box;
+    }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif;
+      background-color: var(--bg-primary);
+      color: var(--text-primary);
+      line-height: 1.6;
+      min-height: 100vh;
+    }
+
+    .container {
+      max-width: 900px;
+      margin: 0 auto;
+      padding: 0 1.5rem;
+    }
+
+    /* Hero */
+    .hero {
+      text-align: center;
+      padding: 4rem 0 3rem;
+    }
+
+    .hero h1 {
+      font-size: 3.5rem;
+      font-weight: 700;
+      margin-bottom: 0.5rem;
+      background: linear-gradient(135deg, var(--accent), #a371f7);
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+      background-clip: text;
+    }
+
+    .hero .tagline {
+      font-size: 1.25rem;
+      color: var(--text-secondary);
+      margin-bottom: 2rem;
+    }
+
+    /* HACS Button */
+    .hacs-button {
+      display: inline-block;
+      transition: transform 0.2s ease, opacity 0.2s ease;
+    }
+
+    .hacs-button:hover {
+      transform: scale(1.05);
+      opacity: 0.9;
+    }
+
+    .hacs-button img {
+      height: 48px;
+    }
+
+    /* Features */
+    .features {
+      padding: 3rem 0;
+    }
+
+    .features-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+      gap: 1.5rem;
+    }
+
+    .feature {
+      background: var(--bg-secondary);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      padding: 1.5rem;
+      text-align: center;
+    }
+
+    .feature-icon {
+      font-size: 2rem;
+      margin-bottom: 0.75rem;
+    }
+
+    .feature h3 {
+      font-size: 1.1rem;
+      margin-bottom: 0.5rem;
+      color: var(--text-primary);
+    }
+
+    .feature p {
+      font-size: 0.9rem;
+      color: var(--text-secondary);
+    }
+
+    /* Footer */
+    .footer {
+      text-align: center;
+      padding: 3rem 0 2rem;
+      border-top: 1px solid var(--border);
+      margin-top: 2rem;
+    }
+
+    .footer a {
+      color: var(--accent);
+      text-decoration: none;
+    }
+
+    .footer a:hover {
+      color: var(--accent-hover);
+      text-decoration: underline;
+    }
+
+    .github-link {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      font-size: 1rem;
+      margin-bottom: 1rem;
+    }
+
+    .github-link svg {
+      width: 20px;
+      height: 20px;
+      fill: currentColor;
+    }
+
+    .footer-text {
+      font-size: 0.85rem;
+      color: var(--text-secondary);
+    }
+
+    /* Responsive */
+    @media (max-width: 600px) {
+      .hero h1 {
+        font-size: 2.5rem;
+      }
+
+      .hero .tagline {
+        font-size: 1rem;
+      }
+
+      .features-grid {
+        grid-template-columns: 1fr;
+      }
+    }
+  </style>
+</head>
+<body>
+  <main class="container">
+    <section class="hero">
+      <h1>Beatify</h1>
+      <p class="tagline">Open-Source Music Trivia Quiz for Home Assistant</p>
+      <a href="https://my.home-assistant.io/redirect/hacs_repository/?owner=mholzi&repository=beatify&category=integration" class="hacs-button" target="_blank" rel="noopener noreferrer">
+        <img src="https://my.home-assistant.io/badges/hacs_repository.svg" alt="Open in HACS">
+      </a>
+    </section>
+
+    <section class="features">
+      <div class="features-grid">
+        <div class="feature">
+          <div class="feature-icon">👥</div>
+          <h3>Multiplayer</h3>
+          <p>Play with friends and family. Compete for the highest score in real-time.</p>
+        </div>
+        <div class="feature">
+          <div class="feature-icon">🔊</div>
+          <h3>Multi-Platform Audio</h3>
+          <p>Works with Sonos, Alexa, Music Assistant, and other media players.</p>
+        </div>
+        <div class="feature">
+          <div class="feature-icon">📱</div>
+          <h3>QR Code Join</h3>
+          <p>Guests join instantly by scanning a QR code. No app install required.</p>
+        </div>
+        <div class="feature">
+          <div class="feature-icon">📅</div>
+          <h3>Year Guessing</h3>
+          <p>Guess the release year of songs for bonus points and extra fun.</p>
+        </div>
+      </div>
+    </section>
+
+    <footer class="footer">
+      <a href="https://github.com/mholzi/beatify" class="github-link" target="_blank" rel="noopener noreferrer">
+        <svg viewBox="0 0 16 16" aria-hidden="true">
+          <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/>
+        </svg>
+        View on GitHub
+      </a>
+      <p class="footer-text">Made with ❤️ for the Home Assistant community</p>
+    </footer>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
Creates `docs/index.html` as a GitHub Pages landing page for Beatify.

## Context
GitHub Pages was configured to serve from `/docs` on `main`, but the folder didn't exist → Pages build error.

## Changes
- **`docs/index.html`**: Self-contained landing page with:
  - Hero section (Beatify heading + tagline)
  - Official HACS badge linking to the correct deeplink:
    `https://my.home-assistant.io/redirect/hacs_repository/?owner=mholzi&repository=beatify&category=integration`
  - 4 feature highlights (Multiplayer, Sonos/Alexa/Music Assistant, QR Code, Year Guessing)
  - GitHub repo link
  - Dark theme, CSS variables, mobile-responsive, no external dependencies
- **`.gitignore`**: Removed `docs/` exclusion so the folder is tracked

## Result
Pages site will be live at https://mholzi.github.io/beatify/

Closes #198