### PR TITLE
fix: shareable result cards — correct screen, better design, richer PNG

### DIFF
--- a/custom_components/beatify/www/admin.html
+++ b/custom_components/beatify/www/admin.html
@@ -288,7 +288,7 @@
             <div id="admin-share-container" class="share-container hidden">
                 <div class="share-header">📤 Share Results</div>
                 <div id="admin-share-player-tabs" class="admin-share-player-tabs"></div>
-                <pre id="admin-share-emoji-grid" class="emoji-grid-preview"></pre>
+                <div id="admin-share-emoji-grid" class="emoji-grid-preview"></div>
                 <div class="share-buttons">
                     <button id="admin-share-copy-btn" class="share-btn">📋 Copy Text</button>
                     <button id="admin-share-save-btn" class="share-btn">📸 Save Card</button>

--- a/custom_components/beatify/www/css/dashboard.css
+++ b/custom_components/beatify/www/css/dashboard.css
@@ -1216,3 +1216,90 @@
         bottom: 150px;
     }
 }
+
+/* ==========================================
+   Shareable Result Cards (Issue #216)
+   ========================================== */
+
+.dashboard-share-container {
+    margin-top: var(--space-xl);
+    padding: var(--space-lg);
+}
+
+.dashboard-share-container .leaderboard-title {
+    margin-bottom: var(--space-lg);
+    text-align: center;
+}
+
+.dashboard-share-grids {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-lg);
+    justify-content: center;
+}
+
+.dashboard-share-card {
+    background: rgba(26, 26, 46, 0.9);
+    border: 1px solid rgba(233, 69, 96, 0.3);
+    border-radius: 16px;
+    padding: var(--space-md) var(--space-lg);
+    min-width: 280px;
+    max-width: 400px;
+    animation: share-card-appear 0.5s ease-out forwards;
+    opacity: 0;
+}
+
+@keyframes share-card-appear {
+    from {
+        opacity: 0;
+        transform: translateY(20px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+.dashboard-share-player-name {
+    font-size: 1.25rem;
+    font-weight: 600;
+    color: var(--color-accent, #e94560);
+    text-align: center;
+    margin-bottom: var(--space-sm);
+}
+
+.emoji-grid-preview {
+    background: #1a1a2e;
+    border: 1px solid rgba(233, 69, 96, 0.3);
+    border-radius: 12px;
+    padding: 16px 20px;
+    text-align: center;
+    font-family: system-ui, -apple-system, sans-serif;
+    font-size: 15px;
+    line-height: 1.9;
+    color: #ffffff;
+    white-space: pre-line;
+    margin: 12px 0;
+    width: 100%;
+    box-sizing: border-box;
+}
+
+.emoji-grid-line {
+    margin: 4px 0;
+}
+
+/* TV Breakpoint for share cards */
+@media (min-width: 1400px) {
+    .dashboard-share-card {
+        min-width: 320px;
+        max-width: 450px;
+    }
+
+    .emoji-grid-preview {
+        font-size: 18px;
+    }
+
+    .dashboard-share-player-name {
+        font-size: 1.5rem;
+    }
+}

--- a/custom_components/beatify/www/css/styles.css
+++ b/custom_components/beatify/www/css/styles.css
@@ -8198,19 +8198,21 @@ body.device-tier-low .reveal-skip-hint {
 }
 
 .emoji-grid-preview {
-    background: var(--card-bg, #1a1a2e);
-    border: 1px solid var(--border-color, #333);
+    background: #1a1a2e;
+    border: 1px solid rgba(233, 69, 96, 0.3);
     border-radius: 12px;
-    padding: 1rem 1.5rem;
-    margin: 0 auto 1rem;
+    padding: 16px 20px;
+    margin: 12px auto;
     max-width: 400px;
-    font-family: 'Segoe UI Emoji', 'Apple Color Emoji', 'Noto Color Emoji', monospace;
-    font-size: 0.9rem;
-    line-height: 1.6;
-    white-space: pre-wrap;
+    font-family: system-ui, -apple-system, 'Segoe UI', sans-serif;
+    font-size: 15px;
+    line-height: 1.9;
+    white-space: pre-line;
     word-break: break-word;
-    text-align: left;
-    color: var(--text-primary, #eee);
+    text-align: center;
+    color: #ffffff;
+    width: 100%;
+    box-sizing: border-box;
 }
 
 .share-buttons {

--- a/custom_components/beatify/www/dashboard.html
+++ b/custom_components/beatify/www/dashboard.html
@@ -223,6 +223,14 @@
                         <!-- Final leaderboard entries rendered by JS -->
                     </div>
                 </div>
+
+                <!-- Shareable Result Cards (Issue #216) -->
+                <div id="dashboard-share-container" class="dashboard-share-container hidden">
+                    <h2 class="leaderboard-title">📤 Share Results</h2>
+                    <div id="dashboard-share-grids" class="dashboard-share-grids">
+                        <!-- All players' emoji grids rendered by JS -->
+                    </div>
+                </div>
             </div>
         </div>
 

--- a/custom_components/beatify/www/js/dashboard.js
+++ b/custom_components/beatify/www/js/dashboard.js
@@ -863,6 +863,59 @@
 
             container.innerHTML = html;
         }
+
+        // Render shareable result cards (Issue #216)
+        renderDashboardShare(data.share_data, leaderboard);
+    }
+
+    /**
+     * Render shareable result cards on dashboard end screen (Issue #216)
+     * Shows all players' emoji grids prominently on the TV screen
+     * @param {Object|null} shareData - Share data with emoji_grids, playlist_name
+     * @param {Array} leaderboard - Leaderboard for ordering players
+     */
+    function renderDashboardShare(shareData, leaderboard) {
+        var container = document.getElementById('dashboard-share-container');
+        var gridsEl = document.getElementById('dashboard-share-grids');
+        if (!container || !gridsEl) return;
+
+        if (!shareData || !shareData.emoji_grids || Object.keys(shareData.emoji_grids).length === 0) {
+            container.classList.add('hidden');
+            return;
+        }
+
+        var emojiGrids = shareData.emoji_grids;
+
+        // Order by leaderboard rank, then show remaining
+        var orderedPlayers = [];
+        leaderboard.forEach(function(entry) {
+            if (emojiGrids[entry.name]) {
+                orderedPlayers.push(entry.name);
+            }
+        });
+        // Add any players not in leaderboard
+        Object.keys(emojiGrids).forEach(function(name) {
+            if (orderedPlayers.indexOf(name) === -1) {
+                orderedPlayers.push(name);
+            }
+        });
+
+        // Render each player's grid
+        var html = '';
+        orderedPlayers.forEach(function(playerName, index) {
+            var grid = emojiGrids[playerName];
+            var gridLines = grid.split('\n').map(function(line) {
+                return '<div class="emoji-grid-line">' + utils.escapeHtml(line) + '</div>';
+            }).join('');
+
+            html += '<div class="dashboard-share-card" style="animation-delay: ' + (index * 0.1) + 's">' +
+                '<div class="dashboard-share-player-name">' + utils.escapeHtml(playerName) + '</div>' +
+                '<div class="emoji-grid-preview">' + gridLines + '</div>' +
+            '</div>';
+        });
+
+        gridsEl.innerHTML = html;
+        container.classList.remove('hidden');
     }
 
     /**

--- a/custom_components/beatify/www/player.html
+++ b/custom_components/beatify/www/player.html
@@ -547,7 +547,7 @@
                 <!-- Shareable Result Cards (Issue #120) -->
                 <div id="share-container" class="share-container hidden">
                     <div class="share-header" data-i18n="share.share_tab">📤 Share</div>
-                    <pre id="share-emoji-grid" class="emoji-grid-preview"></pre>
+                    <div id="share-emoji-grid" class="emoji-grid-preview"></div>
                     <div class="share-buttons">
                         <button id="share-copy-btn" class="share-btn" data-i18n="share.share_copy">📋 Copy Text</button>
                         <button id="share-save-btn" class="share-btn" data-i18n="share.share_save">📸 Save Card</button>


### PR DESCRIPTION
## Summary
Fixes Bug #216 — three separate issues with the shareable result cards feature.

## Problem 1: Wrong screen placement ✅
Share section was shown in the **admin control panel** (admin.html, alongside Revanche/Ende buttons) — the wrong moment.

**Fixed:** Added `#dashboard-share-container` to `dashboard.html` (the TV podium/confetti screen). New `renderDashboardShare()` in `dashboard.js` renders all players' emoji grids on the emotional highlight screen. Players' share section on `player.html` was already on the correct screen (end-view).

## Problem 2: Bad text preview design ✅
Both screens used `<pre class="emoji-grid-preview">` — monospaced, misaligned, debug-output look.

**Fixed:**
- Changed to `<div class="emoji-grid-preview">` in both `admin.html` and `player.html`
- Updated `updateAdminShareGrid()` and `renderShareTab()` to use `innerHTML` with styled line divs
- New CSS: dark card background, system-ui font, centered text, accent border, proper line-height

## Problem 3: PNG card too minimal ✅
`generateAdminVisualCard()` / `generateVisualCard()` only showed winner + points.

**Fixed:** Full canvas redesign (800×600) with:
- Dark gradient background (#0f0c29 → #302b63)
- Beatify header + playlist name
- Player name / rank / score (large, prominent)
- Full emoji grid (32px, centered, row by row)
- Stats row (streak, rounds correct)
- 'beatify.fun' footer

## Files changed (8)
| File | Change |
|------|--------|
| `dashboard.html` | Add `#dashboard-share-container` |
| `dashboard.js` | Add `renderDashboardShare()`, call from `renderEndView()` |
| `dashboard.css` | Styles for dashboard share cards (TV-optimized, animated) |
| `styles.css` | Update `.emoji-grid-preview` CSS |
| `admin.html` | `<pre>` → `<div>` |
| `admin.js` | Redesign `generateAdminVisualCard()`, fix `updateAdminShareGrid()` |
| `player.html` | `<pre>` → `<div>` |
| `player.js` | Redesign `generateVisualCard()`, fix `renderShareTab()` |

Closes #216