### PR TITLE
fix: track streak_10 in analytics (was streak_7)

### DIFF
--- a/custom_components/beatify/analytics.py
+++ b/custom_components/beatify/analytics.py
@@ -43,7 +43,7 @@ class GameRecord(TypedDict):
     # Story 19.11: Streak achievements
     streak_3_count: int  # Number of 3+ streaks achieved
     streak_5_count: int  # Number of 5+ streaks achieved
-    streak_7_count: int  # Number of 7+ streaks achieved
+    streak_10_count: int  # Number of 10+ streaks achieved
     # Story 19.12: Bet tracking
     total_bets: int  # Total bets placed in game
     bets_won: int  # Bets that won (doubled points)
@@ -684,14 +684,14 @@ class AnalyticsStorage:
         # Sum streak achievements across all games
         streak_3_total = sum(g.get("streak_3_count", 0) for g in games)
         streak_5_total = sum(g.get("streak_5_count", 0) for g in games)
-        streak_7_total = sum(g.get("streak_7_count", 0) for g in games)
+        streak_10_total = sum(g.get("streak_10_count", 0) for g in games)
 
-        total_streaks = streak_3_total + streak_5_total + streak_7_total
+        total_streaks = streak_3_total + streak_5_total + streak_10_total
 
         return {
             "streak_3_count": streak_3_total,
             "streak_5_count": streak_5_total,
-            "streak_7_count": streak_7_total,
+            "streak_10_count": streak_10_total,
             "total_streaks": total_streaks,
             "has_data": total_streaks > 0,
         }

--- a/custom_components/beatify/server/views.py
+++ b/custom_components/beatify/server/views.py
@@ -41,7 +41,7 @@ _LOGGER = logging.getLogger(__name__)
 # We avoid reading manifest.json at runtime because HA imports custom components
 # inside the event loop, and any file I/O (even at module level) triggers
 # blocking call warnings in HA 2026.2+.
-_VERSION = "2.6.0-dev"
+_VERSION = "2.6.0"
 
 
 def _get_version() -> str:

--- a/custom_components/beatify/services/stats.py
+++ b/custom_components/beatify/services/stats.py
@@ -163,7 +163,7 @@ class StatsService:
                 # Story 19.11: Streak achievements
                 "streak_3_count": game_summary.get("streak_3_count", 0),
                 "streak_5_count": game_summary.get("streak_5_count", 0),
-                "streak_7_count": game_summary.get("streak_7_count", 0),
+                "streak_10_count": game_summary.get("streak_10_count", 0),
                 # Story 19.12: Bet tracking
                 "total_bets": game_summary.get("total_bets", 0),
                 "bets_won": game_summary.get("bets_won", 0),


### PR DESCRIPTION
## Root Cause
`scoring.py` and `state.py` correctly tracked/exported `streak_10_count`, but `analytics.py` and `stats.py` were still reading `streak_7_count` — a key that no longer exists. Every streak-10 achievement silently dropped to zero in all aggregation.

## Changes
| File | Change |
|------|--------|
| `analytics.py` | `streak_7_count` → `streak_10_count` in TypedDict + `compute_streak_stats()` |
| `services/stats.py` | Read `streak_10_count` from game summary |
| `server/views.py` | Align `_VERSION` with `manifest.json` ("2.6.0-dev" → "2.6.0") |

Note: `scoring.py` (condition `== 10`) and `state.py` (exports `streak_10_count`) were already correct.

## Testing
Existing unit tests cover streak scoring. Analytics aggregation: after this fix, games where a player hits 10 consecutive correct answers will correctly appear in streak stats.

Closes #188