### PR TITLE
fix: shareable result cards — real logo + correct screen position

### DIFF
--- a/custom_components/beatify/www/dashboard.html
+++ b/custom_components/beatify/www/dashboard.html
@@ -203,6 +203,14 @@
                     </div>
                 </div>
 
+                <!-- Shareable Result Cards (Issue #216, #227) — directly under podium -->
+                <div id="dashboard-share-container" class="dashboard-share-container hidden">
+                    <h2 class="leaderboard-title">📤 Share Results</h2>
+                    <div id="dashboard-share-grids" class="dashboard-share-grids">
+                        <!-- All players' emoji grids rendered by JS -->
+                    </div>
+                </div>
+
                 <!-- Stats comparison (Story 14.4) -->
                 <div id="end-stats-comparison" class="stats-comparison hidden">
                     <div class="stats-comparison-content">
@@ -221,14 +229,6 @@
                     <h2 class="leaderboard-title" data-i18n="leaderboard.fullRankings">Full Rankings</h2>
                     <div id="end-leaderboard" class="dashboard-leaderboard dashboard-leaderboard--final">
                         <!-- Final leaderboard entries rendered by JS -->
-                    </div>
-                </div>
-
-                <!-- Shareable Result Cards (Issue #216) -->
-                <div id="dashboard-share-container" class="dashboard-share-container hidden">
-                    <h2 class="leaderboard-title">📤 Share Results</h2>
-                    <div id="dashboard-share-grids" class="dashboard-share-grids">
-                        <!-- All players' emoji grids rendered by JS -->
                     </div>
                 </div>
             </div>

--- a/custom_components/beatify/www/js/admin.js
+++ b/custom_components/beatify/www/js/admin.js
@@ -1789,11 +1789,27 @@ function generateAdminVisualCard(emojiGrid, playlistName, shareData) {
     ctx.fillStyle = accentGrad;
     ctx.fillRect(0, 0, 800, 4);
 
-    // Header: Beatify logo text
-    ctx.fillStyle = '#ffffff';
-    ctx.font = 'bold 28px system-ui, sans-serif';
+    // Header: Beatify logo image (Fix #227)
+    var logoImg = new Image();
+    logoImg.src = '/beatify/static/img/icon-256.png';
+    logoImg.onerror = function() { drawAdminCardContent(null); };
+    logoImg.onload = function() { drawAdminCardContent(logoImg); };
+
+    function drawAdminCardContent(logo) {
+    // Logo image (top-left) + "Beatify" text next to it
+    if (logo) {
+        ctx.drawImage(logo, 16, 8, 48, 48);
+        ctx.fillStyle = '#ffffff';
+        ctx.font = 'bold 26px system-ui, sans-serif';
+        ctx.textAlign = 'left';
+        ctx.fillText('Beatify', 72, 42);
+    } else {
+        ctx.fillStyle = '#ffffff';
+        ctx.font = 'bold 28px system-ui, sans-serif';
+        ctx.textAlign = 'center';
+        ctx.fillText('🎵 Beatify', 400, 45);
+    }
     ctx.textAlign = 'center';
-    ctx.fillText('🎵 Beatify', 400, 45);
 
     // Playlist name
     ctx.fillStyle = '#e94560';
@@ -1857,6 +1873,7 @@ function generateAdminVisualCard(emojiGrid, playlistName, shareData) {
     canvas.toBlob(function(blob) {
         downloadAdminBlob(blob);
     }, 'image/png');
+    } // end drawAdminCardContent
 }
 
 /**

--- a/custom_components/beatify/www/js/player.js
+++ b/custom_components/beatify/www/js/player.js
@@ -3794,11 +3794,27 @@
         ctx.fillStyle = accentGrad;
         ctx.fillRect(0, 0, 800, 4);
 
-        // Header: Beatify logo text
-        ctx.fillStyle = '#ffffff';
-        ctx.font = 'bold 28px system-ui, sans-serif';
+        // Header: Beatify logo image (Fix #227)
+        var logoImg = new Image();
+        logoImg.src = '/beatify/static/img/icon-256.png';
+        logoImg.onerror = function() { drawCardContent(null); };
+        logoImg.onload = function() { drawCardContent(logoImg); };
+
+        function drawCardContent(logo) {
+        // Logo image (top-left) + "Beatify" text next to it
+        if (logo) {
+            ctx.drawImage(logo, 16, 8, 48, 48);
+            ctx.fillStyle = '#ffffff';
+            ctx.font = 'bold 26px system-ui, sans-serif';
+            ctx.textAlign = 'left';
+            ctx.fillText('Beatify', 72, 42);
+        } else {
+            ctx.fillStyle = '#ffffff';
+            ctx.font = 'bold 28px system-ui, sans-serif';
+            ctx.textAlign = 'center';
+            ctx.fillText('🎵 Beatify', 400, 45);
+        }
         ctx.textAlign = 'center';
-        ctx.fillText('🎵 Beatify', 400, 45);
 
         // Playlist name
         ctx.fillStyle = '#e94560';
@@ -3878,6 +3894,7 @@
             }
             downloadBlob(blob);
         }, 'image/png');
+        } // end drawCardContent
     }
 
     /**

--- a/custom_components/beatify/www/player.html
+++ b/custom_components/beatify/www/player.html
@@ -531,6 +531,17 @@
                     </div>
                 </div>
 
+                <!-- Shareable Result Cards (Issue #120, #227) — directly under podium -->
+                <div id="share-container" class="share-container hidden">
+                    <div class="share-header" data-i18n="share.share_tab">📤 Share</div>
+                    <div id="share-emoji-grid" class="emoji-grid-preview"></div>
+                    <div class="share-buttons">
+                        <button id="share-copy-btn" class="share-btn" data-i18n="share.share_copy">📋 Copy Text</button>
+                        <button id="share-save-btn" class="share-btn" data-i18n="share.share_save">📸 Save Card</button>
+                    </div>
+                    <div id="share-toast" class="share-toast hidden" data-i18n="share.share_copied">Copied!</div>
+                </div>
+
                 <!-- Superlatives / Fun Awards (Story 15.2) -->
                 <div id="superlatives-container" class="superlatives-container hidden">
                     <!-- Rendered by JS: award cards with emoji, title, player name, value -->
@@ -542,17 +553,6 @@
                     <div id="highlights-list" class="highlights-list">
                         <!-- Populated by JavaScript -->
                     </div>
-                </div>
-
-                <!-- Shareable Result Cards (Issue #120) -->
-                <div id="share-container" class="share-container hidden">
-                    <div class="share-header" data-i18n="share.share_tab">📤 Share</div>
-                    <div id="share-emoji-grid" class="emoji-grid-preview"></div>
-                    <div class="share-buttons">
-                        <button id="share-copy-btn" class="share-btn" data-i18n="share.share_copy">📋 Copy Text</button>
-                        <button id="share-save-btn" class="share-btn" data-i18n="share.share_save">📸 Save Card</button>
-                    </div>
-                    <div id="share-toast" class="share-toast hidden" data-i18n="share.share_copied">Copied!</div>
                 </div>
 
                 <!-- Full leaderboard -->


### PR DESCRIPTION
## Summary
Fixes both bugs from Issue #227 (follow-up to #216).

## Bug 1 — Logo in PNG Card

**Before:** PNG card header rendered as text `🎵 Beatify` (28px emoji).
**After:** Actual app icon loaded via `new Image()`, drawn with `ctx.drawImage()` at 48×48px top-left, with "Beatify" text beside it.

**Approach:**
```js
var logoImg = new Image();
logoImg.src = '/beatify/static/img/icon-256.png';
logoImg.onerror = function() { drawCardContent(null); }; // graceful fallback
logoImg.onload  = function() { drawCardContent(logoImg); };
```
All canvas drawing moved inside the callback. On error, falls back to emoji text. Applied to both `generateVisualCard()` (player.js) and `generateAdminVisualCard()` (admin.js).

## Bug 2 — Share Section Position

**Before:**
- `player.html`: `#share-container` appeared after `#highlights-container` (far below podium)
- `dashboard.html`: `#dashboard-share-container` appeared after the full leaderboard

**After:**
- `player.html`: `#share-container` moved directly after `.your-result` — immediately below the podium and personal stats
- `dashboard.html`: `#dashboard-share-container` moved directly after `.dashboard-podium` — the first thing visible after the Top 3

DOM order is now: Podium → Share Cards → Stats → Superlatives → Highlights → Leaderboard

## Files Changed (4)
| File | Change |
|------|--------|
| `player.html` | Move `#share-container` before superlatives/highlights |
| `dashboard.html` | Move `#dashboard-share-container` before stats comparison |
| `js/player.js` | `generateVisualCard()`: image load + `drawCardContent()` |
| `js/admin.js` | `generateAdminVisualCard()`: image load + `drawAdminCardContent()` |

Closes #227