### PR TITLE
fix: resolve 404 images on GitHub Pages website

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -27,8 +27,8 @@
   <meta name="twitter:image" content="https://raw.githubusercontent.com/mholzi/beatify/main/images/social-preview.png">
 
   <!-- Favicon -->
-  <link rel="icon" type="image/svg+xml" href="images/icon.svg">
-  <link rel="icon" type="image/png" sizes="192x192" href="images/icon.png">
+  <link rel="icon" type="image/svg+xml" href="https://raw.githubusercontent.com/mholzi/beatify/main/images/icon.svg">
+  <link rel="icon" type="image/png" sizes="192x192" href="https://raw.githubusercontent.com/mholzi/beatify/main/images/icon.png">
 
   <!-- Preconnect hints -->
   <link rel="preconnect" href="https://img.shields.io">
@@ -70,7 +70,7 @@
     <div class="container">
       <nav class="nav" aria-label="Main navigation">
         <a href="#" class="logo" aria-label="Beatify Home">
-          <img src="images/beatify-logo.png" alt="Beatify Logo" width="28" height="28" class="logo-img">
+          <img src="https://raw.githubusercontent.com/mholzi/beatify/main/images/beatify-logo.png" alt="Beatify Logo" width="28" height="28" class="logo-img">
           Beatify
         </a>
         <ul class="nav-links">
@@ -114,7 +114,7 @@
           </div>
 
           <div class="hero-image">
-            <img src="images/qr-lobby.png" alt="Beatify QR code lobby — guests scan to join the music trivia game" width="600" height="400" loading="eager">
+            <img src="https://raw.githubusercontent.com/mholzi/beatify/main/images/qr-lobby.png" alt="Beatify QR code lobby — guests scan to join the music trivia game" width="600" height="400" loading="eager">
           </div>
         </div>
       </section>
@@ -200,15 +200,15 @@
           <h2 class="section-title">See It in Action</h2>
           <div class="screenshots-grid">
             <div class="screenshot-card">
-              <img src="images/player-gameplay.png" alt="Player view — slide to guess the release year" width="320" height="200" loading="lazy">
+              <img src="https://raw.githubusercontent.com/mholzi/beatify/main/images/player-gameplay.png" alt="Player view — slide to guess the release year" width="320" height="200" loading="lazy">
               <p class="screenshot-caption">Slide to guess the release year — every second counts</p>
             </div>
             <div class="screenshot-card">
-              <img src="images/reveal-screen.png" alt="Reveal screen — the year drops and gold confetti flies" width="320" height="200" loading="lazy">
+              <img src="https://raw.githubusercontent.com/mholzi/beatify/main/images/reveal-screen.png" alt="Reveal screen — the year drops and gold confetti flies" width="320" height="200" loading="lazy">
               <p class="screenshot-caption">The year drops. The room erupts. Gold confetti for exact guesses.</p>
             </div>
             <div class="screenshot-card">
-              <img src="images/podium-screen.png" alt="Podium screen — fireworks, medals, personal stats" width="320" height="200" loading="lazy">
+              <img src="https://raw.githubusercontent.com/mholzi/beatify/main/images/podium-screen.png" alt="Podium screen — fireworks, medals, personal stats" width="320" height="200" loading="lazy">
               <p class="screenshot-caption">Fireworks, medals, personal stats — and inevitably, a rematch demand.</p>
             </div>
           </div>
@@ -357,7 +357,7 @@
   <footer class="footer">
     <div class="container">
       <div class="footer-logo">
-        <img src="images/beatify-logo.png" alt="Beatify" width="24" height="24">
+        <img src="https://raw.githubusercontent.com/mholzi/beatify/main/images/beatify-logo.png" alt="Beatify" width="24" height="24">
         <span>Beatify</span>
       </div>
       <p class="footer-heart">Made with ❤️ for the Home Assistant community</p>


### PR DESCRIPTION
## Problem

All images on https://mholzi.github.io/beatify/ returned 404.

**Root cause:** GitHub Pages was configured to serve from `main` branch, `/docs` folder. The `images/` directory is at the repo root, not inside `docs/` — so relative paths like `images/qr-lobby.png` in the HTML resolved to `docs/images/qr-lobby.png` which doesn't exist.

## Fix

Replace all relative `images/...` references in `docs/index.html` with absolute `https://raw.githubusercontent.com/mholzi/beatify/main/images/` URLs.

These serve directly from GitHub's content CDN and work regardless of the Pages source branch configuration. This is a proven pattern for GitHub Pages projects that store assets outside the served directory.

**Affected references (10 total):**
- `beatify-logo.png` (nav logo + footer)
- `icon.svg` / `icon.png` (favicons)
- `qr-lobby.png` (hero image)
- `player-gameplay.png` / `reveal-screen.png` / `podium-screen.png` (screenshots)
- `social-preview.png` (og:image + twitter:image — already absolute, unchanged)

**Additionally:** GitHub Pages source was switched to the `gh-pages` branch (via API) which already has `images/` correctly populated by the deploy workflow (`cp -r images docs/images`). This fix ensures images work in either Pages configuration.