### PR TITLE
feat: Expliziter PWA Install-Button im Admin-Header (#226)

### DIFF
--- a/custom_components/beatify/www/admin.html
+++ b/custom_components/beatify/www/admin.html
@@ -22,11 +22,26 @@
 <body class="theme-dark">
     <header class="admin-header">
         <h1 class="wordmark"><span class="wordmark-beat">Beat</span><span class="wordmark-gradient">ify</span></h1>
-        <!-- Analytics Link (Story 19.2, updated 19.13) -->
-        <a href="/beatify/analytics" class="analytics-icon-link" id="analytics-link" aria-label="Analytics Dashboard">
-            <span aria-hidden="true">📊</span>
-        </a>
+        <div class="admin-header-actions">
+            <!-- PWA Install Button (#226) — hidden by default, shown via JS -->
+            <button type="button" class="pwa-install-btn hidden" id="pwa-install-btn" aria-label="Install Beatify App">
+                <span aria-hidden="true">📲</span>
+            </button>
+            <!-- Analytics Link (Story 19.2, updated 19.13) -->
+            <a href="/beatify/analytics" class="analytics-icon-link" id="analytics-link" aria-label="Analytics Dashboard">
+                <span aria-hidden="true">📊</span>
+            </a>
+        </div>
     </header>
+
+    <!-- PWA iOS Install Hint (#226) -->
+    <div class="pwa-ios-hint hidden" id="pwa-ios-hint">
+        <div class="pwa-ios-hint-content">
+            <button type="button" class="pwa-ios-hint-close" id="pwa-ios-hint-close" aria-label="Close">&times;</button>
+            <p><strong>Install Beatify</strong></p>
+            <p>Tap <span class="pwa-ios-share-icon">⬆️</span> Share, then <strong>"Add to Home Screen"</strong></p>
+        </div>
+    </div>
 
     <main class="admin-content">
         <!-- Media Player Section - Collapsible with last-used memory -->

--- a/custom_components/beatify/www/css/styles.css
+++ b/custom_components/beatify/www/css/styles.css
@@ -272,6 +272,89 @@ body.theme-dark .analytics-icon-link:focus {
     outline: none;
 }
 
+/* Admin Header Actions wrapper (#226) */
+.admin-header-actions {
+    display: flex;
+    align-items: center;
+    gap: var(--space-xs, 8px);
+}
+
+/* PWA Install Button (#226) */
+.pwa-install-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 44px;
+    height: 44px;
+    border-radius: 50%;
+    border: none;
+    background: rgba(0, 245, 255, 0.1);
+    font-size: 1.5rem;
+    cursor: pointer;
+    transition: background-color 0.2s ease, transform 0.2s ease;
+    padding: 0;
+}
+
+.pwa-install-btn:hover,
+.pwa-install-btn:focus {
+    background: rgba(0, 245, 255, 0.2);
+    transform: scale(1.1);
+    outline: none;
+}
+
+/* PWA iOS Hint Modal (#226) */
+.pwa-ios-hint {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    z-index: 1000;
+    display: flex;
+    justify-content: center;
+    padding: var(--space-md, 16px);
+    animation: slideUp 0.3s ease;
+}
+
+.pwa-ios-hint.hidden {
+    display: none;
+}
+
+.pwa-ios-hint-content {
+    position: relative;
+    background: var(--color-bg-elevated, #2a2a3e);
+    border-radius: var(--radius-lg, 12px);
+    padding: var(--space-md, 16px) var(--space-lg, 24px);
+    color: var(--color-text, #fff);
+    text-align: center;
+    max-width: 340px;
+    box-shadow: 0 -2px 20px rgba(0, 0, 0, 0.3);
+}
+
+.pwa-ios-hint-close {
+    position: absolute;
+    top: 8px;
+    right: 12px;
+    background: none;
+    border: none;
+    color: var(--color-text, #fff);
+    font-size: 1.4rem;
+    cursor: pointer;
+    opacity: 0.6;
+}
+
+.pwa-ios-hint-close:hover {
+    opacity: 1;
+}
+
+.pwa-ios-share-icon {
+    font-size: 1.2rem;
+}
+
+@keyframes slideUp {
+    from { transform: translateY(100%); opacity: 0; }
+    to { transform: translateY(0); opacity: 1; }
+}
+
 /* Sections */
 .status-section,
 .card-section {


### PR DESCRIPTION
## Summary

Adds an explicit **📲 PWA install button** in the admin header, making the existing PWA install feature discoverable for users.

### Changes

- **admin.html**: Install button next to analytics icon, plus iOS hint modal
- **admin.js**: Full install prompt lifecycle — `beforeinstallprompt` capture, native prompt trigger, iOS Safari fallback with manual instructions, standalone detection
- **styles.css**: Button styling consistent with existing analytics icon, slide-up iOS hint modal

### Behavior

| Platform | Action |
|----------|--------|
| Android Chrome | Captures `beforeinstallprompt` → button click triggers native install dialog |
| iOS Safari | Detects UA → button click shows "Tap Share → Add to Home Screen" hint |
| Already installed | Button stays hidden (standalone mode check) |
| Desktop (no PWA support) | Button stays hidden (no `beforeinstallprompt` fired) |

Closes #226