### PR TITLE
refactor: Zyklischen Import auflösen (services ↔ game.scoring ↔ game.state) (#192)

### DIFF
--- a/custom_components/beatify/game/__init__.py
+++ b/custom_components/beatify/game/__init__.py
@@ -2,5 +2,6 @@
 
 from .player import PlayerSession
 from .state import GamePhase, GameState
+from .types import RoundAnalytics
 
-__all__ = ["GamePhase", "GameState", "PlayerSession"]
+__all__ = ["GamePhase", "GameState", "PlayerSession", "RoundAnalytics"]

--- a/custom_components/beatify/game/scoring.py
+++ b/custom_components/beatify/game/scoring.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 from statistics import mean, median
 from typing import TYPE_CHECKING, Any
 
+from .types import RoundAnalytics, _get_decade_label
+
 from custom_components.beatify.const import (
     ARTIST_BONUS_POINTS,
     DIFFICULTY_DEFAULT,
@@ -247,12 +249,6 @@ if TYPE_CHECKING:
 # ---------------------------------------------------------------------------
 
 
-def _get_decade_label(year: int) -> str:
-    """Get decade label for a year (e.g., 1985 -> '1980s')."""
-    decade = (year // 10) * 10
-    return f"{decade}s"
-
-
 class ScoringService:
     """Centralised scoring, analytics, and superlative calculations.
 
@@ -427,8 +423,6 @@ class ScoringService:
         round_start_time: float | None,
     ) -> Any:
         """Calculate analytics for current round reveal (Story 13.3)."""
-        from .state import RoundAnalytics  # noqa: PLC0415
-
         if correct_year is None:
             return RoundAnalytics()
 

--- a/custom_components/beatify/game/state.py
+++ b/custom_components/beatify/game/state.py
@@ -44,6 +44,7 @@ from .scoring import (
     ScoringService,
 )
 from .share import build_share_data
+from .types import RoundAnalytics, _get_decade_label
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
@@ -65,51 +66,6 @@ class GamePhase(Enum):
     REVEAL = "REVEAL"
     END = "END"
     PAUSED = "PAUSED"
-
-
-@dataclass
-class RoundAnalytics:
-    """Analytics calculated at end of each round for reveal display (Story 13.3)."""
-
-    # Guesses data (AC1)
-    all_guesses: list[dict[str, Any]] = field(default_factory=list)
-    average_guess: float | None = None
-    median_guess: int | None = None
-
-    # Performance metrics (AC2, AC3)
-    closest_players: list[str] = field(default_factory=list)
-    furthest_players: list[str] = field(default_factory=list)
-    exact_match_players: list[str] = field(default_factory=list)
-    exact_match_count: int = 0
-    scored_count: int = 0
-    total_submitted: int = 0
-    accuracy_percentage: int = 0
-
-    # Speed champion (AC3)
-    speed_champion: dict[str, Any] | None = None
-
-    # Histogram data (AC5, AC6)
-    decade_distribution: dict[str, int] = field(default_factory=dict)
-    correct_decade: str = ""
-
-    def to_dict(self) -> dict[str, Any]:
-        """Convert to JSON-serializable dictionary."""
-        avg = round(self.average_guess, 1) if self.average_guess else None
-        return {
-            "all_guesses": self.all_guesses,
-            "average_guess": avg,
-            "median_guess": self.median_guess,
-            "closest_players": self.closest_players,
-            "furthest_players": self.furthest_players,
-            "exact_match_players": self.exact_match_players,
-            "exact_match_count": self.exact_match_count,
-            "scored_count": self.scored_count,
-            "total_submitted": self.total_submitted,
-            "accuracy_percentage": self.accuracy_percentage,
-            "speed_champion": self.speed_champion,
-            "decade_distribution": self.decade_distribution,
-            "correct_decade": self.correct_decade,
-        }
 
 
 @dataclass
@@ -2231,9 +2187,7 @@ class GameState:
     @staticmethod
     def _get_decade_label(year: int) -> str:
         """Get decade label for a year (e.g., 1985 -> '1980s')."""
-        from .scoring import _get_decade_label as _gdl  # noqa: PLC0415
-
-        return _gdl(year)
+        return _get_decade_label(year)
 
     def calculate_superlatives(self) -> list[dict[str, Any]]:
         """Calculate fun awards (Story 15.2). Delegates to ScoringService (#139)."""

--- a/custom_components/beatify/game/types.py
+++ b/custom_components/beatify/game/types.py
@@ -1,0 +1,65 @@
+"""Shared types for the game package — breaks cyclic imports (#192).
+
+RoundAnalytics and _get_decade_label were previously split across
+state.py and scoring.py, causing a circular dependency.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+def get_decade_label(year: int) -> str:
+    """Get decade label for a year (e.g., 1985 -> '1980s')."""
+    decade = (year // 10) * 10
+    return f"{decade}s"
+
+
+# Keep the underscore-prefixed alias for backward compatibility
+_get_decade_label = get_decade_label
+
+
+@dataclass
+class RoundAnalytics:
+    """Analytics calculated at end of each round for reveal display (Story 13.3)."""
+
+    # Guesses data (AC1)
+    all_guesses: list[dict[str, Any]] = field(default_factory=list)
+    average_guess: float | None = None
+    median_guess: int | None = None
+
+    # Performance metrics (AC2, AC3)
+    closest_players: list[str] = field(default_factory=list)
+    furthest_players: list[str] = field(default_factory=list)
+    exact_match_players: list[str] = field(default_factory=list)
+    exact_match_count: int = 0
+    scored_count: int = 0
+    total_submitted: int = 0
+    accuracy_percentage: int = 0
+
+    # Speed champion (AC3)
+    speed_champion: dict[str, Any] | None = None
+
+    # Histogram data (AC5, AC6)
+    decade_distribution: dict[str, int] = field(default_factory=dict)
+    correct_decade: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to JSON-serializable dictionary."""
+        avg = round(self.average_guess, 1) if self.average_guess else None
+        return {
+            "all_guesses": self.all_guesses,
+            "average_guess": avg,
+            "median_guess": self.median_guess,
+            "closest_players": self.closest_players,
+            "furthest_players": self.furthest_players,
+            "exact_match_players": self.exact_match_players,
+            "exact_match_count": self.exact_match_count,
+            "scored_count": self.scored_count,
+            "total_submitted": self.total_submitted,
+            "accuracy_percentage": self.accuracy_percentage,
+            "speed_champion": self.speed_champion,
+            "decade_distribution": self.decade_distribution,
+            "correct_decade": self.correct_decade,
+        }


### PR DESCRIPTION
## Summary

Resolves the cyclic import between `game/scoring.py` and `game/state.py` by extracting shared types into a new `game/types.py` module.

### Problem

- `state.py` imports `ScoringService` from `scoring.py` (top-level)
- `scoring.py` imports `RoundAnalytics` from `state.py` (late import inside function)
- `state.py` imports `_get_decade_label` from `scoring.py` (late import inside method)

These late imports are a code smell and can cause hard-to-debug import errors.

### Solution

New `game/types.py` module containing:
- `RoundAnalytics` dataclass (moved from `state.py`)
- `_get_decade_label()` helper (moved from `scoring.py`)

Both `scoring.py` and `state.py` now import from `types.py` — no more late imports, no more cycle.

### Changes

- **New:** `game/types.py` — shared types module
- **scoring.py:** removed local `_get_decade_label` def + late `RoundAnalytics` import → top-level import from `types`
- **state.py:** removed `RoundAnalytics` class + late `_get_decade_label` import → top-level import from `types`
- **game/__init__.py:** re-exports `RoundAnalytics` for backward compatibility

### Tests

All 129 tests pass ✅

Closes #192