### PR TITLE
fix: move Share Results to dedicated admin end screen with podium (#245)

### DIFF
--- a/custom_components/beatify/www/admin.html
+++ b/custom_components/beatify/www/admin.html
@@ -306,10 +306,30 @@
                 <button id="rejoin-game" class="btn btn-primary" data-i18n="admin.rejoinGame">Rejoin Game</button>
                 <button id="end-game-existing" class="btn btn-danger" data-i18n="admin.endGame">End Game</button>
             </div>
-            <!-- Issue #108: END phase actions -->
-            <div id="end-phase-actions" class="game-controls-bar hidden">
-                <button id="rematch-game" class="btn btn-primary" data-i18n="admin.rematch">Rematch</button>
-                <button id="dismiss-game" class="btn btn-secondary" data-i18n="admin.endGame">End Game</button>
+        </section>
+
+        <!-- Issue #245: Dedicated admin end screen with podium -->
+        <section id="admin-end-section" class="card-section hidden">
+            <h2 class="section-header"><span class="section-icon" aria-hidden="true">🏆</span><span data-i18n="admin.gameOver">Game Over</span></h2>
+            <div class="podium">
+                <div class="podium-place podium-2">
+                    <div class="podium-medal">🥈</div>
+                    <div class="podium-name" id="admin-end-podium-2-name">—</div>
+                    <div class="podium-score" id="admin-end-podium-2-score"></div>
+                    <div class="podium-stand">2</div>
+                </div>
+                <div class="podium-place podium-1">
+                    <div class="podium-medal">🥇</div>
+                    <div class="podium-name" id="admin-end-podium-1-name">—</div>
+                    <div class="podium-score" id="admin-end-podium-1-score"></div>
+                    <div class="podium-stand">1</div>
+                </div>
+                <div class="podium-place podium-3">
+                    <div class="podium-medal">🥉</div>
+                    <div class="podium-name" id="admin-end-podium-3-name">—</div>
+                    <div class="podium-score" id="admin-end-podium-3-score"></div>
+                    <div class="podium-stand">3</div>
+                </div>
             </div>
 
             <!-- Issue #208: Shareable result cards in admin END screen -->
@@ -322,6 +342,12 @@
                     <button id="admin-share-save-btn" class="share-btn">📸 Save Card</button>
                 </div>
                 <div id="admin-share-toast" class="share-toast hidden">Copied!</div>
+            </div>
+
+            <!-- Issue #108: END phase actions -->
+            <div id="end-phase-actions" class="game-controls-bar">
+                <button id="rematch-game" class="btn btn-primary" data-i18n="admin.rematch">Rematch</button>
+                <button id="dismiss-game" class="btn btn-secondary" data-i18n="admin.endGame">End Game</button>
             </div>
         </section>
     </main>

--- a/custom_components/beatify/www/js/admin.js
+++ b/custom_components/beatify/www/js/admin.js
@@ -150,8 +150,8 @@ async function loadStatus() {
             // Show existing game stub for PLAYING/REVEAL/PAUSED phases
             showExistingGameView(status.active_game);
         } else if (status.active_game && status.active_game.phase === 'END') {
-            // Issue #208: Show end screen with share data instead of setup view
-            showExistingGameView(status.active_game);
+            // Issue #245: Show dedicated end screen with podium and share
+            showAdminEndView(status.active_game);
         } else {
             showSetupView();
         }
@@ -1170,6 +1170,7 @@ function showSetupView() {
     // Hide other views
     document.getElementById('lobby-section')?.classList.add('hidden');
     document.getElementById('existing-game-section')?.classList.add('hidden');
+    document.getElementById('admin-end-section')?.classList.add('hidden');
 }
 
 /**
@@ -1190,8 +1191,9 @@ function showLobbyView(gameData) {
     document.getElementById('start-game')?.classList.add('hidden');
     document.getElementById('playlist-validation-msg')?.classList.add('hidden');
 
-    // Hide existing game view
+    // Hide existing game and end views
     document.getElementById('existing-game-section')?.classList.add('hidden');
+    document.getElementById('admin-end-section')?.classList.add('hidden');
 
     // Show lobby
     document.getElementById('lobby-section')?.classList.remove('hidden');
@@ -1356,8 +1358,9 @@ function showExistingGameView(gameData) {
     document.getElementById('start-game')?.classList.add('hidden');
     document.getElementById('playlist-validation-msg')?.classList.add('hidden');
 
-    // Hide lobby
+    // Hide lobby and end views
     document.getElementById('lobby-section')?.classList.add('hidden');
+    document.getElementById('admin-end-section')?.classList.add('hidden');
 
     // Show existing game section
     document.getElementById('existing-game-section')?.classList.remove('hidden');
@@ -1371,27 +1374,51 @@ function showExistingGameView(gameData) {
     if (phaseEl) phaseEl.textContent = gameData.phase || 'Unknown';
     if (playersEl) playersEl.textContent = gameData.player_count ?? 0;
 
-    // Issue #108: Show END phase actions only when in END phase
-    var endPhaseActions = document.getElementById('end-phase-actions');
-    var regularActions = document.getElementById('existing-game-actions');
+}
 
-    if (endPhaseActions && regularActions) {
-        if (gameData.phase === 'END') {
-            endPhaseActions.classList.remove('hidden');
-            regularActions.classList.add('hidden');
+/**
+ * Show dedicated admin end screen with podium and share results (Issue #245)
+ * @param {Object} gameData - Game data from status API
+ */
+function showAdminEndView(gameData) {
+    currentView = 'admin-end';
+    currentGame = gameData;
+
+    // Hide setup sections
+    setupSections.forEach(id => {
+        const el = document.getElementById(id);
+        if (el) el.classList.add('hidden');
+    });
+
+    // Hide start button and validation
+    document.getElementById('start-game')?.classList.add('hidden');
+    document.getElementById('playlist-validation-msg')?.classList.add('hidden');
+
+    // Hide lobby and existing game sections
+    document.getElementById('lobby-section')?.classList.add('hidden');
+    document.getElementById('existing-game-section')?.classList.add('hidden');
+
+    // Show admin end section
+    document.getElementById('admin-end-section')?.classList.remove('hidden');
+
+    // Populate podium from players sorted by score descending
+    var players = gameData.players || [];
+    var sorted = players.slice().sort(function(a, b) { return (b.score || 0) - (a.score || 0); });
+
+    for (var i = 1; i <= 3; i++) {
+        var nameEl = document.getElementById('admin-end-podium-' + i + '-name');
+        var scoreEl = document.getElementById('admin-end-podium-' + i + '-score');
+        if (sorted[i - 1]) {
+            if (nameEl) nameEl.textContent = sorted[i - 1].name || '—';
+            if (scoreEl) scoreEl.textContent = sorted[i - 1].score || 0;
         } else {
-            endPhaseActions.classList.add('hidden');
-            regularActions.classList.remove('hidden');
+            if (nameEl) nameEl.textContent = '—';
+            if (scoreEl) scoreEl.textContent = '';
         }
     }
 
-    // Issue #208: Render share section when game has ended
-    if (gameData.phase === 'END') {
-        renderAdminShare(gameData);
-    } else {
-        var shareContainer = document.getElementById('admin-share-container');
-        if (shareContainer) shareContainer.classList.add('hidden');
-    }
+    // Render share section
+    renderAdminShare(gameData);
 }
 
 // ==========================================


### PR DESCRIPTION
## Summary

Fixes #245 — Share Results was appearing on the admin END phase management screen (alongside Revanche/End Game buttons) instead of on a dedicated podium/confetti screen.

## Changes

### `admin.html`
- Removed `#end-phase-actions` and `#admin-share-container` from inside `#existing-game-section`
- Added new `<section id="admin-end-section">` after `#existing-game-section` containing:
  - Podium (🥇🥈🥉) with top 3 players
  - Share Results section (moved here from existing-game-section)
  - Revanche + End Game action buttons at the bottom

### `admin.js`
- Status handler now calls `showAdminEndView(gameData)` for END phase instead of `showExistingGameView`
- Removed END-phase share/end-phase-actions logic from `showExistingGameView()`
- Added `showAdminEndView(gameData)`: hides all other views, shows `#admin-end-section`, populates podium from `gameData.players` sorted by score desc, calls `renderAdminShare`
- All other view functions (`showSetupView`, `showLobbyView`, `showExistingGameView`) now also hide `admin-end-section`

## Before / After

**Before:** Phase=END → existing-game-section shows game info + Revanche/End Game buttons + Share Results (all on same screen)

**After:** Phase=END → dedicated admin-end-section shows Podium → Share Results → Revanche/End Game buttons