### PR TITLE
feat: replace Save Card with native Web Share API on mobile (#247)

### DIFF
--- a/custom_components/beatify/www/admin.html
+++ b/custom_components/beatify/www/admin.html
@@ -339,7 +339,7 @@
                 <div id="admin-share-emoji-grid" class="emoji-grid-preview"></div>
                 <div class="share-buttons">
                     <button id="admin-share-copy-btn" class="share-btn">📋 Copy Text</button>
-                    <button id="admin-share-save-btn" class="share-btn">📸 Save Card</button>
+                    <button id="admin-share-save-btn" class="share-btn">📤 Share Card</button>
                 </div>
                 <div id="admin-share-toast" class="share-toast hidden">Copied!</div>
             </div>

--- a/custom_components/beatify/www/i18n/de.json
+++ b/custom_components/beatify/www/i18n/de.json
@@ -569,7 +569,7 @@
   "share": {
     "share_tab": "📤 Teilen",
     "share_copy": "📋 Text kopieren",
-    "share_save": "📸 Bild speichern",
+    "share_save": "📤 Bild teilen",
     "share_copied": "Kopiert!",
     "share_title": "Meine Beatify Ergebnisse"
   }

--- a/custom_components/beatify/www/i18n/en.json
+++ b/custom_components/beatify/www/i18n/en.json
@@ -569,7 +569,7 @@
   "share": {
     "share_tab": "📤 Share",
     "share_copy": "📋 Copy Text",
-    "share_save": "📸 Save Card",
+    "share_save": "📤 Share Card",
     "share_copied": "Copied!",
     "share_title": "My Beatify Results"
   }

--- a/custom_components/beatify/www/i18n/es.json
+++ b/custom_components/beatify/www/i18n/es.json
@@ -569,7 +569,7 @@
   "share": {
     "share_tab": "📤 Compartir",
     "share_copy": "📋 Copiar texto",
-    "share_save": "📸 Guardar imagen",
+    "share_save": "📤 Compartir imagen",
     "share_copied": "¡Copiado!",
     "share_title": "Mis resultados de Beatify"
   }

--- a/custom_components/beatify/www/i18n/fr.json
+++ b/custom_components/beatify/www/i18n/fr.json
@@ -569,7 +569,7 @@
   "share": {
     "share_tab": "📤 Partager",
     "share_copy": "📋 Copier le texte",
-    "share_save": "📸 Sauvegarder l'image",
+    "share_save": "📤 Partager l'image",
     "share_copied": "Copié !",
     "share_title": "Mes résultats Beatify"
   }

--- a/custom_components/beatify/www/js/admin.js
+++ b/custom_components/beatify/www/js/admin.js
@@ -1957,6 +1957,16 @@ function generateAdminVisualCard(emojiGrid, playlistName, shareData) {
     ctx.fillText('beatify.fun', 780, 760);
 
     canvas.toBlob(function(blob) {
+        if (navigator.share && navigator.canShare) {
+            var file = new File([blob], "beatify-results.png", { type: "image/png" });
+            var nativeShareData = { files: [file], title: "My Beatify Results" };
+            if (navigator.canShare(nativeShareData)) {
+                navigator.share(nativeShareData).catch(function() {
+                    downloadAdminBlob(blob);
+                });
+                return;
+            }
+        }
         downloadAdminBlob(blob);
     }, 'image/png');
     } // end drawAdminCardContent

--- a/custom_components/beatify/www/player.html
+++ b/custom_components/beatify/www/player.html
@@ -537,7 +537,7 @@
                     <div id="share-emoji-grid" class="emoji-grid-preview"></div>
                     <div class="share-buttons">
                         <button id="share-copy-btn" class="share-btn" data-i18n="share.share_copy">📋 Copy Text</button>
-                        <button id="share-save-btn" class="share-btn" data-i18n="share.share_save">📸 Save Card</button>
+                        <button id="share-save-btn" class="share-btn" data-i18n="share.share_save">📤 Share Card</button>
                     </div>
                     <div id="share-toast" class="share-toast hidden" data-i18n="share.share_copied">Copied!</div>
                 </div>


### PR DESCRIPTION
## Summary

Fixes #247 — "Save Card" now triggers the native OS share sheet on mobile instead of just downloading the PNG.

## Changes

### `admin.js`
Updated `canvas.toBlob` callback to use the Web Share API (same pattern already implemented in `player.js`):
- Mobile with share support: native share sheet opens with PNG attached
- Desktop / unsupported: falls back to download

### `admin.html` + `player.html`
Button label: **📸 Save Card → 📤 Share Card**

### i18n (en / de / es / fr)
Updated `share_save` strings to match: Share / Teilen / Compartir / Partager

## Behaviour
- **iOS Safari / Android Chrome:** Tap Share Card → native share sheet (WhatsApp, iMessage, Instagram, etc.)
- **Desktop:** Falls back to download as before