### PR TITLE
ux: move Share Results + Revanche to player end screen, strip admin-end-section (#254)

### DIFF
--- a/custom_components/beatify/www/admin.html
+++ b/custom_components/beatify/www/admin.html
@@ -311,38 +311,6 @@
         <!-- Issue #245: Dedicated admin end screen with podium -->
         <section id="admin-end-section" class="card-section hidden">
             <h2 class="section-header"><span class="section-icon" aria-hidden="true">🏆</span><span data-i18n="admin.gameOver">Game Over</span></h2>
-            <div class="podium">
-                <div class="podium-place podium-2">
-                    <div class="podium-medal">🥈</div>
-                    <div class="podium-name" id="admin-end-podium-2-name">—</div>
-                    <div class="podium-score" id="admin-end-podium-2-score"></div>
-                    <div class="podium-stand">2</div>
-                </div>
-                <div class="podium-place podium-1">
-                    <div class="podium-medal">🥇</div>
-                    <div class="podium-name" id="admin-end-podium-1-name">—</div>
-                    <div class="podium-score" id="admin-end-podium-1-score"></div>
-                    <div class="podium-stand">1</div>
-                </div>
-                <div class="podium-place podium-3">
-                    <div class="podium-medal">🥉</div>
-                    <div class="podium-name" id="admin-end-podium-3-name">—</div>
-                    <div class="podium-score" id="admin-end-podium-3-score"></div>
-                    <div class="podium-stand">3</div>
-                </div>
-            </div>
-
-            <!-- Issue #208: Shareable result cards in admin END screen -->
-            <div id="admin-share-container" class="share-container hidden">
-                <div class="share-header">📤 Share Results</div>
-                <div id="admin-share-player-tabs" class="admin-share-player-tabs"></div>
-                <div id="admin-share-emoji-grid" class="emoji-grid-preview"></div>
-                <div class="share-buttons">
-                    <button id="admin-share-copy-btn" class="share-btn">📋 Copy Text</button>
-                    <button id="admin-share-save-btn" class="share-btn">📤 Share Card</button>
-                </div>
-                <div id="admin-share-toast" class="share-toast hidden">Copied!</div>
-            </div>
 
             <!-- Issue #108: END phase actions -->
             <div id="end-phase-actions" class="game-controls-bar">

--- a/custom_components/beatify/www/js/admin.js
+++ b/custom_components/beatify/www/js/admin.js
@@ -1401,24 +1401,6 @@ function showAdminEndView(gameData) {
     // Show admin end section
     document.getElementById('admin-end-section')?.classList.remove('hidden');
 
-    // Populate podium from players sorted by score descending
-    var players = gameData.players || [];
-    var sorted = players.slice().sort(function(a, b) { return (b.score || 0) - (a.score || 0); });
-
-    for (var i = 1; i <= 3; i++) {
-        var nameEl = document.getElementById('admin-end-podium-' + i + '-name');
-        var scoreEl = document.getElementById('admin-end-podium-' + i + '-score');
-        if (sorted[i - 1]) {
-            if (nameEl) nameEl.textContent = sorted[i - 1].name || '—';
-            if (scoreEl) scoreEl.textContent = sorted[i - 1].score || 0;
-        } else {
-            if (nameEl) nameEl.textContent = '—';
-            if (scoreEl) scoreEl.textContent = '';
-        }
-    }
-
-    // Render share section
-    renderAdminShare(gameData);
 }
 
 // ==========================================

--- a/custom_components/beatify/www/js/player.js
+++ b/custom_components/beatify/www/js/player.js
@@ -4549,6 +4549,21 @@
             if (newGameBtn) {
                 newGameBtn.onclick = handleNewGame;
             }
+            // Wire up rematch button (Issue #254)
+            var rematchBtn = document.getElementById('player-rematch-btn');
+            if (rematchBtn) {
+                rematchBtn.onclick = function() {
+                    rematchBtn.disabled = true;
+                    fetch('/beatify/api/rematch-game', { method: 'POST' })
+                        .then(function(resp) {
+                            if (!resp.ok) throw new Error('Rematch failed');
+                        })
+                        .catch(function(err) {
+                            alert(err.message || 'Failed to start rematch');
+                            rematchBtn.disabled = false;
+                        });
+                };
+            }
         } else {
             if (adminControls) adminControls.classList.add('hidden');
             if (playerMessage) playerMessage.classList.remove('hidden');

--- a/custom_components/beatify/www/player.html
+++ b/custom_components/beatify/www/player.html
@@ -565,6 +565,7 @@
 
                 <!-- Admin controls -->
                 <div id="end-admin-controls" class="end-admin-controls hidden">
+                    <button id="player-rematch-btn" class="btn btn-primary btn-large btn-full-width" data-i18n="admin.rematch">Revanche</button>
                     <button id="new-game-btn" class="new-game-btn" data-i18n="admin.startNewGame">
                         Start New Game
                     </button>


### PR DESCRIPTION
## Summary

Fixes #254 — the admin-end-section was duplicating the podium already shown on the player Spielende screen, and the Share Results section was on the wrong screen.

## Changes

### `admin.html`
`#admin-end-section` stripped to just: 🏆 header + Revanche + Spiel beenden buttons. Removed: duplicate podium, entire `#admin-share-container`.

### `admin.js`
`showAdminEndView()` no longer populates the podium or calls `renderAdminShare()` — those are now handled on the player screen.

### `player.html`
Added `#player-rematch-btn` (Revanche) to `#end-admin-controls`, before the existing New Game button. Only shown to admin players.

### `player.js`
Wired `#player-rematch-btn` → POST `/beatify/api/rematch-game`. Success is handled by the existing `rematch_started` WebSocket event. `renderShareTab()` call unchanged — Share Results continue to render on the player end screen.

## Result
- **Player Spielende screen**: podium + Dein Ergebnis + Rangliste + Share Results + (if admin) Revanche + Neues Spiel starten
- **Admin end screen**: clean action panel — just Revanche + Spiel beenden, no duplicate podium