### PR TITLE
fix: re-send reconnect on rematch_started to prevent admin showing as abwesend (#256)

### DIFF
--- a/custom_components/beatify/www/js/player.js
+++ b/custom_components/beatify/www/js/player.js
@@ -5626,6 +5626,12 @@
             // Clean up end-phase UI before state broadcast transitions to LOBBY
             AnimationQueue.clear();
             stopConfetti();
+            // Re-confirm presence in new game session (Issue #256)
+            // player.connected may be False from end-phase disconnect; send reconnect to fix it
+            var sessionId = getSessionCookie();
+            if (sessionId && ws && ws.readyState === WebSocket.OPEN) {
+                ws.send(JSON.stringify({ type: 'reconnect', session_id: sessionId }));
+            }
             // The subsequent state broadcast will show LOBBY phase
         } else if (data.type === 'left') {
             // Story 11.5 - player left game successfully


### PR DESCRIPTION
## Summary

Fixes #256 — admin (and any player) shows as **abwesend** in the lobby after Revanche.

## Root Cause

When the game ends, the backend may set `player.connected = False` (WebSocket closed or timed out during END phase). `rematch_game()` preserves all players *as-is*, so the admin carries over with `connected=False`. The state broadcast immediately after rematch then shows them as abwesend.

## Fix

In the `rematch_started` WebSocket handler in `player.js`, after clearing animations, send a `reconnect` message with the session cookie:

```js
var sessionId = getSessionCookie();
if (sessionId && ws && ws.readyState === WebSocket.OPEN) {
    ws.send(JSON.stringify({ type: 'reconnect', session_id: sessionId }));
}
```

The backend `_handle_reconnect` handler already:
1. Finds the player by session_id
2. Sets `player.connected = True`
3. Updates `player.ws`
4. Sends `reconnect_ack` + broadcasts updated state

Result: by the time the lobby state arrives, the player is already marked connected.