### PR TITLE
fix: hide Spiel starten until admin has joined as player in lobby (#253)

### DIFF
--- a/custom_components/beatify/www/admin.html
+++ b/custom_components/beatify/www/admin.html
@@ -281,7 +281,7 @@
                 <!-- Sticky Lobby Actions -->
                 <div class="lobby-actions lobby-actions--sticky">
                     <!-- Start Gameplay: transitions LOBBY → PLAYING without requiring admin to join as player (Issue #228) -->
-                    <button id="start-gameplay-btn" class="btn btn-primary btn-large btn-full-width">
+                    <button id="start-gameplay-btn" class="btn btn-primary btn-large btn-full-width hidden">
                         <span class="btn-icon" aria-hidden="true">▶️</span>
                         <span data-i18n="admin.startGameplay">Spiel starten</span>
                     </button>

--- a/custom_components/beatify/www/js/admin.js
+++ b/custom_components/beatify/www/js/admin.js
@@ -2078,6 +2078,8 @@ function renderLobbyPlayers(players) {
     if (players.length === 0) {
         listEl.innerHTML = '';
         if (emptyEl) emptyEl.classList.remove('hidden');
+        var startBtn = document.getElementById("start-gameplay-btn");
+        if (startBtn) startBtn.classList.add("hidden");
         previousLobbyPlayers = [];
         return;
     }
@@ -2131,6 +2133,17 @@ function renderLobbyPlayers(players) {
             newCards[i].classList.remove('is-new');
         }
     }, 2000);
+
+    // Issue #253: Only show Start button once admin has joined as a player
+    var startBtn = document.getElementById("start-gameplay-btn");
+    if (startBtn) {
+        var adminJoined = players.some(function(p) { return p.is_admin === true; });
+        if (adminJoined) {
+            startBtn.classList.remove("hidden");
+        } else {
+            startBtn.classList.add("hidden");
+        }
+    }
 
     previousLobbyPlayers = players.slice();
 }


### PR DESCRIPTION
## Summary

Fixes #253 — the **Spiel starten** button was always visible in the lobby, even with 0 players and before the admin had joined.

## Changes

### `admin.html`
Added `hidden` class to `#start-gameplay-btn` — hidden by default.

### `admin.js` — `renderLobbyPlayers()`
- Empty state early return: explicitly hides the button
- End of render: shows button only when `players.some(p => p.is_admin === true)` — i.e. the admin has joined as a player

## Behaviour after
- **0 players / admin not joined:** Spiel starten hidden, only "Join as Player" visible
- **Admin joined:** Spiel starten appears — game can be started