### PR TITLE
fix: align Revanche and Neues Spiel buttons on end screen

### DIFF
--- a/custom_components/beatify/www/css/styles.css
+++ b/custom_components/beatify/www/css/styles.css
@@ -6622,10 +6622,14 @@ body.theme-dark .result-value.is-bet-lost {
 
 /* Admin controls for end */
 .end-admin-controls {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-md);
     margin-bottom: var(--space-md);
 }
 
 .new-game-btn {
+    width: 100%;
     padding: var(--space-md) var(--space-xl);
     font-size: var(--font-size-lg);
     font-weight: var(--font-weight-semibold);


### PR DESCRIPTION
Fixes button alignment on the player end screen (Spielende).

**Problem:** 'Revanche' was full-width but 'Neues Spiel starten' was auto-sized (narrower), and there was no gap between them.

**Fix:**
- `.end-admin-controls` → `display: flex; flex-direction: column; gap: var(--space-md)`
- `.new-game-btn` → `width: 100%`

Both buttons now match width and have consistent spacing.