### PR TITLE
chore: align community playlists to standard format (tags + version bump)

### DIFF
--- a/custom_components/beatify/playlists/community/greatest-metal-songs.json
+++ b/custom_components/beatify/playlists/community/greatest-metal-songs.json
@@ -1,6 +1,13 @@
 {
   "name": "Greatest Metal Songs of All Time 🤘",
-  "version": "1.0",
+  "version": "1.1",
+  "tags": [
+    "metal",
+    "rock",
+    "classic-rock",
+    "international",
+    "classics"
+  ],
   "source": "https://open.spotify.com/playlist/2KB2kUNfUtujzoYvW0lvyN",
   "songs": [
     {

--- a/custom_components/beatify/playlists/community/top100-allertijden-nederlandstalig.json
+++ b/custom_components/beatify/playlists/community/top100-allertijden-nederlandstalig.json
@@ -1,6 +1,13 @@
 {
   "name": "Top 100 Dutch Classics 🇳🇱",
-  "version": "1.3",
+  "version": "1.4",
+  "tags": [
+    "nederlandstalig",
+    "dutch",
+    "top-hits",
+    "classics",
+    "pop"
+  ],
   "source": "https://open.spotify.com/playlist/1im044OopXyqsGbNu8Zqby",
   "songs": [
     {


### PR DESCRIPTION
- Add `tags` field to `greatest-metal-songs` and `top100-nl` (all other playlists have it)\n- Reorder top-level keys consistently: name → version → tags → source → songs\n- Bump greatest-metal-songs: 1.0 → 1.1\n- Bump top100-allertijden-nederlandstalig: 1.3 → 1.4