### PR TITLE
feat: skeleton loading states for media players and playlists (#240)

### DIFF
--- a/custom_components/beatify/www/admin.html
+++ b/custom_components/beatify/www/admin.html
@@ -53,7 +53,11 @@
                 <span class="section-toggle" aria-hidden="true">▼</span>
             </button>
             <div class="section-content" id="media-players-content">
-                <div id="media-players-list" data-i18n="common.loading">Loading...</div>
+                <div id="media-players-list" class="skeleton-list" aria-busy="true">
+                    <div class="skeleton skeleton-row"></div>
+                    <div class="skeleton skeleton-row"></div>
+                    <div class="skeleton skeleton-row"></div>
+                </div>
                 <p class="supported-players-hint">
                     Supported: Music Assistant, Sonos, and Alexa players.
                     <a href="https://music-assistant.io/" target="_blank" rel="noopener">Use Music Assistant</a> for Chromecast/Nest devices.
@@ -104,7 +108,12 @@
             <div id="playlist-filter-bar" class="playlist-filter-bar hidden">
                 <button type="button" class="filter-tag active" data-tag="all" data-i18n="admin.filterAll">All</button>
             </div>
-            <div id="playlists-list" data-i18n="common.loading">Loading...</div>
+            <div id="playlists-list" class="skeleton-list" aria-busy="true">
+                    <div class="skeleton skeleton-card"></div>
+                    <div class="skeleton skeleton-card"></div>
+                    <div class="skeleton skeleton-card"></div>
+                    <div class="skeleton skeleton-card"></div>
+                </div>
             <div id="playlist-summary" class="selection-summary hidden">
                 <span data-i18n="admin.selected">Selected:</span> <span id="selected-count">0</span> <span data-i18n="admin.playlistsLabel">playlists,</span>
                 <span id="total-songs">0</span> <span data-i18n="admin.songsLabel">songs</span>

--- a/custom_components/beatify/www/css/styles.css
+++ b/custom_components/beatify/www/css/styles.css
@@ -8393,3 +8393,37 @@ body.device-tier-low .reveal-skip-hint {
         padding: 0.75rem 1rem;
     }
 }
+
+/* ============================================
+   Skeleton Loading States (#240)
+   ============================================ */
+@keyframes shimmer {
+    0%   { background-position: 200% 0; }
+    100% { background-position: -200% 0; }
+}
+
+.skeleton {
+    background: linear-gradient(90deg, var(--color-bg-card) 25%, #3a3a4e 50%, var(--color-bg-card) 75%);
+    background-size: 200% 100%;
+    animation: shimmer 1.5s infinite;
+    border-radius: var(--radius-md);
+}
+
+.skeleton-list {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-sm);
+    padding: var(--space-sm) 0;
+}
+
+/* Media player rows — match the height of a radio option */
+.skeleton-row {
+    height: 48px;
+    width: 100%;
+}
+
+/* Playlist cards — taller to match playlist card height */
+.skeleton-card {
+    height: 64px;
+    width: 100%;
+}

--- a/custom_components/beatify/www/js/admin.js
+++ b/custom_components/beatify/www/js/admin.js
@@ -414,8 +414,10 @@ function groupPlayersByPlatform(players) {
  */
 function renderMediaPlayers(players) {
     const container = document.getElementById('media-players-list');
-    // Remove data-i18n to prevent initPageTranslations from overwriting rendered content
+    // Remove data-i18n and skeleton state when real content renders
     container?.removeAttribute('data-i18n');
+    container?.removeAttribute('aria-busy');
+    container?.classList.remove('skeleton-list');
     const totalPlayers = players ? players.length : 0;
 
     // Reset selection state
@@ -739,8 +741,10 @@ function updateProviderWarning(player) {
  */
 function renderPlaylists(playlists, playlistDir, preserveSelection = false) {
     const container = document.getElementById('playlists-list');
-    // Remove data-i18n to prevent initPageTranslations from overwriting rendered content
+    // Remove data-i18n and skeleton state when real content renders
     container?.removeAttribute('data-i18n');
+    container?.removeAttribute('aria-busy');
+    container?.classList.remove('skeleton-list');
 
     // Store previous selections before reset (for preserveSelection mode)
     const previousSelections = preserveSelection ? [...selectedPlaylists] : [];


### PR DESCRIPTION
Closes #240

## Changes

**styles.css** — shimmer skeleton animation + two variants:
- `.skeleton-row` (48px) — matches height of a media player radio option
- `.skeleton-card` (64px) — matches height of a playlist card

**admin.html** — both `Loading...` divs replaced with animated skeleton markup

**admin.js** — `renderMediaPlayers()` and `renderPlaylists()` remove skeleton classes when real content loads

## Result
- No raw 'Loading...' text visible
- Shimmer placeholder immediately visible while data loads
- Smooth transition to real content