### PR TITLE
feat: connection status indicator in player header (#238)

### DIFF
--- a/custom_components/beatify/www/css/styles.css
+++ b/custom_components/beatify/www/css/styles.css
@@ -8427,3 +8427,40 @@ body.device-tier-low .reveal-skip-hint {
     height: 64px;
     width: 100%;
 }
+
+/* ============================================
+   Connection Status Indicator (#238)
+   ============================================ */
+.player-header {
+    position: relative;
+}
+
+.connection-indicator {
+    position: absolute;
+    top: 50%;
+    right: var(--space-md);
+    transform: translateY(-50%);
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    opacity: 0;
+    transition: opacity 0.3s ease;
+}
+
+/* Only visible when disconnected/reconnecting */
+.connection-indicator--disconnected {
+    opacity: 1;
+}
+
+.connection-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: var(--color-error, #e94560);
+    animation: pulse-dot 1.2s infinite;
+}
+
+@keyframes pulse-dot {
+    0%, 100% { opacity: 1; transform: scale(1); }
+    50%       { opacity: 0.4; transform: scale(0.7); }
+}

--- a/custom_components/beatify/www/js/player.js
+++ b/custom_components/beatify/www/js/player.js
@@ -1332,6 +1332,7 @@
             reconnectAttempts = 0;
             isReconnecting = false;
             hideReconnectingOverlay();
+            hideConnectionIndicator();
 
             // Send reconnect message with session ID
             ws.send(JSON.stringify({
@@ -5300,7 +5301,35 @@
     /**
      * Show reconnecting overlay (Story 7-3)
      */
+
+    /**
+     * Show connection lost indicator (#238)
+     */
+    function showConnectionIndicator() {
+        var el = document.getElementById('connection-indicator');
+        if (el) {
+            el.classList.remove('connection-indicator--connected');
+            el.classList.add('connection-indicator--disconnected');
+            el.setAttribute('aria-label', 'Disconnected');
+            el.title = 'Disconnected';
+        }
+    }
+
+    /**
+     * Hide connection indicator when connected (#238)
+     */
+    function hideConnectionIndicator() {
+        var el = document.getElementById('connection-indicator');
+        if (el) {
+            el.classList.remove('connection-indicator--disconnected');
+            el.classList.add('connection-indicator--connected');
+            el.setAttribute('aria-label', 'Connected');
+            el.title = 'Connected';
+        }
+    }
+
     function showReconnectingOverlay() {
+        showConnectionIndicator();
         var overlay = document.getElementById('reconnecting-overlay');
         if (overlay) {
             overlay.classList.remove('hidden');
@@ -5372,6 +5401,7 @@
             reconnectAttempts = 0;
             isReconnecting = false;
             hideReconnectingOverlay();
+            hideConnectionIndicator();
 
             var joinMsg = { type: 'join', name: name };
             if (isAdmin) {

--- a/custom_components/beatify/www/player.html
+++ b/custom_components/beatify/www/player.html
@@ -16,6 +16,9 @@
 <body class="theme-dark">
     <header class="player-header">
         <h1 class="wordmark"><span class="wordmark-beat">Beat</span><span class="wordmark-gradient">ify</span></h1>
+        <div id="connection-indicator" class="connection-indicator connection-indicator--connected" aria-label="Connected" title="Connected">
+            <span class="connection-dot"></span>
+        </div>
     </header>
 
     <main class="player-container">


### PR DESCRIPTION
Closes #238

## Was bereits implementiert war
Auto-Reconnect (10 Versuche, exp. Backoff), Reconnect-Overlay, Connection-Lost-Screen, Welcome-Back-Toast, Session-Erhalt — alles schon drin.

## Was gefehlt hat
Visueller Verbindungsindikator — die letzte offene AC.

## Lösung
Pulsierender roter Dot (🔴) in der oberen rechten Ecke des Player-Headers wenn die Verbindung verloren ist. Unsichtbar wenn verbunden.

- `player.html` — `#connection-indicator` div im Header
- `styles.css` — Pulse-Animation, nur sichtbar mit `--disconnected` Klasse
- `player.js` — `showConnectionIndicator()` beim Disconnect, `hideConnectionIndicator()` bei erfolgreichem Reconnect