### PR TITLE
fix: reconnect WebSocket immediately on iOS foreground

### DIFF
--- a/custom_components/beatify/www/js/player-core.js
+++ b/custom_components/beatify/www/js/player-core.js
@@ -889,3 +889,22 @@ if ('serviceWorker' in navigator) {
         });
     });
 }
+
+// ============================================
+// iOS Safari Reconnect on App Foreground
+// ============================================
+// iOS aggressively closes WebSocket connections when the app is backgrounded.
+// When the user returns from another app (e.g. WhatsApp, Safari), we immediately
+// reconnect if the socket is dead — without waiting for the onclose backoff timer.
+document.addEventListener('visibilitychange', function() {
+    if (document.visibilityState === 'visible') {
+        var ws = state.ws;
+        if (!ws || ws.readyState === WebSocket.CLOSING || ws.readyState === WebSocket.CLOSED) {
+            if (state.playerName) {
+                console.log('[Beatify] Page visible, WebSocket dead — reconnecting immediately.');
+                state.reconnectAttempts = 0; // reset backoff so it reconnects instantly
+                connectWithSession();
+            }
+        }
+    }
+});


### PR DESCRIPTION
## Problem
Players joining via QR code on iPhone lose their WebSocket connection when they switch to another app (WhatsApp, etc.) and return. iOS Safari aggressively closes WS connections during backgrounding.

The existing `onclose` handler does eventually reconnect, but only after the backoff delay fires — which can feel like the game is broken.

## Fix
Add a `visibilitychange` listener in `player-core.js` that immediately calls `connectWithSession()` when:
- `document.visibilityState === 'visible'` (user returned to the tab)
- The WebSocket is dead (`CLOSING` or `CLOSED`)
- `state.playerName` is set (player was already in a game)

Also resets `state.reconnectAttempts` to 0 so reconnect happens without backoff penalty — the disconnect was caused by backgrounding, not a flaky connection.

## Testing
1. Join a game via QR code on iPhone
2. Switch to WhatsApp (or any other app) for 10–30 seconds
3. Return to Safari — connection should restore immediately

Fixes: iOS QR-code-join reconnect issue