### PR TITLE
fix: correct Toxicity Spotify URI in metal playlist

### DIFF
--- a/custom_components/beatify/playlists/community/greatest-metal-songs.json
+++ b/custom_components/beatify/playlists/community/greatest-metal-songs.json
@@ -505,7 +505,7 @@
     },
     {
       "year": 2001,
-      "uri": "spotify:track:3NvYHGOKMhfHNXkmVTYcOf4",
+      "uri": "spotify:track:3NvYHGOKMhfHNXkmVTYcOf",
       "artist": "System of a Down",
       "title": "Toxicity",
       "alt_artists": [


### PR DESCRIPTION
## Bug
Admin panel showed: `Invalid: Song 18: 'uri' invalid (expected spotify:track:{22-char-id})` for the **Greatest Metal Songs** playlist.

## Root Cause
Song 18 (System of a Down — Toxicity) had a 23-character track ID — a trailing `4` typo.

```
Was: spotify:track:3NvYHGOKMhfHNXkmVTYcOf4  (23 chars ❌)
Now: spotify:track:3NvYHGOKMhfHNXkmVTYcOf   (22 chars ✅)
```