### PR TITLE
fix: cap highlights reel at 3, deduplicate speed entries

### DIFF
--- a/custom_components/beatify/game/highlights.py
+++ b/custom_components/beatify/game/highlights.py
@@ -203,14 +203,37 @@ class HighlightsTracker:
             )
         )
 
-    def get_top_highlights(self, limit: int = 8) -> list[GameHighlight]:
-        """Return the most interesting highlights, ranked by priority."""
-        # Sort by priority (descending), then by round (ascending) for chronological tiebreak
-        sorted_highlights = sorted(
-            self._highlights,
-            key=lambda h: (-_PRIORITY.get(h.type, 1), h.round),
-        )
-        return sorted_highlights[:limit]
+    def get_top_highlights(self, limit: int = 3) -> list[GameHighlight]:
+        """Return the most interesting highlights (max 3 to keep the reel tight).
+
+        Repetitive low-priority types (speed_record, heartbreaker) are
+        deduplicated: only the single best instance per type is kept so that
+        one fast player in a 7-round game does not fill every slot.
+        """
+        _DEDUPE_TYPES = {"speed_record", "heartbreaker"}
+        seen_dedupe: set[str] = set()
+        deduped: list[GameHighlight] = []
+
+        def sort_key(h: GameHighlight) -> tuple:
+            priority = -_PRIORITY.get(h.type, 1)
+            if h.type == "speed_record":
+                try:
+                    time_val = float(h.description_params.get("time", 999))
+                except (ValueError, TypeError):
+                    time_val = 999.0
+                return (priority, time_val, h.round)
+            return (priority, 0.0, h.round)
+
+        sorted_highlights = sorted(self._highlights, key=sort_key)
+
+        for h in sorted_highlights:
+            if h.type in _DEDUPE_TYPES:
+                if h.type in seen_dedupe:
+                    continue
+                seen_dedupe.add(h.type)
+            deduped.append(h)
+
+        return deduped[:limit]
 
     def to_dict(self) -> list[dict]:
         """Convert top highlights to JSON-serializable list for get_state()."""


### PR DESCRIPTION
## Problem
The highlights section at end-of-game showed one entry per round — if a player answered fast every round, all 6 rounds showed as ⚡ *blitzschnell*. Max was 8 entries but looked overwhelming.

## Fix
- **Cap at 3** highlights (down from 8)
- **Deduplicate** `speed_record` and `heartbreaker` types: only the single best instance is shown (fastest time wins for speed; earliest for heartbreaker)

Priority ranking still decides which 3 appear:
`photo_finish (5) > heartbreaker (5) > streak (4) > comeback (4) > exact_match (3) > bet_win (3) > speed_record (2)`

All 129 tests pass.