### PR TITLE
fix: prevent dual WebSocket on rematch (End Game button unresponsive)

### DIFF
--- a/custom_components/beatify/www/js/player-core.js
+++ b/custom_components/beatify/www/js/player-core.js
@@ -607,9 +607,20 @@ function handleServerMessage(data) {
         AnimationQueue.clear();
         stopConfetti();
         showView('lobby-view');
+        // Reset any rematch button spinner (in case admin triggered this)
+        var rematchBtn = document.getElementById('player-rematch-btn');
+        if (rematchBtn) { rematchBtn.disabled = false; rematchBtn.textContent = '🔁'; }
         var sessionId = getSessionCookie();
-        if (sessionId && state.ws && state.ws.readyState === WebSocket.OPEN) {
-            state.ws.send(JSON.stringify({ type: 'reconnect', session_id: sessionId }));
+        if (sessionId) {
+            if (state.ws && state.ws.readyState === WebSocket.OPEN) {
+                // Existing WS still alive — reuse it (avoid creating a second connection)
+                state.reconnectAttempts = 0;
+                state.ws.send(JSON.stringify({ type: 'reconnect', session_id: sessionId }));
+            } else {
+                // WS was closed — open a fresh one
+                state.reconnectAttempts = 0;
+                connectWithSession();
+            }
         }
     } else if (data.type === 'left') {
         handleLeftGame();

--- a/custom_components/beatify/www/js/player-end.js
+++ b/custom_components/beatify/www/js/player-end.js
@@ -97,11 +97,12 @@ export function updateEndView(data) {
                 })
                     .then(function(resp) {
                         if (!resp.ok) return resp.json().then(function(e) { throw new Error(e.message || 'Rematch failed'); });
-                        AnimationQueue.clear();
-                        stopConfetti();
-                        showView('lobby-view');
-                        state.reconnectAttempts = 0;
-                        state.connectWithSession();
+                        // Server will broadcast rematch_started to all clients (including admin).
+                        // The rematch_started handler in player-core.js reconnects everyone via
+                        // the existing WS — calling connectWithSession() here would race and
+                        // cause a SESSION_TAKEOVER that corrupts state (admin loses isAdmin flag,
+                        // connection-lost view flashes, End Game button becomes unresponsive).
+                        rematchBtn.textContent = '⏳'; // keep spinner until rematch_started arrives
                     })
                     .catch(function(err) {
                         console.error('[Player] Rematch failed:', err);


### PR DESCRIPTION
## Bug
After clicking **Revanche**, the admin could play rounds normally but the **End Game button did nothing**.

## Root Cause
Two reconnect paths raced after Revanche:

1. `rematch_started` handler in `player-core.js` → sent `reconnect` on the existing open WebSocket
2. `fetch('/api/rematch-game').then()` in `player-end.js` → called `state.connectWithSession()` → opened a **second** WebSocket + sent another `reconnect`

Server received two reconnect requests for the same session → sent `SESSION_TAKEOVER` to the first WS → client handled it by setting `state.playerName = null` and calling `showConnectionLostView()`. State eventually recovered (second WS won), but `showConfirmModal` / End Game handler was left in a broken state.

## Fix
- **`player-end.js`**: Remove `state.connectWithSession()` from rematch button — the `rematch_started` broadcast already handles reconnecting all clients (including admin)
- **`player-core.js`**: `rematch_started` handler now handles both cases: reuse the open WS (send reconnect on it) OR open a fresh WS if the existing connection was already closed

All 129 tests pass.