### PR TITLE
fix: bump Greatest Metal Songs playlist version to 1.2

### DIFF
--- a/custom_components/beatify/playlists/community/greatest-metal-songs.json
+++ b/custom_components/beatify/playlists/community/greatest-metal-songs.json
@@ -1,6 +1,6 @@
 {
   "name": "Greatest Metal Songs of All Time 🤘",
-  "version": "1.1",
+  "version": "1.2",
   "tags": [
     "metal",
     "rock",


### PR DESCRIPTION
Bumps version 1.1 → 1.2 so HA reloads the playlist and picks up the Toxicity URI fix from #287.