### PR TITLE
fix: skip SESSION_TAKEOVER when reconnect comes from same WebSocket

### DIFF
--- a/custom_components/beatify/server/websocket.py
+++ b/custom_components/beatify/server/websocket.py
@@ -743,7 +743,8 @@ class BeatifyWebSocketHandler:
             return
 
         # Handle dual-tab scenario: close old connection if still active
-        if player.connected and player.ws and not player.ws.closed:
+        # Skip takeover if the reconnect comes from the SAME WebSocket (e.g. rematch reconnect)
+        if player.connected and player.ws and not player.ws.closed and player.ws is not ws:
             try:
                 await player.ws.send_json(
                     {


### PR DESCRIPTION
## Bug
After clicking **Revanche**, the admin immediately saw **'Verbindung verloren'** (connection lost screen).

## Root Cause
During rematch, the admin sends `reconnect` on their existing open WebSocket. The server's `_handle_reconnect` found `player.connected = True` and `player.ws` not closed → sent `SESSION_TAKEOVER` back to `player.ws`. But `player.ws` **was the same socket** as `ws`. The admin received SESSION_TAKEOVER on their own connection → `state.playerName = null` → `showConnectionLostView()`.

## Fix
```python
if player.connected and player.ws and not player.ws.closed and player.ws is not ws:
```

All 129 tests pass.