### PR TITLE
feat: delay intro rounds until round 4 + admin splash before first intro (#292)

### DIFF
--- a/custom_components/beatify/game/state.py
+++ b/custom_components/beatify/game/state.py
@@ -364,6 +364,10 @@ class GameState:
         # Issue #75: Game highlights reel
         self.highlights_tracker = HighlightsTracker()
 
+        # Issue #292: Intro splash state
+        self._intro_splash_shown: bool = False
+        self._intro_splash_pending: bool = False
+
     def create_game(
         self,
         playlists: list[str],
@@ -518,6 +522,7 @@ class GameState:
             "intro_mode_enabled": self.intro_mode_enabled,
             "is_intro_round": self.is_intro_round,
             "intro_stopped": self.intro_stopped,
+            "intro_splash_pending": self._intro_splash_pending,
         }
 
         # Phase-specific data
@@ -776,6 +781,10 @@ class GameState:
 
         # Issue #75: Reset highlights tracker
         self.highlights_tracker.reset()
+
+        # Issue #292: Reset intro splash state
+        self._intro_splash_shown = False
+        self._intro_splash_pending = False
 
     def end_game(self) -> None:
         """End the current game and reset state."""
@@ -1574,7 +1583,9 @@ class GameState:
         self._intro_round_start_time = None
         self._cancel_intro_timer()
 
-        if self.intro_mode_enabled:
+        if self.intro_mode_enabled and self.round >= 3:
+            # Issue #292: Skip intro rounds for the first 3 display rounds
+            # (self.round is 0-indexed here, incremented later, so round < 3 = display rounds 1-3)
             # Guarantee at least one intro round every 4 rounds
             # Use random chance normally, but force it if too many rounds without one
             force_intro = self._rounds_since_intro >= 3
@@ -1585,15 +1596,24 @@ class GameState:
                     self.is_intro_round = True
                     self._rounds_since_intro = 0
                     self._intro_round_start_time = self._now()
-                    # Schedule auto-stop after intro duration
-                    self._intro_stop_task = asyncio.create_task(
-                        self._intro_auto_stop(INTRO_DURATION_SECONDS)
-                    )
-                    _LOGGER.info(
-                        "Intro round activated for round %d%s",
-                        self.round + 1,
-                        " (forced)" if force_intro else "",
-                    )
+                    # Issue #292: First intro round needs admin confirmation via splash
+                    if not self._intro_splash_shown:
+                        self._intro_splash_pending = True
+                        _LOGGER.info(
+                            "Intro round activated for round %d%s (splash pending)",
+                            self.round + 1,
+                            " (forced)" if force_intro else "",
+                        )
+                    else:
+                        # Schedule auto-stop after intro duration
+                        self._intro_stop_task = asyncio.create_task(
+                            self._intro_auto_stop(INTRO_DURATION_SECONDS)
+                        )
+                        _LOGGER.info(
+                            "Intro round activated for round %d%s",
+                            self.round + 1,
+                            " (forced)" if force_intro else "",
+                        )
                 else:
                     self._rounds_since_intro += 1
                     _LOGGER.info("Skipping intro mode for short song (%dms)", song_duration_ms)

--- a/custom_components/beatify/server/websocket.py
+++ b/custom_components/beatify/server/websocket.py
@@ -531,6 +531,19 @@ class BeatifyWebSocketHandler:
                 # Broadcast state with updated language
                 await self.broadcast_state()
 
+            elif action == "confirm_intro_splash":
+                # Issue #292: Admin confirms the first-intro splash screen
+                if not game_state._intro_splash_pending:
+                    return
+                game_state._intro_splash_pending = False
+                game_state._intro_splash_shown = True
+                from custom_components.beatify.game.state import INTRO_DURATION_SECONDS
+
+                game_state._intro_stop_task = asyncio.create_task(
+                    game_state._intro_auto_stop(INTRO_DURATION_SECONDS)
+                )
+                await self.broadcast_state()
+
             else:
                 _LOGGER.warning("Unknown admin action: %s", action)
 

--- a/custom_components/beatify/www/css/styles.css
+++ b/custom_components/beatify/www/css/styles.css
@@ -7794,6 +7794,67 @@ body.theme-dark .steal-target-btn:hover {
 }
 
 /* ============================================
+   Intro Splash Modal (Issue #292)
+   ============================================ */
+
+.intro-splash-modal {
+    position: fixed;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: var(--z-modal);
+}
+
+.intro-splash-modal-backdrop {
+    position: absolute;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.8);
+    backdrop-filter: blur(4px);
+}
+
+.intro-splash-modal-content {
+    position: relative;
+    background: var(--color-bg-card);
+    border: 2px solid var(--color-accent-primary, #1db954);
+    border-radius: var(--radius-xl);
+    padding: var(--space-lg);
+    max-width: 400px;
+    width: 90%;
+    text-align: center;
+    box-shadow: 0 0 40px rgba(29, 185, 84, 0.3);
+}
+
+.intro-splash-modal-emoji {
+    font-size: 3rem;
+    margin-bottom: var(--space-sm);
+}
+
+.intro-splash-modal-title {
+    font-size: var(--font-size-xl);
+    font-weight: var(--font-weight-bold);
+    color: var(--color-text-primary);
+    margin-bottom: var(--space-xs);
+}
+
+.intro-splash-modal-desc {
+    font-size: var(--font-size-base);
+    color: var(--color-text-secondary);
+    margin-bottom: var(--space-md);
+}
+
+.intro-splash-modal-waiting {
+    font-size: var(--font-size-sm);
+    color: var(--color-text-muted);
+    margin-bottom: var(--space-sm);
+}
+
+.intro-splash-confirm-btn {
+    width: 100%;
+    margin-top: var(--space-sm);
+}
+
+/* ============================================
    Score Animations (Story 13.2)
    ============================================ */
 

--- a/custom_components/beatify/www/i18n/de.json
+++ b/custom_components/beatify/www/i18n/de.json
@@ -592,5 +592,9 @@
     "share_save": "📤 Bild teilen",
     "share_copied": "Kopiert!",
     "share_title": "Meine Beatify Ergebnisse"
-  }
+  },
+  "introSplashTitle": "Intro-Runde!",
+  "introSplashDesc": "Der Song spielt — stoppe ihn, sobald du ihn erkennst! Je schneller du stoppst, desto mehr Punkte.",
+  "introSplashWaiting": "Warten auf Host...",
+  "introSplashStart": "▶ Intro-Runde starten"
 }

--- a/custom_components/beatify/www/i18n/en.json
+++ b/custom_components/beatify/www/i18n/en.json
@@ -592,5 +592,9 @@
     "share_save": "📤 Share Card",
     "share_copied": "Copied!",
     "share_title": "My Beatify Results"
-  }
+  },
+  "introSplashTitle": "Intro Round!",
+  "introSplashDesc": "The song plays — stop it the moment you recognise it! The faster you stop, the more points you earn.",
+  "introSplashWaiting": "Waiting for host...",
+  "introSplashStart": "▶ Start Intro Round"
 }

--- a/custom_components/beatify/www/i18n/es.json
+++ b/custom_components/beatify/www/i18n/es.json
@@ -592,5 +592,9 @@
     "share_save": "📤 Compartir imagen",
     "share_copied": "¡Copiado!",
     "share_title": "Mis resultados de Beatify"
-  }
+  },
+  "introSplashTitle": "¡Ronda Intro!",
+  "introSplashDesc": "La canción suena — detente en cuanto la reconozcas. ¡Cuanto más rápido pares, más puntos!",
+  "introSplashWaiting": "Esperando al anfitrión...",
+  "introSplashStart": "▶ Iniciar Ronda Intro"
 }

--- a/custom_components/beatify/www/i18n/fr.json
+++ b/custom_components/beatify/www/i18n/fr.json
@@ -592,5 +592,9 @@
     "share_save": "📤 Partager l'image",
     "share_copied": "Copié !",
     "share_title": "Mes résultats Beatify"
-  }
+  },
+  "introSplashTitle": "Round Intro !",
+  "introSplashDesc": "La chanson joue — arrêtez-la dès que vous la reconnaissez ! Plus vite vous arrêtez, plus vous marquez.",
+  "introSplashWaiting": "En attente de l'hôte...",
+  "introSplashStart": "▶ Démarrer le Round Intro"
 }

--- a/custom_components/beatify/www/js/player-core.js
+++ b/custom_components/beatify/www/js/player-core.js
@@ -33,7 +33,8 @@ import {
     updateControlBarState, handleSongStopped, handleVolumeChanged,
     handleNextRound, setupAdminControlBar, setupRevealControls,
     setupRevealLeaderboardToggle, setupRoundAnalyticsToggle,
-    resetSongStoppedState
+    resetSongStoppedState,
+    showIntroSplashModal, hideIntroSplashModal
 } from './player-game.js';
 
 import { updateRevealView } from './player-reveal.js';
@@ -476,6 +477,11 @@ function handleServerMessage(data) {
             showView('game-view');
             closeInviteModal();
             updateGameView(data);
+            if (data.intro_splash_pending) {
+                showIntroSplashModal(state.isAdmin);
+            } else {
+                hideIntroSplashModal();
+            }
             if (data.difficulty) {
                 renderDifficultyBadge(data.difficulty);
             }

--- a/custom_components/beatify/www/js/player-game.js
+++ b/custom_components/beatify/www/js/player-game.js
@@ -1825,3 +1825,43 @@ export function setupRevealControls() {
         });
     }
 }
+
+// ============================================
+// Intro Splash Modal (Issue #292)
+// ============================================
+
+/**
+ * Show the intro splash modal
+ * @param {boolean} isAdmin - Whether the current player is admin
+ */
+export function showIntroSplashModal(isAdmin) {
+    var modal = document.getElementById('intro-splash-modal');
+    if (!modal) return;
+    modal.classList.remove('hidden');
+
+    var confirmBtn = document.getElementById('intro-splash-confirm-btn');
+    var waitingMsg = modal.querySelector('.intro-splash-modal-waiting');
+    if (confirmBtn) {
+        if (isAdmin) {
+            confirmBtn.classList.remove('hidden');
+            if (waitingMsg) waitingMsg.classList.add('hidden');
+            confirmBtn.onclick = function() {
+                if (state.ws && state.ws.readyState === WebSocket.OPEN) {
+                    state.ws.send(JSON.stringify({ type: 'admin', action: 'confirm_intro_splash' }));
+                }
+            };
+        } else {
+            confirmBtn.classList.add('hidden');
+            if (waitingMsg) waitingMsg.classList.remove('hidden');
+        }
+    }
+}
+
+/**
+ * Hide the intro splash modal
+ */
+export function hideIntroSplashModal() {
+    var modal = document.getElementById('intro-splash-modal');
+    if (!modal) return;
+    modal.classList.add('hidden');
+}

--- a/custom_components/beatify/www/player.html
+++ b/custom_components/beatify/www/player.html
@@ -621,6 +621,18 @@
         <div id="reaction-container" class="reaction-container"></div>
     </main>
 
+    <!-- Intro Splash Modal (Issue #292) -->
+    <div id="intro-splash-modal" class="intro-splash-modal hidden" role="dialog" aria-modal="true">
+      <div class="intro-splash-modal-backdrop"></div>
+      <div class="intro-splash-modal-content">
+        <div class="intro-splash-modal-emoji">🎵</div>
+        <h2 class="intro-splash-modal-title" data-i18n="game.introSplashTitle">Intro Round!</h2>
+        <p class="intro-splash-modal-desc" data-i18n="game.introSplashDesc">Stop the song the moment you recognise it!</p>
+        <p class="intro-splash-modal-waiting" data-i18n="game.introSplashWaiting">Waiting for host...</p>
+        <button id="intro-splash-confirm-btn" class="btn btn-primary intro-splash-confirm-btn hidden" data-i18n="game.introSplashStart">Start Intro Round</button>
+      </div>
+    </div>
+
     <!-- Reconnecting Overlay (Story 7-3) -->
     <div id="reconnecting-overlay" class="reconnecting-overlay hidden">
         <div class="reconnecting-content">


### PR DESCRIPTION
## Summary
Closes #292.

### 1. Intro rounds delayed until round 4
`state.py`: added `and self.round >= 3` guard — intro mode never fires on display rounds 1–3 so players can learn the basic mechanics first.

### 2. First-intro splash screen
When the first-ever intro round of a game is about to start:
- A full-screen modal appears on **all** player devices
- **Players** see: 🎵, title, mechanic explanation, "Waiting for host..."
- **Admin** sees the same + **▶ Start Intro Round** button
- Admin confirms → server starts the auto-stop timer → round plays normally
- Subsequent intro rounds start immediately without splash

### Files changed
| File | Change |
|---|---|
| `game/state.py` | `_intro_splash_pending`, `_intro_splash_shown` fields; round ≥ 3 guard |
| `server/websocket.py` | New `confirm_intro_splash` admin action |
| `www/player.html` | `#intro-splash-modal` element |
| `www/css/styles.css` | `.intro-splash-modal` styles |
| `www/js/player-game.js` | `showIntroSplashModal()` / `hideIntroSplashModal()` |
| `www/js/player-core.js` | Calls show/hide based on `intro_splash_pending` in state |
| `www/i18n/*.json` | 4 new keys in en/de/es/fr |

All 129 tests pass.