### PR TITLE
chore: bump all playlist versions (post-Deezer enrichment)

### DIFF
--- a/custom_components/beatify/playlists/2000s-pop-anthems.json
+++ b/custom_components/beatify/playlists/2000s-pop-anthems.json
@@ -1,6 +1,6 @@
 {
   "name": "2000s Pop Anthems",
-  "version": "1.2",
+  "version": "1.3",
   "tags": [
     "2000s",
     "pop",

--- a/custom_components/beatify/playlists/80er-hits.json
+++ b/custom_components/beatify/playlists/80er-hits.json
@@ -1,6 +1,6 @@
 {
   "name": "80s Hits",
-  "version": "2.1",
+  "version": "2.2",
   "tags": [
     "1980s",
     "pop",

--- a/custom_components/beatify/playlists/90er-hits.json
+++ b/custom_components/beatify/playlists/90er-hits.json
@@ -1,6 +1,6 @@
 {
   "name": "90s Hits",
-  "version": "1.2",
+  "version": "1.3",
   "tags": [
     "1990s",
     "pop",

--- a/custom_components/beatify/playlists/british-invasion-britpop.json
+++ b/custom_components/beatify/playlists/british-invasion-britpop.json
@@ -1,6 +1,6 @@
 {
   "name": "British Invasion & Britpop 🇬🇧",
-  "version": "1.0",
+  "version": "1.1",
   "tags": [
     "1960s",
     "1990s",

--- a/custom_components/beatify/playlists/disco-funk-classics.json
+++ b/custom_components/beatify/playlists/disco-funk-classics.json
@@ -1,6 +1,6 @@
 {
   "name": "Disco & Funk Classics",
-  "version": "1.1",
+  "version": "1.2",
   "tags": [
     "1970s",
     "1980s",

--- a/custom_components/beatify/playlists/eurodance-90s.json
+++ b/custom_components/beatify/playlists/eurodance-90s.json
@@ -1,6 +1,6 @@
 {
   "name": "Eurodance 90s 💥",
-  "version": "1.2",
+  "version": "1.3",
   "tags": [
     "1990s",
     "eurodance",

--- a/custom_components/beatify/playlists/eurovision-winners.json
+++ b/custom_components/beatify/playlists/eurovision-winners.json
@@ -1,6 +1,6 @@
 {
   "name": "Eurovision Winners (1956-2025)",
-  "version": "1.4",
+  "version": "1.5",
   "tags": [
     "eurovision",
     "contest",

--- a/custom_components/beatify/playlists/fiesta-latina-90s.json
+++ b/custom_components/beatify/playlists/fiesta-latina-90s.json
@@ -1,6 +1,6 @@
 {
   "name": "Fiesta Latina 90s 🇲🇽",
-  "version": "1.2",
+  "version": "1.3",
   "tags": [
     "1990s",
     "latin",

--- a/custom_components/beatify/playlists/greatest-hits-of-all-time.json
+++ b/custom_components/beatify/playlists/greatest-hits-of-all-time.json
@@ -1,6 +1,6 @@
 {
   "name": "Greatest Hits of All Time",
-  "version": "2.1",
+  "version": "2.2",
   "tags": [
     "classics",
     "top-hits",

--- a/custom_components/beatify/playlists/koelner-karneval.json
+++ b/custom_components/beatify/playlists/koelner-karneval.json
@@ -1,6 +1,6 @@
 {
   "name": "Cologne Carnival 🎭",
-  "version": "1.2",
+  "version": "1.3",
   "tags": [
     "german",
     "carnival",

--- a/custom_components/beatify/playlists/motown-soul-classics.json
+++ b/custom_components/beatify/playlists/motown-soul-classics.json
@@ -1,6 +1,6 @@
 {
   "name": "Motown & Soul Classics",
-  "version": "1.1",
+  "version": "1.2",
   "tags": [
     "1960s",
     "1970s",

--- a/custom_components/beatify/playlists/movies-100-greatest-themes.json
+++ b/custom_components/beatify/playlists/movies-100-greatest-themes.json
@@ -1,6 +1,6 @@
 {
   "name": "100 Greatest Movie Themes 🎬",
-  "version": "1.5",
+  "version": "1.6",
   "tags": [
     "movies",
     "soundtrack",

--- a/custom_components/beatify/playlists/one-hit-wonders.json
+++ b/custom_components/beatify/playlists/one-hit-wonders.json
@@ -1,6 +1,6 @@
 {
   "name": "One-Hit Wonders",
-  "version": "1.1",
+  "version": "1.2",
   "tags": [
     "one-hit",
     "classics",

--- a/custom_components/beatify/playlists/pure-pop-punk.json
+++ b/custom_components/beatify/playlists/pure-pop-punk.json
@@ -1,6 +1,6 @@
 {
   "name": "Pure Pop Punk 🎸",
-  "version": "1.1",
+  "version": "1.2",
   "tags": [
     "2000s",
     "pop-punk",

--- a/custom_components/beatify/playlists/schlager-klassiker.json
+++ b/custom_components/beatify/playlists/schlager-klassiker.json
@@ -1,6 +1,6 @@
 {
   "name": "Schlager Classics 🇩🇪",
-  "version": "1.5",
+  "version": "1.6",
   "tags": [
     "german",
     "schlager",

--- a/custom_components/beatify/playlists/summer-party-anthems.json
+++ b/custom_components/beatify/playlists/summer-party-anthems.json
@@ -1,6 +1,6 @@
 {
   "name": "100 Summer Anthems ☀️",
-  "version": "1.5",
+  "version": "1.6",
   "tags": [
     "party",
     "classics",

--- a/custom_components/beatify/playlists/top-100-power-ballads.json
+++ b/custom_components/beatify/playlists/top-100-power-ballads.json
@@ -1,6 +1,6 @@
 {
   "name": "Top 100 Power Ballads",
-  "version": "1.1",
+  "version": "1.2",
   "tags": [
     "1980s",
     "1990s",

--- a/custom_components/beatify/playlists/yacht-rock.json
+++ b/custom_components/beatify/playlists/yacht-rock.json
@@ -1,6 +1,6 @@
 {
   "name": "Yacht Rock ⛵",
-  "version": "1.2",
+  "version": "1.3",
   "tags": [
     "1970s",
     "1980s",


### PR DESCRIPTION
Bumps minor version on all 18 playlists to force Home Assistant to reload the playlist cache after the Deezer URI enrichment added in #296.

All playlists bumped by 0.1 (minor).