### PR TITLE
fix: increase intro round duration from 10s to 15s (#298)

### DIFF
--- a/custom_components/beatify/const.py
+++ b/custom_components/beatify/const.py
@@ -31,7 +31,7 @@ ARTIST_BONUS_POINTS = 5
 MOVIE_BONUS_TIERS: list[int] = [5, 3, 1]
 
 # Intro mode constants (Issue #23)
-INTRO_DURATION_SECONDS = 10
+INTRO_DURATION_SECONDS = 15
 INTRO_ROUND_CHANCE = 0.20  # 20% chance per round
 INTRO_BONUS_TIERS: list[int] = [5, 3, 1]  # Same as movie bonus
 MIN_INTRO_BONUSES_FOR_AWARD = 1  # Minimum to qualify for superlative


### PR DESCRIPTION
Closes #298.

Increases `INTRO_DURATION_SECONDS` from `10` to `15` in `const.py`.

Players now have 5 more seconds to recognise the song before the auto-stop fires. Admin can still stop manually at any time.

All 129 tests pass ✅