### PR TITLE
fix: show all player guess cards in reveal phase (#301)

### DIFF
--- a/custom_components/beatify/www/css/styles.css
+++ b/custom_components/beatify/www/css/styles.css
@@ -6924,16 +6924,18 @@ body.theme-dark .result-value.is-bet-lost {
     text-align: center;
 }
 
-/* Vertical stack — each card full-width (#211) */
+/* Vertical stack — each card full-width (#211, #301) */
 .results-cards-scroll {
     display: flex;
-    flex-direction: row;
-    overflow-x: auto;
+    flex-direction: column;
+    gap: var(--space-sm);
     width: 100%;
+    overflow-y: auto;
+    max-height: 60vh;
 }
 
 .results-cards-scroll::-webkit-scrollbar {
-    height: 4px;
+    width: 3px;
 }
 
 .results-cards-scroll::-webkit-scrollbar-thumb {
@@ -6948,9 +6950,9 @@ body.theme-dark .result-value.is-bet-lost {
     text-align: center;
     border: 2px solid var(--color-border-light);
     transition: all var(--transition-fast);
-    flex: 0 0 100%;
     width: 100%;
     box-sizing: border-box;
+    flex-shrink: 0;
 }
 
 .result-card.is-current {


### PR DESCRIPTION
Closes #301.

## Root cause
`.results-cards-scroll` used `flex-direction: row` with each `.result-card` set to `flex: 0 0 100%`. This made every card 100% wide — only the **first card** was visible, all others were scrolled off-screen to the right with no obvious scroll affordance.

## Fix
Changed `.results-cards-scroll` to `flex-direction: column` with a `gap` and `max-height: 60vh` vertical scroll. All player cards now stack vertically and are visible.

All 129 tests pass ✅