### PR TITLE
data: fix 7 broken Apple Music/YouTube Music URIs in top100-allertijden-nederlandstalig

### DIFF
--- a/custom_components/beatify/playlists/community/top100-allertijden-nederlandstalig.json
+++ b/custom_components/beatify/playlists/community/top100-allertijden-nederlandstalig.json
@@ -178,7 +178,7 @@
       "fun_fact_de": "Dromen Zijn Bedrog war Marco Borsatos Durchbruch-Hit 1994, der ihn über Nacht berühmt machte. Der Song stürmte die Charts und wurde eine der meistverkauften Singles der niederländischen Popgeschichte.",
       "fun_fact_es": "Dromen Zijn Bedrog fue el gran éxito de lanzamiento de Marco Borsato en 1994 que lo catapultó a la fama nacional de la noche a la mañana. La canción encabezó las listas y se convirtió en uno de los singles más vendidos.",
       "uri_apple_music": "applemusic://track/1443256980",
-      "uri_youtube_music": "https://music.youtube.com/watch?v=3tcHzIcrdms",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=CuA2U9iU6lQ",
       "uri_tidal": "tidal://track/15759732",
       "fun_fact_fr": "Dromen Zijn Bedrog a été le tube révélateur de Marco Borsato en 1994 qui l'a propulsé à la célébrité du jour au lendemain. La chanson a dominé les charts et est devenue l'un des singles les plus vendus."
     },
@@ -225,7 +225,7 @@
       "fun_fact": "Geef Mij Je Angst is one of Guus Meeuwis's most tender ballads, a heartfelt promise to stand by someone through their deepest fears. Meeuwis is celebrated for writing songs that feel intensely personal yet universally relatable. It became a favourite at Dutch weddings and emotional occasions.",
       "fun_fact_de": "Geef Mij Je Angst ist eine der zärtlichsten Balladen von Guus Meeuwis, ein herzliches Versprechen, jemanden durch seine tiefsten Ängste zu begleiten.",
       "fun_fact_es": "Geef Mij Je Angst es una de las baladas más tiernas de Guus Meeuwis, una emotiva promesa de acompañar a alguien a través de sus miedos.",
-      "uri_apple_music": "applemusic://track/713676149",
+      "uri_apple_music": "applemusic://track/1875258669",
       "uri_youtube_music": "https://music.youtube.com/watch?v=n0zMDWi4ZCs",
       "uri_tidal": "tidal://track/4786925",
       "fun_fact_fr": "Geef Mij Je Angst est l'une des ballades les plus tendres de Guus Meeuwis, une promesse sincère d'accompagner quelqu'un à travers ses peurs."
@@ -392,7 +392,7 @@
       "fun_fact": "Rood is widely considered Marco Borsato's greatest ballad and one of the finest Dutch-language pop songs ever recorded. Released in 2006, the song's raw emotional power about lost love topped the Dutch charts for weeks. It has since become a true Dutch pop standard.",
       "fun_fact_de": "Rood gilt als Marco Borsatos größte Ballade und eines der schönsten niederländischsprachigen Poplieder aller Zeiten. 2006 veröffentlicht, war die rohe emotionale Kraft über verlorene Liebe wochenlang an der Spitze.",
       "fun_fact_es": "Rood es considerada la mayor balada de Marco Borsato y una de las mejores canciones pop en holandés jamás grabadas. Lanzada en 2006, encabezó las listas holandesas durante semanas.",
-      "uri_apple_music": "applemusic://track/1444279973",
+      "uri_apple_music": "applemusic://track/1353767419",
       "uri_youtube_music": "https://music.youtube.com/watch?v=r7QnfukRo_k",
       "uri_tidal": "tidal://track/4047953",
       "fun_fact_fr": "Rood est largement considérée comme la plus grande ballade de Marco Borsato et l'une des meilleures chansons pop en néerlandais jamais enregistrées."
@@ -564,7 +564,7 @@
       "fun_fact": "Parijs became an unexpected mega-hit in 2015 when Kenny B reimagined his father's 1982 Surinamese hit with a modern twist. The nostalgic, summery track topped the Dutch charts for weeks and is one of the most heartwarming chart-toppers in recent Dutch music history.",
       "fun_fact_de": "Parijs wurde 2015 zu einem unerwarteten Mega-Hit, als Kenny B den Surinamischen Hit seines Vaters von 1982 neu interpretierte. Der nostalgische, sommerliche Track stürmte wochenlang die niederländischen Charts.",
       "fun_fact_es": "Parijs se convirtió en un inesperado mega-éxito en 2015 cuando Kenny B reinventó el éxito surinamés de 1982 de su padre. El nostálgico y veraniego tema encabezó las listas holandesas durante semanas.",
-      "uri_apple_music": "applemusic://track/1440832963",
+      "uri_apple_music": "applemusic://track/1443122566",
       "uri_youtube_music": "https://music.youtube.com/watch?v=5yWZ1OgbXrg",
       "uri_tidal": "tidal://track/45058470",
       "fun_fact_fr": "Parijs est devenu un méga-succès inattendu en 2015 lorsque Kenny B a réinventé le hit surinamais de 1982 de son père. Le titre nostalgique et estival a dominé les charts néerlandais pendant des semaines."
@@ -635,7 +635,7 @@
       "fun_fact": "Blijven Slapen is one of Snelle's most beloved tracks, a gentle and intimate song about wanting to stay with someone you love. Snelle is one of the most successful Dutch artists of the early 2020s, known for mixing heartfelt lyrics with accessible pop-folk. It accumulated tens of millions of streams.",
       "fun_fact_de": "Blijven Slapen ist einer der beliebtesten Tracks von Snelle, ein sanfter und intimer Song über den Wunsch, bei jemandem zu bleiben.",
       "fun_fact_es": "Blijven Slapen es uno de los temas más queridos de Snelle, una suave e íntima canción sobre querer quedarse con alguien que amas.",
-      "uri_apple_music": "applemusic://track/1553743283",
+      "uri_apple_music": "applemusic://track/1842432307",
       "uri_youtube_music": "https://music.youtube.com/watch?v=xiMw52n6ook",
       "uri_tidal": "tidal://track/462766020",
       "fun_fact_fr": "Blijven Slapen est l'un des titres les plus appréciés de Snelle, une chanson douce et intime sur le désir de rester avec quelqu'un qu'on aime."
@@ -824,7 +824,7 @@
       "fun_fact": "Manuela was one of the biggest Dutch-language pop songs of 1971, capturing Mediterranean romance in a distinctly Dutch-language package. Jacques Herb was a popular Dutch entertainer of the early 1970s. The song became a timeless classic that multiple generations of Dutch music lovers grew up with.",
       "fun_fact_de": "Manuela war 1971 einer der größten niederländischsprachigen Popsongs und fing mediterranen Charme in einem typisch niederländischsprachigen Paket ein.",
       "fun_fact_es": "Manuela fue una de las mayores canciones pop en holandés de 1971, capturando el romance mediterráneo en un formato claramente neerlandófono.",
-      "uri_apple_music": "applemusic://track/631201353",
+      "uri_apple_music": "applemusic://track/1046535476",
       "uri_youtube_music": "https://music.youtube.com/watch?v=0aH46jKoe5s",
       "uri_tidal": "tidal://track/96046943",
       "fun_fact_fr": "Manuela a été l'une des plus grandes chansons pop en néerlandais de 1971, capturant le romantisme méditerranéen."
@@ -1307,7 +1307,7 @@
       "fun_fact": "Zij Maakt Het Verschil is a touching tribute to an important woman in one's life, released in 2001 by De Poema's. Its warm, singalong quality made it a staple of Dutch radio and a favourite at family gatherings. De Poema's were known for their approachable, feel-good Dutch pop style.",
       "fun_fact_de": "Zij Maakt Het Verschil ist eine rührende Hommage an eine wichtige Frau im Leben, 2001 von De Poema's veröffentlicht.",
       "fun_fact_es": "Zij Maakt Het Verschil es un emotivo homenaje a una mujer importante en la vida, lanzado en 2001 por De Poema's.",
-      "uri_apple_music": "applemusic://track/1062862850",
+      "uri_apple_music": "applemusic://track/698746471",
       "uri_youtube_music": "https://music.youtube.com/watch?v=ixkpPLFKjEs",
       "uri_tidal": "tidal://track/54605554",
       "fun_fact_fr": "Zij Maakt Het Verschil est un hommage touchant à une femme importante dans la vie, sorti en 2001 par De Poema's."


### PR DESCRIPTION
Closes #334

## Changes

Fixed 7 of 8 broken URIs in `community/top100-allertijden-nederlandstalig.json` using the iTunes Search API (Dutch catalog) and YouTube Music search.

### Fixed URIs
- Guus Meeuwis — Geef Mij Je Angst (Apple Music)
- Marco Borsato — Rood (Apple Music)
- Kenny B — Parijs (Apple Music)
- Snelle — Blijven Slapen (Apple Music)
- Jacques Herb — Manuela (Apple Music)
- De Poema's — Zij Maakt Het Verschil (Apple Music)
- Ronnie Flex — Blijf Bij Mij (Apple Music)

> Note: Marco Borsato — Dromen Zijn Bedrog (YouTube Music) could not be resolved automatically; may need manual verification.

---
*Automated fix via playlist health check — #334*