### PR TITLE
docs: clarify Fritzbox guest WiFi limitations (#339)

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,6 +393,8 @@ That's it. No mDNS, no broadcast, no additional ports.
 - If using a reverse proxy (nginx/Caddy), ensure WebSocket upgrades are allowed for `/beatify/ws` (standard HA proxy configs already handle this)
 - If using HTTPS with a self-signed cert, guests may need to accept it once
 
+> **⚠️ Fritzbox users:** The Fritzbox guest WiFi fully isolates clients from your home network — this cannot be overridden with firewall rules. Players must join the main WiFi, or use a separate VLAN-capable router/access point to create a guest network with selective LAN access.
+
 ---
 
 <br>


### PR DESCRIPTION
## What

Adds a warning note to the Guest WiFi / Network Setup section about **Fritzbox routers** specifically.

## Why

Sascha Brockel's [Beatify review](https://youtube.com/watch?v=5svPtlbgYjk) flagged that the README's suggestion to "just add a firewall rule" is misleading for Fritzbox users. The Fritzbox guest WiFi uses full client isolation by design — there's no way to poke holes in it.

## Changes

- Added ⚠️ Fritzbox-specific note explaining the limitation
- Suggests players join main WiFi or use a VLAN-capable router instead

Closes #339