### PR TITLE
feat: add one-time intro mode explainer splash (#340)

### DIFF
--- a/custom_components/beatify/www/css/styles.css
+++ b/custom_components/beatify/www/css/styles.css
@@ -3905,6 +3905,22 @@ body.theme-dark .admin-controls {
     letter-spacing: 1px;
 }
 
+.intro-splash-explainer {
+    font-size: 16px;
+    color: rgba(255, 255, 255, 0.85);
+    text-align: center;
+    max-width: 320px;
+    line-height: 1.5;
+    margin: 8px 0 0;
+}
+
+.intro-splash-tap-hint {
+    font-size: 13px;
+    color: rgba(255, 255, 255, 0.45);
+    margin-top: 12px;
+    letter-spacing: 0.5px;
+}
+
 @keyframes intro-splash-in {
     from { opacity: 0; }
     to { opacity: 1; }

--- a/custom_components/beatify/www/i18n/de.json
+++ b/custom_components/beatify/www/i18n/de.json
@@ -95,6 +95,8 @@
     "introRound": "INTRO-RUNDE",
     "introStopped": "Intro vorbei!",
     "introHint": "Nur 15 Sekunden!",
+    "introExplainer": "Du hörst nur die ersten Sekunden des Songs, dann Stille. Kannst du das Jahr nur anhand des Intros erraten?",
+    "tapToDismiss": "Tippen zum Fortfahren",
     "loading": "Laden...",
     "wait": "Warten...",
     "skip": "Überspringen",

--- a/custom_components/beatify/www/i18n/en.json
+++ b/custom_components/beatify/www/i18n/en.json
@@ -95,6 +95,8 @@
     "introRound": "INTRO ROUND",
     "introStopped": "Intro complete!",
     "introHint": "Only 15 seconds!",
+    "introExplainer": "You'll hear only the first few seconds of the song, then silence. Can you guess the year from just the intro?",
+    "tapToDismiss": "Tap to continue",
     "loading": "Loading...",
     "wait": "Wait...",
     "skip": "Skip",

--- a/custom_components/beatify/www/i18n/es.json
+++ b/custom_components/beatify/www/i18n/es.json
@@ -95,6 +95,8 @@
     "introRound": "RONDA INTRO",
     "introStopped": "Intro completa!",
     "introHint": "¡Solo 15 segundos!",
+    "introExplainer": "Escucharás solo los primeros segundos de la canción y luego silencio. ¿Puedes adivinar el año solo con la intro?",
+    "tapToDismiss": "Toca para continuar",
     "loading": "Cargando...",
     "wait": "Esperar...",
     "skip": "Saltar",

--- a/custom_components/beatify/www/i18n/fr.json
+++ b/custom_components/beatify/www/i18n/fr.json
@@ -95,6 +95,8 @@
     "introRound": "MANCHE INTRO",
     "introStopped": "Intro terminée !",
     "introHint": "Seulement 15 secondes !",
+    "introExplainer": "Vous n'entendrez que les premières secondes de la chanson, puis le silence. Pouvez-vous deviner l'année rien qu'avec l'intro ?",
+    "tapToDismiss": "Appuyez pour continuer",
     "loading": "Chargement...",
     "wait": "Attendre...",
     "skip": "Passer",

--- a/custom_components/beatify/www/js/player-game.js
+++ b/custom_components/beatify/www/js/player-game.js
@@ -127,9 +127,30 @@ export function updateGameView(data) {
                 if (introSplash && !introSplash._shown) {
                     introSplash._shown = true;
                     introSplash.classList.remove('hidden');
-                    setTimeout(function() {
-                        introSplash.classList.add('hidden');
-                    }, 2000);
+                    var explainer = document.getElementById('intro-splash-explainer');
+                    var tapHint = document.getElementById('intro-splash-tap-hint');
+                    if (!window._introExplainerShown && explainer && tapHint) {
+                        window._introExplainerShown = true;
+                        explainer.classList.remove('hidden');
+                        tapHint.classList.remove('hidden');
+                        introSplash.style.pointerEvents = 'auto';
+                        introSplash.style.cursor = 'pointer';
+                        introSplash.style.animation = 'intro-splash-in 0.3s ease-out';
+                        var dismissHandler = function() {
+                            introSplash.classList.add('hidden');
+                            introSplash.style.pointerEvents = '';
+                            introSplash.style.cursor = '';
+                            introSplash.style.animation = '';
+                            explainer.classList.add('hidden');
+                            tapHint.classList.add('hidden');
+                            introSplash.removeEventListener('click', dismissHandler);
+                        };
+                        introSplash.addEventListener('click', dismissHandler);
+                    } else {
+                        setTimeout(function() {
+                            introSplash.classList.add('hidden');
+                        }, 2000);
+                    }
                 }
             }
         } else {

--- a/custom_components/beatify/www/player.html
+++ b/custom_components/beatify/www/player.html
@@ -201,6 +201,8 @@
                         <span class="intro-splash-icon">⚡</span>
                         <span class="intro-splash-text" data-i18n="game.introRound">INTRO ROUND</span>
                         <span class="intro-splash-hint" data-i18n="game.introHint">Only 10 seconds!</span>
+                        <p id="intro-splash-explainer" class="intro-splash-explainer hidden" data-i18n="game.introExplainer">You'll hear only the first few seconds of the song, then silence. Can you guess the year from just the intro?</p>
+                        <span id="intro-splash-tap-hint" class="intro-splash-tap-hint hidden" data-i18n="game.tapToDismiss">Tap to continue</span>
                     </div>
                 </div>
 


### PR DESCRIPTION
## What

Adds a one-time explainer splash screen when the first Intro Mode round triggers in a game.

## Why

In Sascha Brockel's [Beatify review](https://youtube.com/watch?v=5svPtlbgYjk), he had no idea what Intro Mode was and had to pause mid-game to look it up. Players who didn't configure the game have zero context when a song suddenly stops after 10 seconds.

## Changes

- **player.html**: Added explainer paragraph and "Tap to continue" hint inside existing `#intro-splash` overlay
- **player-game.js**: Session-level flag (`window._introExplainerShown`) — first intro round shows the explainer and waits for tap, subsequent rounds get the normal 2-second auto-dismiss splash
- **styles.css**: Styled explainer text and tap hint
- **i18n**: Added `game.introExplainer` and `game.tapToDismiss` keys in all 4 languages (EN, DE, ES, FR)

## First intro round
> ⚡ **Intro Mode!** You'll hear only the first few seconds of the song, then silence. Can you guess the year from just the intro?
> *(Tap to continue)*

## Subsequent intro rounds
Normal ⚡ splash with 2-second auto-dismiss (unchanged behavior).

Closes #340