### PR TITLE
data: fix 11 broken Apple Music URIs in disco-funk-classics (#338)

### DIFF
--- a/custom_components/beatify/playlists/disco-funk-classics.json
+++ b/custom_components/beatify/playlists/disco-funk-classics.json
@@ -63,7 +63,7 @@
       "fun_fact_de": "Ursprünglich 'Fuck Off' betitelt, nachdem Nile Rodgers und Bernard Edwards der Eintritt ins Studio 54 verwehrt wurde. Es war Atlantic Records' meistverkaufte Single und stand fünf Wochen auf Platz 1 der Billboard Hot 100.",
       "fun_fact_es": "Originalmente titulada 'Fuck Off' después de que a Nile Rodgers y Bernard Edwards les negaran la entrada al Studio 54. Fue el sencillo más vendido de Atlantic Records, permaneciendo cinco semanas en el #1 del Billboard Hot 100.",
       "fun_fact_fr": "À l'origine intitulée « Fuck Off » après que Nile Rodgers et Bernard Edwards se soient vu refuser l'entrée au Studio 54. Plus gros succès d'Atlantic Records à l'époque, le titre est resté cinq semaines en tête du Billboard Hot 100.",
-      "uri_apple_music": "applemusic://track/847723715",
+      "uri_apple_music": "applemusic://track/301649381",
       "uri_youtube_music": "https://music.youtube.com/watch?v=aXgSHL7efKg",
       "uri_tidal": "tidal://track/68699222",
       "uri_deezer": "deezer://track/72060062"
@@ -179,7 +179,7 @@
       "fun_fact_de": "Wurde zur inoffiziellen Hymne der Freilassung der amerikanischen Geiseln aus dem Iran 1981 und ist seitdem bei Feiern weltweit ein Muss. Es war zwei Wochen auf Platz 1 und gehört zu den meistgespielten Songs bei Hochzeiten und Sportevents.",
       "fun_fact_es": "Se convirtió en el himno no oficial de la liberación de los rehenes estadounidenses de Irán en 1981 y desde entonces es un clásico en celebraciones mundiales. Estuvo dos semanas en el #1 y es una de las canciones más tocadas en bodas y eventos deportivos.",
       "fun_fact_fr": "Devenu l'hymne officieux de la libération des otages américains en Iran en 1981, ce titre est depuis un incontournable des festivités à travers le monde. Il est resté deux semaines numéro un et figure parmi les morceaux les plus joués lors de mariages et d'événements sportifs.",
-      "uri_apple_music": "applemusic://track/1595570177",
+      "uri_apple_music": "applemusic://track/1444107530",
       "uri_youtube_music": "https://music.youtube.com/watch?v=3GwjfUFyY6M",
       "uri_tidal": "tidal://track/3094190",
       "uri_deezer": "deezer://track/95873824"
@@ -267,7 +267,7 @@
       "fun_fact_de": "Ursprünglich 1982 veröffentlicht und gefloppt, wurde der Song mit schnellerem Tempo neu aufgenommen und 1984 erfolgreich wiederveröffentlicht. Er erlangte neue Berühmtheit durch Jessie Spanos Koffeinpillen-Szene in 'Saved by the Bell'.",
       "fun_fact_es": "Originalmente lanzada en 1982 sin éxito, fue regrabada con un tempo más rápido y relanzada en 1984 con gran éxito. La canción ganó nueva fama por la escena de las pastillas de cafeína de Jessie Spano en 'Salvados por la Campana'.",
       "fun_fact_fr": "Sortie initialement en 1982 sans succès, la chanson a été réenregistrée avec un tempo plus rapide et relancée en 1984 avec un énorme succès. Elle a connu un regain de popularité grâce à la scène mythique de Jessie Spano et ses pilules de caféine dans « Sauvé par le gong ».",
-      "uri_apple_music": "applemusic://track/294037064",
+      "uri_apple_music": "applemusic://track/298411240",
       "uri_youtube_music": "https://music.youtube.com/watch?v=8iwBM_YB1sE",
       "uri_tidal": "tidal://track/3392941",
       "uri_deezer": "deezer://track/346967941"
@@ -650,7 +650,7 @@
       "fun_fact_de": "Der mehrsprachige Text enthält Wörter aus karibischen, afrikanischen und völlig erfundenen Sprachen. Richie performte den Song bei der Abschlusszeremonie der Olympischen Spiele 1984 in LA. Er war vier Wochen auf Platz 1.",
       "fun_fact_es": "Las letras multilingües incluyen palabras del Caribe, africanas y completamente inventadas. Richie interpretó esta canción en la ceremonia de clausura de los Juegos Olímpicos de LA 1984. Estuvo cuatro semanas en el #1.",
       "fun_fact_fr": "Les paroles multilingues comprennent des mots caribéens, africains et des termes complètement inventés. Richie a interprété ce titre lors de la cérémonie de clôture des Jeux Olympiques de Los Angeles en 1984. Il est resté quatre semaines numéro un et fut l'un des singles les plus vendus de 1983.",
-      "uri_apple_music": "applemusic://track/1440781676",
+      "uri_apple_music": "applemusic://track/1440809027",
       "uri_youtube_music": "https://music.youtube.com/watch?v=nqAvFx3NxUM",
       "uri_tidal": "tidal://track/592285",
       "uri_deezer": "deezer://track/920062"
@@ -679,7 +679,7 @@
       "fun_fact_de": "Cecil Womack war der Bruder von Bobby Womack, und Linda war die Tochter von Sam Cooke. Der Song war ein riesiger europäischer Hit, chartete aber nie in den USA. Er wurde 1988 zum Sommerhit in Großbritannien und ganz Europa.",
       "fun_fact_es": "Cecil Womack era hermano de Bobby Womack, y Linda era hija de Sam Cooke. La canción fue un gran éxito europeo pero nunca entró en las listas de EE.UU. Se convirtió en un himno veraniego en el Reino Unido y toda Europa en 1988.",
       "fun_fact_fr": "Cecil Womack était le frère de Bobby Womack, et Linda était la fille de Sam Cooke. Le titre a été un immense succès européen mais n'a jamais figuré dans les charts américains. Il est devenu un hymne estival au Royaume-Uni et à travers toute l'Europe en 1988.",
-      "uri_apple_music": "applemusic://track/1440670610",
+      "uri_apple_music": "applemusic://track/1361759637",
       "uri_youtube_music": "https://music.youtube.com/watch?v=R8AOAap6_k4",
       "uri_tidal": "tidal://track/1300335",
       "uri_deezer": "deezer://track/477342872"
@@ -793,7 +793,7 @@
       "fun_fact_de": "Gloria Gaynors Disco-Version des Frankie-Valli-Klassikers von 1967 verwandelte eine Doo-Wop-Ballade in eine pulsierende Dancefloor-Hymne. Das Original von Frankie Valli erreichte Platz 2 der Billboard Hot 100 und wurde von über 200 Künstlern gecovert.",
       "fun_fact_es": "La versión disco de Gloria Gaynor del clásico de Frankie Valli de 1967 transformó una balada doo-wop en un himno pulsante de pista de baile. El original de Frankie Valli llegó al #2 del Billboard Hot 100 y ha sido versionada por más de 200 artistas.",
       "fun_fact_fr": "La version disco de Gloria Gaynor du classique de Frankie Valli de 1967 a transformé une ballade doo-wop en un hymne de piste de danse pulsant. L'original de Frankie Valli avait atteint la 2e place du Billboard Hot 100 et a été repris par plus de 200 artistes.",
-      "uri_apple_music": "applemusic://track/530072629",
+      "uri_apple_music": "applemusic://track/1650393398",
       "uri_youtube_music": "https://music.youtube.com/watch?v=-R0EjDM5YFg",
       "uri_tidal": "tidal://track/45751156",
       "uri_deezer": "deezer://track/360910551"
@@ -971,7 +971,7 @@
       "fun_fact_de": "Obwohl bei der Erstveröffentlichung nur ein bescheidener Hit, erlebte der Song in den 2000ern ein massives Revival, als Room 5 ihn für 'Make Luv' sampelte, das in UK Nummer 1 wurde. Cheathams Vocals wurden in der europäischen Clubkultur ikonisch.",
       "fun_fact_es": "Aunque fue un éxito modesto en su lanzamiento, la canción experimentó un gran revival en los 2000 cuando Room 5 la sampleó para 'Make Luv', que llegó al #1 en UK. Las suaves voces de Cheatham se volvieron icónicas en la cultura de clubs europea.",
       "fun_fact_fr": "Bien que modestement accueilli lors de sa sortie, le titre a connu un revival spectaculaire dans les années 2000 lorsque Room 5 l'a samplé pour « Make Luv », qui a atteint la première place au Royaume-Uni. La voix veloutée de Cheatham est devenue iconique dans la culture club européenne.",
-      "uri_apple_music": "applemusic://track/1779019008",
+      "uri_apple_music": "applemusic://track/1646553918",
       "uri_youtube_music": "https://music.youtube.com/watch?v=c29H75mLc-8",
       "uri_tidal": "tidal://track/227703662",
       "uri_deezer": "deezer://track/2044588597"
@@ -1000,7 +1000,7 @@
       "fun_fact_de": "Der zweite Nummer-1-Hit von KC & The Sunshine Band etablierte den Miami-Bass-Sound, der Disco und spätere Bass-Musik beeinflusste. Harry Wayne Casey (KC) schrieb und produzierte die meisten Hits der Band zusammen mit Bassist Richard Finch.",
       "fun_fact_es": "El segundo #1 de KC & The Sunshine Band, estableció el sonido Miami bass que influyó en el disco y la música bass posterior. Harry Wayne Casey (KC) escribió y produjo la mayoría de los éxitos junto al bajista Richard Finch.",
       "fun_fact_fr": "Deuxième numéro un de KC & The Sunshine Band, il a imposé le son Miami bass qui a influencé le disco et les musiques bass ultérieures. Harry Wayne Casey (KC) a écrit et produit la plupart des tubes du groupe aux côtés du bassiste Richard Finch dans leur propre studio.",
-      "uri_apple_music": "applemusic://track/1039402934",
+      "uri_apple_music": "applemusic://track/814050537",
       "uri_youtube_music": "https://music.youtube.com/watch?v=aXxB2QN2IuY",
       "uri_tidal": "tidal://track/50959527",
       "uri_deezer": "deezer://track/107118556"
@@ -1226,7 +1226,7 @@
       "fun_fact_de": "Der erste Nummer-1-Hit von KC & The Sunshine Band definierte den Miami Sound, der Funk, Soul und Pop verband. Harry Wayne Casey und Richard Finch waren Songwriter bei TK Records und schrieben den Song mit 23 bzw. 21 Jahren.",
       "fun_fact_es": "El primer #1 de KC & The Sunshine Band, definió el sonido Miami que combinaba funk, soul y pop. Harry Wayne Casey y Richard Finch eran compositores de TK Records y escribieron esto con 23 y 21 años respectivamente.",
       "fun_fact_fr": "Premier numéro un de KC & The Sunshine Band, il a défini le Miami Sound mêlant funk, soul et pop. Harry Wayne Casey et Richard Finch étaient auteurs-compositeurs chez TK Records et ont écrit ce titre à l'âge de 23 et 21 ans respectivement.",
-      "uri_apple_music": "applemusic://track/1039402935",
+      "uri_apple_music": "applemusic://track/814050540",
       "uri_youtube_music": "https://music.youtube.com/watch?v=BXIBEW5MLuU",
       "uri_tidal": "tidal://track/2407477",
       "uri_deezer": "deezer://track/3151317"
@@ -1456,7 +1456,7 @@
       "fun_fact_de": "Gegründet von Vince Clarke (der gerade Depeche Mode verlassen hatte) und Alison Moyet. Das Duo war in den USA als 'Yaz' bekannt wegen eines Markenrechtsstreits. Clarke gründete später Erasure, Moyet hatte eine erfolgreiche Solokarriere. Sie veröffentlichten nur zwei Alben zusammen.",
       "fun_fact_es": "Formado por Vince Clarke (que acababa de dejar Depeche Mode) y Alison Moyet. El dúo se conocía como 'Yaz' en EE.UU. por una disputa de marca. Clarke formó Erasure después, mientras Moyet tuvo una exitosa carrera en solitario. Solo lanzaron dos álbumes juntos.",
       "fun_fact_fr": "Formé par Vince Clarke (qui venait de quitter Depeche Mode) et Alison Moyet. Le duo était connu sous le nom de « Yaz » aux États-Unis en raison d'un litige de marque. Clarke a ensuite fondé Erasure, tandis que Moyet a mené une brillante carrière solo. Ils n'ont sorti que deux albums ensemble.",
-      "uri_apple_music": "applemusic://track/1436832961",
+      "uri_apple_music": "applemusic://track/62442833",
       "uri_youtube_music": "https://music.youtube.com/watch?v=_sQGwDeambg",
       "uri_tidal": "tidal://track/34978342",
       "uri_deezer": "deezer://track/12650195"
@@ -1959,7 +1959,7 @@
       "fun_fact_de": "Der berühmte französische Refrain 'Voulez-vous coucher avec moi ce soir' galt 1975 als skandalös. Geschrieben von Bob Crewe und Kenny Nolan über eine Prostituierte in New Orleans. Die Version von 2001 mit Christina Aguilera, Lil' Kim, Mýa und Pink erreichte ebenfalls Platz 1.",
       "fun_fact_es": "El famoso estribillo francés 'Voulez-vous coucher avec moi ce soir' se consideró escandaloso en 1975. Escrita por Bob Crewe y Kenny Nolan sobre una prostituta de Nueva Orleans. La versión de 2001 con Christina Aguilera, Lil' Kim, Mýa y Pink también llegó al #1.",
       "fun_fact_fr": "Le célèbre refrain en français « Voulez-vous coucher avec moi ce soir » était considéré comme scandaleux en 1975. Écrite par Bob Crewe et Kenny Nolan et inspirée d'une prostituée de La Nouvelle-Orléans. La version 2001 par Christina Aguilera, Lil' Kim, Mýa et Pink a également atteint la première place.",
-      "uri_apple_music": "applemusic://track/1308524718",
+      "uri_apple_music": "applemusic://track/188249353",
       "uri_youtube_music": "https://music.youtube.com/watch?v=Tw6HrI9e1K4",
       "uri_tidal": "tidal://track/541446",
       "uri_deezer": "deezer://track/1079308"


### PR DESCRIPTION
## What

Replaces 11 dead Apple Music track IDs in `disco-funk-classics.json` with working ones from the iTunes catalog.

## Tracks Fixed

| Artist | Title | Old ID | New ID |
|--------|-------|--------|--------|
| CHIC | Le Freak | 847723715 | 301649381 |
| Kool & The Gang | Celebration | 1595570177 | 1444107530 |
| The Pointer Sisters | I'm So Excited | 294037064 | 298411240 |
| Lionel Richie | All Night Long (All Night) | 1440781676 | 1440809027 |
| Womack & Womack | Teardrops | 1440670610 | 1361759637 |
| Gloria Gaynor | Can't Take My Eyes Off You | 530072629 | 1650393398 |
| Oliver Cheatham | Get Down Saturday Night | 1779019008 | 1646553918 |
| KC & The Sunshine Band | That's the Way (I Like It) | 1039402934 | 814050537 |
| KC & The Sunshine Band | Get Down Tonight | 1039402935 | 814050540 |
| Yazoo | Don't Go | 1436832961 | 62442833 |
| Labelle | Lady Marmalade | 1308524718 | 188249353 |

All new IDs verified via iTunes Search API.

Closes #338