### PR TITLE
fix: MA+YTMusic playback detection — wait for actual audio before starting round

### DIFF
--- a/custom_components/beatify/game/state.py
+++ b/custom_components/beatify/game/state.py
@@ -1493,11 +1493,10 @@ class GameState:
         if self._media_player_service:
             # Pre-flight check: verify speaker is available before playing
             if not self._media_player_service.is_available():
-                error_detail = f"Media player {self.media_player} is unavailable"
-                self.last_error_detail = error_detail
+                self.last_error_detail = f"Media player {self.media_player} is unavailable"
                 _LOGGER.error(
-                    "Media player not available: %s, pausing game",
-                    error_detail,
+                    "Media player %s is not available, pausing game",
+                    self.media_player,
                 )
                 await self.pause_game("media_player_error")
                 return False

--- a/custom_components/beatify/services/media_player.py
+++ b/custom_components/beatify/services/media_player.py
@@ -251,7 +251,7 @@ class MediaPlayerService:
             state = self._hass.states.get(self._entity_id)
             if state and state.state == "playing":
                 current_title = state.attributes.get("media_title", "")
-                position = state.attributes.get("media_position", 999)
+                position = state.attributes.get("media_position", 0)
                 position_updated = state.attributes.get("media_position_updated_at")
 
                 title_changed = current_title and current_title != title_before
@@ -269,11 +269,12 @@ class MediaPlayerService:
             await asyncio.sleep(0.5)
             elapsed += 0.5
 
+        current_state = self._hass.states.get(self._entity_id)
         _LOGGER.warning(
             "MA playback not confirmed after %.1fs for %s (state: %s)",
             PLAYBACK_TIMEOUT,
             uri,
-            self._hass.states.get(self._entity_id).state if self._hass.states.get(self._entity_id) else "unknown",
+            current_state.state if current_state else "unknown",
         )
         # Return True anyway — MA might still be buffering, don't skip the song
         return True

--- a/tests/unit/test_media_player.py
+++ b/tests/unit/test_media_player.py
@@ -16,7 +16,7 @@ def _make_state(
     state: str = "idle",
     media_title: str = "Old Song",
     media_position: float = 0,
-    media_position_updated_at: str = "2026-01-01T00:00:00+00:00",
+    media_position_updated_at: str = "2020-01-01T00:00:00+00:00",
 ) -> MagicMock:
     """Create a mock HA state object."""
     mock = MagicMock()
@@ -64,9 +64,9 @@ class TestMANonBlockingPlayback:
         svc = MediaPlayerService(hass, "media_player.test", platform="music_assistant")
 
         old_state = _make_state("playing", media_title="Old Song", media_position=120,
-                                media_position_updated_at="2026-01-01T00:00:00+00:00")
+                                media_position_updated_at="2020-01-01T00:00:00+00:00")
         new_state = _make_state("playing", media_title="New Song", media_position=1,
-                                media_position_updated_at="2026-01-01T00:00:10+00:00")
+                                media_position_updated_at="2020-01-01T00:00:10+00:00")
         hass.states.get = MagicMock(side_effect=[old_state, new_state])
 
         with patch("custom_components.beatify.services.media_player.asyncio.sleep", new_callable=AsyncMock):
@@ -85,13 +85,13 @@ class TestMANonBlockingPlayback:
 
         call_count = 0
         old_state = _make_state("playing", media_title="Old Song", media_position=120,
-                                media_position_updated_at="2026-01-01T00:00:00+00:00")
+                                media_position_updated_at="2020-01-01T00:00:00+00:00")
         # Title changed, position=0, updated_at fresh — but NOT actually playing yet
         queued_state = _make_state("playing", media_title="New Song", media_position=0,
-                                   media_position_updated_at="2026-01-01T00:00:05+00:00")
+                                   media_position_updated_at="2020-01-01T00:00:05+00:00")
         # Actually playing: position >= 1
         playing_state = _make_state("playing", media_title="New Song", media_position=1,
-                                    media_position_updated_at="2026-01-01T00:00:10+00:00")
+                                    media_position_updated_at="2020-01-01T00:00:10+00:00")
 
         def state_progression(*args):
             nonlocal call_count
@@ -118,9 +118,9 @@ class TestMANonBlockingPlayback:
 
         poll_count = 0
         old_state = _make_state("playing", media_title="Old Song", media_position=100,
-                                media_position_updated_at="2026-01-01T00:00:00+00:00")
+                                media_position_updated_at="2020-01-01T00:00:00+00:00")
         queued_only = _make_state("playing", media_title="New Song", media_position=0,
-                                  media_position_updated_at="2026-01-01T00:00:05+00:00")
+                                  media_position_updated_at="2020-01-01T00:00:05+00:00")
 
         def always_queued(*args):
             nonlocal poll_count
@@ -146,15 +146,15 @@ class TestMANonBlockingPlayback:
 
         poll_count = 0
         old_state = _make_state("playing", media_title="Old Song", media_position=44,
-                                media_position_updated_at="2026-01-01T00:00:00+00:00")
+                                media_position_updated_at="2020-01-01T00:00:00+00:00")
         queued = _make_state("playing", media_title="New Song", media_position=0,
-                             media_position_updated_at="2026-01-01T00:00:05+00:00")
+                             media_position_updated_at="2020-01-01T00:00:05+00:00")
         idle = _make_state("idle", media_title="New Song", media_position=0,
-                           media_position_updated_at="2026-01-01T00:00:05+00:00")
+                           media_position_updated_at="2020-01-01T00:00:05+00:00")
         playing_zero = _make_state("playing", media_title="New Song", media_position=0,
-                                   media_position_updated_at="2026-01-01T00:00:08+00:00")
+                                   media_position_updated_at="2020-01-01T00:00:08+00:00")
         playing_real = _make_state("playing", media_title="New Song", media_position=1,
-                                   media_position_updated_at="2026-01-01T00:00:10+00:00")
+                                   media_position_updated_at="2020-01-01T00:00:10+00:00")
 
         def realistic_flow(*args):
             nonlocal poll_count
@@ -201,7 +201,7 @@ class TestMANonBlockingPlayback:
         no_media.attributes["media_title"] = None
         no_media.attributes["media_position_updated_at"] = None
         playing_new = _make_state("playing", media_title="First Song", media_position=1,
-                                  media_position_updated_at="2026-01-01T00:00:05+00:00")
+                                  media_position_updated_at="2020-01-01T00:00:05+00:00")
 
         def first_song(*args):
             nonlocal call_count


### PR DESCRIPTION
## Summary
- Music Assistant with YouTube Music takes 5-15s to resolve URIs and buffer audio
- `blocking=True` on `music_assistant.play_media` hangs and times out after 8s
- Songs were skipped or rounds started before music was actually playing

## Changes

### `services/media_player.py`
- MA: switched to `blocking=False` + state polling instead of `blocking=True`
- Poll waits for **actual playback** (not just queued): `media_title` changed + `media_position >= 1` + `media_position_updated_at` refreshed
- `position=0` means only "queued" in MA, `position >= 1` means speaker is outputting audio
- Returns `True` on timeout (don't skip song — MA may still be buffering)

### `game/state.py`
- Added `is_available()` check for **all platforms** (including MA) before `play_song()`
- Previously MA was excluded from pre-flight checks

### `tests/unit/test_media_player.py` (new)
- 10 tests covering: non-blocking call, song-change detection, position>=1 gate, 
  realistic YTMusic flow (queued→idle→playing pos=0→playing pos=1), timeout fallback,
  first song edge case, Sonos still uses blocking=True, availability checks

## Test plan
- [x] 287 unit tests passing (10 new)
- [x] Tested live with MA + Sonos + YouTube Music provider
- [x] Verified via HA state polling that `media_position >= 1` is the reliable indicator for actual audio output

🤖 Generated with [Claude Code](https://claude.com/claude-code)