### PR TITLE
data: fix 7 broken Apple Music URIs in fiesta-latina-90s (#353)

### DIFF
--- a/custom_components/beatify/playlists/fiesta-latina-90s.json
+++ b/custom_components/beatify/playlists/fiesta-latina-90s.json
@@ -331,7 +331,7 @@
       "fun_fact_de": "Die als Corona aufgeführte Sängerin Olga De Souza sang nicht die Original-Studioaufnahme — die Vocals stammten von Session-Sängerin Sandy Chambers. Der italienische Eurodance-Hit wurde zu einem der prägenden Songs der 90er-Tanzära.",
       "fun_fact_es": "La cantante acreditada como Corona, Olga De Souza, no cantó las voces originales de estudio — fueron interpretadas por la vocalista de sesión Sandy Chambers. El hit de eurodance italiano se convirtió en uno de los temas definitorios de los 90.",
       "fun_fact_fr": "La chanteuse créditée sous le nom de Corona, Olga De Souza, n'a pas interprété les voix originales en studio — c'est la chanteuse de session Sandy Chambers qui les a enregistrées. Ce tube d'eurodance italien est devenu l'un des morceaux emblématiques de l'ère dance des années 1990.",
-      "uri_apple_music": "applemusic://track/1821144998",
+      "uri_apple_music": "applemusic://track/880365276",
       "uri_youtube_music": "https://music.youtube.com/watch?v=OnT58cIJSpw",
       "uri_tidal": "tidal://track/441956660",
       "uri_deezer": "deezer://track/1428926582"
@@ -450,7 +450,7 @@
       "fun_fact_de": "Chilenische Gruppe, die international zum One-Hit-Wonder wurde. 'La Bomba' eroberte die Charts in Lateinamerika und wurde in Europa zum Club-Klassiker. Der Mix aus Latin-Pop und Eurodance prägte den Party-Sound der späten 90er.",
       "fun_fact_es": "Grupo chileno que se convirtió en un éxito internacional. 'La Bomba' lideró las listas en Latinoamérica y se volvió un clásico de clubs en Europa. Su mezcla de pop latino y eurodance definió el sonido fiestera de los 90.",
       "fun_fact_fr": "Ce groupe chilien est devenu un phénomène international éphémère. « La Bomba » a dominé les classements en Amérique latine et s'est imposé comme un classique des clubs en Europe. Son mélange entraînant de pop latine et d'eurodance a défini le son festif de la fin des années 1990.",
-      "uri_apple_music": "applemusic://track/457516731",
+      "uri_apple_music": "applemusic://track/574008989",
       "uri_youtube_music": "https://music.youtube.com/watch?v=iNHGEQxLwEQ",
       "uri_tidal": "tidal://track/17780815",
       "uri_deezer": "deezer://track/15839179"
@@ -668,7 +668,7 @@
       "fun_fact_de": "Der Nachfolger seines Mega-Hits 'Suavemente' festigte Elvis Crespos Position als führender Merengue-Künstler der späten 1990er. Sein Erfolg half, Merengue-Musik einem internationalen Mainstream-Publikum näherzubringen.",
       "fun_fact_es": "El sucesor de su mega-éxito 'Suavemente', esta canción cementó el lugar de Elvis Crespo como el artista de merengue líder de los años 90. Su éxito ayudó a llevar el merengue al público internacional.",
       "fun_fact_fr": "Suite de son méga-tube « Suavemente », ce morceau a assis la place d'Elvis Crespo comme artiste de merengue numéro un de la fin des années 1990. Son succès a contribué à faire découvrir le merengue au grand public international.",
-      "uri_apple_music": "applemusic://track/299704164",
+      "uri_apple_music": "applemusic://track/187429849",
       "uri_youtube_music": "https://music.youtube.com/watch?v=3CqNeJLqvL0",
       "uri_tidal": "tidal://track/3328572",
       "uri_deezer": "deezer://track/557092"
@@ -869,7 +869,7 @@
       "fun_fact_de": "Das Horror-Musikvideo war von Michael Jacksons 'Thriller' inspiriert. Ursprünglich nur international veröffentlicht, erzwang die Fan-Nachfrage die US-Veröffentlichung. Die Choreografie wurde zu einer der ikonischsten der 90er.",
       "fun_fact_es": "El video musical con temática de terror fue inspirado por 'Thriller' de Michael Jackson. Originalmente lanzado solo internacionalmente, la demanda de los fans forzó su lanzamiento en EE.UU. La coreografía se convirtió en una de las más icónicas de los 90.",
       "fun_fact_fr": "Le clip sur le thème de l'horreur s'inspire de « Thriller » de Michael Jackson. Initialement sorti uniquement à l'international, car le label américain ne voulait pas l'inclure, la pression des fans a fini par imposer sa sortie aux États-Unis. La chorégraphie est devenue l'une des plus emblématiques des années 1990.",
-      "uri_apple_music": "applemusic://track/456229762",
+      "uri_apple_music": "applemusic://track/308611114",
       "uri_youtube_music": "https://music.youtube.com/watch?v=9B4yi51ju1g",
       "uri_tidal": "tidal://track/25688677",
       "uri_deezer": "deezer://track/15608663"
@@ -1067,7 +1067,7 @@
       "fun_fact_de": "Ursprünglich aufgeführt als die Gruppe noch 'Onda Vaselina' hieß — sie wurden 2000 in OV7 umbenannt. Die Gruppe begann als Cast einer mexikanischen Kinder-TV-Show in den 1980ern und entwickelte sich zu einer der beliebtesten Pop-Gruppen Mexikos.",
       "fun_fact_es": "Originalmente interpretada cuando el grupo aún se llamaba 'Onda Vaselina', luego se rebautizaron como OV7 en 2000. El grupo comenzó como elenco de un programa infantil mexicano en los 80 y evolucionó en uno de los grupos pop más queridos de México.",
       "fun_fact_fr": "Interprété à l'origine lorsque le groupe s'appelait encore « Onda Vaselina », celui-ci a été rebaptisé OV7 en 2000. Le groupe a commencé en tant que casting d'une émission télévisée mexicaine pour enfants dans les années 1980 avant de devenir l'un des groupes pop les plus appréciés du Mexique.",
-      "uri_apple_music": "applemusic://track/1774586280",
+      "uri_apple_music": "applemusic://track/322278438",
       "uri_youtube_music": "https://music.youtube.com/watch?v=pmYtefifbx0",
       "uri_tidal": "tidal://track/5153192",
       "uri_deezer": "deezer://track/13340995"
@@ -1148,7 +1148,7 @@
       "fun_fact_de": "Vom Album 'El Color de los Sueños'. Der Titel 'Media Naranja' (halbe Orange) ist eine spanische Redewendung für 'Seelenverwandter'. Fey war in den 90ern einer der größten Teen-Pop-Stars Mexikos.",
       "fun_fact_es": "Del álbum 'El Color de los Sueños'. El título 'Media Naranja' es una expresión que significa 'alma gemela'. Fey fue una de las mayores estrellas del teen pop mexicano en los 90, conocida por su dance pop y voz distintiva.",
       "fun_fact_fr": "Tiré de l'album « El Color de los Sueños ». Le titre « Media Naranja » (moitié d'orange) est une expression espagnole qui désigne l'âme soeur, équivalent du français « sa moitié ». Fey était l'une des plus grandes stars de la teen pop mexicaine des années 1990, connue pour sa dance pop énergique et sa voix reconnaissable entre mille.",
-      "uri_apple_music": "applemusic://track/474401741",
+      "uri_apple_music": "applemusic://track/286244925",
       "uri_youtube_music": "https://music.youtube.com/watch?v=mduVi6XnZbA",
       "uri_tidal": "tidal://track/8631922",
       "uri_deezer": "deezer://track/14299243"
@@ -1403,7 +1403,7 @@
       "fun_fact_de": "Mexikanische Popgruppe, die mit OV7 und Magneto um die Herzen der Teen-Fans in Mexiko konkurrierte. Bekannt für ihre choreografierten Tanzbewegungen und eingängigen Pop-Songs, verkörperten sie die bunte Energie der mexikanischen Popkultur der 90er.",
       "fun_fact_es": "Grupo pop mexicano que competía con OV7 y Magneto por los corazones de los fans adolescentes en México. Conocidos por sus movimientos de baile coreografiados y canciones pop pegajosas, encarnaron la energía colorida de la cultura pop mexicana de los 90.",
       "fun_fact_fr": "Groupe pop mexicain qui rivalisait avec OV7 et Magneto pour conquérir le coeur des fans adolescents au Mexique. Connus pour leurs chorégraphies millimétrées et leurs chansons pop accrocheuses, ils incarnaient l'énergie colorée de la culture pop mexicaine des années 1990.",
-      "uri_apple_music": "applemusic://track/470304028",
+      "uri_apple_music": "applemusic://track/1378513246",
       "uri_youtube_music": "https://music.youtube.com/watch?v=aHa3SQNMnko",
       "uri_tidal": "tidal://track/8126116",
       "uri_deezer": "deezer://track/14135964"


### PR DESCRIPTION
## What

Replaces 7 dead Apple Music track IDs in `fiesta-latina-90s.json` with working ones from the iTunes catalog.

## Tracks Fixed

| Artist | Title | Old ID | New ID |
|--------|-------|--------|--------|
| Corona | The Rhythm of the Night | 1821144998 | 880365276 |
| Azul Azul | La Bomba | 457516731 | 574008989 |
| Elvis Crespo | Tu Sonrisa | 299704164 | 187429849 |
| Backstreet Boys | Everybody (Backstreet's Back) | 456229762 | 308611114 |
| OV7 | Enloquéceme | 1774586280 | 322278438 |
| Fey | Media Naranja | 474401741 | 286244925 |
| Mercurio | Explota Corazón | 470304028 | 1378513246 |

All new IDs verified via iTunes Search API.

Closes #353