### PR TITLE
data: fix 4 broken/wrong URIs in eurovision-winners (#346)

### DIFF
--- a/custom_components/beatify/playlists/eurovision-winners.json
+++ b/custom_components/beatify/playlists/eurovision-winners.json
@@ -1,6 +1,6 @@
 {
   "name": "Eurovision Winners (1956-2025)",
-  "version": "1.5",
+  "version": "1.6",
   "tags": [
     "eurovision",
     "contest",
@@ -74,7 +74,7 @@
       "fun_fact_de": "Net Als Toen (Genau wie damals) bescherte den Niederlanden ihren ersten Eurovision-Sieg. Corry Brokken hatte bereits 1956 teilgenommen und den siebten Platz belegt. Sie gehort zu den wenigen Kunstlern, die nach einer fruheren Eurovision-Teilnahme gewonnen haben.",
       "fun_fact_es": "Net Als Toen (Igual que entonces) dio a los Paises Bajos su primera victoria en Eurovision. Corry Brokken habia competido previamente en 1956, quedando en septimo lugar. Sigue siendo una de las pocas artistas en ganar tras una participacion anterior en Eurovision.",
       "fun_fact_fr": "Net Als Toen (Comme autrefois) a offert aux Pays-Bas leur toute premiere victoire a l'Eurovision. Corry Brokken avait deja participe en 1956, terminant septieme. Elle reste l'une des rares artistes a avoir gagne apres une precedente participation au concours.",
-      "uri_apple_music": "applemusic://track/986305357",
+      "uri_apple_music": "applemusic://track/1681860781",
       "uri_youtube_music": "https://music.youtube.com/watch?v=2EMHvyUPi9o",
       "uri_deezer": "deezer://track/1240513242"
     },
@@ -909,7 +909,7 @@
     },
     {
       "year": 1978,
-      "uri": "spotify:track:557ZG0nAvOppPxR3e1DP42",
+      "uri": "spotify:track:4nErrjZlKRYk9n6XaVnaf3",
       "artist": "Izhar Cohen",
       "alt_artists": [
         "Gali Atari",
@@ -1337,7 +1337,7 @@
       "fun_fact_de": "Rock Me war Jugoslawiens einziger Eurovision-Sieg, bevor das Land zerbrach. Die kroatische Band Riva trat mit ansteckender Energie auf. Tragischerweise bedeutete der Zerfall Jugoslawiens, dass kein vereintes Land diesen historischen Sieg lange feiern konnte.",
       "fun_fact_es": "Rock Me fue la unica victoria de Yugoslavia en Eurovision antes de que el pais se disolviera. La banda croata Riva actuo con energia contagiosa. Tragicamente, la disolucion de Yugoslavia significo que ningun pais unificado pudo celebrar esta victoria historica por mucho tiempo.",
       "fun_fact_fr": "Rock Me a ete l'unique victoire de la Yougoslavie a l'Eurovision avant la dissolution du pays. Le groupe croate Riva a livre une prestation d'une energie contagieuse. Tragiquement, l'eclatement de la Yougoslavie a fait qu'aucun pays unifie n'a pu celebrer longtemps cette victoire historique.",
-      "uri_apple_music": "applemusic://track/504583865",
+      "uri_apple_music": "applemusic://track/1770583863",
       "uri_youtube_music": "https://music.youtube.com/watch?v=7dMX56Ny_xs",
       "uri_tidal": "tidal://track/111867668",
       "uri_deezer": "deezer://track/2994566921"
@@ -1445,7 +1445,7 @@
       "fun_fact_es": "Why Me? fue escrita por Johnny Logan, dandole su tercera victoria en Eurovision (esta vez como compositor). Linda Martin habia competido previamente en 1984. Esto inicio la racha sin precedentes de Irlanda de cuatro victorias consecutivas.",
       "fun_fact_fr": "Why Me? a ete ecrite par Johnny Logan, lui offrant sa troisieme victoire a l'Eurovision (cette fois comme auteur-compositeur). Linda Martin avait deja participe en 1984. Cette victoire a marque le debut de la serie sans precedent de quatre victoires consecutives de l'Irlande.",
       "uri_youtube_music": "https://music.youtube.com/watch?v=fxh6iPwmUng",
-      "uri_apple_music": "applemusic://track/363155322",
+      "uri_apple_music": "applemusic://track/1111959191",
       "uri_tidal": "tidal://track/3382154",
       "uri_deezer": "deezer://track/13232715"
     },


### PR DESCRIPTION
Closes #346. Replaced 4 dead/wrong URIs and bumped playlist version to 1.6.

## Changes
| Artist | Title | Provider | Old ID | New ID |
|--------|-------|----------|--------|--------|
| Corry Brokken | Net Als Toen | Apple Music | 986305357 | 1681860781 |
| Riva | Rock Me | Apple Music | 504583865 | 1770583863 |
| Linda Martin | Why Me? | Apple Music | 363155322 | 1111959191 |
| Izhar Cohen | A-Ba-Ni-Bi | Spotify | 557ZG0nAvOppPxR3e1DP42 | 4nErrjZlKRYk9n6XaVnaf3 |