### PR TITLE
fix: Alle Tipps cards horizontal row with overflow scroll (#355)

### DIFF
--- a/custom_components/beatify/www/css/styles.css
+++ b/custom_components/beatify/www/css/styles.css
@@ -6924,18 +6924,20 @@ body.theme-dark .result-value.is-bet-lost {
     text-align: center;
 }
 
-/* Vertical stack — each card full-width (#211, #301) */
+/* Horizontal row with overflow scroll (#355) */
 .results-cards-scroll {
     display: flex;
-    flex-direction: column;
+    flex-direction: row;
     gap: var(--space-sm);
     width: 100%;
-    overflow-y: auto;
-    max-height: 60vh;
+    overflow-x: auto;
+    overflow-y: hidden;
+    padding-bottom: var(--space-xs);
+    -webkit-overflow-scrolling: touch;
 }
 
 .results-cards-scroll::-webkit-scrollbar {
-    width: 3px;
+    height: 3px;
 }
 
 .results-cards-scroll::-webkit-scrollbar-thumb {
@@ -6950,9 +6952,9 @@ body.theme-dark .result-value.is-bet-lost {
     text-align: center;
     border: 2px solid var(--color-border-light);
     transition: all var(--transition-fast);
-    width: 100%;
+    flex: 0 0 140px;
+    min-width: 140px;
     box-sizing: border-box;
-    flex-shrink: 0;
 }
 
 .result-card.is-current {


### PR DESCRIPTION
Closes #355.

## Change
`.results-cards-scroll`: `flex-direction: row`, `overflow-x: auto`
`.result-card`: `flex: 0 0 140px` (fixed width, no longer 100%)

## Why #302 used column
PR #302 switched to vertical because the original row layout had `flex: 0 0 100%` — every card took full width, so only card 1 was visible. The fix was to change the card width, not the direction.

All 129 tests pass ✅