### PR TITLE
fix: use consistent rank sorting in highlight detection (#363)

### DIFF
--- a/custom_components/beatify/game/state.py
+++ b/custom_components/beatify/game/state.py
@@ -1861,7 +1861,7 @@ class GameState:
             if player.previous_rank is not None:
                 # Calculate current rank
                 sorted_players = sorted(
-                    self.players.values(), key=lambda p: p.score, reverse=True
+                    self.players.values(), key=lambda p: (-p.score, p.name)
                 )
                 current_rank = next(
                     (


### PR DESCRIPTION
Closes #363. Changes comeback detection sorting from `key=lambda p: p.score, reverse=True` to `key=lambda p: (-p.score, p.name)` to match `get_leaderboard()` tie-breaking logic.