### PR TITLE
fix: reset joined_late flag on new game/rematch (#361)

### DIFF
--- a/custom_components/beatify/game/player.py
+++ b/custom_components/beatify/game/player.py
@@ -140,6 +140,9 @@ class PlayerSession:
 
     def reset_for_new_game(self) -> None:
         """Reset all game-level stats for a new game (Story 15.2)."""
+        # Reset join state
+        self.joined_late = False
+
         # Reset score and streaks
         self.score = 0
         self.streak = 0


### PR DESCRIPTION
Closes #361. Adds `self.joined_late = False` to `reset_for_new_game()` so the flag doesn't carry over into rematches.