### PR TITLE
fix: use shared MIN_SUBMISSIONS_FOR_SPEED constant in player.py (#364)

### DIFF
--- a/custom_components/beatify/game/player.py
+++ b/custom_components/beatify/game/player.py
@@ -7,6 +7,8 @@ import uuid
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
+from custom_components.beatify.const import MIN_SUBMISSIONS_FOR_SPEED
+
 if TYPE_CHECKING:
     from aiohttp import web
 
@@ -175,7 +177,7 @@ class PlayerSession:
     @property
     def avg_submission_time(self) -> float | None:
         """Average submission time in seconds (Story 15.2)."""
-        if len(self.submission_times) < 3:
+        if len(self.submission_times) < MIN_SUBMISSIONS_FOR_SPEED:
             return None
         return sum(self.submission_times) / len(self.submission_times)
 


### PR DESCRIPTION
Replaces hardcoded `3` in `avg_submission_time` property with the shared `MIN_SUBMISSIONS_FOR_SPEED` constant from `const.py`, matching what `scoring.py` uses.

Prevents a scenario where a player qualifies for Speed Demon in scoring but has `avg_submission_time` return `None`, or vice versa.

Closes #364