### PR TITLE
fix: prevent duplicate movie option in challenge builder (#362)

### DIFF
--- a/custom_components/beatify/game/challenges.py
+++ b/custom_components/beatify/game/challenges.py
@@ -151,7 +151,7 @@ def build_movie_options(song: dict[str, Any]) -> list[str] | None:
 
     # Ensure correct movie is in the list
     if movie not in valid_choices:
-        valid_choices = [movie] + valid_choices[:2]
+        valid_choices = [movie] + [c for c in valid_choices[:2] if c != movie]
 
     # Shuffle and return
     options = list(valid_choices)


### PR DESCRIPTION
Filters duplicates in `build_movie_options()` when the correct movie is prepended to `valid_choices[:2]`. Previously, if the correct movie was already in that slice, players would see it twice.

Fix: `valid_choices = [movie] + [c for c in valid_choices[:2] if c != movie]`

Closes #362