### PR TITLE
fix: log analytics save errors instead of silently dropping them (#365)

### DIFF
--- a/custom_components/beatify/analytics.py
+++ b/custom_components/beatify/analytics.py
@@ -166,7 +166,13 @@ class AnalyticsStorage:
 
         Uses fire-and-forget pattern to avoid blocking game operations.
         """
-        asyncio.create_task(self._save())
+        task = asyncio.create_task(self._save())
+        task.add_done_callback(self._handle_save_error)
+
+    def _handle_save_error(self, task: asyncio.Task) -> None:
+        """Log exceptions from fire-and-forget save tasks."""
+        if (exc := task.exception()) is not None:
+            _LOGGER.error("Unhandled error in analytics save task: %s", exc)
 
     async def add_game(self, record: GameRecord) -> None:
         """


### PR DESCRIPTION
Adds a `_handle_save_error` done callback to the fire-and-forget `asyncio.create_task()` in `schedule_save()`. Exceptions from `_save()` are now logged via `_LOGGER.error()` instead of being silently swallowed.

**Severity:** high — disk full, permission errors, or serialization failures would cause silent data loss with no indication in logs.

Closes #365