### PR TITLE
refactor: extract shared state serialization from views and websocket (#352)

### DIFF
--- a/custom_components/beatify/server/serializers.py
+++ b/custom_components/beatify/server/serializers.py
@@ -1,0 +1,102 @@
+"""Shared state serialization helpers for views and WebSocket handler.
+
+Both the HTTP views and the WebSocket handler need to build JSON-serializable
+dicts from game state.  This module centralises that logic so changes only
+need to be made in one place (#352).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from custom_components.beatify.const import (
+    DOMAIN,
+    MEDIA_PLAYER_DOCS_URL,
+    PLAYLIST_DOCS_URL,
+)
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+
+    from custom_components.beatify.game.state import GameState
+
+
+def get_game_state(hass: HomeAssistant) -> GameState | None:
+    """Look up the active GameState from hass.data.
+
+    Returns None when no game has been created yet.
+    """
+    return hass.data.get(DOMAIN, {}).get("game")
+
+
+def build_state_message(game_state: GameState) -> dict[str, Any] | None:
+    """Build the WebSocket ``state`` message dict.
+
+    Returns ``{"type": "state", ...}`` ready to broadcast, or *None* when the
+    game has not been initialised.
+    """
+    state = game_state.get_state()
+    if state is None:
+        return None
+    return {"type": "state", **state}
+
+
+def build_status_response(
+    hass: HomeAssistant,
+    *,
+    version: str,
+    media_players: list[dict[str, Any]],
+    playlists: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Build the admin ``/api/status`` JSON payload.
+
+    Centralises the status dict so the admin view and any future consumer
+    assemble the same shape.
+    """
+    data = hass.data.get(DOMAIN, {})
+    game_state: GameState | None = data.get("game")
+
+    active_game = None
+    if game_state and game_state.game_id:
+        active_game = game_state.get_state()
+
+    has_music_assistant = any(
+        entry.domain == "music_assistant"
+        for entry in hass.config_entries.async_entries()
+    )
+
+    return {
+        "version": version,
+        "media_players": media_players,
+        "playlists": playlists,
+        "playlist_dir": data.get("playlist_dir", ""),
+        "playlist_docs_url": PLAYLIST_DOCS_URL,
+        "media_player_docs_url": MEDIA_PLAYER_DOCS_URL,
+        "active_game": active_game,
+        "has_music_assistant": has_music_assistant,
+    }
+
+
+def build_game_status_response(
+    game_state: GameState | None,
+    game_id: str | None,
+) -> dict[str, Any]:
+    """Build the ``/api/game-status`` JSON payload.
+
+    Returns a dict with ``exists``, ``phase``, and ``can_join`` keys.
+    """
+    if not game_id or not game_state or game_state.game_id != game_id:
+        return {
+            "exists": False,
+            "phase": None,
+            "can_join": False,
+        }
+
+    phase = game_state.phase.value
+    can_join = phase in ("LOBBY", "PLAYING", "REVEAL")
+
+    return {
+        "exists": True,
+        "phase": phase,
+        "can_join": can_join,
+    }

--- a/custom_components/beatify/server/views.py
+++ b/custom_components/beatify/server/views.py
@@ -16,8 +16,6 @@ from custom_components.beatify.const import (
     DIFFICULTY_HARD,
     DIFFICULTY_NORMAL,
     DOMAIN,
-    MEDIA_PLAYER_DOCS_URL,
-    PLAYLIST_DOCS_URL,
     PROVIDER_DEFAULT,
     PROVIDER_DEEZER,
     PROVIDER_SPOTIFY,
@@ -28,6 +26,12 @@ from custom_components.beatify.const import (
 )
 from custom_components.beatify.game.playlist import async_discover_playlists
 from custom_components.beatify.game.state import GameState
+from custom_components.beatify.server.serializers import (
+    build_game_status_response,
+    build_state_message,
+    build_status_response,
+    get_game_state,
+)
 from custom_components.beatify.services.media_player import (
     async_get_media_players,
     get_platform_capabilities,
@@ -114,37 +118,19 @@ class StatusView(HomeAssistantView):
 
     async def get(self, request: web.Request) -> web.Response:  # noqa: ARG002
         """Return current status as JSON."""
-        data = self.hass.data.get(DOMAIN, {})
-
-        # Check for active game
-        game_state = data.get("game")
-        active_game = None
-        if game_state and game_state.game_id:
-            active_game = game_state.get_state()
-
         # Fetch media players fresh (not cached) - Story 8-2
         media_players = await async_get_media_players(self.hass)
 
         # Fetch playlists fresh (not cached) - Issue #135
         playlists = await async_discover_playlists(self.hass)
-        data["playlists"] = playlists
+        self.hass.data.get(DOMAIN, {})["playlists"] = playlists
 
-        # Detect Music Assistant integration (not based on entity names)
-        # Check if music_assistant integration is loaded via config entries
-        has_music_assistant = any(
-            entry.domain == "music_assistant" for entry in self.hass.config_entries.async_entries()
+        status = build_status_response(
+            self.hass,
+            version=_get_version(),
+            media_players=media_players,
+            playlists=playlists,
         )
-
-        status = {
-            "version": _get_version(),
-            "media_players": media_players,
-            "playlists": playlists,
-            "playlist_dir": data.get("playlist_dir", ""),
-            "playlist_docs_url": PLAYLIST_DOCS_URL,
-            "media_player_docs_url": MEDIA_PLAYER_DOCS_URL,
-            "active_game": active_game,
-            "has_music_assistant": has_music_assistant,
-        }
 
         return web.json_response(status)
 
@@ -400,9 +386,9 @@ class StartGameView(HomeAssistantView):
         # Broadcast to WebSocket clients
         ws_handler = data.get("ws_handler")
         if ws_handler:
-            state = game_state.get_state()
-            if state:
-                await ws_handler.broadcast({"type": "state", **state})
+            state_msg = build_state_message(game_state)
+            if state_msg:
+                await ws_handler.broadcast(state_msg)
 
         return web.json_response(result)
 
@@ -583,50 +569,10 @@ class GameStatusView(HomeAssistantView):
     async def get(self, request: web.Request) -> web.Response:
         """Get game status."""
         game_id = request.query.get("game")
-
-        # No game ID provided
-        if not game_id:
-            return web.json_response(
-                {
-                    "exists": False,
-                    "phase": None,
-                    "can_join": False,
-                }
-            )
-
-        # Get game state with safe access
-        game_state = self.hass.data.get(DOMAIN, {}).get("game")
-
-        # No game state or different game ID
-        if not game_state:
-            return web.json_response(
-                {
-                    "exists": False,
-                    "phase": None,
-                    "can_join": False,
-                }
-            )
-
-        if game_state.game_id != game_id:
-            return web.json_response(
-                {
-                    "exists": False,
-                    "phase": None,
-                    "can_join": False,
-                }
-            )
-
-        # Game exists - return status
-        phase = game_state.phase.value
-        # Late join supported during LOBBY, PLAYING, and REVEAL (Story 16.5)
-        can_join = phase in ("LOBBY", "PLAYING", "REVEAL")
+        game_state = get_game_state(self.hass)
 
         return web.json_response(
-            {
-                "exists": True,
-                "phase": phase,
-                "can_join": can_join,
-            }
+            build_game_status_response(game_state, game_id)
         )
 
 

--- a/custom_components/beatify/server/websocket.py
+++ b/custom_components/beatify/server/websocket.py
@@ -35,6 +35,7 @@ from custom_components.beatify.const import (
     YEAR_MIN,
 )
 from custom_components.beatify.game.state import GamePhase, GameState
+from custom_components.beatify.server.serializers import build_state_message, get_game_state
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
@@ -144,7 +145,7 @@ class BeatifyWebSocketHandler:
 
         """
         msg_type = data.get("type")
-        game_state = self.hass.data.get(DOMAIN, {}).get("game")
+        game_state = get_game_state(self.hass)
 
         if not game_state or not game_state.game_id:
             await ws.send_json(
@@ -232,7 +233,9 @@ class BeatifyWebSocketHandler:
                     )
 
                 # Send full state to newly joined player
-                state_msg = {"type": "state", **game_state.get_state()}
+                state_msg = build_state_message(game_state)
+                if not state_msg:
+                    return
                 try:
                     await ws.send_json(state_msg)
                 except Exception as err:  # noqa: BLE001
@@ -591,9 +594,9 @@ class BeatifyWebSocketHandler:
 
         elif msg_type == "get_state":
             # Dashboard/observer requesting current state (Story 10.4)
-            state = game_state.get_state()
-            if state:
-                await ws.send_json({"type": "state", **state})
+            state_msg = build_state_message(game_state)
+            if state_msg:
+                await ws.send_json(state_msg)
 
         elif msg_type == "get_steal_targets":
             # Request available steal targets (Story 15.3 AC2, AC5)
@@ -841,8 +844,9 @@ class BeatifyWebSocketHandler:
         )
 
         # Send current state to reconnected player
-        state_msg = {"type": "state", **game_state.get_state()}
-        await ws.send_json(state_msg)
+        state_msg = build_state_message(game_state)
+        if state_msg:
+            await ws.send_json(state_msg)
 
         # Broadcast updated state to all players (connected status changed)
         await self.broadcast_state()
@@ -1281,19 +1285,18 @@ class BeatifyWebSocketHandler:
 
     async def broadcast_state(self) -> None:
         """Broadcast current game state to all connected players."""
-        game_state = self.hass.data.get(DOMAIN, {}).get("game")
+        game_state = get_game_state(self.hass)
         if not game_state:
             _LOGGER.warning("broadcast_state: No game state found in hass.data")
             return
 
-        state = game_state.get_state()
-        if state:
+        state_msg = build_state_message(game_state)
+        if state_msg:
             _LOGGER.debug(
                 "broadcast_state: phase=%s, connections=%d",
-                state.get("phase"),
+                state_msg.get("phase"),
                 len(self.connections),
             )
-            state_msg = {"type": "state", **state}
             await self.broadcast(state_msg)
         else:
             _LOGGER.debug(
@@ -1326,7 +1329,7 @@ class BeatifyWebSocketHandler:
             ws: Disconnected WebSocket
 
         """
-        game_state = self.hass.data.get(DOMAIN, {}).get("game")
+        game_state = get_game_state(self.hass)
         if not game_state:
             return
 


### PR DESCRIPTION
## What

Extracts duplicated state serialization logic from `views.py` and `websocket.py` into a new `server/serializers.py` module.

## New shared helpers

- `get_game_state(hass)` — centralizes game state lookup (was duplicated ~8 times)
- `build_state_message(game_state)` — builds WebSocket state messages (5 call sites)
- `build_status_response(hass, ...)` — admin status JSON payload
- `build_game_status_response(game_state, game_id)` — game status response (3 repeated dict literals)

## Tests

All 264 tests pass. No functional changes — pure refactor.

Closes #352