### PR TITLE
refactor: decouple websocket from GameState internals (#348, #321)

### DIFF
--- a/custom_components/beatify/game/state.py
+++ b/custom_components/beatify/game/state.py
@@ -1872,6 +1872,43 @@ class GameState:
 
         return leaderboard
 
+    def advance_to_end(self) -> None:
+        """Transition to END phase with proper cleanup (#321).
+
+        Use this instead of setting ``phase = GamePhase.END`` directly.
+        Cancels timers so no stale callbacks fire after the game ends.
+        Does NOT clear players (they stay for rematch/end screen).
+        """
+        self.cancel_timer()
+        self._cancel_intro_timer()
+        self.phase = GamePhase.END
+        _LOGGER.info("Game advanced to END phase")
+
+    async def stop_media(self) -> None:
+        """Stop media playback if a media player service is available (#321)."""
+        if self._media_player_service:
+            await self._media_player_service.stop()
+
+    async def set_volume_on_player(self, level: float) -> bool:
+        """Apply volume level to the media player (#321).
+
+        Returns:
+            True if successful, False if failed or no media player.
+        """
+        if self._media_player_service:
+            return await self._media_player_service.set_volume(level)
+        return False
+
+    async def play_deferred_song(self, song: dict) -> bool:
+        """Play a song that was deferred for intro splash (#321).
+
+        Returns:
+            True if playback started, False otherwise.
+        """
+        if self._media_player_service:
+            return await self._media_player_service.play_song(song)
+        return False
+
     def adjust_volume(self, direction: str) -> float:
         """
         Adjust volume level by step (Story 6.4).

--- a/custom_components/beatify/server/websocket.py
+++ b/custom_components/beatify/server/websocket.py
@@ -346,7 +346,7 @@ class BeatifyWebSocketHandler:
                             _LOGGER.debug("Game stats recorded for natural end")
 
                         # No more rounds, end game
-                        game_state.phase = GamePhase.END
+                        game_state.advance_to_end()
                         await self.broadcast_state()
                     else:
                         # Start next round
@@ -366,7 +366,7 @@ class BeatifyWebSocketHandler:
                                 )
 
                             # No more songs
-                            game_state.phase = GamePhase.END
+                            game_state.advance_to_end()
                             await self.broadcast_state()
                 else:
                     await ws.send_json(
@@ -393,8 +393,7 @@ class BeatifyWebSocketHandler:
                     return
 
                 # Stop playback
-                if game_state._media_player_service:
-                    await game_state._media_player_service.stop()
+                await game_state.stop_media()
 
                 game_state.song_stopped = True
                 _LOGGER.info("Admin stopped song in round %d", game_state.round)
@@ -418,14 +417,11 @@ class BeatifyWebSocketHandler:
                 new_level = game_state.adjust_volume(direction)
 
                 # Apply to media player
-                if game_state._media_player_service:
-                    success = await game_state._media_player_service.set_volume(
-                        new_level
+                success = await game_state.set_volume_on_player(new_level)
+                if not success:
+                    _LOGGER.warning(
+                        "Failed to set volume to %.0f%%", new_level * 100
                     )
-                    if not success:
-                        _LOGGER.warning(
-                            "Failed to set volume to %.0f%%", new_level * 100
-                        )
 
                 _LOGGER.info("Volume adjusted %s to %.0f%%", direction, new_level * 100)
 
@@ -449,12 +445,8 @@ class BeatifyWebSocketHandler:
                     )
                     return
 
-                # Cancel timer if running
-                game_state.cancel_timer()
-
                 # Stop media playback
-                if game_state._media_player_service:
-                    await game_state._media_player_service.stop()
+                await game_state.stop_media()
 
                 # Record game stats BEFORE transitioning to END (Story 14.4, 19.1)
                 stats_service = self.hass.data.get(DOMAIN, {}).get("stats")
@@ -466,7 +458,7 @@ class BeatifyWebSocketHandler:
                     _LOGGER.debug("Game stats recorded for early end")
 
                 # Transition to END - players stay connected for rematch option
-                game_state.phase = GamePhase.END
+                game_state.advance_to_end()
                 _LOGGER.info(
                     "Admin ended game early at round %d - players preserved for rematch",
                     game_state.round,
@@ -554,10 +546,8 @@ class BeatifyWebSocketHandler:
 
                 # Play the deferred song now that admin has confirmed
                 deferred_song = game_state._intro_splash_deferred_song
-                if deferred_song and game_state._media_player_service:
-                    success = await game_state._media_player_service.play_song(
-                        deferred_song
-                    )
+                if deferred_song:
+                    success = await game_state.play_deferred_song(deferred_song)
                     if not success:
                         _LOGGER.warning(
                             "Failed to play deferred intro song: %s",


### PR DESCRIPTION
## What

Removes all direct `game_state.phase = GamePhase.END` mutations and `game_state._media_player_service` private access from `websocket.py`.

## New public API on GameState

- `advance_to_end()` — transitions to END with timer cleanup (replaces 3x direct `phase = END`)
- `stop_media()` — stops playback (replaces 3x `_media_player_service.stop()`)
- `set_volume_on_player(level)` — applies volume (replaces 1x `_media_player_service.set_volume()`)
- `play_deferred_song(song)` — plays intro splash deferred song (replaces 1x `_media_player_service.play_song()`)

## Before → After

| Pattern | Before | After |
|---------|--------|-------|
| End game | `game_state.phase = GamePhase.END` | `game_state.advance_to_end()` |
| Stop music | `game_state._media_player_service.stop()` | `game_state.stop_media()` |
| Set volume | `game_state._media_player_service.set_volume()` | `game_state.set_volume_on_player()` |
| Play deferred | `game_state._media_player_service.play_song()` | `game_state.play_deferred_song()` |

**Zero private attribute access** remains in websocket.py (except `_intro_splash_*` fields which are next).

## Tests
264 passed, 2 skipped.

Closes #348, closes #321