### PR TITLE
fix: sync _VERSION in views.py with manifest.json 2.8.0 (#376)

### DIFF
--- a/custom_components/beatify/server/views.py
+++ b/custom_components/beatify/server/views.py
@@ -46,7 +46,7 @@ _LOGGER = logging.getLogger(__name__)
 # We avoid reading manifest.json at runtime because HA imports custom components
 # inside the event loop, and any file I/O (even at module level) triggers
 # blocking call warnings in HA 2026.2+.
-_VERSION = "2.7.0"
+_VERSION = "2.8.0"
 
 
 def _get_version() -> str:


### PR DESCRIPTION
One-liner: `_VERSION` in `views.py` was stuck at 2.7.0, should be 2.8.0 to match `manifest.json`.

Closes #376