### PR TITLE
fix: escape HTML in party-lights entity names to prevent XSS (#385)

### DIFF
--- a/custom_components/beatify/www/js/party-lights.js
+++ b/custom_components/beatify/www/js/party-lights.js
@@ -4,6 +4,12 @@
 (function() {
     'use strict';
 
+    function escapeHtml(text) {
+        var div = document.createElement('div');
+        div.textContent = text;
+        return div.innerHTML;
+    }
+
     var STORAGE_KEY = 'beatify_party_lights';
     var selectedLights = [];
     var selectedIntensity = 'medium';
@@ -61,9 +67,9 @@
             var cap = capLabels[light.capability] || 'On/Off';
             var icon = stateIcons[light.state] || '⚪';
             return '<label class="party-light-item">' +
-                '<input type="checkbox" value="' + light.entity_id + '" ' + checked + '>' +
+                '<input type="checkbox" value="' + escapeHtml(light.entity_id) + '" ' + checked + '>' +
                 '<span class="light-status">' + icon + '</span>' +
-                '<span class="light-name">' + (light.friendly_name || light.entity_id) + '</span>' +
+                '<span class="light-name">' + escapeHtml(light.friendly_name || light.entity_id) + '</span>' +
                 '<span class="light-cap-badge">' + cap + '</span>' +
                 '</label>';
         }).join('');


### PR DESCRIPTION
Escapes `friendly_name` and `entity_id` in party-lights.js before inserting into innerHTML. Prevents potential XSS if a light entity has malicious HTML in its name.

Closes #385