### PR TITLE
fix: use setdefault for playlist cache (#392)

### DIFF
--- a/custom_components/beatify/server/views.py
+++ b/custom_components/beatify/server/views.py
@@ -123,7 +123,7 @@ class StatusView(HomeAssistantView):
 
         # Fetch playlists fresh (not cached) - Issue #135
         playlists = await async_discover_playlists(self.hass)
-        self.hass.data.get(DOMAIN, {})["playlists"] = playlists
+        self.hass.data.setdefault(DOMAIN, {})["playlists"] = playlists
 
         status = build_status_response(
             self.hass,


### PR DESCRIPTION
Changes `.get(DOMAIN, {})` to `.setdefault(DOMAIN, {})` so playlist data is stored in `hass.data` even if the domain key is missing.

Closes #392