### PR TITLE
fix: update SW cache to v2.8.0 and auto-sync version in CI (#388)

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -60,12 +60,28 @@ jobs:
             custom_components/beatify/manifest.json > manifest.tmp \
             && mv manifest.tmp custom_components/beatify/manifest.json
 
+      - name: Update views.py _VERSION
+        if: steps.check.outputs.needed == 'true'
+        run: |
+          sed -i "s/^_VERSION = \".*\"/_VERSION = \"${{ steps.version.outputs.version }}\"/" \
+            custom_components/beatify/server/views.py
+
+      - name: Update service worker cache version
+        if: steps.check.outputs.needed == 'true'
+        run: |
+          sed -i "s/var CACHE_VERSION = 'beatify-v.*'/var CACHE_VERSION = 'beatify-v${{ steps.version.outputs.version }}'/" \
+            custom_components/beatify/www/sw.js
+
       - name: Verify manifest.json
         if: steps.check.outputs.needed == 'true'
         run: |
           echo "Updated manifest.json:"
           cat custom_components/beatify/manifest.json
           jq empty custom_components/beatify/manifest.json
+          echo "Updated _VERSION:"
+          grep "_VERSION" custom_components/beatify/server/views.py
+          echo "Updated CACHE_VERSION:"
+          grep "CACHE_VERSION" custom_components/beatify/www/sw.js
 
       - name: Commit and push
         if: steps.check.outputs.needed == 'true'
@@ -73,6 +89,8 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add custom_components/beatify/manifest.json
+          git add custom_components/beatify/server/views.py
+          git add custom_components/beatify/www/sw.js
           git commit -m "chore: bump version to ${{ steps.version.outputs.version }}"
           git push origin main
 

--- a/custom_components/beatify/www/sw.js
+++ b/custom_components/beatify/www/sw.js
@@ -6,7 +6,7 @@
  */
 'use strict';
 
-var CACHE_VERSION = 'beatify-v2.7.0';
+var CACHE_VERSION = 'beatify-v2.8.0';
 var MAX_CACHE_ITEMS = 50;
 
 // Critical assets to precache on install (minified versions only - fallback handled by HTML)


### PR DESCRIPTION
## What

1. Updates `CACHE_VERSION` in `sw.js` from `beatify-v2.7.0` → `beatify-v2.8.0` (invalidates stale cached assets)
2. Adds `sw.js` and `views.py _VERSION` to the `version-bump.yml` workflow so they auto-update on future releases

## Why

Users who visited during v2.7.0 had stale CSS/JS cached. The service worker never invalidated because the version string wasn't bumped. Now all three version strings (manifest.json, views.py, sw.js) stay in sync automatically.

Closes #388