### PR TITLE
fix: add admin token auth for REST endpoints (#386)

### DIFF
--- a/custom_components/beatify/game/state.py
+++ b/custom_components/beatify/game/state.py
@@ -77,6 +77,7 @@ class GameState:
         """
         self._now = time_fn or time.time
         self.game_id: str | None = None
+        self.admin_token: str | None = None  # Issue #386: REST admin auth
         self.phase: GamePhase = GamePhase.LOBBY
         self.playlists: list[str] = []
         self.songs: list[dict[str, Any]] = []
@@ -331,6 +332,7 @@ class GameState:
         self.clear_all_sessions()
 
         self.game_id = secrets.token_urlsafe(8)
+        self.admin_token = secrets.token_urlsafe(16)  # Issue #386: REST admin auth
         self.phase = GamePhase.LOBBY
         self.playlists = playlists
         self.songs = songs
@@ -740,8 +742,9 @@ class GameState:
         # Reset each player's game stats but keep them connected
         for player in self.players.values():
             player.reset_for_new_game()
-        # Generate new game ID for the rematch
+        # Generate new game ID and admin token for the rematch
         self.game_id = secrets.token_urlsafe(8)
+        self.admin_token = secrets.token_urlsafe(16)  # Issue #386
 
         # Regenerate join_url with new game_id
         if preserved_join_url:

--- a/custom_components/beatify/server/views.py
+++ b/custom_components/beatify/server/views.py
@@ -59,6 +59,24 @@ def _read_file(path: Path) -> str:
     return path.read_text(encoding="utf-8")
 
 
+def _verify_admin_token(request: web.Request, game_state: Any) -> bool:
+    """Verify admin token from Authorization header or query param (#386).
+
+    Accepts:
+    - Header: Authorization: Bearer <token>
+    - Query: ?admin_token=<token>
+    """
+    if not game_state or not game_state.admin_token:
+        return False
+    token = None
+    auth = request.headers.get("Authorization", "")
+    if auth.startswith("Bearer "):
+        token = auth[7:]
+    if not token:
+        token = request.query.get("admin_token")
+    return token == game_state.admin_token
+
+
 class AdminView(HomeAssistantView):
     """Serve the admin page."""
 
@@ -414,6 +432,7 @@ class StartGameView(HomeAssistantView):
 
         result = game_state.create_game(**create_kwargs)
         result["warnings"] = warnings
+        result["admin_token"] = game_state.admin_token  # Issue #386: for REST admin auth
 
         # Record game start time for analytics (Story 19.1)
         stats_service = data.get("stats")
@@ -460,7 +479,7 @@ class EndGameView(HomeAssistantView):
         """Initialize view."""
         self.hass = hass
 
-    async def post(self, request: web.Request) -> web.Response:  # noqa: ARG002
+    async def post(self, request: web.Request) -> web.Response:
         """End the current game."""
         data = self.hass.data.get(DOMAIN, {})
         game_state = data.get("game")
@@ -469,6 +488,12 @@ class EndGameView(HomeAssistantView):
             return web.json_response(
                 {"error": "GAME_NOT_STARTED", "message": "No active game"},
                 status=404,
+            )
+
+        if not _verify_admin_token(request, game_state):
+            return web.json_response(
+                {"error": "UNAUTHORIZED", "message": "Admin token required"},
+                status=403,
             )
 
         game_state.end_game()
@@ -493,7 +518,7 @@ class RematchGameView(HomeAssistantView):
         """Initialize view."""
         self.hass = hass
 
-    async def post(self, request: web.Request) -> web.Response:  # noqa: ARG002
+    async def post(self, request: web.Request) -> web.Response:
         """Start a rematch with current players."""
         from custom_components.beatify.game.state import GamePhase  # noqa: PLC0415
 
@@ -504,6 +529,12 @@ class RematchGameView(HomeAssistantView):
             return web.json_response(
                 {"error": "GAME_NOT_FOUND", "message": "No active game"},
                 status=404,
+            )
+
+        if not _verify_admin_token(request, game_state):
+            return web.json_response(
+                {"error": "UNAUTHORIZED", "message": "Admin token required"},
+                status=403,
             )
 
         if game_state.phase != GamePhase.END:
@@ -541,7 +572,7 @@ class StartGameplayView(HomeAssistantView):
         """Initialize view."""
         self.hass = hass
 
-    async def post(self, request: web.Request) -> web.Response:  # noqa: ARG002
+    async def post(self, request: web.Request) -> web.Response:
         """Start gameplay from lobby."""
         from custom_components.beatify.game.state import GamePhase  # noqa: PLC0415
 
@@ -552,6 +583,12 @@ class StartGameplayView(HomeAssistantView):
             return web.json_response(
                 {"error": "GAME_NOT_STARTED", "message": "No active game"},
                 status=404,
+            )
+
+        if not _verify_admin_token(request, game_state):
+            return web.json_response(
+                {"error": "UNAUTHORIZED", "message": "Admin token required"},
+                status=403,
             )
 
         if game_state.phase != GamePhase.LOBBY:
@@ -660,8 +697,16 @@ class StatsView(HomeAssistantView):
         """Initialize view."""
         self.hass = hass
 
-    async def get(self, request: web.Request) -> web.Response:  # noqa: ARG002
+    async def get(self, request: web.Request) -> web.Response:
         """Get game statistics summary and history."""
+        # Issue #386: Admin token required when game is active
+        game_state = self.hass.data.get(DOMAIN, {}).get("game")
+        if game_state and game_state.game_id and not _verify_admin_token(request, game_state):
+            return web.json_response(
+                {"error": "UNAUTHORIZED", "message": "Admin token required"},
+                status=403,
+            )
+
         stats_service = self.hass.data.get(DOMAIN, {}).get("stats")
 
         if not stats_service:

--- a/custom_components/beatify/www/js/admin.js
+++ b/custom_components/beatify/www/js/admin.js
@@ -3,6 +3,14 @@
  * Vanilla JS - no frameworks
  */
 
+// Issue #386: Admin token auth for REST endpoints
+function _adminHeaders() {
+    var token = sessionStorage.getItem('beatify_admin_token');
+    var headers = { 'Content-Type': 'application/json' };
+    if (token) headers['Authorization'] = 'Bearer ' + token;
+    return headers;
+}
+
 // Module-level state
 let selectedPlaylists = [];
 let playlistData = [];
@@ -1434,6 +1442,11 @@ async function startGame() {
             console.warn('Game started with warnings:', data.warnings);
         }
 
+        // Issue #386: Store admin token for REST auth
+        if (data.admin_token) {
+            sessionStorage.setItem('beatify_admin_token', data.admin_token);
+        }
+
         showLobbyView(data);
 
     } catch (err) {
@@ -1461,7 +1474,7 @@ async function startGameplay() {
     btn.innerHTML = '<span class="btn-icon" aria-hidden="true">⏳</span> ' + BeatifyI18n.t('game.starting');
 
     try {
-        const response = await fetch('/beatify/api/start-gameplay', { method: 'POST' });
+        const response = await fetch('/beatify/api/start-gameplay', { method: 'POST', headers: _adminHeaders() });
         const data = await response.json();
 
         if (!response.ok) {
@@ -1516,7 +1529,7 @@ async function confirmEndGame() {
     closeEndGameModal();
 
     try {
-        const response = await fetch('/beatify/api/end-game', { method: 'POST' });
+        const response = await fetch('/beatify/api/end-game', { method: 'POST', headers: _adminHeaders() });
         if (response.ok) {
             cachedQRUrl = null;  // Clear QR cache
             showSetupView();
@@ -1589,7 +1602,7 @@ async function confirmRematch() {
     closeRematchModal();
 
     try {
-        var response = await fetch('/beatify/api/rematch-game', { method: 'POST' });
+        var response = await fetch('/beatify/api/rematch-game', { method: 'POST', headers: _adminHeaders() });
         if (response.ok) {
             var data = await response.json();
             // Fix #228: If admin was already a player in the previous game,


### PR DESCRIPTION
## What

Adds lightweight admin token authentication to admin-only REST endpoints. Players can still join freely via QR code — only admin actions require the token.

## How it works

1. `create_game()` generates a `secrets.token_urlsafe(16)` admin token
2. Token returned in the start-game API response
3. Admin UI stores it in `sessionStorage`
4. Admin REST calls include `Authorization: Bearer <token>` header
5. `_verify_admin_token()` validates on protected endpoints

## Protected endpoints

| Endpoint | Method | Why |
|---|---|---|
| /beatify/api/end-game | POST | Ends game for all players |
| /beatify/api/rematch-game | POST | Resets game state |
| /beatify/api/start-gameplay | POST | Transitions lobby → playing |
| /beatify/api/stats | GET | Analytics data (when game active) |

## Not protected (intentionally)

- /beatify/api/status — needed for player UI
- /beatify/api/lights — light discovery for admin setup
- /beatify/play — player join page
- /beatify/api/start-game — creates the game (generates the token)

310 tests pass.

Closes #386