### PR TITLE
chore: bump version to 2.9.0

### DIFF
--- a/custom_components/beatify/manifest.json
+++ b/custom_components/beatify/manifest.json
@@ -11,5 +11,5 @@
   "documentation": "https://github.com/mholzi/beatify",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/mholzi/beatify/issues",
-  "version": "2.8.0"
+  "version": "2.9.0"
 }

--- a/custom_components/beatify/server/views.py
+++ b/custom_components/beatify/server/views.py
@@ -46,7 +46,7 @@ _LOGGER = logging.getLogger(__name__)
 # We avoid reading manifest.json at runtime because HA imports custom components
 # inside the event loop, and any file I/O (even at module level) triggers
 # blocking call warnings in HA 2026.2+.
-_VERSION = "2.8.0"
+_VERSION = "2.9.0"
 
 
 def _get_version() -> str:

--- a/custom_components/beatify/www/sw.js
+++ b/custom_components/beatify/www/sw.js
@@ -6,7 +6,7 @@
  */
 'use strict';
 
-var CACHE_VERSION = 'beatify-v2.8.0';
+var CACHE_VERSION = 'beatify-v2.9.0';
 var MAX_CACHE_ITEMS = 50;
 
 // Critical assets to precache on install (minified versions only - fallback handled by HTML)


### PR DESCRIPTION
Bumps version across all 3 locations:
- `manifest.json`: 2.8.0 → 2.9.0
- `views.py _VERSION`: 2.8.0 → 2.9.0
- `sw.js CACHE_VERSION`: beatify-v2.8.0 → beatify-v2.9.0