### PR TITLE
fix: resolve 5 high-severity bugs from code review

### DIFF
--- a/custom_components/beatify/game/player_registry.py
+++ b/custom_components/beatify/game/player_registry.py
@@ -125,8 +125,16 @@ class PlayerRegistry:
         return True, None
 
     def get_player(self, name: str) -> PlayerSession | None:
-        """Get player by name."""
-        return self.players.get(name)
+        """Get player by name (case-insensitive to match add_player reconnection)."""
+        player = self.players.get(name)
+        if player is not None:
+            return player
+        # Fallback: case-insensitive lookup (#413)
+        name_lower = name.lower()
+        for existing_name, existing_player in self.players.items():
+            if existing_name.lower() == name_lower:
+                return existing_player
+        return None
 
     def get_player_by_session_id(self, session_id: str) -> PlayerSession | None:
         """Get player by session ID."""

--- a/custom_components/beatify/game/state.py
+++ b/custom_components/beatify/game/state.py
@@ -828,6 +828,23 @@ class GameState:
                 )
                 _LOGGER.info("Timer restarted with %.1fs remaining", remaining_seconds)
 
+                # Issue #416: Restart intro stop timer if this was an intro round
+                if (
+                    self.is_intro_round
+                    and not self.intro_stopped
+                    and self._intro_round_start_time is not None
+                ):
+                    elapsed_intro = self._now() - self._intro_round_start_time
+                    remaining_intro = INTRO_DURATION_SECONDS - elapsed_intro
+                    if remaining_intro > 0:
+                        self._intro_stop_task = asyncio.create_task(
+                            self._intro_auto_stop(remaining_intro)
+                        )
+                        _LOGGER.info(
+                            "Intro stop timer restarted with %.1fs remaining",
+                            remaining_intro,
+                        )
+
                 # Resume media playback if it was stopped
                 if self._media_player_service and self.current_song:
                     await self._media_player_service.play()
@@ -1478,6 +1495,18 @@ class GameState:
 
         # Get correct year from current song
         correct_year = self.current_song.get("year") if self.current_song else None
+
+        # Issue #415: Warn if scoring without a correct year when players submitted
+        if correct_year is None:
+            submitted_count = sum(1 for p in self.players.values() if p.submitted)
+            if submitted_count > 0:
+                _LOGGER.warning(
+                    "Scoring round %d with no correct_year — %d submitted player(s) "
+                    "will receive 0 points (current_song=%s)",
+                    self.round,
+                    submitted_count,
+                    "missing" if self.current_song is None else "no year field",
+                )
 
         # Calculate scores for all players — delegates to ScoringService (#139)
         all_players = list(self.players.values())

--- a/custom_components/beatify/server/websocket.py
+++ b/custom_components/beatify/server/websocket.py
@@ -216,7 +216,15 @@ class BeatifyWebSocketHandler:
                                 }
                             )
                             return
-                        game_state.set_admin(name)
+                        # Issue #417: Only allow new admin claim during LOBBY
+                        if game_state.phase != GamePhase.LOBBY:
+                            _LOGGER.warning(
+                                "Rejected admin claim from %s during %s phase",
+                                name,
+                                game_state.phase.value,
+                            )
+                        else:
+                            game_state.set_admin(name)
                 else:
                     # Regular player - cancel pending removal on reconnect
                     self.cancel_pending_removal(name)

--- a/custom_components/beatify/services/media_player.py
+++ b/custom_components/beatify/services/media_player.py
@@ -288,13 +288,13 @@ class MediaPlayerService:
 
         current_state = self._hass.states.get(self._entity_id)
         _LOGGER.warning(
-            "MA playback not confirmed after %.1fs for %s (state: %s)",
+            "MA playback not confirmed after %.1fs for %s (state: %s). "
+            "Returning failure so the round can retry or skip. (#418)",
             PLAYBACK_TIMEOUT,
             uri,
             current_state.state if current_state else "unknown",
         )
-        # Return True anyway — MA might still be buffering, don't skip the song
-        return True
+        return False
 
     async def _play_via_sonos(self, song: dict[str, Any]) -> bool:
         """Play via Sonos (URI-based)."""

--- a/tests/unit/test_media_player.py
+++ b/tests/unit/test_media_player.py
@@ -174,7 +174,7 @@ class TestMANonBlockingPlayback:
             ):
                 result = await svc.play_song(_make_song(title="New Song"))
 
-        assert result is True  # returns True anyway (don't skip)
+        assert result is False  # #418: returns False on timeout so round can retry
         assert poll_count >= 4  # but waited until timeout
 
     @pytest.mark.asyncio
@@ -240,8 +240,8 @@ class TestMANonBlockingPlayback:
         assert poll_count >= 8  # waited for the full realistic flow
 
     @pytest.mark.asyncio
-    async def test_ma_returns_true_even_on_timeout(self):
-        """Should return True even if playback never confirmed (don't skip song)."""
+    async def test_ma_returns_false_on_timeout(self):
+        """Should return False if playback never confirmed (#418: allow retry/skip)."""
         hass = _make_hass("buffering", media_title="Old Song")
         svc = MediaPlayerService(hass, "media_player.test", platform="music_assistant")
 
@@ -254,7 +254,7 @@ class TestMANonBlockingPlayback:
             ):
                 result = await svc.play_song(_make_song(title="New Song"))
 
-        assert result is True
+        assert result is False
 
     @pytest.mark.asyncio
     async def test_ma_first_song_no_previous_title(self):


### PR DESCRIPTION
## Summary

Fixes all 5 high-severity bugs identified in the bugs code review ([MHO-3](/MHO/issues/MHO-3)):

- **#413** — `get_player()` now does case-insensitive lookup, matching `add_player()` reconnection behavior. Previously, reconnecting with different case (e.g., "alice" vs "Alice") silently failed to send `session_id`.
- **#415** — Added warning log when `current_song` is None at scoring time. Previously, all players silently received 0 points with no indication of the problem.
- **#416** — `resume_game()` now restarts the intro stop timer with remaining duration after admin reconnect. Previously, intro bonuses could be awarded indefinitely after the window should have closed.
- **#417** — Admin claim via `is_admin` flag is now restricted to LOBBY phase only. Previously, a player joining mid-game could escalate to admin when no admin was connected.
- **#418** — `_play_via_music_assistant()` now returns `False` on timeout instead of `True`. Previously, genuine MA failures were masked and rounds ran in silence.

## Test plan

- [x] All 321 tests pass (2 skipped, 1 pre-existing deselected)
- [ ] Manual test: reconnect with different case and verify session_id is received
- [ ] Manual test: try `is_admin: true` join during PLAYING phase and verify rejection
- [ ] Manual test: pause/resume during intro round and verify intro timer restarts


🤖 Generated with [Claude Code](https://claude.com/claude-code)