### PR TITLE
fix: resolve 7 medium-severity bugs from code review (#414, #419-#424)

### DIFF
--- a/custom_components/beatify/game/state.py
+++ b/custom_components/beatify/game/state.py
@@ -1318,6 +1318,10 @@ class GameState:
         # Story 20.1 / Issue #28: Initialize challenges for this round
         self._challenge_manager.init_round(song)
 
+        # Issue #424: Cancel old timers before creating new ones
+        self.cancel_timer()
+        self._cancel_intro_timer()
+
         # Schedule intro auto-stop timer for non-deferred intro rounds
         if self.is_intro_round and not will_defer_for_splash:
             self._intro_stop_task = asyncio.create_task(
@@ -1349,9 +1353,6 @@ class GameState:
 
         # Reset round analytics for new round (Story 13.3)
         self.round_analytics = None
-
-        # Cancel any existing timer
-        self.cancel_timer()
 
         # Calculate delay until deadline
         now_ms = int(self._now() * 1000)
@@ -1701,8 +1702,8 @@ class GameState:
                     fastest_player.name, fastest_time, self.round
                 )
 
-        # Photo finish (tied scores among top players)
-        scores = [p.score for p in self.players.values()]
+        # Photo finish (tied round scores among top players) — Issue #414
+        scores = [p.round_score for p in self.players.values()]
         if len(scores) >= 2:
             from collections import Counter
 
@@ -1710,7 +1711,9 @@ class GameState:
             for score, count in score_counts.items():
                 if count >= 2 and score > 0:
                     tied_names = [
-                        p.name for p in self.players.values() if p.score == score
+                        p.name
+                        for p in self.players.values()
+                        if p.round_score == score
                     ]
                     # Only record if it's among the top scores
                     top_score = max(scores)

--- a/custom_components/beatify/server/websocket.py
+++ b/custom_components/beatify/server/websocket.py
@@ -229,6 +229,19 @@ class BeatifyWebSocketHandler:
                     # Regular player - cancel pending removal on reconnect
                     self.cancel_pending_removal(name)
 
+                    # Issue #420: If this player matches disconnected admin by name,
+                    # cancel the admin disconnect task even without is_admin flag
+                    if game_state.disconnected_admin_name:
+                        if name.lower() == game_state.disconnected_admin_name.lower():
+                            if self._admin_disconnect_task:
+                                self._admin_disconnect_task.cancel()
+                                self._admin_disconnect_task = None
+                                _LOGGER.info(
+                                    "Admin reconnected without admin flag, "
+                                    "cancelled pause task: %s",
+                                    name,
+                                )
+
                 # Send join acknowledgment with session_id (Story 11.1)
                 # Only the joining player receives their session_id (security)
                 if player:
@@ -802,8 +815,8 @@ class BeatifyWebSocketHandler:
         bet = data.get("bet", False)
         player.bet = bool(bet)
 
-        # Record submission
-        submission_time = time.time()
+        # Record submission — Issue #419: use game_state._now() for clock consistency
+        submission_time = game_state._now()
         player.submit_guess(year, submission_time)
 
         # Send acknowledgment
@@ -1172,8 +1185,8 @@ class BeatifyWebSocketHandler:
             )
             return
 
-        # Submit guess
-        guess_time = time.time()
+        # Submit guess — Issue #419: use game_state._now() for clock consistency
+        guess_time = game_state._now()
         result = game_state.submit_artist_guess(player.name, artist, guess_time)
 
         # Story 20.9: Track that player has made an artist guess
@@ -1272,8 +1285,8 @@ class BeatifyWebSocketHandler:
             )
             return
 
-        # Submit guess with server-side timing
-        guess_time = time.time()
+        # Submit guess with server-side timing — Issue #419: use game_state._now()
+        guess_time = game_state._now()
         result = game_state.submit_movie_guess(player.name, movie, guess_time)
 
         # Issue #28: Track that player has made a movie guess
@@ -1354,13 +1367,9 @@ class BeatifyWebSocketHandler:
         N broadcasts when N players join within the debounce window.
 
         """
-        # Cancel any pending broadcast
+        # Cancel any pending broadcast — Issue #421: don't await cancelled task
         if self._broadcast_debounce_task and not self._broadcast_debounce_task.done():
             self._broadcast_debounce_task.cancel()
-            try:
-                await self._broadcast_debounce_task
-            except asyncio.CancelledError:
-                pass
 
         async def delayed_broadcast() -> None:
             await asyncio.sleep(self._broadcast_debounce_delay)

--- a/custom_components/beatify/services/media_player.py
+++ b/custom_components/beatify/services/media_player.py
@@ -389,8 +389,11 @@ class MediaPlayerService:
             Dict with artist, title, album_art keys
 
         """
-        # Extract track ID from URI (spotify:track:xxx -> xxx)
-        track_id = uri.split(":")[-1] if ":" in uri else uri
+        # Extract track ID from URI — Issue #422: platform-aware parsing
+        if uri.startswith("spotify:"):
+            track_id = uri.split(":")[-1]
+        else:
+            track_id = uri
 
         # Get initial state for comparison
         initial_state = self._hass.states.get(self._entity_id)


### PR DESCRIPTION
## Summary

- **#414**: Photo finish highlight used cumulative `score` instead of `round_score` — caused false photo finish triggers when players had same total score (common early game)
- **#419**: Submission timestamps used `time.time()` instead of `game_state._now()` — clock inconsistency with round start times, breaking time-based scoring in tests
- **#420**: Admin reconnect without `is_admin` flag left disconnect task running — game would pause unexpectedly after admin reconnected
- **#421**: `debounced_broadcast_state` awaited cancelled task — race window where no debounce task existed during concurrent calls
- **#422**: Non-Spotify URI `track_id` extraction used `split(":")[-1]` — produced garbage for HTTP/Apple Music URIs, forcing slow fallback
- **#423**: `last_round` flag ordering — verified already correct in current code (false positive from code review)
- **#424**: Intro stop task created before old timer cancelled in `start_round` — potential for two timer tasks to coexist

## Test plan

- [x] All 321 unit tests pass (2 skipped, 1 deselected: pre-existing #412 Python 3.10 compat)
- [ ] Manual test: verify photo finish only triggers on tied round scores, not cumulative
- [ ] Manual test: admin reconnect without admin flag cancels pause timer
- [ ] Manual test: non-Spotify playback metadata matching

🤖 Generated with [Claude Code](https://claude.com/claude-code)