### PR TITLE
chore: bump version to 2.9.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Turn any gathering into an unforgettable music trivia experience.
 Guests scan, songs play, everyone competes. It's that simple.
 
 [![Home Assistant](https://img.shields.io/badge/Home%20Assistant-2024.1+-41BDF5?style=for-the-badge&logo=homeassistant&logoColor=white)](https://www.home-assistant.io/)
-[![Version](https://img.shields.io/badge/Version-2.7.0-ff00ff?style=for-the-badge)](https://github.com/mholzi/beatify/releases)
+[![Version](https://img.shields.io/badge/Version-2.9.1-ff00ff?style=for-the-badge)](https://github.com/mholzi/beatify/releases)
 [![License](https://img.shields.io/badge/License-MIT-green?style=for-the-badge)](LICENSE)
 
 [**Get Started**](#setup-in-home-assistant) • [**Supported Speakers**](#supported-speakers) • [**See It In Action**](#the-experience)
@@ -271,21 +271,23 @@ Playlists are displayed on the main Beatify admin screen:
 
 ### Included Playlists
 
-Beatify comes with 2,363 songs across 21 curated playlists:
+Beatify comes with 2,453 songs across 23 curated playlists:
 
 - 🎸 **60s Classics** — 45 tracks from the golden age of rock & roll
 - 🎹 **80s Hits** — 208 classic hits from the decade of synths and MTV
 - 🎵 **90s Hits** — 32 essential tracks from the decade
-- 🎵 **2000s Pop Anthems** — 151 essential pop hits from the 2000s
+- 🎵 **2000s Pop Anthems** — 150 essential pop hits from the 2000s
+- 🎤 **90s & 2000s Hip-Hop Bangers** — 40 tracks from 2Pac, Eminem, JAY-Z, Nas, Dr. Dre and more
 - 🇪🇸 **100% en Español** — 127 Latin & Spanish classics
 - 🎬 **100 Greatest Movie Themes** — 162 iconic film soundtracks
 - ☀️ **100 Summer Anthems** — 112 feel-good tracks from 1957-2020
 - 🇬🇧 **British Invasion & Britpop** — 100 tracks from The Beatles to Blur
-- 🎭 **Cologne Carnival** — 291 German carnival favorites
+- 🎭 **Cologne Carnival** — 290 German carnival favorites
 - 🕺 **Disco & Funk Classics** — 76 essential disco and funk tracks from the 70s and 80s
 - 💥 **Eurodance 90s** — 100 party songs from the eurodance era
 - 🏆 **Eurovision Winners (1956-2025)** — 72 winning songs
 - 💃 **Fiesta Latina 90s** — 50 Latin party anthems from Shakira, Ricky Martin, Maná
+- 🤘 **Greatest Metal Songs** — 52 legendary tracks across all major metal subgenres
 - 🎯 **Greatest Hits of All Time** — 180 chart-toppers across four decades
 - 🎵 **Motown & Soul Classics** — 100 iconic soul tracks from Diana Ross, Marvin Gaye, The Temptations
 - 🎤 **One-Hit Wonders** — 98 flash-in-the-pan classics
@@ -485,6 +487,15 @@ The neon dark theme is built-in and looks stunning. Custom theming is on the roa
 <br>
 
 ## What's New
+
+### v2.9.1 — Party Lights, Dutch & Stability 🎉
+- **Party Lights** — Automated light control during games with intensity presets (Subtle/Medium/Party), admin light picker, and preview button. Subtle mode scales relative to your pre-game brightness: +0% lobby, +20% playing, +40% reveal and end
+- **Dutch language support** — Fifth language joins EN, DE, FR, ES. Full UI translations and Dutch fun facts and awards across all playlists
+- **12 bugs fixed** — 5 high-severity and 7 medium-severity findings from systematic code review, including admin claim guard, null song scoring, intro timer restart, MA playback timeout, and Dutch game state serialization
+- **38% smaller assets** — All CSS/JS minified and bundled via esbuild, 590KB → 364KB
+- **5 architecture refactors** — ChallengeManager, PowerUpManager, PlayerRegistry, shared state serializer, WebSocket public API
+- 39 dead streaming URIs replaced across greatest-hits-of-all-time and motown-soul-classics
+- 23 playlists, 2,453 songs, 5 music platforms, 5 languages
 
 ### v2.8.0 — Deezer, Smarter Intro Mode & Architecture Overhaul 🎵
 - **Deezer Support** — Fifth streaming service joins Spotify, YouTube Music, Apple Music and Tidal. 2,000+ Deezer URIs across 19 playlists

--- a/custom_components/beatify/manifest.json
+++ b/custom_components/beatify/manifest.json
@@ -11,5 +11,5 @@
   "documentation": "https://github.com/mholzi/beatify",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/mholzi/beatify/issues",
-  "version": "2.9.0"
+  "version": "2.9.1"
 }

--- a/custom_components/beatify/playlists/2000s-pop-anthems.json
+++ b/custom_components/beatify/playlists/2000s-pop-anthems.json
@@ -1,6 +1,6 @@
 {
   "name": "2000s Pop Anthems",
-  "version": "1.3",
+  "version": "1.4",
   "tags": [
     "2000s",
     "pop",

--- a/custom_components/beatify/playlists/80er-hits.json
+++ b/custom_components/beatify/playlists/80er-hits.json
@@ -1,6 +1,6 @@
 {
   "name": "80s Hits",
-  "version": "2.2",
+  "version": "2.3",
   "tags": [
     "1980s",
     "pop",

--- a/custom_components/beatify/playlists/90er-hits.json
+++ b/custom_components/beatify/playlists/90er-hits.json
@@ -1,6 +1,6 @@
 {
   "name": "90s Hits",
-  "version": "1.4",
+  "version": "1.5",
   "tags": [
     "1990s",
     "pop",

--- a/custom_components/beatify/playlists/90s-2000s-hiphop-bangers.json
+++ b/custom_components/beatify/playlists/90s-2000s-hiphop-bangers.json
@@ -1,6 +1,6 @@
 {
   "name": "90s & 2000s Hip Hop Bangers",
-  "version": "1.0",
+  "version": "1.1",
   "tags": [
     "90s",
     "2000s",

--- a/custom_components/beatify/playlists/british-invasion-britpop.json
+++ b/custom_components/beatify/playlists/british-invasion-britpop.json
@@ -1,6 +1,6 @@
 {
   "name": "British Invasion & Britpop 🇬🇧",
-  "version": "1.1",
+  "version": "1.2",
   "tags": [
     "1960s",
     "1990s",

--- a/custom_components/beatify/playlists/community/greatest-metal-songs.json
+++ b/custom_components/beatify/playlists/community/greatest-metal-songs.json
@@ -1,6 +1,6 @@
 {
   "name": "Greatest Metal Songs of All Time 🤘",
-  "version": "1.3",
+  "version": "1.4",
   "tags": [
     "metal",
     "rock",

--- a/custom_components/beatify/playlists/community/hitster-100-en-espanol.json
+++ b/custom_components/beatify/playlists/community/hitster-100-en-espanol.json
@@ -1,6 +1,6 @@
 {
   "name": "100% en Español 🇪🇸",
-  "version": "1.3",
+  "version": "1.4",
   "tags": [
     "spanish",
     "spain",

--- a/custom_components/beatify/playlists/community/top-songs-der-60er.json
+++ b/custom_components/beatify/playlists/community/top-songs-der-60er.json
@@ -1,6 +1,6 @@
 {
   "name": "60s Classics 🎸",
-  "version": "1.1",
+  "version": "1.2",
   "source": "https://open.spotify.com/playlist/6rtsNFUv2UK3j78PRVMpSd",
   "tags": [
     "1960s",

--- a/custom_components/beatify/playlists/community/top100-allertijden-nederlandstalig.json
+++ b/custom_components/beatify/playlists/community/top100-allertijden-nederlandstalig.json
@@ -1,6 +1,6 @@
 {
   "name": "Top 100 Dutch Classics 🇳🇱",
-  "version": "1.5",
+  "version": "1.6",
   "tags": [
     "nederlandstalig",
     "dutch",

--- a/custom_components/beatify/playlists/disco-funk-classics.json
+++ b/custom_components/beatify/playlists/disco-funk-classics.json
@@ -1,6 +1,6 @@
 {
   "name": "Disco & Funk Classics",
-  "version": "1.3",
+  "version": "1.4",
   "tags": [
     "1970s",
     "1980s",

--- a/custom_components/beatify/playlists/eurodance-90s.json
+++ b/custom_components/beatify/playlists/eurodance-90s.json
@@ -1,6 +1,6 @@
 {
   "name": "Eurodance 90s 💥",
-  "version": "1.4",
+  "version": "1.5",
   "tags": [
     "1990s",
     "eurodance",

--- a/custom_components/beatify/playlists/eurovision-winners.json
+++ b/custom_components/beatify/playlists/eurovision-winners.json
@@ -1,6 +1,6 @@
 {
   "name": "Eurovision Winners (1956-2025)",
-  "version": "1.6",
+  "version": "1.7",
   "tags": [
     "eurovision",
     "contest",

--- a/custom_components/beatify/playlists/fiesta-latina-90s.json
+++ b/custom_components/beatify/playlists/fiesta-latina-90s.json
@@ -1,6 +1,6 @@
 {
   "name": "Fiesta Latina 90s 🇲🇽",
-  "version": "1.4",
+  "version": "1.5",
   "tags": [
     "1990s",
     "latin",

--- a/custom_components/beatify/playlists/greatest-hits-of-all-time.json
+++ b/custom_components/beatify/playlists/greatest-hits-of-all-time.json
@@ -1,6 +1,6 @@
 {
   "name": "Greatest Hits of All Time",
-  "version": "2.3",
+  "version": "2.4",
   "tags": [
     "classics",
     "top-hits",

--- a/custom_components/beatify/playlists/koelner-karneval.json
+++ b/custom_components/beatify/playlists/koelner-karneval.json
@@ -1,6 +1,6 @@
 {
   "name": "Cologne Carnival 🎭",
-  "version": "1.3",
+  "version": "1.4",
   "tags": [
     "german",
     "carnival",

--- a/custom_components/beatify/playlists/motown-soul-classics.json
+++ b/custom_components/beatify/playlists/motown-soul-classics.json
@@ -1,6 +1,6 @@
 {
   "name": "Motown & Soul Classics",
-  "version": "1.3",
+  "version": "1.4",
   "tags": [
     "1960s",
     "1970s",

--- a/custom_components/beatify/playlists/movies-100-greatest-themes.json
+++ b/custom_components/beatify/playlists/movies-100-greatest-themes.json
@@ -1,6 +1,6 @@
 {
   "name": "100 Greatest Movie Themes 🎬",
-  "version": "1.6",
+  "version": "1.7",
   "tags": [
     "movies",
     "soundtrack",

--- a/custom_components/beatify/playlists/one-hit-wonders.json
+++ b/custom_components/beatify/playlists/one-hit-wonders.json
@@ -1,6 +1,6 @@
 {
   "name": "One-Hit Wonders",
-  "version": "1.2",
+  "version": "1.3",
   "tags": [
     "one-hit",
     "classics",

--- a/custom_components/beatify/playlists/pure-pop-punk.json
+++ b/custom_components/beatify/playlists/pure-pop-punk.json
@@ -1,6 +1,6 @@
 {
   "name": "Pure Pop Punk 🎸",
-  "version": "1.2",
+  "version": "1.3",
   "tags": [
     "2000s",
     "pop-punk",

--- a/custom_components/beatify/playlists/schlager-klassiker.json
+++ b/custom_components/beatify/playlists/schlager-klassiker.json
@@ -1,6 +1,6 @@
 {
   "name": "Schlager Classics 🇩🇪",
-  "version": "1.6",
+  "version": "1.7",
   "tags": [
     "german",
     "schlager",

--- a/custom_components/beatify/playlists/summer-party-anthems.json
+++ b/custom_components/beatify/playlists/summer-party-anthems.json
@@ -1,6 +1,6 @@
 {
   "name": "100 Summer Anthems ☀️",
-  "version": "1.6",
+  "version": "1.7",
   "tags": [
     "party",
     "classics",

--- a/custom_components/beatify/playlists/top-100-power-ballads.json
+++ b/custom_components/beatify/playlists/top-100-power-ballads.json
@@ -1,6 +1,6 @@
 {
   "name": "Top 100 Power Ballads",
-  "version": "1.2",
+  "version": "1.3",
   "tags": [
     "1980s",
     "1990s",

--- a/custom_components/beatify/playlists/yacht-rock.json
+++ b/custom_components/beatify/playlists/yacht-rock.json
@@ -1,6 +1,6 @@
 {
   "name": "Yacht Rock ⛵",
-  "version": "1.3",
+  "version": "1.4",
   "tags": [
     "1970s",
     "1980s",


### PR DESCRIPTION
## Summary

- `manifest.json`: 2.9.0 → 2.9.1
- All 23 playlist JSON versions incremented
- README: version badge updated, playlist list corrected (23 playlists, 2,453 songs, 5 languages), v2.9.1 What's New entry added

🤖 Generated with [Claude Code](https://claude.com/claude-code)