### PR TITLE
data: fix 6 broken/wrong Apple Music URIs in one-hit-wonders.json (#438)

### DIFF
--- a/custom_components/beatify/playlists/one-hit-wonders.json
+++ b/custom_components/beatify/playlists/one-hit-wonders.json
@@ -1,6 +1,6 @@
 {
   "name": "One-Hit Wonders",
-  "version": "1.3",
+  "version": "1.4",
   "tags": [
     "one-hit",
     "classics",
@@ -743,7 +743,7 @@
       ],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=mcCK99wHrk0",
-      "uri_apple_music": "applemusic://track/1436478543",
+      "uri_apple_music": "applemusic://track/52310973",
       "uri_tidal": "tidal://track/69145431",
       "uri_deezer": "deezer://track/8081935",
       "fun_fact_nl": "Wordt beschouwd als de eerste commercieel succesvolle hiphopsingle. De leden werden bij elkaar gebracht door een eigenaar van een platenlabel die het potentieel van hiphop zag.",
@@ -875,7 +875,7 @@
         "Gold (US)"
       ],
       "awards": [],
-      "uri_apple_music": "applemusic://track/266222276",
+      "uri_apple_music": "applemusic://track/1874710171",
       "uri_youtube_music": "https://music.youtube.com/watch?v=iIpfWORQWhU",
       "uri_tidal": "tidal://track/4930181",
       "uri_deezer": "deezer://track/1025577",
@@ -930,7 +930,7 @@
         "Gold (US)"
       ],
       "awards": [],
-      "uri_apple_music": "applemusic://track/1733715026",
+      "uri_apple_music": "applemusic://track/1452735552",
       "uri_youtube_music": "https://music.youtube.com/watch?v=BvkbVLRRV5U",
       "uri_tidal": "tidal://track/348276175",
       "uri_deezer": "deezer://track/943152",
@@ -1044,7 +1044,7 @@
         "Gold (DE)"
       ],
       "awards": [],
-      "uri_apple_music": "applemusic://track/1550643320",
+      "uri_apple_music": "applemusic://track/1550643321",
       "uri_tidal": "tidal://track/169150",
       "uri_deezer": "deezer://track/14683660",
       "fun_fact_nl": "Een vervolg op David Bowie's 'Space Oddity'. De Duitse versie 'Völlig Losgelöst' was nog groter in Europa, maar Schilling kwam nooit meer in de hitlijsten van de VS.",
@@ -2420,7 +2420,7 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=Nntd2fgMUYw",
-      "uri_apple_music": "applemusic://track/1440918860",
+      "uri_apple_music": "applemusic://track/171708539",
       "uri_tidal": "tidal://track/610923",
       "uri_deezer": "deezer://track/2252935",
       "fun_fact_nl": "Zoon van jazzlegende Don Cherry en halfbroer van Neneh Cherry. Ondanks familiebanden kon hij zijn eigen succes in de hitlijsten niet behouden.",
@@ -2692,7 +2692,7 @@
         "Grammy Award du disque de l'année (2007)"
       ],
       "uri_youtube_music": "https://music.youtube.com/watch?v=-N4jf6rtyuw",
-      "uri_apple_music": "applemusic://track/135149687",
+      "uri_apple_music": "applemusic://track/1741403966",
       "uri_tidal": "tidal://track/34631719",
       "uri_deezer": "deezer://track/2794160",
       "fun_fact_nl": "Eerste nummer dat alleen al door downloads #1 werd in de Britse hitlijsten. Het duo CeeLo Green en Danger Mouse droeg bij elk optreden uitgebreide kostuums.",


### PR DESCRIPTION
Closes #438.

Fixed 6 Apple Music URIs:
- 4 dead URIs (Rapper's Delight, I Ran, Crazy, Save Tonight)
- 2 wrong URIs (I Melt With You → 1982 original, Major Tom → English version)

Bumped playlist version 1.3 → 1.4.

**Note:** Spotify wrong-track URIs for Modern English and Peter Schilling could not be resolved via automated search — original 1982 Spotify ID for 'I Melt With You' and English Spotify ID for 'Major Tom (Coming Home)' need manual lookup.