### PR TITLE
chore: fix dependency versions — min HA, Python 3.13 CI, pin esbuild, tighten aiohttp floor

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,15 +28,18 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  PYTHON_VERSION: "3.11"
+  PYTHON_VERSION: "3.13"
 
 jobs:
   # ==========================================================================
   # STAGE 1: LINT
   # ==========================================================================
   lint:
-    name: Lint
+    name: Lint (${{ matrix.python-version }})
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.12", "3.13"]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -44,7 +47,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ env.PYTHON_VERSION }}
+          python-version: ${{ matrix.python-version }}
 
       - name: Install ruff
         run: pip install ruff
@@ -59,9 +62,12 @@ jobs:
   # STAGE 2: TEST
   # ==========================================================================
   test:
-    name: Test
+    name: Test (${{ matrix.python-version }})
     runs-on: ubuntu-latest
     needs: lint
+    strategy:
+      matrix:
+        python-version: ["3.12", "3.13"]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -69,7 +75,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ env.PYTHON_VERSION }}
+          python-version: ${{ matrix.python-version }}
 
       - name: Cache pip dependencies
         uses: actions/cache@v4

--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,6 @@ beatify/
 
 # ---- Config & tooling ----
 pyproject.toml
-package.json
 package-lock.json
 requirements.txt
 # requirements_test.txt intentionally NOT ignored

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
     "name": "Beatify",
-    "homeassistant": "2024.1.0",
+    "homeassistant": "2025.1.0",
     "render_readme": true
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "private": true,
+  "name": "beatify",
+  "description": "Build tools for Beatify Home Assistant integration",
+  "devDependencies": {
+    "esbuild": "~0.27.4"
+  }
+}

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -3,4 +3,4 @@
 pytest>=9.0
 pytest-asyncio>=1.0
 pytest-cov>=6.0
-aiohttp>=3.9
+aiohttp>=3.11


### PR DESCRIPTION
Fixes #455, #456, #457, #458

- **#455** — `hacs.json`: bump minimum HA from `2024.1.0` to `2025.1.0`
- **#456** — CI: update Python to `3.13`, add 3.12/3.13 matrix for lint + test jobs
- **#457** — Add `package.json` with pinned `esbuild` devDependency
- **#458** — Tighten `aiohttp>=3.9` floor to `aiohttp>=3.11` in `requirements_test.txt`