### PR TITLE
data: fix 29 broken URIs in schlager-klassiker (#473)

### DIFF
--- a/custom_components/beatify/playlists/schlager-klassiker.json
+++ b/custom_components/beatify/playlists/schlager-klassiker.json
@@ -1,6 +1,6 @@
 {
   "name": "Schlager Classics 🇩🇪",
-  "version": "1.7",
+  "version": "1.8",
   "tags": [
     "german",
     "schlager",
@@ -66,7 +66,7 @@
       "awards_fr": [
         "Victoire au Concours Eurovision de la chanson (1972)"
       ],
-      "uri_apple_music": "applemusic://track/1440923428",
+      "uri_apple_music": "applemusic://track/1442466989",
       "uri_youtube_music": "https://music.youtube.com/watch?v=LU3uZzrAAW4",
       "uri_tidal": "tidal://track/13376316",
       "uri_deezer": "deezer://track/2322409",
@@ -214,7 +214,7 @@
         "Prix Echo (1991)",
         "Diapason d'or (1991)"
       ],
-      "uri_apple_music": "applemusic://track/724238415",
+      "uri_apple_music": "applemusic://track/1611040987",
       "uri_youtube_music": "https://music.youtube.com/watch?v=x6q0ciiqyG0",
       "uri_tidal": "tidal://track/63902379",
       "uri_deezer": "deezer://track/111773080",
@@ -359,7 +359,7 @@
       "awards_fr": [
         "Disque d'or (1982)"
       ],
-      "uri_apple_music": "applemusic://track/331872876",
+      "uri_apple_music": "applemusic://track/207420334",
       "uri_youtube_music": "https://music.youtube.com/watch?v=PPGEGxBI-Ko",
       "uri_tidal": "tidal://track/110219",
       "uri_deezer": "deezer://track/602261",
@@ -389,7 +389,7 @@
         "Gold (DE)"
       ],
       "awards": [],
-      "uri_apple_music": "applemusic://track/915364976",
+      "uri_apple_music": "applemusic://track/303883039",
       "uri_youtube_music": "https://music.youtube.com/watch?v=OD8-q-Zey7Q",
       "uri_tidal": "tidal://track/2991469",
       "uri_deezer": "deezer://track/84668173",
@@ -428,7 +428,7 @@
       "awards_fr": [
         "Prix allemand du cabaret"
       ],
-      "uri_apple_music": "applemusic://track/724003108",
+      "uri_apple_music": "applemusic://track/724105106",
       "uri_youtube_music": "https://music.youtube.com/watch?v=fZMFF8QH3ew",
       "uri_tidal": "tidal://track/1465081",
       "uri_deezer": "deezer://track/3297738",
@@ -469,7 +469,7 @@
       "awards_fr": [
         "Diapason d'or (1977)"
       ],
-      "uri_apple_music": "applemusic://track/713572059",
+      "uri_apple_music": "applemusic://track/724311769",
       "uri_youtube_music": "https://music.youtube.com/watch?v=2t8jOFqN08w",
       "uri_tidal": "tidal://track/3092605",
       "uri_deezer": "deezer://track/3489487",
@@ -498,7 +498,7 @@
         "Gold (DE)"
       ],
       "awards": [],
-      "uri_apple_music": "applemusic://track/1442439783",
+      "uri_apple_music": "applemusic://track/1452870444",
       "uri_youtube_music": "https://music.youtube.com/watch?v=HiVOIxzOx88",
       "uri_tidal": "tidal://track/4920882",
       "uri_deezer": "deezer://track/2319548",
@@ -526,7 +526,7 @@
         "Platinum (DE)"
       ],
       "awards": [],
-      "uri_apple_music": "applemusic://track/331872178",
+      "uri_apple_music": "applemusic://track/250875657",
       "uri_youtube_music": "https://music.youtube.com/watch?v=MRBm8PcMfN0",
       "uri_tidal": "tidal://track/3098942",
       "uri_deezer": "deezer://track/602247",
@@ -565,7 +565,7 @@
       "awards_fr": [
         "Diapason d'or (1975)"
       ],
-      "uri_apple_music": "applemusic://track/703536400",
+      "uri_apple_music": "applemusic://track/1822405353",
       "uri_youtube_music": "https://music.youtube.com/watch?v=s3EMTAr-UBY",
       "uri_tidal": "tidal://track/22371988",
       "uri_deezer": "deezer://track/2312569",
@@ -594,7 +594,7 @@
         "Gold (DE)"
       ],
       "awards": [],
-      "uri_apple_music": "applemusic://track/1442330542",
+      "uri_apple_music": "applemusic://track/1442497015",
       "uri_youtube_music": "https://music.youtube.com/watch?v=XOJbPHQFxzw",
       "uri_tidal": "tidal://track/16234462",
       "uri_deezer": "deezer://track/43438991",
@@ -622,7 +622,7 @@
         "Platinum (DE)"
       ],
       "awards": [],
-      "uri_apple_music": "applemusic://track/211407545",
+      "uri_apple_music": "applemusic://track/264705546",
       "uri_youtube_music": "https://music.youtube.com/watch?v=Mlt2xg_j5AY",
       "uri_tidal": "tidal://track/56290544",
       "uri_deezer": "deezer://track/120358360",
@@ -650,7 +650,7 @@
         "2x Platinum (DE)"
       ],
       "awards": [],
-      "uri_apple_music": "applemusic://track/40548009",
+      "uri_apple_music": "applemusic://track/402994827",
       "uri_youtube_music": "https://music.youtube.com/watch?v=KcoRvp-cM4c",
       "uri_tidal": "tidal://track/109437",
       "uri_deezer": "deezer://track/697623",
@@ -678,7 +678,7 @@
         "Gold (DE)"
       ],
       "awards": [],
-      "uri_apple_music": "applemusic://track/331871942",
+      "uri_apple_music": "applemusic://track/1201255842",
       "uri_youtube_music": "https://music.youtube.com/watch?v=W1t3jiHvCz8",
       "uri_tidal": "tidal://track/3098940",
       "uri_deezer": "deezer://track/4253146",
@@ -753,7 +753,7 @@
         "Prix Echo (2008)",
         "Prix Amadeus de musique autrichienne (2008)"
       ],
-      "uri_apple_music": "applemusic://track/1444443840",
+      "uri_apple_music": "applemusic://track/1442902928",
       "uri_youtube_music": "https://music.youtube.com/watch?v=ICYy0HmnHyo",
       "uri_tidal": "tidal://track/3608585",
       "uri_deezer": "deezer://track/1139093",
@@ -823,7 +823,7 @@
       "awards_fr": [
         "Diapason d'or (1984)"
       ],
-      "uri_apple_music": "applemusic://track/1453685670",
+      "uri_apple_music": "applemusic://track/1609263446",
       "uri_youtube_music": "https://music.youtube.com/watch?v=34r0vMqqSkE",
       "uri_tidal": "tidal://track/7524725",
       "uri_deezer": "deezer://track/2185735",
@@ -909,7 +909,7 @@
         "Platinum (DE)"
       ],
       "awards": [],
-      "uri_apple_music": "applemusic://track/724311867",
+      "uri_apple_music": "applemusic://track/1440814395",
       "uri_youtube_music": "https://music.youtube.com/watch?v=zW1eou-beTc",
       "uri_tidal": "tidal://track/3092603",
       "uri_deezer": "deezer://track/3309776001",
@@ -965,7 +965,7 @@
         "Gold (DE)"
       ],
       "awards": [],
-      "uri_apple_music": "applemusic://track/966556786",
+      "uri_apple_music": "applemusic://track/303883046",
       "uri_youtube_music": "https://music.youtube.com/watch?v=BuVJPaUA4yE",
       "uri_tidal": "tidal://track/34039817",
       "uri_deezer": "deezer://track/1195330",
@@ -1069,7 +1069,7 @@
         "Platinum (DE)"
       ],
       "awards": [],
-      "uri_apple_music": "applemusic://track/1029914710",
+      "uri_apple_music": "applemusic://track/703516566",
       "uri_youtube_music": "https://music.youtube.com/watch?v=jguRJ0fZTuk",
       "uri_tidal": "tidal://track/3380584",
       "uri_deezer": "deezer://track/16267932",
@@ -1138,7 +1138,7 @@
         "Gold (DE)"
       ],
       "awards": [],
-      "uri_apple_music": "applemusic://track/1452867888",
+      "uri_apple_music": "applemusic://track/1442818922",
       "uri_youtube_music": "https://music.youtube.com/watch?v=7eFG6MoCFZc",
       "uri_tidal": "tidal://track/13494392",
       "uri_deezer": "deezer://track/3055769",
@@ -1177,7 +1177,7 @@
       "awards_fr": [
         "Diapason d'or (1980)"
       ],
-      "uri_apple_music": "applemusic://track/634870211",
+      "uri_apple_music": "applemusic://track/1455400306",
       "uri_youtube_music": "https://music.youtube.com/watch?v=nYfqxcKp5HY",
       "uri_tidal": "tidal://track/683707",
       "uri_deezer": "deezer://track/66506378",
@@ -1325,7 +1325,7 @@
       "awards_fr": [
         "Goldene Henne (2015)"
       ],
-      "uri_apple_music": "applemusic://track/913150581",
+      "uri_apple_music": "applemusic://track/913150573",
       "uri_youtube_music": "https://music.youtube.com/watch?v=BNHamTwxJ6Q",
       "uri_tidal": "tidal://track/33903374",
       "uri_deezer": "deezer://track/84206953",
@@ -1355,7 +1355,7 @@
         "Gold (DE)"
       ],
       "awards": [],
-      "uri_apple_music": "applemusic://track/303883842",
+      "uri_apple_music": "applemusic://track/255682337",
       "uri_youtube_music": "https://music.youtube.com/watch?v=xMOZh5xSHrg",
       "uri_tidal": "tidal://track/109228",
       "uri_deezer": "deezer://track/13237692",
@@ -1482,7 +1482,7 @@
         "Gold (DE)"
       ],
       "awards": [],
-      "uri_apple_music": "applemusic://track/915382195",
+      "uri_apple_music": "applemusic://track/252458104",
       "uri_youtube_music": "https://music.youtube.com/watch?v=4-DYhrD-N6M",
       "uri_tidal": "tidal://track/12853649",
       "uri_deezer": "deezer://track/15801849",
@@ -1672,7 +1672,7 @@
         "Gold (DE)"
       ],
       "awards": [],
-      "uri_apple_music": "applemusic://track/1443355536",
+      "uri_apple_music": "applemusic://track/1440783525",
       "uri_youtube_music": "https://music.youtube.com/watch?v=VvqKjahzm6w",
       "uri_tidal": "tidal://track/622060",
       "uri_deezer": "deezer://track/7524195",
@@ -1697,7 +1697,7 @@
       },
       "certifications": [],
       "awards": [],
-      "uri_apple_music": "applemusic://track/1443368139",
+      "uri_apple_music": "applemusic://track/1434568396",
       "uri_youtube_music": "https://music.youtube.com/watch?v=PbKlF8Pb4qw",
       "uri_tidal": "tidal://track/39479533",
       "uri_deezer": "deezer://track/1477458052",
@@ -1725,7 +1725,7 @@
         "Gold (DE)"
       ],
       "awards": [],
-      "uri_apple_music": "applemusic://track/915383380",
+      "uri_apple_music": "applemusic://track/368893225",
       "uri_youtube_music": "https://music.youtube.com/watch?v=O40yPfbLkzw",
       "uri_tidal": "tidal://track/34039819",
       "uri_deezer": "deezer://track/84668179",
@@ -1807,7 +1807,7 @@
       "certifications": [],
       "awards": [],
       "uri_apple_music": "applemusic://track/1642332872",
-      "uri_youtube_music": "https://music.youtube.com/watch?v=2Pj6ePTOgeY",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=jDcC-qmqnc8",
       "uri_tidal": "tidal://track/236476831",
       "uri_deezer": "deezer://track/1831148087",
       "fun_fact_nl": "Wir sagen danke schön van Die Flippers is een welgemeend danklied aan hun fans. De band nam afscheid na een succesvolle carrière van meer dan 40 jaar.",
@@ -1862,7 +1862,7 @@
         "Gold (DE)"
       ],
       "awards": [],
-      "uri_apple_music": "applemusic://track/716021745",
+      "uri_apple_music": "applemusic://track/1021730969",
       "uri_youtube_music": "https://music.youtube.com/watch?v=NLb-rbmcmvk",
       "uri_tidal": "tidal://track/11212266",
       "uri_deezer": "deezer://track/5077323",
@@ -1931,7 +1931,7 @@
         "Gold (DE)"
       ],
       "awards": [],
-      "uri_apple_music": "applemusic://track/304326426",
+      "uri_apple_music": "applemusic://track/1459075340",
       "uri_youtube_music": "https://music.youtube.com/watch?v=cJJ4odOP96Q",
       "uri_tidal": "tidal://track/3014371",
       "uri_deezer": "deezer://track/70524821",


### PR DESCRIPTION
Closes #473.

Replaced 29 dead/wrong URIs in `schlager-klassiker.json` and bumped playlist version from 1.7 → 1.8.

**Changes:**
- 28 Apple Music track IDs replaced with current iTunes catalog IDs
- 1 YouTube Music URI fixed (Die Flippers - Wir sagen danke schön: was Oktoberfest Mix, now correct original 2009 version)

All 28 Apple Music replacements verified live against the iTunes DE catalog before commit.