### PR TITLE
feat: per-announcement TTS toggles and test button in admin settings

### DIFF
--- a/custom_components/beatify/__init__.py
+++ b/custom_components/beatify/__init__.py
@@ -33,6 +33,7 @@ from .server.views import (
     LauncherView,
     LightsView,
     PreviewLightsView,
+    TtsTestView,
     PlayerView,
     PlaylistRequestsView,
     RematchGameView,
@@ -122,6 +123,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.http.register_view(StatusView(hass))
     hass.http.register_view(LightsView(hass))  # Issue #331
     hass.http.register_view(PreviewLightsView(hass))  # Issue #408
+    hass.http.register_view(TtsTestView(hass))
     hass.http.register_view(StartGameView(hass))
     hass.http.register_view(StartGameplayView(hass))
     hass.http.register_view(EndGameView(hass))

--- a/custom_components/beatify/game/state.py
+++ b/custom_components/beatify/game/state.py
@@ -110,6 +110,8 @@ class GameState:
         self._party_lights: PartyLightsProtocol | None = None
         # Issue #447: TTS announcement service
         self._tts_service: Any = None  # TTSService (lazy import)
+        self._tts_announce_game_start: bool = True
+        self._tts_announce_winner: bool = True
         self._bg_tasks: set[asyncio.Task] = set()  # Issue #391: prevent GC of fire-and-forget tasks
 
         # Issue #347: Player management delegated to PlayerRegistry
@@ -1870,11 +1872,20 @@ class GameState:
     # TTS Announcements (#447)
     # ------------------------------------------------------------------
 
-    async def configure_tts(self, hass: Any, entity_id: str) -> None:
+    async def configure_tts(
+        self,
+        hass: Any,
+        entity_id: str,
+        *,
+        announce_game_start: bool = True,
+        announce_winner: bool = True,
+    ) -> None:
         """Configure TTS announcement service for the game."""
         from custom_components.beatify.services.tts import TTSService  # noqa: PLC0415
 
         self._tts_service = TTSService(hass, entity_id)
+        self._tts_announce_game_start = announce_game_start
+        self._tts_announce_winner = announce_winner
 
     async def disable_tts(self) -> None:
         """Disable TTS announcements."""
@@ -1892,7 +1903,7 @@ class GameState:
 
     async def announce_game_start(self) -> None:
         """Announce game start (use case 16)."""
-        if not self._tts_service:
+        if not self._tts_service or not self._tts_announce_game_start:
             return
         message = (
             f"Let's play Beatify! {self.total_rounds} rounds, "
@@ -1902,7 +1913,7 @@ class GameState:
 
     async def announce_winner(self) -> None:
         """Announce the winner (use case 18)."""
-        if not self._tts_service or not self.players:
+        if not self._tts_service or not self._tts_announce_winner or not self.players:
             return
         winner = max(self.players.values(), key=lambda p: p.score)
         message = (

--- a/custom_components/beatify/server/views.py
+++ b/custom_components/beatify/server/views.py
@@ -239,6 +239,45 @@ class PreviewLightsView(HomeAssistantView):
         return web.json_response({"ok": True})
 
 
+class TtsTestView(HomeAssistantView):
+    """Send a test TTS announcement to verify setup."""
+
+    url = "/beatify/api/tts-test"
+    name = "beatify:api:tts-test"
+    requires_auth = False
+
+    def __init__(self, hass: HomeAssistant) -> None:
+        """Initialize view."""
+        self.hass = hass
+
+    async def post(self, request: web.Request) -> web.Response:
+        """Speak a test message via TTS."""
+        try:
+            body = await request.json()
+        except Exception:  # noqa: BLE001
+            return web.json_response({"error": "Invalid JSON"}, status=400)
+
+        entity_id = body.get("entity_id", "")
+        message = body.get("message", "")
+        if not entity_id or not message:
+            return web.json_response(
+                {"error": "entity_id and message required"}, status=400
+            )
+
+        try:
+            await self.hass.services.async_call(
+                "tts",
+                "speak",
+                {"entity_id": entity_id, "message": message},
+                blocking=False,
+            )
+        except Exception:  # noqa: BLE001
+            _LOGGER.exception("TTS test failed for entity: %s", entity_id)
+            return web.json_response({"error": "TTS call failed"}, status=500)
+
+        return web.json_response({"ok": True})
+
+
 class StartGameView(HomeAssistantView):
     """Handle start game requests."""
 
@@ -503,7 +542,16 @@ class StartGameView(HomeAssistantView):
         if tts_config and tts_config.get("enabled"):
             tts_entity_id = tts_config.get("entity_id", "")
             if tts_entity_id:
-                await game_state.configure_tts(self.hass, tts_entity_id)
+                tts_announce_game_start = tts_config.get(
+                    "announce_game_start", True
+                )
+                tts_announce_winner = tts_config.get("announce_winner", True)
+                await game_state.configure_tts(
+                    self.hass,
+                    tts_entity_id,
+                    announce_game_start=tts_announce_game_start,
+                    announce_winner=tts_announce_winner,
+                )
                 await game_state.announce_game_start()
 
         # Broadcast to WebSocket clients

--- a/custom_components/beatify/www/admin.html
+++ b/custom_components/beatify/www/admin.html
@@ -337,6 +337,37 @@
                     </span>
                     <input type="text" id="tts-entity-id" class="input-compact" placeholder="tts.google_en_com" data-i18n-placeholder="admin.ttsEntityIdHint">
                 </div>
+
+                <!-- Announce game start toggle -->
+                <div class="setting-row">
+                    <span class="setting-label">
+                        <span class="setting-icon" aria-hidden="true">🎬</span>
+                        <span data-i18n="admin.ttsAnnounceGameStart">Announce Game Start</span>
+                        <span class="setting-hint" data-i18n="admin.ttsAnnounceGameStartHint">Announce when the game begins</span>
+                    </span>
+                    <label class="toggle-compact">
+                        <input type="checkbox" id="tts-announce-game-start" checked>
+                        <span class="toggle-switch-compact"></span>
+                    </label>
+                </div>
+
+                <!-- Announce winner toggle -->
+                <div class="setting-row">
+                    <span class="setting-label">
+                        <span class="setting-icon" aria-hidden="true">🏆</span>
+                        <span data-i18n="admin.ttsAnnounceWinner">Announce Winner</span>
+                        <span class="setting-hint" data-i18n="admin.ttsAnnounceWinnerHint">Announce the winner at game end</span>
+                    </span>
+                    <label class="toggle-compact">
+                        <input type="checkbox" id="tts-announce-winner" checked>
+                        <span class="toggle-switch-compact"></span>
+                    </label>
+                </div>
+
+                <!-- Test TTS button -->
+                <button type="button" id="tts-test" class="btn btn-secondary btn-full-width" disabled>
+                    🔊 Test TTS
+                </button>
             </div>
         </section>
 

--- a/custom_components/beatify/www/i18n/de.json
+++ b/custom_components/beatify/www/i18n/de.json
@@ -364,7 +364,13 @@
     "ttsAnnouncements": "TTS-Ansagen",
     "ttsEnabled": "TTS aktivieren",
     "ttsEntityId": "TTS-Entität",
-    "ttsEntityIdHint": "z.B. tts.google_de_com"
+    "ttsEntityIdHint": "z.B. tts.google_de_com",
+    "ttsAnnounceGameStart": "Spielstart ansagen",
+    "ttsAnnounceGameStartHint": "Ansage bei Spielbeginn",
+    "ttsAnnounceWinner": "Gewinner ansagen",
+    "ttsAnnounceWinnerHint": "Ansage des Gewinners am Spielende",
+    "ttsTested": "Gesendet",
+    "ttsTestFailed": "Fehlgeschlagen"
   },
   "analyticsDashboard": {
     "title": "Beatify Statistik",

--- a/custom_components/beatify/www/i18n/en.json
+++ b/custom_components/beatify/www/i18n/en.json
@@ -364,7 +364,13 @@
     "ttsAnnouncements": "TTS Announcements",
     "ttsEnabled": "Enable TTS",
     "ttsEntityId": "TTS Entity",
-    "ttsEntityIdHint": "e.g. tts.google_en_com"
+    "ttsEntityIdHint": "e.g. tts.google_en_com",
+    "ttsAnnounceGameStart": "Announce Game Start",
+    "ttsAnnounceGameStartHint": "Announce when the game begins",
+    "ttsAnnounceWinner": "Announce Winner",
+    "ttsAnnounceWinnerHint": "Announce the winner at game end",
+    "ttsTested": "Sent",
+    "ttsTestFailed": "Failed"
   },
   "analyticsDashboard": {
     "title": "Beatify Analytics",

--- a/custom_components/beatify/www/i18n/es.json
+++ b/custom_components/beatify/www/i18n/es.json
@@ -364,7 +364,13 @@
     "ttsAnnouncements": "Anuncios TTS",
     "ttsEnabled": "Activar TTS",
     "ttsEntityId": "Entidad TTS",
-    "ttsEntityIdHint": "p.ej. tts.google_es_com"
+    "ttsEntityIdHint": "p.ej. tts.google_es_com",
+    "ttsAnnounceGameStart": "Anunciar inicio del juego",
+    "ttsAnnounceGameStartHint": "Anunciar cuando comienza el juego",
+    "ttsAnnounceWinner": "Anunciar ganador",
+    "ttsAnnounceWinnerHint": "Anunciar al ganador al final del juego",
+    "ttsTested": "Enviado",
+    "ttsTestFailed": "Error"
   },
   "analyticsDashboard": {
     "title": "Estadisticas de Beatify",

--- a/custom_components/beatify/www/i18n/fr.json
+++ b/custom_components/beatify/www/i18n/fr.json
@@ -364,7 +364,13 @@
     "ttsAnnouncements": "Annonces TTS",
     "ttsEnabled": "Activer TTS",
     "ttsEntityId": "Entité TTS",
-    "ttsEntityIdHint": "ex. tts.google_fr_com"
+    "ttsEntityIdHint": "ex. tts.google_fr_com",
+    "ttsAnnounceGameStart": "Annoncer le début",
+    "ttsAnnounceGameStartHint": "Annoncer quand la partie commence",
+    "ttsAnnounceWinner": "Annoncer le gagnant",
+    "ttsAnnounceWinnerHint": "Annoncer le gagnant en fin de partie",
+    "ttsTested": "Envoyé",
+    "ttsTestFailed": "Échec"
   },
   "analyticsDashboard": {
     "title": "Statistiques Beatify",

--- a/custom_components/beatify/www/i18n/nl.json
+++ b/custom_components/beatify/www/i18n/nl.json
@@ -364,7 +364,13 @@
     "ttsAnnouncements": "TTS-aankondigingen",
     "ttsEnabled": "TTS inschakelen",
     "ttsEntityId": "TTS-entiteit",
-    "ttsEntityIdHint": "bijv. tts.google_nl_com"
+    "ttsEntityIdHint": "bijv. tts.google_nl_com",
+    "ttsAnnounceGameStart": "Spelstart aankondigen",
+    "ttsAnnounceGameStartHint": "Aankondigen wanneer het spel begint",
+    "ttsAnnounceWinner": "Winnaar aankondigen",
+    "ttsAnnounceWinnerHint": "Aankondigen van de winnaar aan het einde",
+    "ttsTested": "Verzonden",
+    "ttsTestFailed": "Mislukt"
   },
   "analyticsDashboard": {
     "title": "Beatify Analytics",

--- a/custom_components/beatify/www/js/tts-settings.js
+++ b/custom_components/beatify/www/js/tts-settings.js
@@ -7,12 +7,16 @@
     var STORAGE_KEY = 'beatify_tts';
     var ttsEnabled = false;
     var ttsEntityId = '';
+    var announceGameStart = true;
+    var announceWinner = true;
 
     function loadState() {
         try {
             var saved = JSON.parse(localStorage.getItem(STORAGE_KEY) || '{}');
             ttsEnabled = saved.enabled || false;
             ttsEntityId = saved.entity_id || '';
+            announceGameStart = saved.announce_game_start !== false;
+            announceWinner = saved.announce_winner !== false;
         } catch (e) { /* ignore */ }
     }
 
@@ -20,7 +24,9 @@
         try {
             localStorage.setItem(STORAGE_KEY, JSON.stringify({
                 enabled: ttsEnabled,
-                entity_id: ttsEntityId
+                entity_id: ttsEntityId,
+                announce_game_start: announceGameStart,
+                announce_winner: announceWinner
             }));
         } catch (e) { /* ignore */ }
     }
@@ -29,6 +35,13 @@
         var summary = document.getElementById('tts-settings-summary');
         if (summary) {
             summary.textContent = ttsEnabled && ttsEntityId ? ttsEntityId : 'Off';
+        }
+    }
+
+    function updateTestButton() {
+        var testBtn = document.getElementById('tts-test');
+        if (testBtn) {
+            testBtn.disabled = !ttsEnabled || !ttsEntityId;
         }
     }
 
@@ -42,6 +55,7 @@
             enableToggle.addEventListener('change', function() {
                 ttsEnabled = this.checked;
                 updateSummary();
+                updateTestButton();
                 saveState();
             });
         }
@@ -53,7 +67,55 @@
             entityInput.addEventListener('input', function() {
                 ttsEntityId = this.value.trim();
                 updateSummary();
+                updateTestButton();
                 saveState();
+            });
+        }
+
+        // Announce game start toggle
+        var gameStartToggle = document.getElementById('tts-announce-game-start');
+        if (gameStartToggle) {
+            gameStartToggle.checked = announceGameStart;
+            gameStartToggle.addEventListener('change', function() {
+                announceGameStart = this.checked;
+                saveState();
+            });
+        }
+
+        // Announce winner toggle
+        var winnerToggle = document.getElementById('tts-announce-winner');
+        if (winnerToggle) {
+            winnerToggle.checked = announceWinner;
+            winnerToggle.addEventListener('change', function() {
+                announceWinner = this.checked;
+                saveState();
+            });
+        }
+
+        // Test TTS button
+        var testBtn = document.getElementById('tts-test');
+        if (testBtn) {
+            testBtn.addEventListener('click', function() {
+                if (!ttsEntityId) return;
+                testBtn.disabled = true;
+                testBtn.textContent = '🔊 ...';
+
+                fetch('/beatify/api/tts-test', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ entity_id: ttsEntityId, message: 'Beatify TTS test \u2014 this is working!' })
+                }).then(function(resp) {
+                    if (!resp.ok) {
+                        testBtn.textContent = '\u2717 ' + (window.BeatifyI18n ? window.BeatifyI18n.t('admin.ttsTestFailed') : 'Failed');
+                        setTimeout(function() { testBtn.textContent = '\uD83D\uDD0A Test TTS'; testBtn.disabled = false; }, 2000);
+                        return;
+                    }
+                    testBtn.textContent = '\u2713 ' + (window.BeatifyI18n ? window.BeatifyI18n.t('admin.ttsTested') : 'Sent');
+                    setTimeout(function() { testBtn.textContent = '\uD83D\uDD0A Test TTS'; testBtn.disabled = false; }, 2000);
+                }).catch(function() {
+                    testBtn.textContent = '\u2717 ' + (window.BeatifyI18n ? window.BeatifyI18n.t('admin.ttsTestFailed') : 'Failed');
+                    setTimeout(function() { testBtn.textContent = '\uD83D\uDD0A Test TTS'; testBtn.disabled = false; }, 2000);
+                });
             });
         }
 
@@ -70,13 +132,16 @@
         }
 
         updateSummary();
+        updateTestButton();
     }
 
     // Expose for admin.js to read when starting game
     window._ttsConfig = function() {
         return {
             enabled: ttsEnabled,
-            entity_id: ttsEntityId
+            entity_id: ttsEntityId,
+            announce_game_start: announceGameStart,
+            announce_winner: announceWinner
         };
     };
 


### PR DESCRIPTION
Enhances TTS settings from #447.

**Per-announcement toggles:**
- Individual checkboxes for game start and winner announcement
- Both default to enabled when TTS is on
- Wired through views.py → state.py → TTSService
- i18n in all 5 languages

**Test button:**
- New `POST /beatify/api/tts-test` endpoint calls `tts.speak` immediately
- Button shows spinner → ✓ Sent / ✗ Failed feedback
- Only active when TTS is enabled with an entity ID