### PR TITLE
fix: add missing await on end_game() calls in views.py (closes #479)

### DIFF
--- a/custom_components/beatify/server/views.py
+++ b/custom_components/beatify/server/views.py
@@ -261,7 +261,7 @@ class StartGameView(HomeAssistantView):
             if game_state.phase == GamePhase.END:
                 # Game is already finished — auto-clean state so a new game can start
                 # without requiring the user to explicitly dismiss the end screen (#206)
-                game_state.end_game()
+                await game_state.end_game()
             else:
                 return web.json_response(
                     {"error": "GAME_ALREADY_STARTED", "message": "End current game first"},
@@ -550,7 +550,7 @@ class EndGameView(HomeAssistantView):
                 status=403,
             )
 
-        game_state.end_game()
+        await game_state.end_game()
 
         # Broadcast game_ended to WebSocket clients so players clean up properly
         ws_handler = data.get("ws_handler")


### PR DESCRIPTION
Fixes #479 — critical bug where `end_game()` was called without `await` in two places in `views.py` (lines 264 and 553). Without await, party lights stay stuck, TTS isn't disabled, and game state isn't cleaned up. Two-character fix with significant impact.