### PR TITLE
fix: add rate limiting to start-game, tts-test, and WebSocket endpoints

### DIFF
--- a/custom_components/beatify/server/views.py
+++ b/custom_components/beatify/server/views.py
@@ -246,12 +246,41 @@ class TtsTestView(HomeAssistantView):
     name = "beatify:api:tts-test"
     requires_auth = False
 
+    RATE_LIMIT_REQUESTS = 5
+    RATE_LIMIT_WINDOW = 60  # seconds
+
     def __init__(self, hass: HomeAssistant) -> None:
         """Initialize view."""
         self.hass = hass
+        self._rate_limits: dict[str, list[float]] = {}
+        self._last_sweep: float = 0.0
+
+    def _check_rate_limit(self, ip: str) -> bool:
+        """Check if IP is within rate limit."""
+        now = time.time()
+        cutoff = now - self.RATE_LIMIT_WINDOW
+        if now - self._last_sweep > 300:
+            self._rate_limits = {
+                k: [t for t in v if t > cutoff]
+                for k, v in self._rate_limits.items()
+                if any(t > cutoff for t in v)
+            }
+            self._last_sweep = now
+        times = [t for t in self._rate_limits.get(ip, []) if t > cutoff]
+        self._rate_limits[ip] = times
+        if len(times) >= self.RATE_LIMIT_REQUESTS:
+            return False
+        times.append(now)
+        return True
 
     async def post(self, request: web.Request) -> web.Response:
         """Speak a test message via TTS."""
+        client_ip = request.remote or "unknown"
+        if not self._check_rate_limit(client_ip):
+            return web.json_response(
+                {"error": "RATE_LIMITED", "message": "Too many requests"},
+                status=429,
+            )
         try:
             body = await request.json()
         except Exception:  # noqa: BLE001
@@ -285,12 +314,42 @@ class StartGameView(HomeAssistantView):
     name = "beatify:api:start-game"
     requires_auth = False
 
+    RATE_LIMIT_REQUESTS = 5
+    RATE_LIMIT_WINDOW = 60  # seconds
+
     def __init__(self, hass: HomeAssistant) -> None:
         """Initialize view."""
         self.hass = hass
+        self._rate_limits: dict[str, list[float]] = {}
+        self._last_sweep: float = 0.0
+
+    def _check_rate_limit(self, ip: str) -> bool:
+        """Check if IP is within rate limit."""
+        now = time.time()
+        cutoff = now - self.RATE_LIMIT_WINDOW
+        if now - self._last_sweep > 300:
+            self._rate_limits = {
+                k: [t for t in v if t > cutoff]
+                for k, v in self._rate_limits.items()
+                if any(t > cutoff for t in v)
+            }
+            self._last_sweep = now
+        times = [t for t in self._rate_limits.get(ip, []) if t > cutoff]
+        self._rate_limits[ip] = times
+        if len(times) >= self.RATE_LIMIT_REQUESTS:
+            return False
+        times.append(now)
+        return True
 
     async def post(self, request: web.Request) -> web.Response:  # noqa: PLR0911, PLR0912
         """Start a new game."""
+        client_ip = request.remote or "unknown"
+        if not self._check_rate_limit(client_ip):
+            return web.json_response(
+                {"error": "RATE_LIMITED", "message": "Too many requests"},
+                status=429,
+            )
+
         data = self.hass.data.get(DOMAIN, {})
         game_state = data.get("game")
 

--- a/custom_components/beatify/server/websocket.py
+++ b/custom_components/beatify/server/websocket.py
@@ -52,6 +52,8 @@ class BeatifyWebSocketHandler:
     # Ping interval in seconds (must be less than proxy timeout, typically 60s)
     # aiohttp's heartbeat sends ping frames automatically
     HEARTBEAT_INTERVAL = 30
+    RATE_LIMIT_CONNECTIONS = 10
+    RATE_LIMIT_WINDOW = 60  # seconds
 
     def __init__(self, hass: HomeAssistant) -> None:
         """
@@ -69,6 +71,8 @@ class BeatifyWebSocketHandler:
         # Debouncing for concurrent player joins (Issue #41)
         self._broadcast_debounce_task: asyncio.Task | None = None
         self._broadcast_debounce_delay = 0.05  # 50ms
+        self._connection_rate_limits: dict[str, list[float]] = {}
+        self._last_rate_sweep: float = 0.0
 
     def set_analytics(self, analytics: AnalyticsStorage) -> None:
         """
@@ -92,6 +96,24 @@ class BeatifyWebSocketHandler:
         if self._analytics:
             self._analytics.record_error(error_type, message)
 
+    def _check_connection_rate_limit(self, ip: str) -> bool:
+        """Check if IP is within WebSocket connection rate limit."""
+        now = time.time()
+        cutoff = now - self.RATE_LIMIT_WINDOW
+        if now - self._last_rate_sweep > 300:
+            self._connection_rate_limits = {
+                k: [t for t in v if t > cutoff]
+                for k, v in self._connection_rate_limits.items()
+                if any(t > cutoff for t in v)
+            }
+            self._last_rate_sweep = now
+        times = [t for t in self._connection_rate_limits.get(ip, []) if t > cutoff]
+        self._connection_rate_limits[ip] = times
+        if len(times) >= self.RATE_LIMIT_CONNECTIONS:
+            return False
+        times.append(now)
+        return True
+
     async def handle(self, request: web.Request) -> web.WebSocketResponse:
         """
         Handle WebSocket connection.
@@ -103,6 +125,10 @@ class BeatifyWebSocketHandler:
             WebSocket response
 
         """
+        client_ip = request.remote or "unknown"
+        if not self._check_connection_rate_limit(client_ip):
+            return web.Response(status=429, text="Too many connections")
+
         # heartbeat parameter enables automatic ping/pong to prevent proxy timeouts
         ws = web.WebSocketResponse(heartbeat=self.HEARTBEAT_INTERVAL)
         await ws.prepare(request)

--- a/custom_components/beatify/server/websocket.py
+++ b/custom_components/beatify/server/websocket.py
@@ -114,7 +114,7 @@ class BeatifyWebSocketHandler:
         times.append(now)
         return True
 
-    async def handle(self, request: web.Request) -> web.WebSocketResponse:
+    async def handle(self, request: web.Request) -> web.StreamResponse:
         """
         Handle WebSocket connection.
 


### PR DESCRIPTION
## Summary
- Adds IP-based rate limiting to `StartGameView` (5 req/min), `TtsTestView` (5 req/min), and `BeatifyWebSocketHandler` (10 conn/min)
- Uses the same rate-limiting pattern already established in `AnalyticsView` and `PlaylistRequestsView`

Closes #491

## Test plan
- [ ] Verify normal game start flow still works
- [ ] Verify TTS test still works
- [ ] Verify WebSocket connections still work for players joining
- [ ] Rapidly hit `/api/start-game` > 5 times in 60s — should get 429
- [ ] Rapidly hit `/api/tts-test` > 5 times in 60s — should get 429
- [ ] Open > 10 WebSocket connections in 60s — should get 429

🤖 Generated with [Claude Code](https://claude.com/claude-code)