### PR TITLE
fix: keep round_scores in sync when correct_year is None

### DIFF
--- a/custom_components/beatify/game/player.py
+++ b/custom_components/beatify/game/player.py
@@ -71,7 +71,7 @@ class PlayerSession:
 
     # Final stats tracking (Story 5.6) - CUMULATIVE, NOT reset in reset_round()
     best_streak: int = 0  # Highest streak achieved during game
-    rounds_played: int = 0  # Rounds where player submitted
+    rounds_played: int = 0  # Rounds the player participated in
     bets_won: int = 0  # Successful bets
 
     # Superlative tracking (Story 15.2) - CUMULATIVE, NOT reset in reset_round()

--- a/custom_components/beatify/game/scoring.py
+++ b/custom_components/beatify/game/scoring.py
@@ -644,3 +644,5 @@ class ScoringService:
                 player.score += player.artist_bonus
             _score_movie_challenge(player, movie_challenge, add_to_score=True)
             player.intro_bonus = 0
+            player.rounds_played += 1
+            player.round_scores.append(0)


### PR DESCRIPTION
## Summary
- Appends `0` to `player.round_scores` and increments `rounds_played` in the else branch of `score_player_round`
- Previously, when `correct_year` was `None` or a player didn't submit, `round_scores` was not updated, causing it to fall out of sync with `rounds_played`
- This broke `final_three_score` and `_superlative_comeback_king` analytics which assume `len(round_scores) == rounds_played`

Closes #492

## Test plan
- [ ] Play a round where the song has no year metadata — verify `round_scores` length matches `rounds_played`
- [ ] Verify comeback king and final three score analytics still work correctly
- [ ] Verify a player who misses a round gets `0` appended to their scores

🤖 Generated with [Claude Code](https://claude.com/claude-code)