### PR TITLE
fix: use STREAK_MILESTONES const for highlight recording

### DIFF
--- a/custom_components/beatify/game/state.py
+++ b/custom_components/beatify/game/state.py
@@ -45,6 +45,7 @@ from custom_components.beatify.const import (
     PROVIDER_DEFAULT,
     ROUND_DURATION_MAX,
     ROUND_DURATION_MIN,
+    STREAK_MILESTONES,
     VOLUME_STEP,
 )
 
@@ -1632,7 +1633,7 @@ class GameState:
                 )
 
             # Streak milestones (3, 5, 7+)
-            if player.streak in (3, 5, 7):
+            if player.streak in STREAK_MILESTONES:
                 self.highlights_tracker.record_streak(
                     player.name, player.streak, self.round
                 )


### PR DESCRIPTION
## Summary
- Replaces hardcoded `(3, 5, 7)` with `STREAK_MILESTONES` from const
- Streaks of 10, 15, 20, 25 now appear in the highlights reel

Closes #495

## Test plan
- [ ] Achieve a 10+ streak — verify it appears in end-game highlights
- [ ] Verify 3 and 5 streaks still trigger highlights

🤖 Generated with [Claude Code](https://claude.com/claude-code)