### PR TITLE
fix: cancel existing timers in confirm_intro_splash to prevent leak

### DIFF
--- a/custom_components/beatify/game/round_manager.py
+++ b/custom_components/beatify/game/round_manager.py
@@ -330,6 +330,10 @@ class RoundManager:
         if song:
             await play_deferred_song(song)
 
+        # Cancel any existing timers to prevent leaks on double-tap (#493)
+        self.cancel_timer()
+        self._cancel_intro_timer()
+
         # Recalculate deadline from now
         now = self._now()
         self.round_start_time = now


### PR DESCRIPTION
## Summary
- Adds `cancel_timer()` and `_cancel_intro_timer()` calls before creating new tasks in `confirm_intro_splash`
- Prevents timer task leak on admin double-tap that could cause a race condition and spurious REVEAL broadcast

Closes #493

## Test plan
- [ ] Rapidly double-tap intro splash confirm — verify only one round timer runs
- [ ] Verify normal intro splash flow still works correctly
- [ ] Verify round ends cleanly after intro confirmation

🤖 Generated with [Claude Code](https://claude.com/claude-code)