### PR TITLE
fix: use actual playing time for intro timer on resume

### DIFF
--- a/custom_components/beatify/game/state.py
+++ b/custom_components/beatify/game/state.py
@@ -961,12 +961,13 @@ class GameState:
                 _LOGGER.info("Timer restarted with %.1fs remaining", remaining_seconds)
 
                 # Issue #416: Restart intro stop timer if this was an intro round
+                # Issue #496: Use actual playing time (excludes pause duration)
                 if (
                     self.is_intro_round
                     and not self.intro_stopped
                     and self._intro_round_start_time is not None
                 ):
-                    elapsed_intro = self._now() - self._intro_round_start_time
+                    elapsed_intro = self._round_manager.round_duration - remaining_seconds
                     remaining_intro = INTRO_DURATION_SECONDS - elapsed_intro
                     if remaining_intro > 0:
                         self._round_manager._intro_stop_task = asyncio.create_task(


### PR DESCRIPTION
## Summary
- Fixes intro auto-stop timer after pause/resume computing elapsed time from wall-clock (including pause duration)
- Now derives elapsed intro time from `round_duration - remaining_seconds`, which correctly excludes pause time
- Previously, a long pause could cause `remaining_intro` to go negative, preventing the intro from ever auto-stopping

Closes #496

## Test plan
- [ ] Start an intro round, pause the game for >30s, resume — verify intro auto-stops correctly
- [ ] Start an intro round without pausing — verify intro auto-stop still works
- [ ] Pause during a non-intro round and resume — verify no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)