### PR TITLE
fix: exclude unscored players from late-joiner average score

### DIFF
--- a/custom_components/beatify/game/player_registry.py
+++ b/custom_components/beatify/game/player_registry.py
@@ -200,11 +200,18 @@ class PlayerRegistry:
         return all(p.submitted for p in connected_players)
 
     def get_average_score(self) -> int:
-        """Calculate average score of all current players."""
-        if not self.players:
+        """Calculate average score for late joiners.
+
+        Uses only players who have completed at least one round to avoid
+        inflating the average with other late joiners' initial scores (#494).
+        """
+        scored_players = [
+            p for p in self.players.values() if p.rounds_played > 0
+        ]
+        if not scored_players:
             return 0
-        total = sum(p.score for p in self.players.values())
-        return round(total / len(self.players))
+        total = sum(p.score for p in scored_players)
+        return round(total / len(scored_players))
 
     def set_admin(self, name: str) -> bool:
         """

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -319,14 +319,27 @@ class TestGetAverageScore:
     def test_single_player(self):
         self.state.add_player("Alice", MagicMock())
         self.state.players["Alice"].score = 40
+        self.state.players["Alice"].rounds_played = 1
         assert self.state.get_average_score() == 40
 
     def test_multiple_players(self):
         self.state.add_player("Alice", MagicMock())
         self.state.add_player("Bob", MagicMock())
         self.state.players["Alice"].score = 40
+        self.state.players["Alice"].rounds_played = 1
         self.state.players["Bob"].score = 60
+        self.state.players["Bob"].rounds_played = 1
         assert self.state.get_average_score() == 50
+
+    def test_excludes_unscored_late_joiners(self):
+        self.state.add_player("Alice", MagicMock())
+        self.state.add_player("Bob", MagicMock())
+        self.state.players["Alice"].score = 40
+        self.state.players["Alice"].rounds_played = 1
+        # Bob is a late joiner with no rounds played
+        self.state.players["Bob"].score = 40
+        self.state.players["Bob"].rounds_played = 0
+        assert self.state.get_average_score() == 40
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `get_average_score` now only considers players with `rounds_played > 0`
- Prevents cascading inflation: previously, late joiners who received the average but hadn't been scored yet were included in the average for the next late joiner
- Addresses the closest-wins mode concern where scores can be zeroed post-scoring

Closes #494

## Test plan
- [ ] Two players join mid-game in sequence — verify second late joiner doesn't get an inflated score from the first
- [ ] Late joiner in closest-wins mode — verify initial score reflects post-zeroing averages
- [ ] No late joiners — verify regular scoring is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)