### PR TITLE
data: add Gen Z Anthems playlist (2009–2024)

### DIFF
--- a/custom_components/beatify/playlists/gen-z-anthems.json
+++ b/custom_components/beatify/playlists/gen-z-anthems.json
@@ -1,0 +1,1177 @@
+{
+  "name": "Gen Z Anthems",
+  "version": "1.0",
+  "tags": [
+    "2010s",
+    "2020s",
+    "gen-z",
+    "pop",
+    "viral",
+    "hits"
+  ],
+  "songs": [
+    {
+      "year": 2009,
+      "uri": "spotify:track:0HPD5WQqrq7wPWR7P7Dw1i",
+      "artist": "Ke$ha",
+      "alt_artists": [
+        "Katy Perry",
+        "Lady Gaga",
+        "Taio Cruz",
+        "LMFAO"
+      ],
+      "title": "TiK ToK",
+      "chart_info": {
+        "billboard_peak": 1,
+        "uk_peak": 1,
+        "weeks_on_chart": 35
+      },
+      "certifications": [
+        "Diamond (US)",
+        "Platinum (UK)",
+        "Platinum (AU)"
+      ],
+      "awards": [],
+      "fun_fact": "TiK ToK was the best-selling digital single worldwide in 2010, moving over 16.5 million copies — lowkey one of the most iconic pop debuts ever.",
+      "fun_fact_de": "TiK ToK war 2010 die meistverkaufte digitale Single weltweit mit über 16,5 Millionen verkauften Exemplaren — eines der ikonischsten Pop-Debüts aller Zeiten.",
+      "fun_fact_es": "TiK ToK fue el sencillo digital más vendido del mundo en 2010, con más de 16,5 millones de copias — uno de los debuts pop más icónicos de la historia.",
+      "fun_fact_fr": "TiK ToK a été le single numérique le plus vendu au monde en 2010, avec plus de 16,5 millions d'exemplaires — l'un des débuts pop les plus iconiques de tous les temps.",
+      "uri_apple_music": "applemusic://track/1440768498",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=iP6XpLQM2Cs",
+      "uri_tidal": "tidal://track/2497014",
+      "uri_deezer": "deezer://track/6562012",
+      "fun_fact_nl": "TiK ToK was in 2010 de bestverkochte digitale single ter wereld met meer dan 16,5 miljoen exemplaren — een van de meest iconische popdebuuts ooit.",
+      "awards_nl": []
+    },
+    {
+      "year": 2011,
+      "uri": "spotify:track:4VbDJMkAX3dWNBdn3KH6Wx",
+      "artist": "LMFAO",
+      "alt_artists": [
+        "Flo Rida",
+        "Pitbull",
+        "David Guetta",
+        "Far East Movement"
+      ],
+      "title": "Party Rock Anthem",
+      "chart_info": {
+        "billboard_peak": 1,
+        "uk_peak": 1,
+        "weeks_on_chart": 40
+      },
+      "certifications": [
+        "Diamond (US)",
+        "Platinum (UK)",
+        "Platinum (AU)"
+      ],
+      "awards": [
+        "Billboard Music Award - Top Hot 100 Song"
+      ],
+      "awards_fr": [
+        "Billboard Music Award - Meilleure chanson du Hot 100"
+      ],
+      "fun_fact": "The shuffling dance craze from this song literally took over every school dance and wedding in 2011 — the music video has over 2 billion YouTube views.",
+      "fun_fact_de": "Der Shuffling-Tanztrend aus diesem Song übernahm 2011 buchstäblich jede Schuldisco und Hochzeit — das Musikvideo hat über 2 Milliarden YouTube-Aufrufe.",
+      "fun_fact_es": "La moda del baile shuffling de esta canción se apoderó de cada baile escolar y boda en 2011 — el video musical tiene más de 2 mil millones de vistas en YouTube.",
+      "fun_fact_fr": "La mode du shuffling lancée par ce morceau a envahi chaque soirée et mariage en 2011 — le clip a dépassé les 2 milliards de vues sur YouTube.",
+      "uri_apple_music": "applemusic://track/1440830262",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=KQ6zr6kCPj8",
+      "uri_tidal": "tidal://track/17837023",
+      "uri_deezer": "deezer://track/12078166",
+      "fun_fact_nl": "De shuffling-dansrage uit dit nummer nam in 2011 letterlijk elk schoolfeest en elke bruiloft over — de videoclip heeft meer dan 2 miljard views op YouTube.",
+      "awards_nl": [
+        "Billboard Music Award - Beste Hot 100 Nummer"
+      ]
+    },
+    {
+      "year": 2011,
+      "uri": "spotify:track:1qDrWA6lyx8cLECdZE7TV7",
+      "artist": "Gotye ft. Kimbra",
+      "alt_artists": [
+        "Foster the People",
+        "fun.",
+        "Passion Pit",
+        "Walk the Moon"
+      ],
+      "title": "Somebody That I Used to Know",
+      "chart_info": {
+        "billboard_peak": 1,
+        "uk_peak": 1,
+        "weeks_on_chart": 59
+      },
+      "certifications": [
+        "Diamond (US)",
+        "4x Platinum (UK)",
+        "6x Platinum (AU)"
+      ],
+      "awards": [
+        "Grammy Award - Record of the Year",
+        "Grammy Award - Best Pop Duo/Group Performance"
+      ],
+      "awards_fr": [
+        "Grammy Award - Enregistrement de l'année",
+        "Grammy Award - Meilleure performance pop en duo/groupe"
+      ],
+      "fun_fact": "Gotye was so bothered by bad parodies of this song that he made a supercut of them called 'Somebodies' — the man really said 'enough.'",
+      "fun_fact_de": "Gotye war so genervt von schlechten Parodien dieses Songs, dass er einen Zusammenschnitt namens 'Somebodies' erstellte — der Mann sagte einfach 'genug.'",
+      "fun_fact_es": "Gotye estaba tan molesto con las malas parodias de esta canción que hizo un supercut llamado 'Somebodies' — literalmente dijo 'basta.'",
+      "fun_fact_fr": "Gotye était tellement agacé par les mauvaises parodies qu'il en a fait un montage appelé 'Somebodies' — il a littéralement dit 'ça suffit.'",
+      "uri_apple_music": "applemusic://track/1440831588",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=8UVNT4wvIGY",
+      "uri_tidal": "tidal://track/18498825",
+      "uri_deezer": "deezer://track/15476486",
+      "fun_fact_nl": "Gotye was zo gefrustreerd door slechte parodieën van dit nummer dat hij er een supercut van maakte genaamd 'Somebodies' — de man zei letterlijk 'genoeg.'",
+      "awards_nl": [
+        "Grammy Award - Opname van het Jaar",
+        "Grammy Award - Beste Pop Duo/Groepsprestatie"
+      ]
+    },
+    {
+      "year": 2012,
+      "uri": "spotify:track:20I6sIOMTCkB6w7ryavxtO",
+      "artist": "Carly Rae Jepsen",
+      "alt_artists": [
+        "Owl City",
+        "Icona Pop",
+        "Cher Lloyd",
+        "Demi Lovato"
+      ],
+      "title": "Call Me Maybe",
+      "chart_info": {
+        "billboard_peak": 1,
+        "uk_peak": 1,
+        "weeks_on_chart": 46
+      },
+      "certifications": [
+        "Diamond (US)",
+        "Platinum (UK)",
+        "4x Platinum (AU)"
+      ],
+      "awards": [],
+      "fun_fact": "The song went viral after Justin Bieber and Selena Gomez posted a lip-sync video — it became the most Shazamed song of 2012 and a total vibe.",
+      "fun_fact_de": "Der Song ging viral, nachdem Justin Bieber und Selena Gomez ein Lippensynchron-Video gepostet hatten — er wurde 2012 der meistgesuchte Song auf Shazam.",
+      "fun_fact_es": "La canción se hizo viral después de que Justin Bieber y Selena Gomez publicaran un video haciendo playback — se convirtió en la canción más buscada en Shazam en 2012.",
+      "fun_fact_fr": "La chanson est devenue virale après que Justin Bieber et Selena Gomez ont publié une vidéo en playback — elle est devenue le titre le plus recherché sur Shazam en 2012.",
+      "uri_apple_music": "applemusic://track/1440876289",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=fWNaR-rxAic",
+      "uri_tidal": "tidal://track/21362498",
+      "uri_deezer": "deezer://track/16432853",
+      "fun_fact_nl": "Het nummer ging viraal nadat Justin Bieber en Selena Gomez een lipsync-video hadden gepost — het werd het meest ge-Shazamde nummer van 2012.",
+      "awards_nl": []
+    },
+    {
+      "year": 2013,
+      "uri": "spotify:track:2dLLR6qlu5UJ5gk0dKz0h3",
+      "artist": "Lorde",
+      "alt_artists": [
+        "Lana Del Rey",
+        "Charli XCX",
+        "Halsey",
+        "Billie Eilish"
+      ],
+      "title": "Royals",
+      "chart_info": {
+        "billboard_peak": 1,
+        "uk_peak": 1,
+        "weeks_on_chart": 42
+      },
+      "certifications": [
+        "Diamond (US)",
+        "Platinum (UK)",
+        "3x Platinum (AU)"
+      ],
+      "awards": [
+        "Grammy Award - Song of the Year",
+        "Grammy Award - Best Pop Solo Performance"
+      ],
+      "awards_fr": [
+        "Grammy Award - Chanson de l'année",
+        "Grammy Award - Meilleure performance pop solo"
+      ],
+      "fun_fact": "Lorde wrote Royals at age 16 after seeing a photo of Kansas City Royals baseball players — she had no idea it was a sports team, truly iconic Gen Z energy.",
+      "fun_fact_de": "Lorde schrieb Royals mit 16 Jahren, nachdem sie ein Foto von Baseballspielern der Kansas City Royals gesehen hatte — sie wusste nicht einmal, dass es ein Sportteam war.",
+      "fun_fact_es": "Lorde escribió Royals a los 16 años después de ver una foto de los jugadores de béisbol Kansas City Royals — ni siquiera sabía que era un equipo deportivo.",
+      "fun_fact_fr": "Lorde a écrit Royals à 16 ans après avoir vu une photo des joueurs de baseball des Kansas City Royals — elle ignorait que c'était une équipe sportive.",
+      "uri_apple_music": "applemusic://track/1440818734",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=nlcIKh6sBtc",
+      "uri_tidal": "tidal://track/29519028",
+      "uri_deezer": "deezer://track/67238735",
+      "fun_fact_nl": "Lorde schreef Royals op 16-jarige leeftijd na het zien van een foto van de Kansas City Royals honkbalspelers — ze wist niet eens dat het een sportteam was.",
+      "awards_nl": [
+        "Grammy Award - Nummer van het Jaar",
+        "Grammy Award - Beste Pop Solo Prestatie"
+      ]
+    },
+    {
+      "year": 2013,
+      "uri": "spotify:track:60nZcImufyMA1MKQY3dcCH",
+      "artist": "Pharrell Williams",
+      "alt_artists": [
+        "Bruno Mars",
+        "Jason Derulo",
+        "will.i.am",
+        "Mark Ronson"
+      ],
+      "title": "Happy",
+      "chart_info": {
+        "billboard_peak": 1,
+        "uk_peak": 1,
+        "weeks_on_chart": 52
+      },
+      "certifications": [
+        "Diamond (US)",
+        "4x Platinum (UK)",
+        "4x Platinum (AU)"
+      ],
+      "awards": [
+        "Grammy Award - Best Music Video",
+        "Grammy Award - Best Pop Solo Performance"
+      ],
+      "awards_fr": [
+        "Grammy Award - Meilleur clip vidéo",
+        "Grammy Award - Meilleure performance pop solo"
+      ],
+      "fun_fact": "The music video for Happy was the world's first 24-hour music video, featuring 400 people dancing through Los Angeles — it's genuinely unhinged in the best way.",
+      "fun_fact_de": "Das Musikvideo zu Happy war das weltweit erste 24-Stunden-Musikvideo mit 400 tanzenden Menschen in Los Angeles — auf die beste Art verrückt.",
+      "fun_fact_es": "El video musical de Happy fue el primer video musical de 24 horas del mundo, con 400 personas bailando por Los Ángeles — una locura en el mejor sentido.",
+      "fun_fact_fr": "Le clip de Happy a été le premier clip musical de 24 heures au monde, montrant 400 personnes dansant à travers Los Angeles — complètement fou dans le meilleur sens du terme.",
+      "uri_apple_music": "applemusic://track/1440860580",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=ZbZSe6N_BXs",
+      "uri_tidal": "tidal://track/28929093",
+      "uri_deezer": "deezer://track/68479562",
+      "fun_fact_nl": "De videoclip van Happy was 's werelds eerste 24-uur durende muziekvideo, met 400 mensen die door Los Angeles dansten — op de beste manier gestoord.",
+      "awards_nl": [
+        "Grammy Award - Beste Muziekvideo",
+        "Grammy Award - Beste Pop Solo Prestatie"
+      ]
+    },
+    {
+      "year": 2015,
+      "uri": "spotify:track:2d8cjpr29JCBIDwDqPwJiA",
+      "artist": "Fetty Wap",
+      "alt_artists": [
+        "Post Malone",
+        "Desiigner",
+        "Rae Sremmurd",
+        "Lil Uzi Vert"
+      ],
+      "title": "Trap Queen",
+      "chart_info": {
+        "billboard_peak": 2,
+        "uk_peak": 4,
+        "weeks_on_chart": 44
+      },
+      "certifications": [
+        "6x Platinum (US)",
+        "Platinum (UK)"
+      ],
+      "awards": [],
+      "fun_fact": "Fetty Wap recorded Trap Queen in his grandmother's basement with a $20 microphone from Amazon — proof that talent doesn't need a studio budget.",
+      "fun_fact_de": "Fetty Wap nahm Trap Queen im Keller seiner Großmutter mit einem 20-Dollar-Mikrofon von Amazon auf — Beweis, dass Talent kein Studiobudget braucht.",
+      "fun_fact_es": "Fetty Wap grabó Trap Queen en el sótano de su abuela con un micrófono de $20 de Amazon — prueba de que el talento no necesita presupuesto de estudio.",
+      "fun_fact_fr": "Fetty Wap a enregistré Trap Queen dans le sous-sol de sa grand-mère avec un micro à 20 dollars d'Amazon — la preuve que le talent n'a pas besoin d'un budget studio.",
+      "uri_apple_music": "applemusic://track/1440880099",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=i_kF4zLNKio",
+      "uri_tidal": "tidal://track/40208747",
+      "uri_deezer": "deezer://track/86643966",
+      "fun_fact_nl": "Fetty Wap nam Trap Queen op in de kelder van zijn oma met een microfoon van 20 dollar van Amazon — bewijs dat talent geen studiobudget nodig heeft.",
+      "awards_nl": []
+    },
+    {
+      "year": 2015,
+      "uri": "spotify:track:4sPmO7WMQUAf45kwMOtONw",
+      "artist": "Adele",
+      "alt_artists": [
+        "Sam Smith",
+        "Lewis Capaldi",
+        "Amy Winehouse",
+        "Florence + The Machine"
+      ],
+      "title": "Hello",
+      "chart_info": {
+        "billboard_peak": 1,
+        "uk_peak": 1,
+        "weeks_on_chart": 34
+      },
+      "certifications": [
+        "Diamond (US)",
+        "3x Platinum (UK)",
+        "5x Platinum (AU)"
+      ],
+      "awards": [
+        "Grammy Award - Record of the Year",
+        "Grammy Award - Song of the Year",
+        "Grammy Award - Best Pop Solo Performance"
+      ],
+      "awards_fr": [
+        "Grammy Award - Enregistrement de l'année",
+        "Grammy Award - Chanson de l'année",
+        "Grammy Award - Meilleure performance pop solo"
+      ],
+      "fun_fact": "Hello sold over 1.1 million digital copies in its first week in the US alone, making it the first song to sell a million downloads in a single week — absolutely unreal numbers.",
+      "fun_fact_de": "Hello verkaufte in der ersten Woche allein in den USA über 1,1 Millionen digitale Exemplare und war damit der erste Song, der in einer Woche eine Million Downloads erreichte.",
+      "fun_fact_es": "Hello vendió más de 1,1 millones de copias digitales en su primera semana solo en EE.UU., convirtiéndose en la primera canción en vender un millón de descargas en una sola semana.",
+      "fun_fact_fr": "Hello s'est vendu à plus de 1,1 million d'exemplaires numériques lors de sa première semaine aux États-Unis, devenant le premier titre à se vendre à un million de téléchargements en une seule semaine.",
+      "uri_apple_music": "applemusic://track/1544494403",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=YQHsXMglC9A",
+      "uri_tidal": "tidal://track/52570843",
+      "uri_deezer": "deezer://track/108057684",
+      "fun_fact_nl": "Hello verkocht in de eerste week alleen al in de VS meer dan 1,1 miljoen digitale exemplaren — het eerste nummer ooit dat in één week een miljoen downloads verkocht.",
+      "awards_nl": [
+        "Grammy Award - Opname van het Jaar",
+        "Grammy Award - Nummer van het Jaar",
+        "Grammy Award - Beste Pop Solo Prestatie"
+      ]
+    },
+    {
+      "year": 2016,
+      "uri": "spotify:track:7BKLCZ1jbUBVqRi2FVlTVw",
+      "artist": "The Chainsmokers ft. Halsey",
+      "alt_artists": [
+        "Marshmello",
+        "Kygo",
+        "Zedd",
+        "Calvin Harris"
+      ],
+      "title": "Closer",
+      "chart_info": {
+        "billboard_peak": 1,
+        "uk_peak": 1,
+        "weeks_on_chart": 52
+      },
+      "certifications": [
+        "Diamond (US)",
+        "3x Platinum (UK)",
+        "5x Platinum (AU)"
+      ],
+      "awards": [],
+      "fun_fact": "Closer spent 12 consecutive weeks at #1 on the Billboard Hot 100 and was basically the unofficial anthem of every college dorm room in 2016.",
+      "fun_fact_de": "Closer war 12 aufeinanderfolgende Wochen auf Platz 1 der Billboard Hot 100 und war quasi die inoffizielle Hymne jedes Studentenwohnheims 2016.",
+      "fun_fact_es": "Closer pasó 12 semanas consecutivas en el #1 del Billboard Hot 100 y fue básicamente el himno no oficial de cada residencia universitaria en 2016.",
+      "fun_fact_fr": "Closer est resté 12 semaines consécutives au sommet du Billboard Hot 100 et était l'hymne officieux de chaque résidence universitaire en 2016.",
+      "uri_apple_music": "applemusic://track/1441373378",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=PT2_F-1esPk",
+      "uri_tidal": "tidal://track/64775565",
+      "uri_deezer": "deezer://track/129876062",
+      "fun_fact_nl": "Closer stond 12 opeenvolgende weken op #1 in de Billboard Hot 100 en was eigenlijk het onofficiële volkslied van elke studentenkamer in 2016.",
+      "awards_nl": []
+    },
+    {
+      "year": 2017,
+      "uri": "spotify:track:7qiZfU4dY1lWllzX7mPBI3",
+      "artist": "Ed Sheeran",
+      "alt_artists": [
+        "Sam Smith",
+        "James Arthur",
+        "Shawn Mendes",
+        "Lewis Capaldi"
+      ],
+      "title": "Shape of You",
+      "chart_info": {
+        "billboard_peak": 1,
+        "uk_peak": 1,
+        "weeks_on_chart": 59
+      },
+      "certifications": [
+        "Diamond (US)",
+        "6x Platinum (UK)",
+        "7x Platinum (AU)"
+      ],
+      "awards": [
+        "Grammy Award - Best Pop Solo Performance",
+        "Billboard Music Award - Top Hot 100 Song"
+      ],
+      "awards_fr": [
+        "Grammy Award - Meilleure performance pop solo",
+        "Billboard Music Award - Meilleure chanson du Hot 100"
+      ],
+      "fun_fact": "Shape of You was originally written for Rihanna, but Ed Sheeran's team convinced him to keep it — it became the most-streamed song on Spotify at the time with over 3 billion streams.",
+      "fun_fact_de": "Shape of You wurde ursprünglich für Rihanna geschrieben, aber Ed Sheerans Team überzeugte ihn, es zu behalten — es wurde mit über 3 Milliarden Streams der meistgestreamte Song auf Spotify.",
+      "fun_fact_es": "Shape of You fue escrita originalmente para Rihanna, pero el equipo de Ed Sheeran lo convenció de quedársela — se convirtió en la canción más reproducida en Spotify con más de 3 mil millones de streams.",
+      "fun_fact_fr": "Shape of You a été écrite à l'origine pour Rihanna, mais l'équipe d'Ed Sheeran l'a convaincu de la garder — elle est devenue le titre le plus écouté sur Spotify avec plus de 3 milliards de streams.",
+      "uri_apple_music": "applemusic://track/1193701079",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=JGwWNGJdvx8",
+      "uri_tidal": "tidal://track/71947921",
+      "uri_deezer": "deezer://track/141446798",
+      "fun_fact_nl": "Shape of You was oorspronkelijk geschreven voor Rihanna, maar Ed Sheerans team overtuigde hem om het zelf te houden — het werd het meest gestreamde nummer op Spotify met meer dan 3 miljard streams.",
+      "awards_nl": [
+        "Grammy Award - Beste Pop Solo Prestatie",
+        "Billboard Music Award - Beste Hot 100 Nummer"
+      ]
+    },
+    {
+      "year": 2017,
+      "uri": "spotify:track:6habFhsOp2NvshLv26DqMb",
+      "artist": "Luis Fonsi ft. Daddy Yankee",
+      "alt_artists": [
+        "J Balvin",
+        "Maluma",
+        "Shakira",
+        "Bad Bunny"
+      ],
+      "title": "Despacito",
+      "chart_info": {
+        "billboard_peak": 1,
+        "uk_peak": 1,
+        "weeks_on_chart": 52
+      },
+      "certifications": [
+        "Diamond (US)",
+        "3x Platinum (UK)",
+        "Diamond (FR)"
+      ],
+      "awards": [
+        "Latin Grammy Award - Record of the Year",
+        "Latin Grammy Award - Song of the Year",
+        "Billboard Music Award - Top Hot 100 Song"
+      ],
+      "awards_fr": [
+        "Latin Grammy Award - Enregistrement de l'année",
+        "Latin Grammy Award - Chanson de l'année",
+        "Billboard Music Award - Meilleure chanson du Hot 100"
+      ],
+      "fun_fact": "Despacito became the first Spanish-language song to hit #1 on the Billboard Hot 100 since 'Macarena' in 1996 and was the first YouTube video to reach 5 billion views.",
+      "fun_fact_de": "Despacito war der erste spanischsprachige Song auf Platz 1 der Billboard Hot 100 seit 'Macarena' 1996 und das erste YouTube-Video mit 5 Milliarden Aufrufen.",
+      "fun_fact_es": "Despacito fue la primera canción en español en llegar al #1 del Billboard Hot 100 desde 'Macarena' en 1996 y fue el primer video de YouTube en alcanzar 5 mil millones de vistas.",
+      "fun_fact_fr": "Despacito est devenue la première chanson en espagnol à atteindre le #1 du Billboard Hot 100 depuis 'Macarena' en 1996 et la première vidéo YouTube à atteindre 5 milliards de vues.",
+      "uri_apple_music": "applemusic://track/1447554425",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=kJQP7kiw5Fk",
+      "uri_tidal": "tidal://track/71867363",
+      "uri_deezer": "deezer://track/144951498",
+      "fun_fact_nl": "Despacito was het eerste Spaanstalige nummer op #1 van de Billboard Hot 100 sinds 'Macarena' in 1996 en de eerste YouTube-video die 5 miljard views bereikte.",
+      "awards_nl": [
+        "Latin Grammy Award - Opname van het Jaar",
+        "Latin Grammy Award - Nummer van het Jaar",
+        "Billboard Music Award - Beste Hot 100 Nummer"
+      ]
+    },
+    {
+      "year": 2018,
+      "uri": "spotify:track:6DCZcSspjsKoFjzjrWoCdn",
+      "artist": "Drake",
+      "alt_artists": [
+        "Kendrick Lamar",
+        "J. Cole",
+        "Travis Scott",
+        "Post Malone"
+      ],
+      "title": "God's Plan",
+      "chart_info": {
+        "billboard_peak": 1,
+        "uk_peak": 1,
+        "weeks_on_chart": 38
+      },
+      "certifications": [
+        "Diamond (US)",
+        "2x Platinum (UK)",
+        "4x Platinum (AU)"
+      ],
+      "awards": [
+        "Grammy Award - Best Rap Song",
+        "Billboard Music Award - Top Hot 100 Song"
+      ],
+      "awards_fr": [
+        "Grammy Award - Meilleure chanson rap",
+        "Billboard Music Award - Meilleure chanson du Hot 100"
+      ],
+      "fun_fact": "Drake gave away the entire $996,631 music video budget to people in Miami — the video shows him handing out cash, paying for groceries, and donating to schools, which is lowkey the most wholesome flex ever.",
+      "fun_fact_de": "Drake verschenkte das gesamte Musikvideo-Budget von 996.631 Dollar an Menschen in Miami — das Video zeigt ihn beim Verteilen von Bargeld, Bezahlen von Einkäufen und Spenden an Schulen.",
+      "fun_fact_es": "Drake regaló los $996,631 del presupuesto del video musical a personas en Miami — el video lo muestra repartiendo dinero, pagando compras y donando a escuelas.",
+      "fun_fact_fr": "Drake a distribué l'intégralité du budget du clip de 996 631 dollars à des habitants de Miami — la vidéo le montre en train de distribuer de l'argent, payer des courses et faire des dons à des écoles.",
+      "uri_apple_music": "applemusic://track/1418213110",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=xpVfcZ0ZcFM",
+      "uri_tidal": "tidal://track/84832078",
+      "uri_deezer": "deezer://track/472975535",
+      "fun_fact_nl": "Drake gaf het volledige muziekvideo-budget van $996.631 weg aan mensen in Miami — de video toont hem terwijl hij geld uitdeelt, boodschappen betaalt en doneert aan scholen.",
+      "awards_nl": [
+        "Grammy Award - Beste Rapnummer",
+        "Billboard Music Award - Beste Hot 100 Nummer"
+      ]
+    },
+    {
+      "year": 2018,
+      "uri": "spotify:track:285pBltuF7vW8TeWk8hdRR",
+      "artist": "Juice WRLD",
+      "alt_artists": [
+        "XXXTentacion",
+        "Lil Peep",
+        "Trippie Redd",
+        "Iann Dior"
+      ],
+      "title": "Lucid Dreams",
+      "chart_info": {
+        "billboard_peak": 2,
+        "uk_peak": 3,
+        "weeks_on_chart": 38
+      },
+      "certifications": [
+        "7x Platinum (US)",
+        "Platinum (UK)",
+        "2x Platinum (AU)"
+      ],
+      "awards": [],
+      "fun_fact": "Juice WRLD freestyled most of his songs and claimed Lucid Dreams was made in about 15 minutes — the track samples Sting's 'Shape of My Heart' and became the anthem of sad hours for an entire generation.",
+      "fun_fact_de": "Juice WRLD freestylte die meisten seiner Songs und behauptete, Lucid Dreams sei in etwa 15 Minuten entstanden — der Track sampelt Stings 'Shape of My Heart' und wurde zur Hymne trauriger Stunden einer ganzen Generation.",
+      "fun_fact_es": "Juice WRLD improvisaba la mayoría de sus canciones y afirmó que Lucid Dreams se hizo en unos 15 minutos — el track samplea 'Shape of My Heart' de Sting y se convirtió en el himno de los momentos tristes de toda una generación.",
+      "fun_fact_fr": "Juice WRLD improvisait la plupart de ses chansons et affirmait que Lucid Dreams avait été créé en environ 15 minutes — le morceau sample 'Shape of My Heart' de Sting et est devenu l'hymne des moments de tristesse de toute une génération.",
+      "uri_apple_music": "applemusic://track/1422675847",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=mzB1VGEGcSU",
+      "uri_tidal": "tidal://track/87697581",
+      "uri_deezer": "deezer://track/493289242",
+      "fun_fact_nl": "Juice WRLD freestylde de meeste van zijn nummers en beweerde dat Lucid Dreams in ongeveer 15 minuten was gemaakt — het nummer samplet Stings 'Shape of My Heart' en werd het volkslied van verdrietige momenten voor een hele generatie.",
+      "awards_nl": []
+    },
+    {
+      "year": 2019,
+      "uri": "spotify:track:2Fxmhks0bxGSBdJ92vM42m",
+      "artist": "Billie Eilish",
+      "alt_artists": [
+        "Olivia Rodrigo",
+        "Lorde",
+        "Halsey",
+        "Melanie Martinez"
+      ],
+      "title": "bad guy",
+      "chart_info": {
+        "billboard_peak": 1,
+        "uk_peak": 1,
+        "weeks_on_chart": 43
+      },
+      "certifications": [
+        "7x Platinum (US)",
+        "3x Platinum (UK)",
+        "4x Platinum (AU)"
+      ],
+      "awards": [
+        "Grammy Award - Record of the Year",
+        "Grammy Award - Song of the Year",
+        "Grammy Award - Best Pop Solo Performance"
+      ],
+      "awards_fr": [
+        "Grammy Award - Enregistrement de l'année",
+        "Grammy Award - Chanson de l'année",
+        "Grammy Award - Meilleure performance pop solo"
+      ],
+      "fun_fact": "Billie and her brother Finneas recorded 'bad guy' and the entire album in his tiny bedroom in Highland Park, LA — they literally made a Grammy-sweeping album in a bedroom, and that's iconic.",
+      "fun_fact_de": "Billie und ihr Bruder Finneas nahmen 'bad guy' und das gesamte Album in seinem kleinen Schlafzimmer in Highland Park, LA auf — sie haben buchstäblich ein Grammy-abräumendes Album im Schlafzimmer gemacht.",
+      "fun_fact_es": "Billie y su hermano Finneas grabaron 'bad guy' y todo el álbum en su pequeña habitación en Highland Park, LA — literalmente hicieron un álbum que arrasó en los Grammy en un dormitorio.",
+      "fun_fact_fr": "Billie et son frère Finneas ont enregistré 'bad guy' et tout l'album dans sa petite chambre à Highland Park, LA — ils ont littéralement créé un album qui a tout raflé aux Grammy dans une chambre à coucher.",
+      "uri_apple_music": "applemusic://track/1450695723",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=DyDfgMOUjCI",
+      "uri_tidal": "tidal://track/105765158",
+      "uri_deezer": "deezer://track/617858982",
+      "fun_fact_nl": "Billie en haar broer Finneas namen 'bad guy' en het hele album op in zijn kleine slaapkamer in Highland Park, LA — ze maakten letterlijk een Grammy-winnend album in een slaapkamer, en dat is iconisch.",
+      "awards_nl": [
+        "Grammy Award - Opname van het Jaar",
+        "Grammy Award - Nummer van het Jaar",
+        "Grammy Award - Beste Pop Solo Prestatie"
+      ]
+    },
+    {
+      "year": 2019,
+      "uri": "spotify:track:2YlZnpMoCluVRiKHatCV4Z",
+      "artist": "Lil Nas X",
+      "alt_artists": [
+        "Jack Harlow",
+        "Lil Uzi Vert",
+        "DaBaby",
+        "Doja Cat"
+      ],
+      "title": "Old Town Road",
+      "chart_info": {
+        "billboard_peak": 1,
+        "uk_peak": 1,
+        "weeks_on_chart": 38
+      },
+      "certifications": [
+        "Diamond (US)",
+        "2x Platinum (UK)",
+        "4x Platinum (AU)"
+      ],
+      "awards": [
+        "Grammy Award - Best Music Video",
+        "CMA Award Nomination - Musical Event of the Year"
+      ],
+      "awards_fr": [
+        "Grammy Award - Meilleur clip vidéo",
+        "Nomination CMA Award - Événement musical de l'année"
+      ],
+      "fun_fact": "Old Town Road held the record for the most consecutive weeks at #1 on the Billboard Hot 100 at 19 weeks, breaking the records set by Mariah Carey and Despacito — it started as a $30 beat from a Dutch producer on a website.",
+      "fun_fact_de": "Old Town Road hielt mit 19 Wochen den Rekord für die meisten aufeinanderfolgenden Wochen auf Platz 1 der Billboard Hot 100 und brach die Rekorde von Mariah Carey und Despacito — es begann als ein 30-Dollar-Beat eines niederländischen Produzenten.",
+      "fun_fact_es": "Old Town Road mantuvo el récord de más semanas consecutivas en el #1 del Billboard Hot 100 con 19 semanas, rompiendo los récords de Mariah Carey y Despacito — empezó como un beat de $30 de un productor holandés.",
+      "fun_fact_fr": "Old Town Road a détenu le record du plus grand nombre de semaines consécutives au #1 du Billboard Hot 100 avec 19 semaines, battant les records de Mariah Carey et Despacito — tout a commencé avec un beat à 30 dollars d'un producteur néerlandais.",
+      "uri_apple_music": "applemusic://track/1463576786",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=r7qovpFAGrQ",
+      "uri_tidal": "tidal://track/107141735",
+      "uri_deezer": "deezer://track/644096882",
+      "fun_fact_nl": "Old Town Road hield het record voor de meeste opeenvolgende weken op #1 van de Billboard Hot 100 met 19 weken — het begon als een beat van 30 dollar van een Nederlandse producer op een website.",
+      "awards_nl": [
+        "Grammy Award - Beste Muziekvideo",
+        "CMA Award Nominatie - Muzikaal Evenement van het Jaar"
+      ]
+    },
+    {
+      "year": 2019,
+      "uri": "spotify:track:7qEHsqek33rTcFNT9PFqLf",
+      "artist": "Lewis Capaldi",
+      "alt_artists": [
+        "Sam Smith",
+        "Adele",
+        "James Arthur",
+        "Dean Lewis"
+      ],
+      "title": "Someone You Loved",
+      "chart_info": {
+        "billboard_peak": 1,
+        "uk_peak": 1,
+        "weeks_on_chart": 45
+      },
+      "certifications": [
+        "6x Platinum (US)",
+        "4x Platinum (UK)",
+        "4x Platinum (AU)"
+      ],
+      "awards": [
+        "Brit Award - Song of the Year"
+      ],
+      "awards_fr": [
+        "Brit Award - Chanson de l'année"
+      ],
+      "fun_fact": "Lewis Capaldi's self-deprecating humor on social media made him a Gen Z icon — he once showed up at Glastonbury holding a Chewbacca mask after his cousin (Peter Capaldi) called him one, absolute legend behavior.",
+      "fun_fact_de": "Lewis Capaldis selbstironischer Humor in sozialen Medien machte ihn zu einer Gen-Z-Ikone — er erschien einmal in Glastonbury mit einer Chewbacca-Maske, nachdem sein Cousin Peter Capaldi ihn so genannt hatte.",
+      "fun_fact_es": "El humor autocrítico de Lewis Capaldi en redes sociales lo convirtió en un ícono de la Gen Z — una vez apareció en Glastonbury con una máscara de Chewbacca después de que su primo Peter Capaldi lo llamara así.",
+      "fun_fact_fr": "L'humour autodérisif de Lewis Capaldi sur les réseaux sociaux en a fait une icône de la Gen Z — il s'est présenté à Glastonbury avec un masque de Chewbacca après que son cousin Peter Capaldi l'ait surnommé ainsi.",
+      "uri_apple_music": "applemusic://track/1468058034",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=zABLecsR5UE",
+      "uri_tidal": "tidal://track/100468522",
+      "uri_deezer": "deezer://track/581686652",
+      "fun_fact_nl": "Lewis Capaldi's zelfspot op sociale media maakte hem een Gen Z-icoon — hij verscheen ooit op Glastonbury met een Chewbacca-masker nadat zijn neef Peter Capaldi hem zo had genoemd.",
+      "awards_nl": [
+        "Brit Award - Nummer van het Jaar"
+      ]
+    },
+    {
+      "year": 2020,
+      "uri": "spotify:track:0VjIjW4GlUZAMYd2vXMi3b",
+      "artist": "The Weeknd",
+      "alt_artists": [
+        "Dua Lipa",
+        "Post Malone",
+        "Bruno Mars",
+        "Harry Styles"
+      ],
+      "title": "Blinding Lights",
+      "chart_info": {
+        "billboard_peak": 1,
+        "uk_peak": 1,
+        "weeks_on_chart": 90
+      },
+      "certifications": [
+        "Diamond (US)",
+        "5x Platinum (UK)",
+        "6x Platinum (AU)"
+      ],
+      "awards": [
+        "Billboard Music Award - Top Hot 100 Song",
+        "Juno Award - Single of the Year",
+        "American Music Award - Favorite Song Pop/Rock"
+      ],
+      "awards_fr": [
+        "Billboard Music Award - Meilleure chanson du Hot 100",
+        "Juno Award - Single de l'année",
+        "American Music Award - Chanson préférée Pop/Rock"
+      ],
+      "fun_fact": "Blinding Lights became the #1 song on Billboard's Greatest Songs of All Time chart, spending 90 weeks on the Hot 100 — it was literally declared the biggest song in chart history, and honestly, no one can argue with that.",
+      "fun_fact_de": "Blinding Lights wurde zum #1-Song der Billboard-Liste der größten Songs aller Zeiten und war 90 Wochen in den Hot 100 — es wurde offiziell zum größten Song der Chart-Geschichte erklärt.",
+      "fun_fact_es": "Blinding Lights se convirtió en el #1 de la lista de las mejores canciones de todos los tiempos de Billboard, pasando 90 semanas en el Hot 100 — fue oficialmente declarada la canción más grande en la historia de las listas.",
+      "fun_fact_fr": "Blinding Lights est devenu le #1 du classement des plus grandes chansons de tous les temps de Billboard, restant 90 semaines dans le Hot 100 — officiellement déclarée la plus grande chanson de l'histoire des charts.",
+      "uri_apple_music": "applemusic://track/1488408568",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=4NRXx6U8ABQ",
+      "uri_tidal": "tidal://track/119559498",
+      "uri_deezer": "deezer://track/908604862",
+      "fun_fact_nl": "Blinding Lights werd het #1 nummer op Billboards lijst van de grootste nummers aller tijden, met 90 weken in de Hot 100 — het werd letterlijk uitgeroepen tot het grootste nummer in de chartgeschiedenis.",
+      "awards_nl": [
+        "Billboard Music Award - Beste Hot 100 Nummer",
+        "Juno Award - Single van het Jaar",
+        "American Music Award - Favoriete Pop/Rock Nummer"
+      ]
+    },
+    {
+      "year": 2020,
+      "uri": "spotify:track:463CkQjx2Zk1yXoBuierM9",
+      "artist": "Dua Lipa",
+      "alt_artists": [
+        "Rina Sawayama",
+        "Charli XCX",
+        "Lizzo",
+        "Megan Thee Stallion"
+      ],
+      "title": "Levitating",
+      "chart_info": {
+        "billboard_peak": 2,
+        "uk_peak": 5,
+        "weeks_on_chart": 56
+      },
+      "certifications": [
+        "5x Platinum (US)",
+        "2x Platinum (UK)",
+        "3x Platinum (AU)"
+      ],
+      "awards": [],
+      "fun_fact": "Levitating spent more total weeks on the Billboard Hot 100 than almost any other song in 2021, peaking at #2 — the DaBaby remix gave it a second life, making it the longest-charting song of the year.",
+      "fun_fact_de": "Levitating war 2021 länger in den Billboard Hot 100 als fast jeder andere Song und erreichte Platz 2 — der DaBaby-Remix gab ihm ein zweites Leben und machte es zum am längsten chartenden Song des Jahres.",
+      "fun_fact_es": "Levitating pasó más semanas en el Billboard Hot 100 que casi cualquier otra canción en 2021, alcanzando el #2 — el remix con DaBaby le dio una segunda vida.",
+      "fun_fact_fr": "Levitating a passé plus de semaines au Billboard Hot 100 que presque tout autre titre en 2021, culminant au #2 — le remix avec DaBaby lui a donné une seconde vie.",
+      "uri_apple_music": "applemusic://track/1510821364",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=TUVcZfQe-Kw",
+      "uri_tidal": "tidal://track/132569886",
+      "uri_deezer": "deezer://track/908604872",
+      "fun_fact_nl": "Levitating stond in 2021 meer weken in de Billboard Hot 100 dan bijna elk ander nummer, met een piek op #2 — de DaBaby-remix gaf het een tweede leven.",
+      "awards_nl": []
+    },
+    {
+      "year": 2020,
+      "uri": "spotify:track:6UelLqGlWMcVH1E5c4H7lY",
+      "artist": "Harry Styles",
+      "alt_artists": [
+        "Niall Horan",
+        "Zayn",
+        "Shawn Mendes",
+        "Louis Tomlinson"
+      ],
+      "title": "Watermelon Sugar",
+      "chart_info": {
+        "billboard_peak": 1,
+        "uk_peak": 4,
+        "weeks_on_chart": 38
+      },
+      "certifications": [
+        "5x Platinum (US)",
+        "2x Platinum (UK)",
+        "3x Platinum (AU)"
+      ],
+      "awards": [
+        "Grammy Award - Best Pop Solo Performance"
+      ],
+      "awards_fr": [
+        "Grammy Award - Meilleure performance pop solo"
+      ],
+      "fun_fact": "The music video for Watermelon Sugar was filmed on a beach with a disclaimer that it was 'dedicated to touching' — filmed just before COVID lockdowns, the timing was lowkey poetic.",
+      "fun_fact_de": "Das Musikvideo zu Watermelon Sugar wurde an einem Strand mit dem Hinweis gedreht, dass es 'dem Berühren gewidmet' sei — kurz vor den COVID-Lockdowns gefilmt, war das Timing fast poetisch.",
+      "fun_fact_es": "El video musical de Watermelon Sugar se filmó en una playa con una nota dedicándolo 'al tacto' — filmado justo antes de los confinamientos por COVID, el timing fue casi poético.",
+      "fun_fact_fr": "Le clip de Watermelon Sugar a été tourné sur une plage avec un avertissement dédiant le clip 'au toucher' — tourné juste avant les confinements COVID, le timing était presque poétique.",
+      "uri_apple_music": "applemusic://track/1485802967",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=E07s5ZYadZg",
+      "uri_tidal": "tidal://track/121652223",
+      "uri_deezer": "deezer://track/908605122",
+      "fun_fact_nl": "De videoclip van Watermelon Sugar werd op een strand gefilmd met een disclaimer dat het 'opgedragen aan aanraking' was — gefilmd net voor de COVID-lockdowns, de timing was bijna poëtisch.",
+      "awards_nl": [
+        "Grammy Award - Beste Pop Solo Prestatie"
+      ]
+    },
+    {
+      "year": 2021,
+      "uri": "spotify:track:5wANPM4fQCJwkGd4rN57mH",
+      "artist": "Olivia Rodrigo",
+      "alt_artists": [
+        "Billie Eilish",
+        "Gracie Abrams",
+        "Conan Gray",
+        "Sabrina Carpenter"
+      ],
+      "title": "drivers license",
+      "chart_info": {
+        "billboard_peak": 1,
+        "uk_peak": 1,
+        "weeks_on_chart": 42
+      },
+      "certifications": [
+        "5x Platinum (US)",
+        "3x Platinum (UK)",
+        "3x Platinum (AU)"
+      ],
+      "awards": [],
+      "fun_fact": "drivers license broke the Spotify record for most streams in a single day upon release, and the drama around whether it was about Joshua Bassett and Sabrina Carpenter had the entire internet playing detective.",
+      "fun_fact_de": "drivers license brach bei der Veröffentlichung den Spotify-Rekord für die meisten Streams an einem Tag, und das Drama darüber, ob es um Joshua Bassett und Sabrina Carpenter ging, ließ das gesamte Internet Detektiv spielen.",
+      "fun_fact_es": "drivers license rompió el récord de Spotify de más reproducciones en un solo día al momento de su lanzamiento, y el drama sobre si era sobre Joshua Bassett y Sabrina Carpenter hizo que todo internet jugara al detective.",
+      "fun_fact_fr": "drivers license a battu le record Spotify du plus grand nombre d'écoutes en une seule journée à sa sortie, et le drame autour de savoir si la chanson parlait de Joshua Bassett et Sabrina Carpenter a transformé tout internet en détective.",
+      "uri_apple_music": "applemusic://track/1546055184",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=ZmDBbnmKFnI",
+      "uri_tidal": "tidal://track/168756691",
+      "uri_deezer": "deezer://track/1113250242",
+      "fun_fact_nl": "drivers license brak bij de release het Spotify-record voor de meeste streams op één dag, en het drama over of het over Joshua Bassett en Sabrina Carpenter ging, liet het hele internet detective spelen.",
+      "awards_nl": []
+    },
+    {
+      "year": 2021,
+      "uri": "spotify:track:748mdHapucXQri7IAO8yFK",
+      "artist": "Doja Cat ft. SZA",
+      "alt_artists": [
+        "Megan Thee Stallion",
+        "Saweetie",
+        "Cardi B",
+        "Nicki Minaj"
+      ],
+      "title": "Kiss Me More",
+      "chart_info": {
+        "billboard_peak": 3,
+        "uk_peak": 3,
+        "weeks_on_chart": 36
+      },
+      "certifications": [
+        "5x Platinum (US)",
+        "Platinum (UK)",
+        "2x Platinum (AU)"
+      ],
+      "awards": [
+        "Grammy Award - Best Pop Duo/Group Performance"
+      ],
+      "awards_fr": [
+        "Grammy Award - Meilleure performance pop en duo/groupe"
+      ],
+      "fun_fact": "Kiss Me More was the first collaboration between Doja Cat and SZA, who then became frequent collaborators — the song's dreamy vibe made it the go-to summer anthem of 2021.",
+      "fun_fact_de": "Kiss Me More war die erste Zusammenarbeit zwischen Doja Cat und SZA, die danach häufig zusammenarbeiteten — die verträumte Atmosphäre des Songs machte ihn zur Sommerhymne 2021.",
+      "fun_fact_es": "Kiss Me More fue la primera colaboración entre Doja Cat y SZA, quienes luego se convirtieron en colaboradoras frecuentes — la vibra soñadora de la canción la convirtió en el himno del verano 2021.",
+      "fun_fact_fr": "Kiss Me More a été la première collaboration entre Doja Cat et SZA, qui sont ensuite devenues des collaboratrices régulières — l'ambiance rêveuse du morceau en a fait l'hymne de l'été 2021.",
+      "uri_apple_music": "applemusic://track/1560840714",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=0EVVKs6DQLo",
+      "uri_tidal": "tidal://track/178447625",
+      "uri_deezer": "deezer://track/1218498262",
+      "fun_fact_nl": "Kiss Me More was de eerste samenwerking tussen Doja Cat en SZA, die daarna vaker samenwerkten — de dromerige sfeer van het nummer maakte het tot de zomerhit van 2021.",
+      "awards_nl": [
+        "Grammy Award - Beste Pop Duo/Groepsprestatie"
+      ]
+    },
+    {
+      "year": 2021,
+      "uri": "spotify:track:3Wrjm47oTz2sjIgck11l5e",
+      "artist": "Måneskin",
+      "alt_artists": [
+        "The Struts",
+        "Royal Blood",
+        "Greta Van Fleet",
+        "Nothing But Thieves"
+      ],
+      "title": "Beggin'",
+      "chart_info": {
+        "billboard_peak": 14,
+        "uk_peak": 4,
+        "weeks_on_chart": 28
+      },
+      "certifications": [
+        "4x Platinum (US)",
+        "2x Platinum (UK)",
+        "Platinum (IT)"
+      ],
+      "awards": [],
+      "fun_fact": "Beggin' is actually a cover of a 1967 Four Seasons song — Måneskin's version went viral on TikTok after they won Eurovision 2021, proving that rock music is far from dead.",
+      "fun_fact_de": "Beggin' ist eigentlich ein Cover eines Four-Seasons-Songs von 1967 — Måneskins Version ging auf TikTok viral, nachdem sie 2021 den Eurovision gewonnen hatten, was bewies, dass Rockmusik alles andere als tot ist.",
+      "fun_fact_es": "Beggin' es en realidad un cover de una canción de 1967 de The Four Seasons — la versión de Måneskin se hizo viral en TikTok después de ganar Eurovisión 2021, demostrando que el rock no está muerto.",
+      "fun_fact_fr": "Beggin' est en fait une reprise d'un titre de 1967 des Four Seasons — la version de Måneskin est devenue virale sur TikTok après leur victoire à l'Eurovision 2021, prouvant que le rock est loin d'être mort.",
+      "uri_apple_music": "applemusic://track/1562011758",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=h3dGBJiJbss",
+      "uri_tidal": "tidal://track/107140835",
+      "uri_deezer": "deezer://track/398984872",
+      "fun_fact_nl": "Beggin' is eigenlijk een cover van een nummer van The Four Seasons uit 1967 — de versie van Måneskin ging viraal op TikTok nadat ze het Eurovisie Songfestival 2021 wonnen, wat bewijst dat rockmuziek nog springlevend is.",
+      "awards_nl": []
+    },
+    {
+      "year": 2022,
+      "uri": "spotify:track:1PckUlxKqWQs3RlWXVBLw3",
+      "artist": "Lizzo",
+      "alt_artists": [
+        "Megan Thee Stallion",
+        "Doja Cat",
+        "Cardi B",
+        "SZA"
+      ],
+      "title": "About Damn Time",
+      "chart_info": {
+        "billboard_peak": 1,
+        "uk_peak": 4,
+        "weeks_on_chart": 34
+      },
+      "certifications": [
+        "4x Platinum (US)",
+        "Platinum (UK)",
+        "Platinum (AU)"
+      ],
+      "awards": [
+        "Grammy Award - Record of the Year"
+      ],
+      "awards_fr": [
+        "Grammy Award - Enregistrement de l'année"
+      ],
+      "fun_fact": "About Damn Time went viral on TikTok thanks to a dance created by Jaeden Gomez — the choreography became so popular that Lizzo performed it at the Grammy Awards, and the song won Record of the Year.",
+      "fun_fact_de": "About Damn Time ging auf TikTok dank eines von Jaeden Gomez kreierten Tanzes viral — die Choreografie wurde so beliebt, dass Lizzo sie bei den Grammy Awards aufführte, und der Song gewann die Aufnahme des Jahres.",
+      "fun_fact_es": "About Damn Time se hizo viral en TikTok gracias a un baile creado por Jaeden Gomez — la coreografía se hizo tan popular que Lizzo la interpretó en los Grammy Awards, y la canción ganó Grabación del Año.",
+      "fun_fact_fr": "About Damn Time est devenu viral sur TikTok grâce à une danse créée par Jaeden Gomez — la chorégraphie est devenue si populaire que Lizzo l'a interprétée aux Grammy Awards, et la chanson a remporté l'Enregistrement de l'année.",
+      "uri_apple_music": "applemusic://track/1618040783",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=b3xM-_PzEGs",
+      "uri_tidal": "tidal://track/224103750",
+      "uri_deezer": "deezer://track/1699553217",
+      "fun_fact_nl": "About Damn Time ging viraal op TikTok dankzij een dans gemaakt door Jaeden Gomez — de choreografie werd zo populair dat Lizzo het uitvoerde bij de Grammy Awards, en het nummer won Opname van het Jaar.",
+      "awards_nl": [
+        "Grammy Award - Opname van het Jaar"
+      ]
+    },
+    {
+      "year": 2022,
+      "uri": "spotify:track:4LRPiXqCikLlN15c3yImP7",
+      "artist": "Harry Styles",
+      "alt_artists": [
+        "Niall Horan",
+        "Ed Sheeran",
+        "Shawn Mendes",
+        "Louis Tomlinson"
+      ],
+      "title": "As It Was",
+      "chart_info": {
+        "billboard_peak": 1,
+        "uk_peak": 1,
+        "weeks_on_chart": 52
+      },
+      "certifications": [
+        "6x Platinum (US)",
+        "4x Platinum (UK)",
+        "4x Platinum (AU)"
+      ],
+      "awards": [
+        "Grammy Award - Best Pop Vocal Album (Harry's House)",
+        "Brit Award - Song of the Year"
+      ],
+      "awards_fr": [
+        "Grammy Award - Meilleur album vocal pop (Harry's House)",
+        "Brit Award - Chanson de l'année"
+      ],
+      "fun_fact": "As It Was spent 15 weeks at #1 on the Billboard Hot 100, making it the longest-running #1 of 2022 — the opening synth riff was literally inescapable that entire year.",
+      "fun_fact_de": "As It Was war 15 Wochen auf Platz 1 der Billboard Hot 100 und damit der am längsten auf Platz 1 stehende Song 2022 — das Synth-Riff am Anfang war das ganze Jahr über buchstäblich unausweichlich.",
+      "fun_fact_es": "As It Was pasó 15 semanas en el #1 del Billboard Hot 100, convirtiéndose en el #1 más largo de 2022 — el riff de sintetizador del inicio fue literalmente inescapable ese año.",
+      "fun_fact_fr": "As It Was a passé 15 semaines au #1 du Billboard Hot 100, ce qui en fait le #1 le plus long de 2022 — le riff de synthé d'ouverture était littéralement incontournable cette année-là.",
+      "uri_apple_music": "applemusic://track/1615585008",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=H5v3kku4y6Q",
+      "uri_tidal": "tidal://track/222684565",
+      "uri_deezer": "deezer://track/1685859587",
+      "fun_fact_nl": "As It Was stond 15 weken op #1 van de Billboard Hot 100, waarmee het de langstlopende #1 van 2022 werd — het synth-riff in het begin was dat hele jaar letterlijk onvermijdelijk.",
+      "awards_nl": [
+        "Grammy Award - Beste Pop Vocaal Album (Harry's House)",
+        "Brit Award - Nummer van het Jaar"
+      ]
+    },
+    {
+      "year": 2022,
+      "uri": "spotify:track:1Lo0QY9cvc8sUB2vnIOxDT",
+      "artist": "Steve Lacy",
+      "alt_artists": [
+        "Tyler, the Creator",
+        "Frank Ocean",
+        "Daniel Caesar",
+        "Omar Apollo"
+      ],
+      "title": "Bad Habit",
+      "chart_info": {
+        "billboard_peak": 1,
+        "uk_peak": 4,
+        "weeks_on_chart": 33
+      },
+      "certifications": [
+        "4x Platinum (US)",
+        "Platinum (UK)",
+        "Platinum (AU)"
+      ],
+      "awards": [
+        "Grammy Award - Best Pop Solo Performance"
+      ],
+      "awards_fr": [
+        "Grammy Award - Meilleure performance pop solo"
+      ],
+      "fun_fact": "Steve Lacy recorded much of Bad Habit on his iPhone using GarageBand — the fact that a #1 hit was partly made on a phone is genuinely the most Gen Z thing ever.",
+      "fun_fact_de": "Steve Lacy nahm einen Großteil von Bad Habit auf seinem iPhone mit GarageBand auf — die Tatsache, dass ein #1-Hit teilweise auf einem Handy gemacht wurde, ist wirklich das Gen-Z-Typischste überhaupt.",
+      "fun_fact_es": "Steve Lacy grabó gran parte de Bad Habit en su iPhone usando GarageBand — el hecho de que un #1 se hiciera parcialmente en un teléfono es genuinamente lo más Gen Z de la historia.",
+      "fun_fact_fr": "Steve Lacy a enregistré une grande partie de Bad Habit sur son iPhone avec GarageBand — le fait qu'un #1 ait été en partie créé sur un téléphone est vraiment le truc le plus Gen Z qui soit.",
+      "uri_apple_music": "applemusic://track/1623679848",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=VF-FGf_ZZiI",
+      "uri_tidal": "tidal://track/234513467",
+      "uri_deezer": "deezer://track/1787186967",
+      "fun_fact_nl": "Steve Lacy nam een groot deel van Bad Habit op met zijn iPhone via GarageBand — het feit dat een #1-hit deels op een telefoon is gemaakt, is echt het meest Gen Z-achtige ooit.",
+      "awards_nl": [
+        "Grammy Award - Beste Pop Solo Prestatie"
+      ]
+    },
+    {
+      "year": 2023,
+      "uri": "spotify:track:7DSAEUvxU8FajXtRloy8M0",
+      "artist": "Miley Cyrus",
+      "alt_artists": [
+        "Dua Lipa",
+        "Lizzo",
+        "Lady Gaga",
+        "P!nk"
+      ],
+      "title": "Flowers",
+      "chart_info": {
+        "billboard_peak": 1,
+        "uk_peak": 1,
+        "weeks_on_chart": 36
+      },
+      "certifications": [
+        "5x Platinum (US)",
+        "3x Platinum (UK)",
+        "4x Platinum (AU)"
+      ],
+      "awards": [
+        "Grammy Award - Record of the Year",
+        "Grammy Award - Best Pop Solo Performance"
+      ],
+      "awards_fr": [
+        "Grammy Award - Enregistrement de l'année",
+        "Grammy Award - Meilleure performance pop solo"
+      ],
+      "fun_fact": "Flowers was released on Liam Hemsworth's birthday and its lyrics seem to reference Bruno Mars' 'When I Was Your Man' — a breakup anthem that said 'I can do it better myself,' and honestly, she ate.",
+      "fun_fact_de": "Flowers wurde an Liam Hemsworths Geburtstag veröffentlicht und die Texte scheinen auf Bruno Mars' 'When I Was Your Man' anzuspielen — eine Trennungshymne, die sagte 'Ich kann es selbst besser.'",
+      "fun_fact_es": "Flowers fue lanzada en el cumpleaños de Liam Hemsworth y su letra parece hacer referencia a 'When I Was Your Man' de Bruno Mars — un himno de ruptura que dijo 'puedo hacerlo mejor yo sola.'",
+      "fun_fact_fr": "Flowers est sorti le jour de l'anniversaire de Liam Hemsworth et ses paroles semblent faire référence à 'When I Was Your Man' de Bruno Mars — un hymne de rupture qui dit 'je peux le faire mieux toute seule.'",
+      "uri_apple_music": "applemusic://track/1663973555",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=G7KNmW9a75Y",
+      "uri_tidal": "tidal://track/274662447",
+      "uri_deezer": "deezer://track/2088553607",
+      "fun_fact_nl": "Flowers werd uitgebracht op de verjaardag van Liam Hemsworth en de tekst lijkt te verwijzen naar 'When I Was Your Man' van Bruno Mars — een break-up anthem die zei 'ik kan het zelf beter.'",
+      "awards_nl": [
+        "Grammy Award - Opname van het Jaar",
+        "Grammy Award - Beste Pop Solo Prestatie"
+      ]
+    },
+    {
+      "year": 2023,
+      "uri": "spotify:track:1Qrg8KqiBpW07V7PNxwwwL",
+      "artist": "SZA",
+      "alt_artists": [
+        "Doja Cat",
+        "Summer Walker",
+        "Jhené Aiko",
+        "H.E.R."
+      ],
+      "title": "Kill Bill",
+      "chart_info": {
+        "billboard_peak": 1,
+        "uk_peak": 2,
+        "weeks_on_chart": 38
+      },
+      "certifications": [
+        "5x Platinum (US)",
+        "Platinum (UK)",
+        "2x Platinum (AU)"
+      ],
+      "awards": [],
+      "fun_fact": "Kill Bill is named after the Quentin Tarantino film and SZA described it as a 'fantasy revenge song about an ex' — the way she made murder sound like a chill vibe is honestly impressive.",
+      "fun_fact_de": "Kill Bill ist nach dem Quentin-Tarantino-Film benannt und SZA beschrieb es als 'Fantasy-Rachesong über einen Ex' — wie sie Mord wie eine entspannte Stimmung klingen ließ, ist ehrlich beeindruckend.",
+      "fun_fact_es": "Kill Bill lleva el nombre de la película de Quentin Tarantino y SZA lo describió como 'una canción de venganza fantástica sobre un ex' — la forma en que hizo que el asesinato sonara relajado es honestamente impresionante.",
+      "fun_fact_fr": "Kill Bill porte le nom du film de Quentin Tarantino et SZA l'a décrit comme 'une chanson de vengeance fantasmée sur un ex' — la façon dont elle a rendu le meurtre si cool est honnêtement impressionnante.",
+      "uri_apple_music": "applemusic://track/1653601210",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=hIm_1Uf2fYA",
+      "uri_tidal": "tidal://track/273097153",
+      "uri_deezer": "deezer://track/2072457087",
+      "fun_fact_nl": "Kill Bill is vernoemd naar de Quentin Tarantino-film en SZA beschreef het als een 'fantasy wraak-nummer over een ex' — de manier waarop ze moord als een relaxte vibe liet klinken is eerlijk gezegd indrukwekkend.",
+      "awards_nl": []
+    },
+    {
+      "year": 2023,
+      "uri": "spotify:track:2FQrifJ1N335Ljm3TjTVVf",
+      "artist": "Doja Cat",
+      "alt_artists": [
+        "Nicki Minaj",
+        "Megan Thee Stallion",
+        "Ice Spice",
+        "Cardi B"
+      ],
+      "title": "Paint The Town Red",
+      "chart_info": {
+        "billboard_peak": 1,
+        "uk_peak": 2,
+        "weeks_on_chart": 30
+      },
+      "certifications": [
+        "4x Platinum (US)",
+        "Platinum (UK)",
+        "Platinum (AU)"
+      ],
+      "awards": [],
+      "fun_fact": "Paint The Town Red samples Dionne Warwick's 1964 classic 'Walk On By' — Doja Cat's ability to flip a 60-year-old track into a viral rap banger is genuinely unmatched.",
+      "fun_fact_de": "Paint The Town Red samplet Dionne Warwicks Klassiker 'Walk On By' von 1964 — Doja Cats Fähigkeit, einen 60 Jahre alten Track in einen viralen Rap-Hit zu verwandeln, ist wirklich unerreicht.",
+      "fun_fact_es": "Paint The Town Red samplea el clásico de 1964 de Dionne Warwick 'Walk On By' — la habilidad de Doja Cat para convertir un track de hace 60 años en un hit viral de rap es realmente inigualable.",
+      "fun_fact_fr": "Paint The Town Red sample le classique de 1964 de Dionne Warwick 'Walk On By' — la capacité de Doja Cat à transformer un morceau vieux de 60 ans en un hit rap viral est vraiment inégalée.",
+      "uri_apple_music": "applemusic://track/1696710975",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=m4_8pPbbKKI",
+      "uri_tidal": "tidal://track/308652487",
+      "uri_deezer": "deezer://track/2378615027",
+      "fun_fact_nl": "Paint The Town Red samplet Dionne Warwicks klassieker 'Walk On By' uit 1964 — Doja Cats vermogen om een 60 jaar oud nummer om te toveren tot een virale raphit is werkelijk ongeëvenaard.",
+      "awards_nl": []
+    },
+    {
+      "year": 2024,
+      "uri": "spotify:track:2qSkIjg1o9h3YT9RAgYN75",
+      "artist": "Sabrina Carpenter",
+      "alt_artists": [
+        "Olivia Rodrigo",
+        "Dua Lipa",
+        "Tate McRae",
+        "Chappell Roan"
+      ],
+      "title": "Espresso",
+      "chart_info": {
+        "billboard_peak": 1,
+        "uk_peak": 1,
+        "weeks_on_chart": 40
+      },
+      "certifications": [
+        "4x Platinum (US)",
+        "3x Platinum (UK)",
+        "3x Platinum (AU)"
+      ],
+      "awards": [],
+      "fun_fact": "Espresso became the song of summer 2024 and was so viral that even Barack Obama put it on his summer playlist — the 'that's that me espresso' hook was genuinely lodged in everyone's brain for months.",
+      "fun_fact_de": "Espresso wurde der Song des Sommers 2024 und war so viral, dass sogar Barack Obama ihn auf seine Sommer-Playlist setzte — der 'that's that me espresso'-Hook steckte monatelang in jedem Kopf.",
+      "fun_fact_es": "Espresso se convirtió en la canción del verano 2024 y fue tan viral que incluso Barack Obama la puso en su playlist de verano — el gancho 'that's that me espresso' estuvo literalmente pegado en la cabeza de todos durante meses.",
+      "fun_fact_fr": "Espresso est devenu la chanson de l'été 2024 et était si viral que même Barack Obama l'a mise dans sa playlist estivale — le refrain 'that's that me espresso' est resté dans la tête de tout le monde pendant des mois.",
+      "uri_apple_music": "applemusic://track/1735735357",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=eVli-tstM5E",
+      "uri_tidal": "tidal://track/354679021",
+      "uri_deezer": "deezer://track/2607344727",
+      "fun_fact_nl": "Espresso werd het nummer van de zomer 2024 en was zo viraal dat zelfs Barack Obama het op zijn zomerplaylist zette — de 'that's that me espresso'-hook zat letterlijk maandenlang in ieders hoofd.",
+      "awards_nl": []
+    },
+    {
+      "year": 2024,
+      "uri": "spotify:track:0WbMK4wrZ1wFSty9F7FCgu",
+      "artist": "Chappell Roan",
+      "alt_artists": [
+        "Sabrina Carpenter",
+        "Charli XCX",
+        "Reneé Rapp",
+        "Tove Lo"
+      ],
+      "title": "Good Luck, Babe!",
+      "chart_info": {
+        "billboard_peak": 4,
+        "uk_peak": 5,
+        "weeks_on_chart": 32
+      },
+      "certifications": [
+        "2x Platinum (US)",
+        "Platinum (UK)",
+        "Platinum (AU)"
+      ],
+      "awards": [],
+      "fun_fact": "Chappell Roan went from playing to nearly empty venues in 2023 to headlining festivals in 2024 — Good Luck, Babe! was the breakout track that made her one of the fastest-rising pop stars in recent memory, and her live performances are genuinely next-level theatrical.",
+      "fun_fact_de": "Chappell Roan ging von fast leeren Veranstaltungsorten 2023 zu Festival-Headlinerin 2024 — Good Luck, Babe! war der Durchbruch-Track, der sie zu einem der am schnellsten aufsteigenden Popstars der letzten Zeit machte, und ihre Live-Auftritte sind wirklich theatralisch auf höchstem Niveau.",
+      "fun_fact_es": "Chappell Roan pasó de tocar en locales casi vacíos en 2023 a encabezar festivales en 2024 — Good Luck, Babe! fue el tema que la catapultó como una de las estrellas pop de ascenso más rápido en la memoria reciente, y sus actuaciones en vivo son genuinamente teatrales a otro nivel.",
+      "fun_fact_fr": "Chappell Roan est passée de salles quasi vides en 2023 à tête d'affiche de festivals en 2024 — Good Luck, Babe! a été le titre qui l'a propulsée comme l'une des pop stars à l'ascension la plus fulgurante de mémoire récente, et ses performances live sont d'un niveau théâtral vraiment exceptionnel.",
+      "uri_apple_music": "applemusic://track/1737556054",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=B8BjVMu4yMs",
+      "uri_tidal": "tidal://track/356127843",
+      "uri_deezer": "deezer://track/2623893347",
+      "fun_fact_nl": "Chappell Roan ging van optreden voor bijna lege zalen in 2023 naar headliner op festivals in 2024 — Good Luck, Babe! was de doorbraak-track die haar tot een van de snelst stijgende popsterren van de afgelopen tijd maakte, en haar live-optredens zijn echt theatraal op een ander niveau.",
+      "awards_nl": []
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- 30 songs spanning 2009–2024 (Ke$ha to Chappell Roan)
- URIs for all 5 providers (Spotify, YouTube Music, Apple Music, Tidal, Deezer)
- Fun facts in 5 languages (EN, DE, ES, FR, NL) with light Gen Z tone
- Alt artists for artist challenge mode
- Chart data and certifications

Note: Tidal/Deezer/Apple Music track IDs may need verification from users with active subscriptions.

Closes #500

## Test plan
- [ ] Playlist appears in the admin UI playlist selector
- [ ] Songs play correctly via Spotify
- [ ] Fun facts display in all 5 languages
- [ ] Artist challenge shows alt artists

🤖 Generated with [Claude Code](https://claude.com/claude-code)