### PR TITLE
feat: add +10s seek forward button to admin control bar

### DIFF
--- a/custom_components/beatify/game/state.py
+++ b/custom_components/beatify/game/state.py
@@ -1849,6 +1849,12 @@ class GameState:
             return await self._media_player_service.set_volume(level)
         return False
 
+    async def seek_forward(self, seconds: int) -> bool:
+        """Seek media player forward by given seconds (#498)."""
+        if self._media_player_service:
+            return await self._media_player_service.seek_forward(seconds)
+        return False
+
     async def play_deferred_song(self, song: dict) -> bool:
         """Play a song that was deferred for intro splash (#321).
 

--- a/custom_components/beatify/server/websocket.py
+++ b/custom_components/beatify/server/websocket.py
@@ -421,6 +421,7 @@ class BeatifyWebSocketHandler:
             "next_round": self._admin_next_round,
             "stop_song": self._admin_stop_song,
             "set_volume": self._admin_set_volume,
+            "seek_forward": self._admin_seek_forward,
             "end_game": self._admin_end_game,
             "dismiss_game": self._admin_dismiss_game,
             "rematch_game": self._admin_rematch_game,
@@ -645,6 +646,17 @@ class BeatifyWebSocketHandler:
                 "level": new_level,
             }
         )
+
+    async def _admin_seek_forward(
+        self, ws: web.WebSocketResponse, data: dict, game_state: GameState
+    ) -> None:
+        """Handle admin seek_forward action (#498)."""
+        if game_state.phase not in (GamePhase.PLAYING, GamePhase.REVEAL):
+            return
+        seconds = data.get("seconds", 10)
+        success = await game_state.seek_forward(seconds)
+        if success:
+            _LOGGER.info("Media seeked forward %ds", seconds)
 
     async def _admin_end_game(
         self, ws: web.WebSocketResponse, data: dict, game_state: GameState

--- a/custom_components/beatify/services/media_player.py
+++ b/custom_components/beatify/services/media_player.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import sys
+from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any
 
 if sys.version_info >= (3, 11):
@@ -561,6 +562,15 @@ class MediaPlayerService:
             if not state:
                 return False
             current_pos = state.attributes.get("media_position", 0) or 0
+            # Adjust for stale cached position — HA only updates
+            # media_position at media_position_updated_at
+            updated_at = state.attributes.get("media_position_updated_at")
+            if updated_at:
+                if isinstance(updated_at, str):
+                    updated_at = datetime.fromisoformat(updated_at)
+                elapsed = (datetime.now(timezone.utc) - updated_at).total_seconds()
+                if elapsed > 0:
+                    current_pos += elapsed
             new_pos = current_pos + seconds
             await self._hass.services.async_call(
                 "media_player",

--- a/custom_components/beatify/services/media_player.py
+++ b/custom_components/beatify/services/media_player.py
@@ -551,6 +551,31 @@ class MediaPlayerService:
             self._record_error("MEDIA_PLAYER_ERROR", f"Failed to set volume: {err}")
             return False
 
+    async def seek_forward(self, seconds: int) -> bool:
+        """Seek media forward by given seconds (#498).
+
+        Reads current position from HA state and seeks to position + seconds.
+        """
+        try:
+            state = self._hass.states.get(self._entity_id)
+            if not state:
+                return False
+            current_pos = state.attributes.get("media_position", 0) or 0
+            new_pos = current_pos + seconds
+            await self._hass.services.async_call(
+                "media_player",
+                "media_seek",
+                {
+                    "entity_id": self._entity_id,
+                    "seek_position": new_pos,
+                },
+            )
+            return True  # noqa: TRY300
+        except Exception as err:  # noqa: BLE001
+            _LOGGER.error("Failed to seek media: %s", err)  # noqa: TRY400
+            self._record_error("MEDIA_PLAYER_ERROR", f"Failed to seek: {err}")
+            return False
+
     def is_available(self) -> bool:
         """
         Check if media player is available.

--- a/custom_components/beatify/www/admin.html
+++ b/custom_components/beatify/www/admin.html
@@ -514,9 +514,10 @@
                 <button id="admin-stop-song" class="btn btn-secondary btn-compact">
                     <span aria-hidden="true">⏹</span> Stop
                 </button>
-                <button id="admin-vol-down" class="btn btn-secondary btn-compact">🔉</button>
-                <button id="admin-vol-up" class="btn btn-secondary btn-compact">🔊</button>
-                <button id="admin-end-game-playing" class="btn btn-danger btn-compact">End Game</button>
+                <button id="admin-seek-forward" class="btn btn-secondary btn-compact" title="Seek forward 10 seconds">⏩ +10s</button>
+                <button id="admin-vol-down" class="btn btn-secondary btn-compact" title="Volume down">🔉</button>
+                <button id="admin-vol-up" class="btn btn-secondary btn-compact" title="Volume up">🔊</button>
+                <button id="admin-end-game-playing" class="btn btn-danger btn-compact" title="End game">End Game</button>
             </div>
 
             <!-- Player game UI (only shown if admin joined as player) -->

--- a/custom_components/beatify/www/js/admin.js
+++ b/custom_components/beatify/www/js/admin.js
@@ -129,6 +129,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
     // Issue #477: Wire game phase control buttons
     document.getElementById('admin-stop-song')?.addEventListener('click', adminStopSong);
+    document.getElementById('admin-seek-forward')?.addEventListener('click', adminSeekForward);
     document.getElementById('admin-vol-down')?.addEventListener('click', adminVolumeDown);
     document.getElementById('admin-vol-up')?.addEventListener('click', adminVolumeUp);
     document.getElementById('admin-end-game-playing')?.addEventListener('click', endGame);
@@ -3022,6 +3023,12 @@ function adminNextRound() {
 function adminStopSong() {
     if (adminWs && adminWs.readyState === WebSocket.OPEN) {
         adminWs.send(JSON.stringify({ type: 'admin', action: 'stop_song' }));
+    }
+}
+
+function adminSeekForward() {
+    if (adminWs && adminWs.readyState === WebSocket.OPEN) {
+        adminWs.send(JSON.stringify({ type: 'admin', action: 'seek_forward', seconds: 10 }));
     }
 }
 


### PR DESCRIPTION
## Summary
- Adds a ⏩ +10s seek forward button to the admin control bar (between Stop and Volume)
- Full end-to-end: HTML button → JS WebSocket message → Python handler → HA media_player.media_seek
- Reads current `media_position` from HA state and seeks to `position + 10s`
- Only active during PLAYING and REVEAL phases
- Adds `title` tooltips to all admin control bar buttons

Closes #498

## Test plan
- [ ] Click +10s during playback — verify song skips forward ~10 seconds
- [ ] Click +10s during REVEAL — verify it still works (song plays during reveal)
- [ ] Verify button is not functional in LOBBY/END phases
- [ ] Verify volume and stop buttons still work as before
- [ ] Test with different media players (Spotify, YouTube Music)

🤖 Generated with [Claude Code](https://claude.com/claude-code)