### PR TITLE
fix: offload blocking glob calls to executor thread

### DIFF
--- a/custom_components/beatify/game/playlist.py
+++ b/custom_components/beatify/game/playlist.py
@@ -187,7 +187,11 @@ async def _copy_bundled_playlists(dest_dir: Path) -> None:
 
     loop = asyncio.get_event_loop()
 
-    for playlist_file in bundled_dir.glob("**/*.json"):
+    # Offload blocking glob to executor to avoid scandir in event loop (#516)
+    playlist_files = await loop.run_in_executor(
+        None, lambda: list(bundled_dir.glob("**/*.json"))
+    )
+    for playlist_file in playlist_files:
         # Preserve relative path (e.g. community/greatest-metal-songs.json)
         rel = playlist_file.relative_to(bundled_dir)
         dest_file = dest_dir / rel
@@ -420,7 +424,11 @@ async def async_discover_playlists(hass: HomeAssistant) -> list[dict]:
 
     loop = asyncio.get_event_loop()
 
-    for json_file in playlist_dir.glob("**/*.json"):
+    # Offload blocking glob to executor to avoid scandir in event loop (#516)
+    json_files = await loop.run_in_executor(
+        None, lambda: list(playlist_dir.glob("**/*.json"))
+    )
+    for json_file in json_files:
         try:
             content = await loop.run_in_executor(None, _read_file, json_file)
             data = json.loads(content)


### PR DESCRIPTION
## Summary
- Wraps both `Path.glob()` calls in `playlist.py` with `run_in_executor()` to avoid blocking `os.scandir` in the HA event loop
- Fixes the WARNING on HA 2026.4+ / Python 3.14 and likely resolves "Media player not responding" errors on startup

Closes #516

## Test plan
- [ ] Start HA with Beatify — no blocking call WARNING in logs
- [ ] Playlists still discovered and loaded correctly
- [ ] Game starts and plays songs normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)