### PR TITLE
fix: add volume text labels to player page control bar

### DIFF
--- a/custom_components/beatify/www/player.html
+++ b/custom_components/beatify/www/player.html
@@ -597,9 +597,11 @@
             </button>
             <button id="volume-down-btn" class="control-btn" type="button">
                 <span class="control-icon">🔉</span>
+                <span class="control-label" data-i18n="admin.volDown">Down</span>
             </button>
             <button id="volume-up-btn" class="control-btn" type="button">
                 <span class="control-icon">🔊</span>
+                <span class="control-label" data-i18n="admin.volUp">Up</span>
             </button>
             <button id="next-round-admin-btn" class="control-btn" type="button">
                 <span class="control-icon">⏭️</span>


### PR DESCRIPTION
## Summary
The previous fix (#536) added volume labels to admin.html but missed the player.html control bar (shown when admin joins as a player). Added `data-i18n` labels matching the same keys.

Closes #533

## Test plan
- [ ] Join game as admin+player — volume buttons show localized labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)