### PR TITLE
fix: re-render chart when expanding collapsed section

### DIFF
--- a/custom_components/beatify/www/js/analytics.js
+++ b/custom_components/beatify/www/js/analytics.js
@@ -1027,6 +1027,12 @@
                     section.classList.toggle('collapsed');
                     var expanded = !section.classList.contains('collapsed');
                     header.setAttribute('aria-expanded', expanded);
+
+                    // Re-render chart when chart section is expanded
+                    // (canvas has zero dimensions while collapsed)
+                    if (expanded && section.id === 'chart-section' && window.currentChartData) {
+                        setTimeout(function() { renderChart(window.currentChartData); }, 50);
+                    }
                 }
             });
         });


### PR DESCRIPTION
## Summary
- Chart canvas has zero dimensions when the section is collapsed at load time
- When the API response triggers `renderChart()`, the canvas draws at 0px width
- Now re-renders the chart with a 50ms delay when the chart section is expanded

## Test plan
- [ ] Open analytics page — expand Chart section — chart should render
- [ ] Resize window with chart visible — chart should resize correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)