### PR TITLE
fix: make all collapsible sections expandable on setup page

### DIFF
--- a/custom_components/beatify/www/js/admin.js
+++ b/custom_components/beatify/www/js/admin.js
@@ -257,8 +257,8 @@ function setupCollapsibleSections() {
         }
     });
 
-    // Lobby section toggles (new compact layout)
-    document.querySelectorAll('.lobby-container--compact .section-header-collapsible').forEach(function(header) {
+    // Generic collapsible section toggles (lobby, HA entities, Party Lights, TTS, etc.)
+    document.querySelectorAll('.section-header-collapsible').forEach(function(header) {
         header.addEventListener('click', function() {
             const section = header.closest('.section-collapsible');
             if (section) {


### PR DESCRIPTION
## Summary
- The collapsible handler only targeted `.lobby-container--compact .section-header-collapsible`
- HA Entities, Party Lights, and TTS sections were not expandable
- Changed to generic `.section-header-collapsible` selector covering all sections

## Test plan
- [ ] Click HA Entities section — should expand/collapse
- [ ] Click Party Lights — should expand/collapse
- [ ] Click TTS Announcements — should expand/collapse
- [ ] Verify lobby sections still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)