### PR TITLE
fix: always show Start button on admin page when players are in lobby

### DIFF
--- a/custom_components/beatify/www/js/admin.js
+++ b/custom_components/beatify/www/js/admin.js
@@ -2301,18 +2301,12 @@ function renderLobbyPlayers(players) {
         }
     }, 2000);
 
-    // Issue #477: Always show Start button when admin WS is connected (admin
-    // can start the game as a spectator host). Falls back to original check
-    // (#253) when WS is not available.
+    // Show Start button when there are players. The admin page IS the admin
+    // control surface — the host should always be able to start the game,
+    // whether they joined as a player or not.
     var startBtn = document.getElementById("start-gameplay-btn");
     if (startBtn) {
-        var hasAdminWs = adminWs && adminWs.readyState === WebSocket.OPEN;
-        var adminJoined = players.some(function(p) { return p.is_admin === true; });
-        if (hasAdminWs || adminJoined) {
-            startBtn.classList.remove("hidden");
-        } else {
-            startBtn.classList.add("hidden");
-        }
+        startBtn.classList.remove("hidden");
     }
 
     previousLobbyPlayers = players.slice();


### PR DESCRIPTION
## Summary
- Start button was hidden unless adminWs was connected or an admin player had joined
- The admin page should always allow starting the game when players are present
- Removed the conditional check — button is now always visible when there are players

## Test plan
- [ ] Open admin page, have a player join from another device — Start button visible
- [ ] Admin doesn't need to "Als Spieler beitreten" to see Start button
- [ ] Start button still hidden when no players (handled by earlier check at line 2249)

🤖 Generated with [Claude Code](https://claude.com/claude-code)