### PR TITLE
fix: remove admin token requirement for rematch REST endpoint

### DIFF
--- a/custom_components/beatify/server/views.py
+++ b/custom_components/beatify/server/views.py
@@ -706,12 +706,9 @@ class RematchGameView(HomeAssistantView):
                 status=404,
             )
 
-        if not _verify_admin_token(request, game_state):
-            return web.json_response(
-                {"error": "UNAUTHORIZED", "message": "Admin token required"},
-                status=403,
-            )
-
+        # Rematch is safe without token — game is already in END phase,
+        # and the action just resets for a new game with the same players.
+        # Token auth was blocking rematch from the player page (#535).
         if game_state.phase != GamePhase.END:
             return web.json_response(
                 {"error": "INVALID_PHASE", "message": "Can only rematch from END phase"},


### PR DESCRIPTION
## Summary
- Removes `_verify_admin_token` check from the rematch REST endpoint
- The phase guard (END only) is sufficient — rematch is non-destructive
- This was the actual root cause of the "Admin token required" error: the player page sends rematch via REST without a token, and the previous WS-only fix didn't help when the WS was disconnected

Closes #535

## Test plan
- [ ] End a game, click Rematch from player page — no error
- [ ] End a game, click Rematch from admin page — no error
- [ ] Verify rematch can't be triggered during PLAYING/REVEAL (phase guard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)