### PR TITLE
fix: remove duplicate collapsible section click listeners

### DIFF
--- a/custom_components/beatify/www/js/party-lights.js
+++ b/custom_components/beatify/www/js/party-lights.js
@@ -234,18 +234,6 @@
             });
         }
 
-        // Collapsible section toggle
-        var toggle = document.getElementById('party-lights-toggle');
-        if (toggle) {
-            toggle.addEventListener('click', function() {
-                var section = document.getElementById('party-lights');
-                if (section) {
-                    var isCollapsed = section.classList.toggle('collapsed');
-                    toggle.setAttribute('aria-expanded', !isCollapsed);
-                }
-            });
-        }
-
         // Fetch lights
         fetchLights();
     }

--- a/custom_components/beatify/www/js/tts-settings.js
+++ b/custom_components/beatify/www/js/tts-settings.js
@@ -119,18 +119,6 @@
             });
         }
 
-        // Collapsible section toggle
-        var toggle = document.getElementById('tts-settings-toggle');
-        if (toggle) {
-            toggle.addEventListener('click', function() {
-                var section = document.getElementById('tts-settings');
-                if (section) {
-                    var isCollapsed = section.classList.toggle('collapsed');
-                    toggle.setAttribute('aria-expanded', !isCollapsed);
-                }
-            });
-        }
-
         updateSummary();
         updateTestButton();
     }


### PR DESCRIPTION
## Summary
- Removed duplicate click listeners from `party-lights.js` and `tts-settings.js` that conflicted with the central `setupCollapsibleSections()` handler in `admin.js`
- Both listeners fired on click, toggling the `collapsed` class on then off, resulting in a no-op that prevented "Party Lights" and "TTS-Ansagen" sections from expanding

## Test plan
- [ ] Open the Beatify admin panel
- [ ] Click the "Party Lights" collapsible section header -- verify it expands and collapses correctly
- [ ] Click the "TTS-Ansagen" collapsible section header -- verify it expands and collapses correctly
- [ ] Verify other collapsible sections still work as expected

Closes #552

🤖 Generated with [Claude Code](https://claude.com/claude-code)