### PR TITLE
fix: accept provider-specific URI fields when loading songs

### DIFF
--- a/custom_components/beatify/server/views.py
+++ b/custom_components/beatify/server/views.py
@@ -484,7 +484,11 @@ class StartGameView(HomeAssistantView):
                 playlist_data = json.loads(file_content)
 
                 for song in playlist_data.get("songs", []):
-                    if "year" in song and "uri" in song:
+                    has_uri = any(
+                        song.get(k)
+                        for k in ("uri", "uri_spotify", "uri_youtube_music", "uri_tidal", "uri_deezer", "uri_apple_music")
+                    )
+                    if "year" in song and has_uri:
                         tagged = dict(song)
                         tagged["_playlist_source"] = playlist_path
                         songs.append(tagged)


### PR DESCRIPTION
## Summary
- Songs with only provider-specific URI fields (e.g., `uri_youtube_music`, `uri_spotify`) but no legacy `uri` field were silently dropped during playlist loading
- Updated the URI check in `views.py` to accept any of the known URI fields: `uri`, `uri_spotify`, `uri_youtube_music`, `uri_tidal`, `uri_deezer`, `uri_apple_music`

Closes #556

## Test plan
- [ ] Load a playlist containing songs with only `uri_youtube_music` (no `uri` field) and verify they are included
- [ ] Load a playlist with songs that have only the legacy `uri` field and verify they still work
- [ ] Load a playlist with songs missing both `year` and any URI field and verify they are correctly rejected with a warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)