### PR TITLE
fix: intro splash timer calls end_round correctly

### DIFF
--- a/custom_components/beatify/game/round_manager.py
+++ b/custom_components/beatify/game/round_manager.py
@@ -313,6 +313,7 @@ class RoundManager:
         self,
         play_deferred_song: Callable[[dict[str, Any]], Awaitable[bool]],
         on_round_end: Callable[[], Awaitable[None]] | None,
+        timer_countdown: Callable[[float], Awaitable[None]] | None = None,
     ) -> None:
         """Handle admin confirmation of intro splash (Issue #292, #403).
 
@@ -341,8 +342,9 @@ class RoundManager:
         self._intro_round_start_time = now
 
         delay = (self.deadline - int(now * 1000)) / 1000.0
+        countdown = timer_countdown or self._timer_countdown
         self._timer_task = asyncio.create_task(
-            self._timer_countdown(delay)
+            countdown(delay)
         )
 
         # Start intro auto-stop

--- a/custom_components/beatify/game/state.py
+++ b/custom_components/beatify/game/state.py
@@ -1722,7 +1722,7 @@ class GameState:
         Delegates to RoundManager.
         """
         await self._round_manager.confirm_intro_splash(
-            self.play_deferred_song, self._on_round_end
+            self.play_deferred_song, self._on_round_end, self._timer_countdown
         )
 
     def is_deadline_passed(self) -> bool:


### PR DESCRIPTION
## Summary
- `confirm_intro_splash` was using `self._timer_countdown` (a bare `asyncio.sleep`) instead of the `GameState._timer_countdown` wrapper that calls `end_round()` when the timer expires. This meant the round never ended automatically after the intro splash was confirmed.
- Added a `timer_countdown` parameter to `RoundManager.confirm_intro_splash` (defaulting to `None` for backwards compatibility) and updated `GameState.confirm_intro_splash` to pass `self._timer_countdown`.

Closes #554

## Test plan
- [ ] Start a game with intro splash enabled
- [ ] Confirm the intro splash as admin
- [ ] Verify the round timer counts down and `end_round` fires automatically when it expires

🤖 Generated with [Claude Code](https://claude.com/claude-code)