### PR TITLE
fix: stop party lights after game ends via advance_to_end

### DIFF
--- a/custom_components/beatify/game/state.py
+++ b/custom_components/beatify/game/state.py
@@ -1840,8 +1840,13 @@ class GameState:
         self.phase = GamePhase.END
         self._notify_state_callbacks()
 
-        # Issue #331: Celebrate with Party Lights
-        await self._lights_celebrate()
+        # Issue #331: Celebrate with Party Lights, then stop (#553)
+        if self._party_lights:
+            try:
+                await self._party_lights.celebrate()
+            except Exception:  # noqa: BLE001
+                _LOGGER.warning("Party Lights celebration failed")
+            await self.disable_party_lights()
 
         # Issue #447: Announce winner via TTS
         await self.announce_winner()


### PR DESCRIPTION
## Summary
- Party lights kept blinking after the game ended because `disable_party_lights()` was only called in `end_game()` (admin click), not in `advance_to_end()`
- Changed `advance_to_end()` to directly await `celebrate()` on the party lights service (instead of fire-and-forget via `_lights_celebrate`), then call `disable_party_lights()` to stop them
- Wrapped the celebration call in a try/except so a lights failure never blocks the end-of-game flow

Closes #553

## Test plan
- [ ] Start a game with party lights enabled
- [ ] Let the game reach the END phase naturally (via `advance_to_end`)
- [ ] Verify party lights celebrate briefly then turn off
- [ ] Verify ending the game via the admin button still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)