### PR TITLE
fix: use _resolved_uri for metadata update URI comparison

### DIFF
--- a/custom_components/beatify/game/state.py
+++ b/custom_components/beatify/game/state.py
@@ -1408,7 +1408,8 @@ class GameState:
             # Fix #124: Only update album_art from media player.
             # Artist/title are authoritative from playlist data — media player
             # state can report stale/wrong track info (especially Sonos + Spotify).
-            if self.current_song and self.current_song.get("uri") == uri:
+            current_uri = self.current_song.get("_resolved_uri") or self.current_song.get("uri")
+            if self.current_song and current_uri == uri:
                 self.current_song["album_art"] = metadata.get(
                     "album_art", "/beatify/static/img/no-artwork.svg"
                 )

--- a/custom_components/beatify/game/state.py
+++ b/custom_components/beatify/game/state.py
@@ -1408,28 +1408,31 @@ class GameState:
             # Fix #124: Only update album_art from media player.
             # Artist/title are authoritative from playlist data — media player
             # state can report stale/wrong track info (especially Sonos + Spotify).
-            current_uri = self.current_song.get("_resolved_uri") or self.current_song.get("uri")
-            if self.current_song and current_uri == uri:
-                self.current_song["album_art"] = metadata.get(
-                    "album_art", "/beatify/static/img/no-artwork.svg"
-                )
-                self.metadata_pending = False
-
-                _LOGGER.info(
-                    "Album art updated for: %s - %s",
-                    self.current_song.get("artist"),
-                    self.current_song.get("title"),
-                )
-
-                # Invoke callback to broadcast update (album art only)
-                if self._on_metadata_update:
-                    await self._on_metadata_update(
-                        {
-                            "artist": self.current_song["artist"],
-                            "title": self.current_song["title"],
-                            "album_art": self.current_song["album_art"],
-                        }
+            if self.current_song:
+                current_uri = self.current_song.get("_resolved_uri") or self.current_song.get("uri")
+                if current_uri == uri:
+                    self.current_song["album_art"] = metadata.get(
+                        "album_art", "/beatify/static/img/no-artwork.svg"
                     )
+                    self.metadata_pending = False
+
+                    _LOGGER.info(
+                        "Album art updated for: %s - %s",
+                        self.current_song.get("artist"),
+                        self.current_song.get("title"),
+                    )
+
+                    # Invoke callback to broadcast update (album art only)
+                    if self._on_metadata_update:
+                        await self._on_metadata_update(
+                            {
+                                "artist": self.current_song["artist"],
+                                "title": self.current_song["title"],
+                                "album_art": self.current_song["album_art"],
+                            }
+                        )
+                else:
+                    _LOGGER.debug("Metadata arrived for different song, ignoring")
             else:
                 _LOGGER.debug("Metadata arrived for different song, ignoring")
 


### PR DESCRIPTION
## Summary
- Fix metadata (album art) updates being silently discarded for non-Spotify providers
- The URI comparison in `_fetch_metadata_background` now checks `_resolved_uri` first, falling back to the legacy `uri` field

Closes #557

## Test plan
- [ ] Start a game with a non-Spotify provider (e.g. YouTube Music via WLED) and verify album art loads correctly
- [ ] Start a game with Spotify and confirm album art still updates as before
- [ ] Confirm no regressions in metadata logging output

🤖 Generated with [Claude Code](https://claude.com/claude-code)