### PR TITLE
fix: use provider-specific URI in mark_played on song retry

### DIFF
--- a/custom_components/beatify/game/state.py
+++ b/custom_components/beatify/game/state.py
@@ -59,7 +59,7 @@ from .challenges import (
 from .config import GameStateConfig
 from .highlights import HighlightsTracker
 from .player import PlayerSession
-from .playlist import PlaylistManager
+from .playlist import PlaylistManager, get_song_uri
 from .player_registry import PlayerRegistry
 from .powerups import PowerUpManager
 from .round_manager import RoundManager
@@ -1266,7 +1266,7 @@ class GameState:
         resolved_uri = song.get("_resolved_uri")
         if not resolved_uri:
             _LOGGER.warning("Skipping song (year %s) - no URI for provider", song.get("year", "?"))
-            self._playlist_manager.mark_played(song.get("uri"))
+            self._playlist_manager.mark_played(get_song_uri(song, self.provider) or song.get("uri"))
             if _retry_count >= MAX_SONG_RETRIES:
                 _LOGGER.error("No playable songs found after %d attempts, pausing game", MAX_SONG_RETRIES)
                 await self.pause_game("no_songs_available")


### PR DESCRIPTION
## Summary
- Fixed `mark_played` in `state.py` using `song.get("uri")` (legacy Spotify URI) instead of the resolved provider URI during song retry
- Now uses `get_song_uri(song, self.provider)` to retrieve the correct provider-specific URI, with a fallback to the legacy `uri` key

Closes #555

## Test plan
- [ ] Verify song retry flow correctly marks songs as played using the provider-specific URI
- [ ] Confirm non-Spotify providers (e.g., WLED) resolve and mark the correct URI
- [ ] Ensure fallback to legacy `song.get("uri")` still works when `get_song_uri` returns `None`

🤖 Generated with [Claude Code](https://claude.com/claude-code)