### PR TITLE
fix: song difficulty not tracked for non-Spotify providers

### DIFF
--- a/custom_components/beatify/game/state.py
+++ b/custom_components/beatify/game/state.py
@@ -659,7 +659,7 @@ class GameState:
             fragment["game_performance"] = game_performance
         # Song difficulty rating (Story 15.1 AC1, AC4)
         if self._stats_service and self.current_song:
-            song_uri = self.current_song.get("uri")
+            song_uri = self.current_song.get("_resolved_uri") or self.current_song.get("uri")
             if song_uri:
                 difficulty = self._stats_service.get_song_difficulty(song_uri)
                 if difficulty:
@@ -1543,7 +1543,7 @@ class GameState:
         # Extended for song statistics (Story 19.7)
         # Wrapped in try/catch to ensure round transition completes even if stats fail
         if self._stats_service and self.current_song:
-            song_uri = self.current_song.get("uri")
+            song_uri = self.current_song.get("_resolved_uri") or self.current_song.get("uri")
             if song_uri:
                 try:
                     # Build player results list for song difficulty calculation


### PR DESCRIPTION
## Summary
- Fix song difficulty tracking for non-Spotify providers (YouTube Music, etc.) by preferring `_resolved_uri` over `uri` when looking up song URIs
- Non-Spotify songs lack a `uri` field, causing `current_song.get("uri")` to return `None` and silently skip difficulty tracking
- Applied the fix in both `_state_reveal` (line 662) and `_end_round_unlocked` (line 1546)

Closes #558

## Test plan
- [ ] Start a game using a non-Spotify provider (e.g., YouTube Music)
- [ ] Complete a round and verify song difficulty is displayed during reveal
- [ ] Verify song difficulty stats are recorded after round ends
- [ ] Confirm Spotify games still track difficulty correctly (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)