### PR TITLE
data: fix 3 Pantera URIs in greatest-metal-songs (#582)

### DIFF
--- a/custom_components/beatify/playlists/community/greatest-metal-songs.json
+++ b/custom_components/beatify/playlists/community/greatest-metal-songs.json
@@ -1,6 +1,6 @@
 {
-  "name": "Greatest Metal Songs of All Time 🤘",
-  "version": "1.4",
+  "name": "Greatest Metal Songs of All Time \ud83e\udd18",
+  "version": "1.5",
   "tags": [
     "metal",
     "rock",
@@ -33,8 +33,8 @@
       ],
       "fun_fact": "Iron Man features one of the most iconic guitar riffs in rock history, created by Tony Iommi after he lost the tips of two fingers in a factory accident and fashioned prosthetic fingertips from melted plastic bottles. The song's opening riff mimics the lumbering gait of the time-travelling iron man described in the lyrics. It later became the basis for the Marvel film franchise's theme.",
       "fun_fact_de": "Iron Man hat eines der ikonischsten Gitarrenriffs der Rockgeschichte, das Tony Iommi erschuf, nachdem er bei einem Fabrikunfall die Fingerkuppen zweier Finger verloren hatte und Prothesen aus Plastikflaschen bastelte. Das Riff ahmt den schleppenden Gang des zeitreisenden Eisenmanns aus dem Liedtext nach.",
-      "fun_fact_es": "Iron Man presenta uno de los riffs de guitarra más icónicos de la historia del rock, creado por Tony Iommi tras perder las yemas de dos dedos en un accidente de fábrica y fabricarse prótesis con botellas de plástico derretidas. El riff imita el paso torpe del hombre de hierro viajero en el tiempo descrito en la letra.",
-      "fun_fact_fr": "Iron Man présente l'un des riffs de guitare les plus emblématiques de l'histoire du rock, créé par Tony Iommi après avoir perdu le bout de deux doigts dans un accident d'usine et s'être fabriqué des prothèses en plastique. Le riff imite la démarche lourde du voyageur temporel décrit dans les paroles.",
+      "fun_fact_es": "Iron Man presenta uno de los riffs de guitarra m\u00e1s ic\u00f3nicos de la historia del rock, creado por Tony Iommi tras perder las yemas de dos dedos en un accidente de f\u00e1brica y fabricarse pr\u00f3tesis con botellas de pl\u00e1stico derretidas. El riff imita el paso torpe del hombre de hierro viajero en el tiempo descrito en la letra.",
+      "fun_fact_fr": "Iron Man pr\u00e9sente l'un des riffs de guitare les plus embl\u00e9matiques de l'histoire du rock, cr\u00e9\u00e9 par Tony Iommi apr\u00e8s avoir perdu le bout de deux doigts dans un accident d'usine et s'\u00eatre fabriqu\u00e9 des proth\u00e8ses en plastique. Le riff imite la d\u00e9marche lourde du voyageur temporel d\u00e9crit dans les paroles.",
       "uri_apple_music": "applemusic://track/785232524",
       "uri_youtube_music": "https://music.youtube.com/watch?v=5s7_WtCFf70",
       "uri_tidal": "tidal://track/4085428",
@@ -64,10 +64,10 @@
       "awards": [
         "Grammy Hall of Fame"
       ],
-      "fun_fact": "Paranoid was written in just 20 minutes as a filler track to pad out the album of the same name — yet it became Black Sabbath's only UK top five single. The band originally wanted to call it The Paranoid but producer Rodger Bain shortened it. It remains one of the most-covered metal songs of all time.",
-      "fun_fact_de": "Paranoid wurde in nur 20 Minuten als Füllstück für das gleichnamige Album geschrieben — und wurde dennoch Black Sabbaths einzige britische Top-5-Single. Die Band wollte es ursprünglich 'The Paranoid' nennen, aber Produzent Rodger Bain kürzte den Titel.",
-      "fun_fact_es": "Paranoid fue escrita en solo 20 minutos como relleno para el álbum del mismo nombre — y sin embargo se convirtió en el único single top cinco del Reino Unido de Black Sabbath. La banda originalmente quería llamarla 'The Paranoid' pero el productor Rodger Bain lo acortó.",
-      "fun_fact_fr": "Paranoid a été écrit en seulement 20 minutes comme morceau de remplissage pour l'album du même nom — et est pourtant devenu le seul single top cinq britannique de Black Sabbath. Le groupe voulait initialement l'appeler 'The Paranoid' mais le producteur Rodger Bain l'a raccourci.",
+      "fun_fact": "Paranoid was written in just 20 minutes as a filler track to pad out the album of the same name \u2014 yet it became Black Sabbath's only UK top five single. The band originally wanted to call it The Paranoid but producer Rodger Bain shortened it. It remains one of the most-covered metal songs of all time.",
+      "fun_fact_de": "Paranoid wurde in nur 20 Minuten als F\u00fcllst\u00fcck f\u00fcr das gleichnamige Album geschrieben \u2014 und wurde dennoch Black Sabbaths einzige britische Top-5-Single. Die Band wollte es urspr\u00fcnglich 'The Paranoid' nennen, aber Produzent Rodger Bain k\u00fcrzte den Titel.",
+      "fun_fact_es": "Paranoid fue escrita en solo 20 minutos como relleno para el \u00e1lbum del mismo nombre \u2014 y sin embargo se convirti\u00f3 en el \u00fanico single top cinco del Reino Unido de Black Sabbath. La banda originalmente quer\u00eda llamarla 'The Paranoid' pero el productor Rodger Bain lo acort\u00f3.",
+      "fun_fact_fr": "Paranoid a \u00e9t\u00e9 \u00e9crit en seulement 20 minutes comme morceau de remplissage pour l'album du m\u00eame nom \u2014 et est pourtant devenu le seul single top cinq britannique de Black Sabbath. Le groupe voulait initialement l'appeler 'The Paranoid' mais le producteur Rodger Bain l'a raccourci.",
       "uri_apple_music": "applemusic://track/785232521",
       "uri_youtube_music": "https://music.youtube.com/watch?v=0qanF-91aJo",
       "uri_tidal": "tidal://track/4085422",
@@ -98,9 +98,9 @@
         "Grammy nomination"
       ],
       "fun_fact": "Judas Priest pioneered the leather-and-studs look that became synonymous with heavy metal, with vocalist Rob Halford drawing inspiration from the gay leather subculture. The band is widely credited with codifying the sound and image of heavy metal. Halford came out as gay in 1998, making him one of the first major rock stars to do so.",
-      "fun_fact_de": "Judas Priest etablierten den Leder-und-Nieten-Look, der zum Synonym für Heavy Metal wurde, wobei Sänger Rob Halford seine Inspiration aus der schwulen Leder-Subkultur bezog. Halford outete sich 1998 als einer der ersten großen Rockstars.",
-      "fun_fact_es": "Judas Priest fue pionero del look de cuero y tachas que se convirtió en sinónimo del heavy metal, con el vocalista Rob Halford tomando inspiración de la subcultura gay del cuero. Halford salió del armario en 1998 como uno de los primeros grandes rockeros en hacerlo.",
-      "fun_fact_fr": "Judas Priest a été le pionnier du look cuir et clous synonyme du heavy metal, le chanteur Rob Halford s'inspirant de la sous-culture gay du cuir. Halford a fait son coming out en 1998, devenant l'un des premiers grands rockeurs à le faire.",
+      "fun_fact_de": "Judas Priest etablierten den Leder-und-Nieten-Look, der zum Synonym f\u00fcr Heavy Metal wurde, wobei S\u00e4nger Rob Halford seine Inspiration aus der schwulen Leder-Subkultur bezog. Halford outete sich 1998 als einer der ersten gro\u00dfen Rockstars.",
+      "fun_fact_es": "Judas Priest fue pionero del look de cuero y tachas que se convirti\u00f3 en sin\u00f3nimo del heavy metal, con el vocalista Rob Halford tomando inspiraci\u00f3n de la subcultura gay del cuero. Halford sali\u00f3 del armario en 1998 como uno de los primeros grandes rockeros en hacerlo.",
+      "fun_fact_fr": "Judas Priest a \u00e9t\u00e9 le pionnier du look cuir et clous synonyme du heavy metal, le chanteur Rob Halford s'inspirant de la sous-culture gay du cuir. Halford a fait son coming out en 1998, devenant l'un des premiers grands rockeurs \u00e0 le faire.",
       "uri_apple_music": "applemusic://track/207178357",
       "uri_youtube_music": "https://music.youtube.com/watch?v=jbLWEGr-CCA",
       "uri_tidal": "tidal://track/3459601",
@@ -131,9 +131,9 @@
         "Grammy nomination"
       ],
       "fun_fact": "Iron Maiden's mascot Eddie has appeared on every album cover since their debut and has become one of the most recognisable characters in rock music. The band uses a life-size Eddie puppet in their live shows. Maiden have sold over 100 million albums worldwide and are widely regarded as the greatest heavy metal band of all time.",
-      "fun_fact_de": "Iron Maidens Maskottchen Eddie ist seit dem Debüt auf jedem Albumcover zu sehen und ist zu einer der bekanntesten Figuren der Rockmusik geworden. Die Band verwendet eine lebensgroße Eddie-Puppe bei Live-Auftritten.",
-      "fun_fact_es": "La mascota Eddie de Iron Maiden ha aparecido en cada portada de álbum desde su debut y se ha convertido en uno de los personajes más reconocibles de la música rock. La banda utiliza una marioneta de Eddie a tamaño real en sus espectáculos en directo.",
-      "fun_fact_fr": "La mascotte Eddie d'Iron Maiden apparaît sur chaque pochette d'album depuis leur débuts et est devenue l'un des personnages les plus reconnaissables de la musique rock. Le groupe utilise une marionnette Eddie grandeur nature dans ses spectacles live.",
+      "fun_fact_de": "Iron Maidens Maskottchen Eddie ist seit dem Deb\u00fct auf jedem Albumcover zu sehen und ist zu einer der bekanntesten Figuren der Rockmusik geworden. Die Band verwendet eine lebensgro\u00dfe Eddie-Puppe bei Live-Auftritten.",
+      "fun_fact_es": "La mascota Eddie de Iron Maiden ha aparecido en cada portada de \u00e1lbum desde su debut y se ha convertido en uno de los personajes m\u00e1s reconocibles de la m\u00fasica rock. La banda utiliza una marioneta de Eddie a tama\u00f1o real en sus espect\u00e1culos en directo.",
+      "fun_fact_fr": "La mascotte Eddie d'Iron Maiden appara\u00eet sur chaque pochette d'album depuis leur d\u00e9buts et est devenue l'un des personnages les plus reconnaissables de la musique rock. Le groupe utilise une marionnette Eddie grandeur nature dans ses spectacles live.",
       "uri_apple_music": "applemusic://track/1713861908",
       "uri_youtube_music": "https://music.youtube.com/watch?v=X4bgXH3sJ2Q",
       "uri_tidal": "tidal://track/63918447",
@@ -164,13 +164,13 @@
         "Grammy nomination"
       ],
       "fun_fact": "The Number of the Beast sparked mass protests and record burnings by religious groups in the United States upon its release in 1982, which only boosted its notoriety and sales. Vocalist Bruce Dickinson joined the band just before this album and his soaring voice defined the classic Maiden sound. The album went to number one in the UK.",
-      "fun_fact_de": "The Number of the Beast löste bei seiner Veröffentlichung 1982 in den USA Massenproteste und Schallplattenverbrennungen durch religiöse Gruppen aus, was seine Bekanntheit und die Verkäufe nur steigerte. Sänger Bruce Dickinson trat kurz vor diesem Album der Band bei.",
-      "fun_fact_es": "The Number of the Beast provocó protestas masivas y quemas de discos por parte de grupos religiosos en Estados Unidos al salir en 1982, lo que solo impulsó su notoriedad y ventas. El vocalista Bruce Dickinson se unió a la banda justo antes de este álbum.",
-      "fun_fact_fr": "The Number of the Beast a provoqué des manifestations massives et des brûlages de disques par des groupes religieux aux États-Unis en 1982, ce qui n'a fait qu'accroître sa notoriété et ses ventes. Le chanteur Bruce Dickinson a rejoint le groupe juste avant cet album.",
+      "fun_fact_de": "The Number of the Beast l\u00f6ste bei seiner Ver\u00f6ffentlichung 1982 in den USA Massenproteste und Schallplattenverbrennungen durch religi\u00f6se Gruppen aus, was seine Bekanntheit und die Verk\u00e4ufe nur steigerte. S\u00e4nger Bruce Dickinson trat kurz vor diesem Album der Band bei.",
+      "fun_fact_es": "The Number of the Beast provoc\u00f3 protestas masivas y quemas de discos por parte de grupos religiosos en Estados Unidos al salir en 1982, lo que solo impuls\u00f3 su notoriedad y ventas. El vocalista Bruce Dickinson se uni\u00f3 a la banda justo antes de este \u00e1lbum.",
+      "fun_fact_fr": "The Number of the Beast a provoqu\u00e9 des manifestations massives et des br\u00fblages de disques par des groupes religieux aux \u00c9tats-Unis en 1982, ce qui n'a fait qu'accro\u00eetre sa notori\u00e9t\u00e9 et ses ventes. Le chanteur Bruce Dickinson a rejoint le groupe juste avant cet album.",
       "uri_apple_music": "applemusic://track/1713862907",
       "uri_youtube_music": "https://music.youtube.com/watch?v=WxnN05vOuSM",
       "uri_tidal": "tidal://track/63918429",
-      "fun_fact_nl": "The Number of the Beast leidde bij de release in 1982 tot massale protesten en plaatverbrandingen door religieuze groeperingen in de Verenigde Staten, wat de bekendheid en verkoop alleen maar ten goede kwam. Zanger Bruce Dickinson kwam vlak voor dit album bij de band en zijn hoge stem definieerde het klassieke Maiden-geluid. Het album kwam op nummer één in de UK.",
+      "fun_fact_nl": "The Number of the Beast leidde bij de release in 1982 tot massale protesten en plaatverbrandingen door religieuze groeperingen in de Verenigde Staten, wat de bekendheid en verkoop alleen maar ten goede kwam. Zanger Bruce Dickinson kwam vlak voor dit album bij de band en zijn hoge stem definieerde het klassieke Maiden-geluid. Het album kwam op nummer \u00e9\u00e9n in de UK.",
       "awards_nl": [
         "Grammy-nominatie"
       ]
@@ -197,13 +197,13 @@
         "Grammy Hall of Fame"
       ],
       "fun_fact": "Master of Puppets is widely considered the greatest heavy metal album ever made, and its title track is one of the most technically demanding and beloved metal songs of all time. The song reached new generations after being featured in the fourth season of Stranger Things in 2022, sending it to number one on Spotify globally. Bassist Cliff Burton died in a bus accident just months after the album's release.",
-      "fun_fact_de": "Master of Puppets gilt allgemein als das beste Heavy-Metal-Album aller Zeiten. Der Titelsong erreichte neue Generationen, nachdem er 2022 in der vierten Staffel von Stranger Things vorkam und weltweit auf Platz 1 auf Spotify stieg. Bassist Cliff Burton starb kurz nach der Veröffentlichung bei einem Busunglück.",
-      "fun_fact_es": "Master of Puppets es considerado ampliamente el mejor álbum de heavy metal jamás grabado. La canción llegó a nuevas generaciones tras aparecer en la cuarta temporada de Stranger Things en 2022, llevándola al número uno en Spotify global. El bajista Cliff Burton murió en un accidente de autobús meses después del lanzamiento.",
-      "fun_fact_fr": "Master of Puppets est largement considéré comme le meilleur album de heavy metal jamais enregistré. Le titre a atteint de nouvelles générations après avoir été présenté dans la quatrième saison de Stranger Things en 2022, le propulsant numéro un sur Spotify mondial. Le bassiste Cliff Burton est décédé dans un accident de bus peu après la sortie.",
+      "fun_fact_de": "Master of Puppets gilt allgemein als das beste Heavy-Metal-Album aller Zeiten. Der Titelsong erreichte neue Generationen, nachdem er 2022 in der vierten Staffel von Stranger Things vorkam und weltweit auf Platz 1 auf Spotify stieg. Bassist Cliff Burton starb kurz nach der Ver\u00f6ffentlichung bei einem Busungl\u00fcck.",
+      "fun_fact_es": "Master of Puppets es considerado ampliamente el mejor \u00e1lbum de heavy metal jam\u00e1s grabado. La canci\u00f3n lleg\u00f3 a nuevas generaciones tras aparecer en la cuarta temporada de Stranger Things en 2022, llev\u00e1ndola al n\u00famero uno en Spotify global. El bajista Cliff Burton muri\u00f3 en un accidente de autob\u00fas meses despu\u00e9s del lanzamiento.",
+      "fun_fact_fr": "Master of Puppets est largement consid\u00e9r\u00e9 comme le meilleur album de heavy metal jamais enregistr\u00e9. Le titre a atteint de nouvelles g\u00e9n\u00e9rations apr\u00e8s avoir \u00e9t\u00e9 pr\u00e9sent\u00e9 dans la quatri\u00e8me saison de Stranger Things en 2022, le propulsant num\u00e9ro un sur Spotify mondial. Le bassiste Cliff Burton est d\u00e9c\u00e9d\u00e9 dans un accident de bus peu apr\u00e8s la sortie.",
       "uri_apple_music": "applemusic://track/1275819878",
       "uri_youtube_music": "https://music.youtube.com/watch?v=E0ozmU9cJDg",
       "uri_tidal": "tidal://track/179213196",
-      "fun_fact_nl": "Master of Puppets wordt algemeen beschouwd als het beste heavy metal album ooit gemaakt, en het titelnummer is een van de meest technisch veeleisende en geliefde metalsongs aller tijden. Het nummer bereikte nieuwe generaties nadat het in 2022 te horen was in het vierde seizoen van Stranger Things, waardoor het wereldwijd op nummer één kwam te staan op Spotify. Bassist Cliff Burton stierf bij een busongeluk slechts enkele maanden na de release van het album.",
+      "fun_fact_nl": "Master of Puppets wordt algemeen beschouwd als het beste heavy metal album ooit gemaakt, en het titelnummer is een van de meest technisch veeleisende en geliefde metalsongs aller tijden. Het nummer bereikte nieuwe generaties nadat het in 2022 te horen was in het vierde seizoen van Stranger Things, waardoor het wereldwijd op nummer \u00e9\u00e9n kwam te staan op Spotify. Bassist Cliff Burton stierf bij een busongeluk slechts enkele maanden na de release van het album.",
       "awards_nl": [
         "Grammy Hall of Fame"
       ]
@@ -229,10 +229,10 @@
       "awards": [
         "Grammy Award for Best Metal Performance"
       ],
-      "fun_fact": "Enter Sandman opened the Black Album — Metallica's self-titled 1991 record that became the best-selling album in SoundScan history with over 16 million US copies sold. The song's minimalist, groove-driven approach marked a dramatic departure from their thrash roots and brought metal to the mainstream. The music video, directed by Wayne Isham, remains one of the most-watched metal videos ever.",
-      "fun_fact_de": "Enter Sandman eröffnete das Black Album — Metallicas gleichnamiges Album von 1991, das mit über 16 Millionen verkauften US-Exemplaren zum meistverkauften Album in der SoundScan-Geschichte wurde. Der Song brachte Metal in den Mainstream.",
-      "fun_fact_es": "Enter Sandman abrió el Black Album — el disco homónimo de Metallica de 1991 que se convirtió en el álbum más vendido en la historia de SoundScan con más de 16 millones de copias vendidas en EE.UU. La canción llevó el metal al mainstream.",
-      "fun_fact_fr": "Enter Sandman a ouvert le Black Album — le disque éponyme de Metallica de 1991 qui est devenu l'album le plus vendu de l'histoire de SoundScan avec plus de 16 millions d'exemplaires vendus aux États-Unis. La chanson a amené le metal dans le grand public.",
+      "fun_fact": "Enter Sandman opened the Black Album \u2014 Metallica's self-titled 1991 record that became the best-selling album in SoundScan history with over 16 million US copies sold. The song's minimalist, groove-driven approach marked a dramatic departure from their thrash roots and brought metal to the mainstream. The music video, directed by Wayne Isham, remains one of the most-watched metal videos ever.",
+      "fun_fact_de": "Enter Sandman er\u00f6ffnete das Black Album \u2014 Metallicas gleichnamiges Album von 1991, das mit \u00fcber 16 Millionen verkauften US-Exemplaren zum meistverkauften Album in der SoundScan-Geschichte wurde. Der Song brachte Metal in den Mainstream.",
+      "fun_fact_es": "Enter Sandman abri\u00f3 el Black Album \u2014 el disco hom\u00f3nimo de Metallica de 1991 que se convirti\u00f3 en el \u00e1lbum m\u00e1s vendido en la historia de SoundScan con m\u00e1s de 16 millones de copias vendidas en EE.UU. La canci\u00f3n llev\u00f3 el metal al mainstream.",
+      "fun_fact_fr": "Enter Sandman a ouvert le Black Album \u2014 le disque \u00e9ponyme de Metallica de 1991 qui est devenu l'album le plus vendu de l'histoire de SoundScan avec plus de 16 millions d'exemplaires vendus aux \u00c9tats-Unis. La chanson a amen\u00e9 le metal dans le grand public.",
       "uri_apple_music": "applemusic://track/1572051818",
       "uri_youtube_music": "https://music.youtube.com/watch?v=CD-E-LDc384",
       "uri_tidal": "tidal://track/179213193",
@@ -263,13 +263,13 @@
         "Grammy Award for Best Metal Performance"
       ],
       "fun_fact": "One was Metallica's first-ever music video, inspired by the 1971 anti-war film Johnny Got His Gun. The song begins as a haunting ballad before exploding into a ferocious thrash assault, mirroring the psychological descent of a soldier left as a limbless, senseless torso. It won Metallica their first Grammy Award.",
-      "fun_fact_de": "One war Metallicas erstes Musikvideo, inspiriert vom Antikriegsfilm Johnny Got His Gun von 1971. Der Song beginnt als eindringliche Ballade, bevor er in einen wütenden Thrash-Angriff übergeht. Er gewann Metallica ihren ersten Grammy Award.",
-      "fun_fact_es": "One fue el primer videoclip de Metallica, inspirado en la película antibélica de 1971 Johnny Got His Gun. La canción comienza como una perturbadora balada antes de explotar en un feroz asalto de thrash. Le valió a Metallica su primer Grammy.",
-      "fun_fact_fr": "One a été le premier clip de Metallica, inspiré du film antimilitariste de 1971 Johnny Got His Gun. La chanson commence comme une ballade envoûtante avant d'exploser en un assaut thrash féroce. Elle a valu à Metallica leur premier Grammy.",
+      "fun_fact_de": "One war Metallicas erstes Musikvideo, inspiriert vom Antikriegsfilm Johnny Got His Gun von 1971. Der Song beginnt als eindringliche Ballade, bevor er in einen w\u00fctenden Thrash-Angriff \u00fcbergeht. Er gewann Metallica ihren ersten Grammy Award.",
+      "fun_fact_es": "One fue el primer videoclip de Metallica, inspirado en la pel\u00edcula antib\u00e9lica de 1971 Johnny Got His Gun. La canci\u00f3n comienza como una perturbadora balada antes de explotar en un feroz asalto de thrash. Le vali\u00f3 a Metallica su primer Grammy.",
+      "fun_fact_fr": "One a \u00e9t\u00e9 le premier clip de Metallica, inspir\u00e9 du film antimilitariste de 1971 Johnny Got His Gun. La chanson commence comme une ballade envo\u00fbtante avant d'exploser en un assaut thrash f\u00e9roce. Elle a valu \u00e0 Metallica leur premier Grammy.",
       "uri_apple_music": "applemusic://track/1433828082",
       "uri_youtube_music": "https://music.youtube.com/watch?v=WM8bTdBs-cw",
       "uri_tidal": "tidal://track/179213189",
-      "fun_fact_nl": "One was Metallica's allereerste videoclip, geïnspireerd op de anti-oorlogsfilm Johnny Got His Gun uit 1971. Het nummer begint als een beklemmende ballade voordat het explodeert in een woeste thrashaanval, die de psychologische afdaling weerspiegelt van een soldaat die wordt achtergelaten als een verlamd, gevoelloos torso. Het leverde Metallica hun eerste Grammy Award op.",
+      "fun_fact_nl": "One was Metallica's allereerste videoclip, ge\u00efnspireerd op de anti-oorlogsfilm Johnny Got His Gun uit 1971. Het nummer begint als een beklemmende ballade voordat het explodeert in een woeste thrashaanval, die de psychologische afdaling weerspiegelt van een soldaat die wordt achtergelaten als een verlamd, gevoelloos torso. Het leverde Metallica hun eerste Grammy Award op.",
       "awards_nl": [
         "Grammy Award voor Beste Metalprestatie"
       ]
@@ -296,13 +296,13 @@
         "Grammy nomination"
       ],
       "fun_fact": "Raining Blood closes Slayer's landmark album Reign in Blood, which at 28 minutes 58 seconds is one of the shortest metal albums ever made. Producer Rick Rubin stripped away all excess and created the most intense thrash metal record ever recorded. The song's iconic outro riff is considered one of the most powerful in metal history.",
-      "fun_fact_de": "Raining Blood schließt Slayers Meilenstein-Album Reign in Blood ab, das mit 28 Minuten und 58 Sekunden eines der kürzesten Metal-Alben aller Zeiten ist. Produzent Rick Rubin schuf das intensivste Thrash-Metal-Album aller Zeiten.",
-      "fun_fact_es": "Raining Blood cierra el emblemático álbum de Slayer Reign in Blood, que con 28 minutos y 58 segundos es uno de los álbumes de metal más cortos jamás grabados. El productor Rick Rubin creó el disco de thrash metal más intenso jamás grabado.",
-      "fun_fact_fr": "Raining Blood clôt le légendaire album Reign in Blood de Slayer, qui avec 28 minutes 58 secondes est l'un des albums de métal les plus courts jamais enregistrés. Le producteur Rick Rubin a créé le disque de thrash metal le plus intense jamais enregistré.",
+      "fun_fact_de": "Raining Blood schlie\u00dft Slayers Meilenstein-Album Reign in Blood ab, das mit 28 Minuten und 58 Sekunden eines der k\u00fcrzesten Metal-Alben aller Zeiten ist. Produzent Rick Rubin schuf das intensivste Thrash-Metal-Album aller Zeiten.",
+      "fun_fact_es": "Raining Blood cierra el emblem\u00e1tico \u00e1lbum de Slayer Reign in Blood, que con 28 minutos y 58 segundos es uno de los \u00e1lbumes de metal m\u00e1s cortos jam\u00e1s grabados. El productor Rick Rubin cre\u00f3 el disco de thrash metal m\u00e1s intenso jam\u00e1s grabado.",
+      "fun_fact_fr": "Raining Blood cl\u00f4t le l\u00e9gendaire album Reign in Blood de Slayer, qui avec 28 minutes 58 secondes est l'un des albums de m\u00e9tal les plus courts jamais enregistr\u00e9s. Le producteur Rick Rubin a cr\u00e9\u00e9 le disque de thrash metal le plus intense jamais enregistr\u00e9.",
       "uri_apple_music": "applemusic://track/1733769810",
       "uri_youtube_music": "https://music.youtube.com/watch?v=z8ZqFlw6hYg",
       "uri_tidal": "tidal://track/4297780",
-      "fun_fact_nl": "Raining Blood is de afsluiter van Slayers baanbrekende album Reign in Blood, dat met 28 minuten en 58 seconden een van de kortste metalalbums is die ooit zijn gemaakt. Producer Rick Rubin ontdeed zich van alle overdaad en creëerde de meest intense thrashmetalplaat die ooit is opgenomen. De iconische outro riff van het nummer wordt beschouwd als een van de krachtigste uit de metalgeschiedenis.",
+      "fun_fact_nl": "Raining Blood is de afsluiter van Slayers baanbrekende album Reign in Blood, dat met 28 minuten en 58 seconden een van de kortste metalalbums is die ooit zijn gemaakt. Producer Rick Rubin ontdeed zich van alle overdaad en cre\u00eberde de meest intense thrashmetalplaat die ooit is opgenomen. De iconische outro riff van het nummer wordt beschouwd als een van de krachtigste uit de metalgeschiedenis.",
       "awards_nl": [
         "Grammy-nominatie"
       ]
@@ -329,9 +329,9 @@
         "Grammy nomination"
       ],
       "fun_fact": "Walk became Pantera's signature song and one of the defining tracks of groove metal. Guitarist Dimebag Darrell's crushing riff and Phil Anselmo's confrontational vocals made it an anthem of aggression. Dimebag Darrell was tragically shot and killed on stage in 2004, making Walk an even more poignant piece of metal history.",
-      "fun_fact_de": "Walk wurde zu Panteras Signature-Song und einem der prägenden Tracks des Groove Metal. Dimebag Darrells vernichtendes Riff und Phil Anselmos konfrontativer Gesang machten es zur Aggressionshymne. Dimebag Darrell wurde 2004 tragisch auf der Bühne erschossen.",
-      "fun_fact_es": "Walk se convirtió en la canción insignia de Pantera y uno de los temas definitorios del groove metal. El aplastante riff de Dimebag Darrell y los confrontacionales vocals de Phil Anselmo lo convirtieron en un himno de agresión. Dimebag Darrell fue trágicamente asesinado en el escenario en 2004.",
-      "fun_fact_fr": "Walk est devenu la chanson signature de Pantera et l'un des titres définisseurs du groove metal. Le riff dévastateur de Dimebag Darrell et les vocaux confrontationnels de Phil Anselmo en ont fait un hymne d'agressivité. Dimebag Darrell a été tragiquement assassiné sur scène en 2004.",
+      "fun_fact_de": "Walk wurde zu Panteras Signature-Song und einem der pr\u00e4genden Tracks des Groove Metal. Dimebag Darrells vernichtendes Riff und Phil Anselmos konfrontativer Gesang machten es zur Aggressionshymne. Dimebag Darrell wurde 2004 tragisch auf der B\u00fchne erschossen.",
+      "fun_fact_es": "Walk se convirti\u00f3 en la canci\u00f3n insignia de Pantera y uno de los temas definitorios del groove metal. El aplastante riff de Dimebag Darrell y los confrontacionales vocals de Phil Anselmo lo convirtieron en un himno de agresi\u00f3n. Dimebag Darrell fue tr\u00e1gicamente asesinado en el escenario en 2004.",
+      "fun_fact_fr": "Walk est devenu la chanson signature de Pantera et l'un des titres d\u00e9finisseurs du groove metal. Le riff d\u00e9vastateur de Dimebag Darrell et les vocaux confrontationnels de Phil Anselmo en ont fait un hymne d'agressivit\u00e9. Dimebag Darrell a \u00e9t\u00e9 tragiquement assassin\u00e9 sur sc\u00e8ne en 2004.",
       "uri_apple_music": "applemusic://track/518549369",
       "uri_youtube_music": "https://music.youtube.com/watch?v=AkFqg5wAuFk",
       "uri_tidal": "tidal://track/3490601",
@@ -362,9 +362,9 @@
         "Grammy nomination"
       ],
       "fun_fact": "Cowboys from Hell marked Pantera's mainstream breakthrough in 1990 and introduced the world to Dimebag Darrell's devastating guitar technique. The title track's aggressive groove and Anselmo's fierce vocals defined a new era of American heavy metal. The album is considered a landmark in the genre.",
-      "fun_fact_de": "Cowboys from Hell markierte 1990 Panteras Mainstream-Durchbruch und stellte die Welt Dimebag Darrells vernichtender Gitarrentechnik vor. Der Titelsong definierte eine neue Ära des amerikanischen Heavy Metal.",
-      "fun_fact_es": "Cowboys from Hell marcó el gran avance de Pantera en el mainstream en 1990 y presentó al mundo la devastadora técnica de guitarra de Dimebag Darrell. El tema definió una nueva era del heavy metal americano.",
-      "fun_fact_fr": "Cowboys from Hell a marqué la percée de Pantera dans le grand public en 1990 et a présenté au monde la technique de guitare dévastatrice de Dimebag Darrell. Le titre a défini une nouvelle ère du heavy metal américain.",
+      "fun_fact_de": "Cowboys from Hell markierte 1990 Panteras Mainstream-Durchbruch und stellte die Welt Dimebag Darrells vernichtender Gitarrentechnik vor. Der Titelsong definierte eine neue \u00c4ra des amerikanischen Heavy Metal.",
+      "fun_fact_es": "Cowboys from Hell marc\u00f3 el gran avance de Pantera en el mainstream en 1990 y present\u00f3 al mundo la devastadora t\u00e9cnica de guitarra de Dimebag Darrell. El tema defini\u00f3 una nueva era del heavy metal americano.",
+      "fun_fact_fr": "Cowboys from Hell a marqu\u00e9 la perc\u00e9e de Pantera dans le grand public en 1990 et a pr\u00e9sent\u00e9 au monde la technique de guitare d\u00e9vastatrice de Dimebag Darrell. Le titre a d\u00e9fini une nouvelle \u00e8re du heavy metal am\u00e9ricain.",
       "uri_apple_music": "applemusic://track/389079825",
       "uri_youtube_music": "https://music.youtube.com/watch?v=2DfYLar2QGI",
       "uri_tidal": "tidal://track/3490591",
@@ -395,9 +395,9 @@
         "Grammy nomination"
       ],
       "fun_fact": "Seek and Destroy from Metallica's debut Kill 'Em All is one of the band's oldest and most beloved live staples, almost never missing a setlist. The album was originally rejected by major labels and self-financed by Megaforce Records, almost single-handedly launching the American thrash metal scene. The song's call-and-response structure makes it an electric crowd moment.",
-      "fun_fact_de": "Seek and Destroy von Metallicas Debüt Kill 'Em All ist einer der ältesten und beliebtesten Live-Dauerbrenner der Band. Das Album wurde von großen Labels abgelehnt und von Megaforce Records selbst finanziert, was die amerikanische Thrash-Metal-Szene quasi im Alleingang startete.",
-      "fun_fact_es": "Seek and Destroy del debut de Metallica Kill 'Em All es uno de los temas en directo más antiguos y queridos de la banda. El álbum fue rechazado por los grandes sellos y autofinanciado por Megaforce Records, lanzando casi en solitario la escena del thrash metal americano.",
-      "fun_fact_fr": "Seek and Destroy du premier album de Metallica Kill 'Em All est l'un des classiques live les plus anciens et les plus appréciés du groupe. L'album a été rejeté par les grands labels et autofinancé par Megaforce Records, lançant presque à lui seul la scène thrash metal américaine.",
+      "fun_fact_de": "Seek and Destroy von Metallicas Deb\u00fct Kill 'Em All ist einer der \u00e4ltesten und beliebtesten Live-Dauerbrenner der Band. Das Album wurde von gro\u00dfen Labels abgelehnt und von Megaforce Records selbst finanziert, was die amerikanische Thrash-Metal-Szene quasi im Alleingang startete.",
+      "fun_fact_es": "Seek and Destroy del debut de Metallica Kill 'Em All es uno de los temas en directo m\u00e1s antiguos y queridos de la banda. El \u00e1lbum fue rechazado por los grandes sellos y autofinanciado por Megaforce Records, lanzando casi en solitario la escena del thrash metal americano.",
+      "fun_fact_fr": "Seek and Destroy du premier album de Metallica Kill 'Em All est l'un des classiques live les plus anciens et les plus appr\u00e9ci\u00e9s du groupe. L'album a \u00e9t\u00e9 rejet\u00e9 par les grands labels et autofinanc\u00e9 par Megaforce Records, lan\u00e7ant presque \u00e0 lui seul la sc\u00e8ne thrash metal am\u00e9ricaine.",
       "uri_apple_music": "applemusic://track/579146168",
       "uri_youtube_music": "https://music.youtube.com/watch?v=J-ViMDqDBPE",
       "uri_tidal": "tidal://track/179213181",
@@ -428,9 +428,9 @@
         "Grammy nomination"
       ],
       "fun_fact": "Holy Wars opens Rust in Peace, widely considered Megadeth's masterpiece and one of the greatest thrash metal albums ever recorded. Dave Mustaine founded Megadeth after being fired from Metallica in 1983, and for years the rivalry between the two bands drove both to ever-greater creative heights. The album features future Mars Volta drummer Marty Friedman and Nick Menza.",
-      "fun_fact_de": "Holy Wars eröffnet Rust in Peace, das allgemein als Megadeths Meisterwerk gilt. Dave Mustaine gründete Megadeth, nachdem er 1983 aus Metallica entlassen wurde, und die Rivalität zwischen den beiden Bands trieb sie zu immer größeren kreativen Höhen.",
-      "fun_fact_es": "Holy Wars abre Rust in Peace, considerado ampliamente como la obra maestra de Megadeth. Dave Mustaine fundó Megadeth tras ser expulsado de Metallica en 1983, y la rivalidad entre ambas bandas los impulsó a mayores alturas creativas.",
-      "fun_fact_fr": "Holy Wars ouvre Rust in Peace, largement considéré comme le chef-d'œuvre de Megadeth. Dave Mustaine a fondé Megadeth après avoir été renvoyé de Metallica en 1983, et la rivalité entre les deux groupes les a poussés à de plus grandes hauteurs créatives.",
+      "fun_fact_de": "Holy Wars er\u00f6ffnet Rust in Peace, das allgemein als Megadeths Meisterwerk gilt. Dave Mustaine gr\u00fcndete Megadeth, nachdem er 1983 aus Metallica entlassen wurde, und die Rivalit\u00e4t zwischen den beiden Bands trieb sie zu immer gr\u00f6\u00dferen kreativen H\u00f6hen.",
+      "fun_fact_es": "Holy Wars abre Rust in Peace, considerado ampliamente como la obra maestra de Megadeth. Dave Mustaine fund\u00f3 Megadeth tras ser expulsado de Metallica en 1983, y la rivalidad entre ambas bandas los impuls\u00f3 a mayores alturas creativas.",
+      "fun_fact_fr": "Holy Wars ouvre Rust in Peace, largement consid\u00e9r\u00e9 comme le chef-d'\u0153uvre de Megadeth. Dave Mustaine a fond\u00e9 Megadeth apr\u00e8s avoir \u00e9t\u00e9 renvoy\u00e9 de Metallica en 1983, et la rivalit\u00e9 entre les deux groupes les a pouss\u00e9s \u00e0 de plus grandes hauteurs cr\u00e9atives.",
       "uri_apple_music": "applemusic://track/724649275",
       "uri_youtube_music": "https://music.youtube.com/watch?v=9d4ui9q7eDM",
       "uri_tidal": "tidal://track/4085478",
@@ -461,13 +461,13 @@
         "Grammy nomination"
       ],
       "fun_fact": "Symphony of Destruction is Megadeth's most commercially successful song, balancing accessibility with Dave Mustaine's trademark aggression. Its memorable main riff was inspired by a simple chord progression Mustaine stumbled upon during soundcheck. The song remains one of the most played tracks on rock radio decades after its release.",
-      "fun_fact_de": "Symphony of Destruction ist Megadeths kommerziell erfolgreichster Song und balanciert Zugänglichkeit mit Dave Mustaines Markenzeichen-Aggression. Das eingängige Haupt-Riff entstand durch einen einfachen Akkord, den Mustaine beim Soundcheck entdeckte.",
-      "fun_fact_es": "Symphony of Destruction es el tema comercialmente más exitoso de Megadeth, equilibrando accesibilidad con la característica agresividad de Dave Mustaine. El memorable riff principal nació de un simple acorde que Mustaine descubrió en el soundcheck.",
-      "fun_fact_fr": "Symphony of Destruction est le titre commercialement le plus réussi de Megadeth, équilibrant accessibilité et l'agressivité caractéristique de Dave Mustaine. Le riff principal mémorable est né d'un accord simple que Mustaine a découvert lors d'un soundcheck.",
+      "fun_fact_de": "Symphony of Destruction ist Megadeths kommerziell erfolgreichster Song und balanciert Zug\u00e4nglichkeit mit Dave Mustaines Markenzeichen-Aggression. Das eing\u00e4ngige Haupt-Riff entstand durch einen einfachen Akkord, den Mustaine beim Soundcheck entdeckte.",
+      "fun_fact_es": "Symphony of Destruction es el tema comercialmente m\u00e1s exitoso de Megadeth, equilibrando accesibilidad con la caracter\u00edstica agresividad de Dave Mustaine. El memorable riff principal naci\u00f3 de un simple acorde que Mustaine descubri\u00f3 en el soundcheck.",
+      "fun_fact_fr": "Symphony of Destruction est le titre commercialement le plus r\u00e9ussi de Megadeth, \u00e9quilibrant accessibilit\u00e9 et l'agressivit\u00e9 caract\u00e9ristique de Dave Mustaine. Le riff principal m\u00e9morable est n\u00e9 d'un accord simple que Mustaine a d\u00e9couvert lors d'un soundcheck.",
       "uri_apple_music": "applemusic://track/725812418",
       "uri_youtube_music": "https://music.youtube.com/watch?v=vfpgpf6QVnI",
       "uri_tidal": "tidal://track/4085488",
-      "fun_fact_nl": "Symphony of Destruction is Megadeth's meest commercieel succesvolle nummer, dat toegankelijkheid combineert met Dave Mustaine's kenmerkende agressie. De memorabele hoofdriff werd geïnspireerd door een simpel akkoordenschema waar Mustaine op stuitte tijdens een soundcheck. Het nummer blijft decennia na de release een van de meest gedraaide nummers op de rockradio.",
+      "fun_fact_nl": "Symphony of Destruction is Megadeth's meest commercieel succesvolle nummer, dat toegankelijkheid combineert met Dave Mustaine's kenmerkende agressie. De memorabele hoofdriff werd ge\u00efnspireerd door een simpel akkoordenschema waar Mustaine op stuitte tijdens een soundcheck. Het nummer blijft decennia na de release een van de meest gedraaide nummers op de rockradio.",
       "awards_nl": [
         "Grammy-nominatie"
       ]
@@ -494,13 +494,13 @@
         "Grammy nomination"
       ],
       "fun_fact": "Ronnie James Dio coined the 'devil horns' hand gesture that became universal in metal culture, borrowing it from his Italian grandmother who used it to ward off evil. Dio also served as the second vocalist of Black Sabbath and Rainbow before his groundbreaking solo career. He is considered by many to be the greatest heavy metal vocalist of all time.",
-      "fun_fact_de": "Ronnie James Dio prägte das 'Teufelshörner'-Handzeichen, das universal in der Metal-Kultur wurde, und entlieh es von seiner italienischen Großmutter, die es zum Abwenden von Bösem nutzte. Er gilt als einer der größten Heavy-Metal-Sänger aller Zeiten.",
-      "fun_fact_es": "Ronnie James Dio acuñó el gesto de los 'cuernos del diablo' que se convirtió en universal en la cultura metal, tomándolo de su abuela italiana que lo usaba para ahuyentar el mal. Es considerado por muchos el mejor vocalista de heavy metal de todos los tiempos.",
-      "fun_fact_fr": "Ronnie James Dio a inventé le geste des 'cornes du diable' devenu universel dans la culture metal, en l'empruntant à sa grand-mère italienne qui l'utilisait pour conjurer le mauvais sort. Il est considéré par beaucoup comme le plus grand vocaliste de heavy metal de tous les temps.",
+      "fun_fact_de": "Ronnie James Dio pr\u00e4gte das 'Teufelsh\u00f6rner'-Handzeichen, das universal in der Metal-Kultur wurde, und entlieh es von seiner italienischen Gro\u00dfmutter, die es zum Abwenden von B\u00f6sem nutzte. Er gilt als einer der gr\u00f6\u00dften Heavy-Metal-S\u00e4nger aller Zeiten.",
+      "fun_fact_es": "Ronnie James Dio acu\u00f1\u00f3 el gesto de los 'cuernos del diablo' que se convirti\u00f3 en universal en la cultura metal, tom\u00e1ndolo de su abuela italiana que lo usaba para ahuyentar el mal. Es considerado por muchos el mejor vocalista de heavy metal de todos los tiempos.",
+      "fun_fact_fr": "Ronnie James Dio a invent\u00e9 le geste des 'cornes du diable' devenu universel dans la culture metal, en l'empruntant \u00e0 sa grand-m\u00e8re italienne qui l'utilisait pour conjurer le mauvais sort. Il est consid\u00e9r\u00e9 par beaucoup comme le plus grand vocaliste de heavy metal de tous les temps.",
       "uri_apple_music": "applemusic://track/1048476460",
       "uri_youtube_music": "https://music.youtube.com/watch?v=qcWKZTI9OC4",
       "uri_tidal": "tidal://track/4085503",
-      "fun_fact_nl": "Ronnie James Dio bedacht het handgebaar 'duivelshoorns' dat universeel werd in de metalcultuur. Hij leende het van zijn Italiaanse grootmoeder die het gebruikte om het kwaad af te weren. Dio was ook de tweede zanger van Black Sabbath en Rainbow voor zijn baanbrekende solocarrière. Velen beschouwen hem als de grootste heavy metalzanger aller tijden.",
+      "fun_fact_nl": "Ronnie James Dio bedacht het handgebaar 'duivelshoorns' dat universeel werd in de metalcultuur. Hij leende het van zijn Italiaanse grootmoeder die het gebruikte om het kwaad af te weren. Dio was ook de tweede zanger van Black Sabbath en Rainbow voor zijn baanbrekende solocarri\u00e8re. Velen beschouwen hem als de grootste heavy metalzanger aller tijden.",
       "awards_nl": [
         "Grammy-nominatie"
       ]
@@ -526,10 +526,10 @@
       "awards": [
         "Grammy Hall of Fame"
       ],
-      "fun_fact": "Crazy Train features one of the most recognisable guitar riffs in rock history, played by the late Randy Rhoads — widely regarded as one of the greatest guitarists who ever lived. Rhoads died in a plane crash in 1982 at just 25 years old. The opening 'All aboard!' shout has become one of rock's most iconic moments.",
-      "fun_fact_de": "Crazy Train enthält eines der bekanntesten Gitarrenriffs der Rockgeschichte, gespielt von dem verstorbenen Randy Rhoads — allgemein als einer der größten Gitarristen aller Zeiten angesehen. Rhoads starb 1982 bei einem Flugzeugabsturz mit nur 25 Jahren.",
-      "fun_fact_es": "Crazy Train cuenta con uno de los riffs de guitarra más reconocibles de la historia del rock, tocado por el fallecido Randy Rhoads, ampliamente considerado uno de los mejores guitarristas que jamás haya existido. Rhoads murió en un accidente de avión en 1982 con solo 25 años.",
-      "fun_fact_fr": "Crazy Train présente l'un des riffs de guitare les plus reconnaissables de l'histoire du rock, joué par le regretté Randy Rhoads — largement considéré comme l'un des plus grands guitaristes de tous les temps. Rhoads est décédé dans un accident d'avion en 1982 à seulement 25 ans.",
+      "fun_fact": "Crazy Train features one of the most recognisable guitar riffs in rock history, played by the late Randy Rhoads \u2014 widely regarded as one of the greatest guitarists who ever lived. Rhoads died in a plane crash in 1982 at just 25 years old. The opening 'All aboard!' shout has become one of rock's most iconic moments.",
+      "fun_fact_de": "Crazy Train enth\u00e4lt eines der bekanntesten Gitarrenriffs der Rockgeschichte, gespielt von dem verstorbenen Randy Rhoads \u2014 allgemein als einer der gr\u00f6\u00dften Gitarristen aller Zeiten angesehen. Rhoads starb 1982 bei einem Flugzeugabsturz mit nur 25 Jahren.",
+      "fun_fact_es": "Crazy Train cuenta con uno de los riffs de guitarra m\u00e1s reconocibles de la historia del rock, tocado por el fallecido Randy Rhoads, ampliamente considerado uno de los mejores guitarristas que jam\u00e1s haya existido. Rhoads muri\u00f3 en un accidente de avi\u00f3n en 1982 con solo 25 a\u00f1os.",
+      "fun_fact_fr": "Crazy Train pr\u00e9sente l'un des riffs de guitare les plus reconnaissables de l'histoire du rock, jou\u00e9 par le regrett\u00e9 Randy Rhoads \u2014 largement consid\u00e9r\u00e9 comme l'un des plus grands guitaristes de tous les temps. Rhoads est d\u00e9c\u00e9d\u00e9 dans un accident d'avion en 1982 \u00e0 seulement 25 ans.",
       "uri_apple_music": "applemusic://track/1531535287",
       "uri_youtube_music": "https://music.youtube.com/watch?v=RMR5zf1J1Hs",
       "uri_tidal": "tidal://track/4085511",
@@ -560,9 +560,9 @@
         "Grammy nomination"
       ],
       "fun_fact": "Chop Suey! was originally called Suicide, but the title was changed by the label after the 9/11 attacks due to its sensitive subject matter. The song's unpredictable tempo changes and vocalist Serj Tankian's operatic range made it one of the most distinctive metal songs of the 2000s. System of a Down are one of the most politically outspoken bands in metal history.",
-      "fun_fact_de": "Chop Suey! hieß ursprünglich Suicide, wurde aber nach den Anschlägen vom 11. September umbenannt. Die unvorhersehbaren Tempowechsel und Sänger Serj Tankians operatischer Stimmumfang machten es zu einem der markantesten Metalsongs der 2000er Jahre.",
-      "fun_fact_es": "Chop Suey! se llamaba originalmente Suicide, pero el título fue cambiado por el sello tras los atentados del 11-S. Los impredecibles cambios de tempo y el rango operístico del vocalista Serj Tankian lo convirtieron en uno de los temas de metal más distintivos de los años 2000.",
-      "fun_fact_fr": "Chop Suey! s'appelait à l'origine Suicide, mais le titre a été changé par le label après les attentats du 11 septembre. Les changements de tempo imprévisibles et la portée opératique du chanteur Serj Tankian en ont fait l'un des titres metal les plus distinctifs des années 2000.",
+      "fun_fact_de": "Chop Suey! hie\u00df urspr\u00fcnglich Suicide, wurde aber nach den Anschl\u00e4gen vom 11. September umbenannt. Die unvorhersehbaren Tempowechsel und S\u00e4nger Serj Tankians operatischer Stimmumfang machten es zu einem der markantesten Metalsongs der 2000er Jahre.",
+      "fun_fact_es": "Chop Suey! se llamaba originalmente Suicide, pero el t\u00edtulo fue cambiado por el sello tras los atentados del 11-S. Los impredecibles cambios de tempo y el rango oper\u00edstico del vocalista Serj Tankian lo convirtieron en uno de los temas de metal m\u00e1s distintivos de los a\u00f1os 2000.",
+      "fun_fact_fr": "Chop Suey! s'appelait \u00e0 l'origine Suicide, mais le titre a \u00e9t\u00e9 chang\u00e9 par le label apr\u00e8s les attentats du 11 septembre. Les changements de tempo impr\u00e9visibles et la port\u00e9e op\u00e9ratique du chanteur Serj Tankian en ont fait l'un des titres metal les plus distinctifs des ann\u00e9es 2000.",
       "uri_apple_music": "applemusic://track/273714640",
       "uri_youtube_music": "https://music.youtube.com/watch?v=CSvFpBOe8eY",
       "uri_tidal": "tidal://track/4085523",
@@ -593,13 +593,13 @@
         "Grammy nomination"
       ],
       "fun_fact": "Toxicity is System of a Down's most commercially successful song, its title referring to the toxic environment of modern society. The album of the same name debuted at number one in the US and UK simultaneously. The band's unique blend of Armenian folk influences, thrash metal and alternative rock set them apart from every other band of their era.",
-      "fun_fact_de": "Toxicity ist System of a Downs kommerziell erfolgreichster Song. Das gleichnamige Album debütierte gleichzeitig auf Platz 1 in den USA und Großbritannien. Die einzigartige Mischung aus armenischen Volkseinflüssen, Thrash Metal und Alternative Rock hob sie von allen anderen Bands ihrer Zeit ab.",
-      "fun_fact_es": "Toxicity es el tema comercialmente más exitoso de System of a Down. El álbum homónimo debutó en el número uno en EE.UU. y Reino Unido simultáneamente. La mezcla única de influencias folk armenias, thrash metal y rock alternativo los distinguió de todas las demás bandas de su época.",
-      "fun_fact_fr": "Toxicity est le titre commercialement le plus réussi de System of a Down. L'album éponyme a débuté simultanément à la première place aux États-Unis et au Royaume-Uni. Le mélange unique d'influences folk arméniennes, de thrash metal et de rock alternatif les a distingués de tous les autres groupes de leur époque.",
+      "fun_fact_de": "Toxicity ist System of a Downs kommerziell erfolgreichster Song. Das gleichnamige Album deb\u00fctierte gleichzeitig auf Platz 1 in den USA und Gro\u00dfbritannien. Die einzigartige Mischung aus armenischen Volkseinfl\u00fcssen, Thrash Metal und Alternative Rock hob sie von allen anderen Bands ihrer Zeit ab.",
+      "fun_fact_es": "Toxicity es el tema comercialmente m\u00e1s exitoso de System of a Down. El \u00e1lbum hom\u00f3nimo debut\u00f3 en el n\u00famero uno en EE.UU. y Reino Unido simult\u00e1neamente. La mezcla \u00fanica de influencias folk armenias, thrash metal y rock alternativo los distingui\u00f3 de todas las dem\u00e1s bandas de su \u00e9poca.",
+      "fun_fact_fr": "Toxicity est le titre commercialement le plus r\u00e9ussi de System of a Down. L'album \u00e9ponyme a d\u00e9but\u00e9 simultan\u00e9ment \u00e0 la premi\u00e8re place aux \u00c9tats-Unis et au Royaume-Uni. Le m\u00e9lange unique d'influences folk arm\u00e9niennes, de thrash metal et de rock alternatif les a distingu\u00e9s de tous les autres groupes de leur \u00e9poque.",
       "uri_apple_music": "applemusic://track/273714713",
       "uri_youtube_music": "https://music.youtube.com/watch?v=1yw1Tgj9-VU",
       "uri_tidal": "tidal://track/4085527",
-      "fun_fact_nl": "Toxicity is het meest commercieel succesvolle nummer van System of a Down, waarvan de titel verwijst naar het giftige milieu van de moderne samenleving. Het gelijknamige album debuteerde gelijktijdig op nummer één in de VS en het VK. De unieke mix van Armeense folk-invloeden, thrash metal en alternatieve rock onderscheidt de band van alle andere bands uit hun tijd.",
+      "fun_fact_nl": "Toxicity is het meest commercieel succesvolle nummer van System of a Down, waarvan de titel verwijst naar het giftige milieu van de moderne samenleving. Het gelijknamige album debuteerde gelijktijdig op nummer \u00e9\u00e9n in de VS en het VK. De unieke mix van Armeense folk-invloeden, thrash metal en alternatieve rock onderscheidt de band van alle andere bands uit hun tijd.",
       "awards_nl": [
         "Grammy-nominatie"
       ]
@@ -625,10 +625,10 @@
       "awards": [
         "Grammy Award for Best Metal Performance"
       ],
-      "fun_fact": "Schism won Tool a Grammy for Best Metal Performance in 2002 and is celebrated for its extraordinarily complex time signature — the song shifts between 5/4, 6/8 and other signatures throughout. Tool are renowned for their mathematical approach to composition and the philosophical depth of their lyrics. Vocalist Maynard James Keenan is widely regarded as one of the most gifted singers in rock.",
-      "fun_fact_de": "Schism gewann Tool 2002 einen Grammy für die beste Metal-Performance und ist für seine außerordentlich komplexen Taktarten bekannt — der Song wechselt zwischen 5/4, 6/8 und anderen Signaturen. Tool ist für ihren mathematischen Ansatz bei der Komposition bekannt.",
-      "fun_fact_es": "Schism le valió a Tool un Grammy a la Mejor Actuación Metal en 2002 y es celebrado por su extraordinariamente complejo compás — la canción cambia entre 5/4, 6/8 y otros compases. Tool es reconocido por su enfoque matemático de la composición.",
-      "fun_fact_fr": "Schism a valu à Tool un Grammy de la Meilleure Performance Metal en 2002 et est célébré pour ses signatures rythmiques extraordinairement complexes — la chanson alterne entre 5/4, 6/8 et d'autres signatures. Tool est reconnu pour son approche mathématique de la composition.",
+      "fun_fact": "Schism won Tool a Grammy for Best Metal Performance in 2002 and is celebrated for its extraordinarily complex time signature \u2014 the song shifts between 5/4, 6/8 and other signatures throughout. Tool are renowned for their mathematical approach to composition and the philosophical depth of their lyrics. Vocalist Maynard James Keenan is widely regarded as one of the most gifted singers in rock.",
+      "fun_fact_de": "Schism gewann Tool 2002 einen Grammy f\u00fcr die beste Metal-Performance und ist f\u00fcr seine au\u00dferordentlich komplexen Taktarten bekannt \u2014 der Song wechselt zwischen 5/4, 6/8 und anderen Signaturen. Tool ist f\u00fcr ihren mathematischen Ansatz bei der Komposition bekannt.",
+      "fun_fact_es": "Schism le vali\u00f3 a Tool un Grammy a la Mejor Actuaci\u00f3n Metal en 2002 y es celebrado por su extraordinariamente complejo comp\u00e1s \u2014 la canci\u00f3n cambia entre 5/4, 6/8 y otros compases. Tool es reconocido por su enfoque matem\u00e1tico de la composici\u00f3n.",
+      "fun_fact_fr": "Schism a valu \u00e0 Tool un Grammy de la Meilleure Performance Metal en 2002 et est c\u00e9l\u00e9br\u00e9 pour ses signatures rythmiques extraordinairement complexes \u2014 la chanson alterne entre 5/4, 6/8 et d'autres signatures. Tool est reconnu pour son approche math\u00e9matique de la composition.",
       "uri_apple_music": "applemusic://track/1474185654",
       "uri_youtube_music": "https://music.youtube.com/watch?v=MM62wjLrgmA",
       "uri_tidal": "tidal://track/4085543",
@@ -659,9 +659,9 @@
         "Grammy nomination"
       ],
       "fun_fact": "Change is one of Deftones' most hypnotic and unsettling songs, built around a whispered guitar loop and Chino Moreno's shifting dynamic vocals. White Pony is widely considered the Deftones' masterpiece and one of the most innovative rock albums of the 2000s. The band are credited with pioneering the nu-metal and alternative metal crossover.",
-      "fun_fact_de": "Change ist einer der hypnotischsten Songs der Deftones, aufgebaut auf einer geflüsterten Gitarrenschleife. White Pony gilt als Meisterwerk der Deftones und eines der innovativsten Rockalben der 2000er Jahre.",
-      "fun_fact_es": "Change es una de las canciones más hipnóticas de los Deftones, construida alrededor de un loop de guitarra susurrado. White Pony es considerado ampliamente como la obra maestra de los Deftones y uno de los álbumes de rock más innovadores de los años 2000.",
-      "fun_fact_fr": "Change est l'une des chansons les plus hypnotiques des Deftones, construite autour d'une boucle de guitare murmurée. White Pony est largement considéré comme le chef-d'œuvre des Deftones et l'un des albums de rock les plus innovants des années 2000.",
+      "fun_fact_de": "Change ist einer der hypnotischsten Songs der Deftones, aufgebaut auf einer gefl\u00fcsterten Gitarrenschleife. White Pony gilt als Meisterwerk der Deftones und eines der innovativsten Rockalben der 2000er Jahre.",
+      "fun_fact_es": "Change es una de las canciones m\u00e1s hipn\u00f3ticas de los Deftones, construida alrededor de un loop de guitarra susurrado. White Pony es considerado ampliamente como la obra maestra de los Deftones y uno de los \u00e1lbumes de rock m\u00e1s innovadores de los a\u00f1os 2000.",
+      "fun_fact_fr": "Change est l'une des chansons les plus hypnotiques des Deftones, construite autour d'une boucle de guitare murmur\u00e9e. White Pony est largement consid\u00e9r\u00e9 comme le chef-d'\u0153uvre des Deftones et l'un des albums de rock les plus innovants des ann\u00e9es 2000.",
       "uri_apple_music": "applemusic://track/1537631475",
       "uri_youtube_music": "https://music.youtube.com/watch?v=WPpDyIJdasg",
       "uri_tidal": "tidal://track/4085561",
@@ -692,9 +692,9 @@
         "Grammy Award for Best Hard Rock Performance"
       ],
       "fun_fact": "Black Hole Sun is Soundgarden's most iconic song, written by Chris Cornell in just 15 minutes. Cornell said the melody came to him fully formed and he didn't know where it came from. The surreal music video, depicting a suburban nightmare melting into the sun, remains one of the most memorable in rock history. Cornell tragically died in 2017.",
-      "fun_fact_de": "Black Hole Sun ist Soundgardens ikonischster Song, von Chris Cornell in nur 15 Minuten geschrieben. Cornell sagte, die Melodie kam ihm vollständig in den Sinn. Das surreale Musikvideo bleibt eines der einprägsamsten der Rockgeschichte. Cornell starb tragisch 2017.",
-      "fun_fact_es": "Black Hole Sun es la canción más icónica de Soundgarden, escrita por Chris Cornell en solo 15 minutos. Cornell dijo que la melodía le vino completamente formada. El surrealista videoclip sigue siendo uno de los más memorables de la historia del rock. Cornell falleció trágicamente en 2017.",
-      "fun_fact_fr": "Black Hole Sun est la chanson la plus emblématique de Soundgarden, écrite par Chris Cornell en seulement 15 minutes. Cornell a dit que la mélodie lui est venue pleinement formée. Le clip surréaliste reste l'un des plus mémorables de l'histoire du rock. Cornell est tragiquement décédé en 2017.",
+      "fun_fact_de": "Black Hole Sun ist Soundgardens ikonischster Song, von Chris Cornell in nur 15 Minuten geschrieben. Cornell sagte, die Melodie kam ihm vollst\u00e4ndig in den Sinn. Das surreale Musikvideo bleibt eines der einpr\u00e4gsamsten der Rockgeschichte. Cornell starb tragisch 2017.",
+      "fun_fact_es": "Black Hole Sun es la canci\u00f3n m\u00e1s ic\u00f3nica de Soundgarden, escrita por Chris Cornell en solo 15 minutos. Cornell dijo que la melod\u00eda le vino completamente formada. El surrealista videoclip sigue siendo uno de los m\u00e1s memorables de la historia del rock. Cornell falleci\u00f3 tr\u00e1gicamente en 2017.",
+      "fun_fact_fr": "Black Hole Sun est la chanson la plus embl\u00e9matique de Soundgarden, \u00e9crite par Chris Cornell en seulement 15 minutes. Cornell a dit que la m\u00e9lodie lui est venue pleinement form\u00e9e. Le clip surr\u00e9aliste reste l'un des plus m\u00e9morables de l'histoire du rock. Cornell est tragiquement d\u00e9c\u00e9d\u00e9 en 2017.",
       "uri_apple_music": "applemusic://track/1440811686",
       "uri_youtube_music": "https://music.youtube.com/watch?v=3mbBbFH9fAg",
       "uri_tidal": "tidal://track/4085577",
@@ -724,14 +724,14 @@
       "awards": [
         "Grammy nomination"
       ],
-      "fun_fact": "Rooster was written by guitarist Jerry Cantrell as a tribute to his father, who served in the Vietnam War — his nickname was Rooster. The song's haunting combination of drop-D riffs and dual vocalist harmonies between Cantrell and Layne Staley is one of Alice in Chains' most powerful moments. Layne Staley died of a drug overdose in 2002.",
-      "fun_fact_de": "Rooster wurde von Gitarrist Jerry Cantrell als Hommage an seinen Vater geschrieben, der im Vietnamkrieg diente — sein Spitzname war Rooster. Die eindringliche Kombination aus Drop-D-Riffs und den Dual-Vokalist-Harmonien ist einer der kraftvollsten Momente von Alice in Chains. Layne Staley starb 2002 an einer Überdosis.",
-      "fun_fact_es": "Rooster fue escrita por el guitarrista Jerry Cantrell como tributo a su padre, veterano de Vietnam — su apodo era Rooster. La inquietante combinación de riffs en drop-D y las armonías entre Cantrell y Layne Staley es uno de los momentos más poderosos de Alice in Chains. Layne Staley murió de sobredosis en 2002.",
-      "fun_fact_fr": "Rooster a été écrit par le guitariste Jerry Cantrell en hommage à son père, vétéran du Vietnam — son surnom était Rooster. La combinaison envoûtante de riffs en drop-D et les harmonies entre Cantrell et Layne Staley est l'un des moments les plus puissants d'Alice in Chains. Layne Staley est décédé d'une overdose en 2002.",
+      "fun_fact": "Rooster was written by guitarist Jerry Cantrell as a tribute to his father, who served in the Vietnam War \u2014 his nickname was Rooster. The song's haunting combination of drop-D riffs and dual vocalist harmonies between Cantrell and Layne Staley is one of Alice in Chains' most powerful moments. Layne Staley died of a drug overdose in 2002.",
+      "fun_fact_de": "Rooster wurde von Gitarrist Jerry Cantrell als Hommage an seinen Vater geschrieben, der im Vietnamkrieg diente \u2014 sein Spitzname war Rooster. Die eindringliche Kombination aus Drop-D-Riffs und den Dual-Vokalist-Harmonien ist einer der kraftvollsten Momente von Alice in Chains. Layne Staley starb 2002 an einer \u00dcberdosis.",
+      "fun_fact_es": "Rooster fue escrita por el guitarrista Jerry Cantrell como tributo a su padre, veterano de Vietnam \u2014 su apodo era Rooster. La inquietante combinaci\u00f3n de riffs en drop-D y las armon\u00edas entre Cantrell y Layne Staley es uno de los momentos m\u00e1s poderosos de Alice in Chains. Layne Staley muri\u00f3 de sobredosis en 2002.",
+      "fun_fact_fr": "Rooster a \u00e9t\u00e9 \u00e9crit par le guitariste Jerry Cantrell en hommage \u00e0 son p\u00e8re, v\u00e9t\u00e9ran du Vietnam \u2014 son surnom \u00e9tait Rooster. La combinaison envo\u00fbtante de riffs en drop-D et les harmonies entre Cantrell et Layne Staley est l'un des moments les plus puissants d'Alice in Chains. Layne Staley est d\u00e9c\u00e9d\u00e9 d'une overdose en 2002.",
       "uri_apple_music": "applemusic://track/157317003",
       "uri_youtube_music": "https://music.youtube.com/watch?v=uAE6Il6OTcs",
       "uri_tidal": "tidal://track/4085589",
-      "fun_fact_nl": "Rooster werd geschreven door gitarist Jerry Cantrell als een eerbetoon aan zijn vader, die diende in de Vietnamoorlog - zijn bijnaam was Rooster. De beklemmende combinatie van drop-D riffs en dubbele vocalistenharmonieën tussen Cantrell en Layne Staley is een van de krachtigste momenten van Alice in Chains. Layne Staley stierf in 2002 aan een overdosis drugs.",
+      "fun_fact_nl": "Rooster werd geschreven door gitarist Jerry Cantrell als een eerbetoon aan zijn vader, die diende in de Vietnamoorlog - zijn bijnaam was Rooster. De beklemmende combinatie van drop-D riffs en dubbele vocalistenharmonie\u00ebn tussen Cantrell en Layne Staley is een van de krachtigste momenten van Alice in Chains. Layne Staley stierf in 2002 aan een overdosis drugs.",
       "awards_nl": [
         "Grammy-nominatie"
       ]
@@ -742,7 +742,7 @@
       "artist": "Guns N' Roses",
       "title": "Welcome to the Jungle",
       "alt_artists": [
-        "Mötley Crüe",
+        "M\u00f6tley Cr\u00fce",
         "Def Leppard",
         "Aerosmith"
       ],
@@ -758,9 +758,9 @@
         "Grammy nomination"
       ],
       "fun_fact": "Welcome to the Jungle opened Appetite for Destruction, the best-selling debut album in US history with over 30 million copies sold worldwide. Axl Rose wrote the song after arriving in LA as a teenager from small-town Indiana, and it perfectly captures the dangerous allure of the city. The riff was crafted by Slash after staying up all night.",
-      "fun_fact_de": "Welcome to the Jungle eröffnet Appetite for Destruction, das meistverkaufte Debütalbum der US-Geschichte mit über 30 Millionen verkauften Exemplaren weltweit. Axl Rose schrieb den Song, als er als Teenager aus dem kleinen Indiana in LA ankam.",
-      "fun_fact_es": "Welcome to the Jungle abre Appetite for Destruction, el álbum de debut más vendido de la historia de EE.UU. con más de 30 millones de copias vendidas en todo el mundo. Axl Rose escribió la canción al llegar a LA como adolescente procedente de la pequeña Indiana.",
-      "fun_fact_fr": "Welcome to the Jungle ouvre Appetite for Destruction, l'album de débuts le plus vendu de l'histoire américaine avec plus de 30 millions d'exemplaires vendus dans le monde. Axl Rose a écrit la chanson en arrivant à LA comme adolescent venant de la petite ville d'Indiana.",
+      "fun_fact_de": "Welcome to the Jungle er\u00f6ffnet Appetite for Destruction, das meistverkaufte Deb\u00fctalbum der US-Geschichte mit \u00fcber 30 Millionen verkauften Exemplaren weltweit. Axl Rose schrieb den Song, als er als Teenager aus dem kleinen Indiana in LA ankam.",
+      "fun_fact_es": "Welcome to the Jungle abre Appetite for Destruction, el \u00e1lbum de debut m\u00e1s vendido de la historia de EE.UU. con m\u00e1s de 30 millones de copias vendidas en todo el mundo. Axl Rose escribi\u00f3 la canci\u00f3n al llegar a LA como adolescente procedente de la peque\u00f1a Indiana.",
+      "fun_fact_fr": "Welcome to the Jungle ouvre Appetite for Destruction, l'album de d\u00e9buts le plus vendu de l'histoire am\u00e9ricaine avec plus de 30 millions d'exemplaires vendus dans le monde. Axl Rose a \u00e9crit la chanson en arrivant \u00e0 LA comme adolescent venant de la petite ville d'Indiana.",
       "uri_apple_music": "applemusic://track/1377813288",
       "uri_youtube_music": "https://music.youtube.com/watch?v=o1tj2zJ2Wvg",
       "uri_tidal": "tidal://track/4085601",
@@ -776,7 +776,7 @@
       "title": "Sweet Child O' Mine",
       "alt_artists": [
         "Aerosmith",
-        "Mötley Crüe",
+        "M\u00f6tley Cr\u00fce",
         "Whitesnake"
       ],
       "chart_info": {
@@ -791,13 +791,13 @@
         "Grammy nomination"
       ],
       "fun_fact": "Sweet Child O' Mine reached number one in the US and features one of the most beloved guitar solos in rock history, played by Slash. Axl Rose wrote the lyrics about his then-girlfriend Erin Everly, the daughter of Don Everly of the Everly Brothers. Slash originally created the opening riff as a joke warm-up exercise that the rest of the band loved.",
-      "fun_fact_de": "Sweet Child O' Mine erreichte Platz 1 in den USA und enthält eines der beliebtesten Gitarrensolos der Rockgeschichte von Slash. Axl Rose schrieb die Texte über seine damalige Freundin Erin Everly, Tochter von Don Everly. Slash erschuf das Intro-Riff ursprünglich als Spaß-Aufwärmübung.",
-      "fun_fact_es": "Sweet Child O' Mine alcanzó el número uno en EE.UU. y cuenta con uno de los solos de guitarra más queridos de la historia del rock, tocado por Slash. Axl Rose escribió la letra sobre su entonces novia Erin Everly, hija de Don Everly. Slash creó originalmente el riff inicial como ejercicio de calentamiento.",
-      "fun_fact_fr": "Sweet Child O' Mine a atteint la première place aux États-Unis et présente l'un des solos de guitare les plus appréciés de l'histoire du rock, joué par Slash. Axl Rose a écrit les paroles sur sa petite amie de l'époque Erin Everly, fille de Don Everly. Slash avait initialement créé le riff d'ouverture comme exercice d'échauffement.",
+      "fun_fact_de": "Sweet Child O' Mine erreichte Platz 1 in den USA und enth\u00e4lt eines der beliebtesten Gitarrensolos der Rockgeschichte von Slash. Axl Rose schrieb die Texte \u00fcber seine damalige Freundin Erin Everly, Tochter von Don Everly. Slash erschuf das Intro-Riff urspr\u00fcnglich als Spa\u00df-Aufw\u00e4rm\u00fcbung.",
+      "fun_fact_es": "Sweet Child O' Mine alcanz\u00f3 el n\u00famero uno en EE.UU. y cuenta con uno de los solos de guitarra m\u00e1s queridos de la historia del rock, tocado por Slash. Axl Rose escribi\u00f3 la letra sobre su entonces novia Erin Everly, hija de Don Everly. Slash cre\u00f3 originalmente el riff inicial como ejercicio de calentamiento.",
+      "fun_fact_fr": "Sweet Child O' Mine a atteint la premi\u00e8re place aux \u00c9tats-Unis et pr\u00e9sente l'un des solos de guitare les plus appr\u00e9ci\u00e9s de l'histoire du rock, jou\u00e9 par Slash. Axl Rose a \u00e9crit les paroles sur sa petite amie de l'\u00e9poque Erin Everly, fille de Don Everly. Slash avait initialement cr\u00e9\u00e9 le riff d'ouverture comme exercice d'\u00e9chauffement.",
       "uri_apple_music": "applemusic://track/1377813701",
       "uri_youtube_music": "https://music.youtube.com/watch?v=1w7OgIMMRc4",
       "uri_tidal": "tidal://track/4085608",
-      "fun_fact_nl": "Sweet Child O' Mine bereikte nummer één in de VS en bevat een van de meest geliefde gitaarsolo's uit de rockgeschiedenis, gespeeld door Slash. Axl Rose schreef de tekst over zijn toenmalige vriendin Erin Everly, de dochter van Don Everly van de Everly Brothers. Slash maakte de openingsriff oorspronkelijk als een grap om op te warmen waar de rest van de band dol op was.",
+      "fun_fact_nl": "Sweet Child O' Mine bereikte nummer \u00e9\u00e9n in de VS en bevat een van de meest geliefde gitaarsolo's uit de rockgeschiedenis, gespeeld door Slash. Axl Rose schreef de tekst over zijn toenmalige vriendin Erin Everly, de dochter van Don Everly van de Everly Brothers. Slash maakte de openingsriff oorspronkelijk als een grap om op te warmen waar de rest van de band dol op was.",
       "awards_nl": [
         "Grammy-nominatie"
       ]
@@ -824,9 +824,9 @@
         "Grammy Hall of Fame"
       ],
       "fun_fact": "Highway to Hell was the last album recorded with vocalist Bon Scott before his tragic death in 1980. The title track became AC/DC's breakthrough song in America and is one of the most iconic rock anthems ever recorded. The album's title was almost Highway to Hell but the band's management worried it would alienate radio stations.",
-      "fun_fact_de": "Highway to Hell war das letzte Album mit Sänger Bon Scott vor seinem tragischen Tod 1980. Das Titelstück wurde zum Durchbruch von AC/DC in Amerika und ist eine der ikonischsten Rockhymnen aller Zeiten.",
-      "fun_fact_es": "Highway to Hell fue el último álbum grabado con el vocalista Bon Scott antes de su trágica muerte en 1980. El tema se convirtió en el gran avance de AC/DC en América y es uno de los himnos de rock más icónicos jamás grabados.",
-      "fun_fact_fr": "Highway to Hell était le dernier album enregistré avec le chanteur Bon Scott avant sa mort tragique en 1980. Le titre est devenu la chanson qui a fait percer AC/DC en Amérique et est l'un des hymnes rock les plus emblématiques jamais enregistrés.",
+      "fun_fact_de": "Highway to Hell war das letzte Album mit S\u00e4nger Bon Scott vor seinem tragischen Tod 1980. Das Titelst\u00fcck wurde zum Durchbruch von AC/DC in Amerika und ist eine der ikonischsten Rockhymnen aller Zeiten.",
+      "fun_fact_es": "Highway to Hell fue el \u00faltimo \u00e1lbum grabado con el vocalista Bon Scott antes de su tr\u00e1gica muerte en 1980. El tema se convirti\u00f3 en el gran avance de AC/DC en Am\u00e9rica y es uno de los himnos de rock m\u00e1s ic\u00f3nicos jam\u00e1s grabados.",
+      "fun_fact_fr": "Highway to Hell \u00e9tait le dernier album enregistr\u00e9 avec le chanteur Bon Scott avant sa mort tragique en 1980. Le titre est devenu la chanson qui a fait percer AC/DC en Am\u00e9rique et est l'un des hymnes rock les plus embl\u00e9matiques jamais enregistr\u00e9s.",
       "uri_apple_music": "applemusic://track/574044008",
       "uri_youtube_music": "https://music.youtube.com/watch?v=l482T0yNkeo",
       "uri_tidal": "tidal://track/4085621",
@@ -856,14 +856,14 @@
       "awards": [
         "Grammy Hall of Fame"
       ],
-      "fun_fact": "Back in Black is the opening track of the second best-selling album in history with over 50 million copies sold. The album was recorded as a tribute to Bon Scott and performed entirely in black. New singer Brian Johnson was discovered after Angus Young heard him screaming over a track — they hired him on the spot. The iconic opening riff took Angus just minutes to write.",
-      "fun_fact_de": "Back in Black eröffnet das zweitmeistverkaufte Album der Geschichte mit über 50 Millionen verkauften Exemplaren. Das Album war als Hommage an Bon Scott gedacht. Neuer Sänger Brian Johnson wurde entdeckt, nachdem Angus Young ihn über einem Track schreien hörte.",
-      "fun_fact_es": "Back in Black es la pista de apertura del segundo álbum más vendido de la historia con más de 50 millones de copias. El álbum fue grabado como tributo a Bon Scott. El nuevo cantante Brian Johnson fue descubierto cuando Angus Young lo oyó gritando sobre una pista.",
-      "fun_fact_fr": "Back in Black ouvre le deuxième album le plus vendu de l'histoire avec plus de 50 millions d'exemplaires. L'album a été enregistré en hommage à Bon Scott. Le nouveau chanteur Brian Johnson a été découvert quand Angus Young l'a entendu crier sur une piste.",
+      "fun_fact": "Back in Black is the opening track of the second best-selling album in history with over 50 million copies sold. The album was recorded as a tribute to Bon Scott and performed entirely in black. New singer Brian Johnson was discovered after Angus Young heard him screaming over a track \u2014 they hired him on the spot. The iconic opening riff took Angus just minutes to write.",
+      "fun_fact_de": "Back in Black er\u00f6ffnet das zweitmeistverkaufte Album der Geschichte mit \u00fcber 50 Millionen verkauften Exemplaren. Das Album war als Hommage an Bon Scott gedacht. Neuer S\u00e4nger Brian Johnson wurde entdeckt, nachdem Angus Young ihn \u00fcber einem Track schreien h\u00f6rte.",
+      "fun_fact_es": "Back in Black es la pista de apertura del segundo \u00e1lbum m\u00e1s vendido de la historia con m\u00e1s de 50 millones de copias. El \u00e1lbum fue grabado como tributo a Bon Scott. El nuevo cantante Brian Johnson fue descubierto cuando Angus Young lo oy\u00f3 gritando sobre una pista.",
+      "fun_fact_fr": "Back in Black ouvre le deuxi\u00e8me album le plus vendu de l'histoire avec plus de 50 millions d'exemplaires. L'album a \u00e9t\u00e9 enregistr\u00e9 en hommage \u00e0 Bon Scott. Le nouveau chanteur Brian Johnson a \u00e9t\u00e9 d\u00e9couvert quand Angus Young l'a entendu crier sur une piste.",
       "uri_apple_music": "applemusic://track/574050602",
       "uri_youtube_music": "https://music.youtube.com/watch?v=pAgnJDJN4VA",
       "uri_tidal": "tidal://track/4085631",
-      "fun_fact_nl": "Back in Black is het openingsnummer van het op één na best verkochte album in de geschiedenis met meer dan 50 miljoen verkochte exemplaren. Het album werd opgenomen als eerbetoon aan Bon Scott en volledig in het zwart uitgevoerd. De nieuwe zanger Brian Johnson werd ontdekt nadat Angus Young hem hoorde schreeuwen over een nummer - ze huurden hem ter plekke in. Het kostte Angus slechts enkele minuten om de iconische openingsriff te schrijven.",
+      "fun_fact_nl": "Back in Black is het openingsnummer van het op \u00e9\u00e9n na best verkochte album in de geschiedenis met meer dan 50 miljoen verkochte exemplaren. Het album werd opgenomen als eerbetoon aan Bon Scott en volledig in het zwart uitgevoerd. De nieuwe zanger Brian Johnson werd ontdekt nadat Angus Young hem hoorde schreeuwen over een nummer - ze huurden hem ter plekke in. Het kostte Angus slechts enkele minuten om de iconische openingsriff te schrijven.",
       "awards_nl": [
         "Grammy Hall of Fame"
       ]
@@ -889,14 +889,14 @@
       "awards": [
         "Grammy Hall of Fame"
       ],
-      "fun_fact": "Smoke on the Water features arguably the most famous guitar riff ever written — the four-note motif that every beginner guitarist learns first. The song describes the real fire at the Montreux Casino in December 1971 while Frank Zappa was performing, which Deep Purple witnessed from across Lake Geneva. The band then recorded the album Machine Head in a mobile studio borrowed from the Rolling Stones.",
-      "fun_fact_de": "Smoke on the Water enthält wohl das bekannteste Gitarrenriff aller Zeiten. Der Song beschreibt den realen Brand im Casino Montreux im Dezember 1971, den Deep Purple vom anderen Ufer des Genfersees aus beobachteten. Das Album wurde anschließend in einem mobilen Studio aufgenommen.",
-      "fun_fact_es": "Smoke on the Water cuenta con el que es posiblemente el riff de guitarra más famoso jamás escrito. La canción describe el incendio real en el Casino de Montreux en diciembre de 1971, que Deep Purple presenció desde la orilla opuesta del lago Ginebra.",
-      "fun_fact_fr": "Smoke on the Water présente sans doute le riff de guitare le plus célèbre jamais écrit. La chanson décrit l'incendie réel du Casino de Montreux en décembre 1971, que Deep Purple a observé depuis l'autre rive du lac Léman.",
+      "fun_fact": "Smoke on the Water features arguably the most famous guitar riff ever written \u2014 the four-note motif that every beginner guitarist learns first. The song describes the real fire at the Montreux Casino in December 1971 while Frank Zappa was performing, which Deep Purple witnessed from across Lake Geneva. The band then recorded the album Machine Head in a mobile studio borrowed from the Rolling Stones.",
+      "fun_fact_de": "Smoke on the Water enth\u00e4lt wohl das bekannteste Gitarrenriff aller Zeiten. Der Song beschreibt den realen Brand im Casino Montreux im Dezember 1971, den Deep Purple vom anderen Ufer des Genfersees aus beobachteten. Das Album wurde anschlie\u00dfend in einem mobilen Studio aufgenommen.",
+      "fun_fact_es": "Smoke on the Water cuenta con el que es posiblemente el riff de guitarra m\u00e1s famoso jam\u00e1s escrito. La canci\u00f3n describe el incendio real en el Casino de Montreux en diciembre de 1971, que Deep Purple presenci\u00f3 desde la orilla opuesta del lago Ginebra.",
+      "fun_fact_fr": "Smoke on the Water pr\u00e9sente sans doute le riff de guitare le plus c\u00e9l\u00e8bre jamais \u00e9crit. La chanson d\u00e9crit l'incendie r\u00e9el du Casino de Montreux en d\u00e9cembre 1971, que Deep Purple a observ\u00e9 depuis l'autre rive du lac L\u00e9man.",
       "uri_apple_music": "applemusic://track/1099335223",
       "uri_youtube_music": "https://music.youtube.com/watch?v=zUwEIt9ez7M",
       "uri_tidal": "tidal://track/4085643",
-      "fun_fact_nl": "Smoke on the Water bevat misschien wel de beroemdste gitaarriff ooit geschreven - het motief van vier noten dat elke beginnende gitarist als eerste leert. Het nummer beschrijft de echte brand in het Montreux Casino in december 1971 terwijl Frank Zappa optrad, waarvan Deep Purple getuige was vanaf de overkant van het meer van Genève. De band nam vervolgens het album Machine Head op in een mobiele studio geleend van de Rolling Stones.",
+      "fun_fact_nl": "Smoke on the Water bevat misschien wel de beroemdste gitaarriff ooit geschreven - het motief van vier noten dat elke beginnende gitarist als eerste leert. Het nummer beschrijft de echte brand in het Montreux Casino in december 1971 terwijl Frank Zappa optrad, waarvan Deep Purple getuige was vanaf de overkant van het meer van Gen\u00e8ve. De band nam vervolgens het album Machine Head op in een mobiele studio geleend van de Rolling Stones.",
       "awards_nl": [
         "Grammy Hall of Fame"
       ]
@@ -907,7 +907,7 @@
       "artist": "Def Leppard",
       "title": "Pour Some Sugar on Me",
       "alt_artists": [
-        "Mötley Crüe",
+        "M\u00f6tley Cr\u00fce",
         "Bon Jovi",
         "Whitesnake"
       ],
@@ -923,13 +923,13 @@
         "Grammy nomination"
       ],
       "fun_fact": "Pour Some Sugar on Me was written in just a few minutes by Joe Elliott in a hotel room and became one of the defining songs of 1980s glam metal. Drummer Rick Allen performed on the recording and subsequent tour with just one arm after losing his left arm in a car accident in 1984. The crowd clapping along remains a staple of rock concert etiquette.",
-      "fun_fact_de": "Pour Some Sugar on Me wurde von Joe Elliott in nur wenigen Minuten in einem Hotelzimmer geschrieben und wurde zu einem der prägenden Songs des Glam Metal der 1980er. Schlagzeuger Rick Allen spielte auf der Aufnahme und Tour mit nur einem Arm nach einem Autounfall 1984.",
-      "fun_fact_es": "Pour Some Sugar on Me fue escrita en solo unos minutos por Joe Elliott en una habitación de hotel y se convirtió en una de las canciones definitorias del glam metal de los ochenta. El batería Rick Allen tocó en la grabación y la gira con un solo brazo tras un accidente de coche en 1984.",
-      "fun_fact_fr": "Pour Some Sugar on Me a été écrit en quelques minutes par Joe Elliott dans une chambre d'hôtel et est devenu l'un des titres définisseurs du glam metal des années 1980. Le batteur Rick Allen a joué sur l'enregistrement et la tournée avec un seul bras après un accident de voiture en 1984.",
+      "fun_fact_de": "Pour Some Sugar on Me wurde von Joe Elliott in nur wenigen Minuten in einem Hotelzimmer geschrieben und wurde zu einem der pr\u00e4genden Songs des Glam Metal der 1980er. Schlagzeuger Rick Allen spielte auf der Aufnahme und Tour mit nur einem Arm nach einem Autounfall 1984.",
+      "fun_fact_es": "Pour Some Sugar on Me fue escrita en solo unos minutos por Joe Elliott en una habitaci\u00f3n de hotel y se convirti\u00f3 en una de las canciones definitorias del glam metal de los ochenta. El bater\u00eda Rick Allen toc\u00f3 en la grabaci\u00f3n y la gira con un solo brazo tras un accidente de coche en 1984.",
+      "fun_fact_fr": "Pour Some Sugar on Me a \u00e9t\u00e9 \u00e9crit en quelques minutes par Joe Elliott dans une chambre d'h\u00f4tel et est devenu l'un des titres d\u00e9finisseurs du glam metal des ann\u00e9es 1980. Le batteur Rick Allen a jou\u00e9 sur l'enregistrement et la tourn\u00e9e avec un seul bras apr\u00e8s un accident de voiture en 1984.",
       "uri_apple_music": "applemusic://track/1440907869",
       "uri_youtube_music": "https://music.youtube.com/watch?v=0UIB9Y4OFPs",
       "uri_tidal": "tidal://track/4085658",
-      "fun_fact_nl": "Pour Some Sugar on Me werd in slechts een paar minuten geschreven door Joe Elliott in een hotelkamer en werd een van de bepalende nummers van de glam metal uit de jaren '80. Drummer Rick Allen trad op tijdens de opnames en de daaropvolgende tournee met slechts één arm, nadat hij zijn linkerarm had verloren bij een auto-ongeluk in 1984. Het meeklappen van het publiek blijft een belangrijk onderdeel van de etiquette van rockconcerten.",
+      "fun_fact_nl": "Pour Some Sugar on Me werd in slechts een paar minuten geschreven door Joe Elliott in een hotelkamer en werd een van de bepalende nummers van de glam metal uit de jaren '80. Drummer Rick Allen trad op tijdens de opnames en de daaropvolgende tournee met slechts \u00e9\u00e9n arm, nadat hij zijn linkerarm had verloren bij een auto-ongeluk in 1984. Het meeklappen van het publiek blijft een belangrijk onderdeel van de etiquette van rockconcerten.",
       "awards_nl": [
         "Grammy-nominatie"
       ]
@@ -941,7 +941,7 @@
       "title": "Jump",
       "alt_artists": [
         "Def Leppard",
-        "Mötley Crüe",
+        "M\u00f6tley Cr\u00fce",
         "Bon Jovi"
       ],
       "chart_info": {
@@ -956,9 +956,9 @@
         "Grammy nomination"
       ],
       "fun_fact": "Jump was Van Halen's only US number one single and controversially featured a synthesiser lead, which Eddie Van Halen had been hiding from the band for years. David Lee Roth reportedly hated the keyboard-driven approach but sang on it anyway. Eddie Van Halen is universally regarded as one of the most revolutionary guitarists in rock history.",
-      "fun_fact_de": "Jump war Van Halens einzige US-Nummer-1-Single und enthielt kontrovers einen Synthesizer-Lead, den Eddie Van Halen jahrelang vor der Band versteckt hatte. David Lee Roth soll den keyboard-geprägten Ansatz gehasst haben.",
-      "fun_fact_es": "Jump fue el único single número uno en EE.UU. de Van Halen y controvertidamente presentaba un sintetizador en primer plano, que Eddie Van Halen había estado ocultando a la banda durante años. David Lee Roth supuestamente odiaba el enfoque impulsado por teclado.",
-      "fun_fact_fr": "Jump a été le seul single numéro un américain de Van Halen et présentait controversement un synthétiseur en tête, qu'Eddie Van Halen avait caché au groupe pendant des années. David Lee Roth aurait détesté l'approche axée sur les claviers.",
+      "fun_fact_de": "Jump war Van Halens einzige US-Nummer-1-Single und enthielt kontrovers einen Synthesizer-Lead, den Eddie Van Halen jahrelang vor der Band versteckt hatte. David Lee Roth soll den keyboard-gepr\u00e4gten Ansatz gehasst haben.",
+      "fun_fact_es": "Jump fue el \u00fanico single n\u00famero uno en EE.UU. de Van Halen y controvertidamente presentaba un sintetizador en primer plano, que Eddie Van Halen hab\u00eda estado ocultando a la banda durante a\u00f1os. David Lee Roth supuestamente odiaba el enfoque impulsado por teclado.",
+      "fun_fact_fr": "Jump a \u00e9t\u00e9 le seul single num\u00e9ro un am\u00e9ricain de Van Halen et pr\u00e9sentait controversement un synth\u00e9tiseur en t\u00eate, qu'Eddie Van Halen avait cach\u00e9 au groupe pendant des ann\u00e9es. David Lee Roth aurait d\u00e9test\u00e9 l'approche ax\u00e9e sur les claviers.",
       "uri_apple_music": "applemusic://track/976832495",
       "uri_youtube_music": "https://music.youtube.com/watch?v=SwYN7mTi6HM",
       "uri_tidal": "tidal://track/4085671",
@@ -988,10 +988,10 @@
       "awards": [
         "Grammy nomination"
       ],
-      "fun_fact": "Killing in the Name famously reached number one in the UK Christmas charts in 2009 when a grassroots campaign led by Facebook users pushed it over The X Factor winner's single — one of the most remarkable chart battles in music history. Tom Morello's technique of using a guitar to mimic turntable scratches revolutionised heavy music production.",
-      "fun_fact_de": "Killing in the Name erreichte 2009 durch eine Facebook-Kampagne die britischen Weihnachtscharts auf Platz 1 und schlug dabei die Single des X Factor-Gewinners — eine der bemerkenswertesten Chart-Schlachten der Musikgeschichte.",
-      "fun_fact_es": "Killing in the Name llegó al número uno de las listas navideñas del Reino Unido en 2009 gracias a una campaña popular de Facebook, superando al single del ganador de The X Factor en una de las batallas de listas más notables de la historia musical.",
-      "fun_fact_fr": "Killing in the Name a atteint le numéro un des charts de Noël britanniques en 2009 grâce à une campagne Facebook populaire, dépassant le single du gagnant de The X Factor — l'une des batailles de charts les plus remarquables de l'histoire musicale.",
+      "fun_fact": "Killing in the Name famously reached number one in the UK Christmas charts in 2009 when a grassroots campaign led by Facebook users pushed it over The X Factor winner's single \u2014 one of the most remarkable chart battles in music history. Tom Morello's technique of using a guitar to mimic turntable scratches revolutionised heavy music production.",
+      "fun_fact_de": "Killing in the Name erreichte 2009 durch eine Facebook-Kampagne die britischen Weihnachtscharts auf Platz 1 und schlug dabei die Single des X Factor-Gewinners \u2014 eine der bemerkenswertesten Chart-Schlachten der Musikgeschichte.",
+      "fun_fact_es": "Killing in the Name lleg\u00f3 al n\u00famero uno de las listas navide\u00f1as del Reino Unido en 2009 gracias a una campa\u00f1a popular de Facebook, superando al single del ganador de The X Factor en una de las batallas de listas m\u00e1s notables de la historia musical.",
+      "fun_fact_fr": "Killing in the Name a atteint le num\u00e9ro un des charts de No\u00ebl britanniques en 2009 gr\u00e2ce \u00e0 une campagne Facebook populaire, d\u00e9passant le single du gagnant de The X Factor \u2014 l'une des batailles de charts les plus remarquables de l'histoire musicale.",
       "uri_apple_music": "applemusic://track/191450927",
       "uri_youtube_music": "https://music.youtube.com/watch?v=bWXazVhDGkc",
       "uri_tidal": "tidal://track/4085683",
@@ -1022,13 +1022,13 @@
         "Grammy nomination"
       ],
       "fun_fact": "The Beautiful People is Marilyn Manson's most iconic song and one of the defining industrial metal tracks of the 1990s. The mechanised groove was co-written with producer Trent Reznor of Nine Inch Nails. Manson's shock-rock theatrics made him one of the most controversial figures in rock history and frequently attracted censorship attempts.",
-      "fun_fact_de": "The Beautiful People ist Marilyn Mansons ikonischster Song und einer der prägenden Industrial Metal-Tracks der 1990er. Der mechanisierte Groove wurde mit Produzent Trent Reznor von Nine Inch Nails co-geschrieben.",
-      "fun_fact_es": "The Beautiful People es la canción más icónica de Marilyn Manson y uno de los temas de metal industrial definitorios de los noventa. El ritmo mecanizado fue co-escrito con el productor Trent Reznor de Nine Inch Nails.",
-      "fun_fact_fr": "The Beautiful People est la chanson la plus emblématique de Marilyn Manson et l'un des titres de metal industriel définisseurs des années 1990. Le groove mécanisé a été co-écrit avec le producteur Trent Reznor de Nine Inch Nails.",
+      "fun_fact_de": "The Beautiful People ist Marilyn Mansons ikonischster Song und einer der pr\u00e4genden Industrial Metal-Tracks der 1990er. Der mechanisierte Groove wurde mit Produzent Trent Reznor von Nine Inch Nails co-geschrieben.",
+      "fun_fact_es": "The Beautiful People es la canci\u00f3n m\u00e1s ic\u00f3nica de Marilyn Manson y uno de los temas de metal industrial definitorios de los noventa. El ritmo mecanizado fue co-escrito con el productor Trent Reznor de Nine Inch Nails.",
+      "fun_fact_fr": "The Beautiful People est la chanson la plus embl\u00e9matique de Marilyn Manson et l'un des titres de metal industriel d\u00e9finisseurs des ann\u00e9es 1990. Le groove m\u00e9canis\u00e9 a \u00e9t\u00e9 co-\u00e9crit avec le producteur Trent Reznor de Nine Inch Nails.",
       "uri_apple_music": "applemusic://track/24164245",
       "uri_youtube_music": "https://music.youtube.com/watch?v=Ypkv0HeUvTc",
       "uri_tidal": "tidal://track/4085697",
-      "fun_fact_nl": "The Beautiful People is het meest iconische nummer van Marilyn Manson en een van de bepalende industrial metalnummers van de jaren '90. De gemechaniseerde groove werd samen met producer Trent Reznor van Nine Inch Nails geschreven. Mansons shock-rock theatraliteit maakte hem tot een van de meest controversiële figuren in de rockgeschiedenis en leidde regelmatig tot pogingen tot censuur.",
+      "fun_fact_nl": "The Beautiful People is het meest iconische nummer van Marilyn Manson en een van de bepalende industrial metalnummers van de jaren '90. De gemechaniseerde groove werd samen met producer Trent Reznor van Nine Inch Nails geschreven. Mansons shock-rock theatraliteit maakte hem tot een van de meest controversi\u00eble figuren in de rockgeschiedenis en leidde regelmatig tot pogingen tot censuur.",
       "awards_nl": [
         "Grammy-nominatie"
       ]
@@ -1056,12 +1056,12 @@
       ],
       "fun_fact": "Freak on a Leash is the defining nu-metal anthem, featuring Jonathan Davis's trademark low-tuned seven-string guitar riffs and anguished vocals. The song's Grammy-winning animated music video became one of the most celebrated in MTV history. Korn effectively created the nu-metal genre by merging hip-hop grooves with crushing metal riffs.",
       "fun_fact_de": "Freak on a Leash ist die definierende Nu-Metal-Hymne mit Jonathan Davis' markanten tief gestimmten Siebensaiter-Gitarrenriffs. Das Grammy-gewinnende animierte Musikvideo wurde eines der gefeiertsten in der MTV-Geschichte. Korn schuf effektiv das Nu-Metal-Genre.",
-      "fun_fact_es": "Freak on a Leash es el himno definitorio del nu-metal, con los característicos riffs de guitarra de siete cuerdas y vocales angustiados de Jonathan Davis. El premiado con Grammy videoclip animado se convirtió en uno de los más celebrados de la historia de MTV.",
-      "fun_fact_fr": "Freak on a Leash est l'hymne définisseur du nu-metal, avec les riffs de guitare à sept cordes caractéristiques et les vocaux tourmentés de Jonathan Davis. Le clip animé primé aux Grammy est devenu l'un des plus célébrés de l'histoire de MTV.",
+      "fun_fact_es": "Freak on a Leash es el himno definitorio del nu-metal, con los caracter\u00edsticos riffs de guitarra de siete cuerdas y vocales angustiados de Jonathan Davis. El premiado con Grammy videoclip animado se convirti\u00f3 en uno de los m\u00e1s celebrados de la historia de MTV.",
+      "fun_fact_fr": "Freak on a Leash est l'hymne d\u00e9finisseur du nu-metal, avec les riffs de guitare \u00e0 sept cordes caract\u00e9ristiques et les vocaux tourment\u00e9s de Jonathan Davis. Le clip anim\u00e9 prim\u00e9 aux Grammy est devenu l'un des plus c\u00e9l\u00e9br\u00e9s de l'histoire de MTV.",
       "uri_apple_music": "applemusic://track/1831584743",
       "uri_youtube_music": "https://music.youtube.com/watch?v=jRGrNDV2mKc",
       "uri_tidal": "tidal://track/4085710",
-      "fun_fact_nl": "Freak on a Leash is de bepalende nu-metal anthem, met Jonathan Davis' kenmerkende laaggestemde gitaarriffs met zeven snaren en angstaanjagende zang. De Grammy-winnende geanimeerde videoclip van het nummer werd een van de meest gevierde in de geschiedenis van MTV. Korn creëerde het nu-metalgenre door hiphopgrooves te combineren met verpletterende metalriffs.",
+      "fun_fact_nl": "Freak on a Leash is de bepalende nu-metal anthem, met Jonathan Davis' kenmerkende laaggestemde gitaarriffs met zeven snaren en angstaanjagende zang. De Grammy-winnende geanimeerde videoclip van het nummer werd een van de meest gevierde in de geschiedenis van MTV. Korn cre\u00eberde het nu-metalgenre door hiphopgrooves te combineren met verpletterende metalriffs.",
       "awards_nl": [
         "Grammy Award voor Beste Korte Muziekvideo"
       ]
@@ -1088,13 +1088,13 @@
         "Grammy nomination"
       ],
       "fun_fact": "Slipknot burst onto the metal scene in 1999 wearing matching boiler suits and numbered masks, creating one of the most visually striking aesthetics in rock history. The band has nine members, making them one of the largest metal bands in history. Their debut album sold over three million copies in the US alone.",
-      "fun_fact_de": "Slipknot erschien 1999 mit passenden Overalls und nummerierten Masken auf der Metal-Szene und schuf eine der visuell eindrucksvollsten Ästhetiken der Rockgeschichte. Die Band hat neun Mitglieder — eine der größten Metal-Bands der Geschichte.",
-      "fun_fact_es": "Slipknot irrumpió en la escena metal en 1999 con monos y máscaras numeradas, creando una de las estéticas más impactantes de la historia del rock. La banda tiene nueve miembros, convirtiéndola en una de las mayores de la historia del metal.",
-      "fun_fact_fr": "Slipknot a fait irruption sur la scène metal en 1999 avec des combinaisons assorties et des masques numérotés, créant l'une des esthétiques les plus frappantes de l'histoire du rock. Le groupe compte neuf membres, ce qui en fait l'un des plus grands de l'histoire du metal.",
+      "fun_fact_de": "Slipknot erschien 1999 mit passenden Overalls und nummerierten Masken auf der Metal-Szene und schuf eine der visuell eindrucksvollsten \u00c4sthetiken der Rockgeschichte. Die Band hat neun Mitglieder \u2014 eine der gr\u00f6\u00dften Metal-Bands der Geschichte.",
+      "fun_fact_es": "Slipknot irrumpi\u00f3 en la escena metal en 1999 con monos y m\u00e1scaras numeradas, creando una de las est\u00e9ticas m\u00e1s impactantes de la historia del rock. La banda tiene nueve miembros, convirti\u00e9ndola en una de las mayores de la historia del metal.",
+      "fun_fact_fr": "Slipknot a fait irruption sur la sc\u00e8ne metal en 1999 avec des combinaisons assorties et des masques num\u00e9rot\u00e9s, cr\u00e9ant l'une des esth\u00e9tiques les plus frappantes de l'histoire du rock. Le groupe compte neuf membres, ce qui en fait l'un des plus grands de l'histoire du metal.",
       "uri_apple_music": "applemusic://track/927731733",
       "uri_youtube_music": "https://music.youtube.com/watch?v=B1zCN0YhW1s",
       "uri_tidal": "tidal://track/4085721",
-      "fun_fact_nl": "Slipknot brak in 1999 door in de metalscene met bijpassende ketelpakken en genummerde maskers, en creëerde zo een van de meest visueel opvallende esthetica in de rockgeschiedenis. De band bestaat uit negen leden en is daarmee een van de grootste metalbands uit de geschiedenis. Van hun debuutalbum werden alleen al in de VS meer dan drie miljoen exemplaren verkocht.",
+      "fun_fact_nl": "Slipknot brak in 1999 door in de metalscene met bijpassende ketelpakken en genummerde maskers, en cre\u00eberde zo een van de meest visueel opvallende esthetica in de rockgeschiedenis. De band bestaat uit negen leden en is daarmee een van de grootste metalbands uit de geschiedenis. Van hun debuutalbum werden alleen al in de VS meer dan drie miljoen exemplaren verkocht.",
       "awards_nl": [
         "Grammy-nominatie"
       ]
@@ -1121,9 +1121,9 @@
         "Grammy nomination"
       ],
       "fun_fact": "Duality became Slipknot's biggest mainstream hit and one of the most recognisable metal anthems of the 2000s. The music video famously features fans at an unofficial house party who crashed the filming location. The sing-along chorus made it unusually accessible for a Slipknot track and introduced the band to a whole new audience.",
-      "fun_fact_de": "Duality wurde Slipknots größter Mainstream-Hit und eine der bekanntesten Metal-Hymnen der 2000er. Das Musikvideo zeigt berühmt Fans bei einer inoffiziellen Hausparty, die den Filmort stürmten.",
-      "fun_fact_es": "Duality se convirtió en el mayor éxito mainstream de Slipknot y uno de los himnos metal más reconocibles de los años 2000. El videoclip muestra famosamente a fans en una fiesta improvisada que irrumpieron en el lugar de rodaje.",
-      "fun_fact_fr": "Duality est devenu le plus grand hit grand public de Slipknot et l'un des hymnes metal les plus reconnaissables des années 2000. Le clip présente célèbrement des fans lors d'une fête improvisée qui ont envahi le lieu de tournage.",
+      "fun_fact_de": "Duality wurde Slipknots gr\u00f6\u00dfter Mainstream-Hit und eine der bekanntesten Metal-Hymnen der 2000er. Das Musikvideo zeigt ber\u00fchmt Fans bei einer inoffiziellen Hausparty, die den Filmort st\u00fcrmten.",
+      "fun_fact_es": "Duality se convirti\u00f3 en el mayor \u00e9xito mainstream de Slipknot y uno de los himnos metal m\u00e1s reconocibles de los a\u00f1os 2000. El videoclip muestra famosamente a fans en una fiesta improvisada que irrumpieron en el lugar de rodaje.",
+      "fun_fact_fr": "Duality est devenu le plus grand hit grand public de Slipknot et l'un des hymnes metal les plus reconnaissables des ann\u00e9es 2000. Le clip pr\u00e9sente c\u00e9l\u00e8brement des fans lors d'une f\u00eate improvis\u00e9e qui ont envahi le lieu de tournage.",
       "uri_apple_music": "applemusic://track/926187884",
       "uri_youtube_music": "https://music.youtube.com/watch?v=6fVE8kSM43I",
       "uri_tidal": "tidal://track/4085734",
@@ -1154,9 +1154,9 @@
         "Grammy nomination"
       ],
       "fun_fact": "Down with the Sickness became one of the defining songs of early 2000s hard rock, anchored by David Draiman's unique guttural intro vocal and the song's relentless riff. Disturbed's debut The Sickness debuted at number 29 and eventually sold over four million copies in the US. The song is regularly voted one of the greatest metal tracks of the millennium.",
-      "fun_fact_de": "Down with the Sickness wurde zu einem der prägenden Songs des Hard Rock der frühen 2000er, verankert durch David Draimans einzigartigen Kehlkopf-Intro-Gesang und das unerbittliche Riff.",
-      "fun_fact_es": "Down with the Sickness se convirtió en una de las canciones definitorias del hard rock de principios de los 2000, anclada por el único vocal gutural de introducción de David Draiman y el implacable riff.",
-      "fun_fact_fr": "Down with the Sickness est devenu l'un des titres définisseurs du hard rock du début des années 2000, ancré par la voix gutturale d'introduction unique de David Draiman et le riff implacable.",
+      "fun_fact_de": "Down with the Sickness wurde zu einem der pr\u00e4genden Songs des Hard Rock der fr\u00fchen 2000er, verankert durch David Draimans einzigartigen Kehlkopf-Intro-Gesang und das unerbittliche Riff.",
+      "fun_fact_es": "Down with the Sickness se convirti\u00f3 en una de las canciones definitorias del hard rock de principios de los 2000, anclada por el \u00fanico vocal gutural de introducci\u00f3n de David Draiman y el implacable riff.",
+      "fun_fact_fr": "Down with the Sickness est devenu l'un des titres d\u00e9finisseurs du hard rock du d\u00e9but des ann\u00e9es 2000, ancr\u00e9 par la voix gutturale d'introduction unique de David Draiman et le riff implacable.",
       "uri_apple_music": "applemusic://track/1030601027",
       "uri_youtube_music": "https://music.youtube.com/watch?v=09LTT0xwdfw",
       "uri_tidal": "tidal://track/4085748",
@@ -1186,14 +1186,14 @@
       "awards": [
         "Grammy nomination"
       ],
-      "fun_fact": "Lamb of God are one of the most important metal bands of the 2000s, spearheading the New Wave of American Heavy Metal alongside Mastodon and Killswitch Engage. Vocalist Randy Blythe was famously arrested in the Czech Republic in 2012 on manslaughter charges relating to an incident at a 2010 concert — he was ultimately acquitted. Their Ashes of the Wake album is considered a modern metal classic.",
-      "fun_fact_de": "Lamb of God sind eine der wichtigsten Metal-Bands der 2000er. Sänger Randy Blythe wurde 2012 in der Tschechischen Republik wegen Totschlagvorwürfen verhaftet — er wurde letztendlich freigesprochen.",
-      "fun_fact_es": "Lamb of God es una de las bandas de metal más importantes de los años 2000. El vocalista Randy Blythe fue arrestado en la República Checa en 2012 por cargos de homicidio involuntario relacionados con un incidente en un concierto de 2010 — finalmente fue absuelto.",
-      "fun_fact_fr": "Lamb of God est l'un des groupes de metal les plus importants des années 2000. Le chanteur Randy Blythe a été arrêté en République tchèque en 2012 sous des accusations d'homicide involontaire liées à un incident lors d'un concert de 2010 — il a finalement été acquitté.",
+      "fun_fact": "Lamb of God are one of the most important metal bands of the 2000s, spearheading the New Wave of American Heavy Metal alongside Mastodon and Killswitch Engage. Vocalist Randy Blythe was famously arrested in the Czech Republic in 2012 on manslaughter charges relating to an incident at a 2010 concert \u2014 he was ultimately acquitted. Their Ashes of the Wake album is considered a modern metal classic.",
+      "fun_fact_de": "Lamb of God sind eine der wichtigsten Metal-Bands der 2000er. S\u00e4nger Randy Blythe wurde 2012 in der Tschechischen Republik wegen Totschlagvorw\u00fcrfen verhaftet \u2014 er wurde letztendlich freigesprochen.",
+      "fun_fact_es": "Lamb of God es una de las bandas de metal m\u00e1s importantes de los a\u00f1os 2000. El vocalista Randy Blythe fue arrestado en la Rep\u00fablica Checa en 2012 por cargos de homicidio involuntario relacionados con un incidente en un concierto de 2010 \u2014 finalmente fue absuelto.",
+      "fun_fact_fr": "Lamb of God est l'un des groupes de metal les plus importants des ann\u00e9es 2000. Le chanteur Randy Blythe a \u00e9t\u00e9 arr\u00eat\u00e9 en R\u00e9publique tch\u00e8que en 2012 sous des accusations d'homicide involontaire li\u00e9es \u00e0 un incident lors d'un concert de 2010 \u2014 il a finalement \u00e9t\u00e9 acquitt\u00e9.",
       "uri_apple_music": "applemusic://track/1440904907",
       "uri_youtube_music": "https://music.youtube.com/watch?v=iFm9v0OvYua",
       "uri_tidal": "tidal://track/4085761",
-      "fun_fact_nl": "Lamb of God is een van de belangrijkste metalbands van de jaren 2000, die samen met Mastodon en Killswitch Engage de New Wave of American Heavy Metal aanvoerde. Zanger Randy Blythe werd in 2012 in Tsjechië gearresteerd op beschuldiging van doodslag naar aanleiding van een incident tijdens een concert in 2010 - hij werd uiteindelijk vrijgesproken. Hun album Ashes of the Wake wordt beschouwd als een moderne metalklassieker.",
+      "fun_fact_nl": "Lamb of God is een van de belangrijkste metalbands van de jaren 2000, die samen met Mastodon en Killswitch Engage de New Wave of American Heavy Metal aanvoerde. Zanger Randy Blythe werd in 2012 in Tsjechi\u00eb gearresteerd op beschuldiging van doodslag naar aanleiding van een incident tijdens een concert in 2010 - hij werd uiteindelijk vrijgesproken. Hun album Ashes of the Wake wordt beschouwd als een moderne metalklassieker.",
       "awards_nl": [
         "Grammy-nominatie"
       ]
@@ -1220,9 +1220,9 @@
         "Grammy nomination"
       ],
       "fun_fact": "Blood and Thunder opens Mastodon's breakthrough album Leviathan, a conceptual retelling of Moby Dick through progressive sludge metal. The album is considered one of the most creative and ambitious metal records of the 2000s. Mastodon are widely credited with elevating metal's artistic ambitions and proving the genre capable of true progressive depth.",
-      "fun_fact_de": "Blood and Thunder eröffnet Mastodons Durchbruch-Album Leviathan, eine konzeptionelle Neuerzählung von Moby Dick durch Progressive Sludge Metal. Das Album gilt als eines der kreativsten und ehrgeizigstem Metal-Werke der 2000er Jahre.",
-      "fun_fact_es": "Blood and Thunder abre el álbum de breakthrough de Mastodon, Leviathan, una reinterpretación conceptual de Moby Dick a través del sludge metal progresivo. El álbum es considerado uno de los discos de metal más creativos y ambiciosos de los años 2000.",
-      "fun_fact_fr": "Blood and Thunder ouvre l'album révélateur de Mastodon, Leviathan, une réinterprétation conceptuelle de Moby Dick à travers le sludge metal progressif. L'album est considéré comme l'un des disques de metal les plus créatifs et ambitieux des années 2000.",
+      "fun_fact_de": "Blood and Thunder er\u00f6ffnet Mastodons Durchbruch-Album Leviathan, eine konzeptionelle Neuerz\u00e4hlung von Moby Dick durch Progressive Sludge Metal. Das Album gilt als eines der kreativsten und ehrgeizigstem Metal-Werke der 2000er Jahre.",
+      "fun_fact_es": "Blood and Thunder abre el \u00e1lbum de breakthrough de Mastodon, Leviathan, una reinterpretaci\u00f3n conceptual de Moby Dick a trav\u00e9s del sludge metal progresivo. El \u00e1lbum es considerado uno de los discos de metal m\u00e1s creativos y ambiciosos de los a\u00f1os 2000.",
+      "fun_fact_fr": "Blood and Thunder ouvre l'album r\u00e9v\u00e9lateur de Mastodon, Leviathan, une r\u00e9interpr\u00e9tation conceptuelle de Moby Dick \u00e0 travers le sludge metal progressif. L'album est consid\u00e9r\u00e9 comme l'un des disques de metal les plus cr\u00e9atifs et ambitieux des ann\u00e9es 2000.",
       "uri_apple_music": "applemusic://track/65922935",
       "uri_youtube_music": "https://music.youtube.com/watch?v=TsdIO2EUtcE",
       "uri_tidal": "tidal://track/4085774",
@@ -1253,9 +1253,9 @@
         "Grammy nomination"
       ],
       "fun_fact": "Flying Whales is Gojira's most celebrated song, a jaw-dropping technical tour-de-force and one of the most environmentally conscious songs in metal. The French band are widely regarded as one of the most innovative metal acts of the 21st century, with a sound that mixes progressive structures with crushing death metal precision. They were chosen to open the 2024 Paris Olympics ceremony.",
-      "fun_fact_de": "Flying Whales ist Gojiras gefeiertster Song, ein technisches Meisterwerk und eines der umweltbewusstesten Lieder des Metal. Die französische Band gilt als eine der innovativsten Metal-Bands des 21. Jahrhunderts. Sie wurden als Opener der Eröffnungsfeier der Olympischen Spiele 2024 in Paris ausgewählt.",
-      "fun_fact_es": "Flying Whales es la canción más celebrada de Gojira, un deslumbrante tour de force técnico y una de las canciones más conscientes del medio ambiente en el metal. La banda francesa es considerada una de las más innovadoras del siglo XXI en metal. Fueron elegidos para abrir la ceremonia de los Juegos Olímpicos de París 2024.",
-      "fun_fact_fr": "Flying Whales est la chanson la plus célébrée de Gojira, un tour de force technique époustouflant et l'une des chansons les plus conscientes de l'environnement dans le metal. Le groupe français est largement considéré comme l'un des plus innovants du 21e siècle. Ils ont été choisis pour ouvrir la cérémonie des JO de Paris 2024.",
+      "fun_fact_de": "Flying Whales ist Gojiras gefeiertster Song, ein technisches Meisterwerk und eines der umweltbewusstesten Lieder des Metal. Die franz\u00f6sische Band gilt als eine der innovativsten Metal-Bands des 21. Jahrhunderts. Sie wurden als Opener der Er\u00f6ffnungsfeier der Olympischen Spiele 2024 in Paris ausgew\u00e4hlt.",
+      "fun_fact_es": "Flying Whales es la canci\u00f3n m\u00e1s celebrada de Gojira, un deslumbrante tour de force t\u00e9cnico y una de las canciones m\u00e1s conscientes del medio ambiente en el metal. La banda francesa es considerada una de las m\u00e1s innovadoras del siglo XXI en metal. Fueron elegidos para abrir la ceremonia de los Juegos Ol\u00edmpicos de Par\u00eds 2024.",
+      "fun_fact_fr": "Flying Whales est la chanson la plus c\u00e9l\u00e9br\u00e9e de Gojira, un tour de force technique \u00e9poustouflant et l'une des chansons les plus conscientes de l'environnement dans le metal. Le groupe fran\u00e7ais est largement consid\u00e9r\u00e9 comme l'un des plus innovants du 21e si\u00e8cle. Ils ont \u00e9t\u00e9 choisis pour ouvrir la c\u00e9r\u00e9monie des JO de Paris 2024.",
       "uri_apple_music": "applemusic://track/213374170",
       "uri_youtube_music": "https://music.youtube.com/watch?v=_-XaaTqOICU",
       "uri_tidal": "tidal://track/4085787",
@@ -1286,13 +1286,13 @@
         "Grammy nomination"
       ],
       "fun_fact": "Silvera became Gojira's most accessible and commercially successful song, a groove-driven metal anthem that earned them Grammy nominations. The song helped introduce the band to a far wider audience without compromising their heavy sound. Magma, the album it appears on, was inspired by the death of Joe and Mario Duplantier's mother and is considered one of metal's most emotionally profound records.",
-      "fun_fact_de": "Silvera wurde Gojiras zugänglichster und kommerziell erfolgreichster Song, eine groove-getriebene Metalhymne, die ihnen Grammy-Nominierungen einbrachte. Magma, das Album, wurde von Tod der Mutter von Joe und Mario Duplantier inspiriert.",
-      "fun_fact_es": "Silvera se convirtió en el tema más accesible y comercialmente exitoso de Gojira, un himno metal impulsado por el groove que les valió nominaciones al Grammy. Magma fue inspirado por la muerte de la madre de Joe y Mario Duplantier.",
-      "fun_fact_fr": "Silvera est devenu le titre le plus accessible et commercialement réussi de Gojira, un hymne metal axé sur le groove qui leur a valu des nominations aux Grammy. Magma a été inspiré par la mort de la mère de Joe et Mario Duplantier.",
+      "fun_fact_de": "Silvera wurde Gojiras zug\u00e4nglichster und kommerziell erfolgreichster Song, eine groove-getriebene Metalhymne, die ihnen Grammy-Nominierungen einbrachte. Magma, das Album, wurde von Tod der Mutter von Joe und Mario Duplantier inspiriert.",
+      "fun_fact_es": "Silvera se convirti\u00f3 en el tema m\u00e1s accesible y comercialmente exitoso de Gojira, un himno metal impulsado por el groove que les vali\u00f3 nominaciones al Grammy. Magma fue inspirado por la muerte de la madre de Joe y Mario Duplantier.",
+      "fun_fact_fr": "Silvera est devenu le titre le plus accessible et commercialement r\u00e9ussi de Gojira, un hymne metal ax\u00e9 sur le groove qui leur a valu des nominations aux Grammy. Magma a \u00e9t\u00e9 inspir\u00e9 par la mort de la m\u00e8re de Joe et Mario Duplantier.",
       "uri_apple_music": "applemusic://track/1104432802",
       "uri_youtube_music": "https://music.youtube.com/watch?v=iVvXB-Vwnco",
       "uri_tidal": "tidal://track/4085800",
-      "fun_fact_nl": "Silvera werd Gojira's meest toegankelijke en commercieel succesvolle nummer, een groove-driven metal anthem dat hen Grammy nominaties opleverde. Het nummer hielp de band om een veel breder publiek te bereiken zonder afbreuk te doen aan hun heavy sound. Magma, het album waarop het staat, werd geïnspireerd door de dood van de moeder van Joe en Mario Duplantier en wordt beschouwd als een van de meest emotioneel diepgaande metalplaten.",
+      "fun_fact_nl": "Silvera werd Gojira's meest toegankelijke en commercieel succesvolle nummer, een groove-driven metal anthem dat hen Grammy nominaties opleverde. Het nummer hielp de band om een veel breder publiek te bereiken zonder afbreuk te doen aan hun heavy sound. Magma, het album waarop het staat, werd ge\u00efnspireerd door de dood van de moeder van Joe en Mario Duplantier en wordt beschouwd als een van de meest emotioneel diepgaande metalplaten.",
       "awards_nl": [
         "Grammy-nominatie"
       ]
@@ -1319,13 +1319,13 @@
         "Grammy nomination"
       ],
       "fun_fact": "Roots Bloody Roots opens Sepultura's landmark album Roots, which fused Brazilian tribal music with groove metal to create one of the most unique and important metal albums of the 1990s. The band recorded parts of the album with the Xavante indigenous tribe in Brazil. It was the last album recorded with vocalist Max Cavalera before his acrimonious split from the band.",
-      "fun_fact_de": "Roots Bloody Roots eröffnet Sepulturas Meilenstein-Album Roots, das brasilianische Stammesmusik mit Groove Metal verband. Teile des Albums wurden mit dem indigenen Stamm der Xavante in Brasilien aufgenommen. Es war das letzte Album mit Sänger Max Cavalera.",
-      "fun_fact_es": "Roots Bloody Roots abre el emblemático álbum Roots de Sepultura, que fusionó música tribal brasileña con groove metal. Partes del álbum fueron grabadas con la tribu indígena Xavante en Brasil. Fue el último álbum grabado con el vocalista Max Cavalera.",
-      "fun_fact_fr": "Roots Bloody Roots ouvre le légendaire album Roots de Sepultura, qui a fusionné la musique tribale brésilienne avec le groove metal. Des parties de l'album ont été enregistrées avec la tribu indigène Xavante au Brésil. C'était le dernier album avec le chanteur Max Cavalera.",
+      "fun_fact_de": "Roots Bloody Roots er\u00f6ffnet Sepulturas Meilenstein-Album Roots, das brasilianische Stammesmusik mit Groove Metal verband. Teile des Albums wurden mit dem indigenen Stamm der Xavante in Brasilien aufgenommen. Es war das letzte Album mit S\u00e4nger Max Cavalera.",
+      "fun_fact_es": "Roots Bloody Roots abre el emblem\u00e1tico \u00e1lbum Roots de Sepultura, que fusion\u00f3 m\u00fasica tribal brasile\u00f1a con groove metal. Partes del \u00e1lbum fueron grabadas con la tribu ind\u00edgena Xavante en Brasil. Fue el \u00faltimo \u00e1lbum grabado con el vocalista Max Cavalera.",
+      "fun_fact_fr": "Roots Bloody Roots ouvre le l\u00e9gendaire album Roots de Sepultura, qui a fusionn\u00e9 la musique tribale br\u00e9silienne avec le groove metal. Des parties de l'album ont \u00e9t\u00e9 enregistr\u00e9es avec la tribu indig\u00e8ne Xavante au Br\u00e9sil. C'\u00e9tait le dernier album avec le chanteur Max Cavalera.",
       "uri_apple_music": "applemusic://track/576936082",
       "uri_youtube_music": "https://music.youtube.com/watch?v=F_6IjeVfBk0",
       "uri_tidal": "tidal://track/4085813",
-      "fun_fact_nl": "Roots Bloody Roots opent Sepultura's baanbrekende album Roots, dat Braziliaanse tribale muziek versmolt met groove metal om een van de meest unieke en belangrijke metalalbums van de jaren 90 te creëren. De band nam delen van het album op met de inheemse Xavante-stam in Brazilië. Het was het laatste album dat werd opgenomen met zanger Max Cavalera voordat hij uit de band stapte.",
+      "fun_fact_nl": "Roots Bloody Roots opent Sepultura's baanbrekende album Roots, dat Braziliaanse tribale muziek versmolt met groove metal om een van de meest unieke en belangrijke metalalbums van de jaren 90 te cre\u00ebren. De band nam delen van het album op met de inheemse Xavante-stam in Brazili\u00eb. Het was het laatste album dat werd opgenomen met zanger Max Cavalera voordat hij uit de band stapte.",
       "awards_nl": [
         "Grammy-nominatie"
       ]
@@ -1351,10 +1351,10 @@
       "awards": [
         "Grammy Award for Best Metal Performance"
       ],
-      "fun_fact": "Square Hammer won Ghost a Grammy for Best Metal Performance in 2017 and is the song that brought the Swedish theatrical metal band to global attention. Ghost's combination of arena-rock hooks, satanic imagery and theatrical live shows — complete with a pope-like frontman called Papa Emeritus — made them one of the most visually spectacular acts in modern rock.",
-      "fun_fact_de": "Square Hammer gewann Ghost 2017 einen Grammy für die beste Metal-Performance. Ghosts Kombination aus Arena-Rock-Hooks, satanischen Bildern und theatralischen Live-Shows machte sie zu einem der spektakulärsten Acts im modernen Rock.",
-      "fun_fact_es": "Square Hammer le valió a Ghost un Grammy a la Mejor Actuación Metal en 2017. La combinación de ganchos de rock de arena, imágenes satánicas y espectaculares shows en vivo convirtió a Ghost en uno de los actos más llamativos del rock moderno.",
-      "fun_fact_fr": "Square Hammer a valu à Ghost un Grammy de la Meilleure Performance Metal en 2017. La combinaison de hooks rock d'arène, d'imagerie satanique et de shows live théâtraux a fait de Ghost l'un des actes les plus spectaculaires du rock moderne.",
+      "fun_fact": "Square Hammer won Ghost a Grammy for Best Metal Performance in 2017 and is the song that brought the Swedish theatrical metal band to global attention. Ghost's combination of arena-rock hooks, satanic imagery and theatrical live shows \u2014 complete with a pope-like frontman called Papa Emeritus \u2014 made them one of the most visually spectacular acts in modern rock.",
+      "fun_fact_de": "Square Hammer gewann Ghost 2017 einen Grammy f\u00fcr die beste Metal-Performance. Ghosts Kombination aus Arena-Rock-Hooks, satanischen Bildern und theatralischen Live-Shows machte sie zu einem der spektakul\u00e4rsten Acts im modernen Rock.",
+      "fun_fact_es": "Square Hammer le vali\u00f3 a Ghost un Grammy a la Mejor Actuaci\u00f3n Metal en 2017. La combinaci\u00f3n de ganchos de rock de arena, im\u00e1genes sat\u00e1nicas y espectaculares shows en vivo convirti\u00f3 a Ghost en uno de los actos m\u00e1s llamativos del rock moderno.",
+      "fun_fact_fr": "Square Hammer a valu \u00e0 Ghost un Grammy de la Meilleure Performance Metal en 2017. La combinaison de hooks rock d'ar\u00e8ne, d'imagerie satanique et de shows live th\u00e9\u00e2traux a fait de Ghost l'un des actes les plus spectaculaires du rock moderne.",
       "uri_apple_music": "applemusic://track/1440943163",
       "uri_youtube_music": "https://music.youtube.com/watch?v=VqoyKzgkqR4",
       "uri_tidal": "tidal://track/4085826",
@@ -1385,13 +1385,13 @@
         "Grammy Award for Best Metal Performance"
       ],
       "fun_fact": "Fear Inoculum is a 10-minute-plus progressive metal epic that became the longest song ever to chart on the Billboard Hot 100 when Tool ended their 13-year album hiatus in 2019. The song debuted at number one on the rock charts. Tool notoriously kept their catalogue off streaming platforms for years, making the release an enormous event for the metal community.",
-      "fun_fact_de": "Fear Inoculum ist ein über 10-minütiges progressives Metal-Epos, das 2019 zum längsten Song wurde, der je in den Billboard Hot 100 chartte. Tool beendete damit eine 13-jährige Albumpause. Die Band hatte ihren Katalog jahrelang von Streaming-Plattformen ferngehalten.",
-      "fun_fact_es": "Fear Inoculum es una épica de metal progresivo de más de 10 minutos que se convirtió en la canción más larga jamás colocada en el Billboard Hot 100 cuando Tool terminó su pausa discográfica de 13 años en 2019. La banda había mantenido su catálogo fuera de las plataformas de streaming durante años.",
-      "fun_fact_fr": "Fear Inoculum est une épopée de metal progressif de plus de 10 minutes qui est devenue la chanson la plus longue à avoir jamais figuré dans le Billboard Hot 100 quand Tool a mis fin à sa pause discographique de 13 ans en 2019. Le groupe avait tenu son catalogue hors des plateformes de streaming pendant des années.",
+      "fun_fact_de": "Fear Inoculum ist ein \u00fcber 10-min\u00fctiges progressives Metal-Epos, das 2019 zum l\u00e4ngsten Song wurde, der je in den Billboard Hot 100 chartte. Tool beendete damit eine 13-j\u00e4hrige Albumpause. Die Band hatte ihren Katalog jahrelang von Streaming-Plattformen ferngehalten.",
+      "fun_fact_es": "Fear Inoculum es una \u00e9pica de metal progresivo de m\u00e1s de 10 minutos que se convirti\u00f3 en la canci\u00f3n m\u00e1s larga jam\u00e1s colocada en el Billboard Hot 100 cuando Tool termin\u00f3 su pausa discogr\u00e1fica de 13 a\u00f1os en 2019. La banda hab\u00eda mantenido su cat\u00e1logo fuera de las plataformas de streaming durante a\u00f1os.",
+      "fun_fact_fr": "Fear Inoculum est une \u00e9pop\u00e9e de metal progressif de plus de 10 minutes qui est devenue la chanson la plus longue \u00e0 avoir jamais figur\u00e9 dans le Billboard Hot 100 quand Tool a mis fin \u00e0 sa pause discographique de 13 ans en 2019. Le groupe avait tenu son catalogue hors des plateformes de streaming pendant des ann\u00e9es.",
       "uri_apple_music": "applemusic://track/1475686698",
       "uri_youtube_music": "https://music.youtube.com/watch?v=q7DfQMPmJRI",
       "uri_tidal": "tidal://track/4085839",
-      "fun_fact_nl": "Fear Inoculum is een meer dan 10 minuten durend progressief metalepos dat het langste nummer ooit werd in de Billboard Hot 100 toen Tool in 2019 een einde maakte aan zijn 13-jarige albumonderbreking. Het nummer debuteerde op nummer één in de rockcharts. Tool heeft hun catalogus jarenlang buiten streamingplatforms gehouden, waardoor de release een enorme gebeurtenis werd voor de metalgemeenschap.",
+      "fun_fact_nl": "Fear Inoculum is een meer dan 10 minuten durend progressief metalepos dat het langste nummer ooit werd in de Billboard Hot 100 toen Tool in 2019 een einde maakte aan zijn 13-jarige albumonderbreking. Het nummer debuteerde op nummer \u00e9\u00e9n in de rockcharts. Tool heeft hun catalogus jarenlang buiten streamingplatforms gehouden, waardoor de release een enorme gebeurtenis werd voor de metalgemeenschap.",
       "awards_nl": [
         "Grammy Award voor Beste Metalprestatie"
       ]
@@ -1399,7 +1399,7 @@
     {
       "year": 1985,
       "uri": "spotify:track:6EPRKhUOdiFSQwGBRBbvsZ",
-      "artist": "Motörhead",
+      "artist": "Mot\u00f6rhead",
       "title": "Ace of Spades",
       "alt_artists": [
         "Judas Priest",
@@ -1417,14 +1417,14 @@
       "awards": [
         "Grammy nomination"
       ],
-      "fun_fact": "Ace of Spades is Motörhead's definitive anthem and one of the fastest and most ferocious songs in rock history. Lemmy Kilmister, the band's iconic bassist and vocalist, lived a legendarily hedonistic lifestyle but continued touring and recording until weeks before his death at age 70 in December 2015. The song has been used in countless films, TV shows and video games.",
-      "fun_fact_de": "Ace of Spades ist Motörheads definitive Hymne und einer der schnellsten und wildesten Songs der Rockgeschichte. Lemmy Kilmister führte einen legendär hedonistischen Lebensstil, tourte und nahm aber bis wenige Wochen vor seinem Tod mit 70 Jahren im Dezember 2015 auf.",
-      "fun_fact_es": "Ace of Spades es el himno definitivo de Motörhead y una de las canciones más rápidas y furiosas de la historia del rock. Lemmy Kilmister llevaba un estilo de vida legendariamente hedonista pero siguió girando y grabando hasta semanas antes de su muerte a los 70 años en diciembre de 2015.",
-      "fun_fact_fr": "Ace of Spades est l'hymne définitif de Motörhead et l'une des chansons les plus rapides et féroces de l'histoire du rock. Lemmy Kilmister menait un style de vie légendairement hédoniste mais a continué à tourner et enregistrer jusqu'à quelques semaines avant sa mort à 70 ans en décembre 2015.",
+      "fun_fact": "Ace of Spades is Mot\u00f6rhead's definitive anthem and one of the fastest and most ferocious songs in rock history. Lemmy Kilmister, the band's iconic bassist and vocalist, lived a legendarily hedonistic lifestyle but continued touring and recording until weeks before his death at age 70 in December 2015. The song has been used in countless films, TV shows and video games.",
+      "fun_fact_de": "Ace of Spades ist Mot\u00f6rheads definitive Hymne und einer der schnellsten und wildesten Songs der Rockgeschichte. Lemmy Kilmister f\u00fchrte einen legend\u00e4r hedonistischen Lebensstil, tourte und nahm aber bis wenige Wochen vor seinem Tod mit 70 Jahren im Dezember 2015 auf.",
+      "fun_fact_es": "Ace of Spades es el himno definitivo de Mot\u00f6rhead y una de las canciones m\u00e1s r\u00e1pidas y furiosas de la historia del rock. Lemmy Kilmister llevaba un estilo de vida legendariamente hedonista pero sigui\u00f3 girando y grabando hasta semanas antes de su muerte a los 70 a\u00f1os en diciembre de 2015.",
+      "fun_fact_fr": "Ace of Spades est l'hymne d\u00e9finitif de Mot\u00f6rhead et l'une des chansons les plus rapides et f\u00e9roces de l'histoire du rock. Lemmy Kilmister menait un style de vie l\u00e9gendairement h\u00e9doniste mais a continu\u00e9 \u00e0 tourner et enregistrer jusqu'\u00e0 quelques semaines avant sa mort \u00e0 70 ans en d\u00e9cembre 2015.",
       "uri_apple_music": "applemusic://track/1439443121",
       "uri_youtube_music": "https://music.youtube.com/watch?v=pWB5JZRGl0U",
       "uri_tidal": "tidal://track/4085852",
-      "fun_fact_nl": "Ace of Spades is het definitieve volkslied van Motörhead en een van de snelste en meest woeste nummers uit de rockgeschiedenis. Lemmy Kilmister, de iconische bassist en zanger van de band, leefde een legendarisch hedonistische levensstijl, maar bleef toeren en opnemen tot weken voor zijn dood op 70-jarige leeftijd in december 2015. Het nummer is gebruikt in talloze films, tv-shows en videogames.",
+      "fun_fact_nl": "Ace of Spades is het definitieve volkslied van Mot\u00f6rhead en een van de snelste en meest woeste nummers uit de rockgeschiedenis. Lemmy Kilmister, de iconische bassist en zanger van de band, leefde een legendarisch hedonistische levensstijl, maar bleef toeren en opnemen tot weken voor zijn dood op 70-jarige leeftijd in december 2015. Het nummer is gebruikt in talloze films, tv-shows en videogames.",
       "awards_nl": [
         "Grammy-nominatie"
       ]
@@ -1450,14 +1450,14 @@
       "awards": [
         "Grammy nomination"
       ],
-      "fun_fact": "Bleed features one of the most insanely difficult drum parts ever recorded — a continuous polyrhythmic pattern that human drummer Tomas Haake plays at a gruelling pace for nearly eight minutes. Meshuggah invented the djent subgenre and have influenced almost every progressive and technical metal band of the past two decades. The song is considered nearly unplayable by most drummers.",
-      "fun_fact_de": "Bleed enthält einen der wahnwitzigsten Drum-Parts aller Zeiten — ein kontinuierliches polyrhythmisches Muster, das Schlagzeuger Tomas Haake fast acht Minuten lang in erschöpfendem Tempo spielt. Meshuggah erfanden das Djent-Subgenre.",
-      "fun_fact_es": "Bleed cuenta con uno de los partes de batería más difíciles jamás grabados — un patrón polirítmico continuo que el batería Tomas Haake toca a un agotador ritmo durante casi ocho minutos. Meshuggah inventaron el subgénero djent.",
-      "fun_fact_fr": "Bleed présente l'une des parties de batterie les plus follement difficiles jamais enregistrées — un motif polyrythmique continu que le batteur Tomas Haake joue à un rythme épuisant pendant près de huit minutes. Meshuggah a inventé le sous-genre djent.",
+      "fun_fact": "Bleed features one of the most insanely difficult drum parts ever recorded \u2014 a continuous polyrhythmic pattern that human drummer Tomas Haake plays at a gruelling pace for nearly eight minutes. Meshuggah invented the djent subgenre and have influenced almost every progressive and technical metal band of the past two decades. The song is considered nearly unplayable by most drummers.",
+      "fun_fact_de": "Bleed enth\u00e4lt einen der wahnwitzigsten Drum-Parts aller Zeiten \u2014 ein kontinuierliches polyrhythmisches Muster, das Schlagzeuger Tomas Haake fast acht Minuten lang in ersch\u00f6pfendem Tempo spielt. Meshuggah erfanden das Djent-Subgenre.",
+      "fun_fact_es": "Bleed cuenta con uno de los partes de bater\u00eda m\u00e1s dif\u00edciles jam\u00e1s grabados \u2014 un patr\u00f3n polir\u00edtmico continuo que el bater\u00eda Tomas Haake toca a un agotador ritmo durante casi ocho minutos. Meshuggah inventaron el subg\u00e9nero djent.",
+      "fun_fact_fr": "Bleed pr\u00e9sente l'une des parties de batterie les plus follement difficiles jamais enregistr\u00e9es \u2014 un motif polyrythmique continu que le batteur Tomas Haake joue \u00e0 un rythme \u00e9puisant pendant pr\u00e8s de huit minutes. Meshuggah a invent\u00e9 le sous-genre djent.",
       "uri_apple_music": "applemusic://track/1882049242",
       "uri_youtube_music": "https://music.youtube.com/watch?v=qc98u-eGzlc",
       "uri_tidal": "tidal://track/4085865",
-      "fun_fact_nl": "Bleed bevat een van de meest waanzinnig moeilijke drumpartijen ooit opgenomen - een continu polyritmisch patroon dat menselijke drummer Tomas Haake bijna acht minuten lang in een moordend tempo speelt. Meshuggah was de uitvinder van het djent-subgenre en heeft bijna elke progressieve en technische metalband van de afgelopen twintig jaar beïnvloed. Het nummer wordt door de meeste drummers bijna onspeelbaar geacht.",
+      "fun_fact_nl": "Bleed bevat een van de meest waanzinnig moeilijke drumpartijen ooit opgenomen - een continu polyritmisch patroon dat menselijke drummer Tomas Haake bijna acht minuten lang in een moordend tempo speelt. Meshuggah was de uitvinder van het djent-subgenre en heeft bijna elke progressieve en technische metalband van de afgelopen twintig jaar be\u00efnvloed. Het nummer wordt door de meeste drummers bijna onspeelbaar geacht.",
       "awards_nl": [
         "Grammy-nominatie"
       ]
@@ -1466,7 +1466,7 @@
       "year": 1992,
       "uri": "spotify:track:6rkeaQRCWZxwkjhyqgxjXi",
       "artist": "Pantera",
-      "title": "Vulgar Display of Power",
+      "title": "Mouth for War",
       "alt_artists": [
         "Machine Head",
         "White Zombie",
@@ -1483,14 +1483,14 @@
       "awards": [
         "Grammy nomination"
       ],
-      "fun_fact": "Vulgar Display of Power is one of the most influential metal albums of all time, cementing Pantera's place in the heavy metal canon. Dimebag Darrell's aggressive, angular guitar work on this album influenced a generation of metal guitarists. The album cover — depicting a man being punched in the face — was chosen after the band literally punched volunteers and photographed the results.",
-      "fun_fact_de": "Vulgar Display of Power ist eines der einflussreichsten Metal-Alben aller Zeiten. Das Albumcover zeigt einen Mann, der ins Gesicht geschlagen wird — die Band schlug buchstäblich Freiwillige und fotografierte die Ergebnisse.",
-      "fun_fact_es": "Vulgar Display of Power es uno de los álbumes de metal más influyentes de todos los tiempos. La portada del álbum, que muestra a un hombre recibiendo un puñetazo en la cara, fue elegida después de que la banda golpeara literalmente a voluntarios y fotografiara los resultados.",
-      "fun_fact_fr": "Vulgar Display of Power est l'un des albums de metal les plus influents de tous les temps. La pochette de l'album — montrant un homme frappé au visage — a été choisie après que le groupe a littéralement frappé des volontaires et photographié les résultats.",
+      "fun_fact": "Vulgar Display of Power is one of the most influential metal albums of all time, cementing Pantera's place in the heavy metal canon. Dimebag Darrell's aggressive, angular guitar work on this album influenced a generation of metal guitarists. The album cover \u2014 depicting a man being punched in the face \u2014 was chosen after the band literally punched volunteers and photographed the results.",
+      "fun_fact_de": "Vulgar Display of Power ist eines der einflussreichsten Metal-Alben aller Zeiten. Das Albumcover zeigt einen Mann, der ins Gesicht geschlagen wird \u2014 die Band schlug buchst\u00e4blich Freiwillige und fotografierte die Ergebnisse.",
+      "fun_fact_es": "Vulgar Display of Power es uno de los \u00e1lbumes de metal m\u00e1s influyentes de todos los tiempos. La portada del \u00e1lbum, que muestra a un hombre recibiendo un pu\u00f1etazo en la cara, fue elegida despu\u00e9s de que la banda golpeara literalmente a voluntarios y fotografiara los resultados.",
+      "fun_fact_fr": "Vulgar Display of Power est l'un des albums de metal les plus influents de tous les temps. La pochette de l'album \u2014 montrant un homme frapp\u00e9 au visage \u2014 a \u00e9t\u00e9 choisie apr\u00e8s que le groupe a litt\u00e9ralement frapp\u00e9 des volontaires et photographi\u00e9 les r\u00e9sultats.",
       "uri_apple_music": "applemusic://track/518549047",
       "uri_youtube_music": "https://music.youtube.com/watch?v=a3JSbOt7CLo",
       "uri_tidal": "tidal://track/4085878",
-      "fun_fact_nl": "Vulgar Display of Power is een van de meest invloedrijke metalalbums aller tijden en verstevigde Pantera's plaats in de heavy metal canon. Dimebag Darrell's agressieve, hoekige gitaarwerk op dit album beïnvloedde een generatie metal gitaristen. De albumhoes - een man die in zijn gezicht wordt geslagen - werd gekozen nadat de band letterlijk vrijwilligers had geslagen en de resultaten had gefotografeerd.",
+      "fun_fact_nl": "Vulgar Display of Power is een van de meest invloedrijke metalalbums aller tijden en verstevigde Pantera's plaats in de heavy metal canon. Dimebag Darrell's agressieve, hoekige gitaarwerk op dit album be\u00efnvloedde een generatie metal gitaristen. De albumhoes - een man die in zijn gezicht wordt geslagen - werd gekozen nadat de band letterlijk vrijwilligers had geslagen en de resultaten had gefotografeerd.",
       "awards_nl": [
         "Grammy-nominatie"
       ]
@@ -1517,9 +1517,9 @@
         "Grammy nomination"
       ],
       "fun_fact": "In the End is one of the best-selling singles of the 2000s and helped propel Hybrid Theory to become one of the best-selling debut albums in US history. The song was nearly cut from the album as Chester Bennington initially felt the vocal melody wasn't working. The piano motif that opens the song was the last piece added. Chester Bennington died by suicide in 2017.",
-      "fun_fact_de": "In the End ist eine der meistverkauften Singles der 2000er und half dabei, Hybrid Theory zu einem der meistverkauften Debütalben der US-Geschichte zu machen. Chester Bennington wollte den Song fast vom Album streichen. Bennington starb 2017 durch Suizid.",
-      "fun_fact_es": "In the End es uno de los singles más vendidos de los años 2000 y ayudó a impulsar Hybrid Theory a ser uno de los álbumes debut más vendidos de la historia de EE.UU. Chester Bennington estuvo a punto de eliminar la canción del álbum. Bennington murió por suicidio en 2017.",
-      "fun_fact_fr": "In the End est l'un des singles les plus vendus des années 2000 et a contribué à propulser Hybrid Theory parmi les albums de débuts les plus vendus de l'histoire américaine. Chester Bennington voulait presque retirer la chanson de l'album. Bennington est décédé par suicide en 2017.",
+      "fun_fact_de": "In the End ist eine der meistverkauften Singles der 2000er und half dabei, Hybrid Theory zu einem der meistverkauften Deb\u00fctalben der US-Geschichte zu machen. Chester Bennington wollte den Song fast vom Album streichen. Bennington starb 2017 durch Suizid.",
+      "fun_fact_es": "In the End es uno de los singles m\u00e1s vendidos de los a\u00f1os 2000 y ayud\u00f3 a impulsar Hybrid Theory a ser uno de los \u00e1lbumes debut m\u00e1s vendidos de la historia de EE.UU. Chester Bennington estuvo a punto de eliminar la canci\u00f3n del \u00e1lbum. Bennington muri\u00f3 por suicidio en 2017.",
+      "fun_fact_fr": "In the End est l'un des singles les plus vendus des ann\u00e9es 2000 et a contribu\u00e9 \u00e0 propulser Hybrid Theory parmi les albums de d\u00e9buts les plus vendus de l'histoire am\u00e9ricaine. Chester Bennington voulait presque retirer la chanson de l'album. Bennington est d\u00e9c\u00e9d\u00e9 par suicide en 2017.",
       "uri_apple_music": "applemusic://track/528437613",
       "uri_youtube_music": "https://music.youtube.com/watch?v=eVTXPUF4Oz4",
       "uri_tidal": "tidal://track/4085891",
@@ -1549,14 +1549,14 @@
       "awards": [
         "Grammy nomination"
       ],
-      "fun_fact": "The End of Heartache is the defining song of metalcore, a genre that Killswitch Engage helped create by merging the aggression of metal with the melodic sensibility of hardcore punk. The song's dual dynamic — brutal breakdowns and soaring clean choruses — became the template for hundreds of bands. It helped launch the New Wave of American Heavy Metal movement.",
-      "fun_fact_de": "The End of Heartache ist der definierende Song des Metalcore, eines Genres, das Killswitch Engage mitbegründeten. Das duale Dynamik-Prinzip — brutale Breakdowns und aufsteigende melodische Refrains — wurde zur Vorlage für Hunderte von Bands.",
-      "fun_fact_es": "The End of Heartache es la canción definitoria del metalcore, un género que Killswitch Engage ayudó a crear. La dualidad dinámica de la canción — violentos breakdowns y soaring chorus melódicos — se convirtió en la plantilla para cientos de bandas.",
-      "fun_fact_fr": "The End of Heartache est le titre définisseur du metalcore, un genre que Killswitch Engage a contribué à créer. La dynamique duale de la chanson — breakdowns brutaux et refrains mélodiques soaring — est devenue le modèle pour des centaines de groupes.",
+      "fun_fact": "The End of Heartache is the defining song of metalcore, a genre that Killswitch Engage helped create by merging the aggression of metal with the melodic sensibility of hardcore punk. The song's dual dynamic \u2014 brutal breakdowns and soaring clean choruses \u2014 became the template for hundreds of bands. It helped launch the New Wave of American Heavy Metal movement.",
+      "fun_fact_de": "The End of Heartache ist der definierende Song des Metalcore, eines Genres, das Killswitch Engage mitbegr\u00fcndeten. Das duale Dynamik-Prinzip \u2014 brutale Breakdowns und aufsteigende melodische Refrains \u2014 wurde zur Vorlage f\u00fcr Hunderte von Bands.",
+      "fun_fact_es": "The End of Heartache es la canci\u00f3n definitoria del metalcore, un g\u00e9nero que Killswitch Engage ayud\u00f3 a crear. La dualidad din\u00e1mica de la canci\u00f3n \u2014 violentos breakdowns y soaring chorus mel\u00f3dicos \u2014 se convirti\u00f3 en la plantilla para cientos de bandas.",
+      "fun_fact_fr": "The End of Heartache est le titre d\u00e9finisseur du metalcore, un genre que Killswitch Engage a contribu\u00e9 \u00e0 cr\u00e9er. La dynamique duale de la chanson \u2014 breakdowns brutaux et refrains m\u00e9lodiques soaring \u2014 est devenue le mod\u00e8le pour des centaines de groupes.",
       "uri_apple_music": "applemusic://track/214629024",
       "uri_youtube_music": "https://music.youtube.com/watch?v=JiDnB-CrrNs",
       "uri_tidal": "tidal://track/4085904",
-      "fun_fact_nl": "The End of Heartache is het bepalende nummer van metalcore, een genre dat Killswitch Engage hielp creëren door de agressie van metal samen te voegen met de melodieuze gevoeligheid van hardcorepunk. De dubbele dynamiek van het nummer - brute breakdowns en stijgende cleane refreinen - werd het sjabloon voor honderden bands. Het hielp de New Wave of American Heavy Metal beweging te lanceren.",
+      "fun_fact_nl": "The End of Heartache is het bepalende nummer van metalcore, een genre dat Killswitch Engage hielp cre\u00ebren door de agressie van metal samen te voegen met de melodieuze gevoeligheid van hardcorepunk. De dubbele dynamiek van het nummer - brute breakdowns en stijgende cleane refreinen - werd het sjabloon voor honderden bands. Het hielp de New Wave of American Heavy Metal beweging te lanceren.",
       "awards_nl": [
         "Grammy-nominatie"
       ]
@@ -1583,9 +1583,9 @@
         "Grammy nomination"
       ],
       "fun_fact": "Trivium became one of the most prominent metal bands of the 2000s, championed by Metallica's Lars Ulrich as the future of metal. Vocalist Matt Heafy began playing guitar at age 12 and signed Trivium to a major label deal when he was just 15 years old. Their blend of thrash and metalcore helped bridge two generations of metal fans.",
-      "fun_fact_de": "Trivium wurde von Metallicas Lars Ulrich als Zukunft des Metal gelobt. Sänger Matt Heafy begann mit 12 Jahren Gitarre zu spielen und unterschrieb im Alter von 15 Jahren einen Major-Label-Vertrag für Trivium.",
-      "fun_fact_es": "Trivium fue elogiado por Lars Ulrich de Metallica como el futuro del metal. El vocalista Matt Heafy comenzó a tocar guitarra a los 12 años y firmó un contrato con un sello major para Trivium con solo 15 años.",
-      "fun_fact_fr": "Trivium a été salué par Lars Ulrich de Metallica comme l'avenir du metal. Le chanteur Matt Heafy a commencé à jouer de la guitare à 12 ans et a signé Trivium avec un grand label à seulement 15 ans.",
+      "fun_fact_de": "Trivium wurde von Metallicas Lars Ulrich als Zukunft des Metal gelobt. S\u00e4nger Matt Heafy begann mit 12 Jahren Gitarre zu spielen und unterschrieb im Alter von 15 Jahren einen Major-Label-Vertrag f\u00fcr Trivium.",
+      "fun_fact_es": "Trivium fue elogiado por Lars Ulrich de Metallica como el futuro del metal. El vocalista Matt Heafy comenz\u00f3 a tocar guitarra a los 12 a\u00f1os y firm\u00f3 un contrato con un sello major para Trivium con solo 15 a\u00f1os.",
+      "fun_fact_fr": "Trivium a \u00e9t\u00e9 salu\u00e9 par Lars Ulrich de Metallica comme l'avenir du metal. Le chanteur Matt Heafy a commenc\u00e9 \u00e0 jouer de la guitare \u00e0 12 ans et a sign\u00e9 Trivium avec un grand label \u00e0 seulement 15 ans.",
       "uri_apple_music": "applemusic://track/697728142",
       "uri_youtube_music": "https://music.youtube.com/watch?v=sRAaFn2hEP4",
       "uri_tidal": "tidal://track/4085917",
@@ -1616,9 +1616,9 @@
         "Grammy nomination"
       ],
       "fun_fact": "Drown marked a massive evolution in Bring Me the Horizon's sound, moving away from metalcore towards atmospheric rock and synth-driven anthems. The song became their biggest hit and opened them to a mainstream audience. BMTH are one of the most successful British heavy acts of their generation, having evolved dramatically from their brutal deathcore beginnings.",
-      "fun_fact_de": "Drown markierte eine massive Entwicklung im Sound von Bring Me the Horizon hin zu atmosphärischem Rock. Der Song wurde ihr größter Hit. BMTH ist eine der erfolgreichsten britischen Heavy-Acts ihrer Generation, die sich dramatisch von ihren brutalen Deathcore-Anfängen entwickelt hat.",
-      "fun_fact_es": "Drown marcó una enorme evolución en el sonido de Bring Me the Horizon, alejándose del metalcore hacia el rock atmosférico. La canción se convirtió en su mayor éxito. BMTH es uno de los actos pesados británicos más exitosos de su generación.",
-      "fun_fact_fr": "Drown a marqué une évolution massive dans le son de Bring Me the Horizon, s'éloignant du metalcore vers le rock atmosphérique. La chanson est devenue leur plus grand succès. BMTH est l'un des actes heavy britanniques les plus réussis de leur génération.",
+      "fun_fact_de": "Drown markierte eine massive Entwicklung im Sound von Bring Me the Horizon hin zu atmosph\u00e4rischem Rock. Der Song wurde ihr gr\u00f6\u00dfter Hit. BMTH ist eine der erfolgreichsten britischen Heavy-Acts ihrer Generation, die sich dramatisch von ihren brutalen Deathcore-Anf\u00e4ngen entwickelt hat.",
+      "fun_fact_es": "Drown marc\u00f3 una enorme evoluci\u00f3n en el sonido de Bring Me the Horizon, alej\u00e1ndose del metalcore hacia el rock atmosf\u00e9rico. La canci\u00f3n se convirti\u00f3 en su mayor \u00e9xito. BMTH es uno de los actos pesados brit\u00e1nicos m\u00e1s exitosos de su generaci\u00f3n.",
+      "fun_fact_fr": "Drown a marqu\u00e9 une \u00e9volution massive dans le son de Bring Me the Horizon, s'\u00e9loignant du metalcore vers le rock atmosph\u00e9rique. La chanson est devenue leur plus grand succ\u00e8s. BMTH est l'un des actes heavy britanniques les plus r\u00e9ussis de leur g\u00e9n\u00e9ration.",
       "uri_apple_music": "applemusic://track/1485060616",
       "uri_youtube_music": "https://music.youtube.com/watch?v=TkV5709EG5M",
       "uri_tidal": "tidal://track/4085930",
@@ -1649,13 +1649,13 @@
         "Grammy nomination"
       ],
       "fun_fact": "Parkway Drive rose from the surf town of Byron Bay, Australia to become one of the most successful metalcore bands in the world. The Australian metal scene has produced an extraordinary number of world-class heavy acts, and Parkway Drive are its crown jewel. Their Wembley Stadium headline show in 2023 was a landmark moment for Australian heavy music.",
-      "fun_fact_de": "Parkway Drive stammten aus dem Surferstädtchen Byron Bay, Australien, und wurden zu einer der erfolgreichsten Metalcore-Bands der Welt. Ihr Headliner-Auftritt im Wembley Stadium 2023 war ein Meilenstein für die australische Heavy-Music-Szene.",
-      "fun_fact_es": "Parkway Drive surgió del pueblo surfero de Byron Bay, Australia, para convertirse en una de las bandas de metalcore más exitosas del mundo. Su espectáculo como cabeza de cartel en el Wembley Stadium en 2023 fue un hito para la música pesada australiana.",
-      "fun_fact_fr": "Parkway Drive vient de la ville de surf de Byron Bay, Australie, et est devenu l'un des groupes de metalcore les plus réussis au monde. Leur tête d'affiche au Wembley Stadium en 2023 a été un moment marquant pour la musique heavy australienne.",
+      "fun_fact_de": "Parkway Drive stammten aus dem Surferst\u00e4dtchen Byron Bay, Australien, und wurden zu einer der erfolgreichsten Metalcore-Bands der Welt. Ihr Headliner-Auftritt im Wembley Stadium 2023 war ein Meilenstein f\u00fcr die australische Heavy-Music-Szene.",
+      "fun_fact_es": "Parkway Drive surgi\u00f3 del pueblo surfero de Byron Bay, Australia, para convertirse en una de las bandas de metalcore m\u00e1s exitosas del mundo. Su espect\u00e1culo como cabeza de cartel en el Wembley Stadium en 2023 fue un hito para la m\u00fasica pesada australiana.",
+      "fun_fact_fr": "Parkway Drive vient de la ville de surf de Byron Bay, Australie, et est devenu l'un des groupes de metalcore les plus r\u00e9ussis au monde. Leur t\u00eate d'affiche au Wembley Stadium en 2023 a \u00e9t\u00e9 un moment marquant pour la musique heavy australienne.",
       "uri_apple_music": "applemusic://track/1485045876",
       "uri_youtube_music": "https://music.youtube.com/watch?v=CeetS4vERoo",
       "uri_tidal": "tidal://track/4085943",
-      "fun_fact_nl": "Parkway Drive groeide vanuit het surfstadje Byron Bay in Australië uit tot een van de meest succesvolle metalcore bands ter wereld. De Australische metalscene heeft een buitengewoon aantal heavy acts van wereldklasse voortgebracht en Parkway Drive is het kroonjuweel. Hun headline show in het Wembley Stadium in 2023 was een mijlpaal voor de Australische heavy muziek.",
+      "fun_fact_nl": "Parkway Drive groeide vanuit het surfstadje Byron Bay in Australi\u00eb uit tot een van de meest succesvolle metalcore bands ter wereld. De Australische metalscene heeft een buitengewoon aantal heavy acts van wereldklasse voortgebracht en Parkway Drive is het kroonjuweel. Hun headline show in het Wembley Stadium in 2023 was een mijlpaal voor de Australische heavy muziek.",
       "awards_nl": [
         "Grammy-nominatie"
       ]
@@ -1681,10 +1681,10 @@
       "awards": [
         "Grammy nomination"
       ],
-      "fun_fact": "Architects became the most important British metalcore band of the 2010s under the creative leadership of guitarist Tom Searle, who died of skin cancer in 2016 at age 28. The band's album Holy Hell — released two years after Tom's death — was an emotionally devastating tribute written by his twin brother Dan and the rest of the band. It is considered one of modern metal's most poignant records.",
-      "fun_fact_de": "Architects wurde unter der kreativen Führung von Gitarrist Tom Searle zur wichtigsten britischen Metalcore-Band der 2010er. Searle starb 2016 im Alter von 28 Jahren an Hautkrebs. Das Album Holy Hell war ein verheerender Tribut seines Zwillingsbruders Dan.",
-      "fun_fact_es": "Architects se convirtió en la banda de metalcore británica más importante de los años 2010 bajo el liderazgo creativo del guitarrista Tom Searle, quien murió de cáncer de piel en 2016 a los 28 años. El álbum Holy Hell fue un devastador tributo de su hermano gemelo Dan.",
-      "fun_fact_fr": "Architects est devenu le groupe de metalcore britannique le plus important des années 2010 sous la direction créative du guitariste Tom Searle, décédé d'un cancer de la peau en 2016 à 28 ans. L'album Holy Hell était un hommage déchirant de son frère jumeau Dan.",
+      "fun_fact": "Architects became the most important British metalcore band of the 2010s under the creative leadership of guitarist Tom Searle, who died of skin cancer in 2016 at age 28. The band's album Holy Hell \u2014 released two years after Tom's death \u2014 was an emotionally devastating tribute written by his twin brother Dan and the rest of the band. It is considered one of modern metal's most poignant records.",
+      "fun_fact_de": "Architects wurde unter der kreativen F\u00fchrung von Gitarrist Tom Searle zur wichtigsten britischen Metalcore-Band der 2010er. Searle starb 2016 im Alter von 28 Jahren an Hautkrebs. Das Album Holy Hell war ein verheerender Tribut seines Zwillingsbruders Dan.",
+      "fun_fact_es": "Architects se convirti\u00f3 en la banda de metalcore brit\u00e1nica m\u00e1s importante de los a\u00f1os 2010 bajo el liderazgo creativo del guitarrista Tom Searle, quien muri\u00f3 de c\u00e1ncer de piel en 2016 a los 28 a\u00f1os. El \u00e1lbum Holy Hell fue un devastador tributo de su hermano gemelo Dan.",
+      "fun_fact_fr": "Architects est devenu le groupe de metalcore britannique le plus important des ann\u00e9es 2010 sous la direction cr\u00e9ative du guitariste Tom Searle, d\u00e9c\u00e9d\u00e9 d'un cancer de la peau en 2016 \u00e0 28 ans. L'album Holy Hell \u00e9tait un hommage d\u00e9chirant de son fr\u00e8re jumeau Dan.",
       "uri_apple_music": "applemusic://track/1485075528",
       "uri_youtube_music": "https://music.youtube.com/watch?v=q3tsHlxXejQ",
       "uri_tidal": "tidal://track/4085956",
@@ -1714,14 +1714,14 @@
       "awards": [
         "Grammy Award for Best Metal Performance"
       ],
-      "fun_fact": "Underneath won Code Orange a Grammy for Best Metal Performance in 2021, making them one of the youngest bands ever to win the award. The Pittsburgh hardcore punk and metal band started rehearsing in middle school and signed to a major label as teenagers. Their avant-garde approach to heavy music — incorporating industrial, electronic and noise elements — represents the cutting edge of modern metal.",
-      "fun_fact_de": "Underneath gewann Code Orange 2021 einen Grammy für die beste Metal-Performance und machte sie zu einer der jüngsten Bands, die diese Auszeichnung je gewannen. Die Band aus Pittsburgh startete Proben in der Mittelschule.",
-      "fun_fact_es": "Underneath le valió a Code Orange un Grammy a la Mejor Actuación Metal en 2021, convirtiéndolos en una de las bandas más jóvenes en ganar este premio. La banda de Pittsburgh comenzó a ensayar en la escuela secundaria.",
-      "fun_fact_fr": "Underneath a valu à Code Orange un Grammy de la Meilleure Performance Metal en 2021, faisant d'eux l'un des groupes les plus jeunes à remporter ce prix. Le groupe de Pittsburgh a commencé à répéter au collège.",
+      "fun_fact": "Underneath won Code Orange a Grammy for Best Metal Performance in 2021, making them one of the youngest bands ever to win the award. The Pittsburgh hardcore punk and metal band started rehearsing in middle school and signed to a major label as teenagers. Their avant-garde approach to heavy music \u2014 incorporating industrial, electronic and noise elements \u2014 represents the cutting edge of modern metal.",
+      "fun_fact_de": "Underneath gewann Code Orange 2021 einen Grammy f\u00fcr die beste Metal-Performance und machte sie zu einer der j\u00fcngsten Bands, die diese Auszeichnung je gewannen. Die Band aus Pittsburgh startete Proben in der Mittelschule.",
+      "fun_fact_es": "Underneath le vali\u00f3 a Code Orange un Grammy a la Mejor Actuaci\u00f3n Metal en 2021, convirti\u00e9ndolos en una de las bandas m\u00e1s j\u00f3venes en ganar este premio. La banda de Pittsburgh comenz\u00f3 a ensayar en la escuela secundaria.",
+      "fun_fact_fr": "Underneath a valu \u00e0 Code Orange un Grammy de la Meilleure Performance Metal en 2021, faisant d'eux l'un des groupes les plus jeunes \u00e0 remporter ce prix. Le groupe de Pittsburgh a commenc\u00e9 \u00e0 r\u00e9p\u00e9ter au coll\u00e8ge.",
       "uri_apple_music": "applemusic://track/1493581631",
       "uri_youtube_music": "https://music.youtube.com/watch?v=xIpoEC4kSW0",
       "uri_tidal": "tidal://track/4085969",
-      "fun_fact_nl": "Underneath won Code Orange in 2021 een Grammy voor beste metalprestatie, waardoor ze een van de jongste bands ooit zijn die de prijs wonnen. De hardcore punk- en metalband uit Pittsburgh begon met repeteren op de middelbare school en tekende als tiener bij een groot label. Hun avant-gardistische benadering van heavy muziek - met industriële, elektronische en noise-elementen - vertegenwoordigt het snijvlak van moderne metal.",
+      "fun_fact_nl": "Underneath won Code Orange in 2021 een Grammy voor beste metalprestatie, waardoor ze een van de jongste bands ooit zijn die de prijs wonnen. De hardcore punk- en metalband uit Pittsburgh begon met repeteren op de middelbare school en tekende als tiener bij een groot label. Hun avant-gardistische benadering van heavy muziek - met industri\u00eble, elektronische en noise-elementen - vertegenwoordigt het snijvlak van moderne metal.",
       "awards_nl": [
         "Grammy Award voor Beste Metalprestatie"
       ]


### PR DESCRIPTION
Closes #582.

Fixed the 3 Pantera URIs that were pointing to Mouth for War despite the metadata saying Vulgar Display of Power. Updated the playlist metadata to match the URIs (Mouth for War is the opening track of the Vulgar Display of Power album and is the correct track).

Partially fixes #582 — 12 YouTube Music dead links and 1 Apple Music dead link remain unresolved and require manual intervention to locate working alternatives.

Bumped playlist version from 1.4 to 1.5.