### PR TITLE
fix: extract PERIOD_DAYS_MAP constant (DRY violation)

### DIFF
--- a/custom_components/beatify/analytics.py
+++ b/custom_components/beatify/analytics.py
@@ -26,6 +26,9 @@ MAX_DETAILED_RECORDS = 1000
 RETENTION_DAYS = 90
 PRUNE_INTERVAL = 10  # Prune every N game records
 
+# Period-to-days mapping used by stats functions
+PERIOD_DAYS_MAP: dict[str, int] = {"7d": 7, "30d": 30, "90d": 90, "all": 365 * 10}
+
 
 class GameRecord(TypedDict):
     """Game record schema (AC: #1)."""
@@ -546,8 +549,7 @@ class AnalyticsStorage:
         now = int(time.time())
 
         # Calculate period boundaries
-        days_map = {"7d": 7, "30d": 30, "90d": 90, "all": 365 * 10}
-        days = days_map.get(period, 30)
+        days = PERIOD_DAYS_MAP.get(period, 30)
         start_ts = now - (days * 86400)
 
         # Filter errors by period
@@ -594,8 +596,7 @@ class AnalyticsStorage:
         now = int(time.time())
 
         # Calculate period boundaries
-        days_map = {"7d": 7, "30d": 30, "90d": 90, "all": 365 * 10}
-        days = days_map.get(period, 30)
+        days = PERIOD_DAYS_MAP.get(period, 30)
 
         current_start = now - (days * 86400)
         previous_start = current_start - (days * 86400)
@@ -708,8 +709,7 @@ class AnalyticsStorage:
         now = int(time.time())
 
         # Calculate period boundaries
-        days_map = {"7d": 7, "30d": 30, "90d": 90, "all": 365 * 10}
-        days = days_map.get(period, 30)
+        days = PERIOD_DAYS_MAP.get(period, 30)
         start_ts = now - (days * 86400)
 
         # Get games for current period
@@ -744,8 +744,7 @@ class AnalyticsStorage:
         now = int(time.time())
 
         # Calculate period boundaries
-        days_map = {"7d": 7, "30d": 30, "90d": 90, "all": 365 * 10}
-        days = days_map.get(period, 30)
+        days = PERIOD_DAYS_MAP.get(period, 30)
         start_ts = now - (days * 86400)
 
         # Get games for current period


### PR DESCRIPTION
## Summary
- Added a module-level `PERIOD_DAYS_MAP` constant to `analytics.py` to replace 4 identical inline `days_map` dicts
- Each of the 4 stats functions (`compute_error_stats`, `compute_metrics`/`get_player_trends`, `compute_streak_stats`, `compute_bet_stats`) now references the shared constant instead of redeclaring the mapping

Closes #585

## Test plan
- [ ] Verify analytics dashboard stats still render correctly for all period filters (7d, 30d, 90d, all)
- [ ] Confirm no regressions in error stats, player trends, streak stats, and bet stats computations

🤖 Generated with [Claude Code](https://claude.com/claude-code)