### PR TITLE
fix: pre-load playlist display names to avoid blocking I/O

### DIFF
--- a/custom_components/beatify/analytics.py
+++ b/custom_components/beatify/analytics.py
@@ -124,6 +124,11 @@ class AnalyticsStorage:
                 )
                 # Prune old records on startup
                 await self._prune_old_records()
+                # Pre-load playlist display names so later sync
+                # callers don't block the event loop with file I/O
+                await self._hass.async_add_executor_job(
+                    self._get_playlist_display_names
+                )
             else:
                 _LOGGER.debug("No analytics file found, starting fresh")
                 self._data = self._empty_data()


### PR DESCRIPTION
## Summary
- Pre-loads playlist display names cache during the async `load()` method using `async_add_executor_job`, so that later sync callers (`compute_playlist_stats` via `compute_metrics`) hit the in-memory cache instead of performing blocking file I/O (glob + read_text) on the event loop.

Closes #590

## Test plan
- [ ] Verify analytics dashboard still displays playlist stats correctly
- [ ] Confirm no blocking I/O warnings in HA logs during `compute_metrics` calls
- [ ] Test with missing playlist directory (should log debug and return empty)

🤖 Generated with [Claude Code](https://claude.com/claude-code)