### PR TITLE
fix: cache HTML files to avoid disk reads on every request

### DIFF
--- a/custom_components/beatify/server/views.py
+++ b/custom_components/beatify/server/views.py
@@ -64,6 +64,21 @@ def _read_file(path: Path) -> str:
     return path.read_text(encoding="utf-8")
 
 
+_html_cache: dict[str, str] = {}
+
+
+async def _get_html(hass: HomeAssistant, path: Path) -> str | None:
+    """Read HTML file with in-memory caching."""
+    key = str(path)
+    if key in _html_cache:
+        return _html_cache[key]
+    if not path.exists():
+        return None
+    content = await hass.async_add_executor_job(_read_file, path)
+    _html_cache[key] = content
+    return content
+
+
 def _verify_admin_token(request: web.Request, game_state: Any) -> bool:
     """Verify admin token from Authorization header or query param (#386).
 
@@ -98,12 +113,10 @@ class AdminView(HomeAssistantView):
     async def get(self, request: web.Request) -> web.Response:  # noqa: ARG002
         """Serve the admin HTML page."""
         html_path = Path(__file__).parent.parent / "www" / "admin.html"
-
-        if not html_path.exists():
+        html_content = await _get_html(self.hass, html_path)
+        if html_content is None:
             _LOGGER.error("Admin page not found: %s", html_path)
             return web.Response(text="Admin page not found", status=500)
-
-        html_content = await self.hass.async_add_executor_job(_read_file, html_path)
         return web.Response(text=html_content, content_type="text/html")
 
 
@@ -121,12 +134,10 @@ class LauncherView(HomeAssistantView):
     async def get(self, request: web.Request) -> web.Response:  # noqa: ARG002
         """Serve the launcher HTML page."""
         html_path = Path(__file__).parent.parent / "www" / "launcher.html"
-
-        if not html_path.exists():
+        html_content = await _get_html(self.hass, html_path)
+        if html_content is None:
             _LOGGER.error("Launcher page not found: %s", html_path)
             return web.Response(text="Launcher page not found", status=500)
-
-        html_content = await self.hass.async_add_executor_job(_read_file, html_path)
         return web.Response(text=html_content, content_type="text/html")
 
 
@@ -809,12 +820,10 @@ class PlayerView(HomeAssistantView):
     async def get(self, request: web.Request) -> web.Response:  # noqa: ARG002
         """Serve the player HTML page."""
         html_path = Path(__file__).parent.parent / "www" / "player.html"
-
-        if not html_path.exists():
+        html_content = await _get_html(self.hass, html_path)
+        if html_content is None:
             _LOGGER.error("Player page not found: %s", html_path)
             return web.Response(text="Player page not found", status=500)
-
-        html_content = await self.hass.async_add_executor_job(_read_file, html_path)
         return web.Response(text=html_content, content_type="text/html")
 
 
@@ -853,12 +862,10 @@ class DashboardView(HomeAssistantView):
     async def get(self, request: web.Request) -> web.Response:  # noqa: ARG002
         """Serve the dashboard HTML page."""
         html_path = Path(__file__).parent.parent / "www" / "dashboard.html"
-
-        if not html_path.exists():
+        html_content = await _get_html(self.hass, html_path)
+        if html_content is None:
             _LOGGER.error("Dashboard page not found: %s", html_path)
             return web.Response(text="Dashboard page not found", status=500)
-
-        html_content = await self.hass.async_add_executor_job(_read_file, html_path)
         return web.Response(text=html_content, content_type="text/html")
 
 
@@ -1026,10 +1033,10 @@ class AnalyticsPageView(HomeAssistantView):
     async def get(self, request: web.Request) -> web.Response:  # noqa: ARG002
         """Serve analytics page."""
         www_path = Path(__file__).parent.parent / "www" / "analytics.html"
-        if www_path.exists():
-            content = await self.hass.async_add_executor_job(_read_file, www_path)
-            return web.Response(text=content, content_type="text/html")
-        return web.Response(text="Analytics page not found", status=404)
+        content = await _get_html(self.hass, www_path)
+        if content is None:
+            return web.Response(text="Analytics page not found", status=404)
+        return web.Response(text=content, content_type="text/html")
 
 
 class SongStatsView(HomeAssistantView):


### PR DESCRIPTION
## Summary
- Adds a module-level `_html_cache` dict and `_get_html()` async helper in `views.py` that reads each HTML file from disk once, then serves from memory on subsequent requests
- Updates all five HTML-serving views (AdminView, LauncherView, PlayerView, DashboardView, AnalyticsPageView) to use `_get_html()` instead of calling `async_add_executor_job(_read_file, ...)` directly
- Playlist JSON reads are intentionally left uncached since those files can change at runtime

Closes #571

## Test plan
- [ ] Load each page (`/beatify/admin`, `/beatify/launcher`, `/beatify/play`, `/beatify/dashboard`, `/beatify/analytics`) and verify they render correctly
- [ ] Confirm second request is served from cache (no executor job triggered)
- [ ] Verify missing-file error paths still return proper 500/404 responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)