### PR TITLE
fix: close #578 — async playlist name loading already resolved

### DIFF
--- a/custom_components/beatify/analytics.py
+++ b/custom_components/beatify/analytics.py
@@ -440,7 +440,8 @@ class AnalyticsStorage:
         # Calculate percentage relative to total games with playlists
         total = sum(count for _, count in sorted_playlists)
 
-        # Get display names mapping
+        # Get display names mapping (cache-only hit: pre-loaded in load()
+        # via async_add_executor_job, see #578 / #590)
         display_names = self._get_playlist_display_names()
 
         return [


### PR DESCRIPTION
## Summary

- Issue #578 reported synchronous file I/O in `_get_playlist_display_names` blocking the event loop during API requests.
- This was already fixed by the work for #590 (PR #611): the `load()` method now calls `await self._hass.async_add_executor_job(self._get_playlist_display_names)` to pre-populate the cache at startup.
- The only other call site (`compute_playlist_stats`, line 444) hits the in-memory cache and performs zero file I/O.
- This PR adds a clarifying comment at the sync call site documenting the cache-only assumption.

Closes #578

## Test plan

- [x] Verified `load()` pre-loads display names via `async_add_executor_job` (line 131-135)
- [x] Verified `_get_playlist_display_names` returns cached dict when `_playlist_display_names is not None` (line 390-391)
- [x] Confirmed no other sync call sites exist in the codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)