### PR TITLE
fix: skip double state broadcast on player guess submission

### DIFF
--- a/custom_components/beatify/server/ws_handlers.py
+++ b/custom_components/beatify/server/ws_handlers.py
@@ -744,7 +744,12 @@ async def handle_submit(
         }
     )
 
-    await handler.broadcast_state()
+    # Issue #581: Only broadcast here when NOT all guesses are complete.
+    # If all guesses are in, trigger_early_reveal_if_complete() will
+    # transition to REVEAL and broadcast via the round_end callback,
+    # avoiding a redundant double broadcast.
+    if not game_state.check_all_guesses_complete():
+        await handler.broadcast_state()
 
     _LOGGER.debug(
         "Early reveal check: phase=%s, artist_challenge=%s",


### PR DESCRIPTION
## Summary
- When the last player submits a guess, `handle_submit` was calling `broadcast_state()` immediately after the submit ack, then `trigger_early_reveal_if_complete()` would transition to REVEAL and broadcast again via the `round_end` callback — two broadcasts in quick succession.
- The fix guards the post-ack broadcast with `check_all_guesses_complete()`: if all guesses are in, the broadcast is skipped because the early reveal path handles its own broadcast.
- When not all guesses are complete (the common case), the broadcast still fires normally to update other players' UIs.

Closes #581

## Test plan
- [ ] Single player game: submit guess, verify only one state broadcast occurs (early reveal path)
- [ ] Multi-player game with partial submissions: verify intermediate broadcasts still fire after each non-final submission
- [ ] Multi-player game where last player submits: verify no double broadcast (check browser network tab or server logs)
- [ ] Artist challenge active: verify early reveal still triggers correctly when all year + artist guesses are complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)