### PR TITLE
security: add .env to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,10 @@ docs/
 # ---- Duplicate deployed copy ----
 beatify/
 
+# ---- Secrets ----
+.env
+*.env.local
+
 # ---- Config & tooling ----
 pyproject.toml
 package-lock.json


### PR DESCRIPTION
## Summary
- Adds `.env` and `*.env.local` to `.gitignore` to prevent accidental commit of API keys and tokens
- The `.env` file was never committed to git history — this is a preventive measure

Closes #628

🤖 Generated with [Claude Code](https://claude.com/claude-code)