### PR TITLE
data: remove Simon & Garfunkel entry with unresolvable YouTube Music URI (#649)

### DIFF
--- a/custom_components/beatify/playlists/greatest-hits-of-all-time.json
+++ b/custom_components/beatify/playlists/greatest-hits-of-all-time.json
@@ -1,6 +1,6 @@
 {
   "name": "Greatest Hits of All Time",
-  "version": "2.5",
+  "version": "2.6",
   "tags": [
     "classics",
     "top-hits",
@@ -2938,46 +2938,6 @@
       "uri_deezer": "deezer://track/116348340",
       "fun_fact_nl": "Twist and Shout werd als laatste opgenomen tijdens de eerste marathonsessie van The Beatles. De stem van John Lennon was bijna weg, waardoor het nummer zijn rauwe, schorre kwaliteit kreeg. Het nummer was eigenlijk een cover, oorspronkelijk opgenomen door de Top Notes. De versie van The Beatles werd definitief en iconisch.",
       "awards_nl": []
-    },
-    {
-      "year": 1964,
-      "uri": "spotify:track:5y788ya4NvwhBznoDIcXwK",
-      "artist": "Simon & Garfunkel",
-      "alt_artists": [
-        "Peter, Paul and Mary",
-        "The Byrds"
-      ],
-      "title": "The Sound of Silence",
-      "chart_info": {
-        "billboard_peak": 1,
-        "weeks_on_chart": 14
-      },
-      "certifications": [
-        "Gold (US)"
-      ],
-      "awards": [
-        "Grammy Hall of Fame (1999)"
-      ],
-      "fun_fact": "The Sound of Silence was originally a flop until a producer added electric instruments without Simon & Garfunkel's knowledge. The duo had broken up by then. When the remixed version became a hit, they reunited and launched one of music's most celebrated partnerships. Truly a tale of serendipity.",
-      "fun_fact_de": "The Sound of Silence war ursprünglich ein Flop, bis ein Produzent ohne Wissen von Simon & Garfunkel elektrische Instrumente hinzufügte. Das Duo hatte sich da bereits getrennt. Als die remixte Version ein Hit wurde, vereinten sie sich wieder und starteten eine der gefeiertsten Partnerschaften der Musik. Wahrhaft eine Geschichte glücklicher Zufälle.",
-      "fun_fact_es": "The Sound of Silence fue originalmente un fracaso hasta que un productor añadió instrumentos eléctricos sin el conocimiento de Simon & Garfunkel. El dúo se había separado para entonces. Cuando la versión remezclada se convirtió en un éxito, se reunieron y lanzaron una de las asociaciones más celebradas de la música. Verdaderamente una historia de serendipia.",
-      "fun_fact_fr": "The Sound of Silence a d'abord été un flop, jusqu'à ce qu'un producteur ajoute des instruments électriques à l'insu de Simon & Garfunkel. Le duo s'était alors séparé. Quand la version remixée est devenue un succès, ils se sont retrouvés et ont lancé l'un des partenariats les plus célébrés de la musique. Un vrai coup du destin.",
-      "awards_de": [
-        "Grammy Hall of Fame (1999)"
-      ],
-      "awards_es": [
-        "Salón de la Fama del Grammy (1999)"
-      ],
-      "awards_fr": [
-        "Grammy Hall of Fame (1999)"
-      ],
-      "uri_youtube_music": "https://music.youtube.com/watch?v=WhIGtXeB9aQ",
-      "uri_tidal": "tidal://track/37667969",
-      "uri_deezer": "deezer://track/2468570",
-      "fun_fact_nl": "The Sound of Silence was aanvankelijk een flop totdat een producer elektrische instrumenten toevoegde zonder medeweten van Simon & Garfunkel. Het duo was toen al uit elkaar. Toen de geremixte versie een hit werd, kwamen ze weer bij elkaar en lanceerden ze een van de meest gevierde partnerschappen in de muziek. Echt een verhaal van serendipiteit.",
-      "awards_nl": [
-        "Grammy Hall of Fame (1999)"
-      ]
     },
     {
       "year": 1989,


### PR DESCRIPTION
Closes #649 (follow-up to #650).

Removes **Simon & Garfunkel — The Sound of Silence** from `greatest-hits-of-all-time.json` because the YouTube Music URI (`WhIGtXeB9aQ`) points to a "vocals only" fan rip and no correct replacement could be found. Per the health-check policy: songs with unresolvable broken URIs are removed from the playlist.

Version bumped: 2.5 → 2.6