### PR TITLE
data: fix 7 broken URIs in koelner-karneval (#655)

### DIFF
--- a/custom_components/beatify/playlists/koelner-karneval.json
+++ b/custom_components/beatify/playlists/koelner-karneval.json
@@ -1,6 +1,6 @@
 {
   "name": "Cologne Carnival 🎭",
-  "version": "1.4",
+  "version": "1.5",
   "tags": [
     "german",
     "carnival",
@@ -102,7 +102,7 @@
       "chart_info": {
         "german_peak": 32
       },
-      "uri_apple_music": "applemusic://track/713042287",
+      "uri_apple_music": "applemusic://track/713842529",
       "uri_tidal": "tidal://track/11203285",
       "uri_deezer": "deezer://track/3155953",
       "fun_fact_nl": "Een van de vroegste hits van de Höhner uit 1971, opnieuw opgenomen in 1997 - de titel 'Ik ben een rover' speelt in op de speelse Keulse dialecthumor.",
@@ -282,7 +282,7 @@
       "chart_info": {
         "german_peak": 8
       },
-      "uri_apple_music": "applemusic://track/1597794427",
+      "uri_apple_music": "applemusic://track/724021418",
       "uri_tidal": "tidal://track/11203214",
       "uri_deezer": "deezer://track/3154486",
       "fun_fact_nl": "Echte Fründe (Echte vrienden) is een van de meest emotionele nummers van de Höhner over ware vriendschap en wordt tijdens carnaval vaak arm in arm gezongen.",
@@ -1255,7 +1255,7 @@
       "fun_fact_fr": "Une chanson nostalgique sur « Ma première petite amie » - les Bläck Fööss allient souvent la fête carnavalesque à des souvenirs personnels touchants.",
       "certifications": [],
       "awards": [],
-      "uri_youtube_music": "https://music.youtube.com/watch?v=tS7Id7YQ1eE",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=1fLNKbiHUac",
       "uri_apple_music": "applemusic://track/713451419",
       "chart_info": {
         "weeks_on_chart": null
@@ -1629,7 +1629,7 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=pMB4xoIB3OI",
-      "uri_apple_music": "applemusic://track/1384483878",
+      "uri_apple_music": "applemusic://track/1766474419",
       "chart_info": {
         "weeks_on_chart": null
       },
@@ -4192,7 +4192,7 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=AOjcKFapP1U",
-      "uri_apple_music": "applemusic://track/1444428549",
+      "uri_apple_music": "applemusic://track/1593095661",
       "chart_info": {
         "weeks_on_chart": null
       },
@@ -7214,13 +7214,12 @@
         "weeks_on_chart": null
       },
       "uri_tidal": "tidal://track/482962193",
-      "uri_deezer": "deezer://track/3864013291",
       "fun_fact_nl": "Keulen aan de Rijn - deze uitgave uit 2025 viert de ligging van de stad aan de beroemde rivier die haar identiteit bepaalt.",
       "awards_nl": []
     },
     {
       "year": 2025,
-      "uri": "spotify:track:4wElx6LCIYwzXMNPNlKUpM",
+      "uri": "spotify:track:4G0RhLOkClQkMpYvGe9Pos",
       "artist": "Mätropolis",
       "alt_artists": [
         "Kasalla",


### PR DESCRIPTION
Closes #655.

## Changes

Fixed 7 confirmed broken/wrong URIs in `koelner-karneval.json` and bumped version to 1.5.

| # | Artist | Title | Provider | Change |
|---|--------|-------|----------|--------|
| 1 | Höhner | Ich ben ne Räuber - Remake '97 | Apple Music | Updated ID: 713042287 → 713842529 |
| 2 | Höhner | Echte Fründe - Remake '97 | Apple Music | Updated ID: 1597794427 → 724021418 |
| 3 | Höhner | Jetzt geht's los - Jahrmarkt-Mix | Apple Music | Updated ID: 1384483878 → 1766474419 |
| 4 | Querbeat | Guten Morgen Barbarossaplatz | Apple Music | Updated ID: 1444428549 → 1593095661 |
| 5 | Bläck Fööss | Ming eetste Fründin | YouTube Music | Updated dead video ID → 1fLNKbiHUac |
| 6 | Marc Eggers | KÖLLE AM RHING | Deezer | Removed URI — pointed to wrong song ("Malle-Entzug"), not on Deezer |
| 7 | Mätropolis | Rakete | Spotify | Replaced DJ Aaron RMX → original track (4G0RhLOkClQkMpYvGe9Pos) |

## Note on remaining Apple Music flags

The health checker flagged 87 additional Apple Music URIs as dead. Investigation showed these tracks are available in the **German iTunes catalog** but not in the US catalog (which the health checker's `lookup` endpoint uses by default). Since `koelner-karneval` targets German users, these URIs work correctly for the intended audience and were left unchanged.

The underlying health checker limitation (US-only iTunes lookup) is a separate issue to address.