### PR TITLE
data: fix 2 broken URIs in motown-soul-classics (#657)

### DIFF
--- a/custom_components/beatify/playlists/motown-soul-classics.json
+++ b/custom_components/beatify/playlists/motown-soul-classics.json
@@ -1,6 +1,6 @@
 {
   "name": "Motown & Soul Classics",
-  "version": "1.4",
+  "version": "1.5",
   "tags": [
     "1960s",
     "1970s",
@@ -624,7 +624,7 @@
       "fun_fact_es": "Una de las primeras grabaciones de Motown y el primer éxito nacional del sello. Co-escrita por el propio Berry Gordy. Los Beatles la versionaron, ayudando a difundir la influencia de Motown en el Reino Unido.",
       "fun_fact_fr": "L'un des tout premiers enregistrements Motown et le premier succès national du label. Co-écrite par Berry Gordy lui-même. Les Beatles l'ont reprise, contribuant à répandre l'influence de Motown au Royaume-Uni.",
       "uri_apple_music": "applemusic://track/1475817481",
-      "uri_youtube_music": "https://music.youtube.com/watch?v=yeVx1C73o8k",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=aWfOfMmPogs",
       "uri_tidal": "tidal://track/2410459",
       "uri_deezer": "deezer://track/2511253",
       "fun_fact_nl": "Een van de allereerste Motown-opnamen en de eerste nationale hit van het label. Mede geschreven door Berry Gordy zelf. The Beatles hebben het gecoverd en zo de invloed van Motown in Groot-Brittannië verspreid.",
@@ -1125,7 +1125,7 @@
       "fun_fact_de": "Der größte Hit der Miracles, aber er kam erst nach Smokey Robinsons Abgang. Billy Griffin übernahm als Leadsänger und brachte einen moderneren Funk-Disco-Sound in die Gruppe.",
       "fun_fact_es": "El mayor éxito de The Miracles, pero llegó después de que Smokey Robinson dejara el grupo. Billy Griffin asumió como vocalista y trajo un sonido funk-disco más moderno al grupo.",
       "fun_fact_fr": "Le plus grand succès des Miracles, mais il est arrivé après le départ de Smokey Robinson. Billy Griffin a pris la relève en tant que chanteur principal et a apporté un son funk-disco plus moderne au groupe.",
-      "uri_apple_music": "applemusic://track/1486425650",
+      "uri_apple_music": "applemusic://track/1464881886",
       "uri_youtube_music": "https://music.youtube.com/watch?v=hNAZxdyQFEY",
       "uri_deezer": "deezer://track/549326392",
       "fun_fact_nl": "De grootste hit van The Miracles, maar hij kwam nadat Smokey Robinson de groep had verlaten. Billy Griffin nam het over als leadzanger en bracht een moderner funk-disco geluid naar de groep.",


### PR DESCRIPTION
Closes #657. Replaced 2 dead URIs and bumped playlist version to 1.5.

**Changes:**
- Barrett Strong - Money (That's What I Want): replaced dead YouTube Music URI `yeVx1C73o8k` → `aWfOfMmPogs` (Barrett Strong - Topic, official)
- The Miracles - Love Machine: replaced dead Apple Music track `1486425650` → `1464881886` (Love Machine Pt. 1, 1975)
- Version bump: 1.4 → 1.5

20 `wrong_track` flags reviewed and dismissed as false positives (Single Version/Mono suffixes, Pt. 1 part labels, Radio Version edit tags, YouTube titles with extra metadata).