### PR TITLE
fix: 7 game logic bugs — scoring, steal, intro, winner ties

### DIFF
--- a/custom_components/beatify/game/powerups.py
+++ b/custom_components/beatify/game/powerups.py
@@ -6,6 +6,7 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 from custom_components.beatify.const import (
+    ERR_ALREADY_SUBMITTED,
     ERR_CANNOT_STEAL_SELF,
     ERR_INVALID_ACTION,
     ERR_NO_STEAL_AVAILABLE,
@@ -89,6 +90,9 @@ class PowerUpManager:
         # Validations
         if not stealer:
             return {"success": False, "error": ERR_NOT_IN_GAME}
+
+        if stealer.submitted:
+            return {"success": False, "error": ERR_ALREADY_SUBMITTED}
 
         if not stealer.steal_available:
             return {"success": False, "error": ERR_NO_STEAL_AVAILABLE}

--- a/custom_components/beatify/game/round_manager.py
+++ b/custom_components/beatify/game/round_manager.py
@@ -67,6 +67,7 @@ class RoundManager:
         # Timer tasks
         self._timer_task: asyncio.Task | None = None
         self._intro_stop_task: asyncio.Task | None = None
+        self._metadata_task: asyncio.Task | None = None
 
         # Intro mode
         self.intro_mode_enabled: bool = False
@@ -86,6 +87,7 @@ class RoundManager:
         """Reset all round state for a new game / end-game."""
         self.cancel_timer()
         self._cancel_intro_timer()
+        self._cancel_metadata_task()
 
         self.round = 0
         self.total_rounds = 0
@@ -123,6 +125,21 @@ class RoundManager:
             self._intro_stop_task.cancel()
             self._intro_stop_task = None
 
+    def _cancel_metadata_task(self) -> None:
+        """Cancel the background metadata task if running."""
+        if self._metadata_task is not None:
+            self._metadata_task.cancel()
+            self._metadata_task = None
+
+    @staticmethod
+    def _on_metadata_task_done(task: asyncio.Task) -> None:
+        """Log unhandled exceptions from background metadata fetch."""
+        if task.cancelled():
+            return
+        exc = task.exception()
+        if exc is not None:
+            _LOGGER.error("Background metadata fetch failed: %s", exc)
+
     def is_deadline_passed(self) -> bool:
         """Return True if the round deadline has passed."""
         if self.deadline is None:
@@ -153,6 +170,8 @@ class RoundManager:
             await asyncio.sleep(remaining_seconds)
             self.intro_stopped = True
             _LOGGER.info("Intro auto-stopped after %.1fs", remaining_seconds)
+            if on_round_end:
+                await on_round_end()
         except asyncio.CancelledError:
             _LOGGER.debug("Intro auto-stop cancelled")
             raise
@@ -301,9 +320,11 @@ class RoundManager:
                 )
 
         # Start background metadata fetch
+        self._cancel_metadata_task()
         metadata_coro = metadata.get("metadata_coro")
         if metadata_coro is not None:
-            asyncio.create_task(metadata_coro)
+            self._metadata_task = asyncio.create_task(metadata_coro)
+            self._metadata_task.add_done_callback(self._on_metadata_task_done)
 
     # ------------------------------------------------------------------
     # Intro splash confirmation

--- a/custom_components/beatify/game/scoring.py
+++ b/custom_components/beatify/game/scoring.py
@@ -441,7 +441,7 @@ class ScoringService:
         *before* the round scores are appended to cumulative totals (they are
         already added in score_player_round, so we need to undo the difference).
         """
-        submitted = [p for p in players if p.submitted]
+        submitted = [p for p in players if p.submitted and p.current_guess is not None]
         if not submitted:
             return
 
@@ -463,6 +463,8 @@ class ScoringService:
                 # and undo the milestone bonus that was already added.
                 p.score -= p.streak_bonus
                 p.streak_bonus = 0
+                p.score -= p.intro_bonus
+                p.intro_bonus = 0
                 p.previous_streak = p.streak
                 p.streak = 0
 

--- a/custom_components/beatify/game/serializers.py
+++ b/custom_components/beatify/game/serializers.py
@@ -177,10 +177,15 @@ class GameStateSerializer:
             "total_rounds": gs.round,
             "total_players": len(gs.players),
         }
-        # Include winner info
+        # Include winner info — detect ties
         if gs.players:
-            winner = max(gs.players.values(), key=lambda p: p.score)
-            state["winner"] = {"name": winner.name, "score": winner.score}
+            top_score = max(p.score for p in gs.players.values())
+            winners = [p for p in gs.players.values() if p.score == top_score]
+            state["winner"] = {
+                "name": ", ".join(w.name for w in winners),
+                "score": top_score,
+                "is_tie": len(winners) > 1,
+            }
         # Game performance comparison for end screen (Story 14.4 AC5, AC6)
         game_performance = gs.get_game_performance()
         if game_performance:

--- a/custom_components/beatify/game/state.py
+++ b/custom_components/beatify/game/state.py
@@ -607,13 +607,17 @@ class GameState:
         player_count = len(self.players)
         rounds_played = self.round
 
-        # Determine winner
+        # Determine winner(s) — detect ties
         winner_name = "Unknown"
         winner_score = 0
         if self.players:
-            winner = max(self.players.values(), key=lambda p: p.score)
-            winner_name = winner.name
-            winner_score = winner.score
+            top_score = max(p.score for p in self.players.values())
+            winners = [p for p in self.players.values() if p.score == top_score]
+            winner_score = top_score
+            if len(winners) == 1:
+                winner_name = winners[0].name
+            else:
+                winner_name = ", ".join(w.name for w in winners)
 
         # Calculate average score per round
         avg_score_per_round = 0.0
@@ -1846,10 +1850,18 @@ class GameState:
         """Announce the winner (use case 18)."""
         if not self._tts_service or not self._tts_announce_winner or not self.players:
             return
-        winner = max(self.players.values(), key=lambda p: p.score)
-        message = (
-            f"And the winner is... {winner.name} with {winner.score} points!"
-        )
+        top_score = max(p.score for p in self.players.values())
+        winners = [p for p in self.players.values() if p.score == top_score]
+        if len(winners) == 1:
+            message = (
+                f"And the winner is... {winners[0].name} "
+                f"with {top_score} points!"
+            )
+        else:
+            names = " and ".join(w.name for w in winners)
+            message = (
+                f"It's a tie between {names} with {top_score} points!"
+            )
         await self._tts_announce(message)
 
     def adjust_volume(self, direction: str) -> float:

--- a/custom_components/beatify/server/ws_handlers.py
+++ b/custom_components/beatify/server/ws_handlers.py
@@ -1035,7 +1035,9 @@ async def handle_steal(
                 "year": result["year"],
             }
         )
-        await handler.broadcast_state()
+        if not game_state.check_all_guesses_complete():
+            await handler.broadcast_state()
+        await game_state.trigger_early_reveal_if_complete()
     else:
         await ws.send_json(
             {


### PR DESCRIPTION
## Summary

Fixes 7 game logic bugs across scoring, powerups, round management, and winner determination:

- **#666** (HIGH): Guard `apply_closest_wins` against `None` `current_guess` — prevents `TypeError` crash
- **#674** (HIGH): Broadcast state after intro auto-stop so clients learn intro phase ended
- **#675**: Block steal if player already submitted — prevents guess overwrite exploit
- **#676**: Subtract `intro_bonus` for non-closest players in Closest Wins mode
- **#677**: Trigger early reveal after steal when all players have submitted
- **#671**: Track background metadata task with done callback, cancel on reset
- **#678**: Recognize all co-winners on END screen, TTS announcement, and game stats

## Test plan

- [ ] Verify Closest Wins mode doesn't crash when a submitted player has `current_guess = None` (steal race condition)
- [ ] Verify intro auto-stop broadcasts state immediately (no stale "INTRO ROUND" badge)
- [ ] Verify steal is blocked after a player has already submitted a guess
- [ ] Verify `intro_bonus` is zeroed for non-closest players in Closest Wins + Intro Mode
- [ ] Verify steal as last submission triggers early reveal without waiting for timer
- [ ] Verify no unhandled exception warnings from background metadata tasks
- [ ] Verify tied winners are both shown on END screen and TTS says "It's a tie"

https://claude.ai/code/session_018KWXt2LBn8Y8ha4aWvjrui