### PR TITLE
fix: credential false-positive & dead monthly summarization

### DIFF
--- a/custom_components/beatify/analytics.py
+++ b/custom_components/beatify/analytics.py
@@ -249,11 +249,6 @@ class AnalyticsStorage:
 
         games = self._data["games"]
 
-        # Age-based retention: remove records older than 90 days regardless of count
-        cutoff_ts = time.time() - (90 * 86400)  # 90 days
-        games = [g for g in games if g.get("ended_at", 0) > cutoff_ts]
-        self._data["games"] = games
-
         if len(games) <= MAX_DETAILED_RECORDS:
             return
 

--- a/custom_components/beatify/services/spotify_import.py
+++ b/custom_components/beatify/services/spotify_import.py
@@ -196,11 +196,11 @@ async def async_save_credentials(
     await store.async_save({"client_id": client_id, "client_secret": client_secret})
 
 
-async def async_load_credentials(hass: HomeAssistant) -> dict[str, str]:
+async def async_load_credentials(hass: HomeAssistant) -> dict[str, str] | None:
     """Load Spotify credentials from HA storage."""
     store = _get_store(hass)
     data = await store.async_load()
-    return data if data else {}
+    return data if data else None
 
 
 async def async_import_playlist(


### PR DESCRIPTION
## Summary
- **#669**: `async_load_credentials` now returns `None` instead of `{}` when no credentials exist, so the `creds is not None` check correctly reports unconfigured status
- **#667**: Removed duplicate age-based filter in `_prune_old_records` that wiped `old_games` before monthly summarization could ever run

## Test plan
- [ ] Verify Spotify credentials page shows "not configured" when no credentials are saved
- [ ] Verify monthly summaries are created when game records exceed MAX_DETAILED_RECORDS and are older than 90 days

https://claude.ai/code/session_01FUpsjsGPt4iKUyaDpahdtZ