### PR TITLE
fix: 22 playlist bugs — security, I/O, validation, perf, UX (#688–#717)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,40 @@
 
 All notable changes to Beatify are documented here. For detailed release notes, see the individual files in `docs/` or the [Releases page](https://github.com/mholzi/beatify/releases).
 
+## [Unreleased]
+
+### Security / hardening
+- Rate limiting on Spotify credential, import, and search endpoints (#712)
+- Input length limits on credential, import, search, and edit endpoints (#703)
+- Credential-scrubbed error responses — no base64 `Authorization` echoes (#690)
+- Removed server-side filesystem path from import response (#704)
+
+### Fixed
+- Tightened Spotify URL parsing — hostname validation + exact 22-char ID match (#699, #711)
+- Tolerant year parsing — malformed `release_date` no longer crashes imports (#700)
+- `MAX_YEAR` is now dynamic (current year + 1); was hardcoded to 2030 (#706)
+- `validate_playlist()` now checks for missing title / artist fields (#697)
+- Playlist file writes are atomic (tempfile + rename) (#696, applies to import and editor)
+- Duplicate-name detection on import; admin is prompted to overwrite (#695)
+- Disk-full / permission errors return friendly messages instead of opaque 500 (#710)
+- `async_ensure_playlist_directory` no longer runs blocking I/O on the event loop (#717)
+- Discovery counts validate URI pattern — no more inflated provider counts (#708)
+- Empty playlists excluded from discovery (#716)
+- `get_remaining_count()` clamped at 0 (was returning negative values) (#707)
+- Zero-playable-song combinations now fail fast with a clear error (#709)
+- Odesli 429 rate-limits logged at WARNING instead of silently swallowed (#694)
+- Imported tracks now carry both `uri` (legacy) and `uri_spotify` (canonical) (#705)
+
+### Performance
+- Spotify client-credentials tokens are cached for their lifetime (#691)
+
+### UX
+- Playlist import now shows in-flight progress updates (#714)
+
+### Notes
+- #688 reported a critical ImportError from deleted `URI_PATTERN_*` constants; verified not reproducible — the constants still exist in `const.py` and the referenced PR #687 is not in `git log`. No code change needed.
+- #689 (`requires_auth = True` on admin endpoints) intentionally not applied — the "Frictionless access per PRD" policy stands. Rate limiting, input length limits, and credential scrubbing reduce the remaining attack surface.
+
 ## [2.7.0] - 2026-03-01
 
 ### Added

--- a/custom_components/beatify/game/playlist.py
+++ b/custom_components/beatify/game/playlist.py
@@ -145,10 +145,16 @@ class PlaylistManager:
         """Get count of unplayed songs.
 
         Returns:
-            Number of songs not yet played
+            Number of songs not yet played (clamped to 0 for robustness, #707)
 
         """
-        return len(self._songs) - len(self._played_uris)
+        # #707: mark_played() accepts any URI (incl. unknown ones), so naive
+        # subtraction can go negative. Clamp at 0.
+        return max(0, len(self._songs) - len(self._played_uris))
+
+    def has_playable_songs(self) -> bool:
+        """True if this manager has any songs for its provider (#709)."""
+        return len(self._songs) > 0
 
     def get_total_count(self) -> int:
         """Get total song count.
@@ -162,7 +168,16 @@ class PlaylistManager:
 
 # Validation constants
 MIN_YEAR = 1900
-MAX_YEAR = 2030
+
+
+def _max_year() -> int:
+    """Dynamic upper bound — current year + 1 (#706).
+
+    The previous hardcoded 2030 would silently reject newer songs.
+    """
+    from datetime import datetime, timezone
+
+    return datetime.now(timezone.utc).year + 1
 
 
 def get_playlist_directory(hass: HomeAssistant) -> Path:
@@ -171,11 +186,21 @@ def get_playlist_directory(hass: HomeAssistant) -> Path:
 
 
 async def async_ensure_playlist_directory(hass: HomeAssistant) -> Path:
-    """Ensure playlist directory exists, create if missing."""
+    """Ensure playlist directory exists, create if missing.
+
+    #717: `exists()` and `mkdir()` are blocking syscalls — run in executor.
+    """
     playlist_dir = get_playlist_directory(hass)
 
-    if not playlist_dir.exists():
+    def _ensure() -> bool:
+        """Return True if we created the directory."""
+        if playlist_dir.exists():
+            return False
         playlist_dir.mkdir(parents=True, exist_ok=True)
+        return True
+
+    created = await hass.async_add_executor_job(_ensure)
+    if created:
         _LOGGER.info("Created playlist directory: %s", playlist_dir)
 
     # Copy bundled playlists if they don't exist in destination
@@ -274,6 +299,7 @@ async def _copy_bundled_playlists(dest_dir: Path) -> None:
 def validate_playlist(data: dict[str, Any]) -> tuple[bool, list[str]]:
     """Validate playlist structure. Returns (is_valid, list_of_errors)."""
     errors: list[str] = []
+    max_year = _max_year()
 
     # Check required top-level fields
     if not isinstance(data.get("name"), str) or not data["name"].strip():
@@ -293,11 +319,19 @@ def validate_playlist(data: dict[str, Any]) -> tuple[bool, list[str]]:
             errors.append(f"Song {i + 1}: not a valid object")
             continue
 
+        # #697: title and artist are required for gameplay (challenge + reveal).
+        title = song.get("title")
+        if not isinstance(title, str) or not title.strip():
+            errors.append(f"Song {i + 1}: missing or empty 'title'")
+        artist = song.get("artist")
+        if not isinstance(artist, str) or not artist.strip():
+            errors.append(f"Song {i + 1}: missing or empty 'artist'")
+
         # Check year
         year = song.get("year")
         if not isinstance(year, int):
             errors.append(f"Song {i + 1}: missing or invalid 'year' (must be integer)")
-        elif not (MIN_YEAR <= year <= MAX_YEAR):
+        elif not (MIN_YEAR <= year <= max_year):
             errors.append(f"Song {i + 1}: year {year} out of range")
 
         # Check URIs - validate patterns and ensure at least one valid URI exists
@@ -425,15 +459,38 @@ async def async_discover_playlists(hass: HomeAssistant) -> list[dict]:
             data = json.loads(content)
             is_valid, errors = validate_playlist(data)
 
-            # Count songs per provider (Story 17.1)
+            # Count songs per provider (Story 17.1), validating URI patterns (#708).
             songs = data.get("songs", [])
+
+            def _count(field: str, pattern: str) -> int:
+                n = 0
+                for s in songs:
+                    v = s.get(field)
+                    if isinstance(v, str) and v and re.match(pattern, v):
+                        n += 1
+                return n
+
             spotify_count = sum(
-                1 for s in songs if s.get("uri") or s.get("uri_spotify")
+                1
+                for s in songs
+                if (
+                    (isinstance(s.get("uri_spotify"), str)
+                     and re.match(URI_PATTERN_SPOTIFY, s["uri_spotify"]))
+                    or (isinstance(s.get("uri"), str)
+                        and re.match(URI_PATTERN_SPOTIFY, s["uri"]))
+                )
             )
-            apple_music_count = sum(1 for s in songs if s.get("uri_apple_music"))
-            youtube_music_count = sum(1 for s in songs if s.get("uri_youtube_music"))
-            tidal_count = sum(1 for s in songs if s.get("uri_tidal"))
-            deezer_count = sum(1 for s in songs if s.get("uri_deezer"))
+            apple_music_count = _count("uri_apple_music", URI_PATTERN_APPLE_MUSIC)
+            youtube_music_count = _count("uri_youtube_music", URI_PATTERN_YOUTUBE_MUSIC)
+            tidal_count = _count("uri_tidal", URI_PATTERN_TIDAL)
+            deezer_count = _count("uri_deezer", URI_PATTERN_DEEZER)
+
+            # #716: skip playlists with no songs entirely — they only confuse the UI.
+            if not is_valid and len(songs) == 0:
+                _LOGGER.debug(
+                    "Skipping empty playlist from discovery: %s", json_file.name
+                )
+                continue
 
             playlists.append(
                 {

--- a/custom_components/beatify/game/state.py
+++ b/custom_components/beatify/game/state.py
@@ -512,9 +512,17 @@ class GameState:
         # Initialize PlaylistManager for song selection (Epic 4, Story 17.2: with provider)
         self._playlist_manager = PlaylistManager(songs, provider)
 
+        # #709: if the chosen provider has zero playable songs, fail fast with
+        # a clear error rather than silently starting a game that will stall.
+        if not self._playlist_manager.has_playable_songs():
+            raise ValueError(
+                f"No playable songs for provider '{provider}' in the selected "
+                f"playlist(s). Pick a different playlist or provider."
+            )
+
         # Reset round tracking for new game
         self.round = 0
-        self.total_rounds = len(songs)
+        self.total_rounds = self._playlist_manager.get_total_count()
         self.deadline = None
         self.current_song = None
         self.last_round = False

--- a/custom_components/beatify/server/playlist_views.py
+++ b/custom_components/beatify/server/playlist_views.py
@@ -21,6 +21,27 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
+# #703: input length limits on credential / import endpoints.
+_MAX_CLIENT_ID_LEN = 128
+_MAX_CLIENT_SECRET_LEN = 256
+_MAX_URL_LEN = 2048
+_MAX_NAME_LEN = 200
+_MAX_FILE_LEN = 300
+_MAX_QUERY_LEN = 200
+
+
+def _sanitize_error(message: str) -> str:
+    """Strip anything that looks like a credential from an error message (#690).
+
+    Token-validation errors can echo back Authorization headers or
+    base64-encoded client_id:client_secret pairs.
+    """
+    import re as _re
+    cleaned = _re.sub(r"[A-Za-z0-9+/=]{40,}", "<redacted>", message)
+    cleaned = _re.sub(r"(?i)authorization[^\s]*", "<redacted>", cleaned)
+    cleaned = _re.sub(r"(?i)bearer\s+\S+", "Bearer <redacted>", cleaned)
+    return cleaned
+
 
 class PlaylistRequestsView(RateLimitMixin, HomeAssistantView):
     """API for managing playlist requests (Story 44).
@@ -123,19 +144,48 @@ class PlaylistRequestsView(RateLimitMixin, HomeAssistantView):
         return web.json_response({"success": True, "requests": data["requests"]})
 
 
-class SpotifyCredentialsView(HomeAssistantView):
-    """Save/validate Spotify API credentials (#165)."""
+# -- In-process import progress tracker (#714) ------------------------------
+# Stored on hass.data under DOMAIN. Not persisted — good enough for a single
+# HA session. Entries: {url: {"status": "...", "pct": int, "message": str}}
+_PROGRESS_KEY = "beatify.playlist_import_progress"
+
+
+def _set_progress(hass: HomeAssistant, key: str, **fields: object) -> None:
+    bucket = hass.data.setdefault(_PROGRESS_KEY, {})
+    entry = bucket.setdefault(key, {})
+    entry.update(fields)
+
+
+def _get_progress(hass: HomeAssistant, key: str) -> dict | None:
+    return hass.data.get(_PROGRESS_KEY, {}).get(key)
+
+
+class SpotifyCredentialsView(RateLimitMixin, HomeAssistantView):
+    """Save/validate Spotify API credentials (#165).
+
+    Rate-limited (#712), input-length-limited (#703), credential-scrubbed
+    error responses (#690). #689 (requires_auth) intentionally left False
+    per the "Frictionless access per PRD" policy.
+    """
 
     url = "/beatify/api/spotify-credentials"
     name = "beatify:api:spotify-credentials"
     requires_auth = False
 
+    RATE_LIMIT_REQUESTS = 5
+    RATE_LIMIT_WINDOW = 60
+
     def __init__(self, hass: HomeAssistant) -> None:
         """Initialize view."""
         self.hass = hass
+        self._init_rate_limits()
 
     async def post(self, request: web.Request) -> web.Response:
         """Save and validate Spotify credentials."""
+        # #712: rate-limit credential submissions.
+        if not self._check_rate_limit(request.remote or "unknown"):
+            return _json_error("Too many requests", 429, code="RATE_LIMITED")
+
         from custom_components.beatify.services.spotify_import import (  # noqa: PLC0415
             async_fetch_spotify_token,
             async_save_credentials,
@@ -152,6 +202,14 @@ class SpotifyCredentialsView(HomeAssistantView):
             return web.json_response(
                 {"error": "client_id and client_secret required"}, status=400
             )
+        # #703: reject oversize inputs.
+        if (
+            len(client_id) > _MAX_CLIENT_ID_LEN
+            or len(client_secret) > _MAX_CLIENT_SECRET_LEN
+        ):
+            return web.json_response(
+                {"error": "Credential fields too long"}, status=413
+            )
 
         # Validate by attempting to fetch a token
         import aiohttp  # noqa: PLC0415
@@ -164,9 +222,20 @@ class SpotifyCredentialsView(HomeAssistantView):
                         {"error": "Invalid credentials — Spotify rejected the token request"},
                         status=401,
                     )
-        except Exception as err:  # noqa: BLE001
+        except aiohttp.ClientResponseError as err:
+            # #690: log full detail server-side, return generic message.
+            _LOGGER.warning("Spotify token validation failed: %s", err)
+            if err.status in (400, 401):
+                return web.json_response(
+                    {"error": "Invalid Spotify credentials"}, status=401
+                )
             return web.json_response(
-                {"error": f"Failed to validate credentials: {err}"},
+                {"error": "Spotify token endpoint unreachable"}, status=502
+            )
+        except Exception as err:  # noqa: BLE001
+            _LOGGER.exception("Credential validation failed")
+            return web.json_response(
+                {"error": _sanitize_error(f"Failed to validate credentials: {err}")},
                 status=500,
             )
 
@@ -183,20 +252,35 @@ class SpotifyCredentialsView(HomeAssistantView):
         return web.json_response({"configured": creds is not None})
 
 
-class ImportPlaylistView(HomeAssistantView):
-    """Import a Spotify playlist (#165)."""
+class ImportPlaylistView(RateLimitMixin, HomeAssistantView):
+    """Import a Spotify playlist (#165).
+
+    Rate-limited (#712), input-limited (#703), progress-reportable (#714),
+    duplicate-name handling (#695), friendly disk-error messages (#710).
+    #689 (requires_auth) intentionally False per PRD.
+    """
 
     url = "/beatify/api/import-playlist"
     name = "beatify:api:import-playlist"
     requires_auth = False
 
+    RATE_LIMIT_REQUESTS = 3
+    RATE_LIMIT_WINDOW = 60
+
     def __init__(self, hass: HomeAssistant) -> None:
         """Initialize view."""
         self.hass = hass
+        self._init_rate_limits()
 
     async def post(self, request: web.Request) -> web.Response:
         """Import a Spotify playlist and save as Beatify JSON."""
+        # #712
+        if not self._check_rate_limit(request.remote or "unknown"):
+            return _json_error("Too many requests", 429, code="RATE_LIMITED")
+
         from custom_components.beatify.services.spotify_import import (  # noqa: PLC0415
+            DuplicatePlaylistError,
+            PlaylistImportError,
             async_import_playlist,
         )
 
@@ -207,27 +291,80 @@ class ImportPlaylistView(HomeAssistantView):
 
         spotify_url = body.get("spotify_url", "").strip()
         playlist_name = body.get("name", "").strip() or None
+        overwrite = bool(body.get("overwrite", False))
         if not spotify_url:
             return web.json_response(
                 {"error": "spotify_url required"}, status=400
             )
+        # #703
+        if len(spotify_url) > _MAX_URL_LEN:
+            return web.json_response({"error": "spotify_url too long"}, status=413)
+        if playlist_name and len(playlist_name) > _MAX_NAME_LEN:
+            return web.json_response({"error": "name too long"}, status=413)
+
+        # #714: minimal progress tracking — client polls GET ?url=...
+        _set_progress(
+            self.hass, spotify_url,
+            status="in_progress", pct=0, message="Starting import…",
+        )
 
         try:
+            _set_progress(self.hass, spotify_url, pct=10, message="Fetching tracks…")
             result = await async_import_playlist(
-                self.hass, spotify_url, name=playlist_name
+                self.hass, spotify_url, name=playlist_name, overwrite=overwrite,
             )
-            return web.json_response(result)
+        except DuplicatePlaylistError as duperr:
+            _set_progress(
+                self.hass, spotify_url, status="error", message=str(duperr),
+            )
+            return web.json_response(
+                {"error": "DUPLICATE_PLAYLIST", "message": str(duperr)}, status=409,
+            )
         except ValueError as err:
+            _set_progress(
+                self.hass, spotify_url, status="error", message=str(err),
+            )
             return web.json_response({"error": str(err)}, status=400)
+        except PlaylistImportError as perr:
+            # #710: map disk/permission errors to friendly status codes.
+            _set_progress(
+                self.hass, spotify_url, status="error", message=str(perr),
+            )
+            msg = str(perr)
+            if "Disk full" in msg:
+                return web.json_response({"error": msg}, status=507)
+            return web.json_response({"error": msg}, status=500)
         except Exception as err:  # noqa: BLE001
             _LOGGER.exception("Playlist import failed")
-            return web.json_response(
-                {"error": f"Import failed: {err}"}, status=500
+            _set_progress(
+                self.hass, spotify_url, status="error", message="Import failed",
             )
+            return web.json_response(
+                {"error": _sanitize_error(f"Import failed: {err}")}, status=500,
+            )
+
+        _set_progress(
+            self.hass, spotify_url,
+            status="done", pct=100, message="Import complete",
+        )
+        return web.json_response(result)
+
+    async def get(self, request: web.Request) -> web.Response:
+        """#714: return progress for an in-flight import.
+
+        Query: ?url=<spotify_url>
+        """
+        key = request.query.get("url", "").strip()
+        if not key:
+            return web.json_response({"error": "url required"}, status=400)
+        progress = _get_progress(self.hass, key)
+        if not progress:
+            return web.json_response({"status": "idle"})
+        return web.json_response(progress)
 
 
 class EditPlaylistView(HomeAssistantView):
-    """Edit an imported playlist (PR #549)."""
+    """Edit an imported playlist (PR #549). Atomic writes (#696)."""
 
     url = "/beatify/api/edit-playlist"
     name = "beatify:api:edit-playlist"
@@ -242,6 +379,8 @@ class EditPlaylistView(HomeAssistantView):
         filename = request.query.get("file", "").strip()
         if not filename:
             return web.json_response({"error": "file parameter required"}, status=400)
+        if len(filename) > _MAX_FILE_LEN:  # #703
+            return web.json_response({"error": "file too long"}, status=413)
 
         playlist_dir = Path(self.hass.config.path("beatify/playlists"))
         file_path = playlist_dir / filename
@@ -281,6 +420,8 @@ class EditPlaylistView(HomeAssistantView):
         filename = body.get("file", "").strip()
         if not filename:
             return web.json_response({"error": "file required"}, status=400)
+        if len(filename) > _MAX_FILE_LEN:  # #703
+            return web.json_response({"error": "file too long"}, status=413)
 
         playlist_dir = Path(self.hass.config.path("beatify/playlists"))
         file_path = playlist_dir / filename
@@ -308,10 +449,24 @@ class EditPlaylistView(HomeAssistantView):
         existing["songs"] = body.get("songs", existing.get("songs", []))
 
         def _save() -> None:
+            import os  # noqa: PLC0415
+            import tempfile  # noqa: PLC0415
+
             file_path.parent.mkdir(parents=True, exist_ok=True)
-            file_path.write_text(
-                json.dumps(existing, indent=2, ensure_ascii=False), encoding="utf-8"
+            # #696: atomic write.
+            tmp_fd, tmp_path = tempfile.mkstemp(
+                dir=file_path.parent, suffix=".json.tmp",
             )
+            try:
+                with os.fdopen(tmp_fd, "w", encoding="utf-8") as f:
+                    json.dump(existing, f, indent=2, ensure_ascii=False)
+                os.replace(tmp_path, file_path)
+            except BaseException:
+                try:
+                    os.unlink(tmp_path)
+                except OSError:
+                    pass
+                raise
 
         await self.hass.async_add_executor_job(_save)
 
@@ -333,6 +488,8 @@ class EditPlaylistView(HomeAssistantView):
             return web.json_response(
                 {"error": "file and remove_index required"}, status=400
             )
+        if len(filename) > _MAX_FILE_LEN:  # #703
+            return web.json_response({"error": "file too long"}, status=413)
 
         playlist_dir = Path(self.hass.config.path("beatify/playlists"))
         file_path = playlist_dir / filename
@@ -367,9 +524,23 @@ class EditPlaylistView(HomeAssistantView):
         data["songs"] = songs
 
         def _save() -> None:
-            file_path.write_text(
-                json.dumps(data, indent=2, ensure_ascii=False), encoding="utf-8"
+            import os  # noqa: PLC0415
+            import tempfile  # noqa: PLC0415
+
+            # #696: atomic write.
+            tmp_fd, tmp_path = tempfile.mkstemp(
+                dir=file_path.parent, suffix=".json.tmp",
             )
+            try:
+                with os.fdopen(tmp_fd, "w", encoding="utf-8") as f:
+                    json.dump(data, f, indent=2, ensure_ascii=False)
+                os.replace(tmp_path, file_path)
+            except BaseException:
+                try:
+                    os.unlink(tmp_path)
+                except OSError:
+                    pass
+                raise
 
         await self.hass.async_add_executor_job(_save)
 
@@ -379,20 +550,29 @@ class EditPlaylistView(HomeAssistantView):
         })
 
 
-class SpotifySearchView(HomeAssistantView):
-    """Search Spotify for tracks (PR #549)."""
+class SpotifySearchView(RateLimitMixin, HomeAssistantView):
+    """Search Spotify for tracks (PR #549). Rate-limited (#712), input-limited (#703)."""
 
     url = "/beatify/api/spotify-search"
     name = "beatify:api:spotify-search"
     requires_auth = False
 
+    RATE_LIMIT_REQUESTS = 20
+    RATE_LIMIT_WINDOW = 60
+
     def __init__(self, hass: HomeAssistant) -> None:
         """Initialize view."""
         self.hass = hass
+        self._init_rate_limits()
 
     async def get(self, request: web.Request) -> web.Response:
         """Search Spotify for tracks matching query."""
+        # #712
+        if not self._check_rate_limit(request.remote or "unknown"):
+            return _json_error("Too many requests", 429, code="RATE_LIMITED")
+
         from custom_components.beatify.services.spotify_import import (  # noqa: PLC0415
+            _safe_parse_year,
             async_fetch_spotify_token,
             async_load_credentials,
         )
@@ -400,6 +580,8 @@ class SpotifySearchView(HomeAssistantView):
         query = request.query.get("q", "").strip()
         if not query:
             return web.json_response({"error": "q parameter required"}, status=400)
+        if len(query) > _MAX_QUERY_LEN:  # #703
+            return web.json_response({"error": "q too long"}, status=413)
 
         credentials = await async_load_credentials(self.hass)
         if not credentials:
@@ -437,22 +619,19 @@ class SpotifySearchView(HomeAssistantView):
             for item in data.get("tracks", {}).get("items", []):
                 artists = ", ".join(a["name"] for a in item.get("artists", []))
                 album = item.get("album", {})
-                release_date = album.get("release_date", "")
-                year = (
-                    int(release_date[:4])
-                    if release_date and len(release_date) >= 4
-                    else 0
-                )
+                year = _safe_parse_year(album.get("release_date", ""))
+                spot_uri = item.get("uri", "")
                 results.append({
                     "title": item["name"],
                     "artist": artists,
                     "year": year,
-                    "uri": item.get("uri", ""),
+                    "uri": spot_uri,
+                    "uri_spotify": spot_uri,  # #705
                 })
 
             return web.json_response({"results": results})
         except Exception as err:  # noqa: BLE001
             _LOGGER.exception("Spotify search failed")
             return web.json_response(
-                {"error": f"Search failed: {err}"}, status=500
+                {"error": _sanitize_error(f"Search failed: {err}")}, status=500
             )

--- a/custom_components/beatify/services/spotify_import.py
+++ b/custom_components/beatify/services/spotify_import.py
@@ -5,7 +5,10 @@ import asyncio
 import base64
 import json
 import logging
+import os
 import re
+import tempfile
+import time
 from pathlib import Path
 from typing import Any
 from urllib.parse import quote, urlparse
@@ -23,20 +26,43 @@ SPOTIFY_TOKEN_URL = "https://accounts.spotify.com/api/token"
 SPOTIFY_API_BASE = "https://api.spotify.com/v1"
 MAX_SONGS = 200
 
+# Spotify playlist IDs are base-62 and exactly 22 chars (#711).
+_PLAYLIST_ID_RE = re.compile(r"^[A-Za-z0-9]{22}$")
+_PLAYLIST_PATH_RE = re.compile(r"^/playlist/([A-Za-z0-9]{22})/?$")
+_VALID_SPOTIFY_HOSTS = frozenset({"open.spotify.com", "play.spotify.com"})
+
 
 def parse_spotify_playlist_id(url: str) -> str:
-    """Parse playlist ID from various Spotify URL formats."""
+    """Parse playlist ID from various Spotify URL formats.
+
+    Accepts:
+        spotify:playlist:<22-char-id>
+        https://open.spotify.com/playlist/<22-char-id>[?si=...]
+    Rejects other hosts, paths, or malformed IDs (#699, #711).
+    """
     # spotify:playlist:37i9dQZF1DXcBWIGoYBM5M
     if url.startswith("spotify:playlist:"):
-        return url.split(":")[-1]
+        pid = url.split(":", 2)[-1]
+        if _PLAYLIST_ID_RE.match(pid):
+            return pid
+        raise ValueError(f"Invalid Spotify playlist ID: {pid}")
 
-    # https://open.spotify.com/playlist/37i9dQZF1DXcBWIGoYBM5M?si=xxx
     parsed = urlparse(url)
-    match = re.match(r"/playlist/([a-zA-Z0-9]+)", parsed.path)
+    if parsed.scheme not in ("http", "https"):
+        raise ValueError(f"Unsupported URL scheme: {parsed.scheme}")
+    if parsed.hostname not in _VALID_SPOTIFY_HOSTS:
+        raise ValueError(f"Not a Spotify URL: {parsed.hostname}")
+
+    match = _PLAYLIST_PATH_RE.match(parsed.path)
     if match:
         return match.group(1)
 
     raise ValueError(f"Cannot parse Spotify playlist ID from: {url}")
+
+
+# Token cache keyed by client_id — avoids refetching on every request (#691).
+_token_cache: dict[str, dict[str, Any]] = {}
+_TOKEN_EXPIRY_BUFFER = 60  # refresh 1 min before expiry
 
 
 async def async_fetch_spotify_token(
@@ -44,7 +70,12 @@ async def async_fetch_spotify_token(
     client_id: str,
     client_secret: str,
 ) -> str:
-    """Fetch access token using Spotify Client Credentials flow."""
+    """Fetch access token using Spotify Client Credentials flow with caching (#691)."""
+    cached = _token_cache.get(client_id)
+    now = time.time()
+    if cached and now < cached["expires_at"] - _TOKEN_EXPIRY_BUFFER:
+        return cached["token"]
+
     credentials = base64.b64encode(
         f"{client_id}:{client_secret}".encode()
     ).decode()
@@ -58,7 +89,26 @@ async def async_fetch_spotify_token(
     async with session.post(SPOTIFY_TOKEN_URL, headers=headers, data=data) as resp:
         resp.raise_for_status()
         result = await resp.json()
-        return result["access_token"]
+
+    token = result["access_token"]
+    expires_in = int(result.get("expires_in", 3600))
+    _token_cache[client_id] = {
+        "token": token,
+        "expires_at": now + expires_in,
+    }
+    return token
+
+
+def _safe_parse_year(release_date: str) -> int:
+    """Parse year from Spotify release_date, tolerating malformed values (#700)."""
+    if not release_date:
+        return 0
+    try:
+        # Spotify returns YYYY, YYYY-MM, or YYYY-MM-DD. Take the first 4 chars.
+        return int(release_date[:4])
+    except (ValueError, TypeError):
+        _LOGGER.debug("Malformed Spotify release_date %r — defaulting to 0", release_date)
+        return 0
 
 
 async def async_fetch_playlist_tracks(
@@ -85,8 +135,7 @@ async def async_fetch_playlist_tracks(
 
             artists = ", ".join(a["name"] for a in track.get("artists", []))
             album = track.get("album", {})
-            release_date = album.get("release_date", "")
-            year = int(release_date[:4]) if release_date and len(release_date) >= 4 else 0
+            year = _safe_parse_year(album.get("release_date", ""))
 
             tracks.append({
                 "title": track["name"],
@@ -125,6 +174,14 @@ def _convert_deezer_url(url: str) -> str:
     return ""
 
 
+_EMPTY_ENRICHMENT = {
+    "uri_youtube_music": "",
+    "uri_apple_music": "",
+    "uri_tidal": "",
+    "uri_deezer": "",
+}
+
+
 async def async_enrich_via_odesli(
     session: aiohttp.ClientSession,
     spotify_uri: str,
@@ -135,14 +192,16 @@ async def async_enrich_via_odesli(
         url = f"{ODESLI_BASE}?url={encoded_uri}&userCountry=US"
 
         async with session.get(url) as resp:
+            if resp.status == 429:
+                # Log rate limits at WARNING so operators see enrichment loss (#694).
+                _LOGGER.warning(
+                    "Odesli rate-limited (429) for %s — track will have no cross-platform URIs",
+                    spotify_uri,
+                )
+                return dict(_EMPTY_ENRICHMENT)
             if resp.status != 200:
                 _LOGGER.debug("Odesli returned %s for %s", resp.status, spotify_uri)
-                return {
-                    "uri_youtube_music": "",
-                    "uri_apple_music": "",
-                    "uri_tidal": "",
-                    "uri_deezer": "",
-                }
+                return dict(_EMPTY_ENRICHMENT)
             data = await resp.json()
 
         links_by_platform = data.get("linksByPlatform", {})
@@ -171,12 +230,7 @@ async def async_enrich_via_odesli(
 
     except Exception as exc:  # noqa: BLE001
         _LOGGER.warning("Odesli enrichment failed for %s: %s", spotify_uri, exc)
-        return {
-            "uri_youtube_music": "",
-            "uri_apple_music": "",
-            "uri_tidal": "",
-            "uri_deezer": "",
-        }
+        return dict(_EMPTY_ENRICHMENT)
 
 
 _CREDS_STORE_KEY = "beatify.spotify_credentials"
@@ -203,10 +257,20 @@ async def async_load_credentials(hass: HomeAssistant) -> dict[str, str] | None:
     return data if data else None
 
 
+class PlaylistImportError(Exception):
+    """Base class for playlist-import failures with friendly messages (#710)."""
+
+
+class DuplicatePlaylistError(PlaylistImportError):
+    """A playlist file with the same slug already exists (#695)."""
+
+
 async def async_import_playlist(
     hass: HomeAssistant,
     spotify_url: str,
     name: str | None = None,
+    *,
+    overwrite: bool = False,
 ) -> dict[str, Any]:
     """Import a Spotify playlist and enrich with cross-platform URIs."""
     playlist_id = parse_spotify_playlist_id(spotify_url)
@@ -246,9 +310,12 @@ async def async_import_playlist(
             uris = await async_enrich_via_odesli(session, track["uri"])
             await asyncio.sleep(0.2)
 
+            spotify_uri = track["uri"]
             song = {
                 "year": track["year"],
-                "uri": track["uri"],
+                # #705: write both `uri` (legacy) and `uri_spotify` (canonical)
+                "uri": spotify_uri,
+                "uri_spotify": spotify_uri,
                 "artist": track["artist"],
                 "title": track["title"],
                 "uri_youtube_music": uris.get("uri_youtube_music", ""),
@@ -277,8 +344,51 @@ async def async_import_playlist(
     output_path = Path(hass.config.path(f"beatify/playlists/{slug}.json"))
 
     def _save() -> None:
-        output_path.parent.mkdir(parents=True, exist_ok=True)
-        output_path.write_text(json.dumps(playlist_data, indent=2, ensure_ascii=False))
+        """Atomic write (#696) with duplicate-name detection (#695) and
+        OSError → friendly error (#710)."""
+        parent = output_path.parent
+        try:
+            parent.mkdir(parents=True, exist_ok=True)
+        except OSError as err:
+            raise PlaylistImportError(
+                f"Cannot create playlist directory: {err.strerror or err}"
+            ) from err
+
+        if output_path.exists() and not overwrite:
+            raise DuplicatePlaylistError(
+                f"A playlist named '{name}' already exists. "
+                f"Re-submit with overwrite=true to replace it."
+            )
+
+        # Write to a temp file in the same dir, then atomically rename (#696).
+        tmp_fd, tmp_path = tempfile.mkstemp(dir=parent, suffix=".json.tmp")
+        try:
+            with os.fdopen(tmp_fd, "w", encoding="utf-8") as f:
+                json.dump(playlist_data, f, indent=2, ensure_ascii=False)
+            os.replace(tmp_path, output_path)
+        except OSError as err:
+            # Clean up temp file on failure
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+            if err.errno == 28:  # ENOSPC
+                raise PlaylistImportError(
+                    "Disk full — could not save playlist. Free up space and retry."
+                ) from err
+            if err.errno == 13:  # EACCES
+                raise PlaylistImportError(
+                    "Permission denied writing playlist file."
+                ) from err
+            raise PlaylistImportError(
+                f"Failed to write playlist: {err.strerror or err}"
+            ) from err
+        except BaseException:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+            raise
 
     await hass.async_add_executor_job(_save)
 
@@ -294,9 +404,10 @@ async def async_import_playlist(
         if s.get("uri_youtube_music") or s.get("uri_apple_music") or s.get("uri_deezer")
     )
 
+    # #704: do NOT leak full server filesystem path to frontend.
     return {
         "name": name,
+        "slug": slug,
         "song_count": len(enriched_songs),
         "enriched_count": enriched_count,
-        "file_path": str(output_path),
     }

--- a/custom_components/beatify/www/js/admin.js
+++ b/custom_components/beatify/www/js/admin.js
@@ -368,24 +368,68 @@ async function setupSpotifyImport() {
         try {
             if (msgEl) msgEl.textContent = '⏳ Fetching songs and enriching URIs for all providers. This may take up to a minute for large playlists...';
 
-            var resp = await fetch('/beatify/api/import-playlist', {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ spotify_url: url })
-            });
-            var data = await resp.json();
-            if (data.error) {
-                if (msgEl) msgEl.textContent = '❌ ' + data.error;
+            // #714: poll for progress while the import runs.
+            var pollInterval = setInterval(async function () {
+                try {
+                    var pr = await fetch(
+                        '/beatify/api/import-playlist?url=' + encodeURIComponent(url)
+                    );
+                    if (!pr.ok) return;
+                    var pd = await pr.json();
+                    if (msgEl && pd && pd.message && pd.status === 'in_progress') {
+                        var pct = typeof pd.pct === 'number' ? ' (' + pd.pct + '%)' : '';
+                        msgEl.textContent = '⏳ ' + pd.message + pct;
+                    }
+                } catch (_) { /* ignore polling errors */ }
+            }, 2000);
+
+            var resp;
+            var data;
+            try {
+                resp = await fetch('/beatify/api/import-playlist', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ spotify_url: url })
+                });
+                data = await resp.json();
+            } finally {
+                clearInterval(pollInterval);
+            }
+
+            // #695: duplicate → offer overwrite retry.
+            if (resp && resp.status === 409 && data && data.error === 'DUPLICATE_PLAYLIST') {
+                var doOverwrite = confirm(
+                    (data.message || 'A playlist with that name already exists.') +
+                    '\n\nReplace the existing playlist?'
+                );
+                if (doOverwrite) {
+                    if (msgEl) msgEl.textContent = '⏳ Overwriting existing playlist…';
+                    resp = await fetch('/beatify/api/import-playlist', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ spotify_url: url, overwrite: true })
+                    });
+                    data = await resp.json();
+                } else {
+                    if (msgEl) msgEl.textContent = '⚠️ Import cancelled.';
+                    this.disabled = false;
+                    this.textContent = '📥 Import Playlist';
+                    return;
+                }
+            }
+
+            if (data && (data.error || !resp.ok)) {
+                if (msgEl) msgEl.textContent = '❌ ' + (data.message || data.error || 'Import failed');
             } else {
                 var enriched = data.enriched_count || 0;
                 var total = data.song_count || 0;
                 if (msgEl) msgEl.textContent = '✅ "' + data.name + '" imported — ' + total + ' songs, ' + enriched + ' with cross-platform URIs.';
                 document.getElementById('spotify-playlist-url').value = '';
                 if (reloadBtn) reloadBtn.classList.remove('hidden');
-                // PR #549: Open editor for the newly imported playlist
-                if (data.file_path) {
-                    var fname = data.file_path.split('/').pop();
-                    openPlaylistEditor(fname);
+                // PR #549: Open editor for the newly imported playlist.
+                // #704: use slug from API (not server-side file_path).
+                if (data.slug) {
+                    openPlaylistEditor(data.slug + '.json');
                 }
             }
         } catch (e) {


### PR DESCRIPTION
## Summary

Addresses the 24-issue playlist-audit batch filed on 2026-04-16.

- **21 bugs fixed** in this PR
- **1 deferred** (#689) — `requires_auth = True` flip intentionally not applied per the "Frictionless access per PRD" policy; attack surface reduced via rate limits, input limits, and credential scrubbing
- **1 phantom** (#688) — not reproducible; the claim that PR #687 deleted `URI_PATTERN_*` does not hold against current `main` (constants still at `const.py:134-140`, PR #687's merge commit is not in `git log --all`)

### Security / hardening
- Rate limiting on Spotify credential, import, and search endpoints (#712)
- Input length limits on credential/import/search/edit endpoints (#703)
- Credential-scrubbed error responses — no base64 `Authorization` echoes (#690)
- Removed server-side filesystem path from import response (#704)

### Data integrity / validation
- Hostname + exact 22-char ID validation on Spotify URLs (#699, #711)
- Tolerant year parsing — malformed `release_date` no longer crashes import (#700)
- `MAX_YEAR` is now dynamic (year + 1), was hardcoded 2030 (#706)
- `validate_playlist()` checks title and artist (#697)
- Atomic playlist writes (tempfile + rename) (#696)
- Duplicate-name detection with admin overwrite prompt (#695)
- Friendly errors for disk-full / permission failures (#710)
- `async_ensure_playlist_directory` runs blocking I/O off-loop (#717)
- Discovery provider counts validate URI regex (#708)
- Empty playlists excluded from discovery (#716)
- `get_remaining_count()` clamped at 0 (#707)
- Zero-playable-song combos fail fast (#709)
- Odesli 429s logged at WARNING (#694)
- Imports write both `uri` (legacy) and `uri_spotify` (canonical) (#705)

### Performance
- Spotify token cache keyed by `client_id` with expiry buffer (#691)

### UX
- Import progress polled via `GET /beatify/api/import-playlist?url=…` (#714)

## Test plan

- [ ] Import a playlist end-to-end (success path, duplicate path w/ overwrite confirm)
- [ ] Editor auto-opens on successful import (slug-based, no server path)
- [ ] 4th import request within 60s → 429
- [ ] `client_id` > 128 chars → 413
- [ ] Token cache: first import fetches token, immediate second import reuses it
- [ ] Start a game with a provider that has zero playable songs → verify clean error (not stall)
- [ ] Confirm `_copy_bundled_playlists` still runs on HA startup
- [ ] Pre-existing test-harness `metaclass conflict` on `HomeAssistantView` is unchanged

Closes #690 #691 #694 #695 #696 #697 #699 #700 #703 #704 #705 #706 #707 #708 #709 #710 #711 #712 #714 #716 #717
Closes #688 (not reproducible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)