### PR TITLE
fix: restore URI_PATTERN_* constants — hotfix for #688

### DIFF
--- a/custom_components/beatify/const.py
+++ b/custom_components/beatify/const.py
@@ -129,6 +129,16 @@ MEDIA_PLAYER_DOCS_URL = "https://www.home-assistant.io/integrations/#media-playe
 
 # Playlist configuration
 PLAYLIST_DIR = "beatify/playlists"
+
+# Multi-provider URI patterns (Story 17.1).
+# Restored in #688 — these ARE used by game/playlist.py for URI validation
+# during playlist discovery. Removed in #687 by mistake.
+URI_PATTERN_SPOTIFY = r"^spotify:track:[a-zA-Z0-9]{22}$"
+URI_PATTERN_APPLE_MUSIC = r"^applemusic://track/\d+$"
+URI_PATTERN_YOUTUBE_MUSIC = r"^https://music\.youtube\.com/watch\?v=[a-zA-Z0-9_-]{11}$"
+URI_PATTERN_TIDAL = r"^tidal://track/\d+$"
+URI_PATTERN_DEEZER = r"^deezer://track/\d+$"
+
 # Provider identifiers (Story 17.1)
 PROVIDER_SPOTIFY = "spotify"
 PROVIDER_APPLE_MUSIC = "apple_music"  # Preserved for future use


### PR DESCRIPTION
## Summary

Post-merge hotfix. PR #687 deleted the 5 `URI_PATTERN_*` regex constants from `const.py` as "dead code", but they are actively imported and used by [playlist.py:21-25](custom_components/beatify/game/playlist.py) for URI validation during playlist discovery. Integration fails to load with `ImportError` on current main.

I incorrectly marked #688 as phantom during the PR #718 triage because my local `main` was stale and did not yet contain #687's deletion. Correcting now.

Restores the 5 constants verbatim.

## Test plan

- [ ] Verify `from custom_components.beatify.game import playlist` no longer raises ImportError
- [ ] Verify Beatify loads cleanly in HA
- [ ] Verify playlist discovery produces correct per-provider counts

Closes #688

🤖 Generated with [Claude Code](https://claude.com/claude-code)