### PR TITLE
chore: bump version to 3.2.0-rc2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to Beatify are documented here. For detailed release notes, 
 
 ## [Unreleased]
 
+## [3.2.0-rc2] - 2026-04-16
+
 ### Security / hardening
 - Rate limiting on Spotify credential, import, and search endpoints (#712)
 - Input length limits on credential, import, search, and edit endpoints (#703)
@@ -11,6 +13,7 @@ All notable changes to Beatify are documented here. For detailed release notes, 
 - Removed server-side filesystem path from import response (#704)
 
 ### Fixed
+- **Critical**: Restored `URI_PATTERN_*` constants in `const.py` — removed by mistake in #687, breaking integration load (#688, #719)
 - Tightened Spotify URL parsing — hostname validation + exact 22-char ID match (#699, #711)
 - Tolerant year parsing — malformed `release_date` no longer crashes imports (#700)
 - `MAX_YEAR` is now dynamic (current year + 1); was hardcoded to 2030 (#706)
@@ -25,6 +28,7 @@ All notable changes to Beatify are documented here. For detailed release notes, 
 - Zero-playable-song combinations now fail fast with a clear error (#709)
 - Odesli 429 rate-limits logged at WARNING instead of silently swallowed (#694)
 - Imported tracks now carry both `uri` (legacy) and `uri_spotify` (canonical) (#705)
+- `_VERSION` in `server/base.py` now tracks manifest (was stuck at `3.0.4`)
 
 ### Performance
 - Spotify client-credentials tokens are cached for their lifetime (#691)
@@ -33,7 +37,6 @@ All notable changes to Beatify are documented here. For detailed release notes, 
 - Playlist import now shows in-flight progress updates (#714)
 
 ### Notes
-- #688 reported a critical ImportError from deleted `URI_PATTERN_*` constants; verified not reproducible — the constants still exist in `const.py` and the referenced PR #687 is not in `git log`. No code change needed.
 - #689 (`requires_auth = True` on admin endpoints) intentionally not applied — the "Frictionless access per PRD" policy stands. Rate limiting, input length limits, and credential scrubbing reduce the remaining attack surface.
 
 ## [2.7.0] - 2026-03-01

--- a/custom_components/beatify/manifest.json
+++ b/custom_components/beatify/manifest.json
@@ -12,5 +12,5 @@
   "documentation": "https://github.com/mholzi/beatify",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/mholzi/beatify/issues",
-  "version": "3.2.0-rc1"
+  "version": "3.2.0-rc2"
 }

--- a/custom_components/beatify/server/base.py
+++ b/custom_components/beatify/server/base.py
@@ -22,7 +22,7 @@ _LOGGER = logging.getLogger(__name__)
 # We avoid reading manifest.json at runtime because HA imports custom components
 # inside the event loop, and any file I/O (even at module level) triggers
 # blocking call warnings in HA 2026.2+.
-_VERSION = "3.0.4"
+_VERSION = "3.2.0-rc2"
 
 
 def _get_version() -> str:


### PR DESCRIPTION
## Summary

- Bump `manifest.json` and `server/base.py` to **3.2.0-rc2**
- Changelog for 3.2.0-rc2 covers everything shipped since rc1: PR #718 (21 playlist fixes) + PR #719 (URI_PATTERN_* restore hotfix)
- Fixes a pre-existing drift where `server/base.py _VERSION` was stuck at `3.0.4` while `manifest.json` was at `3.2.0-rc1`

## Test plan

- [ ] Verify `/beatify/api/status` reports version `3.2.0-rc2`
- [ ] Verify HACS picks up the new version
- [ ] Smoke test playlist discovery + import on a fresh HA

🤖 Generated with [Claude Code](https://claude.com/claude-code)