### PR TITLE
fix: re-enable Spotify Playlist Import UI

### DIFF
--- a/custom_components/beatify/www/admin.html
+++ b/custom_components/beatify/www/admin.html
@@ -150,7 +150,7 @@
             </div>
         </section>
 
-        <!-- Spotify Playlist Import Section (#165) — hidden until feature is ready
+        <!-- Spotify Playlist Import Section (#165) -->
         <section id="import-playlist" class="section-collapsible collapsed" aria-labelledby="import-playlist-heading">
             <button type="button" class="section-header-collapsible" aria-expanded="false" aria-controls="import-playlist-content">
                 <span class="section-icon" aria-hidden="true">📥</span>


### PR DESCRIPTION
## Summary

The \`<section id=\"import-playlist\">\` block in \`admin.html\` was wrapped in an HTML comment (\`<!-- ... hidden until feature is ready\`) that never had a matching \`-->\`. The first \`-->\` was the nested \`<!-- Playlist Editor (PR #549) -->\` on line 189 — which closes the outer comment prematurely and leaves the rest of the section as broken markup that browsers silently ignored.

Replacing the unterminated opener with a plain section comment restores the whole Import Playlist UI (credentials setup, URL input, import button, progress messages, embedded editor). JS wiring in \`admin.js\` was never disabled, so it starts working immediately.

## Test plan

- [ ] Open admin page, verify \"📥 Import Spotify Playlist\" section appears
- [ ] Expand it; verify \"Setup Spotify API\" or \"Import Playlist\" form renders correctly
- [ ] Import a playlist end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)