### PR TITLE
chore: bump version to 3.2.0-rc3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to Beatify are documented here. For detailed release notes, 
 
 ## [Unreleased]
 
+## [3.2.0-rc3] - 2026-04-16
+
+### Fixed
+- Re-enabled Spotify Playlist Import UI in the admin dashboard — the section was hidden by an unterminated HTML comment in `admin.html` (#723)
+
 ## [3.2.0-rc2] - 2026-04-16
 
 ### Security / hardening

--- a/custom_components/beatify/manifest.json
+++ b/custom_components/beatify/manifest.json
@@ -12,5 +12,5 @@
   "documentation": "https://github.com/mholzi/beatify",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/mholzi/beatify/issues",
-  "version": "3.2.0-rc2"
+  "version": "3.2.0-rc3"
 }

--- a/custom_components/beatify/server/base.py
+++ b/custom_components/beatify/server/base.py
@@ -22,7 +22,7 @@ _LOGGER = logging.getLogger(__name__)
 # We avoid reading manifest.json at runtime because HA imports custom components
 # inside the event loop, and any file I/O (even at module level) triggers
 # blocking call warnings in HA 2026.2+.
-_VERSION = "3.2.0-rc2"
+_VERSION = "3.2.0-rc3"
 
 
 def _get_version() -> str:


### PR DESCRIPTION
Includes PR #723 (re-enables Import UI). Ready to tag once merged.