### PR TITLE
fix: useful error for Spotify 403/401 + URL-path sanitizer bug

### DIFF
--- a/custom_components/beatify/server/playlist_views.py
+++ b/custom_components/beatify/server/playlist_views.py
@@ -34,12 +34,17 @@ def _sanitize_error(message: str) -> str:
     """Strip anything that looks like a credential from an error message (#690).
 
     Token-validation errors can echo back Authorization headers or
-    base64-encoded client_id:client_secret pairs.
+    base64-encoded client_id:client_secret pairs. Deliberately does NOT
+    redact URL paths (which include `/` and alphanumerics) — that just
+    obscures debugging.
     """
     import re as _re
-    cleaned = _re.sub(r"[A-Za-z0-9+/=]{40,}", "<redacted>", message)
-    cleaned = _re.sub(r"(?i)authorization[^\s]*", "<redacted>", cleaned)
+    # Authorization headers and Bearer tokens are the real credential leak vectors.
+    cleaned = _re.sub(r"(?i)authorization\s*[:=]\s*\S+", "<redacted>", message)
     cleaned = _re.sub(r"(?i)bearer\s+\S+", "Bearer <redacted>", cleaned)
+    # Base64-style client_id:client_secret blobs use [A-Za-z0-9+/=] — but so do
+    # URLs. To avoid redacting URL paths, require the run to NOT contain `/`.
+    cleaned = _re.sub(r"[A-Za-z0-9+=]{40,}", "<redacted>", cleaned)
     return cleaned
 
 

--- a/custom_components/beatify/services/spotify_import.py
+++ b/custom_components/beatify/services/spotify_import.py
@@ -123,6 +123,22 @@ async def async_fetch_playlist_tracks(
 
     while url and len(tracks) < MAX_SONGS:
         async with session.get(url, headers=headers) as resp:
+            # 403/404 on client-credentials flow = playlist is private, owned by
+            # another user, or one of Spotify's algorithmic/editorial playlists
+            # (e.g. Discover Weekly, Daily Mix). These can't be read without user
+            # OAuth. Give the admin a clear message instead of an aiohttp stacktrace.
+            if resp.status in (403, 404):
+                raise PlaylistImportError(
+                    "Can't read that playlist. Only public, user-created playlists "
+                    "can be imported. Spotify's algorithmic playlists (Discover "
+                    "Weekly, Daily Mix, etc.) and private playlists require "
+                    "personal login which Beatify doesn't support."
+                )
+            if resp.status == 401:
+                raise PlaylistImportError(
+                    "Spotify rejected the auth token. Double-check your Client ID "
+                    "and Client Secret under 'Setup Spotify API'."
+                )
             resp.raise_for_status()
             data = await resp.json()
 


### PR DESCRIPTION
## Summary

### 1. Spotify 403 on playlist tracks → friendly error
Spotify's client-credentials flow can't read:
- Private playlists
- Algorithmic playlists (Discover Weekly, Daily Mix, Release Radar)
- Editorial playlists owned by `spotify:user:spotify` that are region-locked

Previously we surfaced the raw aiohttp error. Now we catch 403/404 at the fetch and raise `PlaylistImportError` with actionable guidance.

### 2. URL paths getting redacted
The `_sanitize_error` regex `[A-Za-z0-9+/=]{40,}` matched URL paths because `/` is in the character class. `v1/playlists/<22-char-id>/tracks` is 43 chars of `[A-Za-z0-9/]` → redacted. That's why the user saw `url='https://api.spotify.<redacted>'`. Removed `/` from the class — URL paths are fine to show, real credentials are caught by the name-based Authorization/Bearer patterns above.

## Test plan

- [ ] Import a known-inaccessible playlist (e.g., `https://open.spotify.com/playlist/37i9dQZF1DXcBWIGoYBM5M` — Today's Top Hits, algorithmic) → verify friendly 'Only public, user-created playlists can be imported' message
- [ ] Import a public playlist you own → verify import still works
- [ ] If you get an actual credential error, verify no base64-looking blob leaks

🤖 Generated with [Claude Code](https://claude.com/claude-code)