### PR TITLE
fix: restore launcher popup on desktop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to Beatify are documented here. For detailed release notes, 
 
 ## [Unreleased]
 
+## [3.2.0-rc8] - 2026-04-16
+
+### Fixed
+- Launcher now re-opens admin in a popup from desktop browsers. PR #664 over-reached: its iframe detection treated the HA sidebar (which is always iframed on desktop) as a WebView and forced same-tab navigation. Popup-blocked fallback still covers genuinely blocked popups.
+
 ## [3.2.0-rc7] - 2026-04-16
 
 ### Removed

--- a/custom_components/beatify/manifest.json
+++ b/custom_components/beatify/manifest.json
@@ -12,5 +12,5 @@
   "documentation": "https://github.com/mholzi/beatify",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/mholzi/beatify/issues",
-  "version": "3.2.0-rc7"
+  "version": "3.2.0-rc8"
 }

--- a/custom_components/beatify/server/base.py
+++ b/custom_components/beatify/server/base.py
@@ -22,7 +22,7 @@ _LOGGER = logging.getLogger(__name__)
 # We avoid reading manifest.json at runtime because HA imports custom components
 # inside the event loop, and any file I/O (even at module level) triggers
 # blocking call warnings in HA 2026.2+.
-_VERSION = "3.2.0-rc7"
+_VERSION = "3.2.0-rc8"
 
 
 def _get_version() -> str:

--- a/custom_components/beatify/www/admin.html
+++ b/custom_components/beatify/www/admin.html
@@ -17,7 +17,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@700;900&display=swap" rel="stylesheet">
     <!-- Story 18.4: Use minified CSS in production -->
-    <link rel="stylesheet" href="/beatify/static/css/styles.min.css?v=3.2.0-rc7">
+    <link rel="stylesheet" href="/beatify/static/css/styles.min.css?v=3.2.0-rc8">
 </head>
 <body class="theme-dark">
     <header class="admin-header">
@@ -959,8 +959,8 @@
     <script src="/beatify/static/js/utils.js?v=1.7.0"></script>
     <!-- Story 44.1: Playlist requests module -->
     <script src="/beatify/static/js/playlist-requests.min.js?v=2.2.1"></script>
-    <script src="/beatify/static/js/admin.min.js?v=3.2.0-rc7"></script>
-    <script src="/beatify/static/js/party-lights.min.js?v=3.2.0-rc7"></script>
-    <script src="/beatify/static/js/tts-settings.js?v=3.2.0-rc7"></script>
+    <script src="/beatify/static/js/admin.min.js?v=3.2.0-rc8"></script>
+    <script src="/beatify/static/js/party-lights.min.js?v=3.2.0-rc8"></script>
+    <script src="/beatify/static/js/tts-settings.js?v=3.2.0-rc8"></script>
 </body>
 </html>

--- a/custom_components/beatify/www/launcher.html
+++ b/custom_components/beatify/www/launcher.html
@@ -129,9 +129,11 @@
         function openBeatify() {
             var adminUrl = window.location.origin + '/beatify/admin';
 
-            // HA Companion App and mobile WebViews block window.open()
-            var isWebView = /HomeAssistant|wv|WebView/i.test(navigator.userAgent)
-                || window.self !== window.top;  // inside iframe (HA sidebar)
+            // HA Companion App and mobile WebViews block window.open(). Desktop
+            // browsers inside the HA sidebar iframe CAN open popups, so don't
+            // force same-tab navigation just because we're iframed — try popup
+            // first and fall back if it's blocked.
+            var isWebView = /HomeAssistant|wv|WebView/i.test(navigator.userAgent);
 
             if (isWebView) {
                 window.location.href = adminUrl;


### PR DESCRIPTION
PR #664 over-reached: it treated any iframe context as a WebView and forced same-tab navigation, which breaks the popup for desktop users (HA sidebar is always iframed on desktop). This restores the popup flow while keeping the UA-based detection for HA Companion App and the popup-blocked fallback.