### PR TITLE
data: fix 2 broken Apple Music URIs in gen-z-anthems (#733)

### DIFF
--- a/custom_components/beatify/playlists/gen-z-anthems.json
+++ b/custom_components/beatify/playlists/gen-z-anthems.json
@@ -1,6 +1,6 @@
 {
   "name": "Gen Z Anthems",
-  "version": "1.1",
+  "version": "1.2",
   "tags": [
     "2010s",
     "2020s",
@@ -74,7 +74,7 @@
       "fun_fact_de": "Der Shuffling-Tanztrend aus diesem Song übernahm 2011 buchstäblich jede Schuldisco und Hochzeit — das Musikvideo hat über 2 Milliarden YouTube-Aufrufe.",
       "fun_fact_es": "La moda del baile shuffling de esta canción se apoderó de cada baile escolar y boda en 2011 — el video musical tiene más de 2 mil millones de vistas en YouTube.",
       "fun_fact_fr": "La mode du shuffling lancée par ce morceau a envahi chaque soirée et mariage en 2011 — le clip a dépassé les 2 milliards de vues sur YouTube.",
-      "uri_apple_music": "applemusic://track/1443085354",
+      "uri_apple_music": "applemusic://track/1443124961",
       "uri_youtube_music": "https://music.youtube.com/watch?v=KQ6zr6kCPj8",
       "uri_tidal": "tidal://track/17837023",
       "uri_deezer": "deezer://track/12660659",
@@ -349,7 +349,7 @@
       "fun_fact_de": "Closer war 12 aufeinanderfolgende Wochen auf Platz 1 der Billboard Hot 100 und war quasi die inoffizielle Hymne jedes Studentenwohnheims 2016.",
       "fun_fact_es": "Closer pasó 12 semanas consecutivas en el #1 del Billboard Hot 100 y fue básicamente el himno no oficial de cada residencia universitaria en 2016.",
       "fun_fact_fr": "Closer est resté 12 semaines consécutives au sommet du Billboard Hot 100 et était l'hymne officieux de chaque résidence universitaire en 2016.",
-      "uri_apple_music": "applemusic://track/1523515877",
+      "uri_apple_music": "applemusic://track/1170699703",
       "uri_youtube_music": "https://music.youtube.com/watch?v=PT2_F-1esPk",
       "uri_tidal": "tidal://track/64775565",
       "uri_deezer": "deezer://track/129310248",


### PR DESCRIPTION
Closes #733. Replaced 2 dead Apple Music URIs and bumped playlist version to 1.2.