### PR TITLE
fix: disable 31-day static cache headers (v3.2.0-rc14)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to Beatify are documented here. For detailed release notes, 
 
 ## [Unreleased]
 
+## [3.2.0-rc14] - 2026-04-18
+
+### Fixed
+- **Static files served with 31-day `Cache-Control: max-age=2678400`** — combined with HACS updates that don't always touch every file, users ended up with `admin.html` pointing at `?v=3.2.0-rcN` while the browser held onto a month-old `admin.min.js` under that same URL. Flipped `cache_headers=False` on the `/beatify/static/` route so the browser revalidates via ETag / Last-Modified on every load and picks up fresh bytes the moment the file on disk changes.
+
 ## [3.2.0-rc13] - 2026-04-18
 
 ### Added

--- a/custom_components/beatify/manifest.json
+++ b/custom_components/beatify/manifest.json
@@ -12,5 +12,5 @@
   "documentation": "https://github.com/mholzi/beatify",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/mholzi/beatify/issues",
-  "version": "3.2.0-rc13"
+  "version": "3.2.0-rc14"
 }

--- a/custom_components/beatify/server/__init__.py
+++ b/custom_components/beatify/server/__init__.py
@@ -15,11 +15,19 @@ _LOGGER = logging.getLogger(__name__)
 
 
 async def async_register_static_paths(hass: HomeAssistant) -> None:
-    """Register static file paths for serving CSS, JS, and images."""
+    """Register static file paths for serving CSS, JS, and images.
+
+    cache_headers=False: HA's default sends ``Cache-Control: public, max-age=2678400``
+    (31 days). Combined with HACS updates that don't always touch every file, users
+    ended up with admin.html pointing at ``?v=3.2.0-rcN`` while the browser held
+    onto a month-old admin.min.js under that same URL. Switching to conditional
+    GETs (ETag / Last-Modified) means the browser revalidates on every load and
+    picks up fresh bytes the moment the file on disk changes.
+    """
     www_path = Path(__file__).parent.parent / "www"
 
     await hass.http.async_register_static_paths(
-        [StaticPathConfig("/beatify/static", str(www_path), cache_headers=True)]
+        [StaticPathConfig("/beatify/static", str(www_path), cache_headers=False)]
     )
 
     _LOGGER.debug("Registered static path: /beatify/static -> %s", www_path)

--- a/custom_components/beatify/www/admin.html
+++ b/custom_components/beatify/www/admin.html
@@ -17,7 +17,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@700;900&display=swap" rel="stylesheet">
     <!-- Story 18.4: Use minified CSS in production -->
-    <link rel="stylesheet" href="/beatify/static/css/styles.min.css?v=3.2.0-rc13">
+    <link rel="stylesheet" href="/beatify/static/css/styles.min.css?v=3.2.0-rc14">
 </head>
 <body class="theme-dark">
     <!-- First-run wizard takeover (see DESIGN.md ## Patterns → First-run wizard) -->
@@ -1157,9 +1157,9 @@
     <script src="/beatify/static/js/utils.js?v=1.7.0"></script>
     <!-- Story 44.1: Playlist requests module -->
     <script src="/beatify/static/js/playlist-requests.min.js?v=2.2.1"></script>
-    <script type="module" src="/beatify/static/js/wizard.js?v=3.2.0-rc13"></script>
-    <script src="/beatify/static/js/admin.min.js?v=3.2.0-rc13"></script>
-    <script src="/beatify/static/js/party-lights.min.js?v=3.2.0-rc13"></script>
-    <script src="/beatify/static/js/tts-settings.js?v=3.2.0-rc13"></script>
+    <script type="module" src="/beatify/static/js/wizard.js?v=3.2.0-rc14"></script>
+    <script src="/beatify/static/js/admin.min.js?v=3.2.0-rc14"></script>
+    <script src="/beatify/static/js/party-lights.min.js?v=3.2.0-rc14"></script>
+    <script src="/beatify/static/js/tts-settings.js?v=3.2.0-rc14"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
HA's aiohttp StaticResource with \`cache_headers=True\` ships \`Cache-Control: public, max-age=2678400\` (31 days). Combined with HACS updates that don't always touch every file, users ended up with \`admin.html\` at \`?v=3.2.0-rcN\` while the browser held onto a month-old \`admin.min.js\` under that same URL.

Flipping to \`cache_headers=False\` switches the route to conditional GETs (ETag / Last-Modified revalidation) so the browser picks up fresh bytes the moment the file on disk changes.

## Test plan
- [ ] After update + HA restart: \`fetch('/beatify/static/js/admin.min.js')\` returns a response without \`max-age=2678400\`
- [ ] Subsequent loads send \`If-None-Match\` and receive 304 when unchanged