### PR TITLE
fix: wizard language chip switches UI immediately (v3.2.0-rc16)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to Beatify are documented here. For detailed release notes, 
 
 ## [Unreleased]
 
+## [3.2.0-rc16] - 2026-04-18
+
+### Fixed
+- **Wizard Step 4 "Ansagesprache" didn't switch the UI language.** Picking Deutsch / Español / Français / Nederlands only updated `chosenLanguage` in wizard state — no call to `BeatifyI18n.setLanguage()`. The UI stayed in English for the rest of the wizard and only actually switched on the next page load. Now the chip click fetches the locale file and re-renders translations immediately.
+
 ## [3.2.0-rc15] - 2026-04-18
 
 ### Fixed

--- a/custom_components/beatify/manifest.json
+++ b/custom_components/beatify/manifest.json
@@ -12,5 +12,5 @@
   "documentation": "https://github.com/mholzi/beatify",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/mholzi/beatify/issues",
-  "version": "3.2.0-rc15"
+  "version": "3.2.0-rc16"
 }

--- a/custom_components/beatify/www/admin.html
+++ b/custom_components/beatify/www/admin.html
@@ -17,7 +17,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@700;900&display=swap" rel="stylesheet">
     <!-- Story 18.4: Use minified CSS in production -->
-    <link rel="stylesheet" href="/beatify/static/css/styles.min.css?v=3.2.0-rc15">
+    <link rel="stylesheet" href="/beatify/static/css/styles.min.css?v=3.2.0-rc16">
 </head>
 <body class="theme-dark">
     <!-- First-run wizard takeover (see DESIGN.md ## Patterns → First-run wizard) -->
@@ -1157,9 +1157,9 @@
     <script src="/beatify/static/js/utils.js?v=1.7.0"></script>
     <!-- Story 44.1: Playlist requests module -->
     <script src="/beatify/static/js/playlist-requests.min.js?v=2.2.1"></script>
-    <script type="module" src="/beatify/static/js/wizard.js?v=3.2.0-rc15"></script>
-    <script src="/beatify/static/js/admin.min.js?v=3.2.0-rc15"></script>
-    <script src="/beatify/static/js/party-lights.min.js?v=3.2.0-rc15"></script>
-    <script src="/beatify/static/js/tts-settings.js?v=3.2.0-rc15"></script>
+    <script type="module" src="/beatify/static/js/wizard.js?v=3.2.0-rc16"></script>
+    <script src="/beatify/static/js/admin.min.js?v=3.2.0-rc16"></script>
+    <script src="/beatify/static/js/party-lights.min.js?v=3.2.0-rc16"></script>
+    <script src="/beatify/static/js/tts-settings.js?v=3.2.0-rc16"></script>
 </body>
 </html>

--- a/custom_components/beatify/www/js/wizard.js
+++ b/custom_components/beatify/www/js/wizard.js
@@ -482,8 +482,19 @@ function _renderGameMode() {
         chosenDuration = val;
         _renderGameMode();
     });
-    _renderChipGroup('wiz-language', LANGUAGES, chosenLanguage, (val) => {
+    _renderChipGroup('wiz-language', LANGUAGES, chosenLanguage, async (val) => {
         chosenLanguage = val;
+        // Switch the UI language immediately so the user sees the wizard in the
+        // language they just picked. Without this, "Ansagesprache" only took
+        // effect after the wizard closed + the page reloaded.
+        if (typeof window !== 'undefined' && window.BeatifyI18n && typeof window.BeatifyI18n.setLanguage === 'function') {
+            try {
+                await window.BeatifyI18n.setLanguage(val);
+                if (typeof window.BeatifyI18n.initPageTranslations === 'function') {
+                    window.BeatifyI18n.initPageTranslations();
+                }
+            } catch (e) { console.warn('[Beatify] language switch failed:', e); }
+        }
         _renderGameMode();
     });
     _renderGameModes();


### PR DESCRIPTION
## Summary
Picking Deutsch / Español / Français / Nederlands on wizard Step 4 only updated \`chosenLanguage\` in wizard state — no call to \`BeatifyI18n.setLanguage()\`. The UI stayed in English for the rest of the wizard and only switched on the next page load.

## Fix
Chip click now:
1. Updates \`chosenLanguage\`
2. Calls \`BeatifyI18n.setLanguage(val)\` (fetches locale file)
3. Calls \`initPageTranslations()\` (re-renders \`data-i18n\` elements)
4. Re-renders the game-mode step (difficulty chip labels + hint + mode cards)

## Test plan
- [ ] On Step 4, click Deutsch → wizard title becomes "Wie möchtest du spielen?", difficulty hint becomes "Ausgewogen: 10 Punkte ..."