### PR TITLE
fix: wizard description i18n + join-as-player race (v3.2.0-rc22)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to Beatify are documented here. For detailed release notes, 
 
 ## [Unreleased]
 
+## [3.2.0-rc22] - 2026-04-18
+
+### Fixed
+- **Wizard descriptions didn't translate on language change.** The `_t()` helper in `wizard.js` called `window.BeatifyI18n.translate()` — a method that doesn't exist on the i18n module (it only exports `t()`). So every dynamically-rendered description (game-mode hints on Step 4, difficulty hint, Party Lights desc, TTS announcement desc on Step 5) silently fell through to the English fallback regardless of the selected language. The language-switch handler was already re-rendering; it just couldn't reach the new strings. One-character fix: `translate` → `t`.
+- **"Join as player" on home-view could error with "No active game found".** `handleAdminJoin`'s home-mode fast-path required `adminWs.readyState === OPEN`. When the socket was mid-reconnect (fresh load race, transient disconnect), the flow fell through to the legacy `/beatify/play` redirect branch — which errored with `alert("No active game found")` when `currentGame.game_id` was stale, and in the good case navigated away from the home-view (violating the rc18 promise). Now in home-mode we never fall through: if the WS isn't open, we kick `connectAdminWebSocket()`, poll for OPEN (≤5 s), then send the join. On timeout, a clearer `admin.home.wsReconnecting` message replaces the misleading "No active game found" alert. Added the new i18n key across de/en/es/fr/nl.
+
 ## [3.2.0-rc21] - 2026-04-18
 
 ### Fixed

--- a/custom_components/beatify/manifest.json
+++ b/custom_components/beatify/manifest.json
@@ -12,5 +12,5 @@
   "documentation": "https://github.com/mholzi/beatify",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/mholzi/beatify/issues",
-  "version": "3.2.0-rc21"
+  "version": "3.2.0-rc22"
 }

--- a/custom_components/beatify/server/base.py
+++ b/custom_components/beatify/server/base.py
@@ -22,7 +22,7 @@ _LOGGER = logging.getLogger(__name__)
 # We avoid reading manifest.json at runtime because HA imports custom components
 # inside the event loop, and any file I/O (even at module level) triggers
 # blocking call warnings in HA 2026.2+.
-_VERSION = "3.2.0-rc21"
+_VERSION = "3.2.0-rc22"
 
 
 def _get_version() -> str:

--- a/custom_components/beatify/www/i18n/de.json
+++ b/custom_components/beatify/www/i18n/de.json
@@ -412,7 +412,8 @@
       "setupSub": "Dauert etwa 2 Minuten. Wir führen dich durch Lautsprecher, Musikdienst, Playlists und Spielmodus.",
       "startSetup": "Einrichtung starten",
       "requestNew": "+ Neue Playlist anfragen",
-      "needPlayerToStart": "Als Spieler beitreten (oder Gäste lassen den QR-Code scannen), bevor das Spiel beginnt."
+      "needPlayerToStart": "Als Spieler beitreten (oder Gäste lassen den QR-Code scannen), bevor das Spiel beginnt.",
+      "wsReconnecting": "Verbindung zum Spielserver wird wiederhergestellt – bitte erneut versuchen."
     }
   },
   "analyticsDashboard": {

--- a/custom_components/beatify/www/i18n/en.json
+++ b/custom_components/beatify/www/i18n/en.json
@@ -412,7 +412,8 @@
       "setupSub": "Takes about 2 minutes. We'll walk you through speakers, music service, playlists, and game mode.",
       "startSetup": "Start setup",
       "requestNew": "+ Request new playlist",
-      "needPlayerToStart": "Join as player (or ask a guest to scan the QR) before starting."
+      "needPlayerToStart": "Join as player (or ask a guest to scan the QR) before starting.",
+      "wsReconnecting": "Reconnecting to game server — please try again."
     }
   },
   "analyticsDashboard": {

--- a/custom_components/beatify/www/i18n/es.json
+++ b/custom_components/beatify/www/i18n/es.json
@@ -412,7 +412,8 @@
       "setupSub": "Unos 2 minutos. Te guiamos por altavoces, servicio de música, listas y modo de juego.",
       "startSetup": "Empezar configuración",
       "requestNew": "+ Solicitar nueva lista",
-      "needPlayerToStart": "Únete como jugador (o pide a un invitado que escanee el QR) antes de empezar."
+      "needPlayerToStart": "Únete como jugador (o pide a un invitado que escanee el QR) antes de empezar.",
+      "wsReconnecting": "Reconectando con el servidor del juego — inténtalo de nuevo."
     }
   },
   "analyticsDashboard": {

--- a/custom_components/beatify/www/i18n/fr.json
+++ b/custom_components/beatify/www/i18n/fr.json
@@ -412,7 +412,8 @@
       "setupSub": "Environ 2 minutes. On te guide à travers enceintes, service musical, playlists et mode de jeu.",
       "startSetup": "Commencer la configuration",
       "requestNew": "+ Demander une playlist",
-      "needPlayerToStart": "Rejoins la partie (ou demande à un invité de scanner le QR) avant de commencer."
+      "needPlayerToStart": "Rejoins la partie (ou demande à un invité de scanner le QR) avant de commencer.",
+      "wsReconnecting": "Reconnexion au serveur de jeu — réessaie."
     }
   },
   "analyticsDashboard": {

--- a/custom_components/beatify/www/i18n/nl.json
+++ b/custom_components/beatify/www/i18n/nl.json
@@ -412,7 +412,8 @@
       "setupSub": "Duurt ongeveer 2 minuten. We leiden je door luidsprekers, muziekdienst, afspeellijsten en spelmodus.",
       "startSetup": "Setup starten",
       "requestNew": "+ Nieuwe afspeellijst aanvragen",
-      "needPlayerToStart": "Doe mee als speler (of laat een gast de QR scannen) voordat je begint."
+      "needPlayerToStart": "Doe mee als speler (of laat een gast de QR scannen) voordat je begint.",
+      "wsReconnecting": "Opnieuw verbinden met de spelserver — probeer het opnieuw."
     }
   },
   "analyticsDashboard": {

--- a/custom_components/beatify/www/js/admin.js
+++ b/custom_components/beatify/www/js/admin.js
@@ -2335,21 +2335,46 @@ function handleAdminJoin() {
     // game_state.players + set_admin). State broadcast then feeds back
     // through handleAdminStateUpdate → showLobbyView → BeatifyHome.renderSession
     // so the admin shows up in the player list without navigating away.
-    if (inHomeMode && wsOpen) {
-        try {
-            sessionStorage.setItem('beatify_admin_name', name);
-            sessionStorage.setItem('beatify_is_admin', 'true');
-            adminPlayerName = name;
-            adminWs.send(JSON.stringify({
-                type: 'join',
-                name: name,
-                is_admin: true,
-            }));
-            closeAdminJoinModal();
-        } catch (err) {
-            console.error('Admin join (home-mode) failed:', err);
-            joinBtn.disabled = false;
-            joinBtn.textContent = BeatifyI18n.t('admin.join');
+    if (inHomeMode) {
+        const sendJoin = () => {
+            try {
+                sessionStorage.setItem('beatify_admin_name', name);
+                sessionStorage.setItem('beatify_is_admin', 'true');
+                adminPlayerName = name;
+                adminWs.send(JSON.stringify({
+                    type: 'join',
+                    name: name,
+                    is_admin: true,
+                }));
+                closeAdminJoinModal();
+            } catch (err) {
+                console.error('Admin join (home-mode) failed:', err);
+                joinBtn.disabled = false;
+                joinBtn.textContent = BeatifyI18n.t('admin.join');
+            }
+        };
+        if (wsOpen) {
+            sendJoin();
+        } else {
+            // WS not yet open — page just loaded, or auto-reconnect is in flight.
+            // Do NOT fall through to the legacy /play redirect: that breaks the
+            // "admin stays on home-view" promise and surfaces "No active game
+            // found" when currentGame.game_id is stale. Instead, nudge the WS
+            // open and send the join once it's ready.
+            connectAdminWebSocket();
+            const startedAt = Date.now();
+            const poll = setInterval(() => {
+                if (adminWs && adminWs.readyState === WebSocket.OPEN) {
+                    clearInterval(poll);
+                    sendJoin();
+                } else if (Date.now() - startedAt > 5000) {
+                    clearInterval(poll);
+                    joinBtn.disabled = false;
+                    joinBtn.textContent = BeatifyI18n.t('admin.join');
+                    showError(BeatifyI18n.t('admin.home.wsReconnecting') ||
+                        'Reconnecting to game server — please try again.');
+                }
+            }, 100);
         }
         return;
     }

--- a/custom_components/beatify/www/js/wizard.js
+++ b/custom_components/beatify/www/js/wizard.js
@@ -109,8 +109,8 @@ let chosenTtsAnnounceWinner = true;
 const TOTAL_STEPS = 5; // 1:speakers 2:music 3:playlist 4:game-mode 5:level-up (+ done frame)
 
 function _t(key, fallback) {
-    if (typeof window !== 'undefined' && window.BeatifyI18n && typeof window.BeatifyI18n.translate === 'function') {
-        return window.BeatifyI18n.translate(key) || fallback;
+    if (typeof window !== 'undefined' && window.BeatifyI18n && typeof window.BeatifyI18n.t === 'function') {
+        return window.BeatifyI18n.t(key) || fallback;
     }
     return fallback;
 }


### PR DESCRIPTION
## Summary

Two fixes shipped as **v3.2.0-rc22**:

1. **Wizard descriptions didn't translate on language change.** `wizard.js`'s `_t()` helper called `window.BeatifyI18n.translate()` — a method that doesn't exist on the i18n module (it only exports `t()`). So every dynamically-rendered description (game-mode hints on Step 4, difficulty hint, Party Lights desc, TTS announcement desc on Step 5) silently fell through to the English fallback regardless of the selected language. One-character fix: `translate` → `t`.

2. **"Join as player" on home-view could error with "No active game found".** `handleAdminJoin`'s home-mode fast-path required `adminWs.readyState === OPEN`. When the socket was mid-reconnect (fresh load race, transient disconnect), it fell through to the legacy `/beatify/play` redirect branch — which errored with `alert("No active game found")` when `currentGame.game_id` was stale, and in the good case navigated away from the home-view (breaking the rc18 promise). Now in home-mode we never fall through: if the WS isn't open, we kick `connectAdminWebSocket()`, poll for OPEN (≤5s), then send the join. On timeout a clearer `admin.home.wsReconnecting` message replaces the misleading alert. New i18n key added to de/en/es/fr/nl.

Bumps `manifest.json` + `server/base.py` `_VERSION` → `3.2.0-rc22`, plus CHANGELOG entry.

## Test plan

- [ ] Fresh admin load → open wizard → Step 4 → switch language chip → game-mode hints, difficulty hint update to new locale
- [ ] Wizard Step 5 → switch language → Party Lights + TTS descriptions update
- [ ] Home-view → click "Als Spieler beitreten" right after page load (WS still connecting) → enter name → join completes without "No active game found" alert, admin stays on home-view and appears in player list
- [ ] Home-view with WS force-closed for >5s → click join → see `wsReconnecting` message instead of "No active game found"
- [ ] Happy path: normal join on established session still works, admin shows up as player chip

🤖 Generated with [Claude Code](https://claude.com/claude-code)