### PR TITLE
feat: auto player-view + prominent chips + slim admin bar (v3.2.0-rc23)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to Beatify are documented here. For detailed release notes, 
 
 ## [Unreleased]
 
+## [3.2.0-rc23] - 2026-04-18
+
+### Changed
+- **Admin who joined as player auto-flips to the player UI on PLAYING.** Previously, after "Join as player" → Start game, the admin still saw the admin-playing view (blurred art, countdown, control bar) and had to click "Player View →" to actually play. Now `handleAdminStateUpdate` detects `adminPlayerName` at the LOBBY → PLAYING transition and calls `handleSwitchToPlayerView()` automatically. The admin still retains control via the slim admin-control-bar baked into `player.html`.
+- **Home-view player chips made prominent; admin gets pink "leader" treatment.** Chip padding bumped 4/10 → 8/14, font-size `xs` → `base`, border `1px/40%` → `1.5px/55%`, added soft cyan box-shadow. New `.home-player-chip--admin` modifier renders the host with pink primary accent + `--glow-primary` + 👑 (reuses the existing `.admin-badge` pattern). Row gap and max-width bumped to accommodate the bigger chips. Follows DESIGN.md: pink reserved for "leader highlights, primary CTAs".
+- **Removed `+10s` and `Lights` buttons from the admin control bar.** The bar now matches `player.html`'s slim variant (Stop / Down / Up / Skip / End). Orphan `adminSeekForward()` handler deleted along with the event wiring.
+
 ## [3.2.0-rc22] - 2026-04-18
 
 ### Fixed

--- a/custom_components/beatify/manifest.json
+++ b/custom_components/beatify/manifest.json
@@ -12,5 +12,5 @@
   "documentation": "https://github.com/mholzi/beatify",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/mholzi/beatify/issues",
-  "version": "3.2.0-rc22"
+  "version": "3.2.0-rc23"
 }

--- a/custom_components/beatify/server/base.py
+++ b/custom_components/beatify/server/base.py
@@ -22,7 +22,7 @@ _LOGGER = logging.getLogger(__name__)
 # We avoid reading manifest.json at runtime because HA imports custom components
 # inside the event loop, and any file I/O (even at module level) triggers
 # blocking call warnings in HA 2026.2+.
-_VERSION = "3.2.0-rc22"
+_VERSION = "3.2.0-rc23"
 
 
 def _get_version() -> str:

--- a/custom_components/beatify/www/admin.html
+++ b/custom_components/beatify/www/admin.html
@@ -845,14 +845,6 @@
                 <span class="control-icon">⏭️</span>
                 <span class="control-label" data-i18n="admin.skipRound">Skip</span>
             </button>
-            <button id="admin-seek-forward" class="control-btn" type="button">
-                <span class="control-icon">⏩</span>
-                <span class="control-label">+10s</span>
-            </button>
-            <button id="admin-stop-lights" class="control-btn" type="button">
-                <span class="control-icon">🔦</span>
-                <span class="control-label" data-i18n="admin.stopLights">Lights</span>
-            </button>
             <button id="admin-end-game-playing" class="control-btn control-btn--danger" type="button">
                 <span class="control-icon">🛑</span>
                 <span class="control-label" data-i18n="admin.end">End</span>

--- a/custom_components/beatify/www/css/styles.css
+++ b/custom_components/beatify/www/css/styles.css
@@ -9884,26 +9884,47 @@ body.home-mode .home-view {
     z-index: 1;
     display: flex;
     flex-wrap: wrap;
-    gap: var(--space-xs);
+    gap: var(--space-sm);
     justify-content: center;
-    max-width: 320px;
+    max-width: 360px;
 }
 .home-players:empty { display: none; }
 .home-player-chip {
-    padding: 4px 10px;
-    background: rgba(0, 245, 255, 0.1);
-    border: 1px solid rgba(0, 245, 255, 0.4);
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-xs);
+    padding: 8px 14px;
+    background: rgba(0, 245, 255, 0.12);
+    border: 1.5px solid rgba(0, 245, 255, 0.55);
     border-radius: var(--radius-full);
     font-family: var(--font-display);
     font-weight: 600;
-    font-size: var(--font-size-xs);
+    font-size: var(--font-size-base);
     color: var(--color-accent-secondary);
+    box-shadow: 0 0 10px rgba(0, 245, 255, 0.2);
+}
+/* Admin/host chip — pink primary + glow per DESIGN.md "leader highlights". */
+.home-player-chip--admin {
+    background: rgba(255, 45, 106, 0.14);
+    border-color: rgba(255, 45, 106, 0.7);
+    color: var(--color-accent-primary);
+    font-weight: 700;
+    box-shadow: var(--glow-primary);
+}
+.home-player-chip--admin .admin-badge {
+    margin-left: 0;
+    color: var(--color-accent-primary);
+    filter: drop-shadow(0 0 4px rgba(255, 45, 106, 0.6));
 }
 .home-player-chip.waiting {
     border-style: dashed;
+    border-width: 1px;
     border-color: var(--color-border-neon);
     background: transparent;
     color: var(--color-text-dim);
+    font-size: var(--font-size-sm);
+    font-weight: 500;
+    box-shadow: none;
 }
 
 .home-meta {

--- a/custom_components/beatify/www/js/admin.js
+++ b/custom_components/beatify/www/js/admin.js
@@ -327,9 +327,19 @@ document.addEventListener('DOMContentLoaded', async () => {
                 el.innerHTML = '<span class="home-player-chip waiting">Waiting for guests…</span>';
                 return;
             }
-            el.innerHTML = players.map((p) =>
-                `<span class="home-player-chip">${p.name || p.id}</span>`
-            ).join('');
+            // Admin chip gets the pink-primary treatment + 👑 (reuses the
+            // existing .admin-badge pattern from the legacy lobby/end views)
+            // to mark the host as the leader of the room. Regular guests stay
+            // on the cyan accent so the host reads as "the one in charge".
+            el.innerHTML = players.map((p) => {
+                const cls = p.is_admin
+                    ? 'home-player-chip home-player-chip--admin'
+                    : 'home-player-chip';
+                const crown = p.is_admin
+                    ? '<span class="admin-badge" aria-hidden="true">👑</span>'
+                    : '';
+                return `<span class="${cls}">${crown}${p.name || p.id}</span>`;
+            }).join('');
         },
         // Fetch playlist-build requests and show/hide the pill. Tap-to-open
         // renders into the inline modal (stays in home-mode). "Manage in admin"
@@ -518,15 +528,9 @@ document.addEventListener('DOMContentLoaded', async () => {
 
     // Issue #477: Wire game phase control buttons
     document.getElementById('admin-stop-song')?.addEventListener('click', adminStopSong);
-    document.getElementById('admin-seek-forward')?.addEventListener('click', adminSeekForward);
     document.getElementById('admin-vol-down')?.addEventListener('click', adminVolumeDown);
     document.getElementById('admin-vol-up')?.addEventListener('click', adminVolumeUp);
     document.getElementById('admin-end-game-playing')?.addEventListener('click', endGame);
-    document.getElementById('admin-stop-lights')?.addEventListener('click', function() {
-        if (adminWs && adminWs.readyState === WebSocket.OPEN) {
-            adminWs.send(JSON.stringify({ type: 'admin', action: 'stop_lights' }));
-        }
-    });
     document.getElementById('admin-next-round')?.addEventListener('click', adminNextRound);
     document.getElementById('admin-skip-round')?.addEventListener('click', adminNextRound);
     document.getElementById('admin-confirm-intro')?.addEventListener('click', function() {
@@ -3337,6 +3341,14 @@ function handleAdminStateUpdate(data) {
             showLobbyView(data);
             break;
         case 'PLAYING':
+            // If the admin has joined as a player, flip them to the player UI
+            // automatically instead of staying on the admin-playing view. The
+            // player page carries its own slim admin-control-bar, so control
+            // isn't lost — and the "Admin View" exit is available on /play.
+            if (adminPlayerName && currentGame && currentGame.game_id) {
+                handleSwitchToPlayerView();
+                return;
+            }
             showAdminPlayingView(data);
             break;
         case 'REVEAL':
@@ -3836,10 +3848,6 @@ function adminNextRound() {
 
 function adminStopSong() {
     sendAdminCommand({ type: 'admin', action: 'stop_song' });
-}
-
-function adminSeekForward() {
-    sendAdminCommand({ type: 'admin', action: 'seek_forward', seconds: 10 });
 }
 
 function adminVolumeUp() {


### PR DESCRIPTION
## Summary

Three changes shipped as **v3.2.0-rc23**:

1. **Admin auto-flips to player view on PLAYING** when they joined as a player. Previously the admin had to click "Player View →" after Start game; now `handleAdminStateUpdate` detects `adminPlayerName` at the LOBBY → PLAYING transition and calls `handleSwitchToPlayerView()` automatically. Host control isn't lost — the slim admin-control-bar on \`player.html\` stays.

2. **Home-view player chips made prominent + admin gets the "leader" treatment.** Padding 4/10 → 8/14, font-size xs → base, border 1px/40% → 1.5px/55%, soft cyan box-shadow. New \`.home-player-chip--admin\` modifier paints the host in pink primary with \`--glow-primary\` and a 👑 (reuses the existing \`.admin-badge\` pattern). Row gap/max-width bumped for the bigger chips. Follows DESIGN.md: pink = "leader highlights".

3. **Removed `+10s` and `Lights`** from the admin-playing control bar — now mirrors \`player.html\`'s slim variant (Stop / Down / Up / Skip / End). Orphan \`adminSeekForward()\` handler deleted.

Bumps \`manifest.json\` + \`server/base.py\` \`_VERSION\` → \`3.2.0-rc23\`.

## Test plan

- [ ] Home-view lobby shows prominent pink admin chip with 👑; guests render cyan
- [ ] Admin joins as player → clicks Start game → auto-navigates to \`/beatify/play\` and sees the player quiz UI
- [ ] Admin who didn't join stays on admin-playing view when game starts (no redirect)
- [ ] Admin-playing control bar shows only Stop / Down / Up / Skip / End (no +10s, no Lights)
- [ ] On \`/play\`, the slim admin-control-bar still works for admin-players

🤖 Generated with [Claude Code](https://claude.com/claude-code)