### PR TITLE
fix: Revanche returns to home-view + Step 4 i18n + oversized Join CTA (v3.2.0-rc24)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to Beatify are documented here. For detailed release notes, 
 
 ## [Unreleased]
 
+## [3.2.0-rc24] - 2026-04-18
+
+### Fixed
+- **Revanche landed on the legacy admin lobby instead of the home-view.** The LOBBY → PLAYING transition calls `BeatifyHome.exit()` to drop `home-mode`, but there was no symmetric re-entry when a rematch created a new LOBBY. `showLobbyView`'s home-mode gate therefore failed and rendered `#lobby-section` (the pre-rc12 inline form) instead of the home-view. `handleAdminStateUpdate` now calls `BeatifyHome.enter()` whenever state comes back as LOBBY and `home-mode` isn't set — so Revanche drops the admin back on the QR + player chips, matching the original post-wizard landing. Restart still reopens the wizard (intentional: Restart = fresh incl. new playlist selection).
+- **Wizard Step 4 difficulty chips didn't translate.** `DIFFICULTIES` in `wizard.js` pointed its labels at `wizard.step3.easy/normal/hard` — but difficulty is a Step 4 feature and those keys only exist under `wizard.step4` in all 5 locales. Non-English users always saw the English fallbacks ("Easy / Normal / Hard"). One-line fix: `step3` → `step4`.
+
+### Changed
+- **"Join as player" CTA oversized.** Vertical padding `md` → `lg`, font-size `base` → `xl` + weight 700, radius `xl`, glow pushed 40 → 48 px at 30% alpha, icon 18 → 26 px with thicker stroke. The single most important action on the home-view now reads as such.
+
 ## [3.2.0-rc23] - 2026-04-18
 
 ### Changed

--- a/custom_components/beatify/manifest.json
+++ b/custom_components/beatify/manifest.json
@@ -12,5 +12,5 @@
   "documentation": "https://github.com/mholzi/beatify",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/mholzi/beatify/issues",
-  "version": "3.2.0-rc23"
+  "version": "3.2.0-rc24"
 }

--- a/custom_components/beatify/server/base.py
+++ b/custom_components/beatify/server/base.py
@@ -22,7 +22,7 @@ _LOGGER = logging.getLogger(__name__)
 # We avoid reading manifest.json at runtime because HA imports custom components
 # inside the event loop, and any file I/O (even at module level) triggers
 # blocking call warnings in HA 2026.2+.
-_VERSION = "3.2.0-rc23"
+_VERSION = "3.2.0-rc24"
 
 
 def _get_version() -> str:

--- a/custom_components/beatify/www/css/styles.css
+++ b/custom_components/beatify/www/css/styles.css
@@ -9963,17 +9963,26 @@ body.home-mode .home-view {
 .home-cta-start.btn-ghost { box-shadow: none; flex: 0 0 auto; }
 
 /* Prominent Join-as-player CTA — lives above the Back/Start row inside the
-   home-stage column. Full-width so the admin's next step is unmissable. */
+   home-stage column. Full-width + oversized so the admin's next step is
+   unmissable (it's the single most important action on the home-view). */
 .home-cta-join {
     width: 100%;
     margin-top: var(--space-md);
-    padding: var(--space-md);
-    font-size: var(--font-size-base);
-    box-shadow: var(--glow-primary), 0 0 40px rgba(255, 45, 106, 0.25);
+    padding: var(--space-lg) var(--space-md);
+    font-size: var(--font-size-xl);
+    font-weight: 700;
+    letter-spacing: 0.02em;
+    border-radius: var(--radius-xl);
+    box-shadow: var(--glow-primary), 0 0 48px rgba(255, 45, 106, 0.3);
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    gap: var(--space-xs);
+    gap: var(--space-sm);
+}
+.home-cta-join svg {
+    width: 26px;
+    height: 26px;
+    stroke-width: 2.25;
 }
 .home-cta-join.hidden { display: none; }
 

--- a/custom_components/beatify/www/js/admin.js
+++ b/custom_components/beatify/www/js/admin.js
@@ -3335,6 +3335,14 @@ function handleAdminStateUpdate(data) {
     if (data.phase && data.phase !== 'LOBBY' && window.BeatifyHome) {
         window.BeatifyHome.exit();
     }
+    // Symmetric re-entry: rematch creates a new LOBBY after END. home-mode
+    // was exited on LOBBY → PLAYING, so if we're coming back to LOBBY (e.g.
+    // Revanche), restore it so the admin lands back on the home-view (QR +
+    // player chips) instead of the legacy #lobby-section.
+    if (data.phase === 'LOBBY' && window.BeatifyHome &&
+        !document.body.classList.contains('home-mode')) {
+        window.BeatifyHome.enter();
+    }
 
     switch (data.phase) {
         case 'LOBBY':

--- a/custom_components/beatify/www/js/wizard.js
+++ b/custom_components/beatify/www/js/wizard.js
@@ -356,9 +356,9 @@ function _renderPlaylists() {
 }
 
 const DIFFICULTIES = [
-    { id: 'easy', labelKey: 'wizard.step3.easy', labelFallback: 'Easy' },
-    { id: 'normal', labelKey: 'wizard.step3.normal', labelFallback: 'Normal' },
-    { id: 'hard', labelKey: 'wizard.step3.hard', labelFallback: 'Hard' },
+    { id: 'easy', labelKey: 'wizard.step4.easy', labelFallback: 'Easy' },
+    { id: 'normal', labelKey: 'wizard.step4.normal', labelFallback: 'Normal' },
+    { id: 'hard', labelKey: 'wizard.step4.hard', labelFallback: 'Hard' },
 ];
 
 // Mirrors DIFFICULTY_SCORING in custom_components/beatify/const.py — keep in sync.


### PR DESCRIPTION
## Summary

**v3.2.0-rc24** — one bug fix, one i18n typo, one prominence bump.

### Fixed
1. **Revanche landed on the legacy admin lobby.** `home-mode` was exited at LOBBY → PLAYING but never re-entered, so when rematch created a new LOBBY, `showLobbyView`'s home-mode gate failed and rendered the pre-rc12 `#lobby-section`. Added a symmetric re-entry in \`handleAdminStateUpdate\`: if phase is LOBBY and \`home-mode\` isn't set, call \`BeatifyHome.enter()\`. Restart is **unchanged** — intentionally reopens the wizard because Restart = fresh game incl. new playlist selection, whereas Revanche = same playlist + same players.
2. **Wizard Step 4 difficulty chips fell back to English in every locale.** \`DIFFICULTIES\` in \`wizard.js\` pointed at \`wizard.step3.easy/normal/hard\` — but difficulty is a Step 4 feature and those keys only exist under \`wizard.step4\` in all 5 locales. One-line fix: \`step3\` → \`step4\`.

### Changed
- **"Join as player" CTA oversized.** Padding md → lg, font-size base → xl + weight 700, radius xl, glow 40 → 48 px at 30% alpha, icon 18 → 26 px with thicker stroke.

Bumps manifest.json + server/base.py to \`3.2.0-rc24\`.

## Test plan
- [ ] Run a full game → END → press **Revanche** → lands on home-view with QR + player chips (not the legacy lobby form)
- [ ] Run a full game → END → press **Start New Game** → reopens wizard at Step 1 pre-hydrated (unchanged behavior)
- [ ] Wizard Step 4 in Deutsch → chips read "Leicht / Normal / Schwer" (not English fallbacks)
- [ ] Home-view "Als Spieler beitreten" CTA is clearly the dominant action on the screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)