### PR TITLE
chore: remove legacy admin lobby (v3.2.0-rc25)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to Beatify are documented here. For detailed release notes, 
 
 ## [Unreleased]
 
+## [3.2.0-rc25] - 2026-04-18
+
+### Removed
+- **Legacy admin lobby dropped.** The pre-rc12 `#lobby-section` + `#existing-game-section` markup and all associated rendering logic have been deleted. After rc24 made the home-view the canonical LOBBY landing for every admin flow (initial creation + Revanche + reload), the legacy section had no reachable call path. Total: ~376 lines removed across `admin.html`, `admin.js`, `styles.css`.
+  - `showLobbyView` is now a thin delegate to `BeatifyHome.renderSession` (keeps the WS-disconnect REST-polling fallback so home-view chips stay fresh).
+  - Dead functions deleted: `showExistingGameView`, `rejoinGame`.
+  - Dead event wiring removed: `#rejoin-game`, `#end-game-existing`, `#start-gameplay-btn`, `#participate-btn`.
+  - `setupQRModal()` stopped binding `#admin-qr-container` (gone) and is now called once at init instead of on every LOBBY state push — fixes an incidental leak that attached a new document-level escape listener per WS update.
+
+### Kept
+- **Shared with `player.html`:** `.lobby-container`, `.lobby-container--compact`, `.lobby-header-compact`, `.lobby-actions`, `.lobby-actions--sticky`, `.stat-badge-bar`, `.qr-section`, `.qr-section--compact`. These CSS rules stay — they dress the player-page lobby.
+
 ## [3.2.0-rc24] - 2026-04-18
 
 ### Fixed

--- a/custom_components/beatify/manifest.json
+++ b/custom_components/beatify/manifest.json
@@ -12,5 +12,5 @@
   "documentation": "https://github.com/mholzi/beatify",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/mholzi/beatify/issues",
-  "version": "3.2.0-rc24"
+  "version": "3.2.0-rc25"
 }

--- a/custom_components/beatify/server/base.py
+++ b/custom_components/beatify/server/base.py
@@ -22,7 +22,7 @@ _LOGGER = logging.getLogger(__name__)
 # We avoid reading manifest.json at runtime because HA imports custom components
 # inside the event loop, and any file I/O (even at module level) triggers
 # blocking call warnings in HA 2026.2+.
-_VERSION = "3.2.0-rc24"
+_VERSION = "3.2.0-rc25"
 
 
 def _get_version() -> str:

--- a/custom_components/beatify/www/admin.html
+++ b/custom_components/beatify/www/admin.html
@@ -163,9 +163,9 @@
             </div>
         </div>
 
-        <!-- Home view — Variant A "QR Hero" aesthetic applied to the pre-session lobby landing.
+        <!-- Home view — canonical pre-session LOBBY landing.
              Shown when setup is complete (wizard just finished OR returning configured user).
-             Toggled via body.home-mode class. Real QR + players appear in #lobby-section after Start. -->
+             Toggled via body.home-mode class. Handles initial LOBBY + Revanche. -->
         <section id="home-view" class="home-view hidden" aria-labelledby="home-view-heading">
             <h2 id="home-view-heading" class="sr-only">Home</h2>
             <div class="home-stage">
@@ -623,98 +623,6 @@
             <p id="playlist-validation-msg" class="status-error hidden" data-i18n="admin.selectPlaylistHint">Select at least one playlist</p>
             <button id="start-game" class="btn btn-primary btn-large btn-full-width hidden" disabled data-i18n="admin.startGame">Start Game</button>
         </div>
-
-        <!-- Lobby view (Story 2.3, mobile-optimized compact layout) -->
-        <div id="lobby-section" class="lobby-view-wrapper hidden">
-            <div class="lobby-container lobby-container--compact">
-                <!-- Header with inline stat badges -->
-                <div class="lobby-header-compact">
-                    <h2 class="section-header section-header--inline">
-                        <span class="section-icon" aria-hidden="true">🎮</span>
-                        <span data-i18n="lobby.gameLobby">Game Lobby</span>
-                    </h2>
-                    <div class="stat-badge-bar" aria-live="polite">
-                        <span class="stat-badge">
-                            <span class="stat-badge-icon" aria-hidden="true">👥</span>
-                            <span id="lobby-player-count" class="stat-badge-value">0</span>
-                        </span>
-                        <!-- Difficulty Badge -->
-                        <span id="lobby-difficulty-badge" class="stat-badge stat-badge--difficulty"></span>
-                    </div>
-                </div>
-
-                <!-- Invite Friends Section - Expanded by default for admin -->
-                <section class="section-collapsible" id="qr-section">
-                    <button type="button" class="section-header-collapsible" aria-expanded="true" aria-controls="qr-content">
-                        <span class="section-icon" aria-hidden="true">📲</span>
-                        <span data-i18n="lobby.inviteFriends">Invite Friends</span>
-                        <span class="section-toggle" aria-hidden="true">▼</span>
-                    </button>
-                    <div class="section-content" id="qr-content">
-                        <div class="qr-section qr-section--compact">
-                            <div class="qr-container" id="admin-qr-container" role="button" tabindex="0"
-                                 aria-label="Tap to enlarge QR code">
-                                <div id="qr-code"></div>
-                            </div>
-                            <p id="join-url" class="qr-url-display qr-url-display--compact"></p>
-                            <!-- Inline dashboard link -->
-                            <a href="#" id="admin-dashboard-url" class="dashboard-link" target="_blank">
-                                <span aria-hidden="true">📺</span>
-                                <span data-i18n="dashboard.castToTv">Cast to TV</span>
-                                <span class="dashboard-link-arrow" aria-hidden="true">→</span>
-                            </a>
-                        </div>
-                    </div>
-                </section>
-
-                <!-- Players Section - Collapsible -->
-                <section class="section-collapsible" id="admin-players-section">
-                    <button type="button" class="section-header-collapsible" aria-expanded="true" aria-controls="admin-players-content">
-                        <span class="section-icon" aria-hidden="true">👥</span>
-                        <span data-i18n="lobby.playersInLobby">Players in Lobby</span>
-                        <span class="section-summary" id="admin-players-summary">0</span>
-                        <span class="section-toggle" aria-hidden="true">▼</span>
-                    </button>
-                    <div class="section-content" id="admin-players-content">
-                        <div id="lobby-players" class="player-cards-grid" aria-live="polite" aria-label="Player list">
-                            <!-- Rendered dynamically by renderLobbyPlayers() -->
-                        </div>
-                        <p id="lobby-players-empty" class="empty-state-inline">
-                            <span aria-hidden="true">👥</span>
-                            <span data-i18n="lobby.waitingForPlayers">Waiting for players to join...</span>
-                        </p>
-                    </div>
-                </section>
-
-                <!-- Sticky Lobby Actions -->
-                <div class="lobby-actions lobby-actions--sticky">
-                    <!-- Start Gameplay: transitions LOBBY → PLAYING without requiring admin to join as player (Issue #228) -->
-                    <button id="start-gameplay-btn" class="btn btn-primary btn-large btn-full-width hidden">
-                        <span class="btn-icon" aria-hidden="true">▶️</span>
-                        <span data-i18n="admin.startGameplay">Spiel starten</span>
-                    </button>
-                    <button id="participate-btn" class="btn btn-secondary btn-large btn-full-width">
-                        <span class="btn-icon" aria-hidden="true">🎮</span>
-                        <span data-i18n="admin.joinAsPlayer">Join as Player</span>
-                    </button>
-                </div>
-            </div>
-        </div>
-
-        <!-- Existing game view (Story 2.3) -->
-        <section id="existing-game-section" class="card-section hidden">
-            <h2 class="section-header"><span class="section-icon" aria-hidden="true">▶️</span><span data-i18n="admin.gameInProgress">Game In Progress</span></h2>
-            <div class="game-info">
-                <p><strong data-i18n="admin.gameId">Game ID:</strong> <span id="existing-game-id"></span></p>
-                <p><strong data-i18n="admin.phase">Phase:</strong> <span id="existing-game-phase"></span></p>
-                <p><strong data-i18n="admin.players">Players:</strong> <span id="existing-game-players"></span></p>
-            </div>
-            <!-- Regular controls (non-END phase) -->
-            <div id="existing-game-actions" class="game-controls-bar">
-                <button id="rejoin-game" class="btn btn-primary" data-i18n="admin.rejoinGame">Rejoin Game</button>
-                <button id="end-game-existing" class="btn btn-danger" data-i18n="admin.endGame">End Game</button>
-            </div>
-        </section>
 
         <!-- Issue #477: PLAYING phase view -->
         <!-- PLAYING phase view (#653: mirrors player.html game-view layout) -->

--- a/custom_components/beatify/www/css/styles.css
+++ b/custom_components/beatify/www/css/styles.css
@@ -2913,68 +2913,6 @@ body.theme-dark .admin-controls {
     margin-top: var(--space-lg);
 }
 
-/* ==========================================
-   Admin Lobby Dark Theme (Story 16.7)
-   ========================================== */
-
-/* Dark background for admin lobby section - matches player lobby */
-#lobby-section {
-    background: var(--color-bg-primary);
-    color: var(--color-text-white);
-    border-radius: var(--radius-lg);
-}
-
-/* Lobby heading - light text for dark background */
-#lobby-section h2 {
-    color: var(--color-text-white);
-}
-
-/* QR instruction text */
-#lobby-section .qr-instruction {
-    color: var(--color-text-white);
-}
-
-/* Join URL - accent color for visibility */
-#lobby-section .join-url {
-    color: var(--color-accent-secondary);
-}
-
-/* Empty state text (Waiting for players) */
-#lobby-section .empty-state {
-    color: var(--color-text-neon-muted);
-}
-
-/* Player list border - use dark theme border */
-#lobby-section .player-list {
-    border-top-color: var(--color-border-neon);
-}
-
-/* Game controls bar border - use dark theme border */
-#lobby-section .game-controls-bar {
-    border-top-color: var(--color-border-neon);
-}
-
-/* QR container - maintain white background for QR visibility */
-#lobby-section .qr-container {
-    background: var(--color-bg-white);
-    box-shadow: var(--shadow-lg);
-}
-
-/* Player cards in admin lobby - dark theme styling */
-#lobby-section .player-card {
-    background: var(--color-dark-surface);
-    border-color: var(--color-border-neon);
-}
-
-#lobby-section .player-card .player-name {
-    color: var(--color-text-white);
-}
-
-#lobby-section .player-card.is-new {
-    background: rgba(57, 255, 20, 0.1);
-    border-color: var(--color-success-neon);
-}
-
 /* Admin badge styling (Story 16.8) */
 .admin-badge {
     font-size: var(--font-size-sm);
@@ -2998,48 +2936,6 @@ body.theme-dark .admin-controls {
     grid-template-columns: repeat(2, 1fr);
     gap: var(--space-md);
     margin-bottom: var(--space-lg);
-}
-
-/* Stat Card styling for lobby (inherits from analytics pattern) */
-#lobby-section .stat-card {
-    background: rgba(255, 255, 255, 0.05);
-    border: 1px solid var(--color-neon-purple);
-    border-radius: var(--radius-md);
-    padding: var(--space-lg) var(--space-md);
-    text-align: center;
-    transition: transform 0.2s ease, box-shadow 0.2s ease;
-}
-
-#lobby-section .stat-card:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 4px 20px rgba(157, 78, 221, 0.3);
-}
-
-#lobby-section .stat-icon {
-    font-size: 2rem;
-    margin-bottom: var(--space-sm);
-}
-
-#lobby-section .stat-value {
-    font-size: 2.5rem;
-    font-weight: 700;
-    color: var(--color-accent-secondary);
-    font-family: 'Outfit', sans-serif;
-    line-height: 1.1;
-}
-
-#lobby-section .stat-value--small {
-    font-size: 0.875rem;
-    word-break: break-all;
-    line-height: 1.3;
-}
-
-#lobby-section .stat-label {
-    font-size: 0.875rem;
-    color: var(--color-text-neon-muted);
-    margin-top: var(--space-xs);
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
 }
 
 /* Clickable stat card (dashboard link) */
@@ -3209,25 +3105,6 @@ body.theme-dark .admin-controls {
     background: var(--color-error);
     color: white;
     border-color: var(--color-error);
-}
-
-/* Empty state for player list */
-#lobby-section .empty-state {
-    text-align: center;
-    padding: var(--space-xl) var(--space-lg);
-    color: var(--color-text-neon-muted);
-}
-
-#lobby-section .empty-icon {
-    font-size: 3rem;
-    margin-bottom: var(--space-md);
-    opacity: 0.5;
-}
-
-#lobby-section .empty-hint {
-    font-size: 0.875rem;
-    margin-top: var(--space-sm);
-    opacity: 0.7;
 }
 
 /* Lobby Actions */
@@ -3418,13 +3295,6 @@ body.theme-dark .admin-controls {
 
 .lobby-wordmark-header .wordmark {
     font-size: 2rem;
-}
-
-/* Lobby View Wrapper */
-.lobby-view-wrapper {
-    min-height: 100vh;
-    display: flex;
-    flex-direction: column;
 }
 
 /* Compact Lobby Container */
@@ -9740,8 +9610,8 @@ body.wizard-active .modal { z-index: calc(var(--z-overlay) + 10); }
    ========================================== */
 
 /* When body is in home-mode: show the home-view card, hide only the setup/config sections.
-   Runtime views (#lobby-section, #admin-playing-*, #admin-reveal-*, #admin-end-*) stay
-   untouched — home-mode is exited before any of those show anyway. */
+   Runtime views (#admin-playing-*, #admin-reveal-*, #admin-end-*) stay untouched —
+   home-mode is exited before any of those show anyway. */
 body.home-mode #media-players,
 body.home-mode #music-service,
 body.home-mode #playlists,
@@ -9754,8 +9624,8 @@ body.home-mode .admin-content > .admin-actions {
     display: none !important;
 }
 /* Variant A — QR Hero aesthetic for the home-view.
-   Centered stage, glowing hero card, dual CTA bar. QR itself appears in
-   the real #lobby-section after Start game creates the session. */
+   Centered stage, glowing hero card, dual CTA bar. QR + player chips render
+   inline via BeatifyHome.renderSession once Start game creates the session. */
 .home-view { display: none; }
 .home-view.hidden { display: none !important; }
 body.home-mode #home-view,

--- a/custom_components/beatify/www/js/admin.js
+++ b/custom_components/beatify/www/js/admin.js
@@ -261,7 +261,7 @@ document.addEventListener('DOMContentLoaded', async () => {
             const loading = document.getElementById('home-qr-loading');
             if (loading) loading.classList.add('hidden');
 
-            // Render the actual QR using the same library + config as #lobby-section
+            // Render the actual QR using the shared QRCode library.
             const qrContainer = document.getElementById('home-qr-code');
             if (qrContainer && gameData.join_url && typeof QRCode !== 'undefined') {
                 if (qrContainer.dataset.url !== gameData.join_url) {
@@ -514,14 +514,14 @@ document.addEventListener('DOMContentLoaded', async () => {
 
     // Wire event listeners
     document.getElementById('start-game')?.addEventListener('click', startGame);
-    document.getElementById('start-gameplay-btn')?.addEventListener('click', startGameplay);
     document.getElementById('print-qr')?.addEventListener('click', printQRCode);
-    document.getElementById('rejoin-game')?.addEventListener('click', rejoinGame);
 
-    // Dashboard URL is now set in showLobbyView() for analytics layout
     document.getElementById('end-game')?.addEventListener('click', endGame);
     document.getElementById('end-game-lobby')?.addEventListener('click', endGame);
-    document.getElementById('end-game-existing')?.addEventListener('click', endGame);
+
+    // QR modal close/backdrop/escape — wired once at init so the home-view
+    // tap-to-enlarge and the admin-playing-view both share the same modal.
+    setupQRModal();
 
     // Admin join setup
     setupAdminJoin();
@@ -1666,8 +1666,6 @@ function showSetupView() {
     }
 
     // Hide other views
-    document.getElementById('lobby-section')?.classList.add('hidden');
-    document.getElementById('existing-game-section')?.classList.add('hidden');
     // Issue #477: Hide game phase views
     document.getElementById('admin-playing-section')?.classList.add('hidden');
     document.getElementById('admin-reveal-section')?.classList.add('hidden');
@@ -1683,97 +1681,21 @@ function showSetupView() {
 }
 
 /**
- * Show lobby view with QR code
- * @param {Object} gameData - Game data from API
+ * Show lobby view — pure delegate to BeatifyHome. The legacy #lobby-section
+ * render was removed in rc25; home-mode is now guaranteed to be on whenever
+ * a LOBBY state arrives (see handleAdminStateUpdate).
  */
 function showLobbyView(gameData) {
     currentView = 'lobby';
     currentGame = gameData;
-
-    // If the user is in home-mode (post-wizard landing), keep them there and
-    // render the real QR + players inline instead of switching to #lobby-section.
-    if (document.body.classList.contains('home-mode') && window.BeatifyHome) {
+    if (window.BeatifyHome) {
         window.BeatifyHome.renderSession(gameData);
-        return;
     }
-
-    // Hide setup sections
-    setupSections.forEach(id => {
-        const el = document.getElementById(id);
-        if (el) el.classList.add('hidden');
-    });
-
-    // Hide start button and validation message (Story 9.10)
-    document.getElementById('start-game')?.classList.add('hidden');
-    document.getElementById('playlist-validation-msg')?.classList.add('hidden');
-
-    // Hide existing game and end views
-    document.getElementById('existing-game-section')?.classList.add('hidden');
-
-    // Show lobby
-    document.getElementById('lobby-section')?.classList.remove('hidden');
-
-    // Generate QR code (only if URL changed) - compact size, CSS scales for desktop
-    const qrContainer = document.getElementById('qr-code');
-    if (qrContainer && gameData.join_url) {
-        if (cachedQRUrl !== gameData.join_url) {
-            qrContainer.innerHTML = '';
-
-            if (typeof QRCode !== 'undefined') {
-                new QRCode(qrContainer, {
-                    text: gameData.join_url,
-                    width: 180,
-                    height: 180,
-                    colorDark: '#000000',
-                    colorLight: '#ffffff',
-                    correctLevel: QRCode.CorrectLevel.M
-                });
-            } else {
-                qrContainer.innerHTML = '<p class="status-error">QR code library not loaded</p>';
-            }
-
-            cachedQRUrl = gameData.join_url;
-        }
-    }
-
-    // Display join URL
-    const urlEl = document.getElementById('join-url');
-    if (urlEl && gameData.join_url) {
-        urlEl.textContent = gameData.join_url;
-    }
-
-    // Update dashboard URL (compact inline link)
-    var dashboardUrl = window.location.origin + '/beatify/dashboard';
-    var dashboardLink = document.getElementById('admin-dashboard-url');
-    if (dashboardLink) {
-        dashboardLink.href = dashboardUrl;
-    }
-
-    // Render initial player list (Story 16.8)
-    renderLobbyPlayers(gameData.players || []);
-    // Issue #477: Use WS push when connected, REST polling as fallback
+    // WS push is the primary source; fall back to REST polling if WS is down
+    // so the home-view chips still update via renderLobbyPlayers → BeatifyHome.renderPlayers.
     if (!adminWs || adminWs.readyState !== WebSocket.OPEN) {
         startLobbyPolling();
     }
-
-    // Update difficulty badge (use gameData.difficulty if available, else selectedDifficulty)
-    updateLobbyDifficultyBadge(gameData.difficulty || selectedDifficulty);
-
-    // Fix #228: Hide participate button if admin is already registered as a player.
-    var participateBtn = document.getElementById('participate-btn');
-    if (participateBtn) {
-        var adminInPlayers = (gameData.players || []).some(function(p) { return p.is_admin; });
-        var adminNameStored = null;
-        try { adminNameStored = sessionStorage.getItem('beatify_admin_name'); } catch(e) {}
-        if (adminInPlayers || adminNameStored || isPlaying) {
-            participateBtn.classList.add('hidden');
-        } else {
-            participateBtn.classList.remove('hidden');
-        }
-    }
-
-    // Setup QR tap-to-enlarge
-    setupQRModal();
 }
 
 // ==========================================
@@ -1824,73 +1746,24 @@ function closeQRModal() {
 }
 
 /**
- * Setup QR modal event handlers
+ * Wire the QR modal once at init. The modal itself is shared between the
+ * home-view tap-to-enlarge (BeatifyHome triggers openQRModal) and the
+ * admin-playing view's QR preview, so only backdrop/close/escape are wired
+ * here — the triggers live with each view.
  */
 function setupQRModal() {
-    var qrContainer = document.getElementById('admin-qr-container');
     var modal = document.getElementById('qr-modal');
     var backdrop = modal ? modal.querySelector('.qr-modal-backdrop') : null;
     var closeBtn = document.getElementById('qr-modal-close');
 
-    // QR container tap to enlarge
-    if (qrContainer) {
-        qrContainer.addEventListener('click', openQRModal);
-        qrContainer.addEventListener('keydown', function(e) {
-            if (e.key === 'Enter' || e.key === ' ') {
-                e.preventDefault();
-                openQRModal();
-            }
-        });
-    }
+    if (backdrop) backdrop.addEventListener('click', closeQRModal);
+    if (closeBtn) closeBtn.addEventListener('click', closeQRModal);
 
-    if (backdrop) {
-        backdrop.addEventListener('click', closeQRModal);
-    }
-    if (closeBtn) {
-        closeBtn.addEventListener('click', closeQRModal);
-    }
-
-    // Escape key to close
     document.addEventListener('keydown', function(e) {
         if (e.key === 'Escape' && modal && !modal.classList.contains('hidden')) {
             closeQRModal();
         }
     });
-}
-
-/**
- * Show existing game view (for rejoin/end)
- * @param {Object} gameData - Game data from status API
- */
-function showExistingGameView(gameData) {
-    currentView = 'existing-game';
-    currentGame = gameData;
-
-    // Hide setup sections
-    setupSections.forEach(id => {
-        const el = document.getElementById(id);
-        if (el) el.classList.add('hidden');
-    });
-
-    // Hide start button and validation message (Story 9.10)
-    document.getElementById('start-game')?.classList.add('hidden');
-    document.getElementById('playlist-validation-msg')?.classList.add('hidden');
-
-    // Hide lobby and end views
-    document.getElementById('lobby-section')?.classList.add('hidden');
-
-    // Show existing game section
-    document.getElementById('existing-game-section')?.classList.remove('hidden');
-
-    // Update game info
-    const idEl = document.getElementById('existing-game-id');
-    const phaseEl = document.getElementById('existing-game-phase');
-    const playersEl = document.getElementById('existing-game-players');
-
-    if (idEl) idEl.textContent = gameData.game_id || 'Unknown';
-    if (phaseEl) phaseEl.textContent = gameData.phase || 'Unknown';
-    if (playersEl) playersEl.textContent = gameData.player_count ?? 0;
-
 }
 
 // ==========================================
@@ -2183,29 +2056,6 @@ function setupRematchModal() {
 }
 
 /**
- * Rejoin the current game - fetches fresh status first
- */
-async function rejoinGame() {
-    if (!currentGame) return;
-
-    // Fetch fresh status to get latest player list
-    try {
-        var response = await fetch('/beatify/api/status');
-        if (response.ok) {
-            var status = await response.json();
-            if (status.active_game) {
-                currentGame = status.active_game;
-            }
-        }
-    } catch (err) {
-        console.error('Failed to refresh game status:', err);
-    }
-
-    // Show lobby view with current (possibly refreshed) game data
-    showLobbyView(currentGame);
-}
-
-/**
  * Print QR code
  */
 function printQRCode() {
@@ -2278,13 +2128,11 @@ function closeAdminJoinModal() {
  * Setup admin join modal and button handlers
  */
 function setupAdminJoin() {
-    const participateBtn = document.getElementById('participate-btn');
     const cancelBtn = document.getElementById('admin-cancel-btn');
     const joinBtn = document.getElementById('admin-join-btn');
     const nameInput = document.getElementById('admin-name-input');
     const backdrop = document.querySelector('#admin-join-modal .modal-backdrop');
 
-    participateBtn?.addEventListener('click', openAdminJoinModal);
     cancelBtn?.addEventListener('click', closeAdminJoinModal);
     backdrop?.addEventListener('click', closeAdminJoinModal);
 
@@ -3242,8 +3090,6 @@ function handleAdminWsMessage(data) {
                 document.cookie = 'beatify_session=' + data.session_id +
                     ';path=/;max-age=86400;SameSite=Strict';
             }
-            // Hide "Join as Player" button since admin is now a player
-            document.getElementById('participate-btn')?.classList.add('hidden');
             console.log('[Admin WS] Joined as player:', adminPlayerName);
             break;
 
@@ -3310,7 +3156,7 @@ function handleAdminStateUpdate(data) {
     }
 
     // Hide all phase sections first
-    var sections = ['setup-container', 'lobby-section', 'existing-game-section',
+    var sections = ['setup-container',
                     'admin-playing-section', 'admin-reveal-section', 'admin-end-section',
                     'admin-control-bar'];
     sections.forEach(function(id) {


### PR DESCRIPTION
## Summary

**v3.2.0-rc25** — dead-code sweep. After rc24 made the home-view the canonical LOBBY landing for every admin path (initial creation + Revanche + reload), the pre-rc12 \`#lobby-section\` had no reachable call site. **~376 lines removed** across HTML/CSS/JS.

### What went
- **admin.html:** \`#lobby-section\` (75 lines) and \`#existing-game-section\` (14 lines)
- **admin.js:** collapsed \`showLobbyView\` to a \`BeatifyHome\` delegate; deleted \`showExistingGameView\`, \`rejoinGame\`; dropped dead event wiring for \`#rejoin-game\`, \`#end-game-existing\`, \`#participate-btn\`, \`#start-gameplay-btn\`
- **styles.css:** all \`#lobby-section\` rules and \`.lobby-view-wrapper\`

### What stayed
- **Shared with \`player.html\`:** \`.lobby-container\`, \`.lobby-container--compact\`, \`.lobby-header-compact\`, \`.lobby-actions\`, \`.lobby-actions--sticky\`, \`.stat-badge-bar\`, \`.qr-section\`, \`.qr-section--compact\` — these dress the player-page lobby.
- **WS-disconnect REST polling** — still runs so home-view chips stay fresh if the WS drops.

### Incidental fix
\`setupQRModal()\` was called from \`showLobbyView\` on every LOBBY WS push, attaching a fresh document-level \`keydown\`/Escape listener each time. Now wired **once** at init.

## Test plan
- [ ] Post-wizard fresh admin load → home-view renders with QR (no legacy lobby seen)
- [ ] Press Start game → auto-creates LOBBY → still on home-view → QR + chips live
- [ ] Press Revanche at end-of-game → returns to home-view (rc24 behavior preserved)
- [ ] Press Start New Game → reopens wizard Step 1 (rc24 behavior preserved)
- [ ] Reload \`/admin\` during LOBBY → lands on home-view with restored chips
- [ ] QR tap-to-enlarge (home-view) still opens modal; Escape closes it
- [ ] Admin joins as player during LOBBY → auto-flips to \`/play\` on Start (rc23 behavior preserved)
- [ ] Player-side lobby (\`/play\`) still styled correctly (shared CSS classes intact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)