### PR TITLE
data: fix 3 broken Apple Music URIs in british-invasion-britpop (#762)

### DIFF
--- a/custom_components/beatify/playlists/british-invasion-britpop.json
+++ b/custom_components/beatify/playlists/british-invasion-britpop.json
@@ -1,6 +1,6 @@
 {
   "name": "British Invasion & Britpop 🇬🇧",
-  "version": "1.2",
+  "version": "1.3",
   "tags": [
     "1960s",
     "1990s",
@@ -1561,7 +1561,7 @@
       "fun_fact": "From the debut album 'Tigermilk', originally pressed as just 1,000 copies as a university music course project. Stuart Murdoch's literary, whispery songwriting style defined the late-90s indie pop revival from Glasgow.",
       "fun_fact_de": "Vom Debütalbum 'Tigermilk', ursprünglich als Universitäts-Musikprojekt in nur 1.000 Exemplaren gepresst. Stuart Murdochs literarischer, flüsternder Songwriting-Stil prägte das Indie-Pop-Revival der späten 90er aus Glasgow.",
       "fun_fact_es": "Del álbum debut 'Tigermilk', originalmente prensado en solo 1.000 copias como proyecto de un curso universitario de música. El estilo literario y susurrante de Stuart Murdoch definió el revival del indie pop de finales de los 90 desde Glasgow.",
-      "uri_apple_music": "applemusic://track/260748632",
+      "uri_apple_music": "applemusic://track/1589190382",
       "uri_youtube_music": "https://music.youtube.com/watch?v=rGf3avdnI8U",
       "uri_tidal": "tidal://track/14575208",
       "fun_fact_fr": "De l'album début « Tigermilk », initialement pressé à seulement 1 000 exemplaires comme projet d'un cours de musique universitaire. Le style d'écriture littéraire et murmuré de Stuart Murdoch a défini le renouveau de l'indie pop de la fin des années 90 depuis Glasgow.",
@@ -1621,7 +1621,6 @@
       "fun_fact": "This Welsh band's unpronounceable name reportedly came from a random phrase a schoolmate invented. 'Patio Song' became their biggest hit and an indie classic.",
       "fun_fact_de": "Der unaussprechliche Name dieser walisischen Band stammte angeblich von einem zufälligen Ausdruck eines Schulkameraden. 'Patio Song' wurde ihr größter Hit und ein Indie-Klassiker.",
       "fun_fact_es": "El nombre impronunciable de esta banda galesa supuestamente provino de una frase aleatoria que inventó un compañero de escuela. 'Patio Song' se convirtió en su mayor éxito y un clásico indie.",
-      "uri_apple_music": "applemusic://track/1443773352",
       "uri_youtube_music": "https://music.youtube.com/watch?v=LXMey9IT7hk",
       "uri_tidal": "tidal://track/632726",
       "fun_fact_fr": "Le nom imprononçable de ce groupe gallois proviendrait d'une phrase aléatoire inventée par un camarade de classe. « Patio Song » est devenu leur plus grand hit et un classique indie.",
@@ -2507,7 +2506,7 @@
       "fun_fact": "A scandal erupted when it was revealed that session musicians had played all the instruments on the recording, and only lead singer Steve Ellis actually performed on the track. The band admitted they were too inexperienced to play on their own debut.",
       "fun_fact_de": "Ein Skandal brach aus, als enthüllt wurde, dass Studiomusiker alle Instrumente auf der Aufnahme gespielt hatten und nur Leadsänger Steve Ellis tatsächlich auf dem Track performte. Die Band gab zu, dass sie zu unerfahren waren, um auf ihrem eigenen Debüt zu spielen.",
       "fun_fact_es": "Estalló un escándalo cuando se reveló que músicos de sesión habían tocado todos los instrumentos en la grabación, y solo el cantante Steve Ellis realmente actuó en la pista. La banda admitió que eran demasiado inexpertos para tocar en su propio debut.",
-      "uri_apple_music": "applemusic://track/268509060",
+      "uri_apple_music": "applemusic://track/909398573",
       "uri_youtube_music": "https://music.youtube.com/watch?v=JaYTNsS_m2w",
       "uri_tidal": "tidal://track/34501",
       "fun_fact_fr": "Un scandale a éclaté quand il a été révélé que des musiciens de session avaient joué tous les instruments sur l'enregistrement, et que seul le chanteur Steve Ellis avait réellement joué sur le morceau. Le groupe a admis qu'ils étaient trop inexpérimentés pour jouer sur leur propre premier album.",


### PR DESCRIPTION
Closes #762.

Replaced 3 dead Apple Music URIs in `british-invasion-britpop.json` and bumped playlist version to **1.3**.

### Changes
- **Belle and Sebastian — Like Dylan in the Movies**: `applemusic://track/260748632` → `applemusic://track/1589190382` (US storefront ID; the original was a non-US storefront ID)
- **Love Affair — Everlasting Love**: `applemusic://track/268509060` → `applemusic://track/909398573` (US storefront, original 1968 recording feat. Steve Ellis)
- **Gorky's Zygotic Mynci — Patio Song**: removed `uri_apple_music` field — track is not present in the US Apple Music catalog. Song remains playable via Spotify, YouTube Music, Tidal, and Deezer.

### Health check summary
- Total URIs checked: 483
- Healthy: 468
- Dead Apple Music URIs (fixed here): 3
- `wrong_track` flags reviewed and dismissed as false positives: 12 (all version suffixes — Mono, Radio Edit, Full Length Version, etc.)