### PR TITLE
data: drop dead Apple Music URI in koelner-karneval (Marc Eggers - KÖLLE AM RHING)

### DIFF
--- a/custom_components/beatify/playlists/community/koelner-karneval.json
+++ b/custom_components/beatify/playlists/community/koelner-karneval.json
@@ -1,6 +1,6 @@
 {
   "name": "Cologne Carnival 🎭",
-  "version": "1.5",
+  "version": "1.6",
   "tags": [
     "german",
     "carnival",
@@ -7213,7 +7213,6 @@
       "certifications": [],
       "awards": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=Cx9RAamwjhY",
-      "uri_apple_music": "applemusic://track/1862452337",
       "chart_info": {
         "weeks_on_chart": null
       },


### PR DESCRIPTION
Closes #770.

After fixing the validator's US-only storefront bug (added `&country=de/gb` fallback to `check_apple_music`), the koelner-karneval health check went from **86 "dead" → 1 dead**. The 85 previously-flagged tracks were all German-catalog-only hits that iTunes' default US storefront returns 0 results for — see the retraction on #769.

The one genuine issue: Marc Eggers — KÖLLE AM RHING (2025). The track isn't on Apple Music at all (checked US/DE/GB storefronts + searched by artist/title/collaborators). Spotify, YouTube Music, and Tidal all validate healthy, so this change removes just the `uri_apple_music` field. The playback fallback from #768 handles it cleanly.

Playlist version: 1.5 → 1.6.

## Summary
- 1420 URIs checked
- 1404 healthy, 1 confirmed dead, 15 `wrong_track` false positives (Spotify Radio Edit / Club Mix / Single Version variants of the same song)

## Test plan
- [ ] HA restart picks up playlist v1.6
- [ ] Marc Eggers - KÖLLE AM RHING plays via Spotify/YT Music/Tidal fallback on Apple-Music-preferred setups