### PR TITLE
i18n: translate rc1 wizard UX (capability badges + MA explainer) for 5 locales

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to Beatify are documented here. For detailed release notes, 
 
 ## [Unreleased]
 
+## [3.3.1-rc2] - 2026-04-24
+
+### Fixed
+- **Wizard translations for rc1 UX (#772)** — the capability badges ("All services", "only") and the Music Assistant explainer card in Step 2 were using hardcoded English fallbacks because the new keys weren't added to the i18n JSON files. Non-English locales (de/es/fr/nl) now get real translations instead of the English source string. The `_t()` helper also now forwards `{placeholder}` params through to `BeatifyI18n.t`, so the explainer interpolates the speaker's platform and the picked provider correctly in every language.
+
+### For contributors
+- Bumped manifest + `sw.js CACHE_VERSION` + `wizard.js?v=` → `3.3.1-rc2`. CSS unchanged.
+
 ## [3.3.1-rc1] - 2026-04-24
 
 ### Fixed

--- a/custom_components/beatify/manifest.json
+++ b/custom_components/beatify/manifest.json
@@ -12,5 +12,5 @@
   "documentation": "https://github.com/mholzi/beatify",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/mholzi/beatify/issues",
-  "version": "3.3.1-rc1"
+  "version": "3.3.1-rc2"
 }

--- a/custom_components/beatify/www/admin.html
+++ b/custom_components/beatify/www/admin.html
@@ -1056,7 +1056,7 @@
     <!-- Story 44.1: Playlist requests module -->
     <script src="/beatify/static/js/playlist-requests.min.js?v=3.3.0"></script>
     <script type="module" src="/beatify/static/js/playlist-hub.js?v=3.3.0"></script>
-    <script type="module" src="/beatify/static/js/wizard.js?v=3.3.1-rc1"></script>
+    <script type="module" src="/beatify/static/js/wizard.js?v=3.3.1-rc2"></script>
     <script src="/beatify/static/js/admin.min.js?v=3.3.0"></script>
     <script src="/beatify/static/js/party-lights.min.js?v=3.3.0"></script>
     <script src="/beatify/static/js/tts-settings.js?v=3.3.0"></script>

--- a/custom_components/beatify/www/i18n/de.json
+++ b/custom_components/beatify/www/i18n/de.json
@@ -727,12 +727,26 @@
       "hint": "Dein Lautsprecher fehlt?",
       "hintLink": "Unterstützte Typen ansehen",
       "empty": "Noch keine Lautsprecher gefunden",
-      "emptyHint": "Music Assistant installieren und aktualisieren"
+      "emptyHint": "Music Assistant installieren und aktualisieren",
+      "capAll": "Alle Dienste",
+      "capOnly": "nur",
+      "capNone": "Keine Dienste"
     },
     "step2": {
       "eyebrow": "Schritt 2 · Musikdienst",
       "title": "Wer streamt?",
-      "sub": "Wähle den Dienst, den dein Lautsprecher nutzt. Beatify spielt Songs über das, was du in Home Assistant eingerichtet hast."
+      "sub": "Wähle den Dienst, den dein Lautsprecher nutzt. Beatify spielt Songs über das, was du in Home Assistant eingerichtet hast.",
+      "explainer": {
+        "yourSpeaker": "dein Lautsprecher",
+        "title": "{provider} auf {platform} benötigt Music Assistant",
+        "body": "{platform} kann Spotify direkt aus Home Assistant abspielen. {provider} und andere Streaming-Dienste brauchen das Music Assistant Add-on, das die Anmeldung und Formatkonvertierung übernimmt, die {platform} allein nicht beherrscht.",
+        "step1": "<strong>Music Assistant</strong> über HACS installieren",
+        "step2": "{provider}-Konto in MA → Provider hinzufügen",
+        "step3": "Zurückkommen — dein {platform} erscheint als Music Assistant-Lautsprecher",
+        "primary": "Music Assistant einrichten →",
+        "ghost": "Anderen Dienst wählen",
+        "footer": "Lieber Spotify? Läuft direkt auf Sonos — kein Add-on nötig."
+      }
     },
     "step3": {
       "eyebrow": "Schritt 3 · Playlist",

--- a/custom_components/beatify/www/i18n/en.json
+++ b/custom_components/beatify/www/i18n/en.json
@@ -727,12 +727,26 @@
       "hint": "Don't see your speaker?",
       "hintLink": "Check supported types",
       "empty": "No speakers found yet",
-      "emptyHint": "Install Music Assistant and refresh"
+      "emptyHint": "Install Music Assistant and refresh",
+      "capAll": "All services",
+      "capOnly": "only",
+      "capNone": "No services"
     },
     "step2": {
       "eyebrow": "Step 2 · Music service",
       "title": "Who's streaming?",
-      "sub": "Pick the service your speaker uses. Beatify plays songs through whatever you already have configured in Home Assistant."
+      "sub": "Pick the service your speaker uses. Beatify plays songs through whatever you already have configured in Home Assistant.",
+      "explainer": {
+        "yourSpeaker": "your speaker",
+        "title": "{provider} on {platform} needs Music Assistant",
+        "body": "{platform} plays Spotify directly from Home Assistant. {provider} and other streaming services need the Music Assistant add-on to route the track — it handles the login and format conversion {platform} can't do on its own.",
+        "step1": "Install <strong>Music Assistant</strong> from HACS",
+        "step2": "Add your {provider} account in MA → Providers",
+        "step3": "Come back — your {platform} appears as a Music Assistant speaker",
+        "primary": "Set up Music Assistant →",
+        "ghost": "Pick a different service",
+        "footer": "Prefer Spotify? It works on Sonos directly — no add-on needed."
+      }
     },
     "step3": {
       "eyebrow": "Step 3 · Playlist",

--- a/custom_components/beatify/www/i18n/es.json
+++ b/custom_components/beatify/www/i18n/es.json
@@ -727,12 +727,26 @@
       "hint": "¿No ves tu altavoz?",
       "hintLink": "Ver tipos compatibles",
       "empty": "Aún no hay altavoces",
-      "emptyHint": "Instala Music Assistant y actualiza"
+      "emptyHint": "Instala Music Assistant y actualiza",
+      "capAll": "Todos los servicios",
+      "capOnly": "solo",
+      "capNone": "Sin servicios"
     },
     "step2": {
       "eyebrow": "Paso 2 · Servicio de música",
       "title": "¿Quién transmite?",
-      "sub": "Elige el servicio que usa tu altavoz. Beatify reproduce a través de lo que ya tienes configurado en Home Assistant."
+      "sub": "Elige el servicio que usa tu altavoz. Beatify reproduce a través de lo que ya tienes configurado en Home Assistant.",
+      "explainer": {
+        "yourSpeaker": "tu altavoz",
+        "title": "{provider} en {platform} necesita Music Assistant",
+        "body": "{platform} reproduce Spotify directamente desde Home Assistant. {provider} y otros servicios de streaming necesitan el complemento Music Assistant para enrutar la pista — se encarga del inicio de sesión y la conversión de formato que {platform} no puede hacer por sí solo.",
+        "step1": "Instala <strong>Music Assistant</strong> desde HACS",
+        "step2": "Añade tu cuenta de {provider} en MA → Proveedores",
+        "step3": "Vuelve — tu {platform} aparece como un altavoz de Music Assistant",
+        "primary": "Configurar Music Assistant →",
+        "ghost": "Elegir otro servicio",
+        "footer": "¿Prefieres Spotify? Funciona directamente en Sonos — sin complementos."
+      }
     },
     "step3": {
       "eyebrow": "Paso 3 · Lista de reproducción",

--- a/custom_components/beatify/www/i18n/fr.json
+++ b/custom_components/beatify/www/i18n/fr.json
@@ -727,12 +727,26 @@
       "hint": "Ton enceinte n'apparaît pas ?",
       "hintLink": "Voir les types compatibles",
       "empty": "Aucune enceinte détectée",
-      "emptyHint": "Installe Music Assistant et rafraîchis"
+      "emptyHint": "Installe Music Assistant et rafraîchis",
+      "capAll": "Tous les services",
+      "capOnly": "uniquement",
+      "capNone": "Aucun service"
     },
     "step2": {
       "eyebrow": "Étape 2 · Service musical",
       "title": "Qui diffuse ?",
-      "sub": "Choisis le service qu'utilise ton enceinte. Beatify joue via ce que tu as déjà configuré dans Home Assistant."
+      "sub": "Choisis le service qu'utilise ton enceinte. Beatify joue via ce que tu as déjà configuré dans Home Assistant.",
+      "explainer": {
+        "yourSpeaker": "ton enceinte",
+        "title": "{provider} sur {platform} nécessite Music Assistant",
+        "body": "{platform} lit Spotify directement depuis Home Assistant. {provider} et les autres services de streaming ont besoin de l'add-on Music Assistant pour router la piste — il gère la connexion et la conversion de format que {platform} ne peut pas faire seul.",
+        "step1": "Installe <strong>Music Assistant</strong> depuis HACS",
+        "step2": "Ajoute ton compte {provider} dans MA → Fournisseurs",
+        "step3": "Reviens — ton {platform} apparaît comme une enceinte Music Assistant",
+        "primary": "Configurer Music Assistant →",
+        "ghost": "Choisir un autre service",
+        "footer": "Tu préfères Spotify ? Ça marche directement sur Sonos — pas besoin d'add-on."
+      }
     },
     "step3": {
       "eyebrow": "Étape 3 · Playlist",

--- a/custom_components/beatify/www/i18n/nl.json
+++ b/custom_components/beatify/www/i18n/nl.json
@@ -727,12 +727,26 @@
       "hint": "Zie je jouw luidspreker niet?",
       "hintLink": "Bekijk ondersteunde types",
       "empty": "Nog geen luidsprekers",
-      "emptyHint": "Installeer Music Assistant en vernieuw"
+      "emptyHint": "Installeer Music Assistant en vernieuw",
+      "capAll": "Alle diensten",
+      "capOnly": "alleen",
+      "capNone": "Geen diensten"
     },
     "step2": {
       "eyebrow": "Stap 2 · Muziekdienst",
       "title": "Wie streamt?",
-      "sub": "Kies de dienst die je luidspreker gebruikt. Beatify speelt via wat je al in Home Assistant hebt ingesteld."
+      "sub": "Kies de dienst die je luidspreker gebruikt. Beatify speelt via wat je al in Home Assistant hebt ingesteld.",
+      "explainer": {
+        "yourSpeaker": "je luidspreker",
+        "title": "{provider} op {platform} heeft Music Assistant nodig",
+        "body": "{platform} speelt Spotify direct vanuit Home Assistant. {provider} en andere streamingdiensten hebben de Music Assistant add-on nodig om de track te routeren — die regelt het inloggen en de formaatconversie die {platform} zelf niet kan.",
+        "step1": "Installeer <strong>Music Assistant</strong> via HACS",
+        "step2": "Voeg je {provider}-account toe in MA → Providers",
+        "step3": "Kom terug — je {platform} verschijnt als Music Assistant-luidspreker",
+        "primary": "Music Assistant instellen →",
+        "ghost": "Andere dienst kiezen",
+        "footer": "Liever Spotify? Werkt direct op Sonos — geen add-on nodig."
+      }
     },
     "step3": {
       "eyebrow": "Stap 3 · Afspeellijst",

--- a/custom_components/beatify/www/js/wizard.js
+++ b/custom_components/beatify/www/js/wizard.js
@@ -117,11 +117,27 @@ let chosenTtsAnnounceWinner = true;
 
 const TOTAL_STEPS = 5; // 1:speakers 2:music 3:playlist 4:game-mode 5:level-up (+ done frame)
 
-function _t(key, fallback) {
+// Lookup a translated string. The optional `params` object is forwarded to
+// BeatifyI18n.t for {placeholder} interpolation inside the translation. When
+// the i18n module isn't loaded (tests, early boot), we fall back to the
+// English default and interpolate `{placeholder}` locally so callers don't
+// care about load state.
+function _t(key, fallback, params) {
+    let translated;
     if (typeof window !== 'undefined' && window.BeatifyI18n && typeof window.BeatifyI18n.t === 'function') {
-        return window.BeatifyI18n.t(key) || fallback;
+        translated = window.BeatifyI18n.t(key, params);
+        // BeatifyI18n returns the key itself when the translation is missing —
+        // that's our cue to use the fallback instead of showing "wizard.step1.capAll"
+        // in the UI.
+        if (translated && translated !== key) return translated;
     }
-    return fallback;
+    let out = fallback;
+    if (params && typeof out === 'string') {
+        Object.keys(params).forEach((p) => {
+            out = out.replace(new RegExp('\\{' + p + '\\}', 'g'), params[p]);
+        });
+    }
+    return out;
 }
 
 async function _fetchStatus() {
@@ -410,16 +426,18 @@ function _showProviderExplainer(providerId) {
     const host = document.getElementById('wiz-provider-explainer');
     if (!host) return;
     const player = _selectedPlayer();
-    const platform = player ? _platformLabel(player.platform) : 'your speaker';
+    const platform = player ? _platformLabel(player.platform) : _t('wizard.step2.explainer.yourSpeaker', 'your speaker');
     const provider = (PROVIDERS.find((p) => p.id === providerId) || {}).label || providerId;
-    const title = _t('wizard.step2.explainer.title', `${provider} on ${platform} needs Music Assistant`);
+    const vars = { provider, platform };
+    const title = _t('wizard.step2.explainer.title', '{provider} on {platform} needs Music Assistant', vars);
     const body = _t(
         'wizard.step2.explainer.body',
-        `${platform} plays Spotify directly from Home Assistant. ${provider} and other streaming services need the Music Assistant add-on to route the track — it handles the login and format conversion ${platform} can't do on its own.`
+        "{platform} plays Spotify directly from Home Assistant. {provider} and other streaming services need the Music Assistant add-on to route the track — it handles the login and format conversion {platform} can't do on its own.",
+        vars,
     );
     const step1 = _t('wizard.step2.explainer.step1', 'Install <strong>Music Assistant</strong> from HACS');
-    const step2 = _t('wizard.step2.explainer.step2', `Add your ${provider} account in MA → Providers`);
-    const step3 = _t('wizard.step2.explainer.step3', `Come back — your ${platform} appears as a Music Assistant speaker`);
+    const step2 = _t('wizard.step2.explainer.step2', 'Add your {provider} account in MA → Providers', vars);
+    const step3 = _t('wizard.step2.explainer.step3', 'Come back — your {platform} appears as a Music Assistant speaker', vars);
     const primary = _t('wizard.step2.explainer.primary', 'Set up Music Assistant →');
     const ghost = _t('wizard.step2.explainer.ghost', 'Pick a different service');
     const footer = _t('wizard.step2.explainer.footer', 'Prefer Spotify? It works on Sonos directly — no add-on needed.');

--- a/custom_components/beatify/www/sw.js
+++ b/custom_components/beatify/www/sw.js
@@ -6,7 +6,7 @@
  */
 'use strict';
 
-var CACHE_VERSION = 'beatify-v3.3.1-rc1';
+var CACHE_VERSION = 'beatify-v3.3.1-rc2';
 var MAX_CACHE_ITEMS = 50;
 
 // Critical assets to precache on install (minified versions only - fallback handled by HTML)


### PR DESCRIPTION
Follow-up to #775 — rc1 shipped the new wizard UX with hardcoded English fallbacks. de/es/fr/nl users were seeing the English source strings plus `[i18n] Missing translation key` warnings in the console.

## Changes

### `_t()` helper now forwards params
`wizard.js`'s `_t(key, fallback, params)` wrapper now passes the params object through to `BeatifyI18n.t`, so `{provider}` / `{platform}` placeholders in translations interpolate correctly. The fallback path (when i18n module isn't loaded — tests, early boot) also does local interpolation, so callers don't need to care about load state.

### 12 new keys × 5 locales

- `wizard.step1.capAll` — "All services"
- `wizard.step1.capOnly` — "only"
- `wizard.step1.capNone` — "No services"
- `wizard.step2.explainer.yourSpeaker` — fallback platform label when no speaker picked
- `wizard.step2.explainer.title` — "{provider} on {platform} needs Music Assistant"
- `wizard.step2.explainer.body` — long-form explanation
- `wizard.step2.explainer.step1/2/3` — setup steps
- `wizard.step2.explainer.primary` / `.ghost` — button labels
- `wizard.step2.explainer.footer` — Spotify hint

German/Spanish/French/Dutch translations written to match the voice of surrounding wizard strings in each file. All JSON files validated with `python -m json.tool`.

## Test plan

- [x] `vitest run` — 34/34 pass (signature change to `_t()` is backward-compatible)
- [x] All 5 JSON files parse as valid JSON
- [x] `explainer` sub-object has 9 keys in every locale (count matches across files)
- [ ] **Live test:** Set HA language to German; pick Sonos; click dimmed Apple Music; verify title reads *"Apple Music auf Sonos benötigt Music Assistant"* (not the English fallback)

## Version

- `manifest.json`: `3.3.1-rc1` → `3.3.1-rc2`
- `sw.js CACHE_VERSION`: `beatify-v3.3.1-rc1` → `beatify-v3.3.1-rc2`
- `wizard.js?v=` cache-buster → `3.3.1-rc2`
- CSS unchanged, `styles.min.css?v=` stays at `3.3.1-rc1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)