### PR TITLE
fix: wizard rerender on speaker change + locale-safe badge/footer (rc3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to Beatify are documented here. For detailed release notes, 
 
 ## [Unreleased]
 
+## [3.3.1-rc3] - 2026-04-24
+
+### Fixed
+- **Wizard provider chips now re-render when speaker changes (#772)** — going Back from Step 2, picking a different speaker, and returning to Step 2 used to show the *previous* speaker's chip dim-state. Caught via live test: after switching from a Sonos speaker to a Music Assistant speaker, Apple Music / YouTube Music / Tidal / Deezer all stayed locked even though MA supports them. Speaker-click handler now re-renders providers and clears `chosenProvider` if it became unsupported on the new speaker.
+- **Explainer footer now uses `{platform}` placeholder** — the footer had hardcoded "Sonos" in every translation, so an Alexa user saw *"Prefer Spotify? It works on Sonos directly"* which is confusing/wrong. Reads correctly in each locale now (en/de/es/fr/nl updated).
+
+### For contributors
+- Bumped manifest + `sw.js CACHE_VERSION` + `wizard.js?v=` → `3.3.1-rc3`. CSS unchanged.
+
 ## [3.3.1-rc2] - 2026-04-24
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,11 @@ All notable changes to Beatify are documented here. For detailed release notes, 
 ### Fixed
 - **Wizard provider chips now re-render when speaker changes (#772)** — going Back from Step 2, picking a different speaker, and returning to Step 2 used to show the *previous* speaker's chip dim-state. Caught via live test: after switching from a Sonos speaker to a Music Assistant speaker, Apple Music / YouTube Music / Tidal / Deezer all stayed locked even though MA supports them. Speaker-click handler now re-renders providers and clears `chosenProvider` if it became unsupported on the new speaker.
 - **Explainer footer now uses `{platform}` placeholder** — the footer had hardcoded "Sonos" in every translation, so an Alexa user saw *"Prefer Spotify? It works on Sonos directly"* which is confusing/wrong. Reads correctly in each locale now (en/de/es/fr/nl updated).
+- **Capability badge word order for non-English locales** — the *"Spotify only"* badge rendered as *"Spotify nur"* in German instead of *"nur Spotify"* (modifier goes first in German, Spanish, Dutch). The old `capOnly` key was a suffix word; replaced with `capOnlyTemplate` containing a `{provider}` placeholder so each locale controls its own word order.
 
 ### For contributors
 - Bumped manifest + `sw.js CACHE_VERSION` + `wizard.js?v=` → `3.3.1-rc3`. CSS unchanged.
+- i18n key rename: `wizard.step1.capOnly` → `wizard.step1.capOnlyTemplate` (a format string with `{provider}` instead of a standalone suffix word).
 
 ## [3.3.1-rc2] - 2026-04-24
 

--- a/custom_components/beatify/manifest.json
+++ b/custom_components/beatify/manifest.json
@@ -12,5 +12,5 @@
   "documentation": "https://github.com/mholzi/beatify",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/mholzi/beatify/issues",
-  "version": "3.3.1-rc2"
+  "version": "3.3.1-rc3"
 }

--- a/custom_components/beatify/www/admin.html
+++ b/custom_components/beatify/www/admin.html
@@ -1056,7 +1056,7 @@
     <!-- Story 44.1: Playlist requests module -->
     <script src="/beatify/static/js/playlist-requests.min.js?v=3.3.0"></script>
     <script type="module" src="/beatify/static/js/playlist-hub.js?v=3.3.0"></script>
-    <script type="module" src="/beatify/static/js/wizard.js?v=3.3.1-rc2"></script>
+    <script type="module" src="/beatify/static/js/wizard.js?v=3.3.1-rc3"></script>
     <script src="/beatify/static/js/admin.min.js?v=3.3.0"></script>
     <script src="/beatify/static/js/party-lights.min.js?v=3.3.0"></script>
     <script src="/beatify/static/js/tts-settings.js?v=3.3.0"></script>

--- a/custom_components/beatify/www/i18n/de.json
+++ b/custom_components/beatify/www/i18n/de.json
@@ -745,7 +745,7 @@
         "step3": "Zurückkommen — dein {platform} erscheint als Music Assistant-Lautsprecher",
         "primary": "Music Assistant einrichten →",
         "ghost": "Anderen Dienst wählen",
-        "footer": "Lieber Spotify? Läuft direkt auf Sonos — kein Add-on nötig."
+        "footer": "Lieber Spotify? Läuft direkt auf {platform} — kein Add-on nötig."
       }
     },
     "step3": {

--- a/custom_components/beatify/www/i18n/de.json
+++ b/custom_components/beatify/www/i18n/de.json
@@ -729,7 +729,7 @@
       "empty": "Noch keine Lautsprecher gefunden",
       "emptyHint": "Music Assistant installieren und aktualisieren",
       "capAll": "Alle Dienste",
-      "capOnly": "nur",
+      "capOnlyTemplate": "nur {provider}",
       "capNone": "Keine Dienste"
     },
     "step2": {

--- a/custom_components/beatify/www/i18n/en.json
+++ b/custom_components/beatify/www/i18n/en.json
@@ -729,7 +729,7 @@
       "empty": "No speakers found yet",
       "emptyHint": "Install Music Assistant and refresh",
       "capAll": "All services",
-      "capOnly": "only",
+      "capOnlyTemplate": "{provider} only",
       "capNone": "No services"
     },
     "step2": {

--- a/custom_components/beatify/www/i18n/en.json
+++ b/custom_components/beatify/www/i18n/en.json
@@ -745,7 +745,7 @@
         "step3": "Come back — your {platform} appears as a Music Assistant speaker",
         "primary": "Set up Music Assistant →",
         "ghost": "Pick a different service",
-        "footer": "Prefer Spotify? It works on Sonos directly — no add-on needed."
+        "footer": "Prefer Spotify? It works on {platform} directly — no add-on needed."
       }
     },
     "step3": {

--- a/custom_components/beatify/www/i18n/es.json
+++ b/custom_components/beatify/www/i18n/es.json
@@ -745,7 +745,7 @@
         "step3": "Vuelve — tu {platform} aparece como un altavoz de Music Assistant",
         "primary": "Configurar Music Assistant →",
         "ghost": "Elegir otro servicio",
-        "footer": "¿Prefieres Spotify? Funciona directamente en Sonos — sin complementos."
+        "footer": "¿Prefieres Spotify? Funciona directamente en {platform} — sin complementos."
       }
     },
     "step3": {

--- a/custom_components/beatify/www/i18n/es.json
+++ b/custom_components/beatify/www/i18n/es.json
@@ -729,7 +729,7 @@
       "empty": "Aún no hay altavoces",
       "emptyHint": "Instala Music Assistant y actualiza",
       "capAll": "Todos los servicios",
-      "capOnly": "solo",
+      "capOnlyTemplate": "solo {provider}",
       "capNone": "Sin servicios"
     },
     "step2": {

--- a/custom_components/beatify/www/i18n/fr.json
+++ b/custom_components/beatify/www/i18n/fr.json
@@ -729,7 +729,7 @@
       "empty": "Aucune enceinte détectée",
       "emptyHint": "Installe Music Assistant et rafraîchis",
       "capAll": "Tous les services",
-      "capOnly": "uniquement",
+      "capOnlyTemplate": "{provider} uniquement",
       "capNone": "Aucun service"
     },
     "step2": {

--- a/custom_components/beatify/www/i18n/fr.json
+++ b/custom_components/beatify/www/i18n/fr.json
@@ -745,7 +745,7 @@
         "step3": "Reviens — ton {platform} apparaît comme une enceinte Music Assistant",
         "primary": "Configurer Music Assistant →",
         "ghost": "Choisir un autre service",
-        "footer": "Tu préfères Spotify ? Ça marche directement sur Sonos — pas besoin d'add-on."
+        "footer": "Tu préfères Spotify ? Ça marche directement sur {platform} — pas besoin d'add-on."
       }
     },
     "step3": {

--- a/custom_components/beatify/www/i18n/nl.json
+++ b/custom_components/beatify/www/i18n/nl.json
@@ -729,7 +729,7 @@
       "empty": "Nog geen luidsprekers",
       "emptyHint": "Installeer Music Assistant en vernieuw",
       "capAll": "Alle diensten",
-      "capOnly": "alleen",
+      "capOnlyTemplate": "alleen {provider}",
       "capNone": "Geen diensten"
     },
     "step2": {

--- a/custom_components/beatify/www/i18n/nl.json
+++ b/custom_components/beatify/www/i18n/nl.json
@@ -745,7 +745,7 @@
         "step3": "Kom terug — je {platform} verschijnt als Music Assistant-luidspreker",
         "primary": "Music Assistant instellen →",
         "ghost": "Andere dienst kiezen",
-        "footer": "Liever Spotify? Werkt direct op Sonos — geen add-on nodig."
+        "footer": "Liever Spotify? Werkt direct op {platform} — geen add-on nodig."
       }
     },
     "step3": {

--- a/custom_components/beatify/www/js/__tests__/wizard.test.js
+++ b/custom_components/beatify/www/js/__tests__/wizard.test.js
@@ -172,6 +172,12 @@ describe('capabilityBadgeForPlayer', () => {
         expect(capabilityBadgeForPlayer(player, providers)).toEqual({ cls: 'partial', label: 'Spotify only' });
     });
 
+    it('respects locale word order via onlyTemplate (German prefixes "nur")', () => {
+        const player = { supports_spotify: true, supports_apple_music: false, supports_youtube_music: false };
+        const badge = capabilityBadgeForPlayer(player, providers, { onlyTemplate: 'nur {provider}' });
+        expect(badge).toEqual({ cls: 'partial', label: 'nur Spotify' });
+    });
+
     it('returns a partial/orange comma-joined badge for a subset (Alexa case)', () => {
         const player = { supports_spotify: true, supports_apple_music: true, supports_youtube_music: false };
         expect(capabilityBadgeForPlayer(player, providers)).toEqual({ cls: 'partial', label: 'Spotify, Apple Music' });

--- a/custom_components/beatify/www/js/wizard.js
+++ b/custom_components/beatify/www/js/wizard.js
@@ -335,13 +335,23 @@ function _renderSpeakers() {
         .join('');
     list.querySelectorAll('.wiz-row[data-entity-id]').forEach((btn) => {
         btn.addEventListener('click', () => {
-            chosenSpeaker = btn.dataset.entityId;
+            const newSpeaker = btn.dataset.entityId;
+            const speakerChanged = chosenSpeaker !== newSpeaker;
+            chosenSpeaker = newSpeaker;
             try { localStorage.setItem(LS_SELECTED_PLAYER, chosenSpeaker); } catch (e) { /* private mode */ }
             // Switching speakers invalidates the provider step — stale explainer
             // would reference the previous platform, and a previously-picked
             // provider may no longer be supported.
             _hideProviderExplainer();
+            if (speakerChanged && chosenProvider && !_providerSupported(chosenProvider)) {
+                // Clear the now-unsupported provider so Step 2 doesn't trap the
+                // user with a selection they can't complete.
+                chosenProvider = null;
+            }
             _renderSpeakers();
+            // Capability set changed — Step 2's chip dimming must be recomputed
+            // or users see stale lock icons from the previous speaker.
+            _renderProviders();
             _updateCta();
         });
     });
@@ -440,7 +450,7 @@ function _showProviderExplainer(providerId) {
     const step3 = _t('wizard.step2.explainer.step3', 'Come back — your {platform} appears as a Music Assistant speaker', vars);
     const primary = _t('wizard.step2.explainer.primary', 'Set up Music Assistant →');
     const ghost = _t('wizard.step2.explainer.ghost', 'Pick a different service');
-    const footer = _t('wizard.step2.explainer.footer', 'Prefer Spotify? It works on Sonos directly — no add-on needed.');
+    const footer = _t('wizard.step2.explainer.footer', 'Prefer Spotify? It works on {platform} directly — no add-on needed.', vars);
     host.innerHTML = `
         <div class="wiz-explainer-title">
             <span class="icon" aria-hidden="true">⚠️</span>

--- a/custom_components/beatify/www/js/wizard.js
+++ b/custom_components/beatify/www/js/wizard.js
@@ -297,7 +297,7 @@ function _capabilityBadge(player) {
     return capabilityBadgeForPlayer(player, PROVIDERS, {
         none: _t('wizard.step1.capNone', 'No services'),
         all: _t('wizard.step1.capAll', 'All services'),
-        only: _t('wizard.step1.capOnly', 'only'),
+        onlyTemplate: _t('wizard.step1.capOnlyTemplate', '{provider} only'),
     });
 }
 
@@ -390,6 +390,11 @@ function _providerSupported(providerId) {
 
 // Pure: summarize a player's service capabilities into a badge descriptor.
 // Returns { cls, label } or null. Exported for tests.
+//
+// labels.onlyTemplate is a format string containing `{provider}`. The word
+// order of "only" vs. the provider name differs per language — English
+// suffixes ("Spotify only") but German, Spanish, Dutch prefix ("nur Spotify",
+// "solo Spotify", "alleen Spotify"). Using a template lets each locale pick.
 export function capabilityBadgeForPlayer(player, providers, labels = {}) {
     if (!player) return null;
     const supported = providers.filter((p) => player[`supports_${p.id}`]);
@@ -398,7 +403,8 @@ export function capabilityBadgeForPlayer(player, providers, labels = {}) {
         return { cls: 'full', label: labels.all || 'All services' };
     }
     if (supported.length === 1) {
-        return { cls: 'partial', label: `${supported[0].label} ${labels.only || 'only'}` };
+        const template = labels.onlyTemplate || '{provider} only';
+        return { cls: 'partial', label: template.replace('{provider}', supported[0].label) };
     }
     return { cls: 'partial', label: supported.map((p) => p.label).join(', ') };
 }

--- a/custom_components/beatify/www/sw.js
+++ b/custom_components/beatify/www/sw.js
@@ -6,7 +6,7 @@
  */
 'use strict';
 
-var CACHE_VERSION = 'beatify-v3.3.1-rc2';
+var CACHE_VERSION = 'beatify-v3.3.1-rc3';
 var MAX_CACHE_ITEMS = 50;
 
 // Critical assets to precache on install (minified versions only - fallback handled by HTML)


### PR DESCRIPTION
Three fixes caught via live testing against @mholzi's Nabu Casa instance, in order of severity.

## 1. 🔴 Chips stale when speaker changes

**Repro:** Step 1 → pick Sonos → Continue → Step 2 (4 chips correctly dimmed) → Back → pick MA speaker → Continue → Step 2 **still** shows 4 dimmed even though MA supports all services.

**Root cause:** `_renderSpeakers` click handler only re-rendered speakers, not providers, so the capability set was stale.

**Fix:** handler now calls `_renderProviders()` after speaker change and clears `chosenProvider` if it became unsupported on the new speaker.

## 2. 🟡 Explainer footer hardcoded "Sonos"

Footer read *"Prefer Spotify? It works on Sonos directly — no add-on needed"* regardless of which platform the user selected. Alexa users saw "Sonos" which is wrong.

**Fix:** moved to `{platform}` placeholder, updated all 5 locale files.

## 3. 🟡 "X only" badge word order wrong for de/es/nl

User caught on German locale: badge rendered as *"Spotify nur"* but German grammar wants *"nur Spotify"* (modifier prefix). Same issue in Spanish (*"solo Spotify"*) and Dutch (*"alleen Spotify"*).

**Fix:** replaced the `capOnly` suffix-word key with `capOnlyTemplate` (format string with `{provider}` placeholder). Each locale now controls its own word order:

| Locale | Before (wrong) | After |
|---|---|---|
| en | Spotify only | Spotify only |
| de | Spotify nur | **nur Spotify** |
| es | Spotify solo | **solo Spotify** |
| fr | Spotify uniquement | Spotify uniquement |
| nl | Spotify alleen | **alleen Spotify** |

## Test plan

- [x] `vitest run` — 35/35 pass (+1 new test for German-prefix word order)
- [x] All 5 i18n JSON files valid
- [ ] Live test: switch HA language to German, verify badge reads *"nur Spotify"*
- [ ] Live test: Alexa speaker + click dimmed chip, footer should name Alexa
- [ ] Live test: pick Sonos → Step 2 → Back → pick MA speaker → Step 2, all chips enabled

## Version

- `manifest.json` + `sw.js CACHE_VERSION` + `wizard.js?v=` → `3.3.1-rc3`
- CSS unchanged (no `styles.min.css?v=` bump)

🤖 Generated with [Claude Code](https://claude.com/claude-code)