### PR TITLE
fix(version): read from manifest.json (closes #784)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to Beatify are documented here. For detailed release notes, 
 
 ## [Unreleased]
 
+## [3.3.1-rc7] - 2026-04-25
+
+### Fixed
+- **Admin footer version label is correct again (#784).** The footer had been showing *"Beatify v3.2.0-rc29"* since mid-April regardless of which version was installed. Root cause: a `_VERSION = "3.2.0-rc29"` constant in [`server/base.py`](custom_components/beatify/server/base.py) was supposed to be auto-bumped by a GitHub workflow that hadn't run since April 15 (the `.github/workflows/` directory got untracked in [`6d056b35`](https://github.com/mholzi/beatify/commit/6d056b35) and GitHub Actions has no copy to execute). Replaced the constant with a read of `manifest.json` at integration setup time — single source of truth, no workflow dependency, can never drift again. Reported by @mholzi in #784.
+
+### For contributors
+- New helper `_read_manifest_version()` in `__init__.py`, called via `async_add_executor_job` to stay off the event loop.
+- Version is cached in `hass.data[DOMAIN]['version']` and read by `_get_version(hass)` in `server/base.py` (signature changed from `_get_version()` — only one caller).
+- Bumped manifest + `sw.js CACHE_VERSION` → `3.3.1-rc7`. No frontend asset changes — HTML cache-busters unchanged.
+- The auto-bump workflow `.github/workflows/version-bump.yml` is now obsolete and can be deleted from the local-only copy. The other untracked workflows (`test.yml`, `validate.yml`, `pages.yml`) are a separate question — re-track them or accept local-only checks as the contract.
+
 ## [3.3.1-rc6] - 2026-04-25
 
 ### Added

--- a/custom_components/beatify/__init__.py
+++ b/custom_components/beatify/__init__.py
@@ -7,7 +7,9 @@ to play music guessing games.
 
 from __future__ import annotations
 
+import json
 import logging
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from homeassistant.components.frontend import (
@@ -59,12 +61,38 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 
 
+def _read_manifest_version() -> str:
+    """Read the integration version from manifest.json (executor-safe).
+
+    Single source of truth for the version label shown in the admin footer
+    and reported via /beatify/api/status. Replaces the previously-hardcoded
+    `_VERSION` constant in server/base.py that drifted out of sync whenever
+    the version-bump.yml workflow failed to run (#784).
+    """
+    manifest_path = Path(__file__).parent / "manifest.json"
+    try:
+        return json.loads(manifest_path.read_text(encoding="utf-8")).get(
+            "version", "unknown"
+        )
+    except (OSError, ValueError):
+        # Defensive: a malformed install shouldn't crash setup. The fallback
+        # value is also what _get_version() returns when hass.data isn't yet
+        # populated, so this stays consistent.
+        return "unknown"
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Beatify from a config entry."""
     _LOGGER.debug("Setting up Beatify integration")
 
     # Initialize domain data storage
     hass.data.setdefault(DOMAIN, {})
+
+    # Read version from manifest.json once at setup (#784). Done in executor
+    # because HA 2026.2+ flags blocking I/O at module level — but doing it
+    # here at setup time, off the event loop, keeps things clean.
+    version = await hass.async_add_executor_job(_read_manifest_version)
+    _LOGGER.debug("Beatify version: %s", version)
 
     # Ensure playlist directory exists
     playlist_dir = await async_ensure_playlist_directory(hass)
@@ -119,6 +147,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # Store discovery results and game infrastructure
     hass.data[DOMAIN] = {
         "entry_id": entry.entry_id,
+        "version": version,  # #784 — single source of truth from manifest.json
         "media_players": media_players,
         "playlists": playlists,
         "playlist_dir": str(playlist_dir),

--- a/custom_components/beatify/manifest.json
+++ b/custom_components/beatify/manifest.json
@@ -12,5 +12,5 @@
   "documentation": "https://github.com/mholzi/beatify",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/mholzi/beatify/issues",
-  "version": "3.3.1-rc6"
+  "version": "3.3.1-rc7"
 }

--- a/custom_components/beatify/server/base.py
+++ b/custom_components/beatify/server/base.py
@@ -18,16 +18,34 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
-# Version is set here and bumped alongside manifest.json in release commits.
-# We avoid reading manifest.json at runtime because HA imports custom components
-# inside the event loop, and any file I/O (even at module level) triggers
-# blocking call warnings in HA 2026.2+.
-_VERSION = "3.2.0-rc29"
+# Fallback version string used only if manifest.json could not be read at
+# integration setup (very rare — would mean a malformed install). The real
+# version is loaded from manifest.json once during async_setup_entry and
+# cached in hass.data[DOMAIN]['version'] (#784).
+#
+# We deliberately do NOT read manifest.json at module import time: HA 2026.2+
+# flags any blocking I/O at module level, including the reload path where the
+# event loop is already running.
+_VERSION_FALLBACK = "unknown"
 
 
-def _get_version() -> str:
-    """Get the integration version."""
-    return _VERSION
+def _get_version(hass: HomeAssistant | None = None) -> str:
+    """
+    Get the integration version.
+
+    Reads from ``hass.data[DOMAIN]['version']`` (populated at setup_entry from
+    manifest.json) when ``hass`` is provided. Falls back to the unknown sentinel
+    if hass isn't available or the key isn't populated yet.
+    """
+    if hass is not None:
+        try:
+            data = hass.data.get(DOMAIN, {})
+            version = data.get("version")
+            if version:
+                return version
+        except (AttributeError, KeyError):  # pragma: no cover — defensive
+            pass
+    return _VERSION_FALLBACK
 
 
 def _read_file(path: Path) -> str:

--- a/custom_components/beatify/server/views.py
+++ b/custom_components/beatify/server/views.py
@@ -207,7 +207,7 @@ class StatusView(HomeAssistantView):
 
         status = build_status_response(
             self.hass,
-            version=_get_version(),
+            version=_get_version(self.hass),
             media_players=media_players,
             playlists=playlists,
         )

--- a/custom_components/beatify/www/sw.js
+++ b/custom_components/beatify/www/sw.js
@@ -6,7 +6,7 @@
  */
 'use strict';
 
-var CACHE_VERSION = 'beatify-v3.3.1-rc6';
+var CACHE_VERSION = 'beatify-v3.3.1-rc7';
 var MAX_CACHE_ITEMS = 50;
 
 // Critical assets to precache on install (minified versions only - fallback handled by HTML)


### PR DESCRIPTION
Closes #784. Cache-busting was a red herring — the admin footer was honestly reporting a stale `_VERSION` constant that hadn't been bumped since April 15.

## Root cause

Two compounding issues:

1. [\`server/base.py:25\`](custom_components/beatify/server/base.py#L25) hardcoded \`_VERSION = \"3.2.0-rc29\"\` as a constant.
2. [Commit 6d056b35](https://github.com/mholzi/beatify/commit/6d056b35) (April 15) untracked \`.github/workflows/\` from git. The version-bump workflow that was supposed to keep \`_VERSION\` in sync still exists on local disks but GitHub Actions has no copy. Last actual run: v3.0.6-rc.4 on 2026-04-15.

Every release since (3.2.x stable, 3.3.0, all six 3.3.1-rc tags) shipped with the wrong footer.

## The fix

Eliminate the duplicated source of truth. Version is now read from \`manifest.json\` once at \`async_setup_entry\` time (via \`async_add_executor_job\` to stay off the event loop, respecting HA 2026.2+'s blocking-I/O detector) and cached in \`hass.data[DOMAIN]['version']\`. \`_get_version(hass)\` reads from there, falls back to \"unknown\" if hass isn't available.

Single source of truth, no GitHub Action dependency, can never drift again.

## Test plan

- [x] \`ruff check\` + \`ruff format --check\` clean
- [x] Smoke-tested \`_read_manifest_version()\` in isolation: returns \"3.3.1-rc6\" from the actual manifest (now rc7 after this PR's bump)
- [x] Smoke-tested \`_get_version(None)\` returns \"unknown\" fallback
- [x] Smoke-tested \`_get_version(fake_hass)\` returns \"3.3.1-rc7\" from mocked \`hass.data[DOMAIN]['version']\`
- [ ] **Live verification:** load \`/beatify/admin\` after rc7 ships, footer should read \"Beatify v3.3.1-rc7\" (not rc29)

## Tradeoffs

- \`_get_version()\` signature changed from no-args to optional \`hass\`. Only one caller (\`StatusView\` in \`server/views.py\`); updated inline.
- The auto-bump workflow \`.github/workflows/version-bump.yml\` is now obsolete. Worth deleting the local-only copy in a follow-up — it's misleading to have \"live\" code that doesn't actually run anywhere.
- Wider scope (out of this PR): \`test.yml\`, \`validate.yml\`, \`pages.yml\` are also untracked. CI hasn't run on PRs since April. Separate decision: re-track them, or accept local-only checks.

## Version

- \`manifest.json\` + \`sw.js CACHE_VERSION\` → \`3.3.1-rc7\`
- No frontend asset changes — HTML cache-busters unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)