### PR TITLE
chore: re-track CI workflows + test infra (follow-up to #784)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,207 @@
+# Beatify CI Pipeline
+# Runs lint, tests, and coverage on every push/PR
+#
+# Stages:
+# 1. lint     - Code quality checks (ruff)
+# 2. test     - Unit and integration tests (pytest)
+# 3. burn-in  - Flaky test detection (10 iterations on PR to main)
+#
+# Performance targets:
+# - Lint: <1 min
+# - Test: <5 min
+# - Burn-in: <15 min (10 iterations)
+
+name: Test
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+  # Weekly burn-in on schedule
+  schedule:
+    - cron: "0 6 * * 1" # Every Monday at 6 AM UTC
+
+# Cancel in-progress runs on new push
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  PYTHON_VERSION: "3.13"
+
+jobs:
+  # ==========================================================================
+  # STAGE 1: LINT
+  # ==========================================================================
+  lint:
+    name: Lint (${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.12", "3.13"]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install ruff
+        run: pip install ruff
+
+      - name: Run ruff linter
+        run: ruff check .
+
+      - name: Run ruff formatter check
+        run: ruff format --check .
+
+  # ==========================================================================
+  # STAGE 2: TEST
+  # ==========================================================================
+  test:
+    name: Test (${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    needs: lint
+    strategy:
+      matrix:
+        python-version: ["3.12", "3.13"]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Cache pip dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements*.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements_test.txt
+
+      - name: Run unit tests
+        run: pytest tests/unit/ -v --tb=short
+        env:
+          PYTHONPATH: ${{ github.workspace }}
+
+      - name: Run integration tests
+        run: pytest tests/integration/ -v --tb=short
+        env:
+          PYTHONPATH: ${{ github.workspace }}
+
+      - name: Run all tests with coverage
+        env:
+          PYTHONPATH: ${{ github.workspace }}
+        run: |
+          pytest tests/unit/ tests/integration/ \
+            --cov=custom_components/beatify \
+            --cov-report=xml \
+            --cov-report=html \
+            --cov-report=term-missing \
+            --cov-fail-under=25  # baseline; raise progressively as coverage grows (#197)
+
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: htmlcov/
+          retention-days: 7
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          files: coverage.xml
+          fail_ci_if_error: false
+        continue-on-error: true
+
+  # ==========================================================================
+  # STAGE 3: BURN-IN (Flaky Test Detection)
+  # ==========================================================================
+  burn-in:
+    name: Burn-in (Flaky Detection)
+    runs-on: ubuntu-latest
+    needs: test
+    # Only run on PRs to main or scheduled
+    if: github.event_name == 'pull_request' && github.base_ref == 'main' || github.event_name == 'schedule'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Cache pip dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements*.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements_test.txt
+
+      - name: Run burn-in loop (10 iterations)
+        env:
+          PYTHONPATH: ${{ github.workspace }}
+        run: |
+          echo "🔥 Starting burn-in loop - 10 iterations"
+          echo "Purpose: Detect flaky/non-deterministic tests"
+          echo ""
+          for i in {1..10}; do
+            echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+            echo "🔥 Burn-in iteration $i/10"
+            echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+            pytest tests/unit/ tests/integration/ -v --tb=short || {
+              echo "❌ FLAKY TEST DETECTED on iteration $i"
+              echo "Tests must pass 10/10 times to be considered stable"
+              exit 1
+            }
+            echo "✅ Iteration $i passed"
+            echo ""
+          done
+          echo "🎉 All 10 burn-in iterations passed - tests are stable!"
+
+      - name: Upload failure artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: burn-in-failures
+          path: |
+            .pytest_cache/
+            htmlcov/
+          retention-days: 30
+
+  # ==========================================================================
+  # STAGE 4: HA VALIDATION (Optional - requires HA dev environment)
+  # ==========================================================================
+  # ha-validation:
+  #   name: Home Assistant Validation
+  #   runs-on: ubuntu-latest
+  #   needs: test
+  #   steps:
+  #     - name: Checkout code
+  #       uses: actions/checkout@v4
+  #
+  #     - name: HACS Validation
+  #       uses: hacs/action@main
+  #       with:
+  #         category: integration
+  #
+  #     - name: hassfest validation
+  #       uses: home-assistant/actions/hassfest@master

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,40 @@
+# HACS and Home Assistant Validation
+# Required for inclusion in the official HACS default repository
+#
+# Validates:
+# - HACS requirements (hacs.json, structure, manifest)
+# - Home Assistant hassfest (manifest.json, translations, services)
+
+name: Validate
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+  schedule:
+    - cron: "0 0 * * *"  # Daily at midnight UTC
+  workflow_dispatch:  # Allow manual trigger
+
+jobs:
+  validate-hacs:
+    name: HACS Validation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: HACS Action
+        uses: hacs/action@main
+        with:
+          category: integration
+
+  validate-hassfest:
+    name: Hassfest Validation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Hassfest
+        uses: home-assistant/actions/hassfest@master

--- a/.gitignore
+++ b/.gitignore
@@ -85,8 +85,23 @@ beatify-stats-history.json
 RELEASE_NOTES_*.md
 CONTRIBUTING.md
 
-# ---- GitHub workflows (not needed in HACS release) ----
-.github/
+# ---- GitHub workflows ----
+# Track CI workflows (test + HACS validation) so GitHub Actions can run them.
+# Untracking the whole .github/ in April 2026 silently broke CI for 2+ months
+# and froze the version label drift in #784. Whitelist the workflows we
+# actually want CI to execute; ignore everything else under .github/.
+.github/*
+!.github/workflows/
+.github/workflows/*
+!.github/workflows/test.yml
+!.github/workflows/validate.yml
+
+# Test infra needed by CI to run pytest cleanly. Without these, the test
+# workflow imports beatify and hits a homeassistant metaclass conflict
+# at collection time (root conftest.py stubs HA modules). pytest.ini
+# enables asyncio_mode = auto which the async tests require.
+!conftest.py
+!pytest.ini
 
 # ---- Minified build artefacts (auto-generated, not tracked) ----
 # Run `make build` locally or see .github/workflows/build-assets.yml

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,73 @@
+"""
+Root conftest.py: stub all homeassistant (HA) modules so beatify game
+logic can be imported and tested without a running HA instance.
+
+Must live at the repo root — pytest processes it before any test file
+or tests/conftest.py imports happen.
+"""
+
+from __future__ import annotations
+
+import sys
+from types import ModuleType
+from unittest.mock import MagicMock
+
+
+def _make_pkg(name: str) -> ModuleType:
+    """Register a real (empty) package so sub-imports work."""
+    mod = ModuleType(name)
+    mod.__path__ = []  # type: ignore[attr-defined]
+    mod.__package__ = name
+    sys.modules[name] = mod
+    return mod
+
+
+def _make_leaf(name: str) -> MagicMock:
+    """Register a MagicMock leaf module (attribute access is unrestricted)."""
+    mock = MagicMock()
+    mock.__name__ = name
+    mock.__spec__ = None
+    sys.modules[name] = mock
+    return mock
+
+
+# ---------------------------------------------------------------------------
+# Stub homeassistant package hierarchy
+# ---------------------------------------------------------------------------
+
+_PACKAGES = [
+    "homeassistant",
+    "homeassistant.components",
+    "homeassistant.helpers",
+    "homeassistant.util",
+]
+
+_LEAVES = [
+    "homeassistant.components.frontend",
+    "homeassistant.components.http",
+    "homeassistant.components.media_player",
+    "homeassistant.components.media_player.const",
+    "homeassistant.core",
+    "homeassistant.config_entries",
+    "homeassistant.helpers.aiohttp_client",
+    "homeassistant.helpers.entity_platform",
+    "homeassistant.helpers.storage",
+    "homeassistant.helpers.entity",
+    "homeassistant.helpers.event",
+    "homeassistant.exceptions",
+    "homeassistant.util.dt",
+]
+
+for _pkg in _PACKAGES:
+    if _pkg not in sys.modules:
+        _make_pkg(_pkg)
+
+for _leaf in _LEAVES:
+    if _leaf not in sys.modules:
+        _make_leaf(_leaf)
+
+# Wire child attributes onto parent packages so `from homeassistant.X import Y` works
+_ha = sys.modules["homeassistant"]
+_ha.components = sys.modules["homeassistant.components"]  # type: ignore[attr-defined]
+_ha.helpers = sys.modules["homeassistant.helpers"]  # type: ignore[attr-defined]
+_ha.util = sys.modules["homeassistant.util"]  # type: ignore[attr-defined]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+testpaths = tests
+asyncio_mode = auto
+pythonpath = .


### PR DESCRIPTION
Follow-up to #784. The April commit [\`6d056b35\`](https://github.com/mholzi/beatify/commit/6d056b35) untracked \`.github/workflows/\` plus root \`conftest.py\` + \`pytest.ini\`. Effects accumulated invisibly:

- Test CI hasn't run on any PR since April 15.
- HACS \`validate.yml\` (hassfest + HACS structure check) never ran — risk of shipping a broken manifest goes uncaught.
- \`version-bump.yml\` silently froze \`_VERSION\` at \`3.2.0-rc29\` for 2+ months before #784 surfaced it.

## Changes

**Re-tracked** (CI dependencies):
- \`.github/workflows/test.yml\` — lint + pytest gate
- \`.github/workflows/validate.yml\` — HACS validation, hassfest
- \`conftest.py\` (root) — stubs \`homeassistant\` modules so tests can import \`beatify\` without a real HA install (without this, CI hits a metaclass conflict at collection time)
- \`pytest.ini\` — \`asyncio_mode = auto\`, \`testpaths = tests\`, \`pythonpath = .\`

**Deleted** (now obsolete):
- \`.github/workflows/version-bump.yml\` — replaced by #785's runtime read of \`manifest.json\`. Couldn't have run on GitHub anyway since it's been untracked for 2+ months.
- \`.github/workflows/pages.yml\` — was deploying \`docs/\`, but \`docs/\` is also untracked; nothing to deploy.

**\`.gitignore\`** now whitelists the two CI workflows under \`.github/workflows/\` and explicitly un-ignores \`conftest.py\` + \`pytest.ini\`.

## Heads up: red CI incoming

Re-tracking \`test.yml\` will surface 6 pre-existing failures in \`test_lights.py\` / \`test_state.py\` / \`test_websocket.py\` that have been broken since before April:

\`\`\`
FAILED tests/unit/test_lights.py::TestStartStop::test_stop_handles_service_call_error
FAILED tests/unit/test_lights.py::TestApplyCapability::test_apply_handles_service_error
FAILED tests/unit/test_lights.py::TestApplyCapability::test_apply_continues_after_one_light_fails
FAILED tests/unit/test_state.py::TestAddPlayer::test_add_duplicate_name_rejected
FAILED tests/unit/test_state.py::TestAddPlayer::test_duplicate_name_case_insensitive
FAILED tests/unit/test_websocket.py::TestPlayerOnboarded::test_players_state_includes_onboarded
\`\`\`

385 pass + 6 fail + 1 xfail. The 6 failures are pre-existing; this PR does not introduce them. **The first merge to main after this lands will show red CI** — that's the correct signal. Worth a follow-up to fix or quarantine, but deliberately out of scope here so this PR stays a clean infra change.

## Why no version bump

This is repo-level infra, not anything that ships to HACS users. The integration is unchanged — \`manifest.json\` and \`sw.js\` stay at \`3.3.1-rc7\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)