### PR TITLE
test: un-xfail 6 stale tests by fixing actual test bugs (closes #788)

### DIFF
--- a/tests/unit/test_lights.py
+++ b/tests/unit/test_lights.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from homeassistant.exceptions import HomeAssistantError
 
 from custom_components.beatify.services.lights import (
     RAINBOW_COLORS,
@@ -220,18 +221,10 @@ class TestStartStop:
         assert svc._current_phase is None
 
     @pytest.mark.asyncio
-    @pytest.mark.xfail(
-        reason=(
-            "Same root cause as the _apply tests: mocks raise generic Exception, "
-            "production code only catches HomeAssistantError + ServiceNotFound. "
-            "Pre-existing bug — flagged for follow-up cleanup."
-        ),
-        strict=False,
-    )
     async def test_stop_handles_service_call_error(self):
         """Stop should not raise even if restore fails."""
         hass = _make_hass()
-        hass.services.async_call = AsyncMock(side_effect=Exception("HA error"))
+        hass.services.async_call = AsyncMock(side_effect=HomeAssistantError("HA error"))
         svc = PartyLightsService(hass)
         await svc.start(["light.living_room"])
         # Should not raise
@@ -745,20 +738,10 @@ class TestApplyCapability:
         assert call_args["entity_id"] == "light.sw"
 
     @pytest.mark.asyncio
-    @pytest.mark.xfail(
-        reason=(
-            "Test mocks side_effect=Exception('HA error'), but production code "
-            "only catches (HomeAssistantError, ServiceNotFound). Generic Exception "
-            "is intentionally NOT caught (#noqa: BLE001 in lights.py:422). The "
-            "test should use HomeAssistantError() instead. Pre-existing bug from "
-            "before CI was untracked — flagged for follow-up cleanup."
-        ),
-        strict=False,
-    )
     async def test_apply_handles_service_error(self):
         """_apply should not raise if a light fails."""
         hass = _make_hass()
-        hass.services.async_call = AsyncMock(side_effect=Exception("HA error"))
+        hass.services.async_call = AsyncMock(side_effect=HomeAssistantError("HA error"))
         svc = PartyLightsService(hass)
         await svc.start(["light.living_room"])
 
@@ -769,15 +752,6 @@ class TestApplyCapability:
         )
 
     @pytest.mark.asyncio
-    @pytest.mark.xfail(
-        reason=(
-            "Same root cause as test_apply_handles_service_error: mocks raise "
-            "generic Exception, production code only catches HomeAssistantError + "
-            "ServiceNotFound. Should use HomeAssistantError() in the side_effect. "
-            "Pre-existing bug — flagged for follow-up cleanup."
-        ),
-        strict=False,
-    )
     async def test_apply_continues_after_one_light_fails(self):
         """If one light errors, remaining lights should still be called."""
         call_count = 0
@@ -786,7 +760,7 @@ class TestApplyCapability:
             nonlocal call_count
             call_count += 1
             if call_count == 1:
-                raise Exception("HA error")  # noqa: TRY002
+                raise HomeAssistantError("HA error")
 
         hass = _make_hass(
             {

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -122,28 +122,22 @@ class TestAddPlayer:
         assert err is None
         assert "Alice" in self.state.players
 
-    @pytest.mark.xfail(
-        reason=(
-            "GameState.add_player no longer rejects duplicate names — production "
-            "code returns ok=True for both attempts. Either the test is stale "
-            "(rejection moved elsewhere, e.g. PlayerRegistry) or the rejection "
-            "was intentionally dropped. Needs investigation. Pre-existing bug — "
-            "flagged for follow-up."
-        ),
-        strict=False,
-    )
     def test_add_duplicate_name_rejected(self):
-        self.state.add_player("Alice", MagicMock())
+        # ws.closed must be explicitly False — bare MagicMock attributes are
+        # MagicMocks (truthy), which PlayerRegistry interprets as a dead
+        # connection and allows rejoin under "stale connected flag" handling
+        # (#646). For this test we want the original ws to look healthy.
+        first_ws = MagicMock()
+        first_ws.closed = False
+        self.state.add_player("Alice", first_ws)
         ok, err = self.state.add_player("Alice", MagicMock())
         assert ok is False
         assert err == ERR_NAME_TAKEN
 
-    @pytest.mark.xfail(
-        reason="Same root cause as test_add_duplicate_name_rejected. Pre-existing bug.",
-        strict=False,
-    )
     def test_duplicate_name_case_insensitive(self):
-        self.state.add_player("Alice", MagicMock())
+        first_ws = MagicMock()
+        first_ws.closed = False
+        self.state.add_player("Alice", first_ws)
         ok, err = self.state.add_player("alice", MagicMock())
         assert ok is False
         assert err == ERR_NAME_TAKEN

--- a/tests/unit/test_websocket.py
+++ b/tests/unit/test_websocket.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock
 
-import pytest
-
 from custom_components.beatify.const import (
     DOMAIN,
     ERR_ADMIN_CANNOT_LEAVE,
@@ -820,20 +818,13 @@ class TestPlayerOnboarded:
         assert alice is not None
         assert alice.onboarded is False
 
-    @pytest.mark.xfail(
-        reason=(
-            "GameState.registry attribute no longer exists — was refactored away "
-            "(probably consolidated into a different accessor). Test needs to be "
-            "updated to use the current API. Pre-existing bug — flagged for "
-            "follow-up."
-        ),
-        strict=False,
-    )
     async def test_players_state_includes_onboarded(self):
         """get_players_state() includes the onboarded flag for the host view."""
         handler, game_state, ws = _make_handler_and_game()
         await handler._handle_message(ws, {"type": "join", "name": "Alice"})
-        rows = game_state.registry.get_players_state()
+        # `.registry` attribute was renamed `_player_registry` (now private).
+        # Use the public accessor on GameState which delegates to it.
+        rows = game_state.get_players_state()
         assert any("onboarded" in row for row in rows)
         alice_row = next(r for r in rows if r["name"] == "Alice")
         assert alice_row["onboarded"] is False


### PR DESCRIPTION
Closes #788. Each xfail was a real test bug, not a production bug.

## Lights × 3

Tests mocked \`hass.services.async_call\` with \`side_effect=Exception(\"HA error\")\`. Production code in \`services/lights.py\` only catches \`(HomeAssistantError, ServiceNotFound)\` — generic \`Exception\` is intentionally not caught (\`# noqa: BLE001\` confirms intent). Swapped the side_effect to \`HomeAssistantError(\"HA error\")\` so the catch clause actually triggers.

## State × 2

Tests passed bare \`MagicMock()\` as ws. \`PlayerRegistry.add_player\` (post-#646) checks \`existing_player.ws.closed\` to detect dead connections — a MagicMock's \`.closed\` attribute is itself a (truthy) MagicMock, so the registry interprets the \"old\" connection as already dead and allows the rejoin path, bypassing duplicate-name rejection.

Fix: explicitly set \`ws.closed = False\` on the first ws so the registry sees a healthy existing connection and rejects.

## WebSocket × 1

Test referenced \`game_state.registry.get_players_state()\`. The attribute was renamed to \`_player_registry\` (private). \`GameState\` already exposes a public delegating accessor, so use \`game_state.get_players_state()\` directly.

## After

\`\`\`
391 passed, 1 xfailed
\`\`\`

The 1 remaining xfail is the pre-existing \`test_state_read_exception_does_not_skip_song\` from #777, separately documented. All 6 #788 xfails removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)