### PR TITLE
fix(admin): allow admin reclaim during any phase (closes #790)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to Beatify are documented here. For detailed release notes, 
 
 ## [Unreleased]
 
+## [3.3.1-rc8] - 2026-04-25
+
+### Fixed
+- **Admin can reclaim their own role during any game phase (#790).** When the admin's WebSocket dropped silently during REVEAL or PLAYING (network blip, AirPlay-induced HA hiccup) and the browser tried to reconnect with the same name + `is_admin=true`, the join handler hit the *"Only allow new admin claim during LOBBY"* rejection at [`ws_handlers.py:113`](custom_components/beatify/server/ws_handlers.py#L113), removed the player from the game, and sent them to the name-entry screen — locking them out of their own game. Now the handler recognises a same-name admin reclaim by checking the existing player record's `is_admin=True` flag and allows the reconnect regardless of phase. New admins claiming during non-LOBBY phases are still rejected. Reported by @Levtos in #790.
+- **`pause_game` always captures the admin name (#790).** Previously only `pause_game("admin_disconnected")` set `disconnected_admin_name`. Server-triggered pauses (`media_player_error`, `no_songs_available`) left the field empty, so even via the existing reconnect path the admin couldn't recover from those pauses. Now any pause stores the current admin's name, giving them a guaranteed recovery route.
+
+### Tests
+- 3 new tests covering: same-name admin reclaim during REVEAL, intruder claim during REVEAL still rejected, `pause_game` capturing admin name on `media_player_error` and `no_songs_available`.
+- Total: 395 passed, 1 xfailed (the pre-existing #777 resilience test).
+
+### For contributors
+- Bumped manifest + `sw.js CACHE_VERSION` → `3.3.1-rc8`. No frontend asset changes — HTML cache-busters unchanged.
+
 ## [3.3.1-rc7] - 2026-04-25
 
 ### Fixed

--- a/custom_components/beatify/game/state.py
+++ b/custom_components/beatify/game/state.py
@@ -781,12 +781,16 @@ class GameState:
         self._previous_phase = self.phase
         self.pause_reason = reason
 
-        # Store admin name for rejoin verification (Story 7-2)
-        if reason == "admin_disconnected":
-            for player in self.players.values():
-                if player.is_admin:
-                    self.disconnected_admin_name = player.name
-                    break
+        # Store admin name for rejoin verification (Story 7-2). #790: capture
+        # this for ANY pause reason, not just "admin_disconnected" — when the
+        # pause is triggered server-side (media_player_error, no_songs_available)
+        # the admin's WS may still be open, but if it later drops they need a
+        # path back. Without this, ws_handlers.py:113 rejects all admin claims
+        # during non-LOBBY phases and the game becomes unrecoverable.
+        for player in self.players.values():
+            if player.is_admin:
+                self.disconnected_admin_name = player.name
+                break
 
         # Stop timer if in PLAYING
         if self.phase == GamePhase.PLAYING:

--- a/custom_components/beatify/manifest.json
+++ b/custom_components/beatify/manifest.json
@@ -12,5 +12,5 @@
   "documentation": "https://github.com/mholzi/beatify",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/mholzi/beatify/issues",
-  "version": "3.3.1-rc7"
+  "version": "3.3.1-rc8"
 }

--- a/custom_components/beatify/server/ws_handlers.py
+++ b/custom_components/beatify/server/ws_handlers.py
@@ -71,7 +71,32 @@ async def handle_join(
         player = game_state.get_player(name)
 
         if is_admin:
-            if game_state.disconnected_admin_name:
+            # #790: Existing admin reclaiming their own role should always be
+            # allowed, regardless of phase. Without this check, an admin whose
+            # WS dropped (network blip, AirPlay-induced HA hiccup) tries to
+            # reconnect with their original name, hits the "Only allow new
+            # admin claim during LOBBY" rejection, and gets remove_player'd
+            # — losing admin entirely. The existing player record matching
+            # by name with is_admin=True means this is the same human host.
+            is_own_admin_reclaim = (
+                player is not None
+                and player.is_admin
+                and not any(
+                    p.is_admin and p.name.lower() != name.lower()
+                    for p in list(game_state.players.values())
+                )
+            )
+            if is_own_admin_reclaim:
+                # Cancel any pending pause task — admin is back.
+                if handler._admin_disconnect_task:
+                    handler._admin_disconnect_task.cancel()
+                    handler._admin_disconnect_task = None
+                    _LOGGER.info("Admin reconnected (own reclaim): %s", name)
+                handler.cancel_pending_removal(name)
+                if game_state.phase == GamePhase.PAUSED:
+                    if await game_state.resume_game():
+                        _LOGGER.info("Game resumed by admin reclaim during PAUSED")
+            elif game_state.disconnected_admin_name:
                 if name.lower() == game_state.disconnected_admin_name.lower():
                     if handler._admin_disconnect_task:
                         handler._admin_disconnect_task.cancel()

--- a/custom_components/beatify/www/sw.js
+++ b/custom_components/beatify/www/sw.js
@@ -6,7 +6,7 @@
  */
 'use strict';
 
-var CACHE_VERSION = 'beatify-v3.3.1-rc7';
+var CACHE_VERSION = 'beatify-v3.3.1-rc8';
 var MAX_CACHE_ITEMS = 50;
 
 // Critical assets to precache on install (minified versions only - fallback handled by HTML)

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -758,6 +758,23 @@ class TestPauseGame:
         await self.state.pause_game("admin_disconnected")
         mock_media.stop.assert_awaited_once()
 
+    @pytest.mark.asyncio
+    async def test_pause_captures_admin_name_for_any_reason(self):
+        """#790: pause_game must capture admin name regardless of reason.
+
+        Without this, server-triggered pauses (media_player_error,
+        no_songs_available) leave disconnected_admin_name empty and the admin
+        can't reclaim via the existing reconnect path — creating an
+        unrecoverable stuck state.
+        """
+        await self.state.pause_game("media_player_error")
+        assert self.state.disconnected_admin_name == "Admin"
+
+    @pytest.mark.asyncio
+    async def test_pause_captures_admin_name_on_no_songs_available(self):
+        await self.state.pause_game("no_songs_available")
+        assert self.state.disconnected_admin_name == "Admin"
+
 
 class TestResumeGame:
     @pytest.fixture(autouse=True)

--- a/tests/unit/test_websocket.py
+++ b/tests/unit/test_websocket.py
@@ -231,6 +231,66 @@ class TestJoin:
         # Game should be resumed
         assert game_state.phase == GamePhase.PLAYING
 
+    async def test_admin_can_reclaim_during_reveal_without_pause(self):
+        """#790: existing admin reclaiming during REVEAL must not be rejected.
+
+        Levtos's symptom: admin's WS dropped silently (no pause_game fired
+        because grace period hadn't expired or didn't trigger), browser
+        reconnects with same name + is_admin=True. Old code hit the
+        line 113 phase!=LOBBY rejection and removed the player. Now we
+        recognize a same-name admin reclaim and allow it regardless of phase.
+        """
+        handler, game_state, ws = _make_handler_and_game()
+        admin_ws = _make_ws()
+        game_state.add_player("Ben", admin_ws)
+        game_state.set_admin("Ben")
+        # Simulate the WS drop that triggers Levtos's flow: connected=False
+        # but no pause yet (grace period running or never fired).
+        game_state.players["Ben"].connected = False
+        game_state.phase = GamePhase.REVEAL
+        assert not game_state.disconnected_admin_name
+
+        new_ws = _make_ws()
+        await handler._handle_message(
+            new_ws, {"type": "join", "name": "Ben", "is_admin": True}
+        )
+
+        # Ben should still be admin, still in players, no error sent.
+        assert "Ben" in game_state.players
+        assert game_state.players["Ben"].is_admin is True
+        # Phase stays REVEAL — reclaim doesn't auto-resume from REVEAL
+        assert game_state.phase == GamePhase.REVEAL
+        # No error was sent on the new ws
+        for call in new_ws.send_json.call_args_list:
+            payload = call[0][0]
+            assert payload.get("type") != "error"
+
+    async def test_new_admin_still_rejected_during_reveal(self):
+        """#790: only the existing admin can reclaim during non-LOBBY phases.
+
+        Someone else trying to claim admin must still be rejected — the
+        reclaim allowance only applies when the joining name matches the
+        current admin record.
+        """
+        handler, game_state, ws = _make_handler_and_game()
+        admin_ws = _make_ws()
+        game_state.add_player("Ben", admin_ws)
+        game_state.set_admin("Ben")
+        game_state.phase = GamePhase.REVEAL
+
+        intruder_ws = _make_ws()
+        await handler._handle_message(
+            intruder_ws,
+            {"type": "join", "name": "Intruder", "is_admin": True},
+        )
+
+        msg = intruder_ws.send_json.call_args[0][0]
+        assert msg["type"] == "error"
+        # Either ERR_ADMIN_EXISTS (existing admin found) or ERR_INVALID_ACTION
+        # (phase check) is acceptable — both mean "no, you're not admin".
+        assert msg["code"] in (ERR_ADMIN_EXISTS, ERR_INVALID_ACTION)
+        assert "Intruder" not in game_state.players
+
 
 # ---------------------------------------------------------------------------
 # Submit


### PR DESCRIPTION
Closes #790. Reported by @Levtos in [PR #783 comment](https://github.com/mholzi/beatify/pull/783#issuecomment-4317311042).

## Bug

Admin's WS drops mid-game (network blip, AirPlay-induced HA hiccup, browser reload during round). Browser reconnects with same name + \`is_admin=true\`. Old code:

1. \`add_player\` succeeds via the existing #646 stale-flag path (existing player record's \`connected=False\` triggers reconnect).
2. \`is_admin=True\` request goes through join handler.
3. \`disconnected_admin_name\` was empty (no \`pause_game\` had fired) so the handler fell through to the *new admin claim* branch.
4. \`existing_admin\` check found nothing (the only admin was the joining player themselves, excluded by \`p.name != name\`).
5. Phase was REVEAL, not LOBBY, so the [\`ws_handlers.py:113\`](custom_components/beatify/server/ws_handlers.py#L113) rejection fired.
6. \`remove_player\` removed Ben from the game entirely.
7. Browser saw \"admin claim only allowed during lobby\" → redirected to name-entry → reload loop.

Levtos's logs confirmed: \`Rejected admin claim from Ben during REVEAL phase\` (×6 attempts).

## Fix

### 1. \`ws_handlers.handle_join\` recognises own-admin reclaim

Before the new-claim branches, check:

\`\`\`python
is_own_admin_reclaim = (
    player is not None
    and player.is_admin
    and not any(
        p.is_admin and p.name.lower() != name.lower()
        for p in list(game_state.players.values())
    )
)
\`\`\`

If true, let them through regardless of phase. Resume the game if currently PAUSED, otherwise keep the existing phase intact. Intruder claims during non-LOBBY phases are still rejected — the new branch only applies when the joining name matches an existing admin record.

### 2. \`pause_game\` always captures admin name

Previously the capture was gated on \`reason == \"admin_disconnected\"\`. Server-triggered pauses (\`media_player_error\`, \`no_songs_available\`) left \`disconnected_admin_name\` empty, so even the existing reconnect path at line 74 didn't help — admin couldn't recover from those pauses. Now any pause stores the current admin's name, giving them a guaranteed recovery route.

## Tests

3 new tests:

- \`test_admin_can_reclaim_during_reveal_without_pause\` — Levtos's scenario. Admin's WS marked \`connected=False\`, phase=REVEAL, no pause yet. Reclaim succeeds, no error sent, role preserved.
- \`test_new_admin_still_rejected_during_reveal\` — confirms the reclaim allowance doesn't open a new-admin loophole.
- \`test_pause_captures_admin_name_for_any_reason\` + \`test_pause_captures_admin_name_on_no_songs_available\` — verify the pause_game broadening.

\`\`\`
395 passed, 1 xfailed in 65.41s
\`\`\`

(The 1 xfail is the pre-existing #777 resilience test.)

## What this doesn't fix

- The underlying *why did Ben's WS drop in round 4* question is still open — likely correlates with the 8s buffering window for AirPlay tracks that don't resolve. Worth observing in his rc8 retest. If it reproduces, separate issue.
- The asyncio \`InvalidStateError\` traces in HA core that Levtos observed — likely tangential, would need to repro them in isolation.
- \`HAOS reload loop\` — that was a downstream symptom of the admin lockout. With recovery available, the loop shouldn't recur. If it does after this fix, the loop has its own root cause and needs a separate trace.

## Version

- \`manifest.json\` + \`sw.js CACHE_VERSION\` → \`3.3.1-rc8\`
- No frontend asset changes — HTML cache-busters unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)