### PR TITLE
release: v3.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,31 @@ All notable changes to Beatify are documented here. For detailed release notes, 
 
 ## [Unreleased]
 
+## [3.3.1] - 2026-04-25
+
+Stable promotion of the 3.3.1-rc line. See [release notes](https://github.com/mholzi/beatify/releases/tag/v3.3.1) for the user-facing summary.
+
+### Fixed
+- **Apple Music via Music Assistant (#772)** — emit MA's native `apple_music://track/<id>` URI; the short `music.apple.com/song/<id>` URL was rejected by MA's parser. Closes the remaining failure from @Levtos's #768 follow-up.
+- **Silent rounds when MA can't start a track (#777)** — strict-detection compares speaker `media_title` and `media_position_updated_at` before/after the wait; "neither moved" is now a hard failure that falls through to the next URI candidate. MA timeout extended 8s → 15s for AirPlay.
+- **Admin can reclaim their own role during any phase (#790)** — same-name + `is_admin=true` reconnect during REVEAL/PLAYING is recognised as the existing admin returning. Bonus: `pause_game` now captures admin name on every reason, not just `admin_disconnected`.
+- **Service worker scope mismatch (#780)** — moved `sw.js` to `/beatify/sw.js` so its `/beatify/` scope claim is allowed. The SW finally activates; all `CACHE_VERSION` bumps now do what they say.
+- **Admin footer version label (#784)** — read from `manifest.json` at setup instead of a hardcoded constant that drifted to `v3.2.0-rc29` since April. Single source of truth, no GitHub Action dependency.
+- **Wizard provider chips re-render on speaker change** — switching speakers in Step 1 no longer leaves stale chip-dimming in Step 2.
+- **Admin i18n keys** (`admin.filterAll`, `admin.skipRound`) added across all 5 locales (#779).
+- **6 stale unit tests** un-xfailed by fixing the actual test bugs (closes #788).
+
+### Added
+- **Wizard service-compatibility UX (#772)** — capability badges per speaker in Step 1 (*"All services"* / *"Spotify only"* / *"Spotify, Apple Music"*) and dimmed-with-lock provider chips in Step 2 with an explainer card pointing to Music Assistant. Continue is blocked until a supported provider is picked. Locale word order respected across en/de/es/fr/nl.
+- **Emergency reset button** — small ⟲ icon in the admin header. One click ends any active game on the server, clears Beatify's localStorage, unregisters the service worker, and reloads. Backed by a new rate-limited `POST /beatify/api/force-reset` endpoint that doesn't require an admin token. Born from @Levtos's "großen roten Button" request.
+- **Backend force-reset endpoint** — `POST /beatify/api/force-reset` (3/hour per IP, no auth — by design, since the situation that needs it is one where the admin token may be unreachable).
+
+### For contributors
+- Bumped manifest + `sw.js CACHE_VERSION` + all HTML `?v=` cache-busters → `3.3.1`.
+- CI restored after two months untracked: `test.yml`, `validate.yml`, `conftest.py`, `pytest.ini` re-tracked. 53 files re-formatted to ruff baseline. `_VERSION` constant deleted; obsolete `version-bump.yml` workflow removed.
+- 17 new tests across MA stale-state detection, provider-capability gating, admin reclaim during REVEAL, pause-game admin-name capture. Total: 395 passed, 1 xfailed.
+- 12 new i18n keys across en/de/es/fr/nl: capability badges (`admin.step1.cap*`), MA explainer (`admin.step2.explainer.*`), reset modal (`admin.reset.*`).
+
 ## [3.3.1-rc8] - 2026-04-25
 
 ### Fixed

--- a/custom_components/beatify/manifest.json
+++ b/custom_components/beatify/manifest.json
@@ -12,5 +12,5 @@
   "documentation": "https://github.com/mholzi/beatify",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/mholzi/beatify/issues",
-  "version": "3.3.1-rc8"
+  "version": "3.3.1"
 }

--- a/custom_components/beatify/www/admin.html
+++ b/custom_components/beatify/www/admin.html
@@ -17,7 +17,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@700;900&display=swap" rel="stylesheet">
     <!-- Story 18.4: Use minified CSS in production -->
-    <link rel="stylesheet" href="/beatify/static/css/styles.min.css?v=3.3.1-rc6">
+    <link rel="stylesheet" href="/beatify/static/css/styles.min.css?v=3.3.1">
 </head>
 <body class="theme-dark">
     <!-- First-run wizard takeover (see DESIGN.md ## Patterns → First-run wizard) -->
@@ -1071,11 +1071,11 @@
     <script src="/beatify/static/js/i18n.js?v=1.7.0"></script>
     <script src="/beatify/static/js/utils.js?v=1.7.0"></script>
     <!-- Story 44.1: Playlist requests module -->
-    <script src="/beatify/static/js/playlist-requests.min.js?v=3.3.0"></script>
-    <script type="module" src="/beatify/static/js/playlist-hub.js?v=3.3.0"></script>
-    <script type="module" src="/beatify/static/js/wizard.js?v=3.3.1-rc3"></script>
-    <script src="/beatify/static/js/admin.min.js?v=3.3.1-rc6"></script>
-    <script src="/beatify/static/js/party-lights.min.js?v=3.3.0"></script>
-    <script src="/beatify/static/js/tts-settings.js?v=3.3.0"></script>
+    <script src="/beatify/static/js/playlist-requests.min.js?v=3.3.1"></script>
+    <script type="module" src="/beatify/static/js/playlist-hub.js?v=3.3.1"></script>
+    <script type="module" src="/beatify/static/js/wizard.js?v=3.3.1"></script>
+    <script src="/beatify/static/js/admin.min.js?v=3.3.1"></script>
+    <script src="/beatify/static/js/party-lights.min.js?v=3.3.1"></script>
+    <script src="/beatify/static/js/tts-settings.js?v=3.3.1"></script>
 </body>
 </html>

--- a/custom_components/beatify/www/dashboard.html
+++ b/custom_components/beatify/www/dashboard.html
@@ -10,7 +10,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Outfit:wght@700;900&display=swap" rel="stylesheet">
     <!-- Story 18.4: Use minified CSS in production -->
     <link rel="stylesheet" href="/beatify/static/css/styles.css?v=1.7.0">
-    <link rel="stylesheet" href="/beatify/static/css/dashboard.min.css?v=3.3.0">
+    <link rel="stylesheet" href="/beatify/static/css/dashboard.min.css?v=3.3.1">
     <!-- Confetti library for celebrations (Story 14.5) -->
     <script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.9.2/dist/confetti.browser.min.js"></script>
 </head>
@@ -283,7 +283,7 @@
     <!-- Version query strings prevent browser caching issues -->
     <script src="/beatify/static/js/i18n.js?v=1.7.0"></script>
     <script src="/beatify/static/js/utils.js?v=1.7.0"></script>
-    <script src="/beatify/static/js/dashboard.min.js?v=3.3.1-rc4"></script>
+    <script src="/beatify/static/js/dashboard.min.js?v=3.3.1"></script>
     <!-- v3.2.1 Arcade shims: submission meter fill, album ring progress, reveal round mirror.
          Pure view-layer helpers — no state, no API calls. Safe to remove if dashboard.js
          ever takes these over directly. -->

--- a/custom_components/beatify/www/player.html
+++ b/custom_components/beatify/www/player.html
@@ -894,6 +894,6 @@
     <!-- Version query strings prevent browser caching issues -->
     <script src="/beatify/static/js/i18n.min.js"></script>
     <script src="/beatify/static/js/utils.min.js"></script>
-    <script type="module" src="/beatify/static/js/player.bundle.min.js?v=3.3.1-rc4"></script>
+    <script type="module" src="/beatify/static/js/player.bundle.min.js?v=3.3.1"></script>
 </body>
 </html>

--- a/custom_components/beatify/www/sw.js
+++ b/custom_components/beatify/www/sw.js
@@ -6,7 +6,7 @@
  */
 'use strict';
 
-var CACHE_VERSION = 'beatify-v3.3.1-rc8';
+var CACHE_VERSION = 'beatify-v3.3.1';
 var MAX_CACHE_ITEMS = 50;
 
 // Critical assets to precache on install (minified versions only - fallback handled by HTML)


### PR DESCRIPTION
Stable promotion of the 3.3.1-rc line.

Bumps manifest + `sw.js CACHE_VERSION` + all HTML `?v=` cache-busters → `3.3.1`.

See CHANGELOG and the v3.3.1 GitHub Release for the user-facing summary.

Closes #772, #777, #779, #780, #784, #786, #787, #788, #790.

🤖 Generated with [Claude Code](https://claude.com/claude-code)