### PR TITLE
fix(playback): Deezer URI passthrough for MA (closes #797)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to Beatify are documented here. For detailed release notes, 
 
 ## [Unreleased]
 
+## [3.3.2-rc2] - 2026-04-26
+
+### Fixed
+- **Deezer via Music Assistant (#797)** — same shape of bug as #772 (Apple Music) but for Deezer. Beatify was converting `deezer://track/<id>` → `https://www.deezer.com/track/<id>`, which routed through MA's generic `http(s)://` branch to the **builtin** provider — and builtin doesn't know how to play Deezer. Result: `HomeAssistantError: No playable items found`. Pass through the native `deezer://track/<id>` form so MA routes directly to the Deezer provider domain. Reported by @Ziigmund84.
+
+### For contributors
+- Bumped manifest + `sw.js CACHE_VERSION` → `3.3.2-rc2`. No frontend asset changes — HTML cache-busters unchanged.
+- 1 new test in `test_media_player.py` covering the native Deezer URI passthrough. 402 passed, 1 xfailed.
+
 ## [3.3.2-rc1] - 2026-04-25
 
 ### Fixed

--- a/custom_components/beatify/manifest.json
+++ b/custom_components/beatify/manifest.json
@@ -12,5 +12,5 @@
   "documentation": "https://github.com/mholzi/beatify",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/mholzi/beatify/issues",
-  "version": "3.3.2-rc1"
+  "version": "3.3.2-rc2"
 }

--- a/custom_components/beatify/services/media_player.py
+++ b/custom_components/beatify/services/media_player.py
@@ -222,6 +222,7 @@ class MediaPlayerService:
 
         Beatify playlists store URIs in internal formats:
         - applemusic://track/<id>  → apple_music://track/<id>  (MA native, #772)
+        - deezer://track/<id>      → unchanged (MA native, #797)
         - tidal://track/<id>       → https://tidal.com/browse/track/<id>
         - spotify:track:<id>       → unchanged (MA native format)
         - https://music.youtube.com/... → unchanged (already a URL)
@@ -237,8 +238,12 @@ class MediaPlayerService:
             return uri
 
         if uri.startswith("deezer://track/"):
-            track_id = uri.removeprefix("deezer://track/")
-            return f"https://www.deezer.com/track/{track_id}"
+            # MA's Deezer provider has domain "deezer". The previous
+            # https://www.deezer.com/track/<id> form was being routed to the
+            # "builtin" provider via MA's generic http(s):// branch — and
+            # builtin doesn't know Deezer, so playback failed with
+            # "No playable items found". Pass through the native form. (#797)
+            return uri
 
         if uri.startswith("applemusic://track/"):
             # MA's Apple Music provider has domain "apple_music". Use MA's native

--- a/custom_components/beatify/www/sw.js
+++ b/custom_components/beatify/www/sw.js
@@ -6,7 +6,7 @@
  */
 'use strict';
 
-var CACHE_VERSION = 'beatify-v3.3.2-rc1';
+var CACHE_VERSION = 'beatify-v3.3.2-rc2';
 var MAX_CACHE_ITEMS = 50;
 
 // Critical assets to precache on install (minified versions only - fallback handled by HTML)

--- a/tests/unit/test_media_player.py
+++ b/tests/unit/test_media_player.py
@@ -620,6 +620,24 @@ class TestMAProviderFallback:
         candidates = svc._get_ma_uri_candidates(song)
         assert candidates[0][1] == "apple_music://track/999"
 
+    def test_candidates_keeps_deezer_native_form(self):
+        """deezer://track/ URIs are passed through unchanged (#797).
+
+        The previous https://www.deezer.com/track/<id> form routed via MA's
+        generic http(s):// branch to the 'builtin' provider, which doesn't
+        know how to play Deezer tracks — failed with "No playable items
+        found". Native provider-URI form routes directly to the deezer
+        provider domain.
+        """
+        hass = _make_hass()
+        svc = MediaPlayerService(hass, "media_player.test", platform="music_assistant")
+        song = {
+            "_resolved_uri": "deezer://track/12345",
+            "uri_deezer": "deezer://track/12345",
+        }
+        candidates = svc._get_ma_uri_candidates(song)
+        assert candidates[0][1] == "deezer://track/12345"
+
     def test_candidates_learned_preference_goes_first(self):
         """If a field was learned as preferred, its URI is tried before primary."""
         hass = _make_hass()


### PR DESCRIPTION
Closes #797. Same shape as #772 (Apple Music) but for Deezer.

## Root cause

Beatify was converting \`deezer://track/<id>\` → \`https://www.deezer.com/track/<id>\` before passing to \`music_assistant.play_media\`. MA's URI parser routes any \`http(s)://\` URI through its generic builtin-provider branch — and **builtin doesn't know how to play Deezer**. Result: \`HomeAssistantError: No playable items found\` for every Deezer URI.

## Fix

Pass \`deezer://track/<id>\` through unchanged. MA's [parser](https://github.com/music-assistant/server/blob/dev/music_assistant/helpers/uri.py) has a generic \`provider://media_type/item_id\` branch that routes to the matching provider domain. The Deezer provider's domain is \`deezer\` (verified via [manifest.json](https://github.com/music-assistant/server/blob/dev/music_assistant/providers/deezer/manifest.json)) so the native URI maps directly.

## Test

1 new assertion in \`test_media_player.py\` verifying the passthrough so we don't regress this. **402 passed, 1 xfailed.**

## Version

\`manifest.json\` + \`sw.js CACHE_VERSION\` → \`3.3.2-rc2\`. No frontend asset changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)