### PR TITLE
fix(playback): stale title alone fails playback validation (closes #795)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to Beatify are documented here. For detailed release notes, 
 
 ## [Unreleased]
 
+## [3.3.2-rc3] - 2026-04-26
+
+### Fixed
+- **Game no longer advances while speaker is stuck on a prior track (#795).** Levtos's playthrough on AirPlay + Apple Music + MA had the speaker stuck on `'Sugar, Sugar'` then `'Lazy Sunday (Mono)'` for multiple rounds while position kept advancing — the rc5 #345 tolerance was treating "title unchanged + position changed" as success because position alone was advancing. But position-only-changing means the *prior* track is still playing in real time, not that a new track started. Tightened invariant: `media_title` MUST advance to something different from before the call. Position alone is no longer enough. The #345 slow-buffer tolerance is preserved when title genuinely changed (handles the "speaker reports new title late" case for legitimate slow buffers).
+
+### For contributors
+- Bumped manifest + `sw.js CACHE_VERSION` → `3.3.2-rc3`. No frontend asset changes — HTML cache-busters unchanged.
+- Updated 1 existing test (renamed `test_ma_tolerates_slow_buffer_when_position_timestamp_advanced` → `test_ma_returns_false_when_title_unchanged_but_position_advances`, flipped expectation to `False`). 402 passed, 1 xfailed.
+
 ## [3.3.2-rc2] - 2026-04-26
 
 ### Fixed

--- a/custom_components/beatify/manifest.json
+++ b/custom_components/beatify/manifest.json
@@ -12,5 +12,5 @@
   "documentation": "https://github.com/mholzi/beatify",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/mholzi/beatify/issues",
-  "version": "3.3.2-rc2"
+  "version": "3.3.2-rc3"
 }

--- a/custom_components/beatify/services/media_player.py
+++ b/custom_components/beatify/services/media_player.py
@@ -465,11 +465,22 @@ class MediaPlayerService:
             )
             return False
 
-        # Hard failure #777: speaker still shows the *previous* track. If
-        # neither the title nor the position-updated timestamp moved during
-        # the entire wait window, the new track never started on the speaker
-        # (common with AirPlay when MA silently fails to enqueue). Fall
-        # through so the caller can try the next URI candidate.
+        # Hard failure: speaker title did not advance. If the title field is
+        # identical to what it was before we called play_media, the new track
+        # never started on the speaker — even if media_position_updated_at
+        # changed (that just means the *prior* track is still ticking).
+        #
+        # #777 originally caught only "title unchanged AND position unchanged"
+        # (everything frozen), but #795 surfaced the more common pattern:
+        # the prior track keeps playing, position advances, and the #345
+        # tolerance below would falsely return True. Levtos's playthrough
+        # had the speaker stuck on 'Sugar, Sugar' then 'Lazy Sunday (Mono)'
+        # for multiple rounds while UI advanced into "guess the year of
+        # SongX" with no actual SongX audio.
+        #
+        # Title-must-advance is the right invariant: if a new track really
+        # started, the title field must eventually become *something*
+        # different. Position alone is not proof of a new track.
         title_after = (
             current_state.attributes.get("media_title", "") if current_state else ""
         )
@@ -478,33 +489,37 @@ class MediaPlayerService:
             if current_state
             else None
         )
-        stale_title = title_after == title_before
-        stale_position = position_updated_after == position_updated_before
-        if stale_title and stale_position:
+        title_advanced = title_after != title_before
+        if not title_advanced:
+            position_changed = position_updated_after != position_updated_before
             _LOGGER.error(
                 "MA playback failed after %.1fs for %s — speaker still on "
-                "prior track %r, position timestamp unchanged; skipping (#777)",
+                "prior track %r (position timestamp %s); skipping (#795, was #777)",
                 MA_PLAYBACK_TIMEOUT,
                 uri,
                 title_before,
+                "advanced — prior track still playing"
+                if position_changed
+                else "also unchanged",
             )
             return False
 
-        # #345 slow-buffer tolerance: something changed on the speaker during
-        # the wait (either title swapped or position clock advanced), so MA is
-        # making progress — just not matching the exact expected title yet.
-        # Returning False here would chase unnecessary retries and cause the
-        # race condition #345 was filed for.
+        # #345 slow-buffer tolerance, narrowed to "title genuinely changed":
+        # title is now different from what it was before the call, so MA is
+        # making progress on *some* new track. We still don't require the
+        # title to match expected_title (AirPlay sometimes delivers
+        # remasters/alternates with mismatched-but-valid titles), but we do
+        # require title evidence of forward motion. Returning False here
+        # would re-trigger the race condition #345 was originally filed for.
         _LOGGER.warning(
             "MA playback not confirmed after %.1fs for %s (state: %s). "
-            "Speaker moved (title %r, pos ts %r → %r). Continuing anyway — "
-            "MA may still be buffering. (#345)",
+            "Title moved %r → %r. Continuing anyway — MA may still be "
+            "buffering. (#345)",
             MA_PLAYBACK_TIMEOUT,
             uri,
             speaker_state,
+            title_before,
             title_after,
-            position_updated_before,
-            position_updated_after,
         )
         return True
 

--- a/custom_components/beatify/www/sw.js
+++ b/custom_components/beatify/www/sw.js
@@ -6,7 +6,7 @@
  */
 'use strict';
 
-var CACHE_VERSION = 'beatify-v3.3.2-rc2';
+var CACHE_VERSION = 'beatify-v3.3.2-rc3';
 var MAX_CACHE_ITEMS = 50;
 
 // Critical assets to precache on install (minified versions only - fallback handled by HTML)

--- a/tests/unit/test_media_player.py
+++ b/tests/unit/test_media_player.py
@@ -316,9 +316,16 @@ class TestMANonBlockingPlayback:
         assert result is True
 
     @pytest.mark.asyncio
-    async def test_ma_tolerates_slow_buffer_when_position_timestamp_advanced(self):
-        """#345 tolerance: title stayed the same but position_updated_at moved —
-        the speaker clock is ticking, MA is reporting fresh state. Trust it.
+    async def test_ma_returns_false_when_title_unchanged_but_position_advances(self):
+        """#795 (was #345 tolerance pre-rc3): if the speaker title is identical
+        to before the call but position keeps ticking, the *prior* track is
+        still playing — a new track did NOT start. Reject so the fallback
+        cascade tries the next URI.
+
+        This is exactly Levtos's #795 scenario: speaker stuck on
+        'Sugar, Sugar' / 'Lazy Sunday (Mono)' for multiple rounds while
+        position advanced; old logic would falsely return True here and
+        the UI advanced into rounds with no actual audio change.
         """
         hass = MagicMock()
         hass.services.async_call = AsyncMock()
@@ -330,9 +337,9 @@ class TestMANonBlockingPlayback:
         )
         after = _make_state(
             "playing",
-            media_title="Old Song",  # same
+            media_title="Old Song",  # SAME title — prior track still playing
             media_position=101,
-            media_position_updated_at="2020-01-01T00:00:05+00:00",  # moved
+            media_position_updated_at="2020-01-01T00:00:05+00:00",  # position moved
         )
 
         poll = 0
@@ -355,7 +362,7 @@ class TestMANonBlockingPlayback:
             ):
                 result = await svc.play_song(_make_song(title="New Song"))
 
-        assert result is True
+        assert result is False
 
     @pytest.mark.asyncio
     async def test_ma_first_song_no_previous_title(self):


### PR DESCRIPTION
Closes #795. Reported by @Levtos on AirPlay + Apple Music + MA.

## The bug

In Levtos's playthrough, the speaker stuck on \`'Sugar, Sugar'\` then \`'Lazy Sunday (Mono)'\` for multiple rounds while the UI advanced into rounds with no actual new audio. Logs:

\`\`\`
MA playback not confirmed after 15.0s for apple_music://track/1412839444
  (state: playing). Speaker moved (title 'Sugar, Sugar', pos ts ...).
  Continuing anyway — MA may still be buffering. (#345)
\`\`\`

The old #345 tolerance returned \`True\` whenever **either** title or position changed. Levtos's case had position advancing (the prior track was still playing in real time) but title was unchanged from before the \`play_media\` call. Tolerance fired falsely → game kept advancing into rounds with stale audio.

## The fix

Tighten the invariant: **\`media_title\` MUST advance** to something different from \`title_before\`. Position alone is no longer enough — position-only-changing means the *prior* track is still ticking, not that a new track started.

The #345 slow-buffer tolerance is preserved when title genuinely changed — that's the legitimate case where the new track starts but its metadata reports late. We don't require the title to *match expected* (AirPlay sometimes delivers remasters/alternates with slightly different titles), just to *change*.

## Test surface

Renamed and inverted the rc5 test that asserted the old behavior:

\`\`\`diff
- test_ma_tolerates_slow_buffer_when_position_timestamp_advanced
+ test_ma_returns_false_when_title_unchanged_but_position_advances
\`\`\`

The setup is unchanged (title same, position advancing), but the assertion flips from \`is True\` → \`is False\` — that's the new correct behavior. **402 passed, 1 xfailed.**

## Version

\`manifest.json\` + \`sw.js CACHE_VERSION\` → \`3.3.2-rc3\`. No frontend asset changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)