### PR TITLE
fix(playback): drop position>=1 fast-path requirement (closes #803)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to Beatify are documented here. For detailed release notes, 
 
 ## [Unreleased]
 
+## [3.3.2-rc5] - 2026-04-26
+
+### Fixed
+- **Round 1 no longer freezes for 10–15s on cold MA start (#803).** @Ziigmund84 reported the wizard kicking off the first round and sitting frozen on REVEAL while audio was already playing through the speaker. Root cause: the strict-detect fast-path in `_try_ma_play` required `media_position >= 1`. On a cold MA boot, the speaker reports `state=playing` and the correct `media_title` within a few seconds, but `media_position` lags at `0` for 10–15s while MA finishes warming up. The old fast-path didn't fire, so `_try_ma_play` waited the full `MA_PLAYBACK_TIMEOUT` before letting the round advance — even though playback was already healthy. Dropped the `position >= 1` requirement: `position_updated_at` advancing already filters out the queued-but-not-playing case (a queued track's timestamp doesn't move). Title-match + fresh `position_updated_at` is enough.
+
+### For contributors
+- Bumped manifest + `sw.js CACHE_VERSION` → `3.3.2-rc5` (skipped `rc4` — that number is reserved for unmerged PR #802 on a separate branch). No frontend asset changes — HTML cache-busters unchanged.
+- Renamed `test_ma_waits_for_position_ge_1` → `test_ma_fast_path_succeeds_when_title_matches_even_if_position_zero` and removed the now-redundant `test_ma_does_not_trigger_on_title_change_alone`. 401 passed, 1 xfailed.
+
 ## [3.3.2-rc3] - 2026-04-26
 
 ### Fixed

--- a/custom_components/beatify/manifest.json
+++ b/custom_components/beatify/manifest.json
@@ -12,5 +12,5 @@
   "documentation": "https://github.com/mholzi/beatify",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/mholzi/beatify/issues",
-  "version": "3.3.2-rc3"
+  "version": "3.3.2-rc5"
 }

--- a/custom_components/beatify/services/media_player.py
+++ b/custom_components/beatify/services/media_player.py
@@ -389,10 +389,21 @@ class MediaPlayerService:
         )
 
         # Wait for the EXPECTED song to actually play on the speaker:
-        # - media_title contains expected title (not just "any change" — prevents
-        #   race condition where a previous slow song arrives during retry)
-        # - media_position >= 1 (pos=0 means only queued in MA, not yet playing)
-        # - media_position_updated_at changed (speaker is actively reporting)
+        # - media_title contains expected title (the strongest single signal —
+        #   speaker explicitly identifies our requested track)
+        # - media_position_updated_at changed (MA is actively reporting state)
+        #
+        # We used to also require media_position >= 1 here as a guard against
+        # MA reporting `state=playing` while a track was only queued. In
+        # practice that case shows itself by `media_position_updated_at`
+        # *not* changing — the queued track's position never updates. So
+        # `position_fresh` already filters it out, and the position-value
+        # check was needlessly delaying confirmation.
+        #
+        # Ziigmund84 reported (#803) on cold MA start the speaker shows
+        # state=playing + correct title within seconds, but media_position
+        # lags at 0 for 10-15s. Old fast-path didn't fire; user heard music
+        # while UI sat in REVEAL waiting for the timeout.
         expected_lower = expected_title.lower()
 
         confirmed = asyncio.Event()
@@ -404,15 +415,13 @@ class MediaPlayerService:
                 return False
             try:
                 current_title = state.attributes.get("media_title", "")
-                position = state.attributes.get("media_position", 0)
                 position_updated = state.attributes.get("media_position_updated_at")
 
                 position_fresh = position_updated != position_updated_before
-                actually_playing = isinstance(position, (int, float)) and position >= 1
                 title_matches = (not expected_lower) or (
                     expected_lower in current_title.lower() if current_title else False
                 )
-                return title_matches and position_fresh and actually_playing
+                return title_matches and position_fresh
             except (AttributeError, KeyError):
                 return False
 

--- a/custom_components/beatify/www/sw.js
+++ b/custom_components/beatify/www/sw.js
@@ -6,7 +6,7 @@
  */
 'use strict';
 
-var CACHE_VERSION = 'beatify-v3.3.2-rc3';
+var CACHE_VERSION = 'beatify-v3.3.2-rc5';
 var MAX_CACHE_ITEMS = 50;
 
 // Critical assets to precache on install (minified versions only - fallback handled by HTML)

--- a/tests/unit/test_media_player.py
+++ b/tests/unit/test_media_player.py
@@ -89,8 +89,13 @@ class TestMANonBlockingPlayback:
         )
 
     @pytest.mark.asyncio
-    async def test_ma_waits_for_position_ge_1(self):
-        """Should NOT return when position=0 (queued but not playing yet)."""
+    async def test_ma_fast_path_succeeds_when_title_matches_even_if_position_zero(self):
+        """#803: on cold MA start the speaker reports state=playing + correct
+        title within seconds, but `media_position` lags at 0 for 10-15s.
+        Fast-path must accept title_matches + position_fresh without waiting
+        for position >= 1, otherwise round 1 sits frozen for the full 15s
+        timeout while audio is already playing.
+        """
         hass = _make_hass("playing", media_title="Old Song")
         svc = MediaPlayerService(hass, "media_player.test", platform="music_assistant")
 
@@ -101,29 +106,19 @@ class TestMANonBlockingPlayback:
             media_position=120,
             media_position_updated_at="2020-01-01T00:00:00+00:00",
         )
-        # Title changed, position=0, updated_at fresh — but NOT actually playing yet
-        queued_state = _make_state(
+        # Title matches expected, position still 0, but updated_at moved →
+        # MA is reporting fresh state for the right track. Accept.
+        playing_pos_zero = _make_state(
             "playing",
             media_title="New Song",
             media_position=0,
             media_position_updated_at="2020-01-01T00:00:05+00:00",
         )
-        # Actually playing: position >= 1
-        playing_state = _make_state(
-            "playing",
-            media_title="New Song",
-            media_position=1,
-            media_position_updated_at="2020-01-01T00:00:10+00:00",
-        )
 
         def state_progression(*args):
             nonlocal call_count
             call_count += 1
-            if call_count <= 1:
-                return old_state
-            if call_count <= 5:
-                return queued_state  # pos=0, should NOT trigger
-            return playing_state  # pos=1, should trigger
+            return old_state if call_count <= 1 else playing_pos_zero
 
         hass.states.get = MagicMock(side_effect=state_progression)
 
@@ -134,52 +129,8 @@ class TestMANonBlockingPlayback:
             result = await svc.play_song(_make_song(title="New Song"))
 
         assert result is True
-        # Event-based waits don't poll; state_before + post-timeout snapshot = 2 calls.
+        # Event-based wait: state_before snapshot + post-timeout snapshot.
         assert call_count >= 2
-
-    @pytest.mark.asyncio
-    async def test_ma_does_not_trigger_on_title_change_alone(self):
-        """Title change with position=0 should NOT trigger (song only queued)."""
-        hass = _make_hass("playing", media_title="Old Song")
-        svc = MediaPlayerService(hass, "media_player.test", platform="music_assistant")
-
-        poll_count = 0
-        old_state = _make_state(
-            "playing",
-            media_title="Old Song",
-            media_position=100,
-            media_position_updated_at="2020-01-01T00:00:00+00:00",
-        )
-        queued_only = _make_state(
-            "playing",
-            media_title="New Song",
-            media_position=0,
-            media_position_updated_at="2020-01-01T00:00:05+00:00",
-        )
-
-        def always_queued(*args):
-            nonlocal poll_count
-            poll_count += 1
-            if poll_count <= 1:
-                return old_state
-            return queued_only
-
-        hass.states.get = MagicMock(side_effect=always_queued)
-
-        with patch(
-            "custom_components.beatify.services.media_player.asyncio.sleep",
-            new_callable=AsyncMock,
-        ):
-            with patch(
-                "custom_components.beatify.services.media_player.MA_PLAYBACK_TIMEOUT",
-                2.0,
-            ):
-                result = await svc.play_song(_make_song(title="New Song"))
-
-        assert (
-            result is True
-        )  # #345: return True on timeout — MA may still be buffering
-        assert poll_count >= 2  # event-based wait, state_before + post-timeout snapshot
 
     @pytest.mark.asyncio
     async def test_ma_realistic_ytmusic_flow(self):


### PR DESCRIPTION
## Summary
- **Round 1 freeze on cold MA start (#803)** — @Ziigmund84 reported the wizard kicking off the first round and sitting frozen on REVEAL while audio was already playing.
- Root cause: the strict-detect fast-path in `_try_ma_play` required `media_position >= 1`. On a cold MA boot the speaker reports `state=playing` and the correct `media_title` within seconds, but `media_position` lags at `0` for 10–15s.
- Fix: `position_updated_at` advancing already filters out the queued-but-not-playing case (a queued track's timestamp doesn't move). Title-match + fresh `position_updated_at` is enough.

## Versions
- `manifest.json`: `3.3.2-rc3` → `3.3.2-rc5` (skipped `rc4` — that number is reserved for unmerged PR #802 on a separate branch).
- `sw.js CACHE_VERSION`: `beatify-v3.3.2-rc3` → `beatify-v3.3.2-rc5`.
- HTML cache-busters unchanged (no JS/CSS modified).

## Test plan
- [x] `pytest tests/unit/` — 401 passed, 1 xfailed.
- [x] `ruff check` + `ruff format --check` — clean.
- [x] Renamed `test_ma_waits_for_position_ge_1` → `test_ma_fast_path_succeeds_when_title_matches_even_if_position_zero` (the old assertion is now invalid).
- [x] Removed redundant `test_ma_does_not_trigger_on_title_change_alone`.
- [ ] User confirms cold-start flow no longer freezes Round 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)