### PR TITLE
fix(playback): respect user's provider choice in URI cascade (closes #805)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to Beatify are documented here. For detailed release notes, 
 
 ## [Unreleased]
 
+## [3.3.2-rc7] - 2026-04-27
+
+### Fixed
+- **MA URI cascade now respects the user's provider choice (#805).** @Levtos's Apple-Music-only setup paid 4×15s of timeouts every failed round because the cascade walked Spotify → legacy `uri` → Apple Music → YouTube Music → Tidal → Deezer regardless of the wizard provider. Three failed rounds in a row hit `MAX_SONG_RETRIES`, the game force-paused, and the WS handler then promoted PAUSED → END so admin couldn't recover. New `_PROVIDER_URI_FIELDS` map keys URI fields by provider; `_get_ma_uri_candidates()` only walks the user-selected provider's fields. `_resolved_uri` is still tried first; the same-provider fallback (e.g. legacy `uri` for Spotify) is preserved.
+- **Game no longer ends silently after MA-error pause (#805 part 2).** When `start_round()` paused the game (media-player error / `MAX_SONG_RETRIES` exhausted), `admin_next_round` was unconditionally calling `advance_to_end()` and dropping the user onto the podium screen. Now: if `start_round()` returns False AND phase has transitioned to PAUSED, we leave it paused and broadcast that state so the UI shows the paused indicator instead. (A resume-from-paused admin button is filed as a follow-up.)
+
+### For contributors
+- Bumped manifest + `sw.js CACHE_VERSION` → `3.3.2-rc7`. No frontend asset changes — HTML cache-busters unchanged.
+- Rewrote 5 cross-provider tests in `TestMAProviderFallback` to assert the new same-provider invariant. Added 2 new `TestAdminNextRoundPausedRecovery` tests in `test_websocket.py` covering the PAUSED-stays-paused path and a regression guard for natural end. 406 passed, 1 xfailed.
+
 ## [3.3.2-rc6] - 2026-04-26
 
 ### Fixed

--- a/custom_components/beatify/manifest.json
+++ b/custom_components/beatify/manifest.json
@@ -12,5 +12,5 @@
   "documentation": "https://github.com/mholzi/beatify",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/mholzi/beatify/issues",
-  "version": "3.3.2-rc6"
+  "version": "3.3.2-rc7"
 }

--- a/custom_components/beatify/server/ws_handlers.py
+++ b/custom_components/beatify/server/ws_handlers.py
@@ -424,6 +424,16 @@ async def admin_next_round(
             success = await game_state.start_round()
             if success:
                 await handler.broadcast_state()
+            elif game_state.phase == GamePhase.PAUSED:
+                # #805: start_round paused the game (MAX_SONG_RETRIES exhausted
+                # or media-player unavailable). Don't force-end — let the
+                # admin recover. The PAUSED-phase state will be broadcast so
+                # the UI shows the paused indicator instead of the podium.
+                _LOGGER.info(
+                    "start_round paused the game (%s); leaving paused for recovery",
+                    game_state.last_error_detail or "playback error",
+                )
+                await handler.broadcast_state()
             else:
                 stats_service = handler.hass.data.get(DOMAIN, {}).get("stats")
                 if stats_service:

--- a/custom_components/beatify/services/media_player.py
+++ b/custom_components/beatify/services/media_player.py
@@ -100,17 +100,31 @@ MA_PLAYBACK_TIMEOUT = 15.0
 # Timeout for waiting for metadata to update after playing (seconds)
 METADATA_WAIT_TIMEOUT = 5.0
 
-# Candidate URI fields on a song, in default fallback order for MA (#768).
-# Primary always comes from `_resolved_uri`; these are the alternates we walk
-# when the user's selected provider isn't configured in Music Assistant.
-_URI_FIELDS: tuple[str, ...] = (
-    "uri_spotify",
-    "uri",
-    "uri_apple_music",
-    "uri_youtube_music",
-    "uri_tidal",
-    "uri_deezer",
-)
+# Candidate URI fields on a song, by user-selected provider (#805).
+#
+# Each provider lists its own playable URI fields in priority order. The
+# fallback cascade in `_get_ma_uri_candidates` only walks the fields for
+# `self._provider` — never tries a different provider's URI.
+#
+# Why: prior to #805 the cascade walked ALL six URI fields regardless of
+# which provider the user picked in the wizard. On Levtos's Apple-Music-only
+# MA setup, every round paid 4×15s of timeouts on Spotify/YT/Tidal URIs that
+# his MA had no provider configured for, before getting to the Apple Music
+# URI that actually worked. After 3 cumulative play_song failures the game
+# was force-paused and the admin couldn't recover.
+#
+# The "fall through to other providers when primary fails" intent of #768
+# only makes sense when the user's MA actually has those other providers
+# configured — which the wizard already gates. If the user picked Apple
+# Music, they're saying "this is the provider MA is set up for". Trust
+# them.
+_PROVIDER_URI_FIELDS: dict[str, tuple[str, ...]] = {
+    "spotify": ("uri_spotify", "uri"),
+    "apple_music": ("uri_apple_music",),
+    "youtube_music": ("uri_youtube_music",),
+    "tidal": ("uri_tidal",),
+    "deezer": ("uri_deezer",),
+}
 
 
 class MediaPlayerService:
@@ -267,11 +281,17 @@ class MediaPlayerService:
         self, song: dict[str, Any]
     ) -> list[tuple[str | None, str]]:
         """
-        Build the ordered list of MA-ready URIs to try for this song (#768).
+        Build the ordered list of MA-ready URIs to try for this song (#805).
+
+        Only walks URI fields belonging to the user's selected provider
+        (`self._provider`). The wizard's provider choice represents what's
+        actually configured in MA — trying URIs from other providers when
+        the user said "Apple Music only" just buys 15s timeouts per
+        unsupported provider before MA reports `MediaNotFoundError`.
 
         Order: previously-successful field (if any) first, then the user's
-        selected URI (`_resolved_uri`), then every other `uri_*` on the song.
-        URIs are converted for MA and deduped by their converted form.
+        selected URI (`_resolved_uri`), then any remaining provider URI
+        fields. URIs are converted for MA and deduped by their converted form.
 
         Returns:
             List of `(field_name, converted_uri)`. `field_name` is `None` for
@@ -280,6 +300,7 @@ class MediaPlayerService:
         """
         seen: set[str] = set()
         candidates: list[tuple[str | None, str]] = []
+        provider_fields = _PROVIDER_URI_FIELDS.get(self._provider, ())
 
         def _add(field: str | None, raw: str | None) -> None:
             if not raw:
@@ -290,16 +311,20 @@ class MediaPlayerService:
             seen.add(converted)
             candidates.append((field, converted))
 
-        # Learned preference — if a specific field worked last time, try it
-        # first so Apple-Music-only setups stop paying the Spotify timeout.
-        if self._ma_preferred_uri_field:
+        # Learned preference — but only if it's a field belonging to the
+        # current provider (the cache survives across games where provider
+        # may have changed).
+        if (
+            self._ma_preferred_uri_field
+            and self._ma_preferred_uri_field in provider_fields
+        ):
             _add(self._ma_preferred_uri_field, song.get(self._ma_preferred_uri_field))
 
         # Primary: the URI Beatify picked based on the user's selected provider.
         _add(None, song.get("_resolved_uri"))
 
-        # Remaining alternates.
-        for field in _URI_FIELDS:
+        # Remaining alternates within the same provider.
+        for field in provider_fields:
             if field != self._ma_preferred_uri_field:
                 _add(field, song.get(field))
 
@@ -307,13 +332,14 @@ class MediaPlayerService:
 
     async def _play_via_music_assistant(self, song: dict[str, Any]) -> bool:
         """
-        Play via Music Assistant, falling back through alternate-provider URIs (#768).
+        Play via Music Assistant, walking the user-provider's URI fields (#805).
 
-        Without this fallback, users whose MA has e.g. only Apple Music see
-        `Could not resolve spotify:track:... to playable media item` on every
-        round. We try the user-selected URI first, then walk the other URIs
-        present on the track, and remember the first field that succeeds so
-        subsequent songs start with the right one.
+        Only candidates from `_PROVIDER_URI_FIELDS[self._provider]` are tried —
+        the wizard's provider choice represents what MA is configured for, so
+        attempting other providers' URIs just burns 15s timeouts per
+        unsupported provider before MA reports `MediaNotFoundError`. This was
+        the originating bug for #805 (Levtos's Apple-Music-only setup paid
+        4×15s of Spotify/YT/Tidal timeouts on every failed round).
         """
         candidates = self._get_ma_uri_candidates(song)
         if not candidates:

--- a/custom_components/beatify/www/sw.js
+++ b/custom_components/beatify/www/sw.js
@@ -6,7 +6,7 @@
  */
 'use strict';
 
-var CACHE_VERSION = 'beatify-v3.3.2-rc6';
+var CACHE_VERSION = 'beatify-v3.3.2-rc7';
 var MAX_CACHE_ITEMS = 50;
 
 // Critical assets to precache on install (minified versions only - fallback handled by HTML)

--- a/tests/unit/test_media_player.py
+++ b/tests/unit/test_media_player.py
@@ -589,7 +589,15 @@ class TestMAPollingResilience:
 
 
 class TestMAProviderFallback:
-    """Tests for multi-provider URI fallback in MA playback (#768)."""
+    """Tests for per-provider URI candidate generation (#768 → narrowed by #805).
+
+    The cascade was originally cross-provider (#768): if Spotify failed, walk
+    Apple Music / YT / Tidal / Deezer URIs in order. #805 narrowed it: only
+    URIs belonging to the user-selected provider are considered. Trying URIs
+    from providers MA isn't configured for just buys 15s timeouts per
+    candidate (Levtos's Apple-Music-only setup paid 4×15s on every failed
+    round before the fix).
+    """
 
     def test_candidates_primary_only(self):
         """Song with only spotify URI → single candidate, field=None (primary)."""
@@ -599,39 +607,85 @@ class TestMAProviderFallback:
         candidates = svc._get_ma_uri_candidates(song)
         assert candidates == [(None, "spotify:track:abc")]
 
-    def test_candidates_primary_then_alternates(self):
-        """Primary comes first, alternates follow in _URI_FIELDS order."""
+    def test_candidates_skip_other_providers_when_apple_music_only(self):
+        """#805: Apple-Music user must NEVER see Spotify/YT/Tidal/Deezer URIs.
+
+        Levtos's exact setup: provider="apple_music", song dict has all six
+        URI fields populated by the catalog. Old cascade tried all of them
+        in fixed order; new behavior tries only apple_music URIs.
+        """
         hass = _make_hass()
-        svc = MediaPlayerService(hass, "media_player.test", platform="music_assistant")
+        svc = MediaPlayerService(
+            hass,
+            "media_player.test",
+            platform="music_assistant",
+            provider="apple_music",
+        )
         song = {
             "uri": "spotify:track:abc",
-            "_resolved_uri": "spotify:track:abc",
+            "uri_spotify": "spotify:track:abc",
+            "uri_apple_music": "applemusic://track/111",
+            "uri_youtube_music": "https://music.youtube.com/watch?v=xyz",
+            "uri_tidal": "tidal://track/222",
+            "uri_deezer": "deezer://track/333",
+            "_resolved_uri": "applemusic://track/111",
+        }
+        uris = [uri for _, uri in svc._get_ma_uri_candidates(song)]
+        # Only the Apple Music URI (converted to MA's native form) should be tried.
+        assert uris == ["apple_music://track/111"]
+
+    def test_candidates_spotify_provider_walks_uri_and_uri_spotify(self):
+        """Spotify provider includes both `uri_spotify` and legacy `uri` fields."""
+        hass = _make_hass()
+        svc = MediaPlayerService(
+            hass,
+            "media_player.test",
+            platform="music_assistant",
+            provider="spotify",
+        )
+        # Two distinct Spotify URIs in the legacy + canonical fields. Both
+        # should be candidates (spotify provider lists both fields).
+        song = {
+            "uri": "spotify:track:legacy",
+            "uri_spotify": "spotify:track:canonical",
+            "_resolved_uri": "spotify:track:canonical",
+            # These should be filtered out — different provider:
             "uri_apple_music": "applemusic://track/111",
             "uri_tidal": "tidal://track/222",
         }
-        fields = [field for field, _ in svc._get_ma_uri_candidates(song)]
-        # Primary first (None), then apple_music before tidal per _URI_FIELDS
-        assert fields[0] is None
-        assert fields.index("uri_apple_music") < fields.index("uri_tidal")
+        uris = [uri for _, uri in svc._get_ma_uri_candidates(song)]
+        assert "spotify:track:canonical" in uris
+        assert "spotify:track:legacy" in uris
+        # Apple Music + Tidal must be excluded.
+        assert all(not u.startswith("apple_music://") for u in uris)
+        assert all(not u.startswith("https://tidal.com") for u in uris)
 
     def test_candidates_dedupe_by_converted_uri(self):
         """`uri` and `uri_spotify` with the same value collapse to one candidate."""
         hass = _make_hass()
-        svc = MediaPlayerService(hass, "media_player.test", platform="music_assistant")
+        svc = MediaPlayerService(
+            hass,
+            "media_player.test",
+            platform="music_assistant",
+            provider="spotify",
+        )
         song = {
             "uri": "spotify:track:abc",
             "uri_spotify": "spotify:track:abc",  # same as uri
             "_resolved_uri": "spotify:track:abc",
-            "uri_apple_music": "applemusic://track/111",
         }
         uris = [uri for _, uri in svc._get_ma_uri_candidates(song)]
-        assert uris.count("spotify:track:abc") == 1
-        assert len(uris) == 2
+        assert uris == ["spotify:track:abc"]
 
     def test_candidates_converts_apple_music(self):
         """applemusic:// URIs are converted to MA-native apple_music:// form (#772)."""
         hass = _make_hass()
-        svc = MediaPlayerService(hass, "media_player.test", platform="music_assistant")
+        svc = MediaPlayerService(
+            hass,
+            "media_player.test",
+            platform="music_assistant",
+            provider="apple_music",
+        )
         song = {
             "_resolved_uri": "applemusic://track/999",
             "uri_apple_music": "applemusic://track/999",
@@ -649,7 +703,12 @@ class TestMAProviderFallback:
         provider domain.
         """
         hass = _make_hass()
-        svc = MediaPlayerService(hass, "media_player.test", platform="music_assistant")
+        svc = MediaPlayerService(
+            hass,
+            "media_player.test",
+            platform="music_assistant",
+            provider="deezer",
+        )
         song = {
             "_resolved_uri": "deezer://track/12345",
             "uri_deezer": "deezer://track/12345",
@@ -657,20 +716,52 @@ class TestMAProviderFallback:
         candidates = svc._get_ma_uri_candidates(song)
         assert candidates[0][1] == "deezer://track/12345"
 
-    def test_candidates_learned_preference_goes_first(self):
-        """If a field was learned as preferred, its URI is tried before primary."""
+    def test_candidates_learned_preference_within_same_provider(self):
+        """Cached preferred field is honored when it belongs to current provider."""
         hass = _make_hass()
-        svc = MediaPlayerService(hass, "media_player.test", platform="music_assistant")
-        svc._ma_preferred_uri_field = "uri_apple_music"
+        svc = MediaPlayerService(
+            hass,
+            "media_player.test",
+            platform="music_assistant",
+            provider="spotify",
+        )
+        # Cached: legacy `uri` field worked last time.
+        svc._ma_preferred_uri_field = "uri"
         song = {
-            "uri": "spotify:track:abc",
-            "_resolved_uri": "spotify:track:abc",
-            "uri_apple_music": "applemusic://track/111",
+            "uri": "spotify:track:legacy",
+            "uri_spotify": "spotify:track:canonical",
+            "_resolved_uri": "spotify:track:canonical",
         }
         candidates = svc._get_ma_uri_candidates(song)
-        assert candidates[0] == ("uri_apple_music", "apple_music://track/111")
-        # Primary still present after
-        assert (None, "spotify:track:abc") in candidates
+        # Cached field's URI is first (before _resolved_uri).
+        assert candidates[0] == ("uri", "spotify:track:legacy")
+        # Primary still present after.
+        assert (None, "spotify:track:canonical") in candidates
+
+    def test_candidates_learned_preference_ignored_across_providers(self):
+        """Cached preferred field from a different provider is not honored.
+
+        The cache survives across games where provider may have changed —
+        e.g. user played a Spotify game (cached `uri_spotify`), then started
+        an Apple Music game on the same speaker. The cached Spotify field
+        must be ignored, not retried as a phantom candidate.
+        """
+        hass = _make_hass()
+        svc = MediaPlayerService(
+            hass,
+            "media_player.test",
+            platform="music_assistant",
+            provider="apple_music",
+        )
+        svc._ma_preferred_uri_field = "uri_spotify"  # stale cache
+        song = {
+            "uri_spotify": "spotify:track:abc",
+            "uri_apple_music": "applemusic://track/111",
+            "_resolved_uri": "applemusic://track/111",
+        }
+        uris = [uri for _, uri in svc._get_ma_uri_candidates(song)]
+        # Stale cached field is ignored; only Apple Music URI is tried.
+        assert uris == ["apple_music://track/111"]
 
     def test_candidates_no_uris_returns_empty(self):
         """Song with no URI fields yields no candidates."""
@@ -679,39 +770,50 @@ class TestMAProviderFallback:
         assert svc._get_ma_uri_candidates({"title": "x", "artist": "y"}) == []
 
     @pytest.mark.asyncio
-    async def test_fallback_tried_when_primary_fails(self):
-        """If primary URI returns False, the orchestrator tries the next candidate."""
+    async def test_fallback_within_provider_tries_next_when_primary_fails(self):
+        """For Spotify, if `_resolved_uri` fails, legacy `uri` field is tried next."""
         hass = _make_hass()
-        svc = MediaPlayerService(hass, "media_player.test", platform="music_assistant")
+        svc = MediaPlayerService(
+            hass,
+            "media_player.test",
+            platform="music_assistant",
+            provider="spotify",
+        )
         song = {
             "title": "Song",
             "artist": "Artist",
-            "_resolved_uri": "spotify:track:abc",
-            "uri_apple_music": "applemusic://track/111",
+            "uri": "spotify:track:legacy",
+            "uri_spotify": "spotify:track:canonical",
+            "_resolved_uri": "spotify:track:canonical",
         }
 
         calls: list[str] = []
 
         async def fake_try(uri: str, expected_title: str) -> bool:
             calls.append(uri)
-            return uri != "spotify:track:abc"  # primary fails, alternate succeeds
+            return uri == "spotify:track:legacy"  # primary fails, legacy succeeds
 
         with patch.object(svc, "_try_ma_play", side_effect=fake_try):
             result = await svc._play_via_music_assistant(song)
 
         assert result is True
-        assert calls == ["spotify:track:abc", "apple_music://track/111"]
-        assert svc._ma_preferred_uri_field == "uri_apple_music"
+        assert calls == ["spotify:track:canonical", "spotify:track:legacy"]
+        assert svc._ma_preferred_uri_field == "uri"
 
     @pytest.mark.asyncio
     async def test_primary_success_does_not_update_preference(self):
         """When primary (`_resolved_uri`) succeeds, no field is cached."""
         hass = _make_hass()
-        svc = MediaPlayerService(hass, "media_player.test", platform="music_assistant")
+        svc = MediaPlayerService(
+            hass,
+            "media_player.test",
+            platform="music_assistant",
+            provider="spotify",
+        )
         song = {
             "title": "Song",
             "_resolved_uri": "spotify:track:abc",
-            "uri_apple_music": "applemusic://track/111",
+            "uri_spotify": "spotify:track:abc",
         }
 
         with patch.object(svc, "_try_ma_play", AsyncMock(return_value=True)):
@@ -724,10 +826,15 @@ class TestMAProviderFallback:
     async def test_all_candidates_fail_returns_false(self):
         """Exhausted candidates → False, no cached preference."""
         hass = _make_hass()
-        svc = MediaPlayerService(hass, "media_player.test", platform="music_assistant")
+        svc = MediaPlayerService(
+            hass,
+            "media_player.test",
+            platform="music_assistant",
+            provider="apple_music",
+        )
         song = {
             "title": "Song",
-            "_resolved_uri": "spotify:track:abc",
+            "_resolved_uri": "applemusic://track/111",
             "uri_apple_music": "applemusic://track/111",
         }
 
@@ -739,38 +846,45 @@ class TestMAProviderFallback:
 
     @pytest.mark.asyncio
     async def test_learned_preference_used_on_next_song(self):
-        """After a fallback succeeds, the next song tries that field first."""
+        """Within Spotify: after legacy `uri` succeeds, next song tries it first."""
         hass = _make_hass()
-        svc = MediaPlayerService(hass, "media_player.test", platform="music_assistant")
+        svc = MediaPlayerService(
+            hass,
+            "media_player.test",
+            platform="music_assistant",
+            provider="spotify",
+        )
 
         song_a = {
             "title": "A",
-            "_resolved_uri": "spotify:track:a",
-            "uri_apple_music": "applemusic://track/a",
+            "uri": "spotify:track:a-legacy",
+            "uri_spotify": "spotify:track:a-canonical",
+            "_resolved_uri": "spotify:track:a-canonical",
         }
         song_b = {
             "title": "B",
-            "_resolved_uri": "spotify:track:b",
-            "uri_apple_music": "applemusic://track/b",
+            "uri": "spotify:track:b-legacy",
+            "uri_spotify": "spotify:track:b-canonical",
+            "_resolved_uri": "spotify:track:b-canonical",
         }
 
         calls: list[str] = []
 
         async def fake_try(uri: str, expected_title: str) -> bool:
             calls.append(uri)
-            # Spotify never works in this user's setup; apple_music always does.
-            return uri.startswith("apple_music://")
+            # Canonical never works in this user's setup; legacy always does.
+            return uri.endswith("-legacy")
 
         with patch.object(svc, "_try_ma_play", side_effect=fake_try):
             assert await svc._play_via_music_assistant(song_a) is True
             assert await svc._play_via_music_assistant(song_b) is True
 
-        # Song A: spotify fails, apple_music succeeds (2 calls)
-        # Song B: apple_music tried first (cached), succeeds (1 call)
+        # Song A: canonical fails, legacy succeeds (2 calls)
+        # Song B: legacy tried first (cached), succeeds (1 call)
         assert calls == [
-            "spotify:track:a",
-            "apple_music://track/a",
-            "apple_music://track/b",
+            "spotify:track:a-canonical",
+            "spotify:track:a-legacy",
+            "spotify:track:b-legacy",
         ]
 
     @pytest.mark.asyncio

--- a/tests/unit/test_websocket.py
+++ b/tests/unit/test_websocket.py
@@ -938,3 +938,70 @@ class TestPlayerOnboarded:
 
         alice.reset_round()
         assert alice.onboarded is True, "onboarded must survive reset_round()"
+
+
+# ---------------------------------------------------------------------------
+# admin_next_round — recovery from PAUSED (#805)
+# ---------------------------------------------------------------------------
+
+
+class TestAdminNextRoundPausedRecovery:
+    """#805: when start_round() pauses the game (e.g. MAX_SONG_RETRIES exhausted),
+    admin_next_round must NOT force-end the game. Levtos's playthrough hit
+    this path and saw the podium instead of a recoverable PAUSED state.
+    """
+
+    async def test_paused_after_start_round_failure_does_not_advance_to_end(self):
+        """start_round → False with phase=PAUSED → keep paused, broadcast state."""
+        from custom_components.beatify.server.ws_handlers import admin_next_round
+
+        handler, game_state, ws = _make_handler_and_game()
+        # Setup: REVEAL phase with more rounds remaining (last_round=False).
+        game_state.phase = GamePhase.REVEAL
+        game_state.last_round = False
+
+        # Simulate the pause_game path inside start_round: returns False AND
+        # transitions phase to PAUSED.
+        async def fake_start_round():
+            game_state.phase = GamePhase.PAUSED
+            game_state.last_error_detail = "media player error"
+            return False
+
+        game_state.start_round = AsyncMock(side_effect=fake_start_round)
+        game_state.advance_to_end = AsyncMock()
+        handler.broadcast_state = AsyncMock()
+
+        await admin_next_round(handler, ws, {"action": "next_round"}, game_state)
+
+        # CRITICAL: must NOT have called advance_to_end — game stays paused.
+        game_state.advance_to_end.assert_not_awaited()
+        # State broadcast still fires so clients see phase=PAUSED.
+        handler.broadcast_state.assert_awaited()
+        assert game_state.phase == GamePhase.PAUSED
+
+    async def test_natural_end_still_advances_to_end(self):
+        """Regression guard: when start_round returns False without pausing
+        (e.g. all songs exhausted, phase already END), the existing
+        advance-to-end path must still fire.
+        """
+        from custom_components.beatify.server.ws_handlers import admin_next_round
+
+        handler, game_state, ws = _make_handler_and_game()
+        game_state.phase = GamePhase.REVEAL
+        game_state.last_round = False
+
+        # Simulate "out of songs" path: start_round sets phase=END internally
+        # and returns False. (Code path at game/state.py:1141-1143.)
+        async def fake_start_round():
+            game_state.phase = GamePhase.END
+            return False
+
+        game_state.start_round = AsyncMock(side_effect=fake_start_round)
+        game_state.advance_to_end = AsyncMock()
+        game_state.finalize_game = MagicMock(return_value={})
+        handler.broadcast_state = AsyncMock()
+
+        await admin_next_round(handler, ws, {"action": "next_round"}, game_state)
+
+        # advance_to_end IS called for the natural-end path.
+        game_state.advance_to_end.assert_awaited_once()


### PR DESCRIPTION
## Summary

Two-part fix for @Levtos's #805 (Apple-Music-only freeze after Round 1):

1. **Provider-filtered cascade.** `_get_ma_uri_candidates()` now walks only URI fields belonging to `self._provider`. Apple-Music-only setups no longer pay 4×15s of MA timeouts on Spotify/YT/Tidal URIs that MA has no provider configured for. Same-provider fallback (e.g. Spotify's legacy `uri` field) is preserved.
2. **No more silent game-end on MA error.** When `start_round()` pauses the game (`MAX_SONG_RETRIES` exhausted), `admin_next_round` no longer promotes PAUSED → END. The PAUSED state is broadcast instead, leaving the game recoverable.

The originating mechanism: Levtos's logs showed `MediaNotFoundError: No playable items found` for `spotify://`, `ytmusic://`, `tidal://` URIs — MA had only Apple Music configured, so cross-provider URIs failed at the resolve step. Three failed rounds in a row hit `MAX_SONG_RETRIES` → `pause_game("media_player_error")`, then the WS handler trampled PAUSED → END and showed the podium with no way to continue.

## Versions
- `manifest.json`: `3.3.2-rc6` → `3.3.2-rc7`.
- `sw.js CACHE_VERSION`: `beatify-v3.3.2-rc6` → `beatify-v3.3.2-rc7`.
- HTML cache-busters unchanged (no JS/CSS modified).

## Out of scope (filed as follow-up)
- Resume-from-paused admin button. PAUSED state now reaches the UI, but there's no manual-recover button yet — the existing PAUSED view is reused.

## Test plan
- [x] `pytest tests/unit/` — 406 passed, 1 xfailed.
- [x] `ruff check` + `ruff format --check` — clean.
- [x] Rewrote 5 cross-provider cascade tests to assert per-provider behavior; added 2 ws-handler tests for the PAUSED-stays-paused path + natural-end regression guard.
- [ ] @Levtos confirms Round 2+ works on Apple-Music-only setup.
- [ ] If a song's primary URI does fail 3x, game stays in PAUSED instead of ending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)