### PR TITLE
fix(views): include apple_music in StartGameView valid_providers (closes #808)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to Beatify are documented here. For detailed release notes, 
 
 ## [Unreleased]
 
+## [3.3.2-rc9] - 2026-04-28
+
+### Fixed
+- **Apple Music wizard selection no longer silently coerced to Spotify (#808).** @Levtos's report against (the now-deleted) v3.3.2 tag exposed the originating bug behind the rc6+rc8 cascade work: `PROVIDER_APPLE_MUSIC` was missing from the `valid_providers` tuple in `StartGameView`, so any wizard selection of "apple_music" silently became "spotify" before reaching `game_state.create_game`. Pre-rc7 this was near-invisible because the cascade walked all six URI fields anyway; after rc7's provider-narrowed cascade (#805), Apple-Music users got Spotify-only candidates and every round failed before MA's resolver. Round 1 couldn't start, the game paused, and the integration was unusable on Apple-Music-only Music Assistant setups.
+
+### For contributors
+- Refactored the inline `valid_providers` tuple into module-level `_validate_provider()` so the rule is unit-testable.
+- Bumped manifest + `sw.js CACHE_VERSION` → `3.3.2-rc9`. No frontend asset changes — HTML cache-busters unchanged.
+- 13 new tests in `tests/unit/test_game_views.py` (round-trip for all 5 providers, explicit Apple-Music regression guard, invalid-input fallback). 426 passed, 1 xfailed.
+
 ## [3.3.2-rc8] - 2026-04-27
 
 ### Added

--- a/custom_components/beatify/manifest.json
+++ b/custom_components/beatify/manifest.json
@@ -12,5 +12,5 @@
   "documentation": "https://github.com/mholzi/beatify",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/mholzi/beatify/issues",
-  "version": "3.3.2-rc8"
+  "version": "3.3.2-rc9"
 }

--- a/custom_components/beatify/server/game_views.py
+++ b/custom_components/beatify/server/game_views.py
@@ -17,6 +17,7 @@ from custom_components.beatify.const import (
     DIFFICULTY_HARD,
     DIFFICULTY_NORMAL,
     DOMAIN,
+    PROVIDER_APPLE_MUSIC,
     PROVIDER_DEFAULT,
     PROVIDER_DEEZER,
     PROVIDER_SPOTIFY,
@@ -41,6 +42,28 @@ if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def _validate_provider(provider: str) -> str:
+    """Coerce unknown providers to PROVIDER_DEFAULT.
+
+    Single source of truth for which providers the wizard may select. #808
+    surfaced the cost of forgetting to update this list: PROVIDER_APPLE_MUSIC
+    was missing, so wizard selections of "apple_music" silently became
+    "spotify". Pre-#805 the cascade walked all six URI fields anyway so the
+    wrong provider was a near-invisible bug. After #805 the cascade only
+    walks the user-selected provider's fields — Apple-Music users were
+    getting Spotify-only candidates, all of which fail on MA without a
+    Spotify provider configured.
+    """
+    valid_providers = (
+        PROVIDER_SPOTIFY,
+        PROVIDER_APPLE_MUSIC,
+        PROVIDER_YOUTUBE_MUSIC,
+        PROVIDER_TIDAL,
+        PROVIDER_DEEZER,
+    )
+    return provider if provider in valid_providers else PROVIDER_DEFAULT
 
 
 class StartGameView(RateLimitMixin, HomeAssistantView):
@@ -103,15 +126,9 @@ class StartGameView(RateLimitMixin, HomeAssistantView):
         if difficulty not in valid_difficulties:
             difficulty = DIFFICULTY_DEFAULT
 
-        # Validate provider (Story 17.6: Spotify, YouTube Music, Tidal supported)
-        valid_providers = (
-            PROVIDER_SPOTIFY,
-            PROVIDER_YOUTUBE_MUSIC,
-            PROVIDER_TIDAL,
-            PROVIDER_DEEZER,
-        )
-        if provider not in valid_providers:
-            provider = PROVIDER_DEFAULT
+        # Validate provider (Story 17.6 + #808). See _validate_provider for
+        # the cost of forgetting to update this list.
+        provider = _validate_provider(provider)
 
         # Validate round_duration if provided (Story 13.1)
         if round_duration is not None:

--- a/custom_components/beatify/www/sw.js
+++ b/custom_components/beatify/www/sw.js
@@ -6,7 +6,7 @@
  */
 'use strict';
 
-var CACHE_VERSION = 'beatify-v3.3.2-rc8';
+var CACHE_VERSION = 'beatify-v3.3.2-rc9';
 var MAX_CACHE_ITEMS = 50;
 
 // Critical assets to precache on install (minified versions only - fallback handled by HTML)

--- a/tests/unit/test_game_views.py
+++ b/tests/unit/test_game_views.py
@@ -1,0 +1,64 @@
+"""Tests for the HTTP API views in custom_components.beatify.server.game_views.
+
+Targeted at the provider-validation regression in #808: Apple Music wizard
+selections were silently coerced to Spotify, breaking Apple-Music-only setups.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from custom_components.beatify.const import (
+    PROVIDER_APPLE_MUSIC,
+    PROVIDER_DEEZER,
+    PROVIDER_DEFAULT,
+    PROVIDER_SPOTIFY,
+    PROVIDER_TIDAL,
+    PROVIDER_YOUTUBE_MUSIC,
+)
+from custom_components.beatify.server.game_views import _validate_provider
+
+
+class TestValidateProvider:
+    """#808: every supported provider must round-trip through _validate_provider."""
+
+    @pytest.mark.parametrize(
+        "provider",
+        [
+            PROVIDER_SPOTIFY,
+            PROVIDER_APPLE_MUSIC,
+            PROVIDER_YOUTUBE_MUSIC,
+            PROVIDER_TIDAL,
+            PROVIDER_DEEZER,
+        ],
+    )
+    def test_valid_provider_round_trips(self, provider: str) -> None:
+        """Each supported provider must come out the same as it went in."""
+        assert _validate_provider(provider) == provider
+
+    def test_apple_music_not_coerced_to_spotify(self) -> None:
+        """#808 regression: apple_music must NOT silently become spotify.
+
+        This was the originating bug — apple_music wasn't in the valid-
+        providers tuple, so the validator fell through to PROVIDER_DEFAULT
+        (= spotify). Apple-Music-only setups then got Spotify URIs in the
+        cascade and every round failed.
+        """
+        assert _validate_provider("apple_music") == PROVIDER_APPLE_MUSIC
+        assert _validate_provider("apple_music") != PROVIDER_DEFAULT
+
+    @pytest.mark.parametrize(
+        "junk",
+        [
+            "",
+            "  ",
+            "qobuz",
+            "soundcloud",
+            "SPOTIFY",  # case-sensitive
+            "apple-music",  # wrong separator
+            None,
+        ],
+    )
+    def test_invalid_provider_falls_back_to_default(self, junk) -> None:
+        """Unknown / malformed providers must coerce to PROVIDER_DEFAULT."""
+        assert _validate_provider(junk) == PROVIDER_DEFAULT


### PR DESCRIPTION
## Summary

Originating bug behind the rc6+rc8 cascade work, exposed by @Levtos's #808 report against v3.3.2:

\`PROVIDER_APPLE_MUSIC\` was missing from the \`valid_providers\` tuple in \`StartGameView.post()\`. Any wizard selection of \`"apple_music"\` silently fell through to \`PROVIDER_DEFAULT\` (= spotify) before reaching \`game_state.create_game()\`.

Pre-rc7 the cascade walked all six URI fields regardless of \`self._provider\`, so the wrong provider was a near-invisible bug. After rc7's provider-narrowed cascade (#805), Apple-Music users got Spotify-only candidates → every round failed before MA's resolver → Round 1 couldn't start → game paused → integration unusable.

## Changes

- **\`game_views.py\`** — Added \`PROVIDER_APPLE_MUSIC\` to the imported constants. Refactored the inline tuple into a module-level \`_validate_provider()\` helper so the rule is testable in isolation.
- **\`tests/unit/test_game_views.py\`** (new) — 13 tests:
  - Round-trip parametrize for all 5 supported providers (catches future drift)
  - Explicit \`apple_music\` regression guard
  - Invalid-input fallback (empty, whitespace, unknown providers, wrong-case, None)
- **\`manifest.json\` + \`sw.js\` CACHE_VERSION** → \`3.3.2-rc9\`. No frontend asset changes.

## Test plan

- [x] \`pytest tests/unit/\` — 426 passed, 1 xfailed.
- [x] \`ruff check\` + \`ruff format --check\` — clean.
- [ ] @Levtos confirms Apple Music starts Round 1 cleanly on his setup.
- [ ] Verify other providers (Spotify, YouTube Music, Tidal, Deezer) still work — the validator now accepts all five.

🤖 Generated with [Claude Code](https://claude.com/claude-code)