### PR TITLE
fix(playback): skip storefront-locked tracks silently (#808 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to Beatify are documented here. For detailed release notes, 
 
 ## [Unreleased]
 
+## [3.3.2-rc11] - 2026-04-28
+
+### Fixed
+- **Region/storefront-locked songs no longer count toward the pause-the-game retry limit (#808 follow-up).** @Levtos's playthrough on rc10 had `apple_music://track/302229811` ("All Together Now") fail with the strict-detect signature ("speaker still on prior track") — and iTunes Lookup confirmed the track is in the **US** Apple Music catalog but **NOT in DE**. Beatify's playlists store predominantly US-storefront Apple Music IDs; for users on other regional storefronts, some subset of songs will be unresolvable through their MA Apple Music provider. These individual track failures shouldn't pause the game — the user can't fix per-track availability. Now: when `_try_ma_play` detects the strict-detect failure mode, the song is classified as `last_failure_reason = "unavailable"` and `start_round` skips it silently without incrementing `_retry_count`. The game keeps playing whatever subset IS in the user's catalog. Systemic failures (offline speaker, broken provider auth) still classify as `"error"`, count toward `MAX_SONG_RETRIES`, and trigger the recovery banner.
+
+### Changed
+- **Clearer log messages on playback failure modes.** The strict-detect path now explicitly explains *"Track is likely not available in your provider's catalog/storefront, OR your provider needs re-authentication in MA. Skipping this song silently — game will try the next one."* The speaker-idle path mentions both possibilities ("speaker offline / MA unauthenticated / track unavailable") so users know which to check. This is the same diagnostic chain @mholzi walked through to find the rc8/rc9 root cause; surfacing it in the logs short-circuits the GitHub-issue-and-back-and-forth cycle.
+
+### For contributors
+- New `MediaPlayerService.last_failure_reason` field (None / "unavailable" / "error"). Cleared at the start of each `_play_via_music_assistant` call; set in the failure paths of `_try_ma_play`. Read by `start_round` in `game/state.py` to decide retry-counter behavior.
+- Bumped manifest + `sw.js CACHE_VERSION` → `3.3.2-rc11`. No frontend asset changes — HTML cache-busters unchanged.
+- 2 new tests in `TestStartRoundFailureClassification`: one verifies "unavailable" doesn't pause across many failures, one verifies "error" still pauses at MAX_SONG_RETRIES. Existing `test_ma_returns_false_when_title_unchanged_but_position_advances` extended to assert classification. 429 passed, 1 xfailed.
+
+### Out of scope (filed as future enhancement)
+- Storefront-aware playlist generation: re-fetch all Apple Music URIs against US/DE/GB/FR/ES storefronts during playlist build; pick the right URI based on the user's MA provider config. Would eliminate the "skip this track" frequency entirely, but requires a meaningful playlist-pipeline change and per-storefront URI storage. Filing separately.
+
 ## [3.3.2-rc10] - 2026-04-28
 
 ### Changed

--- a/custom_components/beatify/game/state.py
+++ b/custom_components/beatify/game/state.py
@@ -1191,10 +1191,34 @@ class GameState:
 
             success = await self._media_player_service.play_song(song)
             if not success:
-                _LOGGER.warning("Failed to play song: %s", song.get("uri"))
+                # #808 follow-up: classify the failure. "unavailable" means
+                # MA accepted the URI but the speaker stayed on the prior
+                # track — typically a region/storefront mismatch (the track
+                # ID isn't in the user's catalog). Skip silently and try the
+                # next song without counting against MAX_SONG_RETRIES; the
+                # user can't fix individual track availability and the game
+                # should keep playing the subset that IS available.
+                #
+                # "error" / unset → systemic failure (speaker offline, MA
+                # provider broken). Count toward MAX_SONG_RETRIES so the
+                # recovery banner kicks in for real problems.
+                failure_reason = getattr(
+                    self._media_player_service, "last_failure_reason", None
+                )
                 self._playlist_manager.mark_played(
                     song.get("_resolved_uri") or song.get("uri")
                 )
+
+                if failure_reason == "unavailable":
+                    _LOGGER.info(
+                        "Skipping unavailable song silently: %s (likely not in "
+                        "your provider's storefront/catalog) — trying next song",
+                        song.get("title") or song.get("uri"),
+                    )
+                    await asyncio.sleep(0.2)
+                    return await self.start_round(_retry_count)
+
+                _LOGGER.warning("Failed to play song: %s", song.get("uri"))
                 if _retry_count >= MAX_SONG_RETRIES:
                     _LOGGER.error(
                         "Media player unreachable after %d attempts, pausing game",

--- a/custom_components/beatify/manifest.json
+++ b/custom_components/beatify/manifest.json
@@ -12,5 +12,5 @@
   "documentation": "https://github.com/mholzi/beatify",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/mholzi/beatify/issues",
-  "version": "3.3.2-rc10"
+  "version": "3.3.2-rc11"
 }

--- a/custom_components/beatify/services/media_player.py
+++ b/custom_components/beatify/services/media_player.py
@@ -157,6 +157,24 @@ class MediaPlayerService:
         # candidate list so subsequent songs don't pay the primary-attempt
         # timeout on every round (#768).
         self._ma_preferred_uri_field: str | None = None
+        # #808 follow-up: classify the most recent failure mode so the
+        # caller (game/state.py:start_round) can decide whether to count
+        # this against MAX_SONG_RETRIES (real failure) or skip silently
+        # (track unavailable in the user's catalog/storefront).
+        #
+        # Values:
+        #   None         — last call succeeded or hasn't been called yet
+        #   "unavailable" — MA accepted the URI but speaker stayed on the
+        #                   prior track. Almost always means the track ID
+        #                   isn't in the user's Apple Music storefront, or
+        #                   MA's provider needs re-authentication for this
+        #                   track. Skipping silently lets the game continue
+        #                   with whatever subset IS playable.
+        #   "error"       — speaker idle/off/unavailable, or hard speaker
+        #                   problem. Counts toward MAX_SONG_RETRIES so the
+        #                   game pauses on systemic issues (offline speaker,
+        #                   broken provider auth across the board).
+        self.last_failure_reason: str | None = None
 
     def set_analytics(self, analytics: AnalyticsStorage) -> None:
         """
@@ -341,6 +359,10 @@ class MediaPlayerService:
         the originating bug for #805 (Levtos's Apple-Music-only setup paid
         4×15s of Spotify/YT/Tidal timeouts on every failed round).
         """
+        # #808 follow-up: clear stale failure classification before each
+        # attempt so start_round reads only the result of THIS song.
+        self.last_failure_reason = None
+
         candidates = self._get_ma_uri_candidates(song)
         if not candidates:
             _LOGGER.error(
@@ -348,6 +370,7 @@ class MediaPlayerService:
                 song.get("artist"),
                 song.get("title"),
             )
+            self.last_failure_reason = "unavailable"
             return False
 
         expected_title = song.get("title") or ""
@@ -369,6 +392,7 @@ class MediaPlayerService:
                 if field and field != self._ma_preferred_uri_field:
                     _LOGGER.debug("MA preferred URI field now: %s (#768)", field)
                     self._ma_preferred_uri_field = field
+                self.last_failure_reason = None
                 return True
 
         _LOGGER.error(
@@ -377,6 +401,8 @@ class MediaPlayerService:
             song.get("artist"),
             song.get("title"),
         )
+        # last_failure_reason carries the classification of the last
+        # _try_ma_play attempt (set by that method); start_round reads it.
         return False
 
     async def _try_ma_play(self, uri: str, expected_title: str) -> bool:
@@ -493,11 +519,19 @@ class MediaPlayerService:
         # Hard failure: speaker is idle/unavailable/off — song won't play
         if speaker_state in ("idle", "unavailable", "off", "unknown"):
             _LOGGER.error(
-                "MA playback failed after %.1fs for %s (state: %s)",
+                "MA playback failed after %.1fs for %s (state: %s). "
+                "Either the speaker is offline, MA's provider is unauthenticated, "
+                "or the track is not available in your provider's catalog. If this "
+                "happens for many tracks, re-authenticate your music provider in MA.",
                 MA_PLAYBACK_TIMEOUT,
                 uri,
                 speaker_state,
             )
+            # Conservative: speaker-idle failures could be systemic (provider
+            # broken across the board) so we keep counting them toward
+            # MAX_SONG_RETRIES. The recovery banner will guide the user to
+            # the re-auth fix once 3 land in a row.
+            self.last_failure_reason = "error"
             return False
 
         # Hard failure: speaker title did not advance. If the title field is
@@ -527,9 +561,18 @@ class MediaPlayerService:
         title_advanced = title_after != title_before
         if not title_advanced:
             position_changed = position_updated_after != position_updated_before
-            _LOGGER.error(
+            # #808 follow-up: this is the storefront/region-mismatch
+            # signature — MA accepted the URI but couldn't resolve a stream
+            # for it, so the speaker just keeps playing the prior track.
+            # @Levtos hit this for `apple_music://track/302229811` (US-only
+            # 'All Together Now' on a DE-storefront MA), and the iTunes
+            # Lookup confirmed: track in US catalog, NOT in DE catalog.
+            _LOGGER.warning(
                 "MA playback failed after %.1fs for %s — speaker still on "
-                "prior track %r (position timestamp %s); skipping (#795, was #777)",
+                "prior track %r (position timestamp %s). Track is likely "
+                "not available in your provider's catalog/storefront, OR "
+                "your provider needs re-authentication in MA. Skipping "
+                "this song silently — game will try the next one. (#795)",
                 MA_PLAYBACK_TIMEOUT,
                 uri,
                 title_before,
@@ -556,6 +599,12 @@ class MediaPlayerService:
                     "media_stop call after stale-title detect failed for %s",
                     self._entity_id,
                 )
+            # #808 follow-up: classify as "unavailable" so start_round skips
+            # silently without counting against MAX_SONG_RETRIES. Storefront
+            # gaps shouldn't pause the game — the user can't fix individual
+            # track availability and the game should keep playing whatever
+            # subset IS in their catalog.
+            self.last_failure_reason = "unavailable"
             return False
 
         # #345 slow-buffer tolerance, narrowed to "title genuinely changed":

--- a/custom_components/beatify/www/sw.js
+++ b/custom_components/beatify/www/sw.js
@@ -6,7 +6,7 @@
  */
 'use strict';
 
-var CACHE_VERSION = 'beatify-v3.3.2-rc10';
+var CACHE_VERSION = 'beatify-v3.3.2-rc11';
 var MAX_CACHE_ITEMS = 50;
 
 // Critical assets to precache on install (minified versions only - fallback handled by HTML)

--- a/tests/unit/test_media_player.py
+++ b/tests/unit/test_media_player.py
@@ -338,6 +338,11 @@ class TestMANonBlockingPlayback:
         'Sugar, Sugar' / 'Lazy Sunday (Mono)' for multiple rounds while
         position advanced; old logic would falsely return True here and
         the UI advanced into rounds with no actual audio change.
+
+        #808 follow-up: this failure mode is now classified as "unavailable"
+        — start_round will skip the song silently rather than counting it
+        toward MAX_SONG_RETRIES (track is most likely region-locked /
+        not in the user's provider catalog).
         """
         hass = MagicMock()
         hass.services.async_call = AsyncMock()
@@ -375,6 +380,9 @@ class TestMANonBlockingPlayback:
                 result = await svc.play_song(_make_song(title="New Song"))
 
         assert result is False
+        # #808 follow-up: title-stale failure is classified as "unavailable"
+        # so start_round can skip silently instead of counting toward retries.
+        assert svc.last_failure_reason == "unavailable"
 
     @pytest.mark.asyncio
     async def test_ma_first_song_no_previous_title(self):
@@ -929,3 +937,95 @@ class TestStartRoundAvailabilityCheck:
         mock_media_service.is_available.assert_called_once()
         mock_game_state.pause_game.assert_awaited_once_with("media_player_error")
         assert "unavailable" in mock_game_state.last_error_detail
+
+
+class TestStartRoundFailureClassification:
+    """#808 follow-up: start_round must distinguish 'unavailable' (skip silently)
+    from 'error' (count toward MAX_SONG_RETRIES → pause).
+    """
+
+    @pytest.mark.asyncio
+    async def test_unavailable_failure_does_not_count_toward_retry_limit(self):
+        """When play_song fails with last_failure_reason='unavailable', the
+        next start_round call must NOT see _retry_count incremented.
+        Region/storefront-locked tracks are user-uncontrollable; the game
+        should keep playing whatever subset IS available without ever
+        pausing on these.
+        """
+        from custom_components.beatify.game.state import GameState  # noqa: PLC0415
+        from tests.conftest import (  # noqa: PLC0415
+            make_game_state,
+            make_songs,
+        )
+
+        gs: GameState = make_game_state()
+        gs.create_game(
+            playlists=["test.json"],
+            songs=make_songs(5),
+            media_player="media_player.test",
+            base_url="http://localhost:8123",
+        )
+
+        # Service: always fails with "unavailable"
+        mock_service = MagicMock()
+        mock_service.is_available.return_value = True
+        mock_service.last_failure_reason = "unavailable"
+        mock_service.play_song = AsyncMock(return_value=False)
+        gs._media_player_service = mock_service
+        gs.media_player = "media_player.test"
+        gs.platform = "music_assistant"
+        gs.pause_game = AsyncMock()  # spy to ensure NOT called
+
+        # Cap recursion to keep the test bounded — start_round will loop
+        # through the playlist marking each song unavailable, eventually
+        # returning False because all songs are exhausted (NOT pausing).
+        with patch(
+            "custom_components.beatify.game.state.asyncio.sleep",
+            new_callable=AsyncMock,
+        ):
+            await gs.start_round()
+
+        # Must NOT have called pause_game — unavailable doesn't pause.
+        gs.pause_game.assert_not_awaited()
+        # play_song was called multiple times (once per song until exhausted).
+        assert mock_service.play_song.await_count >= 2
+
+    @pytest.mark.asyncio
+    async def test_error_failure_still_pauses_after_max_retries(self):
+        """Regression guard: 'error' failures (or unset reason) must still
+        count toward MAX_SONG_RETRIES and pause the game. We don't want the
+        skip-silent path to mask actual systemic problems (offline speaker,
+        broken provider auth across the board).
+        """
+        from custom_components.beatify.game.state import GameState  # noqa: PLC0415
+        from tests.conftest import (  # noqa: PLC0415
+            make_game_state,
+            make_songs,
+        )
+
+        gs: GameState = make_game_state()
+        gs.create_game(
+            playlists=["test.json"],
+            songs=make_songs(10),
+            media_player="media_player.test",
+            base_url="http://localhost:8123",
+        )
+
+        mock_service = MagicMock()
+        mock_service.is_available.return_value = True
+        mock_service.last_failure_reason = "error"
+        mock_service.play_song = AsyncMock(return_value=False)
+        gs._media_player_service = mock_service
+        gs.media_player = "media_player.test"
+        gs.platform = "music_assistant"
+        gs.pause_game = AsyncMock()
+
+        with patch(
+            "custom_components.beatify.game.state.asyncio.sleep",
+            new_callable=AsyncMock,
+        ):
+            result = await gs.start_round()
+
+        # Must have paused once retries exhausted.
+        assert result is False
+        gs.pause_game.assert_awaited_once_with("media_player_error")


### PR DESCRIPTION
## Summary

@Levtos's rc10 playthrough exposed the next layer of the Apple Music story:

- The `apple_music://track/302229811` URI ("All Together Now") hit the strict-detect failure signature ("speaker still on prior track").
- iTunes Lookup confirmed: track is in the **US** Apple Music catalog but **NOT in DE** (\`resultCount=0\`).
- Beatify's playlists predominantly store US-storefront Apple Music IDs; for users on other regional storefronts, some songs are unresolvable through their MA Apple Music provider.

These per-track failures shouldn't pause the game — the user can't fix individual track availability. This PR makes Beatify skip them silently and keep playing whatever subset IS in the user's catalog.

## Changes

**Backend:**
- New \`MediaPlayerService.last_failure_reason\` field (\`None\` / \`"unavailable"\` / \`"error"\`).
  - **\`"unavailable"\`** — strict-detect path (speaker stayed on prior track). Most common cause: track not in user's storefront. Skipped silently, doesn't count toward \`MAX_SONG_RETRIES\`.
  - **\`"error"\`** — speaker idle/off/unavailable, or MA-side resolve failure. Still counts toward retries → recovery banner kicks in for systemic problems.
- \`start_round\` reads \`last_failure_reason\` and routes accordingly.

**Logging:**
- Strict-detect path now explains *"Track is likely not available in your provider's catalog/storefront, OR your provider needs re-authentication in MA"* — same diagnostic chain that found the rc8/rc9 root cause, surfaced in-product.
- Speaker-idle path mentions both possibilities (offline / unauthenticated / unavailable).

## Versions
- \`manifest.json\` + \`sw.js CACHE_VERSION\` → \`3.3.2-rc11\`. No frontend asset changes.

## Test plan
- [x] \`pytest tests/unit/\` — 429 passed (+2 new), 1 xfailed.
- [x] \`ruff check\` + \`ruff format --check\` — clean.
- [x] New \`TestStartRoundFailureClassification\`: one test verifies "unavailable" doesn't pause across many failures, one verifies "error" still pauses at MAX_SONG_RETRIES.
- [x] Existing strict-detect test extended to assert \`last_failure_reason == "unavailable"\`.
- [ ] @Levtos retests on Apple Music DE — game should keep playing through US-only tracks instead of pausing.

## Out of scope (filed separately)
- **Storefront-aware playlist generation**: re-fetch all Apple Music URIs against US/DE/GB/FR/ES storefronts, store per-region IDs, pick the right one based on the user's MA provider config. Real fix for the underlying data issue but a meaningful playlist-pipeline change. Filing as a separate enhancement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)