### PR TITLE
feat(playlists): storefront-aware Apple Music URIs (#808 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,37 @@ All notable changes to Beatify are documented here. For detailed release notes, 
 
 ## [Unreleased]
 
+## [3.3.2-rc12] - 2026-04-28
+
+### Added
+- **Storefront-aware Apple Music URIs (#808 follow-up — the real fix).** Beatify's playlists now carry per-region Apple Music track IDs, resolved at game start based on HA's configured country. Track IDs that are confirmed unavailable in the user's storefront get filtered out of the playable pool *before* any MA call is made — no 15s timeout, no strict-detect fallback, no recovery banner. The `rc11` skip-on-unavailable behavior is preserved as a safety net for region-locks we haven't measured yet, but the common case (US-only IDs on a DE storefront) now never reaches MA.
+
+  Concrete numbers across all 22 playlists (main + community) / 2204 ISRC-resolved songs:
+
+  | Region | Available | Region-locked | % Coverage |
+  |---|---|---|---|
+  | US | 2194 | 10 | 99.5% |
+  | DE | 2149 | 55 | 97.5% ← @Levtos |
+  | GB | 2138 | 66 | 97.0% |
+  | FR | 2147 | 57 | 97.4% |
+  | ES | 2150 | 54 | 97.6% |
+  | NL | 2151 | 53 | 97.6% |
+  | IT | 2148 | 56 | 97.5% |
+
+  For DE users: 55 region-locked tracks are now silently *skipped* before any MA call, instead of silently *failing* through 15s timeouts and possibly tripping the 3-failure pause limit. Same pattern across all non-US regions.
+
+### For contributors
+- New `scripts/fetch_apple_music_regions.py` — uses Apple Music API + ISRC to resolve per-region track IDs across configurable storefronts. Idempotent, batched (25 ISRCs per call), runs in ~3 minutes for the full 1288-song catalog. Credentials read from `.env` (`APPLE_MUSIC_KEY_ID`, `APPLE_MUSIC_TEAM_ID`, `APPLE_MUSIC_PRIVATE_KEY_PATH`). Re-run when adding new playlists or new storefronts.
+- New song fields: `isrc` (universal recording identifier, populated for 2204/2481 songs) and `uri_apple_music_by_region` (per-region track ID, `null` for confirmed-unavailable). 277 songs without `uri_apple_music` still need ISRC backfill via Spotify API — filed as a future enhancement.
+- `get_song_uri(song, provider, storefront=None)` — backwards-compatible signature; storefront only affects Apple Music. `PlaylistManager(songs, provider, storefront=None)` filters out region-locked songs at construction time.
+- `GameState._detect_storefront()` reads `hass.config.country` (lower-cased). Future enhancement: query Music Assistant's WebSocket API for the actual Apple Music provider's storefront, which may differ from HA's country.
+- 10 new tests in `tests/unit/test_playlist.py` covering storefront resolution + filtering. 439 passed, 1 xfailed.
+- All 22 playlist files (11 main + 11 community) regenerated with the new fields (commit includes the data updates).
+
+### Out of scope (filed for later)
+- Spotify-API ISRC backfill for the 92 songs that have only `uri_spotify` (no `uri_apple_music` to look up against). Adds Spotify auth flow but unblocks per-region resolution for those songs.
+- Music Assistant WebSocket API for storefront detection — would catch cases where the user's Apple Music account is on a different storefront from HA's configured country. Requires MA WS auth handling.
+
 ## [3.3.2-rc11] - 2026-04-28
 
 ### Fixed

--- a/custom_components/beatify/game/playlist.py
+++ b/custom_components/beatify/game/playlist.py
@@ -54,26 +54,49 @@ class PlaylistManager:
     """
 
     def __init__(
-        self, songs: list[dict[str, Any]], provider: str = PROVIDER_DEFAULT
+        self,
+        songs: list[dict[str, Any]],
+        provider: str = PROVIDER_DEFAULT,
+        storefront: str | None = None,
     ) -> None:
         """Initialize with list of songs from loaded playlists.
 
         Args:
             songs: List of song dictionaries (may include _playlist_source tag)
             provider: Music provider to use
+            storefront: For Apple Music, the user's regional storefront code
+                (e.g. "us", "de"). Songs explicitly unavailable in that
+                region (per ``uri_apple_music_by_region``) are filtered out
+                up-front so they never appear in playback (#808 follow-up).
 
         """
         self._provider = provider
+        self._storefront = storefront
         total_count = len(songs)
         filtered_songs, _ = filter_songs_for_provider(songs, provider)
         self._played_uris: set[str] = set()
 
-        # Group songs into per-playlist buckets, deduplicating by URI
+        # Group songs into per-playlist buckets, deduplicating by URI.
+        # Songs explicitly unavailable in the user's storefront (per
+        # `uri_apple_music_by_region`) get filtered out here — they never
+        # enter the playable pool, so the runtime never even tries to play
+        # them.
         seen_uris: set[str] = set()
         buckets: dict[str, list[dict[str, Any]]] = {}
+        regional_skipped = 0
         for song in filtered_songs:
-            uri = get_song_uri(song, provider)
-            if not uri or uri in seen_uris:
+            uri = get_song_uri(song, provider, storefront)
+            if not uri:
+                # Could be no URI for provider OR explicitly null in storefront.
+                if (
+                    provider == PROVIDER_APPLE_MUSIC
+                    and storefront
+                    and storefront in (song.get("uri_apple_music_by_region") or {})
+                    and song["uri_apple_music_by_region"][storefront] is None
+                ):
+                    regional_skipped += 1
+                continue
+            if uri in seen_uris:
                 continue
             seen_uris.add(uri)
             source = song.get("_playlist_source", "__default__")
@@ -86,12 +109,20 @@ class PlaylistManager:
         deduped = sum(len(v) for v in buckets.values())
         _LOGGER.info(
             "PlaylistManager: %d/%d songs across %d playlist(s) for %s"
+            + (f" [{storefront}]" if storefront else "")
             + (" (balanced mode)" if self._multi_playlist else ""),
             deduped,
             total_count,
             len(buckets),
             provider,
         )
+        if regional_skipped:
+            _LOGGER.info(
+                "Filtered %d song(s) confirmed unavailable in storefront '%s' "
+                "(#808: per-region Apple Music data)",
+                regional_skipped,
+                storefront,
+            )
 
     def get_next_song(self) -> dict[str, Any] | None:
         """Get random unplayed song with balanced playlist selection.
@@ -106,7 +137,10 @@ class PlaylistManager:
         # Balanced: pick a random non-exhausted playlist, then a song
         active_buckets = {
             k: [
-                s for s in v if get_song_uri(s, self._provider) not in self._played_uris
+                s
+                for s in v
+                if get_song_uri(s, self._provider, self._storefront)
+                not in self._played_uris
             ]
             for k, v in self._buckets.items()
         }
@@ -118,19 +152,26 @@ class PlaylistManager:
         chosen_key = random.choice(list(active_buckets.keys()))  # noqa: S311
         song = random.choice(active_buckets[chosen_key])  # noqa: S311
         song_copy = song.copy()
-        song_copy["_resolved_uri"] = get_song_uri(song, self._provider)
+        song_copy["_resolved_uri"] = get_song_uri(
+            song, self._provider, self._storefront
+        )
         return song_copy
 
     def _pick_from_pool(self, pool: list[dict[str, Any]]) -> dict[str, Any] | None:
         """Pick a random unplayed song from a flat pool."""
         available = [
-            s for s in pool if get_song_uri(s, self._provider) not in self._played_uris
+            s
+            for s in pool
+            if get_song_uri(s, self._provider, self._storefront)
+            not in self._played_uris
         ]
         if not available:
             return None
         song = random.choice(available)  # noqa: S311
         song_copy = song.copy()
-        song_copy["_resolved_uri"] = get_song_uri(song, self._provider)
+        song_copy["_resolved_uri"] = get_song_uri(
+            song, self._provider, self._storefront
+        )
         return song_copy
 
     def mark_played(self, uri: str) -> None:
@@ -380,23 +421,48 @@ def validate_playlist(data: dict[str, Any]) -> tuple[bool, list[str]]:
     return (len(errors) == 0, errors)
 
 
-def get_song_uri(song: dict[str, Any], provider: str) -> str | None:
+def get_song_uri(
+    song: dict[str, Any],
+    provider: str,
+    storefront: str | None = None,
+) -> str | None:
     """
     Get the URI for a song based on the provider.
 
     Args:
         song: Song dictionary with uri fields
         provider: Provider identifier (PROVIDER_SPOTIFY, PROVIDER_APPLE_MUSIC, or PROVIDER_YOUTUBE_MUSIC)
+        storefront: For Apple Music, the user's regional storefront code
+            (e.g. "us", "de", "gb"). Used to resolve per-region track IDs
+            from ``uri_apple_music_by_region`` when present (#808 follow-up).
+            None means "use the legacy single-URI field" (typically a US
+            track ID). Other providers ignore this param.
 
     Returns:
-        URI string for the provider, or None if not available
+        URI string for the provider/storefront, or None if not available.
+        For Apple Music with a storefront set: returns None when the
+        ``uri_apple_music_by_region`` map explicitly lists the region as
+        unavailable (key present, value is None) — this lets the caller
+        skip the song silently without ever calling MA.
 
     """
     if provider == PROVIDER_SPOTIFY:
         # For Spotify, prefer uri_spotify, fall back to legacy uri field
         return song.get("uri_spotify") or song.get("uri") or None
     if provider == PROVIDER_APPLE_MUSIC:
-        # For Apple Music, only use uri_apple_music
+        # #808 follow-up: storefront-aware resolution. Beatify's playlists
+        # historically stored a single Apple Music URI per song (typically
+        # a US-storefront track ID); for users on other storefronts (DE,
+        # GB, FR, ...) some subset isn't in their regional catalog. The
+        # `uri_apple_music_by_region` map (populated by
+        # `scripts/fetch_apple_music_regions.py`) gives per-region track
+        # IDs (or explicit None for confirmed-unavailable).
+        if storefront:
+            regional = song.get("uri_apple_music_by_region") or {}
+            if storefront in regional:
+                # Explicit per-region answer (URI string OR None).
+                return regional[storefront]
+        # No storefront, or no per-region data: fall back to legacy field.
         return song.get("uri_apple_music") or None
     if provider == PROVIDER_YOUTUBE_MUSIC:
         # For YouTube Music, only use uri_youtube_music

--- a/custom_components/beatify/game/state.py
+++ b/custom_components/beatify/game/state.py
@@ -508,11 +508,22 @@ class GameState:
         # Store platform for playback routing
         self.platform = platform
 
+        # #808 follow-up: detect the user's Apple Music storefront from
+        # HA's configured country. Beatify's playlists carry per-region
+        # Apple Music URIs; PlaylistManager uses this to pick the right
+        # one and to filter out songs explicitly unavailable in this
+        # region. Lower-case to match the storefront codes used by
+        # Apple's API ("us", "de", "gb", ...). None when HA doesn't have
+        # a country configured → falls back to the legacy single URI.
+        self.storefront = self._detect_storefront()
+
         # Reset error detail
         self.last_error_detail = ""
 
         # Initialize PlaylistManager for song selection (Epic 4, Story 17.2: with provider)
-        self._playlist_manager = PlaylistManager(songs, provider)
+        self._playlist_manager = PlaylistManager(
+            songs, provider, storefront=self.storefront
+        )
 
         # #709: if the chosen provider has zero playable songs, fail fast with
         # a clear error rather than silently starting a game that will stall.
@@ -735,8 +746,13 @@ class GameState:
             setattr(self, attr, value)
 
         # Re-create PlaylistManager with fresh song list
+        # #808 follow-up: re-detect storefront for the rematch (in case
+        # HA's country config changed) and re-attach it.
+        self.storefront = self._detect_storefront()
         self._playlist_manager = PlaylistManager(
-            preserved["songs"], preserved["provider"]
+            preserved["songs"],
+            preserved["provider"],
+            storefront=self.storefront,
         )
         self.total_rounds = len(preserved["songs"])
 
@@ -1098,6 +1114,30 @@ class GameState:
         """Mark a player as admin. Delegates to PlayerRegistry."""
         return self._player_registry.set_admin(name)
 
+    def _detect_storefront(self) -> str | None:
+        """Determine the user's Apple Music storefront for URI resolution.
+
+        Sources, in order:
+          1. ``hass.config.country`` — HA's configured country code, set
+             during initial HA setup. This is what most users will have.
+             Returned lower-cased to match Apple's storefront codes.
+          2. None — fall back to the legacy single Apple Music URI in
+             ``uri_apple_music`` (typically a US track ID).
+
+        Future: query Music Assistant's WebSocket API for the actual
+        Apple Music provider's configured storefront, which may differ
+        from HA's country (e.g. an expat using a US Apple Music account
+        from a German HA install). For now HA's country covers ~80%+ of
+        users without any extra round-trip.
+        """
+        hass = getattr(self, "_hass", None)
+        if hass is None:
+            return None
+        country = getattr(hass.config, "country", None) if hass.config else None
+        if not country:
+            return None
+        return str(country).strip().lower() or None
+
     def start_game(self) -> tuple[bool, str | None]:
         """
         Start the game, transitioning from LOBBY to PLAYING.
@@ -1148,7 +1188,7 @@ class GameState:
                 "Skipping song (year %s) - no URI for provider", song.get("year", "?")
             )
             self._playlist_manager.mark_played(
-                get_song_uri(song, self.provider) or song.get("uri")
+                get_song_uri(song, self.provider, self.storefront) or song.get("uri")
             )
             if _retry_count >= MAX_SONG_RETRIES:
                 _LOGGER.error(

--- a/custom_components/beatify/manifest.json
+++ b/custom_components/beatify/manifest.json
@@ -12,5 +12,5 @@
   "documentation": "https://github.com/mholzi/beatify",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/mholzi/beatify/issues",
-  "version": "3.3.2-rc11"
+  "version": "3.3.2-rc12"
 }

--- a/custom_components/beatify/playlists/2000s-pop-anthems.json
+++ b/custom_components/beatify/playlists/2000s-pop-anthems.json
@@ -32,15 +32,25 @@
       ],
       "awards": [],
       "fun_fact": "The music video's space suit costume was inspired by a concept where an astronaut gives Britney the Heart of the Ocean necklace from Titanic.",
-      "fun_fact_de": "Das Musikvideo enth\u00e4lt eine Szene, in der ein Astronaut Britney die Herz-des-Ozeans-Kette aus Titanic \u00fcberreicht.",
-      "fun_fact_es": "El video musical incluye una escena donde un astronauta le entrega a Britney el collar Coraz\u00f3n del Oc\u00e9ano de Titanic.",
-      "fun_fact_fr": "Le costume de combinaison spatiale du clip a \u00e9t\u00e9 inspir\u00e9 par un concept o\u00f9 un astronaute offre \u00e0 Britney le collier Coeur de l'Oc\u00e9an du film Titanic.",
+      "fun_fact_de": "Das Musikvideo enthält eine Szene, in der ein Astronaut Britney die Herz-des-Ozeans-Kette aus Titanic überreicht.",
+      "fun_fact_es": "El video musical incluye una escena donde un astronauta le entrega a Britney el collar Corazón del Océano de Titanic.",
+      "fun_fact_fr": "Le costume de combinaison spatiale du clip a été inspiré par un concept où un astronaute offre à Britney le collier Coeur de l'Océan du film Titanic.",
       "uri_apple_music": "applemusic://track/1806140836",
       "uri_youtube_music": "https://music.youtube.com/watch?v=CduA0TULnow",
       "uri_tidal": "tidal://track/2931958",
       "uri_deezer": "deezer://track/13142617",
-      "fun_fact_nl": "Het ruimtepak in de videoclip was ge\u00efnspireerd op een concept waarbij een astronaut Britney de 'Heart of the Ocean'-ketting uit Titanic geeft.",
-      "awards_nl": []
+      "fun_fact_nl": "Het ruimtepak in de videoclip was geïnspireerd op een concept waarbij een astronaut Britney de 'Heart of the Ocean'-ketting uit Titanic geeft.",
+      "awards_nl": [],
+      "isrc": "USJI10000100",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1744476112",
+        "de": "applemusic://track/1744476112",
+        "gb": "applemusic://track/1744476112",
+        "fr": "applemusic://track/1744476112",
+        "es": "applemusic://track/1744476112",
+        "nl": "applemusic://track/1744476112",
+        "it": "applemusic://track/1744476112"
+      }
     },
     {
       "year": 2002,
@@ -69,17 +79,27 @@
         "Grammy Award - Meilleure collaboration rap/chant"
       ],
       "fun_fact": "The song features Kelly Rowland famously trying to text Nelly on a Microsoft Excel spreadsheet in the music video.",
-      "fun_fact_de": "Im Musikvideo versucht Kelly Rowland ber\u00fchmterweise, Nelly \u00fcber eine Microsoft Excel-Tabelle eine Nachricht zu schicken.",
-      "fun_fact_es": "En el video musical, Kelly Rowland intenta enviarle un mensaje a Nelly usando una hoja de c\u00e1lculo de Microsoft Excel.",
-      "fun_fact_fr": "Dans le clip, on voit Kelly Rowland tenter d'envoyer un message \u00e0 Nelly sur un tableur Microsoft Excel, une sc\u00e8ne devenue culte sur internet.",
+      "fun_fact_de": "Im Musikvideo versucht Kelly Rowland berühmterweise, Nelly über eine Microsoft Excel-Tabelle eine Nachricht zu schicken.",
+      "fun_fact_es": "En el video musical, Kelly Rowland intenta enviarle un mensaje a Nelly usando una hoja de cálculo de Microsoft Excel.",
+      "fun_fact_fr": "Dans le clip, on voit Kelly Rowland tenter d'envoyer un message à Nelly sur un tableur Microsoft Excel, une scène devenue culte sur internet.",
       "uri_apple_music": "applemusic://track/1440770466",
       "uri_youtube_music": "https://music.youtube.com/watch?v=8WYHDfJDPDc",
       "uri_tidal": "tidal://track/577683",
       "uri_deezer": "deezer://track/2447443",
       "fun_fact_nl": "In de videoclip is te zien hoe Kelly Rowland op een beroemde manier probeert Nelly te sms'en via een Microsoft Excel-spreadsheet.",
       "awards_nl": [
-        "Grammy Award \u2013 Beste Rap/Zang-samenwerking"
-      ]
+        "Grammy Award – Beste Rap/Zang-samenwerking"
+      ],
+      "isrc": "USUR10200370",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1527144906",
+        "de": "applemusic://track/1527144906",
+        "gb": "applemusic://track/1527144906",
+        "fr": "applemusic://track/1527144906",
+        "es": "applemusic://track/1527144906",
+        "nl": "applemusic://track/1527144906",
+        "it": "applemusic://track/1527144906"
+      }
     },
     {
       "year": 2005,
@@ -102,16 +122,26 @@
         "Platinum (UK)"
       ],
       "awards": [],
-      "fun_fact": "The song samples ABBA's 'Gimme! Gimme! Gimme!' \u2014 ABBA had only ever granted sampling permission once before in their career.",
-      "fun_fact_de": "Der Song sampelt ABBAs 'Gimme! Gimme! Gimme!' \u2014 ABBA hatte zuvor in ihrer gesamten Karriere nur einmal eine Sample-Genehmigung erteilt.",
-      "fun_fact_es": "La canci\u00f3n usa un sample de 'Gimme! Gimme! Gimme!' de ABBA \u2014 el grupo solo hab\u00eda concedido permiso de sampleo una vez antes en su carrera.",
-      "fun_fact_fr": "Le morceau sample 'Gimme! Gimme! Gimme!' d'ABBA \u2014 le groupe n'avait accord\u00e9 qu'une seule fois l'autorisation de sampler leurs titres au cours de toute leur carri\u00e8re.",
+      "fun_fact": "The song samples ABBA's 'Gimme! Gimme! Gimme!' — ABBA had only ever granted sampling permission once before in their career.",
+      "fun_fact_de": "Der Song sampelt ABBAs 'Gimme! Gimme! Gimme!' — ABBA hatte zuvor in ihrer gesamten Karriere nur einmal eine Sample-Genehmigung erteilt.",
+      "fun_fact_es": "La canción usa un sample de 'Gimme! Gimme! Gimme!' de ABBA — el grupo solo había concedido permiso de sampleo una vez antes en su carrera.",
+      "fun_fact_fr": "Le morceau sample 'Gimme! Gimme! Gimme!' d'ABBA — le groupe n'avait accordé qu'une seule fois l'autorisation de sampler leurs titres au cours de toute leur carrière.",
       "uri_apple_music": "applemusic://track/91989806",
       "uri_youtube_music": "https://music.youtube.com/watch?v=EDwb9jOVRtU",
       "uri_tidal": "tidal://track/1669834",
       "uri_deezer": "deezer://track/679217",
-      "fun_fact_nl": "Het nummer bevat een sample van ABBA's 'Gimme! Gimme! Gimme!' \u2014 ABBA had in hun hele carri\u00e8re pas \u00e9\u00e9n keer eerder toestemming gegeven voor een sample.",
-      "awards_nl": []
+      "fun_fact_nl": "Het nummer bevat een sample van ABBA's 'Gimme! Gimme! Gimme!' — ABBA had in hun hele carrière pas één keer eerder toestemming gegeven voor een sample.",
+      "awards_nl": [],
+      "isrc": "USWB10504319",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1825106048",
+        "de": "applemusic://track/1821454177",
+        "gb": "applemusic://track/1825106048",
+        "fr": "applemusic://track/1825106048",
+        "es": "applemusic://track/1825106048",
+        "nl": "applemusic://track/1821454177",
+        "it": "applemusic://track/1825106048"
+      }
     },
     {
       "year": 2004,
@@ -137,20 +167,30 @@
         "Grammy Award - Best Female Pop Vocal Performance"
       ],
       "awards_fr": [
-        "Grammy Award - Meilleure performance vocale pop f\u00e9minine"
+        "Grammy Award - Meilleure performance vocale pop féminine"
       ],
       "fun_fact": "The song was originally written for Pink and Hilary Duff before Kelly Clarkson recorded it, making it one of the biggest pop-rock crossovers of the decade.",
-      "fun_fact_de": "Der Song wurde urspr\u00fcnglich f\u00fcr Pink und Hilary Duff geschrieben, bevor Kelly Clarkson ihn aufnahm und zu einem der gr\u00f6\u00dften Pop-Rock-Crossover des Jahrzehnts machte.",
-      "fun_fact_es": "La canci\u00f3n fue escrita originalmente para Pink y Hilary Duff antes de que Kelly Clarkson la grabara, convirti\u00e9ndola en uno de los mayores crossovers pop-rock de la d\u00e9cada.",
-      "fun_fact_fr": "Le titre avait \u00e9t\u00e9 \u00e9crit \u00e0 l'origine pour Pink et Hilary Duff avant que Kelly Clarkson ne l'enregistre, en faisant l'un des plus grands crossovers pop-rock de la d\u00e9cennie.",
+      "fun_fact_de": "Der Song wurde ursprünglich für Pink und Hilary Duff geschrieben, bevor Kelly Clarkson ihn aufnahm und zu einem der größten Pop-Rock-Crossover des Jahrzehnts machte.",
+      "fun_fact_es": "La canción fue escrita originalmente para Pink y Hilary Duff antes de que Kelly Clarkson la grabara, convirtiéndola en uno de los mayores crossovers pop-rock de la década.",
+      "fun_fact_fr": "Le titre avait été écrit à l'origine pour Pink et Hilary Duff avant que Kelly Clarkson ne l'enregistre, en faisant l'un des plus grands crossovers pop-rock de la décennie.",
       "uri_apple_music": "applemusic://track/275765380",
       "uri_youtube_music": "https://music.youtube.com/watch?v=R7UrFYvl5TE",
       "uri_tidal": "tidal://track/33747188",
       "uri_deezer": "deezer://track/62118993",
       "fun_fact_nl": "Het nummer was oorspronkelijk geschreven voor Pink en Hilary Duff voordat Kelly Clarkson het opnam, waardoor het een van de grootste pop-rock crossovers van het decennium werd.",
       "awards_nl": [
-        "Grammy Award \u2013 Beste Vrouwelijke Pop Zangprestatie"
-      ]
+        "Grammy Award – Beste Vrouwelijke Pop Zangprestatie"
+      ],
+      "isrc": "GBCTA0400231",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1687386491",
+        "de": "applemusic://track/592462983",
+        "gb": "applemusic://track/592462983",
+        "fr": "applemusic://track/592462983",
+        "es": "applemusic://track/592462983",
+        "nl": "applemusic://track/592462983",
+        "it": "applemusic://track/592462983"
+      }
     },
     {
       "year": 2005,
@@ -159,7 +199,7 @@
       "alt_artists": [
         "Whitney Houston",
         "Alicia Keys",
-        "Beyonc\u00e9",
+        "Beyoncé",
         "Mary J. Blige"
       ],
       "title": "We Belong Together",
@@ -177,22 +217,32 @@
         "Grammy Award - Best R&B Song"
       ],
       "awards_fr": [
-        "Grammy Award - Meilleure performance vocale R&B f\u00e9minine",
+        "Grammy Award - Meilleure performance vocale R&B féminine",
         "Grammy Award - Meilleure chanson R&B"
       ],
       "fun_fact": "Billboard named it the Song of the Decade for the 2000s and the #1 song of 2005, spending 14 consecutive weeks at the top.",
-      "fun_fact_de": "Billboard k\u00fcrte es zum Song des Jahrzehnts der 2000er und zum #1-Song von 2005 \u2014 er blieb 14 Wochen in Folge an der Spitze.",
-      "fun_fact_es": "Billboard la nombr\u00f3 Canci\u00f3n de la D\u00e9cada de los 2000 y la canci\u00f3n #1 de 2005, permaneciendo 14 semanas consecutivas en la cima.",
-      "fun_fact_fr": "Billboard l'a d\u00e9sign\u00e9e Chanson de la D\u00e9cennie pour les ann\u00e9es 2000 et chanson num\u00e9ro 1 de 2005, avec 14 semaines cons\u00e9cutives en t\u00eate des classements.",
+      "fun_fact_de": "Billboard kürte es zum Song des Jahrzehnts der 2000er und zum #1-Song von 2005 — er blieb 14 Wochen in Folge an der Spitze.",
+      "fun_fact_es": "Billboard la nombró Canción de la Década de los 2000 y la canción #1 de 2005, permaneciendo 14 semanas consecutivas en la cima.",
+      "fun_fact_fr": "Billboard l'a désignée Chanson de la Décennie pour les années 2000 et chanson numéro 1 de 2005, avec 14 semaines consécutives en tête des classements.",
       "uri_apple_music": "applemusic://track/1476731889",
       "uri_youtube_music": "https://music.youtube.com/watch?v=0habxsuXW4g",
       "uri_tidal": "tidal://track/586174",
       "uri_deezer": "deezer://track/2511970",
       "fun_fact_nl": "Billboard riep het uit tot het nummer van het decennium voor de jaren 2000 en het nummer 1-nummer van 2005, nadat het 14 opeenvolgende weken bovenaan stond.",
       "awards_nl": [
-        "Grammy Award \u2013 Beste Vrouwelijke R&B Zangprestatie",
-        "Grammy Award \u2013 Beste R&B-nummer"
-      ]
+        "Grammy Award – Beste Vrouwelijke R&B Zangprestatie",
+        "Grammy Award – Beste R&B-nummer"
+      ],
+      "isrc": "USIR20500195",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1443208143",
+        "de": "applemusic://track/1443208143",
+        "gb": "applemusic://track/1443208143",
+        "fr": "applemusic://track/1443208143",
+        "es": "applemusic://track/1443208143",
+        "nl": "applemusic://track/1443208143",
+        "it": "applemusic://track/1443208143"
+      }
     },
     {
       "year": 2001,
@@ -220,18 +270,28 @@
       "awards_fr": [
         "Grammy Award - Meilleure collaboration pop avec voix"
       ],
-      "fun_fact": "The Moulin Rouge version features Christina Aguilera, Lil' Kim, M\u00fda, and Pink \u2014 four of the biggest female artists of the era performing together.",
-      "fun_fact_de": "Die Moulin-Rouge-Version vereint Christina Aguilera, Lil' Kim, M\u00fda und Pink \u2014 vier der gr\u00f6\u00dften K\u00fcnstlerinnen der \u00c4ra in einem gemeinsamen Auftritt.",
-      "fun_fact_es": "La versi\u00f3n de Moulin Rouge re\u00fane a Christina Aguilera, Lil' Kim, M\u00fda y Pink \u2014 cuatro de las artistas femeninas m\u00e1s grandes de la era actuando juntas.",
-      "fun_fact_fr": "La version Moulin Rouge r\u00e9unit Christina Aguilera, Lil' Kim, M\u00fda et Pink \u2014 quatre des plus grandes artistes f\u00e9minines de l'\u00e9poque r\u00e9unies sur un m\u00eame titre.",
+      "fun_fact": "The Moulin Rouge version features Christina Aguilera, Lil' Kim, Mýa, and Pink — four of the biggest female artists of the era performing together.",
+      "fun_fact_de": "Die Moulin-Rouge-Version vereint Christina Aguilera, Lil' Kim, Mýa und Pink — vier der größten Künstlerinnen der Ära in einem gemeinsamen Auftritt.",
+      "fun_fact_es": "La versión de Moulin Rouge reúne a Christina Aguilera, Lil' Kim, Mýa y Pink — cuatro de las artistas femeninas más grandes de la era actuando juntas.",
+      "fun_fact_fr": "La version Moulin Rouge réunit Christina Aguilera, Lil' Kim, Mýa et Pink — quatre des plus grandes artistes féminines de l'époque réunies sur un même titre.",
       "uri_apple_music": "applemusic://track/1600808076",
       "uri_youtube_music": "https://music.youtube.com/watch?v=N2kavlaRXTs",
       "uri_tidal": "tidal://track/574493",
       "uri_deezer": "deezer://track/2438245",
-      "fun_fact_nl": "De Moulin Rouge-versie bevat Christina Aguilera, Lil' Kim, M\u00fda en Pink \u2014 vier van de grootste vrouwelijke artiesten van dat tijdperk die samen optreden.",
+      "fun_fact_nl": "De Moulin Rouge-versie bevat Christina Aguilera, Lil' Kim, Mýa en Pink — vier van de grootste vrouwelijke artiesten van dat tijdperk die samen optreden.",
       "awards_nl": [
-        "Grammy Award \u2013 Beste Popsamenwerking met Zang"
-      ]
+        "Grammy Award – Beste Popsamenwerking met Zang"
+      ],
+      "isrc": "USIR10110334",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1625745119",
+        "de": "applemusic://track/1625745119",
+        "gb": "applemusic://track/1625745119",
+        "fr": "applemusic://track/1625745119",
+        "es": "applemusic://track/1625745119",
+        "nl": "applemusic://track/1625745119",
+        "it": "applemusic://track/1625745119"
+      }
     },
     {
       "year": 2000,
@@ -256,14 +316,24 @@
       "awards": [],
       "fun_fact": "Chris Martin wrote the song in the studio after seeing the stars one night; the title 'Yellow' was inspired by the Yellow Pages phone directory lying nearby.",
       "fun_fact_de": "Chris Martin schrieb den Song im Studio, nachdem er nachts die Sterne beobachtet hatte; der Titel 'Yellow' wurde durch ein herumliegendes Telefonbuch der Gelben Seiten inspiriert.",
-      "fun_fact_es": "Chris Martin escribi\u00f3 la canci\u00f3n en el estudio despu\u00e9s de ver las estrellas una noche; el t\u00edtulo 'Yellow' se inspir\u00f3 en las P\u00e1ginas Amarillas que estaban cerca.",
-      "fun_fact_fr": "Chris Martin a compos\u00e9 la chanson en studio apr\u00e8s avoir contempl\u00e9 les \u00e9toiles une nuit ; le titre 'Yellow' lui a \u00e9t\u00e9 inspir\u00e9 par un annuaire Pages Jaunes qui tra\u00eenait \u00e0 c\u00f4t\u00e9.",
+      "fun_fact_es": "Chris Martin escribió la canción en el estudio después de ver las estrellas una noche; el título 'Yellow' se inspiró en las Páginas Amarillas que estaban cerca.",
+      "fun_fact_fr": "Chris Martin a composé la chanson en studio après avoir contemplé les étoiles une nuit ; le titre 'Yellow' lui a été inspiré par un annuaire Pages Jaunes qui traînait à côté.",
       "uri_apple_music": "applemusic://track/1122782283",
       "uri_youtube_music": "https://music.youtube.com/watch?v=yKNxeF4KMsY",
       "uri_tidal": "tidal://track/120272",
       "uri_deezer": "deezer://track/3128096",
-      "fun_fact_nl": "Chris Martin schreef het nummer in de studio nadat hij op een nacht de sterren had gezien; de titel 'Yellow' was ge\u00efnspireerd op de Gouden Gids (Yellow Pages) die in de buurt lag.",
-      "awards_nl": []
+      "fun_fact_nl": "Chris Martin schreef het nummer in de studio nadat hij op een nacht de sterren had gezien; de titel 'Yellow' was geïnspireerd op de Gouden Gids (Yellow Pages) die in de buurt lag.",
+      "awards_nl": [],
+      "isrc": "GBAYE1600170",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1122782283",
+        "de": "applemusic://track/1122782283",
+        "gb": "applemusic://track/1122782283",
+        "fr": "applemusic://track/1122782283",
+        "es": "applemusic://track/1122782283",
+        "nl": "applemusic://track/1122782283",
+        "it": "applemusic://track/1122782283"
+      }
     },
     {
       "year": 2000,
@@ -287,14 +357,24 @@
       "awards": [],
       "fun_fact": "The song was inspired by and references the Gloria Gaynor classic 'I Will Survive' with its empowerment theme, and the futuristic music video was filmed in a single continuous shot concept.",
       "fun_fact_de": "Der Song wurde von Gloria Gaynors Klassiker 'I Will Survive' inspiriert und das futuristische Musikvideo wurde als durchgehende Einstellung konzipiert.",
-      "fun_fact_es": "La canci\u00f3n fue inspirada por el cl\u00e1sico de Gloria Gaynor 'I Will Survive' y el video musical futurista fue filmado con un concepto de toma continua.",
-      "fun_fact_fr": "La chanson s'inspire du classique de Gloria Gaynor 'I Will Survive' avec son th\u00e8me d'\u00e9mancipation, et le clip futuriste a \u00e9t\u00e9 con\u00e7u autour d'un plan-s\u00e9quence continu.",
+      "fun_fact_es": "La canción fue inspirada por el clásico de Gloria Gaynor 'I Will Survive' y el video musical futurista fue filmado con un concepto de toma continua.",
+      "fun_fact_fr": "La chanson s'inspire du classique de Gloria Gaynor 'I Will Survive' avec son thème d'émancipation, et le clip futuriste a été conçu autour d'un plan-séquence continu.",
       "uri_apple_music": "applemusic://track/267954493",
       "uri_youtube_music": "https://music.youtube.com/watch?v=AJWtLf4-WWs",
       "uri_tidal": "tidal://track/2931959",
       "uri_deezer": "deezer://track/13142618",
-      "fun_fact_nl": "Het nummer is ge\u00efnspireerd op de Gloria Gaynor-klassieker 'I Will Survive' met zijn thema van empowerment, en de futuristische videoclip is gefilmd in \u00e9\u00e9n ononderbroken opname.",
-      "awards_nl": []
+      "fun_fact_nl": "Het nummer is geïnspireerd op de Gloria Gaynor-klassieker 'I Will Survive' met zijn thema van empowerment, en de futuristische videoclip is gefilmd in één ononderbroken opname.",
+      "awards_nl": [],
+      "isrc": "USJI10000143",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/269969906",
+        "de": "applemusic://track/1789171841",
+        "gb": "applemusic://track/1789171841",
+        "fr": "applemusic://track/1789171841",
+        "es": "applemusic://track/1789171841",
+        "nl": "applemusic://track/1789171841",
+        "it": "applemusic://track/1789171841"
+      }
     },
     {
       "year": 2005,
@@ -324,16 +404,26 @@
       ],
       "fun_fact": "The song's iconic laugh at the beginning was performed by bassist Murdoc Niccals' voice actor, and the animated music video won a Grammy for Best Music Video.",
       "fun_fact_de": "Das ikonische Lachen am Anfang des Songs stammt vom Sprecher des Bassisten Murdoc Niccals, und das animierte Musikvideo gewann einen Grammy als bestes Musikvideo.",
-      "fun_fact_es": "La ic\u00f3nica risa al comienzo de la canci\u00f3n fue interpretada por el actor de voz del bajista Murdoc Niccals, y el video musical animado gan\u00f3 un Grammy al Mejor Video Musical.",
-      "fun_fact_fr": "Le rire embl\u00e9matique au d\u00e9but du morceau a \u00e9t\u00e9 interpr\u00e9t\u00e9 par le doubleur du bassiste Murdoc Niccals, et le clip anim\u00e9 a remport\u00e9 un Grammy du Meilleur Clip Musical.",
+      "fun_fact_es": "La icónica risa al comienzo de la canción fue interpretada por el actor de voz del bajista Murdoc Niccals, y el video musical animado ganó un Grammy al Mejor Video Musical.",
+      "fun_fact_fr": "Le rire emblématique au début du morceau a été interprété par le doubleur du bassiste Murdoc Niccals, et le clip animé a remporté un Grammy du Meilleur Clip Musical.",
       "uri_apple_music": "applemusic://track/850571371",
       "uri_youtube_music": "https://music.youtube.com/watch?v=HyHNuVaZJ-k",
       "uri_tidal": "tidal://track/1404361",
       "uri_deezer": "deezer://track/3129407",
       "fun_fact_nl": "De iconische lach aan het begin van het nummer werd ingesproken door de stemacteur van bassist Murdoc Niccals, en de geanimeerde videoclip won een Grammy voor Beste Videoclip.",
       "awards_nl": [
-        "Grammy Award \u2013 Beste Popsamenwerking met Zang"
-      ]
+        "Grammy Award – Beste Popsamenwerking met Zang"
+      ],
+      "isrc": "GBAYE1400422",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/850571371",
+        "de": "applemusic://track/850571371",
+        "gb": "applemusic://track/850571371",
+        "fr": "applemusic://track/850571371",
+        "es": "applemusic://track/850571371",
+        "nl": "applemusic://track/850571371",
+        "it": "applemusic://track/850571371"
+      }
     },
     {
       "year": 2002,
@@ -357,15 +447,25 @@
       ],
       "awards": [],
       "fun_fact": "Avril was only 17 when the song was released, and it became a defining anthem of the pop-punk era. A movie adaptation was announced in 2022.",
-      "fun_fact_de": "Avril war erst 17 Jahre alt, als der Song ver\u00f6ffentlicht wurde, und er wurde zur pr\u00e4genden Hymne der Pop-Punk-\u00c4ra. Eine Verfilmung wurde 2022 angek\u00fcndigt.",
-      "fun_fact_es": "Avril ten\u00eda solo 17 a\u00f1os cuando se lanz\u00f3 la canci\u00f3n, y se convirti\u00f3 en un himno definitorio de la era pop-punk. Se anunci\u00f3 una adaptaci\u00f3n cinematogr\u00e1fica en 2022.",
-      "fun_fact_fr": "Avril n'avait que 17 ans \u00e0 la sortie du titre, devenu un hymne incontournable de l'\u00e8re pop-punk. Une adaptation cin\u00e9matographique a \u00e9t\u00e9 annonc\u00e9e en 2022.",
+      "fun_fact_de": "Avril war erst 17 Jahre alt, als der Song veröffentlicht wurde, und er wurde zur prägenden Hymne der Pop-Punk-Ära. Eine Verfilmung wurde 2022 angekündigt.",
+      "fun_fact_es": "Avril tenía solo 17 años cuando se lanzó la canción, y se convirtió en un himno definitorio de la era pop-punk. Se anunció una adaptación cinematográfica en 2022.",
+      "fun_fact_fr": "Avril n'avait que 17 ans à la sortie du titre, devenu un hymne incontournable de l'ère pop-punk. Une adaptation cinématographique a été annoncée en 2022.",
       "uri_apple_music": "applemusic://track/315025826",
       "uri_youtube_music": "https://music.youtube.com/watch?v=TIy3n2b7V9k",
       "uri_tidal": "tidal://track/33713333",
       "uri_deezer": "deezer://track/15587466",
       "fun_fact_nl": "Avril was pas 17 toen het nummer uitkwam en het werd een bepalend volkslied van het pop-punk tijdperk. In 2022 werd een filmadaptatie aangekondigd.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USAR10200229",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1739502950",
+        "de": "applemusic://track/555165330",
+        "gb": "applemusic://track/555165330",
+        "fr": "applemusic://track/555165330",
+        "es": "applemusic://track/555165330",
+        "nl": "applemusic://track/610157999",
+        "it": "applemusic://track/555165330"
+      }
     },
     {
       "year": 2001,
@@ -389,15 +489,25 @@
       ],
       "awards": [],
       "fun_fact": "The song was the first to surpass 1 billion views on YouTube by a rock band, and Mike Shinoda's piano riff at the beginning is one of the most recognized intros in rock history.",
-      "fun_fact_de": "Der Song war der erste einer Rockband, der auf YouTube \u00fcber 1 Milliarde Aufrufe erreichte, und Mike Shinodas Klavierriff am Anfang ist eines der bekanntesten Intros der Rockgeschichte.",
-      "fun_fact_es": "La canci\u00f3n fue la primera de una banda de rock en superar los 1.000 millones de reproducciones en YouTube, y el riff de piano de Mike Shinoda es uno de los intros m\u00e1s reconocidos del rock.",
-      "fun_fact_fr": "C'est la premi\u00e8re chanson d'un groupe de rock \u00e0 d\u00e9passer le milliard de vues sur YouTube, et le riff de piano de Mike Shinoda est l'une des intros les plus reconnaissables de l'histoire du rock.",
+      "fun_fact_de": "Der Song war der erste einer Rockband, der auf YouTube über 1 Milliarde Aufrufe erreichte, und Mike Shinodas Klavierriff am Anfang ist eines der bekanntesten Intros der Rockgeschichte.",
+      "fun_fact_es": "La canción fue la primera de una banda de rock en superar los 1.000 millones de reproducciones en YouTube, y el riff de piano de Mike Shinoda es uno de los intros más reconocidos del rock.",
+      "fun_fact_fr": "C'est la première chanson d'un groupe de rock à dépasser le milliard de vues sur YouTube, et le riff de piano de Mike Shinoda est l'une des intros les plus reconnaissables de l'histoire du rock.",
       "uri_apple_music": "applemusic://track/590431785",
       "uri_youtube_music": "https://music.youtube.com/watch?v=eVTXPUF4Oz4",
       "uri_tidal": "tidal://track/1225577",
       "uri_deezer": "deezer://track/676183",
       "fun_fact_nl": "Het nummer was het eerste van een rockband dat meer dan 1 miljard views op YouTube behaalde, en de pianoriff van Mike Shinoda aan het begin is een van de meest herkende intro's in de rockgeschiedenis.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USWB11201118",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/591534783",
+        "de": "applemusic://track/591534783",
+        "gb": "applemusic://track/591534783",
+        "fr": "applemusic://track/591534783",
+        "es": "applemusic://track/591534783",
+        "nl": "applemusic://track/591534783",
+        "it": "applemusic://track/591534783"
+      }
     },
     {
       "year": 2003,
@@ -426,17 +536,27 @@
         "Grammy Award - Meilleure performance hard rock"
       ],
       "fun_fact": "The label insisted on adding the male rap vocals by Paul McCoy of 12 Stones because they felt a solo female voice wouldn't get rock radio play.",
-      "fun_fact_de": "Das Label bestand darauf, m\u00e4nnliche Rap-Vocals von Paul McCoy (12 Stones) hinzuzuf\u00fcgen, weil sie glaubten, eine weibliche Solostimme w\u00fcrde im Rock-Radio nicht gespielt werden.",
-      "fun_fact_es": "El sello insisti\u00f3 en agregar las voces rap masculinas de Paul McCoy de 12 Stones porque cre\u00edan que una voz femenina solista no sonar\u00eda en la radio rock.",
-      "fun_fact_fr": "Le label a insist\u00e9 pour ajouter les parties rap masculines de Paul McCoy (12 Stones), convaincu qu'une voix f\u00e9minine seule ne passerait pas en radio rock.",
+      "fun_fact_de": "Das Label bestand darauf, männliche Rap-Vocals von Paul McCoy (12 Stones) hinzuzufügen, weil sie glaubten, eine weibliche Solostimme würde im Rock-Radio nicht gespielt werden.",
+      "fun_fact_es": "El sello insistió en agregar las voces rap masculinas de Paul McCoy de 12 Stones porque creían que una voz femenina solista no sonaría en la radio rock.",
+      "fun_fact_fr": "Le label a insisté pour ajouter les parties rap masculines de Paul McCoy (12 Stones), convaincu qu'une voix féminine seule ne passerait pas en radio rock.",
       "uri_apple_music": "applemusic://track/1440666111",
       "uri_youtube_music": "https://music.youtube.com/watch?v=3YxaaGgTQYM",
       "uri_tidal": "tidal://track/31849195",
       "uri_deezer": "deezer://track/80274512",
       "fun_fact_nl": "Het label stond erop om de mannelijke rap-vocals van Paul McCoy van 12 Stones toe te voegen, omdat ze vonden dat een solo vrouwelijke stem niet op de rockradio gedraaid zou worden.",
       "awards_nl": [
-        "Grammy Award \u2013 Beste Hardrockprestatie"
-      ]
+        "Grammy Award – Beste Hardrockprestatie"
+      ],
+      "isrc": "USWU30200093",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1645901771",
+        "de": "applemusic://track/1645901771",
+        "gb": "applemusic://track/1645901771",
+        "fr": "applemusic://track/1645901771",
+        "es": "applemusic://track/1645901771",
+        "nl": "applemusic://track/1645901771",
+        "it": "applemusic://track/1645901771"
+      }
     },
     {
       "year": 2002,
@@ -459,16 +579,26 @@
         "Platinum (UK)"
       ],
       "awards": [],
-      "fun_fact": "The entire music video is played in reverse \u2014 Chris Martin had to learn to sing the lyrics backwards and walk backwards through the scenes.",
-      "fun_fact_de": "Das gesamte Musikvideo wird r\u00fcckw\u00e4rts abgespielt \u2014 Chris Martin musste lernen, den Text r\u00fcckw\u00e4rts zu singen und r\u00fcckw\u00e4rts durch die Szenen zu laufen.",
-      "fun_fact_es": "Todo el video musical se reproduce al rev\u00e9s \u2014 Chris Martin tuvo que aprender a cantar la letra al rev\u00e9s y caminar hacia atr\u00e1s durante las escenas.",
-      "fun_fact_fr": "L'int\u00e9gralit\u00e9 du clip est diffus\u00e9e \u00e0 l'envers \u2014 Chris Martin a d\u00fb apprendre \u00e0 chanter les paroles \u00e0 l'envers et \u00e0 marcher en reculant dans les sc\u00e8nes.",
+      "fun_fact": "The entire music video is played in reverse — Chris Martin had to learn to sing the lyrics backwards and walk backwards through the scenes.",
+      "fun_fact_de": "Das gesamte Musikvideo wird rückwärts abgespielt — Chris Martin musste lernen, den Text rückwärts zu singen und rückwärts durch die Szenen zu laufen.",
+      "fun_fact_es": "Todo el video musical se reproduce al revés — Chris Martin tuvo que aprender a cantar la letra al revés y caminar hacia atrás durante las escenas.",
+      "fun_fact_fr": "L'intégralité du clip est diffusée à l'envers — Chris Martin a dû apprendre à chanter les paroles à l'envers et à marcher en reculant dans les scènes.",
       "uri_apple_music": "applemusic://track/1122776155",
       "uri_youtube_music": "https://music.youtube.com/watch?v=RB-RcX5DS5A",
       "uri_tidal": "tidal://track/128605",
       "uri_deezer": "deezer://track/3098840",
-      "fun_fact_nl": "De hele videoclip wordt achterstevoren afgespeeld \u2014 Chris Martin moest de tekst achterstevoren leren zingen en achteruit door de sc\u00e8nes lopen.",
-      "awards_nl": []
+      "fun_fact_nl": "De hele videoclip wordt achterstevoren afgespeeld — Chris Martin moest de tekst achterstevoren leren zingen en achteruit door de scènes lopen.",
+      "awards_nl": [],
+      "isrc": "GBAYE1600192",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1122776155",
+        "de": "applemusic://track/1122776155",
+        "gb": "applemusic://track/1122776155",
+        "fr": "applemusic://track/1122776155",
+        "es": "applemusic://track/1122776155",
+        "nl": "applemusic://track/1122776155",
+        "it": "applemusic://track/1122776155"
+      }
     },
     {
       "year": 2002,
@@ -498,16 +628,26 @@
       ],
       "fun_fact": "The comic book-themed music video parodies multiple celebrities and features Eminem as a superhero called 'Rap Boy', spoofing Robin from Batman.",
       "fun_fact_de": "Das comichafte Musikvideo parodiert mehrere Prominente und zeigt Eminem als Superhelden namens 'Rap Boy', eine Parodie auf Robin aus Batman.",
-      "fun_fact_es": "El video musical con tem\u00e1tica de c\u00f3mic parodia a varias celebridades y presenta a Eminem como un superh\u00e9roe llamado 'Rap Boy', parodiando a Robin de Batman.",
-      "fun_fact_fr": "Le clip sur le th\u00e8me de la bande dessin\u00e9e parodie de nombreuses c\u00e9l\u00e9brit\u00e9s et met en sc\u00e8ne Eminem en super-h\u00e9ros baptis\u00e9 'Rap Boy', parodiant Robin de Batman.",
+      "fun_fact_es": "El video musical con temática de cómic parodia a varias celebridades y presenta a Eminem como un superhéroe llamado 'Rap Boy', parodiando a Robin de Batman.",
+      "fun_fact_fr": "Le clip sur le thème de la bande dessinée parodie de nombreuses célébrités et met en scène Eminem en super-héros baptisé 'Rap Boy', parodiant Robin de Batman.",
       "uri_apple_music": "applemusic://track/1440903693",
       "uri_youtube_music": "https://music.youtube.com/watch?v=YVkUvmDQ3HY",
       "uri_tidal": "tidal://track/573293",
       "uri_deezer": "deezer://track/916424",
       "fun_fact_nl": "De videoclip in stripboekthema parodieert meerdere beroemdheden en toont Eminem als een superheld genaamd 'Rap Boy', een persiflage op Robin uit Batman.",
       "awards_nl": [
-        "Grammy Award \u2013 Beste Muziekvideo (Korte Vorm)"
-      ]
+        "Grammy Award – Beste Muziekvideo (Korte Vorm)"
+      ],
+      "isrc": "USIR10211038",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1625004633",
+        "de": "applemusic://track/1625004633",
+        "gb": "applemusic://track/1625004633",
+        "fr": "applemusic://track/1625004633",
+        "es": "applemusic://track/1625004633",
+        "nl": "applemusic://track/1625004633",
+        "it": "applemusic://track/1625004633"
+      }
     },
     {
       "year": 2006,
@@ -532,14 +672,24 @@
       "awards": [],
       "fun_fact": "The song marked Nelly Furtado's dramatic transformation from folk-pop to dance-pop, produced by Timbaland, and became her first and only #1 hit on the Billboard Hot 100.",
       "fun_fact_de": "Der Song markierte Nelly Furtados dramatische Wandlung von Folk-Pop zu Dance-Pop, produziert von Timbaland, und wurde ihr erster und einziger #1-Hit in den Billboard Hot 100.",
-      "fun_fact_es": "La canci\u00f3n marc\u00f3 la dram\u00e1tica transformaci\u00f3n de Nelly Furtado del folk-pop al dance-pop, producida por Timbaland, y se convirti\u00f3 en su primer y \u00fanico #1 en el Billboard Hot 100.",
-      "fun_fact_fr": "Le titre marque la transformation spectaculaire de Nelly Furtado, passant du folk-pop au dance-pop sous la houlette de Timbaland, et devenant son seul et unique num\u00e9ro 1 au Billboard Hot 100.",
+      "fun_fact_es": "La canción marcó la dramática transformación de Nelly Furtado del folk-pop al dance-pop, producida por Timbaland, y se convirtió en su primer y único #1 en el Billboard Hot 100.",
+      "fun_fact_fr": "Le titre marque la transformation spectaculaire de Nelly Furtado, passant du folk-pop au dance-pop sous la houlette de Timbaland, et devenant son seul et unique numéro 1 au Billboard Hot 100.",
       "uri_apple_music": "applemusic://track/1442463848",
       "uri_youtube_music": "https://music.youtube.com/watch?v=0J3vgcE5i2o",
       "uri_tidal": "tidal://track/479938",
       "uri_deezer": "deezer://track/2430338",
       "fun_fact_nl": "Het nummer markeerde Nelly Furtado's dramatische transformatie van folk-pop naar dance-pop, geproduceerd door Timbaland, en werd haar eerste en enige nummer 1-hit in de Billboard Hot 100.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USUM70603473",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1708158772",
+        "de": "applemusic://track/1708158772",
+        "gb": "applemusic://track/1708158772",
+        "fr": "applemusic://track/1708158772",
+        "es": "applemusic://track/1708158772",
+        "nl": "applemusic://track/1708158772",
+        "it": "applemusic://track/1708158772"
+      }
     },
     {
       "year": 2003,
@@ -563,15 +713,25 @@
       ],
       "awards": [],
       "fun_fact": "With over 2 billion Spotify streams, it's one of the most-streamed rock songs ever. The Jay-Z mashup 'Numb/Encore' won a Grammy in 2005.",
-      "fun_fact_de": "Mit \u00fcber 2 Milliarden Spotify-Streams ist es einer der meistgestreamten Rocksongs aller Zeiten. Der Jay-Z-Mashup 'Numb/Encore' gewann 2005 einen Grammy.",
-      "fun_fact_es": "Con m\u00e1s de 2 mil millones de reproducciones en Spotify, es una de las canciones de rock m\u00e1s reproducidas de la historia. El mashup con Jay-Z 'Numb/Encore' gan\u00f3 un Grammy en 2005.",
-      "fun_fact_fr": "Avec plus de 2 milliards de streams sur Spotify, c'est l'un des morceaux de rock les plus \u00e9cout\u00e9s de tous les temps. Le mashup avec Jay-Z 'Numb/Encore' a remport\u00e9 un Grammy en 2005.",
+      "fun_fact_de": "Mit über 2 Milliarden Spotify-Streams ist es einer der meistgestreamten Rocksongs aller Zeiten. Der Jay-Z-Mashup 'Numb/Encore' gewann 2005 einen Grammy.",
+      "fun_fact_es": "Con más de 2 mil millones de reproducciones en Spotify, es una de las canciones de rock más reproducidas de la historia. El mashup con Jay-Z 'Numb/Encore' ganó un Grammy en 2005.",
+      "fun_fact_fr": "Avec plus de 2 milliards de streams sur Spotify, c'est l'un des morceaux de rock les plus écoutés de tous les temps. Le mashup avec Jay-Z 'Numb/Encore' a remporté un Grammy en 2005.",
       "uri_apple_music": "applemusic://track/590423552",
       "uri_youtube_music": "https://music.youtube.com/watch?v=kXYiU_JCYtU",
       "uri_tidal": "tidal://track/234806",
       "uri_deezer": "deezer://track/677232",
       "fun_fact_nl": "Met meer dan 2 miljard Spotify-streams is het een van de meest gestroomde rocknummers ooit. De Jay-Z mashup 'Numb/Encore' won een Grammy in 2005.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USWB11201135",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/591534921",
+        "de": "applemusic://track/591534921",
+        "gb": "applemusic://track/591534921",
+        "fr": "applemusic://track/591534921",
+        "es": "applemusic://track/591534921",
+        "nl": "applemusic://track/591534921",
+        "it": "applemusic://track/591534921"
+      }
     },
     {
       "year": 2007,
@@ -595,14 +755,24 @@
       "awards": [],
       "fun_fact": "The song samples Dwele's 'What Profit' and the provocative music video starring model Rita G was directed by Spike Jonze.",
       "fun_fact_de": "Der Song sampelt Dweles 'What Profit' und das provokante Musikvideo mit Model Rita G wurde von Spike Jonze inszeniert.",
-      "fun_fact_es": "La canci\u00f3n samplea 'What Profit' de Dwele y el provocativo video musical protagonizado por la modelo Rita G fue dirigido por Spike Jonze.",
-      "fun_fact_fr": "Le titre sample 'What Profit' de Dwele, et le clip provocant avec le mannequin Rita G a \u00e9t\u00e9 r\u00e9alis\u00e9 par Spike Jonze.",
+      "fun_fact_es": "La canción samplea 'What Profit' de Dwele y el provocativo video musical protagonizado por la modelo Rita G fue dirigido por Spike Jonze.",
+      "fun_fact_fr": "Le titre sample 'What Profit' de Dwele, et le clip provocant avec le mannequin Rita G a été réalisé par Spike Jonze.",
       "uri_apple_music": "applemusic://track/1451903882",
       "uri_youtube_music": "https://music.youtube.com/watch?v=ila-hAUXR5U",
       "uri_tidal": "tidal://track/151380791",
       "uri_deezer": "deezer://track/630827302",
       "fun_fact_nl": "Het nummer bevat een sample van Dwele's 'What Profit' en de provocerende videoclip met model Rita G werd geregisseerd door Spike Jonze.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USUM70749095",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1527144907",
+        "de": "applemusic://track/1469574242",
+        "gb": "applemusic://track/1469574242",
+        "fr": "applemusic://track/1469574242",
+        "es": "applemusic://track/1469574242",
+        "nl": "applemusic://track/1469574242",
+        "it": "applemusic://track/1469574242"
+      }
     },
     {
       "year": 2008,
@@ -629,22 +799,32 @@
         "Grammy Award - Best Pop Performance by Duo or Group"
       ],
       "awards_fr": [
-        "Grammy Award - Chanson de l'ann\u00e9e",
+        "Grammy Award - Chanson de l'année",
         "Grammy Award - Meilleure performance pop d'un duo ou groupe"
       ],
       "fun_fact": "The title is Spanish for 'Long Live Life' and was inspired by a Frida Kahlo painting. It became Coldplay's only #1 hit on the Billboard Hot 100.",
-      "fun_fact_de": "Der Titel ist Spanisch f\u00fcr 'Es lebe das Leben' und wurde von einem Frida-Kahlo-Gem\u00e4lde inspiriert. Es wurde Coldplays einziger #1-Hit in den Billboard Hot 100.",
-      "fun_fact_es": "El t\u00edtulo significa 'Viva la Vida' y fue inspirado por una pintura de Frida Kahlo. Se convirti\u00f3 en el \u00fanico #1 de Coldplay en el Billboard Hot 100.",
-      "fun_fact_fr": "Le titre signifie 'Vive la Vie' en espagnol et a \u00e9t\u00e9 inspir\u00e9 par un tableau de Frida Kahlo. C'est le seul num\u00e9ro 1 de Coldplay au Billboard Hot 100.",
+      "fun_fact_de": "Der Titel ist Spanisch für 'Es lebe das Leben' und wurde von einem Frida-Kahlo-Gemälde inspiriert. Es wurde Coldplays einziger #1-Hit in den Billboard Hot 100.",
+      "fun_fact_es": "El título significa 'Viva la Vida' y fue inspirado por una pintura de Frida Kahlo. Se convirtió en el único #1 de Coldplay en el Billboard Hot 100.",
+      "fun_fact_fr": "Le titre signifie 'Vive la Vie' en espagnol et a été inspiré par un tableau de Frida Kahlo. C'est le seul numéro 1 de Coldplay au Billboard Hot 100.",
       "uri_apple_music": "applemusic://track/1122773680",
       "uri_youtube_music": "https://music.youtube.com/watch?v=dvgZkm1xWPE",
       "uri_tidal": "tidal://track/2128840",
       "uri_deezer": "deezer://track/13444256",
-      "fun_fact_nl": "De titel is Spaans voor 'Leve het leven' en is ge\u00efnspireerd op een schilderij van Frida Kahlo. Het werd Coldplay's enige nummer 1-hit in de Billboard Hot 100.",
+      "fun_fact_nl": "De titel is Spaans voor 'Leve het leven' en is geïnspireerd op een schilderij van Frida Kahlo. Het werd Coldplay's enige nummer 1-hit in de Billboard Hot 100.",
       "awards_nl": [
-        "Grammy Award \u2013 Lied van het Jaar",
-        "Grammy Award \u2013 Beste Popprestatie door Duo of Groep"
-      ]
+        "Grammy Award – Lied van het Jaar",
+        "Grammy Award – Beste Popprestatie door Duo of Groep"
+      ],
+      "isrc": "GBAYE1600217",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1122778616",
+        "de": "applemusic://track/1122778616",
+        "gb": "applemusic://track/1122778616",
+        "fr": "applemusic://track/1122778616",
+        "es": "applemusic://track/1122778616",
+        "nl": "applemusic://track/1122778616",
+        "it": "applemusic://track/1122778616"
+      }
     },
     {
       "year": 2003,
@@ -667,15 +847,25 @@
       ],
       "awards": [],
       "fun_fact": "The lyrics were heavily inspired by the visual art book 'The Art of Not Making' and contain numerous references to repetitive behaviors and artistic creation.",
-      "fun_fact_de": "Der Text wurde stark von einem Kunstbuch inspiriert und enth\u00e4lt zahlreiche Verweise auf sich wiederholende Verhaltensweisen und k\u00fcnstlerisches Schaffen.",
-      "fun_fact_es": "La letra fue muy inspirada por un libro de arte visual y contiene numerosas referencias a comportamientos repetitivos y creaci\u00f3n art\u00edstica.",
-      "fun_fact_fr": "Les paroles se sont largement inspir\u00e9es d'un livre d'art visuel et contiennent de nombreuses r\u00e9f\u00e9rences aux comportements r\u00e9p\u00e9titifs et \u00e0 la cr\u00e9ation artistique.",
+      "fun_fact_de": "Der Text wurde stark von einem Kunstbuch inspiriert und enthält zahlreiche Verweise auf sich wiederholende Verhaltensweisen und künstlerisches Schaffen.",
+      "fun_fact_es": "La letra fue muy inspirada por un libro de arte visual y contiene numerosas referencias a comportamientos repetitivos y creación artística.",
+      "fun_fact_fr": "Les paroles se sont largement inspirées d'un livre d'art visuel et contiennent de nombreuses références aux comportements répétitifs et à la création artistique.",
       "uri_apple_music": "applemusic://track/948438478",
       "uri_youtube_music": "https://music.youtube.com/watch?v=8DyziWtkfBw",
       "uri_tidal": "tidal://track/304865",
       "uri_deezer": "deezer://track/725971",
-      "fun_fact_nl": "De teksten zijn sterk ge\u00efnspireerd op het kunstboek 'The Art of Not Making' en bevatten talloze verwijzingen naar repetitief gedrag en artistieke creatie.",
-      "awards_nl": []
+      "fun_fact_nl": "De teksten zijn sterk geïnspireerd op het kunstboek 'The Art of Not Making' en bevatten talloze verwijzingen naar repetitief gedrag en artistieke creatie.",
+      "awards_nl": [],
+      "isrc": "USWB11402804",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/945578427",
+        "de": "applemusic://track/945578427",
+        "gb": "applemusic://track/945578427",
+        "fr": "applemusic://track/945578427",
+        "es": "applemusic://track/945578427",
+        "nl": "applemusic://track/945578427",
+        "it": "applemusic://track/945578427"
+      }
     },
     {
       "year": 2004,
@@ -699,15 +889,25 @@
       ],
       "awards": [],
       "fun_fact": "The song was written about a tree in Hampstead Heath, London, where the band members used to hang out as kids. Lily Allen's 2013 cover brought it back to UK #1.",
-      "fun_fact_de": "Der Song handelt von einem Baum in Hampstead Heath, London, wo die Bandmitglieder als Kinder herumhingen. Lily Allens Cover von 2013 brachte ihn zur\u00fcck auf UK #1.",
-      "fun_fact_es": "La canci\u00f3n fue escrita sobre un \u00e1rbol en Hampstead Heath, Londres, donde los miembros de la banda sol\u00edan pasar el rato de ni\u00f1os. La versi\u00f3n de Lily Allen en 2013 la llev\u00f3 de vuelta al #1 en el Reino Unido.",
-      "fun_fact_fr": "La chanson \u00e9voque un arbre de Hampstead Heath \u00e0 Londres, o\u00f9 les membres du groupe avaient l'habitude de tra\u00eener enfants. La reprise de Lily Allen en 2013 l'a propuls\u00e9e \u00e0 nouveau au sommet des charts britanniques.",
+      "fun_fact_de": "Der Song handelt von einem Baum in Hampstead Heath, London, wo die Bandmitglieder als Kinder herumhingen. Lily Allens Cover von 2013 brachte ihn zurück auf UK #1.",
+      "fun_fact_es": "La canción fue escrita sobre un árbol en Hampstead Heath, Londres, donde los miembros de la banda solían pasar el rato de niños. La versión de Lily Allen en 2013 la llevó de vuelta al #1 en el Reino Unido.",
+      "fun_fact_fr": "La chanson évoque un arbre de Hampstead Heath à Londres, où les membres du groupe avaient l'habitude de traîner enfants. La reprise de Lily Allen en 2013 l'a propulsée à nouveau au sommet des charts britanniques.",
       "uri_apple_music": "applemusic://track/1445287036",
       "uri_youtube_music": "https://music.youtube.com/watch?v=Oextk-If8HQ",
       "uri_tidal": "tidal://track/23279550",
       "uri_deezer": "deezer://track/2317363",
       "fun_fact_nl": "Het nummer is geschreven over een boom in Hampstead Heath, Londen, waar de bandleden als kind rondhingen. De cover van Lily Allen uit 2013 bracht het weer op nummer 1 in het VK.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAAN0300664",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1582695323",
+        "de": "applemusic://track/1767797836",
+        "gb": "applemusic://track/1582695323",
+        "fr": "applemusic://track/1582695323",
+        "es": "applemusic://track/1582695323",
+        "nl": "applemusic://track/1582695323",
+        "it": "applemusic://track/1582695323"
+      }
     },
     {
       "year": 2007,
@@ -731,15 +931,25 @@
       ],
       "awards": [],
       "fun_fact": "Timbaland wrote the song in just one studio session and the track features Keri Hilson, who was relatively unknown at the time but became a star partly through this collaboration.",
-      "fun_fact_de": "Timbaland schrieb den Song in nur einer Studio-Session und der Track enth\u00e4lt Keri Hilson, die damals noch relativ unbekannt war, aber durch diese Zusammenarbeit zum Star wurde.",
-      "fun_fact_es": "Timbaland escribi\u00f3 la canci\u00f3n en una sola sesi\u00f3n de estudio y la pista presenta a Keri Hilson, quien era relativamente desconocida pero se convirti\u00f3 en estrella gracias a esta colaboraci\u00f3n.",
-      "fun_fact_fr": "Timbaland a compos\u00e9 le morceau en une seule session studio, et le titre met en avant Keri Hilson, alors quasi inconnue, qui est devenue une star en partie gr\u00e2ce \u00e0 cette collaboration.",
+      "fun_fact_de": "Timbaland schrieb den Song in nur einer Studio-Session und der Track enthält Keri Hilson, die damals noch relativ unbekannt war, aber durch diese Zusammenarbeit zum Star wurde.",
+      "fun_fact_es": "Timbaland escribió la canción en una sola sesión de estudio y la pista presenta a Keri Hilson, quien era relativamente desconocida pero se convirtió en estrella gracias a esta colaboración.",
+      "fun_fact_fr": "Timbaland a composé le morceau en une seule session studio, et le titre met en avant Keri Hilson, alors quasi inconnue, qui est devenue une star en partie grâce à cette collaboration.",
       "uri_apple_music": "applemusic://track/1443720826",
       "uri_youtube_music": "https://music.youtube.com/watch?v=U5rLz5AZBIA",
       "uri_tidal": "tidal://track/35738721",
       "uri_deezer": "deezer://track/4685514",
-      "fun_fact_nl": "Timbaland schreef het nummer in slechts \u00e9\u00e9n studiosessie en de track bevat Keri Hilson, die destijds relatief onbekend was maar mede door deze samenwerking een ster werd.",
-      "awards_nl": []
+      "fun_fact_nl": "Timbaland schreef het nummer in slechts één studiosessie en de track bevat Keri Hilson, die destijds relatief onbekend was maar mede door deze samenwerking een ster werd.",
+      "awards_nl": [],
+      "isrc": "USUM70722806",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1710303430",
+        "de": "applemusic://track/1710303430",
+        "gb": "applemusic://track/1710303430",
+        "fr": "applemusic://track/1710303430",
+        "es": "applemusic://track/1710303430",
+        "nl": "applemusic://track/1710303430",
+        "it": "applemusic://track/1710303430"
+      }
     },
     {
       "year": 2008,
@@ -762,16 +972,26 @@
         "Silver (UK)"
       ],
       "awards": [],
-      "fun_fact": "Kanye recorded all the vocals using Auto-Tune while dealing with his breakup from fianc\u00e9e Alexis Phifer. The animated music video was inspired by Ralph Bakshi's style.",
-      "fun_fact_de": "Kanye nahm alle Vocals mit Auto-Tune auf, w\u00e4hrend er die Trennung von seiner Verlobten Alexis Phifer verarbeitete. Das animierte Musikvideo war vom Stil Ralph Bakshis inspiriert.",
-      "fun_fact_es": "Kanye grab\u00f3 todas las voces usando Auto-Tune mientras lidiaba con su ruptura con su prometida Alexis Phifer. El video musical animado fue inspirado por el estilo de Ralph Bakshi.",
-      "fun_fact_fr": "Kanye a enregistr\u00e9 toutes les voix avec l'Auto-Tune en pleine rupture avec sa fianc\u00e9e Alexis Phifer. Le clip anim\u00e9 s'inspire du style de Ralph Bakshi.",
+      "fun_fact": "Kanye recorded all the vocals using Auto-Tune while dealing with his breakup from fiancée Alexis Phifer. The animated music video was inspired by Ralph Bakshi's style.",
+      "fun_fact_de": "Kanye nahm alle Vocals mit Auto-Tune auf, während er die Trennung von seiner Verlobten Alexis Phifer verarbeitete. Das animierte Musikvideo war vom Stil Ralph Bakshis inspiriert.",
+      "fun_fact_es": "Kanye grabó todas las voces usando Auto-Tune mientras lidiaba con su ruptura con su prometida Alexis Phifer. El video musical animado fue inspirado por el estilo de Ralph Bakshi.",
+      "fun_fact_fr": "Kanye a enregistré toutes les voix avec l'Auto-Tune en pleine rupture avec sa fiancée Alexis Phifer. Le clip animé s'inspire du style de Ralph Bakshi.",
       "uri_apple_music": "applemusic://track/1441410309",
       "uri_youtube_music": "https://music.youtube.com/watch?v=Co0tTeuUVhU",
       "uri_tidal": "tidal://track/63863048",
       "uri_deezer": "deezer://track/130412300",
-      "fun_fact_nl": "Kanye nam alle zang op met Auto-Tune terwijl hij bezig was met de breuk met zijn verloofde Alexis Phifer. De geanimeerde videoclip was ge\u00efnspireerd op de stijl van Ralph Bakshi.",
-      "awards_nl": []
+      "fun_fact_nl": "Kanye nam alle zang op met Auto-Tune terwijl hij bezig was met de breuk met zijn verloofde Alexis Phifer. De geanimeerde videoclip was geïnspireerd op de stijl van Ralph Bakshi.",
+      "awards_nl": [],
+      "isrc": "USUM70840511",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1609149063",
+        "de": "applemusic://track/1609149063",
+        "gb": "applemusic://track/1609149063",
+        "fr": "applemusic://track/1609149063",
+        "es": "applemusic://track/1609149063",
+        "nl": "applemusic://track/1609149063",
+        "it": "applemusic://track/1609149063"
+      }
     },
     {
       "year": 2008,
@@ -800,17 +1020,27 @@
         "ARIA Award - Meilleure sortie pop"
       ],
       "fun_fact": "The Australian synth-pop duo's debut single took years to become a global hit, gaining massive popularity through TV placements and going viral on TikTok in the 2020s.",
-      "fun_fact_de": "Die Deb\u00fctsingle des australischen Synth-Pop-Duos brauchte Jahre, um ein globaler Hit zu werden, und gewann durch TV-Platzierungen und TikTok in den 2020ern massive Popularit\u00e4t.",
-      "fun_fact_es": "El sencillo debut del d\u00fao australiano de synth-pop tard\u00f3 a\u00f1os en convertirse en un \u00e9xito global, ganando enorme popularidad a trav\u00e9s de apariciones en TV y volvi\u00e9ndose viral en TikTok en los 2020.",
-      "fun_fact_fr": "Le premier single du duo australien de synth-pop a mis des ann\u00e9es avant de devenir un tube mondial, gagnant une popularit\u00e9 massive gr\u00e2ce aux placements TV et en devenant viral sur TikTok dans les ann\u00e9es 2020.",
+      "fun_fact_de": "Die Debütsingle des australischen Synth-Pop-Duos brauchte Jahre, um ein globaler Hit zu werden, und gewann durch TV-Platzierungen und TikTok in den 2020ern massive Popularität.",
+      "fun_fact_es": "El sencillo debut del dúo australiano de synth-pop tardó años en convertirse en un éxito global, ganando enorme popularidad a través de apariciones en TV y volviéndose viral en TikTok en los 2020.",
+      "fun_fact_fr": "Le premier single du duo australien de synth-pop a mis des années avant de devenir un tube mondial, gagnant une popularité massive grâce aux placements TV et en devenant viral sur TikTok dans les années 2020.",
       "uri_apple_music": "applemusic://track/712862708",
       "uri_youtube_music": "https://music.youtube.com/watch?v=eimgRedLkkU",
       "uri_tidal": "tidal://track/3233354",
       "uri_deezer": "deezer://track/4286051",
       "fun_fact_nl": "De debuutsingle van het Australische synth-popduo deed er jaren over om een wereldwijde hit te worden, won massaal aan populariteit door tv-plaatsingen en ging viraal op TikTok in de jaren 2020.",
       "awards_nl": [
-        "ARIA Award \u2013 Beste Poprelease"
-      ]
+        "ARIA Award – Beste Poprelease"
+      ],
+      "isrc": "AUEI10800039",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1707435588",
+        "de": "applemusic://track/1707435588",
+        "gb": "applemusic://track/1707435588",
+        "fr": "applemusic://track/1707435588",
+        "es": "applemusic://track/1707435588",
+        "nl": "applemusic://track/1707435588",
+        "it": "applemusic://track/1707435588"
+      }
     },
     {
       "year": 2000,
@@ -835,14 +1065,24 @@
       "awards": [],
       "fun_fact": "The music video was one of the first to be rendered entirely as a video game, featuring the band members as playable characters in different California-themed levels.",
       "fun_fact_de": "Das Musikvideo war eines der ersten, das komplett als Videospiel gerendert wurde, mit den Bandmitgliedern als spielbare Charaktere in verschiedenen Kalifornien-Leveln.",
-      "fun_fact_es": "El video musical fue uno de los primeros en ser renderizado completamente como un videojuego, con los miembros de la banda como personajes jugables en diferentes niveles tem\u00e1ticos de California.",
-      "fun_fact_fr": "Le clip a \u00e9t\u00e9 l'un des premiers \u00e0 \u00eatre enti\u00e8rement r\u00e9alis\u00e9 comme un jeu vid\u00e9o, avec les membres du groupe en personnages jouables dans diff\u00e9rents niveaux sur le th\u00e8me de la Californie.",
+      "fun_fact_es": "El video musical fue uno de los primeros en ser renderizado completamente como un videojuego, con los miembros de la banda como personajes jugables en diferentes niveles temáticos de California.",
+      "fun_fact_fr": "Le clip a été l'un des premiers à être entièrement réalisé comme un jeu vidéo, avec les membres du groupe en personnages jouables dans différents niveaux sur le thème de la Californie.",
       "uri_apple_music": "applemusic://track/948354743",
       "uri_youtube_music": "https://music.youtube.com/watch?v=A__cH65WRvE",
       "uri_tidal": "tidal://track/304808",
       "uri_deezer": "deezer://track/725274",
-      "fun_fact_nl": "De videoclip was een van de eerste die volledig als een videogame werd gerenderd, met de bandleden als speelbare personages in verschillende levels met een Californi\u00eb-thema.",
-      "awards_nl": []
+      "fun_fact_nl": "De videoclip was een van de eerste die volledig als een videogame werd gerenderd, met de bandleden als speelbare personages in verschillende levels met een Californië-thema.",
+      "awards_nl": [],
+      "isrc": "USWB11403543",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/948354743",
+        "de": "applemusic://track/947701035",
+        "gb": "applemusic://track/947701035",
+        "fr": "applemusic://track/947701035",
+        "es": "applemusic://track/947701035",
+        "nl": "applemusic://track/947701035",
+        "it": "applemusic://track/947701035"
+      }
     },
     {
       "year": 2004,
@@ -872,16 +1112,26 @@
       ],
       "fun_fact": "The song's iconic Bollywood string sample comes from 'Tere Mere Beech Mein' from the 1981 Indian film Ek Duuje Ke Liye. It won Britney her only Grammy Award.",
       "fun_fact_de": "Das ikonische Bollywood-Streicher-Sample stammt aus 'Tere Mere Beech Mein' aus dem indischen Film Ek Duuje Ke Liye von 1981. Es brachte Britney ihren einzigen Grammy ein.",
-      "fun_fact_es": "El ic\u00f3nico sample de cuerdas de Bollywood proviene de 'Tere Mere Beech Mein' de la pel\u00edcula india de 1981 Ek Duuje Ke Liye. Le vali\u00f3 a Britney su \u00fanico premio Grammy.",
-      "fun_fact_fr": "Le sample embl\u00e9matique de cordes bollywoodiennes provient de 'Tere Mere Beech Mein' du film indien Ek Duuje Ke Liye de 1981. Ce titre a valu \u00e0 Britney son unique Grammy.",
+      "fun_fact_es": "El icónico sample de cuerdas de Bollywood proviene de 'Tere Mere Beech Mein' de la película india de 1981 Ek Duuje Ke Liye. Le valió a Britney su único premio Grammy.",
+      "fun_fact_fr": "Le sample emblématique de cordes bollywoodiennes provient de 'Tere Mere Beech Mein' du film indien Ek Duuje Ke Liye de 1981. Ce titre a valu à Britney son unique Grammy.",
       "uri_apple_music": "applemusic://track/251948354",
       "uri_youtube_music": "https://music.youtube.com/watch?v=LOZuxwVk7TU",
       "uri_tidal": "tidal://track/42298",
       "uri_deezer": "deezer://track/15391618",
       "fun_fact_nl": "De iconische Bollywood-strijkerssample van het nummer is afkomstig uit 'Tere Mere Beech Mein' uit de Indiase film Ek Duuje Ke Liye uit 1981. Het leverde Britney haar enige Grammy Award op.",
       "awards_nl": [
-        "Grammy Award \u2013 Beste Dance-opname"
-      ]
+        "Grammy Award – Beste Dance-opname"
+      ],
+      "isrc": "USJI10301005",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1647919295",
+        "de": "applemusic://track/1647919295",
+        "gb": "applemusic://track/1647919295",
+        "fr": "applemusic://track/1647919295",
+        "es": "applemusic://track/1647919295",
+        "nl": "applemusic://track/1647919295",
+        "it": "applemusic://track/1647919295"
+      }
     },
     {
       "year": 2005,
@@ -905,15 +1155,25 @@
       ],
       "awards": [],
       "fun_fact": "Chris Martin wrote the song for Gwyneth Paltrow after her father's death. The organ intro uses a keyboard that belonged to her late father.",
-      "fun_fact_de": "Chris Martin schrieb den Song f\u00fcr Gwyneth Paltrow nach dem Tod ihres Vaters. Das Orgel-Intro verwendet ein Keyboard, das ihrem verstorbenen Vater geh\u00f6rte.",
-      "fun_fact_es": "Chris Martin escribi\u00f3 la canci\u00f3n para Gwyneth Paltrow tras la muerte de su padre. La intro de \u00f3rgano usa un teclado que perteneci\u00f3 a su difunto padre.",
-      "fun_fact_fr": "Chris Martin a \u00e9crit la chanson pour Gwyneth Paltrow apr\u00e8s le d\u00e9c\u00e8s de son p\u00e8re. L'intro \u00e0 l'orgue utilise un clavier ayant appartenu \u00e0 son d\u00e9funt p\u00e8re.",
+      "fun_fact_de": "Chris Martin schrieb den Song für Gwyneth Paltrow nach dem Tod ihres Vaters. Das Orgel-Intro verwendet ein Keyboard, das ihrem verstorbenen Vater gehörte.",
+      "fun_fact_es": "Chris Martin escribió la canción para Gwyneth Paltrow tras la muerte de su padre. La intro de órgano usa un teclado que perteneció a su difunto padre.",
+      "fun_fact_fr": "Chris Martin a écrit la chanson pour Gwyneth Paltrow après le décès de son père. L'intro à l'orgue utilise un clavier ayant appartenu à son défunt père.",
       "uri_apple_music": "applemusic://track/1123076826",
       "uri_youtube_music": "https://music.youtube.com/watch?v=k4V3Mo61fJM",
       "uri_tidal": "tidal://track/128550",
       "uri_deezer": "deezer://track/3106505",
       "fun_fact_nl": "Chris Martin schreef het nummer voor Gwyneth Paltrow na de dood van haar vader. De orgel-intro maakt gebruik van een keyboard dat van haar overleden vader was.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAYE1600179",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1123076826",
+        "de": "applemusic://track/1123076826",
+        "gb": "applemusic://track/1123076826",
+        "fr": "applemusic://track/1123076826",
+        "es": "applemusic://track/1123076826",
+        "nl": "applemusic://track/1123076826",
+        "it": "applemusic://track/1123076826"
+      }
     },
     {
       "year": 2009,
@@ -944,18 +1204,28 @@
         "Grammy Award - Meilleure collaboration rap/chant"
       ],
       "fun_fact": "Alicia Keys' chorus was recorded in one take and the song became the unofficial anthem of New York City, often played at Yankee Stadium and Knicks games.",
-      "fun_fact_de": "Alicia Keys nahm den Refrain in einem einzigen Take auf und der Song wurde zur inoffiziellen Hymne von New York City, die regelm\u00e4\u00dfig im Yankee Stadium gespielt wird.",
-      "fun_fact_es": "Alicia Keys grab\u00f3 el coro en una sola toma y la canci\u00f3n se convirti\u00f3 en el himno no oficial de la ciudad de Nueva York, a menudo tocada en el Yankee Stadium.",
-      "fun_fact_fr": "Le refrain d'Alicia Keys a \u00e9t\u00e9 enregistr\u00e9 en une seule prise, et le morceau est devenu l'hymne officieux de New York, r\u00e9guli\u00e8rement jou\u00e9 au Yankee Stadium et aux matchs des Knicks.",
+      "fun_fact_de": "Alicia Keys nahm den Refrain in einem einzigen Take auf und der Song wurde zur inoffiziellen Hymne von New York City, die regelmäßig im Yankee Stadium gespielt wird.",
+      "fun_fact_es": "Alicia Keys grabó el coro en una sola toma y la canción se convirtió en el himno no oficial de la ciudad de Nueva York, a menudo tocada en el Yankee Stadium.",
+      "fun_fact_fr": "Le refrain d'Alicia Keys a été enregistré en une seule prise, et le morceau est devenu l'hymne officieux de New York, régulièrement joué au Yankee Stadium et aux matchs des Knicks.",
       "uri_apple_music": "applemusic://track/1440932750",
       "uri_youtube_music": "https://music.youtube.com/watch?v=vk6014HuxcE",
       "uri_tidal": "tidal://track/37704290",
       "uri_deezer": "deezer://track/90533119",
-      "fun_fact_nl": "Het refrein van Alicia Keys werd in \u00e9\u00e9n take opgenomen en het nummer werd het onoffici\u00eble volkslied van New York City, vaak gedraaid in het Yankee Stadium en bij wedstrijden van de Knicks.",
+      "fun_fact_nl": "Het refrein van Alicia Keys werd in één take opgenomen en het nummer werd het onofficiële volkslied van New York City, vaak gedraaid in het Yankee Stadium en bij wedstrijden van de Knicks.",
       "awards_nl": [
-        "Grammy Award \u2013 Beste Rapnummer",
-        "Grammy Award \u2013 Beste Rap/Zang-samenwerking"
-      ]
+        "Grammy Award – Beste Rapnummer",
+        "Grammy Award – Beste Rap/Zang-samenwerking"
+      ],
+      "isrc": "USJZ10900031",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1440750745",
+        "de": "applemusic://track/1440932750",
+        "gb": "applemusic://track/1440932750",
+        "fr": "applemusic://track/1440932750",
+        "es": "applemusic://track/1440932750",
+        "nl": "applemusic://track/1440932750",
+        "it": "applemusic://track/1440932750"
+      }
     },
     {
       "year": 2009,
@@ -982,22 +1252,32 @@
         "Grammy Award - Best Short Form Music Video"
       ],
       "awards_fr": [
-        "Grammy Award - Meilleure performance vocale pop f\u00e9minine",
+        "Grammy Award - Meilleure performance vocale pop féminine",
         "Grammy Award - Meilleur clip musical format court"
       ],
       "fun_fact": "Gaga wrote the song on tour and the 'Ra Ra' hook was inspired by the Queen song 'Radio Ga Ga'. The music video was the first to reach 1 billion views on YouTube.",
       "fun_fact_de": "Gaga schrieb den Song auf Tour und der 'Ra Ra'-Hook wurde vom Queen-Song 'Radio Ga Ga' inspiriert. Das Musikvideo war das erste, das auf YouTube 1 Milliarde Aufrufe erreichte.",
-      "fun_fact_es": "Gaga escribi\u00f3 la canci\u00f3n en gira y el gancho 'Ra Ra' fue inspirado por la canci\u00f3n de Queen 'Radio Ga Ga'. El video musical fue el primero en alcanzar mil millones de vistas en YouTube.",
-      "fun_fact_fr": "Gaga a \u00e9crit la chanson en tourn\u00e9e et le refrain 'Ra Ra' s'inspire de la chanson de Queen 'Radio Ga Ga'. Le clip a \u00e9t\u00e9 le premier \u00e0 atteindre un milliard de vues sur YouTube.",
+      "fun_fact_es": "Gaga escribió la canción en gira y el gancho 'Ra Ra' fue inspirado por la canción de Queen 'Radio Ga Ga'. El video musical fue el primero en alcanzar mil millones de vistas en YouTube.",
+      "fun_fact_fr": "Gaga a écrit la chanson en tournée et le refrain 'Ra Ra' s'inspire de la chanson de Queen 'Radio Ga Ga'. Le clip a été le premier à atteindre un milliard de vues sur YouTube.",
       "uri_apple_music": "applemusic://track/1440860297",
       "uri_youtube_music": "https://music.youtube.com/watch?v=qrO4YZeyl0I",
       "uri_tidal": "tidal://track/77707061",
       "uri_deezer": "deezer://track/4601933",
-      "fun_fact_nl": "Gaga schreef het nummer tijdens een tournee en de 'Ra Ra'-hook was ge\u00efnspireerd op het Queen-nummer 'Radio Ga Ga'. De videoclip was de eerste die 1 miljard views op YouTube behaalde.",
+      "fun_fact_nl": "Gaga schreef het nummer tijdens een tournee en de 'Ra Ra'-hook was geïnspireerd op het Queen-nummer 'Radio Ga Ga'. De videoclip was de eerste die 1 miljard views op YouTube behaalde.",
       "awards_nl": [
-        "Grammy Award \u2013 Beste Vrouwelijke Pop Zangprestatie",
-        "Grammy Award \u2013 Beste Korte Muziekvideo"
-      ]
+        "Grammy Award – Beste Vrouwelijke Pop Zangprestatie",
+        "Grammy Award – Beste Korte Muziekvideo"
+      ],
+      "isrc": "USUM70918596",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1688497897",
+        "de": "applemusic://track/1688497897",
+        "gb": "applemusic://track/1688497897",
+        "fr": "applemusic://track/1688497897",
+        "es": "applemusic://track/1688497897",
+        "nl": "applemusic://track/1688497897",
+        "it": "applemusic://track/1688497897"
+      }
     },
     {
       "year": 2006,
@@ -1026,17 +1306,27 @@
         "Grammy Award - Meilleur enregistrement dance"
       ],
       "fun_fact": "Timbaland produced the track with heavy electronic distortion, and many DJs initially thought it was a new artist rather than Justin Timberlake due to the dramatic sound departure.",
-      "fun_fact_de": "Timbaland produzierte den Track mit starker elektronischer Verzerrung, und viele DJs dachten zun\u00e4chst, es sei ein neuer K\u00fcnstler und nicht Justin Timberlake wegen der dramatischen Klangver\u00e4nderung.",
-      "fun_fact_es": "Timbaland produjo el tema con gran distorsi\u00f3n electr\u00f3nica, y muchos DJs inicialmente pensaron que era un artista nuevo y no Justin Timberlake debido al cambio dram\u00e1tico de sonido.",
-      "fun_fact_fr": "Timbaland a produit le titre avec une forte distorsion \u00e9lectronique, et de nombreux DJ ont d'abord cru qu'il s'agissait d'un nouvel artiste tant le son de Justin Timberlake avait radicalement chang\u00e9.",
+      "fun_fact_de": "Timbaland produzierte den Track mit starker elektronischer Verzerrung, und viele DJs dachten zunächst, es sei ein neuer Künstler und nicht Justin Timberlake wegen der dramatischen Klangveränderung.",
+      "fun_fact_es": "Timbaland produjo el tema con gran distorsión electrónica, y muchos DJs inicialmente pensaron que era un artista nuevo y no Justin Timberlake debido al cambio dramático de sonido.",
+      "fun_fact_fr": "Timbaland a produit le titre avec une forte distorsion électronique, et de nombreux DJ ont d'abord cru qu'il s'agissait d'un nouvel artiste tant le son de Justin Timberlake avait radicalement changé.",
       "uri_apple_music": "applemusic://track/187666051",
       "uri_youtube_music": "https://music.youtube.com/watch?v=3gOHvDP_vCs",
       "uri_tidal": "tidal://track/555115",
       "uri_deezer": "deezer://track/15489383",
       "fun_fact_nl": "Timbaland produceerde de track met zware elektronische vervorming, en veel dj's dachten aanvankelijk dat het een nieuwe artiest was in plaats van Justin Timberlake vanwege de dramatische verandering in geluid.",
       "awards_nl": [
-        "Grammy Award \u2013 Beste Dance-opname"
-      ]
+        "Grammy Award – Beste Dance-opname"
+      ],
+      "isrc": "USJI10600269",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/187666051",
+        "de": "applemusic://track/187666051",
+        "gb": "applemusic://track/187666051",
+        "fr": "applemusic://track/187666051",
+        "es": "applemusic://track/187666051",
+        "nl": "applemusic://track/187666051",
+        "it": "applemusic://track/187666051"
+      }
     },
     {
       "year": 2008,
@@ -1065,17 +1355,27 @@
         "Grammy Award - Meilleure performance rock d'un duo ou groupe avec voix"
       ],
       "fun_fact": "The band nearly didn't include this song on the album because they thought it was too mainstream. It became their biggest worldwide hit and UK's best-selling rock song of 2008.",
-      "fun_fact_de": "Die Band h\u00e4tte den Song fast nicht aufs Album genommen, weil sie ihn f\u00fcr zu kommerziell hielten. Er wurde ihr gr\u00f6\u00dfter weltweiter Hit und der meistverkaufte Rocksong 2008 in UK.",
-      "fun_fact_es": "La banda casi no incluy\u00f3 esta canci\u00f3n en el \u00e1lbum porque pensaban que era demasiado comercial. Se convirti\u00f3 en su mayor \u00e9xito mundial y la canci\u00f3n rock m\u00e1s vendida de 2008 en el Reino Unido.",
-      "fun_fact_fr": "Le groupe a failli ne pas inclure ce morceau sur l'album, le jugeant trop commercial. Il est devenu leur plus grand succ\u00e8s mondial et le titre rock le plus vendu au Royaume-Uni en 2008.",
+      "fun_fact_de": "Die Band hätte den Song fast nicht aufs Album genommen, weil sie ihn für zu kommerziell hielten. Er wurde ihr größter weltweiter Hit und der meistverkaufte Rocksong 2008 in UK.",
+      "fun_fact_es": "La banda casi no incluyó esta canción en el álbum porque pensaban que era demasiado comercial. Se convirtió en su mayor éxito mundial y la canción rock más vendida de 2008 en el Reino Unido.",
+      "fun_fact_fr": "Le groupe a failli ne pas inclure ce morceau sur l'album, le jugeant trop commercial. Il est devenu leur plus grand succès mondial et le titre rock le plus vendu au Royaume-Uni en 2008.",
       "uri_apple_music": "applemusic://track/290303003",
       "uri_youtube_music": "https://music.youtube.com/watch?v=RF0HhrwIwp0",
       "uri_tidal": "tidal://track/1906286",
       "uri_deezer": "deezer://track/15531170",
       "fun_fact_nl": "De band had dit nummer bijna niet op het album gezet omdat ze dachten dat het te mainstream was. Het werd hun grootste wereldwijde hit en het bestverkochte rocknummer van het VK in 2008.",
       "awards_nl": [
-        "Grammy Award \u2013 Beste Rockprestatie door Duo of Groep met Zang"
-      ]
+        "Grammy Award – Beste Rockprestatie door Duo of Groep met Zang"
+      ],
+      "isrc": "USRC10800300",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1441530830",
+        "de": "applemusic://track/1445848997",
+        "gb": "applemusic://track/1893746510",
+        "fr": "applemusic://track/1445848997",
+        "es": "applemusic://track/1445848997",
+        "nl": "applemusic://track/1445848997",
+        "it": "applemusic://track/1445848997"
+      }
     },
     {
       "year": 2002,
@@ -1101,20 +1401,30 @@
         "Grammy Award - Record of the Year"
       ],
       "awards_fr": [
-        "Grammy Award - Enregistrement de l'ann\u00e9e"
+        "Grammy Award - Enregistrement de l'année"
       ],
       "fun_fact": "Chris Martin came up with the piano riff late at night and almost didn't record it because it was meant for another band project. It won the Grammy for Record of the Year in 2004.",
-      "fun_fact_de": "Chris Martin kam sp\u00e4t nachts auf das Klavierriff und h\u00e4tte es fast nicht aufgenommen, da es f\u00fcr ein anderes Bandprojekt gedacht war. Es gewann 2004 den Grammy f\u00fcr die Aufnahme des Jahres.",
-      "fun_fact_es": "Chris Martin cre\u00f3 el riff de piano tarde en la noche y casi no lo graba porque estaba destinado a otro proyecto de la banda. Gan\u00f3 el Grammy a la Grabaci\u00f3n del A\u00f1o en 2004.",
-      "fun_fact_fr": "Chris Martin a trouv\u00e9 le riff de piano tard dans la nuit et a failli ne pas l'enregistrer car il \u00e9tait destin\u00e9 \u00e0 un autre projet. Le titre a remport\u00e9 le Grammy de l'Enregistrement de l'Ann\u00e9e en 2004.",
+      "fun_fact_de": "Chris Martin kam spät nachts auf das Klavierriff und hätte es fast nicht aufgenommen, da es für ein anderes Bandprojekt gedacht war. Es gewann 2004 den Grammy für die Aufnahme des Jahres.",
+      "fun_fact_es": "Chris Martin creó el riff de piano tarde en la noche y casi no lo graba porque estaba destinado a otro proyecto de la banda. Ganó el Grammy a la Grabación del Año en 2004.",
+      "fun_fact_fr": "Chris Martin a trouvé le riff de piano tard dans la nuit et a failli ne pas l'enregistrer car il était destiné à un autre projet. Le titre a remporté le Grammy de l'Enregistrement de l'Année en 2004.",
       "uri_apple_music": "applemusic://track/1122776156",
       "uri_youtube_music": "https://music.youtube.com/watch?v=d020hcWA_Wg",
       "uri_tidal": "tidal://track/128606",
       "uri_deezer": "deezer://track/3098841",
       "fun_fact_nl": "Chris Martin bedacht de pianoriff diep in de nacht en nam hem bijna niet op omdat hij bedoeld was voor een ander bandproject. Het won de Grammy voor Record of the Year in 2004.",
       "awards_nl": [
-        "Grammy Award \u2013 Opname van het Jaar"
-      ]
+        "Grammy Award – Opname van het Jaar"
+      ],
+      "isrc": "GBAYE1600193",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1122776156",
+        "de": "applemusic://track/1122776156",
+        "gb": "applemusic://track/1122776156",
+        "fr": "applemusic://track/1122776156",
+        "es": "applemusic://track/1122776156",
+        "nl": "applemusic://track/1122776156",
+        "it": "applemusic://track/1122776156"
+      }
     },
     {
       "year": 2007,
@@ -1139,21 +1449,31 @@
       "awards": [],
       "fun_fact": "The song was featured as the end credits theme for the 2007 Transformers movie, introducing Linkin Park to an even wider global audience.",
       "fun_fact_de": "Der Song war der Abspanntitel des Transformers-Films von 2007 und machte Linkin Park einem noch breiteren globalen Publikum bekannt.",
-      "fun_fact_es": "La canci\u00f3n fue el tema de los cr\u00e9ditos finales de la pel\u00edcula Transformers de 2007, presentando a Linkin Park a un p\u00fablico global a\u00fan m\u00e1s amplio.",
-      "fun_fact_fr": "Le morceau est le th\u00e8me du g\u00e9n\u00e9rique de fin du film Transformers de 2007, ce qui a fait d\u00e9couvrir Linkin Park \u00e0 un public mondial encore plus large.",
+      "fun_fact_es": "La canción fue el tema de los créditos finales de la película Transformers de 2007, presentando a Linkin Park a un público global aún más amplio.",
+      "fun_fact_fr": "Le morceau est le thème du générique de fin du film Transformers de 2007, ce qui a fait découvrir Linkin Park à un public mondial encore plus large.",
       "uri_apple_music": "applemusic://track/590427450",
       "uri_youtube_music": "https://music.youtube.com/watch?v=8sgycukafqQ",
       "uri_tidal": "tidal://track/406466",
       "uri_deezer": "deezer://track/676847",
       "fun_fact_nl": "Het nummer werd gebruikt als aftitelingsnummer voor de film Transformers uit 2007, waardoor Linkin Park een nog breder wereldwijd publiek bereikte.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USWB11201141",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1622307559",
+        "de": "applemusic://track/1622307559",
+        "gb": "applemusic://track/1622307559",
+        "fr": "applemusic://track/1622307559",
+        "es": "applemusic://track/1622307559",
+        "nl": "applemusic://track/1622307559",
+        "it": "applemusic://track/1622307559"
+      }
     },
     {
       "year": 2007,
       "uri": "spotify:track:0ByMNEPAPpOR5H69DVrTNy",
       "artist": "Rihanna",
       "alt_artists": [
-        "Beyonc\u00e9",
+        "Beyoncé",
         "Ciara",
         "Cassie",
         "Amerie"
@@ -1170,15 +1490,25 @@
       ],
       "awards": [],
       "fun_fact": "The song samples Michael Jackson's 'Wanna Be Startin' Somethin'' and Rihanna personally asked the Jackson estate for permission to use the iconic vocal hook.",
-      "fun_fact_de": "Der Song sampelt Michael Jacksons 'Wanna Be Startin' Somethin'' und Rihanna bat pers\u00f6nlich den Jackson-Nachlass um Erlaubnis, den ikonischen Vocal-Hook zu verwenden.",
-      "fun_fact_es": "La canci\u00f3n samplea 'Wanna Be Startin' Somethin'' de Michael Jackson y Rihanna pidi\u00f3 personalmente permiso al patrimonio de Jackson para usar el ic\u00f3nico gancho vocal.",
-      "fun_fact_fr": "La chanson sample 'Wanna Be Startin' Somethin'' de Michael Jackson, et Rihanna a personnellement demand\u00e9 l'autorisation \u00e0 la succession Jackson pour utiliser le hook vocal embl\u00e9matique.",
+      "fun_fact_de": "Der Song sampelt Michael Jacksons 'Wanna Be Startin' Somethin'' und Rihanna bat persönlich den Jackson-Nachlass um Erlaubnis, den ikonischen Vocal-Hook zu verwenden.",
+      "fun_fact_es": "La canción samplea 'Wanna Be Startin' Somethin'' de Michael Jackson y Rihanna pidió personalmente permiso al patrimonio de Jackson para usar el icónico gancho vocal.",
+      "fun_fact_fr": "La chanson sample 'Wanna Be Startin' Somethin'' de Michael Jackson, et Rihanna a personnellement demandé l'autorisation à la succession Jackson pour utiliser le hook vocal emblématique.",
       "uri_apple_music": "applemusic://track/1441154439",
       "uri_youtube_music": "https://music.youtube.com/watch?v=yd8jh9QYfEs",
       "uri_tidal": "tidal://track/1771729",
       "uri_deezer": "deezer://track/925108",
       "fun_fact_nl": "Het nummer bevat een sample van Michael Jacksons 'Wanna Be Startin' Somethin'' en Rihanna vroeg persoonlijk toestemming aan de erven Jackson om de iconische vocale hook te gebruiken.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USUM70734700",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1472000532",
+        "de": "applemusic://track/1442492867",
+        "gb": "applemusic://track/1442492867",
+        "fr": "applemusic://track/1442489547",
+        "es": "applemusic://track/1442492867",
+        "nl": "applemusic://track/1442492867",
+        "it": "applemusic://track/1444319368"
+      }
     },
     {
       "year": 2007,
@@ -1203,14 +1533,24 @@
       "awards": [],
       "fun_fact": "The song spent 10 weeks at #1 on Billboard and was the best-selling digital single of 2008. Its Apple Bottom jeans lyric made the clothing brand a household name.",
       "fun_fact_de": "Der Song war 10 Wochen auf Platz 1 der Billboard-Charts und war die meistverkaufte digitale Single 2008. Die 'Apple Bottom Jeans'-Zeile machte die Modemarke weltbekannt.",
-      "fun_fact_es": "La canci\u00f3n pas\u00f3 10 semanas en el #1 de Billboard y fue el sencillo digital m\u00e1s vendido de 2008. Su letra sobre 'Apple Bottom jeans' hizo famosa a la marca de ropa.",
-      "fun_fact_fr": "Le titre est rest\u00e9 10 semaines en t\u00eate du Billboard et a \u00e9t\u00e9 le single num\u00e9rique le plus vendu de 2008. Sa r\u00e9f\u00e9rence aux jeans Apple Bottom a fait conna\u00eetre la marque au grand public.",
+      "fun_fact_es": "La canción pasó 10 semanas en el #1 de Billboard y fue el sencillo digital más vendido de 2008. Su letra sobre 'Apple Bottom jeans' hizo famosa a la marca de ropa.",
+      "fun_fact_fr": "Le titre est resté 10 semaines en tête du Billboard et a été le single numérique le plus vendu de 2008. Sa référence aux jeans Apple Bottom a fait connaître la marque au grand public.",
       "uri_apple_music": "applemusic://track/272171635",
       "uri_youtube_music": "https://music.youtube.com/watch?v=U2waT9TxPU0",
       "uri_tidal": "tidal://track/1653995",
       "uri_deezer": "deezer://track/717358",
       "fun_fact_nl": "Het nummer stond 10 weken op nummer 1 in Billboard en was de bestverkochte digitale single van 2008. De tekst over Apple Bottom-jeans maakte het kledingmerk tot een bekende naam.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USAT20705841",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1802159350",
+        "de": "applemusic://track/1802159350",
+        "gb": "applemusic://track/1802159350",
+        "fr": "applemusic://track/1802159350",
+        "es": "applemusic://track/1802159350",
+        "nl": "applemusic://track/1802159350",
+        "it": "applemusic://track/1802159350"
+      }
     },
     {
       "year": 2007,
@@ -1234,15 +1574,25 @@
       ],
       "awards": [],
       "fun_fact": "Released during Britney's turbulent 2007, the song's infamous opening line 'It's Britney, bitch' became one of the most iconic catchphrases in pop culture history.",
-      "fun_fact_de": "Ver\u00f6ffentlicht w\u00e4hrend Britneys turbulentem 2007, wurde die ber\u00fcchtigte Er\u00f6ffnungszeile 'It's Britney, bitch' zu einer der ikonischsten Phrasen der Popkultur.",
-      "fun_fact_es": "Lanzada durante el turbulento 2007 de Britney, la infame frase inicial 'It's Britney, bitch' se convirti\u00f3 en una de las frases m\u00e1s ic\u00f3nicas de la cultura pop.",
-      "fun_fact_fr": "Sorti pendant l'ann\u00e9e tumultueuse de Britney en 2007, la c\u00e9l\u00e8bre phrase d'ouverture 'It's Britney, bitch' est devenue l'une des r\u00e9pliques les plus embl\u00e9matiques de la culture pop.",
+      "fun_fact_de": "Veröffentlicht während Britneys turbulentem 2007, wurde die berüchtigte Eröffnungszeile 'It's Britney, bitch' zu einer der ikonischsten Phrasen der Popkultur.",
+      "fun_fact_es": "Lanzada durante el turbulento 2007 de Britney, la infame frase inicial 'It's Britney, bitch' se convirtió en una de las frases más icónicas de la cultura pop.",
+      "fun_fact_fr": "Sorti pendant l'année tumultueuse de Britney en 2007, la célèbre phrase d'ouverture 'It's Britney, bitch' est devenue l'une des répliques les plus emblématiques de la culture pop.",
       "uri_apple_music": "applemusic://track/266646483",
       "uri_youtube_music": "https://music.youtube.com/watch?v=elueA2rofoo",
       "uri_tidal": "tidal://track/33734602",
       "uri_deezer": "deezer://track/15589893",
       "fun_fact_nl": "Uitgebracht tijdens Britney's turbulente 2007, werd de beruchte openingszin 'It's Britney, bitch' een van de meest iconische catchphrases in de geschiedenis van de popcultuur.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USJI10700609",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/521738935",
+        "de": "applemusic://track/521738935",
+        "gb": "applemusic://track/521738935",
+        "fr": "applemusic://track/521738935",
+        "es": "applemusic://track/521738935",
+        "nl": "applemusic://track/521738935",
+        "it": "applemusic://track/521738935"
+      }
     },
     {
       "year": 2000,
@@ -1271,17 +1621,27 @@
         "Grammy Award - Meilleure performance rap solo"
       ],
       "fun_fact": "Eminem wrote the song just hours before the album's deadline after scrapping the original track. It was recorded in one take and became his signature anthem.",
-      "fun_fact_de": "Eminem schrieb den Song nur Stunden vor dem Album-Abgabetermin, nachdem er den urspr\u00fcnglichen Track verworfen hatte. Er wurde in einem Take aufgenommen und wurde zu seiner Hymne.",
-      "fun_fact_es": "Eminem escribi\u00f3 la canci\u00f3n pocas horas antes de la fecha l\u00edmite del \u00e1lbum tras descartar la pista original. Se grab\u00f3 en una sola toma y se convirti\u00f3 en su himno.",
-      "fun_fact_fr": "Eminem a \u00e9crit la chanson quelques heures seulement avant la date limite de l'album, apr\u00e8s avoir abandonn\u00e9 le morceau original. Elle a \u00e9t\u00e9 enregistr\u00e9e en une seule prise et est devenue son hymne signature.",
+      "fun_fact_de": "Eminem schrieb den Song nur Stunden vor dem Album-Abgabetermin, nachdem er den ursprünglichen Track verworfen hatte. Er wurde in einem Take aufgenommen und wurde zu seiner Hymne.",
+      "fun_fact_es": "Eminem escribió la canción pocas horas antes de la fecha límite del álbum tras descartar la pista original. Se grabó en una sola toma y se convirtió en su himno.",
+      "fun_fact_fr": "Eminem a écrit la chanson quelques heures seulement avant la date limite de l'album, après avoir abandonné le morceau original. Elle a été enregistrée en une seule prise et est devenue son hymne signature.",
       "uri_apple_music": "applemusic://track/1440866926",
       "uri_youtube_music": "https://music.youtube.com/watch?v=eJO5HU_7_1w",
       "uri_tidal": "tidal://track/586946",
       "uri_deezer": "deezer://track/1109737",
-      "fun_fact_nl": "Eminem schreef het nummer slechts enkele uren voor de deadline van het album nadat hij het oorspronkelijke nummer had geschrapt. Het werd in \u00e9\u00e9n take opgenomen en werd zijn kenmerkende lijflied.",
+      "fun_fact_nl": "Eminem schreef het nummer slechts enkele uren voor de deadline van het album nadat hij het oorspronkelijke nummer had geschrapt. Het werd in één take opgenomen en werd zijn kenmerkende lijflied.",
       "awards_nl": [
-        "Grammy Award \u2013 Beste Rap Soloprestatie"
-      ]
+        "Grammy Award – Beste Rap Soloprestatie"
+      ],
+      "isrc": "USIR10000448",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1440866926",
+        "de": "applemusic://track/1443122109",
+        "gb": "applemusic://track/1440866926",
+        "fr": "applemusic://track/1443122109",
+        "es": "applemusic://track/1443122109",
+        "nl": "applemusic://track/1443122109",
+        "it": "applemusic://track/1443122109"
+      }
     },
     {
       "year": 2001,
@@ -1305,14 +1665,24 @@
       ],
       "awards": [],
       "fun_fact": "Billboard named it the #1 song of 2002 and the 4th-biggest song of the decade. Despite memes mocking the band, it was the most-played song on US radio that decade.",
-      "fun_fact_de": "Billboard k\u00fcrte es zum #1-Song von 2002 und zum viertgr\u00f6\u00dften Song des Jahrzehnts. Trotz Internet-Memes war es der meistgespielte Song im US-Radio des Jahrzehnts.",
-      "fun_fact_es": "Billboard la nombr\u00f3 canci\u00f3n #1 de 2002 y la cuarta m\u00e1s grande de la d\u00e9cada. A pesar de los memes burl\u00e1ndose de la banda, fue la canci\u00f3n m\u00e1s reproducida en la radio de EE.UU. en esa d\u00e9cada.",
-      "fun_fact_fr": "Billboard l'a d\u00e9sign\u00e9e chanson num\u00e9ro 1 de 2002 et quatri\u00e8me plus grand titre de la d\u00e9cennie. Malgr\u00e9 les moqueries sur internet, c'est la chanson la plus diffus\u00e9e en radio aux \u00c9tats-Unis durant cette d\u00e9cennie.",
+      "fun_fact_de": "Billboard kürte es zum #1-Song von 2002 und zum viertgrößten Song des Jahrzehnts. Trotz Internet-Memes war es der meistgespielte Song im US-Radio des Jahrzehnts.",
+      "fun_fact_es": "Billboard la nombró canción #1 de 2002 y la cuarta más grande de la década. A pesar de los memes burlándose de la banda, fue la canción más reproducida en la radio de EE.UU. en esa década.",
+      "fun_fact_fr": "Billboard l'a désignée chanson numéro 1 de 2002 et quatrième plus grand titre de la décennie. Malgré les moqueries sur internet, c'est la chanson la plus diffusée en radio aux États-Unis durant cette décennie.",
       "uri_apple_music": "applemusic://track/214475478",
       "uri_youtube_music": "https://music.youtube.com/watch?v=Aiay8I5IPB8",
       "uri_deezer": "deezer://track/71828723",
       "fun_fact_nl": "Billboard riep het uit tot het nummer 1-nummer van 2002 en het op drie na grootste nummer van het decennium. Ondanks memes die de band belachelijk maakten, was het dat decennium het meest gedraaide nummer op de Amerikaanse radio.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "NLA320119533",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1837959921",
+        "de": "applemusic://track/1749002902",
+        "gb": "applemusic://track/1749002902",
+        "fr": "applemusic://track/1749002902",
+        "es": "applemusic://track/1749002902",
+        "nl": "applemusic://track/1749002902",
+        "it": "applemusic://track/1749002902"
+      }
     },
     {
       "year": 2006,
@@ -1336,15 +1706,25 @@
       ],
       "awards": [],
       "fun_fact": "The song shares its title with the 1982 Hall & Oates hit but is a completely original composition produced by Timbaland. It topped charts in over 10 countries.",
-      "fun_fact_de": "Der Song teilt seinen Titel mit dem Hall & Oates-Hit von 1982, ist aber eine komplett eigenst\u00e4ndige Komposition von Timbaland. Er erreichte in \u00fcber 10 L\u00e4ndern Platz 1.",
-      "fun_fact_es": "La canci\u00f3n comparte su t\u00edtulo con el \u00e9xito de Hall & Oates de 1982 pero es una composici\u00f3n completamente original producida por Timbaland. Lleg\u00f3 al #1 en m\u00e1s de 10 pa\u00edses.",
-      "fun_fact_fr": "Le morceau partage son titre avec le tube de Hall & Oates de 1982, mais c'est une composition enti\u00e8rement originale produite par Timbaland. Il a atteint le sommet des charts dans plus de 10 pays.",
+      "fun_fact_de": "Der Song teilt seinen Titel mit dem Hall & Oates-Hit von 1982, ist aber eine komplett eigenständige Komposition von Timbaland. Er erreichte in über 10 Ländern Platz 1.",
+      "fun_fact_es": "La canción comparte su título con el éxito de Hall & Oates de 1982 pero es una composición completamente original producida por Timbaland. Llegó al #1 en más de 10 países.",
+      "fun_fact_fr": "Le morceau partage son titre avec le tube de Hall & Oates de 1982, mais c'est une composition entièrement originale produite par Timbaland. Il a atteint le sommet des charts dans plus de 10 pays.",
       "uri_apple_music": "applemusic://track/1442463828",
       "uri_youtube_music": "https://music.youtube.com/watch?v=PLolag3YSYU",
       "uri_tidal": "tidal://track/479936",
       "uri_deezer": "deezer://track/1151141",
       "fun_fact_nl": "Het nummer deelt zijn titel met de hit van Hall & Oates uit 1982, maar is een volledig originele compositie geproduceerd door Timbaland. Het stond bovenaan de hitlijsten in meer dan 10 landen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USUM70601449",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1705971765",
+        "de": "applemusic://track/1705971765",
+        "gb": "applemusic://track/1705971765",
+        "fr": "applemusic://track/1705971765",
+        "es": "applemusic://track/1705971765",
+        "nl": "applemusic://track/1705971765",
+        "it": "applemusic://track/1705971765"
+      }
     },
     {
       "year": 2008,
@@ -1373,17 +1753,27 @@
         "Grammy Award - Meilleur enregistrement dance"
       ],
       "fun_fact": "Lady Gaga revealed the song is about her bisexuality and the poker face she put on while being with men and thinking of women. It was 2009's best-selling single worldwide.",
-      "fun_fact_de": "Lady Gaga enth\u00fcllte, dass der Song von ihrer Bisexualit\u00e4t handelt und dem Pokerface, das sie aufsetzte, wenn sie mit M\u00e4nnern zusammen war und an Frauen dachte.",
-      "fun_fact_es": "Lady Gaga revel\u00f3 que la canci\u00f3n trata sobre su bisexualidad y la cara de p\u00f3ker que pon\u00eda cuando estaba con hombres y pensaba en mujeres. Fue el sencillo m\u00e1s vendido de 2009.",
-      "fun_fact_fr": "Lady Gaga a r\u00e9v\u00e9l\u00e9 que la chanson parle de sa bisexualit\u00e9 et du visage impassible qu'elle arborait en pr\u00e9sence d'hommes tout en pensant \u00e0 des femmes. C'est le single le plus vendu de 2009 dans le monde.",
+      "fun_fact_de": "Lady Gaga enthüllte, dass der Song von ihrer Bisexualität handelt und dem Pokerface, das sie aufsetzte, wenn sie mit Männern zusammen war und an Frauen dachte.",
+      "fun_fact_es": "Lady Gaga reveló que la canción trata sobre su bisexualidad y la cara de póker que ponía cuando estaba con hombres y pensaba en mujeres. Fue el sencillo más vendido de 2009.",
+      "fun_fact_fr": "Lady Gaga a révélé que la chanson parle de sa bisexualité et du visage impassible qu'elle arborait en présence d'hommes tout en pensant à des femmes. C'est le single le plus vendu de 2009 dans le monde.",
       "uri_apple_music": "applemusic://track/1440818665",
       "uri_youtube_music": "https://music.youtube.com/watch?v=bESGLojNYSo",
       "uri_tidal": "tidal://track/77707019",
       "uri_deezer": "deezer://track/2603558",
       "fun_fact_nl": "Lady Gaga onthulde dat het nummer gaat over haar biseksualiteit en het 'pokerface' dat ze opzette terwijl ze met mannen was en aan vrouwen dacht. Het was de bestverkochte single van 2009 wereldwijd.",
       "awards_nl": [
-        "Grammy Award \u2013 Beste Dance-opname"
-      ]
+        "Grammy Award – Beste Dance-opname"
+      ],
+      "isrc": "USUM70824409",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1710465533",
+        "de": "applemusic://track/1710465533",
+        "gb": "applemusic://track/1710465533",
+        "fr": "applemusic://track/1710465533",
+        "es": "applemusic://track/1710465533",
+        "nl": "applemusic://track/1607496859",
+        "it": "applemusic://track/1710465533"
+      }
     },
     {
       "year": 2010,
@@ -1405,16 +1795,26 @@
         "6x Platinum (US)"
       ],
       "awards": [],
-      "fun_fact": "\u26a0\ufe0f NOTE: Released in 2010, technically outside the 2000-2009 range. The song's dark lyrics about a troubled youth are contrasted by its upbeat indie-pop melody.",
-      "fun_fact_de": "\u26a0\ufe0f HINWEIS: 2010 ver\u00f6ffentlicht, technisch au\u00dferhalb des 2000-2009-Zeitraums. Die dunklen Texte \u00fcber einen gest\u00f6rten Jugendlichen stehen im Kontrast zur fr\u00f6hlichen Indie-Pop-Melodie.",
-      "fun_fact_es": "\u26a0\ufe0f NOTA: Lanzada en 2010, t\u00e9cnicamente fuera del rango 2000-2009. La letra oscura sobre un joven problem\u00e1tico contrasta con su alegre melod\u00eda indie-pop.",
-      "fun_fact_fr": "Sorti en 2010, donc techniquement hors de la p\u00e9riode 2000-2009. Les paroles sombres sur un jeune en difficult\u00e9 contrastent avec la m\u00e9lodie indie-pop entra\u00eenante du titre.",
+      "fun_fact": "⚠️ NOTE: Released in 2010, technically outside the 2000-2009 range. The song's dark lyrics about a troubled youth are contrasted by its upbeat indie-pop melody.",
+      "fun_fact_de": "⚠️ HINWEIS: 2010 veröffentlicht, technisch außerhalb des 2000-2009-Zeitraums. Die dunklen Texte über einen gestörten Jugendlichen stehen im Kontrast zur fröhlichen Indie-Pop-Melodie.",
+      "fun_fact_es": "⚠️ NOTA: Lanzada en 2010, técnicamente fuera del rango 2000-2009. La letra oscura sobre un joven problemático contrasta con su alegre melodía indie-pop.",
+      "fun_fact_fr": "Sorti en 2010, donc techniquement hors de la période 2000-2009. Les paroles sombres sur un jeune en difficulté contrastent avec la mélodie indie-pop entraînante du titre.",
       "uri_apple_music": "applemusic://track/435761212",
       "uri_youtube_music": "https://music.youtube.com/watch?v=SDTZ7iX4vTQ",
       "uri_tidal": "tidal://track/25280917",
       "uri_deezer": "deezer://track/15546830",
-      "fun_fact_nl": "\u26a0\ufe0f OPMERKING: Uitgebracht in 2010, technisch gezien buiten het bereik 2000-2009. de duistere tekst van het nummer over een probleemjongere wordt gecontrasteerd door de vrolijke indie-popmelodie.",
-      "awards_nl": []
+      "fun_fact_nl": "⚠️ OPMERKING: Uitgebracht in 2010, technisch gezien buiten het bereik 2000-2009. de duistere tekst van het nummer over een probleemjongere wordt gecontrasteerd door de vrolijke indie-popmelodie.",
+      "awards_nl": [],
+      "isrc": "USSM11002931",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1459540500",
+        "de": "applemusic://track/1459540500",
+        "gb": "applemusic://track/1459540500",
+        "fr": "applemusic://track/1459540500",
+        "es": "applemusic://track/1459540500",
+        "nl": "applemusic://track/1459540500",
+        "it": "applemusic://track/1459540500"
+      }
     },
     {
       "year": 2002,
@@ -1437,22 +1837,32 @@
       ],
       "awards": [],
       "fun_fact": "Despite never being released as an official single, it became the most-streamed Eminem song on Spotify and one of the most popular workout songs of all time.",
-      "fun_fact_de": "Obwohl er nie als offizielle Single ver\u00f6ffentlicht wurde, wurde er zum meistgestreamten Eminem-Song auf Spotify und einem der beliebtesten Workout-Songs aller Zeiten.",
-      "fun_fact_es": "A pesar de nunca ser lanzada como sencillo oficial, se convirti\u00f3 en la canci\u00f3n m\u00e1s reproducida de Eminem en Spotify y una de las canciones de entrenamiento m\u00e1s populares de todos los tiempos.",
-      "fun_fact_fr": "Bien que jamais sorti en single officiel, il est devenu le titre d'Eminem le plus stream\u00e9 sur Spotify et l'une des chansons d'entra\u00eenement les plus populaires de tous les temps.",
+      "fun_fact_de": "Obwohl er nie als offizielle Single veröffentlicht wurde, wurde er zum meistgestreamten Eminem-Song auf Spotify und einem der beliebtesten Workout-Songs aller Zeiten.",
+      "fun_fact_es": "A pesar de nunca ser lanzada como sencillo oficial, se convirtió en la canción más reproducida de Eminem en Spotify y una de las canciones de entrenamiento más populares de todos los tiempos.",
+      "fun_fact_fr": "Bien que jamais sorti en single officiel, il est devenu le titre d'Eminem le plus streamé sur Spotify et l'une des chansons d'entraînement les plus populaires de tous les temps.",
       "uri_apple_music": "applemusic://track/1440903814",
       "uri_youtube_music": "https://music.youtube.com/watch?v=Pi3_Zs-oRUo",
       "uri_tidal": "tidal://track/573301",
       "uri_deezer": "deezer://track/916445",
-      "fun_fact_nl": "Hoewel het nooit als offici\u00eble single is uitgebracht, werd het het meest gestroomde nummer van Eminem op Spotify en een van de meest populaire workout-nummers aller tijden.",
-      "awards_nl": []
+      "fun_fact_nl": "Hoewel het nooit als officiële single is uitgebracht, werd het het meest gestroomde nummer van Eminem op Spotify en een van de meest populaire workout-nummers aller tijden.",
+      "awards_nl": [],
+      "isrc": "USIR10211066",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1440903814",
+        "de": "applemusic://track/1440903814",
+        "gb": "applemusic://track/1440903814",
+        "fr": "applemusic://track/1440903814",
+        "es": "applemusic://track/1440903814",
+        "nl": "applemusic://track/1440903814",
+        "it": "applemusic://track/1440903814"
+      }
     },
     {
       "year": 2007,
       "uri": "spotify:track:49FYlytm3dAAraYgpoJZux",
       "artist": "Rihanna",
       "alt_artists": [
-        "Beyonc\u00e9",
+        "Beyoncé",
         "Ciara",
         "Alicia Keys",
         "Mary J. Blige"
@@ -1474,17 +1884,27 @@
         "Grammy Award - Meilleure collaboration rap/chant"
       ],
       "fun_fact": "The song was originally written for Britney Spears who turned it down. It spent 10 consecutive weeks at #1 in the UK during one of the rainiest summers on record.",
-      "fun_fact_de": "Der Song wurde urspr\u00fcnglich f\u00fcr Britney Spears geschrieben, die ihn ablehnte. Er blieb 10 Wochen in Folge auf Platz 1 in UK \u2014 w\u00e4hrend eines der regenreichsten Sommer aller Zeiten.",
-      "fun_fact_es": "La canci\u00f3n fue escrita originalmente para Britney Spears, quien la rechaz\u00f3. Pas\u00f3 10 semanas consecutivas en el #1 del Reino Unido durante uno de los veranos m\u00e1s lluviosos registrados.",
-      "fun_fact_fr": "La chanson avait \u00e9t\u00e9 \u00e9crite \u00e0 l'origine pour Britney Spears, qui l'a refus\u00e9e. Elle est rest\u00e9e 10 semaines cons\u00e9cutives en t\u00eate des charts britanniques durant l'un des \u00e9t\u00e9s les plus pluvieux jamais enregistr\u00e9s.",
+      "fun_fact_de": "Der Song wurde ursprünglich für Britney Spears geschrieben, die ihn ablehnte. Er blieb 10 Wochen in Folge auf Platz 1 in UK — während eines der regenreichsten Sommer aller Zeiten.",
+      "fun_fact_es": "La canción fue escrita originalmente para Britney Spears, quien la rechazó. Pasó 10 semanas consecutivas en el #1 del Reino Unido durante uno de los veranos más lluviosos registrados.",
+      "fun_fact_fr": "La chanson avait été écrite à l'origine pour Britney Spears, qui l'a refusée. Elle est restée 10 semaines consécutives en tête des charts britanniques durant l'un des étés les plus pluvieux jamais enregistrés.",
       "uri_apple_music": "applemusic://track/1441154437",
       "uri_youtube_music": "https://music.youtube.com/watch?v=CvBfHwUxHIk",
       "uri_tidal": "tidal://track/1771727",
       "uri_deezer": "deezer://track/925106",
       "fun_fact_nl": "Het nummer was oorspronkelijk geschreven voor Britney Spears, die het weigerde. Het stond 10 opeenvolgende weken op nummer 1 in het VK tijdens een van de regenachtigste zomers ooit gemeten.",
       "awards_nl": [
-        "Grammy Award \u2013 Beste Rap/Zang-samenwerking"
-      ]
+        "Grammy Award – Beste Rap/Zang-samenwerking"
+      ],
+      "isrc": "USUM70736771",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1441154437",
+        "de": "applemusic://track/1444582234",
+        "gb": "applemusic://track/1441154437",
+        "fr": "applemusic://track/1441154437",
+        "es": "applemusic://track/1441154437",
+        "nl": "applemusic://track/1441154437",
+        "it": "applemusic://track/1441154437"
+      }
     },
     {
       "year": 2009,
@@ -1508,15 +1928,25 @@
       ],
       "awards": [],
       "fun_fact": "The song sold over 16.5 million digital copies worldwide, surpassing Lady Gaga's 'Poker Face' as the best-selling digital single at the time.",
-      "fun_fact_de": "Der Song verkaufte sich \u00fcber 16,5 Millionen Mal digital weltweit und \u00fcberholte Lady Gagas 'Poker Face' als meistverkaufte digitale Single ihrer Zeit.",
-      "fun_fact_es": "La canci\u00f3n vendi\u00f3 m\u00e1s de 16,5 millones de copias digitales en todo el mundo, superando a 'Poker Face' de Lady Gaga como el sencillo digital m\u00e1s vendido en su momento.",
-      "fun_fact_fr": "Le titre s'est vendu \u00e0 plus de 16,5 millions d'exemplaires num\u00e9riques dans le monde, d\u00e9passant 'Poker Face' de Lady Gaga comme single num\u00e9rique le plus vendu de l'\u00e9poque.",
+      "fun_fact_de": "Der Song verkaufte sich über 16,5 Millionen Mal digital weltweit und überholte Lady Gagas 'Poker Face' als meistverkaufte digitale Single ihrer Zeit.",
+      "fun_fact_es": "La canción vendió más de 16,5 millones de copias digitales en todo el mundo, superando a 'Poker Face' de Lady Gaga como el sencillo digital más vendido en su momento.",
+      "fun_fact_fr": "Le titre s'est vendu à plus de 16,5 millions d'exemplaires numériques dans le monde, dépassant 'Poker Face' de Lady Gaga comme single numérique le plus vendu de l'époque.",
       "uri_apple_music": "applemusic://track/381237322",
       "uri_youtube_music": "https://music.youtube.com/watch?v=OF04pKp-r9o",
       "uri_tidal": "tidal://track/33810622",
       "uri_deezer": "deezer://track/4764905",
       "fun_fact_nl": "Het nummer verkocht wereldwijd meer dan 16,5 miljoen digitale exemplaren, waarmee het destijds 'Poker Face' van Lady Gaga inhaalde als bestverkochte digitale single.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USRC10900433",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/381237322",
+        "de": "applemusic://track/578034258",
+        "gb": "applemusic://track/6762307317",
+        "fr": "applemusic://track/578034258",
+        "es": "applemusic://track/578034258",
+        "nl": "applemusic://track/578034258",
+        "it": "applemusic://track/896130981"
+      }
     },
     {
       "year": 2005,
@@ -1539,15 +1969,25 @@
       ],
       "awards": [],
       "fun_fact": "Sean Paul wrote the song on a laptop while sitting in a car during a rainstorm in Jamaica. It became the dancehall anthem that dominated clubs worldwide in 2006.",
-      "fun_fact_de": "Sean Paul schrieb den Song auf einem Laptop, w\u00e4hrend er bei einem Regensturm in Jamaika in einem Auto sa\u00df. Es wurde die Dancehall-Hymne, die 2006 weltweit die Clubs dominierte.",
-      "fun_fact_es": "Sean Paul escribi\u00f3 la canci\u00f3n en una laptop mientras estaba sentado en un auto durante una tormenta en Jamaica. Se convirti\u00f3 en el himno de dancehall que domin\u00f3 las discotecas del mundo en 2006.",
-      "fun_fact_fr": "Sean Paul a compos\u00e9 la chanson sur un ordinateur portable assis dans une voiture pendant un orage en Jama\u00efque. C'est devenu l'hymne dancehall qui a domin\u00e9 les clubs du monde entier en 2006.",
+      "fun_fact_de": "Sean Paul schrieb den Song auf einem Laptop, während er bei einem Regensturm in Jamaika in einem Auto saß. Es wurde die Dancehall-Hymne, die 2006 weltweit die Clubs dominierte.",
+      "fun_fact_es": "Sean Paul escribió la canción en una laptop mientras estaba sentado en un auto durante una tormenta en Jamaica. Se convirtió en el himno de dancehall que dominó las discotecas del mundo en 2006.",
+      "fun_fact_fr": "Sean Paul a composé la chanson sur un ordinateur portable assis dans une voiture pendant un orage en Jamaïque. C'est devenu l'hymne dancehall qui a dominé les clubs du monde entier en 2006.",
       "uri_apple_music": "applemusic://track/261648942",
       "uri_youtube_music": "https://music.youtube.com/watch?v=dW2MmuA1nI4",
       "uri_tidal": "tidal://track/2147358",
       "uri_deezer": "deezer://track/662729",
       "fun_fact_nl": "Sean Paul schreef het nummer op een laptop terwijl hij in een auto zat tijdens een regenbui in Jamaica. Het werd de dancehall-hymne die in 2006 wereldwijd de clubs domineerde.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USAT20505520",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1693230861",
+        "de": "applemusic://track/1693230861",
+        "gb": "applemusic://track/1725452981",
+        "fr": "applemusic://track/1725452981",
+        "es": "applemusic://track/1693230861",
+        "nl": "applemusic://track/1693230861",
+        "it": "applemusic://track/1693230861"
+      }
     },
     {
       "year": 2004,
@@ -1575,18 +2015,28 @@
       "awards_fr": [
         "BRIT Award - Meilleur groupe rock britannique"
       ],
-      "fun_fact": "The song has two distinct parts \u2014 a slow intro that abruptly changes into a fast-paced dance-rock anthem. It helped launch the mid-2000s post-punk revival movement.",
-      "fun_fact_de": "Der Song hat zwei unterschiedliche Teile \u2014 ein langsames Intro, das abrupt in eine schnelle Dance-Rock-Hymne wechselt. Er half, die Post-Punk-Revival-Bewegung der 2000er zu starten.",
-      "fun_fact_es": "La canci\u00f3n tiene dos partes distintas \u2014 una intro lenta que cambia abruptamente a un himno dance-rock r\u00e1pido. Ayud\u00f3 a lanzar el movimiento de revival post-punk de mediados de los 2000.",
-      "fun_fact_fr": "Le morceau se compose de deux parties distinctes \u2014 une intro lente qui bascule brusquement en hymne dance-rock effr\u00e9n\u00e9. Il a contribu\u00e9 \u00e0 lancer le revival post-punk du milieu des ann\u00e9es 2000.",
+      "fun_fact": "The song has two distinct parts — a slow intro that abruptly changes into a fast-paced dance-rock anthem. It helped launch the mid-2000s post-punk revival movement.",
+      "fun_fact_de": "Der Song hat zwei unterschiedliche Teile — ein langsames Intro, das abrupt in eine schnelle Dance-Rock-Hymne wechselt. Er half, die Post-Punk-Revival-Bewegung der 2000er zu starten.",
+      "fun_fact_es": "La canción tiene dos partes distintas — una intro lenta que cambia abruptamente a un himno dance-rock rápido. Ayudó a lanzar el movimiento de revival post-punk de mediados de los 2000.",
+      "fun_fact_fr": "Le morceau se compose de deux parties distinctes — une intro lente qui bascule brusquement en hymne dance-rock effréné. Il a contribué à lancer le revival post-punk du milieu des années 2000.",
       "uri_apple_music": "applemusic://track/315844084",
       "uri_youtube_music": "https://music.youtube.com/watch?v=Ijk4j-r7qPA",
       "uri_tidal": "tidal://track/3751639",
       "uri_deezer": "deezer://track/4315684",
-      "fun_fact_nl": "Het nummer heeft twee verschillende delen \u2014 een trage intro die abrupt overgaat in een snel dance-rock volkslied. Het hielp de post-punk revival-beweging van het midden van de jaren 2000 op gang te brengen.",
+      "fun_fact_nl": "Het nummer heeft twee verschillende delen — een trage intro die abrupt overgaat in een snel dance-rock volkslied. Het hielp de post-punk revival-beweging van het midden van de jaren 2000 op gang te brengen.",
       "awards_nl": [
-        "BRIT Award \u2013 Beste Britse Rockact (band)"
-      ]
+        "BRIT Award – Beste Britse Rockact (band)"
+      ],
+      "isrc": "GBCEL0300192",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/315844084",
+        "de": "applemusic://track/315844084",
+        "gb": "applemusic://track/315844084",
+        "fr": "applemusic://track/315844084",
+        "es": "applemusic://track/315844084",
+        "nl": "applemusic://track/315844084",
+        "it": "applemusic://track/315844084"
+      }
     },
     {
       "year": 2005,
@@ -1615,17 +2065,27 @@
         "Nomination aux Grammy - Meilleure performance rap d'un duo ou groupe"
       ],
       "fun_fact": "Ironically, The Game and 50 Cent recorded this collaboration just before their famous feud that split the G-Unit rap group apart.",
-      "fun_fact_de": "Ironischerweise nahmen The Game und 50 Cent diese Zusammenarbeit kurz vor ihrem ber\u00fchmten Streit auf, der die Rap-Gruppe G-Unit spaltete.",
-      "fun_fact_es": "Ir\u00f3nicamente, The Game y 50 Cent grabaron esta colaboraci\u00f3n justo antes de su famosa pelea que dividi\u00f3 al grupo de rap G-Unit.",
-      "fun_fact_fr": "Ironie du sort, The Game et 50 Cent ont enregistr\u00e9 cette collaboration juste avant leur fameuse querelle qui a fait \u00e9clater le groupe de rap G-Unit.",
+      "fun_fact_de": "Ironischerweise nahmen The Game und 50 Cent diese Zusammenarbeit kurz vor ihrem berühmten Streit auf, der die Rap-Gruppe G-Unit spaltete.",
+      "fun_fact_es": "Irónicamente, The Game y 50 Cent grabaron esta colaboración justo antes de su famosa pelea que dividió al grupo de rap G-Unit.",
+      "fun_fact_fr": "Ironie du sort, The Game et 50 Cent ont enregistré cette collaboration juste avant leur fameuse querelle qui a fait éclater le groupe de rap G-Unit.",
       "uri_apple_music": "applemusic://track/1440799195",
       "uri_youtube_music": "https://music.youtube.com/watch?v=BuMBmK5uksg",
       "uri_tidal": "tidal://track/586574",
       "uri_deezer": "deezer://track/4586924",
       "fun_fact_nl": "Ironisch genoeg namen The Game en 50 Cent deze samenwerking op vlak voor hun beroemde vete die de G-Unit-rapgroep uiteendreef.",
       "awards_nl": [
-        "Grammy-nominatie \u2013 Beste Rapprestatie door Duo of Groep"
-      ]
+        "Grammy-nominatie – Beste Rapprestatie door Duo of Groep"
+      ],
+      "isrc": "USIR10401121",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1440799195",
+        "de": "applemusic://track/1444587596",
+        "gb": "applemusic://track/1389727622",
+        "fr": "applemusic://track/1444293746",
+        "es": "applemusic://track/1440799195",
+        "nl": "applemusic://track/1444293746",
+        "it": "applemusic://track/1440799195"
+      }
     },
     {
       "year": 2009,
@@ -1648,16 +2108,26 @@
         "2x Platinum (UK)"
       ],
       "awards": [],
-      "fun_fact": "The song held the Billboard #1 for 14 consecutive weeks \u2014 the longest-running #1 of 2009. It was the first song ever to sell over 1 million digital copies in a single week.",
-      "fun_fact_de": "Der Song hielt sich 14 Wochen in Folge auf Platz 1 der Billboard-Charts. Er war der erste Song, der in einer Woche \u00fcber 1 Million digitale Exemplare verkaufte.",
-      "fun_fact_es": "La canci\u00f3n mantuvo el #1 de Billboard durante 14 semanas consecutivas. Fue la primera canci\u00f3n en vender m\u00e1s de 1 mill\u00f3n de copias digitales en una sola semana.",
-      "fun_fact_fr": "Le titre est rest\u00e9 14 semaines cons\u00e9cutives en t\u00eate du Billboard \u2014 le plus long r\u00e8gne de 2009. C'est aussi la premi\u00e8re chanson \u00e0 d\u00e9passer le million de copies num\u00e9riques vendues en une seule semaine.",
+      "fun_fact": "The song held the Billboard #1 for 14 consecutive weeks — the longest-running #1 of 2009. It was the first song ever to sell over 1 million digital copies in a single week.",
+      "fun_fact_de": "Der Song hielt sich 14 Wochen in Folge auf Platz 1 der Billboard-Charts. Er war der erste Song, der in einer Woche über 1 Million digitale Exemplare verkaufte.",
+      "fun_fact_es": "La canción mantuvo el #1 de Billboard durante 14 semanas consecutivas. Fue la primera canción en vender más de 1 millón de copias digitales en una sola semana.",
+      "fun_fact_fr": "Le titre est resté 14 semaines consécutives en tête du Billboard — le plus long règne de 2009. C'est aussi la première chanson à dépasser le million de copies numériques vendues en une seule semaine.",
       "uri_apple_music": "applemusic://track/1440769310",
       "uri_youtube_music": "https://music.youtube.com/watch?v=uSD4vsh1zDA",
       "uri_tidal": "tidal://track/3159850",
       "uri_deezer": "deezer://track/4619466",
-      "fun_fact_nl": "Het nummer stond 14 opeenvolgende weken op nummer 1 in Billboard \u2014 de langstlopende nummer 1 van 2009. Het was het eerste nummer ooit dat meer dan 1 miljoen digitale exemplaren verkocht in \u00e9\u00e9n week.",
-      "awards_nl": []
+      "fun_fact_nl": "Het nummer stond 14 opeenvolgende weken op nummer 1 in Billboard — de langstlopende nummer 1 van 2009. Het was het eerste nummer ooit dat meer dan 1 miljoen digitale exemplaren verkocht in één week.",
+      "awards_nl": [],
+      "isrc": "USUM70965169",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1593749411",
+        "de": "applemusic://track/1593749411",
+        "gb": "applemusic://track/1593749411",
+        "fr": "applemusic://track/1593749411",
+        "es": "applemusic://track/1593749411",
+        "nl": "applemusic://track/1593749411",
+        "it": "applemusic://track/1593749411"
+      }
     },
     {
       "year": 2005,
@@ -1681,22 +2151,32 @@
       ],
       "awards": [],
       "fun_fact": "The song was inspired by Isaac Slade's experience mentoring a troubled teenager at a camp. It gained massive popularity after being featured in Grey's Anatomy multiple times.",
-      "fun_fact_de": "Der Song wurde inspiriert durch Isaac Slades Erfahrung als Mentor eines schwierigen Teenagers. Er wurde durch mehrfache Verwendung in Grey's Anatomy massiv popul\u00e4r.",
-      "fun_fact_es": "La canci\u00f3n fue inspirada por la experiencia de Isaac Slade como mentor de un adolescente problem\u00e1tico. Gan\u00f3 enorme popularidad tras aparecer varias veces en Grey's Anatomy.",
-      "fun_fact_fr": "La chanson s'inspire de l'exp\u00e9rience d'Isaac Slade comme mentor d'un adolescent en difficult\u00e9 dans un camp. Elle a gagn\u00e9 une immense popularit\u00e9 apr\u00e8s ses multiples apparitions dans Grey's Anatomy.",
+      "fun_fact_de": "Der Song wurde inspiriert durch Isaac Slades Erfahrung als Mentor eines schwierigen Teenagers. Er wurde durch mehrfache Verwendung in Grey's Anatomy massiv populär.",
+      "fun_fact_es": "La canción fue inspirada por la experiencia de Isaac Slade como mentor de un adolescente problemático. Ganó enorme popularidad tras aparecer varias veces en Grey's Anatomy.",
+      "fun_fact_fr": "La chanson s'inspire de l'expérience d'Isaac Slade comme mentor d'un adolescent en difficulté dans un camp. Elle a gagné une immense popularité après ses multiples apparitions dans Grey's Anatomy.",
       "uri_apple_music": "applemusic://track/821031488",
       "uri_youtube_music": "https://music.youtube.com/watch?v=cjVQ36NhbMk",
       "uri_tidal": "tidal://track/5119488",
       "uri_deezer": "deezer://track/7674865",
-      "fun_fact_nl": "Het nummer is ge\u00efnspireerd op de ervaring van Isaac Slade met het begeleiden van een probleemtiener in een kamp. Het won aan enorme populariteit nadat het meerdere keren te horen was in Grey's Anatomy.",
-      "awards_nl": []
+      "fun_fact_nl": "Het nummer is geïnspireerd op de ervaring van Isaac Slade met het begeleiden van een probleemtiener in een kamp. Het won aan enorme populariteit nadat het meerdere keren te horen was in Grey's Anatomy.",
+      "awards_nl": [],
+      "isrc": "USSM10601178",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1741784483",
+        "de": "applemusic://track/1741784483",
+        "gb": "applemusic://track/1741784483",
+        "fr": "applemusic://track/1741784483",
+        "es": "applemusic://track/1741784483",
+        "nl": "applemusic://track/1741784483",
+        "it": "applemusic://track/1741784483"
+      }
     },
     {
       "year": 2004,
       "uri": "spotify:track:3XVBdLihbNbxUwZosxcGuJ",
       "artist": "Alicia Keys",
       "alt_artists": [
-        "Beyonc\u00e9",
+        "Beyoncé",
         "Mary J. Blige",
         "John Legend",
         "Lauryn Hill"
@@ -1715,22 +2195,32 @@
         "Grammy Award - Best R&B Song"
       ],
       "awards_fr": [
-        "Grammy Award - Meilleure performance vocale R&B f\u00e9minine",
+        "Grammy Award - Meilleure performance vocale R&B féminine",
         "Grammy Award - Meilleure chanson R&B"
       ],
       "fun_fact": "Alicia Keys wrote the song after Aaliyah's death, reflecting on what truly matters in life. The soulful piano ballad was recorded in a single session.",
-      "fun_fact_de": "Alicia Keys schrieb den Song nach Aaliyahs Tod und reflektierte dar\u00fcber, was im Leben wirklich z\u00e4hlt. Die gef\u00fchlvolle Klavierballade wurde in einer einzigen Session aufgenommen.",
-      "fun_fact_es": "Alicia Keys escribi\u00f3 la canci\u00f3n tras la muerte de Aaliyah, reflexionando sobre lo que realmente importa en la vida. La emotiva balada de piano fue grabada en una sola sesi\u00f3n.",
-      "fun_fact_fr": "Alicia Keys a \u00e9crit cette chanson apr\u00e8s la mort d'Aaliyah, en s'interrogeant sur ce qui compte vraiment dans la vie. Cette ballade soul au piano a \u00e9t\u00e9 enregistr\u00e9e en une seule session.",
+      "fun_fact_de": "Alicia Keys schrieb den Song nach Aaliyahs Tod und reflektierte darüber, was im Leben wirklich zählt. Die gefühlvolle Klavierballade wurde in einer einzigen Session aufgenommen.",
+      "fun_fact_es": "Alicia Keys escribió la canción tras la muerte de Aaliyah, reflexionando sobre lo que realmente importa en la vida. La emotiva balada de piano fue grabada en una sola sesión.",
+      "fun_fact_fr": "Alicia Keys a écrit cette chanson après la mort d'Aaliyah, en s'interrogeant sur ce qui compte vraiment dans la vie. Cette ballade soul au piano a été enregistrée en une seule session.",
       "uri_apple_music": "applemusic://track/255343130",
       "uri_youtube_music": "https://music.youtube.com/watch?v=Ju8Hr50Ckwk",
       "uri_tidal": "tidal://track/47309",
       "uri_deezer": "deezer://track/629466",
-      "fun_fact_nl": "Alicia Keys schreef het nummer na de dood van Aaliyah, reflecterend op wat echt belangrijk is in het leven. De soulful pianoballade werd in \u00e9\u00e9n sessie opgenomen.",
+      "fun_fact_nl": "Alicia Keys schreef het nummer na de dood van Aaliyah, reflecterend op wat echt belangrijk is in het leven. De soulful pianoballade werd in één sessie opgenomen.",
       "awards_nl": [
-        "Grammy Award \u2013 Beste Vrouwelijke R&B Zangprestatie",
-        "Grammy Award \u2013 Beste R&B-nummer"
-      ]
+        "Grammy Award – Beste Vrouwelijke R&B Zangprestatie",
+        "Grammy Award – Beste R&B-nummer"
+      ],
+      "isrc": "USJAY0300452",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1721921218",
+        "de": "applemusic://track/1721921218",
+        "gb": "applemusic://track/1721921218",
+        "fr": "applemusic://track/1721921218",
+        "es": "applemusic://track/1721921218",
+        "nl": "applemusic://track/1721921218",
+        "it": "applemusic://track/1721921218"
+      }
     },
     {
       "year": 2006,
@@ -1740,7 +2230,7 @@
         "Shakira",
         "Fergie",
         "Christina Aguilera",
-        "Beyonc\u00e9"
+        "Beyoncé"
       ],
       "title": "Say It Right",
       "chart_info": {
@@ -1755,14 +2245,24 @@
       "awards": [],
       "fun_fact": "Timbaland created the hypnotic beat at 4am in the studio and Nelly Furtado recorded the vocals in just two takes. It became her second #1 on the Billboard Hot 100.",
       "fun_fact_de": "Timbaland kreierte den hypnotischen Beat um 4 Uhr morgens im Studio und Nelly Furtado nahm die Vocals in nur zwei Takes auf. Es wurde ihre zweite #1 in den Billboard Hot 100.",
-      "fun_fact_es": "Timbaland cre\u00f3 el hipn\u00f3tico ritmo a las 4am en el estudio y Nelly Furtado grab\u00f3 las voces en solo dos tomas. Se convirti\u00f3 en su segundo #1 en el Billboard Hot 100.",
-      "fun_fact_fr": "Timbaland a cr\u00e9\u00e9 le beat hypnotique \u00e0 4 heures du matin en studio et Nelly Furtado a enregistr\u00e9 les voix en seulement deux prises. C'est devenu son deuxi\u00e8me num\u00e9ro 1 au Billboard Hot 100.",
+      "fun_fact_es": "Timbaland creó el hipnótico ritmo a las 4am en el estudio y Nelly Furtado grabó las voces en solo dos tomas. Se convirtió en su segundo #1 en el Billboard Hot 100.",
+      "fun_fact_fr": "Timbaland a créé le beat hypnotique à 4 heures du matin en studio et Nelly Furtado a enregistré les voix en seulement deux prises. C'est devenu son deuxième numéro 1 au Billboard Hot 100.",
       "uri_apple_music": "applemusic://track/1442464133",
       "uri_youtube_music": "https://music.youtube.com/watch?v=6JnGBs88sL0",
       "uri_tidal": "tidal://track/479944",
       "uri_deezer": "deezer://track/1151147",
-      "fun_fact_nl": "Timbaland cre\u00eberde de hypnotiserende beat om 4 uur 's nachts in de studio en Nelly Furtado nam de zang op in slechts twee takes. Het werd haar tweede nummer 1-hit in de Billboard Hot 100.",
-      "awards_nl": []
+      "fun_fact_nl": "Timbaland creëerde de hypnotiserende beat om 4 uur 's nachts in de studio en Nelly Furtado nam de zang op in slechts twee takes. Het werd haar tweede nummer 1-hit in de Billboard Hot 100.",
+      "awards_nl": [],
+      "isrc": "USUM70603368",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1623268933",
+        "de": "applemusic://track/1623268933",
+        "gb": "applemusic://track/1623268933",
+        "fr": "applemusic://track/1623268933",
+        "es": "applemusic://track/1623268933",
+        "nl": "applemusic://track/1623268933",
+        "it": "applemusic://track/1623268933"
+      }
     },
     {
       "year": 2003,
@@ -1790,17 +2290,17 @@
       "awards_fr": [
         "Grammy Award - Meilleure performance urban/alternative"
       ],
-      "fun_fact": "Andr\u00e9 3000 played all the instruments himself. The 'shake it like a Polaroid picture' lyric prompted Polaroid to issue a statement that shaking photos actually damages them.",
-      "fun_fact_de": "Andr\u00e9 3000 spielte alle Instrumente selbst. Die Textzeile 'shake it like a Polaroid picture' veranlasste Polaroid zu einer Erkl\u00e4rung, dass Sch\u00fctteln die Fotos tats\u00e4chlich besch\u00e4digt.",
-      "fun_fact_es": "Andr\u00e9 3000 toc\u00f3 todos los instrumentos \u00e9l mismo. La letra 'shake it like a Polaroid picture' llev\u00f3 a Polaroid a emitir un comunicado diciendo que agitar las fotos en realidad las da\u00f1a.",
-      "fun_fact_fr": "Andr\u00e9 3000 a jou\u00e9 tous les instruments lui-m\u00eame. La r\u00e9plique 'shake it like a Polaroid picture' a pouss\u00e9 Polaroid \u00e0 publier un communiqu\u00e9 expliquant que secouer les photos les endommage en r\u00e9alit\u00e9.",
+      "fun_fact": "André 3000 played all the instruments himself. The 'shake it like a Polaroid picture' lyric prompted Polaroid to issue a statement that shaking photos actually damages them.",
+      "fun_fact_de": "André 3000 spielte alle Instrumente selbst. Die Textzeile 'shake it like a Polaroid picture' veranlasste Polaroid zu einer Erklärung, dass Schütteln die Fotos tatsächlich beschädigt.",
+      "fun_fact_es": "André 3000 tocó todos los instrumentos él mismo. La letra 'shake it like a Polaroid picture' llevó a Polaroid a emitir un comunicado diciendo que agitar las fotos en realidad las daña.",
+      "fun_fact_fr": "André 3000 a joué tous les instruments lui-même. La réplique 'shake it like a Polaroid picture' a poussé Polaroid à publier un communiqué expliquant que secouer les photos les endommage en réalité.",
       "uri_apple_music": "",
       "uri_youtube_music": "https://music.youtube.com/watch?v=PWgvGjAhvIw",
       "uri_tidal": "tidal://track/1772295",
       "uri_deezer": "deezer://track/628266",
-      "fun_fact_nl": "Andr\u00e9 3000 speelde alle instrumenten zelf. De tekst 'shake it like a Polaroid picture' zette Polaroid ertoe aan een verklaring af te geven dat het schudden van foto's ze in feite beschadigt.",
+      "fun_fact_nl": "André 3000 speelde alle instrumenten zelf. De tekst 'shake it like a Polaroid picture' zette Polaroid ertoe aan een verklaring af te geven dat het schudden van foto's ze in feite beschadigt.",
       "awards_nl": [
-        "Grammy Award \u2013 Beste Urban/Alternatieve Prestatie"
+        "Grammy Award – Beste Urban/Alternatieve Prestatie"
       ]
     },
     {
@@ -1824,15 +2324,25 @@
       ],
       "awards": [],
       "fun_fact": "The song's music video, featuring the band performing on a cliff, required filming at a real coastal cliff edge. Lead singer Scott Stapp said the song was about finding hope.",
-      "fun_fact_de": "Das Musikvideo, das die Band auf einer Klippe zeigt, wurde an einer echten K\u00fcstenklippe gedreht. S\u00e4nger Scott Stapp sagte, der Song handle vom Finden von Hoffnung.",
-      "fun_fact_es": "El video musical, con la banda actuando en un acantilado, fue filmado en un acantilado costero real. El cantante Scott Stapp dijo que la canci\u00f3n trata sobre encontrar esperanza.",
-      "fun_fact_fr": "Le clip, montrant le groupe jouant au bord d'une falaise, a n\u00e9cessit\u00e9 un tournage sur une v\u00e9ritable falaise c\u00f4ti\u00e8re. Le chanteur Scott Stapp a d\u00e9clar\u00e9 que la chanson parlait de trouver l'espoir.",
+      "fun_fact_de": "Das Musikvideo, das die Band auf einer Klippe zeigt, wurde an einer echten Küstenklippe gedreht. Sänger Scott Stapp sagte, der Song handle vom Finden von Hoffnung.",
+      "fun_fact_es": "El video musical, con la banda actuando en un acantilado, fue filmado en un acantilado costero real. El cantante Scott Stapp dijo que la canción trata sobre encontrar esperanza.",
+      "fun_fact_fr": "Le clip, montrant le groupe jouant au bord d'une falaise, a nécessité un tournage sur une véritable falaise côtière. Le chanteur Scott Stapp a déclaré que la chanson parlait de trouver l'espoir.",
       "uri_apple_music": "applemusic://track/1440738795",
       "uri_youtube_music": "https://music.youtube.com/watch?v=qnkuBUAwfe0",
       "uri_tidal": "tidal://track/32074200",
       "uri_deezer": "deezer://track/80274648",
       "fun_fact_nl": "De videoclip van het nummer, waarin de band op een klif optreedt, moest gefilmd worden aan een echte klifkust. Zanger Scott Stapp zei dat het nummer ging over het vinden van hoop.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USWU30107505",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/6762152911",
+        "de": "applemusic://track/6762152911",
+        "gb": "applemusic://track/6762152911",
+        "fr": "applemusic://track/6762152911",
+        "es": "applemusic://track/6762152911",
+        "nl": "applemusic://track/6762152911",
+        "it": "applemusic://track/6762152911"
+      }
     },
     {
       "year": 2004,
@@ -1855,15 +2365,25 @@
       ],
       "awards": [],
       "fun_fact": "Originally featured Lauryn Hill's vocals sampled from 'Mystery of Iniquity', but due to clearance issues, Syleena Johnson re-sang the hook, actually improving the song's accessibility.",
-      "fun_fact_de": "Urspr\u00fcnglich enthielt der Song Lauryn Hills Vocals aus 'Mystery of Iniquity', aber wegen Lizenzproblemen sang Syleena Johnson den Hook neu, was die Zug\u00e4nglichkeit des Songs verbesserte.",
-      "fun_fact_es": "Originalmente inclu\u00eda las voces de Lauryn Hill de 'Mystery of Iniquity', pero por problemas de licencia, Syleena Johnson volvi\u00f3 a cantar el gancho, mejorando la accesibilidad de la canci\u00f3n.",
-      "fun_fact_fr": "Le titre comportait \u00e0 l'origine les voix de Lauryn Hill sampl\u00e9es de 'Mystery of Iniquity', mais des probl\u00e8mes de droits ont conduit Syleena Johnson \u00e0 r\u00e9enregistrer le refrain, am\u00e9liorant finalement l'accessibilit\u00e9 du morceau.",
+      "fun_fact_de": "Ursprünglich enthielt der Song Lauryn Hills Vocals aus 'Mystery of Iniquity', aber wegen Lizenzproblemen sang Syleena Johnson den Hook neu, was die Zugänglichkeit des Songs verbesserte.",
+      "fun_fact_es": "Originalmente incluía las voces de Lauryn Hill de 'Mystery of Iniquity', pero por problemas de licencia, Syleena Johnson volvió a cantar el gancho, mejorando la accesibilidad de la canción.",
+      "fun_fact_fr": "Le titre comportait à l'origine les voix de Lauryn Hill samplées de 'Mystery of Iniquity', mais des problèmes de droits ont conduit Syleena Johnson à réenregistrer le refrain, améliorant finalement l'accessibilité du morceau.",
       "uri_apple_music": "applemusic://track/1412873019",
       "uri_youtube_music": "https://music.youtube.com/watch?v=8kyWDhB_QeI",
       "uri_tidal": "tidal://track/92099361",
       "uri_deezer": "deezer://track/528869461",
       "fun_fact_nl": "Bevatte oorspronkelijk vocals van Lauryn Hill gesampled uit 'Mystery of Iniquity', maar vanwege rechtenkwesties zong Syleena Johnson de hook opnieuw in, wat de toegankelijkheid van het nummer ten goede kwam.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USDJ20301703",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1442284391",
+        "de": "applemusic://track/1442284391",
+        "gb": "applemusic://track/1442284391",
+        "fr": "applemusic://track/1442284391",
+        "es": "applemusic://track/1442284391",
+        "nl": "applemusic://track/1444315281",
+        "it": "applemusic://track/1444315281"
+      }
     },
     {
       "year": 2003,
@@ -1887,15 +2407,25 @@
       ],
       "awards": [],
       "fun_fact": "The song sold over 1 million copies in its first week and the Dr. Dre-produced beat was originally intended for Eminem's album. It became the most listened-to song on 50's birthday each year.",
-      "fun_fact_de": "Der Song verkaufte sich in der ersten Woche \u00fcber 1 Million Mal und der von Dr. Dre produzierte Beat war urspr\u00fcnglich f\u00fcr Eminems Album gedacht.",
-      "fun_fact_es": "La canci\u00f3n vendi\u00f3 m\u00e1s de 1 mill\u00f3n de copias en su primera semana y el beat producido por Dr. Dre estaba originalmente destinado al \u00e1lbum de Eminem.",
-      "fun_fact_fr": "Le titre s'est vendu \u00e0 plus d'un million d'exemplaires d\u00e8s la premi\u00e8re semaine, et le beat produit par Dr. Dre \u00e9tait initialement destin\u00e9 \u00e0 l'album d'Eminem. C'est devenu le morceau le plus \u00e9cout\u00e9 le jour de l'anniversaire de 50 Cent chaque ann\u00e9e.",
+      "fun_fact_de": "Der Song verkaufte sich in der ersten Woche über 1 Million Mal und der von Dr. Dre produzierte Beat war ursprünglich für Eminems Album gedacht.",
+      "fun_fact_es": "La canción vendió más de 1 millón de copias en su primera semana y el beat producido por Dr. Dre estaba originalmente destinado al álbum de Eminem.",
+      "fun_fact_fr": "Le titre s'est vendu à plus d'un million d'exemplaires dès la première semaine, et le beat produit par Dr. Dre était initialement destiné à l'album d'Eminem. C'est devenu le morceau le plus écouté le jour de l'anniversaire de 50 Cent chaque année.",
       "uri_apple_music": "applemusic://track/1440841857",
       "uri_youtube_music": "https://music.youtube.com/watch?v=5qm8PH4xAss",
       "uri_tidal": "tidal://track/607355",
       "uri_deezer": "deezer://track/1141668",
       "fun_fact_nl": "Het nummer verkocht in de eerste week meer dan 1 miljoen exemplaren en de door Dr. Dre geproduceerde beat was oorspronkelijk bedoeld voor het album van Eminem. Het werd elk jaar het meest beluisterde nummer op de verjaardag van 50 Cent.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USIR10300033",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1443208134",
+        "de": "applemusic://track/1443208134",
+        "gb": "applemusic://track/1443208134",
+        "fr": "applemusic://track/1443208134",
+        "es": "applemusic://track/1443208134",
+        "nl": "applemusic://track/1443208134",
+        "it": "applemusic://track/1443208134"
+      }
     },
     {
       "year": 2006,
@@ -1919,15 +2449,25 @@
       ],
       "awards": [],
       "fun_fact": "Amy wrote the song in just one afternoon with Mark Ronson about her on-again, off-again relationship with Blake Fielder-Civil. The album of the same name sold over 16 million copies.",
-      "fun_fact_de": "Amy schrieb den Song an einem einzigen Nachmittag mit Mark Ronson \u00fcber ihre wechselhafte Beziehung mit Blake Fielder-Civil. Das gleichnamige Album verkaufte sich \u00fcber 16 Millionen Mal.",
-      "fun_fact_es": "Amy escribi\u00f3 la canci\u00f3n en una sola tarde con Mark Ronson sobre su relaci\u00f3n intermitente con Blake Fielder-Civil. El \u00e1lbum del mismo nombre vendi\u00f3 m\u00e1s de 16 millones de copias.",
-      "fun_fact_fr": "Amy a \u00e9crit la chanson en un seul apr\u00e8s-midi avec Mark Ronson, sur sa relation tumultueuse avec Blake Fielder-Civil. L'album du m\u00eame nom s'est vendu \u00e0 plus de 16 millions d'exemplaires.",
+      "fun_fact_de": "Amy schrieb den Song an einem einzigen Nachmittag mit Mark Ronson über ihre wechselhafte Beziehung mit Blake Fielder-Civil. Das gleichnamige Album verkaufte sich über 16 Millionen Mal.",
+      "fun_fact_es": "Amy escribió la canción en una sola tarde con Mark Ronson sobre su relación intermitente con Blake Fielder-Civil. El álbum del mismo nombre vendió más de 16 millones de copias.",
+      "fun_fact_fr": "Amy a écrit la chanson en un seul après-midi avec Mark Ronson, sur sa relation tumultueuse avec Blake Fielder-Civil. L'album du même nom s'est vendu à plus de 16 millions d'exemplaires.",
       "uri_apple_music": "applemusic://track/1422677785",
       "uri_youtube_music": "https://music.youtube.com/watch?v=rbBbQ-jldvQ",
       "uri_tidal": "tidal://track/77661295",
       "uri_deezer": "deezer://track/2176856",
-      "fun_fact_nl": "Amy schreef het nummer in slechts \u00e9\u00e9n middag met Mark Ronson over haar knipperlichtrelatie met Blake Fielder-Civil. Het gelijknamige album verkocht meer dan 16 miljoen exemplaren.",
-      "awards_nl": []
+      "fun_fact_nl": "Amy schreef het nummer in slechts één middag met Mark Ronson over haar knipperlichtrelatie met Blake Fielder-Civil. Het gelijknamige album verkocht meer dan 16 miljoen exemplaren.",
+      "awards_nl": [],
+      "isrc": "GBUM70604698",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1440861259",
+        "de": "applemusic://track/1452364277",
+        "gb": "applemusic://track/1440779171",
+        "fr": "applemusic://track/1440779171",
+        "es": "applemusic://track/1440779171",
+        "nl": "applemusic://track/1440779171",
+        "it": "applemusic://track/1440779171"
+      }
     },
     {
       "year": 2000,
@@ -1955,18 +2495,28 @@
       "awards_fr": [
         "Grammy Award - Meilleure performance rap d'un duo ou groupe"
       ],
-      "fun_fact": "Andr\u00e9 3000 wrote the song as an apology to Erykah Badu's mother after their breakup. Badu's mother later said she appreciated the song's sincerity.",
-      "fun_fact_de": "Andr\u00e9 3000 schrieb den Song als Entschuldigung an Erykah Badus Mutter nach ihrer Trennung. Badus Mutter sagte sp\u00e4ter, sie sch\u00e4tze die Aufrichtigkeit des Songs.",
-      "fun_fact_es": "Andr\u00e9 3000 escribi\u00f3 la canci\u00f3n como disculpa a la madre de Erykah Badu tras su ruptura. La madre de Badu dijo despu\u00e9s que apreciaba la sinceridad de la canci\u00f3n.",
-      "fun_fact_fr": "Andr\u00e9 3000 a \u00e9crit cette chanson pour s'excuser aupr\u00e8s de la m\u00e8re d'Erykah Badu apr\u00e8s leur rupture. La m\u00e8re de Badu a ensuite d\u00e9clar\u00e9 qu'elle appr\u00e9ciait la sinc\u00e9rit\u00e9 du morceau.",
+      "fun_fact": "André 3000 wrote the song as an apology to Erykah Badu's mother after their breakup. Badu's mother later said she appreciated the song's sincerity.",
+      "fun_fact_de": "André 3000 schrieb den Song als Entschuldigung an Erykah Badus Mutter nach ihrer Trennung. Badus Mutter sagte später, sie schätze die Aufrichtigkeit des Songs.",
+      "fun_fact_es": "André 3000 escribió la canción como disculpa a la madre de Erykah Badu tras su ruptura. La madre de Badu dijo después que apreciaba la sinceridad de la canción.",
+      "fun_fact_fr": "André 3000 a écrit cette chanson pour s'excuser auprès de la mère d'Erykah Badu après leur rupture. La mère de Badu a ensuite déclaré qu'elle appréciait la sincérité du morceau.",
       "uri_apple_music": "applemusic://track/255836745",
       "uri_youtube_music": "https://music.youtube.com/watch?v=MYxAiK6VnXw",
       "uri_tidal": "tidal://track/514422",
       "uri_deezer": "deezer://track/963042",
-      "fun_fact_nl": "Andr\u00e9 3000 schreef het nummer als verontschuldiging aan de moeder van Erykah Badu na hun breuk. Badu's moeder zei later dat ze de oprechtheid van het nummer waardeerde.",
+      "fun_fact_nl": "André 3000 schreef het nummer als verontschuldiging aan de moeder van Erykah Badu na hun breuk. Badu's moeder zei later dat ze de oprechtheid van het nummer waardeerde.",
       "awards_nl": [
-        "Grammy Award \u2013 Beste Rapprestatie door Duo of Groep"
-      ]
+        "Grammy Award – Beste Rapprestatie door Duo of Groep"
+      ],
+      "isrc": "USLF20000357",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1741741469",
+        "de": "applemusic://track/1741741469",
+        "gb": "applemusic://track/1741741469",
+        "fr": "applemusic://track/1741741469",
+        "es": "applemusic://track/1741741469",
+        "nl": "applemusic://track/1741741469",
+        "it": "applemusic://track/1741741469"
+      }
     },
     {
       "year": 2006,
@@ -1990,15 +2540,25 @@
       ],
       "awards": [],
       "fun_fact": "The song spent a record-breaking 166 weeks on the UK Singles Chart and was voted the UK's most popular song of the 21st century on a BBC Radio poll.",
-      "fun_fact_de": "Der Song verbrachte rekordverd\u00e4chtige 166 Wochen in den UK Singles Charts und wurde in einer BBC-Radio-Umfrage zum beliebtesten Song des 21. Jahrhunderts in Gro\u00dfbritannien gew\u00e4hlt.",
-      "fun_fact_es": "La canci\u00f3n pas\u00f3 un r\u00e9cord de 166 semanas en las listas de sencillos del Reino Unido y fue votada como la canci\u00f3n m\u00e1s popular del siglo XXI en una encuesta de BBC Radio.",
-      "fun_fact_fr": "Le titre a pass\u00e9 un record de 166 semaines dans le classement des singles britanniques et a \u00e9t\u00e9 \u00e9lu chanson la plus populaire du XXIe si\u00e8cle au Royaume-Uni lors d'un sondage BBC Radio.",
+      "fun_fact_de": "Der Song verbrachte rekordverdächtige 166 Wochen in den UK Singles Charts und wurde in einer BBC-Radio-Umfrage zum beliebtesten Song des 21. Jahrhunderts in Großbritannien gewählt.",
+      "fun_fact_es": "La canción pasó un récord de 166 semanas en las listas de sencillos del Reino Unido y fue votada como la canción más popular del siglo XXI en una encuesta de BBC Radio.",
+      "fun_fact_fr": "Le titre a passé un record de 166 semaines dans le classement des singles britanniques et a été élu chanson la plus populaire du XXIe siècle au Royaume-Uni lors d'un sondage BBC Radio.",
       "uri_apple_music": "applemusic://track/1440758864",
       "uri_youtube_music": "https://music.youtube.com/watch?v=GemKqzILV4w",
       "uri_tidal": "tidal://track/4037643",
       "uri_deezer": "deezer://track/1576190",
       "fun_fact_nl": "Het nummer stond een recordbrekende 166 weken in de UK Singles Chart en werd in een peiling van BBC Radio verkozen tot het populairste nummer van de 21e eeuw in het VK.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBUM70600345",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1440758864",
+        "de": "applemusic://track/1444394470",
+        "gb": "applemusic://track/1440758864",
+        "fr": "applemusic://track/1440758864",
+        "es": "applemusic://track/1444394470",
+        "nl": "applemusic://track/1444394470",
+        "it": "applemusic://track/1444394470"
+      }
     },
     {
       "year": 2008,
@@ -2022,15 +2582,25 @@
       ],
       "awards": [],
       "fun_fact": "Lady Gaga wrote the song in 10 minutes while hungover. It was her debut single and took nearly a year to slowly climb to #1, launching her career as a global superstar.",
-      "fun_fact_de": "Lady Gaga schrieb den Song in 10 Minuten mit Kater. Es war ihre Deb\u00fctsingle und brauchte fast ein Jahr, um langsam auf Platz 1 zu klettern.",
-      "fun_fact_es": "Lady Gaga escribi\u00f3 la canci\u00f3n en 10 minutos con resaca. Fue su sencillo debut y tard\u00f3 casi un a\u00f1o en subir lentamente al #1, lanzando su carrera como superestrella mundial.",
-      "fun_fact_fr": "Lady Gaga a \u00e9crit la chanson en 10 minutes avec la gueule de bois. C'\u00e9tait son premier single, et il a mis presque un an \u00e0 grimper lentement jusqu'au sommet, lan\u00e7ant sa carri\u00e8re de superstar mondiale.",
+      "fun_fact_de": "Lady Gaga schrieb den Song in 10 Minuten mit Kater. Es war ihre Debütsingle und brauchte fast ein Jahr, um langsam auf Platz 1 zu klettern.",
+      "fun_fact_es": "Lady Gaga escribió la canción en 10 minutos con resaca. Fue su sencillo debut y tardó casi un año en subir lentamente al #1, lanzando su carrera como superestrella mundial.",
+      "fun_fact_fr": "Lady Gaga a écrit la chanson en 10 minutes avec la gueule de bois. C'était son premier single, et il a mis presque un an à grimper lentement jusqu'au sommet, lançant sa carrière de superstar mondiale.",
       "uri_apple_music": "applemusic://track/1445006767",
       "uri_youtube_music": "https://music.youtube.com/watch?v=2Abk1jAONjw",
       "uri_tidal": "tidal://track/77707016",
       "uri_deezer": "deezer://track/4709947",
-      "fun_fact_nl": "Lady Gaga schreef het nummer in 10 minuten terwijl ze een kater had. Het was haar debuutsingle en het duurde bijna een jaar om langzaam naar nummer 1 te klimmen, wat haar carri\u00e8re als wereldwijde superster lanceerde.",
-      "awards_nl": []
+      "fun_fact_nl": "Lady Gaga schreef het nummer in 10 minuten terwijl ze een kater had. Het was haar debuutsingle en het duurde bijna een jaar om langzaam naar nummer 1 te klimmen, wat haar carrière als wereldwijde superster lanceerde.",
+      "awards_nl": [],
+      "isrc": "USUM70807646",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1690259319",
+        "de": "applemusic://track/1690259319",
+        "gb": "applemusic://track/1690259319",
+        "fr": "applemusic://track/1690259319",
+        "es": "applemusic://track/1690259319",
+        "nl": "applemusic://track/1690259319",
+        "it": "applemusic://track/1690259319"
+      }
     },
     {
       "year": 2009,
@@ -2054,15 +2624,25 @@
       ],
       "awards": [],
       "fun_fact": "Iyaz, born Keidran Jones from the British Virgin Islands, was discovered on MySpace by Sean Kingston's producer. The song became one of the catchiest one-hit wonders of the era.",
-      "fun_fact_de": "Iyaz, geboren als Keidran Jones auf den Britischen Jungferninseln, wurde auf MySpace von Sean Kingstons Produzenten entdeckt. Der Song wurde einer der eing\u00e4ngigsten One-Hit-Wonder der \u00c4ra.",
-      "fun_fact_es": "Iyaz, nacido como Keidran Jones en las Islas V\u00edrgenes Brit\u00e1nicas, fue descubierto en MySpace por el productor de Sean Kingston. La canci\u00f3n se convirti\u00f3 en uno de los \u00e9xitos \u00fanicos m\u00e1s pegadizos de la era.",
-      "fun_fact_fr": "Iyaz, n\u00e9 Keidran Jones aux \u00celes Vierges britanniques, a \u00e9t\u00e9 d\u00e9couvert sur MySpace par le producteur de Sean Kingston. Le titre est devenu l'un des tubes \u00e9ph\u00e9m\u00e8res les plus ent\u00eatants de l'\u00e9poque.",
+      "fun_fact_de": "Iyaz, geboren als Keidran Jones auf den Britischen Jungferninseln, wurde auf MySpace von Sean Kingstons Produzenten entdeckt. Der Song wurde einer der eingängigsten One-Hit-Wonder der Ära.",
+      "fun_fact_es": "Iyaz, nacido como Keidran Jones en las Islas Vírgenes Británicas, fue descubierto en MySpace por el productor de Sean Kingston. La canción se convirtió en uno de los éxitos únicos más pegadizos de la era.",
+      "fun_fact_fr": "Iyaz, né Keidran Jones aux Îles Vierges britanniques, a été découvert sur MySpace par le producteur de Sean Kingston. Le titre est devenu l'un des tubes éphémères les plus entêtants de l'époque.",
       "uri_apple_music": "applemusic://track/326644034",
       "uri_youtube_music": "https://music.youtube.com/watch?v=4FqGpT3yhUI",
       "uri_tidal": "tidal://track/3069302",
       "uri_deezer": "deezer://track/6276158",
       "fun_fact_nl": "Iyaz, geboren als Keidran Jones op de Britse Maagdeneilanden, werd op MySpace ontdekt door de producent van Sean Kingston. Het nummer werd een van de meest aanstekelijke eendagsvliegen van dat tijdperk.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USRE10901161",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1722424944",
+        "de": "applemusic://track/1339644575",
+        "gb": "applemusic://track/1339644575",
+        "fr": "applemusic://track/1339644575",
+        "es": "applemusic://track/1339644575",
+        "nl": "applemusic://track/1469877173",
+        "it": "applemusic://track/1339644575"
+      }
     },
     {
       "year": 2001,
@@ -2070,7 +2650,7 @@
       "artist": "Mary J. Blige",
       "alt_artists": [
         "Alicia Keys",
-        "Beyonc\u00e9",
+        "Beyoncé",
         "Janet Jackson",
         "Lauryn Hill"
       ],
@@ -2088,20 +2668,30 @@
         "Grammy Award - Best Female R&B Vocal Performance"
       ],
       "awards_fr": [
-        "Grammy Award - Meilleure performance vocale R&B f\u00e9minine"
+        "Grammy Award - Meilleure performance vocale R&B féminine"
       ],
       "fun_fact": "Dr. Dre produced the track and Mary J. Blige recorded her vocals in a single studio session. It became her first and only #1 hit on the Billboard Hot 100.",
       "fun_fact_de": "Dr. Dre produzierte den Track und Mary J. Blige nahm ihre Vocals in einer einzigen Studio-Session auf. Es wurde ihr einziger #1-Hit in den Billboard Hot 100.",
-      "fun_fact_es": "Dr. Dre produjo el tema y Mary J. Blige grab\u00f3 sus voces en una sola sesi\u00f3n de estudio. Se convirti\u00f3 en su primer y \u00fanico #1 en el Billboard Hot 100.",
-      "fun_fact_fr": "Dr. Dre a produit le morceau et Mary J. Blige a enregistr\u00e9 ses voix en une seule session studio. C'est devenu son premier et unique num\u00e9ro 1 au Billboard Hot 100.",
+      "fun_fact_es": "Dr. Dre produjo el tema y Mary J. Blige grabó sus voces en una sola sesión de estudio. Se convirtió en su primer y único #1 en el Billboard Hot 100.",
+      "fun_fact_fr": "Dr. Dre a produit le morceau et Mary J. Blige a enregistré ses voix en une seule session studio. C'est devenu son premier et unique numéro 1 au Billboard Hot 100.",
       "uri_apple_music": "applemusic://track/1440817530",
       "uri_youtube_music": "https://music.youtube.com/watch?v=znlFu_lemsU",
       "uri_tidal": "tidal://track/35652987",
       "uri_deezer": "deezer://track/1161679",
-      "fun_fact_nl": "Dr. Dre produceerde de track en Mary J. Blige nam haar vocals op in \u00e9\u00e9n studiosessie. Het werd haar eerste en enige nummer 1-hit in de Billboard Hot 100.",
+      "fun_fact_nl": "Dr. Dre produceerde de track en Mary J. Blige nam haar vocals op in één studiosessie. Het werd haar eerste en enige nummer 1-hit in de Billboard Hot 100.",
       "awards_nl": [
-        "Grammy Award \u2013 Beste Vrouwelijke R&B Zangprestatie"
-      ]
+        "Grammy Award – Beste Vrouwelijke R&B Zangprestatie"
+      ],
+      "isrc": "USMC10111369",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1691778424",
+        "de": "applemusic://track/1691778424",
+        "gb": "applemusic://track/1691778424",
+        "fr": "applemusic://track/1691778424",
+        "es": "applemusic://track/1691778424",
+        "nl": "applemusic://track/1691778424",
+        "it": "applemusic://track/1691778424"
+      }
     },
     {
       "year": 2009,
@@ -2124,16 +2714,26 @@
         "Platinum (UK)"
       ],
       "awards": [],
-      "fun_fact": "The song samples Dead or Alive's 'You Spin Me Round (Like a Record)' and sold 636,000 digital copies in its first week \u2014 a record at the time for digital single sales.",
-      "fun_fact_de": "Der Song sampelt Dead or Alives 'You Spin Me Round (Like a Record)' und verkaufte sich in der ersten Woche 636.000 Mal digital \u2014 ein Rekord f\u00fcr digitale Single-Verk\u00e4ufe.",
-      "fun_fact_es": "La canci\u00f3n samplea 'You Spin Me Round (Like a Record)' de Dead or Alive y vendi\u00f3 636.000 copias digitales en su primera semana \u2014 un r\u00e9cord de ventas digitales en su momento.",
-      "fun_fact_fr": "Le titre sample 'You Spin Me Round (Like a Record)' de Dead or Alive et s'est vendu \u00e0 636 000 exemplaires num\u00e9riques d\u00e8s la premi\u00e8re semaine \u2014 un record \u00e0 l'\u00e9poque pour les ventes de singles num\u00e9riques.",
+      "fun_fact": "The song samples Dead or Alive's 'You Spin Me Round (Like a Record)' and sold 636,000 digital copies in its first week — a record at the time for digital single sales.",
+      "fun_fact_de": "Der Song sampelt Dead or Alives 'You Spin Me Round (Like a Record)' und verkaufte sich in der ersten Woche 636.000 Mal digital — ein Rekord für digitale Single-Verkäufe.",
+      "fun_fact_es": "La canción samplea 'You Spin Me Round (Like a Record)' de Dead or Alive y vendió 636.000 copias digitales en su primera semana — un récord de ventas digitales en su momento.",
+      "fun_fact_fr": "Le titre sample 'You Spin Me Round (Like a Record)' de Dead or Alive et s'est vendu à 636 000 exemplaires numériques dès la première semaine — un record à l'époque pour les ventes de singles numériques.",
       "uri_apple_music": "applemusic://track/1826847228",
       "uri_youtube_music": "https://music.youtube.com/watch?v=CcCw1ggftuQ",
       "uri_tidal": "tidal://track/3086041",
       "uri_deezer": "deezer://track/4162078",
-      "fun_fact_nl": "Het nummer bevat een sample van Dead or Alive's 'You Spin Me Round (Like a Record)' en verkocht 636.000 digitale exemplaren in de eerste week \u2014 een record destijds voor de verkoop van digitale singles.",
-      "awards_nl": []
+      "fun_fact_nl": "Het nummer bevat een sample van Dead or Alive's 'You Spin Me Round (Like a Record)' en verkocht 636.000 digitale exemplaren in de eerste week — een record destijds voor de verkoop van digitale singles.",
+      "awards_nl": [],
+      "isrc": "USAT20900156",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1849868308",
+        "de": "applemusic://track/1458997230",
+        "gb": "applemusic://track/1849868308",
+        "fr": "applemusic://track/1849868308",
+        "es": "applemusic://track/1849868308",
+        "nl": "applemusic://track/1458997230",
+        "it": "applemusic://track/1849868308"
+      }
     },
     {
       "year": 2007,
@@ -2163,16 +2763,26 @@
       ],
       "fun_fact": "The song famously samples Daft Punk's 'Harder, Better, Faster, Stronger' and its futuristic music video was inspired by the anime film Akira.",
       "fun_fact_de": "Der Song sampelt Daft Punks 'Harder, Better, Faster, Stronger' und sein futuristisches Musikvideo wurde vom Anime-Film Akira inspiriert.",
-      "fun_fact_es": "La canci\u00f3n samplea 'Harder, Better, Faster, Stronger' de Daft Punk y su video musical futurista fue inspirado por la pel\u00edcula de anime Akira.",
-      "fun_fact_fr": "Le morceau sample le c\u00e9l\u00e8bre 'Harder, Better, Faster, Stronger' de Daft Punk, et son clip futuriste s'inspire du film d'animation japonais Akira.",
+      "fun_fact_es": "La canción samplea 'Harder, Better, Faster, Stronger' de Daft Punk y su video musical futurista fue inspirado por la película de anime Akira.",
+      "fun_fact_fr": "Le morceau sample le célèbre 'Harder, Better, Faster, Stronger' de Daft Punk, et son clip futuriste s'inspire du film d'animation japonais Akira.",
       "uri_apple_music": "applemusic://track/1451902446",
       "uri_youtube_music": "https://music.youtube.com/watch?v=PsO6ZnUZI0g",
       "uri_tidal": "tidal://track/103805726",
       "uri_deezer": "deezer://track/1178682",
-      "fun_fact_nl": "Het nummer bevat op beroemde wijze een sample van Daft Punk's 'Harder, Better, Faster, Stronger' en de futuristische videoclip was ge\u00efnspireerd op de animefilm Akira.",
+      "fun_fact_nl": "Het nummer bevat op beroemde wijze een sample van Daft Punk's 'Harder, Better, Faster, Stronger' en de futuristische videoclip was geïnspireerd op de animefilm Akira.",
       "awards_nl": [
-        "Grammy Award \u2013 Beste Rap Soloprestatie"
-      ]
+        "Grammy Award – Beste Rap Soloprestatie"
+      ],
+      "isrc": "USUM70741299",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1443830216",
+        "de": "applemusic://track/1445288542",
+        "gb": "applemusic://track/1443830216",
+        "fr": "applemusic://track/1443830216",
+        "es": "applemusic://track/1443830216",
+        "nl": "applemusic://track/1451902446",
+        "it": "applemusic://track/1443830216"
+      }
     },
     {
       "year": 2007,
@@ -2196,15 +2806,25 @@
       ],
       "awards": [],
       "fun_fact": "The band wrote the song while still in college at Wesleyan University. The controversial music video featuring a crying toddler led to the child's mother filing a lawsuit.",
-      "fun_fact_de": "Die Band schrieb den Song noch w\u00e4hrend ihres Studiums an der Wesleyan University. Das kontroverse Musikvideo mit einem weinenden Kleinkind f\u00fchrte zu einer Klage der Mutter des Kindes.",
-      "fun_fact_es": "La banda escribi\u00f3 la canci\u00f3n mientras a\u00fan estaban en la universidad Wesleyan. El controvertido video musical con un ni\u00f1o llorando llev\u00f3 a la madre del ni\u00f1o a presentar una demanda.",
-      "fun_fact_fr": "Le groupe a \u00e9crit la chanson alors qu'ils \u00e9taient encore \u00e9tudiants \u00e0 l'universit\u00e9 Wesleyan. Le clip controvers\u00e9 mettant en sc\u00e8ne un bambin en pleurs a conduit la m\u00e8re de l'enfant \u00e0 intenter un proc\u00e8s.",
+      "fun_fact_de": "Die Band schrieb den Song noch während ihres Studiums an der Wesleyan University. Das kontroverse Musikvideo mit einem weinenden Kleinkind führte zu einer Klage der Mutter des Kindes.",
+      "fun_fact_es": "La banda escribió la canción mientras aún estaban en la universidad Wesleyan. El controvertido video musical con un niño llorando llevó a la madre del niño a presentar una demanda.",
+      "fun_fact_fr": "Le groupe a écrit la chanson alors qu'ils étaient encore étudiants à l'université Wesleyan. Le clip controversé mettant en scène un bambin en pleurs a conduit la mère de l'enfant à intenter un procès.",
       "uri_apple_music": "applemusic://track/264720124",
       "uri_youtube_music": "https://music.youtube.com/watch?v=fe4EK4HSPkI",
       "uri_tidal": "tidal://track/1317019",
       "uri_deezer": "deezer://track/536485",
-      "fun_fact_nl": "De band schreef het nummer toen ze nog op de universiteit van Wesleyan zaten. De controversi\u00eble videoclip met een huilende peuter leidde ertoe dat de moeder van het kind een rechtszaak aanspande.",
-      "awards_nl": []
+      "fun_fact_nl": "De band schreef het nummer toen ze nog op de universiteit van Wesleyan zaten. De controversiële videoclip met een huilende peuter leidde ertoe dat de moeder van het kind een rechtszaak aanspande.",
+      "awards_nl": [],
+      "isrc": "USSM10702135",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/284997740",
+        "de": "applemusic://track/284997740",
+        "gb": "applemusic://track/284997740",
+        "fr": "applemusic://track/284997740",
+        "es": "applemusic://track/284997740",
+        "nl": "applemusic://track/284997740",
+        "it": "applemusic://track/284997740"
+      }
     },
     {
       "year": 2000,
@@ -2227,15 +2847,25 @@
       ],
       "awards": [],
       "fun_fact": "The song was featured in the movie 'Loser' starring Jason Biggs. It went viral on TikTok in 2020, introducing it to a whole new generation over 20 years later.",
-      "fun_fact_de": "Der Song war im Film 'Loser' mit Jason Biggs zu h\u00f6ren. Er ging 2020 auf TikTok viral und erreichte damit eine neue Generation \u00fcber 20 Jahre sp\u00e4ter.",
-      "fun_fact_es": "La canci\u00f3n apareci\u00f3 en la pel\u00edcula 'Loser' con Jason Biggs. Se volvi\u00f3 viral en TikTok en 2020, present\u00e1ndola a una nueva generaci\u00f3n m\u00e1s de 20 a\u00f1os despu\u00e9s.",
-      "fun_fact_fr": "Le titre figure dans le film 'Loser' avec Jason Biggs. Il est devenu viral sur TikTok en 2020, le faisant d\u00e9couvrir \u00e0 une toute nouvelle g\u00e9n\u00e9ration plus de 20 ans apr\u00e8s sa sortie.",
+      "fun_fact_de": "Der Song war im Film 'Loser' mit Jason Biggs zu hören. Er ging 2020 auf TikTok viral und erreichte damit eine neue Generation über 20 Jahre später.",
+      "fun_fact_es": "La canción apareció en la película 'Loser' con Jason Biggs. Se volvió viral en TikTok en 2020, presentándola a una nueva generación más de 20 años después.",
+      "fun_fact_fr": "Le titre figure dans le film 'Loser' avec Jason Biggs. Il est devenu viral sur TikTok en 2020, le faisant découvrir à une toute nouvelle génération plus de 20 ans après sa sortie.",
       "uri_apple_music": "applemusic://track/298160976",
       "uri_youtube_music": "https://music.youtube.com/watch?v=FC3y9llDXuM",
       "uri_tidal": "tidal://track/1924",
       "uri_deezer": "deezer://track/870041",
       "fun_fact_nl": "Het nummer was te horen in de film 'Loser' met Jason Biggs in de hoofdrol. Het ging in 2020 viraal op TikTok, waardoor een hele nieuwe generatie er meer dan 20 jaar later kennis mee maakte.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM10008431",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1788997007",
+        "de": "applemusic://track/1788997007",
+        "gb": "applemusic://track/1788997007",
+        "fr": "applemusic://track/1788997007",
+        "es": "applemusic://track/1788997007",
+        "nl": "applemusic://track/1788997007",
+        "it": "applemusic://track/1788997007"
+      }
     },
     {
       "year": 2003,
@@ -2259,15 +2889,25 @@
       ],
       "awards": [],
       "fun_fact": "The Neptunes-produced track became iconic after the 2004 Super Bowl performance with Janet Jackson that led to the infamous 'wardrobe malfunction' incident.",
-      "fun_fact_de": "Der von den Neptunes produzierte Track wurde nach dem Super-Bowl-Auftritt 2004 mit Janet Jackson und der ber\u00fcchtigten 'Garderoben-Panne' ikonisch.",
-      "fun_fact_es": "El tema producido por The Neptunes se volvi\u00f3 ic\u00f3nico despu\u00e9s de la actuaci\u00f3n del Super Bowl 2004 con Janet Jackson que llev\u00f3 al infame incidente del 'mal funcionamiento de vestuario'.",
-      "fun_fact_fr": "Le titre produit par les Neptunes est devenu culte apr\u00e8s la prestation du Super Bowl 2004 avec Janet Jackson, qui a entra\u00een\u00e9 le fameux incident du 'dysfonctionnement vestimentaire'.",
+      "fun_fact_de": "Der von den Neptunes produzierte Track wurde nach dem Super-Bowl-Auftritt 2004 mit Janet Jackson und der berüchtigten 'Garderoben-Panne' ikonisch.",
+      "fun_fact_es": "El tema producido por The Neptunes se volvió icónico después de la actuación del Super Bowl 2004 con Janet Jackson que llevó al infame incidente del 'mal funcionamiento de vestuario'.",
+      "fun_fact_fr": "Le titre produit par les Neptunes est devenu culte après la prestation du Super Bowl 2004 avec Janet Jackson, qui a entraîné le fameux incident du 'dysfonctionnement vestimentaire'.",
       "uri_apple_music": "applemusic://track/252606598",
       "uri_youtube_music": "https://music.youtube.com/watch?v=TSVHoHyErBQ",
       "uri_tidal": "tidal://track/49588",
       "uri_deezer": "deezer://track/970410",
       "fun_fact_nl": "De door The Neptunes geproduceerde track werd iconisch na het optreden tijdens de Super Bowl van 2004 met Janet Jackson, dat leidde tot het beruchte incident met de 'wardrobe malfunction'.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USJI10200367",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1685076064",
+        "de": "applemusic://track/1685076064",
+        "gb": "applemusic://track/313804527",
+        "fr": "applemusic://track/313804527",
+        "es": "applemusic://track/313804527",
+        "nl": "applemusic://track/1685076064",
+        "it": "applemusic://track/313804527"
+      }
     },
     {
       "year": 2005,
@@ -2292,21 +2932,31 @@
       "awards": [],
       "fun_fact": "The song prominently samples 'Misirlou' by Dick Dale, famously known as the Pulp Fiction theme song. The energetic track became a staple at sporting events worldwide.",
       "fun_fact_de": "Der Song sampelt prominent 'Misirlou' von Dick Dale, bekannt als Pulp-Fiction-Titelsong. Der energetische Track wurde weltweit zu einem festen Bestandteil bei Sportveranstaltungen.",
-      "fun_fact_es": "La canci\u00f3n samplea prominentemente 'Misirlou' de Dick Dale, conocida como el tema de Pulp Fiction. Se convirti\u00f3 en un cl\u00e1sico en eventos deportivos mundiales.",
-      "fun_fact_fr": "Le morceau sample de mani\u00e8re pro\u00e9minente 'Misirlou' de Dick Dale, c\u00e9l\u00e8bre comme th\u00e8me de Pulp Fiction. Ce titre \u00e9nergique est devenu un incontournable des \u00e9v\u00e9nements sportifs \u00e0 travers le monde.",
+      "fun_fact_es": "La canción samplea prominentemente 'Misirlou' de Dick Dale, conocida como el tema de Pulp Fiction. Se convirtió en un clásico en eventos deportivos mundiales.",
+      "fun_fact_fr": "Le morceau sample de manière proéminente 'Misirlou' de Dick Dale, célèbre comme thème de Pulp Fiction. Ce titre énergique est devenu un incontournable des événements sportifs à travers le monde.",
       "uri_apple_music": "applemusic://track/1840455848",
       "uri_youtube_music": "https://music.youtube.com/watch?v=ZaI2IlHwmgQ",
       "uri_tidal": "tidal://track/531023",
       "uri_deezer": "deezer://track/7375556",
       "fun_fact_nl": "Het nummer bevat een prominente sample van 'Misirlou' van Dick Dale, bekend als het thema van Pulp Fiction. De energieke track werd een vast onderdeel op sportevenementen wereldwijd.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USIR10500407",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1699871216",
+        "de": "applemusic://track/1699871216",
+        "gb": "applemusic://track/1699871216",
+        "fr": "applemusic://track/1699871216",
+        "es": "applemusic://track/1699871216",
+        "nl": "applemusic://track/1699871216",
+        "it": "applemusic://track/1699871216"
+      }
     },
     {
       "year": 2008,
       "uri": "spotify:track:2VOomzT6VavJOGBeySqaMc",
       "artist": "Rihanna",
       "alt_artists": [
-        "Beyonc\u00e9",
+        "Beyoncé",
         "Lady Gaga",
         "Ciara",
         "Katy Perry"
@@ -2323,15 +2973,25 @@
       ],
       "awards": [],
       "fun_fact": "Chris Brown co-wrote the song, and it was released just months before their relationship became tabloid news. The horror-themed music video was inspired by thriller movies.",
-      "fun_fact_de": "Chris Brown hat den Song mitgeschrieben, und er wurde nur Monate vor den Schlagzeilen \u00fcber ihre Beziehung ver\u00f6ffentlicht. Das horror-inspirierte Musikvideo war von Thriller-Filmen inspiriert.",
-      "fun_fact_es": "Chris Brown coescribi\u00f3 la canci\u00f3n, y fue lanzada meses antes de que su relaci\u00f3n se convirtiera en noticia de tabloides. El video musical de terror fue inspirado por pel\u00edculas de suspenso.",
-      "fun_fact_fr": "Chris Brown a co\u00e9crit la chanson, sortie quelques mois seulement avant que leur relation ne fasse la une des tablo\u00efds. Le clip d'inspiration horrifique s'inspire des films \u00e0 suspense.",
+      "fun_fact_de": "Chris Brown hat den Song mitgeschrieben, und er wurde nur Monate vor den Schlagzeilen über ihre Beziehung veröffentlicht. Das horror-inspirierte Musikvideo war von Thriller-Filmen inspiriert.",
+      "fun_fact_es": "Chris Brown coescribió la canción, y fue lanzada meses antes de que su relación se convirtiera en noticia de tabloides. El video musical de terror fue inspirado por películas de suspenso.",
+      "fun_fact_fr": "Chris Brown a coécrit la chanson, sortie quelques mois seulement avant que leur relation ne fasse la une des tabloïds. Le clip d'inspiration horrifique s'inspire des films à suspense.",
       "uri_apple_music": "applemusic://track/1441154571",
       "uri_youtube_music": "https://music.youtube.com/watch?v=E1mU6h4Xdxc",
       "uri_tidal": "tidal://track/1771739",
       "uri_deezer": "deezer://track/925118",
-      "fun_fact_nl": "Chris Brown schreef mee aan het nummer, en het werd uitgebracht slechts enkele maanden voordat hun relatie tabloidnieuws werd. De videoclip in horrorthema was ge\u00efnspireerd op thrillerfilms.",
-      "awards_nl": []
+      "fun_fact_nl": "Chris Brown schreef mee aan het nummer, en het werd uitgebracht slechts enkele maanden voordat hun relatie tabloidnieuws werd. De videoclip in horrorthema was geïnspireerd op thrillerfilms.",
+      "awards_nl": [],
+      "isrc": "USUM70814476",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1441154571",
+        "de": "applemusic://track/1444443260",
+        "gb": "applemusic://track/1444443260",
+        "fr": "applemusic://track/1444443260",
+        "es": "applemusic://track/1444443260",
+        "nl": "applemusic://track/1444443260",
+        "it": "applemusic://track/1444443260"
+      }
     },
     {
       "year": 2000,
@@ -2354,15 +3014,25 @@
       ],
       "awards": [],
       "fun_fact": "The song's Superman-themed lyrics were inspired by Brad Arnold's recurring childhood dreams about Superman. It was originally recorded as a demo on a $100 recorder.",
-      "fun_fact_de": "Die Superman-Texte wurden von Brad Arnolds wiederkehrenden Kindheitstr\u00e4umen \u00fcber Superman inspiriert. Der Song wurde urspr\u00fcnglich als Demo auf einem 100-Dollar-Recorder aufgenommen.",
-      "fun_fact_es": "La letra tem\u00e1tica de Superman fue inspirada por los sue\u00f1os recurrentes de la infancia de Brad Arnold sobre Superman. Fue grabada originalmente como demo en una grabadora de $100.",
-      "fun_fact_fr": "Les paroles sur le th\u00e8me de Superman ont \u00e9t\u00e9 inspir\u00e9es par les r\u00eaves d'enfance r\u00e9currents de Brad Arnold \u00e0 propos de Superman. Le morceau a d'abord \u00e9t\u00e9 enregistr\u00e9 comme d\u00e9mo sur un enregistreur \u00e0 100 dollars.",
+      "fun_fact_de": "Die Superman-Texte wurden von Brad Arnolds wiederkehrenden Kindheitsträumen über Superman inspiriert. Der Song wurde ursprünglich als Demo auf einem 100-Dollar-Recorder aufgenommen.",
+      "fun_fact_es": "La letra temática de Superman fue inspirada por los sueños recurrentes de la infancia de Brad Arnold sobre Superman. Fue grabada originalmente como demo en una grabadora de $100.",
+      "fun_fact_fr": "Les paroles sur le thème de Superman ont été inspirées par les rêves d'enfance récurrents de Brad Arnold à propos de Superman. Le morceau a d'abord été enregistré comme démo sur un enregistreur à 100 dollars.",
       "uri_apple_music": "applemusic://track/1440664900",
       "uri_youtube_music": "https://music.youtube.com/watch?v=xPU8OAjjS4k",
       "uri_tidal": "tidal://track/103311351",
       "uri_deezer": "deezer://track/2511224",
-      "fun_fact_nl": "De tekst in Superman-thema was ge\u00efnspireerd op de terugkerende kinderdromen van Brad Arnold over Superman. Het werd oorspronkelijk opgenomen als demo op een recorder van 100 dollar.",
-      "awards_nl": []
+      "fun_fact_nl": "De tekst in Superman-thema was geïnspireerd op de terugkerende kinderdromen van Brad Arnold over Superman. Het werd oorspronkelijk opgenomen als demo op een recorder van 100 dollar.",
+      "awards_nl": [],
+      "isrc": "USUR19980187",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1810258953",
+        "de": "applemusic://track/1810258953",
+        "gb": "applemusic://track/1810258953",
+        "fr": "applemusic://track/1810258953",
+        "es": "applemusic://track/1810258953",
+        "nl": "applemusic://track/1810258953",
+        "it": "applemusic://track/1810258953"
+      }
     },
     {
       "year": 2000,
@@ -2386,15 +3056,25 @@
       ],
       "awards": [],
       "fun_fact": "The song was inspired by an Eddie Murphy comedy bit about being caught cheating. Shaggy wrote it in 1995 but it wasn't released until 2000 when a DJ started playing it.",
-      "fun_fact_de": "Der Song wurde von einem Eddie-Murphy-Comedy-Sketch \u00fcber Untreue inspiriert. Shaggy schrieb ihn 1995, aber er wurde erst 2000 ver\u00f6ffentlicht, als ein DJ ihn spielte.",
-      "fun_fact_es": "La canci\u00f3n fue inspirada por un sketch de comedia de Eddie Murphy sobre ser atrapado siendo infiel. Shaggy la escribi\u00f3 en 1995 pero no se lanz\u00f3 hasta 2000.",
-      "fun_fact_fr": "La chanson s'inspire d'un sketch comique d'Eddie Murphy sur le fait d'\u00eatre pris en flagrant d\u00e9lit d'infid\u00e9lit\u00e9. Shaggy l'a \u00e9crite en 1995, mais elle n'est sortie qu'en 2000 lorsqu'un DJ a commenc\u00e9 \u00e0 la passer.",
+      "fun_fact_de": "Der Song wurde von einem Eddie-Murphy-Comedy-Sketch über Untreue inspiriert. Shaggy schrieb ihn 1995, aber er wurde erst 2000 veröffentlicht, als ein DJ ihn spielte.",
+      "fun_fact_es": "La canción fue inspirada por un sketch de comedia de Eddie Murphy sobre ser atrapado siendo infiel. Shaggy la escribió en 1995 pero no se lanzó hasta 2000.",
+      "fun_fact_fr": "La chanson s'inspire d'un sketch comique d'Eddie Murphy sur le fait d'être pris en flagrant délit d'infidélité. Shaggy l'a écrite en 1995, mais elle n'est sortie qu'en 2000 lorsqu'un DJ a commencé à la passer.",
       "uri_apple_music": "applemusic://track/1440745627",
       "uri_youtube_music": "https://music.youtube.com/watch?v=sTMgX1PDGAE",
       "uri_tidal": "tidal://track/76773941",
       "uri_deezer": "deezer://track/2122532",
-      "fun_fact_nl": "Het nummer is ge\u00efnspireerd op een comedy-sketch van Eddie Murphy over betrapt worden op vreemdgaan. Shaggy schreef het in 1995, maar het werd pas in 2000 uitgebracht toen een dj het begon te draaien.",
-      "awards_nl": []
+      "fun_fact_nl": "Het nummer is geïnspireerd op een comedy-sketch van Eddie Murphy over betrapt worden op vreemdgaan. Shaggy schreef het in 1995, maar het werd pas in 2000 uitgebracht toen een dj het begon te draaien.",
+      "awards_nl": [],
+      "isrc": "USMC10000393",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1698758480",
+        "de": "applemusic://track/1698758480",
+        "gb": "applemusic://track/1698758480",
+        "fr": "applemusic://track/1698758480",
+        "es": "applemusic://track/1698758480",
+        "nl": "applemusic://track/1698758480",
+        "it": "applemusic://track/1698758480"
+      }
     },
     {
       "year": 2009,
@@ -2418,15 +3098,25 @@
       ],
       "awards": [],
       "fun_fact": "The song was written by Jessie J, who has said it's nothing like the music she would make for herself. Miley almost didn't record it because she hadn't heard a Jay-Z song at that point.",
-      "fun_fact_de": "Der Song wurde von Jessie J geschrieben, die sagte, er sei ganz anders als die Musik, die sie f\u00fcr sich selbst machen w\u00fcrde. Miley h\u00e4tte ihn fast nicht aufgenommen.",
-      "fun_fact_es": "La canci\u00f3n fue escrita por Jessie J, quien ha dicho que no se parece en nada a la m\u00fasica que ella har\u00eda. Miley casi no la graba porque no hab\u00eda escuchado una canci\u00f3n de Jay-Z.",
-      "fun_fact_fr": "La chanson a \u00e9t\u00e9 \u00e9crite par Jessie J, qui a d\u00e9clar\u00e9 que ce n'est pas du tout le style de musique qu'elle ferait pour elle-m\u00eame. Miley a failli ne pas l'enregistrer car elle n'avait jamais \u00e9cout\u00e9 de chanson de Jay-Z \u00e0 l'\u00e9poque.",
+      "fun_fact_de": "Der Song wurde von Jessie J geschrieben, die sagte, er sei ganz anders als die Musik, die sie für sich selbst machen würde. Miley hätte ihn fast nicht aufgenommen.",
+      "fun_fact_es": "La canción fue escrita por Jessie J, quien ha dicho que no se parece en nada a la música que ella haría. Miley casi no la graba porque no había escuchado una canción de Jay-Z.",
+      "fun_fact_fr": "La chanson a été écrite par Jessie J, qui a déclaré que ce n'est pas du tout le style de musique qu'elle ferait pour elle-même. Miley a failli ne pas l'enregistrer car elle n'avait jamais écouté de chanson de Jay-Z à l'époque.",
       "uri_apple_music": "applemusic://track/1445007713",
       "uri_youtube_music": "https://music.youtube.com/watch?v=M11SvDtPBhA",
       "uri_tidal": "tidal://track/83582714",
       "uri_deezer": "deezer://track/4233792",
       "fun_fact_nl": "Het nummer is geschreven door Jessie J, die heeft gezegd dat het in niets lijkt op de muziek die ze voor zichzelf zou maken. Miley nam het bijna niet op omdat ze op dat moment nog nooit een nummer van Jay-Z had gehoord.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USHR10924519",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1741021144",
+        "de": "applemusic://track/1741021144",
+        "gb": "applemusic://track/1741021144",
+        "fr": "applemusic://track/1741021144",
+        "es": "applemusic://track/1560729742",
+        "nl": "applemusic://track/1741021144",
+        "it": "applemusic://track/1741021144"
+      }
     },
     {
       "year": 2006,
@@ -2450,15 +3140,25 @@
       ],
       "awards": [],
       "fun_fact": "It was the first song to reach #1 in the UK based on digital downloads alone, before the physical single was even released. It topped the UK chart for 9 consecutive weeks.",
-      "fun_fact_de": "Es war der erste Song, der allein durch digitale Downloads Platz 1 in UK erreichte, bevor die physische Single \u00fcberhaupt erschien. Er war 9 Wochen lang auf Platz 1.",
-      "fun_fact_es": "Fue la primera canci\u00f3n en llegar al #1 en el Reino Unido solo con descargas digitales, antes de que se lanzara el sencillo f\u00edsico. Encabez\u00f3 las listas del Reino Unido durante 9 semanas.",
-      "fun_fact_fr": "C'est la premi\u00e8re chanson \u00e0 atteindre la premi\u00e8re place au Royaume-Uni uniquement gr\u00e2ce aux t\u00e9l\u00e9chargements num\u00e9riques, avant m\u00eame la sortie du single physique. Elle est rest\u00e9e 9 semaines cons\u00e9cutives en t\u00eate.",
+      "fun_fact_de": "Es war der erste Song, der allein durch digitale Downloads Platz 1 in UK erreichte, bevor die physische Single überhaupt erschien. Er war 9 Wochen lang auf Platz 1.",
+      "fun_fact_es": "Fue la primera canción en llegar al #1 en el Reino Unido solo con descargas digitales, antes de que se lanzara el sencillo físico. Encabezó las listas del Reino Unido durante 9 semanas.",
+      "fun_fact_fr": "C'est la première chanson à atteindre la première place au Royaume-Uni uniquement grâce aux téléchargements numériques, avant même la sortie du single physique. Elle est restée 9 semaines consécutives en tête.",
       "uri_apple_music": "applemusic://track/1741403966",
       "uri_youtube_music": "https://music.youtube.com/watch?v=-N4jf6rtyuw",
       "uri_tidal": "tidal://track/34631719",
       "uri_deezer": "deezer://track/2794160",
       "fun_fact_nl": "Het was het eerste nummer dat de eerste plaats in het VK bereikte op basis van uitsluitend digitale downloads, nog voordat de fysieke single was uitgebracht. Het stond 9 opeenvolgende weken bovenaan de Britse hitlijst.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USAT20611041",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1741403966",
+        "de": "applemusic://track/1181210744",
+        "gb": "applemusic://track/1181210744",
+        "fr": "applemusic://track/1181210744",
+        "es": "applemusic://track/1181210744",
+        "nl": "applemusic://track/1181210744",
+        "it": "applemusic://track/1181210744"
+      }
     },
     {
       "year": 2005,
@@ -2482,15 +3182,25 @@
       ],
       "awards": [],
       "fun_fact": "The suggestive song featuring Olivia sparked controversy but became a massive hit. Its music video, set in a mansion, was one of the most expensive hip-hop videos at the time.",
-      "fun_fact_de": "Der suggestive Song mit Olivia sorgte f\u00fcr Kontroversen, wurde aber ein riesiger Hit. Sein Musikvideo in einer Villa war eines der teuersten Hip-Hop-Videos seiner Zeit.",
-      "fun_fact_es": "La sugerente canci\u00f3n con Olivia gener\u00f3 controversia pero se convirti\u00f3 en un gran \u00e9xito. Su video musical, filmado en una mansi\u00f3n, fue uno de los m\u00e1s caros del hip-hop en su momento.",
-      "fun_fact_fr": "Ce titre suggestif avec Olivia a suscit\u00e9 la controverse mais est devenu un immense succ\u00e8s. Son clip, tourn\u00e9 dans un manoir, \u00e9tait l'un des clips hip-hop les plus co\u00fbteux de l'\u00e9poque.",
+      "fun_fact_de": "Der suggestive Song mit Olivia sorgte für Kontroversen, wurde aber ein riesiger Hit. Sein Musikvideo in einer Villa war eines der teuersten Hip-Hop-Videos seiner Zeit.",
+      "fun_fact_es": "La sugerente canción con Olivia generó controversia pero se convirtió en un gran éxito. Su video musical, filmado en una mansión, fue uno de los más caros del hip-hop en su momento.",
+      "fun_fact_fr": "Ce titre suggestif avec Olivia a suscité la controverse mais est devenu un immense succès. Son clip, tourné dans un manoir, était l'un des clips hip-hop les plus coûteux de l'époque.",
       "uri_apple_music": "applemusic://track/1440879604",
       "uri_youtube_music": "https://music.youtube.com/watch?v=SRcnnId15BA",
       "uri_tidal": "tidal://track/35699544",
       "uri_deezer": "deezer://track/145429544",
       "fun_fact_nl": "Het suggestieve nummer met Olivia veroorzaakte controverse maar werd een enorme hit. De videoclip, die zich afspeelt in een landhuis, was destijds een van de duurste hiphopvideo's.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USIR10500072",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1440767680",
+        "de": "applemusic://track/1440767680",
+        "gb": "applemusic://track/1440767680",
+        "fr": "applemusic://track/1440767680",
+        "es": "applemusic://track/1440767680",
+        "nl": "applemusic://track/1440767680",
+        "it": "applemusic://track/1440767680"
+      }
     },
     {
       "year": 2008,
@@ -2517,22 +3227,32 @@
         "Grammy Award - Best Rock Performance by Duo or Group"
       ],
       "awards_fr": [
-        "Grammy Award - Enregistrement de l'ann\u00e9e",
+        "Grammy Award - Enregistrement de l'année",
         "Grammy Award - Meilleure performance rock d'un duo ou groupe"
       ],
-      "fun_fact": "Caleb Followill wrote the song after feeling lonely at a star-studded party. It won Record of the Year at the Grammys, beating out Beyonc\u00e9 and Taylor Swift.",
-      "fun_fact_de": "Caleb Followill schrieb den Song, nachdem er sich auf einer prominenten Party einsam f\u00fchlte. Er gewann den Grammy f\u00fcr die Aufnahme des Jahres und schlug Beyonc\u00e9 und Taylor Swift.",
-      "fun_fact_es": "Caleb Followill escribi\u00f3 la canci\u00f3n tras sentirse solo en una fiesta llena de estrellas. Gan\u00f3 el Grammy a la Grabaci\u00f3n del A\u00f1o, venciendo a Beyonc\u00e9 y Taylor Swift.",
-      "fun_fact_fr": "Caleb Followill a \u00e9crit la chanson apr\u00e8s s'\u00eatre senti seul lors d'une soir\u00e9e remplie de c\u00e9l\u00e9brit\u00e9s. Elle a remport\u00e9 le Grammy de l'Enregistrement de l'Ann\u00e9e, devan\u00e7ant Beyonc\u00e9 et Taylor Swift.",
+      "fun_fact": "Caleb Followill wrote the song after feeling lonely at a star-studded party. It won Record of the Year at the Grammys, beating out Beyoncé and Taylor Swift.",
+      "fun_fact_de": "Caleb Followill schrieb den Song, nachdem er sich auf einer prominenten Party einsam fühlte. Er gewann den Grammy für die Aufnahme des Jahres und schlug Beyoncé und Taylor Swift.",
+      "fun_fact_es": "Caleb Followill escribió la canción tras sentirse solo en una fiesta llena de estrellas. Ganó el Grammy a la Grabación del Año, venciendo a Beyoncé y Taylor Swift.",
+      "fun_fact_fr": "Caleb Followill a écrit la chanson après s'être senti seul lors d'une soirée remplie de célébrités. Elle a remporté le Grammy de l'Enregistrement de l'Année, devançant Beyoncé et Taylor Swift.",
       "uri_apple_music": "applemusic://track/290303018",
       "uri_youtube_music": "https://music.youtube.com/watch?v=gnhXHvRoUd0",
       "uri_tidal": "tidal://track/1906287",
       "uri_deezer": "deezer://track/2924841",
-      "fun_fact_nl": "Caleb Followill schreef het nummer nadat hij zich eenzaam voelde op een feestje vol sterren. Het won Record of the Year bij de Grammy's en versloeg daarmee Beyonc\u00e9 en Taylor Swift.",
+      "fun_fact_nl": "Caleb Followill schreef het nummer nadat hij zich eenzaam voelde op een feestje vol sterren. Het won Record of the Year bij de Grammy's en versloeg daarmee Beyoncé en Taylor Swift.",
       "awards_nl": [
-        "Grammy Award \u2013 Opname van het Jaar",
-        "Grammy Award \u2013 Beste Rockprestatie door Duo of Groep"
-      ]
+        "Grammy Award – Opname van het Jaar",
+        "Grammy Award – Beste Rockprestatie door Duo of Groep"
+      ],
+      "isrc": "USRC10800301",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1351343570",
+        "de": "applemusic://track/1351343570",
+        "gb": "applemusic://track/1351343570",
+        "fr": "applemusic://track/1351343570",
+        "es": "applemusic://track/1351343570",
+        "nl": "applemusic://track/1351343570",
+        "it": "applemusic://track/1351343570"
+      }
     },
     {
       "year": 2000,
@@ -2556,15 +3276,25 @@
       ],
       "awards": [],
       "fun_fact": "The word 'stan' entered the Oxford English Dictionary in 2017 as a term for an obsessive fan, directly derived from this song. Dido's vocals were sampled from her song 'Thank You'.",
-      "fun_fact_de": "Das Wort 'Stan' wurde 2017 ins Oxford English Dictionary aufgenommen als Bezeichnung f\u00fcr einen obsessiven Fan \u2014 direkt abgeleitet von diesem Song. Didos Vocals stammen aus ihrem Song 'Thank You'.",
-      "fun_fact_es": "La palabra 'stan' entr\u00f3 en el Oxford English Dictionary en 2017 como t\u00e9rmino para un fan obsesivo, derivado directamente de esta canci\u00f3n. Las voces de Dido fueron sampleadas de su canci\u00f3n 'Thank You'.",
-      "fun_fact_fr": "Le mot 'stan' est entr\u00e9 dans l'Oxford English Dictionary en 2017 pour d\u00e9signer un fan obsessionnel, directement d\u00e9riv\u00e9 de cette chanson. Les voix de Dido sont sampl\u00e9es de son titre 'Thank You'.",
+      "fun_fact_de": "Das Wort 'Stan' wurde 2017 ins Oxford English Dictionary aufgenommen als Bezeichnung für einen obsessiven Fan — direkt abgeleitet von diesem Song. Didos Vocals stammen aus ihrem Song 'Thank You'.",
+      "fun_fact_es": "La palabra 'stan' entró en el Oxford English Dictionary en 2017 como término para un fan obsesivo, derivado directamente de esta canción. Las voces de Dido fueron sampleadas de su canción 'Thank You'.",
+      "fun_fact_fr": "Le mot 'stan' est entré dans l'Oxford English Dictionary en 2017 pour désigner un fan obsessionnel, directement dérivé de cette chanson. Les voix de Dido sont samplées de son titre 'Thank You'.",
       "uri_apple_music": "applemusic://track/1440866795",
       "uri_youtube_music": "https://music.youtube.com/watch?v=gOMhN-hfMtY",
       "uri_tidal": "tidal://track/586941",
       "uri_deezer": "deezer://track/1109730",
       "fun_fact_nl": "Het woord 'stan' werd in 2017 opgenomen in de Oxford English Dictionary als term voor een obsessieve fan, rechtstreeks afgeleid van dit nummer. De vocals van Dido werden gesampled uit haar nummer 'Thank You'.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USIR10001280",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1440866795",
+        "de": "applemusic://track/1440866795",
+        "gb": "applemusic://track/1440866795",
+        "fr": "applemusic://track/1440866795",
+        "es": "applemusic://track/1440866795",
+        "nl": "applemusic://track/1440866795",
+        "it": "applemusic://track/1440866795"
+      }
     },
     {
       "year": 2004,
@@ -2587,15 +3317,25 @@
       ],
       "awards": [],
       "fun_fact": "The duet with Alicia Keys was Usher's 4th consecutive #1 hit from his 'Confessions' album era, tying the record at the time for most consecutive #1s from one album cycle.",
-      "fun_fact_de": "Das Duett mit Alicia Keys war Ushers vierter #1-Hit in Folge aus seiner 'Confessions'-Album-\u00c4ra und glich damit den damaligen Rekord f\u00fcr die meisten aufeinanderfolgenden #1-Hits aus einem Album aus.",
-      "fun_fact_es": "El d\u00fao con Alicia Keys fue el cuarto #1 consecutivo de Usher de su era del \u00e1lbum 'Confessions', igualando el r\u00e9cord de m\u00e1s #1 consecutivos de un ciclo de \u00e1lbum.",
-      "fun_fact_fr": "Ce duo avec Alicia Keys \u00e9tait le quatri\u00e8me num\u00e9ro 1 cons\u00e9cutif d'Usher issu de l'\u00e8re de l'album 'Confessions', \u00e9galant le record de l'\u00e9poque pour le plus grand nombre de num\u00e9ros 1 cons\u00e9cutifs d'un m\u00eame cycle d'album.",
+      "fun_fact_de": "Das Duett mit Alicia Keys war Ushers vierter #1-Hit in Folge aus seiner 'Confessions'-Album-Ära und glich damit den damaligen Rekord für die meisten aufeinanderfolgenden #1-Hits aus einem Album aus.",
+      "fun_fact_es": "El dúo con Alicia Keys fue el cuarto #1 consecutivo de Usher de su era del álbum 'Confessions', igualando el récord de más #1 consecutivos de un ciclo de álbum.",
+      "fun_fact_fr": "Ce duo avec Alicia Keys était le quatrième numéro 1 consécutif d'Usher issu de l'ère de l'album 'Confessions', égalant le record de l'époque pour le plus grand nombre de numéros 1 consécutifs d'un même cycle d'album.",
       "uri_apple_music": "applemusic://track/386153729",
       "uri_youtube_music": "https://music.youtube.com/watch?v=fPgf2meEX1w",
       "uri_tidal": "tidal://track/11337931",
       "uri_deezer": "deezer://track/601626",
-      "fun_fact_nl": "Het duet met Alicia Keys was Usher's vierde opeenvolgende nummer 1-hit uit zijn 'Confessions'-albumtijdperk, waarmee hij destijds het record evenaarde voor de meeste opeenvolgende nummer 1-hits uit \u00e9\u00e9n albumcyclus.",
-      "awards_nl": []
+      "fun_fact_nl": "Het duet met Alicia Keys was Usher's vierde opeenvolgende nummer 1-hit uit zijn 'Confessions'-albumtijdperk, waarmee hij destijds het record evenaarde voor de meeste opeenvolgende nummer 1-hits uit één albumcyclus.",
+      "awards_nl": [],
+      "isrc": "USAR10400887",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1691572753",
+        "de": "applemusic://track/1691572753",
+        "gb": "applemusic://track/1691572753",
+        "fr": "applemusic://track/1691572753",
+        "es": "applemusic://track/1691572753",
+        "nl": "applemusic://track/1691572753",
+        "it": "applemusic://track/1691572753"
+      }
     },
     {
       "year": 2008,
@@ -2619,15 +3359,25 @@
       ],
       "awards": [],
       "fun_fact": "The song went viral again in 2009 when a wedding party danced down the aisle to it in a YouTube video that got over 100 million views, becoming one of the first viral wedding videos.",
-      "fun_fact_de": "Der Song ging 2009 erneut viral, als eine Hochzeitsgesellschaft in einem YouTube-Video dazu den Gang entlang tanzte, das \u00fcber 100 Millionen Aufrufe erhielt.",
-      "fun_fact_es": "La canci\u00f3n se volvi\u00f3 viral de nuevo en 2009 cuando una fiesta de boda bail\u00f3 por el pasillo con ella en un video de YouTube que obtuvo m\u00e1s de 100 millones de vistas.",
-      "fun_fact_fr": "Le titre est redevenu viral en 2009 lorsqu'un cort\u00e8ge de mariage a dans\u00e9 en remontant l'all\u00e9e sur cette chanson dans une vid\u00e9o YouTube qui a d\u00e9pass\u00e9 les 100 millions de vues, devenant l'une des premi\u00e8res vid\u00e9os de mariage virales.",
+      "fun_fact_de": "Der Song ging 2009 erneut viral, als eine Hochzeitsgesellschaft in einem YouTube-Video dazu den Gang entlang tanzte, das über 100 Millionen Aufrufe erhielt.",
+      "fun_fact_es": "La canción se volvió viral de nuevo en 2009 cuando una fiesta de boda bailó por el pasillo con ella en un video de YouTube que obtuvo más de 100 millones de vistas.",
+      "fun_fact_fr": "Le titre est redevenu viral en 2009 lorsqu'un cortège de mariage a dansé en remontant l'allée sur cette chanson dans une vidéo YouTube qui a dépassé les 100 millions de vues, devenant l'une des premières vidéos de mariage virales.",
       "uri_apple_music": "applemusic://track/282988494",
       "uri_youtube_music": "https://music.youtube.com/watch?v=5sMKX22BHeE",
       "uri_tidal": "tidal://track/1829223",
       "uri_deezer": "deezer://track/15590961",
       "fun_fact_nl": "Het nummer ging in 2009 opnieuw viraal toen een gezelschap op een bruiloft er op danste terwijl ze naar het altaar liepen in een YouTube-video die meer dan 100 miljoen views kreeg, en daarmee een van de eerste virale trouwvideo's werd.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USJI10800113",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/282988494",
+        "de": "applemusic://track/284882083",
+        "gb": "applemusic://track/284882083",
+        "fr": "applemusic://track/284882083",
+        "es": "applemusic://track/284882083",
+        "nl": "applemusic://track/284882083",
+        "it": "applemusic://track/284882083"
+      }
     },
     {
       "year": 2005,
@@ -2651,15 +3401,25 @@
       ],
       "awards": [],
       "fun_fact": "Billie Joe Armstrong wrote the song about his father who died of cancer in September 1982. The music video, set during the Iraq War, made audiences cry in theaters worldwide.",
-      "fun_fact_de": "Billie Joe Armstrong schrieb den Song \u00fcber seinen Vater, der im September 1982 an Krebs starb. Das Musikvideo, das im Irakkrieg spielt, brachte weltweit Kinobesucher zum Weinen.",
-      "fun_fact_es": "Billie Joe Armstrong escribi\u00f3 la canci\u00f3n sobre su padre que muri\u00f3 de c\u00e1ncer en septiembre de 1982. El video musical, ambientado durante la Guerra de Irak, hizo llorar al p\u00fablico en todo el mundo.",
-      "fun_fact_fr": "Billie Joe Armstrong a \u00e9crit cette chanson sur son p\u00e8re d\u00e9c\u00e9d\u00e9 d'un cancer en septembre 1982. Le clip, situ\u00e9 pendant la guerre d'Irak, a fait pleurer les spectateurs dans les salles du monde entier.",
+      "fun_fact_de": "Billie Joe Armstrong schrieb den Song über seinen Vater, der im September 1982 an Krebs starb. Das Musikvideo, das im Irakkrieg spielt, brachte weltweit Kinobesucher zum Weinen.",
+      "fun_fact_es": "Billie Joe Armstrong escribió la canción sobre su padre que murió de cáncer en septiembre de 1982. El video musical, ambientado durante la Guerra de Irak, hizo llorar al público en todo el mundo.",
+      "fun_fact_fr": "Billie Joe Armstrong a écrit cette chanson sur son père décédé d'un cancer en septembre 1982. Le clip, situé pendant la guerre d'Irak, a fait pleurer les spectateurs dans les salles du monde entier.",
       "uri_apple_music": "applemusic://track/1161539483",
       "uri_youtube_music": "https://music.youtube.com/watch?v=NU9JoFKlaZ0",
       "uri_tidal": "tidal://track/292683",
       "uri_deezer": "deezer://track/773430",
       "fun_fact_nl": "Billie Joe Armstrong schreef het nummer over zijn vader die in september 1982 aan kanker overleed. De videoclip, die zich afspeelt tijdens de oorlog in Irak, deed het publiek wereldwijd in bioscopen huilen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USRE11200344",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1161539483",
+        "de": "applemusic://track/1161539483",
+        "gb": "applemusic://track/1161539483",
+        "fr": "applemusic://track/1161539483",
+        "es": "applemusic://track/1161539483",
+        "nl": "applemusic://track/1161539483",
+        "it": "applemusic://track/1161539483"
+      }
     },
     {
       "year": 2009,
@@ -2683,15 +3443,25 @@
       ],
       "awards": [],
       "fun_fact": "Florence Welch wrote the song inspired by a large artwork hanging in her studio that read 'Dog Days Are Over'. It took two years to become a hit after its initial release.",
-      "fun_fact_de": "Florence Welch schrieb den Song inspiriert von einem gro\u00dfen Kunstwerk in ihrem Studio mit der Aufschrift 'Dog Days Are Over'. Es dauerte zwei Jahre, bis er nach der Erstver\u00f6ffentlichung ein Hit wurde.",
-      "fun_fact_es": "Florence Welch escribi\u00f3 la canci\u00f3n inspirada por una gran obra de arte en su estudio que dec\u00eda 'Dog Days Are Over'. Tard\u00f3 dos a\u00f1os en convertirse en \u00e9xito tras su lanzamiento inicial.",
-      "fun_fact_fr": "Florence Welch a \u00e9crit la chanson en s'inspirant d'une grande oeuvre d'art accroch\u00e9e dans son studio portant l'inscription 'Dog Days Are Over'. Il a fallu deux ans apr\u00e8s sa sortie initiale pour qu'elle devienne un tube.",
+      "fun_fact_de": "Florence Welch schrieb den Song inspiriert von einem großen Kunstwerk in ihrem Studio mit der Aufschrift 'Dog Days Are Over'. Es dauerte zwei Jahre, bis er nach der Erstveröffentlichung ein Hit wurde.",
+      "fun_fact_es": "Florence Welch escribió la canción inspirada por una gran obra de arte en su estudio que decía 'Dog Days Are Over'. Tardó dos años en convertirse en éxito tras su lanzamiento inicial.",
+      "fun_fact_fr": "Florence Welch a écrit la chanson en s'inspirant d'une grande oeuvre d'art accrochée dans son studio portant l'inscription 'Dog Days Are Over'. Il a fallu deux ans après sa sortie initiale pour qu'elle devienne un tube.",
       "uri_apple_music": "applemusic://track/1470593922",
       "uri_youtube_music": "https://music.youtube.com/watch?v=iWOyfLBYtuU",
       "uri_tidal": "tidal://track/4951057",
       "uri_deezer": "deezer://track/7561772",
-      "fun_fact_nl": "Florence Welch schreef het nummer ge\u00efnspireerd op een groot kunstwerk in haar studio met de tekst 'Dog Days Are Over'. Het duurde twee jaar voordat het een hit werd na de oorspronkelijke release.",
-      "awards_nl": []
+      "fun_fact_nl": "Florence Welch schreef het nummer geïnspireerd op een groot kunstwerk in haar studio met de tekst 'Dog Days Are Over'. Het duurde twee jaar voordat het een hit werd na de oorspronkelijke release.",
+      "awards_nl": [],
+      "isrc": "GBUM70900209",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1807397587",
+        "de": "applemusic://track/1807397587",
+        "gb": "applemusic://track/1807397587",
+        "fr": "applemusic://track/1807397587",
+        "es": "applemusic://track/1807397587",
+        "nl": "applemusic://track/1807397587",
+        "it": "applemusic://track/1807397587"
+      }
     },
     {
       "year": 2009,
@@ -2714,16 +3484,26 @@
         "Platinum (UK)"
       ],
       "awards": [],
-      "fun_fact": "The space-themed music video features each member in a different environment \u2014 Fergie in a field, will.i.am in space, Taboo underwater, and apl.de.ap on an elephant in a desert.",
-      "fun_fact_de": "Das weltraumthematische Musikvideo zeigt jedes Mitglied in einer anderen Umgebung \u2014 Fergie auf einer Wiese, will.i.am im All, Taboo unter Wasser und apl.de.ap auf einem Elefanten.",
-      "fun_fact_es": "El video musical espacial muestra a cada miembro en un ambiente diferente \u2014 Fergie en un campo, will.i.am en el espacio, Taboo bajo el agua y apl.de.ap en un elefante.",
-      "fun_fact_fr": "Le clip spatial montre chaque membre dans un environnement diff\u00e9rent \u2014 Fergie dans un champ, will.i.am dans l'espace, Taboo sous l'eau et apl.de.ap sur un \u00e9l\u00e9phant dans le d\u00e9sert.",
+      "fun_fact": "The space-themed music video features each member in a different environment — Fergie in a field, will.i.am in space, Taboo underwater, and apl.de.ap on an elephant in a desert.",
+      "fun_fact_de": "Das weltraumthematische Musikvideo zeigt jedes Mitglied in einer anderen Umgebung — Fergie auf einer Wiese, will.i.am im All, Taboo unter Wasser und apl.de.ap auf einem Elefanten.",
+      "fun_fact_es": "El video musical espacial muestra a cada miembro en un ambiente diferente — Fergie en un campo, will.i.am en el espacio, Taboo bajo el agua y apl.de.ap en un elefante.",
+      "fun_fact_fr": "Le clip spatial montre chaque membre dans un environnement différent — Fergie dans un champ, will.i.am dans l'espace, Taboo sous l'eau et apl.de.ap sur un éléphant dans le désert.",
       "uri_apple_music": "applemusic://track/1440769131",
       "uri_youtube_music": "https://music.youtube.com/watch?v=I7HahVwYpwo",
       "uri_tidal": "tidal://track/2846326",
       "uri_deezer": "deezer://track/4619464",
-      "fun_fact_nl": "De videoclip in ruimtethema toont elk lid in een andere omgeving \u2014 Fergie in een veld, will.i.am in de ruimte, Taboo onder water en apl.de.ap op een olifant in een woestijn.",
-      "awards_nl": []
+      "fun_fact_nl": "De videoclip in ruimtethema toont elk lid in een andere omgeving — Fergie in een veld, will.i.am in de ruimte, Taboo onder water en apl.de.ap op een olifant in een woestijn.",
+      "awards_nl": [],
+      "isrc": "USUM70967700",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1706321518",
+        "de": "applemusic://track/1706321518",
+        "gb": "applemusic://track/1706321518",
+        "fr": "applemusic://track/1706321518",
+        "es": "applemusic://track/1706321518",
+        "nl": "applemusic://track/1706321518",
+        "it": "applemusic://track/1706321518"
+      }
     },
     {
       "year": 2008,
@@ -2746,15 +3526,25 @@
       ],
       "awards": [],
       "fun_fact": "The phone number '678-999-8212' in the song became a real voicemail message from Soulja Boy that fans could call. It was his biggest hit since 'Crank That'.",
-      "fun_fact_de": "Die Telefonnummer '678-999-8212' im Song wurde eine echte Mailbox-Nachricht von Soulja Boy, die Fans anrufen konnten. Es war sein gr\u00f6\u00dfter Hit seit 'Crank That'.",
-      "fun_fact_es": "El n\u00famero de tel\u00e9fono '678-999-8212' en la canci\u00f3n se convirti\u00f3 en un buz\u00f3n de voz real de Soulja Boy que los fans pod\u00edan llamar. Fue su mayor \u00e9xito desde 'Crank That'.",
-      "fun_fact_fr": "Le num\u00e9ro de t\u00e9l\u00e9phone '678-999-8212' dans la chanson est devenu un vrai message vocal de Soulja Boy que les fans pouvaient appeler. C'\u00e9tait son plus grand succ\u00e8s depuis 'Crank That'.",
+      "fun_fact_de": "Die Telefonnummer '678-999-8212' im Song wurde eine echte Mailbox-Nachricht von Soulja Boy, die Fans anrufen konnten. Es war sein größter Hit seit 'Crank That'.",
+      "fun_fact_es": "El número de teléfono '678-999-8212' en la canción se convirtió en un buzón de voz real de Soulja Boy que los fans podían llamar. Fue su mayor éxito desde 'Crank That'.",
+      "fun_fact_fr": "Le numéro de téléphone '678-999-8212' dans la chanson est devenu un vrai message vocal de Soulja Boy que les fans pouvaient appeler. C'était son plus grand succès depuis 'Crank That'.",
       "uri_apple_music": "applemusic://track/1440829195",
       "uri_youtube_music": "https://music.youtube.com/watch?v=47Fbo4kU2AU",
       "uri_tidal": "tidal://track/3876316",
       "uri_deezer": "deezer://track/2675175",
       "fun_fact_nl": "Het telefoonnummer '678-999-8212' in het nummer werd een echt voicemailbericht van Soulja Boy dat fans konden bellen. Het was zijn grootste hit sinds 'Crank That'.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USUM70848200",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1559275261",
+        "de": "applemusic://track/1442789684",
+        "gb": "applemusic://track/1442789684",
+        "fr": "applemusic://track/1442789684",
+        "es": "applemusic://track/1442789684",
+        "nl": "applemusic://track/1559275261",
+        "it": "applemusic://track/1559275261"
+      }
     },
     {
       "year": 2002,
@@ -2787,19 +3577,29 @@
         "Grammy Award - Meilleure performance rap solo"
       ],
       "fun_fact": "Eminem wrote the lyrics on set during breaks filming 8 Mile. He famously fell asleep and missed the Oscar ceremony, waking up to find out he won Best Original Song.",
-      "fun_fact_de": "Eminem schrieb den Text am Set von 8 Mile in den Pausen. Er schlief ein und verpasste die Oscar-Verleihung und erfuhr beim Aufwachen, dass er den Oscar f\u00fcr den besten Originalsong gewonnen hatte.",
-      "fun_fact_es": "Eminem escribi\u00f3 la letra en el set durante los descansos del rodaje de 8 Mile. Se qued\u00f3 dormido y se perdi\u00f3 la ceremonia del \u00d3scar, despertando para descubrir que hab\u00eda ganado Mejor Canci\u00f3n Original.",
-      "fun_fact_fr": "Eminem a \u00e9crit les paroles sur le plateau pendant les pauses du tournage de 8 Mile. Il s'est endormi et a rat\u00e9 la c\u00e9r\u00e9monie des Oscars, apprenant \u00e0 son r\u00e9veil qu'il avait remport\u00e9 l'Oscar de la Meilleure Chanson Originale.",
+      "fun_fact_de": "Eminem schrieb den Text am Set von 8 Mile in den Pausen. Er schlief ein und verpasste die Oscar-Verleihung und erfuhr beim Aufwachen, dass er den Oscar für den besten Originalsong gewonnen hatte.",
+      "fun_fact_es": "Eminem escribió la letra en el set durante los descansos del rodaje de 8 Mile. Se quedó dormido y se perdió la ceremonia del Óscar, despertando para descubrir que había ganado Mejor Canción Original.",
+      "fun_fact_fr": "Eminem a écrit les paroles sur le plateau pendant les pauses du tournage de 8 Mile. Il s'est endormi et a raté la cérémonie des Oscars, apprenant à son réveil qu'il avait remporté l'Oscar de la Meilleure Chanson Originale.",
       "uri_apple_music": "applemusic://track/1444221569",
       "uri_youtube_music": "https://music.youtube.com/watch?v=tR1ECf4sEpw",
       "uri_tidal": "tidal://track/622469",
       "uri_deezer": "deezer://track/1109731",
       "fun_fact_nl": "Eminem schreef de tekst op de set tijdens pauzes bij de opnames van 8 Mile. Het is bekend dat hij in slaap viel en de Oscar-uitreiking miste, en wakker werd om te ontdekken dat hij won voor Beste Originele Nummer.",
       "awards_nl": [
-        "Oscar \u2013 Beste Originele Lied",
-        "Grammy Award \u2013 Beste Rapnummer",
-        "Grammy Award \u2013 Beste Rap Soloprestatie"
-      ]
+        "Oscar – Beste Originele Lied",
+        "Grammy Award – Beste Rapnummer",
+        "Grammy Award – Beste Rap Soloprestatie"
+      ],
+      "isrc": "USIR10211559",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1444221569",
+        "de": "applemusic://track/1444221569",
+        "gb": "applemusic://track/1444221569",
+        "fr": "applemusic://track/1444221569",
+        "es": "applemusic://track/1444221569",
+        "nl": "applemusic://track/1444221569",
+        "it": "applemusic://track/1444221569"
+      }
     },
     {
       "year": 2007,
@@ -2823,15 +3623,25 @@
       ],
       "awards": [],
       "fun_fact": "The song interpolates Ben E. King's 'Stand By Me' and was written when Sean Kingston was only 17 years old. A clean version changed 'suicidal' to 'in denial'.",
-      "fun_fact_de": "Der Song interpoliert Ben E. Kings 'Stand By Me' und wurde geschrieben, als Sean Kingston erst 17 Jahre alt war. Eine bereinigte Version \u00e4nderte 'suicidal' zu 'in denial'.",
-      "fun_fact_es": "La canci\u00f3n interpola 'Stand By Me' de Ben E. King y fue escrita cuando Sean Kingston ten\u00eda solo 17 a\u00f1os. Una versi\u00f3n limpia cambi\u00f3 'suicidal' por 'in denial'.",
-      "fun_fact_fr": "Le titre interpole 'Stand By Me' de Ben E. King et a \u00e9t\u00e9 \u00e9crit quand Sean Kingston n'avait que 17 ans. Une version censur\u00e9e a remplac\u00e9 'suicidal' par 'in denial'.",
+      "fun_fact_de": "Der Song interpoliert Ben E. Kings 'Stand By Me' und wurde geschrieben, als Sean Kingston erst 17 Jahre alt war. Eine bereinigte Version änderte 'suicidal' zu 'in denial'.",
+      "fun_fact_es": "La canción interpola 'Stand By Me' de Ben E. King y fue escrita cuando Sean Kingston tenía solo 17 años. Una versión limpia cambió 'suicidal' por 'in denial'.",
+      "fun_fact_fr": "Le titre interpole 'Stand By Me' de Ben E. King et a été écrit quand Sean Kingston n'avait que 17 ans. Une version censurée a remplacé 'suicidal' par 'in denial'.",
       "uri_apple_music": "applemusic://track/1108211473",
       "uri_youtube_music": "https://music.youtube.com/watch?v=MrTz5xjmso4",
       "uri_tidal": "tidal://track/11337903",
       "uri_deezer": "deezer://track/13705276",
       "fun_fact_nl": "Het nummer bevat elementen van Ben E. King's 'Stand By Me' en werd geschreven toen Sean Kingston pas 17 jaar oud was. Een gekuiste versie veranderde 'suicidal' in 'in denial'.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM10701781",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1634923877",
+        "de": "applemusic://track/621297655",
+        "gb": "applemusic://track/1624131798",
+        "fr": "applemusic://track/621297655",
+        "es": "applemusic://track/621297655",
+        "nl": "applemusic://track/621297655",
+        "it": "applemusic://track/621297655"
+      }
     },
     {
       "year": 2001,
@@ -2854,15 +3664,25 @@
       ],
       "awards": [],
       "fun_fact": "The music video featured the band playing with baby animals including puppies and a baby lion. Rivers Cuomo has said it's the most commercial song he's ever written.",
-      "fun_fact_de": "Im Musikvideo spielt die Band mit Tierbabys, darunter Welpen und ein Babyl\u00f6we. Rivers Cuomo hat gesagt, es sei der kommerziellste Song, den er je geschrieben hat.",
-      "fun_fact_es": "El video musical muestra a la banda jugando con animales beb\u00e9s, incluyendo cachorros y un le\u00f3n beb\u00e9. Rivers Cuomo ha dicho que es la canci\u00f3n m\u00e1s comercial que ha escrito.",
-      "fun_fact_fr": "Le clip montre le groupe jouant avec des b\u00e9b\u00e9s animaux dont des chiots et un b\u00e9b\u00e9 lion. Rivers Cuomo a d\u00e9clar\u00e9 que c'est la chanson la plus commerciale qu'il ait jamais \u00e9crite.",
+      "fun_fact_de": "Im Musikvideo spielt die Band mit Tierbabys, darunter Welpen und ein Babylöwe. Rivers Cuomo hat gesagt, es sei der kommerziellste Song, den er je geschrieben hat.",
+      "fun_fact_es": "El video musical muestra a la banda jugando con animales bebés, incluyendo cachorros y un león bebé. Rivers Cuomo ha dicho que es la canción más comercial que ha escrito.",
+      "fun_fact_fr": "Le clip montre le groupe jouant avec des bébés animaux dont des chiots et un bébé lion. Rivers Cuomo a déclaré que c'est la chanson la plus commerciale qu'il ait jamais écrite.",
       "uri_apple_music": "applemusic://track/1440868258",
       "uri_youtube_music": "https://music.youtube.com/watch?v=erG5rgNYSdk",
       "uri_tidal": "tidal://track/573345",
       "uri_deezer": "deezer://track/2544628",
-      "fun_fact_nl": "In de videoclip was de band te zien spelend met jonge dieren, waaronder puppy's en een baby leeuw. Rivers Cuomo heeft gezegd dat het het meest commerci\u00eble nummer is dat hij ooit heeft geschreven.",
-      "awards_nl": []
+      "fun_fact_nl": "In de videoclip was de band te zien spelend met jonge dieren, waaronder puppy's en een baby leeuw. Rivers Cuomo heeft gezegd dat het het meest commerciële nummer is dat hij ooit heeft geschreven.",
+      "awards_nl": [],
+      "isrc": "USIR10110358",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1891518278",
+        "de": "applemusic://track/1891518278",
+        "gb": "applemusic://track/1891518278",
+        "fr": "applemusic://track/1891518278",
+        "es": "applemusic://track/1891518278",
+        "nl": "applemusic://track/1891518278",
+        "it": "applemusic://track/1891518278"
+      }
     },
     {
       "year": 2000,
@@ -2887,14 +3707,24 @@
       "awards": [],
       "fun_fact": "The song samples 'The Edge' by David McCallum (1967) and became one of the most recognizable hip-hop instrumentals ever. The 'smoke weed everyday' outro by Nate Dogg became a massive meme.",
       "fun_fact_de": "Der Song sampelt 'The Edge' von David McCallum (1967) und wurde zu einem der bekanntesten Hip-Hop-Instrumentals aller Zeiten. Nate Doggs 'Smoke Weed Everyday'-Outro wurde zum Mega-Meme.",
-      "fun_fact_es": "La canci\u00f3n samplea 'The Edge' de David McCallum (1967) y se convirti\u00f3 en uno de los instrumentales de hip-hop m\u00e1s reconocibles. El outro 'smoke weed everyday' de Nate Dogg se convirti\u00f3 en un meme masivo.",
-      "fun_fact_fr": "Le morceau sample 'The Edge' de David McCallum (1967) et est devenu l'un des instrumentaux hip-hop les plus reconnaissables de tous les temps. L'outro 'smoke weed everyday' de Nate Dogg est devenu un m\u00e8me culte.",
+      "fun_fact_es": "La canción samplea 'The Edge' de David McCallum (1967) y se convirtió en uno de los instrumentales de hip-hop más reconocibles. El outro 'smoke weed everyday' de Nate Dogg se convirtió en un meme masivo.",
+      "fun_fact_fr": "Le morceau sample 'The Edge' de David McCallum (1967) et est devenu l'un des instrumentaux hip-hop les plus reconnaissables de tous les temps. L'outro 'smoke weed everyday' de Nate Dogg est devenu un mème culte.",
       "uri_apple_music": "applemusic://track/1440783384",
       "uri_youtube_music": "https://music.youtube.com/watch?v=QZXc39hT8t4",
       "uri_tidal": "tidal://track/35748027",
       "uri_deezer": "deezer://track/128743595",
       "fun_fact_nl": "Het nummer bevat een sample van 'The Edge' van David McCallum (1967) en werd een van de meest herkenbare hiphop-instrumentals ooit. De 'smoke weed everyday'-outro van Nate Dogg werd een enorme meme.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USIR19915078",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1440783384",
+        "de": "applemusic://track/1440783384",
+        "gb": "applemusic://track/1440783384",
+        "fr": "applemusic://track/1440783384",
+        "es": "applemusic://track/1440783384",
+        "nl": "applemusic://track/1440783384",
+        "it": "applemusic://track/1440783384"
+      }
     },
     {
       "year": 2006,
@@ -2918,15 +3748,25 @@
       ],
       "awards": [],
       "fun_fact": "The music video pays homage to rock history, showing the band performing as different rock acts through the decades, from Elvis to punk to grunge to their own style.",
-      "fun_fact_de": "Das Musikvideo ist eine Hommage an die Rockgeschichte und zeigt die Band als verschiedene Rock-Acts durch die Jahrzehnte, von Elvis \u00fcber Punk und Grunge bis zu ihrem eigenen Stil.",
-      "fun_fact_es": "El video musical rinde homenaje a la historia del rock, mostrando a la banda interpretando diferentes actos de rock a trav\u00e9s de las d\u00e9cadas, desde Elvis hasta el punk, el grunge y su propio estilo.",
-      "fun_fact_fr": "Le clip rend hommage \u00e0 l'histoire du rock en montrant le groupe incarnant diff\u00e9rents courants musicaux \u00e0 travers les d\u00e9cennies, d'Elvis au punk en passant par le grunge jusqu'\u00e0 leur propre style.",
+      "fun_fact_de": "Das Musikvideo ist eine Hommage an die Rockgeschichte und zeigt die Band als verschiedene Rock-Acts durch die Jahrzehnte, von Elvis über Punk und Grunge bis zu ihrem eigenen Stil.",
+      "fun_fact_es": "El video musical rinde homenaje a la historia del rock, mostrando a la banda interpretando diferentes actos de rock a través de las décadas, desde Elvis hasta el punk, el grunge y su propio estilo.",
+      "fun_fact_fr": "Le clip rend hommage à l'histoire du rock en montrant le groupe incarnant différents courants musicaux à travers les décennies, d'Elvis au punk en passant par le grunge jusqu'à leur propre style.",
       "uri_apple_music": "applemusic://track/208036515",
       "uri_youtube_music": "https://music.youtube.com/watch?v=Sb5aq5HcS1A",
       "uri_tidal": "tidal://track/309896",
       "uri_deezer": "deezer://track/680516",
       "fun_fact_nl": "De videoclip brengt een eerbetoon aan de rockgeschiedenis en toont de band optredend als verschillende rockacts door de decennia heen, van Elvis tot punk tot grunge tot hun eigen stijl.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USWB10600700",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1703790529",
+        "de": "applemusic://track/1703790529",
+        "gb": "applemusic://track/1703790529",
+        "fr": "applemusic://track/1703790529",
+        "es": "applemusic://track/1703790529",
+        "nl": "applemusic://track/1703790529",
+        "it": "applemusic://track/1703790529"
+      }
     },
     {
       "year": 2001,
@@ -2949,15 +3789,25 @@
       ],
       "awards": [],
       "fun_fact": "The uplifting song was almost left off the album because the band considered it too pop. Its record label Capitol Records initially refused to release the album, so the band self-financed it.",
-      "fun_fact_de": "Der aufmunternde Song wurde fast nicht aufs Album genommen, weil die Band ihn f\u00fcr zu pop hielt. Ihr Label Capitol Records weigerte sich zun\u00e4chst, das Album zu ver\u00f6ffentlichen.",
-      "fun_fact_es": "La canci\u00f3n animada casi se queda fuera del \u00e1lbum porque la banda la consideraba demasiado pop. Su sello Capitol Records inicialmente se neg\u00f3 a lanzar el \u00e1lbum.",
-      "fun_fact_fr": "Ce titre f\u00e9d\u00e9rateur a failli ne pas figurer sur l'album car le groupe le trouvait trop pop. Leur label Capitol Records a d'abord refus\u00e9 de sortir l'album, obligeant le groupe \u00e0 le financer lui-m\u00eame.",
+      "fun_fact_de": "Der aufmunternde Song wurde fast nicht aufs Album genommen, weil die Band ihn für zu pop hielt. Ihr Label Capitol Records weigerte sich zunächst, das Album zu veröffentlichen.",
+      "fun_fact_es": "La canción animada casi se queda fuera del álbum porque la banda la consideraba demasiado pop. Su sello Capitol Records inicialmente se negó a lanzar el álbum.",
+      "fun_fact_fr": "Ce titre fédérateur a failli ne pas figurer sur l'album car le groupe le trouvait trop pop. Leur label Capitol Records a d'abord refusé de sortir l'album, obligeant le groupe à le financer lui-même.",
       "uri_apple_music": "applemusic://track/1450030115",
       "uri_youtube_music": "https://music.youtube.com/watch?v=oKsxPW6i3pM",
       "uri_tidal": "tidal://track/77624459",
       "uri_deezer": "deezer://track/623714212",
       "fun_fact_nl": "Het opbeurende nummer werd bijna niet op het album gezet omdat de band het te veel pop vond. Hun platenlabel Capitol Records weigerde aanvankelijk het album uit te brengen, dus financierde de band het zelf.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USDW10110256",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1706919742",
+        "de": "applemusic://track/1706919742",
+        "gb": "applemusic://track/1706919742",
+        "fr": "applemusic://track/1706919742",
+        "es": "applemusic://track/1706919742",
+        "nl": "applemusic://track/1706919742",
+        "it": "applemusic://track/1706919742"
+      }
     },
     {
       "year": 2006,
@@ -2981,15 +3831,25 @@
       ],
       "awards": [],
       "fun_fact": "The song's opening G note became so iconic that emo fans joke about being 'triggered' by any G note on a piano. It's considered the 'Bohemian Rhapsody' of the emo genre.",
-      "fun_fact_de": "Der Er\u00f6ffnungston G wurde so ikonisch, dass Emo-Fans scherzen, von jedem G-Ton auf dem Klavier 'getriggert' zu werden. Er gilt als 'Bohemian Rhapsody' des Emo-Genres.",
-      "fun_fact_es": "La nota Sol de apertura se volvi\u00f3 tan ic\u00f3nica que los fans emo bromean sobre ser 'activados' por cualquier nota Sol en un piano. Se considera la 'Bohemian Rhapsody' del g\u00e9nero emo.",
-      "fun_fact_fr": "La note de Sol d'ouverture est devenue si embl\u00e9matique que les fans d'emo plaisantent en disant \u00eatre 'd\u00e9clench\u00e9s' par toute note de Sol au piano. Le morceau est consid\u00e9r\u00e9 comme le 'Bohemian Rhapsody' du genre emo.",
+      "fun_fact_de": "Der Eröffnungston G wurde so ikonisch, dass Emo-Fans scherzen, von jedem G-Ton auf dem Klavier 'getriggert' zu werden. Er gilt als 'Bohemian Rhapsody' des Emo-Genres.",
+      "fun_fact_es": "La nota Sol de apertura se volvió tan icónica que los fans emo bromean sobre ser 'activados' por cualquier nota Sol en un piano. Se considera la 'Bohemian Rhapsody' del género emo.",
+      "fun_fact_fr": "La note de Sol d'ouverture est devenue si emblématique que les fans d'emo plaisantent en disant être 'déclenchés' par toute note de Sol au piano. Le morceau est considéré comme le 'Bohemian Rhapsody' du genre emo.",
       "uri_apple_music": "applemusic://track/209388682",
       "uri_youtube_music": "https://music.youtube.com/watch?v=RRKJiM9Njr8",
       "uri_tidal": "tidal://track/353335",
       "uri_deezer": "deezer://track/676573",
       "fun_fact_nl": "De G-noot aan het begin van het nummer werd zo iconisch dat emo-fans grappen maken dat ze 'getriggerd' worden door elke G-noot op een piano. Het wordt beschouwd als de 'Bohemian Rhapsody' van het emo-genre.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USRE10602613",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/209388682",
+        "de": "applemusic://track/1499140470",
+        "gb": "applemusic://track/1499140470",
+        "fr": "applemusic://track/1499140470",
+        "es": "applemusic://track/1499140470",
+        "nl": "applemusic://track/1499140470",
+        "it": "applemusic://track/1499140470"
+      }
     },
     {
       "year": 2001,
@@ -3013,15 +3873,25 @@
       ],
       "awards": [],
       "fun_fact": "The song was voted the #1 song of the decade on a VH1 poll in 2012, beating out many more commercially successful tracks. Despite this, The Calling largely remained a one-hit wonder.",
-      "fun_fact_de": "Der Song wurde bei einer VH1-Umfrage 2012 zum #1-Song des Jahrzehnts gew\u00e4hlt und schlug viele kommerziell erfolgreichere Tracks. Trotzdem blieb The Calling ein One-Hit-Wonder.",
-      "fun_fact_es": "La canci\u00f3n fue votada como la #1 de la d\u00e9cada en una encuesta de VH1 en 2012, superando a muchos \u00e9xitos m\u00e1s comerciales. A pesar de esto, The Calling sigui\u00f3 siendo un \u00e9xito \u00fanico.",
-      "fun_fact_fr": "La chanson a \u00e9t\u00e9 \u00e9lue num\u00e9ro 1 de la d\u00e9cennie lors d'un sondage VH1 en 2012, devan\u00e7ant de nombreux titres bien plus vendus. Malgr\u00e9 cela, The Calling est largement rest\u00e9 un groupe \u00e0 un seul tube.",
+      "fun_fact_de": "Der Song wurde bei einer VH1-Umfrage 2012 zum #1-Song des Jahrzehnts gewählt und schlug viele kommerziell erfolgreichere Tracks. Trotzdem blieb The Calling ein One-Hit-Wonder.",
+      "fun_fact_es": "La canción fue votada como la #1 de la década en una encuesta de VH1 en 2012, superando a muchos éxitos más comerciales. A pesar de esto, The Calling siguió siendo un éxito único.",
+      "fun_fact_fr": "La chanson a été élue numéro 1 de la décennie lors d'un sondage VH1 en 2012, devançant de nombreux titres bien plus vendus. Malgré cela, The Calling est largement resté un groupe à un seul tube.",
       "uri_apple_music": "applemusic://track/407593225",
       "uri_youtube_music": "https://music.youtube.com/watch?v=iAP9AF6DCu4",
       "uri_tidal": "tidal://track/2285381",
       "uri_deezer": "deezer://track/994228",
       "fun_fact_nl": "Het nummer werd in een peiling van VH1 in 2012 verkozen tot het nummer 1-nummer van het decennium, waarbij het veel commercieel succesvollere tracks versloeg. Desondanks bleef The Calling grotendeels een eendagsvlieg.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USRC10001047",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1788997576",
+        "de": "applemusic://track/1739396471",
+        "gb": "applemusic://track/1739396471",
+        "fr": "applemusic://track/1739396471",
+        "es": "applemusic://track/1739396471",
+        "nl": "applemusic://track/1739396471",
+        "it": "applemusic://track/1739396471"
+      }
     },
     {
       "year": 2003,
@@ -3044,15 +3914,25 @@
       ],
       "awards": [],
       "fun_fact": "The ballad became the unofficial anthem for military families separated by deployment during the Iraq War, frequently dedicated on radio request shows by soldiers overseas.",
-      "fun_fact_de": "Die Ballade wurde zur inoffiziellen Hymne f\u00fcr Milit\u00e4rfamilien, die durch den Irakkrieg getrennt waren, und wurde h\u00e4ufig im Radio von Soldaten im Ausland gewidmet.",
-      "fun_fact_es": "La balada se convirti\u00f3 en el himno no oficial de las familias militares separadas por el despliegue durante la Guerra de Irak, frecuentemente dedicada en programas de radio por soldados en el extranjero.",
-      "fun_fact_fr": "Cette ballade est devenue l'hymne officieux des familles de militaires s\u00e9par\u00e9es par le d\u00e9ploiement pendant la guerre d'Irak, fr\u00e9quemment d\u00e9di\u00e9e dans les \u00e9missions de radio par des soldats \u00e0 l'\u00e9tranger.",
+      "fun_fact_de": "Die Ballade wurde zur inoffiziellen Hymne für Militärfamilien, die durch den Irakkrieg getrennt waren, und wurde häufig im Radio von Soldaten im Ausland gewidmet.",
+      "fun_fact_es": "La balada se convirtió en el himno no oficial de las familias militares separadas por el despliegue durante la Guerra de Irak, frecuentemente dedicada en programas de radio por soldados en el extranjero.",
+      "fun_fact_fr": "Cette ballade est devenue l'hymne officieux des familles de militaires séparées par le déploiement pendant la guerre d'Irak, fréquemment dédiée dans les émissions de radio par des soldats à l'étranger.",
       "uri_apple_music": "applemusic://track/1440739980",
       "uri_youtube_music": "https://music.youtube.com/watch?v=kPBzTxZQG5Q",
       "uri_tidal": "tidal://track/572144",
       "uri_deezer": "deezer://track/2172900",
-      "fun_fact_nl": "De ballade werd het onoffici\u00eble volkslied voor militaire gezinnen die gescheiden waren door uitzending tijdens de oorlog in Irak, en werd vaak aangevraagd op de radio door soldaten in het buitenland.",
-      "awards_nl": []
+      "fun_fact_nl": "De ballade werd het onofficiële volkslied voor militaire gezinnen die gescheiden waren door uitzending tijdens de oorlog in Irak, en werd vaak aangevraagd op de radio door soldaten in het buitenland.",
+      "awards_nl": [],
+      "isrc": "USUR10200764",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1706561419",
+        "de": "applemusic://track/1706561419",
+        "gb": "applemusic://track/1706561419",
+        "fr": "applemusic://track/1706561419",
+        "es": "applemusic://track/1706561419",
+        "nl": "applemusic://track/1706561419",
+        "it": "applemusic://track/1706561419"
+      }
     },
     {
       "year": 2006,
@@ -3075,16 +3955,26 @@
         "Silver (UK)"
       ],
       "awards": [],
-      "fun_fact": "The song's carefree vibe was written in a deliberately relaxed way \u2014 Corinne said it was about being young and feeling beautiful. Ritt Momney's 2020 cover went viral on TikTok.",
-      "fun_fact_de": "Der unbeschwerte Song wurde bewusst entspannt geschrieben \u2014 Corinne sagte, er handle davon, jung zu sein und sich sch\u00f6n zu f\u00fchlen. Ritt Momneys Cover von 2020 ging auf TikTok viral.",
-      "fun_fact_es": "La canci\u00f3n despreocupada fue escrita de manera deliberadamente relajada \u2014 Corinne dijo que trataba sobre ser joven y sentirse bella. La versi\u00f3n de Ritt Momney de 2020 se volvi\u00f3 viral en TikTok.",
-      "fun_fact_fr": "L'atmosph\u00e8re insouciante de la chanson a \u00e9t\u00e9 d\u00e9lib\u00e9r\u00e9ment compos\u00e9e de mani\u00e8re d\u00e9contract\u00e9e \u2014 Corinne a dit qu'elle parlait d'\u00eatre jeune et de se sentir belle. La reprise de Ritt Momney en 2020 est devenue virale sur TikTok.",
+      "fun_fact": "The song's carefree vibe was written in a deliberately relaxed way — Corinne said it was about being young and feeling beautiful. Ritt Momney's 2020 cover went viral on TikTok.",
+      "fun_fact_de": "Der unbeschwerte Song wurde bewusst entspannt geschrieben — Corinne sagte, er handle davon, jung zu sein und sich schön zu fühlen. Ritt Momneys Cover von 2020 ging auf TikTok viral.",
+      "fun_fact_es": "La canción despreocupada fue escrita de manera deliberadamente relajada — Corinne dijo que trataba sobre ser joven y sentirse bella. La versión de Ritt Momney de 2020 se volvió viral en TikTok.",
+      "fun_fact_fr": "L'atmosphère insouciante de la chanson a été délibérément composée de manière décontractée — Corinne a dit qu'elle parlait d'être jeune et de se sentir belle. La reprise de Ritt Momney en 2020 est devenue virale sur TikTok.",
       "uri_apple_music": "applemusic://track/724884380",
       "uri_youtube_music": "https://music.youtube.com/watch?v=rjOhZZyn30k",
       "uri_tidal": "tidal://track/122876",
       "uri_deezer": "deezer://track/3119484",
-      "fun_fact_nl": "De onbezorgde vibe van het nummer werd op een bewust ontspannen manier geschreven \u2014 Corinne zei dat het ging over jong zijn en je mooi voelen. De cover van Ritt Momney uit 2020 ging viraal op TikTok.",
-      "awards_nl": []
+      "fun_fact_nl": "De onbezorgde vibe van het nummer werd op een bewust ontspannen manier geschreven — Corinne zei dat het ging over jong zijn en je mooi voelen. De cover van Ritt Momney uit 2020 ging viraal op TikTok.",
+      "awards_nl": [],
+      "isrc": "GBAYE0501671",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1737889119",
+        "de": "applemusic://track/1737889119",
+        "gb": "applemusic://track/1737889119",
+        "fr": "applemusic://track/1737889119",
+        "es": "applemusic://track/1737889119",
+        "nl": "applemusic://track/1737889119",
+        "it": "applemusic://track/1737889119"
+      }
     },
     {
       "year": 2008,
@@ -3108,15 +3998,25 @@
       ],
       "awards": [],
       "fun_fact": "The song debuted at #1 on the Billboard Hot 100, making Britney the only artist besides Mariah Carey to have a song debut at the top spot at that time. It marked her comeback.",
-      "fun_fact_de": "Der Song deb\u00fctierte auf Platz 1 der Billboard Hot 100, wodurch Britney neben Mariah Carey die einzige K\u00fcnstlerin mit einem Deb\u00fct auf dem Spitzenplatz war. Er markierte ihr Comeback.",
-      "fun_fact_es": "La canci\u00f3n debut\u00f3 en el #1 del Billboard Hot 100, haciendo de Britney la \u00fanica artista adem\u00e1s de Mariah Carey en debutar en la cima en ese momento. Marc\u00f3 su regreso.",
-      "fun_fact_fr": "Le titre a d\u00e9but\u00e9 directement au num\u00e9ro 1 du Billboard Hot 100, faisant de Britney la seule artiste apr\u00e8s Mariah Carey \u00e0 atteindre la premi\u00e8re place d\u00e8s la sortie \u00e0 cette \u00e9poque. Il a marqu\u00e9 son grand retour.",
+      "fun_fact_de": "Der Song debütierte auf Platz 1 der Billboard Hot 100, wodurch Britney neben Mariah Carey die einzige Künstlerin mit einem Debüt auf dem Spitzenplatz war. Er markierte ihr Comeback.",
+      "fun_fact_es": "La canción debutó en el #1 del Billboard Hot 100, haciendo de Britney la única artista además de Mariah Carey en debutar en la cima en ese momento. Marcó su regreso.",
+      "fun_fact_fr": "Le titre a débuté directement au numéro 1 du Billboard Hot 100, faisant de Britney la seule artiste après Mariah Carey à atteindre la première place dès la sortie à cette époque. Il a marqué son grand retour.",
       "uri_apple_music": "applemusic://track/990422390",
       "uri_youtube_music": "https://music.youtube.com/watch?v=rMqayQ-U74s",
       "uri_tidal": "tidal://track/33753864",
       "uri_deezer": "deezer://track/82199332",
       "fun_fact_nl": "Het nummer debuteerde op nummer 1 in de Billboard Hot 100, waarmee Britney destijds de enige artiest was naast Mariah Carey met een debuut op de eerste plaats. Het markeerde haar comeback.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USJI10800838",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1744458490",
+        "de": "applemusic://track/1632471651",
+        "gb": "applemusic://track/1632471651",
+        "fr": "applemusic://track/1632471651",
+        "es": "applemusic://track/1632471651",
+        "nl": "applemusic://track/1632471651",
+        "it": "applemusic://track/1632471651"
+      }
     },
     {
       "year": 2009,
@@ -3146,19 +4046,29 @@
         "Grammy Award - Meilleure chanson rap",
         "Grammy Award - Meilleure collaboration rap/chant"
       ],
-      "fun_fact": "The collaboration with Rihanna and Kanye West was recorded separately \u2014 all three artists recorded their parts in different studios and the track was assembled afterward.",
-      "fun_fact_de": "Die Zusammenarbeit mit Rihanna und Kanye West wurde getrennt aufgenommen \u2014 alle drei K\u00fcnstler nahmen ihre Parts in verschiedenen Studios auf und der Track wurde danach zusammengesetzt.",
-      "fun_fact_es": "La colaboraci\u00f3n con Rihanna y Kanye West fue grabada por separado \u2014 los tres artistas grabaron sus partes en diferentes estudios y la pista fue ensamblada despu\u00e9s.",
-      "fun_fact_fr": "La collaboration avec Rihanna et Kanye West a \u00e9t\u00e9 enregistr\u00e9e s\u00e9par\u00e9ment \u2014 les trois artistes ont enregistr\u00e9 leurs parties dans des studios diff\u00e9rents et le morceau a \u00e9t\u00e9 assembl\u00e9 apr\u00e8s coup.",
+      "fun_fact": "The collaboration with Rihanna and Kanye West was recorded separately — all three artists recorded their parts in different studios and the track was assembled afterward.",
+      "fun_fact_de": "Die Zusammenarbeit mit Rihanna und Kanye West wurde getrennt aufgenommen — alle drei Künstler nahmen ihre Parts in verschiedenen Studios auf und der Track wurde danach zusammengesetzt.",
+      "fun_fact_es": "La colaboración con Rihanna y Kanye West fue grabada por separado — los tres artistas grabaron sus partes en diferentes estudios y la pista fue ensamblada después.",
+      "fun_fact_fr": "La collaboration avec Rihanna et Kanye West a été enregistrée séparément — les trois artistes ont enregistré leurs parties dans des studios différents et le morceau a été assemblé après coup.",
       "uri_apple_music": "applemusic://track/1440750271",
       "uri_youtube_music": "https://music.youtube.com/watch?v=ztygmWtWCjQ",
       "uri_tidal": "tidal://track/37704289",
       "uri_deezer": "deezer://track/90533115",
-      "fun_fact_nl": "De samenwerking met Rihanna en Kanye West werd afzonderlijk opgenomen \u2014 alle drie de artiesten namen hun partijen op in verschillende studio's en het nummer werd achteraf samengevoegd.",
+      "fun_fact_nl": "De samenwerking met Rihanna en Kanye West werd afzonderlijk opgenomen — alle drie de artiesten namen hun partijen op in verschillende studio's en het nummer werd achteraf samengevoegd.",
       "awards_nl": [
-        "Grammy Award \u2013 Beste Rapnummer",
-        "Grammy Award \u2013 Beste Rap/Zang-samenwerking"
-      ]
+        "Grammy Award – Beste Rapnummer",
+        "Grammy Award – Beste Rap/Zang-samenwerking"
+      ],
+      "isrc": "USJZ10900010",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1440932648",
+        "de": "applemusic://track/1440777177",
+        "gb": "applemusic://track/1440777177",
+        "fr": "applemusic://track/1440777177",
+        "es": "applemusic://track/1440777177",
+        "nl": "applemusic://track/1440777177",
+        "it": "applemusic://track/1440777177"
+      }
     },
     {
       "year": 2009,
@@ -3182,15 +4092,25 @@
       ],
       "awards": [],
       "fun_fact": "Gaga's iconic 2009 VMA performance where she appeared to bleed on stage while performing Paparazzi is considered one of the greatest VMA moments ever.",
-      "fun_fact_de": "Gagas ikonischer VMA-Auftritt 2009, bei dem sie auf der B\u00fchne zu bluten schien, gilt als einer der gr\u00f6\u00dften VMA-Momente aller Zeiten.",
-      "fun_fact_es": "La ic\u00f3nica actuaci\u00f3n de Gaga en los VMA 2009, donde pareci\u00f3 sangrar en el escenario, se considera uno de los mejores momentos de los VMA.",
-      "fun_fact_fr": "La prestation iconique de Gaga aux VMA 2009, o\u00f9 elle semblait saigner sur sc\u00e8ne en interpr\u00e9tant Paparazzi, est consid\u00e9r\u00e9e comme l'un des moments les plus marquants de l'histoire des VMA.",
+      "fun_fact_de": "Gagas ikonischer VMA-Auftritt 2009, bei dem sie auf der Bühne zu bluten schien, gilt als einer der größten VMA-Momente aller Zeiten.",
+      "fun_fact_es": "La icónica actuación de Gaga en los VMA 2009, donde pareció sangrar en el escenario, se considera uno de los mejores momentos de los VMA.",
+      "fun_fact_fr": "La prestation iconique de Gaga aux VMA 2009, où elle semblait saigner sur scène en interprétant Paparazzi, est considérée comme l'un des moments les plus marquants de l'histoire des VMA.",
       "uri_apple_music": "applemusic://track/1768335618",
       "uri_youtube_music": "https://music.youtube.com/watch?v=d2smz_1L2_0",
       "uri_tidal": "tidal://track/77707018",
       "uri_deezer": "deezer://track/4709950",
       "fun_fact_nl": "Gaga's iconische VMA-optreden uit 2009, waarbij het leek alsof ze op het podium bloedde tijdens het uitvoeren van Paparazzi, wordt beschouwd als een van de grootste VMA-momenten ooit.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USUM70824408",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1476095337",
+        "de": "applemusic://track/1476095337",
+        "gb": "applemusic://track/1476095337",
+        "fr": "applemusic://track/1476095337",
+        "es": "applemusic://track/1476095337",
+        "nl": "applemusic://track/1804427975",
+        "it": "applemusic://track/1476095337"
+      }
     },
     {
       "year": 2001,
@@ -3214,15 +4134,25 @@
       ],
       "awards": [],
       "fun_fact": "Del the Funky Homosapien recorded his rap vocals in one take. Damon Albarn created the virtual band concept partly inspired by his frustration with celebrity culture in Britpop.",
-      "fun_fact_de": "Del the Funky Homosapien nahm seinen Rap in einem Take auf. Damon Albarn schuf das Konzept der virtuellen Band teils aus Frustration \u00fcber die Promi-Kultur im Britpop.",
-      "fun_fact_es": "Del the Funky Homosapien grab\u00f3 su rap en una sola toma. Damon Albarn cre\u00f3 el concepto de banda virtual inspirado en parte por su frustraci\u00f3n con la cultura de celebridades del Britpop.",
-      "fun_fact_fr": "Del the Funky Homosapien a enregistr\u00e9 son rap en une seule prise. Damon Albarn a cr\u00e9\u00e9 le concept du groupe virtuel en partie par frustration face \u00e0 la culture des c\u00e9l\u00e9brit\u00e9s dans le Britpop.",
+      "fun_fact_de": "Del the Funky Homosapien nahm seinen Rap in einem Take auf. Damon Albarn schuf das Konzept der virtuellen Band teils aus Frustration über die Promi-Kultur im Britpop.",
+      "fun_fact_es": "Del the Funky Homosapien grabó su rap en una sola toma. Damon Albarn creó el concepto de banda virtual inspirado en parte por su frustración con la cultura de celebridades del Britpop.",
+      "fun_fact_fr": "Del the Funky Homosapien a enregistré son rap en une seule prise. Damon Albarn a créé le concept du groupe virtuel en partie par frustration face à la culture des célébrités dans le Britpop.",
       "uri_apple_music": "applemusic://track/850576665",
       "uri_youtube_music": "https://music.youtube.com/watch?v=1V_xRb0x9aw",
       "uri_tidal": "tidal://track/125352",
       "uri_deezer": "deezer://track/3100444",
-      "fun_fact_nl": "Del the Funky Homosapien nam zijn rap-vocals in \u00e9\u00e9n take op. Damon Albarn cre\u00eberde het concept van de virtuele band deels ge\u00efnspireerd door zijn frustratie over de beroemdheidscultuur in de Britpop.",
-      "awards_nl": []
+      "fun_fact_nl": "Del the Funky Homosapien nam zijn rap-vocals in één take op. Damon Albarn creëerde het concept van de virtuele band deels geïnspireerd door zijn frustratie over de beroemdheidscultuur in de Britpop.",
+      "awards_nl": [],
+      "isrc": "GBAYE1400468",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/850576665",
+        "de": "applemusic://track/850576665",
+        "gb": "applemusic://track/850576665",
+        "fr": "applemusic://track/850576665",
+        "es": "applemusic://track/850576665",
+        "nl": "applemusic://track/850576665",
+        "it": "applemusic://track/850576665"
+      }
     },
     {
       "year": 2001,
@@ -3247,14 +4177,24 @@
       "awards": [],
       "fun_fact": "The song samples 'Angel of the Morning' by Juice Newton and Steve Miller Band's 'The Joker'. It gave Shaggy his second consecutive #1 hit after 'It Wasn't Me'.",
       "fun_fact_de": "Der Song sampelt 'Angel of the Morning' von Juice Newton und 'The Joker' der Steve Miller Band. Er gab Shaggy seinen zweiten #1-Hit in Folge nach 'It Wasn't Me'.",
-      "fun_fact_es": "La canci\u00f3n samplea 'Angel of the Morning' de Juice Newton y 'The Joker' de Steve Miller Band. Le dio a Shaggy su segundo #1 consecutivo despu\u00e9s de 'It Wasn't Me'.",
-      "fun_fact_fr": "Le morceau sample 'Angel of the Morning' de Juice Newton et 'The Joker' du Steve Miller Band. C'est le deuxi\u00e8me num\u00e9ro 1 cons\u00e9cutif de Shaggy apr\u00e8s 'It Wasn't Me'.",
+      "fun_fact_es": "La canción samplea 'Angel of the Morning' de Juice Newton y 'The Joker' de Steve Miller Band. Le dio a Shaggy su segundo #1 consecutivo después de 'It Wasn't Me'.",
+      "fun_fact_fr": "Le morceau sample 'Angel of the Morning' de Juice Newton et 'The Joker' du Steve Miller Band. C'est le deuxième numéro 1 consécutif de Shaggy après 'It Wasn't Me'.",
       "uri_apple_music": "applemusic://track/1440745528",
       "uri_youtube_music": "https://music.youtube.com/watch?v=XWJrPzAUzAs",
       "uri_tidal": "tidal://track/102638288",
       "uri_deezer": "deezer://track/2122528",
       "fun_fact_nl": "Het nummer bevat samples van 'Angel of the Morning' van Juice Newton en 'The Joker' van de Steve Miller Band. Het bezorgde Shaggy zijn tweede opeenvolgende nummer 1-hit na 'It Wasn't Me'.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMC19989405",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1711865533",
+        "de": "applemusic://track/1711865533",
+        "gb": "applemusic://track/1711865533",
+        "fr": "applemusic://track/1711865533",
+        "es": "applemusic://track/1562782304",
+        "nl": "applemusic://track/1711865533",
+        "it": "applemusic://track/1711865533"
+      }
     },
     {
       "year": 2002,
@@ -3278,15 +4218,25 @@
       ],
       "awards": [],
       "fun_fact": "The music video features Anthony Kiedis being kidnapped by a crazed taxi driver, directed by Jonathan Dayton and Valerie Faris who later directed Little Miss Sunshine.",
-      "fun_fact_de": "Im Musikvideo wird Anthony Kiedis von einem verr\u00fcckten Taxifahrer entf\u00fchrt, inszeniert von Jonathan Dayton und Valerie Faris, die sp\u00e4ter Little Miss Sunshine drehten.",
+      "fun_fact_de": "Im Musikvideo wird Anthony Kiedis von einem verrückten Taxifahrer entführt, inszeniert von Jonathan Dayton und Valerie Faris, die später Little Miss Sunshine drehten.",
       "fun_fact_es": "En el video musical, Anthony Kiedis es secuestrado por un taxista enloquecido, dirigido por Jonathan Dayton y Valerie Faris, quienes luego dirigieron Little Miss Sunshine.",
-      "fun_fact_fr": "Dans le clip, Anthony Kiedis est kidnapp\u00e9 par un chauffeur de taxi fou furieux, r\u00e9alis\u00e9 par Jonathan Dayton et Valerie Faris qui ont ensuite r\u00e9alis\u00e9 Little Miss Sunshine.",
+      "fun_fact_fr": "Dans le clip, Anthony Kiedis est kidnappé par un chauffeur de taxi fou furieux, réalisé par Jonathan Dayton et Valerie Faris qui ont ensuite réalisé Little Miss Sunshine.",
       "uri_apple_music": "applemusic://track/945578421",
       "uri_youtube_music": "https://music.youtube.com/watch?v=O-A7It0bZ2w",
       "uri_tidal": "tidal://track/304859",
       "uri_deezer": "deezer://track/725929",
       "fun_fact_nl": "In de videoclip wordt Anthony Kiedis ontvoerd door een krankzinnige taxichauffeur, geregisseerd door Jonathan Dayton en Valerie Faris die later Little Miss Sunshine regisseerden.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USWB11402798",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/947688252",
+        "de": "applemusic://track/947688252",
+        "gb": "applemusic://track/947688252",
+        "fr": "applemusic://track/947688252",
+        "es": "applemusic://track/947688252",
+        "nl": "applemusic://track/947688252",
+        "it": "applemusic://track/947688252"
+      }
     },
     {
       "year": 2003,
@@ -3309,16 +4259,26 @@
         "Silver (UK)"
       ],
       "awards": [],
-      "fun_fact": "The remix featuring Snoop Dogg became even more popular than the original. The song's talk box effect was performed by Roger Troutman's prot\u00e9g\u00e9.",
-      "fun_fact_de": "Der Remix mit Snoop Dogg wurde sogar popul\u00e4rer als das Original. Der Talkbox-Effekt wurde von Roger Troutmans Sch\u00fctzling gespielt.",
-      "fun_fact_es": "El remix con Snoop Dogg se volvi\u00f3 a\u00fan m\u00e1s popular que el original. El efecto de talk box fue interpretado por el protegido de Roger Troutman.",
-      "fun_fact_fr": "Le remix avec Snoop Dogg est devenu encore plus populaire que l'original. L'effet talk box du morceau a \u00e9t\u00e9 r\u00e9alis\u00e9 par le prot\u00e9g\u00e9 de Roger Troutman.",
+      "fun_fact": "The remix featuring Snoop Dogg became even more popular than the original. The song's talk box effect was performed by Roger Troutman's protégé.",
+      "fun_fact_de": "Der Remix mit Snoop Dogg wurde sogar populärer als das Original. Der Talkbox-Effekt wurde von Roger Troutmans Schützling gespielt.",
+      "fun_fact_es": "El remix con Snoop Dogg se volvió aún más popular que el original. El efecto de talk box fue interpretado por el protegido de Roger Troutman.",
+      "fun_fact_fr": "Le remix avec Snoop Dogg est devenu encore plus populaire que l'original. L'effet talk box du morceau a été réalisé par le protégé de Roger Troutman.",
       "uri_apple_music": "applemusic://track/1440842046",
       "uri_youtube_music": "https://music.youtube.com/watch?v=N3xU63cBj0U",
       "uri_tidal": "tidal://track/607361",
       "uri_deezer": "deezer://track/1141674",
-      "fun_fact_nl": "De remix met Snoop Dogg werd zelfs populairder dan het origineel. Het talkbox-effect van het nummer werd uitgevoerd door een proteg\u00e9 van Roger Troutman.",
-      "awards_nl": []
+      "fun_fact_nl": "De remix met Snoop Dogg werd zelfs populairder dan het origineel. Het talkbox-effect van het nummer werd uitgevoerd door een protegé van Roger Troutman.",
+      "awards_nl": [],
+      "isrc": "USIR10300020",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1442989696",
+        "de": "applemusic://track/1469577157",
+        "gb": "applemusic://track/1469577157",
+        "fr": "applemusic://track/1469577157",
+        "es": "applemusic://track/1469577157",
+        "nl": "applemusic://track/1469577157",
+        "it": "applemusic://track/1469577157"
+      }
     },
     {
       "year": 2006,
@@ -3341,16 +4301,26 @@
         "Platinum (UK)"
       ],
       "awards": [],
-      "fun_fact": "Tom Higgenson wrote the song for Delilah DiCrescenzo, a cross-country runner he met at a party. She wasn't his girlfriend \u2014 they were just acquaintances.",
-      "fun_fact_de": "Tom Higgenson schrieb den Song f\u00fcr Delilah DiCrescenzo, eine Langstreckenl\u00e4uferin, die er auf einer Party traf. Sie waren nur Bekannte.",
-      "fun_fact_es": "Tom Higgenson escribi\u00f3 la canci\u00f3n para Delilah DiCrescenzo, una corredora de cross-country que conoci\u00f3 en una fiesta. No eran novios, solo conocidos.",
-      "fun_fact_fr": "Tom Higgenson a \u00e9crit la chanson pour Delilah DiCrescenzo, une coureuse de cross-country rencontr\u00e9e lors d'une f\u00eate. Elle n'\u00e9tait pas sa petite amie \u2014 ils \u00e9taient simplement connaissances.",
+      "fun_fact": "Tom Higgenson wrote the song for Delilah DiCrescenzo, a cross-country runner he met at a party. She wasn't his girlfriend — they were just acquaintances.",
+      "fun_fact_de": "Tom Higgenson schrieb den Song für Delilah DiCrescenzo, eine Langstreckenläuferin, die er auf einer Party traf. Sie waren nur Bekannte.",
+      "fun_fact_es": "Tom Higgenson escribió la canción para Delilah DiCrescenzo, una corredora de cross-country que conoció en una fiesta. No eran novios, solo conocidos.",
+      "fun_fact_fr": "Tom Higgenson a écrit la chanson pour Delilah DiCrescenzo, une coureuse de cross-country rencontrée lors d'une fête. Elle n'était pas sa petite amie — ils étaient simplement connaissances.",
       "uri_apple_music": "applemusic://track/1442825350",
       "uri_youtube_music": "https://music.youtube.com/watch?v=h_m-BjrxmgI",
       "uri_tidal": "tidal://track/35128374",
       "uri_deezer": "deezer://track/921959412",
-      "fun_fact_nl": "Tom Higgenson schreef het nummer voor Delilah DiCrescenzo, een hardloopster die hij op een feestje ontmoette. Ze was niet zijn vriendin \u2014 ze waren slechts kennissen.",
-      "awards_nl": []
+      "fun_fact_nl": "Tom Higgenson schreef het nummer voor Delilah DiCrescenzo, een hardloopster die hij op een feestje ontmoette. Ze was niet zijn vriendin — ze waren slechts kennissen.",
+      "awards_nl": [],
+      "isrc": "USHR10622325",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1635071819",
+        "de": "applemusic://track/1635071819",
+        "gb": "applemusic://track/1635071819",
+        "fr": "applemusic://track/1635071819",
+        "es": "applemusic://track/1635071819",
+        "nl": "applemusic://track/1635071819",
+        "it": "applemusic://track/1635071819"
+      }
     },
     {
       "year": 2007,
@@ -3374,15 +4344,25 @@
       ],
       "awards": [],
       "fun_fact": "The romantic ballad was written by Johnta Austin and showcased Chris Brown's softer vocal side after his uptempo debut hits. It became a prom staple across America.",
-      "fun_fact_de": "Die romantische Ballade wurde von Johnta Austin geschrieben und zeigte Chris Browns sanftere Seite. Sie wurde zu einem festen Bestandteil amerikanischer Abschlussb\u00e4lle.",
-      "fun_fact_es": "La balada rom\u00e1ntica fue escrita por Johnta Austin y mostr\u00f3 el lado vocal m\u00e1s suave de Chris Brown. Se convirti\u00f3 en un cl\u00e1sico de los bailes de graduaci\u00f3n en Am\u00e9rica.",
-      "fun_fact_fr": "Cette ballade romantique \u00e9crite par Johnta Austin a d\u00e9voil\u00e9 le c\u00f4t\u00e9 vocal plus doux de Chris Brown apr\u00e8s ses premiers tubes rythm\u00e9s. Elle est devenue un classique des bals de promo aux \u00c9tats-Unis.",
+      "fun_fact_de": "Die romantische Ballade wurde von Johnta Austin geschrieben und zeigte Chris Browns sanftere Seite. Sie wurde zu einem festen Bestandteil amerikanischer Abschlussbälle.",
+      "fun_fact_es": "La balada romántica fue escrita por Johnta Austin y mostró el lado vocal más suave de Chris Brown. Se convirtió en un clásico de los bailes de graduación en América.",
+      "fun_fact_fr": "Cette ballade romantique écrite par Johnta Austin a dévoilé le côté vocal plus doux de Chris Brown après ses premiers tubes rythmés. Elle est devenue un classique des bals de promo aux États-Unis.",
       "uri_apple_music": "applemusic://track/267264889",
       "uri_youtube_music": "https://music.youtube.com/watch?v=nmjdaBaZe8Y",
       "uri_tidal": "tidal://track/1707456",
       "uri_deezer": "deezer://track/15042720",
       "fun_fact_nl": "De romantische ballade werd geschreven door Johnta Austin en toonde de zachtere vocale kant van Chris Brown na zijn uptempo debuuthits. Het werd een vast onderdeel op gala's in heel Amerika.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USJI10700711",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/267264889",
+        "de": "applemusic://track/267264889",
+        "gb": "applemusic://track/267264889",
+        "fr": "applemusic://track/267264889",
+        "es": "applemusic://track/267264889",
+        "nl": "applemusic://track/267264889",
+        "it": "applemusic://track/267264889"
+      }
     },
     {
       "year": 2005,
@@ -3406,15 +4386,25 @@
       ],
       "awards": [],
       "fun_fact": "Jamie Foxx's vocal sample came from Ray Charles' 'I Got a Woman' and was recorded right after Foxx won the Oscar for playing Ray Charles. Kanye wrote the song in one hour.",
-      "fun_fact_de": "Jamie Foxx' Gesangs-Sample stammt von Ray Charles' 'I Got a Woman' und wurde kurz nach Foxx' Oscar-Gewinn f\u00fcr die Rolle des Ray Charles aufgenommen. Kanye schrieb den Song in einer Stunde.",
-      "fun_fact_es": "La muestra vocal de Jamie Foxx proviene de 'I Got a Woman' de Ray Charles y fue grabada justo despu\u00e9s de que Foxx ganara el \u00d3scar por interpretar a Ray Charles. Kanye escribi\u00f3 la canci\u00f3n en una hora.",
-      "fun_fact_fr": "Le sample vocal de Jamie Foxx vient de 'I Got a Woman' de Ray Charles et a \u00e9t\u00e9 enregistr\u00e9 juste apr\u00e8s que Foxx a remport\u00e9 l'Oscar pour son interpr\u00e9tation de Ray Charles. Kanye a \u00e9crit la chanson en une heure.",
+      "fun_fact_de": "Jamie Foxx' Gesangs-Sample stammt von Ray Charles' 'I Got a Woman' und wurde kurz nach Foxx' Oscar-Gewinn für die Rolle des Ray Charles aufgenommen. Kanye schrieb den Song in einer Stunde.",
+      "fun_fact_es": "La muestra vocal de Jamie Foxx proviene de 'I Got a Woman' de Ray Charles y fue grabada justo después de que Foxx ganara el Óscar por interpretar a Ray Charles. Kanye escribió la canción en una hora.",
+      "fun_fact_fr": "Le sample vocal de Jamie Foxx vient de 'I Got a Woman' de Ray Charles et a été enregistré juste après que Foxx a remporté l'Oscar pour son interprétation de Ray Charles. Kanye a écrit la chanson en une heure.",
       "uri_apple_music": "applemusic://track/1440669054",
       "uri_youtube_music": "https://music.youtube.com/watch?v=6vwNcNOTVzY",
       "uri_tidal": "tidal://track/593851",
       "uri_deezer": "deezer://track/1184309",
-      "fun_fact_nl": "Het vocale sample van Jamie Foxx kwam uit 'I Got a Woman' van Ray Charles en werd opgenomen vlak nadat Foxx de Oscar had gewonnen voor het spelen van Ray Charles. Kanye schreef het nummer in \u00e9\u00e9n uur.",
-      "awards_nl": []
+      "fun_fact_nl": "Het vocale sample van Jamie Foxx kwam uit 'I Got a Woman' van Ray Charles en werd opgenomen vlak nadat Foxx de Oscar had gewonnen voor het spelen van Ray Charles. Kanye schreef het nummer in één uur.",
+      "awards_nl": [],
+      "isrc": "USUM70500143",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1443571076",
+        "de": "applemusic://track/1443571076",
+        "gb": "applemusic://track/1443571076",
+        "fr": "applemusic://track/1443571076",
+        "es": "applemusic://track/1443571076",
+        "nl": "applemusic://track/1443571076",
+        "it": "applemusic://track/1443571076"
+      }
     },
     {
       "year": 2005,
@@ -3422,7 +4412,7 @@
       "artist": "Rihanna",
       "alt_artists": [
         "Sean Paul",
-        "Beyonc\u00e9",
+        "Beyoncé",
         "Ciara",
         "Ashanti"
       ],
@@ -3438,15 +4428,25 @@
       ],
       "awards": [],
       "fun_fact": "Pon de Replay was Rihanna's debut single, recorded when she was just 16 years old after being discovered by Evan Rogers during a vacation in Barbados, who then arranged an audition with Jay-Z at Def Jam.",
-      "fun_fact_de": "Rihanna war erst 16 Jahre alt, als sie 'Pon de Replay' aufnahm. Jay-Z war so beeindruckt von ihrem Vorsingen, dass er sie noch am selben Tag unter Vertrag nahm und sie das B\u00fcro nicht verlassen lie\u00df, bis der Deal unterschrieben war.",
-      "fun_fact_es": "El t\u00edtulo mezcla ingl\u00e9s con patois jamaicano: 'Pon' significa 'poner' y 'de replay' significa 'la repetici\u00f3n', pidiendo al DJ que vuelva a poner la canci\u00f3n \u2014 un tema perfecto para la primera canci\u00f3n de la futura superestrella de Barbados.",
-      "fun_fact_fr": "Pon de Replay est le premier single de Rihanna, enregistr\u00e9 alors qu'elle n'avait que 16 ans apr\u00e8s avoir \u00e9t\u00e9 d\u00e9couverte par Evan Rogers lors de vacances \u00e0 la Barbade, qui lui a ensuite organis\u00e9 une audition avec Jay-Z chez Def Jam.",
+      "fun_fact_de": "Rihanna war erst 16 Jahre alt, als sie 'Pon de Replay' aufnahm. Jay-Z war so beeindruckt von ihrem Vorsingen, dass er sie noch am selben Tag unter Vertrag nahm und sie das Büro nicht verlassen ließ, bis der Deal unterschrieben war.",
+      "fun_fact_es": "El título mezcla inglés con patois jamaicano: 'Pon' significa 'poner' y 'de replay' significa 'la repetición', pidiendo al DJ que vuelva a poner la canción — un tema perfecto para la primera canción de la futura superestrella de Barbados.",
+      "fun_fact_fr": "Pon de Replay est le premier single de Rihanna, enregistré alors qu'elle n'avait que 16 ans après avoir été découverte par Evan Rogers lors de vacances à la Barbade, qui lui a ensuite organisé une audition avec Jay-Z chez Def Jam.",
       "uri_apple_music": "applemusic://track/1440867324",
       "uri_youtube_music": "https://music.youtube.com/watch?v=oEauWw9ZGrA",
       "uri_tidal": "tidal://track/594448",
       "uri_deezer": "deezer://track/2953166",
       "fun_fact_nl": "Pon de Replay was de debuutsingle van Rihanna, opgenomen toen ze pas 16 jaar oud was nadat ze was ontdekt door Evan Rogers tijdens een vakantie op Barbados, die vervolgens een auditie regelde met Jay-Z bij Def Jam.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USIR20500331",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1442974360",
+        "de": "applemusic://track/1442974360",
+        "gb": "applemusic://track/1442974360",
+        "fr": "applemusic://track/1442974360",
+        "es": "applemusic://track/1442974360",
+        "nl": "applemusic://track/1442493528",
+        "it": "applemusic://track/1442493528"
+      }
     },
     {
       "year": 2007,
@@ -3469,15 +4469,25 @@
       ],
       "awards": [],
       "fun_fact": "The vowel-less title was inspired by the band's fascination with the text-speak culture of the mid-2000s. The music video, directed by Alan Ferguson, features a chimpanzee party and cameos from Kim Kardashian.",
-      "fun_fact_de": "Der Titel ohne Vokale war eine bewusste Anspielung auf die SMS-Kultur der 2000er Jahre. Im Musikvideo spielt ein Schimpanse die Hauptrolle bei einer wilden Party \u2013 ein surrealer Clip, der auf MTV zum Hit wurde.",
-      "fun_fact_es": "El t\u00edtulo sin vocales ('Gracias por los recuerdos') refleja la cultura de mensajes de texto de los 2000. El video musical presenta una fiesta de chimpanc\u00e9s y un cameo de Kim Kardashian antes de que se convirtiera en una megaestrella.",
-      "fun_fact_fr": "Le titre sans voyelles s'inspire de la fascination du groupe pour la culture SMS du milieu des ann\u00e9es 2000. Le clip, r\u00e9alis\u00e9 par Alan Ferguson, met en sc\u00e8ne une f\u00eate de chimpanz\u00e9s avec des apparitions de Kim Kardashian.",
+      "fun_fact_de": "Der Titel ohne Vokale war eine bewusste Anspielung auf die SMS-Kultur der 2000er Jahre. Im Musikvideo spielt ein Schimpanse die Hauptrolle bei einer wilden Party – ein surrealer Clip, der auf MTV zum Hit wurde.",
+      "fun_fact_es": "El título sin vocales ('Gracias por los recuerdos') refleja la cultura de mensajes de texto de los 2000. El video musical presenta una fiesta de chimpancés y un cameo de Kim Kardashian antes de que se convirtiera en una megaestrella.",
+      "fun_fact_fr": "Le titre sans voyelles s'inspire de la fascination du groupe pour la culture SMS du milieu des années 2000. Le clip, réalisé par Alan Ferguson, met en scène une fête de chimpanzés avec des apparitions de Kim Kardashian.",
       "uri_apple_music": "applemusic://track/1440787031",
       "uri_youtube_music": "https://music.youtube.com/watch?v=onzL0EM1pKY",
       "uri_tidal": "tidal://track/1213576",
       "uri_deezer": "deezer://track/911496",
-      "fun_fact_nl": "De titel zonder klinkers was ge\u00efnspireerd op de fascinatie van de band voor de sms-taalcultuur van het midden van de jaren 2000. De videoclip, geregisseerd door Alan Ferguson, bevat een chimpanzeefeestje en cameo's van Kim Kardashian.",
-      "awards_nl": []
+      "fun_fact_nl": "De titel zonder klinkers was geïnspireerd op de fascinatie van de band voor de sms-taalcultuur van het midden van de jaren 2000. De videoclip, geregisseerd door Alan Ferguson, bevat een chimpanzeefeestje en cameo's van Kim Kardashian.",
+      "awards_nl": [],
+      "isrc": "USUM70700326",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1440560148",
+        "de": "applemusic://track/1440560148",
+        "gb": "applemusic://track/1440560148",
+        "fr": "applemusic://track/1440560148",
+        "es": "applemusic://track/1440560148",
+        "nl": "applemusic://track/1440560148",
+        "it": "applemusic://track/1440560148"
+      }
     },
     {
       "year": 2001,
@@ -3501,15 +4511,25 @@
       ],
       "awards": [],
       "fun_fact": "Fallin' spent six weeks at #1 on the Billboard Hot 100 and won three Grammy Awards, launching the career of a 20-year-old Alicia Keys who wrote and produced the song herself with minimal outside help.",
-      "fun_fact_de": "Alicia Keys schrieb 'Fallin'' als sie gerade 14 Jahre alt war, aber es wurde erst ver\u00f6ffentlicht, als sie 20 war. Das Lied gewann drei Grammy Awards und machte sie \u00fcber Nacht zum Superstar der R&B-Szene.",
-      "fun_fact_es": "Keys escribi\u00f3 'Fallin'' a los 14 a\u00f1os, inspirada por una relaci\u00f3n tormentosa. La canci\u00f3n gan\u00f3 tres premios Grammy en 2002, incluyendo Canci\u00f3n del A\u00f1o, estableciendo a Keys como una de las grandes voces de su generaci\u00f3n.",
-      "fun_fact_fr": "Fallin' est rest\u00e9 six semaines au sommet du Billboard Hot 100 et a remport\u00e9 trois Grammy Awards, lan\u00e7ant la carri\u00e8re d'Alicia Keys, alors \u00e2g\u00e9e de 20 ans, qui avait \u00e9crit et produit la chanson pratiquement seule.",
+      "fun_fact_de": "Alicia Keys schrieb 'Fallin'' als sie gerade 14 Jahre alt war, aber es wurde erst veröffentlicht, als sie 20 war. Das Lied gewann drei Grammy Awards und machte sie über Nacht zum Superstar der R&B-Szene.",
+      "fun_fact_es": "Keys escribió 'Fallin'' a los 14 años, inspirada por una relación tormentosa. La canción ganó tres premios Grammy en 2002, incluyendo Canción del Año, estableciendo a Keys como una de las grandes voces de su generación.",
+      "fun_fact_fr": "Fallin' est resté six semaines au sommet du Billboard Hot 100 et a remporté trois Grammy Awards, lançant la carrière d'Alicia Keys, alors âgée de 20 ans, qui avait écrit et produit la chanson pratiquement seule.",
       "uri_apple_music": "applemusic://track/256937038",
       "uri_youtube_music": "https://music.youtube.com/watch?v=Urdlvw0SSEc",
       "uri_tidal": "tidal://track/515765",
       "uri_deezer": "deezer://track/959183",
-      "fun_fact_nl": "Fallin' stond zes weken op nummer 1 in de Billboard Hot 100 en won drie Grammy Awards, wat de carri\u00e8re lanceerde van de 20-jarige Alicia Keys die het nummer zelf schreef en produceerde met minimale hulp van buitenaf.",
-      "awards_nl": []
+      "fun_fact_nl": "Fallin' stond zes weken op nummer 1 in de Billboard Hot 100 en won drie Grammy Awards, wat de carrière lanceerde van de 20-jarige Alicia Keys die het nummer zelf schreef en produceerde met minimale hulp van buitenaf.",
+      "awards_nl": [],
+      "isrc": "USJAY0100057",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1789173143",
+        "de": "applemusic://track/1789173143",
+        "gb": "applemusic://track/1789173143",
+        "fr": "applemusic://track/1789173143",
+        "es": "applemusic://track/1789173143",
+        "nl": "applemusic://track/1789173143",
+        "it": "applemusic://track/1789173143"
+      }
     },
     {
       "year": 2001,
@@ -3533,15 +4553,25 @@
       ],
       "awards": [],
       "fun_fact": "The song was rejected by Sophie Ellis-Bextor and S Club 7 before Kylie recorded it. Its hypnotic 'la la la' hook and minimal production made it the best-selling single of 2001 worldwide with over 5 million copies sold.",
-      "fun_fact_de": "Der Song wurde zun\u00e4chst von Sophie Ellis-Bextor und S Club 7 abgelehnt, bevor Kylie ihn aufnahm. Mit \u00fcber 5 Millionen verkauften Exemplaren war es die meistverkaufte Single des Jahres 2001 weltweit.",
-      "fun_fact_es": "La canci\u00f3n fue rechazada por Sophie Ellis-Bextor y S Club 7 antes de llegar a Kylie. Su ic\u00f3nico gancho 'la la la' la convirti\u00f3 en la single m\u00e1s vendida de 2001, con m\u00e1s de 5 millones de copias en todo el mundo.",
-      "fun_fact_fr": "Le titre avait \u00e9t\u00e9 refus\u00e9 par Sophie Ellis-Bextor et S Club 7 avant que Kylie ne l'enregistre. Son refrain hypnotique 'la la la' et sa production minimaliste en ont fait le single le plus vendu de 2001 dans le monde avec plus de 5 millions d'exemplaires.",
+      "fun_fact_de": "Der Song wurde zunächst von Sophie Ellis-Bextor und S Club 7 abgelehnt, bevor Kylie ihn aufnahm. Mit über 5 Millionen verkauften Exemplaren war es die meistverkaufte Single des Jahres 2001 weltweit.",
+      "fun_fact_es": "La canción fue rechazada por Sophie Ellis-Bextor y S Club 7 antes de llegar a Kylie. Su icónico gancho 'la la la' la convirtió en la single más vendida de 2001, con más de 5 millones de copias en todo el mundo.",
+      "fun_fact_fr": "Le titre avait été refusé par Sophie Ellis-Bextor et S Club 7 avant que Kylie ne l'enregistre. Son refrain hypnotique 'la la la' et sa production minimaliste en ont fait le single le plus vendu de 2001 dans le monde avec plus de 5 millions d'exemplaires.",
       "uri_apple_music": "applemusic://track/726320692",
       "uri_youtube_music": "https://music.youtube.com/watch?v=c18441Eh_WE",
       "uri_tidal": "tidal://track/480155",
       "uri_deezer": "deezer://track/3098100",
       "fun_fact_nl": "Het nummer werd geweigerd door Sophie Ellis-Bextor en S Club 7 voordat Kylie het opnam. De hypnotiserende 'la la la'-hook en minimale productie maakten het de bestverkochte single van 2001 wereldwijd met meer dan 5 miljoen verkochte exemplaren.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAYE0100913",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1797553119",
+        "de": "applemusic://track/1550917780",
+        "gb": "applemusic://track/1797553119",
+        "fr": "applemusic://track/1797553119",
+        "es": "applemusic://track/1797553119",
+        "nl": "applemusic://track/1797553119",
+        "it": "applemusic://track/1797553119"
+      }
     },
     {
       "year": 1999,
@@ -3565,15 +4595,25 @@
       ],
       "awards": [],
       "fun_fact": "Say My Name won two Grammy Awards in 2001 and is considered one of the greatest songs of the R&B genre. Its innovative production by Rodney Jerkins featured interlocking vocal parts that were groundbreaking for girl groups.",
-      "fun_fact_de": "Der Song gewann 2001 zwei Grammys, darunter Bester R&B-Song. Die innovative Produktion von Rodney Jerkins mit ineinander verschr\u00e4nkten Gesangsstimmen setzte neue Ma\u00dfst\u00e4be f\u00fcr Girlgroups und beeinflusste die Pop-Produktion der 2000er Jahre.",
-      "fun_fact_es": "La letra trata sobre confrontar a una pareja infiel \u2014 si no puede decir tu nombre, algo est\u00e1 mal. Gan\u00f3 dos premios Grammy y su producci\u00f3n innovadora de Rodney Jerkins cambi\u00f3 el sonido del R&B a principios de los 2000.",
-      "fun_fact_fr": "Say My Name a remport\u00e9 deux Grammy Awards en 2001 et est consid\u00e9r\u00e9 comme l'un des plus grands morceaux du genre R&B. La production innovante de Rodney Jerkins avec ses parties vocales entrelac\u00e9es a r\u00e9volutionn\u00e9 les groupes f\u00e9minins.",
+      "fun_fact_de": "Der Song gewann 2001 zwei Grammys, darunter Bester R&B-Song. Die innovative Produktion von Rodney Jerkins mit ineinander verschränkten Gesangsstimmen setzte neue Maßstäbe für Girlgroups und beeinflusste die Pop-Produktion der 2000er Jahre.",
+      "fun_fact_es": "La letra trata sobre confrontar a una pareja infiel — si no puede decir tu nombre, algo está mal. Ganó dos premios Grammy y su producción innovadora de Rodney Jerkins cambió el sonido del R&B a principios de los 2000.",
+      "fun_fact_fr": "Say My Name a remporté deux Grammy Awards en 2001 et est considéré comme l'un des plus grands morceaux du genre R&B. La production innovante de Rodney Jerkins avec ses parties vocales entrelacées a révolutionné les groupes féminins.",
       "uri_apple_music": "applemusic://track/266809802",
       "uri_youtube_music": "https://music.youtube.com/watch?v=sQgd6MccwZc",
       "uri_tidal": "tidal://track/1321126",
       "uri_deezer": "deezer://track/580936",
       "fun_fact_nl": "Say My Name won twee Grammy Awards in 2001 en wordt beschouwd als een van de grootste nummers in het R&B-genre. De innovatieve productie door Rodney Jerkins bevatte in elkaar grijpende vocale partijen die baanbrekend waren voor meidengroepen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM19901056",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1687425953",
+        "de": "applemusic://track/1687425953",
+        "gb": "applemusic://track/1687425953",
+        "fr": "applemusic://track/1687425953",
+        "es": "applemusic://track/1687425953",
+        "nl": "applemusic://track/1687425953",
+        "it": "applemusic://track/1687425953"
+      }
     },
     {
       "year": 2006,
@@ -3597,15 +4637,25 @@
       ],
       "awards": [],
       "fun_fact": "The 9-minute music video cost over $1 million to produce and starred Scarlett Johansson. The song was widely interpreted as Timberlake's response to his breakup with Britney Spears, though he never confirmed it.",
-      "fun_fact_de": "Das 9-min\u00fctige Musikvideo mit Scarlett Johansson kostete \u00fcber eine Million Dollar. Der Song wurde allgemein als Timberlakes Antwort auf die Trennung von Britney Spears interpretiert, obwohl er dies nie best\u00e4tigte.",
-      "fun_fact_es": "El video musical de 9 minutos con Scarlett Johansson cost\u00f3 m\u00e1s de un mill\u00f3n de d\u00f3lares. La canci\u00f3n fue ampliamente interpretada como la respuesta de Timberlake a su ruptura con Britney Spears, convirti\u00e9ndose en uno de los dramas pop m\u00e1s comentados de la d\u00e9cada.",
-      "fun_fact_fr": "Le clip de 9 minutes a co\u00fbt\u00e9 plus d'un million de dollars \u00e0 produire et met en vedette Scarlett Johansson. La chanson a \u00e9t\u00e9 largement interpr\u00e9t\u00e9e comme la r\u00e9ponse de Timberlake \u00e0 sa rupture avec Britney Spears, bien qu'il ne l'ait jamais confirm\u00e9.",
+      "fun_fact_de": "Das 9-minütige Musikvideo mit Scarlett Johansson kostete über eine Million Dollar. Der Song wurde allgemein als Timberlakes Antwort auf die Trennung von Britney Spears interpretiert, obwohl er dies nie bestätigte.",
+      "fun_fact_es": "El video musical de 9 minutos con Scarlett Johansson costó más de un millón de dólares. La canción fue ampliamente interpretada como la respuesta de Timberlake a su ruptura con Britney Spears, convirtiéndose en uno de los dramas pop más comentados de la década.",
+      "fun_fact_fr": "Le clip de 9 minutes a coûté plus d'un million de dollars à produire et met en vedette Scarlett Johansson. La chanson a été largement interprétée comme la réponse de Timberlake à sa rupture avec Britney Spears, bien qu'il ne l'ait jamais confirmé.",
       "uri_apple_music": "applemusic://track/400946486",
       "uri_youtube_music": "https://music.youtube.com/watch?v=TOrnUquxtwA",
       "uri_tidal": "tidal://track/19054579",
       "uri_deezer": "deezer://track/15489392",
-      "fun_fact_nl": "De 9 minuten durende videoclip kostte meer dan 1 miljoen dollar om te produceren en had Scarlett Johansson in de hoofdrol. Het nummer werd alom ge\u00efnterpreteerd als Timberlake's reactie op zijn breuk met Britney Spears, hoewel hij dat nooit heeft bevestigd.",
-      "awards_nl": []
+      "fun_fact_nl": "De 9 minuten durende videoclip kostte meer dan 1 miljoen dollar om te produceren en had Scarlett Johansson in de hoofdrol. Het nummer werd alom geïnterpreteerd als Timberlake's reactie op zijn breuk met Britney Spears, hoewel hij dat nooit heeft bevestigd.",
+      "awards_nl": [],
+      "isrc": "USJI10600479",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1441493014",
+        "de": "applemusic://track/1441493014",
+        "gb": "applemusic://track/1441493014",
+        "fr": "applemusic://track/1441493014",
+        "es": "applemusic://track/1441493014",
+        "nl": "applemusic://track/1441493014",
+        "it": "applemusic://track/1441493014"
+      }
     },
     {
       "year": 2005,
@@ -3629,14 +4679,24 @@
       "awards": [],
       "fun_fact": "The song spent 26 weeks on the Hot 100 and became the anthem of emo-pop's mainstream breakthrough. Its music video featuring a boy with deer antlers was one of the most played on MTV's TRL in 2005.",
       "fun_fact_de": "Der Song verbrachte 26 Wochen in den Hot 100 und wurde zur Hymne des Emo-Pop-Durchbruchs im Mainstream. Das surreale Musikvideo mit einem Jungen mit Hirschgeweih wurde zu einem der meistgespielten Clips auf MTV.",
-      "fun_fact_es": "La canci\u00f3n pas\u00f3 26 semanas en el Hot 100 y se convirti\u00f3 en el himno del emo-pop en el mainstream. Pete Wentz escribi\u00f3 la letra durante un per\u00edodo dif\u00edcil de su vida, canalizando su dolor en lo que se convertir\u00eda en un cl\u00e1sico generacional.",
-      "fun_fact_fr": "Le titre a pass\u00e9 26 semaines dans le Hot 100 et est devenu l'hymne de la perc\u00e9e de l'emo-pop dans le mainstream. Son clip surr\u00e9aliste mettant en sc\u00e8ne un gar\u00e7on avec des bois de cerf a \u00e9t\u00e9 l'un des plus diffus\u00e9s sur MTV.",
+      "fun_fact_es": "La canción pasó 26 semanas en el Hot 100 y se convirtió en el himno del emo-pop en el mainstream. Pete Wentz escribió la letra durante un período difícil de su vida, canalizando su dolor en lo que se convertiría en un clásico generacional.",
+      "fun_fact_fr": "Le titre a passé 26 semaines dans le Hot 100 et est devenu l'hymne de la percée de l'emo-pop dans le mainstream. Son clip surréaliste mettant en scène un garçon avec des bois de cerf a été l'un des plus diffusés sur MTV.",
       "uri_apple_music": "applemusic://track/1440799364",
       "uri_youtube_music": "https://music.youtube.com/watch?v=uhG-vLZrb-g",
       "uri_tidal": "tidal://track/330924446",
       "uri_deezer": "deezer://track/1138247",
       "fun_fact_nl": "Het nummer stond 26 weken in de Hot 100 en werd het volkslied van de mainstream doorbraak van emo-pop. De videoclip met een jongen met een hertengewei was in 2005 een van de meest gedraaide op MTV's TRL.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USIR20500201",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1716124574",
+        "de": "applemusic://track/1716124574",
+        "gb": "applemusic://track/1716124574",
+        "fr": "applemusic://track/1716124574",
+        "es": "applemusic://track/1716124574",
+        "nl": "applemusic://track/1716124574",
+        "it": "applemusic://track/1716124574"
+      }
     },
     {
       "year": 1999,
@@ -3659,15 +4719,25 @@
       ],
       "awards": [],
       "fun_fact": "Forgot About Dre won the Grammy for Best Rap Performance by a Duo in 2001. Eminem's verse was recorded in a single take and is considered one of the most iconic guest verses in hip-hop history.",
-      "fun_fact_de": "Der Song gewann 2001 den Grammy f\u00fcr die beste Rap-Performance eines Duos. Eminems Vers wurde in einem einzigen Take aufgenommen und gilt als einer der ikonischsten Gaststrophen der Hip-Hop-Geschichte.",
-      "fun_fact_es": "La canci\u00f3n gan\u00f3 el Grammy a la Mejor Interpretaci\u00f3n Rap de un D\u00fao en 2001. El verso de Eminem fue grabado en una sola toma y es considerado uno de los versos invitados m\u00e1s ic\u00f3nicos en la historia del hip-hop.",
-      "fun_fact_fr": "Forgot About Dre a remport\u00e9 le Grammy de la Meilleure Performance Rap en Duo en 2001. Le couplet d'Eminem a \u00e9t\u00e9 enregistr\u00e9 en une seule prise et est consid\u00e9r\u00e9 comme l'un des plus grands couplets invit\u00e9s de l'histoire du hip-hop.",
+      "fun_fact_de": "Der Song gewann 2001 den Grammy für die beste Rap-Performance eines Duos. Eminems Vers wurde in einem einzigen Take aufgenommen und gilt als einer der ikonischsten Gaststrophen der Hip-Hop-Geschichte.",
+      "fun_fact_es": "La canción ganó el Grammy a la Mejor Interpretación Rap de un Dúo en 2001. El verso de Eminem fue grabado en una sola toma y es considerado uno de los versos invitados más icónicos en la historia del hip-hop.",
+      "fun_fact_fr": "Forgot About Dre a remporté le Grammy de la Meilleure Performance Rap en Duo en 2001. Le couplet d'Eminem a été enregistré en une seule prise et est considéré comme l'un des plus grands couplets invités de l'histoire du hip-hop.",
       "uri_apple_music": "applemusic://track/1440783376",
       "uri_youtube_music": "https://music.youtube.com/watch?v=QFcv5Ma8u8k",
       "uri_tidal": "tidal://track/35748026",
       "uri_deezer": "deezer://track/128743593",
-      "fun_fact_nl": "Forgot About Dre won de Grammy voor Best Rap Performance by a Duo in 2001. Het couplet van Eminem werd in \u00e9\u00e9n take opgenomen en wordt beschouwd als een van de meest iconische gastbijdragen in de hiphopgeschiedenis.",
-      "awards_nl": []
+      "fun_fact_nl": "Forgot About Dre won de Grammy voor Best Rap Performance by a Duo in 2001. Het couplet van Eminem werd in één take opgenomen en wordt beschouwd als een van de meest iconische gastbijdragen in de hiphopgeschiedenis.",
+      "awards_nl": [],
+      "isrc": "USIR19915077",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1440783376",
+        "de": "applemusic://track/1440783376",
+        "gb": "applemusic://track/1440783376",
+        "fr": "applemusic://track/1440783376",
+        "es": "applemusic://track/1440783376",
+        "nl": "applemusic://track/1440783376",
+        "it": "applemusic://track/1440783376"
+      }
     },
     {
       "year": 2015,
@@ -3691,14 +4761,24 @@
       "awards": [],
       "fun_fact": "Though from 2015 (outside the 2000s decade), Alright became an anthem of the Black Lives Matter movement. Produced by Pharrell Williams, its chant 'We gon' be alright' was adopted at protests across America.",
       "fun_fact_de": "Obwohl der Song aus dem Jahr 2015 stammt, wurde 'Alright' zur Hymne der Black-Lives-Matter-Bewegung. Von Pharrell Williams produziert, wurde der Refrain 'We gon' be alright' bei Protesten in ganz Amerika gesungen.",
-      "fun_fact_es": "Aunque es de 2015 (fuera de la d\u00e9cada de los 2000), 'Alright' se convirti\u00f3 en el himno del movimiento Black Lives Matter. Producida por Pharrell Williams, su coro fue adoptado en protestas por toda Am\u00e9rica.",
-      "fun_fact_fr": "Bien que sortie en 2015 (hors de la d\u00e9cennie 2000), Alright est devenue un hymne du mouvement Black Lives Matter. Produite par Pharrell Williams, son refrain 'We gon' be alright' a \u00e9t\u00e9 repris lors de manifestations \u00e0 travers les \u00c9tats-Unis.",
+      "fun_fact_es": "Aunque es de 2015 (fuera de la década de los 2000), 'Alright' se convirtió en el himno del movimiento Black Lives Matter. Producida por Pharrell Williams, su coro fue adoptado en protestas por toda América.",
+      "fun_fact_fr": "Bien que sortie en 2015 (hors de la décennie 2000), Alright est devenue un hymne du mouvement Black Lives Matter. Produite par Pharrell Williams, son refrain 'We gon' be alright' a été repris lors de manifestations à travers les États-Unis.",
       "uri_apple_music": "applemusic://track/1440829463",
       "uri_youtube_music": "https://music.youtube.com/watch?v=Z-48u_uWMHY",
       "uri_tidal": "tidal://track/77703643",
       "uri_deezer": "deezer://track/97206068",
       "fun_fact_nl": "Hoewel uit 2015 (buiten het jaren 2000-decennium), werd Alright een volkslied van de Black Lives Matter-beweging. Geproduceerd door Pharrell Williams, werd de chant 'We gon' be alright' overgenomen bij protesten in heel Amerika.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USUM71502498",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1440829463",
+        "de": "applemusic://track/1440829463",
+        "gb": "applemusic://track/1440829463",
+        "fr": "applemusic://track/1440829463",
+        "es": "applemusic://track/1440829463",
+        "nl": "applemusic://track/1440829463",
+        "it": "applemusic://track/1440829463"
+      }
     },
     {
       "year": 2007,
@@ -3722,15 +4802,25 @@
       ],
       "awards": [],
       "fun_fact": "Ne-Yo wrote 'Because of You' in just 15 minutes during a studio session. The song was inspired by a real relationship and became his highest-charting single at the time, peaking at #2 on the Hot 100.",
-      "fun_fact_de": "Ne-Yo schrieb 'Because of You' in nur 15 Minuten w\u00e4hrend einer Studiosession. Der Song wurde von einer echten Beziehung inspiriert und erreichte Platz 2 der Hot 100 \u2013 seine h\u00f6chste Chart-Platzierung zu diesem Zeitpunkt.",
-      "fun_fact_es": "Ne-Yo escribi\u00f3 esta canci\u00f3n en solo 15 minutos durante una sesi\u00f3n de estudio. Inspirada en una relaci\u00f3n real, alcanz\u00f3 el #2 en el Hot 100, consolidando a Ne-Yo como uno de los mejores compositores de R&B de los 2000.",
-      "fun_fact_fr": "Ne-Yo a \u00e9crit 'Because of You' en seulement 15 minutes lors d'une session studio. Inspir\u00e9e d'une vraie relation amoureuse, la chanson est devenue son single le mieux class\u00e9 \u00e0 l'\u00e9poque, atteignant la 2e place du Hot 100.",
+      "fun_fact_de": "Ne-Yo schrieb 'Because of You' in nur 15 Minuten während einer Studiosession. Der Song wurde von einer echten Beziehung inspiriert und erreichte Platz 2 der Hot 100 – seine höchste Chart-Platzierung zu diesem Zeitpunkt.",
+      "fun_fact_es": "Ne-Yo escribió esta canción en solo 15 minutos durante una sesión de estudio. Inspirada en una relación real, alcanzó el #2 en el Hot 100, consolidando a Ne-Yo como uno de los mejores compositores de R&B de los 2000.",
+      "fun_fact_fr": "Ne-Yo a écrit 'Because of You' en seulement 15 minutes lors d'une session studio. Inspirée d'une vraie relation amoureuse, la chanson est devenue son single le mieux classé à l'époque, atteignant la 2e place du Hot 100.",
       "uri_apple_music": "applemusic://track/1440757476",
       "uri_youtube_music": "https://music.youtube.com/watch?v=atz_aZA3rf0",
       "uri_tidal": "tidal://track/331483",
       "uri_deezer": "deezer://track/1102966",
-      "fun_fact_nl": "Ne-Yo schreef 'Because of You' in slechts 15 minuten tijdens een studiosessie. Het nummer was ge\u00efnspireerd op een echte relatie en werd destijds zijn hoogst genoteerde single, met een piek op nummer 2 in de Hot 100.",
-      "awards_nl": []
+      "fun_fact_nl": "Ne-Yo schreef 'Because of You' in slechts 15 minuten tijdens een studiosessie. Het nummer was geïnspireerd op een echte relatie en werd destijds zijn hoogst genoteerde single, met een piek op nummer 2 in de Hot 100.",
+      "awards_nl": [],
+      "isrc": "USUM70731570",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1859004945",
+        "de": "applemusic://track/1859004945",
+        "gb": "applemusic://track/1859004945",
+        "fr": "applemusic://track/1859004945",
+        "es": "applemusic://track/1859004945",
+        "nl": "applemusic://track/1859004945",
+        "it": "applemusic://track/1859004945"
+      }
     },
     {
       "year": 2007,
@@ -3753,15 +4843,25 @@
       ],
       "awards": [],
       "fun_fact": "Electric Feel won the Grammy for Best Pop Performance by a Duo or Group in 2010. The song was written in a burst of creativity during the band's time at Wesleyan University and samples African rhythms.",
-      "fun_fact_de": "Electric Feel gewann 2010 den Grammy f\u00fcr die beste Pop-Darbietung eines Duos. Der Song wurde w\u00e4hrend der Studienzeit der Band an der Wesleyan University geschrieben und verbindet Indie-Rock mit afrikanischen Rhythmen.",
-      "fun_fact_es": "Electric Feel gan\u00f3 el Grammy a la Mejor Interpretaci\u00f3n Pop de D\u00fao o Grupo en 2010. Escrita durante los a\u00f1os universitarios de la banda, la canci\u00f3n mezcla indie rock con ritmos africanos y sintetizadores psicod\u00e9licos.",
-      "fun_fact_fr": "Electric Feel a remport\u00e9 le Grammy de la Meilleure Performance Pop d'un Duo ou Groupe en 2010. \u00c9crite pendant les ann\u00e9es universitaires du groupe \u00e0 Wesleyan, la chanson m\u00eale rock ind\u00e9pendant et rythmes africains.",
+      "fun_fact_de": "Electric Feel gewann 2010 den Grammy für die beste Pop-Darbietung eines Duos. Der Song wurde während der Studienzeit der Band an der Wesleyan University geschrieben und verbindet Indie-Rock mit afrikanischen Rhythmen.",
+      "fun_fact_es": "Electric Feel ganó el Grammy a la Mejor Interpretación Pop de Dúo o Grupo en 2010. Escrita durante los años universitarios de la banda, la canción mezcla indie rock con ritmos africanos y sintetizadores psicodélicos.",
+      "fun_fact_fr": "Electric Feel a remporté le Grammy de la Meilleure Performance Pop d'un Duo ou Groupe en 2010. Écrite pendant les années universitaires du groupe à Wesleyan, la chanson mêle rock indépendant et rythmes africains.",
       "uri_apple_music": "applemusic://track/1687386390",
       "uri_youtube_music": "https://music.youtube.com/watch?v=MmZexg8sxyk",
       "uri_tidal": "tidal://track/1317018",
       "uri_deezer": "deezer://track/536484",
       "fun_fact_nl": "Electric Feel won de Grammy voor Best Pop Performance by a Duo or Group in 2010. Het nummer werd geschreven in een vlaag van creativiteit tijdens de tijd van de band aan de Wesleyan University en bevat Afrikaanse ritmes.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM10702131",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/264720106",
+        "de": "applemusic://track/264720106",
+        "gb": "applemusic://track/264720106",
+        "fr": "applemusic://track/264720106",
+        "es": "applemusic://track/264720106",
+        "nl": "applemusic://track/264720106",
+        "it": "applemusic://track/264720106"
+      }
     },
     {
       "year": 2009,
@@ -3785,22 +4885,32 @@
       ],
       "awards": [],
       "fun_fact": "Adam Young recorded Fireflies entirely in his parents' basement in Owatonna, Minnesota. It topped charts in 13 countries and became the most-downloaded song on iTunes in 2009 with over 10 million downloads.",
-      "fun_fact_de": "Adam Young nahm Fireflies komplett im Keller seiner Eltern in Owatonna, Minnesota auf. Der Song erreichte Platz 1 in 13 L\u00e4ndern und wurde mit \u00fcber 10 Millionen Downloads der meistverkaufte iTunes-Song des Jahres 2009.",
-      "fun_fact_es": "Adam Young grab\u00f3 Fireflies en el s\u00f3tano de la casa de sus padres en Minnesota. La canci\u00f3n lleg\u00f3 al #1 en 13 pa\u00edses y se convirti\u00f3 en la canci\u00f3n m\u00e1s descargada de iTunes en 2009, con m\u00e1s de 10 millones de descargas.",
-      "fun_fact_fr": "Adam Young a enregistr\u00e9 Fireflies enti\u00e8rement dans le sous-sol de la maison de ses parents \u00e0 Owatonna, dans le Minnesota. Le titre a atteint la premi\u00e8re place dans 13 pays et est devenu le morceau le plus t\u00e9l\u00e9charg\u00e9 sur iTunes en 2009 avec plus de 10 millions de t\u00e9l\u00e9chargements.",
+      "fun_fact_de": "Adam Young nahm Fireflies komplett im Keller seiner Eltern in Owatonna, Minnesota auf. Der Song erreichte Platz 1 in 13 Ländern und wurde mit über 10 Millionen Downloads der meistverkaufte iTunes-Song des Jahres 2009.",
+      "fun_fact_es": "Adam Young grabó Fireflies en el sótano de la casa de sus padres en Minnesota. La canción llegó al #1 en 13 países y se convirtió en la canción más descargada de iTunes en 2009, con más de 10 millones de descargas.",
+      "fun_fact_fr": "Adam Young a enregistré Fireflies entièrement dans le sous-sol de la maison de ses parents à Owatonna, dans le Minnesota. Le titre a atteint la première place dans 13 pays et est devenu le morceau le plus téléchargé sur iTunes en 2009 avec plus de 10 millions de téléchargements.",
       "uri_apple_music": "applemusic://track/1440783289",
       "uri_youtube_music": "https://music.youtube.com/watch?v=psuRGfAaju4",
       "uri_tidal": "tidal://track/3140991",
       "uri_deezer": "deezer://track/4188437",
       "fun_fact_nl": "Adam Young nam Fireflies volledig op in de kelder van zijn ouders in Owatonna, Minnesota. Het stond bovenaan de hitlijsten in 13 landen en werd in 2009 het meest gedownloade nummer op iTunes met meer dan 10 miljoen downloads.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USUM70972068",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1711274875",
+        "de": "applemusic://track/1711274875",
+        "gb": "applemusic://track/1711274875",
+        "fr": "applemusic://track/1711274875",
+        "es": "applemusic://track/1711274875",
+        "nl": "applemusic://track/1443207486",
+        "it": "applemusic://track/1711274875"
+      }
     },
     {
       "year": 2009,
       "uri": "spotify:track:60jzFy6Nn4M0iD1d94oteF",
       "artist": "Rihanna",
       "alt_artists": [
-        "Beyonc\u00e9",
+        "Beyoncé",
         "Katy Perry",
         "Lady Gaga",
         "Ciara"
@@ -3817,15 +4927,25 @@
       ],
       "awards": [],
       "fun_fact": "Rude Boy was Rihanna's fifth #1 hit on the Billboard Hot 100, where it stayed for five consecutive weeks. The colorful, pop-art inspired music video was shot on a tight budget using green screens and bold graphics.",
-      "fun_fact_de": "Rude Boy war Rihannas f\u00fcnfter Nummer-1-Hit in den Billboard Hot 100 und blieb dort f\u00fcnf Wochen lang. Das bunte Pop-Art-Musikvideo wurde mit einem knappen Budget und Greenscreens gedreht.",
-      "fun_fact_es": "Rude Boy fue el quinto #1 de Rihanna en el Billboard Hot 100, donde permaneci\u00f3 cinco semanas consecutivas. Su colorido video musical inspirado en el pop art se film\u00f3 con un presupuesto ajustado usando pantallas verdes.",
-      "fun_fact_fr": "Rude Boy \u00e9tait le cinqui\u00e8me num\u00e9ro 1 de Rihanna au Billboard Hot 100, o\u00f9 il est rest\u00e9 cinq semaines cons\u00e9cutives. Le clip color\u00e9 d'inspiration pop art a \u00e9t\u00e9 tourn\u00e9 avec un budget serr\u00e9 \u00e0 l'aide d'\u00e9crans verts.",
+      "fun_fact_de": "Rude Boy war Rihannas fünfter Nummer-1-Hit in den Billboard Hot 100 und blieb dort fünf Wochen lang. Das bunte Pop-Art-Musikvideo wurde mit einem knappen Budget und Greenscreens gedreht.",
+      "fun_fact_es": "Rude Boy fue el quinto #1 de Rihanna en el Billboard Hot 100, donde permaneció cinco semanas consecutivas. Su colorido video musical inspirado en el pop art se filmó con un presupuesto ajustado usando pantallas verdes.",
+      "fun_fact_fr": "Rude Boy était le cinquième numéro 1 de Rihanna au Billboard Hot 100, où il est resté cinq semaines consécutives. Le clip coloré d'inspiration pop art a été tourné avec un budget serré à l'aide d'écrans verts.",
       "uri_apple_music": "applemusic://track/1440885739",
       "uri_youtube_music": "https://music.youtube.com/watch?v=e82VE8UtW8A",
       "uri_tidal": "tidal://track/3190135",
       "uri_deezer": "deezer://track/4670273",
-      "fun_fact_nl": "Rude Boy was Rihanna's vijfde nummer 1-hit in de Billboard Hot 100, waar het vijf opeenvolgende weken bleef staan. De kleurrijke, op popart ge\u00efnspireerde videoclip werd met een krap budget opgenomen met behulp van greenscreens en gedurfde graphics.",
-      "awards_nl": []
+      "fun_fact_nl": "Rude Boy was Rihanna's vijfde nummer 1-hit in de Billboard Hot 100, waar het vijf opeenvolgende weken bleef staan. De kleurrijke, op popart geïnspireerde videoclip werd met een krap budget opgenomen met behulp van greenscreens en gedurfde graphics.",
+      "awards_nl": [],
+      "isrc": "USUM70912459",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1445033711",
+        "de": "applemusic://track/1440885739",
+        "gb": "applemusic://track/1440885739",
+        "fr": "applemusic://track/1440885739",
+        "es": "applemusic://track/1440885739",
+        "nl": "applemusic://track/1440885739",
+        "it": "applemusic://track/1440885739"
+      }
     },
     {
       "year": 2003,
@@ -3848,15 +4968,25 @@
       ],
       "awards": [],
       "fun_fact": "This cover of The Who's 1971 classic reached #1 in the UK and Germany. Fred Durst's softer vocal approach surprised fans and critics who associated him with aggressive nu-metal.",
-      "fun_fact_de": "Dieses Cover des Who-Klassikers von 1971 erreichte Platz 1 in Gro\u00dfbritannien und Deutschland. Fred Dursts sanfterer Gesangsstil \u00fcberraschte Fans, die ihn nur als aggressiven Nu-Metal-S\u00e4nger kannten.",
-      "fun_fact_es": "Esta versi\u00f3n del cl\u00e1sico de The Who de 1971 lleg\u00f3 al #1 en Reino Unido y Alemania. El enfoque vocal m\u00e1s suave de Fred Durst sorprendi\u00f3 a fans y cr\u00edticos que lo asociaban con el nu-metal agresivo.",
-      "fun_fact_fr": "Cette reprise du classique de The Who de 1971 a atteint la premi\u00e8re place au Royaume-Uni et en Allemagne. L'approche vocale plus douce de Fred Durst a surpris les fans et critiques qui l'associaient au nu-metal agressif.",
+      "fun_fact_de": "Dieses Cover des Who-Klassikers von 1971 erreichte Platz 1 in Großbritannien und Deutschland. Fred Dursts sanfterer Gesangsstil überraschte Fans, die ihn nur als aggressiven Nu-Metal-Sänger kannten.",
+      "fun_fact_es": "Esta versión del clásico de The Who de 1971 llegó al #1 en Reino Unido y Alemania. El enfoque vocal más suave de Fred Durst sorprendió a fans y críticos que lo asociaban con el nu-metal agresivo.",
+      "fun_fact_fr": "Cette reprise du classique de The Who de 1971 a atteint la première place au Royaume-Uni et en Allemagne. L'approche vocale plus douce de Fred Durst a surpris les fans et critiques qui l'associaient au nu-metal agressif.",
       "uri_apple_music": "applemusic://track/1440874577",
       "uri_youtube_music": "https://music.youtube.com/watch?v=-0RQU0LyJqg",
       "uri_tidal": "tidal://track/477385",
       "uri_deezer": "deezer://track/1143499",
       "fun_fact_nl": "Deze cover van de klassieker van The Who uit 1971 bereikte de eerste plaats in het VK en Duitsland. Fred Durst's zachtere vocale benadering verraste fans en critici die hem associeerden met agressieve nu-metal.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USIR10312186",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1674978860",
+        "de": "applemusic://track/1674978860",
+        "gb": "applemusic://track/1674978860",
+        "fr": "applemusic://track/1674978860",
+        "es": "applemusic://track/1674978860",
+        "nl": "applemusic://track/1674978860",
+        "it": "applemusic://track/1674978860"
+      }
     },
     {
       "year": 2001,
@@ -3880,15 +5010,25 @@
       ],
       "awards": [],
       "fun_fact": "The song features City Spud (Lavell Webb), who was incarcerated shortly after recording. Its hook 'Hey, must be the money' became one of the most recognizable catchphrases of early 2000s hip-hop.",
-      "fun_fact_de": "City Spud (Lavell Webb) wurde kurz nach der Aufnahme inhaftiert und konnte den Erfolg des Songs kaum miterleben. Der Hook 'Hey, must be the money' wurde zu einem der bekanntesten Spr\u00fcche des fr\u00fchen 2000er Hip-Hop.",
-      "fun_fact_es": "City Spud fue encarcelado poco despu\u00e9s de la grabaci\u00f3n y apenas pudo disfrutar del \u00e9xito. El gancho 'Hey, must be the money' se convirti\u00f3 en una de las frases m\u00e1s reconocibles del hip-hop de principios de los 2000.",
-      "fun_fact_fr": "Le titre met en vedette City Spud (Lavell Webb), incarc\u00e9r\u00e9 peu apr\u00e8s l'enregistrement. Son refrain 'Hey, must be the money' est devenu l'une des phrases les plus reconnaissables du hip-hop du d\u00e9but des ann\u00e9es 2000.",
+      "fun_fact_de": "City Spud (Lavell Webb) wurde kurz nach der Aufnahme inhaftiert und konnte den Erfolg des Songs kaum miterleben. Der Hook 'Hey, must be the money' wurde zu einem der bekanntesten Sprüche des frühen 2000er Hip-Hop.",
+      "fun_fact_es": "City Spud fue encarcelado poco después de la grabación y apenas pudo disfrutar del éxito. El gancho 'Hey, must be the money' se convirtió en una de las frases más reconocibles del hip-hop de principios de los 2000.",
+      "fun_fact_fr": "Le titre met en vedette City Spud (Lavell Webb), incarcéré peu après l'enregistrement. Son refrain 'Hey, must be the money' est devenu l'une des phrases les plus reconnaissables du hip-hop du début des années 2000.",
       "uri_apple_music": "applemusic://track/1434909214",
       "uri_youtube_music": "https://music.youtube.com/watch?v=RtSDWq6HsJE",
       "uri_tidal": "tidal://track/94440831",
       "uri_deezer": "deezer://track/7292333",
       "fun_fact_nl": "In het nummer is City Spud (Lavell Webb) te horen, die kort na de opnames werd opgesloten. De hook 'Hey, must be the money' werd een van de meest herkenbare catchphrases van de hiphop uit het begin van de jaren 2000.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USUR10000183",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1543982455",
+        "de": "applemusic://track/1543982455",
+        "gb": "applemusic://track/1543982455",
+        "fr": "applemusic://track/1543982455",
+        "es": "applemusic://track/1543982455",
+        "nl": "applemusic://track/1543982455",
+        "it": "applemusic://track/1543982455"
+      }
     },
     {
       "year": 2000,
@@ -3912,20 +5052,30 @@
       ],
       "awards": [],
       "fun_fact": "Butterfly samples the Red Hot Chili Peppers' 'Pretty Little Ditty' and spent two weeks at #1 on the Hot 100. It remains one of the biggest one-hit wonders of the 2000s.",
-      "fun_fact_de": "Butterfly sampelt 'Pretty Little Ditty' von den Red Hot Chili Peppers und stand zwei Wochen auf Platz 1 der Hot 100. Es bleibt einer der gr\u00f6\u00dften One-Hit-Wonder der 2000er Jahre.",
-      "fun_fact_es": "Butterfly samplea 'Pretty Little Ditty' de Red Hot Chili Peppers y pas\u00f3 dos semanas en el #1 del Hot 100. Es considerado uno de los mayores \u00e9xitos de un solo hit de la d\u00e9cada de los 2000.",
-      "fun_fact_fr": "Butterfly sample 'Pretty Little Ditty' des Red Hot Chili Peppers et est rest\u00e9 deux semaines en t\u00eate du Hot 100. Il reste l'un des plus grands tubes \u00e9ph\u00e9m\u00e8res des ann\u00e9es 2000.",
+      "fun_fact_de": "Butterfly sampelt 'Pretty Little Ditty' von den Red Hot Chili Peppers und stand zwei Wochen auf Platz 1 der Hot 100. Es bleibt einer der größten One-Hit-Wonder der 2000er Jahre.",
+      "fun_fact_es": "Butterfly samplea 'Pretty Little Ditty' de Red Hot Chili Peppers y pasó dos semanas en el #1 del Hot 100. Es considerado uno de los mayores éxitos de un solo hit de la década de los 2000.",
+      "fun_fact_fr": "Butterfly sample 'Pretty Little Ditty' des Red Hot Chili Peppers et est resté deux semaines en tête du Hot 100. Il reste l'un des plus grands tubes éphémères des années 2000.",
       "uri_apple_music": "applemusic://track/203304621",
       "uri_youtube_music": "https://music.youtube.com/watch?v=6FEDrU85FLE",
       "uri_tidal": "tidal://track/34793",
       "uri_deezer": "deezer://track/13144808",
       "fun_fact_nl": "Butterfly bevat een sample van de Red Hot Chili Peppers' 'Pretty Little Ditty' en stond twee weken op nummer 1 in de Hot 100. Het blijft een van de grootste eendagsvliegen van de jaren 2000.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM19911429",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/203304621",
+        "de": "applemusic://track/1799780923",
+        "gb": "applemusic://track/203304621",
+        "fr": "applemusic://track/203304621",
+        "es": "applemusic://track/203304621",
+        "nl": "applemusic://track/203304621",
+        "it": "applemusic://track/203304621"
+      }
     },
     {
       "year": 2003,
       "uri": "spotify:track:5IVuqXILoxVWvWEPm82Jxr",
-      "artist": "Beyonc\u00e9, JAY-Z",
+      "artist": "Beyoncé, JAY-Z",
       "alt_artists": [
         "Rihanna",
         "Destiny's Child",
@@ -3943,16 +5093,26 @@
         "Platinum (UK)"
       ],
       "awards": [],
-      "fun_fact": "The iconic horn intro samples the Chi-Lites' 1970 track 'Are You My Woman'. Crazy In Love won two Grammy Awards and is considered one of the greatest songs of the 21st century, marking Beyonc\u00e9's solo debut.",
-      "fun_fact_de": "Das ikonische Horn-Intro sampelt die Chi-Lites von 1970. Als Beyonc\u00e9s Solo-Deb\u00fct gewann der Song zwei Grammys und gilt als einer der besten Songs des 21. Jahrhunderts \u2014 er definierte eine \u00c4ra des Pop und R&B.",
-      "fun_fact_es": "El ic\u00f3nico intro de trompetas samplea a los Chi-Lites de 1970. Como debut solista de Beyonc\u00e9, gan\u00f3 dos Grammys y es considerada una de las mejores canciones del siglo XXI, marcando el inicio de una era.",
-      "fun_fact_fr": "L'intro de cuivres embl\u00e9matique sample les Chi-Lites de 1970. En tant que premier single solo de Beyonc\u00e9, Crazy In Love a remport\u00e9 deux Grammy et est consid\u00e9r\u00e9 comme l'un des plus grands morceaux du XXIe si\u00e8cle.",
+      "fun_fact": "The iconic horn intro samples the Chi-Lites' 1970 track 'Are You My Woman'. Crazy In Love won two Grammy Awards and is considered one of the greatest songs of the 21st century, marking Beyoncé's solo debut.",
+      "fun_fact_de": "Das ikonische Horn-Intro sampelt die Chi-Lites von 1970. Als Beyoncés Solo-Debüt gewann der Song zwei Grammys und gilt als einer der besten Songs des 21. Jahrhunderts — er definierte eine Ära des Pop und R&B.",
+      "fun_fact_es": "El icónico intro de trompetas samplea a los Chi-Lites de 1970. Como debut solista de Beyoncé, ganó dos Grammys y es considerada una de las mejores canciones del siglo XXI, marcando el inicio de una era.",
+      "fun_fact_fr": "L'intro de cuivres emblématique sample les Chi-Lites de 1970. En tant que premier single solo de Beyoncé, Crazy In Love a remporté deux Grammy et est considéré comme l'un des plus grands morceaux du XXIe siècle.",
       "uri_apple_music": "applemusic://track/201274644",
       "uri_youtube_music": "https://music.youtube.com/watch?v=ViwtNLUqkMY",
       "uri_tidal": "tidal://track/2859863",
       "uri_deezer": "deezer://track/13138698",
-      "fun_fact_nl": "De iconische blazersintro bevat een sample van de track 'Are You My Woman' van de Chi-Lites uit 1970. Crazy In Love won twee Grammy Awards en wordt beschouwd als een van de beste nummers van de 21e eeuw, en markeerde het solodebuut van Beyonc\u00e9.",
-      "awards_nl": []
+      "fun_fact_nl": "De iconische blazersintro bevat een sample van de track 'Are You My Woman' van de Chi-Lites uit 1970. Crazy In Love won twee Grammy Awards en wordt beschouwd als een van de beste nummers van de 21e eeuw, en markeerde het solodebuut van Beyoncé.",
+      "awards_nl": [],
+      "isrc": "USSM10305425",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1032179409",
+        "de": "applemusic://track/1090310820",
+        "gb": "applemusic://track/1090310820",
+        "fr": "applemusic://track/1090310820",
+        "es": "applemusic://track/1090310820",
+        "nl": "applemusic://track/1090310820",
+        "it": "applemusic://track/1090310820"
+      }
     },
     {
       "year": 2004,
@@ -3975,15 +5135,25 @@
       ],
       "awards": [],
       "fun_fact": "Keane are notable for being one of the few major rock bands to never use a guitar. The song's lush piano-driven sound was inspired by Tom Chaplin's feelings of isolation while his friends moved on with their lives.",
-      "fun_fact_de": "Keane sind eine der wenigen gro\u00dfen Rockbands, die nie eine Gitarre verwenden. Der \u00fcppige Piano-Sound wurde von Tom Chaplins Gef\u00fchl der Isolation inspiriert, als seine Freunde mit ihrem Leben weiterzogen.",
-      "fun_fact_es": "Keane es una de las pocas bandas de rock importantes que nunca usa guitarra. El sonido rico del piano fue inspirado por los sentimientos de aislamiento de Tom Chaplin al ver c\u00f3mo sus amigos segu\u00edan adelante con sus vidas.",
-      "fun_fact_fr": "Keane se distingue comme l'un des rares grands groupes de rock \u00e0 n'avoir jamais utilis\u00e9 de guitare. Le son riche port\u00e9 par le piano a \u00e9t\u00e9 inspir\u00e9 par le sentiment d'isolement de Tom Chaplin en voyant ses amis avancer dans leur vie.",
+      "fun_fact_de": "Keane sind eine der wenigen großen Rockbands, die nie eine Gitarre verwenden. Der üppige Piano-Sound wurde von Tom Chaplins Gefühl der Isolation inspiriert, als seine Freunde mit ihrem Leben weiterzogen.",
+      "fun_fact_es": "Keane es una de las pocas bandas de rock importantes que nunca usa guitarra. El sonido rico del piano fue inspirado por los sentimientos de aislamiento de Tom Chaplin al ver cómo sus amigos seguían adelante con sus vidas.",
+      "fun_fact_fr": "Keane se distingue comme l'un des rares grands groupes de rock à n'avoir jamais utilisé de guitare. Le son riche porté par le piano a été inspiré par le sentiment d'isolement de Tom Chaplin en voyant ses amis avancer dans leur vie.",
       "uri_apple_music": "applemusic://track/1473425007",
       "uri_youtube_music": "https://music.youtube.com/watch?v=Zx4Hjq6KwO0",
       "uri_tidal": "tidal://track/23279549",
       "uri_deezer": "deezer://track/71967076",
-      "fun_fact_nl": "Keane valt op als een van de weinige grote rockbands die nooit een gitaar gebruiken. Het weelderige, door piano gedreven geluid van het nummer was ge\u00efnspireerd op de gevoelens van isolatie van Tom Chaplin, terwijl zijn vrienden verder gingen met hun leven.",
-      "awards_nl": []
+      "fun_fact_nl": "Keane valt op als een van de weinige grote rockbands die nooit een gitaar gebruiken. Het weelderige, door piano gedreven geluid van het nummer was geïnspireerd op de gevoelens van isolatie van Tom Chaplin, terwijl zijn vrienden verder gingen met hun leven.",
+      "awards_nl": [],
+      "isrc": "GBAAN0400092",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1706323365",
+        "de": "applemusic://track/1706323365",
+        "gb": "applemusic://track/1706323365",
+        "fr": "applemusic://track/1706323365",
+        "es": "applemusic://track/1706323365",
+        "nl": "applemusic://track/1706323365",
+        "it": "applemusic://track/1706323365"
+      }
     },
     {
       "year": 2006,
@@ -4007,15 +5177,25 @@
       ],
       "awards": [],
       "fun_fact": "Bruce Springsteen himself praised the song's opening riff as one of the best he'd heard. It was recorded with legendary producers Alan Moulder and Flood at a studio overlooking the English countryside.",
-      "fun_fact_de": "Bruce Springsteen selbst lobte das Er\u00f6ffnungsriff als eines der besten, die er je geh\u00f6rt hat. Der Song wurde mit den legend\u00e4ren Produzenten Alan Moulder und Flood in einem Studio mit Blick auf die englische Landschaft aufgenommen.",
-      "fun_fact_es": "Bruce Springsteen elogi\u00f3 el riff inicial como uno de los mejores que hab\u00eda escuchado. La canci\u00f3n fue grabada con los legendarios productores Alan Moulder y Flood, y se convirti\u00f3 en el mayor \u00e9xito de The Killers en el Reino Unido.",
-      "fun_fact_fr": "Bruce Springsteen en personne a salu\u00e9 le riff d'ouverture comme l'un des meilleurs qu'il ait jamais entendus. Le morceau a \u00e9t\u00e9 enregistr\u00e9 avec les l\u00e9gendaires producteurs Alan Moulder et Flood dans un studio surplombant la campagne anglaise.",
+      "fun_fact_de": "Bruce Springsteen selbst lobte das Eröffnungsriff als eines der besten, die er je gehört hat. Der Song wurde mit den legendären Produzenten Alan Moulder und Flood in einem Studio mit Blick auf die englische Landschaft aufgenommen.",
+      "fun_fact_es": "Bruce Springsteen elogió el riff inicial como uno de los mejores que había escuchado. La canción fue grabada con los legendarios productores Alan Moulder y Flood, y se convirtió en el mayor éxito de The Killers en el Reino Unido.",
+      "fun_fact_fr": "Bruce Springsteen en personne a salué le riff d'ouverture comme l'un des meilleurs qu'il ait jamais entendus. Le morceau a été enregistré avec les légendaires producteurs Alan Moulder et Flood dans un studio surplombant la campagne anglaise.",
       "uri_apple_music": "applemusic://track/1440891558",
       "uri_youtube_music": "https://music.youtube.com/watch?v=ff0oWESdmH0",
       "uri_tidal": "tidal://track/477699",
       "uri_deezer": "deezer://track/1109953",
       "fun_fact_nl": "Bruce Springsteen prees zelf de openingsriff van het nummer als een van de beste die hij ooit had gehoord. Het werd opgenomen met de legendarische producenten Alan Moulder en Flood in een studio met uitzicht op het Engelse platteland.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USUM70605164",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1852004608",
+        "de": "applemusic://track/1852004608",
+        "gb": "applemusic://track/1852004608",
+        "fr": "applemusic://track/1852004608",
+        "es": "applemusic://track/1852004608",
+        "nl": "applemusic://track/1852004608",
+        "it": "applemusic://track/1852004608"
+      }
     },
     {
       "year": 2007,
@@ -4038,16 +5218,26 @@
         "Silver (UK)"
       ],
       "awards": [],
-      "fun_fact": "The Pretender won the Grammy for Best Hard Rock Performance in 2008. Dave Grohl described the song as being about standing up against those who try to control you \u2014 a theme that resonated across generations.",
-      "fun_fact_de": "The Pretender gewann 2008 den Grammy f\u00fcr die beste Hard-Rock-Darbietung. Dave Grohl beschrieb den Song als Aufstand gegen diejenigen, die versuchen, einen zu kontrollieren \u2014 ein Thema, das generations\u00fcbergreifend ankommt.",
-      "fun_fact_es": "The Pretender gan\u00f3 el Grammy a la Mejor Interpretaci\u00f3n de Hard Rock en 2008. Dave Grohl describi\u00f3 la canci\u00f3n como un acto de resistencia contra quienes intentan controlarte, un mensaje que reson\u00f3 en todo el mundo.",
-      "fun_fact_fr": "The Pretender a remport\u00e9 le Grammy de la Meilleure Performance Hard Rock en 2008. Dave Grohl a d\u00e9crit la chanson comme un acte de r\u00e9sistance contre ceux qui cherchent \u00e0 vous contr\u00f4ler \u2014 un message qui a r\u00e9sonn\u00e9 \u00e0 travers les g\u00e9n\u00e9rations.",
+      "fun_fact": "The Pretender won the Grammy for Best Hard Rock Performance in 2008. Dave Grohl described the song as being about standing up against those who try to control you — a theme that resonated across generations.",
+      "fun_fact_de": "The Pretender gewann 2008 den Grammy für die beste Hard-Rock-Darbietung. Dave Grohl beschrieb den Song als Aufstand gegen diejenigen, die versuchen, einen zu kontrollieren — ein Thema, das generationsübergreifend ankommt.",
+      "fun_fact_es": "The Pretender ganó el Grammy a la Mejor Interpretación de Hard Rock en 2008. Dave Grohl describió la canción como un acto de resistencia contra quienes intentan controlarte, un mensaje que resonó en todo el mundo.",
+      "fun_fact_fr": "The Pretender a remporté le Grammy de la Meilleure Performance Hard Rock en 2008. Dave Grohl a décrit la chanson comme un acte de résistance contre ceux qui cherchent à vous contrôler — un message qui a résonné à travers les générations.",
       "uri_apple_music": "applemusic://track/262743414",
       "uri_youtube_music": "https://music.youtube.com/watch?v=SBjQ9tuuTJQ",
       "uri_tidal": "tidal://track/3146736",
       "uri_deezer": "deezer://track/4311597",
-      "fun_fact_nl": "The Pretender won de Grammy voor Best Hard Rock Performance in 2008. Dave Grohl beschreef het nummer als zijnde over het opstaan tegen degenen die je proberen te controleren \u2014 een thema dat resoneerde over generaties heen.",
-      "awards_nl": []
+      "fun_fact_nl": "The Pretender won de Grammy voor Best Hard Rock Performance in 2008. Dave Grohl beschreef het nummer als zijnde over het opstaan tegen degenen die je proberen te controleren — een thema dat resoneerde over generaties heen.",
+      "awards_nl": [],
+      "isrc": "USRW30700007",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/334812015",
+        "de": "applemusic://track/334812015",
+        "gb": "applemusic://track/334812015",
+        "fr": "applemusic://track/334812015",
+        "es": "applemusic://track/334812015",
+        "nl": "applemusic://track/334812015",
+        "it": "applemusic://track/334812015"
+      }
     },
     {
       "year": 2007,
@@ -4071,15 +5261,25 @@
       ],
       "awards": [],
       "fun_fact": "Written by Ryan Tedder and Jesse McCartney, Bleeding Love was originally offered to Jesse himself but his label rejected it. It became the best-selling single of 2008 worldwide with over 9 million copies.",
-      "fun_fact_de": "Ryan Tedder und Jesse McCartney schrieben den Song, der urspr\u00fcnglich f\u00fcr McCartney selbst gedacht war, aber von seinem Label abgelehnt wurde. Er wurde mit \u00fcber 9 Millionen Exemplaren zur meistverkauften Single des Jahres 2008.",
-      "fun_fact_es": "Escrita por Ryan Tedder y Jesse McCartney, la canci\u00f3n fue originalmente ofrecida a Jesse, pero su sello la rechaz\u00f3. Se convirti\u00f3 en el sencillo m\u00e1s vendido de 2008 con m\u00e1s de 9 millones de copias en todo el mundo.",
-      "fun_fact_fr": "\u00c9crite par Ryan Tedder et Jesse McCartney, Bleeding Love avait d'abord \u00e9t\u00e9 propos\u00e9e \u00e0 Jesse lui-m\u00eame, mais son label l'a refus\u00e9e. Elle est devenue le single le plus vendu de 2008 dans le monde avec plus de 9 millions d'exemplaires.",
+      "fun_fact_de": "Ryan Tedder und Jesse McCartney schrieben den Song, der ursprünglich für McCartney selbst gedacht war, aber von seinem Label abgelehnt wurde. Er wurde mit über 9 Millionen Exemplaren zur meistverkauften Single des Jahres 2008.",
+      "fun_fact_es": "Escrita por Ryan Tedder y Jesse McCartney, la canción fue originalmente ofrecida a Jesse, pero su sello la rechazó. Se convirtió en el sencillo más vendido de 2008 con más de 9 millones de copias en todo el mundo.",
+      "fun_fact_fr": "Écrite par Ryan Tedder et Jesse McCartney, Bleeding Love avait d'abord été proposée à Jesse lui-même, mais son label l'a refusée. Elle est devenue le single le plus vendu de 2008 dans le monde avec plus de 9 millions d'exemplaires.",
       "uri_apple_music": "applemusic://track/303682849",
       "uri_youtube_music": "https://music.youtube.com/watch?v=Vzo-EL_62fQ",
       "uri_tidal": "tidal://track/5917917",
       "uri_deezer": "deezer://track/365067",
       "fun_fact_nl": "Bleeding Love is geschreven door Ryan Tedder en Jesse McCartney en werd oorspronkelijk aangeboden aan Jesse zelf, maar zijn label weigerde het. Het werd de bestverkochte single van 2008 wereldwijd met meer dan 9 miljoen exemplaren.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBHMU0700049",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1719042618",
+        "de": "applemusic://track/1719042618",
+        "gb": "applemusic://track/1719042618",
+        "fr": "applemusic://track/1719042618",
+        "es": "applemusic://track/1719042618",
+        "nl": "applemusic://track/1719042618",
+        "it": "applemusic://track/1719042618"
+      }
     },
     {
       "year": 2008,
@@ -4102,15 +5302,25 @@
       ],
       "awards": [],
       "fun_fact": "Isaac Slade wrote the song after a friend overdosed, questioning where God was during the crisis. It was featured in the Season 5 premiere of Grey's Anatomy, which introduced the song to millions of new listeners.",
-      "fun_fact_de": "Isaac Slade schrieb den Song, nachdem ein Freund eine \u00dcberdosis genommen hatte \u2014 eine Auseinandersetzung mit der Frage, wo Gott in der Krise war. Die Verwendung in Grey's Anatomy machte den Song weltweit bekannt.",
-      "fun_fact_es": "Isaac Slade escribi\u00f3 la canci\u00f3n tras la sobredosis de un amigo, cuestionando d\u00f3nde estaba Dios. Su aparici\u00f3n en el estreno de la temporada 5 de Grey's Anatomy la present\u00f3 a millones de nuevos oyentes.",
-      "fun_fact_fr": "Isaac Slade a \u00e9crit la chanson apr\u00e8s l'overdose d'un ami, s'interrogeant sur l'absence de Dieu pendant la crise. Sa diffusion lors de la premi\u00e8re de la saison 5 de Grey's Anatomy l'a fait d\u00e9couvrir \u00e0 des millions de nouveaux auditeurs.",
+      "fun_fact_de": "Isaac Slade schrieb den Song, nachdem ein Freund eine Überdosis genommen hatte — eine Auseinandersetzung mit der Frage, wo Gott in der Krise war. Die Verwendung in Grey's Anatomy machte den Song weltweit bekannt.",
+      "fun_fact_es": "Isaac Slade escribió la canción tras la sobredosis de un amigo, cuestionando dónde estaba Dios. Su aparición en el estreno de la temporada 5 de Grey's Anatomy la presentó a millones de nuevos oyentes.",
+      "fun_fact_fr": "Isaac Slade a écrit la chanson après l'overdose d'un ami, s'interrogeant sur l'absence de Dieu pendant la crise. Sa diffusion lors de la première de la saison 5 de Grey's Anatomy l'a fait découvrir à des millions de nouveaux auditeurs.",
       "uri_apple_music": "applemusic://track/301537185",
       "uri_youtube_music": "https://music.youtube.com/watch?v=jFg_8u87zT0",
       "uri_tidal": "tidal://track/2256444",
       "uri_deezer": "deezer://track/2889763",
-      "fun_fact_nl": "Isaac Slade schreef het nummer nadat een vriend een overdosis had genomen, zich afvragend waar God was tijdens de crisis. Het was te horen in de premi\u00e8re van seizoen 5 van Grey's Anatomy, wat het nummer bij miljoenen nieuwe luisteraars introduceerde.",
-      "awards_nl": []
+      "fun_fact_nl": "Isaac Slade schreef het nummer nadat een vriend een overdosis had genomen, zich afvragend waar God was tijdens de crisis. Het was te horen in de première van seizoen 5 van Grey's Anatomy, wat het nummer bij miljoenen nieuwe luisteraars introduceerde.",
+      "awards_nl": [],
+      "isrc": "USSM10803009",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1737735340",
+        "de": "applemusic://track/1737735340",
+        "gb": "applemusic://track/1737735340",
+        "fr": "applemusic://track/1737735340",
+        "es": "applemusic://track/1737735340",
+        "nl": "applemusic://track/1737735340",
+        "it": "applemusic://track/1737735340"
+      }
     },
     {
       "year": 2009,
@@ -4134,15 +5344,25 @@
       ],
       "awards": [],
       "fun_fact": "Uprising's glam-rock stomp was inspired by Marc Bolan and T. Rex. Matt Bellamy described it as a protest song for the financial crisis era, and it became one of the most-used songs in sports stadiums worldwide.",
-      "fun_fact_de": "Der Glam-Rock-Stampfer wurde von Marc Bolan und T. Rex inspiriert. Matt Bellamy beschrieb ihn als Protestsong der Finanzkrise \u2014 heute ist er einer der meistgespielten Songs in Sportstadien weltweit.",
-      "fun_fact_es": "Inspirada en Marc Bolan y T. Rex, Matt Bellamy la describi\u00f3 como una canci\u00f3n de protesta de la era de la crisis financiera. Se convirti\u00f3 en una de las canciones m\u00e1s utilizadas en estadios deportivos de todo el mundo.",
-      "fun_fact_fr": "Le stomp glam-rock d'Uprising s'inspire de Marc Bolan et T. Rex. Matt Bellamy l'a d\u00e9crit comme une chanson de protestation de l'\u00e8re de la crise financi\u00e8re, et elle est devenue l'un des morceaux les plus jou\u00e9s dans les stades du monde entier.",
+      "fun_fact_de": "Der Glam-Rock-Stampfer wurde von Marc Bolan und T. Rex inspiriert. Matt Bellamy beschrieb ihn als Protestsong der Finanzkrise — heute ist er einer der meistgespielten Songs in Sportstadien weltweit.",
+      "fun_fact_es": "Inspirada en Marc Bolan y T. Rex, Matt Bellamy la describió como una canción de protesta de la era de la crisis financiera. Se convirtió en una de las canciones más utilizadas en estadios deportivos de todo el mundo.",
+      "fun_fact_fr": "Le stomp glam-rock d'Uprising s'inspire de Marc Bolan et T. Rex. Matt Bellamy l'a décrit comme une chanson de protestation de l'ère de la crise financière, et elle est devenue l'un des morceaux les plus joués dans les stades du monde entier.",
       "uri_apple_music": "applemusic://track/992627891",
       "uri_youtube_music": "https://music.youtube.com/watch?v=w8KQmps-Sog",
       "uri_tidal": "tidal://track/3083287",
       "uri_deezer": "deezer://track/4195713",
-      "fun_fact_nl": "De glam-rock stomp van Uprising was ge\u00efnspireerd op Marc Bolan en T. Rex. Matt Bellamy beschreef het als een protestlied voor het tijdperk van de financi\u00eble crisis, en het werd een van de meest gebruikte nummers in sportstadions wereldwijd.",
-      "awards_nl": []
+      "fun_fact_nl": "De glam-rock stomp van Uprising was geïnspireerd op Marc Bolan en T. Rex. Matt Bellamy beschreef het als een protestlied voor het tijdperk van de financiële crisis, en het werd een van de meest gebruikte nummers in sportstadions wereldwijd.",
+      "awards_nl": [],
+      "isrc": "GBAHT1500308",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/992627891",
+        "de": "applemusic://track/992627891",
+        "gb": "applemusic://track/992627891",
+        "fr": "applemusic://track/992627891",
+        "es": "applemusic://track/992627891",
+        "nl": "applemusic://track/992627891",
+        "it": "applemusic://track/992627891"
+      }
     },
     {
       "year": 2005,
@@ -4165,15 +5385,25 @@
       ],
       "awards": [],
       "fun_fact": "The music video was filmed in a high school gym inspired by the prom scene in the movie Carrie. Pete Wentz wrote the lyrics about the awkwardness of teenage romance and not knowing what to say to the person you like.",
-      "fun_fact_de": "Das Musikvideo wurde in einer Schulaula gedreht, inspiriert von der Ballszene aus dem Film 'Carrie'. Pete Wentz schrieb \u00fcber die Unbeholfenheit erster Romanzen und das Gef\u00fchl, nicht die richtigen Worte zu finden.",
-      "fun_fact_es": "El video fue filmado en un gimnasio escolar inspirado en la escena del baile de la pel\u00edcula Carrie. Pete Wentz escribi\u00f3 sobre la torpeza del romance adolescente y no saber qu\u00e9 decirle a la persona que te gusta.",
-      "fun_fact_fr": "Le clip a \u00e9t\u00e9 tourn\u00e9 dans un gymnase de lyc\u00e9e inspir\u00e9 de la sc\u00e8ne du bal de promo du film Carrie. Pete Wentz a \u00e9crit les paroles sur la maladresse des premi\u00e8res amours adolescentes et le fait de ne pas savoir quoi dire \u00e0 la personne qu'on aime.",
+      "fun_fact_de": "Das Musikvideo wurde in einer Schulaula gedreht, inspiriert von der Ballszene aus dem Film 'Carrie'. Pete Wentz schrieb über die Unbeholfenheit erster Romanzen und das Gefühl, nicht die richtigen Worte zu finden.",
+      "fun_fact_es": "El video fue filmado en un gimnasio escolar inspirado en la escena del baile de la película Carrie. Pete Wentz escribió sobre la torpeza del romance adolescente y no saber qué decirle a la persona que te gusta.",
+      "fun_fact_fr": "Le clip a été tourné dans un gymnase de lycée inspiré de la scène du bal de promo du film Carrie. Pete Wentz a écrit les paroles sur la maladresse des premières amours adolescentes et le fait de ne pas savoir quoi dire à la personne qu'on aime.",
       "uri_apple_music": "applemusic://track/1440799368",
       "uri_youtube_music": "https://music.youtube.com/watch?v=C6MOKXm8x50",
       "uri_tidal": "tidal://track/3684437",
       "uri_deezer": "deezer://track/1138246",
-      "fun_fact_nl": "De videoclip werd gefilmd in een gymzaal van een middelbare school, ge\u00efnspireerd op de galasc\u00e8ne in de film Carrie. Pete Wentz schreef de tekst over de onhandigheid van tienerromantiek en het niet weten wat te zeggen tegen de persoon die je leuk vindt.",
-      "awards_nl": []
+      "fun_fact_nl": "De videoclip werd gefilmd in een gymzaal van een middelbare school, geïnspireerd op de galascène in de film Carrie. Pete Wentz schreef de tekst over de onhandigheid van tienerromantiek en het niet weten wat te zeggen tegen de persoon die je leuk vindt.",
+      "awards_nl": [],
+      "isrc": "USDJ20500174",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1779813306",
+        "de": "applemusic://track/1779813306",
+        "gb": "applemusic://track/1779813306",
+        "fr": "applemusic://track/1779813306",
+        "es": "applemusic://track/1779813306",
+        "nl": "applemusic://track/1779813306",
+        "it": "applemusic://track/1779813306"
+      }
     },
     {
       "year": 2007,
@@ -4196,16 +5426,26 @@
         "Platinum (UK)"
       ],
       "awards": [],
-      "fun_fact": "Give It To Me reunited Timbaland's most successful collaborators. It includes subliminal disses aimed at Scott Storch and other producers \u2014 Timbaland was asserting his dominance in the late-2000s production scene.",
-      "fun_fact_de": "Der Song vereinte Timbalands erfolgreichste Kollaborateure. Er enth\u00e4lt versteckte Seitenhiebe gegen Scott Storch und andere Produzenten \u2014 Timbaland setzte damit ein Statement seiner Dominanz in der Musikproduktion.",
-      "fun_fact_es": "La canci\u00f3n reuni\u00f3 a los colaboradores m\u00e1s exitosos de Timbaland e incluye pullas veladas contra Scott Storch y otros productores, con Timbaland afirmando su dominio en la producci\u00f3n musical de finales de los 2000.",
-      "fun_fact_fr": "Give It To Me a r\u00e9uni les collaborateurs les plus c\u00e9l\u00e8bres de Timbaland. Le titre contient des piques subtiles visant Scott Storch et d'autres producteurs \u2014 Timbaland affirmait sa domination sur la sc\u00e8ne musicale de la fin des ann\u00e9es 2000.",
+      "fun_fact": "Give It To Me reunited Timbaland's most successful collaborators. It includes subliminal disses aimed at Scott Storch and other producers — Timbaland was asserting his dominance in the late-2000s production scene.",
+      "fun_fact_de": "Der Song vereinte Timbalands erfolgreichste Kollaborateure. Er enthält versteckte Seitenhiebe gegen Scott Storch und andere Produzenten — Timbaland setzte damit ein Statement seiner Dominanz in der Musikproduktion.",
+      "fun_fact_es": "La canción reunió a los colaboradores más exitosos de Timbaland e incluye pullas veladas contra Scott Storch y otros productores, con Timbaland afirmando su dominio en la producción musical de finales de los 2000.",
+      "fun_fact_fr": "Give It To Me a réuni les collaborateurs les plus célèbres de Timbaland. Le titre contient des piques subtiles visant Scott Storch et d'autres producteurs — Timbaland affirmait sa domination sur la scène musicale de la fin des années 2000.",
       "uri_apple_music": "applemusic://track/1440748877",
       "uri_youtube_music": "https://music.youtube.com/watch?v=RgoiSJ23cSc",
       "uri_tidal": "tidal://track/35738719",
       "uri_deezer": "deezer://track/4685512",
-      "fun_fact_nl": "Give It To Me herenigde Timbalands meest succesvolle medewerkers. Het bevat subliminale 'disses' gericht aan Scott Storch en andere producenten \u2014 Timbaland vestigde zijn dominantie in de productiescene van de late jaren 2000.",
-      "awards_nl": []
+      "fun_fact_nl": "Give It To Me herenigde Timbalands meest succesvolle medewerkers. Het bevat subliminale 'disses' gericht aan Scott Storch en andere producenten — Timbaland vestigde zijn dominantie in de productiescene van de late jaren 2000.",
+      "awards_nl": [],
+      "isrc": "USUM70700995",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1708517061",
+        "de": "applemusic://track/1708517061",
+        "gb": "applemusic://track/1708517061",
+        "fr": "applemusic://track/1708517061",
+        "es": "applemusic://track/1708517061",
+        "nl": "applemusic://track/1708517061",
+        "it": "applemusic://track/1708517061"
+      }
     },
     {
       "year": 2006,
@@ -4228,15 +5468,25 @@
       ],
       "awards": [],
       "fun_fact": "Naive was written by Luke Pritchard about his ex-girlfriend Katie Melua. Its jangly guitar riff became the soundtrack to every UK student union party in 2006 and is one of the defining songs of the mid-2000s British indie scene.",
-      "fun_fact_de": "Luke Pritchard schrieb Naive \u00fcber seine Ex-Freundin Katie Melua. Der janglende Gitarrenriff wurde zum Soundtrack jeder britischen Studentenparty im Jahr 2006 und ist einer der pr\u00e4genden Songs der Britpop-Indie-Szene der Mitte der 2000er.",
-      "fun_fact_es": "Luke Pritchard escribi\u00f3 Naive sobre su ex novia Katie Melua. Su riff de guitarra se convirti\u00f3 en la banda sonora de las fiestas estudiantiles brit\u00e1nicas en 2006 y es una de las canciones definitorias de la escena indie brit\u00e1nica de mediados de los 2000.",
-      "fun_fact_fr": "Naive a \u00e9t\u00e9 \u00e9crite par Luke Pritchard sur son ex-petite amie Katie Melua. Son riff de guitare cristallin est devenu la bande-son de toutes les soir\u00e9es \u00e9tudiantes britanniques en 2006 et l'un des titres phares de la sc\u00e8ne indie britannique du milieu des ann\u00e9es 2000.",
+      "fun_fact_de": "Luke Pritchard schrieb Naive über seine Ex-Freundin Katie Melua. Der janglende Gitarrenriff wurde zum Soundtrack jeder britischen Studentenparty im Jahr 2006 und ist einer der prägenden Songs der Britpop-Indie-Szene der Mitte der 2000er.",
+      "fun_fact_es": "Luke Pritchard escribió Naive sobre su ex novia Katie Melua. Su riff de guitarra se convirtió en la banda sonora de las fiestas estudiantiles británicas en 2006 y es una de las canciones definitorias de la escena indie británica de mediados de los 2000.",
+      "fun_fact_fr": "Naive a été écrite par Luke Pritchard sur son ex-petite amie Katie Melua. Son riff de guitare cristallin est devenu la bande-son de toutes les soirées étudiantes britanniques en 2006 et l'un des titres phares de la scène indie britannique du milieu des années 2000.",
       "uri_apple_music": "applemusic://track/714597985",
       "uri_youtube_music": "https://music.youtube.com/watch?v=jkaMiaRLgvY",
       "uri_tidal": "tidal://track/1529432",
       "uri_deezer": "deezer://track/3158004",
       "fun_fact_nl": "Naive werd geschreven door Luke Pritchard over zijn ex-vriendin Katie Melua. De rammelende gitaarriff werd de soundtrack van elk studentenfeest in het VK in 2006 en is een van de bepalende nummers van de Britse indiescene van het midden van de jaren 2000.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAAA0500836",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1741437602",
+        "de": "applemusic://track/1741437602",
+        "gb": "applemusic://track/1741437602",
+        "fr": "applemusic://track/1741437602",
+        "es": "applemusic://track/1741437602",
+        "nl": "applemusic://track/1741437602",
+        "it": "applemusic://track/1741437602"
+      }
     },
     {
       "year": 2000,
@@ -4259,15 +5509,25 @@
       ],
       "awards": [],
       "fun_fact": "This is a cover of King Harvest's 1972 original. Toploader's version became a massive European hit and is one of the most-played songs in UK pubs and bars, selling over 400,000 copies in the UK alone.",
-      "fun_fact_de": "Dieses Cover des King-Harvest-Originals von 1972 wurde zum Riesenhit in Europa und ist einer der meistgespielten Songs in britischen Pubs. In Gro\u00dfbritannien allein verkaufte es \u00fcber 400.000 Exemplare.",
-      "fun_fact_es": "Esta versi\u00f3n del original de King Harvest de 1972 se convirti\u00f3 en un gran \u00e9xito europeo y es una de las canciones m\u00e1s reproducidas en pubs y bares del Reino Unido, vendiendo m\u00e1s de 400.000 copias solo en Gran Breta\u00f1a.",
-      "fun_fact_fr": "C'est une reprise de l'original de King Harvest de 1972. La version de Toploader est devenue un immense succ\u00e8s europ\u00e9en et l'un des morceaux les plus jou\u00e9s dans les pubs britanniques, avec plus de 400 000 exemplaires vendus au Royaume-Uni.",
+      "fun_fact_de": "Dieses Cover des King-Harvest-Originals von 1972 wurde zum Riesenhit in Europa und ist einer der meistgespielten Songs in britischen Pubs. In Großbritannien allein verkaufte es über 400.000 Exemplare.",
+      "fun_fact_es": "Esta versión del original de King Harvest de 1972 se convirtió en un gran éxito europeo y es una de las canciones más reproducidas en pubs y bares del Reino Unido, vendiendo más de 400.000 copias solo en Gran Bretaña.",
+      "fun_fact_fr": "C'est une reprise de l'original de King Harvest de 1972. La version de Toploader est devenue un immense succès européen et l'un des morceaux les plus joués dans les pubs britanniques, avec plus de 400 000 exemplaires vendus au Royaume-Uni.",
       "uri_apple_music": "applemusic://track/273400021",
       "uri_youtube_music": "https://music.youtube.com/watch?v=0yBnIUX0QAE",
       "uri_tidal": "tidal://track/491747",
       "uri_deezer": "deezer://track/10434104",
       "fun_fact_nl": "Dit is een cover van het origineel van King Harvest uit 1972. De versie van Toploader werd een enorme Europese hit en is een van de meest gedraaide nummers in Britse pubs en bars, met meer dan 400.000 verkochte exemplaren in alleen al het VK.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBBBL9902165",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1744521402",
+        "de": "applemusic://track/1744521402",
+        "gb": "applemusic://track/1744521402",
+        "fr": "applemusic://track/1744521402",
+        "es": "applemusic://track/1744521402",
+        "nl": "applemusic://track/1744521402",
+        "it": "applemusic://track/1744521402"
+      }
     },
     {
       "year": 2010,
@@ -4291,15 +5551,25 @@
       ],
       "awards": [],
       "fun_fact": "Though from 2010 (just outside the 2000s), Mike Posner wrote and produced this song in his dorm room at Duke University. The remix by Gigamesh turned it from a blog hit into a worldwide smash.",
-      "fun_fact_de": "Obwohl von 2010 (knapp au\u00dferhalb der 2000er), schrieb und produzierte Mike Posner den Song in seinem Studentenwohnheim an der Duke University. Der Gigamesh-Remix verwandelte ihn von einem Blog-Hit in einen weltweiten Erfolg.",
-      "fun_fact_es": "Aunque es de 2010, Mike Posner escribi\u00f3 y produjo esta canci\u00f3n en su dormitorio de la Universidad Duke. El remix de Gigamesh la transform\u00f3 de un \u00e9xito de blogs a un hit mundial.",
-      "fun_fact_fr": "Bien que sorti en 2010 (juste en dehors des ann\u00e9es 2000), Mike Posner a \u00e9crit et produit ce titre dans sa chambre d'\u00e9tudiant \u00e0 l'universit\u00e9 Duke. Le remix de Gigamesh l'a transform\u00e9 d'un tube de blogs en succ\u00e8s plan\u00e9taire.",
+      "fun_fact_de": "Obwohl von 2010 (knapp außerhalb der 2000er), schrieb und produzierte Mike Posner den Song in seinem Studentenwohnheim an der Duke University. Der Gigamesh-Remix verwandelte ihn von einem Blog-Hit in einen weltweiten Erfolg.",
+      "fun_fact_es": "Aunque es de 2010, Mike Posner escribió y produjo esta canción en su dormitorio de la Universidad Duke. El remix de Gigamesh la transformó de un éxito de blogs a un hit mundial.",
+      "fun_fact_fr": "Bien que sorti en 2010 (juste en dehors des années 2000), Mike Posner a écrit et produit ce titre dans sa chambre d'étudiant à l'université Duke. Le remix de Gigamesh l'a transformé d'un tube de blogs en succès planétaire.",
       "uri_apple_music": "applemusic://track/383458635",
       "uri_youtube_music": "https://music.youtube.com/watch?v=Bsr8hb3TPBI",
       "uri_tidal": "tidal://track/4253935",
       "uri_deezer": "deezer://track/6697128",
       "fun_fact_nl": "Hoewel uit 2010 (vlak buiten de jaren 2000), schreef en produceerde Mike Posner dit nummer in zijn studentenkamer aan de Duke University. De remix door Gigamesh maakte er van een bloghit een wereldwijde knaller van.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USJAY1000035",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1744523906",
+        "de": "applemusic://track/1744523906",
+        "gb": "applemusic://track/1744523906",
+        "fr": "applemusic://track/1744523906",
+        "es": "applemusic://track/1744523906",
+        "nl": "applemusic://track/1744523906",
+        "it": "applemusic://track/1744523906"
+      }
     },
     {
       "year": 2002,
@@ -4322,15 +5592,25 @@
       ],
       "awards": [],
       "fun_fact": "Feel was co-written with Guy Chambers and nearly wasn't released as a single. It became one of Robbie Williams' signature songs worldwide, especially popular in Europe, though it never charted in the US.",
-      "fun_fact_de": "Feel wurde mit Guy Chambers geschrieben und w\u00e4re fast nicht als Single ver\u00f6ffentlicht worden. Es wurde zu einem von Robbies Signature-Songs, besonders beliebt in Europa, obwohl es in den USA nie chartete.",
-      "fun_fact_es": "Coescrita con Guy Chambers, casi no se lanz\u00f3 como sencillo. Se convirti\u00f3 en una de las canciones emblem\u00e1ticas de Robbie Williams, especialmente popular en Europa, aunque nunca entr\u00f3 en las listas de EE.UU.",
-      "fun_fact_fr": "Feel a \u00e9t\u00e9 co\u00e9crit avec Guy Chambers et a failli ne pas sortir en single. C'est devenu l'un des titres embl\u00e9matiques de Robbie Williams, particuli\u00e8rement populaire en Europe, bien qu'il n'ait jamais \u00e9t\u00e9 class\u00e9 aux \u00c9tats-Unis.",
+      "fun_fact_de": "Feel wurde mit Guy Chambers geschrieben und wäre fast nicht als Single veröffentlicht worden. Es wurde zu einem von Robbies Signature-Songs, besonders beliebt in Europa, obwohl es in den USA nie chartete.",
+      "fun_fact_es": "Coescrita con Guy Chambers, casi no se lanzó como sencillo. Se convirtió en una de las canciones emblemáticas de Robbie Williams, especialmente popular en Europa, aunque nunca entró en las listas de EE.UU.",
+      "fun_fact_fr": "Feel a été coécrit avec Guy Chambers et a failli ne pas sortir en single. C'est devenu l'un des titres emblématiques de Robbie Williams, particulièrement populaire en Europe, bien qu'il n'ait jamais été classé aux États-Unis.",
       "uri_apple_music": "applemusic://track/727506071",
       "uri_youtube_music": "https://music.youtube.com/watch?v=B8IuVzHy19o",
       "uri_tidal": "tidal://track/154010",
       "uri_deezer": "deezer://track/3098217",
       "fun_fact_nl": "Feel werd geschreven samen met Guy Chambers en werd bijna niet als single uitgebracht. Het werd een van de kenmerkende nummers van Robbie Williams wereldwijd, vooral populair in Europa, hoewel het in de VS nooit de hitlijsten haalde.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBFFG0200002",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/724236952",
+        "de": "applemusic://track/724236952",
+        "gb": "applemusic://track/724236952",
+        "fr": "applemusic://track/724236952",
+        "es": "applemusic://track/724236952",
+        "nl": "applemusic://track/724236952",
+        "it": "applemusic://track/724236952"
+      }
     },
     {
       "year": 2001,
@@ -4354,15 +5634,25 @@
       ],
       "awards": [],
       "fun_fact": "The song was Shakira's English-language crossover hit (the Spanish version is called 'Suerte'). Its Andean-influenced charango riff and belly-dancing choreography made it a global phenomenon, selling 7 million copies.",
-      "fun_fact_de": "Der Song war Shakiras englischer Crossover-Hit (die spanische Version hei\u00dft 'Suerte'). Das Andean-beeinflusste Charango-Riff und die Bauchtanz-Choreografie machten ihn mit 7 Millionen verkauften Exemplaren zum globalen Ph\u00e4nomen.",
-      "fun_fact_es": "Conocida en espa\u00f1ol como 'Suerte', esta fue la canci\u00f3n que present\u00f3 a Shakira al mundo anglosaj\u00f3n. Su riff de charango andino y coreograf\u00eda de danza del vientre la convirtieron en un fen\u00f3meno global con 7 millones de copias vendidas.",
-      "fun_fact_fr": "C'est le titre qui a permis \u00e0 Shakira de conqu\u00e9rir le march\u00e9 anglophone (la version espagnole s'appelle 'Suerte'). Son riff de charango andin et sa chor\u00e9graphie de danse orientale en ont fait un ph\u00e9nom\u00e8ne mondial, avec 7 millions d'exemplaires vendus.",
+      "fun_fact_de": "Der Song war Shakiras englischer Crossover-Hit (die spanische Version heißt 'Suerte'). Das Andean-beeinflusste Charango-Riff und die Bauchtanz-Choreografie machten ihn mit 7 Millionen verkauften Exemplaren zum globalen Phänomen.",
+      "fun_fact_es": "Conocida en español como 'Suerte', esta fue la canción que presentó a Shakira al mundo anglosajón. Su riff de charango andino y coreografía de danza del vientre la convirtieron en un fenómeno global con 7 millones de copias vendidas.",
+      "fun_fact_fr": "C'est le titre qui a permis à Shakira de conquérir le marché anglophone (la version espagnole s'appelle 'Suerte'). Son riff de charango andin et sa chorégraphie de danse orientale en ont fait un phénomène mondial, avec 7 millions d'exemplaires vendus.",
       "uri_apple_music": "applemusic://track/188261029",
       "uri_youtube_music": "https://music.youtube.com/watch?v=weRHyjj34ZE",
       "uri_tidal": "tidal://track/26828560",
       "uri_deezer": "deezer://track/15211178",
-      "fun_fact_nl": "Het nummer was de Engelstalige crossover-hit van Shakira (de Spaanse versie heet 'Suerte'). De door de Andes be\u00efnvloede charango-riff en buikdanschoreografie maakten het tot een wereldwijd fenomeen, waarvan 7 miljoen exemplaren werden verkocht.",
-      "awards_nl": []
+      "fun_fact_nl": "Het nummer was de Engelstalige crossover-hit van Shakira (de Spaanse versie heet 'Suerte'). De door de Andes beïnvloede charango-riff en buikdanschoreografie maakten het tot een wereldwijd fenomeen, waarvan 7 miljoen exemplaren werden verkocht.",
+      "awards_nl": [],
+      "isrc": "NLB630100324",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1626184874",
+        "de": "applemusic://track/1626184874",
+        "gb": "applemusic://track/1626184874",
+        "fr": "applemusic://track/1626184874",
+        "es": "applemusic://track/1626184874",
+        "nl": "applemusic://track/1626184874",
+        "it": "applemusic://track/1626184874"
+      }
     },
     {
       "year": 2008,
@@ -4386,15 +5676,25 @@
       ],
       "awards": [],
       "fun_fact": "Hot N Cold has been certified Diamond (10x Platinum) in multiple countries. Katy Perry co-wrote it with Max Martin and Dr. Luke, and the music video features a runaway bride scenario filmed in a real church.",
-      "fun_fact_de": "Hot N Cold wurde in mehreren L\u00e4ndern mit Diamant-Status (10x Platin) ausgezeichnet. Das Musikvideo zeigt eine davonlaufende Braut, gedreht in einer echten Kirche \u2014 geschrieben mit Hit-Produzenten Max Martin und Dr. Luke.",
-      "fun_fact_es": "Hot N Cold ha sido certificada Diamante en varios pa\u00edses. Coescrita con Max Martin y Dr. Luke, su video musical muestra a una novia fugitiva filmada en una iglesia real.",
-      "fun_fact_fr": "Hot N Cold a \u00e9t\u00e9 certifi\u00e9 Diamant (10x Platine) dans plusieurs pays. Katy Perry l'a co\u00e9crit avec Max Martin et Dr. Luke, et le clip met en sc\u00e8ne une mari\u00e9e en fuite tourn\u00e9e dans une vraie \u00e9glise.",
+      "fun_fact_de": "Hot N Cold wurde in mehreren Ländern mit Diamant-Status (10x Platin) ausgezeichnet. Das Musikvideo zeigt eine davonlaufende Braut, gedreht in einer echten Kirche — geschrieben mit Hit-Produzenten Max Martin und Dr. Luke.",
+      "fun_fact_es": "Hot N Cold ha sido certificada Diamante en varios países. Coescrita con Max Martin y Dr. Luke, su video musical muestra a una novia fugitiva filmada en una iglesia real.",
+      "fun_fact_fr": "Hot N Cold a été certifié Diamant (10x Platine) dans plusieurs pays. Katy Perry l'a coécrit avec Max Martin et Dr. Luke, et le clip met en scène une mariée en fuite tournée dans une vraie église.",
       "uri_apple_music": "applemusic://track/715891658",
       "uri_youtube_music": "https://music.youtube.com/watch?v=kTHNpusq654",
       "uri_tidal": "tidal://track/1919430",
       "uri_deezer": "deezer://track/3160142",
       "fun_fact_nl": "Hot N Cold is in meerdere landen Diamond (10x platina) gecertificeerd. Katy Perry schreef het samen met Max Martin en Dr. Luke, en de videoclip toont een scenario met een weggelopen bruid, gefilmd in een echte kerk.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USCA20802544",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1616704079",
+        "de": "applemusic://track/1616704079",
+        "gb": "applemusic://track/1616704079",
+        "fr": "applemusic://track/1616704079",
+        "es": "applemusic://track/1616704079",
+        "nl": "applemusic://track/1616704079",
+        "it": "applemusic://track/1616704079"
+      }
     },
     {
       "year": 2004,
@@ -4417,14 +5717,14 @@
       ],
       "awards": [],
       "fun_fact": "The aerobics-themed music video, inspired by 1980s workout tapes, became one of the most-viewed videos on the early internet and helped push the song to #1 in the UK. It samples Steve Winwood's 'Valerie'.",
-      "fun_fact_de": "Das Aerobic-Musikvideo im Stil der 80er-Jahre-Fitnessvideos wurde zu einem der meistgesehenen Clips im fr\u00fchen Internet und trieb den Song auf Platz 1 in Gro\u00dfbritannien. Es sampelt Steve Winwoods 'Valerie'.",
-      "fun_fact_es": "El video musical de aer\u00f3bic, inspirado en cintas de ejercicio de los 80, se convirti\u00f3 en uno de los videos m\u00e1s vistos del internet temprano y ayud\u00f3 a llevar la canci\u00f3n al #1 en el Reino Unido. Samplea 'Valerie' de Steve Winwood.",
-      "fun_fact_fr": "Le clip sur le th\u00e8me de l'a\u00e9robic, inspir\u00e9 des cassettes de fitness des ann\u00e9es 80, est devenu l'une des vid\u00e9os les plus regard\u00e9es du d\u00e9but d'internet et a propuls\u00e9 le titre en t\u00eate des charts britanniques. Il sample 'Valerie' de Steve Winwood.",
+      "fun_fact_de": "Das Aerobic-Musikvideo im Stil der 80er-Jahre-Fitnessvideos wurde zu einem der meistgesehenen Clips im frühen Internet und trieb den Song auf Platz 1 in Großbritannien. Es sampelt Steve Winwoods 'Valerie'.",
+      "fun_fact_es": "El video musical de aeróbic, inspirado en cintas de ejercicio de los 80, se convirtió en uno de los videos más vistos del internet temprano y ayudó a llevar la canción al #1 en el Reino Unido. Samplea 'Valerie' de Steve Winwood.",
+      "fun_fact_fr": "Le clip sur le thème de l'aérobic, inspiré des cassettes de fitness des années 80, est devenu l'une des vidéos les plus regardées du début d'internet et a propulsé le titre en tête des charts britanniques. Il sample 'Valerie' de Steve Winwood.",
       "uri_apple_music": "",
       "uri_youtube_music": "https://music.youtube.com/watch?v=lw3iCVeTe30",
       "uri_tidal": "tidal://track/71508889",
       "uri_deezer": "deezer://track/144203048",
-      "fun_fact_nl": "De op aerobics ge\u00efnspireerde videoclip, gebaseerd op workoutvideo's uit de jaren 80, werd een van de meest bekeken video's op het vroege internet en hielp het nummer naar de eerste plaats in het VK. Het bevat een sample van Steve Winwoods 'Valerie'.",
+      "fun_fact_nl": "De op aerobics geïnspireerde videoclip, gebaseerd op workoutvideo's uit de jaren 80, werd een van de meest bekeken video's op het vroege internet en hielp het nummer naar de eerste plaats in het VK. Het bevat een sample van Steve Winwoods 'Valerie'.",
       "awards_nl": []
     },
     {
@@ -4449,15 +5749,25 @@
       ],
       "awards": [],
       "fun_fact": "Matt Bellamy wrote Starlight about being separated from his partner while on tour. The driving bassline and romantic lyrics made it Muse's most accessible single, introducing them to a broader pop audience.",
-      "fun_fact_de": "Matt Bellamy schrieb Starlight \u00fcber die Trennung von seiner Partnerin w\u00e4hrend Tourneen. Die eing\u00e4ngige Basslinie und romantische Texte machten es zu Muses zug\u00e4nglichster Single und \u00f6ffneten die Band einem breiteren Pop-Publikum.",
-      "fun_fact_es": "Matt Bellamy escribi\u00f3 Starlight sobre estar separado de su pareja durante las giras. Su l\u00ednea de bajo y letras rom\u00e1nticas la convirtieron en el sencillo m\u00e1s accesible de Muse, present\u00e1ndolos a un p\u00fablico pop m\u00e1s amplio.",
-      "fun_fact_fr": "Matt Bellamy a \u00e9crit Starlight sur la s\u00e9paration d'avec sa partenaire pendant les tourn\u00e9es. La ligne de basse entra\u00eenante et les paroles romantiques en ont fait le single le plus accessible de Muse, les ouvrant \u00e0 un public pop plus large.",
+      "fun_fact_de": "Matt Bellamy schrieb Starlight über die Trennung von seiner Partnerin während Tourneen. Die eingängige Basslinie und romantische Texte machten es zu Muses zugänglichster Single und öffneten die Band einem breiteren Pop-Publikum.",
+      "fun_fact_es": "Matt Bellamy escribió Starlight sobre estar separado de su pareja durante las giras. Su línea de bajo y letras románticas la convirtieron en el sencillo más accesible de Muse, presentándolos a un público pop más amplio.",
+      "fun_fact_fr": "Matt Bellamy a écrit Starlight sur la séparation d'avec sa partenaire pendant les tournées. La ligne de basse entraînante et les paroles romantiques en ont fait le single le plus accessible de Muse, les ouvrant à un public pop plus large.",
       "uri_apple_music": "applemusic://track/992221996",
       "uri_youtube_music": "https://music.youtube.com/watch?v=Pgum6OT_VH8",
       "uri_tidal": "tidal://track/2844707",
       "uri_deezer": "deezer://track/3590185",
-      "fun_fact_nl": "Matt Bellamy schreef Starlight over het gescheiden zijn van zijn partner tijdens een tournee. De stuwende baslijn en romantische teksten maakten het tot de meest toegankelijke single van Muse, waardoor ze bij een breder poppubliek werden ge\u00efntroduceerd.",
-      "awards_nl": []
+      "fun_fact_nl": "Matt Bellamy schreef Starlight over het gescheiden zijn van zijn partner tijdens een tournee. De stuwende baslijn en romantische teksten maakten het tot de meest toegankelijke single van Muse, waardoor ze bij een breder poppubliek werden geïntroduceerd.",
+      "awards_nl": [],
+      "isrc": "GBAHT1500284",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/992221996",
+        "de": "applemusic://track/992221996",
+        "gb": "applemusic://track/992221996",
+        "fr": "applemusic://track/992221996",
+        "es": "applemusic://track/992221996",
+        "nl": "applemusic://track/992221996",
+        "it": "applemusic://track/992221996"
+      }
     },
     {
       "year": 2007,
@@ -4481,15 +5791,25 @@
       ],
       "awards": [],
       "fun_fact": "Girlfriend was the first song to reach #1 on the Billboard Hot 100 based primarily on digital sales. It was recorded in eight languages including Mandarin, Japanese, French, and Spanish.",
-      "fun_fact_de": "Girlfriend war der erste Song, der haupts\u00e4chlich durch digitale Verk\u00e4ufe Platz 1 der Billboard Hot 100 erreichte. Er wurde in acht Sprachen aufgenommen, darunter Mandarin, Japanisch, Franz\u00f6sisch und Spanisch.",
-      "fun_fact_es": "Girlfriend fue la primera canci\u00f3n en llegar al #1 del Billboard Hot 100 principalmente por ventas digitales. Se grab\u00f3 en ocho idiomas, incluyendo mandar\u00edn, japon\u00e9s, franc\u00e9s y espa\u00f1ol.",
-      "fun_fact_fr": "Girlfriend a \u00e9t\u00e9 la premi\u00e8re chanson \u00e0 atteindre le num\u00e9ro 1 du Billboard Hot 100 principalement gr\u00e2ce aux ventes num\u00e9riques. Elle a \u00e9t\u00e9 enregistr\u00e9e en huit langues dont le mandarin, le japonais, le fran\u00e7ais et l'espagnol.",
+      "fun_fact_de": "Girlfriend war der erste Song, der hauptsächlich durch digitale Verkäufe Platz 1 der Billboard Hot 100 erreichte. Er wurde in acht Sprachen aufgenommen, darunter Mandarin, Japanisch, Französisch und Spanisch.",
+      "fun_fact_es": "Girlfriend fue la primera canción en llegar al #1 del Billboard Hot 100 principalmente por ventas digitales. Se grabó en ocho idiomas, incluyendo mandarín, japonés, francés y español.",
+      "fun_fact_fr": "Girlfriend a été la première chanson à atteindre le numéro 1 du Billboard Hot 100 principalement grâce aux ventes numériques. Elle a été enregistrée en huit langues dont le mandarin, le japonais, le français et l'espagnol.",
       "uri_apple_music": "applemusic://track/356980431",
       "uri_youtube_music": "https://music.youtube.com/watch?v=Bg59q4puhmg",
       "uri_tidal": "tidal://track/11337781",
       "uri_deezer": "deezer://track/5495885",
       "fun_fact_nl": "Girlfriend was het eerste nummer dat de eerste plaats in de Billboard Hot 100 bereikte, voornamelijk op basis van digitale verkoop. Het werd opgenomen in acht talen, waaronder Mandarijn, Japans, Frans en Spaans.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USRC10700021",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/356980431",
+        "de": "applemusic://track/356980431",
+        "gb": "applemusic://track/356980431",
+        "fr": "applemusic://track/356980431",
+        "es": "applemusic://track/356980431",
+        "nl": "applemusic://track/356980431",
+        "it": "applemusic://track/356980431"
+      }
     },
     {
       "year": 2002,
@@ -4513,15 +5833,25 @@
       ],
       "awards": [],
       "fun_fact": "Produced by the Neptunes, Hot In Herre stayed at #1 for seven weeks and won the Grammy for Best Male Rap Solo Performance. It became the unofficial summer anthem of 2002 and a permanent party playlist staple.",
-      "fun_fact_de": "Von den Neptunes produziert, stand Hot In Herre sieben Wochen auf Platz 1 und gewann den Grammy f\u00fcr die beste m\u00e4nnliche Rap-Solo-Performance. Er wurde zur inoffiziellen Sommerhymne 2002.",
-      "fun_fact_es": "Producida por The Neptunes, Hot In Herre estuvo siete semanas en el #1 y gan\u00f3 el Grammy a la Mejor Interpretaci\u00f3n Rap Masculina. Se convirti\u00f3 en el himno no oficial del verano de 2002.",
-      "fun_fact_fr": "Produit par les Neptunes, Hot In Herre est rest\u00e9 sept semaines en t\u00eate des charts et a remport\u00e9 le Grammy de la Meilleure Performance Rap Solo Masculine. C'est devenu l'hymne officieux de l'\u00e9t\u00e9 2002.",
+      "fun_fact_de": "Von den Neptunes produziert, stand Hot In Herre sieben Wochen auf Platz 1 und gewann den Grammy für die beste männliche Rap-Solo-Performance. Er wurde zur inoffiziellen Sommerhymne 2002.",
+      "fun_fact_es": "Producida por The Neptunes, Hot In Herre estuvo siete semanas en el #1 y ganó el Grammy a la Mejor Interpretación Rap Masculina. Se convirtió en el himno no oficial del verano de 2002.",
+      "fun_fact_fr": "Produit par les Neptunes, Hot In Herre est resté sept semaines en tête des charts et a remporté le Grammy de la Meilleure Performance Rap Solo Masculine. C'est devenu l'hymne officieux de l'été 2002.",
       "uri_apple_music": "applemusic://track/1440770037",
       "uri_youtube_music": "https://music.youtube.com/watch?v=GeZZr_p6vB8",
       "uri_tidal": "tidal://track/577676",
       "uri_deezer": "deezer://track/2447436",
-      "fun_fact_nl": "Geproduceerd door de Neptunes, stond Hot In Herre zeven weken op nummer 1 en won het de Grammy voor Best Male Rap Solo Performance. Het werd het onoffici\u00eble zomerlied van 2002 en een vast onderdeel van elke feestplaylist.",
-      "awards_nl": []
+      "fun_fact_nl": "Geproduceerd door de Neptunes, stond Hot In Herre zeven weken op nummer 1 en won het de Grammy voor Best Male Rap Solo Performance. Het werd het onofficiële zomerlied van 2002 en een vast onderdeel van elke feestplaylist.",
+      "awards_nl": [],
+      "isrc": "USUR10200371",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1890037534",
+        "de": "applemusic://track/1890037534",
+        "gb": "applemusic://track/1890037534",
+        "fr": "applemusic://track/1890037534",
+        "es": "applemusic://track/1890037534",
+        "nl": "applemusic://track/1890037534",
+        "it": "applemusic://track/1890037534"
+      }
     },
     {
       "year": 2008,
@@ -4545,14 +5875,24 @@
       "awards": [],
       "fun_fact": "Savior spent 65 weeks on the Billboard Hot Rock Songs chart and became Rise Against's most commercially successful song. Despite being a punk band, the song crossed over to mainstream radio.",
       "fun_fact_de": "Savior verbrachte 65 Wochen in den Billboard Hot Rock Songs Charts und wurde zu Rise Againsts kommerziell erfolgreichstem Song, der trotz Punk-Wurzeln den Sprung ins Mainstream-Radio schaffte.",
-      "fun_fact_es": "Savior pas\u00f3 65 semanas en la lista Billboard Hot Rock Songs y se convirti\u00f3 en la canci\u00f3n m\u00e1s exitosa comercialmente de Rise Against, cruzando del punk al radio mainstream.",
-      "fun_fact_fr": "Savior est rest\u00e9 65 semaines dans le classement Billboard Hot Rock Songs et est devenu le titre le plus r\u00e9ussi commercialement de Rise Against. Malgr\u00e9 ses racines punk, la chanson a perc\u00e9 en radio mainstream.",
+      "fun_fact_es": "Savior pasó 65 semanas en la lista Billboard Hot Rock Songs y se convirtió en la canción más exitosa comercialmente de Rise Against, cruzando del punk al radio mainstream.",
+      "fun_fact_fr": "Savior est resté 65 semaines dans le classement Billboard Hot Rock Songs et est devenu le titre le plus réussi commercialement de Rise Against. Malgré ses racines punk, la chanson a percé en radio mainstream.",
       "uri_apple_music": "applemusic://track/1440852127",
       "uri_youtube_music": "https://music.youtube.com/watch?v=e8X3ACToii0",
       "uri_tidal": "tidal://track/35354658",
       "uri_deezer": "deezer://track/7419123",
       "fun_fact_nl": "Savior stond 65 weken in de Billboard Hot Rock Songs-hitlijst en werd het commercieel meest succesvolle nummer van Rise Against. Ondanks dat het een punkband is, maakte het nummer de overstap naar de mainstream radio.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USUM70832584",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1840454073",
+        "de": "applemusic://track/1840454073",
+        "gb": "applemusic://track/1840454073",
+        "fr": "applemusic://track/1840454073",
+        "es": "applemusic://track/1840454073",
+        "nl": "applemusic://track/1840454073",
+        "it": "applemusic://track/1840454073"
+      }
     },
     {
       "year": 2003,
@@ -4576,15 +5916,25 @@
       ],
       "awards": [],
       "fun_fact": "Amy Lee wrote My Immortal when she was just 15. The haunting piano ballad was originally a B-side before fan demand pushed it to single release, becoming one of the defining power ballads of the 2000s.",
-      "fun_fact_de": "Amy Lee schrieb My Immortal mit nur 15 Jahren. Die eindringliche Klavierballade war urspr\u00fcnglich eine B-Seite, bevor Fan-Nachfrage sie zur Single machte \u2014 heute eine der pr\u00e4genden Power-Balladen der 2000er.",
-      "fun_fact_es": "Amy Lee escribi\u00f3 My Immortal a los 15 a\u00f1os. La cautivadora balada de piano fue originalmente una cara B antes de que la demanda de los fans la impulsara como sencillo, convirti\u00e9ndose en una de las baladas definitivas de los 2000.",
-      "fun_fact_fr": "Amy Lee a \u00e9crit My Immortal \u00e0 seulement 15 ans. Cette ballade au piano envo\u00fbtante \u00e9tait \u00e0 l'origine une face B avant que la demande des fans ne la pousse en single, en faisant l'une des power ballads embl\u00e9matiques des ann\u00e9es 2000.",
+      "fun_fact_de": "Amy Lee schrieb My Immortal mit nur 15 Jahren. Die eindringliche Klavierballade war ursprünglich eine B-Seite, bevor Fan-Nachfrage sie zur Single machte — heute eine der prägenden Power-Balladen der 2000er.",
+      "fun_fact_es": "Amy Lee escribió My Immortal a los 15 años. La cautivadora balada de piano fue originalmente una cara B antes de que la demanda de los fans la impulsara como sencillo, convirtiéndose en una de las baladas definitivas de los 2000.",
+      "fun_fact_fr": "Amy Lee a écrit My Immortal à seulement 15 ans. Cette ballade au piano envoûtante était à l'origine une face B avant que la demande des fans ne la pousse en single, en faisant l'une des power ballads emblématiques des années 2000.",
       "uri_apple_music": "applemusic://track/1440666126",
       "uri_youtube_music": "https://music.youtube.com/watch?v=5anLPw0Efmo",
       "uri_tidal": "tidal://track/31849197",
       "uri_deezer": "deezer://track/80274516",
       "fun_fact_nl": "Amy Lee schreef My Immortal toen ze pas 15 was. De beklijvende pianoballade was oorspronkelijk een B-kant voordat de vraag van fans leidde tot een release als single, waarmee het een van de bepalende powerballads van de jaren 2000 werd.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USWU30200104",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1793427884",
+        "de": "applemusic://track/1793427884",
+        "gb": "applemusic://track/1793427884",
+        "fr": "applemusic://track/1793427884",
+        "es": "applemusic://track/1793427884",
+        "nl": "applemusic://track/1793427884",
+        "it": "applemusic://track/1793427884"
+      }
     },
     {
       "year": 2008,
@@ -4608,15 +5958,25 @@
       ],
       "awards": [],
       "fun_fact": "Live Your Life samples the 1985 Romanian pop hit 'Dragostea Din Tei' by O-Zone. T.I. recorded his verses while out on bail awaiting sentencing for federal weapons charges.",
-      "fun_fact_de": "Der Song sampelt den rum\u00e4nischen Pop-Hit 'Dragostea Din Tei' (2004: 'Numa Numa') von O-Zone. T.I. nahm seine Strophen auf, w\u00e4hrend er auf Kaution auf seine Verurteilung wegen Waffenbesitz wartete.",
-      "fun_fact_es": "La canci\u00f3n samplea el \u00e9xito pop rumano 'Dragostea Din Tei' de O-Zone. T.I. grab\u00f3 sus versos mientras estaba en libertad bajo fianza esperando sentencia por cargos federales de armas.",
-      "fun_fact_fr": "Live Your Life sample le tube pop roumain 'Dragostea Din Tei' de O-Zone de 1985. T.I. a enregistr\u00e9 ses couplets alors qu'il \u00e9tait en libert\u00e9 sous caution en attendant sa condamnation pour d\u00e9tention ill\u00e9gale d'armes.",
+      "fun_fact_de": "Der Song sampelt den rumänischen Pop-Hit 'Dragostea Din Tei' (2004: 'Numa Numa') von O-Zone. T.I. nahm seine Strophen auf, während er auf Kaution auf seine Verurteilung wegen Waffenbesitz wartete.",
+      "fun_fact_es": "La canción samplea el éxito pop rumano 'Dragostea Din Tei' de O-Zone. T.I. grabó sus versos mientras estaba en libertad bajo fianza esperando sentencia por cargos federales de armas.",
+      "fun_fact_fr": "Live Your Life sample le tube pop roumain 'Dragostea Din Tei' de O-Zone de 1985. T.I. a enregistré ses couplets alors qu'il était en liberté sous caution en attendant sa condamnation pour détention illégale d'armes.",
       "uri_apple_music": "applemusic://track/1260881180",
       "uri_youtube_music": "https://music.youtube.com/watch?v=6q1ZROE12FA",
       "uri_tidal": "tidal://track/98184566",
       "uri_deezer": "deezer://track/383741911",
       "fun_fact_nl": "Live Your Life bevat een sample van de Roemeense pophit 'Dragostea Din Tei' uit 1985 van O-Zone. T.I. nam zijn coupletten op terwijl hij op borgtocht vrij was in afwachting van zijn veroordeling wegens federale wapenfeiten.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USAT20803620",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1260881180",
+        "de": "applemusic://track/1260881180",
+        "gb": "applemusic://track/1260881180",
+        "fr": "applemusic://track/1260881180",
+        "es": "applemusic://track/1260881180",
+        "nl": "applemusic://track/1260881180",
+        "it": "applemusic://track/1260881180"
+      }
     },
     {
       "year": 2002,
@@ -4640,15 +6000,25 @@
       ],
       "awards": [],
       "fun_fact": "I'm with You showcased a softer, more vulnerable side of Avril Lavigne compared to her punk-pop image. Co-written with the Matrix production team, it remains one of her most emotionally resonant songs.",
-      "fun_fact_de": "I'm with You zeigte eine sanftere, verletzlichere Seite von Avril Lavigne im Vergleich zu ihrem Punk-Pop-Image. Mit dem Matrix-Produktionsteam geschrieben, ist es einer ihrer emotional ber\u00fchrendsten Songs.",
-      "fun_fact_es": "I'm with You mostr\u00f3 un lado m\u00e1s suave y vulnerable de Avril Lavigne. Coescrita con el equipo de producci\u00f3n The Matrix, sigue siendo una de sus canciones m\u00e1s emotivas.",
-      "fun_fact_fr": "I'm with You a d\u00e9voil\u00e9 un c\u00f4t\u00e9 plus doux et plus vuln\u00e9rable d'Avril Lavigne par rapport \u00e0 son image pop-punk. Co\u00e9crit avec l'\u00e9quipe de production The Matrix, il reste l'un de ses morceaux les plus touchants.",
+      "fun_fact_de": "I'm with You zeigte eine sanftere, verletzlichere Seite von Avril Lavigne im Vergleich zu ihrem Punk-Pop-Image. Mit dem Matrix-Produktionsteam geschrieben, ist es einer ihrer emotional berührendsten Songs.",
+      "fun_fact_es": "I'm with You mostró un lado más suave y vulnerable de Avril Lavigne. Coescrita con el equipo de producción The Matrix, sigue siendo una de sus canciones más emotivas.",
+      "fun_fact_fr": "I'm with You a dévoilé un côté plus doux et plus vulnérable d'Avril Lavigne par rapport à son image pop-punk. Coécrit avec l'équipe de production The Matrix, il reste l'un de ses morceaux les plus touchants.",
       "uri_apple_music": "applemusic://track/315025828",
       "uri_youtube_music": "https://music.youtube.com/watch?v=dGR65RWwzg8",
       "uri_tidal": "tidal://track/33713334",
       "uri_deezer": "deezer://track/15587475",
       "fun_fact_nl": "I'm with You toonde een zachtere, kwetsbaardere kant van Avril Lavigne vergeleken met haar punk-pop imago. Het nummer is geschreven in samenwerking met het productieteam van de Matrix en blijft een van haar meest emotioneel resonerende nummers.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USAR10200224",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/315025828",
+        "de": "applemusic://track/315025828",
+        "gb": "applemusic://track/315025828",
+        "fr": "applemusic://track/315025828",
+        "es": "applemusic://track/315025828",
+        "nl": "applemusic://track/315025828",
+        "it": "applemusic://track/315025828"
+      }
     },
     {
       "year": 2002,
@@ -4670,16 +6040,26 @@
         "Platinum (US)"
       ],
       "awards": [],
-      "fun_fact": "What's Luv? was kept from #1 by Foolish by Ashanti \u2014 who also featured on this track. It was part of the 'Murder Inc.' era when Ja Rule and Ashanti dominated charts simultaneously.",
-      "fun_fact_de": "What's Luv? wurde von 'Foolish' von Ashanti von Platz 1 ferngehalten \u2014 die auch auf diesem Track mitwirkte. Es war Teil der 'Murder Inc.'-\u00c4ra, als Ja Rule und Ashanti gleichzeitig die Charts dominierten.",
-      "fun_fact_es": "What's Luv? fue impedida del #1 por 'Foolish' de Ashanti, quien tambi\u00e9n aparece en esta canci\u00f3n. Fue parte de la era 'Murder Inc.' cuando Ja Rule y Ashanti dominaban las listas simult\u00e1neamente.",
-      "fun_fact_fr": "What's Luv? a \u00e9t\u00e9 emp\u00each\u00e9 d'atteindre le num\u00e9ro 1 par 'Foolish' d'Ashanti \u2014 qui figure \u00e9galement sur ce titre. Il faisait partie de l'\u00e8re 'Murder Inc.' quand Ja Rule et Ashanti dominaient les charts simultan\u00e9ment.",
+      "fun_fact": "What's Luv? was kept from #1 by Foolish by Ashanti — who also featured on this track. It was part of the 'Murder Inc.' era when Ja Rule and Ashanti dominated charts simultaneously.",
+      "fun_fact_de": "What's Luv? wurde von 'Foolish' von Ashanti von Platz 1 ferngehalten — die auch auf diesem Track mitwirkte. Es war Teil der 'Murder Inc.'-Ära, als Ja Rule und Ashanti gleichzeitig die Charts dominierten.",
+      "fun_fact_es": "What's Luv? fue impedida del #1 por 'Foolish' de Ashanti, quien también aparece en esta canción. Fue parte de la era 'Murder Inc.' cuando Ja Rule y Ashanti dominaban las listas simultáneamente.",
+      "fun_fact_fr": "What's Luv? a été empêché d'atteindre le numéro 1 par 'Foolish' d'Ashanti — qui figure également sur ce titre. Il faisait partie de l'ère 'Murder Inc.' quand Ja Rule et Ashanti dominaient les charts simultanément.",
       "uri_apple_music": "applemusic://track/268497629",
       "uri_youtube_music": "https://music.youtube.com/watch?v=VpvyG2NrS1Y",
       "uri_tidal": "tidal://track/1297989",
       "uri_deezer": "deezer://track/3905124",
-      "fun_fact_nl": "What's Luv? werd van de eerste plaats gehouden door Foolish van Ashanti \u2014 die ook op deze track te horen was. Het maakte deel uit van het 'Murder Inc.'-tijdperk waarin Ja Rule en Ashanti tegelijkertijd de hitlijsten domineerden.",
-      "awards_nl": []
+      "fun_fact_nl": "What's Luv? werd van de eerste plaats gehouden door Foolish van Ashanti — die ook op deze track te horen was. Het maakte deel uit van het 'Murder Inc.'-tijdperk waarin Ja Rule en Ashanti tegelijkertijd de hitlijsten domineerden.",
+      "awards_nl": [],
+      "isrc": "USAT20110293",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/268497629",
+        "de": "applemusic://track/268497629",
+        "gb": "applemusic://track/268497629",
+        "fr": "applemusic://track/268497629",
+        "es": "applemusic://track/268497629",
+        "nl": "applemusic://track/268497629",
+        "it": "applemusic://track/268497629"
+      }
     },
     {
       "year": 2001,
@@ -4703,15 +6083,25 @@
       ],
       "awards": [],
       "fun_fact": "Let Me Blow Ya Mind won the first-ever Grammy for Best Rap/Sung Collaboration in 2002. The pairing of rapper Eve with No Doubt's Gwen Stefani was considered groundbreaking for genre-crossing collaborations.",
-      "fun_fact_de": "Let Me Blow Ya Mind gewann 2002 den allerersten Grammy f\u00fcr die beste Rap/Gesangs-Kollaboration. Die Kombination aus Rapperin Eve und No-Doubt-S\u00e4ngerin Gwen Stefani galt als bahnbrechend f\u00fcr genre\u00fcbergreifende Zusammenarbeit.",
-      "fun_fact_es": "Gan\u00f3 el primer Grammy a la Mejor Colaboraci\u00f3n Rap/Cantada en 2002. La combinaci\u00f3n de la rapera Eve con Gwen Stefani de No Doubt fue considerada revolucionaria para las colaboraciones entre g\u00e9neros.",
-      "fun_fact_fr": "Let Me Blow Ya Mind a remport\u00e9 le tout premier Grammy de la Meilleure Collaboration Rap/Chant en 2002. L'association de la rappeuse Eve avec Gwen Stefani de No Doubt a \u00e9t\u00e9 consid\u00e9r\u00e9e comme r\u00e9volutionnaire pour les collaborations entre genres.",
+      "fun_fact_de": "Let Me Blow Ya Mind gewann 2002 den allerersten Grammy für die beste Rap/Gesangs-Kollaboration. Die Kombination aus Rapperin Eve und No-Doubt-Sängerin Gwen Stefani galt als bahnbrechend für genreübergreifende Zusammenarbeit.",
+      "fun_fact_es": "Ganó el primer Grammy a la Mejor Colaboración Rap/Cantada en 2002. La combinación de la rapera Eve con Gwen Stefani de No Doubt fue considerada revolucionaria para las colaboraciones entre géneros.",
+      "fun_fact_fr": "Let Me Blow Ya Mind a remporté le tout premier Grammy de la Meilleure Collaboration Rap/Chant en 2002. L'association de la rappeuse Eve avec Gwen Stefani de No Doubt a été considérée comme révolutionnaire pour les collaborations entre genres.",
       "uri_apple_music": "applemusic://track/1440898236",
       "uri_youtube_music": "https://music.youtube.com/watch?v=Wt88GMJmVk0",
       "uri_tidal": "tidal://track/616971",
       "uri_deezer": "deezer://track/886460",
       "fun_fact_nl": "Let Me Blow Ya Mind won in 2002 de allereerste Grammy voor Best Rap/Sung Collaboration. De combinatie van rapper Eve met Gwen Stefani van No Doubt werd beschouwd als baanbrekend voor genre-overschrijdende samenwerkingen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USIR10110155",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1698254410",
+        "de": "applemusic://track/1698254410",
+        "gb": "applemusic://track/1698254410",
+        "fr": "applemusic://track/1698254410",
+        "es": "applemusic://track/1698254410",
+        "nl": "applemusic://track/1698254410",
+        "it": "applemusic://track/1698254410"
+      }
     },
     {
       "year": 2009,
@@ -4734,15 +6124,25 @@
       ],
       "awards": [],
       "fun_fact": "21 Guns is from the rock opera '21st Century Breakdown'. The song borrows chord progressions from 'All the Young Dudes' by Mott the Hoople. It was later adapted into a stage musical on Broadway.",
-      "fun_fact_de": "21 Guns stammt aus der Rock-Oper '21st Century Breakdown'. Die Akkordfolge ist von 'All the Young Dudes' von Mott the Hoople entlehnt. Das Album wurde sp\u00e4ter als Broadway-Musical adaptiert.",
-      "fun_fact_es": "De la \u00f3pera rock '21st Century Breakdown', la canci\u00f3n toma progresiones de acordes de 'All the Young Dudes' de Mott the Hoople. El \u00e1lbum fue adaptado posteriormente como musical de Broadway.",
-      "fun_fact_fr": "21 Guns est tir\u00e9 de l'op\u00e9ra rock '21st Century Breakdown'. La chanson emprunte des progressions d'accords \u00e0 'All the Young Dudes' de Mott the Hoople. L'album a ensuite \u00e9t\u00e9 adapt\u00e9 en com\u00e9die musicale \u00e0 Broadway.",
+      "fun_fact_de": "21 Guns stammt aus der Rock-Oper '21st Century Breakdown'. Die Akkordfolge ist von 'All the Young Dudes' von Mott the Hoople entlehnt. Das Album wurde später als Broadway-Musical adaptiert.",
+      "fun_fact_es": "De la ópera rock '21st Century Breakdown', la canción toma progresiones de acordes de 'All the Young Dudes' de Mott the Hoople. El álbum fue adaptado posteriormente como musical de Broadway.",
+      "fun_fact_fr": "21 Guns est tiré de l'opéra rock '21st Century Breakdown'. La chanson emprunte des progressions d'accords à 'All the Young Dudes' de Mott the Hoople. L'album a ensuite été adapté en comédie musicale à Broadway.",
       "uri_apple_music": "applemusic://track/315611467",
       "uri_youtube_music": "https://music.youtube.com/watch?v=r00ikilDxW4",
       "uri_tidal": "tidal://track/2796001",
       "uri_deezer": "deezer://track/3087241",
       "fun_fact_nl": "21 Guns komt uit de rockopera '21st Century Breakdown'. Het nummer leent akkoordenschema's van 'All the Young Dudes' van Mott the Hoople. Het werd later bewerkt tot een podiummusical op Broadway.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USRE10900679",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1847577917",
+        "de": "applemusic://track/1830226366",
+        "gb": "applemusic://track/1847577917",
+        "fr": "applemusic://track/1847577917",
+        "es": "applemusic://track/1847577917",
+        "nl": "applemusic://track/1847577917",
+        "it": "applemusic://track/1847577917"
+      }
     },
     {
       "year": 2005,
@@ -4766,15 +6166,25 @@
       ],
       "awards": [],
       "fun_fact": "Run It! debuted at #92 and climbed to #1, making Chris Brown the first male artist to have his debut single reach #1 since Diddy's 'Can't Nobody Hold Me Down' in 1997. Brown was just 16 years old.",
-      "fun_fact_de": "Run It! machte Chris Brown mit 16 Jahren zum ersten m\u00e4nnlichen K\u00fcnstler seit Diddy 1997, dessen Deb\u00fctsingle auf Platz 1 der Billboard Hot 100 stieg.",
-      "fun_fact_es": "Run It! hizo de Chris Brown, con 16 a\u00f1os, el primer artista masculino desde Diddy en 1997 cuyo sencillo debut lleg\u00f3 al #1 del Billboard Hot 100.",
-      "fun_fact_fr": "Run It! a d\u00e9but\u00e9 au 92e rang et grimp\u00e9 jusqu'au num\u00e9ro 1, faisant de Chris Brown, \u00e0 16 ans, le premier artiste masculin depuis Diddy en 1997 dont le single de d\u00e9but atteint la premi\u00e8re place du Billboard Hot 100.",
+      "fun_fact_de": "Run It! machte Chris Brown mit 16 Jahren zum ersten männlichen Künstler seit Diddy 1997, dessen Debütsingle auf Platz 1 der Billboard Hot 100 stieg.",
+      "fun_fact_es": "Run It! hizo de Chris Brown, con 16 años, el primer artista masculino desde Diddy en 1997 cuyo sencillo debut llegó al #1 del Billboard Hot 100.",
+      "fun_fact_fr": "Run It! a débuté au 92e rang et grimpé jusqu'au numéro 1, faisant de Chris Brown, à 16 ans, le premier artiste masculin depuis Diddy en 1997 dont le single de début atteint la première place du Billboard Hot 100.",
       "uri_apple_music": "applemusic://track/323098606",
       "uri_youtube_music": "https://music.youtube.com/watch?v=w6QGe-pXgdI",
       "uri_tidal": "tidal://track/1983945",
       "uri_deezer": "deezer://track/71528390",
       "fun_fact_nl": "Run It! debuteerde op nummer 92 en klom naar nummer 1, waardoor Chris Brown de eerste mannelijke artiest werd wiens debuutsingle nummer 1 bereikte sinds 'Can't Nobody Hold Me Down' van Diddy in 1997. Brown was toen pas 16 jaar oud.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USJI10500482",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/323098606",
+        "de": "applemusic://track/323098606",
+        "gb": "applemusic://track/323098606",
+        "fr": "applemusic://track/323098606",
+        "es": "applemusic://track/323098606",
+        "nl": "applemusic://track/323098606",
+        "it": "applemusic://track/323098606"
+      }
     },
     {
       "year": 2009,
@@ -4797,15 +6207,25 @@
       ],
       "awards": [],
       "fun_fact": "This is a rework of The Source featuring Candi Staton's 1986/1991 track. Florence Welch recorded her vocals in a single take. It re-entered the UK charts multiple times and has spent over 200 weeks total on the chart.",
-      "fun_fact_de": "Diese Neubearbeitung des Songs von The Source feat. Candi Staton (1986) wurde von Florence Welch in einem einzigen Take eingesungen. Der Song war insgesamt \u00fcber 200 Wochen in den britischen Charts.",
-      "fun_fact_es": "Una nueva versi\u00f3n del tema de The Source feat. Candi Staton de 1986. Florence Welch grab\u00f3 sus voces en una sola toma. La canci\u00f3n reentr\u00f3 m\u00faltiples veces en las listas del Reino Unido, acumulando m\u00e1s de 200 semanas en total.",
-      "fun_fact_fr": "C'est une reprise du titre de The Source featuring Candi Staton de 1986/1991. Florence Welch a enregistr\u00e9 ses voix en une seule prise. Le morceau est revenu plusieurs fois dans les charts britanniques pour un total de plus de 200 semaines.",
+      "fun_fact_de": "Diese Neubearbeitung des Songs von The Source feat. Candi Staton (1986) wurde von Florence Welch in einem einzigen Take eingesungen. Der Song war insgesamt über 200 Wochen in den britischen Charts.",
+      "fun_fact_es": "Una nueva versión del tema de The Source feat. Candi Staton de 1986. Florence Welch grabó sus voces en una sola toma. La canción reentró múltiples veces en las listas del Reino Unido, acumulando más de 200 semanas en total.",
+      "fun_fact_fr": "C'est une reprise du titre de The Source featuring Candi Staton de 1986/1991. Florence Welch a enregistré ses voix en une seule prise. Le morceau est revenu plusieurs fois dans les charts britanniques pour un total de plus de 200 semaines.",
       "uri_apple_music": "applemusic://track/1440729760",
       "uri_youtube_music": "https://music.youtube.com/watch?v=PQZhN65vq9E",
       "uri_tidal": "tidal://track/2938452",
       "uri_deezer": "deezer://track/7561784",
-      "fun_fact_nl": "Dit is een bewerking van de track van The Source met Candi Staton uit 1986/1991. Florence Welch nam haar vocals in \u00e9\u00e9n take op. Het kwam meerdere keren opnieuw de Britse hitlijsten binnen en heeft in totaal meer dan 200 weken in de lijst gestaan.",
-      "awards_nl": []
+      "fun_fact_nl": "Dit is een bewerking van de track van The Source met Candi Staton uit 1986/1991. Florence Welch nam haar vocals in één take op. Het kwam meerdere keren opnieuw de Britse hitlijsten binnen en heeft in totaal meer dan 200 weken in de lijst gestaan.",
+      "awards_nl": [],
+      "isrc": "GBUM70900237",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1893461588",
+        "de": "applemusic://track/1609152227",
+        "gb": "applemusic://track/1609152227",
+        "fr": "applemusic://track/1609152227",
+        "es": "applemusic://track/1609152227",
+        "nl": "applemusic://track/1609152227",
+        "it": "applemusic://track/1609152227"
+      }
     },
     {
       "year": 2008,
@@ -4813,7 +6233,7 @@
       "artist": "Madonna, Justin Timberlake, Timbaland",
       "alt_artists": [
         "Rihanna",
-        "Beyonc\u00e9",
+        "Beyoncé",
         "Nelly Furtado",
         "Gwen Stefani"
       ],
@@ -4829,15 +6249,25 @@
       ],
       "awards": [],
       "fun_fact": "4 Minutes topped the charts in 21 countries, making it Madonna's 13th #1 in the UK. The song's 'save the world' concept was reflected in a music video featuring a scrolling black bar destroying everything in its path.",
-      "fun_fact_de": "4 Minutes erreichte in 21 L\u00e4ndern Platz 1 und wurde Madonnas 13. Nummer-1-Hit in Gro\u00dfbritannien. Das Musikvideo zeigt einen schwarzen Balken, der alles auf seinem Weg zerst\u00f6rt \u2014 ein Countdown zur Rettung der Welt.",
-      "fun_fact_es": "4 Minutes lleg\u00f3 al #1 en 21 pa\u00edses, convirti\u00e9ndose en el 13\u00b0 #1 de Madonna en el Reino Unido. Su video muestra una barra negra destruyendo todo a su paso \u2014 una cuenta regresiva para salvar el mundo.",
-      "fun_fact_fr": "4 Minutes a atteint la premi\u00e8re place dans 21 pays, devenant le 13e num\u00e9ro 1 de Madonna au Royaume-Uni. Le concept 'sauver le monde' du titre se refl\u00e8te dans un clip montrant une barre noire d\u00e9filante d\u00e9truisant tout sur son passage.",
+      "fun_fact_de": "4 Minutes erreichte in 21 Ländern Platz 1 und wurde Madonnas 13. Nummer-1-Hit in Großbritannien. Das Musikvideo zeigt einen schwarzen Balken, der alles auf seinem Weg zerstört — ein Countdown zur Rettung der Welt.",
+      "fun_fact_es": "4 Minutes llegó al #1 en 21 países, convirtiéndose en el 13° #1 de Madonna en el Reino Unido. Su video muestra una barra negra destruyendo todo a su paso — una cuenta regresiva para salvar el mundo.",
+      "fun_fact_fr": "4 Minutes a atteint la première place dans 21 pays, devenant le 13e numéro 1 de Madonna au Royaume-Uni. Le concept 'sauver le monde' du titre se reflète dans un clip montrant une barre noire défilante détruisant tout sur son passage.",
       "uri_apple_music": "applemusic://track/329064704",
       "uri_youtube_music": "https://music.youtube.com/watch?v=aAQZPBwz2CI",
       "uri_tidal": "tidal://track/3094547",
       "uri_deezer": "deezer://track/3824997331",
       "fun_fact_nl": "4 Minutes stond bovenaan de hitlijsten in 21 landen, waarmee het Madonna's 13e nummer 1-hit in het VK werd. Het 'save the world'-concept van het nummer kwam tot uiting in een videoclip met een scrollende zwarte balk die alles op zijn pad vernietigde.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USWB10903601",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1874757117",
+        "de": "applemusic://track/1874757117",
+        "gb": "applemusic://track/1874757117",
+        "fr": "applemusic://track/1874757117",
+        "es": "applemusic://track/1874757117",
+        "nl": "applemusic://track/1874757117",
+        "it": "applemusic://track/1874757117"
+      }
     },
     {
       "year": 2002,
@@ -4861,15 +6291,25 @@
       ],
       "awards": [],
       "fun_fact": "Written with Timbaland and Scott Storch, the song was inspired by Timberlake's breakup with Britney Spears. The music video features a Britney lookalike, and the song won a Grammy for Best Male Pop Vocal Performance.",
-      "fun_fact_de": "Der Song wurde durch Timberlakes Trennung von Britney Spears inspiriert und mit Timbaland und Scott Storch geschrieben. Das Musikvideo zeigt eine Britney-Doppelg\u00e4ngerin. Er gewann den Grammy f\u00fcr die beste m\u00e4nnliche Pop-Gesangsdarbietung.",
-      "fun_fact_es": "Inspirada en la ruptura de Timberlake con Britney Spears y escrita con Timbaland y Scott Storch, el video muestra a una doble de Britney. Gan\u00f3 el Grammy a la Mejor Interpretaci\u00f3n Vocal Pop Masculina.",
-      "fun_fact_fr": "\u00c9crite avec Timbaland et Scott Storch, la chanson s'inspire de la rupture de Timberlake avec Britney Spears. Le clip met en sc\u00e8ne un sosie de Britney, et le titre a remport\u00e9 un Grammy de la Meilleure Performance Vocale Pop Masculine.",
+      "fun_fact_de": "Der Song wurde durch Timberlakes Trennung von Britney Spears inspiriert und mit Timbaland und Scott Storch geschrieben. Das Musikvideo zeigt eine Britney-Doppelgängerin. Er gewann den Grammy für die beste männliche Pop-Gesangsdarbietung.",
+      "fun_fact_es": "Inspirada en la ruptura de Timberlake con Britney Spears y escrita con Timbaland y Scott Storch, el video muestra a una doble de Britney. Ganó el Grammy a la Mejor Interpretación Vocal Pop Masculina.",
+      "fun_fact_fr": "Écrite avec Timbaland et Scott Storch, la chanson s'inspire de la rupture de Timberlake avec Britney Spears. Le clip met en scène un sosie de Britney, et le titre a remporté un Grammy de la Meilleure Performance Vocale Pop Masculine.",
       "uri_apple_music": "applemusic://track/252606592",
       "uri_youtube_music": "https://music.youtube.com/watch?v=DksSPZTZES0",
       "uri_tidal": "tidal://track/45159",
       "uri_deezer": "deezer://track/969494",
-      "fun_fact_nl": "Het nummer is geschreven samen met Timbaland en Scott Storch en is ge\u00efnspireerd op de breuk van Timberlake met Britney Spears. In de videoclip is een dubbelgangster van Britney te zien, en het nummer won een Grammy voor Best Male Pop Vocal Performance.",
-      "awards_nl": []
+      "fun_fact_nl": "Het nummer is geschreven samen met Timbaland en Scott Storch en is geïnspireerd op de breuk van Timberlake met Britney Spears. In de videoclip is een dubbelgangster van Britney te zien, en het nummer won een Grammy voor Best Male Pop Vocal Performance.",
+      "awards_nl": [],
+      "isrc": "USJI10200366",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1719201833",
+        "de": "applemusic://track/1130010166",
+        "gb": "applemusic://track/313411601",
+        "fr": "applemusic://track/313411601",
+        "es": "applemusic://track/313411601",
+        "nl": "applemusic://track/313411601",
+        "it": "applemusic://track/313411601"
+      }
     },
     {
       "year": 2008,
@@ -4892,16 +6332,26 @@
         "Gold (UK)"
       ],
       "awards": [],
-      "fun_fact": "The lyric 'Are we human or are we dancer?' sparked a global debate \u2014 Brandon Flowers confirmed it was inspired by a Hunter S. Thompson quote about America 'raising a generation of dancers.'",
-      "fun_fact_de": "Die Textzeile 'Are we human or are we dancer?' l\u00f6ste eine weltweite Debatte aus \u2014 Brandon Flowers best\u00e4tigte, dass sie von einem Zitat Hunter S. Thompsons \u00fcber eine 'Generation von T\u00e4nzern' inspiriert war.",
-      "fun_fact_es": "La letra 'Are we human or are we dancer?' provoc\u00f3 un debate global. Brandon Flowers confirm\u00f3 que se inspir\u00f3 en una cita de Hunter S. Thompson sobre criar 'una generaci\u00f3n de bailarines'.",
-      "fun_fact_fr": "La phrase 'Are we human or are we dancer?' a d\u00e9clench\u00e9 un d\u00e9bat mondial \u2014 Brandon Flowers a confirm\u00e9 qu'elle \u00e9tait inspir\u00e9e d'une citation de Hunter S. Thompson sur l'Am\u00e9rique qui \u00e9l\u00e8verait 'une g\u00e9n\u00e9ration de danseurs'.",
+      "fun_fact": "The lyric 'Are we human or are we dancer?' sparked a global debate — Brandon Flowers confirmed it was inspired by a Hunter S. Thompson quote about America 'raising a generation of dancers.'",
+      "fun_fact_de": "Die Textzeile 'Are we human or are we dancer?' löste eine weltweite Debatte aus — Brandon Flowers bestätigte, dass sie von einem Zitat Hunter S. Thompsons über eine 'Generation von Tänzern' inspiriert war.",
+      "fun_fact_es": "La letra 'Are we human or are we dancer?' provocó un debate global. Brandon Flowers confirmó que se inspiró en una cita de Hunter S. Thompson sobre criar 'una generación de bailarines'.",
+      "fun_fact_fr": "La phrase 'Are we human or are we dancer?' a déclenché un débat mondial — Brandon Flowers a confirmé qu'elle était inspirée d'une citation de Hunter S. Thompson sur l'Amérique qui élèverait 'une génération de danseurs'.",
       "uri_apple_music": "applemusic://track/1440864350",
       "uri_youtube_music": "https://music.youtube.com/watch?v=RIZdjT1472Y",
       "uri_tidal": "tidal://track/23273354",
       "uri_deezer": "deezer://track/71955252",
-      "fun_fact_nl": "De tekst 'Are we human or are we dancer?' veroorzaakte een wereldwijd debat \u2014 Brandon Flowers bevestigde dat het was ge\u00efnspireerd op een citaat van Hunter S. Thompson over Amerika dat 'een generatie dansers opvoedt'.",
-      "awards_nl": []
+      "fun_fact_nl": "De tekst 'Are we human or are we dancer?' veroorzaakte een wereldwijd debat — Brandon Flowers bevestigde dat het was geïnspireerd op een citaat van Hunter S. Thompson over Amerika dat 'een generatie dansers opvoedt'.",
+      "awards_nl": [],
+      "isrc": "USUM70837367",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1706933474",
+        "de": "applemusic://track/1622293444",
+        "gb": "applemusic://track/1706933474",
+        "fr": "applemusic://track/1706933474",
+        "es": "applemusic://track/1706933474",
+        "nl": "applemusic://track/1587385929",
+        "it": "applemusic://track/1622293444"
+      }
     },
     {
       "year": 2008,
@@ -4924,15 +6374,25 @@
       ],
       "awards": [],
       "fun_fact": "Whatever You Like debuted at #1 on the Hot 100, making T.I. the fourth artist in history to achieve a first-week debut at the top. The beat was created by Jim Jonsin using an eerie synth melody.",
-      "fun_fact_de": "Whatever You Like deb\u00fctierte direkt auf Platz 1 der Hot 100, was T.I. zum vierten K\u00fcnstler der Geschichte machte, dem ein Deb\u00fct in der ersten Woche an der Spitze gelang.",
-      "fun_fact_es": "Whatever You Like debut\u00f3 en el #1 del Hot 100, convirtiendo a T.I. en el cuarto artista en la historia en lograr un debut directo en la cima. El beat fue creado por Jim Jonsin con una melod\u00eda de sintetizador inquietante.",
-      "fun_fact_fr": "Whatever You Like a d\u00e9but\u00e9 directement au num\u00e9ro 1 du Hot 100, faisant de T.I. le quatri\u00e8me artiste de l'histoire \u00e0 r\u00e9aliser un tel exploit. Le beat a \u00e9t\u00e9 cr\u00e9\u00e9 par Jim Jonsin \u00e0 partir d'une m\u00e9lodie de synth\u00e9tiseur inqui\u00e9tante.",
+      "fun_fact_de": "Whatever You Like debütierte direkt auf Platz 1 der Hot 100, was T.I. zum vierten Künstler der Geschichte machte, dem ein Debüt in der ersten Woche an der Spitze gelang.",
+      "fun_fact_es": "Whatever You Like debutó en el #1 del Hot 100, convirtiendo a T.I. en el cuarto artista en la historia en lograr un debut directo en la cima. El beat fue creado por Jim Jonsin con una melodía de sintetizador inquietante.",
+      "fun_fact_fr": "Whatever You Like a débuté directement au numéro 1 du Hot 100, faisant de T.I. le quatrième artiste de l'histoire à réaliser un tel exploit. Le beat a été créé par Jim Jonsin à partir d'une mélodie de synthétiseur inquiétante.",
       "uri_apple_music": "applemusic://track/1258961897",
       "uri_youtube_music": "https://music.youtube.com/watch?v=nQJACVmankY",
       "uri_tidal": "tidal://track/218974821",
       "uri_deezer": "deezer://track/383742081",
-      "fun_fact_nl": "Whatever You Like debuteerde op nummer 1 in de Hot 100, waarmee T.I. de vierde artiest in de geschiedenis werd die een debuut op de eerste plaats behaalde in de eerste week. De beat werd gecre\u00eberd door Jim Jonsin met behulp van een griezelige synth-melodie.",
-      "awards_nl": []
+      "fun_fact_nl": "Whatever You Like debuteerde op nummer 1 in de Hot 100, waarmee T.I. de vierde artiest in de geschiedenis werd die een debuut op de eerste plaats behaalde in de eerste week. De beat werd gecreëerd door Jim Jonsin met behulp van een griezelige synth-melodie.",
+      "awards_nl": [],
+      "isrc": "USAT20803170",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1260881181",
+        "de": "applemusic://track/1260881181",
+        "gb": "applemusic://track/1260881181",
+        "fr": "applemusic://track/1260881181",
+        "es": "applemusic://track/1260881181",
+        "nl": "applemusic://track/1260881181",
+        "it": "applemusic://track/1260881181"
+      }
     },
     {
       "year": 2004,
@@ -4956,15 +6416,25 @@
       ],
       "awards": [],
       "fun_fact": "Blunt wrote the song about seeing his ex-girlfriend on the London Underground with her new boyfriend. Despite its massive success, Blunt later admitted he was 'annoyed' by how overplayed it became.",
-      "fun_fact_de": "Blunt schrieb den Song, nachdem er seine Ex-Freundin mit ihrem neuen Freund in der Londoner U-Bahn sah. Trotz des riesigen Erfolgs gab er sp\u00e4ter zu, dass er 'genervt' davon war, wie \u00fcberspielt der Song wurde.",
-      "fun_fact_es": "Blunt escribi\u00f3 la canci\u00f3n tras ver a su ex novia con su nuevo novio en el metro de Londres. A pesar de su \u00e9xito masivo, Blunt admiti\u00f3 m\u00e1s tarde estar 'molesto' por lo mucho que sonaba en todas partes.",
-      "fun_fact_fr": "Blunt a \u00e9crit cette chanson apr\u00e8s avoir aper\u00e7u son ex-petite amie dans le m\u00e9tro londonien avec son nouveau copain. Malgr\u00e9 son succ\u00e8s ph\u00e9nom\u00e9nal, Blunt a reconnu plus tard \u00eatre 'agac\u00e9' par la diffusion excessive du titre.",
+      "fun_fact_de": "Blunt schrieb den Song, nachdem er seine Ex-Freundin mit ihrem neuen Freund in der Londoner U-Bahn sah. Trotz des riesigen Erfolgs gab er später zu, dass er 'genervt' davon war, wie überspielt der Song wurde.",
+      "fun_fact_es": "Blunt escribió la canción tras ver a su ex novia con su nuevo novio en el metro de Londres. A pesar de su éxito masivo, Blunt admitió más tarde estar 'molesto' por lo mucho que sonaba en todas partes.",
+      "fun_fact_fr": "Blunt a écrit cette chanson après avoir aperçu son ex-petite amie dans le métro londonien avec son nouveau copain. Malgré son succès phénoménal, Blunt a reconnu plus tard être 'agacé' par la diffusion excessive du titre.",
       "uri_apple_music": "applemusic://track/1734439167",
       "uri_youtube_music": "https://music.youtube.com/watch?v=oofSnsGkops",
       "uri_tidal": "tidal://track/6641096",
       "uri_deezer": "deezer://track/2659940",
-      "fun_fact_nl": "Blunt schreef het nummer over het zien van zijn ex-vriendin in de Londense metro met haar nieuwe vriend. Ondanks het enorme succes gaf Blunt later toe dat hij 'ge\u00efrriteerd' was door hoe vaak het werd gedraaid.",
-      "awards_nl": []
+      "fun_fact_nl": "Blunt schreef het nummer over het zien van zijn ex-vriendin in de Londense metro met haar nieuwe vriend. Ondanks het enorme succes gaf Blunt later toe dat hij 'geïrriteerd' was door hoe vaak het werd gedraaid.",
+      "awards_nl": [],
+      "isrc": "USAT20401588",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1614414521",
+        "de": "applemusic://track/1614414521",
+        "gb": "applemusic://track/1614414521",
+        "fr": "applemusic://track/1614414521",
+        "es": "applemusic://track/1614414521",
+        "nl": "applemusic://track/1614414521",
+        "it": "applemusic://track/1614414521"
+      }
     },
     {
       "year": 2004,
@@ -4988,15 +6458,25 @@
       ],
       "awards": [],
       "fun_fact": "Let Me Love You spent nine consecutive weeks at #1 on the Billboard Hot 100, the longest run at the top in 2004-2005. Produced by Scott Storch, its distinctive piano intro is instantly recognizable.",
-      "fun_fact_de": "Let Me Love You stand neun aufeinanderfolgende Wochen auf Platz 1 der Billboard Hot 100 \u2014 die l\u00e4ngste Spitzenposition 2004-2005. Von Scott Storch produziert, ist das markante Piano-Intro sofort erkennbar.",
-      "fun_fact_es": "Let Me Love You pas\u00f3 nueve semanas consecutivas en el #1 del Billboard Hot 100, la racha m\u00e1s larga de 2004-2005. Producida por Scott Storch, su distintivo intro de piano es instant\u00e1neamente reconocible.",
-      "fun_fact_fr": "Let Me Love You est rest\u00e9 neuf semaines cons\u00e9cutives au sommet du Billboard Hot 100, le plus long r\u00e8gne de 2004-2005. Produit par Scott Storch, son intro de piano distinctive est instantan\u00e9ment reconnaissable.",
+      "fun_fact_de": "Let Me Love You stand neun aufeinanderfolgende Wochen auf Platz 1 der Billboard Hot 100 — die längste Spitzenposition 2004-2005. Von Scott Storch produziert, ist das markante Piano-Intro sofort erkennbar.",
+      "fun_fact_es": "Let Me Love You pasó nueve semanas consecutivas en el #1 del Billboard Hot 100, la racha más larga de 2004-2005. Producida por Scott Storch, su distintivo intro de piano es instantáneamente reconocible.",
+      "fun_fact_fr": "Let Me Love You est resté neuf semaines consécutives au sommet du Billboard Hot 100, le plus long règne de 2004-2005. Produit par Scott Storch, son intro de piano distinctive est instantanément reconnaissable.",
       "uri_apple_music": "applemusic://track/253341227",
       "uri_youtube_music": "https://music.youtube.com/watch?v=H64QG4UsrGI",
       "uri_tidal": "tidal://track/57461",
       "uri_deezer": "deezer://track/607684",
       "fun_fact_nl": "Let Me Love You stond negen opeenvolgende weken op nummer 1 in de Billboard Hot 100, de langste periode aan de top in 2004-2005. Geproduceerd door Scott Storch, is de kenmerkende pianointro direct herkenbaar.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USJAY0400348",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1743004431",
+        "de": "applemusic://track/1743004431",
+        "gb": "applemusic://track/1743004431",
+        "fr": "applemusic://track/1743004431",
+        "es": "applemusic://track/1743004431",
+        "nl": "applemusic://track/1743004431",
+        "it": "applemusic://track/1743004431"
+      }
     }
   ]
 }

--- a/custom_components/beatify/playlists/80er-hits.json
+++ b/custom_components/beatify/playlists/80er-hits.json
@@ -31,7 +31,17 @@
       "uri_tidal": "tidal://track/22371988",
       "uri_deezer": "deezer://track/2312569",
       "fun_fact_nl": "Marianne Rosenbergs Schlager-hit uit 1975 beleefde een grote revival in de jaren 80 en is een Duits klassiek nummer gebleven. Haar krachtige stem en emotionele zang maakten haar een van Duitslands meest geliefde zangeressen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEC737500013",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1626938161",
+        "de": "applemusic://track/1308496247",
+        "gb": "applemusic://track/1308496247",
+        "fr": "applemusic://track/1308496247",
+        "es": "applemusic://track/1308496247",
+        "nl": "applemusic://track/1308496247",
+        "it": "applemusic://track/1308496247"
+      }
     },
     {
       "year": 1978,
@@ -78,7 +88,17 @@
       "uri_tidal": "tidal://track/11210162",
       "uri_deezer": "deezer://track/1006803652",
       "fun_fact_nl": "Oorspronkelijk uitgebracht in 1978, bereikte 'Das Modell' de nummer 1 in het VK in 1982 toen het opnieuw werd uitgebracht als B-kant die populairder werd dan de A-kant 'Computer Love'.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USCA20903078",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/726157363",
+        "de": "applemusic://track/726157363",
+        "gb": "applemusic://track/726157363",
+        "fr": "applemusic://track/726157363",
+        "es": "applemusic://track/726157363",
+        "nl": "applemusic://track/726157363",
+        "it": "applemusic://track/726157363"
+      }
     },
     {
       "year": 1979,
@@ -108,7 +128,17 @@
       "uri_tidal": "tidal://track/21844148",
       "uri_deezer": "deezer://track/67503800",
       "fun_fact_nl": "Freddie Mercury schreef dit rockabilly-eerbetoon aan Elvis Presley in slechts 10 minuten tijdens het baden. Hij speelde bewust ritmegitaar op het nummer, ondanks dat hij zichzelf geen gitarist vond.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBUM71029612",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1824266111",
+        "de": "applemusic://track/1824266111",
+        "gb": "applemusic://track/1824266111",
+        "fr": "applemusic://track/1824266111",
+        "es": "applemusic://track/1824266111",
+        "nl": "applemusic://track/1824266111",
+        "it": "applemusic://track/1824266111"
+      }
     },
     {
       "year": 1979,
@@ -136,7 +166,17 @@
       "uri_tidal": "tidal://track/529738",
       "uri_deezer": "deezer://track/1143625",
       "fun_fact_nl": "The Cures Robert Smith schreef dit over een echte breuk. Aanvankelijk uitgebracht als hun debuutsingle was het een flop. De opnieuw opgenomen versie in 1980 bracht hen eindelijk aandacht en definieerde hun vroege geluid.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBALB7800001",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1828951986",
+        "de": "applemusic://track/1760818997",
+        "gb": "applemusic://track/1760818997",
+        "fr": "applemusic://track/1760818997",
+        "es": "applemusic://track/1760818997",
+        "nl": "applemusic://track/1760818997",
+        "it": "applemusic://track/1760818997"
+      }
     },
     {
       "year": 1980,
@@ -164,7 +204,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=F-mjl63e0ms",
       "uri_deezer": "deezer://track/4677575",
       "fun_fact_nl": "Geschreven en geproduceerd door Nile Rodgers en Bernard Edwards van Chic. Diana Ross besefte de dubbele betekenis van het nummer over het uitkomen als homoseksueel pas na de release, maar omarmde het als LGBTQ+-hymne.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMO18000073",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1581879147",
+        "de": "applemusic://track/1581879147",
+        "gb": "applemusic://track/1581879147",
+        "fr": "applemusic://track/1581879147",
+        "es": "applemusic://track/1581879147",
+        "nl": "applemusic://track/1581879147",
+        "it": "applemusic://track/1581879147"
+      }
     },
     {
       "year": 1980,
@@ -194,7 +244,17 @@
       "uri_tidal": "tidal://track/21844141",
       "uri_deezer": "deezer://track/12206946",
       "fun_fact_nl": "Michael Jackson belde persoonlijk Queen en drong er bij hen op aan dit als single uit te brengen. De iconische baslijn was geïnspireerd op Chics 'Good Times'. Het werd Queens best verkochte single ooit in de Verenigde Staten.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBUM71029605",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1440650719",
+        "de": "applemusic://track/1441571446",
+        "gb": "applemusic://track/1441571446",
+        "fr": "applemusic://track/1441571446",
+        "es": "applemusic://track/1441571446",
+        "nl": "applemusic://track/1441571446",
+        "it": "applemusic://track/1441571446"
+      }
     },
     {
       "year": 1980,
@@ -246,7 +306,17 @@
       "uri_tidal": "tidal://track/20907391",
       "uri_deezer": "deezer://track/68513610",
       "fun_fact_nl": "Dit was Depeche Modes eerste hit en hun laatste echt vrolijke poplied voordat ze overgingen op donkerdere elektronische muziek. Vince Clarke schreef het in 20 minuten. Hij verliet de band vlak na dit album.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAJH9800101",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/665414540",
+        "de": "applemusic://track/665414540",
+        "gb": "applemusic://track/665414540",
+        "fr": "applemusic://track/665414540",
+        "es": "applemusic://track/665414540",
+        "nl": "applemusic://track/665414540",
+        "it": "applemusic://track/665414540"
+      }
     },
     {
       "year": 1981,
@@ -296,7 +366,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=v8oqbWrP1QY",
       "uri_deezer": "deezer://track/3821992",
       "fun_fact_nl": "Met Bill Withers op zang. Het nummer won een Grammy voor Best R&B Song. Will Smith sampelde het later voor zijn hit uit 1998 over vaderschap.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USEE19901162",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/310527535",
+        "de": "applemusic://track/310527535",
+        "gb": "applemusic://track/310527535",
+        "fr": "applemusic://track/310527535",
+        "es": "applemusic://track/310527535",
+        "nl": "applemusic://track/310527535",
+        "it": "applemusic://track/310527535"
+      }
     },
     {
       "year": 1981,
@@ -321,7 +401,17 @@
       "uri_tidal": "tidal://track/375266009",
       "uri_deezer": "deezer://track/2891799832",
       "fun_fact_nl": "Geschreven door Kims vader Marty Wilde en broer Ricky, werd het nummer opgenomen toen Kim pas 20 was en ze nog nooit in Amerika was geweest toen ze het zong.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAYE8100054",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1764365427",
+        "de": "applemusic://track/1764365427",
+        "gb": "applemusic://track/1764365427",
+        "fr": "applemusic://track/1764365427",
+        "es": "applemusic://track/1764365427",
+        "nl": "applemusic://track/1764365427",
+        "it": "applemusic://track/1764365427"
+      }
     },
     {
       "year": 1981,
@@ -351,7 +441,17 @@
       "uri_tidal": "tidal://track/19361867",
       "uri_deezer": "deezer://track/1030221",
       "fun_fact_nl": "Dit nummer was het enige nummer dat ooit tegelijkertijd nummer 1 stond in Australië, Nieuw-Zeeland, het VK en de VS. In 2010 werd de band aangeklaagd wegens het per ongeluk kopiëren van een kinderliedje over kookaburra's.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "NLB638140003",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/282960968",
+        "de": "applemusic://track/323783609",
+        "gb": "applemusic://track/282960968",
+        "fr": "applemusic://track/323783609",
+        "es": "applemusic://track/323783609",
+        "nl": "applemusic://track/323783609",
+        "it": "applemusic://track/323783609"
+      }
     },
     {
       "year": 1981,
@@ -381,7 +481,17 @@
       "uri_tidal": "tidal://track/198430762",
       "uri_deezer": "deezer://track/1483484872",
       "fun_fact_nl": "Ondanks de suggestieve tekst werd dit nummer wereldwijd gespeeld bij aerobicslessen. Het stond 10 weken op nummer 1, waarmee het de langstzittende nummer 1 van de jaren 80 in de VS werd. Olivia filmde de video in een sportschool.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "US86A2100406",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1880871417",
+        "de": "applemusic://track/1880871417",
+        "gb": "applemusic://track/1650521533",
+        "fr": "applemusic://track/1880871417",
+        "es": "applemusic://track/1880871417",
+        "nl": "applemusic://track/1880871417",
+        "it": "applemusic://track/1880871417"
+      }
     },
     {
       "year": 1981,
@@ -406,7 +516,17 @@
       "uri_tidal": "tidal://track/1547144",
       "uri_deezer": "deezer://track/3156225",
       "fun_fact_nl": "Dit was OMDs grootste internationale hit, die meerdere weken nummer 1 stond in Duitsland. Het was de bestverkochte single in Duitsland in 1982.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAAA8100251",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1648522168",
+        "de": "applemusic://track/1648522168",
+        "gb": "applemusic://track/1648522168",
+        "fr": "applemusic://track/1648522168",
+        "es": "applemusic://track/1648522168",
+        "nl": "applemusic://track/1648522168",
+        "it": "applemusic://track/1648522168"
+      }
     },
     {
       "year": 1981,
@@ -436,7 +556,17 @@
       "uri_tidal": "tidal://track/155438",
       "uri_deezer": "deezer://track/3092940",
       "fun_fact_nl": "Phil Oakey schreef dit nummer in 10 minuten als opvulling voor hun album, zonder te verwachten dat het een single zou worden. Het werd de bestverkochte single van 1981 in het VK en lanceerde de New Romantic-beweging in Amerika.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAAA8100001",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1443094123",
+        "de": "applemusic://track/723689448",
+        "gb": "applemusic://track/723689448",
+        "fr": "applemusic://track/723689448",
+        "es": "applemusic://track/723689448",
+        "nl": "applemusic://track/723689448",
+        "it": "applemusic://track/723689448"
+      }
     },
     {
       "year": 1981,
@@ -465,7 +595,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=aENX1Sf3fgQ",
       "uri_deezer": "deezer://track/2525869",
       "fun_fact_nl": "Sting schreef dit jaren voordat The Police werd gevormd. Het pianostuk werd in één take opgenomen door producer Hugh Padgham. Het werd hun grootste VK-hit.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAAM8100003",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1794229794",
+        "de": "applemusic://track/1794229794",
+        "gb": "applemusic://track/1794229794",
+        "fr": "applemusic://track/1794229794",
+        "es": "applemusic://track/1794229794",
+        "nl": "applemusic://track/1794229794",
+        "it": "applemusic://track/1794229794"
+      }
     },
     {
       "year": 1982,
@@ -493,7 +633,17 @@
       "uri_tidal": "tidal://track/519816",
       "uri_deezer": "deezer://track/1005379",
       "fun_fact_nl": "Al Bano en Romina Power waren een getrouwd stel wiens romantische duetten de Italiaanse pop van de jaren 80 definieerden. Dit nummer won het Sanremo Music Festival in 1982 en werd een zomerhit door heel Europa.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USBI10000114",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/298583321",
+        "de": "applemusic://track/298583321",
+        "gb": "applemusic://track/298583321",
+        "fr": "applemusic://track/298583321",
+        "es": "applemusic://track/298583321",
+        "nl": "applemusic://track/298583321",
+        "it": "applemusic://track/298583321"
+      }
     },
     {
       "year": 1982,
@@ -516,7 +666,17 @@
       "uri_tidal": "tidal://track/616262",
       "uri_deezer": "deezer://track/1158199",
       "fun_fact_nl": "Geïnspireerd door de Griekse mythologie over Charon, de veerman van de doden, werd het nummer een wereldwijde hit en vestigde Chris de Burgh als internationaal artiest.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAAM8201059",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1435501318",
+        "de": "applemusic://track/1435501318",
+        "gb": "applemusic://track/1435501318",
+        "fr": "applemusic://track/1435501318",
+        "es": "applemusic://track/1435501318",
+        "nl": "applemusic://track/1435501318",
+        "it": "applemusic://track/1435501318"
+      }
     },
     {
       "year": 1982,
@@ -546,7 +706,17 @@
       "uri_tidal": "tidal://track/1477152",
       "uri_deezer": "deezer://track/3152785",
       "fun_fact_nl": "Boy George schreef dit over zijn ingewikkelde relatie met Culture Clubs drummer Jon Moss. Het reggae-geïnspireerde geluid was ongewoon voor die tijd en hielp de 'New Romantic'-beweging te vestigen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAAA8200048",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/724474136",
+        "de": "applemusic://track/724474136",
+        "gb": "applemusic://track/724474136",
+        "fr": "applemusic://track/724474136",
+        "es": "applemusic://track/724474136",
+        "nl": "applemusic://track/724474136",
+        "it": "applemusic://track/724474136"
+      }
     },
     {
       "year": 1982,
@@ -569,7 +739,17 @@
       "uri_tidal": "tidal://track/1291974",
       "uri_deezer": "deezer://track/15645537",
       "fun_fact_nl": "Aanvankelijk een flop, werd het nummer opnieuw uitgebracht nadat 'Sweet Dreams' een hit werd en klom het naar nummer 6 in het VK. Annie Lennox' androgyne imago in de video was baanbrekend.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBARL0300584",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/207056862",
+        "de": "applemusic://track/207056862",
+        "gb": "applemusic://track/207056862",
+        "fr": "applemusic://track/207056862",
+        "es": "applemusic://track/207056862",
+        "nl": "applemusic://track/207056862",
+        "it": "applemusic://track/207056862"
+      }
     },
     {
       "year": 1982,
@@ -599,7 +779,17 @@
       "uri_tidal": "tidal://track/59110540",
       "uri_deezer": "deezer://track/142334565",
       "fun_fact_nl": "Falco schreef dit nummer in slechts 10 minuten terwijl hij in een Weens koffiehuis zat. Het was het eerste Duitstalige nummer dat de top 5 bereikte in de VS, waarmee het de weg effende voor Nena's '99 Luftballons'.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "ATB158200018",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/256330039",
+        "de": "applemusic://track/256330039",
+        "gb": "applemusic://track/256330039",
+        "fr": "applemusic://track/256330039",
+        "es": "applemusic://track/256330039",
+        "nl": "applemusic://track/256330039",
+        "it": "applemusic://track/256330039"
+      }
     },
     {
       "year": 1982,
@@ -624,7 +814,17 @@
       "uri_tidal": "tidal://track/19374401",
       "uri_deezer": "deezer://track/65461711",
       "fun_fact_nl": "Hubert Kah maakte deel uit van de 'Neue Deutsche Welle'-beweging. Dit romantische synthpopnummer liet de zachtere kant van de Duitse new wave zien, in contrast met de agressievere klanken van andere NDW-bands.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEF068205320",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1702587047",
+        "de": "applemusic://track/1645914140",
+        "gb": "applemusic://track/1645914140",
+        "fr": "applemusic://track/1645914140",
+        "es": "applemusic://track/1645914140",
+        "nl": "applemusic://track/1645914140",
+        "it": "applemusic://track/1645914140"
+      }
     },
     {
       "year": 1982,
@@ -649,7 +849,17 @@
       "uri_tidal": "tidal://track/396593917",
       "uri_deezer": "deezer://track/3069973981",
       "fun_fact_nl": "Geschreven door Suggs over zijn jeugdthuis in Camden Town, bereikte het nummer nummer 7 in de VS en werd het Madness' internationaal meest erkende nummer.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USGF18200301",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1442963585",
+        "de": null,
+        "gb": null,
+        "fr": null,
+        "es": null,
+        "nl": null,
+        "it": null
+      }
     },
     {
       "year": 1982,
@@ -674,7 +884,17 @@
       "uri_tidal": "tidal://track/4186366",
       "uri_deezer": "deezer://track/12180202",
       "fun_fact_nl": "Het nummer werd geschreven als protest tegen uitsmijters die mensen niet lieten pogodansen in clubs. De middeleeuwse video heeft geen verband met de werkelijke betekenis van het nummer.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USUM71918013",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1479631804",
+        "de": null,
+        "gb": null,
+        "fr": null,
+        "es": null,
+        "nl": null,
+        "it": null
+      }
     },
     {
       "year": 1982,
@@ -714,7 +934,17 @@
       "awards_nl": [
         "Grammy Award voor Opname van het Jaar (1984)",
         "Grammy Award voor Beste Mannelijke Rock Zangprestatie (1984)"
-      ]
+      ],
+      "isrc": "USSM18200197",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/310505615",
+        "de": "applemusic://track/310505615",
+        "gb": "applemusic://track/310505615",
+        "fr": "applemusic://track/310505615",
+        "es": "applemusic://track/310505615",
+        "nl": "applemusic://track/310505615",
+        "it": "applemusic://track/310505615"
+      }
     },
     {
       "year": 1982,
@@ -751,7 +981,17 @@
       "fun_fact_nl": "Michael Jackson schreef dit nummer onderweg naar huis, zo verdiept dat hij niet merkte dat zijn auto vlam had gevat. De beroemde baslijn vergde 91 takes om te perfectioneren. Jackson debuteerde de moonwalk tijdens een tv-optreden van dit nummer.",
       "awards_nl": [
         "Grammy Award voor Beste Mannelijke R&B Zangprestatie (1984)"
-      ]
+      ],
+      "isrc": "USSM19902991",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1641781004",
+        "de": "applemusic://track/1641781004",
+        "gb": "applemusic://track/1641781004",
+        "fr": "applemusic://track/1308504774",
+        "es": "applemusic://track/1641781004",
+        "nl": "applemusic://track/1641781004",
+        "it": "applemusic://track/1641781004"
+      }
     },
     {
       "year": 1982,
@@ -781,7 +1021,17 @@
       "uri_tidal": "tidal://track/101149201",
       "uri_deezer": "deezer://track/605723362",
       "fun_fact_nl": "Musical Youth veranderde de tekst van 'Pass the Kutchie' (slang voor marihuanapijp) naar 'Dutchie' (een kookpot) om het geschikt te maken voor de radio. De bandleden waren tussen 11 en 16 jaar oud.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBBBY0300024",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1632073908",
+        "de": "applemusic://track/1632073908",
+        "gb": "applemusic://track/1632073908",
+        "fr": "applemusic://track/1632073908",
+        "es": "applemusic://track/1632073908",
+        "nl": "applemusic://track/1632073908",
+        "it": "applemusic://track/1632073908"
+      }
     },
     {
       "year": 1982,
@@ -810,7 +1060,17 @@
       "uri_tidal": "tidal://track/170985465",
       "uri_deezer": "deezer://track/1222024892",
       "fun_fact_nl": "Dit Duitse spacerockNummer was geïnspireerd op David Bowies 'Space Oddity'. Peter Schilling schreef een compleet andere Engelse versie die ook in de hitparade stond, waardoor hij een van de weinige Duitse artiesten was met hits in beide talen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEA622100158",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1737204455",
+        "de": "applemusic://track/1747790788",
+        "gb": "applemusic://track/1747790788",
+        "fr": "applemusic://track/1747790788",
+        "es": "applemusic://track/1747790788",
+        "nl": "applemusic://track/1747790788",
+        "it": "applemusic://track/1747790788"
+      }
     },
     {
       "year": 1982,
@@ -839,7 +1099,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=C9IwBJYTwQ0",
       "uri_deezer": "deezer://track/134036220",
       "fun_fact_nl": "Een cover van The Supremes' hit uit 1966. Phil Collins nam het op als eerbetoon aan Motown. Het werd zijn eerste nummer 1 als soloartiest in het VK en hielp zijn solocarrière te lanceren.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USRH11600431",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1084058324",
+        "de": "applemusic://track/1084058324",
+        "gb": "applemusic://track/1084058324",
+        "fr": "applemusic://track/1084058324",
+        "es": "applemusic://track/1084058324",
+        "nl": "applemusic://track/1084058324",
+        "it": "applemusic://track/1084058324"
+      }
     },
     {
       "year": 1982,
@@ -868,7 +1138,17 @@
       "uri_tidal": "tidal://track/696825",
       "uri_deezer": "deezer://track/690101",
       "fun_fact_nl": "Geschreven over de nucleaire apocalyps en feesten alsof er geen morgen is. Het nummer keerde terug in de hitparade in 1999 en opnieuw na Princes dood in 2016.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USRH11902851",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1544173942",
+        "de": "applemusic://track/1479564718",
+        "gb": "applemusic://track/1479564718",
+        "fr": "applemusic://track/1479564718",
+        "es": "applemusic://track/1479564718",
+        "nl": "applemusic://track/1479564718",
+        "it": "applemusic://track/1479564718"
+      }
     },
     {
       "year": 1982,
@@ -891,7 +1171,17 @@
       "uri_tidal": "tidal://track/161868",
       "uri_deezer": "deezer://track/3088609",
       "fun_fact_nl": "Het nummer kreeg hernieuwde populariteit nadat Bill Murray het zong in Sofia Coppola's 'Lost in Translation' (2003), waarmee het een nieuwe generatie ermee kennis maakte.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAAA9900092",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1704751586",
+        "de": "applemusic://track/1704751586",
+        "gb": "applemusic://track/1704751586",
+        "fr": "applemusic://track/1704751586",
+        "es": "applemusic://track/1704751586",
+        "nl": "applemusic://track/1704751586",
+        "it": "applemusic://track/1704751586"
+      }
     },
     {
       "year": 1982,
@@ -921,7 +1211,17 @@
       "uri_tidal": "tidal://track/66353435",
       "uri_deezer": "deezer://track/404237102",
       "fun_fact_nl": "Steve Miller Bands grootste hit van de jaren 80 was geïnspireerd op magie en begeerte. De karakteristieke gitaarhook en speelse tekst maakten het een onmiddellijke popklassieker. Het stond twee weken op nummer 1.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USCA28500258",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1706597597",
+        "de": "applemusic://track/1706597597",
+        "gb": "applemusic://track/1706597597",
+        "fr": "applemusic://track/1706597597",
+        "es": "applemusic://track/1706597597",
+        "nl": "applemusic://track/1706597597",
+        "it": "applemusic://track/1706597597"
+      }
     },
     {
       "year": 1982,
@@ -958,7 +1258,17 @@
       "fun_fact_nl": "Sylvester Stallone belde persoonlijk Survivor om dit nummer te schrijven voor Rocky III nadat Queen weigerde hem 'Another One Bites the Dust' te laten gebruiken. De band schreef het in slechts drie dagen.",
       "awards_nl": [
         "Grammy Award voor Beste Rockprestatie door Duo of Groep (1983)"
-      ]
+      ],
+      "isrc": "USVR19300001",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1635636757",
+        "de": "applemusic://track/1635636757",
+        "gb": "applemusic://track/456794433",
+        "fr": "applemusic://track/456794433",
+        "es": "applemusic://track/456794433",
+        "nl": "applemusic://track/456794433",
+        "it": "applemusic://track/456794433"
+      }
     },
     {
       "year": 1982,
@@ -988,7 +1298,17 @@
       "uri_tidal": "tidal://track/81682783",
       "uri_deezer": "deezer://track/433283412",
       "fun_fact_nl": "Taco's synthpopcover van dit Irving Berlin-lied uit 1929 werd een onverwachte hit. De robotachtige dansbewegingen in de video beïnvloedden de opkomende breakdancecultuur van de jaren 80.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USA561018426",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/383470968",
+        "de": "applemusic://track/383470968",
+        "gb": "applemusic://track/383470968",
+        "fr": "applemusic://track/383470968",
+        "es": "applemusic://track/383470968",
+        "nl": "applemusic://track/383470968",
+        "it": "applemusic://track/383470968"
+      }
     },
     {
       "year": 1982,
@@ -1011,7 +1331,17 @@
       "uri_tidal": "tidal://track/2529786",
       "uri_deezer": "deezer://track/1090633",
       "fun_fact_nl": "Gary Jules' sobere cover werd de VK-kerstnummer 1 in 2003 na een vermelding in 'Donnie Darko', maar de originele synthgedreven versie vangt de angstige geest van het begin van de jaren 80.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBF088200040",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1440759670",
+        "de": "applemusic://track/1440759670",
+        "gb": "applemusic://track/1443242473",
+        "fr": "applemusic://track/1440759670",
+        "es": "applemusic://track/1440759670",
+        "nl": "applemusic://track/1440759670",
+        "it": "applemusic://track/1440759670"
+      }
     },
     {
       "year": 1982,
@@ -1041,7 +1371,17 @@
       "uri_tidal": "tidal://track/3392942",
       "uri_deezer": "deezer://track/555755",
       "fun_fact_nl": "Oorspronkelijk aangeboden aan Diana Ross, Cher en Donna Summer, die allemaal weigerden. De versie van The Weather Girls werd een LGBT-hymne en is gecoverd door talloze artiesten, waaronder Geri Halliwell.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM19913325",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/347282458",
+        "de": "applemusic://track/1076305745",
+        "gb": "applemusic://track/453302693",
+        "fr": "applemusic://track/273098536",
+        "es": "applemusic://track/273098536",
+        "nl": "applemusic://track/273098536",
+        "it": "applemusic://track/273098536"
+      }
     },
     {
       "year": 1982,
@@ -1071,7 +1411,17 @@
       "uri_tidal": "tidal://track/539204",
       "uri_deezer": "deezer://track/1079668",
       "fun_fact_nl": "David Paich schreef dit nummer over een man die nooit in Afrika is geweest maar het continent romantiseert. De karakteristieke keyboardintro was geïnspireerd op een documentaire over Afrikaans wild. Het nummer heeft meerdere virale revivals beleefd, decennia na de release.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM19801941",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1626383947",
+        "de": "applemusic://track/1626383947",
+        "gb": "applemusic://track/1626383947",
+        "fr": "applemusic://track/1626383947",
+        "es": "applemusic://track/1626383947",
+        "nl": "applemusic://track/1626383947",
+        "it": "applemusic://track/1626383947"
+      }
     },
     {
       "year": 1982,
@@ -1107,7 +1457,17 @@
       "fun_fact_nl": "Het nummer werd geschreven over actrice Rosanna Arquette, die een relatie had met Toto-toetsenist Steve Porcaro. Het karakteristieke drumpatroon, het 'Rosanna Shuffle' genaamd, wordt nu wereldwijd onderwezen op muziekscholen.",
       "awards_nl": [
         "Grammy Award voor Opname van het Jaar (1983)"
-      ]
+      ],
+      "isrc": "USSM18200245",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/318675271",
+        "de": "applemusic://track/318675271",
+        "gb": "applemusic://track/318675271",
+        "fr": "applemusic://track/318675271",
+        "es": "applemusic://track/318675271",
+        "nl": "applemusic://track/318675271",
+        "it": "applemusic://track/318675271"
+      }
     },
     {
       "year": 1983,
@@ -1132,7 +1492,17 @@
       "uri_tidal": "tidal://track/77662157",
       "uri_deezer": "deezer://track/353398321",
       "fun_fact_nl": "De titel was geïnspireerd op de Franse horrorfilm 'Les Yeux sans Visage' uit 1960. De Franse tekst in het refrein werd gezongen door achtergrondzangeres Perri Lister, destijds Idols vriendin.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USCH38400023",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1768337318",
+        "de": "applemusic://track/1768337318",
+        "gb": "applemusic://track/1768337318",
+        "fr": "applemusic://track/1768337318",
+        "es": "applemusic://track/1768337318",
+        "nl": "applemusic://track/1768337318",
+        "it": "applemusic://track/1768337318"
+      }
     },
     {
       "year": 1983,
@@ -1162,7 +1532,17 @@
       "uri_tidal": "tidal://track/1268496",
       "uri_deezer": "deezer://track/1025659",
       "fun_fact_nl": "Billy Joel schreef dit nummer over zijn relatie met supermodel Elle Macpherson, hoewel hij kort daarna trouwde met Christie Brinkley, die in de video te zien is. De doo-wopstijl was een eerbetoon aan Frankie Valli en The Four Seasons.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM18300270",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1626537261",
+        "de": "applemusic://track/1626537261",
+        "gb": "applemusic://track/273854283",
+        "fr": "applemusic://track/1626537261",
+        "es": "applemusic://track/1626537261",
+        "nl": "applemusic://track/1626537261",
+        "it": "applemusic://track/1626537261"
+      }
     },
     {
       "year": 1983,
@@ -1192,7 +1572,17 @@
       "uri_tidal": "tidal://track/304849",
       "uri_deezer": "deezer://track/532349",
       "fun_fact_nl": "Jim Steinman schreef dit oorspronkelijk voor een vampiermusical, genaamd 'Vampires in Love'. Bonnie Tylers karakteristieke hese stem was het gevolg van een nodulusoperatie die misging.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBBBN8302012",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1504111288",
+        "de": "applemusic://track/1504111288",
+        "gb": "applemusic://track/1504111288",
+        "fr": "applemusic://track/1504111288",
+        "es": "applemusic://track/1504111288",
+        "nl": "applemusic://track/1504111288",
+        "it": "applemusic://track/1504111288"
+      }
     },
     {
       "year": 1983,
@@ -1222,7 +1612,17 @@
       "uri_tidal": "tidal://track/2795827",
       "uri_deezer": "deezer://track/776220",
       "fun_fact_nl": "Dit nummer werd opgenomen met de band Rufus tijdens een impromptu sessie. Chaka Khan improviseerde het grootste deel van haar zang. Het werd een nummer 1 R&B-hit en is gesampeld door talloze artiesten, waaronder LL Cool J.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USWB19600662",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1807720130",
+        "de": "applemusic://track/1395906604",
+        "gb": "applemusic://track/1395906604",
+        "fr": "applemusic://track/1395906604",
+        "es": "applemusic://track/1395906604",
+        "nl": "applemusic://track/1395906604",
+        "it": "applemusic://track/1395906604"
+      }
     },
     {
       "year": 1983,
@@ -1252,7 +1652,17 @@
       "uri_tidal": "tidal://track/159910",
       "uri_deezer": "deezer://track/3152791",
       "fun_fact_nl": "Boy George schreef dit over zijn turbulente relatie met Culture Club-drummer Jon Moss. Het nummer stond drie weken op nummer 1 in de VS en zes weken op nummer 1 in het VK, waarmee het de bestverkochte single van 1983 in het VK werd.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAAA8300010",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1625744249",
+        "de": "applemusic://track/688894910",
+        "gb": "applemusic://track/1713121797",
+        "fr": "applemusic://track/688894910",
+        "es": "applemusic://track/688894910",
+        "nl": "applemusic://track/688894910",
+        "it": "applemusic://track/688894910"
+      }
     },
     {
       "year": 1983,
@@ -1282,7 +1692,17 @@
       "uri_tidal": "tidal://track/27162164",
       "uri_deezer": "deezer://track/72194073",
       "fun_fact_nl": "Cyndi Lauper schreef dit nummer achterin een auto, geïnspireerd door een zin die ze zag op een tv-gids voor een sciencefictionfilm uit 1979. Miles Davis nam later een jazzversie op en noemde het een van zijn favoriete nummers.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM18300650",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1680251140",
+        "de": "applemusic://track/187488704",
+        "gb": "applemusic://track/187488704",
+        "fr": "applemusic://track/187488704",
+        "es": "applemusic://track/187488704",
+        "nl": "applemusic://track/187488704",
+        "it": "applemusic://track/187488704"
+      }
     },
     {
       "year": 1983,
@@ -1305,7 +1725,17 @@
       "uri_tidal": "tidal://track/66932056",
       "uri_deezer": "deezer://track/68513660",
       "fun_fact_nl": "De anti-corporatieve tekst over 'grijpende handen' werd ironisch genoeg geschreven terwijl de band bij een groot platenlabel zat. Het werd een live-favoriet met publieksmee-zingen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAJH0602608",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1174248189",
+        "de": "applemusic://track/1174248189",
+        "gb": "applemusic://track/1174248189",
+        "fr": "applemusic://track/1174248189",
+        "es": "applemusic://track/1174248189",
+        "nl": "applemusic://track/1174248189",
+        "it": "applemusic://track/1174248189"
+      }
     },
     {
       "year": 1983,
@@ -1335,7 +1765,17 @@
       "uri_tidal": "tidal://track/26965",
       "uri_deezer": "deezer://track/561836",
       "fun_fact_nl": "Annie Lennox en Dave Stewart namen dit op in een 8-track thuisstudio boven een lijstenwinkel. Het spookachtige synthriff werd in één take aangemaakt op een sequencer. Het werd het eerste Eurythmics-nummer dat in de VS in de hitparade stond.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBARL0300589",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1736213611",
+        "de": "applemusic://track/1736213611",
+        "gb": "applemusic://track/1736213611",
+        "fr": "applemusic://track/1736213611",
+        "es": "applemusic://track/1736213611",
+        "nl": "applemusic://track/1736213611",
+        "it": "applemusic://track/1736213611"
+      }
     },
     {
       "year": 1983,
@@ -1364,7 +1804,17 @@
       "uri_tidal": "tidal://track/26951",
       "uri_deezer": "deezer://track/561793",
       "fun_fact_nl": "Annie Lennox en Dave Stewart schreven dit in een hotelkamer met uitzicht op de Theems tijdens een regenbui. De melancholische sfeer van het nummer weerspiegelde hun gecompliceerde persoonlijke relatie als ex-geliefden.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBARL0300600",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/206869247",
+        "de": "applemusic://track/206869247",
+        "gb": "applemusic://track/206869247",
+        "fr": "applemusic://track/206869247",
+        "es": "applemusic://track/206869247",
+        "nl": "applemusic://track/206869247",
+        "it": "applemusic://track/206869247"
+      }
     },
     {
       "year": 1983,
@@ -1394,7 +1844,17 @@
       "uri_tidal": "tidal://track/86639810",
       "uri_deezer": "deezer://track/479843772",
       "fun_fact_nl": "De BBC verbood dit nummer vanwege de seksuele inhoud, wat ironisch genoeg de verkoop stimuleerde. De video was zo provocatief dat MTV het aanvankelijk ook weigerde te zenden. Het stond 48 weken in de VK-hitparade.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAHW9900051",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1691630315",
+        "de": "applemusic://track/1691630315",
+        "gb": "applemusic://track/1691630315",
+        "fr": "applemusic://track/1691630315",
+        "es": "applemusic://track/1691630315",
+        "nl": "applemusic://track/1691630315",
+        "it": "applemusic://track/1691630315"
+      }
     },
     {
       "year": 1983,
@@ -1424,7 +1884,17 @@
       "uri_tidal": "tidal://track/12976089",
       "uri_deezer": "deezer://track/992101",
       "fun_fact_nl": "De Italiaanse artiest Gazebo schreef dit nummer geïnspireerd door zijn liefde voor klassieke muziek. Het werd een nummer 1-hit in heel Europa, maar werd als te Europees beschouwd voor de Amerikaanse radio en sloeg daar nooit aan.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "ITJ561800005",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1348826420",
+        "de": "applemusic://track/1348826420",
+        "gb": "applemusic://track/1348826420",
+        "fr": "applemusic://track/1348826420",
+        "es": "applemusic://track/1348826420",
+        "nl": "applemusic://track/1348826420",
+        "it": "applemusic://track/1348826420"
+      }
     },
     {
       "year": 1983,
@@ -1447,7 +1917,17 @@
       "uri_tidal": "tidal://track/34454458",
       "uri_deezer": "deezer://track/14639826",
       "fun_fact_nl": "Het sinistere lachen van Phil Collins in het nummer werd gecreëerd met behulp van het gated reverb-effect van een Roland CR-78 drummachine, wat een van de meest herkenbare intro's van de jaren 80 werd.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAAA0700784",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/919919467",
+        "de": "applemusic://track/267976217",
+        "gb": "applemusic://track/267976217",
+        "fr": "applemusic://track/267976217",
+        "es": "applemusic://track/267976217",
+        "nl": "applemusic://track/267976217",
+        "it": "applemusic://track/267976217"
+      }
     },
     {
       "year": 1983,
@@ -1470,7 +1950,17 @@
       "uri_tidal": "tidal://track/181544332",
       "uri_deezer": "deezer://track/79333905",
       "fun_fact_nl": "Het nummer heeft krachtige zang van Carol Kenyon. Een remixversie bereikte nummer 4 in het VK in 1992, bijna een decennium na de oorspronkelijke release.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAAA8300003",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/880682900",
+        "de": "applemusic://track/880682900",
+        "gb": "applemusic://track/880682900",
+        "fr": "applemusic://track/880682900",
+        "es": "applemusic://track/880682900",
+        "nl": "applemusic://track/880682900",
+        "it": "applemusic://track/880682900"
+      }
     },
     {
       "year": 1983,
@@ -1493,7 +1983,17 @@
       "uri_tidal": "tidal://track/384214827",
       "uri_deezer": "deezer://track/2970589931",
       "fun_fact_nl": "Howard Jones trad in zijn vroege optredens op met een mimespeler genaamd Jed op het podium. Deze synthpopklassieker bereikte nummer 2 in het VK en vestigde hem als een belangrijk 80s-artiest.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAHS0600042",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1765603566",
+        "de": "applemusic://track/1765603566",
+        "gb": "applemusic://track/1765603566",
+        "fr": "applemusic://track/1765603566",
+        "es": "applemusic://track/1765603566",
+        "nl": "applemusic://track/1765603566",
+        "it": "applemusic://track/1765603566"
+      }
     },
     {
       "year": 1983,
@@ -1516,7 +2016,17 @@
       "uri_tidal": "tidal://track/35397009",
       "uri_deezer": "deezer://track/13213908",
       "fun_fact_nl": "De Australische band ICEHOUSE (oorspronkelijk Flowers genaamd) had hun grootste Europese hit met dit nummer, dat nummer 1 bereikte in meerdere landen, waaronder Frankrijk en Duitsland.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "AUC441100023",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/537852245",
+        "de": "applemusic://track/537852245",
+        "gb": "applemusic://track/537852245",
+        "fr": "applemusic://track/537852245",
+        "es": "applemusic://track/537852245",
+        "nl": "applemusic://track/537852245",
+        "it": "applemusic://track/537852245"
+      }
     },
     {
       "year": 1983,
@@ -1556,7 +2066,17 @@
       "awards_nl": [
         "Oscar voor Beste Originele Lied (1984)",
         "Golden Globe voor Beste Originele Lied (1984)"
-      ]
+      ],
+      "isrc": "USA560661522",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/258276259",
+        "de": "applemusic://track/258276259",
+        "gb": "applemusic://track/258276259",
+        "fr": "applemusic://track/258276259",
+        "es": "applemusic://track/258276259",
+        "nl": "applemusic://track/258276259",
+        "it": "applemusic://track/258276259"
+      }
     },
     {
       "year": 1983,
@@ -1586,7 +2106,17 @@
       "uri_tidal": "tidal://track/243083",
       "uri_deezer": "deezer://track/700835",
       "fun_fact_nl": "Tony Hadley van Spandau Ballet nam de zang in één take op. De inspirerende boodschap van het nummer maakte het een vaste waarde bij sportevenementen. Het werd in slechts 45 minuten geschreven door Gary Kemp.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEA629262331",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1747790615",
+        "de": "applemusic://track/1706339647",
+        "gb": "applemusic://track/1747790615",
+        "fr": "applemusic://track/1747790615",
+        "es": "applemusic://track/1747790615",
+        "nl": "applemusic://track/1747790615",
+        "it": "applemusic://track/1747790615"
+      }
     },
     {
       "year": 1983,
@@ -1614,7 +2144,17 @@
       "uri_tidal": "tidal://track/2067495",
       "uri_deezer": "deezer://track/3528853",
       "fun_fact_nl": "Het Deense duo Laid Back creëerde dit nummer dat 'sophisti-pop' definieerde - een ontspannen, elektronisch geluid. Het werd een zomerhit door heel Europa en pionierde het gebruik van synthesizers in reggae.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DKABA0002801",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/693305942",
+        "de": "applemusic://track/1791989534",
+        "gb": "applemusic://track/1791989534",
+        "fr": "applemusic://track/1791989534",
+        "es": "applemusic://track/1791989534",
+        "nl": "applemusic://track/1791989534",
+        "it": "applemusic://track/1791989534"
+      }
     },
     {
       "year": 1983,
@@ -1644,7 +2184,17 @@
       "uri_tidal": "tidal://track/1606827",
       "uri_deezer": "deezer://track/918048",
       "fun_fact_nl": "Lionel Richie schreef deze ballade voor het album 'Can't Slow Down'. De muziekvideo, over een blinde studente, was controversieel maar won de MTV Video Music Award voor Best Male Video.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMO18390012",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1583983140",
+        "de": "applemusic://track/1583983140",
+        "gb": "applemusic://track/1583983140",
+        "fr": "applemusic://track/1583983140",
+        "es": "applemusic://track/1583983140",
+        "nl": "applemusic://track/1583983140",
+        "it": "applemusic://track/1583983140"
+      }
     },
     {
       "year": 1983,
@@ -1674,7 +2224,17 @@
       "uri_tidal": "tidal://track/592285",
       "uri_deezer": "deezer://track/920062",
       "fun_fact_nl": "Lionel Richie verzon de Caribisch klinkende taal in dit nummer - het is volledig bedacht. Hij wilde het nummer een internationaal gevoel geven. Het werd uitgevoerd tijdens de slotceremonie van de Olympische Spelen van 1984 in Los Angeles.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMO10110144",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1445751851",
+        "de": "applemusic://track/1445751851",
+        "gb": "applemusic://track/1445751851",
+        "fr": "applemusic://track/1445751851",
+        "es": "applemusic://track/1445751851",
+        "nl": "applemusic://track/1445751851",
+        "it": "applemusic://track/1445751851"
+      }
     },
     {
       "year": 1983,
@@ -1702,7 +2262,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=ElN_4vUvTPs",
       "uri_deezer": "deezer://track/831196",
       "fun_fact_nl": "Geschreven door Toto's Steve Porcaro over zijn dochter. Quincy Jones hoorde de demo en drong erop aan dat het op Thriller zou komen. SWV sampelde het voor 'Right Here' in 1993.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM19902992",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1641781005",
+        "de": "applemusic://track/1641781005",
+        "gb": "applemusic://track/1641781005",
+        "fr": "applemusic://track/1641781005",
+        "es": "applemusic://track/1641781005",
+        "nl": "applemusic://track/1641781005",
+        "it": "applemusic://track/1641781005"
+      }
     },
     {
       "year": 1983,
@@ -1731,7 +2301,17 @@
       "uri_tidal": "tidal://track/65484195",
       "uri_deezer": "deezer://track/4603396",
       "fun_fact_nl": "Het 'Mama-se, mama-sa'-refrein was geleend van Manu Dibango's 'Soul Makossa'. Michael schikte later een rechtszaak over het sample. Het is een van de meest energieke nummers van Thriller.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM19902986",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/655262176",
+        "de": "applemusic://track/655262176",
+        "gb": "applemusic://track/655262176",
+        "fr": "applemusic://track/655262176",
+        "es": "applemusic://track/655262176",
+        "nl": "applemusic://track/655262176",
+        "it": "applemusic://track/655262176"
+      }
     },
     {
       "year": 1983,
@@ -1756,7 +2336,17 @@
       "uri_tidal": "tidal://track/1105888",
       "uri_deezer": "deezer://track/540168502",
       "fun_fact_nl": "Oorspronkelijk geschreven over een seriemoordenaar, werden de teksten haastig herschreven voor de film 'Flashdance'. Het werd genomineerd voor een Oscar voor Beste Originele Nummer.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USPR38302462",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1808046460",
+        "de": "applemusic://track/1808046460",
+        "gb": "applemusic://track/1443325806",
+        "fr": "applemusic://track/1808046460",
+        "es": "applemusic://track/1808046460",
+        "nl": "applemusic://track/1808046460",
+        "it": "applemusic://track/1808046460"
+      }
     },
     {
       "year": 1983,
@@ -1781,7 +2371,17 @@
       "uri_tidal": "tidal://track/153983458",
       "uri_deezer": "deezer://track/706051",
       "fun_fact_nl": "De bestverkochte 12-inch single aller tijden, 'Blue Monday' verloor berucht geld op elk verkocht exemplaar omdat Peter Savilles uitgesneden hoes zo duur was om te produceren.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAAP0001115",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1530256511",
+        "de": "applemusic://track/1497384809",
+        "gb": "applemusic://track/1544965260",
+        "fr": "applemusic://track/1544965260",
+        "es": "applemusic://track/1544965260",
+        "nl": "applemusic://track/1544965260",
+        "it": "applemusic://track/1544965260"
+      }
     },
     {
       "year": 1983,
@@ -1806,7 +2406,17 @@
       "uri_tidal": "tidal://track/1395047",
       "uri_deezer": "deezer://track/646326522",
       "fun_fact_nl": "Het nummer pionierde het concept van de verhalende muziekvideo. De video, met Benatar die een groep vrouwen leidt tegen een louche clubeigenaar, was baanbrekend voor MTV.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USCH38300002",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1647070675",
+        "de": "applemusic://track/1647070675",
+        "gb": "applemusic://track/1647070675",
+        "fr": "applemusic://track/1647070675",
+        "es": "applemusic://track/1647070675",
+        "nl": "applemusic://track/1647070675",
+        "it": "applemusic://track/1647070675"
+      }
     },
     {
       "year": 1983,
@@ -1836,7 +2446,17 @@
       "uri_tidal": "tidal://track/1398638",
       "uri_deezer": "deezer://track/3130318",
       "fun_fact_nl": "Tony Hadley van Spandau Ballet nam de zang in één take op. De inspirerende boodschap van het nummer maakte het een vaste waarde bij sportevenementen. Het werd in slechts 45 minuten geschreven door Gary Kemp.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAYK8300018",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1876171806",
+        "de": "applemusic://track/1836433204",
+        "gb": "applemusic://track/1836433204",
+        "fr": "applemusic://track/1836433204",
+        "es": "applemusic://track/1836433204",
+        "nl": "applemusic://track/1836433204",
+        "it": "applemusic://track/1836433204"
+      }
     },
     {
       "year": 1983,
@@ -1903,7 +2523,17 @@
       "uri_tidal": "tidal://track/1851836",
       "uri_deezer": "deezer://track/1579265",
       "fun_fact_nl": "Ondanks dat het over de Bloedzondag-massamoord van 1972 gaat, introduceerde Bono het live altijd als 'geen rebellenlied' om de anti-geweldsboodschap te benadrukken.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAAN8300034",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1440882251",
+        "de": "applemusic://track/1440882251",
+        "gb": "applemusic://track/1440882251",
+        "fr": "applemusic://track/1440882251",
+        "es": "applemusic://track/1440882251",
+        "nl": "applemusic://track/1440882251",
+        "it": "applemusic://track/1440882251"
+      }
     },
     {
       "year": 1983,
@@ -1933,7 +2563,17 @@
       "uri_tidal": "tidal://track/1411790",
       "uri_deezer": "deezer://track/3129568",
       "fun_fact_nl": "Oorspronkelijk geschreven en opgenomen door Neil Diamond in 1968, was UB40's reggaeversie aanvankelijk een flop in de VS totdat een dj in Phoenix hem begon te draaien. De band wist niet dat het een cover was toen ze het opnamen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBDDH8300002",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/6763245537",
+        "de": "applemusic://track/6763245537",
+        "gb": "applemusic://track/6763245537",
+        "fr": "applemusic://track/6763245537",
+        "es": "applemusic://track/6763245537",
+        "nl": "applemusic://track/6763245537",
+        "it": "applemusic://track/6763245537"
+      }
     },
     {
       "year": 1983,
@@ -1963,7 +2603,17 @@
       "uri_tidal": "tidal://track/3268253",
       "uri_deezer": "deezer://track/97098410",
       "fun_fact_nl": "Eddie Van Halen had het synthriff jaren eerder geschreven, maar David Lee Roth verwierp het aanvankelijk als 'toetsenopvulling'. Toen ze het uiteindelijk opnamen, werd het Van Halens enige nummer 1-hit in de VS.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USWB11403500",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/977495501",
+        "de": "applemusic://track/977495501",
+        "gb": "applemusic://track/977495501",
+        "fr": "applemusic://track/977495501",
+        "es": "applemusic://track/977495501",
+        "nl": "applemusic://track/977495501",
+        "it": "applemusic://track/977495501"
+      }
     },
     {
       "year": 1983,
@@ -1991,7 +2641,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=WYX0sjP6Za8",
       "uri_deezer": "deezer://track/1073437",
       "fun_fact_nl": "George Michael en Andrew Ridgeley schreven deze satire over pakketvakanties. De video werd gefilmd op Ibiza. De zin 'drinks are free' werd iconisch.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBBBM8300007",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/206897937",
+        "de": "applemusic://track/1023759237",
+        "gb": "applemusic://track/1023759237",
+        "fr": "applemusic://track/1023759237",
+        "es": "applemusic://track/1023759237",
+        "nl": "applemusic://track/1023759237",
+        "it": "applemusic://track/1023759237"
+      }
     },
     {
       "year": 1983,
@@ -2014,7 +2674,17 @@
       "uri_tidal": "tidal://track/69136168",
       "uri_deezer": "deezer://track/3786220042",
       "fun_fact_nl": "Yazoo (bekend als Yaz in de VS) was het kortlevende maar invloedrijke duo van Vince Clarke en Alison Moyet. Na de splitsing richtte Clarke Erasure op.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAJH9900153",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1717063911",
+        "de": null,
+        "gb": null,
+        "fr": null,
+        "es": null,
+        "nl": null,
+        "it": null
+      }
     },
     {
       "year": 1984,
@@ -2042,7 +2712,17 @@
       "uri_tidal": "tidal://track/246156",
       "uri_deezer": "deezer://track/698274",
       "fun_fact_nl": "Alphaville schreef twee compleet verschillende nummers met dezelfde titel voor hun album - een ballade en een dansnummer. Beide werden hits. Het nummer is meer dan 100 keer gecoverd en wordt vaak gespeeld bij diploma-uitreikingen wereldwijd.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEA621800676",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1854680552",
+        "de": "applemusic://track/1854680552",
+        "gb": "applemusic://track/1854680552",
+        "fr": "applemusic://track/1854680552",
+        "es": "applemusic://track/1854680552",
+        "nl": "applemusic://track/1854680552",
+        "it": "applemusic://track/1854680552"
+      }
     },
     {
       "year": 1984,
@@ -2067,7 +2747,17 @@
       "uri_tidal": "tidal://track/246153",
       "uri_deezer": "deezer://track/698260",
       "fun_fact_nl": "De debuutsingle van het Duitse synthpoptrio werd een grote Europese hit. Ondanks de titel was het nooit bijzonder populair in Japan zelf.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEA629260037",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/65122498",
+        "de": "applemusic://track/1488156047",
+        "gb": "applemusic://track/1484829406",
+        "fr": "applemusic://track/1488156047",
+        "es": "applemusic://track/1488156047",
+        "nl": "applemusic://track/1488156047",
+        "it": "applemusic://track/1488156047"
+      }
     },
     {
       "year": 1984,
@@ -2095,7 +2785,17 @@
       "uri_tidal": "tidal://track/82529071",
       "uri_deezer": "deezer://track/428735732",
       "fun_fact_nl": "Jimmy Somerville schreef dit autobiografische nummer over het uit huis gezet worden door zijn familie vanwege zijn homoseksualiteit. Het werd een LGBT-hymne en een van de bepalende nummers van het synthpoptijdperk van 1984.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAAP1812339",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1773352854",
+        "de": "applemusic://track/1773352854",
+        "gb": "applemusic://track/1773352854",
+        "fr": "applemusic://track/1773352854",
+        "es": "applemusic://track/1773352854",
+        "nl": "applemusic://track/1773352854",
+        "it": "applemusic://track/1773352854"
+      }
     },
     {
       "year": 1984,
@@ -2125,7 +2825,17 @@
       "uri_tidal": "tidal://track/24385347",
       "uri_deezer": "deezer://track/15586213",
       "fun_fact_nl": "Ondanks het anthemische geluid is dit nummer eigenlijk een bittere kritiek op de behandeling van Vietnamveteranen. Ronald Reagans campagne van 1984 probeerde het te gebruiken voordat men de ware betekenis besefte.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM18400406",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1741640193",
+        "de": "applemusic://track/1741640193",
+        "gb": "applemusic://track/1741640193",
+        "fr": "applemusic://track/1741640193",
+        "es": "applemusic://track/1741640193",
+        "nl": "applemusic://track/1741640193",
+        "it": "applemusic://track/1741640193"
+      }
     },
     {
       "year": 1984,
@@ -2154,7 +2864,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=129kuDCQtHs",
       "uri_deezer": "deezer://track/15586246",
       "fun_fact_nl": "Geschreven in frustratie toen manager Jon Landau zei dat Born in the U.S.A. een hitsingle nodig had. De video toonde een jonge Courteney Cox die op het podium danste met Bruce.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM18400416",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1692216411",
+        "de": "applemusic://track/1692216411",
+        "gb": "applemusic://track/1692216411",
+        "fr": "applemusic://track/1692216411",
+        "es": "applemusic://track/1692216411",
+        "nl": "applemusic://track/1692216411",
+        "it": "applemusic://track/1692216411"
+      }
     },
     {
       "year": 1984,
@@ -2183,7 +2903,17 @@
       "uri_tidal": "tidal://track/37149247",
       "uri_deezer": "deezer://track/88902741",
       "fun_fact_nl": "Ondanks de titel die verwijst naar 1969 was Bryan Adams slechts 9 jaar oud die zomer. Hij heeft gezegd dat het nummer eigenlijk over vrijen gaat ('69' als dubbelzinnigheid) en het gevoel van jeugdige zomers, niet een specifiek jaar.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USAM18490006",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1440823965",
+        "de": "applemusic://track/1440823965",
+        "gb": "applemusic://track/1484319318",
+        "fr": "applemusic://track/1440823965",
+        "es": "applemusic://track/1440823965",
+        "nl": "applemusic://track/1442499799",
+        "it": "applemusic://track/1440823965"
+      }
     },
     {
       "year": 1984,
@@ -2212,7 +2942,17 @@
       "uri_tidal": "tidal://track/68710438",
       "uri_deezer": "deezer://track/3667363",
       "fun_fact_nl": "Peter Cetera schreef deze power ballad over de geboorte van zijn dochter. Het nummer markeerde Chicago's overgang van jazz-rock naar adult contemporary pop, wat langdurige fans verdeelde maar enorm commercieel succes bracht.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USWB18400039",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1792593099",
+        "de": "applemusic://track/1792593099",
+        "gb": "applemusic://track/1792593099",
+        "fr": "applemusic://track/1792593099",
+        "es": "applemusic://track/1792593099",
+        "nl": "applemusic://track/1792593099",
+        "it": "applemusic://track/1792593099"
+      }
     },
     {
       "year": 1984,
@@ -2237,7 +2977,17 @@
       "uri_tidal": "tidal://track/2450874",
       "uri_deezer": "deezer://track/2321084495",
       "fun_fact_nl": "Het nummer ging oorspronkelijk over nucleaire paranoia maar werd op het laatste moment herschreven om te gaan over het 's nachts dragen van een zonnebril, wat een iconisch 80s-beeld werd.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USEM38400043",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/724506959",
+        "de": "applemusic://track/724506959",
+        "gb": "applemusic://track/1697179412",
+        "fr": "applemusic://track/724506959",
+        "es": "applemusic://track/724506959",
+        "nl": "applemusic://track/724506959",
+        "it": "applemusic://track/724506959"
+      }
     },
     {
       "year": 1984,
@@ -2266,7 +3016,17 @@
       "uri_tidal": "tidal://track/1317409",
       "uri_deezer": "deezer://track/6067362",
       "fun_fact_nl": "Geschreven door Jules Shear, werd dit Cyndi Laupers derde top 5-hit van haar debuutalbum. Het nummer liet haar zachtere kant zien na het speelse 'Girls Just Want to Have Fun'.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM18300652",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/187488853",
+        "de": "applemusic://track/187488853",
+        "gb": "applemusic://track/187488853",
+        "fr": "applemusic://track/187488853",
+        "es": "applemusic://track/187488853",
+        "nl": "applemusic://track/187488853",
+        "it": "applemusic://track/187488853"
+      }
     },
     {
       "year": 1984,
@@ -2291,7 +3051,17 @@
       "uri_tidal": "tidal://track/3392978",
       "uri_deezer": "deezer://track/958021",
       "fun_fact_nl": "Het nummer deed er 3 weken over om van de lagere hitparade naar nummer 1 te klimmen in het VK, en de productie door Stock Aitken Waterman kostte destijds het enorme bedrag van £70.000.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBBBM8502013",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/211418804",
+        "de": "applemusic://track/211418804",
+        "gb": "applemusic://track/211418804",
+        "fr": "applemusic://track/211418804",
+        "es": "applemusic://track/211418804",
+        "nl": "applemusic://track/211418804",
+        "it": "applemusic://track/211418804"
+      }
     },
     {
       "year": 1984,
@@ -2316,7 +3086,17 @@
       "uri_tidal": "tidal://track/20906974",
       "uri_deezer": "deezer://track/68514099",
       "fun_fact_nl": "Dit was Depeche Modes eerste grote internationale hit, die nummer 1 bereikte in Duitsland. Martin Gore uitte later schaamte over de simplistische tekst van het nummer.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAJH0601312",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/665414308",
+        "de": "applemusic://track/665414308",
+        "gb": "applemusic://track/665414308",
+        "fr": "applemusic://track/665414308",
+        "es": "applemusic://track/665414308",
+        "nl": "applemusic://track/665414308",
+        "it": "applemusic://track/665414308"
+      }
     },
     {
       "year": 1984,
@@ -2339,7 +3119,17 @@
       "uri_tidal": "tidal://track/20906980",
       "uri_deezer": "deezer://track/68515080",
       "fun_fact_nl": "Het controversiële nummer over God die een 'ziek gevoel voor humor' heeft, werd verboden door verschillende radiostations. Martin Gore schreef het nadat de moeder van een vriend een zelfmoordpoging deed.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAJH0601318",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/665414812",
+        "de": "applemusic://track/665414812",
+        "gb": "applemusic://track/665414812",
+        "fr": "applemusic://track/665414812",
+        "es": "applemusic://track/665414812",
+        "nl": "applemusic://track/665414812",
+        "it": "applemusic://track/665414812"
+      }
     },
     {
       "year": 1984,
@@ -2362,7 +3152,17 @@
       "uri_tidal": "tidal://track/20906978",
       "uri_deezer": "deezer://track/68514297",
       "fun_fact_nl": "De S&M-thema's en zweepgeluiden van het nummer zorgden voor controverse, waardoor de BBC aanvankelijk aarzelde het te spelen. Het bereikte toch nummer 9 in het VK.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAJH0601316",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/665414560",
+        "de": "applemusic://track/665414560",
+        "gb": "applemusic://track/665414560",
+        "fr": "applemusic://track/665414560",
+        "es": "applemusic://track/665414560",
+        "nl": "applemusic://track/665414560",
+        "it": "applemusic://track/665414560"
+      }
     },
     {
       "year": 1984,
@@ -2390,7 +3190,17 @@
       "uri_tidal": "tidal://track/3392988",
       "uri_deezer": "deezer://track/13162291",
       "fun_fact_nl": "Fiction Factory's enige grote hit ving het romantische new wave-geluid van 1984 perfect. Ondanks het etiket van eenaggers blijft het nummer een geliefde 80s-klassieker.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBBBN8400001",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/429802754",
+        "de": "applemusic://track/466734048",
+        "gb": "applemusic://track/466734048",
+        "fr": "applemusic://track/466734048",
+        "es": "applemusic://track/466734048",
+        "nl": "applemusic://track/466734048",
+        "it": "applemusic://track/466734048"
+      }
     },
     {
       "year": 1984,
@@ -2418,7 +3228,17 @@
       "uri_tidal": "tidal://track/27967088",
       "uri_deezer": "deezer://track/4311056",
       "fun_fact_nl": "Jermaine Jackson en Pia Zadora namen dit krachtige duet op voor de sciencefictionfilm 'Voyage of the Rock Aliens'. Het werd een grote hit in Europa, vooral in Duitsland waar het nummer 1 bereikte.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USAR11200209",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/853593059",
+        "de": "applemusic://track/853593059",
+        "gb": "applemusic://track/853593059",
+        "fr": "applemusic://track/853593059",
+        "es": "applemusic://track/853593059",
+        "nl": "applemusic://track/853593059",
+        "it": "applemusic://track/853593059"
+      }
     },
     {
       "year": 1984,
@@ -2447,7 +3267,17 @@
       "uri_tidal": "tidal://track/3120863",
       "uri_deezer": "deezer://track/4288159",
       "fun_fact_nl": "Dit nummer werd oorspronkelijk in hetzelfde jaar opgenomen door de Italiaanse artiest Raf. Laura Branigans Engelse versie en Rafs Italiaanse versie werden beiden geproduceerd door hetzelfde team en gelijktijdig uitgebracht.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USAT20903047",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1820904484",
+        "de": "applemusic://track/1740921478",
+        "gb": "applemusic://track/1740921478",
+        "fr": "applemusic://track/1740921478",
+        "es": "applemusic://track/1740921478",
+        "nl": "applemusic://track/1740921478",
+        "it": "applemusic://track/1740921478"
+      }
     },
     {
       "year": 1984,
@@ -2474,7 +3304,17 @@
       "uri_tidal": "tidal://track/32572499",
       "uri_deezer": "deezer://track/15218949",
       "fun_fact_nl": "Leonard Cohen schreef 80 conceptcoupletten voordat hij de definitieve tekst vaststelde. Aanvankelijk een flop, werd het nummer iconisch via covers van Jeff Buckley, John Cale en Rufus Wainwright.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM10026643",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1556917286",
+        "de": "applemusic://track/1556917286",
+        "gb": "applemusic://track/1556917286",
+        "fr": "applemusic://track/1556917286",
+        "es": "applemusic://track/1556917286",
+        "nl": "applemusic://track/1556917286",
+        "it": "applemusic://track/1556917286"
+      }
     },
     {
       "year": 1984,
@@ -2504,7 +3344,17 @@
       "uri_tidal": "tidal://track/2123752",
       "uri_deezer": "deezer://track/3824997361",
       "fun_fact_nl": "Billy Steinberg schreef dit over het kwetsbare gevoel bij een nieuwe relatie na zijn scheiding. Madonnas controversiële MTV VMAs-optreden van dit nummer, in een trouwjurk, lanceerde haar rebelse imago.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USWB10002748",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1860831151",
+        "de": "applemusic://track/1468018023",
+        "gb": "applemusic://track/1468018023",
+        "fr": "applemusic://track/1468018023",
+        "es": "applemusic://track/1468018023",
+        "nl": "applemusic://track/1468018023",
+        "it": "applemusic://track/1468018023"
+      }
     },
     {
       "year": 1984,
@@ -2532,7 +3382,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=9c-P7BTvmQ0",
       "uri_deezer": "deezer://track/1174770",
       "fun_fact_nl": "Oorspronkelijk uitgebracht in 1983, keerde het terug in de hitparade in 1984 nadat 'Wouldn't It Be Good' een hit werd. Het nummer gaat over nucleaire angst tijdens de Koude Oorlog.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBBBY0300012",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1647073443",
+        "de": "applemusic://track/1647073443",
+        "gb": "applemusic://track/1647073443",
+        "fr": "applemusic://track/1647073443",
+        "es": "applemusic://track/1647073443",
+        "nl": "applemusic://track/1647073443",
+        "it": "applemusic://track/1647073443"
+      }
     },
     {
       "year": 1984,
@@ -2557,7 +3417,17 @@
       "uri_tidal": "tidal://track/19193082",
       "uri_deezer": "deezer://track/1174769",
       "fun_fact_nl": "Nik Kershaw was pas 26 toen dit nummer een grote hit werd. Hij onthulde later dat het cryptische 'Riddle' werkelijk betekenisloos was, ondanks allerlei fantheorieën.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBBBY0300006",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1647072745",
+        "de": "applemusic://track/1647072745",
+        "gb": "applemusic://track/1647072745",
+        "fr": "applemusic://track/1647072745",
+        "es": "applemusic://track/1647072745",
+        "nl": "applemusic://track/1647072745",
+        "it": "applemusic://track/1647072745"
+      }
     },
     {
       "year": 1984,
@@ -2580,7 +3450,17 @@
       "uri_tidal": "tidal://track/1533697",
       "uri_deezer": "deezer://track/3156228",
       "fun_fact_nl": "Van het album 'Junk Culture' liet deze elegante synthballade OMDs meer toegankelijke popkant zien en bereikte de VK-top 20.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAAA8400017",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/6762966624",
+        "de": "applemusic://track/6762966624",
+        "gb": "applemusic://track/6762966624",
+        "fr": "applemusic://track/6762966624",
+        "es": "applemusic://track/6762966624",
+        "nl": "applemusic://track/6762966624",
+        "it": "applemusic://track/6762966624"
+      }
     },
     {
       "year": 1984,
@@ -2609,7 +3489,17 @@
       "uri_tidal": "tidal://track/1822994",
       "uri_deezer": "deezer://track/3105190",
       "fun_fact_nl": "Pat Benatar aarzelde om deze zachtere ballade op te nemen, uit angst dat het haar rockimago zou veranderen. Het werd een van haar grootste hits en liet haar veelzijdigheid als artiest zien.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USCH38400001",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/6762152900",
+        "de": "applemusic://track/6762152900",
+        "gb": "applemusic://track/6762152900",
+        "fr": "applemusic://track/6762152900",
+        "es": "applemusic://track/6762152900",
+        "nl": "applemusic://track/6762152900",
+        "it": "applemusic://track/6762152900"
+      }
     },
     {
       "year": 1984,
@@ -2646,7 +3536,17 @@
       "fun_fact_nl": "Phil Collins schreef dit voor de gelijknamige film in slechts één nacht. Ondanks het enorme succes van het nummer werd Collins niet uitgenodigd om het op te voeren bij de Oscars - de producers kozen Ann Reinking.",
       "awards_nl": [
         "Grammy Award voor Beste Mannelijke Pop Zangprestatie (1985)"
-      ]
+      ],
+      "isrc": "USRH11603951",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1148642452",
+        "de": "applemusic://track/1148701808",
+        "gb": "applemusic://track/1148642452",
+        "fr": "applemusic://track/1148642452",
+        "es": "applemusic://track/1148642452",
+        "nl": "applemusic://track/1148642452",
+        "it": "applemusic://track/1148642452"
+      }
     },
     {
       "year": 1984,
@@ -2669,7 +3569,17 @@
       "uri_tidal": "tidal://track/198425772",
       "uri_deezer": "deezer://track/1496671562",
       "fun_fact_nl": "Vernoemd naar Fritz Langs fictieve criminele meesterbrein, was dit Propaganda's debuutsingle op ZTT Records en werd een cultklassieker van de 80s-synthscene.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAHW0000201",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/6762966620",
+        "de": "applemusic://track/6762966620",
+        "gb": "applemusic://track/6762966620",
+        "fr": "applemusic://track/6762966620",
+        "es": "applemusic://track/6762966620",
+        "nl": "applemusic://track/6762966620",
+        "it": "applemusic://track/6762966620"
+      }
     },
     {
       "year": 1984,
@@ -2691,7 +3601,17 @@
       "uri_tidal": "tidal://track/63910876",
       "uri_deezer": "deezer://track/130437236",
       "fun_fact_nl": "Deze Duitstalige hit werd een van de meest iconische Neue Deutsche Welle-nummers. Purple Schulz (echte naam: Claus-Jürgen Schulz) was een sleutelfiguur in de Keulse muziekscene.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEA348300911",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1692882667",
+        "de": "applemusic://track/724120597",
+        "gb": "applemusic://track/1692882667",
+        "fr": "applemusic://track/1692882667",
+        "es": "applemusic://track/1692882667",
+        "nl": "applemusic://track/1692882667",
+        "it": "applemusic://track/1692882667"
+      }
     },
     {
       "year": 1984,
@@ -2719,7 +3639,17 @@
       "uri_tidal": "tidal://track/7677489",
       "uri_deezer": "deezer://track/7868651",
       "fun_fact_nl": "De video toonde alle bandleden in drag, parodiëren van de Britse soapserie 'Coronation Street'. Een hit in het VK, werd de video verkeerd begrepen in Amerika en schaadde het succes van het nummer daar.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBUM71106175",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1440810742",
+        "de": "applemusic://track/1440816142",
+        "gb": "applemusic://track/1440816142",
+        "fr": "applemusic://track/1440816142",
+        "es": "applemusic://track/1440816142",
+        "nl": "applemusic://track/1440816142",
+        "it": "applemusic://track/1440816142"
+      }
     },
     {
       "year": 1984,
@@ -2743,7 +3673,17 @@
       "uri_tidal": "tidal://track/3392902",
       "uri_deezer": "deezer://track/969252",
       "fun_fact_nl": "Huey Lewis klaagde Parker aan wegens het plagiëren van 'I Want a New Drug'. De zaak werd buiten de rechtbank geschikt. Het nummer stond 3 weken op nummer 1 in de Billboard Hot 100.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "QZ4KE1600002",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1127014316",
+        "de": "applemusic://track/1127014316",
+        "gb": "applemusic://track/1127014316",
+        "fr": "applemusic://track/1127014316",
+        "es": "applemusic://track/1127014316",
+        "nl": "applemusic://track/1127014316",
+        "it": "applemusic://track/1127014316"
+      }
     },
     {
       "year": 1984,
@@ -2772,7 +3712,17 @@
       "uri_tidal": "tidal://track/6317382",
       "uri_deezer": "deezer://track/10686127",
       "fun_fact_nl": "Sade Adu schreef dit nummer toen ze pas 21 was, nog voordat de band Sade was gevormd. Het verfijnde jazz-popgeluid hielp het 'quiet storm'-radioformaat van de jaren 80 te definiëren.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBBBM8400016",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/160022459",
+        "de": "applemusic://track/160022459",
+        "gb": "applemusic://track/160022459",
+        "fr": "applemusic://track/160022459",
+        "es": "applemusic://track/160022459",
+        "nl": "applemusic://track/160022459",
+        "it": "applemusic://track/160022459"
+      }
     },
     {
       "year": 1984,
@@ -2812,7 +3762,17 @@
       "awards_nl": [
         "Oscar voor Beste Originele Lied (1985)",
         "Golden Globe voor Beste Originele Lied (1985)"
-      ]
+      ],
+      "isrc": "USUMG9900476",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1449299049",
+        "de": "applemusic://track/1449299049",
+        "gb": "applemusic://track/1449299049",
+        "fr": "applemusic://track/1449299049",
+        "es": "applemusic://track/1449299049",
+        "nl": "applemusic://track/1449299049",
+        "it": "applemusic://track/1449299049"
+      }
     },
     {
       "year": 1984,
@@ -2837,7 +3797,17 @@
       "uri_tidal": "tidal://track/1551065",
       "uri_deezer": "deezer://track/3129542",
       "fun_fact_nl": "No Doubts cover uit 2003 bracht dit nummer onder de aandacht van een nieuwe generatie, maar het innovatieve gebruik van synthesizers in het origineel was baanbrekend voor zijn tijd.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAYE8400109",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1862433447",
+        "de": "applemusic://track/1724929798",
+        "gb": "applemusic://track/1724929798",
+        "fr": "applemusic://track/1724929798",
+        "es": "applemusic://track/1724929798",
+        "nl": "applemusic://track/1724929798",
+        "it": "applemusic://track/1724929798"
+      }
     },
     {
       "year": 1984,
@@ -2860,7 +3830,17 @@
       "uri_tidal": "tidal://track/1551063",
       "uri_deezer": "deezer://track/3257505",
       "fun_fact_nl": "Dit was Talk Talks grootste hit op het Europese vasteland, dat nummer 1 bereikte in Duitsland, Italië en meerdere andere landen, terwijl het nauwelijks in de VK-hitparade stond.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAYE9700489",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1704530128",
+        "de": "applemusic://track/1510554531",
+        "gb": "applemusic://track/1510554531",
+        "fr": "applemusic://track/1510554531",
+        "es": "applemusic://track/1510554531",
+        "nl": "applemusic://track/1510554531",
+        "it": "applemusic://track/1510554531"
+      }
     },
     {
       "year": 1984,
@@ -2885,7 +3865,17 @@
       "uri_tidal": "tidal://track/77614286",
       "uri_deezer": "deezer://track/88845907",
       "fun_fact_nl": "De opname van 'Shout' duurde meerdere maanden, waarbij de band obsessief klanken laagde om de dichte geluidslaag te creëren.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBF088490125",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1849816727",
+        "de": "applemusic://track/1849816727",
+        "gb": "applemusic://track/1849816727",
+        "fr": "applemusic://track/1849816727",
+        "es": "applemusic://track/1849816727",
+        "nl": "applemusic://track/1849816727",
+        "it": "applemusic://track/1849816727"
+      }
     },
     {
       "year": 1984,
@@ -2914,7 +3904,17 @@
       "uri_tidal": "tidal://track/3392941",
       "uri_deezer": "deezer://track/346967941",
       "fun_fact_nl": "The Pointer Sisters namen dit oorspronkelijk op in 1982, maar brachten het opnieuw uit in 1984 met een nieuwe video. Het energieke nummer werd een 80s-fitnesshit en is te horen in talloze films en tv-shows.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USRC18203285",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1681210235",
+        "de": "applemusic://track/1681210235",
+        "gb": "applemusic://track/1681210235",
+        "fr": "applemusic://track/1681210235",
+        "es": "applemusic://track/1681210235",
+        "nl": "applemusic://track/1681210235",
+        "it": "applemusic://track/1681210235"
+      }
     },
     {
       "year": 1984,
@@ -2937,7 +3937,17 @@
       "uri_tidal": "tidal://track/3268378",
       "uri_deezer": "deezer://track/5093609",
       "fun_fact_nl": "Johnny Marrs tremo-gitaareffect werd bereikt door het signaal gelijktijdig door vier versterkers te leiden. Het nummer werd later het thema van de tv-serie 'Charmed'.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBCRL1300377",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/803460027",
+        "de": "applemusic://track/803460027",
+        "gb": "applemusic://track/803460027",
+        "fr": "applemusic://track/803460027",
+        "es": "applemusic://track/803460027",
+        "nl": "applemusic://track/803460027",
+        "it": "applemusic://track/803460027"
+      }
     },
     {
       "year": 1984,
@@ -2960,7 +3970,17 @@
       "uri_tidal": "tidal://track/101982430",
       "uri_deezer": "deezer://track/3782900572",
       "fun_fact_nl": "Het nummer bereikte nummer 3 in het VK en was een van de grootste hits van het album 'Into the Gap', dat wereldwijd meer dan 3 miljoen exemplaren verkocht.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBARK8300011",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1446567636",
+        "de": "applemusic://track/1446567636",
+        "gb": "applemusic://track/1446567636",
+        "fr": "applemusic://track/1446567636",
+        "es": "applemusic://track/1446567636",
+        "nl": "applemusic://track/1446567636",
+        "it": "applemusic://track/1446567636"
+      }
     },
     {
       "year": 1984,
@@ -3003,7 +4023,17 @@
         "Grammy Award voor Opname van het Jaar (1985)",
         "Grammy Award voor Lied van het Jaar (1985)",
         "Grammy Award voor Beste Vrouwelijke Pop Zangprestatie (1985)"
-      ]
+      ],
+      "isrc": "USCA28400002",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1762458544",
+        "de": "applemusic://track/1691741301",
+        "gb": "applemusic://track/1691741301",
+        "fr": "applemusic://track/1691741301",
+        "es": "applemusic://track/1691741301",
+        "nl": "applemusic://track/1691741301",
+        "it": "applemusic://track/1691741301"
+      }
     },
     {
       "year": 1984,
@@ -3032,7 +4062,17 @@
       "uri_tidal": "tidal://track/46952204",
       "uri_deezer": "deezer://track/3120269",
       "fun_fact_nl": "Mark Knopfler van Dire Straits schreef dit nummer maar gaf het aan Tina Turner nadat hij besloot dat de tekst te vrouwelijk was voor zijn band. Het werd de titelsong van haar comeback-album en revitaliseerde haar carrière.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAYE1401509",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1717409831",
+        "de": "applemusic://track/1806635519",
+        "gb": "applemusic://track/1800174159",
+        "fr": "applemusic://track/1800174159",
+        "es": "applemusic://track/1800174159",
+        "nl": "applemusic://track/1800174159",
+        "it": "applemusic://track/1800174159"
+      }
     },
     {
       "year": 1984,
@@ -3057,7 +4097,17 @@
       "uri_tidal": "tidal://track/3142287",
       "uri_deezer": "deezer://track/4587261",
       "fun_fact_nl": "Geschreven over Martin Luther King Jr., bevat het nummer een aantoonbare feitelijke fout: King werd neergeschoten in de 'vroege ochtend' van 4 april, niet in de 'vroege avond' zoals Bono zingt.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBUM70817519",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1440732108",
+        "de": "applemusic://track/1440732108",
+        "gb": "applemusic://track/1440732108",
+        "fr": "applemusic://track/1440732108",
+        "es": "applemusic://track/1440732108",
+        "nl": "applemusic://track/1440732108",
+        "it": "applemusic://track/1440732108"
+      }
     },
     {
       "year": 1984,
@@ -3087,7 +4137,17 @@
       "uri_tidal": "tidal://track/33731053",
       "uri_deezer": "deezer://track/14525087",
       "fun_fact_nl": "George Michael schreef dit voor Wham! en het werd hun vierde nummer 1 in het VK. Het thema van onafhankelijkheid was ironisch, gezien het feit dat Michael later zou strijden om 'vrij' te zijn van zijn Sony-platencontract.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBBBN0009302",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/193085002",
+        "de": "applemusic://track/509175363",
+        "gb": "applemusic://track/509175363",
+        "fr": "applemusic://track/509175363",
+        "es": "applemusic://track/509175363",
+        "nl": "applemusic://track/509175363",
+        "it": "applemusic://track/509175363"
+      }
     },
     {
       "year": 1985,
@@ -3117,7 +4177,17 @@
       "uri_tidal": "tidal://track/391687",
       "uri_deezer": "deezer://track/664107",
       "fun_fact_nl": "De iconische muziekvideo met potloodschetsanimatie kostte 16 weken om te maken, met 3.000 handgetekende frames. Het nummer floopte aanvankelijk tweemaal voordat de baanbrekende video het wereldwijd naar nummer 1 bracht.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USWB10403931",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1531680680",
+        "de": "applemusic://track/1810756664",
+        "gb": "applemusic://track/1810756664",
+        "fr": "applemusic://track/1810756664",
+        "es": "applemusic://track/1810756664",
+        "nl": "applemusic://track/1810756664",
+        "it": "applemusic://track/1810756664"
+      }
     },
     {
       "year": 1985,
@@ -3142,7 +4212,17 @@
       "uri_tidal": "tidal://track/112543128",
       "uri_deezer": "deezer://track/664115",
       "fun_fact_nl": "Dit was a-ha's tweede single en bereikte nummer 1 in het VK, waarmee de band bewees geen eenaggers te zijn na 'Take On Me'.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USWB11506479",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1035047673",
+        "de": "applemusic://track/1035047673",
+        "gb": "applemusic://track/1035047673",
+        "fr": "applemusic://track/1035047673",
+        "es": "applemusic://track/1035047673",
+        "nl": "applemusic://track/1035047673",
+        "it": "applemusic://track/1035047673"
+      }
     },
     {
       "year": 1985,
@@ -3171,7 +4251,17 @@
       "uri_tidal": "tidal://track/26542859",
       "uri_deezer": "deezer://track/75392184",
       "fun_fact_nl": "Geschreven voor de film 'The Last Dragon', werd dit DeBarge's enige nummer 1 R&B-hit. De familiegroep, bestaand uit broers en zussen, had eerder op tournee gegaan met Motowns legendarische artiesten.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMO18500526",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1449299031",
+        "de": "applemusic://track/1449299031",
+        "gb": "applemusic://track/1449299031",
+        "fr": "applemusic://track/1449299031",
+        "es": "applemusic://track/1449299031",
+        "nl": "applemusic://track/1449299031",
+        "it": "applemusic://track/1449299031"
+      }
     },
     {
       "year": 1985,
@@ -3200,7 +4290,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=kd9TlGDZGkI",
       "uri_deezer": "deezer://track/2514683",
       "fun_fact_nl": "Mark Knopfler schreef dit vrolijke nummer als eerbetoon aan straatmuzikanten. Het karakteristieke orgelgeluid werd een van de meest herkenbare intro's in de 80s rock.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBF088500675",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1813832414",
+        "de": "applemusic://track/1622293311",
+        "gb": "applemusic://track/1802857118",
+        "fr": "applemusic://track/1802857118",
+        "es": "applemusic://track/1802857118",
+        "nl": "applemusic://track/1802857118",
+        "it": "applemusic://track/1622293311"
+      }
     },
     {
       "year": 1985,
@@ -3250,7 +4350,17 @@
       "uri_tidal": "tidal://track/279765006",
       "uri_deezer": "deezer://track/2173954687",
       "fun_fact_nl": "Het nummer beleefde een enorme revival in 2022 nadat het te horen was in Netflix' 'Stranger Things', waarbij het nummer 1 bereikte in het VK 37 jaar na de oorspronkelijke release.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAYE1800884",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1675560578",
+        "de": "applemusic://track/1675560578",
+        "gb": "applemusic://track/1675560578",
+        "fr": "applemusic://track/1675560578",
+        "es": "applemusic://track/1675560578",
+        "nl": "applemusic://track/1675560578",
+        "it": "applemusic://track/1675560578"
+      }
     },
     {
       "year": 1985,
@@ -3273,7 +4383,17 @@
       "uri_tidal": "tidal://track/279765010",
       "uri_deezer": "deezer://track/2173954727",
       "fun_fact_nl": "Het nummer en de iconische video met Donald Sutherland waren geïnspireerd op Peter Reichs memoir over het controversiële orgone-energieonderzoek van zijn vader Wilhelm Reich.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBCNR8500022",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1675375378",
+        "de": "applemusic://track/1675375378",
+        "gb": "applemusic://track/1675375378",
+        "fr": "applemusic://track/1675375378",
+        "es": "applemusic://track/1675375378",
+        "nl": "applemusic://track/1675375378",
+        "it": "applemusic://track/1675375378"
+      }
     },
     {
       "year": 1985,
@@ -3303,7 +4423,17 @@
       "uri_tidal": "tidal://track/1346602",
       "uri_deezer": "deezer://track/3166724",
       "fun_fact_nl": "Katrina Leskanich heeft gezegd dat ze 'lichamelijk ziek' wordt van het zo vaak uitvoeren van dit nummer. Ondanks bekend als een 80s-nummer werd het eigenlijk al in 1983 uitgebracht met weinig succes, voordat de heruitgave van 1985.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USCA28500452",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1893189187",
+        "de": "applemusic://track/1893189187",
+        "gb": "applemusic://track/1893189187",
+        "fr": "applemusic://track/1893189187",
+        "es": "applemusic://track/1893189187",
+        "nl": "applemusic://track/1893189187",
+        "it": "applemusic://track/1893189187"
+      }
     },
     {
       "year": 1985,
@@ -3326,7 +4456,17 @@
       "uri_tidal": "tidal://track/305757925",
       "uri_deezer": "deezer://track/2217199357",
       "fun_fact_nl": "Dit was Killing Joke's commercieel meest succesvolle single, die nummer 16 bereikte in het VK. De agressieve post-punk stijl van de band beïnvloedde Nirvana, Metallica en Nine Inch Nails.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAAA0701586",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1698417340",
+        "de": "applemusic://track/1698417340",
+        "gb": "applemusic://track/1698417340",
+        "fr": "applemusic://track/1698417340",
+        "es": "applemusic://track/1698417340",
+        "nl": "applemusic://track/1698417340",
+        "it": "applemusic://track/1698417340"
+      }
     },
     {
       "year": 1985,
@@ -3351,7 +4491,17 @@
       "uri_tidal": "tidal://track/75786967",
       "uri_deezer": "deezer://track/3346318",
       "fun_fact_nl": "Het nummer wordt gecrediteerd met het populariseren van de meisjesnaam Kayleigh in het VK. Het was Marillion's grootste hit, die nummer 2 bereikte in het VK.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAYE1601694",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1755174963",
+        "de": "applemusic://track/1755174963",
+        "gb": "applemusic://track/1755174963",
+        "fr": "applemusic://track/1755174963",
+        "es": "applemusic://track/1755174963",
+        "nl": "applemusic://track/1755174963",
+        "it": "applemusic://track/1755174963"
+      }
     },
     {
       "year": 1985,
@@ -3378,7 +4528,17 @@
       "uri_tidal": "tidal://track/1880055",
       "uri_deezer": "deezer://track/630374",
       "fun_fact_nl": "Dit nummer van Münchener Freiheit werd een van de grootste Duitse hits van de jaren 80. De band balanceerde succesvol Duitstalige pop met internationale synthpopgeluiden en inspireerde vele Duitse bands.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEE868500072",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1626938163",
+        "de": "applemusic://track/1620406618",
+        "gb": "applemusic://track/854508977",
+        "fr": "applemusic://track/854508977",
+        "es": "applemusic://track/854508977",
+        "nl": "applemusic://track/1790923442",
+        "it": "applemusic://track/854508977"
+      }
     },
     {
       "year": 1985,
@@ -3401,7 +4561,17 @@
       "uri_tidal": "tidal://track/1533699",
       "uri_deezer": "deezer://track/3153787",
       "fun_fact_nl": "Van het album 'Crush' had 'Secret' een meer gepolijste popproductie die OMD hielp succes te vinden op de Amerikaanse markt.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAAA8500227",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/714551958",
+        "de": "applemusic://track/714551958",
+        "gb": "applemusic://track/714551958",
+        "fr": "applemusic://track/714551958",
+        "es": "applemusic://track/714551958",
+        "nl": "applemusic://track/714551958",
+        "it": "applemusic://track/714551958"
+      }
     },
     {
       "year": 1985,
@@ -3426,7 +4596,17 @@
       "uri_tidal": "tidal://track/233178244",
       "uri_deezer": "deezer://track/2324397795",
       "fun_fact_nl": "De titel verwijst naar de gemiddelde leeftijd van Amerikaanse gevechtssoldaten in Vietnam. De stotterende vocalsamples waren baanbrekend en het bereikte nummer 1 in 13 landen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAYK8500015",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1629177761",
+        "de": "applemusic://track/1629177761",
+        "gb": "applemusic://track/1629177761",
+        "fr": "applemusic://track/1629177761",
+        "es": "applemusic://track/1629177761",
+        "nl": "applemusic://track/1629177761",
+        "it": "applemusic://track/723470830"
+      }
     },
     {
       "year": 1985,
@@ -3454,7 +4634,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=zKVq-P3z5Vg",
       "uri_deezer": "deezer://track/122015000",
       "fun_fact_nl": "Phil Collins' tweede nummer 1 in de VS. Geschreven tijdens zijn scheiding, liet de emotionele ballade zijn zachtere kant zien. Hij speelde zelf alle instrumenten.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USRH11601159",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1088551720",
+        "de": "applemusic://track/1150664385",
+        "gb": "applemusic://track/1088551720",
+        "fr": "applemusic://track/1088551720",
+        "es": "applemusic://track/1088551720",
+        "nl": "applemusic://track/1088551720",
+        "it": "applemusic://track/1088551720"
+      }
     },
     {
       "year": 1985,
@@ -3482,7 +4672,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=r0qBaBb1Y-U",
       "uri_deezer": "deezer://track/122014992",
       "fun_fact_nl": "De titel is een betekenisloos woord dat Phil als tijdelijke aanduiding gebruikte en nooit verving. Sommigen beschuldigden hem van het kopiëren van Princes '1999', wat Phil heeft erkend.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USRH11601155",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1148642435",
+        "de": "applemusic://track/1088551716",
+        "gb": "applemusic://track/1148642435",
+        "fr": "applemusic://track/1148642435",
+        "es": "applemusic://track/1148642435",
+        "nl": "applemusic://track/1148642435",
+        "it": "applemusic://track/1148642435"
+      }
     },
     {
       "year": 1985,
@@ -3505,7 +4705,17 @@
       "uri_tidal": "tidal://track/143494212",
       "uri_deezer": "deezer://track/1496671542",
       "fun_fact_nl": "Geproduceerd door Trevor Horns ZTT Records-team gebruikte het nummer geavanceerde Fairlight CMI-samplingtechnologie die revolutionair was voor die tijd.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAHW0000199",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1839006754",
+        "de": "applemusic://track/1839006754",
+        "gb": "applemusic://track/1839006754",
+        "fr": "applemusic://track/1839006754",
+        "es": "applemusic://track/1839006754",
+        "nl": "applemusic://track/1839006754",
+        "it": "applemusic://track/1839006754"
+      }
     },
     {
       "year": 1985,
@@ -3530,7 +4740,17 @@
       "uri_tidal": "tidal://track/1497500",
       "uri_deezer": "deezer://track/3092548",
       "fun_fact_nl": "Geproduceerd door Michael Cretu (later bekend van Enigma), was dit een van de bestverkochte singles van 1985 in Duitsland en bereikte nummer 1 in 21 landen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEG128700604",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1705321808",
+        "de": "applemusic://track/1705321808",
+        "gb": "applemusic://track/1705321808",
+        "fr": "applemusic://track/1705321808",
+        "es": "applemusic://track/1705321808",
+        "nl": "applemusic://track/1705321808",
+        "it": "applemusic://track/1705321808"
+      }
     },
     {
       "year": 1985,
@@ -3555,7 +4775,17 @@
       "uri_tidal": "tidal://track/2060790",
       "uri_deezer": "deezer://track/2477001",
       "fun_fact_nl": "Mick Hucknall schreef dit toen hij pas 17 was, geïnspireerd door zijn afwezige moeder die wegging toen hij drie was. Het bereikte nummer 1 in de VS in 1986.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBCRL0800119",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1718063870",
+        "de": "applemusic://track/1802225094",
+        "gb": "applemusic://track/1802225094",
+        "fr": "applemusic://track/1802225094",
+        "es": "applemusic://track/1802225094",
+        "nl": "applemusic://track/1802225094",
+        "it": "applemusic://track/1802225094"
+      }
     },
     {
       "year": 1985,
@@ -3583,7 +4813,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=K1b8AhIsSYQ",
       "uri_deezer": "deezer://track/602137972",
       "fun_fact_nl": "Vaak gekozen als een van de slechtste nummers ooit was het eigenlijk een grote hit. Bernie Taupin schreef de tekst over de commercialisering van rockmuziek.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USRC18503424",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1631301659",
+        "de": "applemusic://track/1631301659",
+        "gb": "applemusic://track/1631301659",
+        "fr": "applemusic://track/1631301659",
+        "es": "applemusic://track/1631301659",
+        "nl": "applemusic://track/1870541724",
+        "it": "applemusic://track/1631301659"
+      }
     },
     {
       "year": 1985,
@@ -3606,7 +4846,17 @@
       "uri_tidal": "tidal://track/35687909",
       "uri_deezer": "deezer://track/1140665",
       "fun_fact_nl": "Geschreven tijdens de Koude Oorlog bevat het nummer een sample van Prokofjevs 'Luitenant Kijé'-suite. Sting raakte geïnspireerd na het kijken van Sovjet-televisie via een satellietschotel.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USAM18500044",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1455400379",
+        "de": "applemusic://track/1440922956",
+        "gb": "applemusic://track/1440922956",
+        "fr": "applemusic://track/1440922956",
+        "es": "applemusic://track/1440922956",
+        "nl": "applemusic://track/1440922956",
+        "it": "applemusic://track/1440922956"
+      }
     },
     {
       "year": 1985,
@@ -3629,7 +4879,17 @@
       "uri_tidal": "tidal://track/1486042",
       "uri_deezer": "deezer://track/3136910",
       "fun_fact_nl": "Mark Hollis verplaatste Talk Talk bewust van synthpop naar meer experimentele geluiden, waardoor dit een van de overgangsnummers van de band werd.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAYE8600002",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/693429434",
+        "de": "applemusic://track/693429434",
+        "gb": "applemusic://track/693429434",
+        "fr": "applemusic://track/693429434",
+        "es": "applemusic://track/693429434",
+        "nl": "applemusic://track/693429434",
+        "it": "applemusic://track/693429434"
+      }
     },
     {
       "year": 1985,
@@ -3655,7 +4915,17 @@
       "uri_tidal": "tidal://track/37154397",
       "uri_deezer": "deezer://track/2234314",
       "fun_fact_nl": "Dit nummer won de Brit Award voor Best British Single in 1986 en werd bijna van het album gelaten omdat de band dacht dat het niet sterk genoeg was.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBF088590110",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1704192326",
+        "de": "applemusic://track/1704192326",
+        "gb": "applemusic://track/1704192326",
+        "fr": "applemusic://track/1704192326",
+        "es": "applemusic://track/1704192326",
+        "nl": "applemusic://track/1704192326",
+        "it": "applemusic://track/1704192326"
+      }
     },
     {
       "year": 1985,
@@ -3678,7 +4948,17 @@
       "uri_tidal": "tidal://track/2318097",
       "uri_deezer": "deezer://track/1143634",
       "fun_fact_nl": "De iconische muziekvideo werd gefilmd in een kledingkast die van een klif in zee valt. Smith heeft gezegd dat het nummer over claustrofobie en angst gaat.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USEE10608884",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1704536575",
+        "de": null,
+        "gb": null,
+        "fr": null,
+        "es": null,
+        "nl": null,
+        "it": null
+      }
     },
     {
       "year": 1985,
@@ -3707,7 +4987,17 @@
       "uri_tidal": "tidal://track/1313966",
       "uri_deezer": "deezer://track/856124",
       "fun_fact_nl": "The Outfield nam dit nummer in één take op. Ondanks Brits te zijn, namen de bandleden Amerikaanse accenten aan voor hun opnames om het Amerikaanse publiek aan te spreken. Het blijft een van de meest gespeelde nummers op klassieke rockradio.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM18500059",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1737735336",
+        "de": "applemusic://track/1737735336",
+        "gb": "applemusic://track/1737735336",
+        "fr": "applemusic://track/1737735336",
+        "es": "applemusic://track/1737735336",
+        "nl": "applemusic://track/1737735336",
+        "it": "applemusic://track/1737735336"
+      }
     },
     {
       "year": 1985,
@@ -3736,7 +5026,17 @@
       "uri_tidal": "tidal://track/687202",
       "uri_deezer": "deezer://track/1131192",
       "fun_fact_nl": "Dit nummer was oorspronkelijk geschreven voor Janet Jackson, die het afwees. Whitney Houstons moeder Cissy zong achtergrondzang. De kleurrijke muziekvideo was een van de eerste die veel op MTV werd gedraaid.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USAR18500150",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/349286433",
+        "de": "applemusic://track/349286433",
+        "gb": "applemusic://track/349286433",
+        "fr": "applemusic://track/349286433",
+        "es": "applemusic://track/349286433",
+        "nl": "applemusic://track/734446117",
+        "it": "applemusic://track/349286433"
+      }
     },
     {
       "year": 1986,
@@ -3759,7 +5059,17 @@
       "uri_tidal": "tidal://track/391671",
       "uri_deezer": "deezer://track/664254",
       "fun_fact_nl": "Dit milieugerelateerde nummer van 'Scoundrel Days' toonde a-ha's artistieke groei voorbij synthpop naar complexere arrangementen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USWB10107603",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1764889158",
+        "de": "applemusic://track/1764889158",
+        "gb": "applemusic://track/1764889158",
+        "fr": "applemusic://track/1764889158",
+        "es": "applemusic://track/1764889158",
+        "nl": "applemusic://track/1764889158",
+        "it": "applemusic://track/1764889158"
+      }
     },
     {
       "year": 1986,
@@ -3782,7 +5092,17 @@
       "uri_tidal": "tidal://track/4170131",
       "uri_deezer": "deezer://track/120434350",
       "fun_fact_nl": "De atmosferische 'Manhattan Skyline' was het sluitstuk van 'Scoundrel Days' en werd een favoriet bij fans vanwege de cinematografische kwaliteit.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USWB11001117",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/380906541",
+        "de": "applemusic://track/380906541",
+        "gb": "applemusic://track/380906541",
+        "fr": "applemusic://track/380906541",
+        "es": "applemusic://track/380906541",
+        "nl": "applemusic://track/380906541",
+        "it": "applemusic://track/380906541"
+      }
     },
     {
       "year": 1986,
@@ -3807,7 +5127,17 @@
       "uri_tidal": "tidal://track/80318650",
       "uri_deezer": "deezer://track/421388682",
       "fun_fact_nl": "Oorspronkelijk van Shocking Blue in 1969 bereikte Bananarama's cover, geproduceerd door Stock Aitken Waterman, nummer 1 in de VS, waarmee ze de meest succesvolle vrouwengroep op de Amerikaanse hitparade werden.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAAP9600095",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1299157681",
+        "de": "applemusic://track/1299157681",
+        "gb": "applemusic://track/1299157681",
+        "fr": "applemusic://track/1299157681",
+        "es": "applemusic://track/1299157681",
+        "nl": "applemusic://track/1299157681",
+        "it": "applemusic://track/1299157681"
+      }
     },
     {
       "year": 1986,
@@ -3836,7 +5166,17 @@
       "uri_tidal": "tidal://track/77652529",
       "uri_deezer": "deezer://track/133577580",
       "fun_fact_nl": "Neil Finn schreef dit nummer in slechts 20 minuten. De zin 'Hey now, hey now' was oorspronkelijk een tijdelijke aanduiding die Finn wilde vervangen, maar producer Mitchell Froom overtuigde hem het te bewaren.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USCA28600048",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1679433584",
+        "de": "applemusic://track/1679433584",
+        "gb": "applemusic://track/1679433584",
+        "fr": "applemusic://track/1679433584",
+        "es": "applemusic://track/1679433584",
+        "nl": "applemusic://track/1679433584",
+        "it": "applemusic://track/1679433584"
+      }
     },
     {
       "year": 1986,
@@ -3861,7 +5201,17 @@
       "uri_tidal": "tidal://track/1032",
       "uri_deezer": "deezer://track/6067352",
       "fun_fact_nl": "Lauper ontdeed het originele arrangement van opsmuk tot een simpele pianoballade en het werd een krachtige hymne voor de LGBTQ+-gemeenschap.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM18600632",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1452434657",
+        "de": "applemusic://track/1452434657",
+        "gb": "applemusic://track/1452434657",
+        "fr": "applemusic://track/1452434657",
+        "es": "applemusic://track/1452434657",
+        "nl": "applemusic://track/1452434657",
+        "it": "applemusic://track/1452434657"
+      }
     },
     {
       "year": 1986,
@@ -3890,7 +5240,17 @@
       "uri_tidal": "tidal://track/236278191",
       "uri_deezer": "deezer://track/4298172",
       "fun_fact_nl": "Dit Franse synthpopnummer werd een grote hit in heel Europa en Japan en verkocht meer dan 6 miljoen exemplaren. Ondanks het succes bleef Desireless grotendeels een eenaggers.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEQ858600201",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/322417717",
+        "de": "applemusic://track/322417717",
+        "gb": "applemusic://track/322417717",
+        "fr": "applemusic://track/322417717",
+        "es": "applemusic://track/322417717",
+        "nl": "applemusic://track/322417717",
+        "it": "applemusic://track/322417717"
+      }
     },
     {
       "year": 1986,
@@ -3913,7 +5273,17 @@
       "uri_tidal": "tidal://track/69136573",
       "uri_deezer": "deezer://track/3807061722",
       "fun_fact_nl": "Hoewel het aanvankelijk flopte in het VK, werd 'Oh L'Amour' een enorme hit in heel Europa, vooral in Duitsland, waarmee Erasure's carrière werd gevestigd.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USRHD0900075",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1389132122",
+        "de": null,
+        "gb": null,
+        "fr": null,
+        "es": null,
+        "nl": null,
+        "it": null
+      }
     },
     {
       "year": 1986,
@@ -3938,7 +5308,17 @@
       "uri_tidal": "tidal://track/34452031",
       "uri_deezer": "deezer://track/14637102",
       "fun_fact_nl": "De muziekvideo toonde Spitting Image-poppen die wereldleiders en de band caricaturiseerden en won de MTV VMA voor Best Concept Video in 1987.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USRHD0900223",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/309747610",
+        "de": "applemusic://track/309747610",
+        "gb": "applemusic://track/309747610",
+        "fr": "applemusic://track/309747610",
+        "es": "applemusic://track/309747610",
+        "nl": "applemusic://track/309747610",
+        "it": "applemusic://track/309747610"
+      }
     },
     {
       "year": 1986,
@@ -3961,7 +5341,17 @@
       "uri_tidal": "tidal://track/34452030",
       "uri_deezer": "deezer://track/14638217",
       "fun_fact_nl": "De volledige albumversie is meer dan 9 minuten lang. Een verkorte versie werd gebruikt in een Michelob-bierreclame, wat hielp het nummer 3 te bereiken op de Billboard Hot 100.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAAA0700781",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/919919486",
+        "de": "applemusic://track/263065077",
+        "gb": "applemusic://track/263065077",
+        "fr": "applemusic://track/263065077",
+        "es": "applemusic://track/263065077",
+        "nl": "applemusic://track/263065077",
+        "it": "applemusic://track/263065077"
+      }
     },
     {
       "year": 1986,
@@ -3988,7 +5378,17 @@
       "uri_tidal": "tidal://track/18004852",
       "uri_deezer": "deezer://track/16513318",
       "fun_fact_nl": "Gianna Nannini's doorbraakhit vestigde haar als Italië's vooraanstaande vrouwelijke rockzangeres. Haar hese stem en energieke optreedstijl beïnvloedden een generatie Italiaanse vrouwelijke artiesten.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "ITB001500273",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1048058595",
+        "de": "applemusic://track/1048058595",
+        "gb": "applemusic://track/1048058595",
+        "fr": "applemusic://track/1048058595",
+        "es": "applemusic://track/1048058595",
+        "nl": "applemusic://track/1048058595",
+        "it": "applemusic://track/1048058595"
+      }
     },
     {
       "year": 1986,
@@ -4013,7 +5413,17 @@
       "uri_tidal": "tidal://track/1919983",
       "uri_deezer": "deezer://track/2221501",
       "fun_fact_nl": "Dit anthemische nummer werd Australiës onofficiële volkslied en bereikte nummer 1 in meerdere landen, waarmee Farnham werd getransformeerd van tieneridool naar rocklegende.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "AUBM08641001",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/280839461",
+        "de": "applemusic://track/280839461",
+        "gb": "applemusic://track/280839461",
+        "fr": "applemusic://track/280839461",
+        "es": "applemusic://track/280839461",
+        "nl": "applemusic://track/280839461",
+        "it": "applemusic://track/280839461"
+      }
     },
     {
       "year": 1986,
@@ -4041,7 +5451,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=ovo6zwv6DX4",
       "uri_deezer": "deezer://track/905690",
       "fun_fact_nl": "De iconische video toonde Lionel letterlijk dansen op het plafond met behulp van een draaiende kamerdeckor. Het kostte 500.000 dollar om te maken - enorm voor 1986.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMO18682745",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1888548782",
+        "de": "applemusic://track/1888548782",
+        "gb": "applemusic://track/1888548782",
+        "fr": "applemusic://track/1888548782",
+        "es": "applemusic://track/1888548782",
+        "nl": "applemusic://track/1888548782",
+        "it": "applemusic://track/1888548782"
+      }
     },
     {
       "year": 1986,
@@ -4071,7 +5491,17 @@
       "uri_tidal": "tidal://track/1757136",
       "uri_deezer": "deezer://track/678372",
       "fun_fact_nl": "Madonna had dit oorspronkelijk bedoeld voor Michael Jacksons 'Bad'-album. Het nummer was geïnspireerd op haar liefde voor de Spaanse cultuur en bevat Spaanse teksten. Het werd de bestverkochte single van 1987 in Spanje.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USWB19903355",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1829918990",
+        "de": "applemusic://track/1829918990",
+        "gb": "applemusic://track/1829918990",
+        "fr": "applemusic://track/1829918990",
+        "es": "applemusic://track/1829918990",
+        "nl": "applemusic://track/1829918990",
+        "it": "applemusic://track/1829918990"
+      }
     },
     {
       "year": 1986,
@@ -4099,7 +5529,17 @@
       "uri_tidal": "tidal://track/145434581",
       "uri_deezer": "deezer://track/424565232",
       "fun_fact_nl": "Beschouwd als een van de grootste thrash metal-nummers ooit werd dit 8 minuten durende epos van veel radiostations geweerd vanwege zijn lengte. Het bereikte enorme nieuwe populariteit in 2022 nadat het te horen was in Stranger Things.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "QMKHM1600219",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1632029152",
+        "de": "applemusic://track/1632029152",
+        "gb": "applemusic://track/1632029152",
+        "fr": "applemusic://track/1632029152",
+        "es": "applemusic://track/1632029152",
+        "nl": "applemusic://track/1632029152",
+        "it": "applemusic://track/1632029152"
+      }
     },
     {
       "year": 1986,
@@ -4129,7 +5569,17 @@
       "uri_tidal": "tidal://track/15421944",
       "uri_deezer": "deezer://track/6599483",
       "fun_fact_nl": "De titel kwam van een feestje waar iemand Paul Simon 'Al' noemde en zijn vrouw 'Betty'. Het iconische pennyfluitsolo werd gespeeld door Morris Goldberg. Chevy Chase speelde lipsync in de video terwijl Simon opzij stond.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM11002274",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1441343684",
+        "de": "applemusic://track/1441343684",
+        "gb": "applemusic://track/1441343684",
+        "fr": "applemusic://track/1441343684",
+        "es": "applemusic://track/1441343684",
+        "nl": "applemusic://track/1441343684",
+        "it": "applemusic://track/1441343684"
+      }
     },
     {
       "year": 1986,
@@ -4162,7 +5612,17 @@
       "fun_fact_nl": "Paul Simon nam dit album op in Zuid-Afrika tijdens de apartheid, wat zowel lof als kritiek opleverde. Het album won de Grammy voor Album van het Jaar en introduceerde Afrikaanse muziek bij westers publiek.",
       "awards_nl": [
         "Grammy Award voor Album van het Jaar (1987) – Album"
-      ]
+      ],
+      "isrc": "USSM11002255",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1739846276",
+        "de": "applemusic://track/1739846276",
+        "gb": "applemusic://track/1797591382",
+        "fr": "applemusic://track/1739846276",
+        "es": "applemusic://track/1739846276",
+        "nl": "applemusic://track/1739846276",
+        "it": "applemusic://track/1739846276"
+      }
     },
     {
       "year": 1986,
@@ -4239,7 +5699,17 @@
       "uri_tidal": "tidal://track/5095392",
       "uri_deezer": "deezer://track/7868647",
       "fun_fact_nl": "Geschreven voor de soundtrack van 'Highlander', componeerde Roger Taylor dit nummer. De zin komt uit de film en wordt gebruikt door de onsterfelijken als ze magie uitvoeren. Queen verzorgde de volledige soundtrack.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBUM71029621",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1440783385",
+        "de": "applemusic://track/1441459175",
+        "gb": "applemusic://track/1441459175",
+        "fr": "applemusic://track/1441459175",
+        "es": "applemusic://track/1441459175",
+        "nl": "applemusic://track/1441459175",
+        "it": "applemusic://track/1441459175"
+      }
     },
     {
       "year": 1986,
@@ -4275,7 +5745,17 @@
       "fun_fact_nl": "Steve Winwood werkte samen met Chaka Khan voor achtergrondzang op dit nummer. Het won de Grammy voor Record of the Year in 1987 en markeerde Winwoods succesvolle solocarrière na Traffic.",
       "awards_nl": [
         "Grammy Award voor Opname van het Jaar (1987)"
-      ]
+      ],
+      "isrc": "GBAAN0201051",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1600580801",
+        "de": "applemusic://track/1600580801",
+        "gb": "applemusic://track/1600580801",
+        "fr": "applemusic://track/1600580801",
+        "es": "applemusic://track/1600580801",
+        "nl": "applemusic://track/1600580801",
+        "it": "applemusic://track/1600580801"
+      }
     },
     {
       "year": 1986,
@@ -4300,7 +5780,17 @@
       "uri_tidal": "tidal://track/1273660",
       "uri_deezer": "deezer://track/608749",
       "fun_fact_nl": "Het nummer werd geschreven door Prince onder het pseudoniem 'Christopher'. Het bereikte nummer 2 op de Billboard Hot 100, gehouden van nummer 1 door Princes eigen 'Kiss'.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM19802604",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/200007628",
+        "de": "applemusic://track/292101153",
+        "gb": "applemusic://track/292101153",
+        "fr": "applemusic://track/292101153",
+        "es": "applemusic://track/292101153",
+        "nl": "applemusic://track/292101153",
+        "it": "applemusic://track/292101153"
+      }
     },
     {
       "year": 1986,
@@ -4323,7 +5813,17 @@
       "uri_tidal": "tidal://track/1110933",
       "uri_deezer": "deezer://track/884348",
       "fun_fact_nl": "Wayne Hussey richtte The Mission op na het verlaten van The Sisters of Mercy, en 'Wasteland' werd hun signatuurlied, dat het gothic rock-geluid van de late jaren 80 definieerde.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBF089400266",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1444041882",
+        "de": "applemusic://track/1444041882",
+        "gb": "applemusic://track/1444041882",
+        "fr": "applemusic://track/1444041882",
+        "es": "applemusic://track/1444041882",
+        "nl": "applemusic://track/1444041882",
+        "it": "applemusic://track/1444041882"
+      }
     },
     {
       "year": 1987,
@@ -4379,7 +5879,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=YF1R0hc5Q2I",
       "uri_deezer": "deezer://track/664444",
       "fun_fact_nl": "Geschreven door Christine McVie over haar nieuwe relatie. De dromerige productie en gelaagde harmonieën maakten het een hoogtepunt van Tango in the Night.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USWB19900202",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/202272247",
+        "de": "applemusic://track/1294750451",
+        "gb": "applemusic://track/1294750451",
+        "fr": "applemusic://track/1294750451",
+        "es": "applemusic://track/1294750451",
+        "nl": "applemusic://track/1294750451",
+        "it": "applemusic://track/1294750451"
+      }
     },
     {
       "year": 1987,
@@ -4407,7 +5917,17 @@
       "uri_tidal": "tidal://track/16393278",
       "uri_deezer": "deezer://track/46251471",
       "fun_fact_nl": "Dit nummer is een eerbetoon aan Ella Fitzgerald. France Gall was al een ster geworden na het winnen van het Eurovisiesongfestival in 1965. Het nummer werd geproduceerd door haar man Michel Berger en werd haar grootste internationale hit.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "FRZ041200402",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1772877738",
+        "de": "applemusic://track/1772877738",
+        "gb": "applemusic://track/1772877738",
+        "fr": "applemusic://track/1772877738",
+        "es": "applemusic://track/1772877738",
+        "nl": "applemusic://track/1772877738",
+        "it": "applemusic://track/1772877738"
+      }
     },
     {
       "year": 1987,
@@ -4464,7 +5984,17 @@
       "uri_tidal": "tidal://track/1781902",
       "uri_deezer": "deezer://track/626288",
       "fun_fact_nl": "The Indigo Girls' doorbraaksingle gaat over de zoektocht naar betekenis in het leven. Het werd een hymne voor de folk-rock revival en het kenmerkende harmonieuze zang van het duo werd hun handelsmerk.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM10012978",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/201265808",
+        "de": "applemusic://track/201265808",
+        "gb": "applemusic://track/201265808",
+        "fr": "applemusic://track/201265808",
+        "es": "applemusic://track/201265808",
+        "nl": "applemusic://track/201265808",
+        "it": "applemusic://track/201265808"
+      }
     },
     {
       "year": 1987,
@@ -4490,7 +6020,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=7aYxMuLb3h8",
       "uri_deezer": "deezer://track/2192251",
       "fun_fact_nl": "Oorspronkelijk van het album 'Bring the Family'. Werd een standaard gecoverd door Joe Cocker, Jewel en anderen. Vaak gebruikt bij bruiloften en in films.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USAM18704270",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1469573442",
+        "de": "applemusic://track/1469573442",
+        "gb": "applemusic://track/1452215145",
+        "fr": "applemusic://track/1469573442",
+        "es": "applemusic://track/1469573442",
+        "nl": "applemusic://track/1442921368",
+        "it": "applemusic://track/1469573442"
+      }
     },
     {
       "year": 1987,
@@ -4516,7 +6056,17 @@
       "uri_tidal": "tidal://track/11344011",
       "uri_deezer": "deezer://track/13158212",
       "fun_fact_nl": "Het nummer gaat over het teruggeven van landrechten aan de Pintupi-mensen van de Australische Westelijke Woestijn. Het werd een wereldwijde hit en een hymne voor inheemse rechten.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "AUBM00700707",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/557443471",
+        "de": "applemusic://track/557443471",
+        "gb": "applemusic://track/557443471",
+        "fr": "applemusic://track/1308501055",
+        "es": "applemusic://track/557443471",
+        "nl": "applemusic://track/557443471",
+        "it": "applemusic://track/557443471"
+      }
     },
     {
       "year": 1987,
@@ -4546,7 +6096,17 @@
       "uri_tidal": "tidal://track/2451560",
       "uri_deezer": "deezer://track/3122973",
       "fun_fact_nl": "Neil Tennant schreef dit over zijn katholieke opvoeding en schuldgevoelens op school. De opening van het nummer was geïnspireerd op klassieke muziek, en de productie was opzettelijk groots om de dramatische tekst te weerspiegelen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAYE1700799",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1755142580",
+        "de": "applemusic://track/1755142580",
+        "gb": "applemusic://track/1755142580",
+        "fr": "applemusic://track/1755142580",
+        "es": "applemusic://track/1755142580",
+        "nl": "applemusic://track/1755142580",
+        "it": "applemusic://track/1755142580"
+      }
     },
     {
       "year": 1987,
@@ -4571,7 +6131,17 @@
       "uri_tidal": "tidal://track/628462",
       "uri_deezer": "deezer://track/3154047",
       "fun_fact_nl": "Vaak ten onrechte als een liefdeslied beschouwd, beschreef Michael Stipe het als 'een bruut nummer' over het gebruiken van een ander persoon. Het was R.E.M.'s eerste top 10-hit in de VS.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USCA21202402",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1822456158",
+        "de": "applemusic://track/1822456158",
+        "gb": "applemusic://track/1822456158",
+        "fr": "applemusic://track/1822456158",
+        "es": "applemusic://track/1822456158",
+        "nl": "applemusic://track/1822456158",
+        "it": "applemusic://track/1822456158"
+      }
     },
     {
       "year": 1987,
@@ -4601,7 +6171,17 @@
       "uri_tidal": "tidal://track/101982419",
       "uri_deezer": "deezer://track/14408104",
       "fun_fact_nl": "Stock Aitken Watermans grootste hit. In 2007 werd het de basis van 'Rickrolling' - de internetgrap die Rick Astley een hele nieuwe generatie fans bezorgde.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBARL9300135",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1559523359",
+        "de": "applemusic://track/1559523359",
+        "gb": "applemusic://track/1559523359",
+        "fr": "applemusic://track/1559523359",
+        "es": "applemusic://track/1559523359",
+        "nl": "applemusic://track/1559523359",
+        "it": "applemusic://track/1559523359"
+      }
     },
     {
       "year": 1987,
@@ -4624,7 +6204,17 @@
       "uri_tidal": "tidal://track/36257187",
       "uri_deezer": "deezer://track/87769551",
       "fun_fact_nl": "Dit is een cover van Iggy Pops nummer uit 1977. Siouxsies versie bereikte de VK-top 50 en bracht het nummer onder de aandacht van een breder publiek in de goth-scene van de late jaren 80.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBF068625560",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1612708231",
+        "de": "applemusic://track/1612708231",
+        "gb": "applemusic://track/1612708231",
+        "fr": "applemusic://track/1612708231",
+        "es": "applemusic://track/1612708231",
+        "nl": "applemusic://track/1612708231",
+        "it": "applemusic://track/1612708231"
+      }
     },
     {
       "year": 1987,
@@ -4654,7 +6244,17 @@
       "uri_tidal": "tidal://track/2811812",
       "uri_deezer": "deezer://track/602137932",
       "fun_fact_nl": "Geschreven voor de film Mannequin. Het werd Starships tweede en laatste nummer 1-hit en toonde de overgang van de band van rock naar pure pop.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USRC18702968",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1774435572",
+        "de": "applemusic://track/1654717032",
+        "gb": "applemusic://track/1801938589",
+        "fr": "applemusic://track/1801938589",
+        "es": "applemusic://track/1801938589",
+        "nl": "applemusic://track/1801938589",
+        "it": "applemusic://track/1801938589"
+      }
     },
     {
       "year": 1987,
@@ -4682,7 +6282,17 @@
       "uri_tidal": "tidal://track/2570244",
       "uri_deezer": "deezer://track/2525863",
       "fun_fact_nl": "Sting schreef dit nummer over Quentin Crisp, de excentrieke Britse schrijver die naar New York verhuisde. Crisp verschijnt in de muziekvideo. Het jazz-arrangement was beïnvloed door Stings bewondering voor Branford Marsalis.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USAM18700040",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1445286699",
+        "de": "applemusic://track/1440922149",
+        "gb": "applemusic://track/1440922149",
+        "fr": "applemusic://track/1440922149",
+        "es": "applemusic://track/1440922149",
+        "nl": "applemusic://track/1440922149",
+        "it": "applemusic://track/1440922149"
+      }
     },
     {
       "year": 1987,
@@ -4711,7 +6321,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=Ud6sU3AclT4",
       "uri_deezer": "deezer://track/8164657",
       "fun_fact_nl": "Taylor Daynes debuutsingle die haar carrière lanceerde. Het nummer werd een dansklassieker en is door de decennia heen talloze keren geremorxed.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USAR18700173",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1329359020",
+        "de": "applemusic://track/1329359020",
+        "gb": "applemusic://track/1329359020",
+        "fr": "applemusic://track/1329359020",
+        "es": "applemusic://track/1329359020",
+        "nl": "applemusic://track/1329359020",
+        "it": "applemusic://track/1329359020"
+      }
     },
     {
       "year": 1987,
@@ -4734,7 +6354,17 @@
       "uri_tidal": "tidal://track/529746",
       "uri_deezer": "deezer://track/1143636",
       "fun_fact_nl": "Robert Smith schreef dit over een uitstapje naar Beachy Head met zijn toekomstige vrouw Mary. Het wordt beschouwd als een van de grootste liefdesliedjes van de jaren 80 en werd gecoverd door Dinosaur Jr.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USEE18700009",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1836933287",
+        "de": null,
+        "gb": null,
+        "fr": null,
+        "es": null,
+        "nl": null,
+        "it": null
+      }
     },
     {
       "year": 1987,
@@ -4771,7 +6401,17 @@
       "fun_fact_nl": "Whitney Houston wilde dit nummer aanvankelijk niet opnemen, omdat ze vond dat het te vrolijk was. Producer Narada Michael Walden overtuigde haar, en het werd haar vierde opeenvolgende nummer 1-hit, waarbij ze een Grammy won voor Best Female Pop Vocal.",
       "awards_nl": [
         "Grammy Award voor Beste Vrouwelijke Pop Zangprestatie (1988)"
-      ]
+      ],
+      "isrc": "USAR18700121",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1627099927",
+        "de": "applemusic://track/1627099927",
+        "gb": "applemusic://track/1627099927",
+        "fr": "applemusic://track/1627099927",
+        "es": "applemusic://track/1627099927",
+        "nl": "applemusic://track/1627099927",
+        "it": "applemusic://track/892310917"
+      }
     },
     {
       "year": 1988,
@@ -4799,7 +6439,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=P6Agwu_5J14",
       "uri_deezer": "deezer://track/69941234",
       "fun_fact_nl": "Mede-geschreven met haar broer Ricky. Het synthpopnummer markeerde Kim Wilde's terugkeer naar de VK-top 5 na een paar jaar buiten de hitparades.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAAN0300318",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/6762970661",
+        "de": "applemusic://track/6762970661",
+        "gb": "applemusic://track/6762970661",
+        "fr": "applemusic://track/6762970661",
+        "es": "applemusic://track/6762970661",
+        "nl": "applemusic://track/6762970661",
+        "it": "applemusic://track/6762970661"
+      }
     },
     {
       "year": 1988,
@@ -4825,7 +6475,17 @@
       "uri_tidal": "tidal://track/611303",
       "uri_deezer": "deezer://track/623716262",
       "fun_fact_nl": "Melissa Etheridges doorbraakhit toonde haar rauwe, krachtige zangstem. De gepassioneerde zang en eerlijke teksten vestigden haar als een van de meest authentieke vrouwelijke rockstemmen van de late jaren 80.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USIR28800047",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1697383330",
+        "de": "applemusic://track/1697383330",
+        "gb": "applemusic://track/1697383330",
+        "fr": "applemusic://track/1697383330",
+        "es": "applemusic://track/1697383330",
+        "nl": "applemusic://track/1697383330",
+        "it": "applemusic://track/1697383330"
+      }
     },
     {
       "year": 1988,
@@ -4854,7 +6514,17 @@
       "uri_tidal": "tidal://track/3149403",
       "uri_deezer": "deezer://track/4603411",
       "fun_fact_nl": "Michael Jackson schreef dit nummer niet zelf - het werd geschreven door Siedah Garrett en Glen Ballard. Jackson was zo blij met de boodschap dat hij erop stond het op te nemen. Het gospelkoor werd toegevoegd om het inspirerende gevoel te versterken.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM11204986",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/551515758",
+        "de": "applemusic://track/551515758",
+        "gb": "applemusic://track/551515758",
+        "fr": "applemusic://track/551515758",
+        "es": "applemusic://track/551515758",
+        "nl": "applemusic://track/551515758",
+        "it": "applemusic://track/551515758"
+      }
     },
     {
       "year": 1988,
@@ -4883,7 +6553,17 @@
       "uri_tidal": "tidal://track/1291212",
       "uri_deezer": "deezer://track/2463954555",
       "fun_fact_nl": "Dit was Milli Vanilli's grootste hit, die nummer 1 bereikte in de VS. Het schandaal brak uit in 1990 toen bleek dat Rob Pilatus en Fab Morvan op geen van hun opnames echt gezongen hadden - de zang werd verzorgd door sessiemuzikanten.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DED168800007",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1708318836",
+        "de": "applemusic://track/1708318836",
+        "gb": "applemusic://track/1708318836",
+        "fr": "applemusic://track/1708318836",
+        "es": "applemusic://track/1708318836",
+        "nl": "applemusic://track/1708318836",
+        "it": "applemusic://track/1708318836"
+      }
     },
     {
       "year": 1988,
@@ -4913,7 +6593,17 @@
       "uri_tidal": "tidal://track/21283324",
       "uri_deezer": "deezer://track/69070731",
       "fun_fact_nl": "Dit was Milli Vanilli's eerste grote hit voordat het lipsyncschandaal uitbrak. Het nummer bereikte nummer 2 op de Billboard Hot 100. Na het schandaal werd het Grammy van het duo ingetrokken - de enige keer dat dit is gebeurd.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEC738800004",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/317319311",
+        "de": "applemusic://track/317319311",
+        "gb": "applemusic://track/317319311",
+        "fr": "applemusic://track/317319311",
+        "es": "applemusic://track/317319311",
+        "nl": "applemusic://track/317319311",
+        "it": "applemusic://track/317319311"
+      }
     },
     {
       "year": 1988,
@@ -4949,7 +6639,17 @@
       "fun_fact_nl": "Phil Collins schreef dit samen met Lamont Dozier (van Motowns Holland-Dozier-Holland) voor de film 'Buster'. De samenwerking resulteerde in een modern Motown-geluid dat een Golden Globe won voor Best Original Song.",
       "awards_nl": [
         "Golden Globe voor Beste Originele Lied (1989)"
-      ]
+      ],
+      "isrc": "USWI19600240",
+      "uri_apple_music_by_region": {
+        "us": null,
+        "de": "applemusic://track/110687725",
+        "gb": "applemusic://track/110687725",
+        "fr": "applemusic://track/110687725",
+        "es": "applemusic://track/110687725",
+        "nl": "applemusic://track/110687725",
+        "it": "applemusic://track/110687725"
+      }
     },
     {
       "year": 1988,
@@ -4972,7 +6672,17 @@
       "uri_tidal": "tidal://track/3392964",
       "uri_deezer": "deezer://track/1130916",
       "fun_fact_nl": "De aanstekelijke 'hot dog, jumping frog, Albuquerque'-hook was Paddy McAloons parodie op simplistische popteksten, maar het werd toch hun grootste hit.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBARL1900206",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1476850986",
+        "de": "applemusic://track/1476850986",
+        "gb": "applemusic://track/1476850986",
+        "fr": "applemusic://track/1476850986",
+        "es": "applemusic://track/1476850986",
+        "nl": "applemusic://track/1476850986",
+        "it": "applemusic://track/1476850986"
+      }
     },
     {
       "year": 1988,
@@ -4998,7 +6708,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=AQnxufPCDMI",
       "uri_deezer": "deezer://track/3265593",
       "fun_fact_nl": "Het grootste internationale hit van het Belgische duo. De broers Jan en Paul Leyers combineerden soul en pop op een typisch Europese manier.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "BEI018800101",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/715589899",
+        "de": "applemusic://track/1796180237",
+        "gb": "applemusic://track/1796180237",
+        "fr": "applemusic://track/1796180237",
+        "es": "applemusic://track/1796180237",
+        "nl": "applemusic://track/1796180237",
+        "it": "applemusic://track/1796180237"
+      }
     },
     {
       "year": 1988,
@@ -5021,7 +6741,17 @@
       "uri_tidal": "tidal://track/1666608",
       "uri_deezer": "deezer://track/2518361",
       "fun_fact_nl": "Lee Mavers was zo ontevreden over elke opgenomen versie dat de band het drie keer opnieuw opnam. Er wordt gedebatteerd of het nummer over een meisje of over heroïne gaat.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAQT8800001",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1702052707",
+        "de": "applemusic://track/1702052707",
+        "gb": "applemusic://track/1702052707",
+        "fr": "applemusic://track/1702052707",
+        "es": "applemusic://track/1702052707",
+        "nl": "applemusic://track/1702052707",
+        "it": "applemusic://track/1702052707"
+      }
     },
     {
       "year": 1988,
@@ -5044,7 +6774,17 @@
       "uri_tidal": "tidal://track/3946150",
       "uri_deezer": "deezer://track/1098965",
       "fun_fact_nl": "Uitgebracht op dezelfde dag als The Sisters of Mercy's single, wat een rivaliteit aanwakkerde. Het nummer bereikte nummer 12 in het VK en werd een goth rock-hymne.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBF089400269",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1609525294",
+        "de": "applemusic://track/1442450803",
+        "gb": "applemusic://track/1442409356",
+        "fr": "applemusic://track/1442450803",
+        "es": "applemusic://track/1442450803",
+        "nl": "applemusic://track/1442450803",
+        "it": "applemusic://track/1442450803"
+      }
     },
     {
       "year": 1988,
@@ -5074,7 +6814,17 @@
       "uri_tidal": "tidal://track/137251",
       "uri_deezer": "deezer://track/3109247",
       "fun_fact_nl": "The Proclaimers schreven dit nummer in slechts 15 minuten. Het werd een culthit nadat het in de film 'Benny & Joon' uit 1993 voorkwam, waarbij het nummer 3 bereikte in de VS vijf jaar na de originele release.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAYK8800055",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1730001805",
+        "de": "applemusic://track/1730001805",
+        "gb": "applemusic://track/1702790221",
+        "fr": "applemusic://track/1702790221",
+        "es": "applemusic://track/1702790221",
+        "nl": "applemusic://track/1702790221",
+        "it": "applemusic://track/1702790221"
+      }
     },
     {
       "year": 1988,
@@ -5100,7 +6850,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=bYr3OJOXk60",
       "uri_deezer": "deezer://track/79543188",
       "fun_fact_nl": "Van hun album 'The Seventh One'. Hoewel niet zo groot als 'Africa' of 'Rosanna', toonde het de voortdurende vaardigheid van de band om melodieuze rockballades te schrijven.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM18700225",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/890507762",
+        "de": "applemusic://track/890507762",
+        "gb": "applemusic://track/890507762",
+        "fr": "applemusic://track/890507762",
+        "es": "applemusic://track/890507762",
+        "nl": "applemusic://track/890507762",
+        "it": "applemusic://track/890507762"
+      }
     },
     {
       "year": 1988,
@@ -5130,7 +6890,17 @@
       "uri_tidal": "tidal://track/342802",
       "uri_deezer": "deezer://track/2271563",
       "fun_fact_nl": "Tracy Chapman schreef dit autobiografische nummer over haar ervaringen tijdens haar opgroeien in Cleveland. Ze voerde het op tijdens het Nelson Mandela 70th Birthday Concert, waardoor ze van de ene op de andere dag internationaal beroemd werd.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USEE10180719",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/79565507",
+        "de": "applemusic://track/731530386",
+        "gb": "applemusic://track/79565507",
+        "fr": "applemusic://track/731530386",
+        "es": "applemusic://track/731530386",
+        "nl": "applemusic://track/731530386",
+        "it": "applemusic://track/731530386"
+      }
     },
     {
       "year": 1988,
@@ -5156,7 +6926,17 @@
       "uri_tidal": "tidal://track/342801",
       "uri_deezer": "deezer://track/2271562",
       "fun_fact_nl": "Tracy Chapman schreef dit nummer tijdens haar studie aan de Tufts University. De boodschap over sociale verandering resoneerde tijdens het Reagan-tijdperk, hoewel het meer succes had als albumtrack dan als single.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USEE10100547",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/79565502",
+        "de": "applemusic://track/79565502",
+        "gb": "applemusic://track/79565502",
+        "fr": "applemusic://track/79565502",
+        "es": "applemusic://track/79565502",
+        "nl": "applemusic://track/79565502",
+        "it": "applemusic://track/79565502"
+      }
     },
     {
       "year": 1988,
@@ -5179,7 +6959,17 @@
       "uri_tidal": "tidal://track/342805",
       "uri_deezer": "deezer://track/2271566",
       "fun_fact_nl": "Van haar gelijknamige debuutalbum dat meer dan 20 miljoen exemplaren verkocht. Boyzone had later een nummer 2-hit in het VK met hun cover in 1997.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USEE10180931",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/79565526",
+        "de": "applemusic://track/731530457",
+        "gb": "applemusic://track/1451537511",
+        "fr": "applemusic://track/731530457",
+        "es": "applemusic://track/731530457",
+        "nl": "applemusic://track/731530457",
+        "it": "applemusic://track/731530457"
+      }
     },
     {
       "year": 1988,
@@ -5205,7 +6995,17 @@
       "uri_tidal": "tidal://track/61155968",
       "uri_deezer": "deezer://track/125974205",
       "fun_fact_nl": "De Traveling Wilburys-supergroep (Bob Dylan, George Harrison, Jeff Lynne, Roy Orbison, Tom Petty) nam dit op. Roy Orbison stierf voordat de video werd gefilmd - zijn lege schommelstoel verschijnt als eerbetoon.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBLVT1600010",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1870611363",
+        "de": "applemusic://track/1870611363",
+        "gb": "applemusic://track/1870611363",
+        "fr": "applemusic://track/1870611363",
+        "es": "applemusic://track/1870611363",
+        "nl": "applemusic://track/1870611363",
+        "it": "applemusic://track/1870611363"
+      }
     },
     {
       "year": 1989,
@@ -5235,7 +7035,17 @@
       "uri_tidal": "tidal://track/393496",
       "uri_deezer": "deezer://track/674958",
       "fun_fact_nl": "Dit nummer is een eerbetoon aan Elvis Presley, waarbij 'black velvet' zowel naar zijn stem als naar de schilderijen verwees die na zijn dood werden verkocht. Alannah Myles wachtte drie jaar op het juiste nummer voordat dit haar een ster maakte.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "QMFME2521079",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1837530994",
+        "de": null,
+        "gb": null,
+        "fr": null,
+        "es": null,
+        "nl": null,
+        "it": null
+      }
     },
     {
       "year": 1989,
@@ -5264,7 +7074,17 @@
       "uri_tidal": "tidal://track/1268210",
       "uri_deezer": "deezer://track/626123",
       "fun_fact_nl": "Billy Joel schreef dit nummer na een gesprek met een 21-jarige die zei dat er in zijn leven niets was gebeurd. Joel somde 118 historische gebeurtenissen van 1949-1989 op en schreef de tekst vóór de muziek.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM18900217",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/158816462",
+        "de": "applemusic://track/158816462",
+        "gb": "applemusic://track/273854291",
+        "fr": "applemusic://track/158816462",
+        "es": "applemusic://track/158816462",
+        "nl": "applemusic://track/158816462",
+        "it": "applemusic://track/158816462"
+      }
     },
     {
       "year": 1989,
@@ -5293,7 +7113,17 @@
       "uri_tidal": "tidal://track/637081",
       "uri_deezer": "deezer://track/2307289",
       "fun_fact_nl": "De muziekvideo, gefilmd op de USS Missouri, werd verboden door MTV vanwege Chers onthullende outfit. De marine ontving 15.000 wervingsvragen na de uitzending, ondanks de controverse.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USGF18923901",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1694568917",
+        "de": "applemusic://track/1694568917",
+        "gb": "applemusic://track/1694568917",
+        "fr": "applemusic://track/1694568917",
+        "es": "applemusic://track/1694568917",
+        "nl": "applemusic://track/1694568917",
+        "it": "applemusic://track/1694568917"
+      }
     },
     {
       "year": 1989,
@@ -5316,7 +7146,17 @@
       "uri_tidal": "tidal://track/630180",
       "uri_deezer": "deezer://track/1112161",
       "fun_fact_nl": "Dit wrange sociale commentaar werd Del Amitri's grootste VK-hit en bereikte nummer 11. De cynische tekst over moderne apathie resoneerde diep bij het late 80s-publiek.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAAM8901001",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1443874862",
+        "de": "applemusic://track/1443380924",
+        "gb": "applemusic://track/1443380924",
+        "fr": "applemusic://track/1443380924",
+        "es": "applemusic://track/1443380924",
+        "nl": "applemusic://track/1443380924",
+        "it": "applemusic://track/1443380924"
+      }
     },
     {
       "year": 1989,
@@ -5341,7 +7181,17 @@
       "uri_tidal": "tidal://track/334676",
       "uri_deezer": "deezer://track/44586841",
       "fun_fact_nl": "Dit was Elton Johns eerste solo nummer 1 in het VK, ondanks dat hij al hits had gehad sinds het begin van de jaren 70. Het duurde 20 jaar voordat hij een solochart-topper behaalde in zijn thuisland.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBALX8900001",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1452865752",
+        "de": "applemusic://track/1452865752",
+        "gb": "applemusic://track/1452865752",
+        "fr": "applemusic://track/1452865752",
+        "es": "applemusic://track/1452865752",
+        "nl": "applemusic://track/1452865752",
+        "it": "applemusic://track/1452865752"
+      }
     },
     {
       "year": 1989,
@@ -5371,7 +7221,17 @@
       "uri_tidal": "tidal://track/1669822",
       "uri_deezer": "deezer://track/664507",
       "fun_fact_nl": "De muziekvideo veroorzaakte enorme controverse met religieuze beelden, waardoor Pepsi een sponsordeal van 5 miljoen dollar liet vallen. Ondanks de tegenslagen werd het een van Madonna's meest gewaardeerde werken, geprezen om zijn gospel-invloeden.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USWB10002775",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/83445997",
+        "de": "applemusic://track/1802652819",
+        "gb": "applemusic://track/1802652819",
+        "fr": "applemusic://track/1802652819",
+        "es": "applemusic://track/1802652819",
+        "nl": "applemusic://track/1802652819",
+        "it": "applemusic://track/1802652819"
+      }
     },
     {
       "year": 1989,
@@ -5394,7 +7254,17 @@
       "uri_tidal": "tidal://track/1500350",
       "uri_deezer": "deezer://track/3124296",
       "fun_fact_nl": "Dit anthemische nummer over buitenstaanders en dwerftrekkers werd New Model Army's grootste hit en een festivalfavoriet, dat de geest van de late 80s alternatieve scène verlichaamde.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAYE8900071",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1556026542",
+        "de": "applemusic://track/1556026542",
+        "gb": "applemusic://track/1556026542",
+        "fr": "applemusic://track/692604391",
+        "es": "applemusic://track/1556026542",
+        "nl": "applemusic://track/1556026542",
+        "it": "applemusic://track/1556026542"
+      }
     },
     {
       "year": 1989,
@@ -5431,7 +7301,17 @@
       "fun_fact_nl": "Phil Collins schreef dit nummer over dakloosheid nadat hij mensen op straat had zien slapen in Washington DC. Het won de Grammy voor Record of the Year in 1991 en wakkerde een debat aan over sociale verantwoordelijkheid in popmuziek.",
       "awards_nl": [
         "Grammy Award voor Opname van het Jaar (1991)"
-      ]
+      ],
+      "isrc": "USRH11602405",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1148701937",
+        "de": "applemusic://track/1148701937",
+        "gb": "applemusic://track/1148701937",
+        "fr": "applemusic://track/1148701937",
+        "es": "applemusic://track/1148701937",
+        "nl": "applemusic://track/1148701937",
+        "it": "applemusic://track/1148701937"
+      }
     },
     {
       "year": 1989,
@@ -5456,7 +7336,17 @@
       "uri_tidal": "tidal://track/1463626",
       "uri_deezer": "deezer://track/3140534",
       "fun_fact_nl": "Met een lengte van 6:39 was dit een van de langste singles die nummer 1 bereikte in het VK. Het was geïnspireerd op de Troubles in Noord-Ierland en gebaseerd op het Ierse volkslied 'She Moved Through the Fair'.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAAA0200654",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1891847005",
+        "de": "applemusic://track/1891847005",
+        "gb": "applemusic://track/1891847005",
+        "fr": "applemusic://track/1891847005",
+        "es": "applemusic://track/1891847005",
+        "nl": "applemusic://track/1891847005",
+        "it": "applemusic://track/1891847005"
+      }
     },
     {
       "year": 1989,
@@ -5485,7 +7375,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=zTcu7MCtuTs",
       "uri_deezer": "deezer://track/2477046",
       "fun_fact_nl": "Een cover van Harold Melvin & the Blue Notes' hit uit 1972. Mick Hucknalls soulvolle versie bereikte de top in de VS en werd Simply Red's signatuurlied.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBCRL0800110",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1707332188",
+        "de": "applemusic://track/1714984620",
+        "gb": "applemusic://track/1714984620",
+        "fr": "applemusic://track/1714984620",
+        "es": "applemusic://track/1714984620",
+        "nl": "applemusic://track/1714984620",
+        "it": "applemusic://track/1714984620"
+      }
     },
     {
       "year": 1989,
@@ -5508,7 +7408,17 @@
       "uri_tidal": "tidal://track/80812890",
       "uri_deezer": "deezer://track/424565902",
       "fun_fact_nl": "Oleta Adams zong het duetgedeelte nadat Roland Orzabal haar had ontdekt in een hotelbar in Kansas City tijdens een tournee.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBF088900129",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1892531100",
+        "de": "applemusic://track/1892531100",
+        "gb": "applemusic://track/1892531100",
+        "fr": "applemusic://track/1892531100",
+        "es": "applemusic://track/1892531100",
+        "nl": "applemusic://track/1892531100",
+        "it": "applemusic://track/1892531100"
+      }
     },
     {
       "year": 1989,
@@ -5538,7 +7448,17 @@
       "uri_tidal": "tidal://track/2811812",
       "uri_deezer": "deezer://track/2847452",
       "fun_fact_nl": "Susanna Hoffs nam de hoofdzang op in slechts één take terwijl de studiolichten werden gedimd. Het nummer was geïnspireerd op de eeuwige vlam bij het graf van Elvis Presley in Graceland.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM18700216",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/429802577",
+        "de": "applemusic://track/471197726",
+        "gb": "applemusic://track/471197726",
+        "fr": "applemusic://track/211481198",
+        "es": "applemusic://track/211481198",
+        "nl": "applemusic://track/211481198",
+        "it": "applemusic://track/471197726"
+      }
     },
     {
       "year": 1989,
@@ -5561,7 +7481,17 @@
       "uri_tidal": "tidal://track/3939796",
       "uri_deezer": "deezer://track/1143637",
       "fun_fact_nl": "Het nummer beschrijft hoe je wordt opgegeten door een 'spinneman' en was geïnspireerd op Robert Smiths nachtmerries uit zijn kindertijd. De door Tim Pope geredigeerde video won meerdere prijzen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USEE10901457",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1720381137",
+        "de": null,
+        "gb": null,
+        "fr": null,
+        "es": null,
+        "nl": null,
+        "it": null
+      }
     },
     {
       "year": 1989,
@@ -5591,7 +7521,17 @@
       "uri_tidal": "tidal://track/146736",
       "uri_deezer": "deezer://track/3142379",
       "fun_fact_nl": "Oorspronkelijk opgenomen door Bonnie Tyler, werd Tina Turners versie haar signatuurlied. Het wordt wereldwijd gebruikt door sportteams, met name Liverpool FC-fans die het bij elk duel zingen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAYE2000772",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1569624422",
+        "de": "applemusic://track/1569624422",
+        "gb": "applemusic://track/1569624422",
+        "fr": "applemusic://track/1569624422",
+        "es": "applemusic://track/1569624422",
+        "nl": "applemusic://track/1569624422",
+        "it": "applemusic://track/1569624422"
+      }
     },
     {
       "year": 1989,
@@ -5620,7 +7560,17 @@
       "uri_tidal": "tidal://track/77555379",
       "uri_deezer": "deezer://track/2303727",
       "fun_fact_nl": "Tom Petty en Jeff Lynne schreven dit nummer in slechts twee dagen. Petty heeft gezegd dat het een van de gemakkelijkste nummers is die hij ooit schreef - de volledige structuur kwam bijna moeiteloos samen in één middagsessie.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMC18925673",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1388006141",
+        "de": "applemusic://track/1388006141",
+        "gb": "applemusic://track/1388006141",
+        "fr": "applemusic://track/1388006141",
+        "es": "applemusic://track/1388006141",
+        "nl": "applemusic://track/1388006141",
+        "it": "applemusic://track/1388006141"
+      }
     },
     {
       "year": 1990,
@@ -5645,7 +7595,17 @@
       "uri_tidal": "tidal://track/490869826",
       "uri_deezer": "deezer://track/3783098662",
       "fun_fact_nl": "Geïnspireerd op het Kerstbestand van 1914 tijdens WO I werd het nummer een voetbalhymne en werd later gebruikt voor het Europees Kampioenschap van 2004.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USRE19901615",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1543366109",
+        "de": null,
+        "gb": null,
+        "fr": null,
+        "es": null,
+        "nl": null,
+        "it": null
+      }
     },
     {
       "year": 1991,
@@ -5668,7 +7628,17 @@
       "uri_tidal": "tidal://track/1577114",
       "uri_deezer": "deezer://track/3156233",
       "fun_fact_nl": "Deze comeback-single markeerde OMD's terugkeer naar de hitparade na een rustige periode, bereikte nummer 3 in het VK en werd hun grootste hit sinds het midden van de jaren 80.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAAA9100038",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/6762969233",
+        "de": "applemusic://track/6762969233",
+        "gb": "applemusic://track/6762969233",
+        "fr": "applemusic://track/6762969233",
+        "es": "applemusic://track/6762969233",
+        "nl": "applemusic://track/6762969233",
+        "it": "applemusic://track/6762969233"
+      }
     },
     {
       "year": 1991,
@@ -5698,7 +7668,17 @@
       "uri_tidal": "tidal://track/37668277",
       "uri_deezer": "deezer://track/89748761",
       "fun_fact_nl": "Dit Italiaans-Engels duet met Paul Young werd een internationale hit. Zucchero (Italiaans voor 'Suiker') is een van Italië's meest succesvolle artiesten. Het nummer deed er zes jaar over om internationaal populair te worden.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USBKY0509747",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/98318466",
+        "de": "applemusic://track/98318466",
+        "gb": "applemusic://track/98318466",
+        "fr": "applemusic://track/98318466",
+        "es": "applemusic://track/98318466",
+        "nl": "applemusic://track/98318466",
+        "it": "applemusic://track/98318466"
+      }
     }
   ]
 }

--- a/custom_components/beatify/playlists/90er-hits.json
+++ b/custom_components/beatify/playlists/90er-hits.json
@@ -36,7 +36,17 @@
       "uri_tidal": "tidal://track/261597",
       "uri_deezer": "deezer://track/906621",
       "fun_fact_nl": "De band was bang dat deze akoestische ballade hun rockcredibiliteit zou schaden. Het werd hun grootste hit en liet Nuno Bettencourts ingewikkelde vingerpluktechniek zien.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USAM19090005",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1691630008",
+        "de": "applemusic://track/1691630008",
+        "gb": "applemusic://track/1691630008",
+        "fr": "applemusic://track/1691630008",
+        "es": "applemusic://track/1691630008",
+        "nl": "applemusic://track/1691630008",
+        "it": "applemusic://track/1691630008"
+      }
     },
     {
       "year": 1991,
@@ -66,7 +76,17 @@
       "uri_tidal": "tidal://track/77553047",
       "uri_deezer": "deezer://track/136334560",
       "fun_fact_nl": "De titel is een zuidelijk Amerikaans gezegde voor 'aan het einde van zijn Latijn'. Het mandoline-gedreven nummer werd R.E.M.'s grootste hit. Peter Buck leerde mandoline speciaal voor dit nummer.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USWB10402077",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1422693816",
+        "de": "applemusic://track/1422693816",
+        "gb": "applemusic://track/1422693816",
+        "fr": "applemusic://track/1422693816",
+        "es": "applemusic://track/1422693816",
+        "nl": "applemusic://track/1422693816",
+        "it": "applemusic://track/1422693816"
+      }
     },
     {
       "year": 1991,
@@ -95,7 +115,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=4Fc67yQsPqQ",
       "uri_deezer": "deezer://track/724415",
       "fun_fact_nl": "Oorspronkelijk uitgebracht in 1990, werd het in 1991 een wereldwijde hit. Trevor Horns weelderige productie en Seals kenmerkende stem creëerden een tijdloos geluid.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USWB19000051",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1752096300",
+        "de": "applemusic://track/1687229538",
+        "gb": "applemusic://track/1687229538",
+        "fr": "applemusic://track/1687229538",
+        "es": "applemusic://track/1687229538",
+        "nl": "applemusic://track/1687229538",
+        "it": "applemusic://track/1687229538"
+      }
     },
     {
       "year": 1992,
@@ -124,7 +154,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=G_UXvcr22rM",
       "uri_deezer": "deezer://track/1806786907",
       "fun_fact_nl": "Het duo ontmoette elkaar op een metrostation in New York. Hun chemie was instant en dit nummer werd een wereldwijde hit. Helaas stierf Eddie Chacons partner Charles Pettigrew in 2001.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USCA29200183",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1871618419",
+        "de": "applemusic://track/1871618419",
+        "gb": "applemusic://track/1871618419",
+        "fr": "applemusic://track/1871618419",
+        "es": "applemusic://track/1871618419",
+        "nl": "applemusic://track/1871618419",
+        "it": "applemusic://track/1871618419"
+      }
     },
     {
       "year": 1992,
@@ -153,7 +193,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=H7_sqdkaAfo",
       "uri_deezer": "deezer://track/7675405",
       "fun_fact_nl": "Een cover van Chaka Khans hit uit 1978, gemaakt voor de Bodyguard-soundtrack. Whitney's versie bevatte een sample van het origineel en werd opnieuw een enorme hit van dat album.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USAR19200003",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/264388926",
+        "de": "applemusic://track/266234578",
+        "gb": "applemusic://track/266234578",
+        "fr": "applemusic://track/266234578",
+        "es": "applemusic://track/266234578",
+        "nl": "applemusic://track/266234578",
+        "it": "applemusic://track/266234578"
+      }
     },
     {
       "year": 1993,
@@ -182,7 +232,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=HEXWRTEbj1I",
       "uri_deezer": "deezer://track/3786149242",
       "fun_fact_nl": "In 1998 opnieuw iconisch geworden toen het te horen was in het SNL-sketch 'Night at the Roxbury'. De hoofd-wippende dans werd een cultureel fenomeen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEA410500401",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1731434189",
+        "de": "applemusic://track/1731434189",
+        "gb": "applemusic://track/1731434189",
+        "fr": "applemusic://track/1731434189",
+        "es": "applemusic://track/1731434189",
+        "nl": "applemusic://track/1731434189",
+        "it": "applemusic://track/1731434189"
+      }
     },
     {
       "year": 1994,
@@ -211,7 +271,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=4z2DtNW79sQ",
       "uri_deezer": "deezer://track/552942362",
       "fun_fact_nl": "Geschreven voor de film Philadelphia. Won de Oscar voor Beste Originele Nummer en vier Grammy's. Bruce's sobere, drummachinegedreven productie was revolutionair voor hem.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM19303259",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/272899288",
+        "de": "applemusic://track/1733551954",
+        "gb": "applemusic://track/272899288",
+        "fr": "applemusic://track/272899288",
+        "es": "applemusic://track/272899288",
+        "nl": "applemusic://track/272899288",
+        "it": "applemusic://track/272899288"
+      }
     },
     {
       "year": 1994,
@@ -240,7 +310,17 @@
       "uri_tidal": "tidal://track/134858527",
       "uri_deezer": "deezer://track/81105456",
       "fun_fact_nl": "Geschreven met Tim Rice voor The Lion King. Het Zoeloe-openingsrefrein 'Nants ingonyama' betekent 'Hier komt een leeuw'. Won de Golden Globe voor Beste Originele Nummer.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USWD10110145",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1440669547",
+        "de": "applemusic://track/1440669547",
+        "gb": "applemusic://track/714571920",
+        "fr": "applemusic://track/1440669547",
+        "es": "applemusic://track/1440669547",
+        "nl": "applemusic://track/1440669547",
+        "it": "applemusic://track/1440669547"
+      }
     },
     {
       "year": 1994,
@@ -270,7 +350,17 @@
       "uri_tidal": "tidal://track/51161410",
       "uri_deezer": "deezer://track/922014",
       "fun_fact_nl": "Gebaseerd op een gedicht van Wyn Cooper. De ontspannen SoCal-sfeer en de zin over Billy's bar lanceerden Sheryl Crows carrière. Won Record of the Year bij de Grammy's.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USAM19300013",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1636734016",
+        "de": "applemusic://track/1636734016",
+        "gb": "applemusic://track/1636734016",
+        "fr": "applemusic://track/1636734016",
+        "es": "applemusic://track/1636734016",
+        "nl": "applemusic://track/1636734016",
+        "it": "applemusic://track/1636734016"
+      }
     },
     {
       "year": 1994,
@@ -298,7 +388,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=h3gEkwhdXUE",
       "uri_deezer": "deezer://track/2963317",
       "fun_fact_nl": "Een cover van The Troggs' hit uit 1967, opgenomen voor Four Weddings and a Funeral. Het stond 15 weken op nummer 1 in het VK - de band vroeg radiostations uiteindelijk te stoppen met het spelen ervan.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBF089400173",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1697155301",
+        "de": "applemusic://track/1697155301",
+        "gb": "applemusic://track/1697155301",
+        "fr": "applemusic://track/1697155301",
+        "es": "applemusic://track/1890512928",
+        "nl": "applemusic://track/1697155301",
+        "it": "applemusic://track/1697155301"
+      }
     },
     {
       "year": 1995,
@@ -326,7 +426,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=EITLenR3MeQ",
       "uri_deezer": "deezer://track/94107104",
       "fun_fact_nl": "Een duet over leven voor muziek. Opgenomen met meerdere partners waaronder Giorgia (Italiaans) en Hélène Ségara (Frans). Hielp Bocellis internationale crossovercarrière te lanceren.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "ITZ040700161",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1443833241",
+        "de": "applemusic://track/1443833241",
+        "gb": "applemusic://track/1443833241",
+        "fr": "applemusic://track/1443833241",
+        "es": "applemusic://track/1443833241",
+        "nl": "applemusic://track/1443833241",
+        "it": "applemusic://track/1526639885"
+      }
     },
     {
       "year": 1995,
@@ -354,7 +464,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=nVUHHW1tJYA",
       "uri_deezer": "deezer://track/136341100",
       "fun_fact_nl": "Werd 'Time to Say Goodbye' als duet met Sarah Brightman. Een van de bestverkochte singles aller tijden met meer dan 12 miljoen verkochte exemplaren wereldwijd.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "ITZ049700077",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1637173347",
+        "de": "applemusic://track/1637173347",
+        "gb": "applemusic://track/1637173347",
+        "fr": "applemusic://track/1637173347",
+        "es": "applemusic://track/1637173347",
+        "nl": "applemusic://track/1637173347",
+        "it": "applemusic://track/1637173347"
+      }
     },
     {
       "year": 1995,
@@ -382,7 +502,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=wCQfkEkePx8",
       "uri_deezer": "deezer://track/3750996632",
       "fun_fact_nl": "De internationale doorbraak van de Duitse band. Peter Freudenthaler schreef het tijdens een saaie zondagmiddag. De eenvoudige akoestische melodie werd een Europese zomerhymne.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEAF70927221",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1847889648",
+        "de": "applemusic://track/1847889648",
+        "gb": "applemusic://track/1847889648",
+        "fr": "applemusic://track/1847889648",
+        "es": "applemusic://track/1847889648",
+        "nl": "applemusic://track/1847889648",
+        "it": "applemusic://track/1847889648"
+      }
     },
     {
       "year": 1995,
@@ -411,7 +541,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=8WEtxJ4-sh4",
       "uri_deezer": "deezer://track/1043894",
       "fun_fact_nl": "Spreekt over hiv/aids en drugshandel. De onderwaterscènes in de video waren revolutionair voor die tijd. Left Eye rapt over zelfvernietigend gedrag.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USLF29400133",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1777307809",
+        "de": "applemusic://track/1777307809",
+        "gb": "applemusic://track/1777307809",
+        "fr": "applemusic://track/1777307809",
+        "es": "applemusic://track/1777307809",
+        "nl": "applemusic://track/1777307809",
+        "it": "applemusic://track/1777307809"
+      }
     },
     {
       "year": 1996,
@@ -440,7 +580,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=aIXyKmElvv8",
       "uri_deezer": "deezer://track/869547",
       "fun_fact_nl": "Bevat samples van Enya's 'Boadicea' en de Delfonics. Lauryn Hills zang en de spookachtige productie maakten het een van de bepalende nummers van de 90s hip-hop soul.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USVI28900021",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1706251973",
+        "de": "applemusic://track/1706251973",
+        "gb": "applemusic://track/1706251973",
+        "fr": "applemusic://track/1706251973",
+        "es": "applemusic://track/1706251973",
+        "nl": "applemusic://track/1706251973",
+        "it": "applemusic://track/1706251973"
+      }
     },
     {
       "year": 1996,
@@ -469,7 +619,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=4qPOWeA-L5I",
       "uri_deezer": "deezer://track/629335",
       "fun_fact_nl": "Geschreven voor Space Jam. Won drie Grammy's, waaronder Best R&B Song. De inspirerende hymne werd gespeeld bij talloze diploma-uitreikingen en evenementen wereldwijd.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USJI19610437",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/252023397",
+        "de": "applemusic://track/843678544",
+        "gb": "applemusic://track/843678544",
+        "fr": "applemusic://track/843678544",
+        "es": "applemusic://track/843678544",
+        "nl": "applemusic://track/843678544",
+        "it": "applemusic://track/843678544"
+      }
     },
     {
       "year": 1997,
@@ -498,7 +658,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=nPXqkjpXZ_k",
       "uri_deezer": "deezer://track/706847",
       "fun_fact_nl": "De doorbraakhit van de Britse meisjesgroep. De gesproken intro was geïnspireerd op The Verve's 'Bitter Sweet Symphony'. Won twee BRIT Awards.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAAP9700206",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1553089430",
+        "de": "applemusic://track/1512941086",
+        "gb": "applemusic://track/1512941086",
+        "fr": "applemusic://track/1512941086",
+        "es": "applemusic://track/1512941086",
+        "nl": "applemusic://track/1512941086",
+        "it": "applemusic://track/1512941086"
+      }
     },
     {
       "year": 1997,
@@ -526,7 +696,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=ryCIAJRTwJg",
       "uri_deezer": "deezer://track/90946461",
       "fun_fact_nl": "Van de Bean-filmsoundtrack. Het kenmerkende geluid van de Ierse boyband - weelderige harmonieën en romantische teksten - maakte hen tot VK-superstars.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "IEAAA9700014",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1584859582",
+        "de": "applemusic://track/1584859582",
+        "gb": "applemusic://track/1584859582",
+        "fr": "applemusic://track/1584859582",
+        "es": "applemusic://track/1584859582",
+        "nl": "applemusic://track/1584859582",
+        "it": "applemusic://track/1584859582"
+      }
     },
     {
       "year": 1997,
@@ -556,7 +736,17 @@
       "uri_tidal": "tidal://track/194769522",
       "uri_deezer": "deezer://track/2252935",
       "fun_fact_nl": "De doorbraakhit van de Zweedse zanger. Zoon van jazzlegende Don Cherry. Het akoestische nummer ging over het waarderen van het moment voordat iemand vertrekt.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM10027246",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1695903012",
+        "de": null,
+        "gb": null,
+        "fr": null,
+        "es": null,
+        "nl": null,
+        "it": null
+      }
     },
     {
       "year": 1997,
@@ -586,7 +776,17 @@
       "uri_tidal": "tidal://track/1317019",
       "uri_deezer": "deezer://track/88685889",
       "fun_fact_nl": "Geschreven toen de broers respectievelijk 11, 13 en 16 jaar oud waren. De titel komt van doo-wopzang die ze toevoegden. Het gaat over relaties die langzaam wegebben.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMR19786791",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1697206629",
+        "de": "applemusic://track/1697206629",
+        "gb": "applemusic://track/1697206629",
+        "fr": "applemusic://track/1697206629",
+        "es": "applemusic://track/1697206629",
+        "nl": "applemusic://track/1697206629",
+        "it": "applemusic://track/1697206629"
+      }
     },
     {
       "year": 1997,
@@ -615,7 +815,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=7SXKHiPQPhk",
       "uri_deezer": "deezer://track/1939641407",
       "fun_fact_nl": "Geschreven als eerbetoon aan vrienden die aan aids stierven. Ondanks het droevige onderwerp maakte Janet er een opbeurend dansnummer van ter viering van hun levens en hereniging in de hemel.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USVI29700014",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1611460224",
+        "de": "applemusic://track/1689821388",
+        "gb": "applemusic://track/1689821388",
+        "fr": "applemusic://track/1689821388",
+        "es": "applemusic://track/1689821388",
+        "nl": "applemusic://track/1689821388",
+        "it": "applemusic://track/1689821388"
+      }
     },
     {
       "year": 1997,
@@ -643,7 +853,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=taOL5HJdx1A",
       "uri_deezer": "deezer://track/4668258",
       "fun_fact_nl": "De grootste hit van het Newcastle-duo. Het opbeurende pianonummer werd synoniem met het feel-good 90s-popgeluid. Veel gebruikt in tv en film.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBALS9700072",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1692115822",
+        "de": "applemusic://track/1692115822",
+        "gb": "applemusic://track/1692115822",
+        "fr": "applemusic://track/1692115822",
+        "es": "applemusic://track/1692115822",
+        "nl": "applemusic://track/1692115822",
+        "it": "applemusic://track/1692115822"
+      }
     },
     {
       "year": 1997,
@@ -671,7 +891,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=PyKpNBAv1Bw",
       "uri_deezer": "deezer://track/992131",
       "fun_fact_nl": "Eigenlijk een cover van een obscuur nummer uit 1995 van Ednaswap. Natalies versie werd een van de meest gedraaide nummers ooit op de Australische radio. Ze was een soapseriester voordat ze muzikant werd.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBARL9700412",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1635638730",
+        "de": "applemusic://track/774761984",
+        "gb": "applemusic://track/1635638730",
+        "fr": "applemusic://track/285296230",
+        "es": "applemusic://track/1635638730",
+        "nl": "applemusic://track/1635638730",
+        "it": "applemusic://track/285296230"
+      }
     },
     {
       "year": 1997,
@@ -699,7 +929,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=luwAMFcc2f8",
       "uri_deezer": "deezer://track/3138729",
       "fun_fact_nl": "Samen geschreven met Guy Chambers in slechts 25 minuten. Het is gekozen tot het beste Britse nummer om op begrafenissen te spelen en blijft Robbies signatuurlied.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAYE9700233",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/725818406",
+        "de": "applemusic://track/1442885469",
+        "gb": "applemusic://track/1440769042",
+        "fr": "applemusic://track/1442885469",
+        "es": "applemusic://track/1442885469",
+        "nl": "applemusic://track/1442885469",
+        "it": "applemusic://track/1442885469"
+      }
     },
     {
       "year": 1997,
@@ -728,7 +968,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=fiBLgEx6svA",
       "uri_deezer": "deezer://track/1038073",
       "fun_fact_nl": "Geschreven voor de gelijknamige film. Bevat samples van Patrice Rushen's 'Forget Me Nots'. Lanceerde Will Smiths reeks van filmgerelateerde hits.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM19700762",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/309484308",
+        "de": "applemusic://track/309484308",
+        "gb": "applemusic://track/309484308",
+        "fr": "applemusic://track/309484308",
+        "es": "applemusic://track/309484308",
+        "nl": "applemusic://track/309484308",
+        "it": "applemusic://track/309484308"
+      }
     },
     {
       "year": 1998,
@@ -756,7 +1006,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=7eul_Vt6SZY",
       "uri_deezer": "deezer://track/2203328",
       "fun_fact_nl": "Van de musical Whistle Down the Wind van Andrew Lloyd Webber. Werd Boyzones grootste VK-hit en een karaoke-favoriet.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAKW9800269",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1612523682",
+        "de": "applemusic://track/1612523682",
+        "gb": "applemusic://track/1612523682",
+        "fr": "applemusic://track/1612523682",
+        "es": "applemusic://track/1612523682",
+        "nl": "applemusic://track/1443364301",
+        "it": "applemusic://track/1612523682"
+      }
     },
     {
       "year": 1998,
@@ -786,7 +1046,17 @@
       "uri_tidal": "tidal://track/243218",
       "uri_deezer": "deezer://track/786717",
       "fun_fact_nl": "Pionierde het gebruik van Auto-Tune als bewust effect, nu het 'Cher-effect' genoemd. Op 52-jarige leeftijd werd ze de oudste vrouw met een nummer 1 in het VK. Het nummer verkocht 11 miljoen exemplaren.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAHT9803002",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1820933069",
+        "de": "applemusic://track/1791940687",
+        "gb": "applemusic://track/1820933069",
+        "fr": "applemusic://track/1683414195",
+        "es": "applemusic://track/1820933069",
+        "nl": "applemusic://track/1820933069",
+        "it": "applemusic://track/1820933069"
+      }
     },
     {
       "year": 1998,
@@ -814,7 +1084,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=BKtrWU4zaaI",
       "uri_deezer": "deezer://track/866829",
       "fun_fact_nl": "Beroemd om de vaak bespotte tekst 'I don't want to see a ghost, it's a sight that I fear most.' Ondanks de kritiek was het een feel-good hit door heel Europa.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBBBL9802010",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/211424460",
+        "de": "applemusic://track/211424460",
+        "gb": "applemusic://track/211424460",
+        "fr": "applemusic://track/211424460",
+        "es": "applemusic://track/211424460",
+        "nl": "applemusic://track/829669334",
+        "it": "applemusic://track/211424460"
+      }
     },
     {
       "year": 1998,
@@ -843,7 +1123,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=KNZH-emehxA",
       "uri_deezer": "deezer://track/731732292",
       "fun_fact_nl": "Geschreven over haar relatie met producer Mutt Lange. Won twee Grammy's. Ironisch genoeg scheidden ze later, maar het nummer blijft een bruiloftsfavoriet.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMR19887499",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1616963931",
+        "de": "applemusic://track/1616963931",
+        "gb": "applemusic://track/1616963931",
+        "fr": "applemusic://track/1616963931",
+        "es": "applemusic://track/1616963931",
+        "nl": "applemusic://track/1616963931",
+        "it": "applemusic://track/1616963931"
+      }
     },
     {
       "year": 1999,
@@ -872,7 +1162,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=FrLequ6dUdM",
       "uri_deezer": "deezer://track/1075781",
       "fun_fact_nl": "Definieerde 'scrub' voor een generatie - een kerel die denkt dat hij geweldig is maar blut is. Het antwoordlied 'No Pigeons' van Sporty Thievz werd een kleine hit.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USLF29900479",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1789171500",
+        "de": "applemusic://track/1799780289",
+        "gb": "applemusic://track/1799780289",
+        "fr": "applemusic://track/1799780289",
+        "es": "applemusic://track/1799780289",
+        "nl": "applemusic://track/1799780289",
+        "it": "applemusic://track/1799780289"
+      }
     },
     {
       "year": 1999,

--- a/custom_components/beatify/playlists/community/90s-2000s-hiphop-bangers.json
+++ b/custom_components/beatify/playlists/community/90s-2000s-hiphop-bangers.json
@@ -42,7 +42,17 @@
       "uri_tidal": "tidal://track/75013968",
       "uri_deezer": "deezer://track/13142607",
       "fun_fact_nl": "Het nummer bevat een prominente sample van Lou Reeds 'Walk on the Wild Side', en Reed ontvangt naar verluidt een groot deel van de royalty's van het nummer.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USJI19000004",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1460077428",
+        "de": "applemusic://track/1460077428",
+        "gb": "applemusic://track/1460077428",
+        "fr": "applemusic://track/1460077428",
+        "es": "applemusic://track/1460077428",
+        "nl": "applemusic://track/1460077428",
+        "it": "applemusic://track/1460077428"
+      }
     },
     {
       "year": 1992,
@@ -73,7 +83,17 @@
       "uri_tidal": "tidal://track/64738938",
       "uri_deezer": "deezer://track/2132919007",
       "fun_fact_nl": "Het nummer was de introductie van Snoop Dogg bij het grote publiek en hielp het G-funk subgenre van hiphop te definiëren met zijn soepele synthesizers en relaxte beats.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USIR19200849",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1676313477",
+        "de": "applemusic://track/1706433034",
+        "gb": "applemusic://track/1676313477",
+        "fr": "applemusic://track/1676313477",
+        "es": "applemusic://track/1676313477",
+        "nl": "applemusic://track/1676313477",
+        "it": "applemusic://track/1676313477"
+      }
     },
     {
       "year": 1993,
@@ -104,7 +124,17 @@
       "uri_tidal": "tidal://track/63827621",
       "uri_deezer": "deezer://track/541322",
       "fun_fact_nl": "De titel staat voor 'Cash Rules Everything Around Me' en het nummer is opgebouwd rond een sample van de soultrack 'As Long As I've Got You' van The Charmels uit 1967.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USRC19300133",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/313078108",
+        "de": "applemusic://track/313078108",
+        "gb": "applemusic://track/313078108",
+        "fr": "applemusic://track/313078108",
+        "es": "applemusic://track/313078108",
+        "nl": "applemusic://track/313078108",
+        "it": "applemusic://track/313078108"
+      }
     },
     {
       "year": 1993,
@@ -135,7 +165,17 @@
       "uri_tidal": "tidal://track/64739070",
       "uri_deezer": "deezer://track/2182691847",
       "fun_fact_nl": "De videoclip werd geregisseerd door Dr. Dre en toont een enorm huisfeest, waarmee het een van de meest iconische hiphopvideo's van de jaren 90 werd en naar verluidt $500.000 kostte om te maken.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USKO10403590",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1676306185",
+        "de": "applemusic://track/1676306185",
+        "gb": "applemusic://track/1676306185",
+        "fr": "applemusic://track/1676306185",
+        "es": "applemusic://track/1676306185",
+        "nl": "applemusic://track/1676306185",
+        "it": "applemusic://track/1676306185"
+      }
     },
     {
       "year": 1994,
@@ -166,7 +206,17 @@
       "uri_tidal": "tidal://track/390061",
       "uri_deezer": "deezer://track/2793753",
       "fun_fact_nl": "Het nummer bevat een sample van 'Juicy Fruit' van Mtume en was een van de eerste voorbeelden van Diddy die herkenbare hits uit het verleden omzette in commercieel hiphop-goud, een formule die hij nog vele malen zou herhalen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USBB40802014",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/301231764",
+        "de": "applemusic://track/301231764",
+        "gb": "applemusic://track/301228947",
+        "fr": "applemusic://track/301228947",
+        "es": "applemusic://track/301228947",
+        "nl": "applemusic://track/301228947",
+        "it": "applemusic://track/301228947"
+      }
     },
     {
       "year": 1994,
@@ -197,7 +247,17 @@
       "uri_tidal": "tidal://track/63801375",
       "uri_deezer": "deezer://track/77183271",
       "fun_fact_nl": "Producent DJ Premier nam de beat in één take op tijdens de sessie, en Nas schreef zijn coupletten naar verluidt in slechts één keer. Het nummer werd nooit als single uitgebracht, maar wordt beschouwd als een van de beste hiphoptracks ooit.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM10017351",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/869256495",
+        "de": "applemusic://track/869256495",
+        "gb": "applemusic://track/869256495",
+        "fr": "applemusic://track/869256495",
+        "es": "applemusic://track/869256495",
+        "nl": "applemusic://track/869256495",
+        "it": "applemusic://track/869256495"
+      }
     },
     {
       "year": 1994,
@@ -235,7 +295,17 @@
       "fun_fact_nl": "Het nummer bevat een sample van 'Between the Sheets' van The Isley Brothers en was de track die Biggie echt vestigde als een crossover-ster, waarmee hij zowel een hiphop- als R&B-publiek bereikte.",
       "awards_nl": [
         "Grammy Award – Beste Rap Soloprestatie (genomineerd)"
-      ]
+      ],
+      "isrc": "USBB40580817",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1801961851",
+        "de": "applemusic://track/1802861585",
+        "gb": "applemusic://track/1802861585",
+        "fr": "applemusic://track/1802861585",
+        "es": "applemusic://track/1802861585",
+        "nl": "applemusic://track/1802861585",
+        "it": "applemusic://track/1802861585"
+      }
     },
     {
       "year": 1995,
@@ -274,7 +344,17 @@
       "fun_fact_nl": "Het nummer werd geschreven voor de soundtrack van de film 'Dangerous Minds' met Michelle Pfeiffer, die ook in de videoclip verschijnt. Het was wereldwijd de bestverkochte single van 1995.",
       "awards_nl": [
         "Grammy Award – Beste Rap Soloprestatie"
-      ]
+      ],
+      "isrc": "USTB10400128",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1604646670",
+        "de": "applemusic://track/1604646670",
+        "gb": "applemusic://track/1604646670",
+        "fr": "applemusic://track/1604646670",
+        "es": "applemusic://track/1604646670",
+        "nl": "applemusic://track/1604646670",
+        "it": "applemusic://track/1604646670"
+      }
     },
     {
       "year": 1996,
@@ -306,7 +386,17 @@
       "uri_tidal": "tidal://track/35752287",
       "uri_deezer": "deezer://track/65163036",
       "fun_fact_nl": "De videoclip was geïnspireerd op Mad Max Beyond Thunderdome en werd geregisseerd door Hype Williams. Het werd gefilmd in de woestijn van Californië en toont een post-apocalyptische setting in het jaar 2095.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USUG10702628",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1440784906",
+        "de": "applemusic://track/1440764598",
+        "gb": "applemusic://track/1440764598",
+        "fr": "applemusic://track/1440764598",
+        "es": "applemusic://track/1440764598",
+        "nl": "applemusic://track/1440764598",
+        "it": "applemusic://track/1440764598"
+      }
     },
     {
       "year": 1996,
@@ -337,7 +427,17 @@
       "uri_tidal": "tidal://track/35752270",
       "uri_deezer": "deezer://track/1510293612",
       "fun_fact_nl": "Dit was het openingsnummer van 2Pacs dubbelalbum 'All Eyez on Me' en werd kort na zijn vrijlating uit de gevangenis opgenomen, waarbij rauwe energie en uitdagendheid werden gekanaliseerd in wat velen beschouwen als zijn krachtigste track.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USKO10403591",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1588480731",
+        "de": "applemusic://track/1588480731",
+        "gb": "applemusic://track/1588480731",
+        "fr": "applemusic://track/1588480731",
+        "es": "applemusic://track/1588480731",
+        "nl": "applemusic://track/1588480731",
+        "it": "applemusic://track/1588480731"
+      }
     },
     {
       "year": 1996,
@@ -368,7 +468,17 @@
       "uri_tidal": "tidal://track/63801537",
       "uri_deezer": "deezer://track/1015332",
       "fun_fact_nl": "Het nummer bevat Lauryn Hill op de hook en samples van Kurtis Blow's track 'If I Ruled the World' uit 1985, waarmee een brug werd geslagen tussen old-school en midden-jaren '90 hiphop.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM19601375",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/391724141",
+        "de": "applemusic://track/391724141",
+        "gb": "applemusic://track/391724141",
+        "fr": "applemusic://track/391724141",
+        "es": "applemusic://track/391724141",
+        "nl": "applemusic://track/391724141",
+        "it": "applemusic://track/391724141"
+      }
     },
     {
       "year": 1997,
@@ -400,7 +510,17 @@
       "uri_tidal": "tidal://track/34449417",
       "uri_deezer": "deezer://track/3616651",
       "fun_fact_nl": "Dit was de eerste single van 'Life After Death' en bereikte de eerste plaats slechts twee weken na de tragische moord op Biggie, waarmee het een postume nummer 1-hit werd.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USBB40706425",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1694671572",
+        "de": "applemusic://track/1694671572",
+        "gb": "applemusic://track/1694671572",
+        "fr": "applemusic://track/1694671572",
+        "es": "applemusic://track/1694671572",
+        "nl": "applemusic://track/1694671572",
+        "it": "applemusic://track/1694671572"
+      }
     },
     {
       "year": 1998,
@@ -439,7 +559,17 @@
       "fun_fact_nl": "De videoclip toont een split-screen met twee tijdperken: 1967 en 1998, waarin Lauryn Hill optreedt in outfits die passen bij de betreffende periode. Het was het eerste nummer van een vrouwelijke artiest dat debuteerde op nummer één in de Billboard Hot 100.",
       "awards_nl": [
         "Grammy Award – Beste Vrouwelijke R&B Zangprestatie"
-      ]
+      ],
+      "isrc": "USSM19802337",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1276760748",
+        "de": "applemusic://track/1276760748",
+        "gb": "applemusic://track/1276760748",
+        "fr": "applemusic://track/1276760748",
+        "es": "applemusic://track/1276760748",
+        "nl": "applemusic://track/1276760748",
+        "it": "applemusic://track/1276760748"
+      }
     },
     {
       "year": 1998,
@@ -470,7 +600,17 @@
       "uri_tidal": "tidal://track/35752348",
       "uri_deezer": "deezer://track/910693",
       "fun_fact_nl": "Het nummer werd postuum uitgebracht in 1998, bevat een sample van 'The Way It Is' van Bruce Hornsby en behandelt racisme en sociaal onrecht. Het werd oorspronkelijk opgenomen in 1992, maar werd na de dood van Tupac bewerkt met extra productie.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USIR10110269",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1440764593",
+        "de": "applemusic://track/1440764593",
+        "gb": "applemusic://track/1440764593",
+        "fr": "applemusic://track/1440764593",
+        "es": "applemusic://track/1440764593",
+        "nl": "applemusic://track/1440764593",
+        "it": "applemusic://track/1440764593"
+      }
     },
     {
       "year": 1998,
@@ -509,7 +649,17 @@
       "fun_fact_nl": "Het nummer bevat op beroemde wijze een sample van het koor van 'It's the Hard Knock Life' uit de musical Annie. Jay-Z vreesde aanvankelijk dat de sample hem 'zacht' zou doen lijken, maar het werd een van zijn grootste hits.",
       "awards_nl": [
         "Grammy Award – Beste Rapalbum (voor Vol. 2... Hard Knock Life)"
-      ]
+      ],
+      "isrc": "USRL19800899",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1440913399",
+        "de": "applemusic://track/1440913399",
+        "gb": "applemusic://track/1440913399",
+        "fr": "applemusic://track/1440913399",
+        "es": "applemusic://track/1440913399",
+        "nl": "applemusic://track/1440913399",
+        "it": "applemusic://track/1440913399"
+      }
     },
     {
       "year": 1999,
@@ -541,7 +691,17 @@
       "uri_tidal": "tidal://track/2530346",
       "uri_deezer": "deezer://track/128743581",
       "fun_fact_nl": "Hoewel het op naam van Dr. Dre staat, werd de tekst feitelijk geschreven door Jay-Z. De iconische pianoriff werd gecomponeerd door Scott Storch, die het live op een keyboard speelde tijdens de opnamesessie.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USIR19905031",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1527145027",
+        "de": "applemusic://track/1469575628",
+        "gb": "applemusic://track/1469575628",
+        "fr": "applemusic://track/1469575628",
+        "es": "applemusic://track/1469575628",
+        "nl": "applemusic://track/1469575628",
+        "it": "applemusic://track/1469575628"
+      }
     },
     {
       "year": 1999,
@@ -580,7 +740,17 @@
       "fun_fact_nl": "Hoewel het nooit de top 20 van de Billboard Hot 100 bereikte, werd het nummer een van de meest herkenbare party-anthems van de late jaren '90 en was het te horen in talloze films en tv-shows.",
       "awards_nl": [
         "Grammy Award – Beste Rap Soloprestatie (genomineerd)"
-      ]
+      ],
+      "isrc": "USDJ20010705",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1700354890",
+        "de": "applemusic://track/1700354890",
+        "gb": "applemusic://track/1700354890",
+        "fr": "applemusic://track/1700354890",
+        "es": "applemusic://track/1700354890",
+        "nl": "applemusic://track/1700354890",
+        "it": "applemusic://track/1700354890"
+      }
     },
     {
       "year": 2000,
@@ -625,7 +795,17 @@
         "Grammy Award – Beste Rap Soloprestatie",
         "MTV VMA – Beste Video",
         "MTV VMA – Beste Mannelijke Video"
-      ]
+      ],
+      "isrc": "USIR10000448",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1440866926",
+        "de": "applemusic://track/1443122109",
+        "gb": "applemusic://track/1440866926",
+        "fr": "applemusic://track/1443122109",
+        "es": "applemusic://track/1443122109",
+        "nl": "applemusic://track/1443122109",
+        "it": "applemusic://track/1443122109"
+      }
     },
     {
       "year": 2000,
@@ -664,7 +844,17 @@
       "fun_fact_nl": "Andre 3000 schreef het nummer als verontschuldiging aan de moeder van Erykah Badu na zijn breuk met Badu. 'Ms. Jackson' in het nummer verwijst naar de moeder van Badu, en Erykah zou hebben gereageerd met haar eigen track.",
       "awards_nl": [
         "Grammy Award – Beste Rapprestatie door Duo of Groep"
-      ]
+      ],
+      "isrc": "USLF20000357",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1741741469",
+        "de": "applemusic://track/1741741469",
+        "gb": "applemusic://track/1741741469",
+        "fr": "applemusic://track/1741741469",
+        "es": "applemusic://track/1741741469",
+        "nl": "applemusic://track/1741741469",
+        "it": "applemusic://track/1741741469"
+      }
     },
     {
       "year": 2001,
@@ -703,7 +893,17 @@
       "fun_fact_nl": "Timbaland produceerde de track met een tumbi, een Indiaas instrument, waarmee hij een van de meest kenmerkende beats in de geschiedenis van de hiphop creëerde. Het nummer werd in één sessie opgenomen en Missy improviseerde een groot deel van de tekst.",
       "awards_nl": [
         "Grammy Award – Beste Rap Soloprestatie"
-      ]
+      ],
+      "isrc": "USEW20100037",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1870767889",
+        "de": "applemusic://track/1870767889",
+        "gb": "applemusic://track/1870767889",
+        "fr": "applemusic://track/1870767889",
+        "es": "applemusic://track/1870767889",
+        "nl": "applemusic://track/1870767889",
+        "it": "applemusic://track/1870767889"
+      }
     },
     {
       "year": 2001,
@@ -735,7 +935,17 @@
       "uri_tidal": "tidal://track/614493",
       "uri_deezer": "deezer://track/7292333",
       "fun_fact_nl": "In het nummer is City Spud te horen, een lid van Nelly's groep de St. Lunatics, die zijn couplet opnam terwijl hij in de gevangenis zat. Het bevat een sample van 'Heart of Rock & Roll' van Huey Lewis and the News.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USUR10000172",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1443177039",
+        "de": "applemusic://track/1442689014",
+        "gb": "applemusic://track/1443291289",
+        "fr": "applemusic://track/1440782622",
+        "es": "applemusic://track/1442689014",
+        "nl": "applemusic://track/1442689014",
+        "it": "applemusic://track/1442689014"
+      }
     },
     {
       "year": 2001,
@@ -766,7 +976,17 @@
       "uri_tidal": "tidal://track/3733177",
       "uri_deezer": "deezer://track/925151552",
       "fun_fact_nl": "Busta Rhymes staat bekend om zijn ongelooflijk snelle rapstijl, en deze track toont zijn razendsnelle flow. Het nummer was een van de eerste grote hiphoptracks die intensief werd gedraaid op MTV2.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USJAY0100419",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1511197967",
+        "de": "applemusic://track/1511197967",
+        "gb": "applemusic://track/255170632",
+        "fr": "applemusic://track/1511197967",
+        "es": "applemusic://track/255170632",
+        "nl": "applemusic://track/255170632",
+        "it": "applemusic://track/255170632"
+      }
     },
     {
       "year": 2002,
@@ -805,7 +1025,17 @@
       "fun_fact_nl": "Het nummer bevat talloze verwijzingen naar de popcultuur en parodieën, waaronder steken onder water naar Limp Bizkit, Moby, Dick Cheney en Lynne Cheney. De videoclip toont Eminem als een superheld genaamd 'Rap Boy'.",
       "awards_nl": [
         "Grammy Award – Beste Muziekvideo"
-      ]
+      ],
+      "isrc": "USIR10211038",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1625004633",
+        "de": "applemusic://track/1625004633",
+        "gb": "applemusic://track/1625004633",
+        "fr": "applemusic://track/1625004633",
+        "es": "applemusic://track/1625004633",
+        "nl": "applemusic://track/1625004633",
+        "it": "applemusic://track/1625004633"
+      }
     },
     {
       "year": 2002,
@@ -850,7 +1080,17 @@
         "Oscar – Beste Originele Lied",
         "Grammy Award – Beste Rapnummer",
         "Grammy Award – Beste Rap Soloprestatie"
-      ]
+      ],
+      "isrc": "USIR10211559",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1444221569",
+        "de": "applemusic://track/1444221569",
+        "gb": "applemusic://track/1444221569",
+        "fr": "applemusic://track/1444221569",
+        "es": "applemusic://track/1444221569",
+        "nl": "applemusic://track/1444221569",
+        "it": "applemusic://track/1444221569"
+      }
     },
     {
       "year": 2002,
@@ -889,7 +1129,17 @@
       "fun_fact_nl": "Geproduceerd door The Neptunes (Pharrell Williams en Chad Hugo), bevat het nummer een sample van Chuck Browns 'Bustin' Loose'. Het stond in de zomer van 2002 zeven weken op nummer één in de Billboard Hot 100.",
       "awards_nl": [
         "Grammy Award – Beste Mannelijke Rap Soloprestatie"
-      ]
+      ],
+      "isrc": "USUR10200252",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1692116505",
+        "de": "applemusic://track/1692116505",
+        "gb": "applemusic://track/1692116505",
+        "fr": "applemusic://track/1692116505",
+        "es": "applemusic://track/1692116505",
+        "nl": "applemusic://track/1692116505",
+        "it": "applemusic://track/1692116505"
+      }
     },
     {
       "year": 2002,
@@ -970,7 +1220,17 @@
       "awards_nl": [
         "MTV VMA – Beste Rapvideo",
         "MTV VMA – Beste Nieuwe Artiest"
-      ]
+      ],
+      "isrc": "USIR10300033",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1443208134",
+        "de": "applemusic://track/1443208134",
+        "gb": "applemusic://track/1443208134",
+        "fr": "applemusic://track/1443208134",
+        "es": "applemusic://track/1443208134",
+        "nl": "applemusic://track/1443208134",
+        "it": "applemusic://track/1443208134"
+      }
     },
     {
       "year": 2003,
@@ -1002,7 +1262,17 @@
       "uri_tidal": "tidal://track/614448",
       "uri_deezer": "deezer://track/1141674",
       "fun_fact_nl": "De Snoop Dogg-remixversie met Snoop en G-Unit werd populairder dan het origineel. De beat van het nummer werd geproduceerd door Hi-Tek en bevat een kenmerkend strijkersarrangement.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USIR10300020",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1442989696",
+        "de": "applemusic://track/1469577157",
+        "gb": "applemusic://track/1469577157",
+        "fr": "applemusic://track/1469577157",
+        "es": "applemusic://track/1469577157",
+        "nl": "applemusic://track/1469577157",
+        "it": "applemusic://track/1469577157"
+      }
     },
     {
       "year": 2003,
@@ -1041,7 +1311,17 @@
       "fun_fact_nl": "Andre 3000 speelde zelf alle instrumenten op de track, waaronder gitaar, bas en keyboards. Hij zong ook alle zangpartijen in. De regel 'shake it like a Polaroid picture' leidde ertoe dat Polaroid een verklaring afgaf waarin mensen werd geadviseerd hun foto's niet te schudden.",
       "awards_nl": [
         "Grammy Award – Beste Urban/Alternatieve Prestatie"
-      ]
+      ],
+      "isrc": "USAR10301095",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/202883791",
+        "de": "applemusic://track/202883791",
+        "gb": "applemusic://track/202883791",
+        "fr": "applemusic://track/202883791",
+        "es": "applemusic://track/202883791",
+        "nl": "applemusic://track/734446219",
+        "it": "applemusic://track/202883791"
+      }
     },
     {
       "year": 2003,
@@ -1080,7 +1360,17 @@
       "fun_fact_nl": "Het nummer gebruikt drie verschillende beats over de drie coupletten, elk geproduceerd door een andere producent. Rick Rubin produceerde de door rock beïnvloede hoofdbeat, die was geïnspireerd op 'The Big Beat' van Billy Squier.",
       "awards_nl": [
         "Grammy Award – Beste Rap Soloprestatie"
-      ]
+      ],
+      "isrc": "USDJ20301460",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1440984718",
+        "de": "applemusic://track/1440984718",
+        "gb": "applemusic://track/1443307772",
+        "fr": "applemusic://track/1440984718",
+        "es": "applemusic://track/1440984718",
+        "nl": "applemusic://track/1440984718",
+        "it": "applemusic://track/1440984718"
+      }
     },
     {
       "year": 2003,
@@ -1150,7 +1440,17 @@
       "fun_fact_nl": "Het nummer werd geproduceerd door Kanye West voordat hij een grote soloartiest werd. De samenwerking hielp Kanye op de kaart te zetten als een topproducent in de hiphop.",
       "awards_nl": [
         "Grammy Award – Beste Rapnummer (genomineerd)"
-      ]
+      ],
+      "isrc": "USDJ20300765",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1791859224",
+        "de": "applemusic://track/1469576003",
+        "gb": "applemusic://track/1469576003",
+        "fr": "applemusic://track/1469576003",
+        "es": "applemusic://track/1469576003",
+        "nl": "applemusic://track/1469576003",
+        "it": "applemusic://track/1469576003"
+      }
     },
     {
       "year": 2003,
@@ -1182,7 +1482,17 @@
       "uri_tidal": "tidal://track/21012101",
       "uri_deezer": "deezer://track/75063691",
       "fun_fact_nl": "In het nummer is Jay-Z te horen in een couplet en het was de eerste single van 'The Neptunes Present... Clones'. Pharrell schreef het nummer over het ophouden van een schijnvertoning om romantische gevoelens te verbergen, wat destijds ongebruikelijk was in de hiphop.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USAR10300553",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/819130527",
+        "de": "applemusic://track/1006641396",
+        "gb": "applemusic://track/819130527",
+        "fr": "applemusic://track/819130527",
+        "es": "applemusic://track/819130527",
+        "nl": "applemusic://track/819130527",
+        "it": "applemusic://track/819130527"
+      }
     },
     {
       "year": 2004,
@@ -1214,7 +1524,17 @@
       "uri_tidal": "tidal://track/3715217",
       "uri_deezer": "deezer://track/429125352",
       "fun_fact_nl": "Geproduceerd door The Neptunes, is de beat bijna volledig opgebouwd uit tongklikken, vingergeknip en stemgeluiden, met vrijwel geen traditionele instrumenten. Het was de eerste nummer 1-hit van Snoop Dogg in de Billboard Hot 100.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMC10400640",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1669598360",
+        "de": "applemusic://track/1669598360",
+        "gb": "applemusic://track/1442385435",
+        "fr": "applemusic://track/1669598360",
+        "es": "applemusic://track/1669598360",
+        "nl": "applemusic://track/1669598360",
+        "it": "applemusic://track/1669598360"
+      }
     },
     {
       "year": 2005,
@@ -1253,7 +1573,17 @@
       "fun_fact_nl": "Met Jamie Foxx in de hoofdrol bevat het nummer een sample van Ray Charles' 'I Got a Woman'. Bij de release hield het het record voor de meeste digitale downloads verkocht in één week (80.000).",
       "awards_nl": [
         "Grammy Award – Beste Rap Soloprestatie"
-      ]
+      ],
+      "isrc": "USUM70500143",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1443571076",
+        "de": "applemusic://track/1443571076",
+        "gb": "applemusic://track/1443571076",
+        "fr": "applemusic://track/1443571076",
+        "es": "applemusic://track/1443571076",
+        "nl": "applemusic://track/1443571076",
+        "it": "applemusic://track/1443571076"
+      }
     },
     {
       "year": 2007,
@@ -1292,7 +1622,17 @@
       "fun_fact_nl": "Het nummer bevat een prominente sample van Daft Punk's 'Harder, Better, Faster, Stronger'. Kanye vloog naar Parijs om toestemming te krijgen van het Franse duo, die aanvankelijk aarzelden maar het resultaat uiteindelijk geweldig vonden.",
       "awards_nl": [
         "Grammy Award – Beste Rap Soloprestatie"
-      ]
+      ],
+      "isrc": "USUM70741299",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1443830216",
+        "de": "applemusic://track/1445288542",
+        "gb": "applemusic://track/1443830216",
+        "fr": "applemusic://track/1443830216",
+        "es": "applemusic://track/1443830216",
+        "nl": "applemusic://track/1451902446",
+        "it": "applemusic://track/1443830216"
+      }
     },
     {
       "year": 2008,
@@ -1330,7 +1670,17 @@
       "fun_fact_nl": "Geproduceerd door Bangladesh, maakten de minimalistische beat van het nummer en de 'stream-of-consciousness' rapstijl van Lil Wayne het tot een van de meest geremixte tracks in de geschiedenis van de hiphop, met honderden onofficiële versies die online verschenen.",
       "awards_nl": [
         "Grammy Award – Beste Rap Soloprestatie"
-      ]
+      ],
+      "isrc": "USCM50800553",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1440737322",
+        "de": "applemusic://track/1440737322",
+        "gb": "applemusic://track/1679822345",
+        "fr": "applemusic://track/1440737322",
+        "es": "applemusic://track/1440737322",
+        "nl": "applemusic://track/1440737322",
+        "it": "applemusic://track/1440737322"
+      }
     },
     {
       "year": 2008,
@@ -1368,7 +1718,17 @@
       "fun_fact_nl": "Met de overleden Static Major, die tragisch stierf slechts enkele maanden na het opnemen van de hook, werd het nummer Lil Waynes eerste nummer 1-single in de Billboard Hot 100 en hielp het Tha Carter III om in de eerste week meer dan een miljoen exemplaren te verkopen.",
       "awards_nl": [
         "Grammy Award – Beste Rapnummer"
-      ]
+      ],
+      "isrc": "USCM50800380",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1444285143",
+        "de": "applemusic://track/1444403499",
+        "gb": "applemusic://track/1444285143",
+        "fr": "applemusic://track/1444285143",
+        "es": "applemusic://track/1444285143",
+        "nl": "applemusic://track/1444285143",
+        "it": "applemusic://track/1444285143"
+      }
     },
     {
       "year": 2008,
@@ -1399,7 +1759,17 @@
       "uri_tidal": "tidal://track/2015627",
       "uri_deezer": "deezer://track/383742081",
       "fun_fact_nl": "Het nummer debuteerde op nummer één in de Billboard Hot 100, waarmee T.I. de eerste artiest was die dit in 2008 bereikte. Het was geïnspireerd op de levensstijl die hij wilde bieden aan iemand om wie hij gaf.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USAT20803170",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1260881181",
+        "de": "applemusic://track/1260881181",
+        "gb": "applemusic://track/1260881181",
+        "fr": "applemusic://track/1260881181",
+        "es": "applemusic://track/1260881181",
+        "nl": "applemusic://track/1260881181",
+        "it": "applemusic://track/1260881181"
+      }
     },
     {
       "year": 2008,
@@ -1431,7 +1801,17 @@
       "uri_tidal": "tidal://track/2015641",
       "uri_deezer": "deezer://track/383741911",
       "fun_fact_nl": "In het nummer is Rihanna te horen en het bevat een sample van het Roemeense nummer 'Dragostea Din Tei' van O-Zone, beter bekend als de 'Numa Numa' virale internethit. Het stond zes weken op nummer één in de Billboard Hot 100.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USAT20803619",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1260878657",
+        "de": "applemusic://track/1260878657",
+        "gb": "applemusic://track/1260878657",
+        "fr": "applemusic://track/1260878657",
+        "es": "applemusic://track/1260878657",
+        "nl": "applemusic://track/1260878657",
+        "it": "applemusic://track/1260878657"
+      }
     }
   ]
 }

--- a/custom_components/beatify/playlists/community/british-invasion-britpop.json
+++ b/custom_components/beatify/playlists/community/british-invasion-britpop.json
@@ -42,7 +42,17 @@
       "fun_fact_fr": "Paul McCartney a écrit cette chanson alors qu'il n'avait que 20 ans. La première ligne originale était « She was just seventeen, never been a beauty queen » avant que John Lennon ne suggère de la changer pour quelque chose de plus percutant.",
       "uri_deezer": "deezer://track/116348314",
       "fun_fact_nl": "Paul McCartney schreef het nummer toen hij pas 20 jaar oud was. De oorspronkelijke openingszin was 'She was just seventeen, never been a beauty queen', voordat John Lennon voorstelde om er iets emotionelers van te maken.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAYE0601410",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1441164819",
+        "de": "applemusic://track/1441164819",
+        "gb": "applemusic://track/1441164819",
+        "fr": "applemusic://track/1441164819",
+        "es": "applemusic://track/1441164819",
+        "nl": "applemusic://track/1441164819",
+        "it": "applemusic://track/1441164819"
+      }
     },
     {
       "year": 1994,
@@ -101,7 +111,17 @@
       "fun_fact_fr": "Ray Davies a écrit cette satire de la scène mode de Carnaby Street dans le Swinging London. Les chœurs exagérés « oh yes he is » étaient destinés à moquer la prétention des fashion victims.",
       "uri_deezer": "deezer://track/3786086782",
       "fun_fact_nl": "Ray Davies schreef deze satirische kijk op de modescene van Carnaby Street in het Swinging London van de jaren '60. De overdreven 'oh yes he is' achtergrondzang was bedoeld om de gewichtigheid van modevolgers te bespotten.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAJE6600001",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1440526044",
+        "de": "applemusic://track/1440526044",
+        "gb": "applemusic://track/1440526044",
+        "fr": "applemusic://track/1440526044",
+        "es": "applemusic://track/1440526044",
+        "nl": "applemusic://track/1440526044",
+        "it": "applemusic://track/1440526044"
+      }
     },
     {
       "year": 1994,
@@ -139,7 +159,17 @@
       "fun_fact_nl": "De gesproken tekst werd vertolkt door acteur Phil Daniels, bekend van zijn hoofdrol in Quadrophenia. Damon Albarn schreef de coupletten oorspronkelijk als gezongen tekst, maar besloot dat de gortdroge voordracht beter werkte.",
       "awards_nl": [
         "BRIT Award voor Beste Britse Single (1995)"
-      ]
+      ],
+      "isrc": "GBAYE1200960",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/699606039",
+        "de": "applemusic://track/699606039",
+        "gb": "applemusic://track/699606039",
+        "fr": "applemusic://track/699606039",
+        "es": "applemusic://track/699606039",
+        "nl": "applemusic://track/699606039",
+        "it": "applemusic://track/699606039"
+      }
     },
     {
       "year": 1965,
@@ -179,7 +209,17 @@
       "fun_fact_nl": "Keith Richards bedacht de iconische riff in zijn slaap in een hotel in Clearwater, Florida. Hij nam het op met een cassettespeler naast zijn bed en kon het zich de volgende ochtend niet meer herinneren — de rest van de band bevat alleen gesnurk.",
       "awards_nl": [
         "Grammy Hall of Fame (1998)"
-      ]
+      ],
+      "isrc": "USA176510160",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1623247613",
+        "de": "applemusic://track/1706561182",
+        "gb": "applemusic://track/1706561182",
+        "fr": "applemusic://track/1706561182",
+        "es": "applemusic://track/1706561182",
+        "nl": "applemusic://track/1706561182",
+        "it": "applemusic://track/1706561182"
+      }
     },
     {
       "year": 1994,
@@ -209,7 +249,17 @@
       "fun_fact_fr": "Cette chanson est tirée de l'album Give Out But Don't Give Up, enregistré à Memphis avec les légendaires producteurs Tom Dowd et David Was. L'album a marqué un virage radical du son acid house antérieur du groupe vers un rock 'n' roll brut.",
       "uri_deezer": "deezer://track/14882018",
       "fun_fact_nl": "Afkomstig van het album Give Out But Don't Give Up, dat werd opgenomen in Memphis met de legendarische producenten Tom Dowd en David Was. Het album markeerde een dramatische verschuiving van het eerdere acid house-geluid van de band naar rauwe rock-'n-roll.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USWB10106686",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/302164746",
+        "de": null,
+        "gb": null,
+        "fr": null,
+        "es": null,
+        "nl": null,
+        "it": null
+      }
     },
     {
       "year": 1963,
@@ -239,7 +289,17 @@
       "fun_fact_fr": "Cet instrumental a été composé pour le film de Cliff Richard Summer Holiday et a atteint la première place des charts britanniques. C'était l'un des rares hits des Shadows composé par le groupe lui-même plutôt que par des auteurs externes.",
       "uri_deezer": "deezer://track/3102733",
       "fun_fact_nl": "Dit instrumentale nummer werd gecomponeerd voor de Cliff Richard-film Summer Holiday en bereikte de eerste plaats in de Britse hitlijsten. Het was een van de weinige Shadows-hits die door de band zelf was gecomponeerd in plaats van door een externe schrijver.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAYE9500748",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/692090975",
+        "de": "applemusic://track/692090975",
+        "gb": "applemusic://track/692090975",
+        "fr": "applemusic://track/692090975",
+        "es": "applemusic://track/692090975",
+        "nl": "applemusic://track/692090975",
+        "it": "applemusic://track/692090975"
+      }
     },
     {
       "year": 1996,
@@ -298,7 +358,17 @@
       "fun_fact_fr": "Freddie Garrity était célèbre pour ses performances scéniques délirantes, exécutant une danse comique appelée « The Freddie » avec des mouvements de bras et de jambes frénétiques. Avant la musique, il travaillait comme livreur de lait à Manchester.",
       "uri_deezer": "deezer://track/5902460",
       "fun_fact_nl": "Freddie Garrity was beroemd om zijn manische podiumoptredens, waarbij hij een komische dans deed genaamd 'The Freddie' met wilde arm- en beenbewegingen. Voordat hij de muziek in ging, werkte hij als melkboer in Manchester.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USDEI7701277",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/354977803",
+        "de": "applemusic://track/354977803",
+        "gb": "applemusic://track/354977803",
+        "fr": "applemusic://track/354977803",
+        "es": "applemusic://track/354977803",
+        "nl": "applemusic://track/354977803",
+        "it": "applemusic://track/354977803"
+      }
     },
     {
       "year": 1995,
@@ -330,7 +400,17 @@
       "fun_fact_fr": "Malgré son son joyeux et ensoleillé, le compositeur Martin Carr a déclaré que la chanson parlait en fait de la fin d'une relation. Le nom du groupe vient du personnage Boo Radley dans Ne tirez pas sur l'oiseau moqueur de Harper Lee.",
       "uri_deezer": "deezer://track/13157572",
       "fun_fact_nl": "Ondanks het vrolijke, zonnige geluid zei songwriter Martin Carr dat het nummer eigenlijk over het einde van een relatie ging. De naam van de band is ontleend aan het personage Boo Radley in Harper Lee's To Kill a Mockingbird.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBBQY0500011",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/943232554",
+        "de": "applemusic://track/943232554",
+        "gb": "applemusic://track/370145759",
+        "fr": "applemusic://track/370145759",
+        "es": "applemusic://track/370145759",
+        "nl": "applemusic://track/370145759",
+        "it": "applemusic://track/370145759"
+      }
     },
     {
       "year": 1963,
@@ -360,7 +440,17 @@
       "fun_fact_fr": "The Caravelles était un duo féminin de Londres qui a décroché ce succès transatlantique surprise. Elles étaient l'un des rares groupes féminins britanniques à atteindre le Top 5 américain pendant les premiers jours de la British Invasion.",
       "uri_deezer": "deezer://track/4595838",
       "fun_fact_nl": "The Caravelles waren een vrouwelijk duo uit Londen dat deze verrassende trans-Atlantische hit scoorde. Ze waren een van de weinige Britse vrouwelijke acts die in de begindagen van de British Invasion de Amerikaanse Top 5 bereikten.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBYDR1100043",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1505321056",
+        "de": "applemusic://track/1505321056",
+        "gb": "applemusic://track/1505321056",
+        "fr": "applemusic://track/1505321056",
+        "es": "applemusic://track/1505321056",
+        "nl": "applemusic://track/1505321056",
+        "it": "applemusic://track/1505321056"
+      }
     },
     {
       "year": 1994,
@@ -390,7 +480,17 @@
       "fun_fact_fr": "Shampoo était composé de deux amies d'école de Plumstead, à Londres, qui n'avaient que 15 et 16 ans lors de ce hit. La chanson est devenue un énorme succès au Japon où le duo a atteint un statut quasi-idol.",
       "uri_deezer": "deezer://track/3107787",
       "fun_fact_nl": "Shampoo bestond uit twee schoolvriendinnen uit Plumstead, Londen, die pas 15 en 16 jaar oud waren toen ze deze hit scoorden. Het nummer werd een enorme hit in Japan, waar het duo een status als tieneridolen bereikte.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAYE9400030",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1755209117",
+        "de": "applemusic://track/1755209117",
+        "gb": "applemusic://track/1755209117",
+        "fr": "applemusic://track/1755209117",
+        "es": "applemusic://track/1755209117",
+        "nl": "applemusic://track/1755209117",
+        "it": "applemusic://track/1755209117"
+      }
     },
     {
       "year": 1963,
@@ -449,7 +549,17 @@
       "fun_fact_fr": "The Lightning Seeds était essentiellement un projet solo de Ian Broudie, qui était également un producteur très demandé. Il a produit des albums pour The Zutons, Echo & the Bunnymen et The Coral, entre autres.",
       "uri_deezer": "deezer://track/1016966",
       "fun_fact_nl": "The Lightning Seeds was in feite een soloproject van Ian Broudie, die ook een veelgevraagd producent was. Hij produceerde onder andere albums voor The Zutons, Echo & the Bunnymen en The Coral.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBBBM9402001",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1769235345",
+        "de": "applemusic://track/541519821",
+        "gb": "applemusic://track/541519821",
+        "fr": "applemusic://track/541519821",
+        "es": "applemusic://track/541519821",
+        "nl": "applemusic://track/541519821",
+        "it": "applemusic://track/541519821"
+      }
     },
     {
       "year": 1966,
@@ -479,7 +589,17 @@
       "fun_fact_fr": "Avant de former le groupe, Dave Dee était le cadet de police qui s'est rendu sur les lieux de l'accident de voiture qui a tué Eddie Cochran en 1960. C'est lui qui a veillé sur la guitare de Cochran sur les lieux de l'accident.",
       "uri_deezer": "deezer://track/139102181",
       "fun_fact_nl": "Voordat hij de band oprichtte, was Dave Dee de politieagent in opleiding die aanwezig was bij het auto-ongeluk waarbij Eddie Cochran in 1960 om het leven kwam. Hij was degene die zich over de gitaar van Cochran ontfermde op de plaats van het ongeval.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "NLA240305207",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1778321395",
+        "de": "applemusic://track/1778321395",
+        "gb": "applemusic://track/1778321395",
+        "fr": "applemusic://track/1778321395",
+        "es": "applemusic://track/1778321395",
+        "nl": "applemusic://track/1778321395",
+        "it": "applemusic://track/1778321395"
+      }
     },
     {
       "year": 1995,
@@ -511,7 +631,17 @@
       "fun_fact_fr": "Les membres du groupe n'avaient que 18 ans quand c'est devenu un énorme hit. L'équipe de Steven Spielberg les a approchés pour créer une série télévisée autour du groupe dans le style des Monkees, mais ils ont refusé.",
       "uri_deezer": "deezer://track/17542457",
       "fun_fact_nl": "De bandleden waren pas 18 toen dit een enorme hit werd. Het team van Steven Spielberg benaderde hen voor een tv-show rond de band in de stijl van The Monkees, maar ze weigerden.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAYE9500044",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1437332848",
+        "de": "applemusic://track/1437332848",
+        "gb": "applemusic://track/1437332848",
+        "fr": "applemusic://track/1437332848",
+        "es": "applemusic://track/1437332848",
+        "nl": "applemusic://track/1437332848",
+        "it": "applemusic://track/1437332848"
+      }
     },
     {
       "year": 1967,
@@ -611,7 +741,17 @@
       "fun_fact_fr": "C'est une adaptation en français de « If You Gotta Go, Go Now » de Bob Dylan, ce qui en fait l'un des hits les plus improbables des charts britanniques — un groupe de folk-rock britannique chantant une chanson américaine en français avec une touche cajun.",
       "uri_deezer": "deezer://track/2536197",
       "fun_fact_nl": "Dit is een Franstalige bewerking van Bob Dylans 'If You Gotta Go, Go Now', wat het een van de meest onwaarschijnlijke Britse hitlijstsuccessen ooit maakt — een Britse folkrockband die een Amerikaans nummer in het Frans zingt met een cajun-vibe.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAAN6900031",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1442833614",
+        "de": "applemusic://track/1446737327",
+        "gb": "applemusic://track/1444284989",
+        "fr": "applemusic://track/1446737327",
+        "es": "applemusic://track/1446737327",
+        "nl": "applemusic://track/1446737327",
+        "it": "applemusic://track/1446737327"
+      }
     },
     {
       "year": 1990,
@@ -641,7 +781,17 @@
       "fun_fact_fr": "Le chant d'Elizabeth Fraser sur ce titre est largement glossolalique — elle a inventé ses propres sons ressemblant à un langage plutôt que de chanter des paroles conventionnelles. Le groupe de Grangemouth, en Écosse, est considéré comme pionnier du dream pop.",
       "uri_deezer": "deezer://track/2980156221",
       "fun_fact_nl": "De zang van Elizabeth Fraser op dit nummer is grotendeels glossolalie — ze bedacht haar eigen taalachtige klanken in plaats van conventionele teksten te zingen. De band uit Grangemouth, Schotland, wordt beschouwd als pionier van de dream-pop.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBUM70601582",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1712294111",
+        "de": "applemusic://track/1437372819",
+        "gb": "applemusic://track/1437372819",
+        "fr": "applemusic://track/1437372819",
+        "es": "applemusic://track/1437372819",
+        "nl": "applemusic://track/1437372819",
+        "it": "applemusic://track/1437372819"
+      }
     },
     {
       "year": 1964,
@@ -673,7 +823,17 @@
       "fun_fact_fr": "La chanson a été initialement enregistrée par The Exciters et a fait un flop. La version de Manfred Mann a atteint la première place des deux côtés de l'Atlantique, en faisant l'un des plus grands hits de la British Invasion de 1964.",
       "uri_deezer": "deezer://track/1930318867",
       "fun_fact_nl": "Het nummer werd oorspronkelijk opgenomen door The Exciters en flopte. De versie van Manfred Mann bereikte de eerste plaats aan beide kanten van de Atlantische Oceaan, waarmee het een van de grootste British Invasion-hits van 1964 werd.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAYE6400100",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1478805121",
+        "de": "applemusic://track/1478805121",
+        "gb": "applemusic://track/1478805121",
+        "fr": "applemusic://track/1478805121",
+        "es": "applemusic://track/1478805121",
+        "nl": "applemusic://track/1478805121",
+        "it": "applemusic://track/1478805121"
+      }
     },
     {
       "year": 1996,
@@ -703,7 +863,17 @@
       "fun_fact_fr": "Les Super Furry Animals de Cardiff étaient connus pour chanter en gallois et en anglais. Ils ont une fois acheté un vrai char militaire et l'ont utilisé comme véhicule promotionnel, le conduisant à travers les festivals couvert d'artwork du groupe.",
       "uri_deezer": "deezer://track/3750704312",
       "fun_fact_nl": "Super Furry Animals uit Cardiff stonden bekend om het zingen in zowel het Welsh als het Engels. Ze kochten ooit een echte militaire tank en gebruikten die als promotievoertuig, waarmee ze over festivals reden, bedekt met artwork van de band.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM10202478",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1171886512",
+        "de": "applemusic://track/1439681963",
+        "gb": "applemusic://track/1439681963",
+        "fr": "applemusic://track/1439681963",
+        "es": "applemusic://track/1439681963",
+        "nl": "applemusic://track/1439681963",
+        "it": "applemusic://track/1439681963"
+      }
     },
     {
       "year": 1969,
@@ -733,7 +903,17 @@
       "fun_fact_fr": "Écrit par Peter Green pendant l'ère blues britannique de Fleetwood Mac, bien avant que Stevie Nicks et Lindsey Buckingham ne rejoignent le groupe. Le son de guitare de Green sur ce titre était en partie obtenu grâce à un micro de sa Les Paul installé à l'envers.",
       "uri_deezer": "deezer://track/585645222",
       "fun_fact_nl": "Geschreven door Peter Green tijdens het Britse blues-tijdperk van Fleetwood Mac, lang voordat Stevie Nicks en Lindsey Buckingham erbij kwamen. De gitaarklank van Green op dit nummer werd mede bereikt doordat een element in zijn Les Paul achterstevoren was gemonteerd.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USRH11803724",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1441330107",
+        "de": "applemusic://track/1441330107",
+        "gb": "applemusic://track/1441330107",
+        "fr": "applemusic://track/1441330107",
+        "es": "applemusic://track/1441330107",
+        "nl": "applemusic://track/1441330107",
+        "it": "applemusic://track/1441330107"
+      }
     },
     {
       "year": 1993,
@@ -763,7 +943,17 @@
       "fun_fact_fr": "L'album de Suede était à l'époque le premier album le plus rapidement vendu de l'histoire des charts britanniques, battant le record de Frankie Goes to Hollywood. Brett Anderson s'est célèbrement décrit comme un « homme bisexuel qui n'a jamais eu d'expérience homosexuelle ».",
       "uri_deezer": "deezer://track/11977782",
       "fun_fact_nl": "Het debuutalbum van Suede was destijds het snelst verkopende debuut in de Britse hitlijstgeschiedenis, waarmee het record van Frankie Goes to Hollywood werd verbroken. Brett Anderson verklaarde beroemd dat hij een 'biseksuele man was die nooit een homoseksuele ervaring heeft gehad'.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBL2J1000001",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1690349843",
+        "de": "applemusic://track/1689620206",
+        "gb": "applemusic://track/1689620206",
+        "fr": "applemusic://track/1689620206",
+        "es": "applemusic://track/1689620206",
+        "nl": "applemusic://track/1689620206",
+        "it": "applemusic://track/1689620206"
+      }
     },
     {
       "year": 1966,
@@ -793,7 +983,17 @@
       "fun_fact_fr": "The Cryin' Shames était un groupe de Liverpool qui a repris cette chanson de Burt Bacharach et Bob Hilliard, initialement enregistrée par The Drifters. Malgré un succès modeste dans les charts, ils étaient considérés comme l'un des meilleurs groupes live de la scène Merseybeat.",
       "uri_deezer": "deezer://track/889834572",
       "fun_fact_nl": "The Cryin' Shames was een band uit Liverpool die dit nummer van Burt Bacharach en Bob Hilliard coverde, dat oorspronkelijk door The Drifters was opgenomen. Ondanks het bescheiden hitlijstsucces werden ze beschouwd als een van de beste live-acts in de Merseybeat-scene.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBBLY2305062",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1734885423",
+        "de": "applemusic://track/1734885423",
+        "gb": "applemusic://track/1734885423",
+        "fr": "applemusic://track/1734885423",
+        "es": "applemusic://track/1734885423",
+        "nl": "applemusic://track/1734885423",
+        "it": "applemusic://track/1734885423"
+      }
     },
     {
       "year": 1994,
@@ -823,7 +1023,17 @@
       "fun_fact_fr": "Ce duo met en vedette Hope Sandoval de Mazzy Star, dont la voix douce complète parfaitement le chant sombre de Jim Reid. C'est devenu l'un des plus grands hits du groupe au Royaume-Uni.",
       "uri_deezer": "deezer://track/3918332",
       "fun_fact_nl": "Dit duet is met Hope Sandoval van Mazzy Star, wiens dromerige zang de donkere voordracht van Jim Reid perfect aanvult. Het werd een van de grootste Britse hits van de band.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAHT0200222",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1568651593",
+        "de": "applemusic://track/1810177295",
+        "gb": "applemusic://track/1810177295",
+        "fr": "applemusic://track/1810177295",
+        "es": "applemusic://track/1810177295",
+        "nl": "applemusic://track/1810177295",
+        "it": "applemusic://track/1810177295"
+      }
     },
     {
       "year": 1964,
@@ -853,7 +1063,17 @@
       "fun_fact_fr": "Écrite par Burt Bacharach et Hal David, cette chanson a battu la version originale américaine de Dionne Warwick en tête des charts britanniques. Cilla a été célèbrement découverte par Brian Epstein au Cavern Club.",
       "uri_deezer": "deezer://track/3245399",
       "fun_fact_nl": "Dit nummer, geschreven door Burt Bacharach en Hal David, versloeg de originele Amerikaanse versie van Dionne Warwick in de Britse hitlijsten. Cilla werd op beroemde wijze ontdekt door Brian Epstein in de Cavern Club.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAYE0301100",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1219957007",
+        "de": "applemusic://track/1803070172",
+        "gb": "applemusic://track/1803070172",
+        "fr": "applemusic://track/1803070172",
+        "es": "applemusic://track/1803070172",
+        "nl": "applemusic://track/1803070172",
+        "it": "applemusic://track/1803070172"
+      }
     },
     {
       "year": 1995,
@@ -912,7 +1132,17 @@
       "fun_fact_fr": "Cette chanson a gagné un tout nouveau public quand Boy George l'a reprise pour le film homonyme de Neil Jordan en 1992. L'original a été écrit par Geoff Stephens, qui a également écrit « Winchester Cathedral ».",
       "uri_deezer": "deezer://track/5902520",
       "fun_fact_nl": "Dit nummer kreeg een heel nieuw publiek toen Boy George het coverde voor de gelijknamige film van Neil Jordan uit 1992. Het origineel werd geschreven door Geoff Stephens, die ook 'Winchester Cathedral' schreef.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBF076420140",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1443597121",
+        "de": "applemusic://track/1514703251",
+        "gb": "applemusic://track/1440728581",
+        "fr": "applemusic://track/1514703251",
+        "es": "applemusic://track/1514703251",
+        "nl": "applemusic://track/1514703251",
+        "it": "applemusic://track/1514703251"
+      }
     },
     {
       "year": 1994,
@@ -942,7 +1172,17 @@
       "fun_fact_fr": "C'était le single de Morrissey le mieux classé aux États-Unis, atteignant la 46e place du Billboard Hot 100. Le titre est une parfaite encapsulation de son humour caractéristique sur l'obsession non réciproque.",
       "uri_deezer": "deezer://track/10427216",
       "fun_fact_nl": "Dit was de hoogst genoteerde single van Morrissey in de VS en bereikte nummer 46 in de Billboard Hot 100. De titel is een perfecte samenvatting van zijn kenmerkende humor over onbeantwoorde obsessie.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USWB11400744",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/880823903",
+        "de": null,
+        "gb": null,
+        "fr": null,
+        "es": null,
+        "nl": null,
+        "it": null
+      }
     },
     {
       "year": 1967,
@@ -972,7 +1212,17 @@
       "fun_fact_fr": "Produit par Mark Wirtz dans le cadre d'un album concept ambitieux qui n'a jamais été terminé, ce single sur la mort de Grocer Jack est devenu l'un des grands chefs-d'œuvre perdus du pop psychédélique des années 1960.",
       "uri_deezer": "deezer://track/1263050112",
       "fun_fact_nl": "Geproduceerd door Mark Wirtz als onderdeel van een ambitieus conceptalbum dat nooit werd voltooid, werd deze single over de dood van Grocer Jack een van de grote verloren gewaande psychedelische popmeesterwerken van de jaren '60.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAYE6600534",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1556446114",
+        "de": "applemusic://track/1367446298",
+        "gb": "applemusic://track/1367446298",
+        "fr": "applemusic://track/1367446298",
+        "es": "applemusic://track/1367446298",
+        "nl": "applemusic://track/1367446298",
+        "it": "applemusic://track/1367446298"
+      }
     },
     {
       "year": 1996,
@@ -1002,7 +1252,17 @@
       "fun_fact_fr": "Le chant ironique de Neil Hannon, influencé par Scott Walker, a fait de cette chanson le hit révélation du groupe. Le titre est un euphémisme britannique coquin, et la grandeur orchestrale cachait les origines indie.",
       "uri_deezer": "deezer://track/3756263",
       "fun_fact_nl": "De wrange, door Scott Walker beïnvloede voordracht van Neil Hannon maakte dit de doorbraakhit van de band. De titel is een brutaal Brits eufemisme, en de orchestrale grootsheid van het nummer loochende zijn indie-oorsprong.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBBSR9600149",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/163951054",
+        "de": "applemusic://track/163951054",
+        "gb": "applemusic://track/163951054",
+        "fr": "applemusic://track/163951054",
+        "es": "applemusic://track/163951054",
+        "nl": "applemusic://track/163951054",
+        "it": "applemusic://track/163951054"
+      }
     },
     {
       "year": 1965,
@@ -1032,7 +1292,17 @@
       "fun_fact_fr": "À l'origine un instrumental jazz de Mongo Santamaria, Georgie Fame a ajouté des paroles et en a fait un numéro un britannique. Il était l'un des rares artistes blancs britanniques à se produire régulièrement aux soirées du Flamingo Club.",
       "uri_deezer": "deezer://track/1561012",
       "fun_fact_nl": "Oorspronkelijk was dit een jazz-instrumentaal nummer van Mongo Santamaria, maar Georgie Fame voegde er tekst aan toe en maakte er een Britse nummer 1-hit van. Hij was een van de weinige blanke Britse artiesten die regelmatig optraden tijdens de nachtelijke sessies van de Flamingo Club.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "NLF056590002",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1442955549",
+        "de": "applemusic://track/1452323276",
+        "gb": "applemusic://track/1443160450",
+        "fr": "applemusic://track/1452323276",
+        "es": "applemusic://track/1452323276",
+        "nl": "applemusic://track/1452323276",
+        "it": "applemusic://track/1442955549"
+      }
     },
     {
       "year": 1995,
@@ -1064,7 +1334,17 @@
       "fun_fact_fr": "Cette tendre ballade acoustique a consolidé le statut de Weller comme « Modfather » du Britpop. Elle figure sur l'album « Stanley Road », qui est devenu l'album le plus vendu de 1995 au Royaume-Uni.",
       "uri_deezer": "deezer://track/1177222",
       "fun_fact_nl": "Deze tedere akoestische ballade hielp Wellers status als de 'Modfather' van de Britpop te vestigen. Het verscheen op het album 'Stanley Road', dat in 1995 het best verkochte album in het VK werd.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAQT9500046",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1444179654",
+        "de": "applemusic://track/1444179654",
+        "gb": "applemusic://track/1444179654",
+        "fr": "applemusic://track/1444179654",
+        "es": "applemusic://track/1444179654",
+        "nl": "applemusic://track/1444179654",
+        "it": "applemusic://track/1444179654"
+      }
     },
     {
       "year": 1968,
@@ -1096,7 +1376,17 @@
       "fun_fact_fr": "Arthur Brown interprétait célèbrement cette chanson avec un casque en feu sur la tête, faisant de lui l'un des premiers vrais artistes choc du rock. Le cri d'ouverture « I am the god of hellfire! » est l'un des plus iconiques de l'histoire du rock.",
       "uri_deezer": "deezer://track/1560273",
       "fun_fact_nl": "Arthur Brown voerde dit nummer beroemd uit terwijl hij een brandende helm op zijn hoofd droeg, wat hem een van de eerste echte 'shock performers' van de rock maakte. De openingskreet 'I am the god of hellfire!' is een van de meest iconische in de rockgeschiedenis.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBBLY1605630",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1577744764",
+        "de": "applemusic://track/1657674276",
+        "gb": "applemusic://track/1657674276",
+        "fr": "applemusic://track/1657674276",
+        "es": "applemusic://track/1657674276",
+        "nl": "applemusic://track/1657674276",
+        "it": "applemusic://track/1657674276"
+      }
     },
     {
       "year": 1996,
@@ -1129,7 +1419,17 @@
       "fun_fact_fr": "Le chant punk de Keith Flint était initialement juste une voix guide pour la démo, mais le groupe a décidé qu'il capturait parfaitement l'agressivité de la chanson. Le clip était si controversé que la BBC a reçu de nombreuses plaintes.",
       "uri_deezer": "deezer://track/62126191",
       "fun_fact_nl": "De punk-zang van Keith Flint was aanvankelijk slechts bedoeld als demo-zang, maar de band besloot dat het de agressie van het nummer perfect vastlegde. De videoclip was zo controversieel dat de BBC talloze klachten ontving.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBBKS9700080",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/500162235",
+        "de": "applemusic://track/574422946",
+        "gb": "applemusic://track/574422946",
+        "fr": "applemusic://track/574422946",
+        "es": "applemusic://track/574422946",
+        "nl": "applemusic://track/574422946",
+        "it": "applemusic://track/574422946"
+      }
     },
     {
       "year": 1964,
@@ -1170,7 +1470,17 @@
       "fun_fact_nl": "Dit nummer, geschreven door Tony Hatch na een wandeling door de felle lichten van het Londense West End, was het eerste nummer van een Britse vrouwelijke artiest dat de eerste plaats in de VS bereikte tijdens het tijdperk van de British Invasion.",
       "awards_nl": [
         "Grammy Award voor Beste Rock-'n-Roll-opname (1965)"
-      ]
+      ],
+      "isrc": "FRZ196400510",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1676474357",
+        "de": "applemusic://track/1676474357",
+        "gb": "applemusic://track/1676474357",
+        "fr": "applemusic://track/1676474357",
+        "es": "applemusic://track/1676474357",
+        "nl": "applemusic://track/1676474357",
+        "it": "applemusic://track/1676474357"
+      }
     },
     {
       "year": 1995,
@@ -1200,7 +1510,17 @@
       "fun_fact_fr": "Louise Wener de Sleeper était l'une des voix féminines les plus en vue du Britpop et est ensuite devenue une romancière à succès. Le groupe était un pilier de la scène NME du milieu des années 90 aux côtés d'Elastica et Echobelly.",
       "uri_deezer": "deezer://track/13148358",
       "fun_fact_nl": "Louise Wener van Sleeper was een van de meest prominente vrouwelijke stemmen in de Britpop en werd later een succesvol romanschrijfster. De band was een vaste waarde in de NME-scene van midden jaren '90, naast Elastica en Echobelly.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBARL9700485",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/304803354",
+        "de": "applemusic://track/304803354",
+        "gb": "applemusic://track/540074874",
+        "fr": "applemusic://track/304803354",
+        "es": "applemusic://track/304803354",
+        "nl": "applemusic://track/304803354",
+        "it": "applemusic://track/304803354"
+      }
     },
     {
       "year": 1966,
@@ -1230,7 +1550,17 @@
       "fun_fact_fr": "Bien que jamais sortie en single, cette chanson hypnotique de l'album « Sunshine Superman » est devenue l'une des plus reprises de l'ère psychédélique, avec des versions d'Al Kooper à Dr. John.",
       "uri_deezer": "deezer://track/1064285",
       "fun_fact_nl": "Hoewel het nooit als single werd uitgebracht, werd dit hypnotiserende nummer van het album 'Sunshine Superman' een van de meest gecoverde nummers van het psychedelische tijdperk, met versies van iedereen van Al Kooper tot Dr. John.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM10401136",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/516667494",
+        "de": "applemusic://track/516667494",
+        "gb": null,
+        "fr": "applemusic://track/516667494",
+        "es": "applemusic://track/516667494",
+        "nl": "applemusic://track/516667494",
+        "it": "applemusic://track/516667494"
+      }
     },
     {
       "year": 1995,
@@ -1262,7 +1592,17 @@
       "fun_fact_fr": "Collins a enregistré ceci dans son studio à domicile à West Hampstead. L'ancien leader d'Orange Juice a subi deux hémorragies cérébrales en 2005, mais s'est remarquablement rétabli et a continué à faire de la musique.",
       "uri_deezer": "deezer://track/14282849",
       "fun_fact_nl": "Collins nam dit op in zijn thuisstudio in West Hampstead. De voormalige Orange Juice-frontman kreeg in 2005 twee hersenbloedingen, maar herstelde opmerkelijk goed en bleef muziek maken.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GB72T1100001",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/474270145",
+        "de": "applemusic://track/474270145",
+        "gb": "applemusic://track/474270145",
+        "fr": "applemusic://track/474270145",
+        "es": "applemusic://track/474270145",
+        "nl": "applemusic://track/474270145",
+        "it": "applemusic://track/474270145"
+      }
     },
     {
       "year": 1963,
@@ -1292,7 +1632,17 @@
       "fun_fact_fr": "Écrite et enregistrée à l'origine par Chan Romero en 1959, cette version Merseybeat est devenue un classique de la scène de Liverpool. Les Beatles la jouaient aussi au Cavern Club avant que les Swinging Blue Jeans n'en fassent un hit.",
       "uri_deezer": "deezer://track/1787725097",
       "fun_fact_nl": "Oorspronkelijk geschreven en opgenomen door Chan Romero in 1959, werd deze Merseybeat-versie een vast onderdeel van de scene in Liverpool. The Beatles traden er ook mee op in de Cavern Club voordat de Swinging Blue Jeans er een hit van maakten.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAYE6300043",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1629108896",
+        "de": "applemusic://track/1629108896",
+        "gb": "applemusic://track/1629108896",
+        "fr": "applemusic://track/1629108896",
+        "es": "applemusic://track/1629108896",
+        "nl": "applemusic://track/1629108896",
+        "it": "applemusic://track/1629108896"
+      }
     },
     {
       "year": 1994,
@@ -1322,7 +1672,17 @@
       "fun_fact_fr": "Faisant partie du mouvement éphémère « New Wave of New Wave », These Animal Men étaient connus pour leurs concerts provocateurs et leur style androgyne. Le NME les a promus comme l'avenir de la musique guitare britannique.",
       "uri_deezer": "deezer://track/3163898",
       "fun_fact_nl": "Als onderdeel van de kortstondige 'New Wave of New Wave'-beweging stonden These Animal Men bekend om hun confronterende liveshows en androgyne stijl. De NME prees hen aan als de toekomst van de Britse gitaarmuziek.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAAA9401019",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/714771169",
+        "de": "applemusic://track/714771169",
+        "gb": "applemusic://track/714771169",
+        "fr": "applemusic://track/714771169",
+        "es": "applemusic://track/714771169",
+        "nl": "applemusic://track/714771169",
+        "it": "applemusic://track/714771169"
+      }
     },
     {
       "year": 1964,
@@ -1352,7 +1712,17 @@
       "fun_fact_fr": "C'est la première chanson que Mick Jagger et Keith Richards ont jamais écrite, à la suggestion de leur manager Andrew Loog Oldham. Les Rolling Stones ont enregistré leur propre version en 1965.",
       "uri_deezer": "deezer://track/8081273",
       "fun_fact_nl": "Dit was het eerste nummer dat Mick Jagger en Keith Richards ooit schreven, opgesteld op suggestie van hun manager Andrew Loog Oldham. De Rolling Stones namen in 1965 hun eigen versie op.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USA170550020",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1445283208",
+        "de": "applemusic://track/1445283208",
+        "gb": "applemusic://track/1445283208",
+        "fr": "applemusic://track/1445283208",
+        "es": "applemusic://track/1445283208",
+        "nl": "applemusic://track/1445283208",
+        "it": "applemusic://track/1445283208"
+      }
     },
     {
       "year": 1993,
@@ -1381,7 +1751,17 @@
       "fun_fact_fr": "Saint Etienne mélangeait l'indie pop avec la house music et la Northern soul d'une manière typiquement britannique. La chanteuse Sarah Cracknell est devenue une icône de l'indie pop, et le groupe tire son nom du club de football français.",
       "uri_deezer": "deezer://track/362797721",
       "fun_fact_nl": "Saint Etienne mengde indiepop met housemuziek en Northern soul op een uniek Britse wijze. Zangeres Sarah Cracknell werd een indiepop-icoon, en de band vernoemde zich naar de Franse voetbalclub.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBUM70811386",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1241160162",
+        "de": "applemusic://track/1241160162",
+        "gb": "applemusic://track/1241160162",
+        "fr": "applemusic://track/1241160162",
+        "es": "applemusic://track/1241160162",
+        "nl": "applemusic://track/1241160162",
+        "it": "applemusic://track/1241160162"
+      }
     },
     {
       "year": 1968,
@@ -1411,7 +1791,17 @@
       "fun_fact_fr": "Écrite par Bob Dylan et Rick Danko de The Band, cet arrangement jazzy a fait de la chanson un hit du Top 5 britannique. Des décennies plus tard, elle a été réenregistrée comme générique de la sitcom BBC « Absolutely Fabulous ».",
       "uri_deezer": "deezer://track/907669",
       "fun_fact_nl": "Dit nummer, geschreven door Bob Dylan en Rick Danko van The Band, werd door dit jazzy arrangement een Britse Top 5-hit. Decennia later werd het opnieuw opgenomen als titelnummer voor de BBC-sitcom 'Absolutely Fabulous'.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEG932104482",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1604247466",
+        "de": "applemusic://track/1604247466",
+        "gb": "applemusic://track/1604247466",
+        "fr": "applemusic://track/1604247466",
+        "es": "applemusic://track/1604247466",
+        "nl": "applemusic://track/1604247466",
+        "it": "applemusic://track/1604247466"
+      }
     },
     {
       "year": 1995,
@@ -1441,7 +1831,17 @@
       "fun_fact_fr": "Elastica de Justine Frischmann a été l'un des premiers albums les plus rapidement vendus de l'histoire des charts britanniques. Sa relation très médiatisée avec Damon Albarn de Blur l'a placée au centre de l'univers Britpop.",
       "uri_deezer": "deezer://track/97089134",
       "fun_fact_nl": "Elastica, onder leiding van Justine Frischmann, was een van de snelst verkopende debutanten in de Britse hitlijstgeschiedenis. Ze had een veelbesproken relatie met Damon Albarn van Blur, waardoor ze zich in het middelpunt van het Britpop-universum bevond.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USIR10001402",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1443993602",
+        "de": "applemusic://track/1443993602",
+        "gb": null,
+        "fr": "applemusic://track/1443993602",
+        "es": "applemusic://track/1443993602",
+        "nl": "applemusic://track/1443993602",
+        "it": "applemusic://track/1443993602"
+      }
     },
     {
       "year": 1965,
@@ -1471,7 +1871,17 @@
       "fun_fact_fr": "Cette chanson folk poignante a été écrite sur la mort par overdose d'héroïne de l'ami de Jansch, Buck Polly. Elle est devenue l'un des enregistrements folk britanniques les plus influents, inspirant des artistes de Neil Young à Johnny Marr.",
       "uri_deezer": "deezer://track/3761250722",
       "fun_fact_nl": "Dit indringende folknummer werd geschreven over de dood van Jansch' vriend Buck Polly door een overdosis heroïne. Het werd een van de meest invloedrijke Britse folkopnames en inspireerde artiesten van Neil Young tot Johnny Marr.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAJE6500315",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1439722152",
+        "de": "applemusic://track/1439722152",
+        "gb": "applemusic://track/1439722152",
+        "fr": "applemusic://track/1439722152",
+        "es": "applemusic://track/1439722152",
+        "nl": "applemusic://track/1439722152",
+        "it": "applemusic://track/1439722152"
+      }
     },
     {
       "year": 1997,
@@ -1511,7 +1921,17 @@
       "fun_fact_nl": "Richard Ashcroft schreef dit over de strijd van zijn vader tegen een ziekte en de nutteloosheid van medicatie. Het werd de enige Britse nummer 1-hit van The Verve en wordt vaak aangehaald als een van de beste Britse nummers van de jaren '90.",
       "awards_nl": [
         "BRIT Award voor Beste Britse Single (Nomination, 1998)"
-      ]
+      ],
+      "isrc": "GBUM71601819",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1847714076",
+        "de": "applemusic://track/1847714076",
+        "gb": "applemusic://track/1847714076",
+        "fr": "applemusic://track/1847714076",
+        "es": "applemusic://track/1847714076",
+        "nl": "applemusic://track/1847714076",
+        "it": "applemusic://track/1847714076"
+      }
     },
     {
       "year": 1968,
@@ -1541,7 +1961,17 @@
       "fun_fact_fr": "C'était le seul numéro un britannique de The Move, écrit par Roy Wood qui cofonderait plus tard Electric Light Orchestra avec Jeff Lynne. Wood n'aimait apparemment pas la chanson, la trouvant trop commerciale.",
       "uri_deezer": "deezer://track/133203650",
       "fun_fact_nl": "Dit was de enige Britse nummer 1-hit van The Move, geschreven door Roy Wood die later samen met Jeff Lynne Electric Light Orchestra zou oprichten. Wood hield naar verluidt niet van het nummer, omdat hij het te commercieel vond.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GB01A1100294",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1682052171",
+        "de": "applemusic://track/1682052171",
+        "gb": "applemusic://track/1682052171",
+        "fr": "applemusic://track/1682052171",
+        "es": "applemusic://track/1682052171",
+        "nl": "applemusic://track/1682052171",
+        "it": "applemusic://track/1682052171"
+      }
     },
     {
       "year": 1996,
@@ -1571,7 +2001,17 @@
       "fun_fact_fr": "De l'album début « Tigermilk », initialement pressé à seulement 1 000 exemplaires comme projet d'un cours de musique universitaire. Le style d'écriture littéraire et murmuré de Stuart Murdoch a défini le renouveau de l'indie pop de la fin des années 90 depuis Glasgow.",
       "uri_deezer": "deezer://track/17914652",
       "fun_fact_nl": "Afkomstig van het debuutalbum 'Tigermilk', waarvan oorspronkelijk slechts 1.000 exemplaren werden geperst als project voor een muziekopleiding aan de universiteit. De literaire, fluisterende schrijfstijl van Stuart Murdoch definieerde de indiepop-revival uit Glasgow van de late jaren '90.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBCAX9600104",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1589190382",
+        "de": "applemusic://track/516531196",
+        "gb": "applemusic://track/516531196",
+        "fr": "applemusic://track/516531196",
+        "es": "applemusic://track/516531196",
+        "nl": "applemusic://track/516531196",
+        "it": "applemusic://track/516531196"
+      }
     },
     {
       "year": 1967,
@@ -1601,7 +2041,17 @@
       "fun_fact_fr": "The Incredible String Band était les favoris de Paul McCartney et ont été invités à jouer à Woodstock, bien que leur set ait été retardé par la pluie.",
       "uri_deezer": "deezer://track/7446729",
       "fun_fact_nl": "The Incredible String Band waren favorieten van Paul McCartney en werden uitgenodigd om op Woodstock te spelen, hoewel hun optreden werd vertraagd door de regen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USEE11000520",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/397029247",
+        "de": "applemusic://track/397029247",
+        "gb": "applemusic://track/397029247",
+        "fr": "applemusic://track/397029247",
+        "es": "applemusic://track/397029247",
+        "nl": "applemusic://track/397029247",
+        "it": "applemusic://track/397029247"
+      }
     },
     {
       "year": 1997,
@@ -1660,7 +2110,17 @@
       "fun_fact_fr": "Peter Sellers a interprété cette reprise des Beatles dans le style de Laurence Olivier jouant Richard III de Shakespeare. C'était si drôle que même les Beatles l'ont adorée.",
       "uri_deezer": "deezer://track/3102268",
       "fun_fact_nl": "Peter Sellers voerde deze Beatles-cover uit in de stijl van Laurence Olivier die Shakespeare's Richard III vertolkt. Het was zo grappig dat zelfs de Beatles het geweldig vonden.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAYE6500432",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/726215923",
+        "de": "applemusic://track/1801696087",
+        "gb": "applemusic://track/1801696087",
+        "fr": "applemusic://track/1801696087",
+        "es": "applemusic://track/1801696087",
+        "nl": "applemusic://track/1801696087",
+        "it": "applemusic://track/1801696087"
+      }
     },
     {
       "year": 1995,
@@ -1690,7 +2150,17 @@
       "fun_fact_fr": "Cette version lounge easy-listening de « Wonderwall » d'Oasis a failli battre l'original au numéro un. Noel Gallagher lui-même a dit qu'il préférait cette version.",
       "uri_deezer": "deezer://track/436126502",
       "fun_fact_nl": "Deze easy-listening loungeversie van Oasis' 'Wonderwall' versloeg bijna het origineel in de strijd om de eerste plaats. Noel Gallagher zei zelf dat hij de voorkeur gaf aan deze versie.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBANS9600002",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1319969849",
+        "de": "applemusic://track/1319969849",
+        "gb": "applemusic://track/1319969849",
+        "fr": "applemusic://track/1319969849",
+        "es": "applemusic://track/1319969849",
+        "nl": "applemusic://track/1319969849",
+        "it": "applemusic://track/1319969849"
+      }
     },
     {
       "year": 1967,
@@ -1751,7 +2221,17 @@
       "fun_fact_fr": "Le premier single de Placebo a attiré l'attention de David Bowie, qui les a ensuite invités à jouer à son concert d'anniversaire des 50 ans au Madison Square Garden en 1997.",
       "uri_deezer": "deezer://track/1895558247",
       "fun_fact_nl": "De debuutsingle van Placebo trok de aandacht van David Bowie, die hen later uitnodigde om op te treden tijdens zijn concert ter ere van zijn 50ste verjaardag in Madison Square Garden in 1997.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAAA9600241",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/961067976",
+        "de": "applemusic://track/961067976",
+        "gb": "applemusic://track/961067976",
+        "fr": "applemusic://track/961067976",
+        "es": "applemusic://track/961067976",
+        "nl": "applemusic://track/961067976",
+        "it": "applemusic://track/961067976"
+      }
     },
     {
       "year": 1969,
@@ -1781,7 +2261,17 @@
       "fun_fact_fr": "Cette chanson est devenue célèbre comme générique de la série télévisée BBC « Take Three Girls » en 1969. Sa signature rythmique inhabituelle alterne entre 5/8, 7/8 et 6/8.",
       "uri_deezer": "deezer://track/3786480422",
       "fun_fact_nl": "Dit nummer werd in 1969 alom bekend als de titelmuziek van de BBC-televisieserie 'Take Three Girls'. De ongebruikelijke maatsoort wisselt tussen 5/8, 7/8 en 6/8.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAJE0414233",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1632632849",
+        "de": "applemusic://track/1622801824",
+        "gb": "applemusic://track/1710208620",
+        "fr": "applemusic://track/1622801824",
+        "es": "applemusic://track/1622801824",
+        "nl": "applemusic://track/1622801824",
+        "it": "applemusic://track/1622801824"
+      }
     },
     {
       "year": 1995,
@@ -1811,7 +2301,17 @@
       "fun_fact_fr": "La chanteuse de Dubstar, Sarah Blackwood, avait un style vocal glacé si distinctif qu'elle a ensuite été recrutée par le groupe reformé Client. « Stars » est devenu un classique du synth-pop de l'ère Britpop.",
       "uri_deezer": "deezer://track/3233043",
       "fun_fact_nl": "Zangeres Sarah Blackwood van Dubstar had zo'n kenmerkende koele zangstijl dat ze later werd gerekruteerd door de heropgerichte band Client. 'Stars' werd een synthpop-klassieker uit het Britpop-tijdperk.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USWWW0139594",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1549088515",
+        "de": null,
+        "gb": null,
+        "fr": null,
+        "es": null,
+        "nl": null,
+        "it": null
+      }
     },
     {
       "year": 1969,
@@ -1870,7 +2370,17 @@
       "fun_fact_fr": "Silver Sun était connu pour leur son power-pop influencé par Cheap Trick et les Beach Boys. Malgré les éloges de la critique, ils n'ont jamais réussi à percer dans le succès commercial grand public.",
       "uri_deezer": "deezer://track/399450912",
       "fun_fact_nl": "Silver Sun stond bekend om hun powerpop-geluid beïnvloed door Cheap Trick en de Beach Boys. Ondanks lovende kritieken braken ze nooit door naar commercieel hitlijstsucces.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USQY51704432",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1276092996",
+        "de": "applemusic://track/1276092996",
+        "gb": "applemusic://track/1276092996",
+        "fr": "applemusic://track/1276092996",
+        "es": "applemusic://track/1276092996",
+        "nl": "applemusic://track/1276092996",
+        "it": "applemusic://track/1276092996"
+      }
     },
     {
       "year": 1968,
@@ -1902,7 +2412,17 @@
       "fun_fact_fr": "The Casuals était en fait un groupe de musiciens anglais qui avaient été basés en Italie pendant plusieurs années. « Jesamine » a été un énorme succès dans toute l'Europe, atteignant la 2e place au Royaume-Uni.",
       "uri_deezer": "deezer://track/133562708",
       "fun_fact_nl": "The Casuals was feitelijk een groep Engelse muzikanten die al enkele jaren in Italië gevestigd waren. 'Jesamine' was een enorme hit in heel Europa en bereikte nummer 2 in het VK.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DESK99790101",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1584665120",
+        "de": "applemusic://track/1584665120",
+        "gb": "applemusic://track/1584665120",
+        "fr": "applemusic://track/1584665120",
+        "es": "applemusic://track/1584665120",
+        "nl": "applemusic://track/1584665120",
+        "it": "applemusic://track/1584665120"
+      }
     },
     {
       "year": 1997,
@@ -1934,7 +2454,17 @@
       "fun_fact_fr": "White Town était essentiellement un projet solo de Jyoti Mishra, qui a enregistré « Your Woman » dans sa chambre à Derby. Elle a atteint la première place des charts britanniques, en faisant l'un des premiers numéros un produits dans une chambre.",
       "uri_deezer": "deezer://track/10426810",
       "fun_fact_nl": "White Town was in feite een eenmansproject van Jyoti Mishra, die 'Your Woman' opnam in zijn slaapkamer in Derby. Het bereikte de eerste plaats in de Britse hitlijst, waarmee het een van de eerste op een slaapkamer geproduceerde nummer 1-hits was.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAYE9600116",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/716067885",
+        "de": "applemusic://track/716067885",
+        "gb": "applemusic://track/716067885",
+        "fr": "applemusic://track/716067885",
+        "es": "applemusic://track/716067885",
+        "nl": "applemusic://track/716067885",
+        "it": "applemusic://track/716067885"
+      }
     },
     {
       "year": 1965,
@@ -1964,7 +2494,17 @@
       "fun_fact_fr": "Twinkle était une chanteuse-compositrice adolescente issue d'une famille aisée. « Golden Lights » a ensuite été célèbrement reprise par The Smiths en face B, que Morrissey a qualifiée d'une de ses chansons préférées de tous les temps.",
       "uri_deezer": "deezer://track/59143911",
       "fun_fact_nl": "Twinkle was een tiener singer-songwriter uit een rijke familie. 'Golden Lights' werd later beroemd gecoverd door The Smiths als B-kant, wat Morrissey een van zijn favoriete nummers ooit noemde.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBBLY0100210",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/277839266",
+        "de": "applemusic://track/277839266",
+        "gb": "applemusic://track/277839266",
+        "fr": "applemusic://track/277839266",
+        "es": "applemusic://track/277839266",
+        "nl": "applemusic://track/277839266",
+        "it": "applemusic://track/277839266"
+      }
     },
     {
       "year": 1996,
@@ -1994,7 +2534,17 @@
       "fun_fact_fr": "Kenickie tire son nom d'un personnage de « Grease » et comptait Lauren Laverne, qui est devenue l'une des présentatrices radio et télé les plus en vue de la BBC.",
       "uri_deezer": "deezer://track/3520942",
       "fun_fact_nl": "Kenickie was vernoemd naar een personage uit 'Grease' en bestond onder andere uit Lauren Laverne, die later een van de meest prominente radio- en tv-presentatoren van de BBC werd.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAYE9702450",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/695454622",
+        "de": "applemusic://track/695454622",
+        "gb": "applemusic://track/695454622",
+        "fr": "applemusic://track/695454622",
+        "es": "applemusic://track/695454622",
+        "nl": "applemusic://track/695454622",
+        "it": "applemusic://track/695454622"
+      }
     },
     {
       "year": 1966,
@@ -2024,7 +2574,17 @@
       "fun_fact_fr": "C'était la chanson officielle de la Coupe du Monde de la FIFA 1966 en Angleterre, l'année où l'Angleterre a remporté le tournoi. Lonnie Donegan était connu comme le « Roi du Skiffle » et a énormément influencé les jeunes Beatles.",
       "uri_deezer": "deezer://track/3808826482",
       "fun_fact_nl": "Dit was het officiële nummer voor het WK voetbal van 1966 in Engeland, het jaar waarin Engeland het toernooi won. Lonnie Donegan stond bekend als de 'King of Skiffle' en had een enorme invloed op de jonge Beatles.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAJE6500300",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1439725634",
+        "de": "applemusic://track/1439725634",
+        "gb": "applemusic://track/1439725634",
+        "fr": "applemusic://track/1439725634",
+        "es": "applemusic://track/1439725634",
+        "nl": "applemusic://track/1439725634",
+        "it": "applemusic://track/1439725634"
+      }
     },
     {
       "year": 1996,
@@ -2056,7 +2616,17 @@
       "fun_fact_fr": "Écrite à l'origine pour l'Euro 96, « Three Lions » a atteint quatre fois le numéro un au Royaume-Uni lors de différents tournois de football. Le refrain « It's coming home » est devenu l'hymne officieux du football anglais.",
       "uri_deezer": "deezer://track/581041",
       "fun_fact_nl": "Oorspronkelijk geschreven voor Euro 96, heeft 'Three Lions' bij vier verschillende gelegenheden tijdens diverse voetbaltoernooien de eerste plaats in het VK bereikt. Het refrein 'It's coming home' is uitgegroeid tot het officieuze lijflied van het Engelse voetbal.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBBBM9602007",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/376182543",
+        "de": "applemusic://track/376182543",
+        "gb": "applemusic://track/376182543",
+        "fr": "applemusic://track/376182543",
+        "es": "applemusic://track/376182543",
+        "nl": "applemusic://track/376182543",
+        "it": "applemusic://track/376182543"
+      }
     },
     {
       "year": 1967,
@@ -2086,7 +2656,17 @@
       "fun_fact_fr": "Long John Baldry mesurait 2,01 m, d'où son surnom. Il était une figure clé de la scène blues britannique qui a été le mentor de Rod Stewart et Elton John — en fait, Elton a pris son prénom du saxophoniste de Baldry, Elton Dean.",
       "uri_deezer": "deezer://track/3803081752",
       "fun_fact_nl": "Long John Baldry was 6'7\" lang, vandaar zijn bijnaam. Hij was een sleutelfiguur in de Britse bluesscene en mentor van Rod Stewart en Elton John. Elton ontleende zijn voornaam aan Baldry's saxofonist Elton Dean.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAJE6700058",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1763836668",
+        "de": "applemusic://track/1763836668",
+        "gb": "applemusic://track/1750293082",
+        "fr": "applemusic://track/1763836668",
+        "es": "applemusic://track/1763836668",
+        "nl": "applemusic://track/1763836668",
+        "it": "applemusic://track/1763836668"
+      }
     },
     {
       "year": 1996,
@@ -2116,7 +2696,17 @@
       "fun_fact_fr": "Strangelove tire son nom de la chanson de Depeche Mode. Malgré les éloges de la critique du NME et de Melody Maker, ils n'ont jamais réussi la percée commerciale que leur talent méritait pendant l'ère Britpop.",
       "uri_deezer": "deezer://track/3260682",
       "fun_fact_nl": "Strangelove werden vernoemd naar het nummer van Depeche Mode. Ondanks de lovende kritieken van NME en Melody Maker, bereikten ze nooit de commerciële doorbraak die hun talent verdiende tijdens het Britpop tijdperk.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAYF9600016",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/695450825",
+        "de": "applemusic://track/695450825",
+        "gb": "applemusic://track/695450825",
+        "fr": "applemusic://track/695450825",
+        "es": "applemusic://track/695450825",
+        "nl": "applemusic://track/695450825",
+        "it": "applemusic://track/695450825"
+      }
     },
     {
       "year": 1967,
@@ -2208,7 +2798,17 @@
       "fun_fact_fr": "Quand « Glad All Over » a détrôné « I Want to Hold Your Hand » des Beatles du numéro un britannique en janvier 1964, les journaux ont titré « Le son de Tottenham a écrasé le son du Mersey ! »",
       "uri_deezer": "deezer://track/3768837212",
       "fun_fact_nl": "Toen 'Glad All Over' in januari 1964 The Beatles' 'I Want to Hold Your Hand' van de UK nummer één verdrong, verklaarden de kranten 'Tottenham Sound Has Crushed the Mersey Sound!",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GB5KW1901090",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1469578024",
+        "de": "applemusic://track/1469578024",
+        "gb": "applemusic://track/1469578024",
+        "fr": "applemusic://track/1469578024",
+        "es": "applemusic://track/1469578024",
+        "nl": "applemusic://track/1469578024",
+        "it": "applemusic://track/1469578024"
+      }
     },
     {
       "year": 1997,
@@ -2238,7 +2838,17 @@
       "fun_fact_fr": "Initialement sortie en 1996, « Ready to Go » a été rééditée en 1997 et est devenue un énorme succès après avoir été utilisée dans des émissions de télévision et des événements sportifs. Elle reste un incontournable dans les stades de football à travers le Royaume-Uni.",
       "uri_deezer": "deezer://track/994557",
       "fun_fact_nl": "Ready to Go' werd oorspronkelijk uitgebracht in 1996, opnieuw uitgebracht in 1997 en werd een enorme hit nadat het werd gebruikt in tv-programma's en sportevenementen. Het is nog steeds niet weg te denken van voetbalvelden in heel Groot-Brittannië.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBARL9600018",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/258661746",
+        "de": "applemusic://track/258661746",
+        "gb": "applemusic://track/258661746",
+        "fr": "applemusic://track/258661746",
+        "es": "applemusic://track/258661746",
+        "nl": "applemusic://track/258661746",
+        "it": "applemusic://track/258661746"
+      }
     },
     {
       "year": 1968,
@@ -2268,7 +2878,17 @@
       "fun_fact_fr": "Ce classique novelty a été produit par Paul McCartney sous le pseudonyme « Apollo C. Vermouth ». La Bonzo Dog Band est également apparue dans le film télévisé des Beatles « Magical Mystery Tour ».",
       "uri_deezer": "deezer://track/3252711",
       "fun_fact_nl": "Deze novelty klassieker werd geproduceerd door Paul McCartney onder het pseudoniem 'Apollo C. Vermouth. De Bonzo Dog Band verscheen ook in de Beatles' Magical Mystery Tour TV-film.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAYE0701093",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/717124472",
+        "de": "applemusic://track/717124472",
+        "gb": "applemusic://track/717124472",
+        "fr": "applemusic://track/717124472",
+        "es": "applemusic://track/717124472",
+        "nl": "applemusic://track/717124472",
+        "it": "applemusic://track/717124472"
+      }
     },
     {
       "year": 1996,
@@ -2300,7 +2920,17 @@
       "fun_fact_fr": "L'intro accélérée de « Spaceman » a été utilisée dans une publicité Levi's et a créé un énorme buzz. C'est devenu le single de début le plus rapidement vendu de l'histoire britannique à l'époque, mais Babylon Zoo a eu du mal à reproduire son succès.",
       "uri_deezer": "deezer://track/3389663",
       "fun_fact_nl": "Het versnelde intro van 'Spaceman' werd gebruikt in een Levi's reclame en zorgde voor een enorme hype. Het werd de snelst verkopende debuutsingle in de geschiedenis van Groot-Brittannië in die tijd, maar Babylon Zoo had moeite om het succes te evenaren.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAYE9500084",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1590127365",
+        "de": "applemusic://track/1243422020",
+        "gb": "applemusic://track/1590127365",
+        "fr": "applemusic://track/1590127365",
+        "es": "applemusic://track/1590127365",
+        "nl": "applemusic://track/1590127365",
+        "it": "applemusic://track/1590127365"
+      }
     },
     {
       "year": 1968,
@@ -2330,7 +2960,17 @@
       "fun_fact_fr": "Écrite à l'origine par Joe South, la version de Deep Purple de « Hush » a été leur hit révélation aux États-Unis mais, ironiquement, a à peine figuré dans les charts de leur pays d'origine. Le groupe deviendrait plus tard connu pour un matériel bien plus lourd.",
       "uri_deezer": "deezer://track/3436057",
       "fun_fact_nl": "Deep Purple's versie van 'Hush', oorspronkelijk geschreven door Joe South, was hun doorbraakhit in de VS maar kwam ironisch genoeg nauwelijks in de hitlijsten van hun thuisland. De band zou later bekend worden om veel heavier materiaal.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USWB19903669",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/83155547",
+        "de": null,
+        "gb": null,
+        "fr": null,
+        "es": null,
+        "nl": null,
+        "it": null
+      }
     },
     {
       "year": 1996,
@@ -2362,7 +3002,17 @@
       "fun_fact_fr": "Le premier single de Kula Shaker a fusionné le mysticisme indien avec le rock guitare Britpop, reflétant la profonde fascination du leader Crispian Mills pour la spiritualité hindoue et les chants en sanskrit.",
       "uri_deezer": "deezer://track/2340209765",
       "fun_fact_nl": "De debuutsingle van Kula Shaker versmolt Indiase mystiek met Britpop gitaarrock en weerspiegelde de diepe fascinatie van frontman Crispian Mills voor Hindoeïstische spiritualiteit en Sanskriet zingen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBBBN9600018",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1694076567",
+        "de": "applemusic://track/1694076567",
+        "gb": "applemusic://track/1694076567",
+        "fr": "applemusic://track/1694076567",
+        "es": "applemusic://track/1694076567",
+        "nl": "applemusic://track/1694076567",
+        "it": "applemusic://track/1694076567"
+      }
     },
     {
       "year": 1966,
@@ -2394,7 +3044,17 @@
       "fun_fact_fr": "Écrite par le compositeur new-yorkais Chip Taylor, « Wild Thing » a été enregistrée en une seule prise. L'iconique solo d'ocarina a été joué par le musicien de session David Leach parce que le groupe ne pouvait pas se permettre un arrangement orchestral approprié.",
       "uri_deezer": "deezer://track/729595152",
       "fun_fact_nl": "Geschreven door de New Yorkse songwriter Chip Taylor, werd 'Wild Thing' opgenomen in slechts één take. De iconische ocarina solo werd gespeeld door sessiemuzikant David Leach omdat de band zich geen echt orkestarrangement kon veroorloven.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBF086600001",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1445944071",
+        "de": "applemusic://track/1445944071",
+        "gb": "applemusic://track/1445944071",
+        "fr": "applemusic://track/1442466122",
+        "es": "applemusic://track/1445944071",
+        "nl": "applemusic://track/1445944071",
+        "it": "applemusic://track/1445944071"
+      }
     },
     {
       "year": 1996,
@@ -2426,7 +3086,17 @@
       "fun_fact_fr": "La chanson est devenue un énorme hymne à reprendre en chœur dans les festivals et a été célèbrement utilisée dans une publicité télévisée Sony MiniDisc, ce qui l'a propulsée dans les charts et a fait de Reef l'un des plus grands groupes live de la fin des années 90.",
       "uri_deezer": "deezer://track/10157575",
       "fun_fact_nl": "Het nummer werd een massale meezinger op festivals en werd beroemd gebruikt in een Sony MiniDisc TV-reclame, waardoor het hoger in de hitlijsten kwam en Reef een van de grootste live-acts van de late jaren 90 werd.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBBBL9600127",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/279233106",
+        "de": "applemusic://track/390412696",
+        "gb": "applemusic://track/390412696",
+        "fr": "applemusic://track/390412696",
+        "es": "applemusic://track/390412696",
+        "nl": "applemusic://track/390412696",
+        "it": "applemusic://track/390412696"
+      }
     },
     {
       "year": 1963,
@@ -2456,7 +3126,17 @@
       "fun_fact_fr": "Decca Records a célèbrement choisi de signer Brian Poole & The Tremeloes plutôt que les Beatles en 1962, en partie parce que le groupe habitait plus près des bureaux londoniens du label et coûterait moins cher en frais de déplacement.",
       "uri_deezer": "deezer://track/73535223",
       "fun_fact_nl": "Decca Records verkoos in 1962 Brian Poole & The Tremeloes boven The Beatles, deels omdat de band dichter bij de Londense kantoren van het label woonde en minder reiskosten zou maken.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBHGA1317008",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/715855423",
+        "de": "applemusic://track/715855423",
+        "gb": "applemusic://track/715855423",
+        "fr": "applemusic://track/715855423",
+        "es": "applemusic://track/715855423",
+        "nl": "applemusic://track/715855423",
+        "it": "applemusic://track/715855423"
+      }
     },
     {
       "year": 1994,
@@ -2486,7 +3166,17 @@
       "fun_fact_fr": "Le premier roadie des Inspiral Carpets n'était autre qu'un jeune Noel Gallagher, qui vendait des t-shirts pour le groupe avant de fonder Oasis et de changer le visage du Britpop pour toujours.",
       "uri_deezer": "deezer://track/3750649162",
       "fun_fact_nl": "De vroege roadie van Inspiral Carpets was niemand minder dan een jonge Noel Gallagher, die T-shirts verkocht voor de band voordat hij Oasis oprichtte en het gezicht van Britpop voor altijd veranderde.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAJH0402377",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1435626648",
+        "de": "applemusic://track/1435626648",
+        "gb": "applemusic://track/1435626648",
+        "fr": "applemusic://track/1435626648",
+        "es": "applemusic://track/1435626648",
+        "nl": "applemusic://track/1435626648",
+        "it": "applemusic://track/1435626648"
+      }
     },
     {
       "year": 1968,
@@ -2516,7 +3206,17 @@
       "fun_fact_fr": "Un scandale a éclaté quand il a été révélé que des musiciens de session avaient joué tous les instruments sur l'enregistrement, et que seul le chanteur Steve Ellis avait réellement joué sur le morceau. Le groupe a admis qu'ils étaient trop inexpérimentés pour jouer sur leur propre premier album.",
       "uri_deezer": "deezer://track/612210",
       "fun_fact_nl": "Er brak een schandaal uit toen bekend werd dat sessiemuzikanten alle instrumenten op de opname hadden ingespeeld en alleen leadzanger Steve Ellis daadwerkelijk meespeelde op het nummer. De band gaf toe dat ze te onervaren waren om op hun eigen debuut te spelen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBQRF1020380",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/890693837",
+        "de": "applemusic://track/806830269",
+        "gb": "applemusic://track/806830269",
+        "fr": "applemusic://track/806830269",
+        "es": "applemusic://track/806830269",
+        "nl": "applemusic://track/806830269",
+        "it": "applemusic://track/806830269"
+      }
     },
     {
       "year": 1995,
@@ -2546,7 +3246,17 @@
       "fun_fact_fr": "Menswear est devenu notoire pour avoir signé avec un major et reçu un battage médiatique considérable avant même d'avoir joué un vrai concert, les rendant emblématiques des excès de la frénésie médiatique Britpop.",
       "uri_deezer": "deezer://track/435665222",
       "fun_fact_nl": "Menswear werd berucht omdat ze getekend waren bij een groot label en een uitgebreide mediahype kregen voordat ze ook maar een echt optreden hadden gedaan, waardoor ze poster-kinderen werden voor de excessen van de Britpop-mediagekte.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAAP9500344",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1319434259",
+        "de": "applemusic://track/1319434259",
+        "gb": "applemusic://track/1319434259",
+        "fr": "applemusic://track/1319434259",
+        "es": "applemusic://track/1319434259",
+        "nl": "applemusic://track/1319434259",
+        "it": "applemusic://track/1319434259"
+      }
     },
     {
       "year": 1963,
@@ -2576,7 +3286,17 @@
       "fun_fact_fr": "Screaming Lord Sutch était aussi célèbre pour sa carrière politique que pour sa musique — il a fondé l'Official Monster Raving Loony Party et s'est présenté à plus de 40 élections parlementaires, ne gagnant jamais mais divertissant toujours.",
       "uri_deezer": "deezer://track/348840671",
       "fun_fact_nl": "Screaming Lord Sutch was net zo beroemd om zijn politieke carrière als om zijn muziek - hij richtte de Official Monster Raving Loony Party op en deed mee aan meer dan 40 parlementsverkiezingen, waarbij hij nooit won maar altijd vermaakte.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAGW1520564",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1776684871",
+        "de": "applemusic://track/1776684871",
+        "gb": "applemusic://track/1776684871",
+        "fr": "applemusic://track/1776684871",
+        "es": "applemusic://track/1776684871",
+        "nl": "applemusic://track/1776684871",
+        "it": "applemusic://track/1776684871"
+      }
     },
     {
       "year": 1995,
@@ -2608,7 +3328,17 @@
       "fun_fact_fr": "À l'origine une face B, « Born Slippy » est devenu un énorme hit après que Danny Boyle l'ait utilisée dans la scène finale iconique de Trainspotting. Le chant « lager lager lager » est devenu un hymne officieux de la culture club des années 90.",
       "uri_deezer": "deezer://track/82265248",
       "fun_fact_nl": "Born Slippy' was oorspronkelijk een B-kantje, maar werd een enorme hit nadat Danny Boyle het had gebruikt in de iconische eindscène van Trainspotting. De 'lager lager lager' chant werd een onofficiële hymne voor de jaren 90 clubcultuur.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBCGL9800026",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1649583845",
+        "de": "applemusic://track/1649583845",
+        "gb": "applemusic://track/1649583845",
+        "fr": "applemusic://track/1649583845",
+        "es": "applemusic://track/1649583845",
+        "nl": "applemusic://track/1893188071",
+        "it": "applemusic://track/1649583845"
+      }
     },
     {
       "year": 1971,
@@ -2665,7 +3395,17 @@
       "fun_fact_fr": "Beth Orton a été pionnière d'un mélange distinctif de folktronica, fusionnant le folk acoustique avec la production électronique. Elle a beaucoup collaboré avec The Chemical Brothers et William Orbit avant de sortir son matériel solo.",
       "uri_deezer": "deezer://track/2456161",
       "fun_fact_nl": "Beth Orton was een pionier op het gebied van folktronica, waarbij ze akoestische folk combineerde met elektronische productie. Ze werkte veel samen met The Chemical Brothers en William Orbit voordat ze haar solomateriaal uitbracht.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBARS9600082",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/264782199",
+        "de": "applemusic://track/281788636",
+        "gb": "applemusic://track/281788636",
+        "fr": "applemusic://track/281788636",
+        "es": "applemusic://track/281788636",
+        "nl": "applemusic://track/281788636",
+        "it": "applemusic://track/281788636"
+      }
     },
     {
       "year": 1965,
@@ -2698,7 +3438,17 @@
       "fun_fact_fr": "Écrite par Les Reed et Gordon Mills, c'était le hit révélation de Tom Jones. La chanson a connu un regain de popularité après avoir été présentée dans la série « Le Prince de Bel-Air » où Carlton Banks danse célèbrement dessus.",
       "uri_deezer": "deezer://track/906545",
       "fun_fact_nl": "Geschreven door Les Reed en Gordon Mills was dit de doorbraakhit van Tom Jones. Het nummer beleefde een opleving in populariteit nadat het te zien was in de tv-show 'The Fresh Prince of Bel-Air' waar Carlton Banks er beroemd op danste.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBF076520010",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1596847434",
+        "de": "applemusic://track/1514703261",
+        "gb": "applemusic://track/1442868116",
+        "fr": "applemusic://track/1514703261",
+        "es": "applemusic://track/1514703261",
+        "nl": "applemusic://track/1514703261",
+        "it": "applemusic://track/1514703261"
+      }
     },
     {
       "year": 1996,
@@ -2730,7 +3480,17 @@
       "fun_fact_fr": "La chanson a été utilisée comme thème pour les publicités télévisées de la Carling Premier League et comportait des voix invitées de Cerys Matthews de Catatonia. Son ambiance de film d'espionnage décalée en a fait l'un des singles les plus distinctifs de l'ère Britpop.",
       "uri_deezer": "deezer://track/141458863",
       "fun_fact_nl": "Het nummer werd gebruikt als thema voor de Carling Premier League tv-reclames en bevatte gastvocalen van Cerys Matthews van Catatonia. De eigenzinnige spionagefilm vibe maakte het een van de meest kenmerkende singles uit het Britpop-tijdperk.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBBRL9691749",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1567938226",
+        "de": "applemusic://track/1567938226",
+        "gb": "applemusic://track/1567938226",
+        "fr": "applemusic://track/1567938226",
+        "es": "applemusic://track/1567938226",
+        "nl": "applemusic://track/1567938226",
+        "it": "applemusic://track/1567938226"
+      }
     },
     {
       "year": 1966,
@@ -2760,7 +3520,17 @@
       "fun_fact_fr": "Après que son premier album « Just Another Diamond Day » ait été un échec commercial en 1970, Vashti Bunyan a complètement abandonné la musique pendant 30 ans. L'album a été redécouvert par le mouvement freak folk dans les années 2000 et est maintenant considéré comme un chef-d'œuvre.",
       "uri_deezer": "deezer://track/16168341",
       "fun_fact_nl": "Nadat haar debuutalbum 'Just Another Diamond Day' in 1970 een commerciële mislukking was, stopte Vashti Bunyan 30 jaar lang helemaal met muziek. Het album werd herontdekt door de freak folk beweging in de jaren 2000 en wordt nu beschouwd als een meesterwerk.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "US29D0700012",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/265096509",
+        "de": null,
+        "gb": null,
+        "fr": null,
+        "es": null,
+        "nl": null,
+        "it": null
+      }
     },
     {
       "year": 1995,
@@ -2790,7 +3560,17 @@
       "fun_fact_fr": "Kirsty MacColl était une compositrice extrêmement talentueuse dont le travail couvrait le punk, la pop, les influences latines et celtiques. Elle est peut-être plus connue pour son duo avec Shane MacGowan sur « Fairytale of New York » des Pogues, l'une des chansons de Noël les plus aimées du Royaume-Uni.",
       "uri_deezer": "deezer://track/485730612",
       "fun_fact_nl": "Kirsty MacColl was een enorm getalenteerde songwriter wiens werk punk, pop, latin en Keltische invloeden overspande. Ze is misschien wel het bekendst door haar duet met Shane MacGowan op 'Fairytale of New York' van The Pogues, een van de meest geliefde kerstliedjes in het Verenigd Koninkrijk.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAAA9500419",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1371594902",
+        "de": "applemusic://track/1372009856",
+        "gb": "applemusic://track/1372009856",
+        "fr": "applemusic://track/1372009856",
+        "es": "applemusic://track/1372009856",
+        "nl": "applemusic://track/1372009856",
+        "it": "applemusic://track/1372009856"
+      }
     },
     {
       "year": 1963,
@@ -2849,7 +3629,17 @@
       "fun_fact_fr": "Nick Heyward est devenu célèbre comme leader de Haircut One Hundred avant de lancer une carrière solo. Son style pop ensoleillé était un contrepoint lumineux aux sons plus sombres de la new wave qui dominaient le début des années 1980.",
       "uri_deezer": "deezer://track/7347117",
       "fun_fact_nl": "Nick Heyward werd beroemd als frontman van Haircut One Hundred voordat hij een solocarrière begon. Zijn zonnige popstijl was een helder tegenwicht voor de donkere new wave-klanken die begin jaren tachtig overheersten.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBBBM9302040",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/292747665",
+        "de": "applemusic://track/292747665",
+        "gb": "applemusic://track/292747665",
+        "fr": "applemusic://track/292747665",
+        "es": "applemusic://track/292747665",
+        "nl": "applemusic://track/292747665",
+        "it": "applemusic://track/292747665"
+      }
     },
     {
       "year": 1964,
@@ -2881,7 +3671,17 @@
       "fun_fact_fr": "Shirley Bassey a tenu la note finale de la chanson si longtemps pendant la session d'enregistrement qu'elle se serait évanouie. Elle a chanté un record de trois thèmes de James Bond — Goldfinger, Diamonds Are Forever et Moonraker.",
       "uri_deezer": "deezer://track/3093484",
       "fun_fact_nl": "Shirley Bassey hield de laatste noot van het nummer zo lang vast tijdens de opnamesessie dat ze naar verluidt flauwviel. Ze zong vervolgens drie James Bond-thema's op haar palmares - Goldfinger, Diamonds Are Forever en Moonraker.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMG20700010",
+      "uri_apple_music_by_region": {
+        "us": null,
+        "de": null,
+        "gb": null,
+        "fr": null,
+        "es": null,
+        "nl": null,
+        "it": null
+      }
     },
     {
       "year": 1995,
@@ -2911,7 +3711,17 @@
       "fun_fact_fr": "Salad était mené par la chanteuse d'origine néerlandaise Marijne van der Vlugt et faisait partie de la scène Britpop qui gravitait autour de Camden Town. Malgré les éloges de la critique, ils sont restés l'un des grands groupes sous-estimés de l'époque.",
       "uri_deezer": "deezer://track/1578521",
       "fun_fact_nl": "Salad werd geleid door de in Nederland geboren zangeres Marijne van der Vlugt en maakte deel uit van de Britpop-scene rond Camden Town. Ondanks de lovende kritieken bleven ze een van de meest onderschatte bands uit die tijd.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAAN9500006",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1442559635",
+        "de": "applemusic://track/1442559635",
+        "gb": "applemusic://track/1442559635",
+        "fr": "applemusic://track/1442559635",
+        "es": "applemusic://track/1442559635",
+        "nl": "applemusic://track/1442559635",
+        "it": "applemusic://track/1442559635"
+      }
     },
     {
       "year": 1983,
@@ -2970,7 +3780,17 @@
       "fun_fact_fr": "Aztec Camera était essentiellement le véhicule du talentueux précoce auteur-compositeur écossais Roddy Frame, qui a signé son premier contrat d'enregistrement à seulement 16 ans. L'album début « High Land, Hard Rain » est considéré comme un jalon du jangle pop des années 1980.",
       "uri_deezer": "deezer://track/733578",
       "fun_fact_nl": "Aztec Camera was in wezen het vehikel van de vroegrijp getalenteerde Schotse singer-songwriter Roddy Frame, die zijn eerste platencontract tekende toen hij nog maar 16 was. Het debuutalbum van de band 'High Land, Hard Rain' wordt beschouwd als een mijlpaal in de jaren 80 jangle pop.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBDL58300082",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/516624410",
+        "de": null,
+        "gb": null,
+        "fr": null,
+        "es": null,
+        "nl": null,
+        "it": null
+      }
     },
     {
       "year": 1967,
@@ -3002,7 +3822,17 @@
       "fun_fact_fr": "Justin Hayward a écrit cette chanson à seulement 19 ans. Elle n'a atteint que la 19e place au Royaume-Uni en 1967, mais lors de sa réédition en 1972, elle est montée à la 2e place du Billboard Hot 100 aux États-Unis, devenant un classique mondial.",
       "uri_deezer": "deezer://track/366450991",
       "fun_fact_nl": "Justin Hayward schreef dit nummer toen hij nog maar 19 jaar oud was. Het bereikte oorspronkelijk slechts nummer 19 in de UK in 1967, maar toen het opnieuw werd uitgebracht in 1972, klom het naar nummer 2 op de Billboard Hot 100 in de VS en werd het een wereldwijde klassieker.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBBBA6760792",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1688434926",
+        "de": "applemusic://track/1688024397",
+        "gb": "applemusic://track/1688024397",
+        "fr": "applemusic://track/1688024397",
+        "es": "applemusic://track/1688024397",
+        "nl": "applemusic://track/1688024397",
+        "it": "applemusic://track/1688024397"
+      }
     },
     {
       "year": 1997,
@@ -3032,7 +3862,17 @@
       "fun_fact_fr": "L'album début de Mansun « Attack of the Grey Lantern » était un album concept qui est entré directement au numéro un des charts britanniques. « Wide Open Space » est devenu leur chanson signature avec son refrain planant et sa production atmosphérique de Paul Draper.",
       "uri_deezer": "deezer://track/3016759781",
       "fun_fact_nl": "Mansuns debuutalbum 'Attack of the Grey Lantern' was een conceptalbum dat op nummer één binnenkwam in de Britse hitlijsten. Wide Open Space' werd hun kenmerkende nummer met zijn stijgende refrein en sfeervolle productie van Paul Draper.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBCQV1714868",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1770502871",
+        "de": "applemusic://track/1770502871",
+        "gb": "applemusic://track/1770502871",
+        "fr": "applemusic://track/1770502871",
+        "es": "applemusic://track/1770502871",
+        "nl": "applemusic://track/1770502871",
+        "it": "applemusic://track/1770502871"
+      }
     },
     {
       "year": 1968,
@@ -3062,7 +3902,17 @@
       "fun_fact_fr": "Terry Reid s'est vu offrir le rôle de chanteur principal à la fois dans Led Zeppelin et Deep Purple mais a refusé les deux, recommandant Robert Plant pour Zeppelin à sa place. Il est souvent appelé « la plus grande voix rock que vous n'avez jamais entendue ».",
       "uri_deezer": "deezer://track/561394332",
       "fun_fact_nl": "Terry Reid kreeg de rol van leadzanger aangeboden bij zowel Led Zeppelin als Deep Purple, maar hij wees beide af en beval in plaats daarvan Robert Plant aan voor Zeppelin. Hij wordt vaak 'de beste rockstem die je nog nooit hebt gehoord' genoemd.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAYE6800559",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/692477561",
+        "de": "applemusic://track/692477561",
+        "gb": "applemusic://track/692477561",
+        "fr": "applemusic://track/692477561",
+        "es": "applemusic://track/692477561",
+        "nl": "applemusic://track/692477561",
+        "it": "applemusic://track/692477561"
+      }
     },
     {
       "year": 1999,
@@ -3092,7 +3942,17 @@
       "fun_fact_fr": "Shack était mené par Mick Head, largement considéré comme l'un des plus grands compositeurs méconnus de Liverpool. Les bandes originales de leur deuxième album ont été perdues quand la maison de leur producteur a brûlé, et il a fallu des années pour réenregistrer le matériel.",
       "uri_deezer": "deezer://track/436161482",
       "fun_fact_nl": "Shack werd geleid door Mick Head, alom beschouwd als een van Liverpools grootste onbezongen songwriters. De originele tapes voor hun tweede album gingen verloren toen het huis van hun producer afbrandde en het duurde jaren om het materiaal opnieuw op te nemen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAAP9900083",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1319972623",
+        "de": "applemusic://track/1319972623",
+        "gb": "applemusic://track/1319972623",
+        "fr": "applemusic://track/1319972623",
+        "es": "applemusic://track/1319972623",
+        "nl": "applemusic://track/1319972623",
+        "it": "applemusic://track/1319972623"
+      }
     }
   ]
 }

--- a/custom_components/beatify/playlists/community/eurodance-90s.json
+++ b/custom_components/beatify/playlists/community/eurodance-90s.json
@@ -42,7 +42,17 @@
       "uri_tidal": "tidal://track/1291239",
       "uri_deezer": "deezer://track/4096754",
       "fun_fact_nl": "De grootste hit van La Bouche stond 6 maanden in de Billboard Hot 100. Het duo werd specifiek samengesteld voor de Eurodance-markt, met Lane McCray voor de zang terwijl Melanie Thornton het gezicht van de groep werd.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DED169500047",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/973015801",
+        "de": "applemusic://track/1673414058",
+        "gb": "applemusic://track/1673414058",
+        "fr": "applemusic://track/1673414058",
+        "es": "applemusic://track/1673414058",
+        "nl": "applemusic://track/1673414058",
+        "it": "applemusic://track/1673414058"
+      }
     },
     {
       "year": 1995,
@@ -65,7 +75,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=Se237UXFKlQ",
       "uri_tidal": "tidal://track/4949412",
       "fun_fact_nl": "ATC's 'Around the World' werd in 2000 een enorme internationale hit en bereikte de top 10 in meer dan 20 landen. De aanstekelijke 'La La La La La'-hook maakte het tot een van de meest herkenbare Eurodance-tracks van zijn tijd.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEP810000008",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1308905282",
+        "de": "applemusic://track/1673414298",
+        "gb": "applemusic://track/1673414298",
+        "fr": "applemusic://track/1673414298",
+        "es": "applemusic://track/1673414298",
+        "nl": "applemusic://track/1673414298",
+        "it": "applemusic://track/1673414298"
+      }
     },
     {
       "year": 1994,
@@ -96,7 +116,17 @@
       "uri_tidal": "tidal://track/659924",
       "uri_deezer": "deezer://track/1042543",
       "fun_fact_nl": "De doorbraakhit van Real McCoy bereikte nummer 3 in de VS en nummer 2 in het VK. De groep heette in Europa oorspronkelijk M.C. Sar & The Real McCoy voordat de naam werd ingekort tot Real McCoy voor de Amerikaanse markt.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEC739400815",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/302980623",
+        "de": "applemusic://track/852614408",
+        "gb": "applemusic://track/852614408",
+        "fr": "applemusic://track/852614408",
+        "es": "applemusic://track/852614408",
+        "nl": "applemusic://track/852614408",
+        "it": "applemusic://track/852614408"
+      }
     },
     {
       "year": 1999,
@@ -127,7 +157,17 @@
       "uri_tidal": "tidal://track/7715350",
       "uri_deezer": "deezer://track/11390027",
       "fun_fact_nl": "Darude's 'Sandstorm' werd een van de meest iconische trance/dance-tracks aller tijden en een enorme internetmeme. Het nummer wordt vaak gebruikt in sportstadions en heeft meer dan 400 miljoen streams op Spotify.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "FISGC9900001",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/271969650",
+        "de": "applemusic://track/271969650",
+        "gb": "applemusic://track/271969650",
+        "fr": "applemusic://track/271969650",
+        "es": "applemusic://track/271969650",
+        "nl": "applemusic://track/271969650",
+        "it": "applemusic://track/271969650"
+      }
     },
     {
       "year": 1995,
@@ -186,7 +226,17 @@
       "uri_tidal": "tidal://track/1291238",
       "uri_deezer": "deezer://track/13166572",
       "fun_fact_nl": "De tweede grote hit van La Bouche toonde hun kenmerkende Eurodance-geluid met de krachtige zang van Melanie Thornton.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DED160200020",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/214479597",
+        "de": "applemusic://track/1673414301",
+        "gb": "applemusic://track/1673414301",
+        "fr": "applemusic://track/1673414301",
+        "es": "applemusic://track/1673414301",
+        "nl": "applemusic://track/1673414301",
+        "it": "applemusic://track/1673414301"
+      }
     },
     {
       "year": 1994,
@@ -217,7 +267,17 @@
       "uri_tidal": "tidal://track/11343730",
       "uri_deezer": "deezer://track/1042280",
       "fun_fact_nl": "De opvolger van 'Another Night' van Real McCoy werd ook een grote hit, wat hun status als Eurodance-grootheden bevestigde. De muziek van de groep werd geproduceerd door hetzelfde team dat achter Snap! en Culture Beat zat.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEC739400365",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/402631143",
+        "de": "applemusic://track/1682989430",
+        "gb": "applemusic://track/1682989430",
+        "fr": "applemusic://track/1682989430",
+        "es": "applemusic://track/1682989430",
+        "nl": "applemusic://track/1682989430",
+        "it": "applemusic://track/1682989430"
+      }
     },
     {
       "year": 1995,
@@ -248,7 +308,17 @@
       "uri_tidal": "tidal://track/452927318",
       "uri_deezer": "deezer://track/3498594171",
       "fun_fact_nl": "De trance-cover van DJ Sammy van Bryan Adams' 'Heaven' werd een enorme hit en stond overal in Europa bovenaan de hitlijsten. De emotionele zang en meeslepende synths maakten het tot een klassieker op de dansvloer.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USRE50200231",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/17769882",
+        "de": "applemusic://track/1831927967",
+        "gb": null,
+        "fr": "applemusic://track/1831927967",
+        "es": "applemusic://track/1831927967",
+        "nl": "applemusic://track/1831927967",
+        "it": "applemusic://track/1831927967"
+      }
     },
     {
       "year": 1995,
@@ -278,7 +348,17 @@
       "uri_tidal": "tidal://track/19020552",
       "uri_deezer": "deezer://track/121665394",
       "fun_fact_nl": "Gigi D'Agostino's trance-meesterwerk 'L'amour Toujours' bereikte de top van de Italiaanse hitlijsten en blijft een klassieker in het genre. De emotionele melodie en de stuwende beat maakten het tijdloos.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEA310200623",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/883971256",
+        "de": "applemusic://track/883971256",
+        "gb": "applemusic://track/883971256",
+        "fr": "applemusic://track/883971256",
+        "es": "applemusic://track/883971256",
+        "nl": "applemusic://track/883971256",
+        "it": "applemusic://track/883971256"
+      }
     },
     {
       "year": 2000,
@@ -309,7 +389,17 @@
       "uri_tidal": "tidal://track/70681623",
       "uri_deezer": "deezer://track/2855541182",
       "fun_fact_nl": "Gala's Eurodance-klassieker beleefde in de jaren 2010 een enorme herleving als voetbalchant, vooral als 'Will Grigg's on fire' door fans van Noord-Ierland. Het nummer is sindsdien wereldwijd een vaste waarde in stadions.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "ITA179700143",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1714235527",
+        "de": "applemusic://track/1707386371",
+        "gb": "applemusic://track/1714235527",
+        "fr": "applemusic://track/1714235527",
+        "es": "applemusic://track/1714235527",
+        "nl": "applemusic://track/1714235527",
+        "it": "applemusic://track/1714235527"
+      }
     },
     {
       "year": 1995,
@@ -336,7 +426,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=yhHI1jve9tI",
       "uri_tidal": "tidal://track/4949413",
       "fun_fact_nl": "A Touch Of Class (ATC) scoorde een wereldhit met dit Eurodance-nummer. De aanstekelijke 'Dam Dam Dam'-hook werd direct herkend op dansvloeren over de hele wereld.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEP810000025",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1308905284",
+        "de": "applemusic://track/1673414696",
+        "gb": "applemusic://track/1673414696",
+        "fr": "applemusic://track/1673414696",
+        "es": "applemusic://track/1673414696",
+        "nl": "applemusic://track/1673414696",
+        "it": "applemusic://track/1673414696"
+      }
     },
     {
       "year": 1993,
@@ -396,7 +496,17 @@
       "uri_tidal": "tidal://track/497794",
       "uri_deezer": "deezer://track/972817",
       "fun_fact_nl": "De remix uit '98 van Modern Talking van hun klassieke hit bracht hen terug in de hitlijsten en liet een nieuwe generatie Eurodance-fans kennismaken met hun synth-popgeluid.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEC739800447",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1398208567",
+        "de": "applemusic://track/1398208567",
+        "gb": "applemusic://track/1398208567",
+        "fr": "applemusic://track/1398208567",
+        "es": "applemusic://track/1398208567",
+        "nl": "applemusic://track/1398208567",
+        "it": "applemusic://track/1398208567"
+      }
     },
     {
       "year": 1995,
@@ -427,7 +537,17 @@
       "uri_tidal": "tidal://track/1843333",
       "uri_deezer": "deezer://track/1044489",
       "fun_fact_nl": "De doorbraaksingle van No Mercy werd een enorme hit in heel Europa, waarbij R&B-zang werd gecombineerd met Eurodance-productie.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DED169600128",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1308989226",
+        "de": "applemusic://track/585659458",
+        "gb": "applemusic://track/585659458",
+        "fr": "applemusic://track/585659458",
+        "es": "applemusic://track/585659458",
+        "nl": "applemusic://track/585659458",
+        "it": "applemusic://track/585659458"
+      }
     },
     {
       "year": 1994,
@@ -455,7 +575,17 @@
       "uri_tidal": "tidal://track/1772250",
       "uri_deezer": "deezer://track/71180726",
       "fun_fact_nl": "Nog een hit van Real McCoy die hielp hen te vestigen als Eurodance-supersterren in het midden van de jaren '90.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEC739400377",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/302980626",
+        "de": "applemusic://track/302980626",
+        "gb": "applemusic://track/302980626",
+        "fr": "applemusic://track/302980626",
+        "es": "applemusic://track/302980626",
+        "nl": "applemusic://track/302980626",
+        "it": "applemusic://track/302980626"
+      }
     },
     {
       "year": 1993,
@@ -486,7 +616,17 @@
       "uri_tidal": "tidal://track/238184165",
       "uri_deezer": "deezer://track/3803445032",
       "fun_fact_nl": "Haddaway's bekendste nummer werd een cultureel fenomeen dankzij de 'Night at the Roxbury' SNL-sketches en de film. De scène waarin ze met hun hoofden knikken blies de populariteit van het nummer aan het eind van de jaren '90 nieuw leven in.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEA410500401",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1731434189",
+        "de": "applemusic://track/1731434189",
+        "gb": "applemusic://track/1731434189",
+        "fr": "applemusic://track/1731434189",
+        "es": "applemusic://track/1731434189",
+        "nl": "applemusic://track/1731434189",
+        "it": "applemusic://track/1731434189"
+      }
     },
     {
       "year": 1995,
@@ -514,7 +654,17 @@
       "uri_tidal": "tidal://track/121936615",
       "uri_deezer": "deezer://track/798810542",
       "fun_fact_nl": "De energieke Eurodance-track van Le Click werd een favoriet in clubs met zijn aanstekelijke energie en gedenkwaardige hook.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DED419700161",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1486688649",
+        "de": "applemusic://track/1486688649",
+        "gb": "applemusic://track/1486688649",
+        "fr": "applemusic://track/1486688649",
+        "es": "applemusic://track/1486688649",
+        "nl": "applemusic://track/1486688649",
+        "it": "applemusic://track/1486688649"
+      }
     },
     {
       "year": 1995,
@@ -542,7 +692,17 @@
       "uri_tidal": "tidal://track/3966796",
       "uri_deezer": "deezer://track/14014884",
       "fun_fact_nl": "De energieke Eurodance-track van Da Buzz werd een hit in Zweden en een favoriet in de clubs.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "SEVGT0300201",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/373885803",
+        "de": "applemusic://track/373885803",
+        "gb": "applemusic://track/373885803",
+        "fr": "applemusic://track/373885803",
+        "es": "applemusic://track/373885803",
+        "nl": "applemusic://track/373885803",
+        "it": "applemusic://track/373885803"
+      }
     },
     {
       "year": 1995,
@@ -573,7 +733,17 @@
       "uri_tidal": "tidal://track/2057994",
       "uri_deezer": "deezer://track/3843390961",
       "fun_fact_nl": "De op de tropen geïnspireerde Eurodance-hit van Mr. President werd in heel Europa een zomerhit. De aanstekelijke 'Coco Jamboo'-hook en de eiland-vibes van de Duitse groep maakten het tot een vaste waarde op strandfeesten.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEBS80500020",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1892061490",
+        "de": "applemusic://track/1892061490",
+        "gb": "applemusic://track/1892061490",
+        "fr": "applemusic://track/1892061490",
+        "es": "applemusic://track/1892061490",
+        "nl": "applemusic://track/1892061490",
+        "it": "applemusic://track/1892061490"
+      }
     },
     {
       "year": 1995,
@@ -631,7 +801,17 @@
       "uri_tidal": "tidal://track/441956660",
       "uri_deezer": "deezer://track/1428926582",
       "fun_fact_nl": "Corona's debuutsingle werd een wereldwijde knaller en verkocht meer dan 2 miljoen exemplaren. Het aanstekelijke ritme en de gedenkwaardige hook maakten het een vaste waarde op de dansvloeren van de jaren '90.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAHT0700828",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1835614189",
+        "de": "applemusic://track/1835614189",
+        "gb": "applemusic://track/1835614189",
+        "fr": "applemusic://track/1835614189",
+        "es": "applemusic://track/1835614189",
+        "nl": "applemusic://track/1835614189",
+        "it": "applemusic://track/1835614189"
+      }
     },
     {
       "year": 1995,
@@ -662,7 +842,17 @@
       "uri_tidal": "tidal://track/1772047",
       "uri_deezer": "deezer://track/13203719",
       "fun_fact_nl": "C+C Music Factory's 'Everybody Dance Now' werd een van de grootste dance-klassiekers van de vroege jaren '90, bereikte de eerste plaats in de Billboard Hot 100 en definieerde het geluid van de crossover tussen house en Eurodance.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM19000533",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1744457955",
+        "de": "applemusic://track/471724183",
+        "gb": "applemusic://track/471724183",
+        "fr": "applemusic://track/471724183",
+        "es": "applemusic://track/471724183",
+        "nl": "applemusic://track/471724183",
+        "it": "applemusic://track/471724183"
+      }
     },
     {
       "year": 1992,
@@ -693,7 +883,17 @@
       "uri_tidal": "tidal://track/81728795",
       "uri_deezer": "deezer://track/3785942592",
       "fun_fact_nl": "De grootste hit van Snap! stond bovenaan de hitlijsten in meerdere landen en wordt beschouwd als een van de definitieve Eurodance-klassiekers. De iconische baslijn en de 'It's a soul's companion'-hook zijn direct herkenbaar.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DET189200900",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1437353059",
+        "de": "applemusic://track/1437353059",
+        "gb": "applemusic://track/1437353059",
+        "fr": "applemusic://track/1437353059",
+        "es": "applemusic://track/1437353059",
+        "nl": "applemusic://track/1437353059",
+        "it": "applemusic://track/1437353059"
+      }
     },
     {
       "year": 1995,
@@ -724,7 +924,17 @@
       "uri_tidal": "tidal://track/1291248",
       "uri_deezer": "deezer://track/76461369",
       "fun_fact_nl": "De doorbraaksingle van No Mercy werd een enorme hit in heel Europa, waarbij R&B-zang werd gecombineerd met Eurodance-productie.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DED160200023",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/214479857",
+        "de": "applemusic://track/214479857",
+        "gb": "applemusic://track/214479857",
+        "fr": "applemusic://track/214479857",
+        "es": "applemusic://track/214479857",
+        "nl": "applemusic://track/214479857",
+        "it": "applemusic://track/214479857"
+      }
     },
     {
       "year": 1999,
@@ -752,7 +962,17 @@
       "uri_tidal": "tidal://track/9356441",
       "uri_deezer": "deezer://track/11390029",
       "fun_fact_nl": "De opvolger van Darude op 'Sandstorm' zette zijn kenmerkende trance-geluid voort met stuwende beats en melodieuze synths.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "FISGC0000001",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/271969670",
+        "de": "applemusic://track/271969670",
+        "gb": "applemusic://track/271969670",
+        "fr": "applemusic://track/271969670",
+        "es": "applemusic://track/271969670",
+        "nl": "applemusic://track/271969670",
+        "it": "applemusic://track/271969670"
+      }
     },
     {
       "year": 1995,
@@ -783,7 +1003,17 @@
       "uri_tidal": "tidal://track/3381203",
       "uri_deezer": "deezer://track/5363024",
       "fun_fact_nl": "Bomfunk MC's 'Freestyler' werd een wereldwijd fenomeen met zijn door breakbeat beïnvloede geluid en de gedenkwaardige videoclip vol breakdance.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "FISME9900023",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/260655284",
+        "de": "applemusic://track/260655284",
+        "gb": "applemusic://track/354137528",
+        "fr": "applemusic://track/260655284",
+        "es": "applemusic://track/260655284",
+        "nl": "applemusic://track/260655284",
+        "it": "applemusic://track/260655284"
+      }
     },
     {
       "year": 1999,
@@ -814,7 +1044,17 @@
       "uri_tidal": "tidal://track/235078660",
       "uri_deezer": "deezer://track/1802291377",
       "fun_fact_nl": "De trance-klassieker van Alice Deejay werd een enorme clubhit en is ontelbare keren geremixt en gesampled. De melancholische melodie en krachtige zang van het nummer maakten het tot een klassieker op de dansvloer.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "NLC529811129",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1631123438",
+        "de": "applemusic://track/1631123438",
+        "gb": "applemusic://track/1631123438",
+        "fr": "applemusic://track/1631123438",
+        "es": "applemusic://track/1631123438",
+        "nl": "applemusic://track/1631123438",
+        "it": "applemusic://track/1631123438"
+      }
     },
     {
       "year": 2000,
@@ -872,7 +1112,17 @@
       "uri_tidal": "tidal://track/235077794",
       "uri_deezer": "deezer://track/1802253167",
       "fun_fact_nl": "Het feestnummer van de Vengaboys bereikte de top van de Britse hitlijsten en werd hun bekendste nummer. De kleurrijke, overdreven esthetiek en aanstekelijke hooks van de Nederlandse groep maakten hen tot Eurodance-iconen van de late jaren '90.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "NLC529811150",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1640586263",
+        "de": "applemusic://track/1640586263",
+        "gb": "applemusic://track/1640586263",
+        "fr": "applemusic://track/1640586263",
+        "es": "applemusic://track/1640586263",
+        "nl": "applemusic://track/1640586263",
+        "it": "applemusic://track/1640586263"
+      }
     },
     {
       "year": 1996,
@@ -903,7 +1153,17 @@
       "uri_tidal": "tidal://track/661795",
       "uri_deezer": "deezer://track/990761",
       "fun_fact_nl": "De Bayside Boys-remix van 'Macarena' stond 14 weken op nummer 1 in de Billboard Hot 100 en werd een van de grootste eendagsvliegen ooit. De dansrage veroverde in 1996 de hele wereld.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "ES5109500537",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1784765655",
+        "de": "applemusic://track/509169792",
+        "gb": "applemusic://track/509169792",
+        "fr": "applemusic://track/509169792",
+        "es": "applemusic://track/509169792",
+        "nl": "applemusic://track/509169792",
+        "it": "applemusic://track/509169792"
+      }
     },
     {
       "year": 1994,
@@ -934,7 +1194,17 @@
       "uri_tidal": "tidal://track/104646076",
       "uri_deezer": "deezer://track/637672712",
       "fun_fact_nl": "Corona's debuutsingle werd een wereldwijde knaller en verkocht meer dan 2 miljoen exemplaren. Het aanstekelijke ritme en de gedenkwaardige hook maakten het een vaste waarde op de dansvloeren van de jaren '90.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEE861900621",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1453999499",
+        "de": "applemusic://track/1453999499",
+        "gb": "applemusic://track/1453999499",
+        "fr": "applemusic://track/1453999499",
+        "es": "applemusic://track/1453999499",
+        "nl": "applemusic://track/1453999499",
+        "it": "applemusic://track/1453999499"
+      }
     },
     {
       "year": 1997,
@@ -965,7 +1235,17 @@
       "uri_tidal": "tidal://track/633691",
       "uri_deezer": "deezer://track/1115044",
       "fun_fact_nl": "De controversiële hit van Aqua leidde tot een rechtszaak van Mattel over het handelsmerk Barbie. De rechter deed uitspraak in het voordeel van Aqua en concludeerde beroemd: 'The parties are advised to chill.'",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DKBKA9700403",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1703859938",
+        "de": "applemusic://track/1703859938",
+        "gb": "applemusic://track/1703859938",
+        "fr": "applemusic://track/1703859938",
+        "es": "applemusic://track/1703859938",
+        "nl": "applemusic://track/1703859938",
+        "it": "applemusic://track/1703859938"
+      }
     },
     {
       "year": 1996,
@@ -1025,7 +1305,17 @@
       "uri_tidal": "tidal://track/75174575",
       "uri_deezer": "deezer://track/6472495",
       "fun_fact_nl": "De mix van latin en Eurodance van Paradisio bracht tropische sferen naar de dansvloer met zijn aanstekelijke Spaanse tekst en blazerssamples.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "BEP789688132",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1818370496",
+        "de": "applemusic://track/1818370496",
+        "gb": "applemusic://track/1818370496",
+        "fr": "applemusic://track/1846853834",
+        "es": "applemusic://track/1818370496",
+        "nl": "applemusic://track/1818370496",
+        "it": "applemusic://track/1818370496"
+      }
     },
     {
       "year": 1998,
@@ -1055,7 +1345,17 @@
       "uri_tidal": "tidal://track/17567",
       "uri_deezer": "deezer://track/2896381531",
       "fun_fact_nl": "De remix uit '98 van Modern Talking van hun klassieker uit 1984 bracht hun romantische synth-pop naar het Eurodance-tijdperk.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEC738400032",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/570743501",
+        "de": "applemusic://track/796424475",
+        "gb": "applemusic://track/454704827",
+        "fr": "applemusic://track/796424475",
+        "es": "applemusic://track/796424475",
+        "nl": "applemusic://track/796424475",
+        "it": "applemusic://track/796424475"
+      }
     },
     {
       "year": 1995,
@@ -1085,7 +1385,17 @@
       "uri_tidal": "tidal://track/441959749",
       "uri_deezer": "deezer://track/3413801451",
       "fun_fact_nl": "De Eurodance-cover van Double You van de discoklassieker van KC and the Sunshine Band werd een grote Europese hit.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "IT00C9200201",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1874940720",
+        "de": "applemusic://track/1821318239",
+        "gb": "applemusic://track/1821318239",
+        "fr": "applemusic://track/1821318239",
+        "es": "applemusic://track/1821318239",
+        "nl": "applemusic://track/1821318239",
+        "it": "applemusic://track/1821318239"
+      }
     },
     {
       "year": 1995,
@@ -1115,7 +1425,17 @@
       "uri_tidal": "tidal://track/4978602",
       "uri_deezer": "deezer://track/7035328",
       "fun_fact_nl": "Faithless' 'Insomnia' is een van de meest iconische dancetracks aller tijden, met de gesproken zang van Maxi Jazz over een hypnotiserende dancebeat. Het nummer is ontelbare keren geremixt.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBBXH9600001",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/279233098",
+        "de": "applemusic://track/324727329",
+        "gb": "applemusic://track/370145751",
+        "fr": "applemusic://track/370145751",
+        "es": "applemusic://track/370145751",
+        "nl": "applemusic://track/370145751",
+        "it": "applemusic://track/370145751"
+      }
     },
     {
       "year": 1995,
@@ -1146,7 +1466,17 @@
       "uri_tidal": "tidal://track/15214695",
       "uri_deezer": "deezer://track/99360002",
       "fun_fact_nl": "Scatman John overwon een ernstig stotterprobleem om op 53-jarige leeftijd een internationale ster te worden. Zijn unieke mix van scat-zang en Eurodance werd wereldwijd meer dan 6 miljoen keer verkocht en inspireerde miljoenen mensen met zijn boodschap van het overwinnen van tegenspoed.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DKELA9610005",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/330241516",
+        "de": "applemusic://track/330241516",
+        "gb": "applemusic://track/330241516",
+        "fr": "applemusic://track/330241516",
+        "es": "applemusic://track/330241516",
+        "nl": "applemusic://track/330241516",
+        "it": "applemusic://track/330241516"
+      }
     },
     {
       "year": 1995,
@@ -1174,7 +1504,17 @@
       "uri_tidal": "tidal://track/430704940",
       "uri_deezer": "deezer://track/3328953781",
       "fun_fact_nl": "De opvolger van French Affair op 'Sexy' zette hun door latin beïnvloede Eurodance-geluid voort met zwoele Franse zang.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEX050900074",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1809165568",
+        "de": "applemusic://track/1809165568",
+        "gb": "applemusic://track/1809165568",
+        "fr": "applemusic://track/1809165568",
+        "es": "applemusic://track/1809165568",
+        "nl": "applemusic://track/1809165568",
+        "it": "applemusic://track/1809165568"
+      }
     },
     {
       "year": 1995,
@@ -1202,7 +1542,17 @@
       "uri_tidal": "tidal://track/18143016",
       "uri_deezer": "deezer://track/584373482",
       "fun_fact_nl": "De Eurodance-track van Solid Base bevatte de kenmerkende energieke beats en aanstekelijke hooks die het Zweedse Eurodance-geluid definieerden.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "SERJR9601040",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/105601852",
+        "de": "applemusic://track/105601852",
+        "gb": "applemusic://track/105601852",
+        "fr": "applemusic://track/105601852",
+        "es": "applemusic://track/105601852",
+        "nl": "applemusic://track/105601852",
+        "it": "applemusic://track/105601852"
+      }
     },
     {
       "year": 1995,
@@ -1232,7 +1582,17 @@
       "uri_tidal": "tidal://track/268000545",
       "uri_deezer": "deezer://track/3801448032",
       "fun_fact_nl": "De doorbraakhit van Dr. Alban combineerde reggae-invloeden met Eurodance-beats, wat een uniek geluid creëerde dat overal in Europa de hitlijsten aanvoerde.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEA819200287",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1614485758",
+        "de": "applemusic://track/1614485758",
+        "gb": "applemusic://track/1614485758",
+        "fr": "applemusic://track/1614485758",
+        "es": "applemusic://track/1614485758",
+        "nl": "applemusic://track/1614485758",
+        "it": "applemusic://track/1614485758"
+      }
     },
     {
       "year": 1995,
@@ -1260,7 +1620,17 @@
       "uri_tidal": "tidal://track/5163837",
       "uri_deezer": "deezer://track/2721481",
       "fun_fact_nl": "De speelse Eurodance-track van Daze bevatte aanstekelijke hooks en de kenmerkende energieke productie van het midden van de jaren '90.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DKAXJ9757101",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/300984635",
+        "de": "applemusic://track/300984635",
+        "gb": "applemusic://track/300984635",
+        "fr": "applemusic://track/300984635",
+        "es": "applemusic://track/300984635",
+        "nl": "applemusic://track/300984635",
+        "it": "applemusic://track/300984635"
+      }
     },
     {
       "year": 1995,
@@ -1288,7 +1658,17 @@
       "uri_tidal": "tidal://track/1652707",
       "uri_deezer": "deezer://track/928094",
       "fun_fact_nl": "E-Type creëerde samen met Nana Hedin een Eurodance-hit die bovenaan de Zweedse hitlijsten stond en een favoriet werd in Europese clubs.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "SEBKA0111010",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1442238312",
+        "de": "applemusic://track/1442238312",
+        "gb": "applemusic://track/1442238312",
+        "fr": "applemusic://track/1442238312",
+        "es": "applemusic://track/1442238312",
+        "nl": "applemusic://track/1442238312",
+        "it": "applemusic://track/1442238312"
+      }
     },
     {
       "year": 1995,
@@ -1318,7 +1698,17 @@
       "uri_tidal": "tidal://track/496908",
       "uri_deezer": "deezer://track/971324",
       "fun_fact_nl": "De nieuwe versie van Modern Talking van hun hit uit 1985 bracht hun romantische synth-popgeluid naar het publiek van de late jaren '90.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEC739800159",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/298423500",
+        "de": "applemusic://track/1308574604",
+        "gb": "applemusic://track/1308574604",
+        "fr": "applemusic://track/1308574604",
+        "es": "applemusic://track/1308574604",
+        "nl": "applemusic://track/1308574604",
+        "it": "applemusic://track/1308574604"
+      }
     },
     {
       "year": 1995,
@@ -1375,7 +1765,17 @@
       "uri_tidal": "tidal://track/5163848",
       "uri_deezer": "deezer://track/2721527",
       "fun_fact_nl": "De energieke Eurodance-track van Daze toonde het klassieke jaren '90-geluid met krachtige zang en stuwende beats.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DKAXJ9743601",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/300984612",
+        "de": "applemusic://track/300984612",
+        "gb": "applemusic://track/300984612",
+        "fr": "applemusic://track/300984612",
+        "es": "applemusic://track/300984612",
+        "nl": "applemusic://track/300984612",
+        "it": "applemusic://track/300984612"
+      }
     },
     {
       "year": 1994,
@@ -1405,7 +1805,17 @@
       "uri_tidal": "tidal://track/17251047",
       "uri_deezer": "deezer://track/3413806461",
       "fun_fact_nl": "De opvolger van Corona op 'The Rhythm of the Night' zette hun formule van aanstekelijke hooks en meeslepende dancebeats voort.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "ITA199800034",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1880012357",
+        "de": "applemusic://track/1880012357",
+        "gb": "applemusic://track/1442915486",
+        "fr": "applemusic://track/1880012357",
+        "es": "applemusic://track/1880012357",
+        "nl": "applemusic://track/1880012357",
+        "it": "applemusic://track/1880012357"
+      }
     },
     {
       "year": 1995,
@@ -1433,7 +1843,17 @@
       "uri_tidal": "tidal://track/564885",
       "uri_deezer": "deezer://track/61686264",
       "fun_fact_nl": "De trance-klassieker van Guru Josh beleefde in 2008 een enorme herleving toen de 'Klaas Remix' wereldwijd de hitlijsten aanvoerde, waardoor een nieuwe generatie kennismaakte met het nummer.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBARL9100115",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/943232484",
+        "de": "applemusic://track/852614431",
+        "gb": "applemusic://track/852614431",
+        "fr": "applemusic://track/852614431",
+        "es": "applemusic://track/852614431",
+        "nl": "applemusic://track/852614431",
+        "it": "applemusic://track/852614431"
+      }
     },
     {
       "year": 1994,
@@ -1460,7 +1880,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=w2oZ4CUtfsY",
       "uri_deezer": "deezer://track/71180733",
       "fun_fact_nl": "De romantische Eurodance-ballade van Real McCoy toonde een zachtere kant, terwijl ze hun kenmerkende dansbare energie behielden.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEC739500140",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/302980631",
+        "de": "applemusic://track/302980631",
+        "gb": "applemusic://track/302980631",
+        "fr": "applemusic://track/302980631",
+        "es": "applemusic://track/302980631",
+        "nl": "applemusic://track/302980631",
+        "it": "applemusic://track/302980631"
+      }
     },
     {
       "year": 1995,
@@ -1491,7 +1921,17 @@
       "uri_tidal": "tidal://track/4073681",
       "uri_deezer": "deezer://track/6628158",
       "fun_fact_nl": "De house-klassieker van Robin S werd een enorme crossover-hit en sloeg een brug tussen underground housemuziek en de commerciële pophitlijsten.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USAT29300075",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1811423681",
+        "de": "applemusic://track/1811423681",
+        "gb": "applemusic://track/1811423681",
+        "fr": "applemusic://track/1811423681",
+        "es": "applemusic://track/1811423681",
+        "nl": "applemusic://track/1811423681",
+        "it": "applemusic://track/1811423681"
+      }
     },
     {
       "year": 1995,
@@ -1519,7 +1959,17 @@
       "uri_tidal": "tidal://track/18236683",
       "uri_deezer": "deezer://track/584540102",
       "fun_fact_nl": "De vrolijke Eurodance-track van Sonic Dream Collective bracht elementen van bubblegum-pop naar de dansvloer.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "SERJR9503030",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/105591243",
+        "de": "applemusic://track/105591243",
+        "gb": "applemusic://track/105591243",
+        "fr": "applemusic://track/105591243",
+        "es": "applemusic://track/105591243",
+        "nl": "applemusic://track/105591243",
+        "it": "applemusic://track/105591243"
+      }
     },
     {
       "year": 1995,
@@ -1547,7 +1997,17 @@
       "uri_tidal": "tidal://track/1652537",
       "uri_deezer": "deezer://track/1090815",
       "fun_fact_nl": "De door trance beïnvloede Eurodance-track van Antiloop werd een hit in Zweden dankzij de opbeurende melodie en stuwende beats.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "SEBKC9805010",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1609121449",
+        "de": "applemusic://track/1444581859",
+        "gb": "applemusic://track/1609121449",
+        "fr": "applemusic://track/1609121449",
+        "es": "applemusic://track/1609121449",
+        "nl": "applemusic://track/1609121449",
+        "it": "applemusic://track/1609121449"
+      }
     },
     {
       "year": 1995,
@@ -1575,7 +2035,17 @@
       "uri_tidal": "tidal://track/59555065",
       "uri_deezer": "deezer://track/123528146",
       "fun_fact_nl": "De groovy Eurodance-track van HERBIE combineerde funk-elementen met klassieke jaren '90 dance-productie voor een uniek geluid.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "SEPAS1600023",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1105148553",
+        "de": "applemusic://track/1105148553",
+        "gb": "applemusic://track/1105148553",
+        "fr": "applemusic://track/1105148553",
+        "es": "applemusic://track/1105148553",
+        "nl": "applemusic://track/1105148553",
+        "it": "applemusic://track/1105148553"
+      }
     },
     {
       "year": 1995,
@@ -1605,7 +2075,17 @@
       "uri_tidal": "tidal://track/221105981",
       "uri_deezer": "deezer://track/3801341602",
       "fun_fact_nl": "De door gospel beïnvloede Eurodance-track van Dr. Alban werd een zomerhit dankzij de opbeurende boodschap en het aanstekelijke ritme.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEA819200295",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1614626880",
+        "de": "applemusic://track/1614626880",
+        "gb": "applemusic://track/1614626880",
+        "fr": "applemusic://track/1614626880",
+        "es": "applemusic://track/1614626880",
+        "nl": "applemusic://track/1614626880",
+        "it": "applemusic://track/1614626880"
+      }
     },
     {
       "year": 1995,
@@ -1633,7 +2113,17 @@
       "uri_tidal": "tidal://track/3966651",
       "uri_deezer": "deezer://track/10786026",
       "fun_fact_nl": "De aanstekelijke Eurodance-track van Da Buzz werd een hit in de Zweedse hitlijsten met zijn gedenkwaardige hook en energieke productie.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "SEVJH0703902",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1093529442",
+        "de": "applemusic://track/1093529442",
+        "gb": "applemusic://track/1093529442",
+        "fr": "applemusic://track/1093529442",
+        "es": "applemusic://track/1093529442",
+        "nl": "applemusic://track/1093529442",
+        "it": "applemusic://track/1093529442"
+      }
     },
     {
       "year": 1995,
@@ -1661,7 +2151,17 @@
       "uri_tidal": "tidal://track/464033851",
       "uri_deezer": "deezer://track/3580502441",
       "fun_fact_nl": "De provocerende Eurodance-track van E-Rotic werd berucht om zijn expliciete teksten en gewaagde thema, en groeide uit tot een cultklassieker in het genre.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEQ092000107",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1843207012",
+        "de": "applemusic://track/1843207012",
+        "gb": "applemusic://track/1843207012",
+        "fr": "applemusic://track/1843207012",
+        "es": "applemusic://track/1843207012",
+        "nl": "applemusic://track/1843207012",
+        "it": "applemusic://track/1843207012"
+      }
     },
     {
       "year": 1995,
@@ -1689,7 +2189,17 @@
       "uri_tidal": "tidal://track/419839",
       "uri_deezer": "deezer://track/588319532",
       "fun_fact_nl": "De Eurodance-track van Infinity combineerde emotionele zang met energieke beats, wat zorgde voor een gedenkwaardig moment op de dansvloer.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "NOFFM0192010",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/296114880",
+        "de": "applemusic://track/296114880",
+        "gb": "applemusic://track/296114880",
+        "fr": "applemusic://track/296114880",
+        "es": "applemusic://track/296114880",
+        "nl": "applemusic://track/296114880",
+        "it": "applemusic://track/296114880"
+      }
     },
     {
       "year": 1995,
@@ -1720,7 +2230,17 @@
       "uri_tidal": "tidal://track/1823575",
       "uri_deezer": "deezer://track/992292",
       "fun_fact_nl": "De soulful dance-pop hit van Londonbeat maakte de overstap van R&B naar Eurodance-markten en stond in 1990-1991 wereldwijd bovenaan de hitlijsten.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEA410500815",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1736762314",
+        "de": "applemusic://track/1736762314",
+        "gb": "applemusic://track/1736762314",
+        "fr": "applemusic://track/1736762314",
+        "es": "applemusic://track/1736762314",
+        "nl": "applemusic://track/1736762314",
+        "it": "applemusic://track/1736762314"
+      }
     },
     {
       "year": 1995,
@@ -1748,7 +2268,17 @@
       "uri_tidal": "tidal://track/27521430",
       "uri_deezer": "deezer://track/76489788",
       "fun_fact_nl": "De energieke Eurodance-track van Le Click werd een favoriet in clubs met zijn aanstekelijke energie en gedenkwaardige hook.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DED169600143",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1719278235",
+        "de": "applemusic://track/1719278235",
+        "gb": "applemusic://track/1719278235",
+        "fr": "applemusic://track/1719278235",
+        "es": "applemusic://track/1719278235",
+        "nl": "applemusic://track/1719278235",
+        "it": "applemusic://track/1719278235"
+      }
     },
     {
       "year": 1995,
@@ -1778,7 +2308,17 @@
       "uri_tidal": "tidal://track/17227746",
       "uri_deezer": "deezer://track/2841382",
       "fun_fact_nl": "Blümchen (Jasmin Wagner) werd de Duitse prinses van de bubblegum dance met dit vrolijke Eurodance-nummer, dat vooral een jonger publiek aansprak.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEBL60605394",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/258092643",
+        "de": "applemusic://track/258092643",
+        "gb": "applemusic://track/258092643",
+        "fr": "applemusic://track/258092643",
+        "es": "applemusic://track/258092643",
+        "nl": "applemusic://track/258092643",
+        "it": "applemusic://track/258092643"
+      }
     },
     {
       "year": 1995,
@@ -1836,7 +2376,17 @@
       "uri_tidal": "tidal://track/2570651",
       "uri_deezer": "deezer://track/927981",
       "fun_fact_nl": "De energieke Eurodance-track van E-Type werd een hit in Zweden en toonde de sterke Eurodance-scene van het land in het midden van de jaren '90.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "SEBKA9425040",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1846448048",
+        "de": "applemusic://track/1846448048",
+        "gb": "applemusic://track/1846448048",
+        "fr": "applemusic://track/1846448048",
+        "es": "applemusic://track/1846448048",
+        "nl": "applemusic://track/1846448048",
+        "it": "applemusic://track/1846448048"
+      }
     },
     {
       "year": 1995,
@@ -1863,7 +2413,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=q6O0GxhOvNw",
       "uri_tidal": "tidal://track/50332071",
       "fun_fact_nl": "De door disco beïnvloede Eurodance-track van Alcazar bevatte een sample van 'Spacer' van Sheila & B. Devotion, wat het een retro disco-vibe uit de jaren '70 gaf met een moderne productie.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "SEBMA0065010",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1874296691",
+        "de": "applemusic://track/1874296691",
+        "gb": "applemusic://track/1874296691",
+        "fr": "applemusic://track/1874296691",
+        "es": "applemusic://track/1874296691",
+        "nl": "applemusic://track/1790923405",
+        "it": "applemusic://track/1874296691"
+      }
     },
     {
       "year": 1995,
@@ -1891,7 +2451,17 @@
       "uri_tidal": "tidal://track/388100313",
       "uri_deezer": "deezer://track/3000524821",
       "fun_fact_nl": "De aanstekelijke Eurodance-track van 2 Eivissa bevatte tropische vibes en een onvergetelijke 'Oh la la la'-hook die bepalend was voor zomerse feest-playlists.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "NLML69700076",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1769354971",
+        "de": "applemusic://track/1769354971",
+        "gb": "applemusic://track/1769354971",
+        "fr": "applemusic://track/1769354971",
+        "es": "applemusic://track/1769354971",
+        "nl": "applemusic://track/1769354971",
+        "it": "applemusic://track/1769354971"
+      }
     },
     {
       "year": 1995,
@@ -1922,7 +2492,17 @@
       "uri_tidal": "tidal://track/190476553",
       "uri_deezer": "deezer://track/419139102",
       "fun_fact_nl": "De techno-country fusion van Rednex werd een enorme hit en stond overal in Europa bovenaan de hitlijsten. De 'hillbilly'-personages van de Zweedse groep waren volledig fictief en gecreëerd voor marketingdoeleinden.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAHK9400110",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1540698084",
+        "de": null,
+        "gb": null,
+        "fr": null,
+        "es": null,
+        "nl": null,
+        "it": null
+      }
     },
     {
       "year": 1995,
@@ -1952,7 +2532,17 @@
       "uri_tidal": "tidal://track/3210501",
       "uri_deezer": "deezer://track/12159134",
       "fun_fact_nl": "De doorbraakhit van Urban Cookie Collective combineerde housemuziek met Eurodance-elementen, wat resulteerde in een aanstekelijke clubhit.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBBLG0400734",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/658244084",
+        "de": "applemusic://track/368942943",
+        "gb": "applemusic://track/368942943",
+        "fr": "applemusic://track/368942943",
+        "es": "applemusic://track/368942943",
+        "nl": "applemusic://track/368942943",
+        "it": "applemusic://track/368942943"
+      }
     },
     {
       "year": 1995,
@@ -1983,7 +2573,17 @@
       "uri_tidal": "tidal://track/430704913",
       "uri_deezer": "deezer://track/3328952981",
       "fun_fact_nl": "De door latin beïnvloede Eurodance-track van French Affair bracht een sexy, zwoele vibe naar het genre met zang met een Frans accent.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEX050600040",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1809166399",
+        "de": "applemusic://track/1809166399",
+        "gb": "applemusic://track/1809166399",
+        "fr": "applemusic://track/1809166399",
+        "es": "applemusic://track/1809166399",
+        "nl": "applemusic://track/1809166399",
+        "it": "applemusic://track/1809166399"
+      }
     },
     {
       "year": 1995,
@@ -2041,7 +2641,17 @@
       "uri_tidal": "tidal://track/18142883",
       "uri_deezer": "deezer://track/584540902",
       "fun_fact_nl": "De energieke Eurodance-track van Solid Base werd een Zweedse club-klassieker met zijn onophoudelijke beats en aanstekelijke hooks.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "SERJR9913080",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/105624087",
+        "de": "applemusic://track/105624087",
+        "gb": "applemusic://track/105624087",
+        "fr": "applemusic://track/105624087",
+        "es": "applemusic://track/105624087",
+        "nl": "applemusic://track/105624087",
+        "it": "applemusic://track/105624087"
+      }
     },
     {
       "year": 1995,
@@ -2069,7 +2679,17 @@
       "uri_apple_music": "applemusic://track/1674650427",
       "uri_youtube_music": "https://music.youtube.com/watch?v=n8G5Bzj_U3k",
       "fun_fact_nl": "De hard-trance cover van Scooter van de klassieker van Supertramp werd een enorme hit en toonde hun kenmerkende 'How much is the fish?'-stijl van energieke rave.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEN061301394",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1674650427",
+        "de": "applemusic://track/1674650427",
+        "gb": "applemusic://track/1674650427",
+        "fr": "applemusic://track/1674650427",
+        "es": "applemusic://track/1674650427",
+        "nl": "applemusic://track/1674650427",
+        "it": "applemusic://track/1674650427"
+      }
     },
     {
       "year": 1995,
@@ -2097,7 +2717,17 @@
       "uri_tidal": "tidal://track/18298535",
       "uri_deezer": "deezer://track/584370922",
       "fun_fact_nl": "Het speelse Eurodance-nummer van Bobby Summer bevatte onzinnige maar pakkende teksten die een guilty pleasure werden op de dansvloeren van de jaren 90.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "SERJR9904010",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/105611783",
+        "de": "applemusic://track/105611783",
+        "gb": "applemusic://track/105611783",
+        "fr": "applemusic://track/105611783",
+        "es": "applemusic://track/105611783",
+        "nl": "applemusic://track/105611783",
+        "it": "applemusic://track/105611783"
+      }
     },
     {
       "year": 1995,
@@ -2125,7 +2755,17 @@
       "uri_tidal": "tidal://track/18142886",
       "uri_deezer": "deezer://track/584490832",
       "fun_fact_nl": "Het opzwepende Eurodance-nummer van Solid Base combineert krachtige zang met stuwende beats tot een Zweedse dansklassieker.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "SERJR9913050",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/105612340",
+        "de": "applemusic://track/105612340",
+        "gb": "applemusic://track/105612340",
+        "fr": "applemusic://track/105612340",
+        "es": "applemusic://track/105612340",
+        "nl": "applemusic://track/105612340",
+        "it": "applemusic://track/105612340"
+      }
     },
     {
       "year": 1995,
@@ -2181,7 +2821,17 @@
       "uri_tidal": "tidal://track/1291253",
       "uri_deezer": "deezer://track/76461375",
       "fun_fact_nl": "Het emotionele Eurodance-nummer van La Bouche liet de krachtige zang van Melanie Thornton horen op een aanstekelijke dansproductie.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DED160200024",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/849067456",
+        "de": "applemusic://track/849067456",
+        "gb": "applemusic://track/849067456",
+        "fr": "applemusic://track/849067456",
+        "es": "applemusic://track/849067456",
+        "nl": "applemusic://track/849067456",
+        "it": "applemusic://track/849067456"
+      }
     },
     {
       "year": 1995,
@@ -2235,7 +2885,17 @@
       "uri_tidal": "tidal://track/74209681",
       "uri_deezer": "deezer://track/364243461",
       "fun_fact_nl": "Dance 4 Color bracht high-energy Eurodance naar de dansvloer met pulserende beats en pakkende vocale hooks.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USWR30912098",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/351852661",
+        "de": "applemusic://track/351852661",
+        "gb": "applemusic://track/351852661",
+        "fr": "applemusic://track/351852661",
+        "es": "applemusic://track/351852661",
+        "nl": "applemusic://track/351852661",
+        "it": "applemusic://track/351852661"
+      }
     },
     {
       "year": 1995,
@@ -2263,7 +2923,17 @@
       "uri_tidal": "tidal://track/14635323",
       "uri_deezer": "deezer://track/2208313",
       "fun_fact_nl": "Het duistere Eurodance-nummer van Magic Affair bevat griezelige samples en stuwende beats, die een sfeervolle danservaring creëren.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEEM94000002",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/276609794",
+        "de": "applemusic://track/276609794",
+        "gb": "applemusic://track/276609794",
+        "fr": "applemusic://track/276609794",
+        "es": "applemusic://track/276609794",
+        "nl": "applemusic://track/276609794",
+        "it": "applemusic://track/276609794"
+      }
     },
     {
       "year": 1995,
@@ -2291,7 +2961,17 @@
       "uri_tidal": "tidal://track/74209680",
       "uri_deezer": "deezer://track/364243451",
       "fun_fact_nl": "Het emotionele Eurodance-nummer van Fourteen 14 mengt hartverwarmende zang met upbeat productie voor een bitterzoete danservaring.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "IT00C9402102",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1857138212",
+        "de": "applemusic://track/1857138212",
+        "gb": "applemusic://track/1857138212",
+        "fr": "applemusic://track/1857138212",
+        "es": "applemusic://track/1857138212",
+        "nl": "applemusic://track/1857138212",
+        "it": "applemusic://track/1857138212"
+      }
     },
     {
       "year": 1995,
@@ -2318,7 +2998,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=oiqppGopxB0",
       "uri_deezer": "deezer://track/4369738",
       "fun_fact_nl": "New Limit's opzwepende Eurodance anthem moedigde luisteraars aan om te glimlachen met zijn positieve boodschap en aanstekelijke energie.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "ES5770690316",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1662396340",
+        "de": "applemusic://track/1662396340",
+        "gb": "applemusic://track/1662396340",
+        "fr": "applemusic://track/1662396340",
+        "es": "applemusic://track/1662396340",
+        "nl": "applemusic://track/1662396340",
+        "it": "applemusic://track/1662396340"
+      }
     },
     {
       "year": 1995,
@@ -2346,7 +3036,17 @@
       "uri_tidal": "tidal://track/108568013",
       "uri_deezer": "deezer://track/25574781",
       "fun_fact_nl": "De energieke Eurodance-track van Da Buzz werd een hit in Zweden en een favoriet in de clubs.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "NLA240305443",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1541154481",
+        "de": "applemusic://track/152436126",
+        "gb": "applemusic://track/152436126",
+        "fr": "applemusic://track/152436126",
+        "es": "applemusic://track/152436126",
+        "nl": "applemusic://track/152436126",
+        "it": "applemusic://track/152436126"
+      }
     },
     {
       "year": 1995,
@@ -2374,7 +3074,17 @@
       "uri_tidal": "tidal://track/5163838",
       "uri_deezer": "deezer://track/2721488",
       "fun_fact_nl": "De romantische Eurodance-track van Daze combineert weelderige productie met oprechte zang voor een dromerige dansvloerervaring.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DKAXJ9796102",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/300984638",
+        "de": "applemusic://track/300984638",
+        "gb": "applemusic://track/300984638",
+        "fr": "applemusic://track/300984638",
+        "es": "applemusic://track/300984638",
+        "nl": "applemusic://track/300984638",
+        "it": "applemusic://track/300984638"
+      }
     },
     {
       "year": 1995,
@@ -2402,7 +3112,17 @@
       "uri_tidal": "tidal://track/70979756",
       "uri_deezer": "deezer://track/143154464",
       "fun_fact_nl": "Het energieke Eurodance-nummer van Captain Hollywood Project werd een Europese club met krachtige rapzang en stuwende beats.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEMI60900092",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1210884879",
+        "de": "applemusic://track/1210884879",
+        "gb": "applemusic://track/1210884879",
+        "fr": "applemusic://track/1210884879",
+        "es": "applemusic://track/1210884879",
+        "nl": "applemusic://track/1210884879",
+        "it": "applemusic://track/1210884879"
+      }
     },
     {
       "year": 1995,
@@ -2459,7 +3179,17 @@
       "uri_tidal": "tidal://track/3455003",
       "uri_deezer": "deezer://track/5454980",
       "fun_fact_nl": "Het energieke Eurodance-nummer van Basic Element werd een Zweedse hit met zijn memorabele hooks en stuwende productie.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "SEAMA9375019",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/692569266",
+        "de": "applemusic://track/692569266",
+        "gb": "applemusic://track/692569266",
+        "fr": "applemusic://track/692569266",
+        "es": "applemusic://track/692569266",
+        "nl": "applemusic://track/692569266",
+        "it": "applemusic://track/692569266"
+      }
     },
     {
       "year": 1995,
@@ -2487,7 +3217,17 @@
       "uri_tidal": "tidal://track/6526760",
       "uri_deezer": "deezer://track/12181666",
       "fun_fact_nl": "Het energieke Eurodance-nummer van Rage bevat krachtige zang en meedogenloze beats die perfect zijn voor de dansvloer.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBBLG9200186",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/433668988",
+        "de": "applemusic://track/429538286",
+        "gb": "applemusic://track/429538286",
+        "fr": "applemusic://track/429538286",
+        "es": "applemusic://track/429538286",
+        "nl": "applemusic://track/429538286",
+        "it": "applemusic://track/429538286"
+      }
     },
     {
       "year": 1995,
@@ -2515,7 +3255,17 @@
       "uri_tidal": "tidal://track/174683933",
       "uri_deezer": "deezer://track/1253628332",
       "fun_fact_nl": "De romantische Eurodance-track van La Cream is gericht op oprechte teksten en emotionele overbrenging op pulserende beats.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "SE3SA2101603",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1555581277",
+        "de": "applemusic://track/1555581277",
+        "gb": "applemusic://track/1555581277",
+        "fr": "applemusic://track/1555581277",
+        "es": "applemusic://track/1555581277",
+        "nl": "applemusic://track/1555581277",
+        "it": "applemusic://track/1555581277"
+      }
     },
     {
       "year": 1995,
@@ -2542,7 +3292,17 @@
       "uri_tidal": "tidal://track/500714",
       "uri_deezer": "deezer://track/992958",
       "fun_fact_nl": "De romantische Eurodance-track van La Cream is gericht op oprechte teksten en emotionele overbrenging op pulserende beats.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "SEBMA9887010",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/345069329",
+        "de": "applemusic://track/345069329",
+        "gb": "applemusic://track/345069329",
+        "fr": "applemusic://track/345069329",
+        "es": "applemusic://track/345069329",
+        "nl": "applemusic://track/345069329",
+        "it": "applemusic://track/345069329"
+      }
     },
     {
       "year": 1995,
@@ -2599,7 +3359,17 @@
       "uri_tidal": "tidal://track/1298690",
       "uri_deezer": "deezer://track/62937334",
       "fun_fact_nl": "Dr. Bombay's eigenzinnige 'Taxi, Taxi, Taxi' werd een nieuwe Eurodance hit met zijn speelse Indiase melodie en komische uitvoering.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "SEPQA9821010",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/269174224",
+        "de": "applemusic://track/269174224",
+        "gb": "applemusic://track/269174224",
+        "fr": "applemusic://track/269174224",
+        "es": "applemusic://track/269174224",
+        "nl": "applemusic://track/269174224",
+        "it": "applemusic://track/269174224"
+      }
     },
     {
       "year": 1995,
@@ -2655,7 +3425,17 @@
       "uri_tidal": "tidal://track/3435138",
       "uri_deezer": "deezer://track/61323503",
       "fun_fact_nl": "Toy-Box's bubblegum danstrack met junglethema bevatte speelse teksten en werd met zijn cartoonachtige esthetiek een hit in heel Europa.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DK4BB9800202",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/298618152",
+        "de": "applemusic://track/298618152",
+        "gb": "applemusic://track/298618152",
+        "fr": "applemusic://track/298618152",
+        "es": "applemusic://track/298618152",
+        "nl": "applemusic://track/298618152",
+        "it": "applemusic://track/298618152"
+      }
     },
     {
       "year": 1995,
@@ -2683,7 +3463,17 @@
       "uri_tidal": "tidal://track/658331",
       "uri_deezer": "deezer://track/15263221",
       "fun_fact_nl": "Brooklyn Bounce's harde trance track definieerde de Duitse rave-cultuur van eind jaren 90 met minimale vocalen en maximale energie.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEE860001012",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1571951674",
+        "de": "applemusic://track/1571951674",
+        "gb": "applemusic://track/1571951674",
+        "fr": "applemusic://track/1571951674",
+        "es": "applemusic://track/1571951674",
+        "nl": "applemusic://track/1571951674",
+        "it": "applemusic://track/1571951674"
+      }
     },
     {
       "year": 2000,
@@ -2710,7 +3500,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=G9It3f_5IEA",
       "uri_tidal": "tidal://track/4597496",
       "fun_fact_nl": "Look Twice's remake uit 2010 bracht moderne electro-house productie naar klassieke Eurodance energie.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "FISCA1000025",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/395663450",
+        "de": "applemusic://track/395663450",
+        "gb": "applemusic://track/395663450",
+        "fr": "applemusic://track/395663450",
+        "es": "applemusic://track/395663450",
+        "nl": "applemusic://track/395663450",
+        "it": "applemusic://track/395663450"
+      }
     },
     {
       "year": 1995,
@@ -2740,7 +3540,17 @@
       "uri_tidal": "tidal://track/18938781",
       "uri_deezer": "deezer://track/16204632",
       "fun_fact_nl": "Maxx' energieke Eurodance-nummer werd een UK Top 5-hit met zijn aanstekelijke 'Get-A-Way'-hit en rave-beïnvloede productie.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "NLP431120497",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1628554356",
+        "de": "applemusic://track/1628554356",
+        "gb": "applemusic://track/1628554356",
+        "fr": "applemusic://track/1628554356",
+        "es": "applemusic://track/1628554356",
+        "nl": "applemusic://track/1628554356",
+        "it": "applemusic://track/1628554356"
+      }
     },
     {
       "year": 1995,
@@ -2768,7 +3578,17 @@
       "uri_tidal": "tidal://track/4919585",
       "uri_deezer": "deezer://track/7721762",
       "fun_fact_nl": "De trancepopanthem van Tina Cousins bevat zweverige zang op een opzwepende productie en werd een clubfavoriet.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAHK9800113",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1472192640",
+        "de": "applemusic://track/404126042",
+        "gb": "applemusic://track/404126042",
+        "fr": "applemusic://track/404126042",
+        "es": "applemusic://track/404126042",
+        "nl": "applemusic://track/404126042",
+        "it": "applemusic://track/404126042"
+      }
     },
     {
       "year": 1995,
@@ -2795,7 +3615,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=f4zSaAWDi84",
       "uri_deezer": "deezer://track/10167601",
       "fun_fact_nl": "Het hoogenergetische Eurodance-nummer van Night Rhythm dwong dansers in beweging te komen met zijn stuwende beats en dwingende zang.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "ITA730978301",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/423251106",
+        "de": "applemusic://track/423251106",
+        "gb": "applemusic://track/423251106",
+        "fr": "applemusic://track/423251106",
+        "es": "applemusic://track/423251106",
+        "nl": "applemusic://track/423251106",
+        "it": "applemusic://track/423251106"
+      }
     },
     {
       "year": 1995,
@@ -2823,7 +3653,17 @@
       "uri_tidal": "tidal://track/1474005",
       "uri_deezer": "deezer://track/3196856",
       "fun_fact_nl": "Het speelse Eurodance-nummer van Me & My, met de zang van de tweelingzussen over een bubblegumdansproductie, werd een Deense hit.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DKABA9512306",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1810722143",
+        "de": "applemusic://track/1641445791",
+        "gb": "applemusic://track/1810722143",
+        "fr": "applemusic://track/1810722143",
+        "es": "applemusic://track/1810722143",
+        "nl": "applemusic://track/1510762471",
+        "it": "applemusic://track/1810722143"
+      }
     },
     {
       "year": 1995,
@@ -2851,7 +3691,17 @@
       "uri_tidal": "tidal://track/9788498",
       "uri_deezer": "deezer://track/4369741",
       "fun_fact_nl": "De intense Eurodance-track van New Limit bouwt energie op met zijn krachtige zang en meedogenloze productie.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "ES5770690338",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/893965676",
+        "de": "applemusic://track/893965676",
+        "gb": "applemusic://track/893965676",
+        "fr": "applemusic://track/893965676",
+        "es": "applemusic://track/893965676",
+        "nl": "applemusic://track/893965676",
+        "it": "applemusic://track/893965676"
+      }
     },
     {
       "year": 1995,
@@ -2907,7 +3757,17 @@
       "uri_tidal": "tidal://track/441960087",
       "uri_deezer": "deezer://track/3413832411",
       "fun_fact_nl": "Ice MC's reggae-Eurodance fusion bevatte een krachtige milieuboodschap, waarin luisteraars werden aangespoord om 'na te denken over de manier waarop' de mensheid de planeet behandelt.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "IT00C9400102",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1821306809",
+        "de": "applemusic://track/1613178678",
+        "gb": "applemusic://track/1821306809",
+        "fr": "applemusic://track/1821306809",
+        "es": "applemusic://track/1821306809",
+        "nl": "applemusic://track/1821306809",
+        "it": "applemusic://track/1821306809"
+      }
     }
   ]
 }

--- a/custom_components/beatify/playlists/community/fiesta-latina-90s.json
+++ b/custom_components/beatify/playlists/community/fiesta-latina-90s.json
@@ -43,7 +43,17 @@
       "uri_tidal": "tidal://track/1117587",
       "uri_deezer": "deezer://track/3133738",
       "fun_fact_nl": "Wannabe werd in minder dan 30 minuten opgenomen tijdens de eerste studiosessie van de groep. Het debuteerde op nummer 1 in 37 landen en werd de bestverkochte single van een meidengroep aller tijden, met meer dan 7 miljoen verkochte exemplaren.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAAA9600008",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1742039976",
+        "de": "applemusic://track/1742039976",
+        "gb": "applemusic://track/1742039976",
+        "fr": "applemusic://track/1742039976",
+        "es": "applemusic://track/1742039976",
+        "nl": "applemusic://track/1742039976",
+        "it": "applemusic://track/1742039976"
+      }
     },
     {
       "year": 1997,
@@ -74,7 +84,17 @@
       "uri_tidal": "tidal://track/2388204",
       "uri_deezer": "deezer://track/2820791",
       "fun_fact_nl": "Afkomstig van het album 'Sueños Líquidos', dat destijds het bestverkochte Spaanstalige rockalbum werd met meer dan 10 miljoen exemplaren. Het nummer stond wekenlang bovenaan de Hot Latin Songs-hitlijst.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "MXF159700094",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1768001609",
+        "de": "applemusic://track/1743404648",
+        "gb": "applemusic://track/1768001609",
+        "fr": "applemusic://track/1768001609",
+        "es": "applemusic://track/1768001609",
+        "nl": "applemusic://track/1768001609",
+        "it": "applemusic://track/1768001609"
+      }
     },
     {
       "year": 1997,
@@ -103,7 +123,17 @@
       "uri_tidal": "tidal://track/88580033",
       "uri_deezer": "deezer://track/833443452",
       "fun_fact_nl": "De Dominicaanse percussionist en zanger ChiChi Peralta componeerde deze merengue-hit oorspronkelijk voor een andere artiest voordat hij hem zelf opnam. Het werd een volkslied in heel Latijns-Amerika en is nog steeds een vast onderdeel op Latin-feesten wereldwijd.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USJE61002249",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1389774337",
+        "de": "applemusic://track/1389774337",
+        "gb": "applemusic://track/1389774337",
+        "fr": "applemusic://track/1389774337",
+        "es": "applemusic://track/1389774337",
+        "nl": "applemusic://track/1389774337",
+        "it": "applemusic://track/1389774337"
+      }
     },
     {
       "year": 1999,
@@ -171,7 +201,17 @@
       "uri_tidal": "tidal://track/13567465",
       "uri_deezer": "deezer://track/11126567",
       "fun_fact_nl": "Proyecto Uno waren pioniers van de 'merenhouse', een fusie van Dominicaanse merengue met hiphop en house. Deze doorbraaksingle van hun debuutalbum maakte hen tot iconen van de Dominicaanse diaspora-muziekscene in New York.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "US3Z40407581",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/447454174",
+        "de": "applemusic://track/447454174",
+        "gb": "applemusic://track/447454174",
+        "fr": "applemusic://track/447454174",
+        "es": "applemusic://track/447454174",
+        "nl": "applemusic://track/447454174",
+        "it": "applemusic://track/447454174"
+      }
     },
     {
       "year": 1995,
@@ -202,7 +242,17 @@
       "uri_tidal": "tidal://track/26828295",
       "uri_deezer": "deezer://track/15407617",
       "fun_fact_nl": "Shakira's eerste internationale hit van haar doorbraakalbum 'Pies Descalzos'. Ze schreef het nummer toen ze pas 17 jaar oud was. Het album werd meer dan 5 miljoen keer verkocht en lanceerde haar van een Colombiaanse ster naar een Latijns-Amerikaanse superster.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "COS019500012",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/159119897",
+        "de": "applemusic://track/159119897",
+        "gb": "applemusic://track/159119897",
+        "fr": "applemusic://track/159119897",
+        "es": "applemusic://track/159119897",
+        "nl": "applemusic://track/159119897",
+        "it": "applemusic://track/159119897"
+      }
     },
     {
       "year": 1993,
@@ -234,7 +284,17 @@
       "uri_tidal": "tidal://track/661956",
       "uri_deezer": "deezer://track/994491",
       "fun_fact_nl": "Oorspronkelijk een langzamer nummer in rumba-stijl uit 1993, maar de remix van de Bayside Boys maakte er in 1996 een wereldwijd fenomeen van. Het stond een recordaantal van 14 opeenvolgende weken op nummer 1 in de Billboard Hot 100 en werd een van de bestverkochte singles aller tijden.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "ES5109500538",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/943232519",
+        "de": "applemusic://track/1308532018",
+        "gb": "applemusic://track/1308532018",
+        "fr": "applemusic://track/1308532018",
+        "es": "applemusic://track/1308532018",
+        "nl": "applemusic://track/1308532018",
+        "it": "applemusic://track/1308532018"
+      }
     },
     {
       "year": 1993,
@@ -263,7 +323,17 @@
       "uri_tidal": "tidal://track/4019526",
       "uri_deezer": "deezer://track/2239492",
       "fun_fact_nl": "Afkomstig van Marc Anthony's eerste Spaanstalige salsa-album 'Otra Nota'. Voordat hij zichzelf opnieuw uitvond als salsa-zanger, was hij bekend als freestyle- en popvocalist in de New Yorkse Latin-scene. Dit album lanceerde zijn carrière als salsa-icoon.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USUL10300686",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/6762660295",
+        "de": "applemusic://track/6762660295",
+        "gb": "applemusic://track/6762660295",
+        "fr": "applemusic://track/6762660295",
+        "es": "applemusic://track/6762660295",
+        "nl": "applemusic://track/6762660295",
+        "it": "applemusic://track/6762660295"
+      }
     },
     {
       "year": 1990,
@@ -301,7 +371,17 @@
       "fun_fact_nl": "De titel verwijst naar bilirubine, een stof in het bloed, hier gebruikt als metafoor voor 'ziek van liefde'. Van het Grammy-winnende album 'Bachata Rosa', dat de Dominicaanse bachata en merengue revolutioneerde en internationaal aanzien gaf.",
       "awards_nl": [
         "Grammy Award voor Beste Tropisch Latijns Album (Bachata Rosa)"
-      ]
+      ],
+      "isrc": "USKP10400046",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/19468966",
+        "de": "applemusic://track/19468966",
+        "gb": "applemusic://track/19468966",
+        "fr": "applemusic://track/19468966",
+        "es": "applemusic://track/19468966",
+        "nl": "applemusic://track/19468966",
+        "it": "applemusic://track/19468966"
+      }
     },
     {
       "year": 1999,
@@ -333,7 +413,17 @@
       "uri_tidal": "tidal://track/81794041",
       "uri_deezer": "deezer://track/434625962",
       "fun_fact_nl": "Gebaseerd op het instrumentale 'Mambo No. 5' van de Cubaanse muzikant Pérez Prado uit 1949. De Duits-Oegandese zanger Lou Bega voegde teksten toe met namen van vrouwen die hij kende. Er werden wereldwijd meer dan 16 miljoen exemplaren van verkocht en het bereikte nummer 1 in vrijwel elk Europees land.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEH259900010",
+      "uri_apple_music_by_region": {
+        "us": null,
+        "de": null,
+        "gb": null,
+        "fr": null,
+        "es": null,
+        "nl": "applemusic://track/1656111119",
+        "it": null
+      }
     },
     {
       "year": 1993,
@@ -364,7 +454,17 @@
       "uri_tidal": "tidal://track/441956660",
       "uri_deezer": "deezer://track/1428926582",
       "fun_fact_nl": "De zangeres die als Corona werd vermeld, Olga De Souza, zong de originele studiocreatie eigenlijk niet zelf — die werden ingezongen door sessiezangeres Sandy Chambers. De Italiaanse eurodance-hit werd een van de bepalende nummers van het dancetijdperk van de jaren '90.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAHT0700828",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1835614189",
+        "de": "applemusic://track/1835614189",
+        "gb": "applemusic://track/1835614189",
+        "fr": "applemusic://track/1835614189",
+        "es": "applemusic://track/1835614189",
+        "nl": "applemusic://track/1835614189",
+        "it": "applemusic://track/1835614189"
+      }
     },
     {
       "year": 1994,
@@ -395,7 +495,17 @@
       "uri_tidal": "tidal://track/250408",
       "uri_deezer": "deezer://track/3902675",
       "fun_fact_nl": "Onderdeel van de legendarische 'Romance'-serie bolero-albums van Luis Miguel, die in zijn eentje het bolero-genre nieuw leven inblies. Het album 'Segundo Romance' werd meer dan 4,5 miljoen keer verkocht en bevestigde zijn status als 'De Zon van Mexico'.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USWI19600153",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/100986783",
+        "de": "applemusic://track/121061295",
+        "gb": "applemusic://track/121061295",
+        "fr": "applemusic://track/121061295",
+        "es": "applemusic://track/121061295",
+        "nl": "applemusic://track/121061295",
+        "it": "applemusic://track/121061295"
+      }
     },
     {
       "year": 1998,
@@ -426,7 +536,17 @@
       "uri_tidal": "tidal://track/26807596",
       "uri_deezer": "deezer://track/15407611",
       "fun_fact_nl": "Bevat Arabisch beïnvloede zang, geïnspireerd door Shakira's Libanese afkomst — haar vader is van Libanese afkomst. Van het album 'Dónde Están los Ladrones?', waarvan meer dan 10 miljoen exemplaren werden verkocht. Ze voerde het beroemde nummer uit tijdens de eerste Latin Grammy Awards in 2000.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "COS019800780",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/192683270",
+        "de": "applemusic://track/192683270",
+        "gb": "applemusic://track/192683270",
+        "fr": "applemusic://track/192683270",
+        "es": "applemusic://track/192683270",
+        "nl": "applemusic://track/192683270",
+        "it": "applemusic://track/192683270"
+      }
     },
     {
       "year": 1998,
@@ -464,7 +584,17 @@
       "fun_fact_nl": "Werd het meest gedraaide merengue-nummer op de Amerikaanse radio en won de Grammy voor Best Tropical Latin Performance. De Puerto Ricaanse zanger Elvis Crespo was voorheen lid van Grupo Mania voordat hij zijn solocarrière lanceerde met deze enorme debuuthit.",
       "awards_nl": [
         "Grammy Award voor Beste Tropisch Latijnse Prestatie"
-      ]
+      ],
+      "isrc": "USSD19700576",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/187429633",
+        "de": "applemusic://track/273326469",
+        "gb": "applemusic://track/187429633",
+        "fr": "applemusic://track/187429633",
+        "es": "applemusic://track/187429633",
+        "nl": "applemusic://track/187429633",
+        "it": "applemusic://track/187429633"
+      }
     },
     {
       "year": 1998,
@@ -493,7 +623,17 @@
       "uri_tidal": "tidal://track/17780815",
       "uri_deezer": "deezer://track/15839179",
       "fun_fact_nl": "Chileense groep die een internationale eendagsvlieg werd. 'La Bomba' stond bovenaan de hitlijsten in heel Latijns-Amerika en werd een vaste waarde in Europese clubs. De aanstekelijke mix van Latin pop en eurodance definieerde het feestgeluid van de late jaren '90.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "CLA220000021",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1784765722",
+        "de": "applemusic://track/457516731",
+        "gb": "applemusic://track/457516731",
+        "fr": "applemusic://track/457516731",
+        "es": "applemusic://track/457516731",
+        "nl": "applemusic://track/456821999",
+        "it": "applemusic://track/457516731"
+      }
     },
     {
       "year": 1992,
@@ -522,7 +662,17 @@
       "uri_tidal": "tidal://track/5144750",
       "uri_deezer": "deezer://track/69008106",
       "fun_fact_nl": "De Guatemalteekse singer-songwriter Ricardo Arjona schreef dit eerbetoon aan vrouwen, dat een volkslied werd in heel Latijns-Amerika. Van het album 'Animal Nocturno', dat hem vestigde als een van de belangrijkste Latijns-Amerikaanse songwriters van zijn generatie.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "MXF149200115",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/296337652",
+        "de": "applemusic://track/265634797",
+        "gb": "applemusic://track/365215872",
+        "fr": "applemusic://track/365215872",
+        "es": "applemusic://track/322079872",
+        "nl": "applemusic://track/365215872",
+        "it": "applemusic://track/365215872"
+      }
     },
     {
       "year": 1999,
@@ -553,7 +703,17 @@
       "uri_tidal": "tidal://track/10825865",
       "uri_deezer": "deezer://track/3410774",
       "fun_fact_nl": "Hielp de Colombiaanse vallenato-muziek internationaal populair te maken. Van het album 'El Amor de Mi Tierra'; Vives was een voormalig telenovela-acteur die de traditionele vallenato revolutioneerde door deze te fuseren met rock- en popelementen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "NLA279900268",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/724352963",
+        "de": "applemusic://track/724352963",
+        "gb": "applemusic://track/724352963",
+        "fr": "applemusic://track/724352963",
+        "es": "applemusic://track/724352963",
+        "nl": "applemusic://track/724352963",
+        "it": "applemusic://track/724352963"
+      }
     },
     {
       "year": 1991,
@@ -582,7 +742,17 @@
       "uri_tidal": "tidal://track/3347299",
       "uri_deezer": "deezer://track/88610975",
       "fun_fact_nl": "Spaanstalige cover van de Franse hit 'Voyage, Voyage' van Desireless (1986). De versie van de Mexicaanse boyband werd in Latijns-Amerika veel beroemder dan het origineel en is nog steeds een karaoke- en feestklassieker in de hele Spaanstalige wereld.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "MXF148900153",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1734675094",
+        "de": "applemusic://track/1734675094",
+        "gb": "applemusic://track/1734675094",
+        "fr": "applemusic://track/1734675094",
+        "es": "applemusic://track/1734675094",
+        "nl": "applemusic://track/1734675094",
+        "it": "applemusic://track/1734675094"
+      }
     },
     {
       "year": 1992,
@@ -611,7 +781,17 @@
       "uri_tidal": "tidal://track/119449630",
       "uri_deezer": "deezer://track/769774502",
       "fun_fact_nl": "Bekend als 'El Papá de la Salsa' (De vader van de salsa), was de Puerto Ricaanse zanger Frankie Ruiz een van de belangrijkste stemmen van de salsa romántica. Hij overleed tragisch in 1998 op 40-jarige leeftijd, met een erfenis van tijdloze salsa-klassiekers achterlatend.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USUL19900233",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1710804056",
+        "de": "applemusic://track/1710804056",
+        "gb": "applemusic://track/1710804056",
+        "fr": "applemusic://track/1710804056",
+        "es": "applemusic://track/1710804056",
+        "nl": "applemusic://track/1710804056",
+        "it": "applemusic://track/1710804056"
+      }
     },
     {
       "year": 1990,
@@ -640,7 +820,17 @@
       "uri_tidal": "tidal://track/92607759",
       "uri_deezer": "deezer://track/533306542",
       "fun_fact_nl": "Een Spaanstalige cover van de discohit 'Blame It on the Boogie' van The Jacksons uit 1978. Luis Miguel veranderde de funkklassieker in een Latin pop-volkslied, wat zijn talent toonde om internationale hits te herinterpreteren voor de Spaanstalige markt.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USWI21800001",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1422838920",
+        "de": "applemusic://track/1422838920",
+        "gb": "applemusic://track/1422838920",
+        "fr": "applemusic://track/1422838920",
+        "es": "applemusic://track/1422838920",
+        "nl": "applemusic://track/1422838920",
+        "it": "applemusic://track/1422838920"
+      }
     },
     {
       "year": 1997,
@@ -669,7 +859,17 @@
       "uri_tidal": "tidal://track/30417668",
       "uri_deezer": "deezer://track/79125923",
       "fun_fact_nl": "Proyecto Uno mengde Dominicaanse merengue met hiphop en house, waardoor het genre 'merenhouse' ontstond. Gevestigd in New York vertegenwoordigden zij het geluid van de Dominicaans-Amerikaanse jeugdcultuur en waren ze zeer invloedrijk in de Latin urban-muziek van de jaren '90.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "TCABX1470910",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/885035099",
+        "de": "applemusic://track/885035099",
+        "gb": "applemusic://track/885035099",
+        "fr": "applemusic://track/885035099",
+        "es": "applemusic://track/885035099",
+        "nl": "applemusic://track/885035099",
+        "it": "applemusic://track/885035099"
+      }
     },
     {
       "year": 1995,
@@ -698,7 +898,17 @@
       "uri_tidal": "tidal://track/5022114",
       "uri_deezer": "deezer://track/6696791",
       "fun_fact_nl": "De Mexicaanse popprinses Fey combineerde Latin pop met eurodance-invloeden, waardoor een uniek geluid ontstond dat de Mexicaanse tienerpop van de jaren '90 definieerde. Dit was een van haar grootste hits en hielp haar te vestigen als een van de toonaangevende vrouwelijke popartiesten in Mexico.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "MXF149600253",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/286244921",
+        "de": "applemusic://track/1818156512",
+        "gb": "applemusic://track/1818156512",
+        "fr": "applemusic://track/1818156512",
+        "es": "applemusic://track/1818156512",
+        "nl": "applemusic://track/1818156512",
+        "it": "applemusic://track/1818156512"
+      }
     },
     {
       "year": 1999,
@@ -727,7 +937,17 @@
       "uri_tidal": "tidal://track/3328572",
       "uri_deezer": "deezer://track/557092",
       "fun_fact_nl": "De opvolger van zijn megahit 'Suavemente'. Deze track hielp de positie van Elvis Crespo als de toonaangevende merengue-artiest van de late jaren '90 te verstevigen. Zijn succes hielp merengue-muziek bij een breed internationaal publiek te brengen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSD19700581",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/932987321",
+        "de": "applemusic://track/292608798",
+        "gb": "applemusic://track/292608798",
+        "fr": "applemusic://track/292608798",
+        "es": "applemusic://track/292608798",
+        "nl": "applemusic://track/292608798",
+        "it": "applemusic://track/292608798"
+      }
     },
     {
       "year": 1995,
@@ -758,7 +978,17 @@
       "uri_tidal": "tidal://track/1369093",
       "uri_deezer": "deezer://track/3255362",
       "fun_fact_nl": "Van het album 'En Éxtasis'; Thalía was tegelijkertijd een van de grootste telenovela-sterren en popzangers van Latijns-Amerika. Ze speelde de hoofdrol in de beroemde 'María'-trilogie van telenovela's terwijl ze bovenaan de hitlijsten stond, waardoor ze een echte multimedia-superster werd.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "MXF060100285",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1713867492",
+        "de": "applemusic://track/1713867492",
+        "gb": "applemusic://track/1713867492",
+        "fr": "applemusic://track/1713867492",
+        "es": "applemusic://track/1713867492",
+        "nl": "applemusic://track/1713867492",
+        "it": "applemusic://track/1713867492"
+      }
     },
     {
       "year": 1994,
@@ -787,7 +1017,17 @@
       "uri_tidal": "tidal://track/1840219",
       "uri_deezer": "deezer://track/2889801",
       "fun_fact_nl": "De Spaanse popdiva Monica Naranjo staat bekend om haar buitengewone stembereik van vier octaven. Geboren in Figueres, Spanje, werd ze een van de grootste popexportproducten van het land en heeft ze gedurende haar carrière meer dan 10 miljoen platen verkocht.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "ES5119400123",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/283535727",
+        "de": "applemusic://track/283535727",
+        "gb": "applemusic://track/283535727",
+        "fr": "applemusic://track/283535727",
+        "es": "applemusic://track/283535727",
+        "nl": "applemusic://track/283535727",
+        "it": "applemusic://track/283535727"
+      }
     },
     {
       "year": 1997,
@@ -818,7 +1058,17 @@
       "uri_tidal": "tidal://track/57901570",
       "uri_deezer": "deezer://track/13208810",
       "fun_fact_nl": "De Puerto Ricaanse zanger Chayanne, geboren als Elmer Figueroa Arce, begon als kindlid van de boyband Los Chicos. 'Torero' werd een van zijn grootste hits en toonde zijn talent als zowel zanger als danser — hij wordt vaak de 'Latin heartthrob' genoemd.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "NLB630200016",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1653395835",
+        "de": "applemusic://track/1781779925",
+        "gb": "applemusic://track/1781779925",
+        "fr": "applemusic://track/1781779925",
+        "es": "applemusic://track/1781779925",
+        "nl": "applemusic://track/1781779925",
+        "it": "applemusic://track/1781779925"
+      }
     },
     {
       "year": 1990,
@@ -847,7 +1097,17 @@
       "uri_tidal": "tidal://track/5104603",
       "uri_deezer": "deezer://track/13249435",
       "fun_fact_nl": "De Mexicaanse zanger Emmanuel, wiens echte naam Jesús Emmanuel Acha Martínez is, is al sinds de late jaren '70 een ster. 'Bella Señora' markeerde zijn succesvolle comeback in de jaren '90 en blijft een van zijn meest aangevraagde nummers tijdens concerten in heel Latijns-Amerika.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "NLB639001010",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/321350905",
+        "de": "applemusic://track/321350905",
+        "gb": "applemusic://track/321350905",
+        "fr": "applemusic://track/321350905",
+        "es": "applemusic://track/321350905",
+        "nl": "applemusic://track/476990523",
+        "it": "applemusic://track/321350905"
+      }
     },
     {
       "year": 1993,
@@ -876,7 +1136,17 @@
       "uri_tidal": "tidal://track/42155309",
       "uri_deezer": "deezer://track/83509184",
       "fun_fact_nl": "Colombiaanse tropische groep uit Barranquilla, bekend om hun energieke live-optredens en Caribische geluid. Ze maakten deel uit van de levendige Colombiaanse tropische muziekscene die artiesten als Carlos Vives en Joe Arroyo voortbracht.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USX9P1065200",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/420794872",
+        "de": "applemusic://track/420794872",
+        "gb": "applemusic://track/420794872",
+        "fr": "applemusic://track/420794872",
+        "es": "applemusic://track/420794872",
+        "nl": "applemusic://track/420794872",
+        "it": "applemusic://track/420794872"
+      }
     },
     {
       "year": 1995,
@@ -912,7 +1182,17 @@
       "fun_fact_nl": "De Puerto Ricaanse 'Mujer de Fuego' (Vuurvrouw) Olga Tañón is een van de meest succesvolle vrouwelijke merengue-artiesten in de geschiedenis. Dit krachtige nummer over een liegende partner werd een feministisch volkslied in heel Latijns-Amerika.",
       "awards_nl": [
         "Grammy-nominatie voor Beste Merengue-album"
-      ]
+      ],
+      "isrc": "USWL19400004",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/25454718",
+        "de": "applemusic://track/140962544",
+        "gb": "applemusic://track/140962544",
+        "fr": "applemusic://track/140962544",
+        "es": "applemusic://track/140962544",
+        "nl": "applemusic://track/140962544",
+        "it": "applemusic://track/140962544"
+      }
     },
     {
       "year": 1997,
@@ -944,7 +1224,17 @@
       "uri_tidal": "tidal://track/25688677",
       "uri_deezer": "deezer://track/15608663",
       "fun_fact_nl": "De op horror geïnspireerde videoclip was gebaseerd op 'Thriller' van Michael Jackson. Oorspronkelijk alleen internationaal uitgebracht omdat het Amerikaanse label het niet wilde toevoegen, maar de vraag van fans dwong uiteindelijk tot een Amerikaanse release. De choreografie werd een van de meest iconische van de jaren '90.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USJI19710084",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1691395905",
+        "de": "applemusic://track/1691395905",
+        "gb": "applemusic://track/1691395905",
+        "fr": "applemusic://track/1691395905",
+        "es": "applemusic://track/1691395905",
+        "nl": "applemusic://track/1691395905",
+        "it": "applemusic://track/1691395905"
+      }
     },
     {
       "year": 1998,
@@ -975,7 +1265,17 @@
       "uri_tidal": "tidal://track/4964503",
       "uri_deezer": "deezer://track/895695",
       "fun_fact_nl": "Van het album 'Atado a Tu Amor', waarvan wereldwijd meer dan 5 miljoen exemplaren werden verkocht. De sensuele dancetrack toonde de uitzonderlijke danskwaliteiten van Chayanne — hij is van kinds af aan opgeleid in ballet en moderne dans.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "NLB639850008",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/193022256",
+        "de": "applemusic://track/1719225649",
+        "gb": "applemusic://track/1719225649",
+        "fr": "applemusic://track/1719225649",
+        "es": "applemusic://track/1719225649",
+        "nl": "applemusic://track/1719225649",
+        "it": "applemusic://track/1719225649"
+      }
     },
     {
       "year": 1991,
@@ -1006,7 +1306,17 @@
       "uri_tidal": "tidal://track/37230338",
       "uri_deezer": "deezer://track/13272733",
       "fun_fact_nl": "Bekend als de 'Mexicaanse Madonna' vanwege haar provocerende stijl, werd de debuutsingle van Gloria Trevi een rebels volkslied voor jonge vrouwen in heel Latijns-Amerika. Het titelnummer van haar debuutalbum symboliseerde vrijheid en doorbrak taboes in de conservatieve Mexicaanse samenleving.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "MXF019100516",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/304751873",
+        "de": "applemusic://track/304751873",
+        "gb": "applemusic://track/304751873",
+        "fr": "applemusic://track/304751873",
+        "es": "applemusic://track/304751873",
+        "nl": "applemusic://track/304751873",
+        "it": "applemusic://track/304751873"
+      }
     },
     {
       "year": 1995,
@@ -1038,7 +1348,17 @@
       "uri_tidal": "tidal://track/13163745",
       "uri_deezer": "deezer://track/13111371",
       "fun_fact_nl": "Ricky Martins grootste hit vóór 'Livin' la Vida Loca'. Het was een enorm succes in Europa en Latijns-Amerika en bereikte nummer 1 in meer dan 20 landen. Het aanstekelijke refrein 'Un, dos, tres, un pasito pa'lante María' werd een wereldwijd feestnummer.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "MXF149500003",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/187288293",
+        "de": "applemusic://track/187288293",
+        "gb": "applemusic://track/187288293",
+        "fr": "applemusic://track/187288293",
+        "es": "applemusic://track/187288293",
+        "nl": "applemusic://track/187288293",
+        "it": "applemusic://track/187288293"
+      }
     },
     {
       "year": 1996,
@@ -1067,7 +1387,17 @@
       "uri_tidal": "tidal://track/1380835",
       "uri_deezer": "deezer://track/2430177615",
       "fun_fact_nl": "Het Mexicaanse popduo Alessandra Rosaldo en Chacho Gaytán maakte aanstekelijke, radiovriendelijke pop die de Mexicaanse popscene van de jaren '90 definieerde. Alessandra trouwde later met Eugenio Derbez, waarmee ze een van de beroemdste koppels van Mexico werden.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "MXF069800207",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1698566166",
+        "de": "applemusic://track/1698566166",
+        "gb": "applemusic://track/1698566166",
+        "fr": "applemusic://track/1698566166",
+        "es": "applemusic://track/1698566166",
+        "nl": "applemusic://track/1698566166",
+        "it": "applemusic://track/1698566166"
+      }
     },
     {
       "year": 1992,
@@ -1098,7 +1428,17 @@
       "uri_tidal": "tidal://track/12861584",
       "uri_deezer": "deezer://track/94884900",
       "fun_fact_nl": "Argentijnse rockband uit Córdoba, wiens naam vertaalt als 'Vilma Palma en de Vampiers'. Dit werd een van de grootste Latin rock-feestnummers van de jaren '90, gedraaid op vrijwel elk feest in Latijns-Amerika. Hun poprock-geluid was uniek in de Argentijnse rockscene.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USA560306759",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1621555451",
+        "de": "applemusic://track/1621555451",
+        "gb": "applemusic://track/1621555451",
+        "fr": "applemusic://track/1621555451",
+        "es": "applemusic://track/1621555451",
+        "nl": "applemusic://track/1621555451",
+        "it": "applemusic://track/1621555451"
+      }
     },
     {
       "year": 1980,
@@ -1127,7 +1467,17 @@
       "uri_tidal": "tidal://track/129687123",
       "uri_deezer": "deezer://track/861307112",
       "fun_fact_nl": "De Venezolaanse 'León de la Salsa' (Leeuw van de Salsa) Oscar D'León is een van de belangrijkste salsamuzikanten in de geschiedenis. Deze aanstekelijke dancetrack werd zijn kenmerkende nummer en blijft een essentieel onderdeel van elk salsafeest wereldwijd.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "US2BR9700044",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1495501155",
+        "de": "applemusic://track/1495501155",
+        "gb": "applemusic://track/1495501155",
+        "fr": "applemusic://track/1495501155",
+        "es": "applemusic://track/1495501155",
+        "nl": "applemusic://track/1495501155",
+        "it": "applemusic://track/1495501155"
+      }
     },
     {
       "year": 1997,
@@ -1156,7 +1506,17 @@
       "uri_tidal": "tidal://track/5153192",
       "uri_deezer": "deezer://track/13340995",
       "fun_fact_nl": "Oorspronkelijk uitgevoerd toen de groep nog 'Onda Vaselina' heette; in 2000 veranderden ze hun naam in OV7. De groep begon in de jaren '80 als de cast van een Mexicaans kinderprogramma en groeide uit tot een van de meest geliefde popgroepen van Mexico.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "MXF140000184",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/322278438",
+        "de": "applemusic://track/1774586280",
+        "gb": "applemusic://track/1774586280",
+        "fr": "applemusic://track/1774586280",
+        "es": "applemusic://track/1774586280",
+        "nl": "applemusic://track/1774586280",
+        "it": "applemusic://track/1774586280"
+      }
     },
     {
       "year": 1994,
@@ -1185,7 +1545,17 @@
       "uri_tidal": "tidal://track/90841491",
       "uri_deezer": "deezer://track/25880171",
       "fun_fact_nl": "Italiaans eurodance-project met zangeres Silvana Aliotta. Dit was hun enige internationale hit en werd een zomerhit in Europa en Latijns-Amerika. De onbezorgde sfeer van het nummer vatte het eurodance-tijdperk van de jaren '90 perfect samen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "ITB680700008",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1400440973",
+        "de": "applemusic://track/1400440973",
+        "gb": "applemusic://track/1400440973",
+        "fr": "applemusic://track/1400440973",
+        "es": "applemusic://track/1400440973",
+        "nl": "applemusic://track/1400440973",
+        "it": "applemusic://track/1400440973"
+      }
     },
     {
       "year": 1991,
@@ -1214,7 +1584,17 @@
       "uri_tidal": "tidal://track/8863018",
       "uri_deezer": "deezer://track/11897728",
       "fun_fact_nl": "De Panamese artiest El General (Edgardo Armando Franco) wordt beschouwd als een van de pioniers van de reggaeton en reggae en español. Zijn hits uit de vroege jaren '90 legden de basis voor de explosie van de Latin urban-muziek in de jaren 2000 en beïnvloedden artiesten als Daddy Yankee.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USJE61001648",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/320340067",
+        "de": "applemusic://track/320340067",
+        "gb": "applemusic://track/320340067",
+        "fr": "applemusic://track/320340067",
+        "es": "applemusic://track/320340067",
+        "nl": "applemusic://track/320340067",
+        "it": "applemusic://track/320340067"
+      }
     },
     {
       "year": 1996,
@@ -1243,7 +1623,17 @@
       "uri_tidal": "tidal://track/8631922",
       "uri_deezer": "deezer://track/14299243",
       "fun_fact_nl": "Van het album 'El Color de los Sueños'. De titel 'Media Naranja' (halve sinaasappel) is een Spaanse uitdrukking die 'zielsverwant' betekent. Fey was een van de grootste tienerpopsterren van Mexico in de jaren '90, bekend om haar energieke dance-pop en kenmerkende stem.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "MXF149500057",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/286244925",
+        "de": "applemusic://track/604818916",
+        "gb": "applemusic://track/604818916",
+        "fr": "applemusic://track/604818916",
+        "es": "applemusic://track/604818916",
+        "nl": "applemusic://track/604818916",
+        "it": "applemusic://track/604818916"
+      }
     },
     {
       "year": 1990,
@@ -1272,7 +1662,17 @@
       "uri_tidal": "tidal://track/5163308",
       "uri_deezer": "deezer://track/2455218",
       "fun_fact_nl": "Spaans Roma-popduo bestaande uit de zussen Toñi en Encarna Salazar. Ze vertegenwoordigden Spanje op het Eurovisie Songfestival in 1990 met 'Bandido'. Hun fusie van flamenco en pop maakte hen tot een van de meest kenmerkende muzikale acts van Spanje.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "ES5119901648",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/290883412",
+        "de": "applemusic://track/290883412",
+        "gb": "applemusic://track/290883412",
+        "fr": "applemusic://track/290883412",
+        "es": "applemusic://track/290883412",
+        "nl": "applemusic://track/290883412",
+        "it": "applemusic://track/290883412"
+      }
     },
     {
       "year": 1995,
@@ -1301,7 +1701,17 @@
       "uri_tidal": "tidal://track/5163395",
       "uri_deezer": "deezer://track/13266732",
       "fun_fact_nl": "Onda Vaselina (later bekend als OV7) begon als de cast van een Mexicaans kinderprogramma. Leden waren onder meer Ari Borovoy, die later een belangrijke Latin-muziekpromotor werd, en Lidia Ávila. De groep sloeg de brug tussen kinderentertainment en mainstream pop.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "MXF149700119",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/322076612",
+        "de": "applemusic://track/1774585697",
+        "gb": "applemusic://track/1774585697",
+        "fr": "applemusic://track/1774585697",
+        "es": "applemusic://track/1774585697",
+        "nl": "applemusic://track/1774585697",
+        "it": "applemusic://track/1774585697"
+      }
     },
     {
       "year": 1994,
@@ -1330,7 +1740,17 @@
       "uri_tidal": "tidal://track/67075904",
       "uri_deezer": "deezer://track/1756740787",
       "fun_fact_nl": "Mexicaanse dance-popgroep die deel uitmaakte van de levendige Mexicaanse popexplosie van de jaren '90. Ze waren populair in de club- en dancescene en droegen bij aan de golf van op tieners gerichte popgroepen die de Mexicaanse muziek in het midden van de jaren '90 domineerden.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "MXF110001337",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1710987023",
+        "de": "applemusic://track/1710987023",
+        "gb": "applemusic://track/1710987023",
+        "fr": "applemusic://track/1710987023",
+        "es": "applemusic://track/1710987023",
+        "nl": "applemusic://track/1710987023",
+        "it": "applemusic://track/1710987023"
+      }
     },
     {
       "year": 1991,
@@ -1359,7 +1779,17 @@
       "uri_tidal": "tidal://track/3286045",
       "uri_deezer": "deezer://track/13247121",
       "fun_fact_nl": "Een van de vroegste Spaanstalige dancehall/reggae-hits die een crossover-succes behaalde. El Generals mix van Panamese reggae en español met dancehall-ritmes liep bijna een decennium voor op reggaeton en beïnvloedde het gehele Latin urban-genre.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USBL10000302",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/304768769",
+        "de": "applemusic://track/304768769",
+        "gb": "applemusic://track/304768769",
+        "fr": "applemusic://track/304768769",
+        "es": "applemusic://track/304768769",
+        "nl": "applemusic://track/304768769",
+        "it": "applemusic://track/304768769"
+      }
     },
     {
       "year": 1992,
@@ -1390,7 +1820,17 @@
       "uri_tidal": "tidal://track/4751089",
       "uri_deezer": "deezer://track/7505025",
       "fun_fact_nl": "Van '¿Dónde Jugarán los Niños?', een van de bestverkochte Latin rockalbums aller tijden met meer dan 10 miljoen verkochte exemplaren. De Mexicaanse rockband Maná werd de commercieel meest succesvolle Latijns-Amerikaanse rockgroep in de geschiedenis.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "MXF159200061",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1831755329",
+        "de": "applemusic://track/1831755329",
+        "gb": "applemusic://track/1831755329",
+        "fr": "applemusic://track/1831755329",
+        "es": "applemusic://track/1831755329",
+        "nl": "applemusic://track/1831755329",
+        "it": "applemusic://track/1831755329"
+      }
     },
     {
       "year": 1997,
@@ -1419,7 +1859,17 @@
       "uri_tidal": "tidal://track/1409890",
       "uri_deezer": "deezer://track/3255443",
       "fun_fact_nl": "Van het album 'Amor a la Mexicana'. Thalía speelde tegelijkertijd in haar beroemde telenovela-trilogie ('María Mercedes', 'Marimar', 'María la del Barrio') terwijl ze albums opnam, wat haar tot een van de grootste multimedia-sterren van Latijns-Amerika maakte.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "MXF069500722",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1597444539",
+        "de": "applemusic://track/1597444539",
+        "gb": "applemusic://track/1597444539",
+        "fr": "applemusic://track/1597444539",
+        "es": "applemusic://track/1597444539",
+        "nl": "applemusic://track/1597444539",
+        "it": "applemusic://track/1597444539"
+      }
     },
     {
       "year": 2003,
@@ -1461,7 +1911,17 @@
       "awards_nl": [
         "Latin Grammy voor Opname van het Jaar",
         "Latin Grammy voor Album van het Jaar"
-      ]
+      ],
+      "isrc": "ES5150306001",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1437911775",
+        "de": "applemusic://track/27074488",
+        "gb": "applemusic://track/27074488",
+        "fr": "applemusic://track/27074488",
+        "es": "applemusic://track/1437911775",
+        "nl": "applemusic://track/1437911775",
+        "it": "applemusic://track/1437911775"
+      }
     },
     {
       "year": 1994,
@@ -1490,7 +1950,17 @@
       "uri_tidal": "tidal://track/1375138",
       "uri_deezer": "deezer://track/2430177705",
       "fun_fact_nl": "Een van de grootste hits van het Mexicaanse popduo. Sentidos Opuestos maakten deel uit van de enorme Mexicaanse popgolf van de jaren '90, waarbij groepen en duo's de ether domineerden. Hun toegankelijke, dansbare popgeluid sloeg aan bij het publiek in de hele Spaanstalige wereld.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "MXF069600024",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/714908348",
+        "de": "applemusic://track/1703894852",
+        "gb": "applemusic://track/1703894852",
+        "fr": "applemusic://track/1703894852",
+        "es": "applemusic://track/1703894852",
+        "nl": "applemusic://track/1703894852",
+        "it": "applemusic://track/1703894852"
+      }
     },
     {
       "year": 1996,
@@ -1519,7 +1989,17 @@
       "uri_tidal": "tidal://track/8126116",
       "uri_deezer": "deezer://track/14135964",
       "fun_fact_nl": "Mexicaanse popgroep die met OV7 en Magneto streed om de harten van tienerfans in Mexico. Ze stonden bekend om hun gechoreografeerde danspassen en aanstekelijke popliedjes, en belichaamden de kleurrijke energie van de Mexicaanse popcultuur van de jaren '90.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "MXF149700018",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1378513246",
+        "de": "applemusic://track/470304028",
+        "gb": "applemusic://track/470304028",
+        "fr": "applemusic://track/470304028",
+        "es": "applemusic://track/470304028",
+        "nl": "applemusic://track/470304028",
+        "it": "applemusic://track/470304028"
+      }
     },
     {
       "year": 1991,

--- a/custom_components/beatify/playlists/community/gen-z-anthems.json
+++ b/custom_components/beatify/playlists/community/gen-z-anthems.json
@@ -45,7 +45,17 @@
       "uri_tidal": "tidal://track/2497014",
       "uri_deezer": "deezer://track/4764905",
       "fun_fact_nl": "TiK ToK was in 2010 de bestverkochte digitale single ter wereld met meer dan 16,5 miljoen exemplaren — een van de meest iconische popdebuuts ooit.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USRC10900433",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/381237322",
+        "de": "applemusic://track/578034258",
+        "gb": "applemusic://track/6762307317",
+        "fr": "applemusic://track/578034258",
+        "es": "applemusic://track/578034258",
+        "nl": "applemusic://track/578034258",
+        "it": "applemusic://track/896130981"
+      }
     },
     {
       "year": 2011,
@@ -85,7 +95,17 @@
       "fun_fact_nl": "De shuffling-dansrage uit dit nummer nam in 2011 letterlijk elk schoolfeest en elke bruiloft over — de videoclip heeft meer dan 2 miljard views op YouTube.",
       "awards_nl": [
         "Billboard Music Award - Beste Hot 100 Nummer"
-      ]
+      ],
+      "isrc": "USUM71100061",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1851540442",
+        "de": "applemusic://track/1851540442",
+        "gb": "applemusic://track/1851540442",
+        "fr": "applemusic://track/1851540442",
+        "es": "applemusic://track/1851540442",
+        "nl": "applemusic://track/1851540442",
+        "it": "applemusic://track/1851540442"
+      }
     },
     {
       "year": 2011,
@@ -128,7 +148,17 @@
       "awards_nl": [
         "Grammy Award - Opname van het Jaar",
         "Grammy Award - Beste Pop Duo/Groepsprestatie"
-      ]
+      ],
+      "isrc": "AUZS21100040",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1582231392",
+        "de": "applemusic://track/1582231392",
+        "gb": "applemusic://track/1582231392",
+        "fr": "applemusic://track/1582231392",
+        "es": "applemusic://track/1582231392",
+        "nl": "applemusic://track/1519612333",
+        "it": "applemusic://track/1582231392"
+      }
     },
     {
       "year": 2012,
@@ -161,7 +191,17 @@
       "uri_tidal": "tidal://track/21362498",
       "uri_deezer": "deezer://track/60726419",
       "fun_fact_nl": "Het nummer ging viraal nadat Justin Bieber en Selena Gomez een lipsync-video hadden gepost — het werd het meest ge-Shazamde nummer van 2012.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "CAB391100615",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1710062985",
+        "de": "applemusic://track/1710062985",
+        "gb": "applemusic://track/1710062985",
+        "fr": "applemusic://track/1710062985",
+        "es": "applemusic://track/1710062985",
+        "nl": "applemusic://track/1710062985",
+        "it": "applemusic://track/1710062985"
+      }
     },
     {
       "year": 2013,
@@ -247,7 +287,17 @@
       "awards_nl": [
         "Grammy Award - Beste Muziekvideo",
         "Grammy Award - Beste Pop Solo Prestatie"
-      ]
+      ],
+      "isrc": "USQ4E1300686",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1027167644",
+        "de": "applemusic://track/1027167644",
+        "gb": "applemusic://track/1027167644",
+        "fr": "applemusic://track/1027167644",
+        "es": "applemusic://track/1027167644",
+        "nl": "applemusic://track/1027167644",
+        "it": "applemusic://track/1027167644"
+      }
     },
     {
       "year": 2015,
@@ -279,7 +329,17 @@
       "uri_tidal": "tidal://track/40208747",
       "uri_deezer": "deezer://track/91934728",
       "fun_fact_nl": "Fetty Wap nam Trap Queen op in de kelder van zijn oma met een microfoon van 20 dollar van Amazon — bewijs dat talent geen studiobudget nodig heeft.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "QM7XC1400004",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1684718497",
+        "de": "applemusic://track/1684718497",
+        "gb": "applemusic://track/1684718497",
+        "fr": "applemusic://track/1330567316",
+        "es": "applemusic://track/1330567316",
+        "nl": "applemusic://track/1330567316",
+        "it": "applemusic://track/1330567316"
+      }
     },
     {
       "year": 2015,
@@ -358,7 +418,17 @@
       "uri_tidal": "tidal://track/64775565",
       "uri_deezer": "deezer://track/129310248",
       "fun_fact_nl": "Closer stond 12 opeenvolgende weken op #1 in de Billboard Hot 100 en was eigenlijk het onofficiële volkslied van elke studentenkamer in 2016.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USQX91601347",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1691452924",
+        "de": "applemusic://track/1691452924",
+        "gb": "applemusic://track/1691452924",
+        "fr": "applemusic://track/1691452924",
+        "es": "applemusic://track/1691452924",
+        "nl": "applemusic://track/1691452924",
+        "it": "applemusic://track/1691452924"
+      }
     },
     {
       "year": 2017,
@@ -447,7 +517,17 @@
         "Latin Grammy Award - Opname van het Jaar",
         "Latin Grammy Award - Nummer van het Jaar",
         "Billboard Music Award - Beste Hot 100 Nummer"
-      ]
+      ],
+      "isrc": "USUM71607007",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1683435240",
+        "de": "applemusic://track/1734320511",
+        "gb": "applemusic://track/1683435240",
+        "fr": "applemusic://track/1734320511",
+        "es": "applemusic://track/1683435240",
+        "nl": "applemusic://track/1734320511",
+        "it": "applemusic://track/1683435240"
+      }
     },
     {
       "year": 2018,
@@ -523,7 +603,17 @@
       "uri_tidal": "tidal://track/87697581",
       "uri_deezer": "deezer://track/601837422",
       "fun_fact_nl": "Juice WRLD freestylde de meeste van zijn nummers en beweerde dat Lucid Dreams in ongeveer 15 minuten was gemaakt — het nummer samplet Stings 'Shape of My Heart' en werd het volkslied van verdrietige momenten voor een hele generatie.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USUG11800685",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1627826254",
+        "de": "applemusic://track/1627826254",
+        "gb": "applemusic://track/1627826254",
+        "fr": "applemusic://track/1627826254",
+        "es": "applemusic://track/1627826254",
+        "nl": "applemusic://track/1627826254",
+        "it": "applemusic://track/1627826254"
+      }
     },
     {
       "year": 2019,
@@ -612,7 +702,17 @@
       "awards_nl": [
         "Grammy Award - Beste Muziekvideo",
         "CMA Award Nominatie - Muzikaal Evenement van het Jaar"
-      ]
+      ],
+      "isrc": "USSM11902498",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1468166326",
+        "de": "applemusic://track/1468166326",
+        "gb": "applemusic://track/1468166326",
+        "fr": "applemusic://track/1468166326",
+        "es": "applemusic://track/1468166326",
+        "nl": "applemusic://track/1468166326",
+        "it": "applemusic://track/1468166326"
+      }
     },
     {
       "year": 2019,
@@ -652,7 +752,17 @@
       "fun_fact_nl": "Lewis Capaldi's zelfspot op sociale media maakte hem een Gen Z-icoon — hij verscheen ooit op Glastonbury met een Chewbacca-masker nadat zijn neef Peter Capaldi hem zo had genoemd.",
       "awards_nl": [
         "Brit Award - Nummer van het Jaar"
-      ]
+      ],
+      "isrc": "DEUM71807062",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1580655306",
+        "de": "applemusic://track/1580655306",
+        "gb": "applemusic://track/1580655306",
+        "fr": "applemusic://track/1580655306",
+        "es": "applemusic://track/1580655306",
+        "nl": "applemusic://track/1580655306",
+        "it": "applemusic://track/1580655306"
+      }
     },
     {
       "year": 2020,
@@ -698,7 +808,17 @@
         "Billboard Music Award - Beste Hot 100 Nummer",
         "Juno Award - Single van het Jaar",
         "American Music Award - Favoriete Pop/Rock Nummer"
-      ]
+      ],
+      "isrc": "USUG11904206",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1550877898",
+        "de": "applemusic://track/1550877898",
+        "gb": "applemusic://track/1550877898",
+        "fr": "applemusic://track/1550877898",
+        "es": "applemusic://track/1550877898",
+        "nl": "applemusic://track/1550877898",
+        "it": "applemusic://track/1550877898"
+      }
     },
     {
       "year": 2020,
@@ -771,7 +891,17 @@
       "fun_fact_nl": "De videoclip van Watermelon Sugar werd op een strand gefilmd met een disclaimer dat het 'opgedragen aan aanraking' was — gefilmd net voor de COVID-lockdowns, de timing was bijna poëtisch.",
       "awards_nl": [
         "Grammy Award - Beste Pop Solo Prestatie"
-      ]
+      ],
+      "isrc": "USSM11912587",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1485802967",
+        "de": "applemusic://track/1485802967",
+        "gb": "applemusic://track/1485802967",
+        "fr": "applemusic://track/1485802967",
+        "es": "applemusic://track/1485802967",
+        "nl": "applemusic://track/1485802967",
+        "it": "applemusic://track/1485802967"
+      }
     },
     {
       "year": 2021,
@@ -804,7 +934,17 @@
       "uri_tidal": "tidal://track/168756691",
       "uri_deezer": "deezer://track/1194052302",
       "fun_fact_nl": "drivers license brak bij de release het Spotify-record voor de meeste streams op één dag, en het drama over of het over Joshua Bassett en Sabrina Carpenter ging, liet het hele internet detective spelen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USUG12004749",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1705458605",
+        "de": "applemusic://track/1705458605",
+        "gb": "applemusic://track/1705458605",
+        "fr": "applemusic://track/1705458605",
+        "es": "applemusic://track/1705458605",
+        "nl": "applemusic://track/1705458605",
+        "it": "applemusic://track/1705458605"
+      }
     },
     {
       "year": 2021,
@@ -844,7 +984,17 @@
       "fun_fact_nl": "Kiss Me More was de eerste samenwerking tussen Doja Cat en SZA, die daarna vaker samenwerkten — de dromerige sfeer van het nummer maakte het tot de zomerhit van 2021.",
       "awards_nl": [
         "Grammy Award - Beste Pop Duo/Groepsprestatie"
-      ]
+      ],
+      "isrc": "USRC12100760",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1577637152",
+        "de": "applemusic://track/1577637152",
+        "gb": "applemusic://track/1577637152",
+        "fr": "applemusic://track/1577637152",
+        "es": "applemusic://track/1577637152",
+        "nl": "applemusic://track/1577637152",
+        "it": "applemusic://track/1577637152"
+      }
     },
     {
       "year": 2021,
@@ -877,7 +1027,17 @@
       "uri_tidal": "tidal://track/107140835",
       "uri_deezer": "deezer://track/437046332",
       "fun_fact_nl": "Beggin' is eigenlijk een cover van een nummer van The Four Seasons uit 1967 — de versie van Måneskin ging viraal op TikTok nadat ze het Eurovisie Songfestival 2021 wonnen, wat bewijst dat rockmuziek nog springlevend is.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "ITB001700846",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1634843026",
+        "de": "applemusic://track/1634843026",
+        "gb": "applemusic://track/1634843026",
+        "fr": "applemusic://track/1634843026",
+        "es": "applemusic://track/1634843026",
+        "nl": "applemusic://track/1634843026",
+        "it": "applemusic://track/1634843026"
+      }
     },
     {
       "year": 2022,
@@ -917,7 +1077,17 @@
       "fun_fact_nl": "About Damn Time ging viraal op TikTok dankzij een dans gemaakt door Jaeden Gomez — de choreografie werd zo populair dat Lizzo het uitvoerde bij de Grammy Awards, en het nummer won Opname van het Jaar.",
       "awards_nl": [
         "Grammy Award - Opname van het Jaar"
-      ]
+      ],
+      "isrc": "USAT22202139",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1810531325",
+        "de": "applemusic://track/1810531325",
+        "gb": "applemusic://track/1810531325",
+        "fr": "applemusic://track/1810531325",
+        "es": "applemusic://track/1810531325",
+        "nl": "applemusic://track/1810531325",
+        "it": "applemusic://track/1810531325"
+      }
     },
     {
       "year": 2022,
@@ -960,7 +1130,17 @@
       "awards_nl": [
         "Grammy Award - Beste Pop Vocaal Album (Harry's House)",
         "Brit Award - Nummer van het Jaar"
-      ]
+      ],
+      "isrc": "USSM12200612",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1615585008",
+        "de": "applemusic://track/1615585008",
+        "gb": "applemusic://track/1615585008",
+        "fr": "applemusic://track/1615585008",
+        "es": "applemusic://track/1615585008",
+        "nl": "applemusic://track/1615585008",
+        "it": "applemusic://track/1615585008"
+      }
     },
     {
       "year": 2022,
@@ -1043,7 +1223,17 @@
       "awards_nl": [
         "Grammy Award - Opname van het Jaar",
         "Grammy Award - Beste Pop Solo Prestatie"
-      ]
+      ],
+      "isrc": "USSM12209777",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1784376405",
+        "de": "applemusic://track/1793441765",
+        "gb": "applemusic://track/1793441765",
+        "fr": "applemusic://track/1793441765",
+        "es": "applemusic://track/1793441765",
+        "nl": "applemusic://track/1793441765",
+        "it": "applemusic://track/1793441765"
+      }
     },
     {
       "year": 2023,
@@ -1076,7 +1266,17 @@
       "uri_tidal": "tidal://track/273097153",
       "uri_deezer": "deezer://track/2055292027",
       "fun_fact_nl": "Kill Bill is vernoemd naar de Quentin Tarantino-film en SZA beschreef het als een 'fantasy wraak-nummer over een ex' — de manier waarop ze moord als een relaxte vibe liet klinken is eerlijk gezegd indrukwekkend.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USRC12204584",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1744639020",
+        "de": "applemusic://track/1744639020",
+        "gb": "applemusic://track/1744639020",
+        "fr": "applemusic://track/1744639020",
+        "es": "applemusic://track/1744639020",
+        "nl": "applemusic://track/1744639020",
+        "it": "applemusic://track/1744639020"
+      }
     },
     {
       "year": 2023,
@@ -1109,7 +1309,17 @@
       "uri_tidal": "tidal://track/308652487",
       "uri_deezer": "deezer://track/2387373015",
       "fun_fact_nl": "Paint The Town Red samplet Dionne Warwicks klassieker 'Walk On By' uit 1964 — Doja Cats vermogen om een 60 jaar oud nummer om te toveren tot een virale raphit is werkelijk ongeëvenaard.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USRC12300907",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1784376382",
+        "de": "applemusic://track/1782969240",
+        "gb": "applemusic://track/1782969240",
+        "fr": "applemusic://track/1782969240",
+        "es": "applemusic://track/1782969240",
+        "nl": "applemusic://track/1782969240",
+        "it": "applemusic://track/1782969240"
+      }
     },
     {
       "year": 2024,
@@ -1142,7 +1352,17 @@
       "uri_tidal": "tidal://track/354679021",
       "uri_deezer": "deezer://track/2743578151",
       "fun_fact_nl": "Espresso werd het nummer van de zomer 2024 en was zo viraal dat zelfs Barack Obama het op zijn zomerplaylist zette — de 'that's that me espresso'-hook zat letterlijk maandenlang in ieders hoofd.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USUM72403305",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1808965057",
+        "de": "applemusic://track/1808965057",
+        "gb": "applemusic://track/1808965057",
+        "fr": "applemusic://track/1808965057",
+        "es": "applemusic://track/1808965057",
+        "nl": "applemusic://track/1808965057",
+        "it": "applemusic://track/1808965057"
+      }
     },
     {
       "year": 2024,
@@ -1175,7 +1395,17 @@
       "uri_tidal": "tidal://track/356127843",
       "uri_deezer": "deezer://track/2728070371",
       "fun_fact_nl": "Chappell Roan ging van optreden voor bijna lege zalen in 2023 naar headliner op festivals in 2024 — Good Luck, Babe! was de doorbraak-track die haar tot een van de snelst stijgende popsterren van de afgelopen tijd maakte, en haar live-optredens zijn echt theatraal op een ander niveau.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USUG12401967",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1794598530",
+        "de": "applemusic://track/1794598530",
+        "gb": "applemusic://track/1794598530",
+        "fr": "applemusic://track/1794598530",
+        "es": "applemusic://track/1794598530",
+        "nl": "applemusic://track/1794598530",
+        "it": "applemusic://track/1794598530"
+      }
     }
   ]
 }

--- a/custom_components/beatify/playlists/community/greatest-metal-songs.json
+++ b/custom_components/beatify/playlists/community/greatest-metal-songs.json
@@ -42,7 +42,17 @@
       "fun_fact_nl": "Iron Man bevat een van de meest iconische gitaarriffs uit de rockgeschiedenis, gemaakt door Tony Iommi nadat hij de toppen van twee vingers had verloren bij een fabrieksongeval en prothetische vingertoppen had gemaakt van gesmolten plastic flessen. De openingsriff van het nummer imiteert de lompe tred van de tijdreizende ijzeren man die in de tekst wordt beschreven. Het werd later de basis voor het thema van de Marvel film franchise.",
       "awards_nl": [
         "Grammy Hall of Fame"
-      ]
+      ],
+      "isrc": "USWB11304371",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/787845531",
+        "de": null,
+        "gb": null,
+        "fr": null,
+        "es": null,
+        "nl": null,
+        "it": null
+      }
     },
     {
       "year": 1970,
@@ -75,7 +85,17 @@
       "fun_fact_nl": "Paranoid werd in slechts 20 minuten geschreven als een opvulnummer voor het gelijknamige album - toch werd het Black Sabbaths enige UK top 5 single. De band wilde het oorspronkelijk The Paranoid noemen, maar producer Rodger Bain kortte het in. Het blijft een van de meest gecoverde metalsongs aller tijden.",
       "awards_nl": [
         "Grammy Hall of Fame"
-      ]
+      ],
+      "isrc": "USWB11304369",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/787644021",
+        "de": null,
+        "gb": null,
+        "fr": null,
+        "es": null,
+        "nl": null,
+        "it": null
+      }
     },
     {
       "year": 1975,
@@ -108,7 +128,17 @@
       "fun_fact_nl": "Judas Priest pionierde met de leer-en-studs look die synoniem werd met heavy metal, waarbij zanger Rob Halford inspiratie putte uit de homoseksuele ledersubcultuur. De band wordt alom geprezen voor het codificeren van het geluid en imago van heavy metal. Halford kwam in 1998 uit de kast als homo en was daarmee een van de eerste grote rocksterren die dat deed.",
       "awards_nl": [
         "Grammy-nominatie"
-      ]
+      ],
+      "isrc": "GBBBN8202006",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/978784360",
+        "de": "applemusic://track/978784360",
+        "gb": "applemusic://track/207178357",
+        "fr": "applemusic://track/978784360",
+        "es": "applemusic://track/978784360",
+        "nl": "applemusic://track/978784360",
+        "it": "applemusic://track/978784360"
+      }
     },
     {
       "year": 1980,
@@ -141,7 +171,17 @@
       "fun_fact_nl": "Iron Maiden's mascotte Eddie heeft sinds hun debuut op elke albumhoes gestaan en is een van de meest herkenbare karakters in de rockmuziek geworden. De band gebruikt een levensgrote Eddie-pop in hun liveshows. Maiden heeft wereldwijd meer dan 100 miljoen albums verkocht en wordt algemeen beschouwd als de grootste heavy metalband aller tijden.",
       "awards_nl": [
         "Grammy-nominatie"
-      ]
+      ],
+      "isrc": "GBCHB1500031",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1713861908",
+        "de": "applemusic://track/979938033",
+        "gb": "applemusic://track/979938033",
+        "fr": "applemusic://track/979938033",
+        "es": "applemusic://track/979938033",
+        "nl": "applemusic://track/979938033",
+        "it": "applemusic://track/979938033"
+      }
     },
     {
       "year": 1982,
@@ -174,7 +214,17 @@
       "fun_fact_nl": "The Number of the Beast leidde bij de release in 1982 tot massale protesten en plaatverbrandingen door religieuze groeperingen in de Verenigde Staten, wat de bekendheid en verkoop alleen maar ten goede kwam. Zanger Bruce Dickinson kwam vlak voor dit album bij de band en zijn hoge stem definieerde het klassieke Maiden-geluid. Het album kwam op nummer één in de UK.",
       "awards_nl": [
         "Grammy-nominatie"
-      ]
+      ],
+      "isrc": "GBCHB1500023",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1713862907",
+        "de": "applemusic://track/979954059",
+        "gb": "applemusic://track/979954059",
+        "fr": "applemusic://track/979954059",
+        "es": "applemusic://track/979954059",
+        "nl": "applemusic://track/979954059",
+        "it": "applemusic://track/979954059"
+      }
     },
     {
       "year": 1986,
@@ -207,7 +257,17 @@
       "fun_fact_nl": "Master of Puppets wordt algemeen beschouwd als het beste heavy metal album ooit gemaakt, en het titelnummer is een van de meest technisch veeleisende en geliefde metalsongs aller tijden. Het nummer bereikte nieuwe generaties nadat het in 2022 te horen was in het vierde seizoen van Stranger Things, waardoor het wereldwijd op nummer één kwam te staan op Spotify. Bassist Cliff Burton stierf bij een busongeluk slechts enkele maanden na de release van het album.",
       "awards_nl": [
         "Grammy Hall of Fame"
-      ]
+      ],
+      "isrc": "QMKHM1600219",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1632029152",
+        "de": "applemusic://track/1632029152",
+        "gb": "applemusic://track/1632029152",
+        "fr": "applemusic://track/1632029152",
+        "es": "applemusic://track/1632029152",
+        "nl": "applemusic://track/1632029152",
+        "it": "applemusic://track/1632029152"
+      }
     },
     {
       "year": 1991,
@@ -240,7 +300,17 @@
       "fun_fact_nl": "Enter Sandman opende het Black Album - Metallica's titelloze plaat uit 1991 die het best verkochte album in de SoundScan-geschiedenis werd met meer dan 16 miljoen verkochte exemplaren in de VS. De minimalistische, groove-gedreven aanpak van het nummer betekende een dramatisch afscheid van hun thrash roots en bracht metal naar de mainstream. De videoclip, geregisseerd door Wayne Isham, blijft een van de meest bekeken metalvideo's ooit.",
       "awards_nl": [
         "Grammy Award voor Beste Metalprestatie"
-      ]
+      ],
+      "isrc": "QMKHM1900001",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1572046436",
+        "de": "applemusic://track/1571983951",
+        "gb": "applemusic://track/1571983951",
+        "fr": "applemusic://track/1571983951",
+        "es": "applemusic://track/1571983951",
+        "nl": "applemusic://track/1571983951",
+        "it": "applemusic://track/1571983951"
+      }
     },
     {
       "year": 1988,
@@ -273,7 +343,17 @@
       "fun_fact_nl": "One was Metallica's allereerste videoclip, geïnspireerd op de anti-oorlogsfilm Johnny Got His Gun uit 1971. Het nummer begint als een beklemmende ballade voordat het explodeert in een woeste thrashaanval, die de psychologische afdaling weerspiegelt van een soldaat die wordt achtergelaten als een verlamd, gevoelloos torso. Het leverde Metallica hun eerste Grammy Award op.",
       "awards_nl": [
         "Grammy Award voor Beste Metalprestatie"
-      ]
+      ],
+      "isrc": "QMKHM1700138",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1434424172",
+        "de": "applemusic://track/1435400032",
+        "gb": "applemusic://track/1435400032",
+        "fr": "applemusic://track/1435400032",
+        "es": "applemusic://track/1435400032",
+        "nl": "applemusic://track/1435400032",
+        "it": "applemusic://track/1435400032"
+      }
     },
     {
       "year": 1986,
@@ -306,7 +386,17 @@
       "fun_fact_nl": "Raining Blood is de afsluiter van Slayers baanbrekende album Reign in Blood, dat met 28 minuten en 58 seconden een van de kortste metalalbums is die ooit zijn gemaakt. Producer Rick Rubin ontdeed zich van alle overdaad en creëerde de meest intense thrashmetalplaat die ooit is opgenomen. De iconische outro riff van het nummer wordt beschouwd als een van de krachtigste uit de metalgeschiedenis.",
       "awards_nl": [
         "Grammy-nominatie"
-      ]
+      ],
+      "isrc": "USSM18600241",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1733769810",
+        "de": "applemusic://track/1733769810",
+        "gb": "applemusic://track/1733769810",
+        "fr": "applemusic://track/1733769810",
+        "es": "applemusic://track/1733769810",
+        "nl": "applemusic://track/1733769810",
+        "it": "applemusic://track/1733769810"
+      }
     },
     {
       "year": 1992,
@@ -339,7 +429,17 @@
       "fun_fact_nl": "Walk werd Pantera's signatuurnummer en een van de bepalende nummers van groove metal. De verpletterende riffs van gitarist Dimebag Darrell en de confronterende zang van Phil Anselmo maakten het tot een hymne van agressie. Dimebag Darrell werd in 2004 tragisch doodgeschoten op het podium, waardoor Walk een nog aangrijpender stuk metalgeschiedenis is geworden.",
       "awards_nl": [
         "Grammy-nominatie"
-      ]
+      ],
+      "isrc": "USAT21202190",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/518549369",
+        "de": "applemusic://track/518549369",
+        "gb": "applemusic://track/518549369",
+        "fr": "applemusic://track/518549369",
+        "es": "applemusic://track/518549369",
+        "nl": "applemusic://track/518549369",
+        "it": "applemusic://track/518549369"
+      }
     },
     {
       "year": 1994,
@@ -372,7 +472,17 @@
       "fun_fact_nl": "Cowboys from Hell betekende Pantera's doorbraak in 1990 en liet de wereld kennismaken met Dimebag Darrell's verwoestende gitaartechniek. De agressieve groove van het titelnummer en de felle zang van Anselmo definieerden een nieuw tijdperk van Amerikaanse heavy metal. Het album wordt beschouwd als een mijlpaal in het genre.",
       "awards_nl": [
         "Grammy-nominatie"
-      ]
+      ],
+      "isrc": "USAT21001391",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1814306260",
+        "de": "applemusic://track/1612260842",
+        "gb": "applemusic://track/1612260842",
+        "fr": "applemusic://track/1612260842",
+        "es": "applemusic://track/1612260842",
+        "nl": "applemusic://track/1612260842",
+        "it": "applemusic://track/1612260842"
+      }
     },
     {
       "year": 1983,
@@ -405,7 +515,17 @@
       "fun_fact_nl": "Seek and Destroy van Metallica's debuutalbum Kill 'Em All is een van de oudste en meest geliefde live-albums van de band en ontbreekt bijna nooit op een setlist. Het album werd oorspronkelijk afgewezen door grote labels en zelf gefinancierd door Megaforce Records, waarmee de Amerikaanse thrash metalscene bijna eigenhandig werd gelanceerd. De call-and-response structuur van het nummer maakt het tot een elektrisch publieksmoment.",
       "awards_nl": [
         "Grammy-nominatie"
-      ]
+      ],
+      "isrc": "USEE19900919",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/579146168",
+        "de": null,
+        "gb": null,
+        "fr": null,
+        "es": null,
+        "nl": null,
+        "it": null
+      }
     },
     {
       "year": 1990,
@@ -438,7 +558,17 @@
       "fun_fact_nl": "Holy Wars opent met Rust in Peace, dat algemeen wordt beschouwd als Megadeths meesterwerk en een van de beste thrash metalalbums ooit opgenomen. Dave Mustaine richtte Megadeth op nadat hij in 1983 was ontslagen bij Metallica, en jarenlang dreef de rivaliteit tussen de twee bands beide naar steeds grotere creatieve hoogten. Op het album spelen toekomstige Mars Volta-drummers Marty Friedman en Nick Menza.",
       "awards_nl": [
         "Grammy-nominatie"
-      ]
+      ],
+      "isrc": "USCA29000003",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/724649275",
+        "de": "applemusic://track/724649275",
+        "gb": "applemusic://track/724649275",
+        "fr": "applemusic://track/724649275",
+        "es": "applemusic://track/724649275",
+        "nl": "applemusic://track/724649275",
+        "it": "applemusic://track/724649275"
+      }
     },
     {
       "year": 1990,
@@ -471,7 +601,17 @@
       "fun_fact_nl": "Symphony of Destruction is Megadeth's meest commercieel succesvolle nummer, dat toegankelijkheid combineert met Dave Mustaine's kenmerkende agressie. De memorabele hoofdriff werd geïnspireerd door een simpel akkoordenschema waar Mustaine op stuitte tijdens een soundcheck. Het nummer blijft decennia na de release een van de meest gedraaide nummers op de rockradio.",
       "awards_nl": [
         "Grammy-nominatie"
-      ]
+      ],
+      "isrc": "USCA20400616",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/6762964575",
+        "de": "applemusic://track/6762964575",
+        "gb": "applemusic://track/6762964575",
+        "fr": "applemusic://track/6762964575",
+        "es": "applemusic://track/6762964575",
+        "nl": "applemusic://track/6762964575",
+        "it": "applemusic://track/6762964575"
+      }
     },
     {
       "year": 1984,
@@ -504,7 +644,17 @@
       "fun_fact_nl": "Ronnie James Dio bedacht het handgebaar 'duivelshoorns' dat universeel werd in de metalcultuur. Hij leende het van zijn Italiaanse grootmoeder die het gebruikte om het kwaad af te weren. Dio was ook de tweede zanger van Black Sabbath en Rainbow voor zijn baanbrekende solocarrière. Velen beschouwen hem als de grootste heavy metalzanger aller tijden.",
       "awards_nl": [
         "Grammy-nominatie"
-      ]
+      ],
+      "isrc": "USWB11507137",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1048476460",
+        "de": null,
+        "gb": null,
+        "fr": null,
+        "es": null,
+        "nl": null,
+        "it": null
+      }
     },
     {
       "year": 1980,
@@ -537,7 +687,17 @@
       "fun_fact_nl": "Crazy Train bevat een van de meest herkenbare gitaarriffs uit de rockgeschiedenis, gespeeld door wijlen Randy Rhoads - algemeen beschouwd als een van de grootste gitaristen die ooit heeft geleefd. Rhoads kwam in 1982 op 25-jarige leeftijd om het leven bij een vliegtuigongeluk. De openingskreet 'All aboard!' is een van de meest iconische momenten uit de rockgeschiedenis geworden.",
       "awards_nl": [
         "Grammy Hall of Fame"
-      ]
+      ],
+      "isrc": "USSM11002845",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1626431301",
+        "de": "applemusic://track/1626431301",
+        "gb": "applemusic://track/1626431301",
+        "fr": "applemusic://track/1626431301",
+        "es": "applemusic://track/1626431301",
+        "nl": "applemusic://track/1626431301",
+        "it": "applemusic://track/1626431301"
+      }
     },
     {
       "year": 2001,
@@ -570,7 +730,17 @@
       "fun_fact_nl": "Chop Suey! heette oorspronkelijk Suicide, maar de titel werd door het label veranderd na de aanslagen van 9/11 vanwege het gevoelige onderwerp. De onvoorspelbare tempowisselingen van het nummer en het operatische bereik van zanger Serj Tankian maakten het tot een van de meest kenmerkende metalsongs van de jaren 2000. System of a Down is een van de meest politiek uitgesproken bands in de metalgeschiedenis.",
       "awards_nl": [
         "Grammy-nominatie"
-      ]
+      ],
+      "isrc": "USSM10107256",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/273714640",
+        "de": "applemusic://track/438938124",
+        "gb": "applemusic://track/438938124",
+        "fr": "applemusic://track/1308501043",
+        "es": "applemusic://track/438938124",
+        "nl": "applemusic://track/438938124",
+        "it": "applemusic://track/438938124"
+      }
     },
     {
       "year": 2001,
@@ -603,7 +773,17 @@
       "fun_fact_nl": "Toxicity is het meest commercieel succesvolle nummer van System of a Down, waarvan de titel verwijst naar het giftige milieu van de moderne samenleving. Het gelijknamige album debuteerde gelijktijdig op nummer één in de VS en het VK. De unieke mix van Armeense folk-invloeden, thrash metal en alternatieve rock onderscheidt de band van alle andere bands uit hun tijd.",
       "awards_nl": [
         "Grammy-nominatie"
-      ]
+      ],
+      "isrc": "USSM10107262",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/273714713",
+        "de": "applemusic://track/273714713",
+        "gb": "applemusic://track/273714713",
+        "fr": "applemusic://track/273714713",
+        "es": "applemusic://track/273714713",
+        "nl": "applemusic://track/273714713",
+        "it": "applemusic://track/273714713"
+      }
     },
     {
       "year": 1997,
@@ -636,7 +816,17 @@
       "fun_fact_nl": "Schism leverde Tool in 2002 een Grammy op voor Best Metal Performance en wordt geroemd om zijn buitengewoon complexe maatsoort - het nummer schakelt tussen 5/4, 6/8 en andere maatsoorten. Tool staat bekend om hun wiskundige benadering van compositie en de filosofische diepgang van hun teksten. Zanger Maynard James Keenan wordt algemeen beschouwd als een van de meest begaafde zangers in de rock.",
       "awards_nl": [
         "Grammy Award voor Beste Metalprestatie"
-      ]
+      ],
+      "isrc": "USVR10100013",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1474185654",
+        "de": "applemusic://track/1474185654",
+        "gb": "applemusic://track/1474185654",
+        "fr": "applemusic://track/1474185654",
+        "es": "applemusic://track/1474185654",
+        "nl": "applemusic://track/1474185654",
+        "it": "applemusic://track/1474185654"
+      }
     },
     {
       "year": 2000,
@@ -669,7 +859,17 @@
       "fun_fact_nl": "Change is een van Deftones' meest hypnotiserende en verontrustende nummers, opgebouwd rond een gefluisterde gitaarloop en Chino Moreno's verschuivende dynamische zang. White Pony wordt algemeen beschouwd als het meesterwerk van de Deftones en als een van de meest innovatieve rockalbums van de jaren 2000. De band wordt gezien als pionier op het gebied van nu-metal en alternatieve metal.",
       "awards_nl": [
         "Grammy-nominatie"
-      ]
+      ],
+      "isrc": "USRE11600104",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1537631475",
+        "de": "applemusic://track/1537631475",
+        "gb": "applemusic://track/1537631475",
+        "fr": "applemusic://track/1537631475",
+        "es": "applemusic://track/1537631475",
+        "nl": "applemusic://track/1537631475",
+        "it": "applemusic://track/1537631475"
+      }
     },
     {
       "year": 1994,
@@ -702,7 +902,17 @@
       "fun_fact_nl": "Black Hole Sun is het meest iconische nummer van Soundgarden, geschreven door Chris Cornell in slechts 15 minuten. Cornell zei dat de melodie volledig tot hem kwam en dat hij niet wist waar die vandaan kwam. De surrealistische videoclip, waarin een nachtmerrie in een buitenwijk wordt afgebeeld die in de zon opgaat, blijft een van de meest memorabele uit de rockgeschiedenis. Cornell overleed op tragische wijze in 2017.",
       "awards_nl": [
         "Grammy Award voor Beste Hardrockprestatie"
-      ]
+      ],
+      "isrc": "USAM19400007",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1436558379",
+        "de": "applemusic://track/1528951934",
+        "gb": "applemusic://track/1442404059",
+        "fr": "applemusic://track/1442404059",
+        "es": "applemusic://track/1442404059",
+        "nl": "applemusic://track/1442404059",
+        "it": "applemusic://track/1442404059"
+      }
     },
     {
       "year": 1992,
@@ -735,7 +945,17 @@
       "fun_fact_nl": "Rooster werd geschreven door gitarist Jerry Cantrell als een eerbetoon aan zijn vader, die diende in de Vietnamoorlog - zijn bijnaam was Rooster. De beklemmende combinatie van drop-D riffs en dubbele vocalistenharmonieën tussen Cantrell en Layne Staley is een van de krachtigste momenten van Alice in Chains. Layne Staley stierf in 2002 aan een overdosis drugs.",
       "awards_nl": [
         "Grammy-nominatie"
-      ]
+      ],
+      "isrc": "USSM19200881",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/190809033",
+        "de": "applemusic://track/190809033",
+        "gb": "applemusic://track/190809033",
+        "fr": "applemusic://track/261763500",
+        "es": "applemusic://track/261763500",
+        "nl": "applemusic://track/261763500",
+        "it": "applemusic://track/261763500"
+      }
     },
     {
       "year": 1987,
@@ -768,7 +988,17 @@
       "fun_fact_nl": "Welcome to the Jungle opende Appetite for Destruction, het best verkochte debuutalbum in de geschiedenis van de VS met meer dan 30 miljoen verkochte exemplaren wereldwijd. Axl Rose schreef het nummer nadat hij als tiener vanuit het kleine Indiana in LA aankwam en het geeft perfect de gevaarlijke allure van de stad weer. De riff werd gemaakt door Slash nadat hij de hele nacht was opgebleven.",
       "awards_nl": [
         "Grammy-nominatie"
-      ]
+      ],
+      "isrc": "USGF18714801",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1377826728",
+        "de": "applemusic://track/1377826728",
+        "gb": "applemusic://track/1377826728",
+        "fr": "applemusic://track/1377826728",
+        "es": "applemusic://track/1377826728",
+        "nl": "applemusic://track/1377826728",
+        "it": "applemusic://track/1377826728"
+      }
     },
     {
       "year": 1987,
@@ -801,7 +1031,17 @@
       "fun_fact_nl": "Sweet Child O' Mine bereikte nummer één in de VS en bevat een van de meest geliefde gitaarsolo's uit de rockgeschiedenis, gespeeld door Slash. Axl Rose schreef de tekst over zijn toenmalige vriendin Erin Everly, de dochter van Don Everly van de Everly Brothers. Slash maakte de openingsriff oorspronkelijk als een grap om op te warmen waar de rest van de band dol op was.",
       "awards_nl": [
         "Grammy-nominatie"
-      ]
+      ],
+      "isrc": "USGF18714809",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1377813701",
+        "de": "applemusic://track/1377813701",
+        "gb": "applemusic://track/1377813701",
+        "fr": "applemusic://track/1377813701",
+        "es": "applemusic://track/1377813701",
+        "nl": "applemusic://track/1377813701",
+        "it": "applemusic://track/1377813701"
+      }
     },
     {
       "year": 1979,
@@ -834,7 +1074,17 @@
       "fun_fact_nl": "Highway to Hell was het laatste album dat werd opgenomen met zanger Bon Scott voor zijn tragische dood in 1980. Het titelnummer werd AC/DC's doorbraaknummer in Amerika en is een van de meest iconische rock anthems ooit opgenomen. De titel van het album was bijna Highway to Hell maar het management van de band was bang dat dit radiostations van zich zou vervreemden.",
       "awards_nl": [
         "Grammy Hall of Fame"
-      ]
+      ],
+      "isrc": "AUAP07900028",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/574044008",
+        "de": "applemusic://track/574044008",
+        "gb": "applemusic://track/574044008",
+        "fr": "applemusic://track/574044008",
+        "es": "applemusic://track/574044008",
+        "nl": "applemusic://track/574044008",
+        "it": "applemusic://track/574044008"
+      }
     },
     {
       "year": 1980,
@@ -867,7 +1117,17 @@
       "fun_fact_nl": "Back in Black is het openingsnummer van het op één na best verkochte album in de geschiedenis met meer dan 50 miljoen verkochte exemplaren. Het album werd opgenomen als eerbetoon aan Bon Scott en volledig in het zwart uitgevoerd. De nieuwe zanger Brian Johnson werd ontdekt nadat Angus Young hem hoorde schreeuwen over een nummer - ze huurden hem ter plekke in. Het kostte Angus slechts enkele minuten om de iconische openingsriff te schrijven.",
       "awards_nl": [
         "Grammy Hall of Fame"
-      ]
+      ],
+      "isrc": "AUAP08000046",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/576003082",
+        "de": "applemusic://track/576003082",
+        "gb": "applemusic://track/576003082",
+        "fr": "applemusic://track/576003082",
+        "es": "applemusic://track/576003082",
+        "nl": "applemusic://track/576003082",
+        "it": "applemusic://track/576003082"
+      }
     },
     {
       "year": 1972,
@@ -900,7 +1160,17 @@
       "fun_fact_nl": "Smoke on the Water bevat misschien wel de beroemdste gitaarriff ooit geschreven - het motief van vier noten dat elke beginnende gitarist als eerste leert. Het nummer beschrijft de echte brand in het Montreux Casino in december 1971 terwijl Frank Zappa optrad, waarvan Deep Purple getuige was vanaf de overkant van het meer van Genève. De band nam vervolgens het album Machine Head op in een mobiele studio geleend van de Rolling Stones.",
       "awards_nl": [
         "Grammy Hall of Fame"
-      ]
+      ],
+      "isrc": "USRH11602140",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1099335223",
+        "de": null,
+        "gb": null,
+        "fr": null,
+        "es": null,
+        "nl": null,
+        "it": null
+      }
     },
     {
       "year": 1987,
@@ -933,7 +1203,17 @@
       "fun_fact_nl": "Pour Some Sugar on Me werd in slechts een paar minuten geschreven door Joe Elliott in een hotelkamer en werd een van de bepalende nummers van de glam metal uit de jaren '80. Drummer Rick Allen trad op tijdens de opnames en de daaropvolgende tournee met slechts één arm, nadat hij zijn linkerarm had verloren bij een auto-ongeluk in 1984. Het meeklappen van het publiek blijft een belangrijk onderdeel van de etiquette van rockconcerten.",
       "awards_nl": [
         "Grammy-nominatie"
-      ]
+      ],
+      "isrc": "GBUM71701307",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1438626355",
+        "de": "applemusic://track/1440907033",
+        "gb": "applemusic://track/1744618174",
+        "fr": "applemusic://track/1440907033",
+        "es": "applemusic://track/1568022079",
+        "nl": "applemusic://track/1440907033",
+        "it": "applemusic://track/1440907033"
+      }
     },
     {
       "year": 1984,
@@ -966,7 +1246,17 @@
       "fun_fact_nl": "Jump was Van Halen's enige nummer 1 single in de VS en bevatte controversieel een synthesizer lead, die Eddie Van Halen jarenlang voor de band verborgen had gehouden. David Lee Roth had naar verluidt een hekel aan de keyboard-gedreven aanpak, maar zong er toch op. Eddie Van Halen wordt algemeen beschouwd als een van de meest revolutionaire gitaristen in de rockgeschiedenis.",
       "awards_nl": [
         "Grammy-nominatie"
-      ]
+      ],
+      "isrc": "USWB11403500",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/977495501",
+        "de": "applemusic://track/977495501",
+        "gb": "applemusic://track/977495501",
+        "fr": "applemusic://track/977495501",
+        "es": "applemusic://track/977495501",
+        "nl": "applemusic://track/977495501",
+        "it": "applemusic://track/977495501"
+      }
     },
     {
       "year": 1990,
@@ -999,7 +1289,17 @@
       "fun_fact_nl": "Killing in the Name bereikte in 2009 de eerste plaats in de Britse kerstcharts toen een campagne van Facebook-gebruikers de single van The X Factor-winnaar overstemde - een van de meest opmerkelijke gevechten in de muziekgeschiedenis. Tom Morello's techniek om met een gitaar krassen van draaitafels na te bootsen betekende een revolutie in de productie van heavy muziek.",
       "awards_nl": [
         "Grammy-nominatie"
-      ]
+      ],
+      "isrc": "USSM19200317",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1737564412",
+        "de": "applemusic://track/1737564412",
+        "gb": "applemusic://track/1737564412",
+        "fr": "applemusic://track/1737564412",
+        "es": "applemusic://track/1737564412",
+        "nl": "applemusic://track/1737564412",
+        "it": "applemusic://track/1737564412"
+      }
     },
     {
       "year": 1998,
@@ -1032,7 +1332,17 @@
       "fun_fact_nl": "The Beautiful People is het meest iconische nummer van Marilyn Manson en een van de bepalende industrial metalnummers van de jaren '90. De gemechaniseerde groove werd samen met producer Trent Reznor van Nine Inch Nails geschreven. Mansons shock-rock theatraliteit maakte hem tot een van de meest controversiële figuren in de rockgeschiedenis en leidde regelmatig tot pogingen tot censuur.",
       "awards_nl": [
         "Grammy-nominatie"
-      ]
+      ],
+      "isrc": "USIR19601008",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1704192336",
+        "de": "applemusic://track/1704192336",
+        "gb": "applemusic://track/1704192336",
+        "fr": "applemusic://track/1704192336",
+        "es": "applemusic://track/1704192336",
+        "nl": "applemusic://track/1704192336",
+        "it": "applemusic://track/1704192336"
+      }
     },
     {
       "year": 1994,
@@ -1065,7 +1375,17 @@
       "fun_fact_nl": "Freak on a Leash is de bepalende nu-metal anthem, met Jonathan Davis' kenmerkende laaggestemde gitaarriffs met zeven snaren en angstaanjagende zang. De Grammy-winnende geanimeerde videoclip van het nummer werd een van de meest gevierde in de geschiedenis van MTV. Korn creëerde het nu-metalgenre door hiphopgrooves te combineren met verpletterende metalriffs.",
       "awards_nl": [
         "Grammy Award voor Beste Korte Muziekvideo"
-      ]
+      ],
+      "isrc": "USSM19805391",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1831584743",
+        "de": "applemusic://track/1831584743",
+        "gb": "applemusic://track/1831584743",
+        "fr": "applemusic://track/1831584743",
+        "es": "applemusic://track/1831584743",
+        "nl": "applemusic://track/1831584743",
+        "it": "applemusic://track/1831584743"
+      }
     },
     {
       "year": 1999,
@@ -1098,7 +1418,17 @@
       "fun_fact_nl": "Slipknot brak in 1999 door in de metalscene met bijpassende ketelpakken en genummerde maskers, en creëerde zo een van de meest visueel opvallende esthetica in de rockgeschiedenis. De band bestaat uit negen leden en is daarmee een van de grootste metalbands uit de geschiedenis. Van hun debuutalbum werden alleen al in de VS meer dan drie miljoen exemplaren verkocht.",
       "awards_nl": [
         "Grammy-nominatie"
-      ]
+      ],
+      "isrc": "NLA321400496",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/927736489",
+        "de": "applemusic://track/927736489",
+        "gb": "applemusic://track/927736489",
+        "fr": "applemusic://track/927736489",
+        "es": "applemusic://track/927736489",
+        "nl": "applemusic://track/927736489",
+        "it": "applemusic://track/927736489"
+      }
     },
     {
       "year": 2001,
@@ -1131,7 +1461,17 @@
       "fun_fact_nl": "Duality werd Slipknot's grootste mainstream hit en een van de meest herkenbare metal anthems van de jaren 2000. De videoclip is beroemd geworden door de fans die op een onofficieel huisfeest de opnamelocatie binnenvielen. Het meezingrefrein maakte het ongewoon toegankelijk voor een Slipknot-nummer en introduceerde de band bij een heel nieuw publiek.",
       "awards_nl": [
         "Grammy-nominatie"
-      ]
+      ],
+      "isrc": "NLA321400554",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/927744252",
+        "de": "applemusic://track/927744252",
+        "gb": "applemusic://track/927744252",
+        "fr": "applemusic://track/927744252",
+        "es": "applemusic://track/927744252",
+        "nl": "applemusic://track/927744252",
+        "it": "applemusic://track/927744252"
+      }
     },
     {
       "year": 2000,
@@ -1164,7 +1504,17 @@
       "fun_fact_nl": "Down with the Sickness werd een van de bepalende nummers van de hardrock van begin jaren 2000, verankerd door de unieke gutturale introzang van David Draiman en de meedogenloze riff van het nummer. Disturbed's debuut The Sickness debuteerde op nummer 29 en verkocht uiteindelijk meer dan vier miljoen exemplaren in de VS. Het nummer wordt regelmatig verkozen tot een van de beste metalnummers van het millennium.",
       "awards_nl": [
         "Grammy-nominatie"
-      ]
+      ],
+      "isrc": "USRE11500333",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1030601027",
+        "de": "applemusic://track/1030601027",
+        "gb": "applemusic://track/1030601027",
+        "fr": "applemusic://track/1030601027",
+        "es": "applemusic://track/1030601027",
+        "nl": "applemusic://track/1030601027",
+        "it": "applemusic://track/1030601027"
+      }
     },
     {
       "year": 2003,
@@ -1197,7 +1547,17 @@
       "fun_fact_nl": "Lamb of God is een van de belangrijkste metalbands van de jaren 2000, die samen met Mastodon en Killswitch Engage de New Wave of American Heavy Metal aanvoerde. Zanger Randy Blythe werd in 2012 in Tsjechië gearresteerd op beschuldiging van doodslag naar aanleiding van een incident tijdens een concert in 2010 - hij werd uiteindelijk vrijgesproken. Hun album Ashes of the Wake wordt beschouwd als een moderne metalklassieker.",
       "awards_nl": [
         "Grammy-nominatie"
-      ]
+      ],
+      "isrc": "USRZR0300801",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1440904907",
+        "de": "applemusic://track/1440904907",
+        "gb": "applemusic://track/1440904907",
+        "fr": "applemusic://track/1440904907",
+        "es": "applemusic://track/1440904907",
+        "nl": "applemusic://track/1440904907",
+        "it": "applemusic://track/1440904907"
+      }
     },
     {
       "year": 2004,
@@ -1230,7 +1590,17 @@
       "fun_fact_nl": "Blood and Thunder opent Mastodons doorbraakalbum Leviathan, een conceptuele hervertelling van Moby Dick door middel van progressieve sludgemetal. Het album wordt beschouwd als een van de meest creatieve en ambitieuze metalplaten van de jaren 2000. Mastodon wordt alom geprezen voor het verhogen van de artistieke ambities van metal en het bewijzen dat het genre in staat is tot echte progressieve diepgang.",
       "awards_nl": [
         "Grammy-nominatie"
-      ]
+      ],
+      "isrc": "US2640562201",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/65922935",
+        "de": "applemusic://track/65922935",
+        "gb": "applemusic://track/65922935",
+        "fr": "applemusic://track/65922935",
+        "es": "applemusic://track/65922935",
+        "nl": "applemusic://track/65922935",
+        "it": "applemusic://track/65922935"
+      }
     },
     {
       "year": 2001,
@@ -1263,7 +1633,17 @@
       "fun_fact_nl": "Flying Whales is Gojira's meest gevierde nummer, een technisch hoogstandje en een van de meest milieubewuste nummers in de metal. De Franse band wordt algemeen beschouwd als een van de meest innovatieve metalacts van de 21e eeuw, met een geluid dat progressieve structuren mengt met verpletterende deathmetalprecisie. Ze werden gekozen om de Olympische Spelen van 2024 in Parijs te openen.",
       "awards_nl": [
         "Grammy-nominatie"
-      ]
+      ],
+      "isrc": "FR6V80520037",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/213374170",
+        "de": "applemusic://track/213374170",
+        "gb": "applemusic://track/213374170",
+        "fr": "applemusic://track/213374170",
+        "es": "applemusic://track/213374170",
+        "nl": "applemusic://track/213374170",
+        "it": "applemusic://track/213374170"
+      }
     },
     {
       "year": 2016,
@@ -1296,7 +1676,17 @@
       "fun_fact_nl": "Silvera werd Gojira's meest toegankelijke en commercieel succesvolle nummer, een groove-driven metal anthem dat hen Grammy nominaties opleverde. Het nummer hielp de band om een veel breder publiek te bereiken zonder afbreuk te doen aan hun heavy sound. Magma, het album waarop het staat, werd geïnspireerd door de dood van de moeder van Joe en Mario Duplantier en wordt beschouwd als een van de meest emotioneel diepgaande metalplaten.",
       "awards_nl": [
         "Grammy-nominatie"
-      ]
+      ],
+      "isrc": "NLA321600053",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1104432802",
+        "de": "applemusic://track/1104432802",
+        "gb": "applemusic://track/1104432802",
+        "fr": "applemusic://track/1104432802",
+        "es": "applemusic://track/1104432802",
+        "nl": "applemusic://track/1104432802",
+        "it": "applemusic://track/1104432802"
+      }
     },
     {
       "year": 1995,
@@ -1329,7 +1719,17 @@
       "fun_fact_nl": "Roots Bloody Roots opent Sepultura's baanbrekende album Roots, dat Braziliaanse tribale muziek versmolt met groove metal om een van de meest unieke en belangrijke metalalbums van de jaren 90 te creëren. De band nam delen van het album op met de inheemse Xavante-stam in Brazilië. Het was het laatste album dat werd opgenomen met zanger Max Cavalera voordat hij uit de band stapte.",
       "awards_nl": [
         "Grammy-nominatie"
-      ]
+      ],
+      "isrc": "NLA329513650",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1630107557",
+        "de": "applemusic://track/1823629743",
+        "gb": "applemusic://track/1823629743",
+        "fr": "applemusic://track/1823629743",
+        "es": "applemusic://track/1823629743",
+        "nl": "applemusic://track/1823629743",
+        "it": "applemusic://track/1823629743"
+      }
     },
     {
       "year": 2011,
@@ -1362,7 +1762,17 @@
       "fun_fact_nl": "Square Hammer leverde Ghost in 2017 een Grammy op voor beste metalprestatie en is het nummer dat de Zweedse theatrale metalband wereldwijd onder de aandacht bracht. Ghost's combinatie van arena-rock hooks, satanische beelden en theatrale liveshows - compleet met een pausachtige frontman genaamd Papa Emeritus - maakte hen tot een van de meest visueel spectaculaire acts in de moderne rock.",
       "awards_nl": [
         "Grammy Award voor Beste Metalprestatie"
-      ]
+      ],
+      "isrc": "USC4R1601984",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1440946831",
+        "de": "applemusic://track/1650255958",
+        "gb": "applemusic://track/1650255958",
+        "fr": "applemusic://track/1650255958",
+        "es": "applemusic://track/1650255958",
+        "nl": "applemusic://track/1650255958",
+        "it": "applemusic://track/1650255958"
+      }
     },
     {
       "year": 2019,
@@ -1395,7 +1805,17 @@
       "fun_fact_nl": "Fear Inoculum is een meer dan 10 minuten durend progressief metalepos dat het langste nummer ooit werd in de Billboard Hot 100 toen Tool in 2019 een einde maakte aan zijn 13-jarige albumonderbreking. Het nummer debuteerde op nummer één in de rockcharts. Tool heeft hun catalogus jarenlang buiten streamingplatforms gehouden, waardoor de release een enorme gebeurtenis werd voor de metalgemeenschap.",
       "awards_nl": [
         "Grammy Award voor Beste Metalprestatie"
-      ]
+      ],
+      "isrc": "USRC11902032",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1475686698",
+        "de": "applemusic://track/1475686698",
+        "gb": "applemusic://track/1475686698",
+        "fr": "applemusic://track/1475686698",
+        "es": "applemusic://track/1475686698",
+        "nl": "applemusic://track/1475686698",
+        "it": "applemusic://track/1475686698"
+      }
     },
     {
       "year": 1985,
@@ -1428,7 +1848,17 @@
       "fun_fact_nl": "Ace of Spades is het definitieve volkslied van Motörhead en een van de snelste en meest woeste nummers uit de rockgeschiedenis. Lemmy Kilmister, de iconische bassist en zanger van de band, leefde een legendarisch hedonistische levensstijl, maar bleef toeren en opnemen tot weken voor zijn dood op 70-jarige leeftijd in december 2015. Het nummer is gebruikt in talloze films, tv-shows en videogames.",
       "awards_nl": [
         "Grammy-nominatie"
-      ]
+      ],
+      "isrc": "GBAJE8000033",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1442217683",
+        "de": "applemusic://track/1452532988",
+        "gb": "applemusic://track/1452532988",
+        "fr": "applemusic://track/1452532988",
+        "es": "applemusic://track/1452532988",
+        "nl": "applemusic://track/1452532988",
+        "it": "applemusic://track/1452532988"
+      }
     },
     {
       "year": 1997,
@@ -1461,7 +1891,17 @@
       "fun_fact_nl": "Bleed bevat een van de meest waanzinnig moeilijke drumpartijen ooit opgenomen - een continu polyritmisch patroon dat menselijke drummer Tomas Haake bijna acht minuten lang in een moordend tempo speelt. Meshuggah was de uitvinder van het djent-subgenre en heeft bijna elke progressieve en technische metalband van de afgelopen twintig jaar beïnvloed. Het nummer wordt door de meeste drummers bijna onspeelbaar geacht.",
       "awards_nl": [
         "Grammy-nominatie"
-      ]
+      ],
+      "isrc": "DED830703548",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1882049242",
+        "de": "applemusic://track/1882049242",
+        "gb": "applemusic://track/1882049242",
+        "fr": "applemusic://track/1882049242",
+        "es": "applemusic://track/1882049242",
+        "nl": "applemusic://track/1882049242",
+        "it": "applemusic://track/1882049242"
+      }
     },
     {
       "year": 1992,
@@ -1494,7 +1934,17 @@
       "fun_fact_nl": "Vulgar Display of Power is een van de meest invloedrijke metalalbums aller tijden en verstevigde Pantera's plaats in de heavy metal canon. Dimebag Darrell's agressieve, hoekige gitaarwerk op dit album beïnvloedde een generatie metal gitaristen. De albumhoes - een man die in zijn gezicht wordt geslagen - werd gekozen nadat de band letterlijk vrijwilligers had geslagen en de resultaten had gefotografeerd.",
       "awards_nl": [
         "Grammy-nominatie"
-      ]
+      ],
+      "isrc": "USAT21202188",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/518549047",
+        "de": "applemusic://track/518549047",
+        "gb": "applemusic://track/518549047",
+        "fr": "applemusic://track/518549047",
+        "es": "applemusic://track/518549047",
+        "nl": "applemusic://track/518549047",
+        "it": "applemusic://track/518549047"
+      }
     },
     {
       "year": 2001,
@@ -1527,7 +1977,17 @@
       "fun_fact_nl": "In the End is een van de best verkochte singles van de jaren 2000 en hielp Hybrid Theory om een van de best verkochte debuutalbums in de geschiedenis van de VS te worden. Het nummer was bijna van het album geschrapt omdat Chester Bennington aanvankelijk vond dat de zangmelodie niet werkte. Het pianomotief waarmee het nummer opent was het laatste dat werd toegevoegd. Chester Bennington stierf door zelfmoord in 2017.",
       "awards_nl": [
         "Grammy-nominatie"
-      ]
+      ],
+      "isrc": "USWB11201118",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/591534783",
+        "de": "applemusic://track/591534783",
+        "gb": "applemusic://track/591534783",
+        "fr": "applemusic://track/591534783",
+        "es": "applemusic://track/591534783",
+        "nl": "applemusic://track/591534783",
+        "it": "applemusic://track/591534783"
+      }
     },
     {
       "year": 2003,
@@ -1560,7 +2020,17 @@
       "fun_fact_nl": "The End of Heartache is het bepalende nummer van metalcore, een genre dat Killswitch Engage hielp creëren door de agressie van metal samen te voegen met de melodieuze gevoeligheid van hardcorepunk. De dubbele dynamiek van het nummer - brute breakdowns en stijgende cleane refreinen - werd het sjabloon voor honderden bands. Het hielp de New Wave of American Heavy Metal beweging te lanceren.",
       "awards_nl": [
         "Grammy-nominatie"
-      ]
+      ],
+      "isrc": "NLA320420753",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1840161703",
+        "de": "applemusic://track/1585370207",
+        "gb": "applemusic://track/1585370207",
+        "fr": "applemusic://track/1585370207",
+        "es": "applemusic://track/1585370207",
+        "nl": "applemusic://track/1585370207",
+        "it": "applemusic://track/1585370207"
+      }
     },
     {
       "year": 2006,
@@ -1593,7 +2063,17 @@
       "fun_fact_nl": "Trivium werd een van de meest prominente metalbands van de jaren 2000, door Lars Ulrich van Metallica geprezen als de toekomst van metal. Zanger Matt Heafy begon op 12-jarige leeftijd gitaar te spelen en tekende Trivium bij een major label toen hij slechts 15 jaar oud was. Hun mix van thrash en metalcore hielp twee generaties metalfans te overbruggen.",
       "awards_nl": [
         "Grammy-nominatie"
-      ]
+      ],
+      "isrc": "NLA321392901",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/697728142",
+        "de": "applemusic://track/702469381",
+        "gb": "applemusic://track/702469381",
+        "fr": "applemusic://track/702469381",
+        "es": "applemusic://track/702469381",
+        "nl": "applemusic://track/702469381",
+        "it": "applemusic://track/702469381"
+      }
     },
     {
       "year": 2014,
@@ -1626,7 +2106,17 @@
       "fun_fact_nl": "Drown markeerde een enorme evolutie in het geluid van Bring Me the Horizon, weg van metalcore naar atmosferische rock en synth-gedreven anthems. Het nummer werd hun grootste hit en maakte hen bekend bij een mainstream publiek. BMTH is een van de meest succesvolle Britse heavy acts van hun generatie, die zich enorm heeft ontwikkeld na hun brute deathcore begin.",
       "awards_nl": [
         "Grammy-nominatie"
-      ]
+      ],
+      "isrc": "GBARL1401189",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1485060616",
+        "de": "applemusic://track/922147642",
+        "gb": "applemusic://track/922147642",
+        "fr": "applemusic://track/922147642",
+        "es": "applemusic://track/922147642",
+        "nl": "applemusic://track/922147642",
+        "it": "applemusic://track/922147642"
+      }
     },
     {
       "year": 2010,
@@ -1659,7 +2149,17 @@
       "fun_fact_nl": "Parkway Drive groeide vanuit het surfstadje Byron Bay in Australië uit tot een van de meest succesvolle metalcore bands ter wereld. De Australische metalscene heeft een buitengewoon aantal heavy acts van wereldklasse voortgebracht en Parkway Drive is het kroonjuweel. Hun headline show in het Wembley Stadium in 2023 was een mijlpaal voor de Australische heavy muziek.",
       "awards_nl": [
         "Grammy-nominatie"
-      ]
+      ],
+      "isrc": "USEP41014009",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1485045876",
+        "de": "applemusic://track/1485045876",
+        "gb": "applemusic://track/1485045876",
+        "fr": "applemusic://track/1485045876",
+        "es": "applemusic://track/1485045876",
+        "nl": "applemusic://track/1485045876",
+        "it": "applemusic://track/1485045876"
+      }
     },
     {
       "year": 2012,
@@ -1692,7 +2192,17 @@
       "fun_fact_nl": "Architects werd de belangrijkste Britse metalcoreband van de jaren 2010 onder de creatieve leiding van gitarist Tom Searle, die in 2016 op 28-jarige leeftijd overleed aan huidkanker. Het album Holy Hell van de band - dat twee jaar na Toms dood uitkwam - was een emotioneel verwoestend eerbetoon, geschreven door zijn tweelingbroer Dan en de rest van de band. Het wordt beschouwd als een van de meest aangrijpende platen van moderne metal.",
       "awards_nl": [
         "Grammy-nominatie"
-      ]
+      ],
+      "isrc": "USEP41604038",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1485075528",
+        "de": "applemusic://track/1485075528",
+        "gb": "applemusic://track/1485075528",
+        "fr": "applemusic://track/1485075528",
+        "es": "applemusic://track/1485075528",
+        "nl": "applemusic://track/1485075528",
+        "it": "applemusic://track/1485075528"
+      }
     },
     {
       "year": 2020,
@@ -1725,7 +2235,17 @@
       "fun_fact_nl": "Underneath won Code Orange in 2021 een Grammy voor beste metalprestatie, waardoor ze een van de jongste bands ooit zijn die de prijs wonnen. De hardcore punk- en metalband uit Pittsburgh begon met repeteren op de middelbare school en tekende als tiener bij een groot label. Hun avant-gardistische benadering van heavy muziek - met industriële, elektronische en noise-elementen - vertegenwoordigt het snijvlak van moderne metal.",
       "awards_nl": [
         "Grammy Award voor Beste Metalprestatie"
-      ]
+      ],
+      "isrc": "NLA321900283",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1493581631",
+        "de": "applemusic://track/1493581631",
+        "gb": "applemusic://track/1493581631",
+        "fr": "applemusic://track/1493581631",
+        "es": "applemusic://track/1493581631",
+        "nl": "applemusic://track/1493581631",
+        "it": "applemusic://track/1493581631"
+      }
     }
   ]
 }

--- a/custom_components/beatify/playlists/community/hitster-100-en-espanol.json
+++ b/custom_components/beatify/playlists/community/hitster-100-en-espanol.json
@@ -1,5 +1,5 @@
 {
-  "name": "100% en Espa\u00f1ol \ud83c\uddea\ud83c\uddf8",
+  "name": "100% en Español 🇪🇸",
   "version": "1.5",
   "tags": [
     "spanish",
@@ -19,7 +19,7 @@
       "alt_artists": [
         "Joan Manuel Serrat",
         "Luis Eduardo Aute",
-        "V\u00edctor Manuel"
+        "Víctor Manuel"
       ],
       "title": "Una Dos Y Tres",
       "chart_info": {
@@ -29,15 +29,25 @@
       },
       "certifications": [],
       "awards": [],
-      "fun_fact": "Patxi Andi\u00f3n was a protest singer-songwriter icon during Spain's Franco era, using music for social commentary.",
-      "fun_fact_de": "Patxi Andi\u00f3n war eine Ikone der Protestlied-Bewegung w\u00e4hrend der Franco-\u00c4ra.",
-      "fun_fact_es": "Patxi Andi\u00f3n fue un icono de la canci\u00f3n protesta durante la era franquista.",
-      "fun_fact_fr": "Patxi Andi\u00f3n fut une ic\u00f4ne de la chanson contestataire durant l'\u00e8re franquiste.",
+      "fun_fact": "Patxi Andión was a protest singer-songwriter icon during Spain's Franco era, using music for social commentary.",
+      "fun_fact_de": "Patxi Andión war eine Ikone der Protestlied-Bewegung während der Franco-Ära.",
+      "fun_fact_es": "Patxi Andión fue un icono de la canción protesta durante la era franquista.",
+      "fun_fact_fr": "Patxi Andión fut une icône de la chanson contestataire durant l'ère franquiste.",
       "uri_apple_music": "applemusic://track/1438759692",
       "uri_youtube_music": "https://music.youtube.com/watch?v=UTomUsxKiLw",
       "uri_tidal": "tidal://track/3631762",
-      "fun_fact_nl": "Patxi Andi\u00f3n was een icoon van de protest singer-songwriter tijdens het Franco-tijdperk in Spanje, die muziek gebruikte voor sociaal commentaar.",
-      "awards_nl": []
+      "fun_fact_nl": "Patxi Andión was een icoon van de protest singer-songwriter tijdens het Franco-tijdperk in Spanje, die muziek gebruikte voor sociaal commentaar.",
+      "awards_nl": [],
+      "isrc": "DEVU51894747",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1438759692",
+        "de": "applemusic://track/1438759692",
+        "gb": "applemusic://track/1438759692",
+        "fr": "applemusic://track/1438759692",
+        "es": "applemusic://track/1438759692",
+        "nl": "applemusic://track/1438759692",
+        "it": "applemusic://track/1438759692"
+      }
     },
     {
       "year": 2012,
@@ -56,15 +66,25 @@
       },
       "certifications": [],
       "awards": [],
-      "fun_fact": "This Canarian band from Las Palmas became Spain's feel-good summer anthem kings \u2014 this track dominated Spanish radio in 2012.",
+      "fun_fact": "This Canarian band from Las Palmas became Spain's feel-good summer anthem kings — this track dominated Spanish radio in 2012.",
       "fun_fact_de": "Diese kanarische Band aus Las Palmas wurde 2012 zum Inbegriff spanischer Sommerhits.",
-      "fun_fact_es": "Esta banda canaria de Las Palmas se convirti\u00f3 en reina de los himnos veraniegos espa\u00f1oles en 2012.",
+      "fun_fact_es": "Esta banda canaria de Las Palmas se convirtió en reina de los himnos veraniegos españoles en 2012.",
       "fun_fact_fr": "Ce groupe canarien de Las Palmas est devenu le roi des hymnes estivaux espagnols en 2012.",
       "uri_apple_music": "applemusic://track/1322695796",
       "uri_youtube_music": "https://music.youtube.com/watch?v=n9qU9kVc6jM",
       "uri_tidal": "tidal://track/82198950",
       "fun_fact_nl": "Deze Canarische band uit Las Palmas werd de feel-good zomerhymne van Spanje - dit nummer domineerde de Spaanse radio in 2012.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "ES24C1207102",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1808388180",
+        "de": "applemusic://track/1808388180",
+        "gb": "applemusic://track/1808388180",
+        "fr": "applemusic://track/1808388180",
+        "es": "applemusic://track/1808388180",
+        "nl": "applemusic://track/1808388180",
+        "it": "applemusic://track/1808388180"
+      }
     },
     {
       "year": 2012,
@@ -84,14 +104,24 @@
       "certifications": [],
       "awards": [],
       "fun_fact": "Nancys Rubias is the project of Mario Vaquerizo, one of Spain's most colorful TV personalities and husband of Alaska from Fangoria.",
-      "fun_fact_de": "Nancys Rubias ist das Projekt von Mario Vaquerizo, Ehemann von Alaska (Fangoria) und einer der schillerndsten TV-Pers\u00f6nlichkeiten Spaniens.",
-      "fun_fact_es": "Nancys Rubias es el proyecto de Mario Vaquerizo, marido de Alaska (Fangoria) y una de las personalidades m\u00e1s coloridas de la TV espa\u00f1ola.",
-      "fun_fact_fr": "Nancys Rubias est le projet de Mario Vaquerizo, mari d'Alaska (Fangoria) et personnalit\u00e9 TV espagnole haute en couleur.",
+      "fun_fact_de": "Nancys Rubias ist das Projekt von Mario Vaquerizo, Ehemann von Alaska (Fangoria) und einer der schillerndsten TV-Persönlichkeiten Spaniens.",
+      "fun_fact_es": "Nancys Rubias es el proyecto de Mario Vaquerizo, marido de Alaska (Fangoria) y una de las personalidades más coloridas de la TV española.",
+      "fun_fact_fr": "Nancys Rubias est le projet de Mario Vaquerizo, mari d'Alaska (Fangoria) et personnalité TV espagnole haute en couleur.",
       "uri_apple_music": "applemusic://track/662768349",
       "uri_youtube_music": "https://music.youtube.com/watch?v=W2v72CID98M",
       "uri_tidal": "tidal://track/20970603",
       "fun_fact_nl": "Nancys Rubias is het project van Mario Vaquerizo, een van de kleurrijkste tv-persoonlijkheden van Spanje en echtgenoot van Alaska van Fangoria.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "ES5151300892",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1824185070",
+        "de": "applemusic://track/662768349",
+        "gb": "applemusic://track/1824185070",
+        "fr": "applemusic://track/1824185070",
+        "es": "applemusic://track/1824185070",
+        "nl": "applemusic://track/1824185070",
+        "it": "applemusic://track/1824185070"
+      }
     },
     {
       "year": 2017,
@@ -111,15 +141,25 @@
       },
       "certifications": [],
       "awards": [],
-      "fun_fact": "First Spanish-language song to reach #1 on the Billboard Hot 100 in 20+ years, with over 8 billion YouTube views \u2014 the most-viewed music video ever at its peak.",
-      "fun_fact_de": "Erster spanischsprachiger Song seit \u00fcber 20 Jahren auf Platz 1 der Billboard Hot 100, mit \u00fcber 8 Milliarden YouTube-Aufrufen.",
-      "fun_fact_es": "Primera canci\u00f3n en espa\u00f1ol en alcanzar el #1 del Billboard Hot 100 en m\u00e1s de 20 a\u00f1os, con m\u00e1s de 8 mil millones de reproducciones en YouTube.",
-      "fun_fact_fr": "Premi\u00e8re chanson en espagnol au #1 du Billboard Hot 100 en plus de 20 ans, avec plus de 8 milliards de vues YouTube.",
+      "fun_fact": "First Spanish-language song to reach #1 on the Billboard Hot 100 in 20+ years, with over 8 billion YouTube views — the most-viewed music video ever at its peak.",
+      "fun_fact_de": "Erster spanischsprachiger Song seit über 20 Jahren auf Platz 1 der Billboard Hot 100, mit über 8 Milliarden YouTube-Aufrufen.",
+      "fun_fact_es": "Primera canción en español en alcanzar el #1 del Billboard Hot 100 en más de 20 años, con más de 8 mil millones de reproducciones en YouTube.",
+      "fun_fact_fr": "Première chanson en espagnol au #1 du Billboard Hot 100 en plus de 20 ans, avec plus de 8 milliards de vues YouTube.",
       "uri_apple_music": "applemusic://track/1445011795",
       "uri_youtube_music": "https://music.youtube.com/watch?v=kJQP7kiw5Fk",
       "uri_tidal": "tidal://track/70587299",
       "fun_fact_nl": "Eerste Spaanstalige nummer dat op #1 staat in de Billboard Hot 100 in meer dan 20 jaar, met meer dan 8 miljard views op YouTube - de meest bekeken muziekvideo ooit op het hoogtepunt.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USUM71702239",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1586664786",
+        "de": "applemusic://track/1586664786",
+        "gb": "applemusic://track/1586664786",
+        "fr": "applemusic://track/1586664786",
+        "es": "applemusic://track/1586664786",
+        "nl": "applemusic://track/1586664786",
+        "it": "applemusic://track/1586664786"
+      }
     },
     {
       "year": 1985,
@@ -140,24 +180,34 @@
       "certifications": [],
       "awards": [],
       "fun_fact": "Twin brothers from Madrid's Vallecas district who pioneered 'rumba urbana' (flamenco-pop fusion), selling over 15 million records in Spain.",
-      "fun_fact_de": "Zwillingsbr\u00fcder aus Madrids Vallecas, Pioniere der 'Rumba Urbana' mit \u00fcber 15 Millionen verkauften Platten.",
-      "fun_fact_es": "Hermanos gemelos del barrio madrile\u00f1o de Vallecas, pioneros de la 'rumba urbana', con m\u00e1s de 15 millones de discos vendidos.",
-      "fun_fact_fr": "Fr\u00e8res jumeaux du quartier madril\u00e8ne de Vallecas, pionniers de la 'rumba urbana', plus de 15 millions de disques vendus.",
+      "fun_fact_de": "Zwillingsbrüder aus Madrids Vallecas, Pioniere der 'Rumba Urbana' mit über 15 Millionen verkauften Platten.",
+      "fun_fact_es": "Hermanos gemelos del barrio madrileño de Vallecas, pioneros de la 'rumba urbana', con más de 15 millones de discos vendidos.",
+      "fun_fact_fr": "Frères jumeaux du quartier madrilène de Vallecas, pionniers de la 'rumba urbana', plus de 15 millions de disques vendus.",
       "uri_apple_music": "applemusic://track/259103007",
       "uri_youtube_music": "https://music.youtube.com/watch?v=LPf92fBp2ZY",
       "uri_tidal": "tidal://track/9289819",
       "fun_fact_nl": "Tweelingbroers uit de wijk Vallecas in Madrid die pioniers waren op het gebied van 'rumba urbana' (flamenco-pop fusion) en meer dan 15 miljoen platen verkochten in Spanje.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "ES5630700146",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/958452370",
+        "de": "applemusic://track/958452370",
+        "gb": "applemusic://track/958452370",
+        "fr": "applemusic://track/958452370",
+        "es": "applemusic://track/958452370",
+        "nl": "applemusic://track/958452370",
+        "it": "applemusic://track/958452370"
+      }
     },
     {
       "year": 1996,
       "uri": "spotify:track:6Z8Q8zSG6xpIKAyH0Z77wb",
       "artist": "Luz Casal",
       "alt_artists": [
-        "Ana Bel\u00e9n",
-        "Roc\u00edo D\u00farcal",
-        "M\u00f3nica Naranjo",
-        "Mal\u00fa"
+        "Ana Belén",
+        "Rocío Dúrcal",
+        "Mónica Naranjo",
+        "Malú"
       ],
       "title": "Entre mis recuerdos",
       "chart_info": {
@@ -167,24 +217,34 @@
       },
       "certifications": [],
       "awards": [],
-      "fun_fact": "Luz Casal gained international fame when Pedro Almod\u00f3var featured 'Piensa en m\u00ed' in 'High Heels' (1991), making her one of Spain's most celebrated female voices.",
-      "fun_fact_de": "Luz Casal wurde international bekannt durch Pedro Almod\u00f3vars Film 'High Heels' (1991) mit ihrem Song 'Piensa en m\u00ed'.",
-      "fun_fact_es": "Luz Casal alcanz\u00f3 fama internacional cuando Almod\u00f3var incluy\u00f3 'Piensa en m\u00ed' en 'Tacones lejanos' (1991).",
-      "fun_fact_fr": "Luz Casal est devenue c\u00e9l\u00e8bre quand Almod\u00f3var a utilis\u00e9 'Piensa en m\u00ed' dans 'Talons aiguilles' (1991).",
+      "fun_fact": "Luz Casal gained international fame when Pedro Almodóvar featured 'Piensa en mí' in 'High Heels' (1991), making her one of Spain's most celebrated female voices.",
+      "fun_fact_de": "Luz Casal wurde international bekannt durch Pedro Almodóvars Film 'High Heels' (1991) mit ihrem Song 'Piensa en mí'.",
+      "fun_fact_es": "Luz Casal alcanzó fama internacional cuando Almodóvar incluyó 'Piensa en mí' en 'Tacones lejanos' (1991).",
+      "fun_fact_fr": "Luz Casal est devenue célèbre quand Almodóvar a utilisé 'Piensa en mí' dans 'Talons aiguilles' (1991).",
       "uri_apple_music": "applemusic://track/694098076",
       "uri_youtube_music": "https://music.youtube.com/watch?v=zUnOWCURe2M",
       "uri_tidal": "tidal://track/40783594",
-      "fun_fact_nl": "Luz Casal kreeg internationale bekendheid toen Pedro Almod\u00f3var 'Piensa en m\u00ed' opnam in 'High Heels' (1991), waardoor ze een van de meest gevierde vrouwenstemmen van Spanje werd.",
-      "awards_nl": []
+      "fun_fact_nl": "Luz Casal kreeg internationale bekendheid toen Pedro Almodóvar 'Piensa en mí' opnam in 'High Heels' (1991), waardoor ze een van de meest gevierde vrouwenstemmen van Spanje werd.",
+      "awards_nl": [],
+      "isrc": "ES5081100475",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/694098076",
+        "de": "applemusic://track/694098076",
+        "gb": "applemusic://track/694098076",
+        "fr": "applemusic://track/694098076",
+        "es": "applemusic://track/694098076",
+        "nl": "applemusic://track/694098076",
+        "it": "applemusic://track/694098076"
+      }
     },
     {
       "year": 1978,
       "uri": "spotify:track:7aKs8kWKKau0SDgaeyZMAX",
-      "artist": "Willie Col\u00f3n, Rub\u00e9n Blades",
+      "artist": "Willie Colón, Rubén Blades",
       "alt_artists": [
-        "H\u00e9ctor Lavoe",
+        "Héctor Lavoe",
         "Celia Cruz",
-        "Oscar D'Le\u00f3n",
+        "Oscar D'León",
         "Tito Puente"
       ],
       "title": "Pedro Navaja",
@@ -195,15 +255,25 @@
       },
       "certifications": [],
       "awards": [],
-      "fun_fact": "Considered the greatest salsa song ever \u2014 a 7-minute crime narrative inspired by 'Mack the Knife', from 'Siembra', the best-selling salsa album of all time.",
-      "fun_fact_de": "Gilt als gr\u00f6\u00dfter Salsa-Song aller Zeiten \u2014 7-min\u00fctige Kriminalgeschichte vom meistverkauften Salsa-Album 'Siembra'.",
-      "fun_fact_es": "Considerada la mayor canci\u00f3n de salsa jam\u00e1s escrita \u2014 narrativa criminal de 7 minutos del \u00e1lbum 'Siembra', el m\u00e1s vendido de la salsa.",
-      "fun_fact_fr": "Consid\u00e9r\u00e9e comme la plus grande chanson de salsa \u2014 r\u00e9cit criminel de 7 min tir\u00e9 de 'Siembra', l'album de salsa le plus vendu.",
+      "fun_fact": "Considered the greatest salsa song ever — a 7-minute crime narrative inspired by 'Mack the Knife', from 'Siembra', the best-selling salsa album of all time.",
+      "fun_fact_de": "Gilt als größter Salsa-Song aller Zeiten — 7-minütige Kriminalgeschichte vom meistverkauften Salsa-Album 'Siembra'.",
+      "fun_fact_es": "Considerada la mayor canción de salsa jamás escrita — narrativa criminal de 7 minutos del álbum 'Siembra', el más vendido de la salsa.",
+      "fun_fact_fr": "Considérée comme la plus grande chanson de salsa — récit criminel de 7 min tiré de 'Siembra', l'album de salsa le plus vendu.",
       "uri_apple_music": "applemusic://track/1464957419",
       "uri_youtube_music": "https://music.youtube.com/watch?v=5LqnbAkqRYQ",
       "uri_tidal": "tidal://track/60074360",
-      "fun_fact_nl": "Beschouwd als het beste salsanummer ooit - een 7-minuten durend misdaadverhaal ge\u00efnspireerd door 'Mack the Knife', van 'Siembra', het bestverkochte salsa-album aller tijden.",
-      "awards_nl": []
+      "fun_fact_nl": "Beschouwd als het beste salsanummer ooit - een 7-minuten durend misdaadverhaal geïnspireerd door 'Mack the Knife', van 'Siembra', het bestverkochte salsa-album aller tijden.",
+      "awards_nl": [],
+      "isrc": "USDBB0600261",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1464957419",
+        "de": "applemusic://track/1464957419",
+        "gb": "applemusic://track/1464957419",
+        "fr": "applemusic://track/1464957419",
+        "es": "applemusic://track/1464957419",
+        "nl": "applemusic://track/1464957419",
+        "it": "applemusic://track/1464957419"
+      }
     },
     {
       "year": 1970,
@@ -213,9 +283,9 @@
         "Raphael",
         "Nino Bravo",
         "Julio Iglesias",
-        "Jos\u00e9 Luis Perales"
+        "José Luis Perales"
       ],
-      "title": "Help, \u00e1yudame",
+      "title": "Help, áyudame",
       "chart_info": {
         "billboard_peak": null,
         "uk_peak": null,
@@ -224,14 +294,24 @@
       "certifications": [],
       "awards": [],
       "fun_fact": "Dutch-born Tony Ronald became one of Spain's biggest pop stars. This Spanish adaptation of The Beatles' 'Help!' became a karaoke classic in Spain.",
-      "fun_fact_de": "Der in Holland geborene Tony Ronald wurde einer der gr\u00f6\u00dften Popstars Spaniens mit dieser spanischen Version von Beatles' 'Help!'.",
-      "fun_fact_es": "Tony Ronald, nacido en Holanda, se convirti\u00f3 en estrella del pop espa\u00f1ol con esta adaptaci\u00f3n de 'Help!' de The Beatles.",
-      "fun_fact_fr": "N\u00e9 aux Pays-Bas, Tony Ronald est devenu star du pop espagnol avec cette adaptation de 'Help!' des Beatles.",
+      "fun_fact_de": "Der in Holland geborene Tony Ronald wurde einer der größten Popstars Spaniens mit dieser spanischen Version von Beatles' 'Help!'.",
+      "fun_fact_es": "Tony Ronald, nacido en Holanda, se convirtió en estrella del pop español con esta adaptación de 'Help!' de The Beatles.",
+      "fun_fact_fr": "Né aux Pays-Bas, Tony Ronald est devenu star du pop espagnol avec cette adaptation de 'Help!' des Beatles.",
       "uri_apple_music": "applemusic://track/1461480730",
       "uri_youtube_music": "https://music.youtube.com/watch?v=URRgBxPuuIw",
       "uri_tidal": "tidal://track/343790",
       "fun_fact_nl": "De in Nederland geboren Tony Ronald werd een van de grootste popsterren van Spanje. Deze Spaanse bewerking van The Beatles' 'Help!' werd een karaokeklassieker in Spanje.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "ES5070100059",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/168365130",
+        "de": "applemusic://track/168365130",
+        "gb": "applemusic://track/168365130",
+        "fr": "applemusic://track/168365130",
+        "es": "applemusic://track/930074779",
+        "nl": "applemusic://track/168365130",
+        "it": "applemusic://track/168365130"
+      }
     },
     {
       "year": 2019,
@@ -251,15 +331,25 @@
       },
       "certifications": [],
       "awards": [],
-      "fun_fact": "Catalan indie-pop artist who went viral with this self-referential bop \u2014 a song about wanting to write a hit, which ironically became exactly that.",
-      "fun_fact_de": "Katalanische Indie-Pop-K\u00fcnstlerin, die mit diesem Song \u00fcber den Wunsch einen Hit zu schreiben viral ging \u2014 und ironischerweise genau das schaffte.",
-      "fun_fact_es": "Artista indie-pop catalana que se hizo viral con esta canci\u00f3n sobre querer escribir un hit que, ir\u00f3nicamente, se convirti\u00f3 en uno.",
-      "fun_fact_fr": "Artiste indie-pop catalane devenue virale avec ce titre autor\u00e9f\u00e9rentiel sur l'envie d'\u00e9crire un tube \u2014 qui en est ironiquement devenu un.",
+      "fun_fact": "Catalan indie-pop artist who went viral with this self-referential bop — a song about wanting to write a hit, which ironically became exactly that.",
+      "fun_fact_de": "Katalanische Indie-Pop-Künstlerin, die mit diesem Song über den Wunsch einen Hit zu schreiben viral ging — und ironischerweise genau das schaffte.",
+      "fun_fact_es": "Artista indie-pop catalana que se hizo viral con esta canción sobre querer escribir un hit que, irónicamente, se convirtió en uno.",
+      "fun_fact_fr": "Artiste indie-pop catalane devenue virale avec ce titre autoréférentiel sur l'envie d'écrire un tube — qui en est ironiquement devenu un.",
       "uri_apple_music": "applemusic://track/1804701192",
       "uri_youtube_music": "https://music.youtube.com/watch?v=_I9Qpoi4yMQ",
       "uri_tidal": "tidal://track/420279040",
       "fun_fact_nl": "Catalaanse indie-pop artiest die viraal ging met deze zelfverwijzende bop - een liedje over het willen schrijven van een hit, wat ironisch genoeg precies dat werd.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "ES11D1900262",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1804701192",
+        "de": "applemusic://track/1804701192",
+        "gb": "applemusic://track/1804701192",
+        "fr": "applemusic://track/1804701192",
+        "es": "applemusic://track/1804701192",
+        "nl": "applemusic://track/1804701192",
+        "it": "applemusic://track/1804701192"
+      }
     },
     {
       "year": 1982,
@@ -269,7 +359,7 @@
         "Ricchi e Poveri",
         "Umberto Tozzi",
         "Toto Cutugno",
-        "Raffaella Carr\u00e0"
+        "Raffaella Carrà"
       ],
       "title": "Felicidad",
       "chart_info": {
@@ -281,13 +371,23 @@
       "awards": [],
       "fun_fact": "Italy's golden couple of pop (married 1970-1999). 'Felicidad' became the unofficial anthem of Spanish summer holidays in the 80s.",
       "fun_fact_de": "Italiens goldenes Pop-Paar (1970-1999 verheiratet). 'Felicidad' wurde zur inoffiziellen Hymne spanischer Sommerferien der 80er.",
-      "fun_fact_es": "La pareja dorada del pop italiano (casados 1970-1999). 'Felicidad' se convirti\u00f3 en himno oficioso de las vacaciones espa\u00f1olas de los 80.",
-      "fun_fact_fr": "Le couple en or du pop italien (mari\u00e9s 1970-1999). 'Felicidad' est devenu l'hymne officieux des vacances d'\u00e9t\u00e9 espagnoles des ann\u00e9es 80.",
+      "fun_fact_es": "La pareja dorada del pop italiano (casados 1970-1999). 'Felicidad' se convirtió en himno oficioso de las vacaciones españolas de los 80.",
+      "fun_fact_fr": "Le couple en or du pop italien (mariés 1970-1999). 'Felicidad' est devenu l'hymne officieux des vacances d'été espagnoles des années 80.",
       "uri_apple_music": "applemusic://track/1726909970",
       "uri_youtube_music": "https://music.youtube.com/watch?v=LAt_Ccb2bJI",
       "uri_tidal": "tidal://track/519816",
-      "fun_fact_nl": "Itali\u00eb's gouden popkoppel (getrouwd 1970-1999). Felicidad' werd het onoffici\u00eble volkslied van de Spaanse zomervakantie in de jaren 80.",
-      "awards_nl": []
+      "fun_fact_nl": "Italië's gouden popkoppel (getrouwd 1970-1999). Felicidad' werd het onofficiële volkslied van de Spaanse zomervakantie in de jaren 80.",
+      "awards_nl": [],
+      "isrc": "DEA812400025",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1726909970",
+        "de": "applemusic://track/1726909970",
+        "gb": "applemusic://track/1726909970",
+        "fr": "applemusic://track/1726909970",
+        "es": "applemusic://track/1726909970",
+        "nl": "applemusic://track/1726909970",
+        "it": "applemusic://track/1726909970"
+      }
     },
     {
       "year": 1981,
@@ -307,15 +407,25 @@
       },
       "certifications": [],
       "awards": [],
-      "fun_fact": "A Spanish flamenco-rumba cover of Francis Cabrel's 'Je l'aime \u00e0 mourir' that became even more famous in Spain than the French original.",
-      "fun_fact_de": "Ein Flamenco-Rumba-Cover von Francis Cabrels 'Je l'aime \u00e0 mourir', das in Spanien ber\u00fchmter wurde als das franz\u00f6sische Original.",
-      "fun_fact_es": "Versi\u00f3n flamenca de 'Je l'aime \u00e0 mourir' de Francis Cabrel que se hizo m\u00e1s famosa en Espa\u00f1a que el original franc\u00e9s.",
-      "fun_fact_fr": "Reprise flamenco-rumba de 'Je l'aime \u00e0 mourir' de Francis Cabrel, devenue plus c\u00e9l\u00e8bre en Espagne que l'original.",
+      "fun_fact": "A Spanish flamenco-rumba cover of Francis Cabrel's 'Je l'aime à mourir' that became even more famous in Spain than the French original.",
+      "fun_fact_de": "Ein Flamenco-Rumba-Cover von Francis Cabrels 'Je l'aime à mourir', das in Spanien berühmter wurde als das französische Original.",
+      "fun_fact_es": "Versión flamenca de 'Je l'aime à mourir' de Francis Cabrel que se hizo más famosa en España que el original francés.",
+      "fun_fact_fr": "Reprise flamenco-rumba de 'Je l'aime à mourir' de Francis Cabrel, devenue plus célèbre en Espagne que l'original.",
       "uri_apple_music": "applemusic://track/505148565",
       "uri_youtube_music": "https://music.youtube.com/watch?v=hHNGcwq3ml4",
       "uri_tidal": "tidal://track/10912456",
-      "fun_fact_nl": "Een Spaanse flamenco-rumba cover van Francis Cabrel's 'Je l'aime \u00e0 mourir' die in Spanje nog beroemder werd dan het Franse origineel.",
-      "awards_nl": []
+      "fun_fact_nl": "Een Spaanse flamenco-rumba cover van Francis Cabrel's 'Je l'aime à mourir' die in Spanje nog beroemder werd dan het Franse origineel.",
+      "awards_nl": [],
+      "isrc": "ES5118500063",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1591593239",
+        "de": "applemusic://track/1591593239",
+        "gb": "applemusic://track/1591593239",
+        "fr": "applemusic://track/1591593239",
+        "es": "applemusic://track/1591593239",
+        "nl": "applemusic://track/1591593239",
+        "it": "applemusic://track/1591593239"
+      }
     },
     {
       "year": 2002,
@@ -324,7 +434,7 @@
       "alt_artists": [
         "David Bisbal",
         "Chenoa",
-        "Rosa L\u00f3pez",
+        "Rosa López",
         "Manuel Carrasco"
       ],
       "title": "Feliz",
@@ -335,15 +445,25 @@
       },
       "certifications": [],
       "awards": [],
-      "fun_fact": "Rose to fame on 'Operaci\u00f3n Triunfo' season 1 (2001), the most-watched TV show in Spanish history with 12+ million viewers at the finale.",
-      "fun_fact_de": "Wurde durch 'Operaci\u00f3n Triunfo' Staffel 1 (2001) ber\u00fchmt \u2014 die meistgesehene TV-Show der spanischen Geschichte.",
-      "fun_fact_es": "Salt\u00f3 a la fama en 'Operaci\u00f3n Triunfo' 1 (2001), el programa m\u00e1s visto de la historia de la TV espa\u00f1ola.",
-      "fun_fact_fr": "Devenu c\u00e9l\u00e8bre gr\u00e2ce \u00e0 'Operaci\u00f3n Triunfo' saison 1 (2001), l'\u00e9mission la plus regard\u00e9e de l'histoire de la TV espagnole.",
+      "fun_fact": "Rose to fame on 'Operación Triunfo' season 1 (2001), the most-watched TV show in Spanish history with 12+ million viewers at the finale.",
+      "fun_fact_de": "Wurde durch 'Operación Triunfo' Staffel 1 (2001) berühmt — die meistgesehene TV-Show der spanischen Geschichte.",
+      "fun_fact_es": "Saltó a la fama en 'Operación Triunfo' 1 (2001), el programa más visto de la historia de la TV española.",
+      "fun_fact_fr": "Devenu célèbre grâce à 'Operación Triunfo' saison 1 (2001), l'émission la plus regardée de l'histoire de la TV espagnole.",
       "uri_apple_music": "applemusic://track/1443557151",
       "uri_youtube_music": "https://music.youtube.com/watch?v=WUXjoTtiSXg",
       "uri_tidal": "tidal://track/34192115",
-      "fun_fact_nl": "Werd beroemd in 'Operaci\u00f3n Triunfo' seizoen 1 (2001), de best bekeken tv-show in de Spaanse geschiedenis met meer dan 12 miljoen kijkers bij de finale.",
-      "awards_nl": []
+      "fun_fact_nl": "Werd beroemd in 'Operación Triunfo' seizoen 1 (2001), de best bekeken tv-show in de Spaanse geschiedenis met meer dan 12 miljoen kijkers bij de finale.",
+      "awards_nl": [],
+      "isrc": "ES5701400308",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1711311377",
+        "de": "applemusic://track/1711311377",
+        "gb": "applemusic://track/1711311377",
+        "fr": "applemusic://track/1711311377",
+        "es": "applemusic://track/1442884591",
+        "nl": "applemusic://track/1711311377",
+        "it": "applemusic://track/1711311377"
+      }
     },
     {
       "year": 2021,
@@ -355,7 +475,7 @@
         "Maluma",
         "Marc Anthony"
       ],
-      "title": "Canci\u00f3n Bonita",
+      "title": "Canción Bonita",
       "chart_info": {
         "billboard_peak": null,
         "uk_peak": null,
@@ -363,15 +483,25 @@
       },
       "certifications": [],
       "awards": [],
-      "fun_fact": "A collaboration uniting Colombia's Vives with Puerto Rico's Ricky Martin \u2014 two Latin legends with 70+ combined years of career. A love letter to positivity during the pandemic.",
-      "fun_fact_de": "Vereinte Kolumbiens Vives mit Puerto Ricos Ricky Martin \u2014 zwei Legenden mit \u00fcber 70 Jahren Karriere. Eine Liebeserkl\u00e4rung an die Positivit\u00e4t w\u00e4hrend der Pandemie.",
-      "fun_fact_es": "Uni\u00f3 al colombiano Vives con el puertorrique\u00f1o Ricky Martin \u2014 dos leyendas con m\u00e1s de 70 a\u00f1os de carrera combinados. Canto a la positividad durante la pandemia.",
-      "fun_fact_fr": "A r\u00e9uni le Colombien Vives et le Portoricain Ricky Martin \u2014 deux l\u00e9gendes totalisant 70+ ans de carri\u00e8re. Un hymne \u00e0 la positivit\u00e9 pendant la pand\u00e9mie.",
+      "fun_fact": "A collaboration uniting Colombia's Vives with Puerto Rico's Ricky Martin — two Latin legends with 70+ combined years of career. A love letter to positivity during the pandemic.",
+      "fun_fact_de": "Vereinte Kolumbiens Vives mit Puerto Ricos Ricky Martin — zwei Legenden mit über 70 Jahren Karriere. Eine Liebeserklärung an die Positivität während der Pandemie.",
+      "fun_fact_es": "Unió al colombiano Vives con el puertorriqueño Ricky Martin — dos leyendas con más de 70 años de carrera combinados. Canto a la positividad durante la pandemia.",
+      "fun_fact_fr": "A réuni le Colombien Vives et le Portoricain Ricky Martin — deux légendes totalisant 70+ ans de carrière. Un hymne à la positivité pendant la pandémie.",
       "uri_apple_music": "applemusic://track/1562714028",
       "uri_youtube_music": "https://music.youtube.com/watch?v=KIBeny5wq6M",
       "uri_tidal": "tidal://track/179661758",
-      "fun_fact_nl": "Een samenwerking tussen Colombia's Vives en Puerto Rico's Ricky Martin - twee Latin-legendes met samen meer dan 70 jaar carri\u00e8re. Een liefdesbrief aan positiviteit tijdens de pandemie.",
-      "awards_nl": []
+      "fun_fact_nl": "Een samenwerking tussen Colombia's Vives en Puerto Rico's Ricky Martin - twee Latin-legendes met samen meer dan 70 jaar carrière. Een liefdesbrief aan positiviteit tijdens de pandemie.",
+      "awards_nl": [],
+      "isrc": "USSD12100149",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1562714028",
+        "de": "applemusic://track/1562714028",
+        "gb": "applemusic://track/1562714028",
+        "fr": "applemusic://track/1562714028",
+        "es": "applemusic://track/1562714028",
+        "nl": "applemusic://track/1562714028",
+        "it": "applemusic://track/1562714028"
+      }
     },
     {
       "year": 1981,
@@ -390,15 +520,25 @@
       },
       "certifications": [],
       "awards": [],
-      "fun_fact": "Originally 'Sar\u00e0 perch\u00e9 ti amo' in Italian, the Spanish version became a staple at Spanish weddings and verbenas for decades.",
-      "fun_fact_de": "Die spanische Version von 'Sar\u00e0 perch\u00e9 ti amo' wurde jahrzehntelang zum Dauerbrenner auf spanischen Hochzeiten und Festen.",
-      "fun_fact_es": "La versi\u00f3n espa\u00f1ola de 'Sar\u00e0 perch\u00e9 ti amo' lleva d\u00e9cadas siendo imprescindible en bodas y verbenas espa\u00f1olas.",
-      "fun_fact_fr": "La version espagnole de 'Sar\u00e0 perch\u00e9 ti amo' est un incontournable des mariages et f\u00eates espagnoles depuis des d\u00e9cennies.",
+      "fun_fact": "Originally 'Sarà perché ti amo' in Italian, the Spanish version became a staple at Spanish weddings and verbenas for decades.",
+      "fun_fact_de": "Die spanische Version von 'Sarà perché ti amo' wurde jahrzehntelang zum Dauerbrenner auf spanischen Hochzeiten und Festen.",
+      "fun_fact_es": "La versión española de 'Sarà perché ti amo' lleva décadas siendo imprescindible en bodas y verbenas españolas.",
+      "fun_fact_fr": "La version espagnole de 'Sarà perché ti amo' est un incontournable des mariages et fêtes espagnoles depuis des décennies.",
       "uri_apple_music": "applemusic://track/353035476",
       "uri_youtube_music": "https://music.youtube.com/watch?v=f37dgOF3I6o",
       "uri_tidal": "tidal://track/20153650",
-      "fun_fact_nl": "Oorspronkelijk 'Sar\u00e0 perch\u00e9 ti amo' in het Italiaans, werd de Spaanse versie decennialang een vast onderdeel van Spaanse bruiloften en verbenas.",
-      "awards_nl": []
+      "fun_fact_nl": "Oorspronkelijk 'Sarà perché ti amo' in het Italiaans, werd de Spaanse versie decennialang een vast onderdeel van Spaanse bruiloften en verbenas.",
+      "awards_nl": [],
+      "isrc": "USTCD1000540",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/353035476",
+        "de": "applemusic://track/353035476",
+        "gb": "applemusic://track/353035476",
+        "fr": "applemusic://track/353035476",
+        "es": "applemusic://track/353035476",
+        "nl": "applemusic://track/353035476",
+        "it": "applemusic://track/353035476"
+      }
     },
     {
       "year": 2022,
@@ -419,14 +559,24 @@
       "certifications": [],
       "awards": [],
       "fun_fact": "Despite its title, not traditional bachata but pop-urbano. Became the most-streamed Spanish-language song on Spotify in 2022 with 2+ billion streams.",
-      "fun_fact_de": "Trotz des Titels keine traditionelle Bachata, sondern Pop-Urbano. Meistgestreamter spanischsprachiger Song auf Spotify 2022 mit \u00fcber 2 Milliarden Streams.",
-      "fun_fact_es": "A pesar del t\u00edtulo, no es bachata tradicional sino pop urbano. Canci\u00f3n m\u00e1s reproducida en espa\u00f1ol en Spotify en 2022 con m\u00e1s de 2 mil millones de reproducciones.",
-      "fun_fact_fr": "Malgr\u00e9 son titre, pas de la bachata traditionnelle mais du pop-urbano. Chanson hispanophone la plus stream\u00e9e sur Spotify en 2022 avec 2+ milliards d'\u00e9coutes.",
+      "fun_fact_de": "Trotz des Titels keine traditionelle Bachata, sondern Pop-Urbano. Meistgestreamter spanischsprachiger Song auf Spotify 2022 mit über 2 Milliarden Streams.",
+      "fun_fact_es": "A pesar del título, no es bachata tradicional sino pop urbano. Canción más reproducida en español en Spotify en 2022 con más de 2 mil millones de reproducciones.",
+      "fun_fact_fr": "Malgré son titre, pas de la bachata traditionnelle mais du pop-urbano. Chanson hispanophone la plus streamée sur Spotify en 2022 avec 2+ milliards d'écoutes.",
       "uri_apple_music": "applemusic://track/1624563284",
       "uri_youtube_music": "https://music.youtube.com/watch?v=2w_nFl_87Sw",
       "uri_tidal": "tidal://track/229552658",
       "fun_fact_nl": "Ondanks de titel geen traditionele bachata maar pop-urbano. Werd het meest gestreamde Spaanstalige nummer op Spotify in 2022 met meer dan 2 miljard streams.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "QZDYA1800087",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1624563284",
+        "de": "applemusic://track/1624563284",
+        "gb": "applemusic://track/1624563284",
+        "fr": "applemusic://track/1624563284",
+        "es": "applemusic://track/1624563284",
+        "nl": "applemusic://track/1624563284",
+        "it": "applemusic://track/1624563284"
+      }
     },
     {
       "year": 2023,
@@ -434,11 +584,11 @@
       "artist": "DePol",
       "alt_artists": [
         "Beret",
-        "Pablo Albor\u00e1n",
+        "Pablo Alborán",
         "Manuel Carrasco",
-        "\u00c1lvaro de Luna"
+        "Álvaro de Luna"
       ],
-      "title": "Qui\u00e9n Dir\u00eda",
+      "title": "Quién Diría",
       "chart_info": {
         "billboard_peak": null,
         "uk_peak": null,
@@ -446,15 +596,25 @@
       },
       "certifications": [],
       "awards": [],
-      "fun_fact": "Went viral on TikTok \u2014 became one of Spain's biggest hits of 2023 despite DePol being virtually unknown months before release.",
-      "fun_fact_de": "Ging auf TikTok viral \u2014 wurde 2023 einer der gr\u00f6\u00dften Hits Spaniens, obwohl DePol Monate zuvor noch unbekannt war.",
-      "fun_fact_es": "Se hizo viral en TikTok \u2014 uno de los mayores \u00e9xitos de Espa\u00f1a en 2023 a pesar de ser desconocido meses antes.",
-      "fun_fact_fr": "Devenu viral sur TikTok \u2014 l'un des plus grands succ\u00e8s espagnols de 2023 alors que DePol \u00e9tait quasi inconnu quelques mois avant.",
+      "fun_fact": "Went viral on TikTok — became one of Spain's biggest hits of 2023 despite DePol being virtually unknown months before release.",
+      "fun_fact_de": "Ging auf TikTok viral — wurde 2023 einer der größten Hits Spaniens, obwohl DePol Monate zuvor noch unbekannt war.",
+      "fun_fact_es": "Se hizo viral en TikTok — uno de los mayores éxitos de España en 2023 a pesar de ser desconocido meses antes.",
+      "fun_fact_fr": "Devenu viral sur TikTok — l'un des plus grands succès espagnols de 2023 alors que DePol était quasi inconnu quelques mois avant.",
       "uri_apple_music": "applemusic://track/1619110608",
       "uri_youtube_music": "https://music.youtube.com/watch?v=PE7gYNK8gQg",
       "uri_tidal": "tidal://track/421676922",
       "fun_fact_nl": "Werd viraal op TikTok - werd een van Spanjes grootste hits van 2023 ondanks dat DePol maanden voor de release nog vrijwel onbekend was.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "ES6702209001",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1831063985",
+        "de": "applemusic://track/1831063985",
+        "gb": "applemusic://track/1831063985",
+        "fr": "applemusic://track/1831063985",
+        "es": "applemusic://track/1831063985",
+        "nl": "applemusic://track/1831063985",
+        "it": "applemusic://track/1831063985"
+      }
     },
     {
       "year": 2004,
@@ -463,10 +623,10 @@
       "alt_artists": [
         "Bustamante",
         "Manuel Carrasco",
-        "Pablo Albor\u00e1n",
+        "Pablo Alborán",
         "Antonio Orozco"
       ],
-      "title": "Buler\u00eda",
+      "title": "Bulería",
       "chart_info": {
         "billboard_peak": null,
         "uk_peak": null,
@@ -474,15 +634,25 @@
       },
       "certifications": [],
       "awards": [],
-      "fun_fact": "Operaci\u00f3n Triunfo alumnus from Almer\u00eda fused flamenco with pop. The title refers to buler\u00eda, the fastest and most passionate form of flamenco.",
-      "fun_fact_de": "OT-Absolvent aus Almer\u00eda verschmolz Flamenco mit Pop. Der Titel bezieht sich auf Buler\u00eda, die schnellste und leidenschaftlichste Flamenco-Form.",
-      "fun_fact_es": "Ex alumno de OT de Almer\u00eda que fusion\u00f3 flamenco con pop. El t\u00edtulo se refiere a la buler\u00eda, el palo m\u00e1s r\u00e1pido y apasionado del flamenco.",
-      "fun_fact_fr": "Ancien d'OT originaire d'Almer\u00eda, il a fusionn\u00e9 flamenco et pop. Le titre fait r\u00e9f\u00e9rence \u00e0 la buler\u00eda, la forme la plus rapide du flamenco.",
+      "fun_fact": "Operación Triunfo alumnus from Almería fused flamenco with pop. The title refers to bulería, the fastest and most passionate form of flamenco.",
+      "fun_fact_de": "OT-Absolvent aus Almería verschmolz Flamenco mit Pop. Der Titel bezieht sich auf Bulería, die schnellste und leidenschaftlichste Flamenco-Form.",
+      "fun_fact_es": "Ex alumno de OT de Almería que fusionó flamenco con pop. El título se refiere a la bulería, el palo más rápido y apasionado del flamenco.",
+      "fun_fact_fr": "Ancien d'OT originaire d'Almería, il a fusionné flamenco et pop. Le titre fait référence à la bulería, la forme la plus rapide du flamenco.",
       "uri_apple_music": "applemusic://track/1443232792",
       "uri_youtube_music": "https://music.youtube.com/watch?v=vUqYEh5gJ_c",
       "uri_tidal": "tidal://track/4019496",
-      "fun_fact_nl": "Alumnus van Operaci\u00f3n Triunfo uit Almer\u00eda versmolt flamenco met pop. De titel verwijst naar buler\u00eda, de snelste en meest gepassioneerde vorm van flamenco.",
-      "awards_nl": []
+      "fun_fact_nl": "Alumnus van Operación Triunfo uit Almería versmolt flamenco met pop. De titel verwijst naar bulería, de snelste en meest gepassioneerde vorm van flamenco.",
+      "awards_nl": [],
+      "isrc": "ES6010400020",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1698229459",
+        "de": "applemusic://track/1698229459",
+        "gb": "applemusic://track/1698229459",
+        "fr": "applemusic://track/1698229459",
+        "es": "applemusic://track/1698229459",
+        "nl": "applemusic://track/1698229459",
+        "it": "applemusic://track/1698229459"
+      }
     },
     {
       "year": 2007,
@@ -502,15 +672,25 @@
       },
       "certifications": [],
       "awards": [],
-      "fun_fact": "El Barrio from C\u00e1diz pioneered a unique blend of flamenco, copla and pop \u2014 filling stadiums in Spain while remaining virtually unknown internationally.",
-      "fun_fact_de": "El Barrio aus C\u00e1diz schuf eine einzigartige Mischung aus Flamenco, Copla und Pop \u2014 f\u00fcllt Stadien in Spanien, international aber unbekannt.",
-      "fun_fact_es": "El Barrio, de C\u00e1diz, cre\u00f3 una fusi\u00f3n \u00fanica de flamenco, copla y pop \u2014 llena estadios en Espa\u00f1a pero es desconocido internacionalmente.",
-      "fun_fact_fr": "El Barrio, de Cadix, a cr\u00e9\u00e9 un m\u00e9lange unique de flamenco, copla et pop \u2014 remplit les stades en Espagne mais reste inconnu \u00e0 l'international.",
+      "fun_fact": "El Barrio from Cádiz pioneered a unique blend of flamenco, copla and pop — filling stadiums in Spain while remaining virtually unknown internationally.",
+      "fun_fact_de": "El Barrio aus Cádiz schuf eine einzigartige Mischung aus Flamenco, Copla und Pop — füllt Stadien in Spanien, international aber unbekannt.",
+      "fun_fact_es": "El Barrio, de Cádiz, creó una fusión única de flamenco, copla y pop — llena estadios en España pero es desconocido internacionalmente.",
+      "fun_fact_fr": "El Barrio, de Cadix, a créé un mélange unique de flamenco, copla et pop — remplit les stades en Espagne mais reste inconnu à l'international.",
       "uri_apple_music": "applemusic://track/603228048",
       "uri_youtube_music": "https://music.youtube.com/watch?v=cxZGge2KKnY",
       "uri_tidal": "tidal://track/31852101",
-      "fun_fact_nl": "El Barrio uit C\u00e1diz pionierde met een unieke mix van flamenco, copla en pop - waarmee ze stadions vulden in Spanje terwijl ze internationaal vrijwel onbekend bleven.",
-      "awards_nl": []
+      "fun_fact_nl": "El Barrio uit Cádiz pionierde met een unieke mix van flamenco, copla en pop - waarmee ze stadions vulden in Spanje terwijl ze internationaal vrijwel onbekend bleven.",
+      "awards_nl": [],
+      "isrc": "ES5160300011",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1574359692",
+        "de": "applemusic://track/1574359692",
+        "gb": "applemusic://track/1574359692",
+        "fr": "applemusic://track/1574359692",
+        "es": "applemusic://track/1574359692",
+        "nl": "applemusic://track/1574359692",
+        "it": "applemusic://track/1574359692"
+      }
     },
     {
       "year": 1997,
@@ -531,14 +711,24 @@
       "certifications": [],
       "awards": [],
       "fun_fact": "Los Piratas from Vigo were key figures in Spanish 90s indie rock. This was their crossover hit that brought alternative Spanish rock to mainstream radio.",
-      "fun_fact_de": "Los Piratas aus Vigo waren Schl\u00fcsselfiguren des spanischen 90er-Indie-Rock. Ihr Crossover-Hit brachte alternativen Rock ins Mainstream-Radio.",
-      "fun_fact_es": "Los Piratas de Vigo fueron figuras clave del indie rock espa\u00f1ol de los 90. Su \u00e9xito crossover que llev\u00f3 el rock alternativo a la radio comercial.",
-      "fun_fact_fr": "Los Piratas de Vigo furent des figures cl\u00e9s du rock indie espagnol des ann\u00e9es 90. Leur tube crossover qui a amen\u00e9 le rock alternatif sur les radios commerciales.",
+      "fun_fact_de": "Los Piratas aus Vigo waren Schlüsselfiguren des spanischen 90er-Indie-Rock. Ihr Crossover-Hit brachte alternativen Rock ins Mainstream-Radio.",
+      "fun_fact_es": "Los Piratas de Vigo fueron figuras clave del indie rock español de los 90. Su éxito crossover que llevó el rock alternativo a la radio comercial.",
+      "fun_fact_fr": "Los Piratas de Vigo furent des figures clés du rock indie espagnol des années 90. Leur tube crossover qui a amené le rock alternatif sur les radios commerciales.",
       "uri_apple_music": "applemusic://track/1268518529",
       "uri_youtube_music": "https://music.youtube.com/watch?v=hptUE57xH74",
       "uri_tidal": "tidal://track/77145447",
       "fun_fact_nl": "Los Piratas uit Vigo waren sleutelfiguren in de Spaanse indierock van de jaren 90. Dit was hun crossover hit die alternatieve Spaanse rock naar de mainstream radio bracht.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "ES5159511076",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1743406074",
+        "de": "applemusic://track/1743406074",
+        "gb": "applemusic://track/1743406074",
+        "fr": "applemusic://track/1743406074",
+        "es": "applemusic://track/1743406074",
+        "nl": "applemusic://track/1743406074",
+        "it": "applemusic://track/1743406074"
+      }
     },
     {
       "year": 1974,
@@ -557,20 +747,30 @@
       },
       "certifications": [],
       "awards": [],
-      "fun_fact": "Las Grecas were two Romani sisters from Madrid who fused flamenco with psychedelic rock in the 70s \u2014 decades ahead of their time. This was a #1 hit in Spain.",
-      "fun_fact_de": "Las Grecas waren zwei Roma-Schwestern aus Madrid, die in den 70ern Flamenco mit psychedelischem Rock verschmolzen \u2014 ihrer Zeit um Jahrzehnte voraus.",
-      "fun_fact_es": "Las Grecas eran dos hermanas gitanas de Madrid que fusionaron flamenco con rock psicod\u00e9lico en los 70 \u2014 d\u00e9cadas adelantadas a su tiempo.",
-      "fun_fact_fr": "Las Grecas \u00e9taient deux s\u0153urs gitanes de Madrid qui ont fusionn\u00e9 flamenco et rock psych\u00e9d\u00e9lique dans les ann\u00e9es 70 \u2014 des d\u00e9cennies en avance.",
+      "fun_fact": "Las Grecas were two Romani sisters from Madrid who fused flamenco with psychedelic rock in the 70s — decades ahead of their time. This was a #1 hit in Spain.",
+      "fun_fact_de": "Las Grecas waren zwei Roma-Schwestern aus Madrid, die in den 70ern Flamenco mit psychedelischem Rock verschmolzen — ihrer Zeit um Jahrzehnte voraus.",
+      "fun_fact_es": "Las Grecas eran dos hermanas gitanas de Madrid que fusionaron flamenco con rock psicodélico en los 70 — décadas adelantadas a su tiempo.",
+      "fun_fact_fr": "Las Grecas étaient deux sœurs gitanes de Madrid qui ont fusionné flamenco et rock psychédélique dans les années 70 — des décennies en avance.",
       "uri_apple_music": "applemusic://track/1049532476",
       "uri_youtube_music": "https://music.youtube.com/watch?v=jmb3INqJq_Y",
       "uri_tidal": "tidal://track/652183",
       "fun_fact_nl": "Las Grecas waren twee Romaanse zussen uit Madrid die in de jaren 70 flamenco versmolten met psychedelische rock - decennia hun tijd ver vooruit. Dit was een nummer 1 hit in Spanje.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "ES5117400004",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1049532476",
+        "de": "applemusic://track/1049532476",
+        "gb": "applemusic://track/1049532476",
+        "fr": "applemusic://track/1049532476",
+        "es": "applemusic://track/1049532476",
+        "nl": "applemusic://track/1049532476",
+        "it": "applemusic://track/1049532476"
+      }
     },
     {
       "year": 1981,
       "uri": "spotify:track:59ZWNHCFaMoM1wOTlZ0E0k",
-      "artist": "Raffaella Carr\u00e0",
+      "artist": "Raffaella Carrà",
       "alt_artists": [
         "Al Bano And Romina Power",
         "Ricchi e Poveri",
@@ -585,14 +785,24 @@
       "certifications": [],
       "awards": [],
       "fun_fact": "Italian queen of European pop TV who became a cultural icon in Spain. Her songs and dance moves defined an era of television entertainment across Southern Europe.",
-      "fun_fact_de": "Italienische K\u00f6nigin des europ\u00e4ischen Pop-TV, die in Spanien zur Kulturikone wurde. Ihre Songs und T\u00e4nze pr\u00e4gten eine \u00c4ra der TV-Unterhaltung.",
-      "fun_fact_es": "Reina italiana de la TV pop europea que se convirti\u00f3 en icono cultural en Espa\u00f1a. Sus canciones y bailes definieron una era del entretenimiento televisivo.",
-      "fun_fact_fr": "Reine italienne de la TV pop europ\u00e9enne devenue ic\u00f4ne culturelle en Espagne. Ses chansons et danses ont d\u00e9fini une \u00e8re du divertissement t\u00e9l\u00e9vis\u00e9.",
+      "fun_fact_de": "Italienische Königin des europäischen Pop-TV, die in Spanien zur Kulturikone wurde. Ihre Songs und Tänze prägten eine Ära der TV-Unterhaltung.",
+      "fun_fact_es": "Reina italiana de la TV pop europea que se convirtió en icono cultural en España. Sus canciones y bailes definieron una era del entretenimiento televisivo.",
+      "fun_fact_fr": "Reine italienne de la TV pop européenne devenue icône culturelle en Espagne. Ses chansons et danses ont défini une ère du divertissement télévisé.",
       "uri_apple_music": "applemusic://track/714544662",
       "uri_youtube_music": "https://music.youtube.com/watch?v=l3FrBFhZg28",
       "uri_tidal": "tidal://track/3278048",
       "fun_fact_nl": "Italiaanse koningin van de Europese pop TV die een cultureel icoon werd in Spanje. Haar liedjes en dansbewegingen definieerden een tijdperk van televisie-entertainment in heel Zuid-Europa.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "ES5088100162",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1139910002",
+        "de": "applemusic://track/1139910002",
+        "gb": "applemusic://track/1139910002",
+        "fr": "applemusic://track/1139910002",
+        "es": "applemusic://track/1139910002",
+        "nl": "applemusic://track/1139910002",
+        "it": "applemusic://track/1139910002"
+      }
     },
     {
       "year": 1967,
@@ -600,11 +810,11 @@
       "artist": "Celia Cruz",
       "alt_artists": [
         "Tito Puente",
-        "Oscar D'Le\u00f3n",
+        "Oscar D'León",
         "La Lupe",
         "Compay Segundo"
       ],
-      "title": "Cuando Sal\u00ed De Cuba",
+      "title": "Cuando Salí De Cuba",
       "chart_info": {
         "billboard_peak": null,
         "uk_peak": null,
@@ -613,21 +823,31 @@
       "certifications": [],
       "awards": [],
       "fun_fact": "The 'Queen of Salsa' left Cuba in 1960 and never returned. This deeply personal song about exile became an anthem for the Cuban diaspora worldwide.",
-      "fun_fact_de": "Die 'K\u00f6nigin der Salsa' verlie\u00df Kuba 1960 und kehrte nie zur\u00fcck. Dieser zutiefst pers\u00f6nliche Song \u00fcber das Exil wurde zur Hymne der kubanischen Diaspora.",
-      "fun_fact_es": "La 'Reina de la Salsa' dej\u00f3 Cuba en 1960 y nunca volvi\u00f3. Esta canci\u00f3n profundamente personal sobre el exilio se convirti\u00f3 en himno de la di\u00e1spora cubana.",
-      "fun_fact_fr": "La 'Reine de la Salsa' a quitt\u00e9 Cuba en 1960 sans jamais y retourner. Cette chanson sur l'exil est devenue l'hymne de la diaspora cubaine.",
+      "fun_fact_de": "Die 'Königin der Salsa' verließ Kuba 1960 und kehrte nie zurück. Dieser zutiefst persönliche Song über das Exil wurde zur Hymne der kubanischen Diaspora.",
+      "fun_fact_es": "La 'Reina de la Salsa' dejó Cuba en 1960 y nunca volvió. Esta canción profundamente personal sobre el exilio se convirtió en himno de la diáspora cubana.",
+      "fun_fact_fr": "La 'Reine de la Salsa' a quitté Cuba en 1960 sans jamais y retourner. Cette chanson sur l'exil est devenue l'hymne de la diaspora cubaine.",
       "uri_apple_music": "applemusic://track/1464290953",
       "uri_youtube_music": "https://music.youtube.com/watch?v=usJVkRpLTvM",
       "uri_tidal": "tidal://track/110223084",
       "fun_fact_nl": "De 'Koningin van de Salsa' verliet Cuba in 1960 en keerde nooit meer terug. Dit diep persoonlijke lied over ballingschap werd een hymne voor de Cubaanse diaspora wereldwijd.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USDBB0600696",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1712210818",
+        "de": "applemusic://track/1712210818",
+        "gb": "applemusic://track/1712210818",
+        "fr": "applemusic://track/1712210818",
+        "es": "applemusic://track/1712210818",
+        "nl": "applemusic://track/1712210818",
+        "it": "applemusic://track/1712210818"
+      }
     },
     {
       "year": 1947,
       "uri": "spotify:track:1JG27QjSUOvSnwkjqhTXMi",
-      "artist": "Antonio Mach\u00edn",
+      "artist": "Antonio Machín",
       "alt_artists": [
-        "Beny Mor\u00e9",
+        "Beny Moré",
         "Compay Segundo",
         "Nat King Cole"
       ],
@@ -639,23 +859,33 @@
       },
       "certifications": [],
       "awards": [],
-      "fun_fact": "Cuban-born Mach\u00edn settled in Spain in 1939 and became one of the most popular singers in the country. 'Toda una Vida' remains one of the most-played boleros at Spanish celebrations.",
-      "fun_fact_de": "Der auf Kuba geborene Mach\u00edn lie\u00df sich 1939 in Spanien nieder und wurde einer der beliebtesten S\u00e4nger des Landes.",
-      "fun_fact_es": "Mach\u00edn, nacido en Cuba, se estableci\u00f3 en Espa\u00f1a en 1939 y se convirti\u00f3 en uno de los cantantes m\u00e1s populares del pa\u00eds.",
-      "fun_fact_fr": "N\u00e9 \u00e0 Cuba, Mach\u00edn s'est install\u00e9 en Espagne en 1939 et est devenu l'un des chanteurs les plus populaires du pays.",
+      "fun_fact": "Cuban-born Machín settled in Spain in 1939 and became one of the most popular singers in the country. 'Toda una Vida' remains one of the most-played boleros at Spanish celebrations.",
+      "fun_fact_de": "Der auf Kuba geborene Machín ließ sich 1939 in Spanien nieder und wurde einer der beliebtesten Sänger des Landes.",
+      "fun_fact_es": "Machín, nacido en Cuba, se estableció en España en 1939 y se convirtió en uno de los cantantes más populares del país.",
+      "fun_fact_fr": "Né à Cuba, Machín s'est installé en Espagne en 1939 et est devenu l'un des chanteurs les plus populaires du pays.",
       "uri_apple_music": "applemusic://track/950732841",
       "uri_youtube_music": "https://music.youtube.com/watch?v=isKqhA76QTk",
       "uri_tidal": "tidal://track/207189021",
-      "fun_fact_nl": "De in Cuba geboren Mach\u00edn vestigde zich in 1939 in Spanje en werd een van de populairste zangers van het land. 'Toda una Vida' blijft een van de meest gespeelde bolero's op Spaanse feesten.",
-      "awards_nl": []
+      "fun_fact_nl": "De in Cuba geboren Machín vestigde zich in 1939 in Spanje en werd een van de populairste zangers van het land. 'Toda una Vida' blijft een van de meest gespeelde bolero's op Spaanse feesten.",
+      "awards_nl": [],
+      "isrc": "QM6MZ1422219",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/950732841",
+        "de": "applemusic://track/950732841",
+        "gb": "applemusic://track/950732841",
+        "fr": "applemusic://track/950732841",
+        "es": "applemusic://track/950732841",
+        "nl": "applemusic://track/950732841",
+        "it": "applemusic://track/950732841"
+      }
     },
     {
       "year": 1953,
       "uri": "spotify:track:5iCaLR191eAHNxxlfKzK9f",
-      "artist": "Beny Mor\u00e9",
+      "artist": "Beny Moré",
       "alt_artists": [
         "Compay Segundo",
-        "Antonio Mach\u00edn",
+        "Antonio Machín",
         "Celia Cruz",
         "Tito Puente"
       ],
@@ -667,26 +897,36 @@
       },
       "certifications": [],
       "awards": [],
-      "fun_fact": "Known as 'El B\u00e1rbaro del Ritmo', Beny Mor\u00e9 is considered the greatest Cuban musician of all time. He never learned to read music but could conduct a full orchestra by ear.",
-      "fun_fact_de": "Bekannt als 'El B\u00e1rbaro del Ritmo', gilt Beny Mor\u00e9 als gr\u00f6\u00dfter kubanischer Musiker aller Zeiten. Er konnte keine Noten lesen, dirigierte aber ein ganzes Orchester nach Geh\u00f6r.",
-      "fun_fact_es": "Conocido como 'El B\u00e1rbaro del Ritmo', Beny Mor\u00e9 es considerado el mayor m\u00fasico cubano de la historia. Nunca aprendi\u00f3 a leer m\u00fasica pero dirig\u00eda una orquesta completa de o\u00eddo.",
-      "fun_fact_fr": "Surnomm\u00e9 'El B\u00e1rbaro del Ritmo', Beny Mor\u00e9 est consid\u00e9r\u00e9 comme le plus grand musicien cubain. Il n'a jamais appris \u00e0 lire la musique mais dirigeait un orchestre entier \u00e0 l'oreille.",
+      "fun_fact": "Known as 'El Bárbaro del Ritmo', Beny Moré is considered the greatest Cuban musician of all time. He never learned to read music but could conduct a full orchestra by ear.",
+      "fun_fact_de": "Bekannt als 'El Bárbaro del Ritmo', gilt Beny Moré als größter kubanischer Musiker aller Zeiten. Er konnte keine Noten lesen, dirigierte aber ein ganzes Orchester nach Gehör.",
+      "fun_fact_es": "Conocido como 'El Bárbaro del Ritmo', Beny Moré es considerado el mayor músico cubano de la historia. Nunca aprendió a leer música pero dirigía una orquesta completa de oído.",
+      "fun_fact_fr": "Surnommé 'El Bárbaro del Ritmo', Beny Moré est considéré comme le plus grand musicien cubain. Il n'a jamais appris à lire la musique mais dirigeait un orchestre entier à l'oreille.",
       "uri_apple_music": "applemusic://track/288069714",
       "uri_youtube_music": "https://music.youtube.com/watch?v=HhX5D50Ixqg",
       "uri_tidal": "tidal://track/61597550",
-      "fun_fact_nl": "Beny Mor\u00e9, bekend als 'El B\u00e1rbaro del Ritmo', wordt beschouwd als de grootste Cubaanse muzikant aller tijden. Hij leerde nooit muziek lezen, maar kon een volledig orkest op het gehoor dirigeren.",
-      "awards_nl": []
+      "fun_fact_nl": "Beny Moré, bekend als 'El Bárbaro del Ritmo', wordt beschouwd als de grootste Cubaanse muzikant aller tijden. Hij leerde nooit muziek lezen, maar kon een volledig orkest op het gehoor dirigeren.",
+      "awards_nl": [],
+      "isrc": "USLGD0810034",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/288069714",
+        "de": "applemusic://track/288069714",
+        "gb": "applemusic://track/288069714",
+        "fr": "applemusic://track/288069714",
+        "es": "applemusic://track/288069714",
+        "nl": "applemusic://track/288069714",
+        "it": "applemusic://track/288069714"
+      }
     },
     {
       "year": 1982,
       "uri": "spotify:track:7pIfwKV8EOPmJlConSHk2E",
-      "artist": "Mar\u00eda Jim\u00e9nez",
+      "artist": "María Jiménez",
       "alt_artists": [
-        "Roc\u00edo Jurado",
+        "Rocío Jurado",
         "Lola Flores",
         "Isabel Pantoja"
       ],
-      "title": "Se acab\u00f3",
+      "title": "Se acabó",
       "chart_info": {
         "billboard_peak": null,
         "uk_peak": null,
@@ -694,27 +934,37 @@
       },
       "certifications": [],
       "awards": [],
-      "fun_fact": "Mar\u00eda Jim\u00e9nez was one of Spain's most passionate copla and pop singers, known for her powerful voice and dramatic stage presence rivaling Roc\u00edo Jurado.",
-      "fun_fact_de": "Mar\u00eda Jim\u00e9nez war eine der leidenschaftlichsten Copla- und Pop-S\u00e4ngerinnen Spaniens mit einer dramatischen B\u00fchnenpr\u00e4senz.",
-      "fun_fact_es": "Mar\u00eda Jim\u00e9nez fue una de las cantantes de copla y pop m\u00e1s apasionadas de Espa\u00f1a, con una presencia esc\u00e9nica dram\u00e1tica.",
-      "fun_fact_fr": "Mar\u00eda Jim\u00e9nez fut l'une des chanteuses de copla et pop les plus passionn\u00e9es d'Espagne, avec une pr\u00e9sence sc\u00e9nique dramatique.",
+      "fun_fact": "María Jiménez was one of Spain's most passionate copla and pop singers, known for her powerful voice and dramatic stage presence rivaling Rocío Jurado.",
+      "fun_fact_de": "María Jiménez war eine der leidenschaftlichsten Copla- und Pop-Sängerinnen Spaniens mit einer dramatischen Bühnenpräsenz.",
+      "fun_fact_es": "María Jiménez fue una de las cantantes de copla y pop más apasionadas de España, con una presencia escénica dramática.",
+      "fun_fact_fr": "María Jiménez fut l'une des chanteuses de copla et pop les plus passionnées d'Espagne, avec une présence scénique dramatique.",
       "uri_apple_music": "applemusic://track/154692713",
       "uri_youtube_music": "https://music.youtube.com/watch?v=4H-HdXzZgOA",
       "uri_tidal": "tidal://track/35613298",
-      "fun_fact_nl": "Mar\u00eda Jim\u00e9nez was een van de meest gepassioneerde copla- en popzangeressen van Spanje, bekend om haar krachtige stem en dramatische aanwezigheid op het podium, vergelijkbaar met Roc\u00edo Jurado.",
-      "awards_nl": []
+      "fun_fact_nl": "María Jiménez was een van de meest gepassioneerde copla- en popzangeressen van Spanje, bekend om haar krachtige stem en dramatische aanwezigheid op het podium, vergelijkbaar met Rocío Jurado.",
+      "awards_nl": [],
+      "isrc": "ES5079100127",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/874164902",
+        "de": "applemusic://track/874164902",
+        "gb": "applemusic://track/874164902",
+        "fr": "applemusic://track/874164902",
+        "es": "applemusic://track/874164902",
+        "nl": "applemusic://track/874164902",
+        "it": "applemusic://track/874164902"
+      }
     },
     {
       "year": 1977,
       "uri": "spotify:track:6nO69NbcCDLdSrVuml0Vb4",
-      "artist": "Miguel Bos\u00e9",
+      "artist": "Miguel Bosé",
       "alt_artists": [
         "Raphael",
         "Julio Iglesias",
         "Camilo Sesto",
         "Nino Bravo"
       ],
-      "title": "S\u00faper Superm\u00e1n",
+      "title": "Súper Supermán",
       "chart_info": {
         "billboard_peak": null,
         "uk_peak": null,
@@ -722,25 +972,35 @@
       },
       "certifications": [],
       "awards": [],
-      "fun_fact": "Son of bullfighter Luis Miguel Domingu\u00edn and Italian actress Lucia Bos\u00e8. Miguel Bos\u00e9 transcended Spanish pop to become a bilingual icon across Latin America and Europe.",
-      "fun_fact_de": "Sohn des Stierk\u00e4mpfers Luis Miguel Domingu\u00edn und der italienischen Schauspielerin Lucia Bos\u00e8. Wurde zum zweisprachigen Pop-Icon in Lateinamerika und Europa.",
-      "fun_fact_es": "Hijo del torero Luis Miguel Domingu\u00edn y la actriz italiana Lucia Bos\u00e8. Trascendi\u00f3 el pop espa\u00f1ol para convertirse en icono biling\u00fce en Latinoam\u00e9rica y Europa.",
-      "fun_fact_fr": "Fils du torero Luis Miguel Domingu\u00edn et de l'actrice italienne Lucia Bos\u00e8. A transcend\u00e9 la pop espagnole pour devenir une ic\u00f4ne bilingue en Am\u00e9rique latine et Europe.",
+      "fun_fact": "Son of bullfighter Luis Miguel Dominguín and Italian actress Lucia Bosè. Miguel Bosé transcended Spanish pop to become a bilingual icon across Latin America and Europe.",
+      "fun_fact_de": "Sohn des Stierkämpfers Luis Miguel Dominguín und der italienischen Schauspielerin Lucia Bosè. Wurde zum zweisprachigen Pop-Icon in Lateinamerika und Europa.",
+      "fun_fact_es": "Hijo del torero Luis Miguel Dominguín y la actriz italiana Lucia Bosè. Trascendió el pop español para convertirse en icono bilingüe en Latinoamérica y Europa.",
+      "fun_fact_fr": "Fils du torero Luis Miguel Dominguín et de l'actrice italienne Lucia Bosè. A transcendé la pop espagnole pour devenir une icône bilingue en Amérique latine et Europe.",
       "uri_apple_music": "applemusic://track/281268432",
       "uri_youtube_music": "https://music.youtube.com/watch?v=PJ92wvhp8y0",
       "uri_tidal": "tidal://track/1839746",
-      "fun_fact_nl": "Zoon van stierenvechter Luis Miguel Domingu\u00edn en de Italiaanse actrice Lucia Bos\u00e8. Miguel Bos\u00e9 oversteeg de Spaanse pop en werd een tweetalig icoon in heel Latijns-Amerika en Europa.",
-      "awards_nl": []
+      "fun_fact_nl": "Zoon van stierenvechter Luis Miguel Dominguín en de Italiaanse actrice Lucia Bosè. Miguel Bosé oversteeg de Spaanse pop en werd een tweetalig icoon in heel Latijns-Amerika en Europa.",
+      "awards_nl": [],
+      "isrc": "ES5119200046",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/279847406",
+        "de": "applemusic://track/654758721",
+        "gb": "applemusic://track/654758721",
+        "fr": "applemusic://track/654758721",
+        "es": "applemusic://track/555735457",
+        "nl": "applemusic://track/654758721",
+        "it": "applemusic://track/654758721"
+      }
     },
     {
       "year": 1981,
       "uri": "spotify:track:5BtNKZScq7gRDbcJ2FhIQb",
       "artist": "Julio Iglesias",
       "alt_artists": [
-        "Miguel Bos\u00e9",
+        "Miguel Bosé",
         "Camilo Sesto",
         "Raphael",
-        "Jos\u00e9 Luis Perales"
+        "José Luis Perales"
       ],
       "title": "Hey",
       "chart_info": {
@@ -751,14 +1011,24 @@
       "certifications": [],
       "awards": [],
       "fun_fact": "Julio Iglesias holds a Guinness World Record as the best-selling Latin artist of all time with 300+ million records sold. He was also a professional footballer for Real Madrid's youth team before a car crash changed his path.",
-      "fun_fact_de": "Julio Iglesias h\u00e4lt den Guinness-Rekord als meistverkaufter Latin-K\u00fcnstler mit \u00fcber 300 Millionen Platten. Zuvor spielte er in Real Madrids Jugend.",
-      "fun_fact_es": "Julio Iglesias tiene el r\u00e9cord Guinness como artista latino m\u00e1s vendido con m\u00e1s de 300 millones de discos. Antes jug\u00f3 en la cantera del Real Madrid.",
-      "fun_fact_fr": "Julio Iglesias d\u00e9tient le record Guinness d'artiste latin le plus vendu avec 300+ millions de disques. Il jouait au Real Madrid avant un accident.",
+      "fun_fact_de": "Julio Iglesias hält den Guinness-Rekord als meistverkaufter Latin-Künstler mit über 300 Millionen Platten. Zuvor spielte er in Real Madrids Jugend.",
+      "fun_fact_es": "Julio Iglesias tiene el récord Guinness como artista latino más vendido con más de 300 millones de discos. Antes jugó en la cantera del Real Madrid.",
+      "fun_fact_fr": "Julio Iglesias détient le record Guinness d'artiste latin le plus vendu avec 300+ millions de disques. Il jouait au Real Madrid avant un accident.",
       "uri_apple_music": "applemusic://track/250996960",
       "uri_youtube_music": "https://music.youtube.com/watch?v=F2vT9VyXOks",
       "uri_tidal": "tidal://track/26905983",
       "fun_fact_nl": "Julio Iglesias heeft een Guinness World Record als best verkopende Latin-artiest aller tijden met meer dan 300 miljoen verkochte platen. Hij was ook profvoetballer voor het jeugdteam van Real Madrid voordat een auto-ongeluk zijn leven veranderde.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "NLB639999990",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/250996960",
+        "de": "applemusic://track/250996960",
+        "gb": "applemusic://track/250996960",
+        "fr": "applemusic://track/250996960",
+        "es": "applemusic://track/250996960",
+        "nl": "applemusic://track/250996960",
+        "it": "applemusic://track/250996960"
+      }
     },
     {
       "year": 1986,
@@ -779,14 +1049,24 @@
       "certifications": [],
       "awards": [],
       "fun_fact": "Hombres G were Spain's answer to the British new wave movement. Led by David Summers (son of a famous guitarist), they filled stadiums with their catchy pop-rock and humorous lyrics.",
-      "fun_fact_de": "Hombres G waren Spaniens Antwort auf die britische New-Wave-Bewegung. Mit ihrem eing\u00e4ngigen Pop-Rock und humorvollen Texten f\u00fcllten sie Stadien.",
-      "fun_fact_es": "Hombres G fueron la respuesta espa\u00f1ola al movimiento new wave brit\u00e1nico. Con su pop-rock pegadizo y letras humor\u00edsticas llenaron estadios.",
-      "fun_fact_fr": "Hombres G furent la r\u00e9ponse espagnole au mouvement new wave britannique, remplissant les stades avec leur pop-rock accrocheur.",
+      "fun_fact_de": "Hombres G waren Spaniens Antwort auf die britische New-Wave-Bewegung. Mit ihrem eingängigen Pop-Rock und humorvollen Texten füllten sie Stadien.",
+      "fun_fact_es": "Hombres G fueron la respuesta española al movimiento new wave británico. Con su pop-rock pegadizo y letras humorísticas llenaron estadios.",
+      "fun_fact_fr": "Hombres G furent la réponse espagnole au mouvement new wave britannique, remplissant les stades avec leur pop-rock accrocheur.",
       "uri_apple_music": "applemusic://track/42231524",
       "uri_youtube_music": "https://music.youtube.com/watch?v=ET8Atukjvzk",
       "uri_tidal": "tidal://track/323686",
       "fun_fact_nl": "Hombres G waren het antwoord van Spanje op de Britse new wave-beweging. Onder leiding van David Summers (zoon van een beroemde gitarist) vulden ze stadions met hun aanstekelijke pop-rock en humoristische teksten.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "ES5018672006",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/131367922",
+        "de": "applemusic://track/131367922",
+        "gb": "applemusic://track/131367922",
+        "fr": "applemusic://track/131367922",
+        "es": "applemusic://track/131367922",
+        "nl": "applemusic://track/131367922",
+        "it": "applemusic://track/131367922"
+      }
     },
     {
       "year": 2012,
@@ -795,7 +1075,7 @@
       "alt_artists": [
         "Aitana",
         "Zahara",
-        "Rozal\u00e9n",
+        "Rozalén",
         "La Bien Querida"
       ],
       "title": "Puede Ser",
@@ -808,18 +1088,28 @@
       "awards": [],
       "fun_fact": "Conchita (from OT 2007) crafted a unique indie-pop sound distinct from typical OT alumni, earning critical acclaim and a loyal cult following in Spain.",
       "fun_fact_de": "Conchita (von OT 2007) schuf einen einzigartigen Indie-Pop-Sound, der sich von typischen OT-Absolventen abhob.",
-      "fun_fact_es": "Conchita (de OT 2007) cre\u00f3 un sonido indie-pop \u00fanico diferente de los t\u00edpicos ex OT, gan\u00e1ndose una fiel base de seguidores.",
-      "fun_fact_fr": "Conchita (d'OT 2007) a cr\u00e9\u00e9 un son indie-pop unique, se d\u00e9marquant des anciens d'OT typiques.",
+      "fun_fact_es": "Conchita (de OT 2007) creó un sonido indie-pop único diferente de los típicos ex OT, ganándose una fiel base de seguidores.",
+      "fun_fact_fr": "Conchita (d'OT 2007) a créé un son indie-pop unique, se démarquant des anciens d'OT typiques.",
       "uri_apple_music": "applemusic://track/1523866781",
       "uri_youtube_music": "https://music.youtube.com/watch?v=SoDgagIYxC0",
       "uri_tidal": "tidal://track/417266330",
-      "fun_fact_nl": "Conchita (uit OT 2007) heeft een unieke indie-pop sound gecre\u00eberd die verschilt van de typische OT-alumni. Ze kreeg lovende kritieken en een trouwe schare fans in Spanje.",
-      "awards_nl": []
+      "fun_fact_nl": "Conchita (uit OT 2007) heeft een unieke indie-pop sound gecreëerd die verschilt van de typische OT-alumni. Ze kreeg lovende kritieken en een trouwe schare fans in Spanje.",
+      "awards_nl": [],
+      "isrc": "ES5080600903",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1523866781",
+        "de": "applemusic://track/1523866781",
+        "gb": "applemusic://track/1523866781",
+        "fr": "applemusic://track/1523866781",
+        "es": "applemusic://track/1523866781",
+        "nl": "applemusic://track/1523866781",
+        "it": "applemusic://track/1523866781"
+      }
     },
     {
       "year": 1989,
       "uri": "spotify:track:0WFatRyMXS4JVP9jSfO1Fe",
-      "artist": "Jos\u00e9 Luis Perales",
+      "artist": "José Luis Perales",
       "alt_artists": [
         "Julio Iglesias",
         "Camilo Sesto",
@@ -834,15 +1124,25 @@
       },
       "certifications": [],
       "awards": [],
-      "fun_fact": "One of Spain's most prolific songwriters with 700+ compositions. Perales wrote hits for Julio Iglesias and Roc\u00edo D\u00farcal while maintaining his own hugely successful career.",
-      "fun_fact_de": "Einer der produktivsten Songwriter Spaniens mit \u00fcber 700 Kompositionen. Schrieb Hits f\u00fcr Julio Iglesias und Roc\u00edo D\u00farcal.",
-      "fun_fact_es": "Uno de los compositores m\u00e1s prol\u00edficos de Espa\u00f1a con m\u00e1s de 700 composiciones. Escribi\u00f3 \u00e9xitos para Julio Iglesias y Roc\u00edo D\u00farcal.",
-      "fun_fact_fr": "L'un des compositeurs les plus prolifiques d'Espagne avec 700+ compositions. A \u00e9crit des tubes pour Julio Iglesias et Roc\u00edo D\u00farcal.",
+      "fun_fact": "One of Spain's most prolific songwriters with 700+ compositions. Perales wrote hits for Julio Iglesias and Rocío Dúrcal while maintaining his own hugely successful career.",
+      "fun_fact_de": "Einer der produktivsten Songwriter Spaniens mit über 700 Kompositionen. Schrieb Hits für Julio Iglesias und Rocío Dúrcal.",
+      "fun_fact_es": "Uno de los compositores más prolíficos de España con más de 700 composiciones. Escribió éxitos para Julio Iglesias y Rocío Dúrcal.",
+      "fun_fact_fr": "L'un des compositeurs les plus prolifiques d'Espagne avec 700+ compositions. A écrit des tubes pour Julio Iglesias et Rocío Dúrcal.",
       "uri_apple_music": "applemusic://track/1259333866",
       "uri_youtube_music": "https://music.youtube.com/watch?v=HThwascSkzA",
       "uri_tidal": "tidal://track/63615562",
-      "fun_fact_nl": "Een van Spanjes meest productieve songwriters met meer dan 700 composities. Perales schreef hits voor Julio Iglesias en Roc\u00edo D\u00farcal terwijl hij zijn eigen enorm succesvolle carri\u00e8re in stand hield.",
-      "awards_nl": []
+      "fun_fact_nl": "Een van Spanjes meest productieve songwriters met meer dan 700 composities. Perales schreef hits voor Julio Iglesias en Rocío Dúrcal terwijl hij zijn eigen enorm succesvolle carrière in stand hield.",
+      "awards_nl": [],
+      "isrc": "ES5099800387",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1784911935",
+        "de": "applemusic://track/1855854434",
+        "gb": "applemusic://track/1784911935",
+        "fr": "applemusic://track/1784911935",
+        "es": "applemusic://track/1784911935",
+        "nl": "applemusic://track/1784911935",
+        "it": "applemusic://track/1784911935"
+      }
     },
     {
       "year": 1984,
@@ -854,7 +1154,7 @@
         "Gabinete Caligari",
         "Nacha Pop"
       ],
-      "title": "Malos Tiempos para la L\u00edrica",
+      "title": "Malos Tiempos para la Lírica",
       "chart_info": {
         "billboard_peak": null,
         "uk_peak": null,
@@ -862,15 +1162,25 @@
       },
       "certifications": [],
       "awards": [],
-      "fun_fact": "One of the defining songs of 'La Movida Madrile\u00f1a', Spain's explosive cultural movement after Franco's death. Golpes Bajos from Vigo brought Galician art-rock to the national stage.",
-      "fun_fact_de": "Einer der pr\u00e4genden Songs der 'Movida Madrile\u00f1a', Spaniens explosiver Kulturbewegung nach Francos Tod.",
-      "fun_fact_es": "Una de las canciones definitorias de La Movida Madrile\u00f1a, el explosivo movimiento cultural espa\u00f1ol tras la muerte de Franco.",
-      "fun_fact_fr": "L'une des chansons phares de 'La Movida Madrile\u00f1a', le mouvement culturel explosif espagnol apr\u00e8s la mort de Franco.",
+      "fun_fact": "One of the defining songs of 'La Movida Madrileña', Spain's explosive cultural movement after Franco's death. Golpes Bajos from Vigo brought Galician art-rock to the national stage.",
+      "fun_fact_de": "Einer der prägenden Songs der 'Movida Madrileña', Spaniens explosiver Kulturbewegung nach Francos Tod.",
+      "fun_fact_es": "Una de las canciones definitorias de La Movida Madrileña, el explosivo movimiento cultural español tras la muerte de Franco.",
+      "fun_fact_fr": "L'une des chansons phares de 'La Movida Madrileña', le mouvement culturel explosif espagnol après la mort de Franco.",
       "uri_apple_music": "applemusic://track/873529482",
       "uri_youtube_music": "https://music.youtube.com/watch?v=xAYUO0QeqUk",
       "uri_tidal": "tidal://track/29385967",
-      "fun_fact_nl": "Een van de bepalende nummers van 'La Movida Madrile\u00f1a', de explosieve culturele beweging in Spanje na de dood van Franco. Golpes Bajos uit Vigo bracht Galicische art-rock naar het nationale podium.",
-      "awards_nl": []
+      "fun_fact_nl": "Een van de bepalende nummers van 'La Movida Madrileña', de explosieve culturele beweging in Spanje na de dood van Franco. Golpes Bajos uit Vigo bracht Galicische art-rock naar het nationale podium.",
+      "awards_nl": [],
+      "isrc": "ES5120100502",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/873529482",
+        "de": "applemusic://track/873529482",
+        "gb": "applemusic://track/873529482",
+        "fr": "applemusic://track/873529482",
+        "es": "applemusic://track/873529482",
+        "nl": "applemusic://track/873529482",
+        "it": "applemusic://track/873529482"
+      }
     },
     {
       "year": 2004,
@@ -879,10 +1189,10 @@
       "alt_artists": [
         "Rosana",
         "Luz Casal",
-        "Mal\u00fa",
+        "Malú",
         "Bebe"
       ],
-      "title": "Siempre me quedar\u00e1",
+      "title": "Siempre me quedará",
       "chart_info": {
         "billboard_peak": null,
         "uk_peak": null,
@@ -890,15 +1200,25 @@
       },
       "certifications": [],
       "awards": [],
-      "fun_fact": "Bebe (Mar\u00eda Nieves Rebolledo) from Extremadura won a Latin Grammy for this track. Her raw, raspy voice and socially conscious lyrics made her a voice of her generation.",
-      "fun_fact_de": "Bebe aus Extremadura gewann einen Latin Grammy f\u00fcr diesen Track. Ihre raue Stimme und sozialkritischen Texte machten sie zur Stimme ihrer Generation.",
-      "fun_fact_es": "Bebe, de Extremadura, gan\u00f3 un Latin Grammy por este tema. Su voz rasgada y letras de conciencia social la convirtieron en voz de su generaci\u00f3n.",
-      "fun_fact_fr": "Bebe, d'Estr\u00e9madure, a remport\u00e9 un Latin Grammy pour ce titre. Sa voix rauque et ses textes engag\u00e9s en ont fait la voix de sa g\u00e9n\u00e9ration.",
+      "fun_fact": "Bebe (María Nieves Rebolledo) from Extremadura won a Latin Grammy for this track. Her raw, raspy voice and socially conscious lyrics made her a voice of her generation.",
+      "fun_fact_de": "Bebe aus Extremadura gewann einen Latin Grammy für diesen Track. Ihre raue Stimme und sozialkritischen Texte machten sie zur Stimme ihrer Generation.",
+      "fun_fact_es": "Bebe, de Extremadura, ganó un Latin Grammy por este tema. Su voz rasgada y letras de conciencia social la convirtieron en voz de su generación.",
+      "fun_fact_fr": "Bebe, d'Estrémadure, a remporté un Latin Grammy pour ce titre. Sa voix rauque et ses textes engagés en ont fait la voix de sa génération.",
       "uri_apple_music": "applemusic://track/696023777",
       "uri_youtube_music": "https://music.youtube.com/watch?v=QsjAgjbMVWA",
       "uri_tidal": "tidal://track/147679",
-      "fun_fact_nl": "Bebe (Mar\u00eda Nieves Rebolledo) uit Extremadura won een Latin Grammy voor dit nummer. Haar rauwe, schorre stem en sociaal bewuste teksten maakten haar tot een stem van haar generatie.",
-      "awards_nl": []
+      "fun_fact_nl": "Bebe (María Nieves Rebolledo) uit Extremadura won een Latin Grammy voor dit nummer. Haar rauwe, schorre stem en sociaal bewuste teksten maakten haar tot een stem van haar generatie.",
+      "awards_nl": [],
+      "isrc": "ES5030400004",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1837698661",
+        "de": "applemusic://track/1837698661",
+        "gb": "applemusic://track/1837698661",
+        "fr": "applemusic://track/1837698661",
+        "es": "applemusic://track/1837698661",
+        "nl": "applemusic://track/1837698661",
+        "it": "applemusic://track/1837698661"
+      }
     },
     {
       "year": 2015,
@@ -919,19 +1239,29 @@
       "certifications": [],
       "awards": [],
       "fun_fact": "Panamanian reggaeton artist whose 'Picky' became an inescapable summer hit across Latin America and Spain, with a dance challenge that went viral before TikTok existed.",
-      "fun_fact_de": "Panamaischer Reggaeton-K\u00fcnstler, dessen 'Picky' zum unausweichlichen Sommerhit in Lateinamerika und Spanien wurde.",
-      "fun_fact_es": "Artista paname\u00f1o de reggaeton cuyo 'Picky' se convirti\u00f3 en hit veraniego inevitable en Latinoam\u00e9rica y Espa\u00f1a.",
-      "fun_fact_fr": "Artiste panam\u00e9en de reggaeton dont 'Picky' est devenu un tube estival incontournable en Am\u00e9rique latine et Espagne.",
+      "fun_fact_de": "Panamaischer Reggaeton-Künstler, dessen 'Picky' zum unausweichlichen Sommerhit in Lateinamerika und Spanien wurde.",
+      "fun_fact_es": "Artista panameño de reggaeton cuyo 'Picky' se convirtió en hit veraniego inevitable en Latinoamérica y España.",
+      "fun_fact_fr": "Artiste panaméen de reggaeton dont 'Picky' est devenu un tube estival incontournable en Amérique latine et Espagne.",
       "uri_apple_music": "applemusic://track/1444616864",
       "uri_youtube_music": "https://music.youtube.com/watch?v=RqpKDkVzlqU",
       "uri_tidal": "tidal://track/46785817",
       "fun_fact_nl": "Panamese reggaetonartiest wiens 'Picky' een onontkoombare zomerhit werd in heel Latijns-Amerika en Spanje, met een dansuitdaging die viraal ging voordat TikTok bestond.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USUM71507789",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1708431097",
+        "de": "applemusic://track/1708431097",
+        "gb": "applemusic://track/1708431097",
+        "fr": "applemusic://track/1708431097",
+        "es": "applemusic://track/1708431097",
+        "nl": "applemusic://track/1708431097",
+        "it": "applemusic://track/1708431097"
+      }
     },
     {
       "year": 2022,
       "uri": "spotify:track:2FYGZDfsAnNsrm1gVbyKnG",
-      "artist": "ROSAL\u00cdA",
+      "artist": "ROSALÍA",
       "alt_artists": [
         "C. Tangana",
         "Bad Gyal",
@@ -946,22 +1276,32 @@
       },
       "certifications": [],
       "awards": [],
-      "fun_fact": "ROSAL\u00cdA from Barcelona revolutionized Spanish music by fusing flamenco with electronic and urban sounds. Her album 'Motomami' won Album of the Year at the 2023 Latin Grammys.",
-      "fun_fact_de": "ROSAL\u00cdA aus Barcelona revolutionierte die spanische Musik durch die Fusion von Flamenco mit elektronischen und urbanen Sounds.",
-      "fun_fact_es": "ROSAL\u00cdA de Barcelona revolucion\u00f3 la m\u00fasica espa\u00f1ola fusionando flamenco con sonidos electr\u00f3nicos y urbanos. 'Motomami' gan\u00f3 \u00c1lbum del A\u00f1o en los Latin Grammy 2023.",
-      "fun_fact_fr": "ROSAL\u00cdA de Barcelone a r\u00e9volutionn\u00e9 la musique espagnole en fusionnant flamenco et sons \u00e9lectroniques/urbains. 'Motomami' a gagn\u00e9 l'Album de l'Ann\u00e9e aux Latin Grammys 2023.",
+      "fun_fact": "ROSALÍA from Barcelona revolutionized Spanish music by fusing flamenco with electronic and urban sounds. Her album 'Motomami' won Album of the Year at the 2023 Latin Grammys.",
+      "fun_fact_de": "ROSALÍA aus Barcelona revolutionierte die spanische Musik durch die Fusion von Flamenco mit elektronischen und urbanen Sounds.",
+      "fun_fact_es": "ROSALÍA de Barcelona revolucionó la música española fusionando flamenco con sonidos electrónicos y urbanos. 'Motomami' ganó Álbum del Año en los Latin Grammy 2023.",
+      "fun_fact_fr": "ROSALÍA de Barcelone a révolutionné la musique espagnole en fusionnant flamenco et sons électroniques/urbains. 'Motomami' a gagné l'Album de l'Année aux Latin Grammys 2023.",
       "uri_apple_music": "applemusic://track/1654013499",
       "uri_youtube_music": "https://music.youtube.com/watch?v=ApNQX6fVWQ4",
       "uri_tidal": "tidal://track/220809480",
-      "fun_fact_nl": "ROSAL\u00cdA uit Barcelona zorgde voor een revolutie in de Spaanse muziek door flamenco te versmelten met elektronische en urban geluiden. Haar album 'Motomami' won Album van het Jaar bij de 2023 Latin Grammy's.",
-      "awards_nl": []
+      "fun_fact_nl": "ROSALÍA uit Barcelona zorgde voor een revolutie in de Spaanse muziek door flamenco te versmelten met elektronische en urban geluiden. Haar album 'Motomami' won Album van het Jaar bij de 2023 Latin Grammy's.",
+      "awards_nl": [],
+      "isrc": "ARA822200491",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1654013499",
+        "de": "applemusic://track/1654013499",
+        "gb": "applemusic://track/1654013499",
+        "fr": "applemusic://track/1654013499",
+        "es": "applemusic://track/1654013499",
+        "nl": "applemusic://track/1654013499",
+        "it": "applemusic://track/1654013499"
+      }
     },
     {
       "year": 2021,
       "uri": "spotify:track:42lpuSQmnLUM1ZXJVzIVOi",
       "artist": "Camilo",
       "alt_artists": [
-        "Sebasti\u00e1n Yatra",
+        "Sebastián Yatra",
         "Manuel Turizo",
         "Maluma",
         "Carlos Vives"
@@ -976,13 +1316,23 @@
       "awards": [],
       "fun_fact": "Colombian Camilo Echeverry went from 'Factor X' contestant to global star. Married to Evaluna Montaner (daughter of Ricardo Montaner), their love story drives much of his music.",
       "fun_fact_de": "Kolumbianer Camilo Echeverry wurde vom 'Factor X'-Teilnehmer zum Weltstar. Mit Evaluna Montaner verheiratet, inspiriert ihre Liebesgeschichte seine Musik.",
-      "fun_fact_es": "El colombiano Camilo Echeverry pas\u00f3 de concursante de 'Factor X' a estrella global. Casado con Evaluna Montaner, su historia de amor inspira su m\u00fasica.",
-      "fun_fact_fr": "Le Colombien Camilo Echeverry est pass\u00e9 de candidat de 'Factor X' \u00e0 star mondiale. Mari\u00e9 \u00e0 Evaluna Montaner, leur histoire d'amour inspire sa musique.",
+      "fun_fact_es": "El colombiano Camilo Echeverry pasó de concursante de 'Factor X' a estrella global. Casado con Evaluna Montaner, su historia de amor inspira su música.",
+      "fun_fact_fr": "Le Colombien Camilo Echeverry est passé de candidat de 'Factor X' à star mondiale. Marié à Evaluna Montaner, leur histoire d'amour inspire sa musique.",
       "uri_apple_music": "applemusic://track/1554206953",
       "uri_youtube_music": "https://music.youtube.com/watch?v=ZrUrwUwSHR0",
       "uri_tidal": "tidal://track/175456722",
       "fun_fact_nl": "De Colombiaan Camilo Echeverry ging van 'Factor X'-deelnemer naar wereldster. Getrouwd met Evaluna Montaner (dochter van Ricardo Montaner), is hun liefdesverhaal de drijfveer achter veel van zijn muziek.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSD12100050",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1554206953",
+        "de": "applemusic://track/1554206953",
+        "gb": "applemusic://track/1554206953",
+        "fr": "applemusic://track/1554206953",
+        "es": "applemusic://track/1554206953",
+        "nl": "applemusic://track/1554206953",
+        "it": "applemusic://track/1554206953"
+      }
     },
     {
       "year": 2022,
@@ -1002,15 +1352,25 @@
       },
       "certifications": [],
       "awards": [],
-      "fun_fact": "Lola Indigo (Mimi Doblas) finished second on OT 2017 but became arguably its biggest success \u2014 reinventing herself as Spain's leading urban-pop artist.",
-      "fun_fact_de": "Lola Indigo (Mimi Doblas) wurde Zweite bei OT 2017, aber wohl der gr\u00f6\u00dfte Erfolg der Staffel \u2014 als Spaniens f\u00fchrende Urban-Pop-K\u00fcnstlerin.",
-      "fun_fact_es": "Lola Indigo (Mimi Doblas) qued\u00f3 segunda en OT 2017 pero se convirti\u00f3 en su mayor \u00e9xito, reinvent\u00e1ndose como artista urban-pop l\u00edder de Espa\u00f1a.",
-      "fun_fact_fr": "Lola Indigo (Mimi Doblas), deuxi\u00e8me d'OT 2017, est devenue son plus grand succ\u00e8s en se r\u00e9inventant en artiste urban-pop leader d'Espagne.",
+      "fun_fact": "Lola Indigo (Mimi Doblas) finished second on OT 2017 but became arguably its biggest success — reinventing herself as Spain's leading urban-pop artist.",
+      "fun_fact_de": "Lola Indigo (Mimi Doblas) wurde Zweite bei OT 2017, aber wohl der größte Erfolg der Staffel — als Spaniens führende Urban-Pop-Künstlerin.",
+      "fun_fact_es": "Lola Indigo (Mimi Doblas) quedó segunda en OT 2017 pero se convirtió en su mayor éxito, reinventándose como artista urban-pop líder de España.",
+      "fun_fact_fr": "Lola Indigo (Mimi Doblas), deuxième d'OT 2017, est devenue son plus grand succès en se réinventant en artiste urban-pop leader d'Espagne.",
       "uri_apple_music": "applemusic://track/1732994567",
       "uri_youtube_music": "https://music.youtube.com/watch?v=QdCTs5HZfhU",
       "uri_tidal": "tidal://track/348323227",
       "fun_fact_nl": "Lola Indigo (Mimi Doblas) eindigde als tweede op OT 2017, maar werd misschien wel het grootste succes van OT 2017 - ze vond zichzelf opnieuw uit als de toonaangevende urban-popartieste van Spanje.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "ESUM72400225",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1746808718",
+        "de": "applemusic://track/1746808718",
+        "gb": "applemusic://track/1746808718",
+        "fr": "applemusic://track/1746808718",
+        "es": "applemusic://track/1746808718",
+        "nl": "applemusic://track/1746808718",
+        "it": "applemusic://track/1746808718"
+      }
     },
     {
       "year": 1975,
@@ -1018,9 +1378,9 @@
       "artist": "Luis Eduardo Aute",
       "alt_artists": [
         "Joan Manuel Serrat",
-        "Joaqu\u00edn Sabina",
+        "Joaquín Sabina",
         "Patxi Andion",
-        "Silvio Rodr\u00edguez"
+        "Silvio Rodríguez"
       ],
       "title": "Pasaba por Aqui",
       "chart_info": {
@@ -1030,27 +1390,37 @@
       },
       "certifications": [],
       "awards": [],
-      "fun_fact": "Aute was a Renaissance man \u2014 singer-songwriter, painter, sculptor, and filmmaker. He was one of Spain's most intellectual and poetic voices in popular music.",
-      "fun_fact_de": "Aute war ein Renaissancemensch \u2014 Liedermacher, Maler, Bildhauer und Filmemacher. Eine der intellektuellsten Stimmen der spanischen Musik.",
-      "fun_fact_es": "Aute fue un hombre del Renacimiento \u2014 cantautor, pintor, escultor y cineasta. Una de las voces m\u00e1s intelectuales y po\u00e9ticas de la m\u00fasica popular espa\u00f1ola.",
-      "fun_fact_fr": "Aute \u00e9tait un homme de la Renaissance \u2014 auteur-compositeur, peintre, sculpteur et cin\u00e9aste. L'une des voix les plus intellectuelles de la musique populaire espagnole.",
+      "fun_fact": "Aute was a Renaissance man — singer-songwriter, painter, sculptor, and filmmaker. He was one of Spain's most intellectual and poetic voices in popular music.",
+      "fun_fact_de": "Aute war ein Renaissancemensch — Liedermacher, Maler, Bildhauer und Filmemacher. Eine der intellektuellsten Stimmen der spanischen Musik.",
+      "fun_fact_es": "Aute fue un hombre del Renacimiento — cantautor, pintor, escultor y cineasta. Una de las voces más intelectuales y poéticas de la música popular española.",
+      "fun_fact_fr": "Aute était un homme de la Renaissance — auteur-compositeur, peintre, sculpteur et cinéaste. L'une des voix les plus intellectuelles de la musique populaire espagnole.",
       "uri_apple_music": "applemusic://track/286589993",
       "uri_youtube_music": "https://music.youtube.com/watch?v=7gMQdACCRl4",
       "uri_tidal": "tidal://track/2862037",
-      "fun_fact_nl": "Aute was een Renaissance man - singer-songwriter, schilder, beeldhouwer en filmmaker. Hij was een van Spanjes meest intellectuele en po\u00ebtische stemmen in de populaire muziek.",
-      "awards_nl": []
+      "fun_fact_nl": "Aute was een Renaissance man - singer-songwriter, schilder, beeldhouwer en filmmaker. Hij was een van Spanjes meest intellectuele en poëtische stemmen in de populaire muziek.",
+      "awards_nl": [],
+      "isrc": "ES7110300002",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/286589993",
+        "de": "applemusic://track/286589993",
+        "gb": "applemusic://track/286589993",
+        "fr": "applemusic://track/286589993",
+        "es": "applemusic://track/286589993",
+        "nl": "applemusic://track/286589993",
+        "it": "applemusic://track/286589993"
+      }
     },
     {
       "year": 1984,
       "uri": "spotify:track:7KcFlbQmzhVczGMor3Fhr9",
-      "artist": "Joaqu\u00edn Sabina",
+      "artist": "Joaquín Sabina",
       "alt_artists": [
         "Luis Eduardo Aute",
         "Joan Manuel Serrat",
         "Alejandro Sanz",
-        "Andr\u00e9s Calamaro"
+        "Andrés Calamaro"
       ],
-      "title": "Por el Bulevar de los Sue\u00f1os Rotos",
+      "title": "Por el Bulevar de los Sueños Rotos",
       "chart_info": {
         "billboard_peak": null,
         "uk_peak": null,
@@ -1058,15 +1428,25 @@
       },
       "certifications": [],
       "awards": [],
-      "fun_fact": "Spain's greatest living songwriter \u2014 a chain-smoking bohemian poet who lived in exile in London during the Franco era and whose lyrics are studied in Spanish literature courses.",
-      "fun_fact_de": "Spaniens gr\u00f6\u00dfter lebender Songwriter \u2014 ein kettenrauchender Boh\u00e8me-Poet, der w\u00e4hrend der Franco-\u00c4ra im Londoner Exil lebte.",
-      "fun_fact_es": "El mayor compositor vivo de Espa\u00f1a \u2014 poeta bohemio que vivi\u00f3 exiliado en Londres durante el franquismo y cuyas letras se estudian en clases de literatura.",
-      "fun_fact_fr": "Le plus grand auteur-compositeur vivant d'Espagne \u2014 po\u00e8te boh\u00e8me exil\u00e9 \u00e0 Londres sous Franco, dont les textes sont \u00e9tudi\u00e9s en litt\u00e9rature.",
+      "fun_fact": "Spain's greatest living songwriter — a chain-smoking bohemian poet who lived in exile in London during the Franco era and whose lyrics are studied in Spanish literature courses.",
+      "fun_fact_de": "Spaniens größter lebender Songwriter — ein kettenrauchender Bohème-Poet, der während der Franco-Ära im Londoner Exil lebte.",
+      "fun_fact_es": "El mayor compositor vivo de España — poeta bohemio que vivió exiliado en Londres durante el franquismo y cuyas letras se estudian en clases de literatura.",
+      "fun_fact_fr": "Le plus grand auteur-compositeur vivant d'Espagne — poète bohème exilé à Londres sous Franco, dont les textes sont étudiés en littérature.",
       "uri_apple_music": "applemusic://track/1478351808",
       "uri_youtube_music": "https://music.youtube.com/watch?v=fyWjmlMK8Qg",
       "uri_tidal": "tidal://track/30216368",
       "fun_fact_nl": "Spanje's grootste levende liedjesschrijver - een kettingrokende boheemse dichter die in ballingschap leefde in Londen tijdens het Franco-tijdperk en wiens teksten worden bestudeerd in Spaanse literatuurcursussen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "ES5029400325",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1478351808",
+        "de": "applemusic://track/1478351808",
+        "gb": "applemusic://track/1478351808",
+        "fr": "applemusic://track/1478351808",
+        "es": "applemusic://track/1478351808",
+        "nl": "applemusic://track/1478351808",
+        "it": "applemusic://track/1478351808"
+      }
     },
     {
       "year": 1988,
@@ -1074,11 +1454,11 @@
       "artist": "Maria Del Monte",
       "alt_artists": [
         "Isabel Pantoja",
-        "Roc\u00edo Jurado",
+        "Rocío Jurado",
         "Lola Flores",
         "Pastora Soler"
       ],
-      "title": "C\u00e1ntame",
+      "title": "Cántame",
       "chart_info": {
         "billboard_peak": null,
         "uk_peak": null,
@@ -1086,15 +1466,25 @@
       },
       "certifications": [],
       "awards": [],
-      "fun_fact": "Mar\u00eda del Monte shot to fame singing this at the 1988 Seville Spring Fair. She became one of Spain's most beloved sevillanas singers and a fixture of Andalusian culture.",
-      "fun_fact_de": "Mar\u00eda del Monte wurde 1988 auf der Feria de Sevilla ber\u00fchmt. Sie wurde zu einer der beliebtesten Sevillanas-S\u00e4ngerinnen Spaniens.",
-      "fun_fact_es": "Mar\u00eda del Monte salt\u00f3 a la fama cantando esto en la Feria de Abril de 1988. Se convirti\u00f3 en una de las cantantes de sevillanas m\u00e1s queridas de Espa\u00f1a.",
-      "fun_fact_fr": "Mar\u00eda del Monte est devenue c\u00e9l\u00e8bre en chantant ceci \u00e0 la Feria de S\u00e9ville 1988, devenant l'une des chanteuses de s\u00e9villanes les plus aim\u00e9es d'Espagne.",
+      "fun_fact": "María del Monte shot to fame singing this at the 1988 Seville Spring Fair. She became one of Spain's most beloved sevillanas singers and a fixture of Andalusian culture.",
+      "fun_fact_de": "María del Monte wurde 1988 auf der Feria de Sevilla berühmt. Sie wurde zu einer der beliebtesten Sevillanas-Sängerinnen Spaniens.",
+      "fun_fact_es": "María del Monte saltó a la fama cantando esto en la Feria de Abril de 1988. Se convirtió en una de las cantantes de sevillanas más queridas de España.",
+      "fun_fact_fr": "María del Monte est devenue célèbre en chantant ceci à la Feria de Séville 1988, devenant l'une des chanteuses de sévillanes les plus aimées d'Espagne.",
       "uri_apple_music": "applemusic://track/362776156",
       "uri_youtube_music": "https://music.youtube.com/watch?v=SMD-WzplZgE",
       "uri_tidal": "tidal://track/3675378",
-      "fun_fact_nl": "Mar\u00eda del Monte werd beroemd toen ze dit lied zong op de Sevilla Lentefair in 1988. Ze werd een van Spanjes meest geliefde sevillanas-zangeressen en een vaste waarde in de Andalusische cultuur.",
-      "awards_nl": []
+      "fun_fact_nl": "María del Monte werd beroemd toen ze dit lied zong op de Sevilla Lentefair in 1988. Ze werd een van Spanjes meest geliefde sevillanas-zangeressen en een vaste waarde in de Andalusische cultuur.",
+      "awards_nl": [],
+      "isrc": "ES5339901250",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/362776156",
+        "de": "applemusic://track/362776156",
+        "gb": "applemusic://track/362776156",
+        "fr": "applemusic://track/362776156",
+        "es": "applemusic://track/362776156",
+        "nl": "applemusic://track/362776156",
+        "it": "applemusic://track/362776156"
+      }
     },
     {
       "year": 1992,
@@ -1106,7 +1496,7 @@
         "Ricardo Montaner",
         "Cristian Castro"
       ],
-      "title": "Otro D\u00eda M\u00e1s Sin Verte",
+      "title": "Otro Día Más Sin Verte",
       "chart_info": {
         "billboard_peak": null,
         "uk_peak": null,
@@ -1115,14 +1505,24 @@
       "certifications": [],
       "awards": [],
       "fun_fact": "Cuban-American Jon Secada wrote and sang backing vocals for Gloria Estefan before launching a solo career. This Spanish version of 'Just Another Day' hit #1 in 30 countries.",
-      "fun_fact_de": "Der kubanisch-amerikanische Jon Secada schrieb f\u00fcr Gloria Estefan, bevor er solo durchstartete. Die spanische Version von 'Just Another Day' erreichte #1 in 30 L\u00e4ndern.",
-      "fun_fact_es": "El cubanoamericano Jon Secada escribi\u00f3 para Gloria Estefan antes de su carrera solista. La versi\u00f3n espa\u00f1ola de 'Just Another Day' lleg\u00f3 al #1 en 30 pa\u00edses.",
-      "fun_fact_fr": "Le Cubano-Am\u00e9ricain Jon Secada a \u00e9crit pour Gloria Estefan avant sa carri\u00e8re solo. La version espagnole de 'Just Another Day' a atteint le #1 dans 30 pays.",
+      "fun_fact_de": "Der kubanisch-amerikanische Jon Secada schrieb für Gloria Estefan, bevor er solo durchstartete. Die spanische Version von 'Just Another Day' erreichte #1 in 30 Ländern.",
+      "fun_fact_es": "El cubanoamericano Jon Secada escribió para Gloria Estefan antes de su carrera solista. La versión española de 'Just Another Day' llegó al #1 en 30 países.",
+      "fun_fact_fr": "Le Cubano-Américain Jon Secada a écrit pour Gloria Estefan avant sa carrière solo. La version espagnole de 'Just Another Day' a atteint le #1 dans 30 pays.",
       "uri_apple_music": "applemusic://track/723752149",
       "uri_youtube_music": "https://music.youtube.com/watch?v=zShPLJQDAFY",
       "uri_tidal": "tidal://track/1385339",
-      "fun_fact_nl": "De Cubaans-Amerikaanse Jon Secada schreef en zong achtergrondzang voor Gloria Estefan voordat hij een solocarri\u00e8re begon. Deze Spaanse versie van 'Just Another Day' werd #1 in 30 landen.",
-      "awards_nl": []
+      "fun_fact_nl": "De Cubaans-Amerikaanse Jon Secada schreef en zong achtergrondzang voor Gloria Estefan voordat hij een solocarrière begon. Deze Spaanse versie van 'Just Another Day' werd #1 in 30 landen.",
+      "awards_nl": [],
+      "isrc": "USEL19200004",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1699078486",
+        "de": "applemusic://track/1699078486",
+        "gb": "applemusic://track/1699078486",
+        "fr": "applemusic://track/1699078486",
+        "es": "applemusic://track/1699078486",
+        "nl": "applemusic://track/1699078486",
+        "it": "applemusic://track/1699078486"
+      }
     },
     {
       "year": 1965,
@@ -1142,14 +1542,24 @@
       "certifications": [],
       "awards": [],
       "fun_fact": "Italian singer whose 'Il Mondo' became a global hit. The Spanish version became a karaoke staple across the Spanish-speaking world, covered by countless artists.",
-      "fun_fact_de": "Italienischer S\u00e4nger, dessen 'Il Mondo' ein Welthit wurde. Die spanische Version ist ein Karaoke-Klassiker in der gesamten spanischsprachigen Welt.",
-      "fun_fact_es": "Cantante italiano cuyo 'Il Mondo' fue un \u00e9xito mundial. La versi\u00f3n en espa\u00f1ol se convirti\u00f3 en cl\u00e1sico de karaoke en todo el mundo hispano.",
-      "fun_fact_fr": "Chanteur italien dont 'Il Mondo' est devenu un succ\u00e8s mondial. La version espagnole est un classique du karaok\u00e9 dans le monde hispanophone.",
+      "fun_fact_de": "Italienischer Sänger, dessen 'Il Mondo' ein Welthit wurde. Die spanische Version ist ein Karaoke-Klassiker in der gesamten spanischsprachigen Welt.",
+      "fun_fact_es": "Cantante italiano cuyo 'Il Mondo' fue un éxito mundial. La versión en español se convirtió en clásico de karaoke en todo el mundo hispano.",
+      "fun_fact_fr": "Chanteur italien dont 'Il Mondo' est devenu un succès mondial. La version espagnole est un classique du karaoké dans le monde hispanophone.",
       "uri_apple_music": "applemusic://track/162276553",
       "uri_youtube_music": "https://music.youtube.com/watch?v=HFyCfFJC0no",
       "uri_tidal": "tidal://track/100106555",
       "fun_fact_nl": "Italiaanse zanger wiens 'Il Mondo' een wereldhit werd. De Spaanse versie werd een karaoke nummer in de Spaanstalige wereld, gecoverd door talloze artiesten.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "ES5299600050",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1837691887",
+        "de": "applemusic://track/1837691887",
+        "gb": "applemusic://track/1837691887",
+        "fr": "applemusic://track/1837691887",
+        "es": "applemusic://track/1837691887",
+        "nl": "applemusic://track/1837691887",
+        "it": "applemusic://track/1837691887"
+      }
     },
     {
       "year": 2006,
@@ -1170,24 +1580,34 @@
       "certifications": [],
       "awards": [],
       "fun_fact": "Asturian singer who blends rumba, pop and singer-songwriter traditions. Known for his witty, often humorous lyrics about everyday life and love gone wrong.",
-      "fun_fact_de": "Asturischer S\u00e4nger, der Rumba, Pop und Liedermacher-Tradition verbindet. Bekannt f\u00fcr seine witzigen Texte \u00fcber Alltag und gescheiterte Liebe.",
-      "fun_fact_es": "Cantante asturiano que fusiona rumba, pop y cantautor. Conocido por sus letras ingeniosas y humor\u00edsticas sobre la vida cotidiana y amores fallidos.",
-      "fun_fact_fr": "Chanteur asturien m\u00ealant rumba, pop et tradition d'auteur-compositeur. Connu pour ses textes spirituels sur le quotidien et les amours rat\u00e9es.",
+      "fun_fact_de": "Asturischer Sänger, der Rumba, Pop und Liedermacher-Tradition verbindet. Bekannt für seine witzigen Texte über Alltag und gescheiterte Liebe.",
+      "fun_fact_es": "Cantante asturiano que fusiona rumba, pop y cantautor. Conocido por sus letras ingeniosas y humorísticas sobre la vida cotidiana y amores fallidos.",
+      "fun_fact_fr": "Chanteur asturien mêlant rumba, pop et tradition d'auteur-compositeur. Connu pour ses textes spirituels sur le quotidien et les amours ratées.",
       "uri_apple_music": "applemusic://track/701398502",
       "uri_youtube_music": "https://music.youtube.com/watch?v=eJbIMODHIdw",
       "uri_tidal": "tidal://track/2428547",
       "fun_fact_nl": "Asturiaanse zanger die rumba, pop en singer-songwriter tradities mengt. Hij staat bekend om zijn geestige, vaak humoristische teksten over het dagelijks leven en misgelopen liefde.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "ESD010800122",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1735282442",
+        "de": "applemusic://track/1735282442",
+        "gb": "applemusic://track/1735282442",
+        "fr": "applemusic://track/1735282442",
+        "es": "applemusic://track/1735282442",
+        "nl": "applemusic://track/1735282442",
+        "it": "applemusic://track/1735282442"
+      }
     },
     {
       "year": 1975,
       "uri": "spotify:track:17ZNANF0EA03icw5LpFSOF",
-      "artist": "Lorenzo Santamar\u00eda",
+      "artist": "Lorenzo Santamaría",
       "alt_artists": [
         "Nino Bravo",
         "Camilo Sesto",
         "Julio Iglesias",
-        "Jos\u00e9 Luis Perales"
+        "José Luis Perales"
       ],
       "title": "Para que no me olvides",
       "chart_info": {
@@ -1197,15 +1617,25 @@
       },
       "certifications": [],
       "awards": [],
-      "fun_fact": "Lorenzo Santamar\u00eda from Barcelona was one of Spain's biggest 70s pop stars. This romantic ballad became a wedding classic and is still one of the most-requested songs at Spanish celebrations.",
-      "fun_fact_de": "Lorenzo Santamar\u00eda aus Barcelona war einer der gr\u00f6\u00dften spanischen 70er-Popstars. Diese Ballade ist ein Hochzeitsklassiker.",
-      "fun_fact_es": "Lorenzo Santamar\u00eda de Barcelona fue una de las mayores estrellas del pop espa\u00f1ol de los 70. Esta balada rom\u00e1ntica sigue siendo de las m\u00e1s pedidas en celebraciones.",
-      "fun_fact_fr": "Lorenzo Santamar\u00eda de Barcelone fut l'une des plus grandes stars du pop espagnol des ann\u00e9es 70. Cette ballade reste tr\u00e8s demand\u00e9e lors des c\u00e9l\u00e9brations.",
+      "fun_fact": "Lorenzo Santamaría from Barcelona was one of Spain's biggest 70s pop stars. This romantic ballad became a wedding classic and is still one of the most-requested songs at Spanish celebrations.",
+      "fun_fact_de": "Lorenzo Santamaría aus Barcelona war einer der größten spanischen 70er-Popstars. Diese Ballade ist ein Hochzeitsklassiker.",
+      "fun_fact_es": "Lorenzo Santamaría de Barcelona fue una de las mayores estrellas del pop español de los 70. Esta balada romántica sigue siendo de las más pedidas en celebraciones.",
+      "fun_fact_fr": "Lorenzo Santamaría de Barcelone fut l'une des plus grandes stars du pop espagnol des années 70. Cette ballade reste très demandée lors des célébrations.",
       "uri_apple_music": "applemusic://track/999776200",
       "uri_youtube_music": "https://music.youtube.com/watch?v=Db0OpHeP1LM",
       "uri_tidal": "tidal://track/80256694",
-      "fun_fact_nl": "Lorenzo Santamar\u00eda uit Barcelona was een van de grootste popsterren uit de jaren 70 in Spanje. Deze romantische ballade werd een klassieker op bruiloften en is nog steeds een van de meest gevraagde nummers op Spaanse feesten.",
-      "awards_nl": []
+      "fun_fact_nl": "Lorenzo Santamaría uit Barcelona was een van de grootste popsterren uit de jaren 70 in Spanje. Deze romantische ballade werd een klassieker op bruiloften en is nog steeds een van de meest gevraagde nummers op Spaanse feesten.",
+      "awards_nl": [],
+      "isrc": "ES5089800432",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1757835018",
+        "de": "applemusic://track/1757835018",
+        "gb": "applemusic://track/1757835018",
+        "fr": "applemusic://track/1757835018",
+        "es": "applemusic://track/1757835018",
+        "nl": "applemusic://track/1757835018",
+        "it": "applemusic://track/1757835018"
+      }
     },
     {
       "year": 1977,
@@ -1217,7 +1647,7 @@
         "Karina",
         "Marisol"
       ],
-      "title": "El Cristo de Palacag\u00fcina",
+      "title": "El Cristo de Palacagüina",
       "chart_info": {
         "billboard_peak": null,
         "uk_peak": null,
@@ -1225,15 +1655,25 @@
       },
       "certifications": [],
       "awards": [],
-      "fun_fact": "A Spanish-language cover of a Nicaraguan revolutionary song by Carlos Mej\u00eda Godoy. Elsa Baeza's version brought Central American protest music to Spanish pop audiences.",
+      "fun_fact": "A Spanish-language cover of a Nicaraguan revolutionary song by Carlos Mejía Godoy. Elsa Baeza's version brought Central American protest music to Spanish pop audiences.",
       "fun_fact_de": "Ein spanischsprachiges Cover eines nicaraguanischen Revolutionslieds. Elsa Baezas Version brachte zentralamerikanische Protestmusik zum spanischen Pop-Publikum.",
-      "fun_fact_es": "Versi\u00f3n de una canci\u00f3n revolucionaria nicarag\u00fcense de Carlos Mej\u00eda Godoy. La versi\u00f3n de Elsa Baeza acerc\u00f3 la m\u00fasica de protesta centroamericana al p\u00fablico pop espa\u00f1ol.",
-      "fun_fact_fr": "Reprise d'une chanson r\u00e9volutionnaire nicaraguayenne de Carlos Mej\u00eda Godoy. La version d'Elsa Baeza a apport\u00e9 la musique contestataire centram\u00e9ricaine au public pop espagnol.",
+      "fun_fact_es": "Versión de una canción revolucionaria nicaragüense de Carlos Mejía Godoy. La versión de Elsa Baeza acercó la música de protesta centroamericana al público pop español.",
+      "fun_fact_fr": "Reprise d'une chanson révolutionnaire nicaraguayenne de Carlos Mejía Godoy. La version d'Elsa Baeza a apporté la musique contestataire centraméricaine au public pop espagnol.",
       "uri_apple_music": "applemusic://track/157403623",
       "uri_youtube_music": "https://music.youtube.com/watch?v=ogxEVQjSmpQ",
       "uri_tidal": "tidal://track/458935630",
-      "fun_fact_nl": "Een Spaanstalige cover van een Nicaraguaans revolutionair lied van Carlos Mej\u00eda Godoy. Elsa Baeza's versie bracht Midden-Amerikaanse protestmuziek naar een Spaans poppubliek.",
-      "awards_nl": []
+      "fun_fact_nl": "Een Spaanstalige cover van een Nicaraguaans revolutionair lied van Carlos Mejía Godoy. Elsa Baeza's versie bracht Midden-Amerikaanse protestmuziek naar een Spaans poppubliek.",
+      "awards_nl": [],
+      "isrc": "ES5299500012",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1838122505",
+        "de": "applemusic://track/1838122505",
+        "gb": "applemusic://track/1838122505",
+        "fr": "applemusic://track/1838122505",
+        "es": "applemusic://track/1838122505",
+        "nl": "applemusic://track/1838122505",
+        "it": "applemusic://track/1838122505"
+      }
     },
     {
       "year": 1989,
@@ -1254,26 +1694,36 @@
       "certifications": [],
       "awards": [],
       "fun_fact": "One of the quirkiest bands from Spain's post-Movida era in the Basque Country. Their absurdist humor and catchy melodies made them indie legends in Spain.",
-      "fun_fact_de": "Eine der schr\u00e4gsten Bands der Post-Movida-\u00c4ra im Baskenland. Ihr absurder Humor und eing\u00e4ngige Melodien machten sie zu Indie-Legenden.",
-      "fun_fact_es": "Una de las bandas m\u00e1s peculiares de la era post-Movida en el Pa\u00eds Vasco. Su humor absurdo y melod\u00edas pegadizas los convirtieron en leyendas indie.",
-      "fun_fact_fr": "L'un des groupes les plus d\u00e9cal\u00e9s de l'\u00e8re post-Movida au Pays Basque. Leur humour absurde en a fait des l\u00e9gendes indie en Espagne.",
+      "fun_fact_de": "Eine der schrägsten Bands der Post-Movida-Ära im Baskenland. Ihr absurder Humor und eingängige Melodien machten sie zu Indie-Legenden.",
+      "fun_fact_es": "Una de las bandas más peculiares de la era post-Movida en el País Vasco. Su humor absurdo y melodías pegadizas los convirtieron en leyendas indie.",
+      "fun_fact_fr": "L'un des groupes les plus décalés de l'ère post-Movida au Pays Basque. Leur humour absurde en a fait des légendes indie en Espagne.",
       "uri_apple_music": "applemusic://track/857799592",
       "uri_youtube_music": "https://music.youtube.com/watch?v=T1kLtZv9Sb4",
       "uri_tidal": "tidal://track/186297",
-      "fun_fact_nl": "Een van de meest eigenzinnige bands uit het Spaanse post-Movida tijdperk in Baskenland. Hun absurdistische humor en aanstekelijke melodie\u00ebn maakten hen tot indie-legendes in Spanje.",
-      "awards_nl": []
+      "fun_fact_nl": "Een van de meest eigenzinnige bands uit het Spaanse post-Movida tijdperk in Baskenland. Hun absurdistische humor en aanstekelijke melodieën maakten hen tot indie-legendes in Spanje.",
+      "awards_nl": [],
+      "isrc": "ES5018735000",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1573213551",
+        "de": "applemusic://track/1573213551",
+        "gb": "applemusic://track/1573213551",
+        "fr": "applemusic://track/1573213551",
+        "es": "applemusic://track/1573213551",
+        "nl": "applemusic://track/1573213551",
+        "it": "applemusic://track/1573213551"
+      }
     },
     {
       "year": 2016,
       "uri": "spotify:track:38mCl4EuWhML4eaZPdNQ3a",
-      "artist": "Blas Cant\u00f3",
+      "artist": "Blas Cantó",
       "alt_artists": [
-        "Pablo Albor\u00e1n",
+        "Pablo Alborán",
         "Manuel Carrasco",
         "DePol",
-        "Antonio Jos\u00e9"
+        "Antonio José"
       ],
-      "title": "\u00c9l no soy yo",
+      "title": "Él no soy yo",
       "chart_info": {
         "billboard_peak": null,
         "uk_peak": null,
@@ -1281,15 +1731,25 @@
       },
       "certifications": [],
       "awards": [],
-      "fun_fact": "Blas Cant\u00f3 went from boyband (Auryn) to solo career and was chosen to represent Spain at Eurovision 2020 and 2021. This ballad showcased his powerful voice.",
-      "fun_fact_de": "Blas Cant\u00f3 ging von der Boyband Auryn zur Solokarriere und vertrat Spanien beim Eurovision 2020 und 2021.",
-      "fun_fact_es": "Blas Cant\u00f3 pas\u00f3 del grupo Auryn a carrera solista y fue elegido para representar a Espa\u00f1a en Eurovisi\u00f3n 2020 y 2021.",
-      "fun_fact_fr": "Blas Cant\u00f3 est pass\u00e9 du boys band Auryn \u00e0 une carri\u00e8re solo et a repr\u00e9sent\u00e9 l'Espagne \u00e0 l'Eurovision 2020 et 2021.",
+      "fun_fact": "Blas Cantó went from boyband (Auryn) to solo career and was chosen to represent Spain at Eurovision 2020 and 2021. This ballad showcased his powerful voice.",
+      "fun_fact_de": "Blas Cantó ging von der Boyband Auryn zur Solokarriere und vertrat Spanien beim Eurovision 2020 und 2021.",
+      "fun_fact_es": "Blas Cantó pasó del grupo Auryn a carrera solista y fue elegido para representar a España en Eurovisión 2020 y 2021.",
+      "fun_fact_fr": "Blas Cantó est passé du boys band Auryn à une carrière solo et a représenté l'Espagne à l'Eurovision 2020 et 2021.",
       "uri_apple_music": "applemusic://track/1421843539",
       "uri_youtube_music": "https://music.youtube.com/watch?v=yIg0uKHK8JU",
       "uri_tidal": "tidal://track/85078851",
-      "fun_fact_nl": "Blas Cant\u00f3 ging van een boyband (Auryn) naar een solocarri\u00e8re en werd gekozen om Spanje te vertegenwoordigen op Eurovisie 2020 en 2021. Deze ballade liet zijn krachtige stem horen.",
-      "awards_nl": []
+      "fun_fact_nl": "Blas Cantó ging van een boyband (Auryn) naar een solocarrière en werd gekozen om Spanje te vertegenwoordigen op Eurovisie 2020 en 2021. Deze ballade liet zijn krachtige stem horen.",
+      "awards_nl": [],
+      "isrc": "ES5151800673",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1405563778",
+        "de": "applemusic://track/1405563778",
+        "gb": "applemusic://track/1405563778",
+        "fr": "applemusic://track/1405563778",
+        "es": "applemusic://track/1405563778",
+        "nl": "applemusic://track/1405563778",
+        "it": "applemusic://track/1405563778"
+      }
     },
     {
       "year": 2004,
@@ -1301,7 +1761,7 @@
         "Pereza",
         "Dover"
       ],
-      "title": "El universo sobre m\u00ed",
+      "title": "El universo sobre mí",
       "chart_info": {
         "billboard_peak": null,
         "uk_peak": null,
@@ -1310,14 +1770,24 @@
       "certifications": [],
       "awards": [],
       "fun_fact": "Duo from Zaragoza (Eva Amaral + Juan Aguirre) who became Spain's most successful indie-rock band, filling arenas across the country. This track was a #1 hit.",
-      "fun_fact_de": "Duo aus Zaragoza (Eva Amaral + Juan Aguirre), erfolgreichste Indie-Rock-Band Spaniens, die landesweit Arenen f\u00fcllte.",
-      "fun_fact_es": "D\u00fao de Zaragoza (Eva Amaral + Juan Aguirre), la banda indie-rock m\u00e1s exitosa de Espa\u00f1a, llenando recintos por todo el pa\u00eds.",
-      "fun_fact_fr": "Duo de Saragosse (Eva Amaral + Juan Aguirre), le groupe indie-rock le plus populaire d'Espagne, remplissant les ar\u00e8nes du pays.",
+      "fun_fact_de": "Duo aus Zaragoza (Eva Amaral + Juan Aguirre), erfolgreichste Indie-Rock-Band Spaniens, die landesweit Arenen füllte.",
+      "fun_fact_es": "Dúo de Zaragoza (Eva Amaral + Juan Aguirre), la banda indie-rock más exitosa de España, llenando recintos por todo el país.",
+      "fun_fact_fr": "Duo de Saragosse (Eva Amaral + Juan Aguirre), le groupe indie-rock le plus populaire d'Espagne, remplissant les arènes du pays.",
       "uri_apple_music": "applemusic://track/726148732",
       "uri_youtube_music": "https://music.youtube.com/watch?v=d5alBzLbDNw",
       "uri_tidal": "tidal://track/1404259",
       "fun_fact_nl": "Duo uit Zaragoza (Eva Amaral + Juan Aguirre) die uitgroeiden tot de meest succesvolle indie-rockband van Spanje en door het hele land arena's vulden. Dit nummer was een nummer 1 hit.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "ES5080500001",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1821444438",
+        "de": "applemusic://track/1821444438",
+        "gb": "applemusic://track/1821444438",
+        "fr": "applemusic://track/1821444438",
+        "es": "applemusic://track/695590633",
+        "nl": "applemusic://track/1821444438",
+        "it": "applemusic://track/1821444438"
+      }
     },
     {
       "year": 1966,
@@ -1327,9 +1797,9 @@
         "Julio Iglesias",
         "Camilo Sesto",
         "Nino Bravo",
-        "Miguel Bos\u00e9"
+        "Miguel Bosé"
       ],
-      "title": "Yo soy aqu\u00e9l",
+      "title": "Yo soy aquél",
       "chart_info": {
         "billboard_peak": null,
         "uk_peak": null,
@@ -1338,14 +1808,24 @@
       "certifications": [],
       "awards": [],
       "fun_fact": "Spain's Eurovision entry in 1966 (7th place). Raphael went on to become one of the greatest Spanish-language artists ever, with 60+ years of career and 50+ million records sold.",
-      "fun_fact_de": "Spaniens Eurovision-Beitrag 1966. Raphael wurde einer der gr\u00f6\u00dften spanischsprachigen K\u00fcnstler mit \u00fcber 60 Jahren Karriere und 50+ Millionen verkauften Platten.",
-      "fun_fact_es": "Represent\u00f3 a Espa\u00f1a en Eurovisi\u00f3n 1966. Raphael se convirti\u00f3 en uno de los mayores artistas en espa\u00f1ol con m\u00e1s de 60 a\u00f1os de carrera y 50+ millones de discos.",
-      "fun_fact_fr": "Repr\u00e9sentant l'Espagne \u00e0 l'Eurovision 1966. Raphael est devenu l'un des plus grands artistes hispanophones avec 60+ ans de carri\u00e8re et 50+ millions de disques.",
+      "fun_fact_de": "Spaniens Eurovision-Beitrag 1966. Raphael wurde einer der größten spanischsprachigen Künstler mit über 60 Jahren Karriere und 50+ Millionen verkauften Platten.",
+      "fun_fact_es": "Representó a España en Eurovisión 1966. Raphael se convirtió en uno de los mayores artistas en español con más de 60 años de carrera y 50+ millones de discos.",
+      "fun_fact_fr": "Représentant l'Espagne à l'Eurovision 1966. Raphael est devenu l'un des plus grands artistes hispanophones avec 60+ ans de carrière et 50+ millions de disques.",
       "uri_apple_music": "applemusic://track/693490632",
       "uri_youtube_music": "https://music.youtube.com/watch?v=TEwWrpebnkM",
       "uri_tidal": "tidal://track/1487360",
-      "fun_fact_nl": "De Eurovisie-inzending van Spanje in 1966 (7e plaats). Raphael werd een van de grootste Spaanstalige artiesten ooit, met een carri\u00e8re van meer dan 60 jaar en meer dan 50 miljoen verkochte platen.",
-      "awards_nl": []
+      "fun_fact_nl": "De Eurovisie-inzending van Spanje in 1966 (7e plaats). Raphael werd een van de grootste Spaanstalige artiesten ooit, met een carrière van meer dan 60 jaar en meer dan 50 miljoen verkochte platen.",
+      "awards_nl": [],
+      "isrc": "ES5096600687",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1268544137",
+        "de": "applemusic://track/1268544137",
+        "gb": "applemusic://track/1268544137",
+        "fr": "applemusic://track/1268544137",
+        "es": "applemusic://track/1268544137",
+        "nl": "applemusic://track/1268544137",
+        "it": "applemusic://track/1268544137"
+      }
     },
     {
       "year": 1978,
@@ -1366,14 +1846,24 @@
       "certifications": [],
       "awards": [],
       "fun_fact": "Los Chichos from Vallecas are the undisputed kings of 'rumba flamenca'. Their raw, street-level sound became the soundtrack of working-class Spain in the late 70s and 80s.",
-      "fun_fact_de": "Los Chichos aus Vallecas sind die unbestrittenen K\u00f6nige der 'Rumba Flamenca'. Ihr Sound wurde zum Soundtrack der spanischen Arbeiterklasse.",
-      "fun_fact_es": "Los Chichos de Vallecas son los reyes indiscutibles de la rumba flamenca. Su sonido se convirti\u00f3 en la banda sonora de la Espa\u00f1a obrera.",
-      "fun_fact_fr": "Los Chichos de Vallecas sont les rois incontest\u00e9s de la rumba flamenca. Leur son est devenu la bande-son de l'Espagne ouvri\u00e8re.",
+      "fun_fact_de": "Los Chichos aus Vallecas sind die unbestrittenen Könige der 'Rumba Flamenca'. Ihr Sound wurde zum Soundtrack der spanischen Arbeiterklasse.",
+      "fun_fact_es": "Los Chichos de Vallecas son los reyes indiscutibles de la rumba flamenca. Su sonido se convirtió en la banda sonora de la España obrera.",
+      "fun_fact_fr": "Los Chichos de Vallecas sont les rois incontestés de la rumba flamenca. Leur son est devenu la bande-son de l'Espagne ouvrière.",
       "uri_apple_music": "applemusic://track/1838116573",
       "uri_youtube_music": "https://music.youtube.com/watch?v=giAeZA6hQe8",
       "uri_tidal": "tidal://track/45474653",
       "fun_fact_nl": "Los Chichos uit Vallecas zijn de onbetwiste koningen van de 'rumba flamenca'. Hun rauwe straatgeluid werd de soundtrack van de arbeidersklasse in Spanje aan het eind van de jaren 70 en in de jaren 80.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "ES5299600112",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1838124095",
+        "de": "applemusic://track/1838124095",
+        "gb": "applemusic://track/1838124095",
+        "fr": "applemusic://track/1838124095",
+        "es": "applemusic://track/1838124095",
+        "nl": "applemusic://track/1838124095",
+        "it": "applemusic://track/1838124095"
+      }
     },
     {
       "year": 2021,
@@ -1385,7 +1875,7 @@
         "Manuel Turizo",
         "Rauw Alejandro"
       ],
-      "title": "Pareja Del A\u00f1o",
+      "title": "Pareja Del Año",
       "chart_info": {
         "billboard_peak": null,
         "uk_peak": null,
@@ -1395,13 +1885,23 @@
       "awards": [],
       "fun_fact": "Colombian Yatra and Puerto Rican Myke Towers created a romantic reggaeton hit that blurred the line between Latin pop and urban music, hitting #1 across Latin America.",
       "fun_fact_de": "Der Kolumbianer Yatra und der Puertoricaner Myke Towers schufen einen romantischen Reggaeton-Hit, der Latin Pop und Urban Music verschmolz.",
-      "fun_fact_es": "El colombiano Yatra y el puertorrique\u00f1o Myke Towers crearon un hit de reggaet\u00f3n rom\u00e1ntico que difumin\u00f3 la l\u00ednea entre pop latino y m\u00fasica urbana.",
-      "fun_fact_fr": "Le Colombien Yatra et le Portoricain Myke Towers ont cr\u00e9\u00e9 un hit reggaeton romantique brouillant la fronti\u00e8re entre pop latino et musique urbaine.",
+      "fun_fact_es": "El colombiano Yatra y el puertorriqueño Myke Towers crearon un hit de reggaetón romántico que difuminó la línea entre pop latino y música urbana.",
+      "fun_fact_fr": "Le Colombien Yatra et le Portoricain Myke Towers ont créé un hit reggaeton romantique brouillant la frontière entre pop latino et musique urbaine.",
       "uri_apple_music": "applemusic://track/1561274161",
       "uri_youtube_music": "https://music.youtube.com/watch?v=SRm2Ch4oFWs",
       "uri_tidal": "tidal://track/180009141",
-      "fun_fact_nl": "De Colombiaanse Yatra en Puerto Ricaanse Myke Towers cre\u00eberden een romantische reggaetonhit die de grens tussen latin pop en urban muziek deed vervagen en nummer 1 werd in heel Latijns-Amerika.",
-      "awards_nl": []
+      "fun_fact_nl": "De Colombiaanse Yatra en Puerto Ricaanse Myke Towers creëerden een romantische reggaetonhit die de grens tussen latin pop en urban muziek deed vervagen en nummer 1 werd in heel Latijns-Amerika.",
+      "awards_nl": [],
+      "isrc": "USUM72104664",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1710031988",
+        "de": "applemusic://track/1710031988",
+        "gb": "applemusic://track/1710031988",
+        "fr": "applemusic://track/1710031988",
+        "es": "applemusic://track/1710031988",
+        "nl": "applemusic://track/1710031988",
+        "it": "applemusic://track/1710031988"
+      }
     },
     {
       "year": 1987,
@@ -1423,13 +1923,23 @@
       "awards": [],
       "fun_fact": "Part of Spain's 80s 'techno-pop' wave alongside Mecano and Duncan Dhu. El Norte from Salamanca had a brief but intense career that produced several Spanish pop classics.",
       "fun_fact_de": "Teil der spanischen 80er-Techno-Pop-Welle neben Mecano und Duncan Dhu. El Norte aus Salamanca hatte eine kurze aber intensive Karriere.",
-      "fun_fact_es": "Parte de la ola 'techno-pop' espa\u00f1ola de los 80 junto a Mecano y Duncan Dhu. El Norte de Salamanca tuvo una carrera breve pero intensa.",
-      "fun_fact_fr": "Partie de la vague 'techno-pop' espagnole des ann\u00e9es 80 aux c\u00f4t\u00e9s de Mecano et Duncan Dhu. El Norte de Salamanque eut une carri\u00e8re br\u00e8ve mais intense.",
+      "fun_fact_es": "Parte de la ola 'techno-pop' española de los 80 junto a Mecano y Duncan Dhu. El Norte de Salamanca tuvo una carrera breve pero intensa.",
+      "fun_fact_fr": "Partie de la vague 'techno-pop' espagnole des années 80 aux côtés de Mecano et Duncan Dhu. El Norte de Salamanque eut une carrière brève mais intense.",
       "uri_apple_music": "applemusic://track/1280362581",
       "uri_youtube_music": "https://music.youtube.com/watch?v=TmvfrhXaW9E",
       "uri_tidal": "tidal://track/53033205",
-      "fun_fact_nl": "Maakte deel uit van de Spaanse 'techno-pop' golf uit de jaren 80, samen met Mecano en Duncan Dhu. El Norte uit Salamanca had een korte maar intense carri\u00e8re die verschillende Spaanse popklassiekers opleverde.",
-      "awards_nl": []
+      "fun_fact_nl": "Maakte deel uit van de Spaanse 'techno-pop' golf uit de jaren 80, samen met Mecano en Duncan Dhu. El Norte uit Salamanca had een korte maar intense carrière die verschillende Spaanse popklassiekers opleverde.",
+      "awards_nl": [],
+      "isrc": "ES5110404976",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1643712664",
+        "de": "applemusic://track/1643712664",
+        "gb": "applemusic://track/1643712664",
+        "fr": "applemusic://track/1643712664",
+        "es": "applemusic://track/1643712664",
+        "nl": "applemusic://track/1643712664",
+        "it": "applemusic://track/1643712664"
+      }
     },
     {
       "year": 1985,
@@ -1438,8 +1948,8 @@
       "alt_artists": [
         "Barricada",
         "Extremoduro",
-        "Le\u00f1o",
-        "Platero y T\u00fa"
+        "Leño",
+        "Platero y Tú"
       ],
       "title": "Agradecido",
       "chart_info": {
@@ -1449,15 +1959,25 @@
       },
       "certifications": [],
       "awards": [],
-      "fun_fact": "Rosendo Mercado is the godfather of Spanish rock. Former frontman of Le\u00f1o, he pioneered hard rock in Spain and maintained a 40+ year career as a solo artist.",
-      "fun_fact_de": "Rosendo Mercado ist der Pate des spanischen Rock. Ex-Frontmann von Le\u00f1o, Pionier des Hard Rock in Spanien mit \u00fcber 40 Jahren Solokarriere.",
-      "fun_fact_es": "Rosendo Mercado es el padrino del rock espa\u00f1ol. Ex l\u00edder de Le\u00f1o, fue pionero del hard rock en Espa\u00f1a con m\u00e1s de 40 a\u00f1os de carrera solista.",
-      "fun_fact_fr": "Rosendo Mercado est le parrain du rock espagnol. Ex-leader de Le\u00f1o, pionnier du hard rock en Espagne avec 40+ ans de carri\u00e8re solo.",
+      "fun_fact": "Rosendo Mercado is the godfather of Spanish rock. Former frontman of Leño, he pioneered hard rock in Spain and maintained a 40+ year career as a solo artist.",
+      "fun_fact_de": "Rosendo Mercado ist der Pate des spanischen Rock. Ex-Frontmann von Leño, Pionier des Hard Rock in Spanien mit über 40 Jahren Solokarriere.",
+      "fun_fact_es": "Rosendo Mercado es el padrino del rock español. Ex líder de Leño, fue pionero del hard rock en España con más de 40 años de carrera solista.",
+      "fun_fact_fr": "Rosendo Mercado est le parrain du rock espagnol. Ex-leader de Leño, pionnier du hard rock en Espagne avec 40+ ans de carrière solo.",
       "uri_apple_music": "applemusic://track/273928240",
       "uri_youtube_music": "https://music.youtube.com/watch?v=AOhiJQBYdF4",
       "uri_tidal": "tidal://track/38055100",
-      "fun_fact_nl": "Rosendo Mercado is de peetvader van de Spaanse rock. Hij was de voormalige frontman van Le\u00f1o, pionierde met hardrock in Spanje en had een meer dan 40 jaar durende carri\u00e8re als soloartiest.",
-      "awards_nl": []
+      "fun_fact_nl": "Rosendo Mercado is de peetvader van de Spaanse rock. Hij was de voormalige frontman van Leño, pionierde met hardrock in Spanje en had een meer dan 40 jaar durende carrière als soloartiest.",
+      "awards_nl": [],
+      "isrc": "ES5028500055",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/106258156",
+        "de": "applemusic://track/106258156",
+        "gb": "applemusic://track/106258156",
+        "fr": "applemusic://track/106258156",
+        "es": "applemusic://track/106258156",
+        "nl": "applemusic://track/106258156",
+        "it": "applemusic://track/106258156"
+      }
     },
     {
       "year": 1995,
@@ -1479,21 +1999,31 @@
       "awards": [],
       "fun_fact": "Raimundo Amador from Seville (ex-Pata Negra) is one of the most brilliant flamenco-blues guitarists ever, fusing flamenco with BB King-style blues like nobody else.",
       "fun_fact_de": "Raimundo Amador aus Sevilla (ex-Pata Negra) ist einer der brillantesten Flamenco-Blues-Gitarristen, der Flamenco mit BB King-Blues verschmolz.",
-      "fun_fact_es": "Raimundo Amador de Sevilla (ex Pata Negra) es uno de los guitarristas flamenco-blues m\u00e1s brillantes, fusionando flamenco con blues estilo BB King.",
-      "fun_fact_fr": "Raimundo Amador de S\u00e9ville (ex-Pata Negra) est l'un des plus brillants guitaristes flamenco-blues, fusionnant flamenco et blues \u00e0 la BB King.",
+      "fun_fact_es": "Raimundo Amador de Sevilla (ex Pata Negra) es uno de los guitarristas flamenco-blues más brillantes, fusionando flamenco con blues estilo BB King.",
+      "fun_fact_fr": "Raimundo Amador de Séville (ex-Pata Negra) est l'un des plus brillants guitaristes flamenco-blues, fusionnant flamenco et blues à la BB King.",
       "uri_apple_music": "applemusic://track/1537431985",
       "uri_youtube_music": "https://music.youtube.com/watch?v=ahetDyr7lAE",
       "uri_tidal": "tidal://track/36302896",
       "fun_fact_nl": "Raimundo Amador uit Sevilla (ex-Pata Negra) is een van de meest briljante flamenco-blues gitaristen ooit, die als geen ander flamenco met BB King-stijl blues versmelt.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "ES5622000595",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1537431985",
+        "de": "applemusic://track/1537431985",
+        "gb": "applemusic://track/1537431985",
+        "fr": "applemusic://track/1537431985",
+        "es": "applemusic://track/1537431985",
+        "nl": "applemusic://track/1537431985",
+        "it": "applemusic://track/1537431985"
+      }
     },
     {
       "year": 2008,
       "uri": "spotify:track:5AwsoZ2O4WeGxtq6dnGvAN",
       "artist": "Pol 3.14",
       "alt_artists": [
-        "Pablo Albor\u00e1n",
-        "Antonio Jos\u00e9",
+        "Pablo Alborán",
+        "Antonio José",
         "Beret",
         "Manuel Carrasco"
       ],
@@ -1506,14 +2036,24 @@
       "certifications": [],
       "awards": [],
       "fun_fact": "Pol 3.14 from Barcelona is a singer-songwriter who built his career through YouTube and live performances, representing a generation of Spanish artists who bypassed traditional labels.",
-      "fun_fact_de": "Pol 3.14 aus Barcelona baute seine Karriere \u00fcber YouTube auf und repr\u00e4sentiert eine Generation spanischer K\u00fcnstler abseits traditioneller Labels.",
-      "fun_fact_es": "Pol 3.14 de Barcelona construy\u00f3 su carrera a trav\u00e9s de YouTube, representando una generaci\u00f3n de artistas espa\u00f1oles que evitaron las discogr\u00e1ficas tradicionales.",
-      "fun_fact_fr": "Pol 3.14 de Barcelone a construit sa carri\u00e8re via YouTube, repr\u00e9sentant une g\u00e9n\u00e9ration d'artistes espagnols contournant les labels traditionnels.",
+      "fun_fact_de": "Pol 3.14 aus Barcelona baute seine Karriere über YouTube auf und repräsentiert eine Generation spanischer Künstler abseits traditioneller Labels.",
+      "fun_fact_es": "Pol 3.14 de Barcelona construyó su carrera a través de YouTube, representando una generación de artistas españoles que evitaron las discográficas tradicionales.",
+      "fun_fact_fr": "Pol 3.14 de Barcelone a construit sa carrière via YouTube, représentant une génération d'artistes espagnols contournant les labels traditionnels.",
       "uri_apple_music": "applemusic://track/1840394612",
       "uri_youtube_music": "https://music.youtube.com/watch?v=JQqDOX5kRr0",
       "uri_tidal": "tidal://track/461220656",
-      "fun_fact_nl": "Pol 3.14 uit Barcelona is een singer-songwriter die zijn carri\u00e8re opbouwde via YouTube en live optredens, en vertegenwoordigt een generatie Spaanse artiesten die de traditionele labels links lieten liggen.",
-      "awards_nl": []
+      "fun_fact_nl": "Pol 3.14 uit Barcelona is een singer-songwriter die zijn carrière opbouwde via YouTube en live optredens, en vertegenwoordigt een generatie Spaanse artiesten die de traditionele labels links lieten liggen.",
+      "awards_nl": [],
+      "isrc": "ES7211016303",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1840394612",
+        "de": "applemusic://track/1840394612",
+        "gb": "applemusic://track/1840394612",
+        "fr": "applemusic://track/1840394612",
+        "es": "applemusic://track/1840394612",
+        "nl": "applemusic://track/1840394612",
+        "it": "applemusic://track/1840394612"
+      }
     },
     {
       "year": 1982,
@@ -1533,15 +2073,25 @@
       },
       "certifications": [],
       "awards": [],
-      "fun_fact": "Not to be confused with the George Baker hit \u2014 Los Calis' version is a rumba flamenca classic from Madrid's Romani music scene that became a summer anthem in 80s Spain.",
-      "fun_fact_de": "Nicht zu verwechseln mit dem George Baker Hit \u2014 eine Rumba-Flamenca-Klassiker der Madrider Roma-Musikszene.",
-      "fun_fact_es": "No confundir con el \u00e9xito de George Baker \u2014 la versi\u00f3n de Los Calis es un cl\u00e1sico de rumba flamenca de la escena gitana madrile\u00f1a.",
-      "fun_fact_fr": "\u00c0 ne pas confondre avec le tube de George Baker \u2014 la version de Los Calis est un classique de rumba flamenca de la sc\u00e8ne gitane madril\u00e8ne.",
+      "fun_fact": "Not to be confused with the George Baker hit — Los Calis' version is a rumba flamenca classic from Madrid's Romani music scene that became a summer anthem in 80s Spain.",
+      "fun_fact_de": "Nicht zu verwechseln mit dem George Baker Hit — eine Rumba-Flamenca-Klassiker der Madrider Roma-Musikszene.",
+      "fun_fact_es": "No confundir con el éxito de George Baker — la versión de Los Calis es un clásico de rumba flamenca de la escena gitana madrileña.",
+      "fun_fact_fr": "À ne pas confondre avec le tube de George Baker — la version de Los Calis est un classique de rumba flamenca de la scène gitane madrilène.",
       "uri_apple_music": "applemusic://track/669029704",
       "uri_youtube_music": "https://music.youtube.com/watch?v=oVgdvG1QDho",
       "uri_tidal": "tidal://track/386385",
       "fun_fact_nl": "Niet te verwarren met de hit van George Baker - de versie van Los Calis is een rumba flamenca klassieker uit de Romaanse muziekscene van Madrid die een zomers volkslied werd in het Spanje van de jaren '80.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "ES5079300003",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/874164908",
+        "de": "applemusic://track/874164908",
+        "gb": "applemusic://track/874164908",
+        "fr": "applemusic://track/874164908",
+        "es": "applemusic://track/874164908",
+        "nl": "applemusic://track/874164908",
+        "it": "applemusic://track/874164908"
+      }
     },
     {
       "year": 1985,
@@ -1551,9 +2101,9 @@
         "Alaska y Dinarama",
         "Aviador Dro",
         "Gabinete Caligari",
-        "Par\u00e1lisis Permanente"
+        "Parálisis Permanente"
       ],
-      "title": "Champ\u00fa de huevo",
+      "title": "Champú de huevo",
       "chart_info": {
         "billboard_peak": null,
         "uk_peak": null,
@@ -1561,15 +2111,25 @@
       },
       "certifications": [],
       "awards": [],
-      "fun_fact": "Tino Casal was the most flamboyant figure of 'La Movida Madrile\u00f1a' \u2014 an Asturian glam-pop artist who died tragically in a car accident in 1991 at age 41.",
-      "fun_fact_de": "Tino Casal war die schillerndste Figur der 'Movida Madrile\u00f1a' \u2014 ein asturischer Glam-Pop-K\u00fcnstler, der 1991 mit 41 Jahren bei einem Autounfall starb.",
-      "fun_fact_es": "Tino Casal fue la figura m\u00e1s extravagante de La Movida Madrile\u00f1a \u2014 artista asturiano de glam-pop que muri\u00f3 tr\u00e1gicamente en accidente de coche en 1991 con 41 a\u00f1os.",
-      "fun_fact_fr": "Tino Casal fut la figure la plus flamboyante de La Movida Madrile\u00f1a \u2014 artiste glam-pop asturien mort tragiquement dans un accident en 1991 \u00e0 41 ans.",
+      "fun_fact": "Tino Casal was the most flamboyant figure of 'La Movida Madrileña' — an Asturian glam-pop artist who died tragically in a car accident in 1991 at age 41.",
+      "fun_fact_de": "Tino Casal war die schillerndste Figur der 'Movida Madrileña' — ein asturischer Glam-Pop-Künstler, der 1991 mit 41 Jahren bei einem Autounfall starb.",
+      "fun_fact_es": "Tino Casal fue la figura más extravagante de La Movida Madrileña — artista asturiano de glam-pop que murió trágicamente en accidente de coche en 1991 con 41 años.",
+      "fun_fact_fr": "Tino Casal fut la figure la plus flamboyante de La Movida Madrileña — artiste glam-pop asturien mort tragiquement dans un accident en 1991 à 41 ans.",
       "uri_apple_music": "applemusic://track/691545698",
       "uri_youtube_music": "https://music.youtube.com/watch?v=lr3hkcTqV2M",
       "uri_tidal": "tidal://track/7760003",
-      "fun_fact_nl": "Tino Casal was de meest flamboyante figuur van 'La Movida Madrile\u00f1a' - een Asturiaanse glam-pop artiest die in 1991 op 41-jarige leeftijd tragisch om het leven kwam bij een auto-ongeluk.",
-      "awards_nl": []
+      "fun_fact_nl": "Tino Casal was de meest flamboyante figuur van 'La Movida Madrileña' - een Asturiaanse glam-pop artiest die in 1991 op 41-jarige leeftijd tragisch om het leven kwam bij een auto-ongeluk.",
+      "awards_nl": [],
+      "isrc": "ES5088106546",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1236796106",
+        "de": "applemusic://track/1236796106",
+        "gb": "applemusic://track/1236796106",
+        "fr": "applemusic://track/1236796106",
+        "es": "applemusic://track/1236796106",
+        "nl": "applemusic://track/1236796106",
+        "it": "applemusic://track/1236796106"
+      }
     },
     {
       "year": 1992,
@@ -1579,7 +2139,7 @@
         "Boney M",
         "Las Ketchup",
         "Georgie Dann",
-        "Los Del R\u00edo"
+        "Los Del Río"
       ],
       "title": "Tractor Amarillo",
       "chart_info": {
@@ -1589,15 +2149,25 @@
       },
       "certifications": [],
       "awards": [],
-      "fun_fact": "One of Spain's most iconic novelty songs \u2014 'Yellow Tractor' became an inescapable one-hit wonder that still fills dance floors at Spanish village fiestas 30 years later.",
-      "fun_fact_de": "Einer der ikonischsten Partysongs Spaniens \u2014 'Gelber Traktor' f\u00fcllt noch 30 Jahre sp\u00e4ter die Tanzfl\u00e4chen bei Dorffesten.",
-      "fun_fact_es": "Una de las canciones festivas m\u00e1s ic\u00f3nicas de Espa\u00f1a \u2014 'Tractor Amarillo' sigue llenando pistas de baile en fiestas de pueblo 30 a\u00f1os despu\u00e9s.",
-      "fun_fact_fr": "L'une des chansons festives les plus iconiques d'Espagne \u2014 'Tractor Amarillo' remplit encore les pistes de danse des f\u00eates de village 30 ans plus tard.",
+      "fun_fact": "One of Spain's most iconic novelty songs — 'Yellow Tractor' became an inescapable one-hit wonder that still fills dance floors at Spanish village fiestas 30 years later.",
+      "fun_fact_de": "Einer der ikonischsten Partysongs Spaniens — 'Gelber Traktor' füllt noch 30 Jahre später die Tanzflächen bei Dorffesten.",
+      "fun_fact_es": "Una de las canciones festivas más icónicas de España — 'Tractor Amarillo' sigue llenando pistas de baile en fiestas de pueblo 30 años después.",
+      "fun_fact_fr": "L'une des chansons festives les plus iconiques d'Espagne — 'Tractor Amarillo' remplit encore les pistes de danse des fêtes de village 30 ans plus tard.",
       "uri_apple_music": "applemusic://track/1315218782",
       "uri_youtube_music": "https://music.youtube.com/watch?v=62Z8vUIk9s8",
       "uri_tidal": "tidal://track/81430657",
       "fun_fact_nl": "Een van de meest iconische novelty songs van Spanje - 'Yellow Tractor' werd een onontkoombaar one-hit wonder dat 30 jaar later nog steeds de dansvloeren vult op Spaanse dorpsfeesten.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USJE61710439",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1315218782",
+        "de": "applemusic://track/1315218782",
+        "gb": "applemusic://track/1315218782",
+        "fr": "applemusic://track/1315218782",
+        "es": "applemusic://track/1315218782",
+        "nl": "applemusic://track/1315218782",
+        "it": "applemusic://track/1315218782"
+      }
     },
     {
       "year": 1995,
@@ -1618,14 +2188,24 @@
       "certifications": [],
       "awards": [],
       "fun_fact": "Zaragoza's Heroes del Silencio were Spain's biggest international rock band, selling 6+ million records globally. Led by Enrique Bunbury, they were massive in Latin America and Germany.",
-      "fun_fact_de": "Heroes del Silencio aus Zaragoza waren Spaniens gr\u00f6\u00dfte internationale Rockband mit \u00fcber 6 Millionen verkauften Platten weltweit, besonders in Lateinamerika und Deutschland.",
-      "fun_fact_es": "Heroes del Silencio de Zaragoza fueron la mayor banda de rock internacional de Espa\u00f1a, con m\u00e1s de 6 millones de discos vendidos, enormes en Latinoam\u00e9rica y Alemania.",
-      "fun_fact_fr": "Heroes del Silencio de Saragosse furent le plus grand groupe de rock international d'Espagne, avec 6+ millions de disques vendus, \u00e9normes en Am\u00e9rique latine et Allemagne.",
+      "fun_fact_de": "Heroes del Silencio aus Zaragoza waren Spaniens größte internationale Rockband mit über 6 Millionen verkauften Platten weltweit, besonders in Lateinamerika und Deutschland.",
+      "fun_fact_es": "Heroes del Silencio de Zaragoza fueron la mayor banda de rock internacional de España, con más de 6 millones de discos vendidos, enormes en Latinoamérica y Alemania.",
+      "fun_fact_fr": "Heroes del Silencio de Saragosse furent le plus grand groupe de rock international d'Espagne, avec 6+ millions de disques vendus, énormes en Amérique latine et Allemagne.",
       "uri_apple_music": "applemusic://track/699670267",
       "uri_youtube_music": "https://music.youtube.com/watch?v=QOBUw4IYI7U",
       "uri_tidal": "tidal://track/256325331",
       "fun_fact_nl": "Zaragoza's Heroes del Silencio waren de grootste internationale rockband van Spanje en verkochten wereldwijd meer dan 6 miljoen platen. Onder leiding van Enrique Bunbury waren ze populair in Latijns-Amerika en Duitsland.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "ES5080700723",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/699670267",
+        "de": "applemusic://track/699670267",
+        "gb": "applemusic://track/699670267",
+        "fr": "applemusic://track/699670267",
+        "es": "applemusic://track/699670267",
+        "nl": "applemusic://track/699670267",
+        "it": "applemusic://track/699670267"
+      }
     },
     {
       "year": 2023,
@@ -1637,7 +2217,7 @@
         "Bad Gyal",
         "Becky G"
       ],
-      "title": "M\u00fasica Ligera",
+      "title": "Música Ligera",
       "chart_info": {
         "billboard_peak": null,
         "uk_peak": null,
@@ -1645,15 +2225,25 @@
       },
       "certifications": [],
       "awards": [],
-      "fun_fact": "Ana Mena from M\u00e1laga became a crossover star in Italy before breaking through in Spain. She holds the record for most weeks at #1 on Spain's Los40 chart by a female artist in recent years.",
-      "fun_fact_de": "Ana Mena aus M\u00e1laga wurde erst in Italien zum Star, bevor sie in Spanien durchbrach. Rekord f\u00fcr meiste Wochen auf #1 bei Los40.",
-      "fun_fact_es": "Ana Mena de M\u00e1laga triunf\u00f3 primero en Italia antes de romper en Espa\u00f1a. R\u00e9cord de semanas en el #1 de Los40 para una artista femenina.",
-      "fun_fact_fr": "Ana Mena de M\u00e1laga est devenue star en Italie avant de percer en Espagne. Record de semaines au #1 de Los40 pour une artiste f\u00e9minine.",
+      "fun_fact": "Ana Mena from Málaga became a crossover star in Italy before breaking through in Spain. She holds the record for most weeks at #1 on Spain's Los40 chart by a female artist in recent years.",
+      "fun_fact_de": "Ana Mena aus Málaga wurde erst in Italien zum Star, bevor sie in Spanien durchbrach. Rekord für meiste Wochen auf #1 bei Los40.",
+      "fun_fact_es": "Ana Mena de Málaga triunfó primero en Italia antes de romper en España. Récord de semanas en el #1 de Los40 para una artista femenina.",
+      "fun_fact_fr": "Ana Mena de Málaga est devenue star en Italie avant de percer en Espagne. Record de semaines au #1 de Los40 pour une artiste féminine.",
       "uri_apple_music": "applemusic://track/1677142421",
       "uri_youtube_music": "https://music.youtube.com/watch?v=K340m2VwhqE",
       "uri_tidal": "tidal://track/204868811",
-      "fun_fact_nl": "Ana Mena uit M\u00e1laga werd een crossover-ster in Itali\u00eb voordat ze doorbrak in Spanje. Ze is houder van het record voor de meeste weken op #1 in de Spaanse Los40 chart door een vrouwelijke artiest in de afgelopen jaren.",
-      "awards_nl": []
+      "fun_fact_nl": "Ana Mena uit Málaga werd een crossover-ster in Italië voordat ze doorbrak in Spanje. Ze is houder van het record voor de meeste weken op #1 in de Spaanse Los40 chart door een vrouwelijke artiest in de afgelopen jaren.",
+      "awards_nl": [],
+      "isrc": "ITB002101219",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1658144918",
+        "de": "applemusic://track/1658144918",
+        "gb": "applemusic://track/1658144918",
+        "fr": "applemusic://track/1658144918",
+        "es": "applemusic://track/1658144918",
+        "nl": "applemusic://track/1658144918",
+        "it": "applemusic://track/1658144918"
+      }
     },
     {
       "year": 1986,
@@ -1665,7 +2255,7 @@
         "Siniestro Total",
         "Alaska y Dinarama"
       ],
-      "title": "Mi Ag\u00fcita Amarilla",
+      "title": "Mi Agüita Amarilla",
       "chart_info": {
         "billboard_peak": null,
         "uk_peak": null,
@@ -1673,23 +2263,33 @@
       },
       "certifications": [],
       "awards": [],
-      "fun_fact": "One of the most irreverent bands of the Movida era. 'Mi Ag\u00fcita Amarilla' (My Little Yellow Water) is exactly what you think it's about \u2014 and it was a massive hit anyway.",
-      "fun_fact_de": "Eine der respektlosesten Bands der Movida-\u00c4ra. 'Mi Ag\u00fcita Amarilla' handelt genau davon, woran man denkt \u2014 und war trotzdem ein Riesenhit.",
-      "fun_fact_es": "Una de las bandas m\u00e1s irreverentes de la Movida. 'Mi Ag\u00fcita Amarilla' trata exactamente de lo que imaginas \u2014 y aun as\u00ed fue un \u00e9xito enorme.",
-      "fun_fact_fr": "L'un des groupes les plus irr\u00e9v\u00e9rencieux de la Movida. 'Mi Ag\u00fcita Amarilla' parle exactement de ce que vous pensez \u2014 et ce fut un \u00e9norme succ\u00e8s.",
+      "fun_fact": "One of the most irreverent bands of the Movida era. 'Mi Agüita Amarilla' (My Little Yellow Water) is exactly what you think it's about — and it was a massive hit anyway.",
+      "fun_fact_de": "Eine der respektlosesten Bands der Movida-Ära. 'Mi Agüita Amarilla' handelt genau davon, woran man denkt — und war trotzdem ein Riesenhit.",
+      "fun_fact_es": "Una de las bandas más irreverentes de la Movida. 'Mi Agüita Amarilla' trata exactamente de lo que imaginas — y aun así fue un éxito enorme.",
+      "fun_fact_fr": "L'un des groupes les plus irrévérencieux de la Movida. 'Mi Agüita Amarilla' parle exactement de ce que vous pensez — et ce fut un énorme succès.",
       "uri_apple_music": "applemusic://track/964104426",
       "uri_youtube_music": "https://music.youtube.com/watch?v=Jaf1yvWb1jw",
       "uri_tidal": "tidal://track/34044126",
-      "fun_fact_nl": "Een van de meest oneerbiedige bands uit het Movida-tijdperk. Mi Ag\u00fcita Amarilla' (Mijn Gele Watertje) is precies waar je denkt dat het over gaat - en het was hoe dan ook een enorme hit.",
-      "awards_nl": []
+      "fun_fact_nl": "Een van de meest oneerbiedige bands uit het Movida-tijdperk. Mi Agüita Amarilla' (Mijn Gele Watertje) is precies waar je denkt dat het over gaat - en het was hoe dan ook een enorme hit.",
+      "awards_nl": [],
+      "isrc": "ES5028600144",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1643712675",
+        "de": "applemusic://track/1643712675",
+        "gb": "applemusic://track/1643712675",
+        "fr": "applemusic://track/1643712675",
+        "es": "applemusic://track/1643712675",
+        "nl": "applemusic://track/1643712675",
+        "it": "applemusic://track/1643712675"
+      }
     },
     {
       "year": 1935,
       "uri": "spotify:track:71bkiosdVssjMrVDbdeG7n",
       "artist": "Carlos Gardel",
       "alt_artists": [
-        "Antonio Mach\u00edn",
-        "Beny Mor\u00e9",
+        "Antonio Machín",
+        "Beny Moré",
         "Julio Sosa",
         "Roberto Goyeneche"
       ],
@@ -1702,14 +2302,24 @@
       "certifications": [],
       "awards": [],
       "fun_fact": "The greatest tango singer of all time, Gardel died in a plane crash in 1935 at the peak of his fame. 'Volver' is Argentina's unofficial national anthem and his masterpiece.",
-      "fun_fact_de": "Der gr\u00f6\u00dfte Tangos\u00e4nger aller Zeiten, starb 1935 bei einem Flugzeugabsturz auf dem H\u00f6hepunkt seines Ruhms. 'Volver' ist Argentiniens inoffizielle Nationalhymne.",
-      "fun_fact_es": "El mayor cantante de tango de la historia, muri\u00f3 en un accidente a\u00e9reo en 1935. 'Volver' es el himno oficioso de Argentina y su obra maestra.",
+      "fun_fact_de": "Der größte Tangosänger aller Zeiten, starb 1935 bei einem Flugzeugabsturz auf dem Höhepunkt seines Ruhms. 'Volver' ist Argentiniens inoffizielle Nationalhymne.",
+      "fun_fact_es": "El mayor cantante de tango de la historia, murió en un accidente aéreo en 1935. 'Volver' es el himno oficioso de Argentina y su obra maestra.",
       "fun_fact_fr": "Le plus grand chanteur de tango de tous les temps, mort dans un accident d'avion en 1935. 'Volver' est l'hymne officieux de l'Argentine.",
       "uri_apple_music": "applemusic://track/689435154",
       "uri_youtube_music": "https://music.youtube.com/watch?v=MCwtzp8b8uk",
       "uri_tidal": "tidal://track/1549157",
-      "fun_fact_nl": "Gardel, de grootste tangozanger aller tijden, kwam in 1935 op het hoogtepunt van zijn roem om het leven bij een vliegtuigongeluk. Volver' is het officieuze volkslied van Argentini\u00eb en zijn meesterwerk.",
-      "awards_nl": []
+      "fun_fact_nl": "Gardel, de grootste tangozanger aller tijden, kwam in 1935 op het hoogtepunt van zijn roem om het leven bij een vliegtuigongeluk. Volver' is het officieuze volkslied van Argentinië en zijn meesterwerk.",
+      "awards_nl": [],
+      "isrc": "ARF061100037",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/689435154",
+        "de": "applemusic://track/689435154",
+        "gb": "applemusic://track/689435154",
+        "fr": "applemusic://track/689435154",
+        "es": "applemusic://track/689435154",
+        "nl": "applemusic://track/689435154",
+        "it": "applemusic://track/689435154"
+      }
     },
     {
       "year": 1965,
@@ -1719,7 +2329,7 @@
         "Marisol",
         "Karina",
         "Massiel",
-        "Roc\u00edo D\u00farcal"
+        "Rocío Dúrcal"
       ],
       "title": "Chica Ye Ye",
       "chart_info": {
@@ -1729,15 +2339,25 @@
       },
       "certifications": [],
       "awards": [],
-      "fun_fact": "Conchita Velasco became a symbol of the youthful Spanish pop revolution of the 60s. 'Chica Ye-Y\u00e9' from the film 'Historias de la televisi\u00f3n' defined a generation of young Spaniards.",
+      "fun_fact": "Conchita Velasco became a symbol of the youthful Spanish pop revolution of the 60s. 'Chica Ye-Yé' from the film 'Historias de la televisión' defined a generation of young Spaniards.",
       "fun_fact_de": "Conchita Velasco wurde zum Symbol der jugendlichen Pop-Revolution der 60er in Spanien.",
-      "fun_fact_es": "Conchita Velasco se convirti\u00f3 en s\u00edmbolo de la revoluci\u00f3n pop juvenil espa\u00f1ola de los 60. 'Chica Ye-Y\u00e9' defini\u00f3 una generaci\u00f3n.",
-      "fun_fact_fr": "Conchita Velasco devint le symbole de la r\u00e9volution pop jeune des ann\u00e9es 60 en Espagne. 'Chica Ye-Y\u00e9' a d\u00e9fini une g\u00e9n\u00e9ration.",
+      "fun_fact_es": "Conchita Velasco se convirtió en símbolo de la revolución pop juvenil española de los 60. 'Chica Ye-Yé' definió una generación.",
+      "fun_fact_fr": "Conchita Velasco devint le symbole de la révolution pop jeune des années 60 en Espagne. 'Chica Ye-Yé' a défini une génération.",
       "uri_apple_music": "applemusic://track/160259544",
       "uri_youtube_music": "https://music.youtube.com/watch?v=L2SG1P86JCQ",
       "uri_tidal": "tidal://track/225791006",
-      "fun_fact_nl": "Conchita Velasco werd een symbool van de jeugdige Spaanse poprevolutie van de jaren 60. Chica Ye-Y\u00e9' uit de film 'Historias de la televisi\u00f3n' definieerde een generatie jonge Spanjaarden.",
-      "awards_nl": []
+      "fun_fact_nl": "Conchita Velasco werd een symbool van de jeugdige Spaanse poprevolutie van de jaren 60. Chica Ye-Yé' uit de film 'Historias de la televisión' definieerde een generatie jonge Spanjaarden.",
+      "awards_nl": [],
+      "isrc": "ES5379900152",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1838218765",
+        "de": "applemusic://track/1838218765",
+        "gb": "applemusic://track/1838218765",
+        "fr": "applemusic://track/1838218765",
+        "es": "applemusic://track/1838218765",
+        "nl": "applemusic://track/1838218765",
+        "it": "applemusic://track/1838218765"
+      }
     },
     {
       "year": 2024,
@@ -1749,7 +2369,7 @@
         "Pereza",
         "Maldita Nerea"
       ],
-      "title": "La Ni\u00f1a Que Llora en Tus Fiestas",
+      "title": "La Niña Que Llora en Tus Fiestas",
       "chart_info": {
         "billboard_peak": null,
         "uk_peak": null,
@@ -1757,24 +2377,34 @@
       },
       "certifications": [],
       "awards": [],
-      "fun_fact": "LODVG from San Sebasti\u00e1n have been Spain's most consistent pop band for 25+ years. Originally fronted by Amaia Montero (now Leire Mart\u00ednez), they've sold 10+ million records.",
-      "fun_fact_de": "LODVG aus San Sebasti\u00e1n sind seit \u00fcber 25 Jahren Spaniens konstanteste Popband mit \u00fcber 10 Millionen verkauften Platten.",
-      "fun_fact_es": "LODVG de San Sebasti\u00e1n llevan m\u00e1s de 25 a\u00f1os siendo la banda pop m\u00e1s constante de Espa\u00f1a con m\u00e1s de 10 millones de discos vendidos.",
-      "fun_fact_fr": "LODVG de Saint-S\u00e9bastien sont le groupe pop le plus constant d'Espagne depuis 25+ ans avec 10+ millions de disques vendus.",
+      "fun_fact": "LODVG from San Sebastián have been Spain's most consistent pop band for 25+ years. Originally fronted by Amaia Montero (now Leire Martínez), they've sold 10+ million records.",
+      "fun_fact_de": "LODVG aus San Sebastián sind seit über 25 Jahren Spaniens konstanteste Popband mit über 10 Millionen verkauften Platten.",
+      "fun_fact_es": "LODVG de San Sebastián llevan más de 25 años siendo la banda pop más constante de España con más de 10 millones de discos vendidos.",
+      "fun_fact_fr": "LODVG de Saint-Sébastien sont le groupe pop le plus constant d'Espagne depuis 25+ ans avec 10+ millions de disques vendus.",
       "uri_apple_music": "applemusic://track/450460305",
       "uri_youtube_music": "https://music.youtube.com/watch?v=zAlsSqlxxyI",
       "uri_tidal": "tidal://track/7623587",
-      "fun_fact_nl": "LODVG uit San Sebasti\u00e1n is al meer dan 25 jaar de meest consistente popband van Spanje. Oorspronkelijk aangevoerd door Amaia Montero (nu Leire Mart\u00ednez), hebben ze meer dan 10 miljoen platen verkocht.",
-      "awards_nl": []
+      "fun_fact_nl": "LODVG uit San Sebastián is al meer dan 25 jaar de meest consistente popband van Spanje. Oorspronkelijk aangevoerd door Amaia Montero (nu Leire Martínez), hebben ze meer dan 10 miljoen platen verkocht.",
+      "awards_nl": [],
+      "isrc": "ES5021100465",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/460475142",
+        "de": "applemusic://track/486086746",
+        "gb": "applemusic://track/486086746",
+        "fr": "applemusic://track/486086746",
+        "es": "applemusic://track/486086746",
+        "nl": "applemusic://track/486086746",
+        "it": "applemusic://track/486086746"
+      }
     },
     {
       "year": 1989,
       "uri": "spotify:track:3YYaJCzQTkJ56nPO8FSeQP",
       "artist": "Burning",
       "alt_artists": [
-        "Le\u00f1o",
-        "Bar\u00f3n Rojo",
-        "Ob\u00fas",
+        "Leño",
+        "Barón Rojo",
+        "Obús",
         "Rosendo"
       ],
       "title": "Una Noche Sin Ti",
@@ -1785,15 +2415,25 @@
       },
       "certifications": [],
       "awards": [],
-      "fun_fact": "Burning are the godfathers of Madrid rock \u2014 active since 1975, they're one of the longest-running rock bands in Spanish history with 40+ years of continuous touring.",
-      "fun_fact_de": "Burning sind die Paten des Madrider Rock \u2014 seit 1975 aktiv, eine der langlebigsten Rockbands der spanischen Geschichte.",
-      "fun_fact_es": "Burning son los padrinos del rock madrile\u00f1o \u2014 activos desde 1975, una de las bandas de rock m\u00e1s longevas de la historia espa\u00f1ola.",
-      "fun_fact_fr": "Burning sont les parrains du rock madril\u00e8ne \u2014 actifs depuis 1975, l'un des groupes de rock les plus durables de l'histoire espagnole.",
+      "fun_fact": "Burning are the godfathers of Madrid rock — active since 1975, they're one of the longest-running rock bands in Spanish history with 40+ years of continuous touring.",
+      "fun_fact_de": "Burning sind die Paten des Madrider Rock — seit 1975 aktiv, eine der langlebigsten Rockbands der spanischen Geschichte.",
+      "fun_fact_es": "Burning son los padrinos del rock madrileño — activos desde 1975, una de las bandas de rock más longevas de la historia española.",
+      "fun_fact_fr": "Burning sont les parrains du rock madrilène — actifs depuis 1975, l'un des groupes de rock les plus durables de l'histoire espagnole.",
       "uri_apple_music": "applemusic://track/1838219657",
       "uri_youtube_music": "https://music.youtube.com/watch?v=7ieJgYg1H78",
       "uri_tidal": "tidal://track/2988373",
       "fun_fact_nl": "Burning zijn de peetvaders van de Madrileense rock - actief sinds 1975 en een van de langstlopende rockbands in de Spaanse geschiedenis met meer dan 40 jaar onafgebroken touren.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "ES7580501603",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1838209598",
+        "de": "applemusic://track/1838209598",
+        "gb": "applemusic://track/1838209598",
+        "fr": "applemusic://track/1838209598",
+        "es": "applemusic://track/1838209598",
+        "nl": "applemusic://track/1838209598",
+        "it": "applemusic://track/1838209598"
+      }
     },
     {
       "year": 2014,
@@ -1814,14 +2454,24 @@
       "certifications": [],
       "awards": [],
       "fun_fact": "Cuban reggaeton track that became a global viral phenomenon. The Pitbull remix made it inescapable on European dance floors in 2014-2015.",
-      "fun_fact_de": "Kubanischer Reggaeton-Track, der zum globalen viralen Ph\u00e4nomen wurde. Der Pitbull-Remix machte ihn 2014-2015 auf europ\u00e4ischen Tanzfl\u00e4chen unausweichlich.",
-      "fun_fact_es": "Tema de reggaet\u00f3n cubano que se convirti\u00f3 en fen\u00f3meno viral global. El remix con Pitbull lo hizo inevitable en las pistas europeas en 2014-2015.",
-      "fun_fact_fr": "Titre de reggaeton cubain devenu ph\u00e9nom\u00e8ne viral mondial. Le remix avec Pitbull l'a rendu incontournable sur les pistes europ\u00e9ennes en 2014-2015.",
+      "fun_fact_de": "Kubanischer Reggaeton-Track, der zum globalen viralen Phänomen wurde. Der Pitbull-Remix machte ihn 2014-2015 auf europäischen Tanzflächen unausweichlich.",
+      "fun_fact_es": "Tema de reggaetón cubano que se convirtió en fenómeno viral global. El remix con Pitbull lo hizo inevitable en las pistas europeas en 2014-2015.",
+      "fun_fact_fr": "Titre de reggaeton cubain devenu phénomène viral mondial. Le remix avec Pitbull l'a rendu incontournable sur les pistes européennes en 2014-2015.",
       "uri_apple_music": "applemusic://track/844380593",
       "uri_youtube_music": "https://music.youtube.com/watch?v=qRp3-D3SMwI",
       "uri_tidal": "tidal://track/27670428",
       "fun_fact_nl": "Cubaanse reggaeton track die een wereldwijd viraal fenomeen werd. De remix van Pitbull maakte het nummer onontkoombaar op de Europese dansvloeren in 2014-2015.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "CH9181400018",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/844380593",
+        "de": "applemusic://track/844380593",
+        "gb": "applemusic://track/844380593",
+        "fr": "applemusic://track/844380593",
+        "es": "applemusic://track/844380593",
+        "nl": "applemusic://track/844380593",
+        "it": "applemusic://track/844380593"
+      }
     },
     {
       "year": 2014,
@@ -1842,22 +2492,32 @@
       "certifications": [],
       "awards": [],
       "fun_fact": "The official song of the 2014 FIFA World Cup in Brazil. Shakira became the only artist to perform at three consecutive World Cup ceremonies (2006, 2010, 2014).",
-      "fun_fact_de": "Offizieller Song der FIFA WM 2014 in Brasilien. Shakira wurde die einzige K\u00fcnstlerin, die bei drei aufeinanderfolgenden WM-Zeremonien auftrat.",
-      "fun_fact_es": "Canci\u00f3n oficial del Mundial FIFA 2014 en Brasil. Shakira se convirti\u00f3 en la \u00fanica artista en actuar en tres ceremonias mundialistas consecutivas.",
-      "fun_fact_fr": "Chanson officielle de la Coupe du Monde FIFA 2014. Shakira est la seule artiste \u00e0 s'\u00eatre produite lors de trois c\u00e9r\u00e9monies de Coupes du Monde cons\u00e9cutives.",
+      "fun_fact_de": "Offizieller Song der FIFA WM 2014 in Brasilien. Shakira wurde die einzige Künstlerin, die bei drei aufeinanderfolgenden WM-Zeremonien auftrat.",
+      "fun_fact_es": "Canción oficial del Mundial FIFA 2014 en Brasil. Shakira se convirtió en la única artista en actuar en tres ceremonias mundialistas consecutivas.",
+      "fun_fact_fr": "Chanson officielle de la Coupe du Monde FIFA 2014. Shakira est la seule artiste à s'être produite lors de trois cérémonies de Coupes du Monde consécutives.",
       "uri_apple_music": "applemusic://track/825811735",
       "uri_youtube_music": "https://music.youtube.com/watch?v=-befR4wHsjQ",
       "uri_tidal": "tidal://track/34913114",
-      "fun_fact_nl": "Het offici\u00eble lied van de 2014 FIFA World Cup in Brazili\u00eb. Shakira werd de enige artiest die optrad tijdens drie opeenvolgende WK-ceremonies (2006, 2010, 2014).",
-      "awards_nl": []
+      "fun_fact_nl": "Het officiële lied van de 2014 FIFA World Cup in Brazilië. Shakira werd de enige artiest die optrad tijdens drie opeenvolgende WK-ceremonies (2006, 2010, 2014).",
+      "awards_nl": [],
+      "isrc": "USRC11400458",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1771099307",
+        "de": "applemusic://track/853872923",
+        "gb": "applemusic://track/1771099307",
+        "fr": "applemusic://track/1771099307",
+        "es": "applemusic://track/1771099307",
+        "nl": "applemusic://track/1771099307",
+        "it": "applemusic://track/1771099307"
+      }
     },
     {
       "year": 1987,
       "uri": "spotify:track:4YQ9WEYQG7fq0MAUYeB19Y",
       "artist": "Obus",
       "alt_artists": [
-        "Bar\u00f3n Rojo",
-        "\u00c1ngeles del Infierno",
+        "Barón Rojo",
+        "Ángeles del Infierno",
         "Soziedad Alkoholika",
         "Rosendo"
       ],
@@ -1869,27 +2529,37 @@
       },
       "certifications": [],
       "awards": [],
-      "fun_fact": "Ob\u00fas were pioneers of Spanish heavy metal in the 80s. Part of the 'Rock Radikal Vasco' adjacent scene, they proved heavy metal could be sung effectively in Spanish.",
-      "fun_fact_de": "Ob\u00fas waren Pioniere des spanischen Heavy Metal der 80er und bewiesen, dass Metal auf Spanisch funktioniert.",
-      "fun_fact_es": "Ob\u00fas fueron pioneros del heavy metal espa\u00f1ol en los 80, demostrando que el metal se pod\u00eda cantar eficazmente en espa\u00f1ol.",
-      "fun_fact_fr": "Ob\u00fas furent des pionniers du heavy metal espagnol des ann\u00e9es 80, prouvant que le metal pouvait \u00eatre chant\u00e9 efficacement en espagnol.",
+      "fun_fact": "Obús were pioneers of Spanish heavy metal in the 80s. Part of the 'Rock Radikal Vasco' adjacent scene, they proved heavy metal could be sung effectively in Spanish.",
+      "fun_fact_de": "Obús waren Pioniere des spanischen Heavy Metal der 80er und bewiesen, dass Metal auf Spanisch funktioniert.",
+      "fun_fact_es": "Obús fueron pioneros del heavy metal español en los 80, demostrando que el metal se podía cantar eficazmente en español.",
+      "fun_fact_fr": "Obús furent des pionniers du heavy metal espagnol des années 80, prouvant que le metal pouvait être chanté efficacement en espagnol.",
       "uri_apple_music": "applemusic://track/1807146809",
       "uri_youtube_music": "https://music.youtube.com/watch?v=uOF3iQfregw",
       "uri_tidal": "tidal://track/525954",
-      "fun_fact_nl": "Ob\u00fas waren pioniers van de Spaanse heavy metal in de jaren 80. Ze maakten deel uit van de 'Rock Radikal Vasco' scene en bewezen dat heavy metal effectief in het Spaans gezongen kon worden.",
-      "awards_nl": []
+      "fun_fact_nl": "Obús waren pioniers van de Spaanse heavy metal in de jaren 80. Ze maakten deel uit van de 'Rock Radikal Vasco' scene en bewezen dat heavy metal effectief in het Spaans gezongen kon worden.",
+      "awards_nl": [],
+      "isrc": "ES5108400045",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1807146809",
+        "de": "applemusic://track/1807146809",
+        "gb": "applemusic://track/1807146809",
+        "fr": "applemusic://track/1807146809",
+        "es": "applemusic://track/1807146809",
+        "nl": "applemusic://track/1807146809",
+        "it": "applemusic://track/1807146809"
+      }
     },
     {
       "year": 2003,
       "uri": "spotify:track:5nenV4D7Yw2efQxItXOasH",
-      "artist": "Guaran\u00e1",
+      "artist": "Guaraná",
       "alt_artists": [
         "Pignoise",
         "Pereza",
         "El Canto del Loco",
         "Maldita Nerea"
       ],
-      "title": "En la Casa de In\u00e9s",
+      "title": "En la Casa de Inés",
       "chart_info": {
         "billboard_peak": null,
         "uk_peak": null,
@@ -1897,15 +2567,25 @@
       },
       "certifications": [],
       "awards": [],
-      "fun_fact": "Guaran\u00e1 from Valencia scored one of Spain's catchiest pop-rock hits of the 2000s. The song became a ubiquitous radio staple and a sing-along anthem at live shows.",
-      "fun_fact_de": "Guaran\u00e1 aus Valencia landeten einen der eing\u00e4ngigsten Pop-Rock-Hits der 2000er in Spanien.",
-      "fun_fact_es": "Guaran\u00e1 de Valencia logr\u00f3 uno de los \u00e9xitos pop-rock m\u00e1s pegadizos de los 2000 en Espa\u00f1a.",
-      "fun_fact_fr": "Guaran\u00e1 de Valence a sign\u00e9 l'un des tubes pop-rock les plus accrocheurs des ann\u00e9es 2000 en Espagne.",
+      "fun_fact": "Guaraná from Valencia scored one of Spain's catchiest pop-rock hits of the 2000s. The song became a ubiquitous radio staple and a sing-along anthem at live shows.",
+      "fun_fact_de": "Guaraná aus Valencia landeten einen der eingängigsten Pop-Rock-Hits der 2000er in Spanien.",
+      "fun_fact_es": "Guaraná de Valencia logró uno de los éxitos pop-rock más pegadizos de los 2000 en España.",
+      "fun_fact_fr": "Guaraná de Valence a signé l'un des tubes pop-rock les plus accrocheurs des années 2000 en Espagne.",
       "uri_apple_music": "applemusic://track/507418902",
       "uri_youtube_music": "https://music.youtube.com/watch?v=sTthzVPDjak",
       "uri_tidal": "tidal://track/81716276",
-      "fun_fact_nl": "Guaran\u00e1 uit Valencia scoorde een van de meest aanstekelijke poprockhits van Spanje in de jaren 2000. Het nummer werd een alomtegenwoordige radiohit en een meezinger tijdens liveshows.",
-      "awards_nl": []
+      "fun_fact_nl": "Guaraná uit Valencia scoorde een van de meest aanstekelijke poprockhits van Spanje in de jaren 2000. Het nummer werd een alomtegenwoordige radiohit en een meezinger tijdens liveshows.",
+      "awards_nl": [],
+      "isrc": "ES5110003245",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1317694740",
+        "de": "applemusic://track/1317694740",
+        "gb": "applemusic://track/1317694740",
+        "fr": "applemusic://track/1317694740",
+        "es": "applemusic://track/1317694740",
+        "nl": "applemusic://track/1317694740",
+        "it": "applemusic://track/1317694740"
+      }
     },
     {
       "year": 1993,
@@ -1915,9 +2595,9 @@
         "Celia Cruz",
         "Jon Secada",
         "Shakira",
-        "Thal\u00eda"
+        "Thalía"
       ],
-      "title": "Con los A\u00f1os Que Me Quedan",
+      "title": "Con los Años Que Me Quedan",
       "chart_info": {
         "billboard_peak": null,
         "uk_peak": null,
@@ -1926,14 +2606,24 @@
       "certifications": [],
       "awards": [],
       "fun_fact": "Cuban-American Gloria Estefan survived a devastating tour bus accident in 1990 that nearly left her paralyzed. Her comeback was one of music's greatest stories of resilience.",
-      "fun_fact_de": "Die kubanisch-amerikanische Gloria Estefan \u00fcberlebte 1990 einen schweren Busunfall, der sie fast gel\u00e4hmt h\u00e4tte. Ihr Comeback war eine der gr\u00f6\u00dften Geschichten der Musikwelt.",
-      "fun_fact_es": "La cubanoamericana Gloria Estefan sobrevivi\u00f3 un devastador accidente de autob\u00fas en 1990. Su regreso fue una de las mayores historias de resiliencia de la m\u00fasica.",
-      "fun_fact_fr": "La Cubano-Am\u00e9ricaine Gloria Estefan a surv\u00e9cu \u00e0 un grave accident de bus en 1990. Son retour fut l'une des plus grandes histoires de r\u00e9silience de la musique.",
+      "fun_fact_de": "Die kubanisch-amerikanische Gloria Estefan überlebte 1990 einen schweren Busunfall, der sie fast gelähmt hätte. Ihr Comeback war eine der größten Geschichten der Musikwelt.",
+      "fun_fact_es": "La cubanoamericana Gloria Estefan sobrevivió un devastador accidente de autobús en 1990. Su regreso fue una de las mayores historias de resiliencia de la música.",
+      "fun_fact_fr": "La Cubano-Américaine Gloria Estefan a survécu à un grave accident de bus en 1990. Son retour fut l'une des plus grandes histoires de résilience de la musique.",
       "uri_apple_music": "applemusic://track/196407804",
       "uri_youtube_music": "https://music.youtube.com/watch?v=l6LjNOYvhMk",
       "uri_tidal": "tidal://track/33950566",
       "fun_fact_nl": "De Cubaans-Amerikaanse Gloria Estefan overleefde in 1990 een verwoestend busongeluk waardoor ze bijna verlamd raakte. Haar comeback was een van de grootste verhalen over veerkracht in de muziek.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM10024458",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/196407804",
+        "de": "applemusic://track/532997648",
+        "gb": "applemusic://track/260197499",
+        "fr": "applemusic://track/196407804",
+        "es": "applemusic://track/792605907",
+        "nl": "applemusic://track/196407804",
+        "it": "applemusic://track/196407804"
+      }
     },
     {
       "year": 1996,
@@ -1942,10 +2632,10 @@
       "alt_artists": [
         "Heroes Del Silencio",
         "Barricada",
-        "Platero y T\u00fa",
+        "Platero y Tú",
         "Marea"
       ],
-      "title": "La vereda de la puerta de atr\u00e1s",
+      "title": "La vereda de la puerta de atrás",
       "chart_info": {
         "billboard_peak": null,
         "uk_peak": null,
@@ -1953,15 +2643,25 @@
       },
       "certifications": [],
       "awards": [],
-      "fun_fact": "Robe Iniesta's Extremoduro from Plasencia (Extremadura) became Spain's most beloved underground rock band \u2014 selling out stadiums while never appearing on mainstream TV.",
-      "fun_fact_de": "Robe Iniestas Extremoduro aus Plasencia wurde Spaniens beliebteste Underground-Rockband \u2014 f\u00fcllten Stadien ohne je im Mainstream-TV aufzutreten.",
-      "fun_fact_es": "Extremoduro de Robe Iniesta de Plasencia se convirti\u00f3 en la banda underground m\u00e1s querida de Espa\u00f1a \u2014 llenaban estadios sin aparecer en TV.",
-      "fun_fact_fr": "Extremoduro de Robe Iniesta, de Plasencia, est devenu le groupe rock underground le plus aim\u00e9 d'Espagne \u2014 remplissant les stades sans passer \u00e0 la TV.",
+      "fun_fact": "Robe Iniesta's Extremoduro from Plasencia (Extremadura) became Spain's most beloved underground rock band — selling out stadiums while never appearing on mainstream TV.",
+      "fun_fact_de": "Robe Iniestas Extremoduro aus Plasencia wurde Spaniens beliebteste Underground-Rockband — füllten Stadien ohne je im Mainstream-TV aufzutreten.",
+      "fun_fact_es": "Extremoduro de Robe Iniesta de Plasencia se convirtió en la banda underground más querida de España — llenaban estadios sin aparecer en TV.",
+      "fun_fact_fr": "Extremoduro de Robe Iniesta, de Plasencia, est devenu le groupe rock underground le plus aimé d'Espagne — remplissant les stades sans passer à la TV.",
       "uri_apple_music": "applemusic://track/63836937",
       "uri_youtube_music": "https://music.youtube.com/watch?v=TLpDnHhHMfs",
       "uri_tidal": "tidal://track/293515",
       "fun_fact_nl": "Robe Iniesta's Extremoduro uit Plasencia (Extremadura) werd de meest geliefde underground rockband van Spanje - ze verkochten stadions uit terwijl ze nooit op de mainstream TV verschenen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "ES5010200021",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1737191374",
+        "de": "applemusic://track/1737191374",
+        "gb": "applemusic://track/1737191374",
+        "fr": "applemusic://track/1737191374",
+        "es": "applemusic://track/1737191374",
+        "nl": "applemusic://track/1737191374",
+        "it": "applemusic://track/1737191374"
+      }
     },
     {
       "year": 2017,
@@ -1981,15 +2681,25 @@
       },
       "certifications": [],
       "awards": [],
-      "fun_fact": "El Kanka from M\u00e1laga built his career through social media and word-of-mouth, becoming one of Spain's most loved singer-songwriters without major label support.",
-      "fun_fact_de": "El Kanka aus M\u00e1laga baute seine Karriere \u00fcber Social Media auf und wurde ohne Major-Label einer der beliebtesten Liedermacher Spaniens.",
-      "fun_fact_es": "El Kanka de M\u00e1laga construy\u00f3 su carrera a trav\u00e9s de las redes sociales, convirti\u00e9ndose en uno de los cantautores m\u00e1s queridos sin apoyo de grandes discogr\u00e1ficas.",
-      "fun_fact_fr": "El Kanka de M\u00e1laga a construit sa carri\u00e8re via les r\u00e9seaux sociaux, devenant l'un des auteurs-compositeurs les plus aim\u00e9s sans soutien de major.",
+      "fun_fact": "El Kanka from Málaga built his career through social media and word-of-mouth, becoming one of Spain's most loved singer-songwriters without major label support.",
+      "fun_fact_de": "El Kanka aus Málaga baute seine Karriere über Social Media auf und wurde ohne Major-Label einer der beliebtesten Liedermacher Spaniens.",
+      "fun_fact_es": "El Kanka de Málaga construyó su carrera a través de las redes sociales, convirtiéndose en uno de los cantautores más queridos sin apoyo de grandes discográficas.",
+      "fun_fact_fr": "El Kanka de Málaga a construit sa carrière via les réseaux sociaux, devenant l'un des auteurs-compositeurs les plus aimés sans soutien de major.",
       "uri_apple_music": "applemusic://track/1411538212",
       "uri_youtube_music": "https://music.youtube.com/watch?v=6rzbBs731L8",
       "uri_tidal": "tidal://track/416269147",
-      "fun_fact_nl": "El Kanka uit M\u00e1laga bouwde zijn carri\u00e8re op via sociale media en mond-tot-mondreclame en werd een van de meest geliefde singer-songwriters van Spanje zonder de steun van grote labels.",
-      "awards_nl": []
+      "fun_fact_nl": "El Kanka uit Málaga bouwde zijn carrière op via sociale media en mond-tot-mondreclame en werd een van de meest geliefde singer-songwriters van Spanje zonder de steun van grote labels.",
+      "awards_nl": [],
+      "isrc": "ES8241347702",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1411538212",
+        "de": "applemusic://track/1411538212",
+        "gb": "applemusic://track/1411538212",
+        "fr": "applemusic://track/1411538212",
+        "es": "applemusic://track/1411538212",
+        "nl": "applemusic://track/1411538212",
+        "it": "applemusic://track/1411538212"
+      }
     },
     {
       "year": 1980,
@@ -2009,15 +2719,25 @@
       },
       "certifications": [],
       "awards": [],
-      "fun_fact": "Loquillo (Jos\u00e9 Mar\u00eda Sanz) is Barcelona's rockabilly king \u2014 Spain's answer to Elvis meets The Clash. With Los Trogloditas, he's been a rock institution for 40+ years.",
-      "fun_fact_de": "Loquillo ist Barcelonas Rockabilly-K\u00f6nig \u2014 Spaniens Antwort auf Elvis meets The Clash. Seit \u00fcber 40 Jahren eine Rock-Institution.",
-      "fun_fact_es": "Loquillo es el rey del rockabilly de Barcelona \u2014 la respuesta espa\u00f1ola a Elvis meets The Clash. Una instituci\u00f3n del rock durante m\u00e1s de 40 a\u00f1os.",
-      "fun_fact_fr": "Loquillo est le roi du rockabilly de Barcelone \u2014 la r\u00e9ponse espagnole \u00e0 Elvis rencontre The Clash. Une institution du rock depuis 40+ ans.",
+      "fun_fact": "Loquillo (José María Sanz) is Barcelona's rockabilly king — Spain's answer to Elvis meets The Clash. With Los Trogloditas, he's been a rock institution for 40+ years.",
+      "fun_fact_de": "Loquillo ist Barcelonas Rockabilly-König — Spaniens Antwort auf Elvis meets The Clash. Seit über 40 Jahren eine Rock-Institution.",
+      "fun_fact_es": "Loquillo es el rey del rockabilly de Barcelona — la respuesta española a Elvis meets The Clash. Una institución del rock durante más de 40 años.",
+      "fun_fact_fr": "Loquillo est le roi du rockabilly de Barcelone — la réponse espagnole à Elvis rencontre The Clash. Une institution du rock depuis 40+ ans.",
       "uri_apple_music": "applemusic://track/339614691",
       "uri_youtube_music": "https://music.youtube.com/watch?v=B0YMoFwqkvY",
       "uri_tidal": "tidal://track/5392801",
-      "fun_fact_nl": "Loquillo (Jos\u00e9 Mar\u00eda Sanz) is de rockabillykoning van Barcelona - het Spaanse antwoord op Elvis ontmoet The Clash. Met Los Trogloditas is hij al meer dan 40 jaar een rockinstituut.",
-      "awards_nl": []
+      "fun_fact_nl": "Loquillo (José María Sanz) is de rockabillykoning van Barcelona - het Spaanse antwoord op Elvis ontmoet The Clash. Met Los Trogloditas is hij al meer dan 40 jaar een rockinstituut.",
+      "awards_nl": [],
+      "isrc": "ES5018404000",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1279768387",
+        "de": "applemusic://track/1279768387",
+        "gb": "applemusic://track/1279768387",
+        "fr": "applemusic://track/1279768387",
+        "es": "applemusic://track/1279768387",
+        "nl": "applemusic://track/1279768387",
+        "it": "applemusic://track/1279768387"
+      }
     },
     {
       "year": 1988,
@@ -2026,10 +2746,10 @@
       "alt_artists": [
         "El Fary",
         "Los Chunguitos",
-        "Camar\u00f3n",
-        "Ni\u00f1a Pastori"
+        "Camarón",
+        "Niña Pastori"
       ],
-      "title": "Esta Cobard\u00eda",
+      "title": "Esta Cobardía",
       "chart_info": {
         "billboard_peak": null,
         "uk_peak": null,
@@ -2038,14 +2758,24 @@
       "certifications": [],
       "awards": [],
       "fun_fact": "Chiquetete from Seville was one of the great voices of flamenco-pop, known for his powerful vibrato and emotional intensity. A staple of Spanish variety TV shows in the 80s-90s.",
-      "fun_fact_de": "Chiquetete aus Sevilla war eine der gro\u00dfen Stimmen des Flamenco-Pop, bekannt f\u00fcr sein kraftvolles Vibrato und emotionale Intensit\u00e4t.",
+      "fun_fact_de": "Chiquetete aus Sevilla war eine der großen Stimmen des Flamenco-Pop, bekannt für sein kraftvolles Vibrato und emotionale Intensität.",
       "fun_fact_es": "Chiquetete de Sevilla fue una de las grandes voces del flamenco-pop, conocido por su potente vibrato e intensidad emocional.",
-      "fun_fact_fr": "Chiquetete de S\u00e9ville fut l'une des grandes voix du flamenco-pop, connu pour son vibrato puissant et son intensit\u00e9 \u00e9motionnelle.",
+      "fun_fact_fr": "Chiquetete de Séville fut l'une des grandes voix du flamenco-pop, connu pour son vibrato puissant et son intensité émotionnelle.",
       "uri_apple_music": "applemusic://track/1449551728",
       "uri_youtube_music": "https://music.youtube.com/watch?v=V42RAxg0hjo",
       "uri_tidal": "tidal://track/690085",
-      "fun_fact_nl": "Chiquetete uit Sevilla was een van de grote stemmen van de flamenco-pop, bekend om zijn krachtige vibrato en emotionele intensiteit. Een hoofdrolspeler in de Spaanse vari\u00e9t\u00e9 TV shows in de jaren 80-90.",
-      "awards_nl": []
+      "fun_fact_nl": "Chiquetete uit Sevilla was een van de grote stemmen van de flamenco-pop, bekend om zijn krachtige vibrato en emotionele intensiteit. Een hoofdrolspeler in de Spaanse variété TV shows in de jaren 80-90.",
+      "awards_nl": [],
+      "isrc": "QMFMF1511180",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1449551728",
+        "de": "applemusic://track/1449551728",
+        "gb": "applemusic://track/1449551728",
+        "fr": "applemusic://track/1449551728",
+        "es": "applemusic://track/1449551728",
+        "nl": "applemusic://track/1449551728",
+        "it": "applemusic://track/1449551728"
+      }
     },
     {
       "year": 1970,
@@ -2055,7 +2785,7 @@
         "Raphael",
         "Julio Iglesias",
         "Camilo Sesto",
-        "Jos\u00e9 Luis Perales"
+        "José Luis Perales"
       ],
       "title": "Te Quiero, Te Quiero",
       "chart_info": {
@@ -2067,13 +2797,23 @@
       "awards": [],
       "fun_fact": "Nino Bravo from Valencia died in a car crash at just 28 (1973), but his powerful tenor voice made him one of Spain's most legendary singers. His songs are still covered constantly.",
       "fun_fact_de": "Nino Bravo aus Valencia starb mit nur 28 Jahren (1973) bei einem Autounfall, aber seine kraftvolle Tenorstimme machte ihn zu einer Legende.",
-      "fun_fact_es": "Nino Bravo de Valencia muri\u00f3 en accidente de coche con solo 28 a\u00f1os (1973), pero su potente voz de tenor lo convirti\u00f3 en uno de los cantantes m\u00e1s legendarios de Espa\u00f1a.",
-      "fun_fact_fr": "Nino Bravo de Valence est mort dans un accident \u00e0 seulement 28 ans (1973), mais sa puissante voix de t\u00e9nor en a fait l'un des chanteurs les plus l\u00e9gendaires d'Espagne.",
+      "fun_fact_es": "Nino Bravo de Valencia murió en accidente de coche con solo 28 años (1973), pero su potente voz de tenor lo convirtió en uno de los cantantes más legendarios de España.",
+      "fun_fact_fr": "Nino Bravo de Valence est mort dans un accident à seulement 28 ans (1973), mais sa puissante voix de ténor en a fait l'un des chanteurs les plus légendaires d'Espagne.",
       "uri_apple_music": "applemusic://track/1442457085",
       "uri_youtube_music": "https://music.youtube.com/watch?v=mvHjgZJiA1g",
       "uri_tidal": "tidal://track/37052753",
       "fun_fact_nl": "Nino Bravo uit Valencia stierf op 28-jarige leeftijd (1973) in een auto-ongeluk, maar zijn krachtige tenorstem maakte hem een van de meest legendarische zangers van Spanje. Zijn liedjes worden nog steeds constant gecoverd.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "ES6009500072",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1746172959",
+        "de": "applemusic://track/1746172959",
+        "gb": "applemusic://track/1746172959",
+        "fr": "applemusic://track/1746172959",
+        "es": "applemusic://track/1746172959",
+        "nl": "applemusic://track/1746172959",
+        "it": "applemusic://track/1746172959"
+      }
     },
     {
       "year": 2005,
@@ -2083,7 +2823,7 @@
         "Pereza",
         "El Canto del Loco",
         "Maldita Nerea",
-        "Guaran\u00e1"
+        "Guaraná"
       ],
       "title": "Nada que perder",
       "chart_info": {
@@ -2093,27 +2833,37 @@
       },
       "certifications": [],
       "awards": [],
-      "fun_fact": "Named after a card game (pig nose), this Madrid pop-punk trio became one of Spain's most successful bands of the 2000s. Frontman \u00c1lvaro Benito is a former Real Madrid youth player.",
-      "fun_fact_de": "Nach einem Kartenspiel benannt, wurde dieses Madrider Pop-Punk-Trio eine der erfolgreichsten Bands Spaniens. Frontmann \u00c1lvaro Benito spielte in Real Madrids Jugend.",
-      "fun_fact_es": "Nombrados por un juego de cartas, este tr\u00edo pop-punk madrile\u00f1o fue una de las bandas m\u00e1s exitosas de los 2000. \u00c1lvaro Benito jug\u00f3 en la cantera del Real Madrid.",
-      "fun_fact_fr": "Nomm\u00e9s d'apr\u00e8s un jeu de cartes, ce trio pop-punk madril\u00e8ne fut l'un des plus grands groupes des ann\u00e9es 2000. \u00c1lvaro Benito jouait au Real Madrid.",
+      "fun_fact": "Named after a card game (pig nose), this Madrid pop-punk trio became one of Spain's most successful bands of the 2000s. Frontman Álvaro Benito is a former Real Madrid youth player.",
+      "fun_fact_de": "Nach einem Kartenspiel benannt, wurde dieses Madrider Pop-Punk-Trio eine der erfolgreichsten Bands Spaniens. Frontmann Álvaro Benito spielte in Real Madrids Jugend.",
+      "fun_fact_es": "Nombrados por un juego de cartas, este trío pop-punk madrileño fue una de las bandas más exitosas de los 2000. Álvaro Benito jugó en la cantera del Real Madrid.",
+      "fun_fact_fr": "Nommés d'après un jeu de cartes, ce trio pop-punk madrilène fut l'un des plus grands groupes des années 2000. Álvaro Benito jouait au Real Madrid.",
       "uri_apple_music": "applemusic://track/151630092",
       "uri_youtube_music": "https://music.youtube.com/watch?v=b4YVijo8UFA",
       "uri_tidal": "tidal://track/340902",
-      "fun_fact_nl": "Dit Madrileense pop-punk trio, vernoemd naar een kaartspel (varkensneus), werd een van de succesvolste Spaanse bands van de jaren 2000. Frontman \u00c1lvaro Benito is een voormalig jeugdspeler van Real Madrid.",
-      "awards_nl": []
+      "fun_fact_nl": "Dit Madrileense pop-punk trio, vernoemd naar een kaartspel (varkensneus), werd een van de succesvolste Spaanse bands van de jaren 2000. Frontman Álvaro Benito is een voormalig jeugdspeler van Real Madrid.",
+      "awards_nl": [],
+      "isrc": "ES7210611901",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1519029259",
+        "de": "applemusic://track/1519029259",
+        "gb": "applemusic://track/1519029259",
+        "fr": "applemusic://track/1519029259",
+        "es": "applemusic://track/1519029259",
+        "nl": "applemusic://track/1519029259",
+        "it": "applemusic://track/1519029259"
+      }
     },
     {
       "year": 1950,
       "uri": "spotify:track:3jkVN9ccFjs6HlZD4RtNC8",
       "artist": "Billos Caracas Boys",
       "alt_artists": [
-        "Los Mel\u00f3dicos",
+        "Los Melódicos",
         "Compay Segundo",
-        "Beny Mor\u00e9",
+        "Beny Moré",
         "Celia Cruz"
       ],
-      "title": "Se Va El Caim\u00e1n",
+      "title": "Se Va El Caimán",
       "chart_info": {
         "billboard_peak": null,
         "uk_peak": null,
@@ -2121,22 +2871,32 @@
       },
       "certifications": [],
       "awards": [],
-      "fun_fact": "This Venezuelan-Dominican big band turned a Colombian folk song into a Latin dance standard. 'Se Va El Caim\u00e1n' has been played at every Latin party for 70+ years.",
-      "fun_fact_de": "Diese venezolanisch-dominikanische Big Band machte ein kolumbianisches Volkslied zum Latin-Dance-Standard. Seit \u00fcber 70 Jahren auf jeder lateinamerikanischen Party.",
-      "fun_fact_es": "Esta big band venezolano-dominicana convirti\u00f3 una canci\u00f3n folcl\u00f3rica colombiana en un est\u00e1ndar del baile latino. Suena en cada fiesta latina desde hace m\u00e1s de 70 a\u00f1os.",
-      "fun_fact_fr": "Ce big band v\u00e9n\u00e9zu\u00e9lo-dominicain a transform\u00e9 un chant folklorique colombien en standard de danse latine. Jou\u00e9 \u00e0 chaque f\u00eate latine depuis 70+ ans.",
+      "fun_fact": "This Venezuelan-Dominican big band turned a Colombian folk song into a Latin dance standard. 'Se Va El Caimán' has been played at every Latin party for 70+ years.",
+      "fun_fact_de": "Diese venezolanisch-dominikanische Big Band machte ein kolumbianisches Volkslied zum Latin-Dance-Standard. Seit über 70 Jahren auf jeder lateinamerikanischen Party.",
+      "fun_fact_es": "Esta big band venezolano-dominicana convirtió una canción folclórica colombiana en un estándar del baile latino. Suena en cada fiesta latina desde hace más de 70 años.",
+      "fun_fact_fr": "Ce big band vénézuélo-dominicain a transformé un chant folklorique colombien en standard de danse latine. Joué à chaque fête latine depuis 70+ ans.",
       "uri_apple_music": "applemusic://track/530174656",
       "uri_youtube_music": "https://music.youtube.com/watch?v=xVvsuvAhcg8",
       "uri_tidal": "tidal://track/37191622",
-      "fun_fact_nl": "Deze Venezolaans-Dominicaanse bigband veranderde een Colombiaans volksliedje in een latin dance standard. Se Va El Caim\u00e1n' wordt al meer dan 70 jaar op elk latinfeest gespeeld.",
-      "awards_nl": []
+      "fun_fact_nl": "Deze Venezolaans-Dominicaanse bigband veranderde een Colombiaans volksliedje in een latin dance standard. Se Va El Caimán' wordt al meer dan 70 jaar op elk latinfeest gespeeld.",
+      "awards_nl": [],
+      "isrc": "USJ3V1181222",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/530174656",
+        "de": "applemusic://track/530174656",
+        "gb": "applemusic://track/530174656",
+        "fr": "applemusic://track/530174656",
+        "es": "applemusic://track/530174656",
+        "nl": "applemusic://track/530174656",
+        "it": "applemusic://track/530174656"
+      }
     },
     {
       "year": 1989,
       "uri": "spotify:track:2N2aaDKT2x3p4z8NLpI8Cj",
       "artist": "Camaron De La Isla",
       "alt_artists": [
-        "Paco de Luc\u00eda",
+        "Paco de Lucía",
         "Tomatito",
         "Enrique Morente",
         "Ketama"
@@ -2149,22 +2909,32 @@
       },
       "certifications": [],
       "awards": [],
-      "fun_fact": "Camar\u00f3n de la Isla is universally considered the greatest flamenco singer of all time. 'Soy Gitano' with the Royal Philharmonic Orchestra was a groundbreaking fusion of flamenco and symphonic music.",
-      "fun_fact_de": "Camar\u00f3n de la Isla gilt als gr\u00f6\u00dfter Flamenco-S\u00e4nger aller Zeiten. 'Soy Gitano' mit dem Royal Philharmonic Orchestra war eine bahnbrechende Fusion.",
-      "fun_fact_es": "Camar\u00f3n de la Isla es considerado un\u00e1nimemente el mayor cantaor flamenco de la historia. 'Soy Gitano' con la Royal Philharmonic fue una fusi\u00f3n revolucionaria.",
-      "fun_fact_fr": "Camar\u00f3n de la Isla est universellement consid\u00e9r\u00e9 comme le plus grand chanteur de flamenco. 'Soy Gitano' avec le Royal Philharmonic fut une fusion r\u00e9volutionnaire.",
+      "fun_fact": "Camarón de la Isla is universally considered the greatest flamenco singer of all time. 'Soy Gitano' with the Royal Philharmonic Orchestra was a groundbreaking fusion of flamenco and symphonic music.",
+      "fun_fact_de": "Camarón de la Isla gilt als größter Flamenco-Sänger aller Zeiten. 'Soy Gitano' mit dem Royal Philharmonic Orchestra war eine bahnbrechende Fusion.",
+      "fun_fact_es": "Camarón de la Isla es considerado unánimemente el mayor cantaor flamenco de la historia. 'Soy Gitano' con la Royal Philharmonic fue una fusión revolucionaria.",
+      "fun_fact_fr": "Camarón de la Isla est universellement considéré comme le plus grand chanteur de flamenco. 'Soy Gitano' avec le Royal Philharmonic fut une fusion révolutionnaire.",
       "uri_apple_music": "applemusic://track/1443635392",
       "uri_youtube_music": "https://music.youtube.com/watch?v=jhIIO4mELbs",
       "uri_tidal": "tidal://track/3598038",
-      "fun_fact_nl": "Camar\u00f3n de la Isla wordt algemeen beschouwd als de grootste flamencozanger aller tijden. Soy Gitano' met het Royal Philharmonic Orchestra was een baanbrekende fusie van flamenco en symfonische muziek.",
-      "awards_nl": []
+      "fun_fact_nl": "Camarón de la Isla wordt algemeen beschouwd als de grootste flamencozanger aller tijden. Soy Gitano' met het Royal Philharmonic Orchestra was een baanbrekende fusie van flamenco en symfonische muziek.",
+      "awards_nl": [],
+      "isrc": "ES5700400640",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1443635392",
+        "de": "applemusic://track/1443635392",
+        "gb": "applemusic://track/1443635392",
+        "fr": "applemusic://track/1443635392",
+        "es": "applemusic://track/1443635392",
+        "nl": "applemusic://track/1443635392",
+        "it": null
+      }
     },
     {
       "year": 2021,
       "uri": "spotify:track:5xiAfKzE3mbxYbOkUZPR11",
       "artist": "C. Tangana, NATHY PELUSO",
       "alt_artists": [
-        "ROSAL\u00cdA",
+        "ROSALÍA",
         "Bad Gyal",
         "Rels B",
         "Dellafuente"
@@ -2177,22 +2947,32 @@
       },
       "certifications": [],
       "awards": [],
-      "fun_fact": "C. Tangana (Ant\u00f3n \u00c1lvarez) reinvented Spanish pop with 'El Madrile\u00f1o' \u2014 mixing reggaeton, flamenco, and bossa nova. The 'Ateo' video in a cathedral caused national controversy.",
-      "fun_fact_de": "C. Tangana revolutionierte mit 'El Madrile\u00f1o' den spanischen Pop. Das 'Ateo'-Video in einer Kathedrale sorgte f\u00fcr nationale Kontroverse.",
-      "fun_fact_es": "C. Tangana reinvent\u00f3 el pop espa\u00f1ol con 'El Madrile\u00f1o'. El v\u00eddeo de 'Ateo' en una catedral caus\u00f3 pol\u00e9mica nacional.",
-      "fun_fact_fr": "C. Tangana a r\u00e9invent\u00e9 la pop espagnole avec 'El Madrile\u00f1o'. Le clip d'Ateo' dans une cath\u00e9drale a caus\u00e9 une controverse nationale.",
+      "fun_fact": "C. Tangana (Antón Álvarez) reinvented Spanish pop with 'El Madrileño' — mixing reggaeton, flamenco, and bossa nova. The 'Ateo' video in a cathedral caused national controversy.",
+      "fun_fact_de": "C. Tangana revolutionierte mit 'El Madrileño' den spanischen Pop. Das 'Ateo'-Video in einer Kathedrale sorgte für nationale Kontroverse.",
+      "fun_fact_es": "C. Tangana reinventó el pop español con 'El Madrileño'. El vídeo de 'Ateo' en una catedral causó polémica nacional.",
+      "fun_fact_fr": "C. Tangana a réinventé la pop espagnole avec 'El Madrileño'. Le clip d'Ateo' dans une cathédrale a causé une controverse nationale.",
       "uri_apple_music": "applemusic://track/1588048905",
       "uri_youtube_music": "https://music.youtube.com/watch?v=Y9WJOopLYBQ",
       "uri_tidal": "tidal://track/199322248",
-      "fun_fact_nl": "C. Tangana (Ant\u00f3n \u00c1lvarez) vond de Spaanse pop opnieuw uit met 'El Madrile\u00f1o' - een mix van reggaeton, flamenco en bossanova. De video 'Ateo' in een kathedraal veroorzaakte nationale controverse.",
-      "awards_nl": []
+      "fun_fact_nl": "C. Tangana (Antón Álvarez) vond de Spaanse pop opnieuw uit met 'El Madrileño' - een mix van reggaeton, flamenco en bossanova. De video 'Ateo' in een kathedraal veroorzaakte nationale controverse.",
+      "awards_nl": [],
+      "isrc": "ES5022101546",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1658144922",
+        "de": "applemusic://track/1658144922",
+        "gb": "applemusic://track/1658144922",
+        "fr": "applemusic://track/1658144922",
+        "es": "applemusic://track/1658144922",
+        "nl": "applemusic://track/1658144922",
+        "it": "applemusic://track/1658144922"
+      }
     },
     {
       "year": 2002,
       "uri": "spotify:track:0gdt218D74akk9AqMlbc45",
       "artist": "Paulina Rubio",
       "alt_artists": [
-        "Thal\u00eda",
+        "Thalía",
         "Shakira",
         "Gloria Trevi",
         "Belinda"
@@ -2206,24 +2986,34 @@
       "certifications": [],
       "awards": [],
       "fun_fact": "Mexico's 'Queen of Latin Pop' (ex-Timbiriche). Paulina Rubio was one of the first Latin artists to successfully cross over to the US pop market in the early 2000s.",
-      "fun_fact_de": "Mexikos 'K\u00f6nigin des Latin Pop' (ex-Timbiriche). Eine der ersten lateinamerikanischen K\u00fcnstlerinnen, die in den USA erfolgreich wurden.",
-      "fun_fact_es": "La 'Reina del Pop Latino' de M\u00e9xico (ex Timbiriche). Una de las primeras artistas latinas en cruzar exitosamente al mercado pop estadounidense.",
-      "fun_fact_fr": "La 'Reine du Pop Latin' du Mexique (ex-Timbiriche). L'une des premi\u00e8res artistes latines \u00e0 percer sur le march\u00e9 pop am\u00e9ricain.",
+      "fun_fact_de": "Mexikos 'Königin des Latin Pop' (ex-Timbiriche). Eine der ersten lateinamerikanischen Künstlerinnen, die in den USA erfolgreich wurden.",
+      "fun_fact_es": "La 'Reina del Pop Latino' de México (ex Timbiriche). Una de las primeras artistas latinas en cruzar exitosamente al mercado pop estadounidense.",
+      "fun_fact_fr": "La 'Reine du Pop Latin' du Mexique (ex-Timbiriche). L'une des premières artistes latines à percer sur le marché pop américain.",
       "uri_apple_music": "applemusic://track/1452856259",
       "uri_youtube_music": "https://music.youtube.com/watch?v=PLLBHlGxFCA",
       "uri_tidal": "tidal://track/8056799",
       "fun_fact_nl": "Mexico's 'koningin van de latin pop' (ex-Timbiriche). Paulina Rubio was een van de eerste Latin-artiesten die begin jaren 2000 met succes de overstap maakte naar de Amerikaanse popmarkt.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "ES5700900207",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1705322815",
+        "de": "applemusic://track/1705322815",
+        "gb": "applemusic://track/1705322815",
+        "fr": "applemusic://track/1705322815",
+        "es": "applemusic://track/1705322815",
+        "nl": "applemusic://track/1705322815",
+        "it": "applemusic://track/1705322815"
+      }
     },
     {
       "year": 2000,
       "uri": "spotify:track:3Uht8v2qRF6sDNLSPhLQ2d",
-      "artist": "Ni\u00f1a Pastori",
+      "artist": "Niña Pastori",
       "alt_artists": [
         "Rosario",
         "Estrella Morente",
         "Lola Flores",
-        "Ni\u00f1a de la Puebla"
+        "Niña de la Puebla"
       ],
       "title": "Cartita de Amor",
       "chart_info": {
@@ -2233,15 +3023,25 @@
       },
       "certifications": [],
       "awards": [],
-      "fun_fact": "Ni\u00f1a Pastori from C\u00e1diz was discovered by Camar\u00f3n de la Isla himself at age 5 and blessed by the maestro. She became one of the greatest female flamenco voices of her generation.",
-      "fun_fact_de": "Ni\u00f1a Pastori aus C\u00e1diz wurde mit 5 Jahren von Camar\u00f3n de la Isla selbst entdeckt und gesegnet.",
-      "fun_fact_es": "Ni\u00f1a Pastori de C\u00e1diz fue descubierta por el propio Camar\u00f3n de la Isla con 5 a\u00f1os. Se convirti\u00f3 en una de las mayores voces flamencas femeninas.",
-      "fun_fact_fr": "Ni\u00f1a Pastori de Cadix a \u00e9t\u00e9 d\u00e9couverte par Camar\u00f3n de la Isla lui-m\u00eame \u00e0 5 ans. Elle est devenue l'une des plus grandes voix f\u00e9minines du flamenco.",
+      "fun_fact": "Niña Pastori from Cádiz was discovered by Camarón de la Isla himself at age 5 and blessed by the maestro. She became one of the greatest female flamenco voices of her generation.",
+      "fun_fact_de": "Niña Pastori aus Cádiz wurde mit 5 Jahren von Camarón de la Isla selbst entdeckt und gesegnet.",
+      "fun_fact_es": "Niña Pastori de Cádiz fue descubierta por el propio Camarón de la Isla con 5 años. Se convirtió en una de las mayores voces flamencas femeninas.",
+      "fun_fact_fr": "Niña Pastori de Cadix a été découverte par Camarón de la Isla lui-même à 5 ans. Elle est devenue l'une des plus grandes voix féminines du flamenco.",
       "uri_apple_music": "applemusic://track/276078076",
       "uri_youtube_music": "https://music.youtube.com/watch?v=HHhPsOF2j1c",
       "uri_tidal": "tidal://track/60035550",
-      "fun_fact_nl": "Ni\u00f1a Pastori uit C\u00e1diz werd op 5-jarige leeftijd ontdekt door Camar\u00f3n de la Isla zelf en gezegend door de maestro. Ze werd een van de grootste vrouwelijke flamencostemmen van haar generatie.",
-      "awards_nl": []
+      "fun_fact_nl": "Niña Pastori uit Cádiz werd op 5-jarige leeftijd ontdekt door Camarón de la Isla zelf en gezegend door de maestro. Ze werd een van de grootste vrouwelijke flamencostemmen van haar generatie.",
+      "awards_nl": [],
+      "isrc": "ES5029800190",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/276078076",
+        "de": "applemusic://track/276078076",
+        "gb": "applemusic://track/276078076",
+        "fr": "applemusic://track/276078076",
+        "es": "applemusic://track/276078076",
+        "nl": "applemusic://track/276078076",
+        "it": "applemusic://track/276078076"
+      }
     },
     {
       "year": 2021,
@@ -2250,10 +3050,10 @@
       "alt_artists": [
         "Dvicio",
         "Taburete",
-        "Sebasti\u00e1n Yatra",
+        "Sebastián Yatra",
         "Carlos Vives"
       ],
-      "title": "A D\u00f3nde Vamos",
+      "title": "A Dónde Vamos",
       "chart_info": {
         "billboard_peak": null,
         "uk_peak": null,
@@ -2261,15 +3061,25 @@
       },
       "certifications": [],
       "awards": [],
-      "fun_fact": "Colombian band that became Spain's adopted sons \u2014 more popular in Spain than in Colombia. Their acoustic Latin pop sound resonated deeply with Spanish millennial audiences.",
-      "fun_fact_de": "Kolumbianische Band, die in Spanien popul\u00e4rer wurde als in Kolumbien. Ihr akustischer Latin-Pop traf den Nerv des spanischen Millennial-Publikums.",
-      "fun_fact_es": "Banda colombiana que se convirti\u00f3 en hijos adoptivos de Espa\u00f1a \u2014 m\u00e1s populares en Espa\u00f1a que en Colombia.",
-      "fun_fact_fr": "Groupe colombien devenu les fils adoptifs de l'Espagne \u2014 plus populaires en Espagne qu'en Colombie.",
+      "fun_fact": "Colombian band that became Spain's adopted sons — more popular in Spain than in Colombia. Their acoustic Latin pop sound resonated deeply with Spanish millennial audiences.",
+      "fun_fact_de": "Kolumbianische Band, die in Spanien populärer wurde als in Kolumbien. Ihr akustischer Latin-Pop traf den Nerv des spanischen Millennial-Publikums.",
+      "fun_fact_es": "Banda colombiana que se convirtió en hijos adoptivos de España — más populares en España que en Colombia.",
+      "fun_fact_fr": "Groupe colombien devenu les fils adoptifs de l'Espagne — plus populaires en Espagne qu'en Colombie.",
       "uri_apple_music": "applemusic://track/1574879730",
       "uri_youtube_music": "https://music.youtube.com/watch?v=FO3Ks1J2A5w",
       "uri_tidal": "tidal://track/120964882",
       "fun_fact_nl": "Colombiaanse band die de geadopteerde zonen van Spanje werden - populairder in Spanje dan in Colombia. Hun akoestische latin popgeluid vond een diepe weerklank bij het Spaanse duizendjarige publiek.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "ES5701900845",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1811167390",
+        "de": "applemusic://track/1811167390",
+        "gb": "applemusic://track/1811167390",
+        "fr": "applemusic://track/1811167390",
+        "es": "applemusic://track/1811167390",
+        "nl": "applemusic://track/1811167390",
+        "it": "applemusic://track/1811167390"
+      }
     },
     {
       "year": 1996,
@@ -2278,7 +3088,7 @@
       "alt_artists": [
         "Lola Flores",
         "Ketama",
-        "Ni\u00f1a Pastori",
+        "Niña Pastori",
         "Antonio Flores"
       ],
       "title": "Que Bonito",
@@ -2289,15 +3099,25 @@
       },
       "certifications": [],
       "awards": [],
-      "fun_fact": "Rosario Flores \u2014 daughter of legends Lola Flores and El Pesca\u00edlla, sister of the late Antonio Flores. She merged flamenco with pop and became one of Spain's most iconic female artists.",
-      "fun_fact_de": "Rosario Flores \u2014 Tochter der Legenden Lola Flores und El Pesca\u00edlla. Sie verschmolz Flamenco mit Pop und wurde eine der ikonischsten K\u00fcnstlerinnen Spaniens.",
-      "fun_fact_es": "Rosario Flores \u2014 hija de las leyendas Lola Flores y El Pesca\u00edlla. Fusion\u00f3 flamenco con pop y se convirti\u00f3 en una de las artistas m\u00e1s ic\u00f3nicas de Espa\u00f1a.",
-      "fun_fact_fr": "Rosario Flores \u2014 fille des l\u00e9gendes Lola Flores et El Pesca\u00edlla. Elle a fusionn\u00e9 flamenco et pop, devenant l'une des artistes les plus iconiques d'Espagne.",
+      "fun_fact": "Rosario Flores — daughter of legends Lola Flores and El Pescaílla, sister of the late Antonio Flores. She merged flamenco with pop and became one of Spain's most iconic female artists.",
+      "fun_fact_de": "Rosario Flores — Tochter der Legenden Lola Flores und El Pescaílla. Sie verschmolz Flamenco mit Pop und wurde eine der ikonischsten Künstlerinnen Spaniens.",
+      "fun_fact_es": "Rosario Flores — hija de las leyendas Lola Flores y El Pescaílla. Fusionó flamenco con pop y se convirtió en una de las artistas más icónicas de España.",
+      "fun_fact_fr": "Rosario Flores — fille des légendes Lola Flores et El Pescaílla. Elle a fusionné flamenco et pop, devenant l'une des artistes les plus iconiques d'Espagne.",
       "uri_apple_music": "applemusic://track/672554370",
       "uri_youtube_music": "https://music.youtube.com/watch?v=F1lf6kJzQWM",
       "uri_tidal": "tidal://track/3007112",
-      "fun_fact_nl": "Rosario Flores - dochter van legendes Lola Flores en El Pesca\u00edlla, zus van wijlen Antonio Flores. Ze versmolt flamenco met pop en werd een van de meest iconische vrouwelijke artiesten van Spanje.",
-      "awards_nl": []
+      "fun_fact_nl": "Rosario Flores - dochter van legendes Lola Flores en El Pescaílla, zus van wijlen Antonio Flores. Ze versmolt flamenco met pop en werd een van de meest iconische vrouwelijke artiesten van Spanje.",
+      "awards_nl": [],
+      "isrc": "ES5119600071",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/268499369",
+        "de": "applemusic://track/268499369",
+        "gb": "applemusic://track/268499369",
+        "fr": "applemusic://track/268499369",
+        "es": "applemusic://track/1489854458",
+        "nl": "applemusic://track/268499369",
+        "it": "applemusic://track/268499369"
+      }
     },
     {
       "year": 1958,
@@ -2318,13 +3138,23 @@
       "awards": [],
       "fun_fact": "Sara Montiel was Spain's first international film star, working in Hollywood alongside Gary Cooper and Burt Lancaster. 'Fumando Espero' became her iconic number, still imitated today.",
       "fun_fact_de": "Sara Montiel war Spaniens erster internationaler Filmstar, arbeitete mit Gary Cooper und Burt Lancaster. 'Fumando Espero' ist ihre Ikonen-Nummer.",
-      "fun_fact_es": "Sara Montiel fue la primera estrella de cine internacional de Espa\u00f1a, trabaj\u00f3 con Gary Cooper y Burt Lancaster. 'Fumando Espero' es su n\u00famero ic\u00f3nico.",
-      "fun_fact_fr": "Sara Montiel fut la premi\u00e8re star de cin\u00e9ma internationale d'Espagne, travaillant avec Gary Cooper et Burt Lancaster. 'Fumando Espero' reste son num\u00e9ro iconique.",
+      "fun_fact_es": "Sara Montiel fue la primera estrella de cine internacional de España, trabajó con Gary Cooper y Burt Lancaster. 'Fumando Espero' es su número icónico.",
+      "fun_fact_fr": "Sara Montiel fut la première star de cinéma internationale d'Espagne, travaillant avec Gary Cooper et Burt Lancaster. 'Fumando Espero' reste son numéro iconique.",
       "uri_apple_music": "applemusic://track/437565070",
       "uri_youtube_music": "https://music.youtube.com/watch?v=qqOdh7g7DCs",
       "uri_tidal": "tidal://track/506029",
-      "fun_fact_nl": "Sara Montiel was de eerste internationale filmster van Spanje. Ze werkte in Hollywood naast Gary Cooper en Burt Lancaster. Fumando Espero' werd haar iconische nummer, dat vandaag de dag nog steeds ge\u00efmiteerd wordt.",
-      "awards_nl": []
+      "fun_fact_nl": "Sara Montiel was de eerste internationale filmster van Spanje. Ze werkte in Hollywood naast Gary Cooper en Burt Lancaster. Fumando Espero' werd haar iconische nummer, dat vandaag de dag nog steeds geïmiteerd wordt.",
+      "awards_nl": [],
+      "isrc": "USA371276942",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/437565070",
+        "de": "applemusic://track/437565070",
+        "gb": "applemusic://track/437565070",
+        "fr": "applemusic://track/437565070",
+        "es": "applemusic://track/437565070",
+        "nl": "applemusic://track/437565070",
+        "it": "applemusic://track/437565070"
+      }
     },
     {
       "year": 1984,
@@ -2334,7 +3164,7 @@
         "Siniestro Total",
         "Los Toreros Muertos",
         "Hombres G",
-        "Par\u00e1lisis Permanente"
+        "Parálisis Permanente"
       ],
       "title": "El imperio contraataca",
       "chart_info": {
@@ -2344,15 +3174,25 @@
       },
       "certifications": [],
       "awards": [],
-      "fun_fact": "Los Nikis were Spain's Ramones \u2014 pioneers of Spanish punk-pop with humorous sci-fi and B-movie themed lyrics. Essential band of 'La Movida Madrile\u00f1a'.",
-      "fun_fact_de": "Los Nikis waren Spaniens Ramones \u2014 Pioniere des spanischen Punk-Pop mit humorvollen Science-Fiction-Texten. Essenziell f\u00fcr La Movida.",
-      "fun_fact_es": "Los Nikis fueron los Ramones espa\u00f1oles \u2014 pioneros del punk-pop espa\u00f1ol con letras humor\u00edsticas de ciencia ficci\u00f3n. Esenciales en La Movida.",
-      "fun_fact_fr": "Los Nikis \u00e9taient les Ramones espagnols \u2014 pionniers du punk-pop espagnol avec des paroles humoristiques de science-fiction. Essentiels de La Movida.",
+      "fun_fact": "Los Nikis were Spain's Ramones — pioneers of Spanish punk-pop with humorous sci-fi and B-movie themed lyrics. Essential band of 'La Movida Madrileña'.",
+      "fun_fact_de": "Los Nikis waren Spaniens Ramones — Pioniere des spanischen Punk-Pop mit humorvollen Science-Fiction-Texten. Essenziell für La Movida.",
+      "fun_fact_es": "Los Nikis fueron los Ramones españoles — pioneros del punk-pop español con letras humorísticas de ciencia ficción. Esenciales en La Movida.",
+      "fun_fact_fr": "Los Nikis étaient les Ramones espagnols — pionniers du punk-pop espagnol avec des paroles humoristiques de science-fiction. Essentiels de La Movida.",
       "uri_apple_music": "applemusic://track/110722294",
       "uri_youtube_music": "https://music.youtube.com/watch?v=71m3JuHKngY",
       "uri_tidal": "tidal://track/2119322",
-      "fun_fact_nl": "Los Nikis waren de Ramones van Spanje - pioniers van de Spaanse punkpop met humoristische sciencefiction- en B-filmteksten. Essenti\u00eble band van 'La Movida Madrile\u00f1a'.",
-      "awards_nl": []
+      "fun_fact_nl": "Los Nikis waren de Ramones van Spanje - pioniers van de Spaanse punkpop met humoristische sciencefiction- en B-filmteksten. Essentiële band van 'La Movida Madrileña'.",
+      "awards_nl": [],
+      "isrc": "ES5018534008",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/110722294",
+        "de": "applemusic://track/110722294",
+        "gb": "applemusic://track/110722294",
+        "fr": "applemusic://track/110722294",
+        "es": "applemusic://track/110722294",
+        "nl": "applemusic://track/110722294",
+        "it": "applemusic://track/110722294"
+      }
     },
     {
       "year": 1998,
@@ -2360,7 +3200,7 @@
       "artist": "Camela",
       "alt_artists": [
         "Los Calis",
-        "\u00c1ngeles de Charli",
+        "Ángeles de Charli",
         "El Arrebato",
         "Andy y Lucas"
       ],
@@ -2372,15 +3212,25 @@
       },
       "certifications": [],
       "awards": [],
-      "fun_fact": "Camela are Spain's best-selling techno-flamenco duo with 8+ million records sold. Dismissed by critics but adored by millions \u2014 the ultimate guilty pleasure of Spanish music.",
-      "fun_fact_de": "Camela sind Spaniens meistverkauftes Techno-Flamenco-Duo mit \u00fcber 8 Millionen verkauften Platten. Von Kritikern ignoriert, von Millionen geliebt.",
-      "fun_fact_es": "Camela son el d\u00fao de tecno-flamenco m\u00e1s vendido de Espa\u00f1a con m\u00e1s de 8 millones de discos. Ignorados por la cr\u00edtica pero adorados por millones.",
-      "fun_fact_fr": "Camela est le duo techno-flamenco le plus vendu d'Espagne avec 8+ millions de disques. Ignor\u00e9s par la critique mais ador\u00e9s par des millions.",
+      "fun_fact": "Camela are Spain's best-selling techno-flamenco duo with 8+ million records sold. Dismissed by critics but adored by millions — the ultimate guilty pleasure of Spanish music.",
+      "fun_fact_de": "Camela sind Spaniens meistverkauftes Techno-Flamenco-Duo mit über 8 Millionen verkauften Platten. Von Kritikern ignoriert, von Millionen geliebt.",
+      "fun_fact_es": "Camela son el dúo de tecno-flamenco más vendido de España con más de 8 millones de discos. Ignorados por la crítica pero adorados por millones.",
+      "fun_fact_fr": "Camela est le duo techno-flamenco le plus vendu d'Espagne avec 8+ millions de disques. Ignorés par la critique mais adorés par des millions.",
       "uri_apple_music": "applemusic://track/483833736",
       "uri_youtube_music": "https://music.youtube.com/watch?v=DLm7rrCF7iU",
       "uri_tidal": "tidal://track/11645466",
       "fun_fact_nl": "Camela is het best verkopende techno-flamenco duo van Spanje met meer dan 8 miljoen verkochte platen. Afgewezen door critici maar aanbeden door miljoenen - de ultieme guilty pleasure van de Spaanse muziek.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "ES5630700021",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/251442538",
+        "de": "applemusic://track/251442538",
+        "gb": "applemusic://track/251442538",
+        "fr": "applemusic://track/251442538",
+        "es": "applemusic://track/251442538",
+        "nl": "applemusic://track/251442538",
+        "it": "applemusic://track/251442538"
+      }
     },
     {
       "year": 1988,
@@ -2403,12 +3253,22 @@
       "fun_fact": "Basque punk-rock band from Vitoria-Gasteiz who mixed punk energy with humor and social commentary. Part of the vibrant 'Rock Radikal Vasco' movement of the 80s.",
       "fun_fact_de": "Baskische Punk-Rock-Band aus Vitoria-Gasteiz, Teil der lebhaften 'Rock Radikal Vasco'-Bewegung der 80er.",
       "fun_fact_es": "Banda punk-rock vasca de Vitoria-Gasteiz, parte del vibrante movimiento 'Rock Radical Vasco' de los 80.",
-      "fun_fact_fr": "Groupe punk-rock basque de Vitoria-Gasteiz, partie du vibrant mouvement 'Rock Radical Vasco' des ann\u00e9es 80.",
+      "fun_fact_fr": "Groupe punk-rock basque de Vitoria-Gasteiz, partie du vibrant mouvement 'Rock Radical Vasco' des années 80.",
       "uri_apple_music": "applemusic://track/521551606",
       "uri_youtube_music": "https://music.youtube.com/watch?v=Dl5A9xBKCgw",
       "uri_tidal": "tidal://track/90473142",
       "fun_fact_nl": "Baskische punkrockband uit Vitoria-Gasteiz die punkenergie mengde met humor en sociaal commentaar. Deel van de levendige 'Rock Radikal Vasco' beweging van de jaren 80.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "ES5018987000",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1237074598",
+        "de": "applemusic://track/1237074598",
+        "gb": "applemusic://track/1237074598",
+        "fr": "applemusic://track/1237074598",
+        "es": "applemusic://track/1237074598",
+        "nl": "applemusic://track/1237074598",
+        "it": "applemusic://track/1237074598"
+      }
     },
     {
       "year": 1977,
@@ -2416,8 +3276,8 @@
       "artist": "Carlos Mejia Godoy",
       "alt_artists": [
         "Elsa Baeza",
-        "Silvio Rodr\u00edguez",
-        "Pablo Milan\u00e9s",
+        "Silvio Rodríguez",
+        "Pablo Milanés",
         "Viglietti"
       ],
       "title": "Son tus Perjumenes Mujer",
@@ -2430,23 +3290,33 @@
       "awards": [],
       "fun_fact": "Nicaraguan singer-songwriter who wrote the anthem of the Sandinista revolution. His music blends folk, protest song and Central American rhythms in a way that resonated across the Spanish-speaking world.",
       "fun_fact_de": "Nicaraguanischer Liedermacher, der die Hymne der sandinistischen Revolution schrieb. Seine Musik verbindet Folk und Protestlied.",
-      "fun_fact_es": "Cantautor nicarag\u00fcense que escribi\u00f3 el himno de la revoluci\u00f3n sandinista. Su m\u00fasica fusiona folclore, canci\u00f3n protesta y ritmos centroamericanos.",
-      "fun_fact_fr": "Auteur-compositeur nicaraguayen qui a \u00e9crit l'hymne de la r\u00e9volution sandiniste. Sa musique m\u00eale folk, chanson contestataire et rythmes centram\u00e9ricains.",
+      "fun_fact_es": "Cantautor nicaragüense que escribió el himno de la revolución sandinista. Su música fusiona folclore, canción protesta y ritmos centroamericanos.",
+      "fun_fact_fr": "Auteur-compositeur nicaraguayen qui a écrit l'hymne de la révolution sandiniste. Sa musique mêle folk, chanson contestataire et rythmes centraméricains.",
       "uri_apple_music": "applemusic://track/299706392",
       "uri_youtube_music": "https://music.youtube.com/watch?v=cDtwkdFN9Ik",
       "uri_tidal": "tidal://track/153082566",
       "fun_fact_nl": "Nicaraguaanse singer-songwriter die het volkslied van de Sandinistische revolutie schreef. Zijn muziek mengt folk, protestliederen en Midden-Amerikaanse ritmes op een manier die weerklank vond in de Spaanstalige wereld.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "ES5117700035",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/299706392",
+        "de": "applemusic://track/299706392",
+        "gb": "applemusic://track/299706392",
+        "fr": "applemusic://track/299706392",
+        "es": "applemusic://track/299706392",
+        "nl": "applemusic://track/299706392",
+        "it": "applemusic://track/299706392"
+      }
     },
     {
       "year": 1985,
       "uri": "spotify:track:73Bs0g0AbbUeQczbeUkyb0",
-      "artist": "Ana Bel\u00e9n",
+      "artist": "Ana Belén",
       "alt_artists": [
         "Luz Casal",
-        "Roc\u00edo D\u00farcal",
+        "Rocío Dúrcal",
         "Mocedades",
-        "Mar\u00eda Jim\u00e9nez"
+        "María Jiménez"
       ],
       "title": "Derroche",
       "chart_info": {
@@ -2456,20 +3326,30 @@
       },
       "certifications": [],
       "awards": [],
-      "fun_fact": "Ana Bel\u00e9n is one of Spain's most celebrated singer-actresses. Married to songwriter V\u00edctor Manuel, she was a key cultural figure in Spain's transition to democracy.",
-      "fun_fact_de": "Ana Bel\u00e9n ist eine der gefeiertsten S\u00e4ngerinnen-Schauspielerinnen Spaniens. Eine Schl\u00fcsselfigur im \u00dcbergang zur Demokratie.",
-      "fun_fact_es": "Ana Bel\u00e9n es una de las cantantes-actrices m\u00e1s celebradas de Espa\u00f1a. Figura clave en la transici\u00f3n espa\u00f1ola a la democracia.",
-      "fun_fact_fr": "Ana Bel\u00e9n est l'une des chanteuses-actrices les plus c\u00e9l\u00e8bres d'Espagne. Figure cl\u00e9 de la transition d\u00e9mocratique espagnole.",
+      "fun_fact": "Ana Belén is one of Spain's most celebrated singer-actresses. Married to songwriter Víctor Manuel, she was a key cultural figure in Spain's transition to democracy.",
+      "fun_fact_de": "Ana Belén ist eine der gefeiertsten Sängerinnen-Schauspielerinnen Spaniens. Eine Schlüsselfigur im Übergang zur Demokratie.",
+      "fun_fact_es": "Ana Belén es una de las cantantes-actrices más celebradas de España. Figura clave en la transición española a la democracia.",
+      "fun_fact_fr": "Ana Belén est l'une des chanteuses-actrices les plus célèbres d'Espagne. Figure clé de la transition démocratique espagnole.",
       "uri_apple_music": "applemusic://track/280269117",
       "uri_youtube_music": "https://music.youtube.com/watch?v=hZI_gfVG6Sw",
       "uri_tidal": "tidal://track/1840478",
-      "fun_fact_nl": "Ana Bel\u00e9n is een van de meest gevierde zangeressen-actrices van Spanje. Ze is getrouwd met liedjesschrijver V\u00edctor Manuel en was een belangrijk cultureel figuur in de overgang van Spanje naar democratie.",
-      "awards_nl": []
+      "fun_fact_nl": "Ana Belén is een van de meest gevierde zangeressen-actrices van Spanje. Ze is getrouwd met liedjesschrijver Víctor Manuel en was een belangrijk cultureel figuur in de overgang van Spanje naar democratie.",
+      "awards_nl": [],
+      "isrc": "ES5029400291",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/280269117",
+        "de": "applemusic://track/280269117",
+        "gb": "applemusic://track/280269117",
+        "fr": "applemusic://track/280269117",
+        "es": "applemusic://track/280269117",
+        "nl": "applemusic://track/280269117",
+        "it": "applemusic://track/280269117"
+      }
     },
     {
       "year": 2000,
       "uri": "spotify:track:40A11dg6RXzfDrwMrw5sED",
-      "artist": "Caf\u00e9 Quijano",
+      "artist": "Café Quijano",
       "alt_artists": [
         "Estopa",
         "Melendi",
@@ -2484,15 +3364,25 @@
       },
       "certifications": [],
       "awards": [],
-      "fun_fact": "Three brothers from Le\u00f3n who blended rumba, pop and bolero into a distinctive sound. 'La taberna del Buda' was one of Spain's biggest hits at the turn of the millennium.",
-      "fun_fact_de": "Drei Br\u00fcder aus Le\u00f3n, die Rumba, Pop und Bolero verschmolzen. 'La taberna del Buda' war einer der gr\u00f6\u00dften Hits der Jahrtausendwende.",
-      "fun_fact_es": "Tres hermanos de Le\u00f3n que fusionaron rumba, pop y bolero. 'La taberna del Buda' fue uno de los mayores \u00e9xitos del cambio de milenio en Espa\u00f1a.",
-      "fun_fact_fr": "Trois fr\u00e8res de Le\u00f3n qui ont m\u00e9lang\u00e9 rumba, pop et bol\u00e9ro. 'La taberna del Buda' fut l'un des plus grands succ\u00e8s du tournant du mill\u00e9naire.",
+      "fun_fact": "Three brothers from León who blended rumba, pop and bolero into a distinctive sound. 'La taberna del Buda' was one of Spain's biggest hits at the turn of the millennium.",
+      "fun_fact_de": "Drei Brüder aus León, die Rumba, Pop und Bolero verschmolzen. 'La taberna del Buda' war einer der größten Hits der Jahrtausendwende.",
+      "fun_fact_es": "Tres hermanos de León que fusionaron rumba, pop y bolero. 'La taberna del Buda' fue uno de los mayores éxitos del cambio de milenio en España.",
+      "fun_fact_fr": "Trois frères de León qui ont mélangé rumba, pop et boléro. 'La taberna del Buda' fut l'un des plus grands succès du tournant du millénaire.",
       "uri_apple_music": "applemusic://track/256623726",
       "uri_youtube_music": "https://music.youtube.com/watch?v=K_mJ1NgqiSk",
       "uri_tidal": "tidal://track/603876",
-      "fun_fact_nl": "Drie broers uit Le\u00f3n die rumba, pop en bolero vermengden tot een eigen geluid. La taberna del Buda' was een van de grootste hits van Spanje rond de millenniumwisseling.",
-      "awards_nl": []
+      "fun_fact_nl": "Drie broers uit León die rumba, pop en bolero vermengden tot een eigen geluid. La taberna del Buda' was een van de grootste hits van Spanje rond de millenniumwisseling.",
+      "awards_nl": [],
+      "isrc": "ES5150131006",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1805834825",
+        "de": "applemusic://track/1805834825",
+        "gb": "applemusic://track/1805834825",
+        "fr": "applemusic://track/1805834825",
+        "es": "applemusic://track/1805834825",
+        "nl": "applemusic://track/1805834825",
+        "it": "applemusic://track/1805834825"
+      }
     },
     {
       "year": 1996,
@@ -2500,11 +3390,11 @@
       "artist": "Rosana",
       "alt_artists": [
         "Luz Casal",
-        "Ana Bel\u00e9n",
+        "Ana Belén",
         "Bebe",
-        "Mal\u00fa"
+        "Malú"
       ],
-      "title": "Si t\u00fa no estas",
+      "title": "Si tú no estas",
       "chart_info": {
         "billboard_peak": null,
         "uk_peak": null,
@@ -2512,15 +3402,25 @@
       },
       "certifications": [],
       "awards": [],
-      "fun_fact": "Canarian singer-songwriter from Lanzarote who became a massive star across Latin America. 'Si t\u00fa no est\u00e1s' was a pan-Hispanic hit that established her as a power ballad queen.",
+      "fun_fact": "Canarian singer-songwriter from Lanzarote who became a massive star across Latin America. 'Si tú no estás' was a pan-Hispanic hit that established her as a power ballad queen.",
       "fun_fact_de": "Kanarische Liedermacherin aus Lanzarote, die in ganz Lateinamerika zum Star wurde.",
-      "fun_fact_es": "Cantautora canaria de Lanzarote que se convirti\u00f3 en estrella en toda Latinoam\u00e9rica. 'Si t\u00fa no est\u00e1s' la estableci\u00f3 como reina de las power ballads.",
-      "fun_fact_fr": "Auteure-compositrice canarienne de Lanzarote devenue star en Am\u00e9rique latine. 'Si t\u00fa no est\u00e1s' l'a \u00e9tablie comme reine des power ballades.",
+      "fun_fact_es": "Cantautora canaria de Lanzarote que se convirtió en estrella en toda Latinoamérica. 'Si tú no estás' la estableció como reina de las power ballads.",
+      "fun_fact_fr": "Auteure-compositrice canarienne de Lanzarote devenue star en Amérique latine. 'Si tú no estás' l'a établie comme reine des power ballades.",
       "uri_apple_music": "applemusic://track/258906537",
       "uri_youtube_music": "https://music.youtube.com/watch?v=sKoK3XnTd3g",
       "uri_tidal": "tidal://track/4089916",
-      "fun_fact_nl": "Canarische singer-songwriter uit Lanzarote die een grote ster werd in heel Latijns-Amerika. Si t\u00fa no est\u00e1s' was een pan-Spaanse hit die haar vestigde als power ballad queen.",
-      "awards_nl": []
+      "fun_fact_nl": "Canarische singer-songwriter uit Lanzarote die een grote ster werd in heel Latijns-Amerika. Si tú no estás' was een pan-Spaanse hit die haar vestigde als power ballad queen.",
+      "awards_nl": [],
+      "isrc": "ES6330300130",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1808370247",
+        "de": "applemusic://track/1808370247",
+        "gb": "applemusic://track/1808370247",
+        "fr": "applemusic://track/1808370247",
+        "es": "applemusic://track/1808370247",
+        "nl": "applemusic://track/1808370247",
+        "it": "applemusic://track/1808370247"
+      }
     },
     {
       "year": 2005,
@@ -2532,7 +3432,7 @@
         "Maldita Nerea",
         "Love of Lesbian"
       ],
-      "title": "Podr\u00eda Ser Peor",
+      "title": "Podría Ser Peor",
       "chart_info": {
         "billboard_peak": null,
         "uk_peak": null,
@@ -2540,20 +3440,30 @@
       },
       "certifications": [],
       "awards": [],
-      "fun_fact": "La Casa Azul is the one-man-band project of Guille Milkyway from Barcelona \u2014 Spain's answer to The Postal Service, blending indie-pop with 80s synth aesthetics.",
-      "fun_fact_de": "La Casa Azul ist das Ein-Mann-Projekt von Guille Milkyway aus Barcelona \u2014 Spaniens Antwort auf The Postal Service.",
-      "fun_fact_es": "La Casa Azul es el proyecto de Guille Milkyway de Barcelona \u2014 la respuesta espa\u00f1ola a The Postal Service, fusionando indie-pop con est\u00e9tica synth de los 80.",
-      "fun_fact_fr": "La Casa Azul est le projet solo de Guille Milkyway de Barcelone \u2014 la r\u00e9ponse espagnole \u00e0 The Postal Service.",
+      "fun_fact": "La Casa Azul is the one-man-band project of Guille Milkyway from Barcelona — Spain's answer to The Postal Service, blending indie-pop with 80s synth aesthetics.",
+      "fun_fact_de": "La Casa Azul ist das Ein-Mann-Projekt von Guille Milkyway aus Barcelona — Spaniens Antwort auf The Postal Service.",
+      "fun_fact_es": "La Casa Azul es el proyecto de Guille Milkyway de Barcelona — la respuesta española a The Postal Service, fusionando indie-pop con estética synth de los 80.",
+      "fun_fact_fr": "La Casa Azul est le projet solo de Guille Milkyway de Barcelone — la réponse espagnole à The Postal Service.",
       "uri_apple_music": "applemusic://track/1166156257",
       "uri_youtube_music": "https://music.youtube.com/watch?v=XXzZ_Lz0XKg",
       "uri_tidal": "tidal://track/418738787",
       "fun_fact_nl": "La Casa Azul is het eenmansproject van Guille Milkyway uit Barcelona - het Spaanse antwoord op The Postal Service, dat indie-pop mengt met jaren 80 synth-esthetiek.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "ES6641600141",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1454366846",
+        "de": "applemusic://track/1454366846",
+        "gb": "applemusic://track/1454366846",
+        "fr": "applemusic://track/1454366846",
+        "es": "applemusic://track/1454366846",
+        "nl": "applemusic://track/1454366846",
+        "it": "applemusic://track/1454366846"
+      }
     },
     {
       "year": 1996,
       "uri": "spotify:track:16ZSrvnyA13Cm55Ab9WkJP",
-      "artist": "Carlos N\u00fa\u00f1ez",
+      "artist": "Carlos Núñez",
       "alt_artists": [
         "Hevia",
         "Luar Na Lubre",
@@ -2568,15 +3478,25 @@
       },
       "certifications": [],
       "awards": [],
-      "fun_fact": "Galician bagpipe virtuoso who brought Celtic-Galician music to international audiences. His debut album 'A Brotherhood of Stars' sold over 1 million copies \u2014 unheard of for folk music.",
-      "fun_fact_de": "Galizischer Dudelsack-Virtuose, der keltisch-galizische Musik international bekannt machte. Sein Deb\u00fct verkaufte sich \u00fcber 1 Million Mal.",
-      "fun_fact_es": "Virtuoso gallego de la gaita que llev\u00f3 la m\u00fasica celta-gallega a audiencias internacionales. Su debut vendi\u00f3 m\u00e1s de 1 mill\u00f3n de copias.",
-      "fun_fact_fr": "Virtuose galicien de la cornemuse qui a fait conna\u00eetre la musique celtique-galicienne au monde. Son premier album s'est vendu \u00e0 plus d'1 million d'exemplaires.",
+      "fun_fact": "Galician bagpipe virtuoso who brought Celtic-Galician music to international audiences. His debut album 'A Brotherhood of Stars' sold over 1 million copies — unheard of for folk music.",
+      "fun_fact_de": "Galizischer Dudelsack-Virtuose, der keltisch-galizische Musik international bekannt machte. Sein Debüt verkaufte sich über 1 Million Mal.",
+      "fun_fact_es": "Virtuoso gallego de la gaita que llevó la música celta-gallega a audiencias internacionales. Su debut vendió más de 1 millón de copias.",
+      "fun_fact_fr": "Virtuose galicien de la cornemuse qui a fait connaître la musique celtique-galicienne au monde. Son premier album s'est vendu à plus d'1 million d'exemplaires.",
       "uri_apple_music": "applemusic://track/1510024485",
       "uri_youtube_music": "https://music.youtube.com/watch?v=inN8ADUafr0",
       "uri_tidal": "tidal://track/138832295",
       "fun_fact_nl": "Galicische doedelzakvirtuoos die Keltisch-Galicische muziek naar een internationaal publiek bracht. Van zijn debuutalbum 'A Brotherhood of Stars' werden meer dan 1 miljoen exemplaren verkocht - ongekend voor folkmuziek.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "ES5020000097",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1675962320",
+        "de": "applemusic://track/1675962320",
+        "gb": "applemusic://track/1675962320",
+        "fr": "applemusic://track/1675962320",
+        "es": "applemusic://track/1675962320",
+        "nl": "applemusic://track/1675962320",
+        "it": "applemusic://track/1675962320"
+      }
     },
     {
       "year": 1973,
@@ -2588,7 +3508,7 @@
         "Raphael",
         "Nino Bravo"
       ],
-      "title": "T\u00f3mame o D\u00e9jame",
+      "title": "Tómame o Déjame",
       "chart_info": {
         "billboard_peak": null,
         "uk_peak": null,
@@ -2596,15 +3516,25 @@
       },
       "certifications": [],
       "awards": [],
-      "fun_fact": "Mocedades from Bilbao represented Spain at Eurovision 1973 with 'Eres T\u00fa', finishing 2nd. The song reached #9 on the US Billboard Hot 100 \u2014 Spain's best-ever showing in America.",
-      "fun_fact_de": "Mocedades aus Bilbao vertraten Spanien beim Eurovision 1973 mit 'Eres T\u00fa' (Platz 2). Der Song erreichte Platz 9 der US Billboard Hot 100.",
-      "fun_fact_es": "Mocedades de Bilbao representaron a Espa\u00f1a en Eurovisi\u00f3n 1973 con 'Eres T\u00fa' (2\u00b0 puesto). La canci\u00f3n lleg\u00f3 al #9 del Billboard Hot 100.",
-      "fun_fact_fr": "Mocedades de Bilbao ont repr\u00e9sent\u00e9 l'Espagne \u00e0 l'Eurovision 1973 avec 'Eres T\u00fa' (2e). La chanson a atteint le #9 du Billboard Hot 100 am\u00e9ricain.",
+      "fun_fact": "Mocedades from Bilbao represented Spain at Eurovision 1973 with 'Eres Tú', finishing 2nd. The song reached #9 on the US Billboard Hot 100 — Spain's best-ever showing in America.",
+      "fun_fact_de": "Mocedades aus Bilbao vertraten Spanien beim Eurovision 1973 mit 'Eres Tú' (Platz 2). Der Song erreichte Platz 9 der US Billboard Hot 100.",
+      "fun_fact_es": "Mocedades de Bilbao representaron a España en Eurovisión 1973 con 'Eres Tú' (2° puesto). La canción llegó al #9 del Billboard Hot 100.",
+      "fun_fact_fr": "Mocedades de Bilbao ont représenté l'Espagne à l'Eurovision 1973 avec 'Eres Tú' (2e). La chanson a atteint le #9 du Billboard Hot 100 américain.",
       "uri_apple_music": "applemusic://track/1055226301",
       "uri_youtube_music": "https://music.youtube.com/watch?v=31NTBffoWWA",
       "uri_tidal": "tidal://track/16777",
-      "fun_fact_nl": "Mocedades uit Bilbao vertegenwoordigde Spanje op Eurovisie 1973 met 'Eres T\u00fa' en eindigde als 2e. Het nummer bereikte #9 in de US Billboard Hot 100 - Spanje's beste optreden ooit in Amerika.",
-      "awards_nl": []
+      "fun_fact_nl": "Mocedades uit Bilbao vertegenwoordigde Spanje op Eurovisie 1973 met 'Eres Tú' en eindigde als 2e. Het nummer bereikte #9 in de US Billboard Hot 100 - Spanje's beste optreden ooit in Amerika.",
+      "awards_nl": [],
+      "isrc": "USA2P1546433",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1055226301",
+        "de": "applemusic://track/1055226301",
+        "gb": "applemusic://track/1055226301",
+        "fr": "applemusic://track/1055226301",
+        "es": "applemusic://track/1055226301",
+        "nl": "applemusic://track/1055226301",
+        "it": "applemusic://track/1055226301"
+      }
     },
     {
       "year": 2002,
@@ -2613,7 +3543,7 @@
       "alt_artists": [
         "Rosana",
         "Paulina Rubio",
-        "Mal\u00fa",
+        "Malú",
         "Pastora Soler"
       ],
       "title": "Si No Te Hubieras Ido",
@@ -2624,15 +3554,25 @@
       },
       "certifications": [],
       "awards": [],
-      "fun_fact": "Tamara from Pontevedra exploded onto the Spanish scene with her powerful voice. This Marco Antonio Sol\u00eds cover became one of the biggest ballads in Spain in the early 2000s.",
-      "fun_fact_de": "Tamara aus Pontevedra eroberte die spanische Szene mit ihrer kraftvollen Stimme. Dieses Cover wurde einer der gr\u00f6\u00dften Balladen Spaniens der fr\u00fchen 2000er.",
-      "fun_fact_es": "Tamara de Pontevedra irrumpi\u00f3 en la escena espa\u00f1ola con su potente voz. Esta versi\u00f3n se convirti\u00f3 en una de las mayores baladas de los 2000.",
-      "fun_fact_fr": "Tamara de Pontevedra a explos\u00e9 sur la sc\u00e8ne espagnole avec sa voix puissante. Cette reprise est devenue l'une des plus grandes ballades des ann\u00e9es 2000.",
+      "fun_fact": "Tamara from Pontevedra exploded onto the Spanish scene with her powerful voice. This Marco Antonio Solís cover became one of the biggest ballads in Spain in the early 2000s.",
+      "fun_fact_de": "Tamara aus Pontevedra eroberte die spanische Szene mit ihrer kraftvollen Stimme. Dieses Cover wurde einer der größten Balladen Spaniens der frühen 2000er.",
+      "fun_fact_es": "Tamara de Pontevedra irrumpió en la escena española con su potente voz. Esta versión se convirtió en una de las mayores baladas de los 2000.",
+      "fun_fact_fr": "Tamara de Pontevedra a explosé sur la scène espagnole avec sa voix puissante. Cette reprise est devenue l'une des plus grandes ballades des années 2000.",
       "uri_apple_music": "applemusic://track/278948130",
       "uri_youtube_music": "https://music.youtube.com/watch?v=lCrZ3dgse2g",
       "uri_tidal": "tidal://track/5862461",
-      "fun_fact_nl": "Tamara uit Pontevedra explodeerde in de Spaanse scene met haar krachtige stem. Deze Marco Antonio Sol\u00eds-cover werd een van de grootste ballads in Spanje aan het begin van de jaren 2000.",
-      "awards_nl": []
+      "fun_fact_nl": "Tamara uit Pontevedra explodeerde in de Spaanse scene met haar krachtige stem. Deze Marco Antonio Solís-cover werd een van de grootste ballads in Spanje aan het begin van de jaren 2000.",
+      "awards_nl": [],
+      "isrc": "MXF150800001",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1488157875",
+        "de": "applemusic://track/1488157875",
+        "gb": "applemusic://track/1488157875",
+        "fr": "applemusic://track/1488157875",
+        "es": "applemusic://track/1488157875",
+        "nl": "applemusic://track/1488157875",
+        "it": "applemusic://track/1488157875"
+      }
     },
     {
       "year": 1984,
@@ -2644,7 +3584,7 @@
         "Radio Futura",
         "Loquillo"
       ],
-      "title": "Coraz\u00f3n de ne\u00f3n",
+      "title": "Corazón de neón",
       "chart_info": {
         "billboard_peak": null,
         "uk_peak": null,
@@ -2652,15 +3592,25 @@
       },
       "certifications": [],
       "awards": [],
-      "fun_fact": "Led by the theatrical Javier Gurruchaga, Orquesta Mondrag\u00f3n brought cabaret-rock showmanship to 'La Movida'. Their live shows were legendary multimedia spectacles.",
-      "fun_fact_de": "Angef\u00fchrt vom theatralischen Javier Gurruchaga, brachte Orquesta Mondrag\u00f3n Kabarett-Rock-Showmanship in die Movida.",
-      "fun_fact_es": "Liderada por el teatral Javier Gurruchaga, Orquesta Mondrag\u00f3n llev\u00f3 el espect\u00e1culo cabaret-rock a La Movida. Sus shows eran espect\u00e1culos multimedia legendarios.",
-      "fun_fact_fr": "Men\u00e9e par le th\u00e9\u00e2tral Javier Gurruchaga, Orquesta Mondrag\u00f3n a apport\u00e9 le spectacle cabaret-rock \u00e0 La Movida. Leurs shows \u00e9taient des spectacles multim\u00e9dia l\u00e9gendaires.",
+      "fun_fact": "Led by the theatrical Javier Gurruchaga, Orquesta Mondragón brought cabaret-rock showmanship to 'La Movida'. Their live shows were legendary multimedia spectacles.",
+      "fun_fact_de": "Angeführt vom theatralischen Javier Gurruchaga, brachte Orquesta Mondragón Kabarett-Rock-Showmanship in die Movida.",
+      "fun_fact_es": "Liderada por el teatral Javier Gurruchaga, Orquesta Mondragón llevó el espectáculo cabaret-rock a La Movida. Sus shows eran espectáculos multimedia legendarios.",
+      "fun_fact_fr": "Menée par le théâtral Javier Gurruchaga, Orquesta Mondragón a apporté le spectacle cabaret-rock à La Movida. Leurs shows étaient des spectacles multimédia légendaires.",
       "uri_apple_music": "applemusic://track/1382199358",
       "uri_youtube_music": "https://music.youtube.com/watch?v=7cVGDkzNpwo",
       "uri_tidal": "tidal://track/34307465",
-      "fun_fact_nl": "Onder leiding van de theatrale Javier Gurruchaga bracht Orquesta Mondrag\u00f3n cabaret-rock showmanship naar 'La Movida'. Hun liveshows waren legendarische multimediaspektakels.",
-      "awards_nl": []
+      "fun_fact_nl": "Onder leiding van de theatrale Javier Gurruchaga bracht Orquesta Mondragón cabaret-rock showmanship naar 'La Movida'. Hun liveshows waren legendarische multimediaspektakels.",
+      "awards_nl": [],
+      "isrc": "ES5151801632",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1382199358",
+        "de": "applemusic://track/1382199358",
+        "gb": "applemusic://track/1382199358",
+        "fr": "applemusic://track/1382199358",
+        "es": "applemusic://track/1382199358",
+        "nl": "applemusic://track/1382199358",
+        "it": "applemusic://track/1382199358"
+      }
     },
     {
       "year": 2007,
@@ -2681,14 +3631,24 @@
       "certifications": [],
       "awards": [],
       "fun_fact": "Venezuelan heartthrob who became a massive star in Spain. Baute holds Spanish citizenship and is considered as much a Spanish artist as a Venezuelan one.",
-      "fun_fact_de": "Venezolanischer Schwarm, der in Spanien zum Star wurde. Baute hat die spanische Staatsb\u00fcrgerschaft und gilt als spanischer wie venezolanischer K\u00fcnstler.",
-      "fun_fact_es": "Gal\u00e1n venezolano que se convirti\u00f3 en estrella en Espa\u00f1a. Baute tiene ciudadan\u00eda espa\u00f1ola y es considerado tanto artista espa\u00f1ol como venezolano.",
-      "fun_fact_fr": "Beau gosse v\u00e9n\u00e9zu\u00e9lien devenu star en Espagne. Baute a la nationalit\u00e9 espagnole et est consid\u00e9r\u00e9 comme artiste autant espagnol que v\u00e9n\u00e9zu\u00e9lien.",
+      "fun_fact_de": "Venezolanischer Schwarm, der in Spanien zum Star wurde. Baute hat die spanische Staatsbürgerschaft und gilt als spanischer wie venezolanischer Künstler.",
+      "fun_fact_es": "Galán venezolano que se convirtió en estrella en España. Baute tiene ciudadanía española y es considerado tanto artista español como venezolano.",
+      "fun_fact_fr": "Beau gosse vénézuélien devenu star en Espagne. Baute a la nationalité espagnole et est considéré comme artiste autant espagnol que vénézuélien.",
       "uri_apple_music": "applemusic://track/76158627",
       "uri_youtube_music": "https://music.youtube.com/watch?v=YGrph6Era8A",
       "uri_tidal": "tidal://track/175835",
       "fun_fact_nl": "Venezolaanse hartenbreker die een grote ster werd in Spanje. Baute heeft de Spaanse nationaliteit en wordt beschouwd als een even Spaanse als Venezolaanse artiest.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "ES5150512003",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1677370156",
+        "de": "applemusic://track/1677370156",
+        "gb": "applemusic://track/1677370156",
+        "fr": "applemusic://track/1677370156",
+        "es": "applemusic://track/1677370156",
+        "nl": "applemusic://track/1677370156",
+        "it": "applemusic://track/1677370156"
+      }
     },
     {
       "year": 1991,
@@ -2698,9 +3658,9 @@
         "Ketama",
         "Manzanita",
         "Raimundo Amador",
-        "Camar\u00f3n"
+        "Camarón"
       ],
-      "title": "Alegr\u00eda de Vivir",
+      "title": "Alegría de Vivir",
       "chart_info": {
         "billboard_peak": null,
         "uk_peak": null,
@@ -2708,15 +3668,25 @@
       },
       "certifications": [],
       "awards": [],
-      "fun_fact": "Ray Heredia was a Romani musical genius from Madrid who fused flamenco, jazz and soul. He died of a drug overdose at just 24, leaving behind one brilliant album \u2014 'Quien No Corre, Vuela'.",
-      "fun_fact_de": "Ray Heredia war ein Roma-Musikgenie aus Madrid, das Flamenco, Jazz und Soul verschmolz. Er starb mit nur 24 Jahren an einer \u00dcberdosis.",
-      "fun_fact_es": "Ray Heredia fue un genio musical gitano de Madrid que fusion\u00f3 flamenco, jazz y soul. Muri\u00f3 de sobredosis con solo 24 a\u00f1os, dejando un \u00e1lbum brillante.",
-      "fun_fact_fr": "Ray Heredia \u00e9tait un g\u00e9nie musical gitan de Madrid qui a fusionn\u00e9 flamenco, jazz et soul. Mort d'overdose \u00e0 24 ans, laissant un album brillant.",
+      "fun_fact": "Ray Heredia was a Romani musical genius from Madrid who fused flamenco, jazz and soul. He died of a drug overdose at just 24, leaving behind one brilliant album — 'Quien No Corre, Vuela'.",
+      "fun_fact_de": "Ray Heredia war ein Roma-Musikgenie aus Madrid, das Flamenco, Jazz und Soul verschmolz. Er starb mit nur 24 Jahren an einer Überdosis.",
+      "fun_fact_es": "Ray Heredia fue un genio musical gitano de Madrid que fusionó flamenco, jazz y soul. Murió de sobredosis con solo 24 años, dejando un álbum brillante.",
+      "fun_fact_fr": "Ray Heredia était un génie musical gitan de Madrid qui a fusionné flamenco, jazz et soul. Mort d'overdose à 24 ans, laissant un album brillant.",
       "uri_apple_music": "applemusic://track/1793347154",
       "uri_youtube_music": "https://music.youtube.com/watch?v=lTFt_5CjkYs",
       "uri_tidal": "tidal://track/29489663",
-      "fun_fact_nl": "Ray Heredia was een Romaans muzikaal genie uit Madrid die flamenco, jazz en soul met elkaar versmolt. Hij stierf op 24-jarige leeftijd aan een overdosis drugs en liet \u00e9\u00e9n briljant album achter - 'Quien No Corre, Vuela'.",
-      "awards_nl": []
+      "fun_fact_nl": "Ray Heredia was een Romaans muzikaal genie uit Madrid die flamenco, jazz en soul met elkaar versmolt. Hij stierf op 24-jarige leeftijd aan een overdosis drugs en liet één briljant album achter - 'Quien No Corre, Vuela'.",
+      "awards_nl": [],
+      "isrc": "ESAAI0140838",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1793347154",
+        "de": "applemusic://track/1793347154",
+        "gb": "applemusic://track/1793347154",
+        "fr": "applemusic://track/1793347154",
+        "es": "applemusic://track/1793347154",
+        "nl": "applemusic://track/1793347154",
+        "it": "applemusic://track/1793347154"
+      }
     },
     {
       "year": 1993,
@@ -2736,14 +3706,24 @@
       "certifications": [],
       "awards": [],
       "fun_fact": "El Fary was beloved for his handlebar mustache and working-class Madrid humor. A folk singer and actor who became a national treasure.",
-      "fun_fact_de": "El Fary war ber\u00fchmt f\u00fcr seinen Schnurrbart und verk\u00f6rperte den Humor der Madrider Arbeiterklasse.",
-      "fun_fact_es": "El Fary era querido por su bigote y su humor castizo madrile\u00f1o. Cantante y actor que se convirti\u00f3 en tesoro nacional.",
-      "fun_fact_fr": "El Fary \u00e9tait ador\u00e9 pour sa moustache et son humour populaire madril\u00e8ne. Chanteur et acteur devenu tr\u00e9sor national.",
+      "fun_fact_de": "El Fary war berühmt für seinen Schnurrbart und verkörperte den Humor der Madrider Arbeiterklasse.",
+      "fun_fact_es": "El Fary era querido por su bigote y su humor castizo madrileño. Cantante y actor que se convirtió en tesoro nacional.",
+      "fun_fact_fr": "El Fary était adoré pour sa moustache et son humour populaire madrilène. Chanteur et acteur devenu trésor national.",
       "uri_apple_music": "applemusic://track/1465983109",
       "uri_youtube_music": "https://music.youtube.com/watch?v=j9PjBhJLTc0",
       "uri_tidal": "tidal://track/10925245",
       "fun_fact_nl": "El Fary was geliefd om zijn snor en Madrileense arbeidershumor. Een volkszanger en acteur die een nationale schat werd.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "ES5028400040",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1465983109",
+        "de": "applemusic://track/455667265",
+        "gb": "applemusic://track/455667265",
+        "fr": "applemusic://track/455667265",
+        "es": "applemusic://track/455667265",
+        "nl": "applemusic://track/455667265",
+        "it": "applemusic://track/455667265"
+      }
     },
     {
       "year": 1991,
@@ -2763,14 +3743,24 @@
       "certifications": [],
       "awards": [],
       "fun_fact": "Chimo Bayo was the king of 'bakalao', the Valencian rave scene that dominated Spanish nightlife in the early 90s.",
-      "fun_fact_de": "Chimo Bayo war der K\u00f6nig des 'Bakalao', der valencianischen Rave-Szene der fr\u00fchen 90er.",
-      "fun_fact_es": "Chimo Bayo fue el rey del 'bakalao', la escena rave valenciana que domin\u00f3 la noche espa\u00f1ola a principios de los 90.",
-      "fun_fact_fr": "Chimo Bayo \u00e9tait le roi du 'bakalao', la sc\u00e8ne rave valencienne qui dominait la nuit espagnole au d\u00e9but des ann\u00e9es 90.",
+      "fun_fact_de": "Chimo Bayo war der König des 'Bakalao', der valencianischen Rave-Szene der frühen 90er.",
+      "fun_fact_es": "Chimo Bayo fue el rey del 'bakalao', la escena rave valenciana que dominó la noche española a principios de los 90.",
+      "fun_fact_fr": "Chimo Bayo était le roi du 'bakalao', la scène rave valencienne qui dominait la nuit espagnole au début des années 90.",
       "uri_apple_music": "applemusic://track/891670017",
       "uri_youtube_music": "https://music.youtube.com/watch?v=DwjEDNMqVTc",
       "uri_tidal": "tidal://track/31639887",
       "fun_fact_nl": "Chimo Bayo was de koning van de 'bakalao', de Valenciaanse rave-scene die begin jaren 90 het Spaanse nachtleven domineerde.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "ES5770601012",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/891670017",
+        "de": "applemusic://track/891670017",
+        "gb": "applemusic://track/891670017",
+        "fr": "applemusic://track/891670017",
+        "es": "applemusic://track/891670017",
+        "nl": "applemusic://track/891670017",
+        "it": "applemusic://track/891670017"
+      }
     },
     {
       "year": 1988,
@@ -2778,7 +3768,7 @@
       "artist": "Georgie Dann",
       "alt_artists": [
         "El Fary",
-        "Los Del R\u00edo",
+        "Los Del Río",
         "Peret",
         "Las Ketchup"
       ],
@@ -2791,14 +3781,24 @@
       "certifications": [],
       "awards": [],
       "fun_fact": "French-born Georgie Dann became the undisputed king of Spanish summer songs, releasing a new seasonal hit every year for decades.",
-      "fun_fact_de": "Der in Frankreich geborene Georgie Dann wurde zum K\u00f6nig der spanischen Sommerhits.",
-      "fun_fact_es": "Georgie Dann, nacido en Francia, se convirti\u00f3 en el rey indiscutible de las canciones del verano espa\u00f1ol.",
-      "fun_fact_fr": "N\u00e9 en France, Georgie Dann est devenu le roi incontest\u00e9 des tubes de l'\u00e9t\u00e9 espagnol.",
+      "fun_fact_de": "Der in Frankreich geborene Georgie Dann wurde zum König der spanischen Sommerhits.",
+      "fun_fact_es": "Georgie Dann, nacido en Francia, se convirtió en el rey indiscutible de las canciones del verano español.",
+      "fun_fact_fr": "Né en France, Georgie Dann est devenu le roi incontesté des tubes de l'été espagnol.",
       "uri_apple_music": "applemusic://track/255678856",
       "uri_youtube_music": "https://music.youtube.com/watch?v=lTxGto9ADx0",
       "uri_tidal": "tidal://track/505028",
       "fun_fact_nl": "De in Frankrijk geboren Georgie Dann werd de onbetwiste koning van de Spaanse zomerliedjes en bracht tientallen jaren lang elk jaar een nieuwe seizoenshit uit.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "ES5100100115",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/255678856",
+        "de": "applemusic://track/255678856",
+        "gb": "applemusic://track/255678856",
+        "fr": "applemusic://track/255678856",
+        "es": "applemusic://track/255678856",
+        "nl": "applemusic://track/255678856",
+        "it": "applemusic://track/255678856"
+      }
     },
     {
       "year": 1992,
@@ -2808,7 +3808,7 @@
         "Ketama",
         "Antonio Flores",
         "Lola Flores",
-        "Ni\u00f1a Pastori"
+        "Niña Pastori"
       ],
       "title": "Mi Gato",
       "chart_info": {
@@ -2818,15 +3818,25 @@
       },
       "certifications": [],
       "awards": [],
-      "fun_fact": "Different side of Rosario Flores \u2014 this playful, funky track showed her versatility beyond the flamenco-pop she's known for, becoming a radio staple in early 90s Spain.",
-      "fun_fact_de": "Eine andere Seite von Rosario Flores \u2014 dieser verspielte, funkige Track zeigte ihre Vielseitigkeit jenseits des Flamenco-Pop.",
-      "fun_fact_es": "Otra cara de Rosario Flores \u2014 este tema juguet\u00f3n y funky mostr\u00f3 su versatilidad m\u00e1s all\u00e1 del flamenco-pop por el que es conocida.",
-      "fun_fact_fr": "Un autre visage de Rosario Flores \u2014 ce titre ludique et funky a montr\u00e9 sa polyvalence au-del\u00e0 du flamenco-pop.",
+      "fun_fact": "Different side of Rosario Flores — this playful, funky track showed her versatility beyond the flamenco-pop she's known for, becoming a radio staple in early 90s Spain.",
+      "fun_fact_de": "Eine andere Seite von Rosario Flores — dieser verspielte, funkige Track zeigte ihre Vielseitigkeit jenseits des Flamenco-Pop.",
+      "fun_fact_es": "Otra cara de Rosario Flores — este tema juguetón y funky mostró su versatilidad más allá del flamenco-pop por el que es conocida.",
+      "fun_fact_fr": "Un autre visage de Rosario Flores — ce titre ludique et funky a montré sa polyvalence au-delà du flamenco-pop.",
       "uri_apple_music": "applemusic://track/287519136",
       "uri_youtube_music": "https://music.youtube.com/watch?v=2F3GlAiboVs",
       "uri_tidal": "tidal://track/21162707",
       "fun_fact_nl": "Een andere kant van Rosario Flores - dit speelse, funky nummer toonde haar veelzijdigheid buiten de flamenco-pop waar ze bekend om staat en werd een vaste waarde op de radio in Spanje aan het begin van de jaren 90.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "ES5119201609",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/287519136",
+        "de": "applemusic://track/287519136",
+        "gb": "applemusic://track/287519136",
+        "fr": "applemusic://track/287519136",
+        "es": "applemusic://track/287519136",
+        "nl": "applemusic://track/680288788",
+        "it": "applemusic://track/287519136"
+      }
     },
     {
       "year": 2017,
@@ -2847,14 +3857,24 @@
       "certifications": [],
       "awards": [],
       "fun_fact": "Bombai is a Spanish indie-pop duo who teamed up with Bebe for this summer anthem that became one of Spain's most-played songs of 2017.",
-      "fun_fact_de": "Bombai ist ein spanisches Indie-Pop-Duo, das sich mit Bebe f\u00fcr diesen Sommerhit zusammentat \u2014 einer der meistgespielten Songs 2017.",
-      "fun_fact_es": "Bombai es un d\u00fao indie-pop espa\u00f1ol que se uni\u00f3 a Bebe para este himno veraniego, uno de los temas m\u00e1s sonados de 2017 en Espa\u00f1a.",
-      "fun_fact_fr": "Bombai est un duo indie-pop espagnol qui s'est associ\u00e9 \u00e0 Bebe pour cet hymne estival, l'un des titres les plus diffus\u00e9s en 2017.",
+      "fun_fact_de": "Bombai ist ein spanisches Indie-Pop-Duo, das sich mit Bebe für diesen Sommerhit zusammentat — einer der meistgespielten Songs 2017.",
+      "fun_fact_es": "Bombai es un dúo indie-pop español que se unió a Bebe para este himno veraniego, uno de los temas más sonados de 2017 en España.",
+      "fun_fact_fr": "Bombai est un duo indie-pop espagnol qui s'est associé à Bebe pour cet hymne estival, l'un des titres les plus diffusés en 2017.",
       "uri_apple_music": "applemusic://track/1209479331",
       "uri_youtube_music": "https://music.youtube.com/watch?v=NMVBQ6C4iNA",
       "uri_tidal": "tidal://track/421660438",
       "fun_fact_nl": "Bombai is een Spaans indie-pop duo dat een team vormde met Bebe voor dit zomerse volkslied dat een van de meest gedraaide nummers van 2017 in Spanje werd.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "ES84S1700070",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1442200377",
+        "de": "applemusic://track/1442200377",
+        "gb": "applemusic://track/1442200377",
+        "fr": "applemusic://track/1442200377",
+        "es": "applemusic://track/1442200377",
+        "nl": "applemusic://track/1442200377",
+        "it": "applemusic://track/1442200377"
+      }
     },
     {
       "year": 2006,
@@ -2875,14 +3895,24 @@
       "certifications": [],
       "awards": [],
       "fun_fact": "Mexican singer-songwriter who won the Latin Grammy for Record of the Year with this track in 2006. It became one of the most iconic Spanish-language pop songs of the 2000s.",
-      "fun_fact_de": "Mexikanische Singer-Songwriterin, die 2006 den Latin Grammy f\u00fcr die Aufnahme des Jahres gewann.",
-      "fun_fact_es": "Cantautora mexicana que gan\u00f3 el Latin Grammy a la Grabaci\u00f3n del A\u00f1o con este tema en 2006.",
-      "fun_fact_fr": "Auteure-compositrice mexicaine qui a remport\u00e9 le Latin Grammy de l'Enregistrement de l'Ann\u00e9e avec ce titre en 2006.",
+      "fun_fact_de": "Mexikanische Singer-Songwriterin, die 2006 den Latin Grammy für die Aufnahme des Jahres gewann.",
+      "fun_fact_es": "Cantautora mexicana que ganó el Latin Grammy a la Grabación del Año con este tema en 2006.",
+      "fun_fact_fr": "Auteure-compositrice mexicaine qui a remporté le Latin Grammy de l'Enregistrement de l'Année avec ce titre en 2006.",
       "uri_apple_music": "applemusic://track/604808080",
       "uri_youtube_music": "https://music.youtube.com/watch?v=y8rBC6GCUjg",
       "uri_tidal": "tidal://track/33914577",
       "fun_fact_nl": "Mexicaanse singer-songwriter die in 2006 de Latin Grammy voor plaat van het jaar won met dit nummer. Het werd een van de meest iconische Spaanstalige popsongs van de jaren 2000.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "MXF010600165",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1739171797",
+        "de": "applemusic://track/341527003",
+        "gb": "applemusic://track/341527003",
+        "fr": "applemusic://track/341527003",
+        "es": "applemusic://track/341527003",
+        "nl": "applemusic://track/341527003",
+        "it": "applemusic://track/341527003"
+      }
     },
     {
       "year": 2013,
@@ -2902,15 +3932,25 @@
       },
       "certifications": [],
       "awards": [],
-      "fun_fact": "Second Efecto Pasillo hit in this playlist \u2014 the Canarian band became synonymous with Spanish summer pop, filling festivals across the country.",
-      "fun_fact_de": "Zweiter Efecto Pasillo Hit \u2014 die kanarische Band wurde zum Synonym f\u00fcr spanischen Sommerpop.",
-      "fun_fact_es": "Segundo \u00e9xito de Efecto Pasillo \u2014 la banda canaria se convirti\u00f3 en sin\u00f3nimo del pop veraniego espa\u00f1ol.",
-      "fun_fact_fr": "Deuxi\u00e8me tube d'Efecto Pasillo \u2014 le groupe canarien est devenu synonyme du pop estival espagnol.",
+      "fun_fact": "Second Efecto Pasillo hit in this playlist — the Canarian band became synonymous with Spanish summer pop, filling festivals across the country.",
+      "fun_fact_de": "Zweiter Efecto Pasillo Hit — die kanarische Band wurde zum Synonym für spanischen Sommerpop.",
+      "fun_fact_es": "Segundo éxito de Efecto Pasillo — la banda canaria se convirtió en sinónimo del pop veraniego español.",
+      "fun_fact_fr": "Deuxième tube d'Efecto Pasillo — le groupe canarien est devenu synonyme du pop estival espagnol.",
       "uri_apple_music": "applemusic://track/1322695794",
       "uri_youtube_music": "https://music.youtube.com/watch?v=a5Hp4K0PwRQ",
       "uri_tidal": "tidal://track/82198948",
       "fun_fact_nl": "Tweede Efecto Pasillo hit in deze afspeellijst - de Canarische band werd synoniem met Spaanse zomerpop en vulde festivals door het hele land.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "ES24C1207101",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1806098423",
+        "de": "applemusic://track/1806098423",
+        "gb": "applemusic://track/1806098423",
+        "fr": "applemusic://track/1806098423",
+        "es": "applemusic://track/1806098423",
+        "nl": "applemusic://track/1806098423",
+        "it": "applemusic://track/1806098423"
+      }
     },
     {
       "year": 2003,
@@ -2918,7 +3958,7 @@
       "artist": "Fito y Fitipaldis",
       "alt_artists": [
         "Extremoduro",
-        "Platero y T\u00fa",
+        "Platero y Tú",
         "Rosendo",
         "Barricada"
       ],
@@ -2932,18 +3972,28 @@
       "awards": [],
       "fun_fact": "Fito Cabrales from Bilbao is one of Spain's most beloved rock singer-songwriters. This tender ballad became a generational anthem and is sung at every Spanish gathering.",
       "fun_fact_de": "Fito Cabrales aus Bilbao ist einer der beliebtesten Rock-Liedermacher Spaniens. Diese Ballade wurde zur Generationenhymne.",
-      "fun_fact_es": "Fito Cabrales de Bilbao es uno de los cantautores de rock m\u00e1s queridos de Espa\u00f1a. Esta balada se convirti\u00f3 en himno generacional.",
-      "fun_fact_fr": "Fito Cabrales de Bilbao est l'un des auteurs-compositeurs rock les plus aim\u00e9s d'Espagne. Cette ballade est devenue un hymne g\u00e9n\u00e9rationnel.",
+      "fun_fact_es": "Fito Cabrales de Bilbao es uno de los cantautores de rock más queridos de España. Esta balada se convirtió en himno generacional.",
+      "fun_fact_fr": "Fito Cabrales de Bilbao est l'un des auteurs-compositeurs rock les plus aimés d'Espagne. Cette ballade est devenue un hymne générationnel.",
       "uri_apple_music": "applemusic://track/72167557",
       "uri_youtube_music": "https://music.youtube.com/watch?v=GxQjx7FkmNA",
       "uri_tidal": "tidal://track/172925",
       "fun_fact_nl": "Fito Cabrales uit Bilbao is een van de meest geliefde Spaanse rock singer-songwriters. Deze tedere ballade werd een generatiehymne en wordt op elke Spaanse bijeenkomst gezongen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "ES5010300350",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1686946543",
+        "de": "applemusic://track/1686946543",
+        "gb": "applemusic://track/1686946543",
+        "fr": "applemusic://track/1686946543",
+        "es": "applemusic://track/1686946543",
+        "nl": "applemusic://track/1686946543",
+        "it": "applemusic://track/1686946543"
+      }
     },
     {
       "year": 2002,
       "uri": "spotify:track:7GrAOZRMBhUPN5PdbJZVO9",
-      "artist": "Rosa L\u00f3pez",
+      "artist": "Rosa López",
       "alt_artists": [
         "Bustamante",
         "David Bisbal",
@@ -2958,27 +4008,37 @@
       },
       "certifications": [],
       "awards": [],
-      "fun_fact": "Rosa won Operaci\u00f3n Triunfo 1 and represented Spain at Eurovision 2002. The OT phenomenon drew 12+ million viewers and launched an entire generation of Spanish pop stars.",
-      "fun_fact_de": "Rosa gewann Operaci\u00f3n Triunfo 1 und vertrat Spanien beim Eurovision 2002. Das OT-Ph\u00e4nomen mit \u00fcber 12 Millionen Zuschauern.",
-      "fun_fact_es": "Rosa gan\u00f3 OT 1 y represent\u00f3 a Espa\u00f1a en Eurovisi\u00f3n 2002. El fen\u00f3meno OT reuni\u00f3 a m\u00e1s de 12 millones de espectadores.",
-      "fun_fact_fr": "Rosa a gagn\u00e9 OT 1 et a repr\u00e9sent\u00e9 l'Espagne \u00e0 l'Eurovision 2002. Le ph\u00e9nom\u00e8ne OT a r\u00e9uni plus de 12 millions de t\u00e9l\u00e9spectateurs.",
+      "fun_fact": "Rosa won Operación Triunfo 1 and represented Spain at Eurovision 2002. The OT phenomenon drew 12+ million viewers and launched an entire generation of Spanish pop stars.",
+      "fun_fact_de": "Rosa gewann Operación Triunfo 1 und vertrat Spanien beim Eurovision 2002. Das OT-Phänomen mit über 12 Millionen Zuschauern.",
+      "fun_fact_es": "Rosa ganó OT 1 y representó a España en Eurovisión 2002. El fenómeno OT reunió a más de 12 millones de espectadores.",
+      "fun_fact_fr": "Rosa a gagné OT 1 et a représenté l'Espagne à l'Eurovision 2002. Le phénomène OT a réuni plus de 12 millions de téléspectateurs.",
       "uri_apple_music": "applemusic://track/1577412714",
       "uri_youtube_music": "https://music.youtube.com/watch?v=xBHcyuK1c2I",
       "uri_tidal": "tidal://track/132822856",
-      "fun_fact_nl": "Rosa won Operaci\u00f3n Triunfo 1 en vertegenwoordigde Spanje op Eurovisie 2002. Het fenomeen OT trok meer dan 12 miljoen kijkers en lanceerde een hele generatie Spaanse popsterren.",
-      "awards_nl": []
+      "fun_fact_nl": "Rosa won Operación Triunfo 1 en vertegenwoordigde Spanje op Eurovisie 2002. Het fenomeen OT trok meer dan 12 miljoen kijkers en lanceerde een hele generatie Spaanse popsterren.",
+      "awards_nl": [],
+      "isrc": "ES5701701082",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1577412714",
+        "de": "applemusic://track/1577412714",
+        "gb": "applemusic://track/1577412714",
+        "fr": "applemusic://track/1577412714",
+        "es": "applemusic://track/1577412714",
+        "nl": "applemusic://track/1577412714",
+        "it": "applemusic://track/1577412714"
+      }
     },
     {
       "year": 2022,
       "uri": "spotify:track:5ildQOEKmJuWGl2vRkFdYc",
-      "artist": "ROSAL\u00cdA",
+      "artist": "ROSALÍA",
       "alt_artists": [
         "C. Tangana",
         "Bad Gyal",
         "Aitana",
         "Lola Indigo"
       ],
-      "title": "DESPECH\u00c1",
+      "title": "DESPECHÁ",
       "chart_info": {
         "billboard_peak": null,
         "uk_peak": null,
@@ -2986,15 +4046,25 @@
       },
       "certifications": [],
       "awards": [],
-      "fun_fact": "ROSAL\u00cdA's most viral hit \u2014 leaked months before official release, it still topped charts everywhere. The dance became a TikTok phenomenon with over 2 billion views.",
-      "fun_fact_de": "ROSAL\u00cdAs viralster Hit \u2014 Monate vor der offiziellen Ver\u00f6ffentlichung geleakt, trotzdem \u00fcberall #1. Der Tanz wurde zum TikTok-Ph\u00e4nomen.",
-      "fun_fact_es": "El hit m\u00e1s viral de ROSAL\u00cdA \u2014 filtrado meses antes de su lanzamiento oficial, aun as\u00ed lleg\u00f3 al #1. El baile se convirti\u00f3 en fen\u00f3meno TikTok.",
-      "fun_fact_fr": "Le plus grand tube viral de ROSAL\u00cdA \u2014 fuit\u00e9 des mois avant sa sortie officielle, il a quand m\u00eame atteint le #1 partout.",
+      "fun_fact": "ROSALÍA's most viral hit — leaked months before official release, it still topped charts everywhere. The dance became a TikTok phenomenon with over 2 billion views.",
+      "fun_fact_de": "ROSALÍAs viralster Hit — Monate vor der offiziellen Veröffentlichung geleakt, trotzdem überall #1. Der Tanz wurde zum TikTok-Phänomen.",
+      "fun_fact_es": "El hit más viral de ROSALÍA — filtrado meses antes de su lanzamiento oficial, aun así llegó al #1. El baile se convirtió en fenómeno TikTok.",
+      "fun_fact_fr": "Le plus grand tube viral de ROSALÍA — fuité des mois avant sa sortie officielle, il a quand même atteint le #1 partout.",
       "uri_apple_music": "applemusic://track/1660334835",
       "uri_youtube_music": "https://music.youtube.com/watch?v=Y2ESxHKuSOk",
       "uri_tidal": "tidal://track/240175608",
-      "fun_fact_nl": "ROSAL\u00cdA's meest virale hit - al maanden voor de offici\u00eble release uitgelekt, stond het toch overal bovenaan de hitlijsten. De dans werd een TikTok-fenomeen met meer dan 2 miljard views.",
-      "awards_nl": []
+      "fun_fact_nl": "ROSALÍA's meest virale hit - al maanden voor de officiële release uitgelekt, stond het toch overal bovenaan de hitlijsten. De dans werd een TikTok-fenomeen met meer dan 2 miljard views.",
+      "awards_nl": [],
+      "isrc": "US23A1985156",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1660334835",
+        "de": "applemusic://track/1660334835",
+        "gb": "applemusic://track/1660334835",
+        "fr": "applemusic://track/1660334835",
+        "es": "applemusic://track/1660334835",
+        "nl": "applemusic://track/1660334835",
+        "it": "applemusic://track/1660334835"
+      }
     },
     {
       "year": 2005,
@@ -3016,13 +4086,23 @@
       "awards": [],
       "fun_fact": "The first Spanish-language song to crack the US Billboard Hot 100 top 25 in decades. The collaboration between Colombia's Shakira and Spain's Sanz bridged two continents.",
       "fun_fact_de": "Erster spanischsprachiger Song seit Jahrzehnten in den US Billboard Top 25. Die Kollaboration verband Kolumbien und Spanien.",
-      "fun_fact_es": "Primera canci\u00f3n en espa\u00f1ol en d\u00e9cadas en entrar al top 25 del Billboard Hot 100. La colaboraci\u00f3n uni\u00f3 Colombia y Espa\u00f1a.",
-      "fun_fact_fr": "Premier titre en espagnol depuis des d\u00e9cennies dans le top 25 du Billboard Hot 100. La collaboration a uni Colombie et Espagne.",
+      "fun_fact_es": "Primera canción en español en décadas en entrar al top 25 del Billboard Hot 100. La colaboración unió Colombia y España.",
+      "fun_fact_fr": "Premier titre en espagnol depuis des décennies dans le top 25 du Billboard Hot 100. La collaboration a uni Colombie et Espagne.",
       "uri_apple_music": "applemusic://track/1487072929",
       "uri_youtube_music": "https://music.youtube.com/watch?v=Dsp_8Lm1eSk",
       "uri_tidal": "tidal://track/438737307",
       "fun_fact_nl": "Het eerste Spaanstalige nummer in decennia dat de top 25 van de US Billboard Hot 100 wist te bereiken. De samenwerking tussen de Colombiaanse Shakira en de Spaanse Sanz overbrugde twee continenten.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USQX91902774",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1487072929",
+        "de": "applemusic://track/1487072929",
+        "gb": "applemusic://track/1487072929",
+        "fr": "applemusic://track/1487072929",
+        "es": "applemusic://track/1487072929",
+        "nl": "applemusic://track/1487072929",
+        "it": "applemusic://track/1487072929"
+      }
     },
     {
       "year": 1986,
@@ -3034,7 +4114,7 @@
         "Tino Casal",
         "Gabinete Caligari"
       ],
-      "title": "A qui\u00e9n le importa",
+      "title": "A quién le importa",
       "chart_info": {
         "billboard_peak": null,
         "uk_peak": null,
@@ -3042,15 +4122,25 @@
       },
       "certifications": [],
       "awards": [],
-      "fun_fact": "THE anthem of 'La Movida Madrile\u00f1a' and Spain's LGBTQ+ community. Alaska (Olvido Gara) is a Mexican-born Spanish icon who defined counterculture in post-Franco Spain.",
-      "fun_fact_de": "DIE Hymne der 'Movida Madrile\u00f1a' und der spanischen LGBTQ+-Community. Alaska definierte die Gegenkultur im post-franquistischen Spanien.",
-      "fun_fact_es": "EL himno de La Movida Madrile\u00f1a y de la comunidad LGBTQ+ espa\u00f1ola. Alaska defini\u00f3 la contracultura de la Espa\u00f1a post-franquista.",
-      "fun_fact_fr": "L'HYMNE de La Movida Madrile\u00f1a et de la communaut\u00e9 LGBTQ+ espagnole. Alaska a d\u00e9fini la contre-culture de l'Espagne post-franquiste.",
+      "fun_fact": "THE anthem of 'La Movida Madrileña' and Spain's LGBTQ+ community. Alaska (Olvido Gara) is a Mexican-born Spanish icon who defined counterculture in post-Franco Spain.",
+      "fun_fact_de": "DIE Hymne der 'Movida Madrileña' und der spanischen LGBTQ+-Community. Alaska definierte die Gegenkultur im post-franquistischen Spanien.",
+      "fun_fact_es": "EL himno de La Movida Madrileña y de la comunidad LGBTQ+ española. Alaska definió la contracultura de la España post-franquista.",
+      "fun_fact_fr": "L'HYMNE de La Movida Madrileña et de la communauté LGBTQ+ espagnole. Alaska a défini la contre-culture de l'Espagne post-franquiste.",
       "uri_apple_music": "applemusic://track/726347452",
       "uri_youtube_music": "https://music.youtube.com/watch?v=ixI8vCtZUWQ",
       "uri_tidal": "tidal://track/1517552",
-      "fun_fact_nl": "Het volkslied van 'La Movida Madrile\u00f1a' en de Spaanse LGBTQ+ gemeenschap. Alaska (Olvido Gara) is een in Mexico geboren Spaans icoon dat de tegencultuur in het Spanje van na Franco definieerde.",
-      "awards_nl": []
+      "fun_fact_nl": "Het volkslied van 'La Movida Madrileña' en de Spaanse LGBTQ+ gemeenschap. Alaska (Olvido Gara) is een in Mexico geboren Spaans icoon dat de tegencultuur in het Spanje van na Franco definieerde.",
+      "awards_nl": [],
+      "isrc": "ES5088602056",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1704164844",
+        "de": "applemusic://track/1704164844",
+        "gb": "applemusic://track/1704164844",
+        "fr": "applemusic://track/1704164844",
+        "es": "applemusic://track/1772134228",
+        "nl": "applemusic://track/1704164844",
+        "it": "applemusic://track/1704164844"
+      }
     },
     {
       "year": 1972,
@@ -3058,11 +4148,11 @@
       "artist": "Roberto Carlos",
       "alt_artists": [
         "Julio Iglesias",
-        "Jos\u00e9 Luis Perales",
+        "José Luis Perales",
         "Camilo Sesto",
         "Nino Bravo"
       ],
-      "title": "El Gato Que Est\u00e1 Triste y Azul",
+      "title": "El Gato Que Está Triste y Azul",
       "chart_info": {
         "billboard_peak": null,
         "uk_peak": null,
@@ -3071,14 +4161,24 @@
       "certifications": [],
       "awards": [],
       "fun_fact": "Brazilian legend Roberto Carlos is the best-selling Latin artist from Brazil with 120+ million records. This Spanish-language hit made him equally massive in the Hispanic world.",
-      "fun_fact_de": "Brasilianische Legende Roberto Carlos \u2014 meistverkaufter lateinamerikanischer K\u00fcnstler aus Brasilien mit \u00fcber 120 Millionen Platten.",
-      "fun_fact_es": "La leyenda brasile\u00f1a Roberto Carlos es el artista latino m\u00e1s vendido de Brasil con m\u00e1s de 120 millones de discos.",
-      "fun_fact_fr": "La l\u00e9gende br\u00e9silienne Roberto Carlos est l'artiste latin le plus vendu du Br\u00e9sil avec 120+ millions de disques.",
+      "fun_fact_de": "Brasilianische Legende Roberto Carlos — meistverkaufter lateinamerikanischer Künstler aus Brasilien mit über 120 Millionen Platten.",
+      "fun_fact_es": "La leyenda brasileña Roberto Carlos es el artista latino más vendido de Brasil con más de 120 millones de discos.",
+      "fun_fact_fr": "La légende brésilienne Roberto Carlos est l'artiste latin le plus vendu du Brésil avec 120+ millions de disques.",
       "uri_apple_music": "applemusic://track/903645968",
       "uri_youtube_music": "https://music.youtube.com/watch?v=92icifp-ZPk",
       "uri_tidal": "tidal://track/18405360",
-      "fun_fact_nl": "De Braziliaanse legende Roberto Carlos is de best verkopende Latin-artiest uit Brazili\u00eb met meer dan 120 miljoen platen. Deze Spaanstalige hit maakte hem net zo populair in de Spaanstalige wereld.",
-      "awards_nl": []
+      "fun_fact_nl": "De Braziliaanse legende Roberto Carlos is de best verkopende Latin-artiest uit Brazilië met meer dan 120 miljoen platen. Deze Spaanstalige hit maakte hem net zo populair in de Spaanstalige wereld.",
+      "awards_nl": [],
+      "isrc": "BRSME8800017",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1394221956",
+        "de": "applemusic://track/1394221956",
+        "gb": "applemusic://track/1394221956",
+        "fr": "applemusic://track/1394221956",
+        "es": "applemusic://track/1394221956",
+        "nl": "applemusic://track/1394221956",
+        "it": "applemusic://track/1394221956"
+      }
     },
     {
       "year": 2003,
@@ -3087,8 +4187,8 @@
       "alt_artists": [
         "Estopa",
         "El Barrio",
-        "Caf\u00e9 Quijano",
-        "David DeMar\u00eda"
+        "Café Quijano",
+        "David DeMaría"
       ],
       "title": "Son de Amores",
       "chart_info": {
@@ -3098,24 +4198,34 @@
       },
       "certifications": [],
       "awards": [],
-      "fun_fact": "This C\u00e1diz duo's debut single became one of Spain's biggest hits of 2003. Their flamenco-pop sound and romantic lyrics made them instant stars across the Spanish-speaking world.",
-      "fun_fact_de": "Das Deb\u00fct dieses Duos aus C\u00e1diz wurde 2003 einer der gr\u00f6\u00dften Hits Spaniens.",
-      "fun_fact_es": "El debut de este d\u00fao de C\u00e1diz se convirti\u00f3 en uno de los mayores \u00e9xitos de 2003 en Espa\u00f1a.",
-      "fun_fact_fr": "Le premier single de ce duo de Cadix est devenu l'un des plus grands succ\u00e8s de 2003 en Espagne.",
+      "fun_fact": "This Cádiz duo's debut single became one of Spain's biggest hits of 2003. Their flamenco-pop sound and romantic lyrics made them instant stars across the Spanish-speaking world.",
+      "fun_fact_de": "Das Debüt dieses Duos aus Cádiz wurde 2003 einer der größten Hits Spaniens.",
+      "fun_fact_es": "El debut de este dúo de Cádiz se convirtió en uno de los mayores éxitos de 2003 en España.",
+      "fun_fact_fr": "Le premier single de ce duo de Cadix est devenu l'un des plus grands succès de 2003 en Espagne.",
       "uri_apple_music": "applemusic://track/187478561",
       "uri_youtube_music": "https://music.youtube.com/watch?v=hBnlWuJixk0",
       "uri_tidal": "tidal://track/53432",
-      "fun_fact_nl": "De debuutsingle van dit duo uit C\u00e1diz werd een van de grootste hits van Spanje in 2003. Hun flamenco-popgeluid en romantische teksten maakten van hen meteen sterren in de Spaanstalige wereld.",
-      "awards_nl": []
+      "fun_fact_nl": "De debuutsingle van dit duo uit Cádiz werd een van de grootste hits van Spanje in 2003. Hun flamenco-popgeluid en romantische teksten maakten van hen meteen sterren in de Spaanstalige wereld.",
+      "awards_nl": [],
+      "isrc": "ES5020300148",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1317695349",
+        "de": "applemusic://track/1317695349",
+        "gb": "applemusic://track/1317695349",
+        "fr": "applemusic://track/1317695349",
+        "es": "applemusic://track/1317695349",
+        "nl": "applemusic://track/1317695349",
+        "it": "applemusic://track/1317695349"
+      }
     },
     {
       "year": 2015,
       "uri": "spotify:track:4Egb5xP6cniUx0kgZd5zLB",
-      "artist": "Bomba Est\u00e9reo",
+      "artist": "Bomba Estéreo",
       "alt_artists": [
         "Aterciopelados",
         "ChocQuibTown",
-        "Monsieur Perin\u00e9",
+        "Monsieur Periné",
         "Carlos Vives"
       ],
       "title": "Soy Yo",
@@ -3127,14 +4237,24 @@
       "certifications": [],
       "awards": [],
       "fun_fact": "Colombian electro-tropical band whose music video featuring a confident little girl dancing became a viral symbol of self-empowerment and Latina pride.",
-      "fun_fact_de": "Kolumbianische Elektro-Tropical-Band, deren Musikvideo mit einem selbstbewussten tanzenden M\u00e4dchen zum viralen Symbol wurde.",
-      "fun_fact_es": "Banda colombiana de electro-tropical cuyo videoclip con una ni\u00f1a bailando con confianza se convirti\u00f3 en s\u00edmbolo viral de empoderamiento.",
-      "fun_fact_fr": "Groupe colombien d'\u00e9lectro-tropical dont le clip avec une petite fille dansant avec assurance est devenu un symbole viral d'\u00e9mancipation.",
+      "fun_fact_de": "Kolumbianische Elektro-Tropical-Band, deren Musikvideo mit einem selbstbewussten tanzenden Mädchen zum viralen Symbol wurde.",
+      "fun_fact_es": "Banda colombiana de electro-tropical cuyo videoclip con una niña bailando con confianza se convirtió en símbolo viral de empoderamiento.",
+      "fun_fact_fr": "Groupe colombien d'électro-tropical dont le clip avec une petite fille dansant avec assurance est devenu un symbole viral d'émancipation.",
       "uri_apple_music": "applemusic://track/993274903",
       "uri_youtube_music": "https://music.youtube.com/watch?v=bxWxXncl53U",
       "uri_tidal": "tidal://track/45219792",
       "fun_fact_nl": "Colombiaanse electro-tropische band wiens videoclip met een zelfverzekerd dansend klein meisje een viraal symbool werd van zelf-empowerment en Latina trots.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSD11500075",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/993274903",
+        "de": "applemusic://track/993274903",
+        "gb": "applemusic://track/993274903",
+        "fr": "applemusic://track/993274903",
+        "es": "applemusic://track/993274903",
+        "nl": "applemusic://track/993274903",
+        "it": "applemusic://track/993274903"
+      }
     },
     {
       "year": 1969,
@@ -3146,7 +4266,7 @@
         "Rumba Tres",
         "Peret"
       ],
-      "title": "Achilip\u00fa",
+      "title": "Achilipú",
       "chart_info": {
         "billboard_peak": null,
         "uk_peak": null,
@@ -3154,27 +4274,37 @@
       },
       "certifications": [],
       "awards": [],
-      "fun_fact": "Romani singer Dolores Vargas 'La Terremoto' recorded this flamenco-pop gem that became a timeless party classic in Spain \u2014 still played at every verbena 55 years later.",
-      "fun_fact_de": "Die Roma-S\u00e4ngerin Dolores Vargas nahm dieses Flamenco-Pop-Juwel auf, das seit 55 Jahren auf jeder Verbena l\u00e4uft.",
-      "fun_fact_es": "La cantante gitana Dolores Vargas grab\u00f3 esta joya del flamenco-pop que sigue sonando en cada verbena 55 a\u00f1os despu\u00e9s.",
-      "fun_fact_fr": "La chanteuse gitane Dolores Vargas a enregistr\u00e9 ce bijou de flamenco-pop qui r\u00e9sonne encore dans chaque verbena 55 ans plus tard.",
+      "fun_fact": "Romani singer Dolores Vargas 'La Terremoto' recorded this flamenco-pop gem that became a timeless party classic in Spain — still played at every verbena 55 years later.",
+      "fun_fact_de": "Die Roma-Sängerin Dolores Vargas nahm dieses Flamenco-Pop-Juwel auf, das seit 55 Jahren auf jeder Verbena läuft.",
+      "fun_fact_es": "La cantante gitana Dolores Vargas grabó esta joya del flamenco-pop que sigue sonando en cada verbena 55 años después.",
+      "fun_fact_fr": "La chanteuse gitane Dolores Vargas a enregistré ce bijou de flamenco-pop qui résonne encore dans chaque verbena 55 ans plus tard.",
       "uri_apple_music": "applemusic://track/1838064187",
       "uri_youtube_music": "https://music.youtube.com/watch?v=1xu2oTeWg-A",
       "uri_tidal": "tidal://track/458631281",
       "fun_fact_nl": "De Roma-zangeres Dolores Vargas 'La Terremoto' nam dit flamenco-popjuweeltje op dat een tijdloze feestklassieker werd in Spanje - 55 jaar later nog steeds gedraaid op elke verbena.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "ES5299100001",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1838226434",
+        "de": "applemusic://track/1838226434",
+        "gb": "applemusic://track/1838226434",
+        "fr": "applemusic://track/1838226434",
+        "es": "applemusic://track/1838226434",
+        "nl": "applemusic://track/1838226434",
+        "it": "applemusic://track/1838226434"
+      }
     },
     {
       "year": 2002,
       "uri": "spotify:track:2bPH3Ph0RHQuugStXcpyRP",
       "artist": "Chenoa",
       "alt_artists": [
-        "Rosa L\u00f3pez",
+        "Rosa López",
         "Bustamante",
         "David Bisbal",
         "Natalia"
       ],
-      "title": "Cuando T\u00fa Vas",
+      "title": "Cuando Tú Vas",
       "chart_info": {
         "billboard_peak": null,
         "uk_peak": null,
@@ -3182,15 +4312,25 @@
       },
       "certifications": [],
       "awards": [],
-      "fun_fact": "Argentine-born Chenoa was the breakout star of Operaci\u00f3n Triunfo 1 alongside Bisbal and Bustamante. This debut hit showed her powerful voice and became a pop anthem.",
-      "fun_fact_de": "Die in Argentinien geborene Chenoa war der Durchbruchsstar von Operaci\u00f3n Triunfo 1.",
-      "fun_fact_es": "Chenoa, nacida en Argentina, fue la estrella revelaci\u00f3n de OT 1 junto a Bisbal y Bustamante.",
-      "fun_fact_fr": "N\u00e9e en Argentine, Chenoa fut la star r\u00e9v\u00e9lation d'OT 1 aux c\u00f4t\u00e9s de Bisbal et Bustamante.",
+      "fun_fact": "Argentine-born Chenoa was the breakout star of Operación Triunfo 1 alongside Bisbal and Bustamante. This debut hit showed her powerful voice and became a pop anthem.",
+      "fun_fact_de": "Die in Argentinien geborene Chenoa war der Durchbruchsstar von Operación Triunfo 1.",
+      "fun_fact_es": "Chenoa, nacida en Argentina, fue la estrella revelación de OT 1 junto a Bisbal y Bustamante.",
+      "fun_fact_fr": "Née en Argentine, Chenoa fut la star révélation d'OT 1 aux côtés de Bisbal et Bustamante.",
       "uri_apple_music": "applemusic://track/1577413066",
       "uri_youtube_music": "https://music.youtube.com/watch?v=E2N6UahtzK4",
       "uri_tidal": "tidal://track/36953844",
-      "fun_fact_nl": "De in Argentini\u00eb geboren Chenoa was de ster van Operaci\u00f3n Triunfo 1 naast Bisbal en Bustamante. Deze debuuthit liet haar krachtige stem horen en werd een pophymne.",
-      "awards_nl": []
+      "fun_fact_nl": "De in Argentinië geboren Chenoa was de ster van Operación Triunfo 1 naast Bisbal en Bustamante. Deze debuuthit liet haar krachtige stem horen en werd een pophymne.",
+      "awards_nl": [],
+      "isrc": "ES6010200167",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1698228736",
+        "de": "applemusic://track/1698228736",
+        "gb": "applemusic://track/1698228736",
+        "fr": "applemusic://track/1698228736",
+        "es": "applemusic://track/1698228736",
+        "nl": "applemusic://track/1698228736",
+        "it": "applemusic://track/1698228736"
+      }
     },
     {
       "year": 2000,
@@ -3198,7 +4338,7 @@
       "artist": "Camela",
       "alt_artists": [
         "Los Calis",
-        "\u00c1ngeles de Charli",
+        "Ángeles de Charli",
         "Andy & Lucas",
         "El Arrebato"
       ],
@@ -3210,27 +4350,37 @@
       },
       "certifications": [],
       "awards": [],
-      "fun_fact": "Different Camela hit \u2014 this techno-flamenco ballad is considered their masterpiece and one of the most iconic Spanish guilty pleasure songs ever recorded.",
-      "fun_fact_de": "Anderer Camela-Hit \u2014 diese Techno-Flamenco-Ballade gilt als ihr Meisterwerk und gr\u00f6\u00dfter Guilty-Pleasure-Song Spaniens.",
-      "fun_fact_es": "Otro \u00e9xito de Camela \u2014 esta balada de tecno-flamenco es considerada su obra maestra y uno de los mayores 'guilty pleasures' de la m\u00fasica espa\u00f1ola.",
-      "fun_fact_fr": "Autre tube de Camela \u2014 cette ballade techno-flamenco est consid\u00e9r\u00e9e comme leur chef-d'\u0153uvre et l'un des plus grands 'guilty pleasures' de la musique espagnole.",
+      "fun_fact": "Different Camela hit — this techno-flamenco ballad is considered their masterpiece and one of the most iconic Spanish guilty pleasure songs ever recorded.",
+      "fun_fact_de": "Anderer Camela-Hit — diese Techno-Flamenco-Ballade gilt als ihr Meisterwerk und größter Guilty-Pleasure-Song Spaniens.",
+      "fun_fact_es": "Otro éxito de Camela — esta balada de tecno-flamenco es considerada su obra maestra y uno de los mayores 'guilty pleasures' de la música española.",
+      "fun_fact_fr": "Autre tube de Camela — cette ballade techno-flamenco est considérée comme leur chef-d'œuvre et l'un des plus grands 'guilty pleasures' de la musique espagnole.",
       "uri_apple_music": "applemusic://track/696601345",
       "uri_youtube_music": "https://music.youtube.com/watch?v=eVSIjE8FIi8",
       "uri_tidal": "tidal://track/39833430",
       "fun_fact_nl": "Andere Camela hit - deze techno-flamenco ballade wordt beschouwd als hun meesterwerk en als een van de meest iconische Spaanse guilty pleasure nummers ooit opgenomen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "ES5080400083",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1684785345",
+        "de": "applemusic://track/1800442770",
+        "gb": "applemusic://track/1800442770",
+        "fr": "applemusic://track/1800442770",
+        "es": "applemusic://track/1800442770",
+        "nl": "applemusic://track/1800442770",
+        "it": "applemusic://track/1800442770"
+      }
     },
     {
       "year": 1979,
       "uri": "spotify:track:7EWKAYWmUc1cTfEimTKvou",
       "artist": "Pecos",
       "alt_artists": [
-        "Miguel Bos\u00e9",
-        "Lorenzo Santamar\u00eda",
+        "Miguel Bosé",
+        "Lorenzo Santamaría",
         "Camilo Sesto",
         "Nino Bravo"
       ],
-      "title": "H\u00e1blame de Ti",
+      "title": "Háblame de Ti",
       "chart_info": {
         "billboard_peak": null,
         "uk_peak": null,
@@ -3238,22 +4388,32 @@
       },
       "certifications": [],
       "awards": [],
-      "fun_fact": "Teen idol brothers from Madrid who caused 'Pecosmania' in late 70s Spain \u2014 the Spanish Beatlemania. Girls fainted at their concerts and they sold millions of records.",
-      "fun_fact_de": "Teenager-Idol-Br\u00fcder aus Madrid, die Ende der 70er 'Pecosmania' ausl\u00f6sten \u2014 die spanische Beatlemania.",
-      "fun_fact_es": "Hermanos \u00eddolos adolescentes de Madrid que causaron la 'Pecosman\u00eda' a finales de los 70 \u2014 la Beatleman\u00eda espa\u00f1ola.",
-      "fun_fact_fr": "Fr\u00e8res idoles adolescentes de Madrid qui ont d\u00e9clench\u00e9 la 'Pecosmania' \u00e0 la fin des ann\u00e9es 70 \u2014 la Beatlemania espagnole.",
+      "fun_fact": "Teen idol brothers from Madrid who caused 'Pecosmania' in late 70s Spain — the Spanish Beatlemania. Girls fainted at their concerts and they sold millions of records.",
+      "fun_fact_de": "Teenager-Idol-Brüder aus Madrid, die Ende der 70er 'Pecosmania' auslösten — die spanische Beatlemania.",
+      "fun_fact_es": "Hermanos ídolos adolescentes de Madrid que causaron la 'Pecosmanía' a finales de los 70 — la Beatlemanía española.",
+      "fun_fact_fr": "Frères idoles adolescentes de Madrid qui ont déclenché la 'Pecosmania' à la fin des années 70 — la Beatlemania espagnole.",
       "uri_apple_music": "applemusic://track/507397831",
       "uri_youtube_music": "https://music.youtube.com/watch?v=YrIkw6EjS0w",
       "uri_tidal": "tidal://track/34132522",
       "fun_fact_nl": "Tieneridoolbroers uit Madrid die eind jaren 70 in Spanje 'Pecosmania' veroorzaakten - de Spaanse Beatlemania. Meisjes vielen flauw tijdens hun concerten en ze verkochten miljoenen platen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "ES5117900040",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1591592211",
+        "de": "applemusic://track/1591592211",
+        "gb": "applemusic://track/1591592211",
+        "fr": "applemusic://track/1591592211",
+        "es": "applemusic://track/1591592211",
+        "nl": "applemusic://track/1591592211",
+        "it": "applemusic://track/1591592211"
+      }
     },
     {
       "year": 2011,
       "uri": "spotify:track:1d5obgzCOtwq9qaxfe4Hpw",
-      "artist": "Jos\u00e9 de Rico, Henry Mendez",
+      "artist": "José de Rico, Henry Mendez",
       "alt_artists": [
-        "Juan Mag\u00e1n",
+        "Juan Magán",
         "Dasoul",
         "Danny Romero",
         "Joey Montana"
@@ -3267,23 +4427,33 @@
       "certifications": [],
       "awards": [],
       "fun_fact": "This reggaeton-pop crossover became THE Spanish summer anthem of 2011, inescapable on every beach, club and radio station across Spain.",
-      "fun_fact_de": "Dieser Reggaeton-Pop-Crossover wurde DER spanische Sommerhit 2011 \u2014 an jedem Strand, in jedem Club, auf jedem Sender.",
-      "fun_fact_es": "Este crossover de reggaet\u00f3n-pop se convirti\u00f3 en EL himno del verano espa\u00f1ol de 2011, ineludible en playas, discotecas y emisoras.",
-      "fun_fact_fr": "Ce crossover reggaeton-pop est devenu L'hymne de l'\u00e9t\u00e9 espagnol 2011, incontournable sur chaque plage, club et radio.",
+      "fun_fact_de": "Dieser Reggaeton-Pop-Crossover wurde DER spanische Sommerhit 2011 — an jedem Strand, in jedem Club, auf jedem Sender.",
+      "fun_fact_es": "Este crossover de reggaetón-pop se convirtió en EL himno del verano español de 2011, ineludible en playas, discotecas y emisoras.",
+      "fun_fact_fr": "Ce crossover reggaeton-pop est devenu L'hymne de l'été espagnol 2011, incontournable sur chaque plage, club et radio.",
       "uri_apple_music": "applemusic://track/945394223",
       "uri_youtube_music": "https://music.youtube.com/watch?v=SVjs5DYDWt0",
       "uri_tidal": "tidal://track/19876230",
       "fun_fact_nl": "Deze reggaeton-pop crossover werd HET Spaanse zomerlied van 2011, niet weg te denken van elk strand, elke club en elk radiostation in heel Spanje.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "ES1611100061",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/945394223",
+        "de": "applemusic://track/945394223",
+        "gb": "applemusic://track/945394223",
+        "fr": "applemusic://track/945394223",
+        "es": "applemusic://track/636454225",
+        "nl": "applemusic://track/945394223",
+        "it": "applemusic://track/945394223"
+      }
     },
     {
       "year": 1999,
       "uri": "spotify:track:4Kii4OhkRIezu0KjOiFq0G",
-      "artist": "Joaqu\u00edn Sabina",
+      "artist": "Joaquín Sabina",
       "alt_artists": [
         "Luis Eduardo Aute",
         "Joan Manuel Serrat",
-        "Andr\u00e9s Calamaro",
+        "Andrés Calamaro",
         "Alejandro Sanz"
       ],
       "title": "19 Dias y 500 Noches",
@@ -3294,25 +4464,35 @@
       },
       "certifications": [],
       "awards": [],
-      "fun_fact": "Considered Sabina's greatest song \u2014 a bittersweet breakup masterpiece. The album of the same name is one of the best-selling Spanish-language albums ever in Spain.",
-      "fun_fact_de": "Gilt als Sabinas gr\u00f6\u00dfter Song \u2014 ein bitters\u00fc\u00dfes Trennungsmeisterwerk. Das gleichnamige Album ist eines der meistverkauften in Spanien.",
-      "fun_fact_es": "Considerada la mejor canci\u00f3n de Sabina \u2014 una obra maestra agridulce de desamor. El \u00e1lbum hom\u00f3nimo es uno de los m\u00e1s vendidos en Espa\u00f1a.",
-      "fun_fact_fr": "Consid\u00e9r\u00e9e comme la plus grande chanson de Sabina \u2014 un chef-d'\u0153uvre amer de rupture. L'album \u00e9ponyme est l'un des plus vendus en Espagne.",
+      "fun_fact": "Considered Sabina's greatest song — a bittersweet breakup masterpiece. The album of the same name is one of the best-selling Spanish-language albums ever in Spain.",
+      "fun_fact_de": "Gilt als Sabinas größter Song — ein bittersüßes Trennungsmeisterwerk. Das gleichnamige Album ist eines der meistverkauften in Spanien.",
+      "fun_fact_es": "Considerada la mejor canción de Sabina — una obra maestra agridulce de desamor. El álbum homónimo es uno de los más vendidos en España.",
+      "fun_fact_fr": "Considérée comme la plus grande chanson de Sabina — un chef-d'œuvre amer de rupture. L'album éponyme est l'un des plus vendus en Espagne.",
       "uri_apple_music": "applemusic://track/254639963",
       "uri_youtube_music": "https://music.youtube.com/watch?v=cmmJ1uiRiUM",
       "uri_tidal": "tidal://track/30216384",
       "fun_fact_nl": "Beschouwd als Sabina's beste nummer - een bitterzoet meesterwerk over een gebroken relatie. Het gelijknamige album is een van de best verkochte Spaanstalige albums ooit in Spanje.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "ES5029900169",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1478351788",
+        "de": "applemusic://track/1478351788",
+        "gb": "applemusic://track/1478351788",
+        "fr": "applemusic://track/1478351788",
+        "es": "applemusic://track/1478351788",
+        "nl": "applemusic://track/1478351788",
+        "it": "applemusic://track/1478351788"
+      }
     },
     {
       "year": 1981,
       "uri": "spotify:track:3A58rEqzY7fwWSOnlB2AxB",
       "artist": "COZ",
       "alt_artists": [
-        "Le\u00f1o",
+        "Leño",
         "Burning",
         "Tequila",
-        "Ramonc\u00edn"
+        "Ramoncín"
       ],
       "title": "Las Chicas Son Guerreras",
       "chart_info": {
@@ -3322,15 +4502,25 @@
       },
       "certifications": [],
       "awards": [],
-      "fun_fact": "Proto-punk anthem from the early Movida Madrile\u00f1a. COZ were one of the first bands of the movement, and this feminist-tinged track became a generational rallying cry.",
-      "fun_fact_de": "Proto-Punk-Hymne der fr\u00fchen Movida Madrile\u00f1a. COZ waren eine der ersten Bands der Bewegung.",
+      "fun_fact": "Proto-punk anthem from the early Movida Madrileña. COZ were one of the first bands of the movement, and this feminist-tinged track became a generational rallying cry.",
+      "fun_fact_de": "Proto-Punk-Hymne der frühen Movida Madrileña. COZ waren eine der ersten Bands der Bewegung.",
       "fun_fact_es": "Himno proto-punk de los inicios de La Movida. COZ fueron una de las primeras bandas del movimiento.",
-      "fun_fact_fr": "Hymne proto-punk des d\u00e9buts de La Movida. COZ fut l'un des premiers groupes du mouvement.",
+      "fun_fact_fr": "Hymne proto-punk des débuts de La Movida. COZ fut l'un des premiers groupes du mouvement.",
       "uri_apple_music": "applemusic://track/1563444974",
       "uri_youtube_music": "https://music.youtube.com/watch?v=rq6nOjw9TjU",
       "uri_tidal": "tidal://track/19715861",
-      "fun_fact_nl": "Proto-punk hymne van de vroege Movida Madrile\u00f1a. COZ was een van de eerste bands van de beweging en dit feministisch getinte nummer werd een generatieroepskreet.",
-      "awards_nl": []
+      "fun_fact_nl": "Proto-punk hymne van de vroege Movida Madrileña. COZ was een van de eerste bands van de beweging en dit feministisch getinte nummer werd een generatieroepskreet.",
+      "awards_nl": [],
+      "isrc": "ES5021600431",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1643710176",
+        "de": "applemusic://track/1643710176",
+        "gb": "applemusic://track/1643710176",
+        "fr": "applemusic://track/1643710176",
+        "es": "applemusic://track/1643710176",
+        "nl": "applemusic://track/1643710176",
+        "it": "applemusic://track/1643710176"
+      }
     },
     {
       "year": 1986,
@@ -3342,7 +4532,7 @@
         "Radio Futura",
         "Duncan Dhu"
       ],
-      "title": "Su\u00e9ltate el pelo",
+      "title": "Suéltate el pelo",
       "chart_info": {
         "billboard_peak": null,
         "uk_peak": null,
@@ -3350,15 +4540,25 @@
       },
       "certifications": [],
       "awards": [],
-      "fun_fact": "Another Hombres G classic \u2014 David Summers and crew dominated Spanish pop in the 80s with their catchy, Beatlesque melodies and humorous lyrics about young love.",
-      "fun_fact_de": "Weiterer Hombres G Klassiker \u2014 David Summers dominierte den spanischen Pop der 80er.",
-      "fun_fact_es": "Otro cl\u00e1sico de Hombres G \u2014 David Summers domin\u00f3 el pop espa\u00f1ol de los 80 con sus melod\u00edas pegadizas.",
-      "fun_fact_fr": "Autre classique d'Hombres G \u2014 David Summers a domin\u00e9 la pop espagnole des ann\u00e9es 80.",
+      "fun_fact": "Another Hombres G classic — David Summers and crew dominated Spanish pop in the 80s with their catchy, Beatlesque melodies and humorous lyrics about young love.",
+      "fun_fact_de": "Weiterer Hombres G Klassiker — David Summers dominierte den spanischen Pop der 80er.",
+      "fun_fact_es": "Otro clásico de Hombres G — David Summers dominó el pop español de los 80 con sus melodías pegadizas.",
+      "fun_fact_fr": "Autre classique d'Hombres G — David Summers a dominé la pop espagnole des années 80.",
       "uri_apple_music": "applemusic://track/257173190",
       "uri_youtube_music": "https://music.youtube.com/watch?v=u98N0XJtkjs",
       "uri_tidal": "tidal://track/323692",
-      "fun_fact_nl": "Nog een Hombres G-klassieker - David Summers en zijn crew domineerden de Spaanse pop in de jaren 80 met hun aanstekelijke, Beatles-achtige melodie\u00ebn en humoristische teksten over jonge liefde.",
-      "awards_nl": []
+      "fun_fact_nl": "Nog een Hombres G-klassieker - David Summers en zijn crew domineerden de Spaanse pop in de jaren 80 met hun aanstekelijke, Beatles-achtige melodieën en humoristische teksten over jonge liefde.",
+      "awards_nl": [],
+      "isrc": "ES5018872005",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/80836759",
+        "de": "applemusic://track/80836759",
+        "gb": "applemusic://track/80836759",
+        "fr": "applemusic://track/80836759",
+        "es": "applemusic://track/80836759",
+        "nl": "applemusic://track/80836759",
+        "it": "applemusic://track/80836759"
+      }
     },
     {
       "year": 1990,
@@ -3378,15 +4578,25 @@
       },
       "certifications": [],
       "awards": [],
-      "fun_fact": "One of Spain's most absurdist comedy-rock bands from Sevilla. Their name means 'Don't Step on Me I'm Wearing Flip-Flops' \u2014 and the music is exactly as unhinged as you'd expect.",
+      "fun_fact": "One of Spain's most absurdist comedy-rock bands from Sevilla. Their name means 'Don't Step on Me I'm Wearing Flip-Flops' — and the music is exactly as unhinged as you'd expect.",
       "fun_fact_de": "Eine der absurdesten Comedy-Rock-Bands Spaniens aus Sevilla. Der Name bedeutet 'Tritt mir nicht drauf, ich trage Flip-Flops'.",
-      "fun_fact_es": "Una de las bandas de comedia-rock m\u00e1s absurdas de Espa\u00f1a, de Sevilla. Su nombre significa 'No me pises que llevo chanclas'.",
-      "fun_fact_fr": "L'un des groupes de com\u00e9die-rock les plus absurdes d'Espagne, de S\u00e9ville. Leur nom signifie 'Ne me marche pas dessus, je porte des tongs'.",
+      "fun_fact_es": "Una de las bandas de comedia-rock más absurdas de España, de Sevilla. Su nombre significa 'No me pises que llevo chanclas'.",
+      "fun_fact_fr": "L'un des groupes de comédie-rock les plus absurdes d'Espagne, de Séville. Leur nom signifie 'Ne me marche pas dessus, je porte des tongs'.",
       "uri_apple_music": "applemusic://track/1405339817",
       "uri_youtube_music": "https://music.youtube.com/watch?v=8OVesjOfsME",
       "uri_tidal": "tidal://track/91126498",
       "fun_fact_nl": "Een van de meest absurdistische comedy-rockbands van Spanje uit Sevilla. Hun naam betekent 'Don't Step on Me I'm Wearing Flip-Flops' - en de muziek is precies zo gestoord als je zou verwachten.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "ES5021800453",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1405339817",
+        "de": "applemusic://track/1405339817",
+        "gb": "applemusic://track/1405339817",
+        "fr": "applemusic://track/1405339817",
+        "es": "applemusic://track/1405339817",
+        "nl": "applemusic://track/1405339817",
+        "it": "applemusic://track/1405339817"
+      }
     },
     {
       "year": 1986,
@@ -3406,15 +4616,25 @@
       },
       "certifications": [],
       "awards": [],
-      "fun_fact": "Ole Ole featuring a young Vicky Larraz (later Marta S\u00e1nchez) was one of the defining pop acts of 80s Spain. This synth-pop hit captured the carefree spirit of the era.",
-      "fun_fact_de": "Ole Ole mit der jungen Vicky Larraz war eine der pr\u00e4genden Pop-Acts der 80er in Spanien.",
-      "fun_fact_es": "Ole Ole con la joven Vicky Larraz fue uno de los grupos pop definitorios de los 80 en Espa\u00f1a.",
-      "fun_fact_fr": "Ole Ole avec la jeune Vicky Larraz fut l'un des groupes pop phares des ann\u00e9es 80 en Espagne.",
+      "fun_fact": "Ole Ole featuring a young Vicky Larraz (later Marta Sánchez) was one of the defining pop acts of 80s Spain. This synth-pop hit captured the carefree spirit of the era.",
+      "fun_fact_de": "Ole Ole mit der jungen Vicky Larraz war eine der prägenden Pop-Acts der 80er in Spanien.",
+      "fun_fact_es": "Ole Ole con la joven Vicky Larraz fue uno de los grupos pop definitorios de los 80 en España.",
+      "fun_fact_fr": "Ole Ole avec la jeune Vicky Larraz fut l'un des groupes pop phares des années 80 en Espagne.",
       "uri_apple_music": "applemusic://track/792546172",
       "uri_youtube_music": "https://music.youtube.com/watch?v=WhEwJCtMWbQ",
       "uri_tidal": "tidal://track/5792715",
-      "fun_fact_nl": "Ole Ole met een jonge Vicky Larraz (later Marta S\u00e1nchez) was een van de bepalende popacts van het Spanje van de jaren 80. Deze synthpophit vatte de zorgeloze geest van die tijd.",
-      "awards_nl": []
+      "fun_fact_nl": "Ole Ole met een jonge Vicky Larraz (later Marta Sánchez) was een van de bepalende popacts van het Spanje van de jaren 80. Deze synthpophit vatte de zorgeloze geest van die tijd.",
+      "awards_nl": [],
+      "isrc": "ES5088703839",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1573213378",
+        "de": "applemusic://track/1573213378",
+        "gb": "applemusic://track/1573213378",
+        "fr": "applemusic://track/1573213378",
+        "es": "applemusic://track/1573213378",
+        "nl": "applemusic://track/1573213378",
+        "it": "applemusic://track/1573213378"
+      }
     },
     {
       "year": 1988,
@@ -3435,14 +4655,24 @@
       "certifications": [],
       "awards": [],
       "fun_fact": "Barcelona rockabilly band who brought the greaser aesthetic to Spain. Fronted by Carlos Segarra, they were the louder, wilder cousins of Loquillo in the Spanish rock scene.",
-      "fun_fact_de": "Barcelonas Rockabilly-Band, die die Greaser-\u00c4sthetik nach Spanien brachte.",
-      "fun_fact_es": "Banda de rockabilly de Barcelona que trajo la est\u00e9tica greaser a Espa\u00f1a.",
-      "fun_fact_fr": "Groupe rockabilly de Barcelone qui a apport\u00e9 l'esth\u00e9tique greaser en Espagne.",
+      "fun_fact_de": "Barcelonas Rockabilly-Band, die die Greaser-Ästhetik nach Spanien brachte.",
+      "fun_fact_es": "Banda de rockabilly de Barcelona que trajo la estética greaser a España.",
+      "fun_fact_fr": "Groupe rockabilly de Barcelone qui a apporté l'esthétique greaser en Espagne.",
       "uri_apple_music": "applemusic://track/942842288",
       "uri_youtube_music": "https://music.youtube.com/watch?v=xG_z6AOkh8A",
       "uri_tidal": "tidal://track/38026240",
       "fun_fact_nl": "Rockabillyband uit Barcelona die de greaser-esthetiek naar Spanje bracht. Onder leiding van Carlos Segarra waren ze de luidere, wildere neven van Loquillo in de Spaanse rockscene.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "ES5118801608",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/942842288",
+        "de": "applemusic://track/942842288",
+        "gb": "applemusic://track/942842288",
+        "fr": "applemusic://track/942842288",
+        "es": "applemusic://track/942842288",
+        "nl": "applemusic://track/942842288",
+        "it": "applemusic://track/942842288"
+      }
     },
     {
       "year": 2001,
@@ -3451,7 +4681,7 @@
       "alt_artists": [
         "Las Ketchup",
         "Bom Bom Chip",
-        "Bimba Bos\u00e9",
+        "Bimba Bosé",
         "Zapato Veloz"
       ],
       "title": "El Baile del Gorila",
@@ -3463,22 +4693,32 @@
       "certifications": [],
       "awards": [],
       "fun_fact": "Melody was just 11 years old when this novelty dance track became Spain's biggest hit of 2001. Every Spanish person born in the 90s knows this choreography by heart.",
-      "fun_fact_de": "Melody war erst 11 Jahre alt, als dieser Tanz-Hit 2001 zum gr\u00f6\u00dften Hit Spaniens wurde. Jeder in den 90ern geborene Spanier kennt die Choreografie.",
-      "fun_fact_es": "Melody ten\u00eda solo 11 a\u00f1os cuando este tema de baile se convirti\u00f3 en el mayor \u00e9xito de 2001. Todo espa\u00f1ol nacido en los 90 conoce la coreograf\u00eda.",
-      "fun_fact_fr": "Melody n'avait que 11 ans quand ce titre de danse est devenu le plus grand succ\u00e8s de 2001. Tout Espagnol n\u00e9 dans les ann\u00e9es 90 conna\u00eet la chor\u00e9graphie.",
+      "fun_fact_de": "Melody war erst 11 Jahre alt, als dieser Tanz-Hit 2001 zum größten Hit Spaniens wurde. Jeder in den 90ern geborene Spanier kennt die Choreografie.",
+      "fun_fact_es": "Melody tenía solo 11 años cuando este tema de baile se convirtió en el mayor éxito de 2001. Todo español nacido en los 90 conoce la coreografía.",
+      "fun_fact_fr": "Melody n'avait que 11 ans quand ce titre de danse est devenu le plus grand succès de 2001. Tout Espagnol né dans les années 90 connaît la chorégraphie.",
       "uri_apple_music": "applemusic://track/604951692",
       "uri_youtube_music": "https://music.youtube.com/watch?v=90avMgG5NAM",
       "uri_tidal": "tidal://track/34168280",
       "fun_fact_nl": "Melody was net 11 jaar oud toen dit dansnummer de grootste hit van 2001 in Spanje werd. Elke Spanjaard die in de jaren 90 is geboren kent deze choreografie uit zijn hoofd.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "ES5110103506",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1642779769",
+        "de": "applemusic://track/1642779769",
+        "gb": "applemusic://track/1642779769",
+        "fr": "applemusic://track/1642779769",
+        "es": "applemusic://track/1642779769",
+        "nl": "applemusic://track/1642779769",
+        "it": "applemusic://track/1642779769"
+      }
     },
     {
       "year": 1989,
       "uri": "spotify:track:7iN1s7xHE4ifF5povM6A48",
       "artist": "Isabel Pantoja",
       "alt_artists": [
-        "Roc\u00edo Jurado",
-        "Mar\u00eda del Monte",
+        "Rocío Jurado",
+        "María del Monte",
         "Pastora Soler",
         "Lola Flores"
       ],
@@ -3490,15 +4730,25 @@
       },
       "certifications": [],
       "awards": [],
-      "fun_fact": "Isabel Pantoja \u2014 the most famous copla singer alive and Spain's most tabloid-covered celebrity. Widow of bullfighter Paquirri, her dramatic life has been a national obsession for 40 years.",
-      "fun_fact_de": "Isabel Pantoja \u2014 ber\u00fchmteste lebende Copla-S\u00e4ngerin und Spaniens meist-diskutierte Ber\u00fchmtheit. Seit 40 Jahren nationale Obsession.",
-      "fun_fact_es": "Isabel Pantoja \u2014 la cantante de copla m\u00e1s famosa viva y la celebridad m\u00e1s perseguida por la prensa en Espa\u00f1a. Obsesi\u00f3n nacional desde hace 40 a\u00f1os.",
-      "fun_fact_fr": "Isabel Pantoja \u2014 la plus c\u00e9l\u00e8bre chanteuse de copla vivante et la c\u00e9l\u00e9brit\u00e9 la plus m\u00e9diatis\u00e9e d'Espagne. Obsession nationale depuis 40 ans.",
+      "fun_fact": "Isabel Pantoja — the most famous copla singer alive and Spain's most tabloid-covered celebrity. Widow of bullfighter Paquirri, her dramatic life has been a national obsession for 40 years.",
+      "fun_fact_de": "Isabel Pantoja — berühmteste lebende Copla-Sängerin und Spaniens meist-diskutierte Berühmtheit. Seit 40 Jahren nationale Obsession.",
+      "fun_fact_es": "Isabel Pantoja — la cantante de copla más famosa viva y la celebridad más perseguida por la prensa en España. Obsesión nacional desde hace 40 años.",
+      "fun_fact_fr": "Isabel Pantoja — la plus célèbre chanteuse de copla vivante et la célébrité la plus médiatisée d'Espagne. Obsession nationale depuis 40 ans.",
       "uri_apple_music": "applemusic://track/1314179266",
       "uri_youtube_music": "https://music.youtube.com/watch?v=Ew3EWyDBhy0",
       "uri_tidal": "tidal://track/3133949",
       "fun_fact_nl": "Isabel Pantoja - de beroemdste coplazangeres die nog leeft en de beroemdheid van Spanje die het meest in de publiciteit komt. Als weduwe van stierenvechter Paquirri is haar dramatische leven al 40 jaar een nationale obsessie.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "ES5028900068",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1719221990",
+        "de": "applemusic://track/1719221990",
+        "gb": "applemusic://track/1719221990",
+        "fr": "applemusic://track/1719221990",
+        "es": "applemusic://track/1719221990",
+        "nl": "applemusic://track/1719221990",
+        "it": "applemusic://track/1719221990"
+      }
     },
     {
       "year": 2016,
@@ -3519,14 +4769,24 @@
       "certifications": [],
       "awards": [],
       "fun_fact": "Barcelona indie-rock band who became Spain's biggest independent act. Known for hosting a 5,000-person COVID-safe concert in 2021 that made international headlines.",
-      "fun_fact_de": "Barcelonas Indie-Rock-Band, die Spaniens gr\u00f6\u00dfter Independent-Act wurde. Bekannt f\u00fcr ein COVID-sicheres Konzert mit 5.000 Besuchern 2021.",
-      "fun_fact_es": "Banda indie-rock de Barcelona que se convirti\u00f3 en el mayor acto independiente de Espa\u00f1a. Famosos por su concierto COVID-seguro de 5.000 personas en 2021.",
-      "fun_fact_fr": "Groupe indie-rock de Barcelone devenu le plus grand acte ind\u00e9pendant d'Espagne. C\u00e9l\u00e8bres pour leur concert COVID-safe de 5.000 personnes en 2021.",
+      "fun_fact_de": "Barcelonas Indie-Rock-Band, die Spaniens größter Independent-Act wurde. Bekannt für ein COVID-sicheres Konzert mit 5.000 Besuchern 2021.",
+      "fun_fact_es": "Banda indie-rock de Barcelona que se convirtió en el mayor acto independiente de España. Famosos por su concierto COVID-seguro de 5.000 personas en 2021.",
+      "fun_fact_fr": "Groupe indie-rock de Barcelone devenu le plus grand acte indépendant d'Espagne. Célèbres pour leur concert COVID-safe de 5.000 personnes en 2021.",
       "uri_apple_music": "applemusic://track/655700766",
       "uri_youtube_music": "https://music.youtube.com/watch?v=WNbW2MOJxcY",
       "uri_tidal": "tidal://track/20686792",
       "fun_fact_nl": "Indie-rockband uit Barcelona die uitgroeide tot de grootste onafhankelijke act van Spanje. Bekend van het organiseren van een 5.000-koppig COVID-veilig concert in 2021 dat internationaal de krantenkoppen haalde.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "ES7651300037",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/655700766",
+        "de": "applemusic://track/655700766",
+        "gb": "applemusic://track/655700766",
+        "fr": "applemusic://track/655700766",
+        "es": "applemusic://track/655700766",
+        "nl": "applemusic://track/655700766",
+        "it": "applemusic://track/655700766"
+      }
     },
     {
       "year": 2018,
@@ -3546,15 +4806,25 @@
       },
       "certifications": [],
       "awards": [],
-      "fun_fact": "Leiva (ex-Pereza) is one of Spain's most respected rock songwriters. After his band broke up, his solo career became even bigger \u2014 filling stadiums across Spain.",
+      "fun_fact": "Leiva (ex-Pereza) is one of Spain's most respected rock songwriters. After his band broke up, his solo career became even bigger — filling stadiums across Spain.",
       "fun_fact_de": "Leiva (ex-Pereza) ist einer der angesehensten Rock-Songwriter Spaniens. Solo noch erfolgreicher als mit Band.",
-      "fun_fact_es": "Leiva (ex Pereza) es uno de los compositores de rock m\u00e1s respetados de Espa\u00f1a. En solitario a\u00fan m\u00e1s exitoso que con su banda.",
-      "fun_fact_fr": "Leiva (ex-Pereza) est l'un des compositeurs rock les plus respect\u00e9s d'Espagne. Plus grand succ\u00e8s en solo qu'avec son groupe.",
+      "fun_fact_es": "Leiva (ex Pereza) es uno de los compositores de rock más respetados de España. En solitario aún más exitoso que con su banda.",
+      "fun_fact_fr": "Leiva (ex-Pereza) est l'un des compositeurs rock les plus respectés d'Espagne. Plus grand succès en solo qu'avec son groupe.",
       "uri_apple_music": "applemusic://track/1123044441",
       "uri_youtube_music": "https://music.youtube.com/watch?v=q808C7Lawmo",
       "uri_tidal": "tidal://track/63177405",
-      "fun_fact_nl": "Leiva (ex-Pereza) is een van de meest gerespecteerde Spaanse rockliedjesschrijvers. Nadat zijn band uit elkaar ging, werd zijn solocarri\u00e8re nog groter en vulde hij stadions in heel Spanje.",
-      "awards_nl": []
+      "fun_fact_nl": "Leiva (ex-Pereza) is een van de meest gerespecteerde Spaanse rockliedjesschrijvers. Nadat zijn band uit elkaar ging, werd zijn solocarrière nog groter en vulde hij stadions in heel Spanje.",
+      "awards_nl": [],
+      "isrc": "ES5021600376",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1123044441",
+        "de": "applemusic://track/1123044441",
+        "gb": "applemusic://track/1123044441",
+        "fr": "applemusic://track/1123044441",
+        "es": "applemusic://track/1123044441",
+        "nl": "applemusic://track/1123044441",
+        "it": "applemusic://track/1123044441"
+      }
     }
   ]
 }

--- a/custom_components/beatify/playlists/community/koelner-karneval.json
+++ b/custom_components/beatify/playlists/community/koelner-karneval.json
@@ -36,7 +36,17 @@
       "uri_tidal": "tidal://track/1501197",
       "uri_deezer": "deezer://track/4228741",
       "fun_fact_nl": "Dit nummer, geschreven in 1964, werd het onofficiële volkslied van de Keulse vriendelijkheid - de titel betekent 'Drink er eentje met me mee' in het Kölsch dialect.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEF067312110",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1442246732",
+        "de": "applemusic://track/1442246732",
+        "gb": "applemusic://track/1442246732",
+        "fr": "applemusic://track/1442246732",
+        "es": "applemusic://track/1442246732",
+        "nl": "applemusic://track/1442246732",
+        "it": "applemusic://track/1442246732"
+      }
     },
     {
       "year": 1990,
@@ -61,7 +71,17 @@
       "uri_tidal": "tidal://track/55096544",
       "uri_deezer": "deezer://track/114984842",
       "fun_fact_nl": "Een tijdloos carnavalsliefdeslied van Paveier; 'Leev Marie' (Lieve Marie) toont de romantische kant van de Keulse carnavalsmuziek.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DED191500038",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1658093804",
+        "de": "applemusic://track/1658093804",
+        "gb": "applemusic://track/1658093804",
+        "fr": "applemusic://track/1658093804",
+        "es": "applemusic://track/1658093804",
+        "nl": "applemusic://track/1658093804",
+        "it": "applemusic://track/1658093804"
+      }
     },
     {
       "year": 2014,
@@ -86,7 +106,17 @@
       "uri_tidal": "tidal://track/101873744",
       "uri_deezer": "deezer://track/613096662",
       "fun_fact_nl": "De Beierse band voXXclub coverde dit klassieke Keulse liefdeslied, waardoor de Keulse carnavalsgeest ook buiten de regio bekend werd.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEUM71807194",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1700802293",
+        "de": "applemusic://track/1700802293",
+        "gb": "applemusic://track/1700802293",
+        "fr": "applemusic://track/1700802293",
+        "es": "applemusic://track/1700802293",
+        "nl": "applemusic://track/1700802293",
+        "it": "applemusic://track/1700802293"
+      }
     },
     {
       "year": 1997,
@@ -110,7 +140,17 @@
       "uri_tidal": "tidal://track/11203285",
       "uri_deezer": "deezer://track/3155953",
       "fun_fact_nl": "Een van de vroegste hits van de Höhner uit 1971, opnieuw opgenomen in 1997 - de titel 'Ik ben een rover' speelt in op de speelse Keulse dialecthumor.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEA349700161",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/724021715",
+        "de": "applemusic://track/1384484805",
+        "gb": "applemusic://track/1384484805",
+        "fr": "applemusic://track/1384484805",
+        "es": "applemusic://track/1384484805",
+        "nl": "applemusic://track/1384484805",
+        "it": "applemusic://track/1384484805"
+      }
     },
     {
       "year": 1973,
@@ -137,7 +177,17 @@
       "uri_tidal": "tidal://track/11214230",
       "uri_deezer": "deezer://track/3399556",
       "fun_fact_nl": "Deze hit uit 1973 betekent 'We laten de Dom in Keulen' - een humoristische reactie op de angst dat stadsvernieuwing de geliefde kathedraal van Keulen zou bedreigen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEA348900536",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1764119453",
+        "de": "applemusic://track/1597794138",
+        "gb": "applemusic://track/724002081",
+        "fr": "applemusic://track/724002081",
+        "es": "applemusic://track/724002081",
+        "nl": "applemusic://track/724002081",
+        "it": "applemusic://track/724002081"
+      }
     },
     {
       "year": 1977,
@@ -162,7 +212,17 @@
       "uri_tidal": "tidal://track/3990663",
       "uri_deezer": "deezer://track/4228745",
       "fun_fact_nl": "Een liefdesbrief aan de wijken (Veedel) van Keulen; deze klassieker van de Bläck Fööss viert de hechte gemeenschapszin in de Keulse stadsdelen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEF067312140",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1758093738",
+        "de": "applemusic://track/1758093738",
+        "gb": "applemusic://track/1758093738",
+        "fr": "applemusic://track/1758093738",
+        "es": "applemusic://track/1758093738",
+        "nl": "applemusic://track/1758093738",
+        "it": "applemusic://track/1758093738"
+      }
     },
     {
       "year": 1977,
@@ -290,7 +350,17 @@
       "uri_tidal": "tidal://track/11203214",
       "uri_deezer": "deezer://track/3154486",
       "fun_fact_nl": "Echte Fründe (Echte vrienden) is een van de meest emotionele nummers van de Höhner over ware vriendschap en wordt tijdens carnaval vaak arm in arm gezongen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEA349700162",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/724021418",
+        "de": "applemusic://track/1384484802",
+        "gb": "applemusic://track/1384484802",
+        "fr": "applemusic://track/1384484802",
+        "es": "applemusic://track/1384484802",
+        "nl": "applemusic://track/1384484802",
+        "it": "applemusic://track/1384484802"
+      }
     },
     {
       "year": 1988,
@@ -315,7 +385,17 @@
       "uri_tidal": "tidal://track/3990673",
       "uri_deezer": "deezer://track/4228755",
       "fun_fact_nl": "Over een fictief adres 'Kayjass Nummer Nul' - dit nummer beschrijft op humoristische wijze een luidruchtige Keulse kroeg die officieel niet bestaat.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEF067312090",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1442246889",
+        "de": "applemusic://track/1442246889",
+        "gb": "applemusic://track/1442246889",
+        "fr": "applemusic://track/1442246889",
+        "es": "applemusic://track/1442246889",
+        "nl": "applemusic://track/1442246889",
+        "it": "applemusic://track/1442246889"
+      }
     },
     {
       "year": 1988,
@@ -340,7 +420,17 @@
       "uri_tidal": "tidal://track/3990670",
       "uri_deezer": "deezer://track/4228752",
       "fun_fact_nl": "Een vrolijk nummer over zonnige dagen in Keulen - 'Als de zon mooi schijnt' vangt de optimistische Rijnlandse geest.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEF067709850",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1672404811",
+        "de": "applemusic://track/1672404811",
+        "gb": "applemusic://track/1672404811",
+        "fr": "applemusic://track/1672404811",
+        "es": "applemusic://track/1672404811",
+        "nl": "applemusic://track/1672404811",
+        "it": "applemusic://track/1672404811"
+      }
     },
     {
       "year": 1990,
@@ -438,7 +528,17 @@
       "uri_apple_music": "applemusic://track/1641818574",
       "uri_deezer": "deezer://track/64972515",
       "fun_fact_nl": "Een humoristische ode aan drie Keulse essenties: bloedworst, Kölsch bier en een leuk meisje - het perfecte carnavalstrio!",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEN120103235",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1641818574",
+        "de": "applemusic://track/724060579",
+        "gb": "applemusic://track/724060579",
+        "fr": "applemusic://track/724060579",
+        "es": "applemusic://track/724060579",
+        "nl": "applemusic://track/724060579",
+        "it": "applemusic://track/724060579"
+      }
     },
     {
       "year": 1990,
@@ -515,7 +615,17 @@
       "uri_tidal": "tidal://track/2117519",
       "uri_deezer": "deezer://track/2473720",
       "fun_fact_nl": "De Räuber, opgericht in 1991, scoorden groots met deze hit over het moment dat 'het trommeltje gaat' - het vangt de onweerstaanbare drang om te dansen tijdens carnaval.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DED199300004",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/202229467",
+        "de": "applemusic://track/202229467",
+        "gb": "applemusic://track/202229467",
+        "fr": "applemusic://track/202229467",
+        "es": "applemusic://track/202229467",
+        "nl": "applemusic://track/202229467",
+        "it": "applemusic://track/202229467"
+      }
     },
     {
       "year": 1994,
@@ -540,7 +650,17 @@
       "uri_tidal": "tidal://track/243868700",
       "uri_deezer": "deezer://track/1873301647",
       "fun_fact_nl": "Brings, in 1991 opgericht door de broers Peter en Stephan Brings, verklaarden 'Wij zijn Keulenaren' in dit trotse volkslied over hun lokale identiteit.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEUM72205613",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1639556707",
+        "de": "applemusic://track/1639556707",
+        "gb": "applemusic://track/1639556707",
+        "fr": "applemusic://track/1639556707",
+        "es": "applemusic://track/1639556707",
+        "nl": "applemusic://track/1639556707",
+        "it": "applemusic://track/1639556707"
+      }
     },
     {
       "year": 1994,
@@ -565,7 +685,17 @@
       "uri_tidal": "tidal://track/156381093",
       "uri_deezer": "deezer://track/1090140842",
       "fun_fact_nl": "De versie van de Klüngelköpp van dit Keulse trots-lied - hun naam betekent 'vriendjespolitiek-hoofden', een humoristische knipoog naar de Keulse reputatie van 'Klüngel' (netwerken/ons-kent-ons).",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEEQ82000091",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1548925241",
+        "de": "applemusic://track/1548925241",
+        "gb": "applemusic://track/1548925241",
+        "fr": "applemusic://track/1548925241",
+        "es": "applemusic://track/1548925241",
+        "nl": "applemusic://track/1548925241",
+        "it": "applemusic://track/1548925241"
+      }
     },
     {
       "year": 1994,
@@ -590,7 +720,17 @@
       "uri_tidal": "tidal://track/11056382",
       "uri_deezer": "deezer://track/758881802",
       "fun_fact_nl": "Carnavalsster Marita Köllner viert de 'Keulse meisjes' in dit krachtige lied voor vrouwen tijdens het traditioneel door mannen gedomineerde carnaval.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DED191100075",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1480658474",
+        "de": "applemusic://track/1480658474",
+        "gb": "applemusic://track/1480658474",
+        "fr": "applemusic://track/1480658474",
+        "es": "applemusic://track/1480658474",
+        "nl": "applemusic://track/1480658474",
+        "it": "applemusic://track/1480658474"
+      }
     },
     {
       "year": 1994,
@@ -615,7 +755,17 @@
       "uri_tidal": "tidal://track/2104430",
       "uri_deezer": "deezer://track/2272214",
       "fun_fact_nl": "De uitgebreide versie van de Paveier benadrukt 'Wij zijn Keulenaren uit Keulen aan de Rijn' - de rivier de Rijn staat centraal in de identiteit van Keulen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DED190000084",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/203735442",
+        "de": "applemusic://track/203735442",
+        "gb": "applemusic://track/203735442",
+        "fr": "applemusic://track/203735442",
+        "es": "applemusic://track/203735442",
+        "nl": "applemusic://track/203735442",
+        "it": "applemusic://track/203735442"
+      }
     },
     {
       "year": 1996,
@@ -642,7 +792,17 @@
       "uri_tidal": "tidal://track/1380806",
       "uri_deezer": "deezer://track/3488647",
       "fun_fact_nl": "Deze emotionele klassieker van de Höhner verklaart 'Keulen, je bent een gevoel' - het vangt perfect hoe de inwoners hun stad niet alleen als een plek, maar als een emotie ervaren.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEA340401552",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/713842589",
+        "de": "applemusic://track/713842589",
+        "gb": "applemusic://track/713842589",
+        "fr": "applemusic://track/713842589",
+        "es": "applemusic://track/713842589",
+        "nl": "applemusic://track/713842589",
+        "it": "applemusic://track/713842589"
+      }
     },
     {
       "year": 1996,
@@ -692,7 +852,17 @@
       "uri_tidal": "tidal://track/1380803",
       "uri_deezer": "deezer://track/3488644",
       "fun_fact_nl": "Höhners 'Leven en laten leven' belichaamt de tolerante Keulse geest - het onofficiële motto van de stad is 'Et hätt noch immer jot jejange' (Het is tot nu toe altijd goed gegaan).",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEA349600043",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/713891413",
+        "de": "applemusic://track/713891413",
+        "gb": "applemusic://track/713891413",
+        "fr": "applemusic://track/713891413",
+        "es": "applemusic://track/713891413",
+        "nl": "applemusic://track/713891413",
+        "it": "applemusic://track/713891413"
+      }
     },
     {
       "year": 1997,
@@ -794,7 +964,17 @@
       "uri_tidal": "tidal://track/2104424",
       "uri_deezer": "deezer://track/2647771",
       "fun_fact_nl": "Het filosofische 'Dat gaat voorbij' van de Paveier vangt de Rijnlandse instelling om de problemen van het leven met humor en optimisme te benaderen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DED190700056",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/269373996",
+        "de": "applemusic://track/269373996",
+        "gb": "applemusic://track/269373996",
+        "fr": "applemusic://track/269373996",
+        "es": "applemusic://track/269373996",
+        "nl": "applemusic://track/269373996",
+        "it": "applemusic://track/269373996"
+      }
     },
     {
       "year": 1997,
@@ -818,7 +998,17 @@
       },
       "uri_deezer": "deezer://track/2647751",
       "fun_fact_nl": "Een humoristisch nummer van de Paveier over 'de witste man op het strand' - zelfspot over bleke Duitsers op vakantie is een vast thema in het carnaval.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DED199700061",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/205556986",
+        "de": "applemusic://track/205556986",
+        "gb": "applemusic://track/205556986",
+        "fr": "applemusic://track/205556986",
+        "es": "applemusic://track/205556986",
+        "nl": "applemusic://track/205556986",
+        "it": "applemusic://track/205556986"
+      }
     },
     {
       "year": 1997,
@@ -843,7 +1033,17 @@
       "uri_tidal": "tidal://track/2104428",
       "uri_deezer": "deezer://track/2648948",
       "fun_fact_nl": "De Paveier mixen Spaans en Kölsch in dit aanstekelijke vakantielied - carnavalsmuziek combineert vaak internationale flair met het lokale dialect.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEA499324190",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1698592964",
+        "de": "applemusic://track/1698592964",
+        "gb": "applemusic://track/1698592964",
+        "fr": "applemusic://track/1698592964",
+        "es": "applemusic://track/1698592964",
+        "nl": "applemusic://track/1698592964",
+        "it": "applemusic://track/1698592964"
+      }
     },
     {
       "year": 2001,
@@ -1017,7 +1217,17 @@
       "uri_tidal": "tidal://track/21075",
       "uri_deezer": "deezer://track/1017754",
       "fun_fact_nl": "Colör waarschuwt dat 'Keulse meisjes gevaarlijk zijn' - een speelse hommage aan de zelfverzekerde vrouwen in de Keulse carnavalswereld.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEC680001608",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/314114513",
+        "de": "applemusic://track/314114513",
+        "gb": "applemusic://track/314114513",
+        "fr": "applemusic://track/314114513",
+        "es": "applemusic://track/314114513",
+        "nl": "applemusic://track/314114513",
+        "it": "applemusic://track/314114513"
+      }
     },
     {
       "year": 2001,
@@ -1042,7 +1252,17 @@
       "uri_tidal": "tidal://track/23616790",
       "uri_deezer": "deezer://track/61288042",
       "fun_fact_nl": "De verklaring van carnavalsveteraan Hans Süper 'Ik ben een Keulse jongen' - hij trad meer dan 50 jaar op tijdens carnavalszittingen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEQM61200029",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/563994853",
+        "de": "applemusic://track/563994853",
+        "gb": "applemusic://track/563994853",
+        "fr": "applemusic://track/563994853",
+        "es": "applemusic://track/563994853",
+        "nl": "applemusic://track/563994853",
+        "it": "applemusic://track/563994853"
+      }
     },
     {
       "year": 2001,
@@ -1092,7 +1312,17 @@
       "uri_tidal": "tidal://track/4752902",
       "uri_deezer": "deezer://track/7506967",
       "fun_fact_nl": "De Räuber beweren dat 'Keulse jongens goed kussen' - 'Bützje' (kussentjes) zijn een essentieel onderdeel van de carnavalsgroet.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DED190600080",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/212430353",
+        "de": "applemusic://track/212430353",
+        "gb": "applemusic://track/212430353",
+        "fr": "applemusic://track/212430353",
+        "es": "applemusic://track/212430353",
+        "nl": "applemusic://track/212430353",
+        "it": "applemusic://track/212430353"
+      }
     },
     {
       "year": 2001,
@@ -1142,7 +1372,17 @@
       "uri_tidal": "tidal://track/61266893",
       "uri_deezer": "deezer://track/2809924",
       "fun_fact_nl": "Brings grootste hit ooit - 'Super cool stuff' werd een stadionhymne die zowel bij wedstrijden van FC Köln als op carnavalsavonden werd gespeeld.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEUM71401050",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1660549596",
+        "de": "applemusic://track/1660549596",
+        "gb": "applemusic://track/1660549596",
+        "fr": "applemusic://track/1660549596",
+        "es": "applemusic://track/1660549596",
+        "nl": "applemusic://track/1660549596",
+        "it": "applemusic://track/1660549596"
+      }
     },
     {
       "year": 2002,
@@ -1192,7 +1432,17 @@
       "uri_tidal": "tidal://track/2117412",
       "uri_deezer": "deezer://track/2481845",
       "fun_fact_nl": "De Boore ('De Boeren') zingen over 'De rozen zijn rood' in dit aanstekelijke carnavalsliedje met zijn gedenkwaardige 'jojojojo'-hook.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DED190400044",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/201993850",
+        "de": "applemusic://track/201993850",
+        "gb": "applemusic://track/201993850",
+        "fr": "applemusic://track/201993850",
+        "es": "applemusic://track/201993850",
+        "nl": "applemusic://track/201993850",
+        "it": "applemusic://track/201993850"
+      }
     },
     {
       "year": 2002,
@@ -1217,7 +1467,17 @@
       "uri_tidal": "tidal://track/4752913",
       "uri_deezer": "deezer://track/117006986",
       "fun_fact_nl": "De romantische ballade 'De Roos' van de Räuber laat zien dat carnavalsmuziek niet alleen uit feestnummers bestaat - emotionele momenten worden evenzeer gewaardeerd.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DED190100043",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/399740626",
+        "de": "applemusic://track/399740626",
+        "gb": "applemusic://track/399740626",
+        "fr": "applemusic://track/399740626",
+        "es": "applemusic://track/399740626",
+        "nl": "applemusic://track/399740626",
+        "it": "applemusic://track/399740626"
+      }
     },
     {
       "year": 2003,
@@ -1292,7 +1552,17 @@
       "uri_tidal": "tidal://track/38386372",
       "uri_deezer": "deezer://track/23276721",
       "fun_fact_nl": "Viering van 'Wanneer wij Keulenaren zingen' - gezamenlijk zingen staat centraal in het carnaval, waarbij hele zalen elk refrein meezingen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DED190200034",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/944970484",
+        "de": "applemusic://track/944970484",
+        "gb": "applemusic://track/944970484",
+        "fr": "applemusic://track/944970484",
+        "es": "applemusic://track/944970484",
+        "nl": "applemusic://track/944970484",
+        "it": "applemusic://track/944970484"
+      }
     },
     {
       "year": 2003,
@@ -1342,7 +1612,17 @@
       "uri_tidal": "tidal://track/15403227",
       "uri_deezer": "deezer://track/23276751",
       "fun_fact_nl": "Alternatieve versie van hun ode aan Keulen - de Bläck Fööss nemen vaak meerdere versies van hun nummers op voor verschillende carnavalscontexten.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DED190200027",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/206698193",
+        "de": "applemusic://track/206698193",
+        "gb": "applemusic://track/206698193",
+        "fr": "applemusic://track/206698193",
+        "es": "applemusic://track/206698193",
+        "nl": "applemusic://track/206698193",
+        "it": "applemusic://track/206698193"
+      }
     },
     {
       "year": 2003,
@@ -1367,7 +1647,17 @@
       "uri_tidal": "tidal://track/1394994",
       "uri_deezer": "deezer://track/3156476",
       "fun_fact_nl": "DÉ carnavals-megahit! 'Viva Colonia' werd het beroemdste feestnummer van Duitsland en wordt wereldwijd gedraaid tijdens carnaval, het Oktoberfest en sportevenementen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEA340202100",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1639570404",
+        "de": "applemusic://track/716686053",
+        "gb": "applemusic://track/1639570404",
+        "fr": "applemusic://track/1639570404",
+        "es": "applemusic://track/1639570404",
+        "nl": "applemusic://track/1639570404",
+        "it": "applemusic://track/1639570404"
+      }
     },
     {
       "year": 2005,
@@ -1392,7 +1682,17 @@
       "uri_tidal": "tidal://track/2311463",
       "uri_deezer": "deezer://track/2809927",
       "fun_fact_nl": "Een nostalgische wens om 'Weer 20 te zijn' - deze hit van Brings spreekt carnavalsvierders aan die terugdenken aan hun jonge feestjaren.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEH490400135",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/342760192",
+        "de": "applemusic://track/342760192",
+        "gb": "applemusic://track/342760192",
+        "fr": "applemusic://track/342760192",
+        "es": "applemusic://track/342760192",
+        "nl": "applemusic://track/342760192",
+        "it": "applemusic://track/342760192"
+      }
     },
     {
       "year": 2005,
@@ -1416,7 +1716,17 @@
       },
       "uri_deezer": "deezer://track/145160202",
       "fun_fact_nl": "Een klassieker over 'De mooie prins' - elk jaar kiest Keulen een carnavalsprins die de festiviteiten aanvoert samen met de 'Jungfrau' (maagd) en de 'Bauer' (boer).",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEAF75107382",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1436887142",
+        "de": "applemusic://track/1219254873",
+        "gb": "applemusic://track/1219254873",
+        "fr": "applemusic://track/1219254873",
+        "es": "applemusic://track/1219254873",
+        "nl": "applemusic://track/1219254873",
+        "it": "applemusic://track/1219254873"
+      }
     },
     {
       "year": 2006,
@@ -1441,7 +1751,17 @@
       "uri_tidal": "tidal://track/2118006",
       "uri_deezer": "deezer://track/91133255",
       "fun_fact_nl": "De Bläck Fööss nodigen iedereen uit om te zingen ('Loss mer singe') - vernoemd naar het beroemde Keulse meezingevenement dat elke zomer de Tanzbrunnen vult.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DED190600042",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/944970448",
+        "de": "applemusic://track/944970448",
+        "gb": "applemusic://track/944970448",
+        "fr": "applemusic://track/944970448",
+        "es": "applemusic://track/944970448",
+        "nl": "applemusic://track/944970448",
+        "it": "applemusic://track/944970448"
+      }
     },
     {
       "year": 2006,
@@ -1466,7 +1786,17 @@
       "uri_tidal": "tidal://track/2122157",
       "uri_deezer": "deezer://track/2471493",
       "fun_fact_nl": "De Paveier vieren dat 'Het leven mooi is' - hun optimistische nummers belichamen de levensbevestigende geest van het Keulse carnaval.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DED190600065",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/212444702",
+        "de": "applemusic://track/212444702",
+        "gb": "applemusic://track/212444702",
+        "fr": "applemusic://track/212444702",
+        "es": "applemusic://track/212444702",
+        "nl": "applemusic://track/212444702",
+        "it": "applemusic://track/212444702"
+      }
     },
     {
       "year": 2007,
@@ -1640,7 +1970,17 @@
       "uri_tidal": "tidal://track/1414557",
       "uri_deezer": "deezer://track/3154477",
       "fun_fact_nl": "De kermismix van 'Nu gaat het los!' - carnaval deelt veel met de traditionele kermis; beide vieren de vreugde van de gemeenschap en feestelijke chaos.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEH842401456",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1766474419",
+        "de": "applemusic://track/1766474419",
+        "gb": "applemusic://track/1766474419",
+        "fr": "applemusic://track/1766474419",
+        "es": "applemusic://track/1766474419",
+        "nl": "applemusic://track/1766474419",
+        "it": "applemusic://track/1766474419"
+      }
     },
     {
       "year": 2012,
@@ -1690,7 +2030,17 @@
       "uri_tidal": "tidal://track/2150190",
       "uri_deezer": "deezer://track/2473281",
       "fun_fact_nl": "Een cover van het klassieke Duitse nummer 'Huil maar niet uit liefde' - Brings herinterpreteert vaker Duitse Schlagerhits voor het carnavals-publiek.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DED190700055",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/297068024",
+        "de": "applemusic://track/297068024",
+        "gb": "applemusic://track/297068024",
+        "fr": "applemusic://track/297068024",
+        "es": "applemusic://track/297068024",
+        "nl": "applemusic://track/297068024",
+        "it": "applemusic://track/297068024"
+      }
     },
     {
       "year": 2008,
@@ -1715,7 +2065,17 @@
       "uri_tidal": "tidal://track/2150194",
       "uri_deezer": "deezer://track/2685277",
       "fun_fact_nl": "Brings verklaart 'FC is ons gevoel' - net als de Höhner tonen zij de diepe verbondenheid tussen carnavalsbands en de voetbalclub 1. FC Köln.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DED190800098",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/297068238",
+        "de": "applemusic://track/297068238",
+        "gb": "applemusic://track/297068238",
+        "fr": "applemusic://track/297068238",
+        "es": "applemusic://track/297068238",
+        "nl": "applemusic://track/297068238",
+        "it": "applemusic://track/297068238"
+      }
     },
     {
       "year": 2008,
@@ -1740,7 +2100,17 @@
       "uri_tidal": "tidal://track/2150199",
       "uri_deezer": "deezer://track/2685282",
       "fun_fact_nl": "Het Kölsch dialectwoord voor 'naar huis gaan' - Brings vieren het gevoel van thuiskomen in Keulen na een tijd van huis te zijn geweest.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DED190800103",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/297068259",
+        "de": "applemusic://track/297068259",
+        "gb": "applemusic://track/297068259",
+        "fr": "applemusic://track/297068259",
+        "es": "applemusic://track/297068259",
+        "nl": "applemusic://track/297068259",
+        "it": "applemusic://track/297068259"
+      }
     },
     {
       "year": 2008,
@@ -1765,7 +2135,17 @@
       "uri_tidal": "tidal://track/5495534",
       "uri_deezer": "deezer://track/2809934",
       "fun_fact_nl": "Over een 'reuzenkameel' - carnavalswagens bevatten vaak enorme figuren, en hoe absurder, hoe beter!",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEBA20600128",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/342685586",
+        "de": "applemusic://track/342685586",
+        "gb": "applemusic://track/342685586",
+        "fr": "applemusic://track/342685586",
+        "es": "applemusic://track/342685586",
+        "nl": "applemusic://track/342685586",
+        "it": "applemusic://track/342685586"
+      }
     },
     {
       "year": 2008,
@@ -1790,7 +2170,17 @@
       "uri_tidal": "tidal://track/4752928",
       "uri_deezer": "deezer://track/2685274",
       "fun_fact_nl": "Brings vraagt 'Van wie is de stad?' - het antwoord is altijd 'van de mensen', vooral tijdens carnaval wanneer sociale barrières wegvallen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DED190800095",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/297068030",
+        "de": "applemusic://track/297068030",
+        "gb": "applemusic://track/297068030",
+        "fr": "applemusic://track/297068030",
+        "es": "applemusic://track/297068030",
+        "nl": "applemusic://track/297068030",
+        "it": "applemusic://track/297068030"
+      }
     },
     {
       "year": 2008,
@@ -1815,7 +2205,17 @@
       "uri_tidal": "tidal://track/2146418",
       "uri_deezer": "deezer://track/2614919",
       "fun_fact_nl": "De Wanderer verklaren carnavalsfans 'Hemels gek' - 'Jeck' is het Keulse woord voor de vrolijke waanzin van de carnavalsgeest.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DED190800080",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/295170783",
+        "de": "applemusic://track/295170783",
+        "gb": "applemusic://track/295170783",
+        "fr": "applemusic://track/295170783",
+        "es": "applemusic://track/295170783",
+        "nl": "applemusic://track/295170783",
+        "it": "applemusic://track/295170783"
+      }
     },
     {
       "year": 2008,
@@ -1840,7 +2240,17 @@
       "uri_tidal": "tidal://track/2075783",
       "uri_deezer": "deezer://track/2614921",
       "fun_fact_nl": "De Funky Marys beweren 'Ik heb geen cabrio nodig' - carnaval waardeert gemeenschap en plezier boven materiële bezittingen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DED190800082",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/295170789",
+        "de": "applemusic://track/295170789",
+        "gb": "applemusic://track/295170789",
+        "fr": "applemusic://track/295170789",
+        "es": "applemusic://track/295170789",
+        "nl": "applemusic://track/295170789",
+        "it": "applemusic://track/295170789"
+      }
     },
     {
       "year": 2009,
@@ -1889,7 +2299,17 @@
       "uri_tidal": "tidal://track/3284095",
       "uri_deezer": "deezer://track/5181820",
       "fun_fact_nl": "Over de droom om 'Eén keer prins te zijn in Keulen aan de Rijn' - verkozen worden tot carnavalsprins is een levenslange eer voor elke Keulenaar.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEE760900082",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/346780406",
+        "de": "applemusic://track/346780406",
+        "gb": "applemusic://track/346780406",
+        "fr": "applemusic://track/346780406",
+        "es": "applemusic://track/346780406",
+        "nl": "applemusic://track/346780406",
+        "it": "applemusic://track/346780406"
+      }
     },
     {
       "year": 2009,
@@ -1988,7 +2408,17 @@
       "uri_tidal": "tidal://track/11058096",
       "uri_deezer": "deezer://track/4628428",
       "fun_fact_nl": "De Klüngelköpp mixen Spaanse fiesta-vibes met Keuls carnaval - multiculturele invloeden hebben de Keulse muziekscene altijd verrijkt.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DED190900064",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/337534443",
+        "de": "applemusic://track/476037254",
+        "gb": "applemusic://track/337534443",
+        "fr": "applemusic://track/337534443",
+        "es": "applemusic://track/337534443",
+        "nl": "applemusic://track/337534443",
+        "it": "applemusic://track/337534443"
+      }
     },
     {
       "year": 2009,
@@ -2013,7 +2443,17 @@
       "uri_tidal": "tidal://track/382571206",
       "uri_deezer": "deezer://track/13485028",
       "fun_fact_nl": "Een klassiek drinklied - het repertoire van Willy Millowitsch bevat veel humoristische nummers over de Keulse liefde voor feestvieren.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEA347800973",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1660868181",
+        "de": "applemusic://track/1660868181",
+        "gb": "applemusic://track/1660868181",
+        "fr": "applemusic://track/1660868181",
+        "es": "applemusic://track/1660868181",
+        "nl": "applemusic://track/1660868181",
+        "it": "applemusic://track/1660868181"
+      }
     },
     {
       "year": 2009,
@@ -2063,7 +2503,17 @@
       "uri_tidal": "tidal://track/277174268",
       "uri_deezer": "deezer://track/13485025",
       "fun_fact_nl": "Een van de beroemdste Duitse carnavalsliedjes ooit - 'Heidewitzka' is een onzinwoord dat synoniem werd voor carnavalsplezier.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEA340801089",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1672403076",
+        "de": "applemusic://track/1672403076",
+        "gb": "applemusic://track/1672403076",
+        "fr": "applemusic://track/1672403076",
+        "es": "applemusic://track/1672403076",
+        "nl": "applemusic://track/1672403076",
+        "it": "applemusic://track/1672403076"
+      }
     },
     {
       "year": 2010,
@@ -2088,7 +2538,17 @@
       "uri_tidal": "tidal://track/3750124",
       "uri_deezer": "deezer://track/2473358",
       "fun_fact_nl": "Viering van de Keulse kleuren 'Rood en Wit' - dit zijn de officiële stadskleuren die tijdens het carnavalsseizoen overal op vlaggen te zien zijn.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DED190400055",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/206940874",
+        "de": "applemusic://track/206940874",
+        "gb": "applemusic://track/206940874",
+        "fr": "applemusic://track/206940874",
+        "es": "applemusic://track/206940874",
+        "nl": "applemusic://track/206940874",
+        "it": "applemusic://track/206940874"
+      }
     },
     {
       "year": 2010,
@@ -2113,7 +2573,17 @@
       "uri_tidal": "tidal://track/3750119",
       "uri_deezer": "deezer://track/2478599",
       "fun_fact_nl": "Een eerbetoon aan de kiosk op de hoek in de wijk Bickendorf - de 'Büdchen'-cultuur is uniek voor Keulen, waar de plaatselijke bevolking samenkomt voor Kölsch en een praatje.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DED191000045",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/367841973",
+        "de": "applemusic://track/367841973",
+        "gb": "applemusic://track/367841973",
+        "fr": "applemusic://track/367841973",
+        "es": "applemusic://track/367841973",
+        "nl": "applemusic://track/367841973",
+        "it": "applemusic://track/367841973"
+      }
     },
     {
       "year": 2010,
@@ -2212,7 +2682,17 @@
       "uri_tidal": "tidal://track/4721668",
       "uri_deezer": "deezer://track/7449140",
       "fun_fact_nl": "Klüngelköpp zingt over 'Stars' - romantische carnavalsliedjes herinneren ons eraan dat onder de feestsfeer diepe emoties stromen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DED191000066",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/398590189",
+        "de": "applemusic://track/398590189",
+        "gb": "applemusic://track/398590189",
+        "fr": "applemusic://track/398590189",
+        "es": "applemusic://track/398590189",
+        "nl": "applemusic://track/398590189",
+        "it": "applemusic://track/398590189"
+      }
     },
     {
       "year": 2010,
@@ -2261,7 +2741,17 @@
       "uri_tidal": "tidal://track/4752912",
       "uri_deezer": "deezer://track/7506977",
       "fun_fact_nl": "Vier de wijk Eigelstein - dit historische gebied in de buurt van het hoofdstation staat bekend om zijn multiculturele sfeer en live muziekscene.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DED190600083",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/212431371",
+        "de": "applemusic://track/212431371",
+        "gb": "applemusic://track/212431371",
+        "fr": "applemusic://track/212431371",
+        "es": "applemusic://track/212431371",
+        "nl": "applemusic://track/212431371",
+        "it": "applemusic://track/212431371"
+      }
     },
     {
       "year": 2010,
@@ -2283,7 +2773,17 @@
         "weeks_on_chart": null
       },
       "fun_fact_nl": "Over leven 'Op het marktplein' - de Alter Markt in Keulen is al sinds de middeleeuwen het hart van feestelijkheden.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DED199300008",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/202229994",
+        "de": "applemusic://track/202229994",
+        "gb": "applemusic://track/202229994",
+        "fr": "applemusic://track/202229994",
+        "es": "applemusic://track/202229994",
+        "nl": "applemusic://track/202229994",
+        "it": "applemusic://track/202229994"
+      }
     },
     {
       "year": 2010,
@@ -2308,7 +2808,17 @@
       "uri_tidal": "tidal://track/27946634",
       "uri_deezer": "deezer://track/6618859",
       "fun_fact_nl": "De klassieker 'Loyal Hussar' - Willy Millowitsch (1909-1999) heeft generaties lang het geluid van het traditionele Keulse carnaval helpen bepalen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEA499324650",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/381978049",
+        "de": "applemusic://track/381978049",
+        "gb": "applemusic://track/381978049",
+        "fr": "applemusic://track/381978049",
+        "es": "applemusic://track/381978049",
+        "nl": "applemusic://track/381978049",
+        "it": "applemusic://track/381978049"
+      }
     },
     {
       "year": 2011,
@@ -2333,7 +2843,17 @@
       "uri_tidal": "tidal://track/56201603",
       "uri_deezer": "deezer://track/5194569",
       "fun_fact_nl": "Bläck Fööss upgrade carnavalskusjes naar 'Deluxe Bützje' - de Bützje-traditie bestaat uit het geven van kleine kusjes op de wang als begroeting.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DED191000022",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/367840336",
+        "de": "applemusic://track/367840336",
+        "gb": "applemusic://track/367840336",
+        "fr": "applemusic://track/367840336",
+        "es": "applemusic://track/367840336",
+        "nl": "applemusic://track/367840336",
+        "it": "applemusic://track/367840336"
+      }
     },
     {
       "year": 2011,
@@ -2358,7 +2878,17 @@
       "uri_tidal": "tidal://track/2311465",
       "uri_deezer": "deezer://track/2809929",
       "fun_fact_nl": "Brengt 'Zo'n Dag' - het vastleggen van die perfecte carnavalsmomenten waarop alles samenkomt in vreugdevolle harmonie.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEBA20600124",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/342685559",
+        "de": "applemusic://track/342685559",
+        "gb": "applemusic://track/342685559",
+        "fr": "applemusic://track/342685559",
+        "es": "applemusic://track/342685559",
+        "nl": "applemusic://track/342685559",
+        "it": "applemusic://track/342685559"
+      }
     },
     {
       "year": 2011,
@@ -2382,7 +2912,17 @@
       "uri_apple_music": "applemusic://track/267049791",
       "uri_deezer": "deezer://track/2809926",
       "fun_fact_nl": "Brings' levensbevestigende 'Zolang we nog leven' - carnavalsfilosofie omarmt volledig leven in het huidige moment.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEH490300057",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/680569108",
+        "de": "applemusic://track/680569108",
+        "gb": "applemusic://track/680569108",
+        "fr": "applemusic://track/680569108",
+        "es": "applemusic://track/680569108",
+        "nl": "applemusic://track/680569108",
+        "it": "applemusic://track/680569108"
+      }
     },
     {
       "year": 2011,
@@ -2407,7 +2947,17 @@
       "uri_tidal": "tidal://track/2311461",
       "uri_deezer": "deezer://track/2809925",
       "fun_fact_nl": "Het carnavalstrio van activiteiten: Zoenen, kaarten, dansen' - brengt de essentiële carnavalsbezigheden samen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEH490300033",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/415303322",
+        "de": "applemusic://track/415303322",
+        "gb": "applemusic://track/415303322",
+        "fr": "applemusic://track/415303322",
+        "es": "applemusic://track/415303322",
+        "nl": "applemusic://track/415303322",
+        "it": "applemusic://track/415303322"
+      }
     },
     {
       "year": 2011,
@@ -2555,7 +3105,17 @@
       "uri_tidal": "tidal://track/17914895",
       "uri_deezer": "deezer://track/61929464",
       "fun_fact_nl": "Hartverwarmende hymne over Keulen als thuis - Klüngelköpp (opgericht in 1993) staat bekend om emotionele ballads naast feestnummers.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DED191200018",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/574922257",
+        "de": "applemusic://track/574922257",
+        "gb": "applemusic://track/574922257",
+        "fr": "applemusic://track/574922257",
+        "es": "applemusic://track/574922257",
+        "nl": "applemusic://track/574922257",
+        "it": "applemusic://track/574922257"
+      }
     },
     {
       "year": 2012,
@@ -2753,7 +3313,17 @@
       "uri_tidal": "tidal://track/23181566",
       "uri_deezer": "deezer://track/71704965",
       "fun_fact_nl": "Laten we zingen' - dat is het motto van de beroemde meezingers in Keulen, waar de menigte nieuwe carnavalsliedjes leert.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEUM71403802",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1442294193",
+        "de": "applemusic://track/1442294193",
+        "gb": "applemusic://track/1442294193",
+        "fr": "applemusic://track/1442294193",
+        "es": "applemusic://track/1442294193",
+        "nl": "applemusic://track/1442294193",
+        "it": "applemusic://track/1442294193"
+      }
     },
     {
       "year": 2013,
@@ -2778,7 +3348,17 @@
       "uri_tidal": "tidal://track/23617338",
       "uri_deezer": "deezer://track/72495130",
       "fun_fact_nl": "When snowflakes dance in the sky' - een zeldzaam carnavalslied met een winterthema, want het seizoen loopt van 11 november tot en met februari.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DED191000106",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/404564581",
+        "de": "applemusic://track/404564581",
+        "gb": "applemusic://track/404564581",
+        "fr": "applemusic://track/404564581",
+        "es": "applemusic://track/404564581",
+        "nl": "applemusic://track/404564581",
+        "it": "applemusic://track/404564581"
+      }
     },
     {
       "year": 2016,
@@ -2803,7 +3383,17 @@
       "uri_tidal": "tidal://track/23199294",
       "uri_deezer": "deezer://track/71705170",
       "fun_fact_nl": "Door mijn geluk te kussen' - Bützchen (kleine kusjes) zijn een carnavalstraditie. Miljö werd opgericht in 2015, maar dit vroege nummer toonde hun potentieel.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEUM71303590",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1443269028",
+        "de": "applemusic://track/1443269028",
+        "gb": "applemusic://track/1443269028",
+        "fr": "applemusic://track/1443269028",
+        "es": "applemusic://track/1443269028",
+        "nl": "applemusic://track/1443269028",
+        "it": "applemusic://track/1443269028"
+      }
     },
     {
       "year": 2016,
@@ -2828,7 +3418,17 @@
       "uri_tidal": "tidal://track/23199286",
       "uri_deezer": "deezer://track/71705162",
       "fun_fact_nl": "Heb de wereld nog niet gezien' - Miljö's frisse indie-pop benadering bracht een jonger publiek naar de traditionele carnavalsvieringen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEUM71303582",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1443268826",
+        "de": "applemusic://track/1443268826",
+        "gb": "applemusic://track/1443268826",
+        "fr": "applemusic://track/1443268826",
+        "es": "applemusic://track/1443268826",
+        "nl": "applemusic://track/1443268826",
+        "it": "applemusic://track/1443268826"
+      }
     },
     {
       "year": 2014,
@@ -2853,7 +3453,17 @@
       "uri_tidal": "tidal://track/54022740",
       "uri_deezer": "deezer://track/89242777",
       "fun_fact_nl": "The stars are aligned' in Kölsch - een optimistische hymne die typerend is voor de feelgood carnavalsstijl van Cat Ballou.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DED191400050",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/933255383",
+        "de": "applemusic://track/933255383",
+        "gb": "applemusic://track/933255383",
+        "fr": "applemusic://track/933255383",
+        "es": "applemusic://track/933255383",
+        "nl": "applemusic://track/933255383",
+        "it": "applemusic://track/933255383"
+      }
     },
     {
       "year": 2014,
@@ -2878,7 +3488,17 @@
       "uri_tidal": "tidal://track/38351417",
       "uri_deezer": "deezer://track/91084745",
       "fun_fact_nl": "Spreekt 'DANCE' uit - Funky Marys is een volledig vrouwelijke Kölsch-band die funk en soul naar carnavalspodia brengt.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DED191400058",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/943377495",
+        "de": "applemusic://track/943377495",
+        "gb": "applemusic://track/943377495",
+        "fr": "applemusic://track/943377495",
+        "es": "applemusic://track/943377495",
+        "nl": "applemusic://track/943377495",
+        "it": "applemusic://track/943377495"
+      }
     },
     {
       "year": 2014,
@@ -2903,7 +3523,17 @@
       "uri_tidal": "tidal://track/38774660",
       "uri_deezer": "deezer://track/91885374",
       "fun_fact_nl": "Een leven lang' - Höhner (opgericht in 1972) is de meest succesvolle Kölschband ooit met meer dan 50 jaar carnavalshits.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEUM71401098",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1442557282",
+        "de": "applemusic://track/1442557282",
+        "gb": "applemusic://track/1442557282",
+        "fr": "applemusic://track/1442557282",
+        "es": "applemusic://track/1442557282",
+        "nl": "applemusic://track/1442557282",
+        "it": "applemusic://track/1442557282"
+      }
     },
     {
       "year": 2014,
@@ -2928,7 +3558,17 @@
       "uri_tidal": "tidal://track/38774657",
       "uri_deezer": "deezer://track/91885368",
       "fun_fact_nl": "Sta op, wees luid! - een oproep tot actie die typerend is voor Höhners energieke carnavalsliederen die klaar zijn voor de arena.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEUM71401096",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1442557273",
+        "de": "applemusic://track/1384483898",
+        "gb": "applemusic://track/1384483898",
+        "fr": "applemusic://track/1384483898",
+        "es": "applemusic://track/1384483898",
+        "nl": "applemusic://track/1384483898",
+        "it": "applemusic://track/1384483898"
+      }
     },
     {
       "year": 2014,
@@ -2953,7 +3593,17 @@
       "uri_tidal": "tidal://track/40869664",
       "uri_deezer": "deezer://track/94654714",
       "fun_fact_nl": "Stad met K' - Kasalla's enorme hit over Keulen (Köln begint met K) werd een onofficieel stadslied.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DED191400049",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1168550202",
+        "de": "applemusic://track/1168550202",
+        "gb": "applemusic://track/1168550202",
+        "fr": "applemusic://track/1168550202",
+        "es": "applemusic://track/1168550202",
+        "nl": "applemusic://track/1168550202",
+        "it": "applemusic://track/1168550202"
+      }
     },
     {
       "year": 2014,
@@ -3053,7 +3703,17 @@
       "uri_tidal": "tidal://track/52398929",
       "uri_deezer": "deezer://track/88399449",
       "fun_fact_nl": "Monkeys' in Kölsch - Miljö's speelse stijl combineert indierock met dialectteksten voor een modern carnavalsgeluid.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEUM71403642",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1442689147",
+        "de": "applemusic://track/1442689147",
+        "gb": "applemusic://track/1442689147",
+        "fr": "applemusic://track/1442689147",
+        "es": "applemusic://track/1442689147",
+        "nl": "applemusic://track/1442689147",
+        "it": "applemusic://track/1442689147"
+      }
     },
     {
       "year": 2016,
@@ -3078,7 +3738,17 @@
       "uri_tidal": "tidal://track/37873075",
       "uri_deezer": "deezer://track/90154139",
       "fun_fact_nl": "Traditionele Kölsch namen 'Jan en Griet' (John en Margaret) - een liefdesverhaal verteld in het Keulse dialect.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEUM71403774",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1442798815",
+        "de": "applemusic://track/1442798815",
+        "gb": "applemusic://track/1442798815",
+        "fr": "applemusic://track/1442798815",
+        "es": "applemusic://track/1442798815",
+        "nl": "applemusic://track/1442798815",
+        "it": "applemusic://track/1442798815"
+      }
     },
     {
       "year": 2014,
@@ -3103,7 +3773,17 @@
       "uri_tidal": "tidal://track/37373529",
       "uri_deezer": "deezer://track/89242775",
       "fun_fact_nl": "We doen het goed' - geeft de optimistische Rijnlandse filosofie weer om ondanks alle problemen van het leven te genieten.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DED191400051",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1168549995",
+        "de": "applemusic://track/1168549995",
+        "gb": "applemusic://track/1168549995",
+        "fr": "applemusic://track/1168549995",
+        "es": "applemusic://track/1168549995",
+        "nl": "applemusic://track/1168549995",
+        "it": "applemusic://track/1168549995"
+      }
     },
     {
       "year": 2015,
@@ -3128,7 +3808,17 @@
       "uri_tidal": "tidal://track/23397818",
       "uri_deezer": "deezer://track/110288800",
       "fun_fact_nl": "Het Keulse gevoel' - Björn Heuser is een geliefde solocarnavalsartiest die bekend staat om zijn oprechte Kölsch-ballades.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEQM62003386",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1537957742",
+        "de": "applemusic://track/1537957742",
+        "gb": "applemusic://track/1537957742",
+        "fr": "applemusic://track/1537957742",
+        "es": "applemusic://track/1537957742",
+        "nl": "applemusic://track/1537957742",
+        "it": "applemusic://track/1537957742"
+      }
     },
     {
       "year": 2015,
@@ -3153,7 +3843,17 @@
       "uri_tidal": "tidal://track/52910282",
       "uri_deezer": "deezer://track/112786338",
       "fun_fact_nl": "Again and again' - werd een meezingfavoriet met het pakkende refrein over nooit opgeven.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DED191500042",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1168550101",
+        "de": "applemusic://track/1168550101",
+        "gb": "applemusic://track/1168550101",
+        "fr": "applemusic://track/1168550101",
+        "es": "applemusic://track/1168550101",
+        "nl": "applemusic://track/1168550101",
+        "it": "applemusic://track/1168550101"
+      }
     },
     {
       "year": 2015,
@@ -3178,7 +3878,17 @@
       "uri_tidal": "tidal://track/51104839",
       "uri_deezer": "deezer://track/107396620",
       "fun_fact_nl": "De nummer 1 van de Rijn' - dat is de trots van Keulen als grootste stad aan de Rijn.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DED191300063",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/738530677",
+        "de": "applemusic://track/730943621",
+        "gb": "applemusic://track/738530677",
+        "fr": "applemusic://track/738530677",
+        "es": "applemusic://track/738530677",
+        "nl": "applemusic://track/738530677",
+        "it": "applemusic://track/738530677"
+      }
     },
     {
       "year": 2015,
@@ -3203,7 +3913,17 @@
       "uri_tidal": "tidal://track/51523862",
       "uri_deezer": "deezer://track/107830216",
       "fun_fact_nl": "Dit is mijn thuis' - Domhätzjer betekent 'Domharten', genoemd naar de iconische Dom van Keulen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEF721591201",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1041485882",
+        "de": "applemusic://track/1041485882",
+        "gb": "applemusic://track/1041485882",
+        "fr": "applemusic://track/1041485882",
+        "es": "applemusic://track/1041485882",
+        "nl": "applemusic://track/1041485882",
+        "it": "applemusic://track/1041485882"
+      }
     },
     {
       "year": 2015,
@@ -3227,7 +3947,17 @@
       "uri_apple_music": "applemusic://track/961978804",
       "uri_deezer": "deezer://track/1532168232",
       "fun_fact_nl": "Alle glazen omhoog!' - een drinklied dat onmisbaar werd op elk carnavalsfeest en in elke Kölsch-bierhal.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DED191400048",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/933255544",
+        "de": "applemusic://track/933255544",
+        "gb": "applemusic://track/933255544",
+        "fr": "applemusic://track/933255544",
+        "es": "applemusic://track/933255544",
+        "nl": "applemusic://track/933255544",
+        "it": "applemusic://track/933255544"
+      }
     },
     {
       "year": 2015,
@@ -3252,7 +3982,17 @@
       "uri_tidal": "tidal://track/40869666",
       "uri_deezer": "deezer://track/94654718",
       "fun_fact_nl": "Laten we leven' - belichaamt de Rijnlandse joie de vivre-filosofie van het leven vieren in het moment.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DED191300057",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/961978784",
+        "de": "applemusic://track/961978784",
+        "gb": "applemusic://track/961978784",
+        "fr": "applemusic://track/961978784",
+        "es": "applemusic://track/961978784",
+        "nl": "applemusic://track/961978784",
+        "it": "applemusic://track/961978784"
+      }
     },
     {
       "year": 2015,
@@ -3302,7 +4042,17 @@
       "uri_tidal": "tidal://track/229484738",
       "uri_deezer": "deezer://track/1753026097",
       "fun_fact_nl": "'Ghosts' in Kölsch - Lupo is een carnavalssolist die bekend staat om eigenzinnige, humoristische liedjes met onverwachte thema's.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEQD21500041",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1624673793",
+        "de": "applemusic://track/1624673793",
+        "gb": "applemusic://track/1624673793",
+        "fr": "applemusic://track/1624673793",
+        "es": "applemusic://track/1624673793",
+        "nl": "applemusic://track/1624673793",
+        "it": "applemusic://track/1624673793"
+      }
     },
     {
       "year": 2015,
@@ -3326,7 +4076,17 @@
       },
       "uri_deezer": "deezer://track/110953558",
       "fun_fact_nl": "Mooi is anders' - Miljö's zelfspot en indiesound hebben een jong carnavalspubliek voor zich gewonnen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEUM71724243",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1443009841",
+        "de": "applemusic://track/1443009841",
+        "gb": "applemusic://track/1443009841",
+        "fr": "applemusic://track/1443009841",
+        "es": "applemusic://track/1443009841",
+        "nl": "applemusic://track/1443009841",
+        "it": "applemusic://track/1443009841"
+      }
     },
     {
       "year": 2015,
@@ -3376,7 +4136,17 @@
       "uri_tidal": "tidal://track/57738056",
       "uri_deezer": "deezer://track/121123256",
       "fun_fact_nl": "AnnenMayKantereit begon als straatmuzikanten in Keulen en groeide uit tot Duitslands grootste indieband terwijl ze hun lokale wortels behielden.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEUM71504281",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1440842640",
+        "de": "applemusic://track/1440842640",
+        "gb": "applemusic://track/1440842640",
+        "fr": "applemusic://track/1440842640",
+        "es": "applemusic://track/1440842640",
+        "nl": "applemusic://track/1440842640",
+        "it": "applemusic://track/1440842640"
+      }
     },
     {
       "year": 2016,
@@ -3476,7 +4246,17 @@
       "uri_tidal": "tidal://track/66722156",
       "uri_deezer": "deezer://track/135377764",
       "fun_fact_nl": "We are one' - een eenheidslied dat populair werd tijdens voetbalwedstrijden van FC Köln en tijdens carnaval.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DED191600085",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1170524182",
+        "de": "applemusic://track/1170524182",
+        "gb": "applemusic://track/1170524182",
+        "fr": "applemusic://track/1170524182",
+        "es": "applemusic://track/1170524182",
+        "nl": "applemusic://track/1170524182",
+        "it": "applemusic://track/1170524182"
+      }
     },
     {
       "year": 2016,
@@ -3500,7 +4280,17 @@
       },
       "uri_deezer": "deezer://track/143170276",
       "fun_fact_nl": "Vandaag ben je bij mij' - Kempes Feinest vertegenwoordigen de Kölsch hiphop en reggae fusie in carnavalsmuziek.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DED191600090",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1208124638",
+        "de": "applemusic://track/1208124638",
+        "gb": "applemusic://track/1208124638",
+        "fr": "applemusic://track/1208124638",
+        "es": "applemusic://track/1208124638",
+        "nl": "applemusic://track/1208124638",
+        "it": "applemusic://track/1208124638"
+      }
     },
     {
       "year": 2016,
@@ -3550,7 +4340,17 @@
       "uri_tidal": "tidal://track/67905213",
       "uri_deezer": "deezer://track/132105638",
       "fun_fact_nl": "Een toast op de liefde' - Micky Brühl is al tientallen jaren een vaste waarde in de Keulse muziekscene met zijn romantische carnavalsliedjes.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEEQ81600098",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1606726105",
+        "de": "applemusic://track/1606726105",
+        "gb": "applemusic://track/1606726105",
+        "fr": "applemusic://track/1606726105",
+        "es": "applemusic://track/1606726105",
+        "nl": "applemusic://track/1606726105",
+        "it": "applemusic://track/1606726105"
+      }
     },
     {
       "year": 2016,
@@ -3575,7 +4375,17 @@
       "uri_tidal": "tidal://track/202619488",
       "uri_deezer": "deezer://track/1760611777",
       "fun_fact_nl": "Hou van je stad' - Mo-Torres is een Duitse rapper uit Keulen die hiphop toevoegt aan carnavalsvieringen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEXK81900036",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1687077153",
+        "de": "applemusic://track/1687077153",
+        "gb": "applemusic://track/1687077153",
+        "fr": "applemusic://track/1687077153",
+        "es": "applemusic://track/1687077153",
+        "nl": "applemusic://track/1687077153",
+        "it": "applemusic://track/1687077153"
+      }
     },
     {
       "year": 2016,
@@ -3600,7 +4410,17 @@
       "uri_tidal": "tidal://track/73426561",
       "uri_deezer": "deezer://track/298197581",
       "fun_fact_nl": "Come girl dance' - een klassieke uitnodiging om te dansen, die centraal staat in carnaval waar vreemden danspartners worden.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DED191600082",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1295745630",
+        "de": "applemusic://track/1295745630",
+        "gb": "applemusic://track/1295745630",
+        "fr": "applemusic://track/1295745630",
+        "es": "applemusic://track/1295745630",
+        "nl": "applemusic://track/1295745630",
+        "it": "applemusic://track/1295745630"
+      }
     },
     {
       "year": 2016,
@@ -3625,7 +4445,17 @@
       "uri_tidal": "tidal://track/65790893",
       "uri_deezer": "deezer://track/134024432",
       "fun_fact_nl": "Nooit meer Fastelovend' - ironische titel, want Fastelovend (carnaval in het Kölsch) is voor echte Keulenaars niet te stoppen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEUM71724903",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1442391640",
+        "de": "applemusic://track/1442391640",
+        "gb": "applemusic://track/1442391640",
+        "fr": "applemusic://track/1442391640",
+        "es": "applemusic://track/1442391640",
+        "nl": "applemusic://track/1442391640",
+        "it": "applemusic://track/1442391640"
+      }
     },
     {
       "year": 2016,
@@ -3650,7 +4480,17 @@
       "uri_tidal": "tidal://track/65790896",
       "uri_deezer": "deezer://track/134024438",
       "fun_fact_nl": "Onomatopeeën voor een marching band-geluid - Querbeat (opgericht in 2007) is een 12-koppige brassband die een revolutie teweegbrengt in de carnavalsmuziek.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEUM71503365",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1440867481",
+        "de": "applemusic://track/1442596610",
+        "gb": "applemusic://track/1440867481",
+        "fr": "applemusic://track/1440867481",
+        "es": "applemusic://track/1440867481",
+        "nl": "applemusic://track/1440867481",
+        "it": "applemusic://track/1440867481"
+      }
     },
     {
       "year": 2016,
@@ -3675,7 +4515,17 @@
       "uri_tidal": "tidal://track/65790895",
       "uri_deezer": "deezer://track/134024436",
       "fun_fact_nl": "'The Plan' - Querbeat's high-energy brass sound mengt Balkan beats, ska en traditioneel carnaval op unieke manieren.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEUM71603505",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1440867478",
+        "de": "applemusic://track/1442532584",
+        "gb": "applemusic://track/1440867478",
+        "fr": "applemusic://track/1440867478",
+        "es": "applemusic://track/1440867478",
+        "nl": "applemusic://track/1440867478",
+        "it": "applemusic://track/1440867478"
+      }
     },
     {
       "year": 2016,
@@ -3725,7 +4575,17 @@
       "uri_tidal": "tidal://track/65790900",
       "uri_deezer": "deezer://track/134024446",
       "fun_fact_nl": "Vandaag of nooit' - vat de carnavalsgeest van het leven in het moment voordat Aswoensdag het feest beëindigt.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEUM71303900",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1440867643",
+        "de": "applemusic://track/1440867643",
+        "gb": "applemusic://track/1440867643",
+        "fr": "applemusic://track/1440867643",
+        "es": "applemusic://track/1440867643",
+        "nl": "applemusic://track/1440867643",
+        "it": "applemusic://track/1440867643"
+      }
     },
     {
       "year": 2016,
@@ -3750,7 +4610,17 @@
       "uri_tidal": "tidal://track/65790903",
       "uri_deezer": "deezer://track/134024452",
       "fun_fact_nl": "Kleurrijke piramides' - Querbeats festivaloptredens buiten carnaval hielpen om de Kölsch-muziek bij het grote publiek te brengen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEUM71603508",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1440867650",
+        "de": "applemusic://track/1440867650",
+        "gb": "applemusic://track/1440867650",
+        "fr": "applemusic://track/1440867650",
+        "es": "applemusic://track/1440867650",
+        "nl": "applemusic://track/1440867650",
+        "it": "applemusic://track/1440867650"
+      }
     },
     {
       "year": 2016,
@@ -3775,7 +4645,17 @@
       "uri_tidal": "tidal://track/65790898",
       "uri_deezer": "deezer://track/134024442",
       "fun_fact_nl": "Kölsch jargon voor afkoelen of chillen - ironisch gezien de energieke optredens van Querbeat die het tegenovergestelde doen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEUM71603506",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1440867487",
+        "de": "applemusic://track/1440867487",
+        "gb": "applemusic://track/1440867487",
+        "fr": "applemusic://track/1440867487",
+        "es": "applemusic://track/1440867487",
+        "nl": "applemusic://track/1440867487",
+        "it": "applemusic://track/1440867487"
+      }
     },
     {
       "year": 2016,
@@ -3800,7 +4680,17 @@
       "uri_tidal": "tidal://track/66426111",
       "uri_deezer": "deezer://track/356161881",
       "fun_fact_nl": "Ik heb de kleine Marie gekust' - bützchen (kleine kusjes) worden tijdens carnaval vrijelijk uitgewisseld als begroetingstraditie.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DED191600088",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1208124062",
+        "de": "applemusic://track/1208124062",
+        "gb": "applemusic://track/1208124062",
+        "fr": "applemusic://track/1208124062",
+        "es": "applemusic://track/1208124062",
+        "nl": "applemusic://track/1208124062",
+        "it": "applemusic://track/1208124062"
+      }
     },
     {
       "year": 2017,
@@ -3825,7 +4715,17 @@
       "uri_tidal": "tidal://track/81641693",
       "uri_deezer": "deezer://track/432903552",
       "fun_fact_nl": "Say it in Kölsch' - een liefdesbrief aan het dialect dat Brings in leven heeft helpen houden met hun carnavalsmuziek met rockinvloeden.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEUM71724909",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1440908384",
+        "de": "applemusic://track/1440908384",
+        "gb": "applemusic://track/1440908384",
+        "fr": "applemusic://track/1440908384",
+        "es": "applemusic://track/1440908384",
+        "nl": "applemusic://track/1440908384",
+        "it": "applemusic://track/1440908384"
+      }
     },
     {
       "year": 2017,
@@ -3850,7 +4750,17 @@
       "uri_tidal": "tidal://track/69256938",
       "uri_deezer": "deezer://track/432903562",
       "fun_fact_nl": "'Before we go' - Brings broers Peter en Stephan Brings leiden de band sinds 1991 met hun kenmerkende harmonieën.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEUM71724941",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1440908387",
+        "de": "applemusic://track/1440908387",
+        "gb": "applemusic://track/1440908387",
+        "fr": "applemusic://track/1440908387",
+        "es": "applemusic://track/1440908387",
+        "nl": "applemusic://track/1440908387",
+        "it": "applemusic://track/1440908387"
+      }
     },
     {
       "year": 2017,
@@ -3900,7 +4810,17 @@
       "uri_tidal": "tidal://track/81641691",
       "uri_deezer": "deezer://track/432903532",
       "fun_fact_nl": "Het coolste land' - 'jeil' is Kölsch voor cool/awesome, waarmee het Rijnland wordt gevierd als de beste plek op aarde.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEUM71724910",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1440908288",
+        "de": "applemusic://track/1440908288",
+        "gb": "applemusic://track/1440908288",
+        "fr": "applemusic://track/1440908288",
+        "es": "applemusic://track/1440908288",
+        "nl": "applemusic://track/1440908288",
+        "it": "applemusic://track/1440908288"
+      }
     },
     {
       "year": 2017,
@@ -3925,7 +4845,17 @@
       "uri_tidal": "tidal://track/81641688",
       "uri_deezer": "deezer://track/432903502",
       "fun_fact_nl": "Miracles' - een van de meer reflectieve nummers van Brings, die laat zien dat hun bereik verder gaat dan pure feestnummers.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEUM71724912",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1440908280",
+        "de": "applemusic://track/1440908280",
+        "gb": "applemusic://track/1440908280",
+        "fr": "applemusic://track/1440908280",
+        "es": "applemusic://track/1440908280",
+        "nl": "applemusic://track/1440908280",
+        "it": "applemusic://track/1440908280"
+      }
     },
     {
       "year": 2017,
@@ -3975,7 +4905,17 @@
       "uri_tidal": "tidal://track/80329792",
       "uri_deezer": "deezer://track/421296612",
       "fun_fact_nl": "We zijn gearriveerd' - Domstürmer's feestelijke sound maakte hen tot festivalfavorieten buiten het carnavalsseizoen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "TCADI1716642",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1300050466",
+        "de": "applemusic://track/1300050466",
+        "gb": "applemusic://track/1300050466",
+        "fr": "applemusic://track/1300050466",
+        "es": "applemusic://track/1300050466",
+        "nl": "applemusic://track/1300050466",
+        "it": "applemusic://track/1300050466"
+      }
     },
     {
       "year": 2017,
@@ -4025,7 +4965,17 @@
       "uri_tidal": "tidal://track/77948861",
       "uri_deezer": "deezer://track/418609532",
       "fun_fact_nl": "Koning van Keulen' - tijdens carnaval bestaat de gekozen Dreigestirn (driemanschap) uit een prins die over de festiviteiten regeert.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DED191700021",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1271752709",
+        "de": "applemusic://track/1271752709",
+        "gb": "applemusic://track/1271752709",
+        "fr": "applemusic://track/1271752709",
+        "es": "applemusic://track/1271752709",
+        "nl": "applemusic://track/1271752709",
+        "it": "applemusic://track/1271752709"
+      }
     },
     {
       "year": 2017,
@@ -4050,7 +5000,17 @@
       "uri_tidal": "tidal://track/52910284",
       "uri_deezer": "deezer://track/113422566",
       "fun_fact_nl": "A thousand lives' - Kasalla vult arena's met hun anthemische sound en treedt regelmatig op voor meer dan 10.000 fans.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DED191500039",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1295746112",
+        "de": "applemusic://track/1295746112",
+        "gb": "applemusic://track/1295746112",
+        "fr": "applemusic://track/1295746112",
+        "es": "applemusic://track/1295746112",
+        "nl": "applemusic://track/1295746112",
+        "it": "applemusic://track/1295746112"
+      }
     },
     {
       "year": 2017,
@@ -4075,7 +5035,17 @@
       "uri_tidal": "tidal://track/70998868",
       "uri_deezer": "deezer://track/143170264",
       "fun_fact_nl": "Als je niet kunt dansen' - verzekert dat carnaval voor iedereen is, ongeacht of je kunt dansen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DED191500051",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1295745147",
+        "de": "applemusic://track/1295745147",
+        "gb": "applemusic://track/1295745147",
+        "fr": "applemusic://track/1295745147",
+        "es": "applemusic://track/1295745147",
+        "nl": "applemusic://track/1295745147",
+        "it": "applemusic://track/1295745147"
+      }
     },
     {
       "year": 2017,
@@ -4125,7 +5095,17 @@
       "uri_tidal": "tidal://track/80601003",
       "uri_deezer": "deezer://track/422865762",
       "fun_fact_nl": "Het kleine beetje' - Köbesse is vernoemd naar de traditionele Keulse obers en viert de biercultuur van de stad.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DELJ81762519",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1302832653",
+        "de": "applemusic://track/1302832653",
+        "gb": "applemusic://track/1302832653",
+        "fr": "applemusic://track/1302832653",
+        "es": "applemusic://track/1302832653",
+        "nl": "applemusic://track/1302832653",
+        "it": "applemusic://track/1302832653"
+      }
     },
     {
       "year": 2017,
@@ -4150,7 +5130,17 @@
       "uri_tidal": "tidal://track/229500846",
       "uri_deezer": "deezer://track/1753255527",
       "fun_fact_nl": "'Niet voor de liefde' - Lupo's geestige teksten vertellen vaak humoristische verhalen over het alledaagse Keulse leven en relaties.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEQD21700071",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1624670071",
+        "de": "applemusic://track/1624670071",
+        "gb": "applemusic://track/1624670071",
+        "fr": "applemusic://track/1624670071",
+        "es": "applemusic://track/1624670071",
+        "nl": "applemusic://track/1624670071",
+        "it": "applemusic://track/1624670071"
+      }
     },
     {
       "year": 2017,
@@ -4175,7 +5165,17 @@
       "uri_tidal": "tidal://track/81902148",
       "uri_deezer": "deezer://track/435812152",
       "fun_fact_nl": "Voor ons' - Miljö's toastwaardige hymne werd een favoriet voor het heffen van Kölsch-glazen tijdens feestelijkheden.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEUM71724233",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1443009140",
+        "de": "applemusic://track/1443009140",
+        "gb": "applemusic://track/1443009140",
+        "fr": "applemusic://track/1443009140",
+        "es": "applemusic://track/1443009140",
+        "nl": "applemusic://track/1443009140",
+        "it": "applemusic://track/1443009140"
+      }
     },
     {
       "year": 2017,
@@ -4200,7 +5200,17 @@
       "uri_tidal": "tidal://track/80234188",
       "uri_deezer": "deezer://track/419907462",
       "fun_fact_nl": "Vernoemd naar een groot plein in Keulen - viert het ochtend-na-gevoel wanneer carnaval de volgende dag doorgaat.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEUM71724429",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1593095661",
+        "de": "applemusic://track/1593095661",
+        "gb": "applemusic://track/1593095661",
+        "fr": "applemusic://track/1593095661",
+        "es": "applemusic://track/1593095661",
+        "nl": "applemusic://track/1593095661",
+        "it": "applemusic://track/1593095661"
+      }
     },
     {
       "year": 2017,
@@ -4249,7 +5259,17 @@
       },
       "uri_deezer": "deezer://track/624630562",
       "fun_fact_nl": "Schudden met mijn billen in Kölsch - BeerBitches is een volledig vrouwelijke groep die brutale humor op carnavalspodia brengt.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DED191800035",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1439344305",
+        "de": "applemusic://track/1439344305",
+        "gb": "applemusic://track/1439344305",
+        "fr": "applemusic://track/1439344305",
+        "es": "applemusic://track/1439344305",
+        "nl": "applemusic://track/1439344305",
+        "it": "applemusic://track/1439344305"
+      }
     },
     {
       "year": 2018,
@@ -4274,7 +5294,17 @@
       "uri_tidal": "tidal://track/321688765",
       "uri_deezer": "deezer://track/2497850531",
       "fun_fact_nl": "Een Kölsch-versie van de klassieker van Shakespeare - Brings heeft het tragische liefdesverhaal een Rijnlandse draai gegeven.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEBL62300096",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1711803415",
+        "de": "applemusic://track/1711803415",
+        "gb": "applemusic://track/1711803415",
+        "fr": "applemusic://track/1711803415",
+        "es": "applemusic://track/1711803415",
+        "nl": "applemusic://track/1711803415",
+        "it": "applemusic://track/1711803415"
+      }
     },
     {
       "year": 2018,
@@ -4298,7 +5328,17 @@
       "uri_tidal": "tidal://track/202619488",
       "uri_deezer": "deezer://track/1773045347",
       "fun_fact_nl": "Hou van je stad' - werd een hymne voor de trots van Keulen, gespeeld tijdens officiële stadsevenementen naast carnaval.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEWQ72200017",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1671011632",
+        "de": "applemusic://track/1671011632",
+        "gb": "applemusic://track/1671011632",
+        "fr": "applemusic://track/1671011632",
+        "es": "applemusic://track/1671011632",
+        "nl": "applemusic://track/1671011632",
+        "it": "applemusic://track/1671011632"
+      }
     },
     {
       "year": 2018,
@@ -4348,7 +5388,17 @@
       "uri_tidal": "tidal://track/103524021",
       "uri_deezer": "deezer://track/566885342",
       "fun_fact_nl": "Een week wakker' - verwijst naar de vermoeiende maar opwindende carnavalsweek van Weiberfastnacht tot Aswoensdag.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEEQ81800151",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1665644988",
+        "de": "applemusic://track/1665644988",
+        "gb": "applemusic://track/1665644988",
+        "fr": "applemusic://track/1665644988",
+        "es": "applemusic://track/1665644988",
+        "nl": "applemusic://track/1665644988",
+        "it": "applemusic://track/1665644988"
+      }
     },
     {
       "year": 2018,
@@ -4373,7 +5423,17 @@
       "uri_tidal": "tidal://track/96837824",
       "uri_deezer": "deezer://track/569764172",
       "fun_fact_nl": "Iedereen zo yeah!' - een call-and-response hymne die hele stadionmassa's samen laat scanderen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DED191800027",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1439321317",
+        "de": "applemusic://track/1439321317",
+        "gb": "applemusic://track/1439321317",
+        "fr": "applemusic://track/1439321317",
+        "es": "applemusic://track/1439321317",
+        "nl": "applemusic://track/1439321317",
+        "it": "applemusic://track/1439321317"
+      }
     },
     {
       "year": 2018,
@@ -4397,7 +5457,17 @@
       },
       "uri_deezer": "deezer://track/569764182",
       "fun_fact_nl": "The rest of your life' - Kasalla's emotionele kant komt naar voren in ballads over de kostbare momenten van het leven.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DED191800028",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1621280233",
+        "de": "applemusic://track/1621280233",
+        "gb": "applemusic://track/1621280233",
+        "fr": "applemusic://track/1621280233",
+        "es": "applemusic://track/1621280233",
+        "nl": "applemusic://track/1621280233",
+        "it": "applemusic://track/1621280233"
+      }
     },
     {
       "year": 2018,
@@ -4422,7 +5492,17 @@
       "uri_tidal": "tidal://track/96381973",
       "uri_deezer": "deezer://track/566110592",
       "fun_fact_nl": "1000 nachten' in Kölsch - viert ontelbare carnavalsnachten die je doorbrengt met vrienden en familie.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEEQ81800138",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1537618559",
+        "de": "applemusic://track/1444300157",
+        "gb": "applemusic://track/1537618559",
+        "fr": "applemusic://track/1537618559",
+        "es": "applemusic://track/1537618559",
+        "nl": "applemusic://track/1537618559",
+        "it": "applemusic://track/1537618559"
+      }
     },
     {
       "year": 2018,
@@ -4447,7 +5527,17 @@
       "uri_tidal": "tidal://track/73426562",
       "uri_deezer": "deezer://track/356161941",
       "fun_fact_nl": "Let us jump' - een energiek nummer dat is ontworpen om de menigte te laten stuiteren tijdens carnavalsvieringen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DED191600092",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1208124412",
+        "de": "applemusic://track/1208124412",
+        "gb": "applemusic://track/1208124412",
+        "fr": "applemusic://track/1208124412",
+        "es": "applemusic://track/1208124412",
+        "nl": "applemusic://track/1208124412",
+        "it": "applemusic://track/1208124412"
+      }
     },
     {
       "year": 2018,
@@ -4472,7 +5562,17 @@
       "uri_tidal": "tidal://track/102830948",
       "uri_deezer": "deezer://track/574397762",
       "fun_fact_nl": "Een liefdesliedje voor een vrouw genaamd Claudia - Lupo's romantische carnavalsliedjes vormen een balans tussen de feestnummers in het genre.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DED191800033",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1440053155",
+        "de": "applemusic://track/1440053155",
+        "gb": "applemusic://track/1440053155",
+        "fr": "applemusic://track/1440053155",
+        "es": "applemusic://track/1440053155",
+        "nl": "applemusic://track/1440053155",
+        "it": "applemusic://track/1440053155"
+      }
     },
     {
       "year": 2018,
@@ -4497,7 +5597,17 @@
       "uri_tidal": "tidal://track/102830936",
       "uri_deezer": "deezer://track/621957732",
       "fun_fact_nl": "Nooit meer alcohol' - de klassieke morning-after belofte die elke carnavalsganger breekt bij het volgende feest.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DED191800029",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1658091267",
+        "de": "applemusic://track/1658091267",
+        "gb": "applemusic://track/1658091267",
+        "fr": "applemusic://track/1658091267",
+        "es": "applemusic://track/1658091267",
+        "nl": "applemusic://track/1658091267",
+        "it": "applemusic://track/1658091267"
+      }
     },
     {
       "year": 2018,
@@ -4522,7 +5632,17 @@
       "uri_tidal": "tidal://track/102830951",
       "uri_deezer": "deezer://track/570488332",
       "fun_fact_nl": "Home' - Planschemalöör brengt een modern pop-rockgeluid met behoud van traditionele Kölsch-thema's.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DED191800023",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1439345346",
+        "de": "applemusic://track/1439345346",
+        "gb": "applemusic://track/1439345346",
+        "fr": "applemusic://track/1439345346",
+        "es": "applemusic://track/1439345346",
+        "nl": "applemusic://track/1439345346",
+        "it": "applemusic://track/1439345346"
+      }
     },
     {
       "year": 2018,
@@ -4572,7 +5692,17 @@
       "uri_tidal": "tidal://track/96171807",
       "uri_deezer": "deezer://track/564947362",
       "fun_fact_nl": "Riot & Hooray' - vat de chaotische, vrolijke brassband energie van Querbeat perfect samen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEUM71801370",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1593095340",
+        "de": "applemusic://track/1593095340",
+        "gb": "applemusic://track/1593095340",
+        "fr": "applemusic://track/1593095340",
+        "es": "applemusic://track/1593095340",
+        "nl": "applemusic://track/1593095340",
+        "it": "applemusic://track/1593095340"
+      }
     },
     {
       "year": 2018,
@@ -4597,7 +5727,17 @@
       "uri_tidal": "tidal://track/96171813",
       "uri_deezer": "deezer://track/564947422",
       "fun_fact_nl": "Een liefdesliedje met koperblazers - de veelzijdigheid van Querbeat zorgt ervoor dat ze naast hun feesthits ook romantische nummers kunnen spelen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEUM71801388",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1436480907",
+        "de": "applemusic://track/1436480907",
+        "gb": "applemusic://track/1436480907",
+        "fr": "applemusic://track/1436480907",
+        "es": "applemusic://track/1436480907",
+        "nl": "applemusic://track/1436480907",
+        "it": "applemusic://track/1436480907"
+      }
     },
     {
       "year": 2018,
@@ -4622,7 +5762,17 @@
       "uri_tidal": "tidal://track/96171809",
       "uri_deezer": "deezer://track/564947382",
       "fun_fact_nl": "Hometown' (spreektaal) - plaagt liefkozend het gevoel van een kleine stad, zelfs in een grote stad als Keulen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEUM71801384",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1436480902",
+        "de": "applemusic://track/1436480902",
+        "gb": "applemusic://track/1436480902",
+        "fr": "applemusic://track/1436480902",
+        "es": "applemusic://track/1436480902",
+        "nl": "applemusic://track/1436480902",
+        "it": "applemusic://track/1436480902"
+      }
     },
     {
       "year": 2018,
@@ -4672,7 +5822,17 @@
       "uri_tidal": "tidal://track/121598832",
       "uri_deezer": "deezer://track/795644942",
       "fun_fact_nl": "Zo werkt het hier' - AG Arsch Huh is een collectief tegen racisme en intolerantie, dat carnaval gebruikt voor activisme.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEKM90800250",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1486024753",
+        "de": "applemusic://track/1486024753",
+        "gb": "applemusic://track/1486024753",
+        "fr": "applemusic://track/1486024753",
+        "es": "applemusic://track/1486024753",
+        "nl": "applemusic://track/1486024753",
+        "it": "applemusic://track/1486024753"
+      }
     },
     {
       "year": 2019,
@@ -4697,7 +5857,17 @@
       "uri_tidal": "tidal://track/121680506",
       "uri_deezer": "deezer://track/798056612",
       "fun_fact_nl": "Vernoemd naar een overleden fan - laat zien dat AnnenMayKantereit niet alleen met muziek, maar ook met de Keulse gemeenschap verbonden is.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEUM71906537",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1485719433",
+        "de": "applemusic://track/1485719433",
+        "gb": "applemusic://track/1485719433",
+        "fr": "applemusic://track/1485719433",
+        "es": "applemusic://track/1485719433",
+        "nl": "applemusic://track/1485719433",
+        "it": "applemusic://track/1485719433"
+      }
     },
     {
       "year": 2019,
@@ -4722,7 +5892,17 @@
       "uri_tidal": "tidal://track/120474799",
       "uri_deezer": "deezer://track/779658562",
       "fun_fact_nl": "Rood en wit' - de kleuren van de stad Keulen, om de plaatselijke trots te vieren. Boore mengt Schlager met Kölsch-tradities.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEEQ81900096",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1485631606",
+        "de": "applemusic://track/1485631606",
+        "gb": "applemusic://track/1485631606",
+        "fr": "applemusic://track/1485631606",
+        "es": "applemusic://track/1485631606",
+        "nl": "applemusic://track/1485631606",
+        "it": "applemusic://track/1485631606"
+      }
     },
     {
       "year": 2019,
@@ -4747,7 +5927,17 @@
       "uri_tidal": "tidal://track/102901297",
       "uri_deezer": "deezer://track/621956392",
       "fun_fact_nl": "Remix 'Vandaag regent het Kölsch' - 111 verwijst naar 11.11, de datum waarop het carnavalsseizoen officieel om 11.11 uur begint.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEUM71900486",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1450379825",
+        "de": "applemusic://track/1450379825",
+        "gb": "applemusic://track/1450379825",
+        "fr": "applemusic://track/1450379825",
+        "es": "applemusic://track/1450379825",
+        "nl": "applemusic://track/1450379825",
+        "it": "applemusic://track/1450379825"
+      }
     },
     {
       "year": 2019,
@@ -4772,7 +5962,17 @@
       "uri_tidal": "tidal://track/116146476",
       "uri_deezer": "deezer://track/738385552",
       "fun_fact_nl": "Never fall in love (Bar Girl)' - een waarschuwend verhaal over vallen voor iemand die achter de kermisbar werkt.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEW271327128",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1483773278",
+        "de": "applemusic://track/1483773278",
+        "gb": "applemusic://track/1483773278",
+        "fr": "applemusic://track/1483773278",
+        "es": "applemusic://track/1483773278",
+        "nl": "applemusic://track/1483773278",
+        "it": "applemusic://track/1483773278"
+      }
     },
     {
       "year": 2019,
@@ -4796,7 +5996,17 @@
       },
       "uri_deezer": "deezer://track/774796142",
       "fun_fact_nl": "Whenever night falls' in Kölsch - vangt de magische transformatie wanneer het carnavalsfeest in het donker begint.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEUM71905458",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1482342716",
+        "de": "applemusic://track/1482342716",
+        "gb": "applemusic://track/1482342716",
+        "fr": "applemusic://track/1482342716",
+        "es": "applemusic://track/1482342716",
+        "nl": "applemusic://track/1482342716",
+        "it": "applemusic://track/1482342716"
+      }
     },
     {
       "year": 2019,
@@ -4820,7 +6030,17 @@
       },
       "uri_deezer": "deezer://track/3622713482",
       "fun_fact_nl": "Only with you' - Funky Marys brengt soulvolle vrouwelijke zang naar een carnavalswereld die traditioneel gedomineerd wordt door mannelijke bands.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEEQ81900099",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1539793742",
+        "de": "applemusic://track/1539793742",
+        "gb": "applemusic://track/1539793742",
+        "fr": "applemusic://track/1539793742",
+        "es": "applemusic://track/1539793742",
+        "nl": "applemusic://track/1539793742",
+        "it": "applemusic://track/1539793742"
+      }
     },
     {
       "year": 2019,
@@ -4845,7 +6065,17 @@
       "uri_tidal": "tidal://track/120405349",
       "uri_deezer": "deezer://track/779202382",
       "fun_fact_nl": "Het hart van Keulen' - Höhner trad op tijdens de opening van de FIFA World Cup in 2006 en bracht Kölsch-muziek naar een wereldwijd publiek.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEUM71806769",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1440717939",
+        "de": "applemusic://track/1440717939",
+        "gb": "applemusic://track/1440717939",
+        "fr": "applemusic://track/1440717939",
+        "es": "applemusic://track/1440717939",
+        "nl": "applemusic://track/1440717939",
+        "it": "applemusic://track/1440717939"
+      }
     },
     {
       "year": 2019,
@@ -4870,7 +6100,17 @@
       "uri_tidal": "tidal://track/121776951",
       "uri_deezer": "deezer://track/778919372",
       "fun_fact_nl": "Friet en Champagne' - viert het mengen van bescheiden en chique en belichaamt de egalitaire geest van carnaval.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DED191900050",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1483817040",
+        "de": "applemusic://track/1483817040",
+        "gb": "applemusic://track/1483817040",
+        "fr": "applemusic://track/1483817040",
+        "es": "applemusic://track/1483817040",
+        "nl": "applemusic://track/1483817040",
+        "it": "applemusic://track/1483817040"
+      }
     },
     {
       "year": 2019,
@@ -4894,7 +6134,17 @@
       "uri_tidal": "tidal://track/121776952",
       "uri_deezer": "deezer://track/782349382",
       "fun_fact_nl": "Bend' in Kölsch - Kempes Feinest houdt carnavalsmuziek fris met hun urban muziekinvloeden.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DED191900055",
+      "uri_apple_music_by_region": {
+        "us": null,
+        "de": null,
+        "gb": null,
+        "fr": null,
+        "es": null,
+        "nl": null,
+        "it": null
+      }
     },
     {
       "year": 2019,
@@ -4919,7 +6169,17 @@
       "uri_tidal": "tidal://track/122049045",
       "uri_deezer": "deezer://track/798879362",
       "fun_fact_nl": "Maar als je wilt' - Knittler brengt een singer-songwriter benadering van Kölsch carnavalsmuziek.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEGE91900166",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1548558851",
+        "de": "applemusic://track/1548558851",
+        "gb": "applemusic://track/1548558851",
+        "fr": "applemusic://track/1548558851",
+        "es": "applemusic://track/1548558851",
+        "nl": "applemusic://track/1548558851",
+        "it": "applemusic://track/1548558851"
+      }
     },
     {
       "year": 2019,
@@ -4944,7 +6204,17 @@
       "uri_tidal": "tidal://track/199838401",
       "uri_deezer": "deezer://track/1752673297",
       "fun_fact_nl": "Tot de lichten uitgaan' - de carnavalsmantra van feesten tot het einde.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEL711900124",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1692236097",
+        "de": "applemusic://track/1692236097",
+        "gb": "applemusic://track/1692236097",
+        "fr": "applemusic://track/1692236097",
+        "es": "applemusic://track/1692236097",
+        "nl": "applemusic://track/1692236097",
+        "it": "applemusic://track/1692236097"
+      }
     },
     {
       "year": 2019,
@@ -4969,7 +6239,17 @@
       "uri_tidal": "tidal://track/120568031",
       "uri_deezer": "deezer://track/1607390912",
       "fun_fact_nl": "Vandaag alleen verheven' in Kölsch - 'höösch' betekent deftig/ verheven, het vieren van speciale carnavalsmomenten.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEUM71905453",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1483150511",
+        "de": "applemusic://track/1483150511",
+        "gb": "applemusic://track/1483150511",
+        "fr": "applemusic://track/1483150511",
+        "es": "applemusic://track/1483150511",
+        "nl": "applemusic://track/1483150511",
+        "it": "applemusic://track/1483150511"
+      }
     },
     {
       "year": 2019,
@@ -4994,7 +6274,17 @@
       "uri_tidal": "tidal://track/120568034",
       "uri_deezer": "deezer://track/780611322",
       "fun_fact_nl": "Eén voor allen' - belichaamt de carnavalsgeest waarin sociale barrières verdwijnen en iedereen als gelijken feestviert.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEUM71905455",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1483150525",
+        "de": "applemusic://track/1483150525",
+        "gb": "applemusic://track/1483150525",
+        "fr": "applemusic://track/1483150525",
+        "es": "applemusic://track/1483150525",
+        "nl": "applemusic://track/1483150525",
+        "it": "applemusic://track/1483150525"
+      }
     },
     {
       "year": 2019,
@@ -5019,7 +6309,17 @@
       "uri_tidal": "tidal://track/120568032",
       "uri_deezer": "deezer://track/780611302",
       "fun_fact_nl": "Miljö, opgericht in 2015, groeide al snel uit tot een van de populairste nieuwe carnavalsbands van Keulen met hun aanstekelijke pop-Kölsch-geluid.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEUM71905454",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1483150521",
+        "de": "applemusic://track/1483150521",
+        "gb": "applemusic://track/1483150521",
+        "fr": "applemusic://track/1483150521",
+        "es": "applemusic://track/1483150521",
+        "nl": "applemusic://track/1483150521",
+        "it": "applemusic://track/1483150521"
+      }
     },
     {
       "year": 2019,
@@ -5044,7 +6344,17 @@
       "uri_tidal": "tidal://track/121776949",
       "uri_deezer": "deezer://track/782349362",
       "fun_fact_nl": "Paveier, opgericht in 1983, staan bekend om hun feesthits en dit nummer met Amsterdams thema werd een carnavalsfavoriet vanwege het aanstekelijke refrein.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DED191900048",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1658092286",
+        "de": "applemusic://track/1658092286",
+        "gb": "applemusic://track/1658092286",
+        "fr": "applemusic://track/1658092286",
+        "es": "applemusic://track/1658092286",
+        "nl": "applemusic://track/1658092286",
+        "it": "applemusic://track/1658092286"
+      }
     },
     {
       "year": 2019,
@@ -5069,7 +6379,17 @@
       "uri_tidal": "tidal://track/121776955",
       "uri_deezer": "deezer://track/768334502",
       "fun_fact_nl": "Planschemalöör is een nieuwere carnavalsband die frisse energie naar de Kölner Karneval brengt met hun dansvriendelijke popsongs.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DED191900039",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1481961051",
+        "de": "applemusic://track/1481961051",
+        "gb": "applemusic://track/1481961051",
+        "fr": "applemusic://track/1481961051",
+        "es": "applemusic://track/1481961051",
+        "nl": "applemusic://track/1481961051",
+        "it": "applemusic://track/1481961051"
+      }
     },
     {
       "year": 2020,
@@ -5094,7 +6414,17 @@
       "uri_tidal": "tidal://track/121776964",
       "uri_deezer": "deezer://track/855086482",
       "fun_fact_nl": "Uitgebracht vlak voordat de COVID pandemie carnaval 2020 annuleerde, werd dit Bläck Fööss nummer over het bestellen van de volgende ronde bitterzoet voor fans.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DED191900052",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1495322539",
+        "de": "applemusic://track/1495322539",
+        "gb": "applemusic://track/1495322539",
+        "fr": "applemusic://track/1495322539",
+        "es": "applemusic://track/1495322539",
+        "nl": "applemusic://track/1495322539",
+        "it": "applemusic://track/1495322539"
+      }
     },
     {
       "year": 2020,
@@ -5119,7 +6449,17 @@
       "uri_tidal": "tidal://track/159641015",
       "uri_deezer": "deezer://track/1118054532",
       "fun_fact_nl": "Brings, opgericht door de gebroeders Brings in 1991, creëerde deze Alaafse hymne die de traditionele carnavalsgroet van Keulen viert.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEUM72005899",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1536540220",
+        "de": "applemusic://track/1597792958",
+        "gb": "applemusic://track/1536540220",
+        "fr": "applemusic://track/1536540220",
+        "es": "applemusic://track/1536540220",
+        "nl": "applemusic://track/1536540220",
+        "it": "applemusic://track/1536540220"
+      }
     },
     {
       "year": 2020,
@@ -5144,7 +6484,17 @@
       "uri_tidal": "tidal://track/121776961",
       "uri_deezer": "deezer://track/851750342",
       "fun_fact_nl": "Chanterella is een van de nieuwere vrouwelijke stemmen in Kölner Karneval, die een frisse kijk biedt met oprechte Kölsch-liedjes.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DED191900057",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1494693373",
+        "de": "applemusic://track/1494693373",
+        "gb": "applemusic://track/1494693373",
+        "fr": "applemusic://track/1494693373",
+        "es": "applemusic://track/1494693373",
+        "nl": "applemusic://track/1494693373",
+        "it": "applemusic://track/1494693373"
+      }
     },
     {
       "year": 2020,
@@ -5169,7 +6519,17 @@
       "uri_tidal": "tidal://track/159267641",
       "uri_deezer": "deezer://track/1106480922",
       "fun_fact_nl": "Lupo brengt een romantische Schlager-Kölsch crossover stijl naar carnaval, met Draumprinz als een dromerig liefdesliedje voor het seizoen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DED192000078",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1536552375",
+        "de": "applemusic://track/1536552375",
+        "gb": "applemusic://track/1536552375",
+        "fr": "applemusic://track/1536552375",
+        "es": "applemusic://track/1536552375",
+        "nl": "applemusic://track/1536552375",
+        "it": "applemusic://track/1536552375"
+      }
     },
     {
       "year": 2020,
@@ -5194,7 +6554,17 @@
       "uri_tidal": "tidal://track/148135654",
       "uri_deezer": "deezer://track/1019495302",
       "fun_fact_nl": "De titel betekent 'kermis in het hoofd' in het Kölsch - een perfecte beschrijving van kermisgekte en Miljö's energieke stijl.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEUM72004272",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1521986198",
+        "de": "applemusic://track/1521986198",
+        "gb": "applemusic://track/1521986198",
+        "fr": "applemusic://track/1521986198",
+        "es": "applemusic://track/1521986198",
+        "nl": "applemusic://track/1521986198",
+        "it": "applemusic://track/1521986198"
+      }
     },
     {
       "year": 2020,
@@ -5218,7 +6588,17 @@
       },
       "uri_deezer": "deezer://track/1118025302",
       "fun_fact_nl": "Wurm em Ohr betekent 'oorwurm' in het Kölsch - een metalied over aanstekelijke carnavalsliedjes waar Miljö bekend om staat.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEUM72005648",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1536059328",
+        "de": "applemusic://track/1536059328",
+        "gb": "applemusic://track/1536059328",
+        "fr": "applemusic://track/1536059328",
+        "es": "applemusic://track/1536059328",
+        "nl": "applemusic://track/1536059328",
+        "it": "applemusic://track/1536059328"
+      }
     },
     {
       "year": 2020,
@@ -5243,7 +6623,17 @@
       "uri_tidal": "tidal://track/158732409",
       "uri_deezer": "deezer://track/1106481002",
       "fun_fact_nl": "De boodschap van dit lied om niet op te geven werd uitgebracht tijdens het pandemiejaar en sloeg aan bij carnavalsfans die hun geliefde traditie missen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DED192000077",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1535667500",
+        "de": "applemusic://track/1535667500",
+        "gb": "applemusic://track/1535667500",
+        "fr": "applemusic://track/1535667500",
+        "es": "applemusic://track/1535667500",
+        "nl": "applemusic://track/1535667500",
+        "it": "applemusic://track/1535667500"
+      }
     },
     {
       "year": 2021,
@@ -5268,7 +6658,17 @@
       "uri_tidal": "tidal://track/202552206",
       "uri_deezer": "deezer://track/1755751867",
       "fun_fact_nl": "Cat Ballou, opgericht in 2001, combineert rock met Kölsch-teksten en heeft meerdere carnavalsmuziekprijzen gewonnen voor hun cross-over aantrekkingskracht.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEWQ71800057",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1672174370",
+        "de": "applemusic://track/1672174370",
+        "gb": "applemusic://track/1672174370",
+        "fr": "applemusic://track/1672174370",
+        "es": "applemusic://track/1672174370",
+        "nl": "applemusic://track/1672174370",
+        "it": "applemusic://track/1672174370"
+      }
     },
     {
       "year": 2021,
@@ -5293,7 +6693,17 @@
       "uri_tidal": "tidal://track/199638155",
       "uri_deezer": "deezer://track/1755751937",
       "fun_fact_nl": "De titel betekent 'Nooit in het leven' in Kölsch dialect en laat Cat Ballou's kenmerkende mix van emotionele ballads met carnavalsgeest horen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEWQ71800053",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1672211454",
+        "de": "applemusic://track/1672211454",
+        "gb": "applemusic://track/1672211454",
+        "fr": "applemusic://track/1672211454",
+        "es": "applemusic://track/1672211454",
+        "nl": "applemusic://track/1672211454",
+        "it": "applemusic://track/1672211454"
+      }
     },
     {
       "year": 2021,
@@ -5318,7 +6728,17 @@
       "uri_tidal": "tidal://track/200473156",
       "uri_deezer": "deezer://track/1515795122",
       "fun_fact_nl": "Funky Marys is een carnavalsband die funk- en soulinvloeden toevoegt aan de traditionele Kölner Karneval-muziek.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEEQ82100078",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1713321773",
+        "de": "applemusic://track/1713321773",
+        "gb": "applemusic://track/1713321773",
+        "fr": "applemusic://track/1713321773",
+        "es": "applemusic://track/1713321773",
+        "nl": "applemusic://track/1713321773",
+        "it": "applemusic://track/1713321773"
+      }
     },
     {
       "year": 2021,
@@ -5343,7 +6763,17 @@
       "uri_tidal": "tidal://track/199970080",
       "uri_deezer": "deezer://track/1519161882",
       "fun_fact_nl": "Höhner, opgericht in 1972, is de meest succesvolle Kölsch-band ooit, met meer dan 50 jaar carnavalshits en meer dan 20 miljoen verkochte platen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEW272104083",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1588744775",
+        "de": "applemusic://track/1588744775",
+        "gb": "applemusic://track/1588744775",
+        "fr": "applemusic://track/1588744775",
+        "es": "applemusic://track/1588744775",
+        "nl": "applemusic://track/1588744775",
+        "it": "applemusic://track/1588744775"
+      }
     },
     {
       "year": 2021,
@@ -5368,7 +6798,17 @@
       "uri_tidal": "tidal://track/201571493",
       "uri_deezer": "deezer://track/1750803747",
       "fun_fact_nl": "Kasalla, opgericht in 2011, bracht moderne rock naar carnavalmuziek en werd een van de succesvolste nieuwe Kölsch-bands van de jaren 2010.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DED192100056",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1621280041",
+        "de": "applemusic://track/1621280041",
+        "gb": "applemusic://track/1621280041",
+        "fr": "applemusic://track/1621280041",
+        "es": "applemusic://track/1621280041",
+        "nl": "applemusic://track/1621280041",
+        "it": "applemusic://track/1621280041"
+      }
     },
     {
       "year": 2021,
@@ -5393,7 +6833,17 @@
       "uri_tidal": "tidal://track/202178292",
       "uri_deezer": "deezer://track/1513809052",
       "fun_fact_nl": "Schälsick verwijst naar het gebied aan de verkeerde kant van de Rijn in Keulen - dit lied viert de mensen van de 'schäl' (verkeerde) kant.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DED192100055",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1591622104",
+        "de": "applemusic://track/1591622104",
+        "gb": "applemusic://track/1591622104",
+        "fr": "applemusic://track/1591622104",
+        "es": "applemusic://track/1591622104",
+        "nl": "applemusic://track/1591622104",
+        "it": "applemusic://track/1591622104"
+      }
     },
     {
       "year": 2021,
@@ -5418,7 +6868,17 @@
       "uri_tidal": "tidal://track/99166958",
       "uri_deezer": "deezer://track/591157982",
       "fun_fact_nl": "Kempes Feinest vertegenwoordigt de nieuwere generatie Kölsch carnavalsbands met hun moderne kijk op traditionele carnavalsthema's zoals naar huis gaan.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DED191800036",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1443794901",
+        "de": "applemusic://track/1443794901",
+        "gb": "applemusic://track/1443794901",
+        "fr": "applemusic://track/1443794901",
+        "es": "applemusic://track/1443794901",
+        "nl": "applemusic://track/1443794901",
+        "it": "applemusic://track/1443794901"
+      }
     },
     {
       "year": 2021,
@@ -5443,7 +6903,17 @@
       "uri_tidal": "tidal://track/199337258",
       "uri_deezer": "deezer://track/1508972482",
       "fun_fact_nl": "Klüngelköpp, opgericht in 1993, ontlenen hun naam aan 'Klüngel' - de beroemde Keulse netwerkcultuur, en dit nummer viert straatkinderen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEEQ82100082",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1606725927",
+        "de": "applemusic://track/1606725927",
+        "gb": "applemusic://track/1606725927",
+        "fr": "applemusic://track/1606725927",
+        "es": "applemusic://track/1606725927",
+        "nl": "applemusic://track/1606725927",
+        "it": "applemusic://track/1606725927"
+      }
     },
     {
       "year": 2021,
@@ -5468,7 +6938,17 @@
       "uri_tidal": "tidal://track/200621726",
       "uri_deezer": "deezer://track/1514006362",
       "fun_fact_nl": "Matrozen zijn een klassiek carnavalsthema in Keulen en dit nummer speelt in op de romantische zeemansbeelden.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DED192100059",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1589064651",
+        "de": "applemusic://track/1589064651",
+        "gb": "applemusic://track/1589064651",
+        "fr": "applemusic://track/1589064651",
+        "es": "applemusic://track/1589064651",
+        "nl": "applemusic://track/1589064651",
+        "it": "applemusic://track/1589064651"
+      }
     },
     {
       "year": 2021,
@@ -5493,7 +6973,17 @@
       "uri_tidal": "tidal://track/202131448",
       "uri_deezer": "deezer://track/1529480802",
       "fun_fact_nl": "Noh Huss betekent 'naar huis gaan' in het Kölsch - een sentimenteel thema in carnavalsmuziek als de wilde feestavonden ten einde lopen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEUM72117972",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1590445856",
+        "de": "applemusic://track/1590445856",
+        "gb": "applemusic://track/1590445856",
+        "fr": "applemusic://track/1590445856",
+        "es": "applemusic://track/1590445856",
+        "nl": "applemusic://track/1590445856",
+        "it": "applemusic://track/1590445856"
+      }
     },
     {
       "year": 2021,
@@ -5518,7 +7008,17 @@
       "uri_tidal": "tidal://track/191191031",
       "uri_deezer": "deezer://track/1435834012",
       "fun_fact_nl": "Querbeat, een brassband opgericht in 2007, staat bekend om hun energieke liveshows en deze liefdesbrief aan een nieuw Keulen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEUM72300290",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1669517534",
+        "de": "applemusic://track/1669517534",
+        "gb": "applemusic://track/1669517534",
+        "fr": "applemusic://track/1669517534",
+        "es": "applemusic://track/1669517534",
+        "nl": "applemusic://track/1669517534",
+        "it": "applemusic://track/1669517534"
+      }
     },
     {
       "year": 2022,
@@ -5543,7 +7043,17 @@
       "uri_tidal": "tidal://track/255982620",
       "uri_deezer": "deezer://track/1961464617",
       "fun_fact_nl": "Bläck Fööss (Barefoot Ones), opgericht in 1970, was een pionier op het gebied van Kölsch-rock en dit nummer over de oude stad geeft hun nostalgische stijl goed weer.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DED192200050",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1651369752",
+        "de": "applemusic://track/1651369752",
+        "gb": "applemusic://track/1651369752",
+        "fr": "applemusic://track/1651369752",
+        "es": "applemusic://track/1651369752",
+        "nl": "applemusic://track/1651369752",
+        "it": "applemusic://track/1651369752"
+      }
     },
     {
       "year": 2022,
@@ -5568,7 +7078,17 @@
       "uri_tidal": "tidal://track/252452827",
       "uri_deezer": "deezer://track/1941878867",
       "fun_fact_nl": "Boore mengt Amerikaanse westernthema's met de Kölner Karneval en mengt de Keulse Alaaf-groet met cowboy-yippies.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEEQ82200102",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1648168097",
+        "de": "applemusic://track/1648168097",
+        "gb": "applemusic://track/1648168097",
+        "fr": "applemusic://track/1648168097",
+        "es": "applemusic://track/1648168097",
+        "nl": "applemusic://track/1648168097",
+        "it": "applemusic://track/1648168097"
+      }
     },
     {
       "year": 2022,
@@ -5618,7 +7138,17 @@
       "uri_tidal": "tidal://track/254186688",
       "uri_deezer": "deezer://track/2027779787",
       "fun_fact_nl": "Eldorado is een van de nieuwere carnavalsbands die een fris geluid brengt met liedjes over het leven ten volle.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEW272104077",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1655841923",
+        "de": "applemusic://track/1655841923",
+        "gb": "applemusic://track/1655841923",
+        "fr": "applemusic://track/1655841923",
+        "es": "applemusic://track/1655841923",
+        "nl": "applemusic://track/1655841923",
+        "it": "applemusic://track/1655841923"
+      }
     },
     {
       "year": 2022,
@@ -5643,7 +7173,17 @@
       "uri_tidal": "tidal://track/252771019",
       "uri_deezer": "deezer://track/1952672307",
       "fun_fact_nl": "Fiasko is een nieuwere carnavalsband die bekend staat om hun aanstekelijke feestnummers, en Anita werd een dansvloerfavoriet tijdens de 2022 sessie.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEUM72205942",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1647675473",
+        "de": "applemusic://track/1647675473",
+        "gb": "applemusic://track/1647675473",
+        "fr": "applemusic://track/1647675473",
+        "es": "applemusic://track/1647675473",
+        "nl": "applemusic://track/1647675473",
+        "it": "applemusic://track/1647675473"
+      }
     },
     {
       "year": 2022,
@@ -5668,7 +7208,17 @@
       "uri_tidal": "tidal://track/254186686",
       "uri_deezer": "deezer://track/2943926341",
       "fun_fact_nl": "Höhner is al sinds de jaren 1970 royalty met carnaval, en dit nummer met prinsessenthema laat hun romantische ballade-kant zien.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEW272104088",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1762467487",
+        "de": "applemusic://track/1762467487",
+        "gb": "applemusic://track/1762467487",
+        "fr": "applemusic://track/1762467487",
+        "es": "applemusic://track/1762467487",
+        "nl": "applemusic://track/1762467487",
+        "it": "applemusic://track/1762467487"
+      }
     },
     {
       "year": 2022,
@@ -5693,7 +7243,17 @@
       "uri_tidal": "tidal://track/228939194",
       "uri_deezer": "deezer://track/1750803897",
       "fun_fact_nl": "Kasalla's hit over het zingen van iemand naar huis vat de carnavalstraditie van gezamenlijk zingen tot in de vroege ochtenduren.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DED192300053",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1688730094",
+        "de": "applemusic://track/1688730094",
+        "gb": "applemusic://track/1688730094",
+        "fr": "applemusic://track/1688730094",
+        "es": "applemusic://track/1688730094",
+        "nl": "applemusic://track/1688730094",
+        "it": "applemusic://track/1688730094"
+      }
     },
     {
       "year": 2022,
@@ -5718,7 +7278,17 @@
       "uri_tidal": "tidal://track/257163500",
       "uri_deezer": "deezer://track/1970588467",
       "fun_fact_nl": "Nooit zonder Alaaf - deze hymne geeft de essentie weer van de carnavalsgroet van Keulen die zich onderscheidt van de Helau van Düsseldorf.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEEQ82200108",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1650796698",
+        "de": "applemusic://track/1650796698",
+        "gb": "applemusic://track/1650796698",
+        "fr": "applemusic://track/1650796698",
+        "es": "applemusic://track/1650796698",
+        "nl": "applemusic://track/1650796698",
+        "it": "applemusic://track/1650796698"
+      }
     },
     {
       "year": 2022,
@@ -5768,7 +7338,17 @@
       "uri_tidal": "tidal://track/246221691",
       "uri_deezer": "deezer://track/1964217497",
       "fun_fact_nl": "Deze samenwerking tussen Miljö en Cat Ballou verenigde twee van de populairste moderne carnavalsbands in een krachtig duet.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEUM72205649",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1641877160",
+        "de": "applemusic://track/1641877160",
+        "gb": "applemusic://track/1641877160",
+        "fr": "applemusic://track/1641877160",
+        "es": "applemusic://track/1641877160",
+        "nl": "applemusic://track/1641877160",
+        "it": "applemusic://track/1641877160"
+      }
     },
     {
       "year": 2022,
@@ -5793,7 +7373,17 @@
       "uri_tidal": "tidal://track/390057175",
       "uri_deezer": "deezer://track/1750206307",
       "fun_fact_nl": "Niets is voor altijd - dit reflectieve Miljö-lied herinnert carnavalsgangers eraan het moment te koesteren, omdat de sessie altijd eindigt.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEUM72202297",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1647827276",
+        "de": "applemusic://track/1647827276",
+        "gb": "applemusic://track/1647827276",
+        "fr": "applemusic://track/1647827276",
+        "es": "applemusic://track/1647827276",
+        "nl": "applemusic://track/1647827276",
+        "it": "applemusic://track/1647827276"
+      }
     },
     {
       "year": 2022,
@@ -5818,7 +7408,17 @@
       "uri_tidal": "tidal://track/254061677",
       "uri_deezer": "deezer://track/1964217477",
       "fun_fact_nl": "The Greatest - Miljö domineerde het carnavalsseizoen van 2022 met meerdere hits en vestigde zichzelf als de nieuwe toonaangevende carnavalsband.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEUM72206658",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1647826395",
+        "de": "applemusic://track/1647826395",
+        "gb": "applemusic://track/1647826395",
+        "fr": "applemusic://track/1647826395",
+        "es": "applemusic://track/1647826395",
+        "nl": "applemusic://track/1647826395",
+        "it": "applemusic://track/1647826395"
+      }
     },
     {
       "year": 2022,
@@ -5843,7 +7443,17 @@
       "uri_tidal": "tidal://track/254061678",
       "uri_deezer": "deezer://track/1964217487",
       "fun_fact_nl": "For One Night - dit aanstekelijke Miljö-nummer geeft de magie weer van carnavalsontmoetingen die slechts één onvergetelijke nacht duren.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEUM72206659",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1647826818",
+        "de": "applemusic://track/1647826818",
+        "gb": "applemusic://track/1647826818",
+        "fr": "applemusic://track/1647826818",
+        "es": "applemusic://track/1647826818",
+        "nl": "applemusic://track/1647826818",
+        "it": "applemusic://track/1647826818"
+      }
     },
     {
       "year": 2022,
@@ -5868,7 +7478,17 @@
       "uri_tidal": "tidal://track/252598609",
       "uri_deezer": "deezer://track/1951101247",
       "fun_fact_nl": "Deze speelse titel geeft een carnavaleske draai aan de meme 'Eat Sleep Rave Repeat' en beschrijft perfect de carnavalsmarathon.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DED192200058",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1648649225",
+        "de": "applemusic://track/1648649225",
+        "gb": "applemusic://track/1648649225",
+        "fr": "applemusic://track/1648649225",
+        "es": "applemusic://track/1648649225",
+        "nl": "applemusic://track/1648649225",
+        "it": "applemusic://track/1648649225"
+      }
     },
     {
       "year": 2022,
@@ -5893,7 +7513,17 @@
       "uri_tidal": "tidal://track/249756932",
       "uri_deezer": "deezer://track/1961464587",
       "fun_fact_nl": "Räuber, opgericht in 1991, staan bekend om hun feesthits met onzinnige refreinen die het publiek aan het dansen en meezingen krijgen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DED192200042",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1646259655",
+        "de": "applemusic://track/1646259655",
+        "gb": "applemusic://track/1646259655",
+        "fr": "applemusic://track/1646259655",
+        "es": "applemusic://track/1646259655",
+        "nl": "applemusic://track/1646259655",
+        "it": "applemusic://track/1646259655"
+      }
     },
     {
       "year": 2022,
@@ -5918,7 +7548,17 @@
       "uri_tidal": "tidal://track/253676232",
       "uri_deezer": "deezer://track/1959564747",
       "fun_fact_nl": "Stadtrand vertegenwoordigt de carnavalsscene in de buitenwijken van Keulen en brengt frisse perspectieven vanuit de buitenwijken van de stad.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEWQ72200010",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1709284654",
+        "de": "applemusic://track/1709284654",
+        "gb": "applemusic://track/1709284654",
+        "fr": "applemusic://track/1709284654",
+        "es": "applemusic://track/1709284654",
+        "nl": "applemusic://track/1709284654",
+        "it": "applemusic://track/1709284654"
+      }
     },
     {
       "year": 2023,
@@ -5943,7 +7583,17 @@
       "uri_tidal": "tidal://track/320029653",
       "uri_deezer": "deezer://track/2486854961",
       "fun_fact_nl": "Liefde tegen oorlog - dit lied weerspiegelde het sentiment van het carnavalsseizoen van 2023, dat in het teken stond van solidariteit met Oekraïne.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DED192300099",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1710764730",
+        "de": "applemusic://track/1710764730",
+        "gb": "applemusic://track/1710764730",
+        "fr": "applemusic://track/1710764730",
+        "es": "applemusic://track/1710764730",
+        "nl": "applemusic://track/1710764730",
+        "it": "applemusic://track/1710764730"
+      }
     },
     {
       "year": 2023,
@@ -5968,7 +7618,17 @@
       "uri_tidal": "tidal://track/320029656",
       "uri_deezer": "deezer://track/2484963121",
       "fun_fact_nl": "Hier is Keulen thuis - Bläck Fööss, met meer dan 50 jaar geschiedenis, blijft hun thuisstad vieren met hartverwarmende volksliederen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DED192300093",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1710775886",
+        "de": "applemusic://track/1710775886",
+        "gb": "applemusic://track/1710775886",
+        "fr": "applemusic://track/1710775886",
+        "es": "applemusic://track/1710775886",
+        "nl": "applemusic://track/1710775886",
+        "it": "applemusic://track/1710775886"
+      }
     },
     {
       "year": 2023,
@@ -5993,7 +7653,17 @@
       "uri_tidal": "tidal://track/320004077",
       "uri_deezer": "deezer://track/2484704181",
       "fun_fact_nl": "Good Times - Cat Ballou's feelgood anthem werd een vast onderdeel van de 2023 sessie met zijn opbeurende boodschap.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEWQ72200026",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1710507999",
+        "de": "applemusic://track/1710507999",
+        "gb": "applemusic://track/1710507999",
+        "fr": "applemusic://track/1710507999",
+        "es": "applemusic://track/1710507999",
+        "nl": "applemusic://track/1710507999",
+        "it": "applemusic://track/1710507999"
+      }
     },
     {
       "year": 2023,
@@ -6018,7 +7688,17 @@
       "uri_tidal": "tidal://track/270973264",
       "uri_deezer": "deezer://track/2104421867",
       "fun_fact_nl": "Deze elektronische remix bracht Cat Ballou naar dansvloeren buiten de traditionele carnavalslocaties, door naar mainstream clubs te gaan.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEWQ72200025",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1671000882",
+        "de": "applemusic://track/1671000882",
+        "gb": "applemusic://track/1671000882",
+        "fr": "applemusic://track/1671000882",
+        "es": "applemusic://track/1671000882",
+        "nl": "applemusic://track/1671000882",
+        "it": "applemusic://track/1671000882"
+      }
     },
     {
       "year": 2023,
@@ -6043,7 +7723,17 @@
       "uri_tidal": "tidal://track/312185634",
       "uri_deezer": "deezer://track/2421844835",
       "fun_fact_nl": "Druckluft (Compressed Air) brengt hoogenergieke brassband-feestmuziek, en dit discoacrobatennummer geeft hun speelse stijl goed weer.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEQM62303915",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1840129161",
+        "de": "applemusic://track/1840129161",
+        "gb": "applemusic://track/1840129161",
+        "fr": "applemusic://track/1840129161",
+        "es": "applemusic://track/1840129161",
+        "nl": "applemusic://track/1840129161",
+        "it": "applemusic://track/1840129161"
+      }
     },
     {
       "year": 2023,
@@ -6067,7 +7757,17 @@
       "uri_tidal": "tidal://track/321342618",
       "uri_deezer": "deezer://track/2495017851",
       "fun_fact_nl": "Favoriete nummers - dit meta-carnavalslied over het houden van carnavalsmuziek sloeg aan bij toegewijde Kölner Karneval-fans.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEW272301117",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1711613886",
+        "de": "applemusic://track/1711613886",
+        "gb": "applemusic://track/1711613886",
+        "fr": "applemusic://track/1711613886",
+        "es": "applemusic://track/1711613886",
+        "nl": "applemusic://track/1711613886",
+        "it": "applemusic://track/1711613886"
+      }
     },
     {
       "year": 2023,
@@ -6092,7 +7792,17 @@
       "uri_tidal": "tidal://track/330064386",
       "uri_deezer": "deezer://track/2550422112",
       "fun_fact_nl": "Het is niet wat je denkt - Höhners speelse lied over misverstanden laat na meer dan 50 jaar hun humoristische kant zien.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEW272301118",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1766473799",
+        "de": "applemusic://track/1766473799",
+        "gb": "applemusic://track/1766473799",
+        "fr": "applemusic://track/1766473799",
+        "es": "applemusic://track/1766473799",
+        "nl": "applemusic://track/1766473799",
+        "it": "applemusic://track/1766473799"
+      }
     },
     {
       "year": 2023,
@@ -6117,7 +7827,17 @@
       "uri_tidal": "tidal://track/320309598",
       "uri_deezer": "deezer://track/2487100361",
       "fun_fact_nl": "When I'm an angel - Kasalla's reflectieve lied over sterfelijkheid en nalatenschap raakte carnavalsgangers met zijn diepere betekenis.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DED192300089",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1710791111",
+        "de": "applemusic://track/1710791111",
+        "gb": "applemusic://track/1710791111",
+        "fr": "applemusic://track/1710791111",
+        "es": "applemusic://track/1710791111",
+        "nl": "applemusic://track/1710791111",
+        "it": "applemusic://track/1710791111"
+      }
     },
     {
       "year": 2023,
@@ -6142,7 +7862,17 @@
       "uri_tidal": "tidal://track/319064633",
       "uri_deezer": "deezer://track/2477404641",
       "fun_fact_nl": "De Loreley is een beroemde rots aan de Rijn - dit lied verbindt carnaval met de romantische legendes van de Rijnvallei.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEEQ82300136",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1709627193",
+        "de": "applemusic://track/1709627193",
+        "gb": "applemusic://track/1709627193",
+        "fr": "applemusic://track/1709627193",
+        "es": "applemusic://track/1709627193",
+        "nl": "applemusic://track/1709627193",
+        "it": "applemusic://track/1709627193"
+      }
     },
     {
       "year": 2023,
@@ -6192,7 +7922,17 @@
       "uri_tidal": "tidal://track/321822843",
       "uri_deezer": "deezer://track/2497967701",
       "fun_fact_nl": "De laatste keer - dit bitterzoete nummer over het einde van carnaval is een favoriet geworden bij veel gelegenheden.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DGA0Q2383427",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1721351813",
+        "de": "applemusic://track/1721351813",
+        "gb": "applemusic://track/1721351813",
+        "fr": "applemusic://track/1721351813",
+        "es": "applemusic://track/1721351813",
+        "nl": "applemusic://track/1721351813",
+        "it": "applemusic://track/1721351813"
+      }
     },
     {
       "year": 2023,
@@ -6217,7 +7957,17 @@
       "uri_tidal": "tidal://track/320029646",
       "uri_deezer": "deezer://track/2484963041",
       "fun_fact_nl": "Gulp gulp - dit drinklied van Mätropolis werd meteen een hit met zijn eenvoudige, meezingbare refrein.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DED192300097",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1711786088",
+        "de": "applemusic://track/1711786088",
+        "gb": "applemusic://track/1711786088",
+        "fr": "applemusic://track/1711786088",
+        "es": "applemusic://track/1711786088",
+        "nl": "applemusic://track/1711786088",
+        "it": "applemusic://track/1711786088"
+      }
     },
     {
       "year": 2023,
@@ -6242,7 +7992,17 @@
       "uri_tidal": "tidal://track/326445820",
       "uri_deezer": "deezer://track/2526332121",
       "fun_fact_nl": "Geen Kölsch-bier voor nazi's - het politieke statement van Querbeat werd een hymne tegen rechts-extremisme tijdens carnaval.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DECE72303332",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1714609131",
+        "de": "applemusic://track/1714609131",
+        "gb": "applemusic://track/1714609131",
+        "fr": "applemusic://track/1714609131",
+        "es": "applemusic://track/1714609131",
+        "nl": "applemusic://track/1714609131",
+        "it": "applemusic://track/1714609131"
+      }
     },
     {
       "year": 2023,
@@ -6267,7 +8027,17 @@
       "uri_tidal": "tidal://track/320029648",
       "uri_deezer": "deezer://track/2502267621",
       "fun_fact_nl": "Een Kölsch lied - deze meta-viering van het zingen in het Keulse dialect geeft de trots weer om de taal levend te houden.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DED192300082",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1712059728",
+        "de": "applemusic://track/1712059728",
+        "gb": "applemusic://track/1712059728",
+        "fr": "applemusic://track/1712059728",
+        "es": "applemusic://track/1712059728",
+        "nl": "applemusic://track/1712059728",
+        "it": "applemusic://track/1712059728"
+      }
     },
     {
       "year": 2024,
@@ -6367,7 +8137,17 @@
       "uri_tidal": "tidal://track/80234194",
       "uri_deezer": "deezer://track/419917652",
       "fun_fact_nl": "Liefde wint - De boodschap van liefde en tolerantie van Brings weerspiegelt de carnavalstraditie van acceptatie en saamhorigheid.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEUM71724921",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1440908274",
+        "de": "applemusic://track/1440908274",
+        "gb": "applemusic://track/1440908274",
+        "fr": "applemusic://track/1440908274",
+        "es": "applemusic://track/1440908274",
+        "nl": "applemusic://track/1440908274",
+        "it": "applemusic://track/1440908274"
+      }
     },
     {
       "year": 2024,
@@ -6417,7 +8197,17 @@
       "uri_tidal": "tidal://track/38286132",
       "uri_deezer": "deezer://track/90973013",
       "fun_fact_nl": "Zet de stad op z'n kop - dit feestliedje beschrijft de carnavalstraditie van het op z'n kop zetten van sociale normen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEC611200528",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1764121317",
+        "de": "applemusic://track/715804915",
+        "gb": "applemusic://track/715804915",
+        "fr": "applemusic://track/715804915",
+        "es": "applemusic://track/715804915",
+        "nl": "applemusic://track/715804915",
+        "it": "applemusic://track/715804915"
+      }
     },
     {
       "year": 2024,
@@ -6442,7 +8232,17 @@
       "uri_tidal": "tidal://track/390678468",
       "uri_deezer": "deezer://track/3025370741",
       "fun_fact_nl": "As long as the world keeps turning - Brengt weer een tijdloze boodschap over het vieren van het leven door middel van carnaval.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEBL62300100",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1771763679",
+        "de": "applemusic://track/1771763679",
+        "gb": "applemusic://track/1771763679",
+        "fr": "applemusic://track/1771763679",
+        "es": "applemusic://track/1771763679",
+        "nl": "applemusic://track/1771763679",
+        "it": "applemusic://track/1771763679"
+      }
     },
     {
       "year": 2024,
@@ -6492,7 +8292,17 @@
       "uri_tidal": "tidal://track/52910290",
       "uri_deezer": "deezer://track/113944102",
       "fun_fact_nl": "Zonder de kathedraal, zonder de Rijn, zonder zonneschijn - dit lied somt op wat Keulen incompleet maakt zonder zijn bezienswaardigheden.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEUM71503397",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1442649505",
+        "de": "applemusic://track/1598885298",
+        "gb": "applemusic://track/1442649505",
+        "fr": "applemusic://track/1442649505",
+        "es": "applemusic://track/1442649505",
+        "nl": "applemusic://track/1442649505",
+        "it": "applemusic://track/1442649505"
+      }
     },
     {
       "year": 2024,
@@ -6542,7 +8352,17 @@
       "uri_tidal": "tidal://track/37072520",
       "uri_deezer": "deezer://track/92818656",
       "fun_fact_nl": "Op de goede oude tijd - dit nostalgische lied viert de traditie en herinneringen aan voorbije carnavalsseizoenen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEUM71403587",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1442689544",
+        "de": "applemusic://track/1444269605",
+        "gb": "applemusic://track/1444269605",
+        "fr": "applemusic://track/1444269605",
+        "es": "applemusic://track/1444269605",
+        "nl": "applemusic://track/1444269605",
+        "it": "applemusic://track/1444269605"
+      }
     },
     {
       "year": 2024,
@@ -6567,7 +8387,17 @@
       "uri_tidal": "tidal://track/23206604",
       "uri_deezer": "deezer://track/73697336",
       "fun_fact_nl": "Natuurlijk gek - dit nummer omarmt de inherente gekte van een echte carnavalsliefhebber uit Keulen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEUM71303915",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1442517356",
+        "de": "applemusic://track/1444403882",
+        "gb": "applemusic://track/1444403882",
+        "fr": "applemusic://track/1444403882",
+        "es": "applemusic://track/1444403882",
+        "nl": "applemusic://track/1444403882",
+        "it": "applemusic://track/1444403882"
+      }
     },
     {
       "year": 2024,
@@ -6592,7 +8422,17 @@
       "uri_tidal": "tidal://track/367913197",
       "uri_deezer": "deezer://track/2835979092",
       "fun_fact_nl": "De Duits-Turkse rapper Eko Fresh uit Keulen slaat een brug tussen hiphop en carnaval en viert diversiteit met dit kleurrijke bridge-anthem.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEUM72406723",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1753683710",
+        "de": "applemusic://track/1753683710",
+        "gb": "applemusic://track/1753683710",
+        "fr": "applemusic://track/1753683710",
+        "es": "applemusic://track/1753683710",
+        "nl": "applemusic://track/1753683710",
+        "it": "applemusic://track/1753683710"
+      }
     },
     {
       "year": 2024,
@@ -6617,7 +8457,17 @@
       "uri_tidal": "tidal://track/388499960",
       "uri_deezer": "deezer://track/3000555791",
       "fun_fact_nl": "Helaas weer geëscaleerd - dit humoristische nummer over uit de hand gelopen carnavalsavonden vindt weerklank bij feestveteranen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEUM72408694",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1769179359",
+        "de": "applemusic://track/1769179359",
+        "gb": "applemusic://track/1769179359",
+        "fr": "applemusic://track/1769179359",
+        "es": "applemusic://track/1769179359",
+        "nl": "applemusic://track/1769179359",
+        "it": "applemusic://track/1769179359"
+      }
     },
     {
       "year": 2024,
@@ -6642,7 +8492,17 @@
       "uri_tidal": "tidal://track/96969509",
       "uri_deezer": "deezer://track/1118047042",
       "fun_fact_nl": "Voor jou - Fiasko laat zich van hun romantische kant zien met dit inwijdingsliedje temidden van hun meestal feestgerichte repertoire.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEUM71806630",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1439261265",
+        "de": "applemusic://track/1439261265",
+        "gb": "applemusic://track/1439261265",
+        "fr": "applemusic://track/1439261265",
+        "es": "applemusic://track/1439261265",
+        "nl": "applemusic://track/1439261265",
+        "it": "applemusic://track/1439261265"
+      }
     },
     {
       "year": 2024,
@@ -6667,7 +8527,17 @@
       "uri_tidal": "tidal://track/390057143",
       "uri_deezer": "deezer://track/1118047042",
       "fun_fact_nl": "Song for you - nog een hartverwarmende toewijding van Fiasko die bewijst dat carnavalsbands ook emotionele ballads kunnen afleveren.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEUM72005649",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1536060763",
+        "de": "applemusic://track/1536060763",
+        "gb": "applemusic://track/1536060763",
+        "fr": "applemusic://track/1536060763",
+        "es": "applemusic://track/1536060763",
+        "nl": "applemusic://track/1536060763",
+        "it": "applemusic://track/1536060763"
+      }
     },
     {
       "year": 2024,
@@ -6692,7 +8562,17 @@
       "uri_tidal": "tidal://track/390057130",
       "uri_deezer": "deezer://track/2496460251",
       "fun_fact_nl": "Hearts are out - deze Kölsch zin over het dragen van je hart op je mouw vat de emotionele openheid van carnaval.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEUM72311358",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1769179543",
+        "de": "applemusic://track/1769179543",
+        "gb": "applemusic://track/1769179543",
+        "fr": "applemusic://track/1769179543",
+        "es": "applemusic://track/1769179543",
+        "nl": "applemusic://track/1769179543",
+        "it": "applemusic://track/1769179543"
+      }
     },
     {
       "year": 2024,
@@ -6717,7 +8597,17 @@
       "uri_tidal": "tidal://track/11651889",
       "uri_deezer": "deezer://track/14712948",
       "fun_fact_nl": "Höhners directe viering van het carnaval zelf laat zien waarom ze al meer dan 50 jaar de meest succesvolle band in het genre zijn.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEC611101113",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1764120136",
+        "de": "applemusic://track/1442577247",
+        "gb": "applemusic://track/713704848",
+        "fr": "applemusic://track/713704848",
+        "es": "applemusic://track/713704848",
+        "nl": "applemusic://track/713704848",
+        "it": "applemusic://track/713704848"
+      }
     },
     {
       "year": 2024,
@@ -6767,7 +8657,17 @@
       "uri_tidal": "tidal://track/7842714",
       "uri_deezer": "deezer://track/3154491",
       "fun_fact_nl": "De goede God weet dat ik geen engel ben - dit biechtlied past perfect bij de carnavalstraditie van verwennerij voor de vastentijd.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEA349800648",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1641818947",
+        "de": "applemusic://track/1641818947",
+        "gb": "applemusic://track/1641818947",
+        "fr": "applemusic://track/1641818947",
+        "es": "applemusic://track/1641818947",
+        "nl": "applemusic://track/1641818947",
+        "it": "applemusic://track/1641818947"
+      }
     },
     {
       "year": 2024,
@@ -6817,7 +8717,17 @@
       "uri_tidal": "tidal://track/7842708",
       "uri_deezer": "deezer://track/3488636",
       "fun_fact_nl": "De karavaan trekt verder, de sultan heeft dorst - dit speelse liedje verwijst naar het beroemde Duitse gezegde met een Keuls tintje.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEA349701604",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/724021379",
+        "de": "applemusic://track/724021379",
+        "gb": "applemusic://track/724021379",
+        "fr": "applemusic://track/724021379",
+        "es": "applemusic://track/724021379",
+        "nl": "applemusic://track/724021379",
+        "it": "applemusic://track/724021379"
+      }
     },
     {
       "year": 2024,
@@ -6842,7 +8752,17 @@
       "uri_tidal": "tidal://track/393637120",
       "uri_deezer": "deezer://track/3045007861",
       "fun_fact_nl": "Your south stand - dit nummer legt een link tussen carnaval en de voetbalcultuur van FC Keulen en verwijst naar het beroemde supportersvak van het stadion.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DED192400012",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1774211111",
+        "de": "applemusic://track/1774211111",
+        "gb": "applemusic://track/1774211111",
+        "fr": "applemusic://track/1774211111",
+        "es": "applemusic://track/1774211111",
+        "nl": "applemusic://track/1774211111",
+        "it": "applemusic://track/1774211111"
+      }
     },
     {
       "year": 2024,
@@ -6867,7 +8787,17 @@
       "uri_tidal": "tidal://track/37765136",
       "uri_deezer": "deezer://track/89904333",
       "fun_fact_nl": "Gemaakt van Keuls hout - deze uitdrukking betekent dat je een echte Keulenaar bent, gemaakt van hetzelfde materiaal als de stad zelf.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEUM71403640",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/933255553",
+        "de": "applemusic://track/933255553",
+        "gb": "applemusic://track/933255553",
+        "fr": "applemusic://track/933255553",
+        "es": "applemusic://track/933255553",
+        "nl": "applemusic://track/933255553",
+        "it": "applemusic://track/933255553"
+      }
     },
     {
       "year": 2024,
@@ -6967,7 +8897,17 @@
       "uri_tidal": "tidal://track/120568030",
       "uri_deezer": "deezer://track/780611282",
       "fun_fact_nl": "Nul of honderd - Miljö's alles-of-niets party anthem vangt de intensiteit van het uit je dak gaan tijdens het carnavalsseizoen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEUM71905452",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1764119941",
+        "de": "applemusic://track/1764119941",
+        "gb": "applemusic://track/1764119941",
+        "fr": "applemusic://track/1764119941",
+        "es": "applemusic://track/1764119941",
+        "nl": "applemusic://track/1764119941",
+        "it": "applemusic://track/1764119941"
+      }
     },
     {
       "year": 2024,
@@ -7017,7 +8957,17 @@
       "uri_tidal": "tidal://track/390057150",
       "uri_deezer": "deezer://track/1359247532",
       "fun_fact_nl": "Gooi er wat leven in - dit opbeurende Miljö-nummer moedigt aan om elk moment van de carnavalservaring te omarmen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEUM72113100",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1564379980",
+        "de": "applemusic://track/1771051559",
+        "gb": "applemusic://track/1564379980",
+        "fr": "applemusic://track/1564379980",
+        "es": "applemusic://track/1564379980",
+        "nl": "applemusic://track/1564379980",
+        "it": "applemusic://track/1564379980"
+      }
     },
     {
       "year": 2024,
@@ -7042,7 +8992,17 @@
       "uri_tidal": "tidal://track/96969384",
       "uri_deezer": "deezer://track/571878742",
       "fun_fact_nl": "Hobbelpaard - dit nostalgische Miljö-liedje roept de onschuld van de kindertijd in herinnering en viert tegelijkertijd de hedendaagse carnavalsvreugde.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEUM71806626",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1483150524",
+        "de": "applemusic://track/1483150524",
+        "gb": "applemusic://track/1483150524",
+        "fr": "applemusic://track/1483150524",
+        "es": "applemusic://track/1483150524",
+        "nl": "applemusic://track/1483150524",
+        "it": "applemusic://track/1483150524"
+      }
     },
     {
       "year": 2024,
@@ -7067,7 +9027,17 @@
       "uri_tidal": "tidal://track/37873074",
       "uri_deezer": "deezer://track/90154137",
       "fun_fact_nl": "Stomp on - dit energieke danscommando krijgt mensenmassa's aan het stampen en springen in koor op carnavalsfeesten.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEUM71403714",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1442798808",
+        "de": "applemusic://track/1442798808",
+        "gb": "applemusic://track/1442798808",
+        "fr": "applemusic://track/1442798808",
+        "es": "applemusic://track/1442798808",
+        "nl": "applemusic://track/1442798808",
+        "it": "applemusic://track/1442798808"
+      }
     },
     {
       "year": 2024,
@@ -7092,7 +9062,17 @@
       "uri_tidal": "tidal://track/159640002",
       "uri_deezer": "deezer://track/1118025292",
       "fun_fact_nl": "Tijd terug - Miljö's nostalgische reflectie op vroegere carnavalsherinneringen vindt weerklank bij oude carnavalsliefhebbers.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEUM72005646",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1536059320",
+        "de": "applemusic://track/1536059320",
+        "gb": "applemusic://track/1536059320",
+        "fr": "applemusic://track/1536059320",
+        "es": "applemusic://track/1536059320",
+        "nl": "applemusic://track/1536059320",
+        "it": "applemusic://track/1536059320"
+      }
     },
     {
       "year": 2024,
@@ -7117,7 +9097,17 @@
       "uri_tidal": "tidal://track/113400855",
       "uri_deezer": "deezer://track/713477362",
       "fun_fact_nl": "Pur is een mainstream Duitse popband die zich af en toe begeeft op carnavalsterrein met feestvriendelijke mixcompilaties.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEC649800430",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1709414071",
+        "de": "applemusic://track/1709414071",
+        "gb": "applemusic://track/1709414071",
+        "fr": "applemusic://track/1709414071",
+        "es": "applemusic://track/1709414071",
+        "nl": "applemusic://track/1709414071",
+        "it": "applemusic://track/1709414071"
+      }
     },
     {
       "year": 2024,
@@ -7142,7 +9132,17 @@
       "uri_tidal": "tidal://track/384276613",
       "uri_deezer": "deezer://track/2970839991",
       "fun_fact_nl": "Op en neer - het eenvoudige dansinstructieliedje van Räuber brengt het carnavalspubliek in beweging met gemakkelijk te volgen commando's.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DED192300091",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1754582886",
+        "de": "applemusic://track/1754582886",
+        "gb": "applemusic://track/1754582886",
+        "fr": "applemusic://track/1754582886",
+        "es": "applemusic://track/1754582886",
+        "nl": "applemusic://track/1754582886",
+        "it": "applemusic://track/1754582886"
+      }
     },
     {
       "year": 2025,
@@ -7167,7 +9167,17 @@
       "uri_tidal": "tidal://track/467233077",
       "uri_deezer": "deezer://track/3604402192",
       "fun_fact_nl": "Leef je leven - Brings' 2025 sessie hit zet hun traditie van opbeurende anthems voort na meer dan 30 jaar in carnavalsmuziek.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEBL62300101",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1846449458",
+        "de": "applemusic://track/1846449458",
+        "gb": "applemusic://track/1846449458",
+        "fr": "applemusic://track/1846449458",
+        "es": "applemusic://track/1846449458",
+        "nl": "applemusic://track/1846449458",
+        "it": "applemusic://track/1846449458"
+      }
     },
     {
       "year": 2025,
@@ -7192,7 +9202,17 @@
       "uri_tidal": "tidal://track/472129236",
       "uri_deezer": "deezer://track/3641850942",
       "fun_fact_nl": "Geweldig hoe je danst - Kuhl un de Gäng brengt energieke feestvibes naar carnaval met hun dansgerichte hits.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEL942500148",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1851222882",
+        "de": "applemusic://track/1851222882",
+        "gb": "applemusic://track/1851222882",
+        "fr": "applemusic://track/1851222882",
+        "es": "applemusic://track/1851222882",
+        "nl": "applemusic://track/1851222882",
+        "it": "applemusic://track/1851222882"
+      }
     },
     {
       "year": 2025,
@@ -7239,7 +9259,17 @@
       "uri_tidal": "tidal://track/424379841",
       "uri_deezer": "deezer://track/3325377211",
       "fun_fact_nl": "Rocket - De hit uit 2025 van Mätropolis zet de traditie van de band voort met energieke feestnummers voor op de dansvloer.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DED192400011",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1774224347",
+        "de": "applemusic://track/1774224347",
+        "gb": "applemusic://track/1774224347",
+        "fr": "applemusic://track/1774224347",
+        "es": "applemusic://track/1774224347",
+        "nl": "applemusic://track/1774224347",
+        "it": "applemusic://track/1774224347"
+      }
     }
   ]
 }

--- a/custom_components/beatify/playlists/community/pure-pop-punk.json
+++ b/custom_components/beatify/playlists/community/pure-pop-punk.json
@@ -41,7 +41,17 @@
       "uri_tidal": "tidal://track/10906349",
       "uri_deezer": "deezer://track/3829140",
       "fun_fact_nl": "Paramore stopte met het live spelen van dit nummer in 2018 vanwege controversiële teksten over een andere vrouw, maar bracht het op veler verzoek terug in 2022.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USAT21300089",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/607340408",
+        "de": "applemusic://track/607340408",
+        "gb": "applemusic://track/607340408",
+        "fr": "applemusic://track/607340408",
+        "es": "applemusic://track/607340408",
+        "nl": "applemusic://track/607340408",
+        "it": "applemusic://track/607340408"
+      }
     },
     {
       "year": 1999,
@@ -71,7 +81,17 @@
       "uri_tidal": "tidal://track/173565585",
       "uri_deezer": "deezer://track/552496552",
       "fun_fact_nl": "In de beroemde videoclip rent de band volledig naakt door Los Angeles. Het werd gefilmd in guerrillastijl zonder vergunningen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMC19959007",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1551378216",
+        "de": "applemusic://track/1551378216",
+        "gb": "applemusic://track/1551378216",
+        "fr": "applemusic://track/1551378216",
+        "es": "applemusic://track/1551378216",
+        "nl": "applemusic://track/1551378216",
+        "it": "applemusic://track/1551378216"
+      }
     },
     {
       "year": 2002,
@@ -101,7 +121,17 @@
       "uri_tidal": "tidal://track/31067656",
       "uri_deezer": "deezer://track/1104656",
       "fun_fact_nl": "Sum 41 schreef dit nummer in slechts 20 minuten als gefrustreerd antwoord op de druk van hun platenmaatschappij om een radiovriendelijke single te maken.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USIR20200964",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1443465786",
+        "de": "applemusic://track/1443465786",
+        "gb": null,
+        "fr": null,
+        "es": null,
+        "nl": null,
+        "it": null
+      }
     },
     {
       "year": 2007,
@@ -132,7 +162,17 @@
       "uri_tidal": "tidal://track/1213576",
       "uri_deezer": "deezer://track/911496",
       "fun_fact_nl": "In de titel zijn opzettelijk klinkers weggelaten. Kim Kardashian verscheen in de videoclip als de love interest, gefilmd voordat ze bekend werd op reality-tv.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USUM70700326",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1440560148",
+        "de": "applemusic://track/1440560148",
+        "gb": "applemusic://track/1440560148",
+        "fr": "applemusic://track/1440560148",
+        "es": "applemusic://track/1440560148",
+        "nl": "applemusic://track/1440560148",
+        "it": "applemusic://track/1440560148"
+      }
     },
     {
       "year": 2000,
@@ -162,7 +202,17 @@
       "uri_tidal": "tidal://track/67367298",
       "uri_deezer": "deezer://track/137234110",
       "fun_fact_nl": "Dit nummer stond op de soundtrack van American Pie 2 en hielp The Offspring om relevant te blijven in de poppunkscene van begin jaren 2000.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM10016014",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1850761234",
+        "de": "applemusic://track/1850761234",
+        "gb": "applemusic://track/1850761234",
+        "fr": "applemusic://track/1850761234",
+        "es": "applemusic://track/1850761234",
+        "nl": "applemusic://track/1850761234",
+        "it": "applemusic://track/1850761234"
+      }
     },
     {
       "year": 2004,
@@ -193,7 +243,17 @@
       "uri_tidal": "tidal://track/293936",
       "uri_deezer": "deezer://track/785961",
       "fun_fact_nl": "De videoclip is een briljante parodie op jaren 80 tienerfilms. De band verkleedde zich als middelbare scholieren ondanks dat ze midden 20 waren.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USRE11600525",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1156311437",
+        "de": "applemusic://track/1156311437",
+        "gb": "applemusic://track/1156311437",
+        "fr": "applemusic://track/1156311437",
+        "es": "applemusic://track/1156311437",
+        "nl": "applemusic://track/1156311437",
+        "it": "applemusic://track/1156311437"
+      }
     },
     {
       "year": 2004,
@@ -221,7 +281,17 @@
       "uri_tidal": "tidal://track/33736851",
       "uri_deezer": "deezer://track/7675619",
       "fun_fact_nl": "Deze emotionele ballade toonde Good Charlotte's bereik voorbij hun typische upbeat poppunkstijl en werd een fanfavoriet tijdens concerten.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM10606774",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/402053049",
+        "de": "applemusic://track/261403444",
+        "gb": "applemusic://track/261403444",
+        "fr": "applemusic://track/261403444",
+        "es": "applemusic://track/261403444",
+        "nl": "applemusic://track/261403444",
+        "it": "applemusic://track/261403444"
+      }
     },
     {
       "year": 2002,
@@ -251,7 +321,17 @@
       "uri_tidal": "tidal://track/86346711",
       "uri_deezer": "deezer://track/477008492",
       "fun_fact_nl": "Dit nummer, dat te horen was in de film Cheaper by the Dozen, werd een hymne voor onbegrepen voelen en explodeerde op TikTok in 2020.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USAT20111234",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1821434250",
+        "de": "applemusic://track/1832010856",
+        "gb": "applemusic://track/1821434250",
+        "fr": "applemusic://track/1821434250",
+        "es": "applemusic://track/1821434250",
+        "nl": "applemusic://track/1821434250",
+        "it": "applemusic://track/1821434250"
+      }
     },
     {
       "year": 2004,
@@ -282,7 +362,17 @@
       "uri_tidal": "tidal://track/68638837",
       "uri_deezer": "deezer://track/715954",
       "fun_fact_nl": "Oorspronkelijk getiteld 'Holiday (Bring the Bombs)', is het een anti-oorlog protestlied over de oorlog in Irak van het politiek geladen American Idiot album.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USRE11200336",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1761687881",
+        "de": "applemusic://track/1761687881",
+        "gb": "applemusic://track/1761687881",
+        "fr": "applemusic://track/1761687881",
+        "es": "applemusic://track/1761687881",
+        "nl": "applemusic://track/1761687881",
+        "it": "applemusic://track/1761687881"
+      }
     },
     {
       "year": 2007,
@@ -312,7 +402,17 @@
       "uri_tidal": "tidal://track/144590716",
       "uri_deezer": "deezer://track/6249577",
       "fun_fact_nl": "Geschreven over een stripper die Alex Gaskarth kende in Baltimore. Het nummer werd de doorbraakhit van All Time Low en een vaste waarde in de poppunk.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USHR20747017",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1550014532",
+        "de": "applemusic://track/1550014532",
+        "gb": "applemusic://track/1550014532",
+        "fr": "applemusic://track/1550014532",
+        "es": "applemusic://track/1550014532",
+        "nl": "applemusic://track/1550014532",
+        "it": "applemusic://track/1550014532"
+      }
     },
     {
       "year": 2006,
@@ -340,7 +440,17 @@
       "uri_tidal": "tidal://track/122110",
       "uri_deezer": "deezer://track/3094156",
       "fun_fact_nl": "Het titelnummer van Yellowcard's album uit 2006 bevatte hun kenmerkende vioolgeluid waarmee ze zich onderscheidden van andere poppunkbands.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USCA20501001",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/724535524",
+        "de": "applemusic://track/724535524",
+        "gb": "applemusic://track/724535524",
+        "fr": "applemusic://track/724535524",
+        "es": "applemusic://track/724535524",
+        "nl": "applemusic://track/724535524",
+        "it": "applemusic://track/724535524"
+      }
     },
     {
       "year": 2006,
@@ -368,7 +478,17 @@
       "uri_tidal": "tidal://track/400125",
       "uri_deezer": "deezer://track/1572862",
       "fun_fact_nl": "+44 was het project van Mark Hoppus en Travis Barker tijdens de onderbreking van Blink-182. De bandnaam verwijst naar de landcode van het Verenigd Koninkrijk.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USUM70610945",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1603152493",
+        "de": "applemusic://track/1603152493",
+        "gb": "applemusic://track/1603152493",
+        "fr": "applemusic://track/1603152493",
+        "es": "applemusic://track/1603152493",
+        "nl": "applemusic://track/1603152493",
+        "it": "applemusic://track/1603152493"
+      }
     },
     {
       "year": 2006,
@@ -398,7 +518,17 @@
       "uri_tidal": "tidal://track/1342021",
       "uri_deezer": "deezer://track/3119156",
       "fun_fact_nl": "Dit nummer gaat over huiselijk geweld. De krachtige boodschap zorgde ervoor dat het de grootste en meest betekenisvolle hit van de band werd.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USVI20600108",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1707891990",
+        "de": "applemusic://track/1707891990",
+        "gb": "applemusic://track/1707891990",
+        "fr": "applemusic://track/1707891990",
+        "es": "applemusic://track/1707891990",
+        "nl": "applemusic://track/1707891990",
+        "it": "applemusic://track/1707891990"
+      }
     },
     {
       "year": 2002,
@@ -428,7 +558,17 @@
       "uri_tidal": "tidal://track/114082930",
       "uri_deezer": "deezer://track/980198",
       "fun_fact_nl": "Het kenmerkende nummer van New Found Glory was alomtegenwoordig aan het begin van de jaren 2000 en is nog steeds een vast onderdeel van poppunkshows en reünies op Warped Tour.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMC10200363",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1590465346",
+        "de": "applemusic://track/1590465346",
+        "gb": "applemusic://track/1590465346",
+        "fr": "applemusic://track/1590465346",
+        "es": "applemusic://track/1590465346",
+        "nl": "applemusic://track/1590465346",
+        "it": "applemusic://track/1590465346"
+      }
     },
     {
       "year": 2007,
@@ -486,7 +626,17 @@
       "uri_tidal": "tidal://track/144519621",
       "uri_deezer": "deezer://track/452171092",
       "fun_fact_nl": "Story Untold vertegenwoordigt de moderne golf van poppunk en houdt het genre levend voor nieuwe generaties fans in de jaren 2010.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USHR21710603",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1298835691",
+        "de": "applemusic://track/1298835691",
+        "gb": "applemusic://track/1298835691",
+        "fr": "applemusic://track/1298835691",
+        "es": "applemusic://track/1298835691",
+        "nl": "applemusic://track/1298835691",
+        "it": "applemusic://track/1298835691"
+      }
     },
     {
       "year": 2001,
@@ -516,7 +666,17 @@
       "uri_tidal": "tidal://track/77624459",
       "uri_deezer": "deezer://track/623714212",
       "fun_fact_nl": "Jimmy Eat World ging bijna uit elkaar voordat dit nummer hun onverwachte doorbraak werd. Het is nu een essentiële karaokeklassieker.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USDW10110256",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1706919742",
+        "de": "applemusic://track/1706919742",
+        "gb": "applemusic://track/1706919742",
+        "fr": "applemusic://track/1706919742",
+        "es": "applemusic://track/1706919742",
+        "nl": "applemusic://track/1706919742",
+        "it": "applemusic://track/1706919742"
+      }
     },
     {
       "year": 2004,
@@ -574,7 +734,17 @@
       "uri_tidal": "tidal://track/58476797",
       "uri_deezer": "deezer://track/121591974",
       "fun_fact_nl": "De doorbraakhit van Mayday Parade werd geschreven over een echte roadtrip-romance en werd essentiële luisterervaring voor emo kids overal ter wereld.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "US5260709901",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1834485369",
+        "de": "applemusic://track/1834485369",
+        "gb": "applemusic://track/1834485369",
+        "fr": "applemusic://track/1834485369",
+        "es": "applemusic://track/1834485369",
+        "nl": "applemusic://track/1834485369",
+        "it": "applemusic://track/1834485369"
+      }
     },
     {
       "year": 2006,
@@ -604,7 +774,17 @@
       "uri_tidal": "tidal://track/1604386",
       "uri_deezer": "deezer://track/538948",
       "fun_fact_nl": "Boys Like Girls behaalde een groot succes met dit anthem over losbreken, dat een bepalend nummer werd voor de poppunkscene van eind jaren 2000.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM10603069",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1788999880",
+        "de": "applemusic://track/1788999880",
+        "gb": "applemusic://track/1788999880",
+        "fr": "applemusic://track/1788999880",
+        "es": "applemusic://track/1788999880",
+        "nl": "applemusic://track/1788999880",
+        "it": "applemusic://track/1788999880"
+      }
     },
     {
       "year": 2013,
@@ -634,7 +814,17 @@
       "uri_tidal": "tidal://track/19599591",
       "uri_deezer": "deezer://track/65732147",
       "fun_fact_nl": "Paramore's eerste single na het vertrek van oprichters Josh en Zac Farro bewees dat de band kon gedijen met hun nieuwe line-up.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USAT21300028",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/593148441",
+        "de": "applemusic://track/593148441",
+        "gb": "applemusic://track/942088614",
+        "fr": "applemusic://track/942088614",
+        "es": "applemusic://track/942088614",
+        "nl": "applemusic://track/942088614",
+        "it": "applemusic://track/593148441"
+      }
     },
     {
       "year": 1998,
@@ -664,7 +854,17 @@
       "uri_tidal": "tidal://track/67367330",
       "uri_deezer": "deezer://track/137233986",
       "fun_fact_nl": "Opvallend in South Park: Bigger, Longer & Uncut. De donkere tekst van het nummer over verval in de voorsteden sloeg aan bij de jeugd van de jaren 90.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM19804363",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1551378218",
+        "de": "applemusic://track/1551378218",
+        "gb": "applemusic://track/1551378218",
+        "fr": "applemusic://track/1551378218",
+        "es": "applemusic://track/1551378218",
+        "nl": "applemusic://track/1551378218",
+        "it": "applemusic://track/1551378218"
+      }
     },
     {
       "year": 2006,
@@ -695,7 +895,17 @@
       "uri_tidal": "tidal://track/353341",
       "uri_deezer": "deezer://track/676590",
       "fun_fact_nl": "Gerard Way schreef dit nadat hij merkte dat volwassenen in een winkelcentrum echt bang leken te zijn voor tieners. Het ironische volkslied werd de strijdkreet van een generatie.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USRE10602912",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1740526697",
+        "de": "applemusic://track/1740526697",
+        "gb": "applemusic://track/1740526697",
+        "fr": "applemusic://track/1740526697",
+        "es": "applemusic://track/1740526697",
+        "nl": "applemusic://track/1740526697",
+        "it": "applemusic://track/1740526697"
+      }
     },
     {
       "year": 2002,
@@ -726,7 +936,17 @@
       "uri_tidal": "tidal://track/33713333",
       "uri_deezer": "deezer://track/15587466",
       "fun_fact_nl": "Avril Lavigne schreef dit nummer in slechts 15 minuten. In 2021 werd een verfilming aangekondigd om het volledige verhaal van de personages te vertellen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USAR10200229",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1739502950",
+        "de": "applemusic://track/555165330",
+        "gb": "applemusic://track/555165330",
+        "fr": "applemusic://track/555165330",
+        "es": "applemusic://track/555165330",
+        "nl": "applemusic://track/610157999",
+        "it": "applemusic://track/555165330"
+      }
     },
     {
       "year": 2005,
@@ -757,7 +977,17 @@
       "uri_tidal": "tidal://track/330924446",
       "uri_deezer": "deezer://track/1138247",
       "fun_fact_nl": "De cryptische, bijna onleesbare tekst van het nummer werd een meme. De titel komt van een verkeerd gehoorde tekst die de band besloot te bewaren.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USIR20500201",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1716124574",
+        "de": "applemusic://track/1716124574",
+        "gb": "applemusic://track/1716124574",
+        "fr": "applemusic://track/1716124574",
+        "es": "applemusic://track/1716124574",
+        "nl": "applemusic://track/1716124574",
+        "it": "applemusic://track/1716124574"
+      }
     },
     {
       "year": 1999,
@@ -787,7 +1017,17 @@
       "uri_tidal": "tidal://track/494588",
       "uri_deezer": "deezer://track/967040",
       "fun_fact_nl": "Geschreven in ongeveer 5 minuten en bijna van het album geknipt. Het nummer over dronken spijt werd Lit's kenmerkende hit en een karaoke nummer.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "TCAAX1195851",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/438572311",
+        "de": "applemusic://track/438572311",
+        "gb": "applemusic://track/438572311",
+        "fr": "applemusic://track/438572311",
+        "es": "applemusic://track/438572311",
+        "nl": "applemusic://track/438572311",
+        "it": "applemusic://track/438572311"
+      }
     },
     {
       "year": 2008,
@@ -817,7 +1057,17 @@
       "uri_tidal": "tidal://track/67367356",
       "uri_deezer": "deezer://track/137234202",
       "fun_fact_nl": "Een van The Offspring's meest succesvolle nummers van de jaren 2000, met hun kenmerkende mix van sarcastische teksten en stuwende punkenergie.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM10801605",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1852383211",
+        "de": "applemusic://track/1852383211",
+        "gb": "applemusic://track/1852383211",
+        "fr": "applemusic://track/1852383211",
+        "es": "applemusic://track/1852383211",
+        "nl": "applemusic://track/1852383211",
+        "it": "applemusic://track/1852383211"
+      }
     },
     {
       "year": 2006,
@@ -848,7 +1098,17 @@
       "uri_tidal": "tidal://track/353335",
       "uri_deezer": "deezer://track/676573",
       "fun_fact_nl": "Dit meesterwerk van de rockopera stond bovenaan de hitlijsten in het Verenigd Koninkrijk en werd het onofficiële volkslied van de emo-subcultuur. Het personage Patient stierf op deze datum.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USRE10602613",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/209388682",
+        "de": "applemusic://track/1499140470",
+        "gb": "applemusic://track/1499140470",
+        "fr": "applemusic://track/1499140470",
+        "es": "applemusic://track/1499140470",
+        "nl": "applemusic://track/1499140470",
+        "it": "applemusic://track/1499140470"
+      }
     },
     {
       "year": 1994,
@@ -878,7 +1138,17 @@
       "uri_tidal": "tidal://track/225479",
       "uri_deezer": "deezer://track/678053",
       "fun_fact_nl": "Van Dookie, waarvan meer dan 20 miljoen exemplaren werden verkocht en waarmee Green Day superster werd. De video is opgenomen in San Francisco.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USRE11600557",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1160082350",
+        "de": "applemusic://track/1160082350",
+        "gb": "applemusic://track/1160082350",
+        "fr": "applemusic://track/1160082350",
+        "es": "applemusic://track/1160082350",
+        "nl": "applemusic://track/1160082350",
+        "it": "applemusic://track/1160082350"
+      }
     },
     {
       "year": 2005,
@@ -908,7 +1178,17 @@
       "uri_tidal": "tidal://track/3684437",
       "uri_deezer": "deezer://track/1138246",
       "fun_fact_nl": "De videoclip recreëert een ongemakkelijk schoolbal met Fall Out Boy als de ingehuurde band. Regisseur Alan Ferguson ontmoette er zijn vrouw Solange.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USDJ20500174",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1779813306",
+        "de": "applemusic://track/1779813306",
+        "gb": "applemusic://track/1779813306",
+        "fr": "applemusic://track/1779813306",
+        "es": "applemusic://track/1779813306",
+        "nl": "applemusic://track/1779813306",
+        "it": "applemusic://track/1779813306"
+      }
     },
     {
       "year": 2005,
@@ -968,7 +1248,17 @@
       "uri_tidal": "tidal://track/67367329",
       "uri_deezer": "deezer://track/137234014",
       "fun_fact_nl": "Dit tongue-in-cheek nummer leent zijn melodie van The Beatles' 'Ob-La-Di, Ob-La-Da' en werd een UK #2 hit.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM19804369",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1692669045",
+        "de": "applemusic://track/1692669045",
+        "gb": "applemusic://track/1692669045",
+        "fr": "applemusic://track/1692669045",
+        "es": "applemusic://track/1692669045",
+        "nl": "applemusic://track/1692669045",
+        "it": "applemusic://track/1692669045"
+      }
     },
     {
       "year": 2004,
@@ -998,7 +1288,17 @@
       "uri_tidal": "tidal://track/293932",
       "uri_deezer": "deezer://track/785938",
       "fun_fact_nl": "Een eerbetoon aan Gerard en Mikey Way's oma Elena, die in 2003 overleed. De video met het thema begrafenis is zowel mooi als beklemmend.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USRE11600521",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1156311432",
+        "de": "applemusic://track/1156311432",
+        "gb": "applemusic://track/1156311432",
+        "fr": "applemusic://track/1156311432",
+        "es": "applemusic://track/1156311432",
+        "nl": "applemusic://track/1156311432",
+        "it": "applemusic://track/1156311432"
+      }
     },
     {
       "year": 2005,
@@ -1029,7 +1329,17 @@
       "uri_tidal": "tidal://track/307230",
       "uri_deezer": "deezer://track/5094040",
       "fun_fact_nl": "De video over de circusbruiloft werd in slechts één dag opgenomen. De zin 'closing the goddamn door' moest op de radio worden gecensureerd als 'closing a door'.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "US56V0507710",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1892287615",
+        "de": "applemusic://track/1892287615",
+        "gb": "applemusic://track/1892287615",
+        "fr": "applemusic://track/1892287615",
+        "es": "applemusic://track/1892287615",
+        "nl": "applemusic://track/1892287615",
+        "it": "applemusic://track/1892287615"
+      }
     },
     {
       "year": 2003,
@@ -1059,7 +1369,17 @@
       "uri_tidal": "tidal://track/130434",
       "uri_deezer": "deezer://track/3090887",
       "fun_fact_nl": "Supermodel Rachel Hunter speelde Stacy's moeder. Het liedje parodieert tienerverliefdheid en werd een onverwacht popcultuurfenomeen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USESC0300016",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1779813315",
+        "de": "applemusic://track/1779813315",
+        "gb": "applemusic://track/1779813315",
+        "fr": "applemusic://track/1779813315",
+        "es": "applemusic://track/1779813315",
+        "nl": "applemusic://track/1779813315",
+        "it": "applemusic://track/1779813315"
+      }
     },
     {
       "year": 2004,
@@ -1087,7 +1407,17 @@
       "uri_tidal": "tidal://track/487773215",
       "uri_deezer": "deezer://track/9036712",
       "fun_fact_nl": "Geschreven voor de film Eurotrip, waar Matt Damon het uitvoert in een cameo als punkrocker. Het werd de meest memorabele scène van de film.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USCGJ0612390",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/138625028",
+        "de": "applemusic://track/138625028",
+        "gb": "applemusic://track/138625028",
+        "fr": "applemusic://track/138625028",
+        "es": "applemusic://track/138625028",
+        "nl": "applemusic://track/138625028",
+        "it": "applemusic://track/138625028"
+      }
     },
     {
       "year": 2001,
@@ -1117,7 +1447,17 @@
       "uri_tidal": "tidal://track/35712430",
       "uri_deezer": "deezer://track/125173830",
       "fun_fact_nl": "Van het album Take Off Your Pants and Jacket - een grove woordspeling op zelfbevrediging. De video parodieert de typische angst voor een eerste afspraakje.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMC10110874",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1834485362",
+        "de": "applemusic://track/1834485362",
+        "gb": "applemusic://track/1834485362",
+        "fr": "applemusic://track/1834485362",
+        "es": "applemusic://track/1834485362",
+        "nl": "applemusic://track/1834485362",
+        "it": "applemusic://track/1834485362"
+      }
     },
     {
       "year": 2006,
@@ -1148,7 +1488,17 @@
       "uri_tidal": "tidal://track/353343",
       "uri_deezer": "deezer://track/676594",
       "fun_fact_nl": "De epische afsluiter van het album The Black Parade vertegenwoordigt de laatste momenten van The Patient. Het is een van MCR's meest emotioneel krachtige nummers.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USRE10602914",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1806268582",
+        "de": "applemusic://track/1680122292",
+        "gb": "applemusic://track/1806268582",
+        "fr": "applemusic://track/1806268582",
+        "es": "applemusic://track/1806268582",
+        "nl": "applemusic://track/1680122292",
+        "it": "applemusic://track/1806268582"
+      }
     },
     {
       "year": 2002,
@@ -1179,7 +1529,17 @@
       "uri_tidal": "tidal://track/2914800",
       "uri_deezer": "deezer://track/7675611",
       "fun_fact_nl": "Good Charlotte's doorbraakhit maakte van hen een vaste waarde op MTV en definieerde de esthetiek van de mall punk aan het begin van de jaren 2000. Het is een hymne voor buitenbeentjes overal.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM10209827",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1744619003",
+        "de": "applemusic://track/1744619003",
+        "gb": "applemusic://track/1744619003",
+        "fr": "applemusic://track/1744619003",
+        "es": "applemusic://track/1744619003",
+        "nl": "applemusic://track/1744619003",
+        "it": "applemusic://track/1744619003"
+      }
     },
     {
       "year": 1994,
@@ -1239,7 +1599,17 @@
       "uri_tidal": "tidal://track/155972375",
       "uri_deezer": "deezer://track/1085153582",
       "fun_fact_nl": "MGK's poppunktijdperk bracht het genre terug naar de mainstream hitlijsten. Deze collab met blackbear geeft de rommeligheid na de breuk perfect weer.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USUM72014730",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1705147677",
+        "de": "applemusic://track/1705147677",
+        "gb": "applemusic://track/1705147677",
+        "fr": "applemusic://track/1705147677",
+        "es": "applemusic://track/1705147677",
+        "nl": "applemusic://track/1705147677",
+        "it": "applemusic://track/1705147677"
+      }
     },
     {
       "year": 2003,
@@ -1269,7 +1639,17 @@
       "uri_tidal": "tidal://track/1371390",
       "uri_deezer": "deezer://track/3361193",
       "fun_fact_nl": "Geschreven over Ocean Avenue in Jacksonville, Florida waar zanger Ryan Key opgroeide. De vioolriff maakt het meteen herkenbaar.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USCA20300233",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1640586114",
+        "de": "applemusic://track/1640586114",
+        "gb": "applemusic://track/1640586114",
+        "fr": "applemusic://track/1640586114",
+        "es": "applemusic://track/1640586114",
+        "nl": "applemusic://track/1640586114",
+        "it": "applemusic://track/1640586114"
+      }
     },
     {
       "year": 2009,
@@ -1299,7 +1679,17 @@
       "uri_tidal": "tidal://track/3120356",
       "uri_deezer": "deezer://track/13547838",
       "fun_fact_nl": "Dit nummer werd uitgebracht nadat de Farro broers Paramore verlieten en richt zich direct tot het banddrama met rauwe, eerlijke teksten over verraad.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USAT21300099",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/604800415",
+        "de": "applemusic://track/604800415",
+        "gb": "applemusic://track/604800415",
+        "fr": "applemusic://track/604800415",
+        "es": "applemusic://track/604800415",
+        "nl": "applemusic://track/604800415",
+        "it": "applemusic://track/604800415"
+      }
     },
     {
       "year": 2014,
@@ -1330,7 +1720,17 @@
       "uri_tidal": "tidal://track/31592228",
       "uri_deezer": "deezer://track/80077244",
       "fun_fact_nl": "De debuutsingle van 5 Seconds of Summer haalde de Britse hitlijsten. De Australische band bracht in 2014 poppunk naar een nieuwe generatie fans.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBUM71400377",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1440817084",
+        "de": "applemusic://track/1442958747",
+        "gb": "applemusic://track/1442916959",
+        "fr": "applemusic://track/1442958747",
+        "es": "applemusic://track/1442958747",
+        "nl": "applemusic://track/1442958747",
+        "it": "applemusic://track/1442958747"
+      }
     },
     {
       "year": 1976,
@@ -1358,7 +1758,17 @@
       "uri_tidal": "tidal://track/68697205",
       "uri_deezer": "deezer://track/131744724",
       "fun_fact_nl": "Het 'Hey! Ho! Let's go!' is iconisch en wordt al tientallen jaren gebruikt bij sportevenementen over de hele wereld.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USRH11603648",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1127410268",
+        "de": "applemusic://track/1127410268",
+        "gb": "applemusic://track/1127410268",
+        "fr": "applemusic://track/1127410268",
+        "es": "applemusic://track/1127410268",
+        "nl": "applemusic://track/1127410268",
+        "it": "applemusic://track/1127410268"
+      }
     },
     {
       "year": 2019,
@@ -1388,7 +1798,17 @@
       "uri_tidal": "tidal://track/112488035",
       "uri_deezer": "deezer://track/705273532",
       "fun_fact_nl": "Deze samenwerking bracht MGK, YUNGBLUD en de legendarische drummer Travis Barker samen en luidde de pop punk revival van 2019 in.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USUM71909845",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1631412055",
+        "de": "applemusic://track/1631412055",
+        "gb": "applemusic://track/1631412055",
+        "fr": "applemusic://track/1631412055",
+        "es": "applemusic://track/1631412055",
+        "nl": "applemusic://track/1631412055",
+        "it": "applemusic://track/1631412055"
+      }
     },
     {
       "year": 2004,
@@ -1418,7 +1838,17 @@
       "uri_tidal": "tidal://track/696219",
       "uri_deezer": "deezer://track/3658126",
       "fun_fact_nl": "Simple Plan's emotionele ballade over onbegrepen voelen werd een anthem voor tieners wereldwijd en hun grootste internationale hit.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USAT20402001",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1806338094",
+        "de": "applemusic://track/1742113143",
+        "gb": "applemusic://track/1742113143",
+        "fr": "applemusic://track/1742113143",
+        "es": "applemusic://track/1742113143",
+        "nl": "applemusic://track/1742113143",
+        "it": "applemusic://track/1742113143"
+      }
     },
     {
       "year": 2007,
@@ -1448,7 +1878,17 @@
       "uri_tidal": "tidal://track/68611219",
       "uri_deezer": "deezer://track/3829138",
       "fun_fact_nl": "Hayley Williams schreef dit over haar eigen relatie-ervaringen. Het nummer laat Paramore's talent voor pakkende, toegankelijke poppunk horen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USAT21300087",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/607340402",
+        "de": "applemusic://track/607340402",
+        "gb": "applemusic://track/607340402",
+        "fr": "applemusic://track/607340402",
+        "es": "applemusic://track/607340402",
+        "nl": "applemusic://track/607340402",
+        "it": "applemusic://track/607340402"
+      }
     },
     {
       "year": 2004,
@@ -1478,7 +1918,17 @@
       "uri_tidal": "tidal://track/2993226",
       "uri_deezer": "deezer://track/600631",
       "fun_fact_nl": "Oorspronkelijk opgenomen door SR-71, werd de cover van Bowling For Soup veel populairder. Het nummer kijkt nostalgisch naar de popcultuur van de jaren 80.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USJI10400613",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1744640657",
+        "de": "applemusic://track/1744640657",
+        "gb": "applemusic://track/1443123335",
+        "fr": "applemusic://track/1744640657",
+        "es": "applemusic://track/1744640657",
+        "nl": "applemusic://track/1744640657",
+        "it": "applemusic://track/1744640657"
+      }
     },
     {
       "year": 2001,
@@ -1508,7 +1958,17 @@
       "uri_tidal": "tidal://track/35712433",
       "uri_deezer": "deezer://track/125173836",
       "fun_fact_nl": "Dit nummer geeft perfect de essentie van poppunk weer - zomer, concerten en jonge liefde. Het is een nostalgisch eerbetoon aan de live muziekervaring.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMC10110768",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1680986748",
+        "de": "applemusic://track/1680986748",
+        "gb": "applemusic://track/1680986748",
+        "fr": "applemusic://track/1680986748",
+        "es": "applemusic://track/1680986748",
+        "nl": "applemusic://track/1680986748",
+        "it": "applemusic://track/1680986748"
+      }
     },
     {
       "year": 2020,
@@ -1538,7 +1998,17 @@
       "uri_tidal": "tidal://track/86346708",
       "uri_deezer": "deezer://track/1094939582",
       "fun_fact_nl": "MGK en Halsey creëerden deze bittere breakup anthem. Het hielp MGK's succesvolle overgang van rap naar poppunk te bevestigen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USAT20200123",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1823318105",
+        "de": "applemusic://track/1823318105",
+        "gb": "applemusic://track/1823318105",
+        "fr": "applemusic://track/1823318105",
+        "es": "applemusic://track/1823318105",
+        "nl": "applemusic://track/1823318105",
+        "it": "applemusic://track/1823318105"
+      }
     },
     {
       "year": 2006,
@@ -1568,7 +2038,17 @@
       "uri_tidal": "tidal://track/1314458",
       "uri_deezer": "deezer://track/2253494",
       "fun_fact_nl": "Debuteerde op #1 in iTunes en hielp AFI de overstap te maken van hardcorepunk naar mainstream alternatieve rock. De titel is een woordspeling op 'Miss Murderer'.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM10214990",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1789000039",
+        "de": "applemusic://track/1799756320",
+        "gb": "applemusic://track/1799756320",
+        "fr": "applemusic://track/1799756320",
+        "es": "applemusic://track/1799756320",
+        "nl": "applemusic://track/1799756320",
+        "it": "applemusic://track/1799756320"
+      }
     },
     {
       "year": 2007,
@@ -1598,7 +2078,17 @@
       "uri_tidal": "tidal://track/2795988",
       "uri_deezer": "deezer://track/3829144",
       "fun_fact_nl": "De driedubbele 'crush' in de titel komt overeen met het thema van obsessieve aantrekkingskracht van het nummer. Een van Paramore's zwaarste nummers uit hun Riot! tijdperk.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USRE10900522",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1747073914",
+        "de": "applemusic://track/1799933850",
+        "gb": "applemusic://track/1747073914",
+        "fr": "applemusic://track/1747073914",
+        "es": "applemusic://track/1747073914",
+        "nl": "applemusic://track/1747073914",
+        "it": "applemusic://track/1747073914"
+      }
     },
     {
       "year": 2020,
@@ -1628,7 +2118,17 @@
       "uri_tidal": "tidal://track/75668766",
       "uri_deezer": "deezer://track/918205292",
       "fun_fact_nl": "All Time Low's samenwerking met blackbear werd hun hoogst genoteerde single ooit, wat bewijst dat de band 15 jaar na hun carrière nog steeds relevant is.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USVIC0422803",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1712807601",
+        "de": "applemusic://track/1712807601",
+        "gb": "applemusic://track/1712807601",
+        "fr": "applemusic://track/1712807601",
+        "es": "applemusic://track/1712807601",
+        "nl": "applemusic://track/1712807601",
+        "it": "applemusic://track/1712807601"
+      }
     },
     {
       "year": 2002,
@@ -1659,7 +2159,17 @@
       "uri_tidal": "tidal://track/571901",
       "uri_deezer": "deezer://track/7675610",
       "fun_fact_nl": "Good Charlotte's satirische kijk op de celebritycultuur werd hun commerciële doorbraak, dankzij de rotatie op MTV.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USIR20200791",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1752776092",
+        "de": "applemusic://track/1440788466",
+        "gb": "applemusic://track/1442380830",
+        "fr": "applemusic://track/1440788466",
+        "es": "applemusic://track/1440788466",
+        "nl": "applemusic://track/1440788466",
+        "it": "applemusic://track/1440788466"
+      }
     },
     {
       "year": 2020,
@@ -1689,7 +2199,17 @@
       "uri_tidal": "tidal://track/204310991",
       "uri_deezer": "deezer://track/1094939572",
       "fun_fact_nl": "MGK's eerste single van Tickets to My Downfall, volledig geproduceerd door Travis Barker. Het markeerde zijn officiële ommezwaai naar poppunk.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USAT22107181",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1617061227",
+        "de": "applemusic://track/1824255143",
+        "gb": "applemusic://track/1824255143",
+        "fr": "applemusic://track/1824255143",
+        "es": "applemusic://track/1824255143",
+        "nl": "applemusic://track/1617061227",
+        "it": "applemusic://track/1824255143"
+      }
     },
     {
       "year": 2011,
@@ -1719,7 +2239,17 @@
       "uri_tidal": "tidal://track/1867131",
       "uri_deezer": "deezer://track/10161535",
       "fun_fact_nl": "Panic!'s terugkeer na het vertrek van Ryan Ross en Jon Walker. Het moordmysterie-thema van de video zet Brendon Urie's liefde voor theatrale concepten voort.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USAT20802934",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1536416711",
+        "de": "applemusic://track/1536416711",
+        "gb": "applemusic://track/1536416711",
+        "fr": "applemusic://track/1536416711",
+        "es": "applemusic://track/1536416711",
+        "nl": "applemusic://track/1536416711",
+        "it": "applemusic://track/1536416711"
+      }
     },
     {
       "year": 2001,
@@ -1749,7 +2279,17 @@
       "uri_tidal": "tidal://track/2914804",
       "uri_deezer": "deezer://track/125173826",
       "fun_fact_nl": "Een vervolg op blink-182's eerdere nummer 'Anthem'. Het werd een fanfavoriet vanwege de cathartische energie en rebelse boodschap.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM10209831",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1789000707",
+        "de": "applemusic://track/1789000707",
+        "gb": "applemusic://track/1789000707",
+        "fr": "applemusic://track/1789000707",
+        "es": "applemusic://track/1789000707",
+        "nl": "applemusic://track/1789000707",
+        "it": "applemusic://track/1789000707"
+      }
     },
     {
       "year": 1978,
@@ -1807,7 +2347,17 @@
       "uri_tidal": "tidal://track/570260",
       "uri_deezer": "deezer://track/3361196",
       "fun_fact_nl": "De emotionele power ballad van Yellowcard laat de vioolkunsten van Sean Mackin horen en werd een vaste waarde op de alternatieve radio in het midden van de jaren 2000.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USIR20110114",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1704208610",
+        "de": "applemusic://track/1704208610",
+        "gb": "applemusic://track/1704208610",
+        "fr": "applemusic://track/1704208610",
+        "es": "applemusic://track/1704208610",
+        "nl": "applemusic://track/1704208610",
+        "it": "applemusic://track/1704208610"
+      }
     },
     {
       "year": 2011,
@@ -1837,7 +2387,17 @@
       "uri_tidal": "tidal://track/1402273",
       "uri_deezer": "deezer://track/13547559",
       "fun_fact_nl": "Simple Plan's duet met Natasha Bedingfield over langeafstandsrelaties vond weerklank bij fans over de hele wereld die met dezelfde problemen te maken hebben.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USCA29800348",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1825215870",
+        "de": "applemusic://track/1825215870",
+        "gb": "applemusic://track/1825215870",
+        "fr": "applemusic://track/1825215870",
+        "es": "applemusic://track/1825215870",
+        "nl": "applemusic://track/1825215870",
+        "it": "applemusic://track/1825215870"
+      }
     },
     {
       "year": 2003,
@@ -1867,7 +2427,17 @@
       "uri_tidal": "tidal://track/230795",
       "uri_deezer": "deezer://track/930185",
       "fun_fact_nl": "De eerste single van Fall Out Boy die in de hitlijsten stond, maar het populairst werd na hun latere succes. De 'Grand Theft Auto' woordspeling in de titel was opzettelijk.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USRE11700472",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1295797514",
+        "de": "applemusic://track/1295797514",
+        "gb": "applemusic://track/1295797514",
+        "fr": "applemusic://track/1295797514",
+        "es": "applemusic://track/1295797514",
+        "nl": "applemusic://track/1295797514",
+        "it": "applemusic://track/1295797514"
+      }
     },
     {
       "year": 2002,
@@ -1897,7 +2467,17 @@
       "uri_tidal": "tidal://track/2134635",
       "uri_deezer": "deezer://track/1104653",
       "fun_fact_nl": "Sum 41's agressieve nummer over worstelen met innerlijke demonen. Deryck Whibley vertelde later over gevechten met alcoholisme waar het nummer op zinspeelde.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USUM70835313",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1440772331",
+        "de": "applemusic://track/1440728966",
+        "gb": "applemusic://track/1440728966",
+        "fr": "applemusic://track/1440728966",
+        "es": "applemusic://track/1440728966",
+        "nl": "applemusic://track/1440728966",
+        "it": "applemusic://track/1440728966"
+      }
     },
     {
       "year": 2005,
@@ -1927,7 +2507,17 @@
       "uri_tidal": "tidal://track/22637489",
       "uri_deezer": "deezer://track/785398",
       "fun_fact_nl": "De grootste hit van Story of the Year mengde post-hardcore intensiteit met toegankelijkheid voor poppunk. Uitgelicht in talloze tv-shows en videogames.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USAT21302389",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/684954529",
+        "de": "applemusic://track/684954529",
+        "gb": "applemusic://track/683494791",
+        "fr": "applemusic://track/684954529",
+        "es": "applemusic://track/684954529",
+        "nl": "applemusic://track/684954529",
+        "it": "applemusic://track/684954529"
+      }
     },
     {
       "year": 2009,
@@ -1957,7 +2547,17 @@
       "uri_tidal": "tidal://track/151133060",
       "uri_deezer": "deezer://track/3087228",
       "fun_fact_nl": "Green Day's eerste single van 21st Century Breakdown zet hun traditie van politiek commentaar voort. Het publiek doet live mee.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USHR21166002",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1847999746",
+        "de": "applemusic://track/1847999746",
+        "gb": "applemusic://track/1847999746",
+        "fr": "applemusic://track/1847999746",
+        "es": "applemusic://track/1847999746",
+        "nl": "applemusic://track/1847999746",
+        "it": "applemusic://track/1847999746"
+      }
     },
     {
       "year": 2002,
@@ -1987,7 +2587,17 @@
       "uri_tidal": "tidal://track/37035872",
       "uri_deezer": "deezer://track/477008462",
       "fun_fact_nl": "Met Mark Hoppus van Blink-182 in een onverwachte cameo. Het nummer over onbeantwoorde liefde werd een hoofdbestanddeel van de poppunk aan het begin van de jaren 2000.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USDW10300037",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1704209432",
+        "de": "applemusic://track/1704209432",
+        "gb": "applemusic://track/1704209432",
+        "fr": "applemusic://track/1704209432",
+        "es": "applemusic://track/1704209432",
+        "nl": "applemusic://track/1704209432",
+        "it": "applemusic://track/1704209432"
+      }
     },
     {
       "year": 2009,
@@ -2017,7 +2627,17 @@
       "uri_tidal": "tidal://track/578717",
       "uri_deezer": "deezer://track/2676942",
       "fun_fact_nl": "Fall Out Boy's uitdagende hymne uit Folie à Deux. Het repetitieve refrein is opzettelijk irritant als commentaar op popmuziekformules.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMC10200464",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1471580726",
+        "de": "applemusic://track/1704208814",
+        "gb": "applemusic://track/1704208814",
+        "fr": "applemusic://track/1704208814",
+        "es": "applemusic://track/1704208814",
+        "nl": "applemusic://track/1704208814",
+        "it": "applemusic://track/1704208814"
+      }
     },
     {
       "year": 2005,
@@ -2045,7 +2665,17 @@
       "uri_tidal": "tidal://track/10906353",
       "uri_deezer": "deezer://track/5094039",
       "fun_fact_nl": "Een fanfavoriet van A Fever You Can't Sweat Out. Het theatrale, door vaudeville beïnvloede nummer laat de unieke stijl van Panic! zien.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USAT21300093",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/607340439",
+        "de": "applemusic://track/607340439",
+        "gb": "applemusic://track/607340439",
+        "fr": "applemusic://track/607340439",
+        "es": "applemusic://track/607340439",
+        "nl": "applemusic://track/607340439",
+        "it": "applemusic://track/607340439"
+      }
     },
     {
       "year": 2003,
@@ -2073,7 +2703,17 @@
       "uri_tidal": "tidal://track/134628513",
       "uri_deezer": "deezer://track/69830356",
       "fun_fact_nl": "Het nostalgische nummer van Sugarcult werd een verborgen juweeltje van de poppunkscene van de jaren 2000, geliefd om zijn eerlijke teksten over opgroeien.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USAT22007691",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1848066895",
+        "de": "applemusic://track/1848066895",
+        "gb": "applemusic://track/1848066895",
+        "fr": "applemusic://track/1848066895",
+        "es": "applemusic://track/1848066895",
+        "nl": "applemusic://track/1848066895",
+        "it": "applemusic://track/1848066895"
+      }
     },
     {
       "year": 2003,
@@ -2099,7 +2739,17 @@
       "uri_tidal": "tidal://track/21886283",
       "uri_deezer": "deezer://track/851001",
       "fun_fact_nl": "De Ataris-cover van Don Henley's klassieker bracht een nummer uit de jaren 80 naar een nieuwe generatie. De tekst werd bijgewerkt met een verwijzing naar 'Black Flag-sticker' in plaats van 'Deadhead-sticker'.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USAR50412571",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/5548609",
+        "de": "applemusic://track/5548609",
+        "gb": "applemusic://track/5548609",
+        "fr": "applemusic://track/5548609",
+        "es": "applemusic://track/5548609",
+        "nl": "applemusic://track/5548609",
+        "it": "applemusic://track/5548609"
+      }
     },
     {
       "year": 2002,
@@ -2129,7 +2779,17 @@
       "uri_tidal": "tidal://track/1371393",
       "uri_deezer": "deezer://track/63334975",
       "fun_fact_nl": "Bowling For Soup's Grammy-genomineerde hit over verliefd worden op een alternatief meisje. In de videoclip worden MTV-datingprogramma's liefdevol geparodieerd.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USCA20300236",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1444379324",
+        "de": "applemusic://track/1444379324",
+        "gb": "applemusic://track/1444379324",
+        "fr": "applemusic://track/1444379324",
+        "es": "applemusic://track/1444379324",
+        "nl": "applemusic://track/1444379324",
+        "it": "applemusic://track/1444379324"
+      }
     },
     {
       "year": 2021,
@@ -2157,7 +2817,17 @@
       "uri_tidal": "tidal://track/4918655",
       "uri_deezer": "deezer://track/1546389142",
       "fun_fact_nl": "Avril Lavigne's terugkeer naar de poppunk, geproduceerd door Travis Barker en met haar kenmerkende houding waarmee ze 20 jaar eerder haar carrière lanceerde.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM10412717",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/214701878",
+        "de": "applemusic://track/323078364",
+        "gb": "applemusic://track/214701878",
+        "fr": "applemusic://track/323078364",
+        "es": "applemusic://track/214701878",
+        "nl": "applemusic://track/323078364",
+        "it": "applemusic://track/323078364"
+      }
     },
     {
       "year": 2013,
@@ -2187,7 +2857,17 @@
       "uri_tidal": "tidal://track/35354658",
       "uri_deezer": "deezer://track/71039597",
       "fun_fact_nl": "Geschreven over het gevecht van Spencer Smith met verslaving. De pianoversie is net zo krachtig en laat het stembereik van Brendon Urie horen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USUM70832584",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1840454073",
+        "de": "applemusic://track/1840454073",
+        "gb": "applemusic://track/1840454073",
+        "fr": "applemusic://track/1840454073",
+        "es": "applemusic://track/1840454073",
+        "nl": "applemusic://track/1840454073",
+        "it": "applemusic://track/1840454073"
+      }
     },
     {
       "year": 2016,
@@ -2217,7 +2897,17 @@
       "uri_tidal": "tidal://track/4930592",
       "uri_deezer": "deezer://track/132807420",
       "fun_fact_nl": "Het reflectieve nummer van Green Day over het overleven van moeilijke tijden. Het markeerde een volwassener geluid van de band na 30 jaar samenzijn.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMJ19700131",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/254825686",
+        "de": "applemusic://track/254825686",
+        "gb": "applemusic://track/254825686",
+        "fr": "applemusic://track/254825686",
+        "es": "applemusic://track/254825686",
+        "nl": "applemusic://track/254825686",
+        "it": "applemusic://track/254825686"
+      }
     },
     {
       "year": 2020,
@@ -2247,7 +2937,17 @@
       "uri_tidal": "tidal://track/65019582",
       "uri_deezer": "deezer://track/1153713802",
       "fun_fact_nl": "De samenwerking tussen YUNGBLUD en MGK laat de moderne pop punk revival zien. Beide artiesten noemen Blink-182 als belangrijke invloeden.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USRE11600444",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1140560589",
+        "de": "applemusic://track/1140560589",
+        "gb": "applemusic://track/1140560589",
+        "fr": "applemusic://track/1140560589",
+        "es": "applemusic://track/1140560589",
+        "nl": "applemusic://track/1140560589",
+        "it": "applemusic://track/1140560589"
+      }
     },
     {
       "year": 2008,
@@ -2277,7 +2977,17 @@
       "uri_tidal": "tidal://track/197208034",
       "uri_deezer": "deezer://track/7419123",
       "fun_fact_nl": "De grootste mainstream hit van Rise Against. De politiek geladen band gebruikte dit succes om hun boodschap naar een breder publiek te verspreiden.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USDW10400944",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1703143360",
+        "de": "applemusic://track/1703143360",
+        "gb": "applemusic://track/1703143360",
+        "fr": "applemusic://track/1703143360",
+        "es": "applemusic://track/1703143360",
+        "nl": "applemusic://track/1703143360",
+        "it": "applemusic://track/1703143360"
+      }
     },
     {
       "year": 2002,
@@ -2305,7 +3015,17 @@
       "uri_tidal": "tidal://track/2914801",
       "uri_deezer": "deezer://track/7675612",
       "fun_fact_nl": "De doorbraak van Good Charlotte in het Verenigd Koninkrijk was groter dan hun succes in de Verenigde Staten. Het sociale commentaar van het nummer vond weerklank bij het Britse publiek.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM10210275",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1789000043",
+        "de": "applemusic://track/1789000043",
+        "gb": "applemusic://track/1443123515",
+        "fr": "applemusic://track/1789000043",
+        "es": "applemusic://track/1789000043",
+        "nl": "applemusic://track/1789000043",
+        "it": "applemusic://track/1789000043"
+      }
     },
     {
       "year": 2004,
@@ -2333,7 +3053,17 @@
       "uri_tidal": "tidal://track/14903970",
       "uri_deezer": "deezer://track/642679242",
       "fun_fact_nl": "Jimmy Eat World's opvolger van 'The Middle' van hetzelfde album. Het nummer gaat over liefdesverdriet in hun kenmerkende anthemische stijl.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USAT21100854",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/438829874",
+        "de": "applemusic://track/438829874",
+        "gb": "applemusic://track/1829453491",
+        "fr": "applemusic://track/438829874",
+        "es": "applemusic://track/438829874",
+        "nl": "applemusic://track/438829874",
+        "it": "applemusic://track/438829874"
+      }
     },
     {
       "year": 2000,
@@ -2363,7 +3093,17 @@
       "uri_tidal": "tidal://track/155972369",
       "uri_deezer": "deezer://track/2657779",
       "fun_fact_nl": "De eerste single van Warning, het experimentele album van Green Day dat fans verdeelde maar de artistieke groei van de band liet zien.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USUM72014954",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1526411792",
+        "de": "applemusic://track/1526411792",
+        "gb": "applemusic://track/1526411792",
+        "fr": "applemusic://track/1526411792",
+        "es": "applemusic://track/1526411792",
+        "nl": "applemusic://track/1526411792",
+        "it": "applemusic://track/1526411792"
+      }
     },
     {
       "year": 1997,
@@ -2391,7 +3131,17 @@
       "uri_tidal": "tidal://track/94763289",
       "uri_deezer": "deezer://track/7978573",
       "fun_fact_nl": "Goldfinger's ska-punk anthem werd iconisch door zijn verschijning in Tony Hawk's Pro Skater. De game liet miljoenen mensen kennismaken met het genre.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USWB10201817",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1804583192",
+        "de": "applemusic://track/1804583192",
+        "gb": "applemusic://track/1804583192",
+        "fr": "applemusic://track/1804583192",
+        "es": "applemusic://track/1804583192",
+        "nl": "applemusic://track/1804583192",
+        "it": "applemusic://track/1804583192"
+      }
     },
     {
       "year": 2005,
@@ -2451,7 +3201,17 @@
       "uri_tidal": "tidal://track/121118038",
       "uri_deezer": "deezer://track/604954",
       "fun_fact_nl": "Good Charlotte's meer elektronisch beïnvloede nummer toonde hun bereidheid om te experimenteren terwijl ze hun poppunk kern behielden.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USEP40310201",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1485034321",
+        "de": "applemusic://track/1485034321",
+        "gb": "applemusic://track/1485034321",
+        "fr": "applemusic://track/1485034321",
+        "es": "applemusic://track/1485034321",
+        "nl": "applemusic://track/1485034321",
+        "it": "applemusic://track/1485034321"
+      }
     },
     {
       "year": 2003,
@@ -2479,7 +3239,17 @@
       "uri_tidal": "tidal://track/307229",
       "uri_deezer": "deezer://track/3361192",
       "fun_fact_nl": "Het krachtige nummer van Yellowcard laat de emotionele diepte zien waarmee ze zich onderscheidden van de typische poppunkbands uit die tijd.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USAT22506013",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1846923414",
+        "de": "applemusic://track/1846923414",
+        "gb": "applemusic://track/1846923414",
+        "fr": "applemusic://track/1846923414",
+        "es": "applemusic://track/1846923414",
+        "nl": "applemusic://track/1846923414",
+        "it": "applemusic://track/1846923414"
+      }
     },
     {
       "year": 2003,
@@ -2535,7 +3305,17 @@
       "uri_tidal": "tidal://track/2993795",
       "uri_deezer": "deezer://track/376015631",
       "fun_fact_nl": "Dit nummer, geschreven door Pete Shelley in 1978, werd een punkklassieker en bereikte de 12de plaats in de UK Singles Chart. Het werd later gecoverd door de Fine Young Cannibals voor de 'Something Wild' soundtrack in 1986.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USJI10600507",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1789000528",
+        "de": "applemusic://track/1789000528",
+        "gb": "applemusic://track/1789000528",
+        "fr": "applemusic://track/1789000528",
+        "es": "applemusic://track/1789000528",
+        "nl": "applemusic://track/1789000528",
+        "it": "applemusic://track/1789000528"
+      }
     },
     {
       "year": 2004,
@@ -2563,7 +3343,17 @@
       "uri_tidal": "tidal://track/1371389",
       "uri_deezer": "deezer://track/388976681",
       "fun_fact_nl": "Het kenmerkende nummer van Taking Back Sunday geeft perfect de emotionele intensiteit en dramatische teksten van het emo-tijdperk weer.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USCA20300232",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1834485697",
+        "de": "applemusic://track/1834485697",
+        "gb": "applemusic://track/1834485697",
+        "fr": "applemusic://track/1834485697",
+        "es": "applemusic://track/1834485697",
+        "nl": "applemusic://track/1834485697",
+        "it": "applemusic://track/1834485697"
+      }
     },
     {
       "year": 2006,
@@ -2593,7 +3383,17 @@
       "uri_tidal": "tidal://track/350723",
       "uri_deezer": "deezer://track/2325001",
       "fun_fact_nl": "Het satirische commentaar van Bowling For Soup op de celebritycultuur en hoe volwassenen zich nog steeds gedragen als tieners. Met grappen over beroemde mensen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMV20300129",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1614415982",
+        "de": "applemusic://track/1614415982",
+        "gb": "applemusic://track/1614415982",
+        "fr": "applemusic://track/1614415982",
+        "es": "applemusic://track/1614415982",
+        "nl": "applemusic://track/1614415982",
+        "it": "applemusic://track/1614415982"
+      }
     },
     {
       "year": 2000,
@@ -2621,7 +3421,17 @@
       "uri_tidal": "tidal://track/3979952",
       "uri_deezer": "deezer://track/378254041",
       "fun_fact_nl": "Het Zweedse skatepunklied van Millencolin was te horen in Tony Hawk's Pro Skater 2, waarmee ze werden geïntroduceerd bij het Amerikaanse publiek.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USUM70602578",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1593256834",
+        "de": "applemusic://track/1593256834",
+        "gb": "applemusic://track/1593256834",
+        "fr": "applemusic://track/1593256834",
+        "es": "applemusic://track/1593256834",
+        "nl": "applemusic://track/1593256834",
+        "it": "applemusic://track/1593256834"
+      }
     },
     {
       "year": 2004,
@@ -2649,7 +3459,17 @@
       "uri_tidal": "tidal://track/10925361",
       "uri_deezer": "deezer://track/3658125",
       "fun_fact_nl": "De rebelse hymne van Simple Plan ving de frustratie van tieners over autoritaire figuren op en werd een vaste waarde in de gang van de middelbare school.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "US56V0506103",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1830226049",
+        "de": "applemusic://track/1830226049",
+        "gb": "applemusic://track/1830226049",
+        "fr": "applemusic://track/1830226049",
+        "es": "applemusic://track/1830226049",
+        "nl": "applemusic://track/1830226049",
+        "it": "applemusic://track/1830226049"
+      }
     },
     {
       "year": 2002,
@@ -2677,7 +3497,17 @@
       "uri_tidal": "tidal://track/33208787",
       "uri_deezer": "deezer://track/4709605",
       "fun_fact_nl": "Het meest geliefde nummer van The Starting Line laat de typische 2000s poppunk sound horen met oprechte teksten.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USJI10200080",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1308768606",
+        "de": "applemusic://track/908949291",
+        "gb": "applemusic://track/908949291",
+        "fr": "applemusic://track/908949291",
+        "es": "applemusic://track/908949291",
+        "nl": "applemusic://track/908949291",
+        "it": "applemusic://track/908949291"
+      }
     },
     {
       "year": 2016,
@@ -2705,7 +3535,17 @@
       "uri_tidal": "tidal://track/5935719",
       "uri_deezer": "deezer://track/128770463",
       "fun_fact_nl": "De samenwerking van Neck Deep met Mark Hoppus van Blink-182 was een droom die uitkwam voor de jongere band die opgroeide met Blink.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USAT21002551",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1764037543",
+        "de": "applemusic://track/1835077739",
+        "gb": "applemusic://track/1764037543",
+        "fr": "applemusic://track/1764037543",
+        "es": "applemusic://track/1764037543",
+        "nl": "applemusic://track/1764037543",
+        "it": "applemusic://track/1764037543"
+      }
     },
     {
       "year": 2002,
@@ -2733,7 +3573,17 @@
       "uri_tidal": "tidal://track/141971171",
       "uri_deezer": "deezer://track/2191394",
       "fun_fact_nl": "Box Car Racer was het zijproject van Tom DeLonge en Travis Barker tijdens blink-182, met een donkerder, experimenteler geluid.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAYE9600428",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1282094705",
+        "de": "applemusic://track/1282094705",
+        "gb": "applemusic://track/1282094705",
+        "fr": "applemusic://track/1282094705",
+        "es": "applemusic://track/1282094705",
+        "nl": "applemusic://track/1282094705",
+        "it": "applemusic://track/1282094705"
+      }
     },
     {
       "year": 2006,
@@ -2761,7 +3611,17 @@
       "uri_tidal": "tidal://track/121120957",
       "uri_deezer": "deezer://track/742457",
       "fun_fact_nl": "Cute Is What We Aim For vertegenwoordigde de poppier kant van de emo scene uit de jaren 2000, met gepolijste productie en pakkende hooks.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "SEVHC0001010",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1485032585",
+        "de": "applemusic://track/1485032585",
+        "gb": "applemusic://track/1485032585",
+        "fr": "applemusic://track/1485032585",
+        "es": "applemusic://track/1485032585",
+        "nl": "applemusic://track/1485032585",
+        "it": "applemusic://track/1485032585"
+      }
     },
     {
       "year": 1998,
@@ -2789,7 +3649,17 @@
       "uri_tidal": "tidal://track/163555670",
       "uri_deezer": "deezer://track/3136977",
       "fun_fact_nl": "Less Than Jake's ska-punk anthem viert metalfans en de genre-overschrijdende vriendschappen die gebruikelijk zijn in alternatieve muziekscènes.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USUG12004381",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1577242129",
+        "de": "applemusic://track/1577242129",
+        "gb": "applemusic://track/1577242129",
+        "fr": "applemusic://track/1577242129",
+        "es": "applemusic://track/1577242129",
+        "nl": "applemusic://track/1577242129",
+        "it": "applemusic://track/1577242129"
+      }
     },
     {
       "year": 1994,
@@ -2817,7 +3687,17 @@
       "uri_tidal": "tidal://track/155972368",
       "uri_deezer": "deezer://track/378243751",
       "fun_fact_nl": "Het meest gecoverde nummer van NOFX, een anticonsumptielied. De band heeft de reputatie nooit op tv of in de reguliere media te verschijnen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USUM72005714",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1526411785",
+        "de": "applemusic://track/1526411785",
+        "gb": "applemusic://track/1526411785",
+        "fr": "applemusic://track/1526411785",
+        "es": "applemusic://track/1526411785",
+        "nl": "applemusic://track/1526411785",
+        "it": "applemusic://track/1526411785"
+      }
     },
     {
       "year": 2001,
@@ -2847,7 +3727,17 @@
       "uri_tidal": "tidal://track/174587142",
       "uri_deezer": "deezer://track/1125083",
       "fun_fact_nl": "De grootste commerciële hit van Sum 41, die in de jaren 2000 in veel films en tv-shows te zien was en een favoriet werd voor karaoke.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USAT22100747",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1746676670",
+        "de": "applemusic://track/1746676670",
+        "gb": "applemusic://track/1746676670",
+        "fr": "applemusic://track/1746676670",
+        "es": "applemusic://track/1746676670",
+        "nl": "applemusic://track/1746676670",
+        "it": "applemusic://track/1746676670"
+      }
     },
     {
       "year": 2009,
@@ -2875,7 +3765,17 @@
       "uri_tidal": "tidal://track/301280",
       "uri_deezer": "deezer://track/4289739",
       "fun_fact_nl": "De kenmerkende ballad van A Rocket To The Moon vertegenwoordigt de meer melodieuze, romantische kant van de poppunkscene van eind jaren 2000.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USAT20402497",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/27295869",
+        "de": "applemusic://track/1775799750",
+        "gb": "applemusic://track/1775799750",
+        "fr": "applemusic://track/1775799750",
+        "es": "applemusic://track/1775799750",
+        "nl": "applemusic://track/1775799750",
+        "it": "applemusic://track/1775799750"
+      }
     },
     {
       "year": 2013,
@@ -2903,7 +3803,17 @@
       "uri_tidal": "tidal://track/35712428",
       "uri_deezer": "deezer://track/90362227",
       "fun_fact_nl": "Het volkslied van The Wonder Years vertegenwoordigt de pop punk revival van 2010 met meer volwassen, introspectieve teksten dan vroeger in het genre.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMC10110872",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1752776557",
+        "de": "applemusic://track/1752776557",
+        "gb": "applemusic://track/1752776557",
+        "fr": "applemusic://track/1752776557",
+        "es": "applemusic://track/1752776557",
+        "nl": "applemusic://track/1752776557",
+        "it": "applemusic://track/1752776557"
+      }
     },
     {
       "year": 2021,
@@ -2931,7 +3841,17 @@
       "uri_tidal": "tidal://track/3121091",
       "uri_deezer": "deezer://track/1252913662",
       "fun_fact_nl": "Against The Current houdt poppunk levend voor Gen Z met moderne producties terwijl de wortels van het genre in ere worden gehouden.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USAT20902945",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1792812957",
+        "de": "applemusic://track/1792812957",
+        "gb": "applemusic://track/1792812957",
+        "fr": "applemusic://track/1792812957",
+        "es": "applemusic://track/1792812957",
+        "nl": "applemusic://track/1792812957",
+        "it": "applemusic://track/1792812957"
+      }
     },
     {
       "year": 2007,
@@ -2961,7 +3881,17 @@
       "uri_tidal": "tidal://track/1867131",
       "uri_deezer": "deezer://track/1190659",
       "fun_fact_nl": "De doorbraakhit van The Academy Is..., niet te verwarren met het gelijknamige nummer van Nirvana. Het was een hoofdbestanddeel van MTV's TRL.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USAT20802934",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1536416711",
+        "de": "applemusic://track/1536416711",
+        "gb": "applemusic://track/1536416711",
+        "fr": "applemusic://track/1536416711",
+        "es": "applemusic://track/1536416711",
+        "nl": "applemusic://track/1536416711",
+        "it": "applemusic://track/1536416711"
+      }
     }
   ]
 }

--- a/custom_components/beatify/playlists/community/schlager-klassiker.json
+++ b/custom_components/beatify/playlists/community/schlager-klassiker.json
@@ -37,7 +37,17 @@
       "uri_tidal": "tidal://track/1880055",
       "uri_deezer": "deezer://track/630374",
       "fun_fact_nl": "Ohne Dich (schlaf' ich heut Nacht nicht ein) was een van de grootste hits van Münchener Freiheit en werd een klassieker van de Neue Deutsche Welle. Deze emotionele ballade bereikte topposities in de Duitse hitlijsten.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEE868500072",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1626938163",
+        "de": "applemusic://track/1620406618",
+        "gb": "applemusic://track/854508977",
+        "fr": "applemusic://track/854508977",
+        "es": "applemusic://track/854508977",
+        "nl": "applemusic://track/1790923442",
+        "it": "applemusic://track/854508977"
+      }
     },
     {
       "year": 1975,
@@ -105,7 +115,17 @@
       "uri_tidal": "tidal://track/12578308",
       "uri_deezer": "deezer://track/557211",
       "fun_fact_nl": "Silbermond und Sternenfeuer was Michelles doorbraakhit en maakte haar tot een van de meest succesvolle Duitse schlagerzangeressen. Dit romantische nummer werd een vaste favoriet op feestjes.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEE869500119",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1445880546",
+        "de": "applemusic://track/309769473",
+        "gb": "applemusic://track/309769473",
+        "fr": "applemusic://track/309769473",
+        "es": "applemusic://track/309769473",
+        "nl": "applemusic://track/309769473",
+        "it": "applemusic://track/309769473"
+      }
     },
     {
       "year": 1974,
@@ -148,7 +168,17 @@
       "fun_fact_nl": "Griechischer Wein is Udo Jürgens' eerbetoon aan Griekse gastarbeiders in Duitsland. Het lied werd een onofficiële hymne van de integratie en wordt tot op de dag van vandaag op elk feest meegezongen.",
       "awards_nl": [
         "Gouden Plaat (1974)"
-      ]
+      ],
+      "isrc": "DEA817400019",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1658115617",
+        "de": "applemusic://track/1669322535",
+        "gb": "applemusic://track/1658115617",
+        "fr": "applemusic://track/1658115617",
+        "es": "applemusic://track/1658115617",
+        "nl": "applemusic://track/1658115617",
+        "it": "applemusic://track/1658115617"
+      }
     },
     {
       "year": 1984,
@@ -176,7 +206,17 @@
       "uri_tidal": "tidal://track/37258467",
       "uri_deezer": "deezer://track/2572286372",
       "fun_fact_nl": "1000 und 1 Nacht (Zoom!) van Klaus Lage werd de soundtrack van een hele generatie. Het aanstekelijke refrein 'Tausendundeine Nacht' is een van de meest herkenbare uit de Duitse muziekgeschiedenis.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEA341100553",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1838527134",
+        "de": "applemusic://track/1838527134",
+        "gb": "applemusic://track/1838527134",
+        "fr": "applemusic://track/1838527134",
+        "es": "applemusic://track/1838527134",
+        "nl": "applemusic://track/1838527134",
+        "it": "applemusic://track/1838527134"
+      }
     },
     {
       "year": 1990,
@@ -226,7 +266,17 @@
       "awards_nl": [
         "Echo (1991)",
         "Goldene Stimmgabel (1991)"
-      ]
+      ],
+      "isrc": "DEA651000005",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1611040987",
+        "de": "applemusic://track/1509708299",
+        "gb": "applemusic://track/1509708299",
+        "fr": "applemusic://track/1509708299",
+        "es": "applemusic://track/1509708299",
+        "nl": "applemusic://track/1509708299",
+        "it": "applemusic://track/1509708299"
+      }
     },
     {
       "year": 1995,
@@ -267,7 +317,17 @@
       "fun_fact_nl": "Abenteuerland was PUR's grootste hit en werd een hymne voor dromers en avonturiers. De band uit Bietigheim-Bissingen is een van de succesvolste Duitse rockbands aller tijden.",
       "awards_nl": [
         "Echo (1996)"
-      ]
+      ],
+      "isrc": "DEA349503010",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1890587479",
+        "de": "applemusic://track/1890587479",
+        "gb": "applemusic://track/1890587479",
+        "fr": "applemusic://track/1890587479",
+        "es": "applemusic://track/1890587479",
+        "nl": "applemusic://track/1890587479",
+        "it": "applemusic://track/1890587479"
+      }
     },
     {
       "year": 2013,
@@ -327,7 +387,17 @@
         "Goldene Henne (2014)",
         "Bambi (2014)",
         "Goldene Kamera (2014)"
-      ]
+      ],
+      "isrc": "DEUM71303188",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1709414078",
+        "de": "applemusic://track/1709414078",
+        "gb": "applemusic://track/1709414078",
+        "fr": "applemusic://track/1709414078",
+        "es": "applemusic://track/1709414078",
+        "nl": "applemusic://track/1709414078",
+        "it": "applemusic://track/1709414078"
+      }
     },
     {
       "year": 1982,
@@ -370,7 +440,17 @@
       "fun_fact_nl": "Ich war noch niemals in New York is Udo Jürgens' ode aan onvervulde dromen. Het lied werd later bewerkt tot een succesvolle musical die wereldwijd wordt opgevoerd.",
       "awards_nl": [
         "Gouden Plaat (1982)"
-      ]
+      ],
+      "isrc": "DEA818200038",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1764919615",
+        "de": "applemusic://track/331872876",
+        "gb": "applemusic://track/1764919615",
+        "fr": "applemusic://track/1764919615",
+        "es": "applemusic://track/1764919615",
+        "nl": "applemusic://track/331872876",
+        "it": "applemusic://track/1764919615"
+      }
     },
     {
       "year": 1972,
@@ -439,7 +519,17 @@
       "fun_fact_nl": "Über den Wolken van Reinhard Mey is een van de beroemdste Duitse liederen ooit. Mey schreef het na zijn eerste solovlucht, waarin hij de grenzeloze vrijheid van het vliegen uitdrukt.",
       "awards_nl": [
         "Deutscher Kleinkunstpreis"
-      ]
+      ],
+      "isrc": "DEC649800506",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/724105106",
+        "de": "applemusic://track/724105106",
+        "gb": "applemusic://track/724105106",
+        "fr": "applemusic://track/724105106",
+        "es": "applemusic://track/724105106",
+        "nl": "applemusic://track/724105106",
+        "it": "applemusic://track/724105106"
+      }
     },
     {
       "year": 1977,
@@ -507,7 +597,17 @@
       "uri_tidal": "tidal://track/4920882",
       "uri_deezer": "deezer://track/2319548",
       "fun_fact_nl": "Guten Morgen Sonnenschein werd gezongen door Nana Mouskouri en is een tijdloos feelgood nummer. De Griekse zangeres is een van de succesvolste artiesten ter wereld, met meer dan 300 miljoen verkochte albums.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "CH0527780010",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1609185972",
+        "de": "applemusic://track/1609185972",
+        "gb": "applemusic://track/1609185972",
+        "fr": "applemusic://track/1609185972",
+        "es": "applemusic://track/1609185972",
+        "nl": "applemusic://track/1609185972",
+        "it": "applemusic://track/1609185972"
+      }
     },
     {
       "year": 1976,
@@ -535,7 +635,17 @@
       "uri_tidal": "tidal://track/3098942",
       "uri_deezer": "deezer://track/602247",
       "fun_fact_nl": "Aber bitte mit Sahne is Udo Jürgens' humoristische lofzang op de vreugde van het leven en het zoete leven. De zin is een populaire uitdrukking geworden in de Duitse taal.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "CH0019800001",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1626938360",
+        "de": "applemusic://track/1626938360",
+        "gb": "applemusic://track/1626938360",
+        "fr": "applemusic://track/1626938360",
+        "es": "applemusic://track/1626938360",
+        "nl": "applemusic://track/1626938360",
+        "it": "applemusic://track/1626938360"
+      }
     },
     {
       "year": 1975,
@@ -576,7 +686,17 @@
       "fun_fact_nl": "Er gehört zu mir van Marianne Rosenberg werd een klassieker en een hymne van zelfbevestiging. Rosenberg wordt beschouwd als de 'Koningin van de Schlager' en heeft het genre gevormd sinds de jaren 1970.",
       "awards_nl": [
         "Goldene Stimmgabel (1975)"
-      ]
+      ],
+      "isrc": "DEQS92000744",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1822405353",
+        "de": "applemusic://track/1822469061",
+        "gb": "applemusic://track/1822405353",
+        "fr": "applemusic://track/1822405353",
+        "es": "applemusic://track/1822405353",
+        "nl": "applemusic://track/1822405353",
+        "it": "applemusic://track/1822405353"
+      }
     },
     {
       "year": 1977,
@@ -631,7 +751,17 @@
       "uri_tidal": "tidal://track/56290544",
       "uri_deezer": "deezer://track/120358360",
       "fun_fact_nl": "Verlieben, verloren, vergessen, verzeih'n werd het lijflied van Wolfgang Petry. De zanger, bijgenaamd 'Wolle', staat bekend om zijn energieke liveoptredens en trouwe fans.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEBA20700187",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/264705546",
+        "de": "applemusic://track/264705546",
+        "gb": "applemusic://track/264705546",
+        "fr": "applemusic://track/264705546",
+        "es": "applemusic://track/264705546",
+        "nl": "applemusic://track/264705546",
+        "it": "applemusic://track/264705546"
+      }
     },
     {
       "year": 1965,
@@ -659,7 +789,17 @@
       "uri_tidal": "tidal://track/109437",
       "uri_deezer": "deezer://track/697623",
       "fun_fact_nl": "Marmor, Stein und Eisen bricht van Drafi Deutscher is een eeuwige klassieker over eeuwige liefde. Het origineel uit 1965 wordt nog steeds gespeeld op bruiloften.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEC739200011",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/255692545",
+        "de": "applemusic://track/1308496257",
+        "gb": "applemusic://track/1308496257",
+        "fr": "applemusic://track/1308496257",
+        "es": "applemusic://track/1308496257",
+        "nl": "applemusic://track/1308496257",
+        "it": "applemusic://track/1308496257"
+      }
     },
     {
       "year": 1975,
@@ -715,7 +855,17 @@
       "uri_tidal": "tidal://track/72579011",
       "uri_deezer": "deezer://track/347865751",
       "fun_fact_nl": "Wann wird's mal wieder richtig Sommer van Rudi Carrell werd het volkslied voor iedereen die naar de zomer verlangde. De Nederlandse entertainer was een van de meest geliefde showhosts op de Duitse televisie.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEF457500504",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1690144526",
+        "de": "applemusic://track/1222009615",
+        "gb": "applemusic://track/1222009615",
+        "fr": "applemusic://track/1222009615",
+        "es": "applemusic://track/1222009615",
+        "nl": "applemusic://track/1222009615",
+        "it": "applemusic://track/1222009615"
+      }
     },
     {
       "year": 2007,
@@ -765,7 +915,17 @@
       "awards_nl": [
         "Echo (2008)",
         "Amadeus Austrian Music Award (2008)"
-      ]
+      ],
+      "isrc": "DEUM70606361",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1612326333",
+        "de": "applemusic://track/1612326333",
+        "gb": "applemusic://track/1612326333",
+        "fr": "applemusic://track/1612326333",
+        "es": "applemusic://track/1612326333",
+        "nl": "applemusic://track/1612326333",
+        "it": "applemusic://track/1612326333"
+      }
     },
     {
       "year": 1996,
@@ -793,7 +953,17 @@
       "uri_tidal": "tidal://track/86234775",
       "uri_deezer": "deezer://track/475841442",
       "fun_fact_nl": "Weiß der Geier van Wolfgang Petry laat zich van zijn rockere kant zien. Petry staat bekend om zijn zweetdoordrenkte concerten en de ongelofelijke energie die hij op het podium uitstraalt.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEH499700084",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1642974499",
+        "de": "applemusic://track/1610774673",
+        "gb": "applemusic://track/1610774673",
+        "fr": "applemusic://track/1610774673",
+        "es": "applemusic://track/1610774673",
+        "nl": "applemusic://track/1610774673",
+        "it": "applemusic://track/1610774673"
+      }
     },
     {
       "year": 1983,
@@ -834,7 +1004,17 @@
       "fun_fact_nl": "Jenseits von Eden van Nino de Angelo werd de grootste hit van de zanger. Dit dramatische nummer laat zijn krachtige stem horen en maakte van hem een ster in de jaren 80.",
       "awards_nl": [
         "Goldene Stimmgabel (1984)"
-      ]
+      ],
+      "isrc": "DEA812000536",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1609263446",
+        "de": "applemusic://track/1609263446",
+        "gb": "applemusic://track/1609263446",
+        "fr": "applemusic://track/1609263446",
+        "es": "applemusic://track/1609263446",
+        "nl": "applemusic://track/1609263446",
+        "it": "applemusic://track/1609263446"
+      }
     },
     {
       "year": 1976,
@@ -862,7 +1042,17 @@
       "uri_tidal": "tidal://track/3014373",
       "uri_deezer": "deezer://track/15792368",
       "fun_fact_nl": "Anita van Costa Cordalis bracht Grieks temperament naar de Duitse Schlager. De zangeres werd later bekend bij een nieuw publiek door reality TV.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEE869701028",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/326422804",
+        "de": "applemusic://track/854508971",
+        "gb": "applemusic://track/854508971",
+        "fr": "applemusic://track/854508971",
+        "es": "applemusic://track/854508971",
+        "nl": "applemusic://track/854508971",
+        "it": "applemusic://track/854508971"
+      }
     },
     {
       "year": 1991,
@@ -890,7 +1080,17 @@
       "uri_tidal": "tidal://track/45059944",
       "uri_deezer": "deezer://track/99127332",
       "fun_fact_nl": "Lena van Pur is een emotionele ballade over liefde en verlies. De band uit Baden-Württemberg demonstreert hun veelzijdigheid tussen rock en emotionele ballads.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEA340201643",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1530792637",
+        "de": "applemusic://track/1530792637",
+        "gb": "applemusic://track/1530792637",
+        "fr": "applemusic://track/1530792637",
+        "es": "applemusic://track/1530792637",
+        "nl": "applemusic://track/1530792637",
+        "it": "applemusic://track/1530792637"
+      }
     },
     {
       "year": 1984,
@@ -946,7 +1146,17 @@
       "uri_tidal": "tidal://track/8151434",
       "uri_deezer": "deezer://track/14189399",
       "fun_fact_nl": "Itsy Bitsy Teenie Weenie Honolulu Strand Bikini werd gezongen door Caterina Valente en is de Duitse versie van de Amerikaanse zomerhit. Dit aanstekelijke deuntje is een must-have op elk strandfeest.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DER411100052",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1653575754",
+        "de": "applemusic://track/1653575754",
+        "gb": "applemusic://track/1653575754",
+        "fr": "applemusic://track/1653575754",
+        "es": "applemusic://track/1653575754",
+        "nl": "applemusic://track/1653575754",
+        "it": "applemusic://track/1653575754"
+      }
     },
     {
       "year": 1975,
@@ -1002,7 +1212,17 @@
       "uri_tidal": "tidal://track/33904739",
       "uri_deezer": "deezer://track/84206297",
       "fun_fact_nl": "Marleen van Marianne Rosenberg vertelt het verhaal van een bijzondere vrouw. Het nummer laat Rosenbergs veelzijdigheid zien tussen disco en klassieke Schlager.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEC739000106",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1630810251",
+        "de": "applemusic://track/1630810251",
+        "gb": "applemusic://track/1630810251",
+        "fr": "applemusic://track/1630810251",
+        "es": "applemusic://track/1630810251",
+        "nl": "applemusic://track/1630810251",
+        "it": "applemusic://track/1630810251"
+      }
     },
     {
       "year": 2015,
@@ -1050,7 +1270,17 @@
       "awards_nl": [
         "Amadeus Austrian Music Award (2015)",
         "Echo (2015)"
-      ]
+      ],
+      "isrc": "DEUM71500645",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1702249934",
+        "de": "applemusic://track/1702249934",
+        "gb": "applemusic://track/1702249934",
+        "fr": "applemusic://track/1702249934",
+        "es": "applemusic://track/1702249934",
+        "nl": "applemusic://track/1702249934",
+        "it": "applemusic://track/1702249934"
+      }
     },
     {
       "year": 1974,
@@ -1119,7 +1349,17 @@
       "fun_fact_nl": "Wahnsinn van Wolfgang Petry is een feestlied dat elke dansvloer aan het springen krijgt. Petry staat erom bekend dat zijn fans urenlang meezingen tijdens zijn concerten.",
       "awards_nl": [
         "Goldene Stimmgabel (1983)"
-      ]
+      ],
+      "isrc": "DEC739600528",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1658114506",
+        "de": "applemusic://track/1620406614",
+        "gb": "applemusic://track/1658114506",
+        "fr": "applemusic://track/1658114506",
+        "es": "applemusic://track/1658114506",
+        "nl": "applemusic://track/1790923406",
+        "it": "applemusic://track/1658114506"
+      }
     },
     {
       "year": 1961,
@@ -1243,7 +1483,17 @@
       "uri_tidal": "tidal://track/2775073",
       "uri_deezer": "deezer://track/1415410502",
       "fun_fact_nl": "Fiesta Mexicana van Rex Gildo is een klassieker vol levensvreugde. Het nummer brengt Mexicaanse flair op elk feest en wordt vandaag de dag nog steeds gedraaid.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEA817200003",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1658115196",
+        "de": "applemusic://track/1308496269",
+        "gb": "applemusic://track/1308496269",
+        "fr": "applemusic://track/1308496269",
+        "es": "applemusic://track/1308496269",
+        "nl": "applemusic://track/1308496269",
+        "it": "applemusic://track/1308496269"
+      }
     },
     {
       "year": 1999,
@@ -1268,7 +1518,17 @@
       "uri_tidal": "tidal://track/176579",
       "uri_deezer": "deezer://track/16565276",
       "fun_fact_nl": "Aller Herren Länder van Heinz Rudolf Kunze laat de meer rockende kant van de Duitse Schlager horen. Kunze staat bekend om zijn poëtische teksten en kritische observaties.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEA629851520",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1790397953",
+        "de": "applemusic://track/1790397953",
+        "gb": "applemusic://track/1790397953",
+        "fr": "applemusic://track/1790397953",
+        "es": "applemusic://track/1790397953",
+        "nl": "applemusic://track/1790397953",
+        "it": "applemusic://track/1790397953"
+      }
     },
     {
       "year": 1990,
@@ -1295,7 +1555,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=Rka207wbrz0",
       "uri_tidal": "tidal://track/138813585",
       "fun_fact_nl": "Ich hab' geträumt von dir was een van de eerste grote hits van Matthias Reim. Het origineel uit 1990 vestigde hem als een belangrijke figuur in de Duitse Schlager.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEA651000010",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1611040992",
+        "de": "applemusic://track/1509695327",
+        "gb": "applemusic://track/1509695327",
+        "fr": "applemusic://track/1509695327",
+        "es": "applemusic://track/1509695327",
+        "nl": "applemusic://track/1509695327",
+        "it": "applemusic://track/1509695327"
+      }
     },
     {
       "year": 2014,
@@ -1392,7 +1662,17 @@
       "uri_tidal": "tidal://track/45059947",
       "uri_deezer": "deezer://track/99127338",
       "fun_fact_nl": "Hör gut zu van Pur is een doordachte ballade over communicatie. De band slaagt er consequent in om belangrijke thema's in hun muziek te verwerken.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEA349302121",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1807404011",
+        "de": "applemusic://track/1807404011",
+        "gb": "applemusic://track/1807404011",
+        "fr": "applemusic://track/1807404011",
+        "es": "applemusic://track/1807404011",
+        "nl": "applemusic://track/1807404011",
+        "it": "applemusic://track/1807404011"
+      }
     },
     {
       "year": 1977,
@@ -1422,7 +1702,17 @@
       "uri_tidal": "tidal://track/498733",
       "uri_deezer": "deezer://track/4253149",
       "fun_fact_nl": "Mit 66 Jahren van Udo Jürgens is een optimistische lofzang op het ouder worden. Jürgens zelf belichaamde deze levensvreugde en trad tot op hoge leeftijd op.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEA810000526",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/270579188",
+        "de": "applemusic://track/207186284",
+        "gb": "applemusic://track/270579188",
+        "fr": "applemusic://track/270579188",
+        "es": "applemusic://track/270579188",
+        "nl": "applemusic://track/270579188",
+        "it": "applemusic://track/270579188"
+      }
     },
     {
       "year": 2009,
@@ -1463,7 +1753,17 @@
       "fun_fact_nl": "Ich will immer wieder... dieses Fieber spür'n toont de energie en podiumprésence van Helene Fischer. Ze is de meest succesvolle Duitse artieste van dit moment.",
       "awards_nl": [
         "Echo (2010)"
-      ]
+      ],
+      "isrc": "DEC610900572",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/716328601",
+        "de": "applemusic://track/716328601",
+        "gb": "applemusic://track/716328601",
+        "fr": "applemusic://track/716328601",
+        "es": "applemusic://track/716328601",
+        "nl": "applemusic://track/716328601",
+        "it": "applemusic://track/716328601"
+      }
     },
     {
       "year": 1972,
@@ -1539,7 +1839,17 @@
       "awards_nl": [
         "Winnaar Eurovisie Songfestival (1982)",
         "Goldene Stimmgabel (1982)"
-      ]
+      ],
+      "isrc": "DEC718200001",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/284222244",
+        "de": "applemusic://track/1459075524",
+        "gb": "applemusic://track/284222244",
+        "fr": "applemusic://track/284222244",
+        "es": "applemusic://track/284222244",
+        "nl": "applemusic://track/284222244",
+        "it": "applemusic://track/284222244"
+      }
     },
     {
       "year": 1993,
@@ -1567,7 +1877,17 @@
       "uri_tidal": "tidal://track/45059937",
       "uri_deezer": "deezer://track/99127318",
       "fun_fact_nl": "Indianer van Pur is een rocklied over vrijheid en avontuur. De band weet het publiek al meer dan 40 jaar te boeien met Duitse teksten en opzwepende melodieën.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEA340201632",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1530792638",
+        "de": "applemusic://track/1530792638",
+        "gb": "applemusic://track/1530792638",
+        "fr": "applemusic://track/1530792638",
+        "es": "applemusic://track/1530792638",
+        "nl": "applemusic://track/1530792638",
+        "it": "applemusic://track/1530792638"
+      }
     },
     {
       "year": 1971,
@@ -1595,7 +1915,17 @@
       "uri_tidal": "tidal://track/13362649",
       "uri_deezer": "deezer://track/7063706",
       "fun_fact_nl": "Schön ist es auf der Welt zu sein van Roy Black en Anita is een tijdloos feelgood nummer. Roy Black was een van de grootste sterren van de jaren 60 en 70.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEF067102150",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1622821511",
+        "de": "applemusic://track/1442825796",
+        "gb": "applemusic://track/1442825796",
+        "fr": "applemusic://track/1442825796",
+        "es": "applemusic://track/1442825796",
+        "nl": "applemusic://track/1442825796",
+        "it": "applemusic://track/1442825796"
+      }
     },
     {
       "year": 2017,
@@ -1625,7 +1955,17 @@
       "uri_tidal": "tidal://track/75485715",
       "uri_deezer": "deezer://track/376483341",
       "fun_fact_nl": "Herzbeben van Helene Fischer toont haar evolutie naar internationale pop. Het nummer combineert een modern geluid met de emotionaliteit van Schlager.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEUM71704905",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1709413703",
+        "de": "applemusic://track/1709413703",
+        "gb": "applemusic://track/1709413703",
+        "fr": "applemusic://track/1709413703",
+        "es": "applemusic://track/1709413703",
+        "nl": "applemusic://track/1709413703",
+        "it": "applemusic://track/1709413703"
+      }
     },
     {
       "year": 2018,
@@ -1653,7 +1993,17 @@
       "uri_tidal": "tidal://track/101341700",
       "uri_deezer": "deezer://track/607895352",
       "fun_fact_nl": "Regenbogenfarben van Kerstin Ott en Helene Fischer werd een duethit. Ott werd beroemd door 'Die immer lacht' en is onmisbaar geworden in de moderne Schlager.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEUM71807723",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1709413706",
+        "de": "applemusic://track/1709413706",
+        "gb": "applemusic://track/1709413706",
+        "fr": "applemusic://track/1709413706",
+        "es": "applemusic://track/1709413706",
+        "nl": "applemusic://track/1709413706",
+        "it": "applemusic://track/1709413706"
+      }
     },
     {
       "year": 1973,
@@ -1681,7 +2031,17 @@
       "uri_tidal": "tidal://track/622060",
       "uri_deezer": "deezer://track/7524195",
       "fun_fact_nl": "Goodbye My Love Goodbye van Demis Roussos is een emotioneel afscheidslied. De Griekse zanger wist wereldwijd miljoenen fans te boeien met zijn onmiskenbare stem.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "FRZ037300120",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1443892855",
+        "de": "applemusic://track/1443273552",
+        "gb": "applemusic://track/1443273552",
+        "fr": "applemusic://track/1443273552",
+        "es": "applemusic://track/1443892855",
+        "nl": "applemusic://track/1443273552",
+        "it": "applemusic://track/1443892855"
+      }
     },
     {
       "year": 1961,
@@ -1734,7 +2094,17 @@
       "uri_tidal": "tidal://track/34039819",
       "uri_deezer": "deezer://track/84668179",
       "fun_fact_nl": "Stimmen im Wind van Juliane Werding laat haar emotionele kant zien. Werding is al succesvol sinds de jaren 1970 en heeft zich voortdurend ontwikkeld.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEA629253260",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/360217561",
+        "de": "applemusic://track/1620406823",
+        "gb": "applemusic://track/360217561",
+        "fr": "applemusic://track/360217561",
+        "es": "applemusic://track/360217561",
+        "nl": "applemusic://track/1504678299",
+        "it": "applemusic://track/360217561"
+      }
     },
     {
       "year": 1974,
@@ -1762,7 +2132,17 @@
       "uri_tidal": "tidal://track/12049765",
       "uri_deezer": "deezer://track/552818332",
       "fun_fact_nl": "Du kannst nicht immer 17 sein van Chris Roberts is een nostalgische lofzang op de jeugd. Het lied werd het motto voor iedereen die jong van hart blijft.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEC717400006",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/255715874",
+        "de": "applemusic://track/1459075501",
+        "gb": "applemusic://track/252068133",
+        "fr": "applemusic://track/252068133",
+        "es": "applemusic://track/252068133",
+        "nl": "applemusic://track/252068133",
+        "it": "applemusic://track/252068133"
+      }
     },
     {
       "year": 1972,
@@ -1790,7 +2170,17 @@
       "uri_tidal": "tidal://track/16019356",
       "uri_deezer": "deezer://track/15777630",
       "fun_fact_nl": "Eine neue Liebe ist wie ein neues Leben van Jürgen Marcus werd een evergreen. Dit optimistische lied begeleidt al generaties lang geliefden.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEA370803298",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/453961321",
+        "de": "applemusic://track/453961321",
+        "gb": "applemusic://track/453961321",
+        "fr": "applemusic://track/453961321",
+        "es": "applemusic://track/453961321",
+        "nl": "applemusic://track/453961321",
+        "it": "applemusic://track/453961321"
+      }
     },
     {
       "year": 2009,
@@ -1815,7 +2205,17 @@
       "uri_tidal": "tidal://track/236476831",
       "uri_deezer": "deezer://track/1831148087",
       "fun_fact_nl": "Wir sagen danke schön van Die Flippers is een welgemeend danklied aan hun fans. De band nam afscheid na een succesvolle carrière van meer dan 40 jaar.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEA810900727",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/318685881",
+        "de": "applemusic://track/1669322532",
+        "gb": "applemusic://track/318685881",
+        "fr": "applemusic://track/318685881",
+        "es": "applemusic://track/318685881",
+        "nl": "applemusic://track/318685881",
+        "it": "applemusic://track/318685881"
+      }
     },
     {
       "year": 1976,
@@ -1843,7 +2243,17 @@
       "uri_tidal": "tidal://track/15811933",
       "uri_deezer": "deezer://track/62238193",
       "fun_fact_nl": "Ein Bett im Kornfeld van Jürgen Drews is de zomerhit bij uitstek. Drews, de 'koning van Mallorca', zingt het tot op de dag van vandaag op elk feest.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DELC80800028",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/293895098",
+        "de": "applemusic://track/1887516626",
+        "gb": "applemusic://track/293895098",
+        "fr": "applemusic://track/293895098",
+        "es": "applemusic://track/293895098",
+        "nl": "applemusic://track/293895098",
+        "it": "applemusic://track/293895098"
+      }
     },
     {
       "year": 2009,
@@ -1912,7 +2322,17 @@
       "fun_fact_nl": "Du van Peter Maffay was zijn doorbraakhit en maakte van hem een superster. De titel staat in het Guinness Book als de best verkochte single van een Duitse artiest.",
       "awards_nl": [
         "Gouden Plaat (1970)"
-      ]
+      ],
+      "isrc": "DEA818100076",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/207071929",
+        "de": "applemusic://track/207071929",
+        "gb": "applemusic://track/207071929",
+        "fr": "applemusic://track/207071929",
+        "es": "applemusic://track/207071929",
+        "nl": "applemusic://track/1504678211",
+        "it": "applemusic://track/207071929"
+      }
     },
     {
       "year": 1969,

--- a/custom_components/beatify/playlists/community/top-songs-der-60er.json
+++ b/custom_components/beatify/playlists/community/top-songs-der-60er.json
@@ -36,7 +36,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=NADx3-qRxek",
       "uri_tidal": "tidal://track/150851",
       "fun_fact_nl": "Paul McCartney noemde dit 'het beste nummer ooit geschreven'. Het was een van de eerste popsongs met het woord 'God' in de titel, waardoor radiostations het aanvankelijk niet wilden draaien.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USCA21201937",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1443134674",
+        "de": "applemusic://track/1443134674",
+        "gb": "applemusic://track/1443134674",
+        "fr": "applemusic://track/1443134674",
+        "es": "applemusic://track/1443134674",
+        "nl": "applemusic://track/1443134674",
+        "it": "applemusic://track/1443134674"
+      }
     },
     {
       "year": 1966,
@@ -65,7 +75,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=apBWI6xrbLY",
       "uri_tidal": "tidal://track/1392966",
       "fun_fact_nl": "Het kostte meer dan zes maanden en 50.000 dollar om het nummer te produceren, een astronomisch bedrag in 1966. Het werd opgenomen in vier verschillende studio's en er werd 90 uur tape voor gebruikt.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USCA21202151",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1440901220",
+        "de": "applemusic://track/1442865074",
+        "gb": "applemusic://track/1442865074",
+        "fr": "applemusic://track/1442865074",
+        "es": "applemusic://track/1442865074",
+        "nl": "applemusic://track/1442865074",
+        "it": "applemusic://track/1442865074"
+      }
     },
     {
       "year": 1966,
@@ -94,7 +114,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=4PQAqprjOuA",
       "uri_tidal": "tidal://track/3268142",
       "fun_fact_nl": "Dit nummer, geschreven door Neil Diamond, stond zeven weken op #1 en verkocht wereldwijd meer dan 10 miljoen exemplaren. Het werd later beroemd gecoverd in de film Shrek (2001).",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USRH10125749",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1213403197",
+        "de": "applemusic://track/1373179773",
+        "gb": "applemusic://track/1373179773",
+        "fr": "applemusic://track/1373179773",
+        "es": "applemusic://track/1373179773",
+        "nl": "applemusic://track/1373179773",
+        "it": "applemusic://track/1373179773"
+      }
     },
     {
       "year": 1961,
@@ -123,7 +153,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=z5i9vT8wGY8",
       "uri_tidal": "tidal://track/207819",
       "fun_fact_nl": "Het nummer werd twee keer een nummer 1-hit in 1961 en opnieuw in 1987 nadat het in de gelijknamige film werd gebruikt. De baslijn was geïnspireerd op een gospelsong.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USAT20000556",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1815497962",
+        "de": "applemusic://track/1815497962",
+        "gb": "applemusic://track/1815497962",
+        "fr": "applemusic://track/1815497962",
+        "es": "applemusic://track/1815497962",
+        "nl": "applemusic://track/1815497962",
+        "it": "applemusic://track/1815497962"
+      }
     },
     {
       "year": 1967,
@@ -152,7 +192,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=K3syk2VOmRw",
       "uri_tidal": "tidal://track/3268157",
       "fun_fact_nl": "Geschreven door John Stewart van het Kingston Trio. Davy Jones haatte het nummer aanvankelijk, maar het werd een van de meest geliefde hits van The Monkees.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USRH10125802",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1556224160",
+        "de": "applemusic://track/1625648637",
+        "gb": "applemusic://track/1625648637",
+        "fr": "applemusic://track/1625648637",
+        "es": "applemusic://track/1625648637",
+        "nl": "applemusic://track/1625648637",
+        "it": "applemusic://track/1625648637"
+      }
     },
     {
       "year": 1967,
@@ -181,7 +231,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=_g_tuOS-iZ4",
       "uri_tidal": "tidal://track/389264",
       "fun_fact_nl": "Het beroemde keyboard intro van het nummer werd geschreven door Ray Manzarek, geïnspireerd door Bach. De radiobewerking bracht de albumversie van 7 minuten terug tot minder dan 3 minuten.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USRH11605702",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1192962303",
+        "de": "applemusic://track/1192962303",
+        "gb": "applemusic://track/1192962303",
+        "fr": "applemusic://track/1192962303",
+        "es": "applemusic://track/1192962303",
+        "nl": "applemusic://track/1192962303",
+        "it": "applemusic://track/1192962303"
+      }
     },
     {
       "year": 1967,
@@ -208,7 +268,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=RAiuUCCcdJI",
       "uri_tidal": "tidal://track/68710966",
       "fun_fact_nl": "Dit 12 minuten durende epos is beroemd geworden door Francis Ford Coppola's Apocalypse Now. Het Oedipale gedeelte werd geïmproviseerd door Jim Morrison tijdens een live optreden.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USEE11200530",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/640047587",
+        "de": "applemusic://track/640047587",
+        "gb": "applemusic://track/640047587",
+        "fr": "applemusic://track/640047587",
+        "es": "applemusic://track/640047587",
+        "nl": "applemusic://track/640047587",
+        "it": "applemusic://track/640047587"
+      }
     },
     {
       "year": 1963,
@@ -235,7 +305,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=1WaV2x8GXj0",
       "uri_tidal": "tidal://track/2045087",
       "fun_fact_nl": "Geschreven door June Carter Cash en Merle Kilgore. De kenmerkende mariachi kopersectie werd geïnspireerd door een droom die Johnny Cash had over het nummer.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM19917137",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1308624096",
+        "de": "applemusic://track/1308624096",
+        "gb": "applemusic://track/1308624096",
+        "fr": "applemusic://track/607259953",
+        "es": "applemusic://track/1308624096",
+        "nl": "applemusic://track/1308624096",
+        "it": "applemusic://track/1308624096"
+      }
     },
     {
       "year": 1964,
@@ -262,7 +342,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=MJkr0DWbhTk",
       "uri_tidal": "tidal://track/147055",
       "fun_fact_nl": "Het nummer is een traditioneel volksliedje van onbekende oorsprong. De versie van The Animals werd in slechts één take opgenomen en inspireerde Bob Dylan om elektrisch te gaan.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USA176460010",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1440781975",
+        "de": null,
+        "gb": null,
+        "fr": null,
+        "es": null,
+        "nl": null,
+        "it": null
+      }
     },
     {
       "year": 1966,
@@ -291,7 +381,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=GM1kzbAgo_E",
       "uri_tidal": "tidal://track/158703964",
       "fun_fact_nl": "Geschreven door Lee Hazlewood, die het nummer schreef als een mannelijk nummer maar het aan Nancy gaf omdat hij dacht dat het interessanter zou zijn gezongen door een vrouw.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USASE0500005",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1576574977",
+        "de": "applemusic://track/1576574977",
+        "gb": "applemusic://track/1576574977",
+        "fr": "applemusic://track/1576574977",
+        "es": "applemusic://track/1576574977",
+        "nl": "applemusic://track/1576574977",
+        "it": "applemusic://track/1576574977"
+      }
     },
     {
       "year": 1967,
@@ -318,7 +418,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=z0vCwGUZe1I",
       "uri_tidal": "tidal://track/201461600",
       "fun_fact_nl": "De iconische orgelmelodie is gebaseerd op Bachs 'Air on a G String'. Het stond zes weken op #1 in de UK en is een van de meest gespeelde nummers op openbare plaatsen in de geschiedenis van de UK.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USUG10914316",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1469579797",
+        "de": "applemusic://track/1469579797",
+        "gb": "applemusic://track/1469579797",
+        "fr": "applemusic://track/1469579797",
+        "es": "applemusic://track/1469579797",
+        "nl": "applemusic://track/1469579797",
+        "it": "applemusic://track/1469579797"
+      }
     },
     {
       "year": 1971,
@@ -351,7 +461,17 @@
       "fun_fact_nl": "De herhaling van 'I know' 26 keer was oorspronkelijk een placeholder totdat Withers een goede tekst kon schrijven, maar de producer stond erop om het te houden.",
       "awards_nl": [
         "Grammy Award voor Beste R&B-nummer (1972)"
-      ]
+      ],
+      "isrc": "USSM17100268",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/391725482",
+        "de": "applemusic://track/408958212",
+        "gb": "applemusic://track/1308611756",
+        "fr": "applemusic://track/1308611756",
+        "es": "applemusic://track/1308611756",
+        "nl": "applemusic://track/1308611756",
+        "it": "applemusic://track/1308611756"
+      }
     },
     {
       "year": 1964,
@@ -384,7 +504,17 @@
       "fun_fact_nl": "Het nummer werd geschreven door Tony Hatch in 30 minuten na een bezoek aan Times Square in New York. Het was de eerste Britse vrouwelijke solohit die #1 bereikte in de VS.",
       "awards_nl": [
         "Grammy Award voor Beste Rock-'n-Roll-opname (1965)"
-      ]
+      ],
+      "isrc": "FRZ196400510",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1676474357",
+        "de": "applemusic://track/1676474357",
+        "gb": "applemusic://track/1676474357",
+        "fr": "applemusic://track/1676474357",
+        "es": "applemusic://track/1676474357",
+        "nl": "applemusic://track/1676474357",
+        "it": "applemusic://track/1676474357"
+      }
     },
     {
       "year": 1968,
@@ -413,7 +543,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=egMWlD3fLJ8",
       "uri_tidal": "tidal://track/77611624",
       "fun_fact_nl": "Het nummer bedacht de uitdrukking 'heavy metal thunder' en was daarmee een van de eerste toepassingen van de term 'heavy metal' in de muziek. Het werd iconisch door de film Easy Rider (1969).",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMC16846563",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/6763242221",
+        "de": "applemusic://track/6763242221",
+        "gb": "applemusic://track/6763242221",
+        "fr": "applemusic://track/6763242221",
+        "es": "applemusic://track/6763242221",
+        "nl": "applemusic://track/6763242221",
+        "it": "applemusic://track/6763242221"
+      }
     },
     {
       "year": 1965,
@@ -440,7 +580,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=_38SWIIKITE",
       "uri_tidal": "tidal://track/78447224",
       "fun_fact_nl": "Dit protestlied werd door veel radiostations in de VS verboden omdat het 'te politiek' zou zijn. Het werd in één take opgenomen en je kunt de stem van McGuire soms horen kraken.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMC16500802",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1442439941",
+        "de": "applemusic://track/1443341633",
+        "gb": "applemusic://track/1443341633",
+        "fr": "applemusic://track/1443341633",
+        "es": "applemusic://track/1443341633",
+        "nl": "applemusic://track/1443341633",
+        "it": "applemusic://track/1443341633"
+      }
     },
     {
       "year": 1969,
@@ -471,7 +621,17 @@
       "fun_fact_nl": "Het werd vijf dagen voor de maanlanding van de Apollo 11 uitgebracht door de BBC. Ze vermeden het echter een tijdje daarna uit angst dat het de astronauten zou vervloeken.",
       "awards_nl": [
         "Ivor Novello Award voor Originaliteit (1970)"
-      ]
+      ],
+      "isrc": "USJT10900021",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1486377720",
+        "de": "applemusic://track/1486377720",
+        "gb": "applemusic://track/1486377720",
+        "fr": "applemusic://track/1486377720",
+        "es": "applemusic://track/1486377720",
+        "nl": "applemusic://track/1486377720",
+        "it": "applemusic://track/1486377720"
+      }
     },
     {
       "year": 1964,
@@ -500,7 +660,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=4fWyzwo1xg0",
       "uri_tidal": "tidal://track/109335795",
       "fun_fact_nl": "De oorspronkelijke akoestische versie flopte, maar producer Tom Wilson voegde elektrische instrumenten toe zonder het duo te vertellen, waardoor de hitversie ontstond. Het werd nummer 1 toen ze aan het toeren waren in Denemarken.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM16401131",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1463665119",
+        "de": "applemusic://track/1463665119",
+        "gb": "applemusic://track/1463665119",
+        "fr": "applemusic://track/1463665119",
+        "es": "applemusic://track/1463665119",
+        "nl": "applemusic://track/1463665119",
+        "it": "applemusic://track/1463665119"
+      }
     },
     {
       "year": 1969,
@@ -527,7 +697,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=KQetemT1sWc",
       "uri_tidal": "tidal://track/55130637",
       "fun_fact_nl": "George Harrison schreef dit nummer in de tuin van Eric Clapton terwijl hij een zakelijke Beatles-bijeenkomst oversloeg. Het is nu het meest gestreamde Beatles-nummer op Spotify.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBUM71903335",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1713156666",
+        "de": "applemusic://track/1713156666",
+        "gb": "applemusic://track/1713156666",
+        "fr": "applemusic://track/1713156666",
+        "es": "applemusic://track/1713156666",
+        "nl": "applemusic://track/1713156666",
+        "it": "applemusic://track/1713156666"
+      }
     },
     {
       "year": 1967,
@@ -554,7 +734,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=uzAWDG3ZieM",
       "uri_tidal": "tidal://track/12445712",
       "fun_fact_nl": "Dit nummer stootte 'Penny Lane' van de Beatles van de #1-positie. Het werd door verschillende groepen afgewezen voordat The Turtles het opnamen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USA560587940",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/79087150",
+        "de": "applemusic://track/79087150",
+        "gb": "applemusic://track/79087150",
+        "fr": "applemusic://track/79087150",
+        "es": "applemusic://track/79087150",
+        "nl": "applemusic://track/79087150",
+        "it": "applemusic://track/79087150"
+      }
     },
     {
       "year": 1970,
@@ -581,7 +771,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=e5uei2AFEaQ",
       "uri_tidal": "tidal://track/650233",
       "fun_fact_nl": "De percussie werd gecreëerd door op de dijen te slaan en voorwerpen op de grond te laten vallen in de studio. Het nummer is vernoemd naar Sint Cecilia, de beschermheilige van de muziek.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM16900181",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1463658941",
+        "de": "applemusic://track/1463658941",
+        "gb": "applemusic://track/1463658941",
+        "fr": "applemusic://track/1463658941",
+        "es": "applemusic://track/1463658941",
+        "nl": "applemusic://track/1463658941",
+        "it": "applemusic://track/1463658941"
+      }
     },
     {
       "year": 1968,
@@ -614,7 +814,17 @@
       "fun_fact_nl": "Geschreven voor de film The Graduate (1967), de oorspronkelijke titel was 'Mrs. Roosevelt. De 'DiMaggio' regel was niet gepland-Paul Simon improviseerde het.",
       "awards_nl": [
         "Grammy Award voor Opname van het Jaar (1969)"
-      ]
+      ],
+      "isrc": "USSM16800379",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1463665385",
+        "de": "applemusic://track/1463665385",
+        "gb": "applemusic://track/1463665385",
+        "fr": "applemusic://track/1463665385",
+        "es": "applemusic://track/1463665385",
+        "nl": "applemusic://track/1463665385",
+        "it": "applemusic://track/1463665385"
+      }
     },
     {
       "year": 1965,
@@ -643,7 +853,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=MSSxnv1_J2g",
       "uri_tidal": "tidal://track/5693554",
       "fun_fact_nl": "Keith Richards schreef de riff in zijn slaap en nam hem op met een cassettespeler naast zijn bed. Hij kan zich er niets van herinneren en wilde aanvankelijk de fuzz gitaar vervangen door blazers.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USA176510160",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1623247613",
+        "de": "applemusic://track/1706561182",
+        "gb": "applemusic://track/1706561182",
+        "fr": "applemusic://track/1706561182",
+        "es": "applemusic://track/1706561182",
+        "nl": "applemusic://track/1706561182",
+        "it": "applemusic://track/1706561182"
+      }
     },
     {
       "year": 1965,
@@ -672,7 +892,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=oU6uUEwZ8FM",
       "uri_tidal": "tidal://track/36379797",
       "fun_fact_nl": "Geschreven door John en Michelle Phillips terwijl het vroor in New York City, verlangend naar het warme Californië. De fluitsolo werd toegevoegd omdat Bud Shank toevallig in de studio was.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMC16532697",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1821337433",
+        "de": "applemusic://track/1821337433",
+        "gb": "applemusic://track/1821337433",
+        "fr": "applemusic://track/1821337433",
+        "es": "applemusic://track/1821337433",
+        "nl": "applemusic://track/1821337433",
+        "it": "applemusic://track/1821337433"
+      }
     },
     {
       "year": 1967,
@@ -701,7 +931,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=Qp3eFAKgbDE",
       "uri_tidal": "tidal://track/14558019",
       "fun_fact_nl": "Geschreven door John Phillips om het Monterey Pop Festival te promoten, werd het de hymne van de Summer of Love. McKenzie weigerde het jarenlang live uit te voeren, omdat hij het beu was een 'one-hit wonder' te zijn.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM16701025",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/158701769",
+        "de": "applemusic://track/348894696",
+        "gb": "applemusic://track/348894696",
+        "fr": "applemusic://track/348894696",
+        "es": "applemusic://track/348894696",
+        "nl": "applemusic://track/348894696",
+        "it": "applemusic://track/348894696"
+      }
     },
     {
       "year": 1971,
@@ -730,7 +970,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=PRpiBpDy7MQ",
       "uri_tidal": "tidal://track/153487245",
       "fun_fact_nl": "Het 8,5 minuten durende nummer verwijst naar 'the day the music died'- 3 februari 1959, toen Buddy Holly, Ritchie Valens en The Big Bopper omkwamen bij een vliegtuigongeluk. McLean heeft de tekst nooit helemaal uitgelegd.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USEM38600088",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1886242473",
+        "de": "applemusic://track/1886242473",
+        "gb": "applemusic://track/1886242473",
+        "fr": "applemusic://track/1886242473",
+        "es": "applemusic://track/1886242473",
+        "nl": "applemusic://track/1886242473",
+        "it": "applemusic://track/1886242473"
+      }
     },
     {
       "year": 1964,
@@ -759,7 +1009,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=AMSiHdrHl0g",
       "uri_tidal": "tidal://track/55130565",
       "fun_fact_nl": "De titel komt van een Ringo Starr-misapropisme. Over het beroemde openingsakkoord wordt al tientallen jaren gediscussieerd: het is eigenlijk de 12-snarige Rickenbacker van George Harrison in lagen met andere instrumenten.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAYE0601438",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1441164417",
+        "de": "applemusic://track/1441164417",
+        "gb": "applemusic://track/1441164417",
+        "fr": "applemusic://track/1441164417",
+        "es": "applemusic://track/1441164417",
+        "nl": "applemusic://track/1441164417",
+        "it": "applemusic://track/1441164417"
+      }
     },
     {
       "year": 1965,
@@ -788,7 +1048,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=MKUex3fci5c",
       "uri_tidal": "tidal://track/55130682",
       "fun_fact_nl": "John Lennon zei later dat dit een oprechte schreeuw om hulp was tijdens een moeilijke periode. Oorspronkelijk geschreven als een langzame ballade, versnelde producer George Martin het om het commercieel aantrekkelijk te maken.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAYE0601465",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1441164536",
+        "de": "applemusic://track/1441164536",
+        "gb": "applemusic://track/1441164536",
+        "fr": "applemusic://track/1441164536",
+        "es": "applemusic://track/1441164536",
+        "nl": "applemusic://track/1441164536",
+        "it": "applemusic://track/1441164536"
+      }
     },
     {
       "year": 1965,
@@ -815,7 +1085,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=TQemQRL_YVQ",
       "uri_tidal": "tidal://track/55130694",
       "fun_fact_nl": "Paul McCartney droomde de melodie en gebruikte oorspronkelijk de plaatsvervangende tekst 'Scrambled eggs, oh my baby how I love your legs'. Het is het meest gecoverde nummer in de geschiedenis met meer dan 2.200 versies.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAYE0601477",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1441133496",
+        "de": "applemusic://track/1441133496",
+        "gb": "applemusic://track/1441133496",
+        "fr": "applemusic://track/1441133496",
+        "es": "applemusic://track/1441133496",
+        "nl": "applemusic://track/1441133496",
+        "it": "applemusic://track/1441133496"
+      }
     },
     {
       "year": 1967,
@@ -842,7 +1122,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=z7syIxQCquo",
       "uri_tidal": "tidal://track/55130776",
       "fun_fact_nl": "De piccolotrompetsolo is geïnspireerd op een Brandenburgs concert van Bach dat Paul McCartney op tv hoorde. Penny Lane is een echte straat in Liverpool en de straatnaambordjes worden voortdurend gestolen door fans.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAYE0601641",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1441163777",
+        "de": "applemusic://track/1441163777",
+        "gb": "applemusic://track/1441163777",
+        "fr": "applemusic://track/1441163777",
+        "es": "applemusic://track/1441163777",
+        "nl": "applemusic://track/1441163777",
+        "it": "applemusic://track/1441163777"
+      }
     },
     {
       "year": 1967,
@@ -871,7 +1161,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=_paPrw0gAUo",
       "uri_tidal": "tidal://track/55130778",
       "fun_fact_nl": "Geschreven voor 'Our World', de eerste wereldwijde live satelliet TV-uitzending die door 400 miljoen mensen werd bekeken. Het nummer is met opzet geschreven in ongebruikelijke maatsoorten om het moeilijk te coveren te maken.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAYE0601643",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1441133271",
+        "de": "applemusic://track/1441133271",
+        "gb": "applemusic://track/1441133271",
+        "fr": "applemusic://track/1441133271",
+        "es": "applemusic://track/1441133271",
+        "nl": "applemusic://track/1441133271",
+        "it": "applemusic://track/1441133271"
+      }
     },
     {
       "year": 1968,
@@ -898,7 +1198,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=uLRiGX3L-kw",
       "uri_tidal": "tidal://track/55130616",
       "fun_fact_nl": "Paul McCartney werd geïnspireerd door een National Geographic-foto van een Vietnamese vrouw met het bijschrift 'Mountain Madonna'. De pianoriff werd beïnvloed door Fats Domino's boogie-woogie stijl.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAYE0900594",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1441133276",
+        "de": "applemusic://track/1441133276",
+        "gb": "applemusic://track/1441133276",
+        "fr": "applemusic://track/1441133276",
+        "es": "applemusic://track/1441133276",
+        "nl": "applemusic://track/1441133276",
+        "it": "applemusic://track/1441133276"
+      }
     },
     {
       "year": 1968,
@@ -927,7 +1237,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=mQER0A0ej0M",
       "uri_tidal": "tidal://track/55130617",
       "fun_fact_nl": "Met 7 minuten en 11 seconden was het de langste single die de UK charts haalde. Geschreven voor John Lennons zoon Julian tijdens de scheiding van zijn ouders, stond het 9 weken op #1 in de VS.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBUM71505902",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1856287169",
+        "de": "applemusic://track/1856287169",
+        "gb": "applemusic://track/1856287169",
+        "fr": "applemusic://track/1856287169",
+        "es": "applemusic://track/1856287169",
+        "nl": "applemusic://track/1856287169",
+        "it": "applemusic://track/1856287169"
+      }
     },
     {
       "year": 1966,
@@ -954,7 +1274,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=-Jj4s9I-53g",
       "uri_tidal": "tidal://track/110811717",
       "fun_fact_nl": "Een bewerking van een traditionele Engelse ballade uit minstens 1670. De 'Canticle' met daar overheen een anti-oorlogslied dat Paul Simon schreef als contrapunt.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM16600723",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1463652959",
+        "de": "applemusic://track/1463652959",
+        "gb": "applemusic://track/1463652959",
+        "fr": "applemusic://track/1463652959",
+        "es": "applemusic://track/1463652959",
+        "nl": "applemusic://track/1463652959",
+        "it": "applemusic://track/1463652959"
+      }
     },
     {
       "year": 1969,
@@ -981,7 +1311,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=yXr2EFomFkU",
       "uri_tidal": "tidal://track/393346",
       "fun_fact_nl": "Geschreven toen Mitchell nog maar 23 was, geïnspireerd door het lezen van een passage over wolken in Saul Bellow's roman Henderson the Rain King. Judy Collins had er een hit mee voordat Joni haar eigen versie opnam.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USRE19600234",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1839414248",
+        "de": "applemusic://track/1839414248",
+        "gb": "applemusic://track/1839414248",
+        "fr": "applemusic://track/1839414248",
+        "es": "applemusic://track/1568036799",
+        "nl": "applemusic://track/1839414248",
+        "it": "applemusic://track/1839414248"
+      }
     },
     {
       "year": 1969,
@@ -1008,7 +1348,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=hHc7bR6y06M",
       "uri_tidal": "tidal://track/93164145",
       "fun_fact_nl": "Pete Townshend schreef het om indruk te maken op een journalist die flipperenthousiast was. Het werd de signature song van de rockopera Tommy, later uitgevoerd door Elton John in de film van 1975.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAKW6900102",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1806381586",
+        "de": "applemusic://track/1806381586",
+        "gb": "applemusic://track/1806381586",
+        "fr": "applemusic://track/1806381586",
+        "es": "applemusic://track/1806381586",
+        "nl": "applemusic://track/1806381586",
+        "it": "applemusic://track/1806381586"
+      }
     },
     {
       "year": 1965,
@@ -1063,7 +1413,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=qbqxbGm9hBI",
       "uri_tidal": "tidal://track/81354385",
       "fun_fact_nl": "Justin Hayward was pas 19 toen hij het schreef over onbeantwoorde liefde. Het nummer werd pas een hit in 1972 toen het opnieuw werd uitgebracht, vijf jaar nadat het was opgenomen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBBBA6760792",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1688434926",
+        "de": "applemusic://track/1688024397",
+        "gb": "applemusic://track/1688024397",
+        "fr": "applemusic://track/1688024397",
+        "es": "applemusic://track/1688024397",
+        "nl": "applemusic://track/1688024397",
+        "it": "applemusic://track/1688024397"
+      }
     },
     {
       "year": 1967,
@@ -1090,7 +1450,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=80_39eAx3z8",
       "uri_tidal": "tidal://track/1186304",
       "fun_fact_nl": "Ondanks dat het een anti-Vietnam oorlogslied werd, was het eigenlijk geschreven over de Sunset Strip rellen, toen de politie slaags raakte met jongeren die protesteerden tegen een avondklok in nachtclubs.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USEE10170607",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1852445477",
+        "de": "applemusic://track/1535485171",
+        "gb": "applemusic://track/1535485171",
+        "fr": "applemusic://track/1535485171",
+        "es": "applemusic://track/1535485171",
+        "nl": "applemusic://track/1535485171",
+        "it": "applemusic://track/1535485171"
+      }
     },
     {
       "year": 1966,
@@ -1117,7 +1487,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=6NWjRmfnmIk",
       "uri_tidal": "tidal://track/37667960",
       "fun_fact_nl": "Dit korte, prachtige nummer van het album 'Sounds of Silence' gebruikt de veranderende maanden als metafoor voor de voortgang van een relatie van lenteliefde tot het einde van de herfst.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM16501152",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/192480540",
+        "de": "applemusic://track/192480540",
+        "gb": "applemusic://track/192480540",
+        "fr": "applemusic://track/192480540",
+        "es": "applemusic://track/192480540",
+        "nl": "applemusic://track/192480540",
+        "it": "applemusic://track/192480540"
+      }
     },
     {
       "year": 1965,
@@ -1144,7 +1524,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=oRrz3yYC2Yg",
       "uri_tidal": "tidal://track/55130684",
       "fun_fact_nl": "John Lennons meest door Dylan beïnvloede nummer, met de eerste externe muzikanten op een Beatles-opname - fluitisten. Sommigen geloven dat het over Brian Epstein's verborgen homoseksualiteit gaat.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAYE0601467",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1441164546",
+        "de": "applemusic://track/1441164546",
+        "gb": "applemusic://track/1441164546",
+        "fr": "applemusic://track/1441164546",
+        "es": "applemusic://track/1441164546",
+        "nl": "applemusic://track/1441164546",
+        "it": "applemusic://track/1441164546"
+      }
     },
     {
       "year": 1966,
@@ -1171,7 +1561,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=rOtnpb2EtQ8",
       "uri_tidal": "tidal://track/71574224",
       "fun_fact_nl": "Geschreven door Harry Vanda en George Young (wiens jongere broers later AC/DC zouden vormen). Rolling Stone noemde het een van de beste nummers aller tijden.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "AUAP06600062",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1440508809",
+        "de": "applemusic://track/1440508809",
+        "gb": "applemusic://track/1440508809",
+        "fr": "applemusic://track/1440508809",
+        "es": "applemusic://track/1440508809",
+        "nl": "applemusic://track/1440508809",
+        "it": "applemusic://track/1440508809"
+      }
     },
     {
       "year": 1968,
@@ -1198,7 +1598,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=zXeRB-3nDR8",
       "uri_tidal": "tidal://track/96729950",
       "fun_fact_nl": "Een satirisch nummer over het Engelse leven in de voorsteden dat de band niet als single wilde uitbrengen. Steve Marriott schaamde zich zo voor het succes dat hij mede hierdoor de band verliet.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBA7H1143360",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1439066304",
+        "de": "applemusic://track/1439066304",
+        "gb": null,
+        "fr": "applemusic://track/1439066304",
+        "es": "applemusic://track/1439066304",
+        "nl": "applemusic://track/1439066304",
+        "it": "applemusic://track/1439066304"
+      }
     },
     {
       "year": 1966,
@@ -1227,7 +1637,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=170sceOWWXc",
       "uri_tidal": "tidal://track/13434396",
       "fun_fact_nl": "Bevat een sitar bespeeld door Brian Jones, die het in slechts een paar weken leerde. De komma in de titel was een drukfout die de band besloot te behouden.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USA171010213",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1440745782",
+        "de": "applemusic://track/1440745782",
+        "gb": "applemusic://track/1440745782",
+        "fr": "applemusic://track/1440745782",
+        "es": "applemusic://track/1440745782",
+        "nl": "applemusic://track/1440745782",
+        "it": "applemusic://track/1440745782"
+      }
     },
     {
       "year": 1968,
@@ -1254,7 +1674,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=fJwjLYRPxJY",
       "uri_tidal": "tidal://track/93240303",
       "fun_fact_nl": "Deze versie, oorspronkelijk een jazz standard uit 1931, heeft Mama Cass als leadzangeres. Het werd uitgebracht als een Mama Cass solo single in het Verenigd Koninkrijk, terwijl het in de VS aan de volledige groep werd toegeschreven.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMC16846393",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1833249921",
+        "de": "applemusic://track/1833249921",
+        "gb": "applemusic://track/1833249921",
+        "fr": "applemusic://track/1833249921",
+        "es": "applemusic://track/1833249921",
+        "nl": "applemusic://track/1833249921",
+        "it": "applemusic://track/1833249921"
+      }
     }
   ]
 }

--- a/custom_components/beatify/playlists/community/top100-allertijden-nederlandstalig.json
+++ b/custom_components/beatify/playlists/community/top100-allertijden-nederlandstalig.json
@@ -34,7 +34,17 @@
       "uri_tidal": "tidal://track/444251096",
       "fun_fact_fr": "Stiekem a été un énorme succès en 2022 pour Maan, atteignant le sommet des charts néerlandais avec son son pop accrocheur et doux-amer sur les sentiments secrets. Maan de Steenwinkel est l'une des artistes pop néerlandaises les plus populaires de sa génération.",
       "fun_fact_nl": "Stiekem was een enorme 2022-hit voor Maan en bereikte de top van de Nederlandse hitlijsten met haar aanstekelijke bitterzoete popsound over geheime gevoelens. Maan de Steenwinkel is een van de succesvolste Nederlandse popartiesten van haar generatie, bekend om haar warme stem en toegankelijke teksten. Het nummer verzamelde tientallen miljoenen streams binnen enkele weken na de release.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "NLZ292200147",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1822755934",
+        "de": "applemusic://track/1822755934",
+        "gb": "applemusic://track/1822755934",
+        "fr": "applemusic://track/1822755934",
+        "es": "applemusic://track/1822755934",
+        "nl": "applemusic://track/1822755934",
+        "it": "applemusic://track/1822755934"
+      }
     },
     {
       "year": 2011,
@@ -62,7 +72,17 @@
       "uri_tidal": "tidal://track/15755295",
       "fun_fact_fr": "Ik Neem Je Mee est devenu l'un des plus grands hits néerlandais de 2011, mêlant hip-hop et hook pop émouvant. Le style chaleureux de Gers Pardoel en a fait un classique instantané.",
       "fun_fact_nl": "Ik Neem Je Mee werd een van de grootste Nederlandse hits van 2011, een mix van hiphop met een emotionele pophook die maandenlang in de hitlijsten bleef hangen. Gers Pardoel's warme stem en oprechte teksten maakten het tot een instant klassieker. Het blijft een van de meest gedraaide Nederlandse nummers van het decennium.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "NLG661100427",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1442705463",
+        "de": "applemusic://track/1442705463",
+        "gb": null,
+        "fr": "applemusic://track/1442705463",
+        "es": "applemusic://track/1442705463",
+        "nl": "applemusic://track/1442705463",
+        "it": "applemusic://track/1442705463"
+      }
     },
     {
       "year": 2019,
@@ -88,7 +108,17 @@
       "uri_tidal": "tidal://track/111782301",
       "fun_fact_fr": "Hoe Het Danst est une ballade réflexive de 2019 de Marco Borsato qui explore poétiquement le passage du temps. C'est l'un de ses titres les plus écoutés en streaming.",
       "fun_fact_nl": "Hoe Het Danst is een reflectieve ballade uit 2019 van Marco Borsato die op poëtische wijze thema's verkent als het leven dat voorbijgaat en het koesteren van het moment. Het werd een van zijn meest gestreamde tracks van het decennium. Borsato wordt algemeen beschouwd als de grootste Nederlandse popster van de jaren 90 en 2000.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "NLUM71900070",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1469081352",
+        "de": "applemusic://track/1469081352",
+        "gb": "applemusic://track/1469081352",
+        "fr": "applemusic://track/1469081352",
+        "es": "applemusic://track/1469081352",
+        "nl": "applemusic://track/1469081352",
+        "it": "applemusic://track/1469081352"
+      }
     },
     {
       "year": 2022,
@@ -116,7 +146,17 @@
       "uri_tidal": "tidal://track/462796568",
       "fun_fact_fr": "Ladada a été un phénomène viral en 2022, mêlant paroles françaises et néerlandaises dans un style rétro-pop nostalgique. L'artiste belge Claude a capturé l'ambiance d'un été insouciant.",
       "fun_fact_nl": "Ladada was een virale sensatie in 2022, een mix van Franse en Nederlandse teksten in een nostalgische retro-popstijl die de Nederlandstalige wereld overspoelde. De Belgische artiest Claude ving het gevoel van een zorgeloze zomer met dit aanstekelijke nummer. Het werd een van de meest gestreamde Nederlandstalige nummers van het jaar.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "NLS242200263",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1842435082",
+        "de": "applemusic://track/1842435082",
+        "gb": "applemusic://track/1842435082",
+        "fr": "applemusic://track/1842435082",
+        "es": "applemusic://track/1842435082",
+        "nl": "applemusic://track/1842435082",
+        "it": "applemusic://track/1842435082"
+      }
     },
     {
       "year": 2018,
@@ -143,7 +183,17 @@
       "uri_tidal": "tidal://track/95588758",
       "fun_fact_fr": "IJskoud illustre le talent de Nielson pour mêler R&B doux et paroles néerlandaises sincères. Sorti en 2018, le titre est devenu un moment définissant le pop néerlandais moderne.",
       "fun_fact_nl": "IJskoud laat Nielsons gave zien om vlotte R&B te mengen met oprechte Nederlandse teksten, waardoor een sfeer van emotionele coolness wordt gecreëerd. Het werd uitgebracht in 2018 en werd een bepalend moment in de moderne Nederpop. Nielson is een van de meest consistente hitmakers van Nederland.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "NLG901800010",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1435143697",
+        "de": "applemusic://track/1435143697",
+        "gb": "applemusic://track/1435143697",
+        "fr": "applemusic://track/1435143697",
+        "es": "applemusic://track/1435143697",
+        "nl": "applemusic://track/1435143697",
+        "it": "applemusic://track/1435143697"
+      }
     },
     {
       "year": 1970,
@@ -168,7 +218,17 @@
       "uri_tidal": "tidal://track/463394984",
       "fun_fact_fr": "Huilen Is Voor Jou Te Laat est un classique intemporel de 1970 qui a contribué à définir la musique pop en néerlandais. Corry en de Rekels étaient l'un des groupes les plus appréciés de leur époque.",
       "fun_fact_nl": "Huilen Is Voor Jou Te Laat is een tijdloze klassieker uit 1970 die de Nederlandstalige popmuziek heeft helpen definiëren. Corry en de Rekels waren een van de meest geliefde Nederlandstalig groepen van hun tijd en brachten rauwe emotie in elk optreden. Het nummer blijft een favoriet op Nederlandse retro-avonden.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "NLE320500092",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1842922620",
+        "de": "applemusic://track/1842922620",
+        "gb": "applemusic://track/1842922620",
+        "fr": "applemusic://track/1842922620",
+        "es": "applemusic://track/1842922620",
+        "nl": "applemusic://track/1842922620",
+        "it": "applemusic://track/1842922620"
+      }
     },
     {
       "year": 1994,
@@ -195,7 +255,17 @@
       "uri_tidal": "tidal://track/15759732",
       "fun_fact_fr": "Dromen Zijn Bedrog a été le tube révélateur de Marco Borsato en 1994 qui l'a propulsé à la célébrité du jour au lendemain. La chanson a dominé les charts et est devenue l'un des singles les plus vendus.",
       "fun_fact_nl": "Dromen Zijn Bedrog was Marco Borsato's doorbraakhit in 1994 en katapulteerde hem in één klap naar nationaal sterrendom. Het nummer stond bovenaan de Nederlandse hitlijsten en werd een van de best verkochte Nederlandse singles in de geschiedenis. Het vestigde Borsato als de onbetwiste koning van de Nederlandstalige pop.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "NLA319400194",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1893151548",
+        "de": "applemusic://track/1893151548",
+        "gb": "applemusic://track/1893151548",
+        "fr": "applemusic://track/1893151548",
+        "es": "applemusic://track/1893151548",
+        "nl": "applemusic://track/1893151548",
+        "it": "applemusic://track/1893151548"
+      }
     },
     {
       "year": 2017,
@@ -220,7 +290,17 @@
       "uri_tidal": "tidal://track/97909875",
       "fun_fact_fr": "Zoutelande est sans doute la chanson néerlandaise la plus appréciée du 21e siècle, une ode onirique au village côtier de Zoutelande. La collaboration entre BLØF et la chanteuse belge Geike Arnaert a créé un hymne estival magique.",
       "fun_fact_nl": "Zoutelande is misschien wel het meest geliefde Nederlandse lied van de 21e eeuw, een dromerige ode aan het gelijknamige Zeeuwse kustdorp. De samenwerking tussen BLØF en de Belgische zangeres Geike Arnaert creëerde een magisch zomers volkslied dat nu in elke strandtent in Nederland wordt gedraaid. Het is honderden miljoenen keren gestreamd.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "NLR4H1700015",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1441166227",
+        "de": "applemusic://track/1441166227",
+        "gb": "applemusic://track/1441166227",
+        "fr": "applemusic://track/1441166227",
+        "es": "applemusic://track/1441166227",
+        "nl": "applemusic://track/1695722712",
+        "it": "applemusic://track/1441166227"
+      }
     },
     {
       "year": 2005,
@@ -247,7 +327,17 @@
       "uri_tidal": "tidal://track/4786925",
       "fun_fact_fr": "Geef Mij Je Angst est l'une des ballades les plus tendres de Guus Meeuwis, une promesse sincère d'accompagner quelqu'un à travers ses peurs.",
       "fun_fact_nl": "Geef Mij Je Angst is een van Guus Meeuwis' meest tedere ballads, een oprechte belofte om iemand bij te staan in zijn diepste angsten. Meeuwis wordt geroemd om het schrijven van liedjes die intens persoonlijk aanvoelen, maar toch universeel toepasbaar zijn. Het werd een favoriet op Nederlandse bruiloften en emotionele gelegenheden.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "NLA270300458",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1875258669",
+        "de": "applemusic://track/1875258669",
+        "gb": "applemusic://track/1875258669",
+        "fr": "applemusic://track/1875258669",
+        "es": "applemusic://track/1875258669",
+        "nl": "applemusic://track/1875258669",
+        "it": "applemusic://track/1875258669"
+      }
     },
     {
       "year": 1995,
@@ -272,7 +362,17 @@
       "uri_tidal": "tidal://track/444236115",
       "fun_fact_fr": "Het Is Een Nacht est devenu un énorme succès en 1995 propulsant Guus Meeuwis à la célébrité nationale. La chanson est encore incontournable aux fêtes et festivals néerlandais 30 ans plus tard.",
       "fun_fact_nl": "Het Is Een Nacht werd een enorme hit in 1995, waarmee Guus Meeuwis nationale bekendheid verwierf met een feelgood feestlied over het leven voluit leven. Meer dan 30 jaar later is het nummer nog steeds niet weg te denken van Nederlandse feesten en festivals. Meeuwis brak later bezoekersrecords met uitverkochte zomershows in het Philips Stadion in Eindhoven.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "NLB590800101",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1875258698",
+        "de": "applemusic://track/1875258698",
+        "gb": "applemusic://track/1875258698",
+        "fr": "applemusic://track/1875258698",
+        "es": "applemusic://track/1875258698",
+        "nl": "applemusic://track/1875258698",
+        "it": "applemusic://track/1875258698"
+      }
     },
     {
       "year": 2012,
@@ -299,7 +399,17 @@
       "uri_tidal": "tidal://track/401526844",
       "fun_fact_fr": "Beauty & De Brains a fermement placé Nielson sur la carte du pop néerlandais en 2012 avec des jeux de mots habiles et un hook irrésistible.",
       "fun_fact_nl": "Beauty & De Brains zette Nielson in 2012 stevig op de Nederlandse popkaart met slimme woordspelingen en een onweerstaanbare hook. Het concept werd een cultureel referentiepunt in Nederland. Het liet Nielsons unieke vermogen zien om geestige, memorabele pop te maken.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "NLC282400420",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1781628171",
+        "de": "applemusic://track/1781628171",
+        "gb": "applemusic://track/1781628171",
+        "fr": "applemusic://track/1781628171",
+        "es": "applemusic://track/1781628171",
+        "nl": "applemusic://track/1781628171",
+        "it": "applemusic://track/1781628171"
+      }
     },
     {
       "year": 2018,
@@ -324,7 +434,17 @@
       "uri_tidal": "tidal://track/96012394",
       "fun_fact_fr": "Duurt Te Lang a établi Davina Michelle comme une force majeure du pop néerlandais en 2018 avec ses puissantes vocales sur un hymne de rupture émouvant.",
       "fun_fact_nl": "Met Duurt Te Lang vestigde Davina Michelle zich in 2018 als een belangrijke kracht in de Nederpop door haar krachtige zang te laten horen in een diep emotioneel breakup-anthem. Het nummer schoot naar de top van de hitlijsten en is tientallen miljoenen keren gestreamd. Ze wordt beschouwd als een van de meest getalenteerde zangeressen in de Nederlandse popgeschiedenis.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "NLSU31800036",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1440725466",
+        "de": "applemusic://track/1440725466",
+        "gb": "applemusic://track/1440725466",
+        "fr": "applemusic://track/1440725466",
+        "es": "applemusic://track/1440725466",
+        "nl": "applemusic://track/1440725466",
+        "it": "applemusic://track/1440725466"
+      }
     },
     {
       "year": 2007,
@@ -351,7 +471,17 @@
       "uri_tidal": "tidal://track/18787910",
       "fun_fact_fr": "Jij Bent Zo est devenu le tube signature de Jeroen van der Boom en 2007, conquérant le public de tout le monde néerlandophone avec son énergie charmante.",
       "fun_fact_nl": "Jij Bent Zo werd in 2007 Jeroen van der Booms bekendste hit, die met zijn charmante, feelgood energie publiek in de hele Nederlandstalige wereld veroverde. De aanstekelijke stijl van de Vlaamse zanger maakte van hem een geliefde grensoverschrijdende popact. Het nummer blijft een van de meest herkenbare Nederlandstalige popnummers van de jaren 2000.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "NLC280800033",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/276466510",
+        "de": "applemusic://track/276466510",
+        "gb": "applemusic://track/276466510",
+        "fr": "applemusic://track/276466510",
+        "es": "applemusic://track/276466510",
+        "nl": "applemusic://track/276466510",
+        "it": "applemusic://track/276466510"
+      }
     },
     {
       "year": 2018,
@@ -378,7 +508,17 @@
       "uri_tidal": "tidal://track/97493123",
       "fun_fact_fr": "Als Het Avond Is est l'une des chansons les plus appréciées de Suzan & Freek, un morceau tendre et intime parfait pour les soirées romantiques.",
       "fun_fact_nl": "Als Het Avond Is is een van de meest geliefde nummers van Suzan & Freek, een teder en intiem nummer dat perfect is voor rustige avonden en romantische momenten. Het duo staat steevast bovenaan de Nederlandse hitlijsten met moeiteloze harmonieën. Ze hebben romantische popmuziek in Nederland opnieuw gedefinieerd.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "NL1CK1800001",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1440301993",
+        "de": "applemusic://track/1440301993",
+        "gb": "applemusic://track/1440301993",
+        "fr": "applemusic://track/1440301993",
+        "es": "applemusic://track/1440301993",
+        "nl": "applemusic://track/1656111114",
+        "it": "applemusic://track/1440301993"
+      }
     },
     {
       "year": 1998,
@@ -405,7 +545,17 @@
       "uri_tidal": "tidal://track/99182586",
       "fun_fact_fr": "Zelfs Je Naam Is Mooi est l'une des plus belles chansons d'amour en néerlandais jamais écrites, par Henk Westbroek du groupe Klein Orkest.",
       "fun_fact_nl": "Zelfs Je Naam Is Mooi is een van de mooiste Nederlandstalige liefdesliedjes ooit geschreven, geschreven door Henk Westbroek van de band Klein Orkest. Met zijn eenvoudige maar diepgaande boodschap is het lied op talloze Nederlandse bruiloften gezongen. Het wordt beschouwd als een tijdloze standaard van Nederlandstalige sentimentele pop.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "NLA309800031",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1441967328",
+        "de": "applemusic://track/1441967328",
+        "gb": "applemusic://track/1441967328",
+        "fr": "applemusic://track/1441967328",
+        "es": "applemusic://track/1441967328",
+        "nl": "applemusic://track/1650311770",
+        "it": "applemusic://track/1441967328"
+      }
     },
     {
       "year": 2006,
@@ -428,7 +578,17 @@
       "uri_tidal": "tidal://track/4047953",
       "fun_fact_fr": "Rood est largement considérée comme la plus grande ballade de Marco Borsato et l'une des meilleures chansons pop en néerlandais jamais enregistrées.",
       "fun_fact_nl": "Rood wordt algemeen beschouwd als Marco Borsato's beste ballad en als een van de beste Nederlandstalige popsongs ooit opgenomen. Het nummer werd uitgebracht in 2006 en de rauwe emotionele kracht over verloren liefde stond wekenlang bovenaan de Nederlandse hitlijsten. Sindsdien is het een echte Nederlandse popstandaard geworden.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "NLUM70600609",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1353767419",
+        "de": "applemusic://track/1444279973",
+        "gb": "applemusic://track/1444279973",
+        "fr": "applemusic://track/1444279973",
+        "es": "applemusic://track/1444279973",
+        "nl": "applemusic://track/1444279973",
+        "it": "applemusic://track/1353767419"
+      }
     },
     {
       "year": 2021,
@@ -456,7 +616,17 @@
       "uri_tidal": "tidal://track/194325023",
       "fun_fact_fr": "Dat heb jij gedaan a annoncé MEAU comme un nouveau talent majeur du pop néerlandais en 2021. Le son rétro-pop entraînant en a immédiatement fait un tube.",
       "fun_fact_nl": "Dat heb jij gedaan kondigde MEAU aan als een belangrijk nieuw talent in de Nederpop toen het in 2021 een hit werd in de hitlijsten. Het upbeat retro-popgevoel van het nummer en MEAU's speelse uitvoering maakten het meteen een oorwurm. Het leverde MEAU wijdverspreide erkenning en meerdere award nominaties op.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "NL4FT2100006",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1713386244",
+        "de": "applemusic://track/1713386244",
+        "gb": "applemusic://track/1713386244",
+        "fr": "applemusic://track/1713386244",
+        "es": "applemusic://track/1713386244",
+        "nl": "applemusic://track/1713386244",
+        "it": "applemusic://track/1713386244"
+      }
     },
     {
       "year": 2021,
@@ -482,7 +652,17 @@
       "uri_tidal": "tidal://track/462791104",
       "fun_fact_fr": "Vluchtstrook est devenu un hymne estival feel-good en 2021 avec un groove irrésistible et des paroles insouciantes sur l'évasion du quotidien.",
       "fun_fact_nl": "Vluchtstrook werd in 2021 een feelgood zomerhymne met een onweerstaanbare groove en zorgeloze teksten over ontsnappen aan het alledaagse leven. Het Nederlandse DJ-trio levert consistent luchtige, dansbare hits die de Nederlandse radio domineren. Het is een van hun meest gestreamde tracks tot nu toe.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "NLS242100617",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1841541370",
+        "de": "applemusic://track/1841541370",
+        "gb": "applemusic://track/1841541370",
+        "fr": "applemusic://track/1841541370",
+        "es": "applemusic://track/1841541370",
+        "nl": "applemusic://track/1841541370",
+        "it": "applemusic://track/1841541370"
+      }
     },
     {
       "year": 2018,
@@ -509,7 +689,17 @@
       "uri_tidal": "tidal://track/100509268",
       "fun_fact_fr": "Hij Is Van Mij est devenu un énorme hit de club et de radio en 2018, combinant des paroles néerlandaises avec un beat moderne influencé par le trap.",
       "fun_fact_nl": "Hij Is Van Mij werd in 2018 een enorme club- en radiohit, door Nederlandstalige teksten te combineren met een moderne beat met trapinvloeden. De track liet zien dat Nederlandstalige pop fris en eigentijds kon klinken. Het werd een van de anthems van de Nederlandse festivalzomer 2018.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "NLZ541801715",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1445929048",
+        "de": "applemusic://track/1445929048",
+        "gb": "applemusic://track/1445929048",
+        "fr": "applemusic://track/1445929048",
+        "es": "applemusic://track/1445929048",
+        "nl": "applemusic://track/1445929048",
+        "it": "applemusic://track/1445929048"
+      }
     },
     {
       "year": 2007,
@@ -534,7 +724,17 @@
       "uri_tidal": "tidal://track/1201255",
       "fun_fact_fr": "Blijf Bij Mij honore l'esprit d'André Hazes Sr., l'une des figures les plus emblématiques de l'histoire musicale néerlandaise. La chanson capture la franchise émotionnelle qui a fait du nom Hazes un synonyme de soul néerlandais.",
       "fun_fact_nl": "Blijf Bij Mij eert de geest van André Hazes Sr., een van de meest iconische figuren uit de Nederlandse muziekgeschiedenis. Het nummer bevat de emotionele directheid die de naam Hazes synoniem maakte voor Nederlandse soul. Het werd een enorme hit en een eerbetoon aan een blijvende muzikale nalatenschap.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "NLQ270700007",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/714370809",
+        "de": "applemusic://track/714370809",
+        "gb": "applemusic://track/714370809",
+        "fr": "applemusic://track/714370809",
+        "es": "applemusic://track/714370809",
+        "nl": "applemusic://track/714370809",
+        "it": "applemusic://track/714370809"
+      }
     },
     {
       "year": 1996,
@@ -559,7 +759,17 @@
       "uri_tidal": "tidal://track/247491352",
       "fun_fact_fr": "Banger Hart est l'une des chansons les plus appréciées de Rob de Nijs, une tendre ballade sur un cœur plein de nostalgie. De Nijs est l'une des véritables légendes du pop néerlandais.",
       "fun_fact_nl": "Banger Hart is een van de meest geliefde liedjes van Rob de Nijs, een tedere ballade over een hart vol verlangen. De Nijs is een van de ware legendes van de Nederpop met een carrière die vijf decennia omspant en talloze nummer 1-hits. Het nummer laat zijn tijdloze vocale warmte op zijn best horen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "NLA270200279",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1643061994",
+        "de": "applemusic://track/1643061994",
+        "gb": "applemusic://track/1643061994",
+        "fr": "applemusic://track/1643061994",
+        "es": "applemusic://track/1643061994",
+        "nl": "applemusic://track/1650311926",
+        "it": "applemusic://track/1643061994"
+      }
     },
     {
       "year": 2022,
@@ -587,7 +797,17 @@
       "uri_tidal": "tidal://track/226199673",
       "fun_fact_fr": "Automatisch est une chanson pop onirique et synth qui est devenue l'une des sorties pop néerlandaises les plus distinctives de 2022.",
       "fun_fact_nl": "Automatisch is een dromerig, met synths doordrenkt popliedje dat uitgroeide tot een van de meest kenmerkende Nederlandse popreleases van 2022. FLEMMING's etherische stem en sfeervolle productie onderscheidden haar in het Nederlandse poplandschap. Het nummer verstevigde haar reputatie als een van de meest originele stemmen in de Nederlandse muziek.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "NLZ292200042",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1620891643",
+        "de": "applemusic://track/1620891643",
+        "gb": "applemusic://track/1620891643",
+        "fr": "applemusic://track/1620891643",
+        "es": "applemusic://track/1620891643",
+        "nl": "applemusic://track/1620891643",
+        "it": "applemusic://track/1620891643"
+      }
     },
     {
       "year": 2015,
@@ -614,7 +834,17 @@
       "uri_tidal": "tidal://track/45058470",
       "fun_fact_fr": "Parijs est devenu un méga-succès inattendu en 2015 lorsque Kenny B a réinventé le hit surinamais de 1982 de son père. Le titre nostalgique et estival a dominé les charts néerlandais pendant des semaines.",
       "fun_fact_nl": "Parijs werd in 2015 een onverwachte megahit toen Kenny B de Surinaamse hit van zijn vader uit 1982 een moderne draai gaf. Het nostalgische, zomerse nummer stond wekenlang bovenaan de Nederlandse hitlijsten en is een van de meest hartverwarmende hitlijsten in de recente Nederlandse muziekgeschiedenis.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "NLG661500188",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1560863314",
+        "de": "applemusic://track/1560863314",
+        "gb": "applemusic://track/1560863314",
+        "fr": "applemusic://track/1560863314",
+        "es": "applemusic://track/1560863314",
+        "nl": "applemusic://track/1560863314",
+        "it": "applemusic://track/1560863314"
+      }
     },
     {
       "year": 2020,
@@ -639,7 +869,17 @@
       "uri_tidal": "tidal://track/153048897",
       "fun_fact_fr": "Door De Wind est devenu l'un des hits néerlandais les plus émouvants de 2020, mettant en valeur l'incroyable étendue vocale de Miss Montreal.",
       "fun_fact_nl": "Door De Wind werd een van de meest emotionele Nederlandse hits van 2020, waarin het ongelooflijke stembereik van Miss Montreal te horen is op een nummer over meegesleurd worden door het leven. Ze heeft zichzelf gevestigd als een van de krachtigste vrouwenstemmen in de Nederlandse pop. Het nummer resoneerde diep tijdens een turbulent jaar.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "NLSU32000019",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1565158283",
+        "de": "applemusic://track/1565158283",
+        "gb": "applemusic://track/1565158283",
+        "fr": "applemusic://track/1565158283",
+        "es": "applemusic://track/1565158283",
+        "nl": "applemusic://track/1565158283",
+        "it": "applemusic://track/1565158283"
+      }
     },
     {
       "year": 2022,
@@ -666,7 +906,17 @@
       "uri_tidal": "tidal://track/441794453",
       "fun_fact_fr": "Engelbewaarder est une belle ballade de 2022 de Marco Schuitmaker qui reflète le goût néerlandais pour un pop mélodique et émotionnellement sincère.",
       "fun_fact_nl": "Engelbewaarder is een prachtige 2022 ballad van Marco Schuitmaker die de Nederlandse smaak voor emotioneel oprechte, melodieuze pop weerspiegelt. Schuitmaker staat bekend om zijn warme stem en diep persoonlijke songwriting. Het nummer werd een favoriet op de Nederlandse radio en streamingplatforms.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "NLCN52200061",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1819917156",
+        "de": "applemusic://track/1819917156",
+        "gb": "applemusic://track/1819917156",
+        "fr": "applemusic://track/1819917156",
+        "es": "applemusic://track/1819917156",
+        "nl": "applemusic://track/1819917156",
+        "it": "applemusic://track/1819917156"
+      }
     },
     {
       "year": 2021,
@@ -691,7 +941,17 @@
       "uri_tidal": "tidal://track/462766020",
       "fun_fact_fr": "Blijven Slapen est l'un des titres les plus appréciés de Snelle, une chanson douce et intime sur le désir de rester avec quelqu'un qu'on aime.",
       "fun_fact_nl": "Blijven Slapen is een van Snelle's meest geliefde nummers, een zacht en intiem liedje over bij iemand willen blijven van wie je houdt. Snelle is een van de succesvolste Nederlandse artiesten van de vroege jaren 2020, bekend om het mengen van oprechte teksten met toegankelijke popfolk. Het verzamelde tientallen miljoenen streams.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "NLR1T2100008",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1841967748",
+        "de": "applemusic://track/1841967748",
+        "gb": "applemusic://track/1841967748",
+        "fr": "applemusic://track/1841967748",
+        "es": "applemusic://track/1841967748",
+        "nl": "applemusic://track/1842615775",
+        "it": "applemusic://track/1841967748"
+      }
     },
     {
       "year": 2019,
@@ -714,7 +974,17 @@
       "uri_tidal": "tidal://track/111365858",
       "fun_fact_fr": "Blauwe Dag est une chanson pop tendre et mélancolique qui montre la profondeur émotionnelle de Suzan & Freek.",
       "fun_fact_nl": "Blauwe Dag is een teder, melancholisch popliedje dat het diepere emotionele bereik van Suzan & Freek laat zien. Het nummer over een blauwe, trieste dag vond weerklank bij luisteraars vanwege de eerlijke kwetsbaarheid. Het werd een van hun meest gestreamde ballads.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "NL1CK1900001",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1468914247",
+        "de": "applemusic://track/1468914247",
+        "gb": "applemusic://track/1468914247",
+        "fr": "applemusic://track/1468914247",
+        "es": "applemusic://track/1468914247",
+        "nl": "applemusic://track/1468914247",
+        "it": "applemusic://track/1468914247"
+      }
     },
     {
       "year": 2013,
@@ -739,7 +1009,17 @@
       "uri_tidal": "tidal://track/401526852",
       "fun_fact_fr": "Hoe est un morceau contemplatif dans lequel Nielson explore la confusion et la douleur de la rupture.",
       "fun_fact_nl": "Hoe is een contemplatieve track waarin Nielson de verwarring en pijn van liefdesverdriet verkent met zijn kenmerkende ingetogen stijl. Het werd uitgebracht in 2013 en hielp hem te vestigen als een echte songwriter met emotionele diepgang die verder gaat dan popformules. Het nummer blijft een fanfavoriet vanwege de rauwe eerlijkheid.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "NLC282400430",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1781781692",
+        "de": "applemusic://track/1781781692",
+        "gb": "applemusic://track/1781781692",
+        "fr": "applemusic://track/1781781692",
+        "es": "applemusic://track/1781781692",
+        "nl": "applemusic://track/1781781692",
+        "it": "applemusic://track/1781781692"
+      }
     },
     {
       "year": 2012,
@@ -764,7 +1044,17 @@
       "uri_tidal": "tidal://track/15755301",
       "fun_fact_fr": "Bagagedrager est une chanson hip-hop romantique sur le fait de rouler sur le porte-bagages d'un vélo avec quelqu'un qu'on aime — une image typiquement néerlandaise.",
       "fun_fact_nl": "Bagagedrager is een romantisch en nostalgisch hiphopnummer over fietsen met iemand van wie je houdt - een typisch Nederlands beeld. Het werd uitgebracht in 2012 en werd een enorme hit en een van de meest charmante Nederlandse liefdesliedjes van het decennium. De fietsmetafoor sloot perfect aan bij de Nederlandse cultuur.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "NLG661100433",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1442705659",
+        "de": "applemusic://track/1442705659",
+        "gb": null,
+        "fr": "applemusic://track/1442705659",
+        "es": "applemusic://track/1442705659",
+        "nl": "applemusic://track/1442705659",
+        "it": "applemusic://track/1442705659"
+      }
     },
     {
       "year": 2020,
@@ -789,7 +1079,17 @@
       "uri_tidal": "tidal://track/266518609",
       "fun_fact_fr": "Nu Wij Niet Meer Praten est devenu viral en 2020 avec des paroles déchirantes sur le silence après la fin d'une relation.",
       "fun_fact_nl": "Nu Wij Niet Meer Praten ging in 2020 viral met hartverscheurende teksten over de stilte na het einde van een relatie. Jaap Reesema maakt naast Snelle en Suzan & Freek deel uit van de nieuwe generatie die de Nederpop opnieuw definieert. Het nummer verzamelde meer dan 100 miljoen streams en werd een van de bepalende Nederlandse popsongs van het pandemische tijdperk.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "BEK012000316",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1842496598",
+        "de": "applemusic://track/1842496598",
+        "gb": "applemusic://track/1842496598",
+        "fr": "applemusic://track/1842496598",
+        "es": "applemusic://track/1842496598",
+        "nl": "applemusic://track/1842496598",
+        "it": "applemusic://track/1842496598"
+      }
     },
     {
       "year": 2022,
@@ -814,7 +1114,17 @@
       "uri_tidal": "tidal://track/256064009",
       "fun_fact_fr": "Wat Wil Je Van Mij a propulsé Metejoor au sommet des charts néerlandais et belges en 2022 avec son énergie contagieuse.",
       "fun_fact_nl": "Wat Wil Je Van Mij bracht Metejoor in 2022 naar de top van de Nederlandse en Belgische hitlijsten met aanstekelijke energie en een aanstekelijk refrein. Metejoor is een van de meest opwindende Vlaamse popartiesten van zijn generatie, geliefd om zijn authentieke en jeugdige stijl. Het nummer werd een hymne voor de moderne liefde.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "BEC432200004",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1703024489",
+        "de": "applemusic://track/1703024489",
+        "gb": "applemusic://track/1703024489",
+        "fr": "applemusic://track/1703024489",
+        "es": "applemusic://track/1703024489",
+        "nl": "applemusic://track/1689665217",
+        "it": "applemusic://track/1703024489"
+      }
     },
     {
       "year": 1993,
@@ -841,7 +1151,17 @@
       "uri_tidal": "tidal://track/196779613",
       "fun_fact_fr": "Ik Wil Niet Dat Je Liegt est une ballade profondément émouvante de Paul de Leeuw, montrant le côté musical sérieux d'un entertaineur néerlandais bien-aimé.",
       "fun_fact_nl": "Ik Wil Niet Dat Je Liegt is een diep emotionele ballade van Paul de Leeuw, die de serieuze muzikale kant laat zien van een geliefde Nederlandse entertainer die vooral bekend staat om zijn komedie. Het werd uitgebracht in 1993 en werd een van zijn meest geliefde opnames. De Leeuw's buitengewone stem verheft deze sentimentele klassieker.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "NLD450600005",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1650366247",
+        "de": "applemusic://track/1650366247",
+        "gb": "applemusic://track/1650366247",
+        "fr": "applemusic://track/1650366247",
+        "es": "applemusic://track/1650366247",
+        "nl": "applemusic://track/1650366247",
+        "it": "applemusic://track/1650366247"
+      }
     },
     {
       "year": 1998,
@@ -868,7 +1188,17 @@
       "uri_tidal": "tidal://track/22126541",
       "fun_fact_fr": "Niet Of Nooit Geweest est l'une des chansons pop néerlandaises les plus enchanteresses de la fin des années 1990, un regard nostalgique sur l'amour de jeunesse.",
       "fun_fact_nl": "Niet Of Nooit Geweest is een van de meest betoverende Nederlandstalige popsongs van eind jaren negentig, een weemoedige blik op jeugdliefde en herinneringen. Acda en de Munnik hadden het talent om melancholie te combineren met warme, meezingbare melodieën. Het nummer wordt nog steeds regelmatig gedraaid op de Nederlandse radio.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "NLD049801001",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/698746430",
+        "de": "applemusic://track/272537132",
+        "gb": "applemusic://track/272537132",
+        "fr": "applemusic://track/272537132",
+        "es": "applemusic://track/272537132",
+        "nl": "applemusic://track/272537132",
+        "it": "applemusic://track/272537132"
+      }
     },
     {
       "year": 1971,
@@ -896,7 +1226,17 @@
       "uri_tidal": "tidal://track/96046943",
       "fun_fact_fr": "Manuela a été l'une des plus grandes chansons pop en néerlandais de 1971, capturant le romantisme méditerranéen.",
       "fun_fact_nl": "Manuela was een van de grootste Nederlandstalige popsongs van 1971, met mediterrane romantiek in een duidelijk Nederlandstalige verpakking. Jacques Herb was een populaire Nederlandse entertainer aan het begin van de jaren 1970. Het nummer werd een tijdloze klassieker waar meerdere generaties Nederlandse muziekliefhebbers mee opgroeiden.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "NLE320800151",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1378614864",
+        "de": "applemusic://track/1378614864",
+        "gb": "applemusic://track/1378614864",
+        "fr": "applemusic://track/1378614864",
+        "es": "applemusic://track/1378614864",
+        "nl": "applemusic://track/479859326",
+        "it": "applemusic://track/1378614864"
+      }
     },
     {
       "year": 1973,
@@ -923,7 +1263,17 @@
       "uri_tidal": "tidal://track/462804917",
       "fun_fact_fr": "'T Is Weer Voorbij Die Mooie Zomer capture parfaitement le sentiment doux-amer de la fin de l'été et est devenu un favori pérenne de la radio néerlandaise.",
       "fun_fact_nl": "T Is Weer Voorbij Die Mooie Zomer vangt perfect het bitterzoete gevoel van het einde van de zomer en is sinds de release in 1973 elke herfst een vaste Nederlandse radiofavoriet. Gerard Cox was een van de populairste Nederlandse entertainers van de jaren zeventig, die komedie mengde met oprecht oprechte muziek.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "NLS241500562",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1843745073",
+        "de": "applemusic://track/1843745073",
+        "gb": "applemusic://track/1843745073",
+        "fr": "applemusic://track/1843745073",
+        "es": "applemusic://track/1843745073",
+        "nl": "applemusic://track/1843745073",
+        "it": "applemusic://track/1843745073"
+      }
     },
     {
       "year": 1971,
@@ -950,7 +1300,17 @@
       "uri_tidal": "tidal://track/24884766",
       "fun_fact_fr": "Waarheen, Waarvoor était la candidature néerlandaise à l'Eurovision 1969. Mieke Telkamp était l'une des chanteuses néerlandaises les plus célèbres des années 1960.",
       "fun_fact_nl": "Waarheen, Waarvoor was de Nederlandse inzending voor Eurovisie 1969 en vertegenwoordigde de vraag van een generatie naar de richting van het leven in turbulente tijden. Mieke Telkamp was een van de bekendste Nederlandse zangeressen van de jaren zestig. Het lied werd een blijvende Nederlandse klassieker ver buiten de Eurovisiecontext.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "NLG620428775",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/366419129",
+        "de": "applemusic://track/366419129",
+        "gb": "applemusic://track/366419129",
+        "fr": "applemusic://track/366419129",
+        "es": "applemusic://track/366419129",
+        "nl": "applemusic://track/366419129",
+        "it": "applemusic://track/366419129"
+      }
     },
     {
       "year": 2007,
@@ -977,7 +1337,17 @@
       "uri_tidal": "tidal://track/2887471",
       "fun_fact_fr": "Alles Is Liefde était la chanson titre d'un film de Noël néerlandais très populaire en 2007 et est devenu l'une des chansons les plus emblématiques de BLØF.",
       "fun_fact_nl": "Alles Is Liefde was de titelsong van een enorm succesvolle Nederlandse kerstfilm in 2007 en werd een van BLØF's meest iconische nummers. De boodschap van universele liefde greep de kerstsfeer van de film en vond weerklank bij miljoenen Nederlandse kijkers. Sindsdien is het een geliefde Nederlandse kerstsong geworden.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "NLA270700407",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/806255921",
+        "de": "applemusic://track/806255921",
+        "gb": "applemusic://track/806255921",
+        "fr": "applemusic://track/806255921",
+        "es": "applemusic://track/806255921",
+        "nl": "applemusic://track/806255921",
+        "it": "applemusic://track/806255921"
+      }
     },
     {
       "year": 1967,
@@ -1005,7 +1375,17 @@
       "uri_tidal": "tidal://track/26119982",
       "fun_fact_fr": "Waarom Heb Jij Me Laten Staan? est un classique néerlandais apprécié de 1967 sur l'abandon et le chagrin d'amour.",
       "fun_fact_nl": "Waarom Heb Jij Me Laten Staan? is een geliefde Nederlandse klassieker uit 1967 over verlating en liefdesverdriet, gebracht met de emotionele directheid die typerend is voor Nederlandstalig pop uit de jaren zestig. Wim van Gennip en De Heikrekels waren een van de populairste Nederlandse zanggroepen uit hun tijd.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "NLA340200191",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/315429273",
+        "de": "applemusic://track/315429273",
+        "gb": "applemusic://track/315429273",
+        "fr": "applemusic://track/315429273",
+        "es": "applemusic://track/315429273",
+        "nl": "applemusic://track/315429273",
+        "it": "applemusic://track/315429273"
+      }
     },
     {
       "year": 2020,
@@ -1032,7 +1412,17 @@
       "uri_tidal": "tidal://track/127609494",
       "fun_fact_fr": "Het Is Al Laat Toch est une chanson indie-pop douce-amère de Racoon qui capture le sentiment de veiller tard.",
       "fun_fact_nl": "Het Is Al Laat Toch is een bitterzoet indie-popliedje dat het gevoel weergeeft van laat opblijven en niet willen dat een goed moment eindigt. Racoon is een van de meest geliefde Nederlandse rockbands, bekend om hun oprechte mix van Nederlandse teksten en rockgevoeligheid. Het nummer werd een vaste waarde op de Nederlandse indieradio.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "NLX4G2000001",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1494108727",
+        "de": "applemusic://track/1494108727",
+        "gb": "applemusic://track/1494108727",
+        "fr": "applemusic://track/1494108727",
+        "es": "applemusic://track/1494108727",
+        "nl": "applemusic://track/1494108727",
+        "it": "applemusic://track/1494108727"
+      }
     },
     {
       "year": 1965,
@@ -1081,7 +1471,17 @@
       "uri_tidal": "tidal://track/85371265",
       "fun_fact_fr": "Afscheid Nemen Bestaat Niet est l'une des chansons émotionnellement les plus puissantes du catalogue de Marco Borsato, sur l'impossibilité de vraiment lâcher prise.",
       "fun_fact_nl": "Afscheid Nemen Bestaat Niet is een van de meest emotioneel krachtige nummers uit de catalogus van Marco Borsato, een nummer over de onmogelijkheid om echt los te laten dat in 2003 een enorme hit werd. Het blijft een van de meest gespeelde Nederlandse popsongs aller tijden en een favoriet voor mensen die te maken hebben met verlies.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "NLE070300351",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1353767373",
+        "de": "applemusic://track/1353767373",
+        "gb": "applemusic://track/1353767373",
+        "fr": "applemusic://track/1353767373",
+        "es": "applemusic://track/1353767373",
+        "nl": "applemusic://track/1444394295",
+        "it": "applemusic://track/1353767373"
+      }
     },
     {
       "year": 2021,
@@ -1104,7 +1504,17 @@
       "uri_tidal": "tidal://track/174152918",
       "fun_fact_fr": "Goud est une joyeuse célébration de l'amour durable de Suzan & Freek, sortie en 2021. C'est devenu l'un de leurs plus grands succès commerciaux et un hymne de mariage incontournable.",
       "fun_fact_nl": "Goud is een vrolijke viering van blijvende liefde van Suzan & Freek, uitgebracht in 2021. Het werd een van hun grootste commerciële successen en een hymne voor bruiloften in heel Nederland. De prachtige harmonieën van het duo schitteren vooral op dit opbeurende nummer.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "NL1CK2100001",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1586787695",
+        "de": "applemusic://track/1586787695",
+        "gb": "applemusic://track/1586787695",
+        "fr": "applemusic://track/1586787695",
+        "es": "applemusic://track/1586787695",
+        "nl": "applemusic://track/1591459079",
+        "it": "applemusic://track/1586787695"
+      }
     },
     {
       "year": 2019,
@@ -1131,7 +1541,17 @@
       "uri_tidal": "tidal://track/463286865",
       "fun_fact_fr": "Reünie raconte l'histoire d'une rencontre inattendue avec un ex lors d'une réunion scolaire — un thème identifiable qui en a fait un hit viral en 2019.",
       "fun_fact_nl": "Reünie vertelt het verhaal van een onverwachte ontmoeting met een ex op een schoolreünie - een diep relateerbaar thema waardoor het in 2019 een virale hit werd. Snelle's filmische vertelstijl geeft het nummer een levendige, filmische kwaliteit. Het werd een van de meest opvallende Nederlandse nummers van het jaar.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "NLR1T1900097",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1842616935",
+        "de": "applemusic://track/1842616935",
+        "gb": "applemusic://track/1842616935",
+        "fr": "applemusic://track/1842616935",
+        "es": "applemusic://track/1842616935",
+        "nl": "applemusic://track/1843178313",
+        "it": "applemusic://track/1842616935"
+      }
     },
     {
       "year": 2022,
@@ -1154,7 +1574,17 @@
       "uri_tidal": "tidal://track/444229673",
       "fun_fact_fr": "Paracetamollen est devenu l'une des chansons pop néerlandaises les plus commentées de 2022 avec sa vision astucieuse du chagrin d'amour comme une maladie physique.",
       "fun_fact_nl": "Paracetamollen werd een van de meest besproken Nederlandse popsongs van 2022 met zijn geestige, donker humoristische kijk op liefdesverdriet als lichamelijke ziekte. FLEMMING's scherpe humor in combinatie met haar atmosferische geluid maakten het meteen een opvallende verschijning. Het nummer hield FLEMMING aan de top van de Nederlandse hitlijsten.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "NLZ292200160",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1822761579",
+        "de": "applemusic://track/1822761579",
+        "gb": "applemusic://track/1822761579",
+        "fr": "applemusic://track/1822761579",
+        "es": "applemusic://track/1822761579",
+        "nl": "applemusic://track/1822761579",
+        "it": "applemusic://track/1822761579"
+      }
     },
     {
       "year": 1997,
@@ -1208,7 +1638,17 @@
       "uri_tidal": "tidal://track/87759258",
       "fun_fact_fr": "Sammy est une chanson théâtrale et profondément émouvante de Ramses Shaffy, l'une des figures les plus uniques de l'histoire musicale néerlandaise.",
       "fun_fact_nl": "Sammy is een theatraal en diep ontroerend nummer van Ramses Shaffy, een van de meest unieke en excentrieke figuren uit de Nederlandse muziekgeschiedenis. Het werd uitgebracht in 1966 en vertelt het verhaal van een eenzame zwerver met een buitengewoon mededogen. Shaffy wordt beschouwd als een ware legende en visionair van het Nederlandse chanson.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "NLA306600011",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1374383613",
+        "de": "applemusic://track/1374383613",
+        "gb": "applemusic://track/1374383613",
+        "fr": "applemusic://track/1374383613",
+        "es": "applemusic://track/1374383613",
+        "nl": "applemusic://track/1442427329",
+        "it": "applemusic://track/1374383613"
+      }
     },
     {
       "year": 2012,
@@ -1235,7 +1675,17 @@
       "uri_tidal": "tidal://track/425165543",
       "fun_fact_fr": "Oceaan est la chanson la plus épique de Racoon, une puissante ballade rock qui monte de chuchotements intimes à des vagues de son fracassantes.",
       "fun_fact_nl": "Oceaan is Racoons meest epische en meeslepende nummer, een krachtige rockballad die zich opbouwt van intiem gefluister tot verpletterende geluidsgolven. Het werd uitgebracht in 2012 en werd hun signatuurnummer en een van de grootste Nederlandse rockanthems van het decennium. Het blijft een van de meest gedraaide Nederlandse rocknummers op de radio.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "NLUM71200154",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1803362903",
+        "de": "applemusic://track/1803362903",
+        "gb": "applemusic://track/1803362903",
+        "fr": "applemusic://track/1803362903",
+        "es": "applemusic://track/1803362903",
+        "nl": "applemusic://track/603584774",
+        "it": "applemusic://track/1803362903"
+      }
     },
     {
       "year": 2004,
@@ -1260,7 +1710,17 @@
       "uri_tidal": "tidal://track/15752313",
       "fun_fact_fr": "Cet enregistrement live capture Marco Borsato combinant deux chansons bien-aimées en un moment de concert inoubliable.",
       "fun_fact_nl": "Op deze live-opname combineert Marco Borsato twee geliefde nummers in een onvergetelijk concertmoment. Borsato's live-optredens waren legendarisch in Nederland en verkochten steevast enorme arena's uit. De rauwe emotie van zijn live stem heeft het publiek tot tranen toe bewogen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "NLE070400101",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1442951099",
+        "de": "applemusic://track/1442951099",
+        "gb": "applemusic://track/1442951099",
+        "fr": "applemusic://track/1442951099",
+        "es": "applemusic://track/1442951099",
+        "nl": "applemusic://track/1442951099",
+        "it": "applemusic://track/1442951099"
+      }
     },
     {
       "year": 2004,
@@ -1285,7 +1745,17 @@
       "uri_tidal": "tidal://track/142785516",
       "fun_fact_fr": "Ik Ben Je Zat a été l'une des chansons hip-hop néerlandaises les plus réussies des années 2000, avec Ali B livrant des paroles vives et spirituelles.",
       "fun_fact_nl": "Ik Ben Je Zat was een van de succesvolste Nederlandstalige hiphopnummers van de jaren 2000, met scherpe, geestige teksten van Ali B over een vermoeide relatie. Ali B was een van de pioniers die bewees dat Nederlandstalige hiphop een mainstream publiek kon bereiken. Het nummer werd een culturele toetssteen voor een generatie.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "NLMN20400007",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1515258396",
+        "de": "applemusic://track/1515258396",
+        "gb": "applemusic://track/1515258396",
+        "fr": "applemusic://track/1515258396",
+        "es": "applemusic://track/1515258396",
+        "nl": "applemusic://track/1515258396",
+        "it": "applemusic://track/1515258396"
+      }
     },
     {
       "year": 2019,
@@ -1311,7 +1781,17 @@
       "uri_tidal": "tidal://track/109240336",
       "fun_fact_fr": "Moment est un titre estival et feel-good qui exemplifie le son de Kris Kross Amsterdam — chaleureux, léger et instantanément dansant.",
       "fun_fact_nl": "Moment is een zomers, feelgoodnummer dat het Amsterdamse geluid van Kris Kross illustreert - warm, luchtig en direct dansbaar. Uitgebracht in 2019, werd het een van hun meest gestreamde nummers en een nietje voor de radio dat het gevoel van leven in een perfect moment vastlegt.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "NLG661900400",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1463382212",
+        "de": "applemusic://track/1463382212",
+        "gb": "applemusic://track/1463382212",
+        "fr": "applemusic://track/1463382212",
+        "es": "applemusic://track/1463382212",
+        "nl": "applemusic://track/1463382212",
+        "it": "applemusic://track/1463382212"
+      }
     },
     {
       "year": 1977,
@@ -1338,7 +1818,17 @@
       "uri_tidal": "tidal://track/81957366",
       "fun_fact_fr": "Smurfenlied est peut-être la chanson en néerlandais la plus célèbre internationalement jamais enregistrée, arrivant numéro un dans toute l'Europe en 1977.",
       "fun_fact_nl": "Smurfenlied is misschien wel het meest internationaal bekende Nederlandstalige liedje ooit, dat in 1977 in heel Europa op nummer één kwam. Vader Abrahams novelty hit is vertaald in tientallen talen en liet generaties kinderen wereldwijd kennismaken met De Smurfen. Het blijft een van de best verkochte Nederlandse singles aller tijden.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "NLE320600008",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1563716072",
+        "de": "applemusic://track/1563716072",
+        "gb": "applemusic://track/1563716072",
+        "fr": "applemusic://track/1563716072",
+        "es": "applemusic://track/1563716072",
+        "nl": "applemusic://track/488387973",
+        "it": "applemusic://track/1563716072"
+      }
     },
     {
       "year": 1997,
@@ -1365,7 +1855,17 @@
       "uri_tidal": "tidal://track/196779532",
       "fun_fact_fr": "'k Heb Je Lief est la chanson d'amour la plus tendre de Paul de Leeuw, une déclaration sincère qui est devenue l'une des ballades néerlandaises les plus jouées des années 1990.",
       "fun_fact_nl": "'k Heb Je Lief is Paul de Leeuws meest tedere liefdesliedje, een oprechte liefdesverklaring die een van de meest gespeelde Nederlandse ballades van de jaren negentig werd. De Leeuws vermogen om te bewegen tussen komedie en oprechte emotie is hier op zijn best. Het nummer is op talloze Nederlandse bruiloften gespeeld.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "NLD450600007",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1585392337",
+        "de": "applemusic://track/1585392337",
+        "gb": "applemusic://track/1585392337",
+        "fr": "applemusic://track/1585392337",
+        "es": "applemusic://track/1585392337",
+        "nl": "applemusic://track/1585392337",
+        "it": "applemusic://track/1585392337"
+      }
     },
     {
       "year": 1995,
@@ -1392,7 +1892,17 @@
       "uri_tidal": "tidal://track/169621438",
       "fun_fact_fr": "Ademnood a été un succès surprenant en 1995 du duo mère-fille Linda Roos & Jessica, combinant pop et touche sentimentale typiquement néerlandaise.",
       "fun_fact_nl": "Ademnood was een verrassende hit uit 1995 van het moeder-dochter duo Linda Roos & Jessica, een combinatie van pop met een duidelijk Nederlands sentimenteel tintje. Het nummer sloeg aan vanwege de emotionele rauwheid en de unieke chemie tussen de twee zangeressen. Het blijft een van de meest charmante Nederlandse popsamenwerkingen van het decennium.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "NLA959500136",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1548680688",
+        "de": "applemusic://track/1548680688",
+        "gb": "applemusic://track/1548680688",
+        "fr": "applemusic://track/1548680688",
+        "es": "applemusic://track/1548680688",
+        "nl": "applemusic://track/1548680688",
+        "it": "applemusic://track/1548680688"
+      }
     },
     {
       "year": 2001,
@@ -1419,7 +1929,17 @@
       "uri_tidal": "tidal://track/54605554",
       "fun_fact_fr": "Zij Maakt Het Verschil est un hommage touchant à une femme importante dans la vie, sorti en 2001 par De Poema's.",
       "fun_fact_nl": "Zij Maakt Het Verschil is een ontroerend eerbetoon aan een belangrijke vrouw in iemands leven, uitgebracht in 2001 door De Poema's. De warme, meezingbare kwaliteit maakte het een vaste waarde op de Nederlandse radio en een favoriet tijdens familiebijeenkomsten. De Poema's stonden bekend om hun toegankelijke, feelgood Nederpopstijl.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "NLD010100163",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/698746471",
+        "de": "applemusic://track/698746471",
+        "gb": "applemusic://track/698746471",
+        "fr": "applemusic://track/698746471",
+        "es": "applemusic://track/698746471",
+        "nl": "applemusic://track/698746471",
+        "it": "applemusic://track/698746471"
+      }
     },
     {
       "year": 2006,
@@ -1446,7 +1966,17 @@
       "uri_tidal": "tidal://track/69775518",
       "fun_fact_fr": "Als De Morgen Is Gekomen est l'une des ballades les plus appréciées de Jan Smit, une chanson d'espoir devenue incontournable sur la radio néerlandaise.",
       "fun_fact_nl": "Als De Morgen Is Gekomen is een van Jan Smit's meest geliefde ballads, een lied over hoop en een nieuw begin dat na de release in 2006 een vaste waarde werd op de Nederlandse radio. Jan Smit is een van de meest succesvolle Nederlandse popacts van zijn generatie. Het nummer laat zijn warme, krachtige stem op zijn best horen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "NLUR71700083",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1303580026",
+        "de": "applemusic://track/1303580026",
+        "gb": "applemusic://track/1303580026",
+        "fr": "applemusic://track/1303580026",
+        "es": "applemusic://track/1303580026",
+        "nl": "applemusic://track/1303580026",
+        "it": "applemusic://track/1303580026"
+      }
     },
     {
       "year": 1995,
@@ -1473,7 +2003,17 @@
       "uri_tidal": "tidal://track/1470374",
       "fun_fact_fr": "Passie est la chanson signature de Clouseau, le légendaire duo pop flamand des frères Koen et Arne Wauters. Sortie en 1995, elle est devenue l'un des plus grands hits pop flamands de tous les temps.",
       "fun_fact_nl": "Passie is het signatuurnummer van Clouseau, het legendarische Vlaamse popduo van de broers Koen en Arne Wauters. Het werd uitgebracht in 1995 en werd een van de grootste Vlaamse pophits aller tijden en een grensoverschrijdende favoriet in de Nederlandstalige wereld. Het blijft een gepassioneerde liefdesverklaring die het publiek nog steeds weet te ontroeren.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "BEI019500408",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1273804148",
+        "de": "applemusic://track/1794283425",
+        "gb": "applemusic://track/1794283425",
+        "fr": "applemusic://track/1794283425",
+        "es": "applemusic://track/1794283425",
+        "nl": "applemusic://track/1794283425",
+        "it": "applemusic://track/1794283425"
+      }
     },
     {
       "year": 2017,
@@ -1525,7 +2065,17 @@
       "uri_tidal": "tidal://track/2278553",
       "fun_fact_fr": "Onderweg a été une chanson pop néerlandaise appréciée de 2000 capturant un moment d'errance juvénile et de découverte de soi.",
       "fun_fact_nl": "Onderweg is een geliefde Nederlandse popsong uit 2000 die een moment van jeugdige omzwervingen en zelfontdekking vastlegde. Abel was een van de opmerkelijke Nederlandse singer-songwriters van begin jaren 2000, die persoonlijke verhalen combineerde met toegankelijke popmelodieën. Het nummer werd een radiofavoriet voor een generatie die haar weg zocht.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "NLD329900018",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/61185070",
+        "de": "applemusic://track/61185070",
+        "gb": "applemusic://track/61185070",
+        "fr": "applemusic://track/61185070",
+        "es": "applemusic://track/61185070",
+        "nl": "applemusic://track/61185070",
+        "it": "applemusic://track/61185070"
+      }
     },
     {
       "year": 1997,
@@ -1550,7 +2100,17 @@
       "uri_tidal": "tidal://track/13340946",
       "fun_fact_fr": "Wereld Zonder Jou est une ballade classique de Borsato de 1997 sur le vide inimaginable sans un être cher.",
       "fun_fact_nl": "Wereld Zonder Jou is een klassieke ballade van Borsato uit 1997 over de onvoorstelbare leegte van het leven zonder een geliefde. Het werd uitgebracht tijdens zijn commerciële piekperiode en werd een van zijn meest geliefde nummers. De emotionele kracht is typisch Marco Borsato.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "NLA319600427",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1444144379",
+        "de": "applemusic://track/1444144379",
+        "gb": "applemusic://track/1444144379",
+        "fr": "applemusic://track/1444144379",
+        "es": "applemusic://track/1444144379",
+        "nl": "applemusic://track/1444144379",
+        "it": "applemusic://track/1444144379"
+      }
     },
     {
       "year": 1995,
@@ -1575,7 +2135,17 @@
       "uri_tidal": "tidal://track/158191976",
       "fun_fact_fr": "Sjeng aon de geng est une chanson en dialecte régional bien-aimée du Limbourg, chantée dans le dialecte local et sortie en 1995.",
       "fun_fact_nl": "Sjeng aon de geng is een geliefd Limburgs dialectlied, gezongen in het Limburgs en uitgebracht in 1995. Het werd een hit tot ver buiten Limburg en vierde het unieke karakter van de Zuid-Nederlandse cultuur. Het lied bewijst hoe regionale muziek een groter publiek kan veroveren.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "NLW2R2050266",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1535250660",
+        "de": "applemusic://track/1535250660",
+        "gb": "applemusic://track/1535250660",
+        "fr": "applemusic://track/1535250660",
+        "es": "applemusic://track/1535250660",
+        "nl": "applemusic://track/1535250660",
+        "it": "applemusic://track/1535250660"
+      }
     },
     {
       "year": 2002,
@@ -1602,7 +2172,17 @@
       "uri_tidal": "tidal://track/2825525",
       "fun_fact_fr": "Heb Je Even Voor Mij est l'une des chansons les plus populaires de Frans Bauer, combinant le Schlager néerlandais avec un refrain irrésistiblement accrocheur.",
       "fun_fact_nl": "Heb Je Even Voor Mij is een van Frans Bauers populairste nummers, een combinatie van Nederlandse Schlager met een onweerstaanbaar catchy refrein. Frans Bauer is een van de grootste sterren van de Nederlandse en Vlaamse populaire muziek, bekend om zijn warme persoonlijkheid en zijn vermogen om stadions te vullen. Het nummer werd meteen een meezingklassieker.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "NLD020200097",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/408756716",
+        "de": "applemusic://track/408756716",
+        "gb": "applemusic://track/408756716",
+        "fr": "applemusic://track/408756716",
+        "es": "applemusic://track/408756716",
+        "nl": "applemusic://track/1790923391",
+        "it": "applemusic://track/408756716"
+      }
     },
     {
       "year": 1991,
@@ -1629,7 +2209,17 @@
       "uri_tidal": "tidal://track/495855028",
       "fun_fact_fr": "Mooi Man est une ode feel-good à l'homme travailleur, interprétée avec chaleur et humour par le chœur masculin Karrespoor.",
       "fun_fact_nl": "Mooi Man is een feelgood ode aan de werkende man met veel warmte en humor uitgevoerd door het mannenkoor Karrespoor. Het werd uitgebracht in 1991 en werd een geliefde Nederlandse klassieker die regelmatig wordt gedraaid op familiebijeenkomsten en feestjes. De vrolijke, gemeenschappelijke geest van het lied maakte het tot een uniek Nederlands cultureel fenomeen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "NLA240000366",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1371756545",
+        "de": "applemusic://track/1371756545",
+        "gb": "applemusic://track/1371756545",
+        "fr": "applemusic://track/1371756545",
+        "es": "applemusic://track/1371756545",
+        "nl": "applemusic://track/1557623605",
+        "it": "applemusic://track/1371756545"
+      }
     },
     {
       "year": 2022,
@@ -1656,7 +2246,17 @@
       "uri_tidal": "tidal://track/218683212",
       "fun_fact_fr": "De Diepte a représenté les Pays-Bas à l'Eurovision 2022 et est devenu l'une des participations néerlandaises à l'Eurovision les plus saluées depuis des décennies.",
       "fun_fact_nl": "De Diepte vertegenwoordigde Nederland op Eurovision 2022 en werd een van de meest bejubelde Nederlandse Eurovisie-inzendingen in decennia. S10's beklemmende, minimale elektronische ballade over geestelijke gezondheid markeerde internationaal een nieuw artistiek hoofdstuk voor Nederlandse muziek. De rauwe zangprestaties en artistieke visie oogstten alom bewondering.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "NLG662200040",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1612026523",
+        "de": "applemusic://track/1677174948",
+        "gb": "applemusic://track/1612026523",
+        "fr": "applemusic://track/1612026523",
+        "es": "applemusic://track/1612026523",
+        "nl": "applemusic://track/1677174948",
+        "it": "applemusic://track/1612026523"
+      }
     },
     {
       "year": 1967,
@@ -1683,7 +2283,17 @@
       "uri_tidal": "tidal://track/241668185",
       "fun_fact_fr": "Het Land Van Maas En Waal est l'une des chansons folk-pop néerlandaises les plus emblématiques des années 1960, évoquant le paysage néerlandais.",
       "fun_fact_nl": "Het Land Van Maas En Waal is een van de meest iconische Nederlandse folkpopliedjes uit de jaren zestig, waarin het vlakke, waterige Nederlandse landschap met poëtische precisie wordt verbeeld. Boudewijn de Groot was de belangrijkste Nederlandse singer-songwriter van de jaren 1960, vaak de Nederlandse Bob Dylan genoemd. Het nummer blijft een tijdloze klassieker die de Nederlandse ziel vangt.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "NLA306600126",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1638372855",
+        "de": "applemusic://track/1638372855",
+        "gb": "applemusic://track/1638372855",
+        "fr": "applemusic://track/1638372855",
+        "es": "applemusic://track/1638372855",
+        "nl": "applemusic://track/1638372855",
+        "it": "applemusic://track/1638372855"
+      }
     },
     {
       "year": 1998,
@@ -1710,7 +2320,17 @@
       "uri_tidal": "tidal://track/1830351",
       "fun_fact_fr": "Hou me vast a été le tube révélateur de Volumia!, l'un des groupes de rock-pop néerlandais les plus appréciés de la fin des années 1990.",
       "fun_fact_nl": "Hou me vast was de doorbraakhit voor Volumia!, een van de meest geliefde Nederlandse rockpopbands van eind jaren negentig. Het krachtige refrein en het emotionele pleidooi voor verbondenheid maakten van het nummer een instant anthem. Volumia! werd een van de bepalende Nederlandse acts van hun tijd voordat ze in 2001 uit elkaar gingen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "NLA209800024",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1309033441",
+        "de": "applemusic://track/1309033441",
+        "gb": "applemusic://track/1309033441",
+        "fr": "applemusic://track/1309033441",
+        "es": "applemusic://track/1309033441",
+        "nl": "applemusic://track/1309033441",
+        "it": "applemusic://track/1309033441"
+      }
     },
     {
       "year": 2019,
@@ -1733,7 +2353,17 @@
       "uri_tidal": "tidal://track/444247848",
       "fun_fact_fr": "Ze Huilt Maar Ze Lacht capture l'un des thèmes émotionnellement les plus complexes de Maan — le visage courageux malgré la tristesse.",
       "fun_fact_nl": "Ze Huilt Maar Ze Lacht vat een van Maan's meest emotioneel complexe thema's - het dappere gezicht dat we opzetten door verdriet. Het nummer werd uitgebracht in 2019 en laat Maan's groeiende volwassenheid als songwriter zien. Het werd een van haar meest gestreamde tracks.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "NLZ291900361",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1822754446",
+        "de": "applemusic://track/1822754446",
+        "gb": "applemusic://track/1822754446",
+        "fr": "applemusic://track/1822754446",
+        "es": "applemusic://track/1822754446",
+        "nl": "applemusic://track/1822754446",
+        "it": "applemusic://track/1822754446"
+      }
     },
     {
       "year": 2003,
@@ -1760,7 +2390,17 @@
       "uri_tidal": "tidal://track/1375732",
       "fun_fact_fr": "Ik Wou Dat Ik Jou Was est la chanson signature du duo comique Veldhuis & Kemper, qui a brillamment combiné l'humour de cabaret avec une écriture pop accrocheuse.",
       "fun_fact_nl": "Ik Wou Dat Ik Jou Was is het signatuurnummer van het komische duo Veldhuis & Kemper, dat op briljante wijze cabarethumor combineerde met oprecht aanstekelijke popsongs. Het speelse liedje over jaloezie en bewondering, dat in 2003 werd uitgebracht, werd een van de meest herkenbare Nederlandse liedjes van de jaren 2000.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "NLA270300360",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/724338357",
+        "de": "applemusic://track/724338357",
+        "gb": "applemusic://track/724338357",
+        "fr": "applemusic://track/724338357",
+        "es": "applemusic://track/724338357",
+        "nl": "applemusic://track/724338357",
+        "it": "applemusic://track/724338357"
+      }
     },
     {
       "year": 2008,
@@ -1783,7 +2423,17 @@
       "uri_tidal": "tidal://track/85001155",
       "fun_fact_fr": "Dochters est considérée comme l'une des chansons les plus émouvantes jamais enregistrées par Marco Borsato — un hommage tendre à ses filles.",
       "fun_fact_nl": "Dochters wordt algemeen beschouwd als een van de meest ontroerende liedjes die Marco Borsato ooit heeft opgenomen - een teder eerbetoon aan zijn dochters en de bitterzoete ervaring om ze te zien opgroeien. Het werd uitgebracht in 2008 en vond diepe weerklank bij ouders in heel Nederland en werd een van zijn grootste hits aan het eind van de jaren 2000.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "NLUM70800438",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1442904624",
+        "de": "applemusic://track/1442904624",
+        "gb": "applemusic://track/1353767497",
+        "fr": "applemusic://track/1442904624",
+        "es": "applemusic://track/1442904624",
+        "nl": "applemusic://track/1444290997",
+        "it": "applemusic://track/1442904624"
+      }
     },
     {
       "year": 2016,
@@ -1808,7 +2458,17 @@
       "uri_tidal": "tidal://track/75584484",
       "fun_fact_fr": "Energie a été l'un des titres qui a établi Ronnie Flex comme une force majeure dans le hip-hop néerlandais en 2016.",
       "fun_fact_nl": "Energie was een van de tracks waarmee Ronnie Flex zich in 2016 vestigde als een belangrijke kracht in de Nederlandse hiphop en R&B. De upbeat, positieve vibe contrasteerde met zijn meer introspectieve werk en werd een party anthem en radiofavoriet. Het introduceerde hem bij een mainstream Nederlands publiek.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "NLG661600769",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1440899681",
+        "de": "applemusic://track/1440899681",
+        "gb": "applemusic://track/1440899681",
+        "fr": "applemusic://track/1440899681",
+        "es": "applemusic://track/1440899681",
+        "nl": "applemusic://track/1440717999",
+        "it": "applemusic://track/1440899681"
+      }
     },
     {
       "year": 2006,
@@ -1853,7 +2513,17 @@
       "fun_fact_nl": "Waarom Nou Jij was een van Marco Borsato's vroege hits uit 1994, waarmee hij de basis legde voor de oprechte Nederlandse ballads die zijn carrière zouden bepalen. De kwetsbare vraagstelling van het nummer vond weerklank bij een breed Nederlands publiek en hielp hem naar nationaal sterrendom.",
       "awards_nl": [],
       "uri_apple_music": "applemusic://track/1444144375",
-      "uri_youtube_music": "https://music.youtube.com/watch?v=UFq0vdrp07Q"
+      "uri_youtube_music": "https://music.youtube.com/watch?v=UFq0vdrp07Q",
+      "isrc": "NLA319400230",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1444144375",
+        "de": "applemusic://track/1444144375",
+        "gb": "applemusic://track/1444144375",
+        "fr": "applemusic://track/1444144375",
+        "es": "applemusic://track/1444144375",
+        "nl": "applemusic://track/1444144375",
+        "it": "applemusic://track/1444144375"
+      }
     },
     {
       "year": 2020,
@@ -1905,7 +2575,17 @@
       "fun_fact_nl": "Slapeloosheid verkent de rusteloze nachten en looping gedachten van angst en verlangen met prachtige intimiteit. Suzan & Freek, uitgebracht in 2023, bleven de grenzen van de Nederlandse intieme pop verleggen. Het werd al snel een fanfavoriet, wat hun blijvende aantrekkingskracht bewijst.",
       "awards_nl": [],
       "uri_apple_music": "applemusic://track/1659415213",
-      "uri_youtube_music": "https://music.youtube.com/watch?v=qD_6h-sJF9Y"
+      "uri_youtube_music": "https://music.youtube.com/watch?v=qD_6h-sJF9Y",
+      "isrc": "NL1CK2300001",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1659415213",
+        "de": "applemusic://track/1659415213",
+        "gb": "applemusic://track/1659415213",
+        "fr": "applemusic://track/1659415213",
+        "es": "applemusic://track/1659415213",
+        "nl": "applemusic://track/1659415213",
+        "it": "applemusic://track/1659415213"
+      }
     },
     {
       "year": 1991,
@@ -1931,7 +2611,17 @@
       "fun_fact_nl": "Kon Ik Maar Even Bij Je Zijn was een van Gordons vroege hits waarmee hij zijn talent voor emotioneel directe, sentimentele Nederpop liet zien. Gordon is een razend populaire Nederlandse entertainer die al tientallen jaren een steunpilaar is in de Nederlandse populaire cultuur. Het nummer werd een favoriet voor iedereen die verlangde naar een geliefde ver weg.",
       "awards_nl": [],
       "uri_apple_music": "applemusic://track/151364731",
-      "uri_youtube_music": "https://music.youtube.com/watch?v=u5UKe4GdX2w"
+      "uri_youtube_music": "https://music.youtube.com/watch?v=u5UKe4GdX2w",
+      "isrc": "NLA240502830",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/151364731",
+        "de": "applemusic://track/151364731",
+        "gb": "applemusic://track/151364731",
+        "fr": "applemusic://track/151364731",
+        "es": "applemusic://track/151364731",
+        "nl": "applemusic://track/151364731",
+        "it": "applemusic://track/151364731"
+      }
     },
     {
       "year": 1990,
@@ -1957,7 +2647,17 @@
       "fun_fact_nl": "Mooi Was Die Tijd is een nostalgische ballade die terugblikt op mooie vervlogen tijden en een van de meest geliefde liedjes van Corry Konings. Corry Konings is een van de ware koninginnen van de Nederlandstalige populaire muziek met een carrière van meer dan vijf decennia. Het nummer vindt weerklank bij iedereen die wel eens terugkijkt op een gouden hoofdstuk in zijn of haar leven.",
       "awards_nl": [],
       "uri_apple_music": "applemusic://track/1371915839",
-      "uri_youtube_music": "https://music.youtube.com/watch?v=ioljeGS5UhY"
+      "uri_youtube_music": "https://music.youtube.com/watch?v=ioljeGS5UhY",
+      "isrc": "NLA241801047",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1371915839",
+        "de": "applemusic://track/1371915839",
+        "gb": "applemusic://track/1371915839",
+        "fr": "applemusic://track/1371915839",
+        "es": "applemusic://track/1371915839",
+        "nl": "applemusic://track/1371915839",
+        "it": "applemusic://track/1371915839"
+      }
     },
     {
       "year": 2018,
@@ -1983,7 +2683,17 @@
       "fun_fact_nl": "Lil Craney is een speelse, zelfverwijzende hiphoptrack die in 2018 een virale hit werd en de humoristische en zelfverzekerde stijl van Kraantje Pappie laat horen. Hij is een van de meest vermakelijke en onderscheidende stemmen in de Nederlandse hiphop. Het nummer werd een anthem voor zijn groeiende fanbase.",
       "awards_nl": [],
       "uri_apple_music": "applemusic://track/1357036661",
-      "uri_youtube_music": "https://music.youtube.com/watch?v=nMqaGQpbiVQ"
+      "uri_youtube_music": "https://music.youtube.com/watch?v=nMqaGQpbiVQ",
+      "isrc": "NLG661800298",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1357036661",
+        "de": "applemusic://track/1357036661",
+        "gb": "applemusic://track/1357036661",
+        "fr": "applemusic://track/1357036661",
+        "es": "applemusic://track/1357036661",
+        "nl": "applemusic://track/1357036661",
+        "it": "applemusic://track/1357036661"
+      }
     },
     {
       "year": 1995,
@@ -2009,7 +2719,17 @@
       "fun_fact_nl": "Deze Nederlandstalige versie van Pour Que Tu M'Aimes Encore van Céline Dion werd een enorme hit voor Gordon in 1995, door de kracht van het origineel te combineren met Gordons warme stem. Het werd een van de best verkochte Nederlandse singles van het jaar. Het lied bewees de cross-linguïstische aantrekkingskracht van geweldige popmuziek.",
       "awards_nl": [],
       "uri_apple_music": "applemusic://track/1488115633",
-      "uri_youtube_music": "https://music.youtube.com/watch?v=Y5TOuCCDwsE"
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Y5TOuCCDwsE",
+      "isrc": "NLA249600078",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/485881394",
+        "de": "applemusic://track/485881394",
+        "gb": "applemusic://track/485881394",
+        "fr": "applemusic://track/485881394",
+        "es": "applemusic://track/485881394",
+        "nl": "applemusic://track/485881394",
+        "it": "applemusic://track/485881394"
+      }
     },
     {
       "year": 1970,
@@ -2059,7 +2779,17 @@
       "fun_fact_nl": "De Overkant is een metaforisch nummer over de afstand tussen twee mensen die zich ondanks alles toch dichtbij elkaar voelen, een van de meest poëtische nummers in de catalogus van Suzan & Freek. Het werd uitgebracht in 2020 en toonde de groeiende emotionele verfijning van het duo. Het nummer werd een fanfavoriet vanwege de doordachte tekst.",
       "awards_nl": [],
       "uri_apple_music": "applemusic://track/1525342810",
-      "uri_youtube_music": "https://music.youtube.com/watch?v=lDauv9pXkUc"
+      "uri_youtube_music": "https://music.youtube.com/watch?v=lDauv9pXkUc",
+      "isrc": "NL1CK2000003",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1525342810",
+        "de": "applemusic://track/1525342810",
+        "gb": "applemusic://track/1525342810",
+        "fr": "applemusic://track/1525342810",
+        "es": "applemusic://track/1525342810",
+        "nl": "applemusic://track/1525342810",
+        "it": "applemusic://track/1525342810"
+      }
     },
     {
       "year": 1971,
@@ -2083,7 +2813,17 @@
       "fun_fact_nl": "Zou Het Erg Zijn, Lieve Opa is een ontroerend liedje uit 1971 gericht aan een grootvaderfiguur, waarin met onschuldige verwondering wordt stilgestaan bij vragen over het leven en het einde ervan. Wilma was een opmerkelijke Nederlandse popzangeres aan het begin van de jaren 1970. Het lied werd een gedenkwaardige klassieker vanwege de zachte benadering van een ongewoon onderwerp.",
       "awards_nl": [],
       "uri_apple_music": "applemusic://track/1386061149",
-      "uri_youtube_music": "https://music.youtube.com/watch?v=N6dsPg-YSCI"
+      "uri_youtube_music": "https://music.youtube.com/watch?v=N6dsPg-YSCI",
+      "isrc": "NLE320500074",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1842921739",
+        "de": "applemusic://track/1842921739",
+        "gb": "applemusic://track/1842921739",
+        "fr": "applemusic://track/1842921739",
+        "es": "applemusic://track/1842921739",
+        "nl": "applemusic://track/1842921739",
+        "it": "applemusic://track/1842921739"
+      }
     },
     {
       "year": 2001,
@@ -2109,7 +2849,17 @@
       "fun_fact_nl": "Schudden was een van de meest energieke Nederlandse hiphoptracks van 2001 en vestigde Def Rhymz als een belangrijke kracht in de Nederlandse urban muziek. De onweerstaanbare oproep om te dansen maakte het een club- en radiofavoriet. Def Rhymz groeide uit tot een van de meest gerespecteerde figuren in de Nederlandse hiphopgeschiedenis.",
       "awards_nl": [],
       "uri_apple_music": "applemusic://track/1442289020",
-      "uri_youtube_music": "https://music.youtube.com/watch?v=-cnWgvG_e3o"
+      "uri_youtube_music": "https://music.youtube.com/watch?v=-cnWgvG_e3o",
+      "isrc": "NLA350000241",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1442289020",
+        "de": "applemusic://track/1442289020",
+        "gb": "applemusic://track/1442289020",
+        "fr": "applemusic://track/1442289020",
+        "es": "applemusic://track/1442289020",
+        "nl": "applemusic://track/1442289020",
+        "it": "applemusic://track/1442289020"
+      }
     },
     {
       "year": 1969,
@@ -2135,7 +2885,17 @@
       "fun_fact_nl": "Gina Lollobrigida is een charmant, tongue-in-cheek Nederlandstalig popliedje uit 1969 dat op speelse wijze refereert aan de beroemde Italiaanse actrice. Tony Bass had een talent voor het maken van pakkende, luchtige Nederlandstalige hits. Het nummer werd een geliefde novelty klassieker in Nederland.",
       "awards_nl": [],
       "uri_apple_music": "applemusic://track/315688170",
-      "uri_youtube_music": "https://music.youtube.com/watch?v=UacEtxNuZ-U"
+      "uri_youtube_music": "https://music.youtube.com/watch?v=UacEtxNuZ-U",
+      "isrc": "NLAX70927920",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/315688170",
+        "de": "applemusic://track/315688170",
+        "gb": "applemusic://track/315688170",
+        "fr": "applemusic://track/315688170",
+        "es": "applemusic://track/315688170",
+        "nl": "applemusic://track/315688170",
+        "it": "applemusic://track/315688170"
+      }
     },
     {
       "year": 1998,
@@ -2157,7 +2917,17 @@
       "fun_fact_nl": "Afscheid is een van Volumia's meest emotionele nummers, een rauwe en louterende verkenning van afscheid en verlies, uitgebracht in 1998. Het werd een van de meest kenmerkende nummers van de meest gevierde periode van de band. Volumia! was een van de belangrijkste Nederlandse rock-pop acts van de late jaren 1990.",
       "awards_nl": [],
       "uri_apple_music": "applemusic://track/266295447",
-      "uri_youtube_music": "https://music.youtube.com/watch?v=MltY2wtA3qk"
+      "uri_youtube_music": "https://music.youtube.com/watch?v=MltY2wtA3qk",
+      "isrc": "NLA209800016",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/268228952",
+        "de": "applemusic://track/268228952",
+        "gb": "applemusic://track/268228952",
+        "fr": "applemusic://track/268228952",
+        "es": "applemusic://track/268228952",
+        "nl": "applemusic://track/1449978485",
+        "it": "applemusic://track/268228952"
+      }
     },
     {
       "year": 2021,
@@ -2208,7 +2978,17 @@
       "fun_fact_nl": "Zinloos was Lange Frans' meest succesvolle en sociaal bewuste track, een krachtig commentaar op geweld en de zinloze impact ervan op gemeenschappen. Het werd uitgebracht in 2004 en werd een van de meest besproken Nederlandse hiphopplaten van het decennium. Lange Frans was een van de belangrijkste politieke stemmen in de Nederlandse hiphop.",
       "awards_nl": [],
       "uri_apple_music": "applemusic://track/1480373179",
-      "uri_youtube_music": "https://music.youtube.com/watch?v=WOERov10GH0"
+      "uri_youtube_music": "https://music.youtube.com/watch?v=WOERov10GH0",
+      "isrc": "NLG270400019",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/359159887",
+        "de": "applemusic://track/359159887",
+        "gb": "applemusic://track/359159887",
+        "fr": "applemusic://track/359159887",
+        "es": "applemusic://track/359159887",
+        "nl": "applemusic://track/359159887",
+        "it": "applemusic://track/359159887"
+      }
     },
     {
       "year": 2005,
@@ -2235,7 +3015,17 @@
       "fun_fact_nl": "Watskeburt?! is het meest iconische Nederlandse hiphopnummer ooit gemaakt - chaotisch, grappig en briljant zelfbewust. De track werd uitgebracht in 2005, vatte de geest van de Nederlandse internetcultuur halverwege de jaren 2000 en werd een cultureel fenomeen. De anarchistische aanpak van De Jeugd Van Tegenwoordig maakte hen tot legendes van de Nederlandse hiphop.",
       "awards_nl": [],
       "uri_apple_music": "applemusic://track/1442539933",
-      "uri_youtube_music": "https://music.youtube.com/watch?v=rjER3EX948w"
+      "uri_youtube_music": "https://music.youtube.com/watch?v=rjER3EX948w",
+      "isrc": "NLG660500060",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1442539933",
+        "de": "applemusic://track/1442539933",
+        "gb": null,
+        "fr": "applemusic://track/1442539933",
+        "es": "applemusic://track/1442539933",
+        "nl": "applemusic://track/1442539933",
+        "it": "applemusic://track/1442539933"
+      }
     },
     {
       "year": 2023,
@@ -2259,7 +3049,17 @@
       "fun_fact_nl": "Vas-y is een van de meest emotioneel rauwe nummers van Suzan & Freek, een pijnlijk afscheid waarbij Frans en Nederlands in de titel worden gecombineerd om de complexiteit van het loslaten uit te drukken. Het werd uitgebracht in 2023 en toonde het duo op hun volwassenst. Het nummer vond diepe weerklank bij iedereen die wel eens te maken heeft gehad met een moeilijk afscheid.",
       "awards_nl": [],
       "uri_apple_music": "applemusic://track/1697506042",
-      "uri_youtube_music": "https://music.youtube.com/watch?v=Fx_C99BjbD4"
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Fx_C99BjbD4",
+      "isrc": "NL1CK2300005",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1842435015",
+        "de": "applemusic://track/1842435015",
+        "gb": "applemusic://track/1842435015",
+        "fr": "applemusic://track/1842435015",
+        "es": "applemusic://track/1842435015",
+        "nl": "applemusic://track/1842435015",
+        "it": "applemusic://track/1842435015"
+      }
     },
     {
       "year": 1984,
@@ -2285,7 +3085,17 @@
       "fun_fact_nl": "Waarom Fluister Ik Je Naam Nog is een van de meest aangrijpende Nederlandse liefdesballades van de jaren tachtig, waarin de slepende pijn van een verloren liefde wordt gevangen. Benny Neyman was een van de meest geliefde Nederlands-Vlaamse Schlagerzangers van zijn tijd. Het nummer blijft een klassieker in de Nederlandse sentimentele pop.",
       "awards_nl": [],
       "uri_apple_music": "applemusic://track/145530931",
-      "uri_youtube_music": "https://music.youtube.com/watch?v=6xfH1JWbmCg"
+      "uri_youtube_music": "https://music.youtube.com/watch?v=6xfH1JWbmCg",
+      "isrc": "NLA249900019",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/145530931",
+        "de": "applemusic://track/145530931",
+        "gb": "applemusic://track/145530931",
+        "fr": "applemusic://track/145530931",
+        "es": "applemusic://track/145530931",
+        "nl": "applemusic://track/145530931",
+        "it": "applemusic://track/145530931"
+      }
     },
     {
       "year": 1996,
@@ -2309,7 +3119,17 @@
       "fun_fact_nl": "Per Spoor is een van de vrolijkste Nederlandse liedjes van de jaren 90, een ode aan het reizen per trein door het Nederlandse platteland. Het onomatopeeërieke 'kedeng kedeng' dat treinwielen nabootst werd een van de meest herkenbare geluiden in de Nederpop. Het nummer maakte Guus Meeuwis een begrip naast Het Is Een Nacht.",
       "awards_nl": [],
       "uri_apple_music": "applemusic://track/285327729",
-      "uri_youtube_music": "https://music.youtube.com/watch?v=lSxh-UK7Ays"
+      "uri_youtube_music": "https://music.youtube.com/watch?v=lSxh-UK7Ays",
+      "isrc": "NLB590800103",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1822269633",
+        "de": "applemusic://track/1822269633",
+        "gb": "applemusic://track/1822269633",
+        "fr": "applemusic://track/1822269633",
+        "es": "applemusic://track/1822269633",
+        "nl": "applemusic://track/1822269633",
+        "it": "applemusic://track/1822269633"
+      }
     },
     {
       "year": 1995,
@@ -2333,7 +3153,17 @@
       "fun_fact_nl": "Zonder Jou is een van Paul de Leeuws meest emotionele opnames, een krachtige ballade over de leegte van het leven zonder een geliefd persoon. De Leeuw verraste het publiek voortdurend met de diepte van zijn vocale en emotionele optredens. Het nummer werd een van zijn meest gespeelde opnames.",
       "awards_nl": [],
       "uri_apple_music": "applemusic://track/1585392334",
-      "uri_youtube_music": "https://music.youtube.com/watch?v=0gyV92zZ4mY"
+      "uri_youtube_music": "https://music.youtube.com/watch?v=0gyV92zZ4mY",
+      "isrc": "NLD450600004",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1585392334",
+        "de": "applemusic://track/1585392334",
+        "gb": "applemusic://track/1585392334",
+        "fr": "applemusic://track/1585392334",
+        "es": "applemusic://track/1585392334",
+        "nl": "applemusic://track/1585392334",
+        "it": "applemusic://track/1585392334"
+      }
     },
     {
       "year": 2011,
@@ -2359,7 +3189,17 @@
       "fun_fact_nl": "Afscheid van Glennis Grace is een verbluffende powerballad die een van de meest opmerkelijke stemmen uit de Nederlandse popgeschiedenis laat horen. Grace wordt algemeen beschouwd als een van de grootste Nederlandse vocalisten van haar generatie, met een bereik en emotionele diepte die weinigen kunnen evenaren. Het nummer werd een showcase voor haar buitengewone talent.",
       "awards_nl": [],
       "uri_apple_music": "applemusic://track/1224914189",
-      "uri_youtube_music": "https://music.youtube.com/watch?v=3Qa1UM9C9l4"
+      "uri_youtube_music": "https://music.youtube.com/watch?v=3Qa1UM9C9l4",
+      "isrc": "NLK070900236",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1523444661",
+        "de": "applemusic://track/1523444661",
+        "gb": "applemusic://track/1523444661",
+        "fr": "applemusic://track/1523444661",
+        "es": "applemusic://track/1523444661",
+        "nl": "applemusic://track/1523444661",
+        "it": "applemusic://track/1523444661"
+      }
     },
     {
       "year": 2015,
@@ -2409,7 +3249,17 @@
       "fun_fact_nl": "Dansplaat is een aanstekelijk energiek hiphopnummer uit 2002 van Brainpower, een van de meest inventieve en geletterde Nederlandse MC's. De onweerstaanbare dansbare groove van het nummer zorgde voor een enorme hit en bevestigde Brainpower's status in de Nederlandse hiphopscene. De onweerstaanbare dansbare groove van het nummer maakte het tot een enorme hit en verstevigde Brainpowers status in de Nederlandse hiphopscene. Het blijft een van de definitieve Nederlandse hiphop-feestnummers.",
       "awards_nl": [],
       "uri_apple_music": "applemusic://track/343666377",
-      "uri_youtube_music": "https://music.youtube.com/watch?v=IFeQhLza9O8"
+      "uri_youtube_music": "https://music.youtube.com/watch?v=IFeQhLza9O8",
+      "isrc": "NLD320300048",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/343666377",
+        "de": "applemusic://track/343666377",
+        "gb": "applemusic://track/343666377",
+        "fr": "applemusic://track/343666377",
+        "es": "applemusic://track/343666377",
+        "nl": "applemusic://track/343666377",
+        "it": "applemusic://track/343666377"
+      }
     },
     {
       "year": 1965,
@@ -2435,7 +3285,17 @@
       "fun_fact_nl": "Het Spel Kaarten is een geliefde Nederlandse klassieker uit 1965 van Gerard de Vries die een kaartspel gebruikt als slimme metafoor voor de onzekerheden en liefdes van het leven. De warmte en volkse charme van het lied maakten het tot een tijdloze favoriet. De Vries was een gekoesterd figuur in de Nederlandse folkpop van de jaren 1960.",
       "awards_nl": [],
       "uri_apple_music": "applemusic://track/1326170341",
-      "uri_youtube_music": "https://music.youtube.com/watch?v=gPDeLNL5doo"
+      "uri_youtube_music": "https://music.youtube.com/watch?v=gPDeLNL5doo",
+      "isrc": "NLE320500076",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1750745021",
+        "de": "applemusic://track/1750745021",
+        "gb": "applemusic://track/1750745021",
+        "fr": "applemusic://track/1750745021",
+        "es": "applemusic://track/1750745021",
+        "nl": "applemusic://track/1750745021",
+        "it": "applemusic://track/1750745021"
+      }
     },
     {
       "year": 1997,
@@ -2461,7 +3321,17 @@
       "fun_fact_nl": "Ik Zing Dit Lied Voor Jou Alleen was Jan Smit's debuuthit in 1997, opgenomen toen hij nog maar twaalf jaar oud was, waarmee hij een van de jongste Nederlandse hitparade-toppers in de geschiedenis was. De charmante onschuld van het liedje en de pakkende melodie maakten het meteen tot een klassieker. Jan Smit groeide uit tot een van de grootste Nederlandse popsterren van zijn generatie.",
       "awards_nl": [],
       "uri_apple_music": "applemusic://track/1219058972",
-      "uri_youtube_music": "https://music.youtube.com/watch?v=ugkSOU8ndfk"
+      "uri_youtube_music": "https://music.youtube.com/watch?v=ugkSOU8ndfk",
+      "isrc": "NLA629700003",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1364474697",
+        "de": "applemusic://track/1364474697",
+        "gb": "applemusic://track/1364474697",
+        "fr": "applemusic://track/1364474697",
+        "es": "applemusic://track/1364474697",
+        "nl": "applemusic://track/1364474697",
+        "it": "applemusic://track/1364474697"
+      }
     },
     {
       "year": 2024,
@@ -2486,7 +3356,17 @@
       "fun_fact_nl": "Alles Op Gevoel is een van FLEMMING's meest recente hits uit 2024, waaruit haar voortdurende artistieke groei blijkt en haar vermogen om complexe emoties te vangen met bedrieglijk eenvoudige poparrangementen. Het nummer werd meteen een fanfavoriet en versterkte haar status als een van de toonaangevende stemmen in de hedendaagse Nederpop.",
       "awards_nl": [],
       "uri_apple_music": "applemusic://track/1723046101",
-      "uri_youtube_music": "https://music.youtube.com/watch?v=cczh90jYujU"
+      "uri_youtube_music": "https://music.youtube.com/watch?v=cczh90jYujU",
+      "isrc": "NLK072300478",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1723046101",
+        "de": "applemusic://track/1723046101",
+        "gb": "applemusic://track/1723046101",
+        "fr": "applemusic://track/1723046101",
+        "es": "applemusic://track/1723046101",
+        "nl": "applemusic://track/1723046101",
+        "it": "applemusic://track/1723046101"
+      }
     },
     {
       "year": 2022,
@@ -2561,7 +3441,17 @@
       "fun_fact_nl": "Voorbij is een prachtig ingetogen Marco Borsato ballad uit 2004 over iets dierbaars dat voorbij is en nooit meer terug kan komen. De rustige emotionele kracht van het nummer maakte het tot een fanfavoriet uit een periode dat Borsato op het absolute hoogtepunt van zijn populariteit in Nederland was.",
       "awards_nl": [],
       "uri_apple_music": "applemusic://track/1353767412",
-      "uri_youtube_music": "https://music.youtube.com/watch?v=H2-yBR0b6Tc"
+      "uri_youtube_music": "https://music.youtube.com/watch?v=H2-yBR0b6Tc",
+      "isrc": "NLE070400004",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1442951442",
+        "de": "applemusic://track/1442951442",
+        "gb": "applemusic://track/1442951442",
+        "fr": "applemusic://track/1442951442",
+        "es": "applemusic://track/1442951442",
+        "nl": "applemusic://track/1442951442",
+        "it": "applemusic://track/1442951442"
+      }
     },
     {
       "year": 1984,
@@ -2587,7 +3477,17 @@
       "fun_fact_nl": "Ik Voel Me Zo Verdomd Alleen is een rauwe, hartverscheurende bekentenis van eenzaamheid door Danny de Munk, een van de populairste Nederlandse entertainers van de jaren tachtig. Het nummer werd uitgebracht in 1984 en vond weerklank bij iedereen die zich wel eens alleen heeft gevoeld. Het werd een van de meest memorabele en emotioneel eerlijke Nederlandse popplaten van het decennium.",
       "awards_nl": [],
       "uri_apple_music": "applemusic://track/1709490214",
-      "uri_youtube_music": "https://music.youtube.com/watch?v=2QT5BOcQru0"
+      "uri_youtube_music": "https://music.youtube.com/watch?v=2QT5BOcQru0",
+      "isrc": "NLA209800007",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1709490214",
+        "de": "applemusic://track/1705235721",
+        "gb": "applemusic://track/1705235721",
+        "fr": "applemusic://track/1705235721",
+        "es": "applemusic://track/1705235721",
+        "nl": "applemusic://track/1705235721",
+        "it": "applemusic://track/1705235721"
+      }
     }
   ]
 }

--- a/custom_components/beatify/playlists/community/yacht-rock.json
+++ b/custom_components/beatify/playlists/community/yacht-rock.json
@@ -41,7 +41,17 @@
       "uri_tidal": "tidal://track/17737009",
       "uri_deezer": "deezer://track/4688887",
       "fun_fact_nl": "Won twee Grammy's, waaronder Song of the Year. Michael McDonald schreef het samen met Kenny Loggins tijdens een informele jamsessie.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "US7VG1839677",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1443184580",
+        "de": "applemusic://track/1443184580",
+        "gb": "applemusic://track/1443184580",
+        "fr": "applemusic://track/1443184580",
+        "es": "applemusic://track/1443184580",
+        "nl": "applemusic://track/1443184580",
+        "it": "applemusic://track/1443184580"
+      }
     },
     {
       "year": 1976,
@@ -101,7 +111,17 @@
       "uri_tidal": "tidal://track/1781878",
       "uri_deezer": "deezer://track/10199831",
       "fun_fact_nl": "Mede-geschreven met Michael McDonald. Kenny Loggins schreef het nadat zijn vader was opgenomen in het ziekenhuis en met de dood werd geconfronteerd.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM18200004",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/310505616",
+        "de": "applemusic://track/310505616",
+        "gb": "applemusic://track/310505616",
+        "fr": "applemusic://track/310505616",
+        "es": "applemusic://track/310505616",
+        "nl": "applemusic://track/310505616",
+        "it": "applemusic://track/310505616"
+      }
     },
     {
       "year": 1972,
@@ -131,7 +151,17 @@
       "uri_tidal": "tidal://track/540137",
       "uri_deezer": "deezer://track/6917710",
       "fun_fact_nl": "Prominent te zien in Guardians of the Galaxy Vol. 2, waar het wordt omschreven als 'het grootste nummer ter wereld.'",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM19914421",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1058078772",
+        "de": "applemusic://track/1058078772",
+        "gb": "applemusic://track/1058078772",
+        "fr": "applemusic://track/1058078772",
+        "es": "applemusic://track/1058078772",
+        "nl": "applemusic://track/1058078772",
+        "it": "applemusic://track/1058078772"
+      }
     },
     {
       "year": 1978,
@@ -188,7 +218,17 @@
       "uri_tidal": "tidal://track/57787838",
       "uri_deezer": "deezer://track/4828148",
       "fun_fact_nl": "Michael McDonald verzorgt de achtergrondzang. Het verhaal over een outlaw die naar Mexico vlucht was ongebruikelijk voor soft rock.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USAR17600150",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1744536655",
+        "de": "applemusic://track/1744536655",
+        "gb": "applemusic://track/1744536655",
+        "fr": "applemusic://track/1744536655",
+        "es": "applemusic://track/1744536655",
+        "nl": "applemusic://track/1744536655",
+        "it": "applemusic://track/1744536655"
+      }
     },
     {
       "year": 1982,
@@ -249,7 +289,17 @@
       "uri_tidal": "tidal://track/45105672",
       "uri_deezer": "deezer://track/70016835",
       "fun_fact_nl": "Bevat een noot die Bill Withers 18 seconden vasthoudt - een van de langste noten in de popgeschiedeniss. Het nummer is meer dan 100 keer gesampeld.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM17700024",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/391725492",
+        "de": "applemusic://track/390435224",
+        "gb": "applemusic://track/390435224",
+        "fr": "applemusic://track/390435224",
+        "es": "applemusic://track/390435224",
+        "nl": "applemusic://track/390435224",
+        "it": "applemusic://track/390435224"
+      }
     },
     {
       "year": 1977,
@@ -279,7 +329,17 @@
       "uri_tidal": "tidal://track/2919752",
       "uri_deezer": "deezer://track/665411512",
       "fun_fact_nl": "De band Player had maar deze ene grote hit, waarmee ze de ultieme yacht rock-eenaggers werden.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USRC17607760",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1744521231",
+        "de": "applemusic://track/1778581249",
+        "gb": "applemusic://track/1778581249",
+        "fr": "applemusic://track/1778581249",
+        "es": "applemusic://track/1778581249",
+        "nl": "applemusic://track/1778581249",
+        "it": "applemusic://track/1778581249"
+      }
     },
     {
       "year": 1975,
@@ -339,7 +399,17 @@
       "uri_tidal": "tidal://track/77139773",
       "uri_deezer": "deezer://track/392284592",
       "fun_fact_nl": "Beleefde een enorme revival nadat het te zien was in de openingsscène van Guardians of the Galaxy (2014).",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM17300653",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1719083094",
+        "de": "applemusic://track/1719083094",
+        "gb": "applemusic://track/1719083094",
+        "fr": "applemusic://track/1719083094",
+        "es": "applemusic://track/1719083094",
+        "nl": "applemusic://track/1719083094",
+        "it": "applemusic://track/1719083094"
+      }
     },
     {
       "year": 1980,
@@ -399,7 +469,17 @@
       "uri_tidal": "tidal://track/36056987",
       "uri_deezer": "deezer://track/4828150",
       "fun_fact_nl": "Won drie Grammy's, waaronder Song of the Year. Christopher Cross' zachte stem en nautische thema belichamen het yacht rock-geluid.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USAR10200246",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1088536640",
+        "de": "applemusic://track/1088536640",
+        "gb": "applemusic://track/1088536640",
+        "fr": "applemusic://track/1088536640",
+        "es": "applemusic://track/1088536640",
+        "nl": "applemusic://track/1088536640",
+        "it": "applemusic://track/1088536640"
+      }
     },
     {
       "year": 1972,
@@ -429,7 +509,17 @@
       "uri_tidal": "tidal://track/10923661",
       "uri_deezer": "deezer://track/5416564",
       "fun_fact_nl": "Later gecoverd door The Isley Brothers en Type O Negative. De vredige beelden maakten het decennialang een zomerhit op de radio.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USAT20181306",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1718541736",
+        "de": "applemusic://track/1553905681",
+        "gb": "applemusic://track/1553905681",
+        "fr": "applemusic://track/1553905681",
+        "es": "applemusic://track/1553905681",
+        "nl": "applemusic://track/1553905681",
+        "it": "applemusic://track/1553905681"
+      }
     },
     {
       "year": 1978,
@@ -490,7 +580,17 @@
       "uri_tidal": "tidal://track/3247290",
       "uri_deezer": "deezer://track/3821914",
       "fun_fact_nl": "De titelsong van The Doobie Brothers' Grammy-winnende album. Het markeerde Michael McDonalds volledige overname van het geluid van de band.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBUM71504816",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1443184576",
+        "de": "applemusic://track/1443184576",
+        "gb": "applemusic://track/1443184576",
+        "fr": "applemusic://track/1443184576",
+        "es": "applemusic://track/1443184576",
+        "nl": "applemusic://track/1443184576",
+        "it": "applemusic://track/1443184576"
+      }
     },
     {
       "year": 1979,
@@ -520,7 +620,17 @@
       "uri_tidal": "tidal://track/32997688",
       "uri_deezer": "deezer://track/2801132",
       "fun_fact_nl": "Gebaseerd op een echte persoonlijke advertentie die Rupert Holmes zag. Het eindigde controversieel, met beide partners die elkaar bedriegen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM10025228",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/888837456",
+        "de": "applemusic://track/888837456",
+        "gb": "applemusic://track/888837456",
+        "fr": "applemusic://track/888837456",
+        "es": "applemusic://track/888837456",
+        "nl": "applemusic://track/888837456",
+        "it": "applemusic://track/888837456"
+      }
     },
     {
       "year": 1982,
@@ -551,7 +661,17 @@
       "uri_tidal": "tidal://track/539204",
       "uri_deezer": "deezer://track/1079668",
       "fun_fact_nl": "Werd in de jaren 2010 een viraal meme en werd in meerdere internetpeilingen uitgeroepen tot 'het beste nummer ooit'. Weezers cover werd in 2018 platina.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEUM71602006",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1440841474",
+        "de": "applemusic://track/1440841474",
+        "gb": "applemusic://track/1440841474",
+        "fr": "applemusic://track/1440841474",
+        "es": "applemusic://track/1440841474",
+        "nl": "applemusic://track/1440841474",
+        "it": "applemusic://track/1440841474"
+      }
     },
     {
       "year": 1978,
@@ -581,7 +701,17 @@
       "uri_tidal": "tidal://track/29907",
       "uri_deezer": "deezer://track/534470",
       "fun_fact_nl": "Werd het onofficiële hymne van San Francisco. De honkbalteams uit de Bay Area spelen het al sinds de jaren 80 bij wedstrijden.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEB330917610",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1443155084",
+        "de": "applemusic://track/1443155084",
+        "gb": "applemusic://track/1443155084",
+        "fr": "applemusic://track/1443155084",
+        "es": "applemusic://track/1443155084",
+        "nl": "applemusic://track/1443155084",
+        "it": "applemusic://track/1443155084"
+      }
     },
     {
       "year": 1982,
@@ -611,7 +741,17 @@
       "uri_tidal": "tidal://track/62712130",
       "uri_deezer": "deezer://track/15526164",
       "fun_fact_nl": "Kenny Loggins' vloeiende ballade liet zijn vermogen zien om binnen hetzelfde album te schakelen van uptempo hits naar tedere liefdesliedjes.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USRC17308512",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1568797857",
+        "de": "applemusic://track/1568797857",
+        "gb": "applemusic://track/454438491",
+        "fr": "applemusic://track/1568797857",
+        "es": "applemusic://track/1568797857",
+        "nl": "applemusic://track/1656111809",
+        "it": "applemusic://track/1568797857"
+      }
     },
     {
       "year": 1978,
@@ -641,7 +781,17 @@
       "uri_tidal": "tidal://track/79976217",
       "uri_deezer": "deezer://track/1627634952",
       "fun_fact_nl": "Bobby Caldwell werd aanvankelijk zonder zijn foto op de markt gebracht omdat het platenlabel vreesde dat een witte zanger die klinkt als zwart niet geaccepteerd zou worden door het blanke publiek.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMC17146462",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1875385979",
+        "de": "applemusic://track/1442207039",
+        "gb": "applemusic://track/1442207039",
+        "fr": "applemusic://track/1442207039",
+        "es": "applemusic://track/1442207039",
+        "nl": "applemusic://track/1442207039",
+        "it": "applemusic://track/1442207039"
+      }
     },
     {
       "year": 1978,
@@ -671,7 +821,17 @@
       "uri_tidal": "tidal://track/2865124",
       "uri_deezer": "deezer://track/740855962",
       "fun_fact_nl": "Een duet met Stevie Nicks dat een van de bepalende yacht rock-samenwerkingen van de late jaren 70 werd.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USAR18300001",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1796834282",
+        "de": "applemusic://track/1793191728",
+        "gb": "applemusic://track/1793191728",
+        "fr": "applemusic://track/1793191728",
+        "es": "applemusic://track/1793191728",
+        "nl": "applemusic://track/1793191728",
+        "it": "applemusic://track/1793191728"
+      }
     },
     {
       "year": 1980,
@@ -701,7 +861,17 @@
       "uri_tidal": "tidal://track/26798607",
       "uri_deezer": "deezer://track/75785460",
       "fun_fact_nl": "Over een oudere man die een vrouw datet die te jong is om Aretha Franklins muziek te kennen. Bevat een prominente Fender Rhodes-piano.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USUM71602598",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1440879498",
+        "de": "applemusic://track/1440879498",
+        "gb": "applemusic://track/1440879498",
+        "fr": "applemusic://track/1440879498",
+        "es": "applemusic://track/1440879498",
+        "nl": "applemusic://track/1440879498",
+        "it": "applemusic://track/1440879498"
+      }
     },
     {
       "year": 1977,
@@ -731,7 +901,17 @@
       "uri_tidal": "tidal://track/2861209",
       "uri_deezer": "deezer://track/1015636",
       "fun_fact_nl": "James Taylors vrolijke liefdeslied stak af bij zijn typisch introspectieve repertoire. Het werd geschreven voor zijn toenmalige vrouw.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USAR17500002",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/304781315",
+        "de": "applemusic://track/304781315",
+        "gb": "applemusic://track/304781315",
+        "fr": "applemusic://track/304781315",
+        "es": "applemusic://track/304781315",
+        "nl": "applemusic://track/304781315",
+        "it": "applemusic://track/304781315"
+      }
     },
     {
       "year": 1987,
@@ -792,7 +972,17 @@
       "uri_tidal": "tidal://track/7204763",
       "uri_deezer": "deezer://track/5495390",
       "fun_fact_nl": "Steve Perry's solocarrière bewees dat hij het succes van Journey op eigen kracht kon evenaren met zijn krachtige tenorstem.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM11102620",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/447759255",
+        "de": "applemusic://track/447759255",
+        "gb": "applemusic://track/447759255",
+        "fr": "applemusic://track/447759255",
+        "es": "applemusic://track/447759255",
+        "nl": "applemusic://track/447759255",
+        "it": "applemusic://track/447759255"
+      }
     },
     {
       "year": 1984,
@@ -822,7 +1012,17 @@
       "uri_tidal": "tidal://track/4350147",
       "uri_deezer": "deezer://track/581533",
       "fun_fact_nl": "REO Speedwagons grootste hit werd geschreven door Kevin Cronin in zijn kelder over de loop van vier jaar voordat de band het opnam.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM10903222",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1737563250",
+        "de": "applemusic://track/1737563250",
+        "gb": "applemusic://track/1737563250",
+        "fr": "applemusic://track/1737563250",
+        "es": "applemusic://track/1737563250",
+        "nl": "applemusic://track/1737563250",
+        "it": "applemusic://track/1737563250"
+      }
     },
     {
       "year": 1978,
@@ -850,7 +1050,17 @@
       "uri_tidal": "tidal://track/1886618",
       "uri_deezer": "deezer://track/1081145",
       "fun_fact_nl": "Bevat Cheryl Lynn op zang. Het complexe jazz-fusionarrangement toont TOTO's uitzonderlijke muzikantschap.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEUM71602000",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1440841454",
+        "de": "applemusic://track/1440841454",
+        "gb": "applemusic://track/1440841454",
+        "fr": "applemusic://track/1440841454",
+        "es": "applemusic://track/1440841454",
+        "nl": "applemusic://track/1440841454",
+        "it": "applemusic://track/1440841454"
+      }
     },
     {
       "year": 1976,
@@ -874,7 +1084,17 @@
       "uri_tidal": "tidal://track/31006711",
       "uri_deezer": "deezer://track/120731576",
       "fun_fact_nl": "Silvers enige hit vangt de speelse, zorgeloze geest van de mid-70s soft rock perfect, voordat disco de overhand nam.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USAR18900124",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/888867609",
+        "de": "applemusic://track/888867609",
+        "gb": "applemusic://track/888867609",
+        "fr": "applemusic://track/888867609",
+        "es": "applemusic://track/888867609",
+        "nl": "applemusic://track/888867609",
+        "it": "applemusic://track/888867609"
+      }
     },
     {
       "year": 1976,
@@ -902,7 +1122,17 @@
       "uri_tidal": "tidal://track/3400972",
       "uri_deezer": "deezer://track/1078711",
       "fun_fact_nl": "Een vroeg Kenny Loggins-nummer uit zijn duetperiode met Jim Messina dat een hint gaf naar zijn toekomstige yacht rock-succes.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USWB19901645",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1703789022",
+        "de": "applemusic://track/1703789022",
+        "gb": "applemusic://track/1703789022",
+        "fr": "applemusic://track/1703789022",
+        "es": "applemusic://track/1703789022",
+        "nl": "applemusic://track/1703789022",
+        "it": "applemusic://track/1703789022"
+      }
     },
     {
       "year": 1978,
@@ -932,7 +1162,17 @@
       "uri_tidal": "tidal://track/25688918",
       "uri_deezer": "deezer://track/3169190",
       "fun_fact_nl": "Gerry Rafferty's opvolger van 'Baker Street' bewees dat hij geen eenaggers was met zijn even vloeiende productie.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM11003948",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/741231263",
+        "de": "applemusic://track/741231263",
+        "gb": "applemusic://track/741231263",
+        "fr": "applemusic://track/741231263",
+        "es": "applemusic://track/741231263",
+        "nl": "applemusic://track/741231263",
+        "it": "applemusic://track/741231263"
+      }
     },
     {
       "year": 1978,
@@ -992,7 +1232,17 @@
       "uri_tidal": "tidal://track/3120903",
       "uri_deezer": "deezer://track/546790",
       "fun_fact_nl": "Air Supplys doorbraakhit in Amerika lanceerde een reeks soft rock-ballades die de vroege 80s-radio domineerden.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USAT20000622",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/367380173",
+        "de": "applemusic://track/367380173",
+        "gb": "applemusic://track/580026164",
+        "fr": "applemusic://track/367380173",
+        "es": "applemusic://track/367380173",
+        "nl": "applemusic://track/367380173",
+        "it": "applemusic://track/367380173"
+      }
     },
     {
       "year": 1980,
@@ -1022,7 +1272,17 @@
       "uri_tidal": "tidal://track/68659095",
       "uri_deezer": "deezer://track/3821992",
       "fun_fact_nl": "Won een Grammy. Bill Withers' vloeiende zang over Grover Washington Jr.'s saxofoon creëerde de ultieme verfijnde soul-jazz crossover.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USRH11600652",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1111346318",
+        "de": "applemusic://track/1111346318",
+        "gb": "applemusic://track/1111346318",
+        "fr": "applemusic://track/1111346318",
+        "es": "applemusic://track/1111346318",
+        "nl": "applemusic://track/1111346318",
+        "it": "applemusic://track/1111346318"
+      }
     },
     {
       "year": 1981,
@@ -1142,7 +1402,17 @@
       "uri_tidal": "tidal://track/247879944",
       "uri_deezer": "deezer://track/3730976",
       "fun_fact_nl": "De 'Lido' in het nummer is een fictief personage. Boz Scaggs' zijdezachte zang maakte het een yacht rock-klassieker.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "ITUM71500028",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1440872750",
+        "de": "applemusic://track/1440872750",
+        "gb": "applemusic://track/1440872750",
+        "fr": "applemusic://track/1440872750",
+        "es": "applemusic://track/1440872750",
+        "nl": "applemusic://track/1440872750",
+        "it": "applemusic://track/1440872750"
+      }
     },
     {
       "year": 1978,
@@ -1172,7 +1442,17 @@
       "uri_tidal": "tidal://track/2871015",
       "uri_deezer": "deezer://track/1952713137",
       "fun_fact_nl": "Little River Bands grootste hit. De Australische band was verrassend succesvol in Amerika tijdens het yacht rock-tijdperk.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "CA5KR1839394",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1570550941",
+        "de": "applemusic://track/1570550941",
+        "gb": "applemusic://track/1570550941",
+        "fr": "applemusic://track/1570550941",
+        "es": "applemusic://track/1570550941",
+        "nl": "applemusic://track/1570550941",
+        "it": "applemusic://track/1570550941"
+      }
     },
     {
       "year": 1982,
@@ -1202,7 +1482,17 @@
       "uri_tidal": "tidal://track/40692",
       "uri_deezer": "deezer://track/831298",
       "fun_fact_nl": "Michael Jackson en Paul McCartneys eerste duet leidde tot een vriendschap voordat hun beroemde zakelijke conflict over de Beatles-catalogus uitbrak.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USJY51100057",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1623272739",
+        "de": "applemusic://track/1440665727",
+        "gb": "applemusic://track/1440665727",
+        "fr": "applemusic://track/1440665727",
+        "es": "applemusic://track/1440665727",
+        "nl": "applemusic://track/1440665727",
+        "it": "applemusic://track/1440665727"
+      }
     },
     {
       "year": 1981,
@@ -1292,7 +1582,17 @@
       "uri_tidal": "tidal://track/1274704",
       "uri_deezer": "deezer://track/5495387",
       "fun_fact_nl": "Geschreven over Steve Perry's toenmalige vriendin Sherrie Swafford, die ook in de muziekvideo verscheen. Het nummer was persoonlijker dan zijn Journey-werk.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM19916847",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/197977916",
+        "de": "applemusic://track/197977916",
+        "gb": "applemusic://track/197977916",
+        "fr": "applemusic://track/197977916",
+        "es": "applemusic://track/197977916",
+        "nl": "applemusic://track/197977916",
+        "it": "applemusic://track/197977916"
+      }
     },
     {
       "year": 1980,
@@ -1322,7 +1622,17 @@
       "uri_deezer": "deezer://track/1081069",
       "fun_fact_nl": "Barry Gibb schreef en produceerde dit voor Barbra Streisand. Het gelijknamige album werd het bestverkochte album van een vrouwelijke artiest op dat moment.",
       "awards_nl": [],
-      "uri_apple_music": "applemusic://track/1440862988"
+      "uri_apple_music": "applemusic://track/1440862988",
+      "isrc": "USUM71209505",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1471704327",
+        "de": "applemusic://track/1440854503",
+        "gb": "applemusic://track/1440854503",
+        "fr": "applemusic://track/1440854503",
+        "es": "applemusic://track/1440854503",
+        "nl": "applemusic://track/1440854503",
+        "it": "applemusic://track/1440854503"
+      }
     },
     {
       "year": 1979,
@@ -1348,7 +1658,17 @@
       "uri_tidal": "tidal://track/1290302",
       "uri_deezer": "deezer://track/487484172",
       "fun_fact_nl": "Won de Grammy voor Best R&B Song. Geschreven door David Foster, Jay Graydon en Bill Champlin, toonde het de zachtere kant van Earth, Wind & Fire.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBUM71502343",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1440831292",
+        "de": "applemusic://track/1440831292",
+        "gb": "applemusic://track/1440831292",
+        "fr": "applemusic://track/1440831292",
+        "es": "applemusic://track/1440831292",
+        "nl": "applemusic://track/1440831292",
+        "it": "applemusic://track/1440831292"
+      }
     },
     {
       "year": 1986,
@@ -1408,7 +1728,17 @@
       "uri_tidal": "tidal://track/37772290",
       "uri_deezer": "deezer://track/546801",
       "fun_fact_nl": "Geschreven door Jim Steinman, die ook 'Total Eclipse of the Heart' schreef. De epische productie past bij zijn kenmerkende bombastische stijl.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USAR18100182",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/939730110",
+        "de": "applemusic://track/939730110",
+        "gb": "applemusic://track/939730110",
+        "fr": "applemusic://track/939730110",
+        "es": "applemusic://track/939730110",
+        "nl": "applemusic://track/939730110",
+        "it": "applemusic://track/939730110"
+      }
     },
     {
       "year": 1972,
@@ -1468,7 +1798,17 @@
       "uri_tidal": "tidal://track/94405601",
       "uri_deezer": "deezer://track/13228242",
       "fun_fact_nl": "Dave Masons grootste solosucces. Geschreven door Jim Krueger, werd het een FM-radioklassieker over het accepteren van verschillen in relaties.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USUMG9900628",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1700308640",
+        "de": "applemusic://track/1700308640",
+        "gb": "applemusic://track/1700308640",
+        "fr": "applemusic://track/1700308640",
+        "es": "applemusic://track/1700308640",
+        "nl": "applemusic://track/1700308640",
+        "it": "applemusic://track/1700308640"
+      }
     },
     {
       "year": 1986,
@@ -1496,7 +1836,17 @@
       "uri_tidal": "tidal://track/1317421",
       "uri_deezer": "deezer://track/84340039",
       "fun_fact_nl": "Van Boston's Third Stage-album, dat uitkwam na een onderbreking van 8 jaar. Het perfectionisme van de band veroorzaakte aanzienlijke vertragingen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM10209145",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/185861143",
+        "de": "applemusic://track/185861143",
+        "gb": "applemusic://track/185861143",
+        "fr": "applemusic://track/185861143",
+        "es": "applemusic://track/185861143",
+        "nl": "applemusic://track/185861143",
+        "it": "applemusic://track/185861143"
+      }
     },
     {
       "year": 1980,
@@ -1526,7 +1876,17 @@
       "uri_tidal": "tidal://track/1809085",
       "uri_deezer": "deezer://track/599045",
       "fun_fact_nl": "The Pointer Sisters' crossover-hit bewees dat ze ook in de pop konden slagen naast R&B, waarmee de weg werd vrijgemaakt voor hun succes in de jaren 80.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM17700375",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1737735830",
+        "de": "applemusic://track/1737735830",
+        "gb": "applemusic://track/273854296",
+        "fr": "applemusic://track/1737735830",
+        "es": "applemusic://track/1737735830",
+        "nl": "applemusic://track/1737735830",
+        "it": "applemusic://track/1737735830"
+      }
     },
     {
       "year": 1974,
@@ -1556,7 +1916,17 @@
       "uri_tidal": "tidal://track/2865125",
       "uri_deezer": "deezer://track/106115758",
       "fun_fact_nl": "Hues Corporations eenaggers werd een discoklassieker, maar het vloeiende, pre-disco geluid past ook perfect bij yacht rock.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USAR18500001",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/303178225",
+        "de": "applemusic://track/212048187",
+        "gb": "applemusic://track/212048187",
+        "fr": "applemusic://track/212048187",
+        "es": "applemusic://track/212048187",
+        "nl": "applemusic://track/212048187",
+        "it": "applemusic://track/212048187"
+      }
     },
     {
       "year": 1983,
@@ -1586,7 +1956,17 @@
       "uri_tidal": "tidal://track/53230843",
       "uri_deezer": "deezer://track/831196",
       "fun_fact_nl": "Geschreven door TOTO's Steve Porcaro over zijn dochter die vragen stelde over menselijk gedrag. Het is een van Thrillers meest verfijnde nummers.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USWD11157157",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1440807780",
+        "de": "applemusic://track/1440807780",
+        "gb": "applemusic://track/1440807780",
+        "fr": "applemusic://track/1440807780",
+        "es": "applemusic://track/1440807780",
+        "nl": "applemusic://track/1440807780",
+        "it": "applemusic://track/1440807780"
+      }
     },
     {
       "year": 1973,
@@ -1616,7 +1996,17 @@
       "uri_tidal": "tidal://track/38298566",
       "uri_deezer": "deezer://track/620021372",
       "fun_fact_nl": "Later gecoverd door Uncle Kracker met Dobie Gray in 2003, wat een nog grotere hit werd. Het origineel blijft een yacht rock-essentieel.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM18200128",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/405600300",
+        "de": "applemusic://track/405600300",
+        "gb": "applemusic://track/405600300",
+        "fr": "applemusic://track/405600300",
+        "es": "applemusic://track/405600300",
+        "nl": "applemusic://track/405600300",
+        "it": "applemusic://track/405600300"
+      }
     },
     {
       "year": 1976,
@@ -1646,7 +2036,17 @@
       "uri_tidal": "tidal://track/539525",
       "uri_deezer": "deezer://track/3919664",
       "fun_fact_nl": "England Dan & John Ford Coley's grootste hit. De tekst 'I'm not talking 'bout moving in' maakte duidelijk dat dit over een vrijblijvende romance ging.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM19801933",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/185716729",
+        "de": "applemusic://track/185716729",
+        "gb": "applemusic://track/185716729",
+        "fr": "applemusic://track/185716729",
+        "es": "applemusic://track/185716729",
+        "nl": "applemusic://track/185716729",
+        "it": "applemusic://track/1007028881"
+      }
     },
     {
       "year": 1980,
@@ -1676,7 +2076,17 @@
       "uri_tidal": "tidal://track/26798608",
       "uri_deezer": "deezer://track/546793",
       "fun_fact_nl": "Air Supplys eerste Amerikaanse hit vestigde hun kenmerkende geluid van zwevende harmonieën en romantische teksten.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM17500265",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/186183809",
+        "de": "applemusic://track/186183809",
+        "gb": "applemusic://track/309850174",
+        "fr": "applemusic://track/186183809",
+        "es": "applemusic://track/309850174",
+        "nl": "applemusic://track/309850174",
+        "it": "applemusic://track/309850174"
+      }
     },
     {
       "year": 1988,
@@ -1706,7 +2116,17 @@
       "uri_tidal": "tidal://track/213218874",
       "uri_deezer": "deezer://track/75487832",
       "fun_fact_nl": "Eric Carmens late comeback-hit bracht een eerbetoon aan het geluid van de vroege jaren 60 met zijn oldies-stijlproductie en nostalgische teksten.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USA370532331",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1606273844",
+        "de": "applemusic://track/1606273844",
+        "gb": "applemusic://track/1606273844",
+        "fr": "applemusic://track/1606273844",
+        "es": "applemusic://track/1606273844",
+        "nl": "applemusic://track/1606273844",
+        "it": "applemusic://track/1606273844"
+      }
     },
     {
       "year": 1984,
@@ -1736,7 +2156,17 @@
       "uri_tidal": "tidal://track/1783784",
       "uri_deezer": "deezer://track/2168095",
       "fun_fact_nl": "Billy Oceans grootste hit werd ook uitgebracht als 'European Queen' en 'African Queen' met licht aangepaste teksten voor verschillende markten.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM17700889",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1142416117",
+        "de": "applemusic://track/1142416117",
+        "gb": "applemusic://track/1142416117",
+        "fr": "applemusic://track/1142416117",
+        "es": "applemusic://track/1142416117",
+        "nl": "applemusic://track/1142416117",
+        "it": "applemusic://track/1142416117"
+      }
     },
     {
       "year": 1981,
@@ -1766,7 +2196,17 @@
       "uri_tidal": "tidal://track/27331623",
       "uri_deezer": "deezer://track/12754211",
       "fun_fact_nl": "REO Speedwagons Hi Infidelity-album stond 15 weken op nummer 1. Dit nummer over vermoed overspel was een radioklassieker.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USUM71022556",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1440869600",
+        "de": "applemusic://track/1440869600",
+        "gb": "applemusic://track/1440869600",
+        "fr": "applemusic://track/1440869600",
+        "es": "applemusic://track/1440869600",
+        "nl": "applemusic://track/1440869600",
+        "it": "applemusic://track/1440869600"
+      }
     },
     {
       "year": 1974,
@@ -1826,7 +2266,17 @@
       "uri_tidal": "tidal://track/1781812",
       "uri_deezer": "deezer://track/13142737",
       "fun_fact_nl": "The Pointer Sisters' sensuele hit werd in 1981 als behoorlijk provocatief beschouwd vanwege de suggestieve teksten over het nemen van de tijd in de romance.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM19902992",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1641781005",
+        "de": "applemusic://track/1641781005",
+        "gb": "applemusic://track/1641781005",
+        "fr": "applemusic://track/1641781005",
+        "es": "applemusic://track/1641781005",
+        "nl": "applemusic://track/1641781005",
+        "it": "applemusic://track/1641781005"
+      }
     },
     {
       "year": 1978,
@@ -1857,7 +2307,17 @@
       "uri_tidal": "tidal://track/2865114",
       "uri_deezer": "deezer://track/3169189",
       "fun_fact_nl": "Het iconische saxofoonriff werd gespeeld door Raphael Ravenscroft, die naar verluidt niet blij was met zijn betaling voor het creëren van zo'n memorabele hook.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USAR18000002",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/280839462",
+        "de": "applemusic://track/280839462",
+        "gb": "applemusic://track/280839462",
+        "fr": "applemusic://track/280839462",
+        "es": "applemusic://track/280839462",
+        "nl": "applemusic://track/280839462",
+        "it": "applemusic://track/280839462"
+      }
     },
     {
       "year": 1978,
@@ -1887,7 +2347,17 @@
       "uri_tidal": "tidal://track/668084",
       "uri_deezer": "deezer://track/1559253732",
       "fun_fact_nl": "Een duet tussen Chris Norman van Smokie en Suzi Quatro, het was groter in Amerika dan in het thuisland van beide artiesten.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USRC18101745",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/298411223",
+        "de": "applemusic://track/298411223",
+        "gb": "applemusic://track/298411223",
+        "fr": "applemusic://track/298411223",
+        "es": "applemusic://track/298411223",
+        "nl": "applemusic://track/298411223",
+        "it": "applemusic://track/298411223"
+      }
     },
     {
       "year": 1980,
@@ -1917,7 +2387,17 @@
       "uri_deezer": "deezer://track/5094396",
       "fun_fact_nl": "Geproduceerd door Quincy Jones, hielp het George Benson te vestigen als een smooth jazz-pop-crossover artiest in plaats van alleen een jazzgitarist.",
       "awards_nl": [],
-      "uri_tidal": "tidal://track/3529717"
+      "uri_tidal": "tidal://track/3529717",
+      "isrc": "USAR11300099",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/815691921",
+        "de": "applemusic://track/815691921",
+        "gb": "applemusic://track/815691921",
+        "fr": "applemusic://track/815691921",
+        "es": "applemusic://track/815691921",
+        "nl": "applemusic://track/815691921",
+        "it": "applemusic://track/815691921"
+      }
     },
     {
       "year": 1982,
@@ -1947,7 +2427,17 @@
       "uri_deezer": "deezer://track/5617796",
       "fun_fact_nl": "Michael McDonalds solosucces werd later beroemd gesampeld door Warren G voor 'Regulate', waarmee het een nieuwe generatie kennis maakte.",
       "awards_nl": [],
-      "uri_tidal": "tidal://track/2913652"
+      "uri_tidal": "tidal://track/2913652",
+      "isrc": "USRH10553197",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1710519401",
+        "de": "applemusic://track/1846832145",
+        "gb": "applemusic://track/1846832145",
+        "fr": "applemusic://track/1846832145",
+        "es": "applemusic://track/1846832145",
+        "nl": "applemusic://track/1846832145",
+        "it": "applemusic://track/1846832145"
+      }
     },
     {
       "year": 1976,
@@ -1977,7 +2467,17 @@
       "uri_deezer": "deezer://track/563391",
       "fun_fact_nl": "Won Grammy voor Best R&B Song. Boz Scaggs' verfijnde vermenging van rock, R&B en jazz definieerde het yacht rock-geluid.",
       "awards_nl": [],
-      "uri_tidal": "tidal://track/247879940"
+      "uri_tidal": "tidal://track/247879940",
+      "isrc": "ITUM71500030",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1440872746",
+        "de": "applemusic://track/1440872746",
+        "gb": "applemusic://track/1440872746",
+        "fr": "applemusic://track/1440872746",
+        "es": "applemusic://track/1440872746",
+        "nl": "applemusic://track/1440872746",
+        "it": "applemusic://track/1440872746"
+      }
     },
     {
       "year": 1972,
@@ -2007,7 +2507,17 @@
       "uri_deezer": "deezer://track/569737",
       "fun_fact_nl": "Dr. Hook's verhalende nummer over het niet mogen spreken met een ex-vriendin was gebaseerd op een waargebeurd verhaal van schrijver Shel Silverstein.",
       "awards_nl": [],
-      "uri_tidal": "tidal://track/2975741"
+      "uri_tidal": "tidal://track/2975741",
+      "isrc": "USAR18200001",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1739927802",
+        "de": "applemusic://track/1739927802",
+        "gb": "applemusic://track/1739927802",
+        "fr": "applemusic://track/1739927802",
+        "es": "applemusic://track/1739927802",
+        "nl": "applemusic://track/1739927802",
+        "it": "applemusic://track/1739927802"
+      }
     },
     {
       "year": 1982,
@@ -2037,7 +2547,17 @@
       "uri_deezer": "deezer://track/4213907",
       "fun_fact_nl": "Air Supplys reeks soft rock-hits in het begin van de jaren 80 maakte hen een van de meest betrouwbare hitmakers van het tijdperk.",
       "awards_nl": [],
-      "uri_tidal": "tidal://track/3120908"
+      "uri_tidal": "tidal://track/3120908",
+      "isrc": "USWB10902424",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/321976389",
+        "de": "applemusic://track/1734384167",
+        "gb": "applemusic://track/1734384167",
+        "fr": "applemusic://track/1734384167",
+        "es": "applemusic://track/1734384167",
+        "nl": "applemusic://track/1734384167",
+        "it": "applemusic://track/1734384167"
+      }
     },
     {
       "year": 1980,
@@ -2095,7 +2615,17 @@
       "uri_deezer": "deezer://track/7721441",
       "fun_fact_nl": "Pages was een kortlevende maar invloedrijke yacht rock-band met de latere Mr. Mister-leden Steve George en Richard Page.",
       "awards_nl": [],
-      "uri_tidal": "tidal://track/7721440"
+      "uri_tidal": "tidal://track/7721440",
+      "isrc": "USRH11602321",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1111749679",
+        "de": "applemusic://track/1111749679",
+        "gb": "applemusic://track/1111749679",
+        "fr": "applemusic://track/1111749679",
+        "es": "applemusic://track/1111749679",
+        "nl": "applemusic://track/1111749679",
+        "it": "applemusic://track/1111749679"
+      }
     },
     {
       "year": 1977,
@@ -2185,7 +2715,17 @@
       "uri_deezer": "deezer://track/664442",
       "fun_fact_nl": "Een Fleetwood Mac-duet tussen Christine McVie en Lindsey Buckingham van Mirage, hun commercieel meest succesvolle 80s-album.",
       "awards_nl": [],
-      "uri_tidal": "tidal://track/17182856"
+      "uri_tidal": "tidal://track/17182856",
+      "isrc": "GBUM71507422",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1440833748",
+        "de": "applemusic://track/1440833748",
+        "gb": "applemusic://track/1440833748",
+        "fr": "applemusic://track/1440833748",
+        "es": "applemusic://track/1440833748",
+        "nl": "applemusic://track/1440833748",
+        "it": "applemusic://track/1440833748"
+      }
     },
     {
       "year": 1981,
@@ -2215,7 +2755,17 @@
       "uri_deezer": "deezer://track/90094593",
       "fun_fact_nl": "Gino Vannelli's vloeiende falsetto en verfijnde productie maakten hem een yacht rock-cultfavoriet ondanks beperkt hitparadesucces.",
       "awards_nl": [],
-      "uri_tidal": "tidal://track/2870866"
+      "uri_tidal": "tidal://track/2870866",
+      "isrc": "USSM17600650",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/913902467",
+        "de": "applemusic://track/913902467",
+        "gb": "applemusic://track/913902467",
+        "fr": "applemusic://track/913902467",
+        "es": "applemusic://track/913902467",
+        "nl": "applemusic://track/913902467",
+        "it": "applemusic://track/913902467"
+      }
     },
     {
       "year": 1975,
@@ -2245,7 +2795,17 @@
       "uri_deezer": "deezer://track/13184502",
       "fun_fact_nl": "Melissa Manchesters doorbraakhit toonde haar krachtige stem en Barry Manilows invloed als haar vroege producer.",
       "awards_nl": [],
-      "uri_tidal": "tidal://track/4929771"
+      "uri_tidal": "tidal://track/4929771",
+      "isrc": "USSM18000120",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/356893398",
+        "de": "applemusic://track/356893398",
+        "gb": "applemusic://track/356893398",
+        "fr": "applemusic://track/356893398",
+        "es": "applemusic://track/356893398",
+        "nl": "applemusic://track/356893398",
+        "it": "applemusic://track/356893398"
+      }
     },
     {
       "year": 1980,
@@ -2275,7 +2835,17 @@
       "uri_deezer": "deezer://track/5431773",
       "fun_fact_nl": "Van de Caddyshack-soundtrack. Kenny Loggins werd Hollywoods go-to-man voor filmsoundtracks na dit nummer en 'Footloose'.",
       "awards_nl": [],
-      "uri_tidal": "tidal://track/2865128"
+      "uri_tidal": "tidal://track/2865128",
+      "isrc": "USSM19801712",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1372947839",
+        "de": "applemusic://track/1372947839",
+        "gb": "applemusic://track/1372947839",
+        "fr": "applemusic://track/1372947839",
+        "es": "applemusic://track/1372947839",
+        "nl": "applemusic://track/1372947839",
+        "it": "applemusic://track/1372947839"
+      }
     },
     {
       "year": 1972,
@@ -2305,7 +2875,17 @@
       "uri_deezer": "deezer://track/672394",
       "fun_fact_nl": "Todd Rundgrens enige grote hit. Hij staat beter bekend als producer (Meat Loafs Bat Out of Hell) dan voor zijn eigen muziek.",
       "awards_nl": [],
-      "uri_tidal": "tidal://track/2961406"
+      "uri_tidal": "tidal://track/2961406",
+      "isrc": "USSM17700371",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1739853941",
+        "de": "applemusic://track/1739853941",
+        "gb": "applemusic://track/1739853941",
+        "fr": "applemusic://track/1739853941",
+        "es": "applemusic://track/1739853941",
+        "nl": "applemusic://track/1739853941",
+        "it": "applemusic://track/1739853941"
+      }
     },
     {
       "year": 1984,
@@ -2335,7 +2915,17 @@
       "uri_deezer": "deezer://track/1014360",
       "fun_fact_nl": "Dan Fogelbergs soft rock-ballade ving de gevoelige singer-songwriter-esthetiek van het begin van de jaren 80 perfect.",
       "awards_nl": [],
-      "uri_tidal": "tidal://track/2865129"
+      "uri_tidal": "tidal://track/2865129",
+      "isrc": "USWB19901801",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1829435604",
+        "de": "applemusic://track/1626974448",
+        "gb": "applemusic://track/1626974448",
+        "fr": "applemusic://track/1626974448",
+        "es": "applemusic://track/1626974448",
+        "nl": "applemusic://track/1626974448",
+        "it": "applemusic://track/1626974448"
+      }
     },
     {
       "year": 1971,
@@ -2365,7 +2955,17 @@
       "uri_deezer": "deezer://track/119819700",
       "fun_fact_nl": "Van Carole Kings Tapestry, een van de bestverkochte albums ooit. Ze schreef het over het missen van haar familie tijdens een tournee.",
       "awards_nl": [],
-      "uri_tidal": "tidal://track/2858729"
+      "uri_tidal": "tidal://track/2858729",
+      "isrc": "USSM18600734",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1739905634",
+        "de": "applemusic://track/1739905634",
+        "gb": "applemusic://track/1739905634",
+        "fr": "applemusic://track/1739905634",
+        "es": "applemusic://track/1739905634",
+        "nl": "applemusic://track/1739905634",
+        "it": "applemusic://track/1739905634"
+      }
     },
     {
       "year": 1981,
@@ -2393,7 +2993,17 @@
       "uri_deezer": "deezer://track/70353308",
       "fun_fact_nl": "Atlanta Rhythm Sections vloeiende Southern rock begaf zich in yacht rock-territorium met zijn gepolijste productie.",
       "awards_nl": [],
-      "uri_tidal": "tidal://track/17686571"
+      "uri_tidal": "tidal://track/17686571",
+      "isrc": "USMC17347184",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1686459150",
+        "de": "applemusic://track/1440803730",
+        "gb": "applemusic://track/1440803730",
+        "fr": "applemusic://track/1440803730",
+        "es": "applemusic://track/1440803730",
+        "nl": "applemusic://track/1440803730",
+        "it": "applemusic://track/1440803730"
+      }
     },
     {
       "year": 1975,
@@ -2423,7 +3033,17 @@
       "uri_deezer": "deezer://track/725715",
       "fun_fact_nl": "Oorspronkelijk geschreven over het einde van de drooglegging, veranderde Frankie Valli het in een nummer over het verliezen van de maagdelijkheid. Het bereikte opnieuw nummer 1 in een remix uit 1994.",
       "awards_nl": [],
-      "uri_tidal": "tidal://track/2963680"
+      "uri_tidal": "tidal://track/2963680",
+      "isrc": "USDJ29800844",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1443170382",
+        "de": null,
+        "gb": null,
+        "fr": null,
+        "es": null,
+        "nl": null,
+        "it": null
+      }
     },
     {
       "year": 1978,
@@ -2453,7 +3073,17 @@
       "uri_deezer": "deezer://track/1762490187",
       "fun_fact_nl": "Pablo Cruises grootste hit belichaamde het ontspannen Californische yacht rock-geluid met zijn optimistische boodschap en vloeiende harmonieën.",
       "awards_nl": [],
-      "uri_tidal": "tidal://track/7453549"
+      "uri_tidal": "tidal://track/7453549",
+      "isrc": "USRC19901209",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/399222355",
+        "de": "applemusic://track/399222355",
+        "gb": "applemusic://track/399222355",
+        "fr": "applemusic://track/399222355",
+        "es": "applemusic://track/399222355",
+        "nl": "applemusic://track/399222355",
+        "it": "applemusic://track/399222355"
+      }
     },
     {
       "year": 1984,
@@ -2541,7 +3171,17 @@
       "uri_deezer": "deezer://track/6599446",
       "fun_fact_nl": "Paul Simons meditatie over de strubbelingen van het leven bevatte de Oak Ridge Boys op achtergrondzang, een ongebruikelijke maar effectieve combinatie.",
       "awards_nl": [],
-      "uri_tidal": "tidal://track/2867459"
+      "uri_tidal": "tidal://track/2867459",
+      "isrc": "USMO17700543",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1692666726",
+        "de": "applemusic://track/1692666726",
+        "gb": "applemusic://track/1692666726",
+        "fr": "applemusic://track/1692666726",
+        "es": "applemusic://track/1692666726",
+        "nl": "applemusic://track/1692666726",
+        "it": "applemusic://track/1692666726"
+      }
     },
     {
       "year": 1979,
@@ -2569,7 +3209,17 @@
       "uri_deezer": "deezer://track/1080433",
       "fun_fact_nl": "TOTO's verfijnde muzikantschap was altijd aanwezig. De bandleden waren topstudio-muzikanten in LA voordat ze de groep vormden.",
       "awards_nl": [],
-      "uri_tidal": "tidal://track/3670330"
+      "uri_tidal": "tidal://track/3670330",
+      "isrc": "DEUM71602001",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1440841456",
+        "de": "applemusic://track/1440841456",
+        "gb": "applemusic://track/1440841456",
+        "fr": "applemusic://track/1440841456",
+        "es": "applemusic://track/1440841456",
+        "nl": "applemusic://track/1440841456",
+        "it": "applemusic://track/1440841456"
+      }
     },
     {
       "year": 1982,
@@ -2597,7 +3247,17 @@
       "uri_deezer": "deezer://track/74494297",
       "fun_fact_nl": "Herbie Hancocks smooth jazz-crossover hielp de kloof te overbruggen tussen jazzfusie en pop, en sprak yacht rock-fans aan.",
       "awards_nl": [],
-      "uri_tidal": "tidal://track/3529720"
+      "uri_tidal": "tidal://track/3529720",
+      "isrc": "USEE19901162",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/310527535",
+        "de": "applemusic://track/310527535",
+        "gb": "applemusic://track/310527535",
+        "fr": "applemusic://track/310527535",
+        "es": "applemusic://track/310527535",
+        "nl": "applemusic://track/310527535",
+        "it": "applemusic://track/310527535"
+      }
     },
     {
       "year": 1982,
@@ -2627,7 +3287,17 @@
       "uri_deezer": "deezer://track/540671",
       "fun_fact_nl": "Bezorgde Melissa Manchester de Grammy voor Best Female Pop Vocal Performance. Een late-carrière-hit die haar populariteit nieuw leven inblies.",
       "awards_nl": [],
-      "uri_tidal": "tidal://track/4929774"
+      "uri_tidal": "tidal://track/4929774",
+      "isrc": "USSM17800433",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/890507498",
+        "de": "applemusic://track/890507498",
+        "gb": "applemusic://track/890507498",
+        "fr": "applemusic://track/890507498",
+        "es": "applemusic://track/890507498",
+        "nl": "applemusic://track/890507498",
+        "it": "applemusic://track/890507498"
+      }
     },
     {
       "year": 1979,
@@ -2657,7 +3327,17 @@
       "uri_deezer": "deezer://track/970621",
       "fun_fact_nl": "Ray Parker Jr. vóór zijn Ghostbusters-roem. Zijn vloeiende R&B-stijl paste perfect naast yacht rock op de late jaren 70-radio.",
       "awards_nl": [],
-      "uri_tidal": "tidal://track/6831426"
+      "uri_tidal": "tidal://track/6831426",
+      "isrc": "NLF057790013",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1700309394",
+        "de": "applemusic://track/1700309394",
+        "gb": "applemusic://track/1700309394",
+        "fr": "applemusic://track/1700309394",
+        "es": "applemusic://track/1700309394",
+        "nl": "applemusic://track/1700309394",
+        "it": "applemusic://track/1700309394"
+      }
     },
     {
       "year": 1982,
@@ -2687,7 +3367,17 @@
       "uri_deezer": "deezer://track/729597952",
       "fun_fact_nl": "America's comeback-hit uit de jaren 80 werd geschreven door Russ Ballard en toonde aan dat ze zich konden aanpassen aan de gepolijste productiestijl van het decennium.",
       "awards_nl": [],
-      "uri_tidal": "tidal://track/2858234"
+      "uri_tidal": "tidal://track/2858234",
+      "isrc": "USSM19900786",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/703069487",
+        "de": "applemusic://track/571726",
+        "gb": "applemusic://track/571726",
+        "fr": "applemusic://track/571726",
+        "es": "applemusic://track/703069487",
+        "nl": "applemusic://track/703069487",
+        "it": "applemusic://track/703069487"
+      }
     },
     {
       "year": 1974,
@@ -2717,7 +3407,17 @@
       "uri_deezer": "deezer://track/599402",
       "fun_fact_nl": "Barry Manilows inspirerende hit toonde zijn theatrale, Broadway-geïnspireerde popstijl die hem een soft rock-vaste waarde maakte.",
       "awards_nl": [],
-      "uri_tidal": "tidal://track/2903685"
+      "uri_tidal": "tidal://track/2903685",
+      "isrc": "USWB19903128",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1550936576",
+        "de": "applemusic://track/1550936576",
+        "gb": "applemusic://track/1550936576",
+        "fr": "applemusic://track/1550936576",
+        "es": "applemusic://track/1550936576",
+        "nl": "applemusic://track/1550936576",
+        "it": "applemusic://track/1550936576"
+      }
     },
     {
       "year": 1985,
@@ -2745,7 +3445,17 @@
       "uri_deezer": "deezer://track/13145316",
       "fun_fact_nl": "Air Supply zette hun hitreeks voort tot in het midden van de jaren 80, wat bewees dat de vraag naar romantische soft rock-ballades sterk bleef.",
       "awards_nl": [],
-      "uri_tidal": "tidal://track/3120920"
+      "uri_tidal": "tidal://track/3120920",
+      "isrc": "USSM17800845",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1456446747",
+        "de": "applemusic://track/1456446747",
+        "gb": "applemusic://track/1456446747",
+        "fr": "applemusic://track/1456446747",
+        "es": "applemusic://track/1456446747",
+        "nl": "applemusic://track/1456446747",
+        "it": "applemusic://track/1456446747"
+      }
     },
     {
       "year": 1975,
@@ -2775,7 +3485,17 @@
       "uri_deezer": "deezer://track/3821960",
       "fun_fact_nl": "Gary Wrights synthesizer-gedreven hit was zijn tijd vooruit. Het werd gebruikt in Wayne's World en introduceerde het nummer bij een nieuwe generatie.",
       "awards_nl": [],
-      "uri_tidal": "tidal://track/2970073"
+      "uri_tidal": "tidal://track/2970073",
+      "isrc": "USSM10210125",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1227004981",
+        "de": "applemusic://track/1227004981",
+        "gb": "applemusic://track/1227004981",
+        "fr": "applemusic://track/1227004981",
+        "es": "applemusic://track/1227004981",
+        "nl": "applemusic://track/1227004981",
+        "it": "applemusic://track/1227004981"
+      }
     },
     {
       "year": 1980,
@@ -2805,7 +3525,17 @@
       "uri_deezer": "deezer://track/764505",
       "fun_fact_nl": "Ambrosias vloeiende geluid en ingewikkelde harmonieën maakten hen tot yacht rock-favorieten. David Packs zang schittert op dit nummer.",
       "awards_nl": [],
-      "uri_tidal": "tidal://track/2857836"
+      "uri_tidal": "tidal://track/2857836",
+      "isrc": "HKG079900410",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1443389089",
+        "de": "applemusic://track/1443389089",
+        "gb": "applemusic://track/1443389089",
+        "fr": "applemusic://track/1443389089",
+        "es": "applemusic://track/1443389089",
+        "nl": "applemusic://track/1443389089",
+        "it": "applemusic://track/1443389089"
+      }
     },
     {
       "year": 1980,
@@ -2833,7 +3563,17 @@
       "uri_deezer": "deezer://track/7453550",
       "fun_fact_nl": "Airplay was een kortlevende supergroep met Jay Graydon en David Foster - twee van de belangrijkste producers van yacht rock.",
       "awards_nl": [],
-      "uri_tidal": "tidal://track/7453548"
+      "uri_tidal": "tidal://track/7453548",
+      "isrc": "USSM18400714",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/194771488",
+        "de": "applemusic://track/194771488",
+        "gb": "applemusic://track/194771488",
+        "fr": "applemusic://track/194771488",
+        "es": "applemusic://track/194771488",
+        "nl": "applemusic://track/194771488",
+        "it": "applemusic://track/194771488"
+      }
     },
     {
       "year": 1977,
@@ -2863,7 +3603,17 @@
       "uri_deezer": "deezer://track/548727132",
       "fun_fact_nl": "Chuck Mangiones flugelhorn-instrumentaal waaide over naar de popradio, waarmee werd bewezen dat jazz commercieel succesvol kon zijn.",
       "awards_nl": [],
-      "uri_tidal": "tidal://track/3514547"
+      "uri_tidal": "tidal://track/3514547",
+      "isrc": "USMC17947237",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1700307672",
+        "de": "applemusic://track/1700307672",
+        "gb": "applemusic://track/1700307672",
+        "fr": "applemusic://track/1700307672",
+        "es": "applemusic://track/1700307672",
+        "nl": "applemusic://track/1700307672",
+        "it": "applemusic://track/1700307672"
+      }
     },
     {
       "year": 1982,
@@ -2893,7 +3643,17 @@
       "uri_deezer": "deezer://track/3551809",
       "fun_fact_nl": "Air Supplys reeks van zeven opeenvolgende top vijf-hits in Amerika werd door geen enkele andere soft rock-act van het tijdperk geëvenaard.",
       "awards_nl": [],
-      "uri_tidal": "tidal://track/3120906"
+      "uri_tidal": "tidal://track/3120906",
+      "isrc": "USWB10902466",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1778245411",
+        "de": "applemusic://track/1231208857",
+        "gb": "applemusic://track/1231208857",
+        "fr": "applemusic://track/1231208857",
+        "es": "applemusic://track/1231208857",
+        "nl": "applemusic://track/1231208857",
+        "it": "applemusic://track/1231208857"
+      }
     },
     {
       "year": 1988,
@@ -2949,7 +3709,17 @@
       "awards_nl": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=qmOLtTGvsbM",
       "uri_apple_music": "applemusic://track/1440841470",
-      "uri_tidal": "tidal://track/542177"
+      "uri_tidal": "tidal://track/542177",
+      "isrc": "DEUM71602005",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1440841470",
+        "de": "applemusic://track/1440841470",
+        "gb": "applemusic://track/1440841470",
+        "fr": "applemusic://track/1440841470",
+        "es": "applemusic://track/1440841470",
+        "nl": "applemusic://track/1440841470",
+        "it": "applemusic://track/1440841470"
+      }
     },
     {
       "year": 1982,

--- a/custom_components/beatify/playlists/disco-funk-classics.json
+++ b/custom_components/beatify/playlists/disco-funk-classics.json
@@ -39,7 +39,17 @@
       "uri_tidal": "tidal://track/26703889",
       "uri_deezer": "deezer://track/27533081",
       "fun_fact_nl": "Geschreven door Jon Lind en Allee Willis, die geïnspireerd was door de discoscene in Studio 54. Het nummer bevat The Emotions als achtergrondzangeressen en werd decennia later prominent gebruikt in de film 'Happy Feet'.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM19922860",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1626507943",
+        "de": "applemusic://track/1626507943",
+        "gb": "applemusic://track/1626507943",
+        "fr": "applemusic://track/1626507943",
+        "es": "applemusic://track/1626507943",
+        "nl": "applemusic://track/1626507943",
+        "it": "applemusic://track/1626507943"
+      }
     },
     {
       "year": 1978,
@@ -70,7 +80,17 @@
       "uri_tidal": "tidal://track/68699222",
       "uri_deezer": "deezer://track/72060062",
       "fun_fact_nl": "Oorspronkelijk getiteld 'Fuck Off', nadat Nile Rodgers en Bernard Edwards de toegang tot Studio 54 werd geweigerd. De bestverkochte single ooit van Atlantic Records op dat moment, het stond vijf weken op nummer 1 in de Billboard Hot 100.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USRH11803270",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1442990560",
+        "de": "applemusic://track/1442990560",
+        "gb": "applemusic://track/1442990560",
+        "fr": "applemusic://track/1442990560",
+        "es": "applemusic://track/1442990560",
+        "nl": "applemusic://track/1442990560",
+        "it": "applemusic://track/1442990560"
+      }
     },
     {
       "year": 1977,
@@ -101,7 +121,17 @@
       "uri_tidal": "tidal://track/68493629",
       "uri_deezer": "deezer://track/406815322",
       "fun_fact_nl": "Het tempo van 104 BPM is het ideale ritme voor hartmassage bij reanimatie, en het wordt nu wereldwijd gebruikt in medische trainingen. Het stond vier weken op nummer 1 en werd het signatuurlied van het Saturday Night Fever-tijdperk.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "NLF057790034",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1884981998",
+        "de": "applemusic://track/1884981998",
+        "gb": "applemusic://track/1884981998",
+        "fr": "applemusic://track/1884981998",
+        "es": "applemusic://track/1884981998",
+        "nl": "applemusic://track/1884981998",
+        "it": "applemusic://track/1884981998"
+      }
     },
     {
       "year": 1982,
@@ -132,7 +162,17 @@
       "uri_tidal": "tidal://track/3392942",
       "uri_deezer": "deezer://track/555755",
       "fun_fact_nl": "Geschreven door Paul Jabara en Paul Shaffer (van Late Show-faam). Hoewel het slechts nummer 46 bereikte in de VS, werd het een enorme hit in het VK en een blijvende gay-hymne. Geri Halliwells cover uit 2001 bereikte de top in het VK.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM19913325",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/347282458",
+        "de": "applemusic://track/1076305745",
+        "gb": "applemusic://track/453302693",
+        "fr": "applemusic://track/273098536",
+        "es": "applemusic://track/273098536",
+        "nl": "applemusic://track/273098536",
+        "it": "applemusic://track/273098536"
+      }
     },
     {
       "year": 1976,
@@ -163,7 +203,17 @@
       "uri_tidal": "tidal://track/1277159",
       "uri_deezer": "deezer://track/364951",
       "fun_fact_nl": "Gecreëerd door producer Frank Farian, die later berucht werd vanwege het Milli Vanilli lipsync-schandaal. De mannelijke hoofdzang op Boney M.-platen werd eigenlijk verzorgd door Farian zelf, niet door frontman Bobby Farrell.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEC737600002",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1739904607",
+        "de": "applemusic://track/1739904607",
+        "gb": "applemusic://track/1739904607",
+        "fr": "applemusic://track/1739904607",
+        "es": "applemusic://track/1739904607",
+        "nl": "applemusic://track/1739904607",
+        "it": "applemusic://track/402741374"
+      }
     },
     {
       "year": 1980,
@@ -194,7 +244,17 @@
       "uri_tidal": "tidal://track/3094190",
       "uri_deezer": "deezer://track/95873824",
       "fun_fact_nl": "Werd het onofficiële hymne bij de vrijlating van de Amerikaanse gijzelaars uit Iran in 1981 en is sindsdien een vaste waarde bij feestelijkheden wereldwijd. Het stond twee weken op nummer 1 en is een van de meest gedraaide nummers bij bruiloften en sportevenementen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USPR38007190",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1444107530",
+        "de": "applemusic://track/1444107530",
+        "gb": "applemusic://track/1444107530",
+        "fr": "applemusic://track/1444107530",
+        "es": "applemusic://track/1444107530",
+        "nl": "applemusic://track/1444107530",
+        "it": "applemusic://track/1444107530"
+      }
     },
     {
       "year": 1979,
@@ -225,7 +285,17 @@
       "uri_tidal": "tidal://track/14511863",
       "uri_deezer": "deezer://track/4077573",
       "fun_fact_nl": "De eenaggers van deze Belgisch-Franse zangeres verkocht wereldwijd meer dan 20 miljoen exemplaren. Madonna was ooit een achtergronddanseres van Hernandez voordat ze beroemd werd. Het nummer werd oorspronkelijk opgenomen in 1978 maar werd pas in 1979 een wereldwijde hit.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "FRX957900007",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/325803688",
+        "de": "applemusic://track/325803688",
+        "gb": "applemusic://track/325803688",
+        "fr": "applemusic://track/325803688",
+        "es": "applemusic://track/325803688",
+        "nl": "applemusic://track/325803688",
+        "it": "applemusic://track/325803688"
+      }
     },
     {
       "year": 1976,
@@ -257,7 +327,17 @@
       "uri_tidal": "tidal://track/1771745",
       "uri_deezer": "deezer://track/884025",
       "fun_fact_nl": "ABBA's enige nummer 1-hit in de VS, uitgevoerd op het privéfeest vóór het huwelijk van de Zweedse koning Carl XVI Gustaf en koningin Silvia in 1976. De openingspiano was geïnspireerd op George McCrae's 'Rock Your Baby'. Het is het meest gestreamde ABBA-nummer op Spotify.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "SEAYD7601020",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1580810375",
+        "de": "applemusic://track/1580810375",
+        "gb": "applemusic://track/1580810375",
+        "fr": "applemusic://track/1580810375",
+        "es": "applemusic://track/1560739878",
+        "nl": "applemusic://track/1711492527",
+        "it": "applemusic://track/1580810375"
+      }
     },
     {
       "year": 1984,
@@ -288,7 +368,17 @@
       "uri_tidal": "tidal://track/3392941",
       "uri_deezer": "deezer://track/346967941",
       "fun_fact_nl": "Oorspronkelijk uitgebracht in 1982 en gefloopt, maar opnieuw opgenomen met een sneller tempo en in 1984 opnieuw uitgebracht met groot succes. Het nummer kreeg hernieuwde bekendheid door de cafeïnepillen-inzinkingsscène van Jessie Spano in 'Saved by the Bell'.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USRC18203285",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1681210235",
+        "de": "applemusic://track/1681210235",
+        "gb": "applemusic://track/1681210235",
+        "fr": "applemusic://track/1681210235",
+        "es": "applemusic://track/1681210235",
+        "nl": "applemusic://track/1681210235",
+        "it": "applemusic://track/1681210235"
+      }
     },
     {
       "year": 1980,
@@ -350,7 +440,17 @@
       "uri_tidal": "tidal://track/1771758",
       "uri_deezer": "deezer://track/884041",
       "fun_fact_nl": "Nooit uitgebracht als single in de VS, maar een enorme hit door heel Europa. Madonna sampelde het kenmerkende riff voor 'Hung Up' in 2005, waarmee het het eerste ABBA-nummer werd dat officieel gesampeld werd. De muziekvideo was een van ABBA's meest sfeervolle.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "SEAYD7901120",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1602387451",
+        "de": "applemusic://track/1602387451",
+        "gb": "applemusic://track/1602387451",
+        "fr": "applemusic://track/1602387451",
+        "es": "applemusic://track/1602387451",
+        "nl": "applemusic://track/1602387451",
+        "it": "applemusic://track/1602387451"
+      }
     },
     {
       "year": 1978,
@@ -379,7 +479,17 @@
       "uri_tidal": "tidal://track/11335946",
       "uri_deezer": "deezer://track/72208034",
       "fun_fact_nl": "Opmerkelijk genoeg werd dit nummer geschreven door een Engelse zanger die ook Mick Jackson heet (geen familie). Beide versies werden gelijktijdig uitgebracht, maar The Jacksons' versie werd de definitieve hit. Het was hun eerste single na het verlaten van Motown voor Epic Records.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM17801024",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1398208591",
+        "de": "applemusic://track/1398208591",
+        "gb": "applemusic://track/1398208591",
+        "fr": "applemusic://track/1398208591",
+        "es": "applemusic://track/1398208591",
+        "nl": "applemusic://track/1398208591",
+        "it": "applemusic://track/1130014385"
+      }
     },
     {
       "year": 1980,
@@ -410,7 +520,17 @@
       "uri_tidal": "tidal://track/87782159",
       "uri_deezer": "deezer://track/4677572",
       "fun_fact_nl": "Geproduceerd door CHIC's Nile Rodgers en Bernard Edwards, maar Motown-baas Berry Gordy remixte het zonder hun toestemming. Ondanks de controverse stond het vier weken op nummer 1 en werd het Diana Ross' grootste solosucces.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMO18000379",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1852045429",
+        "de": "applemusic://track/1852045429",
+        "gb": "applemusic://track/1852045429",
+        "fr": "applemusic://track/1852045429",
+        "es": "applemusic://track/1852045429",
+        "nl": "applemusic://track/1852045429",
+        "it": "applemusic://track/1646679707"
+      }
     },
     {
       "year": 1974,
@@ -472,7 +592,17 @@
       "uri_tidal": "tidal://track/15180993",
       "uri_deezer": "deezer://track/27533911",
       "fun_fact_nl": "Bevat een van de vroegste toepassingen van een vocoder in de mainstream popmuziek. Maurice White en Wayne Vaughn schreven het, en het kenmerkende openingsvocaleffect werd bereikt met een Sennheiser-vocoder, waarmee de robotachtige 'Let's groove tonight'-intro werd gecreëerd.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM18100641",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1681209952",
+        "de": "applemusic://track/1681209952",
+        "gb": "applemusic://track/1681209952",
+        "fr": "applemusic://track/1681209952",
+        "es": "applemusic://track/1681209952",
+        "nl": "applemusic://track/1681209952",
+        "it": "applemusic://track/1681209952"
+      }
     },
     {
       "year": 1989,
@@ -504,7 +634,17 @@
       "uri_tidal": "tidal://track/14191377",
       "uri_deezer": "deezer://track/2961498",
       "fun_fact_nl": "De zang werd verzorgd door de Zaïrees-Belgische zangeres Ya Kid K, maar model Felly werd in de muziekvideo gebruikt, wat een controverse veroorzaakte vergelijkbaar met Milli Vanilli. De Belgische productie overbrugde disco-funk met de opkomende housemuziek.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "BEUM70800466",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1696006699",
+        "de": "applemusic://track/1696006699",
+        "gb": "applemusic://track/1696006699",
+        "fr": "applemusic://track/1696006699",
+        "es": "applemusic://track/1696006699",
+        "nl": "applemusic://track/1696006699",
+        "it": "applemusic://track/1696006699"
+      }
     },
     {
       "year": 1981,
@@ -533,7 +673,17 @@
       "uri_tidal": "tidal://track/219141470",
       "uri_deezer": "deezer://track/521606762",
       "fun_fact_nl": "Oorspronkelijk geschreven en opgenomen door Chaz Jankel (van The Blockheads). De titel verwijst naar de controversiële Japanse film 'In the Realm of the Senses' uit 1976. Quincy Jones' versie met zang van Dune werd een dansklassieker.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USWWW0129202",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1622737678",
+        "de": "applemusic://track/1622737678",
+        "gb": "applemusic://track/1622737678",
+        "fr": "applemusic://track/1622737678",
+        "es": "applemusic://track/1622737678",
+        "nl": "applemusic://track/1622737678",
+        "it": "applemusic://track/1622737678"
+      }
     },
     {
       "year": 1982,
@@ -571,7 +721,17 @@
       "fun_fact_nl": "Opgenomen in Oostende, België, tijdens Gayes zelfopgelegde ballingschap uit de VS. Het markeerde zijn comeback na jaren van persoonlijke turbulentie en belastingproblemen. Het nummer won twee Grammy Awards en was zijn laatste grote hit voor zijn tragische dood in 1984.",
       "awards_nl": [
         "Grammy Award voor Beste Mannelijke R&B Zangprestatie"
-      ]
+      ],
+      "isrc": "USSM19803028",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1739929127",
+        "de": "applemusic://track/471752292",
+        "gb": "applemusic://track/471752292",
+        "fr": "applemusic://track/471752292",
+        "es": "applemusic://track/471752292",
+        "nl": "applemusic://track/471752292",
+        "it": "applemusic://track/471752292"
+      }
     },
     {
       "year": 1982,
@@ -600,7 +760,17 @@
       "uri_tidal": "tidal://track/24048294",
       "uri_deezer": "deezer://track/133238776",
       "fun_fact_nl": "Dit Britse trio, geleid door Leee John, stond bekend om zijn optreden zonder shirt. Het nummer was een enorme hit door heel Europa, maar haalde de hitparade in de VS nooit. Het dromerige synth-funkgeluid beïnvloedde vele latere elektronische dansartiesten.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBBXS2401173",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1741838959",
+        "de": "applemusic://track/1741838959",
+        "gb": "applemusic://track/1741838959",
+        "fr": "applemusic://track/1741838959",
+        "es": "applemusic://track/1741838959",
+        "nl": "applemusic://track/1741838959",
+        "it": "applemusic://track/1741838959"
+      }
     },
     {
       "year": 1987,
@@ -639,7 +809,17 @@
       "fun_fact_nl": "Geschreven door George Merrill en Shannon Rubicam, die ook Whitney's 'How Will I Know' schreven. Het stond twee weken op nummer 1 en won de Grammy voor Best Female Pop Vocal. De biopic uit 2022 over Whitney Houston werd vernoemd naar dit nummer.",
       "awards_nl": [
         "Grammy Award voor Beste Vrouwelijke Pop Zangprestatie"
-      ]
+      ],
+      "isrc": "USAR18700121",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1627099927",
+        "de": "applemusic://track/1627099927",
+        "gb": "applemusic://track/1627099927",
+        "fr": "applemusic://track/1627099927",
+        "es": "applemusic://track/1627099927",
+        "nl": "applemusic://track/1627099927",
+        "it": "applemusic://track/892310917"
+      }
     },
     {
       "year": 1983,
@@ -670,7 +850,17 @@
       "uri_tidal": "tidal://track/3392986",
       "uri_deezer": "deezer://track/541998",
       "fun_fact_nl": "Na jaren van dalende populariteit in de VS gaf dit nummer KC een verrassend nummer 1-hit in het VK. Ironisch genoeg bereikte het slechts nummer 18 in de VS, ondanks dat KC een Amerikaanse artiest is. Het markeerde een korte maar triomfantelijke comeback.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM11500957",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1088537699",
+        "de": "applemusic://track/1088537699",
+        "gb": "applemusic://track/1088537699",
+        "fr": "applemusic://track/1088537699",
+        "es": "applemusic://track/1088537699",
+        "nl": "applemusic://track/1088537699",
+        "it": "applemusic://track/1088537699"
+      }
     },
     {
       "year": 1983,
@@ -701,7 +891,17 @@
       "uri_tidal": "tidal://track/592285",
       "uri_deezer": "deezer://track/920062",
       "fun_fact_nl": "De meertalige teksten bevatten woorden uit Caribische, Afrikaanse en volledig verzonnen talen. Richie voerde dit uit tijdens de slotceremonie van de Olympische Spelen van 1984 in LA. Het stond vier weken op nummer 1 en was een van de bestverkochte singles van 1983.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMO10110144",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1445751851",
+        "de": "applemusic://track/1445751851",
+        "gb": "applemusic://track/1445751851",
+        "fr": "applemusic://track/1445751851",
+        "es": "applemusic://track/1445751851",
+        "nl": "applemusic://track/1445751851",
+        "it": "applemusic://track/1445751851"
+      }
     },
     {
       "year": 1988,
@@ -732,7 +932,17 @@
       "uri_tidal": "tidal://track/1300335",
       "uri_deezer": "deezer://track/477342872",
       "fun_fact_nl": "Cecil Womack was de broer van Bobby Womack en Linda was de dochter van Sam Cooke. Het nummer was een enorme Europese hit maar haalde de hitparade in de VS nooit. Het werd een zomerhymne in het VK en door heel Europa in 1988.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USIR28800280",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/6762970659",
+        "de": "applemusic://track/1443285758",
+        "gb": "applemusic://track/6762970659",
+        "fr": "applemusic://track/6762970659",
+        "es": "applemusic://track/1443285758",
+        "nl": "applemusic://track/1443285758",
+        "it": "applemusic://track/1443285758"
+      }
     },
     {
       "year": 1978,
@@ -763,7 +973,17 @@
       "uri_tidal": "tidal://track/106028079",
       "uri_deezer": "deezer://track/487484142",
       "fun_fact_nl": "Mede-schrijfster Allee Willis koos de datum 'the 21st night of September' simpelweg omdat het goed klonk, niet om een speciale reden. Het nummer is op 21 september een viraal fenomeen op sociale media geworden, met miljoenen berichten die de datum vieren.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM17800845",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1456446747",
+        "de": "applemusic://track/1456446747",
+        "gb": "applemusic://track/1456446747",
+        "fr": "applemusic://track/1456446747",
+        "es": "applemusic://track/1456446747",
+        "nl": "applemusic://track/1456446747",
+        "it": "applemusic://track/1456446747"
+      }
     },
     {
       "year": 1979,
@@ -794,7 +1014,17 @@
       "uri_tidal": "tidal://track/93614058",
       "uri_deezer": "deezer://track/541624322",
       "fun_fact_nl": "Markeerde Kool & The Gang's overgang van jazz-funk instrumentals naar pop-funk met zang door de toevoeging van zanger James 'JT' Taylor. Producer Eumir Deodato hielp hun geluid te hervormen, wat leidde tot een reeks hits in het begin van de jaren 80.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USPR37905295",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1660546868",
+        "de": "applemusic://track/1660546868",
+        "gb": "applemusic://track/1660546868",
+        "fr": "applemusic://track/1660546868",
+        "es": "applemusic://track/1660546868",
+        "nl": "applemusic://track/1660546868",
+        "it": "applemusic://track/1686457871"
+      }
     },
     {
       "year": 1978,
@@ -825,7 +1055,17 @@
       "uri_tidal": "tidal://track/68685656",
       "uri_deezer": "deezer://track/4091349",
       "fun_fact_nl": "Oorspronkelijk geschreven door Ashford & Simpson voor Diana Ross, die het afsloeg. Whitney Houstons cover uit 1993 voor de 'The Bodyguard'-soundtrack werd nog beroemder. Chaka voerde het op bij de Super Bowl halftime show-eerbetoon in 2024.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USWB17800019",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1849165884",
+        "de": "applemusic://track/1849165884",
+        "gb": "applemusic://track/1849165884",
+        "fr": "applemusic://track/1849165884",
+        "es": "applemusic://track/1849165884",
+        "nl": "applemusic://track/1849165884",
+        "it": "applemusic://track/1159357319"
+      }
     },
     {
       "year": 1975,
@@ -854,7 +1094,17 @@
       "uri_tidal": "tidal://track/45751156",
       "uri_deezer": "deezer://track/360910551",
       "fun_fact_nl": "Gloria Gaynors discoversie van Frankie Valli's klassieker uit 1967 transformeerde een doo-wopballade in een pulserende dansklassieker. Het origineel van Frankie Valli bereikte nummer 2 op de Billboard Hot 100 en is gecoverd door meer dan 200 artiesten.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "ITT4X2400033",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1838865894",
+        "de": "applemusic://track/1838865894",
+        "gb": "applemusic://track/1838865894",
+        "fr": "applemusic://track/1838865894",
+        "es": "applemusic://track/1838865894",
+        "nl": "applemusic://track/1838865894",
+        "it": "applemusic://track/1838865894"
+      }
     },
     {
       "year": 1974,
@@ -886,7 +1136,17 @@
       "uri_tidal": "tidal://track/86967591",
       "uri_deezer": "deezer://track/537988582",
       "fun_fact_nl": "Oorspronkelijk geschreven als een countrylied genaamd 'You're My First, My Last, My Everything' in 1952. Barry White transformeerde het in een weelderige orkestrale discoclassieker met zijn Love Unlimited Orchestra. Het bereikte nummer 1 in het VK en nummer 2 in de VS.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USUM70502309",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1684775096",
+        "de": "applemusic://track/1684775096",
+        "gb": "applemusic://track/1684775096",
+        "fr": "applemusic://track/1684775096",
+        "es": "applemusic://track/1684775096",
+        "nl": "applemusic://track/1684775096",
+        "it": "applemusic://track/1684775096"
+      }
     },
     {
       "year": 1978,
@@ -947,7 +1207,17 @@
       "uri_tidal": "tidal://track/19542374",
       "uri_deezer": "deezer://track/62960815",
       "fun_fact_nl": "Beschouwd als het ultieme eerbetoon aan de DJ-cultuur en een van de belangrijkste nummers over dj-en ooit geschreven. Het nummer is talloze keren gesampeld en inspireerde een boek uit 2003 met dezelfde naam over de geschiedenis van de diskjockey.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "CAU118201812",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/286849164",
+        "de": "applemusic://track/286849164",
+        "gb": "applemusic://track/286849164",
+        "fr": "applemusic://track/286849164",
+        "es": "applemusic://track/286849164",
+        "nl": "applemusic://track/286849164",
+        "it": "applemusic://track/286849164"
+      }
     },
     {
       "year": 1978,
@@ -986,7 +1256,17 @@
       "fun_fact_nl": "Oorspronkelijk uitgebracht als de B-kant van 'Substitute'. Dj's draaiden de plaat om en het nummer werd een wereldwijde hymne van zelfbeschikking. Het won de eerste en enige Grammy voor Best Disco Recording in 1980 en werd in 2016 opgenomen in de Library of Congress.",
       "awards_nl": [
         "Grammy Award voor Beste Disco-opname"
-      ]
+      ],
+      "isrc": "USPR37800083",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1443818368",
+        "de": "applemusic://track/1443268764",
+        "gb": "applemusic://track/1443090066",
+        "fr": "applemusic://track/1443818368",
+        "es": "applemusic://track/1443818368",
+        "nl": "applemusic://track/1443818368",
+        "it": "applemusic://track/1443818368"
+      }
     },
     {
       "year": 1984,
@@ -1017,7 +1297,17 @@
       "uri_tidal": "tidal://track/93787796",
       "uri_deezer": "deezer://track/541622012",
       "fun_fact_nl": "Van het album 'Emergency' was dit een van vier top-20 hits van dat album, naast 'Cherish', 'Misled' en 'Emergency'. Het nummer is een favoriet in tv-commercials en was te zien in de film 'Happy Gilmore'.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USUMG0000175",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1646679717",
+        "de": "applemusic://track/1646679717",
+        "gb": "applemusic://track/1646679717",
+        "fr": "applemusic://track/1646679717",
+        "es": "applemusic://track/1646679717",
+        "nl": "applemusic://track/1646679717",
+        "it": "applemusic://track/1646679717"
+      }
     },
     {
       "year": 1983,
@@ -1046,7 +1336,17 @@
       "uri_tidal": "tidal://track/227703662",
       "uri_deezer": "deezer://track/2044588597",
       "fun_fact_nl": "Hoewel een bescheiden hit bij de originele release, beleefde het nummer een enorme revival in de jaren 2000 toen het werd gesampeld door Room 5 voor 'Make Luv', dat nummer 1 bereikte in het VK. Cheathams vloeiende zang werd iconisch in de Europese clubcultuur.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USUM72206542",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1646553918",
+        "de": "applemusic://track/1646553918",
+        "gb": "applemusic://track/1646553918",
+        "fr": "applemusic://track/1646553918",
+        "es": "applemusic://track/1646553918",
+        "nl": "applemusic://track/1646553918",
+        "it": "applemusic://track/1646553918"
+      }
     },
     {
       "year": 1975,
@@ -1077,7 +1377,17 @@
       "uri_tidal": "tidal://track/50959527",
       "uri_deezer": "deezer://track/107118556",
       "fun_fact_nl": "KC & The Sunshine Bands tweede nummer 1-hit vestigde het Miami bass-geluid dat disco en latere basmuziek beïnvloedde. Harry Wayne Casey (KC) schreef en produceerde de meeste hits van de band samen met bassist Richard Finch in hun eigen studio.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAYE0400454",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1684200196",
+        "de": "applemusic://track/1684200196",
+        "gb": "applemusic://track/1684200196",
+        "fr": "applemusic://track/1684200196",
+        "es": "applemusic://track/1684200196",
+        "nl": "applemusic://track/1684200196",
+        "it": "applemusic://track/1684200196"
+      }
     },
     {
       "year": 1980,
@@ -1116,7 +1426,17 @@
       "fun_fact_nl": "Geschreven door Michael Gore en Dean Pitchford voor de gelijknamige film uit 1980. Irene Cara speelde ook in de film. Het nummer inspireerde een tv-serie die van 1982 tot 1987 liep. Cara won later een Oscar voor 'Flashdance... What a Feeling' in 1984.",
       "awards_nl": [
         "Oscarnominatie voor Beste Originele Lied"
-      ]
+      ],
+      "isrc": "USNLR1200531",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1454593961",
+        "de": "applemusic://track/1454593961",
+        "gb": "applemusic://track/1454593961",
+        "fr": "applemusic://track/1454593961",
+        "es": "applemusic://track/1454593961",
+        "nl": "applemusic://track/1454593961",
+        "it": "applemusic://track/1454593961"
+      }
     },
     {
       "year": 1980,
@@ -1154,7 +1474,17 @@
       "fun_fact_nl": "Geproduceerd door Quincy Jones en geschreven door Rod Temperton (die ook Michael Jacksons 'Thriller' schreef). Het vermengde jazz-gitaarvirtuositeit met disco-funkgrooves en bewees dat Benson zowel de jazz- als de pophitparade kon domineren.",
       "awards_nl": [
         "Grammy Award voor Beste Mannelijke R&B Zangprestatie"
-      ]
+      ],
+      "isrc": "USWB19900127",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1394020103",
+        "de": "applemusic://track/1394020103",
+        "gb": "applemusic://track/1394020103",
+        "fr": "applemusic://track/1394020103",
+        "es": "applemusic://track/1394020103",
+        "nl": "applemusic://track/1394020103",
+        "it": "applemusic://track/1394020103"
+      }
     },
     {
       "year": 1976,
@@ -1185,7 +1515,17 @@
       "uri_tidal": "tidal://track/241660774",
       "uri_deezer": "deezer://track/126844977",
       "fun_fact_nl": "Oorspronkelijk een bescheiden hit in 1976, maar de Saturday Night Fever-soundtrack in 1977 katapulteerde het naar wereldwijde bekendheid. Het iconische 'Burn baby burn'-refrein werd de strijdkreet van het discotijdperk. De volledige versie duurt meer dan 10 minuten.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USAT20300384",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1525514566",
+        "de": "applemusic://track/1389003502",
+        "gb": "applemusic://track/1389003502",
+        "fr": "applemusic://track/1389003502",
+        "es": "applemusic://track/1389003502",
+        "nl": "applemusic://track/1389003502",
+        "it": "applemusic://track/1389003502"
+      }
     },
     {
       "year": 1976,
@@ -1216,7 +1556,17 @@
       "uri_tidal": "tidal://track/68493628",
       "uri_deezer": "deezer://track/350027741",
       "fun_fact_nl": "Het eerste Bee Gees-nummer met Barry Gibbs iconische falsetto die het discotijdperk zou definiëren. John Travolta gebruikte dit nummer voor zijn solodansscène in Saturday Night Fever. Het stond één week op nummer 1 in de Billboard Hot 100.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "NLF057690020",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1622737438",
+        "de": "applemusic://track/1622737438",
+        "gb": "applemusic://track/1622737438",
+        "fr": "applemusic://track/1622737438",
+        "es": "applemusic://track/1622737438",
+        "nl": "applemusic://track/1622737438",
+        "it": "applemusic://track/1622737438"
+      }
     },
     {
       "year": 1979,
@@ -1254,7 +1604,17 @@
       "fun_fact_nl": "Een van de eerste disconummers met rockgitaar, met Jeff 'Skunk' Baxter van The Doobie Brothers. Het stond drie weken op nummer 1 en won de Grammy voor Best Female Rock Vocal - een zeldzame crossovererprestatie voor een disco-artiest.",
       "awards_nl": [
         "Grammy Award voor Beste Vrouwelijke Rock Zangprestatie"
-      ]
+      ],
+      "isrc": "USPR37907202",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1704761711",
+        "de": "applemusic://track/1704761711",
+        "gb": "applemusic://track/1704761711",
+        "fr": "applemusic://track/1704761711",
+        "es": "applemusic://track/1704761711",
+        "nl": "applemusic://track/1704761711",
+        "it": "applemusic://track/1704761711"
+      }
     },
     {
       "year": 1978,
@@ -1295,7 +1655,17 @@
       "awards_nl": [
         "Oscar voor Beste Originele Lied",
         "Golden Globe"
-      ]
+      ],
+      "isrc": "USPR39402394",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1415204156",
+        "de": "applemusic://track/1415204156",
+        "gb": "applemusic://track/1415204156",
+        "fr": "applemusic://track/1415204156",
+        "es": "applemusic://track/1415204156",
+        "nl": "applemusic://track/1440655219",
+        "it": "applemusic://track/1415204156"
+      }
     },
     {
       "year": 1975,
@@ -1326,7 +1696,17 @@
       "uri_tidal": "tidal://track/2407477",
       "uri_deezer": "deezer://track/3151317",
       "fun_fact_nl": "KC & The Sunshine Bands eerste nummer 1-hit definieerde het Miami Sound dat funk, soul en pop vermengde. Harry Wayne Casey en Richard Finch waren huiscomponisten bij TK Records en schreven dit op respectievelijk 23 en 21-jarige leeftijd.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAYE0400453",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1810404655",
+        "de": "applemusic://track/1810404655",
+        "gb": "applemusic://track/1810404655",
+        "fr": "applemusic://track/1810404655",
+        "es": "applemusic://track/1810404655",
+        "nl": "applemusic://track/1810404655",
+        "it": "applemusic://track/1810404655"
+      }
     },
     {
       "year": 1981,
@@ -1357,7 +1737,17 @@
       "uri_tidal": "tidal://track/7451365",
       "uri_deezer": "deezer://track/543150512",
       "fun_fact_nl": "MC Hammer sampelde de baslijn voor 'U Can't Touch This' in 1990, dat een nog grotere hit werd. Rick James kreeg aanvankelijk nooit de juiste credits. The Temptations verzorgden achtergrondzang op de originele opname.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMO18100048",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1440901138",
+        "de": "applemusic://track/1858861411",
+        "gb": "applemusic://track/1443325994",
+        "fr": "applemusic://track/1858861411",
+        "es": "applemusic://track/1858861411",
+        "nl": "applemusic://track/1858861411",
+        "it": "applemusic://track/1858861411"
+      }
     },
     {
       "year": 1977,
@@ -1388,7 +1778,17 @@
       "uri_tidal": "tidal://track/1895662",
       "uri_deezer": "deezer://track/16235816",
       "fun_fact_nl": "De bestverkochte single ooit van een vrouwenduo, met wereldwijd meer dan 18 miljoen verkochte exemplaren. Het was nummer 1 in het VK en door heel Europa, maar werd nooit als single uitgebracht in de VS. Het werd het onofficiële Schotse voetbalhymne tijdens Euro 2020.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEC760000065",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/164228567",
+        "de": "applemusic://track/402995500",
+        "gb": "applemusic://track/322796500",
+        "fr": "applemusic://track/322796500",
+        "es": "applemusic://track/322796500",
+        "nl": "applemusic://track/322796500",
+        "it": "applemusic://track/322796500"
+      }
     },
     {
       "year": 1977,
@@ -1419,7 +1819,17 @@
       "uri_tidal": "tidal://track/16822019",
       "uri_deezer": "deezer://track/1049893",
       "fun_fact_nl": "Geïnspireerd op het waargebeurde verhaal van Ma Barker, de beruchte Amerikaanse gangstermoeder uit de jaren 30. Het nummer stond nummer 1 in Duitsland, Frankrijk en meerdere andere Europese landen. Producer Frank Farian zei later dat het een van zijn favoriete Boney M.-producties was.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DED169200006",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/220139766",
+        "de": "applemusic://track/220139766",
+        "gb": "applemusic://track/402741465",
+        "fr": "applemusic://track/402741465",
+        "es": "applemusic://track/220139766",
+        "nl": "applemusic://track/220139766",
+        "it": "applemusic://track/220139766"
+      }
     },
     {
       "year": 1978,
@@ -1450,7 +1860,17 @@
       "uri_tidal": "tidal://track/661784",
       "uri_deezer": "deezer://track/364966",
       "fun_fact_nl": "Gebaseerd op Psalm 137, stond het vijf weken op nummer 1 in het VK en is een van de bestverkochte singles aller tijden in Groot-Brittannië met meer dan 2 miljoen verkochte exemplaren. De dubbele A-kant met 'Brown Girl in the Ring' bleef 40 weken in de VK-hitparade.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DED167800003",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1708480197",
+        "de": "applemusic://track/1708480197",
+        "gb": "applemusic://track/1708480197",
+        "fr": "applemusic://track/847480101",
+        "es": "applemusic://track/847480101",
+        "nl": "applemusic://track/1790923338",
+        "it": "applemusic://track/847480101"
+      }
     },
     {
       "year": 1985,
@@ -1481,7 +1901,17 @@
       "uri_tidal": "tidal://track/687202",
       "uri_deezer": "deezer://track/1131192",
       "fun_fact_nl": "Oorspronkelijk geschreven voor Janet Jackson, die het afsloeg. De kleurrijke, energieke muziekvideo toonde Whitney's uitstraling en hielp MTV te vestigen als platform voor zwarte popartiesten. Het was haar derde opeenvolgende nummer 1-hit in de VS.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USAR18500150",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/349286433",
+        "de": "applemusic://track/349286433",
+        "gb": "applemusic://track/349286433",
+        "fr": "applemusic://track/349286433",
+        "es": "applemusic://track/349286433",
+        "nl": "applemusic://track/734446117",
+        "it": "applemusic://track/349286433"
+      }
     },
     {
       "year": 1986,
@@ -1512,7 +1942,17 @@
       "uri_tidal": "tidal://track/6947818",
       "uri_deezer": "deezer://track/9968997",
       "fun_fact_nl": "Geschreven door Narada Michael Walden en Preston Glass, was dit Stewarts grootste hit. Vóór zijn solocarrière was hij danser bij Soul Train en achtergronddanser voor Shalamar. Stewart overleed tragisch aan aids-gerelateerde leverkanker in 1997 op 39-jarige leeftijd.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAAA8500015",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1884692088",
+        "de": "applemusic://track/1884692088",
+        "gb": "applemusic://track/1884692088",
+        "fr": "applemusic://track/1884692088",
+        "es": "applemusic://track/1884692088",
+        "nl": "applemusic://track/1884692088",
+        "it": "applemusic://track/1884692088"
+      }
     },
     {
       "year": 1985,
@@ -1572,7 +2012,17 @@
       "uri_tidal": "tidal://track/34978342",
       "uri_deezer": "deezer://track/12650195",
       "fun_fact_nl": "Gevormd door Vince Clarke (die net Depeche Mode had verlaten) en Alison Moyet. Het duo stond bekend als 'Yaz' in de VS vanwege een merkconflict. Clarke richtte later Erasure op, terwijl Moyet een succesvolle solocarrière had. Ze brachten samen slechts twee albums uit.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAJH0100174",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1690678815",
+        "de": null,
+        "gb": null,
+        "fr": null,
+        "es": null,
+        "nl": null,
+        "it": null
+      }
     },
     {
       "year": 1984,
@@ -1603,7 +2053,17 @@
       "uri_tidal": "tidal://track/5254510",
       "uri_deezer": "deezer://track/1484703292",
       "fun_fact_nl": "Rockwell was eigenlijk Kennedy Gordy, de zoon van Motown-oprichter Berry Gordy. Michael Jackson zong het iconische refrein en Jermaine Jackson verzorgde extra zang. Ondanks het feit dat hij Berry Gordy's zoon was, tekende Rockwell bij Motown onder een pseudoniem om zichzelf te bewijzen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMO10000307",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1647277494",
+        "de": "applemusic://track/1647277494",
+        "gb": "applemusic://track/1647277494",
+        "fr": "applemusic://track/1647277494",
+        "es": "applemusic://track/1647277494",
+        "nl": "applemusic://track/1647277494",
+        "it": "applemusic://track/1647277494"
+      }
     },
     {
       "year": 1980,
@@ -1634,7 +2094,17 @@
       "uri_tidal": "tidal://track/77637963",
       "uri_deezer": "deezer://track/4677575",
       "fun_fact_nl": "Geschreven door Nile Rodgers en Bernard Edwards van CHIC nadat ze Diana Ross-dragimitatoren zagen in een New Yorkse club. Het nummer werd een LGBTQ-hymne, hoewel Ross zei dat ze het bedoelde als verklaring van artistieke onafhankelijkheid van Motown.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMO18000073",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1581879147",
+        "de": "applemusic://track/1581879147",
+        "gb": "applemusic://track/1581879147",
+        "fr": "applemusic://track/1581879147",
+        "es": "applemusic://track/1581879147",
+        "nl": "applemusic://track/1581879147",
+        "it": "applemusic://track/1581879147"
+      }
     },
     {
       "year": 1977,
@@ -1665,7 +2135,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=e6GB04zeDeQ",
       "uri_deezer": "deezer://track/139138751",
       "fun_fact_nl": "Stond acht opeenvolgende weken op nummer 1 in de VS, waarmee het de langstlopende nummer 1-hit van de Bee Gees was. Het Saturday Night Fever-album stond 24 weken op nummer 1 en verkocht meer dan 40 miljoen exemplaren, waarmee het een van de bestverkochte soundtracks ooit werd.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "NLF057790035",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1892485974",
+        "de": "applemusic://track/1892485974",
+        "gb": "applemusic://track/1892485974",
+        "fr": "applemusic://track/1892485974",
+        "es": "applemusic://track/1892485974",
+        "nl": "applemusic://track/1892485974",
+        "it": "applemusic://track/1892485974"
+      }
     },
     {
       "year": 1976,
@@ -1696,7 +2176,17 @@
       "uri_tidal": "tidal://track/12001083",
       "uri_deezer": "deezer://track/8081939",
       "fun_fact_nl": "Geschreven en geproduceerd door Norman Whitfield (beroemde Motown-producer) voor de gelijknamige komedie uit 1976. Het stond één week op nummer 1 en bevatte een funky clavinetriff die onmiddellijk iconisch werd. Christina Aguilera sampelde het voor een filmversie uit 2004.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USA560624107",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1687115289",
+        "de": "applemusic://track/1687115289",
+        "gb": "applemusic://track/1687115289",
+        "fr": "applemusic://track/1687115289",
+        "es": "applemusic://track/1687115289",
+        "nl": "applemusic://track/1687115289",
+        "it": "applemusic://track/1687115289"
+      }
     },
     {
       "year": 1978,
@@ -1727,7 +2217,17 @@
       "uri_tidal": "tidal://track/1852308",
       "uri_deezer": "deezer://track/8014760",
       "fun_fact_nl": "Cheryl Lynn werd ontdekt in het tv-talentenprogramma 'The Gong Show', dat ze won. Mede-geschreven met David Paich en David Foster (later van Toto en een legendarische producer). Het nummer werd een vaste waarde in de dragcultuur en LGBTQ-vieringen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM17800040",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/260302614",
+        "de": "applemusic://track/1378303255",
+        "gb": "applemusic://track/1378303255",
+        "fr": "applemusic://track/1378303255",
+        "es": "applemusic://track/1243525890",
+        "nl": "applemusic://track/1378303255",
+        "it": "applemusic://track/1378303255"
+      }
     },
     {
       "year": 1980,
@@ -1758,7 +2258,17 @@
       "uri_tidal": "tidal://track/4016551",
       "uri_deezer": "deezer://track/2501713",
       "fun_fact_nl": "Geproduceerd door Quincy Jones, die tegelijkertijd werkte aan Michael Jacksons 'Off the Wall'. De gebroeders Johnson (George en Louis) waren sessiemuzikanten voor Quincy Jones voordat ze hun eigen carrière lanceerden. De baslijn is een van de meest iconische uit de funk.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USAM18074730",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1889932358",
+        "de": "applemusic://track/1889932358",
+        "gb": "applemusic://track/1889932358",
+        "fr": "applemusic://track/1889932358",
+        "es": "applemusic://track/1889932358",
+        "nl": "applemusic://track/1889932358",
+        "it": "applemusic://track/1889932358"
+      }
     },
     {
       "year": 1979,
@@ -1789,7 +2299,17 @@
       "uri_tidal": "tidal://track/1785214",
       "uri_deezer": "deezer://track/691615",
       "fun_fact_nl": "Geschreven en geproduceerd door Nile Rodgers en Bernard Edwards van CHIC. Will Smith sampelde het voor 'Gettin' Jiggy wit It'. De vier Sledge-zusjes kwamen uit Philadelphia en dit was van hun doorbraakalbum 'We Are Family', geheel geproduceerd door CHIC.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USAT20102201",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1336575479",
+        "de": "applemusic://track/1336575479",
+        "gb": "applemusic://track/1336575479",
+        "fr": "applemusic://track/1336575479",
+        "es": "applemusic://track/1336575479",
+        "nl": "applemusic://track/1336575479",
+        "it": "applemusic://track/1336575479"
+      }
     },
     {
       "year": 1978,
@@ -1820,7 +2340,17 @@
       "uri_tidal": "tidal://track/11881282",
       "uri_deezer": "deezer://track/364962",
       "fun_fact_nl": "Over de Russische mysticus Grigori Rasputin, werd het nummer in 2020 massaal viraal op TikTok, waarmee het een nieuwe generatie kennis maakte. Het nummer was verboden in de Sovjet-Unie. Producer Frank Farian was gefascineerd door de legendarische reputatie van de historische figuur.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DED167800002",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/824787019",
+        "de": "applemusic://track/824787019",
+        "gb": "applemusic://track/824787019",
+        "fr": "applemusic://track/824787019",
+        "es": "applemusic://track/824787019",
+        "nl": "applemusic://track/847480137",
+        "it": "applemusic://track/824787019"
+      }
     },
     {
       "year": 1983,
@@ -1858,7 +2388,17 @@
       "fun_fact_nl": "Opgenomen met Rufus was dit de laatste grote hit van de band. David 'Hawk' Wolinski schreef het in 15 minuten. Het nummer is uitgebreid gecoverd en gesampeld, met name door Felix voor een danshit uit 1992. Het won de Grammy voor Best R&B Song.",
       "awards_nl": [
         "Grammy Award voor Beste R&B-nummer"
-      ]
+      ],
+      "isrc": "USWB19600662",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1807720130",
+        "de": "applemusic://track/1395906604",
+        "gb": "applemusic://track/1395906604",
+        "fr": "applemusic://track/1395906604",
+        "es": "applemusic://track/1395906604",
+        "nl": "applemusic://track/1395906604",
+        "it": "applemusic://track/1395906604"
+      }
     },
     {
       "year": 1976,
@@ -1889,7 +2429,17 @@
       "uri_tidal": "tidal://track/277901",
       "uri_deezer": "deezer://track/720737",
       "fun_fact_nl": "Geschreven door David Crawford over Statons mishandelende huwelijk. De bevrijdende boodschap resoneerde diep en maakte het een feministische hymne die zijn tijd vooruit was. Het was prominent te horen in Baz Luhrmanns 'Romeo + Juliet' (1996), waarmee het een nieuwe generatie bereikte.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USWB19700370",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1691675172",
+        "de": "applemusic://track/1691675172",
+        "gb": "applemusic://track/1691675172",
+        "fr": "applemusic://track/1691675172",
+        "es": "applemusic://track/1691675172",
+        "nl": "applemusic://track/1691675172",
+        "it": "applemusic://track/1691675172"
+      }
     },
     {
       "year": 1977,
@@ -1920,7 +2470,17 @@
       "uri_tidal": "tidal://track/30234400",
       "uri_deezer": "deezer://track/1026366",
       "fun_fact_nl": "Geschreven en geproduceerd door Maurice White van Earth, Wind & Fire, die ook het album 'Rejoice' van de groep produceerde. Het stond vijf weken op nummer 1 in de Hot 100. De drie Hutchinson-zusjes hadden al samen opgetreden vanaf hun kindertijd in de gospelscène van Chicago.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM17700026",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/170522819",
+        "de": "applemusic://track/268524963",
+        "gb": "applemusic://track/268524963",
+        "fr": "applemusic://track/268524963",
+        "es": "applemusic://track/268524963",
+        "nl": "applemusic://track/268524963",
+        "it": "applemusic://track/268524963"
+      }
     },
     {
       "year": 1977,
@@ -1951,7 +2511,17 @@
       "uri_tidal": "tidal://track/83918588",
       "uri_deezer": "deezer://track/3151318",
       "fun_fact_nl": "KC & The Sunshine Bands vijfde en laatste nummer 1-hit, die hun status als koningen van de 70s-disco bevestigde. De band was een van de weinige door blanken geleide acts die zowel de pop- als de R&B-hitparade aanvoerden tijdens het discotijdperk, dankzij hun authentieke Miami soul-funk geluid.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMC30710029",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1858861535",
+        "de": "applemusic://track/1858861535",
+        "gb": "applemusic://track/1858861535",
+        "fr": "applemusic://track/1858861535",
+        "es": "applemusic://track/1858861535",
+        "nl": "applemusic://track/1858861535",
+        "it": "applemusic://track/1858861535"
+      }
     },
     {
       "year": 1979,
@@ -1982,7 +2552,17 @@
       "uri_tidal": "tidal://track/6407354",
       "uri_deezer": "deezer://track/10370275",
       "fun_fact_nl": "Een discoverwerking van Eddie Floyds soul-klassieker uit 1966. Amii Stewarts versie stond één week op nummer 1 in de VS en verkocht meer dan een miljoen exemplaren. Het origineel werd mede-geschreven door Steve Cropper van Booker T. & the M.G.'s bij Stax Records.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBVUT1050995",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/428921412",
+        "de": "applemusic://track/428921412",
+        "gb": "applemusic://track/428921412",
+        "fr": "applemusic://track/428921412",
+        "es": "applemusic://track/428921412",
+        "nl": "applemusic://track/428921412",
+        "it": "applemusic://track/428921412"
+      }
     },
     {
       "year": 1984,
@@ -2020,7 +2600,17 @@
       "fun_fact_nl": "Geschreven door Marti Sharron, Gary Skardina en Stephen Mitchell. Het won de Grammy voor Best Pop Performance by a Duo or Group. Het nummer kreeg hernieuwde populariteit toen het te zien was in de film 'Love Actually' (2003) en in Hugh Grants beroemde dansscène.",
       "awards_nl": [
         "Grammy Award voor Beste Popprestatie door Duo of Groep"
-      ]
+      ],
+      "isrc": "USRC18303288",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1308611090",
+        "de": "applemusic://track/1308596362",
+        "gb": "applemusic://track/1308596362",
+        "fr": "applemusic://track/1308596362",
+        "es": "applemusic://track/1308596362",
+        "nl": "applemusic://track/1308596362",
+        "it": "applemusic://track/1308596362"
+      }
     },
     {
       "year": 1981,
@@ -2082,7 +2672,17 @@
       "uri_tidal": "tidal://track/82529071",
       "uri_deezer": "deezer://track/428735732",
       "fun_fact_nl": "Een van de eerste openlijk homoseksuele popsongs die een mainstream hit werd, met het verhaal van een jonge homo die gedwongen wordt zijn woonplaats te verlaten. Jimmy Somervilles kenmerkende falsetto werd iconisch. Somerville richtte later The Communards op en had een succesvolle solocarrière.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAAP1812339",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1773352854",
+        "de": "applemusic://track/1773352854",
+        "gb": "applemusic://track/1773352854",
+        "fr": "applemusic://track/1773352854",
+        "es": "applemusic://track/1773352854",
+        "nl": "applemusic://track/1773352854",
+        "it": "applemusic://track/1773352854"
+      }
     },
     {
       "year": 1975,
@@ -2113,7 +2713,17 @@
       "uri_tidal": "tidal://track/541446",
       "uri_deezer": "deezer://track/1079308",
       "fun_fact_nl": "Het beroemde Franse refrein 'Voulez-vous coucher avec moi ce soir' werd in 1975 als schokkend beschouwd. Geschreven door Bob Crewe en Kenny Nolan over een prostituee in New Orleans. De versie uit 2001 door Christina Aguilera, Lil' Kim, Mýa en Pink bereikte ook nummer 1.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM17400284",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/471205219",
+        "de": "applemusic://track/471205219",
+        "gb": "applemusic://track/471205219",
+        "fr": "applemusic://track/471205219",
+        "es": "applemusic://track/471205219",
+        "nl": "applemusic://track/471205219",
+        "it": "applemusic://track/471205219"
+      }
     },
     {
       "year": 1977,
@@ -2170,7 +2780,17 @@
       "uri_tidal": "tidal://track/76792418",
       "uri_deezer": "deezer://track/428984982",
       "fun_fact_nl": "Geschreven door Sandy Linzer en Denny Randell, werd het nummer oorspronkelijk aangeboden aan Frankie Valli. Het trio Odyssey bestond uit de Filipijns-Amerikaanse zusjes Lillian en Louise Lopez naast Tony Reynolds. Het werd een New York City-hymne en wordt nog steeds gespeeld bij stadsevenementen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USRC17708346",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/411443154",
+        "de": "applemusic://track/313084200",
+        "gb": "applemusic://track/313084200",
+        "fr": "applemusic://track/313084200",
+        "es": "applemusic://track/313084200",
+        "nl": "applemusic://track/313084200",
+        "it": "applemusic://track/313084200"
+      }
     },
     {
       "year": 1977,
@@ -2201,7 +2821,17 @@
       "uri_tidal": "tidal://track/637449",
       "uri_deezer": "deezer://track/1119126",
       "fun_fact_nl": "Geschreven door de volledige band, waarbij de openingsbaslijn van Ronald LaPread een van de beroemdste riffs uit de funk werd. Het nummer viert een zelfverzekerde vrouw en is een vaste waarde bij sportevenementen. Lionel Richie was nog bij de band toen dit werd opgenomen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMO17700548",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1586019222",
+        "de": "applemusic://track/1442654229",
+        "gb": "applemusic://track/1442654229",
+        "fr": "applemusic://track/1442654229",
+        "es": "applemusic://track/1442654229",
+        "nl": "applemusic://track/1442890418",
+        "it": "applemusic://track/1442654229"
+      }
     },
     {
       "year": 1974,
@@ -2232,7 +2862,17 @@
       "uri_tidal": "tidal://track/39432487",
       "uri_deezer": "deezer://track/12164497",
       "fun_fact_nl": "Het instrumentale funk-meesterwerk van dit Schotse band stond één week op nummer 1 in de VS. Tragisch genoeg stierf drummer Robbie McIntosh aan een heroïne-overdosis op een feest van Cher kort na het succes van het nummer. Het iconische saxofoonriff werd gespeeld door Roger Ball.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USLS50688104",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/185816158",
+        "de": "applemusic://track/185816158",
+        "gb": "applemusic://track/185816158",
+        "fr": "applemusic://track/185816158",
+        "es": "applemusic://track/185816158",
+        "nl": "applemusic://track/185816158",
+        "it": "applemusic://track/185816158"
+      }
     },
     {
       "year": 1979,
@@ -2261,7 +2901,17 @@
       "uri_tidal": "tidal://track/3745129",
       "uri_deezer": "deezer://track/486747042",
       "fun_fact_nl": "Oorspronkelijk van de Edgar Winter Group schreef Hartman dit disco-epos met zijn opzwepende zang. Take That en Lulu's cover uit 1993 bereikte nummer 1 in het VK. Hartman was ook een productieve componist die 'Living in America' voor James Brown schreef. Hij overleed aan aids in 1994.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM17900565",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1755290621",
+        "de": "applemusic://track/1755290621",
+        "gb": "applemusic://track/455937571",
+        "fr": "applemusic://track/1755290621",
+        "es": "applemusic://track/1755290621",
+        "nl": "applemusic://track/1790923317",
+        "it": "applemusic://track/1755290621"
+      }
     },
     {
       "year": 1979,
@@ -2321,7 +2971,17 @@
       "uri_tidal": "tidal://track/10267153",
       "uri_deezer": "deezer://track/70847278",
       "fun_fact_nl": "Geproduceerd door Stock Aitken Watermans Ian Levine, werd deze Hi-NRG-hymne een bepalend nummer van het genre. Het nummer was een enorme hit in Europese clubs en hielp het Hi-NRG-geluid te definiëren dat de dansmuziek door de jaren 80 zou beïnvloeden.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBQRF0802515",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/585439801",
+        "de": "applemusic://track/585439801",
+        "gb": "applemusic://track/585439801",
+        "fr": "applemusic://track/585439801",
+        "es": "applemusic://track/585439801",
+        "nl": "applemusic://track/585439801",
+        "it": "applemusic://track/585439801"
+      }
     },
     {
       "year": 1980,
@@ -2380,7 +3040,17 @@
       "uri_tidal": "tidal://track/35712031",
       "uri_deezer": "deezer://track/1359256402",
       "fun_fact_nl": "Mede-geschreven door Grace Jones, Kookoo Baya en Dana Manno, met Sly Dunbar en Robbie Shakespeare die het reggae-funkritme verzorgden. De suggestieve teksten waren controversieel. Jones' Compass Point Studios-sessies op Nassau, Bahamas, creëerden een baanbrekende reggae-disco-funk fusie.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USIR28100268",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1702777234",
+        "de": "applemusic://track/1442678921",
+        "gb": "applemusic://track/1443242669",
+        "fr": "applemusic://track/1891514065",
+        "es": "applemusic://track/1891514065",
+        "nl": "applemusic://track/1891514065",
+        "it": "applemusic://track/1891514065"
+      }
     },
     {
       "year": 1983,
@@ -2409,7 +3079,17 @@
       "uri_tidal": "tidal://track/22722310",
       "uri_deezer": "deezer://track/76485944",
       "fun_fact_nl": "Oorspronkelijk van de Broadway-musical 'La Cage aux Folles'. Gloria Gaynors krachtige discoversie werd een bepalende LGBTQ-hymne, zelfs meer dan 'I Will Survive'. Het wordt elk jaar gespeeld bij Pride-evenementen wereldwijd en blijft een verklaring van zelfacceptatie.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBBXS2501376",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1810790226",
+        "de": "applemusic://track/1810790226",
+        "gb": "applemusic://track/1810790226",
+        "fr": "applemusic://track/1810790226",
+        "es": "applemusic://track/1810790226",
+        "nl": "applemusic://track/1810790226",
+        "it": "applemusic://track/1810790226"
+      }
     }
   ]
 }

--- a/custom_components/beatify/playlists/eurovision-winners.json
+++ b/custom_components/beatify/playlists/eurovision-winners.json
@@ -45,7 +45,17 @@
       "fun_fact_nl": "Refrain won het allereerste Eurovisie Songfestival, gehouden in Lugano, Zwitserland. Lys Assia was de enige deelnemer uit Zwitserland en won met een eenvoudig, elegant optreden. Het songfestival van 1956 had nog geen publieksstemmen - alleen de stemmen van de jury telden.",
       "awards_nl": [
         "Eurovisionwinnaar 1956"
-      ]
+      ],
+      "isrc": "US2Y30712375",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/254285129",
+        "de": "applemusic://track/254285129",
+        "gb": "applemusic://track/254285129",
+        "fr": "applemusic://track/254285129",
+        "es": "applemusic://track/254285129",
+        "nl": "applemusic://track/254285129",
+        "it": "applemusic://track/254285129"
+      }
     },
     {
       "year": 1957,
@@ -84,7 +94,17 @@
       "fun_fact_nl": "Net Als Toen bezorgde Nederland de eerste overwinning op het Eurovisie Songfestival. Corry Brokken had eerder deelgenomen in 1956, waar ze zevende werd. Ze blijft een van de weinige artiesten die wonnen na een eerdere deelname.",
       "awards_nl": [
         "Eurovisionwinnaar 1957"
-      ]
+      ],
+      "isrc": "BEK011900098",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1739553677",
+        "de": "applemusic://track/1739553677",
+        "gb": "applemusic://track/1739553677",
+        "fr": "applemusic://track/1739553677",
+        "es": "applemusic://track/1739553677",
+        "nl": "applemusic://track/1739553677",
+        "it": "applemusic://track/1739553677"
+      }
     },
     {
       "year": 1958,
@@ -123,7 +143,17 @@
       "fun_fact_nl": "Dors mon amour (Slaap mijn liefste) was een zacht slaapliedje dat Frankrijk de eerste songfestivaltitel bezorgde. Andre Claveau was voor zijn overwinning al een gevestigde Franse chansonnier, bekend om zijn warme stemgeluid.",
       "awards_nl": [
         "Eurovisionwinnaar 1958"
-      ]
+      ],
+      "isrc": "FR6V82155103",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/794472283",
+        "de": "applemusic://track/794472283",
+        "gb": "applemusic://track/794472283",
+        "fr": "applemusic://track/794472283",
+        "es": "applemusic://track/794472283",
+        "nl": "applemusic://track/794472283",
+        "it": "applemusic://track/794472283"
+      }
     },
     {
       "year": 1959,
@@ -163,7 +193,17 @@
       "fun_fact_nl": "Een Beetje werd een onverwachte internationale hit en haalde in meerdere landen de hitlijsten. Het speelse optreden van Teddy Scholten bezorgde Nederland de tweede overwinning in drie jaar tijd.",
       "awards_nl": [
         "Eurovisionwinnaar 1959"
-      ]
+      ],
+      "isrc": "NLBH71029195",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/420371297",
+        "de": "applemusic://track/420371297",
+        "gb": "applemusic://track/420371297",
+        "fr": "applemusic://track/420371297",
+        "es": "applemusic://track/420371297",
+        "nl": "applemusic://track/420371297",
+        "it": "applemusic://track/420371297"
+      }
     },
     {
       "year": 1960,
@@ -203,7 +243,17 @@
       "fun_fact_nl": "Tom Pillibi vertelt het verhaal van een charmante leugenaar die fantastische verhalen verzint. Jacqueline Boyer was pas 18 jaar oud toen ze won, en haar moeder Lucienne Boyer was ook een beroemde Franse zangeres.",
       "awards_nl": [
         "Eurovisionwinnaar 1960"
-      ]
+      ],
+      "isrc": "FRZ035903640",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1484096278",
+        "de": "applemusic://track/1484096278",
+        "gb": "applemusic://track/1484096278",
+        "fr": "applemusic://track/1484096278",
+        "es": "applemusic://track/1484096278",
+        "nl": "applemusic://track/1484096278",
+        "it": "applemusic://track/1484096278"
+      }
     },
     {
       "year": 1961,
@@ -243,7 +293,17 @@
       "fun_fact_nl": "Nous les amoureux (Wij de geliefden) was de eerste songfestivaloverwinning voor Luxemburg. Jean-Claude Pascal was voor zijn zangcarrière vooral bekend als filmacteur. Het thema van verboden liefde in het nummer sprak het publiek in heel Europa aan.",
       "awards_nl": [
         "Eurovisionwinnaar 1961"
-      ]
+      ],
+      "isrc": "FRZ116103170",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1752888490",
+        "de": "applemusic://track/1752888490",
+        "gb": "applemusic://track/1752888490",
+        "fr": "applemusic://track/1752888490",
+        "es": "applemusic://track/1752888490",
+        "nl": "applemusic://track/1752888490",
+        "it": "applemusic://track/1752888490"
+      }
     },
     {
       "year": 1962,
@@ -283,7 +343,17 @@
       "fun_fact_nl": "Un premier amour (Een eerste liefde) stelde de derde Franse overwinning veilig. Isabelle Aubret overleefde in 1963 een bijna fataal auto-ongeluk, maar maakte een opmerkelijke comeback. Ze vertegenwoordigde Frankrijk opnieuw in 1968 en werd toen derde.",
       "awards_nl": [
         "Eurovisionwinnaar 1962"
-      ]
+      ],
+      "isrc": "FRZ036203430",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1682977904",
+        "de": "applemusic://track/1682977904",
+        "gb": "applemusic://track/1682977904",
+        "fr": "applemusic://track/1682977904",
+        "es": "applemusic://track/1682977904",
+        "nl": "applemusic://track/1682977904",
+        "it": "applemusic://track/1682977904"
+      }
     },
     {
       "year": 1963,
@@ -323,7 +393,17 @@
       "fun_fact_nl": "Dansevise bezorgde Denemarken de eerste songfestivaloverwinning, waarna het 37 jaar zou duren voor de volgende. Grethe en Jorgen Ingmann waren een getrouwd stel, en Jorgen was internationaal al bekend door zijn gitaarnummer 'Apache'.",
       "awards_nl": [
         "Eurovisionwinnaar 1963"
-      ]
+      ],
+      "isrc": "DKABA1100812",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/693093834",
+        "de": "applemusic://track/693093834",
+        "gb": "applemusic://track/693093834",
+        "fr": "applemusic://track/693093834",
+        "es": "applemusic://track/693093834",
+        "nl": "applemusic://track/693093834",
+        "it": "applemusic://track/693093834"
+      }
     },
     {
       "year": 1964,
@@ -363,7 +443,17 @@
       "fun_fact_nl": "Non ho l'eta (Ik ben niet oud genoeg) werd gezongen door de 16-jarige Gigliola Cinquetti, een van de jongste winnaars ooit. Het nummer werd een enorme internationale hit en wordt beschouwd als een van de beste winnende liedjes uit de geschiedenis.",
       "awards_nl": [
         "Eurovisionwinnaar 1964"
-      ]
+      ],
+      "isrc": "ITR006400011",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1769611022",
+        "de": "applemusic://track/213591428",
+        "gb": "applemusic://track/213591428",
+        "fr": "applemusic://track/213591428",
+        "es": "applemusic://track/213591428",
+        "nl": "applemusic://track/213591428",
+        "it": "applemusic://track/213591428"
+      }
     },
     {
       "year": 1965,
@@ -441,7 +531,17 @@
       "fun_fact_nl": "Merci Cherie was de eerste Oostenrijkse overwinning. Udo Jurgens had al twee keer eerder deelgenomen (1964, 1965) voordat hij eindelijk won. Hij groeide uit tot een van de meest succesvolle artiesten van Europa met meer dan 100 miljoen verkochte platen.",
       "awards_nl": [
         "Eurovisionwinnaar 1966"
-      ]
+      ],
+      "isrc": "DEA810602256",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1727305541",
+        "de": "applemusic://track/1727305541",
+        "gb": "applemusic://track/1727305541",
+        "fr": "applemusic://track/1727305541",
+        "es": "applemusic://track/1727305541",
+        "nl": "applemusic://track/1727305541",
+        "it": "applemusic://track/1727305541"
+      }
     },
     {
       "year": 1967,
@@ -481,7 +581,17 @@
       "fun_fact_nl": "Puppet On A String bezorgde het VK de eerste overwinning. Sandie Shaw trad beroemd genoeg op blote voeten op, wat haar handelsmerk werd. Ze hield naar verluidt niet van het nummer, maar het werd een van de grootste hits van 1967.",
       "awards_nl": [
         "Eurovisionwinnaar 1967"
-      ]
+      ],
+      "isrc": "GBCXD0400224",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1467380894",
+        "de": "applemusic://track/1467380894",
+        "gb": "applemusic://track/1467380894",
+        "fr": "applemusic://track/1467380894",
+        "es": "applemusic://track/1467380894",
+        "nl": "applemusic://track/1467380894",
+        "it": "applemusic://track/1467380894"
+      }
     },
     {
       "year": 1968,
@@ -521,7 +631,17 @@
       "fun_fact_nl": "La, La, La was de eerste Spaanse overwinning, met slechts één punt verschil van 'Congratulations' van Cliff Richard. Massiel verving de oorspronkelijke zanger Joan Manuel Serrat slechts enkele dagen voor het festival, nadat hij weigerde in het Spaans in plaats van het Catalaans te zingen.",
       "awards_nl": [
         "Eurovisionwinnaar 1968"
-      ]
+      ],
+      "isrc": "ES5100300048",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1344881200",
+        "de": "applemusic://track/1344881200",
+        "gb": "applemusic://track/1344881200",
+        "fr": "applemusic://track/1344881200",
+        "es": "applemusic://track/1344881200",
+        "nl": "applemusic://track/1344881200",
+        "it": "applemusic://track/1344881200"
+      }
     },
     {
       "year": 1969,
@@ -601,7 +721,17 @@
       "fun_fact_nl": "Boom Bang a Bang was een van de vier gedeelde winnaars in 1969. De Schotse zangeres Lulu was al beroemd door 'Shout' en 'To Sir with Love'. Het vrolijke, aanstekelijke nummer werd een hit in het VK ondanks de gedeelde winst.",
       "awards_nl": [
         "Eurovisionwinnaar 1969 (4-way tie)"
-      ]
+      ],
+      "isrc": "GBAYE6900136",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1323002159",
+        "de": "applemusic://track/1324132498",
+        "gb": "applemusic://track/1324132498",
+        "fr": "applemusic://track/1324132498",
+        "es": "applemusic://track/1324132498",
+        "nl": "applemusic://track/1324132498",
+        "it": "applemusic://track/1324132498"
+      }
     },
     {
       "year": 1969,
@@ -641,7 +771,17 @@
       "fun_fact_nl": "Vivo Cantando bezorgde Spanje een gedeelde overwinning in 1969. Salome's krachtige stem en dramatische stijl maakten haar een ster in de Spaanstalige wereld. Ze bouwde daarna een succesvolle carrière op.",
       "awards_nl": [
         "Eurovisionwinnaar 1969 (4-way tie)"
-      ]
+      ],
+      "isrc": "ES5378900013",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1838068722",
+        "de": "applemusic://track/1838068722",
+        "gb": "applemusic://track/1838068722",
+        "fr": "applemusic://track/1838068722",
+        "es": "applemusic://track/1838068722",
+        "nl": "applemusic://track/1838068722",
+        "it": "applemusic://track/1838068722"
+      }
     },
     {
       "year": 1969,
@@ -681,7 +821,17 @@
       "fun_fact_nl": "Un jour, un enfant completeerde de historische gedeelde winst van 1969. Frida Boccara werd geboren in Marokko en groeide uit tot een van de meest gerespecteerde Franse zangeressen. Haar emotionele ballade viel op tussen de andere winnaars.",
       "awards_nl": [
         "Eurovisionwinnaar 1969 (4-way tie)"
-      ]
+      ],
+      "isrc": "CAU111501580",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1243859629",
+        "de": "applemusic://track/1243859629",
+        "gb": "applemusic://track/1243859629",
+        "fr": "applemusic://track/1243859629",
+        "es": "applemusic://track/1243859629",
+        "nl": "applemusic://track/1243859629",
+        "it": "applemusic://track/1243859629"
+      }
     },
     {
       "year": 1970,
@@ -721,7 +871,17 @@
       "fun_fact_nl": "All Kinds Of Everything was het begin van de Ierse dominantie op het songfestival. Dana was pas 18 en zat nog op school toen ze won. Het lieflijke nummer stond overal in Europa bovenaan de hitlijsten; Dana werd later lid van het Europees Parlement.",
       "awards_nl": [
         "Eurovisionwinnaar 1970"
-      ]
+      ],
+      "isrc": "USCGH1615055",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1078014787",
+        "de": "applemusic://track/1078014787",
+        "gb": "applemusic://track/1078014787",
+        "fr": "applemusic://track/1078014787",
+        "es": "applemusic://track/1078014787",
+        "nl": "applemusic://track/1078014787",
+        "it": "applemusic://track/1078014787"
+      }
     },
     {
       "year": 1971,
@@ -761,7 +921,17 @@
       "fun_fact_nl": "Un Banc, Un Arbre, Une Rue bezorgde Monaco de enige songfestivaloverwinning. Severine was eigenlijk Frans en het nummer werd geschreven door Yves Dessca. De winst kwam op het moment dat er nieuwe stemregels werden geïntroduceerd.",
       "awards_nl": [
         "Eurovisionwinnaar 1971"
-      ]
+      ],
+      "isrc": "USBKY0518252",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/104660824",
+        "de": "applemusic://track/104660824",
+        "gb": "applemusic://track/104660824",
+        "fr": "applemusic://track/104660824",
+        "es": "applemusic://track/104660824",
+        "nl": "applemusic://track/104660824",
+        "it": "applemusic://track/104660824"
+      }
     },
     {
       "year": 1972,
@@ -801,7 +971,17 @@
       "fun_fact_nl": "Apres toi wordt beschouwd als een van de mooiste winnende liedjes ooit. De Grieks-Duitse zangeres Vicky Leandros had Luxemburg al eerder vertegenwoordigd in 1967. Het nummer werd een enorme hit in Europa in verschillende talen.",
       "awards_nl": [
         "Eurovisionwinnaar 1972"
-      ]
+      ],
+      "isrc": "FRZ037201700",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1442450412",
+        "de": "applemusic://track/1442450412",
+        "gb": "applemusic://track/1442450412",
+        "fr": "applemusic://track/1442450412",
+        "es": "applemusic://track/1442450412",
+        "nl": "applemusic://track/1442450412",
+        "it": "applemusic://track/1442450412"
+      }
     },
     {
       "year": 1973,
@@ -841,7 +1021,17 @@
       "fun_fact_nl": "Tu te reconnaitras was de vierde Luxemburgse winst in 12 jaar tijd. Anne-Marie David vertegenwoordigde Frankrijk in 1979, wat haar een van de weinige artiesten maakt die voor twee verschillende landen uitkwamen.",
       "awards_nl": [
         "Eurovisionwinnaar 1973"
-      ]
+      ],
+      "isrc": "FRZ051700133",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1230500284",
+        "de": "applemusic://track/1230500284",
+        "gb": "applemusic://track/1230500284",
+        "fr": "applemusic://track/1230500284",
+        "es": "applemusic://track/1230500284",
+        "nl": "applemusic://track/1230500284",
+        "it": "applemusic://track/1230500284"
+      }
     },
     {
       "year": 1974,
@@ -889,7 +1079,17 @@
       "awards_nl": [
         "Eurovisionwinnaar 1974",
         "Beste Eurovisielied Ooit (2005 peiling)"
-      ]
+      ],
+      "isrc": "SEAYD7415010",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1612497895",
+        "de": "applemusic://track/1612497895",
+        "gb": "applemusic://track/1612497895",
+        "fr": "applemusic://track/1612497895",
+        "es": "applemusic://track/1612497895",
+        "nl": "applemusic://track/1612497895",
+        "it": "applemusic://track/1612497895"
+      }
     },
     {
       "year": 1975,
@@ -966,7 +1166,17 @@
       "fun_fact_nl": "Save Your Kisses For Me was de derde Britse overwinning en werd een van de bestverkochte singles van 1976 wereldwijd. Het liedje lijkt over romantische liefde te gaan, maar aan het eind blijkt het over een driejarige dochter te gaan.",
       "awards_nl": [
         "Eurovisionwinnaar 1976"
-      ]
+      ],
+      "isrc": "NLB127600905",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/283372785",
+        "de": "applemusic://track/283372785",
+        "gb": "applemusic://track/283372785",
+        "fr": "applemusic://track/283372785",
+        "es": "applemusic://track/283372785",
+        "nl": "applemusic://track/283372785",
+        "it": "applemusic://track/283372785"
+      }
     },
     {
       "year": 1977,
@@ -1006,7 +1216,17 @@
       "fun_fact_nl": "L'oiseau et l'enfant is tot op de dag van vandaag de laatste Franse songfestivaloverwinning. De krachtige zang van Marie Myriam maakte het nummer tot een klassieker. Frankrijk heeft sindsdien de langste periode zonder winst van alle voormalige winnende landen.",
       "awards_nl": [
         "Eurovisionwinnaar 1977"
-      ]
+      ],
+      "isrc": "FRZ988800040",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1222623640",
+        "de": "applemusic://track/1222623640",
+        "gb": "applemusic://track/1222623640",
+        "fr": "applemusic://track/1222623640",
+        "es": "applemusic://track/1222623640",
+        "nl": "applemusic://track/1222623640",
+        "it": "applemusic://track/1222623640"
+      }
     },
     {
       "year": 1978,
@@ -1083,7 +1303,17 @@
       "fun_fact_nl": "Hallelujah zorgde voor een tweede Israëlische overwinning op rij. Gezongen door Gali Atari met Milk and Honey, sloeg de vredesboodschap van het nummer diep aan tijdens de gespannen tijden in het Midden-Oosten. Israël organiseerde het festival van 1979 in Jeruzalem.",
       "awards_nl": [
         "Eurovisionwinnaar 1979"
-      ]
+      ],
+      "isrc": "IL1032102005",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1724997885",
+        "de": "applemusic://track/1724997885",
+        "gb": "applemusic://track/1724997885",
+        "fr": "applemusic://track/1724997885",
+        "es": "applemusic://track/1724997885",
+        "nl": "applemusic://track/1724997885",
+        "it": "applemusic://track/1724997885"
+      }
     },
     {
       "year": 1980,
@@ -1123,7 +1353,17 @@
       "fun_fact_nl": "What's Another Year was het begin van de legendarische songfestivalcarrière van Johnny Logan. Hij zou in 1987 opnieuw winnen als zanger en in 1992 als songwriter, waarmee hij de enige is met drie overwinningen. Hij staat bekend als 'Mr. Eurovision'.",
       "awards_nl": [
         "Eurovisionwinnaar 1980"
-      ]
+      ],
+      "isrc": "GBCWS1310103",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/735689364",
+        "de": "applemusic://track/735689364",
+        "gb": "applemusic://track/735689364",
+        "fr": "applemusic://track/735689364",
+        "es": "applemusic://track/735689364",
+        "nl": "applemusic://track/735689364",
+        "it": "applemusic://track/735689364"
+      }
     },
     {
       "year": 1981,
@@ -1165,7 +1405,17 @@
       "fun_fact_nl": "Making Your Mind Up is beroemd om de routine waarbij de mannen de rokken van de vrouwen afscheurden, waarna er kortere rokjes onder vandaan kwamen. Dit werd een van de meest iconische songfestivalmomenten en maakte Bucks Fizz op slag beroemd.",
       "awards_nl": [
         "Eurovisionwinnaar 1981"
-      ]
+      ],
+      "isrc": "GBARL8100025",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/254277909",
+        "de": "applemusic://track/1449906735",
+        "gb": "applemusic://track/1449906735",
+        "fr": "applemusic://track/1449906735",
+        "es": "applemusic://track/1449906735",
+        "nl": "applemusic://track/1449906735",
+        "it": "applemusic://track/1449906735"
+      }
     },
     {
       "year": 1982,
@@ -1208,7 +1458,17 @@
       "fun_fact_nl": "Ein bisschen Frieden bezorgde Duitsland de eerste overwinning en stond overal in Europa bovenaan de hitlijsten. De vredesballade sloeg aan tijdens de Koude Oorlog. Nicole was pas 17 en bracht het nummer op een eenvoudige en oprechte wijze.",
       "awards_nl": [
         "Eurovisionwinnaar 1982"
-      ]
+      ],
+      "isrc": "DEC718200001",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/284222244",
+        "de": "applemusic://track/1459075524",
+        "gb": "applemusic://track/284222244",
+        "fr": "applemusic://track/284222244",
+        "es": "applemusic://track/284222244",
+        "nl": "applemusic://track/284222244",
+        "it": "applemusic://track/284222244"
+      }
     },
     {
       "year": 1983,
@@ -1247,7 +1507,17 @@
       "fun_fact_nl": "Si la vie est cadeau bezorgde Luxemburg de vijfde en laatste overwinning. De powerballade toonde het indrukwekkende stembereik van Corinne Hermes. Luxemburg trok zich in 1994 terug en is pas onlangs weer teruggekeerd.",
       "awards_nl": [
         "Eurovisionwinnaar 1983"
-      ]
+      ],
+      "isrc": "TCAFO2159766",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1568840214",
+        "de": "applemusic://track/1568840214",
+        "gb": "applemusic://track/1568840214",
+        "fr": "applemusic://track/1568840214",
+        "es": "applemusic://track/1568840214",
+        "nl": "applemusic://track/1568840214",
+        "it": "applemusic://track/1568840214"
+      }
     },
     {
       "year": 1984,
@@ -1287,7 +1557,17 @@
       "fun_fact_nl": "Diggi-Loo Diggi-Ley werd gezongen door drie broers in glimmende gouden laarzen, wat hun handelsmerk werd. Het vrolijke Eurodisco-nummer bezorgde Zweden de tweede winst na ABBA. De energieke choreografie van de Herreys was typerend voor het songfestival van de jaren '80.",
       "awards_nl": [
         "Eurovisionwinnaar 1984"
-      ]
+      ],
+      "isrc": "SEVNI0201801",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/440309422",
+        "de": "applemusic://track/440309422",
+        "gb": "applemusic://track/440309422",
+        "fr": "applemusic://track/440309422",
+        "es": "applemusic://track/440309422",
+        "nl": "applemusic://track/440309422",
+        "it": "applemusic://track/440309422"
+      }
     },
     {
       "year": 1985,
@@ -1327,7 +1607,17 @@
       "fun_fact_nl": "La det swinge maakte een eind aan de lange reeks slechte Noorse resultaten met hun allereerste overwinning. Het duo Bobbysocks brak door met een energiek poprock-optreden dat de Europese stemmers wist te bekoren.",
       "awards_nl": [
         "Eurovisionwinnaar 1985"
-      ]
+      ],
+      "isrc": "NOJLA1005130",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/976265487",
+        "de": "applemusic://track/976265487",
+        "gb": "applemusic://track/976265487",
+        "fr": "applemusic://track/976265487",
+        "es": "applemusic://track/976265487",
+        "nl": "applemusic://track/976265487",
+        "it": "applemusic://track/976265487"
+      }
     },
     {
       "year": 1986,
@@ -1367,7 +1657,17 @@
       "fun_fact_nl": "J'aime la vie is tot nu toe de enige Belgische overwinning. Sandra Kim beweerde 15 te zijn, maar was in werkelijkheid pas 13, waarmee ze de jongste winnaar ooit is. De waarheid kwam pas na haar overwinning aan het licht.",
       "awards_nl": [
         "Eurovisionwinnaar 1986"
-      ]
+      ],
+      "isrc": "BEU761000004",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1454276575",
+        "de": "applemusic://track/910784990",
+        "gb": "applemusic://track/910784990",
+        "fr": "applemusic://track/1563774029",
+        "es": "applemusic://track/910784990",
+        "nl": "applemusic://track/910784990",
+        "it": "applemusic://track/910784990"
+      }
     },
     {
       "year": 1987,
@@ -1409,7 +1709,17 @@
       "fun_fact_nl": "Hold Me Now maakte Johnny Logan de eerste artiest die twee keer won als zanger. Hij schreef deze ballade zelf, in tegenstelling tot zijn inzending uit 1980. Logan zou in 1992 voor de derde keer winnen als songwriter van 'Why Me?'.",
       "awards_nl": [
         "Eurovisionwinnaar 1987"
-      ]
+      ],
+      "isrc": "GBBBM8700004",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/429802667",
+        "de": "applemusic://track/335782624",
+        "gb": "applemusic://track/429802667",
+        "fr": "applemusic://track/429802667",
+        "es": "applemusic://track/429802667",
+        "nl": "applemusic://track/429802667",
+        "it": "applemusic://track/429802667"
+      }
     },
     {
       "year": 1988,
@@ -1449,7 +1759,17 @@
       "fun_fact_nl": "Ne partez pas sans moi betekende de Europese doorbraak voor Celine Dion. Ze won met slechts één punt verschil in een zenuwslopende finale. Dion kwam uit voor Zwitserland omdat Canadese artiesten niet voor hun eigen land mochten uitkomen.",
       "awards_nl": [
         "Eurovisionwinnaar 1988"
-      ]
+      ],
+      "isrc": "FRV628800310",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/193622548",
+        "de": "applemusic://track/193622548",
+        "gb": "applemusic://track/193622548",
+        "fr": "applemusic://track/193622548",
+        "es": "applemusic://track/193622548",
+        "nl": "applemusic://track/193622548",
+        "it": "applemusic://track/193622548"
+      }
     },
     {
       "year": 1989,
@@ -1489,7 +1809,17 @@
       "fun_fact_nl": "Rock Me was de enige Joegoslavische overwinning voordat het land uiteenviel. De Kroatische band Riva trad op met aanstekelijke energie. Door het uiteenvallen van Joegoslavië kon geen verenigd land deze winst lang vieren.",
       "awards_nl": [
         "Eurovisionwinnaar 1989"
-      ]
+      ],
+      "isrc": "HRA048918172",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1846157477",
+        "de": "applemusic://track/1846157477",
+        "gb": "applemusic://track/1846157477",
+        "fr": "applemusic://track/1846157477",
+        "es": "applemusic://track/1846157477",
+        "nl": "applemusic://track/1846157477",
+        "it": "applemusic://track/1846157477"
+      }
     },
     {
       "year": 1990,
@@ -1529,7 +1859,17 @@
       "fun_fact_nl": "Insieme: 1992 vierde de Europese eenheid in de aanloop naar de vorming van de EU. Toto Cutugno had al vaak meegedaan voordat hij eindelijk won. Het nummer werd een symbool voor Europese integratie op een cruciaal historisch moment.",
       "awards_nl": [
         "Eurovisionwinnaar 1990"
-      ]
+      ],
+      "isrc": "ITB261002520",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1329254875",
+        "de": "applemusic://track/1329254875",
+        "gb": "applemusic://track/1329254875",
+        "fr": "applemusic://track/1329254875",
+        "es": "applemusic://track/1329254875",
+        "nl": "applemusic://track/1329254875",
+        "it": "applemusic://track/1329254875"
+      }
     },
     {
       "year": 1991,
@@ -1608,7 +1948,17 @@
       "fun_fact_nl": "Why Me? werd geschreven door Johnny Logan, wat hem zijn derde overwinning bezorgde (dit keer als songwriter). Linda Martin had al eerder meegedaan in 1984. Dit was het begin van een reeks van vier Ierse zeges op rij.",
       "awards_nl": [
         "Eurovisionwinnaar 1992"
-      ]
+      ],
+      "isrc": "GBKRX1600856",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1111959191",
+        "de": "applemusic://track/1111959191",
+        "gb": "applemusic://track/1111959191",
+        "fr": "applemusic://track/1111959191",
+        "es": "applemusic://track/1111959191",
+        "nl": "applemusic://track/1111959191",
+        "it": "applemusic://track/1111959191"
+      }
     },
     {
       "year": 1993,
@@ -1648,7 +1998,17 @@
       "fun_fact_nl": "In Your Eyes zorgde voor de tweede Ierse overwinning op rij. De krachtige stem van Niamh Kavanagh leverde de hoogste puntenscore tot dan toe op. Ze keerde in 2010 terug om Ierland nogmaals te vertegenwoordigen.",
       "awards_nl": [
         "Eurovisionwinnaar 1993"
-      ]
+      ],
+      "isrc": "GBARK0400010",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/348924038",
+        "de": "applemusic://track/348924038",
+        "gb": "applemusic://track/348924038",
+        "fr": "applemusic://track/348924038",
+        "es": "applemusic://track/348924038",
+        "nl": "applemusic://track/348924038",
+        "it": "applemusic://track/348924038"
+      }
     },
     {
       "year": 1994,
@@ -1690,7 +2050,17 @@
       "fun_fact_nl": "Rock 'n' Roll Kids betekende de derde Ierse overwinning op rij. Het nostalgische duet over jeugddromen verbrak het puntenrecord. Tijdens dit festival vond ook het eerste optreden van 'Riverdance' plaats, wat een wereldwijd succes werd.",
       "awards_nl": [
         "Eurovisionwinnaar 1994"
-      ]
+      ],
+      "isrc": "US2G40701607",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/212118856",
+        "de": "applemusic://track/212118856",
+        "gb": "applemusic://track/212118856",
+        "fr": "applemusic://track/212118856",
+        "es": "applemusic://track/212118856",
+        "nl": "applemusic://track/212118856",
+        "it": "applemusic://track/212118856"
+      }
     },
     {
       "year": 1995,
@@ -1771,7 +2141,17 @@
       "fun_fact_nl": "The Voice bezorgde Ierland de recordbrekende zevende overwinning (de vierde in vijf jaar). Het serene Keltische optreden van Eimear Quinn zette de Ierse dominantie voort. Geen enkel land won het festival vaker dan Ierland.",
       "awards_nl": [
         "Eurovisionwinnaar 1996"
-      ]
+      ],
+      "isrc": "USDP20403422",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/74409108",
+        "de": "applemusic://track/74409108",
+        "gb": "applemusic://track/74409108",
+        "fr": "applemusic://track/74409108",
+        "es": "applemusic://track/74409108",
+        "nl": "applemusic://track/74409108",
+        "it": "applemusic://track/74409108"
+      }
     },
     {
       "year": 1997,
@@ -1811,7 +2191,17 @@
       "fun_fact_nl": "Love Shine a Light was de vijfde en meest recente Britse overwinning. Katrina & The Waves wonnen met de grootste voorsprong tot dan toe: 70 punten meer dan de nummer twee. Katrina Leskanich was al beroemd van 'Walking on Sunshine'.",
       "awards_nl": [
         "Eurovisionwinnaar 1997"
-      ]
+      ],
+      "isrc": "GBDNM1010071",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1438441951",
+        "de": "applemusic://track/1438441951",
+        "gb": "applemusic://track/1438441951",
+        "fr": "applemusic://track/1438441951",
+        "es": "applemusic://track/1438441951",
+        "nl": "applemusic://track/1438441951",
+        "it": "applemusic://track/1438441951"
+      }
     },
     {
       "year": 1998,
@@ -1890,7 +2280,17 @@
       "fun_fact_nl": "Take Me to Your Heaven was de vierde Zweedse overwinning. Charlotte Nilsson (later Perrelli) bracht een klassiek Scandinavisch popnummer. Ze keerde in 2008 terug met 'Hero' en werd toen 18e.",
       "awards_nl": [
         "Eurovisionwinnaar 1999"
-      ]
+      ],
+      "isrc": "SEVFN9908070",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1477474325",
+        "de": "applemusic://track/1477474325",
+        "gb": "applemusic://track/1477474325",
+        "fr": "applemusic://track/1477474325",
+        "es": "applemusic://track/1477474325",
+        "nl": "applemusic://track/1477474325",
+        "it": "applemusic://track/1477474325"
+      }
     },
     {
       "year": 2000,
@@ -1930,7 +2330,17 @@
       "fun_fact_nl": "Fly on the Wings of Love maakte een eind aan de 37 jaar durende Deense periode zonder winst. De Olsen Brothers waren ervaren muzikanten van in de vijftig toen ze wonnen, wat bewees dat leeftijd geen barrière hoeft te zijn.",
       "awards_nl": [
         "Eurovisionwinnaar 2000"
-      ]
+      ],
+      "isrc": "DKABA1100240",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1676954239",
+        "de": "applemusic://track/1676954239",
+        "gb": "applemusic://track/1676954239",
+        "fr": "applemusic://track/1676954239",
+        "es": "applemusic://track/1676954239",
+        "nl": "applemusic://track/1676954239",
+        "it": "applemusic://track/1676954239"
+      }
     },
     {
       "year": 2001,
@@ -2005,7 +2415,17 @@
       "fun_fact_nl": "I Wanna bezorgde Letland de eerste overwinning bij hun pas derde deelname. Het zwoele optreden van Marie N en de kostuumwissels tijdens het nummer zorgden voor een gedenkwaardig spektakel. Letland organiseerde daarna het festival van 2003 in Riga.",
       "awards_nl": [
         "Eurovisionwinnaar 2002"
-      ]
+      ],
+      "isrc": "USA370580255",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/260662904",
+        "de": "applemusic://track/260662904",
+        "gb": "applemusic://track/260662904",
+        "fr": "applemusic://track/260662904",
+        "es": "applemusic://track/260662904",
+        "nl": "applemusic://track/260662904",
+        "it": "applemusic://track/260662904"
+      }
     },
     {
       "year": 2003,
@@ -2045,7 +2465,17 @@
       "fun_fact_nl": "Everyway That I Can was de eerste en enige Turkse overwinning. De buikdans van Sertab Erener en de Turkse popinvloeden brachten iets nieuws naar het festival. Het optreden bevatte achtergronddansers en een uitgebreide choreografie.",
       "awards_nl": [
         "Eurovisionwinnaar 2003"
-      ]
+      ],
+      "isrc": "TRA160300427",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/400705407",
+        "de": "applemusic://track/1308768327",
+        "gb": "applemusic://track/1308768327",
+        "fr": "applemusic://track/1308768327",
+        "es": "applemusic://track/1308768327",
+        "nl": "applemusic://track/1308768327",
+        "it": "applemusic://track/1308768327"
+      }
     },
     {
       "year": 2004,
@@ -2085,7 +2515,17 @@
       "fun_fact_nl": "Wild Dances was de eerste Oekraïense overwinning en bevatte volksmuziek-elementen uit de Karpaten. Het energieke optreden van Ruslana met vuur en tribale dans was revolutionair. Ze werd later een bekende activiste tijdens de politieke onrust in Oekraïne.",
       "awards_nl": [
         "Eurovisionwinnaar 2004"
-      ]
+      ],
+      "isrc": "UAAO10400001",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1691585109",
+        "de": "applemusic://track/1682977143",
+        "gb": "applemusic://track/1691585109",
+        "fr": "applemusic://track/1682977143",
+        "es": "applemusic://track/1682977143",
+        "nl": "applemusic://track/1682977143",
+        "it": "applemusic://track/1691585109"
+      }
     },
     {
       "year": 2005,
@@ -2125,7 +2565,17 @@
       "fun_fact_nl": "My Number One was de eerste Griekse overwinning na decennia van deelname. De Grieks-Zweedse achtergrond van Helena Paparizou en haar gelikte pop-optreden overtuigden de stemmers. Ze had in 2001 al meegedaan als onderdeel van het duo Antique.",
       "awards_nl": [
         "Eurovisionwinnaar 2005"
-      ]
+      ],
+      "isrc": "GRS010500065",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1782949200",
+        "de": "applemusic://track/1782949200",
+        "gb": "applemusic://track/1782949200",
+        "fr": "applemusic://track/1782949200",
+        "es": "applemusic://track/1782949200",
+        "nl": "applemusic://track/1782949200",
+        "it": "applemusic://track/1782949200"
+      }
     },
     {
       "year": 2006,
@@ -2165,7 +2615,17 @@
       "fun_fact_nl": "Hard Rock Hallelujah schokte het songfestival toen een Finse heavy metalband in monsterkostuums won. Het theatrale optreden van Lordi bewees dat het songfestival alle genres kon omarmen. Finland had nog nooit gewonnen, ondanks deelname sinds 1961.",
       "awards_nl": [
         "Eurovisionwinnaar 2006"
-      ]
+      ],
+      "isrc": "USGMP0700099",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/389516413",
+        "de": null,
+        "gb": null,
+        "fr": null,
+        "es": "applemusic://track/389516413",
+        "nl": null,
+        "it": null
+      }
     },
     {
       "year": 2007,
@@ -2243,7 +2703,17 @@
       "fun_fact_nl": "Believe bezorgde Rusland hun eerste en enige Eurovisie-overwinning. Dima Bilan trad op met de Hongaarse violist Edvin Marton en een Olympische schaatser op het podium. Hij was tweede geworden in 2006, waardoor 2008 zijn verlossingsjaar werd.",
       "awards_nl": [
         "Eurovisionwinnaar 2008"
-      ]
+      ],
+      "isrc": "RUB421500013",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1859966612",
+        "de": "applemusic://track/1859966612",
+        "gb": "applemusic://track/1859966612",
+        "fr": "applemusic://track/1859966612",
+        "es": "applemusic://track/1859966612",
+        "nl": "applemusic://track/1859966612",
+        "it": "applemusic://track/1859966612"
+      }
     },
     {
       "year": 2009,
@@ -2283,7 +2753,17 @@
       "fun_fact_nl": "Fairytale won met 387 punten, de hoogste score ooit behaald op dat moment onder het stemsysteem. Alexander Rybak charmeerde heel Europa met zijn folkpopliedjes en vioolspel. De Wit-Russisch-Noorse artiest was net 22 jaar oud.",
       "awards_nl": [
         "Eurovisionwinnaar 2009"
-      ]
+      ],
+      "isrc": "NO23B0900001",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1438988564",
+        "de": "applemusic://track/1438988564",
+        "gb": "applemusic://track/1438988564",
+        "fr": "applemusic://track/1438988564",
+        "es": "applemusic://track/1438988564",
+        "nl": "applemusic://track/1438988564",
+        "it": "applemusic://track/1438988564"
+      }
     },
     {
       "year": 2010,
@@ -2326,7 +2806,17 @@
       "fun_fact_nl": "Satellite bezorgde Duitsland hun tweede Eurovisie-overwinning en de eerste sinds 1982. Het eigenzinnige, charmante optreden van Lena Meyer-Landrut veroverde harten in heel Europa. Ze werd ontdekt via het Duitse tv-programma 'Unser Star fur Oslo'.",
       "awards_nl": [
         "Eurovisionwinnaar 2010"
-      ]
+      ],
+      "isrc": "DEUM71001210",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1667036971",
+        "de": "applemusic://track/1667036971",
+        "gb": "applemusic://track/1667036971",
+        "fr": "applemusic://track/1667036971",
+        "es": "applemusic://track/1700804689",
+        "nl": "applemusic://track/1667036971",
+        "it": "applemusic://track/1667036971"
+      }
     },
     {
       "year": 2011,
@@ -2406,7 +2896,17 @@
       "fun_fact_nl": "Euphoria wordt beschouwd als een van de beste winnende Eurovisiesongs ooit. Loreen kreeg stemmen voor de eerste plaats uit 18 landen - een record. Het beklijvende dansnummer stond wereldwijd bovenaan de hitlijsten en heeft meer dan 300 miljoen Spotify streams.",
       "awards_nl": [
         "Eurovisionwinnaar 2012"
-      ]
+      ],
+      "isrc": "SEPQA1200005",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1745191015",
+        "de": "applemusic://track/1561954637",
+        "gb": "applemusic://track/1745191015",
+        "fr": "applemusic://track/1745191015",
+        "es": "applemusic://track/1745191015",
+        "nl": "applemusic://track/1675327501",
+        "it": "applemusic://track/1745191015"
+      }
     },
     {
       "year": 2013,
@@ -2448,7 +2948,17 @@
       "fun_fact_nl": "Only Teardrops bezorgde Denemarken hun derde Eurovisie-overwinning. Emmelie de Forest's etherische folk-pop optreden bevatte dansen op blote voeten en tin whistle. De boodschap van het lied over het loslaten van pijn vond weerklank bij kijkers in heel Europa.",
       "awards_nl": [
         "Eurovisionwinnaar 2013"
-      ]
+      ],
+      "isrc": "DKADG1200760",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1442839142",
+        "de": "applemusic://track/1442382943",
+        "gb": "applemusic://track/1442382943",
+        "fr": "applemusic://track/1442382943",
+        "es": "applemusic://track/661545116",
+        "nl": "applemusic://track/1442382943",
+        "it": "applemusic://track/1442382943"
+      }
     },
     {
       "year": 2014,
@@ -2491,7 +3001,17 @@
       "fun_fact_nl": "Rise Like a Phoenix maakte van Conchita Wurst (drag persona van Tom Neuwirth) een wereldwijd icoon en LGBTQ+ symbool. De krachtige ballad van de bebaarde dragqueen was de tweede overwinning voor Oostenrijk. Ze trad op zonder achtergronddansers - de eerste winnares die dat deed sinds 1970.",
       "awards_nl": [
         "Eurovisionwinnaar 2014"
-      ]
+      ],
+      "isrc": "ATE501400401",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/844169216",
+        "de": "applemusic://track/844169216",
+        "gb": "applemusic://track/844169216",
+        "fr": "applemusic://track/844169216",
+        "es": "applemusic://track/844169216",
+        "nl": "applemusic://track/844169216",
+        "it": "applemusic://track/844169216"
+      }
     },
     {
       "year": 2015,
@@ -2534,7 +3054,17 @@
       "fun_fact_nl": "Heroes had baanbrekende visuele effecten met geanimeerde stokfiguren die live op het podium in interactie waren met de artiest. Het optreden van Mans Zelmerlow betekende een revolutie voor de enscenering van Eurovisie. De gebruikte technologie kostte meer dan een miljoen euro om te ontwikkelen.",
       "awards_nl": [
         "Eurovisionwinnaar 2015"
-      ]
+      ],
+      "isrc": "SEPQA1401135",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1612452449",
+        "de": "applemusic://track/1612452449",
+        "gb": "applemusic://track/1612452449",
+        "fr": "applemusic://track/1612452449",
+        "es": "applemusic://track/1612452449",
+        "nl": "applemusic://track/1612452449",
+        "it": "applemusic://track/1612452449"
+      }
     },
     {
       "year": 2016,
@@ -2576,7 +3106,17 @@
       "fun_fact_nl": "1944 vertelde het verhaal van Stalins deportatie van Krim-Tataren, waaronder Jamala's overgrootmoeder. Het politiek geladen lied won controversieel te midden van de spanningen tussen Rusland en Oekraïne. Het blijft een van de meest krachtige en emotionele winnende inzendingen van Eurovisie.",
       "awards_nl": [
         "Eurovisionwinnaar 2016"
-      ]
+      ],
+      "isrc": "RUA1H1518948",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1664506710",
+        "de": "applemusic://track/1664506710",
+        "gb": "applemusic://track/1664506710",
+        "fr": "applemusic://track/1664506710",
+        "es": "applemusic://track/1664506710",
+        "nl": "applemusic://track/1664506710",
+        "it": "applemusic://track/1664506710"
+      }
     },
     {
       "year": 2017,
@@ -2616,7 +3156,17 @@
       "fun_fact_nl": "Amar Pelos Dois (Liefde voor ons beiden) won met 758 punten - de hoogste score ooit in de Eurovisiegeschiedenis. De intieme jazzballad van Salvador Sobral, geschreven door zijn zus Luisa, brak alle records. Hij trad op in afwachting van een harttransplantatie, die hij maanden later kreeg.",
       "awards_nl": [
         "Eurovisionwinnaar 2017"
-      ]
+      ],
+      "isrc": "PTNO11700001",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1812636468",
+        "de": "applemusic://track/1812636468",
+        "gb": "applemusic://track/1812636468",
+        "fr": "applemusic://track/1812636468",
+        "es": "applemusic://track/1812636468",
+        "nl": "applemusic://track/1812636468",
+        "it": "applemusic://track/1812636468"
+      }
     },
     {
       "year": 2018,
@@ -2657,7 +3207,17 @@
       "fun_fact_nl": "De kippengeluiden en loop-pedal performance van Toy maakten het onvergetelijk. Netta Barzilai's 'empowerment anthem' met de boodschap 'I'm not your toy' sloot aan bij de #MeToo-beweging. De eigenzinnige elektronische track verdeelde de meningen maar won beslissend.",
       "awards_nl": [
         "Eurovisionwinnaar 2018"
-      ]
+      ],
+      "isrc": "IL5181100107",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1388547847",
+        "de": "applemusic://track/1388547847",
+        "gb": "applemusic://track/1388547847",
+        "fr": "applemusic://track/1388547847",
+        "es": "applemusic://track/1388547847",
+        "nl": "applemusic://track/1388547847",
+        "it": "applemusic://track/1388547847"
+      }
     },
     {
       "year": 2019,
@@ -2699,7 +3259,17 @@
       "fun_fact_nl": "Arcade werd de grootste post-Eurovisiehit in de geschiedenis nadat het viraal ging op TikTok in 2021, twee jaar na de overwinning. De emotionele pianoballade over verloren liefde heeft meer dan 1 miljard streams. Het bezorgde Nederland hun vijfde Eurovisie-overwinning.",
       "awards_nl": [
         "Eurovisionwinnaar 2019"
-      ]
+      ],
+      "isrc": "NL1TK1900001",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1748200197",
+        "de": "applemusic://track/1748200197",
+        "gb": "applemusic://track/1748200197",
+        "fr": "applemusic://track/1748200197",
+        "es": "applemusic://track/1748200197",
+        "nl": "applemusic://track/1748200197",
+        "it": "applemusic://track/1748200197"
+      }
     },
     {
       "year": 2021,
@@ -2739,7 +3309,17 @@
       "fun_fact_nl": "ZITTI E BUONI (Shut Up and Behave) was het eerste rocknummer dat Eurovisie won sinds Lordi in 2006. Maneskin werd een wereldwijde superster, die wereldwijd hitlijsten aanvoerde en optrad op grote festivals. Frontman Damiano werd geconfronteerd met valse beschuldigingen van drugsgebruik die snel werden weerlegd.",
       "awards_nl": [
         "Eurovisionwinnaar 2021"
-      ]
+      ],
+      "isrc": "ITB002100112",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1728089187",
+        "de": "applemusic://track/1728089187",
+        "gb": "applemusic://track/1728089187",
+        "fr": "applemusic://track/1728089187",
+        "es": "applemusic://track/1728089187",
+        "nl": "applemusic://track/1591459549",
+        "it": "applemusic://track/1728089187"
+      }
     },
     {
       "year": 2022,
@@ -2782,7 +3362,17 @@
       "fun_fact_nl": "Stefania won Eurovisie tijdens de Russische invasie van Oekraïne, waarbij de bandleden na de wedstrijd terugkeerden om te vechten. Oorspronkelijk geschreven over de moeder van frontman Oleh Psiuk, kreeg de tekst een nieuwe betekenis over het moederland. Het kreeg overweldigende publieksstemmen als solidariteit met Oekraïne.",
       "awards_nl": [
         "Eurovisionwinnaar 2022"
-      ]
+      ],
+      "isrc": "DEE862200344",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1614859013",
+        "de": "applemusic://track/1614859013",
+        "gb": "applemusic://track/1614859013",
+        "fr": "applemusic://track/1614859013",
+        "es": "applemusic://track/1614859013",
+        "nl": "applemusic://track/1614859013",
+        "it": "applemusic://track/1614859013"
+      }
     },
     {
       "year": 2023,
@@ -2825,7 +3415,17 @@
       "fun_fact_nl": "Met 'Tattoo' was Loreen de tweede artiest ooit die twee keer Eurovisie won (na Johnny Logan). Haar beklijvende optreden 11 jaar na 'Euphoria' bewees dat de bliksem twee keer kan inslaan. Met zeven overwinningen staat Zweden gelijk met Ierland voor de meeste Eurovisie-overwinningen.",
       "awards_nl": [
         "Eurovisionwinnaar 2023"
-      ]
+      ],
+      "isrc": "SEUM72201638",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1872510113",
+        "de": "applemusic://track/1872510113",
+        "gb": "applemusic://track/1872510113",
+        "fr": "applemusic://track/1872510113",
+        "es": "applemusic://track/1872510113",
+        "nl": "applemusic://track/1872510113",
+        "it": "applemusic://track/1872510113"
+      }
     },
     {
       "year": 2024,
@@ -2865,7 +3465,17 @@
       "fun_fact_nl": "De Code schreef geschiedenis toen Nemo de eerste niet-binaire artiest werd die Eurovisie won. Het theatrale optreden combineerde opera, rap en drum and bass. De derde overwinning van Zwitserland kwam in een controversiële wedstrijd in Malmo, Zweden.",
       "awards_nl": [
         "Eurovisionwinnaar 2024"
-      ]
+      ],
+      "isrc": "DEUM72401182",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1730730673",
+        "de": "applemusic://track/1730730673",
+        "gb": "applemusic://track/1730730673",
+        "fr": "applemusic://track/1730730673",
+        "es": "applemusic://track/1730730673",
+        "nl": "applemusic://track/1730730673",
+        "it": "applemusic://track/1730730673"
+      }
     },
     {
       "year": 2025,
@@ -2905,7 +3515,17 @@
       "fun_fact_nl": "Wasted Love liet JJ's buitengewone countertenor operastem horen in een nummer dat opbouwt van orkestrale zweltonen naar een clubfinish. Johannes Pietsch, die optreedt in de Weense Staatsopera, kreeg de steun van de jury van 8 landen, wat hem dubbele punten opleverde. Oostenrijk zal gastheer zijn van Eurovisie 2026.",
       "awards_nl": [
         "Eurovisionwinnaar 2025"
-      ]
+      ],
+      "isrc": "DEA622500513",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1880012757",
+        "de": "applemusic://track/1880012757",
+        "gb": "applemusic://track/1880012757",
+        "fr": "applemusic://track/1880012757",
+        "es": "applemusic://track/1880012757",
+        "nl": "applemusic://track/1880012757",
+        "it": "applemusic://track/1880012757"
+      }
     }
   ]
 }

--- a/custom_components/beatify/playlists/greatest-hits-of-all-time.json
+++ b/custom_components/beatify/playlists/greatest-hits-of-all-time.json
@@ -50,7 +50,17 @@
       "fun_fact_nl": "Bohemian Rhapsody werd aanvankelijk afgewezen door platenmaatschappijen die dachten dat een opera-rocknummer van 6 minuten nooit op de radio zou komen. Freddie Mercury spendeerde drie weken aan het opnemen van de complexe vocale harmonieën, met 180 afzonderlijke overdubs. Het werd het kenmerkende nummer van Queen.",
       "awards_nl": [
         "Grammy Hall of Fame (2004)"
-      ]
+      ],
+      "isrc": "GBUM71029604",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1842449358",
+        "de": "applemusic://track/1842449358",
+        "gb": "applemusic://track/1842449358",
+        "fr": "applemusic://track/1842449358",
+        "es": "applemusic://track/1842449358",
+        "nl": "applemusic://track/1842449358",
+        "it": "applemusic://track/1842449358"
+      }
     },
     {
       "year": 1982,
@@ -78,7 +88,17 @@
       "uri_tidal": "tidal://track/539204",
       "uri_deezer": "deezer://track/1079668",
       "fun_fact_nl": "Africa is geschreven door TOTO's David Paich over een man die nooit in Afrika is geweest maar het continent romantiseert. Het kenmerkende keyboard intro werd geïnspireerd door een documentaire over Afrikaanse wilde dieren. Het nummer heeft decennia na de release meerdere virale revivals beleefd.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM19801941",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1626383947",
+        "de": "applemusic://track/1626383947",
+        "gb": "applemusic://track/1626383947",
+        "fr": "applemusic://track/1626383947",
+        "es": "applemusic://track/1626383947",
+        "nl": "applemusic://track/1626383947",
+        "it": "applemusic://track/1626383947"
+      }
     },
     {
       "year": 1997,
@@ -107,7 +127,17 @@
       "uri_tidal": "tidal://track/2876035",
       "uri_deezer": "deezer://track/3138729",
       "fun_fact_nl": "Angels werd geschreven door Robbie Williams en Guy Chambers in slechts 25 minuten bij Chambers thuis. Het werd jarenlang het meest gevraagde lied op Britse begrafenissen. Williams heeft gezegd dat het gaat over zijn geloof in beschermengelen en de band tussen mensen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAYE9700233",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/725818406",
+        "de": "applemusic://track/1442885469",
+        "gb": "applemusic://track/1440769042",
+        "fr": "applemusic://track/1442885469",
+        "es": "applemusic://track/1442885469",
+        "nl": "applemusic://track/1442885469",
+        "it": "applemusic://track/1442885469"
+      }
     },
     {
       "year": 1980,
@@ -136,7 +166,17 @@
       "uri_tidal": "tidal://track/35986110",
       "uri_deezer": "deezer://track/92720046",
       "fun_fact_nl": "Back In Black werd opgenomen als eerbetoon aan AC/DC frontman Bon Scott, die in februari 1980 overleed. Het album met dezelfde naam werd een van de best verkochte platen in de geschiedenis. Brian Johnson werd geselecteerd als Scott's vervanger slechts enkele weken voordat de opnames begonnen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "AUAP08000046",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/576003082",
+        "de": "applemusic://track/576003082",
+        "gb": "applemusic://track/576003082",
+        "fr": "applemusic://track/576003082",
+        "es": "applemusic://track/576003082",
+        "nl": "applemusic://track/576003082",
+        "it": "applemusic://track/576003082"
+      }
     },
     {
       "year": 1982,
@@ -177,7 +217,17 @@
       "fun_fact_nl": "De iconische videoclip van Thriller werd geregisseerd door John Landis en kostte 500.000 dollar om te produceren - ongekend voor die tijd. De première duurde 14 minuten en veranderde de muziekvideo-industrie voorgoed. Vincent Price nam zijn beroemde rap op in slechts twee takes.",
       "awards_nl": [
         "Grammy – Beste Mannelijke Pop Zangprestatie (1984)"
-      ]
+      ],
+      "isrc": "USSM19902989",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/655262182",
+        "de": "applemusic://track/655262182",
+        "gb": "applemusic://track/655262182",
+        "fr": "applemusic://track/655262182",
+        "es": "applemusic://track/655262182",
+        "nl": "applemusic://track/655262182",
+        "it": "applemusic://track/655262182"
+      }
     },
     {
       "year": 1984,
@@ -205,7 +255,17 @@
       "uri_tidal": "tidal://track/32572499",
       "uri_deezer": "deezer://track/15218949",
       "fun_fact_nl": "Leonard Cohen schreef ongeveer 80 ontwerpverzen van Hallelujah in vijf jaar voordat hij tot de uiteindelijke versie kwam. Het nummer werd aanvankelijk genegeerd, maar kreeg bekendheid door Jeff Buckley's cover uit 1994. Naar verluidt werkte Cohen aan de verzen terwijl hij in zijn ondergoed in hotels zat.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM10026643",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1556917286",
+        "de": "applemusic://track/1556917286",
+        "gb": "applemusic://track/1556917286",
+        "fr": "applemusic://track/1556917286",
+        "es": "applemusic://track/1556917286",
+        "nl": "applemusic://track/1556917286",
+        "it": "applemusic://track/1556917286"
+      }
     },
     {
       "year": 1970,
@@ -234,7 +294,17 @@
       "uri_tidal": "tidal://track/77647238",
       "uri_deezer": "deezer://track/1157032882",
       "fun_fact_nl": "In Father and Son zingt Cat Stevens beide partijen - de vader met een diepere stem en de zoon in een hoger register. Het was oorspronkelijk geschreven voor een musical genaamd Revolussia die nooit werd geproduceerd. Het nummer is wereldwijd een hymne geworden voor begrip tussen generaties.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBUM71905972",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/6762965231",
+        "de": "applemusic://track/6762965231",
+        "gb": "applemusic://track/6762965231",
+        "fr": "applemusic://track/6762965231",
+        "es": "applemusic://track/6762965231",
+        "nl": "applemusic://track/6762965231",
+        "it": "applemusic://track/6762965231"
+      }
     },
     {
       "year": 1968,
@@ -276,7 +346,17 @@
       "fun_fact_nl": "Hey Jude werd geschreven door Paul McCartney om John Lennons zoon Julian te troosten tijdens de scheiding van zijn ouders. Met 7 minuten en 11 seconden was het de langste single die ooit de UK hitlijsten haalde. Het beroemde 'na-na-na' outro werd geïmproviseerd tijdens de opname.",
       "awards_nl": [
         "Grammy Hall of Fame (2001)"
-      ]
+      ],
+      "isrc": "GBUM71505902",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1856287169",
+        "de": "applemusic://track/1856287169",
+        "gb": "applemusic://track/1856287169",
+        "fr": "applemusic://track/1856287169",
+        "es": "applemusic://track/1856287169",
+        "nl": "applemusic://track/1856287169",
+        "it": "applemusic://track/1856287169"
+      }
     },
     {
       "year": 1984,
@@ -304,7 +384,17 @@
       "uri_tidal": "tidal://track/37149247",
       "uri_deezer": "deezer://track/88902741",
       "fun_fact_nl": "Summer of '69 gaat niet over het jaar 1969-Bryan Adams was toen pas 9 jaar oud. Adams heeft bevestigd dat de titel verwijst naar de seksuele positie. Het nummer vangt het nostalgische gevoel van jeugdige zomers en eerste bandjes en werd wereldwijd een vaste waarde op de rockradio.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USAM18490006",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1440823965",
+        "de": "applemusic://track/1440823965",
+        "gb": "applemusic://track/1484319318",
+        "fr": "applemusic://track/1440823965",
+        "es": "applemusic://track/1440823965",
+        "nl": "applemusic://track/1442499799",
+        "it": "applemusic://track/1440823965"
+      }
     },
     {
       "year": 1970,
@@ -350,7 +440,17 @@
       "awards_nl": [
         "Grammy Hall of Fame (2004)",
         "Grammy – Beste Originele Filmmuziek (1971)"
-      ]
+      ],
+      "isrc": "GBAYE0601713",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1441164738",
+        "de": "applemusic://track/1441164738",
+        "gb": "applemusic://track/1441164738",
+        "fr": "applemusic://track/1441164738",
+        "es": "applemusic://track/1441164738",
+        "nl": "applemusic://track/1441164738",
+        "it": "applemusic://track/1441164738"
+      }
     },
     {
       "year": 1979,
@@ -392,7 +492,17 @@
       "fun_fact_nl": "Highway to Hell was het laatste AC/DC-album met de oorspronkelijke zanger Bon Scott, die zes maanden na de release overleed. De titel verwijst naar het slopende leven van toeren, niet naar satanisme. Producer Mutt Lange duwde de band in de richting van een meer gepolijst geluid dat hun toekomstige werk bepaalde.",
       "awards_nl": [
         "Grammy Hall of Fame (2020)"
-      ]
+      ],
+      "isrc": "AUAP07900028",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/574044008",
+        "de": "applemusic://track/574044008",
+        "gb": "applemusic://track/574044008",
+        "fr": "applemusic://track/574044008",
+        "es": "applemusic://track/574044008",
+        "nl": "applemusic://track/574044008",
+        "it": "applemusic://track/574044008"
+      }
     },
     {
       "year": 1976,
@@ -438,7 +548,17 @@
       "awards_nl": [
         "Grammy – Opname van het Jaar (1978)",
         "Grammy Hall of Fame (2003)"
-      ]
+      ],
+      "isrc": "USEE11300195",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/635770202",
+        "de": "applemusic://track/635770202",
+        "gb": "applemusic://track/635770202",
+        "fr": "applemusic://track/635770202",
+        "es": "applemusic://track/635770202",
+        "nl": "applemusic://track/635770202",
+        "it": "applemusic://track/635770202"
+      }
     },
     {
       "year": 1980,
@@ -479,7 +599,17 @@
       "fun_fact_nl": "Another One Bites the Dust werd aanvankelijk tegengewerkt door het management van Queen die het te disco vond. Michael Jackson moedigde de band persoonlijk aan om het als single uit te brengen. John Deacons baslijn was geïnspireerd op Chic's 'Good Times' en werd een wereldwijd fenomeen.",
       "awards_nl": [
         "American Music Award (1981)"
-      ]
+      ],
+      "isrc": "GBUM71029605",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1440650719",
+        "de": "applemusic://track/1441571446",
+        "gb": "applemusic://track/1441571446",
+        "fr": "applemusic://track/1441571446",
+        "es": "applemusic://track/1441571446",
+        "nl": "applemusic://track/1441571446",
+        "it": "applemusic://track/1441571446"
+      }
     },
     {
       "year": 1982,
@@ -525,7 +655,17 @@
       "awards_nl": [
         "Grammy – Opname van het Jaar (1984)",
         "Grammy – Beste Mannelijke Rock Zangprestatie (1984)"
-      ]
+      ],
+      "isrc": "USSM19902990",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/273598915",
+        "de": "applemusic://track/273598915",
+        "gb": "applemusic://track/273598915",
+        "fr": "applemusic://track/273598915",
+        "es": "applemusic://track/273598915",
+        "nl": "applemusic://track/273598915",
+        "it": "applemusic://track/273598915"
+      }
     },
     {
       "year": 1970,
@@ -553,7 +693,17 @@
       "uri_tidal": "tidal://track/30349437",
       "uri_deezer": "deezer://track/78652582",
       "fun_fact_nl": "Immigrant Song werd geïnspireerd door Led Zeppelins concert in IJsland in 1970. De kenmerkende oorlogskreet van Robert Plant was bedoeld om Vikingovervallers op te roepen. De band verzette zich er aanvankelijk tegen om het als single uit te brengen, omdat ze hun muziek liever alleen op albums uitbrachten, maar gaf toe vanwege de vraag.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USAT21207018",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1436700620",
+        "de": "applemusic://track/1436700620",
+        "gb": "applemusic://track/1436700620",
+        "fr": "applemusic://track/1436700620",
+        "es": "applemusic://track/1436700620",
+        "nl": "applemusic://track/1436700620",
+        "it": "applemusic://track/1436700620"
+      }
     },
     {
       "year": 1972,
@@ -594,7 +744,17 @@
       "fun_fact_nl": "Rocket Man werd geschreven nadat Bernie Taupin werd geïnspireerd door het korte verhaal 'The Rocket Man' van Ray Bradbury. Het werd drie weken voor David Bowie's 'Starman' uitgebracht, wat leidde tot vergelijkingen tussen de nummers met het ruimtethema. Elton John nam de piano en zang in één sessie op.",
       "awards_nl": [
         "Grammy Hall of Fame (1998)"
-      ]
+      ],
+      "isrc": "GBUM71700184",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1652668538",
+        "de": "applemusic://track/1652668538",
+        "gb": "applemusic://track/1652668538",
+        "fr": "applemusic://track/1652668538",
+        "es": "applemusic://track/1652668538",
+        "nl": "applemusic://track/1652668538",
+        "it": "applemusic://track/1652668538"
+      }
     },
     {
       "year": 1982,
@@ -635,7 +795,17 @@
       "fun_fact_nl": "Eye of the Tiger werd geschreven als antwoord op Sylvester Stallone's verzoek om een themalied voor Rocky III nadat Queen's 'Another One Bites the Dust' niet gelicenseerd kon worden. De band schreef het met beelden uit de eerste twee Rocky-films als inspiratie. Het haalde wereldwijd de hitlijsten.",
       "awards_nl": [
         "Grammy – Beste Rockprestatie (1983)"
-      ]
+      ],
+      "isrc": "USVR19300001",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1635636757",
+        "de": "applemusic://track/1635636757",
+        "gb": "applemusic://track/456794433",
+        "fr": "applemusic://track/456794433",
+        "es": "applemusic://track/456794433",
+        "nl": "applemusic://track/456794433",
+        "it": "applemusic://track/456794433"
+      }
     },
     {
       "year": 1990,
@@ -663,7 +833,17 @@
       "uri_tidal": "tidal://track/35986245",
       "uri_deezer": "deezer://track/92720102",
       "fun_fact_nl": "Het kostte Angus Young zo veel tijd om de openingsgitaarriff van Thunderstruck te perfectioneren dat hij tijdens de opname armkramp kreeg. De techniek bestaat uit snelle hammer-ons en pull-offs op één snaar. Het nummer is uitgegroeid tot AC/DC's meest gespeelde nummer tijdens sportevenementen over de hele wereld.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "AUAP09000014",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/574051407",
+        "de": "applemusic://track/574051407",
+        "gb": "applemusic://track/574051407",
+        "fr": "applemusic://track/574051407",
+        "es": "applemusic://track/574051407",
+        "nl": "applemusic://track/574051407",
+        "it": "applemusic://track/574051407"
+      }
     },
     {
       "year": 1972,
@@ -704,7 +884,17 @@
       "fun_fact_nl": "Smoke on the Water vertelt het waargebeurde verhaal van een brand in het Montreux Casino tijdens een concert van Frank Zappa in 1971. Deep Purple zag de brand vanaf de overkant van het meer van Genève waar ze verbleven. De rook ging letterlijk over het water en vormde de inspiratie voor de beroemdste gitaarriff van de rock.",
       "awards_nl": [
         "Grammy Hall of Fame (2023)"
-      ]
+      ],
+      "isrc": "USRH11602140",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1099335223",
+        "de": null,
+        "gb": null,
+        "fr": null,
+        "es": null,
+        "nl": null,
+        "it": null
+      }
     },
     {
       "year": 1977,
@@ -745,7 +935,17 @@
       "fun_fact_nl": "Het tempo van Stayin' Het tempo van 104 BPM komt overeen met het ideale tempo voor het uitvoeren van reanimatie op de borst, waardoor het een aanbevolen nummer is voor medische training. Het nummer werd in slechts een paar uur geschreven tijdens een onderbreking van het filmen van Saturday Night Fever. Het definieerde het discotijdperk.",
       "awards_nl": [
         "Grammy – Beste Pop Zangprestatie (1979)"
-      ]
+      ],
+      "isrc": "NLF057790034",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1884981998",
+        "de": "applemusic://track/1884981998",
+        "gb": "applemusic://track/1884981998",
+        "fr": "applemusic://track/1884981998",
+        "es": "applemusic://track/1884981998",
+        "nl": "applemusic://track/1884981998",
+        "it": "applemusic://track/1884981998"
+      }
     },
     {
       "year": 1977,
@@ -786,7 +986,17 @@
       "fun_fact_nl": "Het is wetenschappelijk bewezen dat We Are the Champions het aanstekelijkste liedje is dat ooit is geschreven, volgens een onderzoek van Goldsmiths University. Freddie Mercury schreef het als een volkslied voor publieksparticipatie. Het wordt al tientallen jaren door sportteams wereldwijd gebruikt als overwinningslied.",
       "awards_nl": [
         "Grammy Hall of Fame (2009)"
-      ]
+      ],
+      "isrc": "GBUM71029619",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1440646546",
+        "de": "applemusic://track/1441457684",
+        "gb": "applemusic://track/1441457684",
+        "fr": "applemusic://track/1441457684",
+        "es": "applemusic://track/1441457684",
+        "nl": "applemusic://track/1441457684",
+        "it": "applemusic://track/1441457684"
+      }
     },
     {
       "year": 1985,
@@ -827,7 +1037,17 @@
       "fun_fact_nl": "Take on Me werd drie keer uitgebracht voordat het een hit werd. De innovatieve videoclip, die een potloodschets-animatie met live action combineerde, kostte 100.000 dollar en de productie nam 16 weken in beslag. Het succes van de video bewees dat MTV de populariteit van een nummer kon maken of breken.",
       "awards_nl": [
         "MTV VMA – Beste Nieuwe Artiest (1986)"
-      ]
+      ],
+      "isrc": "USWB11506543",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1834677612",
+        "de": "applemusic://track/1834677612",
+        "gb": "applemusic://track/1834677612",
+        "fr": "applemusic://track/1834677612",
+        "es": "applemusic://track/1834677612",
+        "nl": "applemusic://track/1834677612",
+        "it": "applemusic://track/1834677612"
+      }
     },
     {
       "year": 1976,
@@ -856,7 +1076,17 @@
       "uri_tidal": "tidal://track/35986171",
       "uri_deezer": "deezer://track/92720006",
       "fun_fact_nl": "T.N.T. werd geschreven over Angus Youngs explosieve energie op het podium en zijn neiging om versterkers op te blazen. Het nummer werd jarenlang de concertopener van AC/DC. Het werd oorspronkelijk alleen uitgebracht in Australië, maar werd een internationale hit toen de band wereldwijd bekend werd.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "AUAP07600012",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/574124824",
+        "de": "applemusic://track/574124824",
+        "gb": "applemusic://track/574124824",
+        "fr": "applemusic://track/574124824",
+        "es": "applemusic://track/574124824",
+        "nl": "applemusic://track/574124824",
+        "it": "applemusic://track/574124824"
+      }
     },
     {
       "year": 1965,
@@ -902,7 +1132,17 @@
       "awards_nl": [
         "Ivor Novello Award (1966)",
         "Grammy Hall of Fame (1997)"
-      ]
+      ],
+      "isrc": "GBAYE0601477",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1441133496",
+        "de": "applemusic://track/1441133496",
+        "gb": "applemusic://track/1441133496",
+        "fr": "applemusic://track/1441133496",
+        "es": "applemusic://track/1441133496",
+        "nl": "applemusic://track/1441133496",
+        "it": "applemusic://track/1441133496"
+      }
     },
     {
       "year": 1983,
@@ -943,7 +1183,17 @@
       "fun_fact_nl": "Sweet Dreams werd geschreven door Annie Lennox en Dave Stewart tijdens het verbreken van hun romantische relatie. De synthesizerhook van het nummer ontstond per ongeluk toen Stewart apparatuur verkeerd had aangesloten. Het werd het bepalende geluid van synthpop uit de jaren 80 en lanceerde Eurythmics naar de roem.",
       "awards_nl": [
         "MTV VMA – Beste Nieuwe Artiest (1984)"
-      ]
+      ],
+      "isrc": "GBARL8300004",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/304826784",
+        "de": "applemusic://track/1308528894",
+        "gb": "applemusic://track/1763233929",
+        "fr": "applemusic://track/1308528894",
+        "es": "applemusic://track/1308528894",
+        "nl": "applemusic://track/1308528894",
+        "it": "applemusic://track/1308528894"
+      }
     },
     {
       "year": 2000,
@@ -971,7 +1221,17 @@
       "uri_tidal": "tidal://track/35981744",
       "uri_deezer": "deezer://track/577487252",
       "fun_fact_nl": "It's My Life markeerde Bon Jovi's succesvolle comeback na een onderbreking van vijf jaar. Het nummer was geschreven om zowel oude fans als een nieuwe generatie aan te spreken. Het is meerdere malen platina verklaard en werd wereldwijd een bepalend rocklied van de vroege jaren 2000.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USIR20000145",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1892465947",
+        "de": "applemusic://track/1892465947",
+        "gb": "applemusic://track/1892465947",
+        "fr": "applemusic://track/1892465947",
+        "es": "applemusic://track/1892465947",
+        "nl": "applemusic://track/1892465947",
+        "it": "applemusic://track/1892465947"
+      }
     },
     {
       "year": 1984,
@@ -999,7 +1259,17 @@
       "uri_tidal": "tidal://track/9978080",
       "uri_deezer": "deezer://track/15194531",
       "fun_fact_nl": "Wake Me Up Before You Go-Go is geïnspireerd op een briefje dat Andrew Ridgeley achterliet voor zijn ouders. De dubbele 'go-go' kwam door een schrijffout. George Michael schreef het nummer in slechts een paar uur en het werd Wham!'s grootste internationale hit, met een wereldwijde nummer één positie.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBBBM8400002",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1441343695",
+        "de": "applemusic://track/1441343695",
+        "gb": "applemusic://track/1441343695",
+        "fr": "applemusic://track/1441343695",
+        "es": "applemusic://track/1441343695",
+        "nl": "applemusic://track/1441343695",
+        "it": "applemusic://track/1441343695"
+      }
     },
     {
       "year": 1977,
@@ -1040,7 +1310,17 @@
       "fun_fact_nl": "De iconische stomp-stomp-clap beat van We Will Rock You werd ontworpen door Brian May om te worden uitgevoerd door stadionpubliek. May wilde iets creëren dat 'zelfs een stadion vol mensen kon doen'. Het nummer wordt tot op de dag van vandaag bij vrijwel elk sportevenement wereldwijd gespeeld.",
       "awards_nl": [
         "Grammy Hall of Fame (2009)"
-      ]
+      ],
+      "isrc": "GBUM71029618",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1834502336",
+        "de": "applemusic://track/1440831384",
+        "gb": "applemusic://track/1440831384",
+        "fr": "applemusic://track/1440831384",
+        "es": "applemusic://track/1440831384",
+        "nl": "applemusic://track/1440831384",
+        "it": "applemusic://track/1440831384"
+      }
     },
     {
       "year": 1990,
@@ -1068,7 +1348,17 @@
       "uri_tidal": "tidal://track/1110429",
       "uri_deezer": "deezer://track/927900",
       "fun_fact_nl": "Wind of Change is geschreven over de val van de Berlijnse Muur en het einde van de Koude Oorlog. Klaus Meine van de Scorpions schreef het na een bezoek aan Moskou tijdens glasnost. Het werd een volkslied voor de Duitse hereniging en er zijn meer dan 14 miljoen exemplaren van verkocht, als symbool van hoop en vrijheid.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USPG19090037",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1434890599",
+        "de": "applemusic://track/340938027",
+        "gb": "applemusic://track/1467970877",
+        "fr": "applemusic://track/1440761801",
+        "es": "applemusic://track/1440761801",
+        "nl": "applemusic://track/1442708452",
+        "it": "applemusic://track/1440761801"
+      }
     },
     {
       "year": 1995,
@@ -1097,7 +1387,17 @@
       "uri_tidal": "tidal://track/144348974",
       "uri_deezer": "deezer://track/985745702",
       "fun_fact_nl": "Wonderwall werd geïnspireerd door Noel Gallagher's toenmalige vriendin Meg Mathews, hoewel hij later zei dat het ging over een 'denkbeeldige vriend' die je zal redden. De titel komt van een album van George Harrison. Het is een van de meest afgespeelde nummers op streamingplatforms en wereldwijd een veelgebruikt karaoke-nummer.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAAW9500189",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1517449902",
+        "de": "applemusic://track/1517449902",
+        "gb": "applemusic://track/1517449902",
+        "fr": "applemusic://track/1517449902",
+        "es": "applemusic://track/1517449902",
+        "nl": "applemusic://track/1517449902",
+        "it": "applemusic://track/1517449902"
+      }
     },
     {
       "year": 1961,
@@ -1125,7 +1425,17 @@
       "uri_tidal": "tidal://track/38931428",
       "uri_deezer": "deezer://track/551383",
       "fun_fact_nl": "Can't Help Falling in Love is een bewerking van het 18e-eeuwse Franse lied 'Plaisir d'Amour'. Elvis Presley voerde het jarenlang uit aan het einde van zijn concerten. Het was te horen in de film Blue Hawaii en werd door meer dan 500 artiesten gecoverd en werd een trouwfavoriet.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USRC16101350",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1524547435",
+        "de": "applemusic://track/1524547435",
+        "gb": "applemusic://track/1524547435",
+        "fr": "applemusic://track/1524547435",
+        "es": "applemusic://track/1524547435",
+        "nl": "applemusic://track/1524547435",
+        "it": "applemusic://track/1524547435"
+      }
     },
     {
       "year": 1984,
@@ -1154,7 +1464,17 @@
       "uri_tidal": "tidal://track/246156",
       "uri_deezer": "deezer://track/698274",
       "fun_fact_nl": "Forever Young werd een hymne uit de Koude Oorlog over nucleaire vernietiging en het verlangen om volledig te leven ondanks onzekerheid. Alphaville's Marian Gold schreef twee versies - een langzame en een uptempo - en kon niet beslissen welke hij zou uitbrengen, dus verschenen ze allebei op het album. Het is nu niet meer weg te denken van het afstuderen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEA629260150",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/322031016",
+        "de": "applemusic://track/1497619878",
+        "gb": "applemusic://track/1497619878",
+        "fr": "applemusic://track/1497619878",
+        "es": "applemusic://track/1497619878",
+        "nl": "applemusic://track/1497619878",
+        "it": "applemusic://track/1497619878"
+      }
     },
     {
       "year": 1969,
@@ -1195,7 +1515,17 @@
       "fun_fact_nl": "Sweet Caroline is geschreven over Caroline Kennedy, de dochter van president JFK, nadat Neil Diamond een foto van haar op de cover van een tijdschrift had gezien. Diamond bevestigde dit pas in 2007. Het 'Bah bah bah'-haakje heeft het tot een favoriete meezinger in het stadion gemaakt, vooral bij wedstrijden van de Boston Red Sox.",
       "awards_nl": [
         "Grammy Hall of Fame (2017)"
-      ]
+      ],
+      "isrc": "USMC16991138",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1422721989",
+        "de": "applemusic://track/1422721989",
+        "gb": "applemusic://track/1422721989",
+        "fr": "applemusic://track/1422721989",
+        "es": "applemusic://track/1422721989",
+        "nl": "applemusic://track/1422721989",
+        "it": "applemusic://track/1422721989"
+      }
     },
     {
       "year": 1962,
@@ -1236,7 +1566,17 @@
       "fun_fact_nl": "Stand By Me werd in slechts 15 minuten geschreven in de kelder van het appartement van Ben E. King in New York. Het nummer was geïnspireerd op een gospelhymne. Het is gebruikt in meer dan 150 films en tv-shows en werd door de Recording Industry Association uitgeroepen tot een van de Songs of the Century.",
       "awards_nl": [
         "Grammy Hall of Fame (1999)"
-      ]
+      ],
+      "isrc": "USAT21402270",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1772635997",
+        "de": "applemusic://track/1772635997",
+        "gb": "applemusic://track/1772635997",
+        "fr": "applemusic://track/1772635997",
+        "es": "applemusic://track/1772635997",
+        "nl": "applemusic://track/1772635997",
+        "it": "applemusic://track/1772635997"
+      }
     },
     {
       "year": 1968,
@@ -1278,7 +1618,17 @@
       "fun_fact_nl": "What a Wonderful World was speciaal geschreven voor Louis Armstrongs gruizige stem en optimistische persoonlijkheid. Het was aanvankelijk een commerciële mislukking in de VS, maar werd nummer één in de UK. Het nummer werd opnieuw populair nadat het te zien was in de film Good Morning, Vietnam uit 1987.",
       "awards_nl": [
         "Grammy Hall of Fame (1999)"
-      ]
+      ],
+      "isrc": "USMC16758823",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1483870398",
+        "de": "applemusic://track/1483870398",
+        "gb": "applemusic://track/1440725936",
+        "fr": "applemusic://track/1483870398",
+        "es": "applemusic://track/1483870398",
+        "nl": "applemusic://track/1483870398",
+        "it": "applemusic://track/1483870398"
+      }
     },
     {
       "year": 1969,
@@ -1319,7 +1669,17 @@
       "fun_fact_nl": "I Want You Back was de debuutsingle van de Jackson 5, met de 11-jarige Michael Jackson als leadzanger. Motown-oprichter Berry Gordy hield persoonlijk toezicht op de productie. Het nummer toonde Michael's ongelooflijke vocale vaardigheden en lanceerde een van de meest legendarische carrières in de muziek.",
       "awards_nl": [
         "Grammy Hall of Fame (1999)"
-      ]
+      ],
+      "isrc": "USMO19400306",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1709698020",
+        "de": "applemusic://track/1709698020",
+        "gb": "applemusic://track/1709698020",
+        "fr": "applemusic://track/1709698020",
+        "es": "applemusic://track/1709698020",
+        "nl": "applemusic://track/1709698020",
+        "it": "applemusic://track/1709698020"
+      }
     },
     {
       "year": 1971,
@@ -1347,7 +1707,17 @@
       "uri_tidal": "tidal://track/119552354",
       "uri_deezer": "deezer://track/82697686",
       "fun_fact_nl": "Take Me Home, Country Roads werd geschreven over West Virginia door twee songwriters die de staat nog nooit hadden bezocht. John Denver zette de laatste puntjes op de i en maakte er zijn lijflied van. In 2014 werd het het officiële volkslied van de staat West Virginia, geliefd bij fans over de hele wereld.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USA370529726",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1482520559",
+        "de": "applemusic://track/1482520559",
+        "gb": "applemusic://track/1482520559",
+        "fr": "applemusic://track/1482520559",
+        "es": "applemusic://track/1482520559",
+        "nl": "applemusic://track/1482520559",
+        "it": "applemusic://track/1482520559"
+      }
     },
     {
       "year": 1985,
@@ -1393,7 +1763,17 @@
       "awards_nl": [
         "Grammy – Opname van het Jaar (1986)",
         "Grammy – Lied van het Jaar (1986)"
-      ]
+      ],
+      "isrc": "US25T0511671",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/41737859",
+        "de": "applemusic://track/41737859",
+        "gb": "applemusic://track/41737859",
+        "fr": "applemusic://track/41737859",
+        "es": "applemusic://track/41737859",
+        "nl": "applemusic://track/41737859",
+        "it": "applemusic://track/41737859"
+      }
     },
     {
       "year": 1975,
@@ -1422,7 +1802,17 @@
       "uri_tidal": "tidal://track/1771748",
       "uri_deezer": "deezer://track/884030",
       "fun_fact_nl": "Mamma Mia lanceerde een wereldwijd fenomeen met een toneelmusical en twee films. ABBA's Benny Andersson schreef de kenmerkende keyboard hook. De titel en de tekst van het nummer spelen met de Italiaanse uitroep. Het was ABBA's eerste nummer één in Groot-Brittannië en hielp hen internationaal te vestigen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "SEAYD7501010",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1892200731",
+        "de": "applemusic://track/1892200731",
+        "gb": "applemusic://track/1892200731",
+        "fr": "applemusic://track/1892200731",
+        "es": "applemusic://track/1892200731",
+        "nl": "applemusic://track/1892200731",
+        "it": "applemusic://track/1892200731"
+      }
     },
     {
       "year": 1976,
@@ -1451,7 +1841,17 @@
       "uri_tidal": "tidal://track/1277161",
       "uri_deezer": "deezer://track/364953",
       "fun_fact_nl": "Sunny werd oorspronkelijk geschreven door Bobby Hebb in 1963 na de moord op JFK en de moord op zijn broer. De discoversie van Boney M. werd een van de grootste hits van 1976. Het nummer is meer dan 300 keer gecoverd en is daarmee een van de meest opgenomen nummers in de geschiedenis.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DED168000002",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1627099053",
+        "de": "applemusic://track/1759138005",
+        "gb": "applemusic://track/1759138005",
+        "fr": "applemusic://track/1759138005",
+        "es": "applemusic://track/1759138005",
+        "nl": "applemusic://track/1759138005",
+        "it": "applemusic://track/1759138005"
+      }
     },
     {
       "year": 1995,
@@ -1480,7 +1880,17 @@
       "uri_tidal": "tidal://track/486407015",
       "uri_deezer": "deezer://track/3750996632",
       "fun_fact_nl": "Lemon Tree werd geschreven door Peter Freudenthaler van Fools Garden over een saaie zondagmiddag die hij doorbracht met het staren naar een foto van een citroenboom. De Duitse band werd internationaal een eendagsvlieg, maar blijft populair in Europa. De vrolijke melodie van het nummer staat in contrast met de melancholische tekst.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEAF70927221",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1847889648",
+        "de": "applemusic://track/1847889648",
+        "gb": "applemusic://track/1847889648",
+        "fr": "applemusic://track/1847889648",
+        "es": "applemusic://track/1847889648",
+        "nl": "applemusic://track/1847889648",
+        "it": "applemusic://track/1847889648"
+      }
     },
     {
       "year": 1988,
@@ -1526,7 +1936,17 @@
       "awards_nl": [
         "Grammy – Opname van het Jaar (1989)",
         "Grammy – Lied van het Jaar (1989)"
-      ]
+      ],
+      "isrc": "USEM38800361",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/6762672295",
+        "de": "applemusic://track/6762672295",
+        "gb": "applemusic://track/6762672295",
+        "fr": "applemusic://track/6762672295",
+        "es": "applemusic://track/6762672295",
+        "nl": "applemusic://track/6762672295",
+        "it": "applemusic://track/6762672295"
+      }
     },
     {
       "year": 1974,
@@ -1568,7 +1988,17 @@
       "fun_fact_nl": "Waterloo was ABBA's doorbraakhit die het Eurovisiesongfestival van 1974 won. Het lied vergelijkt overgave in de liefde met Napoleons nederlaag bij Waterloo. Het werd uitgebracht in zowel een Engelse als Zweedse versie en lanceerde ABBA's carrière als een van de best verkopende groepen in de geschiedenis.",
       "awards_nl": [
         "Eurovisionwinnaar (1974)"
-      ]
+      ],
+      "isrc": "SEAYD7415010",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1612497895",
+        "de": "applemusic://track/1612497895",
+        "gb": "applemusic://track/1612497895",
+        "fr": "applemusic://track/1612497895",
+        "es": "applemusic://track/1612497895",
+        "nl": "applemusic://track/1612497895",
+        "it": "applemusic://track/1612497895"
+      }
     },
     {
       "year": 1978,
@@ -1596,7 +2026,17 @@
       "uri_tidal": "tidal://track/31895290",
       "uri_deezer": "deezer://track/11133258",
       "fun_fact_nl": "YMCA werd geschreven door Jacques Morali nadat hij een YMCA in New York had bezocht en het een geweldige plek vond voor jonge mensen om rond te hangen. Het nummer van de Village People werd een homo-hymne en discoklassieker. De beroemde armbewegingen werden door het publiek bedacht, niet gechoreografeerd.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USPR37800001",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1443926626",
+        "de": null,
+        "gb": null,
+        "fr": null,
+        "es": null,
+        "nl": null,
+        "it": null
+      }
     },
     {
       "year": 1978,
@@ -1624,7 +2064,17 @@
       "uri_tidal": "tidal://track/106028079",
       "uri_deezer": "deezer://track/487484142",
       "fun_fact_nl": "September's openingszin 'Do you remember the 21st night of September?' verwijst niet naar een specifieke gebeurtenis - Allee Willis koos het puur voor het geluid. Maurice White bevestigde dat er geen speciale betekenis is. Het nummer is nu al meer dan vier decennia een essentieel feestlied.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM17800845",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1456446747",
+        "de": "applemusic://track/1456446747",
+        "gb": "applemusic://track/1456446747",
+        "fr": "applemusic://track/1456446747",
+        "es": "applemusic://track/1456446747",
+        "nl": "applemusic://track/1456446747",
+        "it": "applemusic://track/1456446747"
+      }
     },
     {
       "year": 1999,
@@ -1652,7 +2102,17 @@
       "uri_tidal": "tidal://track/81794041",
       "uri_deezer": "deezer://track/434625962",
       "fun_fact_nl": "Mambo No. 5 was oorspronkelijk een Cubaanse instrumental uit 1949. Lou Bega voegde er een tekst aan toe met namen van vrouwen, die zogenaamd echte vriendinnen waren. Het nummer werd een wereldwijd fenomeen en stond in meer dan 10 landen bovenaan de hitlijsten. Naar verluidt verdiende Bega alleen al met deze single wereldwijd 6 miljoen dollar.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEH259900010",
+      "uri_apple_music_by_region": {
+        "us": null,
+        "de": null,
+        "gb": null,
+        "fr": null,
+        "es": null,
+        "nl": "applemusic://track/1656111119",
+        "it": null
+      }
     },
     {
       "year": 1974,
@@ -1680,7 +2140,17 @@
       "uri_tidal": "tidal://track/77820570",
       "uri_deezer": "deezer://track/24949681",
       "fun_fact_nl": "Sweet Home Alabama werd geschreven als reactie op de kritische songs van Neil Young over het Amerikaanse zuiden. Ondanks de vermeende vete waren Young en Lynyrd Skynyrd eigenlijk vrienden. Het nummer werd een hymne voor Southern pride en wordt nog steeds gespeeld tijdens Alabama Crimson Tide football wedstrijden.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMC17446153",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1578934918",
+        "de": "applemusic://track/1578934918",
+        "gb": "applemusic://track/1578934918",
+        "fr": "applemusic://track/1578934918",
+        "es": "applemusic://track/1578934918",
+        "nl": "applemusic://track/1578934918",
+        "it": "applemusic://track/1578934918"
+      }
     },
     {
       "year": 1976,
@@ -1709,7 +2179,17 @@
       "uri_tidal": "tidal://track/1277159",
       "uri_deezer": "deezer://track/364951",
       "fun_fact_nl": "Daddy Cool was een van Boney M.'s eerste grote hits, met Frank Farian's productietechnieken die later voor controverse zorgden. Het aanstekelijke ritme van het nummer maakte het een vaste waarde in de disco. Farian zou later toegeven dat hij op sommige opnames gebruik maakte van sessiezangers, maar Daddy Cool toonde het talent van de groep.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEC737600002",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1739904607",
+        "de": "applemusic://track/1739904607",
+        "gb": "applemusic://track/1739904607",
+        "fr": "applemusic://track/1739904607",
+        "es": "applemusic://track/1739904607",
+        "nl": "applemusic://track/1739904607",
+        "it": "applemusic://track/1739904607"
+      }
     },
     {
       "year": 1986,
@@ -1737,7 +2217,17 @@
       "uri_tidal": "tidal://track/3392900",
       "uri_deezer": "deezer://track/619310",
       "fun_fact_nl": "The Final Countdown is geschreven over ruimtereizen en het achterlaten van de aarde. Het iconische synthesizer-intro heeft het tot een van de meest herkende riffs in de rockgeschiedenis gemaakt. Europe's Joey Tempest werd geïnspireerd door David Bowie's 'Space Oddity'. Het nummer wordt tegenwoordig bij talloze sportevenementen gespeeld.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM18600860",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/424994549",
+        "de": "applemusic://track/555229038",
+        "gb": "applemusic://track/1236688491",
+        "fr": "applemusic://track/555229038",
+        "es": "applemusic://track/555229038",
+        "nl": "applemusic://track/555229038",
+        "it": "applemusic://track/555229038"
+      }
     },
     {
       "year": 1981,
@@ -1765,7 +2255,17 @@
       "uri_tidal": "tidal://track/94089523",
       "uri_deezer": "deezer://track/545992732",
       "fun_fact_nl": "I Love Rock 'n' Roll werd oorspronkelijk opgenomen door Arrows in 1975. Joan Jett zag het optreden op de Britse tv en raakte geobsedeerd door het nummer. Haar versie werd een van de grootste hits van de vroege jaren 80 en definieerde haar carrière als de koningin van de rock-'n-roll attitude.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USBH18100118",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1871187077",
+        "de": "applemusic://track/1778713857",
+        "gb": "applemusic://track/1778713857",
+        "fr": "applemusic://track/1778713857",
+        "es": "applemusic://track/1778713857",
+        "nl": "applemusic://track/1778713857",
+        "it": "applemusic://track/1778713857"
+      }
     },
     {
       "year": 1984,
@@ -1793,7 +2293,17 @@
       "uri_tidal": "tidal://track/3268253",
       "uri_deezer": "deezer://track/97098410",
       "fun_fact_nl": "Jump was het eerste Van Halen-nummer met David Lee Roths idee om synthesizers prominent te gebruiken. Eddie Van Halen had aanvankelijk een hekel aan de keyboard riff. De optimistische boodschap van het nummer over het nemen van risico's maakte het meteen tot een hymne en Van Halen's grootste commerciële succes.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USWB11403500",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/977495501",
+        "de": "applemusic://track/977495501",
+        "gb": "applemusic://track/977495501",
+        "fr": "applemusic://track/977495501",
+        "es": "applemusic://track/977495501",
+        "nl": "applemusic://track/977495501",
+        "it": "applemusic://track/977495501"
+      }
     },
     {
       "year": 1982,
@@ -1822,7 +2332,17 @@
       "uri_tidal": "tidal://track/3392942",
       "uri_deezer": "deezer://track/555755",
       "fun_fact_nl": "It's Raining Men werd oorspronkelijk aangeboden aan Donna Summer, die het afwees omdat het te gewaagd was. De Weather Girls maakten er een disco-anthem van dat is blijven hangen als een camp-klassieker. Songwriters Paul Jabara en Paul Shaffer schreven het als een humoristische viering van vrouwelijk verlangen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM18200686",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1787328102",
+        "de": "applemusic://track/827814095",
+        "gb": "applemusic://track/450578425",
+        "fr": null,
+        "es": "applemusic://track/1298435999",
+        "nl": "applemusic://track/1790923385",
+        "it": "applemusic://track/284881685"
+      }
     },
     {
       "year": 1982,
@@ -1851,7 +2371,17 @@
       "uri_tidal": "tidal://track/221898696",
       "uri_deezer": "deezer://track/69962764",
       "fun_fact_nl": "Should I Stay or Should I Go is geschreven door Mick Jones over zijn relatie met Ellen Foley. De Spaanse achtergrondzang werd opgenomen door de band zonder te begrijpen wat ze zongen. Het nummer kreeg tientallen jaren later opnieuw bekendheid in de Netflix-serie 'Stranger Things'.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBARL1200670",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1441530631",
+        "de": "applemusic://track/1441530631",
+        "gb": "applemusic://track/1441530631",
+        "fr": "applemusic://track/1441530631",
+        "es": "applemusic://track/1441530631",
+        "nl": "applemusic://track/1441530631",
+        "it": "applemusic://track/1441530631"
+      }
     },
     {
       "year": 1980,
@@ -1880,7 +2410,17 @@
       "uri_tidal": "tidal://track/575782",
       "uri_deezer": "deezer://track/884033",
       "fun_fact_nl": "Super Trouper werd vernoemd naar de volgspots die tijdens concerten werden gebruikt. ABBA schreef het tijdens het hoogtepunt van hun roem toen ze zich uitgeput voelden door het toeren. De openingszin 'I was sick and tired of everything' weerspiegelde hun oprechte gevoelens op dat moment, ondanks het wereldwijde succes.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "SEAYD8001010",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1530394070",
+        "de": "applemusic://track/1530394070",
+        "gb": "applemusic://track/1530394070",
+        "fr": "applemusic://track/1530394070",
+        "es": "applemusic://track/1530394070",
+        "nl": "applemusic://track/1530394070",
+        "it": "applemusic://track/1530394070"
+      }
     },
     {
       "year": 1985,
@@ -1908,7 +2448,17 @@
       "uri_tidal": "tidal://track/1346602",
       "uri_deezer": "deezer://track/1351889",
       "fun_fact_nl": "Walking on Sunshine werd door meerdere labels afgewezen voordat het uiteindelijk werd uitgebracht. Het niet aflatende optimisme van het nummer heeft het tot een van de meest gelicenseerde nummers in de reclamegeschiedenis gemaakt. Katrina Leskanich zei dat ze een moeilijke tijd doormaakte toen ze het vrolijke nummer opnam.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USCA28500452",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1893189187",
+        "de": "applemusic://track/1893189187",
+        "gb": "applemusic://track/1893189187",
+        "fr": "applemusic://track/1893189187",
+        "es": "applemusic://track/1893189187",
+        "nl": "applemusic://track/1893189187",
+        "it": "applemusic://track/1893189187"
+      }
     },
     {
       "year": 1976,
@@ -1936,7 +2486,17 @@
       "uri_tidal": "tidal://track/21844149",
       "uri_deezer": "deezer://track/568120932",
       "fun_fact_nl": "Somebody to Love was Queen's eerbetoon aan gospelmuziek, met meer dan 100 vocale overdubs. Freddie Mercury werd geïnspireerd door de gospelachtige optredens van Aretha Franklin. Het nummer laat de ongelooflijke harmonieën van Queen horen en Mercury's vocale bereik van vier octaven op zijn best.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBUM71029613",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1440743586",
+        "de": "applemusic://track/1440822112",
+        "gb": "applemusic://track/1440822112",
+        "fr": "applemusic://track/1440822112",
+        "es": "applemusic://track/1440822112",
+        "nl": "applemusic://track/1440822112",
+        "it": "applemusic://track/1440822112"
+      }
     },
     {
       "year": 1967,
@@ -1987,7 +2547,17 @@
         "Grammy – Beste R&B-opname (1968)",
         "Grammy – Beste R&B Zangprestatie (1968)",
         "Grammy Hall of Fame (1998)"
-      ]
+      ],
+      "isrc": "USAT21403673",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/933578351",
+        "de": "applemusic://track/933578351",
+        "gb": "applemusic://track/933578351",
+        "fr": "applemusic://track/933578351",
+        "es": "applemusic://track/933578351",
+        "nl": "applemusic://track/933578351",
+        "it": "applemusic://track/933578351"
+      }
     },
     {
       "year": 1982,
@@ -2028,7 +2598,17 @@
       "fun_fact_nl": "Rosanna werd geschreven door TOTO's David Paich over actrice Rosanna Arquette, met wie hij kort uitging. Het complexe shuffle ritme, bekend als de 'Rosanna Shuffle', is een benchmark geworden voor drummers wereldwijd. Het nummer won de Grammy voor plaat van het jaar in 1983 voor zijn innovatieve geluid.",
       "awards_nl": [
         "Grammy – Opname van het Jaar (1983)"
-      ]
+      ],
+      "isrc": "USSM18200245",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/318675271",
+        "de": "applemusic://track/318675271",
+        "gb": "applemusic://track/318675271",
+        "fr": "applemusic://track/318675271",
+        "es": "applemusic://track/318675271",
+        "nl": "applemusic://track/318675271",
+        "it": "applemusic://track/318675271"
+      }
     },
     {
       "year": 1976,
@@ -2070,7 +2650,17 @@
       "fun_fact_nl": "Dancing Queen blijft ABBA's meest succesvolle single en de enige die nummer één werd in de VS. Het was geïnspireerd door George McCrae's 'Rock Your Baby'. ABBA voerde het voor het eerst uit op de avond voor het huwelijk van de Zweedse koning Carl XVI Gustaf als eerbetoon aan de nieuwe koningin.",
       "awards_nl": [
         "Grammy Hall of Fame (2015)"
-      ]
+      ],
+      "isrc": "SEAYD7601020",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1580810375",
+        "de": "applemusic://track/1580810375",
+        "gb": "applemusic://track/1580810375",
+        "fr": "applemusic://track/1580810375",
+        "es": "applemusic://track/1560739878",
+        "nl": "applemusic://track/1711492527",
+        "it": "applemusic://track/1580810375"
+      }
     },
     {
       "year": 1978,
@@ -2099,7 +2689,17 @@
       "uri_tidal": "tidal://track/6851486",
       "uri_deezer": "deezer://track/12209331",
       "fun_fact_nl": "Don't Stop Me Now werd geschreven door Freddie Mercury tijdens een bijzonder hedonistische periode van zijn leven. Andere bandleden hadden er aanvankelijk een hekel aan omdat het overdaad zou bevorderen. In 2020 werd het in een wetenschappelijke studie het 'gelukkigste nummer ooit' genoemd op basis van tempo, tekst en toonsoort. Het favoriete Queen-nummer van Mercury.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBUM71029610",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1494536053",
+        "de": "applemusic://track/1441457594",
+        "gb": "applemusic://track/1441457594",
+        "fr": "applemusic://track/1441457594",
+        "es": "applemusic://track/1441457594",
+        "nl": "applemusic://track/1441457594",
+        "it": "applemusic://track/1441457594"
+      }
     },
     {
       "year": 1992,
@@ -2145,7 +2745,17 @@
       "awards_nl": [
         "Grammy – Opname van het Jaar (1994)",
         "Grammy – Beste Pop Zangprestatie (1994)"
-      ]
+      ],
+      "isrc": "USAR19200110",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/650117376",
+        "de": "applemusic://track/1154118533",
+        "gb": "applemusic://track/303848760",
+        "fr": "applemusic://track/650117376",
+        "es": "applemusic://track/303848760",
+        "nl": "applemusic://track/303848760",
+        "it": "applemusic://track/303848760"
+      }
     },
     {
       "year": 1963,
@@ -2186,7 +2796,17 @@
       "fun_fact_nl": "De melodie van Surfin' U.S.A. werd aangepast van Chuck Berry's 'Sweet Little Sixteen', wat leidde tot een rechtszaak. Brian Wilson van de Beach Boys werd gedwongen om Berry de eer te geven voor zijn songwriting. Ondanks de controverse legde het nummer de Californische surfcultuur vast en is het tot op de dag van vandaag een Amerikaanse klassieker.",
       "awards_nl": [
         "Grammy Hall of Fame (2003)"
-      ]
+      ],
+      "isrc": "USCA20001654",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1698230404",
+        "de": "applemusic://track/1698230404",
+        "gb": "applemusic://track/1698230404",
+        "fr": "applemusic://track/1698230404",
+        "es": "applemusic://track/1698230404",
+        "nl": "applemusic://track/1698230404",
+        "it": "applemusic://track/1698230404"
+      }
     },
     {
       "year": 1987,
@@ -2214,7 +2834,17 @@
       "uri_tidal": "tidal://track/16953810",
       "uri_deezer": "deezer://track/4603400",
       "fun_fact_nl": "De kenmerkende slanke vorm van Smooth Criminal werd bereikt doordat Michael Jackson speciale gepatenteerde schoenen gebruikte die vastklikten in pinnen op de podiumvloer. Jackson vond deze schoentechnologie uit en patenteerde deze. De videoclip van het nummer was een 11 minuten durende film met uitgebreide choreografie en baanbrekende effecten.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM19909073",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/273598921",
+        "de": "applemusic://track/273598921",
+        "gb": "applemusic://track/273598921",
+        "fr": "applemusic://track/273598921",
+        "es": "applemusic://track/273598921",
+        "nl": "applemusic://track/273598921",
+        "it": "applemusic://track/273598921"
+      }
     },
     {
       "year": 1982,
@@ -2242,7 +2872,17 @@
       "uri_tidal": "tidal://track/3392941",
       "uri_deezer": "deezer://track/346967941",
       "fun_fact_nl": "I'm So Excited werd oorspronkelijk uitgebracht in 1982, maar werd een grotere hit toen het in 1984 opnieuw werd gemixt en uitgebracht. De Pointer Sisters schreven het over de opwinding van romantische verwachting. Het werd een culturele toetssteen door zijn verschijning in de beroemde aflevering van de cafeïnepil 'Saved by the Bell'.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USRC18203285",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1681210235",
+        "de": "applemusic://track/1681210235",
+        "gb": "applemusic://track/1681210235",
+        "fr": "applemusic://track/1681210235",
+        "es": "applemusic://track/1681210235",
+        "nl": "applemusic://track/1681210235",
+        "it": "applemusic://track/1681210235"
+      }
     },
     {
       "year": 1987,
@@ -2283,7 +2923,17 @@
       "fun_fact_nl": "I Wanna Dance with Somebody is speciaal geschreven voor de krachtige stem van Whitney Houston. Songwriters George Merrill en Shannon Rubicam maakten het als een upbeat aanvulling op haar ballads. Het nummer won de Grammy voor Best Female Pop Vocal Performance en werd een onmisbaar dansnummer.",
       "awards_nl": [
         "Grammy – Beste Pop Zangprestatie (1988)"
-      ]
+      ],
+      "isrc": "USAR18700121",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1627099927",
+        "de": "applemusic://track/1627099927",
+        "gb": "applemusic://track/1627099927",
+        "fr": "applemusic://track/1627099927",
+        "es": "applemusic://track/1627099927",
+        "nl": "applemusic://track/1627099927",
+        "it": "applemusic://track/892310917"
+      }
     },
     {
       "year": 1983,
@@ -2311,7 +2961,17 @@
       "uri_tidal": "tidal://track/1268496",
       "uri_deezer": "deezer://track/1025659",
       "fun_fact_nl": "Uptown Girl werd geschreven door Billy Joel over supermodel Elle Macpherson, hoewel hij later trouwde met Christie Brinkley, die de hoofdrol speelde in de videoclip. Het nummer was geïnspireerd op het geluid van Frankie Valli en The Four Seasons. Het werd een van Joels grootste internationale hits en bereikte de eerste plaats in Groot-Brittannië.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM18300270",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1626537261",
+        "de": "applemusic://track/1626537261",
+        "gb": "applemusic://track/273854283",
+        "fr": "applemusic://track/1626537261",
+        "es": "applemusic://track/1626537261",
+        "nl": "applemusic://track/1626537261",
+        "it": "applemusic://track/1626537261"
+      }
     },
     {
       "year": 1976,
@@ -2381,7 +3041,17 @@
       "fun_fact_nl": "Don't Stop Believin' werd het best verkopende digitale nummer van de 20e eeuw na het gebruik ervan in de finale van The Sopranos. Journey's Steve Perry schreef het over zijn eigen dorpse afkomst. Drie decennia na de release beleefde het nummer een enorme revival, waardoor het bij nieuwe generaties fans werd geïntroduceerd.",
       "awards_nl": [
         "Grammy Hall of Fame (2021)"
-      ]
+      ],
+      "isrc": "USSM18100116",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1681227819",
+        "de": "applemusic://track/1739304009",
+        "gb": "applemusic://track/1739304009",
+        "fr": "applemusic://track/1739304009",
+        "es": "applemusic://track/1739304009",
+        "nl": "applemusic://track/1739304009",
+        "it": "applemusic://track/1739304009"
+      }
     },
     {
       "year": 1994,
@@ -2410,7 +3080,17 @@
       "uri_tidal": "tidal://track/4012757",
       "uri_deezer": "deezer://track/952788",
       "fun_fact_nl": "Zombie werd geschreven door Dolores O'Riordan na de IRA-bomaanslag in Warrington in 1993 waarbij twee kinderen om het leven kwamen. Het meest politieke nummer van The Cranberries werd een wereldwijde hit en een hymne tegen geweld. De kenmerkende jodelachtige zang van O'Riordan maakte het nummer direct herkenbaar en emotioneel krachtig.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USUM72009888",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1860948252",
+        "de": "applemusic://track/1860948252",
+        "gb": "applemusic://track/1860948252",
+        "fr": "applemusic://track/1860948252",
+        "es": "applemusic://track/1860948252",
+        "nl": "applemusic://track/1860948252",
+        "it": "applemusic://track/1860948252"
+      }
     },
     {
       "year": 1978,
@@ -2451,7 +3131,17 @@
       "fun_fact_nl": "I Will Survive werd oorspronkelijk uitgebracht als B-kant voordat DJ's het begonnen te draaien in clubs. Gloria Gaynor nam het in één take op, ondanks het feit dat ze net hersteld was van een rugoperatie. Het nummer werd een disco-anthem en later een symbool van empowerment voor de LGBTQ+ gemeenschap wereldwijd.",
       "awards_nl": [
         "Grammy – Beste Disco-opname (1980)"
-      ]
+      ],
+      "isrc": "USPR37800083",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1443818368",
+        "de": "applemusic://track/1443268764",
+        "gb": "applemusic://track/1443090066",
+        "fr": "applemusic://track/1443818368",
+        "es": "applemusic://track/1443818368",
+        "nl": "applemusic://track/1443818368",
+        "it": "applemusic://track/1443818368"
+      }
     },
     {
       "year": 1978,
@@ -2479,7 +3169,17 @@
       "uri_tidal": "tidal://track/2871014",
       "uri_deezer": "deezer://track/3169189",
       "fun_fact_nl": "De iconische saxofoonriff van Baker Street werd gespeeld door Raphael Ravenscroft, die naar verluidt slechts £27,50 kreeg betaald voor de sessie. Hij beweerde later dat zijn royaltycheque werd geweigerd. Gerry Rafferty schreef het nummer over zijn frustratie over de muziekindustrie en het Londense nachtleven aan het eind van de jaren 1970.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAYE7800619",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/693606496",
+        "de": "applemusic://track/696804850",
+        "gb": "applemusic://track/1541207673",
+        "fr": "applemusic://track/1541207673",
+        "es": "applemusic://track/1541207673",
+        "nl": "applemusic://track/1541207673",
+        "it": "applemusic://track/1541207673"
+      }
     },
     {
       "year": 1979,
@@ -2508,7 +3208,17 @@
       "uri_tidal": "tidal://track/1771758",
       "uri_deezer": "deezer://track/884041",
       "fun_fact_nl": "Geef hier! Gimme! Gimme! was oorspronkelijk een ABBA-nummer dat de basis werd voor Madonna's 'Hung Up' in 2005 - de eerste keer dat ABBA een sample van hun werk goedkeurde. De stuwende discobeat van het nummer en de wanhopige tekst over eenzaamheid creëerden een van hun meest dramatische opnames ooit.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "SEAYD7901120",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1602387451",
+        "de": "applemusic://track/1602387451",
+        "gb": "applemusic://track/1602387451",
+        "fr": "applemusic://track/1602387451",
+        "es": "applemusic://track/1602387451",
+        "nl": "applemusic://track/1602387451",
+        "it": "applemusic://track/1602387451"
+      }
     },
     {
       "year": 1982,
@@ -2554,7 +3264,17 @@
       "awards_nl": [
         "Grammy – Beste R&B Zangprestatie (1984)",
         "Grammy – Beste R&B-nummer (1984)"
-      ]
+      ],
+      "isrc": "USSM19902991",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1641781004",
+        "de": "applemusic://track/1641781004",
+        "gb": "applemusic://track/1641781004",
+        "fr": "applemusic://track/1308504774",
+        "es": "applemusic://track/1641781004",
+        "nl": "applemusic://track/1641781004",
+        "it": "applemusic://track/1641781004"
+      }
     },
     {
       "year": 1983,
@@ -2582,7 +3302,17 @@
       "uri_tidal": "tidal://track/1105888",
       "uri_deezer": "deezer://track/540168502",
       "fun_fact_nl": "Maniac werd geschreven voor de film Flashdance over het verhaal van een staallasser die ervan droomt een balletdanser te worden. Michael Sembello schreef het oorspronkelijk over een seriemoordenaar, maar veranderde de tekst voor de film. Het nummer geeft perfect het fenomeen van de 80-er jaren workout en aerobics weer.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USPR38302462",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1808046460",
+        "de": "applemusic://track/1808046460",
+        "gb": "applemusic://track/1443325806",
+        "fr": "applemusic://track/1808046460",
+        "es": "applemusic://track/1808046460",
+        "nl": "applemusic://track/1808046460",
+        "it": "applemusic://track/1808046460"
+      }
     },
     {
       "year": 1978,
@@ -2610,7 +3340,17 @@
       "uri_tidal": "tidal://track/32616",
       "uri_deezer": "deezer://track/1078779",
       "fun_fact_nl": "Hold the Line was de debuutsingle van TOTO en toonde hun uitzonderlijke muzikaliteit. De band bestond uit sessiemuzikanten die op honderden hits hadden gespeeld. De gitaarriff en de keyboard solo werden meteen herkenbaar en TOTO werd een belangrijke kracht in de rockmuziek.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM17800444",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1739904475",
+        "de": "applemusic://track/827814103",
+        "gb": "applemusic://track/370145672",
+        "fr": "applemusic://track/370145672",
+        "es": "applemusic://track/370145672",
+        "nl": "applemusic://track/370145672",
+        "it": "applemusic://track/370145672"
+      }
     },
     {
       "year": 1980,
@@ -2638,7 +3378,17 @@
       "uri_tidal": "tidal://track/3094190",
       "uri_deezer": "deezer://track/95873824",
       "fun_fact_nl": "Celebration werd geschreven door de bassist en eunice van Kool & The Gang om speciale gelegenheden te herdenken. Het nummer is sinds de release op talloze feestjes, sportevenementen en vieringen gespeeld. Het werd veel gebruikt tijdens de terugkeer van de gijzelaars uit Iran in 1981 en werd een Amerikaans volkslied.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USPR38007166",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1692287480",
+        "de": "applemusic://track/1692287480",
+        "gb": "applemusic://track/1692287480",
+        "fr": "applemusic://track/1692287480",
+        "es": "applemusic://track/1692287480",
+        "nl": "applemusic://track/1692287480",
+        "it": "applemusic://track/1692287480"
+      }
     },
     {
       "year": 1994,
@@ -2666,7 +3416,17 @@
       "uri_tidal": "tidal://track/225476",
       "uri_deezer": "deezer://track/678044",
       "fun_fact_nl": "Basket Case werd geschreven door Billie Joe Armstrong over zijn paniekaanvallen en angsten voordat hij de diagnose paniekstoornis kreeg. Green Day nam het nummer op in de woonkamer van hun producer. Het werd het volkslied van de punkrock uit de jaren 90 en hielp het pop-punkgenre voor een generatie te definiëren.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USRE11600554",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1160990873",
+        "de": "applemusic://track/1160990873",
+        "gb": "applemusic://track/1160990873",
+        "fr": "applemusic://track/1160990873",
+        "es": "applemusic://track/1160990873",
+        "nl": "applemusic://track/1160990873",
+        "it": "applemusic://track/1160990873"
+      }
     },
     {
       "year": 1997,
@@ -2694,7 +3454,17 @@
       "uri_tidal": "tidal://track/20260537",
       "uri_deezer": "deezer://track/15608663",
       "fun_fact_nl": "Everybody (Backstreet's Back) werd eerst alleen internationaal uitgebracht omdat het Amerikaanse label het te cheesy vond. De videoclip met horrorthema was geïnspireerd op Michael Jacksons 'Thriller'. Het nummer werd een van de kenmerkende hits van de Backstreet Boys en een mijlpaal in de popcultuur van de jaren 90.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USJI19710083",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1741785672",
+        "de": "applemusic://track/1447372083",
+        "gb": "applemusic://track/1447372083",
+        "fr": "applemusic://track/1447372083",
+        "es": "applemusic://track/1447372083",
+        "nl": "applemusic://track/1447372083",
+        "it": "applemusic://track/1447372083"
+      }
     },
     {
       "year": 1998,
@@ -2723,7 +3493,17 @@
       "uri_tidal": "tidal://track/489946237",
       "uri_deezer": "deezer://track/3776251662",
       "fun_fact_nl": "Narcotic maakte de Duitse band Liquido internationaal bekend. Het aanstekelijke gitaarrifje en de duidelijke tekst over verslaving maakten van het nummer een alternatief rocknummer aan het eind van de jaren 90. Het nummer stond bovenaan de hitlijsten in heel Europa en blijft een nostalgische favoriet voor fans van rockmuziek uit de jaren 90.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEG129800581",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1857765665",
+        "de": "applemusic://track/1857765665",
+        "gb": "applemusic://track/1857765665",
+        "fr": "applemusic://track/1857765665",
+        "es": "applemusic://track/1857765665",
+        "nl": "applemusic://track/1857765665",
+        "it": "applemusic://track/1857765665"
+      }
     },
     {
       "year": 1997,
@@ -2752,7 +3532,17 @@
       "uri_tidal": "tidal://track/77892506",
       "uri_deezer": "deezer://track/432946922",
       "fun_fact_nl": "Bitter Sweet Symphony samplet een orkestrale versie van The Rolling Stones' 'The Last Time'. Door juridische problemen verloor The Verve alle royalty's van de Stones tot 2019, toen Jagger en Richards de rechten teruggaven aan Richard Ashcroft. Het nummer definieert 90s Britpop melancholie perfect.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBUM71601816",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1893169334",
+        "de": "applemusic://track/1893169334",
+        "gb": "applemusic://track/1893169334",
+        "fr": "applemusic://track/1893169334",
+        "es": "applemusic://track/1893169334",
+        "nl": "applemusic://track/1893169334",
+        "it": "applemusic://track/1893169334"
+      }
     },
     {
       "year": 2005,
@@ -2781,7 +3571,17 @@
       "uri_tidal": "tidal://track/157649",
       "uri_deezer": "deezer://track/3157501",
       "fun_fact_nl": "Jerk It Out werd gebruikt in de iPod-commercial die de band naar een internationaal succes hielp. De Zweedse band Caesars was al jaren samen voor deze doorbraak. Het energieke garagerocknummer gaf perfect de indierockrevival van begin jaren 2000 weer en werd een feestnummer.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "SEVBU0200002",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/688394330",
+        "de": "applemusic://track/688394330",
+        "gb": "applemusic://track/688394330",
+        "fr": "applemusic://track/688394330",
+        "es": "applemusic://track/688394330",
+        "nl": "applemusic://track/688394330",
+        "it": "applemusic://track/688394330"
+      }
     },
     {
       "year": 1997,
@@ -2810,7 +3610,17 @@
       "uri_tidal": "tidal://track/157975",
       "uri_deezer": "deezer://track/3087542",
       "fun_fact_nl": "Let Me Entertain You werd geschreven door Robbie Williams en Guy Chambers als een anthemisch statement van Williams solocarrière. Het nummer bevat 'Rock DJ' elementen en vestigde zijn reputatie als showman. Het werd jarenlang de opener van concerten en definieerde Williams provocerende podiumpersoonlijkheid.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAYE9701083",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/724157567",
+        "de": "applemusic://track/724157567",
+        "gb": "applemusic://track/724157567",
+        "fr": "applemusic://track/724157567",
+        "es": "applemusic://track/724157567",
+        "nl": "applemusic://track/724157567",
+        "it": "applemusic://track/724157567"
+      }
     },
     {
       "year": 1991,
@@ -2839,7 +3649,17 @@
       "uri_tidal": "tidal://track/96583647",
       "uri_deezer": "deezer://track/568121132",
       "fun_fact_nl": "The Show Must Go On werd opgenomen terwijl Freddie Mercury ernstig ziek was door AIDS. Naar verluidt dronk Mercury wodka om zijn pijn te verdoven tijdens de opnames, waarna hij een van de krachtigste zangprestaties van de rock bracht. Brian May zei dat hij niet wist hoe Mercury het fysiek voor elkaar kreeg om het te zingen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBUM71106221",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1699722786",
+        "de": "applemusic://track/1825250853",
+        "gb": "applemusic://track/1825250853",
+        "fr": "applemusic://track/1825250853",
+        "es": "applemusic://track/1825250853",
+        "nl": "applemusic://track/1825250853",
+        "it": "applemusic://track/1825250853"
+      }
     },
     {
       "year": 1961,
@@ -2880,7 +3700,17 @@
       "fun_fact_nl": "Let's Twist Again werd geschreven als een vervolg op 'The Twist' en won een Grammy Award. Chubby Checker werd synoniem met de dansrage die Amerika in het begin van de jaren 60 overspoelde. The Twist was de eerste moderne dans waarbij partners elkaar niet aanraakten, wat een revolutie betekende in de manier waarop mensen dansten.",
       "awards_nl": [
         "Grammy – Beste Rock-'n-Roll-opname (1962)"
-      ]
+      ],
+      "isrc": "USA176140170",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1443091056",
+        "de": "applemusic://track/1443091056",
+        "gb": "applemusic://track/1443091056",
+        "fr": "applemusic://track/1443091056",
+        "es": "applemusic://track/1443091056",
+        "nl": "applemusic://track/1443091056",
+        "it": "applemusic://track/1443091056"
+      }
     },
     {
       "year": 1982,
@@ -2909,7 +3739,17 @@
       "uri_tidal": "tidal://track/6923045",
       "uri_deezer": "deezer://track/12274786",
       "fun_fact_nl": "Under Pressure ontstond tijdens een geïmproviseerde jamsessie tussen Queen en David Bowie. De beroemde baslijn werd gespeeld door John Deacon. Bowie en Mercury hadden naar verluidt ruzie over de creatieve controle en namen elk apart de vocalen op. Het nummer werd een mijlpaal in de rockgeschiedenis.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBUM71404523",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1440651291",
+        "de": "applemusic://track/1422664556",
+        "gb": "applemusic://track/1422664556",
+        "fr": "applemusic://track/1422664556",
+        "es": "applemusic://track/1422664556",
+        "nl": "applemusic://track/1422664556",
+        "it": "applemusic://track/1422664556"
+      }
     },
     {
       "year": 1963,
@@ -2937,7 +3777,17 @@
       "uri_tidal": "tidal://track/55163257",
       "uri_deezer": "deezer://track/116348340",
       "fun_fact_nl": "Twist and Shout werd als laatste opgenomen tijdens de eerste marathonsessie van The Beatles. De stem van John Lennon was bijna weg, waardoor het nummer zijn rauwe, schorre kwaliteit kreeg. Het nummer was eigenlijk een cover, oorspronkelijk opgenomen door de Top Notes. De versie van The Beatles werd definitief en iconisch.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAYE0601423",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1441165136",
+        "de": "applemusic://track/1441165136",
+        "gb": "applemusic://track/1441165136",
+        "fr": "applemusic://track/1441165136",
+        "es": "applemusic://track/1441165136",
+        "nl": "applemusic://track/1441165136",
+        "it": "applemusic://track/1441165136"
+      }
     },
     {
       "year": 1989,
@@ -2965,7 +3815,17 @@
       "uri_tidal": "tidal://track/1268210",
       "uri_deezer": "deezer://track/626123",
       "fun_fact_nl": "We Didn't Start the Fire somt 118 historische gebeurtenissen en figuren op uit de periode 1949-1989. Billy Joel schreef het nadat een 21-jarige hem vertelde dat het een saaie tijd was om op te groeien. Joel leerde alle teksten uit zijn hoofd door mentale beelden te creëren en zei dat hij het haat om het live op te voeren omdat het vermoeiend is.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM18900217",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/158816462",
+        "de": "applemusic://track/158816462",
+        "gb": "applemusic://track/273854291",
+        "fr": "applemusic://track/158816462",
+        "es": "applemusic://track/158816462",
+        "nl": "applemusic://track/158816462",
+        "it": "applemusic://track/158816462"
+      }
     },
     {
       "year": 1973,
@@ -2993,7 +3853,17 @@
       "uri_tidal": "tidal://track/328924",
       "uri_deezer": "deezer://track/1124103",
       "fun_fact_nl": "Crocodile Rock was Elton John's eerste Amerikaanse nummer één single. Het werd geschreven als een nostalgisch eerbetoon aan de rock and roll uit de jaren 1950 en de fictieve dansen uit die tijd. Het 'la la la' refrein was opzettelijk onnozel, om het onschuldige plezier van de vroege rock and roll dance hall cultuur te vangen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAMB7200001",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1440926343",
+        "de": "applemusic://track/1440926343",
+        "gb": "applemusic://track/1440926343",
+        "fr": "applemusic://track/1440926343",
+        "es": "applemusic://track/1440926343",
+        "nl": "applemusic://track/1440926343",
+        "it": "applemusic://track/1440926343"
+      }
     },
     {
       "year": 1986,
@@ -3021,7 +3891,17 @@
       "uri_tidal": "tidal://track/93177983",
       "uri_deezer": "deezer://track/577487242",
       "fun_fact_nl": "You Give Love a Bad Name was Bon Jovi's doorbraakhit die hen naar het supersterrendom bracht. Het nummer werd samen met Desmond Child geschreven, die hielp bij het ontwikkelen van het massieve arenarockgeluid. De a capella openingskreet werd een van de meest dramatische openingszinnen van rock ooit opgenomen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USPR39402224",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1892200978",
+        "de": "applemusic://track/1892200978",
+        "gb": "applemusic://track/1892200978",
+        "fr": "applemusic://track/1892200978",
+        "es": "applemusic://track/1892200978",
+        "nl": "applemusic://track/1892200978",
+        "it": "applemusic://track/1892200978"
+      }
     },
     {
       "year": 1991,
@@ -3062,7 +3942,17 @@
       "fun_fact_nl": "Smells Like Teen Spirit is vernoemd naar een deodorantmerk dat Kurt Cobains vriendin Kathleen Hanna op zijn muur schreef. Cobain wist niet dat het een deodorant was. De explosieve dynamiek van het nummer definieerde grunge en Generatie X. MTV draaide het constant en maakte van Nirvana in één klap onwillige supersterren.",
       "awards_nl": [
         "Grammy Hall of Fame (2017)"
-      ]
+      ],
+      "isrc": "USGF19942501",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1440783625",
+        "de": "applemusic://track/1440783625",
+        "gb": "applemusic://track/1440783625",
+        "fr": "applemusic://track/1440783625",
+        "es": "applemusic://track/1440783625",
+        "nl": "applemusic://track/1440783625",
+        "it": "applemusic://track/1440783625"
+      }
     },
     {
       "year": 1983,
@@ -3090,7 +3980,17 @@
       "uri_tidal": "tidal://track/1317402",
       "uri_deezer": "deezer://track/72194071",
       "fun_fact_nl": "Girls Just Want to Have Fun was oorspronkelijk geschreven door Robert Hazard als een lied vanuit een mannelijk perspectief. Cyndi Lauper veranderde de voornaamwoorden en de toon, waardoor het een feministisch volkslied werd. In de kleurrijke videoclip was Lauper's echte moeder te zien en het hielp de beeldcultuur van MTV te vestigen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM18300548",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1351343432",
+        "de": "applemusic://track/1351343432",
+        "gb": "applemusic://track/1351343432",
+        "fr": "applemusic://track/1351343432",
+        "es": "applemusic://track/1298436194",
+        "nl": "applemusic://track/1351343432",
+        "it": "applemusic://track/1351343432"
+      }
     },
     {
       "year": 1993,
@@ -3118,7 +4018,17 @@
       "uri_tidal": "tidal://track/238184165",
       "uri_deezer": "deezer://track/3786149242",
       "fun_fact_nl": "What Is Love was Haddaway's debuutsingle en werd een Eurodance-klassieker. Het nummer kreeg een cultstatus door het gebruik ervan in de sketches van Saturday Night Live 'Night at the Roxbury'. De head-bobbing danspas werd iconisch. Haddaway stelde echt een filosofische vraag over de liefde.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEA410500401",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1731434189",
+        "de": "applemusic://track/1731434189",
+        "gb": "applemusic://track/1731434189",
+        "fr": "applemusic://track/1731434189",
+        "es": "applemusic://track/1731434189",
+        "nl": "applemusic://track/1731434189",
+        "it": "applemusic://track/1731434189"
+      }
     },
     {
       "year": 1987,
@@ -3146,7 +4056,17 @@
       "uri_tidal": "tidal://track/91059740",
       "uri_deezer": "deezer://track/518458142",
       "fun_fact_nl": "Paradise City werd geïnspireerd door Los Angeles en de belofte van roem en fortuin. Het outro werd opgenomen terwijl de band 12 minuten lang live in de studio speelde. De epische lengte en gitaarsolo's van het nummer maakten het een perfecte concertafsluiter en een van de bepalende nummers van Guns N' Roses.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USGF18714806",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1377813298",
+        "de": "applemusic://track/1377813298",
+        "gb": "applemusic://track/1377813298",
+        "fr": "applemusic://track/1377813298",
+        "es": "applemusic://track/1377813298",
+        "nl": "applemusic://track/1377813298",
+        "it": "applemusic://track/1377813298"
+      }
     },
     {
       "year": 1983,
@@ -3192,7 +4112,17 @@
       "awards_nl": [
         "Grammy – Beste Pop Zangprestatie (1984)",
         "Oscar – Beste Originele Lied (1984)"
-      ]
+      ],
+      "isrc": "CAU118300354",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/280711410",
+        "de": "applemusic://track/280711410",
+        "gb": "applemusic://track/280711410",
+        "fr": "applemusic://track/280711410",
+        "es": "applemusic://track/280711410",
+        "nl": "applemusic://track/280711410",
+        "it": "applemusic://track/280711410"
+      }
     },
     {
       "year": 2002,
@@ -3220,7 +4150,17 @@
       "uri_tidal": "tidal://track/304865",
       "uri_deezer": "deezer://track/725971",
       "fun_fact_nl": "Can't Stop bevat een van de meest herkenbare gitaarriffs van de jaren 2000, gespeeld door John Frusciante. De funk-rock energie van het nummer toonde Red Hot Chili Peppers op hun hoogtepunt. Het drumwerk van Chad Smith op dit nummer wordt beschouwd als zijn beste werk met de band.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USWB11402804",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/945578427",
+        "de": "applemusic://track/945578427",
+        "gb": "applemusic://track/945578427",
+        "fr": "applemusic://track/945578427",
+        "es": "applemusic://track/945578427",
+        "nl": "applemusic://track/945578427",
+        "it": "applemusic://track/945578427"
+      }
     },
     {
       "year": 1999,
@@ -3248,7 +4188,17 @@
       "uri_tidal": "tidal://track/4942590",
       "uri_deezer": "deezer://track/13141170",
       "fun_fact_nl": "I Want It That Way werd geschreven door Max Martin, die later een van de meest succesvolle producers van de popmuziek zou worden. Backstreet Boys geven toe dat de tekst grammaticaal niet helemaal klopt, maar Martin overtuigde hen ervan dat de emotie belangrijker was. Het blijft een van de best verkochte singles aller tijden.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USJI19910614",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1625999385",
+        "de": "applemusic://track/1625999385",
+        "gb": "applemusic://track/1625999385",
+        "fr": "applemusic://track/1625999385",
+        "es": "applemusic://track/1625999385",
+        "nl": "applemusic://track/1625999385",
+        "it": "applemusic://track/1625999385"
+      }
     },
     {
       "year": 1986,
@@ -3276,7 +4226,17 @@
       "uri_tidal": "tidal://track/93177984",
       "uri_deezer": "deezer://track/538660022",
       "fun_fact_nl": "Livin' on a Prayer vertelt het verhaal van Tommy en Gina, mensen uit de arbeidersklasse die worstelen om te overleven. Jon Bon Jovi had aanvankelijk een hekel aan het talkboxeffect van het nummer, maar werd overtuigd door de producer. Het nummer werd een van de meest gespeelde rock anthems op sportevenementen en karaoke avonden wereldwijd.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USPR38619998",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1893169170",
+        "de": "applemusic://track/1893169170",
+        "gb": "applemusic://track/1893169170",
+        "fr": "applemusic://track/1893169170",
+        "es": "applemusic://track/1893169170",
+        "nl": "applemusic://track/1893169170",
+        "it": "applemusic://track/1893169170"
+      }
     },
     {
       "year": 1987,
@@ -3317,7 +4277,17 @@
       "fun_fact_nl": "De iconische gitaarriff van Sweet Child O' Mine was eigenlijk een opwarmoefening die Slash aan het spelen was. Axl Rose hoorde het en eiste dat ze er een nummer van maakten. Het nummer werd in slechts vijf dagen geschreven. Het werd Guns N' Roses' grootste hit en een van de meest geliefde ballads van de rock.",
       "awards_nl": [
         "American Music Award – Favoriete Pop/Rock Single (1989)"
-      ]
+      ],
+      "isrc": "USGF18714809",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1377813701",
+        "de": "applemusic://track/1377813701",
+        "gb": "applemusic://track/1377813701",
+        "fr": "applemusic://track/1377813701",
+        "es": "applemusic://track/1377813701",
+        "nl": "applemusic://track/1377813701",
+        "it": "applemusic://track/1377813701"
+      }
     },
     {
       "year": 2000,
@@ -3345,7 +4315,17 @@
       "uri_tidal": "tidal://track/1225577",
       "uri_deezer": "deezer://track/676183",
       "fun_fact_nl": "In the End werd het kenmerkende nummer van Linkin Park en definieerde het nu-metal tijdperk. Het rappen van Mike Shinoda in combinatie met de zang van Chester Bennington creëerde hun kenmerkende geluid. De thema's van het nummer, hard proberen maar uiteindelijk falen, vonden weerklank bij miljoenen fans over de hele wereld en werden een generatiehymne.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USWB11201118",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/591534783",
+        "de": "applemusic://track/591534783",
+        "gb": "applemusic://track/591534783",
+        "fr": "applemusic://track/591534783",
+        "es": "applemusic://track/591534783",
+        "nl": "applemusic://track/591534783",
+        "it": "applemusic://track/591534783"
+      }
     },
     {
       "year": 1977,
@@ -3377,7 +4357,17 @@
       "uri_tidal": "tidal://track/215115417",
       "uri_deezer": "deezer://track/63480987",
       "fun_fact_nl": "Dreams werd de enige #1-hit van Fleetwood Mac in de VS. Stevie Nicks schreef het nummer in ongeveer tien minuten op een Fender Rhodes in de Record Plant studio terwijl Lindsey Buckingham in een andere kamer zijn breakup song 'Go Your Own Way' aan het opnemen was. Het nummer ging in 2020 opnieuw viraal op TikTok na een video met skateboardend cranberrysap, waardoor het nummer weer in de Billboard Hot 100 terechtkwam.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USWB10400046",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/594061856",
+        "de": "applemusic://track/594061856",
+        "gb": "applemusic://track/594061856",
+        "fr": "applemusic://track/594061856",
+        "es": "applemusic://track/594061856",
+        "nl": "applemusic://track/594061856",
+        "it": "applemusic://track/594061856"
+      }
     },
     {
       "year": 1966,
@@ -3410,7 +4400,17 @@
       "uri_tidal": "tidal://track/13434396",
       "uri_deezer": "deezer://track/7818900",
       "fun_fact_nl": "Paint It, Black was een van de eerste rocknummers met een sitar, bespeeld door Brian Jones die zichzelf het instrument leerde nadat hij was geïnspireerd door George Harrison. De komma in de titel was een drukfout op de originele single die bleef staan. Het nummer werd iconisch als het thema van de tv-serie 'Tour of Duty' en wordt vaak gebruikt in soundtracks van Vietnamfilms.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USA171010213",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1440745782",
+        "de": "applemusic://track/1440745782",
+        "gb": "applemusic://track/1440745782",
+        "fr": "applemusic://track/1440745782",
+        "es": "applemusic://track/1440745782",
+        "nl": "applemusic://track/1440745782",
+        "it": "applemusic://track/1440745782"
+      }
     },
     {
       "year": 1975,
@@ -3442,7 +4442,17 @@
       "uri_tidal": "tidal://track/55391801",
       "uri_deezer": "deezer://track/116914042",
       "fun_fact_nl": "Geschreven als een eerbetoon aan voormalig Pink Floyd frontman Syd Barrett, werd het nummer griezelig aangrijpend toen Barrett onverwacht opdook bij de Abbey Road opnamesessies - zo zwaar en met een kaalgeschoren hoofd dat zijn bandleden hem in eerste instantie niet herkenden. Roger Waters was naar verluidt tot tranen toe geroerd toen hij zich realiseerde wie de vreemdeling was.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBN9Y1100088",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1065973980",
+        "de": "applemusic://track/1065973980",
+        "gb": "applemusic://track/1065973980",
+        "fr": "applemusic://track/1065973980",
+        "es": "applemusic://track/1065973980",
+        "nl": "applemusic://track/1065973980",
+        "it": "applemusic://track/1065973980"
+      }
     },
     {
       "year": 1980,
@@ -3474,7 +4484,17 @@
       "uri_tidal": "tidal://track/155026177",
       "uri_deezer": "deezer://track/1078203362",
       "fun_fact_nl": "De iconische gitaarriff is geschreven door Randy Rhoads, een klassiek geschoolde gitarist die neoklassieke techniek versmolt met heavy metal. Ozzy Osbourne schreef de tekst over de Koude Oorlog en de toestand van de wereld. De opening van het nummer 'All Aboard!' werd geïnspireerd door Ozzy's wens om het nummer te laten klinken als het vertrek van een trein.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM11002845",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1626431301",
+        "de": "applemusic://track/1626431301",
+        "gb": "applemusic://track/1626431301",
+        "fr": "applemusic://track/1626431301",
+        "es": "applemusic://track/1626431301",
+        "nl": "applemusic://track/1626431301",
+        "it": "applemusic://track/1626431301"
+      }
     },
     {
       "year": 1971,
@@ -3516,7 +4536,17 @@
       "fun_fact_nl": "Stairway to Heaven werd nooit uitgebracht als single, maar werd wel het meest gevraagde nummer op FM-radio in de jaren 1970. Jimmy Page componeerde de muziek in Headley Grange met een Harmony Sovereign akoestische gitaar. De structuur van het nummer is revolutionair - het begint als een zachte akoestische ballade en bouwt zich in 8 minuten op tot een donderende rockclimax.",
       "awards_nl": [
         "Grammy Hall of Fame (2003)"
-      ]
+      ],
+      "isrc": "USAT21207031",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/902620521",
+        "de": "applemusic://track/902620521",
+        "gb": "applemusic://track/902620521",
+        "fr": "applemusic://track/902620521",
+        "es": "applemusic://track/902620521",
+        "nl": "applemusic://track/902620521",
+        "it": "applemusic://track/902620521"
+      }
     },
     {
       "year": 1971,
@@ -3627,7 +4657,17 @@
       "uri_tidal": "tidal://track/77610759",
       "uri_deezer": "deezer://track/13791932",
       "fun_fact_nl": "De gitaarriff van Come As You Are lijkt sterk op Killing Joke's 'Eighties', dat zelf weer leek op The Damned's 'Life Goes On. Killing Joke heeft naar verluidt juridische stappen overwogen, maar is daar nooit mee doorgegaan. Kurt Cobain gebruikte een Electro-Harmonix Small Clone chorus pedaal om de kenmerkende waterige gitaartoon van het nummer te maken.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USGF19942503",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1440783636",
+        "de": "applemusic://track/1440783636",
+        "gb": "applemusic://track/1440783636",
+        "fr": "applemusic://track/1440783636",
+        "es": "applemusic://track/1440783636",
+        "nl": "applemusic://track/1440783636",
+        "it": "applemusic://track/1440783636"
+      }
     },
     {
       "year": 1970,
@@ -3669,7 +4709,17 @@
       "fun_fact_nl": "Paranoid werd in slechts 20 minuten geschreven als een last-minute filler track toen het album bijna op was. Tony Iommi bedacht de riff ter plekke en Geezer Butler krabbelde snel een tekst over depressie. Ondanks dat het een bijzaak was, werd het Black Sabbaths grootste hitsingle en het nummer dat heavy metal definieerde.",
       "awards_nl": [
         "Grammy Hall of Fame (2021)"
-      ]
+      ],
+      "isrc": "USWB11304369",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/787644021",
+        "de": null,
+        "gb": null,
+        "fr": null,
+        "es": null,
+        "nl": null,
+        "it": null
+      }
     },
     {
       "year": 1992,
@@ -3702,7 +4752,17 @@
       "uri_tidal": "tidal://track/58990486",
       "uri_deezer": "deezer://track/138547415",
       "fun_fact_nl": "Creep flopte aanvankelijk toen het in 1992 in het Verenigd Koninkrijk werd uitgebracht, maar werd een verrassingshit in Israël en daarna in de VS. Thom Yorke schreef het tijdens zijn studie aan de Universiteit van Exeter over een vrouw die hij volgde op een feestje. De band kreeg zo'n hekel aan het nummer dat ze het jarenlang niet meer live speelden. Ze brachten het alleen af en toe opnieuw uit tijdens speciale shows.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAYE9200070",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1679849415",
+        "de": "applemusic://track/1679849415",
+        "gb": "applemusic://track/1679849415",
+        "fr": "applemusic://track/1679849415",
+        "es": "applemusic://track/1679849415",
+        "nl": "applemusic://track/1679849415",
+        "it": "applemusic://track/1679849415"
+      }
     },
     {
       "year": 1996,
@@ -3777,7 +4837,17 @@
       "fun_fact_nl": "De iconische baslijn is eigenlijk een gitaar die bespeeld wordt door een octaafpedaal - de White Stripes hebben nooit een bas gebruikt. Jack White schreef de riff in een hotelkamer in Melbourne tijdens een tournee. Het nummer werd een van de meest gezongen melodieën in sportstadions wereldwijd, vooral bij voetbalwedstrijden, en evenaart 'We Will Rock You' in alomtegenwoordigheid.",
       "awards_nl": [
         "Grammy – Beste Rocknummer (2004)"
-      ]
+      ],
+      "isrc": "USVT10300001",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1533513537",
+        "de": "applemusic://track/1533513537",
+        "gb": "applemusic://track/1533513537",
+        "fr": "applemusic://track/1533513537",
+        "es": "applemusic://track/1533513537",
+        "nl": "applemusic://track/1533513537",
+        "it": "applemusic://track/1533513537"
+      }
     },
     {
       "year": 1975,
@@ -3809,7 +4879,17 @@
       "uri_tidal": "tidal://track/69761284",
       "uri_deezer": "deezer://track/141820093",
       "fun_fact_nl": "David Bowie bood Golden Years oorspronkelijk aan Elvis Presley aan, maar die weigerde. Het nummer markeerde Bowie's overgang naar zijn 'Thin White Duke' personage en het funk-invloeden tijdperk 'Station to Station'. Bowie nam het op in Los Angeles tijdens een periode van extreem cocaïnegebruik, nauwelijks slapen en voornamelijk bestaan op rode pepers en melk.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USJT11600108",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1135947981",
+        "de": "applemusic://track/1135947981",
+        "gb": "applemusic://track/1135947981",
+        "fr": "applemusic://track/1135947981",
+        "es": "applemusic://track/1135947981",
+        "nl": "applemusic://track/1135947981",
+        "it": "applemusic://track/1135947981"
+      }
     },
     {
       "year": 1969,
@@ -3851,7 +4931,17 @@
       "fun_fact_nl": "Het middelste gedeelte van Whole Lotta Love bevat een psychedelische breakdown gemaakt door Jimmy Page met behulp van een theremin en backwards echo effecten. De tekst van het nummer is gedeeltelijk afgeleid van Willie Dixon's 'You Need Love', wat leidde tot een rechtszaak en een credit voor het songschrijven van Dixon. De riff werd door het tijdschrift Total Guitar uitgeroepen tot de beste gitaarriff aller tijden.",
       "awards_nl": [
         "Grammy Hall of Fame (2014)"
-      ]
+      ],
+      "isrc": "USAT21207009",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/674271148",
+        "de": "applemusic://track/674271148",
+        "gb": "applemusic://track/674271148",
+        "fr": "applemusic://track/674271148",
+        "es": "applemusic://track/674271148",
+        "nl": "applemusic://track/674271148",
+        "it": "applemusic://track/674271148"
+      }
     },
     {
       "year": 1972,
@@ -3883,7 +4973,17 @@
       "uri_tidal": "tidal://track/491295257",
       "uri_deezer": "deezer://track/3794395952",
       "fun_fact_nl": "Changes is een van de meest atypische nummers van Black Sabbath - een pianoballade op een verder heavy metalalbum. Ozzy Osbourne speelde piano op het nummer, een van de weinige keren dat hij instrumentaal bijdroeg. Het nummer werd later opnieuw opgenomen als een duet tussen Ozzy en zijn dochter Kelly in 2003 en bereikte #1 in de UK.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USWB11304343",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/787641279",
+        "de": null,
+        "gb": null,
+        "fr": null,
+        "es": null,
+        "nl": null,
+        "it": null
+      }
     },
     {
       "year": 1964,
@@ -3925,7 +5025,17 @@
       "fun_fact_nl": "The Animals namen House of the Rising Sun in één take op tijdens een sessie van 15 minuten, omdat hun platenmaatschappij hen maar beperkte studiotijd gaf. Het nummer is eigenlijk een traditioneel Amerikaans volksliedje van onbekende oorsprong, mogelijk daterend uit de 18e eeuw. Bob Dylan had een versie opgenomen in 1962 en was naar verluidt zo onder de indruk van het arrangement van The Animals dat hij overstapte van akoestische naar elektrische gitaar.",
       "awards_nl": [
         "Grammy Hall of Fame (1999)"
-      ]
+      ],
+      "isrc": "USA176460010",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1440781975",
+        "de": null,
+        "gb": null,
+        "fr": null,
+        "es": null,
+        "nl": null,
+        "it": null
+      }
     },
     {
       "year": 1997,
@@ -3957,7 +5067,17 @@
       "uri_tidal": "tidal://track/3146735",
       "uri_deezer": "deezer://track/4762041",
       "fun_fact_nl": "Dave Grohl schreef en nam het grootste deel van Everlong alleen op in zijn thuisstudio in Virginia, waarbij hij elk instrument bespeelde behalve de laatste gitaarpartij. Hij beschreef het nummer als zijnde over 'verliefd worden' - in het bijzonder zijn toen nieuwe relatie met Louise Post van Veruca Salt. De videoclip, geregisseerd door Michel Gondry, toont Dave en Taylor Hawkins in een surrealistische droomscène.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USRW29600011",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/362133505",
+        "de": "applemusic://track/1094743999",
+        "gb": "applemusic://track/1094743999",
+        "fr": "applemusic://track/1094743999",
+        "es": "applemusic://track/1094743999",
+        "nl": "applemusic://track/1094743999",
+        "it": "applemusic://track/1094743999"
+      }
     },
     {
       "year": 1989,
@@ -3999,7 +5119,17 @@
       "fun_fact_nl": "Nikki Sixx schreef Kickstart My Heart na een bijna fatale overdosis heroïne in 1987. Hij was klinisch dood gedurende twee minuten voordat paramedici hem weer tot leven wekten met twee injecties met adrenaline recht in het hart. De adrenalinestoot die hem weer tot leven bracht, inspireerde de stuwende energie van het nummer. De basintro is opgenomen op 200+ BPM.",
       "awards_nl": [
         "Grammy-nominatie – Beste Hardrockprestatie (1990)"
-      ]
+      ],
+      "isrc": "USBY29900215",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1764396024",
+        "de": "applemusic://track/1764396024",
+        "gb": "applemusic://track/1764396024",
+        "fr": "applemusic://track/1764396024",
+        "es": "applemusic://track/1764396024",
+        "nl": "applemusic://track/1764396024",
+        "it": "applemusic://track/1764396024"
+      }
     },
     {
       "year": 1973,
@@ -4031,7 +5161,17 @@
       "uri_tidal": "tidal://track/265098169",
       "uri_deezer": "deezer://track/2058907137",
       "fun_fact_nl": "Steven Tyler begon Dream On te schrijven toen hij net 17 jaar oud was, waardoor het een van de beroemdste rocknummers is met een tiener oorsprong. Het nummer werd pas een grote hit toen het opnieuw werd uitgebracht in 1976, drie jaar na de eerste release. Tyler's stijgende stem, die extreem hoge noten bereikt op het hoogtepunt, heeft het tot een van de meest uitdagende nummers gemaakt om live te zingen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM10011897",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1885596530",
+        "de": "applemusic://track/1885596530",
+        "gb": "applemusic://track/1885596530",
+        "fr": "applemusic://track/1885596530",
+        "es": "applemusic://track/1885596530",
+        "nl": "applemusic://track/1885596530",
+        "it": "applemusic://track/1885596530"
+      }
     },
     {
       "year": 1972,
@@ -4063,7 +5203,17 @@
       "uri_tidal": "tidal://track/51161410",
       "uri_deezer": "deezer://track/107471926",
       "fun_fact_nl": "Starman werd op het laatste moment toegevoegd aan het Ziggy Stardust album, ter vervanging van een cover van Chuck Berry's 'Around and Around,' nadat RCA Records een single eiste. Bowie's iconische uitvoering van Starman op BBC's Top of the Pops in juli 1972 - waar hij nonchalant zijn arm om Mick Ronson heen sloeg - wordt gezien als een levensveranderend moment voor talloze toekomstige muzikanten.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USJT11200004",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1350497718",
+        "de": "applemusic://track/1350497718",
+        "gb": "applemusic://track/1350497718",
+        "fr": "applemusic://track/1350497718",
+        "es": "applemusic://track/1350497718",
+        "nl": "applemusic://track/1350497718",
+        "it": "applemusic://track/1350497718"
+      }
     },
     {
       "year": 1999,
@@ -4095,7 +5245,17 @@
       "uri_tidal": "tidal://track/304808",
       "uri_deezer": "deezer://track/725274",
       "fun_fact_nl": "Californication was het eerste album dat werd opgenomen met gitarist John Frusciante na zijn terugkeer van een verwoestende heroïneverslaving die hem bijna dood had achtergelaten. Anthony Kiedis schreef de teksten als kritiek op de corrumperende invloed van Hollywood op de wereldcultuur. De videoclip was baanbrekend voor die tijd, met videogame-achtige 3D-graphics van de bandleden.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USWB11403543",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/948354743",
+        "de": "applemusic://track/947701035",
+        "gb": "applemusic://track/947701035",
+        "fr": "applemusic://track/947701035",
+        "es": "applemusic://track/947701035",
+        "nl": "applemusic://track/947701035",
+        "it": "applemusic://track/947701035"
+      }
     },
     {
       "year": 1991,
@@ -4138,7 +5298,17 @@
       "fun_fact_nl": "Kirk Hammett bedacht de iconische riff van Enter Sandman om 3 uur 's nachts, toen hij het half slapend in een bandrecorder speelde. Producer Bob Rock pushte de band om een toegankelijker geluid te creëren, wat spanning veroorzaakte maar uiteindelijk hun best verkopende album opleverde. Het nummer gebruikt de melodie van 'Hush, Little Baby' in de brug, verdraaid in een nachtmerrieachtige context over kinderangsten.",
       "awards_nl": [
         "Grammy-nominatie – Beste Metalprestatie (1992)"
-      ]
+      ],
+      "isrc": "QMKHM1900001",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1572046436",
+        "de": "applemusic://track/1571983951",
+        "gb": "applemusic://track/1571983951",
+        "fr": "applemusic://track/1571983951",
+        "es": "applemusic://track/1571983951",
+        "nl": "applemusic://track/1571983951",
+        "it": "applemusic://track/1571983951"
+      }
     },
     {
       "year": 1969,
@@ -4170,7 +5340,17 @@
       "uri_tidal": "tidal://track/42685477",
       "uri_deezer": "deezer://track/883648",
       "fun_fact_nl": "John Fogerty schreef Fortunate Son in slechts 20 minuten als protest tegen het dienstplichtsysteem in Vietnam, dat rijke families in staat stelde om hun zonen vrij te kopen van dienstplicht. Ondanks dat het een anti-oorlogslied is, is het ironisch genoeg gebruikt in talloze oorlogsfilms en zelfs op politieke bijeenkomsten. Het is een van de meest gelicenseerde liedjes in de filmgeschiedenis.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USC4R0817618",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/6763077352",
+        "de": "applemusic://track/6763077352",
+        "gb": "applemusic://track/6763077352",
+        "fr": "applemusic://track/6763077352",
+        "es": "applemusic://track/6763077352",
+        "nl": "applemusic://track/6763077352",
+        "it": "applemusic://track/6763077352"
+      }
     },
     {
       "year": 1975,
@@ -4202,7 +5382,17 @@
       "uri_tidal": "tidal://track/14234195",
       "uri_deezer": "deezer://track/15347259",
       "fun_fact_nl": "Hurricane vertelt het verhaal van bokser Rubin 'Hurricane' Carter, die onterecht werd veroordeeld voor drievoudige moord. Dylan schreef het 8 minuten durende protestepos samen met Jacques Levy nadat hij Carter in de gevangenis had bezocht. Het nummer hielp nationale aandacht te vestigen op Carter's zaak en droeg bij aan een nieuw proces. Carter werd uiteindelijk in 1985 vrijgelaten na 19 jaar gevangenschap.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM17500791",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1781109156",
+        "de": "applemusic://track/1781109156",
+        "gb": "applemusic://track/1781109156",
+        "fr": "applemusic://track/1781109156",
+        "es": "applemusic://track/1781109156",
+        "nl": "applemusic://track/1781109156",
+        "it": "applemusic://track/1781109156"
+      }
     },
     {
       "year": 1979,
@@ -4235,7 +5425,17 @@
       "uri_tidal": "tidal://track/55391452",
       "uri_deezer": "deezer://track/116914094",
       "fun_fact_nl": "Het kinderkoor op Another Brick in the Wall werd uitgevoerd door leerlingen van de Islington Green School in de buurt van de studio. De kinderen kregen een eenmalige vergoeding maar ontvingen geen royalty's tot een schikking in 2004. Roger Waters schreef de anti-onderwijs teksten gebaseerd op zijn eigen traumatische schoolervaringen. Het nummer werd verboden in Zuid-Afrika tijdens de apartheid omdat het een protestlied werd.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBN9Y1100099",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1069036964",
+        "de": "applemusic://track/1069036964",
+        "gb": "applemusic://track/1069036964",
+        "fr": "applemusic://track/1069036964",
+        "es": "applemusic://track/1069036964",
+        "nl": "applemusic://track/1069036964",
+        "it": "applemusic://track/1069036964"
+      }
     },
     {
       "year": 1978,
@@ -4268,7 +5468,17 @@
       "uri_tidal": "tidal://track/622359",
       "uri_deezer": "deezer://track/2263033",
       "fun_fact_nl": "Mark Knopfler werd geïnspireerd om Sultans of Swing te schrijven nadat hij een middelmatig jazzbandje had zien spelen in een bijna lege pub in Londen. De leider van de band kondigde hen aan als 'the Sultans of Swing' voor hun kleine publiek. Knopfler's kenmerkende fingerpicking gitaarstijl was ongebruikelijk voor rock in die tijd, en radio DJ's gingen er in eerste instantie van uit dat het cleane geluid een productietruc was.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBF089601041",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1756476093",
+        "de": "applemusic://track/1506306900",
+        "gb": "applemusic://track/1506306900",
+        "fr": "applemusic://track/1506306900",
+        "es": "applemusic://track/1607414719",
+        "nl": "applemusic://track/1506306900",
+        "it": "applemusic://track/1506306900"
+      }
     },
     {
       "year": 1972,
@@ -4300,7 +5510,17 @@
       "uri_tidal": "tidal://track/1493491",
       "uri_deezer": "deezer://track/3161471",
       "fun_fact_nl": "Long Cool Woman werd geschreven door Allan Clarke en Roger Cook als een eerbetoon aan de swamp rock stijl van Creedence Clearwater Revival. Het was zo anders dan de typische harmonie-gedreven pop van The Hollies dat Graham Nash (die al vertrokken was naar CSN) niet geloofde dat zij het waren toen hij het voor het eerst op de radio hoorde. Het verhaal van het nummer over een FBI-agent was geïnspireerd op Amerikaanse misdaadfictie.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBGYU0300038",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1750088188",
+        "de": "applemusic://track/1750088188",
+        "gb": "applemusic://track/1750088188",
+        "fr": "applemusic://track/1750088188",
+        "es": "applemusic://track/1750088188",
+        "nl": "applemusic://track/1750088188",
+        "it": "applemusic://track/1750088188"
+      }
     },
     {
       "year": 1984,
@@ -4332,7 +5552,17 @@
       "uri_tidal": "tidal://track/25858061",
       "uri_deezer": "deezer://track/74628075",
       "fun_fact_nl": "Runaway werd opgenomen voordat Bon Jovi een officiële band had. Jon Bon Jovi stuurde een demo in voor een compilatiealbum van een lokaal radiostation en het nummer werd zo populair dat het hem een platencontract opleverde. De studiomuzikanten op de demo, bekend als 'The All Star Review', waren niet de uiteindelijke line-up van Bon Jovi. De synth intro werd gespeeld door Roy Bittan van Bruce Springsteen's E Street Band.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USPR39402231",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1779813310",
+        "de": "applemusic://track/1779813310",
+        "gb": "applemusic://track/1779813310",
+        "fr": "applemusic://track/1779813310",
+        "es": "applemusic://track/1779813310",
+        "nl": "applemusic://track/1779813310",
+        "it": "applemusic://track/1779813310"
+      }
     },
     {
       "year": 1977,
@@ -4364,7 +5594,17 @@
       "uri_tidal": "tidal://track/1273648",
       "uri_deezer": "deezer://track/855863",
       "fun_fact_nl": "Kerry Livgren schreef Dust in the Wind als een vingeroefening. Zijn vrouw hoorde hem het thuis spelen en vertelde hem dat dit het beste was wat hij ooit had geschreven. De andere bandleden wilden het aanvankelijk niet opnemen omdat het zo anders was dan hun progressieve rockstijl. De filosofische teksten over de vluchtigheid van het menselijk bestaan waren geïnspireerd op een boek met Indiaanse poëzie.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM19803732",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/158580601",
+        "de": "applemusic://track/158580601",
+        "gb": "applemusic://track/158580601",
+        "fr": "applemusic://track/158580601",
+        "es": "applemusic://track/158580601",
+        "nl": "applemusic://track/158580601",
+        "it": "applemusic://track/158580601"
+      }
     },
     {
       "year": 1973,
@@ -4396,7 +5636,17 @@
       "uri_tidal": "tidal://track/297952",
       "uri_deezer": "deezer://track/3667326",
       "fun_fact_nl": "La Grange gaat over de Chicken Ranch, een legendarisch bordeel in de buurt van La Grange, Texas, dat al sinds de jaren 1840 in bedrijf was. Het etablissement werd in 1973 gesloten - hetzelfde jaar dat het nummer werd uitgebracht - na een tv-onderzoek. De boogie riff was geïnspireerd op de gitaarstijl van John Lee Hooker. Billy Gibbons' gitaartoon op het nummer is eindeloos bestudeerd en nagemaakt door gitaristen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USWB11300428",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1728078888",
+        "de": "applemusic://track/1728078888",
+        "gb": "applemusic://track/1728078888",
+        "fr": "applemusic://track/1728078888",
+        "es": "applemusic://track/1728078888",
+        "nl": "applemusic://track/1728078888",
+        "it": "applemusic://track/1728078888"
+      }
     },
     {
       "year": 1983,
@@ -4444,7 +5694,17 @@
       "awards_nl": [
         "Grammy – Lied van het Jaar (1984)",
         "Grammy – Beste Popprestatie door Duo of Groep (1984)"
-      ]
+      ],
+      "isrc": "GBAAM0201110",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1561882481",
+        "de": "applemusic://track/1561882481",
+        "gb": "applemusic://track/1561882481",
+        "fr": "applemusic://track/1561882481",
+        "es": "applemusic://track/1561882481",
+        "nl": "applemusic://track/1561882481",
+        "it": "applemusic://track/1561882481"
+      }
     },
     {
       "year": 1991,
@@ -4476,7 +5736,17 @@
       "uri_tidal": "tidal://track/304849",
       "uri_deezer": "deezer://track/785176",
       "fun_fact_nl": "Anthony Kiedis schreef Under the Bridge als een gedicht over zijn eenzaamheid en drugsverslaving in Los Angeles. Hij was nooit van plan om het aan de band te laten horen, maar producer Rick Rubin ontdekte het gedicht in zijn notitieboekje. John Frusciante en de band worstelden aanvankelijk met het vinden van het juiste arrangement. Het nummer werd de best verkopende single van de Chili Peppers en een bepalend moment voor de rock uit de jaren 90.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USWB11402852",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/948460560",
+        "de": "applemusic://track/948460560",
+        "gb": "applemusic://track/948460560",
+        "fr": "applemusic://track/948460560",
+        "es": "applemusic://track/948460560",
+        "nl": "applemusic://track/948460560",
+        "it": "applemusic://track/948460560"
+      }
     },
     {
       "year": 1991,
@@ -4523,7 +5793,17 @@
       "awards_nl": [
         "Grammy – Beste Korte Muziekvideo (1992)",
         "Grammy – Beste Popprestatie door Duo of Groep (1992)"
-      ]
+      ],
+      "isrc": "USWB10402077",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1422693816",
+        "de": "applemusic://track/1422693816",
+        "gb": "applemusic://track/1422693816",
+        "fr": "applemusic://track/1422693816",
+        "es": "applemusic://track/1422693816",
+        "nl": "applemusic://track/1422693816",
+        "it": "applemusic://track/1422693816"
+      }
     },
     {
       "year": 1977,
@@ -4554,7 +5834,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=xwTPvcPYaOo",
       "uri_deezer": "deezer://track/63480992",
       "fun_fact_nl": "The Chain is het enige nummer op Rumours dat aan alle vijf de bandleden toe te schrijven is. Het werd samengesteld uit fragmenten van verschillende opnames - Mick Fleetwood's basdrumpatroon, John McVie's basriff en verschillende gitaar- en zangpartijen werden in de studio aan elkaar genaaid. De iconische baslijn van het nummer werd de langlopende themamuziek voor BBC's Formule 1-verslaggeving, gebruikt van 1978 tot 2015.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USWB10400053",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1764276183",
+        "de": "applemusic://track/1722450564",
+        "gb": "applemusic://track/1722450564",
+        "fr": "applemusic://track/1722450564",
+        "es": "applemusic://track/1722450564",
+        "nl": "applemusic://track/1722450564",
+        "it": "applemusic://track/1722450564"
+      }
     },
     {
       "year": 1981,
@@ -4586,7 +5876,17 @@
       "uri_tidal": "tidal://track/395304",
       "uri_deezer": "deezer://track/680601",
       "fun_fact_nl": "De titel kwam van een misverstand - toen Tom Petty's vrouw Jane tegen Stevie Nicks zei dat ze Tom ontmoette 'op zeventienjarige leeftijd', hoorde Nicks het verkeerd als 'rand van zeventien'. De stuwende gitaarriff van het nummer is veelvuldig gesampled, met name door Destiny's Child in 'Bootylicious'. Nicks schreef de tekst deels over de moord op John Lennon en deels over de dood van haar oom Jonathan.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USAT28300037",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/6763015779",
+        "de": "applemusic://track/6763015779",
+        "gb": "applemusic://track/6763015779",
+        "fr": "applemusic://track/6763015779",
+        "es": "applemusic://track/6763015779",
+        "nl": "applemusic://track/6763015779",
+        "it": "applemusic://track/6763015779"
+      }
     },
     {
       "year": 1973,
@@ -4618,7 +5918,17 @@
       "uri_tidal": "tidal://track/77652610",
       "uri_deezer": "deezer://track/1559717",
       "fun_fact_nl": "De epische gitaarsolo van Free Bird, die meer dan 4 minuten duurde, werd uitgevoerd door Allen Collins en Gary Rossington en wordt regelmatig genoemd als een van de beste gitaarsolo's ooit. Het nummer werd zo iconisch dat het roepen van 'Free Bird!' tijdens concerten een universele publieksgrap werd. Tragisch genoeg kreeg het nummer een diepere betekenis nadat meerdere bandleden omkwamen bij een vliegtuigongeluk in 1977.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMC17301722",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/6763127029",
+        "de": "applemusic://track/6763127029",
+        "gb": "applemusic://track/6763127029",
+        "fr": "applemusic://track/6763127029",
+        "es": "applemusic://track/6763127029",
+        "nl": "applemusic://track/6763127029",
+        "it": "applemusic://track/6763127029"
+      }
     },
     {
       "year": 1991,
@@ -4650,7 +5960,17 @@
       "uri_tidal": "tidal://track/5120024",
       "uri_deezer": "deezer://track/7675129",
       "fun_fact_nl": "Eddie Vedder schreef de tekst van Even Flow over een dakloze man die hij zag leven in de straten van San Diego. Het gitaarintro van het nummer, gespeeld door Mike McCready, was geïnspireerd door Stevie Ray Vaughan. Ondanks dat het een van de bekendste nummers van Pearl Jam is, heeft de band naar verluidt meer dan 50 verschillende versies opgenomen, omdat McCready zijn gitaarsolo live vaak verandert.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM19100673",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1440902613",
+        "de": "applemusic://track/1440902613",
+        "gb": "applemusic://track/1440902613",
+        "fr": "applemusic://track/1440902613",
+        "es": "applemusic://track/1440902613",
+        "nl": "applemusic://track/1440902613",
+        "it": "applemusic://track/1440902613"
+      }
     },
     {
       "year": 1981,
@@ -4682,7 +6002,17 @@
       "uri_tidal": "tidal://track/77623601",
       "uri_deezer": "deezer://track/10303625",
       "fun_fact_nl": "Tom Sawyer is mede geschreven door Rush en tekstschrijver Pye Dubois van de band Max Webster. De drumpartij van Neil Peart wordt beschouwd als een van de technisch moeilijkste in de rockgeschiedenis en het nummer is een vast onderdeel geworden in drumscholen. Geddy Lee's synthesizerwerk op het nummer hielp als pionier bij de integratie van keyboards in progressieve hardrock. Het nummer kreeg nieuwe bekendheid door het videospel Rock Band.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMR18180103",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1893166276",
+        "de": "applemusic://track/1893166276",
+        "gb": "applemusic://track/1893166276",
+        "fr": "applemusic://track/1893166276",
+        "es": "applemusic://track/1893166276",
+        "nl": "applemusic://track/1893166276",
+        "it": "applemusic://track/1893166276"
+      }
     },
     {
       "year": 1971,
@@ -4724,7 +6054,17 @@
       "fun_fact_nl": "Riders on the Storm was het laatste nummer dat The Doors opnamen met Jim Morrison voor zijn dood in Parijs in juli 1971. De regen- en dondergeluiden werden toegevoegd om een sfeervolle omgeving te creëren. De baslijn van het nummer was geïnspireerd op jazz en de tekst verwijst naar een liftende seriemoordenaar. Morrison fluisterde de zangtrack over zijn gewone zang, waardoor het spookachtige dubbelspooreffect ontstond.",
       "awards_nl": [
         "Grammy Hall of Fame (2009)"
-      ]
+      ],
+      "isrc": "USEE11200581",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1776775823",
+        "de": "applemusic://track/1776775823",
+        "gb": "applemusic://track/1776775823",
+        "fr": "applemusic://track/1776775823",
+        "es": "applemusic://track/1776775823",
+        "nl": "applemusic://track/1776775823",
+        "it": "applemusic://track/1776775823"
+      }
     },
     {
       "year": 1978,
@@ -4756,7 +6096,17 @@
       "uri_tidal": "tidal://track/130955",
       "uri_deezer": "deezer://track/3104498",
       "fun_fact_nl": "Debbie Harry schreef One Way or Another over een echte stalker als ex-vriend die haar terroriseerde voordat Blondie beroemd werd. Ondanks het duistere onderwerp maakte de springerige energie van het nummer het tot een new wave anthem. Het nummer kreeg een tweede leven in 2013 toen One Direction het coverde als een mashup voor Comic Relief en #1 werd in de UK.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USCH38500014",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1880210965",
+        "de": "applemusic://track/1581666166",
+        "gb": "applemusic://track/1581666166",
+        "fr": "applemusic://track/1581666166",
+        "es": "applemusic://track/1573675524",
+        "nl": "applemusic://track/1581666166",
+        "it": "applemusic://track/1581666166"
+      }
     },
     {
       "year": 1991,
@@ -4788,7 +6138,17 @@
       "uri_tidal": "tidal://track/1269502",
       "uri_deezer": "deezer://track/625945",
       "fun_fact_nl": "Mama, I'm Coming Home werd samen geschreven met Lemmy Kilmister van Motörhead, een ongebruikelijke combinatie die een van Ozzy's meest tedere nummers opleverde. Het nummer was geschreven voor Ozzy's vrouw Sharon als verontschuldiging voor zijn jarenlange drugsmisbruik en grillige gedrag. Het akoestische gitaarintro van Zakk Wylde werd een van de meest herkenbare rockballads uit de jaren 90.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM19100017",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/911604139",
+        "de": "applemusic://track/911557410",
+        "gb": "applemusic://track/911604139",
+        "fr": "applemusic://track/911604139",
+        "es": "applemusic://track/911604139",
+        "nl": "applemusic://track/911604139",
+        "it": "applemusic://track/911604139"
+      }
     },
     {
       "year": 1980,
@@ -4820,7 +6180,17 @@
       "uri_tidal": "tidal://track/35986111",
       "uri_deezer": "deezer://track/92720048",
       "fun_fact_nl": "You Shook Me All Night Long was de eerste AC/DC-single met Brian Johnson na de dood van Bon Scott. Angus Young schreef de riff en Malcolm Young verfijnde hem. Het nauwgezette productieproces van producer Mutt Lange maakte de band gek - naar verluidt liet hij hen de gitaarpartijen honderden keren opnemen. Het werd AC/DC's eerste Amerikaanse Top 40-hit.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "AUAP08000047",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/576003085",
+        "de": "applemusic://track/576003085",
+        "gb": "applemusic://track/576003085",
+        "fr": "applemusic://track/576003085",
+        "es": "applemusic://track/576003085",
+        "nl": "applemusic://track/576003085",
+        "it": "applemusic://track/576003085"
+      }
     },
     {
       "year": 1987,
@@ -4853,7 +6223,17 @@
       "uri_tidal": "tidal://track/90822279",
       "uri_deezer": "deezer://track/518458092",
       "fun_fact_nl": "Slash schreef de hoofdriff terwijl hij wat aan het rommelen was op gitaar tijdens een jamsessie. Axl Rose schreef de tekst geïnspireerd door een ontmoeting met een dakloze man in New York City die hem vertelde 'Weet je waar je bent? Je bent in de jungle, baby!' Het nummer was aanvankelijk een commerciële mislukking, maar kreeg enorme bekendheid toen MTV de video vertoonde, waardoor zowel de band als het Appetite for Destruction album werden gelanceerd.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USGF18714801",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1377826728",
+        "de": "applemusic://track/1377826728",
+        "gb": "applemusic://track/1377826728",
+        "fr": "applemusic://track/1377826728",
+        "es": "applemusic://track/1377826728",
+        "nl": "applemusic://track/1377826728",
+        "it": "applemusic://track/1377826728"
+      }
     },
     {
       "year": 1984,
@@ -4885,7 +6265,17 @@
       "uri_tidal": "tidal://track/111052685",
       "uri_deezer": "deezer://track/3807039752",
       "fun_fact_nl": "De iconische openingsriff werd geschreven door gitarist Rudolf Schenker met behulp van een Gibson Flying V. De tekst werd eigenlijk geschreven door een externe songwriter, Herman Rarebell, de drummer van de band, wat ongebruikelijk was voor de Scorpions. Het nummer haalde bijna het album 'Love at First Sting' niet, maar producer Dieter Dierks stond erop om het op te nemen. Het werd internationaal het signatuurnummer van de Scorpions.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USPR38430331",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1624147676",
+        "de": null,
+        "gb": null,
+        "fr": null,
+        "es": null,
+        "nl": null,
+        "it": null
+      }
     },
     {
       "year": 1965,
@@ -4932,7 +6322,17 @@
       "awards_nl": [
         "Grammy Hall of Fame (1998)",
         "Rolling Stone – #2 Beste Nummer Aller Tijden"
-      ]
+      ],
+      "isrc": "USA176510160",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1623247613",
+        "de": "applemusic://track/1706561182",
+        "gb": "applemusic://track/1706561182",
+        "fr": "applemusic://track/1706561182",
+        "es": "applemusic://track/1706561182",
+        "nl": "applemusic://track/1706561182",
+        "it": "applemusic://track/1706561182"
+      }
     },
     {
       "year": 1993,
@@ -4964,7 +6364,17 @@
       "uri_tidal": "tidal://track/99179014",
       "uri_deezer": "deezer://track/588236412",
       "fun_fact_nl": "Mary Jane's Last Dance was een van de laatste nummers opgenomen met de originele bezetting van de Heartbreakers. De videoclip, met Kim Basinger als een mooi lijk, was controversieel maar won de MTV VMA voor Beste Mannelijke Video. Tom Petty heeft verklaard dat het nummer eigenlijk niet over marihuana gaat, ondanks de 'Mary Jane' verwijzing - het gaat over een meisje dat Indiana verlaat voor een beter leven in Californië.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMC19341704",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/6762963005",
+        "de": "applemusic://track/6762963005",
+        "gb": "applemusic://track/6762963005",
+        "fr": "applemusic://track/6762963005",
+        "es": "applemusic://track/6762963005",
+        "nl": "applemusic://track/6762963005",
+        "it": "applemusic://track/6762963005"
+      }
     },
     {
       "year": 1991,
@@ -5039,7 +6449,17 @@
       "uri_tidal": "tidal://track/2893727",
       "uri_deezer": "deezer://track/355108531",
       "fun_fact_nl": "Billy Idol schreef White Wedding over het jachtgeweerhuwelijk van zijn zus - ze was toen zwanger, vandaar het sarcastische 'mooie dag voor een witte bruiloft'. De iconische 'Hey little sister!' hook en de doordringende gitaar van Steve Stevens maakten het een bepalende vroege MTV-hit. De donkere, gotische beelden van de video hielpen de visuele taal van de muziekvideo's uit de jaren 80 te vestigen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USCH30100008",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1767078985",
+        "de": "applemusic://track/1767078985",
+        "gb": "applemusic://track/1767078985",
+        "fr": "applemusic://track/1767078985",
+        "es": "applemusic://track/1767078985",
+        "nl": "applemusic://track/1767078985",
+        "it": "applemusic://track/1767078985"
+      }
     },
     {
       "year": 1970,
@@ -5071,7 +6491,17 @@
       "uri_tidal": "tidal://track/77701512",
       "uri_deezer": "deezer://track/883644",
       "fun_fact_nl": "John Fogerty heeft verklaard dat Have You Ever Seen the Rain gaat over de interne spanningen die Creedence Clearwater Revival uit elkaar scheurden op het hoogtepunt van hun succes. De 'regen' metafoor staat voor het ongeluk tijdens een schijnbaar zonnige periode. Ondanks de ontbinding van de band kort daarna, werd het nummer een van de meest gecoverde nummers in de rockgeschiedenis, met versies in tientallen talen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USC4R0817643",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1697990054",
+        "de": "applemusic://track/1697990054",
+        "gb": "applemusic://track/1697990054",
+        "fr": "applemusic://track/1697990054",
+        "es": "applemusic://track/1697990054",
+        "nl": "applemusic://track/1697990054",
+        "it": "applemusic://track/1697990054"
+      }
     },
     {
       "year": 1981,
@@ -5104,7 +6534,17 @@
       "uri_tidal": "tidal://track/55172078",
       "uri_deezer": "deezer://track/134036212",
       "fun_fact_nl": "De legendarische drumvulling op 3:40 is een van de meest herkenbare momenten in de popmuziek. Collins schreef het nummer tijdens zijn pijnlijke scheiding en stopte rauwe emotie in de tekst. Stadslegendes beweerden ten onrechte dat het over een verdrinking ging, maar Collins heeft dit 'een prachtig verhaal dat niet waar is' genoemd. Het nummer kreeg virale bekendheid in 2007 toen een video van een peuter die reageerde op de drumvulling viral ging.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USAT21502121",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1076060806",
+        "de": "applemusic://track/1076060806",
+        "gb": "applemusic://track/1076060806",
+        "fr": "applemusic://track/1076060806",
+        "es": "applemusic://track/1076060806",
+        "nl": "applemusic://track/1076060806",
+        "it": "applemusic://track/1076060806"
+      }
     },
     {
       "year": 1994,
@@ -5136,7 +6576,17 @@
       "uri_tidal": "tidal://track/3345775",
       "uri_deezer": "deezer://track/2542120",
       "fun_fact_nl": "Rivers Cuomo schreef Say It Ain't So nadat hij een bierflesje in zijn koelkast had gevonden en vreesde dat zijn stiefvader net zo'n alcoholist was geworden als zijn biologische vader. De intens persoonlijke teksten over de cyclus van alcoholisme in zijn familie werden afgezet tegen een bedrieglijk aanstekelijk powerpop arrangement. Ondanks dat het als single nooit in de Hot 100 kwam, werd het een van de meest duurzame alternatieve rocknummers van de jaren 90.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USGF19962907",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1766556108",
+        "de": "applemusic://track/1766556108",
+        "gb": "applemusic://track/1766556108",
+        "fr": "applemusic://track/1766556108",
+        "es": "applemusic://track/1766556108",
+        "nl": "applemusic://track/1766556108",
+        "it": "applemusic://track/1766556108"
+      }
     },
     {
       "year": 1983,
@@ -5168,7 +6618,17 @@
       "uri_tidal": "tidal://track/3268420",
       "uri_deezer": "deezer://track/5094404",
       "fun_fact_nl": "Sharp Dressed Man maakte deel uit van het enorme Eliminator album van ZZ Top dat hen transformeerde van een bluesrock band in MTV supersterren. De videoclip met de iconische rode 1933 Ford Coupe (de 'Eliminator' auto) en mysterieuze vrouwen werd een vast onderdeel van MTV. Ondanks de legendarische lange baarden van Billy Gibbons en Dusty Hill, is drummer Frank Beard ironisch genoeg het enige lid zonder baard.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USWB11301288",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1728071582",
+        "de": "applemusic://track/1728071582",
+        "gb": "applemusic://track/1728071582",
+        "fr": "applemusic://track/1728071582",
+        "es": "applemusic://track/1728071582",
+        "nl": "applemusic://track/1728071582",
+        "it": "applemusic://track/1728071582"
+      }
     },
     {
       "year": 1977,
@@ -5200,7 +6660,17 @@
       "uri_tidal": "tidal://track/68714364",
       "uri_deezer": "deezer://track/747527",
       "fun_fact_nl": "David Byrne schreef Psycho Killer toen hij studeerde aan de Rhode Island School of Design, geïnspireerd door Norman Bates uit 'Psycho' en de theatrale shockrock van Alice Cooper. Het nummer bevat Franse teksten - 'Qu'est-ce que c'est' en 'Fa-fa-fa-fa-fa' - die Byrne toevoegde om het personage van de moordenaar meer beschaafd en verontrustend te laten lijken. De baslijn van Tina Weymouth wordt beschouwd als een van de beste uit de rockgeschiedenis.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USWB10302417",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/20833655",
+        "de": "applemusic://track/20833655",
+        "gb": "applemusic://track/20833655",
+        "fr": "applemusic://track/20833655",
+        "es": "applemusic://track/20833655",
+        "nl": "applemusic://track/20833655",
+        "it": "applemusic://track/20833655"
+      }
     },
     {
       "year": 1991,
@@ -5232,7 +6702,17 @@
       "uri_tidal": "tidal://track/629055",
       "uri_deezer": "deezer://track/1169677",
       "fun_fact_nl": "Don't Cry was een van de eerste nummers die Axl Rose en Izzy Stradlin samen schreven in 1985, jaren voordat het officieel werd opgenomen. Twee versies werden tegelijkertijd uitgebracht op Use Your Illusion I en II, met identieke muziek maar verschillende teksten. Shannon Hoon van Blind Melon verzorgde de achtergrondzang - het nummer is een van zijn meest opmerkelijke gastoptredens voor zijn dood in 1995.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USGF19141504",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1644782461",
+        "de": "applemusic://track/1644782461",
+        "gb": "applemusic://track/1644782461",
+        "fr": "applemusic://track/1644782461",
+        "es": "applemusic://track/1644782461",
+        "nl": "applemusic://track/1644782461",
+        "it": "applemusic://track/1644782461"
+      }
     },
     {
       "year": 1988,
@@ -5306,7 +6786,17 @@
       "fun_fact_nl": "Master of Puppets gaat over drugsverslaving - de 'meester' is drugs die de gebruiker controleert als een marionet. Het nummer duurt meer dan 8 minuten en werd nooit uitgebracht als single, maar werd wel Metallica's meest geliefde nummer. Het kreeg een enorme opleving in 2022 toen het prominent te horen was in seizoen 4 van 'Stranger Things', met Eddie Munson's gitaarscène die het nummer introduceerde bij een nieuwe generatie.",
       "awards_nl": [
         "Grammy Hall of Fame (2016)"
-      ]
+      ],
+      "isrc": "USEV19900002",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1275600554",
+        "de": null,
+        "gb": null,
+        "fr": null,
+        "es": null,
+        "nl": null,
+        "it": null
+      }
     },
     {
       "year": 1969,
@@ -5338,7 +6828,17 @@
       "uri_tidal": "tidal://track/55130631",
       "uri_deezer": "deezer://track/116348452",
       "fun_fact_nl": "John Lennon schreef Come Together oorspronkelijk als campagnelied voor Timothy Leary's gouverneursschap in Californië. De tekst is opzettelijk surrealistisch en onzinnig, Lennon gaf later toe dat hij probeerde een lied te schrijven zonder echte betekenis. De baslijn van Paul McCartney wordt beschouwd als een van zijn beste. Uitgever Morris Levy klaagde Lennon aan voor het lenen van Chuck Berry's 'You Can't Catch Me'.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBUM71903329",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1474833784",
+        "de": "applemusic://track/1474833784",
+        "gb": "applemusic://track/1474833784",
+        "fr": "applemusic://track/1474833784",
+        "es": "applemusic://track/1474833784",
+        "nl": "applemusic://track/1474833784",
+        "it": "applemusic://track/1474833784"
+      }
     },
     {
       "year": 1970,
@@ -5370,7 +6870,17 @@
       "uri_tidal": "tidal://track/142390310",
       "uri_deezer": "deezer://track/1051986",
       "fun_fact_nl": "American Woman werd live geïmproviseerd op het podium in Kitchener, Ontario toen gitarist Randy Bachman een snaar brak en een nieuwe riff begon te jammen terwijl zijn gitaar opnieuw werd bespannen. Het publiek ging uit zijn dak, dus besloot de band om er een volledig nummer van te maken. Ondanks dat het een Canadees nummer is, werd het vanwege het anti-Amerikaanse sentiment (kritiek op de Vietnamoorlog) verbannen uit het Witte Huis tijdens de regering-Nixon.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USRC16908370",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/307552725",
+        "de": "applemusic://track/303189384",
+        "gb": "applemusic://track/207168751",
+        "fr": "applemusic://track/207168751",
+        "es": "applemusic://track/207168751",
+        "nl": "applemusic://track/207168751",
+        "it": "applemusic://track/207168751"
+      }
     },
     {
       "year": 1970,
@@ -5455,7 +6965,17 @@
       "fun_fact_nl": "Fly Away werd in één middag geschreven en opgenomen. Lenny Kravitz bedacht de riff tijdens het jammen in zijn thuisstudio en legde alle instrumenten zelf neer. Het nummer werd zijn grootste commerciële hit en werd veel gebruikt in tv-commercials, videospelletjes en soundtracks van films. Het hielp Kravitz' reputatie als moderne classic rock revivalist te verstevigen.",
       "awards_nl": [
         "Grammy – Beste Mannelijke Rock Zangprestatie (2000)"
-      ]
+      ],
+      "isrc": "USVI29800169",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/713510956",
+        "de": "applemusic://track/1807400663",
+        "gb": "applemusic://track/1807400663",
+        "fr": "applemusic://track/1807400663",
+        "es": "applemusic://track/1807400663",
+        "nl": "applemusic://track/1807400663",
+        "it": "applemusic://track/1807400663"
+      }
     },
     {
       "year": 1970,
@@ -5487,7 +7007,17 @@
       "uri_tidal": "tidal://track/32230316",
       "uri_deezer": "deezer://track/77879660",
       "fun_fact_nl": "Black Magic Woman werd oorspronkelijk geschreven en opgenomen door Peter Green van Fleetwood Mac in 1968, maar het was Santana's latin-rock arrangement dat er een wereldwijde hit van maakte. Carlos Santana versmolt het bluesnummer met Afro-Cubaanse ritmes en zijn kenmerkende sustain-zware gitaartoon. De meeste mensen realiseren zich niet dat het een Fleetwood Mac cover is, wat aangeeft hoe definitief Santana het opnieuw heeft uitgevonden.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM17000643",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/897791068",
+        "de": "applemusic://track/471261811",
+        "gb": "applemusic://track/471261811",
+        "fr": "applemusic://track/471261811",
+        "es": "applemusic://track/471261811",
+        "nl": "applemusic://track/471261811",
+        "it": "applemusic://track/471261811"
+      }
     },
     {
       "year": 1978,
@@ -5519,7 +7049,17 @@
       "uri_tidal": "tidal://track/43725534",
       "uri_deezer": "deezer://track/97173550",
       "fun_fact_nl": "Van Halen's versie van You Really Got Me (oorspronkelijk van The Kinks uit 1964) was hun debuutsingle en introduceerde Eddie Van Halen's revolutionaire gitaartechniek aan de wereld. Hardnekkige geruchten beweerden dat Gene Simmons van KISS betaalde voor de originele demo-opnames. Producer Ted Templeman wilde de rauwe live-energie behouden, dus werd het gitaarnummer in slechts één of twee takes opgenomen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USWB11403459",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/976820537",
+        "de": "applemusic://track/984704828",
+        "gb": "applemusic://track/984704828",
+        "fr": "applemusic://track/984704828",
+        "es": "applemusic://track/984704828",
+        "nl": "applemusic://track/984704828",
+        "it": "applemusic://track/984704828"
+      }
     },
     {
       "year": 1976,
@@ -5551,7 +7091,17 @@
       "uri_tidal": "tidal://track/1274623",
       "uri_deezer": "deezer://track/4006895",
       "fun_fact_nl": "Kerry Livgren schreef Carry on Wayward Son tijdens een spirituele crisis en verkende thema's als het zoeken naar de betekenis van het leven. Het complexe arrangement van het nummer, met zijn verschuivende maatsoorten en meerstemmige harmonieën, laat de progressieve rockroots van Kansas zien. Het werd de best verkochte single van de band en werd gebruikt als het onofficiële themalied van de tv-serie 'Supernatural', dat in elke seizoensfinale wordt gespeeld.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM17600874",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/158580367",
+        "de": "applemusic://track/158580367",
+        "gb": "applemusic://track/278787641",
+        "fr": "applemusic://track/278787641",
+        "es": "applemusic://track/278787641",
+        "nl": "applemusic://track/278787641",
+        "it": "applemusic://track/278787641"
+      }
     },
     {
       "year": 1993,
@@ -5584,7 +7134,17 @@
       "uri_tidal": "tidal://track/528417",
       "uri_deezer": "deezer://track/3107395",
       "fun_fact_nl": "Are You Gonna Go My Way werd in slechts 20 minuten geschreven door Lenny Kravitz en Craig Ross. Kravitz speelde de meeste instrumenten op de opname en produceerde het zelf in zijn thuisstudio. De door Hendrix beïnvloede riff en de explosieve energie van het nummer maakten van Kravitz een wereldwijde rockster. De kenmerkende look van de videoclip was geïnspireerd op beelden van rockconcerten uit de jaren '70 en hielp de retro-rock esthetiek van de vroege jaren '90 te definiëren.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USVI29300001",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1890526100",
+        "de": "applemusic://track/1890526100",
+        "gb": "applemusic://track/1890526100",
+        "fr": "applemusic://track/1890526100",
+        "es": "applemusic://track/1890526100",
+        "nl": "applemusic://track/1890526100",
+        "it": "applemusic://track/1890526100"
+      }
     },
     {
       "year": 1970,
@@ -5617,7 +7177,17 @@
       "uri_tidal": "tidal://track/1649005",
       "uri_deezer": "deezer://track/929222",
       "fun_fact_nl": "Paul Rodgers schreef All Right Now achterin een busje na een teleurstellend optreden in Durham waar het publiek nauwelijks reageerde. De band had een upbeat, eenvoudig rocknummer nodig om het publiek in beweging te krijgen. De basriff van Andy Fraser werd een van de meest herkenbare in de rock. Het nummer is alleen al op de Britse radio meer dan 3 miljoen keer gedraaid, waardoor het een van de meest uitgezonden nummers in de geschiedenis van de Britse radio is.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAAN7000001",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1672103256",
+        "de": "applemusic://track/1442430028",
+        "gb": "applemusic://track/1442430028",
+        "fr": "applemusic://track/1442430028",
+        "es": "applemusic://track/1442430028",
+        "nl": "applemusic://track/1442430028",
+        "it": "applemusic://track/1442430028"
+      }
     },
     {
       "year": 1994,
@@ -5665,7 +7235,17 @@
       "awards_nl": [
         "Grammy – Beste Hardrockprestatie (1995)",
         "Grammy – Beste Metalprestatie (1995)"
-      ]
+      ],
+      "isrc": "USAM19400007",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1436558379",
+        "de": "applemusic://track/1528951934",
+        "gb": "applemusic://track/1442404059",
+        "fr": "applemusic://track/1442404059",
+        "es": "applemusic://track/1442404059",
+        "nl": "applemusic://track/1442404059",
+        "it": "applemusic://track/1442404059"
+      }
     },
     {
       "year": 1977,
@@ -5698,7 +7278,17 @@
       "uri_tidal": "tidal://track/482738028",
       "uri_deezer": "deezer://track/461043312",
       "fun_fact_nl": "Bowie werd geïnspireerd toen hij producer Tony Visconti zag zoenen met reservezangeres Antonia Maass bij de Berlijnse Muur. Het stel wist dat bewakers zouden kunnen schieten, waardoor hun kus een daad van verzet werd. De gitaar van Robert Fripp werd opgenomen met drie microfoons op verschillende afstanden, waardoor het nummer een massief, gelaagd geluid kreeg. Het was een commerciële flop bij de release, maar werd Bowie's meest geliefde nummer.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USJT11700015",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1347894092",
+        "de": "applemusic://track/1347894092",
+        "gb": "applemusic://track/1347894092",
+        "fr": "applemusic://track/1347894092",
+        "es": "applemusic://track/1347894092",
+        "nl": "applemusic://track/1347894092",
+        "it": "applemusic://track/1347894092"
+      }
     },
     {
       "year": 1976,
@@ -5731,7 +7321,17 @@
       "uri_tidal": "tidal://track/235629619",
       "uri_deezer": "deezer://track/5885686",
       "fun_fact_nl": "Het nummer is geïnspireerd op de dood van een KISS-fan die omkwam bij een auto-ongeluk op weg naar een KISS-concert. Het intro bevat geluidseffecten van een auto-ongeluk en een radio DJ. Paul Stanley en Bob Ezrin schreven het als het openingsnummer voor Destroyer, waardoor het een van de meest ambitieuze opnames van KISS werd.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USPR37609134",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1590952411",
+        "de": "applemusic://track/1442323421",
+        "gb": "applemusic://track/1590952411",
+        "fr": "applemusic://track/1590952411",
+        "es": "applemusic://track/1590952411",
+        "nl": "applemusic://track/1590952411",
+        "it": "applemusic://track/1590952411"
+      }
     },
     {
       "year": 1970,
@@ -5764,7 +7364,17 @@
       "uri_tidal": "tidal://track/155212756",
       "uri_deezer": "deezer://track/625170",
       "fun_fact_nl": "Het nummer heeft niets te maken met het Marvel-karakter. Tony Iommi bedacht de hoofdriff en Ozzy Osbourne vond het klinken als 'een grote ijzeren kerel die rondloopt'. De zware gitaarslides van Bill Ward zorgen voor de stemachtige intro. Het was Black Sabbaths enige Amerikaanse Billboard Hot 100-hit en kreeg later nieuwe bekendheid door de Marvel Iron Man-films.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USWB11304371",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/787845531",
+        "de": null,
+        "gb": null,
+        "fr": null,
+        "es": null,
+        "nl": null,
+        "it": null
+      }
     },
     {
       "year": 1979,
@@ -5797,7 +7407,17 @@
       "uri_tidal": "tidal://track/3958004",
       "uri_deezer": "deezer://track/2525861",
       "fun_fact_nl": "De gitaarpartij van Andy Summers maakt gebruik van een kenmerkend arpeggiated patroon dat op alle zes snaren wordt gespeeld. Sting schreef de tekst over isolement en de hoop op verbinding - de metafoor van het sturen van een bericht in een fles en verbaasd zijn dat er 'honderd miljard flessen aanspoelen op de kust'. Het was The Police's eerste nummer 1 in Groot-Brittannië.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAAM0201170",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1440744163",
+        "de": "applemusic://track/1440744163",
+        "gb": "applemusic://track/1440744163",
+        "fr": "applemusic://track/1440744163",
+        "es": "applemusic://track/1440744163",
+        "nl": "applemusic://track/1440744163",
+        "it": "applemusic://track/1440744163"
+      }
     },
     {
       "year": 1968,
@@ -5830,7 +7450,17 @@
       "uri_tidal": "tidal://track/3254298",
       "uri_deezer": "deezer://track/4952889",
       "fun_fact_nl": "Dit is een cover van het origineel van Bob Dylan, maar Hendrix' versie werd zo definitief dat Dylan zelf Hendrix' arrangement overnam voor zijn eigen live optredens. Dylan zei: \"Het overweldigde me echt. Hij had zo'n talent, hij kon dingen in een nummer vinden en ze krachtig ontwikkelen. Het was de laatste single die werd uitgebracht tijdens Hendrix' leven.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USQX90900890",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/344803162",
+        "de": "applemusic://track/344803162",
+        "gb": "applemusic://track/344803162",
+        "fr": "applemusic://track/344803162",
+        "es": "applemusic://track/344803162",
+        "nl": "applemusic://track/344803162",
+        "it": "applemusic://track/344803162"
+      }
     },
     {
       "year": 1984,
@@ -5863,7 +7493,17 @@
       "uri_tidal": "tidal://track/24385347",
       "uri_deezer": "deezer://track/15586213",
       "fun_fact_nl": "Ondanks het anthemische refrein is het nummer een bitter protest over de behandeling van Vietnamveteranen. De campagne van Ronald Reagan probeerde het in 1984 te gebruiken als een patriottisch volkslied, waarbij de tekst volledig verkeerd werd begrepen. Springsteen weigerde. Het gelijknamige album stond 84 weken in de Billboard top 10.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM18400406",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1741640193",
+        "de": "applemusic://track/1741640193",
+        "gb": "applemusic://track/1741640193",
+        "fr": "applemusic://track/1741640193",
+        "es": "applemusic://track/1741640193",
+        "nl": "applemusic://track/1741640193",
+        "it": "applemusic://track/1741640193"
+      }
     },
     {
       "year": 1968,
@@ -5896,7 +7536,17 @@
       "uri_tidal": "tidal://track/77612392",
       "uri_deezer": "deezer://track/1175615",
       "fun_fact_nl": "Jack Bruce en Pete Brown schreven de riff nadat ze de hele nacht waren opgebleven bij een concert van Jimi Hendrix. Eric Clapton voegde de volgende dag het gitaarfiguur toe. De iconische dalende riff werd geïnspireerd door het blue note patroon. Het werd Cream's grootste hit en hielp het powertrio format in de rockmuziek te definiëren.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "NLF050490305",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1893202893",
+        "de": "applemusic://track/1893202893",
+        "gb": "applemusic://track/1893202893",
+        "fr": "applemusic://track/1893202893",
+        "es": "applemusic://track/1893202893",
+        "nl": "applemusic://track/1893202893",
+        "it": "applemusic://track/1893202893"
+      }
     },
     {
       "year": 1964,
@@ -5929,7 +7579,17 @@
       "uri_tidal": "tidal://track/69041281",
       "uri_deezer": "deezer://track/3786363902",
       "fun_fact_nl": "Vaak vergeleken met hun eerdere hit 'You Really Got Me,' wordt de agressieve power chord riff van het nummer beschouwd als een voorloper van punk rock en heavy metal. Ray Davies schreef het als een vervolg. The Doors' 'Hello, I Love You' werd later beschuldigd van een te grote gelijkenis, hoewel er geen rechtszaak werd aangespannen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAJE6400007",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1443064237",
+        "de": "applemusic://track/1622186673",
+        "gb": "applemusic://track/1442862773",
+        "fr": "applemusic://track/1622186673",
+        "es": "applemusic://track/1622186673",
+        "nl": "applemusic://track/1622186673",
+        "it": "applemusic://track/1622186673"
+      }
     },
     {
       "year": 2009,
@@ -5962,7 +7622,17 @@
       "uri_tidal": "tidal://track/3083287",
       "uri_deezer": "deezer://track/4195713",
       "fun_fact_nl": "Matt Bellamy schreef het nummer als een oproep tot rebellie tegen politieke apathie en corrupt gezag. De door glamrock beïnvloede riff werd geïnspireerd door Doctor Who en T. Rex. Het nummer werd een stadionhymne en werd veel gebruikt in sportuitzendingen. In de videoclip zijn teddyberen te zien die een revolutie leiden.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAHT1500308",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/992627891",
+        "de": "applemusic://track/992627891",
+        "gb": "applemusic://track/992627891",
+        "fr": "applemusic://track/992627891",
+        "es": "applemusic://track/992627891",
+        "nl": "applemusic://track/992627891",
+        "it": "applemusic://track/992627891"
+      }
     },
     {
       "year": 1992,
@@ -5995,7 +7665,17 @@
       "uri_tidal": "tidal://track/17953421",
       "uri_deezer": "deezer://track/62082829",
       "fun_fact_nl": "Het nummer werd de UK Christmas #1 in 2009 - 17 jaar na de release - dankzij een Facebook-campagne om te voorkomen dat de X Factor-winnaar de toppositie zou krijgen. Er werden die week alleen al 502.000 exemplaren van verkocht. Tom Morello creëerde de gitaarklanken met behulp van een toggle switch-techniek en een inbussleutel op de snaren.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM19200317",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1737564412",
+        "de": "applemusic://track/1737564412",
+        "gb": "applemusic://track/1737564412",
+        "fr": "applemusic://track/1737564412",
+        "es": "applemusic://track/1737564412",
+        "nl": "applemusic://track/1737564412",
+        "it": "applemusic://track/1737564412"
+      }
     },
     {
       "year": 1976,
@@ -6028,7 +7708,17 @@
       "uri_tidal": "tidal://track/33924910",
       "uri_deezer": "deezer://track/1037414",
       "fun_fact_nl": "Tom Scholz nam het hele debuutalbum op in zijn kelderstudio terwijl hij als technicus bij Polaroid werkte. Het label dacht dat de demo's de definitieve opnames waren omdat de geluidskwaliteit zo hoog was. Kurt Cobain gaf toe dat 'Smells Like Teen Spirit' in wezen 'More Than a Feeling' was met de gitaarriff vertraagd.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM17600941",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1737563091",
+        "de": "applemusic://track/1737563091",
+        "gb": "applemusic://track/1737563091",
+        "fr": "applemusic://track/1737563091",
+        "es": "applemusic://track/1737563091",
+        "nl": "applemusic://track/1737563091",
+        "it": "applemusic://track/1737563091"
+      }
     },
     {
       "year": 1977,
@@ -6061,7 +7751,17 @@
       "uri_tidal": "tidal://track/53230853",
       "uri_deezer": "deezer://track/112662184",
       "fun_fact_nl": "Jeff Lynne schreef Mr. Blue Sky nadat twee weken somber Zwitsers weer plotseling overging in zonneschijn. Hij noemde het 'het nummer dat zichzelf schreef'. De vocoderstem die aan het einde 'Mr. Blue Sky' zegt, werd gecreëerd door de zang door een synthesizer te sturen. Het nummer heeft een enorme opleving beleefd door films als Guardians of the Galaxy.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM10015759",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/894170619",
+        "de": "applemusic://track/1609400686",
+        "gb": "applemusic://track/1609400686",
+        "fr": "applemusic://track/1609400686",
+        "es": "applemusic://track/1609400686",
+        "nl": "applemusic://track/1609400686",
+        "it": "applemusic://track/1609400686"
+      }
     },
     {
       "year": 1988,
@@ -6094,7 +7794,17 @@
       "uri_tidal": "tidal://track/1271506",
       "uri_deezer": "deezer://track/555257552",
       "fun_fact_nl": "Het nummer is mede geschreven door Desmond Child en is bewust gemaakt om een hit te worden. De riff leent de stijl van ZZ Top. Het kreeg later een enorme nieuwe bekendheid toen het werd herwerkt als de Sunday Night Football theme song 'Waiting All Day for Sunday Night' op NBC, waarmee Jett's geluid werd geïntroduceerd bij een hele nieuwe generatie.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM10021818",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/190178976",
+        "de": "applemusic://track/1872028149",
+        "gb": "applemusic://track/1872028149",
+        "fr": "applemusic://track/1872028149",
+        "es": "applemusic://track/1872028149",
+        "nl": "applemusic://track/1872028149",
+        "it": "applemusic://track/1872028149"
+      }
     },
     {
       "year": 1975,
@@ -6127,7 +7837,17 @@
       "uri_tidal": "tidal://track/3050997",
       "uri_deezer": "deezer://track/2258092517",
       "fun_fact_nl": "De albumversie is meer dan 8 minuten lang, waardoor het een van de langste nummers is die veel radio airplay heeft gekregen. De single werd ingekort tot 3:54. Het beleefde een enorme opleving als speelbaar nummer in Guitar Hero III, waardoor het nummer bij miljoenen jongere fans werd geïntroduceerd. Het slidegitaarwerk van Rod Price wordt beschouwd als een van de beste in de bluesrock.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USRH10802802",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1246273382",
+        "de": "applemusic://track/1724743999",
+        "gb": "applemusic://track/1724743999",
+        "fr": "applemusic://track/1724743999",
+        "es": "applemusic://track/1724743999",
+        "nl": "applemusic://track/1724743999",
+        "it": "applemusic://track/1724743999"
+      }
     }
   ]
 }

--- a/custom_components/beatify/playlists/motown-soul-classics.json
+++ b/custom_components/beatify/playlists/motown-soul-classics.json
@@ -39,7 +39,17 @@
       "uri_tidal": "tidal://track/109123225",
       "uri_deezer": "deezer://track/729585912",
       "fun_fact_nl": "Een van de eerste Motown-nummers over sociale kwesties, geïnspireerd door de rellen in Detroit in 1967. De kenmerkende opening werd gemaakt met behulp van een primitieve elektronische oscillator.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMO16782638",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1446620788",
+        "de": "applemusic://track/1446620788",
+        "gb": "applemusic://track/1487452248",
+        "fr": "applemusic://track/1446620788",
+        "es": "applemusic://track/1443404862",
+        "nl": "applemusic://track/1446620788",
+        "it": "applemusic://track/1446620788"
+      }
     },
     {
       "year": 1968,
@@ -70,7 +80,17 @@
       "uri_tidal": "tidal://track/77645153",
       "uri_deezer": "deezer://track/132196486",
       "fun_fact_nl": "Motown-hoofd Berry Gordy verwierp aanvankelijk Marvins versie en bracht eerst Gladys Knight's versie uit. Marvin's versie stond 7 weken op #1 en werd Motown's best verkopende single in die tijd.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMO19582697",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1712802276",
+        "de": "applemusic://track/1712802276",
+        "gb": "applemusic://track/1712802276",
+        "fr": "applemusic://track/1712802276",
+        "es": "applemusic://track/1712802276",
+        "nl": "applemusic://track/1712802276",
+        "it": "applemusic://track/1712802276"
+      }
     },
     {
       "year": 1972,
@@ -108,7 +128,17 @@
       "fun_fact_nl": "De volledige albumversie duurt meer dan 12 minuten met zijn iconische baslijn. The Temptations hadden aanvankelijk een hekel aan het nummer omdat het verwees naar een afwezige vader, wat voor sommige leden te dicht bij huis kwam.",
       "awards_nl": [
         "Grammy Award voor Beste R&B Instrumentale Prestatie"
-      ]
+      ],
+      "isrc": "USMO17200080",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1455682770",
+        "de": "applemusic://track/1099293314",
+        "gb": "applemusic://track/1099293314",
+        "fr": "applemusic://track/1099293314",
+        "es": "applemusic://track/1099293314",
+        "nl": "applemusic://track/1099293314",
+        "it": "applemusic://track/1099293314"
+      }
     },
     {
       "year": 1978,
@@ -139,7 +169,17 @@
       "uri_tidal": "tidal://track/592286",
       "uri_deezer": "deezer://track/2177873",
       "fun_fact_nl": "Lionel Richie schreef het nadat hij zijn vader met zijn moeder had zien dansen op het verjaardagsfeestje van zijn ouders. Het was Motown's best verkopende single in het Verenigd Koninkrijk in die tijd.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMO17800286",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1700307658",
+        "de": "applemusic://track/1700307658",
+        "gb": "applemusic://track/1700307658",
+        "fr": "applemusic://track/1700307658",
+        "es": "applemusic://track/1700307658",
+        "nl": "applemusic://track/1700307658",
+        "it": "applemusic://track/1700307658"
+      }
     },
     {
       "year": 1965,
@@ -168,7 +208,17 @@
       "uri_tidal": "tidal://track/84236373",
       "uri_deezer": "deezer://track/3051164",
       "fun_fact_nl": "Alom beschouwd als een van de beste liedjes ooit geschreven. John Lennon noemde Smokey Robinson 'Amerika's grootste levende dichter'. Het nummer werd in 1998 opgenomen in de Grammy Hall of Fame.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMO16572026",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1440720609",
+        "de": "applemusic://track/1440720609",
+        "gb": "applemusic://track/1440720609",
+        "fr": "applemusic://track/1440720609",
+        "es": "applemusic://track/1440720609",
+        "nl": "applemusic://track/1442674083",
+        "it": "applemusic://track/1440720609"
+      }
     },
     {
       "year": 1961,
@@ -199,7 +249,17 @@
       "uri_tidal": "tidal://track/2175933",
       "uri_deezer": "deezer://track/3051068",
       "fun_fact_nl": "De eerste #1 pophit van Motown. De Beatles coverden het in 1963 en de Carpenters brachten hun versie naar #1 in 1975, waardoor het een van de weinige nummers is die twee keer #1 werd.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMO16100266",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1892514452",
+        "de": "applemusic://track/1442570169",
+        "gb": "applemusic://track/1442570169",
+        "fr": "applemusic://track/1442570169",
+        "es": "applemusic://track/1442570169",
+        "nl": "applemusic://track/1442570169",
+        "it": "applemusic://track/1442570169"
+      }
     },
     {
       "year": 1965,
@@ -230,7 +290,17 @@
       "uri_tidal": "tidal://track/77641490",
       "uri_deezer": "deezer://track/1582310",
       "fun_fact_nl": "Geschreven door het legendarische Holland-Dozier-Holland team. Het verdrong 'Satisfaction' van de Rolling Stones van de #1 positie. De titel van het nummer kwam van de gewoonte van de schrijvers om mensen 'sugar pie' en 'honey bunch' te noemen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMO16582593",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1689685924",
+        "de": "applemusic://track/1689685924",
+        "gb": "applemusic://track/1689685924",
+        "fr": "applemusic://track/1689685924",
+        "es": "applemusic://track/1689685924",
+        "nl": "applemusic://track/1689685924",
+        "it": "applemusic://track/1689685924"
+      }
     },
     {
       "year": 1966,
@@ -259,7 +329,17 @@
       "uri_tidal": "tidal://track/30343490",
       "uri_deezer": "deezer://track/907786",
       "fun_fact_nl": "Jimmy was de oudere broer van David Ruffin. Dit werd oorspronkelijk geschreven voor The Spinners maar aan Jimmy gegeven. Het werd een grotere UK-hit op de heruitgave in 1974 en bereikte #4.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMO10400416",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1443825634",
+        "de": "applemusic://track/1443825634",
+        "gb": "applemusic://track/1443264389",
+        "fr": "applemusic://track/1443825634",
+        "es": "applemusic://track/1443825634",
+        "nl": "applemusic://track/1442674273",
+        "it": "applemusic://track/1443825634"
+      }
     },
     {
       "year": 1964,
@@ -290,7 +370,17 @@
       "uri_tidal": "tidal://track/2176323",
       "uri_deezer": "deezer://track/909576",
       "fun_fact_nl": "Geschreven door Marvin Gaye en William 'Mickey' Stevenson. Later werd het een hymne voor burgerrechten en sociale verandering. David Bowie en Mick Jagger coverden het voor Live Aid in 1985.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMO16400446",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1593074332",
+        "de": "applemusic://track/1692701086",
+        "gb": "applemusic://track/1692701086",
+        "fr": "applemusic://track/1692701086",
+        "es": "applemusic://track/1692701086",
+        "nl": "applemusic://track/1692701086",
+        "it": "applemusic://track/1692701086"
+      }
     },
     {
       "year": 1972,
@@ -319,7 +409,17 @@
       "uri_tidal": "tidal://track/2530592",
       "uri_deezer": "deezer://track/1168354",
       "fun_fact_nl": "Oorspronkelijk een countryhit van Kris Kristofferson. Gladys Knight's soulvolle Motown vertolking gaf het nummer een geheel nieuwe dimensie en liet zien hoe Motown genregrenzen kon overschrijden.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMO17100504",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1445094866",
+        "de": "applemusic://track/1445094866",
+        "gb": "applemusic://track/1445094866",
+        "fr": "applemusic://track/1445094866",
+        "es": "applemusic://track/1445094866",
+        "nl": "applemusic://track/1445094866",
+        "it": "applemusic://track/1445094866"
+      }
     },
     {
       "year": 1984,
@@ -350,7 +450,17 @@
       "uri_tidal": "tidal://track/1606827",
       "uri_deezer": "deezer://track/918048",
       "fun_fact_nl": "In de iconische videoclip was een blinde student te zien die het gezicht van Lionel beeldhouwde. De video won meerdere MTV VMA's en werd een van de meest herkenbare clips van de jaren 1980.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMO18390012",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1583983140",
+        "de": "applemusic://track/1583983140",
+        "gb": "applemusic://track/1583983140",
+        "fr": "applemusic://track/1583983140",
+        "es": "applemusic://track/1583983140",
+        "nl": "applemusic://track/1583983140",
+        "it": "applemusic://track/1583983140"
+      }
     },
     {
       "year": 1967,
@@ -379,7 +489,17 @@
       "uri_tidal": "tidal://track/105505610",
       "uri_deezer": "deezer://track/646327092",
       "fun_fact_nl": "Geschreven door het echtpaar Ashford & Simpson. Diana Ross bracht later een soloversie naar #1 in 1970. Tragisch genoeg zakte Tammi Terrell tijdens een concert in 1967 in Marvin's armen als gevolg van een hersentumor.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMO16700534",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1580460836",
+        "de": "applemusic://track/1580460836",
+        "gb": "applemusic://track/1580460836",
+        "fr": "applemusic://track/1580460836",
+        "es": "applemusic://track/1560736101",
+        "nl": "applemusic://track/1580460836",
+        "it": "applemusic://track/1580460836"
+      }
     },
     {
       "year": 1966,
@@ -408,7 +528,17 @@
       "uri_tidal": "tidal://track/35617425",
       "uri_deezer": "deezer://track/2162963",
       "fun_fact_nl": "Oorspronkelijk opgenomen door Marvin Gaye in 1964. Jr. Walker's saxofoon-gedreven versie voegde een grittier, funkier gevoel toe. James Taylor had er later een hit mee in 1975.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMO16684690",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1835535918",
+        "de": "applemusic://track/1835535918",
+        "gb": "applemusic://track/1835535918",
+        "fr": "applemusic://track/1835535918",
+        "es": "applemusic://track/1835535918",
+        "nl": "applemusic://track/1835535918",
+        "it": "applemusic://track/1835535918"
+      }
     },
     {
       "year": 1964,
@@ -437,7 +567,17 @@
       "uri_tidal": "tidal://track/3713681",
       "uri_deezer": "deezer://track/851331012",
       "fun_fact_nl": "Brenda Holloway was een van de eerste West Coast-artiesten die bij Motown werd getekend. Ze werd ontdekt op een DJ-conventie in Los Angeles en was een van de openingsacts tijdens de Amerikaanse tournee van The Beatles in 1965.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMO16482616",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1444216402",
+        "de": "applemusic://track/1444216402",
+        "gb": "applemusic://track/1444216402",
+        "fr": "applemusic://track/1444216402",
+        "es": "applemusic://track/1444216402",
+        "nl": "applemusic://track/1444216402",
+        "it": "applemusic://track/1444216402"
+      }
     },
     {
       "year": 1975,
@@ -468,7 +608,17 @@
       "uri_tidal": "tidal://track/637890",
       "uri_deezer": "deezer://track/4188299",
       "fun_fact_nl": "Oorspronkelijk opgenomen in 1975 maar uitgebracht als single in 1981 om te profiteren van Michael's solosucces. Het bereikte #1 in de UK ondanks dat het maar #55 werd in de US.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMO17500528",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1464882121",
+        "de": "applemusic://track/1445753013",
+        "gb": "applemusic://track/1443295005",
+        "fr": "applemusic://track/1445753013",
+        "es": "applemusic://track/1445753013",
+        "nl": "applemusic://track/1442921374",
+        "it": "applemusic://track/1445753013"
+      }
     },
     {
       "year": 1975,
@@ -506,7 +656,17 @@
       "fun_fact_nl": "Geschreven voor de film 'Mahogany' met Diana Ross in de hoofdrol. Het werd genomineerd voor een Academy Award voor Beste Originele Song. De slogan van de film was 'Succes is niets zonder iemand van wie je houdt om het mee te delen'.",
       "awards_nl": [
         "Oscarnominatie voor Beste Originele Lied"
-      ]
+      ],
+      "isrc": "USMO17500374",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1819076170",
+        "de": "applemusic://track/1612221191",
+        "gb": "applemusic://track/1612221191",
+        "fr": "applemusic://track/1612221191",
+        "es": "applemusic://track/1612221191",
+        "nl": "applemusic://track/1612221191",
+        "it": "applemusic://track/1612221191"
+      }
     },
     {
       "year": 1964,
@@ -537,7 +697,17 @@
       "uri_tidal": "tidal://track/30263941",
       "uri_deezer": "deezer://track/79083540",
       "fun_fact_nl": "Geschreven en geproduceerd door Smokey Robinson. Mary Wells werd de eerste Motown-artiest met een #1 pophit. Ze verliet Motown kort daarna op 21-jarige leeftijd, een beslissing waar ze later spijt van kreeg.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMO16400486",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1708616830",
+        "de": "applemusic://track/1442248772",
+        "gb": "applemusic://track/1442248772",
+        "fr": "applemusic://track/1442248772",
+        "es": "applemusic://track/1442248772",
+        "nl": "applemusic://track/1442248772",
+        "it": "applemusic://track/1442248772"
+      }
     },
     {
       "year": 1971,
@@ -568,7 +738,17 @@
       "uri_tidal": "tidal://track/4020311",
       "uri_deezer": "deezer://track/2277229",
       "fun_fact_nl": "Geproduceerd door Norman Whitfield, die het oorspronkelijk opnam met The Temptations als een albumtrack van 11 minuten. De kortere versie van The Undisputed Truth werd een grotere hit en een culturele toetssteen over bedrog.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMO17100506",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1455682789",
+        "de": "applemusic://track/1455682789",
+        "gb": "applemusic://track/1442720321",
+        "fr": "applemusic://track/1455682789",
+        "es": "applemusic://track/1455682789",
+        "nl": "applemusic://track/1455682789",
+        "it": "applemusic://track/1455682789"
+      }
     },
     {
       "year": 1965,
@@ -599,7 +779,17 @@
       "uri_tidal": "tidal://track/35712402",
       "uri_deezer": "deezer://track/80123580",
       "fun_fact_nl": "De vijfde opeenvolgende nummer 1-hit van The Supremes, waarmee ze hun ongelooflijke Holland-Dozier-Holland overwinningsreeks verlengden. Het weelderige orkestrale arrangement week af van hun eerdere popsound en gaf een hint naar de verfijning die nog zou komen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMO10000452",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1444126325",
+        "de": "applemusic://track/1444211402",
+        "gb": "applemusic://track/1444211402",
+        "fr": "applemusic://track/1444211402",
+        "es": "applemusic://track/1444211402",
+        "nl": "applemusic://track/1444211402",
+        "it": "applemusic://track/1444211402"
+      }
     },
     {
       "year": 1959,
@@ -628,7 +818,17 @@
       "uri_tidal": "tidal://track/2410459",
       "uri_deezer": "deezer://track/2511253",
       "fun_fact_nl": "Een van de allereerste Motown-opnamen en de eerste nationale hit van het label. Mede geschreven door Berry Gordy zelf. The Beatles hebben het gecoverd en zo de invloed van Motown in Groot-Brittannië verspreid.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMO15900265",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1622747820",
+        "de": "applemusic://track/1622747820",
+        "gb": "applemusic://track/1622747820",
+        "fr": "applemusic://track/1622747820",
+        "es": "applemusic://track/1622747820",
+        "nl": "applemusic://track/1622747820",
+        "it": "applemusic://track/1622747820"
+      }
     },
     {
       "year": 1964,
@@ -659,7 +859,17 @@
       "uri_tidal": "tidal://track/93228739",
       "uri_deezer": "deezer://track/729585822",
       "fun_fact_nl": "Geschreven door Smokey Robinson en Ronald White van The Miracles. De leadzang van David Ruffin maakte het tot het kenmerkende nummer van The Temptations. De iconische openingsgitaarriff werd gespeeld door Robert White, één van Motown's Funk Brothers.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMO16490001",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1427749896",
+        "de": "applemusic://track/1475184421",
+        "gb": "applemusic://track/1475184421",
+        "fr": "applemusic://track/1475184421",
+        "es": "applemusic://track/1475184421",
+        "nl": "applemusic://track/1475184421",
+        "it": "applemusic://track/1475184421"
+      }
     },
     {
       "year": 1964,
@@ -690,7 +900,17 @@
       "uri_tidal": "tidal://track/77642589",
       "uri_deezer": "deezer://track/1182497",
       "fun_fact_nl": "De tweede van vijf opeenvolgende #1-hits voor The Supremes, waarmee ze het record van The Beatles op dat moment evenaarden. Het was ook nummer 1 in de UK, waardoor The Supremes de eerste Motown-act waren die de Britse hitlijsten aanvoerden.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMO16400287",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1828775442",
+        "de": "applemusic://track/1828775442",
+        "gb": "applemusic://track/1828775442",
+        "fr": "applemusic://track/1828775442",
+        "es": "applemusic://track/1828775442",
+        "nl": "applemusic://track/1828775442",
+        "it": "applemusic://track/1828775442"
+      }
     },
     {
       "year": 1966,
@@ -721,7 +941,17 @@
       "uri_tidal": "tidal://track/3558047",
       "uri_deezer": "deezer://track/90265961",
       "fun_fact_nl": "Beschouwd als Holland-Dozier-Holland's meesterwerk. De gepassioneerde zang van Levi Stubbs werd beïnvloed door de rauwe uitvoering van Bob Dylan. Phil Collins coverde het later en bereikte #19 in de VS.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMO10119990",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1431076611",
+        "de": "applemusic://track/1431076611",
+        "gb": "applemusic://track/1443161081",
+        "fr": "applemusic://track/1431076611",
+        "es": "applemusic://track/1431076611",
+        "nl": "applemusic://track/1442672643",
+        "it": "applemusic://track/1431076611"
+      }
     },
     {
       "year": 1971,
@@ -759,7 +989,17 @@
       "fun_fact_nl": "Berry Gordy noemde het \"het slechtste wat ik ooit gehoord heb\" en weigerde het uit te brengen. Marvin dreigde nooit meer op te nemen. Het gelijknamige album wordt steevast gerangschikt onder de beste albums aller tijden.",
       "awards_nl": [
         "Grammy Hall of Fame"
-      ]
+      ],
+      "isrc": "USMO17100041",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1472134764",
+        "de": "applemusic://track/1472134764",
+        "gb": "applemusic://track/1472134764",
+        "fr": "applemusic://track/1472134764",
+        "es": "applemusic://track/1472134764",
+        "nl": "applemusic://track/1472134764",
+        "it": "applemusic://track/1472134764"
+      }
     },
     {
       "year": 1967,
@@ -788,7 +1028,17 @@
       "uri_tidal": "tidal://track/28802911",
       "uri_deezer": "deezer://track/2288142",
       "fun_fact_nl": "Opgenomen in 1964 maar pas uitgebracht in 1967. Het nummer is geschreven door Holland-Dozier-Holland en gaat over een vrouw die heimwee heeft naar haar vriend die weg is. Het werd een van de kenmerkende liedjes van de Vandellas.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMO16700280",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1631589119",
+        "de": "applemusic://track/1631589119",
+        "gb": "applemusic://track/1631589119",
+        "fr": "applemusic://track/1631589119",
+        "es": "applemusic://track/1631589119",
+        "nl": "applemusic://track/1631589119",
+        "it": "applemusic://track/1631589119"
+      }
     },
     {
       "year": 1970,
@@ -819,7 +1069,17 @@
       "uri_tidal": "tidal://track/3043932",
       "uri_deezer": "deezer://track/920082",
       "fun_fact_nl": "Het verdrong The Beatles' 'Let It Be' van de nummer 1 positie en markeerde daarmee symbolisch een generatiewissel in de popmuziek. Michael Jackson was net 11 jaar oud toen dit nummer de hitlijsten aanvoerde.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMO17082628",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1586317904",
+        "de": "applemusic://track/1586317904",
+        "gb": "applemusic://track/1586317904",
+        "fr": "applemusic://track/1586317904",
+        "es": "applemusic://track/1586317904",
+        "nl": "applemusic://track/1586317904",
+        "it": "applemusic://track/1586317904"
+      }
     },
     {
       "year": 1970,
@@ -850,7 +1110,17 @@
       "uri_tidal": "tidal://track/80432163",
       "uri_deezer": "deezer://track/788640132",
       "fun_fact_nl": "Een van Gladys Knight's signatuurnummers bij Motown. Zij en The Pips waren een van de meest consistente hitmakers van het label, maar voelden zich vaak overschaduwd door The Supremes en The Temptations.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMO17082654",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1445669557",
+        "de": "applemusic://track/1445669557",
+        "gb": "applemusic://track/1445669557",
+        "fr": "applemusic://track/1445669557",
+        "es": "applemusic://track/1445669557",
+        "nl": "applemusic://track/1445669557",
+        "it": "applemusic://track/1445669557"
+      }
     },
     {
       "year": 1964,
@@ -879,7 +1149,17 @@
       "uri_tidal": "tidal://track/70547017",
       "uri_deezer": "deezer://track/69454992",
       "fun_fact_nl": "Kim Weston was een van de meest veelzijdige zangeressen van Motown, vooral bekend van haar duet 'It Takes Two' met Marvin Gaye. De Doobie Brothers coverden dit nummer later in 1975 en bereikten nummer 11 in de Billboard Hot 100.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMO10500121",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1443843981",
+        "de": "applemusic://track/1443843981",
+        "gb": "applemusic://track/1443843981",
+        "fr": "applemusic://track/1443843981",
+        "es": "applemusic://track/1443843981",
+        "nl": "applemusic://track/1443843981",
+        "it": "applemusic://track/1443843981"
+      }
     },
     {
       "year": 1969,
@@ -910,7 +1190,17 @@
       "uri_tidal": "tidal://track/3678129",
       "uri_deezer": "deezer://track/549282302",
       "fun_fact_nl": "Geschreven door Norman Whitfield en Barrett Strong was dit een van Marvin Gaye's meest vrolijke opnames. Het bereikte #4 in de Billboard Hot 100 en werd een Northern Soul dansvloer favoriet in de UK.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMO19883507",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1452829547",
+        "de": "applemusic://track/1452829547",
+        "gb": "applemusic://track/1452829547",
+        "fr": "applemusic://track/1452829547",
+        "es": "applemusic://track/1452829547",
+        "nl": "applemusic://track/1452829547",
+        "it": "applemusic://track/1452829547"
+      }
     },
     {
       "year": 1985,
@@ -948,7 +1238,17 @@
       "fun_fact_nl": "Een eerbetoon aan Marvin Gaye en Jackie Wilson, die beiden in 1984 overleden. Het was de grootste hit van de Commodores nadat Lionel Richie de groep had verlaten en won de Grammy voor Beste R&B Performance.",
       "awards_nl": [
         "Grammy Award voor Beste R&B-nummer"
-      ]
+      ],
+      "isrc": "USMO18400528",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/6762971076",
+        "de": "applemusic://track/6762971076",
+        "gb": "applemusic://track/6762971076",
+        "fr": "applemusic://track/6762971076",
+        "es": "applemusic://track/6762971076",
+        "nl": "applemusic://track/6762971076",
+        "it": "applemusic://track/6762971076"
+      }
     },
     {
       "year": 1970,
@@ -978,7 +1278,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=51B55OQysj8",
       "uri_deezer": "deezer://track/1563769",
       "fun_fact_nl": "Oorspronkelijk was het een albumtrack uit 1967, maar het werd eerst uitgebracht als single in de UK waar het nummer 1 werd en daarna in de US waar het ook nummer 1 werd. Smokey schreef de tekst voor een melodie die Stevie Wonder had gecomponeerd.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMO17000525",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1440721058",
+        "de": "applemusic://track/1440721058",
+        "gb": "applemusic://track/1440721058",
+        "fr": "applemusic://track/1440721058",
+        "es": "applemusic://track/1440721058",
+        "nl": "applemusic://track/1442672812",
+        "it": "applemusic://track/1440721058"
+      }
     },
     {
       "year": 1970,
@@ -1006,7 +1316,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=kDFFHLrzTDM",
       "uri_deezer": "deezer://track/909629",
       "fun_fact_nl": "Mede geschreven door Stevie Wonder en ook door hem geproduceerd. Dit was de grootste hit van The Spinners tijdens hun Motown-jaren voordat ze naar Atlantic Records verhuisden en nog meer succes hadden.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMO17082642",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1847714064",
+        "de": "applemusic://track/1847714064",
+        "gb": "applemusic://track/1847714064",
+        "fr": "applemusic://track/1847714064",
+        "es": "applemusic://track/1847714064",
+        "nl": "applemusic://track/1847714064",
+        "it": "applemusic://track/1847714064"
+      }
     },
     {
       "year": 1966,
@@ -1034,7 +1354,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=bjAdfZp8mWw",
       "uri_deezer": "deezer://track/3051037",
       "fun_fact_nl": "Dit stuwende R&B-nummer, geschreven door Holland-Dozier-Holland, liet de rauwe saxofoonstijl van Jr. Walker horen. Het nummer was een van de ruigere, meer rockachtige nummers in de Motown-catalogus.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMO16500012",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1611669578",
+        "de": "applemusic://track/1611669578",
+        "gb": "applemusic://track/1611669578",
+        "fr": "applemusic://track/1611669578",
+        "es": "applemusic://track/1611669578",
+        "nl": "applemusic://track/1611669578",
+        "it": "applemusic://track/1611669578"
+      }
     },
     {
       "year": 1977,
@@ -1071,7 +1401,17 @@
       "fun_fact_nl": "Oorspronkelijk opgenomen door Harold Melvin & the Blue Notes. Thelma Houston's discoversie werd haar enige nummer 1-hit. Ze won de Grammy voor Best R&B Female Vocal Performance voor deze opname.",
       "awards_nl": [
         "Grammy Award voor Beste R&B Zangprestatie"
-      ]
+      ],
+      "isrc": "USMO17600547",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1708519509",
+        "de": "applemusic://track/1708519509",
+        "gb": "applemusic://track/1708519509",
+        "fr": "applemusic://track/1708519509",
+        "es": "applemusic://track/1708519509",
+        "nl": "applemusic://track/1708519509",
+        "it": "applemusic://track/1708519509"
+      }
     },
     {
       "year": 1964,
@@ -1099,7 +1439,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=w0OFTebIuUY",
       "uri_deezer": "deezer://track/729585812",
       "fun_fact_nl": "The Velvelettes waren een van Motown's ondergewaardeerde meidengroepen uit Kalamazoo, Michigan. Ze werden ontdekt door Motown A&R man Mickey Stevenson en namen verschillende Northern Soul favorieten op.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMO16400470",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1555749765",
+        "de": "applemusic://track/1452187833",
+        "gb": "applemusic://track/1452187833",
+        "fr": "applemusic://track/1442830284",
+        "es": "applemusic://track/1452187833",
+        "nl": "applemusic://track/1452187833",
+        "it": "applemusic://track/1452187833"
+      }
     },
     {
       "year": 1975,
@@ -1129,7 +1479,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=hNAZxdyQFEY",
       "uri_deezer": "deezer://track/549326392",
       "fun_fact_nl": "De grootste hit van The Miracles, maar hij kwam nadat Smokey Robinson de groep had verlaten. Billy Griffin nam het over als leadzanger en bracht een moderner funk-disco geluid naar de groep.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USUMG0000284",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1455560518",
+        "de": "applemusic://track/1471566080",
+        "gb": "applemusic://track/1443357712",
+        "fr": "applemusic://track/1471566080",
+        "es": "applemusic://track/1442463684",
+        "nl": "applemusic://track/1471566080",
+        "it": "applemusic://track/1471566080"
+      }
     },
     {
       "year": 1968,
@@ -1166,7 +1526,17 @@
       "fun_fact_nl": "Dit nummer, geschreven door Burt Bacharach en Hal David, werd een van Dionne Warwick's meest bekende nummers en won de Grammy voor Best Contemporary Pop Vocal Performance. Hoewel het geen Motown-opname is, staat het in deze Spotify-afspeellijst naast de Motown-klassiekers.",
       "awards_nl": [
         "Grammy Award voor Beste Hedendaagse Pop Zangprestatie"
-      ]
+      ],
+      "isrc": "USWSP0000033",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1801727260",
+        "de": "applemusic://track/1801727260",
+        "gb": "applemusic://track/1801727260",
+        "fr": "applemusic://track/1801727260",
+        "es": "applemusic://track/1801727260",
+        "nl": "applemusic://track/1801727260",
+        "it": "applemusic://track/1801727260"
+      }
     },
     {
       "year": 1991,
@@ -1196,7 +1566,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=OFCF0u-xc1Q",
       "uri_deezer": "deezer://track/3126330",
       "fun_fact_nl": "De iconische fluittoon van Minnie Riperton maakte dit een van de meest herkenbare nummers van de jaren 1970. Stevie Wonder co-produceerde het album en speelde keyboards. Het gezang van de vogels op de opname was echt, buiten de studio opgenomen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMO19190010",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1444166661",
+        "de": "applemusic://track/1444166661",
+        "gb": "applemusic://track/1444166661",
+        "fr": "applemusic://track/1444166661",
+        "es": "applemusic://track/1444166661",
+        "nl": "applemusic://track/1444166661",
+        "it": "applemusic://track/1444166661"
+      }
     },
     {
       "year": 1979,
@@ -1226,7 +1606,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=RlERDQepZqE",
       "uri_deezer": "deezer://track/7292582",
       "fun_fact_nl": "Uit de film 'Fast Break. Syreeta Wright was de ex-vrouw van Stevie Wonder en een getalenteerde songwriter. Billy Preston stond bekend als de 'Vijfde Beatle' voor zijn werk met The Beatles.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMO17900482",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1444036714",
+        "de": "applemusic://track/1413946617",
+        "gb": "applemusic://track/1413946617",
+        "fr": "applemusic://track/1413946617",
+        "es": "applemusic://track/1413946617",
+        "nl": "applemusic://track/1413946617",
+        "it": "applemusic://track/1413946617"
+      }
     },
     {
       "year": 1972,
@@ -1256,7 +1646,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=uhNnlD3uNS0",
       "uri_deezer": "deezer://track/1761452667",
       "fun_fact_nl": "Een cover van de doo-wop klassieker van Shep and the Limelites uit 1961. Het was Jermaine's eerste grote solohit toen hij nog bij The Jackson 5 hoorde. Hij bleef bij Motown toen zijn broers naar Epic Records vertrokken.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMO17282642",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1444221439",
+        "de": "applemusic://track/1444221439",
+        "gb": "applemusic://track/1444221439",
+        "fr": "applemusic://track/1444221439",
+        "es": "applemusic://track/1444221439",
+        "nl": "applemusic://track/1442913723",
+        "it": "applemusic://track/1444221439"
+      }
     },
     {
       "year": 1983,
@@ -1286,7 +1686,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=nqAvFx3NxUM",
       "uri_deezer": "deezer://track/920062",
       "fun_fact_nl": "Het 'Afrikaanse' gezang in het nummer ('Tom bo li de say de moi ya') is eigenlijk verzonnen taal. Lionel raadpleegde Afrikaanse studenten van zijn alma mater Tuskegee University voor authentiek klinkende lettergrepen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMO10110144",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1445751851",
+        "de": "applemusic://track/1445751851",
+        "gb": "applemusic://track/1445751851",
+        "fr": "applemusic://track/1445751851",
+        "es": "applemusic://track/1445751851",
+        "nl": "applemusic://track/1445751851",
+        "it": "applemusic://track/1445751851"
+      }
     },
     {
       "year": 1969,
@@ -1316,7 +1726,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=6NWhFo3B8Q0",
       "uri_deezer": "deezer://track/4188287",
       "fun_fact_nl": "De debuutsingle van The Jackson 5 en hun eerste van vier opeenvolgende #1-hits. Michael was pas 11 jaar oud. De baslijn, gespeeld door Wilton Felder, wordt beschouwd als een van de beste uit de popgeschiedenis.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMO19400306",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1709698020",
+        "de": "applemusic://track/1709698020",
+        "gb": "applemusic://track/1709698020",
+        "fr": "applemusic://track/1709698020",
+        "es": "applemusic://track/1709698020",
+        "nl": "applemusic://track/1709698020",
+        "it": "applemusic://track/1709698020"
+      }
     },
     {
       "year": 1966,
@@ -1346,7 +1766,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=ovoBi3pXD_A",
       "uri_deezer": "deezer://track/79621446",
       "fun_fact_nl": "Phil Collins coverde het in 1982 en bracht het ook naar #1. Het nummer heeft de klassieke Holland-Dozier-Holland productie met zijn stuwende beat en call-and-response zang.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMO16600346",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1692700539",
+        "de": "applemusic://track/1692700539",
+        "gb": "applemusic://track/1692700539",
+        "fr": "applemusic://track/1692700539",
+        "es": "applemusic://track/1692700539",
+        "nl": "applemusic://track/1692700539",
+        "it": "applemusic://track/1692700539"
+      }
     },
     {
       "year": 1966,
@@ -1374,7 +1804,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=M1xIQmTious",
       "uri_deezer": "deezer://track/119828116",
       "fun_fact_nl": "Geschreven door Holland-Dozier-Holland. Het werd een grotere hit in het Verenigd Koninkrijk bij een heruitgave in 1968 en opnieuw toen Rod Stewart een duetversie opnam met Ronald Isley in 1990.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMO16600488",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1444044792",
+        "de": "applemusic://track/1444044792",
+        "gb": "applemusic://track/1418049753",
+        "fr": "applemusic://track/1444044792",
+        "es": "applemusic://track/1444044792",
+        "nl": "applemusic://track/1444044792",
+        "it": "applemusic://track/1444044792"
+      }
     },
     {
       "year": 1968,
@@ -1402,7 +1842,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=9gHztMbTGe0",
       "uri_deezer": "deezer://track/90265967",
       "fun_fact_nl": "Een cover van de folkklassieker van Tim Hardin, door de krachtige zang van Levi Stubbs omgetoverd tot een soulmeesterwerk. Bobby Darins versie was twee jaar eerder al een hit.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMO16700448",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1452998434",
+        "de": "applemusic://track/1443092702",
+        "gb": "applemusic://track/1443092702",
+        "fr": "applemusic://track/1443092702",
+        "es": "applemusic://track/1443092702",
+        "nl": "applemusic://track/1443092702",
+        "it": "applemusic://track/1443092702"
+      }
     },
     {
       "year": 1962,
@@ -1432,7 +1882,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=ZiftWZnyzB4",
       "uri_deezer": "deezer://track/909565",
       "fun_fact_nl": "Oorspronkelijk geschreven voor The Temptations maar die konden niet gevonden worden toen het tijd was om op te nemen. Het kwam opnieuw de hitlijsten binnen in 1988 nadat het te zien was in de film 'Dirty Dancing'.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMO16200263",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1634846367",
+        "de": "applemusic://track/1634846367",
+        "gb": "applemusic://track/1634846367",
+        "fr": "applemusic://track/1634846367",
+        "es": "applemusic://track/1634846367",
+        "nl": "applemusic://track/1634846367",
+        "it": "applemusic://track/1634846367"
+      }
     },
     {
       "year": 1973,
@@ -1462,7 +1922,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=AqPBfbLoF_M",
       "uri_deezer": "deezer://track/906616",
       "fun_fact_nl": "Een van de meest iconische liefdesliedjes ooit opgenomen. Marvin werd geïnspireerd door zijn ontmoeting met Janis Hunter, die zijn tweede vrouw zou worden. De openingsnoten behoren tot de meest herkenbare in de muziekgeschiedenis.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMO19290019",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/415753587",
+        "de": "applemusic://track/415753587",
+        "gb": "applemusic://track/415753587",
+        "fr": "applemusic://track/415753587",
+        "es": "applemusic://track/415753587",
+        "nl": "applemusic://track/1442673174",
+        "it": "applemusic://track/415753587"
+      }
     },
     {
       "year": 1981,
@@ -1499,7 +1969,17 @@
       "fun_fact_nl": "Stond 9 weken op #1, waarmee het destijds de meest succesvolle Motown-single ooit was. Geschreven voor Franco Zeffirelli's gelijknamige film. Het werd ook genomineerd voor een Academy Award.",
       "awards_nl": [
         "Oscarnominatie voor Beste Originele Lied"
-      ]
+      ],
+      "isrc": "USMO18190008",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1606057197",
+        "de": "applemusic://track/1452232446",
+        "gb": "applemusic://track/1452232446",
+        "fr": "applemusic://track/1452232446",
+        "es": "applemusic://track/1452232446",
+        "nl": "applemusic://track/1452232446",
+        "it": "applemusic://track/1452232446"
+      }
     },
     {
       "year": 1972,
@@ -1536,7 +2016,17 @@
       "fun_fact_nl": "Een liefdesliedje over een rat, uit de horrorfilm 'Ben. Michael was pas 14 toen het zijn eerste nummer 1 solohit werd. Het werd genomineerd voor een Academy Award voor Best Original Song.",
       "awards_nl": [
         "Oscarnominatie voor Beste Originele Lied"
-      ]
+      ],
+      "isrc": "USMO17282631",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1445242536",
+        "de": "applemusic://track/1445242536",
+        "gb": "applemusic://track/1445242536",
+        "fr": "applemusic://track/1445242536",
+        "es": "applemusic://track/1445242536",
+        "nl": "applemusic://track/1445242536",
+        "it": "applemusic://track/1445242536"
+      }
     },
     {
       "year": 1965,
@@ -1564,7 +2054,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=QBXoH53ObYo",
       "uri_deezer": "deezer://track/3051166",
       "fun_fact_nl": "De Rolling Stones coverden het op hun live-album 'Still Life' uit 1982. Het nummer geeft perfect de opwinding van het nachtleven van de jaren 60 weer en werd een favoriet voor de Northern Soul dansvloer.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMO16582608",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1442732598",
+        "de": "applemusic://track/1442732598",
+        "gb": "applemusic://track/1442732598",
+        "fr": "applemusic://track/1442732598",
+        "es": "applemusic://track/1442732598",
+        "nl": "applemusic://track/1442732598",
+        "it": "applemusic://track/1442732598"
+      }
     },
     {
       "year": 1966,
@@ -1594,7 +2094,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=pi00f6oiMu4",
       "uri_deezer": "deezer://track/78932931",
       "fun_fact_nl": "Vanilla Fudge maakte er een psychedelisch rockepos van en Kim Wilde bracht het terug naar #1 in 1987. De dringende gitaarriff van het nummer werd gespeeld door Funk Brothers gitarist Eddie Willis.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMO16682616",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1443222812",
+        "de": "applemusic://track/1443222812",
+        "gb": "applemusic://track/1443222812",
+        "fr": "applemusic://track/1443222812",
+        "es": "applemusic://track/1443222812",
+        "nl": "applemusic://track/1443222812",
+        "it": "applemusic://track/1443222812"
+      }
     },
     {
       "year": 1965,
@@ -1622,7 +2132,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=EexqF4tz-8U",
       "uri_deezer": "deezer://track/2288113",
       "fun_fact_nl": "Geschreven door Holland-Dozier-Holland. Het nummer is gedeeltelijk opgenomen op een assemblagelijn van Ford auto's in de River Rouge fabriek in Dearborn, Michigan, waarbij de fabrieksgeluiden een unieke percussieve achtergrond vormen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMO10200170",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1833004470",
+        "de": "applemusic://track/1833004470",
+        "gb": "applemusic://track/1443161087",
+        "fr": "applemusic://track/1833004470",
+        "es": "applemusic://track/1833004470",
+        "nl": "applemusic://track/1833004470",
+        "it": "applemusic://track/1833004470"
+      }
     },
     {
       "year": 1973,
@@ -1652,7 +2172,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=UjKwmlH0EJE",
       "uri_deezer": "deezer://track/729586092",
       "fun_fact_nl": "Eddie's grootste solohit na zijn vertrek bij The Temptations. De gladde falsetstem en funky groove hielpen de proto-disco sound te definiëren. De singleversie gaat uit, maar de albumversie duurt meer dan 8 minuten.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMO17384645",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1586018958",
+        "de": "applemusic://track/1586018958",
+        "gb": "applemusic://track/1586018958",
+        "fr": "applemusic://track/1586018958",
+        "es": "applemusic://track/1586018958",
+        "nl": "applemusic://track/1586018958",
+        "it": "applemusic://track/1586018958"
+      }
     },
     {
       "year": 1962,
@@ -1680,7 +2210,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=Us18AUBM2RI",
       "uri_deezer": "deezer://track/3051070",
       "fun_fact_nl": "Geschreven door Marvin Gaye, die toen sessiedrummer was bij Motown. Het telefoonnummer in de titel was volledig fictief, maar fans probeerden het nog jarenlang te bellen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMO16200260",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1459443107",
+        "de": "applemusic://track/1459443107",
+        "gb": "applemusic://track/1459443107",
+        "fr": "applemusic://track/1459443107",
+        "es": "applemusic://track/1459443107",
+        "nl": "applemusic://track/1459443107",
+        "it": "applemusic://track/1459443107"
+      }
     },
     {
       "year": 1969,
@@ -1708,7 +2248,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=yLJ7jk6YBw8",
       "uri_deezer": "deezer://track/1172491",
       "fun_fact_nl": "Davids eerste solosingle nadat hij was ontslagen bij The Temptations vanwege zijn divagedrag. De emotionele titel leek een afspiegeling te zijn van zijn werkelijke situatie toen hij zijn plaats in de groep verloor.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMO16984733",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1444212840",
+        "de": "applemusic://track/1444212840",
+        "gb": "applemusic://track/1444212840",
+        "fr": "applemusic://track/1444212840",
+        "es": "applemusic://track/1444212840",
+        "nl": "applemusic://track/1444212840",
+        "it": "applemusic://track/1444212840"
+      }
     },
     {
       "year": 1981,
@@ -1738,7 +2288,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=0P2a6aLDkkM",
       "uri_deezer": "deezer://track/83919737",
       "fun_fact_nl": "Smokey's grootste solohit en een enorme #1 in de UK, die alleen door 'Bette Davis Eyes' van de Amerikaanse toppositie werd afgehouden. Het liet zien dat Smokey kon gedijen als soloartiest decennia nadat hij Motown mede had opgericht.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMO18100484",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1443807905",
+        "de": "applemusic://track/1704750180",
+        "gb": "applemusic://track/1704750180",
+        "fr": "applemusic://track/1704750180",
+        "es": "applemusic://track/1704750180",
+        "nl": "applemusic://track/1704750180",
+        "it": "applemusic://track/1704750180"
+      }
     },
     {
       "year": 1985,
@@ -1768,7 +2328,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=cAQSZhazYk8",
       "uri_deezer": "deezer://track/75392184",
       "fun_fact_nl": "Uitgelicht in de film 'The Last Dragon', een martial arts-meets-Motown film. DeBarge was een familiegroep die vaak werd vergeleken met The Jacksons. El DeBarge's falsetto trok vergelijkingen met een jonge Michael Jackson.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMO18500526",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1449299031",
+        "de": "applemusic://track/1449299031",
+        "gb": "applemusic://track/1449299031",
+        "fr": "applemusic://track/1449299031",
+        "es": "applemusic://track/1449299031",
+        "nl": "applemusic://track/1449299031",
+        "it": "applemusic://track/1449299031"
+      }
     },
     {
       "year": 1981,
@@ -1798,7 +2368,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=QYHxGBH6o4M",
       "uri_deezer": "deezer://track/543150512",
       "fun_fact_nl": "MC Hammer samplede de baslijn voor 'U Can't Touch This', dat een enorme hit werd. Rick James klaagde hem aanvankelijk aan, maar ze schikten en hij kreeg songwriting credit en royalty's. The Temptations zongen als back-up.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMO18100048",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1440901138",
+        "de": "applemusic://track/1858861411",
+        "gb": "applemusic://track/1443325994",
+        "fr": "applemusic://track/1858861411",
+        "es": "applemusic://track/1858861411",
+        "nl": "applemusic://track/1858861411",
+        "it": "applemusic://track/1858861411"
+      }
     },
     {
       "year": 1984,
@@ -1826,7 +2406,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=CH3rx8LhrQo",
       "uri_deezer": "deezer://track/827456132",
       "fun_fact_nl": "Dennis Edwards was de leadzanger van The Temptations. Het nummer werd een enorme hiphopsamplebron, gebruikt door 2Pac, Eric B. & Rakim en vele anderen. Siedah Garrett schreef later mee aan 'Man in the Mirror' van Michael Jackson.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMO18482582",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/6762971077",
+        "de": "applemusic://track/6762971077",
+        "gb": "applemusic://track/6762971077",
+        "fr": "applemusic://track/6762971077",
+        "es": "applemusic://track/6762971077",
+        "nl": "applemusic://track/6762971077",
+        "it": "applemusic://track/6762971077"
+      }
     },
     {
       "year": 1979,
@@ -1854,7 +2444,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=owiYwYdjgM8",
       "uri_deezer": "deezer://track/646746942",
       "fun_fact_nl": "Oorspronkelijk een hit uit 1966 van The Elgins op Motown. Bonnie Pointer, die The Pointer Sisters verliet voor een solocarrière op Motown, gaf het een discobehandeling die haar grootste solohit werd.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMO10000356",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1430158363",
+        "de": "applemusic://track/1430158363",
+        "gb": "applemusic://track/1430158363",
+        "fr": "applemusic://track/1430158363",
+        "es": "applemusic://track/1430158363",
+        "nl": "applemusic://track/1430158363",
+        "it": "applemusic://track/1430158363"
+      }
     },
     {
       "year": 1967,
@@ -1882,7 +2482,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=DVWH9InLMiA",
       "uri_deezer": "deezer://track/549282272",
       "fun_fact_nl": "Marvin's eerste grote duet hit. Kim Weston verliet Motown kort daarna en Tammi Terrell werd zijn bekendste duetpartner. Het nummer werd later gecoverd door Rod Stewart en Tina Turner in 1990.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMO19582687",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1431076615",
+        "de": "applemusic://track/1431076615",
+        "gb": "applemusic://track/1431076615",
+        "fr": "applemusic://track/1431076615",
+        "es": "applemusic://track/1431076615",
+        "nl": "applemusic://track/1442674064",
+        "it": "applemusic://track/1431076615"
+      }
     },
     {
       "year": 1969,
@@ -1910,7 +2520,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=qTkt1j_y9JQ",
       "uri_deezer": "deezer://track/1169751",
       "fun_fact_nl": "Een enorme hit in de UK's Northern Soul scene, die #5 bereikte in de UK charts. De Isley Brothers hadden een gecompliceerde relatie met Motown en vertrokken uiteindelijk voor meer creatieve vrijheid bij T-Neck Records.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMO16782704",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1444126112",
+        "de": "applemusic://track/1442506140",
+        "gb": "applemusic://track/1442506140",
+        "fr": "applemusic://track/1442506140",
+        "es": "applemusic://track/1442506140",
+        "nl": "applemusic://track/1442506140",
+        "it": "applemusic://track/1442506140"
+      }
     },
     {
       "year": 1970,
@@ -1938,7 +2558,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=tCsSP33g75s",
       "uri_deezer": "deezer://track/2250172",
       "fun_fact_nl": "Diana's eerste solosingle nadat ze The Supremes verliet. Geschreven door Ashford & Simpson werd het haar signatuur voor concerten, waarbij Diana het publiek in liep om letterlijk handen aan te raken.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMO17000348",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1445748519",
+        "de": "applemusic://track/1877178737",
+        "gb": "applemusic://track/1628612655",
+        "fr": "applemusic://track/1877178737",
+        "es": "applemusic://track/1877178737",
+        "nl": "applemusic://track/1877178737",
+        "it": "applemusic://track/1877178737"
+      }
     },
     {
       "year": 1983,
@@ -1968,7 +2598,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=0353jrboqOc",
       "uri_deezer": "deezer://track/2511336",
       "fun_fact_nl": "Van zijn titelloze debuutalbum. Lionel schreef het als liefdesballade voor zijn eerste vrouw Brenda. Het album produceerde drie top-vijf hits en lanceerde een van de meest succesvolle solocarrières in de popgeschiedenis.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMO10119943",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1700308556",
+        "de": "applemusic://track/1700308556",
+        "gb": "applemusic://track/1700308556",
+        "fr": "applemusic://track/1700308556",
+        "es": "applemusic://track/1700308556",
+        "nl": "applemusic://track/1700308556",
+        "it": "applemusic://track/1700308556"
+      }
     },
     {
       "year": 1971,
@@ -1998,7 +2638,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=Y9cixo-iXAE",
       "uri_deezer": "deezer://track/2718741",
       "fun_fact_nl": "Michael's eerste solosingle toen hij nog lid was van The Jackson 5. Hij was slechts 13 jaar oud. Het nummer liet de emotionele volwassenheid zien die zijn legendarische carrière zou bepalen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMO17100549",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1443842257",
+        "de": "applemusic://track/1443842257",
+        "gb": "applemusic://track/1443842257",
+        "fr": "applemusic://track/1443842257",
+        "es": "applemusic://track/1443842257",
+        "nl": "applemusic://track/1443842257",
+        "it": "applemusic://track/1443842257"
+      }
     },
     {
       "year": 1967,
@@ -2026,7 +2676,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=u_4ghyswYAU",
       "uri_deezer": "deezer://track/593726612",
       "fun_fact_nl": "Mede geschreven door Smokey Robinson en Miracles gitarist Al Cleveland. De zin kwam van een malapropisme dat Cleveland gebruikte in een gesprek, waarbij hij 'I second that emotion' zei in plaats van 'motion'. De Japanse versie bereikte #1 in hun hitlijsten.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMO16782659",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1434893179",
+        "de": "applemusic://track/1434893179",
+        "gb": "applemusic://track/1434893179",
+        "fr": "applemusic://track/1434893179",
+        "es": "applemusic://track/1434893179",
+        "nl": "applemusic://track/1434893179",
+        "it": "applemusic://track/1434893179"
+      }
     },
     {
       "year": 1970,
@@ -2056,7 +2716,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=yM71RwDtEE0",
       "uri_deezer": "deezer://track/646312932",
       "fun_fact_nl": "Oorspronkelijk opgenomen door The Temptations, maar Motown vreesde dat de anti-oorlogsboodschap hun fans van zich zou vervreemden. Edwin Starr's intense versie werd een protestlied uit het Vietnam-tijdperk. Oorlog! Waar is het goed voor? Absoluut niets!' werd een van de meest geciteerde regels in de rockwereld.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMO17000050",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1590208892",
+        "de": "applemusic://track/1442493300",
+        "gb": "applemusic://track/1442493300",
+        "fr": "applemusic://track/1442493300",
+        "es": "applemusic://track/1442493300",
+        "nl": "applemusic://track/1442674469",
+        "it": "applemusic://track/1590208892"
+      }
     },
     {
       "year": 1966,
@@ -2084,7 +2754,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=NhEuFW7l5c4",
       "uri_deezer": "deezer://track/3051141",
       "fun_fact_nl": "Nog zo'n Holland-Dozier-Holland meesterwerk. Het dramatische arrangement van het nummer beïnvloedde de ontwikkeling van Northern Soul en werd gecoverd door artiesten van Rod Stewart tot The Jackson 5.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMO16700452",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1452998338",
+        "de": "applemusic://track/1442413504",
+        "gb": "applemusic://track/1442413504",
+        "fr": "applemusic://track/1442413504",
+        "es": "applemusic://track/1442413504",
+        "nl": "applemusic://track/1442413504",
+        "it": "applemusic://track/1442413504"
+      }
     },
     {
       "year": 1964,
@@ -2112,7 +2792,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=LYxjAXNNzQE",
       "uri_deezer": "deezer://track/1157145",
       "fun_fact_nl": "The Spinners (ook bekend als The Detroit Spinners in het Verenigd Koninkrijk) hadden beperkt succes bij Motown, maar werden later een van de top soulgroepen van de jaren 1970 na hun overstap naar Atlantic Records.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMO19883496",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1452829703",
+        "de": "applemusic://track/1452829703",
+        "gb": "applemusic://track/1452829703",
+        "fr": "applemusic://track/1452829703",
+        "es": "applemusic://track/1452829703",
+        "nl": "applemusic://track/1452829703",
+        "it": "applemusic://track/1452829703"
+      }
     },
     {
       "year": 1964,
@@ -2142,7 +2832,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=NkH_dm9NkxQ",
       "uri_deezer": "deezer://track/909579",
       "fun_fact_nl": "De derde opeenvolgende #1-hit van The Supremes, allemaal geschreven door Holland-Dozier-Holland. Het werd oorspronkelijk aan The Marvelettes gegeven voordat Berry Gordy besloot dat The Supremes het moesten opnemen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMO10000580",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1440645850",
+        "de": "applemusic://track/1452877853",
+        "gb": "applemusic://track/1487452247",
+        "fr": "applemusic://track/1452877853",
+        "es": "applemusic://track/1452877853",
+        "nl": "applemusic://track/1452877853",
+        "it": "applemusic://track/1452877853"
+      }
     },
     {
       "year": 1972,
@@ -2170,7 +2870,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=7T7utl7-ssk",
       "uri_deezer": "deezer://track/102186478",
       "fun_fact_nl": "Valerie Simpson was de helft van het legendarische songwritersduo Ashford & Simpson, die 'Ain't No Mountain High Enough' en vele andere Motown klassiekers schreven. Haar solowerk toonde haar verbluffende zangkwaliteiten.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMO17282667",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1445243494",
+        "de": "applemusic://track/1445243494",
+        "gb": "applemusic://track/1445243494",
+        "fr": "applemusic://track/1445243494",
+        "es": "applemusic://track/1445243494",
+        "nl": "applemusic://track/1445243494",
+        "it": "applemusic://track/1445243494"
+      }
     },
     {
       "year": 1997,
@@ -2200,7 +2910,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=fUSOZAgl95A",
       "uri_deezer": "deezer://track/1101105",
       "fun_fact_nl": "Boyz II Men tekende in 1991 bij Motown, waardoor het label weer relevant werd in de hedendaagse R&B. Dit nummer leverde hen hun vierde nummer 1-hit op, geproduceerd door Jimmy Jam en Terry Lewis.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMO19783234",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1834511848",
+        "de": "applemusic://track/1834511848",
+        "gb": "applemusic://track/1834511848",
+        "fr": "applemusic://track/1834511848",
+        "es": "applemusic://track/1834511848",
+        "nl": "applemusic://track/1834511848",
+        "it": "applemusic://track/1834511848"
+      }
     },
     {
       "year": 1999,
@@ -2288,7 +3008,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=ULBACmcRES0",
       "uri_deezer": "deezer://track/4229486",
       "fun_fact_nl": "Gerald Alston was de leadzanger van The Manhattans voordat hij zijn solocarrière begon op Motown. Zijn soepele tenorstem was perfect geschikt voor romantische ballads in de quiet storm traditie.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMO10000362",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1430161432",
+        "de": "applemusic://track/1430161432",
+        "gb": "applemusic://track/1430161432",
+        "fr": "applemusic://track/1430161432",
+        "es": "applemusic://track/1430161432",
+        "nl": "applemusic://track/1430161432",
+        "it": "applemusic://track/1430161432"
+      }
     },
     {
       "year": 1969,
@@ -2318,7 +3048,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=Eucp9qqKG0o",
       "uri_deezer": "deezer://track/685846772",
       "fun_fact_nl": "Geschreven en geproduceerd door Marvin Gaye, die ook achtergrondvocalen zong. The Originals waren een van Motown's ondergewaardeerde groepen die ook dienden als achtergrondzangers voor andere Motown artiesten.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBQRF0701544",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/581217805",
+        "de": "applemusic://track/581217805",
+        "gb": "applemusic://track/581217805",
+        "fr": "applemusic://track/581217805",
+        "es": "applemusic://track/581217805",
+        "nl": "applemusic://track/581217805",
+        "it": "applemusic://track/581217805"
+      }
     },
     {
       "year": 1966,
@@ -2346,7 +3086,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=dABWW58dR6U",
       "uri_deezer": "deezer://track/7294807",
       "fun_fact_nl": "Geschreven door Smokey Robinson was dit de laatste grote hit van The Marvelettes. De groep had het moeilijk toen Motown meer aandacht besteedde aan The Supremes, maar hun vroege opnamen hielpen de Motown sound te vestigen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMO16500352",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1447558300",
+        "de": "applemusic://track/1447558300",
+        "gb": "applemusic://track/1447558300",
+        "fr": "applemusic://track/1447558300",
+        "es": "applemusic://track/1447558300",
+        "nl": "applemusic://track/1447558300",
+        "it": "applemusic://track/1447558300"
+      }
     },
     {
       "year": 1962,
@@ -2374,7 +3124,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=xyC7QIKQLWU",
       "uri_deezer": "deezer://track/3051160",
       "fun_fact_nl": "The Beatles coverden dit op hun 'With The Beatles'-album, waarmee ze de trans-Atlantische band tussen Motown en de Britse invasie verstevigden. John Lennon was een grote fan van Smokey Robinson.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMO10200800",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1440720604",
+        "de": "applemusic://track/1440720604",
+        "gb": "applemusic://track/1440720604",
+        "fr": "applemusic://track/1440720604",
+        "es": "applemusic://track/1440720604",
+        "nl": "applemusic://track/1440720604",
+        "it": "applemusic://track/1440720604"
+      }
     },
     {
       "year": 1964,
@@ -2402,7 +3162,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=GdIDUsMrmuY",
       "uri_deezer": "deezer://track/7375117",
       "fun_fact_nl": "Dit nummer, mede geschreven door Smokey Robinson en Bobby Rogers, was de eerste grote hit van The Temptations met zijn slimme reeks vergelijkingen. The Temptations namen het opnieuw op met Hall & Oates in 1985 en bereikten #20 in de Billboard Hot 100.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMO19883509",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1452829685",
+        "de": "applemusic://track/1452829685",
+        "gb": "applemusic://track/1452829685",
+        "fr": "applemusic://track/1452829685",
+        "es": "applemusic://track/1452829685",
+        "nl": "applemusic://track/1452829685",
+        "it": "applemusic://track/1452829685"
+      }
     },
     {
       "year": 1980,
@@ -2430,7 +3200,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=m6DK8KFPDN8",
       "uri_deezer": "deezer://track/94196156",
       "fun_fact_nl": "Teena Marie was een van de weinige blanke artiesten van Motown. Rick James ontdekte haar en ze werd aanvankelijk op de markt gebracht zonder haar foto te laten zien, zodat luisteraars haar ras niet zouden kennen. Ze werd bekend als de 'Ivory Queen of Soul'.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMO18082758",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1430158374",
+        "de": "applemusic://track/1430158374",
+        "gb": "applemusic://track/1430158374",
+        "fr": "applemusic://track/1430158374",
+        "es": "applemusic://track/1430158374",
+        "nl": "applemusic://track/1430158374",
+        "it": "applemusic://track/1430158374"
+      }
     },
     {
       "year": 1980,
@@ -2458,7 +3238,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=dxFmU3_VlQM",
       "uri_deezer": "deezer://track/4677577",
       "fun_fact_nl": "Van het 'diana' album geproduceerd door Nile Rodgers en Bernard Edwards van Chic. Het album werd in eerste instantie geremixt door Motown zonder Diana's toestemming, wat een grote controverse veroorzaakte. My Old Piano' was een UK-hit die #5 bereikte.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMO18090043",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1443160118",
+        "de": "applemusic://track/1443160118",
+        "gb": "applemusic://track/1629366657",
+        "fr": "applemusic://track/1443160118",
+        "es": "applemusic://track/1443160118",
+        "nl": "applemusic://track/1442673183",
+        "it": "applemusic://track/1443160118"
+      }
     },
     {
       "year": 1968,
@@ -2486,7 +3276,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=Jz_D-greh8Q",
       "uri_deezer": "deezer://track/1101120",
       "fun_fact_nl": "Geschreven door Ashford & Simpson. Het was een van de laatste nummers die Tammi Terrell opnam voordat haar gezondheid achteruit ging door een hersentumor. Marvin was zo kapot van haar dood in 1970 dat hij zich jarenlang terugtrok van optredens.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMO19582694",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1442681671",
+        "de": "applemusic://track/1418236782",
+        "gb": "applemusic://track/1418236782",
+        "fr": "applemusic://track/1418236782",
+        "es": "applemusic://track/1418236782",
+        "nl": "applemusic://track/1418236782",
+        "it": "applemusic://track/1418236782"
+      }
     },
     {
       "year": 1971,
@@ -2516,7 +3316,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=WNnb1NfLrK4",
       "uri_deezer": "deezer://track/2499099",
       "fun_fact_nl": "Eddie Kendricks' laatste nummer 1 hit met The Temptations voordat hij solo ging. Het dromerige, zwevende arrangement van Norman Whitfield vormde een dramatisch contrast met de recente psychedelische funkrichting van de groep.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMO17100074",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1445082418",
+        "de": "applemusic://track/1445082418",
+        "gb": "applemusic://track/1445082418",
+        "fr": "applemusic://track/1445082418",
+        "es": "applemusic://track/1445082418",
+        "nl": "applemusic://track/1445082418",
+        "it": "applemusic://track/1445082418"
+      }
     },
     {
       "year": 1965,
@@ -2547,7 +3357,17 @@
       "uri_tidal": "tidal://track/101149336",
       "uri_deezer": "deezer://track/723803",
       "fun_fact_nl": "De originele versie uit 1964 van Dionne Warwick wordt beschouwd als een van de beste Burt Bacharach-Hal David composities. Isaac Hayes nam later een 12 minuten durende epische versie op. Hoewel het geen Motown-opname is, staat deze wel in deze Spotify-afspeellijst.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMO10110349",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1446927022",
+        "de": "applemusic://track/1442239127",
+        "gb": "applemusic://track/1442239127",
+        "fr": "applemusic://track/1442239127",
+        "es": "applemusic://track/1442239127",
+        "nl": "applemusic://track/1442491098",
+        "it": "applemusic://track/1446927022"
+      }
     },
     {
       "year": 1979,
@@ -2578,7 +3398,17 @@
       "uri_tidal": "tidal://track/1606843",
       "uri_deezer": "deezer://track/2177863",
       "fun_fact_nl": "Geschreven door Lionel Richie in slechts vijf minuten op de achterkant van een papieren zak. Het was de tweede #1 pophit van de Commodores na 'Three Times a Lady' en hielp Lionel zich te vestigen als een vooraanstaand balladschrijver.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMO17900557",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1444102403",
+        "de": "applemusic://track/1442396334",
+        "gb": "applemusic://track/1444102403",
+        "fr": "applemusic://track/1444102403",
+        "es": "applemusic://track/1444102403",
+        "nl": "applemusic://track/1444102403",
+        "it": "applemusic://track/1444102403"
+      }
     },
     {
       "year": 1974,
@@ -2607,7 +3437,17 @@
       "uri_tidal": "tidal://track/93228540",
       "uri_deezer": "deezer://track/549282262",
       "fun_fact_nl": "Oorspronkelijk een hit uit 1971 van The Stylistics. De Diana Ross en Marvin Gaye duet versie was een grotere hit in de UK en bereikte #5. Hun duet album was eigenlijk samengesteld uit aparte opnamesessies.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMO17300533",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1684775099",
+        "de": "applemusic://track/1684775099",
+        "gb": "applemusic://track/1684775099",
+        "fr": "applemusic://track/1684775099",
+        "es": "applemusic://track/1684775099",
+        "nl": "applemusic://track/1684775099",
+        "it": "applemusic://track/1684775099"
+      }
     },
     {
       "year": 1970,
@@ -2638,7 +3478,17 @@
       "uri_tidal": "tidal://track/33490093",
       "uri_deezer": "deezer://track/4188290",
       "fun_fact_nl": "De vierde opeenvolgende nummer 1-hit van The Jackson 5 en destijds de best verkochte single in de geschiedenis van Motown. Michael's volwassen vocale prestaties op 12-jarige leeftijd verbaasden luisteraars. Mariah Carey coverde het later en bereikte ook #1.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMO17082635",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1608461969",
+        "de": "applemusic://track/1608461969",
+        "gb": "applemusic://track/1608461969",
+        "fr": "applemusic://track/1608461969",
+        "es": "applemusic://track/1608461969",
+        "nl": "applemusic://track/1608461969",
+        "it": "applemusic://track/1608461969"
+      }
     },
     {
       "year": 1964,
@@ -2667,7 +3517,17 @@
       "uri_tidal": "tidal://track/80432158",
       "uri_deezer": "deezer://track/422280272",
       "fun_fact_nl": "Later gecoverd door Bananarama in 1982, die er een UK Top 5 hit van maakten. The Velvelettes kwamen uit Kalamazoo, Michigan en waren één van Motown's meest geliefde maar commercieel slecht presterende meidengroepen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMO16400468",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1445669372",
+        "de": "applemusic://track/1452187494",
+        "gb": "applemusic://track/1452187494",
+        "fr": "applemusic://track/1442830602",
+        "es": "applemusic://track/1443023894",
+        "nl": "applemusic://track/1452187494",
+        "it": "applemusic://track/1452187494"
+      }
     },
     {
       "year": 1962,
@@ -2696,7 +3556,17 @@
       "uri_tidal": "tidal://track/2176253",
       "uri_deezer": "deezer://track/14487481",
       "fun_fact_nl": "Geschreven en geproduceerd door Smokey Robinson, die veel van Mary Wells' grootste hits heeft gemaakt. Mary was de eerste vrouwelijke ster van Motown en hielp de aanwezigheid van het label in de poplijsten te vestigen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMO16200261",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1459442798",
+        "de": "applemusic://track/1459442798",
+        "gb": "applemusic://track/1459442798",
+        "fr": "applemusic://track/1459442798",
+        "es": "applemusic://track/1459442798",
+        "nl": "applemusic://track/1459442798",
+        "it": "applemusic://track/1459442798"
+      }
     },
     {
       "year": 1968,
@@ -2725,7 +3595,17 @@
       "uri_tidal": "tidal://track/105506248",
       "uri_deezer": "deezer://track/549282432",
       "fun_fact_nl": "Een van de vroegste hits van Marvin Gaye, geschreven door Holland-Dozier-Holland. De Rolling Stones coverden het tijdens hun vroege carrière en hielpen zo het Motown-geluid te verspreiden onder het Britse rockpubliek. De door gospel beïnvloede call-and-response stijl definieerde het vroege Motown.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMO10300653",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1455384527",
+        "de": "applemusic://track/1455384527",
+        "gb": "applemusic://track/1442720335",
+        "fr": "applemusic://track/1455384527",
+        "es": "applemusic://track/1455384527",
+        "nl": "applemusic://track/1455384527",
+        "it": "applemusic://track/1455384527"
+      }
     },
     {
       "year": 1965,
@@ -2756,7 +3636,17 @@
       "uri_tidal": "tidal://track/219345494",
       "uri_deezer": "deezer://track/909584",
       "fun_fact_nl": "Jr. Walkers eerste en grootste hit, vernoemd naar een populaire dans. Hij was een van de weinige instrumentalisten van Motown die groot succes had als frontman. De rauwe, toeterende saxofoon bepaalde de onweerstaanbare groove van het nummer.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMO16500007",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1443858632",
+        "de": "applemusic://track/1611669451",
+        "gb": "applemusic://track/1611669451",
+        "fr": "applemusic://track/1611669451",
+        "es": "applemusic://track/1611669451",
+        "nl": "applemusic://track/1611669451",
+        "it": "applemusic://track/1611669451"
+      }
     },
     {
       "year": 1963,
@@ -2787,7 +3677,17 @@
       "uri_tidal": "tidal://track/28802934",
       "uri_deezer": "deezer://track/78102223",
       "fun_fact_nl": "Het werd geschreven door Holland-Dozier-Holland en was het eerste Motown-nummer dat een Grammy-nominatie verdiende. Linda Ronstadt coverde het in 1975 en had ook een Top 5 hit. Het nummer hielp de Motown Sound te vestigen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMO16300273",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1471569294",
+        "de": "applemusic://track/1444017336",
+        "gb": "applemusic://track/1418049694",
+        "fr": "applemusic://track/1444017336",
+        "es": "applemusic://track/1444017336",
+        "nl": "applemusic://track/1444017336",
+        "it": "applemusic://track/1444017336"
+      }
     },
     {
       "year": 1980,
@@ -2818,7 +3718,17 @@
       "uri_tidal": "tidal://track/93758629",
       "uri_deezer": "deezer://track/2959690341",
       "fun_fact_nl": "Geschreven en geproduceerd door Stevie Wonder. Jermaine bleef bij Motown toen zijn broers naar Epic Records vertrokken omdat hij getrouwd was met Berry Gordy's dochter Hazel. Dit werd zijn grootste solohit bij Motown.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USUM70501188",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1375006291",
+        "de": "applemusic://track/1375006291",
+        "gb": "applemusic://track/1375006291",
+        "fr": "applemusic://track/1375006291",
+        "es": "applemusic://track/1375006291",
+        "nl": "applemusic://track/1375006291",
+        "it": "applemusic://track/1375006291"
+      }
     },
     {
       "year": 1987,
@@ -2849,7 +3759,17 @@
       "uri_tidal": "tidal://track/2527946",
       "uri_deezer": "deezer://track/1114832",
       "fun_fact_nl": "Ja, die Bruce Willis! De 'Die Hard'-ster bracht deze cover van de klassieker van The Drifters uit op Motown Records. Zijn album 'The Return of Bruno' was een verrassend commercieel succes, vooral in Europa.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMO18700468",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1893189290",
+        "de": "applemusic://track/1893189290",
+        "gb": "applemusic://track/1451255425",
+        "fr": "applemusic://track/1893189290",
+        "es": "applemusic://track/1893189290",
+        "nl": "applemusic://track/1893189290",
+        "it": "applemusic://track/1893189290"
+      }
     },
     {
       "year": 1981,
@@ -2880,7 +3800,17 @@
       "uri_tidal": "tidal://track/77815398",
       "uri_deezer": "deezer://track/2500448",
       "fun_fact_nl": "Van hetzelfde album als 'Super Freak' (Street Songs). Rick James blies de relevantie van Motown begin jaren 80 nieuw leven in met zijn funk-punk stijl. Van het album werden meer dan 3 miljoen exemplaren verkocht.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMO18100047",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1583609942",
+        "de": "applemusic://track/1583609942",
+        "gb": "applemusic://track/1583609942",
+        "fr": "applemusic://track/1583609942",
+        "es": "applemusic://track/1583609942",
+        "nl": "applemusic://track/1583609942",
+        "it": "applemusic://track/1583609942"
+      }
     },
     {
       "year": 1984,
@@ -2911,7 +3841,17 @@
       "uri_tidal": "tidal://track/5254510",
       "uri_deezer": "deezer://track/1484703292",
       "fun_fact_nl": "Rockwell was eigenlijk de zoon van Berry Gordy, Kennedy Gordy, die onder een pseudoniem opnam. Michael Jackson zong het gedenkwaardige refrein als een gunst. Het liedje werd een Halloween nummer en won aan populariteit door internet memes.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMO10000307",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1647277494",
+        "de": "applemusic://track/1647277494",
+        "gb": "applemusic://track/1647277494",
+        "fr": "applemusic://track/1647277494",
+        "es": "applemusic://track/1647277494",
+        "nl": "applemusic://track/1647277494",
+        "it": "applemusic://track/1647277494"
+      }
     },
     {
       "year": 1991,
@@ -2942,7 +3882,17 @@
       "uri_tidal": "tidal://track/3874996",
       "uri_deezer": "deezer://track/910925",
       "fun_fact_nl": "Shanice was net 18 toen dit een wereldwijde hit werd. Het bevat een kenmerkende jazzfluitsolo. Het nummer hielp Motown relevant te blijven in het new jack swing-tijdperk van begin jaren 90.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMO19190003",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1808737861",
+        "de": "applemusic://track/1808737861",
+        "gb": "applemusic://track/1808737861",
+        "fr": "applemusic://track/1808737861",
+        "es": "applemusic://track/1808737861",
+        "nl": "applemusic://track/1808737861",
+        "it": "applemusic://track/1808737861"
+      }
     },
     {
       "year": 1991,
@@ -2973,7 +3923,17 @@
       "uri_tidal": "tidal://track/3961405",
       "uri_deezer": "deezer://track/649771222",
       "fun_fact_nl": "De debuutsingle van de groep, geproduceerd door Dallas Austin. De titel combineert 'Motown' (hun label) met 'Philly' (hun geboortestad Philadelphia). Michael Bivins van New Edition ontdekte en begeleidde de groep.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMO19190022",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1440776792",
+        "de": "applemusic://track/1440776792",
+        "gb": "applemusic://track/1440776792",
+        "fr": "applemusic://track/1440776792",
+        "es": "applemusic://track/1440776792",
+        "nl": "applemusic://track/1440776792",
+        "it": "applemusic://track/1440776792"
+      }
     },
     {
       "year": 1986,
@@ -3004,7 +3964,17 @@
       "uri_tidal": "tidal://track/3874732",
       "uri_deezer": "deezer://track/7276129",
       "fun_fact_nl": "Van de soundtrack van de film 'Short Circuit. De falsetto van El DeBarge werd vaak vergeleken met die van een jonge Michael Jackson. Het nummer was zijn grootste solohit en een van Motown's laatste grote pop-successen van het decennium.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMO18600259",
+      "uri_apple_music_by_region": {
+        "us": null,
+        "de": "applemusic://track/1484130932",
+        "gb": "applemusic://track/1484130932",
+        "fr": "applemusic://track/1484130932",
+        "es": "applemusic://track/1484130932",
+        "nl": "applemusic://track/1484130932",
+        "it": "applemusic://track/1484130932"
+      }
     },
     {
       "year": 1979,
@@ -3033,7 +4003,17 @@
       "uri_tidal": "tidal://track/202977725",
       "uri_deezer": "deezer://track/1537023652",
       "fun_fact_nl": "De tweede single van hun duetalbum 'Billy Preston & Syreeta'. Het toonde de muzikale chemie tussen de 'Fifth Beatle' en de ex-vrouw van Stevie Wonder. Syreeta schreef ook mee aan Stevie's 'Signed, Sealed, Delivered'.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMO10401095",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1592733515",
+        "de": "applemusic://track/1592733515",
+        "gb": "applemusic://track/1592733515",
+        "fr": "applemusic://track/1592733515",
+        "es": "applemusic://track/1592733515",
+        "nl": "applemusic://track/1592733515",
+        "it": "applemusic://track/1592733515"
+      }
     }
   ]
 }

--- a/custom_components/beatify/playlists/movies-100-greatest-themes.json
+++ b/custom_components/beatify/playlists/movies-100-greatest-themes.json
@@ -53,7 +53,17 @@
       "awards_nl": [
         "Oscar voor Beste Originele Filmmuziek (2001)",
         "Grammy Award voor Beste Soundtrackpartituur (2002)"
-      ]
+      ],
+      "isrc": "USRE10501631",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1369922084",
+        "de": "applemusic://track/1369922084",
+        "gb": "applemusic://track/1369922084",
+        "fr": "applemusic://track/1369922084",
+        "es": "applemusic://track/1369922084",
+        "nl": "applemusic://track/1369922084",
+        "it": "applemusic://track/1369922084"
+      }
     },
     {
       "year": 1962,
@@ -130,7 +140,17 @@
       "awards_nl": [
         "Oscar voor Beste Originele Filmmuziek (1997)",
         "Golden Globe voor Beste Originele Filmmuziek (1998)"
-      ]
+      ],
+      "isrc": "USSM19702327",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/582727836",
+        "de": "applemusic://track/205743853",
+        "gb": "applemusic://track/205743853",
+        "fr": "applemusic://track/205743853",
+        "es": "applemusic://track/205743853",
+        "nl": "applemusic://track/205743853",
+        "it": "applemusic://track/460047956"
+      }
     },
     {
       "year": 1977,
@@ -182,7 +202,17 @@
       "awards_nl": [
         "Oscar voor Beste Originele Filmmuziek (1977)",
         "Grammy Award voor Beste Soundtrackpartituur (1978)"
-      ]
+      ],
+      "isrc": "USWD11785403",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1375814284",
+        "de": "applemusic://track/1376650140",
+        "gb": "applemusic://track/1375814284",
+        "fr": "applemusic://track/1376645977",
+        "es": "applemusic://track/1376671117",
+        "nl": "applemusic://track/1375814284",
+        "it": "applemusic://track/1376652184"
+      }
     },
     {
       "year": 1977,
@@ -230,7 +260,17 @@
       "fun_fact_nl": "De soundtrack van Saturday Night Fever stond 24 weken op nummer 1 en verkocht meer dan 40 miljoen exemplaren, waardoor het een van de best verkochte soundtracks ooit is.",
       "awards_nl": [
         "Grammy Award voor Album van het Jaar (1979)"
-      ]
+      ],
+      "isrc": "NLF057790034",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1884981998",
+        "de": "applemusic://track/1884981998",
+        "gb": "applemusic://track/1884981998",
+        "fr": "applemusic://track/1884981998",
+        "es": "applemusic://track/1884981998",
+        "nl": "applemusic://track/1884981998",
+        "it": "applemusic://track/1884981998"
+      }
     },
     {
       "year": 1966,
@@ -264,7 +304,17 @@
       "uri_tidal": "tidal://track/2878659",
       "uri_deezer": "deezer://track/3089012",
       "fun_fact_nl": "Ennio Morricone componeerde het thema van The Good, the Bad and the Ugly voordat het filmen begon. Regisseur Sergio Leone speelde het op de set om de acteurs te inspireren.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USNPD0714249",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1714547929",
+        "de": "applemusic://track/1714547929",
+        "gb": "applemusic://track/1714547929",
+        "fr": "applemusic://track/1714547929",
+        "es": "applemusic://track/1714547929",
+        "nl": "applemusic://track/1714547929",
+        "it": "applemusic://track/1714547929"
+      }
     },
     {
       "year": 1999,
@@ -306,7 +356,17 @@
       "fun_fact_nl": "De score voor American Beauty van Thomas Newman maakt gebruik van marimba- en gamelaninstrumenten om een etherische, suburbane soundscape te creëren die een Grammy won.",
       "awards_nl": [
         "Grammy Award voor Beste Soundtrackpartituur (2000)"
-      ]
+      ],
+      "isrc": "USDW19921001",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1437293431",
+        "de": "applemusic://track/1437293431",
+        "gb": "applemusic://track/1437293431",
+        "fr": "applemusic://track/1437293431",
+        "es": "applemusic://track/1452614024",
+        "nl": "applemusic://track/1437293431",
+        "it": "applemusic://track/1437293431"
+      }
     },
     {
       "year": 1994,
@@ -335,7 +395,17 @@
       "uri_tidal": "tidal://track/543388",
       "uri_deezer": "deezer://track/1014549",
       "fun_fact_nl": "Alan Silvestri componeerde het zachte pianothema van Forrest Gump om de onschuldige kijk van het personage op de wereld door tientallen jaren Amerikaanse geschiedenis weer te geven.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM19913841",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/371272703",
+        "de": "applemusic://track/371272703",
+        "gb": "applemusic://track/371272703",
+        "fr": "applemusic://track/371272703",
+        "es": "applemusic://track/371272703",
+        "nl": "applemusic://track/371272703",
+        "it": "applemusic://track/371272703"
+      }
     },
     {
       "year": 1978,
@@ -368,7 +438,17 @@
       "uri_tidal": "tidal://track/77625022",
       "uri_deezer": "deezer://track/781563032",
       "fun_fact_nl": "Frankie Valli nam de titelsong van Grease speciaal voor de film op. Het werd zijn grootste solohit en hielp de nostalgische toon van de film te bepalen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "NLF057890001",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1691911665",
+        "de": "applemusic://track/1691911665",
+        "gb": "applemusic://track/1691911665",
+        "fr": "applemusic://track/1691911665",
+        "es": "applemusic://track/1691911665",
+        "nl": "applemusic://track/1691911665",
+        "it": "applemusic://track/1691911665"
+      }
     },
     {
       "year": 1971,
@@ -462,7 +542,17 @@
       "fun_fact_nl": "Henry Mancini's Pink Panther Theme werd geschreven voor de openingscredits, maar werd zo populair dat er een hele animatieserie uit voortkwam.",
       "awards_nl": [
         "Grammy Award voor Beste Instrumentaal (1964)"
-      ]
+      ],
+      "isrc": "USRC16302654",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/254639881",
+        "de": "applemusic://track/404855280",
+        "gb": "applemusic://track/404855280",
+        "fr": "applemusic://track/1006312033",
+        "es": "applemusic://track/1006312033",
+        "nl": "applemusic://track/1006312033",
+        "it": "applemusic://track/1006312033"
+      }
     },
     {
       "year": 2002,
@@ -491,7 +581,17 @@
       "uri_tidal": "tidal://track/35124692",
       "uri_deezer": "deezer://track/119871694",
       "fun_fact_nl": "John Powells Bourne Identity-score was een pionier in het moderne geluid van actiefilms met stuwende ritmes en elektronische elementen gemengd met orkest.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USQ4E2200050",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1636991684",
+        "de": "applemusic://track/1636991684",
+        "gb": "applemusic://track/1636991684",
+        "fr": "applemusic://track/1636991684",
+        "es": "applemusic://track/1636991684",
+        "nl": "applemusic://track/1636991684",
+        "it": "applemusic://track/1636991684"
+      }
     },
     {
       "year": 1972,
@@ -522,7 +622,17 @@
       "uri_tidal": "tidal://track/638960",
       "uri_deezer": "deezer://track/3040782",
       "fun_fact_nl": "Het Godfather-thema van Nino Rota werd in eerste instantie door de studio afgewezen omdat het te etnisch zou zijn. Regisseur Coppola vocht om het te behouden en het werd iconisch.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMC17251835",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1637170585",
+        "de": "applemusic://track/1637170585",
+        "gb": "applemusic://track/1637170585",
+        "fr": "applemusic://track/1637170585",
+        "es": "applemusic://track/1637170585",
+        "nl": "applemusic://track/1637170585",
+        "it": "applemusic://track/1637170585"
+      }
     },
     {
       "year": 1966,
@@ -574,7 +684,17 @@
       "awards_nl": [
         "Oscar voor Beste Originele Lied (1966)",
         "Oscar voor Beste Originele Filmmuziek (1966)"
-      ]
+      ],
+      "isrc": "USSM10028082",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/209447357",
+        "de": "applemusic://track/209447357",
+        "gb": "applemusic://track/209447357",
+        "fr": "applemusic://track/209447357",
+        "es": "applemusic://track/209447357",
+        "nl": "applemusic://track/209447357",
+        "it": "applemusic://track/209447357"
+      }
     },
     {
       "year": 1994,
@@ -621,7 +741,17 @@
       "fun_fact_nl": "Circle of Life opent The Lion King met een zonsopgang boven Afrika. De Zulu-teksten zijn vertaald door de Zuid-Afrikaanse componist Lebo M.",
       "awards_nl": [
         "Golden Globe voor Beste Originele Lied (1995)"
-      ]
+      ],
+      "isrc": "USWD10220440",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1445732924",
+        "de": "applemusic://track/1445732924",
+        "gb": "applemusic://track/1445732924",
+        "fr": "applemusic://track/1445732924",
+        "es": "applemusic://track/1445732924",
+        "nl": "applemusic://track/1445732924",
+        "it": "applemusic://track/1445732924"
+      }
     },
     {
       "year": 1976,
@@ -668,7 +798,17 @@
       "fun_fact_nl": "Gonna Fly Now uit Rocky werd in één middag geschreven. De triomfantelijke fanfare werd synoniem voor het overwinnen van onmogelijke kansen.",
       "awards_nl": [
         "Oscarnominatie voor Beste Originele Lied (1976)"
-      ]
+      ],
+      "isrc": "USNPD0600582",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1691912797",
+        "de": "applemusic://track/1691912797",
+        "gb": "applemusic://track/1691912797",
+        "fr": "applemusic://track/1691912797",
+        "es": "applemusic://track/1691912797",
+        "nl": "applemusic://track/1691912797",
+        "it": "applemusic://track/1691912797"
+      }
     },
     {
       "year": 1965,
@@ -720,7 +860,17 @@
       "awards_nl": [
         "Oscar voor Beste Originele Filmmuziek (1965)",
         "Golden Globe voor Beste Originele Filmmuziek (1966)"
-      ]
+      ],
+      "isrc": "USNLR1200108",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1455256248",
+        "de": "applemusic://track/1455256248",
+        "gb": "applemusic://track/1455256248",
+        "fr": "applemusic://track/1455256248",
+        "es": "applemusic://track/1455256248",
+        "nl": "applemusic://track/1455256248",
+        "it": "applemusic://track/1455256248"
+      }
     },
     {
       "year": 1960,
@@ -782,7 +932,17 @@
       "uri_tidal": "tidal://track/72223271",
       "uri_deezer": "deezer://track/344967621",
       "fun_fact_nl": "Neal Hefti's Odd Couple Theme vangt perfect de komische botsing tussen nette Felix en slordige Oscar met zijn speelse klavecimbel.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "US3M51620729",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1443666197",
+        "de": "applemusic://track/1443666197",
+        "gb": "applemusic://track/1443666197",
+        "fr": "applemusic://track/1443666197",
+        "es": "applemusic://track/1443666197",
+        "nl": "applemusic://track/1443666197",
+        "it": "applemusic://track/1443666197"
+      }
     },
     {
       "year": 1983,
@@ -839,7 +999,17 @@
       "uri_tidal": "tidal://track/4625777",
       "uri_deezer": "deezer://track/7337316",
       "fun_fact_nl": "De Green Mile-score van Thomas Newman gebruikt zachte piano en strijkers om de thema's medeleven en bovennatuurlijke verlossing in de film te benadrukken.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USWB19902917",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/373216432",
+        "de": "applemusic://track/373216432",
+        "gb": "applemusic://track/373216432",
+        "fr": "applemusic://track/373216432",
+        "es": "applemusic://track/373216432",
+        "nl": "applemusic://track/373216432",
+        "it": "applemusic://track/373216432"
+      }
     },
     {
       "year": 2014,
@@ -881,7 +1051,17 @@
       "fun_fact_nl": "De score van Hans Zimmer voor Interstellar bevat een kerkorgel om de uitgestrektheid van de ruimte over te brengen. Regisseur Nolan hield het plot van de film aanvankelijk geheim voor Zimmer.",
       "awards_nl": [
         "Grammy-nominatie voor Beste Soundtrackpartituur (2015)"
-      ]
+      ],
+      "isrc": "USNLR1400774",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1533984393",
+        "de": "applemusic://track/1533984393",
+        "gb": "applemusic://track/1533984393",
+        "fr": "applemusic://track/1533984393",
+        "es": "applemusic://track/1533984393",
+        "nl": "applemusic://track/1533984393",
+        "it": "applemusic://track/1533984393"
+      }
     },
     {
       "year": 1967,
@@ -961,7 +1141,17 @@
       "awards_nl": [
         "Golden Globe voor Beste Originele Filmmuziek (2016)",
         "BAFTA voor Beste Filmmuziek (2016)"
-      ]
+      ],
+      "isrc": "US5941405853",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1516405842",
+        "de": "applemusic://track/1516405842",
+        "gb": "applemusic://track/1440526406",
+        "fr": "applemusic://track/1516405842",
+        "es": "applemusic://track/1516405842",
+        "nl": "applemusic://track/1516405842",
+        "it": "applemusic://track/1516405842"
+      }
     },
     {
       "year": 2007,
@@ -990,7 +1180,17 @@
       "uri_tidal": "tidal://track/1228011",
       "uri_deezer": "deezer://track/790324",
       "fun_fact_nl": "Alan Silvestri's Beowulf score combineert orkest met elektronische elementen en koor om het oude epische gedicht tot leven te brengen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USWB10704951",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/268374723",
+        "de": "applemusic://track/268374723",
+        "gb": "applemusic://track/268374723",
+        "fr": "applemusic://track/268374723",
+        "es": "applemusic://track/268374723",
+        "nl": "applemusic://track/268374723",
+        "it": "applemusic://track/268374723"
+      }
     },
     {
       "year": 1969,
@@ -1061,7 +1261,17 @@
       "fun_fact_nl": "Francis Lai's A Man and a Woman theme werd een wereldwijde hit. De eenvoudige melodie met scatzang won de Palme d'Or in Cannes.",
       "awards_nl": [
         "Gouden Palm in Cannes (1966)"
-      ]
+      ],
+      "isrc": "FRP366600040",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1453739559",
+        "de": "applemusic://track/546983101",
+        "gb": "applemusic://track/546983101",
+        "fr": "applemusic://track/546983101",
+        "es": "applemusic://track/546983101",
+        "nl": "applemusic://track/546983101",
+        "it": "applemusic://track/546983101"
+      }
     },
     {
       "year": 2010,
@@ -1090,7 +1300,17 @@
       "uri_tidal": "tidal://track/35133246",
       "uri_deezer": "deezer://track/119438266",
       "fun_fact_nl": "John Powell's Knight and Day score mengt actiecues met romantische komedie-elementen, passend bij de genre-overstijgende toon van de film.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "US3M51003401",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1443410090",
+        "de": "applemusic://track/1443410090",
+        "gb": "applemusic://track/1443410090",
+        "fr": "applemusic://track/1443410090",
+        "es": "applemusic://track/1443410090",
+        "nl": "applemusic://track/1443410090",
+        "it": "applemusic://track/1443410090"
+      }
     },
     {
       "year": 1995,
@@ -1142,7 +1362,17 @@
       "awards_nl": [
         "Oscar voor Beste Originele Lied (1995)",
         "Golden Globe voor Beste Originele Lied (1995)"
-      ]
+      ],
+      "isrc": "USWD10110149",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1440720182",
+        "de": "applemusic://track/1440720182",
+        "gb": "applemusic://track/1440720182",
+        "fr": "applemusic://track/1444076666",
+        "es": "applemusic://track/1440720182",
+        "nl": "applemusic://track/1440720182",
+        "it": "applemusic://track/1440720182"
+      }
     },
     {
       "year": 1969,
@@ -1189,7 +1419,17 @@
       "fun_fact_nl": "Raindrops Keep Fallin' on My Head won de Oscar ondanks dat het niet op zijn plaats leek in een western. Het werd het lijflied van B.J. Thomas.",
       "awards_nl": [
         "Oscar voor Beste Originele Lied (1969)"
-      ]
+      ],
+      "isrc": "USAFM0600725",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1832973080",
+        "de": "applemusic://track/1832973080",
+        "gb": "applemusic://track/1832973080",
+        "fr": "applemusic://track/1832973080",
+        "es": "applemusic://track/1832973080",
+        "nl": "applemusic://track/1832973080",
+        "it": "applemusic://track/1832973080"
+      }
     },
     {
       "year": 1969,
@@ -1218,7 +1458,17 @@
       "uri_tidal": "tidal://track/77611627",
       "uri_deezer": "deezer://track/540201452",
       "fun_fact_nl": "The Pusher van Steppenwolf opent Easy Rider en zet de tegenculturele toon. De donkere tekst van het nummer contrasteert met de vrijheid van de open weg.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMC16946566",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1680765823",
+        "de": "applemusic://track/1680765823",
+        "gb": "applemusic://track/1680765823",
+        "fr": "applemusic://track/1680765823",
+        "es": "applemusic://track/1680765823",
+        "nl": "applemusic://track/1680765823",
+        "it": "applemusic://track/1680765823"
+      }
     },
     {
       "year": 1969,
@@ -1247,7 +1497,17 @@
       "uri_tidal": "tidal://track/1420522",
       "uri_deezer": "deezer://track/3509260",
       "fun_fact_nl": "John Barry's Midnight Cowboy-thema gebruikt harmonica om stedelijke eenzaamheid op te roepen. De film was de enige X-rated film die Best Picture won.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USEM30700011",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/697397846",
+        "de": "applemusic://track/697397846",
+        "gb": "applemusic://track/697397846",
+        "fr": "applemusic://track/697397846",
+        "es": "applemusic://track/697397846",
+        "nl": "applemusic://track/697397846",
+        "it": "applemusic://track/697397846"
+      }
     },
     {
       "year": 1975,
@@ -1296,7 +1556,17 @@
       "awards_nl": [
         "Oscar voor Beste Originele Filmmuziek (1975)",
         "Grammy Award voor Beste Soundtrackpartituur (1976)"
-      ]
+      ],
+      "isrc": "USUM72505990",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1842229145",
+        "de": "applemusic://track/1842229145",
+        "gb": "applemusic://track/1842229145",
+        "fr": "applemusic://track/1842229145",
+        "es": "applemusic://track/1842229145",
+        "nl": "applemusic://track/1842229145",
+        "it": "applemusic://track/1842229145"
+      }
     },
     {
       "year": 1978,
@@ -1343,7 +1613,17 @@
       "awards_nl": [
         "Oscar voor Beste Originele Filmmuziek (1978)",
         "Golden Globe voor Beste Originele Filmmuziek (1979)"
-      ]
+      ],
+      "isrc": "USPR37900070",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1609121967",
+        "de": "applemusic://track/1443529354",
+        "gb": "applemusic://track/1609121967",
+        "fr": "applemusic://track/1609121967",
+        "es": "applemusic://track/1609121967",
+        "nl": "applemusic://track/1609121967",
+        "it": "applemusic://track/1609121967"
+      }
     },
     {
       "year": 1987,
@@ -1438,7 +1718,17 @@
       "fun_fact_nl": "Randy Newman schreef You've Got a Friend in Me in slechts één dag. Het werd het hart van de hele Toy Story-franchise.",
       "awards_nl": [
         "Oscarnominatie voor Beste Originele Lied (1995)"
-      ]
+      ],
+      "isrc": "USWD10110108",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1456073416",
+        "de": "applemusic://track/1456073416",
+        "gb": "applemusic://track/1456073416",
+        "fr": "applemusic://track/1456073416",
+        "es": "applemusic://track/1456073416",
+        "nl": "applemusic://track/1456073416",
+        "it": "applemusic://track/1456073416"
+      }
     },
     {
       "year": 1999,
@@ -1467,7 +1757,17 @@
       "uri_tidal": "tidal://track/35122144",
       "uri_deezer": "deezer://track/119871440",
       "fun_fact_nl": "De score van Don Davis voor Matrix combineert orkest met elektronische muziek om de kenmerkende digital reality soundscape van de film te creëren.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "US3M59902601",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1443853925",
+        "de": "applemusic://track/1443853925",
+        "gb": "applemusic://track/1443853925",
+        "fr": "applemusic://track/1443853925",
+        "es": "applemusic://track/1443853925",
+        "nl": "applemusic://track/1443853925",
+        "it": "applemusic://track/1443853925"
+      }
     },
     {
       "year": 1962,
@@ -1496,7 +1796,17 @@
       "uri_tidal": "tidal://track/142205740",
       "uri_deezer": "deezer://track/965156762",
       "fun_fact_nl": "Seventy Six Trombones uit The Music Man bevat uitgebreide marsbandchoreografie. Robert Preston vertolkte zijn Broadway-rol in de film.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBH5G2100049",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1514004194",
+        "de": "applemusic://track/1514004194",
+        "gb": "applemusic://track/1514004194",
+        "fr": "applemusic://track/1514004194",
+        "es": "applemusic://track/1514004194",
+        "nl": "applemusic://track/1514004194",
+        "it": "applemusic://track/1514004194"
+      }
     },
     {
       "year": 2012,
@@ -1525,7 +1835,17 @@
       "uri_tidal": "tidal://track/14508703",
       "uri_deezer": "deezer://track/963636242",
       "fun_fact_nl": "Alan Silvestri's Avengers-thema is de muzikale identiteit van het Marvel Cinematic Universe geworden en verschijnt door de hele franchise heen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USHR11233664",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1891482072",
+        "de": "applemusic://track/1891482072",
+        "gb": "applemusic://track/1891482072",
+        "fr": "applemusic://track/1891482072",
+        "es": "applemusic://track/1891482072",
+        "nl": "applemusic://track/1891482072",
+        "it": "applemusic://track/1891482072"
+      }
     },
     {
       "year": 1996,
@@ -1559,7 +1879,17 @@
       "uri_tidal": "tidal://track/63235194",
       "uri_deezer": "deezer://track/7695301",
       "fun_fact_nl": "Lalo Schifrin's Mission: Impossible thema gebruikt een kenmerkende 5/4 maatsoort. Het komt oorspronkelijk uit de tv-serie uit 1966.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMC16846967",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1443835386",
+        "de": "applemusic://track/1443835386",
+        "gb": "applemusic://track/1443835386",
+        "fr": "applemusic://track/1443835386",
+        "es": "applemusic://track/1452614028",
+        "nl": "applemusic://track/1443835386",
+        "it": "applemusic://track/1443835386"
+      }
     },
     {
       "year": 1980,
@@ -1660,7 +1990,17 @@
       "fun_fact_nl": "De muziek van John Williams voor Home Alone werd een kerstklassieker. De koorversie van Somewhere in My Memory roept kinderlijke verwondering op.",
       "awards_nl": [
         "Oscarnominatie voor Beste Originele Filmmuziek (1990)"
-      ]
+      ],
+      "isrc": "USSM19909870",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1712207945",
+        "de": "applemusic://track/1712207945",
+        "gb": "applemusic://track/1712207945",
+        "fr": "applemusic://track/1712207945",
+        "es": "applemusic://track/1712207945",
+        "nl": "applemusic://track/1712207945",
+        "it": "applemusic://track/1712207945"
+      }
     },
     {
       "year": 1968,
@@ -1746,7 +2086,17 @@
       "fun_fact_nl": "Het Indiana Jones-thema van John Williams staat bekend als de Raiders March. Het werd geschreven voor het filmen en inspireerde de branie van het personage.",
       "awards_nl": [
         "Oscarnominatie voor Beste Originele Filmmuziek (1981)"
-      ]
+      ],
+      "isrc": "USC4R0818847",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1400945114",
+        "de": "applemusic://track/1400945114",
+        "gb": "applemusic://track/1400945114",
+        "fr": "applemusic://track/1400945114",
+        "es": "applemusic://track/1400945114",
+        "nl": "applemusic://track/1400945114",
+        "it": "applemusic://track/1400945114"
+      }
     },
     {
       "year": 1994,
@@ -1778,7 +2128,17 @@
       "uri_tidal": "tidal://track/568517",
       "uri_deezer": "deezer://track/2430597",
       "fun_fact_nl": "Boom Shack-A-Lak van Apache Indian verscheen in Dumb and Dumber en werd een synoniem voor de soundtracks van komedies uit de jaren 90.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAAN9300046",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1569725611",
+        "de": "applemusic://track/1442493286",
+        "gb": "applemusic://track/1466934830",
+        "fr": "applemusic://track/1442493286",
+        "es": "applemusic://track/1442493286",
+        "nl": "applemusic://track/1442493286",
+        "it": "applemusic://track/1569725611"
+      }
     },
     {
       "year": 1964,
@@ -1851,7 +2211,17 @@
       "fun_fact_nl": "The Sound of Music werd de best verdienende film van 1965. Julie Andrews zong alleen.",
       "awards_nl": [
         "Oscar voor Beste Film (1965)"
-      ]
+      ],
+      "isrc": "USRC16406208",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1550187917",
+        "de": "applemusic://track/1550187917",
+        "gb": "applemusic://track/1550187917",
+        "fr": "applemusic://track/1550187917",
+        "es": "applemusic://track/1550187917",
+        "nl": "applemusic://track/1550187917",
+        "it": "applemusic://track/1550187917"
+      }
     },
     {
       "year": 1966,
@@ -1880,7 +2250,17 @@
       "uri_tidal": "tidal://track/2878678",
       "uri_deezer": "deezer://track/3089031",
       "fun_fact_nl": "The Ecstasy of Gold speelt tijdens de kerkhofscène in The Good, the Bad and the Ugly. Metallica gebruikt het om hun concerten te openen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USNPD0800979",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1714548676",
+        "de": "applemusic://track/1714548676",
+        "gb": "applemusic://track/1714548676",
+        "fr": "applemusic://track/1714548676",
+        "es": "applemusic://track/1714548676",
+        "nl": "applemusic://track/1714548676",
+        "it": "applemusic://track/1714548676"
+      }
     },
     {
       "year": 1970,
@@ -1911,7 +2291,17 @@
       "uri_tidal": "tidal://track/359734459",
       "uri_deezer": "deezer://track/2766878181",
       "fun_fact_nl": "Suicide Is Painless werd geschreven voor M*A*S*H door Johnny Mandel. De tienerzoon van de songwriter schreef de opzettelijk domme tekst.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM10007170",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1743285349",
+        "de": "applemusic://track/1743285349",
+        "gb": "applemusic://track/1743285349",
+        "fr": "applemusic://track/1743285349",
+        "es": "applemusic://track/1743285349",
+        "nl": "applemusic://track/1743285349",
+        "it": "applemusic://track/1743285349"
+      }
     },
     {
       "year": 1955,
@@ -2044,7 +2434,17 @@
       "awards_nl": [
         "Oscar voor Beste Originele Lied (1961)",
         "Grammy Award voor Opname van het Jaar (1962)"
-      ]
+      ],
+      "isrc": "USRC10001122",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/298421438",
+        "de": "applemusic://track/1719236777",
+        "gb": "applemusic://track/1719236777",
+        "fr": "applemusic://track/1719236777",
+        "es": "applemusic://track/1719236777",
+        "nl": "applemusic://track/1719236777",
+        "it": "applemusic://track/1719236777"
+      }
     },
     {
       "year": 1994,
@@ -2086,7 +2486,17 @@
       "fun_fact_nl": "De score voor Shawshank Redemption van Thomas Newman maakt gebruik van harmonica en zachte strijkers om hoop binnen de gevangenismuren over te brengen.",
       "awards_nl": [
         "Oscarnominatie voor Beste Originele Filmmuziek (1994)"
-      ]
+      ],
+      "isrc": "USSM10904608",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/331545686",
+        "de": "applemusic://track/331545686",
+        "gb": "applemusic://track/331545686",
+        "fr": "applemusic://track/331545686",
+        "es": "applemusic://track/331545686",
+        "nl": "applemusic://track/331545686",
+        "it": "applemusic://track/331545686"
+      }
     },
     {
       "year": 2002,
@@ -2115,7 +2525,17 @@
       "uri_tidal": "tidal://track/232938",
       "uri_deezer": "deezer://track/783658",
       "fun_fact_nl": "Gollum's Song sluit The Two Towers af. De beklemmende zang van Emiliana Torrini vangt de tragedie van de gecorrumpeerde Smeagol.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USRE10201360",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/297981337",
+        "de": "applemusic://track/297981337",
+        "gb": "applemusic://track/297981337",
+        "fr": "applemusic://track/297981337",
+        "es": "applemusic://track/297981337",
+        "nl": "applemusic://track/297981337",
+        "it": "applemusic://track/297981337"
+      }
     },
     {
       "year": 2004,
@@ -2144,7 +2564,17 @@
       "uri_tidal": "tidal://track/1315755",
       "uri_deezer": "deezer://track/586314",
       "fun_fact_nl": "Het thema van Danny Elfman voor Spider-Man combineert heldhaftig koper met zijn kenmerkende eigenzinnige stijl en is bepalend voor het geluid van de Sam Raimi trilogie.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM10408251",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/186379179",
+        "de": "applemusic://track/186379179",
+        "gb": "applemusic://track/186379179",
+        "fr": "applemusic://track/186379179",
+        "es": "applemusic://track/186379179",
+        "nl": "applemusic://track/186379179",
+        "it": "applemusic://track/186379179"
+      }
     },
     {
       "year": 1959,
@@ -2219,7 +2649,17 @@
       "uri_tidal": "tidal://track/180013712",
       "uri_deezer": "deezer://track/1012513942",
       "fun_fact_nl": "James Brown's Black Caesar soundtrack bracht funk naar blaxploitation cinema. Hij componeerde en speelde de hele score.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USPR37380050",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1560916304",
+        "de": "applemusic://track/1612220245",
+        "gb": "applemusic://track/1612220245",
+        "fr": "applemusic://track/1612220245",
+        "es": "applemusic://track/1612220245",
+        "nl": "applemusic://track/1612220245",
+        "it": "applemusic://track/1612220245"
+      }
     },
     {
       "year": 1964,
@@ -2248,7 +2688,17 @@
       "uri_tidal": "tidal://track/40485",
       "uri_deezer": "deezer://track/538915722",
       "fun_fact_nl": "A Shot in the Dark was de tweede Pink Panther-film. De jazzy score van Henry Mancini versterkte de fysieke komedie van Peter Sellers.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USRC16402661",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/298379578",
+        "de": "applemusic://track/255979664",
+        "gb": "applemusic://track/255979664",
+        "fr": "applemusic://track/255979664",
+        "es": "applemusic://track/255979664",
+        "nl": "applemusic://track/255979664",
+        "it": "applemusic://track/255979664"
+      }
     },
     {
       "year": 1958,
@@ -2278,7 +2728,17 @@
       "fun_fact_nl": "Het Big Country-thema van Jerome Moross maakt gebruik van meeslepende strijkers om de uitgestrektheid van het Amerikaanse Westen vast te leggen.",
       "awards_nl": [],
       "uri_apple_music": "applemusic://track/1657222496",
-      "uri_youtube_music": "https://music.youtube.com/watch?v=RA-m5Ci2Oxg"
+      "uri_youtube_music": "https://music.youtube.com/watch?v=RA-m5Ci2Oxg",
+      "isrc": "GBAJC0002984",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1657216199",
+        "de": "applemusic://track/1657216199",
+        "gb": "applemusic://track/1657216199",
+        "fr": "applemusic://track/1657216199",
+        "es": "applemusic://track/1657216199",
+        "nl": "applemusic://track/1657216199",
+        "it": "applemusic://track/1657216199"
+      }
     },
     {
       "year": 1949,
@@ -2360,7 +2820,17 @@
       "awards_nl": [
         "Oscar voor Beste Originele Lied (1976)",
         "Golden Globe voor Beste Originele Lied (1977)"
-      ]
+      ],
+      "isrc": "USSM10001384",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/192884975",
+        "de": "applemusic://track/192884975",
+        "gb": "applemusic://track/192884975",
+        "fr": "applemusic://track/192884975",
+        "es": "applemusic://track/192884975",
+        "nl": "applemusic://track/192884975",
+        "it": "applemusic://track/192884975"
+      }
     },
     {
       "year": 1980,
@@ -2392,7 +2862,17 @@
       "uri_tidal": "tidal://track/6836336",
       "uri_deezer": "deezer://track/12206981",
       "fun_fact_nl": "Queen schreef het thema van Flash voor Flash Gordon. De opera-achtige zang van Freddie Mercury paste perfect bij de campy toon van de film.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBUM71103355",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1440807379",
+        "de": "applemusic://track/1442443079",
+        "gb": "applemusic://track/1442443079",
+        "fr": "applemusic://track/1442443079",
+        "es": "applemusic://track/1442443079",
+        "nl": "applemusic://track/1442443079",
+        "it": "applemusic://track/1442443079"
+      }
     },
     {
       "year": 1985,
@@ -2447,7 +2927,17 @@
       "uri_tidal": "tidal://track/74417588",
       "uri_deezer": "deezer://track/366403141",
       "fun_fact_nl": "Sunrise, Sunset uit Fiddler on the Roof geeft bitterzoete vreugde weer. Het lied is niet meer weg te denken van Joodse bruiloften over de hele wereld.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USRC16808059",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1240963025",
+        "de": "applemusic://track/275141212",
+        "gb": "applemusic://track/275141212",
+        "fr": "applemusic://track/275141212",
+        "es": "applemusic://track/275141212",
+        "nl": "applemusic://track/275141212",
+        "it": "applemusic://track/275141212"
+      }
     },
     {
       "year": 1969,
@@ -2481,7 +2971,17 @@
       "uri_tidal": "tidal://track/265600746",
       "uri_deezer": "deezer://track/2064134097",
       "fun_fact_nl": "Lee Marvin's schorre Wand'rin' Star uit Paint Your Wagon kwam verrassend op nummer één in het Verenigd Koninkrijk en versloeg The Beatles.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "QZECT2106233",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1657796080",
+        "de": "applemusic://track/1657796080",
+        "gb": "applemusic://track/1657796080",
+        "fr": "applemusic://track/1657796080",
+        "es": "applemusic://track/1657796080",
+        "nl": "applemusic://track/1657796080",
+        "it": "applemusic://track/1657796080"
+      }
     },
     {
       "year": 1980,
@@ -2510,7 +3010,17 @@
       "uri_tidal": "tidal://track/184933857",
       "uri_deezer": "deezer://track/1379125732",
       "fun_fact_nl": "Op de soundtrack van Giorgio Moroder's Foxes staan Donna Summer en andere discoartiesten, die de late jaren 70 clubscene van LA vastleggen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USIR20300668",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1567146201",
+        "de": "applemusic://track/1567146201",
+        "gb": "applemusic://track/1567146201",
+        "fr": "applemusic://track/1567146201",
+        "es": "applemusic://track/1567146201",
+        "nl": "applemusic://track/1567146201",
+        "it": "applemusic://track/1567146201"
+      }
     },
     {
       "year": 1968,
@@ -2538,7 +3048,17 @@
       ],
       "uri_tidal": "tidal://track/172057741",
       "fun_fact_nl": "Lalo Schifrin's score voor Bullitt was een pionier op het gebied van cool jazz in actiefilms. De achtervolging had helemaal geen muziek nodig.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USARI0101801",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1551819861",
+        "de": "applemusic://track/1551819861",
+        "gb": "applemusic://track/1551819861",
+        "fr": "applemusic://track/1551819861",
+        "es": "applemusic://track/1551819861",
+        "nl": "applemusic://track/1551819861",
+        "it": "applemusic://track/1551819861"
+      }
     },
     {
       "year": 2019,
@@ -2567,7 +3087,17 @@
       "uri_tidal": "tidal://track/116579871",
       "uri_deezer": "deezer://track/108213342",
       "fun_fact_nl": "De soundtrack van Once Upon a Time in Hollywood bevat diepe stukken uit de jaren 60. Tarantino heeft elk nummer persoonlijk samengesteld.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMC16519931",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1444009605",
+        "de": "applemusic://track/1452187664",
+        "gb": "applemusic://track/1452187664",
+        "fr": "applemusic://track/1444009605",
+        "es": "applemusic://track/1452187664",
+        "nl": "applemusic://track/1452187664",
+        "it": "applemusic://track/1452187664"
+      }
     },
     {
       "year": 1983,
@@ -2611,7 +3141,17 @@
       "fun_fact_nl": "Ryuichi Sakamoto componeerde en speelde de hoofdrol in Merry Christmas Mr. Lawrence. David Sylvian voegde vocalen toe aan Forbidden Colours.",
       "awards_nl": [
         "BAFTA voor Beste Filmmuziek (1983)"
-      ]
+      ],
+      "isrc": "US5941405510",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1500818278",
+        "de": "applemusic://track/1500818278",
+        "gb": "applemusic://track/1500818278",
+        "fr": "applemusic://track/1500818278",
+        "es": "applemusic://track/1500818278",
+        "nl": "applemusic://track/1500818278",
+        "it": "applemusic://track/1500818278"
+      }
     },
     {
       "year": 1978,
@@ -2683,7 +3223,17 @@
       "uri_tidal": "tidal://track/4916791",
       "uri_deezer": "deezer://track/13147190",
       "fun_fact_nl": "Het Men in Black-thema van Danny Elfman combineert de spanning van spionagefilms met sci-fi-komedie, passend bij de oneerbiedige toon van de film.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM19701030",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/157495883",
+        "de": "applemusic://track/279366740",
+        "gb": "applemusic://track/279366740",
+        "fr": "applemusic://track/279366740",
+        "es": "applemusic://track/279366740",
+        "nl": "applemusic://track/279366740",
+        "it": "applemusic://track/279366740"
+      }
     },
     {
       "year": 2022,
@@ -2712,7 +3262,17 @@
       "uri_tidal": "tidal://track/233998376",
       "uri_deezer": "deezer://track/1793589807",
       "fun_fact_nl": "In Elvis (2022) speelt Austin Butler veel nummers zelf. De film gebruikt originele opnames van Elvis voor bepaalde scènes.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USRC12201935",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1675583296",
+        "de": "applemusic://track/1675583296",
+        "gb": "applemusic://track/1675583296",
+        "fr": "applemusic://track/1675583296",
+        "es": "applemusic://track/1675583296",
+        "nl": "applemusic://track/1675583296",
+        "it": "applemusic://track/1675583296"
+      }
     },
     {
       "year": 1960,
@@ -2787,7 +3347,17 @@
       "uri_tidal": "tidal://track/289142185",
       "uri_deezer": "deezer://track/2238201037",
       "fun_fact_nl": "Tina Turner's We Don't Need Another Hero werd een volkslied van de jaren 80. Mad Max Beyond Thunderdome lanceerde haar filmcarrière.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USCA29400741",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1681196890",
+        "de": "applemusic://track/1681196890",
+        "gb": "applemusic://track/1681196890",
+        "fr": "applemusic://track/1681196890",
+        "es": "applemusic://track/1681196890",
+        "nl": "applemusic://track/1681196890",
+        "it": "applemusic://track/1681196890"
+      }
     },
     {
       "year": 1964,
@@ -2822,7 +3392,17 @@
       "uri_tidal": "tidal://track/59577047",
       "uri_deezer": "deezer://track/3093484",
       "fun_fact_nl": "Goldfinger van Shirley Bassey was het eerste Bond-thema dat een hit werd. Haar krachtige zang zette de standaard voor alle toekomstige Bond-songs.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAYE0001387",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1801513059",
+        "de": "applemusic://track/1358615271",
+        "gb": "applemusic://track/1358615271",
+        "fr": "applemusic://track/1358615271",
+        "es": "applemusic://track/1358615271",
+        "nl": "applemusic://track/1358615271",
+        "it": "applemusic://track/1358615271"
+      }
     },
     {
       "year": 1978,
@@ -2850,7 +3430,17 @@
       ],
       "uri_deezer": "deezer://track/102007907",
       "fun_fact_nl": "John Carpenter componeerde het thema van Halloween zelf op synthesizer. Het eenvoudige 5/4 pianomotiefje kostte bijna niets om te maken.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "TCAAR1072726",
+      "uri_apple_music_by_region": {
+        "us": null,
+        "de": null,
+        "gb": null,
+        "fr": null,
+        "es": null,
+        "nl": null,
+        "it": null
+      }
     },
     {
       "year": 1942,
@@ -2882,7 +3472,17 @@
       "uri_tidal": "tidal://track/105513019",
       "uri_deezer": "deezer://track/56382111",
       "fun_fact_nl": "As Time Goes By werd geschreven in 1931, niet voor Casablanca. De studio wilde het verwijderen, maar het publiek vond het geweldig.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USNLR1300066",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1455698341",
+        "de": "applemusic://track/1455698341",
+        "gb": "applemusic://track/1455698341",
+        "fr": "applemusic://track/1455698341",
+        "es": "applemusic://track/1455698341",
+        "nl": "applemusic://track/1455698341",
+        "it": "applemusic://track/1455698341"
+      }
     },
     {
       "year": 2012,
@@ -2911,7 +3511,17 @@
       "uri_tidal": "tidal://track/18361880",
       "uri_deezer": "deezer://track/62953943",
       "fun_fact_nl": "Django Unchained opent met het originele Django-thema van Luis Bacalov uit 1966, dat Tarantino's film verbindt met Spaghettiwesterns.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USUG11201339",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1440874258",
+        "de": "applemusic://track/1440874258",
+        "gb": "applemusic://track/1440874258",
+        "fr": "applemusic://track/1440874258",
+        "es": "applemusic://track/1440874258",
+        "nl": "applemusic://track/1440874258",
+        "it": "applemusic://track/1440874258"
+      }
     },
     {
       "year": 1996,
@@ -2940,7 +3550,17 @@
       "uri_tidal": "tidal://track/63235162",
       "uri_deezer": "deezer://track/129309962",
       "fun_fact_nl": "De Mission: Impossible filmserie bleef het TV-thema van Lalo Schifrin gebruiken. Het blijft een van de meest herkenbare spionagemotieven.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMC16846984",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1443835382",
+        "de": "applemusic://track/1443835382",
+        "gb": "applemusic://track/1443835382",
+        "fr": "applemusic://track/1443835382",
+        "es": "applemusic://track/1443835382",
+        "nl": "applemusic://track/1443835382",
+        "it": "applemusic://track/1443835382"
+      }
     },
     {
       "year": 1968,
@@ -3021,7 +3641,17 @@
       "awards_nl": [
         "Oscar voor Beste Originele Filmmuziek (1960)",
         "Golden Globe voor Beste Originele Filmmuziek (1961)"
-      ]
+      ],
+      "isrc": "USRC10101348",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1719334913",
+        "de": null,
+        "gb": null,
+        "fr": null,
+        "es": null,
+        "nl": null,
+        "it": null
+      }
     },
     {
       "year": 1999,
@@ -3052,7 +3682,17 @@
       "uri_tidal": "tidal://track/88078827",
       "uri_deezer": "deezer://track/493896182",
       "fun_fact_nl": "John Williams' Duel of the Fates introduceerde koorelementen in Star Wars. De Sanskriet-geïnspireerde tekst werd geschreven voor de partituur.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USWD11785380",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1375814326",
+        "de": "applemusic://track/1376601337",
+        "gb": "applemusic://track/1375814326",
+        "fr": "applemusic://track/1376598370",
+        "es": "applemusic://track/1376604929",
+        "nl": "applemusic://track/1375814326",
+        "it": "applemusic://track/1376604746"
+      }
     },
     {
       "year": 1939,
@@ -3094,7 +3734,17 @@
       "fun_fact_nl": "Max Steiner's Gone with the Wind partituur was in die tijd de langste die ooit geschreven was. Hij componeerde drie uur muziek in slechts drie maanden.",
       "awards_nl": [
         "Oscar voor Beste Originele Filmmuziek (1939)"
-      ]
+      ],
+      "isrc": "USNLR1300001",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1454324974",
+        "de": "applemusic://track/1454324974",
+        "gb": "applemusic://track/1454324974",
+        "fr": "applemusic://track/1454324974",
+        "es": "applemusic://track/1454324974",
+        "nl": "applemusic://track/1454324974",
+        "it": "applemusic://track/1454324974"
+      }
     },
     {
       "year": 1986,
@@ -3156,7 +3806,17 @@
       "uri_tidal": "tidal://track/416278150",
       "uri_deezer": "deezer://track/3221383221",
       "fun_fact_nl": "In For a Few Dollars More van Ennio Morricone komt een muzikaal zakhorloge voor. De melodie wordt een plottwist in de film.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "ITF730501074",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1718039376",
+        "de": "applemusic://track/1718039376",
+        "gb": "applemusic://track/1718039376",
+        "fr": "applemusic://track/1718039376",
+        "es": "applemusic://track/1718039376",
+        "nl": "applemusic://track/1718039376",
+        "it": "applemusic://track/1718039376"
+      }
     },
     {
       "year": 1981,
@@ -3203,7 +3863,17 @@
       "fun_fact_nl": "Het Chariots of Fire-thema van Vangelis maakt gebruik van synthesizers om slow-motion rennen op te roepen. Het won de Oscar voor Beste Originele Score.",
       "awards_nl": [
         "Oscar voor Beste Originele Filmmuziek (1981)"
-      ]
+      ],
+      "isrc": "NLA028100010",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1450958727",
+        "de": "applemusic://track/1450958727",
+        "gb": "applemusic://track/1450958727",
+        "fr": "applemusic://track/1450958727",
+        "es": "applemusic://track/1450958727",
+        "nl": "applemusic://track/1450958727",
+        "it": "applemusic://track/1450958727"
+      }
     },
     {
       "year": 1984,
@@ -3250,7 +3920,17 @@
       "fun_fact_nl": "Ray Parker Jr. schreef Ghostbusters nadat hij de film had gezien. Hij werd aangeklaagd door Huey Lewis voor de gelijkenis met I Want a New Drug.",
       "awards_nl": [
         "Oscarnominatie voor Beste Originele Lied (1984)"
-      ]
+      ],
+      "isrc": "USAR18400117",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1692216413",
+        "de": "applemusic://track/1719230705",
+        "gb": "applemusic://track/1719230705",
+        "fr": "applemusic://track/1719230705",
+        "es": "applemusic://track/1719230705",
+        "nl": "applemusic://track/1719230705",
+        "it": "applemusic://track/1719230705"
+      }
     },
     {
       "year": 1973,
@@ -3329,7 +4009,17 @@
       "uri_tidal": "tidal://track/3748044",
       "uri_deezer": "deezer://track/4094807",
       "fun_fact_nl": "Living Daylights van A-ha was het eerste Bond-thema van een rockband. De Noorse groep bracht synthesizers naar de 007-franchise.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USWB10403938",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1748181688",
+        "de": "applemusic://track/1748181688",
+        "gb": "applemusic://track/1748181688",
+        "fr": "applemusic://track/1748181688",
+        "es": "applemusic://track/1748181688",
+        "nl": "applemusic://track/1748181688",
+        "it": "applemusic://track/1748181688"
+      }
     },
     {
       "year": 1958,
@@ -3358,7 +4048,17 @@
       "uri_tidal": "tidal://track/37075407",
       "uri_deezer": "deezer://track/123339850",
       "fun_fact_nl": "Bernard Herrmanns Vertigo score gebruikt wervelende strijkers om obsessie te weerspiegelen. Hitchcock vond het essentieel voor het effect van de film.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "FRZ811209020",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/600474544",
+        "de": "applemusic://track/600474544",
+        "gb": "applemusic://track/600474544",
+        "fr": "applemusic://track/599988249",
+        "es": "applemusic://track/600474544",
+        "nl": "applemusic://track/600474544",
+        "it": "applemusic://track/600474544"
+      }
     },
     {
       "year": 1967,
@@ -3390,7 +4090,17 @@
       "uri_tidal": "tidal://track/153868467",
       "uri_deezer": "deezer://track/112773936",
       "fun_fact_nl": "Casino Royale uit 1967 was een parodie met meerdere regisseurs. Het thema van Herb Alpert geeft de chaotisch-komische toon van de film goed weer.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "QM4221500255",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1530113036",
+        "de": "applemusic://track/1530113036",
+        "gb": "applemusic://track/1530113036",
+        "fr": "applemusic://track/1530113036",
+        "es": "applemusic://track/1530113036",
+        "nl": "applemusic://track/1530113036",
+        "it": "applemusic://track/1530113036"
+      }
     },
     {
       "year": 1982,
@@ -3437,7 +4147,17 @@
       "awards_nl": [
         "Oscar voor Beste Originele Filmmuziek (1982)",
         "Grammy Award voor Beste Soundtrackpartituur (1983)"
-      ]
+      ],
+      "isrc": "USSM19603560",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1046366480",
+        "de": "applemusic://track/1046366480",
+        "gb": "applemusic://track/1046366480",
+        "fr": "applemusic://track/1046366480",
+        "es": "applemusic://track/1046366480",
+        "nl": "applemusic://track/1046366480",
+        "it": "applemusic://track/1046366480"
+      }
     },
     {
       "year": 1991,
@@ -3466,7 +4186,17 @@
       "uri_tidal": "tidal://track/70546774",
       "uri_deezer": "deezer://track/142745594",
       "fun_fact_nl": "Het Terminator 2-thema van Brad Fiedel maakt gebruik van metaalachtige geluiden en synthesizers om zowel machines als hartslagen op te roepen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "FRS439100034",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1714547761",
+        "de": "applemusic://track/1714547761",
+        "gb": "applemusic://track/1714547761",
+        "fr": "applemusic://track/1714547761",
+        "es": "applemusic://track/1714547761",
+        "nl": "applemusic://track/1714547761",
+        "it": "applemusic://track/1714547761"
+      }
     },
     {
       "year": 1972,
@@ -3500,7 +4230,17 @@
       "uri_tidal": "tidal://track/216857",
       "uri_deezer": "deezer://track/724941",
       "fun_fact_nl": "Dueling Banjos werd in één take opgenomen voor Deliverance. De scène waarin een stadsjongen jamt met een plaatselijke bewoner werd iconisch.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USWB19904166",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1548478990",
+        "de": "applemusic://track/1548478990",
+        "gb": "applemusic://track/1548478990",
+        "fr": "applemusic://track/1548478990",
+        "es": "applemusic://track/1548478990",
+        "nl": "applemusic://track/1548478990",
+        "it": "applemusic://track/1548478990"
+      }
     },
     {
       "year": 1976,
@@ -3562,7 +4302,17 @@
       "uri_tidal": "tidal://track/105363998",
       "uri_deezer": "deezer://track/3991703",
       "fun_fact_nl": "Gene Kelly voerde Singin' in the Rain op terwijl hij ziek was met 103 graden koorts. De plassen werden gemengd met melk voor de zichtbaarheid.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USNLR1200586",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1455420758",
+        "de": "applemusic://track/1455420758",
+        "gb": "applemusic://track/1455420758",
+        "fr": "applemusic://track/1455420758",
+        "es": "applemusic://track/1455420758",
+        "nl": "applemusic://track/1455420758",
+        "it": "applemusic://track/1455420758"
+      }
     },
     {
       "year": 2011,
@@ -3630,7 +4380,17 @@
       "uri_tidal": "tidal://track/27598682",
       "uri_deezer": "deezer://track/76541486",
       "fun_fact_nl": "De score van Ennio Morricone voor The Thing werd afgewezen door John Carpenter, die het te vreemd vond. Het wordt nu beschouwd als een klassieker.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAJC0203994",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1452656167",
+        "de": "applemusic://track/1452656167",
+        "gb": "applemusic://track/1452656167",
+        "fr": "applemusic://track/1452656167",
+        "es": "applemusic://track/1452656167",
+        "nl": "applemusic://track/1452656167",
+        "it": "applemusic://track/1452656167"
+      }
     },
     {
       "year": 1982,
@@ -3689,7 +4449,17 @@
       "uri_tidal": "tidal://track/105619276",
       "uri_deezer": "deezer://track/674743752",
       "fun_fact_nl": "Het North by Northwest-thema van Bernard Herrmann is een fandango die de spanning van de film aandrijft. Hitchcock noemde Herrmann essentieel.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USNLR1400293",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1455885358",
+        "de": "applemusic://track/1455885358",
+        "gb": "applemusic://track/1455885358",
+        "fr": "applemusic://track/1455885358",
+        "es": "applemusic://track/1455885358",
+        "nl": "applemusic://track/1455885358",
+        "it": "applemusic://track/1455885358"
+      }
     },
     {
       "year": 1939,
@@ -3736,7 +4506,17 @@
       "fun_fact_nl": "Over the Rainbow was bijna uit The Wizard of Oz geknipt. Het won de Oscar en werd het lijflied van Judy Garland.",
       "awards_nl": [
         "Oscar voor Beste Originele Lied (1939)"
-      ]
+      ],
+      "isrc": "USNLR1500393",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1455918432",
+        "de": "applemusic://track/1455918432",
+        "gb": "applemusic://track/1455918432",
+        "fr": "applemusic://track/1455918432",
+        "es": "applemusic://track/1455918432",
+        "nl": "applemusic://track/1455918432",
+        "it": "applemusic://track/1455918432"
+      }
     },
     {
       "year": 1982,
@@ -3768,7 +4548,17 @@
       "uri_tidal": "tidal://track/3291296",
       "uri_deezer": "deezer://track/2228633",
       "fun_fact_nl": "David Bowie's Cat People thema werd geschreven met Giorgio Moroder. Het beklijvende nummer ging langer mee dan de film waarvoor het was geschreven.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMC18212795",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1443427544",
+        "de": "applemusic://track/1443427544",
+        "gb": "applemusic://track/1443427544",
+        "fr": "applemusic://track/1443427544",
+        "es": "applemusic://track/1443427544",
+        "nl": "applemusic://track/1443427544",
+        "it": "applemusic://track/1443427544"
+      }
     },
     {
       "year": 1968,
@@ -3853,7 +4643,17 @@
       "uri_tidal": "tidal://track/35119917",
       "uri_deezer": "deezer://track/123818654",
       "fun_fact_nl": "Bernard Herrmanns score voor Psycho bevat alleen strijkers. De gierende violen in de douchescène veranderden de muziek van horrorfilms voorgoed.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "US3M59776501",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1440795713",
+        "de": "applemusic://track/1440795713",
+        "gb": "applemusic://track/1440795713",
+        "fr": "applemusic://track/1440795713",
+        "es": "applemusic://track/1440795713",
+        "nl": "applemusic://track/1440795713",
+        "it": "applemusic://track/1440795713"
+      }
     },
     {
       "year": 1955,
@@ -3986,7 +4786,17 @@
       "fun_fact_nl": "Mike Oldfield's Tubular Bells werden beroemd door The Exorcist. Het album verkocht miljoenen exemplaren na het gebruik ervan in de horrorklassieker.",
       "awards_nl": [
         "Grammy Award voor Beste Instrumentaal (1975)"
-      ]
+      ],
+      "isrc": "GBUM70905030",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1647479393",
+        "de": "applemusic://track/1647479393",
+        "gb": "applemusic://track/1440818532",
+        "fr": "applemusic://track/1647479393",
+        "es": "applemusic://track/1647479393",
+        "nl": "applemusic://track/1647479393",
+        "it": "applemusic://track/1647479393"
+      }
     },
     {
       "year": 1959,
@@ -4028,7 +4838,17 @@
       "fun_fact_nl": "Miklos Rozsa's Ben-Hur score vereiste het grootste orkest ooit bijeengebracht voor een film. Het won de Oscar voor Beste Score.",
       "awards_nl": [
         "Oscar voor Beste Originele Filmmuziek (1959)"
-      ]
+      ],
+      "isrc": "USNLR1400192",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1455700172",
+        "de": "applemusic://track/1455700172",
+        "gb": "applemusic://track/1455700172",
+        "fr": "applemusic://track/1455700172",
+        "es": "applemusic://track/1455700172",
+        "nl": "applemusic://track/1455700172",
+        "it": "applemusic://track/1455700172"
+      }
     },
     {
       "year": 1992,
@@ -4101,7 +4921,17 @@
       "fun_fact_nl": "Het Lawrence of Arabia-thema van Maurice Jarre roept de uitgestrektheid van de woestijn op. De score won een Oscar en definieerde epische cinema.",
       "awards_nl": [
         "Oscar voor Beste Originele Filmmuziek (1962)"
-      ]
+      ],
+      "isrc": "FRZ811210002",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1663023916",
+        "de": "applemusic://track/1663023916",
+        "gb": "applemusic://track/1663023916",
+        "fr": "applemusic://track/593750475",
+        "es": "applemusic://track/1663023916",
+        "nl": "applemusic://track/1663023916",
+        "it": "applemusic://track/1663023916"
+      }
     },
     {
       "year": 1976,
@@ -4130,7 +4960,17 @@
       "uri_tidal": "tidal://track/515654",
       "uri_deezer": "deezer://track/958971",
       "fun_fact_nl": "Bernard Herrmanns Taxi Driver score was zijn laatste. Hij stierf de nacht na het voltooien van de opnamesessies.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USAR17600242",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/174892425",
+        "de": "applemusic://track/174892425",
+        "gb": "applemusic://track/174892425",
+        "fr": "applemusic://track/174892425",
+        "es": "applemusic://track/174892425",
+        "nl": "applemusic://track/174892425",
+        "it": "applemusic://track/174892425"
+      }
     },
     {
       "year": 1964,
@@ -4159,7 +4999,17 @@
       "uri_tidal": "tidal://track/77377947",
       "uri_deezer": "deezer://track/86980803",
       "fun_fact_nl": "Het A Fistful of Dollars-thema van Ennio Morricone creëerde het Spaghettiwestern-geluid. Het fluiten en het kraken van de zweep werden iconisch.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "ITB006400699",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1440831930",
+        "de": "applemusic://track/1718039373",
+        "gb": "applemusic://track/1718039373",
+        "fr": "applemusic://track/1718039373",
+        "es": "applemusic://track/1718039373",
+        "nl": "applemusic://track/1718039373",
+        "it": "applemusic://track/1718039373"
+      }
     },
     {
       "year": 1971,
@@ -4191,7 +5041,17 @@
       "uri_tidal": "tidal://track/1483628",
       "uri_deezer": "deezer://track/3093485",
       "fun_fact_nl": "Diamonds Are Forever van Shirley Bassey was haar tweede Bond-thema. Ze blijft de enige artiest die drie 007-nummers heeft gezongen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMG21500012",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1443116804",
+        "de": null,
+        "gb": null,
+        "fr": null,
+        "es": null,
+        "nl": null,
+        "it": null
+      }
     },
     {
       "year": 1979,
@@ -4219,7 +5079,17 @@
       ],
       "uri_tidal": "tidal://track/36616798",
       "fun_fact_nl": "Wagners Ride of the Valkyries in Apocalypse Now begeleidt een helikopteraanval. Coppola maakte klassieke muziek angstaanjagend.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "SEWDL6013547",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/927346120",
+        "de": "applemusic://track/927346120",
+        "gb": "applemusic://track/927346120",
+        "fr": "applemusic://track/927346120",
+        "es": "applemusic://track/927346120",
+        "nl": "applemusic://track/927346120",
+        "it": "applemusic://track/927346120"
+      }
     },
     {
       "year": 1962,
@@ -4261,7 +5131,17 @@
       "fun_fact_nl": "De partituur van Elmer Bernstein voor To Kill a Mockingbird gebruikt een eenvoudig pianothema om de onschuld van een kindertijd en zuidelijke omgevingen op te roepen.",
       "awards_nl": [
         "Oscarnominatie voor Beste Originele Filmmuziek (1962)"
-      ]
+      ],
+      "isrc": "US3M59904201",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1444004606",
+        "de": "applemusic://track/1444004606",
+        "gb": "applemusic://track/1444004606",
+        "fr": "applemusic://track/1444004606",
+        "es": "applemusic://track/1444004606",
+        "nl": "applemusic://track/1444004606",
+        "it": "applemusic://track/1444004606"
+      }
     },
     {
       "year": 1980,
@@ -4297,7 +5177,17 @@
       "uri_tidal": "tidal://track/20313830",
       "uri_deezer": "deezer://track/13163936",
       "fun_fact_nl": "Xanadu van Olivia Newton-John combineerde disco met ELO-rock. De film flopte maar de soundtrack was een commercieel succes.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMC18010384",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1440743615",
+        "de": null,
+        "gb": null,
+        "fr": null,
+        "es": null,
+        "nl": null,
+        "it": null
+      }
     },
     {
       "year": 1961,
@@ -4387,7 +5277,17 @@
       "fun_fact_nl": "The Bare Necessities uit The Jungle Book was het laatste nummer dat Walt Disney goedkeurde voor zijn dood in 1966.",
       "awards_nl": [
         "Oscarnominatie voor Beste Originele Lied (1967)"
-      ]
+      ],
+      "isrc": "USWD10423008",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1463094850",
+        "de": "applemusic://track/1463094850",
+        "gb": "applemusic://track/1463094850",
+        "fr": "applemusic://track/1463094850",
+        "es": "applemusic://track/1463094850",
+        "nl": "applemusic://track/1463094850",
+        "it": "applemusic://track/1463094850"
+      }
     },
     {
       "year": 1973,
@@ -4419,7 +5319,17 @@
       "uri_tidal": "tidal://track/4681614",
       "uri_deezer": "deezer://track/7398186",
       "fun_fact_nl": "Day by Day uit Godspell werd een pophit. Het zachte folkrocknummer verspreidde de gospelboodschap van de musical wereldwijd.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USAR17400104",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/459757919",
+        "de": "applemusic://track/260129227",
+        "gb": "applemusic://track/260129227",
+        "fr": "applemusic://track/260129227",
+        "es": "applemusic://track/260129227",
+        "nl": "applemusic://track/260129227",
+        "it": "applemusic://track/260129227"
+      }
     },
     {
       "year": 1942,
@@ -4447,7 +5357,17 @@
       "uri_tidal": "tidal://track/105513000",
       "uri_deezer": "deezer://track/1477360442",
       "fun_fact_nl": "De score van Casablanca verweeft klassiek, jazz en het Franse volkslied La Marseillaise in een krachtige barscène.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USNLR1300047",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1455697817",
+        "de": "applemusic://track/1455697817",
+        "gb": "applemusic://track/1455697817",
+        "fr": "applemusic://track/1455697817",
+        "es": "applemusic://track/1455697817",
+        "nl": "applemusic://track/1455697817",
+        "it": "applemusic://track/1455697817"
+      }
     },
     {
       "year": 1979,
@@ -4489,7 +5409,17 @@
       "fun_fact_nl": "Jerry Goldsmith's Alien score creëert angst door middel van atonale strijkers en vreemde geluiden. De stilte is net zo effectief als de muziek.",
       "awards_nl": [
         "Oscarnominatie voor Beste Originele Filmmuziek (1979)"
-      ]
+      ],
+      "isrc": "USUM70759228",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1798286213",
+        "de": "applemusic://track/1798286213",
+        "gb": "applemusic://track/1798286213",
+        "fr": "applemusic://track/1798286213",
+        "es": "applemusic://track/1798286213",
+        "nl": "applemusic://track/1798286213",
+        "it": "applemusic://track/1798286213"
+      }
     },
     {
       "year": 1971,
@@ -4516,7 +5446,17 @@
       ],
       "uri_tidal": "tidal://track/68943398",
       "fun_fact_nl": "Rossini's Thieving Magpie ouverture begeleidt het ultrageweld in A Clockwork Orange. Kubricks klassieke keuzes werden zijn handelsmerk.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "HKI199296401",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1227748545",
+        "de": "applemusic://track/1227748545",
+        "gb": "applemusic://track/1227748545",
+        "fr": "applemusic://track/1227748545",
+        "es": "applemusic://track/1227748545",
+        "nl": "applemusic://track/1227748545",
+        "it": "applemusic://track/1227748545"
+      }
     },
     {
       "year": 1981,
@@ -4568,7 +5508,17 @@
       "awards_nl": [
         "Oscar voor Beste Originele Lied (1981)",
         "Golden Globe voor Beste Originele Lied (1982)"
-      ]
+      ],
+      "isrc": "USWB10800109",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/273426183",
+        "de": "applemusic://track/1549643307",
+        "gb": "applemusic://track/1549643307",
+        "fr": "applemusic://track/1549643307",
+        "es": "applemusic://track/1549643307",
+        "nl": "applemusic://track/1549643307",
+        "it": "applemusic://track/1549643307"
+      }
     },
     {
       "year": 2000,
@@ -4613,7 +5563,17 @@
       "awards_nl": [
         "Oscar voor Beste Originele Filmmuziek (2000)",
         "Golden Globe voor Beste Originele Filmmuziek (2001)"
-      ]
+      ],
+      "isrc": "USUMC0110060",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1452552843",
+        "de": "applemusic://track/1452552843",
+        "gb": "applemusic://track/1452552843",
+        "fr": "applemusic://track/1452552843",
+        "es": "applemusic://track/1452552843",
+        "nl": "applemusic://track/1452552843",
+        "it": "applemusic://track/1452552843"
+      }
     },
     {
       "year": 1995,
@@ -4655,7 +5615,17 @@
       "fun_fact_nl": "De muziek voor Braveheart van James Horner maakt gebruik van Schotse instrumenten zoals doedelzakken en Uilleann pipes. Het won de Oscar.",
       "awards_nl": [
         "Oscar voor Beste Originele Filmmuziek (1995)"
-      ]
+      ],
+      "isrc": "GBBBA9570201",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1440773543",
+        "de": "applemusic://track/1440773543",
+        "gb": "applemusic://track/1440773543",
+        "fr": "applemusic://track/1440773543",
+        "es": "applemusic://track/1440773543",
+        "nl": "applemusic://track/1440773543",
+        "it": "applemusic://track/1440773543"
+      }
     },
     {
       "year": 1954,
@@ -4696,7 +5666,17 @@
       "fun_fact_nl": "Seven Brides for Seven Brothers bevat uitgebreide choreografie voor het optrekken in de schuur. De musical werd gefilmd in 30 dagen.",
       "awards_nl": [
         "Oscar voor Beste Filmmuziek (1954)"
-      ]
+      ],
+      "isrc": "USNLR1701181",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1658406090",
+        "de": "applemusic://track/1658406090",
+        "gb": "applemusic://track/1658406090",
+        "fr": "applemusic://track/1658406090",
+        "es": "applemusic://track/1658406090",
+        "nl": "applemusic://track/1658406090",
+        "it": "applemusic://track/1658406090"
+      }
     },
     {
       "year": 1968,
@@ -4725,7 +5705,17 @@
       "uri_tidal": "tidal://track/109093771",
       "uri_deezer": "deezer://track/7695319",
       "fun_fact_nl": "Jerry Goldsmiths score voor Planet of the Apes maakt gebruik van onconventionele instrumenten, waaronder ramshoorns en mengkommen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "US3M59784802",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1443095011",
+        "de": "applemusic://track/1443095011",
+        "gb": "applemusic://track/1443095011",
+        "fr": "applemusic://track/1443095011",
+        "es": "applemusic://track/1443095011",
+        "nl": "applemusic://track/1443095011",
+        "it": "applemusic://track/1443095011"
+      }
     },
     {
       "year": 1965,
@@ -4773,7 +5763,17 @@
       "fun_fact_nl": "What's New Pussycat van Burt Bacharach werd genomineerd voor een Oscar. De energieke uitvoering van Tom Jones maakte er een nieuwe hit van.",
       "awards_nl": [
         "Oscarnominatie voor Beste Originele Lied (1965)"
-      ]
+      ],
+      "isrc": "GBF076520020",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1409945250",
+        "de": "applemusic://track/1442492045",
+        "gb": "applemusic://track/1442492045",
+        "fr": "applemusic://track/1442492045",
+        "es": "applemusic://track/1442492045",
+        "nl": "applemusic://track/1442492045",
+        "it": "applemusic://track/1440717481"
+      }
     },
     {
       "year": 1957,
@@ -4836,7 +5836,17 @@
       "uri_tidal": "tidal://track/158177543",
       "uri_deezer": "deezer://track/1105410342",
       "fun_fact_nl": "Wendy Carlos' The Shining-score bevat elektronische versies van Berlioz en Bartok, die een verontrustende sfeer creëren.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USNLR2001474",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1535496635",
+        "de": "applemusic://track/1535496635",
+        "gb": "applemusic://track/1535496635",
+        "fr": "applemusic://track/1535496635",
+        "es": "applemusic://track/1535496635",
+        "nl": "applemusic://track/1535496635",
+        "it": "applemusic://track/1535496635"
+      }
     },
     {
       "year": 1969,
@@ -4864,7 +5874,17 @@
       "uri_tidal": "tidal://track/41349300",
       "uri_deezer": "deezer://track/95253896",
       "fun_fact_nl": "De score van Quincy Jones' Italian Job bevat Matt Monro's On Days Like These. De Mini Cooper achtervolging in de film werd legendarisch.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMC10300461",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1802763015",
+        "de": "applemusic://track/1802763015",
+        "gb": "applemusic://track/1802763015",
+        "fr": "applemusic://track/1802763015",
+        "es": "applemusic://track/1802763015",
+        "nl": "applemusic://track/1802763015",
+        "it": "applemusic://track/1802763015"
+      }
     },
     {
       "year": 1964,
@@ -4915,7 +5935,17 @@
       "awards_nl": [
         "Oscar voor Beste Originele Filmmuziek (1964)",
         "Oscar voor Beste Originele Lied (1964)"
-      ]
+      ],
+      "isrc": "USWD10423157",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1377468571",
+        "de": "applemusic://track/1377468571",
+        "gb": "applemusic://track/1377468571",
+        "fr": "applemusic://track/1377468571",
+        "es": "applemusic://track/1377468571",
+        "nl": "applemusic://track/1377468571",
+        "it": "applemusic://track/1377468571"
+      }
     },
     {
       "year": 1965,
@@ -4951,7 +5981,17 @@
       "uri_tidal": "tidal://track/55130682",
       "uri_deezer": "deezer://track/116348672",
       "fun_fact_nl": "The Beatles schreven Help! voor hun tweede film. Het titelnummer werd een van John Lennons meest persoonlijke composities.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAYE0601465",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1441164536",
+        "de": "applemusic://track/1441164536",
+        "gb": "applemusic://track/1441164536",
+        "fr": "applemusic://track/1441164536",
+        "es": "applemusic://track/1441164536",
+        "nl": "applemusic://track/1441164536",
+        "it": "applemusic://track/1441164536"
+      }
     },
     {
       "year": 1985,
@@ -4986,7 +6026,17 @@
       "uri_tidal": "tidal://track/54287690",
       "uri_deezer": "deezer://track/1352264822",
       "fun_fact_nl": "Simple Minds' Don't You Forget About Me definieerde The Breakfast Club. De band wees het nummer aanvankelijk af voordat ze het opnamen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAAA8500062",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1443234133",
+        "de": "applemusic://track/1443234133",
+        "gb": "applemusic://track/1443234133",
+        "fr": "applemusic://track/1443234133",
+        "es": "applemusic://track/1443234133",
+        "nl": "applemusic://track/1443234133",
+        "it": "applemusic://track/1443234133"
+      }
     },
     {
       "year": 1954,
@@ -5028,7 +6078,17 @@
       "fun_fact_nl": "Leonard Bernstein's score voor On the Waterfront bracht jazzinvloeden naar de dramatische film. De score won een Oscar.",
       "awards_nl": [
         "Oscar voor Beste Originele Filmmuziek (1954)"
-      ]
+      ],
+      "isrc": "US4DG1400204",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1816013634",
+        "de": "applemusic://track/1816013634",
+        "gb": "applemusic://track/1816013634",
+        "fr": "applemusic://track/1816013634",
+        "es": "applemusic://track/1816013634",
+        "nl": "applemusic://track/1816013634",
+        "it": "applemusic://track/1816013634"
+      }
     },
     {
       "year": 1963,
@@ -5057,7 +6117,17 @@
       "uri_tidal": "tidal://track/148845645",
       "uri_deezer": "deezer://track/2724821611",
       "fun_fact_nl": "Ernest Gold's It's a Mad, Mad, Mad, Mad World score past bij de manische komedie van de film. In het epos waren alle grote komieken te zien.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USTC50884676",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/285167010",
+        "de": "applemusic://track/285167010",
+        "gb": "applemusic://track/285167010",
+        "fr": "applemusic://track/285167010",
+        "es": "applemusic://track/285167010",
+        "nl": "applemusic://track/285167010",
+        "it": "applemusic://track/285167010"
+      }
     },
     {
       "year": 1962,
@@ -5102,7 +6172,17 @@
       "fun_fact_nl": "Henry Mancini's Baby Elephant Walk uit Hatari! werd een nieuwe hit. Het speelse deuntje paste bij de safarisetting van de film.",
       "awards_nl": [
         "Grammy Award voor Beste Instrumentaal (1963)"
-      ]
+      ],
+      "isrc": "USBB16101029",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/306820503",
+        "de": "applemusic://track/306820503",
+        "gb": "applemusic://track/306820503",
+        "fr": "applemusic://track/306820503",
+        "es": "applemusic://track/306820503",
+        "nl": "applemusic://track/306820503",
+        "it": "applemusic://track/306820503"
+      }
     },
     {
       "year": 1991,
@@ -5130,7 +6210,17 @@
       ],
       "uri_tidal": "tidal://track/4884284",
       "fun_fact_nl": "De score van Howard Shore voor Silence of the Lambs creëert psychologische angst. De subtiele muziek overweldigt nooit de spanning.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMC19034443",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1443219466",
+        "de": "applemusic://track/1443219466",
+        "gb": "applemusic://track/1443219466",
+        "fr": "applemusic://track/1443219466",
+        "es": "applemusic://track/1443219466",
+        "nl": "applemusic://track/1443219466",
+        "it": "applemusic://track/1443219466"
+      }
     },
     {
       "year": 1955,
@@ -5203,7 +6293,17 @@
       "uri_tidal": "tidal://track/172163782",
       "uri_deezer": "deezer://track/1231892972",
       "fun_fact_nl": "Lalo Schifrin's Dirty Harry score gebruikt jazz om de gruizige straten van San Francisco vast te leggen. Clint Eastwood werd een icoon.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USARI0403002",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/205808260",
+        "de": "applemusic://track/205808260",
+        "gb": "applemusic://track/205808260",
+        "fr": "applemusic://track/205808260",
+        "es": "applemusic://track/205808260",
+        "nl": "applemusic://track/205808260",
+        "it": "applemusic://track/205808260"
+      }
     },
     {
       "year": 1955,
@@ -5276,7 +6376,17 @@
       "fun_fact_nl": "John Williams' Close Encounters gebruikt een motief van vijf tonen voor buitenaardse communicatie. De sequentie werd popcultuur steno.",
       "awards_nl": [
         "Oscarnominatie voor Beste Originele Filmmuziek (1977)"
-      ]
+      ],
+      "isrc": "USAR10201963",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/306664733",
+        "de": "applemusic://track/306664733",
+        "gb": "applemusic://track/306664733",
+        "fr": "applemusic://track/306664733",
+        "es": "applemusic://track/306664733",
+        "nl": "applemusic://track/306664733",
+        "it": "applemusic://track/306664733"
+      }
     },
     {
       "year": 1959,
@@ -5364,7 +6474,17 @@
       "uri_tidal": "tidal://track/3175164",
       "uri_deezer": "deezer://track/14628816",
       "fun_fact_nl": "Concerning Hobbits van Howard Shore geeft de vredige huiselijkheid van de Shire weer. Het zachte thema maakt gebruik van tin whistle en fiddle.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USRE10102103",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/323714096",
+        "de": "applemusic://track/323714096",
+        "gb": "applemusic://track/323714096",
+        "fr": "applemusic://track/323714096",
+        "es": "applemusic://track/323714096",
+        "nl": "applemusic://track/323714096",
+        "it": "applemusic://track/323714096"
+      }
     },
     {
       "year": 1971,
@@ -5438,7 +6558,17 @@
       "uri_tidal": "tidal://track/17552268",
       "uri_deezer": "deezer://track/61148738",
       "fun_fact_nl": "Voyage to the Bottom of the Sea was het begin van Irwin Allen's carrière als rampenfilm. Frankie Avalon zingt de titelsong.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "QMDA71416012",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/826934339",
+        "de": "applemusic://track/826934339",
+        "gb": "applemusic://track/826934339",
+        "fr": "applemusic://track/826934339",
+        "es": "applemusic://track/826934339",
+        "nl": "applemusic://track/826934339",
+        "it": "applemusic://track/826934339"
+      }
     },
     {
       "year": 2007,
@@ -5469,7 +6599,17 @@
       "uri_tidal": "tidal://track/69135572",
       "uri_deezer": "deezer://track/3808822422",
       "fun_fact_nl": "Moby's Extreme Ways sluit elke Bourne-film af. De elektronische track werd net zo essentieel voor de franchise als de actie.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USUG10701295",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1442889719",
+        "de": null,
+        "gb": null,
+        "fr": null,
+        "es": null,
+        "nl": null,
+        "it": null
+      }
     },
     {
       "year": 1973,
@@ -5517,7 +6657,17 @@
       "fun_fact_nl": "Live and Let Die van Wings was het explosieve Bond-thema van Paul McCartney. Het was het eerste rocknummer in de franchise.",
       "awards_nl": [
         "Oscarnominatie voor Beste Originele Lied (1973)"
-      ]
+      ],
+      "isrc": "GBCCS7300674",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1440942228",
+        "de": "applemusic://track/1440942228",
+        "gb": "applemusic://track/1440942228",
+        "fr": "applemusic://track/1440942228",
+        "es": "applemusic://track/1440942228",
+        "nl": "applemusic://track/1440942228",
+        "it": "applemusic://track/1440942228"
+      }
     },
     {
       "year": 1968,
@@ -5546,7 +6696,17 @@
       "uri_tidal": "tidal://track/66780978",
       "uri_deezer": "deezer://track/76541459",
       "fun_fact_nl": "The Man With the Harmonica uit Once Upon a Time in the West vertelt een verhaal alleen al door middel van muziek. De melodie onthult de geschiedenis van een personage.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAAA6800002",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1452655336",
+        "de": "applemusic://track/1452299787",
+        "gb": "applemusic://track/1452655336",
+        "fr": "applemusic://track/1452655336",
+        "es": "applemusic://track/1452655336",
+        "nl": "applemusic://track/1452655336",
+        "it": "applemusic://track/1452655336"
+      }
     },
     {
       "year": 1999,
@@ -5575,7 +6735,17 @@
       "uri_tidal": "tidal://track/95842538",
       "uri_deezer": "deezer://track/561867002",
       "fun_fact_nl": "Het tweede nummer van Thomas Newman over American Beauty vangt de voorstedelijke ennui. De score maakt gebruik van percussie en omgevingsgeluiden.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USDW10010007",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1714548385",
+        "de": "applemusic://track/1714548385",
+        "gb": "applemusic://track/1714548385",
+        "fr": "applemusic://track/1714548385",
+        "es": "applemusic://track/1714548385",
+        "nl": "applemusic://track/1714548385",
+        "it": "applemusic://track/1714548385"
+      }
     },
     {
       "year": 1959,
@@ -5679,7 +6849,17 @@
         "Oscar voor Beste Originele Lied (1997)",
         "Golden Globe voor Beste Originele Lied (1998)",
         "Grammy Award voor Opname van het Jaar (1999)"
-      ]
+      ],
+      "isrc": "CAC229700123",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/507298988",
+        "de": "applemusic://track/506688835",
+        "gb": "applemusic://track/506688835",
+        "fr": "applemusic://track/506688835",
+        "es": "applemusic://track/506688835",
+        "nl": "applemusic://track/506688835",
+        "it": "applemusic://track/506688835"
+      }
     },
     {
       "year": 1969,
@@ -5710,7 +6890,17 @@
       "uri_tidal": "tidal://track/2409300",
       "uri_deezer": "deezer://track/3169677",
       "fun_fact_nl": "Louis Armstrongs We Have All the Time in the World sloot af met On Her Majesty's Secret Service. Het was zijn laatste opgenomen nummer.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMG26900002",
+      "uri_apple_music_by_region": {
+        "us": null,
+        "de": "applemusic://track/692547737",
+        "gb": "applemusic://track/692547737",
+        "fr": "applemusic://track/692547737",
+        "es": "applemusic://track/692547737",
+        "nl": "applemusic://track/692547737",
+        "it": "applemusic://track/692547737"
+      }
     },
     {
       "year": 1969,
@@ -5757,7 +6947,17 @@
       "fun_fact_nl": "Everybody's Talkin' van Harry Nilsson won een Grammy voor Midnight Cowboy. Het weemoedige nummer beschrijft dromen van ontsnapping.",
       "awards_nl": [
         "Grammy Award voor Beste Hedendaags Lied (1970)"
-      ]
+      ],
+      "isrc": "USEM36900044",
+      "uri_apple_music_by_region": {
+        "us": null,
+        "de": null,
+        "gb": null,
+        "fr": null,
+        "es": null,
+        "nl": null,
+        "it": null
+      }
     },
     {
       "year": 1980,
@@ -5786,7 +6986,17 @@
       "uri_tidal": "tidal://track/170567568",
       "uri_deezer": "deezer://track/1217644662",
       "fun_fact_nl": "Janis Ian's Fly Too High verscheen in Foxes. De coming-of-age film legde de punk- en discoscènes van LA vast.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USRG40340153",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1550210611",
+        "de": "applemusic://track/1550210611",
+        "gb": "applemusic://track/1550210611",
+        "fr": "applemusic://track/1550210611",
+        "es": "applemusic://track/1550210611",
+        "nl": "applemusic://track/1550210611",
+        "it": "applemusic://track/1550210611"
+      }
     },
     {
       "year": 1963,
@@ -5843,7 +7053,17 @@
       "uri_tidal": "tidal://track/207023490",
       "uri_deezer": "deezer://track/1569861992",
       "fun_fact_nl": "It's a Wonderful Life flopte aanvankelijk, maar werd een kerstklassieker door tv-uitzendingen toen het auteursrecht ervan kwam te vervallen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USKLP2100596",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1597777326",
+        "de": "applemusic://track/1597777326",
+        "gb": "applemusic://track/1597777326",
+        "fr": "applemusic://track/1597777326",
+        "es": "applemusic://track/1597777326",
+        "nl": "applemusic://track/1597777326",
+        "it": "applemusic://track/1597777326"
+      }
     },
     {
       "year": 1942,

--- a/custom_components/beatify/playlists/one-hit-wonders.json
+++ b/custom_components/beatify/playlists/one-hit-wonders.json
@@ -34,7 +34,17 @@
       "uri_tidal": "tidal://track/78447224",
       "uri_deezer": "deezer://track/1137255",
       "fun_fact_nl": "Deze protestsong werd in een uur geschreven en werd door veel radiostations verboden, maar haalde toch #1. Barry McGuire kwam nooit meer in de hitlijsten van de VS.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMC16500802",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1442439941",
+        "de": "applemusic://track/1443341633",
+        "gb": "applemusic://track/1443341633",
+        "fr": "applemusic://track/1443341633",
+        "es": "applemusic://track/1443341633",
+        "nl": "applemusic://track/1443341633",
+        "it": "applemusic://track/1443341633"
+      }
     },
     {
       "year": 1966,
@@ -62,7 +72,17 @@
       "uri_tidal": "tidal://track/2285458",
       "uri_deezer": "deezer://track/2950821",
       "fun_fact_nl": "De leadzanger veranderde zijn naam in '?' en treedt nog steeds op onder die naam. Het nummer werd opgenomen in een woonkamer voor $500.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USA176640140",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1696209760",
+        "de": "applemusic://track/1696209760",
+        "gb": "applemusic://track/1696209760",
+        "fr": "applemusic://track/1696209760",
+        "es": "applemusic://track/1696209760",
+        "nl": "applemusic://track/1696209760",
+        "it": "applemusic://track/1696209760"
+      }
     },
     {
       "year": 1967,
@@ -91,7 +111,17 @@
       "uri_tidal": "tidal://track/14558019",
       "uri_deezer": "deezer://track/869731",
       "fun_fact_nl": "Geschreven door John Phillips van The Mamas & the Papas om het Monterey Pop Festival te promoten. McKenzie was naar verluidt terughoudend om het op te nemen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM16701025",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/158701769",
+        "de": "applemusic://track/348894696",
+        "gb": "applemusic://track/348894696",
+        "fr": "applemusic://track/348894696",
+        "es": "applemusic://track/348894696",
+        "nl": "applemusic://track/348894696",
+        "it": "applemusic://track/348894696"
+      }
     },
     {
       "year": 1968,
@@ -119,7 +149,17 @@
       "uri_tidal": "tidal://track/1298030",
       "uri_deezer": "deezer://track/2680926",
       "fun_fact_nl": "De titel was een vage 'In the Garden of Eden' - de zanger was te dronken om het duidelijk uit te spreken tijdens de opname.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USEE10181094",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1839415198",
+        "de": "applemusic://track/1839415198",
+        "gb": "applemusic://track/1839415198",
+        "fr": "applemusic://track/1839415198",
+        "es": "applemusic://track/1839415198",
+        "nl": "applemusic://track/1839415198",
+        "it": "applemusic://track/1839415198"
+      }
     },
     {
       "year": 1968,
@@ -147,7 +187,17 @@
       "uri_tidal": "tidal://track/615160",
       "uri_deezer": "deezer://track/1560273",
       "fun_fact_nl": "Arthur Brown trad op met een brandende helm op. Hij stak meerdere keren per ongeluk zijn hoofd in brand tijdens liveshows.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBBLY1605630",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1577744764",
+        "de": "applemusic://track/1657674276",
+        "gb": "applemusic://track/1657674276",
+        "fr": "applemusic://track/1657674276",
+        "es": "applemusic://track/1657674276",
+        "nl": "applemusic://track/1657674276",
+        "it": "applemusic://track/1657674276"
+      }
     },
     {
       "year": 1969,
@@ -172,7 +222,17 @@
       "uri_tidal": "tidal://track/124660699",
       "uri_deezer": "deezer://track/3471083641",
       "fun_fact_nl": "Geschreven terwijl hij ingesneeuwd raakte in een piepklein appartement in Seattle. Ondanks een bescheiden succes in de hitlijsten werd het een belangrijk nummer voor de FM-radio in het psychedelische tijdperk.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM16800342",
+      "uri_apple_music_by_region": {
+        "us": null,
+        "de": null,
+        "gb": null,
+        "fr": null,
+        "es": null,
+        "nl": null,
+        "it": null
+      }
     },
     {
       "year": 1969,
@@ -207,7 +267,17 @@
       "fun_fact_nl": "Won de Ivor Novello Award voor Beste Lied. Zijn broers Eden Kane en Clive Sarstedt waren ook zangers, maar Peter had alleen deze ene hit.",
       "awards_nl": [
         "Ivor Novello Award (1969)"
-      ]
+      ],
+      "isrc": "GBAYE6900097",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1801195465",
+        "de": "applemusic://track/1801195465",
+        "gb": "applemusic://track/1801195465",
+        "fr": "applemusic://track/1801195465",
+        "es": "applemusic://track/1801195465",
+        "nl": "applemusic://track/1801195465",
+        "it": "applemusic://track/1801195465"
+      }
     },
     {
       "year": 1969,
@@ -235,7 +305,17 @@
       "uri_tidal": "tidal://track/75496351",
       "uri_deezer": "deezer://track/60703394",
       "fun_fact_nl": "De nummer 1-hit van deze Nederlandse band werd later gecoverd door Bananarama in 1986, die ook nummer 1 bereikte. De originele riff was geïnspireerd op 'The Sorcerer's Apprentice'.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "NLC286900001",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/303734299",
+        "de": "applemusic://track/303734299",
+        "gb": "applemusic://track/303734299",
+        "fr": "applemusic://track/303734299",
+        "es": "applemusic://track/303734299",
+        "nl": "applemusic://track/303734299",
+        "it": "applemusic://track/303734299"
+      }
     },
     {
       "year": 1969,
@@ -264,7 +344,17 @@
       "uri_tidal": "tidal://track/17593678",
       "uri_deezer": "deezer://track/1382508",
       "fun_fact_nl": "De best verkopende single van 1969 werd uitgevoerd door een fictieve cartoonband. Echte muzikanten namen het op, maar de 'bandleden' bestonden niet.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USA560619882",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/214805381",
+        "de": "applemusic://track/214805381",
+        "gb": "applemusic://track/214805381",
+        "fr": "applemusic://track/214805381",
+        "es": "applemusic://track/214805381",
+        "nl": "applemusic://track/214805381",
+        "it": "applemusic://track/214805381"
+      }
     },
     {
       "year": 1969,
@@ -292,7 +382,17 @@
       "uri_tidal": "tidal://track/91980877",
       "uri_deezer": "deezer://track/527883771",
       "fun_fact_nl": "Pete Townshend van The Who produceerde en speelde bas op dit nummer. De band ging kort na hun enige hit uit elkaar.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBF066925310",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1680766396",
+        "de": "applemusic://track/1680766396",
+        "gb": "applemusic://track/1680766396",
+        "fr": "applemusic://track/1680766396",
+        "es": "applemusic://track/1680766396",
+        "nl": "applemusic://track/1680766396",
+        "it": "applemusic://track/1680766396"
+      }
     },
     {
       "year": 1969,
@@ -321,7 +421,17 @@
       "uri_tidal": "tidal://track/1805318",
       "uri_deezer": "deezer://track/392461892",
       "fun_fact_nl": "Stond 6 weken op #1 maar het duo kwam nooit meer in de hitlijsten. Het is een van de meest dramatische valpartijen van #1 naar obscuriteit in de muziekgeschiedenis.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USRC19901100",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1268962872",
+        "de": "applemusic://track/425237275",
+        "gb": "applemusic://track/618891160",
+        "fr": "applemusic://track/618891160",
+        "es": "applemusic://track/618891160",
+        "nl": "applemusic://track/618891160",
+        "it": "applemusic://track/618891160"
+      }
     },
     {
       "year": 1970,
@@ -350,7 +460,17 @@
       "uri_tidal": "tidal://track/117743480",
       "uri_deezer": "deezer://track/673832662",
       "fun_fact_nl": "Greenbaum, die Joods is, schreef dit gospelrocknummer in 15 minuten. Hij verdiende er meer dan 2 miljoen dollar mee, maar had nooit meer een hit.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USRE19600416",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/6762674785",
+        "de": "applemusic://track/6762674785",
+        "gb": "applemusic://track/6762674785",
+        "fr": "applemusic://track/6762674785",
+        "es": "applemusic://track/6762674785",
+        "nl": "applemusic://track/6762674785",
+        "it": "applemusic://track/6762674785"
+      }
     },
     {
       "year": 1970,
@@ -375,7 +495,17 @@
       "uri_tidal": "tidal://track/1498790",
       "uri_deezer": "deezer://track/3299331",
       "fun_fact_nl": "Deze progrockband stond erom bekend geen gitarist te hebben. Het nummer werd een grotere hit in Europa dan in hun thuisland UK.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAAA6900001",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/724210230",
+        "de": "applemusic://track/724210230",
+        "gb": "applemusic://track/1440671708",
+        "fr": "applemusic://track/724210230",
+        "es": "applemusic://track/724210230",
+        "nl": "applemusic://track/724210230",
+        "it": "applemusic://track/724210230"
+      }
     },
     {
       "year": 1972,
@@ -410,7 +540,17 @@
       "fun_fact_nl": "Dit verhaal over een buitenechtelijke affaire won een Grammy. Paul zei later dat hij wenste dat hij een ander signatuurnummer had om door herinnerd te worden.",
       "awards_nl": [
         "Grammy Award voor Beste Mannelijke R&B Zangprestatie (1973)"
-      ]
+      ],
+      "isrc": "USSM17200413",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1566958799",
+        "de": "applemusic://track/1566958799",
+        "gb": "applemusic://track/590672655",
+        "fr": "applemusic://track/1566958799",
+        "es": "applemusic://track/1566958799",
+        "nl": "applemusic://track/1566958799",
+        "it": "applemusic://track/1566958799"
+      }
     },
     {
       "year": 1972,
@@ -438,7 +578,17 @@
       "uri_tidal": "tidal://track/391027",
       "uri_deezer": "deezer://track/682805",
       "fun_fact_nl": "Opgenomen met alleen Thomas op orgel en een drumcomputer. Drake samplede het meer dan 40 jaar later voor 'Hotline Bling'.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USRH10125815",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1794990478",
+        "de": "applemusic://track/1794990478",
+        "gb": "applemusic://track/1794990478",
+        "fr": "applemusic://track/1794990478",
+        "es": "applemusic://track/1794990478",
+        "nl": "applemusic://track/1794990478",
+        "it": "applemusic://track/1794990478"
+      }
     },
     {
       "year": 1974,
@@ -467,7 +617,17 @@
       "uri_tidal": "tidal://track/224189661",
       "uri_deezer": "deezer://track/4633154",
       "fun_fact_nl": "Opgenomen in slechts 10 minuten als B-kant. Het werd een nummer 1 hit in meerdere landen tijdens de martial arts film rage van de jaren 1970.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAJE7400014",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1618248927",
+        "de": "applemusic://track/1618248927",
+        "gb": "applemusic://track/1618248927",
+        "fr": "applemusic://track/1618248927",
+        "es": "applemusic://track/1618248927",
+        "nl": "applemusic://track/1618248927",
+        "it": "applemusic://track/1618248927"
+      }
     },
     {
       "year": 1974,
@@ -496,7 +656,17 @@
       "uri_tidal": "tidal://track/4553606",
       "uri_deezer": "deezer://track/124563036",
       "fun_fact_nl": "Een van de eerste disco songs die #1 werd. Het was oorspronkelijk geschreven voor zijn vrouw Gwen McCrae, maar ze kon niet op de opnamesessie komen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USDEI8704316",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1679403832",
+        "de": "applemusic://track/1679403832",
+        "gb": "applemusic://track/1679403832",
+        "fr": "applemusic://track/1679403832",
+        "es": "applemusic://track/1679403832",
+        "nl": "applemusic://track/1679403832",
+        "it": "applemusic://track/1679403832"
+      }
     },
     {
       "year": 1974,
@@ -525,7 +695,17 @@
       "uri_tidal": "tidal://track/6739245",
       "uri_deezer": "deezer://track/1353054752",
       "fun_fact_nl": "Oorspronkelijk een Belgisch liedje over een stervende man. De Beach Boys namen het bijna als eerste op, maar Jacks was hen voor en verkocht miljoenen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USAR17400171",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/215791443",
+        "de": "applemusic://track/322796562",
+        "gb": "applemusic://track/322796562",
+        "fr": "applemusic://track/322796562",
+        "es": "applemusic://track/322796562",
+        "nl": "applemusic://track/322796562",
+        "it": "applemusic://track/322796562"
+      }
     },
     {
       "year": 1976,
@@ -550,7 +730,17 @@
       "uri_tidal": "tidal://track/298804730",
       "uri_deezer": "deezer://track/521162822",
       "fun_fact_nl": "Een zeldzaam voorbeeld van een cult one-hit wonder. De band had progressieve rockelementen, maar slaagde er niet in om munt te slaan uit hun korte optreden in de hitlijsten.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DED462200616",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1691588293",
+        "de": "applemusic://track/1691588293",
+        "gb": "applemusic://track/1691588293",
+        "fr": "applemusic://track/1691588293",
+        "es": "applemusic://track/1691588293",
+        "nl": "applemusic://track/1691588293",
+        "it": "applemusic://track/1691588293"
+      }
     },
     {
       "year": 1977,
@@ -578,7 +768,17 @@
       "uri_tidal": "tidal://track/30265305",
       "uri_deezer": "deezer://track/550518",
       "fun_fact_nl": "Een rockversie van een traditioneel Afro-Amerikaans werklied. De NAACP protesteerde tegen de tekst. Ram Jam ging kort na deze enige hit uit elkaar.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM10105935",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/971740354",
+        "de": "applemusic://track/444100480",
+        "gb": "applemusic://track/1308659903",
+        "fr": "applemusic://track/1308659903",
+        "es": "applemusic://track/1308659903",
+        "nl": "applemusic://track/1308659903",
+        "it": "applemusic://track/1308659903"
+      }
     },
     {
       "year": 1978,
@@ -606,7 +806,17 @@
       "uri_tidal": "tidal://track/2878744",
       "uri_deezer": "deezer://track/1108249182",
       "fun_fact_nl": "Deze Jamaicaanse tieners namen het nummer op toen ze nog maar 17 en 18 waren. Het was het eerste reggaelied van vrouwelijke artiesten dat #1 werd in de UK.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAAA0100135",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1620050048",
+        "de": "applemusic://track/1620050048",
+        "gb": "applemusic://track/1620050048",
+        "fr": "applemusic://track/1620050048",
+        "es": "applemusic://track/1620050048",
+        "nl": "applemusic://track/1620050048",
+        "it": "applemusic://track/1620050048"
+      }
     },
     {
       "year": 1979,
@@ -635,7 +845,17 @@
       "uri_tidal": "tidal://track/82358708",
       "uri_deezer": "deezer://track/404691712",
       "fun_fact_nl": "Oorspronkelijk geschreven voor een tienerzangeres, werd het herschreven tot een suggestieve discohit. Ward werd een eendagsvlieg ondanks het enorme succes van het nummer.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSZ10503009",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/147664822",
+        "de": "applemusic://track/147664822",
+        "gb": "applemusic://track/147664822",
+        "fr": "applemusic://track/147664822",
+        "es": "applemusic://track/147664822",
+        "nl": "applemusic://track/147664822",
+        "it": "applemusic://track/147664822"
+      }
     },
     {
       "year": 1979,
@@ -690,7 +910,17 @@
       "uri_tidal": "tidal://track/2531405",
       "uri_deezer": "deezer://track/2509817",
       "fun_fact_nl": "De eerste videoclip ooit op MTV op 1 augustus 1981. Bandleden Trevor Horn en Geoff Downes sloten zich later aan bij de progrockband Yes.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAAN7900013",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1810518291",
+        "de": "applemusic://track/1810518291",
+        "gb": "applemusic://track/1810518291",
+        "fr": "applemusic://track/1810518291",
+        "es": "applemusic://track/1810518291",
+        "nl": "applemusic://track/1810518291",
+        "it": "applemusic://track/1810518291"
+      }
     },
     {
       "year": 1979,
@@ -718,7 +948,17 @@
       "uri_tidal": "tidal://track/1747034",
       "uri_deezer": "deezer://track/3248376",
       "fun_fact_nl": "De echte Sharona was de vriendin van de leadzanger - ze was 17. Het nummer stond 6 weken op #1 en was de best verkochte single van 1979.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USCA28900153",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1636947914",
+        "de": "applemusic://track/1636947914",
+        "gb": "applemusic://track/1636947914",
+        "fr": "applemusic://track/1636947914",
+        "es": "applemusic://track/1636947914",
+        "nl": "applemusic://track/1636947914",
+        "it": "applemusic://track/1636947914"
+      }
     },
     {
       "year": 1979,
@@ -747,7 +987,17 @@
       "uri_tidal": "tidal://track/69145431",
       "uri_deezer": "deezer://track/8081935",
       "fun_fact_nl": "Wordt beschouwd als de eerste commercieel succesvolle hiphopsingle. De leden werden bij elkaar gebracht door een eigenaar van een platenlabel die het potentieel van hiphop zag.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USRH10403145",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/52310973",
+        "de": null,
+        "gb": null,
+        "fr": null,
+        "es": null,
+        "nl": null,
+        "it": null
+      }
     },
     {
       "year": 1980,
@@ -800,7 +1050,17 @@
       "uri_tidal": "tidal://track/39683424",
       "uri_deezer": "deezer://track/93114370",
       "fun_fact_nl": "Uitgelicht in de Franse film 'La Boum' (Het feest). Het werd een enorme hit in heel Europa, maar Sanderson bleef elders grotendeels onbekend.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "NLF360801720",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/957549647",
+        "de": "applemusic://track/957549647",
+        "gb": "applemusic://track/957549647",
+        "fr": "applemusic://track/957549647",
+        "es": "applemusic://track/957549647",
+        "nl": "applemusic://track/957549647",
+        "it": "applemusic://track/957549647"
+      }
     },
     {
       "year": 1980,
@@ -826,7 +1086,17 @@
       "uri_tidal": "tidal://track/1574744",
       "uri_deezer": "deezer://track/3177990",
       "fun_fact_nl": "Over de betekenis wordt nog steeds gediscussieerd - de band beweert dat het over obsessie gaat. Vaak verkeerd geïnterpreteerd, werd het een new wave klassieker ondanks dat het hun enige hit was.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAYE8000027",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/714837031",
+        "de": "applemusic://track/696955216",
+        "gb": "applemusic://track/696955216",
+        "fr": "applemusic://track/696955216",
+        "es": "applemusic://track/696955216",
+        "nl": "applemusic://track/696955216",
+        "it": "applemusic://track/723735894"
+      }
     },
     {
       "year": 1980,
@@ -852,7 +1122,17 @@
       "uri_tidal": "tidal://track/618408",
       "uri_deezer": "deezer://track/2285082",
       "fun_fact_nl": "Met Steve Strange als frontman, een pionier van de New Romantic-beweging. Het nummer werd een hymne voor de synthpop scene van begin jaren 80.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USPR38080067",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1890402321",
+        "de": "applemusic://track/1574744315",
+        "gb": "applemusic://track/1574744315",
+        "fr": "applemusic://track/1574744315",
+        "es": "applemusic://track/1574744315",
+        "nl": "applemusic://track/1574744315",
+        "it": "applemusic://track/1574744315"
+      }
     },
     {
       "year": 1982,
@@ -880,7 +1160,17 @@
       "uri_tidal": "tidal://track/4930181",
       "uri_deezer": "deezer://track/1025577",
       "fun_fact_nl": "Het opvallende kapsel van de leadzanger werd net zo beroemd als het nummer. Ondanks lovende kritieken hebben ze dit succes nooit kunnen evenaren in Amerika.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAHK9500304",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1874709779",
+        "de": "applemusic://track/825793214",
+        "gb": "applemusic://track/825793214",
+        "fr": "applemusic://track/825793214",
+        "es": "applemusic://track/825793214",
+        "nl": "applemusic://track/825793214",
+        "it": "applemusic://track/825793214"
+      }
     },
     {
       "year": 1982,
@@ -908,7 +1198,17 @@
       "uri_tidal": "tidal://track/4186366",
       "uri_deezer": "deezer://track/12180202",
       "fun_fact_nl": "Geschreven als protest tegen uitsmijters die pogoën in clubs verboden. De video met middeleeuws thema werd een nietje op MTV in de jaren 1980.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USUM71918013",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1479631804",
+        "de": null,
+        "gb": null,
+        "fr": null,
+        "es": null,
+        "nl": null,
+        "it": null
+      }
     },
     {
       "year": 1982,
@@ -935,7 +1235,17 @@
       "uri_tidal": "tidal://track/348276175",
       "uri_deezer": "deezer://track/943152",
       "fun_fact_nl": "Oorspronkelijk ging het over de nucleaire apocalyps, maar het werd een anthem voor liefdesliedjes. De band was verrast toen het een nieuw leven vond in soundtracks van films uit de jaren 80.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAFL8200036",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1452735552",
+        "de": "applemusic://track/27548320",
+        "gb": "applemusic://track/27548320",
+        "fr": "applemusic://track/27548320",
+        "es": "applemusic://track/27548320",
+        "nl": "applemusic://track/27548320",
+        "it": "applemusic://track/27548320"
+      }
     },
     {
       "year": 1982,
@@ -964,7 +1274,17 @@
       "uri_tidal": "tidal://track/3392942",
       "uri_deezer": "deezer://track/555755",
       "fun_fact_nl": "Het werd een homo-hymne en discoklassieker. Geri Halliwell's cover uit 2001 bereikte #1, maar het originele duo had nooit meer een grote hit.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM19913325",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/347282458",
+        "de": "applemusic://track/1076305745",
+        "gb": "applemusic://track/453302693",
+        "fr": "applemusic://track/273098536",
+        "es": "applemusic://track/273098536",
+        "nl": "applemusic://track/273098536",
+        "it": "applemusic://track/273098536"
+      }
     },
     {
       "year": 1983,
@@ -992,7 +1312,17 @@
       "uri_tidal": "tidal://track/1379251",
       "uri_deezer": "deezer://track/3357587",
       "fun_fact_nl": "De band ontsloeg leadzanger Limahl kort na deze hit. Hij ging solo met het thema 'NeverEnding Story' terwijl de band in de vergetelheid raakte.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAYE8300270",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1717063925",
+        "de": "applemusic://track/1571725724",
+        "gb": "applemusic://track/1671169221",
+        "fr": "applemusic://track/1671169221",
+        "es": "applemusic://track/1671169221",
+        "nl": "applemusic://track/1671169221",
+        "it": "applemusic://track/1671169221"
+      }
     },
     {
       "year": 1983,
@@ -1020,7 +1350,17 @@
       "uri_tidal": "tidal://track/1105888",
       "uri_deezer": "deezer://track/540168502",
       "fun_fact_nl": "Oorspronkelijk geschreven over een seriemoordenaar voordat het werd herschreven voor Flashdance. Sembello was sessiegitarist voor Stevie Wonder.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USPR38302462",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1808046460",
+        "de": "applemusic://track/1808046460",
+        "gb": "applemusic://track/1443325806",
+        "fr": "applemusic://track/1808046460",
+        "es": "applemusic://track/1808046460",
+        "nl": "applemusic://track/1808046460",
+        "it": "applemusic://track/1808046460"
+      }
     },
     {
       "year": 1983,
@@ -1048,7 +1388,17 @@
       "uri_tidal": "tidal://track/169150",
       "uri_deezer": "deezer://track/14683660",
       "fun_fact_nl": "Een vervolg op David Bowie's 'Space Oddity'. De Duitse versie 'Völlig Losgelöst' was nog groter in Europa, maar Schilling kwam nooit meer in de hitlijsten van de VS.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEA622100161",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1689366988",
+        "de": "applemusic://track/1550643321",
+        "gb": "applemusic://track/1550643321",
+        "fr": "applemusic://track/1550643321",
+        "es": "applemusic://track/1550643321",
+        "nl": "applemusic://track/1550643321",
+        "it": "applemusic://track/1550643321"
+      }
     },
     {
       "year": 1983,
@@ -1073,7 +1423,17 @@
       "uri_tidal": "tidal://track/27325274",
       "uri_deezer": "deezer://track/80610262",
       "fun_fact_nl": "Deze Duitse synthpopband had een kleine hit in heel Europa. De nostalgische tekst van het nummer sloeg aan bij het New Wave publiek van de vroege jaren 80.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DED461300130",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/844775625",
+        "de": "applemusic://track/844775625",
+        "gb": "applemusic://track/844775625",
+        "fr": "applemusic://track/844775625",
+        "es": "applemusic://track/844775625",
+        "nl": "applemusic://track/844775625",
+        "it": "applemusic://track/844775625"
+      }
     },
     {
       "year": 1984,
@@ -1101,7 +1461,17 @@
       "uri_tidal": "tidal://track/2450874",
       "uri_deezer": "deezer://track/2321084495",
       "fun_fact_nl": "Hart draagt in het echt een bril. De kenmerkende synthriff van het nummer maakte het tot een klassieker uit de jaren 80, maar hij heeft dit Amerikaanse succes nooit geëvenaard.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USEM30200105",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1434903648",
+        "de": null,
+        "gb": "applemusic://track/1443124564",
+        "fr": "applemusic://track/1443124564",
+        "es": "applemusic://track/1443124564",
+        "nl": "applemusic://track/1443124564",
+        "it": "applemusic://track/1443124564"
+      }
     },
     {
       "year": 1984,
@@ -1129,7 +1499,17 @@
       "uri_tidal": "tidal://track/5254510",
       "uri_deezer": "deezer://track/1484703292",
       "fun_fact_nl": "Rockwell is eigenlijk de zoon van Berry Gordy Jr. Michael Jackson zong het refrein als een gunst, wat hielp om dit paranoïde volkslied tot een succes te maken.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMO10000307",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1647277494",
+        "de": "applemusic://track/1647277494",
+        "gb": "applemusic://track/1647277494",
+        "fr": "applemusic://track/1647277494",
+        "es": "applemusic://track/1647277494",
+        "nl": "applemusic://track/1647277494",
+        "it": "applemusic://track/1647277494"
+      }
     },
     {
       "year": 1985,
@@ -1158,7 +1538,17 @@
       "uri_tidal": "tidal://track/49420",
       "uri_deezer": "deezer://track/958021",
       "fun_fact_nl": "Het duurde 3 pogingen in 18 maanden om te produceren. Leadzanger Pete Burns bracht jaren door met juridische gevechten en tv-optredens, maar had nooit meer een grote hit.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBBBM8400015",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/471205226",
+        "de": "applemusic://track/471205226",
+        "gb": "applemusic://track/471205226",
+        "fr": "applemusic://track/471205226",
+        "es": "applemusic://track/471205226",
+        "nl": "applemusic://track/471205226",
+        "it": "applemusic://track/471205226"
+      }
     },
     {
       "year": 1985,
@@ -1186,7 +1576,17 @@
       "uri_tidal": "tidal://track/233178244",
       "uri_deezer": "deezer://track/2324397795",
       "fun_fact_nl": "Genoemd naar de gemiddelde leeftijd van Amerikaanse soldaten in Vietnam. De stotterende vocale samples waren destijds baanbrekend en beïnvloedden de elektronische muziek.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAYK8500015",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1629177761",
+        "de": "applemusic://track/1629177761",
+        "gb": "applemusic://track/1629177761",
+        "fr": "applemusic://track/1629177761",
+        "es": "applemusic://track/1629177761",
+        "nl": "applemusic://track/1629177761",
+        "it": "applemusic://track/723470830"
+      }
     },
     {
       "year": 1986,
@@ -1215,7 +1615,17 @@
       "uri_tidal": "tidal://track/1307332",
       "uri_deezer": "deezer://track/619310",
       "fun_fact_nl": "De synthriff werd geschreven toen toetsenist Joey Tempest nog maar 14 was. Ondanks het wereldwijde succes hebben ze deze hit nooit internationaal gerepliceerd.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM18600196",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1691572936",
+        "de": "applemusic://track/1739340645",
+        "gb": "applemusic://track/1739340645",
+        "fr": "applemusic://track/1739340645",
+        "es": "applemusic://track/1739340645",
+        "nl": "applemusic://track/1739340645",
+        "it": "applemusic://track/827861903"
+      }
     },
     {
       "year": 1987,
@@ -1270,7 +1680,17 @@
       "uri_tidal": "tidal://track/153834077",
       "uri_deezer": "deezer://track/3077080",
       "fun_fact_nl": "Een baanbrekende sample-gebaseerde track die hielp house muziek te definiëren. Het was een eenmalige samenwerking die nooit werd herhaald.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "US23A8017467",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1695812529",
+        "de": "applemusic://track/1695812529",
+        "gb": "applemusic://track/1695812529",
+        "fr": "applemusic://track/1695812529",
+        "es": "applemusic://track/1695812529",
+        "nl": "applemusic://track/1695812529",
+        "it": "applemusic://track/1695812529"
+      }
     },
     {
       "year": 1988,
@@ -1308,7 +1728,17 @@
       "awards_nl": [
         "Grammy Award voor Lied van het Jaar (1989)",
         "Grammy Award voor Opname van het Jaar (1989)"
-      ]
+      ],
+      "isrc": "USEM38800361",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/6762672295",
+        "de": "applemusic://track/6762672295",
+        "gb": "applemusic://track/6762672295",
+        "fr": "applemusic://track/6762672295",
+        "es": "applemusic://track/6762672295",
+        "nl": "applemusic://track/6762672295",
+        "it": "applemusic://track/6762672295"
+      }
     },
     {
       "year": 1988,
@@ -1334,7 +1764,17 @@
       "uri_tidal": "tidal://track/2527322",
       "uri_deezer": "deezer://track/2498905",
       "fun_fact_nl": "Brickell trouwde later met Paul Simon nadat hij haar dit nummer had zien zingen op SNL. De band ging uit elkaar, maar zij ging verder als folkartiest.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USGF18819201",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1471580732",
+        "de": "applemusic://track/1834281323",
+        "gb": "applemusic://track/1834281323",
+        "fr": "applemusic://track/1834281323",
+        "es": "applemusic://track/1834281323",
+        "nl": "applemusic://track/1834281323",
+        "it": "applemusic://track/1834281323"
+      }
     },
     {
       "year": 1988,
@@ -1362,7 +1802,17 @@
       "uri_tidal": "tidal://track/280493",
       "uri_deezer": "deezer://track/3580415",
       "fun_fact_nl": "Een van de eerste vrouwelijke rapgroepen die mainstream succes had. Ze werden ontdekt door Eazy-E en werden genomineerd voor een Grammy.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USEW18800001",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1740119264",
+        "de": "applemusic://track/1650960428",
+        "gb": "applemusic://track/1650960428",
+        "fr": "applemusic://track/1650960428",
+        "es": "applemusic://track/1650960428",
+        "nl": "applemusic://track/1650960428",
+        "it": "applemusic://track/1650960428"
+      }
     },
     {
       "year": 1988,
@@ -1387,7 +1837,17 @@
       "uri_tidal": "tidal://track/75062708",
       "uri_deezer": "deezer://track/372714321",
       "fun_fact_nl": "Werd iconisch door het gebruik in 'The Silence of the Lambs'. De mysterieuze Q Lazzarus verdween uit de muziek en haar identiteit bleef jarenlang onbekend.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "QMFME1337712",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1247752093",
+        "de": "applemusic://track/1247752093",
+        "gb": "applemusic://track/1247752093",
+        "fr": "applemusic://track/1247752093",
+        "es": "applemusic://track/1247752093",
+        "nl": "applemusic://track/1247752093",
+        "it": "applemusic://track/1247752093"
+      }
     },
     {
       "year": 1988,
@@ -1414,7 +1874,17 @@
       "uri_tidal": "tidal://track/2158292",
       "uri_deezer": "deezer://track/2686266",
       "fun_fact_nl": "Uitgebracht toen ze nog maar 19 jaar oud was. Haar diepe, kenmerkende stem werd vaak vergeleken met Suzanne Vega, maar mainstream succes bleef uit.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAHS0104635",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1776580033",
+        "de": "applemusic://track/1776580033",
+        "gb": "applemusic://track/1776580033",
+        "fr": "applemusic://track/1776580033",
+        "es": "applemusic://track/1776580033",
+        "nl": "applemusic://track/1776580033",
+        "it": "applemusic://track/1776580033"
+      }
     },
     {
       "year": 1988,
@@ -1442,7 +1912,17 @@
       "uri_tidal": "tidal://track/3009887",
       "uri_deezer": "deezer://track/2455621",
       "fun_fact_nl": "De dromerige hit van deze Australische band was geïnspireerd op de opmerking van een vriend dat hij zich verloren voelde. Ze bleven cultfavorieten maar kwamen nooit meer zo hoog in de hitlijsten.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USAR18800002",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1739845144",
+        "de": "applemusic://track/1739845144",
+        "gb": "applemusic://track/1739845144",
+        "fr": "applemusic://track/1739845144",
+        "es": "applemusic://track/1739845144",
+        "nl": "applemusic://track/1739845144",
+        "it": "applemusic://track/1739845144"
+      }
     },
     {
       "year": 1989,
@@ -1468,7 +1948,17 @@
       "uri_tidal": "tidal://track/2067509",
       "uri_deezer": "deezer://track/3528860",
       "fun_fact_nl": "Het door reggae beïnvloede nummer van dit Deense duo werd een Europese culthit. Ze hadden eerder succes met 'White Horse', maar geen van beide nummers brak door in Amerika.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DKFN70700201",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/693306869",
+        "de": "applemusic://track/693306869",
+        "gb": "applemusic://track/693306869",
+        "fr": "applemusic://track/693306869",
+        "es": "applemusic://track/693306869",
+        "nl": "applemusic://track/693306869",
+        "it": "applemusic://track/693306869"
+      }
     },
     {
       "year": 1989,
@@ -1494,7 +1984,17 @@
       "uri_tidal": "tidal://track/3614191",
       "uri_deezer": "deezer://track/1173523",
       "fun_fact_nl": "Dochter van rockgitarist Joe Brown. Deze krachtige ballad was een Europese hit, maar ze had moeite om een vervolg te krijgen in de popwereld.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAAM8800004",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1706249950",
+        "de": "applemusic://track/1706249950",
+        "gb": "applemusic://track/1706249950",
+        "fr": "applemusic://track/1706249950",
+        "es": "applemusic://track/1706249950",
+        "nl": "applemusic://track/1706249950",
+        "it": "applemusic://track/1706249950"
+      }
     },
     {
       "year": 1989,
@@ -1529,7 +2029,17 @@
       "fun_fact_nl": "Won de Grammy voor beste rapprestatie. Young MC schreef ook de hits van Tone Loc, maar heroverde nooit zijn eigen hitsucces.",
       "awards_nl": [
         "Grammy Award voor Beste Rapprestatie (1990)"
-      ]
+      ],
+      "isrc": "USA370507645",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1807406244",
+        "de": "applemusic://track/1807406244",
+        "gb": "applemusic://track/1807406244",
+        "fr": "applemusic://track/1807406244",
+        "es": "applemusic://track/1807406244",
+        "nl": "applemusic://track/1807406244",
+        "it": "applemusic://track/1807406244"
+      }
     },
     {
       "year": 1990,
@@ -1558,7 +2068,17 @@
       "uri_tidal": "tidal://track/3267941",
       "uri_deezer": "deezer://track/75070408",
       "fun_fact_nl": "Met Bootsy Collins en Q-Tip als gastartiesten. De kleurrijke stijl van Lady Miss Kier bepaalde de danscultuur van begin jaren 90, maar de opvolgers flopten.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USEE19687204",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1562873481",
+        "de": "applemusic://track/1391549360",
+        "gb": "applemusic://track/1747286115",
+        "fr": "applemusic://track/1747286115",
+        "es": "applemusic://track/1747286115",
+        "nl": "applemusic://track/1391549360",
+        "it": "applemusic://track/1747286115"
+      }
     },
     {
       "year": 1990,
@@ -1583,7 +2103,17 @@
       "uri_tidal": "tidal://track/147235",
       "uri_deezer": "deezer://track/3113250",
       "fun_fact_nl": "Spanje's grootste rockband van de jaren 90. Ze waren enorm populair in Latijns-Amerika, maar dit blijft hun enige internationaal erkende nummer.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "ES5089000064",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1687931289",
+        "de": "applemusic://track/1838718622",
+        "gb": "applemusic://track/1838718622",
+        "fr": "applemusic://track/1838718622",
+        "es": "applemusic://track/1838718622",
+        "nl": "applemusic://track/1838718622",
+        "it": "applemusic://track/1838718622"
+      }
     },
     {
       "year": 1990,
@@ -1621,7 +2151,17 @@
       "awards_nl": [
         "Grammy Award voor Beste Rap Soloprestatie (1991)",
         "Grammy Award voor Beste R&B-nummer (1991)"
-      ]
+      ],
+      "isrc": "USCA29000294",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1890039717",
+        "de": "applemusic://track/1890039717",
+        "gb": "applemusic://track/1890039717",
+        "fr": "applemusic://track/1890039717",
+        "es": "applemusic://track/1890039717",
+        "nl": "applemusic://track/1890039717",
+        "it": "applemusic://track/1890039717"
+      }
     },
     {
       "year": 1990,
@@ -1649,7 +2189,17 @@
       "uri_tidal": "tidal://track/1666608",
       "uri_deezer": "deezer://track/2518361",
       "fun_fact_nl": "Bandleider Lee Mavers was zo perfectionistisch dat hij hun enige album verstootte. Het nummer vond een nieuw publiek door meerdere film- en tv-plaatsingen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAQT8800001",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1702052707",
+        "de": "applemusic://track/1702052707",
+        "gb": "applemusic://track/1702052707",
+        "fr": "applemusic://track/1702052707",
+        "es": "applemusic://track/1702052707",
+        "nl": "applemusic://track/1702052707",
+        "it": "applemusic://track/1702052707"
+      }
     },
     {
       "year": 1990,
@@ -1678,7 +2228,17 @@
       "uri_tidal": "tidal://track/2615705",
       "uri_deezer": "deezer://track/2397026",
       "fun_fact_nl": "Eerste hiphopsingle die bovenaan de Billboard Hot 100 staat. Hij ontkende in eerste instantie het samplen van Queen's 'Under Pressure', maar schikte later buiten de rechtbank om.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSB29000129",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1888299696",
+        "de": "applemusic://track/1888299696",
+        "gb": "applemusic://track/1888299696",
+        "fr": "applemusic://track/1888299696",
+        "es": "applemusic://track/1888299696",
+        "nl": "applemusic://track/1888299696",
+        "it": "applemusic://track/1888299696"
+      }
     },
     {
       "year": 1991,
@@ -1707,7 +2267,17 @@
       "uri_tidal": "tidal://track/1330757",
       "uri_deezer": "deezer://track/3152715",
       "fun_fact_nl": "Door de controversiële teksten werd het in sommige landen verboden. Leadzangeres Chrissy Amphlett zei dat het echt over zelfversterking ging.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USVI29000004",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1584859579",
+        "de": "applemusic://track/1584859579",
+        "gb": "applemusic://track/1584859579",
+        "fr": "applemusic://track/1584859579",
+        "es": "applemusic://track/1584859579",
+        "nl": "applemusic://track/1584859579",
+        "it": "applemusic://track/1584859579"
+      }
     },
     {
       "year": 1991,
@@ -1735,7 +2305,17 @@
       "uri_tidal": "tidal://track/74568253",
       "uri_deezer": "deezer://track/367782641",
       "fun_fact_nl": "De bandnaam zou staan voor 'Ecstasy Mother****ers'. Ze waren tieners toen deze hit de Amerikaanse hitlijsten haalde, maar verdwenen al snel uit beeld.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAYE9000089",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/72267285",
+        "de": "applemusic://track/72267285",
+        "gb": "applemusic://track/714632458",
+        "fr": "applemusic://track/72267285",
+        "es": "applemusic://track/72267285",
+        "nl": "applemusic://track/72267285",
+        "it": "applemusic://track/72267285"
+      }
     },
     {
       "year": 1991,
@@ -1763,7 +2343,17 @@
       "uri_tidal": "tidal://track/1311444",
       "uri_deezer": "deezer://track/630283",
       "fun_fact_nl": "Het duurde 2 jaar toeren voordat dit nummer eindelijk aansloeg. Ondanks het enorme succes werd de band een punchline voor jaren 90 nostalgie.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM19000350",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1565619209",
+        "de": "applemusic://track/1565619209",
+        "gb": "applemusic://track/1565619209",
+        "fr": "applemusic://track/1565619209",
+        "es": "applemusic://track/1565619209",
+        "nl": "applemusic://track/1565619209",
+        "it": "applemusic://track/1565619209"
+      }
     },
     {
       "year": 1992,
@@ -1791,7 +2381,17 @@
       "uri_tidal": "tidal://track/1332492",
       "uri_deezer": "deezer://track/3359652",
       "fun_fact_nl": "De 'Bee Girl' uit de video werd op slag beroemd. Leadzanger Shannon Hoon stierf in 1995 aan een overdosis, waarmee een einde kwam aan het potentieel van de band.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USCA29200194",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1700785141",
+        "de": "applemusic://track/1700785141",
+        "gb": "applemusic://track/1700785141",
+        "fr": "applemusic://track/1700785141",
+        "es": "applemusic://track/1700785141",
+        "nl": "applemusic://track/1700785141",
+        "it": "applemusic://track/1700785141"
+      }
     },
     {
       "year": 1992,
@@ -1819,7 +2419,17 @@
       "uri_tidal": "tidal://track/222367324",
       "uri_deezer": "deezer://track/1584589772",
       "fun_fact_nl": "Niet weg te denken bij sportevenementen over de hele wereld. DJ Lethal sloot zich later aan bij Limp Bizkit, terwijl Everlast een bescheiden solosucces had maar deze hit nooit evenaarde.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USTB12100088",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1616079470",
+        "de": "applemusic://track/1616079470",
+        "gb": "applemusic://track/1616079470",
+        "fr": "applemusic://track/1616079470",
+        "es": "applemusic://track/1616079470",
+        "nl": "applemusic://track/1616079470",
+        "it": "applemusic://track/1616079470"
+      }
     },
     {
       "year": 1993,
@@ -1847,7 +2457,17 @@
       "uri_tidal": "tidal://track/634519",
       "uri_deezer": "deezer://track/2184743",
       "fun_fact_nl": "Linda Perry schreef later hits voor Pink, Christina Aguilera en Gwen Stefani. Het nummer werd tientallen jaren later een virale meme.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USIR19200553",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1442267078",
+        "de": "applemusic://track/1443342983",
+        "gb": "applemusic://track/1443342983",
+        "fr": "applemusic://track/1443342983",
+        "es": "applemusic://track/1443342983",
+        "nl": "applemusic://track/1443342983",
+        "it": "applemusic://track/1443342983"
+      }
     },
     {
       "year": 1993,
@@ -1873,7 +2493,17 @@
       "uri_tidal": "tidal://track/12585826",
       "uri_deezer": "deezer://track/90630611",
       "fun_fact_nl": "De ongewoon diepe stem van Brad Roberts werd het handelsmerk van het nummer. Weird Al parodieerde het als 'Headline News' op het hoogtepunt van zijn populariteit.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "CAA359300084",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/309226521",
+        "de": "applemusic://track/1154118731",
+        "gb": "applemusic://track/203898858",
+        "fr": "applemusic://track/203898858",
+        "es": "applemusic://track/203898858",
+        "nl": "applemusic://track/1501166566",
+        "it": "applemusic://track/1242098163"
+      }
     },
     {
       "year": 1993,
@@ -1898,7 +2528,17 @@
       "uri_tidal": "tidal://track/440777531",
       "uri_deezer": "deezer://track/3375877811",
       "fun_fact_nl": "De grootste hit van dit Britse elektronische duo samplede een koor. Het werd een rave anthem maar buiten Europa bleven ze grotendeels onbekend.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAHS0500214",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1815573796",
+        "de": "applemusic://track/1815573796",
+        "gb": "applemusic://track/1815573796",
+        "fr": "applemusic://track/1815573796",
+        "es": "applemusic://track/1815573796",
+        "nl": "applemusic://track/1815573796",
+        "it": "applemusic://track/1815573796"
+      }
     },
     {
       "year": 1993,
@@ -1924,7 +2564,17 @@
       "uri_tidal": "tidal://track/2205831",
       "uri_deezer": "deezer://track/378817711",
       "fun_fact_nl": "Opgericht door Pixies-bassist Kim Deal. Dit alternatieve rockjuweeltje betekende hun doorbraak, maar de grillige carrière van de band verhinderde een blijvend mainstreamsucces.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAFL9300109",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/273106994",
+        "de": "applemusic://track/273106994",
+        "gb": "applemusic://track/273106994",
+        "fr": "applemusic://track/273106994",
+        "es": "applemusic://track/273106994",
+        "nl": "applemusic://track/273106994",
+        "it": "applemusic://track/273106994"
+      }
     },
     {
       "year": 1994,
@@ -1974,7 +2624,17 @@
       "uri_tidal": "tidal://track/70686664",
       "uri_deezer": "deezer://track/6907036",
       "fun_fact_nl": "De eerste debuutsingle die op #1 binnenkwam in de UK chart sinds 1984. De bijbehorende dansroutine werd een rage in clubs in heel Europa.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "IT00D9400207",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/125867612",
+        "de": "applemusic://track/1613178667",
+        "gb": "applemusic://track/125867612",
+        "fr": "applemusic://track/125867612",
+        "es": "applemusic://track/125867612",
+        "nl": "applemusic://track/125867612",
+        "it": "applemusic://track/125867612"
+      }
     },
     {
       "year": 1995,
@@ -2000,7 +2660,17 @@
       "uri_tidal": "tidal://track/3969023",
       "uri_deezer": "deezer://track/2315711",
       "fun_fact_nl": "Geschreven over een stel dat zich realiseert dat ze niets gemeen hebben behalve dat ze de film Audrey Hepburn leuk vinden. De band kon deze eigenzinnige hit niet kopiëren.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USIR19500177",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1717158411",
+        "de": "applemusic://track/1717158411",
+        "gb": "applemusic://track/1717158411",
+        "fr": "applemusic://track/1717158411",
+        "es": "applemusic://track/1717158411",
+        "nl": "applemusic://track/1717158411",
+        "it": "applemusic://track/1717158411"
+      }
     },
     {
       "year": 1995,
@@ -2026,7 +2696,17 @@
       "uri_tidal": "tidal://track/258291340",
       "uri_deezer": "deezer://track/14282849",
       "fun_fact_nl": "Collins zat vroeger in Orange Juice. In 2005 kreeg hij twee hersenbloedingen, maar hij herstelde en maakt nog steeds muziek.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GB72T1100001",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/474270145",
+        "de": "applemusic://track/474270145",
+        "gb": "applemusic://track/474270145",
+        "fr": "applemusic://track/474270145",
+        "es": "applemusic://track/474270145",
+        "nl": "applemusic://track/474270145",
+        "it": "applemusic://track/474270145"
+      }
     },
     {
       "year": 1995,
@@ -2052,7 +2732,17 @@
       "uri_tidal": "tidal://track/486407015",
       "uri_deezer": "deezer://track/3750996632",
       "fun_fact_nl": "Het vrolijke nummer van deze Duitse band ging over verveling en depressie. Het voerde de hitlijsten in heel Europa aan, maar in Amerika bleven ze onbekend.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEAF70927221",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1847889648",
+        "de": "applemusic://track/1847889648",
+        "gb": "applemusic://track/1847889648",
+        "fr": "applemusic://track/1847889648",
+        "es": "applemusic://track/1847889648",
+        "nl": "applemusic://track/1847889648",
+        "it": "applemusic://track/1847889648"
+      }
     },
     {
       "year": 1995,
@@ -2078,7 +2768,17 @@
       "uri_tidal": "tidal://track/638870",
       "uri_deezer": "deezer://track/2463249",
       "fun_fact_nl": "Dit filosofische lied over God verdiende 3 Grammy nominaties. Sommige religieuze groeperingen protesteerden, wat de populariteit alleen maar vergrootte.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USPR39500200",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1893169328",
+        "de": "applemusic://track/1893169328",
+        "gb": "applemusic://track/1893169328",
+        "fr": "applemusic://track/1893169328",
+        "es": "applemusic://track/1893169328",
+        "nl": "applemusic://track/1893169328",
+        "it": "applemusic://track/1893169328"
+      }
     },
     {
       "year": 1995,
@@ -2104,7 +2804,17 @@
       "uri_tidal": "tidal://track/40845550",
       "uri_deezer": "deezer://track/73219987",
       "fun_fact_nl": "Een zelfspottende rap over groter en cooler willen zijn. Skee-Lo was eigenlijk 5'8\" - niet zo klein - maar het nummer vond weerklank bij underdogs overal.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "NLML61100033",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/925659212",
+        "de": "applemusic://track/925659212",
+        "gb": "applemusic://track/925659212",
+        "fr": "applemusic://track/925659212",
+        "es": "applemusic://track/925659212",
+        "nl": "applemusic://track/925659212",
+        "it": "applemusic://track/925659212"
+      }
     },
     {
       "year": 1995,
@@ -2130,7 +2840,17 @@
       "uri_tidal": "tidal://track/160558",
       "uri_deezer": "deezer://track/3217894",
       "fun_fact_nl": "Het provocerende industriële rocknummer van deze Zweedse band werd ondanks de vreemde titel airplay op MTV. Ze bereikten nooit meer een mainstream succes.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAAA9500059",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/724612537",
+        "de": "applemusic://track/724612537",
+        "gb": "applemusic://track/724612537",
+        "fr": "applemusic://track/724612537",
+        "es": "applemusic://track/724612537",
+        "nl": "applemusic://track/724612537",
+        "it": "applemusic://track/724612537"
+      }
     },
     {
       "year": 1996,
@@ -2156,7 +2876,17 @@
       "uri_tidal": "tidal://track/1471748",
       "uri_deezer": "deezer://track/3389663",
       "fun_fact_nl": "Gebruikt in een Levi's reclame, werd het de snelst verkopende debuutsingle in de geschiedenis van Groot-Brittannië in die tijd. De hype verdween net zo snel als hij kwam.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAYE9500084",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1590127365",
+        "de": "applemusic://track/1243422020",
+        "gb": "applemusic://track/1590127365",
+        "fr": "applemusic://track/1590127365",
+        "es": "applemusic://track/1590127365",
+        "nl": "applemusic://track/1590127365",
+        "it": "applemusic://track/1590127365"
+      }
     },
     {
       "year": 1996,
@@ -2184,7 +2914,17 @@
       "uri_tidal": "tidal://track/79970915",
       "uri_deezer": "deezer://track/2234278",
       "fun_fact_nl": "De grootste internationale hit van Nieuw-Zeeland. Pauly Fuemana verkocht miljoenen exemplaren maar maakte weinig winst door een slecht platencontract. Hij stierf in 2010.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "NZPY09500002",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1584859314",
+        "de": "applemusic://track/1584859314",
+        "gb": "applemusic://track/1584859314",
+        "fr": "applemusic://track/1584859314",
+        "es": "applemusic://track/1584859314",
+        "nl": "applemusic://track/1584859314",
+        "it": "applemusic://track/1584859314"
+      }
     },
     {
       "year": 1996,
@@ -2209,7 +2949,17 @@
       "uri_tidal": "tidal://track/7917620",
       "uri_deezer": "deezer://track/13807568",
       "fun_fact_nl": "Stootte door naar #1 nadat ze te zien waren in een Levi's jeans advertentie. De band werd speciaal voor de commercial opgericht en ging daarna snel uit elkaar.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEPA81100120",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/464578812",
+        "de": "applemusic://track/464578812",
+        "gb": "applemusic://track/464578812",
+        "fr": "applemusic://track/464578812",
+        "es": "applemusic://track/464578812",
+        "nl": "applemusic://track/464578812",
+        "it": "applemusic://track/464578812"
+      }
     },
     {
       "year": 1997,
@@ -2235,7 +2985,17 @@
       "uri_tidal": "tidal://track/62846208",
       "uri_deezer": "deezer://track/128237751",
       "fun_fact_nl": "De relaxte hit van dit collectief uit Montreal gaf de slackercultuur van de late jaren 90 perfect weer. Ondanks lovende kritieken bleven ze internationaal een eendagsvlieg.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "CAA509814003",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1551605882",
+        "de": "applemusic://track/1551605882",
+        "gb": "applemusic://track/1551605882",
+        "fr": "applemusic://track/1551605882",
+        "es": "applemusic://track/1551605882",
+        "nl": "applemusic://track/1551605882",
+        "it": "applemusic://track/1551605882"
+      }
     },
     {
       "year": 1997,
@@ -2264,7 +3024,17 @@
       "uri_tidal": "tidal://track/15254370",
       "uri_deezer": "deezer://track/3154917",
       "fun_fact_nl": "Deze anarchistische band maakte voor deze hit al 15 jaar muziek. Ze doneerden hun inkomsten aan goede doelen en hebben ooit water over een politicus gegooid.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEA349700542",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1691631077",
+        "de": "applemusic://track/1691631077",
+        "gb": "applemusic://track/1691631077",
+        "fr": "applemusic://track/1691631077",
+        "es": "applemusic://track/1691631077",
+        "nl": "applemusic://track/1691631077",
+        "it": "applemusic://track/1691631077"
+      }
     },
     {
       "year": 1997,
@@ -2290,7 +3060,17 @@
       "uri_tidal": "tidal://track/583613",
       "uri_deezer": "deezer://track/3239961",
       "fun_fact_nl": "De mysterieuze teksten werden geïnspireerd door een desoriënterende feestervaring. De lo-fi opnamekwaliteit was opzettelijk en werd een deel van de charme.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "TCAEY2022600",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1518392883",
+        "de": "applemusic://track/1518392883",
+        "gb": "applemusic://track/1518392883",
+        "fr": "applemusic://track/1518392883",
+        "es": "applemusic://track/1518392883",
+        "nl": "applemusic://track/1518392883",
+        "it": "applemusic://track/1518392883"
+      }
     },
     {
       "year": 1997,
@@ -2316,7 +3096,17 @@
       "uri_tidal": "tidal://track/1409900",
       "uri_deezer": "deezer://track/3156760",
       "fun_fact_nl": "Vaak verward met de stijl van Alanis Morissette. Brooks omarmde haar one-hit wonder status en zei dat ze liever één groot nummer had dan geen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USCA29701376",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1878462499",
+        "de": "applemusic://track/1878462499",
+        "gb": "applemusic://track/1878462499",
+        "fr": "applemusic://track/1878462499",
+        "es": "applemusic://track/1878462499",
+        "nl": "applemusic://track/1878462499",
+        "it": "applemusic://track/1878462499"
+      }
     },
     {
       "year": 1997,
@@ -2346,7 +3136,17 @@
       "uri_tidal": "tidal://track/500426",
       "uri_deezer": "deezer://track/992131",
       "fun_fact_nl": "Eigenlijk een cover van een obscuur nummer uit 1995. De voormalige Australische soapactrice werd een wereldwijde ster, maar had moeite om deze debuuthit te evenaren.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBARL9700412",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1635638730",
+        "de": "applemusic://track/774761984",
+        "gb": "applemusic://track/1635638730",
+        "fr": "applemusic://track/285296230",
+        "es": "applemusic://track/1635638730",
+        "nl": "applemusic://track/1635638730",
+        "it": "applemusic://track/285296230"
+      }
     },
     {
       "year": 1997,
@@ -2372,7 +3172,17 @@
       "uri_tidal": "tidal://track/215538535",
       "uri_deezer": "deezer://track/10426810",
       "fun_fact_nl": "Een slaapkameropname die een Al Bowlly-nummer uit 1930 samplet. Jyoti Mishra nam alles zelf op en was geschokt toen het nummer #1 werd in de UK.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAYE9600116",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/716067885",
+        "de": "applemusic://track/716067885",
+        "gb": "applemusic://track/716067885",
+        "fr": "applemusic://track/716067885",
+        "es": "applemusic://track/716067885",
+        "nl": "applemusic://track/716067885",
+        "it": "applemusic://track/716067885"
+      }
     },
     {
       "year": 1998,
@@ -2398,7 +3208,17 @@
       "uri_tidal": "tidal://track/2215907",
       "uri_deezer": "deezer://track/1120924",
       "fun_fact_nl": "Oorspronkelijk een flop totdat de remix van Fatboy Slim #1 werd. Het gaat over de Bollywood zangeres Asha Bhosle, die meer liedjes heeft opgenomen dan wie dan ook in de geschiedenis.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBBKT9700052",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/714943313",
+        "de": "applemusic://track/286274955",
+        "gb": "applemusic://track/286274955",
+        "fr": "applemusic://track/286274955",
+        "es": "applemusic://track/286274955",
+        "nl": "applemusic://track/286274955",
+        "it": "applemusic://track/286274955"
+      }
     },
     {
       "year": 1998,
@@ -2424,7 +3244,17 @@
       "uri_tidal": "tidal://track/610923",
       "uri_deezer": "deezer://track/2252935",
       "fun_fact_nl": "Zoon van jazzlegende Don Cherry en halfbroer van Neneh Cherry. Ondanks familiebanden kon hij zijn eigen succes in de hitlijsten niet behouden.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM10027246",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1695903012",
+        "de": null,
+        "gb": null,
+        "fr": null,
+        "es": null,
+        "nl": null,
+        "it": null
+      }
     },
     {
       "year": 1998,
@@ -2453,7 +3283,17 @@
       "uri_tidal": "tidal://track/2529963",
       "uri_deezer": "deezer://track/2441438",
       "fun_fact_nl": "Gregg Alexander ging na één album uit elkaar omdat hij een hekel had aan roem. De shoutouts naar beroemdheden zorgden voor controverse, maar versterkten het profiel.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMC19858327",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1671911352",
+        "de": "applemusic://track/1671911352",
+        "gb": "applemusic://track/1671911352",
+        "fr": "applemusic://track/1671911352",
+        "es": "applemusic://track/1671911352",
+        "nl": "applemusic://track/1671911352",
+        "it": "applemusic://track/1671911352"
+      }
     },
     {
       "year": 1998,
@@ -2481,7 +3321,17 @@
       "uri_tidal": "tidal://track/94760881",
       "uri_deezer": "deezer://track/546248912",
       "fun_fact_nl": "Eigenlijk geschreven over de geboorte van het kind van de leadzanger, niet over een cafésluiting. Het werd het ultieme afscheidsliedje ondanks de verborgen betekenis.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMC19800013",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1779813571",
+        "de": "applemusic://track/1779813571",
+        "gb": "applemusic://track/1779813571",
+        "fr": "applemusic://track/1779813571",
+        "es": "applemusic://track/1779813571",
+        "nl": "applemusic://track/1779813571",
+        "it": "applemusic://track/1779813571"
+      }
     },
     {
       "year": 1999,
@@ -2507,7 +3357,17 @@
       "uri_tidal": "tidal://track/2358828",
       "uri_deezer": "deezer://track/3748159",
       "fun_fact_nl": "De marionet Flat Eric in Levi's advertenties. De Franse producer Quentin Dupieux werd later een cultfilmregisseur.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "FRV229900012",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/121304778",
+        "de": "applemusic://track/121304778",
+        "gb": "applemusic://track/121304778",
+        "fr": "applemusic://track/121304778",
+        "es": "applemusic://track/121304778",
+        "nl": "applemusic://track/121304778",
+        "it": "applemusic://track/121304778"
+      }
     },
     {
       "year": 2000,
@@ -2535,7 +3395,17 @@
       "uri_tidal": "tidal://track/34793",
       "uri_deezer": "deezer://track/13144808",
       "fun_fact_nl": "Een sample van Red Hot Chili Peppers' 'Pretty Little Ditty'. Het rap-rocknummer werd nummer 1, maar de band werd synoniem voor de one-hit wonders uit het begin van de jaren 2000.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM19911429",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/203304621",
+        "de": "applemusic://track/1799780923",
+        "gb": "applemusic://track/203304621",
+        "fr": "applemusic://track/203304621",
+        "es": "applemusic://track/203304621",
+        "nl": "applemusic://track/203304621",
+        "it": "applemusic://track/203304621"
+      }
     },
     {
       "year": 2000,
@@ -2561,7 +3431,17 @@
       "uri_tidal": "tidal://track/1924",
       "uri_deezer": "deezer://track/870041",
       "fun_fact_nl": "Uitgelicht in de film 'Loser' met Jason Biggs in de hoofdrol. De nerdy hymne vond een nieuw leven via sociale media meer dan 20 jaar na de release.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM10008431",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1788997007",
+        "de": "applemusic://track/1788997007",
+        "gb": "applemusic://track/1788997007",
+        "fr": "applemusic://track/1788997007",
+        "es": "applemusic://track/1788997007",
+        "nl": "applemusic://track/1788997007",
+        "it": "applemusic://track/1788997007"
+      }
     },
     {
       "year": 2002,
@@ -2587,7 +3467,17 @@
       "uri_tidal": "tidal://track/45929210",
       "uri_deezer": "deezer://track/7804693",
       "fun_fact_nl": "Een expliciete clubanthem die een cultfavoriet werd. Khia nam het op voor slechts $350 en het werd een vaste waarde op feestjes in de jaren 2000.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USAR50210857",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/5622208",
+        "de": "applemusic://track/5622208",
+        "gb": "applemusic://track/5622208",
+        "fr": "applemusic://track/5622208",
+        "es": "applemusic://track/5622208",
+        "nl": "applemusic://track/5622208",
+        "it": "applemusic://track/5622208"
+      }
     },
     {
       "year": 2002,
@@ -2636,7 +3526,17 @@
       "uri_tidal": "tidal://track/1273756",
       "uri_deezer": "deezer://track/624206",
       "fun_fact_nl": "Bekend geworden als het themalied van de tv-serie 'The O.C.'. Acteur Jason Schwartzman was hun originele drummer voordat zijn filmcarrière begon.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM10105453",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1006175834",
+        "de": "applemusic://track/308198608",
+        "gb": "applemusic://track/308198608",
+        "fr": "applemusic://track/308198608",
+        "es": "applemusic://track/308198608",
+        "nl": "applemusic://track/308198608",
+        "it": "applemusic://track/308198608"
+      }
     },
     {
       "year": 2005,
@@ -2662,7 +3562,17 @@
       "uri_tidal": "tidal://track/1309889",
       "uri_deezer": "deezer://track/2553109",
       "fun_fact_nl": "De drumsample van The Meters maakte het meteen herkenbaar. Ondanks lovende kritieken kon Amerie haar aanwezigheid in de hitlijsten niet handhaven.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM10500100",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/153437689",
+        "de": "applemusic://track/153437689",
+        "gb": "applemusic://track/153437689",
+        "fr": "applemusic://track/153437689",
+        "es": "applemusic://track/153437689",
+        "nl": "applemusic://track/153437689",
+        "it": "applemusic://track/153437689"
+      }
     },
     {
       "year": 2006,
@@ -2698,7 +3608,17 @@
       "fun_fact_nl": "Eerste nummer dat alleen al door downloads #1 werd in de Britse hitlijsten. Het duo CeeLo Green en Danger Mouse droeg bij elk optreden uitgebreide kostuums.",
       "awards_nl": [
         "Grammy Award voor Opname van het Jaar (2007)"
-      ]
+      ],
+      "isrc": "USAT20611041",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1741403966",
+        "de": "applemusic://track/1181210744",
+        "gb": "applemusic://track/1181210744",
+        "fr": "applemusic://track/1181210744",
+        "es": "applemusic://track/1181210744",
+        "nl": "applemusic://track/1181210744",
+        "it": "applemusic://track/1181210744"
+      }
     },
     {
       "year": 2011,
@@ -2724,7 +3644,17 @@
       "uri_tidal": "tidal://track/13467719",
       "uri_deezer": "deezer://track/14539929",
       "fun_fact_nl": "Het meest verkochte nummer van 2012 wereldwijd. De Belgisch-Australische Gotye maakte de video voor minder dan $1000 en won 3 Grammy's, maar trok zich terug uit de popmuziek.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "AUZS21100040",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1582231392",
+        "de": "applemusic://track/1582231392",
+        "gb": "applemusic://track/1582231392",
+        "fr": "applemusic://track/1582231392",
+        "es": "applemusic://track/1582231392",
+        "nl": "applemusic://track/1519612333",
+        "it": "applemusic://track/1582231392"
+      }
     }
   ]
 }

--- a/custom_components/beatify/playlists/summer-party-anthems.json
+++ b/custom_components/beatify/playlists/summer-party-anthems.json
@@ -36,7 +36,17 @@
       "fun_fact_fr": "George Harrison a écrit cette chanson dans le jardin d'Eric Clapton après avoir échappé à une réunion d'affaires tendue d'Apple Corps, la qualifiant de « chanson de pur soulagement ».",
       "uri_deezer": "deezer://track/116348464",
       "fun_fact_nl": "George Harrison schreef dit nummer in de tuin van Eric Clapton nadat hij was ontsnapt aan een gespannen Apple Corps zakenbespreking en noemde het 'een lied van pure opluchting'.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBUM71903335",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1713156666",
+        "de": "applemusic://track/1713156666",
+        "gb": "applemusic://track/1713156666",
+        "fr": "applemusic://track/1713156666",
+        "es": "applemusic://track/1713156666",
+        "nl": "applemusic://track/1713156666",
+        "it": "applemusic://track/1713156666"
+      }
     },
     {
       "year": 1977,
@@ -66,7 +76,17 @@
       "fun_fact_fr": "Jeff Lynne a écrit « Mr. Blue Sky » après deux semaines de temps maussade en Suisse qui ont soudainement laissé place à un soleil éclatant. L'enregistrement de la chanson a pris trois mois.",
       "uri_deezer": "deezer://track/112662184",
       "fun_fact_nl": "Jeff Lynne schreef 'Mr. Blue Sky' nadat twee weken somber weer in Zwitserland plotseling plaats maakten voor stralende zonneschijn. Het duurde drie maanden om het nummer op te nemen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM10015759",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/894170619",
+        "de": "applemusic://track/1609400686",
+        "gb": "applemusic://track/1609400686",
+        "fr": "applemusic://track/1609400686",
+        "es": "applemusic://track/1609400686",
+        "nl": "applemusic://track/1609400686",
+        "it": "applemusic://track/1609400686"
+      }
     },
     {
       "year": 1966,
@@ -127,7 +147,17 @@
       "fun_fact_fr": "Kimberley Rew, le compositeur principal de Katrina & The Waves, a écrit « Walking on Sunshine » en environ dix minutes. La chanson est devenue l'un des morceaux feel-good les plus utilisés dans l'histoire de la publicité.",
       "uri_deezer": "deezer://track/3166724",
       "fun_fact_nl": "Katrina & The Waves' lead songwriter Kimberley Rew schreef 'Walking on Sunshine' in ongeveer tien minuten. Het nummer is een van de meest gelicenseerde feelgoodtracks in de reclamegeschiedenis geworden.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USCA28500452",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1893189187",
+        "de": "applemusic://track/1893189187",
+        "gb": "applemusic://track/1893189187",
+        "fr": "applemusic://track/1893189187",
+        "es": "applemusic://track/1893189187",
+        "nl": "applemusic://track/1893189187",
+        "it": "applemusic://track/1893189187"
+      }
     },
     {
       "year": 2005,
@@ -159,7 +189,17 @@
       "fun_fact_fr": "« Love Generation » est devenu l'hymne officieux de la Coupe du Monde FIFA 2006 en Allemagne, bien qu'il ne soit pas la chanson officielle. Il a atteint la première place dans dix pays européens.",
       "uri_deezer": "deezer://track/88679677",
       "fun_fact_nl": "Love Generation' werd het officieuze volkslied van de 2006 FIFA World Cup in Duitsland, ook al was het niet het officiële lied. Het voerde de hitlijsten aan in tien Europese landen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "FR4E41811680",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1771109022",
+        "de": "applemusic://track/1771109022",
+        "gb": "applemusic://track/1771109022",
+        "fr": "applemusic://track/1771109022",
+        "es": "applemusic://track/1771109022",
+        "nl": "applemusic://track/1771109022",
+        "it": "applemusic://track/1771109022"
+      }
     },
     {
       "year": 1977,
@@ -190,7 +230,17 @@
       "fun_fact_fr": "Bill Withers tient une seule note pendant 18 secondes sur le mot « day » dans « Lovely Day », l'une des notes tenues les plus longues dans un single pop à succès.",
       "uri_deezer": "deezer://track/70016835",
       "fun_fact_nl": "Bill Withers houdt een enkele noot 18 seconden vast tijdens het woord 'day' in 'Lovely Day', een van de langst aangehouden noten in een pophit.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM10207844",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1626507316",
+        "de": "applemusic://track/1626507316",
+        "gb": "applemusic://track/1626507316",
+        "fr": "applemusic://track/1626507316",
+        "es": "applemusic://track/1626507316",
+        "nl": "applemusic://track/1626507316",
+        "it": "applemusic://track/1626507316"
+      }
     },
     {
       "year": 1972,
@@ -220,7 +270,17 @@
       "fun_fact_fr": "Johnny Nash a enregistré « I Can See Clearly Now » en Jamaïque avec des musiciens de reggae, en faisant l'un des premiers succès pop influencés par le reggae. Bob Marley a joué de la guitare sur certaines sessions jamaïcaines de Nash.",
       "uri_deezer": "deezer://track/13784672",
       "fun_fact_nl": "Johnny Nash nam 'I Can See Clearly Now' op in Jamaica met reggaemuzikanten, waardoor het een van de vroegste pophits met reggae-invloeden werd. Bob Marley speelde gitaar op sommige van Nash' Jamaicaanse sessies.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBBBN9999947",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/254960638",
+        "de": "applemusic://track/298260001",
+        "gb": "applemusic://track/438886771",
+        "fr": "applemusic://track/298260001",
+        "es": "applemusic://track/298260001",
+        "nl": "applemusic://track/298260001",
+        "it": "applemusic://track/298260001"
+      }
     },
     {
       "year": 1983,
@@ -250,7 +310,17 @@
       "fun_fact_fr": "Le clip de « Club Tropicana » a été tourné dans un vrai complexe hôtelier à Ibiza. George Michael et Andrew Ridgeley étaient encore adolescents quand ils ont formé Wham!, et ce titre est devenu leur tube estival révélateur.",
       "uri_deezer": "deezer://track/1073437",
       "fun_fact_nl": "De videoclip voor 'Club Tropicana' werd opgenomen in een echt resort op Ibiza. George Michael en Andrew Ridgeley waren nog in hun tienerjaren toen ze Wham! vormden, en dit werd hun zomerhit.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBBBM8300007",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/206897937",
+        "de": "applemusic://track/1023759237",
+        "gb": "applemusic://track/1023759237",
+        "fr": "applemusic://track/1023759237",
+        "es": "applemusic://track/1023759237",
+        "nl": "applemusic://track/1023759237",
+        "it": "applemusic://track/1023759237"
+      }
     },
     {
       "year": 1988,
@@ -278,7 +348,17 @@
       "fun_fact_fr": "« Loco in Acapulco » a été coécrite par Phil Collins et Lamont Dozier. Elle a offert aux Four Tops leur plus grand succès britannique en plus de 20 ans, prouvant leur attrait durable à travers les générations.",
       "uri_deezer": "deezer://track/541849",
       "fun_fact_nl": "Loco in Acapulco' werd mede geschreven door Phil Collins en Lamont Dozier. Het bezorgde de Four Tops hun grootste hit in de UK in meer dan 20 jaar en bewees hun blijvende aantrekkingskracht over de generaties heen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USAR18800003",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/501183161",
+        "de": "applemusic://track/1308707068",
+        "gb": "applemusic://track/1308707068",
+        "fr": "applemusic://track/1308707068",
+        "es": "applemusic://track/1308707068",
+        "nl": "applemusic://track/1308707068",
+        "it": "applemusic://track/1308707068"
+      }
     },
     {
       "year": 1963,
@@ -308,7 +388,17 @@
       "fun_fact_fr": "« Surfin' U.S.A. » a tellement emprunté sa mélodie à « Sweet Little Sixteen » de Chuck Berry que Berry a finalement obtenu un crédit d'auteur-compositeur. Elle est devenue l'hymne de la culture surf californienne.",
       "uri_deezer": "deezer://track/3091966",
       "fun_fact_nl": "Surfin' U.S.A.' ontleende zijn melodie zo sterk aan Chuck Berry's 'Sweet Little Sixteen' dat Berry uiteindelijk een credit kreeg voor het schrijven van de song. Het werd het volkslied van de Californische surfcultuur.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USCA20001654",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1698230404",
+        "de": "applemusic://track/1698230404",
+        "gb": "applemusic://track/1698230404",
+        "fr": "applemusic://track/1698230404",
+        "es": "applemusic://track/1698230404",
+        "nl": "applemusic://track/1698230404",
+        "it": "applemusic://track/1698230404"
+      }
     },
     {
       "year": 1988,
@@ -338,7 +428,17 @@
       "fun_fact_fr": "« Somewhere in My Heart » était le seul hit Top 5 d'Aztec Camera. Le leader Roddy Frame n'avait que 23 ans quand elle est devenue la chanson pop estivale britannique par excellence de 1988.",
       "uri_deezer": "deezer://track/782929",
       "fun_fact_nl": "'Somewhere in My Heart' was de enige Top 5-hit van Aztec Camera. Frontman Roddy Frame was net 23 toen het het typische Britse zomerpopliedje van 1988 werd.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBDL58300056",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/516652008",
+        "de": null,
+        "gb": null,
+        "fr": null,
+        "es": null,
+        "nl": null,
+        "it": null
+      }
     },
     {
       "year": 1978,
@@ -368,7 +468,17 @@
       "fun_fact_fr": "« Dreadlock Holiday » a été inspirée par un incident où des membres de 10cc ont été menacés par des locaux pendant leurs vacances à la Barbade. Les paroles « I don't like cricket, I love it » sont devenues une expression culte au Royaume-Uni.",
       "uri_deezer": "deezer://track/23494861",
       "fun_fact_nl": "Dreadlock Holiday' werd geïnspireerd door een incident waarbij leden van 10cc tijdens hun vakantie op Barbados werden bedreigd door de lokale bevolking. De tekst 'I don't like cricket, I love it' werd een slagzin in de UK.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBF087800002",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1824351242",
+        "de": "applemusic://track/1528951687",
+        "gb": "applemusic://track/1824351242",
+        "fr": "applemusic://track/1824351242",
+        "es": "applemusic://track/1824351242",
+        "nl": "applemusic://track/1824351242",
+        "it": "applemusic://track/1824351242"
+      }
     },
     {
       "year": 1966,
@@ -395,7 +505,17 @@
       "uri_tidal": "tidal://track/219653298",
       "fun_fact_fr": "Ray Davies a écrit « Sunny Afternoon » pendant qu'il se remettait d'une dépression nerveuse. La chanson a détrôné « Paperback Writer » des Beatles de la première place au Royaume-Uni en 1966.",
       "fun_fact_nl": "Ray Davies schreef 'Sunny Afternoon' terwijl hij herstelde van een zenuwinzinking. Het nummer stootte The Beatles' 'Paperback Writer' van de UK nummer één positie in 1966.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBUM71102774",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1439527967",
+        "de": "applemusic://track/1439527967",
+        "gb": "applemusic://track/1439527967",
+        "fr": "applemusic://track/1439527967",
+        "es": "applemusic://track/1439527967",
+        "nl": "applemusic://track/1439527967",
+        "it": "applemusic://track/1439527967"
+      }
     },
     {
       "year": 1957,
@@ -425,7 +545,17 @@
       "fun_fact_fr": "La version de « Summertime » par Ella Fitzgerald et Louis Armstrong, tirée de leur album Porgy and Bess, est l'une des plus de 33 000 versions enregistrées de ce classique de Gershwin, ce qui en fait la chanson la plus reprise de l'histoire.",
       "uri_deezer": "deezer://track/540203402",
       "fun_fact_nl": "De versie van 'Summertime' van Ella Fitzgerald en Louis Armstrong van hun album Porgy and Bess is een van de meer dan 33.000 opgenomen versies van deze klassieker van Gershwin, waarmee het het meest gecoverde nummer in de geschiedenis is.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMC10111963",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1442257010",
+        "de": "applemusic://track/1442257010",
+        "gb": "applemusic://track/1442257010",
+        "fr": "applemusic://track/1442257010",
+        "es": "applemusic://track/1442257010",
+        "nl": "applemusic://track/1442257010",
+        "it": "applemusic://track/1442257010"
+      }
     },
     {
       "year": 1966,
@@ -455,7 +585,17 @@
       "fun_fact_fr": "The Lovin' Spoonful a enregistré les sons de circulation et de marteau-piqueur entendus dans « Summer in the City » dans les rues de New York. C'était le seul numéro un du groupe au Billboard Hot 100.",
       "uri_deezer": "deezer://track/600434",
       "fun_fact_nl": "The Lovin' Spoonful namen de verkeers- en drilboorgeluiden in 'Summer in the City' op in de straten van New York. Het was de enige nummer één hit van de band in de Billboard Hot 100.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USBR10300026",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1737735634",
+        "de": "applemusic://track/1737735634",
+        "gb": "applemusic://track/1737735634",
+        "fr": "applemusic://track/1737735634",
+        "es": "applemusic://track/1737735634",
+        "nl": "applemusic://track/1737735634",
+        "it": "applemusic://track/1737735634"
+      }
     },
     {
       "year": 1976,
@@ -483,7 +623,17 @@
       "fun_fact_fr": "« Everybody Loves the Sunshine » est devenue l'une des chansons les plus samplées de l'histoire du hip-hop, utilisée par des artistes comme Mary J. Blige, Big Daddy Kane et bien d'autres. Roy Ayers est souvent appelé le parrain de la neo-soul.",
       "uri_deezer": "deezer://track/549279042",
       "fun_fact_nl": "Everybody Loves the Sunshine' is een van de meest gesamplede nummers in de hiphopgeschiedenis geworden, gebruikt door artiesten als Mary J. Blige, Big Daddy Kane en vele anderen. Roy Ayers wordt vaak de peetvader van de neo-soul genoemd.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USPR37602184",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1874772318",
+        "de": "applemusic://track/1874772318",
+        "gb": "applemusic://track/1874772318",
+        "fr": "applemusic://track/1874772318",
+        "es": "applemusic://track/1874772318",
+        "nl": "applemusic://track/1874772318",
+        "it": "applemusic://track/1874772318"
+      }
     },
     {
       "year": 1978,
@@ -514,7 +664,17 @@
       "fun_fact_fr": "« Summer Nights » de la bande originale de Grease a atteint la première place au Royaume-Uni et est devenu l'un des singles les plus vendus de 1978. La chanson a été réenregistrée pour le film avec des paroles différentes de la version scénique originale.",
       "uri_deezer": "deezer://track/781563042",
       "fun_fact_nl": "Summer Nights' van de soundtrack van Grease bereikte de eerste plaats in Groot-Brittannië en werd een van de best verkochte singles van 1978. Het nummer werd opnieuw opgenomen voor de film met een andere tekst dan de originele toneelversie.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "NLF057890002",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1711275361",
+        "de": "applemusic://track/1711275361",
+        "gb": "applemusic://track/1711275361",
+        "fr": "applemusic://track/1711275361",
+        "es": "applemusic://track/1711275361",
+        "nl": "applemusic://track/1711275361",
+        "it": "applemusic://track/1711275361"
+      }
     },
     {
       "year": 1985,
@@ -544,7 +704,17 @@
       "fun_fact_fr": "Bryan Adams a confirmé que « Summer of '69 » ne parle pas vraiment de l'année 1969. Le titre est un double sens, et Adams n'avait que neuf ans cet été-là. Il a acheté sa première vraie guitare à 14 ans.",
       "uri_deezer": "deezer://track/88902741",
       "fun_fact_nl": "Bryan Adams heeft bevestigd dat 'Summer of '69' niet echt over het jaar 1969 gaat. De titel is een dubbele betekenis en Adams was die zomer pas negen jaar oud. Hij kocht zijn eerste echte gitaar toen hij 14 was.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USAM18490006",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1440823965",
+        "de": "applemusic://track/1440823965",
+        "gb": "applemusic://track/1484319318",
+        "fr": "applemusic://track/1440823965",
+        "es": "applemusic://track/1440823965",
+        "nl": "applemusic://track/1442499799",
+        "it": "applemusic://track/1440823965"
+      }
     },
     {
       "year": 1963,
@@ -572,7 +742,17 @@
       "fun_fact_fr": "« Those Lazy, Hazy, Crazy Days of Summer » de Nat King Cole a été un succès surprise en 1963, atteignant le Top 10 du Billboard Hot 100. Elle est devenue un standard estival bien que Cole soit principalement connu pour ses ballades romantiques.",
       "uri_deezer": "deezer://track/3326285",
       "fun_fact_nl": "Nat King Cole's 'Those Lazy, Hazy, Crazy Days of Summer' was een verrassingshit in 1963 en bereikte de Top 10 van de Billboard Hot 100. Het werd een zomerstandaard ondanks dat Cole vooral bekend stond om romantische ballads. Het werd een zomerse standaard ondanks dat Cole vooral bekend stond om zijn romantische ballads.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USCA29000090",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/716278761",
+        "de": "applemusic://track/716278761",
+        "gb": "applemusic://track/716278761",
+        "fr": "applemusic://track/716278761",
+        "es": "applemusic://track/716278761",
+        "nl": "applemusic://track/716278761",
+        "it": "applemusic://track/716278761"
+      }
     },
     {
       "year": 1966,
@@ -600,7 +780,17 @@
       "fun_fact_fr": "« In the Country » était l'un des nombreux succès britanniques de Cliff Richard qui n'ont jamais percé en Amérique. La chanson capture parfaitement l'imagerie idyllique de la campagne anglaise populaire dans la pop britannique du milieu des années 1960.",
       "uri_deezer": "deezer://track/4224032",
       "fun_fact_nl": "In the Country' was een van de vele Britse hits van Cliff Richard die nooit is overgewaaid naar Amerika. Het nummer geeft perfect de idyllische Engelse plattelandsbeelden weer die populair waren in de Britse pop uit het midden van de jaren 60.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAYE6700451",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1570265233",
+        "de": "applemusic://track/696777000",
+        "gb": "applemusic://track/696777000",
+        "fr": "applemusic://track/696777000",
+        "es": "applemusic://track/696777000",
+        "nl": "applemusic://track/696777000",
+        "it": "applemusic://track/696777000"
+      }
     },
     {
       "year": 1968,
@@ -631,7 +821,17 @@
       "fun_fact_fr": "Otis Redding a enregistré « (Sittin' On) The Dock of the Bay » seulement trois jours avant sa mort dans un accident d'avion en décembre 1967. Le sifflement à la fin était un espace réservé qu'il prévoyait de remplacer par les paroles finales.",
       "uri_deezer": "deezer://track/495824392",
       "fun_fact_nl": "Otis Redding nam '(Sittin' On) The Dock of the Bay' slechts drie dagen voor zijn dood op bij een vliegtuigongeluk in december 1967. Het fluiten aan het einde was een placeholder die hij wilde vervangen door de definitieve tekst.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USAT21501297",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/995809798",
+        "de": "applemusic://track/995809798",
+        "gb": "applemusic://track/995809798",
+        "fr": "applemusic://track/995809798",
+        "es": "applemusic://track/995809798",
+        "nl": "applemusic://track/995809798",
+        "it": "applemusic://track/995809798"
+      }
     },
     {
       "year": 1964,
@@ -661,7 +861,17 @@
       "fun_fact_fr": "« Under the Boardwalk » a été enregistrée en 1964 un jour seulement après que le chanteur principal original Rudy Lewis a été retrouvé mort. Le nouveau chanteur Johnny Moore a pris la relève et a enregistré la voix iconique en une seule prise.",
       "uri_deezer": "deezer://track/676880",
       "fun_fact_nl": "Under the Boardwalk' werd opgenomen in 1964, slechts één dag nadat de originele leadzanger Rudy Lewis dood werd aangetroffen. De nieuwe zanger Johnny Moore stapte in en nam de iconische vocal in één take op.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USAT20001017",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1857915156",
+        "de": "applemusic://track/1857915156",
+        "gb": "applemusic://track/1857915156",
+        "fr": "applemusic://track/1857915156",
+        "es": "applemusic://track/1857915156",
+        "nl": "applemusic://track/1857915156",
+        "it": "applemusic://track/1857915156"
+      }
     },
     {
       "year": 1983,
@@ -689,7 +899,17 @@
       "fun_fact_fr": "« Twisting by the Pool » était une parenthèse humoristique pour Dire Straits, sortie en EP indépendant. Mark Knopfler a dit qu'elle était censée être un morceau amusant sans prétention, mais elle est devenue un succès surprise dans plusieurs pays.",
       "uri_deezer": "deezer://track/4679123",
       "fun_fact_nl": "Twisting by the Pool' was een tongue-in-cheek afscheid voor Dire Straits, uitgebracht als een op zichzelf staande EP. Mark Knopfler heeft gezegd dat het bedoeld was als een leuk wegwerpnummer, maar het werd een verrassingshit in verschillende landen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBF087900668",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1789328825",
+        "de": "applemusic://track/1440912592",
+        "gb": "applemusic://track/1440912592",
+        "fr": "applemusic://track/1440912592",
+        "es": "applemusic://track/1440912592",
+        "nl": "applemusic://track/1440912592",
+        "it": "applemusic://track/1440912592"
+      }
     },
     {
       "year": 1967,
@@ -719,7 +939,17 @@
       "fun_fact_fr": "« Daydream Believer » a été écrite par John Stewart des Kingston Trio. Le bavardage de studio au début où le producteur Chip Douglas compte « 7A » avant le début de la chanson a été laissé intentionnellement et est devenu l'une des intros les plus célèbres du rock.",
       "uri_deezer": "deezer://track/5093933",
       "fun_fact_nl": "Daydream Believer' werd geschreven door John Stewart van het Kingston Trio. Het openingspraatje in de studio waarbij producer Chip Douglas '7A' telt voordat het nummer begint, werd er expres in gelaten en werd een van de beroemdste intro's van de rock.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USRH10125802",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1556224160",
+        "de": "applemusic://track/1625648637",
+        "gb": "applemusic://track/1625648637",
+        "fr": "applemusic://track/1625648637",
+        "es": "applemusic://track/1625648637",
+        "nl": "applemusic://track/1625648637",
+        "it": "applemusic://track/1625648637"
+      }
     },
     {
       "year": 1967,
@@ -777,7 +1007,17 @@
       "fun_fact_fr": "« Love Is in the Air » a connu un énorme renouveau en 1992 quand elle a été utilisée dans le film « Strictly Ballroom ». Le chanteur australien John Paul Young est en fait né à Glasgow, en Écosse.",
       "uri_deezer": "deezer://track/3818296301",
       "fun_fact_nl": "Love Is in the Air' beleefde een enorme opleving in 1992 toen het te zien was in de film 'Strictly Ballroom'. De Australische zanger John Paul Young werd geboren in Glasgow, Schotland.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "AUAP07800004",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1870643447",
+        "de": "applemusic://track/1870643447",
+        "gb": "applemusic://track/1710208358",
+        "fr": "applemusic://track/1870643447",
+        "es": "applemusic://track/1870643447",
+        "nl": "applemusic://track/1870643447",
+        "it": "applemusic://track/1870643447"
+      }
     },
     {
       "year": 1984,
@@ -807,7 +1047,17 @@
       "fun_fact_fr": "« The Boys of Summer » de Don Henley a remporté le Grammy de la meilleure performance vocale rock masculine en 1986. Le clip iconique en noir et blanc, réalisé par Jean-Baptiste Mondino, est considéré comme l'un des plus grands de tous les temps.",
       "uri_deezer": "deezer://track/3977905",
       "fun_fact_nl": "Don Henley's 'The Boys of Summer' won de Grammy voor Beste Mannelijke Rock Vocale Uitvoering in 1986. De iconische zwart-wit videoclip, geregisseerd door Jean-Baptiste Mondino, wordt beschouwd als een van de beste aller tijden.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USGF18502601",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1679433130",
+        "de": "applemusic://track/1602385478",
+        "gb": "applemusic://track/1602385478",
+        "fr": "applemusic://track/1602385478",
+        "es": "applemusic://track/1575645368",
+        "nl": "applemusic://track/1602385478",
+        "it": "applemusic://track/1602385478"
+      }
     },
     {
       "year": 1963,
@@ -837,7 +1087,17 @@
       "fun_fact_fr": "« Summer Holiday » était la chanson titre du film éponyme de Cliff Richard en 1963. Elle a passé deux semaines en tête au Royaume-Uni et est devenue l'une des chansons pop britanniques emblématiques du début des années 1960.",
       "uri_deezer": "deezer://track/3098023",
       "fun_fact_nl": "Summer Holiday' was het titelnummer van Cliff Richards gelijknamige film uit 1963. Het stond twee weken op nummer één in het Verenigd Koninkrijk en werd een van de bepalende Britse popsongs van de vroege jaren 1960.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAYE6300030",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/696776235",
+        "de": "applemusic://track/1458997385",
+        "gb": "applemusic://track/1458997385",
+        "fr": "applemusic://track/1458997385",
+        "es": "applemusic://track/1458997385",
+        "nl": "applemusic://track/1458997385",
+        "it": "applemusic://track/1458997385"
+      }
     },
     {
       "year": 1958,
@@ -867,7 +1127,17 @@
       "fun_fact_fr": "Eddie Cochran a écrit « Summertime Blues » alors qu'il n'avait que 19 ans. La chanson a été reprise par The Who, Blue Cheer et Alan Jackson, et a été intronisée au Grammy Hall of Fame en 1999.",
       "uri_deezer": "deezer://track/3089528",
       "fun_fact_nl": "Eddie Cochran schreef 'Summertime Blues' toen hij nog maar 19 jaar oud was. Het nummer werd gecoverd door The Who, Blue Cheer en Alan Jackson en werd in 1999 opgenomen in de Grammy Hall of Fame.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USEM38800220",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1565014556",
+        "de": "applemusic://track/1565014556",
+        "gb": "applemusic://track/688774178",
+        "fr": "applemusic://track/1565014556",
+        "es": "applemusic://track/1565014556",
+        "nl": "applemusic://track/1565014556",
+        "it": "applemusic://track/1565014556"
+      }
     },
     {
       "year": 1963,
@@ -897,7 +1167,17 @@
       "fun_fact_fr": "« Heat Wave » de Martha and the Vandellas était l'une des premières chansons Motown à présenter le style de production « mur de son ». L'équipe d'auteurs-compositeurs Holland-Dozier-Holland l'a écrite en une seule après-midi.",
       "uri_deezer": "deezer://track/78102223",
       "fun_fact_nl": "Heat Wave' van Martha and the Vandellas was een van de eerste Motown-nummers met de 'wall of sound'-productiestijl. Het songwritingteam Holland-Dozier-Holland schreef het in één enkele middagsessie.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMO16300273",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1471569294",
+        "de": "applemusic://track/1444017336",
+        "gb": "applemusic://track/1418049694",
+        "fr": "applemusic://track/1444017336",
+        "es": "applemusic://track/1444017336",
+        "nl": "applemusic://track/1444017336",
+        "it": "applemusic://track/1444017336"
+      }
     },
     {
       "year": 1972,
@@ -927,7 +1207,17 @@
       "fun_fact_fr": "« Summer Breeze » a été écrite par Jim Seals et Dash Crofts sur les plaisirs simples de rentrer chez soi. Les Isley Brothers l'ont ensuite reprise dans une version funk qui est devenue tout aussi iconique dans un genre différent.",
       "uri_deezer": "deezer://track/5416564",
       "fun_fact_nl": "Summer Breeze' werd geschreven door Jim Seals en Dash Crofts over de eenvoudige geneugten van thuiskomen. De Isley Brothers coverden het later in een funkversie die even iconisch werd in een ander genre.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USWB19901645",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1703789022",
+        "de": "applemusic://track/1703789022",
+        "gb": "applemusic://track/1703789022",
+        "fr": "applemusic://track/1703789022",
+        "es": "applemusic://track/1703789022",
+        "nl": "applemusic://track/1703789022",
+        "it": "applemusic://track/1703789022"
+      }
     },
     {
       "year": 1966,
@@ -957,7 +1247,17 @@
       "fun_fact_fr": "« Sunshine Superman » a été la première chanson à fusionner la musique folk avec la psychédélie et les techniques de production électronique. Un litige juridique a retardé sa sortie au Royaume-Uni de six mois, coûtant à Donovan une potentielle première place.",
       "uri_deezer": "deezer://track/1066178",
       "fun_fact_nl": "Sunshine Superman' was het eerste nummer dat folkmuziek versmolt met psychedelica en elektronische productietechnieken. Een juridisch geschil vertraagde de release in Groot-Brittannië met zes maanden, wat Donovan een potentieel nummer één in Groot-Brittannië kostte.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM19805194",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/158701754",
+        "de": "applemusic://track/158701754",
+        "gb": null,
+        "fr": "applemusic://track/158701754",
+        "es": "applemusic://track/158701754",
+        "nl": "applemusic://track/158701754",
+        "it": "applemusic://track/158701754"
+      }
     },
     {
       "year": 1965,
@@ -987,7 +1287,17 @@
       "fun_fact_fr": "Brian Wilson a écrit « California Girls » après sa première expérience avec le LSD. La fanfare d'ouverture de la chanson a été inspirée par Bach et a pris plus de temps à composer que le reste de la chanson réuni.",
       "uri_deezer": "deezer://track/1786547927",
       "fun_fact_nl": "Brian Wilson schreef 'California Girls' na zijn eerste ervaring met LSD. De openingsfanfare van het nummer was geïnspireerd door Bach en het duurde langer om te componeren dan de rest van het nummer bij elkaar.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USCA21202105",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1443151786",
+        "de": "applemusic://track/1443151786",
+        "gb": "applemusic://track/1443151786",
+        "fr": "applemusic://track/1443151786",
+        "es": "applemusic://track/1443151786",
+        "nl": "applemusic://track/1443151786",
+        "it": "applemusic://track/1443151786"
+      }
     },
     {
       "year": 2000,
@@ -1017,7 +1327,17 @@
       "fun_fact_fr": "La version de « Dancing in the Moonlight » par Toploader est en fait une reprise de l'original de 1972 par King Harvest. Elle a passé 34 semaines incroyables dans les charts britanniques et est devenue l'un des singles les plus longtemps classés des années 2000.",
       "uri_deezer": "deezer://track/10434104",
       "fun_fact_nl": "Toploader's versie van 'Dancing in the Moonlight' is eigenlijk een cover van het origineel uit 1972 van King Harvest. Het stond maar liefst 34 weken in de UK chart en werd een van de langstlopende singles van de jaren 2000.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBBBL9902165",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1744521402",
+        "de": "applemusic://track/1744521402",
+        "gb": "applemusic://track/1744521402",
+        "fr": "applemusic://track/1744521402",
+        "es": "applemusic://track/1744521402",
+        "nl": "applemusic://track/1744521402",
+        "it": "applemusic://track/1744521402"
+      }
     },
     {
       "year": 2013,
@@ -1049,7 +1369,17 @@
       "fun_fact_fr": "« Get Lucky » a pris plus de 18 mois de production à Daft Punk. Nile Rodgers a enregistré environ six heures de parties de guitare, parmi lesquelles le duo a sélectionné le groove final. La chanson a été streamée plus de 270 millions de fois la première année.",
       "uri_deezer": "deezer://track/66609426",
       "fun_fact_nl": "Get Lucky' kostte Daft Punk meer dan 18 maanden om te produceren. Nile Rodgers nam ongeveer zes uur aan gitaarpartijen op, waaruit het duo de uiteindelijke groove selecteerde. Het nummer werd in het eerste jaar meer dan 270 miljoen keer gestreamd.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USQX91300809",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1459540658",
+        "de": "applemusic://track/636968288",
+        "gb": "applemusic://track/636968288",
+        "fr": "applemusic://track/1090310647",
+        "es": "applemusic://track/636968288",
+        "nl": "applemusic://track/636968288",
+        "it": "applemusic://track/636968288"
+      }
     },
     {
       "year": 1966,
@@ -1077,7 +1407,17 @@
       "fun_fact_fr": "Également connue sous le nom de « Feelin' Groovy », cette chanson de Simon & Garfunkel a été écrite par Paul Simon sur le pont de la 59e rue (Queensboro Bridge) à New York. Simon a dit l'avoir écrite comme une célébration du ralentissement dans un monde effréné.",
       "uri_deezer": "deezer://track/680009822",
       "fun_fact_nl": "Dit Simon & Garfunkel-nummer, ook bekend als 'Feelin' Groovy', werd geschreven door Paul Simon over de 59th Street Bridge (Queensboro Bridge) in New York City. Simon heeft gezegd dat hij het schreef als een viering van het vertragen in een snelle wereld.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM16600262",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1463658596",
+        "de": "applemusic://track/1463658596",
+        "gb": "applemusic://track/1463658596",
+        "fr": "applemusic://track/1463658596",
+        "es": "applemusic://track/1463658596",
+        "nl": "applemusic://track/1463658596",
+        "it": "applemusic://track/1463658596"
+      }
     },
     {
       "year": 1965,
@@ -1107,7 +1447,17 @@
       "fun_fact_fr": "La version de « Mr. Tambourine Man » par The Byrds était le premier numéro un folk-rock. Seul Roger McGuinn a joué d'un instrument sur l'enregistrement ; le reste du groupe a été remplacé par des musiciens de session de la légendaire Wrecking Crew.",
       "uri_deezer": "deezer://track/5181118",
       "fun_fact_nl": "De versie van 'Mr. Tambourine Man' van The Byrds was de eerste folkrock nummer 1-hit. Alleen Roger McGuinn speelde een instrument op de opname; de rest van de band werd vervangen door sessiemuzikanten van de legendarische Wrecking Crew.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM16500019",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/153421332",
+        "de": "applemusic://track/1042989415",
+        "gb": "applemusic://track/1042989415",
+        "fr": "applemusic://track/1042989415",
+        "es": "applemusic://track/1042989415",
+        "nl": "applemusic://track/1042989415",
+        "it": "applemusic://track/1042989415"
+      }
     },
     {
       "year": 1967,
@@ -1137,7 +1487,17 @@
       "fun_fact_fr": "La version de « Dedicated to the One I Love » par The Mamas & The Papas était à l'origine un succès des Shirelles de 1959. Les harmonies vocales de Cass Elliot sur ce titre ont contribué à définir le son sunshine pop californien de la fin des années 1960.",
       "uri_deezer": "deezer://track/120302688",
       "fun_fact_nl": "De versie van 'Dedicated to the One I Love' van The Mamas & The Papas was oorspronkelijk een Shirelles-hit uit 1959. Cass Elliot's vocale harmonieën op het nummer hielpen het Californische zonneschijnpopgeluid van de late jaren 1960 te definiëren.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMC16746383",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1858053178",
+        "de": "applemusic://track/1858053178",
+        "gb": "applemusic://track/1858053178",
+        "fr": "applemusic://track/1858053178",
+        "es": "applemusic://track/1858053178",
+        "nl": "applemusic://track/1858053178",
+        "it": "applemusic://track/1858053178"
+      }
     },
     {
       "year": 1968,
@@ -1167,7 +1527,17 @@
       "fun_fact_fr": "Bien que souvent associée à The Mamas & The Papas (avec Mama Cass), « Dream a Little Dream of Me » a été écrite à l'origine en 1931. Leur version est devenue un pilier de la culture flower power des années 1960.",
       "uri_deezer": "deezer://track/538670442",
       "fun_fact_nl": "Hoewel het vaak wordt geassocieerd met The Mamas & The Papas (met Mama Cass), werd 'Dream a Little Dream of Me' oorspronkelijk geschreven in 1931. Hun versie werd een belangrijk onderdeel van de flower power cultuur van de jaren 1960.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMC16846393",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1833249921",
+        "de": "applemusic://track/1833249921",
+        "gb": "applemusic://track/1833249921",
+        "fr": "applemusic://track/1833249921",
+        "es": "applemusic://track/1833249921",
+        "nl": "applemusic://track/1833249921",
+        "it": "applemusic://track/1833249921"
+      }
     },
     {
       "year": 1972,
@@ -1197,7 +1567,17 @@
       "fun_fact_fr": "« Take It Easy » était le premier single des Eagles et a été coécrite par Glenn Frey et Jackson Browne, qui était le voisin de Frey. La célèbre phrase sur « a girl in a flatbed Ford » était la contribution de Browne.",
       "uri_deezer": "deezer://track/68116147",
       "fun_fact_nl": "Take It Easy' was de debuutsingle van de Eagles en was mede geschreven door Glenn Frey en Jackson Browne, die Frey's buurman was. De beroemde regel over 'a girl in a flatbed Ford' was de bijdrage van Browne.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USEE11300142",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/635829446",
+        "de": "applemusic://track/635829446",
+        "gb": "applemusic://track/635829446",
+        "fr": "applemusic://track/635829446",
+        "es": "applemusic://track/635829446",
+        "nl": "applemusic://track/635829446",
+        "it": "applemusic://track/635829446"
+      }
     },
     {
       "year": 1972,
@@ -1227,7 +1607,17 @@
       "fun_fact_fr": "Tom Johnston a écrit « Listen to the Music » en seulement 30 minutes comme une chanson simple et positive. Elle est devenue le tube révélateur et la chanson emblématique des Doobie Brothers, bien qu'elle ait initialement culminé en dehors du Top 10.",
       "uri_deezer": "deezer://track/775032",
       "fun_fact_nl": "Tom Johnston schreef 'Listen to the Music' in slechts 30 minuten als een eenvoudig, positief liedje. Het werd de doorbraakhit van The Doobie Brothers en hun lijflied, hoewel het aanvankelijk buiten de Top 10 viel.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USRH11600587",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1111345699",
+        "de": "applemusic://track/1111345699",
+        "gb": "applemusic://track/1111345699",
+        "fr": "applemusic://track/1111345699",
+        "es": "applemusic://track/1111345699",
+        "nl": "applemusic://track/1111345699",
+        "it": "applemusic://track/1111345699"
+      }
     },
     {
       "year": 1968,
@@ -1255,7 +1645,17 @@
       "fun_fact_fr": "« Lazy Sunday » des Small Faces était un morceau satirique de style music-hall cockney qui est devenu l'une des premières chansons à utiliser des effets de bande à des fins comiques. Son succès a surpris le groupe lui-même.",
       "uri_deezer": "deezer://track/75994746",
       "fun_fact_nl": "Lazy Sunday' van Small Faces was een satirische Cockney music hall-achtige track die een van de eerste nummers werd waarin tape-effecten werden gebruikt voor komische doeleinden. Het was het succes van de B-kant die het nummer voortstuwde, tot grote verrassing van de band.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBA7H1143348",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1815573647",
+        "de": "applemusic://track/1815573647",
+        "gb": null,
+        "fr": "applemusic://track/1815573647",
+        "es": "applemusic://track/1815573647",
+        "nl": "applemusic://track/1815573647",
+        "it": "applemusic://track/1815573647"
+      }
     },
     {
       "year": 1966,
@@ -1285,7 +1685,17 @@
       "fun_fact_fr": "« Mellow Yellow » de Donovan a déclenché une légende urbaine selon laquelle fumer des peaux de banane séchées pouvait faire planer. La rumeur était totalement fausse, mais elle est devenue l'un des canulars les plus célèbres de la contre-culture des années 1960.",
       "uri_deezer": "deezer://track/14926547",
       "fun_fact_nl": "Donovan's 'Mellow Yellow' veroorzaakte een wijdverspreide urban legend dat je high kon worden van het roken van gedroogde bananenschillen. Het gerucht was volledig vals, maar het werd een van de beroemdste hoaxes van de tegencultuur van de jaren 1960.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM16601692",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1308624086",
+        "de": "applemusic://track/1308624086",
+        "gb": null,
+        "fr": "applemusic://track/1308624086",
+        "es": "applemusic://track/1308624086",
+        "nl": "applemusic://track/1308624086",
+        "it": "applemusic://track/1308624086"
+      }
     },
     {
       "year": 1983,
@@ -1316,7 +1726,17 @@
       "fun_fact_fr": "Elton John a écrit « I'm Still Standing » pendant une période de rétablissement personnel dans le sud de la France. Le célèbre clip a été tourné sur la plage de Cannes et est connu pour ses danseurs au corps peint de couleurs vives.",
       "uri_deezer": "deezer://track/1171163",
       "fun_fact_nl": "Elton John schreef 'I'm Still Standing' tijdens een periode van persoonlijk herstel in Zuid-Frankrijk. De beroemde videoclip werd opgenomen op het strand van Cannes en staat bekend om de levendige bodypainting van de dansers.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBALX8300190",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1440912993",
+        "de": "applemusic://track/1440912993",
+        "gb": "applemusic://track/1440912993",
+        "fr": "applemusic://track/1440912993",
+        "es": "applemusic://track/1440912993",
+        "nl": "applemusic://track/1440912993",
+        "it": "applemusic://track/1440912993"
+      }
     },
     {
       "year": 2016,
@@ -1347,7 +1767,17 @@
       "fun_fact_fr": "« CAN'T STOP THE FEELING! » a été écrite pour le film d'animation Trolls et est devenue la première chanson d'une bande originale de film d'animation à atteindre la première place depuis « Colors of the Wind » en 1995. Elle a été nominée aux Oscars.",
       "uri_deezer": "deezer://track/124237488",
       "fun_fact_nl": "CAN'T STOP THE FEELING!' werd geschreven voor de animatiefilm Trolls en werd het eerste nummer van de soundtrack van een animatiefilm dat op nummer één kwam sinds 'Colors of the Wind' in 1995. Het werd genomineerd voor een Academy Award.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USRC11600876",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1154239184",
+        "de": "applemusic://track/1164253140",
+        "gb": "applemusic://track/1691550469",
+        "fr": "applemusic://track/1154239184",
+        "es": "applemusic://track/1154239184",
+        "nl": "applemusic://track/1154239184",
+        "it": "applemusic://track/1154239184"
+      }
     },
     {
       "year": 1961,
@@ -1375,7 +1805,17 @@
       "fun_fact_fr": "« Jump in the Line (Shake, Senora) » de Harry Belafonte a connu un énorme regain de popularité après avoir été utilisée dans le film « Beetlejuice » en 1988. Belafonte, surnommé le « Roi du Calypso », a contribué à populariser la musique caribéenne en Amérique.",
       "uri_deezer": "deezer://track/959903",
       "fun_fact_nl": "Harry Belafonte's 'Jump in the Line (Shake, Senora)' werd massaal opnieuw populair nadat het te zien was in de film 'Beetlejuice' uit 1988. Belafonte, bekend als de 'King of Calypso', hielp de Caribische muziek in Amerika te populariseren.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USRC16607550",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/268458862",
+        "de": "applemusic://track/268458862",
+        "gb": "applemusic://track/268458862",
+        "fr": "applemusic://track/268458862",
+        "es": "applemusic://track/268458862",
+        "nl": "applemusic://track/268458862",
+        "it": "applemusic://track/268458862"
+      }
     },
     {
       "year": 1987,
@@ -1406,7 +1846,17 @@
       "fun_fact_fr": "« La Bamba » de Los Lobos a été enregistrée pour le biopic de Ritchie Valens du même nom. Elle est devenue la première chanson principalement en espagnol à atteindre la première place du Billboard Hot 100, un record qui a tenu 30 ans jusqu'à « Despacito ».",
       "uri_deezer": "deezer://track/705770",
       "fun_fact_nl": "Los Lobos' 'La Bamba' werd opgenomen voor de gelijknamige biopic van Ritchie Valens. Het werd het eerste overwegend Spaanstalige nummer dat nummer één werd in de Billboard Hot 100, een record dat 30 jaar standhield tot 'Despacito'.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USWB19902157",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1691148175",
+        "de": "applemusic://track/1556868625",
+        "gb": "applemusic://track/1556868625",
+        "fr": "applemusic://track/1556868625",
+        "es": "applemusic://track/1556868625",
+        "nl": "applemusic://track/1556868625",
+        "it": "applemusic://track/1528727983"
+      }
     },
     {
       "year": 1987,
@@ -1437,7 +1887,17 @@
       "fun_fact_fr": "« Bamboleo » a fait connaître les Gipsy Kings au monde entier, mêlant le flamenco rom traditionnel au pop occidental. La chanson a contribué à vendre plus de 20 millions d'exemplaires de leur premier album, faisant d'eux l'artiste français le plus vendu de tous les temps à cette époque.",
       "uri_deezer": "deezer://track/10424074",
       "fun_fact_nl": "Bamboleo' introduceerde de Gipsy Kings aan de wereld en vermengde traditionele Romaanse flamenco met westerse pop. Het nummer hielp om meer dan 20 miljoen exemplaren van hun debuutalbum te verkopen, waardoor ze op dat moment de best verkopende Franse act aller tijden waren.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USN018884501",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/31739286",
+        "de": null,
+        "gb": null,
+        "fr": null,
+        "es": null,
+        "nl": null,
+        "it": null
+      }
     },
     {
       "year": 2017,
@@ -1468,7 +1928,17 @@
       "fun_fact_fr": "Le remix de « Despacito » avec Justin Bieber est devenu la première vidéo YouTube à atteindre 5 milliards de vues. Il a battu le record du plus grand nombre de semaines en tête du Billboard Hot 100 (16 semaines), égalant « One Sweet Day » de Mariah Carey.",
       "uri_deezer": "deezer://track/623698182",
       "fun_fact_nl": "De 'Despacito'-remix met Justin Bieber werd de eerste YouTube-video die 5 miljard keer bekeken werd. Het brak het record voor de meeste weken op nummer één in de Billboard Hot 100 (16 weken), samen met Mariah Carey's 'One Sweet Day'.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USUM71703825",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1442256603",
+        "de": "applemusic://track/1442256603",
+        "gb": "applemusic://track/1442256603",
+        "fr": "applemusic://track/1442256603",
+        "es": "applemusic://track/1442256603",
+        "nl": "applemusic://track/1442256603",
+        "it": "applemusic://track/1442256603"
+      }
     },
     {
       "year": 1960,
@@ -1498,7 +1968,17 @@
       "uri_tidal": "tidal://track/57755161",
       "uri_deezer": "deezer://track/13205914",
       "fun_fact_nl": "Sam Cooke's 'Wonderful World' kwam nauwelijks in de Top 12 toen het voor het eerst werd uitgebracht in 1960, maar werd een enorme hit toen het opnieuw werd uitgebracht in 1986 nadat het te zien was in een Levi's commercial en nummer 2 bereikte in het Verenigd Koninkrijk.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USRC10501177",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1088173094",
+        "de": "applemusic://track/1088173094",
+        "gb": "applemusic://track/1088173094",
+        "fr": "applemusic://track/1088173094",
+        "es": "applemusic://track/1088173094",
+        "nl": "applemusic://track/1088173094",
+        "it": "applemusic://track/1088173094"
+      }
     },
     {
       "year": 1958,
@@ -1528,7 +2008,17 @@
       "fun_fact_fr": "« Tequila » des Champs ne contient qu'un seul mot dans toutes ses paroles : « Tequila ! » crié trois fois. Elle a remporté le Grammy de la meilleure performance R&B en 1959 et est apparue dans d'innombrables films, notamment dans « Pee-wee's Big Adventure ».",
       "uri_deezer": "deezer://track/455528682",
       "fun_fact_nl": "The Champs' 'Tequila' bevat slechts één woord in de hele tekst: Tequila!', drie keer geroepen. Het won de Grammy voor Best R&B Performance in 1959 en verscheen in talloze films, het meest memorabel in 'Pee-wee's Big Adventure'.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USATV0500278",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/205237767",
+        "de": "applemusic://track/205237767",
+        "gb": "applemusic://track/205237767",
+        "fr": "applemusic://track/205237767",
+        "es": "applemusic://track/205237767",
+        "nl": "applemusic://track/205237767",
+        "it": "applemusic://track/205237767"
+      }
     },
     {
       "year": 1970,
@@ -1558,7 +2048,17 @@
       "fun_fact_fr": "« Moondance » n'a jamais été sortie en single de l'album de 1970, mais elle est devenue la chanson la plus reconnaissable de Van Morrison. Le morceau a été certifié Platine uniquement grâce aux ventes numériques et au streaming, des décennies après sa sortie.",
       "uri_deezer": "deezer://track/71433037",
       "fun_fact_nl": "Moondance' werd nooit uitgebracht als single van het album uit 1970, maar werd wel Van Morrisons meest herkenbare nummer. Het albumnummer is alleen al decennia na de release platina gecertificeerd op basis van digitale verkoop en streaming.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USWB11302597",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/712727462",
+        "de": "applemusic://track/712727462",
+        "gb": "applemusic://track/712727462",
+        "fr": "applemusic://track/712727462",
+        "es": "applemusic://track/712727462",
+        "nl": "applemusic://track/712727462",
+        "it": "applemusic://track/712727462"
+      }
     },
     {
       "year": 1991,
@@ -1588,7 +2088,17 @@
       "fun_fact_fr": "« Summertime » de DJ Jazzy Jeff & The Fresh Prince a samplé « Summer Madness » de Kool & The Gang. Will Smith l'a qualifiée de chanson préférée qu'il ait jamais enregistrée, et elle a remporté le Grammy de la meilleure performance rap en 1992.",
       "uri_deezer": "deezer://track/546826",
       "fun_fact_nl": "DJ Jazzy Jeff & The Fresh Prince's 'Summertime' sampled Kool & The Gang's 'Summer Madness'. Will Smith noemde het zijn favoriete nummer ooit en het won de Grammy voor Beste Rap Performance in 1992.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USJI19100002",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1566957891",
+        "de": "applemusic://track/1566957891",
+        "gb": "applemusic://track/1518863085",
+        "fr": "applemusic://track/1566957891",
+        "es": "applemusic://track/1566957891",
+        "nl": "applemusic://track/1566957891",
+        "it": "applemusic://track/1566957891"
+      }
     },
     {
       "year": 1970,
@@ -1618,7 +2128,17 @@
       "fun_fact_fr": "« In the Summertime » de Mungo Jerry s'est vendue à plus de 30 millions d'exemplaires dans le monde, ce qui en fait l'un des singles les plus vendus de tous les temps. Ray Dorset l'a écrite en seulement 10 minutes sur une guitare d'occasion, et elle a été enregistrée en une seule prise.",
       "uri_deezer": "deezer://track/2036977",
       "fun_fact_nl": "Van 'In the Summertime' van Mungo Jerry zijn wereldwijd meer dan 30 miljoen exemplaren verkocht, waarmee het een van de best verkochte singles ooit is. Ray Dorset schreef het in slechts 10 minuten op een tweedehands gitaar en het werd in één take opgenomen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAJE7000049",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1729632102",
+        "de": "applemusic://track/1729632102",
+        "gb": "applemusic://track/1729632102",
+        "fr": "applemusic://track/1729632102",
+        "es": "applemusic://track/1729632102",
+        "nl": "applemusic://track/1729632102",
+        "it": "applemusic://track/1729632102"
+      }
     },
     {
       "year": 1980,
@@ -1649,7 +2169,17 @@
       "fun_fact_fr": "« The Tide Is High » de Blondie est une reprise d'un original rocksteady de 1967 par The Paragons de Jamaïque. Debbie Harry a découvert la chanson en écoutant de la musique jamaïcaine, et elle a offert à Blondie leur troisième numéro un américain.",
       "uri_deezer": "deezer://track/3167194",
       "fun_fact_nl": "Blondie's 'The Tide Is High' is een cover van een rocksteady uit 1967 van The Paragons uit Jamaica. Debbie Harry ontdekte het nummer terwijl ze naar Jamaicaanse muziek luisterde en het bezorgde Blondie hun derde nummer één in de VS.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USCH39800019",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/723508366",
+        "de": "applemusic://track/723508366",
+        "gb": "applemusic://track/723508366",
+        "fr": "applemusic://track/723508366",
+        "es": "applemusic://track/723508366",
+        "nl": "applemusic://track/723508366",
+        "it": "applemusic://track/723508366"
+      }
     },
     {
       "year": 2002,
@@ -1679,7 +2209,17 @@
       "fun_fact_fr": "« Soak Up the Sun » de Sheryl Crow a été écrite comme un antidote volontairement optimiste à l'atmosphère sombre en Amérique après le 11 septembre 2001. La chanson présente une participation de Liz Phair aux chœurs.",
       "uri_deezer": "deezer://track/916383",
       "fun_fact_nl": "Sheryl Crow's 'Soak Up the Sun' werd geschreven als een opzettelijk vrolijk tegengif voor de sombere stemming in Amerika na 11 september 2001. Het nummer heeft een gastrol van Liz Phair met achtergrondzang.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USAM10200092",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1680231376",
+        "de": "applemusic://track/1680231376",
+        "gb": "applemusic://track/1680231376",
+        "fr": "applemusic://track/1680231376",
+        "es": "applemusic://track/1680231376",
+        "nl": "applemusic://track/1680231376",
+        "it": "applemusic://track/1680231376"
+      }
     },
     {
       "year": 2008,
@@ -1709,7 +2249,17 @@
       "fun_fact_fr": "« All Summer Long » de Kid Rock sample à la fois « Sweet Home Alabama » de Lynyrd Skynyrd et « Werewolves of London » de Warren Zevon, combinant deux riffs iconiques en un énorme tube estival.",
       "uri_deezer": "deezer://track/4087608",
       "fun_fact_nl": "Kid Rock's 'All Summer Long' samplet zowel Lynyrd Skynyrd's 'Sweet Home Alabama' als Warren Zevon's 'Werewolves of London' en combineert twee iconische riffs in één grote zomerhit.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USWB11801930",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1433803661",
+        "de": "applemusic://track/1433803661",
+        "gb": "applemusic://track/1433803661",
+        "fr": "applemusic://track/1433803661",
+        "es": "applemusic://track/1433803661",
+        "nl": "applemusic://track/1433803661",
+        "it": "applemusic://track/1433803661"
+      }
     },
     {
       "year": 1999,
@@ -1739,7 +2289,17 @@
       "fun_fact_fr": "Texas a enregistré « Summer Son » dans les studios Real World de Peter Gabriel. La boucle de guitare scintillante de la chanson a été inspirée par les vacances du groupe dans le sud de la France et est devenue leur plus grand succès européen.",
       "uri_deezer": "deezer://track/2099312287",
       "fun_fact_nl": "Texas nam 'Summer Son' op in de Real World Studios van Peter Gabriel. Het glinsterende gitaarloopje van het nummer was geïnspireerd op de vakantie van de band in Zuid-Frankrijk en werd hun grootste Europese hit.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBF089900144",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1663571807",
+        "de": "applemusic://track/1663571807",
+        "gb": "applemusic://track/1663571807",
+        "fr": "applemusic://track/1663571807",
+        "es": "applemusic://track/1663571807",
+        "nl": "applemusic://track/1663571807",
+        "it": "applemusic://track/1663571807"
+      }
     },
     {
       "year": 2019,
@@ -1771,7 +2331,17 @@
       "fun_fact_fr": "« Watermelon Sugar » a mis un temps inhabituellement long de 18 mois pour atteindre la première place du Billboard Hot 100. Harry Styles a dit que la chanson parle de « l'euphorie initiale d'une relation », bien que le clip suggestif ait suscité beaucoup de spéculations parmi les fans.",
       "uri_deezer": "deezer://track/830336922",
       "fun_fact_nl": "Watermelon Sugar' deed er 18 maanden over om op nummer 1 te komen in de Billboard Hot 100. Harry Styles heeft gezegd dat het nummer gaat over 'de eerste euforie van een relatie'. Harry Styles heeft gezegd dat het nummer gaat over 'de eerste euforie van een relatie', hoewel de suggestieve videoclip tot veel fanspeculatie leidde.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM11912587",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1485802967",
+        "de": "applemusic://track/1485802967",
+        "gb": "applemusic://track/1485802967",
+        "fr": "applemusic://track/1485802967",
+        "es": "applemusic://track/1485802967",
+        "nl": "applemusic://track/1485802967",
+        "it": "applemusic://track/1485802967"
+      }
     },
     {
       "year": 2020,
@@ -1803,7 +2373,17 @@
       "fun_fact_fr": "« Heat Waves » détient le record de la plus longue ascension vers la première place du Billboard Hot 100, prenant 59 semaines pour atteindre le sommet. Son succès viral a été alimenté par une vidéo hommage Minecraft sur YouTube qui a accumulé plus de 70 millions de vues.",
       "uri_deezer": "deezer://track/1040154662",
       "fun_fact_nl": "Heat Waves' is recordhouder voor de langste klim naar nummer 1 in de Billboard Hot 100. Het duurde 59 weken om de top te bereiken. Het virale succes werd aangewakkerd door een Minecraft YouTube-video met meer dan 70 miljoen views.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBUM72000433",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1703302929",
+        "de": "applemusic://track/1703302929",
+        "gb": "applemusic://track/1703302929",
+        "fr": "applemusic://track/1703302929",
+        "es": "applemusic://track/1703302929",
+        "nl": "applemusic://track/1703302929",
+        "it": "applemusic://track/1703302929"
+      }
     },
     {
       "year": 1973,
@@ -1833,7 +2413,17 @@
       "fun_fact_fr": "Stevie Wonder a enregistré « You Are the Sunshine of My Life » alors qu'il n'avait que 22 ans. Les deux premières lignes sont en fait chantées par les choristes Jim Gilstrap et Lani Groves avant que Stevie ne prenne le relais, un détail que beaucoup d'auditeurs manquent.",
       "uri_deezer": "deezer://track/596034712",
       "fun_fact_nl": "Stevie Wonder nam 'You Are the Sunshine of My Life' op toen hij nog maar 22 jaar oud was. De eerste twee regels worden eigenlijk gezongen door achtergrondzangers Jim Gilstrap en Lani Groves voordat Stevie het overneemt, een detail dat veel luisteraars over het hoofd zien.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMO17282852",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1859698635",
+        "de": "applemusic://track/1859698635",
+        "gb": "applemusic://track/1859698635",
+        "fr": "applemusic://track/1859698635",
+        "es": "applemusic://track/1859698635",
+        "nl": "applemusic://track/1859698635",
+        "it": "applemusic://track/1859698635"
+      }
     },
     {
       "year": 1986,
@@ -1861,7 +2451,17 @@
       "fun_fact_fr": "Chris Rea a écrit « On the Beach » pendant qu'il se remettait d'une grave maladie, rêvant de s'évader vers une destination balnéaire ensoleillée. La chanson est depuis devenue l'un des morceaux estivaux les plus diffusés à la radio britannique.",
       "uri_deezer": "deezer://track/425956582",
       "fun_fact_nl": "Chris Rea schreef 'On the Beach' toen hij herstellende was van een ernstige ziekte en droomde van een ontsnapping naar een warme bestemming aan zee. Het nummer is sindsdien uitgegroeid tot een van de meest gedraaide zomertracks op de Britse radio en een hoofdbestanddeel van vakantiecompilatiealbums.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USEE19900869",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1849613487",
+        "de": "applemusic://track/1562668239",
+        "gb": "applemusic://track/1562668239",
+        "fr": "applemusic://track/1562668239",
+        "es": "applemusic://track/1562668239",
+        "nl": "applemusic://track/1562668239",
+        "it": "applemusic://track/1562668239"
+      }
     },
     {
       "year": 1964,
@@ -1889,7 +2489,17 @@
       "fun_fact_fr": "C'était l'une des chansons du film de Cliff Richard « Wonderful Life » de 1964, tourné aux îles Canaries. Les Shadows ont fourni l'arrangement de guitare distinctif qui capturait parfaitement l'atmosphère insouciante de la plage de cette époque.",
       "uri_deezer": "deezer://track/3421021",
       "fun_fact_nl": "Dit was een van de nummers uit Cliff Richard's film 'Wonderful Life' uit 1964, opgenomen op locatie op de Canarische Eilanden. The Shadows zorgden voor het kenmerkende gitaararrangement dat de zorgeloze strandsfeer van die tijd perfect weergaf.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAYE6400642",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/696776654",
+        "de": "applemusic://track/696776654",
+        "gb": "applemusic://track/696776654",
+        "fr": "applemusic://track/696776654",
+        "es": "applemusic://track/696776654",
+        "nl": "applemusic://track/696776654",
+        "it": "applemusic://track/696776654"
+      }
     },
     {
       "year": 1983,
@@ -1919,7 +2529,17 @@
       "fun_fact_fr": "« Cruel Summer » de Bananarama a gagné une nouvelle notoriété en apparaissant dans le film « Karate Kid » de 1984. Taylor Swift a repris la chanson en 2019, et sa version est devenue un énorme numéro un, présentant le titre à une nouvelle génération.",
       "uri_deezer": "deezer://track/421388782",
       "fun_fact_nl": "Bananarama's 'Cruel Summer' kreeg opnieuw bekendheid toen het verscheen in de film 'The Karate Kid' uit 1984. Het nummer werd later gecoverd door Taylor Swift in 2019, wiens versie een enorme nummer 1-hit werd en de titel introduceerde bij een nieuwe generatie.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAAP9500222",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1301440487",
+        "de": "applemusic://track/1301440487",
+        "gb": "applemusic://track/1301440487",
+        "fr": "applemusic://track/1301440487",
+        "es": "applemusic://track/1301440487",
+        "nl": "applemusic://track/1301440487",
+        "it": "applemusic://track/1301440487"
+      }
     },
     {
       "year": 1969,
@@ -1947,7 +2567,17 @@
       "fun_fact_fr": "Sly Stone a écrit « Hot Fun in the Summertime » juste après avoir joué à Woodstock en août 1969. Bien qu'elle parle de l'été, elle a en fait atteint son pic dans les charts à l'automne, devenant un hymne doux-amer de fin d'été.",
       "uri_deezer": "deezer://track/1360396932",
       "fun_fact_nl": "Sly Stone schreef 'Hot Fun in the Summertime' in de onmiddellijke nasleep van een optreden op Woodstock in augustus 1969. Ondanks dat het over de zomer ging, piekte het in de herfst in de hitlijsten en werd het een bitterzoet anthem tegen het einde van de zomer.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM19901654",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1567720916",
+        "de": "applemusic://track/1567720916",
+        "gb": "applemusic://track/1567720916",
+        "fr": "applemusic://track/1567720916",
+        "es": "applemusic://track/1567720916",
+        "nl": "applemusic://track/1567720916",
+        "it": "applemusic://track/1567720916"
+      }
     },
     {
       "year": 1984,
@@ -1975,7 +2605,17 @@
       "fun_fact_fr": "Jonathan Richman a enregistré « That Summer Feeling » dans un style épuré et intime avec à peine de production. La chanson est une méditation nostalgique sur le fait que les souvenirs d'été ne peuvent jamais vraiment être recapturés, et est devenue un favori culte parmi les fans d'indie rock.",
       "uri_deezer": "deezer://track/1145363602",
       "fun_fact_nl": "Jonathan Richman nam 'That Summer Feeling' op in een spaarzame, intieme stijl met nauwelijks productie. Het nummer is een nostalgische meditatie over hoe zomerherinneringen nooit echt kunnen worden herbeleefd en is een cultfavoriet geworden onder indierockfans.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USRO29203607",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1720041028",
+        "de": "applemusic://track/2543105",
+        "gb": "applemusic://track/2543105",
+        "fr": "applemusic://track/2543105",
+        "es": "applemusic://track/2543105",
+        "nl": "applemusic://track/2543105",
+        "it": "applemusic://track/2543105"
+      }
     },
     {
       "year": 1983,
@@ -2006,7 +2646,17 @@
       "fun_fact_fr": "« Holiday » était le premier single de Madonna à entrer dans les charts aux États-Unis et au Royaume-Uni, lançant sa carrière de Reine de la Pop. Elle a été écrite et produite par Curtis Hudson et Lisa Stevens du groupe Pure Energy, pas par Madonna elle-même.",
       "uri_deezer": "deezer://track/723836",
       "fun_fact_nl": "Holiday' was Madonna's eerste single die zowel in de VS als in het VK in de hitlijsten kwam en lanceerde haar carrière als de Queen of Pop. Het werd geschreven en geproduceerd door Curtis Hudson en Lisa Stevens van de groep Pure Energy, niet door Madonna zelf.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USWB18300013",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1800734988",
+        "de": "applemusic://track/1800734988",
+        "gb": "applemusic://track/1800734988",
+        "fr": "applemusic://track/1800734988",
+        "es": "applemusic://track/1800734988",
+        "nl": "applemusic://track/1800734988",
+        "it": "applemusic://track/1800734988"
+      }
     },
     {
       "year": 1983,
@@ -2034,7 +2684,17 @@
       "fun_fact_fr": "Paul Weller a écrit « Long Hot Summer » pour The Style Council comme un départ délibéré du son punk de The Jam, adoptant des influences européennes continentales. La chanson a été inspirée par la Nouvelle Vague française et a capturé l'esprit de l'été britannique inhabituellement chaud de 1983.",
       "uri_deezer": "deezer://track/921808",
       "fun_fact_nl": "Paul Weller schreef 'Long Hot Summer' voor The Style Council om bewust af te wijken van het punkgeluid van The Jam en invloeden van het Europese vasteland te omarmen. Het nummer was geïnspireerd door de Franse New Wave en vatte de geest van de ongewoon warme Britse zomer van 1983.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAKW8300524",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1549265939",
+        "de": "applemusic://track/1442794685",
+        "gb": "applemusic://track/1442794685",
+        "fr": "applemusic://track/1442794685",
+        "es": "applemusic://track/1549265939",
+        "nl": "applemusic://track/1442794685",
+        "it": "applemusic://track/1549265939"
+      }
     },
     {
       "year": 1971,
@@ -2062,7 +2722,17 @@
       "fun_fact_fr": "« Sun Is Shining » a été enregistrée à l'origine pour l'album « Soul Revolution Part II » de 1971, mais a gagné une renommée mondiale des décennies plus tard quand Robin Schulz l'a remixée en 2015. La version originale met en valeur le style roots reggae profond des débuts de Bob Marley & The Wailers.",
       "uri_deezer": "deezer://track/66315754",
       "fun_fact_nl": "Sun Is Shining' werd oorspronkelijk opgenomen voor het album 'Soul Revolution Part II' uit 1971, maar kreeg decennia later wereldwijde bekendheid toen Robin Schulz het in 2015 remixte. De originele versie laat de diepe roots reggaestijl van de vroege Bob Marley & The Wailers horen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USIR27800260",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1446929757",
+        "de": "applemusic://track/1446929757",
+        "gb": "applemusic://track/1446929757",
+        "fr": "applemusic://track/1446929757",
+        "es": "applemusic://track/1446929757",
+        "nl": "applemusic://track/1446929757",
+        "it": "applemusic://track/1446929757"
+      }
     },
     {
       "year": 1985,
@@ -2092,7 +2762,17 @@
       "fun_fact_fr": "David Bowie et Mick Jagger ont enregistré « Dancing in the Street » en un seul après-midi pour l'événement caritatif Live Aid en 1985. Le clip notoirement extravagant, tourné sans répétition dans les rues de Londres, est devenu un classique culte à part entière.",
       "uri_deezer": "deezer://track/3432277",
       "fun_fact_nl": "David Bowie en Mick Jagger namen 'Dancing in the Street' in slechts één middag op voor het Live Aid liefdadigheidsevenement in 1985. De beruchte campy videoclip, gefilmd in de straten van Londen zonder enige repetitie, is een cultklassieker geworden.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USJT10200043",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/726125362",
+        "de": "applemusic://track/726125362",
+        "gb": "applemusic://track/726125362",
+        "fr": "applemusic://track/726125362",
+        "es": "applemusic://track/726125362",
+        "nl": "applemusic://track/726125362",
+        "it": "applemusic://track/726125362"
+      }
     },
     {
       "year": 1961,
@@ -2122,7 +2802,17 @@
       "fun_fact_fr": "« Let's Twist Again » a remporté le Grammy Award du meilleur enregistrement rock and roll en 1962, ce qui en fait l'une des premières chansons rock à recevoir une reconnaissance aux Grammy. Chubby Checker l'a sortie comme suite de « The Twist », et elle est devenue un succès encore plus grand en Europe qu'aux États-Unis.",
       "uri_deezer": "deezer://track/64638141",
       "fun_fact_nl": "Let's Twist Again' won de Grammy Award voor Best Rock and Roll Recording in 1962 en was daarmee een van de eerste rocknummers die Grammy-erkenning kreeg. Chubby Checker bracht het uit als een vervolg op 'The Twist' en het werd zelfs een grotere hit in Europa dan in de VS.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USA176140170",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1443091056",
+        "de": "applemusic://track/1443091056",
+        "gb": "applemusic://track/1443091056",
+        "fr": "applemusic://track/1443091056",
+        "es": "applemusic://track/1443091056",
+        "nl": "applemusic://track/1443091056",
+        "it": "applemusic://track/1443091056"
+      }
     },
     {
       "year": 1963,
@@ -2152,7 +2842,17 @@
       "fun_fact_fr": "« Surf City » a été la première chanson de surf rock à atteindre la première place du Billboard Hot 100. Elle a été coécrite par Brian Wilson des Beach Boys, qui a plus tard regretté d'avoir donné la chanson à Jan & Dean car elle a surpassé les singles de son propre groupe à l'époque.",
       "uri_deezer": "deezer://track/11652020",
       "fun_fact_nl": "Surf City' was het eerste surfrocknummer dat #1 werd in de Billboard Hot 100. Het was mede geschreven door Brian Wilson van de Beach Boys. Het was mede geschreven door Brian Wilson van de Beach Boys, die later spijt had dat hij het nummer aan Jan & Dean had gegeven omdat het beter presteerde dan de singles van zijn eigen groep in die tijd.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USEM38800157",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/721209970",
+        "de": "applemusic://track/721209970",
+        "gb": "applemusic://track/721209970",
+        "fr": "applemusic://track/721209970",
+        "es": "applemusic://track/721209970",
+        "nl": "applemusic://track/721209970",
+        "it": "applemusic://track/721209970"
+      }
     },
     {
       "year": 1979,
@@ -2182,7 +2882,17 @@
       "fun_fact_fr": "« Hot Stuff » de Donna Summer était l'une des premières chansons disco à présenter une guitare rock proéminente, jouée par Jeff « Skunk » Baxter des Doobie Brothers et Steely Dan. Elle a remporté le Grammy de la meilleure performance vocale R&B féminine en 1980.",
       "uri_deezer": "deezer://track/538706952",
       "fun_fact_nl": "Hot Stuff' van Donna Summer was een van de eerste discoliedjes met prominente rockgitaar, gespeeld door Jeff 'Skunk' Baxter van de Doobie Brothers en Steely Dan. Het won de Grammy voor Best Female R&B Vocal Performance in 1980.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USPR37907202",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1704761711",
+        "de": "applemusic://track/1704761711",
+        "gb": "applemusic://track/1704761711",
+        "fr": "applemusic://track/1704761711",
+        "es": "applemusic://track/1704761711",
+        "nl": "applemusic://track/1704761711",
+        "it": "applemusic://track/1704761711"
+      }
     },
     {
       "year": 1988,
@@ -2212,7 +2922,17 @@
       "fun_fact_fr": "« Kokomo » a offert aux Beach Boys leur premier numéro un en 22 ans quand elle a dominé les charts Billboard en 1988. Écrite pour le film « Cocktail », elle a été enregistrée sans Brian Wilson et mentionne des lieux caribéens réels comme Aruba, la Jamaïque et Key Largo.",
       "uri_deezer": "deezer://track/3091987",
       "fun_fact_nl": "Kokomo' bezorgde de Beach Boys hun eerste nummer 1-hit in 22 jaar toen het in 1988 de Billboard chart aanvoerde. Geschreven voor de film 'Cocktail', werd het opgenomen zonder Brian Wilson en noemt echte Caribische locaties zoals Aruba, Jamaica en Key Largo.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USNPD0713481",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1443009761",
+        "de": "applemusic://track/1443009761",
+        "gb": "applemusic://track/1443009761",
+        "fr": "applemusic://track/1443009761",
+        "es": "applemusic://track/1443009761",
+        "nl": "applemusic://track/1443009761",
+        "it": "applemusic://track/1443009761"
+      }
     },
     {
       "year": 1979,
@@ -2242,7 +2962,17 @@
       "fun_fact_fr": "La ligne de basse de « Good Times » de CHIC, jouée par Bernard Edwards, est l'une des plus samplées de l'histoire de la musique. Elle a directement inspiré « Rapper's Delight » du Sugarhill Gang et « Another One Bites the Dust » de Queen, en faisant un riff fondateur pour le hip-hop et le rock.",
       "uri_deezer": "deezer://track/6614292",
       "fun_fact_nl": "De baslijn van CHIC's 'Good Times', gespeeld door Bernard Edwards, is een van de meest gesamplede in de muziekgeschiedenis. Het vormde de directe inspiratie voor 'Rapper's Delight' van de Sugarhill Gang en 'Another One Bites the Dust' van Queen, waardoor het een basisriff is voor zowel hiphop als rock.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USRH11803298",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1437139751",
+        "de": "applemusic://track/1437139751",
+        "gb": "applemusic://track/1437139751",
+        "fr": "applemusic://track/1437139751",
+        "es": "applemusic://track/1437139751",
+        "nl": "applemusic://track/1437139751",
+        "it": "applemusic://track/1437139751"
+      }
     },
     {
       "year": 2012,
@@ -2273,7 +3003,17 @@
       "fun_fact_fr": "« Good Time » était le résultat d'une collaboration improbable entre Adam Young d'Owl City et Carly Rae Jepsen, qui se sont connectés après avoir tous deux eu des succès viraux surprises. La chanson a été écrite et enregistrée à distance, les deux artistes n'ayant jamais été dans le même studio.",
       "uri_deezer": "deezer://track/53825251",
       "fun_fact_nl": "Good Time' was het resultaat van een onwaarschijnlijke samenwerking tussen Adam Young van Owl City en Carly Rae Jepsen, die een band kregen nadat ze allebei verrassende virale hits hadden. Het nummer werd op afstand geschreven en opgenomen, waarbij de twee artiesten tijdens de productie nooit in dezelfde studio waren.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USUM71206288",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1675581007",
+        "de": "applemusic://track/1675581007",
+        "gb": "applemusic://track/1443239198",
+        "fr": "applemusic://track/1675581007",
+        "es": "applemusic://track/1675581007",
+        "nl": "applemusic://track/1675581007",
+        "it": "applemusic://track/1675581007"
+      }
     },
     {
       "year": 1979,
@@ -2303,7 +3043,17 @@
       "fun_fact_fr": "Rupert Holmes n'aimait pas à l'origine le titre « The Pina Colada Song » et préférait l'appeler « Escape ». C'était le dernier numéro un des années 1970 au Billboard Hot 100, atteignant le sommet dans la dernière semaine de décembre 1979. L'intrigue de la chanson met en scène un couple qui répond tous deux à des petites annonces pour découvrir qu'ils se cherchaient mutuellement.",
       "uri_deezer": "deezer://track/2801132",
       "fun_fact_nl": "Rupert Holmes had oorspronkelijk een hekel aan de titel 'The Pina Colada Song' en noemde het liever 'Escape'. Het was de laatste nummer 1 hit van de jaren 1970 op de Billboard Hot 100, en bereikte de toppositie in de laatste week van december 1979. De plot van het liedje gaat over een koppel dat beide reageert op een contactadvertentie, om er vervolgens achter te komen dat ze elkaar zijn.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMC17948997",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1700308648",
+        "de": "applemusic://track/1700308648",
+        "gb": "applemusic://track/1700308648",
+        "fr": "applemusic://track/1700308648",
+        "es": "applemusic://track/1700308648",
+        "nl": "applemusic://track/1700308648",
+        "it": "applemusic://track/1700308648"
+      }
     },
     {
       "year": 1965,
@@ -2333,7 +3083,17 @@
       "fun_fact_fr": "Les paroles de « Turn! Turn! Turn! » sont tirées presque textuellement du Livre de l'Ecclésiaste dans la Bible, Pete Seeger n'ayant ajouté que la ligne du titre et la phrase « a time for peace, I swear it's not too late ». Elle a la distinction d'avoir l'une des paroles les plus anciennes à avoir jamais dominé les charts.",
       "uri_deezer": "deezer://track/1013046",
       "fun_fact_nl": "De tekst van 'Turn! Turn! Turn!' is bijna letterlijk overgenomen uit het boek Prediker in de Bijbel, waarbij Pete Seeger alleen de titelregel en de zin 'a time for peace, I swear it's not too late' toevoegde. Het heeft de eer een van de oudste songteksten te zijn die ooit bovenaan de hitlijsten heeft gestaan.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM16500041",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1445669329",
+        "de": "applemusic://track/1445669329",
+        "gb": "applemusic://track/1445669329",
+        "fr": "applemusic://track/1445669329",
+        "es": "applemusic://track/1445669329",
+        "nl": "applemusic://track/1445669329",
+        "it": "applemusic://track/1445669329"
+      }
     },
     {
       "year": 1973,
@@ -2363,7 +3123,17 @@
       "fun_fact_fr": "« Long Train Runnin' » des Doobie Brothers était à l'origine un jam sans titre que le groupe jouait en échauffement avant les concerts. Le producteur Ted Templeman les a entendus jouer en coulisses et a insisté pour qu'ils l'enregistrent, transformant un riff décontracté en l'une des chansons les plus reconnaissables du rock classique.",
       "uri_deezer": "deezer://track/3616544",
       "fun_fact_nl": "The Doobie Brothers' 'Long Train Runnin'' was oorspronkelijk een jam zonder titel die de band speelde als opwarmertje voor concerten. Producer Ted Templeman hoorde ze het backstage spelen en stond erop dat ze het opnamen, waardoor een terloopse riff een van de meest herkenbare nummers van classic rock werd.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USRH11600598",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1111420475",
+        "de": "applemusic://track/1111420475",
+        "gb": "applemusic://track/1111420475",
+        "fr": "applemusic://track/1111420475",
+        "es": "applemusic://track/1111420475",
+        "nl": "applemusic://track/1111420475",
+        "it": "applemusic://track/1111420475"
+      }
     },
     {
       "year": 1966,
@@ -2391,7 +3161,17 @@
       "fun_fact_fr": "« Daydream » de The Lovin' Spoonful présente le son d'un vrai chat qui ronronne en arrière-plan, enregistré par le leader John Sebastian pour renforcer l'ambiance paresseuse et satisfaite de la chanson. Ce morceau a été l'un des premiers à mélanger folk, pop et musique jug band dans ce qui est devenu la « good time music ».",
       "uri_deezer": "deezer://track/970192",
       "fun_fact_nl": "Daydream' van The Lovin' Spoonful bevat het geluid van een echte kat die op de achtergrond spint, opgenomen door frontman John Sebastian om de luie, tevreden stemming van het nummer te versterken. Het nummer was een van de eerste die folk, pop en jugbandmuziek mengde tot wat bekend werd als 'good time music'.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USBR16600005",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/276286200",
+        "de": "applemusic://track/438929554",
+        "gb": "applemusic://track/438929554",
+        "fr": "applemusic://track/438929554",
+        "es": "applemusic://track/438929554",
+        "nl": "applemusic://track/438929554",
+        "it": "applemusic://track/438929554"
+      }
     },
     {
       "year": 1966,
@@ -2419,7 +3199,17 @@
       "fun_fact_fr": "Bobby Hebb a écrit « Sunny » en 1963, le lendemain de l'assassinat du président Kennedy et un jour seulement après que son frère Harold a été poignardé à mort devant une boîte de nuit de Nashville. Cette chanson optimiste et joyeuse était sa façon de traiter le deuil et de chercher l'optimisme dans les moments les plus sombres.",
       "uri_deezer": "deezer://track/1175777",
       "fun_fact_nl": "Bobby Hebb schreef 'Sunny' in 1963, op de dag na de moord op president Kennedy en slechts één dag nadat zijn eigen broer Harold was doodgestoken buiten een nachtclub in Nashville. Het vrolijke, hoopvolle nummer was zijn manier om verdriet te verwerken en optimisme te zoeken in de donkerste tijden.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USPR39402093",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1589123510",
+        "de": "applemusic://track/1589123510",
+        "gb": "applemusic://track/1589123510",
+        "fr": "applemusic://track/1589123510",
+        "es": "applemusic://track/1589123510",
+        "nl": "applemusic://track/1589123510",
+        "it": "applemusic://track/1589123510"
+      }
     },
     {
       "year": 1966,
@@ -2447,7 +3237,17 @@
       "fun_fact_fr": "« Sitting In The Park » de Georgie Fame était une reprise d'un classique soul de Billy Stewart. Fame, né Clive Powell, était l'un des rares artistes britanniques blancs à gagner en crédibilité dans la scène mod jazz et R&B, se produisant régulièrement au légendaire Flamingo Club de Londres aux côtés d'authentiques artistes soul américains.",
       "uri_deezer": "deezer://track/3803518322",
       "fun_fact_nl": "Georgie Fame's 'Sitting In The Park' was een cover van een Billy Stewart soulklassieker. Fame, geboren als Clive Powell, was een van de weinige blanke Britse artiesten die geloofwaardigheid verwierf in de mod jazz en R&B scene. Hij trad regelmatig op in de legendarische Flamingo Club in Londen naast echte Amerikaanse soulartiesten.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAKW0300207",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1442991088",
+        "de": "applemusic://track/1442991088",
+        "gb": "applemusic://track/1442991088",
+        "fr": "applemusic://track/1442991088",
+        "es": "applemusic://track/1442991088",
+        "nl": "applemusic://track/1442991088",
+        "it": "applemusic://track/1442991088"
+      }
     },
     {
       "year": 1967,
@@ -2478,7 +3278,17 @@
       "fun_fact_fr": "« San Francisco (Be Sure to Wear Flowers in Your Hair) » a été écrite par John Phillips de The Mamas & The Papas pour promouvoir le festival pop de Monterey en 1967. Scott McKenzie l'a enregistrée en une seule prise, et elle est devenue l'hymne officieux du Summer of Love, se vendant à plus de 7 millions d'exemplaires dans le monde.",
       "uri_deezer": "deezer://track/869731",
       "fun_fact_nl": "San Francisco (Be Sure to Wear Flowers in Your Hair)' werd geschreven door John Phillips van The Mamas & The Papas om het Monterey Pop Festival van 1967 te promoten. Scott McKenzie nam het in één take op en het werd het officieuze volkslied van de Summer of Love, waarvan wereldwijd meer dan 7 miljoen exemplaren werden verkocht.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USLIC0601857",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/418556961",
+        "de": "applemusic://track/418556961",
+        "gb": "applemusic://track/418556961",
+        "fr": "applemusic://track/418556961",
+        "es": "applemusic://track/418556961",
+        "nl": "applemusic://track/418556961",
+        "it": "applemusic://track/418556961"
+      }
     },
     {
       "year": 1970,
@@ -2508,7 +3318,17 @@
       "fun_fact_fr": "La reprise de « Woodstock » par Matthews' Southern Comfort a atteint la première place au Royaume-Uni, se vendant mieux que la version de Crosby, Stills, Nash & Young et l'original de Joni Mitchell, qui a écrit la chanson sans jamais avoir assisté au festival de Woodstock.",
       "uri_deezer": "deezer://track/122973866",
       "fun_fact_nl": "Matthews' Southern Comfort cover van 'Woodstock' bereikte nummer 1 in de UK en was daarmee beter dan de versie van Crosby, Stills, Nash & Young en het origineel van Joni Mitchell, die het nummer schreef ondanks dat ze nooit op het Woodstock festival was.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USCGJ1667941",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1103750213",
+        "de": "applemusic://track/1103750213",
+        "gb": "applemusic://track/1103750213",
+        "fr": "applemusic://track/1103750213",
+        "es": "applemusic://track/1103750213",
+        "nl": "applemusic://track/1103750213",
+        "it": "applemusic://track/1103750213"
+      }
     },
     {
       "year": 1967,
@@ -2536,7 +3356,17 @@
       "fun_fact_fr": "« Paper Sun » était le premier single de Traffic et présentait Steve Winwood, qui n'avait que 19 ans. La guitare d'influence indienne ressemblant au sitar et la production psychédélique en ont fait l'un des sons par excellence du Summer of Love de 1967 en Grande-Bretagne.",
       "uri_deezer": "deezer://track/6435679",
       "fun_fact_nl": "Paper Sun' was de debuutsingle van Traffic met Steve Winwood, die toen net 19 jaar oud was. De Indiase sitar-achtige gitaar en psychedelische productie van het nummer maakten het tot een van de meest kenmerkende geluiden van de Summer of Love van 1967 in Groot-Brittannië.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAAN6800039",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1452870820",
+        "de": "applemusic://track/1444141240",
+        "gb": "applemusic://track/1443370412",
+        "fr": "applemusic://track/1444141240",
+        "es": "applemusic://track/1444141240",
+        "nl": "applemusic://track/1444141240",
+        "it": "applemusic://track/1444141240"
+      }
     },
     {
       "year": 1967,
@@ -2564,7 +3394,17 @@
       "fun_fact_fr": "« Kites » de Simon Dupree & The Big Sound était un chef-d'œuvre de pop psychédélique orchestrale que le groupe lui-même n'aimait apparemment pas, le considérant comme trop commercial. Le membre du groupe Derek Shulman est devenu plus tard un important dirigeant de l'industrie musicale, signant des groupes comme Bon Jovi et Nickelback.",
       "uri_deezer": "deezer://track/3275705",
       "fun_fact_nl": "Simon Dupree & The Big Sound's 'Kites' was een orkestraal psychedelisch pop meesterwerk waar de band zelf naar verluidt een hekel aan had, omdat ze het te commercieel vonden. Groepslid Derek Shulman werd later een belangrijke leidinggevende in de muziekindustrie en tekende bands als Bon Jovi en Nickelback.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAYE0400016",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1206261002",
+        "de": "applemusic://track/1206261002",
+        "gb": "applemusic://track/1206261002",
+        "fr": "applemusic://track/1206261002",
+        "es": "applemusic://track/1206261002",
+        "nl": "applemusic://track/1206261002",
+        "it": "applemusic://track/1206261002"
+      }
     },
     {
       "year": 1967,
@@ -2594,7 +3434,17 @@
       "fun_fact_fr": "Le chanteur connu simplement sous le nom de « Keith » était en fait James Barry Keefer de Philadelphie. « 98.6 » fait référence à la température corporelle humaine normale en Fahrenheit et a été utilisé comme métaphore pour dire que tout va parfaitement bien. Malgré son statut de one-hit wonder, la chanson s'est vendue à plus d'un million d'exemplaires.",
       "uri_deezer": "deezer://track/349057621",
       "fun_fact_nl": "De zanger die simpelweg bekend stond als 'Keith' was eigenlijk James Barry Keefer uit Philadelphia. 98.6' verwijst naar de normale lichaamstemperatuur in Fahrenheit en werd gebruikt als metafoor voor alles wat perfect in orde is. Ondanks dat het een eendagsvlieg was, werden er meer dan een miljoen exemplaren van het nummer verkocht.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USIR20300599",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1443850324",
+        "de": "applemusic://track/1443850324",
+        "gb": "applemusic://track/1443850324",
+        "fr": "applemusic://track/1443850324",
+        "es": "applemusic://track/1443850324",
+        "nl": "applemusic://track/1443850324",
+        "it": "applemusic://track/1443850324"
+      }
     },
     {
       "year": 1967,
@@ -2624,7 +3474,17 @@
       "fun_fact_fr": "« Windy » de The Association a passé quatre semaines en tête du Billboard Hot 100 pendant l'été 1967. L'auteure-compositrice Ruthann Friedman l'avait écrite à l'origine sur un homme, mais le groupe a changé les pronoms pour rendre le sujet féminin, créant le personnage léger et mystérieux qui a rendu la chanson iconique.",
       "uri_deezer": "deezer://track/733073",
       "fun_fact_nl": "Windy' van The Association stond vier weken op #1 in de Billboard Hot 100 in de zomer van 1967. Songwriter Ruthann Friedman schreef het oorspronkelijk over een man, maar de band veranderde de voornaamwoorden om het onderwerp vrouwelijk te maken en creëerde zo het luchtige, mysterieuze karakter dat het nummer iconisch maakte.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USWB10300946",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1847686670",
+        "de": "applemusic://track/1847686670",
+        "gb": "applemusic://track/1847686670",
+        "fr": "applemusic://track/1847686670",
+        "es": "applemusic://track/1847686670",
+        "nl": "applemusic://track/1847686670",
+        "it": "applemusic://track/1847686670"
+      }
     },
     {
       "year": 1989,
@@ -2685,7 +3545,17 @@
       "fun_fact_fr": "« Macarena » a passé un record de 14 semaines en tête du Billboard Hot 100 en 1996 dans sa version remix des Bayside Boys. La version originale espagnole est sortie en 1993, mais c'est le remix anglais avec sa danse d'accompagnement qui en a fait l'un des plus grands one-hit wonders de tous les temps.",
       "uri_deezer": "deezer://track/994491",
       "fun_fact_nl": "Macarena' stond in 1996 in de Bayside Boys-remixversie maar liefst 14 weken op #1 in de Billboard Hot 100. De originele Spaanse versie werd uitgebracht in 1993. De originele Spaanse versie werd uitgebracht in 1993, maar het was de Engelse remix met bijbehorende dans die het tot een van de grootste one-hit wonders aller tijden maakte.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "ES5109500538",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/943232519",
+        "de": "applemusic://track/1308532018",
+        "gb": "applemusic://track/1308532018",
+        "fr": "applemusic://track/1308532018",
+        "es": "applemusic://track/1308532018",
+        "nl": "applemusic://track/1308532018",
+        "it": "applemusic://track/1308532018"
+      }
     },
     {
       "year": 2010,
@@ -2716,7 +3586,17 @@
       "fun_fact_fr": "« Waka Waka » était la chanson officielle de la Coupe du Monde FIFA 2010 en Afrique du Sud. La mélodie est basée sur « Zangalewa », une chanson de 1986 du groupe camerounais Golden Sounds. Son clip est la chanson de Coupe du Monde la plus vue sur YouTube avec plus de 3,5 milliards de vues.",
       "uri_deezer": "deezer://track/6121149",
       "fun_fact_nl": "Waka Waka' was het officiële lied van de 2010 FIFA World Cup in Zuid-Afrika. De melodie is gebaseerd op 'Zangalewa', een lied uit 1986 van de Kameroense groep Golden Sounds. De videoclip is het meest bekeken WK-lied op YouTube met meer dan 3,5 miljard views.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM11001353",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1681268428",
+        "de": "applemusic://track/1681268428",
+        "gb": "applemusic://track/1681268428",
+        "fr": "applemusic://track/1308504781",
+        "es": "applemusic://track/1681268428",
+        "nl": "applemusic://track/1681268428",
+        "it": "applemusic://track/1681268428"
+      }
     },
     {
       "year": 1983,
@@ -2747,7 +3627,17 @@
       "fun_fact_fr": "Lionel Richie a interprété « All Night Long » lors de la cérémonie de clôture des Jeux Olympiques de Los Angeles en 1984 devant une audience télévisée mondiale de plus de 2,6 milliards de personnes. Les paroles festives incluent des mots de dialectes caribéens et africains, bien que Richie ait admis que certaines phrases sont totalement inventées.",
       "uri_deezer": "deezer://track/2177861",
       "fun_fact_nl": "Lionel Richie bracht 'All Night Long' ten gehore tijdens de slotceremonie van de Olympische Spelen in Los Angeles in 1984 voor een wereldwijd televisiepubliek van meer dan 2,6 miljard mensen. De feestelijke tekst van het nummer bevat woorden uit Caribische en Afrikaanse dialecten, hoewel Richie heeft toegegeven dat sommige zinnen volledig verzonnen zijn.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMO18390005",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1688457787",
+        "de": "applemusic://track/1688457787",
+        "gb": "applemusic://track/1688457787",
+        "fr": "applemusic://track/1688457787",
+        "es": "applemusic://track/1688457787",
+        "nl": "applemusic://track/1688457787",
+        "it": "applemusic://track/1688457787"
+      }
     },
     {
       "year": 1993,
@@ -2778,7 +3668,17 @@
       "fun_fact_fr": "Israel Kamakawiwo'ole a enregistré son medley de « Somewhere Over the Rainbow/What a Wonderful World » en une seule prise à 3 heures du matin dans un studio d'Honolulu en 1988. L'enregistrement était largement méconnu jusqu'à son utilisation dans des émissions de télé et des films des années plus tard, devenant finalement l'une des chansons les plus streamées de tous les temps avec plus d'un milliard de vues sur YouTube.",
       "uri_deezer": "deezer://track/1416006612",
       "fun_fact_nl": "Israel Kamakawiwo'ole nam zijn medley van 'Somewhere Over the Rainbow/What a Wonderful World' op in één take om 3 uur 's nachts in een studio in Honolulu in 1988. De opname was grotendeels onbekend totdat het jaren later werd gebruikt in tv-programma's en films. Uiteindelijk werd het een van de meest gestreamde nummers aller tijden met meer dan 1 miljard views op YouTube.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMAC9300084",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1440714382",
+        "de": "applemusic://track/267541232",
+        "gb": "applemusic://track/267541232",
+        "fr": "applemusic://track/1440714382",
+        "es": "applemusic://track/1440714382",
+        "nl": "applemusic://track/1440714382",
+        "it": "applemusic://track/1440714382"
+      }
     },
     {
       "year": 1960,
@@ -2808,7 +3708,17 @@
       "fun_fact_fr": "Brian Hyland n'avait que 16 ans quand « Itsy Bitsy Teenie Weenie Yellow Polka Dot Bikini » a atteint la première place en 1960. La chanson a été inspirée par un incident réel impliquant la fille de deux ans du compositeur Paul Vance, qui était trop timide pour sortir de l'eau dans son nouveau bikini.",
       "uri_deezer": "deezer://track/16025611",
       "fun_fact_nl": "Brian Hyland was pas 16 jaar oud toen 'Itsy Bitsy Teenie Weenie Yellow Polka Dot Bikini' in 1960 op #1 kwam. Het nummer was geïnspireerd op een echt voorval met de tweejarige dochter van songwriter Paul Vance, die te verlegen was om in haar nieuwe bikini uit het water te komen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMC16051029",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1450968642",
+        "de": "applemusic://track/1450968642",
+        "gb": "applemusic://track/1450968642",
+        "fr": "applemusic://track/1450968642",
+        "es": "applemusic://track/1450968642",
+        "nl": "applemusic://track/1450968642",
+        "it": "applemusic://track/1450968642"
+      }
     },
     {
       "year": 1980,
@@ -2836,7 +3746,17 @@
       "fun_fact_fr": "« Pulling Mussels (From the Shell) » est largement considérée comme la meilleure chanson de Squeeze et un chef-d'œuvre de la narration new wave britannique. Écrite par Chris Difford et Glenn Tilbrook, elle dépeint avec vivacité des vacances au bord de la mer britannique, avec ses voyages organisés et ses sandwichs pleins de sable.",
       "uri_deezer": "deezer://track/932571",
       "fun_fact_nl": "Pulling Mussels (From the Shell)' wordt algemeen beschouwd als Squeeze's beste nummer en een meesterwerk van de Britse new wave storytelling. Geschreven door Chris Difford en Glenn Tilbrook, schetst het een levendig beeld van een Britse vakantie aan zee, compleet met pakketreizen en zanderige sandwiches, en werd het geprezen door Elvis Costello.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAAM8001016",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1446091638",
+        "de": "applemusic://track/1446091638",
+        "gb": "applemusic://track/1446091638",
+        "fr": "applemusic://track/1446091638",
+        "es": "applemusic://track/1446091638",
+        "nl": "applemusic://track/1446091638",
+        "it": "applemusic://track/1446091638"
+      }
     },
     {
       "year": 1959,
@@ -2864,7 +3784,17 @@
       "fun_fact_fr": "« Here Comes Summer » de Jerry Keller a été un succès transatlantique en 1959, atteignant la première place au Royaume-Uni. Keller est devenu plus tard un auteur-compositeur à succès en Europe, particulièrement en France et en Allemagne, écrivant pour des artistes comme Sacha Distel, et la chanson reste un favori éternel des playlists radio estivales.",
       "uri_deezer": "deezer://track/63086446",
       "fun_fact_nl": "Jerry Keller's 'Here Comes Summer' was een trans-Atlantische hit in 1959 en bereikte #1 in de UK. Keller werd later een succesvol songwriter in Europa, vooral in Frankrijk en Duitsland, waar hij schreef voor artiesten als Sacha Distel, en het nummer blijft een vaste favoriet op de afspeellijsten van de zomerradio.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBHGA1103724",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/431739542",
+        "de": "applemusic://track/431739542",
+        "gb": "applemusic://track/431739542",
+        "fr": "applemusic://track/431739542",
+        "es": "applemusic://track/431739542",
+        "nl": "applemusic://track/431739542",
+        "it": "applemusic://track/431739542"
+      }
     },
     {
       "year": 1967,
@@ -2894,7 +3824,17 @@
       "fun_fact_fr": "« Groovin' » des Young Rascals a été inspirée par les après-midi paresseux du dimanche que Felix Cavaliere passait avec sa petite amie à New York. Les sons extérieurs de l'enregistrement, y compris les oiseaux qui chantent, ont été enregistrés en direct dans un parc. La chanson a dominé le Billboard Hot 100 pendant quatre semaines au printemps 1967.",
       "uri_deezer": "deezer://track/81769154",
       "fun_fact_nl": "The Young Rascals' 'Groovin'' is geïnspireerd op luie zondagmiddagen die Felix Cavaliere doorbracht met zijn vriendin in New York. De buitengeluiden in de opname, waaronder het getjilp van vogels, werden live opgenomen in een park. Het nummer stond vier weken in de Billboard Hot 100 in de lente van 1967.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USAT21402930",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/900766610",
+        "de": "applemusic://track/900766610",
+        "gb": "applemusic://track/900766610",
+        "fr": "applemusic://track/900766610",
+        "es": "applemusic://track/900766610",
+        "nl": "applemusic://track/900766610",
+        "it": "applemusic://track/900766610"
+      }
     },
     {
       "year": 1975,
@@ -2924,7 +3864,17 @@
       "fun_fact_fr": "La version de « Sailing » par Rod Stewart a été écrite par Gavin Sutherland des Sutherland Brothers. Elle est devenue la chanson thème de la série documentaire de la BBC « Sailor » sur le porte-avions HMS Ark Royal, ce qui l'a propulsée à la première place au Royaume-Uni deux fois : en 1975 et de nouveau en 1976.",
       "uri_deezer": "deezer://track/2550600",
       "fun_fact_nl": "Rod Stewart's versie van 'Sailing' werd geschreven door Gavin Sutherland van de Sutherland Brothers. Het werd het themalied voor de BBC documentaireserie 'Sailor' over het vliegdekschip HMS Ark Royal, waardoor het twee keer op #1 kwam in de UK - eenmaal in 1975 en opnieuw in 1976.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USWB10000780",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1052498339",
+        "de": "applemusic://track/1052498339",
+        "gb": "applemusic://track/1052498339",
+        "fr": "applemusic://track/1052498339",
+        "es": "applemusic://track/1052498339",
+        "nl": "applemusic://track/1052498339",
+        "it": "applemusic://track/1052498339"
+      }
     },
     {
       "year": 1988,
@@ -2955,7 +3905,17 @@
       "fun_fact_fr": "« Orinoco Flow » tire son nom des Orinoco Studios à Londres où elle a été enregistrée. Le label d'Enya, Warner Bros, était sceptique quant à sa sortie en single, mais le producteur Nicky Ryan a insisté, et elle est devenue un numéro un mondial surprise, propulsant Enya d'artiste new age obscure à star mondiale.",
       "uri_deezer": "deezer://track/917594892",
       "fun_fact_nl": "Orinoco Flow' werd vernoemd naar de Orinoco Studios in Londen waar het werd opgenomen. Enya's label Warner Bros was sceptisch over het uitbrengen ervan als single, maar producer Nicky Ryan stond erop en het werd een verrassende wereldwijde nummer 1 hit, die Enya van obscure New Age artiest tot wereldster lanceerde.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAHT2000196",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1503341802",
+        "de": "applemusic://track/1503341802",
+        "gb": "applemusic://track/1503341802",
+        "fr": "applemusic://track/1503341802",
+        "es": "applemusic://track/1503341802",
+        "nl": "applemusic://track/1503341802",
+        "it": "applemusic://track/1503341802"
+      }
     },
     {
       "year": 1992,
@@ -2983,7 +3943,17 @@
       "fun_fact_fr": "« Nightswimming » de R.E.M. présente Mike Mills au piano comme instrument principal, enregistré en une seule performance. La chanson parle de souvenirs nostalgiques de baignades nues à Athens, en Géorgie, et Michael Stipe l'a qualifiée de l'une des chansons les plus personnelles qu'il ait jamais écrites.",
       "uri_deezer": "deezer://track/121921386",
       "fun_fact_nl": "R.E.M.'s 'Nightswimming' heeft Mike Mills op piano als het belangrijkste instrument, opgenomen in één enkel optreden. Het nummer gaat over nostalgische herinneringen aan naaktzwemmen in Athens, Georgia, en Michael Stipe heeft het een van de meest persoonlijke nummers genoemd die hij ooit heeft geschreven.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USC4R1700248",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1571671623",
+        "de": "applemusic://track/1571671623",
+        "gb": "applemusic://track/1571671623",
+        "fr": "applemusic://track/1571671623",
+        "es": "applemusic://track/1571671623",
+        "nl": "applemusic://track/1571671623",
+        "it": "applemusic://track/1571671623"
+      }
     },
     {
       "year": 1977,
@@ -3011,7 +3981,17 @@
       "fun_fact_fr": "La version smooth jazz de « Nature Boy » par George Benson a donné une nouvelle vie à une chanson écrite à l'origine par eden ahbez, un mystique excentrique né à Brooklyn qui vivait sous le panneau Hollywood et écrivait son nom en minuscules. La chanson a été rendue célèbre pour la première fois par Nat King Cole en 1948.",
       "uri_deezer": "deezer://track/3822141",
       "fun_fact_nl": "George Bensons soepele jazzversie van 'Nature Boy' gaf een nieuw leven aan een nummer dat oorspronkelijk geschreven was door eden ahbez, een excentrieke mysticus uit Brooklyn die onder het Hollywood-bord woonde en zijn naam met kleine letters spelde. Het nummer werd voor het eerst beroemd door Nat King Cole in 1948.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USWB11500188",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1801473288",
+        "de": "applemusic://track/1801473288",
+        "gb": "applemusic://track/1801473288",
+        "fr": "applemusic://track/1801473288",
+        "es": "applemusic://track/1801473288",
+        "nl": "applemusic://track/1801473288",
+        "it": "applemusic://track/1801473288"
+      }
     },
     {
       "year": 1998,
@@ -3041,7 +4021,17 @@
       "fun_fact_fr": "« Outside » de George Michael a été écrite comme une réponse de défi à son arrestation pour « acte obscène » dans des toilettes publiques à Beverly Hills en 1998. Le clip ironique a même recréé l'incident, les toilettes étant transformées en discothèque. Plutôt que de se cacher du scandale, Michael en a fait un succès.",
       "uri_deezer": "deezer://track/15626274",
       "fun_fact_nl": "George Michael's 'Outside' werd geschreven als een uitdagende reactie op zijn arrestatie voor 'het uitvoeren van een ontuchtige handeling' in een openbaar toilet in Beverly Hills in 1998. In de brutale videoclip werd het incident zelfs nagespeeld, waarbij het toilet werd omgetoverd tot een discotheek. In plaats van zich te verbergen voor het schandaal, maakte Michael er een hit van.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBBBM9802121",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/429945685",
+        "de": "applemusic://track/1308550969",
+        "gb": "applemusic://track/1308550969",
+        "fr": "applemusic://track/1308550969",
+        "es": "applemusic://track/1308550969",
+        "nl": "applemusic://track/1308550969",
+        "it": "applemusic://track/1308550969"
+      }
     },
     {
       "year": 1974,
@@ -3069,7 +4059,17 @@
       "fun_fact_fr": "« Summer Love Sensation » des Bay City Rollers faisait partie de leur ère d'idoles adolescentes vêtus de tartan qui a déclenché la « Rollermania » au Royaume-Uni. Le manager du groupe, Tam Paton, était connu pour contrôler chaque aspect de leur image, et la chanson a capitalisé sur leur charme estival auprès des fans adolescentes en délire.",
       "uri_deezer": "deezer://track/75486819",
       "fun_fact_nl": "Bay City Rollers' 'Summer Love Sensation' maakte deel uit van hun in ruitjes gehulde tieneridooltijdperk dat de 'Rollermania' in Groot-Brittannië aanwakkerde. De manager van de band, Tam Paton, stond erom bekend dat hij elk aspect van hun imago controleerde en het nummer speelde in op hun gezonde zomerse aantrekkingskracht op schreeuwende tienerfans.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USAR10000006",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/325440104",
+        "de": "applemusic://track/1221186931",
+        "gb": "applemusic://track/325440104",
+        "fr": "applemusic://track/325440104",
+        "es": "applemusic://track/325440104",
+        "nl": "applemusic://track/325440104",
+        "it": "applemusic://track/1221186931"
+      }
     },
     {
       "year": 1975,
@@ -3100,7 +4100,17 @@
       "fun_fact_fr": "« You Sexy Thing » de Hot Chocolate a eu trois passages séparés dans les charts britanniques : en 1975, 1987 et 1997, chaque fois boosté par une apparition dans un film. Son utilisation la plus célèbre était dans « The Full Monty » (1997), où elle accompagnait la scène de strip-tease iconique.",
       "uri_deezer": "deezer://track/3851861",
       "fun_fact_nl": "Hot Chocolate's 'You Sexy Thing' is drie keer in de UK in de hitlijsten gekomen: in 1975, 1987 en 1997, elke keer versterkt door een filmoptreden. Het beroemdste gebruik was in 'The Full Monty' (1997), waar het de soundtrack vormde voor de iconische striptease scène.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAYE0900553",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/693504632",
+        "de": "applemusic://track/693504632",
+        "gb": "applemusic://track/693504632",
+        "fr": "applemusic://track/693504632",
+        "es": "applemusic://track/693504632",
+        "nl": "applemusic://track/693504632",
+        "it": "applemusic://track/693504632"
+      }
     },
     {
       "year": 1973,
@@ -3130,7 +4140,17 @@
       "fun_fact_fr": "« Stuck in the Middle with You » a été écrite par Gerry Rafferty et Joe Egan comme une parodie du style de chant nasal de Bob Dylan. La chanson a gagné une seconde vie de célébrité quand Quentin Tarantino l'a utilisée dans l'infâme scène de torture de l'oreille coupée dans « Reservoir Dogs » (1992), liant à jamais cette chanson joyeuse à une violence choquante.",
       "uri_deezer": "deezer://track/1577612",
       "fun_fact_nl": "Stuck in the Middle with You' werd geschreven door Gerry Rafferty en Joe Egan als parodie op de nasale zangstijl van Bob Dylan. Het liedje kreeg een tweede leven van roem toen Quentin Tarantino het gebruikte in de beruchte oorafsnijdende martelscène in 'Reservoir Dogs' (1992), waardoor het vrolijke liedje voor altijd verbonden werd met schokkend geweld.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAAM7200002",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1686851478",
+        "de": "applemusic://track/1686851478",
+        "gb": "applemusic://track/1469548395",
+        "fr": "applemusic://track/1686851478",
+        "es": "applemusic://track/1686851478",
+        "nl": "applemusic://track/1686851478",
+        "it": "applemusic://track/1686851478"
+      }
     },
     {
       "year": 1965,
@@ -3161,7 +4181,17 @@
       "fun_fact_fr": "« It's Not Unusual » a été écrite à l'origine par Les Reed et Gordon Mills pour Sandie Shaw, mais quand Tom Jones a enregistré la démo, sa performance vocale puissante était si extraordinaire que les compositeurs lui ont donné la chanson. Elle a lancé Jones vers la célébrité internationale à 24 ans.",
       "uri_deezer": "deezer://track/906545",
       "fun_fact_nl": "It's Not Unusual' was oorspronkelijk geschreven door Les Reed en Gordon Mills voor Sandie Shaw, maar toen Tom Jones de demo opnam, was zijn krachtige vocale prestatie zo buitengewoon dat de songschrijvers hem het nummer gaven. Het lanceerde Jones op 24-jarige leeftijd naar het internationale sterrendom.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBF076520010",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1596847434",
+        "de": "applemusic://track/1514703261",
+        "gb": "applemusic://track/1442868116",
+        "fr": "applemusic://track/1514703261",
+        "es": "applemusic://track/1514703261",
+        "nl": "applemusic://track/1514703261",
+        "it": "applemusic://track/1514703261"
+      }
     },
     {
       "year": 1975,
@@ -3191,7 +4221,17 @@
       "fun_fact_fr": "Malgré son titre faisant référence à décembre, « Oh What a Night » a été écrite à l'origine sur l'abrogation de la Prohibition en 1933. Le producteur Bob Gaudio a changé les paroles pour parler d'une rencontre romantique, et la chanson est devenue le plus grand succès des Four Seasons, passant trois semaines en tête en 1976.",
       "uri_deezer": "deezer://track/725715",
       "fun_fact_nl": "Ondanks dat de titel verwijst naar december, was 'Oh What a Night' oorspronkelijk geschreven over de intrekking van de drooglegging in 1933. Producer Bob Gaudio veranderde de tekst om over een romantische ontmoeting te gaan en het nummer werd de grootste hit ooit van de Four Seasons met drie weken op #1 in 1976.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USCRB0405942",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/82347771",
+        "de": "applemusic://track/82347771",
+        "gb": "applemusic://track/82347771",
+        "fr": "applemusic://track/82347771",
+        "es": "applemusic://track/82347771",
+        "nl": "applemusic://track/82347771",
+        "it": "applemusic://track/82347771"
+      }
     },
     {
       "year": 1966,
@@ -3222,7 +4262,17 @@
       "fun_fact_fr": "« I'm a Believer » a été écrite par Neil Diamond et produite par Jeff Barry. Elle a été enregistrée par The Monkees pour la série télévisée, passant sept semaines en tête et devenant le single le plus vendu de 1967. Elle a atteint une nouvelle génération grâce au film « Shrek » en 2001, interprétée par Smash Mouth.",
       "uri_deezer": "deezer://track/764920",
       "fun_fact_nl": "I'm a Believer' is geschreven door Neil Diamond en geproduceerd door Jeff Barry. Het werd opgenomen door The Monkees voor de TV-serie, stond zeven weken op #1 en werd de best verkochte single van 1967. Later bereikte het een nieuwe generatie door de film 'Shrek' uit 2001, uitgevoerd door Smash Mouth.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USRH10125749",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1213403197",
+        "de": "applemusic://track/1373179773",
+        "gb": "applemusic://track/1373179773",
+        "fr": "applemusic://track/1373179773",
+        "es": "applemusic://track/1373179773",
+        "nl": "applemusic://track/1373179773",
+        "it": "applemusic://track/1373179773"
+      }
     },
     {
       "year": 1967,
@@ -3252,7 +4302,17 @@
       "fun_fact_fr": "« Brown Eyed Girl » est l'une des chansons les plus diffusées à la radio américaine, avec environ 10 millions de diffusions. Van Morrison a dit qu'il n'aimait pas la chanson et la trouvait embarrassante par rapport à son travail ultérieur plus artistique. Elle s'intitulait à l'origine « Brown Skinned Girl » mais a été modifiée pendant l'enregistrement.",
       "uri_deezer": "deezer://track/5981840",
       "fun_fact_nl": "Brown Eyed Girl' is een van de meest gedraaide nummers op de Amerikaanse radio, met naar schatting 10 miljoen beluisteringen. Van Morrison heeft gezegd dat hij het nummer niet mooi vindt en het gênant vindt vergeleken met zijn latere, artistiekere werk. Het was oorspronkelijk getiteld 'Brown Skinned Girl' maar werd tijdens de opnames veranderd.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USQX91501797",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1838782096",
+        "de": "applemusic://track/1838782096",
+        "gb": "applemusic://track/1838782096",
+        "fr": "applemusic://track/1838782096",
+        "es": "applemusic://track/1838782096",
+        "nl": "applemusic://track/1838782096",
+        "it": "applemusic://track/1838782096"
+      }
     },
     {
       "year": 1965,
@@ -3282,7 +4342,17 @@
       "fun_fact_fr": "« I Can't Help Myself (Sugar Pie, Honey Bunch) » était le plus grand succès des Four Tops et a passé deux semaines en tête en 1965. Le chanteur principal Levi Stubbs n'a jamais poursuivi de carrière solo malgré sa voix extraordinaire, restant fidèle aux Four Tops pendant plus de 50 ans jusqu'à sa mort en 2008.",
       "uri_deezer": "deezer://track/1582310",
       "fun_fact_nl": "I Can't Help Myself (Sugar Pie, Honey Bunch)' was de grootste hit van de Four Tops en stond twee weken op #1 in 1965. De leadzanger van de groep, Levi Stubbs, heeft ondanks zijn buitengewone stem nooit een solocarrière nagestreefd. Hij bleef de Four Tops meer dan 50 jaar trouw tot aan zijn dood in 2008.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMO16582593",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1689685924",
+        "de": "applemusic://track/1689685924",
+        "gb": "applemusic://track/1689685924",
+        "fr": "applemusic://track/1689685924",
+        "es": "applemusic://track/1689685924",
+        "nl": "applemusic://track/1689685924",
+        "it": "applemusic://track/1689685924"
+      }
     },
     {
       "year": 1978,
@@ -3313,7 +4383,17 @@
       "fun_fact_fr": "Le riff de saxophone iconique de « Baker Street » a été joué par Raphael Ravenscroft, qui n'a été payé que 27,50 livres de cachet de session. Le chèque de royalties qu'il a reçu plus tard a été refusé, et il n'a jamais reçu de compensation appropriée pour avoir créé l'un des hooks instrumentaux les plus reconnaissables de l'histoire du rock.",
       "uri_deezer": "deezer://track/3169189",
       "fun_fact_nl": "De iconische saxofoonriff in 'Baker Street' werd gespeeld door Raphael Ravenscroft, die een sessievergoeding van slechts 27,50 pond kreeg. De royaltycheque die hij later ontving werd geweigerd en hij heeft nooit de juiste compensatie gekregen voor het creëren van een van de meest herkenbare instrumentale hooks in de rockgeschiedenis.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAYE7800619",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/693606496",
+        "de": "applemusic://track/696804850",
+        "gb": "applemusic://track/1541207673",
+        "fr": "applemusic://track/1541207673",
+        "es": "applemusic://track/1541207673",
+        "nl": "applemusic://track/1541207673",
+        "it": "applemusic://track/1541207673"
+      }
     },
     {
       "year": 1969,
@@ -3344,7 +4424,17 @@
       "fun_fact_fr": "« Sugar, Sugar » des Archies était le single numéro un de 1969 aux États-Unis, se vendant plus que les Beatles, les Rolling Stones et tous les autres vrais groupes cette année-là. Elle a été interprétée par un groupe de dessin animé fictif créé pour l'émission de télé « The Archie Show », avec le chanteur de session Ron Dante assurant le chant principal.",
       "uri_deezer": "deezer://track/1382508",
       "fun_fact_nl": "Sugar, Sugar' van The Archies was de #1 single van 1969 in de VS en verkocht meer dan de Beatles, Rolling Stones en elke andere echte band dat jaar. Het werd uitgevoerd door een fictieve cartoonband die was gemaakt voor de tv-show 'The Archie Show', met sessiezanger Ron Dante die de leadzang voor zijn rekening nam.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "QM6N21704357",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1412839444",
+        "de": "applemusic://track/1412839444",
+        "gb": "applemusic://track/1412839444",
+        "fr": "applemusic://track/1412839444",
+        "es": "applemusic://track/1412839444",
+        "nl": "applemusic://track/1412839444",
+        "it": "applemusic://track/1412839444"
+      }
     }
   ]
 }

--- a/custom_components/beatify/playlists/top-100-power-ballads.json
+++ b/custom_components/beatify/playlists/top-100-power-ballads.json
@@ -37,7 +37,17 @@
       "uri_tidal": "tidal://track/61126692",
       "uri_deezer": "deezer://track/2061078257",
       "fun_fact_nl": "Geschreven door Diane Warren in slechts 4 uur. Steven Tyler wilde het aanvankelijk niet opnemen, maar het werd Aerosmiths enige nummer 1-hit. Het nummer was geïnspireerd op Warren die iemand zag slapen en haar ogen niet wilde sluiten.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM19801545",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1660108804",
+        "de": "applemusic://track/1660108804",
+        "gb": "applemusic://track/1660108804",
+        "fr": "applemusic://track/1660108804",
+        "es": "applemusic://track/1660108804",
+        "nl": "applemusic://track/1660108804",
+        "it": "applemusic://track/1660108804"
+      }
     },
     {
       "year": 1992,
@@ -67,7 +77,17 @@
       "uri_tidal": "tidal://track/10902755",
       "uri_deezer": "deezer://track/1169683",
       "fun_fact_nl": "Met een duur van 8:57 was het het langste nummer dat de top 10 haalde sinds 'American Pie'. De weelderige muziekvideo kostte 1,5 miljoen dollar en werd gefilmd in een echte trouwkapel in Las Vegas.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USGF19141510",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1533361268",
+        "de": "applemusic://track/1533361268",
+        "gb": "applemusic://track/1533361268",
+        "fr": "applemusic://track/1533361268",
+        "es": "applemusic://track/1533361268",
+        "nl": "applemusic://track/1533361268",
+        "it": "applemusic://track/1533361268"
+      }
     },
     {
       "year": 1984,
@@ -94,7 +114,17 @@
       "uri_tidal": "tidal://track/637081",
       "uri_deezer": "deezer://track/675818",
       "fun_fact_nl": "Een klassieke power ballad van Foreigner.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USAT29900662",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1801475539",
+        "de": "applemusic://track/1810428489",
+        "gb": "applemusic://track/1676594611",
+        "fr": "applemusic://track/1676594611",
+        "es": "applemusic://track/1676594611",
+        "nl": "applemusic://track/1676594611",
+        "it": "applemusic://track/1676594611"
+      }
     },
     {
       "year": 1993,
@@ -124,7 +154,17 @@
       "uri_tidal": "tidal://track/703088",
       "uri_deezer": "deezer://track/3552732191",
       "fun_fact_nl": "Het 'that' verwijst naar verschillende dingen die door het nummer worden genoemd - niet één specifieke handeling. Jim Steinmans epische productie duurde meer dan 3 maanden.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMC19341323",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1795086370",
+        "de": "applemusic://track/1795086370",
+        "gb": "applemusic://track/1795086370",
+        "fr": "applemusic://track/1795086370",
+        "es": "applemusic://track/1795086370",
+        "nl": "applemusic://track/1795086370",
+        "it": "applemusic://track/1795086370"
+      }
     },
     {
       "year": 1987,
@@ -154,7 +194,17 @@
       "uri_tidal": "tidal://track/207292",
       "uri_deezer": "deezer://track/912486",
       "fun_fact_nl": "U2's eerste nummer 1 in de VS. The Edge gebruikte een Infinite Guitar-prototype dat de kenmerkende aanhoudende noten van het nummer creëerde. Bono schreef de tekst in 10 minuten.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAAN8790003",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1842425551",
+        "de": "applemusic://track/1842425551",
+        "gb": "applemusic://track/1842425551",
+        "fr": "applemusic://track/1842425551",
+        "es": "applemusic://track/1842425551",
+        "nl": "applemusic://track/1842425551",
+        "it": "applemusic://track/1842425551"
+      }
     },
     {
       "year": 1991,
@@ -184,7 +234,17 @@
       "uri_tidal": "tidal://track/1330631",
       "uri_deezer": "deezer://track/1182159",
       "fun_fact_nl": "Stond 16 opeenvolgende weken op nummer 1 in het VK - nog steeds een record. Geschreven voor Robin Hood: Prince of Thieves, het werd in 45 minuten gecomponeerd.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "US23A1515538",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1870995778",
+        "de": "applemusic://track/1870995778",
+        "gb": "applemusic://track/1870995778",
+        "fr": "applemusic://track/1870995778",
+        "es": "applemusic://track/1870995778",
+        "nl": "applemusic://track/1870995778",
+        "it": "applemusic://track/1870995778"
+      }
     },
     {
       "year": 1980,
@@ -213,7 +273,17 @@
       "uri_tidal": "tidal://track/77447199",
       "uri_deezer": "deezer://track/581979",
       "fun_fact_nl": "Kevin Cronin schreef dit na een echte ruzie met zijn vriendin waarbij ze hem op een leugen betrapte. Het succes van het nummer transformeerde REO van een arenabandband naar popsterren.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM11102617",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/965879795",
+        "de": "applemusic://track/1452434840",
+        "gb": "applemusic://track/1452434840",
+        "fr": "applemusic://track/1452434840",
+        "es": "applemusic://track/1452434840",
+        "nl": "applemusic://track/1452434840",
+        "it": "applemusic://track/673075377"
+      }
     },
     {
       "year": 1992,
@@ -243,7 +313,17 @@
       "uri_tidal": "tidal://track/629055",
       "uri_deezer": "deezer://track/1483825282",
       "fun_fact_nl": "James Hetfield schreef dit terwijl hij met één hand zijn vriendin aan de telefoon had. Hij was nooit van plan de band het te laten horen, omdat hij het te persoonlijk vond.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "QMKHM1900008",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1572051825",
+        "de": "applemusic://track/1571984673",
+        "gb": "applemusic://track/1571984673",
+        "fr": "applemusic://track/1571984673",
+        "es": "applemusic://track/1571984673",
+        "nl": "applemusic://track/1571984673",
+        "it": "applemusic://track/1571984673"
+      }
     },
     {
       "year": 1996,
@@ -273,7 +353,17 @@
       "uri_tidal": "tidal://track/23267439",
       "uri_deezer": "deezer://track/714269242",
       "fun_fact_nl": "Oorspronkelijk een hit van Eric Carmen uit 1975, die de melodie baseerde op Rachmaninov. Célines krachtige versie toonde haar ongelooflijke vocale bereik en werd een karaokeklassieker.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "CAC229800162",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1473319811",
+        "de": "applemusic://track/1473319811",
+        "gb": "applemusic://track/1473319811",
+        "fr": "applemusic://track/1473319811",
+        "es": "applemusic://track/1473319811",
+        "nl": "applemusic://track/1473319811",
+        "it": "applemusic://track/1473319811"
+      }
     },
     {
       "year": 1985,
@@ -302,7 +392,17 @@
       "uri_tidal": "tidal://track/572144",
       "uri_deezer": "deezer://track/15391705",
       "fun_fact_nl": "De titel komt van het boek 'Broken Wings' van Kahlil Gibran. Richard Page schreef het nummer over het helpen van een vriend door moeilijke tijden.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USRC10100406",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1741860937",
+        "de": "applemusic://track/1741860937",
+        "gb": "applemusic://track/298356657",
+        "fr": "applemusic://track/1741860937",
+        "es": "applemusic://track/1741860937",
+        "nl": "applemusic://track/1741860937",
+        "it": "applemusic://track/1741860937"
+      }
     },
     {
       "year": 1988,
@@ -331,7 +431,17 @@
       "uri_tidal": "tidal://track/1218919",
       "uri_deezer": "deezer://track/734302",
       "fun_fact_nl": "Een van Van Halens meest succesvolle ballades met Sammy Hagar. Eddie Van Halens toetsenwerk toonde het geëvolueerde geluid van de band ten opzichte van hun vroege hardrock-dagen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USWB10902240",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/319580987",
+        "de": "applemusic://track/319580987",
+        "gb": "applemusic://track/319580987",
+        "fr": "applemusic://track/319580987",
+        "es": "applemusic://track/319580987",
+        "nl": "applemusic://track/319580987",
+        "it": "applemusic://track/319580987"
+      }
     },
     {
       "year": 1986,
@@ -360,7 +470,17 @@
       "uri_tidal": "tidal://track/35728806",
       "uri_deezer": "deezer://track/365822521",
       "fun_fact_nl": "Geschreven door Bernie Taupin en Martin Page, werd dit Hearts eerste nummer 1-hit. Nancy Wilson zong de hoofdzang in plaats van Ann omdat haar zachtere stem beter paste bij de dromerige teksten.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USCA28500010",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1704750505",
+        "de": "applemusic://track/1704750505",
+        "gb": "applemusic://track/1434443807",
+        "fr": "applemusic://track/1704750505",
+        "es": "applemusic://track/1704750505",
+        "nl": "applemusic://track/1704750505",
+        "it": "applemusic://track/1704750505"
+      }
     },
     {
       "year": 1987,
@@ -390,7 +510,17 @@
       "uri_tidal": "tidal://track/314856703",
       "uri_deezer": "deezer://track/730433472",
       "fun_fact_nl": "David Coverdale schreef dit voor zijn toenmalige vriendin Tawny Kitaen, die te zien was in de iconische video. Het nummer was geïnspireerd op zijn verlangen te bewijzen dat hij tedere ballades kon schrijven.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GB01A1700007",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1862662879",
+        "de": "applemusic://track/1862662879",
+        "gb": "applemusic://track/1862662879",
+        "fr": "applemusic://track/1862662879",
+        "es": "applemusic://track/1862662879",
+        "nl": "applemusic://track/1862662879",
+        "it": "applemusic://track/1862662879"
+      }
     },
     {
       "year": 1990,
@@ -420,7 +550,17 @@
       "uri_tidal": "tidal://track/277252292",
       "uri_deezer": "deezer://track/3098301",
       "fun_fact_nl": "Oorspronkelijk geschreven als een kerstlied in 1987. Het werd opnieuw opgenomen voor Pretty Woman en werd Roxettes grootste internationale hit.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "SEAMA8777131",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/697409304",
+        "de": "applemusic://track/697409304",
+        "gb": "applemusic://track/1452287331",
+        "fr": "applemusic://track/697409304",
+        "es": "applemusic://track/697409304",
+        "nl": "applemusic://track/697409304",
+        "it": "applemusic://track/712448713"
+      }
     },
     {
       "year": 1996,
@@ -450,7 +590,17 @@
       "uri_tidal": "tidal://track/268979931",
       "uri_deezer": "deezer://track/24246391",
       "fun_fact_nl": "Geschreven door Gwen Stefani over haar breuk met bassist Tony Kanal, terwijl ze nog in de band zaten. De emotionele spanning tijdens de opname is voelbaar in het eindresultaat.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USIR19500279",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1893192358",
+        "de": "applemusic://track/1893192358",
+        "gb": "applemusic://track/1893192358",
+        "fr": "applemusic://track/1893192358",
+        "es": "applemusic://track/1893192358",
+        "nl": "applemusic://track/1893192358",
+        "it": "applemusic://track/1893192358"
+      }
     },
     {
       "year": 1976,
@@ -480,7 +630,17 @@
       "uri_tidal": "tidal://track/1331974",
       "uri_deezer": "deezer://track/3616306",
       "fun_fact_nl": "Peter Cetera schreef dit na een breuk. Het was Chicago's eerste nummer 1-hit en won de Grammy voor Best Pop Vocal Performance. De band wilde het aanvankelijk niet op het album opnemen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USRH10285535",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1561117103",
+        "de": "applemusic://track/1561117103",
+        "gb": "applemusic://track/1561117103",
+        "fr": "applemusic://track/1561117103",
+        "es": "applemusic://track/1561117103",
+        "nl": "applemusic://track/1561117103",
+        "it": "applemusic://track/1561117103"
+      }
     },
     {
       "year": 2001,
@@ -510,7 +670,17 @@
       "uri_tidal": "tidal://track/68665696",
       "uri_deezer": "deezer://track/71828723",
       "fun_fact_nl": "Het meest gespeelde nummer op de Amerikaanse radio in de jaren 2000. Chad Kroeger schreef het in 10 minuten na een avond drinken, terugdenkend aan een moeizame relatie.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "NLA320119533",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1837959921",
+        "de": "applemusic://track/1749002902",
+        "gb": "applemusic://track/1749002902",
+        "fr": "applemusic://track/1749002902",
+        "es": "applemusic://track/1749002902",
+        "nl": "applemusic://track/1749002902",
+        "it": "applemusic://track/1749002902"
+      }
     },
     {
       "year": 1991,
@@ -540,7 +710,17 @@
       "uri_tidal": "tidal://track/261597",
       "uri_deezer": "deezer://track/906621",
       "fun_fact_nl": "De band was bang dat deze akoestische ballade hun rockcredibiliteit zou schaden. Het werd hun grootste hit en toonde Nuno Bettencourts ingewikkelde vingerpluktechniek.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USAM19090005",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1691630008",
+        "de": "applemusic://track/1691630008",
+        "gb": "applemusic://track/1691630008",
+        "fr": "applemusic://track/1691630008",
+        "es": "applemusic://track/1691630008",
+        "nl": "applemusic://track/1691630008",
+        "it": "applemusic://track/1691630008"
+      }
     },
     {
       "year": 1982,
@@ -569,7 +749,17 @@
       "uri_tidal": "tidal://track/138804",
       "uri_deezer": "deezer://track/625672",
       "fun_fact_nl": "Steve Perry schreef dit samen met Jonathan Cain. Het werd bijna niet opgenomen op het Escape-album, maar werd een van Journeys meest geliefde nummers, gecoverd door Mariah Carey in 1996.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM10015427",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/159174191",
+        "de": "applemusic://track/159174191",
+        "gb": "applemusic://track/159174191",
+        "fr": "applemusic://track/159174191",
+        "es": "applemusic://track/159174191",
+        "nl": "applemusic://track/159174191",
+        "it": "applemusic://track/159174191"
+      }
     },
     {
       "year": 1988,
@@ -598,7 +788,17 @@
       "uri_tidal": "tidal://track/393496",
       "uri_deezer": "deezer://track/3874974",
       "fun_fact_nl": "Bret Michaels schreef dit in een wasserette nadat hij zijn vriendin belde vanuit een telefooncel en een andere man hoorde opnemen. Het is een van de bepalende power ballades van de jaren 80.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USCA20300335",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/6762961488",
+        "de": "applemusic://track/6762961488",
+        "gb": "applemusic://track/6762961488",
+        "fr": "applemusic://track/6762961488",
+        "es": "applemusic://track/6762961488",
+        "nl": "applemusic://track/6762961488",
+        "it": "applemusic://track/6762961488"
+      }
     },
     {
       "year": 1991,
@@ -628,7 +828,17 @@
       "uri_tidal": "tidal://track/1894868",
       "uri_deezer": "deezer://track/927900",
       "fun_fact_nl": "Geschreven nadat de Scorpions het Moscow Music Peace Festival speelden in 1989. De gefloten intro werd iconisch als symbool voor het einde van de Koude Oorlog.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USPG19090037",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1434890599",
+        "de": "applemusic://track/340938027",
+        "gb": "applemusic://track/1467970877",
+        "fr": "applemusic://track/1440761801",
+        "es": "applemusic://track/1440761801",
+        "nl": "applemusic://track/1442708452",
+        "it": "applemusic://track/1440761801"
+      }
     },
     {
       "year": 1981,
@@ -658,7 +868,17 @@
       "uri_tidal": "tidal://track/99361661",
       "uri_deezer": "deezer://track/134036212",
       "fun_fact_nl": "De beroemde drumovergang werd gecreëerd met behulp van een per ongeluk uitgevonden gated reverb-techniek. Stedelijke legendes over de betekenis van het nummer blijven bestaan, maar Phil zegt dat het over zijn scheiding gaat.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USAT21502121",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1076060806",
+        "de": "applemusic://track/1076060806",
+        "gb": "applemusic://track/1076060806",
+        "fr": "applemusic://track/1076060806",
+        "es": "applemusic://track/1076060806",
+        "nl": "applemusic://track/1076060806",
+        "it": "applemusic://track/1076060806"
+      }
     },
     {
       "year": 1990,
@@ -688,7 +908,17 @@
       "uri_tidal": "tidal://track/1408377",
       "uri_deezer": "deezer://track/674958",
       "fun_fact_nl": "Geschreven als eerbetoon aan Elvis Presley, verwijst het 'Black Velvet' naar zijn donkere, vloeiende stem. Alannahs hese zang leverde haar een Grammy op voor Best Female Rock Vocal.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "QMFME2521079",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1837530994",
+        "de": null,
+        "gb": null,
+        "fr": null,
+        "es": null,
+        "nl": null,
+        "it": null
+      }
     },
     {
       "year": 1985,
@@ -717,7 +947,17 @@
       "uri_tidal": "tidal://track/1781742",
       "uri_deezer": "deezer://track/3788403452",
       "fun_fact_nl": "Geschreven door Nikki Sixx en Vince Neil over het missen van thuis tijdens een tournee. De pianogedreven ballade bewees dat hair metal-bands kwetsbaar konden zijn en werd een concertvaste waarde.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "QMRSZ2200081",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1606706533",
+        "de": "applemusic://track/1606706533",
+        "gb": "applemusic://track/1606706533",
+        "fr": "applemusic://track/1606706533",
+        "es": "applemusic://track/1606706533",
+        "nl": "applemusic://track/1606706533",
+        "it": "applemusic://track/1606706533"
+      }
     },
     {
       "year": 2002,
@@ -747,7 +987,17 @@
       "uri_tidal": "tidal://track/2918517",
       "uri_deezer": "deezer://track/967334",
       "fun_fact_nl": "Geschreven door Linda Perry, werd dit een hymne voor zelfacceptatie. Christina's rauwe, emotionele zang maakte het een bepalend nummer van haar carrière en won een Grammy.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USRC10201067",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1460054687",
+        "de": "applemusic://track/542368744",
+        "gb": "applemusic://track/392670508",
+        "fr": "applemusic://track/542368744",
+        "es": "applemusic://track/542368744",
+        "nl": "applemusic://track/542368744",
+        "it": "applemusic://track/892306869"
+      }
     },
     {
       "year": 1984,
@@ -776,7 +1026,17 @@
       "uri_tidal": "tidal://track/5128020",
       "uri_deezer": "deezer://track/1559555",
       "fun_fact_nl": "Geschreven door drummer Kelly Keagy over zijn jongere zus. De beroemde 'motoring'-zin was oorspronkelijk 'mothering' - de band veranderde het in de veronderstelling dat Kelly het verkeerd zong.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMC18314773",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/6762963003",
+        "de": "applemusic://track/6762963003",
+        "gb": "applemusic://track/6762963003",
+        "fr": "applemusic://track/6762963003",
+        "es": "applemusic://track/6762963003",
+        "nl": "applemusic://track/6762963003",
+        "it": "applemusic://track/6762963003"
+      }
     },
     {
       "year": 1983,
@@ -806,7 +1066,17 @@
       "uri_tidal": "tidal://track/304849",
       "uri_deezer": "deezer://track/532349",
       "fun_fact_nl": "Jim Steinman schreef dit oorspronkelijk voor een vampiermusical, getiteld 'Vampires in Love'. Bonnie Tylers kenmerkende hese stem was het gevolg van een mislukte operatie aan een stemnodul.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBBBN8302012",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1504111288",
+        "de": "applemusic://track/1504111288",
+        "gb": "applemusic://track/1504111288",
+        "fr": "applemusic://track/1504111288",
+        "es": "applemusic://track/1504111288",
+        "nl": "applemusic://track/1504111288",
+        "it": "applemusic://track/1504111288"
+      }
     },
     {
       "year": 2004,
@@ -835,7 +1105,17 @@
       "uri_tidal": "tidal://track/3081936",
       "uri_deezer": "deezer://track/1103890762",
       "fun_fact_nl": "Doug Robb schreef dit na reflectie over fouten in vroegere relaties. Het werd de doorbraakhit van de band en definieerde het mid-jaren 2000 rockballadesgeluid.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USIR20300704",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1696224307",
+        "de": "applemusic://track/1696224307",
+        "gb": "applemusic://track/1696224307",
+        "fr": "applemusic://track/1696224307",
+        "es": "applemusic://track/1696224307",
+        "nl": "applemusic://track/1696224307",
+        "it": "applemusic://track/1696224307"
+      }
     },
     {
       "year": 1985,
@@ -864,7 +1144,17 @@
       "uri_tidal": "tidal://track/127195",
       "uri_deezer": "deezer://track/3158164",
       "fun_fact_nl": "Vernoemd naar een echte vrouw met wie Fish (de zanger) een relatie had. De naam Kayleigh werd na dit nummer enorm populair en werd een toptienaam voor baby's in het VK.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAYE8500007",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/952775627",
+        "de": "applemusic://track/1027022361",
+        "gb": "applemusic://track/1027022361",
+        "fr": "applemusic://track/1027022361",
+        "es": "applemusic://track/1027022361",
+        "nl": "applemusic://track/1027022361",
+        "it": "applemusic://track/1027022361"
+      }
     },
     {
       "year": 1997,
@@ -893,7 +1183,17 @@
       "uri_tidal": "tidal://track/73862558",
       "uri_deezer": "deezer://track/3138729",
       "fun_fact_nl": "Samen geschreven met Guy Chambers in slechts 25 minuten. Het is verkozen tot het beste Britse nummer om op begrafenissen te spelen en blijft Robbies signatuurlied.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAYE9700233",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/725818406",
+        "de": "applemusic://track/1442885469",
+        "gb": "applemusic://track/1440769042",
+        "fr": "applemusic://track/1442885469",
+        "es": "applemusic://track/1442885469",
+        "nl": "applemusic://track/1442885469",
+        "it": "applemusic://track/1442885469"
+      }
     },
     {
       "year": 1984,
@@ -923,7 +1223,17 @@
       "uri_tidal": "tidal://track/2987610",
       "uri_deezer": "deezer://track/674711",
       "fun_fact_nl": "Benjamin Orr zong de hoofdzang op deze emotionele ballade. Het kreeg hernieuwde aandacht toen het werd gebruikt in een Live Aid-video over de hongersnood in Ethiopië, die kijkers tot tranen toe ontroerde.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USRH11509874",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1088534641",
+        "de": "applemusic://track/1088534641",
+        "gb": "applemusic://track/1088534641",
+        "fr": "applemusic://track/1088534641",
+        "es": "applemusic://track/1088534641",
+        "nl": "applemusic://track/1088534641",
+        "it": "applemusic://track/1088534641"
+      }
     },
     {
       "year": 1985,
@@ -952,7 +1262,17 @@
       "uri_tidal": "tidal://track/31849290",
       "uri_deezer": "deezer://track/581807",
       "fun_fact_nl": "Stond 5 weken op nummer 1 in het VK en werd het eerste nummer van een Amerikaanse vrouwelijke artiest dat een miljoen exemplaren verkocht in het VK. Later gecoverd door Céline Dion.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "DEE868400100",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1308473771",
+        "de": "applemusic://track/209450471",
+        "gb": "applemusic://track/1308473771",
+        "fr": "applemusic://track/1308473771",
+        "es": "applemusic://track/1308473771",
+        "nl": "applemusic://track/1308473771",
+        "it": "applemusic://track/1308473771"
+      }
     },
     {
       "year": 1994,
@@ -982,7 +1302,17 @@
       "uri_tidal": "tidal://track/65556726",
       "uri_deezer": "deezer://track/538586982",
       "fun_fact_nl": "Oorspronkelijk geschreven voor de film Romeo Is Bleeding maar afgewezen. Het werd een van Bon Jovis grootste hits en Jon's persoonlijke favoriete ballade.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USPR39412221",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1699699905",
+        "de": "applemusic://track/1699699905",
+        "gb": "applemusic://track/1699699905",
+        "fr": "applemusic://track/1699699905",
+        "es": "applemusic://track/1699699905",
+        "nl": "applemusic://track/1699699905",
+        "it": "applemusic://track/1699699905"
+      }
     },
     {
       "year": 1989,
@@ -1012,7 +1342,17 @@
       "uri_tidal": "tidal://track/546775",
       "uri_deezer": "deezer://track/2847452",
       "fun_fact_nl": "Geschreven nadat Susanna Hoffs de eeuwige vlam op het graf van Elvis Presley bezocht. Billy Steinberg co-schreef het na een droom over een eeuwige vlam.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM18800153",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/193605920",
+        "de": "applemusic://track/312048459",
+        "gb": "applemusic://track/312048459",
+        "fr": "applemusic://track/312048459",
+        "es": "applemusic://track/312048459",
+        "nl": "applemusic://track/312048459",
+        "it": "applemusic://track/291417924"
+      }
     },
     {
       "year": 1988,
@@ -1041,7 +1381,17 @@
       "uri_tidal": "tidal://track/661020",
       "uri_deezer": "deezer://track/548729192",
       "fun_fact_nl": "Tom Keifer schreef dit over een vroegere relatie. De pianogedreven ballade liet een andere kant van de glam metal-band zien en werd hun signatuurlied.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMR18886884",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1435808378",
+        "de": "applemusic://track/1440665848",
+        "gb": "applemusic://track/1435808378",
+        "fr": "applemusic://track/1435808378",
+        "es": "applemusic://track/1435808378",
+        "nl": "applemusic://track/1435808378",
+        "it": "applemusic://track/1435808378"
+      }
     },
     {
       "year": 1989,
@@ -1071,7 +1421,17 @@
       "uri_tidal": "tidal://track/11668522",
       "uri_deezer": "deezer://track/3168937",
       "fun_fact_nl": "Geschreven voor zijn vrouw Cynthia Rhodes terwijl zij een film opnam in Zuid-Afrika en hij haar niet kon bezoeken vanwege de apartheidsreisbeperkingen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USEM38900208",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1891813311",
+        "de": "applemusic://track/1891813311",
+        "gb": "applemusic://track/1891813311",
+        "fr": "applemusic://track/1891813311",
+        "es": "applemusic://track/1891813311",
+        "nl": "applemusic://track/1891813311",
+        "it": "applemusic://track/1891813311"
+      }
     },
     {
       "year": 2003,
@@ -1100,7 +1460,17 @@
       "uri_tidal": "tidal://track/100578065",
       "uri_deezer": "deezer://track/2172900",
       "fun_fact_nl": "Geschreven door Brad Arnold in slechts 15 minuten terwijl hij nadacht over weg zijn van thuis. Het leger nam het over als hymne voor in het buitenland gestationeerde troepen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USUM71213126",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1621745267",
+        "de": "applemusic://track/1621745267",
+        "gb": "applemusic://track/1621745267",
+        "fr": "applemusic://track/1621745267",
+        "es": "applemusic://track/1621745267",
+        "nl": "applemusic://track/1621745267",
+        "it": "applemusic://track/1621745267"
+      }
     },
     {
       "year": 1987,
@@ -1130,7 +1500,17 @@
       "uri_tidal": "tidal://track/530",
       "uri_deezer": "deezer://track/3152709",
       "fun_fact_nl": "Nick Van Eede schreef dit gebaseerd op de Franse uitdrukking 'la petite mort' (de kleine dood), een metafoor voor een orgasme. Het is Cutting Crew's enige grote hit.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAAA8600046",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/6762659492",
+        "de": "applemusic://track/1440665974",
+        "gb": "applemusic://track/712949421",
+        "fr": "applemusic://track/712949421",
+        "es": "applemusic://track/712949421",
+        "nl": "applemusic://track/712949421",
+        "it": "applemusic://track/716737146"
+      }
     },
     {
       "year": 1994,
@@ -1160,7 +1540,17 @@
       "uri_tidal": "tidal://track/2845116",
       "uri_deezer": "deezer://track/595920",
       "fun_fact_nl": "Oorspronkelijk van Badfinger in 1970, later een grote hit voor Harry Nilsson. Mariah's krachtige versie toonde haar ongelooflijke fluisterregister en werd de definitieve versie.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM19303176",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1706160979",
+        "de": "applemusic://track/1706160979",
+        "gb": "applemusic://track/1706160979",
+        "fr": "applemusic://track/1706160979",
+        "es": "applemusic://track/1706160979",
+        "nl": "applemusic://track/1683633450",
+        "it": "applemusic://track/1706160979"
+      }
     },
     {
       "year": 1975,
@@ -1189,7 +1579,17 @@
       "uri_tidal": "tidal://track/1195363",
       "uri_deezer": "deezer://track/2662287",
       "fun_fact_nl": "Geschreven door Boudleaux Bryant in 1960 en voor het eerst opgenomen door The Everly Brothers. Nazareths hardrockversie is de bekendste, hoewel ze hem bijna niet uitbrachten.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USAM19500609",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1440632340",
+        "de": null,
+        "gb": null,
+        "fr": null,
+        "es": null,
+        "nl": null,
+        "it": null
+      }
     },
     {
       "year": 1988,
@@ -1218,7 +1618,17 @@
       "uri_tidal": "tidal://track/48933",
       "uri_deezer": "deezer://track/11282935",
       "fun_fact_nl": "Michael Hutchence en Andrew Farriss schreven deze orkestrale rockballade. De strijkers werden gearrangeerd door de legendarische Nick Launay, waardoor het een epische, cinematografische kwaliteit kreeg.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USAT21400633",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/828779772",
+        "de": null,
+        "gb": null,
+        "fr": null,
+        "es": null,
+        "nl": null,
+        "it": null
+      }
     },
     {
       "year": 1992,
@@ -1248,7 +1658,17 @@
       "uri_tidal": "tidal://track/579992",
       "uri_deezer": "deezer://track/394510092",
       "fun_fact_nl": "Geschreven in 1989 maar pas uitgebracht met het Right Man-album. Eric Martin zong de hoofdzang op deze akoestische ballade, die tegelijkertijd nummer 1 stond in 15 landen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USAT20302609",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1270576306",
+        "de": "applemusic://track/1270576306",
+        "gb": "applemusic://track/1270576306",
+        "fr": "applemusic://track/1270576306",
+        "es": "applemusic://track/1270576306",
+        "nl": "applemusic://track/1270576306",
+        "it": "applemusic://track/1270576306"
+      }
     },
     {
       "year": 1989,
@@ -1278,7 +1698,17 @@
       "uri_tidal": "tidal://track/196435453",
       "uri_deezer": "deezer://track/2307289",
       "fun_fact_nl": "Geschreven door Diane Warren. De controversiële muziekvideo werd gefilmd op de USS Missouri met Cher in een onthullend outfit, waardoor sommige zenders het verboden.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USGF18923901",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1694568917",
+        "de": "applemusic://track/1694568917",
+        "gb": "applemusic://track/1694568917",
+        "fr": "applemusic://track/1694568917",
+        "es": "applemusic://track/1694568917",
+        "nl": "applemusic://track/1694568917",
+        "it": "applemusic://track/1694568917"
+      }
     },
     {
       "year": 1988,
@@ -1307,7 +1737,17 @@
       "uri_tidal": "tidal://track/170798223",
       "uri_deezer": "deezer://track/447552812",
       "fun_fact_nl": "Def Leppards enige nummer 1-hit in de VS. Het nummer duurde 4 jaar om te voltooien als onderdeel van het Hysteria-album, dat geteisterd werd door het ongeluk van drummer Rick Allen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBF088700608",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1440904256",
+        "de": "applemusic://track/1440904256",
+        "gb": "applemusic://track/1440904256",
+        "fr": "applemusic://track/1440904256",
+        "es": "applemusic://track/1440904256",
+        "nl": "applemusic://track/1440904256",
+        "it": "applemusic://track/1440904256"
+      }
     },
     {
       "year": 2000,
@@ -1365,7 +1805,17 @@
       "uri_tidal": "tidal://track/7935352",
       "uri_deezer": "deezer://track/546790",
       "fun_fact_nl": "Graham Russell schreef dit in 10 minuten. Het kenmerkende toetsenriff van het nummer werd een 80s soft rock-signatuur en maakte Air Supply tot internationale sterren.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USAR18000002",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/280839462",
+        "de": "applemusic://track/280839462",
+        "gb": "applemusic://track/280839462",
+        "fr": "applemusic://track/280839462",
+        "es": "applemusic://track/280839462",
+        "nl": "applemusic://track/280839462",
+        "it": "applemusic://track/280839462"
+      }
     },
     {
       "year": 2001,
@@ -1392,7 +1842,17 @@
       "uri_tidal": "tidal://track/1870901",
       "uri_deezer": "deezer://track/3866895",
       "fun_fact_nl": "Een klassieke power ballad van Chad Kroeger.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "NLA320219756",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/216661494",
+        "de": "applemusic://track/216661494",
+        "gb": "applemusic://track/216661494",
+        "fr": "applemusic://track/216661494",
+        "es": "applemusic://track/216661494",
+        "nl": "applemusic://track/216661494",
+        "it": "applemusic://track/216661494"
+      }
     },
     {
       "year": 1982,
@@ -1421,7 +1881,17 @@
       "uri_tidal": "tidal://track/3267925",
       "uri_deezer": "deezer://track/3156388",
       "fun_fact_nl": "Geschreven voor An Officer and a Gentleman, won het de Oscar voor Beste Originele Nummer. Joe Cocker en Jennifer Warnes moesten hun delen apart opnemen vanwege planningsproblemen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USIR28200024",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1894028699",
+        "de": "applemusic://track/1894028699",
+        "gb": "applemusic://track/1725030221",
+        "fr": "applemusic://track/1894028699",
+        "es": "applemusic://track/1894028699",
+        "nl": "applemusic://track/1894028699",
+        "it": "applemusic://track/1894028699"
+      }
     },
     {
       "year": 1991,
@@ -1450,7 +1920,17 @@
       "uri_tidal": "tidal://track/3238202",
       "uri_deezer": "deezer://track/675175",
       "fun_fact_nl": "Gebaseerd op Marc Cohns eerste bezoek aan Memphis, inclusief zijn bezoek aan Graceland. Hij was zo ontroerd door de ervaring dat hij het nummer in één nacht schreef.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USAT29900737",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1872064122",
+        "de": "applemusic://track/1872064122",
+        "gb": "applemusic://track/1872064122",
+        "fr": "applemusic://track/1872064122",
+        "es": "applemusic://track/1872064122",
+        "nl": "applemusic://track/1872064122",
+        "it": "applemusic://track/1872064122"
+      }
     },
     {
       "year": 1990,
@@ -1479,7 +1959,17 @@
       "uri_tidal": "tidal://track/31849195",
       "uri_deezer": "deezer://track/3822022",
       "fun_fact_nl": "Geschreven door Tommy Shaw en Jack Blades. De supergroep bevatte Ted Nugent, en deze power ballad bewees dat ze meer konden dan hardgedreven rock.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USWB10902497",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1807977780",
+        "de": "applemusic://track/1553760383",
+        "gb": "applemusic://track/1553760383",
+        "fr": "applemusic://track/1553760383",
+        "es": "applemusic://track/1553760383",
+        "nl": "applemusic://track/1553760383",
+        "it": "applemusic://track/1553760383"
+      }
     },
     {
       "year": 1988,
@@ -1509,7 +1999,17 @@
       "uri_tidal": "tidal://track/1273648",
       "uri_deezer": "deezer://track/2795612",
       "fun_fact_nl": "Geschreven voor de Olympische Spelen van 1988 in Seoul. Albert Hammond en John Bettis schreven het speciaal voor Whitney's stem, en het werd een hymne voor atleten wereldwijd.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USAR19901006",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1580627167",
+        "de": "applemusic://track/1580627167",
+        "gb": "applemusic://track/1580627167",
+        "fr": "applemusic://track/1580627167",
+        "es": "applemusic://track/1580627167",
+        "nl": "applemusic://track/1580627167",
+        "it": "applemusic://track/1580627167"
+      }
     },
     {
       "year": 1976,
@@ -1538,7 +2038,17 @@
       "uri_tidal": "tidal://track/158013",
       "uri_deezer": "deezer://track/67503801",
       "fun_fact_nl": "Freddie Mercury was geïnspireerd door gospelmuziek en Aretha Franklin. De harmonieën vereisten meer dan 100 vocale overdubs om het kooreffect te bereiken.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBUM71029613",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1440743586",
+        "de": "applemusic://track/1440822112",
+        "gb": "applemusic://track/1440822112",
+        "fr": "applemusic://track/1440822112",
+        "es": "applemusic://track/1440822112",
+        "nl": "applemusic://track/1440822112",
+        "it": "applemusic://track/1440822112"
+      }
     },
     {
       "year": 1992,
@@ -1564,7 +2074,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=6NXnxTNIWkc",
       "uri_tidal": "tidal://track/21844149",
       "fun_fact_nl": "Een klassieke power ballad van 4 Non Blondes.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USIR19200553",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1442267078",
+        "de": "applemusic://track/1443342983",
+        "gb": "applemusic://track/1443342983",
+        "fr": "applemusic://track/1443342983",
+        "es": "applemusic://track/1443342983",
+        "nl": "applemusic://track/1443342983",
+        "it": "applemusic://track/1443342983"
+      }
     },
     {
       "year": 2005,
@@ -1593,7 +2113,17 @@
       "uri_tidal": "tidal://track/135463",
       "uri_deezer": "deezer://track/15043431",
       "fun_fact_nl": "De comeback-single na een onderbreking van 3 jaar. Geschreven door Backstreet Boys met Dan Muckala, het sprak over hun tijd apart en emotionele reis.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USJI10500131",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/303190455",
+        "de": "applemusic://track/1008081137",
+        "gb": "applemusic://track/325253469",
+        "fr": "applemusic://track/325253469",
+        "es": "applemusic://track/303190455",
+        "nl": "applemusic://track/325253469",
+        "it": "applemusic://track/325253469"
+      }
     },
     {
       "year": 1984,
@@ -1623,7 +2153,17 @@
       "uri_tidal": "tidal://track/1568613",
       "uri_deezer": "deezer://track/374283061",
       "fun_fact_nl": "De epische versie van 8 minuten werd in één take live opgenomen in First Avenue in Minneapolis. Prince schreef het over het einde van de wereld en het zoeken naar verlossing door geloof.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USWB11700198",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1229320478",
+        "de": "applemusic://track/1229320478",
+        "gb": "applemusic://track/1229320478",
+        "fr": "applemusic://track/1229320478",
+        "es": "applemusic://track/1229320478",
+        "nl": "applemusic://track/1229320478",
+        "it": "applemusic://track/1229320478"
+      }
     },
     {
       "year": 1989,
@@ -1653,7 +2193,17 @@
       "uri_tidal": "tidal://track/113471911",
       "uri_deezer": "deezer://track/1015071",
       "fun_fact_nl": "Geschreven door Desmond Child en markeerde Alice Coopers commerciële comeback. De theatrale aard van het nummer paste perfect bij zijn horror-rockpersona.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM18900004",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1692216418",
+        "de": "applemusic://track/960015871",
+        "gb": "applemusic://track/960015871",
+        "fr": "applemusic://track/960015871",
+        "es": "applemusic://track/960015871",
+        "nl": "applemusic://track/960015871",
+        "it": "applemusic://track/960015871"
+      }
     },
     {
       "year": 1990,
@@ -1680,7 +2230,17 @@
       "uri_tidal": "tidal://track/71770978",
       "uri_deezer": "deezer://track/13162280",
       "fun_fact_nl": "Jani Lane schreef deze ballade die Warrants zachtere kant toonde. Het werd een MTV-vaste waarde en bewees dat de band emotionele diepgang kon leveren buiten feesthymnes.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM18800040",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/157402588",
+        "de": "applemusic://track/492659858",
+        "gb": "applemusic://track/492659858",
+        "fr": "applemusic://track/492659858",
+        "es": "applemusic://track/492659858",
+        "nl": "applemusic://track/492659858",
+        "it": "applemusic://track/492659858"
+      }
     },
     {
       "year": 1983,
@@ -1709,7 +2269,17 @@
       "uri_tidal": "tidal://track/7204760",
       "uri_deezer": "deezer://track/3093078",
       "fun_fact_nl": "Bevat een van MTV's eerste verhalende muziekvideo's met danschoreografie. Pat Benatar aarzelde aanvankelijk over het theatrale videoconcept.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USCH38400020",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/6762962564",
+        "de": "applemusic://track/6762962564",
+        "gb": "applemusic://track/6762962564",
+        "fr": "applemusic://track/6762962564",
+        "es": "applemusic://track/6762962564",
+        "nl": "applemusic://track/6762962564",
+        "it": "applemusic://track/6762962564"
+      }
     },
     {
       "year": 1990,
@@ -1735,7 +2305,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=OEPvv9pjIoQ",
       "uri_tidal": "tidal://track/1110429",
       "fun_fact_nl": "Een klassieke power ballad van Bad Company.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USRH11503260",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1038338052",
+        "de": "applemusic://track/1038338052",
+        "gb": "applemusic://track/1038338052",
+        "fr": "applemusic://track/1038338052",
+        "es": "applemusic://track/1038338052",
+        "nl": "applemusic://track/1038338052",
+        "it": "applemusic://track/1038338052"
+      }
     },
     {
       "year": 1990,
@@ -1762,7 +2342,17 @@
       "uri_tidal": "tidal://track/629061",
       "uri_deezer": "deezer://track/102271990",
       "fun_fact_nl": "Een klassieke power ballad van Tina Turner.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USCA29100186",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1799964337",
+        "de": "applemusic://track/1799964337",
+        "gb": "applemusic://track/1799964337",
+        "fr": "applemusic://track/1799964337",
+        "es": "applemusic://track/1799964337",
+        "nl": "applemusic://track/1799964337",
+        "it": "applemusic://track/1799964337"
+      }
     },
     {
       "year": 1991,
@@ -1791,7 +2381,17 @@
       "uri_tidal": "tidal://track/691735",
       "uri_deezer": "deezer://track/3135512",
       "fun_fact_nl": "Geschreven over lucide dromen door Chris DeGarmo. Het orkestrale arrangement was ongebruikelijk voor een progressieve metalband en bezorgde hen mainstream succes.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USEM30200450",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/715506437",
+        "de": "applemusic://track/715506437",
+        "gb": "applemusic://track/715506437",
+        "fr": "applemusic://track/715506437",
+        "es": "applemusic://track/715506437",
+        "nl": "applemusic://track/715506437",
+        "it": "applemusic://track/715506437"
+      }
     },
     {
       "year": 1984,
@@ -1820,7 +2420,17 @@
       "uri_tidal": "tidal://track/348192",
       "uri_deezer": "deezer://track/4216602",
       "fun_fact_nl": "Geschreven over de ontkenningsfase van een breuk. De ironische tekst 'I ain't missing you' werd de emotionele haak van het nummer terwijl John Waites stem breekt van emotie.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USEM38800236",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1700309037",
+        "de": "applemusic://track/1700309037",
+        "gb": "applemusic://track/1700309037",
+        "fr": "applemusic://track/1700309037",
+        "es": "applemusic://track/1700309037",
+        "nl": "applemusic://track/1700309037",
+        "it": "applemusic://track/1700309037"
+      }
     },
     {
       "year": 1990,
@@ -1847,7 +2457,17 @@
       "uri_tidal": "tidal://track/4785383",
       "uri_deezer": "deezer://track/3123893",
       "fun_fact_nl": "De doorbraakhit van de Britse rockband Thunder. Danny Bowes' soulvolle zang en Luke Morleys composities toonden dat ze konden concurreren met Amerikaanse arenabands.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAYE9000090",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/696375679",
+        "de": "applemusic://track/1535767182",
+        "gb": "applemusic://track/1532898878",
+        "fr": "applemusic://track/1532898878",
+        "es": "applemusic://track/1532898878",
+        "nl": "applemusic://track/1532898878",
+        "it": "applemusic://track/1532898878"
+      }
     },
     {
       "year": 1987,
@@ -1877,7 +2497,17 @@
       "uri_tidal": "tidal://track/2811812",
       "uri_deezer": "deezer://track/602137932",
       "fun_fact_nl": "Geschreven voor de film Mannequin. Het werd Starships tweede en laatste nummer 1-hit en toonde de overgang van de band van rock naar pure pop.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USRC18702968",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1774435572",
+        "de": "applemusic://track/1654717032",
+        "gb": "applemusic://track/1801938589",
+        "fr": "applemusic://track/1801938589",
+        "es": "applemusic://track/1801938589",
+        "nl": "applemusic://track/1801938589",
+        "it": "applemusic://track/1801938589"
+      }
     },
     {
       "year": 1992,
@@ -1907,7 +2537,17 @@
       "uri_tidal": "tidal://track/1105825",
       "uri_deezer": "deezer://track/785176",
       "fun_fact_nl": "Anthony Kiedis schreef dit over zijn eenzaamheid en vroegere drugsgebruik in Los Angeles. Producer Rick Rubin vond het gedicht en overtuigde hem er een nummer van te maken.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USWB11402852",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/948460560",
+        "de": "applemusic://track/948460560",
+        "gb": "applemusic://track/948460560",
+        "fr": "applemusic://track/948460560",
+        "es": "applemusic://track/948460560",
+        "nl": "applemusic://track/948460560",
+        "it": "applemusic://track/948460560"
+      }
     },
     {
       "year": 1998,
@@ -1937,7 +2577,17 @@
       "uri_tidal": "tidal://track/544229",
       "uri_deezer": "deezer://track/4290138",
       "fun_fact_nl": "Geschreven voor de City of Angels-soundtrack. John Rzeznik gebruikte een unieke open stemming die hij sindsdien in veel nummers heeft gebruikt. Het stond 18 weken op nummer 1 in de Hot 100 Airplay-lijst.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USWB11507961",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1109658204",
+        "de": "applemusic://track/1109658204",
+        "gb": "applemusic://track/1109658204",
+        "fr": "applemusic://track/1109658204",
+        "es": "applemusic://track/1109658204",
+        "nl": "applemusic://track/1109658204",
+        "it": "applemusic://track/1109658204"
+      }
     },
     {
       "year": 1984,
@@ -1966,7 +2616,17 @@
       "uri_tidal": "tidal://track/393348",
       "uri_deezer": "deezer://track/353398321",
       "fun_fact_nl": "Vernoemd naar de Franse horrorfilm. Billy Idol wilde een kwetsbare kant laten zien die afweek van zijn punkimago. De gefluisterde Franse zang versterkt de spookachtige sfeer.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USCH38400023",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1768337318",
+        "de": "applemusic://track/1768337318",
+        "gb": "applemusic://track/1768337318",
+        "fr": "applemusic://track/1768337318",
+        "es": "applemusic://track/1768337318",
+        "nl": "applemusic://track/1768337318",
+        "it": "applemusic://track/1768337318"
+      }
     },
     {
       "year": 1981,
@@ -1994,7 +2654,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=xJeWySiuq1I",
       "uri_tidal": "tidal://track/11842696",
       "fun_fact_nl": "Berucht van de nummer 1 plek in het VK gehouden door Joe Dolce's 'Shaddap You Face'. De epische synthballade wordt beschouwd als een van de grootste nummers die nooit nummer 1 bereikte in Groot-Brittannië.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAYK8000061",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1631055268",
+        "de": "applemusic://track/1631055268",
+        "gb": "applemusic://track/1631055268",
+        "fr": "applemusic://track/1631055268",
+        "es": "applemusic://track/1631055268",
+        "nl": "applemusic://track/1631055268",
+        "it": "applemusic://track/1631055268"
+      }
     },
     {
       "year": 1990,
@@ -2023,7 +2693,17 @@
       "uri_tidal": "tidal://track/2571006",
       "uri_deezer": "deezer://track/4086601",
       "fun_fact_nl": "Geschreven door Kip Winger over het weg zijn van dierbaren tijdens een tournee. De ballade toonde zijn klassiek geschoolde muzikale vaardigheden buiten hair metal.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USAT20000874",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1563710858",
+        "de": "applemusic://track/1213308981",
+        "gb": "applemusic://track/1213308981",
+        "fr": "applemusic://track/1213308981",
+        "es": "applemusic://track/1213308981",
+        "nl": "applemusic://track/1213308981",
+        "it": "applemusic://track/1213308981"
+      }
     },
     {
       "year": 2001,
@@ -2052,7 +2732,17 @@
       "uri_tidal": "tidal://track/3392919",
       "uri_deezer": "deezer://track/3611381",
       "fun_fact_nl": "Oorspronkelijk opgevoerd als duet met Fred Durst bij Woodstock '99. De rauwe emotionele uitvoering werd viraal en lanceerde Stainds mainstream carrière.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USEE10100309",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/263059095",
+        "de": "applemusic://track/1484936170",
+        "gb": "applemusic://track/1484936170",
+        "fr": "applemusic://track/1484936170",
+        "es": "applemusic://track/1484936170",
+        "nl": "applemusic://track/1484936170",
+        "it": "applemusic://track/1484936170"
+      }
     },
     {
       "year": 1981,
@@ -2082,7 +2772,17 @@
       "uri_tidal": "tidal://track/3029519",
       "uri_deezer": "deezer://track/977947",
       "fun_fact_nl": "Stond 10 weken op nummer 2, geblokkeerd van nummer 1 door Olivia Newton-Johns 'Physical'. Mick Jones schreef het over zijn geïdealiseerde visie op ware liefde.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USAT20802339",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1802249801",
+        "de": "applemusic://track/1802225468",
+        "gb": "applemusic://track/1802225468",
+        "fr": "applemusic://track/1802225468",
+        "es": "applemusic://track/1802225468",
+        "nl": "applemusic://track/1802225468",
+        "it": "applemusic://track/1802225468"
+      }
     },
     {
       "year": 1978,
@@ -2111,7 +2811,17 @@
       "uri_tidal": "tidal://track/1894031",
       "uri_deezer": "deezer://track/125468090",
       "fun_fact_nl": "Jim Steinman schreef dit als reactie op Elvis Presley's 'I Want You, I Need You, I Love You'. De epische productiestijl werd Meat Loafs signatuur.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM11206828",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/991385388",
+        "de": "applemusic://track/991385388",
+        "gb": null,
+        "fr": "applemusic://track/991385388",
+        "es": "applemusic://track/991385388",
+        "nl": "applemusic://track/991385388",
+        "it": "applemusic://track/991385388"
+      }
     },
     {
       "year": 1990,
@@ -2140,7 +2850,17 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=0-EF60neguk",
       "uri_tidal": "tidal://track/10904532",
       "fun_fact_nl": "Geschreven door Prince in 1985 voor The Family. Sinéads sobere video, in één take gefilmd met een enkele traan, werd een van MTV's meest iconische momenten.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAYK9000017",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1629185307",
+        "de": "applemusic://track/1629185307",
+        "gb": "applemusic://track/1629185307",
+        "fr": "applemusic://track/1629185307",
+        "es": "applemusic://track/1629185307",
+        "nl": "applemusic://track/1629185307",
+        "it": "applemusic://track/1629185307"
+      }
     },
     {
       "year": 1985,
@@ -2169,7 +2889,17 @@
       "uri_tidal": "tidal://track/233192935",
       "uri_deezer": "deezer://track/581533",
       "fun_fact_nl": "Kevin Cronin begon dit te schrijven in 1978 maar kon het jaren lang niet afmaken. Het werd een van de bepalende power ballades en REO's tweede nummer 1-hit.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM18400442",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1452434710",
+        "de": "applemusic://track/1452434710",
+        "gb": "applemusic://track/1452434710",
+        "fr": "applemusic://track/1452434710",
+        "es": "applemusic://track/1452434710",
+        "nl": "applemusic://track/1452434710",
+        "it": "applemusic://track/1452434710"
+      }
     },
     {
       "year": 1987,
@@ -2198,7 +2928,17 @@
       "uri_tidal": "tidal://track/614307",
       "uri_deezer": "deezer://track/341024771",
       "fun_fact_nl": "Geschreven door Lindsey Buckingham over zijn gecompliceerde gevoelens voor Stevie Nicks. Zijn ingewikkeld akoestisch gitaarwerk werd legendarisch in live optredens.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USWB19900209",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/202272743",
+        "de": "applemusic://track/202272743",
+        "gb": "applemusic://track/202272743",
+        "fr": "applemusic://track/202272743",
+        "es": "applemusic://track/202272743",
+        "nl": "applemusic://track/202272743",
+        "it": "applemusic://track/202272743"
+      }
     },
     {
       "year": 2002,
@@ -2228,7 +2968,17 @@
       "uri_tidal": "tidal://track/1852738",
       "uri_deezer": "deezer://track/2319140",
       "fun_fact_nl": "Daniel schreef dit op 17-jarige leeftijd, met existentiële vragen over zielsverwanten. Hij nam vroege demo's op in zijn slaapkamer, waarmee de bedroom producer-trend werd gelanceerd.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBAKW0201297",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1696211325",
+        "de": "applemusic://track/1696211325",
+        "gb": "applemusic://track/1696211325",
+        "fr": "applemusic://track/1696211325",
+        "es": "applemusic://track/1696211325",
+        "nl": "applemusic://track/1696211325",
+        "it": "applemusic://track/1696211325"
+      }
     },
     {
       "year": 1986,
@@ -2255,7 +3005,17 @@
       "uri_tidal": "tidal://track/14219182",
       "uri_deezer": "deezer://track/98351162",
       "fun_fact_nl": "Sammy Hagar schreef dit na een droom over een buitenaardse bezoeker. Het nummer toonde het geëvolueerde geluid van Van Halen met toetsen op de voorgrond.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USWB10902266",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/319402893",
+        "de": "applemusic://track/319402893",
+        "gb": "applemusic://track/319402893",
+        "fr": "applemusic://track/319402893",
+        "es": "applemusic://track/319402893",
+        "nl": "applemusic://track/319402893",
+        "it": "applemusic://track/319402893"
+      }
     },
     {
       "year": 2004,
@@ -2282,7 +3042,17 @@
       "uri_tidal": "tidal://track/2865114",
       "uri_deezer": "deezer://track/13142681",
       "fun_fact_nl": "Geschreven over verslavingsproblemen, resoneerde het diep met de supergroep - voormalige muzikanten van Guns N' Roses en Stone Temple Pilots.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USRC10400142",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1756982317",
+        "de": "applemusic://track/1778714266",
+        "gb": "applemusic://track/1778714266",
+        "fr": "applemusic://track/1778714266",
+        "es": "applemusic://track/1778714266",
+        "nl": "applemusic://track/1778714266",
+        "it": "applemusic://track/1778714266"
+      }
     },
     {
       "year": 1991,
@@ -2311,7 +3081,17 @@
       "uri_tidal": "tidal://track/14338595",
       "uri_deezer": "deezer://track/2076571447",
       "fun_fact_nl": "Miljenko Matijevics ongelooflijke vocaal bereik van 5 octaven schittert in deze power ballad. De band stond op het punt beroemd te worden voordat grunge het muzikale landschap veranderde.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMC18930635",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1660628664",
+        "de": "applemusic://track/1660628664",
+        "gb": "applemusic://track/1660628664",
+        "fr": "applemusic://track/1660628664",
+        "es": "applemusic://track/1660628664",
+        "nl": "applemusic://track/1660628664",
+        "it": "applemusic://track/1660628664"
+      }
     },
     {
       "year": 1984,
@@ -2341,7 +3121,17 @@
       "uri_tidal": "tidal://track/462054967",
       "uri_deezer": "deezer://track/134036230",
       "fun_fact_nl": "Geschreven voor de film Against All Odds. Phil Collins schreef en nam het in één dag op na het bekijken van een ruwe snede van de film. Het won een Grammy.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USRH11603951",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1148642452",
+        "de": "applemusic://track/1148701808",
+        "gb": "applemusic://track/1148642452",
+        "fr": "applemusic://track/1148642452",
+        "es": "applemusic://track/1148642452",
+        "nl": "applemusic://track/1148642452",
+        "it": "applemusic://track/1148642452"
+      }
     },
     {
       "year": 1988,
@@ -2370,7 +3160,17 @@
       "uri_tidal": "tidal://track/574517",
       "uri_deezer": "deezer://track/3690646862",
       "fun_fact_nl": "Geschreven door Steven Tyler en Desmond Child over Tylers dochter. De tedere ballade toonde Aerosmiths zachtere kant tijdens hun commerciële comeback.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USIR10000457",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1440823557",
+        "de": "applemusic://track/1440823557",
+        "gb": "applemusic://track/1440823557",
+        "fr": "applemusic://track/1440823557",
+        "es": "applemusic://track/1440823557",
+        "nl": "applemusic://track/1440823557",
+        "it": "applemusic://track/1440823557"
+      }
     },
     {
       "year": 1995,
@@ -2399,7 +3199,17 @@
       "uri_tidal": "tidal://track/94406416",
       "uri_deezer": "deezer://track/2281042777",
       "fun_fact_nl": "Oorspronkelijk opgenomen voor het Adrenalize-album maar achtergehouden. Het werd een enorme hit in het VK en toonde dat Def Leppard nog steeds emotionele ballades kon leveren.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "GBF089500378",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1438626559",
+        "de": "applemusic://track/1444308649",
+        "gb": "applemusic://track/1444308649",
+        "fr": "applemusic://track/1444308649",
+        "es": "applemusic://track/1444308649",
+        "nl": "applemusic://track/1444308649",
+        "it": "applemusic://track/1444308649"
+      }
     },
     {
       "year": 1983,
@@ -2428,7 +3238,17 @@
       "uri_tidal": "tidal://track/1211254",
       "uri_deezer": "deezer://track/534464",
       "fun_fact_nl": "Jonathan Cain schreef dit op een tourbus, denkend na over hoe toerneren relaties beïnvloedt. Steve Perry's emotionele zang maakte het een klassiek trouwlied.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM18300110",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/476986080",
+        "de": "applemusic://track/476986080",
+        "gb": "applemusic://track/476986080",
+        "fr": "applemusic://track/476986080",
+        "es": "applemusic://track/476986080",
+        "nl": "applemusic://track/476986080",
+        "it": "applemusic://track/476986080"
+      }
     },
     {
       "year": 2002,
@@ -2455,7 +3275,17 @@
       "uri_tidal": "tidal://track/1919983",
       "uri_deezer": "deezer://track/847227",
       "fun_fact_nl": "Corey Taylor schreef deze akoestische ballade voor de Spider-Man-soundtrack. Het toonde een kwetsbare kant van de Slipknot/Stone Sour-frontman.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "NLA320219758",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/217523491",
+        "de": "applemusic://track/217523491",
+        "gb": "applemusic://track/217523491",
+        "fr": null,
+        "es": "applemusic://track/217523491",
+        "nl": "applemusic://track/217523491",
+        "it": "applemusic://track/217523491"
+      }
     },
     {
       "year": 1972,
@@ -2482,7 +3312,17 @@
       "uri_tidal": "tidal://track/1500870",
       "uri_deezer": "deezer://track/3794395952",
       "fun_fact_nl": "De enige ballade op Black Sabbath's Vol. 4-album. Tony Iommi speelde voor het eerst piano op een plaat, wat een onverwacht teder moment in de heavy metal creëerde.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USWB11304343",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/787641279",
+        "de": null,
+        "gb": null,
+        "fr": null,
+        "es": null,
+        "nl": null,
+        "it": null
+      }
     },
     {
       "year": 1986,
@@ -2511,7 +3351,17 @@
       "uri_tidal": "tidal://track/1108913",
       "uri_deezer": "deezer://track/3475780",
       "fun_fact_nl": "De doorbraakhit van deze Canadese band bevatte Bryan Adams op achtergrondzang. Het ving het quintessentiële 80s power ballad-geluid.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "CAE158600001",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/6762961485",
+        "de": "applemusic://track/6762961485",
+        "gb": "applemusic://track/6762961485",
+        "fr": "applemusic://track/6762961485",
+        "es": "applemusic://track/6762961485",
+        "nl": "applemusic://track/6762961485",
+        "it": "applemusic://track/6762961485"
+      }
     },
     {
       "year": 1989,
@@ -2541,7 +3391,17 @@
       "uri_tidal": "tidal://track/115810706",
       "uri_deezer": "deezer://track/637054252",
       "fun_fact_nl": "Geschreven over een moeizame jeugd. Sebastian Bach's krachtige zang en de verhalende structuur van het nummer maakten het een van de bepalende power ballades van de late jaren 80.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USRH11804134",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1727232300",
+        "de": "applemusic://track/1727232300",
+        "gb": "applemusic://track/1727232300",
+        "fr": "applemusic://track/1727232300",
+        "es": "applemusic://track/1727232300",
+        "nl": "applemusic://track/1727232300",
+        "it": "applemusic://track/1727232300"
+      }
     },
     {
       "year": 1978,
@@ -2600,7 +3460,17 @@
       "uri_tidal": "tidal://track/2876035",
       "uri_deezer": "deezer://track/80274512",
       "fun_fact_nl": "Het platenlabel stond op Paul McCoy's mannenzang, hoewel Amy Lee het oorspronkelijk schreef als solo. De unieke rock/orkestrale vermenging van het nummer lanceerde het genre.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USWU30200093",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1645901771",
+        "de": "applemusic://track/1645901771",
+        "gb": "applemusic://track/1645901771",
+        "fr": "applemusic://track/1645901771",
+        "es": "applemusic://track/1645901771",
+        "nl": "applemusic://track/1645901771",
+        "it": "applemusic://track/1645901771"
+      }
     },
     {
       "year": 1989,
@@ -2654,7 +3524,17 @@
       "uri_tidal": "tidal://track/55172078",
       "uri_deezer": "deezer://track/1169677",
       "fun_fact_nl": "Een klassieke power ballad van Guns N' Roses.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USGF19141504",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1644782461",
+        "de": "applemusic://track/1644782461",
+        "gb": "applemusic://track/1644782461",
+        "fr": "applemusic://track/1644782461",
+        "es": "applemusic://track/1644782461",
+        "nl": "applemusic://track/1644782461",
+        "it": "applemusic://track/1644782461"
+      }
     },
     {
       "year": 1981,
@@ -2681,7 +3561,17 @@
       "uri_tidal": "tidal://track/3268257",
       "uri_deezer": "deezer://track/6769496",
       "fun_fact_nl": "Mede-geschreven met Lou Reed. Deze onkarakteristieke ballade verscheen tijdens KISS' experimentele fase en toonde Paul Stanley's kwetsbare zangprestatie.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USMR18100007",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1590962269",
+        "de": "applemusic://track/1595986989",
+        "gb": "applemusic://track/1590962269",
+        "fr": "applemusic://track/1590962269",
+        "es": "applemusic://track/1590962269",
+        "nl": "applemusic://track/1590962269",
+        "it": "applemusic://track/1590962269"
+      }
     },
     {
       "year": 1986,
@@ -2710,7 +3600,17 @@
       "uri_tidal": "tidal://track/1770105",
       "uri_deezer": "deezer://track/2221501",
       "fun_fact_nl": "Enorme hit in Australië en Europa. Het doedelzakgedreven hymne werd een onofficieel Australisch volkslied en revitaliseerde John Farnhams carrière.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "AUBM08641001",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/280839461",
+        "de": "applemusic://track/280839461",
+        "gb": "applemusic://track/280839461",
+        "fr": "applemusic://track/280839461",
+        "es": "applemusic://track/280839461",
+        "nl": "applemusic://track/280839461",
+        "it": "applemusic://track/280839461"
+      }
     },
     {
       "year": 1990,
@@ -2739,7 +3639,17 @@
       "uri_tidal": "tidal://track/1411755",
       "uri_deezer": "deezer://track/3123862",
       "fun_fact_nl": "Geschreven door Sheriff-leden die opnieuw samenkwamen als Alias. Het nummer zette hun power ballad-succes voort na Sheriff's 'When I'm With You'.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "CAE159000001",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1707064758",
+        "de": "applemusic://track/712779002",
+        "gb": "applemusic://track/714420565",
+        "fr": "applemusic://track/714420565",
+        "es": "applemusic://track/714420565",
+        "nl": "applemusic://track/714420565",
+        "it": "applemusic://track/714420565"
+      }
     },
     {
       "year": 2001,
@@ -2769,7 +3679,17 @@
       "uri_tidal": "tidal://track/1375869",
       "uri_deezer": "deezer://track/2276253",
       "fun_fact_nl": "Oorspronkelijk aangeboden aan meerdere andere artiesten die het afsloegen. Enrique nam een Engelse en Spaanse versie op, waarbij de Engelse versie zijn signatuurlied werd.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USIR10120047",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1440799744",
+        "de": "applemusic://track/1356764751",
+        "gb": "applemusic://track/1356764751",
+        "fr": "applemusic://track/1440769284",
+        "es": "applemusic://track/1356764751",
+        "nl": "applemusic://track/1356764751",
+        "it": "applemusic://track/1356764751"
+      }
     },
     {
       "year": 1990,
@@ -2796,7 +3716,17 @@
       "uri_tidal": "tidal://track/76773928",
       "uri_deezer": "deezer://track/1069270",
       "fun_fact_nl": "Een klassieke power ballad van Firehouse.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM19000353",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/375136376",
+        "de": "applemusic://track/375136376",
+        "gb": "applemusic://track/375136376",
+        "fr": "applemusic://track/375136376",
+        "es": "applemusic://track/375136376",
+        "nl": "applemusic://track/375136376",
+        "it": "applemusic://track/375136376"
+      }
     },
     {
       "year": 2000,
@@ -2825,7 +3755,17 @@
       "uri_tidal": "tidal://track/168381910",
       "uri_deezer": "deezer://track/80274470",
       "fun_fact_nl": "Scott Stapp schreef dit nadat hij hoorde dat hij vader zou worden. Het won de Grammy voor Best Rock Song en werd Creed's enige nummer 1-hit.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USWU39908053",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1727629936",
+        "de": "applemusic://track/1727629936",
+        "gb": "applemusic://track/1727629936",
+        "fr": "applemusic://track/1727629936",
+        "es": "applemusic://track/1727629936",
+        "nl": "applemusic://track/1727629936",
+        "it": "applemusic://track/1727629936"
+      }
     },
     {
       "year": 1988,
@@ -2852,7 +3792,17 @@
       "uri_tidal": "tidal://track/97708782",
       "uri_deezer": "deezer://track/966435",
       "fun_fact_nl": "Van Lita Fords hitalbum 'Lita'. De voormalige Runaways-gitariste toonde haar veelzijdigheid met power ballades naast haar hardere rockmateriaal.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USRC19004308",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/254964865",
+        "de": "applemusic://track/254964865",
+        "gb": "applemusic://track/254964865",
+        "fr": "applemusic://track/254964865",
+        "es": "applemusic://track/254964865",
+        "nl": "applemusic://track/254964865",
+        "it": "applemusic://track/254964865"
+      }
     },
     {
       "year": 1988,
@@ -2881,7 +3831,17 @@
       "uri_tidal": "tidal://track/39650336",
       "uri_deezer": "deezer://track/611354",
       "fun_fact_nl": "Geschreven door externe componisten, wat de band aanvankelijk weerstond. Het werd Cheap Trick's enige nummer 1-hit in de VS, hoewel ze het zelden live spelen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "isrc": "USSM18700122",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1739845480",
+        "de": "applemusic://track/1739845480",
+        "gb": "applemusic://track/1739845480",
+        "fr": "applemusic://track/1739845480",
+        "es": "applemusic://track/1739845480",
+        "nl": "applemusic://track/1739845480",
+        "it": "applemusic://track/1739845480"
+      }
     }
   ]
 }

--- a/custom_components/beatify/www/sw.js
+++ b/custom_components/beatify/www/sw.js
@@ -6,7 +6,7 @@
  */
 'use strict';
 
-var CACHE_VERSION = 'beatify-v3.3.2-rc11';
+var CACHE_VERSION = 'beatify-v3.3.2-rc12';
 var MAX_CACHE_ITEMS = 50;
 
 // Critical assets to precache on install (minified versions only - fallback handled by HTML)

--- a/tests/unit/test_playlist.py
+++ b/tests/unit/test_playlist.py
@@ -1,0 +1,203 @@
+"""Tests for storefront-aware Apple Music URI resolution (#808 follow-up).
+
+Beatify's playlists carry per-region Apple Music track IDs in
+``uri_apple_music_by_region``. The resolver in ``playlist.py:get_song_uri``
+picks the right one based on the user's storefront, and PlaylistManager
+filters out songs explicitly unavailable in the user's region so the
+runtime never even tries to play them.
+"""
+
+from __future__ import annotations
+
+from custom_components.beatify.const import (
+    PROVIDER_APPLE_MUSIC,
+    PROVIDER_SPOTIFY,
+)
+from custom_components.beatify.game.playlist import (
+    PlaylistManager,
+    get_song_uri,
+)
+
+
+# ---------------------------------------------------------------------------
+# get_song_uri — storefront resolution
+# ---------------------------------------------------------------------------
+
+
+class TestGetSongUriStorefrontAware:
+    def test_no_storefront_falls_back_to_legacy_uri(self):
+        """Default behavior (storefront=None): use the legacy single URI field."""
+        song = {
+            "uri_apple_music": "applemusic://track/302229811",
+            "uri_apple_music_by_region": {
+                "de": None,
+                "us": "applemusic://track/302229811",
+            },
+        }
+        assert (
+            get_song_uri(song, PROVIDER_APPLE_MUSIC) == "applemusic://track/302229811"
+        )
+
+    def test_storefront_picks_regional_uri(self):
+        """When storefront is set, the per-region URI wins over legacy."""
+        song = {
+            "uri_apple_music": "applemusic://track/100",  # legacy/US
+            "uri_apple_music_by_region": {
+                "us": "applemusic://track/100",
+                "gb": "applemusic://track/200",  # different ID for UK
+            },
+        }
+        assert (
+            get_song_uri(song, PROVIDER_APPLE_MUSIC, storefront="gb")
+            == "applemusic://track/200"
+        )
+
+    def test_storefront_unavailable_returns_none_explicitly(self):
+        """If region is explicitly None in the per-region map, return None.
+        This is the storefront-mismatch case (#808): track is confirmed
+        unavailable in the user's region. Returning None lets PlaylistManager
+        skip the song without ever trying MA.
+        """
+        song = {
+            "uri_apple_music": "applemusic://track/302229811",  # US-only
+            "uri_apple_music_by_region": {
+                "us": "applemusic://track/302229811",
+                "de": None,  # confirmed unavailable in DE
+            },
+        }
+        assert get_song_uri(song, PROVIDER_APPLE_MUSIC, storefront="de") is None
+
+    def test_storefront_not_in_map_falls_back_to_legacy(self):
+        """If the user's storefront isn't in the per-region map at all,
+        fall back to the legacy field. Important for backwards-compat with
+        playlists that haven't been regenerated yet.
+        """
+        song = {
+            "uri_apple_music": "applemusic://track/302229811",
+            "uri_apple_music_by_region": {
+                "us": "applemusic://track/302229811",
+                "de": None,
+            },
+        }
+        # User in JP — not yet covered by the regen script
+        assert (
+            get_song_uri(song, PROVIDER_APPLE_MUSIC, storefront="jp")
+            == "applemusic://track/302229811"
+        )
+
+    def test_storefront_ignored_for_non_apple_providers(self):
+        """The storefront param only affects Apple Music; Spotify ignores it."""
+        song = {
+            "uri_spotify": "spotify:track:abc123",
+            "uri_apple_music_by_region": {"de": None},
+        }
+        assert (
+            get_song_uri(song, PROVIDER_SPOTIFY, storefront="de")
+            == "spotify:track:abc123"
+        )
+
+    def test_no_per_region_data_uses_legacy(self):
+        """Songs that haven't been regenerated yet (no by_region map) still
+        resolve via the legacy single URI."""
+        song = {"uri_apple_music": "applemusic://track/12345"}
+        assert (
+            get_song_uri(song, PROVIDER_APPLE_MUSIC, storefront="de")
+            == "applemusic://track/12345"
+        )
+
+
+# ---------------------------------------------------------------------------
+# PlaylistManager — storefront-aware filtering
+# ---------------------------------------------------------------------------
+
+
+def _song(*, title: str, by_region: dict[str, str | None] | None = None) -> dict:
+    """Build a minimal song dict for tests."""
+    s = {
+        "title": title,
+        "artist": "Test Artist",
+        "year": 1990,
+        "uri_apple_music": "applemusic://track/legacy",
+    }
+    if by_region is not None:
+        s["uri_apple_music_by_region"] = by_region
+    return s
+
+
+class TestPlaylistManagerStorefrontFiltering:
+    def test_songs_unavailable_in_storefront_are_filtered_out(self):
+        """#808: PlaylistManager removes songs explicitly unavailable in the
+        user's storefront from the playable pool entirely. They never
+        appear in get_next_song output → MA is never asked to play them.
+        """
+        songs = [
+            _song(
+                title="Available everywhere",
+                by_region={"us": "applemusic://track/1", "de": "applemusic://track/1"},
+            ),
+            _song(
+                title="US-only (DE unavailable)",
+                by_region={"us": "applemusic://track/2", "de": None},
+            ),
+            _song(
+                title="DE-only (US unavailable)",
+                by_region={"us": None, "de": "applemusic://track/3"},
+            ),
+        ]
+        # DE user: only songs 1 and 3 should be playable
+        pm = PlaylistManager(songs, provider=PROVIDER_APPLE_MUSIC, storefront="de")
+        assert pm.has_playable_songs()
+
+        playable_titles: set[str] = set()
+        for _ in range(20):  # sample a bunch of times to be sure
+            picked = pm.get_next_song()
+            if picked is None:
+                break
+            playable_titles.add(picked["title"])
+            pm.mark_played(picked["_resolved_uri"])
+
+        assert "Available everywhere" in playable_titles
+        assert "DE-only (US unavailable)" in playable_titles
+        assert "US-only (DE unavailable)" not in playable_titles
+
+    def test_resolved_uri_uses_storefront(self):
+        """get_next_song's _resolved_uri must be the per-region URI."""
+        songs = [
+            _song(
+                title="Different IDs per region",
+                by_region={
+                    "us": "applemusic://track/usid",
+                    "gb": "applemusic://track/gbid",
+                },
+            ),
+        ]
+        pm = PlaylistManager(songs, provider=PROVIDER_APPLE_MUSIC, storefront="gb")
+        picked = pm.get_next_song()
+        assert picked is not None
+        assert picked["_resolved_uri"] == "applemusic://track/gbid"
+
+    def test_no_storefront_uses_legacy_uri(self):
+        """Backwards-compat: PlaylistManager without storefront uses the
+        legacy single URI, ignoring per-region data."""
+        songs = [
+            _song(
+                title="Available US, unavailable DE",
+                by_region={"us": "applemusic://track/legacy", "de": None},
+            ),
+        ]
+        # No storefront → legacy URI used → song IS playable.
+        pm = PlaylistManager(songs, provider=PROVIDER_APPLE_MUSIC)
+        picked = pm.get_next_song()
+        assert picked is not None
+        assert picked["_resolved_uri"] == "applemusic://track/legacy"
+
+    def test_song_with_no_per_region_data_still_playable(self):
+        """Songs without ``uri_apple_music_by_region`` (not yet regenerated)
+        fall back to legacy URI even when a storefront is set."""
+        songs = [
+            _song(title="Not regenerated yet"),  # no by_region key
+        ]
+        pm = PlaylistManager(songs, provider=PROVIDER_APPLE_MUSIC, storefront="de")
+        picked = pm.get_next_song()
+        assert picked is not None
+        assert picked["_resolved_uri"] == "applemusic://track/legacy"


### PR DESCRIPTION
## Summary

Final piece of the #808 saga — the **real** fix for the underlying data issue.

Beatify's playlists historically stored a single Apple Music URI per song (typically a US track ID). For users on other storefronts (DE, GB, FR, ES, NL, IT), some subset of those IDs aren't in their regional Apple Music catalog → MA returns \`no playable items found\` → strict-detect catches it → game silently skips. After rc11 those skips don't pause the game, but the user still loses a few rounds per playthrough waiting on 15s timeouts.

This PR pre-resolves per-region Apple Music URIs at playlist-build time so the runtime never even tries to play unavailable tracks. No MA round-trips, no timeouts, no recovery banner.

## Coverage

22 playlists (11 main + 11 community), 2204 ISRC-resolved songs:

| Region | Available | Region-locked |
|---|---|---|
| US | 99.5% | 10 |
| **DE** | **97.5%** | **55** ← @Levtos |
| GB | 97.0% | 66 |
| FR | 97.4% | 57 |
| ES | 97.6% | 54 |
| NL | 97.6% | 53 |
| IT | 97.5% | 56 |

For DE users: 55 silently-unplayable tracks are now silently *skipped* at playlist load instead of silently *failing* through 15s MA timeouts at runtime.

## Changes

**Tooling (gitignored — local maintenance script):**
- \`scripts/fetch_apple_music_regions.py\` — uses Apple Music API + ISRC to resolve per-region track IDs. Idempotent, batched (25 ISRCs/call), ~3 minutes for the full 2481-song catalog. Credentials read from \`.env\`. Re-run when adding playlists or storefronts.

**Schema (committed):**
- New song fields: \`isrc\` and \`uri_apple_music_by_region: {us, de, gb, fr, es, nl, it}\` (\`null\` value = confirmed unavailable in that storefront).
- All 22 playlists regenerated.

**Runtime (\`game/playlist.py\`, \`game/state.py\`):**
- \`get_song_uri(song, provider, storefront=None)\` — storefront param only affects Apple Music; backwards-compatible default.
- \`PlaylistManager(..., storefront=None)\` filters region-locked songs at construction time.
- \`GameState._detect_storefront()\` reads \`hass.config.country.lower()\`.

## Versions
- \`manifest.json\` + \`sw.js CACHE_VERSION\` → \`3.3.2-rc12\`. No frontend asset changes.

## Test plan
- [x] \`pytest tests/unit/\` — 439 passed (+10 new), 1 xfailed.
- [x] \`ruff check\` + \`ruff format --check\` — clean.
- [x] Smoke-tested Apple Music API: confirmed \`apple_music://track/302229811\` (Levtos's failing case) returns \`null\` for DE in the regenerated playlist.
- [ ] @Levtos retests on Apple Music DE — should see fewer skipped rounds, faster game flow.

## Out of scope (filed for later)
- **Spotify-API ISRC backfill** for the 277 songs that have only \`uri_spotify\` (no \`uri_apple_music\` to look up against). Adds Spotify auth flow but unblocks per-region resolution for those songs too.
- **MA WebSocket API for storefront detection** — covers cases where the user's Apple Music account storefront differs from HA's configured country (e.g. expat using US Apple Music from a German HA install). Requires MA WS auth handling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)