### PR TITLE
fix(playback): UI returns ~1s on title mismatch (was 15s)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to Beatify are documented here. For detailed release notes, 
 
 ## [Unreleased]
 
+## [3.3.2-rc13] - 2026-04-28
+
+### Fixed
+- **UI no longer lags ~15s after pressing "Next song" when MA reports a title that doesn't substring-match the playlist (#808 follow-up).** @Levtos's playthrough on rc12 had the music start immediately on round-advance, but the game screen took several seconds to appear. The cause: `_check_state` fast-path required `expected_title.lower()` to be a substring of the speaker's reported `media_title`. When the playlist had "Das Modell" but Apple Music returned "The Model", or "Hallelujah" became "Hallelujah - Live", the substring check failed and the wait timed out via the 15s slow-buffer tolerance fallback. Relaxed the fast-path to also accept *"title moved to anything different from before the call"* — the same signal the slow-buffer fallback was using, just promoted into the fast-path. UI now returns within ~1s of MA actually starting playback. The #795 stale-title invariant is preserved: if the title hasn't changed from before the call, the fast-path still rejects (covered by the existing test).
+- **Reduced metadata-fetch timeout 5s → 2s.** When the playback fast-path fired (which it now does in ~1s), the game's pre-round metadata refresh would still wait up to 5 more seconds for fresh artwork from MA. That was the secondary contributor to the post-fix UI lag. New 2s budget; on timeout we fall back to the playlist's existing `album_art` field. Briefly stale art at the top of a round in worst case, but the speaker corrects on its own state callback.
+
+### For contributors
+- Bumped manifest + `sw.js CACHE_VERSION` → `3.3.2-rc13`. No frontend asset changes.
+- 1 new test in `test_media_player.py` covering the German/English title-mismatch fast-path. 440 passed, 1 xfailed.
+
 ## [3.3.2-rc12] - 2026-04-28
 
 ### Added
@@ -24,7 +34,7 @@ All notable changes to Beatify are documented here. For detailed release notes, 
   For DE users: 55 region-locked tracks are now silently *skipped* before any MA call, instead of silently *failing* through 15s timeouts and possibly tripping the 3-failure pause limit. Same pattern across all non-US regions.
 
 ### For contributors
-- New `scripts/fetch_apple_music_regions.py` — uses Apple Music API + ISRC to resolve per-region track IDs across configurable storefronts. Idempotent, batched (25 ISRCs per call), runs in ~3 minutes for the full 1288-song catalog. Credentials read from `.env` (`APPLE_MUSIC_KEY_ID`, `APPLE_MUSIC_TEAM_ID`, `APPLE_MUSIC_PRIVATE_KEY_PATH`). Re-run when adding new playlists or new storefronts.
+- New `scripts/fetch_apple_music_regions.py` — uses Apple Music API + ISRC to resolve per-region track IDs across configurable storefronts. Idempotent, batched (25 ISRCs per call), runs in ~3 minutes for the full 2481-song catalog (22 playlists: 11 main + 11 community). Credentials read from `.env` (`APPLE_MUSIC_KEY_ID`, `APPLE_MUSIC_TEAM_ID`, `APPLE_MUSIC_PRIVATE_KEY_PATH`). Re-run when adding new playlists or new storefronts.
 - New song fields: `isrc` (universal recording identifier, populated for 2204/2481 songs) and `uri_apple_music_by_region` (per-region track ID, `null` for confirmed-unavailable). 277 songs without `uri_apple_music` still need ISRC backfill via Spotify API — filed as a future enhancement.
 - `get_song_uri(song, provider, storefront=None)` — backwards-compatible signature; storefront only affects Apple Music. `PlaylistManager(songs, provider, storefront=None)` filters out region-locked songs at construction time.
 - `GameState._detect_storefront()` reads `hass.config.country` (lower-cased). Future enhancement: query Music Assistant's WebSocket API for the actual Apple Music provider's storefront, which may differ from HA's country.

--- a/custom_components/beatify/manifest.json
+++ b/custom_components/beatify/manifest.json
@@ -12,5 +12,5 @@
   "documentation": "https://github.com/mholzi/beatify",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/mholzi/beatify/issues",
-  "version": "3.3.2-rc12"
+  "version": "3.3.2-rc13"
 }

--- a/custom_components/beatify/services/media_player.py
+++ b/custom_components/beatify/services/media_player.py
@@ -98,7 +98,15 @@ PLAYBACK_TIMEOUT = 8.0
 MA_PLAYBACK_TIMEOUT = 15.0
 
 # Timeout for waiting for metadata to update after playing (seconds)
-METADATA_WAIT_TIMEOUT = 5.0
+# Wait up to 2s for MA to push fresh metadata (album art, etc.) after a
+# playback transition. Reduced from 5s — that earlier value was the
+# dominant secondary cause of "UI lag after pressing next" (after the 15s
+# playback-confirm wait, addressed by the title_advanced fast-path).
+# When this times out, Beatify falls back to the playlist's existing
+# album_art / title / artist fields; the visible cost is briefly stale
+# album art at the top of a round, which the speaker corrects on its own
+# state callback within a few seconds.
+METADATA_WAIT_TIMEOUT = 2.0
 
 # Candidate URI fields on a song, by user-selected provider (#805).
 #
@@ -462,18 +470,49 @@ class MediaPlayerService:
         start_time = asyncio.get_event_loop().time()
 
         def _check_state(state) -> bool:
-            """Return True if the state confirms expected playback."""
+            """Return True if the state confirms expected playback.
+
+            Two acceptance paths:
+              1. Title contains expected (substring) — the strongest signal.
+              2. Title moved to ANYTHING different from before the call — MA
+                 is making progress on a new track, accept it.
+
+            Path 2 was previously only reachable via the 15-second slow-buffer
+            tolerance below. Levtos reported that pressing "next" caused the
+            UI to lag while the music had already started: the playlist had
+            a song with a slightly different title format (e.g. German
+            "Das Modell" vs MA's English "The Model", or "(Remastered)"
+            suffix mismatches) so the substring-match in path 1 failed and
+            the wait timed out. With path 2 in the fast-path, the UI now
+            returns within ~1s of MA actually starting playback.
+
+            #795 invariant still holds: if the title is unchanged from
+            before the call (`title_before`), neither path fires and we
+            fall through to the title-must-advance hard-failure check.
+            """
             if not state or state.state != "playing":
                 return False
             try:
-                current_title = state.attributes.get("media_title", "")
+                current_title = state.attributes.get("media_title", "") or ""
                 position_updated = state.attributes.get("media_position_updated_at")
 
                 position_fresh = position_updated != position_updated_before
-                title_matches = (not expected_lower) or (
-                    expected_lower in current_title.lower() if current_title else False
-                )
-                return title_matches and position_fresh
+                if not position_fresh:
+                    return False
+
+                # Path 1: exact-ish title match (substring).
+                if expected_lower and expected_lower in current_title.lower():
+                    return True
+                # If no expected title was supplied, position-fresh alone is
+                # all the signal we have — accept (matches old behavior).
+                if not expected_lower:
+                    return True
+
+                # Path 2: title moved to something different from before.
+                if current_title and current_title != title_before:
+                    return True
+
+                return False
             except (AttributeError, KeyError):
                 return False
 

--- a/custom_components/beatify/www/sw.js
+++ b/custom_components/beatify/www/sw.js
@@ -6,7 +6,7 @@
  */
 'use strict';
 
-var CACHE_VERSION = 'beatify-v3.3.2-rc12';
+var CACHE_VERSION = 'beatify-v3.3.2-rc13';
 var MAX_CACHE_ITEMS = 50;
 
 // Critical assets to precache on install (minified versions only - fallback handled by HTML)

--- a/tests/unit/test_media_player.py
+++ b/tests/unit/test_media_player.py
@@ -133,6 +133,56 @@ class TestMANonBlockingPlayback:
         assert call_count >= 2
 
     @pytest.mark.asyncio
+    async def test_ma_fast_path_accepts_title_advanced_without_exact_match(self):
+        """Levtos's UI-lag scenario: title moved to a NEW song after the call,
+        but the new title doesn't substring-match what the playlist expected
+        (e.g. playlist has 'Das Modell', MA reports 'The Model'; or
+        playlist has 'Hallelujah' and MA returns 'Hallelujah - Live'). The
+        fast-path must still confirm playback so the UI returns within ~1s
+        instead of waiting the full 15s timeout.
+
+        #795 invariant is preserved: if the title is UNCHANGED from before,
+        the fast-path still rejects (covered by the separate stale-title test).
+        """
+        hass = _make_hass("playing", media_title="Manhattan Skyline")
+        svc = MediaPlayerService(hass, "media_player.test", platform="music_assistant")
+
+        before = _make_state(
+            "playing",
+            media_title="Manhattan Skyline",  # previous track
+            media_position=120,
+            media_position_updated_at="2020-01-01T00:00:00+00:00",
+        )
+        # MA started playing the new track. Title moved to "The Model" but
+        # the playlist expected "Das Modell" (German title) — substring match
+        # fails, but title_advanced succeeds.
+        after = _make_state(
+            "playing",
+            media_title="The Model",  # different from `before`, but doesn't contain "Das Modell"
+            media_position=2,
+            media_position_updated_at="2020-01-01T00:00:01+00:00",  # fresh
+        )
+        call_count = 0
+
+        def state_progression(*_args):
+            nonlocal call_count
+            call_count += 1
+            return before if call_count <= 1 else after
+
+        hass.states.get = MagicMock(side_effect=state_progression)
+
+        with patch(
+            "custom_components.beatify.services.media_player.asyncio.sleep",
+            new_callable=AsyncMock,
+        ):
+            result = await svc.play_song(_make_song(title="Das Modell"))
+
+        # Fast-path must fire — title moved, even though it doesn't match.
+        assert result is True
+        # Should NOT have needed to wait the full timeout; few state reads.
+        assert call_count >= 2
+
+    @pytest.mark.asyncio
     async def test_ma_realistic_ytmusic_flow(self):
         """Simulate real MA+YTMusic flow: queued → idle → playing pos=0 → playing pos=1."""
         hass = _make_hass("playing", media_title="Old Song")


### PR DESCRIPTION
## Summary

@Levtos reported on rc12 that pressing "Next song" caused the game screen to lag a few seconds before appearing — even though the music started immediately. Logs showed:

\`\`\`
MA playback not confirmed after 15.0s for apple_music://track/...
Title moved 'Manhattan Skyline' → 'The Model'.
Continuing anyway — MA may still be buffering. (#345)
\`\`\`

The track was playing fine. The wait timed out because \`expected_lower in current_title.lower()\` failed — the playlist had a slightly different title format (German vs English, remaster suffix, "(Live)" version, etc.).

## Fix

**1. Relaxed fast-path** — `_check_state` now also accepts "title moved to anything different from before the call" (in addition to the existing substring-match path). Same signal the slow-buffer fallback was using, promoted into the fast-path. UI returns in ~1s.

**2. Reduced metadata-fetch timeout** 5s → 2s. Secondary contributor to the lag. On timeout, fall back to playlist's existing album_art.

## Invariants preserved

- **#795 stale-title detection**: if title is unchanged from before the call, fast-path still rejects. Existing test `test_ma_returns_false_when_title_unchanged_but_position_advances` still passes.
- **#803 cold-start**: position-fresh + title-match still confirms when position lags at 0.
- **#777 hard-failure**: idle/unavailable/off speaker still classifies as "error".

## Versions
- `manifest.json` + `sw.js CACHE_VERSION` → `3.3.2-rc13`. No frontend asset changes.

## Test plan
- [x] `pytest tests/unit/` — 440 passed (+1 new), 1 xfailed.
- [x] `ruff check` + `ruff format --check` — clean.
- [x] New test `test_ma_fast_path_accepts_title_advanced_without_exact_match` covers the German/English title-mismatch case explicitly.
- [ ] @Levtos retests on rc13 — pressing "Next song" should bring the game screen up within ~1-2s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)