### PR TITLE
fix(state): round no longer freezes on PLAYING when scoring throws (closes #816)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to Beatify are documented here. For detailed release notes, 
 
 ## [Unreleased]
 
+## [3.3.2-rc14] - 2026-04-28
+
+### Fixed
+- **Round no longer freezes on PLAYING when scoring throws (#816).** @mholzi reported the timer hitting 0 but the UI staying frozen on the playing screen — no transition to REVEAL, no broadcast. Root cause: the scoring loop in `_end_round_unlocked` (`ScoringService.score_player_round` × every player, plus `apply_closest_wins`, plus the `round_results` append loop) was NOT wrapped in try/except. By round 9 of a long playlist, accumulated state edge cases (a player with an unusual challenge field, a corrupted timer, etc.) could throw mid-loop, propagating up and aborting `_end_round_unlocked` BEFORE the phase-transition line. Phase stayed `PLAYING`, no broadcast fired, the UI was stuck. Now: each scoring step is per-player isolated and wrapped — one failed player loses their score for the round (logged loudly) but the round still ends and the broadcast fires.
+- **Silent timer-task crashes are now logged.** Companion fix to #816: every timer task created in `RoundManager.initialize_round`, `confirm_intro_splash`, and `GameState.resume_game` now has an `add_done_callback` that surfaces any unretrieved exception with a stack trace. Previously, an unhandled exception in the timer coroutine would leave the asyncio Task in `done with exception` state but nobody called `task.result()`, so the round stayed frozen with no diagnostic in the logs. Future occurrences of this class of bug will leave a clear trail.
+
+### For contributors
+- 2 new tests in `TestEndRoundResilience` (`test_state.py`) covering the scoring-throws path and the closest-wins-throws path. 442 passed, 1 xfailed.
+- Bumped manifest + `sw.js CACHE_VERSION` → `3.3.2-rc14`. No frontend asset changes.
+
 ## [3.3.2-rc13] - 2026-04-28
 
 ### Fixed

--- a/custom_components/beatify/game/round_manager.py
+++ b/custom_components/beatify/game/round_manager.py
@@ -33,6 +33,30 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
+
+def _log_timer_task_failure(task: asyncio.Task) -> None:
+    """Surface silent crashes in the round timer task (#816).
+
+    Without this done-callback, an unhandled exception in the timer
+    coroutine (or anything it awaits — including end_round and the
+    full scoring path) leaves the task in `done with exception` state
+    but nobody retrieves the result, so the round stays frozen on
+    PLAYING with no diagnostic in the logs. Logging the exception here
+    means the next time this happens we have a clear stack trace
+    pointing at the actual cause.
+    """
+    if task.cancelled():
+        return  # Cancellation is expected (admin pressed End/Pause/Skip).
+    exc = task.exception()
+    if exc is not None:
+        _LOGGER.error(
+            "Round timer task crashed silently — round will stay frozen "
+            "on PLAYING. Error: %s",
+            exc,
+            exc_info=exc,
+        )
+
+
 # Intro mode constraints
 _INTRO_MIN_ROUND = 3  # No intro before round 3
 _INTRO_MIN_GAP = 2  # At least 2 normal rounds between intros
@@ -311,6 +335,13 @@ class RoundManager:
         else:
             delay = (self.deadline - int(self._now() * 1000)) / 1000.0
             self._timer_task = asyncio.create_task(timer_countdown(delay))
+            # #816: surface any silent task crash. Without this callback,
+            # an unhandled exception inside `timer_countdown` (or anything
+            # it awaits, e.g. end_round → scoring) leaves the task in
+            # `done with exception` state but nobody calls `task.result()`,
+            # so the round stays frozen on PLAYING with no log of what
+            # went wrong. Now we always log the failure mode.
+            self._timer_task.add_done_callback(_log_timer_task_failure)
 
             # Start intro auto-stop timer if this is an intro round
             if self.is_intro_round and on_round_end:
@@ -365,6 +396,7 @@ class RoundManager:
         delay = (self.deadline - int(now * 1000)) / 1000.0
         countdown = timer_countdown or self._timer_countdown
         self._timer_task = asyncio.create_task(countdown(delay))
+        self._timer_task.add_done_callback(_log_timer_task_failure)
 
         # Start intro auto-stop
         self._intro_stop_task = asyncio.create_task(

--- a/custom_components/beatify/game/state.py
+++ b/custom_components/beatify/game/state.py
@@ -847,8 +847,16 @@ class GameState:
 
             if remaining_ms > 0:
                 remaining_seconds = remaining_ms / 1000.0
+                # Local import to avoid module-level cycle.
+                from custom_components.beatify.game.round_manager import (  # noqa: PLC0415
+                    _log_timer_task_failure,
+                )
+
                 self._round_manager._timer_task = asyncio.create_task(
                     self._timer_countdown(remaining_seconds)
+                )
+                self._round_manager._timer_task.add_done_callback(
+                    _log_timer_task_failure
                 )
                 _LOGGER.info("Timer restarted with %.1fs remaining", remaining_seconds)
 
@@ -1462,29 +1470,55 @@ class GameState:
                     "missing" if self.current_song is None else "no year field",
                 )
 
-        # Calculate scores for all players — delegates to ScoringService (#139)
+        # Calculate scores for all players — delegates to ScoringService (#139).
+        # #816: wrap in try/except so an unexpected state shape in ONE player
+        # doesn't abort the whole round-end transition. Without this, a
+        # ScoringService exception bubbles up before line 1573 (where phase
+        # gets set to REVEAL) and broadcast_state never fires — the UI
+        # stays frozen on the PLAYING screen with the timer at 0. Per-player
+        # isolation: if one player's scoring fails, the rest still score and
+        # the round still ends.
         all_players = list(self.players.values())
         for player in self.players.values():
-            ScoringService.score_player_round(
-                player,
-                correct_year=correct_year,
-                round_start_time=self.round_start_time,
-                round_duration=self.round_duration,
-                difficulty=self.difficulty,
-                artist_challenge=self.artist_challenge,
-                movie_challenge=self.movie_challenge,
-                is_intro_round=self.is_intro_round,
-                intro_round_start_time=self._round_manager._intro_round_start_time,
-                all_players=all_players,
-                streak_achievements=self.streak_achievements,
-                bet_tracking=self.bet_tracking,
-            )
+            try:
+                ScoringService.score_player_round(
+                    player,
+                    correct_year=correct_year,
+                    round_start_time=self.round_start_time,
+                    round_duration=self.round_duration,
+                    difficulty=self.difficulty,
+                    artist_challenge=self.artist_challenge,
+                    movie_challenge=self.movie_challenge,
+                    is_intro_round=self.is_intro_round,
+                    intro_round_start_time=self._round_manager._intro_round_start_time,
+                    all_players=all_players,
+                    streak_achievements=self.streak_achievements,
+                    bet_tracking=self.bet_tracking,
+                )
+            except (KeyError, AttributeError, TypeError, ValueError) as err:
+                _LOGGER.error(
+                    "Scoring failed for player %s in round %d: %s — "
+                    "their score is unchanged this round, round still ends",
+                    getattr(player, "name", "?"),
+                    self.round,
+                    err,
+                )
 
-        # Issue #442: Closest Wins — zero out non-closest players' scores
+        # Issue #442: Closest Wins — zero out non-closest players' scores.
+        # #816: same defensive wrap as above.
         if self.closest_wins_mode and correct_year is not None:
-            ScoringService.apply_closest_wins(all_players, correct_year)
+            try:
+                ScoringService.apply_closest_wins(all_players, correct_year)
+            except (KeyError, AttributeError, TypeError, ValueError) as err:
+                _LOGGER.error(
+                    "apply_closest_wins failed in round %d: %s — round still ends",
+                    self.round,
+                    err,
+                )
 
-        # Issue #120: Track round results for shareable result cards
+        # Issue #120: Track round results for shareable result cards.
+        # #816: defensive wrap so a corrupt player.years_off doesn't block
+        # the round-end transition.
         if correct_year is not None:
             scoring_cfg = DIFFICULTY_SCORING.get(
                 self.difficulty, DIFFICULTY_SCORING[DIFFICULTY_DEFAULT]
@@ -1492,17 +1526,24 @@ class GameState:
             close_range = scoring_cfg["close_range"]
             near_range = scoring_cfg["near_range"]
             for player in self.players.values():
-                if player.submitted and player.years_off is not None:
-                    if player.years_off == 0:
-                        player.round_results.append("exact")
-                    elif close_range > 0 and player.years_off <= close_range:
-                        player.round_results.append("scored")
-                    elif near_range > 0 and player.years_off <= near_range:
-                        player.round_results.append("close")
+                try:
+                    if player.submitted and player.years_off is not None:
+                        if player.years_off == 0:
+                            player.round_results.append("exact")
+                        elif close_range > 0 and player.years_off <= close_range:
+                            player.round_results.append("scored")
+                        elif near_range > 0 and player.years_off <= near_range:
+                            player.round_results.append("close")
+                        else:
+                            player.round_results.append("missed")
                     else:
                         player.round_results.append("missed")
-                else:
-                    player.round_results.append("missed")
+                except (AttributeError, TypeError) as err:
+                    _LOGGER.error(
+                        "round_results append failed for player %s: %s",
+                        getattr(player, "name", "?"),
+                        err,
+                    )
 
         # Issue #75: Record highlights after scoring
         try:

--- a/custom_components/beatify/manifest.json
+++ b/custom_components/beatify/manifest.json
@@ -12,5 +12,5 @@
   "documentation": "https://github.com/mholzi/beatify",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/mholzi/beatify/issues",
-  "version": "3.3.2-rc13"
+  "version": "3.3.2-rc14"
 }

--- a/custom_components/beatify/www/sw.js
+++ b/custom_components/beatify/www/sw.js
@@ -6,7 +6,7 @@
  */
 'use strict';
 
-var CACHE_VERSION = 'beatify-v3.3.2-rc13';
+var CACHE_VERSION = 'beatify-v3.3.2-rc14';
 var MAX_CACHE_ITEMS = 50;
 
 // Critical assets to precache on install (minified versions only - fallback handled by HTML)

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -886,3 +886,68 @@ class TestResumeGame:
         assert self.state.phase == GamePhase.PAUSED
         await self.state.resume_game()
         assert self.state.phase == original_phase
+
+
+# ---------------------------------------------------------------------------
+# end_round resilience (#816)
+# ---------------------------------------------------------------------------
+
+
+class TestEndRoundResilience:
+    """#816: a scoring exception on one player must NOT block the round-end
+    transition. Without the defensive try/except in `_end_round_unlocked`,
+    `ScoringService.score_player_round` raising propagated up before line
+    1573 (where `phase = GamePhase.REVEAL` is set) — leaving the UI frozen
+    on the PLAYING screen with the timer at 0 and no broadcast.
+
+    The transition + broadcast must happen even if scoring partially fails.
+    """
+
+    def setup_method(self):
+        self.state = make_game_state()
+        _create_fresh_game(self.state)
+        self.state.add_player("Alice", MagicMock())
+        self.state.add_player("Bob", MagicMock())
+        self.state.start_game()
+        # Set up a current song so end_round has correct_year context.
+        self.state.current_song = {
+            "title": "Test Song",
+            "artist": "Test Artist",
+            "year": 1990,
+        }
+        self.state.round_start_time = self.state._now()
+
+    @pytest.mark.asyncio
+    async def test_end_round_completes_when_scoring_one_player_throws(self):
+        """If ScoringService.score_player_round throws on one player,
+        the round STILL transitions to REVEAL and the broadcast still fires.
+        """
+        broadcast = AsyncMock()
+        self.state.set_round_end_callback(broadcast)
+
+        with patch(
+            "custom_components.beatify.game.scoring.ScoringService.score_player_round",
+            side_effect=AttributeError("simulated state corruption"),
+        ):
+            await self.state.end_round()
+
+        # Phase MUST have transitioned despite the scoring exception.
+        assert self.state.phase == GamePhase.REVEAL
+        # Broadcast MUST have been called so the UI updates.
+        broadcast.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_end_round_completes_when_apply_closest_wins_throws(self):
+        """Closest-wins exception path: same defensive guarantee."""
+        self.state.closest_wins_mode = True
+        broadcast = AsyncMock()
+        self.state.set_round_end_callback(broadcast)
+
+        with patch(
+            "custom_components.beatify.game.scoring.ScoringService.apply_closest_wins",
+            side_effect=ValueError("simulated bad state"),
+        ):
+            await self.state.end_round()
+
+        assert self.state.phase == GamePhase.REVEAL
+        broadcast.assert_awaited_once()


### PR DESCRIPTION
## Summary

@mholzi reported on rc13 that the timer hit 0 (round 9 of 199) but the UI stayed frozen on the playing screen — no transition to REVEAL, no broadcast. See screenshot in #816.

## Root cause

The scoring loop in `_end_round_unlocked` was NOT wrapped in try/except:
- \`ScoringService.score_player_round\` × every player (lines 1467-1481)
- \`apply_closest_wins\` (line 1485)
- The \`round_results.append\` loop (lines 1494-1505)

By round 9 of a long playlist, accumulated state edge cases (a player with an unusual challenge field, a corrupted timer, etc.) could throw mid-loop, propagating up and aborting \`_end_round_unlocked\` **before** line 1573 where phase is set to REVEAL. Phase stayed \`PLAYING\`, no broadcast fired, UI stuck.

To make matters worse: the timer task that calls \`end_round\` had no done-callback, so the asyncio Task died in \`done with exception\` state but nobody called \`task.result()\`. **Zero diagnostic in the logs** — pure silent failure.

## Fix

**Defensive wraps around scoring** in `_end_round_unlocked`:
- Per-player try/except around `score_player_round` — one failed player loses their score for the round (logged loudly) but the round still ends.
- Try/except around `apply_closest_wins`.
- Try/except around the `round_results.append` loop.

**Timer-task done-callback** on every timer creation site (3 places: `RoundManager.initialize_round`, `confirm_intro_splash`, `GameState.resume_game`). Surfaces any silent task crash with full stack trace. Future occurrences of this class of bug leave a clear trail.

## Versions
- `manifest.json` + `sw.js CACHE_VERSION` → `3.3.2-rc14`. No frontend asset changes.

## Test plan
- [x] `pytest tests/unit/` — 442 passed (+2 new), 1 xfailed.
- [x] `ruff check` + `ruff format --check` — clean.
- [x] 2 new tests in `TestEndRoundResilience`: one verifies round still ends when `score_player_round` throws; one verifies same for `apply_closest_wins`. Both assert `phase == REVEAL` and `broadcast_state` was called.
- [ ] @mholzi retests on rc14: timer should reliably advance to REVEAL even on the round that previously got stuck.

## Note: still doesn't tell us WHAT exactly was throwing on round 9

This PR makes the round-end transition resilient to *any* scoring exception, but it doesn't identify the original throwing line. With the new task-failure callback, the next time this happens we'll have a full stack trace in the logs — pointing at the specific player/song/state combo that triggered it. Worth filing a follow-up cleanup once we have that data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)