### PR TITLE
fix(wizard): use detectBrowserLanguage() instead of getLanguage() (#822 part 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to Beatify are documented here. For detailed release notes, 
 
 ## [Unreleased]
 
+## [3.3.2-rc18] - 2026-04-28
+
+### Fixed
+- **Wizard "Game language" default actually works now (#822 part 2).** The rc17 fix used `BeatifyI18n.getLanguage()` to read the current UI language, but `admin.js:loadSavedSettings()` runs on every page load and calls `BeatifyI18n.setLanguage(settings.language)` to apply the saved language preference. For a user with `navigator.language='de-DE'` and a stale `settings.language='en'` (from any pre-rc15 wizard run), the auto-detection's `'de'` got silently overridden to `'en'` BEFORE the wizard opened — so `getLanguage()` returned `'en'` and the rc17 fix selected the English chip. Now using `BeatifyI18n.detectBrowserLanguage()` instead — a pure read of `navigator.language`, no session state, no race. The user's browser language wins as the wizard default; explicit chip-tap during the wizard still overrides and persists.
+
+### For contributors
+- Bumped manifest + `sw.js CACHE_VERSION` → `3.3.2-rc18`. Bumped `wizard.js` cache-buster in `admin.html` to `3.3.2-rc18`. No CSS or other JS changes.
+- 442 tests pass, 1 xfailed.
+
 ## [3.3.2-rc17] - 2026-04-28
 
 ### Fixed

--- a/custom_components/beatify/manifest.json
+++ b/custom_components/beatify/manifest.json
@@ -12,5 +12,5 @@
   "documentation": "https://github.com/mholzi/beatify",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/mholzi/beatify/issues",
-  "version": "3.3.2-rc17"
+  "version": "3.3.2-rc18"
 }

--- a/custom_components/beatify/www/admin.html
+++ b/custom_components/beatify/www/admin.html
@@ -1095,7 +1095,7 @@
     <!-- Story 44.1: Playlist requests module -->
     <script src="/beatify/static/js/playlist-requests.min.js?v=3.3.1"></script>
     <script type="module" src="/beatify/static/js/playlist-hub.js?v=3.3.1"></script>
-    <script type="module" src="/beatify/static/js/wizard.js?v=3.3.2-rc17"></script>
+    <script type="module" src="/beatify/static/js/wizard.js?v=3.3.2-rc18"></script>
     <script src="/beatify/static/js/admin.min.js?v=3.3.2-rc15"></script>
     <script src="/beatify/static/js/party-lights.min.js?v=3.3.1"></script>
     <script src="/beatify/static/js/tts-settings.js?v=3.3.2-rc1"></script>

--- a/custom_components/beatify/www/js/wizard.js
+++ b/custom_components/beatify/www/js/wizard.js
@@ -1037,22 +1037,30 @@ export async function show(stepOverride) {
             if (s.provider) chosenProvider = s.provider;
             if (s.difficulty) chosenDifficulty = s.difficulty;
             if (s.duration) chosenDuration = s.duration;
-            // #815 + #822: prefer the CURRENT UI language as the game-language
-            // default. The saved value only takes precedence if the UI
-            // language can't be determined.
+            // #815 + #822: prefer the BROWSER's language as the game-language
+            // default. Saved value only wins if browser detection isn't
+            // available.
             //
-            // Why: a user with German UI saw "English" preselected in the
-            // game-language pills because a previous wizard run had saved
-            // language='en' — even after rc15 corrected the first-time
-            // default. People treat UI language as their canonical signal,
-            // and saved game-language is usually a stale leftover. Power
-            // users who actually want game language ≠ UI language can tap
-            // the chip during the wizard; that explicit tap re-saves and
-            // the next wizard entry will see UI=game both times.
+            // Why navigator.language (via detectBrowserLanguage), not
+            // BeatifyI18n.getLanguage()?  Earlier rc15/rc17 attempts used
+            // getLanguage() but `admin.js:loadSavedSettings()` calls
+            // BeatifyI18n.setLanguage(settings.language) on every page
+            // load — which silently overrides the auto-detected language
+            // with whatever's in localStorage. A user with `navigator
+            // .language='de-DE'` plus stale settings.language='en' from a
+            // pre-rc15 wizard run would see currentLanguage='en' by the
+            // time the wizard opened, and the rc17 fix returned 'en' too.
+            // detectBrowserLanguage() is a pure read of navigator.language
+            // — no session state, no race.
+            //
+            // Power users who actually want game-language ≠ browser-
+            // language can tap the chip during the wizard; that explicit
+            // tap re-saves and persists across reloads via the chip
+            // handler in wizard.js's _renderChipGroup callback.
             let _resolvedLang = null;
             try {
-                if (window.BeatifyI18n && typeof window.BeatifyI18n.getLanguage === 'function') {
-                    _resolvedLang = window.BeatifyI18n.getLanguage();
+                if (window.BeatifyI18n && typeof window.BeatifyI18n.detectBrowserLanguage === 'function') {
+                    _resolvedLang = window.BeatifyI18n.detectBrowserLanguage();
                 }
             } catch (e) { /* ignore */ }
             if (!_resolvedLang && s.language) _resolvedLang = s.language;

--- a/custom_components/beatify/www/sw.js
+++ b/custom_components/beatify/www/sw.js
@@ -6,7 +6,7 @@
  */
 'use strict';
 
-var CACHE_VERSION = 'beatify-v3.3.2-rc17';
+var CACHE_VERSION = 'beatify-v3.3.2-rc18';
 var MAX_CACHE_ITEMS = 50;
 
 // Critical assets to precache on install (minified versions only - fallback handled by HTML)


### PR DESCRIPTION
## Summary

Reopen of #822 — rc17's fix didn't actually work. @mholzi confirmed the wizard still preselected English on his German install.

## Root cause

The rc17 fix used \`BeatifyI18n.getLanguage()\` to read the current UI language. But \`admin.js:loadSavedSettings()\` runs on every page load and calls \`BeatifyI18n.setLanguage(settings.language)\` to apply the saved preference.

A user with \`navigator.language='de-DE'\` but a stale \`settings.language='en'\` (from any pre-rc15 wizard run) had this sequence on every reload:

1. \`i18n.init()\` → auto-detects 'de' from navigator.language → \`currentLanguage='de'\`
2. \`loadSavedSettings()\` → reads \`settings.language='en'\` → \`setLanguage('en')\` → \`currentLanguage='en'\` (silently overridden)
3. User opens wizard → my rc17 fix calls \`getLanguage()\` → returns 'en' → English chip selected

## Fix

Use \`BeatifyI18n.detectBrowserLanguage()\` instead — a pure read of \`navigator.language\` with no session state, no race. The browser's language wins as the wizard default.

Explicit chip-tap during the wizard still overrides and persists (the chip handler in \`_renderChipGroup\` saves the explicit choice).

## Versions
- \`manifest.json\` + \`sw.js CACHE_VERSION\` → \`3.3.2-rc18\`
- \`wizard.js\` cache-buster bumped in \`admin.html\` → rc18

## Test plan
- [x] \`pytest tests/unit/\` — 442 passed
- [x] \`ruff check\` + \`ruff format --check\` — clean
- [ ] @mholzi: open wizard with browser/OS in German + stale localStorage → German chip should be active

🤖 Generated with [Claude Code](https://claude.com/claude-code)