### PR TITLE
data: fix 10 broken URIs in top100-allertijden-nederlandstalig (#828)

### DIFF
--- a/custom_components/beatify/playlists/community/top100-allertijden-nederlandstalig.json
+++ b/custom_components/beatify/playlists/community/top100-allertijden-nederlandstalig.json
@@ -1,6 +1,6 @@
 {
   "name": "Top 100 Dutch Classics 🇳🇱",
-  "version": "1.7",
+  "version": "1.8",
   "tags": [
     "nederlandstalig",
     "dutch",
@@ -1606,7 +1606,6 @@
       "fun_fact": "Toen Ik Je Zag is a romantic Dutch pop classic from 1997 that captured the feeling of love at first sight with a simple, timeless melody. Hero was one of the notable Dutch pop acts of the late 1990s. The song has remained a sentimental favourite on Dutch radio.",
       "fun_fact_de": "Toen Ik Je Zag ist ein romantischer niederländischer Popklassiker von 1997, der das Gefühl der Liebe auf den ersten Blick mit einer einfachen, zeitlosen Melodie einfängt.",
       "fun_fact_es": "Toen Ik Je Zag es un romántico clásico pop holandés de 1997 que capturó el sentimiento del amor a primera vista.",
-      "uri_apple_music": "applemusic://track/1442586411",
       "uri_youtube_music": "https://music.youtube.com/watch?v=-kejeU8dnzE",
       "uri_tidal": "tidal://track/15755985",
       "fun_fact_fr": "Toen Ik Je Zag est un classique pop romantique néerlandais de 1997 qui a capturé le sentiment du coup de foudre.",
@@ -2488,7 +2487,6 @@
       "fun_fact": "Toppertje! became the unofficial anthem of the Dutch Toppers concerts, wildly popular entertainment spectacles featuring Gordon, Gerard Joling and Jan Smit. The upbeat, campy track perfectly captured the over-the-top spirit of the Toppers brand. It became one of the most recognisable Dutch party tracks of the mid-2000s.",
       "fun_fact_de": "Toppertje! wurde die inoffizielle Hymne der niederländischen Toppers-Konzerte mit Gordon, Gerard Joling und Jan Smit.",
       "fun_fact_es": "Toppertje! se convirtió en el himno no oficial de los conciertos Toppers holandeses con Gordon, Gerard Joling y Jan Smit.",
-      "uri_youtube_music": "https://music.youtube.com/watch?v=mZsjbj3R7Yc",
       "fun_fact_fr": "Toppertje! est devenu l'hymne non officiel des concerts Toppers néerlandais avec Gordon, Gerard Joling et Jan Smit.",
       "fun_fact_nl": "Toppertje! werd het officieuze volkslied van de Nederlandse Toppers-concerten, razend populaire entertainmentspektakels met Gordon, Gerard Joling en Jan Smit. Het upbeat, campy nummer vatte perfect de over-the-top spirit van het merk Toppers. Het werd een van de meest herkenbare Nederlandse feestnummers van midden jaren 2000.",
       "awards_nl": []
@@ -2548,7 +2546,6 @@
       "fun_fact_fr": "Smoorverliefd est l'un des titres les plus joyeux de Snelle, une célébration du sentiment vertigineux du nouvel amour, sorti en 2020.",
       "fun_fact_nl": "Smoorverliefd is een van Snelle's meest vrolijke tracks, een viering van het duizelingwekkende, alles verterende gevoel van een nieuwe liefde, uitgebracht in 2020. Het werd een streaminghit en een feelgood anthem voor een generatie. Snelle's vermogen om Nederlandstalige pop fris en authentiek te laten aanvoelen, spat er vanaf.",
       "awards_nl": [],
-      "uri_apple_music": "applemusic://track/1493379541",
       "uri_youtube_music": "https://music.youtube.com/watch?v=LDDy4m_TiVk"
     },
     {
@@ -2647,7 +2644,6 @@
       "fun_fact_nl": "Mooi Was Die Tijd is een nostalgische ballade die terugblikt op mooie vervlogen tijden en een van de meest geliefde liedjes van Corry Konings. Corry Konings is een van de ware koninginnen van de Nederlandstalige populaire muziek met een carrière van meer dan vijf decennia. Het nummer vindt weerklank bij iedereen die wel eens terugkijkt op een gouden hoofdstuk in zijn of haar leven.",
       "awards_nl": [],
       "uri_apple_music": "applemusic://track/1371915839",
-      "uri_youtube_music": "https://music.youtube.com/watch?v=ioljeGS5UhY",
       "isrc": "NLA241801047",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1371915839",
@@ -2753,9 +2749,7 @@
       "fun_fact_es": "Mijn Gebed es una canción pop holandesa con influencia gospel de 1970 que mostró la poderosa voz de D.C. Lewis.",
       "fun_fact_fr": "Mijn Gebed est une chanson pop néerlandaise aux accents gospel de 1970 qui a mis en valeur la voix puissante de D.C. Lewis.",
       "fun_fact_nl": "Mijn Gebed is een gospel-achtig Nederlandstalig popliedje uit 1970 dat de krachtige, soulvolle stem van D.C. Lewis liet horen. Het nummer werd een geliefde klassieker in de Nederlandstalige pop met zijn spirituele thema van gebed en geloof. Het blijft een van de meest kenmerkende Nederlandstalige popopnames van de vroege jaren 1970.",
-      "awards_nl": [],
-      "uri_apple_music": "applemusic://track/1443374286",
-      "uri_youtube_music": "https://music.youtube.com/watch?v=JS9nJtfx70I"
+      "awards_nl": []
     },
     {
       "year": 2020,
@@ -2849,7 +2843,6 @@
       "fun_fact_nl": "Schudden was een van de meest energieke Nederlandse hiphoptracks van 2001 en vestigde Def Rhymz als een belangrijke kracht in de Nederlandse urban muziek. De onweerstaanbare oproep om te dansen maakte het een club- en radiofavoriet. Def Rhymz groeide uit tot een van de meest gerespecteerde figuren in de Nederlandse hiphopgeschiedenis.",
       "awards_nl": [],
       "uri_apple_music": "applemusic://track/1442289020",
-      "uri_youtube_music": "https://music.youtube.com/watch?v=-cnWgvG_e3o",
       "isrc": "NLA350000241",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1442289020",
@@ -2952,7 +2945,6 @@
       "fun_fact_fr": "Zij Wil Mij est un morceau confiant et autonomisant de FLEMMING explorant les thèmes du désir.",
       "fun_fact_nl": "Zij Wil Mij is een zelfverzekerd, krachtig nummer van FLEMMING dat thema's als verlangen en zelfverzekerdheid verkent. Het werd uitgebracht in 2021 en liet zien dat ze in staat is om sfeervolle pop te maken met een sterk standpunt. Het nummer werd een van haar meest gevierde nummers.",
       "awards_nl": [],
-      "uri_apple_music": "applemusic://track/1600444510",
       "uri_youtube_music": "https://music.youtube.com/watch?v=-mABxYPPqYc"
     },
     {
@@ -3392,7 +3384,6 @@
       "fun_fact_fr": "Hallo est devenu un énorme hit viral pour Antoon en 2022, dominant les charts néerlandais avec son ode nostalgique et chaleureuse.",
       "fun_fact_nl": "Hallo werd in 2022 een enorme viral hit voor Antoon, die de Nederlandse hitlijsten aanvoerde met zijn warme, nostalgische ode aan iemand uit het verleden. Antoon is een van de meest succesvolle jonge Nederlandse popartiesten, bekend om zijn pakkende melodieën en relativerende teksten. Het nummer werd een van de meest gestreamde Nederlandse tracks van het jaar.",
       "awards_nl": [],
-      "uri_apple_music": "applemusic://track/1610314688",
       "uri_youtube_music": "https://music.youtube.com/watch?v=8EAUAGtTclo"
     },
     {
@@ -3416,7 +3407,6 @@
       "fun_fact_fr": "De Bostella est un classique néerlandais animé et dansant de 1967 avec un rythme irrésistible à influences latines.",
       "fun_fact_nl": "De Bostella is een levendige, dansbare Nederlandse klassieker uit 1967 met een onweerstaanbaar ritme met latin invloeden. Johnny was een van de populaire Nederlandse entertainers uit de jaren 60 die een upbeat, internationaal tintje aan de Nederlandstalige popmuziek gaf. Het nummer blijft een geliefde vaste waarde op Nederlandse nostalgische feest-afspeellijsten.",
       "awards_nl": [],
-      "uri_apple_music": "applemusic://track/1502646456",
       "uri_youtube_music": "https://music.youtube.com/watch?v=sJUsGo_v4_c"
     },
     {


### PR DESCRIPTION
Closes #828. 

Fixed 10 broken provider-specific URIs identified in the playlist health check:

**Removed URIs:**
- 6 dead Apple Music track IDs (Hero, Snelle, FLEMMING, Antoon, Johnny, D.C. Lewis)
- 4 dead YouTube Music video IDs (Corry Konings, D.C. Lewis, Def Rhymz, Guillermo)

**Action taken:** Removed the dead URIs while keeping working Spotify URIs intact. These tracks remain playable via Spotify while the unavailable provider-specific URIs have been cleaned up.

**Version bump:** 1.7 → 1.8