### PR TITLE
data: fix 1 dead Apple Music URI in eurovision-winners (#830)

### DIFF
--- a/custom_components/beatify/playlists/eurovision-winners.json
+++ b/custom_components/beatify/playlists/eurovision-winners.json
@@ -1,6 +1,6 @@
 {
   "name": "Eurovision Winners (1956-2025)",
-  "version": "1.7",
+  "version": "1.8",
   "tags": [
     "eurovision",
     "contest",
@@ -674,7 +674,7 @@
       "fun_fact_de": "De Troubadour war Teil des einzigen vierfachen Gleichstands in der Eurovision-Geschichte. Die Niederlande, Frankreich, Spanien und das Vereinigte Konigreich teilten sich mit jeweils 18 Punkten den ersten Platz. Dieses umstrittene Ergebnis fuhrte zu Regelanderungen, um zukunftige Gleichstande zu verhindern.",
       "fun_fact_es": "De Troubadour fue parte del unico empate a cuatro en la historia de Eurovision. Paises Bajos, Francia, Espana y Reino Unido compartieron el primer lugar con 18 puntos cada uno. Este resultado controversial llevo a cambios en las reglas para evitar futuros empates.",
       "fun_fact_fr": "De Troubadour a fait partie du seul quadruple ex aequo de l'histoire de l'Eurovision. Les Pays-Bas, la France, l'Espagne et le Royaume-Uni se sont partage la premiere place avec 18 points chacun. Ce resultat controverse a entraine des modifications du reglement pour eviter de futurs ex aequo.",
-      "uri_apple_music": "applemusic://track/1442813455",
+      "uri_apple_music": "applemusic://track/1622858673",
       "uri_youtube_music": "https://music.youtube.com/watch?v=b7PlOtvIM-g",
       "uri_tidal": "tidal://track/15754206",
       "uri_deezer": "deezer://track/1743404927",


### PR DESCRIPTION
Closes #830. 

Replaced 1 dead Apple Music URI (Lenny Kuhr — De Troubadour) with the correct track ID verified at https://music.apple.com/us/song/de-troubadour/1622858673

- Bumped playlist version from 1.7 to 1.8
- Fixed Apple Music URI: 1442813455 → 1622858673

This was the only confirmed issue found in the Eurovision Winners playlist. 11 other flagged URIs were reviewed and cleared as false positives (language variants, version tags, accent differences).