### PR TITLE
data: fix 2 broken URIs in one-hit-wonders (#843)

### DIFF
--- a/custom_components/beatify/playlists/one-hit-wonders.json
+++ b/custom_components/beatify/playlists/one-hit-wonders.json
@@ -1,6 +1,6 @@
 {
   "name": "One-Hit Wonders",
-  "version": "1.4",
+  "version": "1.5",
   "tags": [
     "one-hit",
     "classics",
@@ -1212,7 +1212,7 @@
     },
     {
       "year": 1982,
-      "uri": "spotify:track:78ocJAEFOYKVjYgXZ8fggD",
+      "uri": "spotify:track:6J2rMSRhgb4HuX6dWgM3nJ",
       "artist": "Modern English",
       "alt_artists": [
         "Depeche Mode",
@@ -1364,7 +1364,7 @@
     },
     {
       "year": 1983,
-      "uri": "spotify:track:6lXKNdOsnaLv9LwulZbxNl",
+      "uri": "spotify:track:5xhL6QuD2DvJVeiwmGYHBv",
       "artist": "Peter Schilling",
       "alt_artists": [
         "Depeche Mode",


### PR DESCRIPTION
Closes #843. Replaced 2 wrong Spotify URIs and bumped playlist version to 1.5.

- **Modern English — I Melt With You**: replaced re-recorded version (`78ocJAEFOYKVjYgXZ8fggD`) with original 1982 recording (`6J2rMSRhgb4HuX6dWgM3nJ`)
- **Peter Schilling — Major Tom (Coming Home)**: replaced German version "völlig losgelöst" (`6lXKNdOsnaLv9LwulZbxNl`) with English version "Coming Home" (`5xhL6QuD2DvJVeiwmGYHBv`)