### PR TITLE
data: fix 2 broken YouTube Music URIs in greatest-metal-songs (#845)

### DIFF
--- a/custom_components/beatify/playlists/community/greatest-metal-songs.json
+++ b/custom_components/beatify/playlists/community/greatest-metal-songs.json
@@ -1,6 +1,6 @@
 {
   "name": "Greatest Metal Songs of All Time 🤘",
-  "version": "1.6",
+  "version": "1.7",
   "tags": [
     "metal",
     "rock",
@@ -1542,7 +1542,7 @@
       "fun_fact_es": "Lamb of God es una de las bandas de metal más importantes de los años 2000. El vocalista Randy Blythe fue arrestado en la República Checa en 2012 por cargos de homicidio involuntario relacionados con un incidente en un concierto de 2010 — finalmente fue absuelto.",
       "fun_fact_fr": "Lamb of God est l'un des groupes de metal les plus importants des années 2000. Le chanteur Randy Blythe a été arrêté en République tchèque en 2012 sous des accusations d'homicide involontaire liées à un incident lors d'un concert de 2010 — il a finalement été acquitté.",
       "uri_apple_music": "applemusic://track/1440904907",
-      "uri_youtube_music": "https://music.youtube.com/watch?v=iFm9v0OvYua",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=iFm9v0wvEnw",
       "uri_tidal": "tidal://track/4085761",
       "fun_fact_nl": "Lamb of God is een van de belangrijkste metalbands van de jaren 2000, die samen met Mastodon en Killswitch Engage de New Wave of American Heavy Metal aanvoerde. Zanger Randy Blythe werd in 2012 in Tsjechië gearresteerd op beschuldiging van doodslag naar aanleiding van een incident tijdens een concert in 2010 - hij werd uiteindelijk vrijgesproken. Hun album Ashes of the Wake wordt beschouwd als een moderne metalklassieker.",
       "awards_nl": [
@@ -1714,7 +1714,7 @@
       "fun_fact_es": "Roots Bloody Roots abre el emblemático álbum Roots de Sepultura, que fusionó música tribal brasileña con groove metal. Partes del álbum fueron grabadas con la tribu indígena Xavante en Brasil. Fue el último álbum grabado con el vocalista Max Cavalera.",
       "fun_fact_fr": "Roots Bloody Roots ouvre le légendaire album Roots de Sepultura, qui a fusionné la musique tribale brésilienne avec le groove metal. Des parties de l'album ont été enregistrées avec la tribu indigène Xavante au Brésil. C'était le dernier album avec le chanteur Max Cavalera.",
       "uri_apple_music": "applemusic://track/576936082",
-      "uri_youtube_music": "https://music.youtube.com/watch?v=0TanJ9jf-p4",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=F_6IjeprfEs",
       "uri_tidal": "tidal://track/4085813",
       "fun_fact_nl": "Roots Bloody Roots opent Sepultura's baanbrekende album Roots, dat Braziliaanse tribale muziek versmolt met groove metal om een van de meest unieke en belangrijke metalalbums van de jaren 90 te creëren. De band nam delen van het album op met de inheemse Xavante-stam in Brazilië. Het was het laatste album dat werd opgenomen met zanger Max Cavalera voordat hij uit de band stapte.",
       "awards_nl": [


### PR DESCRIPTION
Closes #845. 

- Sepultura — Roots Bloody Roots: YouTube Music URI was pointing to \"Attitude [OFFICIAL VIDEO]\" (a different song) → replaced with `F_6IjeprfEs` (official video)
- Lamb of God — Ruin: YouTube Music URI had a typo in video ID (`iFm9v0OvYua` → `iFm9v0wvEnw`, persistent 400 error since Apr-19 run) → replaced with `iFm9v0wvEnw` (official video)

Playlist version bumped 1.6 → 1.7.