### PR TITLE
data: fix 1 broken URI in hitster-100-en-espanol (#856)

### DIFF
--- a/custom_components/beatify/playlists/community/hitster-100-en-espanol.json
+++ b/custom_components/beatify/playlists/community/hitster-100-en-espanol.json
@@ -1,6 +1,6 @@
 {
   "name": "100% en Español 🇪🇸",
-  "version": "1.5",
+  "version": "1.6",
   "tags": [
     "spanish",
     "spain",
@@ -677,7 +677,7 @@
       "fun_fact_es": "El Barrio, de Cádiz, creó una fusión única de flamenco, copla y pop — llena estadios en España pero es desconocido internacionalmente.",
       "fun_fact_fr": "El Barrio, de Cadix, a créé un mélange unique de flamenco, copla et pop — remplit les stades en Espagne mais reste inconnu à l'international.",
       "uri_apple_music": "applemusic://track/603228048",
-      "uri_youtube_music": "https://music.youtube.com/watch?v=cxZGge2KKnY",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=xIavxtPTjBA",
       "uri_tidal": "tidal://track/31852101",
       "fun_fact_nl": "El Barrio uit Cádiz pionierde met een unieke mix van flamenco, copla en pop - waarmee ze stadions vulden in Spanje terwijl ze internationaal vrijwel onbekend bleven.",
       "awards_nl": [],


### PR DESCRIPTION
Closes #856. Replaced 1 dead YouTube Music URI and bumped playlist version to 1.6.

El Barrio - Quiereme YouTube Music URI was inaccessible (API error). Replaced with official video track ID from search.

AI review completed — 6 additional wrong_track flags were dismissed as false positives (metadata reversals, version variants).