### PR TITLE
fix: respect safe-area-inset-bottom in playlist detail sheet (#855)

### DIFF
--- a/custom_components/beatify/www/css/styles.css
+++ b/custom_components/beatify/www/css/styles.css
@@ -13853,7 +13853,7 @@ body.theme-dark .your-result-stats .stat-value {
 .plh-sheet-provider b { color: var(--color-accent-secondary); font-weight: 800; }
 
 .plh-sheet-foot {
-    padding: 14px 20px;
+    padding: 14px 20px calc(14px + env(safe-area-inset-bottom, 0px)) 20px;
     background: rgba(10, 10, 18, 0.95);
     border-top: 1px solid var(--color-border-neon);
     display: flex;


### PR DESCRIPTION
## Summary
- Fixes #855 reported by @ludgerbeckmann: add/remove button at the bottom of the playlist detail sheet was clipped on iOS devices.
- Root cause: `.plh-sheet-foot` had no `env(safe-area-inset-bottom)` padding, so the footer rendered underneath the iPhone home-indicator gesture area.
- 1-line change in `custom_components/beatify/www/css/styles.css`.

## Test plan
- [ ] Open the playlist detail sheet in Chrome devtools with an iPhone 14 Pro preset and confirm the Add button sits above the home-indicator bar.
- [ ] Verify the sheet still looks correct on desktop (no extra padding when `env(safe-area-inset-bottom)` resolves to 0).
- [ ] Sanity-check on a real iPhone (HA companion app) if available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)