### PR TITLE
chore: ruff format state.py + media_player.py

### DIFF
--- a/custom_components/beatify/game/state.py
+++ b/custom_components/beatify/game/state.py
@@ -116,7 +116,9 @@ class GameState:
         self._tts_announce_winner: bool = True
         # Issue #471 Phase 1: Game Flow announcements
         self._tts_announce_round_start: bool = True
-        self._tts_announce_countdown: bool = False  # off by default — intrusive every round
+        self._tts_announce_countdown: bool = (
+            False  # off by default — intrusive every round
+        )
         self._tts_announce_time_up: bool = True
         self._tts_announce_correct_answer: bool = True
         self._tts_announce_nobody_correct: bool = True
@@ -1631,9 +1633,7 @@ class GameState:
         # round had at least one submitter and zero of them got years_off == 0.
         await self.announce_correct_answer(correct_year)
         had_submitters = any(p.submitted for p in self.players.values())
-        any_exact = any(
-            p.submitted and p.years_off == 0 for p in self.players.values()
-        )
+        any_exact = any(p.submitted and p.years_off == 0 for p in self.players.values())
         if had_submitters and not any_exact:
             await self.announce_nobody_correct()
 

--- a/custom_components/beatify/services/media_player.py
+++ b/custom_components/beatify/services/media_player.py
@@ -227,9 +227,7 @@ class MediaPlayerService:
             )
             return None
 
-    async def _safe_state_with_retry(
-        self, retries: int = 3, delay: float = 0.5
-    ):
+    async def _safe_state_with_retry(self, retries: int = 3, delay: float = 0.5):
         """Read entity state with short retry loop; for the post-timeout site
         where having a state is critical for the title-advance check.
 


### PR DESCRIPTION
## Summary
- Two files drifted out of ruff format style.
- Pure whitespace/line-wrap changes from `ruff format .` — no semantic changes.
- Unblocks the Lint (3.12) CI check that has been red on main.

## Test plan
- [ ] `ruff format --check .` passes (verified locally: 56 files already formatted).
- [ ] pytest still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)