### PR TITLE
data: fix 1 dead YouTube Music URI in top-songs-der-60er (#862)

### DIFF
--- a/custom_components/beatify/playlists/community/top-songs-der-60er.json
+++ b/custom_components/beatify/playlists/community/top-songs-der-60er.json
@@ -1,6 +1,6 @@
 {
   "name": "60s Classics 🎸",
-  "version": "1.3",
+  "version": "1.4",
   "source": "https://open.spotify.com/playlist/6rtsNFUv2UK3j78PRVMpSd",
   "tags": [
     "1960s",
@@ -1158,7 +1158,7 @@
       "fun_fact_es": "Escrita para 'Our World,' la primera transmisión de televisión por satélite en vivo global vista por 400 millones de personas. La canción fue deliberadamente escrita en compases inusuales para hacerla difícil de versionar.",
       "fun_fact_fr": "Écrite pour « Our World », la première émission télévisée mondiale en direct par satellite regardée par 400 millions de personnes. La chanson a été délibérément composée dans des mesures inhabituelles pour la rendre difficile à reprendre.",
       "uri_apple_music": "applemusic://track/1441133271",
-      "uri_youtube_music": "https://music.youtube.com/watch?v=_paPrw0gAUo",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=_7xMfIp-irg",
       "uri_tidal": "tidal://track/55130778",
       "fun_fact_nl": "Geschreven voor 'Our World', de eerste wereldwijde live satelliet TV-uitzending die door 400 miljoen mensen werd bekeken. Het nummer is met opzet geschreven in ongebruikelijke maatsoorten om het moeilijk te coveren te maken.",
       "awards_nl": [],


### PR DESCRIPTION
Closes #862. Replaced 1 dead YouTube Music URI and bumped playlist version to 1.4.

**Change:** The Beatles – All You Need Is Love
- Dead: `https://music.youtube.com/watch?v=_paPrw0gAUo` (404)
- Replacement: `https://music.youtube.com/watch?v=_7xMfIp-irg` (Remastered 2009, verified)

8 other `wrong_track` flags were reviewed by AI and dismissed as false positives (remastered/mono/stereo/single version suffixes, soundtrack attributions, lyric video variants).