### PR TITLE
feat: TTS announcements — Player Achievements, Phase 2 of 4 (#840)

### DIFF
--- a/custom_components/beatify/game/state.py
+++ b/custom_components/beatify/game/state.py
@@ -122,6 +122,15 @@ class GameState:
         self._tts_announce_time_up: bool = True
         self._tts_announce_correct_answer: bool = True
         self._tts_announce_nobody_correct: bool = True
+        # Issue #840 Phase 2: Player Achievement announcements
+        self._tts_announce_exact_guess: bool = True
+        self._tts_announce_closest_guess: bool = True
+        self._tts_announce_streak_milestone: bool = True
+        self._tts_announce_streak_broken: bool = False  # off — noisy mid-game
+        self._tts_announce_leader_change: bool = True
+        self._tts_announce_tied_first: bool = True
+        # Leader-change detection needs the prior round's leader name.
+        self._tts_previous_leader: str | None = None
         self._bg_tasks: set[asyncio.Task] = (
             set()
         )  # Issue #391: prevent GC of fire-and-forget tasks
@@ -1637,6 +1646,13 @@ class GameState:
         if had_submitters and not any_exact:
             await self.announce_nobody_correct()
 
+        # Issue #840 Phase 2: Player Achievement announcements. Wrapped so a
+        # TTS hiccup never blocks the REVEAL phase transition below.
+        try:
+            await self._announce_player_achievements(correct_year)
+        except (KeyError, AttributeError, TypeError, ValueError) as err:
+            _LOGGER.error("Phase-2 achievement announcements failed: %s", err)
+
         # Transition to REVEAL
         self._player_registry._reactions_this_phase = (
             set()
@@ -1995,6 +2011,13 @@ class GameState:
         announce_time_up: bool = True,
         announce_correct_answer: bool = True,
         announce_nobody_correct: bool = True,
+        # Issue #840 Phase 2: Player Achievement announcements
+        announce_exact_guess: bool = True,
+        announce_closest_guess: bool = True,
+        announce_streak_milestone: bool = True,
+        announce_streak_broken: bool = False,
+        announce_leader_change: bool = True,
+        announce_tied_first: bool = True,
     ) -> None:
         """Configure TTS announcement service for the game.
 
@@ -2020,6 +2043,14 @@ class GameState:
         self._tts_announce_time_up = announce_time_up
         self._tts_announce_correct_answer = announce_correct_answer
         self._tts_announce_nobody_correct = announce_nobody_correct
+        self._tts_announce_exact_guess = announce_exact_guess
+        self._tts_announce_closest_guess = announce_closest_guess
+        self._tts_announce_streak_milestone = announce_streak_milestone
+        self._tts_announce_streak_broken = announce_streak_broken
+        self._tts_announce_leader_change = announce_leader_change
+        self._tts_announce_tied_first = announce_tied_first
+        # Fresh game — no prior leader yet.
+        self._tts_previous_leader = None
 
     async def disable_tts(self) -> None:
         """Disable TTS announcements."""
@@ -2110,6 +2141,130 @@ class GameState:
             return
         message = "Nobody got it this round!"
         await self._tts_announce(message)
+
+    # ------------------------------------------------------------------
+    # Issue #840 Phase 2 — Player Achievement announcements
+    # ------------------------------------------------------------------
+
+    async def announce_exact_guess(self, player_names: list[str]) -> None:
+        """Announce players who guessed the year exactly (use case 6).
+
+        ``player_names`` is the list of players with years_off == 0 this
+        round. Single name → "Marco got it exactly right!"; multiple →
+        "Marco and Anna got it exactly right!".
+        """
+        if not self._tts_service or not self._tts_announce_exact_guess:
+            return
+        if not player_names:
+            return
+        if len(player_names) == 1:
+            message = f"{player_names[0]} got it exactly right!"
+        else:
+            names = " and ".join(player_names)
+            message = f"{names} got it exactly right!"
+        await self._tts_announce(message)
+
+    async def announce_closest_guess(self, player_name: str, year: int | None) -> None:
+        """Announce the Closest-Wins-mode round winner (use case 7)."""
+        if not self._tts_service or not self._tts_announce_closest_guess:
+            return
+        if year is None:
+            message = f"{player_name} was closest!"
+        else:
+            message = f"{player_name} was closest with {year}!"
+        await self._tts_announce(message)
+
+    async def announce_streak_milestone(self, player_name: str, streak: int) -> None:
+        """Announce a player hitting a streak milestone (use case 8)."""
+        if not self._tts_service or not self._tts_announce_streak_milestone:
+            return
+        message = f"{player_name} is on a {streak}-song streak!"
+        await self._tts_announce(message)
+
+    async def announce_streak_broken(self, player_name: str, streak: int) -> None:
+        """Announce a notable streak ending (use case 9).
+
+        Off by default — firing on every missed round mid-game is noisy.
+        Only fires for streaks worth calling out (caller gates on length).
+        """
+        if not self._tts_service or not self._tts_announce_streak_broken:
+            return
+        message = f"{player_name}'s streak ends at {streak}!"
+        await self._tts_announce(message)
+
+    async def announce_leader_change(self, player_name: str) -> None:
+        """Announce a new game leader (use case 10)."""
+        if not self._tts_service or not self._tts_announce_leader_change:
+            return
+        message = f"{player_name} just took the lead!"
+        await self._tts_announce(message)
+
+    async def announce_tied_first(self) -> None:
+        """Announce a tie at the top of the leaderboard (use case 11)."""
+        if not self._tts_service or not self._tts_announce_tied_first:
+            return
+        message = "It's a tie at the top!"
+        await self._tts_announce(message)
+
+    async def _announce_player_achievements(self, correct_year: int | None) -> None:
+        """Fire all Phase-2 achievement announcements for the round just scored.
+
+        Called from end_round() right after the Phase-1 REVEAL announcements,
+        before the phase transition. Reads post-scoring player state.
+
+        Ordering is intentional — accuracy first (exact / closest), then
+        streaks, then standings — so the audio narrates the round in the
+        order a host would describe it.
+        """
+        if not self._tts_service:
+            return
+        players = list(self.players.values())
+
+        # Use case 6 — exact guesses.
+        exact = [p.name for p in players if p.submitted and p.years_off == 0]
+        if exact:
+            await self.announce_exact_guess(exact)
+
+        # Use case 7 — Closest-Wins round winner. Only meaningful in that
+        # mode, and only when nobody was exact (otherwise #6 already covered
+        # it). The closest player is the one with the smallest years_off
+        # who still has a non-zero round_score after the closest-wins sweep.
+        if self.closest_wins_mode and not exact:
+            submitted = [p for p in players if p.submitted and p.years_off is not None]
+            if submitted:
+                winner = min(submitted, key=lambda p: p.years_off)
+                if winner.round_score > 0:
+                    await self.announce_closest_guess(winner.name, correct_year)
+
+        # Use case 8 — streak milestones. streak_bonus is non-zero only on
+        # the exact round a milestone (3/5/10/15/20/25) is reached.
+        for p in players:
+            if p.streak_bonus > 0:
+                await self.announce_streak_milestone(p.name, p.streak)
+
+        # Use case 9 — streak broken. previous_streak holds the pre-reset
+        # length for players who missed this round. Gate at >= 3 so a
+        # one-off miss after a short run doesn't trigger chatter.
+        for p in players:
+            if p.streak == 0 and p.previous_streak >= 3:
+                await self.announce_streak_broken(p.name, p.previous_streak)
+
+        # Use cases 10 + 11 — leader change / tie at the top.
+        leaderboard = sorted(players, key=lambda p: p.score, reverse=True)
+        if leaderboard and leaderboard[0].score > 0:
+            top_score = leaderboard[0].score
+            leaders = [p for p in leaderboard if p.score == top_score]
+            if len(leaders) > 1:
+                await self.announce_tied_first()
+                self._tts_previous_leader = None
+            else:
+                new_leader = leaders[0].name
+                if new_leader != self._tts_previous_leader:
+                    # Suppress the very first leader announcement — round 1
+                    # always "changes" the leader from nobody.
+                    if self._tts_previous_leader is not None:
+                        await self.announce_leader_change(new_leader)
+                self._tts_previous_leader = new_leader
 
     def adjust_volume(self, direction: str) -> float:
         """

--- a/custom_components/beatify/server/game_views.py
+++ b/custom_components/beatify/server/game_views.py
@@ -338,6 +338,20 @@ class StartGameView(RateLimitMixin, HomeAssistantView):
                     announce_nobody_correct=tts_config.get(
                         "announce_nobody_correct", True
                     ),
+                    announce_exact_guess=tts_config.get("announce_exact_guess", True),
+                    announce_closest_guess=tts_config.get(
+                        "announce_closest_guess", True
+                    ),
+                    announce_streak_milestone=tts_config.get(
+                        "announce_streak_milestone", True
+                    ),
+                    announce_streak_broken=tts_config.get(
+                        "announce_streak_broken", False
+                    ),
+                    announce_leader_change=tts_config.get(
+                        "announce_leader_change", True
+                    ),
+                    announce_tied_first=tts_config.get("announce_tied_first", True),
                 )
                 await game_state.announce_game_start()
 

--- a/custom_components/beatify/www/js/tts-settings.js
+++ b/custom_components/beatify/www/js/tts-settings.js
@@ -17,6 +17,14 @@
     var announceTimeUp = true;
     var announceCorrectAnswer = true;
     var announceNobodyCorrect = true;
+    // #840 Phase 2: Player Achievement toggles. streak-broken defaults off —
+    // firing on every missed round mid-game is noisy.
+    var announceExactGuess = true;
+    var announceClosestGuess = true;
+    var announceStreakMilestone = true;
+    var announceStreakBroken = false;
+    var announceLeaderChange = true;
+    var announceTiedFirst = true;
 
     function loadState() {
         try {
@@ -30,6 +38,12 @@
             announceTimeUp = saved.announce_time_up !== false;
             announceCorrectAnswer = saved.announce_correct_answer !== false;
             announceNobodyCorrect = saved.announce_nobody_correct !== false;
+            announceExactGuess = saved.announce_exact_guess !== false;
+            announceClosestGuess = saved.announce_closest_guess !== false;
+            announceStreakMilestone = saved.announce_streak_milestone !== false;
+            announceStreakBroken = saved.announce_streak_broken === true;
+            announceLeaderChange = saved.announce_leader_change !== false;
+            announceTiedFirst = saved.announce_tied_first !== false;
         } catch (e) { /* ignore */ }
     }
 
@@ -44,7 +58,13 @@
                 announce_countdown: announceCountdown,
                 announce_time_up: announceTimeUp,
                 announce_correct_answer: announceCorrectAnswer,
-                announce_nobody_correct: announceNobodyCorrect
+                announce_nobody_correct: announceNobodyCorrect,
+                announce_exact_guess: announceExactGuess,
+                announce_closest_guess: announceClosestGuess,
+                announce_streak_milestone: announceStreakMilestone,
+                announce_streak_broken: announceStreakBroken,
+                announce_leader_change: announceLeaderChange,
+                announce_tied_first: announceTiedFirst
             }));
         } catch (e) { /* ignore */ }
     }
@@ -132,7 +152,14 @@
             ['tts-announce-countdown', function(v) { announceCountdown = v; }, function() { return announceCountdown; }],
             ['tts-announce-time-up', function(v) { announceTimeUp = v; }, function() { return announceTimeUp; }],
             ['tts-announce-correct-answer', function(v) { announceCorrectAnswer = v; }, function() { return announceCorrectAnswer; }],
-            ['tts-announce-nobody-correct', function(v) { announceNobodyCorrect = v; }, function() { return announceNobodyCorrect; }]
+            ['tts-announce-nobody-correct', function(v) { announceNobodyCorrect = v; }, function() { return announceNobodyCorrect; }],
+            // #840 Phase 2: Player Achievement toggles
+            ['tts-announce-exact-guess', function(v) { announceExactGuess = v; }, function() { return announceExactGuess; }],
+            ['tts-announce-closest-guess', function(v) { announceClosestGuess = v; }, function() { return announceClosestGuess; }],
+            ['tts-announce-streak-milestone', function(v) { announceStreakMilestone = v; }, function() { return announceStreakMilestone; }],
+            ['tts-announce-streak-broken', function(v) { announceStreakBroken = v; }, function() { return announceStreakBroken; }],
+            ['tts-announce-leader-change', function(v) { announceLeaderChange = v; }, function() { return announceLeaderChange; }],
+            ['tts-announce-tied-first', function(v) { announceTiedFirst = v; }, function() { return announceTiedFirst; }]
         ].forEach(function(pair) {
             var el = document.getElementById(pair[0]);
             if (el) {
@@ -197,7 +224,14 @@
             announce_countdown: announceCountdown,
             announce_time_up: announceTimeUp,
             announce_correct_answer: announceCorrectAnswer,
-            announce_nobody_correct: announceNobodyCorrect
+            announce_nobody_correct: announceNobodyCorrect,
+            // #840 Phase 2: Player Achievement toggles
+            announce_exact_guess: announceExactGuess,
+            announce_closest_guess: announceClosestGuess,
+            announce_streak_milestone: announceStreakMilestone,
+            announce_streak_broken: announceStreakBroken,
+            announce_leader_change: announceLeaderChange,
+            announce_tied_first: announceTiedFirst
         };
     };
 


### PR DESCRIPTION
Closes #840. Phase 2 of 4 in the TTS announcements expansion (parent: #471, Phase 1 shipped in v3.3.4).

## Six new announcements
| # | Event | Example |
|---|---|---|
| 6 | Exact guess | "Marco got it exactly right!" |
| 7 | Closest guess (Closest-Wins mode) | "Anna was closest with 1985!" |
| 8 | Streak milestone | "Anna is on a 5-song streak!" |
| 9 | Streak broken | "Marco's streak ends at 7!" |
| 10 | Leader change | "Sara just took the lead!" |
| 11 | Tied for first | "It's a tie at the top!" |

## Plumbing
- `state.py` — 6 `_tts_announce_*` flags + `_tts_previous_leader`, 6 `configure_tts()` params, 6 `announce_*` methods, one `_announce_player_achievements()` orchestrator called from `end_round()` after the Phase-1 REVEAL announcements. try/except-wrapped so a TTS hiccup never blocks the phase transition.
- `game_views.py` — forwards the 6 new `tts_config` keys.
- `tts-settings.js` — 6 toggle variables through loadState / saveState / `_ttsConfig()` / the init binding loop.

## Detection (post-scoring, at REVEAL)
- **Exact**: `years_off == 0`.
- **Closest**: Closest-Wins mode + nobody exact → min `years_off` with surviving `round_score > 0`.
- **Streak milestone**: `streak_bonus > 0`.
- **Streak broken**: `streak == 0 and previous_streak >= 3`.
- **Leader change**: top of leaderboard vs `_tts_previous_leader`; round-1 "change from nobody" suppressed; tie fires `announce_tied_first` instead.

`announce_streak_broken` defaults **off** (noisiness note in the issue); the rest default on.

## Notes
- **UI**: like Phase 1's 5 game-flow toggles, these 6 are wired + persisted in `tts-settings.js` but no `admin.html` toggle rows are added. Exposing the full TTS toggle matrix in the UI is a separate task (should cover Phase 1 too).
- **i18n**: announcement strings are hard-coded English, matching Phase 1. Localizing TTS copy is cross-cutting and out of scope here.

## Test plan
- [ ] Play a round where one player nails the year — hear the exact-guess line.
- [ ] Hit a 3/5/10-streak — hear the milestone line; then miss a round — hear streak-broken (after enabling the toggle).
- [ ] Watch the lead change hands — hear leader-change; force a tie — hear tied-first.
- [ ] Closest-Wins mode round with no exact guess — hear the closest-guess line.
- [ ] pytest 172 passed (tts/scoring/state) · vitest 35 passed · ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)