### PR TITLE
feat: wizard TTS hint explains how to add the Google Translate TTS integration

### DIFF
--- a/custom_components/beatify/www/i18n/de.json
+++ b/custom_components/beatify/www/i18n/de.json
@@ -834,7 +834,7 @@
         "desc": "TTS ruft Rundennummern, Sieger und Fun Facts aus.",
         "unavailable": "Kein TTS-Dienst in Home Assistant registriert.",
         "entityLabel": "TTS-Dienst (Entity-ID)",
-        "entityHint": "Aus Home Assistant → Entwicklertools → Zustände kopieren (Filter: tts.)",
+        "entityHint": "Noch kein TTS-Dienst? In Home Assistant: Einstellungen → Geräte & Dienste → Integration hinzufügen → 'Google Translate text-to-speech' (gratis, kein API-Key). Dann die erzeugte tts.*-Entity hier eintragen.",
         "announce": "Ansagen",
         "announceStart": "Spielstart",
         "announceWinner": "Rundengewinner",

--- a/custom_components/beatify/www/i18n/en.json
+++ b/custom_components/beatify/www/i18n/en.json
@@ -834,7 +834,7 @@
         "desc": "TTS calls out round numbers, winners, and fun facts.",
         "unavailable": "No TTS service registered in Home Assistant.",
         "entityLabel": "TTS service (entity ID)",
-        "entityHint": "Copy from Home Assistant → Developer Tools → States (filter: tts.)",
+        "entityHint": "No TTS service yet? In Home Assistant: Settings → Devices & Services → Add Integration → 'Google Translate text-to-speech' (free, no API key). Then enter the tts.* entity it creates here.",
         "announce": "Announce",
         "announceStart": "Game start",
         "announceWinner": "Round winner",

--- a/custom_components/beatify/www/i18n/es.json
+++ b/custom_components/beatify/www/i18n/es.json
@@ -834,7 +834,7 @@
         "desc": "TTS anuncia número de ronda, ganadores y datos curiosos.",
         "unavailable": "No hay servicio TTS registrado en Home Assistant.",
         "entityLabel": "Servicio TTS (ID de entidad)",
-        "entityHint": "Copia desde Home Assistant → Herramientas para desarrolladores → Estados (filtro: tts.)",
+        "entityHint": "¿Aún no tienes servicio TTS? En Home Assistant: Ajustes → Dispositivos y servicios → Añadir integración → 'Google Translate text-to-speech' (gratis, sin clave API). Luego introduce aquí la entidad tts.* creada.",
         "announce": "Anunciar",
         "announceStart": "Inicio del juego",
         "announceWinner": "Ganador de ronda",

--- a/custom_components/beatify/www/i18n/fr.json
+++ b/custom_components/beatify/www/i18n/fr.json
@@ -834,7 +834,7 @@
         "desc": "Le TTS annonce le numéro de manche, les gagnants et les anecdotes.",
         "unavailable": "Aucun service TTS enregistré dans Home Assistant.",
         "entityLabel": "Service TTS (ID d'entité)",
-        "entityHint": "Copie depuis Home Assistant → Outils développeur → États (filtre : tts.)",
+        "entityHint": "Pas encore de service TTS ? Dans Home Assistant : Paramètres → Appareils et services → Ajouter une intégration → 'Google Translate text-to-speech' (gratuit, sans clé API). Saisis ensuite ici l'entité tts.* créée.",
         "announce": "Annoncer",
         "announceStart": "Début de partie",
         "announceWinner": "Gagnant de manche",

--- a/custom_components/beatify/www/i18n/nl.json
+++ b/custom_components/beatify/www/i18n/nl.json
@@ -834,7 +834,7 @@
         "desc": "TTS roept rondenummers, winnaars en weetjes uit.",
         "unavailable": "Geen TTS-service geregistreerd in Home Assistant.",
         "entityLabel": "TTS-service (entity ID)",
-        "entityHint": "Kopieer vanuit Home Assistant → Ontwikkelaarstools → Statussen (filter: tts.)",
+        "entityHint": "Nog geen TTS-dienst? In Home Assistant: Instellingen → Apparaten en diensten → Integratie toevoegen → 'Google Translate text-to-speech' (gratis, geen API-sleutel). Voer daarna de aangemaakte tts.*-entiteit hier in.",
         "announce": "Aankondigen",
         "announceStart": "Start van het spel",
         "announceWinner": "Winnaar van ronde",

--- a/custom_components/beatify/www/js/wizard.js
+++ b/custom_components/beatify/www/js/wizard.js
@@ -760,7 +760,7 @@ function _ttsDetailHtml() {
           <div class="wiz-field">
             <span class="wiz-field-label">${_t('wizard.step5.tts.entityLabel', 'TTS service (entity ID)')}</span>
             <input type="text" id="wiz-tts-entity" class="wiz-detail-input" placeholder="tts.google_en_com" value="${chosenTtsEntityId}">
-            <span class="wiz-field-hint">${_t('wizard.step5.tts.entityHint', 'Copy from Home Assistant → Developer Tools → States (filter: tts.)')}</span>
+            <span class="wiz-field-hint">${_t('wizard.step5.tts.entityHint', "No TTS service yet? In Home Assistant: Settings → Devices & Services → Add Integration → 'Google Translate text-to-speech' (free, no API key). Then enter the tts.* entity it creates here.")}</span>
             <button type="button" id="wiz-tts-test" class="btn btn-ghost wiz-detail-test" ${chosenTtsEntityId ? '' : 'disabled'}>
               🔊 ${_t('wizard.step5.tts.test', 'Send test announcement')}
             </button>


### PR DESCRIPTION
The TTS entity-ID hint in wizard step 5 assumed the user already has a TTS service. Replaced with a hint that explains adding the free 'Google Translate text-to-speech' integration. All 5 locales.

🤖 Generated with [Claude Code](https://claude.com/claude-code)