### PR TITLE
data: add Best of Giraffenaffen community playlist (26 songs, #883)

### DIFF
--- a/custom_components/beatify/playlists/community/best-of-giraffenaffen.json
+++ b/custom_components/beatify/playlists/community/best-of-giraffenaffen.json
@@ -1,0 +1,720 @@
+{
+  "name": "Best of Giraffenaffen",
+  "version": "1.1",
+  "tags": [
+    "kinderlieder",
+    "kids",
+    "deutsch",
+    "familie"
+  ],
+  "language": "de",
+  "author": "Beatify Community",
+  "added_date": "2026-05-15",
+  "description": "Die beliebtesten Lieder der Giraffenaffen-Kinderlieder-Sammlung — moderne deutsche Kinderlieder zum Mitsingen. Angefragt über den In-App-Playlist-Funnel (#883).",
+  "songs": [
+    {
+      "artist": "Johannes Oerding",
+      "title": "Ich wär so gern wie Du",
+      "year": 2013,
+      "isrc": "DEQR41300081",
+      "uri": "spotify:track:0qlGbjqjt5eBbZ8MlT1PuY",
+      "uri_apple_music": "applemusic://track/1488847430",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1488847430",
+        "de": "applemusic://track/1488847430",
+        "gb": "applemusic://track/1488847430",
+        "fr": "applemusic://track/1488847430",
+        "es": "applemusic://track/1488847430",
+        "nl": "applemusic://track/1488847430",
+        "it": "applemusic://track/1488847430"
+      },
+      "uri_youtube_music": "https://music.youtube.com/watch?v=2GRYX1vivPo",
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/822657962",
+      "alt_artists": [
+        "Giraffenaffen"
+      ],
+      "fun_fact": "A German children's song from the popular Giraffenaffen collection (2013).",
+      "fun_fact_de": "Ein deutsches Kinderlied aus der beliebten Giraffenaffen-Sammlung (2013).",
+      "fun_fact_es": "Una canción infantil alemana de la popular colección Giraffenaffen (2013).",
+      "fun_fact_fr": "Une chanson pour enfants allemande de la célèbre collection Giraffenaffen (2013).",
+      "fun_fact_nl": "Een Duits kinderliedje uit de populaire Giraffenaffen-collectie (2013)."
+    },
+    {
+      "artist": "Stefanie Heinzmann",
+      "title": "Unter dem Meer",
+      "year": 2014,
+      "isrc": "DEQR41400185",
+      "uri": "spotify:track:1TGdhVJgT8iWOPu9QjyXzF",
+      "uri_apple_music": "applemusic://track/1750546224",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1488855968",
+        "de": "applemusic://track/1488855968",
+        "gb": "applemusic://track/1488855968",
+        "fr": "applemusic://track/1488855968",
+        "es": "applemusic://track/1488855968",
+        "nl": "applemusic://track/1488855968",
+        "it": "applemusic://track/1488855968"
+      },
+      "uri_youtube_music": "https://music.youtube.com/watch?v=GdXC0BhtEh4",
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/822653432",
+      "alt_artists": [
+        "Giraffenaffen"
+      ],
+      "fun_fact": "A German children's song from the popular Giraffenaffen collection (2014).",
+      "fun_fact_de": "Ein deutsches Kinderlied aus der beliebten Giraffenaffen-Sammlung (2014).",
+      "fun_fact_es": "Una canción infantil alemana de la popular colección Giraffenaffen (2014).",
+      "fun_fact_fr": "Une chanson pour enfants allemande de la célèbre collection Giraffenaffen (2014).",
+      "fun_fact_nl": "Een Duits kinderliedje uit de populaire Giraffenaffen-collectie (2014)."
+    },
+    {
+      "artist": "Slime",
+      "title": "Trau dich",
+      "year": 2013,
+      "isrc": "DEQR41300086",
+      "uri": "spotify:track:46BILtPQBh0o97nqVWzTud",
+      "uri_apple_music": "applemusic://track/1488847644",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1488847644",
+        "de": "applemusic://track/1488847644",
+        "gb": "applemusic://track/1488847644",
+        "fr": "applemusic://track/1488847644",
+        "es": "applemusic://track/1488847644",
+        "nl": "applemusic://track/1488847644",
+        "it": "applemusic://track/1488847644"
+      },
+      "uri_youtube_music": "https://music.youtube.com/watch?v=jn0SHMP05i0",
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/822658012",
+      "alt_artists": [
+        "Giraffenaffen"
+      ],
+      "fun_fact": "A German children's song from the popular Giraffenaffen collection (2013).",
+      "fun_fact_de": "Ein deutsches Kinderlied aus der beliebten Giraffenaffen-Sammlung (2013).",
+      "fun_fact_es": "Una canción infantil alemana de la popular colección Giraffenaffen (2013).",
+      "fun_fact_fr": "Une chanson pour enfants allemande de la célèbre collection Giraffenaffen (2013).",
+      "fun_fact_nl": "Een Duits kinderliedje uit de populaire Giraffenaffen-collectie (2013)."
+    },
+    {
+      "artist": "LEA",
+      "title": "Die Gedanken sind frei",
+      "year": 2020,
+      "isrc": "DEQR42001363",
+      "uri": "spotify:track:0JFcBPRtJvbCThGzaEyZSU",
+      "uri_apple_music": "applemusic://track/1502086057",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1502086057",
+        "de": "applemusic://track/1502086057",
+        "gb": "applemusic://track/1502086057",
+        "fr": "applemusic://track/1502086057",
+        "es": "applemusic://track/1502086057",
+        "nl": "applemusic://track/1502086057",
+        "it": "applemusic://track/1502086057"
+      },
+      "uri_youtube_music": "https://music.youtube.com/watch?v=n5I-zwNR-gQ",
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1005383332",
+      "alt_artists": [
+        "Giraffenaffen"
+      ],
+      "fun_fact": "A German children's song from the popular Giraffenaffen collection (2020).",
+      "fun_fact_de": "Ein deutsches Kinderlied aus der beliebten Giraffenaffen-Sammlung (2020).",
+      "fun_fact_es": "Una canción infantil alemana de la popular colección Giraffenaffen (2020).",
+      "fun_fact_fr": "Une chanson pour enfants allemande de la célèbre collection Giraffenaffen (2020).",
+      "fun_fact_nl": "Een Duits kinderliedje uit de populaire Giraffenaffen-collectie (2020)."
+    },
+    {
+      "artist": "Dendemann",
+      "title": "Manah Mannah",
+      "year": 2012,
+      "isrc": "DEQR41200009",
+      "uri": "spotify:track:0PpoJxLwBwueUEM3Mw9PZG",
+      "uri_apple_music": "applemusic://track/1730854099",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1488854505",
+        "de": "applemusic://track/1488854505",
+        "gb": "applemusic://track/1488854505",
+        "fr": "applemusic://track/1488854505",
+        "es": "applemusic://track/1488854505",
+        "nl": "applemusic://track/1488854505",
+        "it": "applemusic://track/1488854505"
+      },
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Lx2wfGt0DnE",
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/822653012",
+      "alt_artists": [
+        "Giraffenaffen"
+      ],
+      "fun_fact": "A German children's song from the popular Giraffenaffen collection (2012).",
+      "fun_fact_de": "Ein deutsches Kinderlied aus der beliebten Giraffenaffen-Sammlung (2012).",
+      "fun_fact_es": "Una canción infantil alemana de la popular colección Giraffenaffen (2012).",
+      "fun_fact_fr": "Une chanson pour enfants allemande de la célèbre collection Giraffenaffen (2012).",
+      "fun_fact_nl": "Een Duits kinderliedje uit de populaire Giraffenaffen-collectie (2012)."
+    },
+    {
+      "artist": "Giraffenaffen",
+      "title": "Dir gehört mein Herz",
+      "year": 2023,
+      "isrc": "DEQR42302022",
+      "uri": "spotify:track:32mtvC6mMgpchiKt8IAcPA",
+      "uri_apple_music": "applemusic://track/1698687882",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1698687882",
+        "de": "applemusic://track/1698687882",
+        "gb": "applemusic://track/1698687882",
+        "fr": "applemusic://track/1698687882",
+        "es": "applemusic://track/1698687882",
+        "nl": "applemusic://track/1698687882",
+        "it": "applemusic://track/1698687882"
+      },
+      "uri_youtube_music": "https://music.youtube.com/watch?v=JKmQFeYFZcM",
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2444519415",
+      "alt_artists": [
+        "Michael Schulte"
+      ],
+      "fun_fact": "A German children's song from the popular Giraffenaffen collection (2023).",
+      "fun_fact_de": "Ein deutsches Kinderlied aus der beliebten Giraffenaffen-Sammlung (2023).",
+      "fun_fact_es": "Una canción infantil alemana de la popular colección Giraffenaffen (2023).",
+      "fun_fact_fr": "Une chanson pour enfants allemande de la célèbre collection Giraffenaffen (2023).",
+      "fun_fact_nl": "Een Duits kinderliedje uit de populaire Giraffenaffen-collectie (2023)."
+    },
+    {
+      "artist": "Giraffenaffen",
+      "title": "Astronaut",
+      "year": 2023,
+      "isrc": "DEQR42302025",
+      "uri": "spotify:track:07YL4ShpUPyi0R34tbLahM",
+      "uri_apple_music": "applemusic://track/1698687873",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1698687873",
+        "de": "applemusic://track/1698687873",
+        "gb": "applemusic://track/1698687873",
+        "fr": "applemusic://track/1698687873",
+        "es": "applemusic://track/1698687873",
+        "nl": "applemusic://track/1698687873",
+        "it": "applemusic://track/1698687873"
+      },
+      "uri_youtube_music": "https://music.youtube.com/watch?v=isHOM3_hZ4s",
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2395988385",
+      "alt_artists": [
+        "DIKKA",
+        "dikki"
+      ],
+      "fun_fact": "A German children's song from the popular Giraffenaffen collection (2023).",
+      "fun_fact_de": "Ein deutsches Kinderlied aus der beliebten Giraffenaffen-Sammlung (2023).",
+      "fun_fact_es": "Una canción infantil alemana de la popular colección Giraffenaffen (2023).",
+      "fun_fact_fr": "Une chanson pour enfants allemande de la célèbre collection Giraffenaffen (2023).",
+      "fun_fact_nl": "Een Duits kinderliedje uit de populaire Giraffenaffen-collectie (2023)."
+    },
+    {
+      "artist": "Giraffenaffen",
+      "title": "Let It Go",
+      "year": 2023,
+      "isrc": "DEQR42302023",
+      "uri": "spotify:track:2yIclBfjl1B7gIizZzwBkd",
+      "uri_apple_music": "applemusic://track/1698688143",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1698687874",
+        "de": "applemusic://track/1698687874",
+        "gb": "applemusic://track/1698687874",
+        "fr": "applemusic://track/1698687874",
+        "es": "applemusic://track/1698687874",
+        "nl": "applemusic://track/1698687874",
+        "it": "applemusic://track/1698687874"
+      },
+      "uri_youtube_music": "https://music.youtube.com/watch?v=RztCBPgRQCM",
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2444519395",
+      "alt_artists": [
+        "Loi"
+      ],
+      "fun_fact": "A German children's song from the popular Giraffenaffen collection (2023).",
+      "fun_fact_de": "Ein deutsches Kinderlied aus der beliebten Giraffenaffen-Sammlung (2023).",
+      "fun_fact_es": "Una canción infantil alemana de la popular colección Giraffenaffen (2023).",
+      "fun_fact_fr": "Une chanson pour enfants allemande de la célèbre collection Giraffenaffen (2023).",
+      "fun_fact_nl": "Een Duits kinderliedje uit de populaire Giraffenaffen-collectie (2023)."
+    },
+    {
+      "artist": "Thomas Anders",
+      "title": "Kleine Taschenlampe brenn",
+      "year": 2022,
+      "isrc": "DEQR42201897",
+      "uri": "spotify:track:6l3FBRVgKBKlrScN6sjlay",
+      "uri_apple_music": "applemusic://track/1620399998",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1620399998",
+        "de": "applemusic://track/1620399998",
+        "gb": "applemusic://track/1620399998",
+        "fr": "applemusic://track/1620399998",
+        "es": "applemusic://track/1620399998",
+        "nl": "applemusic://track/1620399998",
+        "it": "applemusic://track/1620399998"
+      },
+      "uri_youtube_music": "https://music.youtube.com/watch?v=wQ61xZ0ZK58",
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1776968147",
+      "alt_artists": [
+        "Giraffenaffen"
+      ],
+      "fun_fact": "A German children's song from the popular Giraffenaffen collection (2022).",
+      "fun_fact_de": "Ein deutsches Kinderlied aus der beliebten Giraffenaffen-Sammlung (2022).",
+      "fun_fact_es": "Una canción infantil alemana de la popular colección Giraffenaffen (2022).",
+      "fun_fact_fr": "Une chanson pour enfants allemande de la célèbre collection Giraffenaffen (2022).",
+      "fun_fact_nl": "Een Duits kinderliedje uit de populaire Giraffenaffen-collectie (2022)."
+    },
+    {
+      "artist": "voXXclub",
+      "title": "Hakuna Matata",
+      "year": 2022,
+      "isrc": "DEQR42201898",
+      "uri": "spotify:track:2C91VnXhPNC6jVFgWObd7t",
+      "uri_apple_music": "applemusic://track/1620400003",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1620400003",
+        "de": "applemusic://track/1886517199",
+        "gb": "applemusic://track/1886517199",
+        "fr": "applemusic://track/1886517199",
+        "es": "applemusic://track/1886517199",
+        "nl": "applemusic://track/1886517199",
+        "it": "applemusic://track/1886517199"
+      },
+      "uri_youtube_music": "https://music.youtube.com/watch?v=TGwxUWqlxFY",
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1776968157",
+      "alt_artists": [
+        "Giraffenaffen"
+      ],
+      "fun_fact": "A German children's song from the popular Giraffenaffen collection (2022).",
+      "fun_fact_de": "Ein deutsches Kinderlied aus der beliebten Giraffenaffen-Sammlung (2022).",
+      "fun_fact_es": "Una canción infantil alemana de la popular colección Giraffenaffen (2022).",
+      "fun_fact_fr": "Une chanson pour enfants allemande de la célèbre collection Giraffenaffen (2022).",
+      "fun_fact_nl": "Een Duits kinderliedje uit de populaire Giraffenaffen-collectie (2022)."
+    },
+    {
+      "artist": "Tim Bendzko",
+      "title": "Nessaja",
+      "year": 2014,
+      "isrc": "DEQR41400190",
+      "uri": "spotify:track:7Az8ZsXX7Wvv7dYsWkOdSF",
+      "uri_apple_music": "applemusic://track/1488855984",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1488855984",
+        "de": "applemusic://track/1488855984",
+        "gb": "applemusic://track/1488855984",
+        "fr": "applemusic://track/1488855984",
+        "es": "applemusic://track/1488855984",
+        "nl": "applemusic://track/1488855984",
+        "it": "applemusic://track/1488855984"
+      },
+      "uri_youtube_music": "https://music.youtube.com/watch?v=OWWsts3sFVE",
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/822653482",
+      "alt_artists": [
+        "Giraffenaffen"
+      ],
+      "fun_fact": "A German children's song from the popular Giraffenaffen collection (2014).",
+      "fun_fact_de": "Ein deutsches Kinderlied aus der beliebten Giraffenaffen-Sammlung (2014).",
+      "fun_fact_es": "Una canción infantil alemana de la popular colección Giraffenaffen (2014).",
+      "fun_fact_fr": "Une chanson pour enfants allemande de la célèbre collection Giraffenaffen (2014).",
+      "fun_fact_nl": "Een Duits kinderliedje uit de populaire Giraffenaffen-collectie (2014)."
+    },
+    {
+      "artist": "Dendemann",
+      "title": "Vielen Dank für die Blumen",
+      "year": 2014,
+      "isrc": "DEQR41400195",
+      "uri": "spotify:track:0XaG07cncTVy51QiYghSHS",
+      "uri_apple_music": "applemusic://track/1488856239",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1488856239",
+        "de": "applemusic://track/1488856239",
+        "gb": "applemusic://track/1488856239",
+        "fr": "applemusic://track/1488856239",
+        "es": "applemusic://track/1488856239",
+        "nl": "applemusic://track/1488856239",
+        "it": "applemusic://track/1488856239"
+      },
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Hd1To7UeYZY",
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/822653532",
+      "alt_artists": [
+        "Giraffenaffen"
+      ],
+      "fun_fact": "A German children's song from the popular Giraffenaffen collection (2014).",
+      "fun_fact_de": "Ein deutsches Kinderlied aus der beliebten Giraffenaffen-Sammlung (2014).",
+      "fun_fact_es": "Una canción infantil alemana de la popular colección Giraffenaffen (2014).",
+      "fun_fact_fr": "Une chanson pour enfants allemande de la célèbre collection Giraffenaffen (2014).",
+      "fun_fact_nl": "Een Duits kinderliedje uit de populaire Giraffenaffen-collectie (2014)."
+    },
+    {
+      "artist": "Blumentopf",
+      "title": "Du hast'n Freund in mir",
+      "year": 2013,
+      "isrc": "DEQR41300085",
+      "uri": "spotify:track:5zTUPsMjz9sSxZc8DLQaSs",
+      "uri_apple_music": "applemusic://track/1488847642",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1488847642",
+        "de": "applemusic://track/1488847642",
+        "gb": "applemusic://track/1488847642",
+        "fr": "applemusic://track/1488847642",
+        "es": "applemusic://track/1488847642",
+        "nl": "applemusic://track/1488847642",
+        "it": "applemusic://track/1488847642"
+      },
+      "uri_youtube_music": "https://music.youtube.com/watch?v=9UnZrZEsmsg",
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/822658002",
+      "alt_artists": [
+        "Giraffenaffen",
+        "Adriano Prestel"
+      ],
+      "fun_fact": "A German children's song from the popular Giraffenaffen collection (2013).",
+      "fun_fact_de": "Ein deutsches Kinderlied aus der beliebten Giraffenaffen-Sammlung (2013).",
+      "fun_fact_es": "Una canción infantil alemana de la popular colección Giraffenaffen (2013).",
+      "fun_fact_fr": "Une chanson pour enfants allemande de la célèbre collection Giraffenaffen (2013).",
+      "fun_fact_nl": "Een Duits kinderliedje uit de populaire Giraffenaffen-collectie (2013)."
+    },
+    {
+      "artist": "Roger Cicero",
+      "title": "Wir sind da (Giraffenaffensong)",
+      "year": 2012,
+      "isrc": "DEQR41200001",
+      "uri": "spotify:track:7CU7RYj3F03AgfKmlXimfo",
+      "uri_apple_music": "applemusic://track/1488854256",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1488854256",
+        "de": "applemusic://track/1488854256",
+        "gb": "applemusic://track/1488854256",
+        "fr": "applemusic://track/1488854256",
+        "es": "applemusic://track/1488854256",
+        "nl": "applemusic://track/1488854256",
+        "it": "applemusic://track/1488854256"
+      },
+      "uri_youtube_music": "https://music.youtube.com/watch?v=dk36Mjchgh8",
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/822652932",
+      "alt_artists": [
+        "Giraffenaffen"
+      ],
+      "fun_fact": "A German children's song from the popular Giraffenaffen collection (2012).",
+      "fun_fact_de": "Ein deutsches Kinderlied aus der beliebten Giraffenaffen-Sammlung (2012).",
+      "fun_fact_es": "Una canción infantil alemana de la popular colección Giraffenaffen (2012).",
+      "fun_fact_fr": "Une chanson pour enfants allemande de la célèbre collection Giraffenaffen (2012).",
+      "fun_fact_nl": "Een Duits kinderliedje uit de populaire Giraffenaffen-collectie (2012)."
+    },
+    {
+      "artist": "Davit Nikalayan",
+      "title": "Ich will jetzt gleich König sein",
+      "year": 2019,
+      "isrc": "USWD11993836",
+      "uri": "spotify:track:0hSHUe7uvHPq5ufE30cuRr",
+      "uri_apple_music": "applemusic://track/1472094384",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1472094384",
+        "de": "applemusic://track/1472094384",
+        "gb": "applemusic://track/1472094384",
+        "fr": "applemusic://track/1472094384",
+        "es": "applemusic://track/1472094384",
+        "nl": "applemusic://track/1472094384",
+        "it": "applemusic://track/1472094384"
+      },
+      "uri_youtube_music": "https://music.youtube.com/watch?v=qxCDMe_F01U",
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/709647632",
+      "alt_artists": [
+        "Anisa Celik",
+        "Axel Malzacher"
+      ],
+      "fun_fact": "A German children's song from the popular Giraffenaffen collection (2019).",
+      "fun_fact_de": "Ein deutsches Kinderlied aus der beliebten Giraffenaffen-Sammlung (2019).",
+      "fun_fact_es": "Una canción infantil alemana de la popular colección Giraffenaffen (2019).",
+      "fun_fact_fr": "Une chanson pour enfants allemande de la célèbre collection Giraffenaffen (2019).",
+      "fun_fact_nl": "Een Duits kinderliedje uit de populaire Giraffenaffen-collectie (2019)."
+    },
+    {
+      "artist": "Jupiter Jones",
+      "title": "Probiers mal mit Gemütlichkeit",
+      "year": 2013,
+      "isrc": "DEQR41300077",
+      "uri": "spotify:track:2zdRMua6yTKFlmtcxwJ6ld",
+      "uri_apple_music": "applemusic://track/1750546220",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1750546220",
+        "de": "applemusic://track/1892497996",
+        "gb": "applemusic://track/1750546220",
+        "fr": "applemusic://track/1750546220",
+        "es": "applemusic://track/1750546220",
+        "nl": "applemusic://track/1750546220",
+        "it": "applemusic://track/1750546220"
+      },
+      "uri_youtube_music": "https://music.youtube.com/watch?v=vGBPnXu1B5c",
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/822657922",
+      "alt_artists": [
+        "Giraffenaffen"
+      ],
+      "fun_fact": "A German children's song from the popular Giraffenaffen collection (2013).",
+      "fun_fact_de": "Ein deutsches Kinderlied aus der beliebten Giraffenaffen-Sammlung (2013).",
+      "fun_fact_es": "Una canción infantil alemana de la popular colección Giraffenaffen (2013).",
+      "fun_fact_fr": "Une chanson pour enfants allemande de la célèbre collection Giraffenaffen (2013).",
+      "fun_fact_nl": "Een Duits kinderliedje uit de populaire Giraffenaffen-collectie (2013)."
+    },
+    {
+      "artist": "Randale",
+      "title": "Geburtstagslied",
+      "year": 2010,
+      "isrc": "DEZ651203440",
+      "uri": "spotify:track:4s6By8HjGUxstLQR09dwho",
+      "uri_apple_music": "applemusic://track/1624189986",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1624189986",
+        "de": "applemusic://track/1624189986",
+        "gb": "applemusic://track/1624189986",
+        "fr": "applemusic://track/1624189986",
+        "es": "applemusic://track/1624189986",
+        "nl": "applemusic://track/1624189986",
+        "it": "applemusic://track/1624189986"
+      },
+      "uri_youtube_music": "https://music.youtube.com/watch?v=QNXVYQI1X08",
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1779682227",
+      "fun_fact": "A German children's song from the popular Giraffenaffen collection (2010).",
+      "fun_fact_de": "Ein deutsches Kinderlied aus der beliebten Giraffenaffen-Sammlung (2010).",
+      "fun_fact_es": "Una canción infantil alemana de la popular colección Giraffenaffen (2010).",
+      "fun_fact_fr": "Une chanson pour enfants allemande de la célèbre collection Giraffenaffen (2010).",
+      "fun_fact_nl": "Een Duits kinderliedje uit de populaire Giraffenaffen-collectie (2010)."
+    },
+    {
+      "artist": "YOUNG SPROUTS",
+      "title": "Schenk der Welt ein Lächeln",
+      "year": 2020,
+      "isrc": "DEVL11800318",
+      "uri": "spotify:track:6ginP4NQaySiuO3ZGyndSG",
+      "uri_apple_music": "applemusic://track/1512788984",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1512788984",
+        "de": "applemusic://track/1512788984",
+        "gb": "applemusic://track/1512788984",
+        "fr": "applemusic://track/1512788984",
+        "es": "applemusic://track/1512788984",
+        "nl": "applemusic://track/1512788984",
+        "it": "applemusic://track/1512788984"
+      },
+      "uri_youtube_music": "https://music.youtube.com/watch?v=CZ--4tGZO4U",
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/957737972",
+      "fun_fact": "A German children's song from the popular Giraffenaffen collection (2020).",
+      "fun_fact_de": "Ein deutsches Kinderlied aus der beliebten Giraffenaffen-Sammlung (2020).",
+      "fun_fact_es": "Una canción infantil alemana de la popular colección Giraffenaffen (2020).",
+      "fun_fact_fr": "Une chanson pour enfants allemande de la célèbre collection Giraffenaffen (2020).",
+      "fun_fact_nl": "Een Duits kinderliedje uit de populaire Giraffenaffen-collectie (2020)."
+    },
+    {
+      "artist": "Suppi Huhn und die Kinderkönige",
+      "title": "Danke für die schöne Zeit mit Dir",
+      "year": 2009,
+      "isrc": "DEM060901814",
+      "uri": "spotify:track:4h0ZAR2gMsYtqRTD0OT0tR",
+      "uri_apple_music": "applemusic://track/1615368685",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1615368685",
+        "de": "applemusic://track/1615368685",
+        "gb": "applemusic://track/1615368685",
+        "fr": "applemusic://track/1615368685",
+        "es": "applemusic://track/1615368685",
+        "nl": "applemusic://track/1615368685",
+        "it": "applemusic://track/1615368685"
+      },
+      "uri_youtube_music": "https://music.youtube.com/watch?v=VBWo0f7qrjo",
+      "uri_tidal": null,
+      "uri_deezer": null,
+      "fun_fact": "A German children's song from the popular Giraffenaffen collection (2009).",
+      "fun_fact_de": "Ein deutsches Kinderlied aus der beliebten Giraffenaffen-Sammlung (2009).",
+      "fun_fact_es": "Una canción infantil alemana de la popular colección Giraffenaffen (2009).",
+      "fun_fact_fr": "Une chanson pour enfants allemande de la célèbre collection Giraffenaffen (2009).",
+      "fun_fact_nl": "Een Duits kinderliedje uit de populaire Giraffenaffen-collectie (2009)."
+    },
+    {
+      "artist": "Dizzy Disco",
+      "title": "Badewannensong",
+      "year": 2024,
+      "isrc": "DEUM72405902",
+      "uri": "spotify:track:2DPZItWzfTDvyvKqpt1dQB",
+      "uri_apple_music": "applemusic://track/1820429612",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1820429612",
+        "de": "applemusic://track/1820429612",
+        "gb": "applemusic://track/1820429612",
+        "fr": "applemusic://track/1820429612",
+        "es": "applemusic://track/1820429612",
+        "nl": "applemusic://track/1820429612",
+        "it": "applemusic://track/1820429612"
+      },
+      "uri_youtube_music": "https://music.youtube.com/watch?v=DO1tcoD5FiI",
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2896921651",
+      "alt_artists": [
+        "DIKKA"
+      ],
+      "fun_fact": "A German children's song from the popular Giraffenaffen collection (2024).",
+      "fun_fact_de": "Ein deutsches Kinderlied aus der beliebten Giraffenaffen-Sammlung (2024).",
+      "fun_fact_es": "Una canción infantil alemana de la popular colección Giraffenaffen (2024).",
+      "fun_fact_fr": "Une chanson pour enfants allemande de la célèbre collection Giraffenaffen (2024).",
+      "fun_fact_nl": "Een Duits kinderliedje uit de populaire Giraffenaffen-collectie (2024)."
+    },
+    {
+      "artist": "Andreas Bourani",
+      "title": "Voll gerne",
+      "year": 2016,
+      "isrc": "USWD11678072",
+      "uri": "spotify:track:2ZMr5Q3uBlfFvvJkD7IxLe",
+      "uri_apple_music": "applemusic://track/6762975307",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/6762975307",
+        "de": "applemusic://track/1440666001",
+        "gb": "applemusic://track/6762975307",
+        "fr": "applemusic://track/6762975307",
+        "es": "applemusic://track/6762975307",
+        "nl": "applemusic://track/6762975307",
+        "it": null
+      },
+      "uri_youtube_music": "https://music.youtube.com/watch?v=inPn84PQyF8",
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/138225341",
+      "fun_fact": "A German children's song from the popular Giraffenaffen collection (2016).",
+      "fun_fact_de": "Ein deutsches Kinderlied aus der beliebten Giraffenaffen-Sammlung (2016).",
+      "fun_fact_es": "Una canción infantil alemana de la popular colección Giraffenaffen (2016).",
+      "fun_fact_fr": "Une chanson pour enfants allemande de la célèbre collection Giraffenaffen (2016).",
+      "fun_fact_nl": "Een Duits kinderliedje uit de populaire Giraffenaffen-collectie (2016)."
+    },
+    {
+      "artist": "Honigkuchenpferde",
+      "title": "Honigkuchenshake",
+      "year": 2025,
+      "isrc": "DEC712415130",
+      "uri": "spotify:track:22cYXH9UHp4ITL3qCNG4lY",
+      "uri_apple_music": "applemusic://track/1797538474",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1887886482",
+        "de": "applemusic://track/1887886482",
+        "gb": "applemusic://track/1887886482",
+        "fr": "applemusic://track/1887886482",
+        "es": "applemusic://track/1887886482",
+        "nl": "applemusic://track/1887886482",
+        "it": "applemusic://track/1887886482"
+      },
+      "uri_youtube_music": "https://music.youtube.com/watch?v=ZAarovnkAM0",
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3242580421",
+      "fun_fact": "A German children's song from the popular Giraffenaffen collection (2025).",
+      "fun_fact_de": "Ein deutsches Kinderlied aus der beliebten Giraffenaffen-Sammlung (2025).",
+      "fun_fact_es": "Una canción infantil alemana de la popular colección Giraffenaffen (2025).",
+      "fun_fact_fr": "Une chanson pour enfants allemande de la célèbre collection Giraffenaffen (2025).",
+      "fun_fact_nl": "Een Duits kinderliedje uit de populaire Giraffenaffen-collectie (2025)."
+    },
+    {
+      "artist": "Max Raabe",
+      "title": "Viel zu selten gehen wir zelten",
+      "year": 2018,
+      "isrc": "DEB581800402",
+      "uri": "spotify:track:6P2jNS6A6q6nAknBDg4pty",
+      "uri_apple_music": "applemusic://track/1421739482",
+      "uri_apple_music_by_region": {
+        "us": null,
+        "de": "applemusic://track/1421739482",
+        "gb": null,
+        "fr": null,
+        "es": null,
+        "nl": null,
+        "it": null
+      },
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Ngc8KChibgI",
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/559296952",
+      "fun_fact": "A German children's song from the popular Giraffenaffen collection (2018).",
+      "fun_fact_de": "Ein deutsches Kinderlied aus der beliebten Giraffenaffen-Sammlung (2018).",
+      "fun_fact_es": "Una canción infantil alemana de la popular colección Giraffenaffen (2018).",
+      "fun_fact_fr": "Une chanson pour enfants allemande de la célèbre collection Giraffenaffen (2018).",
+      "fun_fact_nl": "Een Duits kinderliedje uit de populaire Giraffenaffen-collectie (2018)."
+    },
+    {
+      "artist": "LazyTown",
+      "title": "Aufstehn !",
+      "year": 2014,
+      "isrc": "DEBA20600097",
+      "uri": "spotify:track:225Ckvo4jY6vIROV309ZUe",
+      "uri_apple_music": "applemusic://track/291214346",
+      "uri_apple_music_by_region": {
+        "us": null,
+        "de": "applemusic://track/291214346",
+        "gb": null,
+        "fr": null,
+        "es": null,
+        "nl": null,
+        "it": null
+      },
+      "uri_youtube_music": "https://music.youtube.com/watch?v=WkUlLkSFQ0g",
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/79494762",
+      "fun_fact": "A German children's song from the popular Giraffenaffen collection (2014).",
+      "fun_fact_de": "Ein deutsches Kinderlied aus der beliebten Giraffenaffen-Sammlung (2014).",
+      "fun_fact_es": "Una canción infantil alemana de la popular colección Giraffenaffen (2014).",
+      "fun_fact_fr": "Une chanson pour enfants allemande de la célèbre collection Giraffenaffen (2014).",
+      "fun_fact_nl": "Een Duits kinderliedje uit de populaire Giraffenaffen-collectie (2014)."
+    },
+    {
+      "artist": "Edgar Ott",
+      "title": "Probier’s mal mit Gemütlichkeit",
+      "year": 2007,
+      "isrc": "USWD10423629",
+      "uri": "spotify:track:4S1vA0mTayFbnHrwdkzPWT",
+      "uri_apple_music": "applemusic://track/724179483",
+      "uri_apple_music_by_region": {
+        "us": null,
+        "de": "applemusic://track/724179483",
+        "gb": null,
+        "fr": "applemusic://track/724179483",
+        "es": "applemusic://track/724179483",
+        "nl": "applemusic://track/724179483",
+        "it": "applemusic://track/724179483"
+      },
+      "uri_youtube_music": "https://music.youtube.com/watch?v=1WFS9fHPTFM",
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/13472681",
+      "fun_fact": "A German children's song from the popular Giraffenaffen collection (2007).",
+      "fun_fact_de": "Ein deutsches Kinderlied aus der beliebten Giraffenaffen-Sammlung (2007).",
+      "fun_fact_es": "Una canción infantil alemana de la popular colección Giraffenaffen (2007).",
+      "fun_fact_fr": "Une chanson pour enfants allemande de la célèbre collection Giraffenaffen (2007).",
+      "fun_fact_nl": "Een Duits kinderliedje uit de populaire Giraffenaffen-collectie (2007)."
+    },
+    {
+      "artist": "Willy Astor",
+      "title": "Pubertier",
+      "year": 2019,
+      "isrc": "DEUM71905648",
+      "uri": "spotify:track:3yiiSJJwzC6jvYh6DxuL50",
+      "uri_apple_music": "applemusic://track/1481950886",
+      "uri_apple_music_by_region": {
+        "us": null,
+        "de": "applemusic://track/1481950886",
+        "gb": null,
+        "fr": null,
+        "es": null,
+        "nl": null,
+        "it": null
+      },
+      "uri_youtube_music": "https://music.youtube.com/watch?v=xS29W9GikEU",
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/788629672",
+      "fun_fact": "A German children's song from the popular Giraffenaffen collection (2019).",
+      "fun_fact_de": "Ein deutsches Kinderlied aus der beliebten Giraffenaffen-Sammlung (2019).",
+      "fun_fact_es": "Una canción infantil alemana de la popular colección Giraffenaffen (2019).",
+      "fun_fact_fr": "Une chanson pour enfants allemande de la célèbre collection Giraffenaffen (2019).",
+      "fun_fact_nl": "Een Duits kinderliedje uit de populaire Giraffenaffen-collectie (2019)."
+    }
+  ]
+}


### PR DESCRIPTION
Fulfils playlist request #883 — the popular German children's-music collection "Giraffenaffen".

## Coverage (small playlist, full enrichment)
| Field | Coverage |
|---|---|
| `uri` (Spotify) | 26/26 |
| `year` (2007-2025) | 26/26 |
| `uri_apple_music` + per-region | 26/26 |
| `uri_youtube_music` | 26/26 |
| `isrc` | 26/26 |
| `uri_deezer` | 25/26 |
| `fun_facts` (5 languages) | 26/26 |
| `uri_tidal` | 0 |

26 songs is on the small side (the source playlist is genuinely ~26 tracks), but it's a coherent themed playlist and opens a family-friendly Kinderlieder category Beatify didn't have before. fun_facts are collection-level — per-song trivia for niche children's tracks isn't reliably sourceable.

## Test plan
- [ ] Loads in the playlist hub.
- [ ] Smoke-play a couple of tracks.
- [ ] Close #883, add `playlist-ready`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)