### PR TITLE
release: v3.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to Beatify are documented here. For detailed release notes, 
 
 ## [Unreleased]
 
+## [3.3.5] - 2026-05-15
+
+Stable promotion of the 3.3.5-rc1 line. See [release notes](https://github.com/mholzi/beatify/releases/tag/v3.3.5) for the user-facing summary.
+
+### Added
+- **TTS Player Achievements — Phase 2 of 4 (#840).** Six new voice announcements driven from player results rather than round lifecycle: exact-year guess, Closest-Wins winner, streak milestone, streak broken, new leader, and a tie at the top. Each is an independent toggle in `configure_tts`. Orchestrated by a new `_announce_player_achievements()` in `game/state.py` with six `_tts_announce_*` flags plus `_tts_previous_leader` for leader-change detection. Phase 1 (round lifecycle) shipped in 3.3.4; phases 3-4 (betting/state, special modes) remain in #841 / #842.
+- **Five new community playlists.** Anime Openings (101 songs), Ballermann Party Hits (189), Harder Styles (150), Best of Giraffenaffen (26), and 2010s & 2020s Hits (128) — the last closing the decade gap between the 2000s playlist and today. Four came from in-app playlist requests (#878, #887, #889, #883).
+
+### Fixed
+- **Admin Stop button no longer silently dead (#880).** On a WebSocket reconnect race the player-view Stop button could no-op without feedback. `handleStopSong()` now surfaces a connection-lost label when the socket is down, and `debounceAdminAction()` was rewritten to a timestamp-based guard (`lastAdminActionAt`) so it can no longer wedge every admin button after a missed action.
+- **Fun-fact spoiler leak on participant admin dashboard closed (#882).** A reconnect race could briefly render the song's fun fact on a playing admin's dashboard before REVEAL. The fair-play guard now uses a durable `sessionStorage['beatify_admin_name']` signal that survives reconnects.
+- **Repo landing-page link works again (#881).** The GitHub project link redirected to a parked blank page — the `beatify.life` custom domain on the `gh-pages` branch pointed at a Strato parking page. The dead `CNAME` was removed and SEO URLs updated so the link serves directly.
+
+### Data
+- 98 songs backfilled into the existing decade and greatest-hits playlists (`top-songs-der-60er`, `greatest-hits-of-all-time`, `80er-hits`, `90er-hits`, `2000s-pop-anthems`) from the Hitster Deutschland request (#892) — only 29% overlap with existing coverage, the rest bucketed by decade. Beatify now ships 30 playlists / 3,273 songs. All new and backfilled songs carry full Spotify / Apple Music (incl. per-region) / YouTube Music / Deezer URIs, years and fun facts in 5 languages.
+
 ## [3.3.4] - 2026-05-14
 
 Stable promotion of the 3.3.4-rc line (rc1 → rc5). See [release notes](https://github.com/mholzi/beatify/releases/tag/v3.3.4) for the user-facing summary.

--- a/custom_components/beatify/manifest.json
+++ b/custom_components/beatify/manifest.json
@@ -12,5 +12,5 @@
   "documentation": "https://github.com/mholzi/beatify",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/mholzi/beatify/issues",
-  "version": "3.3.5-rc1"
+  "version": "3.3.5"
 }

--- a/custom_components/beatify/www/admin.html
+++ b/custom_components/beatify/www/admin.html
@@ -8,7 +8,7 @@
          query-string version, a stale en.json from a prior rc gets served
          after upgrade and references to newer keys render as raw strings.
          Bumped each rc alongside manifest.json + sw.js CACHE_VERSION. -->
-    <meta name="beatify-version" content="3.3.5-rc1">
+    <meta name="beatify-version" content="3.3.5">
     <title data-i18n="admin.title">Beatify Admin</title>
     <!-- PWA: Web App Manifest — Admin installs Beatify to homescreen (Issue #166) -->
     <link rel="manifest" href="/beatify/static/site.webmanifest">
@@ -1101,9 +1101,9 @@
     <!-- Story 44.1: Playlist requests module -->
     <script src="/beatify/static/js/playlist-requests.min.js?v=3.3.4"></script>
     <script type="module" src="/beatify/static/js/playlist-hub.js?v=3.3.1"></script>
-    <script type="module" src="/beatify/static/js/wizard.js?v=3.3.4"></script>
-    <script src="/beatify/static/js/admin.min.js?v=3.3.4"></script>
+    <script type="module" src="/beatify/static/js/wizard.js?v=3.3.5"></script>
+    <script src="/beatify/static/js/admin.min.js?v=3.3.5"></script>
     <script src="/beatify/static/js/party-lights.min.js?v=3.3.1"></script>
-    <script src="/beatify/static/js/tts-settings.js?v=3.3.2-rc1"></script>
+    <script src="/beatify/static/js/tts-settings.js?v=3.3.5"></script>
 </body>
 </html>

--- a/custom_components/beatify/www/dashboard.html
+++ b/custom_components/beatify/www/dashboard.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <!-- #824: cache-bust i18n JSON fetches. See admin.html for rationale. -->
-    <meta name="beatify-version" content="3.3.5-rc1">
+    <meta name="beatify-version" content="3.3.5">
     <title data-i18n="dashboard.title">Beatify - Dashboard</title>
     <!-- Preconnect for faster font loading (Story 9.8) -->
     <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/custom_components/beatify/www/player.html
+++ b/custom_components/beatify/www/player.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <!-- #824: cache-bust i18n JSON fetches. See admin.html for rationale. -->
-    <meta name="beatify-version" content="3.3.5-rc1">
+    <meta name="beatify-version" content="3.3.5">
     <title data-i18n="join.title">Beatify - Join Game</title>
     <!-- Preconnect for faster font loading (Story 9.8) -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -906,6 +906,6 @@
     <!-- Version query strings prevent browser caching issues -->
     <script src="/beatify/static/js/i18n.min.js"></script>
     <script src="/beatify/static/js/utils.min.js"></script>
-    <script type="module" src="/beatify/static/js/player.bundle.min.js?v=3.3.4"></script>
+    <script type="module" src="/beatify/static/js/player.bundle.min.js?v=3.3.5"></script>
 </body>
 </html>

--- a/custom_components/beatify/www/sw.js
+++ b/custom_components/beatify/www/sw.js
@@ -6,7 +6,7 @@
  */
 'use strict';
 
-var CACHE_VERSION = 'beatify-v3.3.5-rc1';
+var CACHE_VERSION = 'beatify-v3.3.5';
 var MAX_CACHE_ITEMS = 50;
 
 // Critical assets to precache on install (minified versions only - fallback handled by HTML)


### PR DESCRIPTION
Stable promotion of the 3.3.5-rc1 line. No code changes since rc1 — version-marker bump only.

## Bumps
- `manifest.json` 3.3.5-rc1 → 3.3.5
- `sw.js` CACHE_VERSION → beatify-v3.3.5
- `<meta beatify-version>` on admin/dashboard/player → 3.3.5
- `?v=` cache-busters on files changed since 3.3.4: admin.min.js, player.bundle.min.js, tts-settings.js, wizard.js → 3.3.5
- CHANGELOG `[3.3.5]` section

## Test plan
- [x] vitest 35 green (verified at rc1)
- [ ] Install in HA, confirm 30 playlists / 3,273 songs load

🤖 Generated with [Claude Code](https://claude.com/claude-code)