### PR TITLE
data: fix 2 broken URIs in anime-openings (#896)

### DIFF
--- a/custom_components/beatify/playlists/community/anime-openings.json
+++ b/custom_components/beatify/playlists/community/anime-openings.json
@@ -1,6 +1,6 @@
 {
   "name": "Anime Openings",
-  "version": "1.3",
+  "version": "1.4",
   "tags": [
     "anime",
     "japanese",
@@ -1428,7 +1428,7 @@
         "nl": "applemusic://track/1538275660",
         "it": "applemusic://track/1538275660"
       },
-      "uri_youtube_music": "https://music.youtube.com/watch?v=_AfZwbht5yE",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=9aJVr5tTTWk",
       "uri_tidal": null,
       "uri_deezer": null,
       "fun_fact": "Opening of 'My Hero Academia' Season 2 (2017) by Kenshi Yonezu.",
@@ -2347,15 +2347,15 @@
       "year": 2009,
       "isrc": "QMFMF1324377",
       "uri": "spotify:track:31A3fFQivbhGo9aJQQCdtP",
-      "uri_apple_music": "applemusic://track/1367858045",
+      "uri_apple_music": "applemusic://track/1536257542",
       "uri_apple_music_by_region": {
-        "us": "applemusic://track/1367858045",
-        "de": "applemusic://track/1367858045",
-        "gb": "applemusic://track/1367858045",
-        "fr": "applemusic://track/1367858045",
-        "es": "applemusic://track/1367858045",
-        "nl": "applemusic://track/1367858045",
-        "it": "applemusic://track/1367858045"
+        "us": "applemusic://track/1536257542",
+        "de": "applemusic://track/1536257542",
+        "gb": "applemusic://track/1536257542",
+        "fr": "applemusic://track/1536257542",
+        "es": "applemusic://track/1536257542",
+        "nl": "applemusic://track/1536257542",
+        "it": "applemusic://track/1536257542"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=7TRD1UZkXN0",
       "uri_tidal": null,


### PR DESCRIPTION
Closes #896. Replaced 2 wrong-track URIs and bumped playlist version to 1.4.

- Kenshi Yonezu ピースサイン: YouTube Music `_AfZwbht5yE` → `9aJVr5tTTWk` (was pointing to Kaijyuunomarch)
- SCANDAL 少女Ｓ: Apple Music `1367858045` → `1536257542` all regions (was pointing to Ailee - Scandal)