### PR TITLE
release: v3.3.6-rc1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to Beatify are documented here. For detailed release notes, 
 
 ## [Unreleased]
 
+## [3.3.6] - 2026-05-16
+
+First rc of the 3.3.6 line. See [release notes](https://github.com/mholzi/beatify/releases/tag/v3.3.6-rc1) for the user-facing summary.
+
+### Added
+- **TTS announcements — Betting & Game State (Phase 3 of 4, #841).** Seven new voice announcements: bet won, bet lost, player join, player reconnect, last round, podium, and rematch. Player-reconnect defaults off (phones re-establish the WebSocket constantly).
+- **TTS announcements — Special Modes (Phase 4 of 4, #842).** Three new announcements: intro round, steal unlocked, steal used. Completes the #471 TTS roadmap.
+- **Admin TTS toggle UI for all three phases.** Phase 1/2 shipped toggle plumbing but no checkboxes; all 23 event toggles are now rendered in the TTS Announcements section, grouped into Game Flow / Player Achievements / Betting & Game State / Special Modes. 39 i18n keys across all 5 locales.
+- **TTS verbosity presets.** A Minimal / Standard / Full selector bulk-sets the 23 toggles; editing one by hand flips it to Custom.
+
+### Changed
+- **Combined REVEAL announcement.** The per-round REVEAL events (correct answer, accuracy, streaks, bet outcomes, steal unlocks, standings) are collected into one narrated utterance instead of up to ~7 separate TTS clips. Each fragment is still gated by its own toggle.
+
+### Fixed
+- _(none — rc1 is feature + data work; see 3.3.5 for the prior fix line.)_
+
+### Data
+- **Harder Styles — 150 → 190 songs (#899).** 40 modern hardstyle tracks (festival anthems + hardstyle remixes of chart hits) folded in from playlist request #899, with per-region Apple Music URIs.
+- **90er Ohrwürmer request routed (#906).** 90s Hits 58 → 94 songs (international, no German-language tracks — EAV removed); Deutschpop Klassiker 100 → 106 songs (scope widened to the 90s/NDW canon). Years resolved via MusicBrainz first-release dates.
+- **TTS announcement test coverage.** 14 unit tests for the combined REVEAL announcement.
+
 ## [3.3.5] - 2026-05-15
 
 Stable promotion of the 3.3.5-rc1 line. See [release notes](https://github.com/mholzi/beatify/releases/tag/v3.3.5) for the user-facing summary.

--- a/custom_components/beatify/manifest.json
+++ b/custom_components/beatify/manifest.json
@@ -12,5 +12,5 @@
   "documentation": "https://github.com/mholzi/beatify",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/mholzi/beatify/issues",
-  "version": "3.3.5"
+  "version": "3.3.6-rc1"
 }

--- a/custom_components/beatify/www/admin.html
+++ b/custom_components/beatify/www/admin.html
@@ -8,7 +8,7 @@
          query-string version, a stale en.json from a prior rc gets served
          after upgrade and references to newer keys render as raw strings.
          Bumped each rc alongside manifest.json + sw.js CACHE_VERSION. -->
-    <meta name="beatify-version" content="3.3.5">
+    <meta name="beatify-version" content="3.3.6-rc1">
     <title data-i18n="admin.title">Beatify Admin</title>
     <!-- PWA: Web App Manifest — Admin installs Beatify to homescreen (Issue #166) -->
     <link rel="manifest" href="/beatify/static/site.webmanifest">

--- a/custom_components/beatify/www/dashboard.html
+++ b/custom_components/beatify/www/dashboard.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <!-- #824: cache-bust i18n JSON fetches. See admin.html for rationale. -->
-    <meta name="beatify-version" content="3.3.5">
+    <meta name="beatify-version" content="3.3.6-rc1">
     <title data-i18n="dashboard.title">Beatify - Dashboard</title>
     <!-- Preconnect for faster font loading (Story 9.8) -->
     <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/custom_components/beatify/www/player.html
+++ b/custom_components/beatify/www/player.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <!-- #824: cache-bust i18n JSON fetches. See admin.html for rationale. -->
-    <meta name="beatify-version" content="3.3.5">
+    <meta name="beatify-version" content="3.3.6-rc1">
     <title data-i18n="join.title">Beatify - Join Game</title>
     <!-- Preconnect for faster font loading (Story 9.8) -->
     <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/custom_components/beatify/www/sw.js
+++ b/custom_components/beatify/www/sw.js
@@ -6,7 +6,7 @@
  */
 'use strict';
 
-var CACHE_VERSION = 'beatify-v3.3.5';
+var CACHE_VERSION = 'beatify-v3.3.6-rc1';
 var MAX_CACHE_ITEMS = 50;
 
 // Critical assets to precache on install (minified versions only - fallback handled by HTML)


### PR DESCRIPTION
First rc of the 3.3.6 line. Bundles everything merged since v3.3.5.

## Included
- **TTS Phase 3 + 4** (#841 / #842) — completes the #471 announcement roadmap
- **TTS toggle UI** for all 4 phases + **verbosity presets** (Minimal / Standard / Full)
- **Combined REVEAL announcement** — one narrated sentence instead of ~7 clips + 14 unit tests
- **Harder Styles** 150 → 190 (#899); **90s Hits** 58 → 94 + **Deutschpop Klassiker** 100 → 106 (#906)

## Bumps
- `manifest.json` 3.3.5 → 3.3.6-rc1
- `sw.js` CACHE_VERSION → beatify-v3.3.6-rc1
- `<meta beatify-version>` on admin/dashboard/player
- CHANGELOG `[3.3.6]` section

No `?v=` cache-buster bumps (rc — those land on the stable build).

## Test plan
- [x] vitest 35 / pytest TTS+state suites green
- [ ] Install rc1 in HA — verify the combined reveal sentence, presets, and the new playlists in a real game

🤖 Generated with [Claude Code](https://claude.com/claude-code)