### PR TITLE
fix: round stuck on "Waiting for others" — ghost player blocks early reveal (#928)

### DIFF
--- a/custom_components/beatify/game/player.py
+++ b/custom_components/beatify/game/player.py
@@ -94,6 +94,17 @@ class PlayerSession:
         default_factory=list
     )  # Per-round: who stole this player's answer
 
+    @property
+    def is_active(self) -> bool:
+        """True only if the player is genuinely still connected.
+
+        ``connected`` alone is not enough: a dropped/closed WebSocket whose
+        ``_handle_disconnect`` has not run yet leaves a stale ``connected =
+        True`` ghost. Counting such a ghost as an active participant blocks
+        all-submitted detection (early reveal) for the whole room — #928.
+        """
+        return self.connected and self.ws is not None and not self.ws.closed
+
     def submit_guess(self, year: int, timestamp: float) -> None:
         """Record a guess submission."""
         self.submitted = True

--- a/custom_components/beatify/game/player_registry.py
+++ b/custom_components/beatify/game/player_registry.py
@@ -204,11 +204,16 @@ class PlayerRegistry:
         ]
 
     def all_submitted(self) -> bool:
-        """Check if all connected players have submitted their guess."""
-        connected_players = [p for p in self.players.values() if p.connected]
-        if not connected_players:
+        """Check if all genuinely-connected players have submitted their guess.
+
+        Uses ``is_active`` rather than the raw ``connected`` flag so a stale
+        ghost (closed WebSocket not yet cleaned up) can't block early reveal
+        for the whole room — #928.
+        """
+        active_players = [p for p in self.players.values() if p.is_active]
+        if not active_players:
             return False
-        return all(p.submitted for p in connected_players)
+        return all(p.submitted for p in active_players)
 
     def get_average_score(self) -> int:
         """Calculate average score for late joiners.

--- a/custom_components/beatify/game/state.py
+++ b/custom_components/beatify/game/state.py
@@ -1016,11 +1016,11 @@ class GameState:
         if self.artist_challenge_enabled and self.artist_challenge:
             has_winner = getattr(self.artist_challenge, "winner", None) is not None
             anyone_guessed = any(
-                p.has_artist_guess for p in self.players.values() if p.connected
+                p.has_artist_guess for p in self.players.values() if p.is_active
             )
             if not has_winner and anyone_guessed:
                 for player in self.players.values():
-                    if player.connected and not player.has_artist_guess:
+                    if player.is_active and not player.has_artist_guess:
                         return False
 
         # Issue #28: If movie quiz enabled and active, check movie guesses
@@ -1028,11 +1028,11 @@ class GameState:
         if self.movie_quiz_enabled and self.movie_challenge:
             has_correct = len(self.movie_challenge.correct_guesses) > 0
             anyone_guessed = any(
-                p.has_movie_guess for p in self.players.values() if p.connected
+                p.has_movie_guess for p in self.players.values() if p.is_active
             )
             if not has_correct and anyone_guessed:
                 for player in self.players.values():
-                    if player.connected and not player.has_movie_guess:
+                    if player.is_active and not player.has_movie_guess:
                         return False
 
         return True

--- a/custom_components/beatify/server/websocket.py
+++ b/custom_components/beatify/server/websocket.py
@@ -361,6 +361,15 @@ class BeatifyWebSocketHandler:
         # Broadcast disconnect state immediately
         await self.broadcast_state()
 
+        # #928: a mid-round disconnect can itself complete the round. If
+        # everyone still active has already submitted, the departing player
+        # was the last thing the room was waiting on — advance to REVEAL now
+        # instead of stalling on "Waiting for others" until the timer.
+        try:
+            await game_state.trigger_early_reveal_if_complete()
+        except Exception:  # noqa: BLE001
+            _LOGGER.warning("Early-reveal check after disconnect failed")
+
         # Admin disconnect: pause game after grace period (Story 7-1)
         if player.is_admin:
 

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -241,8 +241,9 @@ class TestAllSubmitted:
     def setup_method(self):
         self.state = make_game_state()
         _create_fresh_game(self.state)
-        self.state.add_player("Alice", MagicMock())
-        self.state.add_player("Bob", MagicMock())
+        # closed=False → the ws looks live, so is_active is True.
+        self.state.add_player("Alice", MagicMock(closed=False))
+        self.state.add_player("Bob", MagicMock(closed=False))
 
     def test_no_submissions_returns_false(self):
         assert self.state.all_submitted() is False
@@ -258,6 +259,13 @@ class TestAllSubmitted:
 
     def test_disconnected_player_excluded(self):
         self.state.players["Bob"].connected = False
+        self.state.players["Alice"].submitted = True
+        assert self.state.all_submitted() is True
+
+    def test_stale_connected_ghost_excluded(self):
+        # #928: a player whose WebSocket is already closed but whose
+        # `connected` flag has not been cleared must not block all-submitted.
+        self.state.players["Bob"].ws.closed = True
         self.state.players["Alice"].submitted = True
         assert self.state.all_submitted() is True
 


### PR DESCRIPTION
Fixes #928 — reported by @semimo: players all submit, the round never advances, everyone sits on "Waiting for others", and restarting the song hits the same wall.

## Root cause
Early reveal fires once **every connected player has submitted**, via `all_submitted()`. That check counted every player with `connected = True` — including a **stale ghost**: a player whose WebSocket has dropped/closed but whose `connected` flag hasn't been cleared yet (`_handle_disconnect` not run, or a half-open connection). The ghost never submits → `all_submitted()` never returns True → no early reveal → the room is stuck. A round restart doesn't help: the ghost persists, so it happens again — exactly what @semimo described.

## Fix
- **New `PlayerSession.is_active`** — `connected` AND a live (open) WebSocket.
- `all_submitted()` and `check_all_guesses_complete()`'s artist/movie checks now use `is_active`, so a closed-ws ghost no longer blocks the room.
- `_handle_disconnect` now re-runs the early-reveal check — a mid-round disconnect can itself complete the round, so it advances to REVEAL immediately rather than stalling until the timer.

The round timer stays the backstop for genuinely-idle-but-live connected players (unchanged — you can't tell a slow player from an absent one without it).

## Test plan
- [x] `pytest test_state / test_websocket / test_round_manager / test_tts*` — 193 passed
- [x] New regression test `test_stale_connected_ghost_excluded`
- [ ] Manual: drop a player's WS mid-round, confirm the round advances once the rest submit

Candidate for v3.3.6 (core-loop bug) or v3.3.7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)