### PR TITLE
fix(qa): stop event-loop poisoning that broke 88 unit tests in CI

### DIFF
--- a/tests/unit/test_round_manager.py
+++ b/tests/unit/test_round_manager.py
@@ -78,16 +78,17 @@ class TestCancelTimer:
         rm.cancel_timer()  # Should not raise
         assert rm._timer_task is None
 
-    def test_cancel_clears_task(self):
+    async def test_cancel_clears_task(self):
         import asyncio
 
-        async def _run():
-            rm = _make_rm()
-            rm._timer_task = asyncio.create_task(asyncio.sleep(100))
-            rm.cancel_timer()
-            assert rm._timer_task is None
-
-        asyncio.run(_run())
+        # Must be an async test (asyncio_mode=auto manages the loop). A bare
+        # asyncio.run() here calls set_event_loop(None) on exit, poisoning the
+        # global loop policy so every later async test in the suite errors
+        # with "There is no current event loop".
+        rm = _make_rm()
+        rm._timer_task = asyncio.create_task(asyncio.sleep(100))
+        rm.cancel_timer()
+        assert rm._timer_task is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

`tests/unit/test_round_manager.py::test_cancel_clears_task` used a bare
`asyncio.run()` inside a sync test. `asyncio.run()` calls
`asyncio.set_event_loop(None)` on exit, poisoning the global event-loop
policy for the rest of the run.

Every async test that runs afterward (`test_state.py`, `test_websocket.py` —
alphabetical order) then errored with
`RuntimeError: There is no current event loop in thread 'MainThread'`.

## Impact

A full `pytest tests/unit/` run reported **12 failed + 76 errors** purely from
this ordering side effect. That is exactly the command CI runs on Python
3.12/3.13 (`.github/workflows/test.yml`), so the test job was red while the
game logic itself was fine.

Proof of root cause:
- `pytest tests/unit/test_state.py` alone → **99 passed**
- `pytest tests/unit/test_round_manager.py tests/unit/test_state.py` → **12 failed, 76 errors**

## Fix

Convert `test_cancel_clears_task` to an `async def` test so `asyncio_mode=auto`
manages the loop instead of `asyncio.run()`. One file, 9 insertions / 8 deletions.

## Verification

Full suite after fix: **458 passed, 2 skipped** (0 failures, 0 errors).
Frontend: **35 vitest tests pass**.

Found via `/qa`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)