### PR TITLE
fix(#933): proxy album art so QR-join players can load it

### DIFF
--- a/custom_components/beatify/__init__.py
+++ b/custom_components/beatify/__init__.py
@@ -28,6 +28,7 @@ from .game.state import GameState
 from .server import async_register_static_paths
 from .server.views import (
     AdminView,
+    AlbumArtView,
     AnalyticsPageView,
     AnalyticsView,
     CapabilitiesView,
@@ -169,6 +170,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.http.register_view(StatusView(hass))
     hass.http.register_view(CapabilitiesView(hass))
     hass.http.register_view(LightsView(hass))  # Issue #331
+    hass.http.register_view(AlbumArtView(hass))  # Issue #933 — remote album art
     hass.http.register_view(PreviewLightsView(hass))  # Issue #408
     hass.http.register_view(TtsTestView(hass))
     hass.http.register_view(StartGameView(hass))

--- a/custom_components/beatify/server/views.py
+++ b/custom_components/beatify/server/views.py
@@ -309,9 +309,7 @@ class AlbumArtView(HomeAssistantView):
 
         session = async_get_clientsession(self.hass)
         try:
-            async with session.get(
-                raw_url, timeout=ClientTimeout(total=10)
-            ) as resp:
+            async with session.get(raw_url, timeout=ClientTimeout(total=10)) as resp:
                 if resp.status != 200:
                     return web.Response(status=resp.status)
                 body = await resp.read()

--- a/custom_components/beatify/server/views.py
+++ b/custom_components/beatify/server/views.py
@@ -7,12 +7,14 @@ views from sub-modules for backward compatibility.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from aiohttp import web
+from aiohttp import ClientError, ClientTimeout, web
 from homeassistant.components.http import HomeAssistantView
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from custom_components.beatify.const import DOMAIN
 from custom_components.beatify.game.state import GamePhase
@@ -278,6 +280,51 @@ class LightsView(HomeAssistantView):
             )
 
         return web.json_response({"lights": lights})
+
+
+class AlbumArtView(HomeAssistantView):
+    """Same-origin proxy for media-player album art (#933).
+
+    Music Assistant exposes ``entity_picture`` as an absolute URL on the MA
+    server's LAN address (e.g. ``http://192.168.x.x:8095/imageproxy?...``). A
+    player who joined via the nabu.casa remote URL is on a public origin, so
+    the browser's Private Network Access policy blocks the LAN request and
+    album art never loads. This view re-fetches the image server-side — HA can
+    reach the LAN — and re-serves it same-origin under ``/beatify/api/albumart``.
+    """
+
+    url = "/beatify/api/albumart"
+    name = "beatify:api:albumart"
+    requires_auth = False  # player browsers are unauthenticated
+
+    def __init__(self, hass: HomeAssistant) -> None:
+        """Initialize the album-art proxy view."""
+        self.hass = hass
+
+    async def get(self, request: web.Request) -> web.Response:
+        """Fetch the upstream image and re-serve it same-origin."""
+        raw_url = request.query.get("url", "")
+        if not raw_url.startswith(("http://", "https://")):
+            return web.Response(status=400, text="invalid url")
+
+        session = async_get_clientsession(self.hass)
+        try:
+            async with session.get(
+                raw_url, timeout=ClientTimeout(total=10)
+            ) as resp:
+                if resp.status != 200:
+                    return web.Response(status=resp.status)
+                body = await resp.read()
+                content_type = resp.headers.get("Content-Type", "image/jpeg")
+        except (ClientError, asyncio.TimeoutError):
+            _LOGGER.warning("Album-art proxy fetch failed for %s", raw_url)
+            return web.Response(status=502, text="upstream fetch failed")
+
+        return web.Response(
+            body=body,
+            content_type=content_type,
+            headers={"Cache-Control": "public, max-age=86400"},
+        )
 
 
 class PreviewLightsView(HomeAssistantView):

--- a/custom_components/beatify/services/media_player.py
+++ b/custom_components/beatify/services/media_player.py
@@ -7,6 +7,7 @@ import logging
 import sys
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any
+from urllib.parse import quote
 
 if sys.version_info >= (3, 11):
     from asyncio import timeout as async_timeout
@@ -133,6 +134,26 @@ _PROVIDER_URI_FIELDS: dict[str, tuple[str, ...]] = {
     "tidal": ("uri_tidal",),
     "deezer": ("uri_deezer",),
 }
+
+
+def proxy_album_art(url: str) -> str:
+    """Route an absolute album-art URL through the same-origin proxy (#933).
+
+    Music Assistant exposes ``entity_picture`` as an absolute URL on the MA
+    server's LAN address (e.g. ``http://192.168.x.x:8095/imageproxy?...``). A
+    player who joined via the nabu.casa remote URL is on a public origin, so
+    the browser's Private Network Access policy blocks the LAN request and
+    album art never loads. Wrapping such URLs in ``/beatify/api/albumart`` lets
+    the HA server fetch the image (it can reach the LAN) and re-serve it
+    same-origin.
+
+    Relative URLs — HA's own signed media-player proxy path, the
+    ``no-artwork.svg`` fallback — are already same-origin and pass through
+    unchanged.
+    """
+    if url and url.startswith(("http://", "https://")):
+        return "/beatify/api/albumart?url=" + quote(url, safe="")
+    return url
 
 
 class MediaPlayerService:
@@ -776,8 +797,10 @@ class MediaPlayerService:
         return {
             "artist": state.attributes.get("media_artist", "Unknown Artist"),
             "title": state.attributes.get("media_title", "Unknown Title"),
-            "album_art": state.attributes.get(
-                "entity_picture", "/beatify/static/img/no-artwork.svg"
+            "album_art": proxy_album_art(
+                state.attributes.get(
+                    "entity_picture", "/beatify/static/img/no-artwork.svg"
+                )
             ),
         }
 
@@ -876,8 +899,10 @@ class MediaPlayerService:
         return {
             "artist": state.attributes.get("media_artist", "Unknown Artist"),
             "title": state.attributes.get("media_title", "Unknown Title"),
-            "album_art": state.attributes.get(
-                "entity_picture", "/beatify/static/img/no-artwork.svg"
+            "album_art": proxy_album_art(
+                state.attributes.get(
+                    "entity_picture", "/beatify/static/img/no-artwork.svg"
+                )
             ),
         }
 

--- a/tests/unit/test_album_art_view.py
+++ b/tests/unit/test_album_art_view.py
@@ -1,0 +1,34 @@
+"""Tests for AlbumArtView — the same-origin album-art proxy (#933)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from custom_components.beatify.server.views import AlbumArtView
+
+
+def _request(query: dict) -> MagicMock:
+    """Build a mock aiohttp request with the given query params."""
+    request = MagicMock()
+    request.query = query
+    return request
+
+
+class TestAlbumArtView:
+    """Input validation for the album-art proxy endpoint."""
+
+    def test_endpoint_is_unauthenticated(self):
+        # Player browsers join unauthenticated — the proxy must be reachable.
+        assert AlbumArtView.requires_auth is False
+        assert AlbumArtView.url == "/beatify/api/albumart"
+
+    async def test_missing_url_returns_400(self):
+        view = AlbumArtView(MagicMock())
+        resp = await view.get(_request({}))
+        assert resp.status == 400
+
+    async def test_non_http_scheme_returns_400(self):
+        # A file:// URL must never be fetched server-side.
+        view = AlbumArtView(MagicMock())
+        resp = await view.get(_request({"url": "file:///etc/passwd"}))
+        assert resp.status == 400

--- a/tests/unit/test_media_player.py
+++ b/tests/unit/test_media_player.py
@@ -6,7 +6,10 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from custom_components.beatify.services.media_player import MediaPlayerService
+from custom_components.beatify.services.media_player import (
+    MediaPlayerService,
+    proxy_album_art,
+)
 
 
 def _make_state(
@@ -1068,3 +1071,65 @@ class TestStartRoundFailureClassification:
         # Must have paused once retries exhausted.
         assert result is False
         gs.pause_game.assert_awaited_once_with("media_player_error")
+
+
+class TestProxyAlbumArt:
+    """proxy_album_art — same-origin wrapping so remote players see art (#933)."""
+
+    def test_absolute_http_lan_url_is_wrapped(self):
+        # The exact shape Music Assistant emits — an absolute LAN URL.
+        url = "http://192.168.0.191:8095/imageproxy?provider=apple_music&path=x"
+        result = proxy_album_art(url)
+        assert result.startswith("/beatify/api/albumart?url=")
+        # The LAN host is percent-encoded into the query, not left bare.
+        assert "192.168.0.191" not in result.split("?url=")[0]
+        assert "%3A%2F%2F" in result  # :// is encoded
+
+    def test_https_url_is_wrapped(self):
+        result = proxy_album_art("https://cdn.example.com/cover.jpg")
+        assert result.startswith("/beatify/api/albumart?url=")
+
+    def test_relative_ha_proxy_path_passes_through(self):
+        # HA's own signed media-player proxy path is already same-origin.
+        url = "/api/media_player_proxy/media_player.sonos?token=abc"
+        assert proxy_album_art(url) == url
+
+    def test_no_artwork_fallback_passes_through(self):
+        url = "/beatify/static/img/no-artwork.svg"
+        assert proxy_album_art(url) == url
+
+    def test_empty_string_passes_through(self):
+        assert proxy_album_art("") == ""
+
+
+class TestMetadataAlbumArtWrapping:
+    """get_metadata / _extract_metadata route absolute art through the proxy (#933)."""
+
+    async def test_get_metadata_wraps_ma_lan_url(self):
+        hass = _make_hass()
+        hass.states.get().attributes["entity_picture"] = (
+            "http://192.168.0.191:8095/imageproxy?x=1"
+        )
+        svc = MediaPlayerService(hass, "media_player.test")
+        meta = await svc.get_metadata()
+        assert meta["album_art"].startswith("/beatify/api/albumart?url=")
+
+    def test_extract_metadata_wraps_ma_lan_url(self):
+        svc = MediaPlayerService(_make_hass(), "media_player.test")
+        state = _make_state()
+        state.attributes["entity_picture"] = "http://10.0.0.5:8095/imageproxy?y=2"
+        meta = svc._extract_metadata(state)
+        assert meta["album_art"].startswith("/beatify/api/albumart?url=")
+
+    def test_extract_metadata_keeps_relative_entity_picture(self):
+        svc = MediaPlayerService(_make_hass(), "media_player.test")
+        state = _make_state()
+        state.attributes["entity_picture"] = "/api/media_player_proxy/x?token=t"
+        meta = svc._extract_metadata(state)
+        assert meta["album_art"] == "/api/media_player_proxy/x?token=t"
+
+    def test_extract_metadata_defaults_to_no_artwork(self):
+        # No entity_picture attribute → the relative fallback, left untouched.
+        svc = MediaPlayerService(_make_hass(), "media_player.test")
+        meta = svc._extract_metadata(_make_state())
+        assert meta["album_art"] == "/beatify/static/img/no-artwork.svg"


### PR DESCRIPTION
Fixes #933.

## Problem

Music Assistant exposes `entity_picture` as an **absolute URL on the MA
server's LAN address** — e.g. `http://192.168.0.191:8095/imageproxy?...`.
Beatify read that via `MediaPlayerService.get_metadata` / `_extract_metadata`
and forwarded it verbatim to player clients.

A guest who joins via the QR code / nabu.casa remote URL is on a public
origin, so the browser's Private Network Access policy blocks the LAN
request:

```
Access to image at 'http://192.168.0.191:8095/imageproxy?...' blocked by
CORS policy: Permission was denied for this request to access the `local`
address space.  —  net::ERR_FAILED
```

Result: **broken album art for the primary join path** (any player not on
the LAN). Found by `/qa` live testing.

## Fix

Serve album art same-origin:

- **`proxy_album_art()`** (`services/media_player.py`) wraps any absolute
  `http(s)` album-art URL as `/beatify/api/albumart?url=<encoded>`. Relative
  URLs — HA's own signed media-player proxy path, the `no-artwork.svg`
  fallback — already same-origin, pass through untouched. Applied in both
  `get_metadata` and `_extract_metadata` so every broadcast path carries the
  proxied URL.
- **`AlbumArtView`** (`/beatify/api/albumart`, `requires_auth=False` so
  player browsers can reach it) re-fetches the upstream image server-side —
  HA *can* reach the LAN — and re-serves it same-origin with a 1-day cache
  header. Non-`http(s)` URLs are rejected with `400`.

## Tests

12 new tests: `proxy_album_art` wrapping/passthrough, `get_metadata` /
`_extract_metadata` wrapping, `AlbumArtView` input validation. Full suite:
382 passed (+12), no new failures.

> Note: the 12 failed / 76 errored tests on this branch are the pre-existing
> event-loop poisoning fixed separately in #932 — unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)