### PR TITLE
fix(#937): drop removed content_type kwarg from playlist-requests POST

### DIFF
--- a/custom_components/beatify/server/playlist_views.py
+++ b/custom_components/beatify/server/playlist_views.py
@@ -91,7 +91,13 @@ class PlaylistRequestsView(RateLimitMixin, HomeAssistantView):
             return _json_error("Too many requests", 429, code="RATE_LIMITED")
 
         try:
-            body = await request.json(content_type=None)
+            # #937: do NOT pass `content_type=` here — aiohttp 3.11+ removed
+            # that parameter from Request.json(). Passing it raised TypeError
+            # on every call, which the broad except below mislabelled as
+            # "Invalid JSON" — so every playlist-request save 400'd. Modern
+            # json() already parses without a content-type check, which is
+            # exactly what `content_type=None` was meant to achieve.
+            body = await request.json()
         except Exception:  # noqa: BLE001
             return _json_error("Invalid JSON", 400, code="INVALID_REQUEST")
 

--- a/tests/unit/test_playlist_requests_view.py
+++ b/tests/unit/test_playlist_requests_view.py
@@ -1,0 +1,72 @@
+"""Tests for PlaylistRequestsView's POST handler (#937).
+
+Before #937, POST /beatify/api/playlist-requests called
+`request.json(content_type=None)`. aiohttp 3.11+ removed the `content_type`
+parameter, so every call raised TypeError — masked by a broad except as
+"Invalid JSON" — and every save 400'd. These tests drive the *real* aiohttp
+`request.json()`, so a re-added `content_type=` kwarg would fail them again.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from unittest import mock
+from unittest.mock import AsyncMock, MagicMock
+
+from aiohttp import StreamReader
+from aiohttp.test_utils import make_mocked_request
+
+from custom_components.beatify.server.views import PlaylistRequestsView
+
+
+def _request_with_body(body: bytes):
+    """Build a POST request whose real `.json()` will read `body`."""
+    reader = StreamReader(
+        mock.Mock(_reading_paused=False), 2**16, loop=asyncio.get_event_loop()
+    )
+    reader.feed_data(body)
+    reader.feed_eof()
+    return make_mocked_request(
+        "POST",
+        "/beatify/api/playlist-requests",
+        headers={"Content-Type": "application/json"},
+        payload=reader,
+    )
+
+
+def _view() -> PlaylistRequestsView:
+    """A view whose file save is stubbed out (no disk I/O in the test)."""
+    hass = MagicMock()
+    hass.config.path = MagicMock(return_value="/tmp/beatify-test/requests.json")
+    # post() saves via async_add_executor_job(self._save_requests, data).
+    hass.async_add_executor_job = AsyncMock(return_value=True)
+    return PlaylistRequestsView(hass)
+
+
+class TestPlaylistRequestsPost:
+    """POST must accept a valid JSON body — it 400'd unconditionally before #937."""
+
+    async def test_valid_empty_body_is_saved(self):
+        request = _request_with_body(b'{"requests": [], "last_poll": null}')
+        resp = await _view().post(request)
+        # Regression: this returned 400 "Invalid JSON" for ALL bodies because
+        # request.json(content_type=None) raised TypeError on aiohttp 3.11+.
+        assert resp.status == 200
+        assert json.loads(resp.body)["success"] is True
+
+    async def test_valid_body_with_requests_is_saved(self):
+        item = {"issue_number": 1, "playlist_name": "Test", "status": "pending"}
+        request = _request_with_body(
+            json.dumps({"requests": [item], "last_poll": None}).encode()
+        )
+        resp = await _view().post(request)
+        assert resp.status == 200
+        assert json.loads(resp.body)["requests"][0]["issue_number"] == 1
+
+    async def test_malformed_json_still_returns_400(self):
+        # A genuinely broken body must still be rejected — that 400 is correct.
+        request = _request_with_body(b"{not valid json")
+        resp = await _view().post(request)
+        assert resp.status == 400
+        assert json.loads(resp.body)["error"] == "INVALID_REQUEST"


### PR DESCRIPTION
Fixes #937.

## Problem

Every `POST /beatify/api/playlist-requests` returned
`400 {"error":"INVALID_REQUEST","message":"Invalid JSON"}` — regardless of
the payload. Verified live: a minimal, valid `{"requests":[],"last_poll":null}`
body still 400'd.

`PlaylistRequestsView.post()` called:

```python
body = await request.json(content_type=None)
```

But the deployed **aiohttp 3.13** `Request.json` signature is:

```python
async def json(self, *, loads: JSONDecoder = DEFAULT_JSON_DECODER) -> Any:
```

aiohttp 3.11+ **removed the `content_type` parameter**. So the call raised
`TypeError: json() got an unexpected keyword argument 'content_type'` on
*every* request, before the body was read. The broad `except Exception:`
swallowed the `TypeError` and mislabelled it "Invalid JSON".

**Effect:** the playlist-request feature could read (`GET` works) but never
persist — `saveRequests()` failed silently after every submit, and every
admin page load logged `[PlaylistRequests] Backend save failed: 400`.

## Fix

Call plain `request.json()`. Modern aiohttp's `json()` already parses
without a content-type check — exactly what `content_type=None` was meant
to achieve. Confirmed isolated: this was the only `request.json(content_type=...)`
in the codebase; the other three POST handlers already use plain
`request.json()` and work (verified `preview-lights` live).

## Tests

3 new tests drive the **real** aiohttp `request.json()` via
`make_mocked_request` + `StreamReader` — not a mock — so a re-added
`content_type=` kwarg fails them again. A valid body now saves (`200`);
malformed JSON still correctly `400`s. I verified the tests fail with the
bug reintroduced and pass with the fix.

Pure backend Python — no bundle rebuild, no cache-buster bump.

> Note: any 12 failed / 76 errored tests on this branch are the
> pre-existing event-loop poisoning fixed separately in #932.

🤖 Generated with [Claude Code](https://claude.com/claude-code)