### PR TITLE
chore: ruff format 4 files to unblock the CI lint gate

### DIFF
--- a/custom_components/beatify/game/state.py
+++ b/custom_components/beatify/game/state.py
@@ -2189,14 +2189,8 @@ class GameState:
         if exact and self._tts_announce_exact_guess:
             names = exact[0] if len(exact) == 1 else " and ".join(exact)
             frags.append(f"{names} got it exactly right.")
-        elif (
-            self.closest_wins_mode
-            and not exact
-            and self._tts_announce_closest_guess
-        ):
-            submitted = [
-                p for p in players if p.submitted and p.years_off is not None
-            ]
+        elif self.closest_wins_mode and not exact and self._tts_announce_closest_guess:
+            submitted = [p for p in players if p.submitted and p.years_off is not None]
             if submitted:
                 winner = min(submitted, key=lambda p: p.years_off)
                 if winner.round_score > 0:
@@ -2337,9 +2331,7 @@ class GameState:
         """Announce a player using steal on another (use case 23)."""
         if not self._tts_service or not self._tts_announce_steal_used:
             return
-        await self._tts_announce(
-            f"{stealer_name} stole the answer from {target_name}!"
-        )
+        await self._tts_announce(f"{stealer_name} stole the answer from {target_name}!")
 
     def adjust_volume(self, direction: str) -> float:
         """

--- a/custom_components/beatify/server/game_views.py
+++ b/custom_components/beatify/server/game_views.py
@@ -365,9 +365,7 @@ class StartGameView(RateLimitMixin, HomeAssistantView):
                     announce_tied_first=tts_config.get("announce_tied_first", True),
                     announce_bet_won=tts_config.get("announce_bet_won", True),
                     announce_bet_lost=tts_config.get("announce_bet_lost", True),
-                    announce_player_join=tts_config.get(
-                        "announce_player_join", True
-                    ),
+                    announce_player_join=tts_config.get("announce_player_join", True),
                     announce_player_reconnect=tts_config.get(
                         "announce_player_reconnect", False
                     ),

--- a/custom_components/beatify/server/ws_handlers.py
+++ b/custom_components/beatify/server/ws_handlers.py
@@ -1379,14 +1379,18 @@ async def handle_report_data(
         playlist_file,
     )
 
-    reports_path = Path(handler.hass.config.path("beatify")) / "data_quality_reports.json"
+    reports_path = (
+        Path(handler.hass.config.path("beatify")) / "data_quality_reports.json"
+    )
     try:
         reports_path.parent.mkdir(parents=True, exist_ok=True)
         existing: list = []
         if reports_path.exists():
             existing = json.loads(reports_path.read_text(encoding="utf-8"))
         existing.append(report)
-        reports_path.write_text(json.dumps(existing, indent=2, ensure_ascii=False), encoding="utf-8")
+        reports_path.write_text(
+            json.dumps(existing, indent=2, ensure_ascii=False), encoding="utf-8"
+        )
     except Exception:  # noqa: BLE001
         _LOGGER.warning("Failed to write data quality report to %s", reports_path)
 
@@ -1424,7 +1428,11 @@ async def _create_gh_issue(
                 if resp.status not in (200, 201):
                     _LOGGER.debug(
                         "Worker /report-data returned %s for %s — %s",
-                        resp.status, artist, title,
+                        resp.status,
+                        artist,
+                        title,
                     )
     except Exception:  # noqa: BLE001
-        _LOGGER.debug("Worker /report-data call failed (non-critical) for %s — %s", artist, title)
+        _LOGGER.debug(
+            "Worker /report-data call failed (non-critical) for %s — %s", artist, title
+        )

--- a/tests/unit/test_tts_announcements.py
+++ b/tests/unit/test_tts_announcements.py
@@ -83,8 +83,9 @@ async def test_multiple_exact_guesses_joined():
 async def test_streak_milestone_fragment():
     state = _state()
     state.players = {
-        "Marco": _player("Marco", submitted=True, years_off=0, score=10,
-                          streak=5, streak_bonus=3),
+        "Marco": _player(
+            "Marco", submitted=True, years_off=0, score=10, streak=5, streak_bonus=3
+        ),
     }
     await state._announce_reveal(1991)
     assert "Marco is on a 5-song streak." in _spoken(state)
@@ -94,10 +95,12 @@ async def test_streak_milestone_fragment():
 async def test_bet_won_and_lost_fragments():
     state = _state()
     state.players = {
-        "Marco": _player("Marco", submitted=True, years_off=0, score=10,
-                          bet=True, bet_outcome="won"),
-        "Anna": _player("Anna", submitted=True, years_off=8, score=2,
-                        bet=True, bet_outcome="lost"),
+        "Marco": _player(
+            "Marco", submitted=True, years_off=0, score=10, bet=True, bet_outcome="won"
+        ),
+        "Anna": _player(
+            "Anna", submitted=True, years_off=8, score=2, bet=True, bet_outcome="lost"
+        ),
     }
     await state._announce_reveal(1991)
     spoken = _spoken(state)
@@ -109,10 +112,8 @@ async def test_bet_won_and_lost_fragments():
 async def test_closest_wins_winner_fragment():
     state = _state(closest_wins_mode=True)
     state.players = {
-        "Marco": _player("Marco", submitted=True, years_off=2, round_score=5,
-                         score=5),
-        "Anna": _player("Anna", submitted=True, years_off=9, round_score=0,
-                        score=0),
+        "Marco": _player("Marco", submitted=True, years_off=2, round_score=5, score=5),
+        "Anna": _player("Anna", submitted=True, years_off=9, round_score=0, score=0),
     }
     await state._announce_reveal(1991)
     assert "Marco was closest." in _spoken(state)
@@ -153,8 +154,9 @@ async def test_tie_at_top_resets_previous_leader():
 @pytest.mark.asyncio
 async def test_steal_unlock_announced_once_per_game():
     state = _state()
-    marco = _player("Marco", submitted=True, years_off=0, score=10,
-                    steal_available=True)
+    marco = _player(
+        "Marco", submitted=True, years_off=0, score=10, steal_available=True
+    )
     state.players = {"Marco": marco}
 
     await state._announce_reveal(1991)
@@ -192,8 +194,16 @@ async def test_all_toggles_off_is_silent():
 async def test_fragments_combine_into_one_utterance():
     state = _state(_tts_previous_leader="Anna")
     state.players = {
-        "Marco": _player("Marco", submitted=True, years_off=0, score=20,
-                         streak=5, streak_bonus=3, bet=True, bet_outcome="won"),
+        "Marco": _player(
+            "Marco",
+            submitted=True,
+            years_off=0,
+            score=20,
+            streak=5,
+            streak_bonus=3,
+            bet=True,
+            bet_outcome="won",
+        ),
     }
     await state._announce_reveal(1987)
     # One call, one combined sentence carrying every enabled fragment.


### PR DESCRIPTION
## Why

CI's `Lint` job runs `ruff format --check .`, which has been failing on 4
long-unformatted files:

- `custom_components/beatify/game/state.py`
- `custom_components/beatify/server/game_views.py`
- `custom_components/beatify/server/ws_handlers.py`
- `tests/unit/test_tts_announcements.py`

The CI `Test` job is gated `needs: lint`. So that formatting debt has been
**silently skipping the entire test suite on every push and PR** — 476
passing unit tests that GitHub never actually runs.

## What

`ruff format` on the 4 files. **Pure formatting** — line re-wrapping only
(collapsing multi-line calls that fit on one line, expanding ones that
don't). No logic change; review the diff to confirm.

## Verification

- `ruff format --check .` → all 60 files clean
- `ruff check .` → `All checks passed!`
- `pytest tests/unit/` → `476 passed`

Once this lands, the CI `Lint` gate goes green and the `Test` job runs for
the first time in a while — restoring real CI coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)