### PR TITLE
release: v3.3.6-rc4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ See [release notes](https://github.com/mholzi/beatify/releases/tag/v3.3.6) for t
 ### Fixed
 - **40 broken URIs in `harder-styles` (#916).** An automated health-check found 40 URIs (32 YouTube Music, 5 Apple Music, 3 Deezer) pointing to the wrong track. 32 re-resolved automatically; 5 obscure festival anthems pointed at the official label/organiser channel uploads; 3 left as best-available.
 - **Round stuck on "Waiting for others" (#928).** Early reveal counted every `connected` player, including a stale ghost whose WebSocket had already dropped — that ghost never submits, so the round never advanced and a restart hit the same wall. All-submitted detection now ignores players with a closed WebSocket, and a mid-round disconnect re-checks for early reveal.
+- **Album art broken for remote players (#933).** With a Music Assistant speaker, album art was served straight from the MA server's LAN address — so any guest who joined via the QR code / remote URL had it blocked by the browser. Art is now proxied through Beatify, same-origin, so remote players see it.
+- **Player kicked back to the join screen mid-round (#934).** A year/artist guess submitted in the instant a round flipped to reveal was rejected, and the player UI fell all the way back to the name-entry screen — wiping their session. Late guesses are now handled gracefully; the player simply lands on the reveal.
+- **"Start game" did nothing in the lobby (#935).** After a page reload the admin's Start button could call the create-game endpoint instead of begin-rounds and dead-end on a "409 — end current game first", for a game already sitting in the lobby. It now reconciles with the server before acting, and recovers automatically if it raced.
+- **Playlist requests never saved (#937).** Every save to the playlist-request store failed with a 400 — the handler passed an aiohttp parameter that newer versions removed, so the call crashed before reading the body. Saves work again.
 
 ### Data
 - **Harder Styles — 150 → 190 songs (#899).** 40 modern hardstyle tracks (festival anthems + hardstyle remixes of chart hits) folded in from playlist request #899, with per-region Apple Music URIs.

--- a/custom_components/beatify/manifest.json
+++ b/custom_components/beatify/manifest.json
@@ -12,5 +12,5 @@
   "documentation": "https://github.com/mholzi/beatify",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/mholzi/beatify/issues",
-  "version": "3.3.6-rc3"
+  "version": "3.3.6-rc4"
 }

--- a/custom_components/beatify/www/admin.html
+++ b/custom_components/beatify/www/admin.html
@@ -8,7 +8,7 @@
          query-string version, a stale en.json from a prior rc gets served
          after upgrade and references to newer keys render as raw strings.
          Bumped each rc alongside manifest.json + sw.js CACHE_VERSION. -->
-    <meta name="beatify-version" content="3.3.6-rc3">
+    <meta name="beatify-version" content="3.3.6-rc4">
     <title data-i18n="admin.title">Beatify Admin</title>
     <!-- PWA: Web App Manifest — Admin installs Beatify to homescreen (Issue #166) -->
     <link rel="manifest" href="/beatify/static/site.webmanifest">

--- a/custom_components/beatify/www/dashboard.html
+++ b/custom_components/beatify/www/dashboard.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <!-- #824: cache-bust i18n JSON fetches. See admin.html for rationale. -->
-    <meta name="beatify-version" content="3.3.6-rc3">
+    <meta name="beatify-version" content="3.3.6-rc4">
     <title data-i18n="dashboard.title">Beatify - Dashboard</title>
     <!-- Preconnect for faster font loading (Story 9.8) -->
     <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/custom_components/beatify/www/player.html
+++ b/custom_components/beatify/www/player.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <!-- #824: cache-bust i18n JSON fetches. See admin.html for rationale. -->
-    <meta name="beatify-version" content="3.3.6-rc3">
+    <meta name="beatify-version" content="3.3.6-rc4">
     <title data-i18n="join.title">Beatify - Join Game</title>
     <!-- Preconnect for faster font loading (Story 9.8) -->
     <link rel="preconnect" href="https://fonts.googleapis.com">


### PR DESCRIPTION
Cuts pre-release **v3.3.6-rc4** — the four QA-pass bug fixes on top of rc3.

## Included since rc3
- **#933** — album art proxied so QR-join / remote players can load it (was blocked: served from a LAN address)
- **#934** — late guesses no longer kick the player back to the join screen and wipe their session
- **#935** — the lobby "Start game" button no longer dead-ends on a 409
- **#937** — playlist-request saves no longer 400 (removed aiohttp kwarg)

(Also on main since rc3, not user-facing: #932 test event-loop fix, #945 lint-format debt cleared — CI's test job now runs.)

## Version bumps
- `manifest.json` → `3.3.6-rc4`
- `<meta beatify-version>` in `admin.html` / `dashboard.html` / `player.html` → `3.3.6-rc4`
- `sw.js` `CACHE_VERSION` already at `beatify-v3.3.6-rc4` (bumped by the merged #934/#935 fixes)
- `CHANGELOG.md` `[3.3.6]` Fixed section updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)