### PR TITLE
chore: fix stale player bundle path in service worker precache

### DIFF
--- a/custom_components/beatify/www/sw.js
+++ b/custom_components/beatify/www/sw.js
@@ -13,7 +13,7 @@ var MAX_CACHE_ITEMS = 50;
 var PRECACHE_ASSETS = [
     '/beatify/static/css/styles.min.css',
     '/beatify/static/css/dashboard.min.css',
-    '/beatify/static/js/player.min.js',
+    '/beatify/static/js/player.bundle.min.js',
     '/beatify/static/js/admin.min.js',
     '/beatify/static/js/dashboard.min.js',
     '/beatify/static/js/i18n.min.js',


### PR DESCRIPTION
## Summary
- `custom_components/beatify/www/sw.js` precached `/beatify/static/js/player.min.js`, a file that no longer exists after the player frontend migrated to an esbuild bundle.
- The service worker's install handler ran `cache.add()` on that path, which 404'd on every page load and threw `TypeError: Failed to execute 'add' on 'Cache'`. It's caught by a `.catch()` so it was harmless, but it spammed the browser console.
- Found while reviewing browser console logs during QA. This is a no-behavior-change fix — it just points the precache entry at the real file, `player.bundle.min.js`.

## Notes
- `sw.js` is served as-is (no build step), and browsers byte-compare it on their own update cycle, so no `CACHE_VERSION` bump is needed.
- The other 10 `PRECACHE_ASSETS` entries were verified and are fine.

## Test plan
- [ ] Load a Beatify page and confirm no `Failed to execute 'add' on 'Cache'` error in the console for `player.bundle.min.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)