### PR TITLE
release: v3.3.6-rc7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ See [release notes](https://github.com/mholzi/beatify/releases/tag/v3.3.6) for t
 - **Service worker no longer logs a failed-cache error (#948).** The offline precache list still pointed at the old single-file player script after it became a bundle; corrected to the real filename.
 - **No feedback when Music Assistant can't play (#949).** When the speaker stayed silent (idle, or the streaming provider unauthenticated), the game retried for ~2 minutes behind a frozen "Starting…" button before saying anything. It now pauses within seconds and shows the recovery banner — which names the provider to re-authenticate and offers Resume — straight away.
 - **"Join as player" button vanished after the first game (#956).** Once the host had joined any game as a player, a stale browser-session marker hid the button for every later game in that tab — even a brand-new lobby. The button now reflects only the current game's state.
+- **Admin "Start game" button could freeze on "Starting…" (#949).** When playback couldn't begin, the server reported the failure but the admin page didn't act on it — the button stayed frozen with no message. It now resets, surfaces the reason, and drops the host straight onto the recovery banner.
+- **Missing Intro Mode translations (#938).** The intro-round splash referenced four translation keys that didn't exist, logging console warnings on load; added across all five languages.
+- **Admin page no longer calls the GitHub API from the browser (#939).** The playlist-request list polled GitHub directly from the browser — unauthenticated, rate-limited, and spamming the console with 403s. The browser-side poll was removed; the list still loads from Beatify's own backend.
+- **"1 players in lobby" pluralization (#940).** A one-player lobby now reads "1 player".
 
 ### Data
 - **3 wrong URIs fixed in 2010s & 2020s Hits (#954).** Three tracks in the community playlist pointed at the wrong song; re-resolved.

--- a/custom_components/beatify/manifest.json
+++ b/custom_components/beatify/manifest.json
@@ -12,5 +12,5 @@
   "documentation": "https://github.com/mholzi/beatify",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/mholzi/beatify/issues",
-  "version": "3.3.6-rc6"
+  "version": "3.3.6-rc7"
 }

--- a/custom_components/beatify/www/admin.html
+++ b/custom_components/beatify/www/admin.html
@@ -8,7 +8,7 @@
          query-string version, a stale en.json from a prior rc gets served
          after upgrade and references to newer keys render as raw strings.
          Bumped each rc alongside manifest.json + sw.js CACHE_VERSION. -->
-    <meta name="beatify-version" content="3.3.6-rc6">
+    <meta name="beatify-version" content="3.3.6-rc7">
     <title data-i18n="admin.title">Beatify Admin</title>
     <!-- PWA: Web App Manifest — Admin installs Beatify to homescreen (Issue #166) -->
     <link rel="manifest" href="/beatify/static/site.webmanifest">

--- a/custom_components/beatify/www/dashboard.html
+++ b/custom_components/beatify/www/dashboard.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <!-- #824: cache-bust i18n JSON fetches. See admin.html for rationale. -->
-    <meta name="beatify-version" content="3.3.6-rc6">
+    <meta name="beatify-version" content="3.3.6-rc7">
     <title data-i18n="dashboard.title">Beatify - Dashboard</title>
     <!-- Preconnect for faster font loading (Story 9.8) -->
     <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/custom_components/beatify/www/player.html
+++ b/custom_components/beatify/www/player.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <!-- #824: cache-bust i18n JSON fetches. See admin.html for rationale. -->
-    <meta name="beatify-version" content="3.3.6-rc6">
+    <meta name="beatify-version" content="3.3.6-rc7">
     <title data-i18n="join.title">Beatify - Join Game</title>
     <!-- Preconnect for faster font loading (Story 9.8) -->
     <link rel="preconnect" href="https://fonts.googleapis.com">


### PR DESCRIPTION
Pre-release **v3.3.6-rc7** — closes out the QA-pass bug list.

## Since rc6
- **#949** — the admin "Start game" button no longer freezes on "Starting…" when playback can't begin; it resets, surfaces the reason, and shows the recovery banner (completes the server-side half shipped in rc6).
- **#938** — missing Intro Mode translation keys added across all 5 languages.
- **#939** — removed the browser-side GitHub API poll (unauthenticated, rate-limited, 403-spam).
- **#940** — "1 player in lobby" pluralization.

## Version
- `manifest.json` + `<meta beatify-version>` → `3.3.6-rc7`
- `sw.js` `CACHE_VERSION` and `?v=` cache-busters already at `rc7` (from #959/#960)
- `CHANGELOG.md` updated

`main` health at cut: 480 unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)