### PR TITLE
release: v3.3.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to Beatify are documented here. For detailed release notes, 
 
 ## [Unreleased]
 
-## [3.3.6] - 2026-05-17
+## [3.3.6] - 2026-05-18
 
 See [release notes](https://github.com/mholzi/beatify/releases/tag/v3.3.6) for the user-facing summary.
 

--- a/custom_components/beatify/manifest.json
+++ b/custom_components/beatify/manifest.json
@@ -12,5 +12,5 @@
   "documentation": "https://github.com/mholzi/beatify",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/mholzi/beatify/issues",
-  "version": "3.3.6-rc9"
+  "version": "3.3.6"
 }

--- a/custom_components/beatify/www/admin.html
+++ b/custom_components/beatify/www/admin.html
@@ -8,7 +8,7 @@
          query-string version, a stale en.json from a prior rc gets served
          after upgrade and references to newer keys render as raw strings.
          Bumped each rc alongside manifest.json + sw.js CACHE_VERSION. -->
-    <meta name="beatify-version" content="3.3.6-rc9">
+    <meta name="beatify-version" content="3.3.6">
     <title data-i18n="admin.title">Beatify Admin</title>
     <!-- PWA: Web App Manifest — Admin installs Beatify to homescreen (Issue #166) -->
     <link rel="manifest" href="/beatify/static/site.webmanifest">

--- a/custom_components/beatify/www/dashboard.html
+++ b/custom_components/beatify/www/dashboard.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <!-- #824: cache-bust i18n JSON fetches. See admin.html for rationale. -->
-    <meta name="beatify-version" content="3.3.6-rc9">
+    <meta name="beatify-version" content="3.3.6">
     <title data-i18n="dashboard.title">Beatify - Dashboard</title>
     <!-- Preconnect for faster font loading (Story 9.8) -->
     <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/custom_components/beatify/www/player.html
+++ b/custom_components/beatify/www/player.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <!-- #824: cache-bust i18n JSON fetches. See admin.html for rationale. -->
-    <meta name="beatify-version" content="3.3.6-rc9">
+    <meta name="beatify-version" content="3.3.6">
     <title data-i18n="join.title">Beatify - Join Game</title>
     <!-- Preconnect for faster font loading (Story 9.8) -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -912,6 +912,6 @@
     <!-- Version query strings prevent browser caching issues -->
     <script src="/beatify/static/js/i18n.min.js"></script>
     <script src="/beatify/static/js/utils.min.js"></script>
-    <script type="module" src="/beatify/static/js/player.bundle.min.js?v=3.3.6-rc9"></script>
+    <script type="module" src="/beatify/static/js/player.bundle.min.js?v=3.3.6"></script>
 </body>
 </html>

--- a/custom_components/beatify/www/sw.js
+++ b/custom_components/beatify/www/sw.js
@@ -6,7 +6,7 @@
  */
 'use strict';
 
-var CACHE_VERSION = 'beatify-v3.3.6-rc9';
+var CACHE_VERSION = 'beatify-v3.3.6';
 var MAX_CACHE_ITEMS = 50;
 
 // Critical assets to precache on install (minified versions only - fallback handled by HTML)


### PR DESCRIPTION
Stable promotion of the **v3.3.6-rc1 … rc9** line.

## Highlights

- **The TTS voice roadmap is complete** — Phases 3 & 4 add the last ten announcements, the per-round REVEAL is narrated as one flowing sentence, and verbosity presets (Minimal / Standard / Full) land in both the admin panel and the setup wizard.
- **Party-night reliability pass** — self-healing stuck rounds (#928, #964, #967), reload-proof host controls (#935, #951), an actionable playback-failure banner (#949), no mid-round kick to the join screen (#934), album art for remote players (#933), and a TV dashboard that scales to any viewport (#963).
- **Two new community playlists** — Divorced Dad Rock (#910) and EDM Anthems (#955); Harder Styles, 90s Hits and Deutschpop Klassiker expanded.
- **Library-wide year audit** — 274 wrong release years corrected (#911).

## Release mechanics

Strips the `-rc9` suffix from `manifest.json`, the three `<meta beatify-version>` tags, `sw.js` `CACHE_VERSION` (→ `beatify-v3.3.6`) and the player `?v=` cache-buster. CHANGELOG `[3.3.6]` dated 2026-05-18.

No code changes vs rc9 — version strings only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)