### PR TITLE
fix: sync playlist-request status from GitHub issue state (#970)

### DIFF
--- a/custom_components/beatify/server/playlist_views.py
+++ b/custom_components/beatify/server/playlist_views.py
@@ -2,13 +2,17 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
+import re
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 from aiohttp import web
 from homeassistant.components.http import HomeAssistantView
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from custom_components.beatify.server.base import (
     RateLimitMixin,
@@ -19,6 +23,34 @@ if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
 
 _LOGGER = logging.getLogger(__name__)
+
+# Labels that mean a closed request was turned down rather than delivered.
+_DECLINED_LABELS = frozenset({"declined", "wont-fix", "wontfix", "duplicate", "invalid"})
+# Optional vX.Y.Z label the maintainer may add to record the shipping release.
+_VERSION_LABEL_RE = re.compile(r"^v?(\d+\.\d+\.\d+\S*)$")
+
+
+def _issue_to_status(state: str, labels: list[str]) -> tuple[str, str | None]:
+    """Map a GitHub issue's state + labels to a request status (#970).
+
+    The issue STATE is the source of truth, not a specific label: any
+    closed request issue counts as delivered unless it carries a decline
+    label. This is deliberate — the old browser poller only recognised a
+    `playlist-ready` + `vX.Y.Z` label pair, so requests the maintainer
+    closed with `approved` (the actual habit) never advanced past
+    "submitted". Returns (status, release_version | None).
+    """
+    if state != "closed":
+        return "pending", None
+    if any(label.lower() in _DECLINED_LABELS for label in labels):
+        return "declined", None
+    version: str | None = None
+    for label in labels:
+        match = _VERSION_LABEL_RE.match(label.strip())
+        if match:
+            version = match.group(1)
+            break
+    return "ready", version
 
 
 class PlaylistRequestsView(RateLimitMixin, HomeAssistantView):
@@ -36,6 +68,13 @@ class PlaylistRequestsView(RateLimitMixin, HomeAssistantView):
     MAX_FIELD_LENGTH = 500
     RATE_LIMIT_REQUESTS = 10
     RATE_LIMIT_WINDOW = 60  # seconds
+
+    # Server-side status sync (#970). GET reconciles pending requests
+    # against GitHub issue state, throttled to once an hour so a busy Hub
+    # tab can't hammer GitHub's unauthenticated 60/hr-per-IP limit.
+    GITHUB_ISSUES_API = "https://api.github.com/repos/mholzi/beatify/issues"
+    POLL_INTERVAL_SECONDS = 3600
+    POLL_TIMEOUT_SECONDS = 12
 
     def __init__(self, hass: HomeAssistant) -> None:
         """Initialize view."""
@@ -78,9 +117,100 @@ class PlaylistRequestsView(RateLimitMixin, HomeAssistantView):
             _LOGGER.error("Failed to save playlist requests: %s", e)
             return False
 
+    def _poll_due(self, data: dict) -> bool:
+        """Return True if the GitHub status sync hasn't run within the interval."""
+        last_poll = data.get("last_poll")
+        if not last_poll:
+            return True
+        try:
+            last = datetime.fromisoformat(str(last_poll).replace("Z", "+00:00"))
+        except ValueError:
+            return True
+        if last.tzinfo is None:
+            last = last.replace(tzinfo=timezone.utc)
+        elapsed = (datetime.now(timezone.utc) - last).total_seconds()
+        return elapsed >= self.POLL_INTERVAL_SECONDS
+
+    async def _fetch_issue(
+        self, session: object, issue_number: object
+    ) -> tuple[str, list[str]] | None:
+        """Fetch one GitHub issue's state + label names, or None on any failure."""
+        try:
+            async with session.get(
+                f"{self.GITHUB_ISSUES_API}/{issue_number}",
+                headers={"Accept": "application/vnd.github+json"},
+            ) as resp:
+                if resp.status != 200:
+                    _LOGGER.debug(
+                        "Playlist-request poll: issue %s returned HTTP %s",
+                        issue_number,
+                        resp.status,
+                    )
+                    return None
+                issue = await resp.json()
+            labels = [
+                label.get("name", "")
+                for label in issue.get("labels", [])
+                if isinstance(label, dict)
+            ]
+            return issue.get("state", ""), labels
+        except Exception as err:  # noqa: BLE001
+            _LOGGER.debug("Playlist-request poll: issue %s failed: %s", issue_number, err)
+            return None
+
+    async def _poll_statuses(self, data: dict) -> dict:
+        """Reconcile pending request statuses against GitHub issue state (#970).
+
+        Stamps `last_poll` whenever a poll is attempted — even if there is
+        nothing pending or GitHub is unreachable — so a failure backs off
+        for the full interval instead of retrying on every Hub open.
+        """
+        now = datetime.now(timezone.utc).isoformat()
+        data["last_poll"] = now
+
+        requests = data.get("requests", [])
+        pending = [
+            r
+            for r in requests
+            if isinstance(r, dict)
+            and r.get("issue_number")
+            and r.get("status") in (None, "", "pending", "ready")
+        ]
+        if not pending:
+            return data
+
+        session = async_get_clientsession(self.hass)
+        try:
+            results = await asyncio.wait_for(
+                asyncio.gather(
+                    *(self._fetch_issue(session, r["issue_number"]) for r in pending)
+                ),
+                timeout=self.POLL_TIMEOUT_SECONDS,
+            )
+        except Exception as err:  # noqa: BLE001
+            _LOGGER.debug("Playlist-request poll aborted: %s", err)
+            return data
+
+        for req, result in zip(pending, results):
+            if result is None:
+                continue
+            state, labels = result
+            status, version = _issue_to_status(state, labels)
+            req["status"] = status
+            req["last_checked"] = now
+            if version:
+                req["release_version"] = version
+        return data
+
     async def get(self, request: web.Request) -> web.Response:  # noqa: ARG002
-        """Get all playlist requests."""
+        """Get all playlist requests, refreshing statuses from GitHub if due."""
         data = await self.hass.async_add_executor_job(self._load_requests)
+        if self._poll_due(data):
+            try:
+                data = await self._poll_statuses(data)
+                await self.hass.async_add_executor_job(self._save_requests, data)
+            except Exception as err:  # noqa: BLE001
+                _LOGGER.debug("Playlist-request status poll failed: %s", err)
         return web.json_response(data)
 
     async def post(self, request: web.Request) -> web.Response:

--- a/custom_components/beatify/server/playlist_views.py
+++ b/custom_components/beatify/server/playlist_views.py
@@ -25,7 +25,9 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 
 # Labels that mean a closed request was turned down rather than delivered.
-_DECLINED_LABELS = frozenset({"declined", "wont-fix", "wontfix", "duplicate", "invalid"})
+_DECLINED_LABELS = frozenset(
+    {"declined", "wont-fix", "wontfix", "duplicate", "invalid"}
+)
 # Optional vX.Y.Z label the maintainer may add to record the shipping release.
 _VERSION_LABEL_RE = re.compile(r"^v?(\d+\.\d+\.\d+\S*)$")
 
@@ -155,7 +157,9 @@ class PlaylistRequestsView(RateLimitMixin, HomeAssistantView):
             ]
             return issue.get("state", ""), labels
         except Exception as err:  # noqa: BLE001
-            _LOGGER.debug("Playlist-request poll: issue %s failed: %s", issue_number, err)
+            _LOGGER.debug(
+                "Playlist-request poll: issue %s failed: %s", issue_number, err
+            )
             return None
 
     async def _poll_statuses(self, data: dict) -> dict:

--- a/tests/unit/test_playlist_requests_view.py
+++ b/tests/unit/test_playlist_requests_view.py
@@ -11,12 +11,14 @@ from __future__ import annotations
 
 import asyncio
 import json
+from datetime import datetime, timezone
 from unittest import mock
 from unittest.mock import AsyncMock, MagicMock
 
 from aiohttp import StreamReader
 from aiohttp.test_utils import make_mocked_request
 
+from custom_components.beatify.server.playlist_views import _issue_to_status
 from custom_components.beatify.server.views import PlaylistRequestsView
 
 
@@ -70,3 +72,107 @@ class TestPlaylistRequestsPost:
         resp = await _view().post(request)
         assert resp.status == 400
         assert json.loads(resp.body)["error"] == "INVALID_REQUEST"
+
+
+# ---------------------------------------------------------------------------
+# Server-side status sync (#970)
+# ---------------------------------------------------------------------------
+
+
+class TestIssueToStatus:
+    """The issue STATE is the source of truth — not a specific label. A
+    request closed however the maintainer labelled it counts as delivered."""
+
+    def test_open_issue_is_pending(self):
+        assert _issue_to_status("open", ["playlist-request"]) == ("pending", None)
+
+    def test_closed_with_approved_is_delivered(self):
+        # The exact case of #73 / #74 — closed with `approved`, never
+        # `playlist-ready`. The old poller left these stuck on "submitted".
+        assert _issue_to_status("closed", ["playlist-request", "approved"]) == (
+            "ready",
+            None,
+        )
+
+    def test_closed_with_no_labels_is_delivered(self):
+        assert _issue_to_status("closed", []) == ("ready", None)
+
+    def test_closed_with_decline_label_is_declined(self):
+        assert _issue_to_status("closed", ["wont-fix"]) == ("declined", None)
+
+    def test_version_label_is_extracted(self):
+        status, version = _issue_to_status("closed", ["playlist-ready", "v3.3.6"])
+        assert status == "ready"
+        assert version == "3.3.6"
+
+
+def _get_view_with_store(store: dict) -> PlaylistRequestsView:
+    """A view whose load/save are stubbed so get() runs against `store`."""
+    hass = MagicMock()
+    hass.config.path = MagicMock(return_value="/tmp/beatify-test/requests.json")
+    # get() funnels both _load_requests and _save_requests through this.
+    hass.async_add_executor_job = AsyncMock(side_effect=lambda fn, *a: fn(*a))
+    view = PlaylistRequestsView(hass)
+    view._load_requests = MagicMock(return_value=store)
+    view._save_requests = MagicMock(return_value=True)
+    return view
+
+
+def _get_request():
+    return make_mocked_request("GET", "/beatify/api/playlist-requests")
+
+
+class TestStatusSyncOnGet:
+    """GET reconciles pending requests against GitHub, throttled by last_poll."""
+
+    async def test_get_marks_closed_request_delivered(self):
+        store = {
+            "requests": [{"issue_number": 73, "status": "pending"}],
+            "last_poll": None,
+        }
+        view = _get_view_with_store(store)
+        view._fetch_issue = AsyncMock(return_value=("closed", ["approved"]))
+
+        with mock.patch(
+            "custom_components.beatify.server.playlist_views.async_get_clientsession",
+            return_value=MagicMock(),
+        ):
+            resp = await view.get(_get_request())
+
+        body = json.loads(resp.body)
+        assert body["requests"][0]["status"] == "ready"
+        assert body["last_poll"] is not None
+        view._save_requests.assert_called_once()
+
+    async def test_get_skips_poll_when_recently_polled(self):
+        store = {
+            "requests": [{"issue_number": 73, "status": "pending"}],
+            "last_poll": datetime.now(timezone.utc).isoformat(),
+        }
+        view = _get_view_with_store(store)
+        view._fetch_issue = AsyncMock()
+
+        resp = await view.get(_get_request())
+
+        view._fetch_issue.assert_not_awaited()
+        assert json.loads(resp.body)["requests"][0]["status"] == "pending"
+
+    async def test_get_keeps_status_when_github_unreachable(self):
+        store = {
+            "requests": [{"issue_number": 73, "status": "pending"}],
+            "last_poll": None,
+        }
+        view = _get_view_with_store(store)
+        # _fetch_issue returning None == GitHub error / 403 / network failure.
+        view._fetch_issue = AsyncMock(return_value=None)
+
+        with mock.patch(
+            "custom_components.beatify.server.playlist_views.async_get_clientsession",
+            return_value=MagicMock(),
+        ):
+            resp = await view.get(_get_request())
+
+        body = json.loads(resp.body)
+        assert body["requests"][0]["status"] == "pending"
+        # last_poll still stamped so a failure backs off for the full interval.
+        assert body["last_poll"] is not None


### PR DESCRIPTION
Closes #970.

## Problem

A delivered playlist request stays stuck on "submitted" in the Playlist Hub's "Meine" tab forever — e.g. #73 and #74, both shipped and closed since January, still show `OFFEN / EINGEREICHT`.

The request `status` field is write-once: `playlist-requests.js` stores `'pending'` at submission and nothing reconciles it afterward.

**This predates #939.** The old browser poller (`pollStatuses`) only advanced a request when its issue carried **both** a `playlist-ready` label **and** a `vX.Y.Z` version label:

```js
else if (labels.includes('playlist-ready')) {
    const versionLabel = labels.find(l => /^v\d+\.\d+\.\d+/.test(l));
    if (versionLabel) { /* only here: status -> ready */ }
}
```

The maintainer closes request issues with `approved`, so they never matched. #939 then removed that poller entirely (it was 403-spamming the console, unauthenticated) — widening the breakage from "`approved`-closed requests" to *every* request.

## Fix

`PlaylistRequestsView.get()` now reconciles pending requests against GitHub issue state, server-side:

- Throttled to once per hour via the long-unused `last_poll` field already in the storage schema.
- The issue **state** is the source of truth, **not a label** — any closed request issue counts as delivered unless it carries a decline label (`wont-fix`, `declined`, `duplicate`, …). This repairs both the original label-mismatch failure and the post-#939 total failure.
- A `vX.Y.Z` label, if present, is still picked up for the "update available" CTA — but it is no longer *required* to mark a request delivered.
- One HA server polling hourly stays far under GitHub's unauthenticated 60/hr-per-IP limit — the opposite of the old every-browser-tab poll.
- A failed / timed-out poll still stamps `last_poll`, so it backs off for the full interval instead of retrying on every Hub open.

**No frontend change** — the Hub already renders `status: 'ready'` as delivered (progress bar full). The bug was purely that nothing ever set that status.

## Tests

`TestIssueToStatus` (5) — state→status mapping, incl. the `approved`-closed case. `TestStatusSyncOnGet` (3) — GET marks a closed request delivered, skips the poll when recently polled, and keeps status unchanged when GitHub is unreachable. Full unit suite: 493 passed · `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)