### PR TITLE
release: v3.3.7-rc1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to Beatify are documented here. For detailed release notes, 
 
 ## [Unreleased]
 
+## [3.3.7] - 2026-05-18
+
+### Fixed
+- **Playlist-request status never updated (#970).** A delivered playlist request stayed stuck on "submitted" in the Playlist Hub's "Meine" tab forever. The request `status` field was write-once and nothing reconciled it afterward — the old browser poller (removed in #939) had only ever advanced a request carrying both a `playlist-ready` label and a `vX.Y.Z` version label, so requests the maintainer closed with `approved` never matched. `PlaylistRequestsView.get()` now reconciles pending requests against GitHub issue **state** (a closed issue means delivered, independent of label), server-side and throttled to once an hour.
+
 ## [3.3.6] - 2026-05-18
 
 See [release notes](https://github.com/mholzi/beatify/releases/tag/v3.3.6) for the user-facing summary.

--- a/custom_components/beatify/manifest.json
+++ b/custom_components/beatify/manifest.json
@@ -12,5 +12,5 @@
   "documentation": "https://github.com/mholzi/beatify",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/mholzi/beatify/issues",
-  "version": "3.3.6"
+  "version": "3.3.7-rc1"
 }

--- a/custom_components/beatify/www/admin.html
+++ b/custom_components/beatify/www/admin.html
@@ -8,7 +8,7 @@
          query-string version, a stale en.json from a prior rc gets served
          after upgrade and references to newer keys render as raw strings.
          Bumped each rc alongside manifest.json + sw.js CACHE_VERSION. -->
-    <meta name="beatify-version" content="3.3.6">
+    <meta name="beatify-version" content="3.3.7-rc1">
     <title data-i18n="admin.title">Beatify Admin</title>
     <!-- PWA: Web App Manifest — Admin installs Beatify to homescreen (Issue #166) -->
     <link rel="manifest" href="/beatify/static/site.webmanifest">

--- a/custom_components/beatify/www/dashboard.html
+++ b/custom_components/beatify/www/dashboard.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <!-- #824: cache-bust i18n JSON fetches. See admin.html for rationale. -->
-    <meta name="beatify-version" content="3.3.6">
+    <meta name="beatify-version" content="3.3.7-rc1">
     <title data-i18n="dashboard.title">Beatify - Dashboard</title>
     <!-- Preconnect for faster font loading (Story 9.8) -->
     <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/custom_components/beatify/www/player.html
+++ b/custom_components/beatify/www/player.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <!-- #824: cache-bust i18n JSON fetches. See admin.html for rationale. -->
-    <meta name="beatify-version" content="3.3.6">
+    <meta name="beatify-version" content="3.3.7-rc1">
     <title data-i18n="join.title">Beatify - Join Game</title>
     <!-- Preconnect for faster font loading (Story 9.8) -->
     <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/custom_components/beatify/www/sw.js
+++ b/custom_components/beatify/www/sw.js
@@ -6,7 +6,7 @@
  */
 'use strict';
 
-var CACHE_VERSION = 'beatify-v3.3.6';
+var CACHE_VERSION = 'beatify-v3.3.7-rc1';
 var MAX_CACHE_ITEMS = 50;
 
 // Critical assets to precache on install (minified versions only - fallback handled by HTML)


### PR DESCRIPTION
First **v3.3.7** release candidate. Carries the one fix that missed the v3.3.6 cutoff:

- **#970** — playlist-request status now syncs from GitHub issue state. A delivered request advances past "submitted" in the Playlist Hub's "Meine" tab, instead of staying stuck forever. The reconciliation is server-side, treats issue **state** (closed = delivered) as the source of truth, and is throttled to once an hour.

Bumps `manifest.json` + `<meta beatify-version>` to `3.3.7-rc1` and `sw.js` `CACHE_VERSION` to `beatify-v3.3.7-rc1`. Per-asset `?v=` cache-busters are unchanged — #970 was a server-side Python fix, no `www/` asset changed. CHANGELOG updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)