### PR TITLE
fix: show declined playlist requests as declined, not ready (#970 follow-up)

### DIFF
--- a/custom_components/beatify/server/playlist_views.py
+++ b/custom_components/beatify/server/playlist_views.py
@@ -32,19 +32,29 @@ _DECLINED_LABELS = frozenset(
 _VERSION_LABEL_RE = re.compile(r"^v?(\d+\.\d+\.\d+\S*)$")
 
 
-def _issue_to_status(state: str, labels: list[str]) -> tuple[str, str | None]:
-    """Map a GitHub issue's state + labels to a request status (#970).
+def _issue_to_status(
+    state: str, state_reason: str, labels: list[str]
+) -> tuple[str, str | None]:
+    """Map a GitHub issue's state + close reason + labels to a request status.
 
     The issue STATE is the source of truth, not a specific label: any
-    closed request issue counts as delivered unless it carries a decline
-    label. This is deliberate — the old browser poller only recognised a
-    `playlist-ready` + `vX.Y.Z` label pair, so requests the maintainer
-    closed with `approved` (the actual habit) never advanced past
-    "submitted". Returns (status, release_version | None).
+    closed request issue counts as delivered unless it was closed as "not
+    planned" or carries a decline label. This is deliberate — the old
+    browser poller only recognised a `playlist-ready` + `vX.Y.Z` label
+    pair, so requests the maintainer closed with `approved` (the actual
+    habit) never advanced past "submitted".
+
+    Honouring GitHub's `not_planned` close reason (follow-up to #970) means
+    a maintainer can decline a request just by closing it that way — a
+    declined request would otherwise show the user a misleading "ready"
+    status unless a decline label was added by hand. Returns
+    (status, release_version | None).
     """
     if state != "closed":
         return "pending", None
-    if any(label.lower() in _DECLINED_LABELS for label in labels):
+    if state_reason == "not_planned" or any(
+        label.lower() in _DECLINED_LABELS for label in labels
+    ):
         return "declined", None
     version: str | None = None
     for label in labels:
@@ -135,8 +145,8 @@ class PlaylistRequestsView(RateLimitMixin, HomeAssistantView):
 
     async def _fetch_issue(
         self, session: object, issue_number: object
-    ) -> tuple[str, list[str]] | None:
-        """Fetch one GitHub issue's state + label names, or None on any failure."""
+    ) -> tuple[str, str, list[str]] | None:
+        """Fetch a GitHub issue's state, close reason and labels, or None on failure."""
         try:
             async with session.get(
                 f"{self.GITHUB_ISSUES_API}/{issue_number}",
@@ -155,7 +165,7 @@ class PlaylistRequestsView(RateLimitMixin, HomeAssistantView):
                 for label in issue.get("labels", [])
                 if isinstance(label, dict)
             ]
-            return issue.get("state", ""), labels
+            return issue.get("state", ""), issue.get("state_reason") or "", labels
         except Exception as err:  # noqa: BLE001
             _LOGGER.debug(
                 "Playlist-request poll: issue %s failed: %s", issue_number, err
@@ -198,8 +208,8 @@ class PlaylistRequestsView(RateLimitMixin, HomeAssistantView):
         for req, result in zip(pending, results):
             if result is None:
                 continue
-            state, labels = result
-            status, version = _issue_to_status(state, labels)
+            state, state_reason, labels = result
+            status, version = _issue_to_status(state, state_reason, labels)
             req["status"] = status
             req["last_checked"] = now
             if version:

--- a/tests/unit/test_playlist_requests_view.py
+++ b/tests/unit/test_playlist_requests_view.py
@@ -81,27 +81,41 @@ class TestPlaylistRequestsPost:
 
 class TestIssueToStatus:
     """The issue STATE is the source of truth — not a specific label. A
-    request closed however the maintainer labelled it counts as delivered."""
+    request closed as completed counts as delivered; one closed as "not
+    planned" (or carrying a decline label) counts as declined."""
 
     def test_open_issue_is_pending(self):
-        assert _issue_to_status("open", ["playlist-request"]) == ("pending", None)
+        assert _issue_to_status("open", "", ["playlist-request"]) == ("pending", None)
 
     def test_closed_with_approved_is_delivered(self):
         # The exact case of #73 / #74 — closed with `approved`, never
         # `playlist-ready`. The old poller left these stuck on "submitted".
-        assert _issue_to_status("closed", ["playlist-request", "approved"]) == (
-            "ready",
+        assert _issue_to_status(
+            "closed", "completed", ["playlist-request", "approved"]
+        ) == ("ready", None)
+
+    def test_closed_with_no_labels_is_delivered(self):
+        assert _issue_to_status("closed", "completed", []) == ("ready", None)
+
+    def test_closed_with_decline_label_is_declined(self):
+        assert _issue_to_status("closed", "completed", ["wont-fix"]) == (
+            "declined",
             None,
         )
 
-    def test_closed_with_no_labels_is_delivered(self):
-        assert _issue_to_status("closed", []) == ("ready", None)
-
-    def test_closed_with_decline_label_is_declined(self):
-        assert _issue_to_status("closed", ["wont-fix"]) == ("declined", None)
+    def test_closed_not_planned_is_declined(self):
+        # A request the maintainer simply closed as "not planned", with no
+        # decline label — must not show the user a misleading "ready".
+        assert _issue_to_status("closed", "not_planned", []) == ("declined", None)
+        assert _issue_to_status("closed", "not_planned", ["playlist-request"]) == (
+            "declined",
+            None,
+        )
 
     def test_version_label_is_extracted(self):
-        status, version = _issue_to_status("closed", ["playlist-ready", "v3.3.6"])
+        status, version = _issue_to_status(
+            "closed", "completed", ["playlist-ready", "v3.3.6"]
+        )
         assert status == "ready"
         assert version == "3.3.6"
 
@@ -131,7 +145,9 @@ class TestStatusSyncOnGet:
             "last_poll": None,
         }
         view = _get_view_with_store(store)
-        view._fetch_issue = AsyncMock(return_value=("closed", ["approved"]))
+        view._fetch_issue = AsyncMock(
+            return_value=("closed", "completed", ["approved"])
+        )
 
         with mock.patch(
             "custom_components.beatify.server.playlist_views.async_get_clientsession",
@@ -143,6 +159,25 @@ class TestStatusSyncOnGet:
         assert body["requests"][0]["status"] == "ready"
         assert body["last_poll"] is not None
         view._save_requests.assert_called_once()
+
+    async def test_get_corrects_ready_to_declined_when_not_planned(self):
+        # A request previously synced to "ready" must be re-polled and
+        # corrected once the issue is seen as closed "not planned" — the
+        # poller already re-checks "ready" rows, so the fix is retroactive.
+        store = {
+            "requests": [{"issue_number": 980, "status": "ready"}],
+            "last_poll": None,
+        }
+        view = _get_view_with_store(store)
+        view._fetch_issue = AsyncMock(return_value=("closed", "not_planned", []))
+
+        with mock.patch(
+            "custom_components.beatify.server.playlist_views.async_get_clientsession",
+            return_value=MagicMock(),
+        ):
+            resp = await view.get(_get_request())
+
+        assert json.loads(resp.body)["requests"][0]["status"] == "declined"
 
     async def test_get_skips_poll_when_recently_polled(self):
         store = {


### PR DESCRIPTION
## Problem
When a playlist request was declined by simply closing its GitHub issue as **"not planned"** (without adding a decline label), the in-app status sync mapped it to **"✅ Ready"** — telling the requesting user their playlist had shipped, when it had actually been turned down.

`_issue_to_status` only ever checked issue *labels* (`declined`, `wontfix`, `duplicate`, `invalid`); GitHub's `not_planned` close reason was ignored entirely.

## Fix
- `_fetch_issue` now also reads `state_reason` from the GitHub issue.
- `_issue_to_status` treats a closed issue with `state_reason == "not_planned"` as **declined** — so declining a request needs no label discipline, just closing it the normal way.
- The poller already re-checks `ready` rows, so this corrects already-mis-synced requests retroactively on the next poll.

## Data backfill
Closed-but-not-implemented playlist requests that were sitting as `completed` have been re-marked `not_planned` so they now display correctly: **#54, #55, #66, #174, #884, #909, #926**. (Implemented requests and duplicate-of-an-existing-playlist requests were left as `completed`.)

## Tests
`tests/unit/test_playlist_requests_view.py` — updated for the new signature, plus new cases: a `not_planned` close maps to `declined`, and a request already synced to `ready` is corrected to `declined` on re-poll. 13 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)