### PR TITLE
release: v3.3.7-rc2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,16 @@ All notable changes to Beatify are documented here. For detailed release notes, 
 
 ## [3.3.7] - 2026-05-18
 
+### Added
+- **Playlist acceptance criteria in the request modal (#986).** The request form carried only a one-line note; it now lists the six concrete criteria a playlist must meet — themed, not a duplicate, a fixed selection, curated in size, recognisable to a party crowd, no explicit content — so users can self-filter before submitting. Translated across all five locales.
+
 ### Fixed
 - **Playlist-request status never updated (#970).** A delivered playlist request stayed stuck on "submitted" in the Playlist Hub's "Meine" tab forever. The request `status` field was write-once and nothing reconciled it afterward — the old browser poller (removed in #939) had only ever advanced a request carrying both a `playlist-ready` label and a `vX.Y.Z` version label, so requests the maintainer closed with `approved` never matched. `PlaylistRequestsView.get()` now reconciles pending requests against GitHub issue **state** (a closed issue means delivered, independent of label), server-side and throttled to once an hour.
+- **Declined playlist requests showed as "ready" (#970 follow-up).** A request the maintainer closed as "not planned" without a decline label was still synced to "✅ Ready", telling the user their playlist had shipped when it had been turned down. The status sync now also honours GitHub's `not_planned` close reason, and existing mis-marked requests were corrected.
+
+### Data
+- **New playlist: 40s & 50s Classics (#922).** 152 rock'n'roll, doo-wop and early-pop classics spanning 1939–1962.
+- **Greatest Metal Songs enriched (#981).** Nine canonical anthems added — Painkiller, Breaking the Law, Angel of Death, Cemetery Gates, Hangar 18, Stargazer, Nothing Else Matters, I Want Out, B.Y.O.B. — taking the playlist from 52 to 61 songs.
 
 ## [3.3.6] - 2026-05-18
 

--- a/custom_components/beatify/manifest.json
+++ b/custom_components/beatify/manifest.json
@@ -12,5 +12,5 @@
   "documentation": "https://github.com/mholzi/beatify",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/mholzi/beatify/issues",
-  "version": "3.3.7-rc1"
+  "version": "3.3.7-rc2"
 }

--- a/custom_components/beatify/www/admin.html
+++ b/custom_components/beatify/www/admin.html
@@ -8,7 +8,7 @@
          query-string version, a stale en.json from a prior rc gets served
          after upgrade and references to newer keys render as raw strings.
          Bumped each rc alongside manifest.json + sw.js CACHE_VERSION. -->
-    <meta name="beatify-version" content="3.3.7-rc1">
+    <meta name="beatify-version" content="3.3.7-rc2">
     <title data-i18n="admin.title">Beatify Admin</title>
     <!-- PWA: Web App Manifest — Admin installs Beatify to homescreen (Issue #166) -->
     <link rel="manifest" href="/beatify/static/site.webmanifest">

--- a/custom_components/beatify/www/dashboard.html
+++ b/custom_components/beatify/www/dashboard.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <!-- #824: cache-bust i18n JSON fetches. See admin.html for rationale. -->
-    <meta name="beatify-version" content="3.3.7-rc1">
+    <meta name="beatify-version" content="3.3.7-rc2">
     <title data-i18n="dashboard.title">Beatify - Dashboard</title>
     <!-- Preconnect for faster font loading (Story 9.8) -->
     <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/custom_components/beatify/www/player.html
+++ b/custom_components/beatify/www/player.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <!-- #824: cache-bust i18n JSON fetches. See admin.html for rationale. -->
-    <meta name="beatify-version" content="3.3.7-rc1">
+    <meta name="beatify-version" content="3.3.7-rc2">
     <title data-i18n="join.title">Beatify - Join Game</title>
     <!-- Preconnect for faster font loading (Story 9.8) -->
     <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/custom_components/beatify/www/sw.js
+++ b/custom_components/beatify/www/sw.js
@@ -6,7 +6,7 @@
  */
 'use strict';
 
-var CACHE_VERSION = 'beatify-v3.3.7-rc1';
+var CACHE_VERSION = 'beatify-v3.3.7-rc2';
 var MAX_CACHE_ITEMS = 50;
 
 // Critical assets to precache on install (minified versions only - fallback handled by HTML)


### PR DESCRIPTION
## Summary
Refreshes the 3.3.7 release candidate — rc1 (cut this morning) is stale and missing everything merged since.

Picks up since rc1:
- **40s & 50s Classics playlist** (#922) — 152 songs, 1939–1962
- **Greatest Metal Songs enriched** (#981) — 52 → 61 songs
- **Declined playlist requests no longer show as "ready"** (#970 follow-up, #985)
- **Playlist acceptance criteria in the request modal** (#986)

Version markers bumped to `3.3.7-rc2` (manifest, sw.js cache version, 3× HTML meta). No `?v=` cache-buster bumps — pre-release.

## Test plan
- [ ] HACS picks up v3.3.7-rc2 as a pre-release
- [ ] Request modal shows the six criteria
- [ ] A declined playlist request shows "Declined", not "Ready"