### PR TITLE
data: fix two flagged release years in harder-styles (#992, #994)

### DIFF
--- a/custom_components/beatify/playlists/community/harder-styles.json
+++ b/custom_components/beatify/playlists/community/harder-styles.json
@@ -1,6 +1,6 @@
 {
   "name": "Harder Styles",
-  "version": "1.4",
+  "version": "1.5",
   "tags": [
     "hardstyle",
     "hardcore",
@@ -2158,7 +2158,7 @@
     {
       "artist": "Endymion",
       "title": "Pussy Motherfuckerz - D-Fence Remix",
-      "year": 2003,
+      "year": 2018,
       "isrc": "NLHY51800661",
       "uri": "spotify:track:3txHkfFFEeMRblGlfe1kdm",
       "uri_apple_music": "applemusic://track/1842474143",
@@ -4128,7 +4128,7 @@
     {
       "artist": "DJ Gollum, Noiseflow, Triple X, Scarlet",
       "title": "All the Things She Said - Noiseflow & Triple X Remix",
-      "year": 2008,
+      "year": 2024,
       "isrc": "DEHK92109326",
       "uri": "spotify:track:4WGIYb6FewZn8IHH2Lnk6b",
       "uri_apple_music": "applemusic://track/1759935260",


### PR DESCRIPTION
## Summary
Four in-game "wrong year" flags came in (#991, #992, #994, #995). Verified each:

| Issue | Song | Stored | Verified | Result |
|-------|------|--------|----------|--------|
| #991 | The Game — Hate It Or Love It | 2005 | 2005 | ✅ correct |
| #992 | DJ Gollum … — All the Things She Said (Noiseflow & Triple X Remix) | 2008 | **2024** | ❌ fixed |
| #994 | Endymion — Pussy Motherfuckerz (D-Fence Remix) | 2003 | **2018** | ❌ fixed |
| #995 | TNT — Countdown | 2011 | 2011 | ✅ correct |

Two genuine errors — both hardstyle **remixes** whose stored year belonged to the original track, not the remix. Fixed in `harder-styles.json` (v1.4 → v1.5). #991 and #995 were false positives, closed without change.

Closes #992
Closes #994

🤖 Generated with [Claude Code](https://claude.com/claude-code)