### PR TITLE
docs: clarify Artist Challenge is first-correct-wins (#947)

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ Score zero: **Lose it all.**
 
 ### Artist Challenge (Optional)
 Know your artists? Enable this mode in game setup.
-Guess the artist after the song: **+5 bonus points.**
+After the song, it's a race — the **first** player to guess the artist correctly earns **+5 bonus points.**
 Alternate names accepted—"Prince" or "The Artist" both count.
 
 ### Movie Quiz Bonus (Optional)


### PR DESCRIPTION
## Summary
Discussion #947: a user read the README's Artist Challenge section as "everyone who guesses the artist correctly scores +5". The actual behaviour is a **race** — only the *first* correct guess wins the bonus (`ArtistChallenge` tracks a single `winner`; the in-app toggle hint already says "First correct guess earns +5 points").

One-line README wording fix to match the real behaviour.

Refs #947

🤖 Generated with [Claude Code](https://claude.com/claude-code)