### PR TITLE
ux: rename TV-dashboard link to "Open TV Dashboard" for discoverability

### DIFF
--- a/custom_components/beatify/www/admin.html
+++ b/custom_components/beatify/www/admin.html
@@ -208,7 +208,7 @@
                 <div class="home-utility-row">
                     <a href="#" id="home-dashboard-url" class="home-cast-link hidden" target="_blank" rel="noopener">
                         <span aria-hidden="true">📺</span>
-                        <span data-i18n="admin.home.castToTv">Cast to TV</span>
+                        <span data-i18n="admin.home.castToTv">Open TV Dashboard</span>
                         <span aria-hidden="true">→</span>
                     </a>
                 </div>

--- a/custom_components/beatify/www/i18n/de.json
+++ b/custom_components/beatify/www/i18n/de.json
@@ -538,7 +538,7 @@
       "party": "Party",
       "scanToJoin": "Scannen zum Beitreten",
       "qrLoading": "Raum wird erstellt…",
-      "castToTv": "Auf TV streamen",
+      "castToTv": "TV-Dashboard öffnen",
       "printQr": "Drucken",
       "endGame": "Spiel beenden",
       "requestsTitle": "Playlist-Anfragen",

--- a/custom_components/beatify/www/i18n/en.json
+++ b/custom_components/beatify/www/i18n/en.json
@@ -538,7 +538,7 @@
       "party": "party",
       "scanToJoin": "Scan to join",
       "qrLoading": "Creating room…",
-      "castToTv": "Cast to TV",
+      "castToTv": "Open TV Dashboard",
       "printQr": "Print",
       "endGame": "End game",
       "requestsTitle": "Playlist requests",

--- a/custom_components/beatify/www/i18n/es.json
+++ b/custom_components/beatify/www/i18n/es.json
@@ -538,7 +538,7 @@
       "party": "fiesta",
       "scanToJoin": "Escanea para unirte",
       "qrLoading": "Creando sala…",
-      "castToTv": "Enviar a la TV",
+      "castToTv": "Abrir panel de TV",
       "printQr": "Imprimir",
       "endGame": "Terminar partida",
       "requestsTitle": "Solicitudes de listas",

--- a/custom_components/beatify/www/i18n/fr.json
+++ b/custom_components/beatify/www/i18n/fr.json
@@ -538,7 +538,7 @@
       "party": "soirée",
       "scanToJoin": "Scanner pour rejoindre",
       "qrLoading": "Création du salon…",
-      "castToTv": "Diffuser sur la TV",
+      "castToTv": "Ouvrir le tableau de bord TV",
       "printQr": "Imprimer",
       "endGame": "Terminer la partie",
       "requestsTitle": "Demandes de playlist",

--- a/custom_components/beatify/www/i18n/nl.json
+++ b/custom_components/beatify/www/i18n/nl.json
@@ -538,7 +538,7 @@
       "party": "party",
       "scanToJoin": "Scan om mee te doen",
       "qrLoading": "Kamer aanmaken…",
-      "castToTv": "Cast naar TV",
+      "castToTv": "TV-dashboard openen",
       "printQr": "Afdrukken",
       "endGame": "Spel beëindigen",
       "requestsTitle": "Afspeellijst-verzoeken",


### PR DESCRIPTION
## Why
In discussion #1009 a user asked for a SmartTV scoreboard — but Beatify's **TV Dashboard already exists**. The host just couldn't find it: on the home screen the link was labelled **"Cast to TV"**, which doesn't read as "the TV dashboard is here".

## Change
Renamed the `#home-dashboard-url` link label from "Cast to TV" → **"Open TV Dashboard"** across all five locales (en/de/es/fr/nl), plus the HTML fallback. The 📺 icon stays.

## Note / possible follow-up
The link still only appears once a game is live (it needs a valid `dashboard_url`). Showing it during setup too would mean linking to an empty dashboard — a separate, bigger change with a dead-link tradeoff; happy to do it if wanted. This PR is the surgical, no-risk findability fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)