### PR TITLE
playlist(deutschpop-klassiker): add Die Orsons – Schwung in die Kiste (#1022)

### DIFF
--- a/custom_components/beatify/playlists/community/deutschpop-klassiker.json
+++ b/custom_components/beatify/playlists/community/deutschpop-klassiker.json
@@ -1,6 +1,6 @@
 {
   "name": "Deutschpop Klassiker 🇩🇪",
-  "version": "0.3",
+  "version": "0.4",
   "tags": [
     "german",
     "pop",
@@ -3825,6 +3825,41 @@
       "fun_fact_es": "Un éxito de EAV (Erste Allgemeine Verunsicherung) (1990).",
       "fun_fact_fr": "Un tube de EAV (Erste Allgemeine Verunsicherung) (1990).",
       "fun_fact_nl": "Een chart-hit van EAV (Erste Allgemeine Verunsicherung) (1990)."
+    },
+    {
+      "artist": "Die Orsons",
+      "title": "Schwung in die Kiste",
+      "year": 2015,
+      "isrc": "DEUM71403809",
+      "uri": "spotify:track:1d0LKskvREPlQfBanvabh8",
+      "uri_apple_music": "applemusic://track/1443399430",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1443399430",
+        "de": "applemusic://track/1443399430",
+        "gb": "applemusic://track/1443399430",
+        "fr": "applemusic://track/1443399430",
+        "es": "applemusic://track/1443399430",
+        "nl": "applemusic://track/1443399430",
+        "it": "applemusic://track/1443399430"
+      },
+      "uri_deezer": "deezer://track/95965268",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=6_7qL92z3pA",
+      "uri_tidal": null,
+      "alt_artists": [
+        "Die Fantastischen Vier",
+        "Kraftklub",
+        "Marteria",
+        "Casper"
+      ],
+      "fun_fact": "Stand-out track from Die Orsons' 2015 album 'What's Goes?' on Chimperator. The Stuttgart hip-hop collective behind it — Tua, KAAS, Bartek and Maeckes — all went on to successful solo careers, but this brass-driven sing-along stayed a festival staple and one of the album's signature singles.",
+      "fun_fact_de": "Markante Single aus dem 2015er Album 'What's Goes?' der Stuttgarter Crew Die Orsons (Chimperator). Tua, KAAS, Bartek und Maeckes machten danach alle solo Karriere — der Bläser-getriebene Mitsing-Refrain blieb aber ein Festival-Klassiker und einer der prägenden Hits des Albums.",
+      "fun_fact_es": "Tema destacado del álbum 'What's Goes?' (2015) de Die Orsons en el sello Chimperator. El cuarteto de Stuttgart — Tua, KAAS, Bartek y Maeckes — siguió luego con exitosas carreras en solitario, pero este pegadizo himno con vientos se mantuvo como un fijo de los festivales.",
+      "fun_fact_fr": "Morceau emblématique de l'album 'What's Goes?' (2015) du collectif hip-hop de Stuttgart Die Orsons (label Chimperator). Tua, KAAS, Bartek et Maeckes ont tous mené ensuite des carrières solos, mais ce refrain à cuivres reste un classique des festivals.",
+      "fun_fact_nl": "Stand-outtrack van het album 'What's Goes?' (2015) van Die Orsons (label Chimperator). De Stuttgartse hiphopcrew — Tua, KAAS, Bartek en Maeckes — ging daarna solo, maar deze blazergedreven meezinger bleef een vaste waarde op zomerfestivals.",
+      "awards": [],
+      "awards_nl": [],
+      "certifications": [],
+      "chart_info": {}
     }
   ]
 }


### PR DESCRIPTION
## Decision

Theme **already exists** as `custom_components/beatify/playlists/community/deutschpop-klassiker.json` (whose description literally says it is "Sourced from Spotify Editorial 'Deutschpop Klassiker'"). Per the scheduled-task rules this is case **5a** — enrich the existing file rather than create a new one.

## Source

- Issue: #1022
- Requested playlist: [Spotify – Deutschpop Klassiker](https://open.spotify.com/playlist/37i9dQZF1DX2cNqJ4LgCMf) (`37i9dQZF1DX2cNqJ4LgCMf`)
- Snapshot pulled via `browser-harness` `http_get` against `open.spotify.com/embed/playlist/...` → parsed `__NEXT_DATA__.trackList` (100 tracks).

## Diff vs. existing curation

| Bucket | Count |
|---|---|
| Tracks in Spotify snapshot | 100 |
| Tracks in existing curated playlist | 106 |
| Already present (URI match) | 99 |
| **New (added in this PR)** | **1** |
| In curated playlist but not in the Spotify snapshot | 7 (kept — sourced from the in-app #906 funnel, per the file's description) |

Only one new URI surfaced: **Die Orsons – Schwung in die Kiste** (`spotify:track:1d0LKskvREPlQfBanvabh8`). Everything else in the editorial playlist was already curated.

## What changed

- Appended one song entry to `songs[]`.
- Bumped `version` `0.3` → `0.4`.
- No structural / schema changes.

## Enrichment completeness — Die Orsons – Schwung in die Kiste

| Field | Source | Filled |
|---|---|---:|
| `artist` | Spotify | 100% |
| `title` | Spotify | 100% |
| `year` (2015) | Spotify `releaseDate` + iTunes Search | 100% |
| `isrc` (`DEUM71403809`) | Deezer track API | 100% |
| `uri` (Spotify) | Spotify | 100% |
| `uri_apple_music` (`1443399430`) | iTunes Search API | 100% |
| `uri_apple_music_by_region` (us, de, gb, fr, es, nl, it) | iTunes Search per storefront — same trackId across all 7 | 100% (7/7) |
| `uri_deezer` (`95965268`) | Deezer search | 100% |
| `uri_youtube_music` (`6_7qL92z3pA`, official DieOrsonsVEVO, verified via YouTube oEmbed) | YouTube search | 100% |
| `uri_tidal` | not researched | 0% (null — matches 105/106 existing entries) |
| `alt_artists` | manually curated (Die Fantastischen Vier, Kraftklub, Marteria, Casper) | 100% |
| `fun_fact` (en) | hand-written | 100% |
| `fun_fact_de` | hand-written | 100% |
| `fun_fact_es` | hand-written | 100% |
| `fun_fact_fr` | hand-written | 100% |
| `fun_fact_nl` | hand-written | 100% |
| `awards` / `awards_nl` | not researched | 0% (empty — matches 106/106 existing entries) |
| `certifications` | not researched | 0% (empty — 47/106 existing entries non-empty) |
| `chart_info` | not researched | 0% (empty — 69/106 existing entries non-empty) |

**Core + multi-region streaming + multilingual fun facts: 100% covered.** Optional discographic fields (Tidal, awards, certifications, chart_info) are left empty to match the conservative baseline used elsewhere in the file when reliable sources weren't available.

## Closing

Closes #1022.

🤖 Filed via the scheduled `beatify-playlist-request` task.