### PR TITLE
chore: ruff format state.py to unblock CI

### DIFF
--- a/custom_components/beatify/game/state.py
+++ b/custom_components/beatify/game/state.py
@@ -1808,9 +1808,7 @@ class GameState:
                 "Round %d ended with zero guesses — holding after song-end",
                 self.round,
             )
-            self._auto_advance_task = asyncio.create_task(
-                self._reveal_idle_halt()
-            )
+            self._auto_advance_task = asyncio.create_task(self._reveal_idle_halt())
 
         # Issue #331/#517: Update Party Lights for reveal phase + event flashes
         await self._lights_set_phase(GamePhase.REVEAL)


### PR DESCRIPTION
CI `ruff format --check` failed on `custom_components/beatify/game/state.py` (one multi-line `asyncio.create_task` call that ruff wants on a single line). Applied `ruff format`. 504 tests still pass.