### PR TITLE
fix: timer task no longer self-cancels via end_round (#1029)

### DIFF
--- a/custom_components/beatify/game/state.py
+++ b/custom_components/beatify/game/state.py
@@ -1423,6 +1423,16 @@ class GameState:
         """
         try:
             await self._round_manager._timer_countdown(delay_seconds)
+            # #1029: release the timer-task handle BEFORE invoking end_round.
+            # end_round → _end_round_unlocked calls self.cancel_timer(), which
+            # would cancel `_timer_task` — and `_timer_task` IS the currently
+            # running task. A self-cancel schedules CancelledError on the next
+            # real yield, interrupting the REVEAL broadcast (and historically
+            # the phase transition itself before fake-await chains masked it).
+            # _log_timer_task_failure treats cancellations as silent, so the
+            # round froze on PLAYING with no diagnostic. Clearing the handle
+            # here makes the subsequent cancel_timer() a no-op for this task.
+            self._round_manager._timer_task = None
             # Timer completed normally — check phase and end round
             if self.phase == GamePhase.PLAYING:
                 # #471 Phase 1: announce time-up only when timer ran to zero

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -1049,3 +1049,60 @@ class TestEndRoundResilience:
 
         assert self.state.phase == GamePhase.REVEAL
         broadcast.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# Timer-task self-cancellation (#1029)
+# ---------------------------------------------------------------------------
+
+
+class TestTimerExpiryNoSubmissions:
+    """#1029: timer expiry with zero submitted guesses must transition to
+    REVEAL and broadcast cleanly. The timer task is `_timer_task`, and
+    end_round calls cancel_timer() — which cancels the running task itself.
+    That self-cancel schedules CancelledError on the next real `await`,
+    interrupting the broadcast at the end of end_round. The fix releases the
+    timer-task handle before invoking end_round so cancel_timer() is a no-op.
+    """
+
+    def setup_method(self):
+        self.state = make_game_state()
+        _create_fresh_game(self.state)
+        self.state.add_player("Alice", MagicMock())
+        self.state.add_player("Bob", MagicMock())
+        self.state.start_game()
+        self.state.current_song = {
+            "title": "Test Song",
+            "artist": "Test Artist",
+            "year": 1990,
+        }
+        self.state.round_start_time = self.state._now()
+        # Players have NOT submitted — this is the #1029 scenario.
+
+    @pytest.mark.asyncio
+    async def test_timer_expiry_no_submissions_reaches_reveal_and_broadcasts(
+        self,
+    ):
+        """Run _timer_countdown as a real asyncio task so cancel_timer()
+        inside end_round targets the running task. Without the fix, the
+        broadcast at the end of end_round is interrupted by CancelledError.
+        """
+        broadcast = AsyncMock()
+        self.state.set_round_end_callback(broadcast)
+
+        # Patch the inner sleep so the test finishes instantly.
+        with patch.object(
+            self.state._round_manager,
+            "_timer_countdown",
+            new=AsyncMock(return_value=None),
+        ):
+            timer_task = asyncio.create_task(self.state._timer_countdown(0.0))
+            # Register as the round timer so cancel_timer() targets it
+            # (this mirrors how RoundManager.initialize_round wires it up).
+            self.state._round_manager._timer_task = timer_task
+            await timer_task
+
+        assert self.state.phase == GamePhase.REVEAL
+        broadcast.assert_awaited_once()
+        # Task must complete cleanly — no self-cancellation.
+        assert not timer_task.cancelled()


### PR DESCRIPTION
Closes #1029

## Readiness assessment
- [ ] Ready to merge
- [x] Borderline — see notes
- [ ] Not ready — needs human review

**Honest summary:** Fixes a real bug — the timer task calls `end_round`, which calls `cancel_timer`, which cancels the running task itself. I verified the self-cancellation experimentally with a Python repro and the added regression test fails without the fix. The shaky part: the user's #1029 symptom is "phase still PLAYING after reload," and my deeper trace suggests that in a typical Home Assistant setup `phase = REVEAL` is actually reached before the cancellation lands at a real `await` (the broadcast call). So this fix definitively repairs an interrupted REVEAL broadcast, and likely repairs the user's stuck-PLAYING symptom — but the exact mechanism by which phase stayed PLAYING in the rc5 report isn't 100% pinned down (could be that intermediate awaits yielded on the user's HA instance in ways my analysis missed, or the client never received the broadcast and was reading stale state).

## Test plan
- [x] New regression test `TestTimerExpiryNoSubmissions::test_timer_expiry_no_submissions_reaches_reveal_and_broadcasts` — verified failing without the fix (raises CancelledError), passing with it.
- [x] Existing `TestEndRoundResilience` tests still pass.
- [x] Full unit-test suite: 507 passed, 2 skipped.
- [x] `ruff check` and `ruff format --check` clean on touched files.
- [ ] Manual repro from the issue (admin-only player, no submission, timer to zero) — not run; the user should re-test once landed and confirm the round transitions to REVEAL on timer expiry.

## Risk assessment
- **Blast radius:** `custom_components/beatify/game/state.py::_timer_countdown` (one path; one new assignment line). Affects every round timer expiry, not just no-submitter rounds.
- **What could go wrong:**
  - If something else in the codebase reads `_round_manager._timer_task` between sleep-return and `end_round` running, that something would now see `None` slightly earlier than before. Grep showed no such reader on the hot path, but I didn't audit every reference.
  - If `end_round` is *itself* interrupted by a real cancellation (e.g. game end during the few sync lines between the handle-clear and `end_round`), `_timer_task` would already be `None` — but `cancel_timer` is already idempotent w.r.t. None, so behavior is unchanged.
- **What I did NOT test:**
  - Real Home Assistant integration — only the unit-test path.
  - Whether the fix resolves the user's exact "still PLAYING on reload" report (see Readiness honest summary).
  - The rc7 client-watchdog interaction — that retry path is still in place as a backstop, but I didn't re-verify it interacts cleanly with the fixed end_round.

🤖 Auto-generated by issue-triage routine