### PR TITLE
feat: searchable light entity list in wizard step 5 (#1039)

### DIFF
--- a/custom_components/beatify/www/admin.html
+++ b/custom_components/beatify/www/admin.html
@@ -1416,7 +1416,7 @@
     <!-- Story 44.1: Playlist requests module -->
     <script src="/beatify/static/js/playlist-requests.min.js?v=3.3.6-rc7"></script>
     <script type="module" src="/beatify/static/js/playlist-hub.js?v=3.3.1"></script>
-    <script type="module" src="/beatify/static/js/wizard.js?v=3.3.7-rc9-fix1028b"></script>
+    <script type="module" src="/beatify/static/js/wizard.js?v=3.3.7-rc9-feat1039"></script>
     <script src="/beatify/static/js/admin.min.js?v=3.3.7-rc9"></script>
     <script src="/beatify/static/js/party-lights.min.js?v=3.3.7-rc9-fix1011b"></script>
     <script src="/beatify/static/js/tts-settings.js?v=3.3.7-rc9-fix1011c"></script>

--- a/custom_components/beatify/www/i18n/de.json
+++ b/custom_components/beatify/www/i18n/de.json
@@ -889,6 +889,7 @@
         "desc": "Synchronisiere deine Hue-Lampen zum Beat. Puls bei Rundenwechsel, Blitz beim Sieger.",
         "unavailable": "Keine Lampen in Home Assistant gefunden.",
         "pickLabel": "Lampen zum Synchronisieren",
+        "searchPlaceholder": "Lampen suchen…",
         "intensity": "Intensität",
         "subtle": "Dezent",
         "medium": "Mittel",

--- a/custom_components/beatify/www/i18n/en.json
+++ b/custom_components/beatify/www/i18n/en.json
@@ -889,6 +889,7 @@
         "desc": "Sync your Hue lights to the beat. Pulse on round changes, flash on winner.",
         "unavailable": "No lights found in Home Assistant.",
         "pickLabel": "Lights to sync",
+        "searchPlaceholder": "Search lights…",
         "intensity": "Intensity",
         "subtle": "Subtle",
         "medium": "Medium",

--- a/custom_components/beatify/www/i18n/es.json
+++ b/custom_components/beatify/www/i18n/es.json
@@ -889,6 +889,7 @@
         "desc": "Sincroniza tus luces Hue al ritmo. Pulso al cambiar ronda, destello para el ganador.",
         "unavailable": "No hay luces en Home Assistant.",
         "pickLabel": "Luces a sincronizar",
+        "searchPlaceholder": "Buscar luces…",
         "intensity": "Intensidad",
         "subtle": "Sutil",
         "medium": "Media",

--- a/custom_components/beatify/www/i18n/fr.json
+++ b/custom_components/beatify/www/i18n/fr.json
@@ -889,6 +889,7 @@
         "desc": "Synchronise tes ampoules Hue sur le rythme. Pulsation entre manches, flash pour le gagnant.",
         "unavailable": "Aucune lumière trouvée dans Home Assistant.",
         "pickLabel": "Lumières à synchroniser",
+        "searchPlaceholder": "Rechercher des lumières…",
         "intensity": "Intensité",
         "subtle": "Discret",
         "medium": "Moyen",

--- a/custom_components/beatify/www/i18n/nl.json
+++ b/custom_components/beatify/www/i18n/nl.json
@@ -889,6 +889,7 @@
         "desc": "Synchroniseer je Hue-lampen op het ritme. Puls bij ronde-wissel, flits bij winnaar.",
         "unavailable": "Geen lampen gevonden in Home Assistant.",
         "pickLabel": "Lampen om te synchroniseren",
+        "searchPlaceholder": "Lampen zoeken…",
         "intensity": "Intensiteit",
         "subtle": "Subtiel",
         "medium": "Gemiddeld",

--- a/custom_components/beatify/www/js/wizard.js
+++ b/custom_components/beatify/www/js/wizard.js
@@ -736,12 +736,22 @@ function _lightsDetailHtml() {
     const rows = lights.length
         ? lights.map((l) => {
               const checked = chosenLightEntityIds.has(l.entity_id) ? 'checked' : '';
-              return `<label class="wiz-detail-check">
+              const searchable = `${l.friendly_name || ''} ${l.entity_id}`.toLowerCase();
+              return `<label class="wiz-detail-check" data-light-search="${searchable.replace(/"/g, '&quot;')}">
             <input type="checkbox" data-light-id="${l.entity_id}" ${checked}>
             <span class="wiz-detail-check-name">${l.friendly_name || l.entity_id}</span>
           </label>`;
           }).join('')
         : `<div class="wiz-detail-empty">${_t('wizard.step5.lights.noneFound', 'No lights available')}</div>`;
+    // #1039: search input above the entity list — long HA installs have 10+
+    // light.* entities, alphabetical scroll is the only way to find one today.
+    // Filter is applied via class toggle so chosenLightEntityIds (the source
+    // of truth for selection state) is untouched when rows hide/show.
+    const searchInput = lights.length > 1
+        ? `<input type="text" id="wiz-light-search" class="wiz-detail-input wiz-light-search"
+             placeholder="${_t('wizard.step5.lights.searchPlaceholder', 'Search lights…')}"
+             aria-label="${_t('wizard.step5.lights.searchPlaceholder', 'Search lights…')}">`
+        : '';
     const chip = (id, label, group) => `<button type="button" class="wiz-chip ${(group === 'intensity' ? chosenLightIntensity : chosenLightMode) === id ? 'active' : ''}" data-${group}="${id}">${label}</button>`;
 
     const wledBlock = chosenLightMode === 'wled'
@@ -764,6 +774,7 @@ function _lightsDetailHtml() {
         <div class="wiz-detail">
           <div class="wiz-field">
             <span class="wiz-field-label">${_t('wizard.step5.lights.pickLabel', 'Lights to sync')}</span>
+            ${searchInput}
             <div class="wiz-detail-checks">${rows}</div>
           </div>
           <div class="wiz-field">
@@ -879,6 +890,19 @@ function _renderLevelUp() {
             else chosenLightEntityIds.delete(id);
         });
     });
+    // #1039: filter light rows by substring match on friendly_name/entity_id.
+    // Hide via inline display so chosenLightEntityIds is unaffected — clearing
+    // the search restores rows with their original checkbox state intact.
+    const lightSearch = list.querySelector('#wiz-light-search');
+    if (lightSearch) {
+        lightSearch.addEventListener('input', () => {
+            const q = lightSearch.value.trim().toLowerCase();
+            list.querySelectorAll('[data-light-search]').forEach((row) => {
+                const hay = row.getAttribute('data-light-search') || '';
+                row.style.display = !q || hay.includes(q) ? '' : 'none';
+            });
+        });
+    }
     list.querySelectorAll('[data-intensity]').forEach((btn) => {
         btn.addEventListener('click', (e) => {
             e.stopPropagation();

--- a/custom_components/beatify/www/sw.js
+++ b/custom_components/beatify/www/sw.js
@@ -6,7 +6,7 @@
  */
 'use strict';
 
-var CACHE_VERSION = 'beatify-v3.3.7-rc9-fix1028b';
+var CACHE_VERSION = 'beatify-v3.3.7-rc9-feat1039';
 var MAX_CACHE_ITEMS = 50;
 
 // Critical assets to precache on install (minified versions only - fallback handled by HTML)


### PR DESCRIPTION
Closes #1039

## Readiness assessment
- [x] Ready to merge
- [ ] Borderline — see notes
- [ ] Not ready — needs human review

**Honest summary:** Small, contained feature with no behavioural risk to existing flows. Filter touches only DOM visibility — `chosenLightEntityIds` (source of truth for which lights the user picked) is untouched, so checking → searching → clearing search → toggling chips all preserve selections. Untested in a live browser since this routine is unattended; verification below is code-level only.

## What changed
- `wizard.js` → `_lightsDetailHtml()`: add a search `<input>` above the rows when `lights.length > 1`; tag each row with `data-light-search="<lowercase friendly_name + entity_id>"`.
- `wizard.js` → `_renderLevelUp()`: wire up an `input` listener that toggles `row.style.display` based on substring match.
- Cache-busters bumped per project convention (memory: source edits don't ship until `?v=` + sw.js `CACHE_VERSION` are bumped):
  - `admin.html` wizard.js: `v=3.3.7-rc9` → `v=3.3.7-rc9-feat1039`
  - `sw.js` `CACHE_VERSION`: `beatify-v3.3.7-rc9` → `beatify-v3.3.7-rc9-feat1039`

No `.min.js` needed — wizard.js is loaded as an ES module directly, no minified twin exists in the repo.

## Test plan
- [ ] Open admin wizard, advance to Step 5, toggle Party Lights on
- [ ] Search field appears above the entity list (only if 2+ lights returned by `/beatify/api/lights`)
- [ ] Type a substring of a friendly name → only matching rows visible
- [ ] Type a substring of an entity_id (e.g. `kitchen`) → only matching rows visible
- [ ] Mixed-case query matches lowercase haystack (case-insensitive)
- [ ] Clear the search → all rows visible again with prior checkbox state intact
- [ ] Check a row, search to hide it, clear search → checkbox still checked
- [ ] Click an intensity or mode chip → wizard re-renders; search resets (expected — whole detail re-renders); selections persist
- [ ] With 0 or 1 lights, search input does not render

## Risk assessment
- **Blast radius:** Wizard step 5 lights picker only. No backend, no game logic, no localStorage schema changes.
- **What could go wrong:**
  - Friendly names containing `<`/`>`/`&` are already trusted by surrounding code (rendered unescaped into span text). New `data-light-search` attribute escapes `"` but not `&` — matches existing trust level in this file.
  - Translation string `wizard.step5.lights.searchPlaceholder` is new and falls back to `Search lights…` if not provided in locale files.
  - Search filter resets when the user clicks intensity/mode chips (because `_renderLevelUp()` rebuilds the entire detail). Acceptable trade-off — selections still survive via `chosenLightEntityIds`.
- **What I did NOT test:**
  - Live browser interaction (unattended run, no GUI access)
  - Behavior with 50+ lights (potential perf, but `querySelectorAll` over a few dozen rows is trivially fast)
  - Mobile/touch UX of the search input
  - Screen-reader announcement of filtered rows
  - Locale files in other languages — only English fallback is wired

🤖 Generated with [Claude Code](https://claude.com/claude-code)