### PR TITLE
Add Auto-Advance chips to wizard Step 4 (#1028 follow-up)

### DIFF
--- a/custom_components/beatify/www/admin.html
+++ b/custom_components/beatify/www/admin.html
@@ -87,6 +87,10 @@
                     <div id="wiz-timer" class="wiz-chip-group"></div>
                 </div>
                 <div class="wiz-field">
+                    <label class="wiz-field-label" data-i18n="wizard.step4.autoAdvance">Auto-advance reveal</label>
+                    <div id="wiz-autoadvance" class="wiz-chip-group"></div>
+                </div>
+                <div class="wiz-field">
                     <label class="wiz-field-label" data-i18n="wizard.step4.language">Announcement language</label>
                     <div id="wiz-language" class="wiz-chip-group"></div>
                 </div>
@@ -1412,7 +1416,7 @@
     <!-- Story 44.1: Playlist requests module -->
     <script src="/beatify/static/js/playlist-requests.min.js?v=3.3.6-rc7"></script>
     <script type="module" src="/beatify/static/js/playlist-hub.js?v=3.3.1"></script>
-    <script type="module" src="/beatify/static/js/wizard.js?v=3.3.7-rc9-fix1011c"></script>
+    <script type="module" src="/beatify/static/js/wizard.js?v=3.3.7-rc9-fix1028b"></script>
     <script src="/beatify/static/js/admin.min.js?v=3.3.7-rc9"></script>
     <script src="/beatify/static/js/party-lights.min.js?v=3.3.7-rc9-fix1011b"></script>
     <script src="/beatify/static/js/tts-settings.js?v=3.3.7-rc9-fix1011c"></script>

--- a/custom_components/beatify/www/i18n/de.json
+++ b/custom_components/beatify/www/i18n/de.json
@@ -863,6 +863,8 @@
       "sub": "Standardwerte passen für die meisten Partys. Anpassen optional.",
       "difficulty": "Schwierigkeit",
       "timer": "Zeit pro Runde",
+      "autoAdvance": "Auto-Weiter im Reveal",
+      "autoAdvanceOff": "Aus",
       "language": "Ansagesprache",
       "easy": "Leicht",
       "normal": "Normal",

--- a/custom_components/beatify/www/i18n/en.json
+++ b/custom_components/beatify/www/i18n/en.json
@@ -863,6 +863,8 @@
       "sub": "Defaults work for most parties. Tweak if you want.",
       "difficulty": "Difficulty",
       "timer": "Time per round",
+      "autoAdvance": "Auto-advance reveal",
+      "autoAdvanceOff": "Off",
       "language": "Announcement language",
       "easy": "Easy",
       "normal": "Normal",

--- a/custom_components/beatify/www/i18n/es.json
+++ b/custom_components/beatify/www/i18n/es.json
@@ -863,6 +863,8 @@
       "sub": "Los valores por defecto funcionan para la mayoría. Ajusta si quieres.",
       "difficulty": "Dificultad",
       "timer": "Tiempo por ronda",
+      "autoAdvance": "Avance automático en revelación",
+      "autoAdvanceOff": "Desactivado",
       "language": "Idioma de anuncios",
       "easy": "Fácil",
       "normal": "Normal",

--- a/custom_components/beatify/www/i18n/fr.json
+++ b/custom_components/beatify/www/i18n/fr.json
@@ -863,6 +863,8 @@
       "sub": "Les réglages par défaut conviennent pour la plupart. Ajuste si tu veux.",
       "difficulty": "Difficulté",
       "timer": "Temps par manche",
+      "autoAdvance": "Avance auto au reveal",
+      "autoAdvanceOff": "Désactivé",
       "language": "Langue des annonces",
       "easy": "Facile",
       "normal": "Normal",

--- a/custom_components/beatify/www/i18n/nl.json
+++ b/custom_components/beatify/www/i18n/nl.json
@@ -863,6 +863,8 @@
       "sub": "Standaardinstellingen werken voor de meeste feesten. Pas aan indien gewenst.",
       "difficulty": "Moeilijkheid",
       "timer": "Tijd per ronde",
+      "autoAdvance": "Auto-doorgaan bij reveal",
+      "autoAdvanceOff": "Uit",
       "language": "Aankondigingstaal",
       "easy": "Makkelijk",
       "normal": "Normaal",

--- a/custom_components/beatify/www/js/wizard.js
+++ b/custom_components/beatify/www/js/wizard.js
@@ -98,6 +98,7 @@ const chosenPlaylists = new Set(); // paths — multi-select
 // Step 4 (game mode) — default to what admin.js uses when beatify_game_settings is empty
 let chosenDifficulty = 'normal';
 let chosenDuration = 45;
+let chosenRevealAutoAdvance = 30; // #1028: REVEAL auto-advance seconds (0 = off)
 let chosenLanguage = 'en';
 // Game-mode toggles (defaults match admin.js: artistChallenge on, movieQuiz on, intro off, closestWins off)
 let chosenArtistChallenge = true;
@@ -588,6 +589,12 @@ const DIFFICULTY_HINTS = {
     },
 };
 const DURATIONS = [15, 30, 45, 60]; // seconds per round
+const AUTO_ADVANCE_OPTIONS = [
+    { id: 0, labelKey: 'wizard.step4.autoAdvanceOff', labelFallback: 'Off' },
+    { id: 30, label: '30s' },
+    { id: 60, label: '60s' },
+    { id: 90, label: '90s' },
+];
 const LANGUAGES = [
     { id: 'en', label: 'English' },
     { id: 'de', label: 'Deutsch' },
@@ -700,6 +707,10 @@ function _renderGameMode() {
     _renderDifficultyHint();
     _renderChipGroup('wiz-timer', DURATIONS, chosenDuration, (val) => {
         chosenDuration = val;
+        _renderGameMode();
+    });
+    _renderChipGroup('wiz-autoadvance', AUTO_ADVANCE_OPTIONS, chosenRevealAutoAdvance, (val) => {
+        chosenRevealAutoAdvance = parseInt(val, 10) || 0;
         _renderGameMode();
     });
     _renderChipGroup('wiz-language', LANGUAGES, chosenLanguage, async (val) => {
@@ -1055,6 +1066,7 @@ function _persistGameSettings() {
             provider: chosenProvider || existing.provider,
             difficulty: chosenDifficulty,
             duration: chosenDuration,
+            revealAutoAdvance: chosenRevealAutoAdvance,
             language: chosenLanguage,
             artistChallenge: chosenArtistChallenge,
             movieQuiz: chosenMovieQuiz,
@@ -1091,6 +1103,7 @@ export async function show(stepOverride) {
             if (s.provider) chosenProvider = s.provider;
             if (s.difficulty) chosenDifficulty = s.difficulty;
             if (s.duration) chosenDuration = s.duration;
+            if (typeof s.revealAutoAdvance === 'number') chosenRevealAutoAdvance = s.revealAutoAdvance;
             // #815 + #822: prefer the BROWSER's language as the game-language
             // default. Saved value only wins if browser detection isn't
             // available.

--- a/custom_components/beatify/www/sw.js
+++ b/custom_components/beatify/www/sw.js
@@ -6,7 +6,7 @@
  */
 'use strict';
 
-var CACHE_VERSION = 'beatify-v3.3.7-rc9-fix1011c';
+var CACHE_VERSION = 'beatify-v3.3.7-rc9-fix1028b';
 var MAX_CACHE_ITEMS = 50;
 
 // Critical assets to precache on install (minified versions only - fallback handled by HTML)


### PR DESCRIPTION
Follow-up to PR #1034 which added Auto-Advance chips to the **admin panel** but missed the **wizard**.

Markus reported he still couldn't find the toggle — screenshot showed him in wizard Step 4 ("Wie möchtest du spielen?"), which only had Difficulty / Timer / Language. The chips were only in the admin's collapsible Game Settings section.

## Changes

- `admin.html` (wiz-frame 4): add `<div class="wiz-field">` between Timer and Language with `wiz-autoadvance` chip-group.
- `wizard.js`:
  - new `chosenRevealAutoAdvance = 30` state (matches #1012 server default).
  - `AUTO_ADVANCE_OPTIONS` array: Off / 30s / 60s / 90s.
  - render via `_renderChipGroup` in `_renderGameMode`.
  - hydrate from `beatify_game_settings.revealAutoAdvance`.
  - persist via `_persistGameSettings` into the same key the admin chips read/write.
- 5-locale i18n (`wizard.step4.autoAdvance` label + `wizard.step4.autoAdvanceOff`).
- Cache-bust + sw.js → `-fix1028b`.

Net: admin chips and wizard chips are now two views on one state.

## Test plan

- [ ] Fresh install, run wizard → Step 4 shows Auto-Advance row with `30s` active by default
- [ ] Pick `60s` → finish wizard → open admin → Game Settings → Auto-Advance shows `60s` selected
- [ ] Admin → switch to `Off` → re-enter wizard → Step 4 Auto-Advance shows `Off`
- [ ] German locale → label reads "Auto-Weiter im Reveal" / "Aus"
- [ ] No regression on Difficulty / Timer / Language ordering

🤖 Generated with [Claude Code](https://claude.com/claude-code)