### PR TITLE
data: fix Danube Incident release year (1968 → 1969)

### DIFF
--- a/custom_components/beatify/playlists/movies-100-greatest-themes.json
+++ b/custom_components/beatify/playlists/movies-100-greatest-themes.json
@@ -3524,7 +3524,7 @@
       }
     },
     {
-      "year": 1968,
+      "year": 1969,
       "artist": "Lalo Schifrin",
       "title": "Danube Incident",
       "uri": "spotify:track:2QqouLGFYMynquwDMYUGk1",


### PR DESCRIPTION
## Issue
GitHub issue #1061 reported incorrect release year for Lalo Schifrin's 'Danube Incident'.

## Finding
The song was recorded in 1968 but released in 1969 on the album 'More Mission: Impossible' by the Paramount label.

**Playlist**: `custom_components/beatify/playlists/movies-100-greatest-themes.json`
**Old Year**: 1968
**Correct Year**: 1969

## Research Sources
- Album: More Mission: Impossible by Lalo Schifrin
- Release Year: 1969 (recorded 1968)
- Sources Verified:
  - Wikipedia: More Mission: Impossible
  - Spotify: Danube Incident track page
  - Apple Music: Danube Incident track page
  - Deezer: Danube Incident track page

Closes #1061