### PR TITLE
fix: correct year for Alcazar 'Crying At the Discoteque' (2000, not 2012)

### DIFF
--- a/custom_components/beatify/playlists/community/hits-2010s-2020s.json
+++ b/custom_components/beatify/playlists/community/hits-2010s-2020s.json
@@ -1007,9 +1007,9 @@
       "fun_fact_nl": "Een chart-hit van Leony (2023)."
     },
     {
-      "artist": "Alcatraz",
+      "artist": "Alcazar",
       "title": "Crying At the Discoteque",
-      "year": 2012,
+      "year": 2000,
       "isrc": "DEZ921200553",
       "uri": "spotify:track:5UcMexhqzhHXwGvYuA6kVj",
       "uri_apple_music": "applemusic://track/556437629",
@@ -1025,11 +1025,11 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=a1fFwOXBxik",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/57286181",
-      "fun_fact": "A chart hit by Alcatraz (2012).",
-      "fun_fact_de": "Ein Chart-Hit von Alcatraz (2012).",
-      "fun_fact_es": "Un éxito de Alcatraz (2012).",
-      "fun_fact_fr": "Un tube de Alcatraz (2012).",
-      "fun_fact_nl": "Een chart-hit van Alcatraz (2012)."
+      "fun_fact": "A chart hit by Alcazar (2000).",
+      "fun_fact_de": "Ein Chart-Hit von Alcazar (2000).",
+      "fun_fact_es": "Un éxito de Alcazar (2000).",
+      "fun_fact_fr": "Un tube de Alcazar (2000).",
+      "fun_fact_nl": "Een chart-hit van Alcazar (2000)."
     },
     {
       "artist": "Imany",


### PR DESCRIPTION
## Finding

Data quality issue #1068 reported that 'Crying At the Discoteque' had the wrong year in the playlist.

### Investigation

Researched the song using artist name and title:
- **Artist**: Alcazar (Swedish pop group)
- **Song**: Crying At the Discoteque  
- **Reported year**: 2012
- **Actual release date**: April 2000 (per [Wikipedia](https://en.wikipedia.org/wiki/Crying_at_the_Discoteque) and [Discogs](https://www.discogs.com/release/90408-Alcazar-Crying-At-The-Discoteque))

### Changes

- Updated year from 2012 → 2000
- Corrected artist name from 'Alcatraz' → 'Alcazar'
- Updated all multi-language fun_fact fields to reflect correct year

Fixes #1068