### PR TITLE
release: v3.4.0-rc7 — admin merge-conflict fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to Beatify are documented here. For detailed release notes, 
 
 ## [Unreleased]
 
+## [3.4.0-rc7] - 2026-05-21
+
+### Fixed
+- **Unresolved Git merge conflict markers in admin assets (#1071).** The PR #1007 (security gate #998) merge accidentally committed unresolved `<<<<<<< HEAD … >>>>>>> 984697bd` markers in `admin.html`, `admin.min.js` (3 places), and `party-lights.min.js`. Symptom on rc6: the literal marker block leaked into the admin page footer, and because `admin.min.js` started with `<<<<<<<` on line 1, the whole admin UI failed with a JS SyntaxError and only skeleton loaders rendered. The sources (`admin.js`, `party-lights.js`) were already correctly merged — only the minified outputs were broken; this release regenerates them via `make build`. Also re-includes `playlist-generator.min.js` (deleted by `make clean` because it was missing from Makefile `JS_FILES`).
+- **Stale unit test for `admin_connect` (post-#998).** `test_admin_command_from_admin_ws` still sent the retired `admin_token` field; the handler now expects `ha_token`. The test is updated to mirror the pattern of the passing tests; full `test_websocket.py` suite (71 tests) green.
+
 ## [3.4.0-rc6] - 2026-05-20
 
 ### Security

--- a/custom_components/beatify/manifest.json
+++ b/custom_components/beatify/manifest.json
@@ -12,5 +12,5 @@
   "documentation": "https://github.com/mholzi/beatify",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/mholzi/beatify/issues",
-  "version": "3.4.0-rc6"
+  "version": "3.4.0-rc7"
 }

--- a/custom_components/beatify/www/admin.html
+++ b/custom_components/beatify/www/admin.html
@@ -8,7 +8,7 @@
          query-string version, a stale en.json from a prior rc gets served
          after upgrade and references to newer keys render as raw strings.
          Bumped each rc alongside manifest.json + sw.js CACHE_VERSION. -->
-    <meta name="beatify-version" content="3.4.0-rc6">
+    <meta name="beatify-version" content="3.4.0-rc7">
     <title data-i18n="admin.title">Beatify Admin</title>
     <!-- PWA: Web App Manifest — Admin installs Beatify to homescreen (Issue #166) -->
     <link rel="manifest" href="/beatify/static/site.webmanifest">
@@ -23,7 +23,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@700;900&display=swap" rel="stylesheet">
     <!-- Story 18.4: Use minified CSS in production -->
-    <link rel="stylesheet" href="/beatify/static/css/styles.min.css?v=3.4.0-rc6">
+    <link rel="stylesheet" href="/beatify/static/css/styles.min.css?v=3.4.0-rc7">
 </head>
 <body class="theme-dark">
     <!-- First-run wizard takeover (see DESIGN.md ## Patterns → First-run wizard) -->
@@ -1412,17 +1412,17 @@
     <!-- Story 18.4: Use minified JS in production with fallback to source -->
     <!-- Version query strings prevent browser caching issues -->
     <!-- #998: HA OAuth client — must load before any admin script uses BeatifyAuth -->
-    <script src="/beatify/static/js/ha-auth.js?v=3.4.0-rc6"></script>
+    <script src="/beatify/static/js/ha-auth.js?v=3.4.0-rc7"></script>
     <script src="/beatify/static/js/i18n.js?v=1.7.0"></script>
     <script src="/beatify/static/js/utils.js?v=1.7.0"></script>
     <!-- Story 44.1: Playlist requests module -->
-    <script src="/beatify/static/js/playlist-requests.min.js?v=3.4.0-rc6"></script>
+    <script src="/beatify/static/js/playlist-requests.min.js?v=3.4.0-rc7"></script>
     <!-- #1052: LLM-assisted playlist generator (load before playlist-hub so the Mine-tab button finds it) -->
-    <script src="/beatify/static/js/playlist-generator.min.js?v=3.4.0-rc6"></script>
-    <script type="module" src="/beatify/static/js/playlist-hub.js?v=3.4.0-rc6"></script>
-    <script type="module" src="/beatify/static/js/wizard.js?v=3.4.0-rc6"></script>
-    <script src="/beatify/static/js/admin.min.js?v=3.4.0-rc6"></script>
-    <script src="/beatify/static/js/party-lights.min.js?v=3.4.0-rc6"></script>
-    <script src="/beatify/static/js/tts-settings.js?v=3.4.0-rc6"></script>
+    <script src="/beatify/static/js/playlist-generator.min.js?v=3.4.0-rc7"></script>
+    <script type="module" src="/beatify/static/js/playlist-hub.js?v=3.4.0-rc7"></script>
+    <script type="module" src="/beatify/static/js/wizard.js?v=3.4.0-rc7"></script>
+    <script src="/beatify/static/js/admin.min.js?v=3.4.0-rc7"></script>
+    <script src="/beatify/static/js/party-lights.min.js?v=3.4.0-rc7"></script>
+    <script src="/beatify/static/js/tts-settings.js?v=3.4.0-rc7"></script>
 </body>
 </html>

--- a/custom_components/beatify/www/dashboard.html
+++ b/custom_components/beatify/www/dashboard.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <!-- #824: cache-bust i18n JSON fetches. See admin.html for rationale. -->
-    <meta name="beatify-version" content="3.4.0-rc6">
+    <meta name="beatify-version" content="3.4.0-rc7">
     <title data-i18n="dashboard.title">Beatify - Dashboard</title>
     <!-- Preconnect for faster font loading (Story 9.8) -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -12,7 +12,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Outfit:wght@700;900&display=swap" rel="stylesheet">
     <!-- Story 18.4: Use minified CSS in production -->
     <link rel="stylesheet" href="/beatify/static/css/styles.css?v=1.7.0">
-    <link rel="stylesheet" href="/beatify/static/css/dashboard.min.css?v=3.4.0-rc6">
+    <link rel="stylesheet" href="/beatify/static/css/dashboard.min.css?v=3.4.0-rc7">
     <!-- Confetti library for celebrations (Story 14.5) -->
     <script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.9.2/dist/confetti.browser.min.js"></script>
 </head>
@@ -285,7 +285,7 @@
     <!-- Version query strings prevent browser caching issues -->
     <script src="/beatify/static/js/i18n.js?v=1.7.0"></script>
     <script src="/beatify/static/js/utils.js?v=1.7.0"></script>
-    <script src="/beatify/static/js/dashboard.min.js?v=3.4.0-rc6"></script>
+    <script src="/beatify/static/js/dashboard.min.js?v=3.4.0-rc7"></script>
     <!-- v3.2.1 Arcade shims: submission meter fill, album ring progress, reveal round mirror.
          Pure view-layer helpers — no state, no API calls. Safe to remove if dashboard.js
          ever takes these over directly. -->

--- a/custom_components/beatify/www/player.html
+++ b/custom_components/beatify/www/player.html
@@ -4,14 +4,14 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <!-- #824: cache-bust i18n JSON fetches. See admin.html for rationale. -->
-    <meta name="beatify-version" content="3.4.0-rc6">
+    <meta name="beatify-version" content="3.4.0-rc7">
     <title data-i18n="join.title">Beatify - Join Game</title>
     <!-- Preconnect for faster font loading (Story 9.8) -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@700;900&display=swap" rel="stylesheet">
     <!-- Story 18.4: Use minified CSS in production -->
-    <link rel="stylesheet" href="/beatify/static/css/styles.min.css?v=3.4.0-rc6">
+    <link rel="stylesheet" href="/beatify/static/css/styles.min.css?v=3.4.0-rc7">
     <!-- Confetti library for celebrations (Story 14.5) -->
     <script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.9.2/dist/confetti.browser.min.js"></script>
 </head>
@@ -918,9 +918,9 @@
     <!-- Story 18.4: Use minified JS in production with fallback to source -->
     <!-- Version query strings prevent browser caching issues -->
     <!-- #998: HA OAuth client — only used when a host claims the admin role -->
-    <script src="/beatify/static/js/ha-auth.js?v=3.4.0-rc6"></script>
+    <script src="/beatify/static/js/ha-auth.js?v=3.4.0-rc7"></script>
     <script src="/beatify/static/js/i18n.min.js"></script>
     <script src="/beatify/static/js/utils.min.js"></script>
-    <script type="module" src="/beatify/static/js/player.bundle.min.js?v=3.4.0-rc6"></script>
+    <script type="module" src="/beatify/static/js/player.bundle.min.js?v=3.4.0-rc7"></script>
 </body>
 </html>

--- a/custom_components/beatify/www/sw.js
+++ b/custom_components/beatify/www/sw.js
@@ -6,7 +6,7 @@
  */
 'use strict';
 
-var CACHE_VERSION = 'beatify-v3.4.0-rc6';
+var CACHE_VERSION = 'beatify-v3.4.0-rc7';
 var MAX_CACHE_ITEMS = 50;
 
 // Critical assets to precache on install (minified versions only - fallback handled by HTML)


### PR DESCRIPTION
## Summary

v3.4.0-rc7 = v3.4.0-rc6 + #1071 (admin merge-conflict fix).

### What's in this release
- **Conflict markers gone**: admin.html, admin.min.js (3 places), party-lights.min.js were leaking literal `<<<<<<< HEAD … >>>>>>> 984697bd` markers. admin.min.js Z.1 broke the entire admin UI with a JS SyntaxError (only skeleton loaders rendered, marker text in footer).
- **Test fix**: `test_admin_command_from_admin_ws` now passes `ha_token` instead of the retired `admin_token` (post-#998).
- **Version bumps**: `manifest.json`, `sw.js` cache, and `?v=` cache-busters across admin/dashboard/player HTML.

### Test plan
- [ ] Tag this as Pre-Release on GitHub after merge.
- [ ] Markus installs via HACS, opens `/beatify/admin`.
- [ ] Expected: no skeleton-only state, no merge marker in footer, admin UI fully interactive (start/end/rematch/lights/TTS), HA-login gate still works (#998 not regressed).
- [ ] If clean → tag v3.4.0 stable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)