### PR TITLE
release: v3.4.0-rc10 — TTS-Dropdown, Selected-Playlists, mobile fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to Beatify are documented here. For detailed release notes, 
 
 ## [Unreleased]
 
+## [3.4.0-rc10] - 2026-05-21
+
+### Added
+- **TTS-Entity-Dropdown im Setup-Wizard (#1073, ludgerbeckmann).** Statt freier Texteingabe listet die TTS-Konfiguration jetzt alle in HA registrierten `tts.*`-Entities zur Auswahl. Reduziert Tippfehler und macht die TTS-Konfiguration einsehbar (bisheriges Behavior: User musste die Entity-ID exakt eintippen, mit hoher Fehlerrate). Locales: en/de/es/fr/nl. PR #1079.
+- **"Ausgewählte Playlists"-Sheet mit Bulk-Remove (#1074, ludgerbeckmann).** Die Bottom-Nav-Counter-Pill ("N Playlists gewählt") öffnet jetzt ein Sheet mit allen aktuell gewählten Playlists, jede mit Remove-Button — Markus-Schmerzpunkt: bisher musste man jede Playlist im Hub einzeln finden um sie zu entfernen. Locales en+de. PR #1083.
+
+### Fixed
+- **Year truncation auf Reveal-Screen schmaler Telefone (#1072, laberning).** Auf Android Chrome mit Default-Zoom waren bei manchen Bildschirmgrößen nur 2-3 Stellen der Jahreszahl sichtbar. CSS-Fix zwingt die Year-Anzeige auf overflow-visible mit responsivem `min-width`. PR #1077.
+- **Tighter Game-View-Layout — Artist-Tiles über dem Fold (#1076, laberning).** Beim Player-Screen lagen die Artist-Selection-Buttons im unteren Bildschirmdrittel — alle Spieler mussten jede Runde scrollen um zu voten. Padding/Margin der oberen Sektionen reduziert + Artist-Grid kompakter; die Vote-Buttons sind jetzt direkt unter dem Song-Indicator sichtbar. CSS-Only. PR #1084.
+
 ## [3.4.0-rc9] - 2026-05-21
 
 ### Fixed

--- a/custom_components/beatify/manifest.json
+++ b/custom_components/beatify/manifest.json
@@ -12,5 +12,5 @@
   "documentation": "https://github.com/mholzi/beatify",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/mholzi/beatify/issues",
-  "version": "3.4.0-rc9"
+  "version": "3.4.0-rc10"
 }

--- a/custom_components/beatify/www/admin.html
+++ b/custom_components/beatify/www/admin.html
@@ -8,7 +8,7 @@
          query-string version, a stale en.json from a prior rc gets served
          after upgrade and references to newer keys render as raw strings.
          Bumped each rc alongside manifest.json + sw.js CACHE_VERSION. -->
-    <meta name="beatify-version" content="3.4.0-rc9">
+    <meta name="beatify-version" content="3.4.0-rc10">
     <title data-i18n="admin.title">Beatify Admin</title>
     <!-- PWA: Web App Manifest — Admin installs Beatify to homescreen (Issue #166) -->
     <link rel="manifest" href="/beatify/static/site.webmanifest">
@@ -23,7 +23,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@700;900&display=swap" rel="stylesheet">
     <!-- Story 18.4: Use minified CSS in production -->
-    <link rel="stylesheet" href="/beatify/static/css/styles.min.css?v=3.4.0-rc9">
+    <link rel="stylesheet" href="/beatify/static/css/styles.min.css?v=3.4.0-rc10">
 </head>
 <body class="theme-dark">
     <!-- First-run wizard takeover (see DESIGN.md ## Patterns → First-run wizard) -->
@@ -1414,17 +1414,17 @@
     <!-- Story 18.4: Use minified JS in production with fallback to source -->
     <!-- Version query strings prevent browser caching issues -->
     <!-- #998: HA OAuth client — must load before any admin script uses BeatifyAuth -->
-    <script src="/beatify/static/js/ha-auth.js?v=3.4.0-rc9"></script>
+    <script src="/beatify/static/js/ha-auth.js?v=3.4.0-rc10"></script>
     <script src="/beatify/static/js/i18n.js?v=1.7.0"></script>
     <script src="/beatify/static/js/utils.js?v=1.7.0"></script>
     <!-- Story 44.1: Playlist requests module -->
-    <script src="/beatify/static/js/playlist-requests.min.js?v=3.4.0-rc9"></script>
+    <script src="/beatify/static/js/playlist-requests.min.js?v=3.4.0-rc10"></script>
     <!-- #1052: LLM-assisted playlist generator (load before playlist-hub so the Mine-tab button finds it) -->
-    <script src="/beatify/static/js/playlist-generator.min.js?v=3.4.0-rc9"></script>
-    <script type="module" src="/beatify/static/js/playlist-hub.js?v=3.4.0-rc9"></script>
-    <script type="module" src="/beatify/static/js/wizard.js?v=3.4.0-rc9"></script>
-    <script src="/beatify/static/js/admin.min.js?v=3.4.0-rc9"></script>
-    <script src="/beatify/static/js/party-lights.min.js?v=3.4.0-rc9"></script>
-    <script src="/beatify/static/js/tts-settings.js?v=3.4.0-rc9"></script>
+    <script src="/beatify/static/js/playlist-generator.min.js?v=3.4.0-rc10"></script>
+    <script type="module" src="/beatify/static/js/playlist-hub.js?v=3.4.0-rc10"></script>
+    <script type="module" src="/beatify/static/js/wizard.js?v=3.4.0-rc10"></script>
+    <script src="/beatify/static/js/admin.min.js?v=3.4.0-rc10"></script>
+    <script src="/beatify/static/js/party-lights.min.js?v=3.4.0-rc10"></script>
+    <script src="/beatify/static/js/tts-settings.js?v=3.4.0-rc10"></script>
 </body>
 </html>

--- a/custom_components/beatify/www/dashboard.html
+++ b/custom_components/beatify/www/dashboard.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <!-- #824: cache-bust i18n JSON fetches. See admin.html for rationale. -->
-    <meta name="beatify-version" content="3.4.0-rc9">
+    <meta name="beatify-version" content="3.4.0-rc10">
     <title data-i18n="dashboard.title">Beatify - Dashboard</title>
     <!-- Preconnect for faster font loading (Story 9.8) -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -12,7 +12,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Outfit:wght@700;900&display=swap" rel="stylesheet">
     <!-- Story 18.4: Use minified CSS in production -->
     <link rel="stylesheet" href="/beatify/static/css/styles.css?v=1.7.0">
-    <link rel="stylesheet" href="/beatify/static/css/dashboard.min.css?v=3.4.0-rc9">
+    <link rel="stylesheet" href="/beatify/static/css/dashboard.min.css?v=3.4.0-rc10">
     <!-- Confetti library for celebrations (Story 14.5) -->
     <script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.9.2/dist/confetti.browser.min.js"></script>
 </head>
@@ -285,7 +285,7 @@
     <!-- Version query strings prevent browser caching issues -->
     <script src="/beatify/static/js/i18n.js?v=1.7.0"></script>
     <script src="/beatify/static/js/utils.js?v=1.7.0"></script>
-    <script src="/beatify/static/js/dashboard.min.js?v=3.4.0-rc9"></script>
+    <script src="/beatify/static/js/dashboard.min.js?v=3.4.0-rc10"></script>
     <!-- v3.2.1 Arcade shims: submission meter fill, album ring progress, reveal round mirror.
          Pure view-layer helpers — no state, no API calls. Safe to remove if dashboard.js
          ever takes these over directly. -->

--- a/custom_components/beatify/www/player.html
+++ b/custom_components/beatify/www/player.html
@@ -4,14 +4,14 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <!-- #824: cache-bust i18n JSON fetches. See admin.html for rationale. -->
-    <meta name="beatify-version" content="3.4.0-rc9">
+    <meta name="beatify-version" content="3.4.0-rc10">
     <title data-i18n="join.title">Beatify - Join Game</title>
     <!-- Preconnect for faster font loading (Story 9.8) -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@700;900&display=swap" rel="stylesheet">
     <!-- Story 18.4: Use minified CSS in production -->
-    <link rel="stylesheet" href="/beatify/static/css/styles.min.css?v=3.4.0-rc9">
+    <link rel="stylesheet" href="/beatify/static/css/styles.min.css?v=3.4.0-rc10">
     <!-- Confetti library for celebrations (Story 14.5) -->
     <script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.9.2/dist/confetti.browser.min.js"></script>
 </head>
@@ -918,9 +918,9 @@
     <!-- Story 18.4: Use minified JS in production with fallback to source -->
     <!-- Version query strings prevent browser caching issues -->
     <!-- #998: HA OAuth client — only used when a host claims the admin role -->
-    <script src="/beatify/static/js/ha-auth.js?v=3.4.0-rc9"></script>
+    <script src="/beatify/static/js/ha-auth.js?v=3.4.0-rc10"></script>
     <script src="/beatify/static/js/i18n.min.js"></script>
     <script src="/beatify/static/js/utils.min.js"></script>
-    <script type="module" src="/beatify/static/js/player.bundle.min.js?v=3.4.0-rc9"></script>
+    <script type="module" src="/beatify/static/js/player.bundle.min.js?v=3.4.0-rc10"></script>
 </body>
 </html>

--- a/custom_components/beatify/www/sw.js
+++ b/custom_components/beatify/www/sw.js
@@ -6,7 +6,7 @@
  */
 'use strict';
 
-var CACHE_VERSION = 'beatify-v3.4.0-rc9';
+var CACHE_VERSION = 'beatify-v3.4.0-rc10';
 var MAX_CACHE_ITEMS = 50;
 
 // Critical assets to precache on install (minified versions only - fallback handled by HTML)


### PR DESCRIPTION
## Summary

v3.4.0-rc10 = rc9 + 4 user-facing fixes/features that shipped while rc9 was being released:

- **#1077 (#1072)** — Year truncation auf Reveal-Screen schmaler Telefone (laberning, CSS fix)
- **#1079 (#1073)** — TTS-Entity-Dropdown im Setup-Wizard (ludgerbeckmann, neu)
- **#1083 (#1074)** — "Ausgewählte Playlists"-Sheet mit Bulk-Remove (ludgerbeckmann, neu)
- **#1084 (#1076)** — Tighter Game-View-Layout — Artist-Tiles über dem Fold (laberning, CSS fix)

Bumps rc9→rc10 in manifest.json, sw.js cache version, and `?v=` cache-busters across admin.html / dashboard.html / player.html.

## Test plan
- [ ] Install via HACS → admin lädt clean, kein Skeleton-only.
- [ ] TTS-Settings: Dropdown zeigt deine `tts.*`-Entities.
- [ ] Playlist-Counter-Pill öffnet Sheet mit Bulk-Remove.
- [ ] Reveal-Screen auf Android Chrome: ganze Jahreszahl sichtbar.
- [ ] Player-Screen: Artist-Vote-Buttons direkt ohne Scrollen.

Wenn alles clean → tag v3.4.0 stable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)