### PR TITLE
v3.4.0-rc11 fix(sw): self-healing SW recovery — no more cache clearing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to Beatify are documented here. For detailed release notes, 
 
 ## [Unreleased]
 
+## [3.4.0-rc11] - 2026-05-21
+
+### Fixed
+- **Login loop after HACS update — users no longer need to clear browser cache (#998 follow-up).** The service worker from a previous Beatify version was sticky: it precached `/beatify/static/js/ha-auth.js` (no query string) and Safari/WebKit would serve the stale entry for the cache-busted `?v=...` URL too, leaving users in an unrecoverable login loop on any auth-code change. Two structural fixes ensure no future upgrade requires a manual "Quit Safari + Clear Storage" dance:
+  1. `sw.js` — `ha-auth.js` is now in a `NEVER_CACHE` list and the fetch handler bypasses the cache for it. The browser fetches it directly from HA on every load, where `_NO_CACHE_HEADERS` keeps ETag revalidation cheap (~30 bytes of overhead). Stale `ha-auth.js` is no longer reachable from the SW path.
+  2. `admin.html` and `player.html` — inline bootstrap script at the very top of `<head>` compares the page's `beatify-version` meta tag against `localStorage.beatify_sw_version`. On mismatch with an active SW, it unregisters all SWs and reloads before any other script runs. First load after upgrade self-heals; steady-state cost is one localStorage read. Users stuck on rc10 with a stale SW auto-recover on their next admin/player page load.
+
+The rc8/rc9 auth fixes (FormData transport, zombie-token probe, ha_token in admin join) are unchanged — those addressed the symptoms; rc11 closes the upgrade-pathology that masked them.
+
 ## [3.4.0-rc10] - 2026-05-21
 
 ### Added

--- a/custom_components/beatify/manifest.json
+++ b/custom_components/beatify/manifest.json
@@ -12,5 +12,5 @@
   "documentation": "https://github.com/mholzi/beatify",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/mholzi/beatify/issues",
-  "version": "3.4.0-rc10"
+  "version": "3.4.0-rc11"
 }

--- a/custom_components/beatify/www/admin.html
+++ b/custom_components/beatify/www/admin.html
@@ -8,7 +8,39 @@
          query-string version, a stale en.json from a prior rc gets served
          after upgrade and references to newer keys render as raw strings.
          Bumped each rc alongside manifest.json + sw.js CACHE_VERSION. -->
-    <meta name="beatify-version" content="3.4.0-rc10">
+    <meta name="beatify-version" content="3.4.0-rc11">
+    <!-- Self-healing SW recovery (rc11): an older-version service worker
+         may serve a stale ha-auth.js even with cache-busters, leaving users
+         in an unrecoverable login loop. Compare the current page's version
+         (meta tag above) against the last-seen version in localStorage; on
+         mismatch with an active SW, unregister all SWs + reload. First load
+         after upgrade auto-recovers; steady state is a single localStorage
+         read with zero side effects. Inline + first script in head so it
+         runs before any external module/script that might block on auth. -->
+    <script>
+        (function() {
+            if (!('serviceWorker' in navigator)) return;
+            var meta = document.querySelector('meta[name=beatify-version]');
+            var current = meta && meta.content;
+            if (!current) return;
+            var seen = null;
+            try { seen = localStorage.getItem('beatify_sw_version'); } catch (e) {}
+            if (seen === current) return;
+            if (!navigator.serviceWorker.controller) {
+                try { localStorage.setItem('beatify_sw_version', current); } catch (e) {}
+                return;
+            }
+            navigator.serviceWorker.getRegistrations()
+                .then(function(regs) {
+                    return Promise.all(regs.map(function(r) { return r.unregister(); }));
+                })
+                .then(function() {
+                    try { localStorage.setItem('beatify_sw_version', current); } catch (e) {}
+                    location.reload();
+                })
+                .catch(function() { /* best-effort; reload will retry */ });
+        })();
+    </script>
     <title data-i18n="admin.title">Beatify Admin</title>
     <!-- PWA: Web App Manifest — Admin installs Beatify to homescreen (Issue #166) -->
     <link rel="manifest" href="/beatify/static/site.webmanifest">
@@ -23,7 +55,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@700;900&display=swap" rel="stylesheet">
     <!-- Story 18.4: Use minified CSS in production -->
-    <link rel="stylesheet" href="/beatify/static/css/styles.min.css?v=3.4.0-rc10">
+    <link rel="stylesheet" href="/beatify/static/css/styles.min.css?v=3.4.0-rc11">
 </head>
 <body class="theme-dark">
     <!-- First-run wizard takeover (see DESIGN.md ## Patterns → First-run wizard) -->
@@ -1414,17 +1446,17 @@
     <!-- Story 18.4: Use minified JS in production with fallback to source -->
     <!-- Version query strings prevent browser caching issues -->
     <!-- #998: HA OAuth client — must load before any admin script uses BeatifyAuth -->
-    <script src="/beatify/static/js/ha-auth.js?v=3.4.0-rc10"></script>
+    <script src="/beatify/static/js/ha-auth.js?v=3.4.0-rc11"></script>
     <script src="/beatify/static/js/i18n.js?v=1.7.0"></script>
     <script src="/beatify/static/js/utils.js?v=1.7.0"></script>
     <!-- Story 44.1: Playlist requests module -->
-    <script src="/beatify/static/js/playlist-requests.min.js?v=3.4.0-rc10"></script>
+    <script src="/beatify/static/js/playlist-requests.min.js?v=3.4.0-rc11"></script>
     <!-- #1052: LLM-assisted playlist generator (load before playlist-hub so the Mine-tab button finds it) -->
-    <script src="/beatify/static/js/playlist-generator.min.js?v=3.4.0-rc10"></script>
-    <script type="module" src="/beatify/static/js/playlist-hub.js?v=3.4.0-rc10"></script>
-    <script type="module" src="/beatify/static/js/wizard.js?v=3.4.0-rc10"></script>
-    <script src="/beatify/static/js/admin.min.js?v=3.4.0-rc10"></script>
-    <script src="/beatify/static/js/party-lights.min.js?v=3.4.0-rc10"></script>
-    <script src="/beatify/static/js/tts-settings.js?v=3.4.0-rc10"></script>
+    <script src="/beatify/static/js/playlist-generator.min.js?v=3.4.0-rc11"></script>
+    <script type="module" src="/beatify/static/js/playlist-hub.js?v=3.4.0-rc11"></script>
+    <script type="module" src="/beatify/static/js/wizard.js?v=3.4.0-rc11"></script>
+    <script src="/beatify/static/js/admin.min.js?v=3.4.0-rc11"></script>
+    <script src="/beatify/static/js/party-lights.min.js?v=3.4.0-rc11"></script>
+    <script src="/beatify/static/js/tts-settings.js?v=3.4.0-rc11"></script>
 </body>
 </html>

--- a/custom_components/beatify/www/dashboard.html
+++ b/custom_components/beatify/www/dashboard.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <!-- #824: cache-bust i18n JSON fetches. See admin.html for rationale. -->
-    <meta name="beatify-version" content="3.4.0-rc10">
+    <meta name="beatify-version" content="3.4.0-rc11">
     <title data-i18n="dashboard.title">Beatify - Dashboard</title>
     <!-- Preconnect for faster font loading (Story 9.8) -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -12,7 +12,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Outfit:wght@700;900&display=swap" rel="stylesheet">
     <!-- Story 18.4: Use minified CSS in production -->
     <link rel="stylesheet" href="/beatify/static/css/styles.css?v=1.7.0">
-    <link rel="stylesheet" href="/beatify/static/css/dashboard.min.css?v=3.4.0-rc10">
+    <link rel="stylesheet" href="/beatify/static/css/dashboard.min.css?v=3.4.0-rc11">
     <!-- Confetti library for celebrations (Story 14.5) -->
     <script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.9.2/dist/confetti.browser.min.js"></script>
 </head>
@@ -285,7 +285,7 @@
     <!-- Version query strings prevent browser caching issues -->
     <script src="/beatify/static/js/i18n.js?v=1.7.0"></script>
     <script src="/beatify/static/js/utils.js?v=1.7.0"></script>
-    <script src="/beatify/static/js/dashboard.min.js?v=3.4.0-rc10"></script>
+    <script src="/beatify/static/js/dashboard.min.js?v=3.4.0-rc11"></script>
     <!-- v3.2.1 Arcade shims: submission meter fill, album ring progress, reveal round mirror.
          Pure view-layer helpers — no state, no API calls. Safe to remove if dashboard.js
          ever takes these over directly. -->

--- a/custom_components/beatify/www/player.html
+++ b/custom_components/beatify/www/player.html
@@ -4,14 +4,39 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <!-- #824: cache-bust i18n JSON fetches. See admin.html for rationale. -->
-    <meta name="beatify-version" content="3.4.0-rc10">
+    <meta name="beatify-version" content="3.4.0-rc11">
+    <!-- Self-healing SW recovery (rc11) — see admin.html for the rationale. -->
+    <script>
+        (function() {
+            if (!('serviceWorker' in navigator)) return;
+            var meta = document.querySelector('meta[name=beatify-version]');
+            var current = meta && meta.content;
+            if (!current) return;
+            var seen = null;
+            try { seen = localStorage.getItem('beatify_sw_version'); } catch (e) {}
+            if (seen === current) return;
+            if (!navigator.serviceWorker.controller) {
+                try { localStorage.setItem('beatify_sw_version', current); } catch (e) {}
+                return;
+            }
+            navigator.serviceWorker.getRegistrations()
+                .then(function(regs) {
+                    return Promise.all(regs.map(function(r) { return r.unregister(); }));
+                })
+                .then(function() {
+                    try { localStorage.setItem('beatify_sw_version', current); } catch (e) {}
+                    location.reload();
+                })
+                .catch(function() { /* best-effort; reload will retry */ });
+        })();
+    </script>
     <title data-i18n="join.title">Beatify - Join Game</title>
     <!-- Preconnect for faster font loading (Story 9.8) -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@700;900&display=swap" rel="stylesheet">
     <!-- Story 18.4: Use minified CSS in production -->
-    <link rel="stylesheet" href="/beatify/static/css/styles.min.css?v=3.4.0-rc10">
+    <link rel="stylesheet" href="/beatify/static/css/styles.min.css?v=3.4.0-rc11">
     <!-- Confetti library for celebrations (Story 14.5) -->
     <script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.9.2/dist/confetti.browser.min.js"></script>
 </head>
@@ -918,9 +943,9 @@
     <!-- Story 18.4: Use minified JS in production with fallback to source -->
     <!-- Version query strings prevent browser caching issues -->
     <!-- #998: HA OAuth client — only used when a host claims the admin role -->
-    <script src="/beatify/static/js/ha-auth.js?v=3.4.0-rc10"></script>
+    <script src="/beatify/static/js/ha-auth.js?v=3.4.0-rc11"></script>
     <script src="/beatify/static/js/i18n.min.js"></script>
     <script src="/beatify/static/js/utils.min.js"></script>
-    <script type="module" src="/beatify/static/js/player.bundle.min.js?v=3.4.0-rc10"></script>
+    <script type="module" src="/beatify/static/js/player.bundle.min.js?v=3.4.0-rc11"></script>
 </body>
 </html>

--- a/custom_components/beatify/www/sw.js
+++ b/custom_components/beatify/www/sw.js
@@ -6,16 +6,16 @@
  */
 'use strict';
 
-var CACHE_VERSION = 'beatify-v3.4.0-rc10';
+var CACHE_VERSION = 'beatify-v3.4.0-rc11';
 var MAX_CACHE_ITEMS = 50;
 
-// Critical assets to precache on install (minified versions only - fallback handled by HTML)
+// Critical assets to precache on install (minified versions only - fallback handled by HTML).
+// ha-auth.js is intentionally excluded — see NEVER_CACHE below.
 var PRECACHE_ASSETS = [
     '/beatify/static/css/styles.min.css',
     '/beatify/static/css/dashboard.min.css',
     '/beatify/static/js/player.bundle.min.js',
     '/beatify/static/js/admin.min.js',
-    '/beatify/static/js/ha-auth.js',
     '/beatify/static/js/dashboard.min.js',
     '/beatify/static/js/i18n.min.js',
     '/beatify/static/js/vendor/qrcode.min.js',
@@ -23,6 +23,16 @@ var PRECACHE_ASSETS = [
     '/beatify/static/site.webmanifest',
     '/beatify/static/img/icon-256.png',
     '/beatify/static/img/icon-512.png'
+];
+
+// Files that must NEVER be served from cache. The cache-buster on script tags
+// is supposed to defeat staleness, but once the SW has precached the canonical
+// URL (no query string), some browsers (notably Safari/WebKit) will return the
+// stale entry for the versioned URL too. A stale ha-auth.js leaves users in an
+// unrecoverable login loop. Network-only ensures the user's browser always
+// asks HA directly, where _NO_CACHE_HEADERS makes ETag revalidation work.
+var NEVER_CACHE = [
+    '/beatify/static/js/ha-auth.js',
 ];
 
 /**
@@ -92,6 +102,12 @@ self.addEventListener('fetch', function(event) {
 
     // Skip non-GET requests
     if (event.request.method !== 'GET') {
+        return;
+    }
+
+    // Auth-critical files: never cache. Returning without respondWith lets the
+    // browser do its normal network fetch (still respects HTTP cache headers).
+    if (NEVER_CACHE.indexOf(url.pathname) !== -1) {
         return;
     }
 


### PR DESCRIPTION
## Summary

**Closes the upgrade pathology that strands users in a login loop after HACS updates.** No more "clear Safari site data" workaround required.

### Root cause

The service worker from a previous Beatify version was sticky: it precached \`/beatify/static/js/ha-auth.js\` (canonical URL, no query string) at install time, and Safari/WebKit would serve that stale entry even when the page requested the cache-busted \`?v=...\` URL. Any \`ha-auth.js\` change after first install was unreachable from the user's browser. Symptom: login loops that the user can only escape by manually clearing site data — not acceptable for an integration shipped to non-technical users.

### Fixes (both structural, no behavioral changes for happy paths)

**1. \`sw.js\` — never cache \`ha-auth.js\`**
- Moved out of \`PRECACHE_ASSETS\`
- New \`NEVER_CACHE\` list checked first in the fetch handler; matched URLs return without \`respondWith\`, letting the browser do a normal network fetch
- HA's \`_NO_CACHE_HEADERS\` make ETag revalidation cheap (~30 byte overhead per page load)
- Stale \`ha-auth.js\` is no longer reachable from the SW path

**2. \`admin.html\` + \`player.html\` — inline self-healing bootstrap**
- First script in \`<head>\`, runs before any external script that might block on auth
- Compares \`<meta name=beatify-version>\` against \`localStorage.beatify_sw_version\`
- On mismatch with an active SW: \`getRegistrations().unregister()\` for all, then \`location.reload()\`
- Steady-state cost: one localStorage read (\`if (seen === current) return;\`)
- Users currently stuck on rc10 with a stale SW will auto-recover on their next admin or player page load

## Why two fixes

\`sw.js\` is the structural prevention going forward. The HTML bootstrap is the migration path for users on older versions whose stale SW would otherwise keep serving the bad bundle until they manually intervened. Both can coexist forever — bootstrap is a localStorage compare in steady state.

## Test Coverage

- JS suite: 85/85 pass
- Python suite: 520/520 pass

## Manual Verification

For users currently in a login loop on rc10:
1. Update via HACS (Show beta versions enabled)
2. Reload HA
3. Open \`/beatify/admin\` once — bootstrap detects SW version mismatch, unregisters old SW, page reloads
4. Login flow completes normally; no manual cache clearing required

For all future users:
- Every Beatify release with a meta-version bump triggers the recovery automatically when an old SW is still controlling the page
- \`ha-auth.js\` is structurally outside the SW cache forever

## Test plan
- [x] JS test suite passes (85/85)
- [x] Python test suite passes (520/520)
- [x] sw.js NEVER_CACHE bypass returns before any \`respondWith\`
- [x] Bootstrap runs synchronously inline before external scripts
- [ ] Manual: user on rc10 with stale SW updates to rc11 → admin loads on first reload without clearing cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)