### PR TITLE
fix: auto-select first speaker + Spotify default on first-run wizard (#1082)

### DIFF
--- a/custom_components/beatify/www/js/__tests__/wizard.test.js
+++ b/custom_components/beatify/www/js/__tests__/wizard.test.js
@@ -3,7 +3,7 @@
  * These helpers drive the state machine: when to show, where to resume, when to show the pill.
  */
 import { describe, it, expect, beforeEach } from 'vitest';
-import { resumeAtStep, shouldTrigger, shouldShowPill, providerSupportedForPlayer, capabilityBadgeForPlayer } from '../wizard.js';
+import { resumeAtStep, shouldTrigger, shouldShowPill, providerSupportedForPlayer, capabilityBadgeForPlayer, pickAutoSelections } from '../wizard.js';
 
 function makeLS(initial = {}) {
     const store = { ...initial };
@@ -192,5 +192,63 @@ describe('capabilityBadgeForPlayer', () => {
         const player = { supports_spotify: true, supports_apple_music: true, supports_youtube_music: true };
         const badge = capabilityBadgeForPlayer(player, providers, { all: 'Alle Dienste' });
         expect(badge.label).toBe('Alle Dienste');
+    });
+});
+
+// ------------------------------------------------------------------
+// pickAutoSelections — first-run defaults: first speaker + Spotify when supported (#1082)
+// ------------------------------------------------------------------
+describe('pickAutoSelections', () => {
+    it('picks the first player and Spotify on a fresh install', () => {
+        const players = [
+            { entity_id: 'media_player.sonos_kitchen', supports_spotify: true },
+            { entity_id: 'media_player.sonos_lounge', supports_spotify: true },
+        ];
+        expect(pickAutoSelections(players, null, null)).toEqual({
+            speaker: 'media_player.sonos_kitchen',
+            provider: 'spotify',
+        });
+    });
+
+    it('skips provider when the picked speaker does not support Spotify', () => {
+        const players = [
+            { entity_id: 'media_player.cast', supports_spotify: false, supports_apple_music: true },
+        ];
+        expect(pickAutoSelections(players, null, null)).toEqual({
+            speaker: 'media_player.cast',
+            provider: null,
+        });
+    });
+
+    it('keeps a previously saved speaker even when more are available', () => {
+        const players = [
+            { entity_id: 'media_player.sonos_kitchen', supports_spotify: true },
+            { entity_id: 'media_player.sonos_lounge', supports_spotify: true },
+        ];
+        const result = pickAutoSelections(players, 'media_player.sonos_lounge', null);
+        expect(result.speaker).toBe('media_player.sonos_lounge');
+        expect(result.provider).toBe('spotify');
+    });
+
+    it('keeps a previously saved provider even when not Spotify', () => {
+        const players = [
+            { entity_id: 'media_player.ma_lounge', supports_spotify: true, supports_apple_music: true },
+        ];
+        const result = pickAutoSelections(players, null, 'apple_music');
+        expect(result.provider).toBe('apple_music');
+    });
+
+    it('returns nulls when no players exist (fresh HA before MA finishes)', () => {
+        expect(pickAutoSelections([], null, null)).toEqual({ speaker: null, provider: null });
+        expect(pickAutoSelections(null, null, null)).toEqual({ speaker: null, provider: null });
+    });
+
+    it('falls through to Spotify when supports_spotify is undefined (treat unknown as supported)', () => {
+        // Older backend responses may omit supports_* flags entirely.
+        const players = [{ entity_id: 'media_player.legacy' }];
+        expect(pickAutoSelections(players, null, null)).toEqual({
+            speaker: 'media_player.legacy',
+            provider: 'spotify',
+        });
     });
 });

--- a/custom_components/beatify/www/js/wizard.js
+++ b/custom_components/beatify/www/js/wizard.js
@@ -413,6 +413,27 @@ export function providerSupportedForPlayer(player, providerId) {
     return player[key] !== false;
 }
 
+// Pure: pick sensible first-run defaults from the API-returned player list.
+// Honors any value the user already saved — only fills empty slots.
+// Returns { speaker, provider }, either field may be null when nothing fits.
+// Spotify is the default provider per #1082 because it plays directly on
+// Sonos/Alexa without Music Assistant, so it's the lowest-friction default.
+export function pickAutoSelections(players, savedSpeaker, savedProvider) {
+    const list = Array.isArray(players) ? players : [];
+    let speaker = savedSpeaker || null;
+    if (!speaker && list.length > 0) {
+        speaker = list[0].entity_id || null;
+    }
+    let provider = savedProvider || null;
+    if (!provider && speaker) {
+        const playerRec = list.find((p) => p.entity_id === speaker) || null;
+        if (providerSupportedForPlayer(playerRec, 'spotify')) {
+            provider = 'spotify';
+        }
+    }
+    return { speaker, provider };
+}
+
 function _providerSupported(providerId) {
     return providerSupportedForPlayer(_selectedPlayer(), providerId);
 }
@@ -1212,6 +1233,19 @@ export async function show(stepOverride) {
             }
         }
     } catch (e) { /* private mode or malformed JSON */ }
+    // #1082 — pre-fill first-run defaults (first speaker, Spotify when supported)
+    // so fresh installs land on a "click Continue" path instead of a "pick from
+    // empty selectors" path. Persist the speaker so resumeAtStep moves past
+    // step 1 next open, matching the behavior of a manual selection.
+    const players = (cachedStatus && cachedStatus.media_players) || [];
+    const auto = pickAutoSelections(players, chosenSpeaker, chosenProvider);
+    if (!chosenSpeaker && auto.speaker) {
+        chosenSpeaker = auto.speaker;
+        try { if (ls) ls.setItem(LS_SELECTED_PLAYER, chosenSpeaker); } catch (e) { /* private mode */ }
+    }
+    if (!chosenProvider && auto.provider) {
+        chosenProvider = auto.provider;
+    }
     _hydrateLevelUpDetails();
     _renderSpeakers();
     _renderProviders();


### PR DESCRIPTION
Closes #1082

## Readiness assessment
- [ ] Ready to merge
- [x] Borderline — see notes
- [ ] Not ready — needs human review

**Honest summary:** This is the smallest slice of #1082 that ships value without making product decisions the maintainer flagged as needing human judgment. On a fresh wizard launch, step 1 now arrives with the first detected speaker pre-highlighted and Spotify pre-selected for step 2 (when supported). Users can still override either by tapping a different chip. Everything else from the issue's "express setup" vision — starter playlist, skipped game-mode step, single-screen chip-edit surface, i18n copy update — is intentionally deferred because each one carries an open product question.

## Root cause
Not a bug — `approved` enhancement #1082. The current `wizard.js#show()` hydrates `chosenSpeaker`/`chosenProvider` only from saved localStorage. On a first run there is nothing to hydrate, so step 1 loads with no row highlighted and step 2 loads with no provider chip active. The user must manually pick both before Continue enables. The issue's acceptance criterion ("30s, one button click") is unreachable without pre-filling these.

## Files changed
- `custom_components/beatify/www/js/wizard.js` — new pure helper `pickAutoSelections(players, savedSpeaker, savedProvider)` (exported for tests) + 13 lines in `show()` to apply it after hydration. The speaker is persisted to `localStorage` (mirroring the manual-click handler at line 370) so `resumeAtStep` advances past step 1 on the next open; the provider persists naturally via `_persistGameSettings()` when the user clicks Continue on step 2.
- `custom_components/beatify/www/js/__tests__/wizard.test.js` — 6 new tests for `pickAutoSelections`: fresh install, unsupported-Spotify speaker, pre-saved speaker honored, pre-saved provider honored, empty/null players list, and missing `supports_*` flag treated as supported (matches the existing `providerSupportedForPlayer` contract).

No `.min.js` regeneration — `wizard.js` is loaded directly as source from `admin.html:1457`, confirmed by the absence of a `wizard.min.js` file. No version-bump files touched.

## /review findings
/review skill not invoked (auto-fix routine ran headless). Manual self-review of `git diff origin/main...HEAD`:
- No SQL, trust boundary, or LLM-input touched (frontend pure helper).
- One new `localStorage.setItem` write, guarded by `if (!chosenSpeaker && auto.speaker)` so it only fires on the first-run path. Wrapped in try/catch matching the file's existing private-mode pattern.
- Helper is pure (no DOM, no I/O), trivially unit-tested.
- No new dependencies, no scope creep into admin.js / HTML / CSS / i18n.

## /qa-only evidence
Skipped — no test instance available in the auto-fix worktree at /tmp. The change is JS-only and verified by 6 new vitest cases (91 tests pass total).

## Test plan
- [x] `npx vitest run` — all 91 tests pass (34 in wizard.test.js, +6 new).
- [ ] Manual: fresh HACS install on a HA box with at least one Sonos / MA media player → open `/beatify/admin` → wizard step 1 shows the speaker row pre-highlighted, Continue enabled.
- [ ] Manual: same setup, click Continue → step 2 shows Spotify chip active, Continue enabled.
- [ ] Manual: tap a different speaker on step 1 → selection moves, Continue still enabled.
- [ ] Manual: tap a non-Spotify provider on step 2 → selection moves correctly.
- [ ] Manual: speaker with `supports_spotify: false` (e.g. Cast without MA) → step 2 loads with no provider preselected, Continue disabled until user picks one. (Reproduces the "no auto-pick if Spotify unsupported" branch.)
- [ ] Manual: open wizard on a HA install with zero compatible media_players → step 1 shows the "No speakers found" empty state, no auto-select crash. (Reproduces the empty-players branch.)
- [ ] Manual: open wizard → close (skip) → re-open → speaker row stays highlighted (persisted), provider stays selected only if user tapped Continue past step 2. (Reproduces the persistence boundary.)

## Risk assessment
- **Blast radius:** `wizard.js` (one new helper + 13 lines in `show()`) and its tests. No other module imports anything that changed.
- **What could go wrong:**
  - **Non-deterministic first-speaker selection.** The backend builds `media_players` by iterating `hass.states.async_all("media_player")` without explicit sorting (custom_components/beatify/services/media_player.py:1132). Across HA restarts the order may shuffle, so a user with multiple speakers could see a different default pre-highlighted on different sessions. The maintainer's own analysis comment on #1082 flagged this exact concern ("alphabetical? prefer MA?") as needing a human decision. I am not solving it here because picking a tiebreaker is a product call. The user is never silently committed — they always see the highlighted row before clicking Continue.
  - **Spotify default may be wrong for users on MA + Tidal/Apple.** The issue says "default music service: pick whatever provider has the most playable URIs (today: Spotify)". I hardcoded Spotify. A future PR can replace the constant with a dynamic count over `cachedStatus.playlists`, but that was listed as an open question.
  - **Does not satisfy the issue's acceptance criterion alone.** "Click one button → Ready to host" still requires the user to walk through steps 1-5 (now with defaults pre-filled). The full express-view redesign is needed to hit the 30s number — deferred per the 7 open questions in the maintainer's analysis comment.
- **What I did NOT test:**
  - Live HA instance (no test instance reachable from the auto-fix worktree).
  - End-to-end timing against the 30-second acceptance criterion.
  - Behavior when MA is installed mid-session (cachedStatus is fetched once in `show()`; a second wizard open re-fetches, so this should be fine but unverified).
  - Multi-locale rendering — no i18n strings changed.

🤖 Auto-generated by issue-triage routine