### PR TITLE
release: v3.4.0-rc12 — Safari 18 /auth/token fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to Beatify are documented here. For detailed release notes, 
 
 ## [Unreleased]
 
+## [3.4.0-rc12] - 2026-05-21
+
+### Fixed
+- **Safari 18 login loop on macOS Sequoia / iOS 18 (#998 follow-up).** Markus reported the rc11 admin still flickered to HA-login on Safari 18 — both on LAN and via Nabu Casa, in private windows, with the SW unregistered. Chrome worked fine. Console showed `TypeError: Load failed` at `ha-auth.js:228` (the `exchangeCode` catch); the Network tab had no `/auth/token` entry — Safari rejected the FormData fetch before the request left the browser. `exchangeCode` resolved false silently, `init()` saw `!isAuthenticated`, called `login()` and bounced the user back to the HA approve screen. Same loop shape as the original `c03b4ae5` redirect_uri bug, different transport-layer failure. The rc8 FormData fix is still needed (it survives the Nabu Casa SniTun relay that drops urlencoded POSTs); Safari 18 broke the other side of that trade.
+- **Fix: `postToken` now tries FormData first (keeps Nabu Casa working) and falls back to urlencoded on `TypeError` only — fetch-level failures where the request never reached HA. HTTP rejections (4xx/5xx) propagate without retry, since retrying a server-side `invalid_grant` would just produce the same response. Both transports are needed now: FormData survives SniTun, urlencoded survives Safari 18.** New `__tests__/ha-auth.test.js` covers all three paths (TypeError → retry, HTTP 4xx → no retry, happy path → no retry). 88/88 JS tests pass.
+
 ## [3.4.0-rc11] - 2026-05-21
 
 ### Fixed

--- a/custom_components/beatify/manifest.json
+++ b/custom_components/beatify/manifest.json
@@ -12,5 +12,5 @@
   "documentation": "https://github.com/mholzi/beatify",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/mholzi/beatify/issues",
-  "version": "3.4.0-rc11"
+  "version": "3.4.0-rc12"
 }

--- a/custom_components/beatify/www/admin.html
+++ b/custom_components/beatify/www/admin.html
@@ -8,7 +8,7 @@
          query-string version, a stale en.json from a prior rc gets served
          after upgrade and references to newer keys render as raw strings.
          Bumped each rc alongside manifest.json + sw.js CACHE_VERSION. -->
-    <meta name="beatify-version" content="3.4.0-rc11">
+    <meta name="beatify-version" content="3.4.0-rc12">
     <!-- Self-healing SW recovery (rc11): an older-version service worker
          may serve a stale ha-auth.js even with cache-busters, leaving users
          in an unrecoverable login loop. Compare the current page's version
@@ -55,7 +55,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@700;900&display=swap" rel="stylesheet">
     <!-- Story 18.4: Use minified CSS in production -->
-    <link rel="stylesheet" href="/beatify/static/css/styles.min.css?v=3.4.0-rc11">
+    <link rel="stylesheet" href="/beatify/static/css/styles.min.css?v=3.4.0-rc12">
 </head>
 <body class="theme-dark">
     <!-- First-run wizard takeover (see DESIGN.md ## Patterns → First-run wizard) -->
@@ -1446,17 +1446,17 @@
     <!-- Story 18.4: Use minified JS in production with fallback to source -->
     <!-- Version query strings prevent browser caching issues -->
     <!-- #998: HA OAuth client — must load before any admin script uses BeatifyAuth -->
-    <script src="/beatify/static/js/ha-auth.js?v=3.4.0-rc11"></script>
+    <script src="/beatify/static/js/ha-auth.js?v=3.4.0-rc12"></script>
     <script src="/beatify/static/js/i18n.js?v=1.7.0"></script>
     <script src="/beatify/static/js/utils.js?v=1.7.0"></script>
     <!-- Story 44.1: Playlist requests module -->
-    <script src="/beatify/static/js/playlist-requests.min.js?v=3.4.0-rc11"></script>
+    <script src="/beatify/static/js/playlist-requests.min.js?v=3.4.0-rc12"></script>
     <!-- #1052: LLM-assisted playlist generator (load before playlist-hub so the Mine-tab button finds it) -->
-    <script src="/beatify/static/js/playlist-generator.min.js?v=3.4.0-rc11"></script>
-    <script type="module" src="/beatify/static/js/playlist-hub.js?v=3.4.0-rc11"></script>
-    <script type="module" src="/beatify/static/js/wizard.js?v=3.4.0-rc11"></script>
-    <script src="/beatify/static/js/admin.min.js?v=3.4.0-rc11"></script>
-    <script src="/beatify/static/js/party-lights.min.js?v=3.4.0-rc11"></script>
-    <script src="/beatify/static/js/tts-settings.js?v=3.4.0-rc11"></script>
+    <script src="/beatify/static/js/playlist-generator.min.js?v=3.4.0-rc12"></script>
+    <script type="module" src="/beatify/static/js/playlist-hub.js?v=3.4.0-rc12"></script>
+    <script type="module" src="/beatify/static/js/wizard.js?v=3.4.0-rc12"></script>
+    <script src="/beatify/static/js/admin.min.js?v=3.4.0-rc12"></script>
+    <script src="/beatify/static/js/party-lights.min.js?v=3.4.0-rc12"></script>
+    <script src="/beatify/static/js/tts-settings.js?v=3.4.0-rc12"></script>
 </body>
 </html>

--- a/custom_components/beatify/www/dashboard.html
+++ b/custom_components/beatify/www/dashboard.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <!-- #824: cache-bust i18n JSON fetches. See admin.html for rationale. -->
-    <meta name="beatify-version" content="3.4.0-rc11">
+    <meta name="beatify-version" content="3.4.0-rc12">
     <title data-i18n="dashboard.title">Beatify - Dashboard</title>
     <!-- Preconnect for faster font loading (Story 9.8) -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -12,7 +12,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Outfit:wght@700;900&display=swap" rel="stylesheet">
     <!-- Story 18.4: Use minified CSS in production -->
     <link rel="stylesheet" href="/beatify/static/css/styles.css?v=1.7.0">
-    <link rel="stylesheet" href="/beatify/static/css/dashboard.min.css?v=3.4.0-rc11">
+    <link rel="stylesheet" href="/beatify/static/css/dashboard.min.css?v=3.4.0-rc12">
     <!-- Confetti library for celebrations (Story 14.5) -->
     <script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.9.2/dist/confetti.browser.min.js"></script>
 </head>
@@ -285,7 +285,7 @@
     <!-- Version query strings prevent browser caching issues -->
     <script src="/beatify/static/js/i18n.js?v=1.7.0"></script>
     <script src="/beatify/static/js/utils.js?v=1.7.0"></script>
-    <script src="/beatify/static/js/dashboard.min.js?v=3.4.0-rc11"></script>
+    <script src="/beatify/static/js/dashboard.min.js?v=3.4.0-rc12"></script>
     <!-- v3.2.1 Arcade shims: submission meter fill, album ring progress, reveal round mirror.
          Pure view-layer helpers — no state, no API calls. Safe to remove if dashboard.js
          ever takes these over directly. -->

--- a/custom_components/beatify/www/js/__tests__/ha-auth.test.js
+++ b/custom_components/beatify/www/js/__tests__/ha-auth.test.js
@@ -1,0 +1,159 @@
+/**
+ * Unit tests for ha-auth.js token POST fallback.
+ *
+ * The bug under test: Safari 18 throws "TypeError: Load failed" on the
+ * FormData /auth/token POST (the rc8 fix that survives Nabu Casa SniTun).
+ * The request never reaches HA, exchangeCode rejects, init bounces to
+ * login() — the symptom is a HA-login → flash-of-Beatify → HA-login loop.
+ *
+ * The fix: postToken tries FormData first, falls back to urlencoded on
+ * TypeError. Other errors (HTTP 4xx/5xx) propagate without a retry —
+ * retrying a server rejection just wastes a request.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import vm from 'node:vm';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SRC_PATH = join(__dirname, '..', 'ha-auth.js');
+const SRC = readFileSync(SRC_PATH, 'utf8');
+
+// Build a fresh sandbox per test so localStorage / window.BeatifyAuth from
+// one test don't leak into the next.
+function loadHaAuth({ fetchFn, localStorageData = {} } = {}) {
+    const storage = (initial) => {
+        const map = new Map(Object.entries(initial));
+        return {
+            getItem: (k) => (map.has(k) ? map.get(k) : null),
+            setItem: (k, v) => { map.set(k, String(v)); },
+            removeItem: (k) => { map.delete(k); },
+            _map: map,
+        };
+    };
+    const ls = storage(localStorageData);
+    const ss = storage({});
+    const sandboxWindow = {
+        location: { origin: 'https://ha.example', pathname: '/beatify/admin', search: '', hash: '' },
+        localStorage: ls,
+        sessionStorage: ss,
+        crypto: { getRandomValues: (buf) => { for (let i = 0; i < buf.length; i++) buf[i] = i; return buf; } },
+        history: { replaceState: () => {} },
+    };
+    const ctx = {
+        window: sandboxWindow,
+        // ha-auth.js references bare `localStorage` / `sessionStorage` (not
+        // window.localStorage) — expose them at the top level of the vm
+        // context so the IIFE can read them.
+        localStorage: ls,
+        sessionStorage: ss,
+        document: { title: 'test' },
+        console,
+        fetch: fetchFn,
+        URLSearchParams,
+        FormData,
+        Promise,
+        Date,
+        Array,
+        Object,
+        Error,
+        TypeError,
+        parseInt,
+        encodeURIComponent,
+        setTimeout,
+    };
+    vm.createContext(ctx);
+    vm.runInContext(SRC, ctx);
+    return { BeatifyAuth: sandboxWindow.BeatifyAuth, localStorage: ls, calls: [] };
+}
+
+describe('postToken transport fallback', () => {
+    it('retries with urlencoded body when FormData fetch throws TypeError', async () => {
+        const calls = [];
+        const fetchFn = async (url, opts) => {
+            calls.push({ url, body: opts.body, headers: opts.headers });
+            if (opts.body instanceof FormData) {
+                // Simulate Safari 18: the FormData request never leaves the browser.
+                throw new TypeError('Load failed');
+            }
+            // urlencoded fallback succeeds
+            return {
+                ok: true,
+                json: async () => ({
+                    access_token: 'new-access',
+                    refresh_token: 'new-refresh',
+                    expires_in: 1800,
+                }),
+            };
+        };
+        const { BeatifyAuth } = loadHaAuth({
+            fetchFn,
+            localStorageData: { beatify_ha_refresh: 'stored-refresh' },
+        });
+
+        // getAccessToken with a stored refresh token but no fresh access token
+        // takes the refreshAccess path, which calls postToken.
+        const token = await BeatifyAuth.getAccessToken();
+
+        expect(token).toBe('new-access');
+        expect(calls).toHaveLength(2);
+        expect(calls[0].body).toBeInstanceOf(FormData);
+        expect(typeof calls[1].body).toBe('string');
+        expect(calls[1].body).toContain('grant_type=refresh_token');
+        expect(calls[1].body).toContain('refresh_token=stored-refresh');
+        expect(calls[1].headers['Content-Type']).toBe('application/x-www-form-urlencoded');
+    });
+
+    it('does NOT retry on a 4xx HTTP response — server rejection propagates', async () => {
+        const calls = [];
+        const fetchFn = async (url, opts) => {
+            calls.push({ url, body: opts.body });
+            // Server-side rejection (e.g. revoked refresh token). Retrying with
+            // urlencoded would just produce the same 400 — pointless work.
+            return {
+                ok: false,
+                status: 400,
+                text: async () => 'invalid_grant',
+            };
+        };
+        const { BeatifyAuth } = loadHaAuth({
+            fetchFn,
+            localStorageData: { beatify_ha_refresh: 'revoked-refresh' },
+        });
+
+        // refreshAccess catches the error internally and resolves to null.
+        // What we care about is that only ONE fetch happened — no fallback
+        // retry on a server-level rejection.
+        const token = await BeatifyAuth.getAccessToken();
+
+        expect(token).toBeNull();
+        expect(calls).toHaveLength(1);
+        expect(calls[0].body).toBeInstanceOf(FormData);
+    });
+
+    it('skips the fallback when the FormData request succeeds', async () => {
+        const calls = [];
+        const fetchFn = async (url, opts) => {
+            calls.push({ url, body: opts.body });
+            return {
+                ok: true,
+                json: async () => ({
+                    access_token: 'cloud-token',
+                    refresh_token: 'cloud-refresh',
+                    expires_in: 1800,
+                }),
+            };
+        };
+        const { BeatifyAuth } = loadHaAuth({
+            fetchFn,
+            localStorageData: { beatify_ha_refresh: 'stored-refresh' },
+        });
+
+        const token = await BeatifyAuth.getAccessToken();
+
+        expect(token).toBe('cloud-token');
+        expect(calls).toHaveLength(1);
+        expect(calls[0].body).toBeInstanceOf(FormData);
+    });
+});

--- a/custom_components/beatify/www/js/ha-auth.js
+++ b/custom_components/beatify/www/js/ha-auth.js
@@ -105,14 +105,22 @@
 
   // -- OAuth2 token endpoint ----------------------------------------------
 
-  function postToken(params) {
+  function _readTokenResponse(resp) {
+    if (!resp.ok) {
+      return resp.text().then(function (t) {
+        throw new Error('HA token endpoint ' + resp.status + ': ' + t);
+      });
+    }
+    return resp.json();
+  }
+
+  function _postTokenFormData(params) {
     // Mirror home-assistant-js-websocket's tokenRequest: FormData (multipart),
     // explicit credentials:'same-origin', no manual Content-Type. The URL-
     // encoded variant intermittently fails through the Nabu Casa SniTun
     // relay with Safari's "TypeError: Load failed" — the bytes never make
     // it back. HA's own frontend works on cloud because it uses this shape;
-    // matching it removes Beatify from the broken path. Same wire format
-    // HA's /auth/token already accepts, just a different Content-Type.
+    // matching it removes Beatify from the broken path.
     var form = new FormData();
     Object.keys(params).forEach(function (k) {
       form.append(k, params[k]);
@@ -121,13 +129,45 @@
       method: 'POST',
       credentials: 'same-origin',
       body: form,
-    }).then(function (resp) {
-      if (!resp.ok) {
-        return resp.text().then(function (t) {
-          throw new Error('HA token endpoint ' + resp.status + ': ' + t);
-        });
+    }).then(_readTokenResponse);
+  }
+
+  function _postTokenUrlEncoded(params) {
+    // Pre-rc8 transport, kept as a fallback. Safari 18 throws
+    // "TypeError: Load failed" on the FormData variant for some users on
+    // both LAN and Nabu Casa — the request never leaves the browser. The
+    // urlencoded body sidesteps Safari's multipart-boundary path entirely
+    // and still hits HA's IndieAuth /auth/token (HA accepts both
+    // application/x-www-form-urlencoded and multipart/form-data here).
+    var body = Object.keys(params)
+      .map(function (k) {
+        return encodeURIComponent(k) + '=' + encodeURIComponent(params[k]);
+      })
+      .join('&');
+    return fetch(origin() + '/auth/token', {
+      method: 'POST',
+      credentials: 'same-origin',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: body,
+    }).then(_readTokenResponse);
+  }
+
+  function postToken(params) {
+    // FormData first (the rc8 fix that survives Nabu Casa SniTun). On a
+    // TypeError — fetch-level failure, the request never reached HA —
+    // retry once with urlencoded. Other errors (HTTP 4xx/5xx surfaced by
+    // _readTokenResponse) propagate as-is; retrying a server rejection
+    // would just produce the same response.
+    return _postTokenFormData(params).catch(function (err) {
+      if (err && err.name === 'TypeError') {
+        console.warn(
+          '[BeatifyAuth] FormData /auth/token failed (' +
+            err.message +
+            '); retrying urlencoded'
+        );
+        return _postTokenUrlEncoded(params);
       }
-      return resp.json();
+      throw err;
     });
   }
 

--- a/custom_components/beatify/www/player.html
+++ b/custom_components/beatify/www/player.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <!-- #824: cache-bust i18n JSON fetches. See admin.html for rationale. -->
-    <meta name="beatify-version" content="3.4.0-rc11">
+    <meta name="beatify-version" content="3.4.0-rc12">
     <!-- Self-healing SW recovery (rc11) — see admin.html for the rationale. -->
     <script>
         (function() {
@@ -36,7 +36,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@700;900&display=swap" rel="stylesheet">
     <!-- Story 18.4: Use minified CSS in production -->
-    <link rel="stylesheet" href="/beatify/static/css/styles.min.css?v=3.4.0-rc11">
+    <link rel="stylesheet" href="/beatify/static/css/styles.min.css?v=3.4.0-rc12">
     <!-- Confetti library for celebrations (Story 14.5) -->
     <script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.9.2/dist/confetti.browser.min.js"></script>
 </head>
@@ -943,9 +943,9 @@
     <!-- Story 18.4: Use minified JS in production with fallback to source -->
     <!-- Version query strings prevent browser caching issues -->
     <!-- #998: HA OAuth client — only used when a host claims the admin role -->
-    <script src="/beatify/static/js/ha-auth.js?v=3.4.0-rc11"></script>
+    <script src="/beatify/static/js/ha-auth.js?v=3.4.0-rc12"></script>
     <script src="/beatify/static/js/i18n.min.js"></script>
     <script src="/beatify/static/js/utils.min.js"></script>
-    <script type="module" src="/beatify/static/js/player.bundle.min.js?v=3.4.0-rc11"></script>
+    <script type="module" src="/beatify/static/js/player.bundle.min.js?v=3.4.0-rc12"></script>
 </body>
 </html>

--- a/custom_components/beatify/www/sw.js
+++ b/custom_components/beatify/www/sw.js
@@ -6,7 +6,7 @@
  */
 'use strict';
 
-var CACHE_VERSION = 'beatify-v3.4.0-rc11';
+var CACHE_VERSION = 'beatify-v3.4.0-rc12';
 var MAX_CACHE_ITEMS = 50;
 
 // Critical assets to precache on install (minified versions only - fallback handled by HTML).


### PR DESCRIPTION
## Summary
- Fixes a Safari 18 (macOS Sequoia / iOS 18) login loop where the rc8 FormData POST to `/auth/token` is rejected by Safari's fetch layer with `TypeError: Load failed` — the request never leaves the browser. Symptom matches the original `c03b4ae5` redirect_uri bug shape (HA-login → flash of Beatify → bounce back to HA-login), but the root cause is a transport-layer failure newly introduced by Safari 18.
- `postToken` now tries FormData first (keeps Nabu Casa SniTun working — that's why rc8 introduced it) and falls back to urlencoded only on `TypeError`. HTTP rejections (4xx/5xx) propagate without retry — retrying a server-side `invalid_grant` would just produce the same response.
- New `__tests__/ha-auth.test.js` covers all three paths via a `vm` sandbox: TypeError → urlencoded retry, HTTP 4xx → no retry, FormData happy path → no fallback. 88/88 JS tests pass.
- rc12 version bumps: `manifest.json`, `sw.js` `CACHE_VERSION`, `beatify-version` meta + every `?v=` cache-buster across `admin.html`/`player.html`/`dashboard.html`. CHANGELOG gets a single rc12 section pointing at the fix.

## Test plan
- [x] `npx vitest run` → 88/88 pass (3 new tests in `ha-auth.test.js`)
- [ ] Markus tests on Safari 18 (macOS Sequoia) over both LAN and Nabu Casa — expect to see `[BeatifyAuth] FormData /auth/token failed (Load failed); retrying urlencoded` in the console once, then normal admin load. No more loop.
- [ ] Chrome regression check on either transport — FormData succeeds, no fallback warning, admin loads normally.
- [ ] Cold reload from rc11: SW NEVER_CACHE for ha-auth.js + `cache_headers=False` on the static handler should ETag-revalidate the new bundle without manual cache clearing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)