### PR TITLE
release: v3.4.0-rc13 — Safari 18 /auth/token XHR fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to Beatify are documented here. For detailed release notes, 
 
 ## [Unreleased]
 
+## [3.4.0-rc13] - 2026-05-21
+
+### Fixed
+- **Safari 18 login loop — `/auth/token` fallback now uses XHR (#998 follow-up to rc12).** rc12's urlencoded-via-`fetch` fallback hit a different Safari 18 failure mode on both LAN and Nabu Casa: `Fetch API cannot load … due to access control checks` — Safari incorrectly applies a CORS check to the same-origin POST, rejecting the request before it leaves the browser. Same end symptom as rc11/rc12 (HA-login → flash of Beatify → bounce), one transport layer deeper. The full failure shape on Safari 18 is: FormData via `fetch` throws `TypeError: Load failed` (Safari rejects multipart synchronously); urlencoded via `fetch` is rejected for "access control checks" (same-origin POST treated as cross-origin); both transports through `fetch` are dead.
+- **Fix:** the fallback now uses `XMLHttpRequest` with an urlencoded body. XHR predates the `fetch` spec quirks Safari 18 is hitting and uses a different network path internally — same-origin POST through XHR isn't subject to the buggy CORS check. `postToken` still tries FormData via `fetch` first (preserves rc8 Nabu Casa SniTun support for Chrome and pre-Safari-18) and falls back to XHR only on `TypeError`. HTTP rejections still propagate without retry. New test case in `ha-auth.test.js` covers the XHR HTTP-error path; 89/89 JS tests pass.
+
+After rc13, Safari 18 users will see a one-time console warning when the fallback fires:
+```
+[BeatifyAuth] FormData /auth/token failed (Load failed); retrying via XHR
+```
+That's the fix doing its job — the XHR request then succeeds and admin loads normally.
+
 ## [3.4.0-rc12] - 2026-05-21
 
 ### Fixed

--- a/custom_components/beatify/manifest.json
+++ b/custom_components/beatify/manifest.json
@@ -12,5 +12,5 @@
   "documentation": "https://github.com/mholzi/beatify",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/mholzi/beatify/issues",
-  "version": "3.4.0-rc12"
+  "version": "3.4.0-rc13"
 }

--- a/custom_components/beatify/www/admin.html
+++ b/custom_components/beatify/www/admin.html
@@ -8,7 +8,7 @@
          query-string version, a stale en.json from a prior rc gets served
          after upgrade and references to newer keys render as raw strings.
          Bumped each rc alongside manifest.json + sw.js CACHE_VERSION. -->
-    <meta name="beatify-version" content="3.4.0-rc12">
+    <meta name="beatify-version" content="3.4.0-rc13">
     <!-- Self-healing SW recovery (rc11): an older-version service worker
          may serve a stale ha-auth.js even with cache-busters, leaving users
          in an unrecoverable login loop. Compare the current page's version
@@ -55,7 +55,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@700;900&display=swap" rel="stylesheet">
     <!-- Story 18.4: Use minified CSS in production -->
-    <link rel="stylesheet" href="/beatify/static/css/styles.min.css?v=3.4.0-rc12">
+    <link rel="stylesheet" href="/beatify/static/css/styles.min.css?v=3.4.0-rc13">
 </head>
 <body class="theme-dark">
     <!-- First-run wizard takeover (see DESIGN.md ## Patterns → First-run wizard) -->
@@ -1446,17 +1446,17 @@
     <!-- Story 18.4: Use minified JS in production with fallback to source -->
     <!-- Version query strings prevent browser caching issues -->
     <!-- #998: HA OAuth client — must load before any admin script uses BeatifyAuth -->
-    <script src="/beatify/static/js/ha-auth.js?v=3.4.0-rc12"></script>
+    <script src="/beatify/static/js/ha-auth.js?v=3.4.0-rc13"></script>
     <script src="/beatify/static/js/i18n.js?v=1.7.0"></script>
     <script src="/beatify/static/js/utils.js?v=1.7.0"></script>
     <!-- Story 44.1: Playlist requests module -->
-    <script src="/beatify/static/js/playlist-requests.min.js?v=3.4.0-rc12"></script>
+    <script src="/beatify/static/js/playlist-requests.min.js?v=3.4.0-rc13"></script>
     <!-- #1052: LLM-assisted playlist generator (load before playlist-hub so the Mine-tab button finds it) -->
-    <script src="/beatify/static/js/playlist-generator.min.js?v=3.4.0-rc12"></script>
-    <script type="module" src="/beatify/static/js/playlist-hub.js?v=3.4.0-rc12"></script>
-    <script type="module" src="/beatify/static/js/wizard.js?v=3.4.0-rc12"></script>
-    <script src="/beatify/static/js/admin.min.js?v=3.4.0-rc12"></script>
-    <script src="/beatify/static/js/party-lights.min.js?v=3.4.0-rc12"></script>
-    <script src="/beatify/static/js/tts-settings.js?v=3.4.0-rc12"></script>
+    <script src="/beatify/static/js/playlist-generator.min.js?v=3.4.0-rc13"></script>
+    <script type="module" src="/beatify/static/js/playlist-hub.js?v=3.4.0-rc13"></script>
+    <script type="module" src="/beatify/static/js/wizard.js?v=3.4.0-rc13"></script>
+    <script src="/beatify/static/js/admin.min.js?v=3.4.0-rc13"></script>
+    <script src="/beatify/static/js/party-lights.min.js?v=3.4.0-rc13"></script>
+    <script src="/beatify/static/js/tts-settings.js?v=3.4.0-rc13"></script>
 </body>
 </html>

--- a/custom_components/beatify/www/dashboard.html
+++ b/custom_components/beatify/www/dashboard.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <!-- #824: cache-bust i18n JSON fetches. See admin.html for rationale. -->
-    <meta name="beatify-version" content="3.4.0-rc12">
+    <meta name="beatify-version" content="3.4.0-rc13">
     <title data-i18n="dashboard.title">Beatify - Dashboard</title>
     <!-- Preconnect for faster font loading (Story 9.8) -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -12,7 +12,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Outfit:wght@700;900&display=swap" rel="stylesheet">
     <!-- Story 18.4: Use minified CSS in production -->
     <link rel="stylesheet" href="/beatify/static/css/styles.css?v=1.7.0">
-    <link rel="stylesheet" href="/beatify/static/css/dashboard.min.css?v=3.4.0-rc12">
+    <link rel="stylesheet" href="/beatify/static/css/dashboard.min.css?v=3.4.0-rc13">
     <!-- Confetti library for celebrations (Story 14.5) -->
     <script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.9.2/dist/confetti.browser.min.js"></script>
 </head>
@@ -285,7 +285,7 @@
     <!-- Version query strings prevent browser caching issues -->
     <script src="/beatify/static/js/i18n.js?v=1.7.0"></script>
     <script src="/beatify/static/js/utils.js?v=1.7.0"></script>
-    <script src="/beatify/static/js/dashboard.min.js?v=3.4.0-rc12"></script>
+    <script src="/beatify/static/js/dashboard.min.js?v=3.4.0-rc13"></script>
     <!-- v3.2.1 Arcade shims: submission meter fill, album ring progress, reveal round mirror.
          Pure view-layer helpers — no state, no API calls. Safe to remove if dashboard.js
          ever takes these over directly. -->

--- a/custom_components/beatify/www/js/__tests__/ha-auth.test.js
+++ b/custom_components/beatify/www/js/__tests__/ha-auth.test.js
@@ -1,16 +1,23 @@
 /**
  * Unit tests for ha-auth.js token POST fallback.
  *
- * The bug under test: Safari 18 throws "TypeError: Load failed" on the
- * FormData /auth/token POST (the rc8 fix that survives Nabu Casa SniTun).
- * The request never reaches HA, exchangeCode rejects, init bounces to
- * login() — the symptom is a HA-login → flash-of-Beatify → HA-login loop.
+ * The bug under test: Safari 18 rejects the rc8 FormData /auth/token POST
+ * with "TypeError: Load failed" (the request never leaves the browser),
+ * and rejects the rc12 urlencoded fetch fallback with "Fetch API cannot
+ * load … due to access control checks" (Safari incorrectly applies a
+ * CORS check to a same-origin POST). rc13 falls back to XMLHttpRequest,
+ * which uses a different network path internally and isn't subject to
+ * the fetch CORS quirk for same-origin POST.
  *
- * The fix: postToken tries FormData first, falls back to urlencoded on
- * TypeError. Other errors (HTTP 4xx/5xx) propagate without a retry —
- * retrying a server rejection just wastes a request.
+ * Symptom for users: HA-login → flash of Beatify → bounce back to HA-login.
+ *
+ * Strategy: postToken tries FormData via fetch first (preserves rc8 Nabu
+ * Casa SniTun support for Chrome and pre-Safari-18), falls back to XHR
+ * urlencoded on TypeError. HTTP rejections (4xx/5xx) propagate without
+ * retry — retrying a server-side invalid_grant just produces the same
+ * response.
  */
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
@@ -20,9 +27,38 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const SRC_PATH = join(__dirname, '..', 'ha-auth.js');
 const SRC = readFileSync(SRC_PATH, 'utf8');
 
-// Build a fresh sandbox per test so localStorage / window.BeatifyAuth from
-// one test don't leak into the next.
-function loadHaAuth({ fetchFn, localStorageData = {} } = {}) {
+// Mock XMLHttpRequest that drives a queued list of responses. Each test
+// configures one response shape (success/4xx/network-error) per XHR opened.
+function makeMockXhrCtor(responseFn, callLog) {
+    return function MockXMLHttpRequest() {
+        const xhr = {
+            _headers: {},
+            open(method, url) { this._method = method; this._url = url; },
+            setRequestHeader(k, v) { this._headers[k] = v; },
+            withCredentials: false,
+            onload: null,
+            onerror: null,
+            send(body) {
+                callLog.push({ method: this._method, url: this._url, headers: this._headers, body, withCredentials: this.withCredentials });
+                // Defer the callback so .send returns first, matching real XHR.
+                setTimeout(() => {
+                    const r = responseFn(body, this);
+                    if (r.networkError) {
+                        if (this.onerror) this.onerror();
+                    } else {
+                        this.status = r.status;
+                        this.statusText = r.statusText || '';
+                        this.responseText = r.responseText;
+                        if (this.onload) this.onload();
+                    }
+                }, 0);
+            },
+        };
+        return xhr;
+    };
+}
+
+function loadHaAuth({ fetchFn, xhrCtor, localStorageData = {} } = {}) {
     const storage = (initial) => {
         const map = new Map(Object.entries(initial));
         return {
@@ -43,14 +79,12 @@ function loadHaAuth({ fetchFn, localStorageData = {} } = {}) {
     };
     const ctx = {
         window: sandboxWindow,
-        // ha-auth.js references bare `localStorage` / `sessionStorage` (not
-        // window.localStorage) — expose them at the top level of the vm
-        // context so the IIFE can read them.
         localStorage: ls,
         sessionStorage: ss,
         document: { title: 'test' },
         console,
         fetch: fetchFn,
+        XMLHttpRequest: xhrCtor,
         URLSearchParams,
         FormData,
         Promise,
@@ -65,95 +99,122 @@ function loadHaAuth({ fetchFn, localStorageData = {} } = {}) {
     };
     vm.createContext(ctx);
     vm.runInContext(SRC, ctx);
-    return { BeatifyAuth: sandboxWindow.BeatifyAuth, localStorage: ls, calls: [] };
+    return { BeatifyAuth: sandboxWindow.BeatifyAuth, localStorage: ls };
 }
 
 describe('postToken transport fallback', () => {
-    it('retries with urlencoded body when FormData fetch throws TypeError', async () => {
-        const calls = [];
+    it('retries via XHR when FormData fetch throws TypeError (Safari 18 path)', async () => {
+        const fetchCalls = [];
         const fetchFn = async (url, opts) => {
-            calls.push({ url, body: opts.body, headers: opts.headers });
-            if (opts.body instanceof FormData) {
-                // Simulate Safari 18: the FormData request never leaves the browser.
-                throw new TypeError('Load failed');
-            }
-            // urlencoded fallback succeeds
-            return {
-                ok: true,
-                json: async () => ({
-                    access_token: 'new-access',
-                    refresh_token: 'new-refresh',
-                    expires_in: 1800,
-                }),
-            };
+            fetchCalls.push({ url, body: opts.body });
+            // Simulate Safari 18 + Nabu Casa: FormData request never leaves the browser.
+            throw new TypeError('Load failed');
         };
+        const xhrCalls = [];
+        const xhrCtor = makeMockXhrCtor(() => ({
+            status: 200,
+            responseText: JSON.stringify({
+                access_token: 'xhr-access',
+                refresh_token: 'xhr-refresh',
+                expires_in: 1800,
+            }),
+        }), xhrCalls);
         const { BeatifyAuth } = loadHaAuth({
             fetchFn,
+            xhrCtor,
             localStorageData: { beatify_ha_refresh: 'stored-refresh' },
         });
 
-        // getAccessToken with a stored refresh token but no fresh access token
-        // takes the refreshAccess path, which calls postToken.
+        // getAccessToken with a stored refresh token but no fresh access takes
+        // the refreshAccess path → postToken.
         const token = await BeatifyAuth.getAccessToken();
 
-        expect(token).toBe('new-access');
-        expect(calls).toHaveLength(2);
-        expect(calls[0].body).toBeInstanceOf(FormData);
-        expect(typeof calls[1].body).toBe('string');
-        expect(calls[1].body).toContain('grant_type=refresh_token');
-        expect(calls[1].body).toContain('refresh_token=stored-refresh');
-        expect(calls[1].headers['Content-Type']).toBe('application/x-www-form-urlencoded');
+        expect(token).toBe('xhr-access');
+        expect(fetchCalls).toHaveLength(1);
+        expect(fetchCalls[0].body).toBeInstanceOf(FormData);
+        expect(xhrCalls).toHaveLength(1);
+        expect(xhrCalls[0].method).toBe('POST');
+        expect(xhrCalls[0].url).toBe('https://ha.example/auth/token');
+        expect(xhrCalls[0].body).toContain('grant_type=refresh_token');
+        expect(xhrCalls[0].body).toContain('refresh_token=stored-refresh');
+        expect(xhrCalls[0].headers['Content-Type']).toBe('application/x-www-form-urlencoded');
+        expect(xhrCalls[0].withCredentials).toBe(true);
     });
 
-    it('does NOT retry on a 4xx HTTP response — server rejection propagates', async () => {
-        const calls = [];
+    it('does NOT fall back to XHR on a 4xx fetch response — server rejection propagates', async () => {
+        const fetchCalls = [];
         const fetchFn = async (url, opts) => {
-            calls.push({ url, body: opts.body });
-            // Server-side rejection (e.g. revoked refresh token). Retrying with
-            // urlencoded would just produce the same 400 — pointless work.
+            fetchCalls.push({ url, body: opts.body });
+            // HA-side rejection (e.g. revoked refresh token). Retrying with XHR
+            // would just produce the same 400.
             return {
                 ok: false,
                 status: 400,
                 text: async () => 'invalid_grant',
             };
         };
+        const xhrCalls = [];
+        const xhrCtor = makeMockXhrCtor(() => ({ status: 500, responseText: 'should-not-be-called' }), xhrCalls);
         const { BeatifyAuth } = loadHaAuth({
             fetchFn,
+            xhrCtor,
             localStorageData: { beatify_ha_refresh: 'revoked-refresh' },
         });
 
-        // refreshAccess catches the error internally and resolves to null.
-        // What we care about is that only ONE fetch happened — no fallback
-        // retry on a server-level rejection.
         const token = await BeatifyAuth.getAccessToken();
 
         expect(token).toBeNull();
-        expect(calls).toHaveLength(1);
-        expect(calls[0].body).toBeInstanceOf(FormData);
+        expect(fetchCalls).toHaveLength(1);
+        expect(xhrCalls).toHaveLength(0);
     });
 
-    it('skips the fallback when the FormData request succeeds', async () => {
-        const calls = [];
+    it('skips the fallback when FormData fetch succeeds (Chrome / pre-Safari-18 path)', async () => {
+        const fetchCalls = [];
         const fetchFn = async (url, opts) => {
-            calls.push({ url, body: opts.body });
+            fetchCalls.push({ url, body: opts.body });
             return {
                 ok: true,
                 json: async () => ({
-                    access_token: 'cloud-token',
-                    refresh_token: 'cloud-refresh',
+                    access_token: 'fetch-token',
+                    refresh_token: 'fetch-refresh',
                     expires_in: 1800,
                 }),
             };
         };
+        const xhrCalls = [];
+        const xhrCtor = makeMockXhrCtor(() => { throw new Error('XHR should not be invoked'); }, xhrCalls);
         const { BeatifyAuth } = loadHaAuth({
             fetchFn,
+            xhrCtor,
             localStorageData: { beatify_ha_refresh: 'stored-refresh' },
         });
 
         const token = await BeatifyAuth.getAccessToken();
 
-        expect(token).toBe('cloud-token');
-        expect(calls).toHaveLength(1);
-        expect(calls[0].body).toBeInstanceOf(FormData);
+        expect(token).toBe('fetch-token');
+        expect(fetchCalls).toHaveLength(1);
+        expect(fetchCalls[0].body).toBeInstanceOf(FormData);
+        expect(xhrCalls).toHaveLength(0);
+    });
+
+    it('surfaces XHR HTTP errors when the fallback path also fails server-side', async () => {
+        const fetchFn = async () => { throw new TypeError('Load failed'); };
+        const xhrCalls = [];
+        const xhrCtor = makeMockXhrCtor(() => ({
+            status: 400,
+            responseText: 'invalid_grant',
+        }), xhrCalls);
+        const { BeatifyAuth } = loadHaAuth({
+            fetchFn,
+            xhrCtor,
+            localStorageData: { beatify_ha_refresh: 'broken-refresh' },
+        });
+
+        // refreshAccess catches the rejection internally and returns null,
+        // but the XHR fallback should have been attempted.
+        const token = await BeatifyAuth.getAccessToken();
+
+        expect(token).toBeNull();
+        expect(xhrCalls).toHaveLength(1);
     });
 });

--- a/custom_components/beatify/www/js/ha-auth.js
+++ b/custom_components/beatify/www/js/ha-auth.js
@@ -132,40 +132,71 @@
     }).then(_readTokenResponse);
   }
 
-  function _postTokenUrlEncoded(params) {
-    // Pre-rc8 transport, kept as a fallback. Safari 18 throws
-    // "TypeError: Load failed" on the FormData variant for some users on
-    // both LAN and Nabu Casa — the request never leaves the browser. The
-    // urlencoded body sidesteps Safari's multipart-boundary path entirely
-    // and still hits HA's IndieAuth /auth/token (HA accepts both
-    // application/x-www-form-urlencoded and multipart/form-data here).
-    var body = Object.keys(params)
-      .map(function (k) {
-        return encodeURIComponent(k) + '=' + encodeURIComponent(params[k]);
-      })
-      .join('&');
-    return fetch(origin() + '/auth/token', {
-      method: 'POST',
-      credentials: 'same-origin',
-      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-      body: body,
-    }).then(_readTokenResponse);
+  function _postTokenXhrUrlEncoded(params) {
+    // rc13 fallback: XMLHttpRequest with urlencoded body. The rc12 attempt
+    // used fetch + urlencoded as the fallback, but on Safari 18 + Nabu
+    // Casa that path is rejected with "Fetch API cannot load … due to
+    // access control checks" — Safari incorrectly applies a CORS check to
+    // the same-origin POST. XHR predates fetch and uses a different
+    // network path internally; same-origin POSTs through XHR don't hit
+    // the buggy CORS path. Same wire format HA's /auth/token expects.
+    return new Promise(function (resolve, reject) {
+      var body = Object.keys(params)
+        .map(function (k) {
+          return encodeURIComponent(k) + '=' + encodeURIComponent(params[k]);
+        })
+        .join('&');
+      var xhr = new XMLHttpRequest();
+      xhr.open('POST', origin() + '/auth/token', true);
+      // Matches `credentials: 'same-origin'` for same-origin URLs — sends
+      // session cookies. (For cross-origin XHR this would request CORS
+      // with credentials, but /auth/token is always same-origin here.)
+      xhr.withCredentials = true;
+      xhr.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded');
+      xhr.onload = function () {
+        if (xhr.status >= 200 && xhr.status < 300) {
+          try {
+            resolve(JSON.parse(xhr.responseText));
+          } catch (e) {
+            reject(new Error('HA token endpoint: malformed JSON response'));
+          }
+        } else {
+          reject(
+            new Error(
+              'HA token endpoint ' +
+                xhr.status +
+                ': ' +
+                (xhr.responseText || xhr.statusText)
+            )
+          );
+        }
+      };
+      // Surface a TypeError for parity with fetch's network-error shape,
+      // though nothing currently differentiates on this — kept for tests.
+      xhr.onerror = function () {
+        reject(new TypeError('XHR /auth/token network error'));
+      };
+      xhr.send(body);
+    });
   }
 
   function postToken(params) {
-    // FormData first (the rc8 fix that survives Nabu Casa SniTun). On a
-    // TypeError — fetch-level failure, the request never reached HA —
-    // retry once with urlencoded. Other errors (HTTP 4xx/5xx surfaced by
-    // _readTokenResponse) propagate as-is; retrying a server rejection
-    // would just produce the same response.
+    // FormData via fetch first (the rc8 fix that survives Nabu Casa
+    // SniTun on Chrome and pre-Safari-18). On a TypeError — fetch-level
+    // failure, the request never reached HA — retry via XHR. Safari 18
+    // breaks the fetch path entirely (FormData = TypeError, urlencoded
+    // fetch = CORS access-control rejection), but XHR same-origin POST
+    // works. Other errors (HTTP 4xx/5xx surfaced by _readTokenResponse)
+    // propagate as-is; retrying a server rejection would produce the
+    // same response.
     return _postTokenFormData(params).catch(function (err) {
       if (err && err.name === 'TypeError') {
         console.warn(
           '[BeatifyAuth] FormData /auth/token failed (' +
             err.message +
-            '); retrying urlencoded'
+            '); retrying via XHR'
         );
-        return _postTokenUrlEncoded(params);
+        return _postTokenXhrUrlEncoded(params);
       }
       throw err;
     });

--- a/custom_components/beatify/www/player.html
+++ b/custom_components/beatify/www/player.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <!-- #824: cache-bust i18n JSON fetches. See admin.html for rationale. -->
-    <meta name="beatify-version" content="3.4.0-rc12">
+    <meta name="beatify-version" content="3.4.0-rc13">
     <!-- Self-healing SW recovery (rc11) — see admin.html for the rationale. -->
     <script>
         (function() {
@@ -36,7 +36,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@700;900&display=swap" rel="stylesheet">
     <!-- Story 18.4: Use minified CSS in production -->
-    <link rel="stylesheet" href="/beatify/static/css/styles.min.css?v=3.4.0-rc12">
+    <link rel="stylesheet" href="/beatify/static/css/styles.min.css?v=3.4.0-rc13">
     <!-- Confetti library for celebrations (Story 14.5) -->
     <script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.9.2/dist/confetti.browser.min.js"></script>
 </head>
@@ -943,9 +943,9 @@
     <!-- Story 18.4: Use minified JS in production with fallback to source -->
     <!-- Version query strings prevent browser caching issues -->
     <!-- #998: HA OAuth client — only used when a host claims the admin role -->
-    <script src="/beatify/static/js/ha-auth.js?v=3.4.0-rc12"></script>
+    <script src="/beatify/static/js/ha-auth.js?v=3.4.0-rc13"></script>
     <script src="/beatify/static/js/i18n.min.js"></script>
     <script src="/beatify/static/js/utils.min.js"></script>
-    <script type="module" src="/beatify/static/js/player.bundle.min.js?v=3.4.0-rc12"></script>
+    <script type="module" src="/beatify/static/js/player.bundle.min.js?v=3.4.0-rc13"></script>
 </body>
 </html>

--- a/custom_components/beatify/www/sw.js
+++ b/custom_components/beatify/www/sw.js
@@ -6,7 +6,7 @@
  */
 'use strict';
 
-var CACHE_VERSION = 'beatify-v3.4.0-rc12';
+var CACHE_VERSION = 'beatify-v3.4.0-rc13';
 var MAX_CACHE_ITEMS = 50;
 
 // Critical assets to precache on install (minified versions only - fallback handled by HTML).


### PR DESCRIPTION
## Summary
- Follow-up to rc12 (#1091). Markus reported rc12 still loops on Safari 18 — both LAN and Nabu Casa — with a different error than rc11: `Fetch API cannot load … due to access control checks`. Safari 18 incorrectly applies a CORS check to the same-origin POST when the urlencoded fetch fallback fires. Both fetch transports are dead on Safari 18 (FormData = TypeError; urlencoded = CORS rejection).
- Replace the fallback transport with `XMLHttpRequest` + urlencoded body. XHR predates the fetch spec quirks Safari is hitting and uses a different network path; same-origin POST through XHR isn't subject to the buggy CORS check. `postToken` still tries FormData via `fetch` first (preserves rc8 Nabu Casa SniTun support for Chrome and pre-Safari-18) and falls back to XHR only on `TypeError`.
- rc13 version bumps across `manifest.json`, `sw.js` `CACHE_VERSION`, all `beatify-version` metas, and every `?v=` cache-buster.

## Test plan
- [x] `npx vitest run` → 89/89 pass (test file now stubs XMLHttpRequest in the vm sandbox; new 4th case covers XHR HTTP-error path)
- [ ] Markus tests on Safari 18 (macOS Sequoia) on both LAN and Nabu Casa — expect to see `[BeatifyAuth] FormData /auth/token failed (Load failed); retrying via XHR` once, then normal admin load. No more loop.
- [ ] Chrome regression check on either transport — FormData succeeds, no fallback warning, admin loads normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)