### PR TITLE
release: v3.4.0 — Lock the Door, Then Build the Robot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,35 @@ All notable changes to Beatify are documented here. For detailed release notes, 
 
 ## [Unreleased]
 
+## [3.4.0] - 2026-05-21
+
+Stable promotion of the v3.4.0-rc15 line with one additional fix (#1080 reset-state-persistence, PR #1089). See [release-notes-v3.4.0.md](release-notes-v3.4.0.md) for the user-facing summary.
+
+### Headline
+- **Security Gate (#998, PR #1007).** `/beatify/admin` and every WebSocket command behind it now require an authenticated Home Assistant session. Anonymous external access is no longer possible.
+- **LLM-Assisted Playlist Generator (#1052, #1057, #1060).** Describe a vibe, get a 40-track candidate list with provider URIs + release years, validated and sanitized. Save locally or submit upstream.
+- **REVEAL Auto-Advance countdown (#1048).** v3.3.7's Auto-Advance now shows the countdown on the sticky "Next round" button.
+
+### Added
+- TTS-Entity-Dropdown im Setup-Wizard (#1073, PR #1079, @ludgerbeckmann)
+- "Ausgewählte Playlists"-Sheet mit Bulk-Remove (#1074, PR #1083, @ludgerbeckmann)
+
+### Fixed
+- Reset-State-Persistence — wizard state now clears on Start New Game (#1080, PR #1089, @BK0101xx)
+- Year-truncation on narrow phones (#1072, PR #1077, @laberning)
+- Tighter game-view so artist tiles land above the fold on mobile (#1076, PR #1084, @laberning)
+- Self-healing service worker — upgrades no longer require manual cache clearing (PR #1086)
+- Safari 18 OAuth flow — entire token exchange now server-side, cookies for transport (rc12–rc15, PRs #1091–#1094)
+- Nabu Casa SniTun token relay — FormData transport (rc8, PR #1078)
+- Zombie token detection (rc8/rc9, commit 36f84e93)
+- Merge-conflict-markers in admin assets (rc7, PR #1071)
+- Playlist Generator modal copy tightened (PR #1065)
+- Playlist Hub FAB icon visibility (#1054, PR #1058)
+
+### Data
+- Danube Incident release year 1968 → 1969 (PR #1063)
+- Alcazar "Crying At the Discoteque" year 2012 → 2000 (PR #1070)
+
 ## [3.4.0-rc15] - 2026-05-21
 
 ### Fixed

--- a/custom_components/beatify/manifest.json
+++ b/custom_components/beatify/manifest.json
@@ -12,5 +12,5 @@
   "documentation": "https://github.com/mholzi/beatify",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/mholzi/beatify/issues",
-  "version": "3.4.0-rc15"
+  "version": "3.4.0"
 }

--- a/custom_components/beatify/server/views.py
+++ b/custom_components/beatify/server/views.py
@@ -410,9 +410,7 @@ class BeatifyAuthRefreshView(HomeAssistantView):
         """Refresh the access token using the HttpOnly refresh cookie."""
         refresh_token = request.cookies.get(_REFRESH_COOKIE)
         if not refresh_token:
-            response = web.json_response(
-                {"error": "no_refresh_token"}, status=401
-            )
+            response = web.json_response({"error": "no_refresh_token"}, status=401)
             _clear_session_cookies(response)
             return response
 
@@ -426,9 +424,7 @@ class BeatifyAuthRefreshView(HomeAssistantView):
         )
         status, parsed, raw = await _exchange_with_ha(self.hass, body)
         if status != 200 or not parsed or not parsed.get("access_token"):
-            _LOGGER.info(
-                "Refresh failed (status=%s) — clearing session", status
-            )
+            _LOGGER.info("Refresh failed (status=%s) — clearing session", status)
             response = web.json_response(
                 {"error": "refresh_failed", "ha_status": status}, status=401
             )

--- a/custom_components/beatify/www/admin.html
+++ b/custom_components/beatify/www/admin.html
@@ -8,7 +8,7 @@
          query-string version, a stale en.json from a prior rc gets served
          after upgrade and references to newer keys render as raw strings.
          Bumped each rc alongside manifest.json + sw.js CACHE_VERSION. -->
-    <meta name="beatify-version" content="3.4.0-rc15">
+    <meta name="beatify-version" content="3.4.0">
     <!-- Self-healing SW recovery (rc11): an older-version service worker
          may serve a stale ha-auth.js even with cache-busters, leaving users
          in an unrecoverable login loop. Compare the current page's version
@@ -55,7 +55,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@700;900&display=swap" rel="stylesheet">
     <!-- Story 18.4: Use minified CSS in production -->
-    <link rel="stylesheet" href="/beatify/static/css/styles.min.css?v=3.4.0-rc15">
+    <link rel="stylesheet" href="/beatify/static/css/styles.min.css?v=3.4.0">
 </head>
 <body class="theme-dark">
     <!-- First-run wizard takeover (see DESIGN.md ## Patterns → First-run wizard) -->
@@ -1446,17 +1446,17 @@
     <!-- Story 18.4: Use minified JS in production with fallback to source -->
     <!-- Version query strings prevent browser caching issues -->
     <!-- #998: HA OAuth client — must load before any admin script uses BeatifyAuth -->
-    <script src="/beatify/static/js/ha-auth.js?v=3.4.0-rc15"></script>
+    <script src="/beatify/static/js/ha-auth.js?v=3.4.0"></script>
     <script src="/beatify/static/js/i18n.js?v=1.7.0"></script>
     <script src="/beatify/static/js/utils.js?v=1.7.0"></script>
     <!-- Story 44.1: Playlist requests module -->
-    <script src="/beatify/static/js/playlist-requests.min.js?v=3.4.0-rc15"></script>
+    <script src="/beatify/static/js/playlist-requests.min.js?v=3.4.0"></script>
     <!-- #1052: LLM-assisted playlist generator (load before playlist-hub so the Mine-tab button finds it) -->
-    <script src="/beatify/static/js/playlist-generator.min.js?v=3.4.0-rc15"></script>
-    <script type="module" src="/beatify/static/js/playlist-hub.js?v=3.4.0-rc15"></script>
-    <script type="module" src="/beatify/static/js/wizard.js?v=3.4.0-rc15"></script>
-    <script src="/beatify/static/js/admin.min.js?v=3.4.0-rc15"></script>
-    <script src="/beatify/static/js/party-lights.min.js?v=3.4.0-rc15"></script>
-    <script src="/beatify/static/js/tts-settings.js?v=3.4.0-rc15"></script>
+    <script src="/beatify/static/js/playlist-generator.min.js?v=3.4.0"></script>
+    <script type="module" src="/beatify/static/js/playlist-hub.js?v=3.4.0"></script>
+    <script type="module" src="/beatify/static/js/wizard.js?v=3.4.0"></script>
+    <script src="/beatify/static/js/admin.min.js?v=3.4.0"></script>
+    <script src="/beatify/static/js/party-lights.min.js?v=3.4.0"></script>
+    <script src="/beatify/static/js/tts-settings.js?v=3.4.0"></script>
 </body>
 </html>

--- a/custom_components/beatify/www/dashboard.html
+++ b/custom_components/beatify/www/dashboard.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <!-- #824: cache-bust i18n JSON fetches. See admin.html for rationale. -->
-    <meta name="beatify-version" content="3.4.0-rc15">
+    <meta name="beatify-version" content="3.4.0">
     <title data-i18n="dashboard.title">Beatify - Dashboard</title>
     <!-- Preconnect for faster font loading (Story 9.8) -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -12,7 +12,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Outfit:wght@700;900&display=swap" rel="stylesheet">
     <!-- Story 18.4: Use minified CSS in production -->
     <link rel="stylesheet" href="/beatify/static/css/styles.css?v=1.7.0">
-    <link rel="stylesheet" href="/beatify/static/css/dashboard.min.css?v=3.4.0-rc15">
+    <link rel="stylesheet" href="/beatify/static/css/dashboard.min.css?v=3.4.0">
     <!-- Confetti library for celebrations (Story 14.5) -->
     <script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.9.2/dist/confetti.browser.min.js"></script>
 </head>
@@ -285,7 +285,7 @@
     <!-- Version query strings prevent browser caching issues -->
     <script src="/beatify/static/js/i18n.js?v=1.7.0"></script>
     <script src="/beatify/static/js/utils.js?v=1.7.0"></script>
-    <script src="/beatify/static/js/dashboard.min.js?v=3.4.0-rc15"></script>
+    <script src="/beatify/static/js/dashboard.min.js?v=3.4.0"></script>
     <!-- v3.2.1 Arcade shims: submission meter fill, album ring progress, reveal round mirror.
          Pure view-layer helpers — no state, no API calls. Safe to remove if dashboard.js
          ever takes these over directly. -->

--- a/custom_components/beatify/www/player.html
+++ b/custom_components/beatify/www/player.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <!-- #824: cache-bust i18n JSON fetches. See admin.html for rationale. -->
-    <meta name="beatify-version" content="3.4.0-rc15">
+    <meta name="beatify-version" content="3.4.0">
     <!-- Self-healing SW recovery (rc11) — see admin.html for the rationale. -->
     <script>
         (function() {
@@ -36,7 +36,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@700;900&display=swap" rel="stylesheet">
     <!-- Story 18.4: Use minified CSS in production -->
-    <link rel="stylesheet" href="/beatify/static/css/styles.min.css?v=3.4.0-rc15">
+    <link rel="stylesheet" href="/beatify/static/css/styles.min.css?v=3.4.0">
     <!-- Confetti library for celebrations (Story 14.5) -->
     <script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.9.2/dist/confetti.browser.min.js"></script>
 </head>
@@ -943,9 +943,9 @@
     <!-- Story 18.4: Use minified JS in production with fallback to source -->
     <!-- Version query strings prevent browser caching issues -->
     <!-- #998: HA OAuth client — only used when a host claims the admin role -->
-    <script src="/beatify/static/js/ha-auth.js?v=3.4.0-rc15"></script>
+    <script src="/beatify/static/js/ha-auth.js?v=3.4.0"></script>
     <script src="/beatify/static/js/i18n.min.js"></script>
     <script src="/beatify/static/js/utils.min.js"></script>
-    <script type="module" src="/beatify/static/js/player.bundle.min.js?v=3.4.0-rc15"></script>
+    <script type="module" src="/beatify/static/js/player.bundle.min.js?v=3.4.0"></script>
 </body>
 </html>

--- a/custom_components/beatify/www/sw.js
+++ b/custom_components/beatify/www/sw.js
@@ -6,7 +6,7 @@
  */
 'use strict';
 
-var CACHE_VERSION = 'beatify-v3.4.0-rc15';
+var CACHE_VERSION = 'beatify-v3.4.0';
 var MAX_CACHE_ITEMS = 50;
 
 // Critical assets to precache on install (minified versions only - fallback handled by HTML).

--- a/tests/unit/test_auth_callback_view.py
+++ b/tests/unit/test_auth_callback_view.py
@@ -83,9 +83,7 @@ class TestBeatifyAuthCallbackView:
             "custom_components.beatify.server.views.async_get_clientsession",
             return_value=mock_session,
         ):
-            resp = await view.get(
-                _request({"code": "abc", "state": "xyz"})
-            )
+            resp = await view.get(_request({"code": "abc", "state": "xyz"}))
 
         assert resp.status == 302
         location = resp.headers["Location"]
@@ -123,18 +121,14 @@ class TestBeatifyAuthCallbackView:
         view = BeatifyAuthCallbackView(_hass())
         mock_session = MagicMock()
         mock_session.post = MagicMock(
-            return_value=_MockResponseCtx(
-                status=400, text='{"error":"invalid_grant"}'
-            )
+            return_value=_MockResponseCtx(status=400, text='{"error":"invalid_grant"}')
         )
 
         with patch(
             "custom_components.beatify.server.views.async_get_clientsession",
             return_value=mock_session,
         ):
-            resp = await view.get(
-                _request({"code": "expired", "state": "xyz"})
-            )
+            resp = await view.get(_request({"code": "expired", "state": "xyz"}))
 
         assert resp.status == 302
         assert "auth_error=exchange_failed" in resp.headers["Location"]
@@ -152,9 +146,7 @@ class TestBeatifyAuthCallbackView:
             "custom_components.beatify.server.views.async_get_clientsession",
             return_value=mock_session,
         ):
-            resp = await view.get(
-                _request({"code": "abc", "state": "xyz"})
-            )
+            resp = await view.get(_request({"code": "abc", "state": "xyz"}))
 
         assert resp.status == 302
         assert "auth_error=exchange_failed" in resp.headers["Location"]
@@ -170,9 +162,7 @@ class TestBeatifyAuthCallbackView:
         mock_session.post = MagicMock(
             return_value=_MockResponseCtx(
                 status=200,
-                text=(
-                    '{"access_token":"a","refresh_token":"r","expires_in":1800}'
-                ),
+                text=('{"access_token":"a","refresh_token":"r","expires_in":1800}'),
             )
         )
 

--- a/tests/unit/test_auth_refresh_view.py
+++ b/tests/unit/test_auth_refresh_view.py
@@ -114,9 +114,7 @@ class TestBeatifyAuthRefreshView:
         view = BeatifyAuthRefreshView(_hass())
         mock_session = MagicMock()
         mock_session.post = MagicMock(
-            return_value=_MockResponseCtx(
-                status=400, text='{"error":"invalid_grant"}'
-            )
+            return_value=_MockResponseCtx(status=400, text='{"error":"invalid_grant"}')
         )
 
         with patch(


### PR DESCRIPTION
Stable promotion of the v3.4.0-rc15 line + the late #1080 reset fix (PR #1089).

## Summary

- **Security Gate (#998, PR #1007)** — admin panel + WS commands now require an authenticated HA session
- **LLM-Assisted Playlist Generator (#1052, #1057, #1060)** — describe a vibe, get a 40-track validated playlist
- **REVEAL Auto-Advance countdown (#1048)** — v3.3.7's auto-advance finished with visible countdown on the sticky button
- Eight RCs of auth hardening behind the gate: Nabu Casa SniTun (FormData), zombie-token detection, Safari 18 server-side OAuth, self-healing SW
- @ludgerbeckmann TTS-Entity-Dropdown (#1073) + Selected-Playlists-Sheet (#1074)
- @laberning year-truncation (#1072) + tighter game-view (#1076) mobile fixes
- @BK0101xx reset-state-persistence fix (#1080)
- Two data fixes (Danube Incident #1063, Alcazar #1070)

Version markers consolidated 3.4.0-rc15 → 3.4.0 (manifest, 3× HTML meta, all admin/player/dashboard ?v= cache-busters, sw.js CACHE_VERSION). CHANGELOG section added.

Release notes: docs/release-notes-v3.4.0.md (gitignored — used at tag creation via `--notes-file`).

## Test plan
- [x] CI 7/7 grün auf rc15 + #1089
- [ ] HACS-Install-Verify nach stable-release (Markus)
- [ ] Safari 18 admin loads cleanly nach Upgrade

🤖 Generated with [Claude Code](https://claude.com/claude-code)