### PR TITLE
release: v3.4.0-rc16 — fix Companion App redirect (#1096) + REST i18n (#1097)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to Beatify are documented here. For detailed release notes, 
 
 ## [Unreleased]
 
+## [3.4.0-rc16] - 2026-05-22
+
+Walks back v3.4.0 stable to fix two regressions reported within hours of the v3.4.0 release. The v3.4.0 GitHub release has been removed; rc16 ships as the new pre-release while these fixes bake before re-cutting stable.
+
+### Fixed
+- **HA Companion App on iOS — "Invalid redirect URI" on Beatify open (#1096, @ludgerbeckmann).** Since v3.4.0, opening Beatify via the HA Companion App on iOS surfaced HA's IndieAuth error page immediately, on both LAN and Nabu Casa. rc15 had changed the OAuth `redirect_uri` from the page URL to the new server-side callback path (`/beatify/auth/callback`), and the Companion App rejects redirect_uris pointing at paths it doesn't recognize as registered panel URLs. rc16 reverts the `redirect_uri` to the page URL (the value the Companion App accepted from rc1 through rc14) and threads the actual server-side exchange via a JS-level top-level navigation step: the page receives `?code=&state=`, ha-auth.js immediately navigates to `/beatify/auth/callback?code=…&state=…&redirect_uri=<page>`, and the callback view uses the threaded `redirect_uri` for the loopback `/auth/token` exchange (RFC 6749 §4.1.3 requires byte-identical redirect_uri values across `/auth/authorize` and `/auth/token`). The Safari 18 fix is preserved end-to-end — the browser still never POSTs to an auth endpoint.
+- **REST error responses now expose `data.code` instead of just `data.error` (#1097, @ludgerbeckmann).** Two regressions collapsed into one root cause: `_json_error` in `server/base.py` wrote `{error: <code>, message: <text>}`, but the frontend admin.js reads `data.code` (matching the WebSocket error shape). The mismatch made (a) the `GAME_IN_LOBBY` auto-recovery silently dead — users saw a modal with the raw English message instead of seamless gameplay start — and (b) the `errors.<CODE>` i18n lookup never fire, so German, Spanish, French, and Dutch users got the raw English `message` for every REST-side error. rc16 emits both `code` and `error` (full backwards-compat) so existing code paths light up. New `errors.GAME_IN_LOBBY` translations added to all five locales.
+
+### Tests
+- 539 Python pass (+5 new for `_json_error` body shape, +2 for the `redirect_uri` query-param forwarding in `BeatifyAuthCallbackView`).
+- 98 JS pass (+2 for the new `?code=` → callback-view bounce path and the rc16 `redirect_uri` shape).
+
 ## [3.4.0] - 2026-05-21
 
 Stable promotion of the v3.4.0-rc15 line with one additional fix (#1080 reset-state-persistence, PR #1089). See [release-notes-v3.4.0.md](release-notes-v3.4.0.md) for the user-facing summary.

--- a/custom_components/beatify/manifest.json
+++ b/custom_components/beatify/manifest.json
@@ -12,5 +12,5 @@
   "documentation": "https://github.com/mholzi/beatify",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/mholzi/beatify/issues",
-  "version": "3.4.0"
+  "version": "3.4.0-rc16"
 }

--- a/custom_components/beatify/server/base.py
+++ b/custom_components/beatify/server/base.py
@@ -68,8 +68,26 @@ async def _get_html(hass: HomeAssistant, path: Path) -> str | None:
 
 
 def _json_error(message: str, status: int, *, code: str = "ERROR") -> web.Response:
-    """Return a consistent JSON error response."""
-    return web.json_response({"error": code, "message": message}, status=status)
+    """Return a consistent JSON error response.
+
+    rc16 (#1097): the body now puts the machine-readable code under
+    ``code`` (matching the WebSocket error shape — see ws_handlers.py).
+    Before rc16 this used the key ``error``, which caused two regressions:
+
+    1. ``admin.js`` checks ``data.code === 'GAME_IN_LOBBY'`` to silently
+       recover when a LOBBY game already exists; with the old key the
+       check was dead code and the user got dropped into a modal with
+       the raw English message instead of the seamless gameplay start.
+    2. The ``errors.<CODE>`` i18n lookup (also reading ``data.code``)
+       never fired, so German / Spanish / French / Dutch users saw the
+       raw English ``message`` for every REST-side error response.
+
+    The ``error`` key is kept too so anything still reading it from
+    older builds doesn't break — drop after a few releases.
+    """
+    return web.json_response(
+        {"code": code, "error": code, "message": message}, status=status
+    )
 
 
 class RateLimitMixin:

--- a/custom_components/beatify/server/views.py
+++ b/custom_components/beatify/server/views.py
@@ -357,16 +357,23 @@ class BeatifyAuthCallbackView(HomeAssistantView):
             return self._redirect_to_admin(request, error="missing_code")
 
         origin = _origin_from_request(request)
+        # rc16 (#1096): redirect_uri now arrives as a query param from
+        # ha-auth.js because the HA Companion App on iOS rejects callback-
+        # path redirect_uris with "Invalid redirect URI". ha-auth.js sends
+        # the page URL it told HA, and we forward that byte-identical
+        # value here per RFC 6749 §4.1.3. Fall back to the rc15 hardcoded
+        # value defensively if the param is missing.
+        redirect_uri = request.query.get(
+            "redirect_uri", f"{origin}/beatify/auth/callback"
+        )
         body = urlencode(
             {
                 "grant_type": "authorization_code",
                 "code": code,
-                # client_id and redirect_uri MUST match what the frontend
-                # sent to /auth/authorize, per RFC 6749 §4.1.3. ha-auth.js
-                # uses origin + '/beatify/' as client_id and this exact
-                # callback URL as redirect_uri.
+                # client_id mirrors what ha-auth.js computes:
+                # window.location.origin + '/beatify/'.
                 "client_id": f"{origin}/beatify/",
-                "redirect_uri": f"{origin}/beatify/auth/callback",
+                "redirect_uri": redirect_uri,
             }
         )
 

--- a/custom_components/beatify/www/admin.html
+++ b/custom_components/beatify/www/admin.html
@@ -8,7 +8,7 @@
          query-string version, a stale en.json from a prior rc gets served
          after upgrade and references to newer keys render as raw strings.
          Bumped each rc alongside manifest.json + sw.js CACHE_VERSION. -->
-    <meta name="beatify-version" content="3.4.0">
+    <meta name="beatify-version" content="3.4.0-rc16">
     <!-- Self-healing SW recovery (rc11): an older-version service worker
          may serve a stale ha-auth.js even with cache-busters, leaving users
          in an unrecoverable login loop. Compare the current page's version
@@ -55,7 +55,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@700;900&display=swap" rel="stylesheet">
     <!-- Story 18.4: Use minified CSS in production -->
-    <link rel="stylesheet" href="/beatify/static/css/styles.min.css?v=3.4.0">
+    <link rel="stylesheet" href="/beatify/static/css/styles.min.css?v=3.4.0-rc16">
 </head>
 <body class="theme-dark">
     <!-- First-run wizard takeover (see DESIGN.md ## Patterns → First-run wizard) -->
@@ -1446,17 +1446,17 @@
     <!-- Story 18.4: Use minified JS in production with fallback to source -->
     <!-- Version query strings prevent browser caching issues -->
     <!-- #998: HA OAuth client — must load before any admin script uses BeatifyAuth -->
-    <script src="/beatify/static/js/ha-auth.js?v=3.4.0"></script>
+    <script src="/beatify/static/js/ha-auth.js?v=3.4.0-rc16"></script>
     <script src="/beatify/static/js/i18n.js?v=1.7.0"></script>
     <script src="/beatify/static/js/utils.js?v=1.7.0"></script>
     <!-- Story 44.1: Playlist requests module -->
-    <script src="/beatify/static/js/playlist-requests.min.js?v=3.4.0"></script>
+    <script src="/beatify/static/js/playlist-requests.min.js?v=3.4.0-rc16"></script>
     <!-- #1052: LLM-assisted playlist generator (load before playlist-hub so the Mine-tab button finds it) -->
-    <script src="/beatify/static/js/playlist-generator.min.js?v=3.4.0"></script>
-    <script type="module" src="/beatify/static/js/playlist-hub.js?v=3.4.0"></script>
-    <script type="module" src="/beatify/static/js/wizard.js?v=3.4.0"></script>
-    <script src="/beatify/static/js/admin.min.js?v=3.4.0"></script>
-    <script src="/beatify/static/js/party-lights.min.js?v=3.4.0"></script>
-    <script src="/beatify/static/js/tts-settings.js?v=3.4.0"></script>
+    <script src="/beatify/static/js/playlist-generator.min.js?v=3.4.0-rc16"></script>
+    <script type="module" src="/beatify/static/js/playlist-hub.js?v=3.4.0-rc16"></script>
+    <script type="module" src="/beatify/static/js/wizard.js?v=3.4.0-rc16"></script>
+    <script src="/beatify/static/js/admin.min.js?v=3.4.0-rc16"></script>
+    <script src="/beatify/static/js/party-lights.min.js?v=3.4.0-rc16"></script>
+    <script src="/beatify/static/js/tts-settings.js?v=3.4.0-rc16"></script>
 </body>
 </html>

--- a/custom_components/beatify/www/dashboard.html
+++ b/custom_components/beatify/www/dashboard.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <!-- #824: cache-bust i18n JSON fetches. See admin.html for rationale. -->
-    <meta name="beatify-version" content="3.4.0">
+    <meta name="beatify-version" content="3.4.0-rc16">
     <title data-i18n="dashboard.title">Beatify - Dashboard</title>
     <!-- Preconnect for faster font loading (Story 9.8) -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -12,7 +12,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Outfit:wght@700;900&display=swap" rel="stylesheet">
     <!-- Story 18.4: Use minified CSS in production -->
     <link rel="stylesheet" href="/beatify/static/css/styles.css?v=1.7.0">
-    <link rel="stylesheet" href="/beatify/static/css/dashboard.min.css?v=3.4.0">
+    <link rel="stylesheet" href="/beatify/static/css/dashboard.min.css?v=3.4.0-rc16">
     <!-- Confetti library for celebrations (Story 14.5) -->
     <script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.9.2/dist/confetti.browser.min.js"></script>
 </head>
@@ -285,7 +285,7 @@
     <!-- Version query strings prevent browser caching issues -->
     <script src="/beatify/static/js/i18n.js?v=1.7.0"></script>
     <script src="/beatify/static/js/utils.js?v=1.7.0"></script>
-    <script src="/beatify/static/js/dashboard.min.js?v=3.4.0"></script>
+    <script src="/beatify/static/js/dashboard.min.js?v=3.4.0-rc16"></script>
     <!-- v3.2.1 Arcade shims: submission meter fill, album ring progress, reveal round mirror.
          Pure view-layer helpers — no state, no API calls. Safe to remove if dashboard.js
          ever takes these over directly. -->

--- a/custom_components/beatify/www/i18n/de.json
+++ b/custom_components/beatify/www/i18n/de.json
@@ -764,6 +764,7 @@
     "GAME_ALREADY_STARTED": "Es läuft bereits ein Spiel. Beende es, bevor du ein neues startest.",
     "GAME_ENDED": "Spiel beendet",
     "GAME_FULL": "Spiel ist voll",
+    "GAME_IN_LOBBY": "Ein Spiel wartet bereits in der Lobby — starte stattdessen das Gameplay.",
     "GAME_NOT_STARTED": "Spiel noch nicht gestartet",
     "GITHUB_ERROR": "Backend ist gerade nicht erreichbar — bitte gleich nochmal probieren.",
     "INVALID_ACTION": "Ungültige Aktion",

--- a/custom_components/beatify/www/i18n/en.json
+++ b/custom_components/beatify/www/i18n/en.json
@@ -764,6 +764,7 @@
     "GAME_ALREADY_STARTED": "A game is already in progress. End the current game before starting a new one.",
     "GAME_ENDED": "Game has ended",
     "GAME_FULL": "Game is full",
+    "GAME_IN_LOBBY": "A game is already waiting in the lobby — start gameplay instead.",
     "GAME_NOT_STARTED": "Game has not started",
     "GITHUB_ERROR": "Backend is unavailable right now — please try again in a moment.",
     "INVALID_ACTION": "Invalid action",

--- a/custom_components/beatify/www/i18n/es.json
+++ b/custom_components/beatify/www/i18n/es.json
@@ -764,6 +764,7 @@
     "GAME_ALREADY_STARTED": "Ya hay una partida en curso. Termínala antes de empezar una nueva.",
     "GAME_ENDED": "El juego ha terminado",
     "GAME_FULL": "El juego esta lleno",
+    "GAME_IN_LOBBY": "Ya hay un juego esperando en el lobby — comienza a jugar directamente.",
     "GAME_NOT_STARTED": "El juego no ha comenzado",
     "GITHUB_ERROR": "El backend no esta disponible ahora mismo — intentalo de nuevo en un momento.",
     "INVALID_ACTION": "Accion invalida",

--- a/custom_components/beatify/www/i18n/fr.json
+++ b/custom_components/beatify/www/i18n/fr.json
@@ -764,6 +764,7 @@
     "GAME_ALREADY_STARTED": "Une partie est déjà en cours. Termine-la avant d'en lancer une nouvelle.",
     "GAME_ENDED": "La partie est terminée",
     "GAME_FULL": "La partie est complète",
+    "GAME_IN_LOBBY": "Une partie attend déjà dans le lobby — lance directement le jeu.",
     "GAME_NOT_STARTED": "La partie n'a pas commencé",
     "GITHUB_ERROR": "Le backend est indisponible pour le moment — réessaye dans un instant.",
     "INVALID_ACTION": "Action invalide",

--- a/custom_components/beatify/www/i18n/nl.json
+++ b/custom_components/beatify/www/i18n/nl.json
@@ -764,6 +764,7 @@
     "GAME_ALREADY_STARTED": "Er is al een spel bezig. Beëindig het voordat je een nieuwe start.",
     "GAME_ENDED": "Het spel is afgelopen",
     "GAME_FULL": "Het spel zit vol",
+    "GAME_IN_LOBBY": "Er wacht al een spel in de lobby — start het gameplay direct.",
     "GAME_NOT_STARTED": "Het spel is nog niet gestart",
     "GITHUB_ERROR": "Backend is op dit moment niet bereikbaar — probeer het zo nog eens.",
     "INVALID_ACTION": "Ongeldige actie",

--- a/custom_components/beatify/www/js/__tests__/ha-auth.test.js
+++ b/custom_components/beatify/www/js/__tests__/ha-auth.test.js
@@ -255,18 +255,60 @@ describe('init() auth callback handling', () => {
 });
 
 describe('login() OAuth redirect', () => {
-    it('uses /beatify/auth/callback as redirect_uri (rc15: server-side exchange)', () => {
+    it('uses the page URL as redirect_uri (rc16: Companion App accepts only registered paths)', () => {
+        // rc15 pointed redirect_uri at /beatify/auth/callback, which the HA
+        // iOS Companion App rejected as "Invalid redirect URI". rc16
+        // reverts to the page URL (the value Companion accepted for years)
+        // and routes the code via JS into the callback view instead.
         const { BeatifyAuth, sandboxWindow } = loadHaAuth({});
         BeatifyAuth.login();
         const url = sandboxWindow.location._lastReplace;
         expect(url).toContain('/auth/authorize');
         expect(url).toContain('response_type=code');
         expect(url).toContain(
-            'redirect_uri=' + encodeURIComponent('https://ha.example/beatify/auth/callback')
+            'redirect_uri=' + encodeURIComponent('https://ha.example/beatify/admin')
         );
-        // client_id is origin + /beatify/
+        // client_id is origin + /beatify/ (unchanged across RCs).
         expect(url).toContain(
             'client_id=' + encodeURIComponent('https://ha.example/beatify/')
         );
+    });
+});
+
+describe('init() ?code= bounce to callback (rc16)', () => {
+    it('navigates to /beatify/auth/callback when ?code=&state= arrive on the page', async () => {
+        const { BeatifyAuth, sandboxWindow } = loadHaAuth({});
+        sandboxWindow.location.search = '?code=AUTH_CODE_123&state=state-xyz';
+
+        const result = await Promise.race([
+            BeatifyAuth.init({ requireAuth: true }),
+            new Promise((r) => setTimeout(() => r('SUSPENDED'), 5)),
+        ]);
+        expect(result).toBe('SUSPENDED');
+
+        const navigated = sandboxWindow.location._lastReplace;
+        expect(navigated).toContain('/beatify/auth/callback');
+        expect(navigated).toContain('code=AUTH_CODE_123');
+        expect(navigated).toContain('state=state-xyz');
+        // The redirect_uri threaded through must be byte-identical to
+        // what login() sent to /auth/authorize, per RFC 6749 §4.1.3.
+        expect(navigated).toContain(
+            'redirect_uri=' + encodeURIComponent('https://ha.example/beatify/admin')
+        );
+    });
+
+    it('does not bounce when there is no ?code= (regular page load)', async () => {
+        const fetchFn = async () => ({ ok: false, status: 401, json: async () => ({}) });
+        const { BeatifyAuth, sandboxWindow } = loadHaAuth({ fetchFn });
+        // No ?code= — init must fall through to refreshAccess (and on
+        // failure, login()), NOT bounce to the callback view.
+        const result = await Promise.race([
+            BeatifyAuth.init({ requireAuth: true }),
+            new Promise((r) => setTimeout(() => r('SUSPENDED'), 5)),
+        ]);
+        expect(result).toBe('SUSPENDED');
+        // login() was called (target is /auth/authorize, not callback view).
+        expect(sandboxWindow.location._lastReplace).toContain('/auth/authorize');
+        expect(sandboxWindow.location._lastReplace).not.toContain('/beatify/auth/callback');
     });
 });

--- a/custom_components/beatify/www/js/ha-auth.js
+++ b/custom_components/beatify/www/js/ha-auth.js
@@ -61,10 +61,14 @@
     return origin() + '/beatify/';
   }
   function redirectUri() {
-    // rc15: redirect_uri is the server-side callback view, not the page.
-    // The view performs the code exchange and sets cookies before the
-    // browser ever reaches the admin page again.
-    return origin() + '/beatify/auth/callback';
+    // rc16 (#1096): the HA Companion App on iOS rejects /auth/authorize
+    // with "Invalid redirect URI" when redirect_uri points at a path
+    // it doesn't recognize. Sending the page URL itself (the value used
+    // up through rc14) is the only redirect_uri shape Companion accepts.
+    // The server-side callback view still handles the code exchange —
+    // ha-auth.js detects the ?code= echo on this page and navigates to
+    // /beatify/auth/callback as a separate step (see _bounceCodeToCallback).
+    return origin() + window.location.pathname;
   }
 
   function randomState() {
@@ -191,6 +195,34 @@
       '&state=' +
       encodeURIComponent(state);
     window.location.replace(url);
+  }
+
+  /**
+   * Forward a freshly-arrived OAuth code to the server-side callback view.
+   *
+   * HA redirected us back to ``${origin}${pathname}?code=…&state=…`` because
+   * that's the redirect_uri the HA Companion App accepts (see ``redirectUri``).
+   * The actual exchange must happen server-side (Safari 18 can't POST it from
+   * the browser); navigate to the callback view, passing the exact
+   * redirect_uri HA saw so the loopback exchange can satisfy RFC 6749 §4.1.3.
+   *
+   * Returns true when navigation has been initiated — caller should suspend.
+   */
+  function _bounceCodeToCallback() {
+    var params = new URLSearchParams(window.location.search);
+    var code = params.get('code');
+    var state = params.get('state');
+    if (!code) return false;
+    var url =
+      origin() +
+      '/beatify/auth/callback?code=' +
+      encodeURIComponent(code) +
+      '&state=' +
+      encodeURIComponent(state || '') +
+      '&redirect_uri=' +
+      encodeURIComponent(redirectUri());
+    window.location.replace(url);
+    return true;
   }
 
   /**
@@ -345,6 +377,16 @@
   function init(options) {
     options = options || {};
     _migrateFromLocalStorage();
+
+    // If we arrived from /auth/authorize with ?code=&state=, forward
+    // to the server-side callback view. This is the rc16 detour: HA's
+    // redirect lands on the page itself (the only redirect_uri the
+    // Companion App accepts) and we hop one extra step to do the
+    // exchange server-side. Navigation is in-flight; suspend init.
+    if (_bounceCodeToCallback()) {
+      return new Promise(function () {});
+    }
+
     var callbackResult = _consumeAuthCallback();
 
     // callbackResult === false means the server-side exchange reported a

--- a/custom_components/beatify/www/player.html
+++ b/custom_components/beatify/www/player.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <!-- #824: cache-bust i18n JSON fetches. See admin.html for rationale. -->
-    <meta name="beatify-version" content="3.4.0">
+    <meta name="beatify-version" content="3.4.0-rc16">
     <!-- Self-healing SW recovery (rc11) — see admin.html for the rationale. -->
     <script>
         (function() {
@@ -36,7 +36,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@700;900&display=swap" rel="stylesheet">
     <!-- Story 18.4: Use minified CSS in production -->
-    <link rel="stylesheet" href="/beatify/static/css/styles.min.css?v=3.4.0">
+    <link rel="stylesheet" href="/beatify/static/css/styles.min.css?v=3.4.0-rc16">
     <!-- Confetti library for celebrations (Story 14.5) -->
     <script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.9.2/dist/confetti.browser.min.js"></script>
 </head>
@@ -943,9 +943,9 @@
     <!-- Story 18.4: Use minified JS in production with fallback to source -->
     <!-- Version query strings prevent browser caching issues -->
     <!-- #998: HA OAuth client — only used when a host claims the admin role -->
-    <script src="/beatify/static/js/ha-auth.js?v=3.4.0"></script>
+    <script src="/beatify/static/js/ha-auth.js?v=3.4.0-rc16"></script>
     <script src="/beatify/static/js/i18n.min.js"></script>
     <script src="/beatify/static/js/utils.min.js"></script>
-    <script type="module" src="/beatify/static/js/player.bundle.min.js?v=3.4.0"></script>
+    <script type="module" src="/beatify/static/js/player.bundle.min.js?v=3.4.0-rc16"></script>
 </body>
 </html>

--- a/custom_components/beatify/www/sw.js
+++ b/custom_components/beatify/www/sw.js
@@ -6,7 +6,7 @@
  */
 'use strict';
 
-var CACHE_VERSION = 'beatify-v3.4.0';
+var CACHE_VERSION = 'beatify-v3.4.0-rc16';
 var MAX_CACHE_ITEMS = 50;
 
 // Critical assets to precache on install (minified versions only - fallback handled by HTML).

--- a/tests/unit/test_auth_callback_view.py
+++ b/tests/unit/test_auth_callback_view.py
@@ -66,6 +66,69 @@ class TestBeatifyAuthCallbackView:
         assert "auth_error=missing_code" in resp.headers["Location"]
 
     @pytest.mark.asyncio
+    async def test_forwards_redirect_uri_query_param_to_loopback_exchange(self):
+        # rc16 (#1096): ha-auth.js passes the page URL it told HA as the
+        # redirect_uri query param. We must forward that byte-identical
+        # value to /auth/token (RFC 6749 §4.1.3), NOT hardcode our own.
+        view = BeatifyAuthCallbackView(_hass())
+        mock_session = MagicMock()
+        mock_session.post = MagicMock(
+            return_value=_MockResponseCtx(
+                status=200,
+                text=(
+                    '{"access_token":"a","refresh_token":"r","expires_in":1800}'
+                ),
+            )
+        )
+
+        with patch(
+            "custom_components.beatify.server.views.async_get_clientsession",
+            return_value=mock_session,
+        ):
+            await view.get(
+                _request(
+                    {
+                        "code": "abc",
+                        "state": "xyz",
+                        # The page URL ha-auth.js used as redirect_uri at
+                        # /auth/authorize. The Companion App accepts this.
+                        "redirect_uri": "http://ha.local:8123/beatify/admin",
+                    }
+                )
+            )
+
+        call_body = mock_session.post.call_args.kwargs["data"]
+        # urlencoded body — the forwarded redirect_uri must match.
+        assert (
+            "redirect_uri=http%3A%2F%2Fha.local%3A8123%2Fbeatify%2Fadmin"
+            in call_body
+        )
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_legacy_callback_redirect_uri_when_param_missing(self):
+        # Defensive fallback for the rc15 frontend that didn't send a
+        # redirect_uri param. Should keep working until everyone's on rc16+.
+        view = BeatifyAuthCallbackView(_hass())
+        mock_session = MagicMock()
+        mock_session.post = MagicMock(
+            return_value=_MockResponseCtx(
+                status=200,
+                text='{"access_token":"a","refresh_token":"r","expires_in":1800}',
+            )
+        )
+
+        with patch(
+            "custom_components.beatify.server.views.async_get_clientsession",
+            return_value=mock_session,
+        ):
+            await view.get(_request({"code": "abc", "state": "xyz"}))
+
+        call_body = mock_session.post.call_args.kwargs["data"]
+        # Falls back to the rc15 hardcoded callback URL.
+        assert "redirect_uri=" in call_body
+        assert "%2Fbeatify%2Fauth%2Fcallback" in call_body
+
+    @pytest.mark.asyncio
     async def test_successful_exchange_sets_cookies_and_redirects(self):
         view = BeatifyAuthCallbackView(_hass())
         mock_session = MagicMock()

--- a/tests/unit/test_json_error.py
+++ b/tests/unit/test_json_error.py
@@ -1,0 +1,61 @@
+"""Tests for the shared _json_error helper (#1097 / rc16).
+
+The body shape changed in rc16: it now sets the code under both ``code``
+and ``error``. Frontend code (admin.js) reads ``data.code``; before rc16
+the helper only set ``error``, so the GAME_IN_LOBBY auto-recovery and
+i18n-by-code lookup were both silently dead.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from custom_components.beatify.server.base import _json_error
+
+
+class TestJsonError:
+    @pytest.mark.asyncio
+    async def test_body_includes_code_field_for_frontend(self):
+        # admin.js:1998 / :2006 read data.code. rc15 and earlier only set
+        # ``error`` — those branches never fired. rc16 emits both keys so
+        # ``data.code`` works without breaking anything still reading
+        # ``data.error``.
+        resp = _json_error("Test message", 409, code="TEST_CODE")
+        body = json.loads(resp.body)
+        assert body["code"] == "TEST_CODE"
+        assert body["message"] == "Test message"
+
+    @pytest.mark.asyncio
+    async def test_body_keeps_legacy_error_field_for_backcompat(self):
+        # Anything still reading data.error from older builds keeps working.
+        resp = _json_error("Test message", 409, code="TEST_CODE")
+        body = json.loads(resp.body)
+        assert body["error"] == "TEST_CODE"
+
+    @pytest.mark.asyncio
+    async def test_default_code_is_generic_error(self):
+        resp = _json_error("Boom", 500)
+        body = json.loads(resp.body)
+        assert body["code"] == "ERROR"
+        assert body["error"] == "ERROR"
+
+    @pytest.mark.asyncio
+    async def test_status_code_is_set(self):
+        resp = _json_error("Bad input", 400, code="INVALID_REQUEST")
+        assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_game_in_lobby_response_shape(self):
+        # The specific case from #1097: ensure the GAME_IN_LOBBY response
+        # body carries `code` so admin.js's auto-recovery and i18n lookup
+        # both light up.
+        resp = _json_error(
+            "A game is already in the lobby — start gameplay instead",
+            409,
+            code="GAME_IN_LOBBY",
+        )
+        body = json.loads(resp.body)
+        assert body["code"] == "GAME_IN_LOBBY"
+        assert body["message"].startswith("A game is already in the lobby")


### PR DESCRIPTION
## Summary
- Walks back v3.4.0 stable to fix two regressions reported within hours of v3.4.0 release. v3.4.0 GitHub release has been removed; rc16 ships as a new pre-release.
- **#1096 — HA Companion App on iOS shows "Invalid redirect URI" when opening Beatify.** rc15 changed `redirect_uri` from the page URL to a new server-side callback path. Companion App rejects redirect_uris pointing at paths it doesn't recognize. Fix reverts `redirect_uri` to the page URL (Companion has accepted this since rc1) and threads the actual server-side exchange via a JS-level top-level navigation step. Safari 18 fix preserved end-to-end — the browser still never POSTs to an auth endpoint.
- **#1097 — German users see English error messages (and `GAME_IN_LOBBY` auto-recovery is dead).** `_json_error` wrote `{error: <code>, message: <text>}` but admin.js reads `data.code`. Field-name mismatch silently killed both the `GAME_IN_LOBBY` seamless-start auto-recovery and the `errors.<CODE>` i18n lookup. Fix emits both `code` and `error` (full backwards compat) and adds `errors.GAME_IN_LOBBY` to all 5 locales.

## Test plan
- [x] `python3 -m pytest tests/` → 539/539 (+5 `test_json_error` for body shape, +2 `test_auth_callback_view` for `redirect_uri` query-param forwarding)
- [x] `npx vitest run` → 98/98 (+2 `ha-auth.test` for the `?code=` bounce path and the rc16 `redirect_uri` shape)
- [ ] Markus tests HA Companion App on iOS — expect: Beatify opens without "Invalid redirect URI" on both LAN and Nabu Casa.
- [ ] Markus tests start-game on a German UI — expect: clicking "Spiel starten" with a LOBBY game already present silently transitions to gameplay (the auto-recovery), no modal with English message.
- [ ] Chrome / Safari 18 regression on either transport — same redirect chain works (one extra in-browser hop now: HA login → /beatify/admin?code → ha-auth.js navigates to /beatify/auth/callback?code → cookies set → /beatify/admin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)