### PR TITLE
release: v3.4.0-rc17 — launcher opens Beatify outside HA Companion App

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to Beatify are documented here. For detailed release notes, 
 
 ## [Unreleased]
 
+## [3.4.0-rc17] - 2026-05-22
+
+### Fixed
+- **HA Companion App on iOS — "Invalid redirect URI" still appears on rc16 (#1096 follow-up).** rc16's fix (revert `redirect_uri` to the page URL) wasn't enough — the Companion App on iOS intercepts `/auth/authorize` navigations inside its own WKWebView and runs its native auto-login flow with hardcoded values that don't match Beatify's client_id. The fix has to happen one layer earlier: don't let the OAuth flow run inside the Companion App's webview at all.
+- **Fix: launcher now uses `<a target="_blank" rel="noopener">` instead of a script-driven `window.open`.** From any webview (HA Companion on iOS / Android), `target="_blank"` opens the URL outside the webview — external Safari, Safari View Controller, or in-app Custom Tabs depending on platform and user settings. Each has its own cookie jar and runs the OAuth flow cleanly with no Companion-side interception. On desktop browsers iframed in the HA panel, the same `target="_blank"` opens a new top-level tab outside the iframe — same effect as the old `window.open` path. Trade-off: we lose the "click again to focus the existing tab" affordance the old launcher had, but the auth fix is the priority.
+
 ## [3.4.0-rc16] - 2026-05-22
 
 Walks back v3.4.0 stable to fix two regressions reported within hours of the v3.4.0 release. The v3.4.0 GitHub release has been removed; rc16 ships as the new pre-release while these fixes bake before re-cutting stable.

--- a/custom_components/beatify/manifest.json
+++ b/custom_components/beatify/manifest.json
@@ -12,5 +12,5 @@
   "documentation": "https://github.com/mholzi/beatify",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/mholzi/beatify/issues",
-  "version": "3.4.0-rc16"
+  "version": "3.4.0-rc17"
 }

--- a/custom_components/beatify/www/admin.html
+++ b/custom_components/beatify/www/admin.html
@@ -8,7 +8,7 @@
          query-string version, a stale en.json from a prior rc gets served
          after upgrade and references to newer keys render as raw strings.
          Bumped each rc alongside manifest.json + sw.js CACHE_VERSION. -->
-    <meta name="beatify-version" content="3.4.0-rc16">
+    <meta name="beatify-version" content="3.4.0-rc17">
     <!-- Self-healing SW recovery (rc11): an older-version service worker
          may serve a stale ha-auth.js even with cache-busters, leaving users
          in an unrecoverable login loop. Compare the current page's version
@@ -55,7 +55,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@700;900&display=swap" rel="stylesheet">
     <!-- Story 18.4: Use minified CSS in production -->
-    <link rel="stylesheet" href="/beatify/static/css/styles.min.css?v=3.4.0-rc16">
+    <link rel="stylesheet" href="/beatify/static/css/styles.min.css?v=3.4.0-rc17">
 </head>
 <body class="theme-dark">
     <!-- First-run wizard takeover (see DESIGN.md ## Patterns → First-run wizard) -->
@@ -1446,17 +1446,17 @@
     <!-- Story 18.4: Use minified JS in production with fallback to source -->
     <!-- Version query strings prevent browser caching issues -->
     <!-- #998: HA OAuth client — must load before any admin script uses BeatifyAuth -->
-    <script src="/beatify/static/js/ha-auth.js?v=3.4.0-rc16"></script>
+    <script src="/beatify/static/js/ha-auth.js?v=3.4.0-rc17"></script>
     <script src="/beatify/static/js/i18n.js?v=1.7.0"></script>
     <script src="/beatify/static/js/utils.js?v=1.7.0"></script>
     <!-- Story 44.1: Playlist requests module -->
-    <script src="/beatify/static/js/playlist-requests.min.js?v=3.4.0-rc16"></script>
+    <script src="/beatify/static/js/playlist-requests.min.js?v=3.4.0-rc17"></script>
     <!-- #1052: LLM-assisted playlist generator (load before playlist-hub so the Mine-tab button finds it) -->
-    <script src="/beatify/static/js/playlist-generator.min.js?v=3.4.0-rc16"></script>
-    <script type="module" src="/beatify/static/js/playlist-hub.js?v=3.4.0-rc16"></script>
-    <script type="module" src="/beatify/static/js/wizard.js?v=3.4.0-rc16"></script>
-    <script src="/beatify/static/js/admin.min.js?v=3.4.0-rc16"></script>
-    <script src="/beatify/static/js/party-lights.min.js?v=3.4.0-rc16"></script>
-    <script src="/beatify/static/js/tts-settings.js?v=3.4.0-rc16"></script>
+    <script src="/beatify/static/js/playlist-generator.min.js?v=3.4.0-rc17"></script>
+    <script type="module" src="/beatify/static/js/playlist-hub.js?v=3.4.0-rc17"></script>
+    <script type="module" src="/beatify/static/js/wizard.js?v=3.4.0-rc17"></script>
+    <script src="/beatify/static/js/admin.min.js?v=3.4.0-rc17"></script>
+    <script src="/beatify/static/js/party-lights.min.js?v=3.4.0-rc17"></script>
+    <script src="/beatify/static/js/tts-settings.js?v=3.4.0-rc17"></script>
 </body>
 </html>

--- a/custom_components/beatify/www/dashboard.html
+++ b/custom_components/beatify/www/dashboard.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <!-- #824: cache-bust i18n JSON fetches. See admin.html for rationale. -->
-    <meta name="beatify-version" content="3.4.0-rc16">
+    <meta name="beatify-version" content="3.4.0-rc17">
     <title data-i18n="dashboard.title">Beatify - Dashboard</title>
     <!-- Preconnect for faster font loading (Story 9.8) -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -12,7 +12,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Outfit:wght@700;900&display=swap" rel="stylesheet">
     <!-- Story 18.4: Use minified CSS in production -->
     <link rel="stylesheet" href="/beatify/static/css/styles.css?v=1.7.0">
-    <link rel="stylesheet" href="/beatify/static/css/dashboard.min.css?v=3.4.0-rc16">
+    <link rel="stylesheet" href="/beatify/static/css/dashboard.min.css?v=3.4.0-rc17">
     <!-- Confetti library for celebrations (Story 14.5) -->
     <script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.9.2/dist/confetti.browser.min.js"></script>
 </head>
@@ -285,7 +285,7 @@
     <!-- Version query strings prevent browser caching issues -->
     <script src="/beatify/static/js/i18n.js?v=1.7.0"></script>
     <script src="/beatify/static/js/utils.js?v=1.7.0"></script>
-    <script src="/beatify/static/js/dashboard.min.js?v=3.4.0-rc16"></script>
+    <script src="/beatify/static/js/dashboard.min.js?v=3.4.0-rc17"></script>
     <!-- v3.2.1 Arcade shims: submission meter fill, album ring progress, reveal round mirror.
          Pure view-layer helpers — no state, no API calls. Safe to remove if dashboard.js
          ever takes these over directly. -->

--- a/custom_components/beatify/www/launcher.html
+++ b/custom_components/beatify/www/launcher.html
@@ -115,73 +115,59 @@
         <span class="beat">Beat</span><span class="ify">ify</span>
     </div>
     <p class="message" id="message" data-i18n="launcher.clickToLaunch">Launch the game in fullscreen — no distractions.</p>
-    <button class="btn" id="openBtn" onclick="openBeatify()">
+    <a class="btn" id="openBtn" target="_blank" rel="noopener" href="#">
         <span class="btn-icon">🎵</span>
         <span data-i18n="launcher.openBeatify">Open Beatify</span>
-    </button>
+    </a>
     <p class="hint" id="hint"></p>
     <p class="status" id="status"></p>
 
     <script src="/beatify/static/js/i18n.js"></script>
     <script>
-        var beatifyWindow = null;
+        // rc17 (#1096): the launcher is an `<a target="_blank">` link
+        // instead of a script-driven `window.open`. Reason:
+        //
+        //   - HA Companion App on iOS intercepts `/auth/authorize`
+        //     navigations inside its own WKWebView and runs its native
+        //     auto-login flow, which uses a hardcoded client_id /
+        //     redirect_uri pair that doesn't match Beatify's. Result:
+        //     "Invalid redirect URI" 403 from HA's IndieAuth.
+        //   - `target="_blank"` from a Companion App webview opens the
+        //     URL OUTSIDE the webview (external Safari, or Safari View
+        //     Controller — both fine: each has its own cookie jar and
+        //     runs the OAuth flow cleanly with no Companion-side
+        //     interception).
+        //   - On desktop browsers iframed inside the HA panel,
+        //     `target="_blank"` opens a new top-level tab outside the
+        //     iframe — same effect as the old `window.open` path.
+        //   - On Android Companion, `target="_blank"` opens external
+        //     Chrome / Custom Tabs (or honors the user's preference).
+        //
+        // We lose the "focus existing tab" affordance the old window.open
+        // path had — acceptable trade for unblocking iOS Companion users.
 
-        function openBeatify() {
-            var adminUrl = window.location.origin + '/beatify/admin';
-
-            // HA Companion App and mobile WebViews block window.open(). Desktop
-            // browsers inside the HA sidebar iframe CAN open popups, so don't
-            // force same-tab navigation just because we're iframed — try popup
-            // first and fall back if it's blocked.
-            var isWebView = /HomeAssistant|wv|WebView/i.test(navigator.userAgent);
-
-            if (isWebView) {
-                window.location.href = adminUrl;
-                return;
-            }
-
-            // If we already have an open window, focus it
-            if (beatifyWindow && !beatifyWindow.closed) {
-                beatifyWindow.focus();
-                updateUI('focused');
-                return;
-            }
-
-            var messageEl = document.getElementById('message');
-            messageEl.classList.add('opening');
-
-            beatifyWindow = window.open(adminUrl, 'beatify_game', 'noopener');
-
-            if (beatifyWindow) {
-                updateUI('opened');
-            } else {
-                // Fallback if popup still blocked
-                window.location.href = adminUrl;
-            }
-        }
-
-        function updateUI(state) {
-            var messageEl = document.getElementById('message');
-            var hintEl = document.getElementById('hint');
-            var btnEl = document.getElementById('openBtn');
-            messageEl.classList.remove('opening');
-
-            if (state === 'opened') {
-                messageEl.textContent = BeatifyI18n.t('launcher.openedInNewTab') || 'Beatify is running in a new tab! 🎶';
-                hintEl.textContent = BeatifyI18n.t('launcher.clickToFocus') || 'Click again to focus the game tab';
-                btnEl.querySelector('[data-i18n]').textContent = BeatifyI18n.t('launcher.focusBeatify') || 'Focus Beatify';
-            } else if (state === 'focused') {
-                messageEl.textContent = BeatifyI18n.t('launcher.focusedTab') || 'Switched to Beatify tab! 🎯';
-            } else if (state === 'blocked') {
-                messageEl.textContent = BeatifyI18n.t('launcher.popupBlocked') || 'Pop-up was blocked by your browser.';
-                hintEl.innerHTML = BeatifyI18n.t('launcher.allowPopups') || 'Allow pop-ups for this site, or <a href="' + window.location.origin + '/beatify/admin" target="_blank" style="color: var(--color-accent-secondary);">click here</a> to open directly.';
-            }
-        }
-
-        // Initialize i18n
         window.addEventListener('load', async function() {
-            await BeatifyI18n.init();
-            BeatifyI18n.initPageTranslations();
+            // Set the href on load so we pick up window.location.origin
+            // dynamically (LAN, Nabu Casa, custom domain all just work).
+            var openBtn = document.getElementById('openBtn');
+            if (openBtn) openBtn.href = window.location.origin + '/beatify/admin';
+
+            // Once the user taps, update the launcher UI so it's obvious
+            // Beatify opened in another tab/window. target="_blank" still
+            // fires the click — we just decorate the same page after.
+            if (openBtn) openBtn.addEventListener('click', function() {
+                var msg = document.getElementById('message');
+                if (msg) {
+                    msg.textContent =
+                        (window.BeatifyI18n && BeatifyI18n.t('launcher.openedInNewTab')) ||
+                        'Beatify is running in a new tab! 🎶';
+                }
+            });
+
+            if (window.BeatifyI18n) {
+                await BeatifyI18n.init();
+                BeatifyI18n.initPageTranslations();
+            }
         });
     </script>
 </body>

--- a/custom_components/beatify/www/player.html
+++ b/custom_components/beatify/www/player.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <!-- #824: cache-bust i18n JSON fetches. See admin.html for rationale. -->
-    <meta name="beatify-version" content="3.4.0-rc16">
+    <meta name="beatify-version" content="3.4.0-rc17">
     <!-- Self-healing SW recovery (rc11) — see admin.html for the rationale. -->
     <script>
         (function() {
@@ -36,7 +36,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@700;900&display=swap" rel="stylesheet">
     <!-- Story 18.4: Use minified CSS in production -->
-    <link rel="stylesheet" href="/beatify/static/css/styles.min.css?v=3.4.0-rc16">
+    <link rel="stylesheet" href="/beatify/static/css/styles.min.css?v=3.4.0-rc17">
     <!-- Confetti library for celebrations (Story 14.5) -->
     <script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.9.2/dist/confetti.browser.min.js"></script>
 </head>
@@ -943,9 +943,9 @@
     <!-- Story 18.4: Use minified JS in production with fallback to source -->
     <!-- Version query strings prevent browser caching issues -->
     <!-- #998: HA OAuth client — only used when a host claims the admin role -->
-    <script src="/beatify/static/js/ha-auth.js?v=3.4.0-rc16"></script>
+    <script src="/beatify/static/js/ha-auth.js?v=3.4.0-rc17"></script>
     <script src="/beatify/static/js/i18n.min.js"></script>
     <script src="/beatify/static/js/utils.min.js"></script>
-    <script type="module" src="/beatify/static/js/player.bundle.min.js?v=3.4.0-rc16"></script>
+    <script type="module" src="/beatify/static/js/player.bundle.min.js?v=3.4.0-rc17"></script>
 </body>
 </html>

--- a/custom_components/beatify/www/sw.js
+++ b/custom_components/beatify/www/sw.js
@@ -6,7 +6,7 @@
  */
 'use strict';
 
-var CACHE_VERSION = 'beatify-v3.4.0-rc16';
+var CACHE_VERSION = 'beatify-v3.4.0-rc17';
 var MAX_CACHE_ITEMS = 50;
 
 // Critical assets to precache on install (minified versions only - fallback handled by HTML).


### PR DESCRIPTION
## Summary
- rc16's `redirect_uri` revert wasn't enough — Markus reports HA Companion App on iOS still shows "Invalid redirect URI". The Companion App intercepts `/auth/authorize` navigations inside its WKWebView and runs its native auto-login flow with hardcoded values that don't match Beatify's client_id. No OAuth tweak gets around this; the flow can't run inside the Companion webview at all.
- **Fix one layer up: launcher now opens Beatify outside the Companion webview.** `launcher.html` renders the "Open Beatify" button as `<a target="_blank" rel="noopener">` instead of a script-driven `window.open`. From any webview (HA Companion iOS / Android), `target="_blank"` opens the URL OUTSIDE the webview — external Safari, Safari View Controller, or in-app Custom Tabs depending on platform / user settings. Each has its own cookie jar and runs the OAuth flow cleanly.
- On desktop browsers iframed in the HA panel, the same `target="_blank"` opens a new top-level tab outside the iframe — same effect as the old `window.open` path.
- Trade-off: loses the "click again to focus existing tab" affordance. Acceptable for unblocking iOS Companion users.

## Test plan
- [x] `npx vitest run` → 98/98 pass
- [x] `python3 -m pytest tests/unit/test_auth_callback_view.py tests/unit/test_auth_refresh_view.py tests/unit/test_json_error.py` → 19/19 pass
- [ ] Markus tests HA Companion App on iOS: tap Beatify in HA sidebar → tap "Open Beatify" → expect external Safari (or in-app SFSafariViewController) to open with `/beatify/admin`, no "Invalid redirect URI", OAuth completes.
- [ ] Desktop browser regression: tap Beatify in HA sidebar → tap "Open Beatify" → expect new top-level tab outside the HA iframe, Beatify loads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)