### PR TITLE
release: v3.4.0-rc18 — restore rc15 OAuth flow on top of rc17 launcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to Beatify are documented here. For detailed release notes, 
 
 ## [Unreleased]
 
+## [3.4.0-rc18] - 2026-05-22
+
+### Fixed
+- **Safari auth loop on rc17 — restored the rc15 OAuth architecture (#1096 follow-up).** rc17's `target="_blank"` launcher correctly opens Beatify outside the HA Companion App webview, but rc16's leftover JS-bounce hop (`/beatify/admin?code=...` → ha-auth.js navigates to `/beatify/auth/callback`) tripped Safari 18 in a different way and brought back the pre-rc15 auth loop in external Safari. The bounce was a workaround for HA Companion's interception of `/auth/authorize`; the rc17 launcher already eliminates that by opening externally, so the bounce was both unnecessary and disruptive.
+- **Fix: ha-auth.js back to rc15's clean OAuth flow.** `redirect_uri` points directly at `/beatify/auth/callback`, the server-side callback runs the exchange, sets cookies, and 302s to `/beatify/admin?auth_state=…`. No JS-driven mid-flow navigation. The rc16/17 callback-view `redirect_uri` query-param handling reverted along with it. The rc17 launcher (`<a target="_blank">`) is preserved — that's the actual fix for HA Companion App, and it works without any OAuth-side adjustment.
+
+### Net architecture (rc18)
+- Launcher: `<a target="_blank">` opens Beatify in external Safari / Safari View Controller / Custom Tabs, outside any HA Companion webview.
+- OAuth: `redirect_uri = /beatify/auth/callback` (server-side endpoint); HA login → callback view exchanges over loopback → sets cookies → 302 to admin. No frontend POSTs to auth endpoints (Safari 18 fix preserved). No extra JS bounce (Safari 18 second-order fix preserved).
+
 ## [3.4.0-rc17] - 2026-05-22
 
 ### Fixed

--- a/custom_components/beatify/manifest.json
+++ b/custom_components/beatify/manifest.json
@@ -12,5 +12,5 @@
   "documentation": "https://github.com/mholzi/beatify",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/mholzi/beatify/issues",
-  "version": "3.4.0-rc17"
+  "version": "3.4.0-rc18"
 }

--- a/custom_components/beatify/server/views.py
+++ b/custom_components/beatify/server/views.py
@@ -357,23 +357,19 @@ class BeatifyAuthCallbackView(HomeAssistantView):
             return self._redirect_to_admin(request, error="missing_code")
 
         origin = _origin_from_request(request)
-        # rc16 (#1096): redirect_uri now arrives as a query param from
-        # ha-auth.js because the HA Companion App on iOS rejects callback-
-        # path redirect_uris with "Invalid redirect URI". ha-auth.js sends
-        # the page URL it told HA, and we forward that byte-identical
-        # value here per RFC 6749 §4.1.3. Fall back to the rc15 hardcoded
-        # value defensively if the param is missing.
-        redirect_uri = request.query.get(
-            "redirect_uri", f"{origin}/beatify/auth/callback"
-        )
+        # rc18: ha-auth.js's redirect_uri is /beatify/auth/callback again
+        # (rc15 architecture restored — the rc16 detour was unnecessary
+        # once the rc17 launcher started opening Beatify in external
+        # Safari via target="_blank", so HA Companion's interception of
+        # /auth/authorize is no longer a concern). client_id and
+        # redirect_uri MUST match what ha-auth.js sent to /auth/authorize
+        # per RFC 6749 §4.1.3.
         body = urlencode(
             {
                 "grant_type": "authorization_code",
                 "code": code,
-                # client_id mirrors what ha-auth.js computes:
-                # window.location.origin + '/beatify/'.
                 "client_id": f"{origin}/beatify/",
-                "redirect_uri": redirect_uri,
+                "redirect_uri": f"{origin}/beatify/auth/callback",
             }
         )
 

--- a/custom_components/beatify/www/admin.html
+++ b/custom_components/beatify/www/admin.html
@@ -8,7 +8,7 @@
          query-string version, a stale en.json from a prior rc gets served
          after upgrade and references to newer keys render as raw strings.
          Bumped each rc alongside manifest.json + sw.js CACHE_VERSION. -->
-    <meta name="beatify-version" content="3.4.0-rc17">
+    <meta name="beatify-version" content="3.4.0-rc18">
     <!-- Self-healing SW recovery (rc11): an older-version service worker
          may serve a stale ha-auth.js even with cache-busters, leaving users
          in an unrecoverable login loop. Compare the current page's version
@@ -55,7 +55,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@700;900&display=swap" rel="stylesheet">
     <!-- Story 18.4: Use minified CSS in production -->
-    <link rel="stylesheet" href="/beatify/static/css/styles.min.css?v=3.4.0-rc17">
+    <link rel="stylesheet" href="/beatify/static/css/styles.min.css?v=3.4.0-rc18">
 </head>
 <body class="theme-dark">
     <!-- First-run wizard takeover (see DESIGN.md ## Patterns → First-run wizard) -->
@@ -1446,17 +1446,17 @@
     <!-- Story 18.4: Use minified JS in production with fallback to source -->
     <!-- Version query strings prevent browser caching issues -->
     <!-- #998: HA OAuth client — must load before any admin script uses BeatifyAuth -->
-    <script src="/beatify/static/js/ha-auth.js?v=3.4.0-rc17"></script>
+    <script src="/beatify/static/js/ha-auth.js?v=3.4.0-rc18"></script>
     <script src="/beatify/static/js/i18n.js?v=1.7.0"></script>
     <script src="/beatify/static/js/utils.js?v=1.7.0"></script>
     <!-- Story 44.1: Playlist requests module -->
-    <script src="/beatify/static/js/playlist-requests.min.js?v=3.4.0-rc17"></script>
+    <script src="/beatify/static/js/playlist-requests.min.js?v=3.4.0-rc18"></script>
     <!-- #1052: LLM-assisted playlist generator (load before playlist-hub so the Mine-tab button finds it) -->
-    <script src="/beatify/static/js/playlist-generator.min.js?v=3.4.0-rc17"></script>
-    <script type="module" src="/beatify/static/js/playlist-hub.js?v=3.4.0-rc17"></script>
-    <script type="module" src="/beatify/static/js/wizard.js?v=3.4.0-rc17"></script>
-    <script src="/beatify/static/js/admin.min.js?v=3.4.0-rc17"></script>
-    <script src="/beatify/static/js/party-lights.min.js?v=3.4.0-rc17"></script>
-    <script src="/beatify/static/js/tts-settings.js?v=3.4.0-rc17"></script>
+    <script src="/beatify/static/js/playlist-generator.min.js?v=3.4.0-rc18"></script>
+    <script type="module" src="/beatify/static/js/playlist-hub.js?v=3.4.0-rc18"></script>
+    <script type="module" src="/beatify/static/js/wizard.js?v=3.4.0-rc18"></script>
+    <script src="/beatify/static/js/admin.min.js?v=3.4.0-rc18"></script>
+    <script src="/beatify/static/js/party-lights.min.js?v=3.4.0-rc18"></script>
+    <script src="/beatify/static/js/tts-settings.js?v=3.4.0-rc18"></script>
 </body>
 </html>

--- a/custom_components/beatify/www/dashboard.html
+++ b/custom_components/beatify/www/dashboard.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <!-- #824: cache-bust i18n JSON fetches. See admin.html for rationale. -->
-    <meta name="beatify-version" content="3.4.0-rc17">
+    <meta name="beatify-version" content="3.4.0-rc18">
     <title data-i18n="dashboard.title">Beatify - Dashboard</title>
     <!-- Preconnect for faster font loading (Story 9.8) -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -12,7 +12,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Outfit:wght@700;900&display=swap" rel="stylesheet">
     <!-- Story 18.4: Use minified CSS in production -->
     <link rel="stylesheet" href="/beatify/static/css/styles.css?v=1.7.0">
-    <link rel="stylesheet" href="/beatify/static/css/dashboard.min.css?v=3.4.0-rc17">
+    <link rel="stylesheet" href="/beatify/static/css/dashboard.min.css?v=3.4.0-rc18">
     <!-- Confetti library for celebrations (Story 14.5) -->
     <script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.9.2/dist/confetti.browser.min.js"></script>
 </head>
@@ -285,7 +285,7 @@
     <!-- Version query strings prevent browser caching issues -->
     <script src="/beatify/static/js/i18n.js?v=1.7.0"></script>
     <script src="/beatify/static/js/utils.js?v=1.7.0"></script>
-    <script src="/beatify/static/js/dashboard.min.js?v=3.4.0-rc17"></script>
+    <script src="/beatify/static/js/dashboard.min.js?v=3.4.0-rc18"></script>
     <!-- v3.2.1 Arcade shims: submission meter fill, album ring progress, reveal round mirror.
          Pure view-layer helpers — no state, no API calls. Safe to remove if dashboard.js
          ever takes these over directly. -->

--- a/custom_components/beatify/www/js/__tests__/ha-auth.test.js
+++ b/custom_components/beatify/www/js/__tests__/ha-auth.test.js
@@ -255,60 +255,25 @@ describe('init() auth callback handling', () => {
 });
 
 describe('login() OAuth redirect', () => {
-    it('uses the page URL as redirect_uri (rc16: Companion App accepts only registered paths)', () => {
-        // rc15 pointed redirect_uri at /beatify/auth/callback, which the HA
-        // iOS Companion App rejected as "Invalid redirect URI". rc16
-        // reverts to the page URL (the value Companion accepted for years)
-        // and routes the code via JS into the callback view instead.
+    it('uses /beatify/auth/callback as redirect_uri (rc18: restored from rc15)', () => {
+        // rc16/rc17 routed redirect_uri at the page URL with a JS-bounce
+        // hop to dodge HA Companion App's webview interception. rc18
+        // restores rc15's clean architecture because the rc17 launcher's
+        // target="_blank" already opens Beatify in external Safari
+        // outside the Companion webview, so Companion's interception is
+        // no longer reachable. Restoring the direct server-side
+        // callback removes the extra navigation hop that broke Safari 18.
         const { BeatifyAuth, sandboxWindow } = loadHaAuth({});
         BeatifyAuth.login();
         const url = sandboxWindow.location._lastReplace;
         expect(url).toContain('/auth/authorize');
         expect(url).toContain('response_type=code');
         expect(url).toContain(
-            'redirect_uri=' + encodeURIComponent('https://ha.example/beatify/admin')
+            'redirect_uri=' + encodeURIComponent('https://ha.example/beatify/auth/callback')
         );
         // client_id is origin + /beatify/ (unchanged across RCs).
         expect(url).toContain(
             'client_id=' + encodeURIComponent('https://ha.example/beatify/')
         );
-    });
-});
-
-describe('init() ?code= bounce to callback (rc16)', () => {
-    it('navigates to /beatify/auth/callback when ?code=&state= arrive on the page', async () => {
-        const { BeatifyAuth, sandboxWindow } = loadHaAuth({});
-        sandboxWindow.location.search = '?code=AUTH_CODE_123&state=state-xyz';
-
-        const result = await Promise.race([
-            BeatifyAuth.init({ requireAuth: true }),
-            new Promise((r) => setTimeout(() => r('SUSPENDED'), 5)),
-        ]);
-        expect(result).toBe('SUSPENDED');
-
-        const navigated = sandboxWindow.location._lastReplace;
-        expect(navigated).toContain('/beatify/auth/callback');
-        expect(navigated).toContain('code=AUTH_CODE_123');
-        expect(navigated).toContain('state=state-xyz');
-        // The redirect_uri threaded through must be byte-identical to
-        // what login() sent to /auth/authorize, per RFC 6749 §4.1.3.
-        expect(navigated).toContain(
-            'redirect_uri=' + encodeURIComponent('https://ha.example/beatify/admin')
-        );
-    });
-
-    it('does not bounce when there is no ?code= (regular page load)', async () => {
-        const fetchFn = async () => ({ ok: false, status: 401, json: async () => ({}) });
-        const { BeatifyAuth, sandboxWindow } = loadHaAuth({ fetchFn });
-        // No ?code= — init must fall through to refreshAccess (and on
-        // failure, login()), NOT bounce to the callback view.
-        const result = await Promise.race([
-            BeatifyAuth.init({ requireAuth: true }),
-            new Promise((r) => setTimeout(() => r('SUSPENDED'), 5)),
-        ]);
-        expect(result).toBe('SUSPENDED');
-        // login() was called (target is /auth/authorize, not callback view).
-        expect(sandboxWindow.location._lastReplace).toContain('/auth/authorize');
-        expect(sandboxWindow.location._lastReplace).not.toContain('/beatify/auth/callback');
     });
 });

--- a/custom_components/beatify/www/js/ha-auth.js
+++ b/custom_components/beatify/www/js/ha-auth.js
@@ -61,14 +61,17 @@
     return origin() + '/beatify/';
   }
   function redirectUri() {
-    // rc16 (#1096): the HA Companion App on iOS rejects /auth/authorize
-    // with "Invalid redirect URI" when redirect_uri points at a path
-    // it doesn't recognize. Sending the page URL itself (the value used
-    // up through rc14) is the only redirect_uri shape Companion accepts.
-    // The server-side callback view still handles the code exchange —
-    // ha-auth.js detects the ?code= echo on this page and navigates to
-    // /beatify/auth/callback as a separate step (see _bounceCodeToCallback).
-    return origin() + window.location.pathname;
+    // rc18: back to the rc15 architecture — redirect_uri points at the
+    // server-side callback view directly. The intermediate rc16/rc17
+    // detour (redirect_uri = page URL, then JS-bounce to the callback
+    // view) was a workaround for HA Companion App intercepting
+    // /auth/authorize inside its WKWebView. rc17's launcher change
+    // (`<a target="_blank">`) already opens Beatify in external Safari
+    // outside Companion's webview, so Companion never sees the OAuth
+    // flow at all — making the JS bounce both unnecessary and
+    // disruptive (Safari 18 broke when an extra script-driven nav
+    // happened during the OAuth-callback page load).
+    return origin() + '/beatify/auth/callback';
   }
 
   function randomState() {
@@ -195,34 +198,6 @@
       '&state=' +
       encodeURIComponent(state);
     window.location.replace(url);
-  }
-
-  /**
-   * Forward a freshly-arrived OAuth code to the server-side callback view.
-   *
-   * HA redirected us back to ``${origin}${pathname}?code=…&state=…`` because
-   * that's the redirect_uri the HA Companion App accepts (see ``redirectUri``).
-   * The actual exchange must happen server-side (Safari 18 can't POST it from
-   * the browser); navigate to the callback view, passing the exact
-   * redirect_uri HA saw so the loopback exchange can satisfy RFC 6749 §4.1.3.
-   *
-   * Returns true when navigation has been initiated — caller should suspend.
-   */
-  function _bounceCodeToCallback() {
-    var params = new URLSearchParams(window.location.search);
-    var code = params.get('code');
-    var state = params.get('state');
-    if (!code) return false;
-    var url =
-      origin() +
-      '/beatify/auth/callback?code=' +
-      encodeURIComponent(code) +
-      '&state=' +
-      encodeURIComponent(state || '') +
-      '&redirect_uri=' +
-      encodeURIComponent(redirectUri());
-    window.location.replace(url);
-    return true;
   }
 
   /**
@@ -377,16 +352,6 @@
   function init(options) {
     options = options || {};
     _migrateFromLocalStorage();
-
-    // If we arrived from /auth/authorize with ?code=&state=, forward
-    // to the server-side callback view. This is the rc16 detour: HA's
-    // redirect lands on the page itself (the only redirect_uri the
-    // Companion App accepts) and we hop one extra step to do the
-    // exchange server-side. Navigation is in-flight; suspend init.
-    if (_bounceCodeToCallback()) {
-      return new Promise(function () {});
-    }
-
     var callbackResult = _consumeAuthCallback();
 
     // callbackResult === false means the server-side exchange reported a

--- a/custom_components/beatify/www/player.html
+++ b/custom_components/beatify/www/player.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <!-- #824: cache-bust i18n JSON fetches. See admin.html for rationale. -->
-    <meta name="beatify-version" content="3.4.0-rc17">
+    <meta name="beatify-version" content="3.4.0-rc18">
     <!-- Self-healing SW recovery (rc11) — see admin.html for the rationale. -->
     <script>
         (function() {
@@ -36,7 +36,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@700;900&display=swap" rel="stylesheet">
     <!-- Story 18.4: Use minified CSS in production -->
-    <link rel="stylesheet" href="/beatify/static/css/styles.min.css?v=3.4.0-rc17">
+    <link rel="stylesheet" href="/beatify/static/css/styles.min.css?v=3.4.0-rc18">
     <!-- Confetti library for celebrations (Story 14.5) -->
     <script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.9.2/dist/confetti.browser.min.js"></script>
 </head>
@@ -943,9 +943,9 @@
     <!-- Story 18.4: Use minified JS in production with fallback to source -->
     <!-- Version query strings prevent browser caching issues -->
     <!-- #998: HA OAuth client — only used when a host claims the admin role -->
-    <script src="/beatify/static/js/ha-auth.js?v=3.4.0-rc17"></script>
+    <script src="/beatify/static/js/ha-auth.js?v=3.4.0-rc18"></script>
     <script src="/beatify/static/js/i18n.min.js"></script>
     <script src="/beatify/static/js/utils.min.js"></script>
-    <script type="module" src="/beatify/static/js/player.bundle.min.js?v=3.4.0-rc17"></script>
+    <script type="module" src="/beatify/static/js/player.bundle.min.js?v=3.4.0-rc18"></script>
 </body>
 </html>

--- a/custom_components/beatify/www/sw.js
+++ b/custom_components/beatify/www/sw.js
@@ -6,7 +6,7 @@
  */
 'use strict';
 
-var CACHE_VERSION = 'beatify-v3.4.0-rc17';
+var CACHE_VERSION = 'beatify-v3.4.0-rc18';
 var MAX_CACHE_ITEMS = 50;
 
 // Critical assets to precache on install (minified versions only - fallback handled by HTML).

--- a/tests/unit/test_auth_callback_view.py
+++ b/tests/unit/test_auth_callback_view.py
@@ -66,48 +66,11 @@ class TestBeatifyAuthCallbackView:
         assert "auth_error=missing_code" in resp.headers["Location"]
 
     @pytest.mark.asyncio
-    async def test_forwards_redirect_uri_query_param_to_loopback_exchange(self):
-        # rc16 (#1096): ha-auth.js passes the page URL it told HA as the
-        # redirect_uri query param. We must forward that byte-identical
-        # value to /auth/token (RFC 6749 §4.1.3), NOT hardcode our own.
-        view = BeatifyAuthCallbackView(_hass())
-        mock_session = MagicMock()
-        mock_session.post = MagicMock(
-            return_value=_MockResponseCtx(
-                status=200,
-                text=(
-                    '{"access_token":"a","refresh_token":"r","expires_in":1800}'
-                ),
-            )
-        )
-
-        with patch(
-            "custom_components.beatify.server.views.async_get_clientsession",
-            return_value=mock_session,
-        ):
-            await view.get(
-                _request(
-                    {
-                        "code": "abc",
-                        "state": "xyz",
-                        # The page URL ha-auth.js used as redirect_uri at
-                        # /auth/authorize. The Companion App accepts this.
-                        "redirect_uri": "http://ha.local:8123/beatify/admin",
-                    }
-                )
-            )
-
-        call_body = mock_session.post.call_args.kwargs["data"]
-        # urlencoded body — the forwarded redirect_uri must match.
-        assert (
-            "redirect_uri=http%3A%2F%2Fha.local%3A8123%2Fbeatify%2Fadmin"
-            in call_body
-        )
-
-    @pytest.mark.asyncio
-    async def test_falls_back_to_legacy_callback_redirect_uri_when_param_missing(self):
-        # Defensive fallback for the rc15 frontend that didn't send a
-        # redirect_uri param. Should keep working until everyone's on rc16+.
+    async def test_loopback_exchange_uses_callback_redirect_uri(self):
+        # rc18: redirect_uri is the callback view itself, matching what
+        # ha-auth.js sends to /auth/authorize per RFC 6749 §4.1.3. The
+        # rc16 query-param-forwarding mechanism was reverted along with
+        # the JS-bounce architecture it supported.
         view = BeatifyAuthCallbackView(_hass())
         mock_session = MagicMock()
         mock_session.post = MagicMock(
@@ -124,9 +87,12 @@ class TestBeatifyAuthCallbackView:
             await view.get(_request({"code": "abc", "state": "xyz"}))
 
         call_body = mock_session.post.call_args.kwargs["data"]
-        # Falls back to the rc15 hardcoded callback URL.
-        assert "redirect_uri=" in call_body
-        assert "%2Fbeatify%2Fauth%2Fcallback" in call_body
+        # The exchange must send redirect_uri = callback URL itself.
+        assert (
+            "redirect_uri=http%3A%2F%2Fha.local%3A8123%2Fbeatify%2Fauth%2Fcallback"
+            in call_body
+        )
+        assert "client_id=http%3A%2F%2Fha.local%3A8123%2Fbeatify%2F" in call_body
 
     @pytest.mark.asyncio
     async def test_successful_exchange_sets_cookies_and_redirects(self):


### PR DESCRIPTION
## Summary
- rc17's launcher (`<a target="_blank">`) correctly opens Beatify outside the HA Companion App's webview — that's the right fix for #1096. But rc16's leftover JS-bounce hop in ha-auth.js (`/beatify/admin?code=…` → JS navigates to `/beatify/auth/callback`) tripped Safari 18 in a different way and brought back the pre-rc15 auth loop in external Safari. Markus reports this in the rc17 PR comments.
- The JS-bounce was a workaround for Companion's webview interception of `/auth/authorize`; rc17's launcher already solves that by opening externally. So the bounce was both unnecessary and disruptive.
- **rc18: revert ha-auth.js to the rc15 OAuth architecture.** `redirect_uri = /beatify/auth/callback` (direct server-side endpoint); HA redirects there after login; callback view exchanges + sets cookies + 302s to admin. No JS-driven mid-flow navigation. Removes `_bounceCodeToCallback`, shortens `init()`. Callback view's rc16 `redirect_uri` query-param handling reverted along with it.
- rc17 launcher preserved — that's the actual fix for HA Companion App.

## Test plan
- [x] `npx vitest run` → 96/96 (-2: removed rc16 `?code=` bounce tests, restored login `redirect_uri` expectation to `/beatify/auth/callback`)
- [x] `python3 -m pytest tests/` → 538/538 (-1: removed rc16 `redirect_uri` query-param tests)
- [ ] Markus tests on external Safari (via launcher's "Open Beatify" button from HA Companion App on iOS) — expect: no auth loop, admin loads normally after one HA login.
- [ ] Direct Safari (not via Companion) — expect: same clean OAuth flow as rc15.
- [ ] Chrome on either transport — expect: same flow works.

## Net architecture after rc18
- **Launcher:** `<a target="_blank">` opens Beatify externally (Safari / Safari View Controller / Custom Tabs), outside any HA Companion webview.
- **OAuth:** clean rc15 flow — `redirect_uri = /beatify/auth/callback`, no JS bounce, no frontend POSTs to auth endpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)