### PR TITLE
release: v3.4.1 — re-cut of v3.4.0 with Companion App + i18n fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to Beatify are documented here. For detailed release notes, 
 
 ## [Unreleased]
 
+## [3.4.1] - 2026-05-22
+
+Re-cut of the v3.4.0 line after the original stable was pulled to fix two regressions found within hours of release. Contains everything in v3.4.0 plus the rc16–rc18 fix series.
+
+### Fixed (since v3.4.0)
+- **HA Companion App on iOS — "Invalid redirect URI" on Beatify open (#1096).** Companion App intercepts `/auth/authorize` navigations inside its WKWebView and runs its native auto-login flow with hardcoded values that don't match Beatify's client_id. Fix: launcher now opens Beatify via `<a target="_blank" rel="noopener">` so the URL opens outside the Companion webview (external Safari, Safari View Controller, or Custom Tabs depending on platform). OAuth flow then runs in a clean browser context with no Companion-side interception.
+- **REST error responses now expose `data.code` (#1097).** `_json_error` was writing `{error: <code>, message: <text>}` but the frontend reads `data.code` (matching the WebSocket error shape). Mismatch silently killed both the `GAME_IN_LOBBY` seamless-start auto-recovery and the `errors.<CODE>` i18n lookup — non-English locales got the raw English `message` for every REST-side error. Fix emits both `code` and `error` (backwards-compat); added `errors.GAME_IN_LOBBY` translation to en/de/es/fr/nl.
+
+### Patch test totals
+- 538 Python pass (+5 for `_json_error` body shape, callback view tests adjusted for the rc18 architecture restore)
+- 96 JS pass (+1 net after the rc16-bounce tests retired)
+
 ## [3.4.0-rc18] - 2026-05-22
 
 ### Fixed

--- a/custom_components/beatify/manifest.json
+++ b/custom_components/beatify/manifest.json
@@ -12,5 +12,5 @@
   "documentation": "https://github.com/mholzi/beatify",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/mholzi/beatify/issues",
-  "version": "3.4.0-rc18"
+  "version": "3.4.1"
 }

--- a/custom_components/beatify/www/admin.html
+++ b/custom_components/beatify/www/admin.html
@@ -8,7 +8,7 @@
          query-string version, a stale en.json from a prior rc gets served
          after upgrade and references to newer keys render as raw strings.
          Bumped each rc alongside manifest.json + sw.js CACHE_VERSION. -->
-    <meta name="beatify-version" content="3.4.0-rc18">
+    <meta name="beatify-version" content="3.4.1">
     <!-- Self-healing SW recovery (rc11): an older-version service worker
          may serve a stale ha-auth.js even with cache-busters, leaving users
          in an unrecoverable login loop. Compare the current page's version
@@ -55,7 +55,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@700;900&display=swap" rel="stylesheet">
     <!-- Story 18.4: Use minified CSS in production -->
-    <link rel="stylesheet" href="/beatify/static/css/styles.min.css?v=3.4.0-rc18">
+    <link rel="stylesheet" href="/beatify/static/css/styles.min.css?v=3.4.1">
 </head>
 <body class="theme-dark">
     <!-- First-run wizard takeover (see DESIGN.md ## Patterns → First-run wizard) -->
@@ -1446,17 +1446,17 @@
     <!-- Story 18.4: Use minified JS in production with fallback to source -->
     <!-- Version query strings prevent browser caching issues -->
     <!-- #998: HA OAuth client — must load before any admin script uses BeatifyAuth -->
-    <script src="/beatify/static/js/ha-auth.js?v=3.4.0-rc18"></script>
+    <script src="/beatify/static/js/ha-auth.js?v=3.4.1"></script>
     <script src="/beatify/static/js/i18n.js?v=1.7.0"></script>
     <script src="/beatify/static/js/utils.js?v=1.7.0"></script>
     <!-- Story 44.1: Playlist requests module -->
-    <script src="/beatify/static/js/playlist-requests.min.js?v=3.4.0-rc18"></script>
+    <script src="/beatify/static/js/playlist-requests.min.js?v=3.4.1"></script>
     <!-- #1052: LLM-assisted playlist generator (load before playlist-hub so the Mine-tab button finds it) -->
-    <script src="/beatify/static/js/playlist-generator.min.js?v=3.4.0-rc18"></script>
-    <script type="module" src="/beatify/static/js/playlist-hub.js?v=3.4.0-rc18"></script>
-    <script type="module" src="/beatify/static/js/wizard.js?v=3.4.0-rc18"></script>
-    <script src="/beatify/static/js/admin.min.js?v=3.4.0-rc18"></script>
-    <script src="/beatify/static/js/party-lights.min.js?v=3.4.0-rc18"></script>
-    <script src="/beatify/static/js/tts-settings.js?v=3.4.0-rc18"></script>
+    <script src="/beatify/static/js/playlist-generator.min.js?v=3.4.1"></script>
+    <script type="module" src="/beatify/static/js/playlist-hub.js?v=3.4.1"></script>
+    <script type="module" src="/beatify/static/js/wizard.js?v=3.4.1"></script>
+    <script src="/beatify/static/js/admin.min.js?v=3.4.1"></script>
+    <script src="/beatify/static/js/party-lights.min.js?v=3.4.1"></script>
+    <script src="/beatify/static/js/tts-settings.js?v=3.4.1"></script>
 </body>
 </html>

--- a/custom_components/beatify/www/dashboard.html
+++ b/custom_components/beatify/www/dashboard.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <!-- #824: cache-bust i18n JSON fetches. See admin.html for rationale. -->
-    <meta name="beatify-version" content="3.4.0-rc18">
+    <meta name="beatify-version" content="3.4.1">
     <title data-i18n="dashboard.title">Beatify - Dashboard</title>
     <!-- Preconnect for faster font loading (Story 9.8) -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -12,7 +12,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Outfit:wght@700;900&display=swap" rel="stylesheet">
     <!-- Story 18.4: Use minified CSS in production -->
     <link rel="stylesheet" href="/beatify/static/css/styles.css?v=1.7.0">
-    <link rel="stylesheet" href="/beatify/static/css/dashboard.min.css?v=3.4.0-rc18">
+    <link rel="stylesheet" href="/beatify/static/css/dashboard.min.css?v=3.4.1">
     <!-- Confetti library for celebrations (Story 14.5) -->
     <script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.9.2/dist/confetti.browser.min.js"></script>
 </head>
@@ -285,7 +285,7 @@
     <!-- Version query strings prevent browser caching issues -->
     <script src="/beatify/static/js/i18n.js?v=1.7.0"></script>
     <script src="/beatify/static/js/utils.js?v=1.7.0"></script>
-    <script src="/beatify/static/js/dashboard.min.js?v=3.4.0-rc18"></script>
+    <script src="/beatify/static/js/dashboard.min.js?v=3.4.1"></script>
     <!-- v3.2.1 Arcade shims: submission meter fill, album ring progress, reveal round mirror.
          Pure view-layer helpers — no state, no API calls. Safe to remove if dashboard.js
          ever takes these over directly. -->

--- a/custom_components/beatify/www/player.html
+++ b/custom_components/beatify/www/player.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <!-- #824: cache-bust i18n JSON fetches. See admin.html for rationale. -->
-    <meta name="beatify-version" content="3.4.0-rc18">
+    <meta name="beatify-version" content="3.4.1">
     <!-- Self-healing SW recovery (rc11) — see admin.html for the rationale. -->
     <script>
         (function() {
@@ -36,7 +36,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@700;900&display=swap" rel="stylesheet">
     <!-- Story 18.4: Use minified CSS in production -->
-    <link rel="stylesheet" href="/beatify/static/css/styles.min.css?v=3.4.0-rc18">
+    <link rel="stylesheet" href="/beatify/static/css/styles.min.css?v=3.4.1">
     <!-- Confetti library for celebrations (Story 14.5) -->
     <script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.9.2/dist/confetti.browser.min.js"></script>
 </head>
@@ -943,9 +943,9 @@
     <!-- Story 18.4: Use minified JS in production with fallback to source -->
     <!-- Version query strings prevent browser caching issues -->
     <!-- #998: HA OAuth client — only used when a host claims the admin role -->
-    <script src="/beatify/static/js/ha-auth.js?v=3.4.0-rc18"></script>
+    <script src="/beatify/static/js/ha-auth.js?v=3.4.1"></script>
     <script src="/beatify/static/js/i18n.min.js"></script>
     <script src="/beatify/static/js/utils.min.js"></script>
-    <script type="module" src="/beatify/static/js/player.bundle.min.js?v=3.4.0-rc18"></script>
+    <script type="module" src="/beatify/static/js/player.bundle.min.js?v=3.4.1"></script>
 </body>
 </html>

--- a/custom_components/beatify/www/sw.js
+++ b/custom_components/beatify/www/sw.js
@@ -6,7 +6,7 @@
  */
 'use strict';
 
-var CACHE_VERSION = 'beatify-v3.4.0-rc18';
+var CACHE_VERSION = 'beatify-v3.4.1';
 var MAX_CACHE_ITEMS = 50;
 
 // Critical assets to precache on install (minified versions only - fallback handled by HTML).


### PR DESCRIPTION
## Summary
Stable promotion of the v3.4.0-rc18 line. Re-cut of v3.4.0 after the original stable was pulled to fix two regressions found within hours of release.

Contains everything in v3.4.0 plus the rc16–rc18 fix series:
- **#1096** — HA Companion App on iOS shows "Invalid redirect URI". Launcher now uses `<a target="_blank">` to open Beatify outside the Companion webview.
- **#1097** — REST error responses now expose `data.code`. Resurrects the silently-dead `GAME_IN_LOBBY` auto-recovery and i18n-by-code lookup; adds `errors.GAME_IN_LOBBY` translation to all five locales.

Version markers consolidated 3.4.0-rc18 → 3.4.1 (manifest, 3× HTML meta, all admin/player/dashboard `?v=` cache-busters, sw.js CACHE_VERSION). CHANGELOG section added.

## Test plan
- [x] `python3 -m pytest tests/` → 538/538 pass
- [x] `npx vitest run` → 96/96 pass
- [ ] HACS install/upgrade verify after release
- [ ] HA Companion App on iOS: tap Beatify → "Open Beatify" → external Safari opens cleanly, login works
- [ ] Regular browser flow: admin loads cleanly with no auth loop

🤖 Generated with [Claude Code](https://claude.com/claude-code)