### PR TITLE
feat(playlist-hub): drop Editor's Picks from Bundled, add By Style to Community (#1108)

### DIFF
--- a/custom_components/beatify/www/i18n/de.json
+++ b/custom_components/beatify/www/i18n/de.json
@@ -1107,7 +1107,9 @@
     },
     "sections": {
       "byCountry": "Nach Land",
-      "countries": "Länder"
+      "byStyle": "Nach Stil",
+      "countries": "Länder",
+      "styles": "Stile"
     },
     "selected": {
       "title": "Deine ausgewählten Playlists",

--- a/custom_components/beatify/www/i18n/en.json
+++ b/custom_components/beatify/www/i18n/en.json
@@ -1107,7 +1107,9 @@
     },
     "sections": {
       "byCountry": "By Country",
-      "countries": "countries"
+      "byStyle": "By Style",
+      "countries": "countries",
+      "styles": "styles"
     },
     "selected": {
       "title": "Your selected playlists",

--- a/custom_components/beatify/www/js/playlist-hub.js
+++ b/custom_components/beatify/www/js/playlist-hub.js
@@ -657,16 +657,11 @@ function _renderBundled(host) {
         }));
     }
 
-    // Editor's Picks — featured (sorted by song_count desc, top 5)
-    const featured = [...filtered].sort((a, b) => (b.song_count || 0) - (a.song_count || 0)).slice(0, 5);
-    if (featured.length > 0) {
-        html.push(_shelfHtml({
-            title: `✨ ${_t('playlistHub.shelves.editorsPicks', "Editor's Picks")}`,
-            featured: true,
-            see: _t('playlistHub.seeAll', 'See all'),
-            cards: featured.map((p) => _cardHtml(p, { featured: true })),
-        }));
-    }
+    // #1108: "Editor's Picks" was just top-5-by-song-count on the Bundled
+    // tab — not actual curation, and the song-count proxy is misleading.
+    // Removed from Bundled. The Community tab keeps its equivalent shelf
+    // where "popular by song-count" is a more defensible signal for
+    // user-contributed content.
 
     // Genre shelves (up to 4)
     const genreShelves = groupByGenreShelves(filtered, 4);
@@ -788,6 +783,36 @@ function _renderCommunity(host) {
                     see: `${items.length}`,
                     cards: items.slice(0, 8).map((p) => _cardHtml(p, { community: true, showAuthor: true })),
                 }));
+            }
+        }
+
+        // #1108: By Style — same idea as By Country, but for community
+        // playlists that have no language label (instrumental, electronic,
+        // movie soundtracks, etc.). Without this section those playlists
+        // are invisible in the structured view and only show up in
+        // Editor's Picks / Recently added / Regional & Specialty (if any).
+        const noLang = all.filter((p) => !(p.language || '').trim());
+        if (noLang.length >= 2) {
+            const styleShelves = groupByGenreShelves(noLang, 4);
+            if (styleShelves.length >= 1) {
+                const totalStyles = styleShelves.length;
+                const totalPlaylists = styleShelves.reduce((n, s) => n + s.items.length, 0);
+                html.push(`
+                    <div class="plh-section-head">
+                        <div class="plh-section-head-title">
+                            <span class="plh-section-head-emoji">🎨</span>
+                            <span>${_escape(_t('playlistHub.sections.byStyle', 'By Style'))}</span>
+                        </div>
+                        <div class="plh-section-head-meta">${totalStyles} ${_escape(_t('playlistHub.sections.styles', 'styles'))} · ${totalPlaylists} ${_escape(_t('playlistHub.songs', 'playlists'))}</div>
+                    </div>
+                `);
+                for (const g of styleShelves) {
+                    html.push(_shelfHtml({
+                        title: _t(g.genre.key, g.genre.fallback),
+                        see: `${g.items.length}`,
+                        cards: g.items.slice(0, 8).map((p) => _cardHtml(p, { community: true, showAuthor: true })),
+                    }));
+                }
             }
         }
 


### PR DESCRIPTION
Closes #1108.

## Summary

Two related Playlist Hub tweaks:

### 1. Bundled tab — remove "Editor's Picks ✨"
It was just top-5-by-song-count, not actual curation. On the Bundled tab (which is already a hand-picked set), the song-count ranking wasn't a meaningful signal — looked like editorial recommendation when it wasn't. Removed.

**New Bundled order:** Your most-played → Recently played → Genre shelves → Community peek.

The Community tab keeps its equivalent Editor's Picks shelf where song-count is a more defensible "popular by content size" proxy for user-contributed content.

### 2. Community tab — add "By Style" 🎨
Parallel to "By Country", but for community playlists that have no `language` label (instrumental, electronic, movie soundtracks, etc.). Before this PR those playlists were invisible in the structured view — only appearing in Editor's Picks, search, or Recently added / Regional & Specialty if applicable.

Grouped by genre tag (reuses `GENRE_TAXONOMY` first-match-wins logic) with the same `≥2 items per shelf` gating as By Country.

**New Community order:** Request banner → Editor's Picks → By Country → **By Style** *(new)* → Recently added → Regional & Specialty.

### i18n
Added `playlistHub.sections.byStyle` / `.styles` to en + de. es/fr/nl fall back to the inline English defaults (same pattern as the rest of the `playlistHub` block — those locales don't translate it today).

## Test plan
- [x] `npx vitest run` → 96/96 pass
- [ ] Visual check: Bundled tab no longer shows "Editor's Picks" shelf
- [ ] Visual check: Community tab — with current data (all 20 community playlists have a `language`), "By Style" doesn't render (correct — needs ≥2 language-less community playlists). To verify the new section actually appears, temporarily blank out the `language` field on 2 community playlists.

## Notes

No backend or test changes; pure UI rendering update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)