### PR TITLE
fix(#1111): admin browser advance button is "Next", not "Skip"

### DIFF
--- a/custom_components/beatify/www/admin.html
+++ b/custom_components/beatify/www/admin.html
@@ -1115,9 +1115,17 @@
                 <span class="control-icon">🔊</span>
                 <span class="control-label" data-i18n="admin.volUp">Up</span>
             </button>
+            <!-- #1111: same handler as the in-page "Next Round" button
+                 (`adminNextRound`). Used to say "Skip" / "Überspringen",
+                 but that read as "skip this", not "advance round" — users
+                 with the in-page button below the fold concluded there
+                 was no way to advance and fell back to End Game. The
+                 player view's identical-function button at
+                 player.html:775 has used `admin.next` for years, so just
+                 align the admin browser to the same key. -->
             <button id="admin-skip-round" class="control-btn" type="button">
                 <span class="control-icon">⏭️</span>
-                <span class="control-label" data-i18n="admin.skipRound">Skip</span>
+                <span class="control-label" data-i18n="admin.next">Next</span>
             </button>
             <button id="admin-end-game-playing" class="control-btn control-btn--danger" type="button">
                 <span class="control-icon">🛑</span>

--- a/tests/unit/test_next_round_label_parity.py
+++ b/tests/unit/test_next_round_label_parity.py
@@ -1,0 +1,64 @@
+"""Regression test for #1111 — admin browser and player view "Next Round"
+control-bar buttons must use the same i18n label key.
+
+Both buttons invoke the same `adminNextRound` handler and send the same
+WebSocket `{type: admin, action: next_round}` message. The user-facing
+label must match — historically the admin browser said "Skip" /
+"Überspringen" which read as "skip this", not "advance round". A German
+user (#1111, Max Lindner) didn't recognize the affordance and fell back
+to End Game when their timer expired without all submissions.
+
+This test pins the invariant: both buttons must reference the same
+i18n key so the labels can't drift apart again.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+WWW = Path(__file__).parent.parent.parent / "custom_components" / "beatify" / "www"
+
+
+def _data_i18n_for(html_path: Path, button_id: str) -> str:
+    """Return the data-i18n attribute used by the .control-label inside the
+    button with the given id. None if not found."""
+    text = html_path.read_text(encoding="utf-8")
+    # Find the <button id="..."> opening + the next .control-label data-i18n
+    btn = re.search(
+        rf'<button[^>]*id="{re.escape(button_id)}"[^>]*>(.*?)</button>',
+        text,
+        re.DOTALL,
+    )
+    assert btn, f"button #{button_id} not found in {html_path.name}"
+    label_match = re.search(
+        r'class="control-label"[^>]*data-i18n="([^"]+)"', btn.group(1)
+    )
+    return label_match.group(1) if label_match else None
+
+
+def test_admin_browser_and_player_view_use_same_next_round_label():
+    """#1111: the admin browser's control-bar advance button used to say
+    'Skip' (admin.skipRound) while the player view's identical-function
+    button said 'Next' (admin.next). Same handler, same WebSocket message,
+    different label — German users didn't realize 'Überspringen' was the
+    way to advance the round. Pin the two together."""
+    admin_label = _data_i18n_for(WWW / "admin.html", "admin-skip-round")
+    player_label = _data_i18n_for(WWW / "player.html", "next-round-admin-btn")
+
+    assert admin_label == "admin.next", (
+        f"admin browser control-bar advance button uses '{admin_label}'; "
+        f"must use 'admin.next' to match the player view's same-function "
+        f"button (regression of #1111)."
+    )
+    assert player_label == "admin.next", (
+        f"player view control-bar advance button uses '{player_label}'; "
+        f"must use 'admin.next' (regression of #1111)."
+    )
+    assert admin_label == player_label, (
+        f"admin/player advance labels diverged: "
+        f"admin='{admin_label}' vs player='{player_label}'. "
+        f"Both buttons call the same adminNextRound handler — labels must "
+        f"stay aligned so users on either side see the same affordance "
+        f"text."
+    )


### PR DESCRIPTION
Closes #1111.

## Diagnosis

@maxlin1 reports the game stuck on REVEAL with "no way to advance" when one player misses the timer. The big in-page "Next Round" button is below the fold on long REVEAL pages, so users rely on the control bar at the bottom. The admin browser's control-bar advance button is labeled \`admin.skipRound\` → **"Skip" / "Überspringen"**. The player view's identical-function button is labeled \`admin.next\` → **"Next" / "Weiter"**.

Same handler (\`adminNextRound\`), same WebSocket message (\`{type: 'admin', action: 'next_round'}\`), different label. A German user sees "Überspringen" and reads "skip this thing", not "advance to next round". Max fell back to End Game because the affordance didn't communicate its function.

**Not a regression from #1029.** That fix made timer-expiry → REVEAL work correctly when one player misses. Pre-fix, users were stuck on PLAYING (worse symptom that masked this UX bug). Now that REVEAL is reachable, the mislabeled control-bar button is exposed.

## Fix

Single-line label change at [\`admin.html:1120\`](custom_components/beatify/www/admin.html#L1120):
- \`data-i18n="admin.skipRound"\` → \`data-i18n="admin.next"\`
- Inline fallback "Skip" → "Next"

This aligns the admin browser with [\`player.html:777\`](custom_components/beatify/www/player.html#L777) which has used \`admin.next\` for years. No JS, CSS, or backend changes; both buttons already use the same handler.

## Regression test

New [\`tests/unit/test_next_round_label_parity.py\`](tests/unit/test_next_round_label_parity.py) parses both HTML files and asserts both control-bar advance buttons reference \`admin.next\`. Verified:
- **Without fix:** fails with \`AssertionError: admin browser control-bar advance button uses 'admin.skipRound'; must use 'admin.next'\`
- **With fix:** passes
- Test reverse-verified by stashing the HTML change, re-running, restoring, re-running.

## Test plan
- [x] \`python3 -m pytest tests/\` → 539/539 (+1 new) pass
- [x] \`npx vitest run\` → 96/96 pass
- [x] Regression test fails on broken state, passes on fixed state
- [ ] Manual: open admin browser, start a game, time out without all players submitting, verify ⏭️ "Next" / "Weiter" appears in control bar and advances the round

🤖 Generated with [Claude Code](https://claude.com/claude-code)