### PR TITLE
fix(#1114): Android Companion launcher — top-frame navigation

### DIFF
--- a/custom_components/beatify/www/launcher.html
+++ b/custom_components/beatify/www/launcher.html
@@ -145,17 +145,39 @@
         //
         // We lose the "focus existing tab" affordance the old window.open
         // path had — acceptable trade for unblocking iOS Companion users.
+        //
+        // Android HA Companion (#1114) follow-up: the Android WebView
+        // swallows target="_blank" silently — no external tab opens, the
+        // launcher UI just shows the "opened in new tab" toast but
+        // nothing actually launched. We detect the Companion Android UA
+        // and switch to a top-frame navigation (`window.top.location`)
+        // on click, which loads Beatify directly in the same Companion
+        // view. Trade-off: no separate tab, but Beatify actually opens.
+
+        function isAndroidCompanion() {
+            var ua = navigator.userAgent || '';
+            return /Android/i.test(ua) && /Home ?Assistant/i.test(ua);
+        }
 
         window.addEventListener('load', async function() {
             // Set the href on load so we pick up window.location.origin
             // dynamically (LAN, Nabu Casa, custom domain all just work).
             var openBtn = document.getElementById('openBtn');
-            if (openBtn) openBtn.href = window.location.origin + '/beatify/admin';
+            var beatifyUrl = window.location.origin + '/beatify/admin';
+            if (openBtn) openBtn.href = beatifyUrl;
 
-            // Once the user taps, update the launcher UI so it's obvious
-            // Beatify opened in another tab/window. target="_blank" still
-            // fires the click — we just decorate the same page after.
-            if (openBtn) openBtn.addEventListener('click', function() {
+            if (openBtn) openBtn.addEventListener('click', function(evt) {
+                // Android Companion: bypass target="_blank" entirely —
+                // navigate the top frame so Beatify actually loads.
+                if (isAndroidCompanion()) {
+                    evt.preventDefault();
+                    try { window.top.location.href = beatifyUrl; }
+                    catch (e) { window.location.href = beatifyUrl; }
+                    return;
+                }
+                // All other contexts (iOS Companion, desktop iframe,
+                // standalone browser): let target="_blank" do its job
+                // and decorate the launcher to say "opened in a new tab".
                 var msg = document.getElementById('message');
                 if (msg) {
                     msg.textContent =


### PR DESCRIPTION
## Summary

- Detect HA Companion Android UA on launcher button click; `preventDefault()` and navigate `window.top.location.href` instead of relying on `target="_blank"` (which the Android Companion WebView silently swallows).
- iOS Companion, desktop iframe, and standalone browser paths are unchanged — they still open Beatify in a new tab and show the "opened in new tab" launcher decoration.
- Closes #1114.

## Context

rc17 (PR #1102) replaced the script-driven `window.open()` launcher with an `<a target="_blank" rel="noopener">` link so iOS Companion users could escape the WKWebView's OAuth interception. That works on iOS but not on Android Companion: the WebView swallows `target="_blank"` silently, the i18n toast `"Beatify in neuem Tab geöffnet!"` fires, but no tab actually opens.

3 external reporters confirmed on v3.4.1 with up-to-date HA Companion + Android (Samsung S25 / Android 16 / HA Companion 2026.4.4-full). @markist verified Beatify works fine when opened directly in Brave Browser — confirming the issue is purely the Companion WebView blocking the new-tab navigation.

## Test plan

- [x] `npx vitest run` — 96/96 tests pass locally
- [ ] Manual: Android HA Companion (Samsung / Pixel) — tap "Beatify öffnen" → Beatify loads in the same Companion view
- [ ] Manual: iOS HA Companion — tap "Beatify öffnen" → Beatify opens in external Safari (unchanged behavior)
- [ ] Manual: Desktop HA panel (Chrome / Firefox) — tap "Beatify öffnen" → opens in new tab (unchanged behavior)
- [ ] Manual: Standalone browser on Android (Brave / Chrome) — tap "Beatify öffnen" → opens in new tab (unchanged behavior — UA doesn't match Companion)

Version bumps deferred — that's for the rc cut that ships this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)