### PR TITLE
release: v3.4.2-rc1 — Android Companion launcher fix

### DIFF
--- a/custom_components/beatify/manifest.json
+++ b/custom_components/beatify/manifest.json
@@ -12,5 +12,5 @@
   "documentation": "https://github.com/mholzi/beatify",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/mholzi/beatify/issues",
-  "version": "3.4.1"
+  "version": "3.4.2-rc1"
 }

--- a/custom_components/beatify/www/admin.html
+++ b/custom_components/beatify/www/admin.html
@@ -8,7 +8,7 @@
          query-string version, a stale en.json from a prior rc gets served
          after upgrade and references to newer keys render as raw strings.
          Bumped each rc alongside manifest.json + sw.js CACHE_VERSION. -->
-    <meta name="beatify-version" content="3.4.1">
+    <meta name="beatify-version" content="3.4.2-rc1">
     <!-- Self-healing SW recovery (rc11): an older-version service worker
          may serve a stale ha-auth.js even with cache-busters, leaving users
          in an unrecoverable login loop. Compare the current page's version
@@ -55,7 +55,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@700;900&display=swap" rel="stylesheet">
     <!-- Story 18.4: Use minified CSS in production -->
-    <link rel="stylesheet" href="/beatify/static/css/styles.min.css?v=3.4.1">
+    <link rel="stylesheet" href="/beatify/static/css/styles.min.css?v=3.4.2-rc1">
 </head>
 <body class="theme-dark">
     <!-- First-run wizard takeover (see DESIGN.md ## Patterns → First-run wizard) -->
@@ -1454,17 +1454,17 @@
     <!-- Story 18.4: Use minified JS in production with fallback to source -->
     <!-- Version query strings prevent browser caching issues -->
     <!-- #998: HA OAuth client — must load before any admin script uses BeatifyAuth -->
-    <script src="/beatify/static/js/ha-auth.js?v=3.4.1"></script>
+    <script src="/beatify/static/js/ha-auth.js?v=3.4.2-rc1"></script>
     <script src="/beatify/static/js/i18n.js?v=1.7.0"></script>
     <script src="/beatify/static/js/utils.js?v=1.7.0"></script>
     <!-- Story 44.1: Playlist requests module -->
-    <script src="/beatify/static/js/playlist-requests.min.js?v=3.4.1"></script>
+    <script src="/beatify/static/js/playlist-requests.min.js?v=3.4.2-rc1"></script>
     <!-- #1052: LLM-assisted playlist generator (load before playlist-hub so the Mine-tab button finds it) -->
-    <script src="/beatify/static/js/playlist-generator.min.js?v=3.4.1"></script>
-    <script type="module" src="/beatify/static/js/playlist-hub.js?v=3.4.1"></script>
-    <script type="module" src="/beatify/static/js/wizard.js?v=3.4.1"></script>
-    <script src="/beatify/static/js/admin.min.js?v=3.4.1"></script>
-    <script src="/beatify/static/js/party-lights.min.js?v=3.4.1"></script>
-    <script src="/beatify/static/js/tts-settings.js?v=3.4.1"></script>
+    <script src="/beatify/static/js/playlist-generator.min.js?v=3.4.2-rc1"></script>
+    <script type="module" src="/beatify/static/js/playlist-hub.js?v=3.4.2-rc1"></script>
+    <script type="module" src="/beatify/static/js/wizard.js?v=3.4.2-rc1"></script>
+    <script src="/beatify/static/js/admin.min.js?v=3.4.2-rc1"></script>
+    <script src="/beatify/static/js/party-lights.min.js?v=3.4.2-rc1"></script>
+    <script src="/beatify/static/js/tts-settings.js?v=3.4.2-rc1"></script>
 </body>
 </html>

--- a/custom_components/beatify/www/analytics.html
+++ b/custom_components/beatify/www/analytics.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <!-- #1098: drives the footer version string + cache-busts i18n JSON.
          Bumped each rc alongside manifest.json + sw.js CACHE_VERSION. -->
-    <meta name="beatify-version" content="3.4.1">
+    <meta name="beatify-version" content="3.4.2-rc1">
     <title data-i18n="analyticsDashboard.title">Beatify Analytics</title>
     <!-- Preconnect for faster font loading -->
     <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/custom_components/beatify/www/dashboard.html
+++ b/custom_components/beatify/www/dashboard.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <!-- #824: cache-bust i18n JSON fetches. See admin.html for rationale. -->
-    <meta name="beatify-version" content="3.4.1">
+    <meta name="beatify-version" content="3.4.2-rc1">
     <title data-i18n="dashboard.title">Beatify - Dashboard</title>
     <!-- Preconnect for faster font loading (Story 9.8) -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -12,7 +12,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Outfit:wght@700;900&display=swap" rel="stylesheet">
     <!-- Story 18.4: Use minified CSS in production -->
     <link rel="stylesheet" href="/beatify/static/css/styles.css?v=1.7.0">
-    <link rel="stylesheet" href="/beatify/static/css/dashboard.min.css?v=3.4.1">
+    <link rel="stylesheet" href="/beatify/static/css/dashboard.min.css?v=3.4.2-rc1">
     <!-- Confetti library for celebrations (Story 14.5) -->
     <script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.9.2/dist/confetti.browser.min.js"></script>
 </head>
@@ -285,7 +285,7 @@
     <!-- Version query strings prevent browser caching issues -->
     <script src="/beatify/static/js/i18n.js?v=1.7.0"></script>
     <script src="/beatify/static/js/utils.js?v=1.7.0"></script>
-    <script src="/beatify/static/js/dashboard.min.js?v=3.4.1"></script>
+    <script src="/beatify/static/js/dashboard.min.js?v=3.4.2-rc1"></script>
     <!-- v3.2.1 Arcade shims: submission meter fill, album ring progress, reveal round mirror.
          Pure view-layer helpers — no state, no API calls. Safe to remove if dashboard.js
          ever takes these over directly. -->

--- a/custom_components/beatify/www/player.html
+++ b/custom_components/beatify/www/player.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <!-- #824: cache-bust i18n JSON fetches. See admin.html for rationale. -->
-    <meta name="beatify-version" content="3.4.1">
+    <meta name="beatify-version" content="3.4.2-rc1">
     <!-- Self-healing SW recovery (rc11) — see admin.html for the rationale. -->
     <script>
         (function() {
@@ -36,7 +36,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@700;900&display=swap" rel="stylesheet">
     <!-- Story 18.4: Use minified CSS in production -->
-    <link rel="stylesheet" href="/beatify/static/css/styles.min.css?v=3.4.1">
+    <link rel="stylesheet" href="/beatify/static/css/styles.min.css?v=3.4.2-rc1">
     <!-- Confetti library for celebrations (Story 14.5) -->
     <script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.9.2/dist/confetti.browser.min.js"></script>
 </head>
@@ -943,9 +943,9 @@
     <!-- Story 18.4: Use minified JS in production with fallback to source -->
     <!-- Version query strings prevent browser caching issues -->
     <!-- #998: HA OAuth client — only used when a host claims the admin role -->
-    <script src="/beatify/static/js/ha-auth.js?v=3.4.1"></script>
+    <script src="/beatify/static/js/ha-auth.js?v=3.4.2-rc1"></script>
     <script src="/beatify/static/js/i18n.min.js"></script>
     <script src="/beatify/static/js/utils.min.js"></script>
-    <script type="module" src="/beatify/static/js/player.bundle.min.js?v=3.4.1"></script>
+    <script type="module" src="/beatify/static/js/player.bundle.min.js?v=3.4.2-rc1"></script>
 </body>
 </html>

--- a/custom_components/beatify/www/sw.js
+++ b/custom_components/beatify/www/sw.js
@@ -6,7 +6,7 @@
  */
 'use strict';
 
-var CACHE_VERSION = 'beatify-v3.4.1';
+var CACHE_VERSION = 'beatify-v3.4.2-rc1';
 var MAX_CACHE_ITEMS = 50;
 
 // Critical assets to precache on install (minified versions only - fallback handled by HTML).


### PR DESCRIPTION
## Summary

- Bumps 3.4.1 → 3.4.2-rc1 across manifest.json, sw.js (CACHE_VERSION), beatify-version meta on admin/player/dashboard/analytics, and all `?v=` cache-busters.
- Ships the launcher fix from #1116 (closes #1114) — Android Companion `target="_blank"` workaround.

## Test plan

- [x] vitest 96/96 pass (from #1116)
- [x] Bumps verified — 0 occurrences of `3.4.1` remaining in versioned files, 20 occurrences of `3.4.2-rc1` (manifest 1 + sw.js 1 + admin 10 + dashboard 3 + analytics 1 + player 4).
- [ ] Manual Android Companion verification after release.

Release notes in `docs/release-notes-v3.4.2-rc1.md` (gitignored; used as release body).

🤖 Generated with [Claude Code](https://claude.com/claude-code)