### PR TITLE
fix: Android Companion launcher bounces back to launcher (#1114)

### DIFF
--- a/custom_components/beatify/www/launcher.html
+++ b/custom_components/beatify/www/launcher.html
@@ -150,9 +150,18 @@
         // swallows target="_blank" silently — no external tab opens, the
         // launcher UI just shows the "opened in new tab" toast but
         // nothing actually launched. We detect the Companion Android UA
-        // and switch to a top-frame navigation (`window.top.location`)
-        // on click, which loads Beatify directly in the same Companion
-        // view. Trade-off: no separate tab, but Beatify actually opens.
+        // and navigate `window.location` (the current iframe) to the
+        // admin URL directly, bypassing HA's SPA router.
+        //
+        // Why not window.top? HA's SPA is registered as a panel under
+        // the path prefix `/beatify/*`. Navigating the top frame to
+        // `/beatify/admin` causes HA's router to intercept and re-load
+        // the Beatify panel (which iframes `/beatify/launcher`), bouncing
+        // the user back to this page. Navigating `window.location` (the
+        // iframe itself) skips HA's router entirely — the backend serves
+        // the admin HTML straight into the panel frame.
+        // Trade-off: admin runs inside HA's chrome rather than fullscreen,
+        // but it is fully functional.
 
         function isAndroidCompanion() {
             var ua = navigator.userAgent || '';
@@ -168,11 +177,10 @@
 
             if (openBtn) openBtn.addEventListener('click', function(evt) {
                 // Android Companion: bypass target="_blank" entirely —
-                // navigate the top frame so Beatify actually loads.
+                // navigate the current iframe so Beatify actually loads.
                 if (isAndroidCompanion()) {
                     evt.preventDefault();
-                    try { window.top.location.href = beatifyUrl; }
-                    catch (e) { window.location.href = beatifyUrl; }
+                    window.location.href = beatifyUrl;
                     return;
                 }
                 // All other contexts (iOS Companion, desktop iframe,


### PR DESCRIPTION
Closes #1114

## Readiness assessment
- [ ] Ready to merge
- [x] Borderline — see notes

**Honest summary:** The UA detection (`isAndroidCompanion()`) is correct and always was — the regex matches the reported UA. The actual bug is that `window.top.location.href = '/beatify/admin'` triggers HA's SPA panel router, which owns the `/beatify/*` path prefix, causing it to re-render the Beatify panel and load `launcher.html` again (the "flash and back" symptom). Fix: navigate `window.location` (the panel iframe itself) to bypass HA's router. The admin loads inside HA's chrome rather than fullscreen, which is a UX downgrade but fully functional.

Marked Borderline because the fullscreen trade-off is intentional but should be reviewed by Markus — a future improvement could close the sidebar or use HA's full-panel navigation API if one exists.

## Test plan
- Install on Android HA Companion (v2026.4.4+), open Beatify from sidebar
- Tap "Beatify öffnen" — admin should load in the panel (HA chrome visible), no bounce back to launcher
- Verify the same button on iOS Companion still opens admin in external Safari (target="_blank" path unchanged)
- Verify on desktop browser (Chrome/Firefox/Safari) the button still opens a new tab

## Risk assessment
- **Blast radius:** `launcher.html` inline script only — 2 lines changed, no separate JS file
- **What could go wrong:**
  - Admin opens with HA's sidebar/chrome visible on Android (not fullscreen) — intentional trade-off, noted above
  - First-time users without a `beatify_access` cookie will run `ha-auth.js`'s OAuth flow inside the panel iframe; if Android Companion intercepts `/auth/authorize` (as iOS did), they'd hit an auth error. Existing users with valid cookies are unaffected.
  - SW `CACHE_VERSION` not bumped — but `launcher.html` is served `networkFirst`, so this is not needed for correctness.
- **What I did NOT test:** Physical Android Companion device (can't access); first-time auth flow on Android; Nabu Casa / custom domain setups

🤖 Auto-generated by issue-triage routine