### PR TITLE
fix: idle-halt skips stop() when phase already left REVEAL (#1123)

### DIFF
--- a/custom_components/beatify/game/state.py
+++ b/custom_components/beatify/game/state.py
@@ -1548,6 +1548,16 @@ class GameState:
             # Clear the handle before stopping so a manual start_round's
             # _cancel_auto_advance() doesn't cancel this running task.
             self._auto_advance_task = None
+            # #1123: re-check phase after clearing the handle.  The admin may have
+            # clicked "Next Round" in the narrow window between the song-finished
+            # detection (loop exit) and this stop() call.  Without the guard,
+            # stop() would silence the newly-started next song even though the
+            # game has already advanced to PLAYING.
+            if self.phase != GamePhase.REVEAL:
+                _LOGGER.debug(
+                    "Idle halt: phase left REVEAL before stop() — skipping stop"
+                )
+                return
             if self._media_player_service:
                 try:
                     await self._media_player_service.stop()

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -195,6 +195,36 @@ class TestRevealAutoAdvance:
         state._media_player_service.stop.assert_not_awaited()
         state.start_round.assert_not_awaited()
 
+    async def test_idle_halt_no_stop_when_phase_changes_as_song_finishes(self):
+        """#1123 regression guard: admin clicked 'Next Round' exactly when the
+        song finished.  The loop detects song-end and exits, but between the
+        loop exit and the stop() call the admin's next_round command was
+        processed and phase moved to PLAYING.  idle_halt must skip stop() so
+        the newly-started song is not immediately silenced.
+
+        Simulated by having _song_finished() flip the phase to PLAYING as a
+        side-effect (represents the instant the song ends AND admin advances).
+        """
+        state = make_game_state()
+        _create_fresh_game(state)
+        state.phase = GamePhase.REVEAL
+        state._media_player_service = MagicMock()
+        state._media_player_service.stop = AsyncMock()
+
+        def song_finished_and_phase_change():
+            # Admin clicked Next Round at the exact moment the song ended:
+            # start_round() already transitioned the phase to PLAYING.
+            state.phase = GamePhase.PLAYING
+            return True
+
+        state._song_finished = MagicMock(side_effect=song_finished_and_phase_change)
+
+        with patch("asyncio.sleep", new=AsyncMock()):
+            await state._reveal_idle_halt()
+
+        # Phase left REVEAL — stop() must NOT be called (would silence new song)
+        state._media_player_service.stop.assert_not_awaited()
+
 
 # ---------------------------------------------------------------------------
 # REVEAL countdown surface (#1048)


### PR DESCRIPTION
Closes #1123

## Readiness assessment
- [ ] Ready to merge
- [x] Borderline — see notes
- [ ] Not ready — needs human review

**Honest summary:** The root-cause race condition is real and the fix is correct, but it covers a specific timing window (song finishes naturally in a zero-guess round AND admin clicks Next Round in that exact moment) that is hard to reproduce manually. The new regression test uses a synthetic side-effect approach to prove the guard works. Confidence is high on the code path; lower on whether this is the *only* cause of the reported "button doesn't work" experience.

## Root cause
`_reveal_idle_halt` clears its own task handle (`_auto_advance_task = None`) before calling `media_player.stop()`.  In the window between handle-clear and the actual stop() call, an admin click of "Next Round" runs `start_round()` → `_cancel_auto_advance()` which sees `None` and does nothing. `start_round()` then starts the next song, but the idle-halt's pending `stop()` call subsequently silences it.

Result: game phase advances to PLAYING (state broadcast succeeds), but no audio — admin perceives "Next Round button did nothing."

## Fix
One conditional added in `game/state.py::_reveal_idle_halt()`: after clearing the handle, re-check `self.phase != GamePhase.REVEAL`. If the admin has already advanced the game, skip `stop()` entirely.

## Test plan
- Run `pytest tests/unit/test_state.py -k idle_halt` — 3 pass including new regression
- Run `pytest tests/unit/` — 540 pass
- Manual: start a 2-player game, let both players miss the timer (zero guesses), wait for song to finish (~3–5 min idle), then immediately click Next Round — next round should play music
- Manual: same scenario but click Next Round *before* song finishes — should still work (existing path, idle halt is cancelled via `_cancel_auto_advance`)

## Risk assessment
- **Blast radius:** `_reveal_idle_halt` only — only reachable when zero players submitted a guess
- **What could go wrong:** If phase somehow stays REVEAL after `_song_finished()` but then changes before the check (extremely unlikely; synchronous code between loop-exit and the guard), the guard would fire unnecessarily. Net effect: media player not explicitly stopped at idle-halt — harmless, since the next start_round will play a new song anyway
- **What I did NOT test:** Music Assistant vs. HA native media player behaviour; Companion App path; actual HA integration (pure unit tests only)

🤖 Auto-generated by issue-triage routine