### PR TITLE
fix(#1131): always skip OAuth in Android Companion (no bridge probe)

### DIFF
--- a/custom_components/beatify/www/js/__tests__/ha-auth.test.js
+++ b/custom_components/beatify/www/js/__tests__/ha-auth.test.js
@@ -455,12 +455,16 @@ describe('Companion bypass mode (#1131 — UA + RFC1918 trust on server)', () =>
         expect(BeatifyAuth.isCompanionBypassMode()).toBe(true);
     });
 
-    it('isCompanionBypassMode() returns false when externalAppV2 is exposed (bridge path will work)', () => {
+    it('isCompanionBypassMode() returns true even when externalAppV2 is exposed (rc10: bridge unreliable)', () => {
+        // rc10 (#1131): field data shows recent Companion builds advertise the
+        // bridge but it either never replies or replies with a token HA rejects.
+        // The bypass therefore ignores bridge presence and trusts the
+        // server-side UA+RFC1918 check unconditionally.
         const { BeatifyAuth } = loadHaAuth({
             userAgent: COMPANION_UA,
             externalAppV2: { postMessage() {} },
         });
-        expect(BeatifyAuth.isCompanionBypassMode()).toBe(false);
+        expect(BeatifyAuth.isCompanionBypassMode()).toBe(true);
     });
 
     it('isCompanionBypassMode() returns false on desktop browsers', () => {

--- a/custom_components/beatify/www/js/ha-auth.js
+++ b/custom_components/beatify/www/js/ha-auth.js
@@ -212,17 +212,27 @@
     return false;
   }
 
-  // #1131: when HA Android Companion is detected but the externalAppV2 bridge
-  // is missing (older Companion build, or a build that hides the bridge from
-  // user-script contexts), the OAuth flow is also dead — Companion intercepts
-  // /auth/authorize. In that case the server-side companion_auth.py grants
-  // access based on UA + RFC1918, so the frontend just skips the auth dance.
-  // UA presence alone is enough here; the server still verifies remote-addr.
+  // #1131 / rc10: when HA Android Companion is detected, ALWAYS skip the OAuth
+  // dance and rely on the server-side UA+RFC1918 bypass in companion_auth.py.
+  //
+  // History: rc8/rc9 limited the client-side skip to "bridge missing" — the
+  // reasoning was that builds with a working bridge could still get a real
+  // Bearer token. Field data (Logan-80, nelbs) showed that path is wrong:
+  // recent Companion builds advertise the bridge but it either never replies
+  // or replies with a token HA rejects. The bridge attempt then runs into a
+  // 10s timeout (see _CompanionAuthBridge below) and falls through to a hard
+  // OAuth redirect that Companion's WebView blocks with "Invalid redirect URI".
+  //
+  // Trade-off: builds where the bridge would have worked no longer get a
+  // real Bearer token. Admin endpoints continue to function because the
+  // server-side bypass authorises any UA-matching request from an RFC1918
+  // address. No HA per-user identity is exposed in beatify's admin surface,
+  // so dropping the per-user token has no functional consequence.
   function isCompanionBypassMode() {
     var ua = (typeof navigator !== 'undefined' && navigator.userAgent) || '';
     if (!/Android/i.test(ua)) return false;
     if (!/Home ?Assistant|HACompanion|Hass/i.test(ua)) return false;
-    return !_hasCompanionAuthBridge();
+    return true;
   }
 
   // -- multiplexed callback receiver ---------------------------------------


### PR DESCRIPTION
## Summary
- rc8/rc9 only skipped OAuth when the externalApp/externalAppV2 bridge was *missing*. Field data confirms that path is wrong — recent Companion builds expose a broken bridge.
- rc10: when UA matches Android + HA Companion, \`isCompanionBypassMode()\` unconditionally returns true. \`init()\` resolves without any auth attempt; the server-side \`companion_auth.py\` UA+RFC1918 bypass (rc8) accepts subsequent API calls.

## Field evidence (rc8 / rc9)
- **Logan-80** ([#1131](https://github.com/mholzi/beatify/issues/1131)) — Android Companion 2026.4.4-full (21576). Sees admin render briefly, then "Invalid redirect URI" after ~15s. Reproduced locally on Redmi 25028RN03Y / Android 15 / same Companion build.
- **nelbs** ([#1120](https://github.com/mholzi/beatify/issues/1120)) — same Companion build, same symptom.

## Root cause
1. \`isCompanionBypassMode()\` checks \`!_hasCompanionAuthBridge()\`.
2. \`externalAppV2.postMessage\` IS exposed on these builds → bridge check returns true → bypass returns false.
3. \`init()\` proceeds with OAuth.
4. The bridge \`postMessage\` either never replies or replies with a token \`async_validate_access_token\` rejects.
5. 10s timeout fires (see \`_CompanionAuthBridge\` at ha-auth.js:275).
6. Falls through to \`login()\` → redirect to \`/auth/authorize\`.
7. Companion's WebView blocks the redirect → "Invalid redirect URI".

## Fix
\`isCompanionBypassMode()\` now returns true whenever UA matches the Android Companion regex. The bridge is no longer probed for the auth-skip decision. Server-side \`companion_auth.py\` (rc8) handles authorisation on UA+RFC1918.

## Trade-off
Companion builds where the bridge *would* have worked no longer obtain a real Bearer token. Beatify's admin surface does not consume HA per-user identity, so dropping the per-user token has no functional consequence here.

## Test plan
- [x] 106 / 106 JS pass — one test inverted to assert the new behaviour
- [x] 40 / 40 Python pass — server side untouched
- [x] No \`.min.js\` regen needed — ha-auth.js is loaded directly
- [ ] Smoke on rc10: install in HA, open Beatify in Android Companion App, expect admin to load cleanly (no 15s wait, no bounce)

🤖 Generated with [Claude Code](https://claude.com/claude-code)