### PR TITLE
fix(#1131): ensureAuthenticated() returns null in Companion bypass

### DIFF
--- a/custom_components/beatify/www/js/__tests__/ha-auth.test.js
+++ b/custom_components/beatify/www/js/__tests__/ha-auth.test.js
@@ -508,6 +508,33 @@ describe('Companion bypass mode (#1131 — UA + RFC1918 trust on server)', () =>
         const h = observedHeaders[0].headers;
         expect(h?.Authorization).toBeUndefined();
     });
+
+    it('ensureAuthenticated() resolves null in Companion bypass mode (rc12: no OAuth attempt)', async () => {
+        // rc11 admin → "join as host" hung on Android Companion because
+        // ensureAuthenticated() called login() → /auth/authorize → blocked
+        // by Companion's WebView ("Invalid redirect URI"). The returned
+        // promise never resolved and `adminWs.send({...ha_token: token})`
+        // never fired. rc12 short-circuits to null so the WS send proceeds
+        // and the server-side bypass kicks in on UA+RFC1918.
+        let loginCalls = 0;
+        const fetchFn = async () => {
+            // refreshAccess should NOT be called either — bypass mode means
+            // there is no OAuth to refresh.
+            return { ok: false, status: 401 };
+        };
+        const { BeatifyAuth, sandboxWindow } = loadHaAuth({
+            fetchFn,
+            userAgent: COMPANION_UA,
+        });
+        const _originalReplace = sandboxWindow.location.replace;
+        sandboxWindow.location.replace = function (url) {
+            loginCalls += 1;
+            return _originalReplace.call(this, url);
+        };
+        const token = await BeatifyAuth.ensureAuthenticated();
+        expect(token).toBeNull();
+        expect(loginCalls).toBe(0); // no /auth/authorize navigation
+    });
 });
 
 describe('login() OAuth redirect', () => {

--- a/custom_components/beatify/www/js/ha-auth.js
+++ b/custom_components/beatify/www/js/ha-auth.js
@@ -599,8 +599,26 @@
   /**
    * Guarantee an access token. If none can be obtained this navigates away
    * to the HA login page and the returned promise never resolves.
+   *
+   * rc12 (#1131): when the page is running inside HA Android Companion's
+   * WebView and `isCompanionBypassMode()` told `init()` to skip OAuth,
+   * there is no access token to obtain — and calling `login()` here would
+   * navigate to `/auth/authorize`, which Companion's WebView blocks with
+   * "Invalid redirect URI" (the exact bug rc10 worked around for `init()`).
+   * Resolve with `null` instead so callers can still send their WS / fetch
+   * with no `ha_token`; the server-side bypass in `companion_auth.py`
+   * accepts those requests on the UA+RFC1918 signature.
+   *
+   * Without this rc11 admin → "join the game as host" hung forever on
+   * Android Companion: `admin.js:2562` awaits this function before sending
+   * the WS join, so the WS upgrade fired (admin already had a socket open)
+   * but the join message was never enqueued and `[WS-Debug] join` never
+   * logged — the missing data point that surfaced the bug.
    */
   function ensureAuthenticated() {
+    if (isCompanionBypassMode()) {
+      return Promise.resolve(null);
+    }
     return getAccessToken().then(function (token) {
       if (token) return token;
       login();


### PR DESCRIPTION
## Summary
\`ensureAuthenticated()\` still ran OAuth even in Companion bypass mode — calling \`login()\` → \`/auth/authorize\` → blocked on Android Companion. The returned promise never resolved and \`admin.js:2562\` hung before sending the WS join message. rc12 short-circuits to \`Promise.resolve(null)\` when bypass mode is active.

## Root cause
rc10 flipped \`isCompanionBypassMode()\` to true for Android Companion so \`init()\` skips OAuth. But \`ensureAuthenticated()\` — called later by \`admin.js:2562\` before the WS join-as-host message — still did:

\`\`\`
getAccessToken() → null → login() → window.location = /auth/authorize
\`\`\`

On Android Companion that lands on HA's IndieAuth error and the returned promise NEVER resolves. \`admin.js\` awaits it before calling \`adminWs.send({type: 'join', ha_token: token})\`, so the WS upgrade fires (socket was already open from \`connectAdminWebSocket()\`) but the join message is never enqueued.

## Field evidence
Reproduced on rc11 (Redmi Note 14 5G EEA / Android 15 / Companion 2026.4.4-full):
- Admin loads cleanly (rc11 #1138 fix works)
- Tap "join as host" → join popup hangs forever
- \`[WS-Debug] join\` never logs — confirmed by mholzi's "no WS-Debug entries in the log" report

iPhone Companion path is unaffected: \`isCompanionBypassMode()\` returns false there (regex requires Android), OAuth runs normally, the bridge returns a real Bearer token, \`ensureAuthenticated()\` resolves it.

## Fix
\`ensureAuthenticated()\` checks \`isCompanionBypassMode()\` first and returns \`Promise.resolve(null)\` immediately. Callers send \`ha_token: null\`; server-side \`_is_ha_authenticated\` already treats falsy tokens as the trigger to consult \`is_companion_trusted_meta(ws.beatify_request_meta)\`, which accepts on the UA+RFC1918 signature stashed at WS upgrade time.

## Test plan
- [x] 22 / 22 JS pass — new test asserts both the null return AND that \`window.location.replace\` is NOT called (no OAuth navigation)
- [x] No \`.min.js\` regen (ha-auth.js loaded directly, no bundle)
- [ ] Smoke on rc12: admin → "join as host" succeeds, lobby renders, host's name appears in player list, no hang

🤖 Generated with [Claude Code](https://claude.com/claude-code)