### PR TITLE
fix: bump stale rc8 cache-busters + default body home-mode

### DIFF
--- a/custom_components/beatify/www/admin.html
+++ b/custom_components/beatify/www/admin.html
@@ -8,7 +8,7 @@
          query-string version, a stale en.json from a prior rc gets served
          after upgrade and references to newer keys render as raw strings.
          Bumped each rc alongside manifest.json + sw.js CACHE_VERSION. -->
-    <meta name="beatify-version" content="3.4.3-rc8">
+    <meta name="beatify-version" content="3.4.3-rc14">
     <!-- Self-healing SW recovery (rc11): an older-version service worker
          may serve a stale ha-auth.js even with cache-busters, leaving users
          in an unrecoverable login loop. Compare the current page's version
@@ -55,9 +55,9 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@700;900&display=swap" rel="stylesheet">
     <!-- Story 18.4: Use minified CSS in production -->
-    <link rel="stylesheet" href="/beatify/static/css/styles.min.css?v=3.4.3-rc8">
+    <link rel="stylesheet" href="/beatify/static/css/styles.min.css?v=3.4.3-rc14">
 </head>
-<body class="theme-dark">
+<body class="theme-dark home-mode">
     <!-- First-run wizard takeover (see DESIGN.md ## Patterns → First-run wizard) -->
     <div id="wizard-root" class="wizard-takeover hidden" aria-hidden="true">
         <div class="wiz-bg"></div>
@@ -1454,21 +1454,21 @@
     <!-- Story 18.4: Use minified JS in production with fallback to source -->
     <!-- Version query strings prevent browser caching issues -->
     <!-- #998: HA OAuth client — must load before any admin script uses BeatifyAuth -->
-    <script src="/beatify/static/js/ha-auth.js?v=3.4.3-rc13"></script>
+    <script src="/beatify/static/js/ha-auth.js?v=3.4.3-rc14"></script>
     <script src="/beatify/static/js/i18n.js?v=1.7.0"></script>
     <script src="/beatify/static/js/utils.js?v=1.7.0"></script>
     <!-- Story 44.1: Playlist requests module -->
-    <script src="/beatify/static/js/playlist-requests.min.js?v=3.4.3-rc8"></script>
+    <script src="/beatify/static/js/playlist-requests.min.js?v=3.4.3-rc14"></script>
     <!-- #1052: LLM-assisted playlist generator (load before playlist-hub so the Mine-tab button finds it) -->
-    <script src="/beatify/static/js/playlist-generator.min.js?v=3.4.3-rc8"></script>
-    <script type="module" src="/beatify/static/js/playlist-hub.js?v=3.4.3-rc8"></script>
-    <script type="module" src="/beatify/static/js/wizard.js?v=3.4.3-rc8"></script>
+    <script src="/beatify/static/js/playlist-generator.min.js?v=3.4.3-rc14"></script>
+    <script type="module" src="/beatify/static/js/playlist-hub.js?v=3.4.3-rc14"></script>
+    <script type="module" src="/beatify/static/js/wizard.js?v=3.4.3-rc14"></script>
     <!-- #1122 rc7: NoSleep.js Layer 2 fallback for iOS Companion WKWebView,
          loaded before admin.min.js so window.NoSleep is available when
          _requestWakeLock() runs on game start. -->
-    <script src="/beatify/static/js/vendor/no-sleep.min.js?v=3.4.3-rc8"></script>
-    <script src="/beatify/static/js/admin.min.js?v=3.4.3-rc8"></script>
-    <script src="/beatify/static/js/party-lights.min.js?v=3.4.3-rc8"></script>
-    <script src="/beatify/static/js/tts-settings.js?v=3.4.3-rc8"></script>
+    <script src="/beatify/static/js/vendor/no-sleep.min.js?v=3.4.3-rc14"></script>
+    <script src="/beatify/static/js/admin.min.js?v=3.4.3-rc14"></script>
+    <script src="/beatify/static/js/party-lights.min.js?v=3.4.3-rc14"></script>
+    <script src="/beatify/static/js/tts-settings.js?v=3.4.3-rc14"></script>
 </body>
 </html>

--- a/custom_components/beatify/www/analytics.html
+++ b/custom_components/beatify/www/analytics.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <!-- #1098: drives the footer version string + cache-busts i18n JSON.
          Bumped each rc alongside manifest.json + sw.js CACHE_VERSION. -->
-    <meta name="beatify-version" content="3.4.3-rc8">
+    <meta name="beatify-version" content="3.4.3-rc14">
     <!-- Self-healing SW recovery — see admin.html for the rationale.
          Analytics is rarely opened, so a session that lands here after a
          long gap may still hold a stale SW from many rcs back. Inline +

--- a/custom_components/beatify/www/dashboard.html
+++ b/custom_components/beatify/www/dashboard.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <!-- #824: cache-bust i18n JSON fetches. See admin.html for rationale. -->
-    <meta name="beatify-version" content="3.4.3-rc8">
+    <meta name="beatify-version" content="3.4.3-rc14">
     <!-- Self-healing SW recovery — see admin.html for the rationale.
          Mirrored here because dashboards run on always-on TVs that rarely
          get hard-refreshed, so a stale SW serving rc(N-1) assets is the
@@ -41,7 +41,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Outfit:wght@700;900&display=swap" rel="stylesheet">
     <!-- Story 18.4: Use minified CSS in production -->
     <link rel="stylesheet" href="/beatify/static/css/styles.css?v=1.7.0">
-    <link rel="stylesheet" href="/beatify/static/css/dashboard.min.css?v=3.4.3-rc8">
+    <link rel="stylesheet" href="/beatify/static/css/dashboard.min.css?v=3.4.3-rc14">
     <!-- Confetti library for celebrations (Story 14.5) -->
     <script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.9.2/dist/confetti.browser.min.js"></script>
 </head>
@@ -317,8 +317,8 @@
     <!-- #1122 rc7: NoSleep.js Layer 2 fallback for iOS Companion WKWebView,
          loaded before dashboard.min.js so window.NoSleep is available when
          requestWakeLock() runs on dashboard init. -->
-    <script src="/beatify/static/js/vendor/no-sleep.min.js?v=3.4.3-rc8"></script>
-    <script src="/beatify/static/js/dashboard.min.js?v=3.4.3-rc8"></script>
+    <script src="/beatify/static/js/vendor/no-sleep.min.js?v=3.4.3-rc14"></script>
+    <script src="/beatify/static/js/dashboard.min.js?v=3.4.3-rc14"></script>
     <!-- v3.2.1 Arcade shims: submission meter fill, album ring progress, reveal round mirror.
          Pure view-layer helpers — no state, no API calls. Safe to remove if dashboard.js
          ever takes these over directly. -->

--- a/custom_components/beatify/www/player.html
+++ b/custom_components/beatify/www/player.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <!-- #824: cache-bust i18n JSON fetches. See admin.html for rationale. -->
-    <meta name="beatify-version" content="3.4.3-rc8">
+    <meta name="beatify-version" content="3.4.3-rc14">
     <!-- Self-healing SW recovery (rc11) — see admin.html for the rationale. -->
     <script>
         (function() {
@@ -36,7 +36,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@700;900&display=swap" rel="stylesheet">
     <!-- Story 18.4: Use minified CSS in production -->
-    <link rel="stylesheet" href="/beatify/static/css/styles.min.css?v=3.4.3-rc8">
+    <link rel="stylesheet" href="/beatify/static/css/styles.min.css?v=3.4.3-rc14">
     <!-- Confetti library for celebrations (Story 14.5) -->
     <script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.9.2/dist/confetti.browser.min.js"></script>
 </head>
@@ -940,13 +940,13 @@
     </div>
 
     <script src="/beatify/static/js/vendor/qrcode.min.js"></script>
-    <script src="/beatify/static/js/vendor/no-sleep.min.js?v=3.4.3-rc8"></script>
+    <script src="/beatify/static/js/vendor/no-sleep.min.js?v=3.4.3-rc14"></script>
     <!-- Story 18.4: Use minified JS in production with fallback to source -->
     <!-- Version query strings prevent browser caching issues -->
     <!-- #998: HA OAuth client — only used when a host claims the admin role -->
-    <script src="/beatify/static/js/ha-auth.js?v=3.4.3-rc13"></script>
+    <script src="/beatify/static/js/ha-auth.js?v=3.4.3-rc14"></script>
     <script src="/beatify/static/js/i18n.min.js"></script>
     <script src="/beatify/static/js/utils.min.js"></script>
-    <script type="module" src="/beatify/static/js/player.bundle.min.js?v=3.4.3-rc8"></script>
+    <script type="module" src="/beatify/static/js/player.bundle.min.js?v=3.4.3-rc14"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
Two stale-cache fixes targeting the rc13 symptom mholzi reported tonight: "tap join as host → briefly shows legacy flat admin → updates to home-view".

## 1. Cache-buster strings frozen at rc8
\`admin.html\`, \`player.html\`, \`dashboard.html\`, \`analytics.html\` all referenced minified JS / CSS with \`?v=3.4.3-rc8\` — never bumped alongside the manifest / sw cache version since rc8. Other browser layers (HA Companion's WebView keyed on the URL) honored the same stale \`?v=rc8\` cache-key and served stale \`admin.min.js\` (the rc8 version with the \`setupSections.forEach(removeClass('hidden'))\` bug from before #1138).

Bumping all asset references to \`?v=3.4.3-rc14\` and the \`meta beatify-version\` tags to \`3.4.3-rc14\` invalidates every cache layer simultaneously on rc14 upgrade.

## 2. Default \`home-mode\` class on \`<body>\` in admin.html
Even with fresh JS, the legacy \`#media-players\` / \`#playlists\` / \`#game-settings\` sections flash visible for the milliseconds between page render and \`BeatifyHome.enter()\` (which adds \`home-mode\` and lets CSS hide them). Adding \`home-mode\` to \`<body>\` by default hides them from first paint. \`BeatifyHome.enter().add('home-mode')\` stays idempotent so nothing else changes.

## Test plan
- [x] 107 / 107 JS pass
- [x] 40 / 40 Python pass (companion_auth)
- [ ] Smoke on rc14: admin opens directly in home-view, no legacy flash, fresh assets served

🤖 Generated with [Claude Code](https://claude.com/claude-code)