### PR TITLE
fix(#1131): EndGameView + StartGameplayView accept Companion bypass

### DIFF
--- a/custom_components/beatify/server/game_views.py
+++ b/custom_components/beatify/server/game_views.py
@@ -419,9 +419,17 @@ class EndGameView(BeatifyAdminView):
 
     url = "/beatify/api/end-game"
     name = "beatify:api:end-game"
+    # rc15 (#1131): HA's middleware-enforced auth would block the request
+    # before is_authorized_http() ever runs, so Companion bypass requests
+    # land on a generic 401 HTML page from HA → admin.js fetches it and
+    # response.json() throws → "Network error" alert. Match the pattern
+    # StartGameView / ForceResetView / RematchView already use.
+    requires_auth = False
 
-    async def post(self, request: web.Request) -> web.Response:  # noqa: ARG002
+    async def post(self, request: web.Request) -> web.Response:
         """End the current game."""
+        if not await is_authorized_http(request, self.hass):
+            return _json_error("Unauthorized", 401, code="UNAUTHORIZED")
         data = self.hass.data.get(DOMAIN, {})
         game_state = data.get("game")
 
@@ -547,9 +555,15 @@ class StartGameplayView(BeatifyAdminView):
 
     url = "/beatify/api/start-gameplay"
     name = "beatify:api:start-gameplay"
+    # rc15 (#1131): see EndGameView above — without this override,
+    # Companion-bypass requests get a HA-middleware 401 and the JSON parse
+    # fails on the admin client, surfacing as "Network error".
+    requires_auth = False
 
-    async def post(self, request: web.Request) -> web.Response:  # noqa: ARG002
+    async def post(self, request: web.Request) -> web.Response:
         """Start gameplay from lobby."""
+        if not await is_authorized_http(request, self.hass):
+            return _json_error("Unauthorized", 401, code="UNAUTHORIZED")
         from custom_components.beatify.game.state import GamePhase  # noqa: PLC0415
 
         data = self.hass.data.get(DOMAIN, {})


### PR DESCRIPTION
## Summary
Both views extended \`BeatifyAdminView\` and inherited \`requires_auth = True\`. HA's middleware then blocked Companion-bypass requests with a 401 *before* \`is_authorized_http()\` could consult the UA+RFC1918 trust signature.

## Root cause traced from screenshot
mholzi's rc14 screenshot shows the "Network error. Please try again." alert on the home-view with a freshly-created LOBBY (QR visible). The path:

1. Tap "Start game" on home-view
2. \`BeatifyHome.enter()\` already auto-called \`startSession()\` → \`startGame()\` → 1st POST \`/beatify/api/start-game\` (200 OK, LOBBY created)
3. User tap fires \`home-start-game\` listener → \`startGame()\` again → 2nd POST \`/beatify/api/start-game\` → returns 409 \`GAME_IN_LOBBY\`
4. Recovery code at admin.js:2065 calls \`loadStatus()\` then \`startGameplay()\`
5. \`startGameplay()\` falls back to REST (admin WS not open in bypass mode yet) → POST \`/beatify/api/start-gameplay\`
6. HA middleware sees no Bearer token, \`requires_auth = True\` → returns 401 HTML
7. \`response.json()\` throws on HTML
8. Catch fires: \`showError('Network error. Please try again.')\` → \`alert(...)\`

## Fix
Match the pattern \`StartGameView\` / \`ForceResetView\` / \`RematchView\` already use: set \`requires_auth = False\` and call \`is_authorized_http()\` at the top of the handler.

## Test plan
- [x] 53 / 53 Python pass (companion_auth + game_views)
- [ ] Smoke on rc15: admin → "Start game" works without Network error alert

🤖 Generated with [Claude Code](https://claude.com/claude-code)