### PR TITLE
data(hits-2010s-2020s): correct Sun Is Shining year 2017→2015 (#1135)

### DIFF
--- a/custom_components/beatify/playlists/hits-2010s-2020s.json
+++ b/custom_components/beatify/playlists/hits-2010s-2020s.json
@@ -1,6 +1,6 @@
 {
   "name": "2010s & 2020s Hits",
-  "version": "1.3",
+  "version": "1.4",
   "tags": [
     "pop",
     "charts",
@@ -1667,7 +1667,7 @@
     {
       "artist": "Axwell /\\ Ingrosso",
       "title": "Sun Is Shining",
-      "year": 2017,
+      "year": 2015,
       "isrc": "USUG11500070",
       "uri": "spotify:track:4b2tcjrG1qUkSdsqEFP2dB",
       "uri_apple_music": "applemusic://track/1440907562",
@@ -1687,11 +1687,11 @@
         "Axwell",
         "Sebastian Ingrosso"
       ],
-      "fun_fact": "A chart hit by Axwell /\\ Ingrosso (2017).",
-      "fun_fact_de": "Ein Chart-Hit von Axwell /\\ Ingrosso (2017).",
-      "fun_fact_es": "Un éxito de Axwell /\\ Ingrosso (2017).",
-      "fun_fact_fr": "Un tube de Axwell /\\ Ingrosso (2017).",
-      "fun_fact_nl": "Een chart-hit van Axwell /\\ Ingrosso (2017)."
+      "fun_fact": "A chart hit by Axwell /\\ Ingrosso (2015).",
+      "fun_fact_de": "Ein Chart-Hit von Axwell /\\ Ingrosso (2015).",
+      "fun_fact_es": "Un éxito de Axwell /\\ Ingrosso (2015).",
+      "fun_fact_fr": "Un tube de Axwell /\\ Ingrosso (2015).",
+      "fun_fact_nl": "Een chart-hit van Axwell /\\ Ingrosso (2015)."
     },
     {
       "artist": "Nathan Evans",


### PR DESCRIPTION
## Fix

Axwell /\ Ingrosso — "Sun Is Shining" in `custom_components/beatify/playlists/hits-2010s-2020s.json`:

- Year: `2017` → `2015`
- All five `fun_fact*` fields: `(2017)` → `(2015)`
- Playlist `version`: `1.3` → `1.4`

## Why

Reported via in-game data-quality flag by player "Simon Herzog" (#1135). Original single released **12 June 2015** in Sweden as fourth single from the *More Than You Know* album (which itself dropped 2017 — that's the value that crept in).

The ISRC already in the playlist — `USUG11500070` — encodes year `15` per IFPI convention, so the 2017 figure was simply album-year contamination.

## Sources

- [Wikipedia — Sun Is Shining (Axwell & Ingrosso song)](https://en.wikipedia.org/wiki/Sun_Is_Shining_(Axwell_%26_Ingrosso_song))
- [Discogs Master 852705](https://www.discogs.com/master/852705-Axwell-Ingrosso-Sun-Is-Shining)

Closes #1135