### PR TITLE
data(essential-alternative): fix wrong YouTube Music URI for Smashing Pumpkins — Today (#1147)

### DIFF
--- a/custom_components/beatify/playlists/community/essential-alternative.json
+++ b/custom_components/beatify/playlists/community/essential-alternative.json
@@ -1,6 +1,6 @@
 {
   "name": "Essential Alternative 🎸",
-  "version": "0.1",
+  "version": "0.2",
   "tags": [
     "alternative",
     "rock",
@@ -2719,7 +2719,7 @@
       "fun_fact_es": "Billy Corgan escribió 'Today' en el peor día de su vida — su melodía alegre y la letra 'I want to turn you on' ocultan una depresión suicida.",
       "fun_fact_fr": "Billy Corgan a écrit 'Today' le pire jour de sa vie — la mélodie joyeuse et la phrase 'I want to turn you on' masquent une dépression suicidaire.",
       "uri_apple_music": "applemusic://track/1707070137",
-      "uri_youtube_music": "https://music.youtube.com/watch?v=JzSeC5sFyT8",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=xmUZ6nCFNoU",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/14738294",
       "fun_fact_nl": "Billy Corgan schreef 'Today' op de slechtste dag van zijn leven — de vrolijke melodie en de regel 'I want to turn you on' verhullen suïcidale depressie.",


### PR DESCRIPTION
Closes #1147. Replaced wrong YouTube Music URI for The Smashing Pumpkins — Today (was pointing to "Tonight, Tonight") with correct URI. Bumped playlist version to 0.2.

1 `wrong_track` flag dismissed as false positive (Weezer "Say It Ain't So" with "Original Mix" suffix — same song, version tag).