### PR TITLE
data(top-100-power-ballads): fix Jennifer Rush "The Power of Love" 1985 → 1984 (#1155)

### DIFF
--- a/custom_components/beatify/playlists/top-100-power-ballads.json
+++ b/custom_components/beatify/playlists/top-100-power-ballads.json
@@ -1,6 +1,6 @@
 {
   "name": "Top 100 Power Ballads",
-  "version": "1.6",
+  "version": "1.7",
   "tags": [
     "1980s",
     "1990s",
@@ -1236,7 +1236,7 @@
       }
     },
     {
-      "year": 1985,
+      "year": 1984,
       "uri": "spotify:track:7EkFVRqmso1h8WjrUrlXIT",
       "artist": "Jennifer Rush",
       "alt_artists": [


### PR DESCRIPTION
## Decision: real fix (year was off by 1)

| Field | Before | After |
|---|---|---|
| year | 1985 | 1984 |
| ISRC | DEE-868-84-00100 | (unchanged — note "84" matches the corrected year) |
| Playlist version | 1.6 | 1.7 |

### Verification

"The Power of Love" by Jennifer Rush was first released as a single in **December 1984 in West Germany**, from her self-titled 1984 debut album. The UK single release came in June 1985, which is the most likely source of the "1985" tag. Per the playlist convention we use the song's **original** single-release year, so the correct value is 1984.

Sources consulted:
- [Wikipedia: The Power of Love (Jennifer Rush song)](https://en.wikipedia.org/wiki/The_Power_of_Love_(Jennifer_Rush_song)) — "released in West Germany in December 1984"
- [Wikipedia: Jennifer Rush (1984 album)](https://en.wikipedia.org/wiki/Jennifer_Rush_(1984_album)) — confirms album year
- [Songfacts.com](https://www.songfacts.com/facts/jennifer-rush/the-power-of-love) — original German release 1984
- ISRC reference year `84` in `DEE-868-84-00100` corroborates 1984

Closes #1155