### PR TITLE
fix: correct Apple Music URI for Village People YMCA (#1159)

### DIFF
--- a/custom_components/beatify/playlists/greatest-hits-of-all-time.json
+++ b/custom_components/beatify/playlists/greatest-hits-of-all-time.json
@@ -7854,15 +7854,15 @@
       "year": 1978,
       "isrc": "FR22F8000900",
       "uri": "spotify:track:54OR1VDpfkBuOY5zZjhZAY",
-      "uri_apple_music": "applemusic://track/1874432085",
+      "uri_apple_music": "applemusic://track/1872720856",
       "uri_apple_music_by_region": {
         "us": null,
-        "de": "applemusic://track/1874432085",
-        "gb": "applemusic://track/1874432085",
-        "fr": "applemusic://track/1874432085",
-        "es": "applemusic://track/1874432085",
-        "nl": "applemusic://track/1874432085",
-        "it": "applemusic://track/1874432085"
+        "de": "applemusic://track/1872720856",
+        "gb": "applemusic://track/1872720856",
+        "fr": "applemusic://track/1872720856",
+        "es": "applemusic://track/1872720856",
+        "nl": "applemusic://track/1872720856",
+        "it": "applemusic://track/1872720856"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=7-F8wkjKWg8",
       "uri_tidal": null,


### PR DESCRIPTION
Closes #1159

## Readiness assessment
- [x] Ready to merge
- [ ] Borderline — see notes
- [ ] Not ready — needs human review

**Honest summary:** The Apple Music URI for Village People "YMCA - Original Version 1978" in `greatest-hits-of-all-time.json` pointed to track `1874432085`, which is the *live* version ("YMCA (Live)" from the "Live and Sleazy" album). The correct track ID `1872720856` is the original 1978 studio recording from the "YMCA" single/EP. Verified availability in all 6 target regions (DE/GB/FR/ES/NL/IT) via the iTunes Lookup API before replacing. Change is a pure data fix — 7 lines, one JSON file, no code, no frontend.

## Test plan
- [ ] Open Beatify with the greatest-hits-of-all-time playlist and navigate to Village People "YMCA - Original Version 1978"
- [ ] Tap the Apple Music link — confirm it opens the studio recording (not the live version)
- [ ] Verify in at least one non-US storefront (e.g. DE) that the track resolves correctly
- [ ] Run playlist-health-check against this playlist — the YMCA entry should now be clean

## Risk assessment
- **Blast radius:** Single track entry in one playlist JSON; no code, no UI, no frontend bundle
- **What could go wrong:** Track `1872720856` could be region-locked in a storefront not checked (US is set to `null`, matching the original entry — left unchanged). No other edge cases identified.
- **What I did NOT test:** US storefront (already `null` in the original, intentionally); live device playback (requires Apple Music auth)

🤖 Auto-generated by issue-triage routine