### PR TITLE
data: fix broken Apple Music URI for Village People YMCA (#1159)

### DIFF
--- a/custom_components/beatify/playlists/greatest-hits-of-all-time.json
+++ b/custom_components/beatify/playlists/greatest-hits-of-all-time.json
@@ -1,6 +1,6 @@
 {
   "name": "Greatest Hits of All Time",
-  "version": "2.8",
+  "version": "2.9",
   "tags": [
     "classics",
     "top-hits",
@@ -7854,15 +7854,15 @@
       "year": 1978,
       "isrc": "FR22F8000900",
       "uri": "spotify:track:54OR1VDpfkBuOY5zZjhZAY",
-      "uri_apple_music": "applemusic://track/1874432085",
+      "uri_apple_music": null,
       "uri_apple_music_by_region": {
         "us": null,
-        "de": "applemusic://track/1874432085",
-        "gb": "applemusic://track/1874432085",
-        "fr": "applemusic://track/1874432085",
-        "es": "applemusic://track/1874432085",
-        "nl": "applemusic://track/1874432085",
-        "it": "applemusic://track/1874432085"
+        "de": null,
+        "gb": null,
+        "fr": null,
+        "es": null,
+        "nl": null,
+        "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=7-F8wkjKWg8",
       "uri_tidal": null,


### PR DESCRIPTION
Closes #1159. 

The Apple Music URI `applemusic://track/1874432085` for "YMCA - Original Version 1978" by Village People resolved to **YMCA (Live)** — a live recording — instead of the original 1978 studio version. The ISRC `FR22F8000900` (French pressing) is not available as a studio recording on Apple Music, so `uri_apple_music` and all `uri_apple_music_by_region` entries are set to `null`. Beatify will gracefully fall back to Spotify, YouTube Music, and Deezer for this track.

Bumps playlist version `2.8` → `2.9`.

**Health check summary:** 898 URIs checked, 879 healthy, 1 confirmed wrong track, 18 false positives dismissed (version suffixes, single versions, radio edits, remastered tags).