### PR TITLE
data(movies-100-greatest-themes): fix dead Apple Music URI for Prelude And Rooftop (#1162)

### DIFF
--- a/custom_components/beatify/playlists/movies-100-greatest-themes.json
+++ b/custom_components/beatify/playlists/movies-100-greatest-themes.json
@@ -1,6 +1,6 @@
 {
   "name": "100 Greatest Movie Themes 🎬",
-  "version": "1.10",
+  "version": "1.11",
   "tags": [
     "movies",
     "soundtrack",
@@ -4037,7 +4037,7 @@
       "chart_info": {},
       "certifications": [],
       "awards": [],
-      "uri_apple_music": "applemusic://track/600474544",
+      "uri_apple_music": "applemusic://track/1444008064",
       "uri_youtube_music": "https://music.youtube.com/watch?v=Fg8wtmrABig",
       "movie": "Vertigo",
       "movie_choices": [
@@ -4051,13 +4051,13 @@
       "awards_nl": [],
       "isrc": "FRZ811209020",
       "uri_apple_music_by_region": {
-        "us": "applemusic://track/600474544",
-        "de": "applemusic://track/600474544",
-        "gb": "applemusic://track/600474544",
-        "fr": "applemusic://track/599988249",
-        "es": "applemusic://track/600474544",
-        "nl": "applemusic://track/600474544",
-        "it": "applemusic://track/600474544"
+        "us": "applemusic://track/1444008064",
+        "de": "applemusic://track/1444008064",
+        "gb": "applemusic://track/1444008064",
+        "fr": "applemusic://track/1444008064",
+        "es": "applemusic://track/1444008064",
+        "nl": "applemusic://track/1444008064",
+        "it": "applemusic://track/1444008064"
       }
     },
     {


### PR DESCRIPTION
## Summary

Replaces the dead Apple Music URI `applemusic://track/600474544` (and the FR variant `599988249`, both 404 in all 7 target regions) for **Bernard Herrmann — *Prelude And Rooftop*** with `1444008064` from the official *Vertigo (Original Motion Picture Soundtrack)* album.

## Changes

- 8 replacements in `custom_components/beatify/playlists/movies-100-greatest-themes.json`:
  - 1× legacy `uri_apple_music`
  - 6× region overrides (US/DE/GB/ES/NL/IT)
  - 1× FR-specific override (was the variant `599988249`)
- Playlist `version`: `1.10` → `1.11`

## Verification

- iTunes Lookup API confirmed `1444008064` exists in all 7 target regions (US/GB/DE/FR/ES/NL/IT).
- Old IDs `600474544` and `599988249` confirmed dead in all 7 regions.
- JSON parses cleanly; song count unchanged (162).

## Source

Triggered by `playlist-health-check` skill (Mode 1) via heartbeat `playlist-review` catch-up run on 2026-05-28. The skill also flagged 12 wrong_track entries on the same playlist — all verified as false positives (variant title formatting only).

Closes #1162

🤖 Generated with [Claude Code](https://claude.com/claude-code)