### PR TITLE
chore: ruff format ws_handlers.py (unblock lint CI)

### DIFF
--- a/custom_components/beatify/server/ws_handlers.py
+++ b/custom_components/beatify/server/ws_handlers.py
@@ -164,12 +164,13 @@ async def handle_join(
     # surfaces on the client. Remove once #1131 lands stable.
     meta = getattr(ws, "beatify_request_meta", None)
     _LOGGER.info(
-        "[WS-Debug] join name=%r is_admin=%s ha_token_present=%s "
-        "phase=%s meta=%s",
+        "[WS-Debug] join name=%r is_admin=%s ha_token_present=%s phase=%s meta=%s",
         name,
         is_admin,
         bool(data.get("ha_token")),
-        game_state.phase.value if hasattr(game_state.phase, "value") else game_state.phase,
+        game_state.phase.value
+        if hasattr(game_state.phase, "value")
+        else game_state.phase,
         meta,
     )
 
@@ -180,8 +181,7 @@ async def handle_join(
 
     success, error_code = game_state.add_player(name, ws)
     _LOGGER.info(
-        "[WS-Debug] join add_player name=%r success=%s error_code=%s "
-        "was_existing=%s",
+        "[WS-Debug] join add_player name=%r success=%s error_code=%s was_existing=%s",
         name,
         success,
         error_code,


### PR DESCRIPTION
## Summary
- Pure `ruff format` reformat of `custom_components/beatify/server/ws_handlers.py` — two long log-message strings collapsed back onto one line and one ternary reformatted by current ruff (0.15.x) default style.
- Restores `Lint (3.13)` workflow to green; main has been red on lint for at least the last 3 pushes (#1161, #1148, #1147) blocking the mergeable=clean state for unrelated data-PRs.
- Zero behaviour change. No tests touched.

## Test plan
- [x] `python3 -m ruff format --check .` — 67 files already formatted
- [x] `python3 -m ruff check .` — All checks passed
- [ ] CI Lint (3.12) + (3.13) both green