### PR TITLE
data(90er-hits): fix Crystal Waters "Gypsy Woman" fun_fact year mismatch

### DIFF
--- a/custom_components/beatify/playlists/90er-hits.json
+++ b/custom_components/beatify/playlists/90er-hits.json
@@ -1,6 +1,6 @@
 {
   "name": "90s Hits",
-  "version": "1.9",
+  "version": "1.10",
   "tags": [
     "1990s",
     "pop",
@@ -3417,11 +3417,11 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=NqThf-MpCjs",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/907649",
-      "fun_fact": "A chart hit by Crystal Waters (2007).",
-      "fun_fact_de": "Ein Chart-Hit von Crystal Waters (2007).",
-      "fun_fact_es": "Un éxito de Crystal Waters (2007).",
-      "fun_fact_fr": "Un tube de Crystal Waters (2007).",
-      "fun_fact_nl": "Een chart-hit van Crystal Waters (2007)."
+      "fun_fact": "Released in 1991 as Crystal Waters' debut single, inspired by a homeless woman she saw daily near her Washington D.C. apartment. The 'la da dee, la da da' hook propelled it to the top of European charts and to #8 on the Billboard Hot 100.",
+      "fun_fact_de": "1991 als Crystal Waters' Debut-Single erschienen, inspiriert von einer obdachlosen Frau, die sie täglich in der Nähe ihrer Wohnung in Washington D.C. sah. Der „la da dee, la da da\"-Hook brachte den Song an die Spitze europäischer Charts und auf Platz 8 der Billboard Hot 100.",
+      "fun_fact_es": "Lanzada en 1991 como el sencillo debut de Crystal Waters, inspirada en una mujer sin hogar que veía a diario cerca de su apartamento en Washington D.C. El estribillo «la da dee, la da da» la llevó a lo más alto de las listas europeas y al puesto 8 del Billboard Hot 100.",
+      "fun_fact_fr": "Sortie en 1991 comme premier single de Crystal Waters, inspirée par une femme sans-abri qu'elle voyait quotidiennement près de son appartement à Washington D.C. Le refrain « la da dee, la da da » a propulsé le titre en tête des charts européens et au numéro 8 du Billboard Hot 100.",
+      "fun_fact_nl": "Verschenen in 1991 als de debuutsingle van Crystal Waters, geïnspireerd door een dakloze vrouw die ze dagelijks zag bij haar appartement in Washington D.C. De „la da dee, la da da\"-hook bracht het nummer naar de top van Europese hitlijsten en naar #8 in de Billboard Hot 100."
     },
     {
       "artist": "Blur",


### PR DESCRIPTION
## Decision

User-reported via Telegram screenshot: game ran Crystal Waters – Gypsy Woman (She's Homeless) with `RICHTIG WAR 1991` (correct), but the fun fact in all 5 languages stated `(2007)`.

**Root cause:** the song's `year: 1991` field is correct (original release April 1991, Crystal Waters' debut single). The mismatch was inside the `fun_fact_*` strings, which had been auto-enriched with a hallucinated `(2007)` reference. Other fields (URI, ISRC `USPR39102713`, artist/title) all align with the 1991 single.

**Fix scope:** strings-only — replace all 5 `fun_fact_*` fields with a factual 2-sentence text per language. No URI/year/identifier changes.

## Source

- User screenshot (Beatify HA dashboard, 29.05.2026 ~07:30 UTC) shows the in-game discrepancy
- Wikipedia: ["Gypsy Woman (She's Homeless)"](https://en.wikipedia.org/wiki/Gypsy_Woman_(She%27s_Homeless)) — release date April 1991, peak positions in NL/BE/CH/IT/ES/AT (#1), UK (#2), US Billboard Hot 100 (#8)

## Diff

\`custom_components/beatify/playlists/90er-hits.json\` — Crystal Waters / Gypsy Woman entry:
- All 5 \`fun_fact_*\` rewritten with year-consistent 2-sentence text (origin story + iconic hook + chart performance)
- Playlist \`version: 1.9\` → \`1.10\`
- No other fields touched

## Test plan

- [ ] Visual check: in-game Fun Fact now matches \`RICHTIG WAR 1991\`
- [ ] All 5 languages render without curly-quote/encoding artifacts
- [ ] No other Crystal Waters / similar 90s entries have the same \`(2007)\`-style mismatch (out of scope here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)