### PR TITLE
data(2000s-pop-anthems): fix wrong Deezer URI for Daddy DJ "Daddy DJ" (#1169)

### DIFF
--- a/custom_components/beatify/playlists/2000s-pop-anthems.json
+++ b/custom_components/beatify/playlists/2000s-pop-anthems.json
@@ -1,6 +1,6 @@
 {
   "name": "2000s Pop Anthems",
-  "version": "1.9",
+  "version": "1.10",
   "tags": [
     "2000s",
     "pop",
@@ -7005,7 +7005,7 @@
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=QWBMCtIllEM",
       "uri_tidal": null,
-      "uri_deezer": "deezer://track/1745366907",
+      "uri_deezer": "deezer://track/3477676331",
       "fun_fact": "A chart hit by Daddy DJ (2022).",
       "fun_fact_de": "Ein Chart-Hit von Daddy DJ (2022).",
       "fun_fact_es": "Un éxito de Daddy DJ (2022).",


### PR DESCRIPTION
Closes #1169.

## Decision

The Deezer URI for **Daddy DJ — "Daddy DJ"** in `2000s-pop-anthems.json` was pointing to "Gabry Ponte — We Could Be Together (feat. Daddy DJ)" (a 2024 feature-collab). Replaced with the canonical Daddy DJ original radio edit.

## Source

- `playlist-health-check` audit 2026-05-29 14:01–14:13 UTC: 862 URIs checked, validator flagged 7, AI review confirmed 1 real defect (this) + 5 oEmbed false-positives + 1 transient 504.
- Deezer API search confirms `track/3477676331` is the closest canonical match — Deezer's pre-2025 originals for this single were retired; only 25th-anniversary remasters remain.

## Diff

- `custom_components/beatify/playlists/2000s-pop-anthems.json`:
  - Daddy DJ entry: `uri_deezer` `1745366907` → `3477676331`
  - Playlist `version` `1.9` → `1.10`

## Test plan

- [ ] CI green (Lint 3.12/3.13, Test 3.12/3.13, Hassfest, HACS)
- [ ] Deezer URI resolves to correct track on next ingame play

## Out of scope

Same entry's `fun_fact_*` fields say "(2022)" — same hallucination pattern as #1168 (Crystal Waters). Not fixed here, one-issue-one-fix discipline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)