### PR TITLE
data: remove wrong YouTube Music URI for Chim Chim Cher-ee in disney-classics (#1174)

### DIFF
--- a/custom_components/beatify/playlists/disney-classics.json
+++ b/custom_components/beatify/playlists/disney-classics.json
@@ -1,6 +1,6 @@
 {
   "name": "Disney Classics",
-  "version": "1.0",
+  "version": "1.1",
   "tags": [
     "disney",
     "movies",
@@ -3148,7 +3148,6 @@
         "Grammy-nominatie"
       ],
       "uri_apple_music": "applemusic://track/1434821546",
-      "uri_youtube_music": "https://music.youtube.com/watch?v=8Mh09VuGlKo",
       "movie": "Mary Poppins",
       "movie_choices": [
         "Mary Poppins",


### PR DESCRIPTION
Closes #1174.

Removed 1 wrong YouTube Music URI and bumped playlist version to 1.1.

The URI `https://music.youtube.com/watch?v=8Mh09VuGlKo` pointed to an official Disney UK sing-alongs lyric video instead of the Relaxing Piano Crew instrumental cover. The correct YouTube Music track ID was not locatable via public search (the Relaxing Piano Crew catalog doesn't appear to be indexed by Google). Spotify (`spotify:track:0IKYsgkoaylTKGzrlfrpu7`), Deezer (`deezer://track/462639092`), and Apple Music (`applemusic://track/1434821546`) URIs are all healthy — removing only the broken YouTube Music URI rather than the full song entry.

**Note:** The correct YouTube Music URL (ISRC: FR10S1851773, album: "Disney Dreams: Classic Disney Piano Ballads for Sleeping" by Relaxing Piano Crew) should be added manually when found on music.youtube.com.