### PR TITLE
data: null 11 mismatched YouTube Music URIs in disney-classics

### DIFF
--- a/custom_components/beatify/playlists/disney-classics.json
+++ b/custom_components/beatify/playlists/disney-classics.json
@@ -1,6 +1,6 @@
 {
   "name": "Disney Classics",
-  "version": "1.1",
+  "version": "1.2",
   "tags": [
     "disney",
     "movies",
@@ -94,7 +94,7 @@
       "awards_fr": [],
       "awards_nl": [],
       "uri_apple_music": "applemusic://track/1440639393",
-      "uri_youtube_music": "https://music.youtube.com/watch?v=bhiLtH5X97w",
+      "uri_youtube_music": null,
       "movie": "Moana",
       "movie_choices": [
         "Moana",
@@ -1541,7 +1541,7 @@
         "Grammy voor Best Song Written for Visual Media (2001)"
       ],
       "uri_apple_music": "applemusic://track/1437333914",
-      "uri_youtube_music": "https://music.youtube.com/watch?v=O1NoURD1YFs",
+      "uri_youtube_music": null,
       "movie": "Tarzan",
       "movie_choices": [
         "Tarzan",
@@ -2592,7 +2592,7 @@
         "Critics' Choice Movie Award voor Beste Song (2022)"
       ],
       "uri_apple_music": "applemusic://track/1594677760",
-      "uri_youtube_music": "https://music.youtube.com/watch?v=0tGMPAodXJA",
+      "uri_youtube_music": null,
       "movie": "Encanto",
       "movie_choices": [
         "Encanto",
@@ -2795,7 +2795,7 @@
       "awards_fr": [],
       "awards_nl": [],
       "uri_apple_music": "applemusic://track/1664564080",
-      "uri_youtube_music": "https://music.youtube.com/watch?v=koWKsgOSs1w",
+      "uri_youtube_music": null,
       "movie": "Anastasia",
       "movie_choices": [
         "Anastasia",
@@ -2848,7 +2848,7 @@
         "Oscar-nominatie voor Beste Originele Song (1998)"
       ],
       "uri_apple_music": "applemusic://track/1664565006",
-      "uri_youtube_music": "https://music.youtube.com/watch?v=gZQJsceaqDA",
+      "uri_youtube_music": null,
       "movie": "Anastasia",
       "movie_choices": [
         "Anastasia",
@@ -2894,7 +2894,7 @@
       "awards_fr": [],
       "awards_nl": [],
       "uri_apple_music": "applemusic://track/1443634546",
-      "uri_youtube_music": "https://music.youtube.com/watch?v=2b9cbz1mkBk",
+      "uri_youtube_music": null,
       "movie": "Treasure Planet",
       "movie_choices": [
         "Treasure Planet",
@@ -2937,7 +2937,7 @@
       "awards_fr": [],
       "awards_nl": [],
       "uri_apple_music": "applemusic://track/1467938153",
-      "uri_youtube_music": "https://music.youtube.com/watch?v=tqQxlvZfeLE",
+      "uri_youtube_music": null,
       "movie": "The Jungle Book",
       "movie_choices": [
         "The Jungle Book",
@@ -3048,7 +3048,7 @@
         "Oscar-nominatie voor Beste Originele Song (1965)"
       ],
       "uri_apple_music": "applemusic://track/1444019946",
-      "uri_youtube_music": "https://music.youtube.com/watch?v=XH-dPy9JJMY",
+      "uri_youtube_music": null,
       "movie": "Mary Poppins",
       "movie_choices": [
         "Mary Poppins",
@@ -3090,7 +3090,7 @@
       "awards_fr": [],
       "awards_nl": [],
       "uri_apple_music": "applemusic://track/1444019703",
-      "uri_youtube_music": "https://music.youtube.com/watch?v=dKzqc54g0z4",
+      "uri_youtube_music": null,
       "movie": "Mary Poppins",
       "movie_choices": [
         "Mary Poppins",
@@ -3190,7 +3190,7 @@
       "awards_fr": [],
       "awards_nl": [],
       "uri_apple_music": "applemusic://track/1440357115",
-      "uri_youtube_music": "https://music.youtube.com/watch?v=bdIR6-6BMyA",
+      "uri_youtube_music": null,
       "movie": "The Hunchback of Notre Dame",
       "movie_choices": [
         "The Hunchback of Notre Dame",
@@ -3318,7 +3318,7 @@
       "awards_fr": [],
       "awards_nl": [],
       "uri_apple_music": "applemusic://track/1440669863",
-      "uri_youtube_music": "https://music.youtube.com/watch?v=yq8XjPReQpw",
+      "uri_youtube_music": null,
       "movie": "The Aristocats",
       "movie_choices": [
         "The Aristocats",


### PR DESCRIPTION
## Summary

Per-URI audit of all 68 `uri_youtube_music` entries in `disney-classics.json` via `yt-dlp` (extracting channel/uploader/title). Identified 11 URIs that play a recording different from the JSON-declared artist — set those to `null` so the provider-fallback chain (Spotify → Apple Music → Deezer) takes over instead of playing the wrong recording.

Extends the #1174 fix (single URI cleanup) to a full sweep — Markus' explicit ask: "Verifiziere alle und merge".

## Verifier Method

```bash
yt-dlp --no-warnings --skip-download \
  --print "%(channel)s|%(uploader)s|%(channel_id)s|%(title)s" <url>
```

Run in 8-thread pool over 68 URLs (~3 min). 0 errors, 0 404s — every URL is live, but 11 point to the wrong recording.

## Classification

| Bucket | Count | Action |
|---|---|---|
| ✅ Whitelist (DisneyMusicVEVO, Walt Disney Records, Disney Music, Pixar) | 32 | keep |
| ✅ Grey-OK: `- Topic` channels of the actual original singer (Lea Salonga / Brad Kane / Paige O'Hara / Samuel E. Wright / Nathan Lane / Jeremy Irons / etc.) | 14 | keep |
| ✅ Grey-OK: Artist self-channel of the original singer (Judy Kuhn / Mandy Moore / Sarah McLachlan / Shakira / Phil Collins #68) | 7 | keep |
| ✅ Grey-OK: Disney sub-brand (Disney Kids) or fan-uploaded OST rip of the canonical recording | 4 | keep |
| ❌ Mismatch: channel content ≠ JSON-declared artist's recording | **11** | **null** |

## Nulled (11)

| # | Song (JSON artist) | YT channel | Issue |
|---|---|---|---|
| 1 | You're Welcome (Dwayne Johnson) | Sharpe Family Singers | shorts/comedy cover |
| 30 | You'll Be In My Heart (Phil Collins) | Glenn Close - Topic | lullaby alt-version, not the Phil Collins solo |
| 51 | We Don't Talk About Bruno (Encanto Cast) | Lang Lang | piano cover |
| 55 | Once Upon a December (Christy Altomare) | Liz Callaway - Topic | 1997-film version, not 2017-Broadway cast |
| 56 | Journey to the Past (Christy Altomare) | Liz Callaway - Topic | same Liz Callaway film-vs-Broadway mismatch |
| 57 | I'm Still Here (John Rzeznik) | TeenTitansRaven | Swedish dub of Treasure Planet |
| 58 | I Wan'na Be Like You (Louis Prima/Phil Harris) | Geoff Love - Topic | UK orchestral cover, not the 1967 film original |
| 60 | Supercalifragilistic (Australian Cast) | Julie Andrews - Topic | 1964 film original, not the stage musical cast |
| 61 | A Spoonful of Sugar (Australian Cast) | Julie Andrews - Topic | same film-vs-stage mismatch |
| 63 | God Help the Outcasts (Ciara Renée) | Heidi Mollenhauer - Topic | 1996 film, not the Broadway revival |
| 66 | Ev'rybody Wants to Be a Cat (Scatman Crothers) | WeLoveDisneyVEVO | Charles Perry cover, not the 1970 film original |

## Diff

- `version`: `1.1` → `1.2`
- 11 × `uri_youtube_music: "https://music.youtube.com/watch?v=..."` → `null`
- All other URIs (Apple Music, Deezer, Spotify) untouched
- Songs themselves untouched — playback still works via provider fallback

Files changed: 1 (`disney-classics.json`), 12 insertions / 12 deletions.

## Test plan

- [x] yt-dlp verifier output reviewed song-by-song (`/tmp/disney-verify/results.tsv`)
- [x] 11 mismatch classifications cross-checked against song-title / source-film / known original-recording-artist
- [x] All non-nulled entries either (a) on Disney whitelist or (b) Topic-channel of the canonical singer
- [x] JSON is valid (`python3 -m json.tool` clean)
- [ ] CI green (Lint / Test / Validate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)