### PR TITLE
feat(reveal): per-player dot-axis replaces histogram on phone (#1178)

### DIFF
--- a/custom_components/beatify/game/scoring.py
+++ b/custom_components/beatify/game/scoring.py
@@ -521,6 +521,7 @@ class ScoringService:
                     "name": p.name,
                     "guess": p.current_guess,
                     "years_off": p.years_off or 0,
+                    "round_score": p.round_score,
                 }
                 for p in submitted
             ],

--- a/custom_components/beatify/www/css/styles.css
+++ b/custom_components/beatify/www/css/styles.css
@@ -5735,6 +5735,147 @@ body.theme-dark .movie-reveal-section {
     margin-bottom: var(--space-sm);
 }
 
+/* #1178: per-player dot-axis (replaces aggregated histogram on phone reveal).
+   Each player's guess is a colored dot at the exact year on a horizontal axis;
+   the correct year is marked by a vertical cyan line. */
+.dotaxis-wrap {
+    margin: 14px 0 16px;
+}
+.dotaxis-axis {
+    position: relative;
+    height: 88px;
+    margin: 0 14px;
+}
+.dotaxis-line {
+    position: absolute;
+    left: 0; right: 0;
+    top: 52px;
+    height: 2px;
+    background: rgba(255, 255, 255, 0.12);
+    border-radius: 2px;
+}
+.dotaxis-tick {
+    position: absolute;
+    top: 48px;
+    width: 1px;
+    height: 10px;
+    background: rgba(255, 255, 255, 0.18);
+}
+.dotaxis-tick-label {
+    position: absolute;
+    top: 64px;
+    font-size: 9px;
+    color: rgba(255, 255, 255, 0.5);
+    transform: translateX(-50%);
+    letter-spacing: 0.3px;
+    font-weight: 500;
+}
+.dotaxis-marker {
+    position: absolute;
+    top: 4px;
+    bottom: 18px;
+    width: 2px;
+    background: linear-gradient(180deg, transparent, var(--color-cyan, #00d4ff) 30%, var(--color-cyan, #00d4ff) 80%, transparent);
+    box-shadow: 0 0 8px var(--color-cyan, #00d4ff), 0 0 16px rgba(0, 212, 255, 0.6);
+}
+.dotaxis-marker-label {
+    position: absolute;
+    top: -4px;
+    left: 50%;
+    transform: translateX(-50%);
+    background: var(--color-cyan, #00d4ff);
+    color: #0a0a0e;
+    font-family: var(--font-family-display, 'Outfit', sans-serif);
+    font-weight: 900;
+    font-size: 12px;
+    padding: 3px 8px;
+    border-radius: 6px;
+    box-shadow: 0 0 14px rgba(0, 212, 255, 0.6);
+    white-space: nowrap;
+}
+.dotaxis-dot {
+    position: absolute;
+    top: 39px;
+    width: 26px;
+    height: 26px;
+    border-radius: 50%;
+    transform: translateX(-50%);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-family: var(--font-family-display, 'Outfit', sans-serif);
+    font-weight: 900;
+    font-size: 12px;
+    color: #fff;
+    text-shadow: 0 1px 2px rgba(0, 0, 0, 0.5);
+    box-shadow: 0 0 0 3px var(--color-bg-primary, #0d0d12), 0 4px 10px rgba(0, 0, 0, 0.4);
+    cursor: default;
+}
+.dotaxis-dot--c1 { background: linear-gradient(135deg, #ff6ec7, #d846a7); }
+.dotaxis-dot--c2 { background: linear-gradient(135deg, #6e3bff, #4a25c8); }
+.dotaxis-dot--c3 { background: linear-gradient(135deg, #ffd60a, #e6b800); color: #1a1a22; text-shadow: none; }
+.dotaxis-dot--c4 { background: linear-gradient(135deg, #00d4ff, #008abf); }
+.dotaxis-dot--correct {
+    box-shadow: 0 0 0 3px var(--color-bg-primary, #0d0d12), 0 0 18px currentColor, 0 4px 10px rgba(0, 0, 0, 0.4);
+}
+.dotaxis-dot--me {
+    box-shadow: 0 0 0 3px var(--color-bg-primary, #0d0d12), 0 0 0 5px rgba(255, 159, 67, 0.6), 0 4px 10px rgba(0, 0, 0, 0.4);
+}
+.dotaxis-dot--correct.dotaxis-dot--me {
+    box-shadow: 0 0 0 3px var(--color-bg-primary, #0d0d12), 0 0 0 5px rgba(255, 159, 67, 0.6), 0 0 22px currentColor, 0 4px 10px rgba(0, 0, 0, 0.4);
+}
+.dotaxis-score {
+    position: absolute;
+    top: 12px;
+    transform: translateX(-50%);
+    font-family: var(--font-family-display, 'Outfit', sans-serif);
+    font-weight: 800;
+    font-size: 11px;
+    padding: 2px 6px;
+    border-radius: 6px;
+    background: rgba(255, 255, 255, 0.08);
+    white-space: nowrap;
+}
+.dotaxis-score--pos {
+    background: rgba(0, 212, 255, 0.18);
+    color: var(--color-cyan, #00d4ff);
+}
+.dotaxis-score--zero {
+    color: rgba(255, 255, 255, 0.35);
+}
+.dotaxis-legend {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 8px 14px;
+    font-size: 11px;
+    color: rgba(255, 255, 255, 0.75);
+    margin-top: 4px;
+}
+.dotaxis-legend-entry {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+}
+.dotaxis-legend-dot {
+    display: inline-block;
+    width: 11px;
+    height: 11px;
+    border-radius: 50%;
+    flex-shrink: 0;
+}
+.dotaxis-legend-medal {
+    font-size: 13px;
+    line-height: 1;
+}
+.dotaxis-legend-me {
+    color: rgba(255, 159, 67, 1);
+    font-weight: 700;
+    font-size: 10px;
+    margin-left: 2px;
+    letter-spacing: 0.3px;
+}
+
 .histogram-bars {
     display: flex;
     justify-content: space-between;

--- a/custom_components/beatify/www/i18n/de.json
+++ b/custom_components/beatify/www/i18n/de.json
@@ -685,7 +685,9 @@
     "furthestGuess": "Am weitesten daneben",
     "noSubmissions": "Keine Antworten in dieser Runde",
     "noGuesses": "Keine Tipps",
-    "histogram": "Antwort-Verteilung"
+    "histogram": "Antwort-Verteilung",
+    "guessAxis": "Wo alle getippt haben",
+    "youMarker": "(DU)"
   },
   "artistChallenge": {
     "whoSings": "Wer singt diesen Song?",

--- a/custom_components/beatify/www/i18n/en.json
+++ b/custom_components/beatify/www/i18n/en.json
@@ -685,7 +685,9 @@
     "furthestGuess": "Most off",
     "noSubmissions": "No submissions this round",
     "noGuesses": "No guesses",
-    "histogram": "Guess distribution"
+    "histogram": "Guess distribution",
+    "guessAxis": "Where everyone guessed",
+    "youMarker": "(YOU)"
   },
   "artistChallenge": {
     "whoSings": "Who sings this song?",

--- a/custom_components/beatify/www/i18n/es.json
+++ b/custom_components/beatify/www/i18n/es.json
@@ -685,7 +685,9 @@
     "furthestGuess": "Mas alejado",
     "noSubmissions": "Sin respuestas en esta ronda",
     "noGuesses": "Sin respuestas",
-    "histogram": "Distribucion de respuestas"
+    "histogram": "Distribucion de respuestas",
+    "guessAxis": "Donde apostaron todos",
+    "youMarker": "(TU)"
   },
   "artistChallenge": {
     "whoSings": "¿Quién canta esta canción?",

--- a/custom_components/beatify/www/i18n/fr.json
+++ b/custom_components/beatify/www/i18n/fr.json
@@ -685,7 +685,9 @@
     "furthestGuess": "Le plus éloigné",
     "noSubmissions": "Pas de réponses cette manche",
     "noGuesses": "Pas de réponses",
-    "histogram": "Distribution des réponses"
+    "histogram": "Distribution des réponses",
+    "guessAxis": "Où chacun a parié",
+    "youMarker": "(TOI)"
   },
   "artistChallenge": {
     "whoSings": "Qui chante cette chanson ?",

--- a/custom_components/beatify/www/i18n/nl.json
+++ b/custom_components/beatify/www/i18n/nl.json
@@ -685,7 +685,9 @@
     "furthestGuess": "Meest ernaast",
     "noSubmissions": "Geen inzendingen deze ronde",
     "noGuesses": "Geen gokken",
-    "histogram": "Verdeling van gokken"
+    "histogram": "Verdeling van gokken",
+    "guessAxis": "Waar iedereen gokte",
+    "youMarker": "(JIJ)"
   },
   "artistChallenge": {
     "whoSings": "Wie zingt dit nummer?",

--- a/custom_components/beatify/www/js/player-reveal.js
+++ b/custom_components/beatify/www/js/player-reveal.js
@@ -210,7 +210,9 @@ function renderRoundAnalytics(analytics, correctYear) {
         }
     }
 
-    var histogramHtml = renderHistogram(analytics.all_guesses, correctYear);
+    // #1178: per-player dot-axis replaces the aggregated histogram so each player
+    // can see at a glance where everyone else guessed and what they scored.
+    var histogramHtml = renderPlayerDotAxis(analytics.all_guesses, correctYear, state.playerName);
 
     var achievementsHtml = '';
 
@@ -258,7 +260,7 @@ function renderRoundAnalytics(analytics, correctYear) {
         '</div>' +
         '<div class="stat-comparison-line">' + avgComparison + '</div>' +
         '<div class="analytics-histogram">' +
-        '<h4 class="histogram-title">' + utils.t('analytics.histogram') + '</h4>' +
+        '<h4 class="histogram-title">' + utils.t('analytics.guessAxis') + '</h4>' +
         histogramHtml +
         '</div>' +
         (achievementsHtml ? '<div class="analytics-achievements">' + achievementsHtml + '</div>' : '');
@@ -338,6 +340,113 @@ function renderHistogram(allGuesses, correctYear) {
     }
 
     return '<div class="histogram-bars">' + barsHtml + '</div>';
+}
+
+/**
+ * Render per-player dot-axis (#1178): each player's guess is a colored dot on
+ * a horizontal year-axis, with the correct year marked by a vertical cyan
+ * line. Replaces the aggregated histogram on the player phone — same backend
+ * data (all_guesses), denser per-player view.
+ *
+ * @param {Array} allGuesses - {name, guess, years_off, round_score}[]
+ * @param {number} correctYear - The correct year for the cyan marker
+ * @param {string} currentPlayerName - Mark "you" with an extra ring
+ * @returns {string} HTML string
+ */
+function renderPlayerDotAxis(allGuesses, correctYear, currentPlayerName) {
+    if (!allGuesses || allGuesses.length === 0) {
+        return '<div class="histogram-empty">' + utils.t('analytics.noGuesses') + '</div>';
+    }
+
+    var guessYears = allGuesses.map(function(g) { return g.guess; });
+    var minBound = Math.min.apply(null, guessYears.concat([correctYear]));
+    var maxBound = Math.max.apply(null, guessYears.concat([correctYear]));
+    var pad = Math.max(2, Math.floor((maxBound - minBound) * 0.1));
+    var axisMin = minBound - pad;
+    var axisMax = maxBound + pad;
+    var axisRange = Math.max(1, axisMax - axisMin);
+
+    function pct(year) { return ((year - axisMin) / axisRange) * 100; }
+
+    // Cyan correct-year marker.
+    var correctPct = pct(correctYear);
+    var markerHtml =
+        '<div class="dotaxis-marker" style="left:' + correctPct + '%">' +
+        '<div class="dotaxis-marker-label">' + correctYear + '</div>' +
+        '</div>';
+
+    // 5 evenly spaced axis tick-labels.
+    var ticksHtml = '';
+    for (var t = 0; t <= 4; t++) {
+        var yr = Math.round(axisMin + (axisRange * t / 4));
+        var lp = (t * 25);
+        ticksHtml +=
+            '<div class="dotaxis-tick" style="left:' + lp + '%"></div>' +
+            '<div class="dotaxis-tick-label" style="left:' + lp + '%">' + yr + '</div>';
+    }
+
+    // Player dots. Color is a deterministic hash of name → c1..c4.
+    function colorClass(name) {
+        var h = 0;
+        for (var i = 0; i < name.length; i++) {
+            h = (h * 31 + name.charCodeAt(i)) >>> 0;
+        }
+        return 'c' + ((h % 4) + 1);
+    }
+
+    var dotsHtml = '';
+    for (var k = 0; k < allGuesses.length; k++) {
+        var g = allGuesses[k];
+        var p = pct(g.guess);
+        var initial = (g.name || '?').charAt(0).toUpperCase();
+        var cls = colorClass(g.name || '');
+        var isMe = currentPlayerName && g.name === currentPlayerName;
+        var meCls = isMe ? ' dotaxis-dot--me' : '';
+        var glowCls = (g.years_off === 0) ? ' dotaxis-dot--correct' : '';
+        var score = g.round_score || 0;
+        var scoreCls = score > 0 ? 'dotaxis-score--pos' : 'dotaxis-score--zero';
+        var scoreText = score > 0 ? '+' + score : '+0';
+
+        dotsHtml +=
+            '<div class="dotaxis-dot dotaxis-dot--' + cls + glowCls + meCls + '" ' +
+                'style="left:' + p + '%" ' +
+                'title="' + escapeHtml(g.name) + ' — ' + g.guess + ' (' + scoreText + ')">' +
+            initial +
+            '</div>' +
+            '<div class="dotaxis-score ' + scoreCls + '" style="left:' + p + '%">' + scoreText + '</div>';
+    }
+
+    // Compact legend: name with color-dot, "(DU)" marker for current player.
+    var legendItems = allGuesses.slice().sort(function(a, b) {
+        return (a.years_off || 0) - (b.years_off || 0);
+    });
+    var medals = ['🏆', '🥈', '🥉'];
+    var legendHtml = '';
+    for (var m = 0; m < legendItems.length; m++) {
+        var item = legendItems[m];
+        var lcls = colorClass(item.name || '');
+        var medal = m < 3 ? '<span class="dotaxis-legend-medal">' + medals[m] + '</span>' : '';
+        var meMark = (currentPlayerName && item.name === currentPlayerName)
+            ? ' <span class="dotaxis-legend-me">' + utils.t('analytics.youMarker') + '</span>' : '';
+        legendHtml +=
+            '<span class="dotaxis-legend-entry">' +
+                medal +
+                '<span class="dotaxis-legend-dot dotaxis-dot--' + lcls + '"></span>' +
+                escapeHtml(item.name || '?') + meMark +
+            '</span>';
+    }
+
+    return (
+        '<div class="dotaxis-wrap">' +
+            '<div class="dotaxis-axis">' +
+                ticksHtml +
+                '<div class="dotaxis-line"></div>' +
+                markerHtml +
+                dotsHtml +
+            '</div>' +
+        '</div>' +
+        '<div class="dotaxis-legend">' + legendHtml + '</div>'
+    );
 }
 
 // ============================================


### PR DESCRIPTION
## Summary

Closes #1178.

After each round, instead of the aggregated 7-bin histogram, the player phone reveal now shows every player as a colored dot on a horizontal year-axis (1985 → 2010 scale, auto-bounds). The correct year is marked by a cyan vertical line; each dot carries a tiny `+N` score-bubble. The current player's dot has an orange ring so they spot themselves instantly. A compact legend below shows player names + medal-icons for the top 3.

Direct answer to @Hendrik0123 / Tobias's Reddit DM: _"was der andere getippt hat und wieviele Punkte er dadurch hat"_.

The TV dashboard reveal keeps the aggregated bin histogram (denser data, suits the wide canvas). Phone is where per-player precision matters.

## Mockup (Variant C from /design-shotgun)

Markus picked Variant C from three HTML mockups (interactive histogram / round-recap list / dot-axis). This PR implements the dot-axis.

## Changes

**Backend** (`game/scoring.py`):
- `all_guesses` dict now also carries `round_score` per player. Additive — existing consumers ignore the new key.

**Frontend** (`www/js/player-reveal.js`):
- New `renderPlayerDotAxis(allGuesses, correctYear, currentPlayerName)`. Determines axis bounds from min/max guess (padded). Cyan correct-year marker, 5 tick-labels, colored dots from a name-hash → c1..c4 palette, orange ring for the current player, glow for exact-matches, score-bubbles, sorted legend with medal-icons.
- `renderRoundAnalytics()` now calls the dot-axis instead of the histogram. `renderHistogram()` is preserved (still used by the dashboard/TV reveal — not touched in this PR).

**CSS** (`www/css/styles.css`):
- New `.dotaxis-*` family (axis, line, tick, tick-label, marker, marker-label, dot, dot--c1..c4, dot--correct, dot--me, score, score--pos, score--zero, legend, legend-entry, legend-dot, legend-medal, legend-me). All design tokens reuse existing `--color-bg-primary`, `--color-cyan`, `--font-family-display` where available.

**i18n** (`www/i18n/{en,de,es,fr,nl}.json`):
- New keys `analytics.guessAxis` ("Where everyone guessed" / "Wo alle getippt haben" / …)
- New keys `analytics.youMarker` ("(YOU)" / "(DU)" / …)

## Diff stats

8 files, +268 / -7. No new files. No new dependencies.

## Test plan

- [x] JSON validates in all 5 locales (`python3 -m json.tool`)
- [x] `scoring.py` parses (`ast.parse`)
- [x] Backend change is additive — no existing test or consumer breaks
- [ ] CI green (Lint / Test 3.12+3.13 / HACS / Hassfest)
- [ ] Manual: phone reveal with 2 / 3 / 5 / 8 players → dots position correctly, legend wraps, current-player ring visible
- [ ] Manual: exact-match (years_off=0) player → dot has cyan glow
- [ ] Manual: extreme-spread guesses (1965 vs 2025) → axis bounds auto-expand
- [ ] Manual: i18n switch DE / EN — strings update

🤖 Generated with [Claude Code](https://claude.com/claude-code)