### PR TITLE
data(80er-hits): fix wrong Apple Music URI for Kraftwerk Das Model (#1186)

### DIFF
--- a/custom_components/beatify/playlists/80er-hits.json
+++ b/custom_components/beatify/playlists/80er-hits.json
@@ -1,6 +1,6 @@
 {
   "name": "80s Hits",
-  "version": "2.7",
+  "version": "2.8",
   "tags": [
     "1980s",
     "pop",
@@ -83,7 +83,7 @@
       "fun_fact_fr": "Sorti à l'origine en 1978, 'Das Modell' a atteint le #1 au Royaume-Uni en 1982 lors de sa ressortie en face B, devenue plus populaire que la face A 'Computer Love'.",
       "chart_info": {},
       "awards": [],
-      "uri_apple_music": "applemusic://track/726157363",
+      "uri_apple_music": "applemusic://track/693113326",
       "uri_youtube_music": "https://music.youtube.com/watch?v=qCFIRjycV5Q",
       "uri_tidal": "tidal://track/11210162",
       "uri_deezer": "deezer://track/1006803652",
@@ -91,13 +91,13 @@
       "awards_nl": [],
       "isrc": "USCA20903078",
       "uri_apple_music_by_region": {
-        "us": "applemusic://track/726157363",
-        "de": "applemusic://track/726157363",
-        "gb": "applemusic://track/726157363",
-        "fr": "applemusic://track/726157363",
-        "es": "applemusic://track/726157363",
-        "nl": "applemusic://track/726157363",
-        "it": "applemusic://track/726157363"
+        "us": "applemusic://track/693113326",
+        "de": "applemusic://track/693113326",
+        "gb": "applemusic://track/693113326",
+        "fr": "applemusic://track/693113326",
+        "es": "applemusic://track/693113326",
+        "nl": "applemusic://track/693113326",
+        "it": "applemusic://track/693113326"
       }
     },
     {


### PR DESCRIPTION
Closes #1186. Replaces English "The Model" (`applemusic://track/726157363`) with German "Das Modell" 2009 Remaster (`applemusic://track/693113326`) on all 7 storefronts (us/de/gb/fr/es/nl/it). Bumps playlist version 2.7→2.8.