### PR TITLE
data(90er-hits): fix 3 wrong YouTube Music URIs (#1188)

### DIFF
--- a/custom_components/beatify/playlists/90er-hits.json
+++ b/custom_components/beatify/playlists/90er-hits.json
@@ -1,6 +1,6 @@
 {
   "name": "90s Hits",
-  "version": "1.10",
+  "version": "1.11",
   "tags": [
     "1990s",
     "pop",
@@ -1574,7 +1574,7 @@
         "nl": "applemusic://track/1842243063",
         "it": "applemusic://track/1842243063"
       },
-      "uri_youtube_music": "https://music.youtube.com/watch?v=RSEDv_bZLfs",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Uj9y8MKP5y0",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/347192701",
       "fun_fact": "A chart hit by Funkstar De Luxe (1999).",
@@ -3035,7 +3035,7 @@
         "nl": "applemusic://track/478013623",
         "it": "applemusic://track/478013623"
       },
-      "uri_youtube_music": "https://music.youtube.com/watch?v=JTF0CkXib0s",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=tR4vamT51Nw",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/142393497",
       "fun_fact": "A chart hit by Die Toten Hosen (2011).",
@@ -3102,7 +3102,7 @@
       "uri": "spotify:track:3lcUQs5nyrjoHpQR9Vo2aA",
       "uri_apple_music": null,
       "uri_apple_music_by_region": {},
-      "uri_youtube_music": "https://music.youtube.com/watch?v=MMeA8N1y3JA",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=BlaWhtHmUw4",
       "uri_tidal": null,
       "uri_deezer": null,
       "fun_fact": "A chart hit by The Adventures Of Stevie V (2013).",


### PR DESCRIPTION
Closes #1188. Fixes 3 wrong YouTube Music URIs: Funkstar De Luxe Sun Is Shining (Firebeatz remix → De Luxe Edit), Die Toten Hosen Zehn kleine Jägermeister (wrong song entirely → official MV), Adventures Of Stevie V Dirty Cash (Fitzpatrick techno remix → Sold Out 7 Inch Mix). Bumps version 1.10→1.11.