### PR TITLE
data(pure-pop-punk): fix 5 wrong Spotify URIs (#1193)

### DIFF
--- a/custom_components/beatify/playlists/community/pure-pop-punk.json
+++ b/custom_components/beatify/playlists/community/pure-pop-punk.json
@@ -1,6 +1,6 @@
 {
   "name": "Pure Pop Punk 🎸",
-  "version": "1.4",
+  "version": "1.5",
   "tags": [
     "2000s",
     "pop-punk",
@@ -2253,7 +2253,7 @@
     },
     {
       "year": 2001,
-      "uri": "spotify:track:65mxB9IWpmVo4qUjdGSxRB",
+      "uri": "spotify:track:24CRDgNOgA72JLL7PHFjgB",
       "artist": "blink-182",
       "alt_artists": [
         "Sum 41",
@@ -2361,7 +2361,7 @@
     },
     {
       "year": 2011,
-      "uri": "spotify:track:1hh4GY1zM7SUAyM3a2ziH5",
+      "uri": "spotify:track:5lRhH11B8XYQ5PDuPfnyaL",
       "artist": "Simple Plan, Natasha Bedingfield",
       "alt_artists": [
         "Good Charlotte",
@@ -3029,7 +3029,7 @@
     },
     {
       "year": 2004,
-      "uri": "spotify:track:0I329vpTJRdSRjEcWaQsSL",
+      "uri": "spotify:track:0SUClY63fA1awioMFtMYeE",
       "artist": "Jimmy Eat World",
       "alt_artists": [
         "Third Eye Blind",
@@ -3145,7 +3145,7 @@
     },
     {
       "year": 2005,
-      "uri": "spotify:track:1Up4RdOBpChNDytatxKDXP",
+      "uri": "spotify:track:58HpsDKeYoLtNhXFQyQmz5",
       "artist": "The All-American Rejects",
       "alt_artists": [
         "Boys Like Girls",
@@ -3586,7 +3586,7 @@
     },
     {
       "year": 2006,
-      "uri": "spotify:track:3KLkRy9l3us98SIp6mmxkk",
+      "uri": "spotify:track:6uzuW7L1t1UhnzbfXwtMtQ",
       "artist": "Cute Is What We Aim For",
       "alt_artists": [
         "The Academy Is...",


### PR DESCRIPTION
Closes #1193. Five Spotify track IDs were pointing to sibling songs within the same playlist (Good Charlotte, Less Than Jake, Simple Plan, The Starting Line, Millencolin IDs used for blink-182/Simple Plan/Jimmy Eat World/AAR/CIWWAF entries). Fixed with correct IDs. Bumps version 1.4→1.5.