### PR TITLE
data(world-cup-anthems): fix 4 wrong URIs (#1195)

### DIFF
--- a/custom_components/beatify/playlists/world-cup-anthems.json
+++ b/custom_components/beatify/playlists/world-cup-anthems.json
@@ -1,6 +1,6 @@
 {
   "name": "World Cup Anthems",
-  "version": "1.0",
+  "version": "1.1",
   "tags": [
     "world-cup",
     "fifa",
@@ -135,7 +135,7 @@
       "uri_apple_music": null,
       "uri_youtube_music": null,
       "uri_tidal": null,
-      "uri_deezer": "deezer://track/71964438",
+      "uri_deezer": null,
       "isrc": null,
       "uri_apple_music_by_region": {}
     },
@@ -295,7 +295,7 @@
       "uri_apple_music": "applemusic://track/359615452",
       "uri_youtube_music": null,
       "uri_tidal": null,
-      "uri_deezer": "deezer://track/1072800762",
+      "uri_deezer": null,
       "isrc": null,
       "uri_apple_music_by_region": {}
     },
@@ -317,7 +317,7 @@
       "awards_es": [],
       "awards_fr": [],
       "awards_nl": [],
-      "uri_apple_music": "applemusic://track/1440912652",
+      "uri_apple_music": "applemusic://track/471764799",
       "uri_youtube_music": null,
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3345558141",
@@ -346,7 +346,7 @@
       "awards_es": [],
       "awards_fr": [],
       "awards_nl": [],
-      "uri_apple_music": "applemusic://track/1465709259",
+      "uri_apple_music": "applemusic://track/1536120433",
       "uri_youtube_music": null,
       "uri_tidal": null,
       "uri_deezer": null,


### PR DESCRIPTION
Fixes #1195

## Changes
- **Plácido Domingo — El Mundial** (Deezer): `deezer://track/71964438` was resolving to "El Triste" → removed (song not available on Deezer)
- **Youssou N'Dour & Axelle Red — La Cour des Grands** (Deezer): `deezer://track/1072800762` was resolving to "L'ours" by Christophe Maé → removed (song not available on Deezer)
- **Anastacia — Boom** (Apple Music): `applemusic://track/1440912652` was resolving to Elton John "Saturday Night's Alright" (live) → fixed to `applemusic://track/471764799`
- **Voices of Korea/Japan — Let's Get Together Now** (Apple Music): `applemusic://track/1465709259` was resolving to TWICE "Breakthrough" → fixed to `applemusic://track/1536120433` (Japan version)

Version bump: 1.0 → 1.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)