### PR TITLE
data(one-hit-wonders): fix The La's "There She Goes" year 1990 → 1988 (#1197)

### DIFF
--- a/custom_components/beatify/playlists/one-hit-wonders.json
+++ b/custom_components/beatify/playlists/one-hit-wonders.json
@@ -1,6 +1,6 @@
 {
   "name": "One-Hit Wonders",
-  "version": "1.5",
+  "version": "1.6",
   "tags": [
     "one-hit",
     "classics",
@@ -2164,7 +2164,7 @@
       }
     },
     {
-      "year": 1990,
+      "year": 1988,
       "uri": "spotify:track:4c6vZqYHFur11FbWATIJ9P",
       "artist": "The La's",
       "alt_artists": [


### PR DESCRIPTION
## Summary

Closes #1197.

Player Silvio's in-game year-flag was correct. "There She Goes" was first released as a **Go! Discs single on 31 October 1988** (Bob Andrews production, reached UK #59). The version everyone remembers — the chart hit — is the **Steve Lillywhite remix re-issued on 22 October 1990**. The song's *original* release year is 1988.

Beatify convention (established by closures of #1167 Crystal Waters and #1183 Lenny Kravitz): `year` = original release, not the chart-hit year of a later remix.

## Diff

`one-hit-wonders.json` song #57: `year: 1990 → 1988`. Version bump `1.5 → 1.6`. No URI / metadata changes.

## Sources

- [Wikipedia — There She Goes (The La's song)](https://en.wikipedia.org/wiki/There_She_Goes_(The_La's_song))
- [Discogs — Original 1988 Vinyl Release](https://www.discogs.com/release/858363-The-Las-There-She-Goes)

## Test plan

- [x] Year matches first-release convention (1988-10-31)
- [x] No fun_fact strings contained the year — no text follow-up needed
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)