### PR TITLE
data: fix 1 wrong Spotify URI in hitster-100-en-espanol (#1201)

### DIFF
--- a/custom_components/beatify/playlists/community/hitster-100-en-espanol.json
+++ b/custom_components/beatify/playlists/community/hitster-100-en-espanol.json
@@ -1,6 +1,6 @@
 {
   "name": "100% en Español 🇪🇸",
-  "version": "1.7",
+  "version": "1.8",
   "tags": [
     "spanish",
     "spain",
@@ -2475,7 +2475,7 @@
     },
     {
       "year": 2014,
-      "uri": "spotify:track:6i2kn3iS5WKzsaYBdeHLIQ",
+      "uri": "spotify:track:1i0zBh7TE6qcvy6dVXQ20c",
       "artist": "Shakira, Carlinhos Brown",
       "alt_artists": [
         "Jennifer Lopez",


### PR DESCRIPTION
Closes #1201. Replaced 1 wrong Spotify URI and bumped playlist version to 1.8.

**Change:** `spotify:track:6i2kn3iS5WKzsaYBdeHLIQ` → `spotify:track:1i0zBh7TE6qcvy6dVXQ20c`
**Track:** Shakira, Carlinhos Brown — La La La (Brasil 2014)
**Reason:** Previous URI pointed to a Portuguese cover/lyrics track ("Tradução/Letra"), not the official Shakira recording.