### PR TITLE
data: fix 7 broken URIs in ballermann-party-hits (#1205)

### DIFF
--- a/custom_components/beatify/playlists/community/ballermann-party-hits.json
+++ b/custom_components/beatify/playlists/community/ballermann-party-hits.json
@@ -1,6 +1,6 @@
 {
   "name": "Ballermann Party Hits",
-  "version": "1.2",
+  "version": "1.3",
   "tags": [
     "schlager",
     "party",
@@ -649,7 +649,6 @@
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=5G6WhC39x3k",
       "uri_tidal": null,
-      "uri_deezer": "deezer://track/141827681",
       "alt_artists": [
         "Olaf der Flipper"
       ],
@@ -3117,7 +3116,7 @@
       "year": 1989,
       "isrc": "DEUM71724149",
       "uri": "spotify:track:4rRy0O445uZImn0Lrni1Ip",
-      "uri_apple_music": "applemusic://track/1862840847",
+      "uri_apple_music": "applemusic://track/1676710601",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1862840847",
         "de": "applemusic://track/1862840847",
@@ -3309,7 +3308,7 @@
       "year": 2014,
       "isrc": "DEL942100016",
       "uri": "spotify:track:0J26VAtZqKQsez0WAJh7Q6",
-      "uri_apple_music": "applemusic://track/1565934569",
+      "uri_apple_music": "applemusic://track/981944911",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1565934569",
         "de": "applemusic://track/1565934569",
@@ -3319,9 +3318,9 @@
         "nl": "applemusic://track/1565934569",
         "it": "applemusic://track/1565934569"
       },
-      "uri_youtube_music": "https://music.youtube.com/watch?v=SNrHhfjg5vQ",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=bo-VESZUZY8",
       "uri_tidal": null,
-      "uri_deezer": "deezer://track/2066569277",
+      "uri_deezer": "deezer://track/98699294",
       "fun_fact": "A Mallorca / Ballermann party hit (2022).",
       "fun_fact_de": "Ein Mallorca-/Ballermann-Partyhit (2022).",
       "fun_fact_es": "Un éxito de fiesta de Mallorca / Ballermann (2022).",
@@ -4123,7 +4122,7 @@
         "nl": "applemusic://track/1784923514",
         "it": "applemusic://track/1784923514"
       },
-      "uri_youtube_music": "https://music.youtube.com/watch?v=KJV1ZMMZ0pU",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=nqraNWUjasA",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3136075381",
       "fun_fact": "Mickie Krause is one of Germany's best-known Ballermann entertainers, famous for his sing-along party hits.",
@@ -4523,7 +4522,6 @@
       "year": 2008,
       "isrc": "DEUM72006668",
       "uri": "spotify:track:6utaoKGSLouzClxNttqPa4",
-      "uri_apple_music": "applemusic://track/1862840544",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1862840544",
         "de": "applemusic://track/1862840544",


### PR DESCRIPTION
Closes #1205. Replaced 7 dead/wrong URIs and bumped playlist version to 1.3.

**Fixes:**
- Jürgen Drews — *Irgendwann irgendwo irgendwie* (Apple Music): dead `1862840847` → `1676710601` (Remastered 2017)
- Axel Fischer — *Amsterdam - 2010 Vollgas-Party-Mix* (Apple Music): dead `1862840544` → removed (mix unavailable on AM)
- Lorenz Büffel — *Mallorca Mallorca* (Deezer): wrong `141827681` (was Johnny Däpp) → removed (track ID unconfirmed)
- Stefan Stürmer — *Mallorca - Mein Herz ruft nach Dir* (YouTube Music): wrong `SNrHhfjg5vQ` (was *Mallorca wir sind wieder da*) → `bo-VESZUZY8`
- Stefan Stürmer — *Mallorca - Mein Herz ruft nach Dir* (Deezer): wrong `2066569277` (was *Mallorca ich komm heim*) → `98699294`
- Stefan Stürmer — *Mallorca - Mein Herz ruft nach Dir* (Apple Music): wrong `1565934569` (was *Mallorca ich komm heim*) → `981944911`
- Mickie Krause — *Nur noch Schuhe an - Party-Version 2013* (YouTube Music): wrong `KJV1ZMMZ0pU` (was Zalando branded version) → `nqraNWUjasA`