### PR TITLE
fix(#1122): acquire admin wake lock inside the start-game gesture

### DIFF
--- a/custom_components/beatify/www/js/admin.js
+++ b/custom_components/beatify/www/js/admin.js
@@ -534,6 +534,17 @@ document.addEventListener('DOMContentLoaded', async () => {
         }
     });
     document.getElementById('home-start-game')?.addEventListener('click', async () => {
+        // #1122: Acquire the wake lock SYNCHRONOUSLY here, inside the click's
+        // user-gesture window. The Layer 2 NoSleep.js silent-video fallback
+        // needs an active user activation to call video.play() on iOS — and
+        // iOS consumes that activation after the first `await`. Both start
+        // paths below (startGameplay / startGame) only reach their existing
+        // _requestWakeLock() calls *after* awaiting fetch()/loadStatus(), by
+        // which point the gesture is gone and the video silently fails to
+        // start, so admin/admin+player screens kept sleeping. This call runs
+        // before any await; the later calls are idempotent re-affirms
+        // (guarded by _noSleepActive).
+        _requestWakeLock();
         // Home-mode auto-creates the LOBBY session on enter, so the user's Start
         // button triggers the actual "begin rounds" action (startGameplay).
         // #935: currentGame is null until the async loadStatus() fetch returns,


### PR DESCRIPTION
## Problem

Re #1122. @maxlin1 isolated the bug cleanly on v3.4.4 (iOS): screens stay awake **only** for the pure-player role. **Admin**, **Admin+Player** and the **TV dashboard** still sleep.

## Root cause (verified @HEAD)

All three surfaces (`admin.js`, `dashboard.js`, `player-utils.js`) **already** ship the layered wake lock (Layer 1 native `navigator.wakeLock` + Layer 2 NoSleep.js silent-video). The earlier "admin/dashboard lacks the NoSleep fallback" theory was outdated.

The real issue is **the call site**. On the admin surface, every `_requestWakeLock()` call fires *after* an `await`:
- `startGame()` calls it at line ~2007, **after** `await BeatifyAuth.fetch('/beatify/api/start-game')` + `await response.json()`
- the home-start-game click handler itself `await loadStatus()` and can hit `window.confirm()` before either start path runs

iOS consumes the click's user-activation token after the first `await`, so when NoSleep's `video.play()` finally runs there is no active gesture → iOS rejects it → Layer 2 never engages. Player screens are unaffected because they request inside frequent, fresh touch gestures.

## Fix

Call `_requestWakeLock()` **synchronously as the first statement** of the `home-start-game` click handler, before any `await`, so the silent video starts while the gesture is still hot. The existing later calls (`startGame` ~2007, `#647` reconnect, `visibilitychange`) become idempotent re-affirms (guarded by `_noSleepActive`).

- 1 file, additive, 1 effective new call + comment
- 108/108 vitest green

## Out of scope

The **passive TV/dashboard** case is a separate problem: a wall-mounted display receives **no** user gesture at all, so neither NoSleep video nor native wake lock can start on iOS. That needs a one-time "tap to keep screen awake" overlay or a documented iOS Auto-Lock → Never workaround — intentionally **not** in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)