### PR TITLE
data: fix 5 broken provider URIs in harder-styles (#1209)

### DIFF
--- a/custom_components/beatify/playlists/community/harder-styles.json
+++ b/custom_components/beatify/playlists/community/harder-styles.json
@@ -1,6 +1,6 @@
 {
   "name": "Harder Styles",
-  "version": "1.5",
+  "version": "1.6",
   "tags": [
     "hardstyle",
     "hardcore",
@@ -29,7 +29,7 @@
         "nl": "applemusic://track/1234316278",
         "it": "applemusic://track/1234316278"
       },
-      "uri_youtube_music": "https://music.youtube.com/watch?v=k6KSs-DJdlc",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=d5P-W9W7s-A",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/358775611",
       "fun_fact": "A hardstyle / hardcore track (2008).",
@@ -112,9 +112,9 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": "https://music.youtube.com/watch?v=hbly8I6fkp0",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=x9V3fWmOXkk",
       "uri_tidal": null,
-      "uri_deezer": "deezer://track/3575638661",
+      "uri_deezer": "deezer://track/86472299",
       "alt_artists": [
         "Wildstylez",
         "Noisecontrollers"
@@ -822,7 +822,7 @@
         "nl": "applemusic://track/1740385583",
         "it": "applemusic://track/1740385583"
       },
-      "uri_youtube_music": "https://music.youtube.com/watch?v=IXAmaN2Sje8",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=kqlRcIf6w0c",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/116994412",
       "fun_fact": "A hardstyle / hardcore track (2015).",
@@ -1006,15 +1006,15 @@
       "year": 2016,
       "isrc": "NLS761600444",
       "uri": "spotify:track:2HJlWhSPynPl6me2OCjf3B",
-      "uri_apple_music": "applemusic://track/1219962083",
+      "uri_apple_music": "applemusic://track/1155514601",
       "uri_apple_music_by_region": {
-        "us": "applemusic://track/1219962083",
-        "de": "applemusic://track/1219962083",
-        "gb": "applemusic://track/1219962083",
-        "fr": "applemusic://track/1219962083",
-        "es": "applemusic://track/1219962083",
-        "nl": "applemusic://track/1219962083",
-        "it": "applemusic://track/1219962083"
+        "us": "applemusic://track/1155514601",
+        "de": "applemusic://track/1155514601",
+        "gb": "applemusic://track/1155514601",
+        "fr": "applemusic://track/1155514601",
+        "es": "applemusic://track/1155514601",
+        "nl": "applemusic://track/1155514601",
+        "it": "applemusic://track/1155514601"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=AKKVLba_BmE",
       "uri_tidal": null,
@@ -2684,7 +2684,7 @@
       "uri": "spotify:track:7gCEbFFBn9Mq5C8PhYUP2v",
       "uri_apple_music": null,
       "uri_apple_music_by_region": {},
-      "uri_youtube_music": "https://music.youtube.com/watch?v=lOto8QkiJeU",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=dP_KhSmjFzI",
       "uri_tidal": null,
       "uri_deezer": null,
       "fun_fact": "A hardstyle / hardcore track (2018).",


### PR DESCRIPTION
Closes #1209.

Replaces 5 dead/wrong per-provider URIs in `community/harder-styles.json` found by the daily playlist-review audit, and bumps the playlist version 1.5 → 1.6.

| Song | Provider | Old → New |
|---|---|---|
| Dozer – Church of the Darkside (Original Edit) | YouTube Music | Piano Version → `d5P-W9W7s-A` |
| Headhunterz – Tonight (Original Mix) | YouTube Music | Alpha² Remix → `x9V3fWmOXkk` (official Topic) |
| Headhunterz – Tonight (Original Mix) | Deezer | Alpha² Remix → `track/86472299` |
| Deepack – Down Low (2016 Reamp) | YouTube Music | 2015 Radio Version → `kqlRcIf6w0c` (Q-dance) |
| Ransom – The Great Unknown | YouTube Music | wrong track → `dP_KhSmjFzI` (Q-dance) |
| Digital Punk – Hit Me With The Hard | Apple Music | `1219962083` (404) → `1155514601` (main + 7 region IDs) |

All replacements re-validated through `validate_uris.py` → **7/7 ok**. Diff is 14/14 lines (URIs + version only); 190 songs unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)