### PR TITLE
data: fix 3 broken URIs in trance-classics (#1213)

### DIFF
--- a/custom_components/beatify/playlists/community/trance-classics.json
+++ b/custom_components/beatify/playlists/community/trance-classics.json
@@ -1,6 +1,6 @@
 {
   "name": "Trance Classics",
-  "version": "1.0",
+  "version": "1.1",
   "tags": [
     "trance",
     "hands-up",
@@ -2395,7 +2395,7 @@
       "year": 2004,
       "isrc": "DEVY92500111",
       "uri": "spotify:track:4m4H1c9VvFH8xBoniWNkEl",
-      "uri_apple_music": "applemusic://track/1736231517",
+      "uri_apple_music": "applemusic://track/1809974901",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1809974901",
         "de": "applemusic://track/1809974901",
@@ -2470,7 +2470,7 @@
       "year": 2004,
       "isrc": "DEN060401868",
       "uri": "spotify:track:6jbglMwIqyg1G1N96COAsD",
-      "uri_apple_music": "applemusic://track/1361152140",
+      "uri_apple_music": "applemusic://track/41483825",
       "uri_apple_music_by_region": {
         "us": null,
         "de": "applemusic://track/1573248494",
@@ -2822,7 +2822,7 @@
       "uri": "spotify:track:1vkOScXgwl6dX6UF4x5sIx",
       "uri_apple_music": null,
       "uri_apple_music_by_region": {},
-      "uri_youtube_music": "https://music.youtube.com/watch?v=4nqZ_6-SFJw",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=01UCTSe2BX8",
       "uri_tidal": null,
       "uri_deezer": null,
       "fun_fact": "A trance and dance-floor classic (2006).",


### PR DESCRIPTION
Closes #1213. Replaced 3 wrong URIs and bumped playlist version to 1.1.

- **The Disco Boys — For You** (Apple Music): was pointing to "Panic! At the Disco — Hey Look Ma, I Made It"; fixed to `applemusic://track/41483825`
- **Karotte — Go To Bed** (YouTube Music): was pointing to "Ketambourine (Dave Shokh Remix)"; fixed to `https://music.youtube.com/watch?v=01UCTSe2BX8`
- **Roman Flügel — Geht's Noch?** (Apple Music): was pointing to "La Forza Del Destino (Radio Slave Remix)"; fixed to `applemusic://track/1809974901`

66 other `wrong_track` flags were dismissed as false positives (version/edit/mix suffixes, Spotify oEmbed format quirk).