### PR TITLE
playlist(anime-openings): fix Masatoshi Ono – Departure! year 2022→2011 (#1218)

### DIFF
--- a/custom_components/beatify/playlists/community/anime-openings.json
+++ b/custom_components/beatify/playlists/community/anime-openings.json
@@ -1,6 +1,6 @@
 {
   "name": "Anime Openings",
-  "version": "1.7",
+  "version": "1.8",
   "tags": [
     "anime",
     "japanese",
@@ -1062,7 +1062,7 @@
     {
       "artist": "Masatoshi Ono",
       "title": "Departure!",
-      "year": 2022,
+      "year": 2011,
       "isrc": "JPVP01107401",
       "uri": "spotify:track:5sjoJa0YmBCCPMrBPsBMge",
       "uri_apple_music": "applemusic://track/551273032",


### PR DESCRIPTION
## Data fix — wrong year

**Song:** Masatoshi Ono – "Departure!" (`community/anime-openings.json`)
**Year in playlist:** 2022 → **2011** (corrected)

### Verification
"departure!" is the **Hunter × Hunter (2011)** opening theme. The single was released **2011-12-21**.

- ISRC `JPVP01107401` → year-of-reference `11` = **2011** (intrinsic confirmation)
- [Deezer single](https://www.deezer.com/us/album/548671252), [Spotify track](https://open.spotify.com/track/5sjoJa0YmBCCPMrBPsBMge), animesonglyrics — all HxH 2011 OP

Beatify convention = original single release year. 2022 was clearly wrong.

Bumped playlist `version` 1.7 → 1.8.

Closes #1218