### PR TITLE
playlist(edm-anthems): fix R3HAB – How We Party Apple Music URI (wrong track)

### DIFF
--- a/custom_components/beatify/playlists/community/edm-anthems.json
+++ b/custom_components/beatify/playlists/community/edm-anthems.json
@@ -1,6 +1,6 @@
 {
   "name": "EDM Anthems",
-  "version": "1.1",
+  "version": "1.2",
   "tags": [
     "edm",
     "electronic",
@@ -2594,7 +2594,7 @@
       "year": 2014,
       "isrc": "NLZ541400629",
       "uri": "spotify:track:2b0N6oW4f87wNr9uahicc2",
-      "uri_apple_music": "applemusic://track/310863481",
+      "uri_apple_music": "applemusic://track/1346085087",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1346085087",
         "de": "applemusic://track/1346085087",


### PR DESCRIPTION
## Wrong-track Apple Music URI

**Track:** R3HAB – "How We Party" (`community/edm-anthems.json`, ISRC `NLZ541400629`)

`uri_apple_music` pointed to **`applemusic://track/310863481`** which is actually **"Hardwell & R3HAB – Mrkrstft (Original Mix)"** — a different song. On an Apple Music storefront this plays the wrong track (or strict-detect skips it).

### Fix
Corrected to **`applemusic://track/1346085087`** = **"R3HAB & Vinai – How We Party"**.

### Verification
- iTunes lookup `310863481` → "Hardwell & R3HAB – Mrkrstft" (confirmed wrong)
- iTunes lookup `1346085087` → "R3HAB & Vinai – How We Party" (correct)
- Deezer ISRC `NLZ541400629` → "R3HAB – How We Party" (canonical recording)
- The `uri_apple_music_by_region` IDs already used `1346085087`; only the top-level field was stale

Caught by the playlist-review job (2026-06-02). Bumped `version` 1.1 → 1.2.