### PR TITLE
release: v3.4.5-rc2 (Lights, Camera, Stay Awake)

### DIFF
--- a/custom_components/beatify/manifest.json
+++ b/custom_components/beatify/manifest.json
@@ -12,5 +12,5 @@
   "documentation": "https://github.com/mholzi/beatify",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/mholzi/beatify/issues",
-  "version": "3.4.5-rc1"
+  "version": "3.4.5-rc2"
 }

--- a/docs/release-notes-v3.4.5-rc2.md
+++ b/docs/release-notes-v3.4.5-rc2.md
@@ -1,0 +1,29 @@
+## v3.4.5-rc2 — Lights, Camera, Stay Awake
+
+A few screens used to nod off in the middle of a game and quietly drop people out. Not anymore. This build keeps your displays awake, lines the round timer up with the spoken announcements, sharpens the reveal — and adds a brand-new movie-songs playlist to play with.
+
+### 📺 Your screens stay awake now
+
+If your phone or your big-screen dashboard ever dimmed mid-round and disconnected you, that's fixed. Beatify now holds the screen awake from the moment you start a game — including passive TV and dashboard displays that nobody is touching. Thanks to **@maxlin1** for flagging the disconnect.
+
+### ⏱️ The timer lines up with the announcements
+
+When spoken announcements are switched on, the round timer now waits for the voice to finish before the clock starts. The countdown matches the music instead of running about ten seconds ahead. Thanks to **@nixbuongiorno** for the catch.
+
+### 🎬 A clearer reveal
+
+On your phone, the reveal now places a dot for every player along the timeline, so you can see at a glance where everyone landed. On the TV, the round advances on its own with a countdown ring — no need to tap through. Requested by **@Dtrieb**.
+
+### 🎉 New music to play
+
+Two fresh playlists to dig into: **iconic-movie-songs** — 72 unforgettable songs from the movies, with a dedicated movie-guessing mode — and **world-cup-anthems**, the official tournament songs from 1962 to today. The Disney and disco-funk collections both grew, too.
+
+### 🙏 Thank you
+
+Beatify keeps getting better because you tell us what's off. Thanks to **@maxlin1**, **@nixbuongiorno** and **@Dtrieb** for this round — keep the reports coming.
+
+---
+
+**38 playlists · 4,340 songs · 5 music platforms · 5 languages**
+
+[Report a Bug](https://github.com/mholzi/beatify/issues) · [Discussions](https://github.com/mholzi/beatify/discussions) · [Full Changelog](https://github.com/mholzi/beatify/blob/main/CHANGELOG.md)


### PR DESCRIPTION
Pre-release bump to **v3.4.5-rc2**.

Bumps `manifest.json` → `3.4.5-rc2` and adds `docs/release-notes-v3.4.5-rc2.md`.

Bundles everything player-facing since v3.4.4: wake-lock fixes (#1122/#1208), timer↔TTS sync (#1211), clearer reveal (#1178/#1185), and the new iconic-movie-songs playlist (#1217).

After merge: tag `v3.4.5-rc2` + GitHub pre-release with the notes as body.