### PR TITLE
feat(tts): localize voice announcements to the selected game language

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to Beatify are documented here. For detailed release notes, 
 ## [Unreleased]
 
 ### Added
+- **Localized TTS voice announcements.** In-game voice announcements now follow the selected game language (German, Spanish, French, Dutch) instead of always speaking English — the `language` setting previously drove only the web UI. The game language is forwarded to the TTS engine only when the target entity advertises support for it (resolved to the engine's own code, e.g. `de`→`de-DE`), so an unsupported code can't silence announcements. Numbers (years, scores, round/streak counts) are spoken as words via `num2words` so neural engines (e.g. ElevenLabs) don't swallow bare digits in non-English speech. English output is unchanged. Adds the `num2words` dependency.
 - **iconic-movie-songs — new community playlist (72 tracks).** Iconic songs from the movies, built end-to-end through the in-app "request a playlist" funnel and enriched across all providers (Spotify, Apple Music across 7 storefront regions, Deezer, YouTube Music), with a dedicated movie-quiz mode (`movie` + `movie_choices`). Closes #1215 (PR #1217).
 
 ### Fixed

--- a/custom_components/beatify/game/state.py
+++ b/custom_components/beatify/game/state.py
@@ -68,6 +68,7 @@ from .scoring import (
 )
 from .protocols import MediaPlayerProtocol, PartyLightsProtocol
 from .serializers import GameStateSerializer
+from . import tts_phrases
 
 from .types import RoundAnalytics, _get_decade_label
 
@@ -2298,11 +2299,21 @@ class GameState:
         """Disable TTS announcements."""
         self._tts_service = None
 
+    def _lang(self) -> str:
+        """Resolve the game's TTS language, defaulting to English.
+
+        ``self.language`` is injected by the start-game handlers; fall back to
+        English defensively so announcements never crash if it's unset.
+        """
+        return tts_phrases.normalize_language(getattr(self, "language", None))
+
     async def _tts_announce(self, message: str) -> None:
         """Speak a TTS announcement (fire-and-forget)."""
         if self._tts_service:
             try:
-                task = asyncio.create_task(self._tts_service.speak(message))
+                task = asyncio.create_task(
+                    self._tts_service.speak(message, language=self._lang())
+                )
                 self._bg_tasks.add(task)
                 task.add_done_callback(self._bg_tasks.discard)
             except Exception:  # noqa: BLE001
@@ -2312,9 +2323,12 @@ class GameState:
         """Announce game start (use case 16)."""
         if not self._tts_service or not self._tts_announce_game_start:
             return
-        message = (
-            f"Let's play Beatify! {self.total_rounds} rounds, "
-            f"{self.difficulty} difficulty."
+        lang = self._lang()
+        message = tts_phrases.phrase(
+            lang,
+            "game_start",
+            rounds=tts_phrases.spoken_number(lang, self.total_rounds),
+            difficulty=tts_phrases.difficulty_label(lang, self.difficulty),
         )
         await self._tts_announce(message)
 
@@ -2322,13 +2336,17 @@ class GameState:
         """Announce the winner (use case 18)."""
         if not self._tts_service or not self._tts_announce_winner or not self.players:
             return
+        lang = self._lang()
         top_score = max(p.score for p in self.players.values())
         winners = [p for p in self.players.values() if p.score == top_score]
+        points = tts_phrases.spoken_number(lang, top_score)
         if len(winners) == 1:
-            message = f"And the winner is... {winners[0].name} with {top_score} points!"
+            message = tts_phrases.phrase(
+                lang, "winner_single", name=winners[0].name, points=points
+            )
         else:
-            names = " and ".join(w.name for w in winners)
-            message = f"It's a tie between {names} with {top_score} points!"
+            names = tts_phrases.join_names(lang, [w.name for w in winners])
+            message = tts_phrases.phrase(lang, "winner_tie", names=names, points=points)
         await self._tts_announce(message)
 
     # ------------------------------------------------------------------
@@ -2339,7 +2357,10 @@ class GameState:
         """Announce round start (use case 1). Fires after round number bump."""
         if not self._tts_service or not self._tts_announce_round_start:
             return
-        message = f"Round {self.round} — get ready!"
+        lang = self._lang()
+        message = tts_phrases.phrase(
+            lang, "round_start", round=tts_phrases.spoken_number(lang, self.round)
+        )
         await self._tts_announce(message)
 
     async def announce_countdown(self) -> None:
@@ -2351,7 +2372,7 @@ class GameState:
         """
         if not self._tts_service or not self._tts_announce_countdown:
             return
-        message = "Three, two, one — go!"
+        message = tts_phrases.phrase(self._lang(), "countdown")
         await self._tts_announce(message)
 
     async def announce_time_up(self) -> None:
@@ -2360,7 +2381,7 @@ class GameState:
         """
         if not self._tts_service or not self._tts_announce_time_up:
             return
-        message = "Time's up!"
+        message = tts_phrases.phrase(self._lang(), "time_up")
         await self._tts_announce(message)
 
     async def _announce_reveal(self, correct_year: int | None) -> None:
@@ -2378,51 +2399,67 @@ class GameState:
         """
         if not self._tts_service:
             return
+        lang = self._lang()
         players = list(self.players.values())
         frags: list[str] = []
 
         # Correct answer.
         if self._tts_announce_correct_answer and correct_year is not None:
-            frags.append(f"The answer was {correct_year}.")
+            year = tts_phrases.spoken_number(lang, correct_year, "year")
+            frags.append(tts_phrases.phrase(lang, "answer", year=year))
 
         # Accuracy — exact guesses, else the Closest-Wins winner, else the
         # "nobody got it" line (mutually exclusive).
         exact = [p.name for p in players if p.submitted and p.years_off == 0]
         had_submitters = any(p.submitted for p in players)
         if exact and self._tts_announce_exact_guess:
-            names = exact[0] if len(exact) == 1 else " and ".join(exact)
-            frags.append(f"{names} got it exactly right.")
+            names = tts_phrases.join_names(lang, exact)
+            frags.append(tts_phrases.phrase(lang, "exact", names=names))
         elif self.closest_wins_mode and not exact and self._tts_announce_closest_guess:
             submitted = [p for p in players if p.submitted and p.years_off is not None]
             if submitted:
                 winner = min(submitted, key=lambda p: p.years_off)
                 if winner.round_score > 0:
-                    frags.append(f"{winner.name} was closest.")
+                    frags.append(tts_phrases.phrase(lang, "closest", name=winner.name))
         elif had_submitters and not exact and self._tts_announce_nobody_correct:
-            frags.append("Nobody got it this round.")
+            frags.append(tts_phrases.phrase(lang, "nobody"))
 
         # Streak milestones — streak_bonus is non-zero only on the exact
         # round a milestone (3/5/10/15/20/25) is reached.
         if self._tts_announce_streak_milestone:
             for p in players:
                 if p.streak_bonus > 0:
-                    frags.append(f"{p.name} is on a {p.streak}-song streak.")
+                    frags.append(
+                        tts_phrases.phrase(
+                            lang,
+                            "streak_milestone",
+                            name=p.name,
+                            streak=tts_phrases.spoken_number(lang, p.streak),
+                        )
+                    )
 
         # Streak broken — previous_streak holds the pre-reset length. Gate
         # at >= 3 so a one-off miss after a short run doesn't trigger it.
         if self._tts_announce_streak_broken:
             for p in players:
                 if p.streak == 0 and p.previous_streak >= 3:
-                    frags.append(f"{p.name}'s streak ends at {p.previous_streak}.")
+                    frags.append(
+                        tts_phrases.phrase(
+                            lang,
+                            "streak_broken",
+                            name=p.name,
+                            previous=tts_phrases.spoken_number(lang, p.previous_streak),
+                        )
+                    )
 
         # Bet outcomes — gated on submitted so a stale outcome can't misfire.
         for p in players:
             if not (p.submitted and p.bet):
                 continue
             if p.bet_outcome == "won" and self._tts_announce_bet_won:
-                frags.append(f"{p.name} doubled their points.")
+                frags.append(tts_phrases.phrase(lang, "bet_won", name=p.name))
             elif p.bet_outcome == "lost" and self._tts_announce_bet_lost:
-                frags.append(f"{p.name} loses the bet.")
+                frags.append(tts_phrases.phrase(lang, "bet_lost", name=p.name))
 
         # Steal unlocks — once per player per game. The dedup set is updated
         # regardless of the toggle so a mid-game toggle-on can't replay it.
@@ -2430,7 +2467,9 @@ class GameState:
             if p.steal_available and p.name not in self._tts_steal_unlocked_announced:
                 self._tts_steal_unlocked_announced.add(p.name)
                 if self._tts_announce_steal_unlocked:
-                    frags.append(f"{p.name} unlocked steal.")
+                    frags.append(
+                        tts_phrases.phrase(lang, "steal_unlocked", name=p.name)
+                    )
 
         # Standings — leader change / tie at the top. _tts_previous_leader
         # is updated regardless of the toggles so detection stays correct.
@@ -2440,7 +2479,7 @@ class GameState:
             leaders = [p for p in leaderboard if p.score == top_score]
             if len(leaders) > 1:
                 if self._tts_announce_tied_first:
-                    frags.append("It's a tie at the top.")
+                    frags.append(tts_phrases.phrase(lang, "tie_at_top"))
                 self._tts_previous_leader = None
             else:
                 new_leader = leaders[0].name
@@ -2451,7 +2490,9 @@ class GameState:
                         self._tts_previous_leader is not None
                         and self._tts_announce_leader_change
                     ):
-                        frags.append(f"{new_leader} just took the lead.")
+                        frags.append(
+                            tts_phrases.phrase(lang, "leader_change", name=new_leader)
+                        )
                 self._tts_previous_leader = new_leader
 
         if frags:
@@ -2465,7 +2506,7 @@ class GameState:
         """Announce a new player joining the game (use case 14)."""
         if not self._tts_service or not self._tts_announce_player_join:
             return
-        message = f"{player_name} has joined the game!"
+        message = tts_phrases.phrase(self._lang(), "player_join", name=player_name)
         await self._tts_announce(message)
 
     async def announce_player_reconnect(self, player_name: str) -> None:
@@ -2477,7 +2518,7 @@ class GameState:
         """
         if not self._tts_service or not self._tts_announce_player_reconnect:
             return
-        message = f"Welcome back, {player_name}!"
+        message = tts_phrases.phrase(self._lang(), "player_reconnect", name=player_name)
         await self._tts_announce(message)
 
     async def announce_last_round(self) -> None:
@@ -2488,7 +2529,7 @@ class GameState:
         """
         if not self._tts_service or not self._tts_announce_last_round:
             return
-        message = "This is the final round!"
+        message = tts_phrases.phrase(self._lang(), "last_round")
         await self._tts_announce(message)
 
     async def announce_podium(self) -> None:
@@ -2504,9 +2545,10 @@ class GameState:
         podium = [p for p in ranked if p.score > 0][:3]
         if not podium:
             return
-        labels = {0: "1st place", 1: "2nd place", 2: "3rd place"}
+        lang = self._lang()
         segments = [
-            f"{labels[i]}: {podium[i].name}{'!' if i == 0 else '.'}"
+            f"{tts_phrases.place_label(lang, i + 1)}: "
+            f"{podium[i].name}{'!' if i == 0 else '.'}"
             for i in reversed(range(len(podium)))
         ]
         await self._tts_announce(" ".join(segments))
@@ -2515,7 +2557,7 @@ class GameState:
         """Announce a rematch starting (use case 20)."""
         if not self._tts_service or not self._tts_announce_rematch:
             return
-        message = "Rematch! Get ready!"
+        message = tts_phrases.phrase(self._lang(), "rematch")
         await self._tts_announce(message)
 
     # ------------------------------------------------------------------
@@ -2526,15 +2568,17 @@ class GameState:
         """Announce the start of an intro-mode round (use case 21)."""
         if not self._tts_service or not self._tts_announce_intro_round:
             return
-        await self._tts_announce(
-            "Intro round — quick, you only get the opening seconds!"
-        )
+        await self._tts_announce(tts_phrases.phrase(self._lang(), "intro_round"))
 
     async def announce_steal_used(self, stealer_name: str, target_name: str) -> None:
         """Announce a player using steal on another (use case 23)."""
         if not self._tts_service or not self._tts_announce_steal_used:
             return
-        await self._tts_announce(f"{stealer_name} stole the answer from {target_name}!")
+        await self._tts_announce(
+            tts_phrases.phrase(
+                self._lang(), "steal_used", stealer=stealer_name, target=target_name
+            )
+        )
 
     def adjust_volume(self, direction: str) -> float:
         """

--- a/custom_components/beatify/game/tts_phrases.py
+++ b/custom_components/beatify/game/tts_phrases.py
@@ -1,0 +1,257 @@
+"""Localized TTS announcement phrases.
+
+Game TTS announcements were hardcoded English: the game's ``language`` setting
+(en/de/es/fr/nl) was wired only to the web UI, so spoken announcements always
+came out in English regardless of the selected language. This module holds the
+spoken-phrase templates per language.
+
+English is authoritative — its strings MUST stay byte-identical to the original
+announcement code (the announcement tests pin them). Any missing language or
+missing key falls back to English, and a translation that fails to format (e.g.
+a stray placeholder) also falls back to English so a bad string can never break
+a live game.
+
+Templates are ``str.format`` strings; placeholders like ``{name}`` are filled by
+the caller. ``{names}`` may hold a single name or several joined by
+``join_names`` (the language's "and" word).
+"""
+
+from __future__ import annotations
+
+DEFAULT_LANGUAGE = "en"
+
+# Languages the game accepts (matches the validation in the WS/REST handlers).
+SUPPORTED_LANGUAGES = ("en", "de", "es", "fr", "nl")
+
+# Word joining names in a spoken list ("Marco and Anna"). The English form uses
+# " and ".join(...) verbatim, so two names read "A and B" and the rare 3+ case
+# reads "A and B and C" exactly as before.
+_AND: dict[str, str] = {
+    "en": "and",
+    "de": "und",
+    "es": "y",
+    "fr": "et",
+    "nl": "en",
+}
+
+# Spoken difficulty labels inserted into the game_start template via {difficulty}.
+_DIFFICULTY: dict[str, dict[str, str]] = {
+    "en": {"easy": "easy", "normal": "normal", "hard": "hard"},
+    "de": {"easy": "leicht", "normal": "normal", "hard": "schwer"},
+    "es": {"easy": "fácil", "normal": "normal", "hard": "difícil"},
+    "fr": {"easy": "facile", "normal": "normale", "hard": "difficile"},
+    "nl": {"easy": "makkelijk", "normal": "normaal", "hard": "moeilijk"},
+}
+
+# Podium place labels, used as "{label}: {name}" in the top-3 readout.
+_PLACE: dict[str, dict[int, str]] = {
+    "en": {1: "1st place", 2: "2nd place", 3: "3rd place"},
+    "de": {1: "erster Platz", 2: "zweiter Platz", 3: "dritter Platz"},
+    "es": {1: "primer puesto", 2: "segundo puesto", 3: "tercer puesto"},
+    "fr": {1: "première place", 2: "deuxième place", 3: "troisième place"},
+    "nl": {1: "eerste plaats", 2: "tweede plaats", 3: "derde plaats"},
+}
+
+# str.format templates per language. Keys must be identical across languages;
+# English is the fallback for any missing language or key.
+_PHRASES: dict[str, dict[str, str]] = {
+    "en": {
+        "game_start": "Let's play Beatify! {rounds} rounds, {difficulty} difficulty.",
+        "winner_single": "And the winner is... {name} with {points} points!",
+        "winner_tie": "It's a tie between {names} with {points} points!",
+        "round_start": "Round {round} — get ready!",
+        "countdown": "Three, two, one — go!",
+        "time_up": "Time's up!",
+        "player_join": "{name} has joined the game!",
+        "player_reconnect": "Welcome back, {name}!",
+        "last_round": "This is the final round!",
+        "rematch": "Rematch! Get ready!",
+        "intro_round": "Intro round — quick, you only get the opening seconds!",
+        "steal_used": "{stealer} stole the answer from {target}!",
+        "answer": "The answer was {year}.",
+        "exact": "{names} got it exactly right.",
+        "closest": "{name} was closest.",
+        "nobody": "Nobody got it this round.",
+        "streak_milestone": "{name} is on a {streak}-song streak.",
+        "streak_broken": "{name}'s streak ends at {previous}.",
+        "bet_won": "{name} doubled their points.",
+        "bet_lost": "{name} loses the bet.",
+        "steal_unlocked": "{name} unlocked steal.",
+        "tie_at_top": "It's a tie at the top.",
+        "leader_change": "{name} just took the lead.",
+    },
+    "de": {
+        "game_start": "Auf geht's mit Beatify! {rounds} Runden, Schwierigkeit {difficulty}.",
+        "winner_single": "Und der Sieger ist... {name} mit {points} Punkten!",
+        "winner_tie": "Gleichstand zwischen {names} mit je {points} Punkten!",
+        "round_start": "Runde {round} — macht euch bereit!",
+        "countdown": "Drei, zwei, eins — los!",
+        "time_up": "Zeit ist um!",
+        "player_join": "{name} ist jetzt im Spiel dabei!",
+        "player_reconnect": "Willkommen zurück, {name}!",
+        "last_round": "Das ist die letzte Runde!",
+        "rematch": "Revanche! Macht euch bereit!",
+        "intro_round": "Intro-Runde — schnell, ihr hört nur die ersten Sekunden!",
+        "steal_used": "{stealer} hat {target} die Antwort geklaut!",
+        "answer": "Die Antwort war {year}.",
+        "exact": "Goldrichtig: {names}.",
+        "closest": "{name} war am nächsten dran.",
+        "nobody": "Diese Runde hatte niemand richtig.",
+        "streak_milestone": "{name} ist auf einer Serie von {streak} Songs!",
+        "streak_broken": "{name}s Serie endet bei {previous}.",
+        "bet_won": "{name} hat die Punkte verdoppelt.",
+        "bet_lost": "{name} verliert die Wette.",
+        "steal_unlocked": "{name} hat Klauen freigeschaltet.",
+        "tie_at_top": "Gleichstand an der Spitze.",
+        "leader_change": "{name} geht in Führung!",
+    },
+    "es": {
+        "game_start": "¡A jugar a Beatify! {rounds} rondas, dificultad {difficulty}.",
+        "winner_single": "Y el ganador es... ¡{name} con {points} puntos!",
+        "winner_tie": "¡Empate entre {names} con {points} puntos!",
+        "round_start": "Ronda {round}: ¡preparados!",
+        "countdown": "Tres, dos, uno... ¡ya!",
+        "time_up": "¡Se acabó el tiempo!",
+        "player_join": "¡{name} entra en juego!",
+        "player_reconnect": "¡Bienvenido de nuevo, {name}!",
+        "last_round": "¡Esta es la ronda final!",
+        "rematch": "¡Revancha! ¡Preparados!",
+        "intro_round": "¡Ronda intro! Rápido, ¡solo suenan los primeros segundos!",
+        "steal_used": "¡{stealer} le robó la respuesta a {target}!",
+        "answer": "La respuesta era {year}.",
+        "exact": "{names}: ¡respuesta exacta!",
+        "closest": "{name} fue quien más se acercó.",
+        "nobody": "Nadie acertó esta ronda.",
+        "streak_milestone": "{name} lleva una racha de {streak} canciones.",
+        "streak_broken": "La racha de {name} se corta en {previous}.",
+        "bet_won": "{name} dobla sus puntos.",
+        "bet_lost": "{name} pierde la apuesta.",
+        "steal_unlocked": "{name} desbloquea el robo.",
+        "tie_at_top": "¡Empate en la cima!",
+        "leader_change": "¡{name} se pone en cabeza!",
+    },
+    "fr": {
+        "game_start": "On joue à Beatify ! {rounds} manches, difficulté {difficulty}.",
+        "winner_single": "Et le gagnant est... {name} avec {points} points !",
+        "winner_tie": "Égalité entre {names} avec {points} points !",
+        "round_start": "Manche {round} — préparez-vous !",
+        "countdown": "Trois, deux, un — partez !",
+        "time_up": "Temps écoulé !",
+        "player_join": "{name} rejoint la partie !",
+        "player_reconnect": "Bon retour, {name} !",
+        "last_round": "C'est la dernière manche !",
+        "rematch": "Revanche ! Préparez-vous !",
+        "intro_round": "Manche intro — vite, vous n'avez que les premières secondes !",
+        "steal_used": "{stealer} a volé la réponse de {target} !",
+        "answer": "La réponse était {year}.",
+        "exact": "{names}, dans le mille !",
+        "closest": "{name} était le plus proche.",
+        "nobody": "Personne n'a trouvé cette manche.",
+        "streak_milestone": "{name} enchaîne {streak} titres d'affilée.",
+        "streak_broken": "La série de {name} s'arrête à {previous}.",
+        "bet_won": "{name} double ses points.",
+        "bet_lost": "{name} perd son pari.",
+        "steal_unlocked": "{name} débloque le vol.",
+        "tie_at_top": "Égalité en tête.",
+        "leader_change": "{name} prend la tête !",
+    },
+    "nl": {
+        "game_start": "We spelen Beatify! {rounds} rondes, moeilijkheid {difficulty}.",
+        "winner_single": "En de winnaar is... {name} met {points} punten!",
+        "winner_tie": "Gelijkspel tussen {names} met {points} punten!",
+        "round_start": "Ronde {round} — maak je klaar!",
+        "countdown": "Drie, twee, een — go!",
+        "time_up": "De tijd is om!",
+        "player_join": "{name} doet mee!",
+        "player_reconnect": "Welkom terug, {name}!",
+        "last_round": "Dit is de laatste ronde!",
+        "rematch": "Revanche! Maak je klaar!",
+        "intro_round": "Introronde — snel, je hoort alleen de eerste seconden!",
+        "steal_used": "{stealer} jatte het antwoord van {target}!",
+        "answer": "Het antwoord was {year}.",
+        "exact": "{names} had het precies goed.",
+        "closest": "{name} zat er het dichtst bij.",
+        "nobody": "Niemand had het deze ronde goed.",
+        "streak_milestone": "{name} heeft een reeks van {streak} nummers.",
+        "streak_broken": "De reeks van {name} eindigt op {previous}.",
+        "bet_won": "{name} verdubbelt de punten.",
+        "bet_lost": "{name} verliest de weddenschap.",
+        "steal_unlocked": "{name} heeft jatten vrijgespeeld.",
+        "tie_at_top": "Het is gelijkspel aan kop.",
+        "leader_change": "{name} neemt de leiding.",
+    },
+}
+
+
+def normalize_language(language: str | None) -> str:
+    """Return a language we have phrases for, defaulting to English."""
+    if language and language in _PHRASES:
+        return language
+    return DEFAULT_LANGUAGE
+
+
+def phrase(language: str | None, key: str, **kwargs: object) -> str:
+    """Render a localized announcement phrase, falling back to English.
+
+    Falls back to the English template when the language/key is missing, and
+    again if a (translated) template fails to format — a malformed string must
+    never break a live game.
+    """
+    lang = normalize_language(language)
+    template = _PHRASES.get(lang, {}).get(key)
+    if template is None:
+        template = _PHRASES[DEFAULT_LANGUAGE][key]
+    try:
+        return template.format(**kwargs)
+    except (KeyError, IndexError, ValueError):
+        return _PHRASES[DEFAULT_LANGUAGE][key].format(**kwargs)
+
+
+def join_names(language: str | None, names: list[str]) -> str:
+    """Join names for speech ("Marco and Anna") using the language's word.
+
+    Mirrors the original ``" and ".join(...)`` so English output is unchanged.
+    """
+    lang = normalize_language(language)
+    and_word = _AND.get(lang, _AND[DEFAULT_LANGUAGE])
+    return f" {and_word} ".join(names)
+
+
+def difficulty_label(language: str | None, difficulty: str) -> str:
+    """Localized label for a difficulty value (easy/normal/hard)."""
+    lang = normalize_language(language)
+    table = _DIFFICULTY.get(lang, _DIFFICULTY[DEFAULT_LANGUAGE])
+    en = _DIFFICULTY[DEFAULT_LANGUAGE]
+    return table.get(difficulty) or en.get(difficulty, difficulty)
+
+
+def place_label(language: str | None, place: int) -> str:
+    """Localized podium label for a 1-based place (1/2/3)."""
+    lang = normalize_language(language)
+    table = _PLACE.get(lang, _PLACE[DEFAULT_LANGUAGE])
+    en = _PLACE[DEFAULT_LANGUAGE]
+    return table.get(place) or en.get(place, str(place))
+
+
+def spoken_number(language: str | None, value: int, kind: str = "cardinal") -> str:
+    """Render a number as words so neural TTS engines don't swallow bare digits.
+
+    Some engines (observed with ElevenLabs) read digits cleanly in English but
+    drop a bare multi-digit number in other languages. Spelling it out in the
+    game language avoids relying on the engine's number normalization.
+
+    English keeps digits — engines read them fine and the English announcement
+    strings are pinned. ``kind`` is ``"year"`` for a natural year reading (e.g.
+    "neunzehnhunderteinundneunzig") or ``"cardinal"`` for counts. Falls back to
+    digits if num2words is unavailable or errors, so an announcement is never
+    lost over a number.
+    """
+    lang = normalize_language(language)
+    if lang == DEFAULT_LANGUAGE:
+        return str(value)
+    try:
+        from num2words import num2words  # noqa: PLC0415
+
+        return num2words(value, lang=lang, to=kind)
+    except Exception:  # noqa: BLE001 — never let a number break the announcement
+        return str(value)

--- a/custom_components/beatify/manifest.json
+++ b/custom_components/beatify/manifest.json
@@ -12,5 +12,8 @@
   "documentation": "https://github.com/mholzi/beatify",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/mholzi/beatify/issues",
+  "requirements": [
+    "num2words==0.5.14"
+  ],
   "version": "3.4.5-rc2"
 }

--- a/custom_components/beatify/services/tts.py
+++ b/custom_components/beatify/services/tts.py
@@ -11,6 +11,29 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 
 
+def _match_language(language: str | None, supported: list[str] | None) -> str | None:
+    """Resolve a game language to a code the TTS engine actually supports.
+
+    Returns the engine's own code (so game ``"de"`` resolves to ``"de-DE"`` when
+    that's what the engine advertises), or ``None`` when the language can't be
+    matched — callers then omit it rather than forcing a code the engine would
+    reject (which makes some engines drop the announcement entirely). Matching is
+    case-insensitive and treats ``-``/``_`` separators alike, first exact then by
+    base language.
+    """
+    if not language or not supported:
+        return None
+    target = language.lower()
+    for code in supported:
+        if code.lower() == target:
+            return code
+    for code in supported:
+        base = code.lower().replace("_", "-").split("-", 1)[0]
+        if base == target:
+            return code
+    return None
+
+
 class TTSService:
     """Announce game events via Home Assistant TTS.
 
@@ -35,8 +58,16 @@ class TTSService:
         self._tts_entity_id = tts_entity_id
         self._media_player_entity_id = media_player_entity_id
 
-    async def speak(self, message: str) -> None:
-        """Speak a message via TTS. Fails gracefully if either entity is unavailable."""
+    async def speak(self, message: str, language: str | None = None) -> None:
+        """Speak a message via TTS. Fails gracefully if either entity is unavailable.
+
+        ``language`` (e.g. ``"de"``) is the game language. It is forwarded to
+        ``tts.speak`` ONLY when the target entity advertises support for it
+        (resolved to the engine's own code, e.g. ``"de-DE"``). If support can't
+        be confirmed it is omitted and the engine uses its configured voice —
+        forcing an unsupported code makes some engines silently drop the
+        announcement. The message text is already localized either way.
+        """
         if not message:
             return
         if not self._tts_entity_id or not self._media_player_entity_id:
@@ -63,15 +94,22 @@ class TTSService:
             )
             return
 
+        service_data = {
+            "entity_id": self._tts_entity_id,
+            "media_player_entity_id": self._media_player_entity_id,
+            "message": message,
+        }
+        resolved = (
+            _match_language(language, self._supported_languages()) if language else None
+        )
+        if resolved:
+            service_data["language"] = resolved
+
         try:
             await self._hass.services.async_call(
                 "tts",
                 "speak",
-                {
-                    "entity_id": self._tts_entity_id,
-                    "media_player_entity_id": self._media_player_entity_id,
-                    "message": message,
-                },
+                service_data,
                 blocking=False,
             )
         except Exception:  # noqa: BLE001
@@ -80,3 +118,28 @@ class TTSService:
                 self._tts_entity_id,
                 self._media_player_entity_id,
             )
+
+    def _supported_languages(self) -> list[str] | None:
+        """Best-effort read of the TTS entity's advertised language codes.
+
+        Locates the ``tts`` entity component regardless of HA version (it scans
+        ``hass.data`` for the component rather than assuming a key) and returns
+        the entity's ``supported_languages``. Returns ``None`` on any problem so
+        the caller safely omits the language rather than guessing one.
+        """
+        try:
+            from homeassistant.helpers.entity_component import (  # noqa: PLC0415
+                EntityComponent,
+            )
+
+            for value in self._hass.data.values():
+                if (
+                    isinstance(value, EntityComponent)
+                    and getattr(value, "domain", None) == "tts"
+                ):
+                    entity = value.get_entity(self._tts_entity_id)
+                    langs = getattr(entity, "supported_languages", None)
+                    return list(langs) if langs else None
+        except Exception:  # noqa: BLE001 — introspection is strictly best-effort
+            return None
+        return None

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -4,3 +4,4 @@ pytest>=8.0
 pytest-asyncio>=1.0
 pytest-cov>=6.0
 aiohttp>=3.11
+num2words>=0.5.14  # spoken-number rendering for TTS announcements

--- a/tests/unit/test_tts_localization.py
+++ b/tests/unit/test_tts_localization.py
@@ -1,0 +1,284 @@
+"""Tests for localized TTS announcements.
+
+The game's ``language`` setting (en/de/es/fr/nl) used to drive only the web UI;
+spoken announcements were hardcoded English. ``game.tts_phrases`` adds per-
+language phrase tables and ``GameState`` now renders announcements in the game
+language and forwards that language to ``tts.speak`` so multilingual engines use
+the matching voice.
+
+The placeholder-fidelity tests are the safety net for the (machine-assisted)
+de/es/fr/nl translations: any missing key or drifted ``{placeholder}`` fails CI
+rather than silently degrading a live game.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import string
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.beatify.game import tts_phrases as tp
+from custom_components.beatify.game.player import PlayerSession
+from custom_components.beatify.services.tts import TTSService, _match_language
+from tests.conftest import make_game_state
+
+# A superset of every placeholder used by any phrase, so a template renders
+# regardless of which slots it uses.
+SAMPLE = {
+    "rounds": 10,
+    "difficulty": "normal",
+    "name": "Marco",
+    "names": "Marco and Anna",
+    "points": 42,
+    "round": 3,
+    "year": 1991,
+    "streak": 5,
+    "previous": 4,
+    "stealer": "Marco",
+    "target": "Anna",
+}
+
+
+def _fields(template: str) -> set[str]:
+    """Placeholder names referenced by a str.format template."""
+    return {
+        name for _, name, _, _ in string.Formatter().parse(template) if name is not None
+    }
+
+
+# ---------------------------------------------------------------------------
+# Pack integrity — the translation safety net
+# ---------------------------------------------------------------------------
+
+
+def test_every_language_has_every_phrase_key():
+    en_keys = set(tp._PHRASES["en"])
+    assert set(tp._PHRASES) == set(tp.SUPPORTED_LANGUAGES)
+    for lang, pack in tp._PHRASES.items():
+        assert set(pack) == en_keys, f"{lang} phrase keys differ from English"
+
+
+def test_placeholder_sets_match_english_exactly():
+    # Every translated phrase must use the SAME {placeholders} as English —
+    # none missing, added, renamed, or with text translated inside the braces.
+    for key, en_template in tp._PHRASES["en"].items():
+        expected = _fields(en_template)
+        for lang in tp.SUPPORTED_LANGUAGES:
+            assert _fields(tp._PHRASES[lang][key]) == expected, f"{lang}/{key}"
+
+
+def test_every_phrase_formats_without_error_or_stray_braces():
+    for lang in tp.SUPPORTED_LANGUAGES:
+        for key, template in tp._PHRASES[lang].items():
+            rendered = template.format(**SAMPLE)
+            assert "{" not in rendered and "}" not in rendered, f"{lang}/{key}"
+
+
+def test_aux_tables_cover_every_language():
+    for lang in tp.SUPPORTED_LANGUAGES:
+        assert lang in tp._AND
+        assert set(tp._DIFFICULTY[lang]) == {"easy", "normal", "hard"}
+        assert set(tp._PLACE[lang]) == {1, 2, 3}
+
+
+# ---------------------------------------------------------------------------
+# Helper behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_language_falls_back_to_english():
+    assert tp.normalize_language("de") == "de"
+    assert tp.normalize_language("xx") == "en"
+    assert tp.normalize_language(None) == "en"
+    assert tp.normalize_language("") == "en"
+
+
+def test_phrase_english_is_byte_identical_to_original():
+    # These must match the pre-localization hardcoded strings verbatim.
+    assert tp.phrase("en", "time_up") == "Time's up!"
+    assert tp.phrase("en", "round_start", round=3) == "Round 3 — get ready!"
+    assert tp.phrase("en", "answer", year=1991) == "The answer was 1991."
+    assert tp.phrase("en", "countdown") == "Three, two, one — go!"
+    assert (
+        tp.phrase("en", "game_start", rounds=10, difficulty="normal")
+        == "Let's play Beatify! 10 rounds, normal difficulty."
+    )
+
+
+def test_phrase_renders_german():
+    assert tp.phrase("de", "time_up") == "Zeit ist um!"
+    assert tp.phrase("de", "round_start", round=4) == "Runde 4 — macht euch bereit!"
+    assert tp.phrase("de", "answer", year=1991) == "Die Antwort war 1991."
+
+
+def test_phrase_unknown_language_falls_back_to_english():
+    assert tp.phrase("xx", "time_up") == "Time's up!"
+
+
+def test_phrase_malformed_translation_falls_back_to_english(monkeypatch):
+    # A bad translation (stray placeholder) must never crash a live game.
+    broken = dict(tp._PHRASES)
+    broken["de"] = dict(broken["de"], answer="Antwort {does_not_exist}.")
+    monkeypatch.setattr(tp, "_PHRASES", broken)
+    assert tp.phrase("de", "answer", year=1991) == "The answer was 1991."
+
+
+def test_join_names_uses_language_word():
+    assert tp.join_names("en", ["Marco"]) == "Marco"
+    assert tp.join_names("en", ["Marco", "Anna"]) == "Marco and Anna"
+    assert tp.join_names("de", ["Marco", "Anna"]) == "Marco und Anna"
+    assert tp.join_names("fr", ["Marco", "Anna"]) == "Marco et Anna"
+
+
+def test_difficulty_and_place_labels_localized():
+    assert tp.difficulty_label("en", "normal") == "normal"
+    assert tp.difficulty_label("de", "hard") == "schwer"
+    assert tp.difficulty_label("xx", "easy") == "easy"
+    assert tp.place_label("en", 1) == "1st place"
+    assert tp.place_label("de", 1) == "erster Platz"
+
+
+def test_spoken_number_english_keeps_digits():
+    # English reads digits fine and its strings are pinned — never spell out.
+    assert tp.spoken_number("en", 1991, "year") == "1991"
+    assert tp.spoken_number("en", 42) == "42"
+    assert tp.spoken_number("xx", 1991) == "1991"  # unknown → English/digits
+
+
+def test_spoken_number_spells_out_non_english():
+    assert tp.spoken_number("de", 1991, "year") == "neunzehnhunderteinundneunzig"
+    assert tp.spoken_number("de", 42) == "zweiundvierzig"
+    assert tp.spoken_number("fr", 1991, "year") == "mille neuf cent quatre-vingt-onze"
+    assert tp.spoken_number("es", 2005, "year") == "dos mil cinco"
+
+
+# ---------------------------------------------------------------------------
+# GameState wiring
+# ---------------------------------------------------------------------------
+
+
+def _player(name, **fields):
+    player = PlayerSession(name=name, ws=None)
+    for key, value in fields.items():
+        setattr(player, key, value)
+    return player
+
+
+@pytest.mark.asyncio
+async def test_announce_round_start_localized_german():
+    state = make_game_state()
+    state._tts_service = MagicMock()
+    state._tts_announce = AsyncMock()
+    state.language = "de"
+    state.round = 4
+    await state.announce_round_start()
+    state._tts_announce.assert_awaited_once_with("Runde vier — macht euch bereit!")
+
+
+@pytest.mark.asyncio
+async def test_announce_round_start_defaults_to_english_when_unset():
+    # No language set on the state → English, unchanged behaviour.
+    state = make_game_state()
+    state._tts_service = MagicMock()
+    state._tts_announce = AsyncMock()
+    state.round = 4
+    await state.announce_round_start()
+    state._tts_announce.assert_awaited_once_with("Round 4 — get ready!")
+
+
+@pytest.mark.asyncio
+async def test_announce_reveal_localized_german():
+    state = make_game_state()
+    state._tts_service = MagicMock()
+    state._tts_announce = AsyncMock()
+    state.language = "de"
+    state.players = {"Marco": _player("Marco", submitted=True, years_off=0, score=10)}
+    await state._announce_reveal(1991)
+    spoken = state._tts_announce.await_args.args[0]
+    assert "Die Antwort war neunzehnhunderteinundneunzig." in spoken
+    assert "Goldrichtig: Marco." in spoken
+
+
+@pytest.mark.asyncio
+async def test_tts_announce_forwards_language_to_speak():
+    state = make_game_state()
+    svc = MagicMock()
+    svc.speak = AsyncMock()
+    state._tts_service = svc
+    state.language = "de"
+    await state._tts_announce("hallo")
+    await asyncio.sleep(0)  # let the fire-and-forget task run
+    svc.speak.assert_awaited_once_with("hallo", language="de")
+
+
+# ---------------------------------------------------------------------------
+# TTSService language forwarding
+# ---------------------------------------------------------------------------
+
+
+def _make_hass() -> MagicMock:
+    hass = MagicMock()
+    hass.services.async_call = AsyncMock()
+
+    def _get(entity_id: str):
+        if entity_id.startswith(("tts.", "media_player.")):
+            return MagicMock(state="idle")
+        return None
+
+    hass.states.get = MagicMock(side_effect=_get)
+    return hass
+
+
+def _payload(hass: MagicMock) -> dict:
+    args, kwargs = hass.services.async_call.call_args
+    for value in (*args, *kwargs.values()):
+        if isinstance(value, dict) and "message" in value:
+            return value
+    raise AssertionError("no service-data dict with 'message' found")
+
+
+def test_match_language_exact_then_prefix():
+    assert _match_language("de", ["en-US", "de-DE"]) == "de-DE"  # de -> de-DE
+    assert _match_language("de", ["de", "en"]) == "de"  # exact wins
+    assert _match_language("de", ["DE_DE"]) == "DE_DE"  # case/sep-insensitive
+    assert _match_language("de", ["en-US", "fr-FR"]) is None  # unsupported
+    assert _match_language("de", None) is None
+    assert _match_language("de", []) is None
+    assert _match_language(None, ["de-DE"]) is None
+
+
+@pytest.mark.asyncio
+async def test_speak_forwards_resolved_language_when_supported(monkeypatch):
+    hass = _make_hass()
+    svc = TTSService(hass, "tts.x", "media_player.y")
+    monkeypatch.setattr(svc, "_supported_languages", lambda: ["en-US", "de-DE"])
+    await svc.speak("hallo", language="de")
+    assert _payload(hass)["language"] == "de-DE"
+
+
+@pytest.mark.asyncio
+async def test_speak_omits_language_when_unsupported(monkeypatch):
+    hass = _make_hass()
+    svc = TTSService(hass, "tts.x", "media_player.y")
+    monkeypatch.setattr(svc, "_supported_languages", lambda: ["en-US"])
+    await svc.speak("hallo", language="de")
+    assert "language" not in _payload(hass)
+
+
+@pytest.mark.asyncio
+async def test_speak_omits_language_when_support_unknown(monkeypatch):
+    # Introspection failed (e.g. older HA) → omit rather than force a code.
+    hass = _make_hass()
+    svc = TTSService(hass, "tts.x", "media_player.y")
+    monkeypatch.setattr(svc, "_supported_languages", lambda: None)
+    await svc.speak("hallo", language="de")
+    assert "language" not in _payload(hass)
+
+
+@pytest.mark.asyncio
+async def test_speak_omits_language_when_not_set():
+    hass = _make_hass()
+    await TTSService(hass, "tts.x", "media_player.y").speak("hello")
+    assert "language" not in _payload(hass)


### PR DESCRIPTION
## Summary

In-game TTS voice announcements were hardcoded in English. The game `language` setting (`en`/`de`/`es`/`fr`/`nl`) only drove the **web UI** (i18n) — the server-side announcement strings ignored it, so announcements always spoke English even with German selected.

This PR localizes the spoken announcements to the selected game language, forwards that language to the TTS engine safely, and makes numbers robust on neural engines.

## Root cause

`GameState.announce_*` and `_announce_reveal` built every message as a hardcoded English f-string and never read `self.language`. `tts.speak` was also called without a `language`, so even a German-capable voice wasn't told which language to use.

## Changes

- **New `game/tts_phrases.py`** — per-language phrase tables (`de`/`es`/`fr`/`nl`), with **English authoritative and byte-identical** to the previous strings (the existing announcement tests pin them). A missing language/key — or a malformed translation that fails to format — falls back to English, so a bad string can never break a live game. Helpers: `phrase()`, `join_names()`, `difficulty_label()`, `place_label()`, `spoken_number()`.
- **`game/state.py`** — all `announce_*` methods and the combined REVEAL utterance now render in the game language (`self._lang()`, defaulting to English).
- **`services/tts.py`** — the game language is forwarded to `tts.speak` **only when the target entity advertises support for it**, resolved to the engine's own code (e.g. `de` → `de-DE`). If support can't be confirmed it is omitted, so an unsupported code can't silently drop the announcement and the engine uses its configured voice. Introspection is best-effort and version-independent (scans `hass.data` for the `tts` `EntityComponent`).
- **Spelled-out numbers** — years, scores, and round/streak counts are spoken as words via `num2words` in non-English languages (e.g. `1991` → "neunzehnhunderteinundneunzig"), because some neural engines (observed with ElevenLabs) swallow bare multi-digit numbers in non-English speech. English keeps digits. Falls back to digits if `num2words` is unavailable.

## Behavior & compatibility

- **English is unchanged** (text and number formatting) — verified by the pre-existing announcement tests.
- No config or migration needed; it follows the language the host already selects at game start.

## New dependency

- Adds `num2words==0.5.14` to `manifest.json` `requirements` (pure-Python; Home Assistant installs it automatically on integration load). Also added to `requirements_test.txt`.

## Testing

- **605 unit tests pass** (`pytest tests/unit/`), incl. new `tests/unit/test_tts_localization.py`: per-language placeholder-fidelity (identical `{placeholder}` sets across all languages, every template formats without error), English byte-identical output, German rendering, language-forwarding only when supported (`de`→`de-DE`), and number spelling.
- `ruff check .` and `ruff format --check .` clean.
- **Manually verified in a live Home Assistant game** (German, ElevenLabs voice via Home Assistant): announcements speak German, the voice matches, and years/scores come through cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)