### PR TITLE
data: fix dead Apple Music URI for Vincent Gross Ouzo in hits-2010s-2020s (#1226)

### DIFF
--- a/custom_components/beatify/playlists/hits-2010s-2020s.json
+++ b/custom_components/beatify/playlists/hits-2010s-2020s.json
@@ -1,6 +1,6 @@
 {
   "name": "2010s & 2020s Hits",
-  "version": "1.4",
+  "version": "1.5",
   "tags": [
     "pop",
     "charts",
@@ -1357,14 +1357,14 @@
       "year": 2023,
       "isrc": "CH7812354719",
       "uri": "spotify:track:6QeQs7lz8qR2miwx9n2epp",
-      "uri_apple_music": "applemusic://track/1862841058",
+      "uri_apple_music": "applemusic://track/1705233750",
       "uri_apple_music_by_region": {
-        "us": "applemusic://track/1862841058",
-        "de": "applemusic://track/1862841058",
-        "gb": "applemusic://track/1862841058",
-        "fr": "applemusic://track/1862841058",
-        "es": "applemusic://track/1862841058",
-        "nl": "applemusic://track/1862841058",
+        "us": "applemusic://track/1705233750",
+        "de": "applemusic://track/1705233750",
+        "gb": "applemusic://track/1705233750",
+        "fr": "applemusic://track/1705233750",
+        "es": "applemusic://track/1705233750",
+        "nl": "applemusic://track/1705233750",
         "it": "applemusic://track/1705233750"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=bKoWnKMgRr8",


### PR DESCRIPTION
Closes #1226. Replaced dead Apple Music URI `applemusic://track/1862841058` (404 in US/DE/GB) with correct `applemusic://track/1705233750` for Vincent Gross - Ouzo across all 7 storefronts. Version bumped 1.4→1.5.

3 `wrong_track` flags dismissed as false positives: PSY Gangnam Style Korean/English title order swap on YT; Daft Punk Get Lucky bracket parser confusion on YT; Mike Posner Cooler Than Me Single Mix suffix inversion on Spotify.