### PR TITLE
fix(reveal): cancel auto-advance in end_game to prevent a post-end song (#1012)

### DIFF
--- a/custom_components/beatify/game/state.py
+++ b/custom_components/beatify/game/state.py
@@ -755,6 +755,12 @@ class GameState:
         """End the current game and reset state."""
         _LOGGER.info("Game ended: %s", self.game_id)
         self.cancel_timer()
+        # #1012: cancel the REVEAL auto-advance task synchronously, BEFORE the
+        # awaits below. Otherwise a countdown expiring at the same instant could
+        # fire start_round() during disable_party_lights()/disable_tts() (phase
+        # is still REVEAL there) and trigger the next song after the game ended.
+        # advance_to_end() already does this; the HTTP/force-end path lands here.
+        self._cancel_auto_advance()
         # Issue #331: Restore lights before resetting
         await self.disable_party_lights()
         # Issue #447: Disable TTS

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -225,6 +225,34 @@ class TestRevealAutoAdvance:
         # Phase left REVEAL — stop() must NOT be called (would silence new song)
         state._media_player_service.stop.assert_not_awaited()
 
+    async def test_end_game_cancels_auto_advance_task(self):
+        """#1012 hardening: ending the game during REVEAL must cancel the
+        auto-advance task synchronously, before end_game's awaits — otherwise a
+        countdown expiring at that instant could fire start_round() (phase still
+        REVEAL inside disable_party_lights/disable_tts) and play the next song
+        after the game ended. Mirrors advance_to_end(); guards the HTTP/force-end
+        path that calls end_game() directly.
+        """
+        state = make_game_state()
+        _create_fresh_game(state, reveal_auto_advance=30)
+        state.phase = GamePhase.REVEAL
+        state.start_round = AsyncMock()
+
+        # A real pending auto-advance task, parked on its first poll-sleep.
+        task = asyncio.create_task(state._reveal_auto_advance(30))
+        state._auto_advance_task = task
+        await asyncio.sleep(0)  # let it reach `await asyncio.sleep(poll)`
+
+        await state.end_game()
+
+        # Handle cleared, task cancelled, no next round triggered.
+        assert state._auto_advance_task is None
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert task.cancelled()
+        state.start_round.assert_not_awaited()
+        assert state.phase == GamePhase.LOBBY
+
 
 # ---------------------------------------------------------------------------
 # REVEAL countdown surface (#1048)


### PR DESCRIPTION
## Problem

You asked: *end the game while the reveal countdown is running — will the next song still be triggered?*

For the in-game **"End game" button** the answer is no: it goes through `admin_end_game` → `stop_media()` → `advance_to_end()`, which cancels the auto-advance task **synchronously before any `await`** and flips the phase to `END`. Race-free.

But there's a second end path — the HTTP `EndGameView` / force-reset in `game_views.py` — that calls **`end_game()` directly**. `end_game()` only cancelled the *round* timer (`cancel_timer()`), not the REVEAL auto-advance task. It relied solely on flipping `phase = LOBBY`, and it does that **after** two `await`s (`disable_party_lights()`, `disable_tts()`).

So a narrow race existed: if the game was force-ended at the exact instant the reveal countdown expired, the auto-advance task could wake during those awaits — phase still `REVEAL` — pass its `if self.phase != REVEAL: return` guard, and call `start_round()`, **playing the next song after the game ended**.

## Fix

Cancel the auto-advance task synchronously at the top of `end_game()`, before any `await`:

```python
self.cancel_timer()
self._cancel_auto_advance()   # <-- added
await self.disable_party_lights()
...
```

`task.cancel()` guarantees the task's next resume raises `CancelledError` instead of continuing — so even though `end_game()` yields right after, the auto-advance task can't reach `start_round()`. This mirrors what `advance_to_end()` already does, making both end paths consistent.

## Test

- New regression in `tests/unit/test_state.py`: parks a real `_reveal_auto_advance` task, calls `end_game()`, asserts the task is cancelled, the handle is cleared, `start_round()` never fires, and phase is `LOBBY`.
- **Verified it fails without the fix** (task left pending) and passes with it.
- Full unit suite: 608/608 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)