### PR TITLE
chore: P3 polish — TTS number guard + wizard light-mode chip test

### DIFF
--- a/custom_components/beatify/game/tts_phrases.py
+++ b/custom_components/beatify/game/tts_phrases.py
@@ -246,6 +246,12 @@ def spoken_number(language: str | None, value: int, kind: str = "cardinal") -> s
     digits if num2words is unavailable or errors, so an announcement is never
     lost over a number.
     """
+    # Defensive (callers always pass plain ints): guard a stray None / float so
+    # it can never speak as "None" or "neunzehn Komma fünf" in an announcement.
+    if value is None:
+        return ""
+    if isinstance(value, float):
+        value = round(value)
     lang = normalize_language(language)
     if lang == DEFAULT_LANGUAGE:
         return str(value)

--- a/custom_components/beatify/www/js/__tests__/wizard.test.js
+++ b/custom_components/beatify/www/js/__tests__/wizard.test.js
@@ -3,7 +3,7 @@
  * These helpers drive the state machine: when to show, where to resume, when to show the pill.
  */
 import { describe, it, expect, beforeEach } from 'vitest';
-import { resumeAtStep, shouldTrigger, shouldShowPill, providerSupportedForPlayer, capabilityBadgeForPlayer } from '../wizard.js';
+import { resumeAtStep, shouldTrigger, shouldShowPill, providerSupportedForPlayer, capabilityBadgeForPlayer, buildWizChip } from '../wizard.js';
 
 function makeLS(initial = {}) {
     const store = { ...initial };
@@ -192,5 +192,28 @@ describe('capabilityBadgeForPlayer', () => {
         const player = { supports_spotify: true, supports_apple_music: true, supports_youtube_music: true };
         const badge = capabilityBadgeForPlayer(player, providers, { all: 'Alle Dienste' });
         expect(badge.label).toBe('Alle Dienste');
+    });
+});
+
+// ------------------------------------------------------------------
+// buildWizChip — Light Mode chip markup contract (#1228 regression)
+// ------------------------------------------------------------------
+describe('buildWizChip', () => {
+    it('emits a kebab-case data-light-mode attribute (matches the [data-light-mode] binding)', () => {
+        const html = buildWizChip('static', 'Static', 'light-mode', 'dynamic');
+        // The exact attribute that broke before: must be data-light-mode, not
+        // data-lightMode. The browser maps data-light-mode -> dataset.lightMode
+        // by spec, so locking the kebab attribute name guards the whole binding.
+        expect(html).toContain('data-light-mode="static"');
+        expect(html).not.toContain('data-lightMode');
+    });
+
+    it('marks the active chip and only the active chip', () => {
+        expect(buildWizChip('static', 'Static', 'light-mode', 'static')).toContain('wiz-chip active');
+        expect(buildWizChip('dynamic', 'Dynamic', 'light-mode', 'static')).not.toContain('active');
+    });
+
+    it('works for the intensity group too', () => {
+        expect(buildWizChip('party', 'Party', 'intensity', 'party')).toContain('data-intensity="party"');
     });
 });

--- a/custom_components/beatify/www/js/wizard.js
+++ b/custom_components/beatify/www/js/wizard.js
@@ -616,6 +616,22 @@ const LANGUAGES = [
     { id: 'nl', label: 'Nederlands' },
 ];
 
+/**
+ * Build a wizard chip button. Pure helper so the attribute contract is testable
+ * (#1228 regression: the `data-<group>` name must stay kebab-case so the
+ * `[data-light-mode]` click binding + `dataset.lightMode` read keep matching —
+ * a `data-lightMode` typo silently unbinds the Static/Dynamic/WLED chips).
+ * @param {string} id - chip value, written into data-<group>
+ * @param {string} label - visible text
+ * @param {string} group - kebab-case attribute group (e.g. "light-mode")
+ * @param {string} activeId - currently-selected id; adds "active" when it matches
+ * @returns {string} button HTML
+ */
+export function buildWizChip(id, label, group, activeId) {
+    const active = activeId === id ? ' active' : '';
+    return `<button type="button" class="wiz-chip${active}" data-${group}="${id}">${label}</button>`;
+}
+
 function _renderChipGroup(elId, items, active, onPick) {
     const el = document.getElementById(elId);
     if (!el) return;
@@ -765,7 +781,7 @@ function _lightsDetailHtml() {
              placeholder="${_t('wizard.step5.lights.searchPlaceholder', 'Search lights…')}"
              aria-label="${_t('wizard.step5.lights.searchPlaceholder', 'Search lights…')}">`
         : '';
-    const chip = (id, label, group) => `<button type="button" class="wiz-chip ${(group === 'intensity' ? chosenLightIntensity : chosenLightMode) === id ? 'active' : ''}" data-${group}="${id}">${label}</button>`;
+    const chip = (id, label, group) => buildWizChip(id, label, group, group === 'intensity' ? chosenLightIntensity : chosenLightMode);
 
     const wledBlock = chosenLightMode === 'wled'
         ? `<div class="wiz-field">

--- a/tests/unit/test_tts_localization.py
+++ b/tests/unit/test_tts_localization.py
@@ -154,6 +154,16 @@ def test_spoken_number_spells_out_non_english():
     assert tp.spoken_number("es", 2005, "year") == "dos mil cinco"
 
 
+def test_spoken_number_guards_none_and_float():
+    # Defense-in-depth (#1225): a stray None / float must never speak as "None"
+    # or a fractional reading. None drops out; a float rounds to a whole number.
+    assert tp.spoken_number("de", None) == ""
+    assert tp.spoken_number("en", None) == ""
+    assert tp.spoken_number("en", 19.0) == "19"
+    assert tp.spoken_number("de", 42.4) == "zweiundvierzig"  # rounds, no "Komma"
+    assert "," not in tp.spoken_number("de", 19.5)  # never "neunzehn Komma fünf"
+
+
 # ---------------------------------------------------------------------------
 # GameState wiring
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Two low-severity (P3) follow-ups flagged during the post-3.4.4 verification of #1225 and #1228. Both are defense-in-depth — neither was reachable on the live path.

## TTS number guard (#1225)
`spoken_number()` would return the literal `"None"` for a `None` value and read a float as e.g. "neunzehn Komma fünf". Callers always pass plain ints (year is `is not None`-gated), but the guard makes a stray value impossible to speak:
- `None` → `""` (drops out of the phrase)
- `float` → rounded to a whole number

## Wizard light-mode chip test (#1228)
The Static / Dynamic / WLED chips broke once before on a `data-lightMode` vs `[data-light-mode]` case mismatch, and nothing tested it. Extracted a pure `buildWizChip(id, label, group, activeId)` helper (the inline renderer now delegates to it, behaviour unchanged) and added a regression test that locks the kebab-case `data-light-mode` attribute — the browser maps `data-light-mode` → `dataset.lightMode` by spec, so locking the attribute name guards the whole click binding.

## Test
- Python: **609/609** (new `test_spoken_number_guards_none_and_float`).
- JS: **117/117** (3 new `buildWizChip` cases).
- No bundle or version/cache-buster changes — `tts_phrases.py` is server-side and `wizard.js` is served as raw source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)