### PR TITLE
data: fix 5 wrong-year reports (#1237–#1241)

### DIFF
--- a/custom_components/beatify/playlists/community/ballermann-party-hits.json
+++ b/custom_components/beatify/playlists/community/ballermann-party-hits.json
@@ -3155,7 +3155,7 @@
     {
       "artist": "Jürgen Drews",
       "title": "Ein Bett im Kornfeld - Version 2017",
-      "year": 1976,
+      "year": 2017,
       "isrc": "DEUM71724145",
       "uri": "spotify:track:6vxwh7gW1qhl3XW4QHGznj",
       "uri_apple_music": "applemusic://track/1838526767",

--- a/custom_components/beatify/playlists/community/eurodance-90s.json
+++ b/custom_components/beatify/playlists/community/eurodance-90s.json
@@ -469,7 +469,7 @@
       "awards_nl": []
     },
     {
-      "year": 1986,
+      "year": 1998,
       "uri": "spotify:track:2X7jfQnEMQYYmvkhr6mzS9",
       "artist": "Modern Talking, Eric Singleton",
       "alt_artists": [

--- a/custom_components/beatify/playlists/disney-classics.json
+++ b/custom_components/beatify/playlists/disney-classics.json
@@ -2816,7 +2816,7 @@
       }
     },
     {
-      "year": 1997,
+      "year": 2017,
       "artist": "Christy Altomare",
       "title": "Journey to the Past",
       "uri": "spotify:track:5bVNYvkjRZuaQnKKdAGuq5",

--- a/custom_components/beatify/playlists/one-hit-wonders.json
+++ b/custom_components/beatify/playlists/one-hit-wonders.json
@@ -2280,7 +2280,7 @@
       }
     },
     {
-      "year": 1991,
+      "year": 1990,
       "uri": "spotify:track:5VYTKiOnHw4iTrB9pG3yum",
       "artist": "EMF",
       "alt_artists": [


### PR DESCRIPTION
## Wrong-year data fixes

Batch of in-game data-quality flags. Each song's `year` was corrected to follow Beatify's tagging convention (original release year, unless the title marks a specific re-recording).

| Song | Playlist(s) | Old → New | Justification |
|------|-------------|-----------|---------------|
| EMF – Unbelievable | one-hit-wonders | 1991 → 1990 | Original UK single released Oct 1990; 1991 was the US chart-topping year. Tag by original release. |
| Jürgen Drews – Ein Bett im Kornfeld - Version 2017 | community/ballermann-party-hits | 1976 → 2017 | Title marks the 2017 re-recording (ISRC DEUM71724145). Original 1976 entry ("Ein Bett Im Kornfeld") in community/schlager-klassiker is left unchanged. |
| Christy Altomare – Journey to the Past | disney-classics | 1997 → 2017 | This is the Anastasia Original Broadway Cast Recording (Christy Altomare, 2017), not the 1997 animated film version. |
| Modern Talking / Eric Singleton – Brother Louie Mix '98 (Radio Edit) | community/eurodance-90s | 1986 → 1998 | Title marks the 1998 remix; 1986 was the original "Brother Louie". |

### Not changed
- **#1240 — Auli'i Cravalho – How Far I'll Go** (disney-classics, iconic-movie-songs): already `2016`, which is correct (Moana soundtrack, Nov 18 2016). No edit needed; the flag was a false positive. The separate Da Tweekaz hardstyle cover in community/harder-styles (2017) is a different recording and is left as-is.

Data-only change: no version, manifest, sw.js, cache-buster, or `.min` regeneration.

Closes #1237
Closes #1238
Closes #1239
Closes #1241

Note: #1240 is referenced above but not auto-closed since no data change was required — leaving it open for maintainer review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>