### PR TITLE
fix(data): correct release year for Höhner – Mir Kumme Mit Allemann Vorbei Single Mix (2007→2008)

### DIFF
--- a/custom_components/beatify/playlists/community/koelner-karneval.json
+++ b/custom_components/beatify/playlists/community/koelner-karneval.json
@@ -1849,7 +1849,7 @@
       "awards_nl": []
     },
     {
-      "year": 2007,
+      "year": 2008,
       "uri": "spotify:track:5exVs36HI4FglGY1dhfFAK",
       "artist": "Höhner",
       "alt_artists": [


### PR DESCRIPTION
## Summary

- Corrects release year for **Höhner – Mir Kumme Mit Allemann Vorbei (Festpiraten) - Single Mix** in `koelner-karneval.json` from 2007 → 2008
- The 2007 year belongs to the album version (*Jetzt und hier*); the Single Mix was released in 2008 on its own EP — confirmed via iTunes DE catalog (track ID 716166286)
- Flagged in-game by player Jan, auto-reported as issue #1255

## Test plan

- [ ] Verify the song displays year 2008 in a Kölner Karneval game session

Closes #1255

🤖 Generated with [Claude Code](https://claude.com/claude-code)