### PR TITLE
fix: wait for entity_picture before broadcasting album art (#1260)

### DIFF
--- a/custom_components/beatify/services/media_player.py
+++ b/custom_components/beatify/services/media_player.py
@@ -109,6 +109,15 @@ MA_PLAYBACK_TIMEOUT = 15.0
 # state callback within a few seconds.
 METADATA_WAIT_TIMEOUT = 2.0
 
+# After detecting that the new song has started (content_id / title match),
+# wait up to this many additional seconds for entity_picture to also update.
+# entity_picture reliably lags behind content_id and media_title on most
+# platforms (Spotify, Music Assistant, etc.) — reading it at the moment of
+# content_id/title match returns the previous song's artwork (issue #1260).
+# If entity_picture hasn't changed within this window (same-album or platform
+# doesn't update it) we fall back to the current state, which is correct.
+ENTITY_PICTURE_WAIT = 1.0
+
 # Candidate URI fields on a song, by user-selected provider (#805).
 #
 # Each provider lists its own playable URI fields in priority order. The
@@ -811,6 +820,15 @@ class MediaPlayerService:
         Listens for state changes until media_content_id contains the track ID
         from the URI, or timeout is reached.
 
+        Two-phase approach (issue #1260 — stale album art):
+        Phase 1 — wait for content_id / title to match the new song.
+        Phase 2 — wait up to ENTITY_PICTURE_WAIT more seconds for
+                   entity_picture to also change (it reliably lags behind
+                   content_id/title on Spotify, Music Assistant, etc.).
+                   If entity_picture doesn't change (same-album or platform
+                   doesn't update it) we fall back to the current state,
+                   which is still correct for same-album art.
+
         Args:
             uri: The Spotify URI that was just played (e.g., spotify:track:xxx)
 
@@ -829,48 +847,68 @@ class MediaPlayerService:
         initial_title = (
             initial_state.attributes.get("media_title") if initial_state else None
         )
+        initial_entity_picture = (
+            initial_state.attributes.get("entity_picture") if initial_state else None
+        )
 
-        matched = asyncio.Event()
-        matched_metadata: dict[str, Any] = {}
+        # Phase 1: song started (content_id / title match)
+        song_matched = asyncio.Event()
+        # Phase 2: entity_picture also changed
+        art_changed = asyncio.Event()
+
+        art_metadata: dict[str, Any] = {}
         start_time = asyncio.get_event_loop().time()
 
-        def _check_state(state) -> dict[str, Any] | None:
-            """Return extracted metadata if state matches, else None."""
+        def _song_started(state) -> bool:
+            """Return True if state signals the new song has started."""
             if not state:
-                return None
-            # Check if media_content_id contains our track ID
+                return False
             content_id = state.attributes.get("media_content_id", "")
             if track_id in content_id:
-                return self._extract_metadata(state)
-            # Also check if title changed (fallback)
+                return True
             current_title = state.attributes.get("media_title")
-            if current_title and current_title != initial_title:
-                return self._extract_metadata(state)
-            return None
+            return bool(current_title and current_title != initial_title)
 
         def _state_changed(ev):
             new_state = ev.data.get("new_state")
-            result = _check_state(new_state)
-            if result is not None:
-                matched_metadata.update(result)
-                matched.set()
+            if new_state is None:
+                return
+            if not song_matched.is_set() and _song_started(new_state):
+                song_matched.set()
+            # Track entity_picture change regardless — it may arrive in a
+            # later event than the content_id/title change.
+            if not art_changed.is_set():
+                ep = new_state.attributes.get("entity_picture")
+                if ep != initial_entity_picture:
+                    art_metadata.update(self._extract_metadata(new_state))
+                    art_changed.set()
 
         unsub = async_track_state_change_event(
             self._hass, [self._entity_id], _state_changed
         )
         try:
-            # Check current state first — metadata may already be updated
+            # ── Phase 1: check current state / wait for song to start ──────
             current = self._hass.states.get(self._entity_id)
-            result = _check_state(current)
-            if result is not None:
-                elapsed = asyncio.get_event_loop().time() - start_time
-                _LOGGER.debug(
-                    "Metadata updated after %.1fs (immediate check)",
-                    elapsed,
-                )
-                return result
+            if current:
+                if _song_started(current):
+                    song_matched.set()
+                ep = current.attributes.get("entity_picture")
+                if ep != initial_entity_picture:
+                    art_metadata.update(self._extract_metadata(current))
+                    art_changed.set()
 
-            await asyncio.wait_for(matched.wait(), timeout=METADATA_WAIT_TIMEOUT)
+            if not song_matched.is_set():
+                try:
+                    await asyncio.wait_for(
+                        song_matched.wait(), timeout=METADATA_WAIT_TIMEOUT
+                    )
+                except asyncio.TimeoutError:
+                    _LOGGER.warning(
+                        "Metadata not updated within %.1fs, using current state",
+                        METADATA_WAIT_TIMEOUT,
+                    )
+                    return await self.get_metadata()
+
             elapsed = asyncio.get_event_loop().time() - start_time
             current_state = self._hass.states.get(self._entity_id)
             content_id = (
@@ -879,18 +917,31 @@ class MediaPlayerService:
                 else ""
             )
             reason = "matched track ID" if track_id in content_id else "title changed"
-            _LOGGER.debug(
-                "Metadata updated after %.1fs (%s)",
-                elapsed,
-                reason,
-            )
-            return matched_metadata
-        except asyncio.TimeoutError:
-            _LOGGER.warning(
-                "Metadata not updated within %.1fs, using current state",
-                METADATA_WAIT_TIMEOUT,
-            )
-            return await self.get_metadata()
+            _LOGGER.debug("Song started after %.1fs (%s)", elapsed, reason)
+
+            # ── Phase 2: wait for entity_picture to also update ───────────
+            if art_changed.is_set():
+                elapsed = asyncio.get_event_loop().time() - start_time
+                _LOGGER.debug("Album art updated after %.1fs (same event)", elapsed)
+                return art_metadata
+
+            try:
+                await asyncio.wait_for(art_changed.wait(), timeout=ENTITY_PICTURE_WAIT)
+                elapsed = asyncio.get_event_loop().time() - start_time
+                _LOGGER.debug("Album art updated after %.1fs total", elapsed)
+                return art_metadata
+            except asyncio.TimeoutError:
+                # entity_picture didn't change within ENTITY_PICTURE_WAIT.
+                # Either same-album art or the platform doesn't update it —
+                # read the current state, which is correct in both cases.
+                elapsed = asyncio.get_event_loop().time() - start_time
+                _LOGGER.debug(
+                    "Entity picture unchanged after %.1fs extra wait "
+                    "(same album art or platform unchanged) — using current state",
+                    ENTITY_PICTURE_WAIT,
+                )
+                return await self.get_metadata()
+
         finally:
             unsub()
 

--- a/custom_components/beatify/services/media_player.py
+++ b/custom_components/beatify/services/media_player.py
@@ -118,6 +118,12 @@ METADATA_WAIT_TIMEOUT = 2.0
 # doesn't update it) we fall back to the current state, which is correct.
 ENTITY_PICTURE_WAIT = 1.0
 
+# Same-origin placeholder shown when a player reports no artwork. During a
+# track transition entity_picture can briefly clear to None or flip to this
+# placeholder before the real cover loads — Phase 2 must NOT treat that
+# transient as "the new art has arrived" (issue #1260 follow-up).
+NO_ARTWORK_PLACEHOLDER = "/beatify/static/img/no-artwork.svg"
+
 # Candidate URI fields on a song, by user-selected provider (#805).
 #
 # Each provider lists its own playable URI fields in priority order. The
@@ -869,6 +875,17 @@ class MediaPlayerService:
             current_title = state.attributes.get("media_title")
             return bool(current_title and current_title != initial_title)
 
+        def _is_new_art(ep) -> bool:
+            """True if entity_picture is a real cover that differs from initial.
+
+            A transient clear to None/empty or to the no-artwork placeholder
+            during the track transition is NOT the new art — keep waiting for
+            the real cover (issue #1260 follow-up).
+            """
+            if ep == initial_entity_picture:
+                return False
+            return bool(ep) and ep != NO_ARTWORK_PLACEHOLDER
+
         def _state_changed(ev):
             new_state = ev.data.get("new_state")
             if new_state is None:
@@ -879,7 +896,7 @@ class MediaPlayerService:
             # later event than the content_id/title change.
             if not art_changed.is_set():
                 ep = new_state.attributes.get("entity_picture")
-                if ep != initial_entity_picture:
+                if _is_new_art(ep):
                     art_metadata.update(self._extract_metadata(new_state))
                     art_changed.set()
 
@@ -893,7 +910,7 @@ class MediaPlayerService:
                 if _song_started(current):
                     song_matched.set()
                 ep = current.attributes.get("entity_picture")
-                if ep != initial_entity_picture:
+                if _is_new_art(ep):
                     art_metadata.update(self._extract_metadata(current))
                     art_changed.set()
 

--- a/tests/unit/test_media_player.py
+++ b/tests/unit/test_media_player.py
@@ -1331,17 +1331,10 @@ class TestWaitForMetadataUpdateAlbumArt:
         assert result["album_art"] == "/api/media_player_proxy/x?token=old"
 
     @pytest.mark.asyncio
-    @pytest.mark.xfail(
-        reason="#1260 follow-up: a transient entity_picture change (a momentary "
-        "None/placeholder during track transition) sets art_changed on the "
-        "FIRST change, so the placeholder can be broadcast instead of the real "
-        "cover. Not currently guarded — documents the known limitation.",
-        strict=False,
-    )
-    async def test_transient_entity_picture_flicker_should_be_ignored(self):
-        """Art goes old → placeholder → real cover across events. Desired
-        behaviour is to surface the REAL cover; the current code latches onto
-        the first (placeholder) change."""
+    async def test_transient_entity_picture_flicker_is_ignored(self):
+        """#1260 follow-up: art goes old → placeholder → real cover across
+        events. The guard skips the transient placeholder and surfaces the
+        REAL cover."""
         old = _art_state(
             title="Old",
             content_id="spotify:track:OLD",
@@ -1383,3 +1376,43 @@ class TestWaitForMetadataUpdateAlbumArt:
             result = await task
 
         assert result["album_art"] == "/api/media_player_proxy/x?token=NEW"
+
+    @pytest.mark.asyncio
+    async def test_art_that_stays_placeholder_falls_back_without_hanging(self):
+        """If the player genuinely reports no artwork (entity_picture never
+        leaves the placeholder), the guard must not hang waiting for a 'real'
+        cover — Phase 2 times out and falls back to the current state."""
+        old = _art_state(
+            title="Old",
+            content_id="spotify:track:OLD",
+            entity_picture="/api/media_player_proxy/x?token=old",
+        )
+        svc, box = self._service_with_states(old)
+
+        captured: dict = {}
+
+        def _fake_track(hass, entity_ids, cb):
+            captured["cb"] = cb
+            return MagicMock()
+
+        with patch(_TRACK_PATH, side_effect=_fake_track), patch(
+            "custom_components.beatify.services.media_player.ENTITY_PICTURE_WAIT",
+            0.05,
+        ):
+            task = asyncio.create_task(
+                svc.wait_for_metadata_update("spotify:track:NEW")
+            )
+            await asyncio.sleep(0)
+
+            new = _art_state(
+                title="New",
+                content_id="spotify:track:NEW",
+                entity_picture="/beatify/static/img/no-artwork.svg",
+            )
+            box["current"] = new
+            captured["cb"](_event(new))
+
+            result = await task
+
+        assert result["title"] == "New"
+        assert result["album_art"] == "/beatify/static/img/no-artwork.svg"

--- a/tests/unit/test_media_player.py
+++ b/tests/unit/test_media_player.py
@@ -1290,9 +1290,12 @@ class TestWaitForMetadataUpdateAlbumArt:
             captured["cb"] = cb
             return MagicMock()
 
-        with patch(_TRACK_PATH, side_effect=_fake_track), patch(
-            "custom_components.beatify.services.media_player.ENTITY_PICTURE_WAIT",
-            0.05,
+        with (
+            patch(_TRACK_PATH, side_effect=_fake_track),
+            patch(
+                "custom_components.beatify.services.media_player.ENTITY_PICTURE_WAIT",
+                0.05,
+            ),
         ):
             task = asyncio.create_task(
                 svc.wait_for_metadata_update("spotify:track:NEW")
@@ -1321,9 +1324,12 @@ class TestWaitForMetadataUpdateAlbumArt:
         )
         svc, _box = self._service_with_states(old)
 
-        with patch(_TRACK_PATH, side_effect=lambda *a, **k: MagicMock()), patch(
-            "custom_components.beatify.services.media_player.METADATA_WAIT_TIMEOUT",
-            0.05,
+        with (
+            patch(_TRACK_PATH, side_effect=lambda *a, **k: MagicMock()),
+            patch(
+                "custom_components.beatify.services.media_player.METADATA_WAIT_TIMEOUT",
+                0.05,
+            ),
         ):
             result = await svc.wait_for_metadata_update("spotify:track:NEW")
 
@@ -1395,9 +1401,12 @@ class TestWaitForMetadataUpdateAlbumArt:
             captured["cb"] = cb
             return MagicMock()
 
-        with patch(_TRACK_PATH, side_effect=_fake_track), patch(
-            "custom_components.beatify.services.media_player.ENTITY_PICTURE_WAIT",
-            0.05,
+        with (
+            patch(_TRACK_PATH, side_effect=_fake_track),
+            patch(
+                "custom_components.beatify.services.media_player.ENTITY_PICTURE_WAIT",
+                0.05,
+            ),
         ):
             task = asyncio.create_task(
                 svc.wait_for_metadata_update("spotify:track:NEW")

--- a/tests/unit/test_media_player.py
+++ b/tests/unit/test_media_player.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -1135,3 +1136,250 @@ class TestMetadataAlbumArtWrapping:
         svc = MediaPlayerService(_make_hass(), "media_player.test")
         meta = svc._extract_metadata(_make_state())
         assert meta["album_art"] == "/beatify/static/img/no-artwork.svg"
+
+
+def _art_state(
+    title: str,
+    content_id: str,
+    entity_picture: str,
+    artist: str = "Test Artist",
+) -> MagicMock:
+    """Mock HA state carrying the attributes wait_for_metadata_update reads."""
+    state = MagicMock()
+    state.attributes = {
+        "media_artist": artist,
+        "media_title": title,
+        "media_content_id": content_id,
+        "entity_picture": entity_picture,
+    }
+    return state
+
+
+def _event(new_state) -> MagicMock:
+    """Mock a HA state_changed event carrying ``new_state``."""
+    ev = MagicMock()
+    ev.data = {"new_state": new_state}
+    return ev
+
+
+_TRACK_PATH = (
+    "custom_components.beatify.services.media_player.async_track_state_change_event"
+)
+
+
+class TestWaitForMetadataUpdateAlbumArt:
+    """Two-phase album-art wait — wait_for_metadata_update (#1260).
+
+    The bug: content_id/media_title update before entity_picture on Spotify and
+    Music Assistant, so reading entity_picture the instant the song matched
+    returned the *previous* song's cover. Phase 2 waits for entity_picture to
+    also change before reading it.
+    """
+
+    @staticmethod
+    def _service_with_states(initial_state):
+        """Build a service whose states.get returns a mutable 'current' state.
+
+        Returns (service, box); mutate ``box["current"]`` to advance what the
+        media player currently reports (read by the Phase-1 check and the
+        get_metadata fallback).
+        """
+        hass = MagicMock()
+        box = {"current": initial_state}
+        hass.states.get = MagicMock(side_effect=lambda *a, **k: box["current"])
+        svc = MediaPlayerService(hass, "media_player.test")
+        return svc, box
+
+    @pytest.mark.asyncio
+    async def test_waits_for_entity_picture_to_change_in_later_event(self):
+        """#1260 core fix: the new cover arrives in a LATER state event than
+        the content_id/title change. Phase 2 must wait for it and return the
+        NEW art, not the stale previous-song cover."""
+        old = _art_state(
+            title="Er gehört zu mir",
+            content_id="spotify:track:OLD",
+            entity_picture="/api/media_player_proxy/x?token=old",
+        )
+        svc, box = self._service_with_states(old)
+
+        captured: dict = {}
+
+        def _fake_track(hass, entity_ids, cb):
+            captured["cb"] = cb
+            return MagicMock()
+
+        with patch(_TRACK_PATH, side_effect=_fake_track):
+            task = asyncio.create_task(
+                svc.wait_for_metadata_update("spotify:track:NEW")
+            )
+            await asyncio.sleep(0)  # let it reach the Phase 1 await
+
+            # Event 1: song started (content_id matches) — art still lagging.
+            song_started = _art_state(
+                title="Never Gonna Give You Up",
+                content_id="spotify:track:NEW",
+                entity_picture="/api/media_player_proxy/x?token=old",
+            )
+            box["current"] = song_started
+            captured["cb"](_event(song_started))
+            await asyncio.sleep(0)
+
+            # Event 2: entity_picture finally updates to the new cover.
+            art_arrived = _art_state(
+                title="Never Gonna Give You Up",
+                content_id="spotify:track:NEW",
+                entity_picture="/api/media_player_proxy/x?token=NEW",
+            )
+            box["current"] = art_arrived
+            captured["cb"](_event(art_arrived))
+
+            result = await task
+
+        assert result["title"] == "Never Gonna Give You Up"
+        assert result["album_art"] == "/api/media_player_proxy/x?token=NEW"
+
+    @pytest.mark.asyncio
+    async def test_art_present_in_same_event_returns_immediately(self):
+        """When entity_picture changes in the same event that signals the new
+        song, Phase 2 short-circuits and returns that event's art."""
+        old = _art_state(
+            title="Old",
+            content_id="spotify:track:OLD",
+            entity_picture="/api/media_player_proxy/x?token=old",
+        )
+        svc, box = self._service_with_states(old)
+
+        captured: dict = {}
+
+        def _fake_track(hass, entity_ids, cb):
+            captured["cb"] = cb
+            return MagicMock()
+
+        with patch(_TRACK_PATH, side_effect=_fake_track):
+            task = asyncio.create_task(
+                svc.wait_for_metadata_update("spotify:track:NEW")
+            )
+            await asyncio.sleep(0)
+
+            both = _art_state(
+                title="New",
+                content_id="spotify:track:NEW",
+                entity_picture="/api/media_player_proxy/x?token=NEW",
+            )
+            box["current"] = both
+            captured["cb"](_event(both))
+
+            result = await task
+
+        assert result["album_art"] == "/api/media_player_proxy/x?token=NEW"
+
+    @pytest.mark.asyncio
+    async def test_same_album_falls_back_to_current_state(self):
+        """Two songs from the same album share entity_picture, so Phase 2 never
+        sees a change — after the short extra wait we fall back to the current
+        (correct, same-album) art rather than hanging or returning stale data."""
+        art = "/api/media_player_proxy/x?token=album"
+        old = _art_state(
+            title="Track A", content_id="spotify:track:OLD", entity_picture=art
+        )
+        svc, box = self._service_with_states(old)
+
+        captured: dict = {}
+
+        def _fake_track(hass, entity_ids, cb):
+            captured["cb"] = cb
+            return MagicMock()
+
+        with patch(_TRACK_PATH, side_effect=_fake_track), patch(
+            "custom_components.beatify.services.media_player.ENTITY_PICTURE_WAIT",
+            0.05,
+        ):
+            task = asyncio.create_task(
+                svc.wait_for_metadata_update("spotify:track:NEW")
+            )
+            await asyncio.sleep(0)
+
+            new = _art_state(
+                title="Track B", content_id="spotify:track:NEW", entity_picture=art
+            )
+            box["current"] = new
+            captured["cb"](_event(new))
+
+            result = await task
+
+        assert result["title"] == "Track B"
+        assert result["album_art"] == art
+
+    @pytest.mark.asyncio
+    async def test_song_never_starts_falls_back_after_phase1_timeout(self):
+        """If content_id/title never update, Phase 1 times out and we return
+        whatever get_metadata() reports for the current state."""
+        old = _art_state(
+            title="Old",
+            content_id="spotify:track:OLD",
+            entity_picture="/api/media_player_proxy/x?token=old",
+        )
+        svc, _box = self._service_with_states(old)
+
+        with patch(_TRACK_PATH, side_effect=lambda *a, **k: MagicMock()), patch(
+            "custom_components.beatify.services.media_player.METADATA_WAIT_TIMEOUT",
+            0.05,
+        ):
+            result = await svc.wait_for_metadata_update("spotify:track:NEW")
+
+        assert result["title"] == "Old"
+        assert result["album_art"] == "/api/media_player_proxy/x?token=old"
+
+    @pytest.mark.asyncio
+    @pytest.mark.xfail(
+        reason="#1260 follow-up: a transient entity_picture change (a momentary "
+        "None/placeholder during track transition) sets art_changed on the "
+        "FIRST change, so the placeholder can be broadcast instead of the real "
+        "cover. Not currently guarded — documents the known limitation.",
+        strict=False,
+    )
+    async def test_transient_entity_picture_flicker_should_be_ignored(self):
+        """Art goes old → placeholder → real cover across events. Desired
+        behaviour is to surface the REAL cover; the current code latches onto
+        the first (placeholder) change."""
+        old = _art_state(
+            title="Old",
+            content_id="spotify:track:OLD",
+            entity_picture="/api/media_player_proxy/x?token=old",
+        )
+        svc, box = self._service_with_states(old)
+
+        captured: dict = {}
+
+        def _fake_track(hass, entity_ids, cb):
+            captured["cb"] = cb
+            return MagicMock()
+
+        with patch(_TRACK_PATH, side_effect=_fake_track):
+            task = asyncio.create_task(
+                svc.wait_for_metadata_update("spotify:track:NEW")
+            )
+            await asyncio.sleep(0)
+
+            # Song starts; entity_picture momentarily clears to the placeholder.
+            flicker = _art_state(
+                title="New",
+                content_id="spotify:track:NEW",
+                entity_picture="/beatify/static/img/no-artwork.svg",
+            )
+            box["current"] = flicker
+            captured["cb"](_event(flicker))
+            await asyncio.sleep(0)
+
+            # Real cover arrives a moment later.
+            real = _art_state(
+                title="New",
+                content_id="spotify:track:NEW",
+                entity_picture="/api/media_player_proxy/x?token=NEW",
+            )
+            box["current"] = real
+            captured["cb"](_event(real))
+
+            result = await task
+
+        assert result["album_art"] == "/api/media_player_proxy/x?token=NEW"


### PR DESCRIPTION
Closes #1260

## Readiness assessment
- [x] Ready to merge
- [ ] Borderline — see notes
- [ ] Not ready — needs human review

**Honest summary:** Root cause is confirmed and the fix is targeted. `wait_for_metadata_update` previously snapshotted `entity_picture` the moment `media_content_id`/`media_title` matched — but those attributes update before `entity_picture` on Spotify and Music Assistant, so the previous song's cover was always returned and broadcast to clients. The two-phase approach waits an additional 1 s for `entity_picture` to also change before reading it. All 759 existing tests pass. The only observable regression risk is a 1 s longer placeholder display for back-to-back songs from the same album (same entity_picture URL won't trigger the Phase 2 match, so we fall through to `get_metadata()` after 1 s — correct artwork, slight extra delay).

## Test plan
- Play a game across at least 3 consecutive rounds with songs from different albums
- Verify the dashboard and in-game views show the **correct** album art for each new round (not the previous song's art)
- Play two consecutive songs from the **same album** — confirm artwork still appears within ~3 s and is correct
- Confirm existing automated test suite: `python3 -m pytest tests/ -x -q` → 759 passed, 2 skipped

## Risk assessment
- **Blast radius:** `MediaPlayerService.wait_for_metadata_update` only — single method in `services/media_player.py`
- **What could go wrong:**
  - Platforms where `entity_picture` never updates (e.g. always `None` or a static URL) will now incur an extra 1 s wait before falling back to `get_metadata()` — visual impact is the placeholder shows 1 s longer per round
  - Maximum total metadata wait goes from 2 s to 3 s (2 s Phase 1 timeout + 1 s Phase 2 timeout); still well under the previous 5 s value
- **What I did NOT test:** live hardware integration (Sonos, Google Home, Apple HomePod) — only automated unit tests and code analysis

🤖 Auto-generated by issue-triage routine