### PR TITLE
ci: raise pytest coverage gate from 25 to 68 (#1282)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -133,7 +133,7 @@ jobs:
             --cov-report=xml \
             --cov-report=html \
             --cov-report=term-missing \
-            --cov-fail-under=25  # baseline; raise progressively as coverage grows (#197)
+            --cov-fail-under=68  # gate just below measured 69.86% (#1282); raise progressively as coverage grows
 
       - name: Upload coverage report
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Closes #1282

## Was

Der Coverage-Gate existierte bereits (`--cov-fail-under=25`, eingeführt mit #197), war aber mit 25 % weit unter der realen Abdeckung und damit zahnlos gegen Regressionen. Dieser PR hebt die Schwelle auf **68 %** an.

## Gemessene Coverage

Voller Lauf (`tests/unit/` + `tests/integration/`) lokal auf **Python 3.13** (= CI-Matrix), exakt mit dem CI-Coverage-Kommando:

```
777 passed, 2 skipped
TOTAL coverage: 69.86 %
```

Threshold = **68** → knapp unter den gemessenen 69,86 %, ca. 1,8pp Sicherheitsmarge gegen Cross-Version-/Plattform-Varianz (CI läuft 3.12 + 3.13).

## Verifikation

- Gate @ 68 → **PASS**: `Required test coverage of 68% reached. Total coverage: 69.86%`
- Gate @ 71 → **FAIL** (Sanity-Check, Gate hat Zähne): `Required test coverage of 71% not reached. Total coverage: 69.86%`
- `ruff check .` → All checks passed
- YAML-Syntax validiert (`yaml.safe_load`)

## Readiness assessment
- [x] Ready to merge
- [ ] Borderline — see notes
- [ ] Not ready — needs human review

**Honest summary:** Einzeiliger Workflow-Edit, kein Produktionscode. Gate-Verhalten in beide Richtungen verifiziert (PASS @68, FAIL @71). Einzige Restunsicherheit: lokal gemessen mit Py 3.13; Py-3.12-Coverage auf CI könnte minimal abweichen — die 1,8pp-Marge deckt das ab. Acceptance Criteria des Issues (Coverage-Report in CI, Build failt unter Threshold) waren formal schon erfüllt; dieser PR macht den Gate erst wirksam.

## Test plan
- CI Stage 2 (Test) auf 3.12 + 3.13 muss grün bleiben (Coverage ≥ 68 %).
- Erwartetes Ergebnis: gleiche 777 passed / 2 skipped, Gate erfüllt.

## Risk assessment
- **Blast radius:** nur `.github/workflows/test.yml`, eine Zeile (`--cov-fail-under` 25 → 68). Kein Laufzeit-/App-Code.
- **What could go wrong:** Falls Py-3.12-Coverage auf CI > ~1,8pp unter 3.13 läge, könnte der Gate rot — unwahrscheinlich, dann Schwelle 1–2 Punkte senken.
- **What I did NOT test:** den realen GitHub-Actions-Lauf auf Python 3.12 (lokal nicht verfügbar; nur 3.13 gemessen).

🤖 Auto-generated by issue-triage routine