### PR TITLE
ci: playlist JSON schema gate before merge (#1284)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -4,6 +4,7 @@
 # Validates:
 # - HACS requirements (hacs.json, structure, manifest)
 # - Home Assistant hassfest (manifest.json, translations, services)
+# - Playlist JSON files against scripts/playlist_schema.json (#1284)
 
 name: Validate
 
@@ -38,3 +39,21 @@ jobs:
 
       - name: Hassfest
         uses: home-assistant/actions/hassfest@master
+
+  validate-playlists:
+    name: Playlist JSON Schema Gate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install jsonschema
+        run: pip install "jsonschema>=4.0"
+
+      - name: Validate playlist files against schema
+        run: python scripts/validate_playlists.py

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -5,3 +5,4 @@ pytest-asyncio>=1.0
 pytest-cov>=6.0
 aiohttp>=3.11
 num2words>=0.5.14  # spoken-number rendering for TTS announcements
+jsonschema>=4.0   # playlist JSON-schema gate (#1284)

--- a/scripts/playlist_schema.json
+++ b/scripts/playlist_schema.json
@@ -1,0 +1,99 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://beatify.app/schemas/playlist.schema.json",
+  "title": "Beatify Playlist",
+  "description": "Schema for Beatify playlist JSON files in custom_components/beatify/playlists/. Validated in CI (see scripts/validate_playlists.py). Required fields + types are enforced; optional metadata fields are described for documentation but not required.",
+  "type": "object",
+  "required": ["name", "version", "tags", "songs"],
+  "additionalProperties": true,
+  "properties": {
+    "name": {
+      "type": "string",
+      "minLength": 1
+    },
+    "version": {
+      "type": "string",
+      "minLength": 1
+    },
+    "tags": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "language": { "type": "string" },
+    "description": { "type": "string" },
+    "added_date": { "type": "string" },
+    "author": { "type": "string" },
+    "source": { "type": "string" },
+    "movie_quiz_enabled": { "type": "boolean" },
+    "songs": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/song" }
+    }
+  },
+  "$defs": {
+    "song": {
+      "type": "object",
+      "required": [
+        "artist",
+        "title",
+        "uri",
+        "year",
+        "fun_fact",
+        "fun_fact_de",
+        "fun_fact_es",
+        "fun_fact_fr",
+        "fun_fact_nl"
+      ],
+      "additionalProperties": true,
+      "properties": {
+        "artist": { "type": "string", "minLength": 1 },
+        "title": { "type": "string", "minLength": 1 },
+        "year": {
+          "type": "integer",
+          "minimum": 1900,
+          "maximum": 2100
+        },
+        "uri": {
+          "description": "Spotify track URI (canonical playback source) or null when no playable track exists.",
+          "oneOf": [
+            { "type": "string", "pattern": "^spotify:track:[A-Za-z0-9]{22}$" },
+            { "type": "null" }
+          ]
+        },
+        "isrc": {
+          "oneOf": [
+            { "type": "string", "pattern": "^[A-Z]{2}[A-Z0-9]{3}[0-9]{7}$" },
+            { "type": "null" }
+          ]
+        },
+        "uri_apple_music": { "type": ["string", "null"] },
+        "uri_youtube_music": { "type": ["string", "null"] },
+        "uri_tidal": { "type": ["string", "null"] },
+        "uri_deezer": { "type": ["string", "null"] },
+        "uri_apple_music_by_region": { "type": "object" },
+        "alt_artists": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "fun_fact": { "type": "string" },
+        "fun_fact_de": { "type": "string" },
+        "fun_fact_es": { "type": "string" },
+        "fun_fact_fr": { "type": "string" },
+        "fun_fact_nl": { "type": "string" },
+        "chart_info": { "type": ["object", "string"] },
+        "certifications": { "type": ["array", "string"] },
+        "awards": { "type": ["array", "string"] },
+        "awards_de": { "type": ["array", "string"] },
+        "awards_es": { "type": ["array", "string"] },
+        "awards_fr": { "type": ["array", "string"] },
+        "awards_nl": { "type": ["array", "string"] },
+        "movie": { "type": "string" },
+        "movie_choices": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      }
+    }
+  }
+}

--- a/scripts/validate_playlists.py
+++ b/scripts/validate_playlists.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Validate Beatify playlist JSON files against the playlist schema.
+
+Used as a CI gate (see .github/workflows/validate.yml) so that broken
+URIs / years / missing fields fail the PR instead of being caught later by
+the playlist-review job. See issue #1284.
+
+Checks per file:
+  1. File is valid JSON.                         -> hard failure (fails CI)
+  2. File conforms to scripts/playlist_schema.json (required fields, types,
+     year range, Spotify URI format, ISRC format). -> hard failure (fails CI)
+  3. Light lint: duplicate (non-null) Spotify URIs within the same file.
+     -> warning only (does NOT fail CI; issue #1284 marks duplicate-lint
+        optional). Surfaces existing data smells without blocking legacy
+        files. Pass --strict to turn warnings into failures.
+
+Exit code 0 = no hard errors, 1 = at least one hard error
+(or any warning when --strict is set).
+
+Usage:
+    python scripts/validate_playlists.py            # validate all playlists
+    python scripts/validate_playlists.py a.json b.json   # validate given files
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+
+try:
+    from jsonschema import Draft202012Validator
+except ImportError:  # pragma: no cover - guidance for local runs
+    sys.stderr.write(
+        "error: 'jsonschema' is not installed. Run: pip install jsonschema\n"
+    )
+    sys.exit(2)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCHEMA_PATH = REPO_ROOT / "scripts" / "playlist_schema.json"
+PLAYLIST_DIR = REPO_ROOT / "custom_components" / "beatify" / "playlists"
+
+
+def load_schema_validator() -> Draft202012Validator:
+    schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+    Draft202012Validator.check_schema(schema)
+    return Draft202012Validator(schema)
+
+
+def discover_playlists() -> list[Path]:
+    return sorted(PLAYLIST_DIR.rglob("*.json"))
+
+
+def validate_file(
+    path: Path, validator: Draft202012Validator
+) -> tuple[list[str], list[str]]:
+    """Validate one file.
+
+    Returns ``(errors, warnings)``:
+      - errors:   hard problems (invalid JSON / schema violations) that fail CI.
+      - warnings: soft lint findings (duplicate URIs) that do not fail CI
+                  unless --strict is set.
+    """
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        return ([f"invalid JSON: {exc}"], [])
+
+    errors: list[str] = []
+    warnings: list[str] = []
+
+    for err in sorted(validator.iter_errors(data), key=lambda e: list(e.path)):
+        location = "/".join(str(p) for p in err.path) or "<root>"
+        errors.append(f"schema: at '{location}': {err.message}")
+
+    # Light lint: duplicate Spotify URIs within the same playlist.
+    if isinstance(data, dict) and isinstance(data.get("songs"), list):
+        uris = [s["uri"] for s in data["songs"] if isinstance(s, dict) and s.get("uri")]
+        dupes = [uri for uri, count in Counter(uris).items() if count > 1]
+        for uri in dupes:
+            warnings.append(f"lint: duplicate uri within file: {uri}")
+
+    return (errors, warnings)
+
+
+def main(argv: list[str]) -> int:
+    strict = "--strict" in argv
+    paths = [a for a in argv if a != "--strict"]
+
+    validator = load_schema_validator()
+
+    if paths:
+        files = [Path(a).resolve() for a in paths]
+    else:
+        files = discover_playlists()
+
+    if not files:
+        sys.stderr.write(f"error: no playlist files found under {PLAYLIST_DIR}\n")
+        return 1
+
+    total_errors = 0
+    total_warnings = 0
+    for path in files:
+        rel = path.relative_to(REPO_ROOT) if path.is_relative_to(REPO_ROOT) else path
+        errors, warnings = validate_file(path, validator)
+        total_errors += len(errors)
+        total_warnings += len(warnings)
+        if errors:
+            print(f"FAIL {rel}")
+        elif warnings:
+            print(f"warn {rel}")
+        else:
+            print(f"ok   {rel}")
+        for msg in errors:
+            print(f"  ❌ {msg}")
+        for msg in warnings:
+            print(f"  ⚠️  {msg}")
+
+    print()
+    if total_warnings:
+        print(f"⚠️  {total_warnings} lint warning(s) (non-blocking unless --strict).")
+    if total_errors:
+        print(
+            f"❌ Playlist validation failed: {total_errors} error(s) in {len(files)} file(s)."
+        )
+        return 1
+    if strict and total_warnings:
+        print("❌ --strict: treating warnings as errors.")
+        return 1
+
+    print(f"✅ All {len(files)} playlist file(s) valid (schema gate passed).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tests/unit/test_playlist_schema.py
+++ b/tests/unit/test_playlist_schema.py
@@ -1,0 +1,53 @@
+"""Schema gate for the shipped playlist JSON files (#1284).
+
+These tests are the in-pytest mirror of ``scripts/validate_playlists.py``:
+every playlist under ``custom_components/beatify/playlists/`` must conform to
+``scripts/playlist_schema.json`` (required fields, types, year range, Spotify
+URI format, ISRC format). A broken playlist now fails CI on the PR instead of
+being caught later by the playlist-review job.
+
+The dedicated CI step (``.github/workflows/validate.yml``) runs the script with
+the same schema; this test guarantees the gate also fires in the normal test
+matrix and is easy to run locally via ``pytest``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCHEMA_PATH = REPO_ROOT / "scripts" / "playlist_schema.json"
+PLAYLIST_DIR = REPO_ROOT / "custom_components" / "beatify" / "playlists"
+
+PLAYLIST_FILES = sorted(PLAYLIST_DIR.rglob("*.json"))
+
+
+def _validator() -> Draft202012Validator:
+    schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+    Draft202012Validator.check_schema(schema)
+    return Draft202012Validator(schema)
+
+
+def test_schema_is_itself_valid() -> None:
+    # Raises SchemaError if the meta-schema is violated.
+    _validator()
+
+
+def test_playlist_files_discovered() -> None:
+    assert PLAYLIST_FILES, f"no playlist files found under {PLAYLIST_DIR}"
+
+
+@pytest.mark.parametrize("path", PLAYLIST_FILES, ids=[p.name for p in PLAYLIST_FILES])
+def test_playlist_conforms_to_schema(path: Path) -> None:
+    validator = _validator()
+    data = json.loads(path.read_text(encoding="utf-8"))
+    errors = sorted(validator.iter_errors(data), key=lambda e: list(e.path))
+    messages = [
+        f"at '{'/'.join(str(p) for p in e.path) or '<root>'}': {e.message}"
+        for e in errors
+    ]
+    assert not messages, "schema violations:\n" + "\n".join(messages)


### PR DESCRIPTION
Closes #1284

## Readiness assessment
- [ ] Ready to merge
- [x] Borderline — see notes
- [ ] Not ready — needs human review

**Honest summary:** Schema-Gate + CI-Job + pytest-Mirror sind solide und alle 40 (nicht 17 — Repo ist gewachsen) Playlist-Files validieren grün; verifiziert, dass das Gate bei kaputten Daten (Bad-URI, Year out-of-range, fehlende Pflichtfelder) hart failt. Borderline aus zwei Gründen: (1) der Duplikat-URI-Lint ist bewusst nur Warnung (Issue markiert Duplikat-Check als "optional"), und (2) er hat dabei echte Daten-Bugs aufgedeckt — 6 Songs in mehreren Playlists teilen sich denselben Spotify-URI (verschiedene Künstler/Titel → falsche Wiedergabe). Diese Legacy-Dupes blockieren den PR nicht, sollten aber separat gefixt werden.

## Test plan
- `python scripts/validate_playlists.py` → exit 0, "All 40 playlist file(s) valid".
- `pytest tests/unit/test_playlist_schema.py` → 42 passed.
- Negativ-Test: Datei mit Bad-URI / year 3050 / fehlendem fun_fact → exit 1 mit präzisen Pfaden (`songs/0/uri`, `songs/0/year`, …). ✅ verifiziert.
- Voller Unit-Lauf `pytest tests/unit/` → 819 passed. ruff check + format --check grün.

## Risk assessment
- **Blast radius:** rein additiv — neuer CI-Job + Tooling. Kein Produktionscode (`custom_components/beatify/**` unberührt außer Lese-Validierung). Keine Frontend-Files → kein .min.js/sw.js/cache-buster-Guardrail nötig.
- **What could go wrong:** Schema bewusst permissiv bei Mixed-Type-Legacy-Feldern (`awards`/`certifications`/`chart_info` dürfen str ODER list/dict sein) und `uri: null` ist erlaubt (7 Songs in world-cup-anthems = "kein spielbarer Track") — strengere Regeln würden bestehende Files brechen. `scripts/` ist in `.gitignore`; die zwei Dateien wurden wie das vorhandene `scripts/build.mjs` force-added (`git add -f`).
- **What I did NOT test:** den GitHub-Actions-Job live (läuft erst beim CI-Run); Cross-File-Duplikate (nur Innerhalb-Datei-Dupes werden gelintet).

## Hinweis für Markus — echte Daten-Bugs gefunden
Der Duplikat-Lint meldet 11 Warnungen in 5 Files. In `top-100-power-ballads.json` zeigen z.B. Foreigner "I Want to Know What Love Is", Whitesnake "Is This Love" und Queen "Somebody To Love" alle auf **denselben** `spotify:track:1JLn8RhQzHz3qDqsChcmBl`. Das ist falsche Playback-Zuordnung — separat fixen (eigenes Issue?). Wenn diese URIs korrigiert sind, kann der Gate mit `--strict` scharf gestellt werden.

🤖 Auto-generated by issue-triage routine