### PR TITLE
test: CI guard against hardcoded cache-busters (#1278)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -155,7 +155,10 @@ bug where a source edit never reaches the bundle the browser actually loads.
 Notes:
 - HTML cache-busters (`?v={{ASSET_VER}}`) and the service worker's
   `CACHE_VERSION` are templated by the integration at serve time — you do **not**
-  edit `?v=` values or `CACHE_VERSION` by hand.
+  edit `?v=` values or `CACHE_VERSION` by hand. A CI guard
+  (`tests/unit/test_asset_cachebuster.py::TestNoHardcodedCacheBusters`) fails the
+  PR if a hardcoded literal is ever pasted back into a template, so the
+  rc8→rc14-style drift can't regress.
 - When you change a `.js`, commit both the source **and** the regenerated
   `.min.js` in the same PR.
 

--- a/tests/unit/test_asset_cachebuster.py
+++ b/tests/unit/test_asset_cachebuster.py
@@ -8,6 +8,11 @@ identical, so browsers / the service worker kept serving stale assets.
 
 from __future__ import annotations
 
+import re
+from pathlib import Path
+
+import pytest
+
 from custom_components.beatify.const import DOMAIN
 from custom_components.beatify.server import base
 from custom_components.beatify.server.base import (
@@ -145,3 +150,66 @@ class TestServedPagesHaveNoUnresolvedTokens:
         assert resp.status == 200
         assert "{{ASSET_VER}}" not in resp.text
         assert "beatify-v9.9.9-" in resp.text
+
+
+# ---------------------------------------------------------------------------
+# Static consistency guard (#1278)
+# ---------------------------------------------------------------------------
+#
+# #1266 made cache-busting automatic by templating ``{{ASSET_VER}}`` /
+# ``{{VERSION}}`` at serve time, so nobody bumps ``?v=`` or ``CACHE_VERSION`` by
+# hand anymore. The remaining risk is a *regression*: someone re-introduces a
+# hardcoded literal (the rc8->rc14 drift / legacy-admin-flash class) by pasting
+# a ``?v=4.0.0`` or ``CACHE_VERSION = 'beatify-v4.0.0'`` back into a template.
+# These tests are the CI guard requested in #1278 AC #2 — they fail the PR the
+# moment a literal slips in, instead of waiting for stale assets in production.
+
+_WWW_DIR = Path(__file__).resolve().parents[2] / "custom_components" / "beatify" / "www"
+
+# Any ``?v=`` whose value is not the {{ASSET_VER}} token is a hardcoded literal.
+_HARDCODED_V = re.compile(r"\?v=(?!\{\{ASSET_VER\}\})")
+# A CACHE_VERSION assignment whose value doesn't carry the token is hardcoded.
+_HARDCODED_CACHE_VERSION = re.compile(
+    r"CACHE_VERSION\s*=\s*['\"](?![^'\"]*\{\{ASSET_VER\}\})"
+)
+
+
+def _html_files() -> list[Path]:
+    return sorted(_WWW_DIR.glob("*.html"))
+
+
+class TestNoHardcodedCacheBusters:
+    """Every shipped template must use the token, never a baked-in literal."""
+
+    def test_www_dir_is_present(self) -> None:
+        # Guards the guard: a wrong path would make the checks below vacuous.
+        assert _WWW_DIR.is_dir(), _WWW_DIR
+        assert _html_files(), "no HTML templates found to check"
+
+    @pytest.mark.parametrize("html", _html_files(), ids=lambda p: p.name)
+    def test_html_has_no_hardcoded_v_query(self, html: Path) -> None:
+        text = html.read_text(encoding="utf-8")
+        offenders = [
+            line
+            for line in text.splitlines()
+            if "?v=" in line and _HARDCODED_V.search(line)
+        ]
+        assert not offenders, (
+            f"{html.name} contains hardcoded ?v= cache-buster(s) — use "
+            f"'?v={{{{ASSET_VER}}}}' so #1266 templating busts them automatically "
+            f"(#1278):\n  " + "\n  ".join(offenders)
+        )
+
+    def test_sw_js_cache_version_uses_token(self) -> None:
+        sw = _WWW_DIR / "sw.js"
+        text = sw.read_text(encoding="utf-8")
+        assignments = [line for line in text.splitlines() if "CACHE_VERSION =" in line]
+        assert assignments, "sw.js has no CACHE_VERSION assignment"
+        offenders = [
+            line for line in assignments if _HARDCODED_CACHE_VERSION.search(line)
+        ]
+        assert not offenders, (
+            "sw.js CACHE_VERSION must carry the {{ASSET_VER}} token, not a "
+            "hardcoded literal, so it busts on any asset change (#1278):\n  "
+            + "\n  ".join(offenders)
+        )


### PR DESCRIPTION
Closes #1278

## Was dieser PR macht

Der eigentliche Kern von #1278 — *„ein Befehl bumpt alle Asset-Refs konsistent"* — ist seit **#1266 bereits gelöst**: HTML-`?v=` und `sw.js`-`CACHE_VERSION` nutzen ausschließlich die Serve-Time-Tokens `{{ASSET_VER}}` / `{{VERSION}}` (Fingerprint aus den realen css/js/i18n-Dateien). Der manuelle 6-File-Bump existiert nicht mehr. Es gibt also **nichts mehr zu „bumpen"**.

Was fehlte, ist **AC #2 (Konsistenz-Check)**: ein Regressions-Guard, der verhindert, dass jemand wieder ein hardcoded Literal (`?v=4.0.0`, `CACHE_VERSION = 'beatify-v4.0.0'`) in ein Template einpastet — genau die rc8→rc14-Drift / Legacy-Admin-Flash-Klasse.

- `tests/unit/test_asset_cachebuster.py::TestNoHardcodedCacheBusters` — parametrisiert über alle `www/*.html` + `sw.js`; failt, sobald ein `?v=`- oder `CACHE_VERSION`-Wert nicht das Token trägt.
- `CONTRIBUTING.md` — Notiz, die auf den Guard verweist (AC #3, Release-Flow doc).

## Readiness assessment
- [x] Ready to merge
- [ ] Borderline — see notes
- [ ] Not ready — needs human review

**Honest summary:** Reiner Test- + Doc-Change, kein Produktionscode berührt. 19/19 Tests grün (14 vorher + 5 neu), ruff lint+format clean. Negativtest verifiziert: künstlich eingepasstes `?v=4.0.0` lässt den Guard rot werden. Einzige Designfrage ist der Scope — siehe unten.

## Test plan
- `pytest tests/unit/test_asset_cachebuster.py` → 19 passed
- Negativ: temporär `?v={{ASSET_VER}}` → `?v=4.0.0` in player.html → Guard failt mit klarer Offender-Zeile (verifiziert, wieder zurückgesetzt)
- `ruff check` + `ruff format --check` auf der Testdatei → clean

## Risk assessment
- **Blast radius:** nur `tests/unit/test_asset_cachebuster.py` + `CONTRIBUTING.md`. Kein Produktionscode, keine UI-Surface, kein Frontend-Bundle.
- **What could go wrong:** praktisch nichts zur Laufzeit. Der Guard ist statisch (liest Dateien von Disk). Theoretisch könnte ein zukünftiges legitimes anderes `?v=`-Schema den Guard fälschlich auslösen — dann ist die Regex anzupassen.
- **What I did NOT test:** ich habe NICHT die volle Suite (`pytest tests/unit tests/integration`) laufen lassen, nur die cache-buster-Datei; meine Änderung berührt aber nichts anderes. CI deckt den Rest ab.

## Anmerkung für Markus (Scope-Entscheidung)
Das Issue fragt nach „ein Befehl/Build-Step der die Version aus manifest.json liest und alle Refs setzt". Das ist bei der aktuellen #1266-Architektur **gegenstandslos** — die Templates enthalten keine Versionsliterale mehr, die man setzen könnte. Ich habe deshalb bewusst KEIN Bump-Skript gebaut (das wäre toter Code), sondern den noch offenen Konsistenz-Check geliefert. Falls du das Issue lieber komplett als „durch #1266 erledigt" schließen willst, ist dieser PR optional — er ist aber ein billiger, dauerhafter Drift-Schutz.

🤖 Auto-generated by issue-triage routine