### PR TITLE
fix: validate provider URI dispatch + warn on miss/unknown provider (#1276)

### DIFF
--- a/custom_components/beatify/services/media_player.py
+++ b/custom_components/beatify/services/media_player.py
@@ -405,7 +405,25 @@ class MediaPlayerService:
         """
         seen: set[str] = set()
         candidates: list[tuple[str | None, str]] = []
-        provider_fields = _PROVIDER_URI_FIELDS.get(self._provider, ())
+        # Validate the dispatch key explicitly (#1276). An unknown provider
+        # (key absent from the table) is a config-level mismatch — the wizard
+        # is supposed to gate it, but if it slips through, `.get(..., ())`
+        # would silently yield zero candidates and playback would fail with
+        # no actionable diagnostic. This is the silent-fail pattern behind
+        # #768/#808. A KNOWN provider mapped to `()` (e.g. amazon_music, which
+        # plays via Alexa text-search, not URIs) is intentional and stays
+        # quiet. `_resolved_uri` is still honored below as a last resort so an
+        # unexpected provider doesn't hard-fail when the song does carry a URI.
+        provider_fields = _PROVIDER_URI_FIELDS.get(self._provider)
+        if provider_fields is None:
+            _LOGGER.warning(
+                "MA dispatch: unknown provider %r — no URI field mapping; "
+                "falling back to _resolved_uri only for %s - %s (#1276)",
+                self._provider,
+                song.get("artist"),
+                song.get("title"),
+            )
+            provider_fields = ()
 
         def _add(field: str | None, raw: str | None) -> None:
             if not raw:
@@ -452,8 +470,11 @@ class MediaPlayerService:
 
         candidates = self._get_ma_uri_candidates(song)
         if not candidates:
-            _LOGGER.error(
-                "MA playback: no URIs for %s - %s",
+            # #1276: surface the provider so a missing-URI miss is debuggable
+            # (which provider was selected vs. which fields the song carries).
+            _LOGGER.warning(
+                "MA playback: no playable URI for provider %r — %s - %s (#1276)",
+                self._provider,
                 song.get("artist"),
                 song.get("title"),
             )

--- a/tests/unit/test_media_player.py
+++ b/tests/unit/test_media_player.py
@@ -820,6 +820,75 @@ class TestMAProviderFallback:
         svc = MediaPlayerService(hass, "media_player.test", platform="music_assistant")
         assert svc._get_ma_uri_candidates({"title": "x", "artist": "y"}) == []
 
+    def test_candidates_unknown_provider_warns_and_falls_back(self, caplog):
+        """#1276: an unmapped provider logs a warning and falls back to _resolved_uri.
+
+        The wizard is supposed to gate provider selection, but if an unknown
+        value reaches the dispatch the old `.get(..., ())` produced zero
+        candidates with no diagnostic (the silent-fail pattern behind
+        #768/#808). The provider must be named in the warning, and a song
+        that still carries `_resolved_uri` must remain playable.
+        """
+        hass = _make_hass()
+        svc = MediaPlayerService(
+            hass,
+            "media_player.test",
+            platform="music_assistant",
+            provider="napster",  # not in _PROVIDER_URI_FIELDS
+        )
+        song = {
+            "artist": "A",
+            "title": "T",
+            "_resolved_uri": "spotify:track:abc",
+        }
+        with caplog.at_level("WARNING"):
+            candidates = svc._get_ma_uri_candidates(song)
+        # _resolved_uri is still honored as a last resort.
+        assert candidates == [(None, "spotify:track:abc")]
+        # Warning names the unknown provider so the mismatch is debuggable.
+        assert any(
+            "napster" in rec.message and rec.levelname == "WARNING"
+            for rec in caplog.records
+        )
+
+    def test_candidates_known_provider_empty_fields_stays_quiet(self, caplog):
+        """#1276: a known provider mapped to () (amazon_music) must NOT warn.
+
+        amazon_music plays via Alexa text-search and intentionally has no URI
+        fields — it must not be mistaken for the unknown-provider miss-case.
+        """
+        hass = _make_hass()
+        svc = MediaPlayerService(
+            hass,
+            "media_player.test",
+            platform="music_assistant",
+            provider="amazon_music",
+        )
+        with caplog.at_level("WARNING"):
+            svc._get_ma_uri_candidates({"artist": "A", "title": "T"})
+        assert not any("unknown provider" in rec.message for rec in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_play_via_ma_no_candidate_warns_with_provider(self, caplog):
+        """#1276: a missing-URI miss logs a warning naming the provider + song."""
+        hass = _make_hass()
+        svc = MediaPlayerService(
+            hass,
+            "media_player.test",
+            platform="music_assistant",
+            provider="apple_music",
+        )
+        # Song has no apple_music URI → no candidates.
+        song = {"artist": "Artist", "title": "Title", "uri_spotify": "spotify:track:x"}
+        with caplog.at_level("WARNING"):
+            result = await svc._play_via_music_assistant(song)
+        assert result is False
+        assert svc.last_failure_reason == "unavailable"
+        assert any(
+            "apple_music" in rec.message and "Artist" in rec.message
+            for rec in caplog.records
+        )
+
     @pytest.mark.asyncio
     async def test_fallback_within_provider_tries_next_when_primary_fails(self):
         """For Spotify, if `_resolved_uri` fails, legacy `uri` field is tried next."""


### PR DESCRIPTION
Closes #1276

## Readiness assessment
- [x] Ready to merge
- [ ] Borderline — see notes
- [ ] Not ready — needs human review

**Honest summary:** Tightens the `_PROVIDER_URI_FIELDS` dispatch in `services/media_player.py` so the two silent-fail surfaces behind #768/#808 are now diagnosable. An **unknown** provider (key absent from the table) used to fall through `.get(..., ())` to zero candidates with no log; it now emits a WARNING naming the provider + song and still honors `_resolved_uri` as a last-resort fallback. The empty-candidates path in `_play_via_music_assistant` now logs a WARNING that names the selected provider (previously an ERROR with no provider). No control-flow or `last_failure_reason` contract changes — purely observability + the unknown-provider fallback. Backend-only, no UI surface.

## Test plan
- Added 3 unit tests in `tests/unit/test_media_player.py`:
  - `test_candidates_unknown_provider_warns_and_falls_back` — unmapped provider logs WARNING + `_resolved_uri` still produces a candidate.
  - `test_candidates_known_provider_empty_fields_stays_quiet` — `amazon_music` (legit empty mapping) does NOT warn.
  - `test_play_via_ma_no_candidate_warns_with_provider` — miss-case logs WARNING with provider + song, `last_failure_reason="unavailable"`.
- `pytest tests/unit/` → 822 passed.
- `ruff check .` + `ruff format --check .` → clean.

## Risk assessment
- **Blast radius:** `_get_ma_uri_candidates` + `_play_via_music_assistant` in `custom_components/beatify/services/media_player.py`; tests only otherwise.
- **What could go wrong:** Severity of the empty-candidates log dropped ERROR→WARNING. This is intentional (a song missing from a provider catalog is an expected, recoverable skip, not a hard error) but if any log-scraping/alerting keyed on the ERROR string `"MA playback: no URIs for"`, it would need updating.
- **What I did NOT test:** No live HA / Music Assistant integration run; verification is unit-level only. Integration test suite not run locally (CI covers it).

🤖 Auto-generated by issue-triage routine