### PR TITLE
test(admin): vitest smoke tests for pure helpers — #1279 Schritt 1/6

### DIFF
--- a/custom_components/beatify/www/js/__tests__/admin-helpers-loader.js
+++ b/custom_components/beatify/www/js/__tests__/admin-helpers-loader.js
@@ -1,0 +1,125 @@
+/**
+ * Smoke-test loader for admin.js pure helpers (#1279, Schritt 1/6).
+ *
+ * admin.js is a CLASSIC GLOBAL SCRIPT — no `export`s, no `import`s, and a pile
+ * of top-level side effects (document.addEventListener, IIFEs, serviceWorker
+ * registration). It cannot be `import`ed, and evaluating the whole file would
+ * require stubbing its entire browser surface.
+ *
+ * Decomposition step 1 must NOT touch production code, so instead of adding
+ * exports we extract the SOURCE TEXT of the individual pure helpers straight
+ * out of admin.js at test time (brace-matched) and eval only those snippets in
+ * a controlled scope. The tests therefore run the EXACT production source and
+ * stay in sync automatically — if someone edits `escapeHtml` in admin.js, the
+ * extracted text (and the test) changes with it.
+ *
+ * When step 2 turns these helpers into a real ESM `admin/util.js`, this loader
+ * is deleted and the tests switch to a plain `import`.
+ */
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ADMIN_JS = join(__dirname, '..', 'admin.js');
+
+let _src = null;
+function adminSource() {
+    if (_src === null) _src = readFileSync(ADMIN_JS, 'utf8');
+    return _src;
+}
+
+/**
+ * Extract a top-level `function NAME(...) { ... }` declaration's full source
+ * text by matching braces from its opening `{`. Throws if the name is absent
+ * (so a renamed/removed helper fails loudly instead of silently testing stale
+ * inlined copies).
+ */
+export function extractFunction(name) {
+    const src = adminSource();
+    const re = new RegExp(`(?:^|\\n)((?:async\\s+)?function\\s+${name}\\s*\\()`);
+    const m = re.exec(src);
+    if (!m) throw new Error(`admin.js: function ${name} not found`);
+    const start = m.index + (m[0].startsWith('\n') ? 1 : 0);
+    // find the first '{' after the signature
+    let i = src.indexOf('{', m.index + m[0].length - 1);
+    if (i === -1) throw new Error(`admin.js: no body for ${name}`);
+    const end = matchBrace(src, i);
+    return src.slice(start, end + 1);
+}
+
+/**
+ * Extract a top-level `const NAME = { ... };` object literal source text.
+ */
+export function extractConst(name) {
+    const src = adminSource();
+    const re = new RegExp(`(?:^|\\n)(const\\s+${name}\\s*=\\s*)`);
+    const m = re.exec(src);
+    if (!m) throw new Error(`admin.js: const ${name} not found`);
+    const start = m.index + (m[0].startsWith('\n') ? 1 : 0);
+    let i = src.indexOf('{', m.index + m[0].length - 1);
+    if (i === -1) throw new Error(`admin.js: no object body for ${name}`);
+    const end = matchBrace(src, i);
+    return src.slice(start, end + 1) + ';';
+}
+
+// Brace matcher that skips string/template/comment content so braces inside
+// HTML-template literals (buildRequestRowHtml) don't throw off the count.
+function matchBrace(src, openIdx) {
+    let depth = 0;
+    let i = openIdx;
+    let mode = 'code'; // code | sq | dq | tpl | line | block
+    while (i < src.length) {
+        const c = src[i];
+        const n = src[i + 1];
+        if (mode === 'code') {
+            if (c === '/' && n === '/') { mode = 'line'; i += 2; continue; }
+            if (c === '/' && n === '*') { mode = 'block'; i += 2; continue; }
+            if (c === "'") { mode = 'sq'; i++; continue; }
+            if (c === '"') { mode = 'dq'; i++; continue; }
+            if (c === '`') { mode = 'tpl'; i++; continue; }
+            if (c === '{') depth++;
+            else if (c === '}') { depth--; if (depth === 0) return i; }
+        } else if (mode === 'line') {
+            if (c === '\n') mode = 'code';
+        } else if (mode === 'block') {
+            if (c === '*' && n === '/') { mode = 'code'; i += 2; continue; }
+        } else if (mode === 'sq') {
+            if (c === '\\') { i += 2; continue; }
+            if (c === "'") mode = 'code';
+        } else if (mode === 'dq') {
+            if (c === '\\') { i += 2; continue; }
+            if (c === '"') mode = 'code';
+        } else if (mode === 'tpl') {
+            if (c === '\\') { i += 2; continue; }
+            if (c === '`') mode = 'code';
+            // NOTE: nested ${ } interpolation braces are intentionally ignored
+            // for these helpers (none nest an unbalanced object literal inside).
+        }
+        i++;
+    }
+    throw new Error('admin.js: unbalanced braces while extracting helper');
+}
+
+/**
+ * Compile a set of extracted declarations into a single live scope and return
+ * the requested names. `globals` is injected as in-scope variables (e.g.
+ * currentGame, localStorage, document, REQUEST_STATUS_LABELS) so the helpers
+ * resolve their free references against test stubs instead of real browser
+ * globals.
+ */
+export function loadHelpers({ functions = [], consts = [], globals = {}, expose }) {
+    const decls = [
+        ...consts.map(extractConst),
+        ...functions.map(extractFunction),
+    ].join('\n\n');
+    const exposeNames = expose || functions;
+    const globalKeys = Object.keys(globals);
+    const body = `
+        ${decls}
+        return { ${exposeNames.join(', ')} };
+    `;
+    // eslint-disable-next-line no-new-func
+    const factory = new Function(...globalKeys, body);
+    return factory(...globalKeys.map((k) => globals[k]));
+}

--- a/custom_components/beatify/www/js/__tests__/admin-helpers.test.js
+++ b/custom_components/beatify/www/js/__tests__/admin-helpers.test.js
@@ -1,0 +1,256 @@
+/**
+ * Smoke-test safety net for the pure helpers in admin.js (#1279, Schritt 1/6).
+ *
+ * admin.js (4428 lines) is a classic global script with ZERO test coverage and
+ * is slated for a 6-step modularisation. Step 1 (this file) pins down the
+ * behaviour of the small, side-effect-free helper functions BEFORE any code is
+ * moved, so the later extraction into `admin/util.js` / `admin/api.js` can be
+ * verified against a green baseline.
+ *
+ * The helpers are not exported (admin.js stays untouched in step 1), so their
+ * source text is lifted out of admin.js at runtime and eval'd in an isolated
+ * scope — see admin-helpers-loader.js. The tests run the exact production
+ * source.
+ *
+ * Helpers covered:
+ *   - _getAdminToken()           (token resolution: per-game → global → null)
+ *   - _setAdminToken(t, gameId)  (persistence to localStorage + sessionStorage cleanup)
+ *   - _adminHeaders()            (REST header builder, Bearer iff token present)
+ *   - groupPlayersByPlatform()   (pure grouping)
+ *   - escapeHtml()               (XSS escaping via DOM textContent)
+ *   - buildRequestRowHtml()      (request-card HTML, status-label lookup, escaping)
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { loadHelpers } from './admin-helpers-loader.js';
+
+// --- minimal localStorage / sessionStorage stub ----------------------------
+function makeStorage() {
+    const map = new Map();
+    return {
+        getItem: (k) => (map.has(k) ? map.get(k) : null),
+        setItem: (k, v) => { map.set(k, String(v)); },
+        removeItem: (k) => { map.delete(k); },
+        _map: map,
+    };
+}
+
+// --- minimal document stub for escapeHtml (textContent → innerHTML) --------
+// Mirrors the browser's HTML-escaping of textContent for the characters the
+// helper guards against (&, <, >). Quotes are NOT escaped by textContent in a
+// real browser, so we don't escape them here either.
+function makeDocumentStub() {
+    return {
+        createElement() {
+            const el = {
+                _text: '',
+                set textContent(v) { el._text = v == null ? '' : String(v); },
+                get innerHTML() {
+                    return el._text
+                        .replace(/&/g, '&amp;')
+                        .replace(/</g, '&lt;')
+                        .replace(/>/g, '&gt;');
+                },
+            };
+            return el;
+        },
+    };
+}
+
+describe('admin.js pure helpers — token + headers (#1279 step 1)', () => {
+    let localStorage;
+    let sessionStorage;
+
+    function load(currentGame) {
+        return loadHelpers({
+            functions: ['_getAdminToken', '_setAdminToken', '_adminHeaders'],
+            globals: { currentGame, localStorage, sessionStorage },
+        });
+    }
+
+    beforeEach(() => {
+        localStorage = makeStorage();
+        sessionStorage = makeStorage();
+    });
+
+    it('_getAdminToken returns null when nothing is stored', () => {
+        const { _getAdminToken } = load({ game_id: 'g1' });
+        expect(_getAdminToken()).toBeNull();
+    });
+
+    it('_getAdminToken prefers the per-game token over the global token', () => {
+        localStorage.setItem('beatify_admin_token', 'GLOBAL');
+        localStorage.setItem('beatify_admin_token_g1', 'PERGAME');
+        const { _getAdminToken } = load({ game_id: 'g1' });
+        expect(_getAdminToken()).toBe('PERGAME');
+    });
+
+    it('_getAdminToken falls back to the global token when no per-game token', () => {
+        localStorage.setItem('beatify_admin_token', 'GLOBAL');
+        const { _getAdminToken } = load({ game_id: 'g1' });
+        expect(_getAdminToken()).toBe('GLOBAL');
+    });
+
+    it('_getAdminToken uses the global token when there is no current game', () => {
+        localStorage.setItem('beatify_admin_token', 'GLOBAL');
+        const { _getAdminToken } = load(undefined);
+        expect(_getAdminToken()).toBe('GLOBAL');
+    });
+
+    it('_getAdminToken swallows storage exceptions and returns null', () => {
+        const throwing = {
+            getItem() { throw new Error('SecurityError'); },
+        };
+        const { _getAdminToken } = loadHelpers({
+            functions: ['_getAdminToken'],
+            globals: { currentGame: { game_id: 'g1' }, localStorage: throwing },
+        });
+        expect(_getAdminToken()).toBeNull();
+    });
+
+    it('_setAdminToken writes both per-game and global keys and clears sessionStorage', () => {
+        sessionStorage.setItem('beatify_admin_token', 'STALE');
+        const { _setAdminToken } = load({ game_id: 'g1' });
+        _setAdminToken('TOKEN123', 'g1');
+        expect(localStorage.getItem('beatify_admin_token_g1')).toBe('TOKEN123');
+        expect(localStorage.getItem('beatify_admin_token')).toBe('TOKEN123');
+        expect(sessionStorage.getItem('beatify_admin_token')).toBeNull();
+    });
+
+    it('_setAdminToken writes only the global key when no gameId is given', () => {
+        const { _setAdminToken } = load(undefined);
+        _setAdminToken('TOKEN123');
+        expect(localStorage.getItem('beatify_admin_token')).toBe('TOKEN123');
+        expect(localStorage.getItem('beatify_admin_token_undefined')).toBeNull();
+    });
+
+    it('_adminHeaders includes a Bearer header when a token is present', () => {
+        localStorage.setItem('beatify_admin_token', 'TOK');
+        const { _adminHeaders } = load(undefined);
+        expect(_adminHeaders()).toEqual({
+            'Content-Type': 'application/json',
+            Authorization: 'Bearer TOK',
+        });
+    });
+
+    it('_adminHeaders omits Authorization when no token is present', () => {
+        const { _adminHeaders } = load(undefined);
+        const headers = _adminHeaders();
+        expect(headers).toEqual({ 'Content-Type': 'application/json' });
+        expect(headers.Authorization).toBeUndefined();
+    });
+});
+
+describe('admin.js pure helpers — groupPlayersByPlatform (#1279 step 1)', () => {
+    function load() {
+        return loadHelpers({ functions: ['groupPlayersByPlatform'], globals: {} });
+    }
+
+    it('groups players by their platform field', () => {
+        const { groupPlayersByPlatform } = load();
+        const players = [
+            { entity_id: 'a', platform: 'spotify' },
+            { entity_id: 'b', platform: 'sonos' },
+            { entity_id: 'c', platform: 'spotify' },
+        ];
+        const groups = groupPlayersByPlatform(players);
+        expect(Object.keys(groups).sort()).toEqual(['sonos', 'spotify']);
+        expect(groups.spotify.map((p) => p.entity_id)).toEqual(['a', 'c']);
+        expect(groups.sonos.map((p) => p.entity_id)).toEqual(['b']);
+    });
+
+    it('buckets players with a missing platform under "unknown"', () => {
+        const { groupPlayersByPlatform } = load();
+        const groups = groupPlayersByPlatform([{ entity_id: 'x' }, { entity_id: 'y', platform: null }]);
+        expect(groups.unknown.map((p) => p.entity_id)).toEqual(['x', 'y']);
+    });
+
+    it('returns an empty object for an empty list', () => {
+        const { groupPlayersByPlatform } = load();
+        expect(groupPlayersByPlatform([])).toEqual({});
+    });
+});
+
+describe('admin.js pure helpers — escapeHtml (#1279 step 1)', () => {
+    function load() {
+        return loadHelpers({
+            functions: ['escapeHtml'],
+            globals: { document: makeDocumentStub() },
+        });
+    }
+
+    it('escapes angle brackets and ampersands', () => {
+        const { escapeHtml } = load();
+        expect(escapeHtml('<script>alert("x")&</script>')).toBe(
+            '&lt;script&gt;alert("x")&amp;&lt;/script&gt;',
+        );
+    });
+
+    it('leaves plain text unchanged', () => {
+        const { escapeHtml } = load();
+        expect(escapeHtml('Hello World 123')).toBe('Hello World 123');
+    });
+
+    it('coerces nullish input to an empty string', () => {
+        const { escapeHtml } = load();
+        expect(escapeHtml(null)).toBe('');
+        expect(escapeHtml(undefined)).toBe('');
+    });
+});
+
+describe('admin.js pure helpers — buildRequestRowHtml (#1279 step 1)', () => {
+    function load() {
+        return loadHelpers({
+            functions: ['buildRequestRowHtml', 'escapeHtml'],
+            consts: ['REQUEST_STATUS_LABELS'],
+            globals: { document: makeDocumentStub() },
+            expose: ['buildRequestRowHtml'],
+        });
+    }
+
+    it('renders the mapped status label and escaped playlist name', () => {
+        const { buildRequestRowHtml } = load();
+        const html = buildRequestRowHtml({
+            status: 'ready',
+            playlist_name: 'Rock & <Roll>',
+            relative_time: '2h ago',
+        });
+        expect(html).toContain('Rock &amp; &lt;Roll&gt;');
+        expect(html).toContain('✅ Ready');
+        expect(html).toContain('request-status--ready');
+        expect(html).toContain('2h ago');
+    });
+
+    it('falls back to the raw status when it is not in the label map', () => {
+        const { buildRequestRowHtml } = load();
+        const html = buildRequestRowHtml({ status: 'weird', playlist_name: 'X' });
+        expect(html).toContain('request-status--weird');
+        expect(html).toContain('>weird</span>');
+    });
+
+    it('uses the "Untitled request" fallback when no name is provided', () => {
+        const { buildRequestRowHtml } = load();
+        const html = buildRequestRowHtml({ status: 'pending' });
+        expect(html).toContain('Untitled request');
+        expect(html).toContain('⏳ Pending');
+    });
+
+    it('shows the update button only for ready+update_available requests', () => {
+        const { buildRequestRowHtml } = load();
+        const withUpdate = buildRequestRowHtml({
+            status: 'ready',
+            update_available: true,
+            release_version: '4.1.0',
+            playlist_name: 'P',
+        });
+        expect(withUpdate).toContain('Update to v4.1.0');
+
+        const noUpdate = buildRequestRowHtml({ status: 'ready', playlist_name: 'P' });
+        expect(noUpdate).not.toContain('request-update-btn');
+    });
+
+    it('renders the placeholder thumbnail when no thumbnail_url is set', () => {
+        const { buildRequestRowHtml } = load();
+        const html = buildRequestRowHtml({ status: 'pending', playlist_name: 'P' });
+        expect(html).toContain('request-item-thumbnail-placeholder');
+    });
+});


### PR DESCRIPTION
Part of #1279 — **Schritt 1/6** of the `admin.js` decomposition plan ([Triage-Kommentar](https://github.com/mholzi/beatify/issues/1279#issuecomment-4664141225)). Only step Markus freigegeben hat: a **test safety net BEFORE any code moves**. No modularisation, no `type="module"`, no `www/` production change.

## What this does
Adds vitest smoke tests pinning the behaviour of the pure, side-effect-free helpers in `admin.js`, so step 2 (extracting them into `admin/util.js`) can be verified against a green baseline.

Helpers covered (20 new tests):
- `_getAdminToken` — per-game → global → null resolution + exception swallowing
- `_setAdminToken` — localStorage persistence + sessionStorage cleanup
- `_adminHeaders` — Bearer header iff token present
- `groupPlayersByPlatform` — pure grouping incl. `unknown` fallback
- `escapeHtml` — `& < >` escaping + nullish coercion
- `buildRequestRowHtml` — status-label lookup, escaped name, update-button gate, thumbnail fallback

## How it tests admin.js without changing it
`admin.js` is a **classic global script** — zero `export`s, zero `import`s, and top-level side effects (document listeners, IIFEs, serviceWorker registration). It can't be `import`ed, and eval'ing the whole file would mean stubbing its entire browser surface.

So `admin-helpers-loader.js` lifts the **source text** of each named helper out of `admin.js` at test time (brace-matched, string/comment-aware) and eval's only those snippets in a controlled scope with stubbed globals. The tests run the **exact production source** and stay in sync automatically — `admin.js` is **byte-for-byte untouched** (`git diff origin/main -- admin.js` is empty).

## Readiness assessment
- [x] Ready to merge (test-only, additive)
- [ ] Borderline
- [ ] Not ready

**Honest summary:** Test-only, additive, zero production change. `npm test` 180 → 200 green, `npm run build` + `build:check` drift-free. The eval-extraction loader is a deliberate step-1 stopgap, explicitly designed to be deleted in step 2.

## Test plan
- `npm test` → 200 passed (was 180)
- `npm run build && npm run build:check` → drift-free (no `www/` change)
- `git diff origin/main -- custom_components/beatify/www/js/admin.js` → empty

## Risk assessment
- **Blast radius:** 2 new files under `www/js/__tests__/` only. No production / bundle / HTML / sw.js change → frontend-bundle guardrail N/A.
- **What could go wrong:** the loader's brace-matcher would throw loudly (not silently pass) if a helper is renamed/removed; that's intended as a drift alarm. The `escapeHtml`/document stub mirrors browser `textContent` escaping for `& < >` only (quotes aren't escaped by textContent, matching the browser).
- **What I did NOT test:** any DOM-mutating / stateful / WS / view-render function (out of scope for step 1 — those get tested as they're extracted in steps 2–6).

## Needed for Schritt 2 (not in this PR)
- Migrate `admin` from `MINIFY` → `BUNDLES` in `scripts/build.mjs` + `admin.html` to `type="module"`, with `window.X = X` re-export shims for the existing globals (`loadStatus`, `BeatifyHome`, …).
- At that point `admin-helpers-loader.js` is deleted and these tests switch to a plain `import` from `admin/util.js`.

🤖 Auto-generated by issue-triage routine (Schritt 1/6)