### PR TITLE
refactor(state): SSOT phase transitions via _set_phase — first increment (#1273)

### DIFF
--- a/custom_components/beatify/game/state.py
+++ b/custom_components/beatify/game/state.py
@@ -246,6 +246,50 @@ class GameState:
         for cb in self._state_callbacks:
             cb()
 
+    # ------------------------------------------------------------------
+    # Phase transitions — Single Source of Truth (Issue #1273)
+    # ------------------------------------------------------------------
+    #
+    # ALL writes to ``self.phase`` go through ``_set_phase``. This makes the
+    # backend the one authoritative owner of the game phase and gives every
+    # transition a single, auditable chokepoint. Two invariants that were
+    # previously hand-maintained at each scattered ``self.phase = …`` site are
+    # now enforced here so they can never drift:
+    #
+    #   * ``reveal_started_at`` (#1048) is non-None *iff* phase is REVEAL —
+    #     stamped on entry to REVEAL, cleared on every other transition.
+    #   * registered state observers (#441) are notified on every phase change.
+    #
+    # This is the first increment of the SSOT state-machine described in the
+    # issue: it centralises the *write* path without yet modelling explicit
+    # transition guards. Follow-up increments can layer a transition table on
+    # top of this single chokepoint (see PR description / migration path).
+
+    def _set_phase(self, new_phase: GamePhase, *, notify: bool = True) -> None:
+        """Authoritatively transition the game to ``new_phase``.
+
+        The single write-point for ``self.phase`` (Issue #1273). Maintains the
+        ``reveal_started_at`` invariant (#1048) and notifies state observers
+        (#441) so no transition site has to remember either bookkeeping step.
+
+        Args:
+            new_phase: The phase to transition into.
+            notify: Whether to fire registered state callbacks. Defaults to
+                True; pass False only when the caller batches its own notify
+                immediately afterwards (kept for callers that interleave other
+                bookkeeping between the phase write and the broadcast).
+
+        """
+        self.phase = new_phase
+        # #1048: the REVEAL-entry timestamp is owned entirely by the phase
+        # transition. Entering REVEAL stamps it; any other phase clears it.
+        if new_phase is GamePhase.REVEAL:
+            self.reveal_started_at = int(self._now() * 1000)
+        else:
+            self.reveal_started_at = None
+        if notify:
+            self._notify_state_callbacks()
+
     def current_time(self) -> float:
         """Return the current timestamp from the injected clock."""
         return self._now()
@@ -635,8 +679,7 @@ class GameState:
 
         self.game_id = secrets.token_urlsafe(8)
         self.admin_token = secrets.token_urlsafe(16)  # Issue #386: REST admin auth
-        self.phase = GamePhase.LOBBY
-        self._notify_state_callbacks()
+        self._set_phase(GamePhase.LOBBY)
         self.playlists = playlists
         self.songs = songs
         self.media_player = media_player
@@ -866,7 +909,7 @@ class GameState:
         await self.disable_tts()
         self._reset_game_internals()
         self.game_id = None
-        self.phase = GamePhase.LOBBY
+        self._set_phase(GamePhase.LOBBY, notify=False)
         self.players = {}
         self.clear_all_sessions()
         self._notify_state_callbacks()
@@ -911,8 +954,7 @@ class GameState:
         )
         self.total_rounds = len(preserved["songs"])
 
-        self.phase = GamePhase.LOBBY
-        self._notify_state_callbacks()
+        self._set_phase(GamePhase.LOBBY)
         # Reset each player's game stats but keep them connected
         for player in self.players.values():
             player.reset_for_new_game()
@@ -975,10 +1017,8 @@ class GameState:
             if self._media_player_service:
                 await self._media_player_service.stop()
 
-        # Transition to PAUSED
-        self.phase = GamePhase.PAUSED
-        self.reveal_started_at = None  # #1048: leaving REVEAL
-        self._notify_state_callbacks()
+        # Transition to PAUSED (clears reveal_started_at + notifies, #1273)
+        self._set_phase(GamePhase.PAUSED)
         _LOGGER.info("Game paused: %s", reason)
 
         return True
@@ -1046,7 +1086,12 @@ class GameState:
                     await self._media_player_service.play()
                     _LOGGER.info("Media playback resumed")
             else:
-                # Timer expired during pause — end the round immediately
+                # Timer expired during pause — end the round immediately.
+                # #1273: resume *restores* a saved phase rather than making a
+                # forward transition, so it intentionally does NOT route through
+                # _set_phase — re-stamping reveal_started_at on a resume-to-REVEAL
+                # would change behaviour (the auto-advance countdown must not
+                # restart). Kept as a direct write; see PR migration notes.
                 _LOGGER.info("Timer expired during pause, ending round")
                 self.phase = previous
                 self._notify_state_callbacks()
@@ -1056,7 +1101,8 @@ class GameState:
                 await self.end_round()
                 return True
 
-        # Restore previous phase
+        # Restore previous phase (direct write, not _set_phase — see #1273 note
+        # in the timer-expired branch above: resume must not re-stamp REVEAL).
         self.phase = previous
         self._notify_state_callbacks()
         self.pause_reason = None
@@ -1328,8 +1374,7 @@ class GameState:
         if len(self.players) < MIN_PLAYERS:
             return False, ERR_GAME_NOT_STARTED  # Need at least MIN_PLAYERS to play
 
-        self.phase = GamePhase.PLAYING
-        self._notify_state_callbacks()
+        self._set_phase(GamePhase.PLAYING)
         # Round and song selection will be implemented in Epic 4
         _LOGGER.info("Game started: %d players", len(self.players))
         return True, None
@@ -1359,8 +1404,7 @@ class GameState:
         song = self._playlist_manager.get_next_song()
         if not song:
             _LOGGER.info("All songs exhausted, ending game")
-            self.phase = GamePhase.END
-            self._notify_state_callbacks()
+            self._set_phase(GamePhase.END)
             return False
 
         resolved_uri = song.get("_resolved_uri")
@@ -1553,9 +1597,8 @@ class GameState:
             extra_deadline_ms=extra_deadline_ms,
         )
         self.round_analytics = None
-        self.phase = GamePhase.PLAYING
-        self.reveal_started_at = None  # #1048: leaving REVEAL
-        self._notify_state_callbacks()
+        # #1273: transition clears reveal_started_at (#1048) + notifies (#441).
+        self._set_phase(GamePhase.PLAYING)
 
     async def _timer_countdown(self, delay_seconds: float) -> None:
         """Wait for round to end, then trigger reveal.
@@ -2093,11 +2136,10 @@ class GameState:
         self._player_registry._reactions_this_phase = (
             set()
         )  # Story 18.9: Clear for new reveal phase
-        self.phase = GamePhase.REVEAL
-        # #1048: timestamp REVEAL entry so admin client can render the
-        # auto-advance countdown on the sticky Next button.
-        self.reveal_started_at = int(self._now() * 1000)
-        self._notify_state_callbacks()
+        # #1273: _set_phase stamps reveal_started_at on REVEAL entry (#1048 —
+        # so the admin client can render the auto-advance countdown on the
+        # sticky Next button) and notifies observers (#441).
+        self._set_phase(GamePhase.REVEAL)
 
         # #1012: schedule the unattended REVEAL auto-advance — always on
         # (timer 0 = advance at song-end). start_round itself ends the
@@ -2375,9 +2417,8 @@ class GameState:
         self.cancel_timer()
         self._round_manager._cancel_intro_timer()
         self._cancel_auto_advance()  # #1012
-        self.phase = GamePhase.END
-        self.reveal_started_at = None  # #1048
-        self._notify_state_callbacks()
+        # #1273: transition clears reveal_started_at (#1048) + notifies (#441).
+        self._set_phase(GamePhase.END)
 
         # Issue #331: Celebrate with Party Lights, then stop (#553)
         if self._party_lights:

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -1315,3 +1315,61 @@ class TestTitleArtistMode:
         # Now Bob too
         gs.players["Bob"].has_title_artist_guess = True
         assert gs.check_all_guesses_complete() is True
+
+
+# ---------------------------------------------------------------------------
+# Phase transition SSOT (_set_phase) — Issue #1273
+# ---------------------------------------------------------------------------
+
+
+class TestSetPhaseSSOT:
+    """The single phase write-point centralises phase + its invariants (#1273)."""
+
+    def test_sets_phase(self):
+        state = make_game_state()
+        state._set_phase(GamePhase.PLAYING)
+        assert state.phase == GamePhase.PLAYING
+
+    def test_entering_reveal_stamps_reveal_started_at(self):
+        # Deterministic clock so the stamp is predictable (#1048).
+        state = make_game_state(time_fn=lambda: 1000.0)
+        state._set_phase(GamePhase.REVEAL)
+        assert state.phase == GamePhase.REVEAL
+        assert state.reveal_started_at == 1_000_000  # int(now * 1000)
+
+    @pytest.mark.parametrize(
+        "phase",
+        [GamePhase.LOBBY, GamePhase.PLAYING, GamePhase.PAUSED, GamePhase.END],
+    )
+    def test_leaving_reveal_clears_reveal_started_at(self, phase):
+        state = make_game_state(time_fn=lambda: 1000.0)
+        state._set_phase(GamePhase.REVEAL)
+        assert state.reveal_started_at is not None
+        # Any non-REVEAL transition clears the stamp — the SSOT invariant.
+        state._set_phase(phase)
+        assert state.reveal_started_at is None
+
+    def test_invariant_reveal_started_at_iff_reveal(self):
+        # reveal_started_at is non-None *iff* phase is REVEAL, for every phase.
+        state = make_game_state(time_fn=lambda: 1000.0)
+        for phase in GamePhase:
+            state._set_phase(phase)
+            if phase is GamePhase.REVEAL:
+                assert state.reveal_started_at is not None
+            else:
+                assert state.reveal_started_at is None
+
+    def test_notifies_state_callbacks_by_default(self):
+        state = make_game_state()
+        calls: list[int] = []
+        state.register_state_callback(lambda: calls.append(1))
+        state._set_phase(GamePhase.PLAYING)
+        assert calls == [1]
+
+    def test_notify_false_skips_callbacks(self):
+        state = make_game_state()
+        calls: list[int] = []
+        state.register_state_callback(lambda: calls.append(1))
+        state._set_phase(GamePhase.PLAYING, notify=False)
+        assert calls == []
+        assert state.phase == GamePhase.PLAYING


### PR DESCRIPTION
Refs #1273 (first increment — does NOT fully close the issue)

## What this is
The **first, behavior-preserving increment** of the Single-Source-of-Truth game-state-machine from #1273. It does **not** rewrite the whole state model. It establishes the SSOT *seam*: one authoritative write-point for the game phase.

Before, `self.phase = <GamePhase>` was written at **9 scattered sites** across `game/state.py`, and two cross-cutting invariants were hand-maintained at each site (and drifted — some sites forgot the notify, the `reveal_started_at` clear was duplicated). Now a single `GameState._set_phase(new_phase, *, notify=True)` owns:
- the `self.phase` write,
- the `reveal_started_at` invariant (#1048): non-None **iff** phase is REVEAL — stamped on REVEAL entry, cleared on every other transition,
- state-observer notification (#441) on every transition.

All forward transitions now route through it: create/reset/rematch → LOBBY, start → PLAYING, reveal → REVEAL, songs-exhausted/end → END, pause → PAUSED.

## Readiness assessment
- [ ] Ready to merge
- [x] Borderline — see notes
- [ ] Not ready — needs human review

**Honest summary:** The change is small, mechanical, fully behavior-preserving, and well-covered (full suite 829 passed + 9 new invariant tests). It is "Borderline" only because it is explicitly a **first increment**, not the full state-machine the issue ultimately wants — it centralises the *write path* but does not yet add a transition table / explicit guards / failure-path triggers. The migration path for that is in the docstring on `_set_phase`. Acceptance criterion 1 ("Definierte Phasen + Transitions an einer Stelle") is now half-met (transitions funnel through one method); criteria 2 (failure-path advance/recovery triggers) and 3 (FE holds no authoritative timer state) are deliberately **out of scope** for this PR.

## Deliberate exception (read before reviewing the diff)
The **two `resume_game` writes** (`self.phase = previous`) intentionally stay direct and do NOT route through `_set_phase`. Resume *restores* a previously-saved phase; routing it through `_set_phase` would re-stamp `reveal_started_at` on a resume-to-REVEAL, restarting the auto-advance countdown — a behavior change. Both sites are documented inline. Folding resume into the SSOT is a follow-up (it needs the saved-timestamp restored, not re-stamped).

## Test plan
- `python3 -m pytest` → **829 passed, 2 skipped** (pre-existing skips)
- New `TestSetPhaseSSOT` (9 cases): phase set, REVEAL stamps `reveal_started_at`, every non-REVEAL transition clears it, the iff-invariant across all phases, notify default + `notify=False`.
- `python3 -m ruff check custom_components/beatify/` → clean
- `npx vitest run` → 14 files / 227 passed (unaffected — no frontend touched)

## Risk assessment
- **Blast radius:** one file's transition sites (`game/state.py`) + its test file. No frontend (`www/**`) touched → frontend bundle guardrail N/A.
- **What could go wrong:** the `reveal_started_at` invariant is now enforced on *every* transition, including LOBBY transitions that previously did not explicitly clear it (reset_to_lobby/rematch). This is behavior-preserving because those phases are never REVEAL, but it is a slightly broader clear than before. The resume exception is the one place the SSOT does not yet reach.
- **What I did NOT test:** live game runtime (HA integration / real media player / WS clients) — only the automated suites. Resume-to-REVEAL behavior is asserted unchanged by construction (left as a direct write), not by a new live test.

🤖 Auto-generated by issue-triage routine