### PR TITLE
fix(wizard): declutter speaker-picker service-capability badges (#1319)

### DIFF
--- a/custom_components/beatify/www/css/styles.css
+++ b/custom_components/beatify/www/css/styles.css
@@ -9820,6 +9820,9 @@ body.wizard-active > .pwa-ios-hint {
     border-radius: var(--radius-sm);
     border: 1px solid;
     vertical-align: middle;
+    /* #1319: the badge text itself never wraps — summaries keep it short, the
+       accent cases ("Spotify only") are short by construction. */
+    white-space: nowrap;
 }
 .wiz-row-sub .cap-badge.full {
     color: var(--color-success-neon);
@@ -9835,6 +9838,18 @@ body.wizard-active > .pwa-ios-hint {
     color: var(--color-error-neon);
     background: rgba(255, 0, 64, 0.08);
     border-color: rgba(255, 0, 64, 0.4);
+}
+/* #1319: multi-service capability is static info, not actionable — drop the
+   orange/uppercase/pill chrome so the speaker name stays the hero. Muted,
+   borderless, plain-case secondary text. The full list lives on the tooltip. */
+.wiz-row-sub .cap-badge.summary {
+    color: var(--color-text-dim);
+    background: none;
+    border: none;
+    padding: 0;
+    text-transform: none;
+    letter-spacing: 0;
+    font-weight: 500;
 }
 
 /* Explainer card shown when user clicks a dimmed provider chip (#772). */

--- a/custom_components/beatify/www/i18n/de.json
+++ b/custom_components/beatify/www/i18n/de.json
@@ -882,7 +882,9 @@
       "empty": "Noch keine Lautsprecher gefunden",
       "emptyHint": "Music Assistant installieren und aktualisieren",
       "capAll": "Alle Dienste",
+      "capMost": "Alle gängigen Dienste",
       "capOnlyTemplate": "nur {provider}",
+      "capMoreTemplate": "{provider} +{count}",
       "capNone": "Keine Dienste"
     },
     "step2": {

--- a/custom_components/beatify/www/i18n/en.json
+++ b/custom_components/beatify/www/i18n/en.json
@@ -882,7 +882,9 @@
       "empty": "No speakers found yet",
       "emptyHint": "Install Music Assistant and refresh",
       "capAll": "All services",
+      "capMost": "All major services",
       "capOnlyTemplate": "{provider} only",
+      "capMoreTemplate": "{provider} +{count}",
       "capNone": "No services"
     },
     "step2": {

--- a/custom_components/beatify/www/i18n/es.json
+++ b/custom_components/beatify/www/i18n/es.json
@@ -882,7 +882,9 @@
       "empty": "Aún no hay altavoces",
       "emptyHint": "Instala Music Assistant y actualiza",
       "capAll": "Todos los servicios",
+      "capMost": "Todos los servicios principales",
       "capOnlyTemplate": "solo {provider}",
+      "capMoreTemplate": "{provider} +{count}",
       "capNone": "Sin servicios"
     },
     "step2": {

--- a/custom_components/beatify/www/i18n/fr.json
+++ b/custom_components/beatify/www/i18n/fr.json
@@ -882,7 +882,9 @@
       "empty": "Aucune enceinte détectée",
       "emptyHint": "Installe Music Assistant et rafraîchis",
       "capAll": "Tous les services",
+      "capMost": "Tous les services principaux",
       "capOnlyTemplate": "{provider} uniquement",
+      "capMoreTemplate": "{provider} +{count}",
       "capNone": "Aucun service"
     },
     "step2": {

--- a/custom_components/beatify/www/i18n/nl.json
+++ b/custom_components/beatify/www/i18n/nl.json
@@ -882,7 +882,9 @@
       "empty": "Nog geen luidsprekers",
       "emptyHint": "Installeer Music Assistant en vernieuw",
       "capAll": "Alle diensten",
+      "capMost": "Alle grote diensten",
       "capOnlyTemplate": "alleen {provider}",
+      "capMoreTemplate": "{provider} +{count}",
       "capNone": "Geen diensten"
     },
     "step2": {

--- a/custom_components/beatify/www/js/__tests__/wizard.test.js
+++ b/custom_components/beatify/www/js/__tests__/wizard.test.js
@@ -178,9 +178,13 @@ describe('capabilityBadgeForPlayer', () => {
         expect(badge).toEqual({ cls: 'partial', label: 'nur Spotify' });
     });
 
-    it('returns a partial/orange comma-joined badge for a subset (Alexa case)', () => {
+    it('lists both services (muted summary) for a two-service subset, full list on title (#1319)', () => {
         const player = { supports_spotify: true, supports_apple_music: true, supports_youtube_music: false };
-        expect(capabilityBadgeForPlayer(player, providers)).toEqual({ cls: 'partial', label: 'Spotify, Apple Music' });
+        expect(capabilityBadgeForPlayer(player, providers)).toEqual({
+            cls: 'summary',
+            label: 'Spotify, Apple Music',
+            title: 'Spotify, Apple Music',
+        });
     });
 
     it('returns a none badge when no provider is supported (e.g. cast without MA)', () => {
@@ -192,6 +196,60 @@ describe('capabilityBadgeForPlayer', () => {
         const player = { supports_spotify: true, supports_apple_music: true, supports_youtube_music: true };
         const badge = capabilityBadgeForPlayer(player, providers, { all: 'Alle Dienste' });
         expect(badge.label).toBe('Alle Dienste');
+    });
+
+    // #1319: with the real 6-provider universe, multi-service rows must collapse
+    // to a single short, muted line instead of a wrapping uppercase comma list.
+    describe('summarization over the full 6-provider set (#1319)', () => {
+        const six = [
+            { id: 'spotify', label: 'Spotify' },
+            { id: 'apple_music', label: 'Apple Music' },
+            { id: 'youtube_music', label: 'YouTube Music' },
+            { id: 'tidal', label: 'Tidal' },
+            { id: 'deezer', label: 'Deezer' },
+            { id: 'amazon_music', label: 'Amazon Music' },
+        ];
+
+        it('collapses the typical MA player (5 of 6, all but Amazon) to "All major services"', () => {
+            const player = {
+                supports_spotify: true, supports_apple_music: true, supports_youtube_music: true,
+                supports_tidal: true, supports_deezer: true, supports_amazon_music: false,
+            };
+            expect(capabilityBadgeForPlayer(player, six)).toEqual({
+                cls: 'summary',
+                label: 'All major services',
+                title: 'Spotify, Apple Music, YouTube Music, Tidal, Deezer',
+            });
+        });
+
+        it('collapses 3 of 6 to "first +N" with the full list on title', () => {
+            const player = {
+                supports_spotify: true, supports_apple_music: true, supports_youtube_music: true,
+                supports_tidal: false, supports_deezer: false, supports_amazon_music: false,
+            };
+            expect(capabilityBadgeForPlayer(player, six)).toEqual({
+                cls: 'summary',
+                label: 'Spotify +2',
+                title: 'Spotify, Apple Music, YouTube Music',
+            });
+        });
+
+        it('keeps the single-service accent badge (cls partial) even in the 6-provider set', () => {
+            const player = {
+                supports_spotify: true, supports_apple_music: false, supports_youtube_music: false,
+                supports_tidal: false, supports_deezer: false, supports_amazon_music: false,
+            };
+            expect(capabilityBadgeForPlayer(player, six)).toEqual({ cls: 'partial', label: 'Spotify only' });
+        });
+
+        it('respects custom summary templates (locale)', () => {
+            const player = {
+                supports_spotify: true, supports_apple_music: true, supports_youtube_music: true,
+                supports_tidal: false, supports_deezer: false, supports_amazon_music: false,
+            };
+            const badge = capabilityBadgeForPlayer(player, six, { moreTemplate: '{provider} und {count} weitere' });
+            expect(badge.label).toBe('Spotify und 2 weitere');
+        });
     });
 });
 

--- a/custom_components/beatify/www/js/wizard.js
+++ b/custom_components/beatify/www/js/wizard.js
@@ -402,7 +402,9 @@ function _capabilityBadge(player) {
     return capabilityBadgeForPlayer(player, PROVIDERS, {
         none: _t('wizard.step1.capNone', 'No services'),
         all: _t('wizard.step1.capAll', 'All services'),
+        most: _t('wizard.step1.capMost', 'All major services'),
         onlyTemplate: _t('wizard.step1.capOnlyTemplate', '{provider} only'),
+        moreTemplate: _t('wizard.step1.capMoreTemplate', '{provider} +{count}'),
     });
 }
 
@@ -425,8 +427,11 @@ function _renderSpeakers() {
             const selected = chosenSpeaker === p.entity_id;
             const platform = _platformLabel(p.platform) || p.state || '';
             const badge = _capabilityBadge(p);
+            // Summarized badges keep the full service list on a title tooltip so
+            // no information is lost (#1319 AC: full list still discoverable).
+            const badgeTitle = badge && badge.title ? ` title="${badge.title}"` : '';
             const badgeHtml = badge
-                ? `<span class="cap-dot" aria-hidden="true"></span><span class="cap-badge ${badge.cls}">${badge.label}</span>`
+                ? `<span class="cap-dot" aria-hidden="true"></span><span class="cap-badge ${badge.cls}"${badgeTitle}>${badge.label}</span>`
                 : '';
             return `<button type="button" class="wiz-row ${selected ? 'selected' : ''}" data-entity-id="${p.entity_id}">
           <div class="wiz-row-avatar">${SPEAKER_ICON}</div>
@@ -495,24 +500,50 @@ function _providerSupported(providerId) {
 }
 
 // Pure: summarize a player's service capabilities into a badge descriptor.
-// Returns { cls, label } or null. Exported for tests.
+// Returns { cls, label, title? } or null. Exported for tests.
+//
+// Layout contract (#1319): the badge must fit ONE line at mobile width and
+// stay visually secondary to the speaker name. Only the genuinely constrained
+// single-service case ("Spotify only") keeps the orange accent (cls 'partial');
+// every multi-service case is muted (cls 'summary') and, for 3+ providers,
+// collapsed to "first +N" so a typical MA player (5 of 6 services) no longer
+// spells out a wrapping uppercase list. The full list is preserved in `title`
+// (rendered as a tooltip) so no information is lost.
 //
 // labels.onlyTemplate is a format string containing `{provider}`. The word
 // order of "only" vs. the provider name differs per language — English
 // suffixes ("Spotify only") but German, Spanish, Dutch prefix ("nur Spotify",
 // "solo Spotify", "alleen Spotify"). Using a template lets each locale pick.
+// labels.moreTemplate ("{provider} +{count}") and labels.most ("All major
+// services") are the summary strings.
 export function capabilityBadgeForPlayer(player, providers, labels = {}) {
     if (!player) return null;
     const supported = providers.filter((p) => player[`supports_${p.id}`]);
-    if (supported.length === 0) return { cls: 'none', label: labels.none || 'No services' };
-    if (supported.length === providers.length) {
+    const n = supported.length;
+    if (n === 0) return { cls: 'none', label: labels.none || 'No services' };
+    if (n === providers.length) {
         return { cls: 'full', label: labels.all || 'All services' };
     }
-    if (supported.length === 1) {
+    if (n === 1) {
+        // The one case that genuinely limits playback — keep the accent.
         const template = labels.onlyTemplate || '{provider} only';
         return { cls: 'partial', label: template.replace('{provider}', supported[0].label) };
     }
-    return { cls: 'partial', label: supported.map((p) => p.label).join(', ') };
+    // Everything below is multi-service: muted, single-line, full list in title.
+    const fullList = supported.map((p) => p.label).join(', ');
+    // "Most" = all but one (only meaningful from 4+ providers, else it overlaps
+    // the two-service case). A typical MA player (5 of 6) lands here.
+    if (n >= 3 && n === providers.length - 1) {
+        return { cls: 'summary', label: labels.most || 'All major services', title: fullList };
+    }
+    if (n === 2) {
+        // Two still fits one line — list both, just de-emphasized.
+        return { cls: 'summary', label: fullList, title: fullList };
+    }
+    // 3+ (but not "most"): first provider + overflow count, full list on tooltip.
+    const moreTemplate = labels.moreTemplate || '{provider} +{count}';
+    const label = moreTemplate.replace('{provider}', supported[0].label).replace('{count}', String(n - 1));
+    return { cls: 'summary', label, title: fullList };
 }
 
 function _renderProviders() {


### PR DESCRIPTION
## Summary

Fixes #1319 — the setup wizard **Step 1 · Speakers** spelled out every supported music service as an UPPERCASE, orange-outlined, comma-separated string (`SPOTIFY, APPLE MUSIC, YOUTUBE MUSIC, TIDAL, DEEZER`). On mobile this wrapped to two lines, inflated each row to ~110px, and made the orange capability text compete with the speaker name.

## Change

`capabilityBadgeForPlayer` (`www/js/wizard.js`) now summarizes the multi-service case and mutes its styling:

| supported | badge | style |
|---|---|---|
| 0 | `No services` | red (unchanged) |
| 1 | `Spotify only` | **orange accent kept** — the one genuinely constrained case |
| 2 | `Spotify, Apple Music` | muted summary |
| 3+ (not all-but-one) | `Spotify +2` | muted summary |
| all but one (typical MA, 5 of 6) | `All major services` | muted summary |
| all | `All services` | green (unchanged) |

Every multi-service badge uses a new muted, borderless, plain-case `.cap-badge.summary` style and carries the **full service list on a `title` tooltip**, so no information is lost and each row fits one line at mobile width.

## Acceptance criteria
- [x] Capability renders on a **single line** at mobile width (short summary + `white-space:nowrap`)
- [x] Speaker name stays the hero; multi-service capability is muted secondary text
- [x] Full service list still discoverable via `title` tooltip
- [x] `… only` (single-service) constraint keeps its accent (orange)
- [x] Applies to the wizard speaker step; verified for a 5-of-6 MA player (unit test)

## Notes
- `wizard.js` is served as a raw ES module (`admin.html`), **not** bundled — no `.min.js` rebuild needed; `build:check` stays clean.
- i18n keys `capMost` / `capMoreTemplate` added for en/de/es/fr/nl.
- The modularized admin `renderPlayerItem` (`admin/sections/media-players.js`) does **not** render a capability list (only a platform badge + state), so the noisy string lived solely in the wizard path — that's the only renderer touched.

## Tests
- `npm test` → **231 passed** (+4 new `capabilityBadgeForPlayer` cases over the full 6-provider set, incl. the 5-of-6 MA case)
- `npm run build:check` → all 10 bundles match source

🤖 Generated with [Claude Code](https://claude.com/claude-code)
