### PR TITLE
refactor: extract leaderboard cluster from GameState into LeaderboardMixin (#1271)

### DIFF
--- a/custom_components/beatify/game/state.py
+++ b/custom_components/beatify/game/state.py
@@ -69,6 +69,7 @@ from .scoring import (
 )
 from .protocols import MediaPlayerProtocol, PartyLightsProtocol
 from .serializers import GameStateSerializer
+from .state_leaderboard import LeaderboardMixin
 from .state_tts import TtsAnnouncerMixin
 
 from .types import RoundAnalytics, _get_decade_label
@@ -94,11 +95,14 @@ class GamePhase(Enum):
     PAUSED = "PAUSED"
 
 
-class GameState(TtsAnnouncerMixin):
+class GameState(LeaderboardMixin, TtsAnnouncerMixin):
     """Manages game state and phase transitions.
 
     The TTS / spoken-announcement subsystem (Issue #1271 first-increment
     extraction) lives in :class:`~custom_components.beatify.game.state_tts.TtsAnnouncerMixin`.
+
+    The leaderboard / ranking subsystem (Issue #1271 next-increment
+    extraction) lives in :class:`~custom_components.beatify.game.state_leaderboard.LeaderboardMixin`.
     """
 
     def __init__(self, time_fn: Callable[[], float] | None = None) -> None:
@@ -2345,105 +2349,6 @@ class GameState(TtsAnnouncerMixin):
     def is_deadline_passed(self) -> bool:
         """Check if the round deadline has passed. Delegates to RoundManager."""
         return self._round_manager.is_deadline_passed()
-
-    def get_leaderboard(self) -> list[dict[str, Any]]:
-        """
-        Get leaderboard sorted by score (Story 5.5).
-
-        Returns:
-            List of player data with rank and movement info.
-            Note: is_current is set client-side based on playerName.
-
-        """
-        # Sort by score descending, then by name for tie-breaking display order
-        sorted_players = sorted(
-            self.players.values(),
-            key=lambda p: (-p.score, p.name),
-        )
-
-        leaderboard = []
-        current_rank = 0
-        previous_score = None
-
-        for i, player in enumerate(sorted_players):
-            # Handle ties (same score = same rank)
-            # Example: scores [100, 80, 80, 50] -> ranks [1, 2, 2, 4]
-            if player.score != previous_score:
-                current_rank = i + 1  # Rank jumps to position (skips tied ranks)
-            previous_score = player.score
-
-            # Calculate rank change (positive = moved up)
-            rank_change = 0
-            if player.previous_rank is not None:
-                rank_change = player.previous_rank - current_rank
-
-            entry = {
-                "rank": current_rank,
-                "name": player.name,
-                "score": player.score,
-                "streak": player.streak,
-                "is_admin": player.is_admin,
-                "rank_change": rank_change,
-                "connected": player.connected,
-            }
-            leaderboard.append(entry)
-
-        return leaderboard
-
-    def _store_previous_ranks(self) -> None:
-        """Store current ranks before scoring for rank change detection."""
-        sorted_players = sorted(
-            self.players.values(),
-            key=lambda p: (-p.score, p.name),
-        )
-
-        current_rank = 0
-        previous_score = None
-
-        for i, player in enumerate(sorted_players):
-            if player.score != previous_score:
-                current_rank = i + 1
-            previous_score = player.score
-            player.previous_rank = current_rank
-
-    def get_final_leaderboard(self) -> list[dict[str, Any]]:
-        """
-        Get final leaderboard with full player stats (Story 5.6).
-
-        Returns:
-            List of player data with rank and final stats.
-            Note: is_current is set client-side based on playerName.
-
-        """
-        # Sort by score descending, then by name for tie-breaking display order
-        sorted_players = sorted(
-            self.players.values(),
-            key=lambda p: (-p.score, p.name),
-        )
-
-        leaderboard = []
-        current_rank = 0
-        previous_score = None
-
-        for i, player in enumerate(sorted_players):
-            if player.score != previous_score:
-                current_rank = i + 1
-            previous_score = player.score
-
-            entry = {
-                "rank": current_rank,
-                "name": player.name,
-                "score": player.score,
-                "is_admin": player.is_admin,
-                "connected": player.connected,
-                # Final stats (Story 5.6)
-                "best_streak": player.best_streak,
-                "rounds_played": player.rounds_played,
-                "bets_won": player.bets_won,
-            }
-            leaderboard.append(entry)
-
-        return leaderboard
 
     async def advance_to_end(self) -> None:
         """Transition to END phase with proper cleanup (#321).

--- a/custom_components/beatify/game/state_leaderboard.py
+++ b/custom_components/beatify/game/state_leaderboard.py
@@ -1,0 +1,131 @@
+"""Leaderboard subsystem for :class:`GameState`.
+
+Issue #1271 next-increment extraction: the leaderboard / ranking cluster
+(``get_leaderboard``, ``_store_previous_ranks``, ``get_final_leaderboard`` —
+originally Stories 5.5 / 5.6) is pulled out of the ``game/state.py``
+God-Object into this ``LeaderboardMixin``.
+
+The mixin is **behavior-preserving**: it carries the exact same methods that
+previously lived on ``GameState``. ``GameState`` inherits them, so its public
+API and every caller / test are unchanged.
+
+The mixin relies on a single attribute the host class owns and that lives on
+``self`` at runtime:
+
+* ``self.players`` — mapping of player name → ``PlayerSession``. Each session
+  exposes ``score``, ``name``, ``streak``, ``is_admin``, ``connected``,
+  ``previous_rank``, ``best_streak``, ``rounds_played`` and ``bets_won``.
+
+It carries no state of its own and imports nothing from ``state.py``, so the
+extraction introduces no cyclic imports.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class LeaderboardMixin:
+    """Leaderboard / ranking behavior for :class:`GameState`.
+
+    See module docstring for the host-class attributes this mixin reads.
+    """
+
+    def get_leaderboard(self) -> list[dict[str, Any]]:
+        """
+        Get leaderboard sorted by score (Story 5.5).
+
+        Returns:
+            List of player data with rank and movement info.
+            Note: is_current is set client-side based on playerName.
+
+        """
+        # Sort by score descending, then by name for tie-breaking display order
+        sorted_players = sorted(
+            self.players.values(),
+            key=lambda p: (-p.score, p.name),
+        )
+
+        leaderboard = []
+        current_rank = 0
+        previous_score = None
+
+        for i, player in enumerate(sorted_players):
+            # Handle ties (same score = same rank)
+            # Example: scores [100, 80, 80, 50] -> ranks [1, 2, 2, 4]
+            if player.score != previous_score:
+                current_rank = i + 1  # Rank jumps to position (skips tied ranks)
+            previous_score = player.score
+
+            # Calculate rank change (positive = moved up)
+            rank_change = 0
+            if player.previous_rank is not None:
+                rank_change = player.previous_rank - current_rank
+
+            entry = {
+                "rank": current_rank,
+                "name": player.name,
+                "score": player.score,
+                "streak": player.streak,
+                "is_admin": player.is_admin,
+                "rank_change": rank_change,
+                "connected": player.connected,
+            }
+            leaderboard.append(entry)
+
+        return leaderboard
+
+    def _store_previous_ranks(self) -> None:
+        """Store current ranks before scoring for rank change detection."""
+        sorted_players = sorted(
+            self.players.values(),
+            key=lambda p: (-p.score, p.name),
+        )
+
+        current_rank = 0
+        previous_score = None
+
+        for i, player in enumerate(sorted_players):
+            if player.score != previous_score:
+                current_rank = i + 1
+            previous_score = player.score
+            player.previous_rank = current_rank
+
+    def get_final_leaderboard(self) -> list[dict[str, Any]]:
+        """
+        Get final leaderboard with full player stats (Story 5.6).
+
+        Returns:
+            List of player data with rank and final stats.
+            Note: is_current is set client-side based on playerName.
+
+        """
+        # Sort by score descending, then by name for tie-breaking display order
+        sorted_players = sorted(
+            self.players.values(),
+            key=lambda p: (-p.score, p.name),
+        )
+
+        leaderboard = []
+        current_rank = 0
+        previous_score = None
+
+        for i, player in enumerate(sorted_players):
+            if player.score != previous_score:
+                current_rank = i + 1
+            previous_score = player.score
+
+            entry = {
+                "rank": current_rank,
+                "name": player.name,
+                "score": player.score,
+                "is_admin": player.is_admin,
+                "connected": player.connected,
+                # Final stats (Story 5.6)
+                "best_streak": player.best_streak,
+                "rounds_played": player.rounds_played,
+                "bets_won": player.bets_won,
+            }
+            leaderboard.append(entry)
+
+        return leaderboard


### PR DESCRIPTION
Part of #1271 — incremental, behavior-preserving decomposition of the `game/state.py` God-Object.

## What this does
Extracts the leaderboard / ranking cluster (`get_leaderboard`, `_store_previous_ranks`, `get_final_leaderboard`, originally Stories 5.5 / 5.6) out of `GameState` into a new sibling `game/state_leaderboard.py::LeaderboardMixin`. `GameState` inherits the mixin, so the public API and every caller/test are unchanged. This follows the exact pattern of the earlier `TtsAnnouncerMixin` extraction.

`state.py`: 2622 → 2527 lines (−95). New `state_leaderboard.py`: 134 lines.

## Readiness assessment
- [x] Ready to merge
- [ ] Borderline — see notes
- [ ] Not ready — needs human review

**Honest summary:** Pure mechanical move — the three methods are copied verbatim into a mixin and removed from `GameState`. They only read `self.players` and write `player.previous_rank`, so there is zero new coupling and no cyclic-import risk (the new module imports nothing from `state.py`). Full pytest suite stays green (838 passed, 2 pre-existing skips). This is one cohesive increment of the larger refactor, not the whole split.

## Test plan
- `python3 -m pytest` → 838 passed, 2 skipped (unchanged from baseline)
- `python3 -m pytest tests/unit/test_state.py` → 132 passed
- `ruff check` on both changed files → clean
- Methods verified present on `GameState` via MRO (`LeaderboardMixin` in `GameState.__mro__`)

## Risk assessment
- **Blast radius:** `custom_components/beatify/game/state.py` (imports + class bases + removed methods), new `custom_components/beatify/game/state_leaderboard.py`. Callers (`serializers.py`, internal `_store_previous_ranks`) untouched — they still call the same names on `GameState`.
- **What could go wrong:** nothing logic-level; the only behavioral surface is MRO method resolution, covered by the full suite passing.
- **What I did NOT test:** live HA runtime (covered by unit tests only); no `www/` frontend involved.

🤖 Auto-generated by issue-triage routine