### PR TITLE
refactor(state): route resume_game restores through _set_phase — SSOT next increment (#1273)

### DIFF
--- a/custom_components/beatify/game/state.py
+++ b/custom_components/beatify/game/state.py
@@ -219,22 +219,27 @@ class GameState(TtsAnnouncerMixin):
     # Phase transitions — Single Source of Truth (Issue #1273)
     # ------------------------------------------------------------------
     #
-    # ALL writes to ``self.phase`` go through ``_set_phase``. This makes the
-    # backend the one authoritative owner of the game phase and gives every
-    # transition a single, auditable chokepoint. Two invariants that were
-    # previously hand-maintained at each scattered ``self.phase = …`` site are
-    # now enforced here so they can never drift:
+    # ALL writes to ``self.phase`` now go through ``_set_phase`` — including the
+    # two ``resume_game`` restores, which pass ``restore=True`` (#1273). There
+    # are no remaining direct ``self.phase = …`` assignments anywhere in the
+    # codebase. This makes the backend the one authoritative owner of the game
+    # phase and gives every transition a single, auditable chokepoint. Two
+    # invariants that were previously hand-maintained at each scattered
+    # ``self.phase = …`` site are now enforced here so they can never drift:
     #
-    #   * ``reveal_started_at`` (#1048) is non-None *iff* phase is REVEAL —
-    #     stamped on entry to REVEAL, cleared on every other transition.
+    #   * ``reveal_started_at`` (#1048) is owned by forward transitions: non-None
+    #     *iff* phase is REVEAL — stamped on entry to REVEAL, cleared on every
+    #     other forward transition. A ``restore=True`` resume deliberately leaves
+    #     it untouched (resume must not restart the auto-advance countdown).
     #   * registered state observers (#441) are notified on every phase change.
     #
-    # This is the first increment of the SSOT state-machine described in the
-    # issue: it centralises the *write* path without yet modelling explicit
+    # This centralises the *write* path without yet modelling explicit
     # transition guards. Follow-up increments can layer a transition table on
-    # top of this single chokepoint (see PR description / migration path).
+    # top of this single chokepoint (see issue / migration path).
 
-    def _set_phase(self, new_phase: GamePhase, *, notify: bool = True) -> None:
+    def _set_phase(
+        self, new_phase: GamePhase, *, notify: bool = True, restore: bool = False
+    ) -> None:
         """Authoritatively transition the game to ``new_phase``.
 
         The single write-point for ``self.phase`` (Issue #1273). Maintains the
@@ -247,15 +252,27 @@ class GameState(TtsAnnouncerMixin):
                 True; pass False only when the caller batches its own notify
                 immediately afterwards (kept for callers that interleave other
                 bookkeeping between the phase write and the broadcast).
+            restore: Pass True only from ``resume_game`` (#1273). A resume
+                *restores* a previously-saved phase rather than making a forward
+                transition, so it must NOT re-stamp ``reveal_started_at`` — a
+                resume-to-REVEAL would otherwise restart the auto-advance
+                countdown. With ``restore=True`` the ``reveal_started_at`` value
+                is left exactly as-is (neither stamped nor cleared); only the
+                phase write + notify happen. This lets the two resume writes
+                join the SSOT chokepoint without changing behaviour. Defaults to
+                False (forward transitions own the timestamp invariant).
 
         """
         self.phase = new_phase
-        # #1048: the REVEAL-entry timestamp is owned entirely by the phase
-        # transition. Entering REVEAL stamps it; any other phase clears it.
-        if new_phase is GamePhase.REVEAL:
-            self.reveal_started_at = int(self._now() * 1000)
-        else:
-            self.reveal_started_at = None
+        # #1048: the REVEAL-entry timestamp is owned entirely by forward phase
+        # transitions. Entering REVEAL stamps it; any other phase clears it.
+        # A restore (resume) deliberately leaves the timestamp untouched — see
+        # the ``restore`` arg docstring.
+        if not restore:
+            if new_phase is GamePhase.REVEAL:
+                self.reveal_started_at = int(self._now() * 1000)
+            else:
+                self.reveal_started_at = None
         if notify:
             self._notify_state_callbacks()
 
@@ -1057,23 +1074,22 @@ class GameState(TtsAnnouncerMixin):
             else:
                 # Timer expired during pause — end the round immediately.
                 # #1273: resume *restores* a saved phase rather than making a
-                # forward transition, so it intentionally does NOT route through
-                # _set_phase — re-stamping reveal_started_at on a resume-to-REVEAL
-                # would change behaviour (the auto-advance countdown must not
-                # restart). Kept as a direct write; see PR migration notes.
+                # forward transition, so it routes through _set_phase with
+                # restore=True — that writes the phase + notifies but leaves
+                # reveal_started_at untouched, so a resume-to-REVEAL does NOT
+                # re-stamp it (the auto-advance countdown must not restart).
                 _LOGGER.info("Timer expired during pause, ending round")
-                self.phase = previous
-                self._notify_state_callbacks()
+                self._set_phase(previous, restore=True)
                 self.pause_reason = None
                 self.disconnected_admin_name = None
                 self._previous_phase = None
                 await self.end_round()
                 return True
 
-        # Restore previous phase (direct write, not _set_phase — see #1273 note
-        # in the timer-expired branch above: resume must not re-stamp REVEAL).
-        self.phase = previous
-        self._notify_state_callbacks()
+        # Restore previous phase via _set_phase(restore=True) — see the
+        # timer-expired branch above and the _set_phase ``restore`` docstring:
+        # a resume must not re-stamp reveal_started_at on a resume-to-REVEAL.
+        self._set_phase(previous, restore=True)
         self.pause_reason = None
         self.disconnected_admin_name = None
         self._previous_phase = None

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -1051,6 +1051,20 @@ class TestResumeGame:
         assert self.state.phase == GamePhase.REVEAL
 
     @pytest.mark.asyncio
+    async def test_resume_to_reveal_does_not_restamp_reveal_started_at(self):
+        # #1273: resume routes through _set_phase(restore=True), which must NOT
+        # re-stamp reveal_started_at. pause_game cleared it (left REVEAL), so it
+        # stays None across the resume — the auto-advance countdown is not
+        # restarted. Behaviour-preserving vs. the prior direct phase write.
+        self.state.phase = GamePhase.REVEAL
+        await self.state.pause_game("admin_disconnected")
+        assert self.state.reveal_started_at is None
+        result = await self.state.resume_game()
+        assert result is True
+        assert self.state.phase == GamePhase.REVEAL
+        assert self.state.reveal_started_at is None
+
+    @pytest.mark.asyncio
     async def test_resume_not_paused(self):
         result = await self.state.resume_game()
         assert result is False
@@ -1373,3 +1387,29 @@ class TestSetPhaseSSOT:
         state._set_phase(GamePhase.PLAYING, notify=False)
         assert calls == []
         assert state.phase == GamePhase.PLAYING
+
+    def test_restore_to_reveal_does_not_stamp_reveal_started_at(self):
+        # #1273: a resume *restores* a saved phase and must NOT re-stamp the
+        # REVEAL timestamp (that would restart the auto-advance countdown).
+        state = make_game_state(time_fn=lambda: 1000.0)
+        assert state.reveal_started_at is None
+        state._set_phase(GamePhase.REVEAL, restore=True)
+        assert state.phase == GamePhase.REVEAL
+        # restore=True leaves reveal_started_at exactly as it was (None here).
+        assert state.reveal_started_at is None
+
+    def test_restore_leaves_existing_reveal_started_at_untouched(self):
+        # A pre-existing stamp survives a restore unchanged (neither cleared
+        # nor re-stamped) — restore touches only the phase + notify.
+        state = make_game_state(time_fn=lambda: 1000.0)
+        state.reveal_started_at = 555
+        state._set_phase(GamePhase.LOBBY, restore=True)
+        assert state.phase == GamePhase.LOBBY
+        assert state.reveal_started_at == 555
+
+    def test_restore_still_notifies_by_default(self):
+        state = make_game_state()
+        calls: list[int] = []
+        state.register_state_callback(lambda: calls.append(1))
+        state._set_phase(GamePhase.PLAYING, restore=True)
+        assert calls == [1]


### PR DESCRIPTION
Refs #1273 (next increment — does NOT fully close the issue)

## What this is
The **next behavior-preserving increment** of the Single-Source-of-Truth game-state-machine from #1273, building directly on PR #1322 (the `_set_phase` first increment).

PR #1322 funnelled all *forward* transitions through `GameState._set_phase`, but left **two deliberate direct `self.phase = previous` writes** in `resume_game` outside the chokepoint — resume *restores* a saved phase and must NOT re-stamp `reveal_started_at` (that would restart the REVEAL auto-advance countdown). This PR folds those last two writes in via a new `restore=True` flag.

After this change there are **no remaining direct `self.phase = …` assignments anywhere in the codebase** (verified by grep). Acceptance criterion 1 ("Definierte Phasen + Transitions an einer Stelle") — the single write-point half — is now fully met.

`_set_phase(new_phase, *, notify=True, restore=False)`:
- `restore=False` (default, all forward transitions): unchanged — owns the `reveal_started_at` iff-invariant (stamp on REVEAL, clear otherwise).
- `restore=True` (only the two resume writes): writes the phase + notifies, but leaves `reveal_started_at` **exactly as-is** (neither stamped nor cleared).

## Readiness assessment
- [ ] Ready to merge
- [x] Borderline — see notes
- [ ] Not ready — needs human review

**Honest summary:** Small, mechanical, provably behavior-preserving. Each replaced site was `self.phase = previous; self._notify_state_callbacks()` with `reveal_started_at` left untouched — `_set_phase(previous, restore=True)` does exactly that and nothing else. Full suite stays green (842 passed). "Borderline" only because it is, like #1322, an explicit increment toward the SSOT — it does NOT add a transition table, explicit guards, or failure-path advance/recovery triggers (AC#2/#3 remain out of scope).

## Scope note (why not more)
The full AC (transition table + every failure-path has a recovery trigger + FE holds no authoritative timer state) is a multi-PR effort. I reviewed the `start_round` failure paths (media-player-error / no-songs / unavailable-song) and the REVEAL auto-advance / idle-halt paths: they already route to `pause_game` (recovery banner + Resume) or have hard caps + phase re-checks. I found **no provably-missing recovery trigger** I could add behavior-preservingly, so I did not invent one. This write-path increment is the one safe, confirmed-root-cause step available.

## Test plan
- `python3 -m pytest` → **842 passed, 2 skipped** (pre-existing skips)
- New in `TestSetPhaseSSOT` (3 cases): `restore=True` to REVEAL does not stamp; restore leaves an existing `reveal_started_at` untouched; restore still notifies.
- New in `TestResumeGame`: `test_resume_to_reveal_does_not_restamp_reveal_started_at` — locks the preserved behavior (resume-to-REVEAL keeps `reveal_started_at` None).
- `python3 -m ruff check` on touched files → clean.

## Risk assessment
- **Blast radius:** one file (`game/state.py`, `_set_phase` + 2 resume sites) + its test file. No frontend (`www/**`) touched → bundle guardrail N/A.
- **What could go wrong:** the `restore=True` branch is the one place `_set_phase` does NOT enforce the `reveal_started_at` iff-invariant — by design, but it means a future caller passing `restore=True` on a forward transition could leave the timestamp inconsistent. Mitigated by the docstring ("Pass True only from resume_game") and the fact that the only two callers are the resume sites.
- **What I did NOT test:** live game runtime (HA integration / real media player / WS clients) — automated suites only. Resume-to-REVEAL `reveal_started_at` behavior is asserted unchanged by the new regression test, not by a live test.

🤖 Auto-generated by issue-triage routine