### PR TITLE
feat(data): provider-URI backfill skill + coverage report (#1289)

### DIFF
--- a/.claude/skills/provider-uri-backfill/SKILL.md
+++ b/.claude/skills/provider-uri-backfill/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: provider-uri-backfill
+description: >
+  Recurring backfill job (#1289) that systematically fills missing per-provider
+  track URIs across Beatify playlists. For every song that has a Spotify `uri`
+  but is missing `uri_apple_music` / `uri_tidal` / `uri_deezer`, it resolves the
+  gaps via the keyless Odesli / song.link API (Tidal + Deezer reliably, Apple
+  Music best-effort) with a verifying Deezer-ISRC fallback; missing
+  `uri_youtube_music` is filled via the YouTube Data API behind a resume-cursor +
+  daily quota budget. Rate-limit safe (Odesli throttle + 429 backoff, YouTube
+  daily budget). Emits a per-playlist Markdown coverage report. Use this skill
+  whenever the user asks to backfill provider URIs, fill missing Apple/Tidal/
+  Deezer/YouTube links, improve provider coverage, run the URI backfill, or check
+  per-playlist provider coverage.
+---
+
+# Provider-URI Backfill
+
+Fills missing per-provider streaming URIs across Beatify playlists so games on
+non-Spotify providers (Music Assistant Apple/Tidal/Deezer/YouTube backends) have
+something playable for every song. Resolves issue #1289.
+
+## When to use
+
+- Provider coverage drifts after new playlists are added (they ship Spotify-only
+  or partial).
+- Periodically, to chip away at the Tidal gap (the biggest — ~52% covered) and
+  top up Apple/Deezer/YouTube.
+- To regenerate the coverage report (`docs/provider-coverage.md`).
+
+## How to run
+
+The script defaults to **dry-run** (writes only the coverage report; never
+touches playlist JSON). Gate real writes behind `--apply`.
+
+```bash
+# Dry-run: coverage report only (safe, no JSON mutation). No keys needed for
+# the report itself; Odesli is hit only for fillable songs.
+python3 .claude/skills/provider-uri-backfill/scripts/backfill_provider_uris.py \
+  --repo-root . --playlist eurovision-winners
+
+# Apply: write resolved URIs back to JSON.
+python3 .claude/skills/provider-uri-backfill/scripts/backfill_provider_uris.py \
+  --repo-root . --playlist eurovision-winners --apply
+```
+
+Run one playlist at a time (`--playlist <basename>` or `--playlist community/<name>`)
+to keep within Odesli's free rate limit. Without `--playlist` it walks the whole
+catalog (main + community) — expect this to take a long time because of the
+6 s/track Odesli throttle.
+
+### Options
+
+| Flag | Default | Purpose |
+|---|---|---|
+| `--repo-root` | `.` | Beatify repo root |
+| `--playlist` | all | Process one playlist (basename or `community/<name>`) |
+| `--apply` | off | Write filled URIs back to JSON (else dry-run report only) |
+| `--output` | `docs/provider-coverage.md` | Coverage report path |
+| `--state` | `skill/.backfill-state.json` | YouTube resume-cursor + daily-budget state |
+| `--odesli-sleep` | `6.0` | Seconds between Odesli calls (free tier ~10/min) |
+| `--youtube-budget` | `90` | Max YouTube `search.list` calls per day |
+
+## Resolvers + stored URI formats
+
+The script writes **byte-identical** stored formats (verified against existing
+non-null values + a live Odesli probe, 2026-06):
+
+| Field | Stored format | Source |
+|---|---|---|
+| `uri_tidal` | `tidal://track/<numeric>` | Odesli `entityUniqueId` `TIDAL_SONG::<id>` (or URL `/track/<id>`) |
+| `uri_deezer` | `deezer://track/<numeric>` | Odesli `DEEZER_SONG::<id>`; fallback `api.deezer.com/track/isrc:<ISRC>` |
+| `uri_apple_music` | `applemusic://track/<numeric>` | Odesli `appleMusic`/`itunes` entity id, **when present** (often absent — see below) |
+| `uri_youtube_music` | `https://music.youtube.com/watch?v=<11-char-id>` | YouTube Data API `search.list` top hit |
+
+If the script cannot confidently extract a numeric id in the expected format for
+a provider, it **skips** that provider for that song (it never guesses a format).
+
+### Odesli / song.link (primary)
+
+One `GET https://api.song.link/v1-alpha.1/links?url=<spotify-url>` per track maps
+the Spotify URI to all providers at once. Keyless, free, ~10 req/min — the script
+sleeps `--odesli-sleep` (6 s) between calls and retries HTTP 429 with exponential
+backoff.
+
+**Known limitation:** Odesli's keyless responses frequently omit Apple Music
+entirely (observed live for multiple mainstream tracks, 2026-06). Tidal + Deezer
+come back reliably. Apple gaps are therefore better served by the existing
+[`playlist-health-check` Mode 2](../playlist-health-check/SKILL.md) (Apple Music
+API + per-region ISRC), with this skill catching whatever Odesli happens to
+surface. Deezer has a secondary ISRC verify (`api.deezer.com/track/isrc:<ISRC>`)
+when Odesli misses it.
+
+### YouTube Data API (YouTube only)
+
+Odesli's `youtube` field is unreliable for this catalog, so `uri_youtube_music`
+uses `search.list` (100 quota units each; 10,000/day default ⇒ ~100 searches/day).
+A **resume cursor** + **daily budget** in `.backfill-state.json` cap each run at
+`--youtube-budget` searches and resume the catalog scan across days/runs:
+
+```json
+{"youtube": {"date": "2026-06-10", "spent_today": 90, "cursor": 512, "budget": 90}}
+```
+
+`spent_today` resets when the date rolls over; `cursor` carries forward so the
+next day continues where the last left off. The key is read from `YOUTUBE_API_KEY`;
+if unset the whole YouTube phase is **skipped gracefully** with a note in the
+report (no crash). Never hardcode a key.
+
+## Coverage report
+
+`docs/provider-coverage.md` (style like `docs/beatify-stats.md`): a summary table
+of per-provider coverage across the whole catalog plus a per-playlist table
+showing how many songs have Apple/Tidal/Deezer/YouTube vs total, and how many URIs
+this run filled (0 in dry-run).
+
+## Scope / safety
+
+- **Dry-run by default.** `--apply` is required to mutate JSON. A mass backfill of
+  2000+ files is a deliberate follow-up, not a side effect of running the report.
+- Touches only `custom_components/beatify/playlists/**` JSON and the report — no
+  `www/**`, no schema changes. There is no `uri_amazon_music` field, so Amazon is
+  out of scope despite Odesli returning it.
+- iTunes Search is intentionally NOT used (ban risk); Apple gaps go through the
+  health-check Mode 2 flow.
+
+## Tests
+
+Pure logic (Odesli→URI mapping per provider, gap detection, resume-cursor
+accounting, coverage aggregation) is unit-tested with mocked HTTP in
+`tests/unit/test_provider_uri_backfill.py` — no network in tests.

--- a/.claude/skills/provider-uri-backfill/scripts/backfill_provider_uris.py
+++ b/.claude/skills/provider-uri-backfill/scripts/backfill_provider_uris.py
@@ -1,0 +1,503 @@
+#!/usr/bin/env python3
+"""Backfill missing per-provider track URIs across Beatify playlists (#1289).
+
+Fills gaps in ``uri_apple_music`` / ``uri_tidal`` / ``uri_deezer`` /
+``uri_youtube_music`` for songs that already carry a Spotify ``uri``.
+
+Resolvers
+---------
+* **Odesli / song.link** (primary, keyless) — one call per track maps the
+  Spotify URI to Apple Music + Tidal + Deezer in a single response. Free tier
+  is ~10 req/min, so calls are throttled (``--odesli-sleep``, default 6s) and
+  HTTP 429 is retried with exponential backoff.
+* **Deezer ISRC** (secondary verify for Deezer) — the undocumented public
+  ``https://api.deezer.com/track/isrc:<ISRC>`` endpoint maps a song's ISRC to a
+  Deezer track id, used when Odesli has no Deezer link but the song has an ISRC.
+* **YouTube Data API** (YouTube only) — Odesli's ``youtube`` field is
+  unreliable for this catalog, so ``uri_youtube_music`` is filled via
+  ``search.list`` (100 quota units each). A resume-cursor in the state file caps
+  each run at a daily budget (``--youtube-budget``, default 90) and resumes
+  across runs/days. Needs ``YOUTUBE_API_KEY``; absent → the phase is skipped
+  with a logged note (never crashes).
+
+Stored URI formats (matched byte-for-byte from existing data — verified live
+against Odesli for tidal/deezer; see scripts/PROVIDER_FORMATS below):
+
+    uri_apple_music    applemusic://track/<numeric>
+    uri_tidal          tidal://track/<numeric>
+    uri_deezer         deezer://track/<numeric>
+    uri_youtube_music  https://music.youtube.com/watch?v=<11-char-id>
+
+Safety: defaults to **dry-run** (report only). JSON files are only mutated when
+``--apply`` is passed. Running the full backfill at scale is a deliberate
+follow-up, not the default.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable
+
+# Providers we fill and their stored URI formats. The ``format`` callable turns
+# a bare provider track id (string) into the exact stored URI. Keep these in
+# sync with scripts/playlist_health-check + validate_playlists.py patterns.
+PROVIDER_FIELDS = {
+    "apple_music": "uri_apple_music",
+    "tidal": "uri_tidal",
+    "deezer": "uri_deezer",
+    "youtube_music": "uri_youtube_music",
+}
+
+USER_AGENT = "beatify-provider-uri-backfill/1.0 (+https://github.com/mholzi/beatify)"
+
+
+# ---------------------------------------------------------------------------
+# Pure URI-format mapping (unit-tested, no network)
+# ---------------------------------------------------------------------------
+def apple_uri(track_id: str) -> str:
+    return f"applemusic://track/{track_id}"
+
+
+def tidal_uri(track_id: str) -> str:
+    return f"tidal://track/{track_id}"
+
+
+def deezer_uri(track_id: str) -> str:
+    return f"deezer://track/{track_id}"
+
+
+def youtube_uri(video_id: str) -> str:
+    return f"https://music.youtube.com/watch?v={video_id}"
+
+
+_NUMERIC = re.compile(r"^\d+$")
+_YT_ID = re.compile(r"^[A-Za-z0-9_-]{11}$")
+
+
+def spotify_track_id(uri: str | None) -> str | None:
+    """Extract the 22-char track id from ``spotify:track:<id>``."""
+    if not uri:
+        return None
+    m = re.match(r"^spotify:track:([A-Za-z0-9]{22})$", uri)
+    return m.group(1) if m else None
+
+
+def _numeric_id(value: Any) -> str | None:
+    """Coerce a provider id (str or int) to a bare numeric string, else None."""
+    if value is None:
+        return None
+    s = str(value).strip()
+    return s if _NUMERIC.match(s) else None
+
+
+def odesli_to_uris(payload: dict) -> dict[str, str]:
+    """Map an Odesli ``/links`` response to stored Beatify URIs per provider.
+
+    Returns a dict like ``{"tidal": "tidal://track/123", ...}`` containing only
+    the providers we could resolve into a byte-identical stored format. A
+    provider whose id can't be confidently extracted is skipped (never guessed).
+    """
+    out: dict[str, str] = {}
+    links = (payload or {}).get("linksByPlatform", {}) or {}
+    entities = (payload or {}).get("entitiesByUniqueId", {}) or {}
+
+    def entity_id_for(platform_key: str) -> str | None:
+        eid = (links.get(platform_key) or {}).get("entityUniqueId")
+        if not eid:
+            return None
+        return _numeric_id((entities.get(eid) or {}).get("id"))
+
+    # --- Tidal: entity id is numeric (TIDAL_SONG::<id>) ---
+    tid = entity_id_for("tidal")
+    if tid is None:
+        tid = _id_from_url((links.get("tidal") or {}).get("url"), r"/track/(\d+)")
+    if tid:
+        out["tidal"] = tidal_uri(tid)
+
+    # --- Deezer: entity id is numeric (DEEZER_SONG::<id>) ---
+    did = entity_id_for("deezer")
+    if did is None:
+        did = _id_from_url((links.get("deezer") or {}).get("url"), r"/track/(\d+)")
+    if did:
+        out["deezer"] = deezer_uri(did)
+
+    # --- Apple Music: best-effort. Odesli keyless responses frequently omit
+    # Apple entirely (observed live, 2026-06). When present, the entity/id is
+    # the numeric storefront track id used by applemusic://track/<id>. ---
+    aid = entity_id_for("appleMusic") or entity_id_for("itunes")
+    if aid is None:
+        aid = _id_from_url(
+            (links.get("appleMusic") or links.get("itunes") or {}).get("url"),
+            r"/(?:album/[^/]+/)?(?:i=)?(\d+)(?:[?&]i=(\d+))?",
+        )
+    if aid:
+        out["apple_music"] = apple_uri(aid)
+
+    return out
+
+
+def _id_from_url(url: str | None, pattern: str) -> str | None:
+    if not url:
+        return None
+    m = re.search(pattern, url)
+    if not m:
+        return None
+    # Prefer the last captured numeric group (e.g. Apple ``?i=<song-id>``).
+    for g in reversed(m.groups()):
+        if g and _NUMERIC.match(g):
+            return g
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Gap detection + coverage aggregation (pure, unit-tested)
+# ---------------------------------------------------------------------------
+@dataclass
+class PlaylistCoverage:
+    name: str
+    path: str
+    total: int = 0
+    have: dict[str, int] = field(default_factory=dict)
+    fillable: int = 0  # songs with spotify uri AND >=1 provider gap
+    filled_this_run: dict[str, int] = field(default_factory=dict)
+
+
+def song_gaps(song: dict) -> list[str]:
+    """Provider keys that are missing (null/empty) for this song."""
+    return [p for p, fld in PROVIDER_FIELDS.items() if not song.get(fld)]
+
+
+def coverage_for_playlist(name: str, path: str, songs: list[dict]) -> PlaylistCoverage:
+    cov = PlaylistCoverage(name=name, path=path, total=len(songs))
+    cov.have = {p: 0 for p in PROVIDER_FIELDS}
+    for s in songs:
+        for p, fld in PROVIDER_FIELDS.items():
+            if s.get(fld):
+                cov.have[p] += 1
+        if spotify_track_id(s.get("uri")) and song_gaps(s):
+            cov.fillable += 1
+    return cov
+
+
+# ---------------------------------------------------------------------------
+# Resume-cursor / state accounting (pure, unit-tested)
+# ---------------------------------------------------------------------------
+@dataclass
+class YouTubeBudget:
+    """Tracks the YouTube Data API daily budget + resume cursor.
+
+    The cursor is the global index (across the flattened song list) of the next
+    song to attempt YouTube resolution for, so runs resume where they stopped.
+    """
+
+    budget: int
+    spent_today: int = 0
+    cursor: int = 0
+    date: str = ""
+
+    def remaining(self) -> int:
+        return max(0, self.budget - self.spent_today)
+
+    def can_spend(self) -> bool:
+        return self.remaining() > 0
+
+    def spend(self) -> None:
+        self.spent_today += 1
+
+
+def load_state(path: Path, today: str, budget: int) -> YouTubeBudget:
+    data = {}
+    if path.exists():
+        try:
+            data = json.loads(path.read_text())
+        except (OSError, json.JSONDecodeError):
+            data = {}
+    yt = data.get("youtube", {})
+    # Reset the daily counter when the date rolls over; keep the cursor so we
+    # resume the catalog scan across days.
+    spent = yt.get("spent_today", 0) if yt.get("date") == today else 0
+    return YouTubeBudget(
+        budget=budget,
+        spent_today=spent,
+        cursor=yt.get("cursor", 0),
+        date=today,
+    )
+
+
+def save_state(path: Path, yt: YouTubeBudget) -> None:
+    data = {}
+    if path.exists():
+        try:
+            data = json.loads(path.read_text())
+        except (OSError, json.JSONDecodeError):
+            data = {}
+    data["youtube"] = {
+        "date": yt.date,
+        "spent_today": yt.spent_today,
+        "cursor": yt.cursor,
+        "budget": yt.budget,
+    }
+    path.write_text(json.dumps(data, indent=2) + "\n")
+
+
+# ---------------------------------------------------------------------------
+# HTTP helpers (network; mocked in tests)
+# ---------------------------------------------------------------------------
+def _http_get_json(url: str, timeout: int = 30) -> dict:
+    req = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def fetch_odesli(spotify_id: str, *, sleep: float = 6.0, max_retries: int = 4,
+                 getter: Callable[[str], dict] = _http_get_json,
+                 sleeper: Callable[[float], None] = time.sleep) -> dict | None:
+    """Call Odesli for one Spotify track. Throttles + backs off on HTTP 429."""
+    spotify_url = f"https://open.spotify.com/track/{spotify_id}"
+    api = ("https://api.song.link/v1-alpha.1/links?url="
+           + urllib.parse.quote(spotify_url, safe=""))
+    backoff = sleep
+    for attempt in range(max_retries + 1):
+        try:
+            return getter(api)
+        except urllib.error.HTTPError as e:
+            if e.code == 429 and attempt < max_retries:
+                sleeper(backoff)
+                backoff *= 2
+                continue
+            if e.code == 404:
+                return None
+            raise
+    return None
+
+
+def fetch_deezer_isrc(isrc: str,
+                      getter: Callable[[str], dict] = _http_get_json) -> str | None:
+    """Map an ISRC to a Deezer track id via the public endpoint. None if absent."""
+    try:
+        data = getter(f"https://api.deezer.com/track/isrc:{isrc}")
+    except urllib.error.HTTPError:
+        return None
+    if not data or data.get("error"):
+        return None
+    return _numeric_id(data.get("id"))
+
+
+def youtube_search_id(api_key: str, artist: str, title: str,
+                      getter: Callable[[str], dict] = _http_get_json) -> str | None:
+    """search.list for ``artist title``; return the top video id (11 chars)."""
+    q = urllib.parse.quote(f"{artist} {title}")
+    url = (
+        "https://www.googleapis.com/youtube/v3/search"
+        f"?part=snippet&type=video&maxResults=1&q={q}&key={api_key}"
+    )
+    try:
+        data = getter(url)
+    except urllib.error.HTTPError:
+        return None
+    items = (data or {}).get("items") or []
+    if not items:
+        return None
+    vid = (items[0].get("id") or {}).get("videoId")
+    return vid if vid and _YT_ID.match(vid) else None
+
+
+# ---------------------------------------------------------------------------
+# Playlist IO
+# ---------------------------------------------------------------------------
+def discover_playlists(root: Path) -> list[Path]:
+    base = root / "custom_components" / "beatify" / "playlists"
+    files = sorted(base.glob("*.json"))
+    files += sorted((base / "community").glob("*.json"))
+    return files
+
+
+def rel_name(root: Path, path: Path) -> str:
+    base = root / "custom_components" / "beatify" / "playlists"
+    return str(path.relative_to(base))
+
+
+# ---------------------------------------------------------------------------
+# Orchestration
+# ---------------------------------------------------------------------------
+def run(args: argparse.Namespace) -> int:
+    root = Path(args.repo_root).resolve()
+    state_path = Path(args.state) if args.state else (
+        Path(__file__).resolve().parent.parent / ".backfill-state.json")
+    today = time.strftime("%Y-%m-%d")
+    yt_key = os.environ.get("YOUTUBE_API_KEY")
+    yt_state = load_state(state_path, today, args.youtube_budget)
+
+    playlist_paths = discover_playlists(root)
+    if args.playlist:
+        playlist_paths = [p for p in playlist_paths
+                          if p.stem == args.playlist or rel_name(root, p) == args.playlist]
+        if not playlist_paths:
+            print(f"No playlist matched '{args.playlist}'", file=sys.stderr)
+            return 2
+
+    coverages: list[PlaylistCoverage] = []
+    # Global flat index for the YouTube resume cursor.
+    global_idx = 0
+    yt_phase_note = (
+        "skipped — YOUTUBE_API_KEY not set" if not yt_key
+        else f"budget {yt_state.remaining()}/{yt_state.budget} left today, "
+             f"cursor at song #{yt_state.cursor}"
+    )
+
+    for path in playlist_paths:
+        data = json.loads(path.read_text())
+        songs = data.get("songs", [])
+        cov = coverage_for_playlist(rel_name(root, path), str(path), songs)
+        cov.filled_this_run = {p: 0 for p in PROVIDER_FIELDS}
+        dirty = False
+
+        for song in songs:
+            this_global_idx = global_idx
+            global_idx += 1
+            sid = spotify_track_id(song.get("uri"))
+            gaps = song_gaps(song)
+            if not sid or not gaps:
+                continue
+
+            # ---- Odesli (apple/tidal/deezer) ----
+            non_yt_gaps = [g for g in gaps if g != "youtube_music"]
+            if non_yt_gaps:
+                payload = fetch_odesli(sid, sleep=args.odesli_sleep)
+                resolved = odesli_to_uris(payload or {})
+                for prov in non_yt_gaps:
+                    val = resolved.get(prov)
+                    if val:
+                        song[PROVIDER_FIELDS[prov]] = val
+                        cov.filled_this_run[prov] += 1
+                        dirty = True
+                # Deezer secondary verify via ISRC if Odesli missed it.
+                if "deezer" in non_yt_gaps and not song.get("uri_deezer") and song.get("isrc"):
+                    did = fetch_deezer_isrc(song["isrc"])
+                    if did:
+                        song["uri_deezer"] = deezer_uri(did)
+                        cov.filled_this_run["deezer"] += 1
+                        dirty = True
+                time.sleep(args.odesli_sleep)
+
+            # ---- YouTube Data API (resume-cursor + daily budget) ----
+            if "youtube_music" in gaps and yt_key:
+                if this_global_idx < yt_state.cursor:
+                    continue  # already passed this index in a prior run
+                if not yt_state.can_spend():
+                    yt_phase_note = (f"daily budget {yt_state.budget} exhausted; "
+                                     f"resume at song #{yt_state.cursor}")
+                    continue
+                vid = youtube_search_id(yt_key, song.get("artist", ""),
+                                        song.get("title", ""))
+                yt_state.spend()
+                yt_state.cursor = this_global_idx + 1
+                if vid:
+                    song["uri_youtube_music"] = youtube_uri(vid)
+                    cov.filled_this_run["youtube_music"] += 1
+                    dirty = True
+
+        coverages.append(cov)
+        if dirty and args.apply:
+            path.write_text(json.dumps(data, ensure_ascii=False, indent=2) + "\n")
+
+    if yt_key:
+        save_state(state_path, yt_state)
+
+    report = build_report(coverages, today, applied=args.apply,
+                          yt_phase_note=yt_phase_note)
+    out_path = Path(args.output) if args.output else (
+        root / "docs" / "provider-coverage.md")
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(report)
+    print(f"Wrote coverage report → {out_path}")
+    print(f"Mode: {'APPLY (wrote JSON)' if args.apply else 'DRY-RUN (report only)'}")
+    print(f"YouTube phase: {yt_phase_note}")
+    return 0
+
+
+def build_report(coverages: list[PlaylistCoverage], today: str, *,
+                 applied: bool, yt_phase_note: str) -> str:
+    label = {"apple_music": "Apple", "tidal": "Tidal",
+             "deezer": "Deezer", "youtube_music": "YouTube"}
+    total = sum(c.total for c in coverages)
+    have_tot = {p: sum(c.have[p] for c in coverages) for p in PROVIDER_FIELDS}
+    filled_tot = {p: sum(c.filled_this_run.get(p, 0) for c in coverages)
+                  for p in PROVIDER_FIELDS}
+
+    lines = [
+        "# Beatify Provider-URI Coverage",
+        f"> Generated: {today}",
+        f"> Mode: {'APPLY' if applied else 'DRY-RUN (no JSON written)'}",
+        f"> YouTube phase: {yt_phase_note}",
+        "",
+        "## Summary",
+        "",
+        "| Provider | Have | Total | Coverage | Filled this run |",
+        "|---|---:|---:|---:|---:|",
+    ]
+    for p in PROVIDER_FIELDS:
+        pct = (100 * have_tot[p] / total) if total else 0
+        lines.append(
+            f"| {label[p]} | {have_tot[p]} | {total} | {pct:.1f}% | "
+            f"{filled_tot[p]} |"
+        )
+    lines += [
+        "",
+        "## Per-playlist coverage",
+        "",
+        "| Playlist | Songs | Apple | Tidal | Deezer | YouTube | Filled |",
+        "|---|---:|---:|---:|---:|---:|---:|",
+    ]
+    for c in sorted(coverages, key=lambda x: x.name):
+        filled = sum(c.filled_this_run.values())
+        lines.append(
+            f"| {c.name} | {c.total} | "
+            f"{c.have['apple_music']} | {c.have['tidal']} | "
+            f"{c.have['deezer']} | {c.have['youtube_music']} | "
+            f"{filled if filled else ''} |"
+        )
+    lines.append("")
+    lines.append(
+        "*Coverage = songs with a non-null URI for that provider. "
+        "“Filled” = URIs this run added (0 in dry-run).*"
+    )
+    return "\n".join(lines) + "\n"
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--repo-root", default=".",
+                   help="Beatify repo root (default: cwd)")
+    p.add_argument("--playlist",
+                   help="Only process this playlist (basename or community/<name>)")
+    p.add_argument("--apply", action="store_true",
+                   help="Write filled URIs back to JSON (default: dry-run report only)")
+    p.add_argument("--output",
+                   help="Coverage report path (default: docs/provider-coverage.md)")
+    p.add_argument("--state",
+                   help="YouTube resume-state file (default: skill/.backfill-state.json)")
+    p.add_argument("--odesli-sleep", type=float, default=6.0,
+                   help="Seconds between Odesli calls (free tier ~10/min, default 6)")
+    p.add_argument("--youtube-budget", type=int, default=90,
+                   help="Max YouTube search.list calls per day (default 90)")
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_arg_parser().parse_args(argv)
+    return run(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/skills/provider-uri-backfill/scripts/backfill_provider_uris.py
+++ b/.claude/skills/provider-uri-backfill/scripts/backfill_provider_uris.py
@@ -32,6 +32,7 @@ Safety: defaults to **dry-run** (report only). JSON files are only mutated when
 ``--apply`` is passed. Running the full backfill at scale is a deliberate
 follow-up, not the default.
 """
+
 from __future__ import annotations
 
 import argparse
@@ -258,13 +259,19 @@ def _http_get_json(url: str, timeout: int = 30) -> dict:
         return json.loads(resp.read().decode("utf-8"))
 
 
-def fetch_odesli(spotify_id: str, *, sleep: float = 6.0, max_retries: int = 4,
-                 getter: Callable[[str], dict] = _http_get_json,
-                 sleeper: Callable[[float], None] = time.sleep) -> dict | None:
+def fetch_odesli(
+    spotify_id: str,
+    *,
+    sleep: float = 6.0,
+    max_retries: int = 4,
+    getter: Callable[[str], dict] = _http_get_json,
+    sleeper: Callable[[float], None] = time.sleep,
+) -> dict | None:
     """Call Odesli for one Spotify track. Throttles + backs off on HTTP 429."""
     spotify_url = f"https://open.spotify.com/track/{spotify_id}"
-    api = ("https://api.song.link/v1-alpha.1/links?url="
-           + urllib.parse.quote(spotify_url, safe=""))
+    api = "https://api.song.link/v1-alpha.1/links?url=" + urllib.parse.quote(
+        spotify_url, safe=""
+    )
     backoff = sleep
     for attempt in range(max_retries + 1):
         try:
@@ -280,8 +287,9 @@ def fetch_odesli(spotify_id: str, *, sleep: float = 6.0, max_retries: int = 4,
     return None
 
 
-def fetch_deezer_isrc(isrc: str,
-                      getter: Callable[[str], dict] = _http_get_json) -> str | None:
+def fetch_deezer_isrc(
+    isrc: str, getter: Callable[[str], dict] = _http_get_json
+) -> str | None:
     """Map an ISRC to a Deezer track id via the public endpoint. None if absent."""
     try:
         data = getter(f"https://api.deezer.com/track/isrc:{isrc}")
@@ -292,8 +300,12 @@ def fetch_deezer_isrc(isrc: str,
     return _numeric_id(data.get("id"))
 
 
-def youtube_search_id(api_key: str, artist: str, title: str,
-                      getter: Callable[[str], dict] = _http_get_json) -> str | None:
+def youtube_search_id(
+    api_key: str,
+    artist: str,
+    title: str,
+    getter: Callable[[str], dict] = _http_get_json,
+) -> str | None:
     """search.list for ``artist title``; return the top video id (11 chars)."""
     q = urllib.parse.quote(f"{artist} {title}")
     url = (
@@ -331,16 +343,22 @@ def rel_name(root: Path, path: Path) -> str:
 # ---------------------------------------------------------------------------
 def run(args: argparse.Namespace) -> int:
     root = Path(args.repo_root).resolve()
-    state_path = Path(args.state) if args.state else (
-        Path(__file__).resolve().parent.parent / ".backfill-state.json")
+    state_path = (
+        Path(args.state)
+        if args.state
+        else (Path(__file__).resolve().parent.parent / ".backfill-state.json")
+    )
     today = time.strftime("%Y-%m-%d")
     yt_key = os.environ.get("YOUTUBE_API_KEY")
     yt_state = load_state(state_path, today, args.youtube_budget)
 
     playlist_paths = discover_playlists(root)
     if args.playlist:
-        playlist_paths = [p for p in playlist_paths
-                          if p.stem == args.playlist or rel_name(root, p) == args.playlist]
+        playlist_paths = [
+            p
+            for p in playlist_paths
+            if p.stem == args.playlist or rel_name(root, p) == args.playlist
+        ]
         if not playlist_paths:
             print(f"No playlist matched '{args.playlist}'", file=sys.stderr)
             return 2
@@ -349,9 +367,10 @@ def run(args: argparse.Namespace) -> int:
     # Global flat index for the YouTube resume cursor.
     global_idx = 0
     yt_phase_note = (
-        "skipped — YOUTUBE_API_KEY not set" if not yt_key
+        "skipped — YOUTUBE_API_KEY not set"
+        if not yt_key
         else f"budget {yt_state.remaining()}/{yt_state.budget} left today, "
-             f"cursor at song #{yt_state.cursor}"
+        f"cursor at song #{yt_state.cursor}"
     )
 
     for path in playlist_paths:
@@ -381,7 +400,11 @@ def run(args: argparse.Namespace) -> int:
                         cov.filled_this_run[prov] += 1
                         dirty = True
                 # Deezer secondary verify via ISRC if Odesli missed it.
-                if "deezer" in non_yt_gaps and not song.get("uri_deezer") and song.get("isrc"):
+                if (
+                    "deezer" in non_yt_gaps
+                    and not song.get("uri_deezer")
+                    and song.get("isrc")
+                ):
                     did = fetch_deezer_isrc(song["isrc"])
                     if did:
                         song["uri_deezer"] = deezer_uri(did)
@@ -394,11 +417,14 @@ def run(args: argparse.Namespace) -> int:
                 if this_global_idx < yt_state.cursor:
                     continue  # already passed this index in a prior run
                 if not yt_state.can_spend():
-                    yt_phase_note = (f"daily budget {yt_state.budget} exhausted; "
-                                     f"resume at song #{yt_state.cursor}")
+                    yt_phase_note = (
+                        f"daily budget {yt_state.budget} exhausted; "
+                        f"resume at song #{yt_state.cursor}"
+                    )
                     continue
-                vid = youtube_search_id(yt_key, song.get("artist", ""),
-                                        song.get("title", ""))
+                vid = youtube_search_id(
+                    yt_key, song.get("artist", ""), song.get("title", "")
+                )
                 yt_state.spend()
                 yt_state.cursor = this_global_idx + 1
                 if vid:
@@ -413,10 +439,12 @@ def run(args: argparse.Namespace) -> int:
     if yt_key:
         save_state(state_path, yt_state)
 
-    report = build_report(coverages, today, applied=args.apply,
-                          yt_phase_note=yt_phase_note)
-    out_path = Path(args.output) if args.output else (
-        root / "docs" / "provider-coverage.md")
+    report = build_report(
+        coverages, today, applied=args.apply, yt_phase_note=yt_phase_note
+    )
+    out_path = (
+        Path(args.output) if args.output else (root / "docs" / "provider-coverage.md")
+    )
     out_path.parent.mkdir(parents=True, exist_ok=True)
     out_path.write_text(report)
     print(f"Wrote coverage report → {out_path}")
@@ -425,14 +453,20 @@ def run(args: argparse.Namespace) -> int:
     return 0
 
 
-def build_report(coverages: list[PlaylistCoverage], today: str, *,
-                 applied: bool, yt_phase_note: str) -> str:
-    label = {"apple_music": "Apple", "tidal": "Tidal",
-             "deezer": "Deezer", "youtube_music": "YouTube"}
+def build_report(
+    coverages: list[PlaylistCoverage], today: str, *, applied: bool, yt_phase_note: str
+) -> str:
+    label = {
+        "apple_music": "Apple",
+        "tidal": "Tidal",
+        "deezer": "Deezer",
+        "youtube_music": "YouTube",
+    }
     total = sum(c.total for c in coverages)
     have_tot = {p: sum(c.have[p] for c in coverages) for p in PROVIDER_FIELDS}
-    filled_tot = {p: sum(c.filled_this_run.get(p, 0) for c in coverages)
-                  for p in PROVIDER_FIELDS}
+    filled_tot = {
+        p: sum(c.filled_this_run.get(p, 0) for c in coverages) for p in PROVIDER_FIELDS
+    }
 
     lines = [
         "# Beatify Provider-URI Coverage",
@@ -448,8 +482,7 @@ def build_report(coverages: list[PlaylistCoverage], today: str, *,
     for p in PROVIDER_FIELDS:
         pct = (100 * have_tot[p] / total) if total else 0
         lines.append(
-            f"| {label[p]} | {have_tot[p]} | {total} | {pct:.1f}% | "
-            f"{filled_tot[p]} |"
+            f"| {label[p]} | {have_tot[p]} | {total} | {pct:.1f}% | {filled_tot[p]} |"
         )
     lines += [
         "",
@@ -475,22 +508,37 @@ def build_report(coverages: list[PlaylistCoverage], today: str, *,
 
 
 def build_arg_parser() -> argparse.ArgumentParser:
-    p = argparse.ArgumentParser(description=__doc__,
-                                formatter_class=argparse.RawDescriptionHelpFormatter)
-    p.add_argument("--repo-root", default=".",
-                   help="Beatify repo root (default: cwd)")
-    p.add_argument("--playlist",
-                   help="Only process this playlist (basename or community/<name>)")
-    p.add_argument("--apply", action="store_true",
-                   help="Write filled URIs back to JSON (default: dry-run report only)")
-    p.add_argument("--output",
-                   help="Coverage report path (default: docs/provider-coverage.md)")
-    p.add_argument("--state",
-                   help="YouTube resume-state file (default: skill/.backfill-state.json)")
-    p.add_argument("--odesli-sleep", type=float, default=6.0,
-                   help="Seconds between Odesli calls (free tier ~10/min, default 6)")
-    p.add_argument("--youtube-budget", type=int, default=90,
-                   help="Max YouTube search.list calls per day (default 90)")
+    p = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    p.add_argument("--repo-root", default=".", help="Beatify repo root (default: cwd)")
+    p.add_argument(
+        "--playlist", help="Only process this playlist (basename or community/<name>)"
+    )
+    p.add_argument(
+        "--apply",
+        action="store_true",
+        help="Write filled URIs back to JSON (default: dry-run report only)",
+    )
+    p.add_argument(
+        "--output", help="Coverage report path (default: docs/provider-coverage.md)"
+    )
+    p.add_argument(
+        "--state",
+        help="YouTube resume-state file (default: skill/.backfill-state.json)",
+    )
+    p.add_argument(
+        "--odesli-sleep",
+        type=float,
+        default=6.0,
+        help="Seconds between Odesli calls (free tier ~10/min, default 6)",
+    )
+    p.add_argument(
+        "--youtube-budget",
+        type=int,
+        default=90,
+        help="Max YouTube search.list calls per day (default 90)",
+    )
     return p
 
 

--- a/docs/provider-coverage.md
+++ b/docs/provider-coverage.md
@@ -1,0 +1,60 @@
+# Beatify Provider-URI Coverage
+> Generated: 2026-06-10
+> Mode: DRY-RUN (no JSON written)
+> YouTube phase: skipped — sample report generated without network (YOUTUBE_API_KEY not set)
+
+## Summary
+
+| Provider | Have | Total | Coverage | Filled this run |
+|---|---:|---:|---:|---:|
+| Apple | 4082 | 4495 | 90.8% | 0 |
+| Tidal | 2340 | 4495 | 52.1% | 0 |
+| Deezer | 4035 | 4495 | 89.8% | 0 |
+| YouTube | 4348 | 4495 | 96.7% | 0 |
+
+## Per-playlist coverage
+
+| Playlist | Songs | Apple | Tidal | Deezer | YouTube | Filled |
+|---|---:|---:|---:|---:|---:|---:|
+| 2000s-pop-anthems.json | 182 | 175 | 144 | 179 | 182 |  |
+| 40s-50s-classics.json | 152 | 115 | 0 | 149 | 152 |  |
+| 70s-hits.json | 163 | 84 | 0 | 163 | 163 |  |
+| 80er-hits.json | 238 | 229 | 186 | 238 | 234 |  |
+| 90er-hits.json | 115 | 99 | 9 | 113 | 115 |  |
+| community/90s-2000s-hiphop-bangers.json | 40 | 40 | 40 | 40 | 40 |  |
+| community/anime-openings.json | 140 | 140 | 0 | 102 | 139 |  |
+| community/ballermann-party-hits.json | 189 | 178 | 0 | 175 | 189 |  |
+| community/best-of-giraffenaffen.json | 26 | 26 | 0 | 25 | 25 |  |
+| community/british-invasion-britpop.json | 100 | 86 | 98 | 100 | 98 |  |
+| community/deutschpop-klassiker.json | 107 | 106 | 1 | 107 | 107 |  |
+| community/divorced-dad-rock.json | 107 | 56 | 0 | 107 | 107 |  |
+| community/edm-anthems.json | 126 | 103 | 0 | 126 | 126 |  |
+| community/essential-alternative.json | 100 | 100 | 0 | 98 | 100 |  |
+| community/eurodance-90s.json | 100 | 86 | 92 | 91 | 97 |  |
+| community/fiesta-latina-90s.json | 50 | 48 | 50 | 50 | 50 |  |
+| community/gen-z-anthems.json | 30 | 30 | 30 | 30 | 30 |  |
+| community/greatest-metal-songs.json | 61 | 61 | 52 | 0 | 61 |  |
+| community/harder-styles.json | 190 | 174 | 0 | 182 | 190 |  |
+| community/hitster-100-en-espanol.json | 127 | 127 | 127 | 0 | 127 |  |
+| community/iconic-movie-songs.json | 72 | 72 | 0 | 72 | 71 |  |
+| community/koelner-karneval.json | 290 | 289 | 276 | 288 | 273 |  |
+| community/pure-pop-punk.json | 100 | 97 | 100 | 100 | 100 |  |
+| community/schlager-klassiker.json | 60 | 58 | 60 | 59 | 60 |  |
+| community/schweizer-hits.json | 97 | 90 | 17 | 97 | 97 |  |
+| community/top100-allertijden-nederlandstalig.json | 104 | 96 | 68 | 0 | 100 |  |
+| community/trance-classics.json | 120 | 103 | 0 | 109 | 120 |  |
+| community/yacht-rock.json | 100 | 98 | 100 | 100 | 100 |  |
+| disco-funk-classics.json | 98 | 88 | 73 | 96 | 73 |  |
+| disney-classics.json | 69 | 69 | 0 | 69 | 57 |  |
+| eurovision-winners.json | 72 | 63 | 62 | 71 | 67 |  |
+| greatest-hits-of-all-time.json | 236 | 225 | 196 | 236 | 194 |  |
+| hits-2010s-2020s.json | 71 | 67 | 3 | 68 | 71 |  |
+| motown-soul-classics.json | 100 | 98 | 47 | 100 | 98 |  |
+| movies-100-greatest-themes.json | 162 | 122 | 156 | 148 | 139 |  |
+| one-hit-wonders.json | 98 | 94 | 98 | 98 | 94 |  |
+| summer-party-anthems.json | 112 | 109 | 112 | 111 | 111 |  |
+| top-100-power-ballads.json | 99 | 96 | 99 | 95 | 99 |  |
+| top-songs-der-60er.json | 66 | 62 | 44 | 22 | 66 |  |
+| world-cup-anthems.json | 26 | 23 | 0 | 21 | 26 |  |
+
+*Coverage = songs with a non-null URI for that provider. “Filled” = URIs this run added (0 in dry-run).*

--- a/tests/unit/test_provider_uri_backfill.py
+++ b/tests/unit/test_provider_uri_backfill.py
@@ -18,8 +18,11 @@ import pytest
 # Register in sys.modules before exec so dataclass type-resolution works on 3.9.
 _SKILL = (
     Path(__file__).resolve().parents[2]
-    / ".claude" / "skills" / "provider-uri-backfill"
-    / "scripts" / "backfill_provider_uris.py"
+    / ".claude"
+    / "skills"
+    / "provider-uri-backfill"
+    / "scripts"
+    / "backfill_provider_uris.py"
 )
 _spec = importlib.util.spec_from_file_location("backfill_provider_uris", _SKILL)
 bf = importlib.util.module_from_spec(_spec)
@@ -29,10 +32,15 @@ _spec.loader.exec_module(bf)
 
 # --- spotify_track_id ------------------------------------------------------
 def test_spotify_track_id_valid():
-    assert bf.spotify_track_id("spotify:track:7aUCLXZ4D4UD5sCgIgxqjl") == "7aUCLXZ4D4UD5sCgIgxqjl"
+    assert (
+        bf.spotify_track_id("spotify:track:7aUCLXZ4D4UD5sCgIgxqjl")
+        == "7aUCLXZ4D4UD5sCgIgxqjl"
+    )
 
 
-@pytest.mark.parametrize("bad", [None, "", "spotify:album:x", "tidal://track/1", "spotify:track:short"])
+@pytest.mark.parametrize(
+    "bad", [None, "", "spotify:album:x", "tidal://track/1", "spotify:track:short"]
+)
 def test_spotify_track_id_invalid(bad):
     assert bf.spotify_track_id(bad) is None
 
@@ -42,10 +50,14 @@ def test_odesli_maps_tidal_and_deezer_from_entity_ids():
     # Shape mirrors the live response observed 2026-06 (entityUniqueId numeric).
     payload = {
         "linksByPlatform": {
-            "tidal": {"url": "https://listen.tidal.com/track/33833948",
-                      "entityUniqueId": "TIDAL_SONG::33833948"},
-            "deezer": {"url": "https://www.deezer.com/track/13111375",
-                       "entityUniqueId": "DEEZER_SONG::13111375"},
+            "tidal": {
+                "url": "https://listen.tidal.com/track/33833948",
+                "entityUniqueId": "TIDAL_SONG::33833948",
+            },
+            "deezer": {
+                "url": "https://www.deezer.com/track/13111375",
+                "entityUniqueId": "DEEZER_SONG::13111375",
+            },
         },
         "entitiesByUniqueId": {
             "TIDAL_SONG::33833948": {"id": "33833948"},
@@ -74,8 +86,10 @@ def test_odesli_falls_back_to_url_when_entity_missing():
 def test_odesli_maps_apple_when_present():
     payload = {
         "linksByPlatform": {
-            "appleMusic": {"url": "https://music.apple.com/us/album/x/123?i=987654321",
-                           "entityUniqueId": "ITUNES_SONG::987654321"},
+            "appleMusic": {
+                "url": "https://music.apple.com/us/album/x/123?i=987654321",
+                "entityUniqueId": "ITUNES_SONG::987654321",
+            },
         },
         "entitiesByUniqueId": {"ITUNES_SONG::987654321": {"id": "987654321"}},
     }
@@ -97,7 +111,9 @@ def test_odesli_apple_url_fallback_prefers_song_id():
 
 def test_odesli_empty_and_malformed_safe():
     assert bf.odesli_to_uris({}) == {}
-    assert bf.odesli_to_uris({"linksByPlatform": None, "entitiesByUniqueId": None}) == {}
+    assert (
+        bf.odesli_to_uris({"linksByPlatform": None, "entitiesByUniqueId": None}) == {}
+    )
 
 
 def test_odesli_skips_non_numeric_id():
@@ -127,11 +143,16 @@ def test_song_gaps_none_when_complete():
 # --- coverage aggregation --------------------------------------------------
 def test_coverage_counts_have_and_fillable():
     songs = [
-        {"uri": "spotify:track:" + "a" * 22, "uri_tidal": "tidal://track/1"},  # gaps → fillable
-        {"uri": "spotify:track:" + "b" * 22,                                   # all gaps → fillable
-         },
+        {
+            "uri": "spotify:track:" + "a" * 22,
+            "uri_tidal": "tidal://track/1",
+        },  # gaps → fillable
+        {
+            "uri": "spotify:track:" + "b" * 22,  # all gaps → fillable
+        },
         {"uri": None, "uri_tidal": None},  # no spotify uri → not fillable
-        {f: "x" for f in bf.PROVIDER_FIELDS.values()} | {"uri": "spotify:track:" + "c" * 22},  # complete
+        {f: "x" for f in bf.PROVIDER_FIELDS.values()}
+        | {"uri": "spotify:track:" + "c" * 22},  # complete
     ]
     cov = bf.coverage_for_playlist("p.json", "/p.json", songs)
     assert cov.total == 4
@@ -171,6 +192,7 @@ def test_load_state_missing_file(tmp_path):
 # --- HTTP wrappers with mocked getters -------------------------------------
 def test_fetch_odesli_retries_on_429(monkeypatch):
     import urllib.error
+
     calls = {"n": 0}
 
     def getter(url):
@@ -180,8 +202,9 @@ def test_fetch_odesli_retries_on_429(monkeypatch):
         return {"ok": True}
 
     slept = []
-    out = bf.fetch_odesli("x" * 22, sleep=0.01, getter=getter,
-                          sleeper=lambda s: slept.append(s))
+    out = bf.fetch_odesli(
+        "x" * 22, sleep=0.01, getter=getter, sleeper=lambda s: slept.append(s)
+    )
     assert out == {"ok": True}
     assert calls["n"] == 3
     assert len(slept) == 2 and slept[1] > slept[0]  # exponential backoff
@@ -208,8 +231,10 @@ def test_fetch_deezer_isrc_no_data():
 
 def test_youtube_search_extracts_video_id():
     resp = {"items": [{"id": {"videoId": "dQw4w9WgXcQ"}}]}
-    assert bf.youtube_search_id("KEY", "Rick Astley", "Never Gonna",
-                                getter=lambda u: resp) == "dQw4w9WgXcQ"
+    assert (
+        bf.youtube_search_id("KEY", "Rick Astley", "Never Gonna", getter=lambda u: resp)
+        == "dQw4w9WgXcQ"
+    )
 
 
 def test_youtube_search_no_items():
@@ -220,7 +245,12 @@ def test_youtube_search_no_items():
 def test_build_report_has_summary_and_rows():
     cov = bf.PlaylistCoverage(name="p.json", path="/p.json", total=10)
     cov.have = {"apple_music": 8, "tidal": 5, "deezer": 9, "youtube_music": 10}
-    cov.filled_this_run = {"apple_music": 0, "tidal": 3, "deezer": 0, "youtube_music": 0}
+    cov.filled_this_run = {
+        "apple_music": 0,
+        "tidal": 3,
+        "deezer": 0,
+        "youtube_music": 0,
+    }
     md = bf.build_report([cov], "2026-06-10", applied=True, yt_phase_note="skipped")
     assert "# Beatify Provider-URI Coverage" in md
     assert "## Summary" in md
@@ -234,33 +264,54 @@ def test_run_dry_run_no_mutation(tmp_path, monkeypatch):
     pl_dir = tmp_path / "custom_components" / "beatify" / "playlists"
     pl_dir.mkdir(parents=True)
     playlist = {
-        "name": "Test", "version": "1.0", "tags": [],
-        "songs": [{
-            "artist": "A", "title": "T", "year": 2000,
-            "uri": "spotify:track:" + "a" * 22,
-            "isrc": "USRE19901615",
-            "fun_fact": "", "fun_fact_de": "", "fun_fact_es": "",
-            "fun_fact_fr": "", "fun_fact_nl": "",
-        }],
+        "name": "Test",
+        "version": "1.0",
+        "tags": [],
+        "songs": [
+            {
+                "artist": "A",
+                "title": "T",
+                "year": 2000,
+                "uri": "spotify:track:" + "a" * 22,
+                "isrc": "USRE19901615",
+                "fun_fact": "",
+                "fun_fact_de": "",
+                "fun_fact_es": "",
+                "fun_fact_fr": "",
+                "fun_fact_nl": "",
+            }
+        ],
     }
     f = pl_dir / "test.json"
     f.write_text(json.dumps(playlist))
 
     # No network should be hit in dry-run: gaps are detected and resolvers are
     # called, so mock them to assert no mutation reaches disk anyway.
-    monkeypatch.setattr(bf, "fetch_odesli", lambda *a, **k: {
-        "linksByPlatform": {"tidal": {"entityUniqueId": "TIDAL_SONG::1"}},
-        "entitiesByUniqueId": {"TIDAL_SONG::1": {"id": "1"}},
-    })
+    monkeypatch.setattr(
+        bf,
+        "fetch_odesli",
+        lambda *a, **k: {
+            "linksByPlatform": {"tidal": {"entityUniqueId": "TIDAL_SONG::1"}},
+            "entitiesByUniqueId": {"TIDAL_SONG::1": {"id": "1"}},
+        },
+    )
     monkeypatch.setattr(bf, "fetch_deezer_isrc", lambda *a, **k: None)
     monkeypatch.setattr(bf.time, "sleep", lambda s: None)
     monkeypatch.delenv("YOUTUBE_API_KEY", raising=False)
 
     out = tmp_path / "coverage.md"
-    rc = bf.main([
-        "--repo-root", str(tmp_path), "--output", str(out),
-        "--state", str(tmp_path / "state.json"), "--odesli-sleep", "0",
-    ])
+    rc = bf.main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "--output",
+            str(out),
+            "--state",
+            str(tmp_path / "state.json"),
+            "--odesli-sleep",
+            "0",
+        ]
+    )
     assert rc == 0
     # Dry-run: report written, JSON untouched.
     assert out.exists()
@@ -272,35 +323,56 @@ def test_run_apply_writes_uri(tmp_path, monkeypatch):
     pl_dir = tmp_path / "custom_components" / "beatify" / "playlists"
     pl_dir.mkdir(parents=True)
     playlist = {
-        "name": "Test", "version": "1.0", "tags": [],
-        "songs": [{
-            "artist": "A", "title": "T", "year": 2000,
-            "uri": "spotify:track:" + "a" * 22,
-            "fun_fact": "", "fun_fact_de": "", "fun_fact_es": "",
-            "fun_fact_fr": "", "fun_fact_nl": "",
-        }],
+        "name": "Test",
+        "version": "1.0",
+        "tags": [],
+        "songs": [
+            {
+                "artist": "A",
+                "title": "T",
+                "year": 2000,
+                "uri": "spotify:track:" + "a" * 22,
+                "fun_fact": "",
+                "fun_fact_de": "",
+                "fun_fact_es": "",
+                "fun_fact_fr": "",
+                "fun_fact_nl": "",
+            }
+        ],
     }
     f = pl_dir / "test.json"
     f.write_text(json.dumps(playlist))
 
-    monkeypatch.setattr(bf, "fetch_odesli", lambda *a, **k: {
-        "linksByPlatform": {
-            "tidal": {"entityUniqueId": "TIDAL_SONG::42"},
-            "deezer": {"entityUniqueId": "DEEZER_SONG::99"},
+    monkeypatch.setattr(
+        bf,
+        "fetch_odesli",
+        lambda *a, **k: {
+            "linksByPlatform": {
+                "tidal": {"entityUniqueId": "TIDAL_SONG::42"},
+                "deezer": {"entityUniqueId": "DEEZER_SONG::99"},
+            },
+            "entitiesByUniqueId": {
+                "TIDAL_SONG::42": {"id": "42"},
+                "DEEZER_SONG::99": {"id": "99"},
+            },
         },
-        "entitiesByUniqueId": {
-            "TIDAL_SONG::42": {"id": "42"},
-            "DEEZER_SONG::99": {"id": "99"},
-        },
-    })
+    )
     monkeypatch.setattr(bf.time, "sleep", lambda s: None)
     monkeypatch.delenv("YOUTUBE_API_KEY", raising=False)
 
-    rc = bf.main([
-        "--repo-root", str(tmp_path), "--apply",
-        "--output", str(tmp_path / "coverage.md"),
-        "--state", str(tmp_path / "state.json"), "--odesli-sleep", "0",
-    ])
+    rc = bf.main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "--apply",
+            "--output",
+            str(tmp_path / "coverage.md"),
+            "--state",
+            str(tmp_path / "state.json"),
+            "--odesli-sleep",
+            "0",
+        ]
+    )
     assert rc == 0
     song = json.loads(f.read_text())["songs"][0]
     assert song["uri_tidal"] == "tidal://track/42"

--- a/tests/unit/test_provider_uri_backfill.py
+++ b/tests/unit/test_provider_uri_backfill.py
@@ -1,0 +1,307 @@
+"""Tests for the provider-URI-backfill skill (#1289).
+
+Covers the pure logic: Odesli-response → stored URI mapping per provider,
+gap detection, resume-cursor / daily-budget accounting, and coverage-report
+aggregation. All network calls are mocked — no live HTTP here.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+# The skill script lives outside the importable package tree, so load it by path.
+# Register in sys.modules before exec so dataclass type-resolution works on 3.9.
+_SKILL = (
+    Path(__file__).resolve().parents[2]
+    / ".claude" / "skills" / "provider-uri-backfill"
+    / "scripts" / "backfill_provider_uris.py"
+)
+_spec = importlib.util.spec_from_file_location("backfill_provider_uris", _SKILL)
+bf = importlib.util.module_from_spec(_spec)
+sys.modules["backfill_provider_uris"] = bf
+_spec.loader.exec_module(bf)
+
+
+# --- spotify_track_id ------------------------------------------------------
+def test_spotify_track_id_valid():
+    assert bf.spotify_track_id("spotify:track:7aUCLXZ4D4UD5sCgIgxqjl") == "7aUCLXZ4D4UD5sCgIgxqjl"
+
+
+@pytest.mark.parametrize("bad", [None, "", "spotify:album:x", "tidal://track/1", "spotify:track:short"])
+def test_spotify_track_id_invalid(bad):
+    assert bf.spotify_track_id(bad) is None
+
+
+# --- odesli_to_uris: byte-identical stored formats -------------------------
+def test_odesli_maps_tidal_and_deezer_from_entity_ids():
+    # Shape mirrors the live response observed 2026-06 (entityUniqueId numeric).
+    payload = {
+        "linksByPlatform": {
+            "tidal": {"url": "https://listen.tidal.com/track/33833948",
+                      "entityUniqueId": "TIDAL_SONG::33833948"},
+            "deezer": {"url": "https://www.deezer.com/track/13111375",
+                       "entityUniqueId": "DEEZER_SONG::13111375"},
+        },
+        "entitiesByUniqueId": {
+            "TIDAL_SONG::33833948": {"id": "33833948"},
+            "DEEZER_SONG::13111375": {"id": 13111375},  # int id tolerated
+        },
+    }
+    out = bf.odesli_to_uris(payload)
+    assert out["tidal"] == "tidal://track/33833948"
+    assert out["deezer"] == "deezer://track/13111375"
+    assert "apple_music" not in out  # not in response → not guessed
+
+
+def test_odesli_falls_back_to_url_when_entity_missing():
+    payload = {
+        "linksByPlatform": {
+            "tidal": {"url": "https://listen.tidal.com/track/150210255"},
+            "deezer": {"url": "https://www.deezer.com/track/1035796702"},
+        },
+        "entitiesByUniqueId": {},
+    }
+    out = bf.odesli_to_uris(payload)
+    assert out["tidal"] == "tidal://track/150210255"
+    assert out["deezer"] == "deezer://track/1035796702"
+
+
+def test_odesli_maps_apple_when_present():
+    payload = {
+        "linksByPlatform": {
+            "appleMusic": {"url": "https://music.apple.com/us/album/x/123?i=987654321",
+                           "entityUniqueId": "ITUNES_SONG::987654321"},
+        },
+        "entitiesByUniqueId": {"ITUNES_SONG::987654321": {"id": "987654321"}},
+    }
+    out = bf.odesli_to_uris(payload)
+    assert out["apple_music"] == "applemusic://track/987654321"
+
+
+def test_odesli_apple_url_fallback_prefers_song_id():
+    # No entity → parse the ?i=<song-id> param, not the album id.
+    payload = {
+        "linksByPlatform": {
+            "appleMusic": {"url": "https://music.apple.com/us/album/foo/111?i=222333"},
+        },
+        "entitiesByUniqueId": {},
+    }
+    out = bf.odesli_to_uris(payload)
+    assert out["apple_music"] == "applemusic://track/222333"
+
+
+def test_odesli_empty_and_malformed_safe():
+    assert bf.odesli_to_uris({}) == {}
+    assert bf.odesli_to_uris({"linksByPlatform": None, "entitiesByUniqueId": None}) == {}
+
+
+def test_odesli_skips_non_numeric_id():
+    payload = {
+        "linksByPlatform": {"tidal": {"entityUniqueId": "TIDAL_SONG::abc"}},
+        "entitiesByUniqueId": {"TIDAL_SONG::abc": {"id": "not-a-number"}},
+    }
+    assert "tidal" not in bf.odesli_to_uris(payload)
+
+
+# --- gap detection ---------------------------------------------------------
+def test_song_gaps_detects_missing_and_empty():
+    song = {
+        "uri_apple_music": "applemusic://track/1",
+        "uri_tidal": None,
+        "uri_deezer": "",
+        # uri_youtube_music absent
+    }
+    assert set(bf.song_gaps(song)) == {"tidal", "deezer", "youtube_music"}
+
+
+def test_song_gaps_none_when_complete():
+    song = {f: "x" for f in bf.PROVIDER_FIELDS.values()}
+    assert bf.song_gaps(song) == []
+
+
+# --- coverage aggregation --------------------------------------------------
+def test_coverage_counts_have_and_fillable():
+    songs = [
+        {"uri": "spotify:track:" + "a" * 22, "uri_tidal": "tidal://track/1"},  # gaps → fillable
+        {"uri": "spotify:track:" + "b" * 22,                                   # all gaps → fillable
+         },
+        {"uri": None, "uri_tidal": None},  # no spotify uri → not fillable
+        {f: "x" for f in bf.PROVIDER_FIELDS.values()} | {"uri": "spotify:track:" + "c" * 22},  # complete
+    ]
+    cov = bf.coverage_for_playlist("p.json", "/p.json", songs)
+    assert cov.total == 4
+    assert cov.have["tidal"] == 2  # song 0 + complete song
+    assert cov.have["apple_music"] == 1  # only the complete song
+    assert cov.fillable == 2  # songs 0 and 1
+
+
+# --- YouTube budget / resume-cursor accounting -----------------------------
+def test_budget_spend_and_remaining():
+    b = bf.YouTubeBudget(budget=3)
+    assert b.can_spend() and b.remaining() == 3
+    b.spend()
+    b.spend()
+    assert b.remaining() == 1 and b.can_spend()
+    b.spend()
+    assert b.remaining() == 0 and not b.can_spend()
+
+
+def test_state_roundtrip_resets_daily_keeps_cursor(tmp_path):
+    p = tmp_path / "state.json"
+    yt = bf.YouTubeBudget(budget=90, spent_today=40, cursor=512, date="2026-06-10")
+    bf.save_state(p, yt)
+    # Same day → spent_today preserved, cursor preserved.
+    same = bf.load_state(p, "2026-06-10", 90)
+    assert same.spent_today == 40 and same.cursor == 512
+    # New day → counter resets to 0, cursor carries over (resume across days).
+    nextday = bf.load_state(p, "2026-06-11", 90)
+    assert nextday.spent_today == 0 and nextday.cursor == 512
+
+
+def test_load_state_missing_file(tmp_path):
+    yt = bf.load_state(tmp_path / "nope.json", "2026-06-10", 90)
+    assert yt.spent_today == 0 and yt.cursor == 0 and yt.budget == 90
+
+
+# --- HTTP wrappers with mocked getters -------------------------------------
+def test_fetch_odesli_retries_on_429(monkeypatch):
+    import urllib.error
+    calls = {"n": 0}
+
+    def getter(url):
+        calls["n"] += 1
+        if calls["n"] < 3:
+            raise urllib.error.HTTPError(url, 429, "rate", {}, None)
+        return {"ok": True}
+
+    slept = []
+    out = bf.fetch_odesli("x" * 22, sleep=0.01, getter=getter,
+                          sleeper=lambda s: slept.append(s))
+    assert out == {"ok": True}
+    assert calls["n"] == 3
+    assert len(slept) == 2 and slept[1] > slept[0]  # exponential backoff
+
+
+def test_fetch_odesli_404_returns_none():
+    import urllib.error
+
+    def getter(url):
+        raise urllib.error.HTTPError(url, 404, "nf", {}, None)
+
+    assert bf.fetch_odesli("x" * 22, sleep=0, getter=getter) is None
+
+
+def test_fetch_deezer_isrc_maps_id():
+    out = bf.fetch_deezer_isrc("USRE19901615", getter=lambda u: {"id": 2268878307})
+    assert out == "2268878307"
+
+
+def test_fetch_deezer_isrc_no_data():
+    out = bf.fetch_deezer_isrc("BAD", getter=lambda u: {"error": {"code": 800}})
+    assert out is None
+
+
+def test_youtube_search_extracts_video_id():
+    resp = {"items": [{"id": {"videoId": "dQw4w9WgXcQ"}}]}
+    assert bf.youtube_search_id("KEY", "Rick Astley", "Never Gonna",
+                                getter=lambda u: resp) == "dQw4w9WgXcQ"
+
+
+def test_youtube_search_no_items():
+    assert bf.youtube_search_id("KEY", "a", "b", getter=lambda u: {"items": []}) is None
+
+
+# --- report aggregation ----------------------------------------------------
+def test_build_report_has_summary_and_rows():
+    cov = bf.PlaylistCoverage(name="p.json", path="/p.json", total=10)
+    cov.have = {"apple_music": 8, "tidal": 5, "deezer": 9, "youtube_music": 10}
+    cov.filled_this_run = {"apple_music": 0, "tidal": 3, "deezer": 0, "youtube_music": 0}
+    md = bf.build_report([cov], "2026-06-10", applied=True, yt_phase_note="skipped")
+    assert "# Beatify Provider-URI Coverage" in md
+    assert "## Summary" in md
+    assert "p.json" in md
+    assert "DRY-RUN" not in md  # applied=True
+    assert "| Tidal |" in md
+
+
+# --- end-to-end dry-run over a temp repo (no network) ----------------------
+def test_run_dry_run_no_mutation(tmp_path, monkeypatch):
+    pl_dir = tmp_path / "custom_components" / "beatify" / "playlists"
+    pl_dir.mkdir(parents=True)
+    playlist = {
+        "name": "Test", "version": "1.0", "tags": [],
+        "songs": [{
+            "artist": "A", "title": "T", "year": 2000,
+            "uri": "spotify:track:" + "a" * 22,
+            "isrc": "USRE19901615",
+            "fun_fact": "", "fun_fact_de": "", "fun_fact_es": "",
+            "fun_fact_fr": "", "fun_fact_nl": "",
+        }],
+    }
+    f = pl_dir / "test.json"
+    f.write_text(json.dumps(playlist))
+
+    # No network should be hit in dry-run: gaps are detected and resolvers are
+    # called, so mock them to assert no mutation reaches disk anyway.
+    monkeypatch.setattr(bf, "fetch_odesli", lambda *a, **k: {
+        "linksByPlatform": {"tidal": {"entityUniqueId": "TIDAL_SONG::1"}},
+        "entitiesByUniqueId": {"TIDAL_SONG::1": {"id": "1"}},
+    })
+    monkeypatch.setattr(bf, "fetch_deezer_isrc", lambda *a, **k: None)
+    monkeypatch.setattr(bf.time, "sleep", lambda s: None)
+    monkeypatch.delenv("YOUTUBE_API_KEY", raising=False)
+
+    out = tmp_path / "coverage.md"
+    rc = bf.main([
+        "--repo-root", str(tmp_path), "--output", str(out),
+        "--state", str(tmp_path / "state.json"), "--odesli-sleep", "0",
+    ])
+    assert rc == 0
+    # Dry-run: report written, JSON untouched.
+    assert out.exists()
+    assert json.loads(f.read_text())["songs"][0].get("uri_tidal") is None
+    assert "DRY-RUN" in out.read_text()
+
+
+def test_run_apply_writes_uri(tmp_path, monkeypatch):
+    pl_dir = tmp_path / "custom_components" / "beatify" / "playlists"
+    pl_dir.mkdir(parents=True)
+    playlist = {
+        "name": "Test", "version": "1.0", "tags": [],
+        "songs": [{
+            "artist": "A", "title": "T", "year": 2000,
+            "uri": "spotify:track:" + "a" * 22,
+            "fun_fact": "", "fun_fact_de": "", "fun_fact_es": "",
+            "fun_fact_fr": "", "fun_fact_nl": "",
+        }],
+    }
+    f = pl_dir / "test.json"
+    f.write_text(json.dumps(playlist))
+
+    monkeypatch.setattr(bf, "fetch_odesli", lambda *a, **k: {
+        "linksByPlatform": {
+            "tidal": {"entityUniqueId": "TIDAL_SONG::42"},
+            "deezer": {"entityUniqueId": "DEEZER_SONG::99"},
+        },
+        "entitiesByUniqueId": {
+            "TIDAL_SONG::42": {"id": "42"},
+            "DEEZER_SONG::99": {"id": "99"},
+        },
+    })
+    monkeypatch.setattr(bf.time, "sleep", lambda s: None)
+    monkeypatch.delenv("YOUTUBE_API_KEY", raising=False)
+
+    rc = bf.main([
+        "--repo-root", str(tmp_path), "--apply",
+        "--output", str(tmp_path / "coverage.md"),
+        "--state", str(tmp_path / "state.json"), "--odesli-sleep", "0",
+    ])
+    assert rc == 0
+    song = json.loads(f.read_text())["songs"][0]
+    assert song["uri_tidal"] == "tidal://track/42"
+    assert song["uri_deezer"] == "deezer://track/99"


### PR DESCRIPTION
## What this does

Adds a recurring **provider-URI backfill** job (new `provider-uri-backfill` skill) that systematically fills missing per-provider track URIs across all Beatify playlists, plus a per-playlist coverage report. Resolves the three acceptance criteria of #1289 (finds + fills gaps, rate-limit safe, per-playlist coverage report).

For every song that already has a Spotify `uri` but is missing `uri_apple_music` / `uri_tidal` / `uri_deezer` / `uri_youtube_music`, it resolves the gaps and writes **byte-identical** stored URI formats.

## Researched design

- **Odesli / song.link (primary, keyless).** One `GET /v1-alpha.1/links?url=<spotify-url>` per track returns all providers at once. Free tier ~10 req/min → throttled (`--odesli-sleep`, default 6 s) with HTTP 429 exponential backoff.
- **Deezer ISRC verify (secondary).** `https://api.deezer.com/track/isrc:<ISRC>` fills Deezer when Odesli misses it.
- **YouTube Data API (YouTube only).** Odesli's `youtube` field is unreliable for this catalog, so `uri_youtube_music` uses `search.list` (100 quota units each, ~100/day). A **resume-cursor + daily budget** in `.backfill-state.json` caps each run (`--youtube-budget`, default 90) and resumes the catalog scan across days. Key from `YOUTUBE_API_KEY`; absent → phase skipped gracefully (never crashes, never hardcoded).
- **Markdown coverage report** → `docs/provider-coverage.md` (style like `docs/beatify-stats.md`): per-provider catalog summary + per-playlist Apple/Tidal/Deezer/YouTube counts vs total + what each run filled.

## URI formats matched (verified against stored data + live Odesli, 2026-06)

| Field | Stored format | Source |
|---|---|---|
| `uri_tidal` | `tidal://track/<numeric>` | Odesli `TIDAL_SONG::<id>` entity / URL |
| `uri_deezer` | `deezer://track/<numeric>` | Odesli `DEEZER_SONG::<id>`; ISRC fallback |
| `uri_apple_music` | `applemusic://track/<numeric>` | Odesli apple entity **when present** |
| `uri_youtube_music` | `https://music.youtube.com/watch?v=<11-char>` | YouTube `search.list` top hit |

If a provider id can't be confidently extracted in the expected format, that provider is **skipped** for that song — no format is ever guessed.

## Live Odesli validation (real Beatify Spotify URIs, no key)

- `spotify:track:7aUCLXZ4D4UD5sCgIgxqjl` (Ricky Martin — La Copa de la Vida): had no `uri_tidal`/`uri_deezer` → Odesli `entityUniqueId` `TIDAL_SONG::33833948` / `DEEZER_SONG::13111375` → **filled** `tidal://track/33833948`, `deezer://track/13111375`.
- `spotify:track:0ktdPRYjxiA6Grcy1sBO7w` (Giorgio Moroder — To Be Number One): → `tidal://track/150210255`, `deezer://track/1035796702` (Deezer id matches the format of existing stored values exactly).
- Deezer ISRC endpoint cross-check: `USRE19901615` → `id 2268878307` (“All Together Now”) → `deezer://track/2268878307`.

## Honest readiness / risk

- **Apple Music via Odesli is unreliable.** In live probes the keyless Odesli API returned **no Apple Music links** for multiple mainstream tracks (incl. Blinding Lights, Cut To The Feeling, even with `userCountry=US`), while Tidal/Deezer came back every time. The skill fills Apple when Odesli surfaces it, but the realistic primary for Apple gaps remains the existing `playlist-health-check` Mode 2 (Apple Music API + per-region ISRC). Documented in SKILL.md.
- **YouTube phase is unexercised** in this PR — it requires `YOUTUBE_API_KEY` (not set here). The pure logic (resume-cursor, daily-budget accounting, id extraction) is unit-tested with mocked HTTP; the live `search.list` path has not been run.
- **`--apply` not run at scale.** The script defaults to **dry-run** (report only); JSON writes are gated behind `--apply`. The committed `docs/provider-coverage.md` is a coverage snapshot, not a mutation. Mass-filling 2000+ files is a deliberate follow-up.
- Current catalog coverage (from the committed report): Apple 90.8%, Tidal 52.1% (biggest gap), Deezer 89.8%, YouTube 96.7% of 4495 songs.

## Tests

`tests/unit/test_provider_uri_backfill.py` — 27 unit tests, mocked HTTP, no network: Odesli→URI mapping per provider (incl. entity/URL fallback + non-numeric skip), gap detection, coverage aggregation, resume-cursor / daily-budget roundtrip (daily reset + cursor carry-over), 429 backoff, Deezer-ISRC + YouTube id extraction, and end-to-end dry-run (no mutation) + `--apply` (writes) over a temp repo.

Full suite: **869 passed, 2 skipped** (pre-existing skips). `ruff check` clean on the new files. `validate_playlists.py` still green.

## Scope

Touches only `.claude/skills/provider-uri-backfill/**`, `docs/provider-coverage.md`, and the new test. No `www/**`, no schema change. No `uri_amazon_music` field exists → Amazon out of scope. iTunes Search deliberately not used (ban risk).

Closes #1289.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
