### PR TITLE
refactor(state): observational phase-transition table at _set_phase (#1273)

### DIFF
--- a/custom_components/beatify/game/state.py
+++ b/custom_components/beatify/game/state.py
@@ -318,10 +318,7 @@ class GameState(LeaderboardMixin, TtsAnnouncerMixin):
         # Same-phase writes and restores are exempt (see the table comment).
         if not restore and new_phase is not self.phase:
             allowed = _VALID_PHASE_TRANSITIONS.get(self.phase, frozenset())
-            if (
-                new_phase not in _UNIVERSAL_PHASE_TARGETS
-                and new_phase not in allowed
-            ):
+            if new_phase not in _UNIVERSAL_PHASE_TARGETS and new_phase not in allowed:
                 _LOGGER.warning(
                     "Unexpected phase transition %s -> %s (not in transition "
                     "table); proceeding. If this is a new legitimate edge, add "

--- a/custom_components/beatify/game/state.py
+++ b/custom_components/beatify/game/state.py
@@ -95,6 +95,47 @@ class GamePhase(Enum):
     PAUSED = "PAUSED"
 
 
+# ---------------------------------------------------------------------------
+# Phase-transition table (Issue #1273, AC#1 consolidation increment)
+# ---------------------------------------------------------------------------
+#
+# The legal *forward* phase transitions, derived from every ``_set_phase`` call
+# site in this module. This makes the transition graph an explicit, auditable
+# data structure layered on the single ``_set_phase`` chokepoint — the exact
+# follow-up the ``_set_phase`` docstring invited ("Follow-up increments can
+# layer a transition table on top of this single chokepoint").
+#
+# IMPORTANT — observational, not enforcing: ``_set_phase`` only logs a WARNING
+# when an *unexpected* edge is taken; it never raises and never blocks the
+# write. This is deliberately behaviour-preserving: it surfaces drift (a new
+# transition added without updating this table, or a genuinely illegal flip)
+# without ever changing control flow. Exemptions: same-phase writes (e.g. the
+# PLAYING→PLAYING next-round commit) and ``restore=True`` resumes are never
+# checked — a resume legitimately restores PAUSED→PLAYING / PAUSED→REVEAL.
+#
+# Edges (source → allowed targets):
+#   * LOBBY and END are valid targets from ANY phase — ``start_game`` /
+#     rematch / reset re-initialise to LOBBY from anywhere, and
+#     ``advance_to_end`` is a documented universal terminal.
+#   * LOBBY   → PLAYING            (start_game)
+#   * PLAYING → REVEAL, PAUSED     (reveal / pause)
+#   * REVEAL  → PLAYING, PAUSED    (next-round commit / pause)
+# Same-phase forward writes (LOBBY→LOBBY re-init, PLAYING→PLAYING next round)
+# are covered by the same-phase exemption, not by this table.
+_VALID_PHASE_TRANSITIONS: dict[GamePhase, frozenset[GamePhase]] = {
+    GamePhase.LOBBY: frozenset({GamePhase.PLAYING}),
+    GamePhase.PLAYING: frozenset({GamePhase.REVEAL, GamePhase.PAUSED}),
+    GamePhase.REVEAL: frozenset({GamePhase.PLAYING, GamePhase.PAUSED}),
+    GamePhase.PAUSED: frozenset(),
+    GamePhase.END: frozenset(),
+}
+
+# Targets reachable from *any* source phase (re-init + universal terminal).
+_UNIVERSAL_PHASE_TARGETS: frozenset[GamePhase] = frozenset(
+    {GamePhase.LOBBY, GamePhase.END}
+)
+
+
 class GameState(LeaderboardMixin, TtsAnnouncerMixin):
     """Manages game state and phase transitions.
 
@@ -237,9 +278,12 @@ class GameState(LeaderboardMixin, TtsAnnouncerMixin):
     #     it untouched (resume must not restart the auto-advance countdown).
     #   * registered state observers (#441) are notified on every phase change.
     #
-    # This centralises the *write* path without yet modelling explicit
-    # transition guards. Follow-up increments can layer a transition table on
-    # top of this single chokepoint (see issue / migration path).
+    # This centralises the *write* path. An explicit, auditable transition
+    # table (``_VALID_PHASE_TRANSITIONS`` above) is now layered on top of this
+    # chokepoint: ``_set_phase`` logs a WARNING on any forward edge missing from
+    # the table. The check is observational only — it never raises or blocks, so
+    # behaviour is unchanged; it exists to surface drift (an un-tabled new edge
+    # or a genuinely illegal flip).
 
     def _set_phase(
         self, new_phase: GamePhase, *, notify: bool = True, restore: bool = False
@@ -267,6 +311,24 @@ class GameState(LeaderboardMixin, TtsAnnouncerMixin):
                 False (forward transitions own the timestamp invariant).
 
         """
+        # #1273 (AC#1 consolidation): observational transition-validity check.
+        # Logs — never raises, never blocks — when a forward edge isn't in the
+        # explicit transition table, so drift (an un-tabled new transition or a
+        # genuinely illegal flip) is surfaced without altering control flow.
+        # Same-phase writes and restores are exempt (see the table comment).
+        if not restore and new_phase is not self.phase:
+            allowed = _VALID_PHASE_TRANSITIONS.get(self.phase, frozenset())
+            if (
+                new_phase not in _UNIVERSAL_PHASE_TARGETS
+                and new_phase not in allowed
+            ):
+                _LOGGER.warning(
+                    "Unexpected phase transition %s -> %s (not in transition "
+                    "table); proceeding. If this is a new legitimate edge, add "
+                    "it to _VALID_PHASE_TRANSITIONS (#1273).",
+                    self.phase.value,
+                    new_phase.value,
+                )
         self.phase = new_phase
         # #1048: the REVEAL-entry timestamp is owned entirely by forward phase
         # transitions. Entering REVEAL stamps it; any other phase clears it.

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -1413,3 +1413,70 @@ class TestSetPhaseSSOT:
         state.register_state_callback(lambda: calls.append(1))
         state._set_phase(GamePhase.PLAYING, restore=True)
         assert calls == [1]
+
+    # -- Transition-validity table (#1273 AC#1 consolidation) ----------------
+
+    @pytest.mark.parametrize(
+        ("src", "dst"),
+        [
+            # Forward edges from the table.
+            (GamePhase.LOBBY, GamePhase.PLAYING),
+            (GamePhase.PLAYING, GamePhase.REVEAL),
+            (GamePhase.PLAYING, GamePhase.PAUSED),
+            (GamePhase.REVEAL, GamePhase.PLAYING),
+            (GamePhase.REVEAL, GamePhase.PAUSED),
+            # Universal targets reachable from any phase (re-init / terminal).
+            (GamePhase.PLAYING, GamePhase.LOBBY),
+            (GamePhase.REVEAL, GamePhase.LOBBY),
+            (GamePhase.PAUSED, GamePhase.LOBBY),
+            (GamePhase.END, GamePhase.LOBBY),
+            (GamePhase.PLAYING, GamePhase.END),
+            (GamePhase.REVEAL, GamePhase.END),
+            (GamePhase.PAUSED, GamePhase.END),
+        ],
+    )
+    def test_valid_transition_does_not_warn(self, src, dst, caplog):
+        state = make_game_state()
+        state.phase = src
+        with caplog.at_level("WARNING"):
+            state._set_phase(dst)
+        assert state.phase == dst
+        assert "Unexpected phase transition" not in caplog.text
+
+    def test_same_phase_write_does_not_warn(self, caplog):
+        # The PLAYING->PLAYING next-round commit must not be flagged.
+        state = make_game_state()
+        state.phase = GamePhase.PLAYING
+        with caplog.at_level("WARNING"):
+            state._set_phase(GamePhase.PLAYING)
+        assert "Unexpected phase transition" not in caplog.text
+
+    def test_restore_never_warns(self, caplog):
+        # A resume restores PAUSED->PLAYING/REVEAL — exempt from the check.
+        for dst in (GamePhase.PLAYING, GamePhase.REVEAL):
+            state = make_game_state()
+            state.phase = GamePhase.PAUSED
+            with caplog.at_level("WARNING"):
+                state._set_phase(dst, restore=True)
+            assert "Unexpected phase transition" not in caplog.text
+
+    def test_unexpected_transition_warns_but_proceeds(self, caplog):
+        # LOBBY->REVEAL is not a legal forward edge: it must WARN yet still
+        # perform the write (observational, never blocking).
+        state = make_game_state()
+        state.phase = GamePhase.LOBBY
+        with caplog.at_level("WARNING"):
+            state._set_phase(GamePhase.REVEAL)
+        assert "Unexpected phase transition" in caplog.text
+        assert "LOBBY -> REVEAL" in caplog.text
+        assert state.phase == GamePhase.REVEAL  # write still happened
+
+    def test_paused_to_playing_without_restore_warns(self, caplog):
+        # Resuming PAUSED->PLAYING is legal ONLY via restore=True; a plain
+        # forward write of that edge is unexpected and should be flagged.
+        state = make_game_state()
+        state.phase = GamePhase.PAUSED
+        with caplog.at_level("WARNING"):
+            state._set_phase(GamePhase.PLAYING)
+        assert "Unexpected phase transition" in caplog.text
+        assert state.phase == GamePhase.PLAYING


### PR DESCRIPTION
Refs #1273 (advances **AC#1** — "definierte Phasen + Transitions an einer Stelle").

## What this increment does
Layers an explicit, auditable `_VALID_PHASE_TRANSITIONS` table on top of the existing single `_set_phase` chokepoint — exactly the follow-up the `_set_phase` docstring already invited ("Follow-up increments can layer a transition table on top of this single chokepoint"). `_set_phase` now logs a WARNING when a forward transition isn't in the table, surfacing drift (an un-tabled new edge, or a genuinely illegal flip).

## Why it's bounded & behavior-preserving
- The check is **observational only**: it never raises and never blocks — the phase write always happens, control flow is unchanged.
- **Same-phase writes** (e.g. the `PLAYING→PLAYING` next-round commit) and **`restore=True` resumes** (`PAUSED→PLAYING` / `PAUSED→REVEAL`) are exempt, matching the SSOT semantics established in #1322/#1329.
- The table was derived from every existing `_set_phase` call site in `state.py`; `LOBBY` and `END` are universal targets (re-init via `start_game`/rematch/reset; `advance_to_end` terminal).
- Backend-only. No `www/**` touched, so no bundle/cache-buster/`sw.js` concerns.

## Which AC
Advances **AC#1**: makes the phase-transition graph an explicit data structure with drift-detection, hardening the SSOT chokepoint. AC#2 (recovery triggers) and AC#3 (FE timer authority) remain open and out of scope here.

## Readiness assessment
- [ ] Ready to merge
- [x] Borderline — see notes
- [ ] Not ready — needs human review

**Honest summary:** Solid and low-risk — the change is non-enforcing (log-only) and cannot alter game behavior, and the transition table is exercised by 17 new parametrized tests covering every legal edge, same-phase, restore, and two unexpected-edge cases. Marked Borderline only because it is not live-validated on a running HA instance (the WARNING path is verified by unit tests, not observed in production logs).

## Test plan
- `python3 -m pytest` → **858 passed, 2 skipped** (full suite green).
- `python3 -m ruff check` on changed files → clean.
- New `TestSetPhaseSSOT` cases assert: every legal edge + same-phase + restore produce NO warning; `LOBBY→REVEAL` and a non-restore `PAUSED→PLAYING` warn yet still write.

## Risk assessment
- **Blast radius:** `custom_components/beatify/game/state.py` (`_set_phase` + module-level table), `tests/unit/test_state.py`.
- **What could go wrong:** if a legitimate transition was missed in the table, it would emit a benign WARNING (no functional impact) until the table is extended. No control-flow risk.
- **What I did NOT test:** live HA runtime log output; only unit-level verification of the warning path.

🤖 Auto-generated by issue-triage routine