### PR TITLE
refactor: extract media/lights output cluster from state.py God-Object (#1271)

### DIFF
--- a/custom_components/beatify/game/state.py
+++ b/custom_components/beatify/game/state.py
@@ -47,7 +47,6 @@ from custom_components.beatify.const import (
     ROUND_DURATION_MIN,
     STREAK_MILESTONES,
     TITLE_ARTIST_VOTE_WINDOW_SECONDS,
-    VOLUME_STEP,
 )
 
 from .challenges import (
@@ -70,6 +69,7 @@ from .scoring import (
 from .protocols import MediaPlayerProtocol, PartyLightsProtocol
 from .serializers import GameStateSerializer
 from .state_leaderboard import LeaderboardMixin
+from .state_media import MediaControlMixin
 from .state_tts import TtsAnnouncerMixin
 
 from .types import RoundAnalytics, _get_decade_label
@@ -136,7 +136,7 @@ _UNIVERSAL_PHASE_TARGETS: frozenset[GamePhase] = frozenset(
 )
 
 
-class GameState(LeaderboardMixin, TtsAnnouncerMixin):
+class GameState(LeaderboardMixin, MediaControlMixin, TtsAnnouncerMixin):
     """Manages game state and phase transitions.
 
     The TTS / spoken-announcement subsystem (Issue #1271 first-increment
@@ -144,6 +144,10 @@ class GameState(LeaderboardMixin, TtsAnnouncerMixin):
 
     The leaderboard / ranking subsystem (Issue #1271 next-increment
     extraction) lives in :class:`~custom_components.beatify.game.state_leaderboard.LeaderboardMixin`.
+
+    The media-player & party-lights output subsystem (Issue #1271
+    next-increment extraction) lives in
+    :class:`~custom_components.beatify.game.state_media.MediaControlMixin`.
     """
 
     def __init__(self, time_fn: Callable[[], float] | None = None) -> None:
@@ -2452,102 +2456,6 @@ class GameState(LeaderboardMixin, TtsAnnouncerMixin):
         await self.announce_podium()
 
         _LOGGER.info("Game advanced to END phase")
-
-    async def stop_media(self) -> None:
-        """Stop media playback if a media player service is available (#321)."""
-        if self._media_player_service:
-            await self._media_player_service.stop()
-
-    async def set_volume_on_player(self, level: float) -> bool:
-        """Apply volume level to the media player (#321).
-
-        Returns:
-            True if successful, False if failed or no media player.
-        """
-        if self._media_player_service:
-            return await self._media_player_service.set_volume(level)
-        return False
-
-    async def seek_forward(self, seconds: int) -> bool:
-        """Seek media player forward by given seconds (#498)."""
-        if self._media_player_service:
-            return await self._media_player_service.seek_forward(seconds)
-        return False
-
-    async def play_deferred_song(self, song: dict) -> bool:
-        """Play a song that was deferred for intro splash (#321).
-
-        Returns:
-            True if playback started, False otherwise.
-        """
-        if self._media_player_service:
-            return await self._media_player_service.play_song(song)
-        return False
-
-    # ------------------------------------------------------------------
-    # Party Lights (#331)
-    # ------------------------------------------------------------------
-
-    async def configure_party_lights(
-        self,
-        entity_ids: list[str],
-        intensity: str = "medium",
-        light_mode: str = "dynamic",
-        wled_presets: dict[str, int] | None = None,
-    ) -> None:
-        """Configure and start Party Lights for the game."""
-        # Lazy import: only the concrete class for instantiation; type hints
-        # use PartyLightsProtocol (module-level) to keep the import graph acyclic.
-        from custom_components.beatify.services.lights import PartyLightsService  # noqa: PLC0415
-
-        self._party_lights = PartyLightsService(self._hass)
-        await self._party_lights.start(entity_ids, intensity, light_mode, wled_presets)
-
-    async def disable_party_lights(self) -> None:
-        """Stop Party Lights and restore original light states."""
-        if self._party_lights:
-            await self._party_lights.stop()
-            self._party_lights = None
-
-    async def _lights_set_phase(self, phase: GamePhase) -> None:
-        """Set Party Lights phase color (fire-and-forget)."""
-        if self._party_lights:
-            try:
-                await self._party_lights.set_phase(phase)
-            except Exception:  # noqa: BLE001
-                _LOGGER.warning("Party Lights phase change failed")
-
-    async def _lights_flash(self, color: str) -> None:
-        """Flash Party Lights (fire-and-forget)."""
-        if self._party_lights:
-            try:
-                task = asyncio.create_task(self._party_lights.flash(color))
-                self._bg_tasks.add(task)
-                task.add_done_callback(self._bg_tasks.discard)
-            except Exception:  # noqa: BLE001
-                _LOGGER.warning("Party Lights flash failed")
-
-    def adjust_volume(self, direction: str) -> float:
-        """
-        Adjust volume level by step (Story 6.4).
-
-        Args:
-            direction: "up" to increase, "down" to decrease
-
-        Returns:
-            New volume level (clamped 0.0 to 1.0)
-
-        """
-        # Sync with actual media player volume before adjusting
-        if self._media_player_service:
-            self.volume_level = self._media_player_service.get_volume()
-
-        if direction == "up":
-            self.volume_level = min(1.0, self.volume_level + VOLUME_STEP)
-        elif direction == "down":
-            self.volume_level = max(0.0, self.volume_level - VOLUME_STEP)
-
-        return self.volume_level
 
     def calculate_round_analytics(self) -> RoundAnalytics:
         """Calculate round analytics (Story 13.3). Delegates to ScoringService (#139)."""

--- a/custom_components/beatify/game/state_media.py
+++ b/custom_components/beatify/game/state_media.py
@@ -1,0 +1,144 @@
+"""Media-player & party-lights output subsystem for :class:`GameState`.
+
+Issue #1271 next-increment extraction: the external-output cluster — media
+transport (``stop_media``, ``set_volume_on_player``, ``seek_forward``,
+``play_deferred_song``), party-lights control (``configure_party_lights``,
+``disable_party_lights``, ``_lights_set_phase``, ``_lights_flash``) and the
+host-side ``adjust_volume`` helper — is pulled out of the ``game/state.py``
+God-Object into this ``MediaControlMixin``.
+
+The mixin is **behavior-preserving**: it carries the exact same methods that
+previously lived on ``GameState`` (originally Stories 6.4 / Issues #321 /
+#331 / #498). ``GameState`` inherits them, so its public API and every
+caller / test are unchanged.
+
+The mixin relies on attributes the host class owns and that live on ``self``
+at runtime:
+
+* ``self._media_player_service`` — :class:`MediaPlayerProtocol` instance (or
+  ``None`` before the first round), the transport all playback flows through.
+* ``self._party_lights`` — :class:`PartyLightsProtocol` instance (or ``None``).
+* ``self._hass`` — Home Assistant instance (to construct the lights service).
+* ``self._bg_tasks`` — set of fire-and-forget background tasks.
+* ``self.volume_level`` — current game volume, clamped 0.0–1.0.
+
+It carries no state of its own and imports nothing from ``state.py`` at
+runtime (``GamePhase`` is a typing-only import), so the extraction introduces
+no cyclic imports.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import TYPE_CHECKING
+
+from custom_components.beatify.const import VOLUME_STEP
+
+if TYPE_CHECKING:
+    from .state import GamePhase
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class MediaControlMixin:
+    """Media-player & party-lights output behavior for :class:`GameState`.
+
+    See module docstring for the host-class attributes this mixin reads.
+    """
+
+    async def stop_media(self) -> None:
+        """Stop media playback if a media player service is available (#321)."""
+        if self._media_player_service:
+            await self._media_player_service.stop()
+
+    async def set_volume_on_player(self, level: float) -> bool:
+        """Apply volume level to the media player (#321).
+
+        Returns:
+            True if successful, False if failed or no media player.
+        """
+        if self._media_player_service:
+            return await self._media_player_service.set_volume(level)
+        return False
+
+    async def seek_forward(self, seconds: int) -> bool:
+        """Seek media player forward by given seconds (#498)."""
+        if self._media_player_service:
+            return await self._media_player_service.seek_forward(seconds)
+        return False
+
+    async def play_deferred_song(self, song: dict) -> bool:
+        """Play a song that was deferred for intro splash (#321).
+
+        Returns:
+            True if playback started, False otherwise.
+        """
+        if self._media_player_service:
+            return await self._media_player_service.play_song(song)
+        return False
+
+    # ------------------------------------------------------------------
+    # Party Lights (#331)
+    # ------------------------------------------------------------------
+
+    async def configure_party_lights(
+        self,
+        entity_ids: list[str],
+        intensity: str = "medium",
+        light_mode: str = "dynamic",
+        wled_presets: dict[str, int] | None = None,
+    ) -> None:
+        """Configure and start Party Lights for the game."""
+        # Lazy import: only the concrete class for instantiation; type hints
+        # use PartyLightsProtocol (module-level) to keep the import graph acyclic.
+        from custom_components.beatify.services.lights import PartyLightsService  # noqa: PLC0415
+
+        self._party_lights = PartyLightsService(self._hass)
+        await self._party_lights.start(entity_ids, intensity, light_mode, wled_presets)
+
+    async def disable_party_lights(self) -> None:
+        """Stop Party Lights and restore original light states."""
+        if self._party_lights:
+            await self._party_lights.stop()
+            self._party_lights = None
+
+    async def _lights_set_phase(self, phase: GamePhase) -> None:
+        """Set Party Lights phase color (fire-and-forget)."""
+        if self._party_lights:
+            try:
+                await self._party_lights.set_phase(phase)
+            except Exception:  # noqa: BLE001
+                _LOGGER.warning("Party Lights phase change failed")
+
+    async def _lights_flash(self, color: str) -> None:
+        """Flash Party Lights (fire-and-forget)."""
+        if self._party_lights:
+            try:
+                task = asyncio.create_task(self._party_lights.flash(color))
+                self._bg_tasks.add(task)
+                task.add_done_callback(self._bg_tasks.discard)
+            except Exception:  # noqa: BLE001
+                _LOGGER.warning("Party Lights flash failed")
+
+    def adjust_volume(self, direction: str) -> float:
+        """
+        Adjust volume level by step (Story 6.4).
+
+        Args:
+            direction: "up" to increase, "down" to decrease
+
+        Returns:
+            New volume level (clamped 0.0 to 1.0)
+
+        """
+        # Sync with actual media player volume before adjusting
+        if self._media_player_service:
+            self.volume_level = self._media_player_service.get_volume()
+
+        if direction == "up":
+            self.volume_level = min(1.0, self.volume_level + VOLUME_STEP)
+        elif direction == "down":
+            self.volume_level = max(0.0, self.volume_level - VOLUME_STEP)
+
+        return self.volume_level


### PR DESCRIPTION
Incremental refactor toward #1271 (does **not** close it — see open AC below).

This is one further behavior-preserving extraction increment, following the
already-merged `LeaderboardMixin` (PR #1328) and `TtsAnnouncerMixin` (PR #1321).

## What changed
Pulled the cohesive **external-output** cluster out of `game/state.py` into a
new `MediaControlMixin` (`game/state_media.py`):

- Media transport: `stop_media`, `set_volume_on_player`, `seek_forward`, `play_deferred_song` (#321/#498)
- Party lights: `configure_party_lights`, `disable_party_lights`, `_lights_set_phase`, `_lights_flash` (#331)
- `adjust_volume` (Story 6.4)

`GameState` now inherits `MediaControlMixin` alongside the existing mixins, so
its public API is byte-identical and **no call sites change**. The cluster is
loosely coupled — it only reads host attributes (`_media_player_service`,
`_party_lights`, `_hass`, `_bg_tasks`, `volume_level`) plus the `VOLUME_STEP`
const, which moved into the mixin. The unused `VOLUME_STEP` import was removed
from `state.py`. `GamePhase` is a typing-only import in the mixin (under
`from __future__ import annotations`), so **no cyclic imports** are introduced.

**Line reduction:** `state.py` 2602 -> 2510 (-92 lines).

## Verification
- `pytest tests/unit tests/integration` — **885 passed, 2 skipped** (Python 3.13, CI parity)
- `ruff check .` — clean (full repo, ruff 0.15.7 = CI pin)
- `ruff format --check .` — clean (84 files already formatted)
- No files under `custom_components/beatify/www/**` touched -> frontend bundle guardrail N/A
- `state_media.py` stays out of the mypy gate, matching the precedent set by `state_leaderboard.py` / `state_tts.py`

## Open AC (why #1271 stays open)
- [ ] `state.py < ~800 lines` — **not yet met** (2510). Further extraction increments needed (lifecycle, scoring, vote-window clusters).
- [x] No cyclic imports
- [x] pytest green, no behavior change

## Risk
- **Blast radius:** `game/state.py` + new `game/state_media.py` only.
- **What could go wrong:** MRO method resolution — covered, the 885-test suite exercises `GameState` through the real class (149 media/light/song-tagged tests pass).
- **Not tested:** live Home Assistant runtime (media-player / party-lights hardware) — tests use the conftest HA stubs, same as all existing coverage.

🤖 Auto-generated by issue-triage routine