### PR TITLE
refactor: extract player-lifecycle cluster from state.py God-Object (#1271)

### DIFF
--- a/custom_components/beatify/game/state.py
+++ b/custom_components/beatify/game/state.py
@@ -71,6 +71,7 @@ from .serializers import GameStateSerializer
 from .state_challenge import ChallengeMixin
 from .state_leaderboard import LeaderboardMixin
 from .state_media import MediaControlMixin
+from .state_player import PlayerLifecycleMixin
 from .state_tts import TtsAnnouncerMixin
 
 from .types import RoundAnalytics, _get_decade_label
@@ -141,6 +142,7 @@ class GameState(
     ChallengeMixin,
     LeaderboardMixin,
     MediaControlMixin,
+    PlayerLifecycleMixin,
     TtsAnnouncerMixin,
 ):
     """Manages game state and phase transitions.
@@ -158,6 +160,11 @@ class GameState(
     The challenge-delegation subsystem (Issue #1271 next-increment
     extraction, stacked on the media extraction) lives in
     :class:`~custom_components.beatify.game.state_challenge.ChallengeMixin`.
+
+    The player-lifecycle subsystem (Issue #1271 next-increment extraction:
+    PlayerRegistry + PowerUpManager delegation — player lookups, sessions,
+    reactions, admin, steal/streak/bet pass-throughs) lives in
+    :class:`~custom_components.beatify.game.state_player.PlayerLifecycleMixin`.
     """
 
     def __init__(self, time_fn: Callable[[], float] | None = None) -> None:
@@ -358,24 +365,9 @@ class GameState(
         return self._now()
 
     # ------------------------------------------------------------------
-    # Player registry delegation (keep public interface identical)
+    # Player registry / power-up delegation lives in PlayerLifecycleMixin
+    # (Issue #1271 extraction). See game/state_player.py.
     # ------------------------------------------------------------------
-
-    @property
-    def players(self) -> dict[str, PlayerSession]:
-        """Player dict — delegated to PlayerRegistry."""
-        return self._player_registry.players
-
-    @players.setter
-    def players(self, value: dict[str, PlayerSession]) -> None:
-        self._player_registry.players = value
-
-    @property
-    def leader(self) -> PlayerSession | None:
-        """Get current leader player (cached per state change)."""
-        if not self.players:
-            return None
-        return max(self.players.values(), key=lambda p: p.score)
 
     # ------------------------------------------------------------------
     # RoundManager delegation (keep public interface identical)
@@ -516,26 +508,9 @@ class GameState(
         self._round_manager.metadata_pending = value
 
     # ------------------------------------------------------------------
-    # Power-up delegation properties (keep public interface identical)
+    # Power-up delegation properties live in PlayerLifecycleMixin
+    # (Issue #1271 extraction). See game/state_player.py.
     # ------------------------------------------------------------------
-
-    @property
-    def streak_achievements(self) -> dict[str, int]:
-        """Streak achievement counters."""
-        return self._powerup_manager.streak_achievements
-
-    @streak_achievements.setter
-    def streak_achievements(self, value: dict[str, int]) -> None:
-        self._powerup_manager.streak_achievements = value
-
-    @property
-    def bet_tracking(self) -> dict[str, int]:
-        """Bet outcome counters."""
-        return self._powerup_manager.bet_tracking
-
-    @bet_tracking.setter
-    def bet_tracking(self, value: dict[str, int]) -> None:
-        self._powerup_manager.bet_tracking = value
 
     def get_song_difficulty(self, song_uri: str) -> dict[str, Any] | None:
         """Get song difficulty rating — delegated to StatsService."""
@@ -1030,59 +1005,10 @@ class GameState(
 
         return True
 
-    def get_average_score(self) -> int:
-        """Calculate average score of all current players. Delegates to PlayerRegistry."""
-        return self._player_registry.get_average_score()
-
-    def add_player(
-        self, name: str, ws: web.WebSocketResponse
-    ) -> tuple[bool, str | None]:
-        """Add a player to the game. Delegates to PlayerRegistry."""
-        return self._player_registry.add_player(
-            name, ws, self.phase, self.get_average_score
-        )
-
-    def get_player(self, name: str) -> PlayerSession | None:
-        """Get player by name. Delegates to PlayerRegistry."""
-        return self._player_registry.get_player(name)
-
-    def get_player_by_session_id(self, session_id: str) -> PlayerSession | None:
-        """Get player by session ID. Delegates to PlayerRegistry."""
-        return self._player_registry.get_player_by_session_id(session_id)
-
-    def get_player_by_ws(self, ws: web.WebSocketResponse) -> PlayerSession | None:
-        """Get player by WebSocket connection. Delegates to PlayerRegistry."""
-        return self._player_registry.get_player_by_ws(ws)
-
-    def record_reaction(self, player_name: str, emoji: str) -> bool:
-        """Record a player reaction. Delegates to PlayerRegistry."""
-        return self._player_registry.record_reaction(player_name, emoji)
-
-    def get_steal_targets(self, stealer_name: str) -> list[str]:
-        """Get list of players who can be stolen from (Story 15.3). Delegates to PowerUpManager."""
-        return self._powerup_manager.get_steal_targets(stealer_name, self.players)
-
-    def use_steal(self, stealer_name: str, target_name: str) -> dict[str, Any]:
-        """Execute steal power-up (Story 15.3). Delegates to PowerUpManager."""
-        return self._powerup_manager.use_steal(
-            stealer_name, target_name, self.players, self.phase, self._now()
-        )
-
-    def remove_player(self, name: str) -> None:
-        """Remove player from game. Delegates to PlayerRegistry."""
-        self._player_registry.remove_player(name)
-
-    def clear_all_sessions(self) -> None:
-        """Clear all session mappings for game reset. Delegates to PlayerRegistry."""
-        self._player_registry.clear_all_sessions()
-
-    def get_players_state(self) -> list[dict[str, Any]]:
-        """Get player list for state broadcast. Delegates to PlayerRegistry."""
-        return self._player_registry.get_players_state()
-
-    def all_submitted(self) -> bool:
-        """Check if all connected players have submitted. Delegates to PlayerRegistry."""
-        return self._player_registry.all_submitted()
+    # ------------------------------------------------------------------
+    # Player lifecycle / lookup + power-up delegation lives in
+    # PlayerLifecycleMixin (Issue #1271 extraction). See game/state_player.py.
+    # ------------------------------------------------------------------
 
     def check_all_guesses_complete(self) -> bool:
         """
@@ -1248,10 +1174,6 @@ class GameState(
             "is_first_game": comparison["is_first_game"],
             "message": message_data,
         }
-
-    def set_admin(self, name: str) -> bool:
-        """Mark a player as admin. Delegates to PlayerRegistry."""
-        return self._player_registry.set_admin(name)
 
     def _detect_storefront(self) -> str | None:
         """Determine the user's Apple Music storefront for URI resolution.

--- a/custom_components/beatify/game/state_player.py
+++ b/custom_components/beatify/game/state_player.py
@@ -1,0 +1,158 @@
+"""Player-lifecycle delegation subsystem for :class:`GameState`.
+
+Issue #1271 next-increment extraction (off ``origin/main``, following the
+TTS / leaderboard / media-lights / challenge-delegation cuts): the
+**player-lifecycle** cluster is pulled out of the ``game/state.py``
+God-Object into this ``PlayerLifecycleMixin``.
+
+The cluster is the thin pass-through layer between ``GameState`` and its two
+player-owning subsystems:
+
+* :class:`~custom_components.beatify.game.player_registry.PlayerRegistry`
+  (``self._player_registry``) — player dict, lookups (by name / session-id /
+  WebSocket), sessions, reactions, admin flag, submitted-state aggregates and
+  the average-score helper, and
+* :class:`~custom_components.beatify.game.powerups.PowerUpManager`
+  (``self._powerup_manager``) — steal targeting / execution and the
+  streak-achievement + bet-tracking counters.
+
+The mixin is **behavior-preserving**: it carries the exact same methods and
+properties that previously lived on ``GameState``, so its public API and every
+caller / test are unchanged.
+
+The mixin relies on attributes the host class owns and that live on ``self``
+at runtime:
+
+* ``self._player_registry`` — the actual player state + lookup logic this
+  layer delegates to.
+* ``self._powerup_manager`` — steal / streak / bet state this layer delegates
+  to.
+* ``self.phase`` — the current :class:`GamePhase`, passed through to
+  ``add_player`` and ``use_steal`` (read-only here; the phase write-path stays
+  on ``GameState``).
+* ``self._now`` — the clock callable, passed through to ``use_steal``.
+
+It carries no state of its own and imports nothing from ``state.py`` at
+runtime (``PlayerSession`` is a typing-only import), so the extraction
+introduces no cyclic imports.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from aiohttp import web
+
+    from .player import PlayerSession
+
+
+class PlayerLifecycleMixin:
+    """Player-lifecycle delegation behavior for :class:`GameState`.
+
+    See module docstring for the host-class attributes this mixin reads.
+    """
+
+    # ------------------------------------------------------------------
+    # Player registry delegation (keep public interface identical)
+    # ------------------------------------------------------------------
+
+    @property
+    def players(self) -> dict[str, PlayerSession]:
+        """Player dict — delegated to PlayerRegistry."""
+        return self._player_registry.players
+
+    @players.setter
+    def players(self, value: dict[str, PlayerSession]) -> None:
+        self._player_registry.players = value
+
+    @property
+    def leader(self) -> PlayerSession | None:
+        """Get current leader player (cached per state change)."""
+        if not self.players:
+            return None
+        return max(self.players.values(), key=lambda p: p.score)
+
+    # ------------------------------------------------------------------
+    # Power-up delegation properties (keep public interface identical)
+    # ------------------------------------------------------------------
+
+    @property
+    def streak_achievements(self) -> dict[str, int]:
+        """Streak achievement counters."""
+        return self._powerup_manager.streak_achievements
+
+    @streak_achievements.setter
+    def streak_achievements(self, value: dict[str, int]) -> None:
+        self._powerup_manager.streak_achievements = value
+
+    @property
+    def bet_tracking(self) -> dict[str, int]:
+        """Bet outcome counters."""
+        return self._powerup_manager.bet_tracking
+
+    @bet_tracking.setter
+    def bet_tracking(self, value: dict[str, int]) -> None:
+        self._powerup_manager.bet_tracking = value
+
+    # ------------------------------------------------------------------
+    # Player lifecycle / lookup delegation (keep public interface identical)
+    # ------------------------------------------------------------------
+
+    def get_average_score(self) -> int:
+        """Calculate average score of all current players. Delegates to PlayerRegistry."""
+        return self._player_registry.get_average_score()
+
+    def add_player(
+        self, name: str, ws: web.WebSocketResponse
+    ) -> tuple[bool, str | None]:
+        """Add a player to the game. Delegates to PlayerRegistry."""
+        return self._player_registry.add_player(
+            name, ws, self.phase, self.get_average_score
+        )
+
+    def get_player(self, name: str) -> PlayerSession | None:
+        """Get player by name. Delegates to PlayerRegistry."""
+        return self._player_registry.get_player(name)
+
+    def get_player_by_session_id(self, session_id: str) -> PlayerSession | None:
+        """Get player by session ID. Delegates to PlayerRegistry."""
+        return self._player_registry.get_player_by_session_id(session_id)
+
+    def get_player_by_ws(self, ws: web.WebSocketResponse) -> PlayerSession | None:
+        """Get player by WebSocket connection. Delegates to PlayerRegistry."""
+        return self._player_registry.get_player_by_ws(ws)
+
+    def record_reaction(self, player_name: str, emoji: str) -> bool:
+        """Record a player reaction. Delegates to PlayerRegistry."""
+        return self._player_registry.record_reaction(player_name, emoji)
+
+    def get_steal_targets(self, stealer_name: str) -> list[str]:
+        """Get list of players who can be stolen from (Story 15.3). Delegates to PowerUpManager."""
+        return self._powerup_manager.get_steal_targets(stealer_name, self.players)
+
+    def use_steal(self, stealer_name: str, target_name: str) -> dict[str, Any]:
+        """Execute steal power-up (Story 15.3). Delegates to PowerUpManager."""
+        return self._powerup_manager.use_steal(
+            stealer_name, target_name, self.players, self.phase, self._now()
+        )
+
+    def remove_player(self, name: str) -> None:
+        """Remove player from game. Delegates to PlayerRegistry."""
+        self._player_registry.remove_player(name)
+
+    def clear_all_sessions(self) -> None:
+        """Clear all session mappings for game reset. Delegates to PlayerRegistry."""
+        self._player_registry.clear_all_sessions()
+
+    def get_players_state(self) -> list[dict[str, Any]]:
+        """Get player list for state broadcast. Delegates to PlayerRegistry."""
+        return self._player_registry.get_players_state()
+
+    def all_submitted(self) -> bool:
+        """Check if all connected players have submitted. Delegates to PlayerRegistry."""
+        return self._player_registry.all_submitted()
+
+    def set_admin(self, name: str) -> bool:
+        """Mark a player as admin. Delegates to PlayerRegistry."""
+        return self._player_registry.set_admin(name)


### PR DESCRIPTION
Refs #1271 (not "Closes" — the AC "state.py < 800 lines" is not yet met; this is one more incremental extraction).

Next clean increment for the `game/state.py` God-Object split, branched off `origin/main` (no stacking). Follows the already-merged TTS / leaderboard / media-lights / challenge-delegation mixin extractions.

## What was extracted
The **player-lifecycle** cluster — the thin pass-through delegation layer between `GameState` and its two player-owning subsystems:
- `PlayerRegistry` (`self._player_registry`): `players` dict + setter, `leader`, `get_average_score`, `add_player`, `get_player`, `get_player_by_session_id`, `get_player_by_ws`, `record_reaction`, `remove_player`, `clear_all_sessions`, `get_players_state`, `all_submitted`, `set_admin`.
- `PowerUpManager` (`self._powerup_manager`): `streak_achievements` + `bet_tracking` properties, `get_steal_targets`, `use_steal`.

Moved verbatim into a new `PlayerLifecycleMixin`; `GameState` now inherits it. This was chosen as the lowest-risk clean cut: every member is pure delegation that reads only `self._player_registry`, `self._powerup_manager`, `self.phase`, `self.players` and `self._now` — no coupling to the score lock, auto-advance task or vote-window cluster.

## Files
- **New:** `custom_components/beatify/game/state_player.py` (`PlayerLifecycleMixin`, 158 lines), typing-only imports (`web`, `PlayerSession`) under `TYPE_CHECKING` to avoid cycles.
- **Changed:** `custom_components/beatify/game/state.py` — removed the moved members, added the mixin to the base list + import, updated the class docstring.

state.py: **2347 → 2269 lines** (−78).

## Readiness assessment
- [x] Ready to merge
- [ ] Borderline — see notes
- [ ] Not ready — needs human review

**Honest summary:** Behavior-preserving move-only refactor. The public API of `GameState` is byte-identical (methods now resolve via inheritance); no call site changed. Mechanical and low-risk. No re-exports needed — no test imports these symbols from `game.state` directly (only `GameState` itself).

## Test plan
- `pytest tests/unit tests/integration`: **885 passed, 2 skipped** (pre-existing skips).
- `ruff check .`: clean. `ruff format --check .`: 86 files already formatted.
- Manual: lobby join / leave / reactions / steal power-up exercise the moved delegations; covered by the green suite.

## Risk assessment
- **Blast radius:** `game/state.py` + new `game/state_player.py` only. No frontend files.
- **What could go wrong:** an MRO surprise if another mixin defined the same player members — verified none do (the cluster lived solely on `GameState`).
- **What I did NOT test:** live Home Assistant runtime (unit + integration suite is the gate); no live WebSocket session run.

🤖 Auto-generated by issue-triage routine