### PR TITLE
refactor: extract title/artist vote-window cluster from state.py (#1271)

### DIFF
--- a/custom_components/beatify/game/state.py
+++ b/custom_components/beatify/game/state.py
@@ -46,7 +46,6 @@ from custom_components.beatify.const import (
     ROUND_DURATION_MAX,
     ROUND_DURATION_MIN,
     STREAK_MILESTONES,
-    TITLE_ARTIST_VOTE_WINDOW_SECONDS,
 )
 
 from .challenges import (
@@ -73,6 +72,7 @@ from .state_leaderboard import LeaderboardMixin
 from .state_media import MediaControlMixin
 from .state_player import PlayerLifecycleMixin
 from .state_tts import TtsAnnouncerMixin
+from .state_vote_window import VoteWindowMixin
 
 from .types import RoundAnalytics, _get_decade_label
 
@@ -144,6 +144,7 @@ class GameState(
     MediaControlMixin,
     PlayerLifecycleMixin,
     TtsAnnouncerMixin,
+    VoteWindowMixin,
 ):
     """Manages game state and phase transitions.
 
@@ -165,6 +166,12 @@ class GameState(
     PlayerRegistry + PowerUpManager delegation — player lookups, sessions,
     reactions, admin, steal/streak/bet pass-throughs) lives in
     :class:`~custom_components.beatify.game.state_player.PlayerLifecycleMixin`.
+
+    The Title & Artist REVEAL vote-window subsystem (Issue #1271
+    next-increment extraction — the #1180 Phase 4 vote-window scheduling +
+    finalization writers the challenge-delegation cut deliberately left
+    behind, coupled to the score lock and the auto-advance task) lives in
+    :class:`~custom_components.beatify.game.state_vote_window.VoteWindowMixin`.
     """
 
     def __init__(self, time_fn: Callable[[], float] | None = None) -> None:
@@ -1522,108 +1529,6 @@ class GameState(
                     self.round,
                     err,
                 )
-
-    def _schedule_title_artist_vote_window(self) -> None:
-        """Open or skip the conditional 30s near-miss vote window (#1180 P4).
-
-        Called from _end_round_unlocked while phase is REVEAL and title/artist
-        mode is on. If there are near-misses, flip voting_open and spawn the
-        window task (reused _auto_advance_task slot so a manual next_round,
-        pause or end cancels it via _cancel_auto_advance). With no near-misses,
-        resolve immediately so scoring/advance proceed unchanged.
-        """
-        if not self.title_artist_mode:
-            return
-        if self.has_near_misses():
-            self._title_artist_voting_open = True
-            self._title_artist_vote_deadline = (
-                self._now() + TITLE_ARTIST_VOTE_WINDOW_SECONDS
-            )
-            self._cancel_auto_advance()
-            self._auto_advance_task = asyncio.create_task(
-                self._title_artist_vote_window(TITLE_ARTIST_VOTE_WINDOW_SECONDS)
-            )
-        else:
-            # No vote-eligible fields — finalize now (everything exact/fuzzy/
-            # skipped), no window, advance behaves exactly as the year mode.
-            self._challenge_manager.resolve_title_artist()
-            self._title_artist_voting_open = False
-            self._title_artist_vote_deadline = None
-
-    async def _title_artist_vote_window(self, window_seconds: int) -> None:
-        """Hold REVEAL open for community voting, then resolve (#1180 P4).
-
-        Sleeps in short polls so a manual host-advance / pause / end can
-        cancel promptly. On natural expiry, finalizes near-misses via
-        resolve_title_artist, scores the deferred round, then re-broadcasts so
-        the accepted points and closed window reach every client. A late firing
-        is a no-op once the phase has left REVEAL.
-        """
-        poll = 0.5
-        try:
-            elapsed = 0.0
-            while elapsed < window_seconds:
-                await asyncio.sleep(poll)
-                elapsed += poll
-                if self.phase != GamePhase.REVEAL:
-                    return  # advanced / paused / ended elsewhere
-            # Window expired naturally — clear the handle first so a manual
-            # start_round's _cancel_auto_advance() can't cancel this task.
-            self._auto_advance_task = None
-            if self.phase != GamePhase.REVEAL:
-                return
-            await self._finalize_title_artist_window()
-            if self._on_round_end:
-                try:
-                    await self._on_round_end()
-                except (ConnectionError, OSError, TypeError) as err:
-                    _LOGGER.error("Vote-window broadcast failed: %s", err)
-        except asyncio.CancelledError:
-            _LOGGER.debug("Title/artist vote window cancelled")
-            raise
-
-    async def _finalize_title_artist_window(self) -> None:
-        """Resolve near-misses and apply title/artist scoring (#1180 P4).
-
-        Guarded by voting_open so a host-advance + timer expiry race resolves
-        exactly once. Scoring was deferred out of _end_round_unlocked's main
-        loop (the per-player score depends on the final near-miss resolution),
-        so this runs the single, post-resolve scoring pass under the score lock
-        — accepted near-misses are now reflected in the leaderboard.
-        """
-        if not self._title_artist_voting_open:
-            return
-        self._title_artist_voting_open = False
-        self._title_artist_vote_deadline = None
-        self._challenge_manager.resolve_title_artist()
-        async with self._score_lock:
-            await self._score_title_artist_round()
-
-    async def _score_title_artist_round(self) -> None:
-        """Run the deferred title/artist scoring pass. Caller holds the lock.
-
-        Scores every player exactly once now that near-misses are resolved,
-        reusing _score_all_players so this path and _end_round_unlocked share
-        one scoring loop. Players were intentionally NOT scored in the main
-        loop (defer_title_artist), so this is the first and only score for the
-        round — no double-counting.
-        """
-        correct_year = self.current_song.get("year") if self.current_song else None
-        all_players = list(self.players.values())
-        self._score_all_players(correct_year, all_players)
-
-    async def resolve_title_artist_if_pending(self) -> None:
-        """Finalize an open vote window early (host advanced) (#1180 P4).
-
-        Called from the next_round admin handler before it starts the next
-        round / ends the game, so accepted near-misses are scored first.
-        Cancels the pending window task and finalizes. No-op when the window
-        isn't open (year mode, no near-misses, or already resolved).
-        """
-        if not self._title_artist_voting_open:
-            return
-        self._cancel_auto_advance()
-        await self._finalize_title_artist_window()
 
     def _song_finished(self) -> bool:
         """True once the round's song is no longer playing (#1012).

--- a/custom_components/beatify/game/state_vote_window.py
+++ b/custom_components/beatify/game/state_vote_window.py
@@ -1,0 +1,181 @@
+"""Title & Artist vote-window subsystem for :class:`GameState`.
+
+Issue #1271 next-increment extraction: the **title/artist REVEAL vote-window**
+cluster is pulled out of the ``game/state.py`` God-Object into this
+``VoteWindowMixin``.
+
+This is the scheduling + finalization half that the challenge-delegation cut
+(:class:`~custom_components.beatify.game.state_challenge.ChallengeMixin`)
+deliberately left behind — there the *read* surface (``is_title_artist_voting_open``,
+``title_artist_vote_seconds_remaining``, …) was extracted, while the writers
+that own the REVEAL dwell stayed on ``GameState`` because they are coupled to
+the round scoring lock and the auto-advance task. This mixin now carries that
+writer cluster (#1180 Phase 4):
+
+* ``_schedule_title_artist_vote_window`` — opens (or skips) the conditional 30s
+  near-miss window from the round-end path; reuses the ``_auto_advance_task``
+  slot so a manual advance / pause / end cancels it.
+* ``_title_artist_vote_window`` — the window task that holds REVEAL open, then
+  finalizes near-misses, scores the deferred round, and re-broadcasts on expiry.
+* ``_finalize_title_artist_window`` — resolves near-misses and applies the
+  deferred title/artist scoring pass under the score lock (idempotent via the
+  ``voting_open`` guard).
+* ``_score_title_artist_round`` — the deferred per-player scoring pass; caller
+  holds the lock.
+* ``resolve_title_artist_if_pending`` — finalizes an open window early when the
+  host advances (called from the next_round admin handler).
+
+The mixin is **behavior-preserving**: it carries the exact same methods that
+previously lived on ``GameState``, so its public API and every caller / test
+are unchanged.
+
+The mixin relies on attributes / methods the host class owns and that live on
+``self`` at runtime:
+
+* ``self.title_artist_mode`` — whether the title/artist challenge mode is on
+  (a :class:`ChallengeMixin` property).
+* ``self.has_near_misses`` / ``self._challenge_manager.resolve_title_artist``
+  — the near-miss query + resolution surface delegated to the
+  :class:`~custom_components.beatify.game.challenges.ChallengeManager`.
+* ``self._title_artist_voting_open`` / ``self._title_artist_vote_deadline`` —
+  the server-owned REVEAL vote-window flag + deadline (in ``self._now`` units);
+  this mixin is the writer of those fields.
+* ``self._now`` — the monotonic-ish clock callable used for the vote deadline.
+* ``self._cancel_auto_advance`` / ``self._auto_advance_task`` — the REVEAL
+  auto-advance task handle this window reuses (so a manual next_round / pause /
+  end cancels the window via the same path).
+* ``self._score_lock`` — the asyncio lock guarding score mutations; the
+  deferred scoring pass runs under it.
+* ``self._score_all_players`` — the shared per-player scoring loop (stays on
+  ``GameState`` so the round-end and vote-window paths cannot drift).
+* ``self.players`` / ``self.current_song`` / ``self.phase`` — round state read
+  while the window is open.
+* ``self._on_round_end`` — the async broadcast callback fired after expiry.
+
+It carries no state of its own. ``GamePhase`` is imported lazily inside the
+window task (matching the ``powerups`` / ``serializers`` pattern) to avoid the
+cyclic import with ``state.py`` (which imports this mixin at module load), so
+the extraction introduces no import cycle.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from custom_components.beatify.const import (
+    TITLE_ARTIST_VOTE_WINDOW_SECONDS,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class VoteWindowMixin:
+    """Title & Artist REVEAL vote-window behavior for :class:`GameState`.
+
+    See module docstring for the host-class attributes this mixin reads/writes.
+    """
+
+    def _schedule_title_artist_vote_window(self) -> None:
+        """Open or skip the conditional 30s near-miss vote window (#1180 P4).
+
+        Called from _end_round_unlocked while phase is REVEAL and title/artist
+        mode is on. If there are near-misses, flip voting_open and spawn the
+        window task (reused _auto_advance_task slot so a manual next_round,
+        pause or end cancels it via _cancel_auto_advance). With no near-misses,
+        resolve immediately so scoring/advance proceed unchanged.
+        """
+        if not self.title_artist_mode:
+            return
+        if self.has_near_misses():
+            self._title_artist_voting_open = True
+            self._title_artist_vote_deadline = (
+                self._now() + TITLE_ARTIST_VOTE_WINDOW_SECONDS
+            )
+            self._cancel_auto_advance()
+            self._auto_advance_task = asyncio.create_task(
+                self._title_artist_vote_window(TITLE_ARTIST_VOTE_WINDOW_SECONDS)
+            )
+        else:
+            # No vote-eligible fields — finalize now (everything exact/fuzzy/
+            # skipped), no window, advance behaves exactly as the year mode.
+            self._challenge_manager.resolve_title_artist()
+            self._title_artist_voting_open = False
+            self._title_artist_vote_deadline = None
+
+    async def _title_artist_vote_window(self, window_seconds: int) -> None:
+        """Hold REVEAL open for community voting, then resolve (#1180 P4).
+
+        Sleeps in short polls so a manual host-advance / pause / end can
+        cancel promptly. On natural expiry, finalizes near-misses via
+        resolve_title_artist, scores the deferred round, then re-broadcasts so
+        the accepted points and closed window reach every client. A late firing
+        is a no-op once the phase has left REVEAL.
+        """
+        from .state import GamePhase  # noqa: PLC0415 — avoid circular import
+
+        poll = 0.5
+        try:
+            elapsed = 0.0
+            while elapsed < window_seconds:
+                await asyncio.sleep(poll)
+                elapsed += poll
+                if self.phase != GamePhase.REVEAL:
+                    return  # advanced / paused / ended elsewhere
+            # Window expired naturally — clear the handle first so a manual
+            # start_round's _cancel_auto_advance() can't cancel this task.
+            self._auto_advance_task = None
+            if self.phase != GamePhase.REVEAL:
+                return
+            await self._finalize_title_artist_window()
+            if self._on_round_end:
+                try:
+                    await self._on_round_end()
+                except (ConnectionError, OSError, TypeError) as err:
+                    _LOGGER.error("Vote-window broadcast failed: %s", err)
+        except asyncio.CancelledError:
+            _LOGGER.debug("Title/artist vote window cancelled")
+            raise
+
+    async def _finalize_title_artist_window(self) -> None:
+        """Resolve near-misses and apply title/artist scoring (#1180 P4).
+
+        Guarded by voting_open so a host-advance + timer expiry race resolves
+        exactly once. Scoring was deferred out of _end_round_unlocked's main
+        loop (the per-player score depends on the final near-miss resolution),
+        so this runs the single, post-resolve scoring pass under the score lock
+        — accepted near-misses are now reflected in the leaderboard.
+        """
+        if not self._title_artist_voting_open:
+            return
+        self._title_artist_voting_open = False
+        self._title_artist_vote_deadline = None
+        self._challenge_manager.resolve_title_artist()
+        async with self._score_lock:
+            await self._score_title_artist_round()
+
+    async def _score_title_artist_round(self) -> None:
+        """Run the deferred title/artist scoring pass. Caller holds the lock.
+
+        Scores every player exactly once now that near-misses are resolved,
+        reusing _score_all_players so this path and _end_round_unlocked share
+        one scoring loop. Players were intentionally NOT scored in the main
+        loop (defer_title_artist), so this is the first and only score for the
+        round — no double-counting.
+        """
+        correct_year = self.current_song.get("year") if self.current_song else None
+        all_players = list(self.players.values())
+        self._score_all_players(correct_year, all_players)
+
+    async def resolve_title_artist_if_pending(self) -> None:
+        """Finalize an open vote window early (host advanced) (#1180 P4).
+
+        Called from the next_round admin handler before it starts the next
+        round / ends the game, so accepted near-misses are scored first.
+        Cancels the pending window task and finalizes. No-op when the window
+        isn't open (year mode, no near-misses, or already resolved).
+        """
+        if not self._title_artist_voting_open:
+            return
+        self._cancel_auto_advance()
+        await self._finalize_title_artist_window()

--- a/tests/unit/test_state_title_artist_window.py
+++ b/tests/unit/test_state_title_artist_window.py
@@ -150,7 +150,7 @@ class TestConditionalWindow:
         for p in gs.players.values():
             p.submitted = True
         # Patch the window length to ~0 so the test does not wait 15s.
-        import custom_components.beatify.game.state as state_mod
+        import custom_components.beatify.game.state_vote_window as state_mod
 
         orig = state_mod.TITLE_ARTIST_VOTE_WINDOW_SECONDS
         state_mod.TITLE_ARTIST_VOTE_WINDOW_SECONDS = 0
@@ -248,7 +248,7 @@ class TestVoteWindowScoring:
         gs = make_game_state()
         await self._setup_near_miss(gs)
         gs.set_title_artist_override("Alice:title", True)
-        import custom_components.beatify.game.state as state_mod
+        import custom_components.beatify.game.state_vote_window as state_mod
 
         orig = state_mod.TITLE_ARTIST_VOTE_WINDOW_SECONDS
         state_mod.TITLE_ARTIST_VOTE_WINDOW_SECONDS = 0


### PR DESCRIPTION
## Increment for #1271 (state.py God-Object split)

One bounded, behavior-preserving cut. **Refs #1271 — the issue stays OPEN.**

### Cluster chosen
The **title/artist REVEAL vote-window** cluster (#1180 Phase 4) — the *writer* half that the earlier `ChallengeMixin` extraction (PR #1338) deliberately left on `GameState` because it's coupled to the score lock and the auto-advance task. Now it has a clean home.

Moved verbatim into new `custom_components/beatify/game/state_vote_window.py` as `VoteWindowMixin`:
- `_schedule_title_artist_vote_window`
- `_title_artist_vote_window`
- `_finalize_title_artist_window`
- `_score_title_artist_round`
- `resolve_title_artist_if_pending`

`VoteWindowMixin` is added to the `GameState(...)` base list (after `TtsAnnouncerMixin`) with a matching docstring paragraph, exactly like the existing `state_*.py` mixins.

### Line delta
`game/state.py`: **2269 → 2174** (−95). `state_vote_window.py`: +181 (incl. the standard module docstring documenting every host-class attribute the mixin reads/writes).

### API unchanged
Pure code movement, no behavior change. Method bodies are byte-identical to the originals. `GamePhase` is imported lazily inside the window task (the established `powerups`/`serializers` `# noqa: PLC0415` pattern) to avoid a cyclic import; `TITLE_ARTIST_VOTE_WINDOW_SECONDS` moves with the cluster. All external callers (`ws_handlers.py`, tests) reach the methods via the instance through normal MRO — no re-exports needed.

The only test touch: two window tests monkeypatch the window-length constant; their patch target moves with the symbol to `state_vote_window` (no behavior change, just following the moved constant).

### Test / lint status (local, in worktree)
- `python3 -m pytest -q` → **885 passed, 2 skipped** ✅
- `python3 -m ruff check custom_components/ tests/` → **All checks passed** ✅
- `python3 -m ruff format --check custom_components/` → **all formatted** ✅
- Frontend build: N/A (pure Python refactor)

Not validated against a live Home Assistant instance (refactor is mechanical + fully covered by the existing vote-window unit tests).

### Progress toward #1271's <800 goal
Still an increment, not the finish line: 2174 lines, down from 2269. The next coherent candidates remain Scoring/Round-Resolution (`_score_round`, `_record_round_stats`, `_score_all_players`, `_song_finished`/auto-advance) and the serialization/state-dict path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)