### PR TITLE
data: fix Summer Nights release year 2019→1978 (#1344)

### DIFF
--- a/custom_components/beatify/playlists/community/iconic-movie-songs.json
+++ b/custom_components/beatify/playlists/community/iconic-movie-songs.json
@@ -1,6 +1,6 @@
 {
   "name": "ICONIC movie songs 🎬",
-  "version": "0.2",
+  "version": "0.3",
   "tags": [
     "movies",
     "soundtracks",
@@ -654,7 +654,7 @@
       ]
     },
     {
-      "year": 2019,
+      "year": 1978,
       "uri": "spotify:track:2AVkArcfALVk2X8sfPRzya",
       "artist": "John Travolta, Olivia Newton-John",
       "alt_artists": [


### PR DESCRIPTION
Closes #1344

## What changed
Fixed the release year for **"Summer Nights - From Grease"** (John Travolta, Olivia Newton-John) in `custom_components/beatify/playlists/community/iconic-movie-songs.json`.

| Field | Before | After |
|-------|--------|-------|
| `year` | 2019 | 1978 |
| `version` | 0.2 | 0.3 |

## Verification
The song was originally released as a single in **1978** alongside the Grease film soundtrack:
- [Discogs master release r627095](https://www.discogs.com/release/627095-John-Travolta-Olivia-Newton-John-Summer-Nights) — vinyl 7", 45 RPM, 1978
- [Discogs master listing](https://www.discogs.com/master/98109-John-Travolta-Olivia-Newton-John-Summer-Nights) — confirms 1978 original
- [Wikipedia — Summer Nights (Grease song)](https://en.wikipedia.org/wiki/Summer_Nights_(Grease_song)) — released as single during Grease (1978)

Note: the fun_fact field already correctly referenced "Grease (1978)" — the year field alone was wrong.

## Risk assessment
- **Blast radius:** 1 field in 1 community playlist (iconic-movie-songs.json). No code changes.
- **What could go wrong:** N/A — pure data correction, no logic affected.
- **What I did NOT test:** Full playlist health check (URI validity unchanged).

🤖 Auto-generated by issue-triage routine