### PR TITLE
data: fix release year for Michael Jackson – Thriller (#1345)

### DIFF
--- a/custom_components/beatify/playlists/community/iconic-movie-songs.json
+++ b/custom_components/beatify/playlists/community/iconic-movie-songs.json
@@ -1,6 +1,6 @@
 {
   "name": "ICONIC movie songs 🎬",
-  "version": "0.3",
+  "version": "0.4",
   "tags": [
     "movies",
     "soundtracks",
@@ -1334,7 +1334,7 @@
       ]
     },
     {
-      "year": 2008,
+      "year": 1982,
       "uri": "spotify:track:7azo4rpSUh8nXgtonC6Pkq",
       "artist": "Michael Jackson",
       "alt_artists": [


### PR DESCRIPTION
Closes #1345

## Change

Corrects the release year for **Michael Jackson – Thriller** in `custom_components/beatify/playlists/community/iconic-movie-songs.json`:

| Field | Before | After |
|-------|--------|-------|
| `year` | 2008 | 1982 |
| playlist `version` | 0.3 | 0.4 |

## Verification source

**Discogs Master Release:** https://www.discogs.com/master/101825-Michael-Jackson-Thriller

- The *Thriller* **album** was released November 30, 1982 (Epic Records)
- The "Thriller" **single** followed in November 1983 (UK) / January 1984 (US) — i.e., single came *after* the album
- Beatify convention: original song release year = album year when the single post-dates it → **1982** ✅
- The existing `fun_fact` fields already stated "(1982)", confirming this was a data-entry error

The year 2008 has no known connection to this song.

## Readiness assessment
- [x] Ready to merge

**Honest summary:** Single-field correction with clear canonical source (Discogs Master + Wikipedia). Year 2008 was plainly wrong; the fun_facts in the same record already referenced 1982. Low risk — isolated to one JSON entry in one playlist.

## Risk assessment
- **Blast radius:** 1 field in 1 playlist file (`iconic-movie-songs.json`); no code changes
- **What could go wrong:** Nothing material — correcting factually wrong trivia data
- **What I did NOT test:** Live game round with this specific song (no CI test for playlist year values)

🤖 Auto-generated by issue-triage routine (music-data-check dispatch)