### PR TITLE
fix: game language follows browser locale on first wizard open (#1354)

### DIFF
--- a/custom_components/beatify/www/js/__tests__/wizard.test.js
+++ b/custom_components/beatify/www/js/__tests__/wizard.test.js
@@ -3,7 +3,7 @@
  * These helpers drive the state machine: when to show, where to resume, when to show the pill.
  */
 import { describe, it, expect, beforeEach } from 'vitest';
-import { resumeAtStep, shouldTrigger, shouldShowPill, providerSupportedForPlayer, capabilityBadgeForPlayer, applyGameModeTogglePrecedence, difficultyDisplayFor, buildWizChip } from '../wizard.js';
+import { resumeAtStep, shouldTrigger, shouldShowPill, providerSupportedForPlayer, capabilityBadgeForPlayer, applyGameModeTogglePrecedence, difficultyDisplayFor, buildWizChip, resolveGameLanguageDefault } from '../wizard.js';
 
 function makeLS(initial = {}) {
     const store = { ...initial };
@@ -445,5 +445,36 @@ describe('buildWizChip', () => {
 
     it('works for the intensity group too', () => {
         expect(buildWizChip('party', 'Party', 'intensity', 'party')).toContain('data-intensity="party"');
+    });
+});
+
+// ------------------------------------------------------------------
+// resolveGameLanguageDefault — game language must follow the browser
+// locale on EVERY wizard open, including a first-time user with no
+// saved settings (#1354: German wizard but English game).
+// ------------------------------------------------------------------
+describe('resolveGameLanguageDefault', () => {
+    it('uses the browser language even when there are NO saved settings (#1354)', () => {
+        // The bug: first-time user, no beatify_game_settings → game went out
+        // as the hard-coded 'en' default while the wizard UI was German.
+        expect(resolveGameLanguageDefault(() => 'de', null, 'en')).toBe('de');
+    });
+
+    it('browser language wins over a stale saved language', () => {
+        expect(resolveGameLanguageDefault(() => 'de', { language: 'en' }, 'en')).toBe('de');
+    });
+
+    it('falls back to saved language when browser detection is unavailable', () => {
+        expect(resolveGameLanguageDefault(null, { language: 'fr' }, 'en')).toBe('fr');
+    });
+
+    it('falls back to saved language when the detector throws', () => {
+        const throwing = () => { throw new Error('no navigator'); };
+        expect(resolveGameLanguageDefault(throwing, { language: 'es' }, 'en')).toBe('es');
+    });
+
+    it('falls back to the current default when nothing resolves', () => {
+        expect(resolveGameLanguageDefault(null, null, 'en')).toBe('en');
+        expect(resolveGameLanguageDefault(() => '', {}, 'en')).toBe('en');
     });
 });

--- a/custom_components/beatify/www/js/wizard.js
+++ b/custom_components/beatify/www/js/wizard.js
@@ -160,6 +160,33 @@ export function difficultyDisplayFor(titleArtistMode) {
         : { showChips: true, summaryKey: null };
 }
 
+/**
+ * Resolve the game-language default the wizard sends when starting a game.
+ *
+ * #1354: the browser language must win on EVERY wizard open, including a
+ * first-time user with no saved settings — otherwise the wizard UI renders in
+ * the browser locale (via BeatifyI18n auto-detect) while the started game goes
+ * out as 'en', leaving the player/game screens stuck in English.
+ *
+ * Order: browser detection (navigator.language) → saved settings.language →
+ * the caller's current default. Returns the resolved code (or `current` when
+ * nothing else is available). Pure: `detectFn` and `saved` are injected so this
+ * is unit-testable without a DOM.
+ *
+ * @param {function():string} [detectFn] - browser-language detector
+ * @param {{language?: string}|null} [saved] - parsed saved game settings
+ * @param {string} [current='en'] - fallback when neither source resolves
+ * @returns {string}
+ */
+export function resolveGameLanguageDefault(detectFn, saved, current = 'en') {
+    let resolved = null;
+    try {
+        if (typeof detectFn === 'function') resolved = detectFn();
+    } catch (e) { /* ignore */ }
+    if (!resolved && saved && saved.language) resolved = saved.language;
+    return resolved || current;
+}
+
 // ------------------------------------------------------------------
 // DOM-driven controller (browser-only below this line)
 // ------------------------------------------------------------------
@@ -1442,40 +1469,44 @@ export async function show(stepOverride) {
     try {
         chosenSpeaker = ls ? ls.getItem(LS_SELECTED_PLAYER) : null;
         const rawSettings = ls ? ls.getItem(LS_GAME_SETTINGS) : null;
-        if (rawSettings) {
-            const s = JSON.parse(rawSettings);
+        const savedSettings = rawSettings ? JSON.parse(rawSettings) : null;
+
+        // #1354 + #815 + #822: resolve the game-language default from the
+        // BROWSER on EVERY wizard open, regardless of whether saved settings
+        // exist. Previously this lived inside the `if (rawSettings)` block, so
+        // a first-time user with no saved settings kept the hard-coded
+        // chosenLanguage='en' default — the wizard UI rendered in German (via
+        // BeatifyI18n auto-detect) but the started game went out as 'en',
+        // leaving the player/game screens in English (#1354).
+        //
+        // Why navigator.language (via detectBrowserLanguage), not
+        // BeatifyI18n.getLanguage()?  Earlier rc15/rc17 attempts used
+        // getLanguage() but `admin.js:loadSavedSettings()` calls
+        // BeatifyI18n.setLanguage(settings.language) on every page
+        // load — which silently overrides the auto-detected language
+        // with whatever's in localStorage. A user with `navigator
+        // .language='de-DE'` plus stale settings.language='en' from a
+        // pre-rc15 wizard run would see currentLanguage='en' by the
+        // time the wizard opened, and the rc17 fix returned 'en' too.
+        // detectBrowserLanguage() is a pure read of navigator.language
+        // — no session state, no race.
+        //
+        // Power users who actually want game-language ≠ browser-
+        // language can tap the chip during the wizard; that explicit
+        // tap re-saves and persists across reloads via the chip
+        // handler in wizard.js's _renderChipGroup callback.
+        const _detectFn = (typeof window !== 'undefined' && window.BeatifyI18n
+            && typeof window.BeatifyI18n.detectBrowserLanguage === 'function')
+            ? window.BeatifyI18n.detectBrowserLanguage
+            : null;
+        chosenLanguage = resolveGameLanguageDefault(_detectFn, savedSettings, chosenLanguage);
+
+        if (savedSettings) {
+            const s = savedSettings;
             if (s.provider) chosenProvider = s.provider;
             if (s.difficulty) chosenDifficulty = s.difficulty;
             if (s.duration) chosenDuration = s.duration;
             if (typeof s.revealAutoAdvance === 'number') chosenRevealAutoAdvance = s.revealAutoAdvance;
-            // #815 + #822: prefer the BROWSER's language as the game-language
-            // default. Saved value only wins if browser detection isn't
-            // available.
-            //
-            // Why navigator.language (via detectBrowserLanguage), not
-            // BeatifyI18n.getLanguage()?  Earlier rc15/rc17 attempts used
-            // getLanguage() but `admin.js:loadSavedSettings()` calls
-            // BeatifyI18n.setLanguage(settings.language) on every page
-            // load — which silently overrides the auto-detected language
-            // with whatever's in localStorage. A user with `navigator
-            // .language='de-DE'` plus stale settings.language='en' from a
-            // pre-rc15 wizard run would see currentLanguage='en' by the
-            // time the wizard opened, and the rc17 fix returned 'en' too.
-            // detectBrowserLanguage() is a pure read of navigator.language
-            // — no session state, no race.
-            //
-            // Power users who actually want game-language ≠ browser-
-            // language can tap the chip during the wizard; that explicit
-            // tap re-saves and persists across reloads via the chip
-            // handler in wizard.js's _renderChipGroup callback.
-            let _resolvedLang = null;
-            try {
-                if (window.BeatifyI18n && typeof window.BeatifyI18n.detectBrowserLanguage === 'function') {
-                    _resolvedLang = window.BeatifyI18n.detectBrowserLanguage();
-                }
-            } catch (e) { /* ignore */ }
-            if (!_resolvedLang && s.language) _resolvedLang = s.language;
-            if (_resolvedLang) chosenLanguage = _resolvedLang;
             if (typeof s.artistChallenge === 'boolean') chosenArtistChallenge = s.artistChallenge;
             if (typeof s.movieQuiz === 'boolean') chosenMovieQuiz = s.movieQuiz;
             if (typeof s.introMode === 'boolean') chosenIntroMode = s.introMode;


### PR DESCRIPTION
Closes #1354

## Root cause
The setup wizard resolved its game-language default from the browser locale (`BeatifyI18n.detectBrowserLanguage()`) **only inside the `if (rawSettings)` block** in `wizard.js#show()`. A first-time user with no `beatify_game_settings` in localStorage therefore kept the hard-coded `chosenLanguage = 'en'` default.

The wizard *UI* still rendered in the browser locale (German), because `BeatifyI18n.init()` auto-detects independently. But the language sent to the server on game start (`language: chosenLanguage`) stayed `'en'`, so the game state went out as English and the player/game screens stayed English — exactly the inconsistency reported (German wizard, English game).

## Fix
Hoisted the browser-language resolution out of the saved-settings branch into a pure, unit-tested helper `resolveGameLanguageDefault(detectFn, saved, current)` that runs on **every** wizard open. Resolution order is unchanged: browser detection → saved `settings.language` → current default. Users who already have saved settings see identical behaviour.

## Readiness assessment
- [x] Ready to merge
- [ ] Borderline — see notes
- [ ] Not ready — needs human review

**Honest summary:** Small, surgical change that closes a clear logic gap; the only behavioural change is that first-time users now inherit their browser locale into the game just like returning users already did. Covered by 5 new unit tests; full vitest (240) and pytest (885) suites green.

## Test plan
- Automated: `npm test` (vitest, 240 passed incl. 5 new `resolveGameLanguageDefault` cases), `python3 -m pytest` (885 passed, 2 skipped), `node scripts/build.mjs --check` (all 10 bundles match source).
- Manual: HA language German, fresh browser profile (no localStorage) → open wizard → start a game without touching the language chip → player phone + dashboard render in German.
- Regression: returning user with saved `beatify_game_settings` still gets browser-locale default; explicit chip tap still overrides and persists.

## Risk assessment
- **Blast radius:** `custom_components/beatify/www/js/wizard.js` (`show()` hydration + new pure helper) and its unit test. No backend, no other frontend files.
- **Frontend bundle guardrail:** `wizard.js` ships **unminified** as a `<script type="module">` in `admin.html` (it is *not* part of `admin.min.js`), so there is no `.min.js` to regenerate — `build:check` confirms all bundles still match. Cache-busting is the serve-time `{{ASSET_VER}}` asset fingerprint (`server/base.py`, hashes mtime+size of `css/js/i18n`), which moves automatically when `wizard.js` changes; no manual `?v=` or `sw.js CACHE_VERSION` bump is needed or applicable.
- **What could go wrong:** if a user's browser locale differs from the HA/server locale they expect, the game now follows the browser (matching the wizard UI) — this is the intended consistency fix, and the language chip still lets them override.
- **What I did NOT test:** live end-to-end on a real HA instance (verified by unit tests + code path analysis only).

🤖 Auto-generated by issue-triage routine