### PR TITLE
fix: close AlbumArtView SSRF with HMAC-signed URLs + host/size guards (#1356)

### DIFF
--- a/custom_components/beatify/server/views.py
+++ b/custom_components/beatify/server/views.py
@@ -10,10 +10,12 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import socket
 import time
+from ipaddress import ip_address
 from pathlib import Path
 from typing import TYPE_CHECKING
-from urllib.parse import urlencode
+from urllib.parse import urlencode, urlsplit
 
 from aiohttp import ClientError, ClientTimeout, web
 from homeassistant.components.http import HomeAssistantView
@@ -35,7 +37,10 @@ from custom_components.beatify.server.serializers import (
     build_status_response,
 )
 from custom_components.beatify.services.lights import PartyLightsService
-from custom_components.beatify.services.media_player import async_get_media_players
+from custom_components.beatify.services.media_player import (
+    album_art_signature_is_valid,
+    async_get_media_players,
+)
 
 # Re-export game views
 from custom_components.beatify.server.game_views import (  # noqa: F401
@@ -652,32 +657,96 @@ class AlbumArtView(HomeAssistantView):
     name = "beatify:api:albumart"
     requires_auth = False  # player browsers are unauthenticated
 
+    # Cap the re-served image so a hostile/huge upstream can't exhaust memory.
+    _MAX_BYTES = 5 * 1024 * 1024
+
     def __init__(self, hass: HomeAssistant) -> None:
         """Initialize the album-art proxy view."""
         self.hass = hass
 
     async def get(self, request: web.Request) -> web.Response:
-        """Fetch the upstream image and re-serve it same-origin."""
+        """Fetch the upstream image and re-serve it same-origin (#933, hardened #1356).
+
+        The endpoint is unauthenticated (player browsers have no token), so it
+        must not be usable as a server-side request forge. Defences:
+
+        * **HMAC signature** — only URLs the integration itself produced (via
+          ``proxy_album_art``) carry a valid ``sig``; everything else is 403.
+          This is the primary SSRF guard.
+        * **Host allow-list** — loopback, link-local (incl. the
+          ``169.254.169.254`` cloud-metadata endpoint), multicast and reserved
+          ranges are refused. RFC1918 private addresses stay allowed because
+          that is exactly where the Music Assistant LAN server lives (#933).
+        * **No redirects**, a **read-size cap** and an **``image/*``
+          content-type check** so the proxy can only ever return a bounded image.
+        """
         raw_url = request.query.get("url", "")
+        signature = request.query.get("sig", "")
         if not raw_url.startswith(("http://", "https://")):
             return web.Response(status=400, text="invalid url")
+        if not album_art_signature_is_valid(raw_url, signature):
+            _LOGGER.warning("Album-art proxy rejected an unsigned/forged URL")
+            return web.Response(status=403, text="forbidden")
+
+        host = urlsplit(raw_url).hostname
+        if not host or not await self._host_is_allowed(host):
+            _LOGGER.warning("Album-art proxy refused a disallowed host")
+            return web.Response(status=403, text="forbidden")
 
         session = async_get_clientsession(self.hass)
         try:
-            async with session.get(raw_url, timeout=ClientTimeout(total=10)) as resp:
+            async with session.get(
+                raw_url,
+                timeout=ClientTimeout(total=10),
+                allow_redirects=False,
+            ) as resp:
                 if resp.status != 200:
-                    return web.Response(status=resp.status)
-                body = await resp.read()
-                content_type = resp.headers.get("Content-Type", "image/jpeg")
+                    return web.Response(status=502, text="upstream fetch failed")
+                content_type = resp.headers.get("Content-Type", "")
+                if not content_type.startswith("image/"):
+                    return web.Response(status=415, text="not an image")
+                declared = resp.headers.get("Content-Length")
+                if declared is not None and declared.isdigit():
+                    if int(declared) > self._MAX_BYTES:
+                        return web.Response(status=413, text="image too large")
+                body = bytearray()
+                async for chunk in resp.content.iter_chunked(65536):
+                    body += chunk
+                    if len(body) > self._MAX_BYTES:
+                        return web.Response(status=413, text="image too large")
         except (ClientError, asyncio.TimeoutError):
-            _LOGGER.warning("Album-art proxy fetch failed for %s", raw_url)
+            _LOGGER.warning("Album-art proxy fetch failed")
             return web.Response(status=502, text="upstream fetch failed")
 
         return web.Response(
-            body=body,
+            body=bytes(body),
             content_type=content_type,
             headers={"Cache-Control": "public, max-age=86400"},
         )
+
+    async def _host_is_allowed(self, host: str) -> bool:
+        """Reject hosts that resolve to loopback/link-local/reserved ranges (#1356)."""
+        try:
+            infos = await self.hass.async_add_executor_job(
+                socket.getaddrinfo, host, None
+            )
+        except OSError:
+            return False
+        for info in infos:
+            addr = info[4][0]
+            try:
+                ip = ip_address(addr.split("%")[0])
+            except ValueError:
+                return False
+            if (
+                ip.is_loopback
+                or ip.is_link_local
+                or ip.is_multicast
+                or ip.is_unspecified
+                or ip.is_reserved
+            ):
+                return False
+        return True
 
 
 class PreviewLightsView(HomeAssistantView):

--- a/custom_components/beatify/services/media_player.py
+++ b/custom_components/beatify/services/media_player.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
+import hmac
 import logging
+import secrets
 from asyncio import timeout as async_timeout
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any
@@ -208,6 +211,29 @@ _PROVIDER_URI_FIELDS: dict[str, tuple[str, ...]] = {
 }
 
 
+# Process-global key used to sign the absolute URLs that the album-art proxy
+# is allowed to fetch (#1356). It is minted fresh on every HA start: only URLs
+# that *this* integration produced via ``proxy_album_art`` carry a valid
+# signature, which is what stops AlbumArtView from being an open SSRF proxy. A
+# restart simply invalidates previously-signed URLs — clients 403 once and pick
+# up the freshly-signed URL from the next state broadcast.
+_ALBUM_ART_SIGNING_KEY = secrets.token_bytes(32)
+
+
+def _album_art_signature(url: str) -> str:
+    """Return the hex HMAC-SHA256 signature for an album-art proxy URL (#1356)."""
+    return hmac.new(
+        _ALBUM_ART_SIGNING_KEY, url.encode("utf-8"), hashlib.sha256
+    ).hexdigest()
+
+
+def album_art_signature_is_valid(url: str, signature: str) -> bool:
+    """Verify, in constant time, that ``signature`` matches ``url`` (#1356)."""
+    if not signature:
+        return False
+    return hmac.compare_digest(_album_art_signature(url), signature)
+
+
 def proxy_album_art(url: str) -> str:
     """Route an absolute album-art URL through the same-origin proxy (#933).
 
@@ -219,12 +245,21 @@ def proxy_album_art(url: str) -> str:
     the HA server fetch the image (it can reach the LAN) and re-serve it
     same-origin.
 
+    The wrapped URL carries an HMAC signature (#1356) so the proxy only ever
+    fetches URLs the integration itself produced — without it the endpoint
+    would be an unauthenticated server-side request forge.
+
     Relative URLs — HA's own signed media-player proxy path, the
     ``no-artwork.svg`` fallback — are already same-origin and pass through
     unchanged.
     """
     if url and url.startswith(("http://", "https://")):
-        return "/beatify/api/albumart?url=" + quote(url, safe="")
+        return (
+            "/beatify/api/albumart?url="
+            + quote(url, safe="")
+            + "&sig="
+            + _album_art_signature(url)
+        )
     return url
 
 

--- a/tests/unit/test_album_art_view.py
+++ b/tests/unit/test_album_art_view.py
@@ -1,10 +1,15 @@
-"""Tests for AlbumArtView — the same-origin album-art proxy (#933)."""
+"""Tests for AlbumArtView — the same-origin album-art proxy (#933, SSRF-hardened #1356)."""
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from custom_components.beatify.server.views import AlbumArtView
+from custom_components.beatify.services.media_player import (
+    _album_art_signature,
+    album_art_signature_is_valid,
+    proxy_album_art,
+)
 
 
 def _request(query: dict) -> MagicMock:
@@ -14,8 +19,74 @@ def _request(query: dict) -> MagicMock:
     return request
 
 
+def _signed_query(url: str) -> dict:
+    """A query dict carrying a valid signature for ``url`` (#1356)."""
+    return {"url": url, "sig": _album_art_signature(url)}
+
+
+def _hass_resolving_to(addr: str) -> MagicMock:
+    """A mock hass whose executor resolves any host to ``addr``."""
+    hass = MagicMock()
+    hass.async_add_executor_job = AsyncMock(return_value=[(2, 1, 6, "", (addr, 0))])
+    return hass
+
+
+async def _aiter(chunks):
+    for c in chunks:
+        yield c
+
+
+class _FakeResponse:
+    """Minimal async-context-manager stand-in for an aiohttp response."""
+
+    def __init__(
+        self, status=200, content_type="image/jpeg", chunks=(b"img",), headers=None
+    ):
+        self.status = status
+        self.headers = {"Content-Type": content_type}
+        if headers:
+            self.headers.update(headers)
+        self.content = MagicMock()
+        self.content.iter_chunked = lambda _n: _aiter(chunks)
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_a):
+        return False
+
+
+def _session_returning(resp: _FakeResponse) -> MagicMock:
+    session = MagicMock()
+    session.get = MagicMock(return_value=resp)
+    return session
+
+
+class TestAlbumArtSignature:
+    """The HMAC signature is what stops the proxy being an open SSRF relay."""
+
+    def test_proxy_album_art_appends_valid_signature(self):
+        wrapped = proxy_album_art("http://192.168.1.9:8095/imageproxy?x=1")
+        assert wrapped.startswith("/beatify/api/albumart?url=")
+        assert "&sig=" in wrapped
+
+    def test_relative_urls_pass_through_unsigned(self):
+        assert (
+            proxy_album_art("/beatify/static/img/no-artwork.svg")
+            == "/beatify/static/img/no-artwork.svg"
+        )
+
+    def test_empty_signature_is_rejected(self):
+        assert album_art_signature_is_valid("http://x/y", "") is False
+
+    def test_signature_is_url_specific(self):
+        sig = _album_art_signature("http://a/1")
+        assert album_art_signature_is_valid("http://a/1", sig) is True
+        assert album_art_signature_is_valid("http://a/2", sig) is False
+
+
 class TestAlbumArtView:
-    """Input validation for the album-art proxy endpoint."""
+    """Input validation + SSRF defences for the proxy endpoint."""
 
     def test_endpoint_is_unauthenticated(self):
         # Player browsers join unauthenticated — the proxy must be reachable.
@@ -32,3 +103,91 @@ class TestAlbumArtView:
         view = AlbumArtView(MagicMock())
         resp = await view.get(_request({"url": "file:///etc/passwd"}))
         assert resp.status == 400
+
+    async def test_unsigned_url_returns_403(self):
+        # Without our signature the URL is attacker-controlled → refuse.
+        view = AlbumArtView(MagicMock())
+        resp = await view.get(
+            _request({"url": "http://169.254.169.254/latest/meta-data/"})
+        )
+        assert resp.status == 403
+
+    async def test_forged_signature_returns_403(self):
+        view = AlbumArtView(MagicMock())
+        resp = await view.get(
+            _request({"url": "http://evil.example/x", "sig": "deadbeef"})
+        )
+        assert resp.status == 403
+
+    async def test_signed_but_loopback_host_returns_403(self):
+        # Valid signature, but the host resolves to loopback → still refused.
+        url = "http://127.0.0.1:8095/imageproxy"
+        hass = _hass_resolving_to("127.0.0.1")
+        view = AlbumArtView(hass)
+        resp = await view.get(_request(_signed_query(url)))
+        assert resp.status == 403
+        # Proves we got past the signature gate to the host check.
+        hass.async_add_executor_job.assert_awaited()
+
+    async def test_signed_metadata_endpoint_returns_403(self):
+        url = "http://169.254.169.254/latest/meta-data/"
+        hass = _hass_resolving_to("169.254.169.254")
+        view = AlbumArtView(hass)
+        resp = await view.get(_request(_signed_query(url)))
+        assert resp.status == 403
+
+    async def test_signed_private_host_is_fetched(self):
+        # RFC1918 is the legitimate Music Assistant LAN target (#933).
+        url = "http://192.168.1.9:8095/imageproxy?x=1"
+        hass = _hass_resolving_to("192.168.1.9")
+        view = AlbumArtView(hass)
+        resp = _FakeResponse(status=200, content_type="image/png", chunks=(b"PNGDATA",))
+        with patch(
+            "custom_components.beatify.server.views.async_get_clientsession",
+            return_value=_session_returning(resp),
+        ):
+            out = await view.get(_request(_signed_query(url)))
+        assert out.status == 200
+        assert out.body == b"PNGDATA"
+
+    async def test_non_image_content_type_returns_415(self):
+        url = "http://192.168.1.9/page.html"
+        hass = _hass_resolving_to("192.168.1.9")
+        view = AlbumArtView(hass)
+        resp = _FakeResponse(status=200, content_type="text/html", chunks=(b"<html>",))
+        with patch(
+            "custom_components.beatify.server.views.async_get_clientsession",
+            return_value=_session_returning(resp),
+        ):
+            out = await view.get(_request(_signed_query(url)))
+        assert out.status == 415
+
+    async def test_oversize_content_length_returns_413(self):
+        url = "http://192.168.1.9/huge.jpg"
+        hass = _hass_resolving_to("192.168.1.9")
+        view = AlbumArtView(hass)
+        resp = _FakeResponse(
+            status=200,
+            content_type="image/jpeg",
+            chunks=(b"x",),
+            headers={"Content-Length": str(50 * 1024 * 1024)},
+        )
+        with patch(
+            "custom_components.beatify.server.views.async_get_clientsession",
+            return_value=_session_returning(resp),
+        ):
+            out = await view.get(_request(_signed_query(url)))
+        assert out.status == 413
+
+    async def test_streamed_body_over_cap_returns_413(self):
+        url = "http://192.168.1.9/huge.jpg"
+        hass = _hass_resolving_to("192.168.1.9")
+        view = AlbumArtView(hass)
+        big = b"x" * (3 * 1024 * 1024)
+        resp = _FakeResponse(status=200, content_type="image/jpeg", chunks=(big, big))
+        with patch(
+            "custom_components.beatify.server.views.async_get_clientsession",
+            return_value=_session_returning(resp),
+        ):
+            out = await view.get(_request(_signed_query(url)))
+        assert out.status == 413


### PR DESCRIPTION
Closes #1356.

## Problem
`AlbumArtView` (`/beatify/api/albumart`, `requires_auth = False`) fetched **any** `http(s)` URL server-side and returned the body — an unauthenticated **open SSRF proxy**. Internal targets (supervisor API, `169.254.169.254` cloud metadata, LAN hosts) were readable, and `resp.read()` had **no size limit** (memory DoS). It is reachable from the internet via the Nabu Casa remote.

## Fix
**Primary guard — HMAC signature.** `proxy_album_art()` now appends an `&sig=` HMAC-SHA256 over the URL; `AlbumArtView` verifies it in constant time and 403s anything it didn't sign. The signing key is a per-process secret minted at startup, so only URLs the integration itself produced (from real Music Assistant `entity_picture` values) are ever fetched. A restart invalidates old signed URLs — clients 403 once and pick up the freshly-signed URL from the next state broadcast.

**Defence in depth:**
- **Host allow-list** — refuses loopback, link-local (incl. the `169.254.169.254` metadata endpoint), multicast, unspecified and reserved ranges. **RFC1918 private stays allowed on purpose** — that LAN address is the legitimate MA target the proxy exists for (#933); blocking it would break album art for every remote player.
- `allow_redirects=False` (no redirect-based bypass).
- **5 MiB streamed read cap** → `413` (rejects via `Content-Length` and while streaming).
- **`image/*` content-type check** → `415`.

## Tests
15 unit tests in `test_album_art_view.py`: signature validity/url-specificity, unsigned→403, forged→403, loopback→403, metadata→403, RFC1918 happy-path 200, non-image→415, oversize (header + streamed)→413. `66 passed` for album-art + media_player, `131 passed` across view/server tests. Ruff clean. No JS touched (no `min.js` drift).

## Notes / caveats
- Blocking RFC1918 (as the issue literally suggested) was **deliberately not done** — it would break #933's whole purpose. The HMAC signature is what actually closes the SSRF; the IP allow-list is belt-and-suspenders for ranges MA never lives in.
- DNS-rebinding: the host check resolves once before the fetch; aiohttp re-resolves on connect. With the HMAC gate in place (URLs are integration-produced) this is not exploitable in practice, but a pinned-IP connector would close the theoretical gap.
- Not yet verified against a live MA + Nabu Casa setup — album art should still load for remote players; worth a smoke test before un-drafting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)