### PR TITLE
fix: gate Companion auth-bypass behind opt-in option + drop loopback trust (#1357)

### DIFF
--- a/custom_components/beatify/__init__.py
+++ b/custom_components/beatify/__init__.py
@@ -18,7 +18,11 @@ from homeassistant.components.frontend import (
 )
 
 from .analytics import AnalyticsStorage
-from .const import DOMAIN
+from .const import (
+    CONF_ENABLE_COMPANION_AUTH_BYPASS,
+    DEFAULT_ENABLE_COMPANION_AUTH_BYPASS,
+    DOMAIN,
+)
 from .game.playlist import (
     async_discover_playlists,
     async_ensure_playlist_directory,
@@ -158,6 +162,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # Issue #603/#609: Create GameService facade
     game_service = GameService(hass, game_state)
 
+    # #1357: Companion auth-bypass opt-in. Read once at setup; the auth helper
+    # in server/companion_auth.py reads this live from hass.data per request,
+    # so the options-update listener below can flip it without a full reload.
+    companion_auth_bypass_enabled = entry.options.get(
+        CONF_ENABLE_COMPANION_AUTH_BYPASS, DEFAULT_ENABLE_COMPANION_AUTH_BYPASS
+    )
+
     # Store discovery results and game infrastructure
     hass.data[DOMAIN] = {
         "entry_id": entry.entry_id,
@@ -170,7 +181,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         "ws_handler": ws_handler,
         "stats": stats_service,
         "analytics": analytics,
+        "companion_auth_bypass_enabled": companion_auth_bypass_enabled,
     }
+
+    # #1357: refresh the bypass flag in place when the options change. No full
+    # reload is needed — companion_auth.py reads hass.data live per request.
+    entry.async_on_unload(entry.add_update_listener(_async_update_options))
 
     # Issue #441: Forward sensor and binary_sensor platforms
     await hass.config_entries.async_forward_entry_setups(
@@ -262,6 +278,25 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     _LOGGER.info("Beatify integration setup complete")
     return True
+
+
+async def _async_update_options(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Refresh in-place state when the integration options change (#1357).
+
+    Currently this only mirrors the ``enable_companion_auth_bypass`` toggle into
+    ``hass.data[DOMAIN]``. The auth helper reads that value live per request, so
+    flipping the option takes effect immediately without reloading the entry.
+    """
+    domain_data = hass.data.get(DOMAIN)
+    if not isinstance(domain_data, dict):
+        return
+    domain_data["companion_auth_bypass_enabled"] = entry.options.get(
+        CONF_ENABLE_COMPANION_AUTH_BYPASS, DEFAULT_ENABLE_COMPANION_AUTH_BYPASS
+    )
+    _LOGGER.debug(
+        "Beatify options updated: companion_auth_bypass_enabled=%s",
+        domain_data["companion_auth_bypass_enabled"],
+    )
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/custom_components/beatify/config_flow.py
+++ b/custom_components/beatify/config_flow.py
@@ -6,9 +6,20 @@ import logging
 from typing import Any
 
 import voluptuous as vol
-from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+from homeassistant.config_entries import (
+    ConfigEntry,
+    ConfigFlow,
+    ConfigFlowResult,
+    OptionsFlow,
+)
+from homeassistant.core import callback
+from homeassistant.helpers import config_validation as cv
 
-from .const import DOMAIN
+from .const import (
+    CONF_ENABLE_COMPANION_AUTH_BYPASS,
+    DEFAULT_ENABLE_COMPANION_AUTH_BYPASS,
+    DOMAIN,
+)
 from .services.media_player import async_get_media_players
 
 _LOGGER = logging.getLogger(__name__)
@@ -18,6 +29,12 @@ class BeatifyConfigFlow(ConfigFlow, domain=DOMAIN):
     """Config flow for Beatify."""
 
     VERSION = 1
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry: ConfigEntry) -> BeatifyOptionsFlow:
+        """Return the options flow handler for Beatify (#1357)."""
+        return BeatifyOptionsFlow()
 
     async def async_step_user(
         self,
@@ -68,3 +85,34 @@ class BeatifyConfigFlow(ConfigFlow, domain=DOMAIN):
             data_schema=vol.Schema({}),
             description_placeholders=description_placeholders,
         )
+
+
+class BeatifyOptionsFlow(OptionsFlow):
+    """Options flow for Beatify (#1357).
+
+    Exposes the single ``enable_companion_auth_bypass`` toggle. The bypass is
+    OFF by default; enabling it weakens auth on the local network and should
+    stay off unless the HA Android Companion app genuinely cannot authenticate.
+    """
+
+    async def async_step_init(
+        self,
+        user_input: dict[str, Any] | None = None,
+    ) -> ConfigFlowResult:
+        """Manage the Beatify options."""
+        if user_input is not None:
+            return self.async_create_entry(title="", data=user_input)
+
+        current = self.config_entry.options.get(
+            CONF_ENABLE_COMPANION_AUTH_BYPASS,
+            DEFAULT_ENABLE_COMPANION_AUTH_BYPASS,
+        )
+        data_schema = vol.Schema(
+            {
+                vol.Optional(
+                    CONF_ENABLE_COMPANION_AUTH_BYPASS,
+                    default=current,
+                ): cv.boolean,
+            }
+        )
+        return self.async_show_form(step_id="init", data_schema=data_schema)

--- a/custom_components/beatify/const.py
+++ b/custom_components/beatify/const.py
@@ -2,6 +2,14 @@
 
 DOMAIN = "beatify"
 
+# Companion auth-bypass opt-in (#1357). The HA Android Companion bypass in
+# server/companion_auth.py grants admin access on a UA + private-IP match with
+# zero credentials. That is unsafe behind Nabu Casa / reverse proxies, so the
+# bypass is OFF by default and only takes effect when the user explicitly
+# enables this option in the integration's options flow.
+CONF_ENABLE_COMPANION_AUTH_BYPASS = "enable_companion_auth_bypass"
+DEFAULT_ENABLE_COMPANION_AUTH_BYPASS = False
+
 # Game configuration
 MAX_PLAYERS = 20
 MIN_PLAYERS = 2

--- a/custom_components/beatify/manifest.json
+++ b/custom_components/beatify/manifest.json
@@ -1,6 +1,9 @@
 {
   "domain": "beatify",
   "name": "Beatify",
+  "after_dependencies": [
+    "cloud"
+  ],
   "codeowners": [
     "@mholzi"
   ],

--- a/custom_components/beatify/server/companion_auth.py
+++ b/custom_components/beatify/server/companion_auth.py
@@ -12,12 +12,26 @@ beatify treats it as authenticated even without a Bearer token. The bypass
 is intentionally conservative — desktop browsers, iOS Companion, and any
 internet-origin request fall through to the unchanged OAuth path.
 
-Threat model: the bypass adds no new attack surface beyond "anyone on the
-local network who can spoof an HA-Android-Companion User-Agent gains the
-admin endpoints that #998 protects (lights inventory, TTS trigger, host a
-game)". On a residential LAN this is roughly equivalent to "the network is
-already trusted"; on a hostile LAN, leave ``enable_companion_auth_bypass``
-off in the integration config.
+#1357 hardening — the bypass is now **opt-in and OFF by default**, gated on
+the ``enable_companion_auth_bypass`` integration option (stored live in
+``hass.data[DOMAIN]["companion_auth_bypass_enabled"]``). Two further defenses
+close the "internet-reachable bypass" hole:
+
+  * **No loopback in the trusted set.** ``127.0.0.0/8`` / ``::1/128`` are
+    deliberately excluded — a Companion WebView never connects from loopback,
+    only reverse proxies and Nabu Casa's snitun tunnel terminator do (snitun
+    hands requests to HA from 127.0.0.1). Removing loopback is the primary
+    structural defense for the Nabu Casa setup.
+  * **Cloud-connection refusal.** On the HTTP path we additionally consult
+    HA's ``is_cloud_connection(hass)`` helper and refuse the bypass for
+    cloud-tunnelled requests (defense-in-depth).
+
+Threat model: with the bypass enabled, the only added attack surface is
+"anyone on the local network who can spoof an HA-Android-Companion
+User-Agent gains the admin endpoints that #998 protects (lights inventory,
+TTS trigger, host a game)". On a residential LAN this is roughly equivalent
+to "the network is already trusted"; on a hostile LAN, leave
+``enable_companion_auth_bypass`` off (the default).
 """
 
 from __future__ import annotations
@@ -26,6 +40,8 @@ import ipaddress
 import logging
 import re
 from typing import TYPE_CHECKING
+
+from ..const import DOMAIN
 
 if TYPE_CHECKING:
     from aiohttp import web
@@ -42,18 +58,22 @@ _LOGGER = logging.getLogger(__name__)
 _ANDROID_RE = re.compile(r"Android", re.IGNORECASE)
 _HA_APP_RE = re.compile(r"Home\s?Assistant|HACompanion|Hass", re.IGNORECASE)
 
+# #1357: loopback (127.0.0.0/8, ::1/128) is intentionally NOT in this set.
+# A real HA Android Companion WebView never connects from loopback — only
+# reverse proxies and Nabu Casa's snitun tunnel terminator hand requests to
+# HA from 127.0.0.1. Trusting loopback was the core internet-reachable hole.
 _PRIVATE_NETS = [
     ipaddress.ip_network("10.0.0.0/8"),
     ipaddress.ip_network("172.16.0.0/12"),
     ipaddress.ip_network("192.168.0.0/16"),
-    ipaddress.ip_network("127.0.0.0/8"),
     ipaddress.ip_network("fc00::/7"),
-    ipaddress.ip_network("::1/128"),
 ]
 
 
 def is_local_remote(remote: str | None) -> bool:
-    """Return True if ``remote`` is an RFC1918 / loopback / ULA address.
+    """Return True if ``remote`` is an RFC1918 / ULA private address.
+
+    Loopback is deliberately excluded (#1357) — see ``_PRIVATE_NETS``.
 
     aiohttp sometimes hands us an IPv6-mapped IPv4 ("::ffff:192.168.1.5") —
     ``ipaddress`` parses that as IPv6 but its ``.ipv4_mapped`` attribute
@@ -77,15 +97,41 @@ def is_companion_ua(user_agent: str | None) -> bool:
     return bool(_ANDROID_RE.search(user_agent)) and bool(_HA_APP_RE.search(user_agent))
 
 
-def is_companion_trusted_request(request: web.Request) -> bool:
+def is_companion_trusted_request(request: web.Request, hass: HomeAssistant) -> bool:
     """Return True if an HTTP request comes from a trusted HA Android Companion.
 
-    A request is "trusted" when ALL three hold:
-      1. User-Agent matches the HA Android Companion regex.
-      2. Source IP is private/loopback (request did not cross the public internet).
-      3. (No header check — Companion's WebView does not reliably ship Bearer
+    A request is "trusted" when ALL of these hold (#1357):
+      0. The ``enable_companion_auth_bypass`` option is ON (default OFF). If the
+         bypass is disabled, this returns False immediately — no UA/IP is ever
+         trusted.
+      1. The request is NOT a Home Assistant Cloud (Nabu Casa) tunnelled
+         request. snitun terminates locally and would otherwise reach us from
+         127.0.0.1; loopback removal (see ``_PRIVATE_NETS``) is the primary
+         structural defense, this ``is_cloud_connection`` check is
+         defense-in-depth for the HTTP path.
+      2. User-Agent matches the HA Android Companion regex.
+      3. Source IP is private (RFC1918 / ULA; loopback excluded — request did
+         not cross the public internet and did not arrive via a local tunnel).
+      4. (No header check — Companion's WebView does not reliably ship Bearer
          when ha-auth.js fails, and that's exactly the case we're bypassing.)
     """
+    # #1357 gate: the whole bypass is opt-in and OFF by default.
+    if not hass.data.get(DOMAIN, {}).get("companion_auth_bypass_enabled", False):
+        return False
+
+    # #1357 defense-in-depth: refuse the bypass for Nabu Casa cloud-tunnelled
+    # requests. snitun terminates the tunnel locally, so request.remote would
+    # be 127.0.0.1 — loopback removal already blocks that, but the cloud helper
+    # also catches reverse-proxy/forwarded cases where remote was rewritten to
+    # a private IP. Lazily imported because the cloud component may be absent.
+    try:
+        from homeassistant.components.cloud import is_cloud_connection
+
+        if is_cloud_connection(hass):
+            return False
+    except Exception:  # noqa: BLE001 — cloud component unavailable / not a cloud context
+        pass
+
     ua = request.headers.get("User-Agent")
     remote = request.remote
     ua_match = is_companion_ua(ua)
@@ -106,13 +152,25 @@ def is_companion_trusted_request(request: web.Request) -> bool:
     return trusted
 
 
-def is_companion_trusted_meta(meta: dict | None) -> bool:
+def is_companion_trusted_meta(meta: dict | None, hass: HomeAssistant) -> bool:
     """Same check as :func:`is_companion_trusted_request` but for WebSocket meta.
 
     The WebSocket layer collects ``{ua, remote}`` from the incoming HTTP upgrade
     request and stashes it on the connection so message handlers can re-use the
     same trust decision.
+
+    #1357: same opt-in gate first — if the bypass is disabled, never trust.
+    Unlike the HTTP path, we do NOT call ``is_cloud_connection`` here: that
+    helper reads a request-scoped contextvar that is unreliable from a WS
+    message handler (the message arrives long after the HTTP upgrade, off the
+    original request context). We therefore rely on the enabled-gate plus the
+    loopback removal in ``_PRIVATE_NETS`` (snitun/proxy requests arrive from
+    127.0.0.1, which is no longer trusted) as the defense for the WS path.
     """
+    # #1357 gate: the whole bypass is opt-in and OFF by default.
+    if not hass.data.get(DOMAIN, {}).get("companion_auth_bypass_enabled", False):
+        return False
+
     if not isinstance(meta, dict):
         _LOGGER.info("[Companion-Debug] WS meta=None (no signature collected)")
         return False
@@ -166,7 +224,7 @@ def is_authorized_http(request: web.Request, hass: HomeAssistant) -> bool:
             "[Companion-Debug] HTTP path=%s bearer_present=True bearer_valid=False (falling back to bypass)",
             request.path,
         )
-    return is_companion_trusted_request(request)
+    return is_companion_trusted_request(request, hass)
 
 
 def extract_request_meta(request: web.Request) -> dict:

--- a/custom_components/beatify/server/ws_handlers.py
+++ b/custom_components/beatify/server/ws_handlers.py
@@ -115,7 +115,7 @@ def _is_ha_authenticated(
     """
     token = data.get("ha_token")
     if not token or not isinstance(token, str):
-        if _ws_companion_trusted(ws):
+        if _ws_companion_trusted(ws, handler.hass):
             _LOGGER.info(
                 "[WS auth] admin_connect: ha_token missing — accepting via "
                 "Companion bypass (UA+RFC1918 match on upgrade request)"
@@ -130,7 +130,7 @@ def _is_ha_authenticated(
     try:
         result = handler.hass.auth.async_validate_access_token(token)
     except Exception as err:  # noqa: BLE001 — any decode/validation error means "no"
-        if _ws_companion_trusted(ws):
+        if _ws_companion_trusted(ws, handler.hass):
             _LOGGER.info(
                 "[WS auth] admin_connect: ha_token unparseable (%s) — accepting "
                 "via Companion bypass",
@@ -145,7 +145,7 @@ def _is_ha_authenticated(
         )
         return False
     if result is None:
-        if _ws_companion_trusted(ws):
+        if _ws_companion_trusted(ws, handler.hass):
             _LOGGER.info(
                 "[WS auth] admin_connect: ha_token did not resolve to a refresh "
                 "token — accepting via Companion bypass"
@@ -163,12 +163,14 @@ def _is_ha_authenticated(
     return True
 
 
-def _ws_companion_trusted(ws: web.WebSocketResponse | None) -> bool:
+def _ws_companion_trusted(
+    ws: web.WebSocketResponse | None, hass: HomeAssistant
+) -> bool:
     """Check the request-meta stashed by ``BeatifyWebSocketHandler.handle``."""
     if ws is None:
         return False
     meta = getattr(ws, "beatify_request_meta", None)
-    return is_companion_trusted_meta(meta)
+    return is_companion_trusted_meta(meta, hass)
 
 
 # ---------------------------------------------------------------------------

--- a/custom_components/beatify/translations/de.json
+++ b/custom_components/beatify/translations/de.json
@@ -12,5 +12,19 @@
         "abort": {
             "already_configured": "Beatify ist bereits konfiguriert."
         }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "title": "Beatify-Optionen",
+                "description": "Erweiterte Authentifizierungseinstellungen. Belasse diese auf den Standardwerten, sofern du sie nicht ausdrücklich benötigst.",
+                "data": {
+                    "enable_companion_auth_bypass": "Auth-Bypass für die HA-Android-Companion-App aktivieren"
+                },
+                "data_description": {
+                    "enable_companion_auth_bypass": "Standardmäßig AUS. Wenn aktiv, werden Anfragen der HA-Android-Companion-App aus deinem lokalen Netzwerk ohne Login als Host behandelt. Das schwächt die Authentifizierung und sollte AUS bleiben, sofern sich die Companion-App nicht wirklich anders authentifizieren kann. NICHT aktivieren, wenn Beatify über Home Assistant Cloud (Nabu Casa) oder einen Reverse-Proxy erreichbar ist, der die echte Client-IP nicht weiterreicht — in solchen Setups könnte sonst ein Besucher aus dem Internet ohne Zugangsdaten Spiele hosten."
+                }
+            }
+        }
     }
 }

--- a/custom_components/beatify/translations/en.json
+++ b/custom_components/beatify/translations/en.json
@@ -12,5 +12,19 @@
         "abort": {
             "already_configured": "Beatify is already configured."
         }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "title": "Beatify options",
+                "description": "Advanced authentication settings. Leave these at their defaults unless you know you need them.",
+                "data": {
+                    "enable_companion_auth_bypass": "Enable HA Android Companion auth bypass"
+                },
+                "data_description": {
+                    "enable_companion_auth_bypass": "OFF by default. When on, requests from the HA Android Companion app on your local network are treated as the host without a login. This weakens authentication and should stay OFF unless the Companion app genuinely cannot authenticate. Do NOT enable it if Beatify is reachable through Home Assistant Cloud (Nabu Casa) or a reverse proxy that does not forward the real client IP — in those setups it could let an internet visitor host games without credentials."
+                }
+            }
+        }
     }
 }

--- a/custom_components/beatify/translations/es.json
+++ b/custom_components/beatify/translations/es.json
@@ -12,5 +12,19 @@
         "abort": {
             "already_configured": "Beatify ya está configurado."
         }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "title": "Opciones de Beatify",
+                "description": "Ajustes avanzados de autenticación. Déjalos con sus valores predeterminados a menos que sepas que los necesitas.",
+                "data": {
+                    "enable_companion_auth_bypass": "Activar el bypass de autenticación de la app HA Android Companion"
+                },
+                "data_description": {
+                    "enable_companion_auth_bypass": "Desactivado de forma predeterminada. Cuando está activado, las solicitudes de la app HA Android Companion en tu red local se tratan como el anfitrión sin necesidad de iniciar sesión. Esto debilita la autenticación y debería permanecer DESACTIVADO salvo que la app Companion realmente no pueda autenticarse. NO lo actives si Beatify es accesible a través de Home Assistant Cloud (Nabu Casa) o un proxy inverso que no reenvíe la IP real del cliente: en esos casos podría permitir que un visitante de Internet organice partidas sin credenciales."
+                }
+            }
+        }
     }
 }

--- a/custom_components/beatify/translations/fr.json
+++ b/custom_components/beatify/translations/fr.json
@@ -12,5 +12,19 @@
         "abort": {
             "already_configured": "Beatify est déjà configuré."
         }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "title": "Options de Beatify",
+                "description": "Paramètres d'authentification avancés. Laissez-les sur leurs valeurs par défaut sauf si vous savez en avoir besoin.",
+                "data": {
+                    "enable_companion_auth_bypass": "Activer le contournement d'authentification de l'app HA Android Companion"
+                },
+                "data_description": {
+                    "enable_companion_auth_bypass": "Désactivé par défaut. Lorsqu'il est activé, les requêtes de l'app HA Android Companion sur votre réseau local sont traitées comme l'hôte sans connexion. Cela affaiblit l'authentification et doit rester DÉSACTIVÉ sauf si l'app Companion ne peut vraiment pas s'authentifier. NE l'activez PAS si Beatify est accessible via Home Assistant Cloud (Nabu Casa) ou un proxy inverse qui ne transmet pas la véritable IP du client : dans ces configurations, un visiteur d'Internet pourrait héberger des parties sans identifiants."
+                }
+            }
+        }
     }
 }

--- a/custom_components/beatify/translations/nl.json
+++ b/custom_components/beatify/translations/nl.json
@@ -12,5 +12,19 @@
     "abort": {
       "already_configured": "Beatify is al geconfigureerd."
     }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Beatify-opties",
+        "description": "Geavanceerde authenticatie-instellingen. Laat deze op de standaardwaarden staan tenzij je zeker weet dat je ze nodig hebt.",
+        "data": {
+          "enable_companion_auth_bypass": "Auth-bypass voor de HA Android Companion-app inschakelen"
+        },
+        "data_description": {
+          "enable_companion_auth_bypass": "Standaard UIT. Indien ingeschakeld worden verzoeken van de HA Android Companion-app op je lokale netwerk zonder login als host behandeld. Dit verzwakt de authenticatie en moet UIT blijven tenzij de Companion-app echt niet kan authenticeren. Schakel dit NIET in als Beatify bereikbaar is via Home Assistant Cloud (Nabu Casa) of een reverse proxy die het echte client-IP niet doorgeeft — in die opstellingen zou een bezoeker van internet zonder inloggegevens spellen kunnen hosten."
+        }
+      }
+    }
   }
 }

--- a/tests/unit/_ha_stubs.py
+++ b/tests/unit/_ha_stubs.py
@@ -56,6 +56,24 @@ class _ConfigFlow:
         return {"type": "form", **kwargs}
 
 
+class _OptionsFlow:
+    """OptionsFlow stand-in for the #1357 companion-bypass toggle.
+
+    Mirrors :class:`_ConfigFlow`'s helpers and carries a ``config_entry``
+    attribute (real HA injects the entry into the OptionsFlow instance) so
+    ``async_step_init`` can read ``self.config_entry.options``.
+    """
+
+    hass: Any = None
+    config_entry: Any = None
+
+    def async_create_entry(self, **kwargs: Any) -> dict[str, Any]:
+        return {"type": "create_entry", **kwargs}
+
+    def async_show_form(self, **kwargs: Any) -> dict[str, Any]:
+        return {"type": "form", **kwargs}
+
+
 def install() -> None:
     """Force-install real HA stubs needed by the B6 platform modules."""
     core = _module("homeassistant.core")
@@ -67,6 +85,7 @@ def install() -> None:
     ce.ConfigEntry = object  # type: ignore[attr-defined]
     ce.ConfigFlowResult = dict  # type: ignore[attr-defined]
     ce.ConfigFlow = _ConfigFlow  # type: ignore[attr-defined]
+    ce.OptionsFlow = _OptionsFlow  # type: ignore[attr-defined]
 
     # Base entity classes expose a no-op async_write_ha_state so _on_state_changed
     # can be invoked directly in tests.
@@ -92,3 +111,15 @@ def install() -> None:
     # (empty) data schema, so a passthrough callable is enough.
     vol = _module("voluptuous")
     vol.Schema = lambda schema=None, **kwargs: schema  # type: ignore[attr-defined]
+    # #1357: the OptionsFlow schema uses ``vol.Optional(key, default=...)`` as a
+    # dict key and ``cv.boolean`` as its value. The stub only needs the import
+    # to resolve and ``async_step_init`` to build *a* schema object — identity /
+    # passthrough callables are enough (no real validation happens in tests).
+    vol.Optional = lambda key, **kwargs: key  # type: ignore[attr-defined]
+
+    # ``config_flow`` does ``from homeassistant.helpers import
+    # config_validation as cv`` (#1357) and references ``cv.boolean`` as the
+    # voluptuous validator for the toggle. config_validation is not installed in
+    # the minimal CI env, so stub the module with a passthrough ``boolean``.
+    cv = _module("homeassistant.helpers.config_validation")
+    cv.boolean = lambda value: value  # type: ignore[attr-defined]

--- a/tests/unit/test_companion_auth.py
+++ b/tests/unit/test_companion_auth.py
@@ -1,11 +1,14 @@
-"""Tests for the HA Android Companion auth-bypass (#1131)."""
+"""Tests for the HA Android Companion auth-bypass (#1131, hardened in #1357)."""
 
 from __future__ import annotations
 
+import sys
+from types import ModuleType
 from unittest.mock import MagicMock
 
 import pytest
 
+from custom_components.beatify.const import DOMAIN
 from custom_components.beatify.server.companion_auth import (
     extract_request_meta,
     is_authorized_http,
@@ -60,13 +63,11 @@ class TestLocalRemote:
             "10.255.255.255",
             "172.16.0.1",
             "172.31.255.254",
-            "127.0.0.1",
-            "::1",
             "fc00::1",
             "fd12:3456:789a::1",
         ],
     )
-    def test_accepts_private_and_loopback(self, ip):
+    def test_accepts_private(self, ip):
         assert is_local_remote(ip) is True
 
     @pytest.mark.parametrize(
@@ -77,9 +78,14 @@ class TestLocalRemote:
             "172.32.0.1",  # outside 172.16/12
             "11.0.0.1",
             "2001:db8::1",
+            # #1357: loopback is NO LONGER trusted — only proxies/tunnels
+            # (snitun, reverse proxies) connect from loopback, never a real
+            # Companion WebView.
+            "127.0.0.1",
+            "::1",
         ],
     )
-    def test_rejects_public_internet(self, ip):
+    def test_rejects_public_and_loopback(self, ip):
         assert is_local_remote(ip) is False
 
     def test_handles_ipv6_mapped_ipv4(self):
@@ -91,6 +97,55 @@ class TestLocalRemote:
         assert is_local_remote(None) is False
         assert is_local_remote("") is False
         assert is_local_remote("not-an-ip") is False
+
+
+# ---------------------------------------------------------------------------
+# hass helpers (#1357 — bypass is gated on hass.data live flag)
+# ---------------------------------------------------------------------------
+
+
+def _hass(*, bypass_enabled: bool = True, valid_token: str | None = None) -> MagicMock:
+    """Build a hass mock with the #1357 bypass flag set in hass.data."""
+    hass = MagicMock()
+    hass.data = {DOMAIN: {"companion_auth_bypass_enabled": bypass_enabled}}
+
+    def _validate(token):
+        if valid_token is not None and token == valid_token:
+            return MagicMock()  # represents a RefreshToken
+        return None
+
+    hass.auth.async_validate_access_token.side_effect = _validate
+    return hass
+
+
+@pytest.fixture
+def _fake_cloud_not_connected():
+    """Inject a fake homeassistant.components.cloud whose is_cloud_connection -> False.
+
+    ``homeassistant.components.cloud`` is NOT stubbed in conftest.py, so the
+    lazy import in companion_auth would otherwise raise (caught by the
+    except-pass). For the "trusted" cases we inject a benign module so the
+    cloud check runs and returns False (request is not cloud-tunnelled).
+    """
+    mod = ModuleType("homeassistant.components.cloud")
+    mod.is_cloud_connection = lambda hass: False  # type: ignore[attr-defined]
+    sys.modules["homeassistant.components.cloud"] = mod
+    try:
+        yield
+    finally:
+        sys.modules.pop("homeassistant.components.cloud", None)
+
+
+@pytest.fixture
+def _fake_cloud_connected():
+    """Inject a fake homeassistant.components.cloud whose is_cloud_connection -> True."""
+    mod = ModuleType("homeassistant.components.cloud")
+    mod.is_cloud_connection = lambda hass: True  # type: ignore[attr-defined]
+    sys.modules["homeassistant.components.cloud"] = mod
+    try:
+        yield
+    finally:
+        sys.modules.pop("homeassistant.components.cloud", None)
 
 
 # ---------------------------------------------------------------------------
@@ -111,37 +166,75 @@ def _request(ua: str | None, remote: str | None, auth: str | None = None) -> Mag
 
 
 class TestIsCompanionTrustedRequest:
-    def test_companion_ua_plus_local_net_is_trusted(self):
+    def test_companion_ua_plus_local_net_is_trusted(self, _fake_cloud_not_connected):
         req = _request("Home Assistant/2026 (Android 14)", "192.168.1.5")
-        assert is_companion_trusted_request(req) is True
+        assert is_companion_trusted_request(req, _hass()) is True
 
-    def test_companion_ua_but_public_remote_is_not_trusted(self):
+    def test_companion_ua_but_public_remote_is_not_trusted(
+        self, _fake_cloud_not_connected
+    ):
         # UA-spoof from the public internet must not gain admin access.
         req = _request("Home Assistant/2026 (Android 14)", "8.8.8.8")
-        assert is_companion_trusted_request(req) is False
+        assert is_companion_trusted_request(req, _hass()) is False
 
-    def test_desktop_ua_on_local_net_is_not_trusted(self):
+    def test_desktop_ua_on_local_net_is_not_trusted(self, _fake_cloud_not_connected):
         # Local-net alone isn't enough — must look like Companion.
         req = _request("Mozilla/5.0 (Macintosh) Safari/17", "192.168.1.5")
-        assert is_companion_trusted_request(req) is False
+        assert is_companion_trusted_request(req, _hass()) is False
 
-    def test_missing_ua_is_not_trusted(self):
+    def test_missing_ua_is_not_trusted(self, _fake_cloud_not_connected):
         req = _request(None, "192.168.1.5")
-        assert is_companion_trusted_request(req) is False
+        assert is_companion_trusted_request(req, _hass()) is False
+
+    def test_loopback_remote_is_not_trusted(self, _fake_cloud_not_connected):
+        # #1357: a request arriving from 127.0.0.1 (snitun / reverse proxy)
+        # with a perfect Companion UA must NOT be trusted.
+        req = _request("Home Assistant/2026 (Android 14)", "127.0.0.1")
+        assert is_companion_trusted_request(req, _hass()) is False
+
+    def test_bypass_disabled_rejects_perfect_companion(self):
+        # #1357: with the opt-in flag OFF (default), even a perfect Companion
+        # UA + LAN IP is rejected. No cloud module is injected — the disabled
+        # gate short-circuits before the lazy import is reached.
+        req = _request("Home Assistant/2026 (Android 14)", "192.168.1.5")
+        assert is_companion_trusted_request(req, _hass(bypass_enabled=False)) is False
+
+    def test_bypass_enabled_but_cloud_connection_rejected(self, _fake_cloud_connected):
+        # #1357: bypass on, perfect Companion signature, but the request is a
+        # Nabu Casa cloud-tunnelled request -> refuse.
+        req = _request("Home Assistant/2026 (Android 14)", "192.168.1.5")
+        assert is_companion_trusted_request(req, _hass()) is False
+
+    def test_cloud_import_unavailable_falls_through(self):
+        # #1357: when homeassistant.components.cloud is not importable (the
+        # default test env), the except-pass lets the UA + IP check proceed.
+        assert "homeassistant.components.cloud" not in sys.modules
+        req = _request("Home Assistant/2026 (Android 14)", "192.168.1.5")
+        assert is_companion_trusted_request(req, _hass()) is True
 
 
 class TestIsCompanionTrustedMeta:
     def test_accepts_stashed_meta_with_companion_signature(self):
         meta = {"ua": "Home Assistant/2026 (Android 14)", "remote": "192.168.1.5"}
-        assert is_companion_trusted_meta(meta) is True
+        assert is_companion_trusted_meta(meta, _hass()) is True
 
     def test_rejects_public_remote(self):
         meta = {"ua": "Home Assistant/2026 (Android 14)", "remote": "8.8.8.8"}
-        assert is_companion_trusted_meta(meta) is False
+        assert is_companion_trusted_meta(meta, _hass()) is False
+
+    def test_rejects_loopback_remote(self):
+        # #1357: loopback no longer trusted on the WS path either.
+        meta = {"ua": "Home Assistant/2026 (Android 14)", "remote": "127.0.0.1"}
+        assert is_companion_trusted_meta(meta, _hass()) is False
 
     def test_rejects_empty_meta(self):
-        assert is_companion_trusted_meta(None) is False
-        assert is_companion_trusted_meta({}) is False
+        assert is_companion_trusted_meta(None, _hass()) is False
+        assert is_companion_trusted_meta({}, _hass()) is False
+
+    def test_bypass_disabled_rejects_perfect_companion(self):
+        # #1357: opt-in gate also guards the WS path.
+        meta = {"ua": "Home Assistant/2026 (Android 14)", "remote": "192.168.1.5"}
+        assert is_companion_trusted_meta(meta, _hass(bypass_enabled=False)) is False
 
 
 # ---------------------------------------------------------------------------
@@ -149,73 +242,69 @@ class TestIsCompanionTrustedMeta:
 # ---------------------------------------------------------------------------
 
 
-def _hass_with_token(valid_token: str | None) -> MagicMock:
-    hass = MagicMock()
-
-    def _validate(token):
-        if valid_token is not None and token == valid_token:
-            return MagicMock()  # represents a RefreshToken
-        return None
-
-    hass.auth.async_validate_access_token.side_effect = _validate
-    return hass
-
-
 class TestIsAuthorizedHttp:
     async def test_valid_bearer_authorizes_any_origin(self):
         # Path 1 (Bearer) does not depend on UA / remote — same behavior as
-        # HA's own requires_auth=True middleware.
+        # HA's own requires_auth=True middleware. Does not consult the bypass,
+        # so no cloud module / bypass flag is needed.
         req = _request(
             "Mozilla/5.0 (Macintosh) Safari/17",
             "203.0.113.5",  # public IP — doesn't matter for Bearer path
             auth="Bearer good-token",
         )
-        hass = _hass_with_token("good-token")
+        hass = _hass(bypass_enabled=False, valid_token="good-token")
         assert is_authorized_http(req, hass) is True
 
-    async def test_invalid_bearer_falls_through_to_companion_path(self):
+    async def test_invalid_bearer_falls_through_to_companion_path(
+        self, _fake_cloud_not_connected
+    ):
         # Bearer is well-formed but HA auth manager rejects it. Companion
-        # signature should still rescue the request when valid.
+        # signature should still rescue the request when the bypass is enabled.
         req = _request(
             "Home Assistant/2026 (Android 14)",
             "192.168.1.5",
             auth="Bearer not-a-real-token",
         )
-        hass = _hass_with_token(None)
-        assert is_authorized_http(req, hass) is True
+        assert is_authorized_http(req, _hass()) is True
 
-    async def test_invalid_bearer_and_no_companion_returns_false(self):
+    async def test_invalid_bearer_and_no_companion_returns_false(
+        self, _fake_cloud_not_connected
+    ):
         req = _request(
             "Mozilla/5.0 (Macintosh) Safari/17",
             "192.168.1.5",
             auth="Bearer not-a-real-token",
         )
-        hass = _hass_with_token(None)
-        assert is_authorized_http(req, hass) is False
+        assert is_authorized_http(req, _hass()) is False
 
-    async def test_no_bearer_companion_local_authorizes(self):
+    async def test_no_bearer_companion_local_authorizes(
+        self, _fake_cloud_not_connected
+    ):
         # The #1131 happy path — Companion fails to attach a token, server
-        # picks up the request via UA + RFC1918.
+        # picks up the request via UA + RFC1918 (bypass enabled).
         req = _request("Home Assistant/2026 (Android 14)", "192.168.1.5")
-        hass = _hass_with_token(None)
-        assert is_authorized_http(req, hass) is True
+        assert is_authorized_http(req, _hass()) is True
 
-    async def test_no_bearer_companion_public_remote_rejects(self):
+    async def test_no_bearer_companion_public_remote_rejects(
+        self, _fake_cloud_not_connected
+    ):
         # An attacker spoofing UA from the internet must NOT get access.
         req = _request("Home Assistant/2026 (Android 14)", "8.8.8.8")
-        hass = _hass_with_token(None)
-        assert is_authorized_http(req, hass) is False
+        assert is_authorized_http(req, _hass()) is False
 
-    async def test_no_bearer_desktop_local_rejects(self):
+    async def test_no_bearer_desktop_local_rejects(self, _fake_cloud_not_connected):
         # Desktop user without a token stays 401 — no Companion-UA, no bypass.
         req = _request("Mozilla/5.0 (Macintosh) Safari/17", "192.168.1.5")
-        hass = _hass_with_token(None)
-        assert is_authorized_http(req, hass) is False
+        assert is_authorized_http(req, _hass()) is False
 
-    async def test_no_bearer_no_ua_no_remote_rejects(self):
+    async def test_no_bearer_no_ua_no_remote_rejects(self, _fake_cloud_not_connected):
         req = _request(None, None)
-        hass = _hass_with_token(None)
-        assert is_authorized_http(req, hass) is False
+        assert is_authorized_http(req, _hass()) is False
+
+    async def test_bypass_disabled_rejects_companion(self):
+        # #1357: with the opt-in flag OFF, the Companion fallback is dead.
+        req = _request("Home Assistant/2026 (Android 14)", "192.168.1.5")
+        assert is_authorized_http(req, _hass(bypass_enabled=False)) is False
 
 
 class TestExtractRequestMeta:

--- a/tests/unit/test_setup_reload_routes.py
+++ b/tests/unit/test_setup_reload_routes.py
@@ -141,7 +141,16 @@ def _patch_heavy_helpers(monkeypatch):
 
 
 def _make_entry(entry_id: str = "entry-1"):
-    return SimpleNamespace(entry_id=entry_id)
+    # #1357: async_setup_entry now reads ``entry.options`` for the Companion
+    # auth-bypass toggle and registers an options-update listener via
+    # ``add_update_listener`` / ``async_on_unload``. Provide inert stand-ins so
+    # these route-registration reload tests stay focused on routing.
+    return SimpleNamespace(
+        entry_id=entry_id,
+        options={},
+        add_update_listener=MagicMock(return_value=lambda: None),
+        async_on_unload=MagicMock(),
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## The vulnerability (Critical, auth)

`server/companion_auth.py` granted full admin access (lights inventory, TTS, host game — every `#998`-protected view in `views.py` / `game_views.py` and the WS `admin_connect` path) with **zero credentials** whenever a request had:

1. a User-Agent matching the HA Android Companion regex, and
2. `request.remote` in an RFC1918/loopback range.

Two problems made this internet-reachable:

- **Loopback was trusted.** Behind **Nabu Casa**, snitun terminates the tunnel locally, so requests arrive from `127.0.0.1`. Behind a reverse proxy that doesn't forward the real client IP, `request.remote` is the proxy's LAN/loopback address. In both setups any internet attacker who sets a Companion-looking UA (two `curl -A` flags) was fully authorized.
- **The bypass was always-on.** The `enable_companion_auth_bypass` option referenced in the module docstring **did not actually exist or gate anything** (confirmed by grep — it appeared only in the docstring). The bypass ran unconditionally.

## The fix (three confirmed requirements)

**1. Opt-in option, default OFF, actually gating the bypass**
- `const.py`: `CONF_ENABLE_COMPANION_AUTH_BYPASS` + `DEFAULT_ENABLE_COMPANION_AUTH_BYPASS = False`.
- `config_flow.py`: new `BeatifyOptionsFlow` (`async_get_options_flow` → `async_step_init`) with a single `cv.boolean` toggle defaulting to the current value; saved via `async_create_entry(title="", data=...)`.
- `__init__.py`: `async_setup_entry` reads `entry.options.get(...)` into `hass.data[DOMAIN]["companion_auth_bypass_enabled"]` and registers an options-update listener (`entry.add_update_listener(_async_update_options)`) that refreshes the flag **in place** — no full reload needed because the auth helper reads `hass.data` live per request.
- `translations/{en,de,es,fr,nl}.json`: `options` step strings with a warning that this weakens auth, should stay OFF unless the Companion app genuinely can't authenticate, and must NOT be enabled behind Nabu Casa / a reverse proxy that doesn't forward the real client IP.

**2. Gate the whole bypass + reject cloud-tunnelled requests**
- `is_companion_trusted_request(request, hass)` and `is_companion_trusted_meta(meta, hass)` now take `hass` and **return `False` immediately if the flag is off**.
- HTTP path additionally refuses Nabu Casa requests via a lazily-imported `homeassistant.components.cloud.is_cloud_connection(hass)` (wrapped in `try/except` so an absent cloud component is harmless).
- `is_authorized_http` passes `hass` through. `DOMAIN` imported from `..const`.

**3. Remove loopback from the trusted set**
- `127.0.0.0/8` and `::1/128` deleted from `_PRIVATE_NETS` (kept 10/8, 172.16/12, 192.168/16, fc00::/7). `is_local_remote` docstring updated.

**`hass` threading at the WS call site**
- `ws_handlers.py`: `_ws_companion_trusted(ws, hass)`; the three call sites in `_is_ha_authenticated` pass `handler.hass`; `is_companion_trusted_meta(meta, hass)` updated accordingly.

## Rationale: cloud-check + loopback-removal

The **loopback removal** is the primary structural defense for Nabu Casa: snitun hands requests to HA from `127.0.0.1`, which is no longer trusted, so the bypass can never fire for a tunnelled request regardless of UA. The **`is_cloud_connection` check** is defense-in-depth on the HTTP path (also catches reverse-proxy/forwarded cases where `remote` was rewritten to a private IP). On the **WS path** we deliberately do NOT call `is_cloud_connection`: it reads a request-scoped contextvar that is unreliable from a WS message handler (the message arrives long after the HTTP upgrade), so the WS path relies on the enabled-gate + loopback removal. Comments in the code document all of this.

## Omitted "Player-…" requirement (flag, not guessed)

Markus's instruction was truncated mid-sentence at **"Player-…"** — a possible 4th requirement that could not be confirmed. This PR implements **only the three confirmed requirements above**; any player-endpoint-scoping addendum is deferred pending clarification.

## Player-join-path verification

The **player WS join path is NOT affected** by the bypass gate. Confirmed by reading `handle_join` in `ws_handlers.py`: normal players join with `is_admin=False` and never reach `_is_ha_authenticated` / `_ws_companion_trusted`. Only the `is_admin=True` admin-claim branch (the `#998`-protected path) consults the Companion trust decision. So tightening the bypass cannot lock out ordinary players — it only restricts who can claim the host/admin role.

## Test coverage (`tests/unit/test_companion_auth.py`)

- `127.0.0.1` / `::1` moved from accepted → rejected lists.
- Existing "bypass authorizes" cases now build a `hass` mock with `companion_auth_bypass_enabled=True` (since default is now off) and inject a fake `homeassistant.components.cloud` (`is_cloud_connection -> False`).
- New tests: (a) bypass **disabled** → trusted returns `False` even for a perfect Companion UA + LAN IP (HTTP, WS, and `is_authorized_http`); (b) bypass enabled but `is_cloud_connection` returns `True` (fake module injected via `sys.modules`) → `False`; (c) bypass enabled + private non-loopback IP + Companion UA + not cloud → `True`; (d) the default no-injection path still works through the `except: pass` fallback.

## Quality gate (run in an isolated `/tmp` worktree off `origin/main`)

- `pytest`: **892 passed, 2 skipped** (full suite).
- `ruff check .` (0.15.7, matching CI): **All checks passed**.
- `ruff format --check .`: clean (95 files).
- `mypy` (1.18.2, gated `pyproject [tool.mypy]` scope): **Success, no issues** (the changed modules aren't in the gated `files` list, but they introduce no new mypy errors).

## Readiness — honest assessment

This is **security-critical and was NOT validated against a live HA instance.** The config-flow option, the options-update listener, and the `is_cloud_connection` cloud detection are exercised by unit tests with mocks but **need a real-HA smoke test** before relying on them in production:
- verify the new options toggle appears in the integration's UI and persists,
- verify enabling/disabling it flips behaviour without a reload,
- verify `is_cloud_connection` resolves correctly for an actual Nabu Casa request.

No frontend changes (no `min.js` / cache-buster / `sw.js` work needed). Default-OFF means the worst-case post-merge behaviour is the bypass simply not firing — fail-closed, which is the safe direction for a security fix.

Closes #1357
