### PR TITLE
fix: keep all Amazon Music tracks playable across rounds (#1361)

### DIFF
--- a/custom_components/beatify/game/playlist.py
+++ b/custom_components/beatify/game/playlist.py
@@ -475,8 +475,25 @@ def get_song_uri(
         # For Deezer, only use uri_deezer
         return song.get("uri_deezer") or None
     if provider == PROVIDER_AMAZON_MUSIC:
-        # Amazon Music uses Alexa text search — no URI needed; all songs are playable.
-        return PROVIDER_AMAZON_MUSIC
+        # Amazon Music uses Alexa text search — there is no real per-track URI.
+        # We still must return a *distinct* identity per song, because the
+        # PlaylistManager uses this value both as the dedup key (__init__) and
+        # as the played-tracking key (mark_played). Returning a single constant
+        # for every song collapsed the whole playlist to one playable track and
+        # ended every Alexa game after round 1 (#1361). Derive a stable key from
+        # the song's artist+title so each track survives dedup and is tracked
+        # independently. `_resolved_uri` is only ever consumed for Alexa
+        # text-search (artist+title), never as a real media URI, so this
+        # synthetic key is purely internal.
+        artist = (song.get("artist") or "").strip().casefold()
+        title = (song.get("title") or "").strip().casefold()
+        if artist or title:
+            return f"amazon:{artist}|{title}"
+        # No metadata at all — fall back to the song's id so it stays distinct.
+        song_id = song.get("id")
+        if song_id is not None:
+            return f"amazon:id:{song_id}"
+        return None
     return None
 
 

--- a/tests/unit/test_playlist.py
+++ b/tests/unit/test_playlist.py
@@ -10,6 +10,7 @@ runtime never even tries to play them.
 from __future__ import annotations
 
 from custom_components.beatify.const import (
+    PROVIDER_AMAZON_MUSIC,
     PROVIDER_APPLE_MUSIC,
     PROVIDER_SPOTIFY,
 )
@@ -201,3 +202,85 @@ class TestPlaylistManagerStorefrontFiltering:
         picked = pm.get_next_song()
         assert picked is not None
         assert picked["_resolved_uri"] == "applemusic://track/legacy"
+
+
+# ---------------------------------------------------------------------------
+# Amazon Music — per-song identity (regression for #1361)
+# ---------------------------------------------------------------------------
+#
+# Amazon Music plays via Alexa text-search, so there is no real per-track URI.
+# Previously ``get_song_uri`` returned the constant ``"amazon_music"`` for every
+# song. Because PlaylistManager uses that value both as the dedup key (in
+# ``__init__``) AND as the played-tracking key (``mark_played``), the whole
+# playlist collapsed to a single playable track and every Alexa game ended after
+# round 1. These tests pin the per-song identity behavior so that never
+# regresses.
+
+
+def _amazon_song(artist: str, title: str, year: int = 1990) -> dict:
+    """Minimal Amazon-Music-style song (no URI fields — Alexa text-search)."""
+    return {"artist": artist, "title": title, "year": year}
+
+
+class TestGetSongUriAmazonMusic:
+    def test_distinct_songs_get_distinct_keys(self):
+        a = get_song_uri(_amazon_song("ABBA", "Waterloo"), PROVIDER_AMAZON_MUSIC)
+        b = get_song_uri(
+            _amazon_song("Queen", "Bohemian Rhapsody"), PROVIDER_AMAZON_MUSIC
+        )
+        assert a != b
+        assert a is not None and b is not None
+
+    def test_key_is_stable_for_same_song(self):
+        song = _amazon_song("ABBA", "Waterloo")
+        assert get_song_uri(song, PROVIDER_AMAZON_MUSIC) == get_song_uri(
+            song, PROVIDER_AMAZON_MUSIC
+        )
+
+    def test_key_is_case_insensitive(self):
+        assert get_song_uri(
+            _amazon_song("ABBA", "Waterloo"), PROVIDER_AMAZON_MUSIC
+        ) == get_song_uri(_amazon_song("abba", "waterloo"), PROVIDER_AMAZON_MUSIC)
+
+    def test_falls_back_to_id_when_no_metadata(self):
+        key = get_song_uri({"id": 42}, PROVIDER_AMAZON_MUSIC)
+        assert key == "amazon:id:42"
+
+
+class TestPlaylistManagerAmazonMusic:
+    def test_full_playlist_survives_dedup(self):
+        """#1361: all 10 distinct songs survive — not collapsed to one."""
+        songs = [_amazon_song(f"Artist {i}", f"Title {i}") for i in range(10)]
+        pm = PlaylistManager(songs, provider=PROVIDER_AMAZON_MUSIC)
+        assert pm.get_total_count() == 10
+
+    def test_ten_successive_rounds_play_all_songs(self):
+        """#1361: a 10-song Amazon game must run 10 rounds, not end after 1.
+
+        Mirrors the runtime loop: get_next_song() then
+        mark_played(_resolved_uri). With the old constant URI, mark_played
+        poisoned the whole pool after round 1 and get_next_song returned None.
+        """
+        songs = [_amazon_song(f"Artist {i}", f"Title {i}") for i in range(10)]
+        pm = PlaylistManager(songs, provider=PROVIDER_AMAZON_MUSIC)
+
+        played: list[str] = []
+        for _ in range(10):
+            song = pm.get_next_song()
+            assert song is not None, "game ended early — pool collapsed"
+            played.append(song["_resolved_uri"])
+            pm.mark_played(song["_resolved_uri"])
+
+        # All 10 rounds played distinct songs, and the pool is now exhausted.
+        assert len(set(played)) == 10
+        assert pm.get_next_song() is None
+        assert pm.get_remaining_count() == 0
+
+    def test_true_duplicate_songs_are_deduped(self):
+        """Identical artist+title genuinely collapse (intended dedup)."""
+        songs = [
+            _amazon_song("ABBA", "Waterloo"),
+            _amazon_song("ABBA", "Waterloo"),
+        ]
+        pm = PlaylistManager(songs, provider=PROVIDER_AMAZON_MUSIC)
+        assert pm.get_total_count() == 1


### PR DESCRIPTION
Closes #1361

## Summary
Amazon Music games collapsed to a single playable song and ended after round 1. Root cause: `get_song_uri()` returned the constant `"amazon_music"` for **every** song when the provider is `amazon_music`. `PlaylistManager` uses that value as **both** the dedup key (`__init__`) **and** the played-tracking key (`mark_played`):

- In `__init__`, all songs after the first hit `if uri in seen_uris: continue` and were dropped, so the playable pool, `total_rounds`, and `get_total_count()` all became 1.
- Even with one song surviving, `mark_played("amazon_music")` (called from `round_manager.initialize_round` with `_resolved_uri == "amazon_music"`) marked the shared key played after round 1, so `_pick_from_pool` returned `None` and the game ended.

`amazon_music` is a real, selectable provider (admin UI + `services/media_player.py` Alexa text-search playback), so every Alexa-platform game was a 1-round game.

## Fix
For `amazon_music`, `get_song_uri()` now returns a **distinct, stable per-song identity** instead of a constant:
- `amazon:<artist>|<title>` (both `.strip().casefold()`d), or
- `amazon:id:<id>` when artist+title are both missing, or
- `None` only when there's no metadata at all.

This makes dedup, played-set membership, and `mark_played` coherent again, so all tracks survive and each is tracked independently. `_resolved_uri` for `amazon_music` is only ever consumed by the Alexa text-search path (`_play_via_alexa` → `_get_alexa_search_text`, which uses artist+title), **never** as a real media URI — so this synthetic internal key has no playback side effects. As a bonus, per-song difficulty stats (keyed on `_resolved_uri` in the serializer) are now per-track instead of all sharing one bucket.

## Test plan
**Automated** (added to `tests/unit/test_playlist.py`):
- `TestGetSongUriAmazonMusic`: distinct songs get distinct keys; key stable + case-insensitive; id fallback.
- `TestPlaylistManagerAmazonMusic`: 10-song playlist keeps `get_total_count() == 10`; 10 successive `get_next_song()`+`mark_played()` rounds play 10 distinct songs then exhaust the pool (`get_next_song() is None`, `get_remaining_count() == 0`); true duplicate (same artist+title) tracks still dedupe to 1.

**Manual:** start an Alexa/Amazon-Music game with a 10-song playlist → it should run all 10 rounds instead of ending after round 1.

Gates: `pytest` 892 passed / 2 skipped · `ruff check .` clean · `ruff format --check .` clean · `mypy` 1.18.2 clean.

## Risk assessment
- **Blast radius:** `custom_components/beatify/game/playlist.py` (`get_song_uri` amazon branch only) + its unit test. No other provider's branch changed. No frontend touched.
- **What could go wrong:** if two genuinely different Amazon tracks share an identical artist+title, they dedupe to one (intended — that's a true duplicate). Songs with no artist/title/id at all resolve to `None` and are skipped (same as other providers with missing URIs).
- **What I did NOT test:** live Alexa playback against a real device (no hardware); behavior was verified to route through the artist+title text-search path by code inspection of `services/media_player.py`.

## Readiness assessment
- [x] Ready to merge
- [ ] Borderline — see notes
- [ ] Not ready — needs human review

**Honest summary:** Root cause is unambiguous and matches the issue's own analysis; the fix is the minimal, coherent change (one provider branch) with a regression test that reproduces the exact 1-round failure and proves all 10 rounds now play. The only unverified surface is live Alexa hardware playback, which this change doesn't alter (it never fed a real URI).

🤖 Auto-generated by issue-triage routine