### PR TITLE
fix: broadcast game-end + winner ceremony on unattended REVEAL auto-advance (#1360)

### DIFF
--- a/custom_components/beatify/game/state_auto_advance.py
+++ b/custom_components/beatify/game/state_auto_advance.py
@@ -54,6 +54,11 @@ The mixin relies on attributes / methods the host class owns and that live on
 * ``self.start_round`` — the next-round trigger the auto-advance fires.
 * ``self._on_round_end`` — the async WebSocket broadcast callback mirrored after
   the auto-advance ``start_round`` so the new PLAYING state reaches clients.
+* ``self.advance_to_end`` — the terminal game-end ceremony (party-light
+  celebration + winner/podium TTS + END transition; lives on
+  ``RevealTransitionMixin``). Run when the auto-advance carries the final round
+  and ``start_round`` exhausts the playlist (#1360), so the unattended end fires
+  the same ceremony + broadcast as the manual ``admin_next_round`` game-end.
 
 It carries no state of its own. ``GamePhase`` is imported lazily inside the
 methods that need it (``# noqa: PLC0415``) to avoid a top-level circular import
@@ -137,13 +142,32 @@ class RevealAutoAdvanceMixin:
                 elapsed,
             )
             success = await self.start_round()
+            # #1360: when the playlist is exhausted, start_round() flips the
+            # phase to END and returns False (a bare _set_phase(END), NOT the
+            # advance_to_end() terminal path). On this unattended final round
+            # the manual admin_next_round game-end ceremony never runs, so
+            # without intervention here the game ends with: no party-light
+            # celebration, no announce_winner/announce_podium TTS, and — because
+            # success is False — no broadcast, leaving every client frozen on
+            # REVEAL. Run the proper terminal ceremony so the unattended end
+            # mirrors the manual end. advance_to_end() re-sets END idempotently
+            # (a same-phase write), celebrates the lights and fires the winner /
+            # podium announcements; the broadcast below then pushes END.
+            if not success and self.phase == GamePhase.END:
+                _LOGGER.info(
+                    "REVEAL auto-advance reached the final round — running "
+                    "game-end ceremony"
+                )
+                await self.advance_to_end()
+                success = True
             # start_round() only fires sync state-callbacks via
             # _notify_state_callbacks; the async WebSocket broadcast
             # (`_on_round_end` = ws_handler.broadcast_state) is what actually
-            # pushes the new PLAYING state to clients. The manual
+            # pushes the new PLAYING (or END) state to clients. The manual
             # admin_next_round path explicitly awaits handler.broadcast_state()
-            # after start_round — mirror that here, otherwise music starts but
-            # the admin + player UIs stay frozen on REVEAL.
+            # after start_round / advance_to_end — mirror that here, otherwise
+            # music starts (or the game ends) but the admin + player UIs stay
+            # frozen on REVEAL.
             if success and self._on_round_end:
                 try:
                     await self._on_round_end()

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -174,6 +174,63 @@ class TestRevealAutoAdvance:
             await state._reveal_auto_advance(0)
         state.start_round.assert_not_awaited()
 
+    async def test_unattended_final_round_runs_end_ceremony_and_broadcasts(self):
+        """#1360 regression: when the auto-advance carries the FINAL round and
+        start_round() exhausts the playlist, it flips phase to END and returns
+        False (a bare _set_phase(END), bypassing advance_to_end). Previously the
+        broadcast only fired `if success`, so the game ended with no winner
+        ceremony AND no broadcast — every client frozen on REVEAL.
+
+        The unattended end must mirror the manual admin_next_round game-end: run
+        advance_to_end() (party-light celebration + winner/podium TTS) AND fire
+        the broadcast so the END state reaches clients.
+        """
+        state = make_game_state()
+        _create_fresh_game(state)
+        state.phase = GamePhase.REVEAL
+        state._song_finished = MagicMock(return_value=True)
+
+        # Simulate playlist exhaustion: start_round() flips to END + returns
+        # False, exactly like the bare _set_phase(GamePhase.END) exhaustion
+        # branch in RoundLifecycleMixin.start_round.
+        async def exhausted_start_round(*_args, **_kwargs):
+            state.phase = GamePhase.END
+            return False
+
+        state.start_round = AsyncMock(side_effect=exhausted_start_round)
+
+        # Spy on the terminal ceremony + the broadcast callback.
+        state.advance_to_end = AsyncMock()
+        broadcast = AsyncMock()
+        state.set_round_end_callback(broadcast)
+
+        with patch("asyncio.sleep", new=AsyncMock()):
+            await state._reveal_auto_advance(0)
+
+        # Ceremony ran (winner/podium TTS + party lights) and END was broadcast.
+        state.advance_to_end.assert_awaited_once()
+        broadcast.assert_awaited_once()
+
+    async def test_advance_broadcasts_after_normal_next_round(self):
+        """Counterpart to #1360: a NON-final auto-advance (start_round succeeds)
+        must still broadcast the new PLAYING state, and must NOT run the
+        game-end ceremony.
+        """
+        state = make_game_state()
+        _create_fresh_game(state)
+        state.phase = GamePhase.REVEAL
+        state._song_finished = MagicMock(return_value=True)
+        state.start_round = AsyncMock(return_value=True)
+        state.advance_to_end = AsyncMock()
+        broadcast = AsyncMock()
+        state.set_round_end_callback(broadcast)
+
+        with patch("asyncio.sleep", new=AsyncMock()):
+            await state._reveal_auto_advance(0)
+
+        broadcast.assert_awaited_once()
+        state.advance_to_end.assert_not_awaited()
+
     async def test_idle_halt_stops_playback_and_does_not_advance(self):
         """Zero-guess round: song-end stops the speaker, no new round."""
         state = make_game_state()


### PR DESCRIPTION
Closes #1360

## Root cause
When the playlist is exhausted, `start_round()` flips the phase to `END` and returns `False` (`state_lifecycle.py:164-166` — a bare `self._set_phase(GamePhase.END); return False`), deliberately bypassing `advance_to_end()`. The REVEAL auto-advance task (`_reveal_auto_advance`, the unattended #1012 flow) only broadcast and ran the end ceremony `if success and self._on_round_end`. So a game whose **final** round's REVEAL is carried by auto-advance ended with:

- phase `END` server-side, but **no WebSocket broadcast** (`_notify_state_callbacks` only feeds HA sensors), so every client stayed **frozen on REVEAL**;
- **no** `announce_winner` / `announce_podium` TTS;
- **no** party-light celebration.

The admin's Next/End buttons then both reject (both disallow the `END` phase), so the game was stuck. The manual `admin_next_round` path handles this correctly via `advance_to_end()` + `broadcast_state()`; the auto path did not.

## Fix
In `_reveal_auto_advance`, after `start_round()` returns: if it returned `False` **and** the phase is now `END`, run the proper terminal ceremony via `advance_to_end()` (party-light celebration + winner/podium TTS + idempotent `END` transition — a same-phase `_set_phase` write, exempt from the transition-table warning), then fall through to the existing `_on_round_end` broadcast so the `END` state actually reaches clients. This mirrors the manual `admin_next_round` game-end path.

`advance_to_end()` calls `_cancel_auto_advance()`, which is a safe no-op here: the task already cleared its own `_auto_advance_task` handle before advancing.

## Readiness assessment
- [x] Ready to merge
- [ ] Borderline — see notes
- [ ] Not ready — needs human review

**Honest summary:** Minimal, contained backend fix in the mixin that owns the auto-advance path; no public API change, no UI surface. The unattended end now fires the exact same ceremony + broadcast as the manual end. The fix is guarded behind `not success and self.phase == GamePhase.END`, so the normal next-round path is unchanged (verified by a dedicated counterpart test). One known scope boundary noted below (stats recording).

## Test plan
- **Automated (added):**
  - `test_unattended_final_round_runs_end_ceremony_and_broadcasts` — simulates playlist exhaustion (`start_round` → phase `END`, returns `False`); asserts `advance_to_end()` is awaited once **and** the `_on_round_end` broadcast fires once.
  - `test_advance_broadcasts_after_normal_next_round` — counterpart: a non-final auto-advance still broadcasts the new PLAYING state and does **not** run the game-end ceremony.
- **Full suite:** `python3 -m pytest` → 887 passed, 2 skipped.
- **Lint:** `ruff check .` clean + `ruff format --check .` clean (ruff 0.15.7, the CI pin).
- **Types:** `mypy` (1.18.2) → success, no issues.
- **Manual:** run an unattended game with REVEAL auto-advance enabled; let the final round's REVEAL auto-advance carry through. Expect: clients transition off REVEAL to the END/podium screen, winner+podium TTS plays, party lights celebrate.

## Risk assessment
- **Blast radius:** `custom_components/beatify/game/state_auto_advance.py` (one added branch + docstring contract line) and `tests/unit/test_state.py` (two new tests). Backend only — no frontend / `www/**` files touched, no cache-buster/sw.js work needed.
- **What could go wrong:** `advance_to_end()` runs party-lights + TTS; if either subsystem raises it is already internally guarded (party-lights wrapped in try/except in `advance_to_end`; TTS announcers no-op when unconfigured). The branch is gated on `phase == END` so a normal next-round can't trip it.
- **What I did NOT change (known scope boundary):** the manual `admin_next_round` game-end also records stats (`finalize_game()` + `stats_service.record_game()`) before `advance_to_end()`. That lives in the **service / ws_handler layer**, which has the `stats_service`; the `GameState` auto-advance task has no such reference, so the unattended-exhaustion end does not record game stats — this was already true before this PR (the old path silently returned `False`). Wiring stats into the unattended end is a separate, larger change and is intentionally out of scope for this fix, which targets only the user-visible freeze (broadcast + ceremony).
- **What I did NOT test:** live HA hardware (TTS speaker, real party-light hub); verified via unit tests + the existing `advance_to_end` test coverage.

🤖 Auto-generated by issue-triage routine