### PR TITLE
fix: re-validate game/phase after awaits in start_round (#1358)

### DIFF
--- a/custom_components/beatify/game/state.py
+++ b/custom_components/beatify/game/state.py
@@ -271,6 +271,12 @@ class GameState(
         self._hass: HomeAssistant | None = None
         self.game_id: str | None = None
         self.admin_token: str | None = None  # Issue #386: REST admin auth
+        # #1358: monotonic game-identity epoch. Bumped by create_game /
+        # end_game / rematch_game so a long-running start_round can detect that
+        # the game it was launched for has been torn down or replaced while it
+        # was parked inside an await (verify_responsive / play_song), and bail
+        # instead of stamping PLAYING onto a game with game_id=None / no players.
+        self._game_epoch: int = 0
         self.phase: GamePhase = GamePhase.LOBBY
         # #1012: REVEAL auto-advance (seconds; 0 = manual) + its task handle
         self.reveal_auto_advance: int = 0

--- a/custom_components/beatify/game/state_lifecycle.py
+++ b/custom_components/beatify/game/state_lifecycle.py
@@ -149,6 +149,14 @@ class RoundLifecycleMixin:
 
         MAX_SONG_RETRIES = 3
 
+        # #1358: snapshot the game-identity epoch at entry. start_round parks in
+        # long awaits (verify_responsive, play_song — play_song waits a full
+        # Music Assistant timeout). If end_game / rematch_game / create_game runs
+        # while we're parked, the epoch advances and we must abort instead of
+        # resuming onto a torn-down or replaced game (game_id=None, no players,
+        # phase LOBBY) — see _round_start_aborted.
+        start_epoch = self._game_epoch
+
         # #1012: a (manual or auto) round start supersedes any pending
         # REVEAL auto-advance.
         if _retry_count == 0:
@@ -204,6 +212,11 @@ class RoundLifecycleMixin:
                     responsive,
                     error_detail,
                 ) = await self._media_player_service.verify_responsive()
+                # #1358: the game may have been torn down / replaced while we
+                # waited on verify_responsive — bail before play_song so we
+                # don't start music on a dead game.
+                if await self._round_start_aborted(start_epoch):
+                    return False
                 if not responsive:
                     self.last_error_detail = error_detail
                     _LOGGER.error(
@@ -256,6 +269,14 @@ class RoundLifecycleMixin:
                 await self.pause_game("media_player_error")
                 return False
 
+            # #1358: play_song just succeeded, but it parks for a full Music
+            # Assistant timeout — long enough for the admin to end the game
+            # (or a rematch / new game) in the meantime. If the game we started
+            # for is gone, stop the playback we just kicked off and bail BEFORE
+            # _initialize_round stamps PLAYING onto the torn-down game.
+            if await self._round_start_aborted(start_epoch, stop_playback=True):
+                return False
+
         metadata = self._build_round_metadata(song, resolved_uri, will_defer_for_splash)
         # Issue #1211: when TTS pre-round announcements are active, shift the
         # deadline forward so the timer doesn't count down during the TTS
@@ -296,6 +317,55 @@ class RoundLifecycleMixin:
         if self.is_intro_round:
             await self.announce_intro_round()
 
+        return True
+
+    async def _round_start_aborted(
+        self, start_epoch: int, *, stop_playback: bool = False
+    ) -> bool:
+        """Decide whether an in-flight ``start_round`` must bail (#1358).
+
+        Re-validates, after a long await, that the game ``start_round`` was
+        launched for is still the live, playable game. Returns ``True`` (abort)
+        when either:
+
+        * the game-identity epoch has advanced — ``create_game`` / ``end_game``
+          / ``rematch_game`` ran while we were parked (the original game is gone
+          or has been replaced; ``end_game``/``rematch`` flip the phase to
+          ``LOBBY`` without bumping it back), or
+        * the phase has moved to ``PAUSED`` or ``END`` — a concurrent
+          ``pause_game`` (which does NOT bump the epoch) or a game-end that
+          ``_initialize_round``'s unconditional ``_set_phase(PLAYING)`` would
+          otherwise silently undo.
+
+        ``LOBBY`` is deliberately NOT a stand-alone abort trigger: the very
+        first round of a game is started straight from ``LOBBY`` (no epoch
+        change), so checking ``LOBBY`` directly would abort every legitimate
+        first round. An ``end_game``/``rematch`` that lands on ``LOBBY`` is
+        instead caught by the epoch bump.
+
+        When ``stop_playback`` is set and we abort, the playback this round
+        already started is stopped so the speaker doesn't keep playing on a
+        torn-down game.
+        """
+        from .state import GamePhase  # noqa: PLC0415 — avoid circular import
+
+        if self._game_epoch == start_epoch and self.phase not in (
+            GamePhase.END,
+            GamePhase.PAUSED,
+        ):
+            return False
+
+        _LOGGER.info(
+            "Aborting start_round: game changed during await (epoch %s→%s, phase %s)",
+            start_epoch,
+            self._game_epoch,
+            self.phase.value,
+        )
+        if stop_playback and self._media_player_service:
+            try:
+                await self._media_player_service.stop()
+            except Exception as err:  # noqa: BLE001 — a stop error must not raise
+                _LOGGER.warning("start_round abort: stop playback failed: %s", err)
         return True
 
     def _ensure_media_player_service(self) -> None:

--- a/custom_components/beatify/game/state_setup.py
+++ b/custom_components/beatify/game/state_setup.py
@@ -156,6 +156,9 @@ class GameSetupMixin:
         # Clear any leftover sessions from previous/crashed game (Story 11.6)
         self.clear_all_sessions()
 
+        # #1358: a new game invalidates any start_round still parked in an
+        # await from a prior game/session.
+        self._game_epoch += 1
         self.game_id = secrets.token_urlsafe(8)
         self.admin_token = secrets.token_urlsafe(16)  # Issue #386: REST admin auth
         self._set_phase(GamePhase.LOBBY)
@@ -302,6 +305,13 @@ class GameSetupMixin:
         # is still REVEAL there) and trigger the next song after the game ended.
         # advance_to_end() already does this; the HTTP/force-end path lands here.
         self._cancel_auto_advance()
+        # #1358: bump the game-identity epoch synchronously, BEFORE the awaits
+        # below (same rationale as the _cancel_auto_advance above). A start_round
+        # that's parked in play_song and resumes anytime during this teardown —
+        # even during disable_party_lights()/disable_tts(), while phase is still
+        # REVEAL/PLAYING — then sees the changed epoch and bails instead of
+        # stamping PLAYING onto the now-empty game.
+        self._game_epoch += 1
         # Issue #331: Restore lights before resetting
         await self.disable_party_lights()
         # Issue #447: Disable TTS
@@ -356,6 +366,9 @@ class GameSetupMixin:
         self.total_rounds = len(preserved["songs"])
 
         self._set_phase(GamePhase.LOBBY)
+        # #1358: a rematch replaces the game identity — invalidate any
+        # start_round still parked in an await from the finished game.
+        self._game_epoch += 1
         # Reset each player's game stats but keep them connected
         for player in self.players.values():
             player.reset_for_new_game()

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -1480,3 +1480,133 @@ class TestSetPhaseSSOT:
             state._set_phase(GamePhase.PLAYING)
         assert "Unexpected phase transition" in caplog.text
         assert state.phase == GamePhase.PLAYING
+
+
+# ---------------------------------------------------------------------------
+# #1358: start_round must re-validate game identity / phase after awaits
+# ---------------------------------------------------------------------------
+
+
+class TestStartRoundGhostRoundGuard:
+    """#1358: start_round parks in long awaits (verify_responsive, play_song —
+    play_song waits a full Music Assistant timeout). If the game is torn down or
+    replaced while parked, start_round must NOT resume and stamp PLAYING onto a
+    dead/replaced game. The fix snapshots a monotonic _game_epoch at entry and
+    re-validates epoch + phase after the playback await, stopping the playback
+    it just started and bailing instead of committing the round.
+    """
+
+    def _setup(self) -> GameState:
+        state = make_game_state()
+        _create_fresh_game(state)
+        state.add_player("Admin", MagicMock())
+        state.add_player("Bob", MagicMock())
+        state.set_admin("Admin")
+        state.start_game()  # LOBBY -> PLAYING (needs MIN_PLAYERS)
+        state.phase = GamePhase.PLAYING
+        # music_assistant platform skips the verify_responsive branch so the
+        # only await before _initialize_round is play_song.
+        state.platform = "music_assistant"
+        media = AsyncMock()
+        media.is_available = MagicMock(return_value=True)
+        state._media_player_service = media
+        state._ensure_media_player_service = MagicMock()  # keep our mock service
+        return state
+
+    @pytest.mark.asyncio
+    async def test_end_game_during_play_song_aborts_round(self):
+        """end_game() completing while start_round is parked in play_song must
+        not produce a ghost PLAYING round on a torn-down game."""
+        state = self._setup()
+        media = state._media_player_service
+
+        async def end_game_then_succeed(_song):
+            # Simulate the admin ending the game while play_song is parked.
+            await state.end_game()
+            return True
+
+        media.play_song.side_effect = end_game_then_succeed
+
+        result = await state.start_round()
+
+        assert result is False
+        # Game was torn down: must NOT be flipped to PLAYING.
+        assert state.phase != GamePhase.PLAYING
+        assert state.game_id is None
+        assert state.round == 0  # _initialize_round never ran
+        # The playback we kicked off must be stopped on the dead game.
+        media.stop.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_concurrent_pause_during_play_song_not_overwritten(self):
+        """A concurrent pause_game (-> PAUSED) while parked in play_song must not
+        be silently overwritten back to PLAYING by _initialize_round."""
+        state = self._setup()
+        media = state._media_player_service
+
+        async def pause_then_succeed(_song):
+            await state.pause_game("admin_disconnected")
+            return True
+
+        media.play_song.side_effect = pause_then_succeed
+
+        result = await state.start_round()
+
+        assert result is False
+        assert state.phase == GamePhase.PAUSED
+        assert state.round == 0
+
+    @pytest.mark.asyncio
+    async def test_rematch_during_play_song_aborts_round(self):
+        """A rematch replacing the game identity mid-await must abort the round
+        even though the new game is also a valid (LOBBY) game."""
+        state = self._setup()
+        media = state._media_player_service
+
+        async def rematch_then_succeed(_song):
+            state.rematch_game()  # new epoch, new game_id, phase LOBBY
+            return True
+
+        media.play_song.side_effect = rematch_then_succeed
+
+        result = await state.start_round()
+
+        assert result is False
+        assert state.phase != GamePhase.PLAYING
+        assert state.round == 0
+        media.stop.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_normal_round_still_starts(self):
+        """Guard must be inert on the happy path: no teardown during play_song,
+        the round commits to PLAYING as before."""
+        state = self._setup()
+        media = state._media_player_service
+        media.play_song.return_value = True
+
+        result = await state.start_round()
+
+        assert result is True
+        assert state.phase == GamePhase.PLAYING
+        assert state.round == 1
+
+    @pytest.mark.asyncio
+    async def test_epoch_bumped_by_lifecycle_boundaries(self):
+        """create_game / end_game / rematch_game each advance the epoch."""
+        state = make_game_state()
+        e0 = state._game_epoch
+        _create_fresh_game(state)
+        e1 = state._game_epoch
+        assert e1 > e0
+
+        state.add_player("Admin", MagicMock())
+        state.set_admin("Admin")
+        await state.end_game()
+        e2 = state._game_epoch
+        assert e2 > e1
+
+        _create_fresh_game(state)
+        state.add_player("Admin", MagicMock())
+        state.set_admin("Admin")
+        state.rematch_game()
+        assert state._game_epoch > e2


### PR DESCRIPTION
Closes #1358

## Problem
`start_round` suspends for long periods (`verify_responsive`, and especially `play_song`, which waits a full Music Assistant timeout — seconds to tens of seconds) but never re-checked `self.phase` or the game identity after any await. The REVEAL auto-advance task deliberately clears its own handle *before* calling `start_round` (`state_auto_advance.py`), so once it fires, `end_game()`'s `_cancel_auto_advance()` finds `None` and cannot stop it.

If the admin ends the game (or a rematch / new game starts, or a concurrent pause lands) while `start_round` is parked inside `play_song`, the teardown completes (`game_id=None`, `players={}`, phase LOBBY), then `start_round` resumes and `_initialize_round` unconditionally runs `_set_phase(GamePhase.PLAYING)`. Result: music playing and `phase=PLAYING/round=1` on a game with `game_id=None` and zero players — a "ghost round" on a dead game. LOBBY→PLAYING is even a legal edge in `_VALID_PHASE_TRANSITIONS`, so the observational phase check stayed silent. The same hole let a concurrent `pause_game` (PAUSED) be silently overwritten back to PLAYING.

## Root cause
`start_round` had no notion of game identity surviving an await. There was no token to detect that the game it was launched for had been torn down or replaced, and no re-validation point after the suspending media calls.

## Fix
- Added a monotonic `self._game_epoch` counter (in `GameState.__init__`), bumped by `create_game`, `end_game`, and `rematch_game` — the three game-identity boundaries. In `end_game` the bump happens synchronously *before* its `disable_party_lights()`/`disable_tts()` awaits (same rationale as the existing pre-await `_cancel_auto_advance()`), so a `start_round` resuming any time during teardown already sees the changed epoch.
- `start_round` snapshots `start_epoch = self._game_epoch` at entry and calls a new `_round_start_aborted(start_epoch)` guard after the suspending media awaits: once after `verify_responsive` (before `play_song`), and once after `play_song` succeeds (before `_initialize_round`, with `stop_playback=True`).
- The guard aborts (returns `False`, round not committed) when the epoch advanced (end_game / rematch / new game) **or** the phase moved to PAUSED/END (concurrent pause does not bump the epoch). When aborting after playback started, it stops the speaker so it doesn't keep playing on a torn-down game.
- LOBBY is intentionally **not** a standalone abort trigger: the first round of a game starts straight from LOBBY with no epoch change, so an end_game/rematch that lands on LOBBY is caught by the epoch bump instead — avoiding false aborts of every legitimate first round.

## Tests
Added `TestStartRoundGhostRoundGuard` (`tests/unit/test_state.py`):
- `test_end_game_during_play_song_aborts_round` — end_game mid-`play_song` → round not committed, `game_id is None`, `round==0`, `stop()` called.
- `test_concurrent_pause_during_play_song_not_overwritten` — concurrent `pause_game` → phase stays PAUSED, round not committed.
- `test_rematch_during_play_song_aborts_round` — rematch (new epoch + LOBBY) → aborts, `stop()` called.
- `test_normal_round_still_starts` — happy path still commits PLAYING / `round==1` (guard is inert).
- `test_epoch_bumped_by_lifecycle_boundaries` — create_game / end_game / rematch_game each advance the epoch.

## Readiness assessment
- [x] Ready to merge
- [ ] Borderline — see notes
- [ ] Not ready — needs human review

**Honest summary:** Backend concurrency hardening, no UI surface. Targeted, minimal change layered on the existing `_set_phase` chokepoint and the epoch counter. Full gate green locally on Python 3.13: `pytest` 890 passed / 2 skipped, `ruff check .` clean, `ruff format --check .` clean, `mypy` (1.18.2) clean. The one pytest warning is a pre-existing AsyncMock artifact in `test_stats.py`, unrelated to this change.

## Test plan
- Automated: the 5 new regression tests above plus the full existing suite (890 passing).
- Manual: start a game → reach a round where `play_song` is slow / the speaker stalls → end the game (or hit Rematch, or pause) while the round button still shows "Starting…" → confirm the speaker does not start a ghost track and the UI does not flip to a PLAYING round on the ended game.

## Risk assessment
- **Blast radius:** `game/state.py` (one new field), `game/state_lifecycle.py` (`start_round` guard + new `_round_start_aborted` helper), `game/state_setup.py` (3 one-line epoch bumps). No frontend / `www/**` changes.
- **What could go wrong:** if some other code path tears down or replaces the game without going through create_game/end_game/rematch_game, the epoch wouldn't bump there — but those are the only three identity boundaries today, and the PAUSED/END phase check is a second net. The post-`play_song` abort relies on `_media_player_service.stop()`; a stop error is caught and logged, never raised.
- **What I did NOT test:** real Music Assistant hardware timing; the exact interleaving on a live HA instance (covered by reasoning + the simulated-teardown unit tests, not a live race).

🤖 Auto-generated by issue-triage routine