### PR TITLE
fix: register HTTP views/WS/static paths once per HA run (#1364)

### DIFF
--- a/custom_components/beatify/__init__.py
+++ b/custom_components/beatify/__init__.py
@@ -65,6 +65,13 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
+# hass.data key (outside DOMAIN, so it survives async_unload_entry popping
+# hass.data[DOMAIN]) guarding one-time HTTP route registration. aiohttp routes
+# cannot be unregistered, so views/WS/static paths must be registered exactly
+# once per HA run — re-registering on a config-entry reload would shadow the
+# new handlers with stale duplicates (#1364).
+_ROUTES_REGISTERED = f"{DOMAIN}_routes_registered"
+
 
 def _read_manifest_version() -> str:
     """Read the integration version from manifest.json (executor-safe).
@@ -168,46 +175,75 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         entry, ["sensor", "binary_sensor"]
     )
 
-    # Register HTTP views
-    hass.http.register_view(AdminView(hass))
-    hass.http.register_view(LauncherView(hass))
-    # Safari 18 /auth/token workaround — server-side OAuth handling, the
-    # frontend never POSTs to auth endpoints (rc15+).
-    hass.http.register_view(BeatifyAuthCallbackView(hass))
-    hass.http.register_view(BeatifyAuthRefreshView(hass))
-    hass.http.register_view(StatusView(hass))
-    hass.http.register_view(CapabilitiesView(hass))
-    hass.http.register_view(LightsView(hass))  # Issue #331
-    hass.http.register_view(AlbumArtView(hass))  # Issue #933 — remote album art
-    hass.http.register_view(PreviewLightsView(hass))  # Issue #408
-    hass.http.register_view(TtsEntitiesView(hass))  # Issue #1073
-    hass.http.register_view(TtsTestView(hass))
-    hass.http.register_view(StartGameView(hass))
-    hass.http.register_view(StartGameplayView(hass))
-    hass.http.register_view(EndGameView(hass))
-    hass.http.register_view(
-        ForceResetView(hass)
-    )  # #777 follow-up — stuck-state escape hatch
-    hass.http.register_view(RematchGameView(hass))  # Issue #108
-    hass.http.register_view(PlayerView(hass))
-    hass.http.register_view(
-        SwJsView(hass)
-    )  # #780 — SW at /beatify/sw.js for /beatify/ scope
-    hass.http.register_view(GameStatusView(hass))
-    hass.http.register_view(DashboardView(hass))
-    hass.http.register_view(StatsView(hass))
-    hass.http.register_view(AnalyticsView(hass))
-    hass.http.register_view(AnalyticsPageView(hass))
-    hass.http.register_view(SongStatsView(hass))  # Story 19.7
-    hass.http.register_view(PlaylistRequestsView(hass))  # Story 44
-    hass.http.register_view(SavePlaylistView(hass))  # #1057
-    hass.http.register_view(UsageView(hass))  # v3.3 Playlist Hub local stats
+    # Register HTTP views, the WebSocket route, and static paths exactly ONCE
+    # per HA run (#1364). aiohttp's router cannot unregister resources, and its
+    # dispatcher resolves to the FIRST matching resource — so re-registering on
+    # a config-entry reload (unload + setup) would leave stale handlers serving
+    # while the freshly-wired game state's callbacks point at the new, empty
+    # handler. All views resolve their state from hass.data at request time, and
+    # the WS route below dispatches to the *current* handler in hass.data, so a
+    # single registration keeps working across reloads.
+    if not hass.data.get(_ROUTES_REGISTERED):
+        hass.http.register_view(AdminView(hass))
+        hass.http.register_view(LauncherView(hass))
+        # Safari 18 /auth/token workaround — server-side OAuth handling, the
+        # frontend never POSTs to auth endpoints (rc15+).
+        hass.http.register_view(BeatifyAuthCallbackView(hass))
+        hass.http.register_view(BeatifyAuthRefreshView(hass))
+        hass.http.register_view(StatusView(hass))
+        hass.http.register_view(CapabilitiesView(hass))
+        hass.http.register_view(LightsView(hass))  # Issue #331
+        hass.http.register_view(AlbumArtView(hass))  # Issue #933 — remote album art
+        hass.http.register_view(PreviewLightsView(hass))  # Issue #408
+        hass.http.register_view(TtsEntitiesView(hass))  # Issue #1073
+        hass.http.register_view(TtsTestView(hass))
+        hass.http.register_view(StartGameView(hass))
+        hass.http.register_view(StartGameplayView(hass))
+        hass.http.register_view(EndGameView(hass))
+        hass.http.register_view(
+            ForceResetView(hass)
+        )  # #777 follow-up — stuck-state escape hatch
+        hass.http.register_view(RematchGameView(hass))  # Issue #108
+        hass.http.register_view(PlayerView(hass))
+        hass.http.register_view(
+            SwJsView(hass)
+        )  # #780 — SW at /beatify/sw.js for /beatify/ scope
+        hass.http.register_view(GameStatusView(hass))
+        hass.http.register_view(DashboardView(hass))
+        hass.http.register_view(StatsView(hass))
+        hass.http.register_view(AnalyticsView(hass))
+        hass.http.register_view(AnalyticsPageView(hass))
+        hass.http.register_view(SongStatsView(hass))  # Story 19.7
+        hass.http.register_view(PlaylistRequestsView(hass))  # Story 44
+        hass.http.register_view(SavePlaylistView(hass))  # #1057
+        hass.http.register_view(UsageView(hass))  # v3.3 Playlist Hub local stats
 
-    # Register WebSocket endpoint
-    hass.http.app.router.add_get("/beatify/ws", ws_handler.handle)
+        # Register WebSocket endpoint via a stable dispatch closure that
+        # resolves the *current* handler from hass.data at call time (#1364).
+        # Binding ws_handler.handle directly would pin the route to the handler
+        # created in THIS setup; after a reload the new game state's callbacks
+        # would target a new handler while clients kept landing in the old one's
+        # (now empty) connection set, freezing round-end broadcasts.
+        async def _ws_dispatch(request):
+            handler = hass.data.get(DOMAIN, {}).get("ws_handler")
+            if handler is None:
+                from aiohttp import web  # noqa: PLC0415
 
-    # Register static file paths
-    await async_register_static_paths(hass)
+                return web.Response(status=503, text="Beatify not ready")
+            return await handler.handle(request)
+
+        hass.http.app.router.add_get("/beatify/ws", _ws_dispatch)
+
+        # Register static file paths
+        await async_register_static_paths(hass)
+
+        hass.data[_ROUTES_REGISTERED] = True
+        _LOGGER.debug("Beatify HTTP routes registered (once per HA run)")
+    else:
+        _LOGGER.debug(
+            "Beatify HTTP routes already registered this HA run — skipping "
+            "re-registration on reload (#1364)"
+        )
 
     # Register sidebar panel (Story 10.3)
     # Points to launcher page which opens game in a new tab (fullscreen, no HA chrome)

--- a/tests/unit/test_setup_reload_routes.py
+++ b/tests/unit/test_setup_reload_routes.py
@@ -1,0 +1,206 @@
+"""Regression tests for one-time HTTP route registration on reload (#1364).
+
+A config-entry reload runs async_unload_entry followed by async_setup_entry.
+aiohttp routes cannot be unregistered, and its dispatcher resolves to the FIRST
+registered resource — so re-registering the ~28 views, the WebSocket route, and
+the static paths on every setup would leave stale handlers shadowing the freshly
+wired ones. For the WebSocket that is a functional break: round-end broadcasts
+target the new (empty) handler while clients stay attached to the old one.
+
+These tests stub the small ``homeassistant.*`` surface that the integration's
+top-level ``__init__`` imports at module load, then drive ``async_setup_entry``
+twice (initial setup + reload) against a mock ``hass`` and assert that routes are
+registered exactly once and the WS route always dispatches to the *current*
+handler stored in ``hass.data``.
+"""
+
+from __future__ import annotations
+
+import sys
+from types import ModuleType, SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+# --------------------------------------------------------------------------
+# Stub the homeassistant modules imported at module load by the integration's
+# top-level __init__ (and its transitive runtime imports). Mirrors the stubbing
+# pattern already used in tests/conftest.py. Must run before importing the
+# integration package.
+# --------------------------------------------------------------------------
+
+
+def _ensure_module(name: str) -> ModuleType:
+    mod = sys.modules.get(name)
+    if mod is None:
+        mod = ModuleType(name)
+        sys.modules[name] = mod
+    return mod
+
+
+_ensure_module("homeassistant")
+_ensure_module("homeassistant.components")
+_frontend = _ensure_module("homeassistant.components.frontend")
+_frontend.async_register_built_in_panel = MagicMock()
+_frontend.async_remove_panel = MagicMock()
+
+_http = _ensure_module("homeassistant.components.http")
+_http.StaticPathConfig = MagicMock(name="StaticPathConfig")
+
+
+class _HomeAssistantView:  # minimal base for server.views import
+    url = ""
+    name = ""
+    requires_auth = False
+
+
+_http.HomeAssistantView = _HomeAssistantView
+
+_helpers = _ensure_module("homeassistant.helpers")
+_aiohttp_client = _ensure_module("homeassistant.helpers.aiohttp_client")
+_aiohttp_client.async_get_clientsession = MagicMock()
+_event = _ensure_module("homeassistant.helpers.event")
+_event.async_track_state_change_event = MagicMock()
+_er = _ensure_module("homeassistant.helpers.entity_registry")
+_er.async_get = MagicMock()
+_exceptions = _ensure_module("homeassistant.exceptions")
+
+
+class _HomeAssistantError(Exception):
+    pass
+
+
+class _ServiceNotFound(Exception):
+    pass
+
+
+_exceptions.HomeAssistantError = _HomeAssistantError
+_exceptions.ServiceNotFound = _ServiceNotFound
+
+import custom_components.beatify as beatify_init  # noqa: E402
+from custom_components.beatify.const import DOMAIN  # noqa: E402
+
+
+@pytest.fixture
+def mock_hass():
+    """A mock hass whose http router records every registered view/route."""
+    registered_views = []
+    added_routes = {}
+
+    http = MagicMock()
+    http.register_view.side_effect = registered_views.append
+    http.async_register_static_paths = AsyncMock()
+
+    def _add_get(path, handler):
+        added_routes[path] = handler
+
+    http.app.router.add_get.side_effect = _add_get
+
+    hass = MagicMock()
+    hass.data = {}
+    hass.http = http
+    # async_add_executor_job just runs the callable synchronously for the test.
+    hass.async_add_executor_job = AsyncMock(side_effect=lambda fn, *a: fn(*a))
+    hass.config_entries.async_forward_entry_setups = AsyncMock()
+    hass.config_entries.async_unload_platforms = AsyncMock(return_value=True)
+
+    hass._registered_views = registered_views
+    hass._added_routes = added_routes
+    return hass
+
+
+@pytest.fixture(autouse=True)
+def _patch_heavy_helpers(monkeypatch):
+    """Patch the integration's heavy async setup helpers to no-ops."""
+    monkeypatch.setattr(
+        beatify_init,
+        "async_ensure_playlist_directory",
+        AsyncMock(return_value="/tmp/p"),
+    )
+    monkeypatch.setattr(
+        beatify_init, "async_discover_playlists", AsyncMock(return_value=[])
+    )
+    monkeypatch.setattr(
+        beatify_init, "async_get_media_players", AsyncMock(return_value=[])
+    )
+
+    # StatsService / AnalyticsStorage do real Store I/O — replace with stubs that
+    # carry just the attributes async_setup_entry reads/wires.
+    stats = MagicMock()
+    stats.load = AsyncMock()
+    stats.games_played = 0
+    monkeypatch.setattr(beatify_init, "StatsService", MagicMock(return_value=stats))
+
+    analytics = MagicMock()
+    analytics.load = AsyncMock()
+    analytics.total_games = 0
+    monkeypatch.setattr(
+        beatify_init, "AnalyticsStorage", MagicMock(return_value=analytics)
+    )
+
+
+def _make_entry(entry_id: str = "entry-1"):
+    return SimpleNamespace(entry_id=entry_id)
+
+
+@pytest.mark.asyncio
+async def test_routes_registered_once_across_reload(mock_hass):
+    """Initial setup registers routes; a reload must NOT re-register them."""
+    entry = _make_entry()
+
+    assert await beatify_init.async_setup_entry(mock_hass, entry) is True
+    first_view_count = len(mock_hass._registered_views)
+    assert first_view_count > 20, "expected the full view set on first setup"
+    assert "/beatify/ws" in mock_hass._added_routes
+    assert mock_hass.http.async_register_static_paths.await_count == 1
+    assert mock_hass.data[beatify_init._ROUTES_REGISTERED] is True
+
+    # --- reload: unload then setup again ---
+    assert await beatify_init.async_unload_entry(mock_hass, entry) is True
+    # unload pops hass.data[DOMAIN]; the route-guard flag lives outside DOMAIN
+    # and must survive so the second setup skips registration.
+    assert mock_hass.data.get(beatify_init._ROUTES_REGISTERED) is True
+
+    assert await beatify_init.async_setup_entry(mock_hass, entry) is True
+
+    # No new views, no second WS route add, no second static-path registration.
+    assert len(mock_hass._registered_views) == first_view_count
+    assert mock_hass.http.app.router.add_get.call_count == 1
+    assert mock_hass.http.async_register_static_paths.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_ws_route_dispatches_to_current_handler(mock_hass):
+    """The registered WS route resolves the live handler from hass.data."""
+    entry = _make_entry()
+    await beatify_init.async_setup_entry(mock_hass, entry)
+
+    ws_dispatch = mock_hass._added_routes["/beatify/ws"]
+    handler_after_setup = mock_hass.data[DOMAIN]["ws_handler"]
+
+    # Swap in a fresh handler (what a reload produces) and confirm the SAME
+    # registered route now dispatches to the new instance, not the old one.
+    new_handler = MagicMock()
+    new_handler.handle = AsyncMock(return_value="dispatched")
+    mock_hass.data[DOMAIN]["ws_handler"] = new_handler
+    assert new_handler is not handler_after_setup
+
+    request = MagicMock()
+    result = await ws_dispatch(request)
+
+    new_handler.handle.assert_awaited_once_with(request)
+    assert result == "dispatched"
+
+
+@pytest.mark.asyncio
+async def test_ws_route_503_when_handler_missing(mock_hass):
+    """If hass.data has no ws_handler, the route returns 503 (not an error)."""
+    entry = _make_entry()
+    await beatify_init.async_setup_entry(mock_hass, entry)
+    ws_dispatch = mock_hass._added_routes["/beatify/ws"]
+
+    # Simulate the integration being torn down (hass.data[DOMAIN] popped).
+    mock_hass.data.pop(DOMAIN, None)
+
+    response = await ws_dispatch(MagicMock())
+    assert response.status == 503


### PR DESCRIPTION
Closes #1364

## Root cause
`async_setup_entry` registered ~28 `HomeAssistantView`s, the `/beatify/ws` WebSocket route, and the static paths on **every** setup, but aiohttp routes cannot be unregistered and the dispatcher resolves to the **first** matching resource. On a config-entry reload (unload + setup) every route is added a second time; the **old** view/handler instances keep serving. For stateless views this only bloats the route table, but for the WebSocket it is a functional break: clients connecting to `/beatify/ws` land in the OLD handler's `connections` set while the NEW `GameState`'s round-end / metadata callbacks are wired to the NEW handler (empty connection set). After a reload, timer-expiry / round-end broadcasts reach nobody — the game appears frozen for all connected players.

## Fix
Register views, the WS route, and static paths **exactly once per HA run**, guarded by a `hass.data` flag stored **outside** `DOMAIN` (so it survives `async_unload_entry` popping `hass.data[DOMAIN]`). The WS route is now a stable dispatch closure that resolves the **current** `ws_handler` from `hass.data` at request time, so it always targets the live handler across reloads. All views already resolve their state from `hass.data` lazily, so single registration keeps them correct after a reload.

Files: `custom_components/beatify/__init__.py`, `tests/unit/test_setup_reload_routes.py` (new regression test).

## Readiness assessment
- [x] Ready to merge
- [ ] Borderline — see notes
- [ ] Not ready — needs human review

**Honest summary:** Solid, minimal, root-cause fix matching the issue's prescribed approach. New regression test drives `async_setup_entry` twice and asserts routes register once + WS dispatch follows the live handler. The one judgment call is the WS-route 503 fallback when no handler is present (a teardown race) — returns a clean 503 instead of a 500 traceback.

## Test plan
- Automated: `tests/unit/test_setup_reload_routes.py` — (1) setup→unload→setup registers the full view set + WS route + static path exactly once; the guard flag survives unload; (2) swapping `hass.data[DOMAIN]['ws_handler']` makes the registered WS route dispatch to the new handler; (3) missing handler yields 503.
- Full suite: pytest 910 passed / 2 skipped; vitest 240 passed.
- Manual (recommended on a live HA): reload the Beatify config entry mid-lobby, then start/advance a round and confirm timer-expiry/round-end broadcasts still reach connected players (no freeze) and the route table doesn't grow.

## Risk assessment
- **Blast radius:** `async_setup_entry` registration block only; no change to view/handler logic, game state, or the unload path beyond the existing `hass.data[DOMAIN]` pop.
- **What could go wrong:** if some view captured per-entry state at construction it would now go stale on reload — verified none do (every view `__init__` takes only `hass` and reads `hass.data` at request time). The guard flag is intentionally never cleared (routes live for the HA process lifetime), consistent with the standard HA "register once" pattern.
- **What I did NOT test:** live HA reload on real hardware (no HA test harness in this repo — `homeassistant` is not a test dependency; the test stubs the imported `homeassistant.*` surface).

🤖 Auto-generated by issue-triage routine