### PR TITLE
fix: keep cascade-stop idle classified as unavailable, not error (#1363)

### DIFF
--- a/custom_components/beatify/services/media_player.py
+++ b/custom_components/beatify/services/media_player.py
@@ -226,6 +226,13 @@ class MediaPlayerService:
         #                   broken provider auth across the board).
         self.last_failure_reason: str | None = None
 
+        # #1363: set when Beatify itself issues a same-song media_stop after a
+        # stale-title detect (line ~729). The stop forces the speaker to
+        # 'idle'; if the NEXT cascade candidate also fails to resolve, the
+        # idle-failure branch must NOT misread that self-induced idle as a
+        # systemic 'error' (which pauses the game). Reset before each song.
+        self._stopped_for_cascade: bool = False
+
     def set_analytics(self, analytics: AnalyticsStorage) -> None:
         """
         Set analytics storage for error recording (Story 19.1 AC: #2).
@@ -467,6 +474,9 @@ class MediaPlayerService:
         # #808 follow-up: clear stale failure classification before each
         # attempt so start_round reads only the result of THIS song.
         self.last_failure_reason = None
+        # #1363: clear the cascade-stop flag at the start of each song so a
+        # stop from a PRIOR song never leaks into this song's classification.
+        self._stopped_for_cascade = False
 
         candidates = self._get_ma_uri_candidates(song)
         if not candidates:
@@ -657,6 +667,25 @@ class MediaPlayerService:
 
         # Hard failure: speaker is idle/unavailable/off — song won't play
         if speaker_state in ("idle", "unavailable", "off", "unknown"):
+            # #1363: if the speaker is 'idle' only because WE stopped it after a
+            # prior same-song stale-title detect, this is a storefront-gap
+            # cascade (e.g. apple_music's `_resolved_uri` and a differing
+            # `uri_apple_music` both point at an unavailable catalog entry), NOT
+            # a systemic speaker/provider failure. Misclassifying it as 'error'
+            # makes state_lifecycle pause the whole game on a per-track gap —
+            # the exact #805/#808 regression. Keep it 'unavailable' so the game
+            # skips the song silently and tries the next one.
+            if self._stopped_for_cascade and speaker_state == "idle":
+                _LOGGER.warning(
+                    "MA playback failed after %.1fs for %s — speaker idle, but "
+                    "Beatify stopped it after a same-song stale-title detect. "
+                    "Treating as a storefront/catalog gap (unavailable), not a "
+                    "systemic error — game will skip this song silently. (#1363)",
+                    MA_PLAYBACK_TIMEOUT,
+                    uri,
+                )
+                self.last_failure_reason = "unavailable"
+                return False
             _LOGGER.error(
                 "MA playback failed after %.1fs for %s (state: %s). "
                 "Either the speaker is offline, MA's provider is unauthenticated, "
@@ -733,6 +762,10 @@ class MediaPlayerService:
                     {"entity_id": self._entity_id},
                     blocking=False,
                 )
+                # #1363: record that the next cascade candidate will see an
+                # 'idle' speaker WE caused, so its idle-failure isn't
+                # misclassified as a systemic 'error'.
+                self._stopped_for_cascade = True
             except (HomeAssistantError, ServiceNotFound, ConnectionError, OSError):
                 _LOGGER.debug(
                     "media_stop call after stale-title detect failed for %s",

--- a/tests/unit/test_media_player.py
+++ b/tests/unit/test_media_player.py
@@ -474,6 +474,70 @@ class TestMANonBlockingPlayback:
         assert result is True
 
     @pytest.mark.asyncio
+    async def test_ma_idle_after_cascade_stop_is_unavailable_not_error(self):
+        """#1363: when Beatify itself stopped the speaker after a same-song
+        stale-title detect, the NEXT candidate timing out into 'idle' must be
+        classified 'unavailable' (storefront gap → skip silently), NOT 'error'
+        (systemic → pause the whole game). This is the #805/#808 regression for
+        any provider whose candidate list has >=2 entries.
+        """
+        hass = _make_hass("idle", media_title="Old Song")
+        svc = MediaPlayerService(hass, "media_player.test", platform="music_assistant")
+        # Simulate the prior candidate's media_stop having already fired.
+        svc._stopped_for_cascade = True
+
+        with patch(
+            "custom_components.beatify.services.media_player.asyncio.sleep",
+            new_callable=AsyncMock,
+        ):
+            with patch(
+                "custom_components.beatify.services.media_player.MA_PLAYBACK_TIMEOUT",
+                1.0,
+            ):
+                result = await svc._try_ma_play("apple_music://track/302229811", "X")
+
+        assert result is False
+        assert svc.last_failure_reason == "unavailable"
+
+    @pytest.mark.asyncio
+    async def test_ma_idle_without_cascade_stop_is_error(self):
+        """#1363 guard: a genuinely idle speaker that Beatify did NOT stop
+        (offline speaker / unauthenticated provider) must still classify as
+        'error' so MAX_SONG_RETRIES + the recovery banner kick in.
+        """
+        hass = _make_hass("idle", media_title="Old Song")
+        svc = MediaPlayerService(hass, "media_player.test", platform="music_assistant")
+        assert svc._stopped_for_cascade is False
+
+        with patch(
+            "custom_components.beatify.services.media_player.asyncio.sleep",
+            new_callable=AsyncMock,
+        ):
+            with patch(
+                "custom_components.beatify.services.media_player.MA_PLAYBACK_TIMEOUT",
+                1.0,
+            ):
+                result = await svc._try_ma_play("apple_music://track/302229811", "X")
+
+        assert result is False
+        assert svc.last_failure_reason == "error"
+
+    @pytest.mark.asyncio
+    async def test_ma_cascade_stop_flag_reset_each_song(self):
+        """#1363: the cascade-stop flag must not leak across songs. A stop on
+        song A must not make song B's idle-failure look like a storefront gap.
+        """
+        hass = _make_hass("idle", media_title="Old Song")
+        svc = MediaPlayerService(hass, "media_player.test", platform="music_assistant")
+        svc._stopped_for_cascade = True  # leftover from a prior song
+
+        # _play_via_music_assistant must reset the flag before the cascade.
+        with patch.object(svc, "_try_ma_play", AsyncMock(return_value=False)):
+            await svc._play_via_music_assistant(_make_song())
+
+        assert svc._stopped_for_cascade is False
+
+    @pytest.mark.asyncio
     async def test_sonos_still_uses_blocking_true(self):
         """Non-MA platforms should still use blocking=True."""
         hass = _make_hass("playing")


### PR DESCRIPTION
Closes #1363

## Root cause
After a same-song stale-title detect, #801 issues `media_player.media_stop` before the MA cascade tries the next URI candidate — this forces the speaker into `idle`. When the next candidate also fails to resolve (the storefront-gap case: both `apple_music` URI variants point at the same unavailable catalog entry, or spotify's `uri`/`uri_spotify` differ), `_try_ma_play`'s idle-failure branch (`media_player.py:659`) read the self-induced `idle` and set `last_failure_reason = "error"`. `game/state_lifecycle.py:228` then calls `pause_game("media_player_error")` instead of skipping the song — re-creating the #805/#808 force-pause for any provider whose candidate list has ≥2 entries.

## Fix
Track a `self._stopped_for_cascade` flag, set when Beatify itself issues the cascade `media_stop` (line ~729). In the idle-failure branch, when the speaker is `idle` *only because we just stopped it*, classify the subsequent timeout as `unavailable` (game skips the song silently) rather than `error`. A genuinely idle speaker that Beatify did NOT stop (offline speaker / unauthenticated provider) still classifies `error` so `MAX_SONG_RETRIES` + the recovery banner kick in. The flag resets at the start of each song's cascade so a stop from a prior song never leaks.

Files: `custom_components/beatify/services/media_player.py`, `tests/unit/test_media_player.py`.

## Readiness assessment
- [x] Ready to merge
- [ ] Borderline — see notes
- [ ] Not ready — needs human review

**Honest summary:** Minimal, surgical change matching the issue's suggested flag approach. Backend-only (no UI surface, no `www/**` changes). Three new regression tests cover the unavailable-vs-error split and the cross-song flag reset; full pytest (910 passed) and vitest (240 passed) are green, and ruff check + format pass on CI version 0.15.7.

## Test plan
- `pytest tests/unit/test_media_player.py` — 54 passed (3 new: idle-after-cascade-stop → unavailable, idle-without-stop → error, flag reset per song).
- Full `pytest` — 910 passed, 2 skipped.
- `npx vitest run` — 240 passed.
- `ruff check` + `ruff format --check` on touched files — clean (ruff 0.15.7).
- Manual: apple_music user with a region-gapped track and ≥2 candidate URIs — game should skip the song silently instead of pausing with the recovery banner.

## Risk assessment
- **Blast radius:** single method `_try_ma_play` (idle-failure classification) plus one new instance flag; no behaviour change for single-candidate providers or for genuinely-offline speakers.
- **What could go wrong:** if some other code path could leave `_stopped_for_cascade` True across a real systemic idle within the same song, an `error` could be downgraded to `unavailable` — mitigated because the flag is only ever set by Beatify's own cascade stop and reset at each song start.
- **What I did NOT test:** live end-to-end on real MA hardware with an actual apple_music storefront gap.

🤖 Auto-generated by issue-triage routine