### PR TITLE
fix: redact quiz answers from player broadcast payload during PLAYING (#1366)

### DIFF
--- a/custom_components/beatify/server/serializers.py
+++ b/custom_components/beatify/server/serializers.py
@@ -50,6 +50,54 @@ def build_state_message(game_state: GameState) -> dict[str, Any] | None:
     return {"type": "state", **state}
 
 
+# Placeholder shown to players for an answer field that is hidden until REVEAL.
+REDACTED_PLACEHOLDER = "???"
+
+
+def redact_state_for_player(message: dict[str, Any]) -> dict[str, Any]:
+    """Return a player-safe copy of a ``state`` / ``metadata_update`` message.
+
+    The full broadcast payload built by :func:`build_state_message` (and the
+    ``metadata_update`` payload) carries the round's answers so the spectator
+    admin / TV can display them. Those frames are broadcast identically to
+    every connection, so a player can read the answer straight off the
+    WebSocket before guessing (#1366). This strips the answers for non-admin
+    recipients:
+
+    * ``admin_song`` (the year answer + fun facts) is removed entirely — it is
+      never meant for players in any mode.
+    * When ``title_artist_mode`` is active and the game is still ``PLAYING``,
+      ``song.artist`` / ``song.title`` ARE the answers being guessed, so they
+      are replaced with a placeholder. ``album_art`` is left intact (players
+      need it to play along). The REVEAL payload is untouched — by then the
+      answers are public.
+
+    The input is not mutated; only the keys that need changing are shallow
+    copied.
+    """
+    if not isinstance(message, dict):
+        return message
+
+    # Nothing to redact if neither answer-bearing key is present.
+    has_admin_song = "admin_song" in message
+    redact_song = (
+        message.get("title_artist_mode")
+        and message.get("phase") == "PLAYING"
+        and isinstance(message.get("song"), dict)
+    )
+    if not has_admin_song and not redact_song:
+        return message
+
+    redacted = dict(message)
+    redacted.pop("admin_song", None)
+    if redact_song:
+        song = dict(redacted["song"])
+        song["artist"] = REDACTED_PLACEHOLDER
+        song["title"] = REDACTED_PLACEHOLDER
+        redacted["song"] = song
+    return redacted
+
+
 def build_status_response(
     hass: HomeAssistant,
     *,

--- a/custom_components/beatify/server/websocket.py
+++ b/custom_components/beatify/server/websocket.py
@@ -14,8 +14,10 @@ from custom_components.beatify.const import (
     LOBBY_DISCONNECT_GRACE_PERIOD,
 )
 from custom_components.beatify.server.serializers import (
+    REDACTED_PLACEHOLDER,
     build_state_message,
     get_game_state,
+    redact_state_for_player,
 )
 from custom_components.beatify.server.ws_handlers import (
     handle_admin,
@@ -292,15 +294,53 @@ class BeatifyWebSocketHandler:
         if not targets:
             return
 
+        # #1366: the broadcast payload carries the round's answers (admin_song
+        # year; song.artist/title in title_artist_mode) for the spectator admin
+        # / TV. Sent unfiltered, any player could read them off the WebSocket
+        # before guessing. Redact per-recipient: only the spectator admin WS
+        # gets the answers; every player connection gets a redacted copy.
+        player_message = self._redact_for_player(message, game_state)
+
+        admin_ws = game_state._admin_ws if game_state else None
+
         # Build list of send tasks for all open connections
         tasks = []
         for ws in list(targets):
             if not ws.closed:
-                tasks.append(self._safe_send(ws, message))
+                payload = message if ws is admin_ws else player_message
+                tasks.append(self._safe_send(ws, payload))
 
         # Execute all sends in parallel
         if tasks:
             await asyncio.gather(*tasks)
+
+    @staticmethod
+    def _redact_for_player(message: dict, game_state) -> dict:  # noqa: ANN001
+        """Return the player-safe variant of an answer-bearing broadcast (#1366).
+
+        Returns ``message`` unchanged for payloads that carry no answers.
+        ``metadata_update`` frames (sent mid-PLAYING when song metadata lands)
+        have no ``phase`` / ``title_artist_mode`` of their own, so the
+        title_artist context is taken from ``game_state``.
+        """
+        msg_type = message.get("type")
+        if msg_type == "state":
+            return redact_state_for_player(message)
+        if msg_type == "metadata_update" and game_state is not None:
+            from custom_components.beatify.game.state import (  # noqa: PLC0415
+                GamePhase,
+            )
+
+            if (
+                game_state.title_artist_mode
+                and game_state.phase == GamePhase.PLAYING
+                and isinstance(message.get("song"), dict)
+            ):
+                song = dict(message["song"])
+                song["artist"] = REDACTED_PLACEHOLDER
+                song["title"] = REDACTED_PLACEHOLDER
+                return {**message, "song": song}
+        return message
 
     async def _safe_send(self, ws: web.WebSocketResponse, message: dict) -> None:
         """

--- a/custom_components/beatify/server/ws_handlers.py
+++ b/custom_components/beatify/server/ws_handlers.py
@@ -50,12 +50,33 @@ from custom_components.beatify.const import (
 )
 from custom_components.beatify.game.state import GamePhase, GameState
 from custom_components.beatify.server.companion_auth import is_companion_trusted_meta
-from custom_components.beatify.server.serializers import build_state_message
+from custom_components.beatify.server.serializers import (
+    build_state_message,
+    redact_state_for_player,
+)
 
 if TYPE_CHECKING:
     from custom_components.beatify.server.websocket import BeatifyWebSocketHandler
 
 _LOGGER = logging.getLogger(__name__)
+
+
+async def _send_state_to(
+    ws: web.WebSocketResponse, state_msg: dict, game_state: GameState
+) -> None:
+    """Send a ``state`` message to a single recipient, redacted for players.
+
+    #1366: ``state`` frames carry the round's answers (admin_song year;
+    song.artist/title in title_artist_mode). Only the spectator admin WS
+    (``game_state._admin_ws``) may receive them unfiltered; every other
+    connection — including an admin who joined as a *participant* — gets a
+    redacted copy, matching the per-recipient filtering in
+    ``BeatifyWebSocketHandler.broadcast``.
+    """
+    payload = state_msg
+    if ws is not game_state._admin_ws:
+        payload = redact_state_for_player(state_msg)
+    await ws.send_json(payload)
 
 
 # ---------------------------------------------------------------------------
@@ -326,12 +347,12 @@ async def handle_join(
                 }
             )
 
-        # Send full state to newly joined player
+        # Send state to newly joined player (redacted — #1366)
         state_msg = build_state_message(game_state)
         if not state_msg:
             return
         try:
-            await ws.send_json(state_msg)
+            await _send_state_to(ws, state_msg, game_state)
         except (ConnectionError, RuntimeError) as err:
             _LOGGER.warning("Failed to send state to new player: %s", err)
             return
@@ -443,7 +464,7 @@ async def handle_get_state(
     """Handle dashboard/observer state request (Story 10.4)."""
     state_msg = build_state_message(game_state)
     if state_msg:
-        await ws.send_json(state_msg)
+        await _send_state_to(ws, state_msg, game_state)
 
 
 async def handle_round_timeout(
@@ -1215,7 +1236,7 @@ async def handle_reconnect(
 
     state_msg = build_state_message(game_state)
     if state_msg:
-        await ws.send_json(state_msg)
+        await _send_state_to(ws, state_msg, game_state)
 
     await handler.broadcast_state()
 

--- a/tests/unit/test_redact_answers_1366.py
+++ b/tests/unit/test_redact_answers_1366.py
@@ -1,0 +1,167 @@
+"""Tests for per-recipient answer redaction in broadcasts (#1366).
+
+The broadcast payload carries the round's answers (``admin_song`` year;
+``song.artist`` / ``song.title`` in title_artist_mode) so the spectator admin
+/ TV can show them. Those frames were sent unfiltered to every connection, so a
+player could read the answer off the WebSocket before guessing. These tests
+pin the redaction: only the spectator admin WS gets the answers; every player
+connection gets a redacted copy.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+from custom_components.beatify.const import DOMAIN
+from custom_components.beatify.game.state import GamePhase
+from custom_components.beatify.server.serializers import (
+    REDACTED_PLACEHOLDER,
+    build_state_message,
+    redact_state_for_player,
+)
+from custom_components.beatify.server.websocket import BeatifyWebSocketHandler
+from tests.conftest import make_game_state, make_songs
+
+
+def _playing_game(*, title_artist_mode: bool):
+    gs = make_game_state()
+    gs.create_game(
+        playlists=["test.json"],
+        songs=make_songs(3),
+        media_player="media_player.test",
+        base_url="http://localhost:8123",
+        title_artist_mode=title_artist_mode,
+    )
+    gs.phase = GamePhase.PLAYING
+    gs.current_song = {
+        "title": "Hey Jude",
+        "artist": "The Beatles",
+        "year": 1968,
+        "album_art": "/art.png",
+    }
+    if title_artist_mode:
+        gs._challenge_manager.init_round(gs.current_song)
+    return gs
+
+
+# ---------------------------------------------------------------------------
+# redact_state_for_player — pure function
+# ---------------------------------------------------------------------------
+
+
+class TestRedactStateForPlayer:
+    def test_admin_song_stripped_during_playing(self):
+        msg = build_state_message(_playing_game(title_artist_mode=False))
+        assert "admin_song" in msg  # full payload carries the year answer
+        assert msg["admin_song"]["year"] == 1968
+
+        redacted = redact_state_for_player(msg)
+        assert "admin_song" not in redacted
+        # The original is not mutated.
+        assert "admin_song" in msg
+
+    def test_year_only_mode_keeps_song_artist_title(self):
+        # Without title_artist_mode the song.artist/title are NOT the answer
+        # (the year is), so they stay — only admin_song is stripped.
+        msg = build_state_message(_playing_game(title_artist_mode=False))
+        redacted = redact_state_for_player(msg)
+        assert redacted["song"]["artist"] == "The Beatles"
+        assert redacted["song"]["title"] == "Hey Jude"
+        assert redacted["song"]["album_art"] == "/art.png"
+
+    def test_title_artist_mode_masks_artist_and_title(self):
+        msg = build_state_message(_playing_game(title_artist_mode=True))
+        redacted = redact_state_for_player(msg)
+        assert redacted["song"]["artist"] == REDACTED_PLACEHOLDER
+        assert redacted["song"]["title"] == REDACTED_PLACEHOLDER
+        # Album art must survive so the player can still play along.
+        assert redacted["song"]["album_art"] == "/art.png"
+        # admin_song still gone.
+        assert "admin_song" not in redacted
+        # Original untouched.
+        assert msg["song"]["artist"] == "The Beatles"
+
+    def test_reveal_payload_not_redacted(self):
+        gs = _playing_game(title_artist_mode=True)
+        gs.phase = GamePhase.REVEAL
+        msg = build_state_message(gs)
+        # REVEAL carries the truth at the right time and has no admin_song.
+        redacted = redact_state_for_player(msg)
+        assert redacted["song"]["artist"] == "The Beatles"
+        assert redacted["song"]["title"] == "Hey Jude"
+        assert redacted["song"]["year"] == 1968
+
+    def test_lobby_payload_passthrough(self):
+        gs = make_game_state()
+        gs.create_game(
+            playlists=["test.json"],
+            songs=make_songs(3),
+            media_player="media_player.test",
+            base_url="http://localhost:8123",
+        )
+        msg = build_state_message(gs)  # LOBBY — no song, no admin_song
+        assert redact_state_for_player(msg) is msg  # unchanged, same object
+
+
+# ---------------------------------------------------------------------------
+# broadcast — per-recipient routing
+# ---------------------------------------------------------------------------
+
+
+def _make_ws() -> AsyncMock:
+    ws = AsyncMock()
+    ws.send_json = AsyncMock()
+    ws.closed = False
+    return ws
+
+
+class TestBroadcastRedaction:
+    def _handler(self, gs):
+        mock_hass = MagicMock()
+        mock_hass.data = {DOMAIN: {"game": gs}}
+        return BeatifyWebSocketHandler(mock_hass)
+
+    async def test_player_gets_redacted_admin_gets_full(self):
+        gs = _playing_game(title_artist_mode=True)
+        handler = self._handler(gs)
+
+        admin_ws = _make_ws()
+        player_ws = _make_ws()
+        gs._admin_ws = admin_ws
+        handler.connections = {admin_ws, player_ws}
+
+        msg = build_state_message(gs)
+        await handler.broadcast(msg)
+
+        admin_payload = admin_ws.send_json.call_args[0][0]
+        player_payload = player_ws.send_json.call_args[0][0]
+
+        # Spectator admin keeps the answers.
+        assert admin_payload["admin_song"]["year"] == 1968
+        assert admin_payload["song"]["artist"] == "The Beatles"
+        assert admin_payload["song"]["title"] == "Hey Jude"
+
+        # Player gets them stripped / masked.
+        assert "admin_song" not in player_payload
+        assert player_payload["song"]["artist"] == REDACTED_PLACEHOLDER
+        assert player_payload["song"]["title"] == REDACTED_PLACEHOLDER
+
+    async def test_metadata_update_masked_for_player_in_ta_mode(self):
+        gs = _playing_game(title_artist_mode=True)
+        handler = self._handler(gs)
+
+        admin_ws = _make_ws()
+        player_ws = _make_ws()
+        gs._admin_ws = admin_ws
+        handler.connections = {admin_ws, player_ws}
+
+        await handler.broadcast_metadata_update(
+            {"artist": "The Beatles", "title": "Hey Jude", "album_art": "/art.png"}
+        )
+
+        admin_payload = admin_ws.send_json.call_args[0][0]
+        player_payload = player_ws.send_json.call_args[0][0]
+        assert admin_payload["song"]["artist"] == "The Beatles"
+        assert player_payload["song"]["artist"] == REDACTED_PLACEHOLDER
+        assert player_payload["song"]["title"] == REDACTED_PLACEHOLDER
+        assert player_payload["song"]["album_art"] == "/art.png"


### PR DESCRIPTION
Closes #1366

## Readiness assessment
- [x] Ready to merge
- [ ] Borderline — see notes
- [ ] Not ready — needs human review

**Honest summary:** Closes an answer-leak / cheating vector. The PLAYING broadcast carried the round's answers (`admin_song.year`; `song.artist`/`song.title` in `title_artist_mode`) and `broadcast()` sent one identical payload to every connection, so any player could read the answer off the WebSocket (devtools) before guessing. The only prior gating was client-side (`admin.js:2450`). Fix redacts **per recipient** in the broadcast layer: only the spectator admin WS (`game_state._admin_ws`) gets the answers; every player connection — including an admin who joined as a *participant* — gets a redacted copy. Pure server-side payload change; no frontend files touched, so no `.min.js`/cache-buster/`sw.js` bumps required.

## What changed
- `server/serializers.py`: new `redact_state_for_player()` — strips `admin_song`; in `title_artist_mode` + PLAYING masks `song.artist`/`song.title` to `???` (keeps `album_art`); REVEAL untouched. Non-mutating.
- `server/websocket.py`: `broadcast()` now sends the full payload only to `_admin_ws` and a redacted copy to all other connections; covers the `metadata_update` frame too (mid-PLAYING artist/title leak).
- `server/ws_handlers.py`: new `_send_state_to()` applied to the three single-recipient `state` sends that bypass `broadcast` (`handle_join`, `handle_get_state`, `handle_reconnect`). `handle_admin_connect` keeps the full payload (that WS is `_admin_ws`).
- `tests/unit/test_redact_answers_1366.py`: 7 new tests (pure-function redaction + broadcast per-recipient routing).

## Test plan
- Automated: `pytest` 914 passed / 2 skipped; new file 7/7. `vitest run` 240 passed. `ruff check` + `ruff format --check` clean on touched files (pinned 0.15.7).
- Manual: start a `title_artist_mode` game; as a player open devtools → WS frames during PLAYING should show `song.artist`/`song.title` = `???` and no `admin_song`. The TV/spectator admin still shows year + fun facts. At REVEAL, players see the real artist/title/year.

## Risk assessment
- **Blast radius:** WebSocket state/metadata broadcast layer (`server/serializers.py`, `server/websocket.py`, `server/ws_handlers.py`). No frontend, no game logic, no scoring.
- **What could go wrong:** Admin-identity hinges on `ws is game_state._admin_ws`. An admin who joins only as a *participant* (no separate spectator connection) now gets the redacted payload — which is the intended fair-play behaviour and matches the existing client-side guard (`admin.js:2447` hides spoilers from a participating admin). If a future spectator-admin path forgets to register `_admin_ws`, that admin would over-redact (lose answers), not under-redact — fail-safe direction.
- **What I did NOT test:** live HA add-on end-to-end with a real Android Companion admin + multiple phones; relied on unit coverage for the payload shape.

🤖 Auto-generated by issue-triage routine