### PR TITLE
fix: require auth for SavePlaylistView to prevent unauthenticated disk writes (#1368)

### DIFF
--- a/custom_components/beatify/server/playlist_views.py
+++ b/custom_components/beatify/server/playlist_views.py
@@ -335,6 +335,17 @@ class SavePlaylistView(RateLimitMixin, HomeAssistantView):
 
     async def post(self, request: web.Request) -> web.Response:
         """Save a validated playlist JSON to the user/ subfolder."""
+        # #1368: this handler persists a caller-supplied JSON document to disk
+        # under <config>/beatify/playlists/user/<slug>.json and creates a new
+        # non-clobbering file on every save. Without an auth gate any
+        # unauthenticated client on the LAN (or via the Nabu Casa remote URL)
+        # could repeatedly POST distinct playlists to exhaust the HA config
+        # volume (disk-exhaustion DoS) and pollute the Community playlist tab.
+        # Mirror the StartGameView / #1367 PlaylistRequestsView pattern: require
+        # a valid HA Bearer token (or the Companion trust fallback) before
+        # touching disk.
+        if not await is_authorized_http(request, self.hass):
+            return _json_error("Unauthorized", 401, code="UNAUTHORIZED")
         client_ip = request.remote or "unknown"
         if not self._check_rate_limit(client_ip):
             return _json_error("Too many requests", 429, code="RATE_LIMITED")

--- a/tests/unit/test_save_playlist_view.py
+++ b/tests/unit/test_save_playlist_view.py
@@ -19,6 +19,8 @@ from pathlib import Path
 from unittest import mock
 from unittest.mock import AsyncMock, MagicMock
 
+import pytest
+
 from aiohttp import StreamReader
 from aiohttp.test_utils import make_mocked_request
 
@@ -69,6 +71,14 @@ def _request_with_body(body: bytes):
     )
 
 
+def _authorized():
+    """Patch is_authorized_http to allow the POST through (#1368)."""
+    return mock.patch(
+        "custom_components.beatify.server.playlist_views.is_authorized_http",
+        new=AsyncMock(return_value=True),
+    )
+
+
 def _view_with_tmp_config(tmp_path: Path) -> SavePlaylistView:
     hass = MagicMock()
     # get_playlist_directory resolves to <config>/beatify/playlists.
@@ -100,6 +110,13 @@ class TestSlugify:
 
 
 class TestSavePlaylistView:
+    @pytest.fixture(autouse=True)
+    def _allow_auth(self):
+        # #1368: post() now gates on is_authorized_http before any disk work.
+        # These cases exercise the validation/persistence path, so authorize them.
+        with _authorized():
+            yield
+
     async def test_valid_payload_writes_to_user_subdir(self, tmp_path):
         view = _view_with_tmp_config(tmp_path)
         body = json.dumps({"playlist": _valid_playlist("My Mix")}).encode()
@@ -157,6 +174,38 @@ class TestSavePlaylistView:
         second = await view.post(_request_with_body(body))
         assert first.status == 200
         assert second.status == 429
+
+
+class TestSavePlaylistViewAuth:
+    """#1368: POST persists a caller-supplied JSON to disk and creates a new
+    non-clobbering file on every save, so it must require auth.
+
+    Before the fix any unauthenticated client on the LAN (or via the Nabu Casa
+    remote URL) could repeatedly POST distinct playlists to exhaust the HA
+    config volume (disk-exhaustion DoS) and pollute the Community tab — only IP
+    rate limiting stood in the way.
+    """
+
+    async def test_unauthorized_post_is_rejected_401(self, tmp_path):
+        view = _view_with_tmp_config(tmp_path)
+        body = json.dumps({"playlist": _valid_playlist("Blocked")}).encode()
+        with mock.patch(
+            "custom_components.beatify.server.playlist_views.is_authorized_http",
+            new=AsyncMock(return_value=False),
+        ):
+            resp = await view.post(_request_with_body(body))
+        assert resp.status == 401
+        assert json.loads(resp.body)["error"] == "UNAUTHORIZED"
+
+    async def test_unauthorized_post_does_not_write_to_disk(self, tmp_path):
+        view = _view_with_tmp_config(tmp_path)
+        body = json.dumps({"playlist": _valid_playlist("Blocked")}).encode()
+        with mock.patch(
+            "custom_components.beatify.server.playlist_views.is_authorized_http",
+            new=AsyncMock(return_value=False),
+        ):
+            await view.post(_request_with_body(body))
+        view.hass.async_add_executor_job.assert_not_called()
 
 
 class TestUserSubdirIsCommunityInDiscovery:


### PR DESCRIPTION
Closes #1368

## Readiness assessment
- [x] Ready to merge
- [ ] Borderline — see notes
- [ ] Not ready — needs human review

**Honest summary:** Drop-in mirror of the merged #1367 fix on the sibling `PlaylistRequestsView` (same file, same module-level `is_authorized_http` import). `SavePlaylistView.post` now rejects unauthenticated callers with 401 before any disk work, closing the disk-exhaustion DoS / Community-tab-pollution vector. No new auth scheme invented; the existing StartGameView/Companion-trust path is reused verbatim. Low blast radius — backend-only, no UI surface.

## What changed
- `custom_components/beatify/server/playlist_views.py` — added `if not await is_authorized_http(request, self.hass): return _json_error("Unauthorized", 401, code="UNAUTHORIZED")` as the first line of `SavePlaylistView.post`, before the rate-limit check (identical placement to the #1367 fix).
- `tests/unit/test_save_playlist_view.py` — existing happy-path tests now authorize via a patched `is_authorized_http` (autouse fixture, mirrors #1367's `_authorized()`), plus a new `TestSavePlaylistViewAuth` class asserting 401 + no disk write when unauthenticated.

## Test plan
- `pytest tests/unit` → 917 passed (incl. new auth tests + the existing 6 SavePlaylistView cases).
- `npm test` (vitest) → 240 passed.
- `ruff check` + `ruff format --check` (0.15.7) clean on both touched files.
- Manual: POST to `/beatify/api/playlists/save` without a valid HA Bearer token (and outside the Companion UA+RFC1918 trust path) now returns 401 and writes nothing; an authenticated save still lands under `playlists/user/<slug>.json`.

## Risk assessment
- **Blast radius:** one HTTP handler (`SavePlaylistView.post`) + its unit test; no frontend, no shared logic.
- **What could go wrong:** if a legitimate save client was relying on the unauthenticated endpoint it will now 401 — but the authenticated PWA already carries the HA Bearer token / Companion trust, the same path PlaylistRequestsView uses since #1367, so the save flow is unchanged for real users.
- **What I did NOT test:** live end-to-end save from the running PWA against a real HA instance (covered by unit + mocked-auth tests only).

🤖 Auto-generated by issue-triage routine