### PR TITLE
fix: offload data-quality report file I/O to executor (#1372)

### DIFF
--- a/custom_components/beatify/server/ws_handlers.py
+++ b/custom_components/beatify/server/ws_handlers.py
@@ -1788,6 +1788,22 @@ async def handle_title_artist_override(
 # ---------------------------------------------------------------------------
 
 
+def _write_report(reports_path: Path, report: dict) -> None:
+    """Append a data quality report to the JSON file (blocking I/O).
+
+    Runs in the executor (see ``handle_report_data``) so the mkdir/read/write
+    never blocks the HA event loop (Issue #1372).
+    """
+    reports_path.parent.mkdir(parents=True, exist_ok=True)
+    existing: list = []
+    if reports_path.exists():
+        existing = json.loads(reports_path.read_text(encoding="utf-8"))
+    existing.append(report)
+    reports_path.write_text(
+        json.dumps(existing, indent=2, ensure_ascii=False), encoding="utf-8"
+    )
+
+
 async def handle_report_data(
     handler: BeatifyWebSocketHandler,
     ws: web.WebSocketResponse,
@@ -1835,14 +1851,9 @@ async def handle_report_data(
         Path(handler.hass.config.path("beatify")) / "data_quality_reports.json"
     )
     try:
-        reports_path.parent.mkdir(parents=True, exist_ok=True)
-        existing: list = []
-        if reports_path.exists():
-            existing = json.loads(reports_path.read_text(encoding="utf-8"))
-        existing.append(report)
-        reports_path.write_text(
-            json.dumps(existing, indent=2, ensure_ascii=False), encoding="utf-8"
-        )
+        # Filesystem I/O is blocking and must not run on the HA event loop
+        # (Issue #1372) — offload the read-append-write to the executor.
+        await handler.hass.async_add_executor_job(_write_report, reports_path, report)
     except (OSError, ValueError):
         _LOGGER.warning("Failed to write data quality report to %s", reports_path)
 


### PR DESCRIPTION
Closes #1372
Closes #1383

#1383 is a byte-for-byte duplicate of #1372 (same location `ws_handlers.py:1827-1840`, identical body, both filed by the same deep-code-review run). This PR fixes the single shared code path, so it closes both.

## Readiness assessment
- [x] Ready to merge
- [ ] Borderline — see notes
- [ ] Not ready — needs human review

**Honest summary:** Tight, behaviour-preserving fix. The blocking `mkdir`/`exists`/`read_text`/`write_text` block in `handle_report_data` is moved verbatim into a module-level sync helper `_write_report` and run via `hass.async_add_executor_job`, exactly matching the off-loop file-I/O pattern already used in `playlist_views.py`, `analytics.py`, and `services/stats.py`. The read-append-write logic and the `except (OSError, ValueError)` guard are unchanged — only the execution context moves off the event loop. No new dependency, no API/contract change, no UI surface.

## Test plan
- Automated: `pytest tests/unit/` (915 passed) + `tests/integration/` (2 skipped) + `npx vitest run` (240 passed). Ruff check + `ruff format --check` clean (ruff 0.15.7, CI-pinned).
- Manual: in a running game, on a player's REVEAL screen tap "report wrong data" → expect a `report_data_ack` and a new entry appended to `<config>/beatify/data_quality_reports.json`, with no "blocking call inside the event loop" warning in the HA log.

## Risk assessment
- **Blast radius:** one function in `custom_components/beatify/server/ws_handlers.py` (+ new private helper). Only the data-quality-report write path.
- **What could go wrong:** the O(n) full-file read-rewrite per report remains (the issue's optional JSONL suggestion was intentionally left out of scope to keep the fix minimal) — but it now runs in the executor, off the loop, so it no longer stalls HA core. Exception semantics preserved: the helper raises and the caller's existing `except` logs the same warning.
- **What I did NOT test:** live HA instance (verified via unit/integration/JS suites + static review only); behaviour under a corrupted existing `data_quality_reports.json` is unchanged from before this PR.

🤖 Auto-generated by issue-triage routine