### PR TITLE
fix: escape HA friendly_name/entity_id in wizard speaker + light lists (#1370)

### DIFF
--- a/custom_components/beatify/www/js/wizard.js
+++ b/custom_components/beatify/www/js/wizard.js
@@ -23,6 +23,15 @@ const LS_GAME_SETTINGS = 'beatify_game_settings'; // set by admin.js, contains {
 
 let _hubMounted = false;
 
+// HTML-escape helpers. HA friendly_name / entity_id values come from devices
+// and integrations on the LAN and are NOT trusted — a Sonos/Cast/DLNA device
+// can advertise an arbitrary name (e.g. `<img src=x onerror=...>`) that HA
+// stores as friendly_name. They must be escaped before entering innerHTML.
+// escapeAttr also escapes quotes for use inside attribute values; escapeText
+// is for text content between tags (#1370).
+const escapeAttr = (s) => String(s).replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+const escapeText = (s) => String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+
 // ------------------------------------------------------------------
 // Pure helpers — exported for vitest
 // ------------------------------------------------------------------
@@ -460,10 +469,10 @@ function _renderSpeakers() {
             const badgeHtml = badge
                 ? `<span class="cap-dot" aria-hidden="true"></span><span class="cap-badge ${badge.cls}"${badgeTitle}>${badge.label}</span>`
                 : '';
-            return `<button type="button" class="wiz-row ${selected ? 'selected' : ''}" data-entity-id="${p.entity_id}">
+            return `<button type="button" class="wiz-row ${selected ? 'selected' : ''}" data-entity-id="${escapeAttr(p.entity_id)}">
           <div class="wiz-row-avatar">${SPEAKER_ICON}</div>
           <div class="wiz-row-text">
-            <div class="wiz-row-name">${p.friendly_name || p.entity_id}</div>
+            <div class="wiz-row-name">${escapeText(p.friendly_name || p.entity_id)}</div>
             <div class="wiz-row-sub">${platform}${badgeHtml}</div>
           </div>
           ${selected ? '<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" class="wiz-row-check"><path d="M5 12l5 5L20 7"/></svg>' : ''}
@@ -1042,9 +1051,9 @@ function _lightsDetailHtml() {
         ? lights.map((l) => {
               const checked = chosenLightEntityIds.has(l.entity_id) ? 'checked' : '';
               const searchable = `${l.friendly_name || ''} ${l.entity_id}`.toLowerCase();
-              return `<label class="wiz-detail-check" data-light-search="${searchable.replace(/"/g, '&quot;')}">
-            <input type="checkbox" data-light-id="${l.entity_id}" ${checked}>
-            <span class="wiz-detail-check-name">${l.friendly_name || l.entity_id}</span>
+              return `<label class="wiz-detail-check" data-light-search="${escapeAttr(searchable)}">
+            <input type="checkbox" data-light-id="${escapeAttr(l.entity_id)}" ${checked}>
+            <span class="wiz-detail-check-name">${escapeText(l.friendly_name || l.entity_id)}</span>
           </label>`;
           }).join('')
         : `<div class="wiz-detail-empty">${_t('wizard.step5.lights.noneFound', 'No lights available')}</div>`;
@@ -1116,8 +1125,6 @@ function _ttsDetailHtml() {
     // load any entities (e.g. offline or older HA) so the wizard never
     // becomes un-completable.
     const entities = cachedTtsEntities || [];
-    const escapeAttr = (s) => String(s).replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
-    const escapeText = (s) => String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
     const known = new Set(entities.map((e) => e.entity_id));
     const optsHtml = entities.map((e) => {
         const label = e.friendly_name && e.friendly_name !== e.entity_id


### PR DESCRIPTION
Closes #1370

## Root cause
`_renderSpeakers()` and `_lightsDetailHtml()` in `wizard.js` interpolated `friendly_name || entity_id` (and the `data-entity-id` / `data-light-id` / `data-light-search` attributes) straight into `innerHTML` without escaping. HA friendly_name values are not trusted — they come from devices/integrations on the LAN (a Sonos/Cast/DLNA device can advertise an arbitrary name), so a name like `<img src=x onerror=...>` executes stored XSS in the Beatify admin page, which holds the BeatifyAuth admin session. The TTS dropdown 70 lines below already escaped via local `escapeAttr`/`escapeText`; the speaker + light lists were the outliers.

## Fix
- Hoisted the `escapeAttr` / `escapeText` helpers (previously local to `_ttsDetailHtml`) to module scope in `custom_components/beatify/www/js/wizard.js`.
- `_renderSpeakers`: `escapeAttr(entity_id)` for the `data-entity-id` attribute, `escapeText(friendly_name || entity_id)` for the visible name.
- `_lightsDetailHtml`: `escapeAttr` for `data-light-id` and `data-light-search` (the latter previously only escaped `"` and is now fully escaped), `escapeText` for the visible name.
- Removed the now-duplicate local helpers in `_ttsDetailHtml`.

`wizard.js` is served raw as `<script type="module">` (admin.html line 1477), not bundled into any `.min.js` and not a `scripts/build.mjs` entry — so there is no min.js to regenerate. Cache-buster is server-templated `{{ASSET_VER}}` and auto-moves on content change. `npm run build:check` confirms no bundle drift.

## Readiness assessment
- [x] Ready to merge
- [ ] Borderline — see notes
- [ ] Not ready — needs human review

**Honest summary:** Minimal, surgical security fix reusing the codebase's existing escaping pattern. Both vulnerable lists (speakers + lights) plus all four injection sinks (3 attributes + 2 text nodes) are covered. No behavior change for legitimate names; only malicious/markup-containing names are neutralized.

## Test plan
- Automated: `npx vitest run` (240 passed, incl. 49 wizard tests), `python3 -m pytest` (915 passed / 2 skipped), `npm run build:check` (no drift).
- Manual: rename a media_player/light entity in HA to `<img src=x onerror=alert(1)>`, open the admin first-run wizard Step 1 (speakers) and Step 5 (lights) — the name now renders as literal text, no script executes.

## Risk assessment
- **Blast radius:** one file, `custom_components/beatify/www/js/wizard.js` (speaker list, light list, TTS helper hoist).
- **What could go wrong:** very low — escaping is idempotent for normal names; the only visible effect is that names containing `&`/`<`/`>`/`"` now display literally instead of as markup (correct behavior).
- **What I did NOT test:** live in-browser rendering against a real malicious HA entity name (covered by the manual test plan above, not executed here).

🤖 Auto-generated by issue-triage routine