### PR TITLE
fix: re-arm REVEAL auto-advance/idle-halt/vote-window on resume (#1371)

### DIFF
--- a/custom_components/beatify/game/state.py
+++ b/custom_components/beatify/game/state.py
@@ -287,6 +287,13 @@ class GameState(
         # open vote window, so the serializer publishes an authoritative
         # vote_seconds_remaining (no client clock-skew). None when not voting.
         self._title_artist_vote_deadline: float | None = None
+        # #1371: pause snapshot of the open vote window. pause_game() cancels the
+        # vote-window task, whose CancelledError handler async-resets
+        # _title_artist_voting_open / _title_artist_vote_deadline before
+        # resume_game() runs — so the live flags are unreliable at resume time.
+        # These capture the window state at pause so resume can re-arm it.
+        self._paused_vote_open: bool = False
+        self._paused_vote_deadline: float | None = None
         # #1048: ms timestamp REVEAL was entered — clients compute remaining
         # countdown vs Date.now(). None outside REVEAL.
         self.reveal_started_at: int | None = None
@@ -745,16 +752,28 @@ class GameState(
         if self.title_artist_mode:
             self._schedule_title_artist_vote_window()
         if not self._title_artist_voting_open:
-            if any(p.submitted for p in self.players.values()):
-                self._auto_advance_task = asyncio.create_task(
-                    self._reveal_auto_advance(self.reveal_auto_advance)
-                )
-            else:
-                _LOGGER.info(
-                    "Round %d ended with zero guesses — holding after song-end",
-                    self.round,
-                )
-                self._auto_advance_task = asyncio.create_task(self._reveal_idle_halt())
+            self._schedule_song_end_auto_advance()
+
+    def _schedule_song_end_auto_advance(self) -> None:
+        """Spawn the song-end auto-advance / idle-halt task (#1012).
+
+        The non-vote-window tail of :meth:`_schedule_reveal_advance`: if anyone
+        submitted a guess, arm the song-end auto-advance; otherwise the party is
+        idle, so arm the idle-halt (let the song finish, stop, hold on REVEAL).
+        Assumes the caller already cancelled any prior task and that no vote
+        window owns the ``_auto_advance_task`` slot. Reused by
+        ``resume_game`` (#1371) to re-arm a REVEAL that was paused mid-dwell.
+        """
+        if any(p.submitted for p in self.players.values()):
+            self._auto_advance_task = asyncio.create_task(
+                self._reveal_auto_advance(self.reveal_auto_advance)
+            )
+        else:
+            _LOGGER.info(
+                "Round %d ended with zero guesses — holding after song-end",
+                self.round,
+            )
+            self._auto_advance_task = asyncio.create_task(self._reveal_idle_halt())
 
     # ------------------------------------------------------------------
     # REVEAL transition (_transition_to_reveal / _apply_reveal_lights), the

--- a/custom_components/beatify/game/state_pause.py
+++ b/custom_components/beatify/game/state_pause.py
@@ -112,6 +112,15 @@ class PauseResumeMixin:
                 self.disconnected_admin_name = player.name
                 break
 
+        # #1371: snapshot the open title/artist vote window BEFORE cancelling.
+        # _cancel_auto_advance() cancels the vote-window task, whose
+        # CancelledError handler async-resets _title_artist_voting_open /
+        # _title_artist_vote_deadline before resume_game() runs — so resume
+        # cannot trust the live flags. Capture them here so a resume-to-REVEAL
+        # can re-arm the window (or finalize it if its deadline elapsed).
+        self._paused_vote_open = self._title_artist_voting_open
+        self._paused_vote_deadline = self._title_artist_vote_deadline
+
         # #1012: a pause stops the unattended REVEAL auto-advance too.
         self._cancel_auto_advance()
 
@@ -217,6 +226,79 @@ class PauseResumeMixin:
         self.disconnected_admin_name = None
         self._previous_phase = None
 
+        # #1371: a resume-to-REVEAL must re-arm the REVEAL task that pause_game()
+        # cancelled — otherwise the auto-advance / idle-halt / title-artist
+        # vote-window silently never fires and the game stalls on REVEAL forever
+        # (the very admin-disconnect pause unattended mode is meant to survive).
+        # The phase is now REVEAL again, so the re-armed tasks' phase-checks pass.
+        if previous == GamePhase.REVEAL:
+            await self._rearm_reveal_after_resume()
+
         _LOGGER.info("Game resumed to phase: %s", previous.value)
 
         return True
+
+    async def _rearm_reveal_after_resume(self) -> None:
+        """Re-arm the REVEAL task cancelled by the pause (#1371).
+
+        ``pause_game`` cancels whichever REVEAL task was running
+        (``_reveal_auto_advance`` / ``_reveal_idle_halt`` / the title-artist
+        ``_title_artist_vote_window``). ``resume_game`` restores the REVEAL
+        phase but, before this, never rescheduled any of them — so the
+        auto-advance died and an open vote window stayed ``voting_open`` with an
+        elapsed deadline, rendering a 0s window forever and never scoring.
+
+        Using the pause snapshot (``_paused_vote_*`` — the live flags are
+        unreliable, see ``pause_game``):
+
+        * **Vote window was open:** if its deadline still has time left, respawn
+          ``_title_artist_vote_window`` with the *remaining* seconds (restoring
+          ``voting_open`` + a fresh deadline); if it already elapsed during the
+          pause, finalize the window now (resolve near-misses + score).
+        * **No vote window:** re-arm the song-end auto-advance / idle-halt.
+        """
+        from custom_components.beatify.game.round_manager import (  # noqa: PLC0415
+            _log_timer_task_failure,
+        )
+
+        # Consume the snapshot regardless of branch.
+        paused_vote_open = self._paused_vote_open
+        paused_vote_deadline = self._paused_vote_deadline
+        self._paused_vote_open = False
+        self._paused_vote_deadline = None
+
+        if paused_vote_open:
+            remaining = (
+                (paused_vote_deadline - self._now())
+                if paused_vote_deadline is not None
+                else 0.0
+            )
+            if remaining > 0:
+                # Window still has time — re-open it for the remaining seconds.
+                self._title_artist_voting_open = True
+                self._title_artist_vote_deadline = self._now() + remaining
+                self._cancel_auto_advance()
+                self._auto_advance_task = asyncio.create_task(
+                    self._title_artist_vote_window(remaining)
+                )
+                self._auto_advance_task.add_done_callback(_log_timer_task_failure)
+                _LOGGER.info(
+                    "Vote window re-armed with %.1fs remaining after resume",
+                    remaining,
+                )
+            else:
+                # Deadline elapsed during the pause — finalize now (resolve
+                # near-misses + run the deferred scoring pass). _finalize is
+                # guarded by _title_artist_voting_open, so restore it first.
+                self._title_artist_voting_open = True
+                self._title_artist_vote_deadline = paused_vote_deadline
+                _LOGGER.info(
+                    "Vote window deadline elapsed during pause — finalizing on resume"
+                )
+                await self._finalize_title_artist_window()
+            return
+
+        # No vote window was open — re-arm the song-end auto-advance / idle-halt.
+        self._cancel_auto_advance()
+        self._schedule_song_end_auto_advance()
+        _LOGGER.info("REVEAL auto-advance re-armed after resume")

--- a/custom_components/beatify/game/state_setup.py
+++ b/custom_components/beatify/game/state_setup.py
@@ -238,6 +238,9 @@ class GameSetupMixin:
         # REVEAL auto-advance and double-scores a round. Reset them explicitly.
         self._title_artist_voting_open = False
         self._title_artist_vote_deadline = None
+        # #1371: clear the pause snapshot of the vote window too.
+        self._paused_vote_open = False
+        self._paused_vote_deadline = None
 
         # Reset round analytics (Story 13.3)
         self.round_analytics = None

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -1122,6 +1122,72 @@ class TestResumeGame:
         assert self.state.reveal_started_at is None
 
     @pytest.mark.asyncio
+    async def test_resume_to_reveal_rearms_auto_advance(self):
+        """#1371: a pause during REVEAL cancels the auto-advance task; resume
+        must re-arm it, otherwise the game stalls on REVEAL forever (the very
+        admin-disconnect pause unattended mode is meant to survive)."""
+        self.state.phase = GamePhase.REVEAL
+        # A round where someone submitted → auto-advance (not idle-halt).
+        for p in self.state.players.values():
+            p.submitted = True
+        await self.state.pause_game("admin_disconnected")
+        assert self.state._auto_advance_task is None  # pause cancelled it
+        with patch.object(self.state, "_schedule_song_end_auto_advance") as rearm:
+            result = await self.state.resume_game()
+        assert result is True
+        assert self.state.phase == GamePhase.REVEAL
+        rearm.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_resume_to_reveal_rearms_idle_halt_when_no_guesses(self):
+        """#1371: zero-guess REVEAL must re-arm via the same scheduler helper
+        (which picks idle-halt when nobody submitted)."""
+        self.state.phase = GamePhase.REVEAL
+        for p in self.state.players.values():
+            p.submitted = False
+        await self.state.pause_game("admin_disconnected")
+        with patch.object(self.state, "_schedule_song_end_auto_advance") as rearm:
+            await self.state.resume_game()
+        rearm.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_resume_to_playing_does_not_rearm_reveal(self):
+        """#1371 guard: a resume-to-PLAYING must NOT touch the REVEAL re-arm."""
+        with patch.object(self.state, "_schedule_song_end_auto_advance") as rearm:
+            await self.state.pause_game("admin_disconnected")  # from PLAYING
+            await self.state.resume_game()
+        rearm.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_resume_to_reveal_respawns_open_vote_window(self):
+        """#1371: a vote window open at pause with time left is re-opened for
+        the remaining seconds — voting_open True again with a fresh deadline."""
+        self.state.phase = GamePhase.REVEAL
+        self.state._title_artist_voting_open = True
+        self.state._title_artist_vote_deadline = self.state._now() + 20
+        await self.state.pause_game("admin_disconnected")
+        # pause snapshotted the window even though cancel may reset live flags.
+        assert self.state._paused_vote_open is True
+        with patch.object(self.state, "_title_artist_vote_window", new=AsyncMock()):
+            await self.state.resume_game()
+        assert self.state._title_artist_voting_open is True
+        assert self.state._title_artist_vote_deadline is not None
+        # Snapshot consumed.
+        assert self.state._paused_vote_open is False
+
+    @pytest.mark.asyncio
+    async def test_resume_to_reveal_finalizes_elapsed_vote_window(self):
+        """#1371: a vote window whose deadline elapsed during the pause is
+        finalized on resume (no zombie 0s-window) instead of respawned."""
+        self.state.phase = GamePhase.REVEAL
+        self.state._title_artist_voting_open = True
+        self.state._title_artist_vote_deadline = self.state._now() - 5  # elapsed
+        await self.state.pause_game("admin_disconnected")
+        self.state._finalize_title_artist_window = AsyncMock()
+        await self.state.resume_game()
+        self.state._finalize_title_artist_window.assert_awaited_once()
+
+    @pytest.mark.asyncio
     async def test_resume_not_paused(self):
         result = await self.state.resume_game()
         assert result is False


### PR DESCRIPTION
Closes #1371

## Root cause
`pause_game()` unconditionally calls `_cancel_auto_advance()`, killing whichever REVEAL task is running (`_reveal_auto_advance` / `_reveal_idle_halt` / `_title_artist_vote_window`). `resume_game()` only restored timers for `previous == PLAYING` — a resume-to-REVEAL never rescheduled any of these tasks. Result: the #1012 unattended auto-advance silently dies after any pause in REVEAL (the common trigger is an admin phone locking and dropping its WebSocket → `admin_disconnected`), so an "unattended" game stalls on REVEAL forever; and in title/artist mode the vote window stays `voting_open` with a deadline that elapses during the pause, rendering a 0s window indefinitely while the deferred scoring pass never runs.

## Fix
`resume_game()` now calls a new `_rearm_reveal_after_resume()` when `previous == GamePhase.REVEAL`:
- **Vote window open at pause:** respawn `_title_artist_vote_window` for its *remaining* seconds (deadline still valid), or finalize it immediately (resolve near-misses + deferred scoring) if the deadline elapsed during the pause.
- **No vote window:** re-arm the song-end auto-advance / idle-halt.

Because the cancelled vote-window task's `CancelledError` handler async-resets the live `_title_artist_voting_open` / `_title_artist_vote_deadline` flags *before* resume runs, `pause_game()` snapshots them (`_paused_vote_*`) **before** `_cancel_auto_advance()`; resume consumes the snapshot. The song-end re-arm reuses a new `_schedule_song_end_auto_advance()` helper extracted from `_schedule_reveal_advance()` so the round-end and resume paths can't drift.

**Files:** `state_pause.py` (snapshot + re-arm), `state.py` (extracted helper + snapshot fields), `state_setup.py` (snapshot reset in `create_game`), `tests/unit/test_state.py` (6 new tests).

Consistent with the just-merged #1408 (game-end ceremony on exhausted auto-advance) and #1405/#1359 (vote-flag reset): the re-armed `_reveal_auto_advance` still carries the #1408 `advance_to_end` path unchanged, and the snapshot is taken precisely because the #1359 CancelledError reset clears the live flags.

## Readiness assessment
- [x] Ready to merge
- [ ] Borderline — see notes
- [ ] Not ready — needs human review

**Honest summary:** Backend-only task-lifecycle fix, minimal and well-scoped. The trickiest part — the cancellation race that resets the vote-window flags before resume — is handled by snapshotting at pause; covered by a dedicated test. The note: the secondary observation in the issue (a near-miss `_title_artist_vote_window` never scheduling an auto-advance after finalizing, even without a pause) is intentionally NOT addressed here — that is a separate round-end behavior, out of scope for the pause/resume fix.

## Test plan
- Automated: `pytest tests/unit/` (920 passed), `npm run test` (vitest 240 passed), `mypy` (clean), `ruff check`/`ruff format --check` (clean).
- New tests: resume-to-REVEAL re-arms auto-advance; re-arms idle-halt on zero-guess; does NOT re-arm on resume-to-PLAYING; respawns an open vote window; finalizes an elapsed vote window.
- Manual: start a title/artist game, reach REVEAL with near-misses, lock the admin phone (triggers `admin_disconnected` pause), reconnect → vote window should resume with remaining time (or finalize+score if it ran out); year mode → auto-advance should fire after song-end.

## Risk assessment
- **Blast radius:** pause/resume + REVEAL auto-advance scheduling. No frontend, no UI surface, no schema/i18n changes.
- **What could go wrong:** if a future caller invokes `resume_game()` with `previous == REVEAL` but the GameState wasn't actually paused mid-REVEAL, the snapshot defaults (`False`/`None`) make it re-arm a fresh auto-advance — benign. The respawned vote-window's `add_done_callback` mirrors the original spawn path.
- **What I did NOT test:** real WebSocket admin-disconnect→reconnect end-to-end on a live HA instance (only the state-layer unit behavior).

🤖 Auto-generated by issue-triage routine