### PR TITLE
fix: hold HA access token in memory, never in a JS-readable cookie (#1369)

### DIFF
--- a/custom_components/beatify/server/views.py
+++ b/custom_components/beatify/server/views.py
@@ -11,7 +11,6 @@ import asyncio
 import json
 import logging
 import socket
-import time
 from ipaddress import ip_address
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -248,29 +247,23 @@ def _set_session_cookies(
     response: web.Response,
     request: web.Request,
     *,
-    access_token: str,
-    expires_in: int,
     refresh_token: str | None,
 ) -> None:
-    """Write the two-cookie pair onto an outgoing response."""
+    """Set the HttpOnly refresh cookie onto an outgoing response.
+
+    #1369: the HA access token is NEVER written to a cookie. A JS-readable
+    ``beatify_access`` cookie would let any XSS on a /beatify page exfiltrate
+    a token that authorizes the whole HA REST + WebSocket API. The access
+    token is instead returned only in the refresh endpoint's JSON body, where
+    the frontend (ha-auth.js) holds it in a module-scoped variable for the
+    page's lifetime and re-bootstraps it from this HttpOnly refresh cookie on
+    every page load. The callback view sets only the refresh cookie; the
+    frontend's first ``GET /beatify/auth/refresh`` then mints the access token.
+    """
     secure = _is_secure_origin(request)
-    # Render ``expires_at`` as an absolute Unix timestamp (seconds) so the
-    # frontend doesn't have to know when the cookie was actually set.
-    expires_at = int(time.time()) + max(0, int(expires_in) - 30)
-    access_payload = json.dumps(
-        {"access_token": access_token, "expires_at": expires_at}
-    )
-    response.set_cookie(
-        _ACCESS_COOKIE,
-        access_payload,
-        path="/beatify",
-        # Match HA's own token lifetime — when the cookie expires the
-        # frontend re-fetches a fresh access via /beatify/auth/refresh.
-        max_age=max(60, int(expires_in) - 30),
-        samesite="Lax",
-        secure=secure,
-        httponly=False,  # JS reads this to populate Authorization header
-    )
+    # Defensive: wipe any legacy JS-readable access cookie an upgraded client
+    # still carries, so a real HA token can't linger in document.cookie.
+    response.del_cookie(_ACCESS_COOKIE, path="/beatify")
     if refresh_token is not None:
         response.set_cookie(
             _REFRESH_COOKIE,
@@ -388,11 +381,12 @@ class BeatifyAuthCallbackView(HomeAssistantView):
             return self._redirect_to_admin(request, error="exchange_failed")
 
         response = self._redirect_to_admin(request, state=state)
+        # #1369: only the HttpOnly refresh cookie is set here. The frontend
+        # mints its in-memory access token via GET /beatify/auth/refresh on
+        # the post-callback page load.
         _set_session_cookies(
             response,
             request,
-            access_token=parsed["access_token"],
-            expires_in=parsed.get("expires_in", 1800),
             refresh_token=parsed.get("refresh_token"),
         )
         return response
@@ -402,9 +396,10 @@ class BeatifyAuthRefreshView(HomeAssistantView):
     """Silent refresh endpoint — keeps the frontend off ``/auth/token``.
 
     Reads the HttpOnly ``beatify_refresh`` cookie, posts the refresh
-    grant to HA over loopback, updates the access cookie, and returns
-    JSON with the fresh access token so ha-auth.js can populate its
-    in-memory cache. On refresh failure both cookies are wiped — the
+    grant to HA over loopback, and returns JSON with the fresh access
+    token so ha-auth.js can populate its in-memory cache (#1369: the
+    access token is never written to a cookie). On refresh failure both
+    cookies are wiped — the
     frontend then redirects to ``/auth/authorize`` for a full re-login.
     """
 
@@ -441,9 +436,11 @@ class BeatifyAuthRefreshView(HomeAssistantView):
             _clear_session_cookies(response)
             return response
 
-        # HA's refresh-token grant does NOT return a new refresh_token —
-        # it stays the long-lived one already in the HttpOnly cookie.
-        # Reissue ONLY the access cookie.
+        # #1369: the fresh access token is returned ONLY in the JSON body —
+        # the frontend caches it in memory, never in a cookie. HA's
+        # refresh-token grant does NOT return a new refresh_token (the
+        # long-lived one stays in the HttpOnly cookie), so no Set-Cookie is
+        # needed here beyond wiping any legacy JS-readable access cookie.
         response = web.json_response(
             {
                 "access_token": parsed["access_token"],
@@ -454,8 +451,6 @@ class BeatifyAuthRefreshView(HomeAssistantView):
         _set_session_cookies(
             response,
             request,
-            access_token=parsed["access_token"],
-            expires_in=parsed.get("expires_in", 1800),
             # Don't overwrite the long-lived refresh cookie.
             refresh_token=None,
         )

--- a/custom_components/beatify/www/js/__tests__/ha-auth.test.js
+++ b/custom_components/beatify/www/js/__tests__/ha-auth.test.js
@@ -1,15 +1,21 @@
 /**
- * Unit tests for ha-auth.js — rc15 cookie-based session.
+ * Unit tests for ha-auth.js — in-memory access-token session (#1369).
  *
- * rc15 moves the OAuth code exchange and refresh server-side because
+ * rc15 moved the OAuth code exchange and refresh server-side because
  * Safari 18 silently refuses certain same-origin POSTs from the OAuth-
- * callback page state. ha-auth.js now never POSTs to an auth endpoint:
+ * callback page state. ha-auth.js never POSTs to an auth endpoint.
  *
- *   - The access token lives in a JS-readable `beatify_access` cookie
- *     (JSON {access_token, expires_at}) set by BeatifyAuthCallbackView.
+ * #1369 hardening: the HA access token is NO LONGER persisted in a
+ * JS-readable cookie (it authorizes the whole HA API, so any XSS could
+ * exfiltrate it). Instead:
+ *
+ *   - The access token lives ONLY in a module-scoped variable, populated
+ *     from the JSON body of GET /beatify/auth/refresh.
  *   - The refresh token lives in an HttpOnly `beatify_refresh` cookie
- *     that JS can never read; only BeatifyAuthRefreshView reads it.
- *   - Silent refresh is a fetch GET to /beatify/auth/refresh.
+ *     that JS can never read; only BeatifyAuthRefreshView reads it. It is
+ *     the sole persistent credential and the page-load bootstrap source.
+ *   - Silent refresh is a fetch GET to /beatify/auth/refresh that returns
+ *     {access_token, expires_in} in its body (never via Set-Cookie).
  */
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
@@ -153,33 +159,58 @@ function cookieFor(name, payload) {
     return name + '=' + encodeURIComponent(JSON.stringify(payload));
 }
 
-describe('cookie session', () => {
-    it('isAuthenticated() reads access_token + expires_at from beatify_access cookie', () => {
+describe('in-memory session (#1369)', () => {
+    it('never persists the access token in document.cookie', async () => {
+        // The whole point of #1369: even after a successful refresh, the HA
+        // access token must not appear in the JS-readable cookie jar.
+        const { BeatifyAuth, cookieJar } = loadHaAuth({
+            fetchFn: async () => ({
+                ok: true,
+                status: 200,
+                json: async () => ({ access_token: 'in-mem', expires_in: 1800 }),
+            }),
+        });
+        const token = await BeatifyAuth.getAccessToken();
+        expect(token).toBe('in-mem');
+        expect(cookieJar.value).not.toContain('beatify_access');
+    });
+
+    it('isAuthenticated() is false before any refresh (no cookie carries the token)', () => {
+        // A seeded JS-readable access cookie must NOT authenticate — the token
+        // only ever comes from the HttpOnly-refresh bootstrap now.
         const farFuture = Math.floor(Date.now() / 1000) + 3600;
         const { BeatifyAuth } = loadHaAuth({
             cookie: cookieFor('beatify_access', { access_token: 'abc', expires_at: farFuture }),
         });
-        expect(BeatifyAuth.isAuthenticated()).toBe(true);
-    });
-
-    it('isAuthenticated() returns false when expires_at is in the past', () => {
-        const farPast = Math.floor(Date.now() / 1000) - 60;
-        const { BeatifyAuth } = loadHaAuth({
-            cookie: cookieFor('beatify_access', { access_token: 'abc', expires_at: farPast }),
-        });
         expect(BeatifyAuth.isAuthenticated()).toBe(false);
     });
 
-    it('getAccessToken() returns the cookied token without hitting the network', async () => {
-        const farFuture = Math.floor(Date.now() / 1000) + 3600;
+    it('isAuthenticated() is true once a fresh token is held in memory', async () => {
+        const { BeatifyAuth } = loadHaAuth({
+            fetchFn: async () => ({
+                ok: true,
+                status: 200,
+                json: async () => ({ access_token: 'abc', expires_in: 1800 }),
+            }),
+        });
+        await BeatifyAuth.getAccessToken();
+        expect(BeatifyAuth.isAuthenticated()).toBe(true);
+    });
+
+    it('getAccessToken() reuses the in-memory token without a second fetch', async () => {
         const fetchCalls = [];
         const { BeatifyAuth } = loadHaAuth({
-            cookie: cookieFor('beatify_access', { access_token: 'cached', expires_at: farFuture }),
-            fetchFn: async (...args) => { fetchCalls.push(args); throw new Error('should not fetch'); },
+            fetchFn: async (...args) => {
+                fetchCalls.push(args);
+                return { ok: true, status: 200, json: async () => ({ access_token: 'cached', expires_in: 1800 }) };
+            },
         });
-        const token = await BeatifyAuth.getAccessToken();
-        expect(token).toBe('cached');
-        expect(fetchCalls).toHaveLength(0);
+        const first = await BeatifyAuth.getAccessToken();
+        const second = await BeatifyAuth.getAccessToken();
+        expect(first).toBe('cached');
+        expect(second).toBe('cached');
+        // First call bootstraps via refresh; the second reuses memory.
+        expect(fetchCalls).toHaveLength(1);
     });
 
     it('clears legacy localStorage keys on init (migration from rc11–rc14)', async () => {
@@ -274,10 +305,16 @@ describe('init() auth callback handling', () => {
         expect(cookieJar.value).not.toContain('beatify_access=');
     });
 
-    it('on ?auth_state= matching sessionStorage trusts the freshly-set cookie', async () => {
-        const farFuture = Math.floor(Date.now() / 1000) + 3600;
+    it('on ?auth_state= matching sessionStorage bootstraps the token via refresh (#1369)', async () => {
+        // After the server-side callback, only the HttpOnly refresh cookie is
+        // set — no JS-readable access cookie. init() validates the state echo
+        // then GETs /beatify/auth/refresh to mint the in-memory access token.
+        const fetchCalls = [];
         const { BeatifyAuth, sandboxWindow } = loadHaAuth({
-            cookie: cookieFor('beatify_access', { access_token: 'freshly-set', expires_at: farFuture }),
+            fetchFn: async (url) => {
+                fetchCalls.push(url);
+                return { ok: true, status: 200, json: async () => ({ access_token: 'freshly-set', expires_in: 1800 }) };
+            },
         });
         // Frontend stored this state before redirecting to /auth/authorize.
         sandboxWindow.sessionStorage.setItem('beatify_ha_oauth_state', 'state-abc');
@@ -285,6 +322,7 @@ describe('init() auth callback handling', () => {
 
         const ok = await BeatifyAuth.init({ requireAuth: true });
         expect(ok).toBe(true);
+        expect(fetchCalls[0]).toBe('https://ha.example/beatify/auth/refresh');
         expect(await BeatifyAuth.getAccessToken()).toBe('freshly-set');
     });
 
@@ -368,9 +406,16 @@ describe('bounded login loop on persistent OAuth failure (#1394)', () => {
     });
 
     it('resets the counter after a successful callback so later sessions get a fresh budget', async () => {
-        const farFuture = Math.floor(Date.now() / 1000) + 3600;
+        // #1369: a successful callback no longer carries a JS-readable access
+        // cookie — init() validates the state echo, then GETs
+        // /beatify/auth/refresh to mint the in-memory access token. The
+        // bounded-loop counter (#1394) is cleared on that success path.
         const ctx = loadHaAuth({
-            cookie: cookieFor('beatify_access', { access_token: 'freshly-set', expires_at: farFuture }),
+            fetchFn: async () => ({
+                ok: true,
+                status: 200,
+                json: async () => ({ access_token: 'freshly-set', expires_in: 1800 }),
+            }),
             sessionStorageData: { [K]: '2' }, // two prior failures
             withDomBody: true,
         });
@@ -482,8 +527,9 @@ describe('Android Companion auth bridge (#1114, #1120 — rc5)', () => {
         bridge.window = sandboxWindow;
         const token = await BeatifyAuth.getAccessToken();
         expect(token).toBe('v2-token');
-        // The cookie was planted by _setSessionCookieFromCompanion.
-        expect(cookieJar.value).toContain('beatify_access=');
+        // #1369: the Companion token is held in memory, never in a cookie.
+        expect(cookieJar.value).not.toContain('beatify_access');
+        expect(BeatifyAuth.isAuthenticated()).toBe(true);
         // V2 message shape: {id, type: "getExternalAuth", payload: {callback, force}}
         expect(bridge.calls).toHaveLength(1);
         expect(bridge.calls[0].type).toBe('getExternalAuth');
@@ -503,7 +549,9 @@ describe('Android Companion auth bridge (#1114, #1120 — rc5)', () => {
         bridge.window = sandboxWindow;
         const token = await BeatifyAuth.getAccessToken();
         expect(token).toBe('v1-token');
-        expect(cookieJar.value).toContain('beatify_access=');
+        // #1369: in-memory, not cookie-persisted.
+        expect(cookieJar.value).not.toContain('beatify_access');
+        expect(BeatifyAuth.isAuthenticated()).toBe(true);
         // V1 message shape: {callback, force}. The callback MUST be the
         // fixed string "externalAuthSetToken" — Companion ≥ 2026.4.4 silently
         // rejects any other name (security fix GHSA-7jp2-p2fw-mgvf).

--- a/custom_components/beatify/www/js/ha-auth.js
+++ b/custom_components/beatify/www/js/ha-auth.js
@@ -17,12 +17,18 @@
  *     /beatify/auth/callback. The Beatify server (BeatifyAuthCallbackView)
  *     receives the code, exchanges it over loopback HTTP, and sets two
  *     cookies before redirecting back to /beatify/admin.
- *   - beatify_access cookie: JS-readable JSON {access_token, expires_at}.
- *     This module reads it on page load and includes the token in
- *     Authorization headers for /beatify/api/* calls.
+ *   - The access token is NEVER persisted in a JS-readable cookie (#1369).
+ *     It lives only in a module-scoped variable for the lifetime of the
+ *     page. On page load this module bootstraps it from the HttpOnly
+ *     refresh cookie via GET /beatify/auth/refresh — the same cold-start
+ *     path used whenever the in-memory token has expired. Keeping the HA
+ *     access token out of document.cookie means an XSS on any /beatify
+ *     page can no longer exfiltrate a token that authorizes the whole HA
+ *     REST + WebSocket API.
  *   - beatify_refresh cookie: HttpOnly. Never exposed to JS. The refresh
  *     view (BeatifyAuthRefreshView) reads it server-side when this module
- *     does fetch GET /beatify/auth/refresh.
+ *     does fetch GET /beatify/auth/refresh, which returns the fresh access
+ *     token in its JSON body (never via Set-Cookie).
  *
  * Normal players never touch this module — joining /beatify/play stays
  * frictionless. It is only invoked on the admin page (on load) and on the
@@ -48,10 +54,15 @@
     } catch (e) { /* ignore */ }
   }
 
-  // JS-readable session cookie set by BeatifyAuthCallbackView. Contains a
-  // URL-encoded JSON object: {access_token: string, expires_at: number}.
-  // expires_at is an absolute Unix timestamp (seconds) so we don't depend
-  // on the client clock matching the server when the cookie was set.
+  // In-memory access-token session (#1369). The HA access token is held
+  // ONLY here — never in document.cookie — so an XSS cannot read it. Shape:
+  // {access_token: string, expires_at: number} where expires_at is an
+  // absolute Unix timestamp (seconds). null when no token is cached.
+  var _session = null;
+
+  // Legacy JS-readable cookie name (pre-#1369). The server no longer sets
+  // it; we proactively wipe any leftover copy from an upgraded session so a
+  // real access token can't linger in document.cookie past this deploy.
   var ACCESS_COOKIE = 'beatify_access';
 
   // sessionStorage: CSRF state lives only for the duration of one redirect.
@@ -108,32 +119,24 @@
       .join('');
   }
 
-  // -- cookie session ------------------------------------------------------
+  // -- in-memory session ---------------------------------------------------
 
-  function _readSessionCookie() {
-    try {
-      var raw = document.cookie || '';
-      var prefix = ACCESS_COOKIE + '=';
-      var parts = raw.split(';');
-      for (var i = 0; i < parts.length; i++) {
-        var p = parts[i].replace(/^\s+/, '');
-        if (p.indexOf(prefix) === 0) {
-          var value = p.substring(prefix.length);
-          var data = JSON.parse(decodeURIComponent(value));
-          if (data && data.access_token && data.expires_at) return data;
-          return null;
-        }
-      }
-      return null;
-    } catch (e) {
-      return null;
-    }
+  // Store a fresh access token in the module-scoped session (#1369).
+  // expiresIn is the HA token TTL in seconds; we shave 30s so we refresh
+  // slightly ahead of the server-side expiry.
+  function _setSession(accessToken, expiresIn) {
+    var ttl =
+      typeof expiresIn === 'number' && expiresIn > 0 ? expiresIn : 1800;
+    _session = {
+      access_token: accessToken,
+      expires_at: Math.floor(Date.now() / 1000) + Math.max(0, ttl - 30),
+    };
   }
 
-  function _clearAccessCookie() {
-    // The HttpOnly refresh cookie can only be cleared server-side (the
-    // refresh view does this when refresh fails). The access cookie is
-    // JS-readable, so we can wipe it here on logout / state mismatch.
+  function _wipeLegacyAccessCookie() {
+    // Defensive: the access token is no longer cookie-persisted, but an
+    // upgraded browser may still carry the old JS-readable beatify_access
+    // cookie. Wipe it so a real HA token can't linger in document.cookie.
     try {
       document.cookie =
         ACCESS_COOKIE +
@@ -142,6 +145,13 @@
     } catch (e) {
       /* ignore */
     }
+  }
+
+  function _clearSession() {
+    // Drop the in-memory token; the HttpOnly refresh cookie can only be
+    // cleared server-side (the refresh view does this when refresh fails).
+    _session = null;
+    _wipeLegacyAccessCookie();
   }
 
   function _migrateFromLocalStorage() {
@@ -157,15 +167,13 @@
   }
 
   function storedAccess() {
-    var data = _readSessionCookie();
-    return data ? data.access_token : null;
+    return _session ? _session.access_token : null;
   }
 
   function accessFresh() {
-    var data = _readSessionCookie();
-    if (!data) return false;
-    // expires_at from the server is Unix seconds; Date.now() is millis.
-    return data.expires_at * 1000 > Date.now();
+    if (!_session) return false;
+    // expires_at is Unix seconds; Date.now() is millis.
+    return _session.expires_at * 1000 > Date.now();
   }
 
   // -- Android Companion App auth bridge (#1114, #1120 — rc5) --------------
@@ -404,17 +412,16 @@
     return entry.promise;
   }
 
-  // Persist a Companion-supplied token in the JS-readable session cookie so
-  // the rest of the module (accessFresh / storedAccess / authedFetch) keeps
-  // working without further branching. The HttpOnly refresh cookie isn't
-  // needed on Companion — we just call getExternalAuth(force=true) again
-  // when the access token expires.
-  function _setSessionCookieFromCompanion(payload) {
+  // Stash a Companion-supplied token in the in-memory session (#1369) so the
+  // rest of the module (accessFresh / storedAccess / authedFetch) keeps
+  // working without further branching. The token is never written to a
+  // cookie. The HttpOnly refresh cookie isn't needed on Companion — we just
+  // call getExternalAuth(force=true) again when the access token expires.
+  function _setSessionFromCompanion(payload) {
     var expiresIn =
       typeof payload.expires_in === 'number' && payload.expires_in > 0
         ? payload.expires_in
         : 1800;
-    var expiresAt = Math.floor(Date.now() / 1000) + expiresIn;
     // rc6 (#1120 diagnostics): log token characteristics on each bridge
     // response. If `force: true` is honoured by Companion, the prefix
     // should change between successive calls; if it's the same prefix
@@ -431,20 +438,7 @@
         ', expires_in=' + expiresIn + ')'
       );
     } catch (e) { /* ignore */ }
-    var cookieValue = encodeURIComponent(
-      JSON.stringify({
-        access_token: payload.access_token,
-        expires_at: expiresAt,
-      })
-    );
-    var cookieStr =
-      ACCESS_COOKIE +
-      '=' +
-      cookieValue +
-      '; Path=/beatify; SameSite=Lax; Max-Age=' +
-      expiresIn;
-    if (location.protocol === 'https:') cookieStr += '; Secure';
-    try { document.cookie = cookieStr; } catch (e) { /* ignore */ }
+    _setSession(payload.access_token, expiresIn);
   }
 
   // -- silent refresh via /beatify/auth/refresh ----------------------------
@@ -461,7 +455,7 @@
       // the Companion in-app token bridge instead.
       refreshInFlight = getCompanionAuthToken(true)
         .then(function (payload) {
-          _setSessionCookieFromCompanion(payload);
+          _setSessionFromCompanion(payload);
           return payload.access_token;
         })
         .catch(function (err) {
@@ -491,7 +485,15 @@
           return null;
         }
         return resp.json().then(function (body) {
-          return (body && body.access_token) || null;
+          var token = (body && body.access_token) || null;
+          if (token) {
+            // #1369: the refresh JSON body is now the sole carrier of the
+            // access token (no Set-Cookie). Cache it in memory so
+            // accessFresh() / storedAccess() / authedFetch() can reuse it
+            // without another round-trip.
+            _setSession(token, body && body.expires_in);
+          }
+          return token;
         });
       })
       .catch(function (err) {
@@ -634,7 +636,7 @@
       // intercepts and 403s.
       getCompanionAuthToken(true)
         .then(function (payload) {
-          _setSessionCookieFromCompanion(payload);
+          _setSessionFromCompanion(payload);
           window.location.href = origin() + '/beatify/admin';
         })
         .catch(function (err) {
@@ -671,7 +673,7 @@
         '[BeatifyAuth] server-side OAuth exchange returned error:',
         authError
       );
-      _clearAccessCookie();
+      _clearSession();
       _stripQuery();
       return false;
     }
@@ -686,7 +688,7 @@
     _stripQuery();
     if (expected && authState !== expected) {
       console.warn('[BeatifyAuth] OAuth state mismatch — clearing session');
-      _clearAccessCookie();
+      _clearSession();
       return false;
     }
     // Successful callback — reset the bounded login-loop counter (#1394).
@@ -787,7 +789,7 @@
       );
       return Promise.resolve(null);
     }
-    _clearAccessCookie();
+    _clearSession();
     return refreshAccess().then(function (token) {
       if (token) return token;
       login();
@@ -910,7 +912,7 @@
   window.BeatifyAuth = {
     init: init,
     login: login,
-    logout: _clearAccessCookie,
+    logout: _clearSession,
     isAuthenticated: isAuthenticated,
     getAccessToken: getAccessToken,
     ensureAuthenticated: ensureAuthenticated,

--- a/tests/unit/test_auth_callback_view.py
+++ b/tests/unit/test_auth_callback_view.py
@@ -1,9 +1,11 @@
 """Tests for BeatifyAuthCallbackView — server-side OAuth code exchange (rc15).
 
 The browser arrives here via /auth/authorize's redirect carrying ?code= and
-?state=. The view exchanges the code over loopback HTTP and sets the
-beatify_access (JS-readable JSON) + beatify_refresh (HttpOnly) cookies
-before redirecting to /beatify/admin with state echoed for CSRF validation.
+?state=. The view exchanges the code over loopback HTTP and sets ONLY the
+HttpOnly beatify_refresh cookie before redirecting to /beatify/admin with
+state echoed for CSRF validation. Per #1369 the HA access token is never
+written to a JS-readable cookie — the frontend mints it in memory from
+GET /beatify/auth/refresh on the post-callback page load.
 """
 
 from __future__ import annotations
@@ -95,7 +97,10 @@ class TestBeatifyAuthCallbackView:
         assert "client_id=http%3A%2F%2Fha.local%3A8123%2Fbeatify%2F" in call_body
 
     @pytest.mark.asyncio
-    async def test_successful_exchange_sets_cookies_and_redirects(self):
+    async def test_successful_exchange_sets_refresh_cookie_only(self):
+        # #1369: the access token must NOT be persisted in a JS-readable
+        # cookie. Only the HttpOnly refresh cookie is set; the access token
+        # never appears in a live Set-Cookie value.
         view = BeatifyAuthCallbackView(_hass())
         mock_session = MagicMock()
         mock_session.post = MagicMock(
@@ -122,25 +127,20 @@ class TestBeatifyAuthCallbackView:
         # auth_error must NOT be present on success.
         assert "auth_error" not in location
 
-        # Verify both cookies were set. aiohttp Response.cookies is a
-        # SimpleCookie-like mapping.
-        assert "beatify_access" in resp.cookies
+        # The HttpOnly refresh cookie is the sole persistent credential.
         assert "beatify_refresh" in resp.cookies
-
-        access_morsel = resp.cookies["beatify_access"]
-        # JS reads this — must NOT be HttpOnly.
-        assert access_morsel["httponly"] in (False, "")
-        # Scoped to /beatify to avoid leaking to the wider HA app.
-        assert access_morsel["path"] == "/beatify"
-        # The cookie body is the URL-encoded JSON. aiohttp leaves the
-        # raw value alone, so we can just check for the access token.
-        assert "new-access" in access_morsel.value
-
         refresh_morsel = resp.cookies["beatify_refresh"]
-        # Refresh token MUST be HttpOnly — JS must never see it.
         assert refresh_morsel["httponly"] is True
         assert refresh_morsel["path"] == "/beatify"
         assert refresh_morsel.value == "new-refresh"
+
+        # The access token must never ride out in a live access cookie.
+        # del_cookie emits a beatify_access morsel, but it MUST be an
+        # expiry (max-age=0 / empty value), not a real token.
+        access_morsel = resp.cookies.get("beatify_access")
+        if access_morsel is not None:
+            assert "new-access" not in access_morsel.value
+            assert str(access_morsel["max-age"]) == "0"
 
     @pytest.mark.asyncio
     async def test_ha_rejection_redirects_with_exchange_error(self):
@@ -210,7 +210,8 @@ class TestBeatifyAuthCallbackView:
         ):
             resp = await view.get(forwarded_request)
 
-        assert resp.cookies["beatify_access"]["secure"] is True
+        # #1369: only the refresh cookie is set; its Secure flag must follow
+        # what the browser saw (HTTPS via X-Forwarded-Proto).
         assert resp.cookies["beatify_refresh"]["secure"] is True
 
         # And client_id / redirect_uri in the exchange body must use the

--- a/tests/unit/test_auth_refresh_view.py
+++ b/tests/unit/test_auth_refresh_view.py
@@ -1,9 +1,11 @@
 """Tests for BeatifyAuthRefreshView — silent server-side refresh (rc15).
 
-The frontend calls ``GET /beatify/auth/refresh`` when its access cookie is
-about to expire. The view reads the HttpOnly ``beatify_refresh`` cookie,
-posts the refresh grant to HA over loopback, updates the access cookie,
-and returns JSON so ha-auth.js can immediately use the new token.
+The frontend calls ``GET /beatify/auth/refresh`` when its in-memory access
+token is about to expire (and once on every page load to bootstrap it). The
+view reads the HttpOnly ``beatify_refresh`` cookie, posts the refresh grant
+to HA over loopback, and returns the fresh access token in the JSON body so
+ha-auth.js can hold it in memory. Per #1369 the access token is never put
+back into a JS-readable cookie.
 """
 
 from __future__ import annotations
@@ -92,18 +94,23 @@ class TestBeatifyAuthRefreshView:
 
         assert resp.status == 200
         body = json.loads(resp.body)
+        # #1369: the JSON body is the SOLE carrier of the access token —
+        # the frontend caches it in memory, never in a cookie.
         assert body["access_token"] == "refreshed-access"
         assert body["expires_in"] == 1800
         # Browser caches MUST NOT keep an auth response around.
         assert resp.headers.get("Cache-Control") == "no-store"
 
-        # Access cookie reissued.
-        access = resp.cookies["beatify_access"]
-        assert "refreshed-access" in access.value
-        assert access["path"] == "/beatify"
-        # Crucially, the refresh cookie is NOT touched — HA's refresh
-        # grant doesn't return a new refresh_token, so we leave the
-        # existing long-lived one in place.
+        # The access token must NOT be reissued in a live JS-readable cookie.
+        # del_cookie may emit a beatify_access morsel, but it must be an
+        # expiry (max-age=0), never a token-bearing value.
+        access = resp.cookies.get("beatify_access")
+        if access is not None:
+            assert "refreshed-access" not in access.value
+            assert str(access["max-age"]) == "0"
+        # The refresh cookie is NOT touched — HA's refresh grant doesn't
+        # return a new refresh_token, so we leave the existing long-lived
+        # one in place.
         assert "beatify_refresh" not in resp.cookies
 
     @pytest.mark.asyncio


### PR DESCRIPTION
Closes #1369

## Root cause
The HA access token was persisted in the non-HttpOnly `beatify_access` cookie (`{access_token, expires_at}`), readable via `document.cookie`. That token authorizes the **entire HA REST + WebSocket API** as the (admin) user, so any XSS on any `/beatify` page could exfiltrate it — blast radius far beyond Beatify. The refresh token was already HttpOnly; the access token never needed cookie persistence (it is only ever attached as an `Authorization` header by `ha-auth.js`).

## Fix
- **`www/js/ha-auth.js`**: the access token is now held only in a module-scoped `_session` variable. It is populated from the JSON body of `GET /beatify/auth/refresh` — the cold-start path that already ran whenever the access cookie had expired, now the *only* path (one extra round-trip per page load). Companion-bridge tokens go to the same in-memory store. `logout()`/state-mismatch clears memory and defensively wipes any legacy `beatify_access` cookie.
- **`server/views.py`**: `_set_session_cookies` no longer sets a JS-readable access cookie — it sets only the HttpOnly refresh cookie and `del_cookie`s any legacy access cookie. The refresh endpoint still returns `{access_token, expires_in}` in its JSON body (now the sole carrier).

No change to the login/auth flow the user experiences — the post-callback redirect just mints the in-memory token via the refresh endpoint instead of reading it from a cookie.

## Readiness assessment
- [x] Ready to merge
- [ ] Borderline — see notes
- [ ] Not ready — needs human review

**Honest summary:** Contained, well-scoped change exactly matching the reporter's recommended approach. Both gates green. The refresh endpoint already returned the token in its body, so this is a small re-wiring of where the token is held, not a flow change. Companion (in-memory token), web (refresh-bootstrap), and bypass-mode paths all keep working — covered by updated unit tests.

## Test plan
- Automated: `pytest` (915 passed, 2 skipped) — incl. updated `test_auth_callback_view.py` / `test_auth_refresh_view.py` asserting the access token never rides in a live cookie. `vitest run` (241 passed) — incl. 24 ha-auth tests rewritten for in-memory session + a guard that `document.cookie` never contains `beatify_access`.
- `npm run build:check`: no bundle drift (ha-auth.js is served raw, not minified).
- Manual (recommended before un-drafting): log in via OAuth on web (LAN HTTP + Nabu Casa HTTPS), confirm admin loads and `document.cookie` shows only `beatify_refresh`; let the access token expire and confirm silent refresh still works; verify Android Companion host-claim still authenticates.

## Risk assessment
- **Blast radius:** `ha-auth.js`, `server/views.py`, and their two unit-test files. Touches the auth token path (security-critical) but not the OAuth redirect flow.
- **What could go wrong:** every page load now requires one `GET /beatify/auth/refresh` before the first authed call (previously skipped when the access cookie was still fresh) — a minor extra round-trip, already the documented cold-start path. If the refresh endpoint were unreachable on first load the page would fall to `login()` (same as a missing cookie today).
- **What I did NOT test:** live browser OAuth round-trip, live Android/iOS Companion, live Nabu Casa remote — all stubbed in unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)