### PR TITLE
fix: preserve earned movie-quiz bonus when TA guess is skipped (#1376)

### DIFF
--- a/custom_components/beatify/game/scoring.py
+++ b/custom_components/beatify/game/scoring.py
@@ -759,7 +759,14 @@ class ScoringService:
                 player.streak_bonus = 0
                 player.bet_outcome = None
                 player.artist_bonus = 0
-                player.movie_bonus = 0
+                # #1376: the movie quiz is an independent guess that stacks on
+                # top of the year/title-artist score. A player who skipped the
+                # title/artist guess but answered the movie quiz correctly must
+                # still earn its points and the movie_bonus_total increment
+                # (Film Buff superlative) — mirroring the year-mode missed
+                # branch below. Previously this was hard-zeroed, silently
+                # dropping the earned bonus.
+                _score_movie_challenge(player, movie_challenge, add_to_score=True)
                 player.intro_bonus = 0
                 player.rounds_played += 1
                 player.round_scores.append(0)

--- a/tests/unit/test_scoring.py
+++ b/tests/unit/test_scoring.py
@@ -370,7 +370,17 @@ class _FakeTitleArtistManager:
         return self._title_status.get(player_name, "skipped")
 
 
-def _score_title_artist(player, manager):
+class _FakeMovieChallenge:
+    """Minimal stand-in exposing the get_player_bonus surface."""
+
+    def __init__(self, bonus_by_player):
+        self._bonus = bonus_by_player
+
+    def get_player_bonus(self, player_name):
+        return self._bonus.get(player_name, 0)
+
+
+def _score_title_artist(player, manager, movie_challenge=None):
     """Invoke score_player_round in title/artist mode with sane defaults."""
     ScoringService.score_player_round(
         player,
@@ -379,7 +389,7 @@ def _score_title_artist(player, manager):
         round_duration=30.0,
         difficulty="normal",
         artist_challenge=None,
-        movie_challenge=None,
+        movie_challenge=movie_challenge,
         is_intro_round=False,
         intro_round_start_time=None,
         all_players=[player],
@@ -463,6 +473,43 @@ class TestTitleArtistScoring:
         assert p.missed_round is True
         assert p.streak == 0
         assert p.round_scores == [0]
+
+    def test_not_submitted_no_movie_challenge_keeps_zero_bonus(self):
+        # Regression guard: when there is no movie challenge, a skipped TA
+        # guess must still record a zero movie bonus.
+        mgr = _FakeTitleArtistManager({}, {})
+        p = self._player()
+        p.submitted = False
+        _score_title_artist(p, mgr, movie_challenge=None)
+        assert p.movie_bonus == 0
+        assert p.movie_bonus_total == 0
+        assert p.score == 0
+
+    def test_not_submitted_preserves_earned_movie_bonus(self):
+        # #1376: skipping the title/artist guess must NOT forfeit a correctly
+        # earned movie-quiz bonus — it stacks independently of the TA score.
+        mgr = _FakeTitleArtistManager({}, {})
+        movie = _FakeMovieChallenge({"Alice": 30})
+        p = self._player()
+        p.submitted = False
+        _score_title_artist(p, mgr, movie_challenge=movie)
+        assert p.round_score == 0  # TA guess still missed
+        assert p.missed_round is True
+        assert p.movie_bonus == 30  # earned bonus surfaced
+        assert p.score == 30  # and added to the score
+        assert p.movie_bonus_total == 30  # Film Buff superlative credited
+
+    def test_not_submitted_no_movie_win_keeps_score_zero(self):
+        # A skipped TA guess with a movie challenge present but no win for this
+        # player leaves the score and totals untouched.
+        mgr = _FakeTitleArtistManager({}, {})
+        movie = _FakeMovieChallenge({"Bob": 30})  # Alice did not win
+        p = self._player()
+        p.submitted = False
+        _score_title_artist(p, mgr, movie_challenge=movie)
+        assert p.movie_bonus == 0
+        assert p.movie_bonus_total == 0
+        assert p.score == 0
 
 
 class TestTitleArtistSuperlativeCounters:


### PR DESCRIPTION
Closes #1376

## Root cause
In Title & Artist mode, the not-submitted branch of `score_player_round` (`game/scoring.py`) hard-set `player.movie_bonus = 0` instead of scoring the movie challenge. A player who skipped the title/artist guess but answered the movie quiz correctly therefore lost both the movie points and the `movie_bonus_total` increment that drives the Film Buff superlative — even though the reveal still occupied a speed-rank slot and displayed a bonus that was never added to their score. The year-mode missed branch already does the right thing via `_score_movie_challenge(player, movie_challenge, add_to_score=True)`.

## Fix
Replace `player.movie_bonus = 0` in the TA not-submitted branch with `_score_movie_challenge(player, movie_challenge, add_to_score=True)`, mirroring the year-mode missed branch. The movie quiz is an independent guess that stacks on top of the (here zero) TA round score.

## Readiness assessment
- [x] Ready to merge
- [ ] Borderline — see notes
- [ ] Not ready — needs human review

**Honest summary:** Minimal, surgical one-line behavioural change that brings the TA missed branch in line with the already-correct year-mode missed branch. Backed by new unit tests. Backend game-logic only, no UI surface.

## Test plan
- New `tests/unit/test_scoring.py` cases:
  - `test_not_submitted_preserves_earned_movie_bonus` — skipped TA guess + correct movie quiz: `movie_bonus == 30`, `score == 30`, `movie_bonus_total == 30`, round still missed.
  - `test_not_submitted_no_movie_win_keeps_score_zero` — movie challenge present but no win for this player: score/totals stay 0.
  - `test_not_submitted_no_movie_challenge_keeps_zero_bonus` — regression guard for the no-challenge path.
- Full suite: 932 passed, 2 skipped.
- `ruff check .` clean, `ruff format --check .` clean, `mypy` (scoped CI run) green.

## Risk assessment
- **Blast radius:** single branch in `game/scoring.py` (TA mode, player did not submit) + test additions.
- **What could go wrong:** if a movie bonus were ever expected to be suppressed specifically for non-submitters in TA mode, this would change that — but the year-mode path proves the intended design is to always credit the independent movie guess.
- **What I did NOT test:** live end-to-end game / reveal rendering; relied on unit-level scoring assertions.

🤖 Auto-generated by issue-triage routine