### PR TITLE
fix: rematch_game total_rounds from filtered PlaylistManager count (#1377)

### DIFF
--- a/custom_components/beatify/game/state_setup.py
+++ b/custom_components/beatify/game/state_setup.py
@@ -386,7 +386,13 @@ class GameSetupMixin:
             preserved["provider"],
             storefront=self.storefront,
         )
-        self.total_rounds = len(preserved["songs"])
+        # #1377: derive total_rounds from the filtered/deduped playable pool
+        # (exactly like create_game, state_setup.py), not the raw song list.
+        # Using len(preserved["songs"]) inflated total_rounds whenever the
+        # PlaylistManager dropped songs (no provider URI, duplicate URI, or
+        # storefront-unavailable), breaking 'Round X of Y' and the last-round
+        # TTS gate.
+        self.total_rounds = self._playlist_manager.get_total_count()
 
         self._set_phase(GamePhase.LOBBY)
         # #1358: a rematch replaces the game identity — invalidate any

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -992,6 +992,38 @@ class TestRematchGame:
         assert len(self.state.songs) > 0
         assert self.state.total_rounds > 0
 
+    def test_rematch_total_rounds_uses_filtered_count(self):
+        """#1377: total_rounds after rematch must come from the filtered/deduped
+        PlaylistManager pool (like create_game), NOT len(raw songs).
+
+        Two songs share a URI, so PlaylistManager dedupes one away: the raw
+        list has 2 entries but the playable pool has 1. total_rounds must be 1.
+        """
+        songs = [
+            {
+                "year": 2000,
+                "uri": "spotify:track:dup",
+                "_resolved_uri": "spotify:track:dup",
+                "title": "First",
+                "artist": "A",
+            },
+            {
+                "year": 2001,
+                "uri": "spotify:track:dup",  # duplicate URI → deduped out
+                "_resolved_uri": "spotify:track:dup",
+                "title": "Second",
+                "artist": "B",
+            },
+        ]
+        _create_fresh_game(self.state, songs=songs)
+        # create_game already derives the filtered count; sanity-check it.
+        assert self.state.total_rounds == 1
+        self.state.phase = GamePhase.END
+        self.state.rematch_game()
+        # rematch must match create_game, not len(preserved["songs"]) == 2.
+        assert self.state.total_rounds == self.state._playlist_manager.get_total_count()
+        assert self.state.total_rounds == 1
+
 
 # ---------------------------------------------------------------------------
 # GameState.pause_game / resume_game


### PR DESCRIPTION
Closes #1377

## Readiness assessment
- [x] Ready to merge
- [ ] Borderline — see notes
- [ ] Not ready — needs human review

**Honest summary:** One-line behavioral fix in `rematch_game`: `total_rounds` now comes from `self._playlist_manager.get_total_count()` (the filtered/deduped playable pool) instead of `len(preserved["songs"])` (the raw list) — exactly mirroring `create_game`. Backend-only, no UI/asset surface. Full suite green (930 passed), ruff + mypy clean.

## Root cause
`create_game` sets `total_rounds = self._playlist_manager.get_total_count()` (filtered: drops no-URI songs, dedupes by URI, removes storefront-unavailable). `rematch_game` instead used `len(preserved["songs"])` (raw). After a rematch on any playlist where filtering removed songs, `total_rounds` was inflated → wrong "Round X of Y" broadcast, and the last-round TTS gate `round >= total_rounds` could never fire (game ends on song exhaustion first).

## Test plan
- New regression test `test_rematch_total_rounds_uses_filtered_count`: playlist with two songs sharing a URI (2 raw → 1 playable). Asserts `create_game` yields `total_rounds == 1`, and after `rematch_game` that `total_rounds == get_total_count() == 1` (not 2). Verified the test fails on the pre-fix line and passes after.
- Full suite: `python3 -m pytest` → 930 passed, 2 skipped.
- `ruff check` + `ruff format --check` (0.15.7) clean; `mypy` (1.18.2) → no issues.

## Risk assessment
- **Blast radius:** `custom_components/beatify/game/state_setup.py` (`rematch_game`, 1 line + comment) and one new test.
- **What could go wrong:** Negligible. Same expression already proven in `create_game`. `total_rounds` now reflects the actual playable pool — anything keying off the old inflated value would have been relying on a bug.
- **What I did NOT test:** Live end-to-end rematch on a real Apple Music storefront-filtered playlist (covered logically by the dedup-path test, which exercises the same `get_total_count()` source).

🤖 Auto-generated by issue-triage routine