### PR TITLE
fix: roll back streak side-effects when closest-wins voids a round (#1375)

### DIFF
--- a/custom_components/beatify/game/scoring.py
+++ b/custom_components/beatify/game/scoring.py
@@ -561,6 +561,7 @@ class ScoringService:
     def apply_closest_wins(
         players: list[PlayerSession],
         correct_year: int,
+        streak_achievements: dict[str, int] | None = None,
     ) -> None:
         """Zero out round_score for players who are not closest to the correct year.
 
@@ -571,6 +572,12 @@ class ScoringService:
         Must be called *after* score_player_round has run for every player, and
         *before* the round scores are appended to cumulative totals (they are
         already added in score_player_round, so we need to undo the difference).
+
+        ``streak_achievements`` is the same shared milestone-counter dict passed
+        to score_player_round. It is needed to roll back a milestone increment
+        for a streak round that closest-wins voids (#1375). When omitted the
+        milestone counter cannot be decremented (callers that don't track
+        achievements may pass ``None``).
         """
         submitted = [p for p in players if p.submitted and p.current_guess is not None]
         if not submitted:
@@ -596,8 +603,40 @@ class ScoringService:
                 p.streak_bonus = 0
                 p.score -= p.intro_bonus
                 p.intro_bonus = 0
-                p.previous_streak = p.streak
-                p.streak = 0
+                # #1375: only roll back / break the streak when this player
+                # actually SCORED this round (lost > 0). _apply_streak already
+                # set streak=0 and saved the real previous_streak for players
+                # who scored 0 — overwriting previous_streak with the now-0
+                # streak here would wipe their "lost X-streak" reveal display.
+                if lost > 0:
+                    # _apply_streak incremented streak for this scoring round,
+                    # so the pre-round streak is (streak - 1). Roll back the
+                    # side-effects that the now-voided round produced:
+                    pre_round_streak = p.streak - 1
+                    # (a) milestone achievement counter (#147) — decrement the
+                    #     bucket this round's streak ticked, if any.
+                    if streak_achievements is not None:
+                        milestone_key = f"streak_{p.streak}"
+                        if streak_achievements.get(milestone_key, 0) > 0:
+                            streak_achievements[milestone_key] -= 1
+                    # (b) steal unlock — revoke only if THIS round newly unlocked
+                    #     it (streak hit the threshold) and it hasn't been used.
+                    if (
+                        p.streak == STEAL_UNLOCK_STREAK
+                        and p.steal_available
+                        and not p.steal_used
+                    ):
+                        p.steal_available = False
+                    # (c) best_streak — roll back to the pre-round value only
+                    #     when THIS round set the record (best_streak == the
+                    #     streak we're voiding). If an earlier round already
+                    #     peaked higher, best_streak stays untouched. (A rare
+                    #     identical earlier peak would dip by 1 — acceptable vs.
+                    #     the inflated value the bug left, per #1375.)
+                    if p.best_streak == p.streak:
+                        p.best_streak = pre_round_streak
+                    p.previous_streak = pre_round_streak
+                    p.streak = 0
 
     @staticmethod
     def calculate_superlatives(

--- a/custom_components/beatify/game/state_scoring.py
+++ b/custom_components/beatify/game/state_scoring.py
@@ -114,7 +114,9 @@ class RoundScoringMixin:
         # #816: same defensive wrap as above.
         if self.closest_wins_mode and correct_year is not None:
             try:
-                ScoringService.apply_closest_wins(all_players, correct_year)
+                ScoringService.apply_closest_wins(
+                    all_players, correct_year, self.streak_achievements
+                )
             except (KeyError, AttributeError, TypeError, ValueError) as err:
                 _LOGGER.error(
                     "apply_closest_wins failed in round %d: %s — round still ends",

--- a/tests/unit/test_scoring.py
+++ b/tests/unit/test_scoring.py
@@ -329,7 +329,12 @@ class TestApplyClosestWins:
         assert p1.round_scores == [10]
 
     def test_streak_break_for_non_closest(self):
-        """Non-closest player's streak resets to 0."""
+        """Non-closest player's streak resets to 0.
+
+        The streak value on the loser is the *incremented* streak that
+        _apply_streak produced for this (now-voided) scoring round, so
+        previous_streak rolls back to the pre-round value (streak - 1), #1375.
+        """
         p1 = _make_player("Alice", 2000, 10, streak=3, streak_bonus=20)
         p1.score = 10 + 20  # round_score + streak_bonus already added
         p2 = _make_player("Bob", 1990, 5, streak=4, streak_bonus=0)
@@ -339,11 +344,113 @@ class TestApplyClosestWins:
         # Winner keeps streak
         assert p1.streak == 3
         assert p1.streak_bonus == 20
-        # Loser's streak is broken
+        # Loser's streak is broken; previous_streak = pre-round value (4 - 1).
         assert p2.streak == 0
         assert p2.streak_bonus == 0
-        assert p2.previous_streak == 4
+        assert p2.previous_streak == 3
         assert p2.round_score == 0
+
+    def test_best_streak_rolled_back_when_round_voided(self):
+        """A voided streak round must not leave best_streak inflated (#1375)."""
+        # Alice wins; Bob scored this round (streak 3) and set best_streak=3.
+        p1 = _make_player("Alice", 2000, 10)
+        p2 = _make_player("Bob", 1990, 5, streak=3, best_streak=3)
+
+        ScoringService.apply_closest_wins([p1, p2], 2000)
+
+        # The streak Bob built this round is revoked, so the record it set is
+        # rolled back to the pre-round value.
+        assert p2.streak == 0
+        assert p2.best_streak == 2
+
+    def test_best_streak_kept_when_earlier_peak_higher(self):
+        """best_streak from an earlier, higher peak survives the rollback."""
+        p1 = _make_player("Alice", 2000, 10)
+        p2 = _make_player("Bob", 1990, 5, streak=3, best_streak=7)
+
+        ScoringService.apply_closest_wins([p1, p2], 2000)
+
+        assert p2.streak == 0
+        assert p2.best_streak == 7  # untouched — earlier round peaked higher
+
+    def test_milestone_counter_decremented(self):
+        """A voided round that hit a milestone decrements the shared counter."""
+        # Bob's streak reached 3, ticking the streak_3 milestone last round.
+        p1 = _make_player("Alice", 2000, 10)
+        p2 = _make_player("Bob", 1990, 5, streak=3)
+        achievements = {"streak_3": 1, "streak_5": 0}
+
+        ScoringService.apply_closest_wins([p1, p2], 2000, achievements)
+
+        assert achievements["streak_3"] == 0
+        assert achievements["streak_5"] == 0
+
+    def test_milestone_counter_not_below_zero(self):
+        """No milestone bucket for this streak → counter untouched, no crash."""
+        p1 = _make_player("Alice", 2000, 10)
+        p2 = _make_player("Bob", 1990, 5, streak=2)  # streak_2 not a milestone
+        achievements = {"streak_3": 1}
+
+        ScoringService.apply_closest_wins([p1, p2], 2000, achievements)
+
+        assert achievements["streak_3"] == 1  # unrelated bucket untouched
+
+    def test_steal_unlock_revoked_when_newly_unlocked(self):
+        """Steal unlocked by the voided streak round is revoked (#1375)."""
+        from custom_components.beatify.const import STEAL_UNLOCK_STREAK
+
+        p1 = _make_player("Alice", 2000, 10)
+        p2 = _make_player(
+            "Bob",
+            1990,
+            5,
+            streak=STEAL_UNLOCK_STREAK,
+            steal_available=True,
+            steal_used=False,
+        )
+
+        ScoringService.apply_closest_wins([p1, p2], 2000)
+
+        assert p2.streak == 0
+        assert p2.steal_available is False
+
+    def test_used_steal_not_revoked(self):
+        """An already-USED steal stays used; only the credit can be revoked."""
+        from custom_components.beatify.const import STEAL_UNLOCK_STREAK
+
+        p1 = _make_player("Alice", 2000, 10)
+        p2 = _make_player(
+            "Bob",
+            1990,
+            5,
+            streak=STEAL_UNLOCK_STREAK,
+            steal_available=False,
+            steal_used=True,
+        )
+
+        ScoringService.apply_closest_wins([p1, p2], 2000)
+
+        assert p2.steal_used is True
+        assert p2.steal_available is False
+
+    def test_previous_streak_preserved_for_zero_score_player(self):
+        """A player who scored 0 this round keeps their real previous_streak.
+
+        _apply_streak already broke their streak and saved the pre-break value
+        in previous_streak; apply_closest_wins must not overwrite it with 0
+        (which would break the "lost X-streak" reveal display), #1375.
+        """
+        p1 = _make_player("Alice", 2000, 10)
+        # Bob guessed badly, scored 0, _apply_streak set streak=0 and saved
+        # previous_streak=6 ("lost a 6-streak"). He's also non-closest here.
+        p2 = _make_player("Bob", 1980, 0, streak=0, previous_streak=6)
+
+        ScoringService.apply_closest_wins([p1, p2], 2000)
+
+        assert p2.round_score == 0
+        assert p2.streak == 0
+        # Real previous_streak preserved — NOT clobbered to 0.
+        assert p2.previous_streak == 6
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #1375

## Readiness assessment
- [x] Borderline — see notes (best_streak rollback has one documented edge case)

**Honest summary:** `apply_closest_wins` zeroed the round score + streak but left every other side-effect of the voided scoring round standing — inflated `best_streak`, an over-counted `streak_achievements` milestone, a steal unlocked by that streak, and (for 0-score players) a clobbered `previous_streak`. The fix guards the streak block with `if lost > 0`, rolls back to the pre-round streak value, decrements the milestone counter, and revokes a newly-unlocked unused steal. Solid for the common case; the one soft spot is `best_streak` (see Risk).

## Test plan
- Unit (added to `tests/unit/test_scoring.py::TestApplyClosestWins`): best_streak rollback when this round set the record; best_streak preserved when an earlier round peaked higher; milestone counter decremented + floor-at-bucket; steal revoked when newly unlocked; used steal not revoked; previous_streak preserved for 0-score non-closest players; existing `test_streak_break_for_non_closest` updated to the corrected previous_streak (pre-round value).
- Manual: closest-wins game, build a 3-streak then lose it via a non-closest round → Lucky Streak superlative, steal power-up, and "lost X-streak" reveal all reflect the voided round.

## Risk assessment
- **Blast radius:** `game/scoring.py::apply_closest_wins` (closest-wins mode only) + its one caller in `game/state_scoring.py`. No effect on non-closest-wins games.
- **What could go wrong:** `best_streak` is rolled back only when it equals the voided streak (i.e. this round set the record). A *rare identical earlier peak* would dip by 1 — accepted as strictly better than the prior inflation, since a single call can't reconstruct full round history (matches the issue's suggested remedy). The new `streak_achievements` param is optional/keyword-safe; other callers are unaffected.
- **What I did NOT test:** live multi-round closest-wins game on a device (unit-level only); interaction with title/artist mode (closest-wins is year-mode only, so not applicable).

🤖 Auto-generated by issue-triage routine