### PR TITLE
fix: classify share-card round_results from field statuses in Title & Artist mode (#1373)

### DIFF
--- a/custom_components/beatify/game/challenges.py
+++ b/custom_components/beatify/game/challenges.py
@@ -817,6 +817,32 @@ class ChallengeManager:
             return "skipped"
         return guess[f"{field}_status"]
 
+    def title_artist_round_result(self, player_name: str) -> str:
+        """Classify a player's title/artist round for the share grid (#1373).
+
+        Returns one of "exact" / "scored" / "close" / "missed" from the stored
+        field statuses, mirroring _field_points scoring:
+
+        * "exact"  — both fields exact.
+        * "scored" — at least one field earned full points (exact or fuzzy).
+        * "close"  — only accepted near-miss(es) earned partial points.
+        * "missed" — nothing earned points.
+
+        In title/artist mode player.years_off is always None, so the year-mode
+        round_results classifier in _score_round marks every round "missed".
+        This routes round_results off the field statuses instead.
+        """
+        title_status = self.title_artist_status(player_name, "title")
+        artist_status = self.title_artist_status(player_name, "artist")
+        full = (STATUS_EXACT, STATUS_FUZZY)
+        if title_status == STATUS_EXACT and artist_status == STATUS_EXACT:
+            return "exact"
+        if title_status in full or artist_status in full:
+            return "scored"
+        if STATUS_NEAR_MISS_ACCEPTED in (title_status, artist_status):
+            return "close"
+        return "missed"
+
     @staticmethod
     def _field_points(status: str, full: int, partial: int) -> int:
         """Map a stored field status to awarded points."""

--- a/custom_components/beatify/game/state_scoring.py
+++ b/custom_components/beatify/game/state_scoring.py
@@ -42,6 +42,9 @@ The mixin relies on attributes / methods the host class owns and that live on
   ``self.round_start_time`` — round state read while scoring.
 * ``self.title_artist_mode`` / ``self.has_near_misses`` — gate the deferred
   title/artist scoring path (#1180 Phase 4).
+* ``self._challenge_manager`` — :class:`ChallengeManager`; its
+  ``title_artist_round_result`` classifies ``round_results`` from the resolved
+  field statuses in title/artist mode (#1373).
 * ``self.closest_wins_mode`` / ``self.difficulty`` — Closest-Wins + scoring
   config selection.
 * ``self.calculate_round_analytics`` — Story 13.3 analytics (delegates to
@@ -123,33 +126,55 @@ class RoundScoringMixin:
                 )
 
         # Issue #120: Track round results for shareable result cards.
-        # #816: defensive wrap so a corrupt player.years_off doesn't block
-        # the round-end transition.
-        if correct_year is not None:
-            scoring_cfg = DIFFICULTY_SCORING.get(
-                self.difficulty, DIFFICULTY_SCORING[DIFFICULTY_DEFAULT]
-            )
-            close_range = scoring_cfg["close_range"]
-            near_range = scoring_cfg["near_range"]
-            for player in self.players.values():
-                try:
-                    if player.submitted and player.years_off is not None:
-                        if player.years_off == 0:
-                            player.round_results.append("exact")
-                        elif close_range > 0 and player.years_off <= close_range:
-                            player.round_results.append("scored")
-                        elif near_range > 0 and player.years_off <= near_range:
-                            player.round_results.append("close")
-                        else:
-                            player.round_results.append("missed")
+        # #1373: in title/artist mode with deferred near-miss scoring, the field
+        # statuses aren't final until _finalize_title_artist_window — defer the
+        # round_results append to that path too, so it classifies the resolved
+        # statuses instead of marking the round "missed".
+        if correct_year is not None and not defer_title_artist:
+            self._append_round_results()
+
+    def _append_round_results(self) -> None:
+        """Append one round_results entry per player (#120, #1373).
+
+        Year mode classifies from player.years_off; title/artist mode classifies
+        from the resolved field statuses (years_off is always None there, which
+        would otherwise mark every round "missed" — #1373). Called from the main
+        scoring pass for year / non-deferred rounds, and from
+        _finalize_title_artist_window once deferred near-misses are resolved.
+
+        #816: each player is wrapped so a corrupt player state doesn't block the
+        round-end transition.
+        """
+        title_artist_mode = self.title_artist_mode
+        manager = self._challenge_manager if title_artist_mode else None
+        scoring_cfg = DIFFICULTY_SCORING.get(
+            self.difficulty, DIFFICULTY_SCORING[DIFFICULTY_DEFAULT]
+        )
+        close_range = scoring_cfg["close_range"]
+        near_range = scoring_cfg["near_range"]
+        for player in self.players.values():
+            try:
+                if title_artist_mode and manager is not None:
+                    player.round_results.append(
+                        manager.title_artist_round_result(player.name)
+                    )
+                elif player.submitted and player.years_off is not None:
+                    if player.years_off == 0:
+                        player.round_results.append("exact")
+                    elif close_range > 0 and player.years_off <= close_range:
+                        player.round_results.append("scored")
+                    elif near_range > 0 and player.years_off <= near_range:
+                        player.round_results.append("close")
                     else:
                         player.round_results.append("missed")
-                except (AttributeError, TypeError) as err:
-                    _LOGGER.error(
-                        "round_results append failed for player %s: %s",
-                        getattr(player, "name", "?"),
-                        err,
-                    )
+                else:
+                    player.round_results.append("missed")
+            except (AttributeError, TypeError) as err:
+                _LOGGER.error(
+                    "round_results append failed for player %s: %s",
+                    getattr(player, "name", "?"),
+                    err,
+                )
 
     async def _record_round_stats(self, correct_year: int | None) -> None:
         """Record highlights, round analytics and song-result stats (#1272).

--- a/custom_components/beatify/game/state_vote_window.py
+++ b/custom_components/beatify/game/state_vote_window.py
@@ -48,6 +48,9 @@ The mixin relies on attributes / methods the host class owns and that live on
   deferred scoring pass runs under it.
 * ``self._score_all_players`` — the shared per-player scoring loop (stays on
   ``GameState`` so the round-end and vote-window paths cannot drift).
+* ``self._append_round_results`` — the shared round_results classifier (owned by
+  :class:`RoundScoringMixin`); called after the deferred scoring pass so the
+  share grid reflects the resolved title/artist field statuses (#1373).
 * ``self.players`` / ``self.current_song`` / ``self.phase`` — round state read
   while the window is open.
 * ``self._on_round_end`` — the async broadcast callback fired after expiry.
@@ -174,6 +177,10 @@ class VoteWindowMixin:
         correct_year = self.current_song.get("year") if self.current_song else None
         all_players = list(self.players.values())
         self._score_all_players(correct_year, all_players)
+        # #1373: append round_results here for the deferred title/artist path —
+        # the main scoring pass skipped it so this classifies the resolved
+        # field statuses (years_off is None in this mode) instead of "missed".
+        self._append_round_results()
 
     async def resolve_title_artist_if_pending(self) -> None:
         """Finalize an open vote window early (host advanced) (#1180 P4).

--- a/tests/unit/test_state_title_artist_window.py
+++ b/tests/unit/test_state_title_artist_window.py
@@ -302,6 +302,121 @@ class TestVoteWindowScoring:
         assert alice.rounds_played == 1
 
 
+class TestRoundResultsShareGrid:
+    """#1373: the share-card emoji grid must reflect title/artist results.
+
+    Before the fix, round_results was classified solely from player.years_off,
+    which is always None in title/artist mode — so every round was appended as
+    "missed" and the end-of-game share card showed an all-red grid + "0/N
+    correct" even for a player who nailed every title and artist. These assert
+    round_results is now classified from the resolved field statuses, on both
+    the immediate-resolve and the deferred vote-window paths.
+    """
+
+    async def test_all_exact_grid_is_not_missed(self):
+        """Immediate-resolve path: both fields exact -> 'exact', not 'missed'."""
+        gs = make_game_state()
+        await _start_round(gs)
+        await gs.start_round()
+        gs._challenge_manager.submit_title_artist_guess(
+            "Alice", gs.current_song["title"], gs.current_song["artist"], 1.0
+        )
+        gs._challenge_manager.submit_title_artist_guess(
+            "Bob", gs.current_song["title"], gs.current_song["artist"], 1.0
+        )
+        for p in gs.players.values():
+            p.submitted = True
+        await gs.end_round()
+        assert gs.is_title_artist_voting_open() is False
+        for p in gs.players.values():
+            assert p.round_results == ["exact"]
+        gs._cancel_auto_advance()
+
+    async def test_title_only_correct_is_scored(self):
+        """One field exact, other wrong (no near-miss) -> 'scored'."""
+        gs = make_game_state()
+        await _start_round(gs)
+        await gs.start_round()
+        # Exact title, clearly-wrong artist (not a near-miss -> immediate resolve).
+        gs._challenge_manager.submit_title_artist_guess(
+            "Alice", gs.current_song["title"], "Totally Different Band", 1.0
+        )
+        gs._challenge_manager.submit_title_artist_guess(
+            "Bob", gs.current_song["title"], gs.current_song["artist"], 1.0
+        )
+        for p in gs.players.values():
+            p.submitted = True
+        await gs.end_round()
+        assert gs.is_title_artist_voting_open() is False
+        assert gs.players["Alice"].round_results == ["scored"]
+        assert gs.players["Bob"].round_results == ["exact"]
+        gs._cancel_auto_advance()
+
+    async def test_accepted_near_miss_is_close_deferred_path(self):
+        """Deferred vote-window path: accepted near-miss title -> 'close'.
+
+        Alice has a near-miss title + exact artist; an override accepts it. The
+        round_results append must run AFTER the window resolves so it sees the
+        promoted near_miss_accepted status.
+        """
+        gs = make_game_state()
+        await _start_round(gs)
+        await gs.start_round()
+        gs._challenge_manager.submit_title_artist_guess(
+            "Alice", "Real Mismatch", gs.current_song["artist"], 1.0
+        )
+        gs._challenge_manager.submit_title_artist_guess(
+            "Bob", gs.current_song["title"], gs.current_song["artist"], 1.0
+        )
+        for p in gs.players.values():
+            p.submitted = True
+        await gs.end_round()
+        # Deferred — no round_results banked yet while the window is open.
+        assert gs.players["Alice"].round_results == []
+        gs.set_title_artist_override("Alice:title", True)
+        await gs.resolve_title_artist_if_pending()
+        # Alice: accepted near-miss title (partial) + exact artist -> "scored"
+        # (artist is exact, which earns full points). Bob exact/exact -> "exact".
+        assert gs.players["Alice"].round_results == ["scored"]
+        assert gs.players["Bob"].round_results == ["exact"]
+
+    async def test_rejected_near_miss_only_is_close(self):
+        """A near-miss accepted with no other full-points field -> 'close'."""
+        gs = make_game_state()
+        await _start_round(gs)
+        await gs.start_round()
+        # Alice: near-miss title AND wrong artist -> only the accepted title
+        # earns (partial) points, so the round classifies as "close".
+        gs._challenge_manager.submit_title_artist_guess(
+            "Alice", "Real Mismatch", "Totally Different Band", 1.0
+        )
+        gs._challenge_manager.submit_title_artist_guess(
+            "Bob", gs.current_song["title"], gs.current_song["artist"], 1.0
+        )
+        for p in gs.players.values():
+            p.submitted = True
+        await gs.end_round()
+        gs.set_title_artist_override("Alice:title", True)
+        await gs.resolve_title_artist_if_pending()
+        assert gs.players["Alice"].round_results == ["close"]
+
+    async def test_no_submission_is_missed(self):
+        """A player who didn't guess in title/artist mode -> 'missed'."""
+        gs = make_game_state()
+        await _start_round(gs)
+        await gs.start_round()
+        gs._challenge_manager.submit_title_artist_guess(
+            "Bob", gs.current_song["title"], gs.current_song["artist"], 1.0
+        )
+        gs.players["Bob"].submitted = True
+        # Alice never submits.
+        await gs.end_round()
+        assert gs.is_title_artist_voting_open() is False
+        assert gs.players["Alice"].round_results == ["missed"]
+        assert gs.players["Bob"].round_results == ["exact"]
+        gs._cancel_auto_advance()
+
+
 class TestVoteWindowFlagReset:
     """#1359: the vote-window flags must not leak past a game's lifecycle.
 

--- a/tests/unit/test_title_artist_challenge.py
+++ b/tests/unit/test_title_artist_challenge.py
@@ -150,6 +150,50 @@ class TestTitleArtistPoints:
         assert mgr.title_artist_points("Nobody") == (0, 0)
 
 
+class TestTitleArtistRoundResult:
+    """title_artist_round_result classifies the share-grid cell (#1373).
+
+    exact / scored / close / missed, mirroring _field_points scoring.
+    """
+
+    def test_both_exact_is_exact(self):
+        mgr = _make_manager()
+        mgr.submit_title_artist_guess("Alice", "Bohemian Rhapsody", "Queen", ts=1.0)
+        assert mgr.title_artist_round_result("Alice") == "exact"
+
+    def test_title_exact_artist_wrong_is_scored(self):
+        mgr = _make_manager()
+        mgr.submit_title_artist_guess(
+            "Alice", "Bohemian Rhapsody", "Totally Different", ts=1.0
+        )
+        assert mgr.title_artist_round_result("Alice") == "scored"
+
+    def test_fuzzy_field_is_scored(self):
+        mgr = _make_manager()
+        # fuzzy title earns full points -> "scored" (not "exact").
+        mgr.submit_title_artist_guess("Bob", "Bohemian Rhapsdy", "Queen", ts=1.0)
+        assert mgr.title_artist_round_result("Bob") == "scored"
+
+    def test_accepted_near_miss_only_is_close(self):
+        mgr = _make_manager()
+        # Near-miss title accepted, artist wrong -> only partial points -> close.
+        mgr.submit_title_artist_guess("Dan", "Bohemian", "Totally Different", ts=1.0)
+        mgr.set_title_artist_override("Dan:title", accept=True)
+        mgr.resolve_title_artist()
+        assert mgr.title_artist_round_result("Dan") == "close"
+
+    def test_unaccepted_near_miss_is_missed(self):
+        mgr = _make_manager()
+        # Near-miss both, no votes/override -> rejected -> 0 points -> missed.
+        mgr.submit_title_artist_guess("Dan", "Bohemian", "Queen Rock", ts=1.0)
+        mgr.resolve_title_artist()
+        assert mgr.title_artist_round_result("Dan") == "missed"
+
+    def test_no_guess_is_missed(self):
+        mgr = _make_manager()
+        assert mgr.title_artist_round_result("Nobody") == "missed"
+
+
 class TestNearMisses:
     """get_near_misses / has_near_misses surface near-miss fields."""
 


### PR DESCRIPTION
Closes #1373

## Root cause
`_score_round` (state_scoring.py) classified each player's `round_results`
(the end-of-game share-card emoji grid) **solely** from `player.years_off`. In
Title & Artist mode `years_off` is always `None` (`_score_title_artist_round`
sets it so), and on the deferred near-miss path players aren't scored yet when
that block runs — so `player.submitted and player.years_off is not None` was
always False and **every round got appended as `"missed"`**. The share card
showed an all-red grid + "0/N correct" even for a perfect game.

## Fix
- New `ChallengeManager.title_artist_round_result(player_name)` classifies a
  round from the resolved field statuses: both fields exact -> `exact`; either
  field earns full points (exact/fuzzy) -> `scored`; only an accepted near-miss
  earns partial points -> `close`; otherwise -> `missed`.
- Extracted the round_results loop into `RoundScoringMixin._append_round_results`,
  which routes title/artist rounds through the new classifier and keeps the
  unchanged year-mode `years_off` branch for year games.
- The append is now **deferred** in the near-miss vote-window path: skipped in
  the main scoring pass (`defer_title_artist`) and run inside
  `_finalize_title_artist_window` after `resolve_title_artist`, so it sees the
  promoted `near_miss_accepted` statuses instead of pre-resolution values.

## Readiness assessment
- [x] Ready to merge
- [ ] Borderline — see notes
- [ ] Not ready — needs human review

**Honest summary:** Backend game-logic fix, no UI/frontend surface (only the
data feeding the existing share grid changes). Year-mode classification is moved
verbatim, so year games are unaffected. Both the immediate-resolve and the
deferred vote-window title/artist paths are covered by new tests. Not validated
on a live HA instance.

## Test plan
- Unit: `TestTitleArtistRoundResult` (6 cases) locks the classifier mapping.
- End-to-end via GameState harness: `TestRoundResultsShareGrid` (5 cases) —
  all-exact -> `["exact"]` (the regression), title-only -> `["scored"]`,
  deferred accepted near-miss -> resolved status, accepted-near-miss-only ->
  `["close"]`, no submission -> `["missed"]`.
- Full suites green: test_state_title_artist_window, test_title_artist_challenge,
  test_scoring, test_state (298 passed).

## Risk assessment
- **Blast radius:** `round_results` classification only (share-card grid + the
  derived `scored/exact` counts). No score/leaderboard mutation.
- **What could go wrong:** if a future status value isn't covered by the four
  buckets it falls through to `missed` (safe default, matches prior behavior).
- **What I did NOT test:** live HA share-card render; multi-round accumulation
  beyond the single-round unit harness.

Gates: pytest 298 passed · ruff check + ruff format --check clean (0.15.7) ·
mypy 1.18.2 clean (15 files). No frontend files touched.

🤖 Auto-generated by issue-triage routine