### PR TITLE
fix: guard verify_responsive ping against unreported volume_level (#1382)

### DIFF
--- a/custom_components/beatify/services/media_player.py
+++ b/custom_components/beatify/services/media_player.py
@@ -1214,20 +1214,34 @@ class MediaPlayerService:
             return False, msg
 
         try:
-            # Use volume_set with current volume as a lightweight ping
-            # This wakes up sleeping speakers without changing anything
-            current_volume = self.get_volume()
+            # Read the *real* reported volume — NOT get_volume(), which masks
+            # an unreported volume_level as a hard-coded 0.5. Writing that 0.5
+            # back via volume_set would physically blast an idle speaker (the
+            # very speakers this ping targets) to 50%, instead of being the
+            # promised no-op (#1382).
+            reported_volume = state.attributes.get("volume_level")
 
             async with async_timeout(PREFLIGHT_TIMEOUT):
-                await self._hass.services.async_call(
-                    "media_player",
-                    "volume_set",
-                    {
-                        "entity_id": self._entity_id,
-                        "volume_level": current_volume,
-                    },
-                    blocking=True,
-                )
+                if reported_volume is not None:
+                    # Genuine no-op ping: re-set the speaker to its own volume.
+                    await self._hass.services.async_call(
+                        "media_player",
+                        "volume_set",
+                        {
+                            "entity_id": self._entity_id,
+                            "volume_level": float(reported_volume),
+                        },
+                        blocking=True,
+                    )
+                else:
+                    # No volume reported (sleeping/idle speaker): use a truly
+                    # read-only refresh as the ping so we never change volume.
+                    await self._hass.services.async_call(
+                        "homeassistant",
+                        "update_entity",
+                        {"entity_id": self._entity_id},
+                        blocking=True,
+                    )
             _LOGGER.debug("Media player %s is responsive", self._entity_id)
             self._preflight_verified = True
             return True, ""

--- a/tests/unit/test_media_player.py
+++ b/tests/unit/test_media_player.py
@@ -1558,3 +1558,54 @@ class TestWaitForMetadataUpdateAlbumArt:
 
         assert result["title"] == "New"
         assert result["album_art"] == "/beatify/static/img/no-artwork.svg"
+
+
+class TestVerifyResponsivePing:
+    """Pre-flight ping must never raise an idle speaker's volume (#1382)."""
+
+    @pytest.mark.asyncio
+    async def test_unreported_volume_does_not_set_volume(self):
+        """volume_level is None -> NO volume_set (no absolute 50% blast)."""
+        hass = _make_hass(initial_state="idle")
+        state = hass.states.get("media_player.test")
+        state.attributes["volume_level"] = None
+
+        svc = MediaPlayerService(hass, "media_player.test", platform="sonos")
+
+        ok, detail = await svc.verify_responsive()
+
+        assert ok is True
+        assert detail == ""
+
+        calls = hass.services.async_call.await_args_list
+        # No volume_set at all when volume is unreported.
+        assert all(call.args[1] != "volume_set" for call in calls), (
+            f"verify_responsive must not call volume_set on unreported volume: {calls}"
+        )
+        # Used a read-only refresh ping instead.
+        assert any(
+            call.args[0] == "homeassistant" and call.args[1] == "update_entity"
+            for call in calls
+        ), f"expected homeassistant.update_entity ping, got: {calls}"
+
+    @pytest.mark.asyncio
+    async def test_reported_volume_pings_with_exact_value(self):
+        """A real reported volume is echoed back unchanged via volume_set."""
+        hass = _make_hass(initial_state="idle")
+        state = hass.states.get("media_player.test")
+        state.attributes["volume_level"] = 0.12
+
+        svc = MediaPlayerService(hass, "media_player.test", platform="sonos")
+
+        ok, detail = await svc.verify_responsive()
+
+        assert ok is True
+        assert detail == ""
+
+        vol_calls = [
+            call
+            for call in hass.services.async_call.await_args_list
+            if call.args[:2] == ("media_player", "volume_set")
+        ]
+        assert len(vol_calls) == 1
+        assert vol_calls[0].args[2]["volume_level"] == 0.12


### PR DESCRIPTION
Closes #1382

## Readiness assessment
- [x] Ready to merge
- [ ] Borderline — see notes
- [ ] Not ready — needs human review

**Honest summary:** Solid root-cause fix. `verify_responsive`'s "lightweight ping" called `get_volume()`, which returns a hard-coded `0.5` when `volume_level` is unreported (None) — exactly the idle/sleeping speakers the ping targets. Writing that back via `volume_set` physically set the speaker to 50% instead of being a no-op. Fix reads the *real* reported `volume_level` from state; only echoes it back via `volume_set` when present, otherwise falls back to a read-only `homeassistant.update_entity` ping. Two unit tests prove the no-blast behavior.

## Test plan
- `tests/unit/test_media_player.py::TestVerifyResponsivePing::test_unreported_volume_does_not_set_volume` — asserts NO `volume_set` call (no absolute 50%) and a `homeassistant.update_entity` ping when `volume_level` is None.
- `test_reported_volume_pings_with_exact_value` — asserts a real reported volume (0.12) is echoed back unchanged via `volume_set`.
- Full suite: 956 passed, 2 skipped. `ruff check .` + `ruff format --check .` clean. `mypy` clean (15 files).

## Risk assessment
- **Blast radius:** `verify_responsive` only (pre-flight wake/responsiveness check for non-MA platforms at game start). Touches `services/media_player.py` + its unit test.
- **What could go wrong:** Relies on `homeassistant.update_entity` being available + a valid responsiveness probe; if a speaker integration ignores it the timeout/exception paths still classify it unresponsive exactly as before. No behavior change when a real volume is reported.
- **What I did NOT test:** Live speaker hardware (Alexa/Sonos idle); the read-only `update_entity` ping's wake efficacy on a genuinely sleeping device vs. the old volume_set. Backend-only, no frontend surface.

🤖 Auto-generated by issue-triage routine