### PR TITLE
fix: match metadata confirmation against MA content_id form for non-Spotify URIs (#1380)

### DIFF
--- a/custom_components/beatify/services/media_player.py
+++ b/custom_components/beatify/services/media_player.py
@@ -389,6 +389,49 @@ class MediaPlayerService:
         # spotify:track:<id> and https:// URLs are passed through unchanged
         return uri
 
+    @classmethod
+    def _uri_match_tokens(cls, uri: str) -> list[str]:
+        """Tokens to look for in MA's media_content_id to confirm playback.
+
+        Issue #1380: the raw Beatify-internal URI is not what MA reports in
+        media_content_id — MA echoes the _convert_uri_for_ma form. To reliably
+        detect that the requested track started, match against BOTH the
+        MA-converted URI and the bare track ID (last path/ID segment), which is
+        identical across the internal and the MA-converted form for every
+        provider (Spotify, Apple Music, Tidal, YT Music, Deezer).
+
+        Args:
+            uri: The Beatify-internal URI that was requested.
+
+        Returns:
+            Ordered, deduped, non-empty substring tokens.
+
+        """
+        tokens: list[str] = []
+
+        def _add(token: str | None) -> None:
+            if token and token not in tokens:
+                tokens.append(token)
+
+        # The form MA actually reports.
+        _add(cls._convert_uri_for_ma(uri))
+        # The raw form too, in case a provider echoes the internal URI verbatim.
+        _add(uri)
+
+        # Bare track ID — stable across both forms.
+        if uri.startswith("spotify:"):
+            _add(uri.split(":")[-1])
+        elif "watch?v=" in uri:
+            # https://music.youtube.com/watch?v=<id>[&extra]
+            _add(uri.split("watch?v=", 1)[-1].split("&", 1)[0])
+        elif "://" in uri:
+            # applemusic://track/<id>, tidal://track/<id>, deezer://track/<id>,
+            # and plain https URLs — the bare ID is the last "/"-segment.
+            tail = uri.rstrip("/").rsplit("/", 1)[-1]
+            _add(tail.split("?", 1)[0])
+
+        return tokens
+
     def _get_ma_uri_candidates(
         self, song: dict[str, Any]
     ) -> list[tuple[str | None, str]]:
@@ -911,11 +954,16 @@ class MediaPlayerService:
             Dict with artist, title, album_art keys
 
         """
-        # Extract track ID from URI — Issue #422: platform-aware parsing
-        if uri.startswith("spotify:"):
-            track_id = uri.split(":")[-1]
-        else:
-            track_id = uri
+        # Build the substring tokens to look for in MA's media_content_id.
+        # Issue #1380: for non-Spotify providers the raw Beatify-internal URI
+        # (applemusic://track/123, tidal://track/123,
+        # https://music.youtube.com/watch?v=ABC) never appears in MA's
+        # content_id, because MA reports its own form derived from
+        # _convert_uri_for_ma (apple_music://track/123,
+        # https://tidal.com/browse/track/123, ytmusic://track/ABC). Match
+        # against the MA-converted URI AND the bare track ID (the last path/ID
+        # segment), which is stable across both forms.
+        match_tokens = self._uri_match_tokens(uri)
 
         # Get initial state for comparison
         initial_state = self._hass.states.get(self._entity_id)
@@ -939,7 +987,7 @@ class MediaPlayerService:
             if not state:
                 return False
             content_id = state.attributes.get("media_content_id", "")
-            if track_id in content_id:
+            if any(token in content_id for token in match_tokens):
                 return True
             current_title = state.attributes.get("media_title")
             return bool(current_title and current_title != initial_title)
@@ -989,6 +1037,16 @@ class MediaPlayerService:
                         song_matched.wait(), timeout=METADATA_WAIT_TIMEOUT
                     )
                 except asyncio.TimeoutError:
+                    # Issue #1380: if entity_picture already advanced to a real
+                    # new cover during the wait, honor that captured metadata
+                    # (the #1260 two-phase freshness) instead of discarding it.
+                    if art_changed.is_set():
+                        _LOGGER.warning(
+                            "Song match not detected within %.1fs, but new album "
+                            "art arrived — using captured metadata",
+                            METADATA_WAIT_TIMEOUT,
+                        )
+                        return art_metadata
                     _LOGGER.warning(
                         "Metadata not updated within %.1fs, using current state",
                         METADATA_WAIT_TIMEOUT,
@@ -1002,7 +1060,11 @@ class MediaPlayerService:
                 if current_state
                 else ""
             )
-            reason = "matched track ID" if track_id in content_id else "title changed"
+            reason = (
+                "matched track ID"
+                if any(token in content_id for token in match_tokens)
+                else "title changed"
+            )
             _LOGGER.debug("Song started after %.1fs (%s)", elapsed, reason)
 
             # ── Phase 2: wait for entity_picture to also update ───────────

--- a/tests/unit/test_media_player.py
+++ b/tests/unit/test_media_player.py
@@ -1609,3 +1609,158 @@ class TestVerifyResponsivePing:
         ]
         assert len(vol_calls) == 1
         assert vol_calls[0].args[2]["volume_level"] == 0.12
+
+
+class TestUriMatchTokens:
+    """#1380: confirmation must match MA's content_id form, not the raw URI.
+
+    MA echoes the _convert_uri_for_ma form in media_content_id, so the raw
+    Beatify-internal URI is never a substring for Apple/Tidal/YT Music. The
+    match tokens must therefore include the MA-converted URI and the bare
+    track ID (which is stable across both forms).
+    """
+
+    @pytest.mark.parametrize(
+        ("uri", "ma_content_id", "bare_id"),
+        [
+            # Spotify — unchanged form, bare id is the last ":" segment.
+            ("spotify:track:ABC123", "spotify:track:ABC123", "ABC123"),
+            # Apple Music — internal applemusic:// vs MA apple_music://.
+            ("applemusic://track/123", "apple_music://track/123", "123"),
+            # Tidal — internal tidal:// vs MA https://tidal.com/browse/track.
+            ("tidal://track/456", "https://tidal.com/browse/track/456", "456"),
+            # YT Music — internal watch?v= URL vs MA ytmusic://track form.
+            (
+                "https://music.youtube.com/watch?v=XYZ",
+                "ytmusic://track/XYZ",
+                "XYZ",
+            ),
+            # Deezer — passed through unchanged by _convert_uri_for_ma.
+            ("deezer://track/789", "deezer://track/789", "789"),
+        ],
+    )
+    def test_tokens_match_ma_content_id_and_bare_id(self, uri, ma_content_id, bare_id):
+        tokens = MediaPlayerService._uri_match_tokens(uri)
+        # The MA-converted form is always reproducible in content_id.
+        assert any(tok in ma_content_id for tok in tokens), (
+            f"{uri!r} tokens {tokens!r} don't match MA content_id {ma_content_id!r}"
+        )
+        # The bare track ID is present as a token.
+        assert bare_id in tokens
+
+    def test_youtube_watch_url_strips_extra_query_params(self):
+        tokens = MediaPlayerService._uri_match_tokens(
+            "https://music.youtube.com/watch?v=XYZ&list=PL1"
+        )
+        assert "XYZ" in tokens
+        assert "XYZ&list=PL1" not in tokens
+
+    def test_empty_uri_yields_no_tokens(self):
+        assert MediaPlayerService._uri_match_tokens("") == []
+
+
+class TestWaitForMetadataUpdateCrossProvider:
+    """#1380: Phase-1 song-match must fire for non-Spotify providers, and a
+    Phase-1 timeout that nonetheless captured new art must return that art."""
+
+    @staticmethod
+    def _service_with_states(initial_state):
+        hass = MagicMock()
+        box = {"current": initial_state}
+        hass.states.get = MagicMock(side_effect=lambda *a, **k: box["current"])
+        svc = MediaPlayerService(hass, "media_player.test")
+        return svc, box
+
+    @pytest.mark.parametrize(
+        ("uri", "ma_content_id"),
+        [
+            ("applemusic://track/123", "apple_music://track/123"),
+            ("tidal://track/456", "https://tidal.com/browse/track/456"),
+            (
+                "https://music.youtube.com/watch?v=XYZ",
+                "ytmusic://track/XYZ",
+            ),
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_song_match_fires_for_provider_content_id(self, uri, ma_content_id):
+        """The new song is detected via content_id even though MA reports its
+        own converted URI form — not the raw Beatify-internal URI. Title is
+        deliberately unchanged so ONLY the content_id path can match."""
+        same_title = "Same Title"
+        old = _art_state(
+            title=same_title,
+            content_id="apple_music://track/OLD",
+            entity_picture="/api/media_player_proxy/x?token=old",
+        )
+        svc, box = self._service_with_states(old)
+
+        captured: dict = {}
+
+        def _fake_track(hass, entity_ids, cb):
+            captured["cb"] = cb
+            return MagicMock()
+
+        with patch(_TRACK_PATH, side_effect=_fake_track):
+            task = asyncio.create_task(svc.wait_for_metadata_update(uri))
+            await asyncio.sleep(0)
+
+            # Song started: content_id is MA's converted form, title unchanged,
+            # new cover present in the same event.
+            started = _art_state(
+                title=same_title,
+                content_id=ma_content_id,
+                entity_picture="/api/media_player_proxy/x?token=NEW",
+            )
+            box["current"] = started
+            captured["cb"](_event(started))
+
+            result = await task
+
+        # Must return the NEW art (proves content_id match, not a 2s timeout
+        # fall-through to get_metadata()).
+        assert result["album_art"] == "/api/media_player_proxy/x?token=NEW"
+
+    @pytest.mark.asyncio
+    async def test_phase1_timeout_returns_captured_art(self):
+        """#1380: if the song-match never fires but a real new cover arrived
+        during the wait, return the captured art metadata instead of
+        discarding it and falling back to the current state."""
+        old = _art_state(
+            title="Old",
+            content_id="apple_music://track/OLD",
+            entity_picture="/api/media_player_proxy/x?token=old",
+        )
+        svc, box = self._service_with_states(old)
+
+        captured: dict = {}
+
+        def _fake_track(hass, entity_ids, cb):
+            captured["cb"] = cb
+            return MagicMock()
+
+        with (
+            patch(_TRACK_PATH, side_effect=_fake_track),
+            patch(
+                "custom_components.beatify.services.media_player.METADATA_WAIT_TIMEOUT",
+                0.05,
+            ),
+        ):
+            task = asyncio.create_task(
+                svc.wait_for_metadata_update("applemusic://track/UNMATCHED")
+            )
+            await asyncio.sleep(0)
+
+            # New cover arrives, but content_id/title NEVER match the requested
+            # track (simulating the dead-fallback scenario from the issue).
+            art_only = _art_state(
+                title="Old",
+                content_id="apple_music://track/OLD",
+                entity_picture="/api/media_player_proxy/x?token=NEW",
+            )
+            box["current"] = art_only
+            captured["cb"](_event(art_only))
+
+            result = await task
+
+        assert result["album_art"] == "/api/media_player_proxy/x?token=NEW"


### PR DESCRIPTION
Closes #1380

## Root cause
`MediaPlayerService.wait_for_metadata_update` matched the **raw** Beatify-internal URI against MA's `media_content_id`. But MA echoes the `_convert_uri_for_ma` form in `content_id` (`apple_music://track/<id>`, `https://tidal.com/browse/track/<id>`, `ytmusic://track/<id>`), so `track_id in content_id` could never match for Apple Music / Tidal / YT Music. Every non-Spotify round therefore burned the full `METADATA_WAIT_TIMEOUT` and fell back to `get_metadata()`, bypassing the #1260 two-phase entity_picture freshness. Additionally, the Phase-1 timeout branch discarded any new album art (`art_metadata`) it had already captured.

## Fix (backend-only — no UI surface)
File: `custom_components/beatify/services/media_player.py`
- **New `MediaPlayerService._uri_match_tokens(uri)`** (classmethod): builds the substring tokens to look for in `media_content_id` — the MA-converted URI (via `_convert_uri_for_ma`), the raw URI, and the bare track ID (last path/ID segment), which is stable across both forms for every provider.
- **`wait_for_metadata_update`**: `_song_started` and the debug `reason` line now match against these tokens instead of `track_id in content_id`. The Phase-1 `TimeoutError` branch returns the captured `art_metadata` when `art_changed.is_set()` before falling back to `get_metadata()`.

## Overlap note (sibling resolvers)
Issues #1379 and #1381 may also edit `services/media_player.py`. This change is scoped to `_uri_match_tokens` (new method, after `_convert_uri_for_ma`), the token comparison inside `wait_for_metadata_update`, and that method's Phase-1 timeout branch. Sequence accordingly on merge.

## Readiness assessment
- [x] Ready to merge
- [ ] Borderline — see notes
- [ ] Not ready — needs human review

**Honest summary:** Tightly-scoped fix with new + parametrized regression tests proving the match works for Apple/Tidal/YT Music (provider-prefixed vs MA content_id) and that Phase-1-timeout art capture is honored. Spotify and Deezer paths covered too. The bare-ID extraction is a generic last-path-segment heuristic — robust for all current providers but assumes the ID is the final segment.

## Test plan
- `python3 -m pytest` — 965 passed, 2 skipped
- `ruff check .` clean; `ruff format --check` clean; `mypy` clean
- New: `TestUriMatchTokens` (5 providers + YT query-param stripping + empty), `TestWaitForMetadataUpdateCrossProvider` (content_id match for Apple/Tidal/YT with unchanged title so only the content_id path can match; Phase-1-timeout-returns-captured-art).

## Risk assessment
- **Blast radius:** `wait_for_metadata_update` confirmation path only; `get_metadata`/`_extract_metadata`/`_convert_uri_for_ma` untouched.
- **What could go wrong:** if a future provider's MA `content_id` does NOT contain the bare track ID nor the converted URI, match would fall through to the (still-present) title-changed heuristic — same or better than before.
- **What I did NOT test:** live MA hardware round against real Apple/Tidal/YT speakers.

🤖 Auto-generated by issue-triage routine