### PR TITLE
fix: validate no-playable-songs before mutating state in create_game (#1378)

### DIFF
--- a/custom_components/beatify/game/state_setup.py
+++ b/custom_components/beatify/game/state_setup.py
@@ -153,6 +153,36 @@ class GameSetupMixin:
                 f"and {ROUND_DURATION_MAX} seconds"
             )
 
+        # #1378: validate BEFORE mutating any state. Building the
+        # PlaylistManager and running the #709 no-playable-songs check first —
+        # into locals, touching nothing on self — means a validation failure
+        # leaves GameState completely untouched (game_id stays None, phase
+        # unchanged, players intact). Otherwise the host hits a zombie
+        # zero-song LOBBY that the create-handler's existing-game guard
+        # (#935) then rejects with 409 on every retry.
+        #
+        # #808 follow-up: detect the user's Apple Music storefront from
+        # HA's configured country. Beatify's playlists carry per-region
+        # Apple Music URIs; PlaylistManager uses this to pick the right
+        # one and to filter out songs explicitly unavailable in this
+        # region. Lower-case to match the storefront codes used by
+        # Apple's API ("us", "de", "gb", ...). None when HA doesn't have
+        # a country configured → falls back to the legacy single URI.
+        # _detect_storefront is read-only, so it is safe to run pre-mutation.
+        storefront = self._detect_storefront()
+
+        # Initialize PlaylistManager for song selection (Epic 4, Story 17.2: with provider)
+        playlist_manager = PlaylistManager(songs, provider, storefront=storefront)
+
+        # #709: if the chosen provider has zero playable songs, fail fast with
+        # a clear error rather than silently starting a game that will stall.
+        if not playlist_manager.has_playable_songs():
+            raise ValueError(
+                f"No playable songs for provider '{provider}' in the selected "
+                f"playlist(s). Pick a different playlist or provider."
+            )
+
+        # Validation passed — now it is safe to mutate game state.
         # Clear any leftover sessions from previous/crashed game (Story 11.6)
         self.clear_all_sessions()
 
@@ -174,30 +204,12 @@ class GameSetupMixin:
         # Store platform for playback routing
         self.platform = platform
 
-        # #808 follow-up: detect the user's Apple Music storefront from
-        # HA's configured country. Beatify's playlists carry per-region
-        # Apple Music URIs; PlaylistManager uses this to pick the right
-        # one and to filter out songs explicitly unavailable in this
-        # region. Lower-case to match the storefront codes used by
-        # Apple's API ("us", "de", "gb", ...). None when HA doesn't have
-        # a country configured → falls back to the legacy single URI.
-        self.storefront = self._detect_storefront()
+        self.storefront = storefront
 
         # Reset error detail
         self.last_error_detail = ""
 
-        # Initialize PlaylistManager for song selection (Epic 4, Story 17.2: with provider)
-        self._playlist_manager = PlaylistManager(
-            songs, provider, storefront=self.storefront
-        )
-
-        # #709: if the chosen provider has zero playable songs, fail fast with
-        # a clear error rather than silently starting a game that will stall.
-        if not self._playlist_manager.has_playable_songs():
-            raise ValueError(
-                f"No playable songs for provider '{provider}' in the selected "
-                f"playlist(s). Pick a different playlist or provider."
-            )
+        self._playlist_manager = playlist_manager
 
         # Reset round tracking for new game
         self.round = 0

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -113,6 +113,65 @@ class TestCreateGame:
         assert state.total_rounds == 10
 
 
+class TestCreateGameNoPlayableSongsAtomicity:
+    """#1378: the #709 no-playable-songs check must run BEFORE any mutation.
+
+    make_songs() yields Spotify-only URIs, so requesting provider
+    "apple_music" leaves zero playable songs and create_game must raise
+    ValueError without leaving GameState half-built (game_id minted, phase
+    flipped to LOBBY, players wiped) — otherwise the host is dead-ended by
+    the create-handler's existing-game guard (#935) on every retry.
+    """
+
+    def test_raises_for_no_playable_songs(self):
+        state = make_game_state()
+        with pytest.raises(ValueError, match="No playable songs"):
+            _create_fresh_game(state, provider="apple_music")
+
+    def test_game_id_not_minted_on_validation_failure(self):
+        state = make_game_state()
+        assert state.game_id is None
+        with pytest.raises(ValueError, match="No playable songs"):
+            _create_fresh_game(state, provider="apple_music")
+        assert state.game_id is None
+
+    def test_set_phase_not_invoked_on_validation_failure(self):
+        # A fresh GameState already defaults to LOBBY, so asserting on the
+        # final phase value can't distinguish "never touched" from "flipped".
+        # Assert the _set_phase chokepoint is never called instead.
+        state = make_game_state()
+        with patch.object(state, "_set_phase", wraps=state._set_phase) as set_phase:
+            with pytest.raises(ValueError, match="No playable songs"):
+                _create_fresh_game(state, provider="apple_music")
+        set_phase.assert_not_called()
+
+    def test_players_not_wiped_on_validation_failure(self):
+        state = make_game_state()
+        # Seed a real lobby with a player (the "existing game" scenario).
+        _create_fresh_game(state)
+        state.add_player("Alice", MagicMock())
+        good_game_id = state.game_id
+        assert len(state.players) == 1
+
+        # A failed create attempt (bad provider) must NOT wipe the existing
+        # game's players, game_id, or phase.
+        with pytest.raises(ValueError, match="No playable songs"):
+            _create_fresh_game(state, provider="apple_music")
+        assert len(state.players) == 1
+        assert state.game_id == good_game_id
+        assert state.phase == GamePhase.LOBBY
+
+    def test_retry_with_valid_provider_succeeds_after_failure(self):
+        state = make_game_state()
+        with pytest.raises(ValueError, match="No playable songs"):
+            _create_fresh_game(state, provider="apple_music")
+        # Pre-mutation validation means retrying with a working provider just
+        # works — no zombie lobby blocking it.
+        result = _create_fresh_game(state, provider="spotify")
+        assert result["game_id"] is not None
+        assert state.phase == GamePhase.LOBBY
+
+
 # ---------------------------------------------------------------------------
 # REVEAL auto-advance (#1012)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #1378

## Root cause
`create_game` minted `game_id`/`admin_token`, called `_set_phase(LOBBY)`, and wiped `self.players` **before** building the PlaylistManager and running the #709 `has_playable_songs()` check. When that check raised `ValueError`, the exception propagated as a 400 but left `GameState` half-built: `game_id` non-None, phase `LOBBY`, zero playable songs. The create handler's existing-game guard (#935) then returned 409 `GAME_IN_LOBBY` on every retry, dead-ending the host.

## Fix
Validate before mutating. `_detect_storefront()` is read-only, so storefront detection, the `PlaylistManager` construction, and the #709 check now run into locals (`storefront`, `playlist_manager`) and touch nothing on `self`. Only after the check passes does `create_game` start assigning `game_id`/phase/players, then bind `self.storefront`/`self._playlist_manager` from the locals. A failed create now leaves an existing game fully intact and lets the host immediately retry with a different playlist or provider.

## Readiness assessment
- [x] Ready to merge
- [ ] Borderline — see notes
- [ ] Not ready — needs human review

**Honest summary:** Minimal reorder — no behavior change on the success path (same assignments, same order relative to each other), only the validation moved ahead of mutation. Storefront detection is read-only so it is safe to run early. Backend-only, no UI surface.

## Test plan
- New `TestCreateGameNoPlayableSongsAtomicity` (5 tests): provider `apple_music` against Spotify-only songs raises `No playable songs`, and proves `game_id` stays None, `_set_phase` is never called, an existing game's players/game_id/phase survive a failed attempt, and a retry with a working provider succeeds.
- Full suite: 959 passed, 2 skipped.

## Risk assessment
- **Blast radius:** `custom_components/beatify/game/state_setup.py` (`create_game` only) + `tests/unit/test_state.py`.
- **What could go wrong:** Low. The only ordering shift is `clear_all_sessions()` now runs after validation instead of before — desirable, since a failed create no longer clears the previous session.
- **What I did NOT test:** End-to-end HTTP create flow against a live HA instance (covered by unit-level state assertions).

## Gates
- pytest: 959 passed, 2 skipped
- ruff check + ruff format --check: clean
- mypy 1.18.2 (scoped CI config): no issues

🤖 Auto-generated by issue-triage routine