### PR TITLE
fix: make _get_ma_uri_candidates storefront-aware (#1379)

### DIFF
--- a/custom_components/beatify/services/media_player.py
+++ b/custom_components/beatify/services/media_player.py
@@ -401,9 +401,17 @@ class MediaPlayerService:
         the user said "Apple Music only" just buys 15s timeouts per
         unsupported provider before MA reports `MediaNotFoundError`.
 
-        Order: previously-successful field (if any) first, then the user's
-        selected URI (`_resolved_uri`), then any remaining provider URI
-        fields. URIs are converted for MA and deduped by their converted form.
+        Order: the user's selected URI (`_resolved_uri`, storefront-resolved by
+        the caller) ALWAYS first, then the previously-successful field (if any),
+        then any remaining provider URI fields. URIs are converted for MA and
+        deduped by their converted form.
+
+        For apple_music, the legacy `uri_apple_music` field (a single,
+        historically US-storefront ID) is dropped from the alternates whenever
+        the song carries a `uri_apple_music_by_region` map — otherwise a non-US
+        user would re-pay the wrong-storefront timeout #808 eliminated, and a
+        cross-storefront-lucky US hit could become the learned preferred field
+        and bypass region-correct resolution for the rest of the session (#1379).
 
         Returns:
             List of `(field_name, converted_uri)`. `field_name` is `None` for
@@ -441,21 +449,45 @@ class MediaPlayerService:
             seen.add(converted)
             candidates.append((field, converted))
 
+        # #1379: storefront-unaware fallback guard. For apple_music, the legacy
+        # `uri_apple_music` field holds a single (historically US-storefront)
+        # track ID. The caller (`get_song_uri`) already resolves `_resolved_uri`
+        # storefront-aware from `uri_apple_music_by_region` when that map exists.
+        # Appending the legacy US field as an alternate for a non-US user
+        # re-introduces exactly the wrong-storefront 15s stale-title timeout that
+        # #808 eliminated — and if that US ID ever resolves cross-storefront, it
+        # becomes the learned preferred field and systematically outranks the
+        # region-correct URI for the rest of the session. When a regional map is
+        # present, drop the legacy field entirely so only `_resolved_uri` (the
+        # region-correct ID, or None when unavailable) is tried.
+        skip_legacy_apple = self._provider == "apple_music" and bool(
+            song.get("uri_apple_music_by_region")
+        )
+
+        def _field_eligible(field: str) -> bool:
+            return not (skip_legacy_apple and field == "uri_apple_music")
+
+        # #1379: `_resolved_uri` is ALWAYS tried first — it is the URI Beatify
+        # resolved for the user's selected provider AND storefront. The learned
+        # preference must never outrank it (a US ID that resolved once must not
+        # systematically bypass storefront-correct resolution); the preference is
+        # used only to order the REMAINING alternates below.
+        _add(None, song.get("_resolved_uri"))
+
         # Learned preference — but only if it's a field belonging to the
         # current provider (the cache survives across games where provider
-        # may have changed).
+        # may have changed) and not a legacy field we're skipping for storefront
+        # reasons (#1379). Ordered ahead of the other alternates, behind primary.
         if (
             self._ma_preferred_uri_field
             and self._ma_preferred_uri_field in provider_fields
+            and _field_eligible(self._ma_preferred_uri_field)
         ):
             _add(self._ma_preferred_uri_field, song.get(self._ma_preferred_uri_field))
 
-        # Primary: the URI Beatify picked based on the user's selected provider.
-        _add(None, song.get("_resolved_uri"))
-
         # Remaining alternates within the same provider.
         for field in provider_fields:
-            if field != self._ma_preferred_uri_field:
+            if field != self._ma_preferred_uri_field and _field_eligible(field):
                 _add(field, song.get(field))
 
         return candidates

--- a/tests/unit/test_media_player.py
+++ b/tests/unit/test_media_player.py
@@ -832,7 +832,12 @@ class TestMAProviderFallback:
         assert candidates[0][1] == "deezer://track/12345"
 
     def test_candidates_learned_preference_within_same_provider(self):
-        """Cached preferred field is honored when it belongs to current provider."""
+        """Cached preferred field is honored, but ordered behind `_resolved_uri`.
+
+        #1379: `_resolved_uri` is the storefront-resolved primary and must
+        ALWAYS be tried first; the learned preference only orders the remaining
+        alternates (here the legacy `uri` field), so it comes right after.
+        """
         hass = _make_hass()
         svc = MediaPlayerService(
             hass,
@@ -848,10 +853,10 @@ class TestMAProviderFallback:
             "_resolved_uri": "spotify:track:canonical",
         }
         candidates = svc._get_ma_uri_candidates(song)
-        # Cached field's URI is first (before _resolved_uri).
-        assert candidates[0] == ("uri", "spotify:track:legacy")
-        # Primary still present after.
-        assert (None, "spotify:track:canonical") in candidates
+        # Primary (`_resolved_uri`) is always first.
+        assert candidates[0] == (None, "spotify:track:canonical")
+        # Cached field is ordered ahead of the other alternates, behind primary.
+        assert candidates[1] == ("uri", "spotify:track:legacy")
 
     def test_candidates_learned_preference_ignored_across_providers(self):
         """Cached preferred field from a different provider is not honored.
@@ -883,6 +888,72 @@ class TestMAProviderFallback:
         hass = _make_hass()
         svc = MediaPlayerService(hass, "media_player.test", platform="music_assistant")
         assert svc._get_ma_uri_candidates({"title": "x", "artist": "y"}) == []
+
+    def test_candidates_skip_legacy_us_field_when_regional_map_present(self):
+        """#1379: non-US Apple-Music user must NOT get the legacy US ID appended.
+
+        The song carries `uri_apple_music_by_region` (so `get_song_uri` already
+        resolved `_resolved_uri` storefront-aware to the DE track). The legacy
+        `uri_apple_music` field holds the wrong-storefront US ID and must be
+        dropped — appending it re-introduces the #808 wrong-storefront timeout.
+        """
+        hass = _make_hass()
+        svc = MediaPlayerService(
+            hass,
+            "media_player.test",
+            platform="music_assistant",
+            provider="apple_music",
+        )
+        song = {
+            "uri_apple_music": "applemusic://track/US111",  # legacy US ID
+            "uri_apple_music_by_region": {"de": "applemusic://track/DE222"},
+            "_resolved_uri": "applemusic://track/DE222",  # DE-resolved
+        }
+        uris = [uri for _, uri in svc._get_ma_uri_candidates(song)]
+        # Only the storefront-resolved DE URI is tried; the US legacy ID is gone.
+        assert uris == ["apple_music://track/DE222"]
+        assert "apple_music://track/US111" not in uris
+
+    def test_candidates_legacy_field_kept_without_regional_map(self):
+        """#1379: with no regional map, the legacy field is still a valid
+        alternate (storefront resolution doesn't apply — single-URI playlist).
+        """
+        hass = _make_hass()
+        svc = MediaPlayerService(
+            hass,
+            "media_player.test",
+            platform="music_assistant",
+            provider="apple_music",
+        )
+        song = {
+            "uri_apple_music": "applemusic://track/111",
+            "_resolved_uri": "applemusic://track/111",
+        }
+        uris = [uri for _, uri in svc._get_ma_uri_candidates(song)]
+        assert uris == ["apple_music://track/111"]
+
+    def test_candidates_learned_us_field_never_outranks_resolved_uri(self):
+        """#1379 core: even with `uri_apple_music` learned as preferred, it must
+        not be ordered ahead of the storefront-resolved `_resolved_uri`, and for
+        a song with a regional map it must not appear at all.
+        """
+        hass = _make_hass()
+        svc = MediaPlayerService(
+            hass,
+            "media_player.test",
+            platform="music_assistant",
+            provider="apple_music",
+        )
+        # A prior song without a regional map "learned" the legacy US field.
+        svc._ma_preferred_uri_field = "uri_apple_music"
+        song = {
+            "uri_apple_music": "applemusic://track/US111",  # wrong storefront
+            "uri_apple_music_by_region": {"de": "applemusic://track/DE222"},
+            "_resolved_uri": "applemusic://track/DE222",  # DE-resolved
+        }
+        candidates = svc._get_ma_uri_candidates(song)
+        # Storefront-resolved URI first; learned US field dropped entirely.
+        assert candidates == [(None, "apple_music://track/DE222")]
 
     def test_candidates_unknown_provider_warns_and_falls_back(self, caplog):
         """#1276: an unmapped provider logs a warning and falls back to _resolved_uri.
@@ -1029,8 +1100,15 @@ class TestMAProviderFallback:
         assert svc._ma_preferred_uri_field is None
 
     @pytest.mark.asyncio
-    async def test_learned_preference_used_on_next_song(self):
-        """Within Spotify: after legacy `uri` succeeds, next song tries it first."""
+    async def test_learned_preference_orders_alternates_behind_primary(self):
+        """Within Spotify: after legacy `uri` succeeds, it's learned and ordered
+        ahead of OTHER alternates on the next song — but #1379 keeps the
+        storefront-resolved `_resolved_uri` primary tried first regardless.
+
+        Here `song_b` has a third distinct alternate (`uri_spotify` ==
+        `_resolved_uri` is the primary; legacy `uri` is the learned alternate).
+        The learned legacy field must come right after the primary.
+        """
         hass = _make_hass()
         svc = MediaPlayerService(
             hass,
@@ -1063,11 +1141,14 @@ class TestMAProviderFallback:
             assert await svc._play_via_music_assistant(song_a) is True
             assert await svc._play_via_music_assistant(song_b) is True
 
-        # Song A: canonical fails, legacy succeeds (2 calls)
-        # Song B: legacy tried first (cached), succeeds (1 call)
+        # Song A: canonical (primary) fails, legacy succeeds → learns "uri".
+        # Song B: #1379 — primary `_resolved_uri` is STILL tried first (fails),
+        #   then the learned legacy field (succeeds). The learned preference no
+        #   longer skips the storefront-resolved primary.
         assert calls == [
             "spotify:track:a-canonical",
             "spotify:track:a-legacy",
+            "spotify:track:b-canonical",
             "spotify:track:b-legacy",
         ]
 


### PR DESCRIPTION
Closes #1379

## Root cause
`_get_ma_uri_candidates` (`custom_components/beatify/services/media_player.py`) was storefront-unaware. For apple_music it appended the raw legacy `uri_apple_music` (a single, historically US-storefront ID) as an alternate even when the song carried a `uri_apple_music_by_region` map — so a non-US user re-paid the wrong-storefront 15s stale-title timeout that #808 eliminated, on every song whose regional URI failed. Worse, if that US ID ever resolved cross-storefront once, it became the learned `_ma_preferred_uri_field` and was ordered FIRST for all subsequent songs (ahead of the storefront-resolved `_resolved_uri`), systematically bypassing region-correct resolution for the rest of the session.

## Fix
`_get_ma_uri_candidates` only (no other functions/files touched):
- **`_resolved_uri` is ALWAYS tried first.** The learned `_ma_preferred_uri_field` now only orders the *remaining* alternates — it can never outrank the storefront-resolved primary.
- **Legacy `uri_apple_music` is dropped** from the candidate list (including when it's the learned preferred field) whenever `self._provider == "apple_music"` AND the song carries a non-empty `uri_apple_music_by_region` map. Without a regional map (single-URI playlists) the legacy field is still a valid alternate.

## Readiness assessment
- [x] Ready to merge
- [ ] Borderline — see notes
- [ ] Not ready — needs human review

**Honest summary:** Tightly scoped to the #1379 root cause inside one function. The storefront signal is derived from `self._provider` + the song's own `uri_apple_music_by_region` map (already on the dict the caller passes), so no new plumbing/state. Behavior change is intentional and asserted by tests: the learned preference no longer skips the primary.

## Test plan
- Unit: `tests/unit/test_media_player.py` — added 3 tests (legacy US field dropped when regional map present; legacy kept without a regional map; learned US field never outranks/reintroduces ahead of `_resolved_uri`). Updated 2 tests that asserted the old "preferred before primary" ordering.
- Full suite: `python3 -m pytest` → 957 passed, 2 skipped.
- Gates: `ruff check .` clean, `ruff format --check .` clean, `mypy` (config-driven, 15 files) clean.

## Risk assessment
- **Blast radius:** `_get_ma_uri_candidates` ordering/eligibility only. All MA playback flows through it.
- **What could go wrong:** ordering change means an apple_music song that *only* resolved via the legacy US field (no regional map, learned preference) now tries `_resolved_uri` first — but for that song `_resolved_uri == uri_apple_music` (same value, deduped), so no extra attempt. Songs WITH a regional map intentionally lose the US fallback (that's the bug).
- **What I did NOT test:** live MA round against a real non-US Apple Music storefront (env can't reach MA).

## Parallel-resolver note (merge sequencing)
Per the run brief, #1380 and #1381 may also touch Music-Assistant playback-recovery code. **This PR changes only `_get_ma_uri_candidates` in `custom_components/beatify/services/media_player.py`** (plus `tests/unit/test_media_player.py`). If a sibling PR edits the same function or the candidate-ordering tests, sequence/rebase accordingly.

🤖 Auto-generated by issue-triage routine