### PR TITLE
fix: gate fast-path Path 2 with title/artist similarity (#1381)

### DIFF
--- a/custom_components/beatify/services/media_player.py
+++ b/custom_components/beatify/services/media_player.py
@@ -101,6 +101,62 @@ PLAYBACK_TIMEOUT = 8.0
 # advanced before the track had actually swapped on the speaker.
 MA_PLAYBACK_TIMEOUT = 15.0
 
+# #1381: Fast-path Path 2 (title-advanced-without-exact-match) must not
+# instant-accept an *arbitrary* title change. If a requested URI fails to
+# resolve in MA while the speaker's prior queue naturally auto-advances to its
+# next track within the wait window, the title changes to an unrelated song and
+# the old code confirmed it as success in ~1s — silently running a round whose
+# audio is the wrong track (the #795 failure class). Path 2 now requires cheap
+# evidence that the new title is plausibly OUR track: either a token overlap
+# with the expected title (remaster/translation tolerance, e.g. "Das Modell"
+# vs "The Model" share no tokens but the artist matches) OR the expected artist
+# appearing in the speaker's media_artist. The unbounded "any new title"
+# acceptance is reserved for the post-timeout #345 branch, where it is logged.
+_TITLE_TOKEN_MIN_LEN = 3
+
+
+def _normalize_for_match(text: str) -> str:
+    """Lower-case and strip non-alphanumeric to ASCII-ish tokens for matching."""
+    return "".join(c if c.isalnum() else " " for c in text.lower())
+
+
+def _title_tokens(text: str) -> set[str]:
+    """Significant word tokens of a title (drops short noise words/suffixes)."""
+    return {
+        tok
+        for tok in _normalize_for_match(text).split()
+        if len(tok) >= _TITLE_TOKEN_MIN_LEN
+    }
+
+
+def _titles_plausibly_match(expected_title: str, current_title: str) -> bool:
+    """Cheap similarity gate for fast-path Path 2 (#1381).
+
+    True when the two titles share at least one significant token, or one
+    normalized title is a prefix of the other (covers "(Remastered)" suffixes
+    and minor punctuation differences). False for genuinely unrelated titles
+    (e.g. the prior queue auto-advancing to a different song).
+    """
+    exp_norm = _normalize_for_match(expected_title).strip()
+    cur_norm = _normalize_for_match(current_title).strip()
+    if not exp_norm or not cur_norm:
+        return False
+    if cur_norm.startswith(exp_norm) or exp_norm.startswith(cur_norm):
+        return True
+    return bool(_title_tokens(expected_title) & _title_tokens(current_title))
+
+
+def _artist_matches(expected_artist: str, media_artist: str) -> bool:
+    """True when the expected artist is plausibly present in media_artist (#1381)."""
+    exp = _normalize_for_match(expected_artist).strip()
+    cur = _normalize_for_match(media_artist).strip()
+    if not exp or not cur:
+        return False
+    if exp in cur or cur in exp:
+        return True
+    return bool(_title_tokens(expected_artist) & _title_tokens(media_artist))
+
+
 # Timeout for waiting for metadata to update after playing (seconds)
 # Wait up to 2s for MA to push fresh metadata (album art, etc.) after a
 # playback transition. Reduced from 5s — that earlier value was the
@@ -207,6 +263,11 @@ class MediaPlayerService:
         # candidate list so subsequent songs don't pay the primary-attempt
         # timeout on every round (#768).
         self._ma_preferred_uri_field: str | None = None
+        # #1381: which acceptance path confirmed the most recent successful
+        # _try_ma_play. 1 = expected-title substring (Path 1, strongest), 2 =
+        # similarity/artist gate (Path 2), 0 = post-timeout #345 tolerance.
+        # Only Path 1 is strong enough to promote a URI field to preferred.
+        self._last_confirm_path: int = 0
         # #808 follow-up: classify the most recent failure mode so the
         # caller (game/state.py:start_round) can decide whether to count
         # this against MAX_SONG_RETRIES (real failure) or skip silently
@@ -492,6 +553,7 @@ class MediaPlayerService:
             return False
 
         expected_title = song.get("title") or ""
+        expected_artist = song.get("artist") or ""
         if not expected_title:
             _LOGGER.warning(
                 "MA playback: no expected title — skipping title verification"
@@ -505,9 +567,20 @@ class MediaPlayerService:
                     len(candidates),
                     uri,
                 )
-            success = await self._try_ma_play(uri, expected_title)
+            success = await self._try_ma_play(uri, expected_title, expected_artist)
             if success:
-                if field and field != self._ma_preferred_uri_field:
+                # #1381: only learn a candidate's URI field as the new preferred
+                # one when an EXPECTED-TITLE substring match (Path 1) confirmed
+                # it. A weaker confirmation (artist/token gate, or the
+                # post-timeout #345 tolerance) is not strong enough proof that
+                # THIS field actually resolved our track — promoting it would
+                # reorder future candidates wrongly for a field that never
+                # really worked.
+                if (
+                    field
+                    and field != self._ma_preferred_uri_field
+                    and self._last_confirm_path == 1
+                ):
                     _LOGGER.debug("MA preferred URI field now: %s (#768)", field)
                     self._ma_preferred_uri_field = field
                 self.last_failure_reason = None
@@ -523,7 +596,9 @@ class MediaPlayerService:
         # _try_ma_play attempt (set by that method); start_round reads it.
         return False
 
-    async def _try_ma_play(self, uri: str, expected_title: str) -> bool:
+    async def _try_ma_play(
+        self, uri: str, expected_title: str, expected_artist: str = ""
+    ) -> bool:
         """
         Attempt a single MA `play_media` call and wait for playback confirmation.
 
@@ -532,6 +607,10 @@ class MediaPlayerService:
         URI. Returns True both when playback is confirmed AND when the speaker
         is showing ambiguous-but-changing state (MA may still be buffering —
         preserving the #345 tolerance so we don't chase flaky retries).
+
+        `expected_artist` (#1381) feeds the fast-path Path 2 similarity gate so
+        an arbitrary title change from the prior queue auto-advancing is not
+        instant-accepted as our track.
         """
         _LOGGER.debug("MA playback: %s on %s", uri, self._entity_id)
 
@@ -584,8 +663,9 @@ class MediaPlayerService:
 
             Two acceptance paths:
               1. Title contains expected (substring) — the strongest signal.
-              2. Title moved to ANYTHING different from before the call — MA
-                 is making progress on a new track, accept it.
+              2. Title moved to a *plausibly-our-track* new title — MA is
+                 making progress on a new track that shares a token with the
+                 expected title, or whose artist matches the expected artist.
 
             Path 2 was previously only reachable via the 15-second slow-buffer
             tolerance below. Levtos reported that pressing "next" caused the
@@ -596,6 +676,17 @@ class MediaPlayerService:
             the wait timed out. With path 2 in the fast-path, the UI now
             returns within ~1s of MA actually starting playback.
 
+            #1381 tightened Path 2: it used to accept ANY title that differed
+            from `title_before`. If the requested URI failed to resolve in MA
+            while the speaker's prior queue auto-advanced to its next track
+            during the 15s window, that unrelated title was instant-confirmed
+            as success — the #795 "guess the year of SongX with no SongX audio"
+            class, but silently. Path 2 now requires a cheap similarity gate
+            (token overlap / normalized-prefix vs expected_title, OR expected
+            artist present in media_artist). The unbounded "any new title"
+            acceptance is reserved for the post-timeout #345 branch, where it
+            is logged.
+
             #795 invariant still holds: if the title is unchanged from
             before the call (`title_before`), neither path fires and we
             fall through to the title-must-advance hard-failure check.
@@ -604,23 +695,34 @@ class MediaPlayerService:
                 return False
             try:
                 current_title = state.attributes.get("media_title", "") or ""
+                current_artist = state.attributes.get("media_artist", "") or ""
                 position_updated = state.attributes.get("media_position_updated_at")
 
                 position_fresh = position_updated != position_updated_before
                 if not position_fresh:
                     return False
 
-                # Path 1: exact-ish title match (substring).
+                # Path 1: exact-ish title match (substring) — strongest signal,
+                # the only path strong enough to learn a preferred URI field.
                 if expected_lower and expected_lower in current_title.lower():
+                    self._last_confirm_path = 1
                     return True
                 # If no expected title was supplied, position-fresh alone is
                 # all the signal we have — accept (matches old behavior).
                 if not expected_lower:
+                    self._last_confirm_path = 2
                     return True
 
-                # Path 2: title moved to something different from before.
+                # Path 2 (#1381): title moved to a DIFFERENT title AND that
+                # title is plausibly our track (shared token / prefix) OR the
+                # artist matches. A bare "any different title" no longer
+                # qualifies — that is the prior-queue auto-advance trap.
                 if current_title and current_title != title_before:
-                    return True
+                    if _titles_plausibly_match(
+                        expected_title, current_title
+                    ) or _artist_matches(expected_artist, current_artist):
+                        self._last_confirm_path = 2
+                        return True
 
                 return False
             except (AttributeError, KeyError):
@@ -796,6 +898,10 @@ class MediaPlayerService:
             title_before,
             title_after,
         )
+        # #1381: a post-timeout #345 tolerance confirmation is the weakest
+        # acceptance — it must NOT promote this candidate's URI field to
+        # preferred (it never proved THIS field actually resolved our track).
+        self._last_confirm_path = 0
         return True
 
     async def _play_via_sonos(self, song: dict[str, Any]) -> bool:

--- a/tests/unit/test_media_player.py
+++ b/tests/unit/test_media_player.py
@@ -635,6 +635,199 @@ class TestMANonBlockingPlayback:
 
         assert result is True
 
+    @pytest.mark.asyncio
+    async def test_fast_path_rejects_unrelated_auto_advance_title(self):
+        """#1381: the requested URI fails to resolve in MA, but the speaker's
+        prior queue naturally auto-advances to its NEXT track within the wait
+        window. The new title is unrelated (different song, different artist),
+        so fast-path Path 2 must NOT instant-confirm it as our track.
+
+        The old code accepted ANY title != title_before with fresh position →
+        a round ran with the wrong audio, silently (the #795 failure class).
+        """
+        before = _make_state(
+            "playing",
+            media_title="Bohemian Rhapsody",
+            media_position=120,
+            media_position_updated_at="2020-01-01T00:00:00+00:00",
+        )
+        # Prior queue auto-advanced to its own next track — unrelated to ours.
+        auto_advanced = _make_state(
+            "playing",
+            media_title="Another One Bites the Dust",
+            media_position=2,
+            media_position_updated_at="2020-01-01T00:00:01+00:00",  # fresh
+        )
+        auto_advanced.attributes["media_artist"] = "Queen"
+
+        hass = _make_hass("playing", media_title="Bohemian Rhapsody")
+        svc = MediaPlayerService(hass, "media_player.test", platform="music_assistant")
+
+        call_count = 0
+
+        def progression(*_args):
+            nonlocal call_count
+            call_count += 1
+            return before if call_count <= 1 else auto_advanced
+
+        hass.states.get = MagicMock(side_effect=progression)
+
+        # No state-change events fire; force the wait to time out instantly so
+        # the test does not block for MA_PLAYBACK_TIMEOUT.
+        async def _instant_timeout(awaitable=None, *_a, **_k):
+            if awaitable is not None and asyncio.iscoroutine(awaitable):
+                awaitable.close()  # don't leak an un-awaited coroutine
+            raise asyncio.TimeoutError
+
+        with patch(
+            "custom_components.beatify.services.media_player.asyncio.wait_for",
+            new=_instant_timeout,
+        ):
+            confirmed = await svc._try_ma_play(
+                "spotify:track:our-song", "Sweet Child O' Mine", "Guns N' Roses"
+            )
+
+        # The fast-path (Path 2) must NOT have confirmed this unrelated track.
+        # (It falls through to the post-timeout #345 tolerance, path 0.)
+        assert svc._last_confirm_path != 2
+        # And whatever the final outcome, an unrelated auto-advance must never
+        # be learned as a working URI field.
+        assert confirmed is True  # #345 tolerance still returns True post-timeout
+        assert svc._last_confirm_path == 0
+
+    @pytest.mark.asyncio
+    async def test_fast_path_accepts_title_token_overlap(self):
+        """#1381: a punctuation/word-order mismatch where the exact substring
+        (Path 1) fails but the titles share a significant token must still
+        fast-path confirm via Path 2's similarity gate. Expected
+        "Sweet Child O' Mine" vs MA's "Sweet Child o Mine (Remaster)" — the
+        apostrophe/casing breaks the substring, tokens still overlap."""
+        before = _make_state(
+            "playing",
+            media_title="Old Track",
+            media_position=120,
+            media_position_updated_at="2020-01-01T00:00:00+00:00",
+        )
+        current = _make_state(
+            "playing",
+            media_title="Sweet Child o Mine (Remaster)",
+            media_position=2,
+            media_position_updated_at="2020-01-01T00:00:01+00:00",
+        )
+        current.attributes["media_artist"] = "Some Cover Artist"
+
+        hass = _make_hass("playing", media_title="Old Track")
+        svc = MediaPlayerService(hass, "media_player.test", platform="music_assistant")
+        hass.states.get = MagicMock(side_effect=[before, current])
+
+        confirmed = await svc._try_ma_play(
+            "spotify:track:x", "Sweet Child O' Mine", "Different Artist"
+        )
+
+        assert confirmed is True
+        assert svc._last_confirm_path == 2
+
+    @pytest.mark.asyncio
+    async def test_fast_path_accepts_artist_match_on_title_mismatch(self):
+        """#1381: 'Das Modell' vs MA's 'The Model' share no title token, but the
+        expected artist matches media_artist → Path 2 confirms (Levtos case)."""
+        before = _make_state(
+            "playing",
+            media_title="Manhattan Skyline",
+            media_position=120,
+            media_position_updated_at="2020-01-01T00:00:00+00:00",
+        )
+        current = _make_state(
+            "playing",
+            media_title="The Model",
+            media_position=2,
+            media_position_updated_at="2020-01-01T00:00:01+00:00",
+        )
+        current.attributes["media_artist"] = "Kraftwerk"
+
+        hass = _make_hass("playing", media_title="Manhattan Skyline")
+        svc = MediaPlayerService(hass, "media_player.test", platform="music_assistant")
+        hass.states.get = MagicMock(side_effect=[before, current])
+
+        confirmed = await svc._try_ma_play("spotify:track:x", "Das Modell", "Kraftwerk")
+
+        assert confirmed is True
+        assert svc._last_confirm_path == 2
+
+    @pytest.mark.asyncio
+    async def test_preferred_uri_field_not_learned_on_path2_confirmation(self):
+        """#1381: a fallback candidate that only confirmed via Path 2 (weaker
+        similarity gate, not an expected-title substring) must NOT be promoted
+        to _ma_preferred_uri_field — doing so reorders future candidates wrongly
+        for a field that never proved it resolved our track."""
+        hass = _make_hass()
+        svc = MediaPlayerService(
+            hass,
+            "media_player.test",
+            platform="music_assistant",
+            provider="spotify",
+        )
+        song = {
+            "title": "Song",
+            "artist": "Artist",
+            "uri": "spotify:track:legacy",
+            "uri_spotify": "spotify:track:canonical",
+            "_resolved_uri": "spotify:track:canonical",
+        }
+
+        async def fake_try(
+            uri: str, expected_title: str, expected_artist: str = ""
+        ) -> bool:
+            ok = uri == "spotify:track:legacy"
+            if ok:
+                svc._last_confirm_path = 2  # weak (similarity-gate) confirmation
+            return ok
+
+        with patch.object(svc, "_try_ma_play", side_effect=fake_try):
+            result = await svc._play_via_music_assistant(song)
+
+        assert result is True
+        # Path-2-only confirmation must not learn the field.
+        assert svc._ma_preferred_uri_field is None
+
+
+class TestTitleSimilarityGate:
+    """#1381: unit tests for the fast-path Path 2 similarity helpers."""
+
+    def test_token_overlap_matches_suffix(self):
+        from custom_components.beatify.services.media_player import (
+            _titles_plausibly_match,
+        )
+
+        assert _titles_plausibly_match("Hallelujah", "Hallelujah - Live")
+        assert _titles_plausibly_match("Sweet Child O' Mine", "Sweet Child o Mine")
+
+    def test_prefix_matches_remaster_suffix(self):
+        from custom_components.beatify.services.media_player import (
+            _titles_plausibly_match,
+        )
+
+        assert _titles_plausibly_match("Africa", "Africa (Remastered 2020)")
+
+    def test_unrelated_titles_do_not_match(self):
+        from custom_components.beatify.services.media_player import (
+            _titles_plausibly_match,
+        )
+
+        assert not _titles_plausibly_match(
+            "Sweet Child O' Mine", "Another One Bites the Dust"
+        )
+        # Short noise words alone never bridge two unrelated titles.
+        assert not _titles_plausibly_match("Go", "No")
+
+    def test_artist_match_helper(self):
+        from custom_components.beatify.services.media_player import _artist_matches
+
+        assert _artist_matches("Kraftwerk", "Kraftwerk")
+        assert _artist_matches("The Beatles", "Beatles")
+        assert not _artist_matches("Queen", "Guns N' Roses")
+        assert not _artist_matches("", "Queen")
+
 
 class TestAvailabilityCheck:
     """Tests for is_available() used in state.py pre-flight."""
@@ -973,9 +1166,16 @@ class TestMAProviderFallback:
 
         calls: list[str] = []
 
-        async def fake_try(uri: str, expected_title: str) -> bool:
+        async def fake_try(
+            uri: str, expected_title: str, expected_artist: str = ""
+        ) -> bool:
             calls.append(uri)
-            return uri == "spotify:track:legacy"  # primary fails, legacy succeeds
+            ok = uri == "spotify:track:legacy"  # primary fails, legacy succeeds
+            if ok:
+                # Simulate a Path-1 (expected-title substring) confirmation —
+                # the only path strong enough to learn a preferred URI field.
+                svc._last_confirm_path = 1
+            return ok
 
         with patch.object(svc, "_try_ma_play", side_effect=fake_try):
             result = await svc._play_via_music_assistant(song)
@@ -1054,10 +1254,15 @@ class TestMAProviderFallback:
 
         calls: list[str] = []
 
-        async def fake_try(uri: str, expected_title: str) -> bool:
+        async def fake_try(
+            uri: str, expected_title: str, expected_artist: str = ""
+        ) -> bool:
             calls.append(uri)
             # Canonical never works in this user's setup; legacy always does.
-            return uri.endswith("-legacy")
+            ok = uri.endswith("-legacy")
+            if ok:
+                svc._last_confirm_path = 1  # Path-1 confirmation learns the field
+            return ok
 
         with patch.object(svc, "_try_ma_play", side_effect=fake_try):
             assert await svc._play_via_music_assistant(song_a) is True


### PR DESCRIPTION
Closes #1381

## Root cause
`_check_state` Path 2 in `custom_components/beatify/services/media_player.py` returned `True` whenever `media_title` became anything different from `title_before` with a fresh `media_position_updated_at`. When the requested URI fails to resolve in MA but the speaker's prior queue naturally auto-advances to its next track within the 15s window, that unrelated title was instant-confirmed as playback success in ~1s — silently running a round whose audio is the wrong track (the #795 "guess the year of SongX with no SongX audio" class). On a fallback candidate it also wrote `_ma_preferred_uri_field` for a field that never actually resolved our track, reordering future candidates wrongly.

## Fix
- **`_check_state` Path 2 now requires a cheap similarity gate** before instant-accept: the changed title must share a significant token with / be a normalized prefix of the expected title, OR the expected artist must appear in `media_artist`. The legitimate remaster/translated-title motivation (e.g. "Das Modell" → "The Model", artist matches) is preserved; arbitrary auto-advance titles are rejected.
- **The unbounded "any new title" acceptance is reserved for the post-timeout #345 branch**, where it remains logged.
- **`_ma_preferred_uri_field` is only promoted on a Path-1 (expected-title substring) confirmation** — a weak Path-2/timeout confirmation no longer learns a URI field. Tracked via a new `_last_confirm_path` instance attribute.

## Files changed (name functions)
- `custom_components/beatify/services/media_player.py` — new module helpers `_normalize_for_match`, `_title_tokens`, `_titles_plausibly_match`, `_artist_matches`; `_try_ma_play` gains an `expected_artist` param and its inner `_check_state` Path 2 gate + `_last_confirm_path` bookkeeping; `_play_via_music_assistant` threads `expected_artist` and gates the `_ma_preferred_uri_field` update on Path 1; `__init__` initializes `_last_confirm_path`.
- `tests/unit/test_media_player.py` — new regression tests + updated two stub signatures.

Net delta: +323 / −12 across 2 files.

> **Parallel-resolver note:** sibling issues #1379 and #1380 also touch Music-Assistant playback-recovery code in this same file (`services/media_player.py`). This change is scoped to the fast-path Path-2 confirmation (`_check_state`) + the `_ma_preferred_uri_field` learning gate only. Sequence overlapping merges accordingly.

## Readiness assessment
- [x] Ready to merge
- [ ] Borderline — see notes
- [ ] Not ready — needs human review

**Honest summary:** Backend-only, tightly scoped. The similarity gate is intentionally lenient (token-overlap OR artist-match) to preserve the existing remaster/translation tolerance while closing the unbounded-acceptance hole; it can still false-accept if the auto-advanced track happens to share a title token AND the gate fires, but that is far narrower than "any change". Existing #345 logged tolerance behaviour is unchanged.

## Test plan
- New unit tests in `tests/unit/test_media_player.py`:
  - `test_fast_path_rejects_unrelated_auto_advance_title` — unrelated auto-advance (different song + artist) is NOT Path-2 confirmed (`_last_confirm_path == 0`, falls through to logged #345 tolerance).
  - `test_fast_path_accepts_title_token_overlap` — punctuation/word-order mismatch with shared token still Path-2 confirms.
  - `test_fast_path_accepts_artist_match_on_title_mismatch` — "Das Modell"→"The Model" with matching artist still confirms.
  - `test_preferred_uri_field_not_learned_on_path2_confirmation` — a Path-2-only success does NOT promote `_ma_preferred_uri_field`.
  - `TestTitleSimilarityGate` — direct helper unit tests.
- Full suite: `962 passed, 2 skipped`. `ruff check .` + `ruff format --check .` clean (0.15.7). `mypy` (1.18.2) clean.

## Risk assessment
- **Blast radius:** MA playback confirmation fast-path only; Sonos/Alexa/Cast paths untouched.
- **What could go wrong:** an over-strict gate could regress the #803/#345 fast-path (UI lag) — mitigated by keeping artist-match + token-overlap + prefix acceptance, all covered by retained tests.
- **What I did NOT test:** live MA hardware; only mocked HA state flows.

🤖 Auto-generated by issue-triage routine