### PR TITLE
fix: write stats.json atomically to prevent corruption and stats reset (#1386)

### DIFF
--- a/custom_components/beatify/services/stats.py
+++ b/custom_components/beatify/services/stats.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import os
 import time
 import uuid
 from datetime import datetime, timezone
@@ -37,6 +38,7 @@ class StatsService:
         self._game_start_time: int | None = None
         self._all_time_avg_cache: float | None = None
         self._save_task: asyncio.Task | None = None
+        self._save_lock = asyncio.Lock()
 
     def set_analytics(self, analytics: AnalyticsStorage) -> None:
         """
@@ -91,20 +93,38 @@ class StatsService:
             await self.save()
 
     async def save(self) -> None:
-        """Persist stats to file."""
-        try:
-            # Ensure directory exists
-            await self._hass.async_add_executor_job(
-                self._stats_file.parent.mkdir, 0o755, True, True
-            )
-            # Write stats
-            content = json.dumps(self._stats, indent=2)
-            await self._hass.async_add_executor_job(
-                self._stats_file.write_text, content
-            )
-            _LOGGER.debug("Stats saved to %s", self._stats_file)
-        except OSError as err:
-            _LOGGER.error("Failed to save stats: %s", err)
+        """
+        Persist stats to file with a crash-safe atomic write.
+
+        Mirrors the temp-file + os.replace pattern used by
+        ``AnalyticsStorage._save``: the JSON is written to ``stats.json.tmp``
+        first and then atomically renamed over ``stats.json``. A crash or
+        power loss mid-write leaves the previous (valid) stats.json intact
+        instead of a truncated file that load() would discard, wiping all
+        game history (#1386). The lock serializes concurrent saves (e.g. a
+        directly-awaited save from load()'s corruption path interleaving with
+        a scheduled save task).
+        """
+        async with self._save_lock:
+            try:
+                # Ensure directory exists
+                await self._hass.async_add_executor_job(
+                    self._stats_file.parent.mkdir, 0o755, True, True
+                )
+
+                # Write to temp file first, then atomically rename into place
+                temp_path = self._stats_file.with_suffix(".json.tmp")
+                content = json.dumps(self._stats, indent=2)
+
+                def _write_atomic() -> None:
+                    temp_path.write_text(content)
+                    # Atomic rename (POSIX guarantees atomicity)
+                    os.replace(temp_path, self._stats_file)
+
+                await self._hass.async_add_executor_job(_write_atomic)
+                _LOGGER.debug("Stats saved to %s", self._stats_file)
+            except OSError as err:
+                _LOGGER.error("Failed to save stats: %s", err)
 
     def schedule_save(self) -> None:
         """

--- a/tests/unit/test_stats.py
+++ b/tests/unit/test_stats.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -610,3 +611,100 @@ class TestMiscProperties:
         self.service._stats["games"] = [{"id": f"g{i}"} for i in range(15)]
         history = await self.service.get_history()
         assert len(history) == 10
+
+
+# ---------------------------------------------------------------------------
+# StatsService.save — atomic write (#1386)
+# ---------------------------------------------------------------------------
+
+
+def _make_real_fs_service(stats_path) -> StatsService:
+    """Create a StatsService that writes to a real on-disk stats.json path."""
+    mock_hass = MagicMock()
+    mock_hass.config.path.return_value = str(stats_path)
+    # Run executor jobs inline on the calling thread.
+    mock_hass.async_add_executor_job = AsyncMock(
+        side_effect=lambda fn, *args: fn(*args)
+    )
+    return StatsService(mock_hass)
+
+
+class TestAtomicSave:
+    """save() must write stats.json atomically (temp file + os.replace)."""
+
+    @pytest.mark.asyncio
+    async def test_save_uses_temp_then_replace(self, tmp_path):
+        import json as _json
+
+        stats_path = tmp_path / "beatify" / "stats.json"
+        service = _make_real_fs_service(stats_path)
+        service._stats["all_time"]["games_played"] = 7
+
+        await service.save()
+
+        # Final file exists with the written content.
+        assert stats_path.exists()
+        data = _json.loads(stats_path.read_text())
+        assert data["all_time"]["games_played"] == 7
+        # No leftover temp file after a successful save.
+        assert not (tmp_path / "beatify" / "stats.json.tmp").exists()
+
+    @pytest.mark.asyncio
+    async def test_crash_mid_write_leaves_old_file_intact(self, tmp_path):
+        """A crash before os.replace must not corrupt the existing stats.json."""
+        import json as _json
+
+        stats_path = tmp_path / "beatify" / "stats.json"
+        service = _make_real_fs_service(stats_path)
+
+        # First, persist a valid file with real game history.
+        service._stats["all_time"]["games_played"] = 42
+        service._stats["games"] = [{"id": "keepme"}]
+        await service.save()
+        good_content = stats_path.read_text()
+        assert _json.loads(good_content)["all_time"]["games_played"] == 42
+
+        # Now simulate a crash mid-write: os.replace raises before the temp
+        # file is promoted over the live stats.json.
+        service._stats["all_time"]["games_played"] = 999
+
+        def _boom(_src, _dst):
+            raise OSError("simulated power loss mid-write")
+
+        with patch("custom_components.beatify.services.stats.os.replace", _boom):
+            # save() swallows OSError and logs it; it must not raise.
+            await service.save()
+
+        # The original file is untouched — history is NOT lost.
+        assert stats_path.exists()
+        assert stats_path.read_text() == good_content
+        reloaded = _json.loads(stats_path.read_text())
+        assert reloaded["all_time"]["games_played"] == 42
+        assert reloaded["games"] == [{"id": "keepme"}]
+
+    @pytest.mark.asyncio
+    async def test_save_is_serialized_by_lock(self, tmp_path):
+        """Concurrent save() calls must not interleave (lock held)."""
+        stats_path = tmp_path / "beatify" / "stats.json"
+        service = _make_real_fs_service(stats_path)
+
+        in_flight = 0
+        max_concurrent = 0
+
+        async def _tracking_executor(fn, *args):
+            nonlocal in_flight, max_concurrent
+            in_flight += 1
+            max_concurrent = max(max_concurrent, in_flight)
+            # Yield control so a second save() could interleave if unlocked.
+            await asyncio.sleep(0)
+            try:
+                return fn(*args)
+            finally:
+                in_flight -= 1
+
+        service._hass.async_add_executor_job = AsyncMock(side_effect=_tracking_executor)
+
+        await asyncio.gather(service.save(), service.save())
+
+        # The lock guarantees the file-I/O sections never overlap.
+        assert max_concurrent == 1


### PR DESCRIPTION
Closes #1386

## Root cause
`StatsService.save()` (`custom_components/beatify/services/stats.py`) persisted `stats.json` with a direct `write_text()`. A crash/power loss mid-write left a truncated file; the next `load()` hit the `JSONDecodeError` path, reset stats to empty and saved — permanently losing all game history, song-difficulty data, and all-time records. There was also no lock, so a directly-awaited `save()` from `load()`'s corruption path could interleave with a scheduled save task.

## Fix
Mirror the temp-file + `os.replace` atomic pattern already used by `AnalyticsStorage._save()`:
- `StatsService.save()` now writes to `stats.json.tmp` then atomically renames it over `stats.json` (POSIX-atomic rename).
- Added `self._save_lock = asyncio.Lock()` and wrapped the save body in `async with self._save_lock:` to serialize concurrent saves.

Scope kept minimal and limited to `stats.json` — `analytics.py` is unchanged.

## Files changed
- `custom_components/beatify/services/stats.py` — added `import os`; added `_save_lock` in `__init__`; rewrote `save()` to atomic temp+replace under the lock.
- `tests/unit/test_stats.py` — new `TestAtomicSave` class (3 tests): temp+replace leaves no leftover `.tmp`; a simulated `os.replace` crash mid-write leaves the old valid file (and its history) intact; concurrent `save()` calls are serialized by the lock.

Net delta: +132 / −14 across 2 files.

## Readiness assessment
- [x] Ready to merge
- [ ] Borderline — see notes
- [ ] Not ready — needs human review

**Honest summary:** Small, well-isolated backend change that copies an already-proven pattern from the sibling analytics module. The new crash-mid-write test fails on the old code and passes on the new code, directly proving the fix.

## Test plan
- `python3 -m pytest tests/unit/test_stats.py` — 51 passed (incl. 3 new atomic tests).
- Full suite: 964 passed, 2 skipped.
- `ruff check .` + `ruff format --check .`: clean. `mypy` (1.18.2): no issues in 15 files.

## Risk assessment
- **Blast radius:** `StatsService.save()` only — every stats persistence path (record_game, record_song_result, load() corruption recovery).
- **What could go wrong:** `os.replace` is atomic on the same filesystem; `stats.json.tmp` lives in the same `beatify/` dir so this holds. A leftover `stats.json.tmp` from a crash-before-replace is harmless and overwritten on the next save.
- **What I did NOT test:** real on-hardware power-loss; cross-filesystem rename (not applicable here).

## Sibling-PR note (merge sequencing)
Parallel resolvers for #1385/#1388 may touch the same analytics/storage area. This PR touches ONLY `custom_components/beatify/services/stats.py` (function `StatsService.save`, `StatsService.__init__`) and `tests/unit/test_stats.py`. It does not add a shared helper and does not modify `analytics.py`, so no overlap is expected.

🤖 Auto-generated by issue-triage routine