### PR TITLE
fix: pre-warm playlist display names off the event loop on every load path (#1387)

### DIFF
--- a/custom_components/beatify/analytics.py
+++ b/custom_components/beatify/analytics.py
@@ -130,11 +130,6 @@ class AnalyticsStorage:
                 )
                 # Prune old records on startup
                 await self._prune_old_records()
-                # Pre-load playlist display names so later sync
-                # callers don't block the event loop with file I/O
-                await self._hass.async_add_executor_job(
-                    self._get_playlist_display_names
-                )
             else:
                 _LOGGER.debug("No analytics file found, starting fresh")
                 self._data = self._empty_data()
@@ -142,6 +137,12 @@ class AnalyticsStorage:
             _LOGGER.warning("Analytics file corrupted, recreating: %s", err)
             self._data = self._empty_data()
             await self._save()
+        # Pre-load playlist display names so later sync callers don't block the
+        # event loop with file I/O. Must run on EVERY load path (fresh install,
+        # corruption recovery, normal load) — otherwise the first sync
+        # compute_playlist_stats() call globs+reads playlist JSON in the event
+        # loop. See #1387.
+        await self._hass.async_add_executor_job(self._get_playlist_display_names)
 
     async def _save(self) -> None:
         """
@@ -466,6 +467,9 @@ class AnalyticsStorage:
 
         if not playlist_dir.exists():
             _LOGGER.debug("Playlist directory not found: %s", playlist_dir)
+            # Cache the empty result so the blocking exists() stat does not run
+            # on every subsequent call. See #1387.
+            self._playlist_display_names = display_names
             return display_names
 
         for json_file in playlist_dir.glob("*.json"):

--- a/tests/unit/test_analytics.py
+++ b/tests/unit/test_analytics.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import time
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -592,3 +593,91 @@ class TestPlaylistStats:
         games = [_make_game_record(playlist_names=[f"playlist-{i}"]) for i in range(10)]
         result = self.storage.compute_playlist_stats(games)
         assert len(result) <= 5
+
+
+# ---------------------------------------------------------------------------
+# TestLoadPrewarm — playlist display names must be pre-warmed via the executor
+# on EVERY load path, so later sync callers never block the event loop (#1387)
+# ---------------------------------------------------------------------------
+
+
+class TestLoadPrewarm:
+    def setup_method(self):
+        self.hass = _mock_hass()
+        self.hass.config.path.side_effect = lambda *parts: (
+            "/tmp/test_beatify/" + "/".join(parts)
+        )
+        self.storage = AnalyticsStorage(self.hass)
+
+    @pytest.mark.asyncio
+    async def test_fresh_install_prewarms_via_executor(self):
+        """On a fresh install (no analytics.json) load() must still pre-warm
+        the playlist display names through async_add_executor_job, so the first
+        sync compute_playlist_stats() is a pure cache hit (no event-loop I/O)."""
+        # No analytics file -> else branch.
+        with patch(
+            "custom_components.beatify.analytics.Path.exists", return_value=False
+        ):
+            await self.storage.load()
+
+        # The pre-warm ran through the executor (not directly in the loop) and
+        # populated the cache.
+        assert self.storage._playlist_display_names is not None
+        prewarm_calls = [
+            c
+            for c in self.hass.async_add_executor_job.await_args_list
+            if c.args
+            and getattr(c.args[0], "__name__", "") == "_get_playlist_display_names"
+        ]
+        assert prewarm_calls, "load() must pre-warm playlist names via the executor"
+
+    @pytest.mark.asyncio
+    async def test_corruption_recovery_prewarms_via_executor(self):
+        """After corruption recovery (JSONDecodeError branch) the cache must
+        still be pre-warmed via the executor."""
+
+        def _raise_corrupt(_content):
+            raise json.JSONDecodeError("corrupt", "doc", 0)
+
+        with (
+            patch("custom_components.beatify.analytics.Path.exists", return_value=True),
+            patch(
+                "custom_components.beatify.analytics.Path.read_text",
+                return_value="{ corrupt",
+            ),
+            patch(
+                "custom_components.beatify.analytics.json.loads",
+                side_effect=_raise_corrupt,
+            ),
+            patch.object(self.storage, "_save", new_callable=AsyncMock),
+            # _get_playlist_display_names globs playlist JSON; an empty glob
+            # keeps it from touching json.loads on real files.
+            patch("custom_components.beatify.analytics.Path.glob", return_value=[]),
+        ):
+            await self.storage.load()
+
+        prewarm_calls = [
+            c
+            for c in self.hass.async_add_executor_job.await_args_list
+            if c.args
+            and getattr(c.args[0], "__name__", "") == "_get_playlist_display_names"
+        ]
+        assert prewarm_calls, (
+            "load() must pre-warm playlist names via the executor even after "
+            "corruption recovery"
+        )
+        assert self.storage._playlist_display_names is not None
+
+    def test_missing_playlist_dir_caches_empty_result(self):
+        """When the playlist dir is absent, the empty result must be cached so
+        the blocking exists() stat does not run on every subsequent call."""
+        with patch(
+            "custom_components.beatify.analytics.Path.exists", return_value=False
+        ) as mock_exists:
+            first = self.storage._get_playlist_display_names()
+            assert first == {}
+            calls_after_first = mock_exists.call_count
+            # Second call must be a pure cache hit -> no further exists() stat.
+            second = self.storage._get_playlist_display_names()
+            assert second == {}
+            assert mock_exists.call_count == calls_after_first


### PR DESCRIPTION
Closes #1387

## Readiness assessment
- [x] Ready to merge
- [ ] Borderline — see notes
- [ ] Not ready — needs human review

**Honest summary:** Backend-only, two-line behavioural fix plus a comment. Moves the existing executor pre-warm of `_get_playlist_display_names()` out of the `if self._path.exists()` branch so it runs on every `load()` path, and caches the empty result before the missing-dir early return. Three new tests fail without the fix and pass with it.

## Root cause
`_get_playlist_display_names()` does synchronous disk I/O (`exists()`, `glob`, `read_text`). The executor pre-warm lived inside the `if self._path.exists()` branch of `load()`, so on a fresh install (no `analytics.json`) or after corruption recovery it never ran — the first sync `compute_playlist_stats()`/`compute_metrics()` call, invoked from the API handler in the event loop, then globbed and read every playlist JSON directly in the loop. Separately, the missing-playlist-dir branch returned early without caching, so the blocking `exists()` stat ran on every call forever.

## Test plan
- `python3 -m pytest tests/unit/test_analytics.py` — 46 pass (43 existing + 3 new).
- New `TestLoadPrewarm`:
  - `test_fresh_install_prewarms_via_executor` — no analytics.json: pre-warm still goes through `async_add_executor_job`, cache populated.
  - `test_corruption_recovery_prewarms_via_executor` — JSONDecodeError branch: same.
  - `test_missing_playlist_dir_caches_empty_result` — second sync call performs no further `exists()` stat.
- Verified all three FAIL against the unpatched `analytics.py` and PASS with the fix.
- Full suite: 964 passed, 2 skipped. `ruff check .` + `ruff format --check .` clean. `mypy` (1.18.2, CI-scoped) clean.

## Risk assessment
- **Blast radius:** `custom_components/beatify/analytics.py` (load path + one early-return cache line), `tests/unit/test_analytics.py` (new test class). No frontend, no API surface.
- **What could go wrong:** Pre-warm now also runs on the corruption-recovery path, adding one executor hop after `_save()` — negligible and intended. Behaviour on the normal-load path is unchanged.
- **What I did NOT test:** Real HA runtime integration (mock-based unit tests only).

🤖 Auto-generated by issue-triage routine