### PR TITLE
fix: skip/quarantine corrupt analytics record instead of wiping file (#1385)

### DIFF
--- a/custom_components/beatify/analytics.py
+++ b/custom_components/beatify/analytics.py
@@ -14,7 +14,7 @@ import os
 import time
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, TypedDict
+from typing import TYPE_CHECKING, Any, TypedDict, cast
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
@@ -118,31 +118,75 @@ class AnalyticsStorage:
         }
 
     async def load(self) -> None:
-        """Load analytics data from file (AC: #3)."""
+        """Load analytics data from file (AC: #3).
+
+        Only an unparseable file (bad JSON or wrong top-level type) is treated
+        as corrupt. A single malformed *record* must never wipe the whole
+        history — pruning and aggregation use ``.get()`` with defaults so they
+        skip/tolerate individual bad records instead of raising (#1385). When
+        the file truly is corrupt, the original is quarantined to
+        ``analytics.json.corrupt`` rather than being destroyed.
+        """
         try:
-            if self._path.exists():
-                content = await self._hass.async_add_executor_job(self._path.read_text)
-                self._data = json.loads(content)
-                _LOGGER.debug(
-                    "Loaded analytics: %d games, %d errors",
-                    len(self._data.get("games", [])),
-                    len(self._data.get("errors", [])),
-                )
-                # Prune old records on startup
-                await self._prune_old_records()
-            else:
+            if not self._path.exists():
                 _LOGGER.debug("No analytics file found, starting fresh")
                 self._data = self._empty_data()
-        except (json.JSONDecodeError, KeyError, TypeError) as err:
-            _LOGGER.warning("Analytics file corrupted, recreating: %s", err)
-            self._data = self._empty_data()
-            await self._save()
-        # Pre-load playlist display names so later sync callers don't block the
-        # event loop with file I/O. Must run on EVERY load path (fresh install,
-        # corruption recovery, normal load) — otherwise the first sync
-        # compute_playlist_stats() call globs+reads playlist JSON in the event
-        # loop. See #1387.
-        await self._hass.async_add_executor_job(self._get_playlist_display_names)
+                return
+
+            content = await self._hass.async_add_executor_job(self._path.read_text)
+            try:
+                parsed = json.loads(content)
+            except json.JSONDecodeError as err:
+                await self._quarantine_corrupt_file(err)
+                return
+
+            if not isinstance(parsed, dict):
+                await self._quarantine_corrupt_file(
+                    TypeError(
+                        f"analytics root is {type(parsed).__name__}, expected dict"
+                    )
+                )
+                return
+
+            self._data = cast("AnalyticsData", parsed)
+            _LOGGER.debug(
+                "Loaded analytics: %d games, %d errors",
+                len(self._data.get("games", [])),
+                len(self._data.get("errors", [])),
+            )
+            # Prune old records on startup. This runs OUTSIDE the parse guard:
+            # a single malformed record must not silently reset the whole store,
+            # so prune tolerates bad records via .get() defaults (#1385).
+            await self._prune_old_records()
+        finally:
+            # Pre-load playlist display names so later sync callers don't block
+            # the event loop with file I/O. Must run on EVERY load path (fresh
+            # install, corruption recovery, normal load) — otherwise the first
+            # sync compute_playlist_stats() globs+reads playlist JSON in the
+            # event loop. See #1387.
+            await self._hass.async_add_executor_job(self._get_playlist_display_names)
+
+    async def _quarantine_corrupt_file(self, err: Exception) -> None:
+        """Move an unparseable analytics file aside and start fresh (#1385).
+
+        Renames the bad file to ``<path>.corrupt`` so the data is preserved
+        for inspection/recovery instead of being overwritten. Then resets
+        in-memory state to empty and persists the fresh store.
+        """
+        corrupt_path = self._path.with_suffix(self._path.suffix + ".corrupt")
+        _LOGGER.warning(
+            "Analytics file unparseable (%s); quarantining to %s and starting fresh",
+            err,
+            corrupt_path,
+        )
+        try:
+            await self._hass.async_add_executor_job(
+                os.replace, self._path, corrupt_path
+            )
+        except OSError as move_err:
+            _LOGGER.error("Failed to quarantine corrupt analytics file: %s", move_err)
+        self._data = self._empty_data()
+        await self._save()
 
     async def _save(self) -> None:
         """
@@ -260,7 +304,11 @@ class AnalyticsStorage:
         recent_games: list[GameRecord] = []
 
         for game in games:
-            if game["ended_at"] < cutoff:
+            # Tolerate records missing 'ended_at' (hand-edited file, older
+            # schema, partial write): default to 0 so they sort as "old" and
+            # get summarized rather than raising KeyError and wiping the store
+            # (#1385).
+            if game.get("ended_at", 0) < cutoff:
                 old_games.append(game)
             else:
                 recent_games.append(game)
@@ -271,7 +319,7 @@ class AnalyticsStorage:
         # Group old games by month and create summaries
         monthly_groups: dict[str, list[GameRecord]] = {}
         for game in old_games:
-            dt = datetime.fromtimestamp(game["ended_at"], tz=timezone.utc)
+            dt = datetime.fromtimestamp(game.get("ended_at", 0), tz=timezone.utc)
             month_key = dt.strftime("%Y-%m")
             if month_key not in monthly_groups:
                 monthly_groups[month_key] = []
@@ -281,14 +329,18 @@ class AnalyticsStorage:
         for month, month_games in monthly_groups.items():
             # Check if summary already exists
             existing = next(
-                (s for s in self._data["monthly_summaries"] if s["month"] == month),
+                (s for s in self._data["monthly_summaries"] if s.get("month") == month),
                 None,
             )
             if existing:
                 # Update existing summary
                 existing["games_count"] += len(month_games)
-                existing["total_players"] += sum(g["player_count"] for g in month_games)
-                existing["total_rounds"] += sum(g["rounds_played"] for g in month_games)
+                existing["total_players"] += sum(
+                    g.get("player_count", 0) for g in month_games
+                )
+                existing["total_rounds"] += sum(
+                    g.get("rounds_played", 0) for g in month_games
+                )
                 # Recalculate averages
                 if existing["games_count"] > 0:
                     existing["avg_players_per_game"] = round(
@@ -299,9 +351,9 @@ class AnalyticsStorage:
                     )
             else:
                 # Create new summary
-                total_players = sum(g["player_count"] for g in month_games)
-                total_rounds = sum(g["rounds_played"] for g in month_games)
-                total_errors = sum(g["error_count"] for g in month_games)
+                total_players = sum(g.get("player_count", 0) for g in month_games)
+                total_rounds = sum(g.get("rounds_played", 0) for g in month_games)
+                total_errors = sum(g.get("error_count", 0) for g in month_games)
                 games_count = len(month_games)
 
                 summary: MonthlySummary = {
@@ -318,9 +370,11 @@ class AnalyticsStorage:
         # Keep only recent games
         self._data["games"] = recent_games
 
-        # Also prune old errors (keep last 90 days)
+        # Also prune old errors (keep last 90 days). Use .get() so an error
+        # record missing 'timestamp' (schema drift) defaults to 0 and is pruned
+        # rather than raising KeyError (#1385).
         self._data["errors"] = [
-            e for e in self._data["errors"] if e["timestamp"] >= cutoff
+            e for e in self._data["errors"] if e.get("timestamp", 0) >= cutoff
         ]
 
         _LOGGER.info(

--- a/tests/unit/test_analytics.py
+++ b/tests/unit/test_analytics.py
@@ -368,6 +368,146 @@ class TestPruneOldData:
 
 
 # ---------------------------------------------------------------------------
+# TestLoadResilience (#1385)
+# ---------------------------------------------------------------------------
+
+
+class TestLoadResilience:
+    """A single corrupt/schema-drifted record must not wipe the whole file."""
+
+    def setup_method(self):
+        self.hass = _mock_hass()
+        self.storage = AnalyticsStorage(self.hass)
+
+    @pytest.mark.asyncio
+    async def test_schema_drifted_record_does_not_wipe_valid_records(self):
+        """One record missing required keys is tolerated; valid history survives.
+
+        Forces a prune (games > MAX_DETAILED_RECORDS) so the prune path that
+        previously did ``game["ended_at"]`` runs against a record missing that
+        key. The whole store must NOT be reset to empty.
+        """
+        now = int(time.time())
+        recent_ts = now - 3600
+        old_ts = now - (RETENTION_DAYS + 30) * 86400
+
+        games = [
+            _make_game_record(game_id=f"recent-{i}", ended_at=recent_ts)
+            for i in range(MAX_DETAILED_RECORDS)
+        ]
+        # Enough old games to push over the limit and trigger summarization.
+        for i in range(20):
+            games.append(_make_game_record(game_id=f"old-{i}", ended_at=old_ts))
+        # A schema-drifted record: missing 'ended_at', 'player_count', etc.
+        games.append({"game_id": "broken", "started_at": old_ts})
+
+        payload = {
+            "version": 1,
+            "games": games,
+            "errors": [{"timestamp": now - 100, "type": "ERR", "message": "keep"}],
+            "monthly_summaries": [],
+        }
+
+        save_mock = AsyncMock()
+        with (
+            patch.object(self.storage, "_save", save_mock),
+            patch.object(self.storage, "_get_playlist_display_names", return_value={}),
+        ):
+            self.storage._path = MagicMock()
+            self.storage._path.exists.return_value = True
+            self.storage._path.read_text.return_value = json.dumps(payload)
+            self.hass.async_add_executor_job = AsyncMock(
+                side_effect=lambda fn, *args: fn(*args)
+            )
+            await self.storage.load()
+
+        # The store was NOT wiped: recent games survive.
+        assert len(self.storage._data["games"]) == MAX_DETAILED_RECORDS
+        assert any(
+            g.get("game_id", "").startswith("recent-")
+            for g in self.storage._data["games"]
+        )
+        # Old + broken records were summarized, not discarded as a full reset.
+        assert len(self.storage._data["monthly_summaries"]) > 0
+        # Valid error record preserved.
+        assert len(self.storage._data["errors"]) == 1
+
+    @pytest.mark.asyncio
+    async def test_bad_json_quarantines_instead_of_destroying(self):
+        """Unparseable JSON renames the file to .corrupt rather than wiping it."""
+        save_mock = AsyncMock()
+        replace_calls: list[tuple] = []
+
+        def _exec(fn, *args):
+            # Intercept os.replace so we don't touch the real filesystem.
+            if getattr(fn, "__name__", "") == "replace":
+                replace_calls.append(args)
+                return None
+            return fn(*args)
+
+        with patch.object(self.storage, "_save", save_mock):
+            self.storage._path = MagicMock()
+            self.storage._path.exists.return_value = True
+            self.storage._path.read_text.return_value = "{not valid json"
+            self.storage._path.suffix = ".json"
+            self.storage._path.with_suffix.return_value = "analytics.json.corrupt"
+            self.hass.async_add_executor_job = AsyncMock(side_effect=_exec)
+            await self.storage.load()
+
+        # File was moved aside (quarantined), not silently overwritten.
+        assert len(replace_calls) == 1
+        # Fresh empty store in memory + persisted.
+        assert self.storage._data == self.storage._empty_data()
+        save_mock.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_non_dict_root_quarantines(self):
+        """A JSON file whose root is a list (not dict) is treated as corrupt."""
+        save_mock = AsyncMock()
+        replace_calls: list[tuple] = []
+
+        def _exec(fn, *args):
+            if getattr(fn, "__name__", "") == "replace":
+                replace_calls.append(args)
+                return None
+            return fn(*args)
+
+        with patch.object(self.storage, "_save", save_mock):
+            self.storage._path = MagicMock()
+            self.storage._path.exists.return_value = True
+            self.storage._path.read_text.return_value = "[1, 2, 3]"
+            self.storage._path.suffix = ".json"
+            self.storage._path.with_suffix.return_value = "analytics.json.corrupt"
+            self.hass.async_add_executor_job = AsyncMock(side_effect=_exec)
+            await self.storage.load()
+
+        assert len(replace_calls) == 1
+        assert self.storage._data == self.storage._empty_data()
+
+    @pytest.mark.asyncio
+    async def test_prune_tolerates_record_missing_keys(self):
+        """_prune_old_records skips bad records without raising KeyError."""
+        now = int(time.time())
+        recent_ts = now - 3600
+        old_ts = now - (RETENTION_DAYS + 30) * 86400
+
+        games = [
+            _make_game_record(game_id=f"recent-{i}", ended_at=recent_ts)
+            for i in range(MAX_DETAILED_RECORDS)
+        ]
+        for i in range(10):
+            games.append(_make_game_record(game_id=f"old-{i}", ended_at=old_ts))
+        # Record missing every aggregated field.
+        games.append({"game_id": "broken"})
+        self.storage._data["games"] = games
+
+        # Must not raise.
+        await self.storage._prune_old_records()
+
+        assert len(self.storage._data["games"]) == MAX_DETAILED_RECORDS
+
+
+# ---------------------------------------------------------------------------
 # TestComputeMetrics
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #1385

## Root cause
`AnalyticsStorage.load()` wrapped both `json.loads` AND `_prune_old_records()` in a single `except (json.JSONDecodeError, KeyError, TypeError)` that reset `self._data` to empty and immediately persisted it. `_prune_old_records` used direct key access (`game["ended_at"]`, `g["player_count"]`, `g["rounds_played"]`, `g["error_count"]`, `e["timestamp"]`, `s["month"]`). One record missing a single key (hand-edited file, older schema, partial write) raised `KeyError` and wiped the ENTIRE analytics history.

## Fix (backend-only, no UI surface)
- **Narrow the parse guard** to `json.loads` only; `_prune_old_records()` runs OUTSIDE it.
- **Tolerate malformed records** in prune via `.get()` defaults instead of direct key access.
- **Quarantine** a truly-unparseable file to `analytics.json.corrupt` via `os.replace` instead of overwriting it; also reject non-`dict` JSON roots.

## Readiness assessment
- [x] Ready to merge
- [ ] Borderline — see notes
- [ ] Not ready — needs human review

**Honest summary:** Tight, surgical change confined to `analytics.py` `load()` / `_prune_old_records()` plus 4 new tests. The blast-radius reduction is exactly what the issue asked for: one bad record no longer destroys the store. All gates green.

## Files changed (functions)
- `custom_components/beatify/analytics.py` — `load()` (split parse vs prune, non-dict-root guard), new `_quarantine_corrupt_file()`, `_prune_old_records()` (`.get()` defaults). Net +82/-34.
- `tests/unit/test_analytics.py` — new `TestLoadResilience` (4 tests). Net +141.

## Test plan
- `python3 -m pytest` → 965 passed, 2 skipped (4 new analytics tests included).
- New tests prove: schema-drifted record does NOT wipe valid records (recent games + valid error survive); bad JSON quarantines to `.corrupt`; non-dict root quarantines; prune tolerates a record missing every key.
- `ruff check .` + `ruff format --check .` clean; `mypy` (1.18.2) clean (CI-scoped + file-scoped).

## Risk assessment
- **Blast radius:** analytics load/prune path only. No callers of `load()`/`_prune_old_records()` signatures change.
- **What could go wrong:** quarantine `os.replace` failure is caught and logged (load still proceeds fresh). A non-dict root is now treated as corrupt (previously `json.loads` of e.g. `[]` would have set `_data` to a list then crashed later) — strictly safer.
- **Sibling overlap (#1386 / #1388):** both likely touch this same module. My changes are scoped to `load()`, the new `_quarantine_corrupt_file()`, and `.get()` swaps inside `_prune_old_records()`. #1386 (stats.json atomicity) and #1388 (errors list) should sequence cleanly but may conflict on `_save()`/`_prune_old_records()` lines — flag at merge.
- **What I did NOT test:** real on-disk quarantine rename (mocked `os.replace` in tests); HA runtime integration.

🤖 Auto-generated by issue-triage routine