### PR TITLE
fix: bound analytics errors list and debounce error saves (#1388)

### DIFF
--- a/custom_components/beatify/__init__.py
+++ b/custom_components/beatify/__init__.py
@@ -278,7 +278,11 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     # Clean up domain data
     if DOMAIN in hass.data:
-        hass.data.pop(DOMAIN)
+        domain_data = hass.data.pop(DOMAIN)
+        # Flush any pending debounced analytics error save before teardown (#1388)
+        analytics = domain_data.get("analytics")
+        if analytics is not None:
+            await analytics.async_shutdown()
 
     _LOGGER.info("Beatify integration unloaded")
     return True

--- a/custom_components/beatify/analytics.py
+++ b/custom_components/beatify/analytics.py
@@ -26,6 +26,17 @@ MAX_DETAILED_RECORDS = 1000
 RETENTION_DAYS = 90
 PRUNE_INTERVAL = 10  # Prune every N game records
 
+# Hard cap on retained error events. record_error() is invoked once per
+# error event (e.g. websocket reconnect storms, flapping media players), so
+# without an independent cap the errors list grows unbounded between the rare
+# game-driven prune passes. Keep only the most recent events. (#1388)
+MAX_ERROR_RECORDS = 500
+
+# Debounce window (seconds) for coalescing error-driven saves. A burst of
+# errors would otherwise trigger one full-file rewrite per event; instead we
+# delay-coalesce them into a single write. (#1388)
+ERROR_SAVE_DEBOUNCE_SECONDS = 5.0
+
 # Period-to-days mapping used by stats functions
 PERIOD_DAYS_MAP: dict[str, int] = {"7d": 7, "30d": 30, "90d": 90, "all": 365 * 10}
 
@@ -103,6 +114,8 @@ class AnalyticsStorage:
         self._games_since_prune = 0
         self._session_error_count = 0
         self._save_lock = asyncio.Lock()
+        # Pending debounced error-save timer handle (#1388)
+        self._error_save_handle: asyncio.TimerHandle | None = None
         self._playlist_display_names: dict[str, str] | None = None
         self._metrics_cache: dict[
             str, tuple[float, dict]
@@ -185,6 +198,40 @@ class AnalyticsStorage:
         if (exc := task.exception()) is not None:
             _LOGGER.error("Unhandled error in analytics save task: %s", exc)
 
+    def _schedule_error_save(self) -> None:
+        """
+        Schedule a debounced save for error events (#1388).
+
+        Error events can arrive in bursts (reconnect storms, flapping media
+        players). Writing the whole analytics file per event hammers the disk
+        and runs json.dumps of the growing structure in the event loop. Instead
+        we coalesce: a save is scheduled ERROR_SAVE_DEBOUNCE_SECONDS in the
+        future, and any error arriving before it fires resets the timer, so a
+        burst results in a single write.
+        """
+        if self._error_save_handle is not None:
+            self._error_save_handle.cancel()
+
+        def _fire() -> None:
+            self._error_save_handle = None
+            self.schedule_save()
+
+        self._error_save_handle = self._hass.loop.call_later(
+            ERROR_SAVE_DEBOUNCE_SECONDS, _fire
+        )
+
+    async def async_shutdown(self) -> None:
+        """
+        Cancel any pending debounced error save and flush to disk (#1388).
+
+        Called on unload so the last coalesced batch of error events isn't lost
+        when its debounce timer never fires.
+        """
+        if self._error_save_handle is not None:
+            self._error_save_handle.cancel()
+            self._error_save_handle = None
+            await self._save()
+
     async def add_game(self, record: GameRecord) -> None:
         """
         Add game record and schedule save (AC: #1).
@@ -225,9 +272,16 @@ class AnalyticsStorage:
             "type": error_type,
             "message": message[:500],  # Limit message length
         }
-        self._data["errors"].append(event)
+        errors = self._data["errors"]
+        errors.append(event)
+        # Cap independently of the game-driven prune, which most installs never
+        # trigger. Keep only the most recent MAX_ERROR_RECORDS events so a burst
+        # cannot grow the list (and the per-save json.dumps) without bound.
+        if len(errors) > MAX_ERROR_RECORDS:
+            del errors[:-MAX_ERROR_RECORDS]
         self._session_error_count += 1
-        self.schedule_save()
+        # Debounce/coalesce the save instead of a full-file rewrite per event.
+        self._schedule_error_save()
 
         _LOGGER.debug("Recorded error event: %s - %s", error_type, message)
 

--- a/tests/unit/test_analytics.py
+++ b/tests/unit/test_analytics.py
@@ -8,7 +8,9 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from custom_components.beatify.analytics import (
+    ERROR_SAVE_DEBOUNCE_SECONDS,
     MAX_DETAILED_RECORDS,
+    MAX_ERROR_RECORDS,
     PRUNE_INTERVAL,
     RETENTION_DAYS,
     AnalyticsStorage,
@@ -187,10 +189,75 @@ class TestRecordError:
             self.storage.record_error("ERR", long_msg)
         assert len(self.storage._data["errors"][0]["message"]) == 500
 
-    def test_calls_schedule_save(self):
+    def test_debounces_save_instead_of_per_event_rewrite(self):
+        """Each error schedules a debounced save, not an immediate full rewrite (#1388)."""
         with patch.object(self.storage, "schedule_save") as mock_save:
             self.storage.record_error("ERR", "msg")
+        # No immediate per-event save; a debounce timer is armed instead.
+        mock_save.assert_not_called()
+        self.hass.loop.call_later.assert_called_once()
+        # The debounce window is used.
+        assert self.hass.loop.call_later.call_args.args[0] == (
+            ERROR_SAVE_DEBOUNCE_SECONDS
+        )
+
+    def test_debounce_coalesces_burst_into_single_pending_save(self):
+        """A burst of errors cancels the prior timer and arms one new one (#1388)."""
+        handle1 = MagicMock()
+        handle2 = MagicMock()
+        handle3 = MagicMock()
+        self.hass.loop.call_later.side_effect = [handle1, handle2, handle3]
+        self.storage.record_error("ERR", "msg1")
+        self.storage.record_error("ERR", "msg2")
+        self.storage.record_error("ERR", "msg3")
+        # Each new error cancels the previous pending timer (coalescing).
+        handle1.cancel.assert_called_once()
+        handle2.cancel.assert_called_once()
+        handle3.cancel.assert_not_called()
+        # Only one save fires when the surviving timer elapses.
+        with patch.object(self.storage, "schedule_save") as mock_save:
+            fire = self.hass.loop.call_later.call_args.args[1]
+            fire()
         mock_save.assert_called_once()
+
+    def test_caps_errors_list_independently_of_game_prune(self):
+        """errors list is bounded by MAX_ERROR_RECORDS without any game prune (#1388)."""
+        with patch.object(self.storage, "_schedule_error_save"):
+            for i in range(MAX_ERROR_RECORDS + 200):
+                self.storage.record_error("ERR", f"msg{i}")
+        errors = self.storage._data["errors"]
+        assert len(errors) == MAX_ERROR_RECORDS
+        # Oldest entries are trimmed; the most recent are retained.
+        assert errors[0]["message"] == "msg200"
+        assert errors[-1]["message"] == f"msg{MAX_ERROR_RECORDS + 199}"
+
+
+# ---------------------------------------------------------------------------
+# TestErrorSaveShutdown
+# ---------------------------------------------------------------------------
+
+
+class TestErrorSaveShutdown:
+    def setup_method(self):
+        self.hass = _mock_hass()
+        self.storage = AnalyticsStorage(self.hass)
+
+    @pytest.mark.asyncio
+    async def test_shutdown_cancels_pending_timer_and_flushes(self):
+        handle = MagicMock()
+        self.hass.loop.call_later.return_value = handle
+        self.storage.record_error("ERR", "msg")
+        with patch.object(self.storage, "_save", AsyncMock()) as mock_save:
+            await self.storage.async_shutdown()
+        handle.cancel.assert_called_once()
+        mock_save.assert_awaited_once()
+        assert self.storage._error_save_handle is None
+
+    @pytest.mark.asyncio
+    async def test_shutdown_noop_when_nothing_pending(self):
+        with patch.object(self.storage, "_save", AsyncMock()) as mock_save:
+            await self.storage.async_shutdown()
+        mock_save.assert_not_awaited()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_setup_reload_routes.py
+++ b/tests/unit/test_setup_reload_routes.py
@@ -133,6 +133,7 @@ def _patch_heavy_helpers(monkeypatch):
 
     analytics = MagicMock()
     analytics.load = AsyncMock()
+    analytics.async_shutdown = AsyncMock()
     analytics.total_games = 0
     monkeypatch.setattr(
         beatify_init, "AnalyticsStorage", MagicMock(return_value=analytics)


### PR DESCRIPTION
Closes #1388

## Root cause
`record_error()` (analytics.py) appended to `self._data["errors"]` and called `schedule_save()` — a full `json.dumps` + rewrite of the whole analytics file in the event loop — on **every** error. The only pruning lived in `_prune_old_records()`, which early-returns unless `len(games) > MAX_DETAILED_RECORDS` (1000), a threshold most installs never reach. An error storm (flapping media player / websocket reconnect loop — exactly the events these error types represent) therefore grew `errors` unbounded with one disk write per event.

## Fix
- **Bound the list independently:** new `MAX_ERROR_RECORDS = 500`; `record_error()` trims with `del errors[:-MAX_ERROR_RECORDS]` regardless of game volume.
- **Debounce saves:** new `_schedule_error_save()` coalesces a burst into a single write `ERROR_SAVE_DEBOUNCE_SECONDS` (5s) out via `hass.loop.call_later`, cancelling the prior pending timer — replacing the per-event full-file rewrite.
- **No data loss on teardown:** new `AnalyticsStorage.async_shutdown()` cancels the pending timer and flushes; wired into `async_unload_entry`.

## Functions/files changed (net +130/-4)
- `custom_components/beatify/analytics.py` — constants `MAX_ERROR_RECORDS`, `ERROR_SAVE_DEBOUNCE_SECONDS`; `__init__` (`_error_save_handle`); `record_error()` (cap + debounced save); new `_schedule_error_save()`, `async_shutdown()`.
- `custom_components/beatify/__init__.py` — `async_unload_entry()` flushes analytics via `async_shutdown()`.
- `tests/unit/test_analytics.py` — new tests: cap trims oldest/keeps newest, burst coalesces to one save, debounce window, shutdown flush/no-op.
- `tests/unit/test_setup_reload_routes.py` — stub analytics mock gains `async_shutdown` AsyncMock.

## Readiness assessment
- [x] Ready to merge
- [ ] Borderline — see notes
- [ ] Not ready — needs human review

**Honest summary:** Tightly scoped backend change matching the issue's prescription exactly. The cap and coalescing are simple and well-tested. Debounce relies on `hass.loop.call_later` (real in HA, MagicMock in unit tests), and the shutdown flush prevents losing the last batch.

## Test plan
- `python3 -m pytest` → 965 passed, 2 skipped.
- `ruff check .` + `ruff format --check .` → clean. `mypy` → clean (analytics.py/__init__.py are outside the gated `files` list but pass).
- New tests prove: errors list bounded at 500 with oldest trimmed under no game prune; a 3-error burst arms one surviving timer → single save; shutdown cancels + flushes.

## Risk assessment
- **Blast radius:** analytics error recording + integration unload. No UI surface, no frontend bundle.
- **What could go wrong:** error saves are now delayed up to 5s — a hard crash within that window loses the most recent un-flushed errors (acceptable: these are diagnostic events, and a write-per-event was the bug). The 500-cap drops oldest errors past the cap.
- **Sibling overlap (#1385/#1386):** this touches `analytics.py` `record_error` / `__init__` / new `_schedule_error_save` / `async_shutdown`, and `__init__.py async_unload_entry`. #1385 (analytics file) and #1386 (stats.json atomicity) may touch the same module — sequence at merge. No overlap with `_save()`/atomic-write internals here.
- **What I did NOT test:** live HA runtime debounce firing (timer is MagicMock in unit tests); real reconnect-storm load.

🤖 Auto-generated by issue-triage routine