### PR TITLE
fix: track data-report follow-up as HA background task + reuse shared session (#1384)

### DIFF
--- a/custom_components/beatify/server/ws_handlers.py
+++ b/custom_components/beatify/server/ws_handlers.py
@@ -20,6 +20,7 @@ from typing import TYPE_CHECKING
 
 import aiohttp
 from aiohttp import web
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from custom_components.beatify.const import (
     ARTIST_BONUS_POINTS,
@@ -56,6 +57,8 @@ from custom_components.beatify.server.serializers import (
 )
 
 if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+
     from custom_components.beatify.server.websocket import BeatifyWebSocketHandler
 
 _LOGGER = logging.getLogger(__name__)
@@ -1878,8 +1881,12 @@ async def handle_report_data(
     except (OSError, ValueError):
         _LOGGER.warning("Failed to write data quality report to %s", reports_path)
 
-    asyncio.ensure_future(
-        _create_gh_issue(artist, title, year, playlist_file, player.name)
+    # #1384: track the follow-up via HA's background-task registry so it can't
+    # be garbage-collected mid-flight and is cancelled on integration unload —
+    # instead of a bare asyncio.ensure_future that HA never sees.
+    handler.hass.async_create_background_task(
+        _create_gh_issue(handler.hass, artist, title, year, playlist_file, player.name),
+        name="beatify-report-data",
     )
 
     await ws.send_json({"type": "report_data_ack"})
@@ -1889,33 +1896,39 @@ _WORKER_URL = "https://beatify-api.mholzi.workers.dev"
 
 
 async def _create_gh_issue(
+    hass: HomeAssistant,
     artist: str,
     title: str,
     year: int | None,
     playlist_file: str,
     reporter: str,
 ) -> None:
-    """Report data quality issue via Cloudflare Worker (best-effort)."""
+    """Report data quality issue via Cloudflare Worker (best-effort).
+
+    #1384: reuses HA's shared aiohttp ClientSession via
+    ``async_get_clientsession(hass)`` rather than spinning up (and tearing down)
+    a fresh ``aiohttp.ClientSession`` per call.
+    """
     try:
-        async with aiohttp.ClientSession() as session:
-            async with session.post(
-                f"{_WORKER_URL}/report-data",
-                json={
-                    "artist": artist,
-                    "title": title,
-                    "year": year,
-                    "playlist_file": playlist_file,
-                    "reporter": reporter,
-                },
-                timeout=aiohttp.ClientTimeout(total=15),
-            ) as resp:
-                if resp.status not in (200, 201):
-                    _LOGGER.debug(
-                        "Worker /report-data returned %s for %s — %s",
-                        resp.status,
-                        artist,
-                        title,
-                    )
+        session = async_get_clientsession(hass)
+        async with session.post(
+            f"{_WORKER_URL}/report-data",
+            json={
+                "artist": artist,
+                "title": title,
+                "year": year,
+                "playlist_file": playlist_file,
+                "reporter": reporter,
+            },
+            timeout=aiohttp.ClientTimeout(total=15),
+        ) as resp:
+            if resp.status not in (200, 201):
+                _LOGGER.debug(
+                    "Worker /report-data returned %s for %s — %s",
+                    resp.status,
+                    artist,
+                    title,
+                )
     except (aiohttp.ClientError, asyncio.TimeoutError, OSError):
         _LOGGER.debug(
             "Worker /report-data call failed (non-critical) for %s — %s", artist, title

--- a/tests/unit/test_report_data_task_1384.py
+++ b/tests/unit/test_report_data_task_1384.py
@@ -1,0 +1,109 @@
+"""Tests for the data-quality report follow-up task (#1384).
+
+Two regressions are guarded here:
+
+1. ``handle_report_data`` must launch ``_create_gh_issue`` via HA's
+   ``hass.async_create_background_task`` registry — not a bare
+   ``asyncio.ensure_future`` that HA never sees (which HA may garbage-collect
+   mid-flight and never cancels on unload).
+2. ``_create_gh_issue`` must reuse HA's shared aiohttp ClientSession via
+   ``async_get_clientsession(hass)`` instead of constructing a fresh
+   ``aiohttp.ClientSession()`` per call.
+"""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.beatify.game.state import GamePhase
+from custom_components.beatify.server import ws_handlers
+from custom_components.beatify.server.ws_handlers import (
+    _create_gh_issue,
+    handle_report_data,
+)
+from tests.conftest import make_player
+
+
+def _ws() -> AsyncMock:
+    ws = AsyncMock()
+    ws.send_json = AsyncMock()
+    ws.closed = False
+    return ws
+
+
+def _handler_and_state():
+    """A handler whose hass exposes a spyable async_create_background_task."""
+    handler = MagicMock()
+    handler.hass = MagicMock()
+    handler.hass.async_create_background_task = MagicMock()
+
+    game_state = MagicMock()
+    game_state.phase = GamePhase.REVEAL
+    game_state.current_song = {
+        "artist": "ABBA",
+        "title": "Waterloo",
+        "year": 1974,
+        "_playlist_source": "70s.json",
+    }
+    game_state.game_id = "g1"
+    game_state.get_player_by_ws.return_value = make_player("Alice")
+    return handler, game_state
+
+
+@pytest.mark.asyncio
+async def test_report_data_launches_tracked_background_task():
+    """The follow-up is registered as an HA background task, not orphaned."""
+    handler, game_state = _handler_and_state()
+    ws = _ws()
+    handler.hass.async_add_executor_job = AsyncMock()
+
+    coros: list = []
+
+    def _capture(coro, name=None):
+        coros.append((coro, name))
+        coro.close()  # never scheduled in the test; avoid "never awaited" warning
+        return MagicMock()
+
+    handler.hass.async_create_background_task.side_effect = _capture
+
+    # If the old bare ensure_future path were taken, this would fire instead.
+    with patch.object(ws_handlers.asyncio, "ensure_future") as ensure_future:
+        await handle_report_data(handler, ws, {}, game_state)
+
+    handler.hass.async_create_background_task.assert_called_once()
+    ensure_future.assert_not_called()
+
+    # Named so it is identifiable in HA's task registry.
+    assert coros[0][1] == "beatify-report-data"
+    ws.send_json.assert_awaited_once_with({"type": "report_data_ack"})
+
+
+@pytest.mark.asyncio
+async def test_create_gh_issue_reuses_shared_session():
+    """_create_gh_issue must use async_get_clientsession(hass), not a new one."""
+    hass = MagicMock()
+
+    resp = AsyncMock()
+    resp.status = 200
+
+    @asynccontextmanager
+    async def _post(*args, **kwargs):
+        yield resp
+
+    session = MagicMock()
+    session.post = _post
+
+    with (
+        patch.object(
+            ws_handlers, "async_get_clientsession", return_value=session
+        ) as get_session,
+        patch.object(ws_handlers.aiohttp, "ClientSession") as new_session,
+    ):
+        await _create_gh_issue(hass, "ABBA", "Waterloo", 1974, "70s.json", "Alice")
+
+    get_session.assert_called_once_with(hass)
+    # A per-call session must never be constructed.
+    new_session.assert_not_called()


### PR DESCRIPTION
Closes #1384

## Root cause
`handle_report_data` launched `_create_gh_issue` with a bare `asyncio.ensure_future` (untracked → HA can GC it mid-flight; not cancelled on unload), and `_create_gh_issue` opened a fresh `aiohttp.ClientSession()` per call instead of HA's shared session.

## Fix
- `handle_report_data` now launches the follow-up via `handler.hass.async_create_background_task(_create_gh_issue(hass, ...), name="beatify-report-data")` — HA holds a live reference and cancels it on unload.
- `_create_gh_issue` now takes `hass` and uses `session = async_get_clientsession(hass)` (the pattern already used in `views.py:296/665`, `playlist_views.py:201`) instead of constructing a per-call session.

## Files changed
- `custom_components/beatify/server/ws_handlers.py` — `handle_report_data` (task launch), `_create_gh_issue` (new `hass` param + shared session); added `async_get_clientsession` import + `HomeAssistant` TYPE_CHECKING import.
- `tests/unit/test_report_data_task_1384.py` — new (2 tests).

Net delta: +144 / −22 across 2 files.

## Sibling-overlap note
Touches `custom_components/beatify/server/ws_handlers.py` (`handle_report_data`, `_create_gh_issue`). Parallel resolvers for #1385/#1386/#1388 touch analytics/stats/errors persistence — flagging in case any of them also touch this handler's data-report write path (`_write_report` is left untouched here).

## Readiness assessment
- [x] Ready to merge
- [ ] Borderline — see notes
- [ ] Not ready — needs human review

**Honest summary:** Minimal, targeted change matching the exact fix described in the issue and the established session pattern elsewhere in the repo. Both new tests genuinely guard the regression (verified the assertions fail against the old code path). Backend-only, no UI surface.

## Test plan
- `python3 -m pytest` → 963 passed, 2 skipped.
- New `tests/unit/test_report_data_task_1384.py`: asserts the follow-up is launched via `async_create_background_task` (name `beatify-report-data`) and never via `asyncio.ensure_future`; asserts `_create_gh_issue` calls `async_get_clientsession(hass)` and never constructs a new `aiohttp.ClientSession`.
- `ruff check .` clean, `ruff format --check .` clean, `mypy` clean.

## Risk assessment
- **Blast radius:** the data-quality report follow-up (`handle_report_data` → `_create_gh_issue`) only; the synchronous JSON write (`_write_report`) is unchanged.
- **What could go wrong:** `async_create_background_task` requires HA ≥ 2023.4 (well below the integration's floor). Low risk.
- **What I did NOT test:** live network round-trip to the Cloudflare Worker (mocked); real HA task-registry cancellation on unload (only the registration call is asserted).

🤖 Auto-generated by issue-triage routine