### PR TITLE
fix: flash()/strobe() restore intensity-adjusted brightness in subtle mode (#1389)

### DIFF
--- a/custom_components/beatify/services/lights.py
+++ b/custom_components/beatify/services/lights.py
@@ -157,6 +157,30 @@ class PartyLightsService:
             len(self._wled_entities),
         )
 
+    def _phase_service_data(self, phase_name: str) -> dict[str, Any] | None:
+        """Build the service data (color + intensity-adjusted brightness) for a phase.
+
+        Single source of truth for the subtle/intensity brightness logic so that
+        set_phase() and the flash()/strobe() restore paths all agree — in subtle
+        mode they must restore to the gentle pre-game level, not full brightness
+        (#1389).
+        """
+        phase_data = PHASE_COLORS.get(phase_name)
+        if not phase_data:
+            return None
+
+        service_data = dict(phase_data)
+        if self._intensity == "subtle":
+            offset = int(SUBTLE_BRIGHTNESS_OFFSETS.get(phase_name, 0.0) * 255)
+            service_data["brightness"] = min(self._base_brightness + offset, 255)
+        else:
+            preset = INTENSITY_PRESETS.get(self._intensity, INTENSITY_PRESETS["medium"])
+            if "brightness" in service_data:
+                service_data["brightness"] = int(
+                    service_data["brightness"] * preset["brightness_scale"]
+                )
+        return service_data
+
     async def set_phase(self, phase: Any) -> None:
         """Apply phase-appropriate colors/brightness."""
         if not self._active or not self._entity_ids:
@@ -186,22 +210,9 @@ class PartyLightsService:
                 if phase_data:
                     await self._apply(non_wled, dict(phase_data), transition=1.0)
         else:
-            phase_data = PHASE_COLORS.get(phase_name)
-            if not phase_data:
+            service_data = self._phase_service_data(phase_name)
+            if service_data is None:
                 return
-
-            service_data = dict(phase_data)
-            if self._intensity == "subtle":
-                offset = int(SUBTLE_BRIGHTNESS_OFFSETS.get(phase_name, 0.0) * 255)
-                service_data["brightness"] = min(self._base_brightness + offset, 255)
-            else:
-                preset = INTENSITY_PRESETS.get(
-                    self._intensity, INTENSITY_PRESETS["medium"]
-                )
-                if "brightness" in service_data:
-                    service_data["brightness"] = int(
-                        service_data["brightness"] * preset["brightness_scale"]
-                    )
 
             await self._apply(self._entity_ids, service_data, transition=1.0)
 
@@ -230,14 +241,11 @@ class PartyLightsService:
 
         await asyncio.sleep(flash_dur)
 
-        # Restore phase color
-        if self._current_phase and self._current_phase in PHASE_COLORS:
-            phase_data = dict(PHASE_COLORS[self._current_phase])
-            if "brightness" in phase_data:
-                phase_data["brightness"] = int(
-                    phase_data["brightness"] * preset["brightness_scale"]
-                )
-            await self._apply(self._entity_ids, phase_data, transition=0.3)
+        # Restore phase color at the intensity-adjusted brightness (#1389) — in
+        # subtle mode this restores the gentle pre-game level, not full brightness.
+        restore_data = self._phase_service_data(self._current_phase or "")
+        if restore_data is not None:
+            await self._apply(self._entity_ids, restore_data, transition=0.3)
 
     async def start_beat_loop(self, bpm: int = 120) -> None:
         """Start a background beat-flash loop during PLAYING phase (#517)."""
@@ -289,10 +297,11 @@ class PartyLightsService:
                 transition=0.05,
             )
             await asyncio.sleep(interval / 2)
-        # Restore phase color
-        if self._current_phase and self._current_phase in PHASE_COLORS:
-            phase_data = dict(PHASE_COLORS[self._current_phase])
-            await self._apply(self._entity_ids, phase_data, transition=0.3)
+        # Restore phase color at the intensity-adjusted brightness (#1389) — in
+        # subtle mode this restores the gentle pre-game level, not full brightness.
+        restore_data = self._phase_service_data(self._current_phase or "")
+        if restore_data is not None:
+            await self._apply(self._entity_ids, restore_data, transition=0.3)
 
     async def celebrate(self) -> None:
         """Rainbow cycle celebration for ~5 seconds."""

--- a/tests/unit/test_lights.py
+++ b/tests/unit/test_lights.py
@@ -435,6 +435,99 @@ class TestFlash:
 
 
 # ---------------------------------------------------------------------------
+# subtle-mode restore (flash / strobe) — #1389
+# ---------------------------------------------------------------------------
+
+
+class TestSubtleRestore:
+    """flash() and strobe() must restore the subtle (pre-game) brightness, not full."""
+
+    @staticmethod
+    def _subtle_hass():
+        # Pre-game brightness 100 → base_brightness == 100 in subtle mode.
+        return _make_hass(
+            {
+                "light.living_room": {
+                    "state": "on",
+                    "attributes": {
+                        "supported_color_modes": ["rgb"],
+                        "brightness": 100,
+                        "rgb_color": [255, 255, 255],
+                    },
+                },
+            }
+        )
+
+    @pytest.mark.asyncio
+    async def test_flash_restores_subtle_brightness_not_full(self):
+        hass = self._subtle_hass()
+        svc = PartyLightsService(hass)
+        await svc.start(["light.living_room"], intensity="subtle")
+        svc._current_phase = "PLAYING"
+        hass.services.async_call.reset_mock()
+
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            await svc.flash("gold")
+
+        # PLAYING raw brightness is 153 (full). Subtle restore must be
+        # base (100) + 20% of 255 (51) = 151, NOT 153 and NOT 255.
+        expected = min(100 + int(0.2 * 255), 255)
+        restore_call = hass.services.async_call.call_args_list[1]
+        assert restore_call[0][2]["brightness"] == expected
+        assert restore_call[0][2]["brightness"] != 153
+        assert restore_call[0][2]["rgb_color"] == [0, 100, 255]
+
+    @pytest.mark.asyncio
+    async def test_strobe_restores_subtle_brightness_not_full(self):
+        hass = self._subtle_hass()
+        svc = PartyLightsService(hass)
+        await svc.start(["light.living_room"], intensity="subtle")
+        svc._current_phase = "REVEAL"
+        hass.services.async_call.reset_mock()
+
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            await svc.strobe(count=2, interval=0.1)
+
+        # REVEAL raw brightness is 204 (full). Subtle restore must be
+        # base (100) + 40% of 255 (102) = 202, NOT 204.
+        expected = min(100 + int(0.4 * 255), 255)
+        restore_call = hass.services.async_call.call_args_list[-1]
+        assert restore_call[0][2]["brightness"] == expected
+        assert restore_call[0][2]["brightness"] != 204
+
+    @pytest.mark.asyncio
+    async def test_strobe_restores_phase_color_in_medium_mode(self):
+        # Regression: non-subtle restore still applies the raw phase color.
+        hass = _make_hass()
+        svc = PartyLightsService(hass)
+        await svc.start(["light.living_room"], intensity="medium")
+        svc._current_phase = "PLAYING"
+        hass.services.async_call.reset_mock()
+
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            await svc.strobe(count=2, interval=0.1)
+
+        restore_call = hass.services.async_call.call_args_list[-1]
+        assert restore_call[0][2]["rgb_color"] == [0, 100, 255]
+        assert restore_call[0][2]["brightness"] == 153
+
+    @pytest.mark.asyncio
+    async def test_strobe_without_phase_does_not_restore(self):
+        hass = _make_hass()
+        svc = PartyLightsService(hass)
+        await svc.start(["light.living_room"])
+        svc._current_phase = None
+        hass.services.async_call.reset_mock()
+
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            await svc.strobe(count=1, interval=0.1)
+
+        # Two strobe applies (on + dim), no restore call with rgb_color.
+        for call in hass.services.async_call.call_args_list:
+            assert call[0][2].get("rgb_color") != [0, 100, 255]
+
+
+# ---------------------------------------------------------------------------
 # celebrate
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #1389

## Root cause
`set_phase()` computed subtle-mode brightness as `base_brightness + offset` (capped 255), but the restore paths in `flash()` and `strobe()` re-applied raw `PHASE_COLORS` (strobe: no adjustment at all; flash: scaled only by `brightness_scale`, always 1.0). So in subtle mode every answer-reveal flash / countdown strobe permanently jumped the room from the gentle pre-game level to full game brightness until the next phase change.

## Fix
Extracted a single `_phase_service_data(phase_name)` helper holding the subtle/intensity brightness logic, and routed `set_phase()`, `flash()`, and `strobe()` restore paths through it so all three agree. The transient flash-on / strobe-on peaks stay deliberately bright; only the restore now respects subtle mode.

**Changed:**
- `custom_components/beatify/services/lights.py` — new `_phase_service_data()`; `set_phase()`, `flash()`, `strobe()` use it.
- `tests/unit/test_lights.py` — new `TestSubtleRestore` (flash + strobe subtle restore, medium-mode regression, no-phase guard).

Net: +129 / -27 across 2 files.

## Readiness assessment
- [x] Ready to merge
- [ ] Borderline — see notes
- [ ] Not ready — needs human review

**Honest summary:** Backend-only, no UI surface. Behavior change is narrow (restore brightness in subtle mode) and fully covered by new tests asserting flash restores 151 (not 153/255) and strobe restores 202 (not 204). Medium/party modes unchanged (regression test confirms raw phase color + brightness still applied).

## Test plan
- `python3 -m pytest` — 995 passed, 2 skipped.
- `ruff check .` + `ruff format --check .` — clean (ruff 0.15.7, CI-pinned).
- `mypy` — no issues (lights.py is in the gated `files` list).
- Manual: start party lights in subtle mode at a low pre-game brightness, trigger a flash (answer reveal) and a strobe (countdown) — room returns to the gentle subtle level, not full brightness.

## Risk assessment
- **Blast radius:** `services/lights.py` only (PartyLightsService restore paths).
- **What could go wrong:** none expected; logic is a refactor-to-single-source plus the documented subtle-mode correction.
- **What I did NOT test:** real Home Assistant hardware / WLED-mode interaction (WLED path unchanged — flash/strobe restore applies to the non-WLED color path as before).

## Sibling note (merge sequencing)
Parallel resolver **#1390** (WLED END preset) likely touches the SAME file `custom_components/beatify/services/lights.py`. My change adds `_phase_service_data()` and edits `set_phase()`/`flash()`/`strobe()` restore blocks; #1390 is expected around the WLED `END`/preset path. Functions touched here: `_phase_service_data` (new), `set_phase`, `flash`, `strobe`. Sequence at merge to avoid overlap.

🤖 Auto-generated by issue-triage routine