### PR TITLE
fix: apply configured WLED END preset before END early-return (#1390)

### DIFF
--- a/custom_components/beatify/services/lights.py
+++ b/custom_components/beatify/services/lights.py
@@ -170,7 +170,15 @@ class PartyLightsService:
             await self.stop_beat_loop()
 
         if phase_name == "END":
-            # END phase triggers celebration via separate call
+            # END phase triggers the rainbow celebration via a separate
+            # celebrate() call. In WLED mode, though, the user-configured END
+            # preset must still fire here — celebrate() only drives raw rgb
+            # colors and skips WLED entities (#1390).
+            if self._light_mode == "wled" and self._wled_entities:
+                preset_id = self._wled_presets.get("END")
+                if preset_id is not None:
+                    for entity_id in self._wled_entities:
+                        await self._apply_wled(entity_id, preset_id)
             return
 
         # WLED mode: activate preset instead of setting colors
@@ -300,6 +308,16 @@ class PartyLightsService:
             return
 
         _LOGGER.info("Party Lights celebration sequence started")
+        # In WLED mode the END preset is applied by set_phase(); the rainbow
+        # cycle only drives raw rgb, so skip WLED entities to preserve their
+        # configured END preset (#1390).
+        if self._light_mode == "wled":
+            entities = [e for e in self._entity_ids if e not in self._wled_entities]
+        else:
+            entities = list(self._entity_ids)
+        if not entities:
+            return
+
         if self._intensity == "subtle":
             offset = int(SUBTLE_BRIGHTNESS_OFFSETS["END"] * 255)
             brightness = min(self._base_brightness + offset, 255)
@@ -309,7 +327,7 @@ class PartyLightsService:
             if not self._active:
                 break
             await self._apply(
-                self._entity_ids,
+                entities,
                 {"rgb_color": color, "brightness": brightness},
                 transition=0.3,
             )

--- a/tests/unit/test_lights.py
+++ b/tests/unit/test_lights.py
@@ -490,6 +490,104 @@ class TestCelebrate:
 
 
 # ---------------------------------------------------------------------------
+# WLED END preset reachability (#1390)
+# ---------------------------------------------------------------------------
+
+
+class TestWledEndPreset:
+    """The configured END WLED preset must fire despite the END early-return."""
+
+    @pytest.mark.asyncio
+    async def test_set_phase_end_applies_wled_preset(self):
+        """END in wled mode applies the configured END preset, not raw rgb."""
+        hass = _make_hass()
+        svc = PartyLightsService(hass)
+        await svc.start(["light.wled_strip"])
+        # Configure wled mode + a WLED entity (detection happens in start()
+        # via the entity registry; emulate the configured result here).
+        svc._light_mode = "wled"
+        svc._wled_entities = {"light.wled_strip"}
+        hass.services.async_call.reset_mock()
+
+        with patch.object(svc, "_apply_wled", new_callable=AsyncMock) as apply_wled:
+            phase = _make_phase("END")
+            await svc.set_phase(phase)
+
+        assert svc._current_phase == "END"
+        # END preset default is 6.
+        apply_wled.assert_awaited_once_with("light.wled_strip", 6)
+        # No raw rgb commands to lights for the WLED entity.
+        hass.services.async_call.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_set_phase_end_honors_custom_end_preset(self):
+        """A user-configured END preset overrides the default."""
+        hass = _make_hass()
+        svc = PartyLightsService(hass)
+        await svc.start(
+            ["light.wled_strip"],
+            light_mode="wled",
+            wled_presets={"END": 12},
+        )
+        svc._light_mode = "wled"
+        svc._wled_entities = {"light.wled_strip"}
+        hass.services.async_call.reset_mock()
+
+        with patch.object(svc, "_apply_wled", new_callable=AsyncMock) as apply_wled:
+            await svc.set_phase(_make_phase("END"))
+
+        apply_wled.assert_awaited_once_with("light.wled_strip", 12)
+
+    @pytest.mark.asyncio
+    async def test_set_phase_end_non_wled_mode_skips_wled(self):
+        """In non-wled mode END stays an early-return no-op (celebrate handles it)."""
+        hass = _make_hass()
+        svc = PartyLightsService(hass)
+        await svc.start(["light.living_room"])
+        hass.services.async_call.reset_mock()
+
+        with patch.object(svc, "_apply_wled", new_callable=AsyncMock) as apply_wled:
+            await svc.set_phase(_make_phase("END"))
+
+        apply_wled.assert_not_awaited()
+        hass.services.async_call.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_celebrate_skips_wled_entities_in_wled_mode(self):
+        """Rainbow celebration must not overwrite the WLED END preset."""
+        hass = _make_hass()
+        svc = PartyLightsService(hass)
+        await svc.start(["light.wled_strip", "light.living_room"])
+        svc._light_mode = "wled"
+        svc._wled_entities = {"light.wled_strip"}
+        hass.services.async_call.reset_mock()
+
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            await svc.celebrate()
+
+        # Every rainbow command targets only the non-WLED entity.
+        targeted = {
+            call[0][2]["entity_id"] for call in hass.services.async_call.call_args_list
+        }
+        assert targeted == {"light.living_room"}
+
+    @pytest.mark.asyncio
+    async def test_celebrate_wled_only_setup_is_noop(self):
+        """If every entity is WLED, celebrate sends no raw rgb at all."""
+        hass = _make_hass()
+        svc = PartyLightsService(hass)
+        await svc.start(["light.wled_strip"])
+        svc._light_mode = "wled"
+        svc._wled_entities = {"light.wled_strip"}
+        hass.services.async_call.reset_mock()
+
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            await svc.celebrate()
+
+        hass.services.async_call.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
 # _get_capability
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #1390

## Root cause
`set_phase()` returned early on phase `END` (delegating light effects to a
separate `celebrate()` call) **before** reaching the WLED branch. So a
user-configured END WLED preset (`WLED_PRESET_DEFAULTS["END"] = 6`) was silently
dead config, and `celebrate()` only drives raw rainbow rgb on every entity —
WLED strips got raw colors instead of their chosen END preset.

## Fix
- `set_phase()`: before the `END` early-return, when `light_mode == "wled"` and
  WLED entities are present, apply the configured END preset via `_apply_wled()`
  to each WLED entity.
- `celebrate()`: in wled mode, skip WLED entities (they already received their
  END preset in `set_phase()`); the rainbow cycle now targets only non-WLED
  entities. WLED-only setups make `celebrate()` a no-op.

## Files changed
- `custom_components/beatify/services/lights.py` — functions `PartyLightsService.set_phase` and `PartyLightsService.celebrate` (+22 / −2)
- `tests/unit/test_lights.py` — new `TestWledEndPreset` class, 5 tests (+98)

Net delta: 2 files, +118 / −4.

## Readiness assessment
- [x] Ready to merge
- [ ] Borderline — see notes
- [ ] Not ready — needs human review

**Honest summary:** Small, scoped control-flow fix with direct tests proving the
END WLED preset now fires and that celebrate() no longer clobbers WLED entities.
Backend-only (no `www/**`), so no min.js / cache-buster / sw.js concerns. Full
suite green (996 passed, 2 skipped), ruff check + ruff format --check clean,
mypy clean (lights.py is in the mypy `files` scope).

## Test plan
- New tests: END in wled mode calls `_apply_wled(entity, 6)`; custom END preset
  (12) honored; non-wled END stays a no-op; `celebrate()` targets only non-WLED
  entities in wled mode; WLED-only celebrate is a no-op.
- Regression: existing `test_set_phase_end_does_not_apply_colors` still passes
  (default mode, no WLED entities → early-return no-op).
- Manual: configure a WLED strip in wled mode with a custom END preset, finish a
  game, confirm the strip activates the END preset rather than cycling raw rgb.

## Risk assessment
- **Blast radius:** `lights.py` `set_phase` + `celebrate` only. Non-wled mode and
  non-END phases are unchanged.
- **What could go wrong:** if WLED detection (`_wled_entities`) is empty at END,
  behavior is identical to before (preset skipped, raw rgb) — i.e. no regression,
  just no improvement when detection fails.
- **What I did NOT test:** real WLED hardware / live HA; preset entity resolution
  inside `_apply_wled` is unchanged and out of scope.

## Sibling overlap (#1389)
Parallel resolver #1389 (flash/strobe intensity) likely touches the same
`lights.py`. My change is confined to `set_phase` (END branch) and `celebrate`;
#1389's flash/strobe intensity work is in different functions. Touched
functions named above for merge sequencing.

🤖 Auto-generated by issue-triage routine