### PR TITLE
fix: cancel game tasks/timers and close WebSockets on unload (#1391)

### DIFF
--- a/custom_components/beatify/__init__.py
+++ b/custom_components/beatify/__init__.py
@@ -276,6 +276,27 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     except KeyError:
         _LOGGER.debug("Beatify sidebar panel was not registered, skipping removal")
 
+    # #1391: tear down the live game infrastructure BEFORE popping hass.data,
+    # otherwise running game tasks/timers and open WebSockets keep operating on
+    # an orphaned GameState/handler (and race a fresh GameState after reload —
+    # two timers driving one media player). Best-effort so a teardown error here
+    # never blocks the unload.
+    domain_data = hass.data.get(DOMAIN, {})
+    game_state = domain_data.get("game")
+    if game_state is not None:
+        try:
+            game_state.async_shutdown()
+        except Exception:  # noqa: BLE001
+            _LOGGER.warning("Error shutting down game state on unload", exc_info=True)
+    ws_handler = domain_data.get("ws_handler")
+    if ws_handler is not None:
+        try:
+            await ws_handler.async_close_all()
+        except Exception:  # noqa: BLE001
+            _LOGGER.warning(
+                "Error closing WebSocket connections on unload", exc_info=True
+            )
+
     # Clean up domain data
     if DOMAIN in hass.data:
         hass.data.pop(DOMAIN)

--- a/custom_components/beatify/game/state.py
+++ b/custom_components/beatify/game/state.py
@@ -386,6 +386,31 @@ class GameState(
         for cb in self._state_callbacks:
             cb()
 
+    def async_shutdown(self) -> None:
+        """Cancel every running game task/timer on integration unload (#1391).
+
+        ``async_unload_entry`` pops ``hass.data[DOMAIN]`` but never tore down the
+        live game infrastructure. If a game was active at unload, the round-timer
+        task (``_timer_task``), the intro auto-stop timer (``_intro_stop_task``),
+        the background metadata task (``_metadata_task``), the REVEAL
+        ``_auto_advance_task`` and the fire-and-forget ``_bg_tasks`` (#391) all
+        kept running against an orphaned GameState — firing media_player service
+        calls and racing a fresh GameState after reload (two timers driving one
+        media player). This cancels them all idempotently.
+        """
+        # Round timer, intro timer, and background metadata task all live on the
+        # RoundManager (their cancel helpers are defensive no-ops when idle).
+        self._round_manager.cancel_timer()
+        self._round_manager._cancel_intro_timer()
+        self._round_manager._cancel_metadata_task()
+        # REVEAL auto-advance task (#1012).
+        self._cancel_auto_advance()
+        # Fire-and-forget party-light / media / TTS tasks (#391).
+        for task in list(self._bg_tasks):
+            if not task.done():
+                task.cancel()
+        self._bg_tasks.clear()
+
     # ------------------------------------------------------------------
     # Phase transitions — Single Source of Truth (Issue #1273)
     # ------------------------------------------------------------------

--- a/custom_components/beatify/server/websocket.py
+++ b/custom_components/beatify/server/websocket.py
@@ -7,7 +7,7 @@ import logging
 import time
 from typing import TYPE_CHECKING
 
-from aiohttp import WSMsgType, web
+from aiohttp import WSCloseCode, WSMsgType, web
 
 from custom_components.beatify.const import (
     ERR_GAME_NOT_STARTED,
@@ -506,6 +506,41 @@ class BeatifyWebSocketHandler:
         self._admin_disconnect_task = None
 
         _LOGGER.debug("Cleaned up all pending game tasks")
+
+    async def async_close_all(self) -> None:
+        """Cancel pending tasks and close every open WebSocket on unload (#1391).
+
+        ``async_unload_entry`` previously left this handler's tasks
+        (``_pending_removals``, ``_admin_disconnect_task``,
+        ``_broadcast_debounce_task``) running and every player/admin WebSocket
+        open, pinning the orphaned handler + GameState after the integration was
+        torn down. This cancels all of them and sends each client a going-away
+        close so they reconnect cleanly to a fresh handler after reload.
+        """
+        # Reuse the existing pending-task cleanup (_pending_removals +
+        # _admin_disconnect_task), then additionally cancel the debounce task
+        # that cleanup_game_tasks does not cover.
+        await self.cleanup_game_tasks()
+        if self._broadcast_debounce_task and not self._broadcast_debounce_task.done():
+            self._broadcast_debounce_task.cancel()
+        self._broadcast_debounce_task = None
+
+        # Close every open connection with a going-away code. Snapshot the set
+        # first: ws.close() resolves the handle() finally-block which discards
+        # from self.connections, mutating it mid-iteration otherwise.
+        for ws in list(self.connections):
+            if not ws.closed:
+                try:
+                    await ws.close(
+                        code=WSCloseCode.GOING_AWAY, message=b"beatify-unload"
+                    )
+                except Exception:  # noqa: BLE001 — best-effort teardown
+                    _LOGGER.debug(
+                        "Error closing WebSocket during unload", exc_info=True
+                    )
+        self.connections.clear()
+
+        _LOGGER.debug("Closed all WebSocket connections on unload")
 
     def cancel_pending_removal(self, player_name: str) -> None:
         """

--- a/tests/unit/test_unload_teardown.py
+++ b/tests/unit/test_unload_teardown.py
@@ -1,0 +1,266 @@
+"""Regression tests for unload teardown of game tasks/timers/WebSockets (#1391).
+
+``async_unload_entry`` used to pop ``hass.data[DOMAIN]`` without shutting down
+the live game infrastructure. A game active at unload left the round-timer task,
+intro timer, background metadata task, the REVEAL auto-advance task and the
+fire-and-forget ``_bg_tasks`` running against an orphaned ``GameState``, plus the
+WebSocket handler's pending tasks and every open player/admin connection — which
+then raced a fresh ``GameState`` after reload (two timers driving one media
+player).
+
+These tests prove:
+1. ``GameState.async_shutdown()`` cancels every running game task/timer.
+2. ``BeatifyWebSocketHandler.async_close_all()`` cancels its pending tasks and
+   closes every open WebSocket with a going-away code.
+3. ``async_unload_entry`` invokes both before popping ``hass.data[DOMAIN]``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from types import ModuleType, SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.beatify.server.websocket import BeatifyWebSocketHandler
+from tests.conftest import make_game_state
+
+
+# ---------------------------------------------------------------------------
+# 1. GameState.async_shutdown()
+# ---------------------------------------------------------------------------
+
+
+async def _never() -> None:
+    """A coroutine that never completes — stands in for a live timer task."""
+    await asyncio.Event().wait()
+
+
+@pytest.mark.asyncio
+async def test_async_shutdown_cancels_every_game_task():
+    """async_shutdown cancels the round/intro/metadata/auto-advance/bg tasks."""
+    game = make_game_state()
+    rm = game._round_manager
+
+    rm._timer_task = asyncio.ensure_future(_never())
+    rm._intro_stop_task = asyncio.ensure_future(_never())
+    rm._metadata_task = asyncio.ensure_future(_never())
+    game._auto_advance_task = asyncio.ensure_future(_never())
+    bg = asyncio.ensure_future(_never())
+    game._bg_tasks.add(bg)
+
+    handles = [
+        rm._timer_task,
+        rm._intro_stop_task,
+        rm._metadata_task,
+        game._auto_advance_task,
+        bg,
+    ]
+
+    game.async_shutdown()
+    # Give the loop a tick so the cancellations propagate.
+    await asyncio.sleep(0)
+
+    for task in handles:
+        assert task.cancelled() or task.done(), f"{task!r} still running after shutdown"
+
+    # Slots cleared so nothing dangles / re-cancels.
+    assert rm._timer_task is None
+    assert rm._intro_stop_task is None
+    assert rm._metadata_task is None
+    assert game._auto_advance_task is None
+    assert game._bg_tasks == set()
+
+
+@pytest.mark.asyncio
+async def test_async_shutdown_idempotent_when_idle():
+    """async_shutdown is a no-op when no game is running (no exceptions)."""
+    game = make_game_state()
+    # No tasks set anywhere — must not raise.
+    game.async_shutdown()
+    game.async_shutdown()
+
+
+# ---------------------------------------------------------------------------
+# 2. BeatifyWebSocketHandler.async_close_all()
+# ---------------------------------------------------------------------------
+
+
+def _make_handler() -> BeatifyWebSocketHandler:
+    return BeatifyWebSocketHandler(MagicMock())
+
+
+@pytest.mark.asyncio
+async def test_async_close_all_cancels_pending_tasks():
+    """Pending removals, admin-disconnect, and debounce tasks are cancelled."""
+    handler = _make_handler()
+
+    removal = asyncio.ensure_future(_never())
+    admin = asyncio.ensure_future(_never())
+    debounce = asyncio.ensure_future(_never())
+    handler._pending_removals["Alice"] = removal
+    handler._admin_disconnect_task = admin
+    handler._broadcast_debounce_task = debounce
+
+    await handler.async_close_all()
+    await asyncio.sleep(0)
+
+    assert removal.cancelled() or removal.done()
+    assert admin.cancelled() or admin.done()
+    assert debounce.cancelled() or debounce.done()
+    assert handler._pending_removals == {}
+    assert handler._admin_disconnect_task is None
+    assert handler._broadcast_debounce_task is None
+
+
+@pytest.mark.asyncio
+async def test_async_close_all_closes_open_connections():
+    """Every open WebSocket is closed with the going-away code; set is cleared."""
+    from aiohttp import WSCloseCode
+
+    handler = _make_handler()
+    ws_open = AsyncMock()
+    ws_open.closed = False
+    ws_open.close = AsyncMock()
+    ws_already_closed = AsyncMock()
+    ws_already_closed.closed = True
+    ws_already_closed.close = AsyncMock()
+
+    handler.connections.add(ws_open)
+    handler.connections.add(ws_already_closed)
+
+    await handler.async_close_all()
+
+    ws_open.close.assert_awaited_once()
+    assert ws_open.close.await_args.kwargs["code"] == WSCloseCode.GOING_AWAY
+    # An already-closed connection is not re-closed.
+    ws_already_closed.close.assert_not_called()
+    assert handler.connections == set()
+
+
+@pytest.mark.asyncio
+async def test_async_close_all_survives_close_error():
+    """A close() that raises does not abort teardown of the remaining sockets."""
+    handler = _make_handler()
+    ws_bad = AsyncMock()
+    ws_bad.closed = False
+    ws_bad.close = AsyncMock(side_effect=RuntimeError("boom"))
+    ws_good = AsyncMock()
+    ws_good.closed = False
+    ws_good.close = AsyncMock()
+    handler.connections.update({ws_bad, ws_good})
+
+    await handler.async_close_all()
+
+    ws_good.close.assert_awaited_once()
+    assert handler.connections == set()
+
+
+# ---------------------------------------------------------------------------
+# 3. async_unload_entry wiring
+# ---------------------------------------------------------------------------
+# Stub the homeassistant surface the integration's top-level __init__ imports at
+# module load (mirrors tests/unit/test_setup_reload_routes.py).
+
+
+def _ensure_module(name: str) -> ModuleType:
+    mod = sys.modules.get(name)
+    if mod is None:
+        mod = ModuleType(name)
+        sys.modules[name] = mod
+    return mod
+
+
+_ensure_module("homeassistant")
+_ensure_module("homeassistant.components")
+_frontend = _ensure_module("homeassistant.components.frontend")
+_frontend.async_register_built_in_panel = MagicMock()
+_frontend.async_remove_panel = MagicMock()
+
+_http = _ensure_module("homeassistant.components.http")
+_http.StaticPathConfig = MagicMock(name="StaticPathConfig")
+
+
+class _HomeAssistantView:  # minimal base for server.views import
+    url = ""
+    name = ""
+    requires_auth = False
+
+
+_http.HomeAssistantView = _HomeAssistantView
+
+_helpers = _ensure_module("homeassistant.helpers")
+_aiohttp_client = _ensure_module("homeassistant.helpers.aiohttp_client")
+_aiohttp_client.async_get_clientsession = MagicMock()
+_event = _ensure_module("homeassistant.helpers.event")
+_event.async_track_state_change_event = MagicMock()
+_er = _ensure_module("homeassistant.helpers.entity_registry")
+_er.async_get = MagicMock()
+_exceptions = _ensure_module("homeassistant.exceptions")
+
+
+class _HomeAssistantError(Exception):
+    pass
+
+
+class _ServiceNotFound(Exception):
+    pass
+
+
+_exceptions.HomeAssistantError = _HomeAssistantError
+_exceptions.ServiceNotFound = _ServiceNotFound
+
+import custom_components.beatify as beatify_init  # noqa: E402
+from custom_components.beatify.const import DOMAIN  # noqa: E402
+
+
+def _unload_hass(domain_data: dict) -> MagicMock:
+    hass = MagicMock()
+    hass.data = {DOMAIN: domain_data}
+    hass.config_entries.async_unload_platforms = AsyncMock(return_value=True)
+    return hass
+
+
+@pytest.mark.asyncio
+async def test_unload_entry_shuts_down_game_and_closes_ws():
+    """async_unload_entry tears down game + ws BEFORE popping hass.data."""
+    game = MagicMock()
+    game.async_shutdown = MagicMock()
+    ws_handler = MagicMock()
+    ws_handler.async_close_all = AsyncMock()
+
+    hass = _unload_hass({"game": game, "ws_handler": ws_handler})
+    entry = SimpleNamespace(entry_id="e1")
+
+    assert await beatify_init.async_unload_entry(hass, entry) is True
+
+    game.async_shutdown.assert_called_once()
+    ws_handler.async_close_all.assert_awaited_once()
+    # Domain data popped after teardown.
+    assert DOMAIN not in hass.data
+
+
+@pytest.mark.asyncio
+async def test_unload_entry_tolerates_missing_game_infrastructure():
+    """No game/ws_handler in hass.data → unload still succeeds, no crash."""
+    hass = _unload_hass({})
+    entry = SimpleNamespace(entry_id="e1")
+    assert await beatify_init.async_unload_entry(hass, entry) is True
+    assert DOMAIN not in hass.data
+
+
+@pytest.mark.asyncio
+async def test_unload_entry_swallows_teardown_errors():
+    """A teardown error never blocks the unload (data still popped)."""
+    game = MagicMock()
+    game.async_shutdown = MagicMock(side_effect=RuntimeError("boom"))
+    ws_handler = MagicMock()
+    ws_handler.async_close_all = AsyncMock(side_effect=RuntimeError("boom"))
+
+    hass = _unload_hass({"game": game, "ws_handler": ws_handler})
+    entry = SimpleNamespace(entry_id="e1")
+
+    assert await beatify_init.async_unload_entry(hass, entry) is True
+    assert DOMAIN not in hass.data


### PR DESCRIPTION
Closes #1391

## Root cause
`async_unload_entry` (`custom_components/beatify/__init__.py`) popped `hass.data[DOMAIN]` but never tore down the live game infrastructure. With a game active at unload, the round-timer task, intro timer, background metadata task, the REVEAL `_auto_advance_task`, the fire-and-forget `_bg_tasks`, and the WebSocket handler's pending tasks all kept running against an orphaned `GameState`/handler, and every player/admin WebSocket stayed open. After reload they raced a fresh `GameState` (two timers driving one media player).

## What changed (exact functions — for merge sequencing)
- **`custom_components/beatify/game/state.py`** — new `GameState.async_shutdown()` (placed after `_notify_state_callbacks`). Cancels `_round_manager._timer_task` (`cancel_timer`), `_intro_stop_task` (`_cancel_intro_timer`), `_metadata_task` (`_cancel_metadata_task`), `_auto_advance_task` (`_cancel_auto_advance`), and all `_bg_tasks` (#391). Idempotent / safe when idle.
- **`custom_components/beatify/server/websocket.py`** — new `BeatifyWebSocketHandler.async_close_all()` (placed after `cleanup_game_tasks`). Reuses `cleanup_game_tasks()` (`_pending_removals` + `_admin_disconnect_task`), additionally cancels `_broadcast_debounce_task`, and closes every open connection with `WSCloseCode.GOING_AWAY`. Added `WSCloseCode` to the `aiohttp` import.
- **`custom_components/beatify/__init__.py`** — `async_unload_entry`: fetches `game`/`ws_handler` from `hass.data[DOMAIN]` and calls `game_state.async_shutdown()` + `await ws_handler.async_close_all()` (each wrapped best-effort) **before** popping `hass.data[DOMAIN]`. No other part of `async_unload_entry` touched.
- **`tests/unit/test_unload_teardown.py`** — new, 8 tests.

### Overlap note (per resolver brief)
`async_unload_entry` is also touched by sibling #1392 and by open PR #1433 (errors-debounce `async_shutdown`). This change is scoped to the new teardown block only (added immediately before the existing `hass.data.pop(DOMAIN)`); the platform-unload and panel-removal lines are unchanged. If #1433 merges first, expect a trivial context rebase around the pop. The method name `GameState.async_shutdown()` here is the game-task/timer teardown — confirm it doesn't collide with #1433's errors-debounce `async_shutdown` (different class) before merge.

## Readiness assessment
- [x] Ready to merge
- [ ] Borderline — see notes
- [ ] Not ready — needs human review

**Honest summary:** Tightly scoped, additive teardown reusing existing cancel helpers; all gates green. Shaky-ish: the real `ws.close()` GOING_AWAY behaviour and the `handle()` finally-block / `self.connections` mutation interplay are covered by mock-based unit tests, not a live aiohttp connection — verified by snapshotting `list(self.connections)` before iterating.

## Test plan
- Automated: `tests/unit/test_unload_teardown.py` — `async_shutdown` cancels all 5 task kinds + clears slots; idle no-op; `async_close_all` cancels pending/admin/debounce tasks, closes open sockets with GOING_AWAY, skips already-closed, survives a `close()` error; `async_unload_entry` invokes both before pop, tolerates missing infra, swallows teardown errors.
- Manual: start a game, trigger a config-entry reload mid-round, confirm no orphaned timer fires media_player calls and players reconnect cleanly to the fresh handler.

## Risk assessment
- **Blast radius:** unload path only (`async_unload_entry`) + two new methods on `GameState` / `BeatifyWebSocketHandler`. No setup-path or in-game behaviour changed.
- **What could go wrong:** if a future caller relies on `_bg_tasks` surviving teardown (none today); if #1433 introduces a name-colliding `async_shutdown`.
- **What I did NOT test:** live aiohttp WebSocket close handshake; concurrent unload+active-game on a real HA instance.

🤖 Auto-generated by issue-triage routine