### PR TITLE
fix: bound OAuth login retry loop on persistent exchange failure (#1394)

### DIFF
--- a/custom_components/beatify/www/js/__tests__/ha-auth.test.js
+++ b/custom_components/beatify/www/js/__tests__/ha-auth.test.js
@@ -28,6 +28,8 @@ function loadHaAuth({
     userAgent = '',
     externalApp = null,
     externalAppV2 = null,
+    sessionStorageData = {},
+    withDomBody = false,
 } = {}) {
     const storage = (initial) => {
         const map = new Map(Object.entries(initial));
@@ -39,14 +41,46 @@ function loadHaAuth({
         };
     };
     const ls = storage(localStorageData);
-    const ss = storage({});
+    const ss = storage(sessionStorageData);
 
     // Mutable cookie jar — JS reads via document.cookie, our shim allows
     // tests to seed an initial value and inspect mutations. Honors
     // Max-Age=0 by actually removing the entry, matching browsers.
     const cookieJar = { value: cookie };
+    // Minimal DOM shim so #1394's _renderAuthError() can mount its error card.
+    // Only created when withDomBody is set; otherwise document has no body and
+    // _renderAuthError() short-circuits (matching a not-yet-painted page).
+    let bodyShim = null;
+    if (withDomBody) {
+        const makeEl = () => {
+            const el = {
+                style: { cssText: '' },
+                children: [],
+                _listeners: {},
+                setAttribute() {},
+                set innerHTML(html) { this._html = html; },
+                get innerHTML() { return this._html || ''; },
+                appendChild(c) { this.children.push(c); return c; },
+                addEventListener(ev, fn) { this._listeners[ev] = fn; },
+                querySelector() { return makeEl(); },
+            };
+            return el;
+        };
+        bodyShim = makeEl();
+    }
     const documentShim = {
         title: 'test',
+        body: bodyShim,
+        createElement: bodyShim ? () => ({
+            style: { cssText: '' },
+            _listeners: {},
+            id: '',
+            setAttribute() {},
+            set innerHTML(html) { this._html = html; },
+            get innerHTML() { return this._html || ''; },
+            appendChild() {},
+            querySelector() { return { addEventListener: () => {} }; },
+        }) : undefined,
         get cookie() { return cookieJar.value; },
         set cookie(v) {
             const name = v.split('=')[0];
@@ -108,6 +142,9 @@ function loadHaAuth({
         BeatifyAuth: sandboxWindow.BeatifyAuth,
         cookieJar,
         localStorage: ls,
+        sessionStorage: ss,
+        documentShim,
+        bodyShim,
         sandboxWindow,
     };
 }
@@ -265,6 +302,97 @@ describe('init() auth callback handling', () => {
         ]);
         expect(result).toBe('LOGIN_NAVIGATED');
         expect(cookieJar.value).not.toContain('beatify_access=');
+    });
+});
+
+describe('bounded login loop on persistent OAuth failure (#1394)', () => {
+    const K = 'beatify_login_attempts';
+
+    function failingCallback(attemptsSoFar) {
+        // Each "page load" arrives back from the server with ?auth_error= and
+        // carries forward the attempt counter in sessionStorage (which survives
+        // the redirect in a real browser).
+        return loadHaAuth({
+            fetchFn: async () => ({ ok: false, status: 401, json: async () => ({}) }),
+            sessionStorageData: attemptsSoFar > 0 ? { [K]: String(attemptsSoFar) } : {},
+            withDomBody: true,
+        });
+    }
+
+    it('keeps redirecting while under the attempt budget, incrementing the counter', async () => {
+        // First failed callback: counter 0 -> 1, still redirects.
+        const ctx = failingCallback(0);
+        ctx.sandboxWindow.location.search = '?auth_error=exchange_failed';
+        const result = await Promise.race([
+            ctx.BeatifyAuth.init({ requireAuth: true }),
+            new Promise((r) => setTimeout(() => r('LOGIN_NAVIGATED'), 5)),
+        ]);
+        expect(result).toBe('LOGIN_NAVIGATED');
+        expect(ctx.sandboxWindow.location._lastReplace).toContain('/auth/authorize');
+        expect(ctx.sessionStorage.getItem(K)).toBe('1');
+    });
+
+    it('stops redirecting and renders an error once the budget is exhausted', async () => {
+        // Arrive back on the page with the counter already at the max (3 prior
+        // failed login redirects). The 4th callback must NOT redirect again.
+        const ctx = failingCallback(3);
+        ctx.sandboxWindow.location.search = '?auth_error=exchange_failed';
+        const result = await ctx.BeatifyAuth.init({ requireAuth: true });
+        // init() resolves (does NOT hang on a never-resolving login redirect).
+        expect(result).toBe(false);
+        // No new /auth/authorize redirect was issued.
+        expect(ctx.sandboxWindow.location._lastReplace).toBeUndefined();
+        // A user-visible error card was mounted instead of looping.
+        expect(ctx.bodyShim.children.length).toBe(1);
+    });
+
+    it('drives the full loop to a bounded stop (no infinite redirect)', async () => {
+        // Simulate consecutive page loads, carrying the counter forward each
+        // time exactly as a real browser would across the redirect bounce.
+        let attempts = 0;
+        let redirects = 0;
+        for (let i = 0; i < 10; i++) {
+            const ctx = failingCallback(attempts);
+            ctx.sandboxWindow.location.search = '?auth_error=exchange_failed';
+            const result = await Promise.race([
+                ctx.BeatifyAuth.init({ requireAuth: true }),
+                new Promise((r) => setTimeout(() => r('LOGIN_NAVIGATED'), 5)),
+            ]);
+            const next = ctx.sessionStorage.getItem(K);
+            attempts = next ? parseInt(next, 10) : attempts;
+            if (result === 'LOGIN_NAVIGATED') redirects += 1;
+            else break; // budget exhausted — loop terminated
+        }
+        // Loop is bounded: at most MAX_LOGIN_ATTEMPTS (3) redirects, then stop.
+        expect(redirects).toBe(3);
+    });
+
+    it('resets the counter after a successful callback so later sessions get a fresh budget', async () => {
+        const farFuture = Math.floor(Date.now() / 1000) + 3600;
+        const ctx = loadHaAuth({
+            cookie: cookieFor('beatify_access', { access_token: 'freshly-set', expires_at: farFuture }),
+            sessionStorageData: { [K]: '2' }, // two prior failures
+            withDomBody: true,
+        });
+        ctx.sandboxWindow.sessionStorage.setItem('beatify_ha_oauth_state', 'state-ok');
+        ctx.sandboxWindow.location.search = '?auth_state=state-ok';
+        const ok = await ctx.BeatifyAuth.init({ requireAuth: true });
+        expect(ok).toBe(true);
+        // Counter cleared on the successful callback.
+        expect(ctx.sessionStorage.getItem(K)).toBeNull();
+    });
+
+    it('also bounds the refresh-failed branch (no callback, refresh keeps failing)', async () => {
+        // No ?auth_error in the URL: init() falls through to refreshAccess(),
+        // which 401s. With the counter at max, it must stop instead of looping.
+        const ctx = loadHaAuth({
+            fetchFn: async () => ({ ok: false, status: 401, json: async () => ({}) }),
+            sessionStorageData: { [K]: '3' },
+            withDomBody: true,
+        });
+        const result = await ctx.BeatifyAuth.init({ requireAuth: true });
+        expect(result).toBe(false);
+        expect(ctx.sandboxWindow.location._lastReplace).toBeUndefined();
     });
 });
 

--- a/custom_components/beatify/www/js/ha-auth.js
+++ b/custom_components/beatify/www/js/ha-auth.js
@@ -57,6 +57,15 @@
   // sessionStorage: CSRF state lives only for the duration of one redirect.
   var K_STATE = 'beatify_ha_oauth_state';
 
+  // sessionStorage: consecutive login() redirects that ended in a failed
+  // server-side OAuth exchange (?auth_error=) or state mismatch. Cleared on a
+  // successful callback. Bounds the admin → /auth/authorize → callback?auth_error
+  // → login() loop so a persistently-broken exchange (e.g. the rc15 loopback
+  // HTTP exchange misconfigured) surfaces an error instead of redirecting
+  // forever (#1394). Mirrors the WS path's MAX_ADMIN_WS_AUTH_RECOVERIES.
+  var K_LOGIN_ATTEMPTS = 'beatify_login_attempts';
+  var MAX_LOGIN_ATTEMPTS = 3;
+
   // Old rc8–rc14 localStorage keys. We clear them once on init so a user
   // upgrading from a previous RC doesn't carry forward dead state that
   // could confuse a future debugger.
@@ -517,6 +526,91 @@
     window.location.replace(url);
   }
 
+  // -- bounded login loop guard (#1394) ------------------------------------
+
+  function _loginAttempts() {
+    try {
+      return parseInt(sessionStorage.getItem(K_LOGIN_ATTEMPTS), 10) || 0;
+    } catch (e) {
+      return 0;
+    }
+  }
+
+  function _clearLoginAttempts() {
+    try {
+      sessionStorage.removeItem(K_LOGIN_ATTEMPTS);
+    } catch (e) {
+      /* ignore — best-effort */
+    }
+  }
+
+  /**
+   * Render a terminal auth-error state into the page instead of redirecting
+   * again. Called once the bounded retry budget is exhausted (#1394) so a
+   * persistently-failing server-side OAuth exchange stops the redirect loop
+   * and shows the user what happened.
+   */
+  function _renderAuthError() {
+    try {
+      console.error(
+        '[BeatifyAuth] OAuth exchange failed ' +
+          MAX_LOGIN_ATTEMPTS +
+          ' times in a row — stopping the login loop (#1394)'
+      );
+    } catch (e) { /* ignore */ }
+    try {
+      if (typeof document === 'undefined' || !document.body) return;
+      var box = document.createElement('div');
+      box.id = 'beatify-auth-error';
+      box.setAttribute('role', 'alert');
+      box.style.cssText =
+        'position:fixed;inset:0;z-index:2147483647;display:flex;' +
+        'align-items:center;justify-content:center;padding:24px;' +
+        'background:#1c1c1e;color:#fff;font:16px/1.5 system-ui,sans-serif;' +
+        'text-align:center;';
+      box.innerHTML =
+        '<div style="max-width:420px">' +
+        '<h2 style="margin:0 0 12px">Anmeldung fehlgeschlagen</h2>' +
+        '<p style="margin:0 0 20px;opacity:.85">Die Verbindung zu Home ' +
+        'Assistant konnte nicht hergestellt werden. Bitte pr&uuml;fe die ' +
+        'Beatify-Konfiguration (interne URL / SSL) und versuche es erneut.</p>' +
+        '<button type="button" style="padding:10px 20px;border:0;' +
+        'border-radius:8px;background:#0a84ff;color:#fff;font-size:16px;' +
+        'cursor:pointer">Erneut versuchen</button>' +
+        '</div>';
+      var btn = box.querySelector('button');
+      if (btn) {
+        btn.addEventListener('click', function () {
+          _clearLoginAttempts();
+          login();
+        });
+      }
+      document.body.appendChild(box);
+    } catch (e) {
+      /* ignore — error UI is best-effort */
+    }
+  }
+
+  /**
+   * Begin the OAuth redirect, but stop after MAX_LOGIN_ATTEMPTS consecutive
+   * failed callbacks and render an error instead. Returns true if a redirect
+   * was issued, false if the budget was exhausted (caller should stop).
+   */
+  function _attemptLogin() {
+    var attempts = _loginAttempts();
+    if (attempts >= MAX_LOGIN_ATTEMPTS) {
+      _renderAuthError();
+      return false;
+    }
+    try {
+      sessionStorage.setItem(K_LOGIN_ATTEMPTS, String(attempts + 1));
+    } catch (e) {
+      /* ignore — counting is best-effort if storage is unavailable */
+    }
+    login();
+    return true;
+  }
+
   function login() {
     if (isAndroidCompanion() && _hasCompanionAuthBridge()) {
       // Companion path: pull a fresh token from the in-app bridge, plant
@@ -580,6 +674,8 @@
       _clearAccessCookie();
       return false;
     }
+    // Successful callback — reset the bounded login-loop counter (#1394).
+    _clearLoginAttempts();
     return true;
   }
 
@@ -746,8 +842,11 @@
     // In either case the cookies are not usable; jump straight to login.
     if (callbackResult === false) {
       if (options.requireAuth) {
-        login();
-        return new Promise(function () {});
+        // Bounded retry: a persistently-failing server-side exchange must not
+        // loop admin → /auth/authorize → callback?auth_error → login() forever
+        // (#1394). _attemptLogin() renders an error once the budget is spent.
+        if (_attemptLogin()) return new Promise(function () {});
+        return Promise.resolve(false);
       }
       return Promise.resolve(false);
     }
@@ -755,6 +854,8 @@
     if (accessFresh()) {
       // Cookie has a fresh access token (either from the just-completed
       // callback, or a returning session within the cookie's lifetime).
+      // A usable session means the loop is broken — reset the counter (#1394).
+      _clearLoginAttempts();
       return Promise.resolve(true);
     }
 
@@ -762,10 +863,15 @@
     // refresh cookie may still be valid even if the access cookie has
     // already expired (different lifetimes by design).
     return refreshAccess().then(function (token) {
-      if (token) return true;
+      if (token) {
+        _clearLoginAttempts();
+        return true;
+      }
       if (!options.requireAuth) return false;
-      login();
-      return new Promise(function () {});
+      // Same bounded-loop guard as the failed-callback branch (#1394): if
+      // login() keeps producing auth_error callbacks, stop and show an error.
+      if (_attemptLogin()) return new Promise(function () {});
+      return false;
     });
   }
 


### PR DESCRIPTION
Closes #1394

## Root cause
`init({requireAuth:true})` in `www/js/ha-auth.js` re-`login()`'d unconditionally on every failed callback. When the server-side OAuth code exchange fails persistently (e.g. the rc15 loopback HTTP exchange misconfigured — wrong internal URL/SSL), HA auto-approves the known client and bounces straight back with `?auth_error=`, producing a tight `admin → /auth/authorize → callback?auth_error → login()` loop with no counter, backoff, or user-visible error. The WS path had `MAX_ADMIN_WS_AUTH_RECOVERIES`; this page-load path had nothing.

## Fix
Adds a `sessionStorage` attempt counter (`beatify_login_attempts`, max **3**) that survives the redirect bounce:
- New helpers in `ha-auth.js`: `_loginAttempts()`, `_clearLoginAttempts()`, `_renderAuthError()`, `_attemptLogin()`.
- `init()`'s two redirect branches — the failed-callback branch (`callbackResult === false`) and the refresh-failed branch — now call `_attemptLogin()` instead of `login()` directly. After 3 consecutive failures it renders a terminal, user-visible error card ("Anmeldung fehlgeschlagen" + retry button) instead of redirecting again.
- Counter is reset on any successful session: `_consumeAuthCallback()` success path, the fresh-cookie path, and the refresh-success path — so a later transient failure starts with a full budget.

`ha-auth.js` is served **raw** (`/beatify/static/js/ha-auth.js?v={{ASSET_VER}}`, server-templated cache-buster) — it has no min.js bundle in `scripts/build.mjs`, so there is nothing to regenerate or hand-bump. `build:check` confirms 0 drift.

## Readiness assessment
- [x] Ready to merge
- [ ] Borderline — see notes
- [ ] Not ready — needs human review

**Honest summary:** Tightly scoped loop-bounding change. Logic is solid and fully unit-tested (bounded stop after 3 redirects, counter reset on success, both the callback and refresh branches covered). The only soft spot is the error-card copy/styling (German, minimal inline CSS) — functional but not design-reviewed.

## Test plan
- Automated: 5 new vitest cases in `__tests__/ha-auth.test.js` prove (a) it keeps redirecting under budget while incrementing the counter, (b) it stops + renders an error once the budget is spent, (c) the full simulated loop terminates after exactly 3 redirects (no infinite loop), (d) the counter resets after a successful callback, (e) the refresh-failed branch is bounded too. `npm test` = 245 passed. `npm run build:check` = 0 drift.
- Manual: misconfigure the loopback exchange so `/beatify/auth/callback` always returns `?auth_error=`, open `/beatify/admin`, confirm it stops after 3 redirects and shows the error card with a working "Erneut versuchen" button.

## Risk assessment
- **Blast radius:** `www/js/ha-auth.js` (admin + player host-claim auth init) and its test file. No server/Python changes.
- **Overlap:** open PR **#1439** (#1393, bypass-mode guard in `handleServerRejection`) also touches `ha-auth.js` and may merge first. This change is isolated to `init()` + new helpers around `login()`/`_consumeAuthCallback()` — does NOT touch `handleServerRejection()`, so rebase should be clean. Sibling resolvers #1395/#1397 touch `admin/api.js` (different file); no shared auth helpers touched here.
- **What could go wrong:** if a real environment legitimately needs >3 redirects to settle (not expected), users would hit the error card — they can retry via the button, which clears the counter. Error UI is best-effort (`document.body` guard) — if the page hasn't painted, it logs to console and resolves without redirect rather than looping.
- **What I did NOT test:** live browser against a real broken HA loopback exchange; the error card's visual rendering (no design review).

🤖 Auto-generated by issue-triage routine