### PR TITLE
fix: preserve tts_pre_round_delay on wizard finish (#1401)

### DIFF
--- a/custom_components/beatify/www/js/__tests__/wizard.test.js
+++ b/custom_components/beatify/www/js/__tests__/wizard.test.js
@@ -3,7 +3,7 @@
  * These helpers drive the state machine: when to show, where to resume, when to show the pill.
  */
 import { describe, it, expect, beforeEach } from 'vitest';
-import { resumeAtStep, shouldTrigger, shouldShowPill, providerSupportedForPlayer, capabilityBadgeForPlayer, applyGameModeTogglePrecedence, difficultyDisplayFor, buildWizChip, resolveGameLanguageDefault } from '../wizard.js';
+import { resumeAtStep, shouldTrigger, shouldShowPill, providerSupportedForPlayer, capabilityBadgeForPlayer, applyGameModeTogglePrecedence, difficultyDisplayFor, buildWizChip, resolveGameLanguageDefault, buildTtsPayload } from '../wizard.js';
 
 function makeLS(initial = {}) {
     const store = { ...initial };
@@ -476,5 +476,65 @@ describe('resolveGameLanguageDefault', () => {
     it('falls back to the current default when nothing resolves', () => {
         expect(resolveGameLanguageDefault(null, null, 'en')).toBe('en');
         expect(resolveGameLanguageDefault(() => '', {}, 'en')).toBe('en');
+    });
+});
+
+// ------------------------------------------------------------------
+// buildTtsPayload — wizard finish must NOT wipe admin-owned keys (#1401)
+// ------------------------------------------------------------------
+describe('buildTtsPayload (#1401 — preserve tts_pre_round_delay)', () => {
+    // Minimal stand-in for window.BeatifyTtsPresets (tts-settings.js).
+    const presets = {
+        KEYS: ['announce_game_start', 'announce_round_start'],
+        presetValues: (name) => name === 'minimal'
+            ? { announce_game_start: true, announce_round_start: false }
+            : { announce_game_start: true, announce_round_start: true },
+    };
+
+    it('carries over an existing tts_pre_round_delay (#1211) on a preset finish', () => {
+        // Admin had configured a 3s pre-round delay via tts-settings.js.
+        const prev = { tts_pre_round_delay: 3, announce_game_start: false };
+        const out = buildTtsPayload(prev, {
+            enabled: true, entityId: 'tts.google', preset: 'standard', presets,
+        });
+        // The #1211 setting survives the wizard rebuild...
+        expect(out.tts_pre_round_delay).toBe(3);
+        // ...and the preset booleans are still applied.
+        expect(out.enabled).toBe(true);
+        expect(out.entity_id).toBe('tts.google');
+        expect(out.preset).toBe('standard');
+        expect(out.announce_game_start).toBe(true);
+    });
+
+    it('carries over tts_pre_round_delay on a custom-preset finish', () => {
+        const prev = { tts_pre_round_delay: 1.5, announce_round_start: false };
+        const out = buildTtsPayload(prev, {
+            enabled: true, entityId: 'tts.google', preset: 'custom', presets,
+        });
+        expect(out.tts_pre_round_delay).toBe(1.5);
+        // custom keeps hand-tuned booleans from prev
+        expect(out.announce_round_start).toBe(false);
+    });
+
+    it('preserves a zero delay (0 is a valid configured value, not "unset")', () => {
+        const out = buildTtsPayload({ tts_pre_round_delay: 0 }, {
+            enabled: false, entityId: '', preset: 'minimal', presets,
+        });
+        expect(out.tts_pre_round_delay).toBe(0);
+    });
+
+    it('omits the key entirely when none was previously stored', () => {
+        const out = buildTtsPayload({}, {
+            enabled: true, entityId: 'tts.google', preset: 'standard', presets,
+        });
+        expect('tts_pre_round_delay' in out).toBe(false);
+    });
+
+    it('tolerates a null prev (private mode / first run)', () => {
+        const out = buildTtsPayload(null, {
+            enabled: true, entityId: 'tts.google', preset: 'standard', presets,
+        });
+        expect('tts_pre_round_delay' in out).toBe(false);
+        expect(out.preset).toBe('standard');
     });
 });

--- a/custom_components/beatify/www/js/wizard.js
+++ b/custom_components/beatify/www/js/wizard.js
@@ -1326,6 +1326,42 @@ function _renderLevelUp() {
     });
 }
 
+/**
+ * Build the beatify_tts localStorage payload the wizard writes on finish.
+ *
+ * Pure + exported so it can be unit-tested. `prevTts` is the previously stored
+ * beatify_tts object (parse of localStorage); `presets` is window.BeatifyTtsPresets.
+ *
+ * #1401: the admin TTS panel (tts-settings.js) writes `tts_pre_round_delay`
+ * (the #1211 setting) into beatify_tts, but the wizard rebuilt the payload from
+ * scratch — silently wiping the delay back to 0 whenever the wizard was
+ * finished. Carry over any previously-stored keys the wizard doesn't manage
+ * (at minimum tts_pre_round_delay) so finishing the wizard never clobbers them.
+ */
+export function buildTtsPayload(prevTts, { enabled, entityId, preset, presets }) {
+    const prev = prevTts || {};
+    const ttsPayload = {
+        enabled,
+        entity_id: entityId,
+        preset,
+    };
+    if (presets && preset !== 'custom') {
+        const vals = presets.presetValues(preset);
+        presets.KEYS.forEach((k) => { ttsPayload[k] = vals[k]; });
+    } else if (presets && preset === 'custom') {
+        // Preserve hand-tuned toggles from the admin panel — don't clobber.
+        presets.KEYS.forEach((k) => {
+            if (typeof prev[k] === 'boolean') ttsPayload[k] = prev[k];
+        });
+    }
+    // #1401: preserve unmanaged keys the admin TTS panel owns. The wizard never
+    // edits tts_pre_round_delay (#1211), so carry the previous value over.
+    if (prev.tts_pre_round_delay !== undefined) {
+        ttsPayload.tts_pre_round_delay = prev.tts_pre_round_delay;
+    }
+    return ttsPayload;
+}
+
 function _persistLevelUpDetails() {
     try {
         if (chosenLevelUps.lights) {
@@ -1348,22 +1384,13 @@ function _persistLevelUpDetails() {
         // Write a complete config: enabled + entity + preset + all 23
         // announce_* booleans, so the admin TTS panel and game engine read a
         // consistent state. BeatifyTtsPresets is exposed by tts-settings.js.
-        const ttsPayload = {
+        const prevTts = JSON.parse(localStorage.getItem('beatify_tts') || '{}');
+        const ttsPayload = buildTtsPayload(prevTts, {
             enabled: chosenLevelUps.tts,
-            entity_id: chosenTtsEntityId,
+            entityId: chosenTtsEntityId,
             preset: chosenTtsPreset,
-        };
-        const presets = window.BeatifyTtsPresets;
-        if (presets && chosenTtsPreset !== 'custom') {
-            const vals = presets.presetValues(chosenTtsPreset);
-            presets.KEYS.forEach((k) => { ttsPayload[k] = vals[k]; });
-        } else if (presets && chosenTtsPreset === 'custom') {
-            // Preserve hand-tuned toggles from the admin panel — don't clobber.
-            const prev = JSON.parse(localStorage.getItem('beatify_tts') || '{}');
-            presets.KEYS.forEach((k) => {
-                if (typeof prev[k] === 'boolean') ttsPayload[k] = prev[k];
-            });
-        }
+            presets: window.BeatifyTtsPresets,
+        });
         localStorage.setItem('beatify_tts', JSON.stringify(ttsPayload));
     } catch (e) { /* private mode */ }
 }


### PR DESCRIPTION
Closes #1401

## Root cause
`_persistLevelUpDetails()` in `custom_components/beatify/www/js/wizard.js` rebuilt the `beatify_tts` localStorage payload from scratch (`enabled` + `entity_id` + `preset` + 23 `announce_*` booleans), never carrying over `tts_pre_round_delay` — the #1211 setting the admin TTS panel (`tts-settings.js`) owns. Any user who configured a pre-round delay and later finished/re-ran the wizard had it silently reset to 0, so TTS announcements started eating into the guess timer again. The payload is written unconditionally on wizard finish, even when the user never opened Step 5's TTS card.

## Changes
- **`custom_components/beatify/www/js/wizard.js`**
  - New exported pure helper **`buildTtsPayload(prevTts, { enabled, entityId, preset, presets })`** — builds the `beatify_tts` payload and carries over any previously-stored `tts_pre_round_delay` (`!== undefined`, so a configured `0` is preserved too). Custom-preset hand-tuned booleans are still preserved as before.
  - **`_persistLevelUpDetails()`** now reads the previous `beatify_tts` and delegates to `buildTtsPayload`, so finishing the wizard no longer clobbers the admin-owned delay.
- **`custom_components/beatify/www/js/__tests__/wizard.test.js`** — new `describe('buildTtsPayload (#1401 …)')` block (5 tests): preset finish preserves a 3s delay, custom finish preserves 1.5s, a configured `0` survives, the key is omitted when none was stored, and `null` prev (private mode) is tolerated.

**Frontend bundle status:** `wizard.js` is raw-served as an ES module (`<script type="module" src="/beatify/static/js/wizard.js?v={{ASSET_VER}}">` in `admin.html`) — it is NOT in `scripts/build.mjs` MINIFY/BUNDLES, so no `.min.js` exists/regenerates. Cache-buster is server-templated `{{ASSET_VER}}` — not hand-bumped. `sw.js` untouched.

## Readiness assessment
- [x] Ready to merge
- [ ] Borderline — see notes
- [ ] Not ready — needs human review

**Honest summary:** Minimal, targeted fix matching the issue's prescribed remedy exactly. Logic extracted into a pure, unit-tested helper. No behavior change other than preserving the previously-dropped key. Backend/data-only change to client persistence — no visible UI surface altered.

## Test plan
- Automated: `npm test` (vitest) — 245 tests pass incl. 5 new `buildTtsPayload` tests.
- `npm run build:check` — 0 drift (all 10 bundles match source; wizard.js not bundled).
- Manual: set a pre-round delay in the admin TTS panel, re-run/finish the wizard, confirm `localStorage.beatify_tts.tts_pre_round_delay` is unchanged.

## Risk assessment
- **Blast radius:** wizard finish persistence only (`beatify_tts` write). Same `announce_*`/preset behavior as before.
- **What could go wrong:** none identified — additive key preservation; `0` handled explicitly via `!== undefined`.
- **What I did NOT test:** live admin→wizard round-trip in a running HA instance (covered by unit tests + manual plan).

🤖 Auto-generated by issue-triage routine