### PR TITLE
fix: #1402 B3 — challenges/playlist batch

### DIFF
--- a/custom_components/beatify/game/challenges.py
+++ b/custom_components/beatify/game/challenges.py
@@ -232,10 +232,22 @@ def build_artist_options(song: dict[str, Any]) -> list[str] | None:
     if not alt_artists or not isinstance(alt_artists, list):
         return None
 
-    # Filter valid alternatives
-    valid_alts = [a.strip() for a in alt_artists if isinstance(a, str) and a.strip()]
+    # Filter valid alternatives, deduplicating case-insensitively and dropping
+    # any alt that equals the correct artist (a duplicated correct answer in the
+    # options would leak the truth / break the single-correct-choice contract).
+    seen = {artist.lower()}
+    valid_alts: list[str] = []
+    for a in alt_artists:
+        if not isinstance(a, str):
+            continue
+        stripped = a.strip()
+        if not stripped or stripped.lower() in seen:
+            continue
+        seen.add(stripped.lower())
+        valid_alts.append(stripped)
 
     if not valid_alts:
+        # No distinct decoy remains after dedup — challenge would be trivial.
         return None
 
     # Build and shuffle options
@@ -285,7 +297,14 @@ class ChallengeManager:
             title_artist_mode: Whether title/artist guessing replaces the year guess
 
         """
-        self.artist_challenge_enabled = artist_challenge_enabled
+        # Title & Artist mode already asks players for the artist directly, so
+        # the artist multiple-choice challenge must never run alongside it —
+        # otherwise the broadcast options leak the correct artist (and the +5
+        # ack path is dead anyway). Enforce this server-side, not just in the
+        # admin UI, so the options never reach clients in TA mode.
+        self.artist_challenge_enabled = (
+            artist_challenge_enabled and not title_artist_mode
+        )
         self.artist_challenge = None
 
         self.movie_quiz_enabled = movie_quiz_enabled

--- a/custom_components/beatify/game/playlist.py
+++ b/custom_components/beatify/game/playlist.py
@@ -74,7 +74,7 @@ class PlaylistManager:
         self._provider = provider
         self._storefront = storefront
         total_count = len(songs)
-        filtered_songs, _ = filter_songs_for_provider(songs, provider)
+        filtered_songs, _ = filter_songs_for_provider(songs, provider, storefront)
         self._played_uris: set[str] = set()
 
         # Group songs into per-playlist buckets, deduplicating by URI.
@@ -287,21 +287,32 @@ async def _copy_bundled_playlists(dest_dir: Path) -> None:
     # Bundled playlists are in custom_components/beatify/playlists/
     bundled_dir = Path(__file__).parent.parent / "playlists"
 
-    if not bundled_dir.exists():
+    loop = asyncio.get_running_loop()
+
+    # #1402 B3: `exists()` is a blocking syscall — run it (and the glob) in the
+    # executor instead of on the event loop.
+    if not await loop.run_in_executor(None, bundled_dir.exists):
         return
 
     def _copy_file(src: Path, dst: Path) -> None:
-        """Copy file contents (runs in executor)."""
+        """Copy file contents, creating parent dirs (runs in executor).
+
+        #1402 B3: folds the previously-on-event-loop ``mkdir`` in here.
+        """
+        dst.parent.mkdir(parents=True, exist_ok=True)
         content = src.read_text(encoding="utf-8")
         dst.write_text(content, encoding="utf-8")
 
-    def _get_versions(src: Path, dst: Path) -> tuple[str, str]:
-        """Get versions from both files (runs in executor)."""
-        bundled_ver = _get_playlist_version(src)
-        existing_ver = _get_playlist_version(dst) if dst.exists() else "0.0"
-        return bundled_ver, existing_ver
+    def _get_versions(src: Path, dst: Path) -> tuple[str, str, bool]:
+        """Get versions from both files + whether dst exists (runs in executor).
 
-    loop = asyncio.get_running_loop()
+        #1402 B3: returns ``dst_exists`` so the caller reuses this single stat
+        instead of re-running a blocking ``dst.exists()`` on the event loop.
+        """
+        bundled_ver = _get_playlist_version(src)
+        dst_exists = dst.exists()
+        existing_ver = _get_playlist_version(dst) if dst_exists else "0.0"
+        return bundled_ver, existing_ver, dst_exists
 
     # Offload blocking glob to executor to avoid scandir in event loop (#516)
     playlist_files = await loop.run_in_executor(
@@ -311,14 +322,13 @@ async def _copy_bundled_playlists(dest_dir: Path) -> None:
         # Preserve relative path (e.g. community/greatest-metal-songs.json)
         rel = playlist_file.relative_to(bundled_dir)
         dest_file = dest_dir / rel
-        dest_file.parent.mkdir(parents=True, exist_ok=True)
         try:
-            # Get versions
-            bundled_ver, existing_ver = await loop.run_in_executor(
+            # Get versions (+ existence, reused below — _copy_file makes the dir)
+            bundled_ver, existing_ver, dest_exists = await loop.run_in_executor(
                 None, _get_versions, playlist_file, dest_file
             )
 
-            if not dest_file.exists():
+            if not dest_exists:
                 # New playlist - copy it
                 await loop.run_in_executor(None, _copy_file, playlist_file, dest_file)
                 _LOGGER.info(
@@ -498,7 +508,9 @@ def get_song_uri(
 
 
 def filter_songs_for_provider(
-    songs: list[dict[str, Any]], provider: str
+    songs: list[dict[str, Any]],
+    provider: str,
+    storefront: str | None = None,
 ) -> tuple[list[dict[str, Any]], int]:
     """
     Filter songs to only those available for the specified provider.
@@ -506,6 +518,11 @@ def filter_songs_for_provider(
     Args:
         songs: List of song dictionaries
         provider: Provider identifier (PROVIDER_SPOTIFY or PROVIDER_APPLE_MUSIC)
+        storefront: For Apple Music, the user's regional storefront code. Must
+            be threaded through to ``get_song_uri`` so storefront-only tracks
+            (present in ``uri_apple_music_by_region`` but absent from the legacy
+            ``uri_apple_music`` field) are kept instead of dropped by a
+            storefront-blind pre-filter (#1402 B3). Other providers ignore it.
 
     Returns:
         Tuple of (filtered_songs, skipped_count)
@@ -515,7 +532,7 @@ def filter_songs_for_provider(
     skipped = 0
 
     for song in songs:
-        uri = get_song_uri(song, provider)
+        uri = get_song_uri(song, provider, storefront)
         if uri:
             filtered.append(song)
         else:
@@ -533,15 +550,16 @@ async def async_discover_playlists(hass: HomeAssistant) -> list[dict]:
     playlist_dir = get_playlist_directory(hass)
     playlists: list[dict] = []
 
-    if not playlist_dir.exists():
+    loop = asyncio.get_running_loop()
+
+    # #1402 B3: `exists()` is a blocking syscall — run it in the executor.
+    if not await loop.run_in_executor(None, playlist_dir.exists):
         _LOGGER.debug("Playlist directory does not exist: %s", playlist_dir)
         return playlists
 
     def _read_file(path: Path) -> str:
         """Read file contents (runs in executor)."""
         return path.read_text(encoding="utf-8")
-
-    loop = asyncio.get_running_loop()
 
     # Offload blocking glob to executor to avoid scandir in event loop (#516)
     json_files = await loop.run_in_executor(
@@ -666,7 +684,10 @@ async def async_load_and_validate_playlist(
     """Load and validate a playlist file."""
     path = Path(path)
 
-    if not path.exists():
+    loop = asyncio.get_running_loop()
+
+    # #1402 B3: `exists()` is a blocking syscall — run it in the executor.
+    if not await loop.run_in_executor(None, path.exists):
         return (None, [f"File not found: {path}"])
 
     def _read_file(p: Path) -> str:
@@ -674,9 +695,7 @@ async def async_load_and_validate_playlist(
         return p.read_text(encoding="utf-8")
 
     try:
-        content = await asyncio.get_running_loop().run_in_executor(
-            None, _read_file, path
-        )
+        content = await loop.run_in_executor(None, _read_file, path)
         data = json.loads(content)
     except json.JSONDecodeError as e:
         return (None, [f"Invalid JSON: {e}"])

--- a/tests/unit/test_playlist.py
+++ b/tests/unit/test_playlist.py
@@ -16,6 +16,7 @@ from custom_components.beatify.const import (
 )
 from custom_components.beatify.game.playlist import (
     PlaylistManager,
+    filter_songs_for_provider,
     get_song_uri,
 )
 
@@ -202,6 +203,75 @@ class TestPlaylistManagerStorefrontFiltering:
         picked = pm.get_next_song()
         assert picked is not None
         assert picked["_resolved_uri"] == "applemusic://track/legacy"
+
+    def test_storefront_only_song_without_legacy_uri_survives_prefilter(self):
+        """#1402 B3: a song that has NO legacy ``uri_apple_music`` field but is
+        available via ``uri_apple_music_by_region`` for the user's storefront
+        must NOT be dropped by the pre-filter. The storefront-blind pre-filter
+        used to call get_song_uri without the storefront, get None (no legacy
+        field), and silently drop the song before the storefront-aware bucket
+        loop ever saw it.
+        """
+        song = {
+            "title": "DE storefront-exclusive",
+            "artist": "Test Artist",
+            "year": 1990,
+            # No legacy uri_apple_music field at all — only per-region data.
+            "uri_apple_music_by_region": {"de": "applemusic://track/de-only"},
+        }
+        pm = PlaylistManager([song], provider=PROVIDER_APPLE_MUSIC, storefront="de")
+        assert pm.has_playable_songs()
+        picked = pm.get_next_song()
+        assert picked is not None
+        assert picked["_resolved_uri"] == "applemusic://track/de-only"
+
+
+class TestFilterSongsForProviderStorefront:
+    """#1402 B3: filter_songs_for_provider must thread the storefront through to
+    get_song_uri so it isn't storefront-blind."""
+
+    def test_storefront_only_song_kept(self):
+        songs = [
+            {
+                "title": "DE-only",
+                "artist": "A",
+                "year": 1990,
+                "uri_apple_music_by_region": {"de": "applemusic://track/de"},
+            },
+        ]
+        filtered, skipped = filter_songs_for_provider(
+            songs, PROVIDER_APPLE_MUSIC, storefront="de"
+        )
+        assert len(filtered) == 1
+        assert skipped == 0
+
+    def test_song_unavailable_in_storefront_is_skipped(self):
+        songs = [
+            {
+                "title": "Not in DE",
+                "artist": "A",
+                "year": 1990,
+                "uri_apple_music_by_region": {"de": None},
+            },
+        ]
+        filtered, skipped = filter_songs_for_provider(
+            songs, PROVIDER_APPLE_MUSIC, storefront="de"
+        )
+        assert filtered == []
+        assert skipped == 1
+
+    def test_default_no_storefront_still_works(self):
+        songs = [
+            {
+                "title": "Legacy",
+                "artist": "A",
+                "year": 1990,
+                "uri_apple_music": "applemusic://track/legacy",
+            },
+        ]
+        filtered, skipped = filter_songs_for_provider(songs, PROVIDER_APPLE_MUSIC)
+        assert len(filtered) == 1
+        assert skipped == 0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_playlist_copy_bundled_1402.py
+++ b/tests/unit/test_playlist_copy_bundled_1402.py
@@ -1,0 +1,44 @@
+"""Tests for non-blocking _copy_bundled_playlists (#1402 B3).
+
+The bundled-playlist copy previously ran ``exists()`` / ``mkdir()`` directly on
+the event loop and re-stat'd the destination after already computing its
+existence. These tests pin the observable behaviour (the copy still creates the
+nested ``community/`` destination dir, copies new files, and is idempotent) so
+the refactor that moved those syscalls into the executor stays correct.
+
+They run against the real bundled playlists shipped in the package (which
+include a nested ``community/`` subdir), so the mkdir-in-executor path is
+exercised end-to-end.
+"""
+
+from __future__ import annotations
+
+from custom_components.beatify.game.playlist import _copy_bundled_playlists
+
+
+async def test_copies_bundled_playlists_into_nested_dirs(tmp_path):
+    dest = tmp_path / "dest"
+    dest.mkdir()
+
+    await _copy_bundled_playlists(dest)
+
+    copied = list(dest.glob("**/*.json"))
+    assert copied, "expected bundled playlists to be copied into dest"
+    # The bundled set includes a nested community/ subdir — its parent dir must
+    # have been created in the executor (mkdir folded into _copy_file).
+    assert (dest / "community").is_dir()
+    assert list((dest / "community").glob("*.json"))
+
+
+async def test_copy_is_idempotent(tmp_path):
+    dest = tmp_path / "dest"
+    dest.mkdir()
+
+    await _copy_bundled_playlists(dest)
+    first = {p.relative_to(dest) for p in dest.glob("**/*.json")}
+
+    # Second run: everything is already up to date — must not error or drop files.
+    await _copy_bundled_playlists(dest)
+    second = {p.relative_to(dest) for p in dest.glob("**/*.json")}
+
+    assert first == second

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -878,6 +878,39 @@ class TestBuildArtistOptions:
         options = build_artist_options(song)
         assert "ABBA" in options
 
+    def test_dedups_alt_equal_to_correct_artist(self):
+        # #1402 B3: an alt_artist matching the correct artist (any case) must
+        # never produce a duplicated correct answer in the options.
+        song = {
+            "artist": "Queen",
+            "alt_artists": ["queen", "QUEEN", "David Bowie"],
+        }
+        options = build_artist_options(song)
+        assert options is not None
+        assert options.count("Queen") == 1
+        assert "David Bowie" in options
+        assert len(options) == 2
+
+    def test_dedups_duplicate_alts_case_insensitively(self):
+        # #1402 B3: repeated decoys collapse to a single option.
+        song = {
+            "artist": "Madonna",
+            "alt_artists": ["Cher", "cher", "CHER"],
+        }
+        options = build_artist_options(song)
+        assert options is not None
+        assert options.count("Cher") == 1
+        assert len(options) == 2
+
+    def test_returns_none_when_only_decoy_is_the_correct_artist(self):
+        # #1402 B3: if every alt collapses to the correct artist, no distinct
+        # decoy remains -> the challenge would be trivial, so return None.
+        song = {
+            "artist": "U2",
+            "alt_artists": ["u2", "U2"],
+        }
+        assert build_artist_options(song) is None
+
 
 # ---------------------------------------------------------------------------
 # GameState.finalize_game

--- a/tests/unit/test_title_artist_challenge.py
+++ b/tests/unit/test_title_artist_challenge.py
@@ -71,6 +71,49 @@ class TestTitleArtistChallengeModel:
         assert mgr.title_artist_challenge is None
 
 
+class TestConfigureForcesArtistChallengeOffInTaMode:
+    """#1402 B3: TA mode must disable the artist multiple-choice challenge
+    server-side, so the broadcast options never leak the correct artist."""
+
+    def test_artist_challenge_forced_off_when_ta_mode_on(self):
+        mgr = ChallengeManager()
+        # Even if the caller (or stale admin UI) requests artist challenge,
+        # TA mode wins and the flag is forced off.
+        mgr.configure(
+            artist_challenge_enabled=True,
+            movie_quiz_enabled=False,
+            title_artist_mode=True,
+        )
+        assert mgr.artist_challenge_enabled is False
+
+    def test_init_round_builds_no_artist_challenge_in_ta_mode(self):
+        mgr = ChallengeManager()
+        mgr.configure(
+            artist_challenge_enabled=True,
+            movie_quiz_enabled=False,
+            title_artist_mode=True,
+        )
+        mgr.init_round(
+            {
+                "title": "Bohemian Rhapsody",
+                "artist": "Queen",
+                "alt_artists": ["ABBA", "Blur"],
+            }
+        )
+        # No artist challenge object -> options never reach clients.
+        assert mgr.artist_challenge is None
+        assert mgr.get_artist_challenge_dict(include_answer=False) is None
+
+    def test_artist_challenge_still_works_without_ta_mode(self):
+        mgr = ChallengeManager()
+        mgr.configure(
+            artist_challenge_enabled=True,
+            movie_quiz_enabled=False,
+            title_artist_mode=False,
+        )
+        assert mgr.artist_challenge_enabled is True
+
+
 class TestSubmitTitleArtistGuess:
     """submit_title_artist_guess classifies and stores per field."""
 


### PR DESCRIPTION
Bundle **B3 (Challenges/Playlist)** from #1402. One cohesive PR fixing all four findings. Refs #1402 (does not close it; the checklist is untouched).

## Findings fixed

**1. Title & Artist mode leaked the correct artist via the artist multiple-choice challenge** — `game/challenges.py`
`ChallengeManager.configure()` now forces `artist_challenge_enabled = artist_challenge_enabled and not title_artist_mode` **server-side** (not just in the admin UI). In TA mode the artist challenge is never built, so its broadcast options never reach clients, and the dead +5 ack path disappears. `GameState.artist_challenge_enabled` is a property delegating to the manager, so the serialized setup state reports `False` correctly too.

**2. `build_artist_options` did not deduplicate** — `game/challenges.py`
Alt artists are now deduplicated case-insensitively, and any alt equal to the correct artist is dropped, so the correct answer can never appear twice in the options. Returns `None` when no distinct decoy remains (the challenge would be trivial). Implemented with an explicit loop instead of the `seen.add()`-in-comprehension trick (the latter trips mypy `func-returns-value`).

**3. Blocking filesystem calls on the event loop** — `game/playlist.py`
- `_copy_bundled_playlists`: `bundled_dir.exists()` now runs in the executor; the per-file `dest_file.parent.mkdir()` is folded into `_copy_file` (executor); `_get_versions` now also returns `dst_exists` so the previously-redundant `dest_file.exists()` re-stat on the event loop is gone.
- `async_discover_playlists` and `async_load_and_validate_playlist`: the `.exists()` checks are wrapped in `run_in_executor`.
- Note: `async_ensure_playlist_directory._ensure` (lines 244/246) and `_get_versions` (line 301) already ran inside executors and were left as-is.

**4. Apple Music storefront-only songs dropped by the storefront-blind pre-filter** — `game/playlist.py`
`filter_songs_for_provider(songs, provider, storefront)` now threads `storefront` through to `get_song_uri`. Previously the pre-filter called `get_song_uri` without a storefront, got `None` for tracks that only have a `uri_apple_music_by_region` entry (no legacy `uri_apple_music`), and silently dropped them before the storefront-aware bucket loop ever saw them.

## Readiness assessment
- [x] Ready to merge
- [ ] Borderline — see notes
- [ ] Not ready — needs human review

**Honest summary:** All four are root-caused, minimal, and backed by new/extended tests. The blocking-fs fix is the broadest in surface but only reorders syscalls onto the executor with no behaviour change (idempotent copy verified). No frontend files touched.

## Test plan
- `python3 -m pytest` — full suite: **1030 passed, 2 skipped** (pre-existing skips).
- New tests:
  - `test_state.py::TestBuildArtistOptions` — dedup of alt==correct, case-insensitive duplicate decoys, `None` when only-decoy-is-correct.
  - `test_title_artist_challenge.py::TestConfigureForcesArtistChallengeOffInTaMode` — artist challenge forced off in TA mode, no challenge/options built, still works without TA mode.
  - `test_playlist.py::TestPlaylistManagerStorefrontFiltering` + `TestFilterSongsForProviderStorefront` — storefront-only song (no legacy URI) survives the pre-filter; unavailable storefront still skipped.
  - `test_playlist_copy_bundled_1402.py` — bundled copy still creates the nested `community/` dir and is idempotent.

## Gate results
- `python3 -m pytest`: green (1030 passed, 2 skipped)
- `ruff check .` (0.15.7): All checks passed
- `ruff format --check .` (0.15.7): all formatted
- `python3 -m mypy` (1.18.2): Success, no issues (15 gated source files incl. challenges.py + playlist.py)

## Risk assessment
- **Blast radius:** `game/challenges.py` (configure + option builder), `game/playlist.py` (bundled-copy, discover, load, provider filter). No frontend, no UI surface.
- **What could go wrong:** Finding 4 widens the playable Apple Music pool for storefront users — songs that were silently dropped will now play; correct per #808 semantics. Finding 1 is a behaviour change only for the (invalid) TA + artist-challenge combo.
- **What I did NOT test:** live Home Assistant runtime / real MA playback (no HA in the test env); exercised via unit tests + mocks only.

🤖 Auto-generated by issue-triage routine