### PR TITLE
fix: #1402 B5 — server/ws cleanup

### DIFF
--- a/custom_components/beatify/server/companion_auth.py
+++ b/custom_components/beatify/server/companion_auth.py
@@ -132,7 +132,7 @@ def is_companion_trusted_meta(meta: dict | None) -> bool:
     return trusted
 
 
-async def is_authorized_http(request: web.Request, hass: HomeAssistant) -> bool:
+def is_authorized_http(request: web.Request, hass: HomeAssistant) -> bool:
     """Return True if ``request`` may invoke a #998-protected endpoint.
 
     Two paths are accepted:
@@ -144,6 +144,9 @@ async def is_authorized_http(request: web.Request, hass: HomeAssistant) -> bool:
     call this helper at the top of their handler. HA's middleware no longer
     short-circuits the request, so the Bearer check moves into application
     code — equivalent behaviour for the happy path, plus the Companion fallback.
+
+    Synchronous: ``async_validate_access_token`` and ``is_companion_trusted_request``
+    are both sync, so this helper does no awaiting and is a plain function.
     """
     auth = request.headers.get("Authorization", "")
     bearer_present = False

--- a/custom_components/beatify/server/game_views.py
+++ b/custom_components/beatify/server/game_views.py
@@ -86,7 +86,7 @@ class StartGameView(RateLimitMixin, HomeAssistantView):
 
     async def post(self, request: web.Request) -> web.Response:  # noqa: PLR0911, PLR0912
         """Start a new game."""
-        if not await is_authorized_http(request, self.hass):
+        if not is_authorized_http(request, self.hass):
             return _json_error("Unauthorized", 401, code="UNAUTHORIZED")
         client_ip = request.remote or "unknown"
         if not self._check_rate_limit(client_ip):
@@ -442,7 +442,7 @@ class EndGameView(BeatifyAdminView):
 
     async def post(self, request: web.Request) -> web.Response:
         """End the current game."""
-        if not await is_authorized_http(request, self.hass):
+        if not is_authorized_http(request, self.hass):
             return _json_error("Unauthorized", 401, code="UNAUTHORIZED")
         data = self.hass.data.get(DOMAIN, {})
         game_state = data.get("game")
@@ -486,7 +486,7 @@ class ForceResetView(RateLimitMixin, HomeAssistantView):
 
     async def post(self, request: web.Request) -> web.Response:
         """Force-end any active game and report what was cleaned up."""
-        if not await is_authorized_http(request, self.hass):
+        if not is_authorized_http(request, self.hass):
             return _json_error("Unauthorized", 401, code="UNAUTHORIZED")
         client_ip = request.remote or "unknown"
         if not self._check_rate_limit(client_ip):
@@ -528,7 +528,7 @@ class RematchGameView(HomeAssistantView):
 
     async def post(self, request: web.Request) -> web.Response:
         """Start a rematch with current players."""
-        if not await is_authorized_http(request, self.hass):
+        if not is_authorized_http(request, self.hass):
             return _json_error("Unauthorized", 401, code="UNAUTHORIZED")
         from custom_components.beatify.game.state import GamePhase  # noqa: PLC0415
 
@@ -576,7 +576,7 @@ class StartGameplayView(BeatifyAdminView):
 
     async def post(self, request: web.Request) -> web.Response:
         """Start gameplay from lobby."""
-        if not await is_authorized_http(request, self.hass):
+        if not is_authorized_http(request, self.hass):
             return _json_error("Unauthorized", 401, code="UNAUTHORIZED")
         from custom_components.beatify.game.state import GamePhase  # noqa: PLC0415
 

--- a/custom_components/beatify/server/playlist_views.py
+++ b/custom_components/beatify/server/playlist_views.py
@@ -241,7 +241,7 @@ class PlaylistRequestsView(RateLimitMixin, HomeAssistantView):
         # {"requests": []} to wipe every household request, or inject arbitrary
         # entries. Mirror the StartGameView pattern: require a valid HA Bearer
         # token (or the Companion trust fallback) before touching disk.
-        if not await is_authorized_http(request, self.hass):
+        if not is_authorized_http(request, self.hass):
             return _json_error("Unauthorized", 401, code="UNAUTHORIZED")
         # Rate limiting
         client_ip = request.remote or "unknown"
@@ -344,7 +344,7 @@ class SavePlaylistView(RateLimitMixin, HomeAssistantView):
         # Mirror the StartGameView / #1367 PlaylistRequestsView pattern: require
         # a valid HA Bearer token (or the Companion trust fallback) before
         # touching disk.
-        if not await is_authorized_http(request, self.hass):
+        if not is_authorized_http(request, self.hass):
             return _json_error("Unauthorized", 401, code="UNAUTHORIZED")
         client_ip = request.remote or "unknown"
         if not self._check_rate_limit(client_ip):

--- a/custom_components/beatify/server/views.py
+++ b/custom_components/beatify/server/views.py
@@ -544,7 +544,7 @@ class CapabilitiesView(HomeAssistantView):
 
     async def get(self, request: web.Request) -> web.Response:
         """Return flags the wizard's Step 4 uses to gate toggles."""
-        if not await is_authorized_http(request, self.hass):
+        if not is_authorized_http(request, self.hass):
             return _json_error("Unauthorized", 401, code="UNAUTHORIZED")
         light_count = len(self.hass.states.async_all("light"))
         tts_services = self.hass.services.async_services().get("tts", {})
@@ -571,7 +571,7 @@ class LightsView(HomeAssistantView):
 
     async def get(self, request: web.Request) -> web.Response:
         """Return available light entities with capabilities."""
-        if not await is_authorized_http(request, self.hass):
+        if not is_authorized_http(request, self.hass):
             return _json_error("Unauthorized", 401, code="UNAUTHORIZED")
         lights = []
         for state in self.hass.states.async_all("light"):
@@ -624,7 +624,7 @@ class TtsEntitiesView(HomeAssistantView):
 
     async def get(self, request: web.Request) -> web.Response:
         """Return registered TTS entities sorted by friendly name."""
-        if not await is_authorized_http(request, self.hass):
+        if not is_authorized_http(request, self.hass):
             return _json_error("Unauthorized", 401, code="UNAUTHORIZED")
         entities = [
             {
@@ -693,7 +693,7 @@ class PreviewLightsView(HomeAssistantView):
 
     async def post(self, request: web.Request) -> web.Response:
         """Run a ~5s party lights preview on the given entity_ids."""
-        if not await is_authorized_http(request, self.hass):
+        if not is_authorized_http(request, self.hass):
             return _json_error("Unauthorized", 401, code="UNAUTHORIZED")
         try:
             body = await request.json()
@@ -748,7 +748,7 @@ class TtsTestView(RateLimitMixin, HomeAssistantView):
         media player to route through (#793). Caller passes both:
         ``entity_id`` (the TTS entity) and ``media_player_entity_id``.
         """
-        if not await is_authorized_http(request, self.hass):
+        if not is_authorized_http(request, self.hass):
             return _json_error("Unauthorized", 401, code="UNAUTHORIZED")
         client_ip = request.remote or "unknown"
         if not self._check_rate_limit(client_ip):

--- a/custom_components/beatify/server/websocket.py
+++ b/custom_components/beatify/server/websocket.py
@@ -68,7 +68,6 @@ class BeatifyWebSocketHandler:
         """
         self.hass = hass
         self.connections: set[web.WebSocketResponse] = set()
-        self._pending_removals: dict[str, asyncio.Task] = {}
         self._admin_disconnect_task: asyncio.Task | None = None
         self._analytics: AnalyticsStorage | None = None
         # Debouncing for concurrent player joins (Issue #41)
@@ -494,12 +493,6 @@ class BeatifyWebSocketHandler:
         Called when game ends to prevent dangling async tasks.
 
         """
-        # Cancel all pending player removals
-        for task in list(self._pending_removals.values()):
-            if not task.done():
-                task.cancel()
-        self._pending_removals.clear()
-
         # Cancel admin disconnect task
         if self._admin_disconnect_task and not self._admin_disconnect_task.done():
             self._admin_disconnect_task.cancel()
@@ -511,15 +504,15 @@ class BeatifyWebSocketHandler:
         """Cancel pending tasks and close every open WebSocket on unload (#1391).
 
         ``async_unload_entry`` previously left this handler's tasks
-        (``_pending_removals``, ``_admin_disconnect_task``,
-        ``_broadcast_debounce_task``) running and every player/admin WebSocket
-        open, pinning the orphaned handler + GameState after the integration was
-        torn down. This cancels all of them and sends each client a going-away
-        close so they reconnect cleanly to a fresh handler after reload.
+        (``_admin_disconnect_task``, ``_broadcast_debounce_task``) running and
+        every player/admin WebSocket open, pinning the orphaned handler +
+        GameState after the integration was torn down. This cancels all of them
+        and sends each client a going-away close so they reconnect cleanly to a
+        fresh handler after reload.
         """
-        # Reuse the existing pending-task cleanup (_pending_removals +
-        # _admin_disconnect_task), then additionally cancel the debounce task
-        # that cleanup_game_tasks does not cover.
+        # Reuse the existing pending-task cleanup (_admin_disconnect_task),
+        # then additionally cancel the debounce task that cleanup_game_tasks
+        # does not cover.
         await self.cleanup_game_tasks()
         if self._broadcast_debounce_task and not self._broadcast_debounce_task.done():
             self._broadcast_debounce_task.cancel()
@@ -541,16 +534,3 @@ class BeatifyWebSocketHandler:
         self.connections.clear()
 
         _LOGGER.debug("Closed all WebSocket connections on unload")
-
-    def cancel_pending_removal(self, player_name: str) -> None:
-        """
-        Cancel a pending player removal (on reconnect).
-
-        Args:
-            player_name: Name of reconnecting player
-
-        """
-        if player_name in self._pending_removals:
-            self._pending_removals[player_name].cancel()
-            del self._pending_removals[player_name]
-            _LOGGER.info("Cancelled removal for reconnecting player: %s", player_name)

--- a/custom_components/beatify/server/ws_handlers.py
+++ b/custom_components/beatify/server/ws_handlers.py
@@ -257,7 +257,6 @@ async def handle_join(
                     handler._admin_disconnect_task.cancel()
                     handler._admin_disconnect_task = None
                     _LOGGER.info("Admin reconnected (own reclaim): %s", name)
-                handler.cancel_pending_removal(name)
                 if game_state.phase == GamePhase.PAUSED:
                     if await game_state.resume_game():
                         _LOGGER.info("Game resumed by admin reclaim during PAUSED")
@@ -269,7 +268,6 @@ async def handle_join(
                         _LOGGER.info(
                             "Admin reconnected, cancelled pause task: %s", name
                         )
-                    handler.cancel_pending_removal(name)
                     if game_state.phase == GamePhase.PAUSED:
                         if await game_state.resume_game():
                             _LOGGER.info("Game resumed by admin reconnection")
@@ -318,8 +316,6 @@ async def handle_join(
                 else:
                     game_state.set_admin(name)
         else:
-            handler.cancel_pending_removal(name)
-
             # Issue #420: If this player matches disconnected admin by name,
             # cancel the admin disconnect task even without is_admin flag
             if game_state.disconnected_admin_name:
@@ -1217,7 +1213,6 @@ async def handle_reconnect(
 
     player.ws = ws
     player.connected = True
-    handler.cancel_pending_removal(player.name)
 
     if player.is_admin:
         if handler._admin_disconnect_task:

--- a/tests/unit/test_companion_auth.py
+++ b/tests/unit/test_companion_auth.py
@@ -171,7 +171,7 @@ class TestIsAuthorizedHttp:
             auth="Bearer good-token",
         )
         hass = _hass_with_token("good-token")
-        assert await is_authorized_http(req, hass) is True
+        assert is_authorized_http(req, hass) is True
 
     async def test_invalid_bearer_falls_through_to_companion_path(self):
         # Bearer is well-formed but HA auth manager rejects it. Companion
@@ -182,7 +182,7 @@ class TestIsAuthorizedHttp:
             auth="Bearer not-a-real-token",
         )
         hass = _hass_with_token(None)
-        assert await is_authorized_http(req, hass) is True
+        assert is_authorized_http(req, hass) is True
 
     async def test_invalid_bearer_and_no_companion_returns_false(self):
         req = _request(
@@ -191,31 +191,31 @@ class TestIsAuthorizedHttp:
             auth="Bearer not-a-real-token",
         )
         hass = _hass_with_token(None)
-        assert await is_authorized_http(req, hass) is False
+        assert is_authorized_http(req, hass) is False
 
     async def test_no_bearer_companion_local_authorizes(self):
         # The #1131 happy path — Companion fails to attach a token, server
         # picks up the request via UA + RFC1918.
         req = _request("Home Assistant/2026 (Android 14)", "192.168.1.5")
         hass = _hass_with_token(None)
-        assert await is_authorized_http(req, hass) is True
+        assert is_authorized_http(req, hass) is True
 
     async def test_no_bearer_companion_public_remote_rejects(self):
         # An attacker spoofing UA from the internet must NOT get access.
         req = _request("Home Assistant/2026 (Android 14)", "8.8.8.8")
         hass = _hass_with_token(None)
-        assert await is_authorized_http(req, hass) is False
+        assert is_authorized_http(req, hass) is False
 
     async def test_no_bearer_desktop_local_rejects(self):
         # Desktop user without a token stays 401 — no Companion-UA, no bypass.
         req = _request("Mozilla/5.0 (Macintosh) Safari/17", "192.168.1.5")
         hass = _hass_with_token(None)
-        assert await is_authorized_http(req, hass) is False
+        assert is_authorized_http(req, hass) is False
 
     async def test_no_bearer_no_ua_no_remote_rejects(self):
         req = _request(None, None)
         hass = _hass_with_token(None)
-        assert await is_authorized_http(req, hass) is False
+        assert is_authorized_http(req, hass) is False
 
 
 class TestExtractRequestMeta:

--- a/tests/unit/test_lights_view.py
+++ b/tests/unit/test_lights_view.py
@@ -8,7 +8,7 @@ do nothing during the game.
 from __future__ import annotations
 
 import json
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -38,7 +38,7 @@ def _body(response) -> dict:
 
 @pytest.mark.asyncio
 async def test_unavailable_lights_are_hidden(monkeypatch):
-    monkeypatch.setattr(views, "is_authorized_http", AsyncMock(return_value=True))
+    monkeypatch.setattr(views, "is_authorized_http", MagicMock(return_value=True))
     hass = _hass(
         [
             _light("light.regal", "off", ["color_temp", "rgb"]),
@@ -54,7 +54,7 @@ async def test_unavailable_lights_are_hidden(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_capability_mapping_for_listed_lights(monkeypatch):
-    monkeypatch.setattr(views, "is_authorized_http", AsyncMock(return_value=True))
+    monkeypatch.setattr(views, "is_authorized_http", MagicMock(return_value=True))
     hass = _hass(
         [
             _light("light.rgb", "on", ["rgb"]),

--- a/tests/unit/test_playlist_requests_view.py
+++ b/tests/unit/test_playlist_requests_view.py
@@ -50,7 +50,7 @@ def _authorized():
     """Patch is_authorized_http to allow the POST through (#1367)."""
     return mock.patch(
         "custom_components.beatify.server.playlist_views.is_authorized_http",
-        new=AsyncMock(return_value=True),
+        new=MagicMock(return_value=True),
     )
 
 
@@ -98,7 +98,7 @@ class TestPlaylistRequestsPostAuth:
         view = _view()
         with mock.patch(
             "custom_components.beatify.server.playlist_views.is_authorized_http",
-            new=AsyncMock(return_value=False),
+            new=MagicMock(return_value=False),
         ):
             resp = await view.post(request)
         assert resp.status == 401
@@ -110,7 +110,7 @@ class TestPlaylistRequestsPostAuth:
         view = _view()
         with mock.patch(
             "custom_components.beatify.server.playlist_views.is_authorized_http",
-            new=AsyncMock(return_value=False),
+            new=MagicMock(return_value=False),
         ):
             await view.post(request)
         view.hass.async_add_executor_job.assert_not_called()

--- a/tests/unit/test_save_playlist_view.py
+++ b/tests/unit/test_save_playlist_view.py
@@ -75,7 +75,7 @@ def _authorized():
     """Patch is_authorized_http to allow the POST through (#1368)."""
     return mock.patch(
         "custom_components.beatify.server.playlist_views.is_authorized_http",
-        new=AsyncMock(return_value=True),
+        new=MagicMock(return_value=True),
     )
 
 
@@ -191,7 +191,7 @@ class TestSavePlaylistViewAuth:
         body = json.dumps({"playlist": _valid_playlist("Blocked")}).encode()
         with mock.patch(
             "custom_components.beatify.server.playlist_views.is_authorized_http",
-            new=AsyncMock(return_value=False),
+            new=MagicMock(return_value=False),
         ):
             resp = await view.post(_request_with_body(body))
         assert resp.status == 401
@@ -202,7 +202,7 @@ class TestSavePlaylistViewAuth:
         body = json.dumps({"playlist": _valid_playlist("Blocked")}).encode()
         with mock.patch(
             "custom_components.beatify.server.playlist_views.is_authorized_http",
-            new=AsyncMock(return_value=False),
+            new=MagicMock(return_value=False),
         ):
             await view.post(_request_with_body(body))
         view.hass.async_add_executor_job.assert_not_called()

--- a/tests/unit/test_start_game_view.py
+++ b/tests/unit/test_start_game_view.py
@@ -122,7 +122,7 @@ def start_game_env():
     with (
         patch(
             "custom_components.beatify.server.game_views.is_authorized_http",
-            new=AsyncMock(return_value=True),
+            new=MagicMock(return_value=True),
         ),
         patch("custom_components.beatify.server.game_views.Path") as mock_path_cls,
         patch(

--- a/tests/unit/test_unload_teardown.py
+++ b/tests/unit/test_unload_teardown.py
@@ -94,23 +94,19 @@ def _make_handler() -> BeatifyWebSocketHandler:
 
 @pytest.mark.asyncio
 async def test_async_close_all_cancels_pending_tasks():
-    """Pending removals, admin-disconnect, and debounce tasks are cancelled."""
+    """Admin-disconnect and debounce tasks are cancelled."""
     handler = _make_handler()
 
-    removal = asyncio.ensure_future(_never())
     admin = asyncio.ensure_future(_never())
     debounce = asyncio.ensure_future(_never())
-    handler._pending_removals["Alice"] = removal
     handler._admin_disconnect_task = admin
     handler._broadcast_debounce_task = debounce
 
     await handler.async_close_all()
     await asyncio.sleep(0)
 
-    assert removal.cancelled() or removal.done()
     assert admin.cancelled() or admin.done()
     assert debounce.cancelled() or debounce.done()
-    assert handler._pending_removals == {}
     assert handler._admin_disconnect_task is None
     assert handler._broadcast_debounce_task is None
 


### PR DESCRIPTION
Part of #1402 (bundle B5 — Server/WS cleanup). Does **not** close #1402.

Two scoped, behaviour-preserving cleanups in the server/WS layer.

## Findings fixed

### 1. Dead `_pending_removals` plumbing (`server/websocket.py` + `server/ws_handlers.py`)
`self._pending_removals` was declared in `__init__` but **never populated** anywhere in the codebase (verified by grep). Consequently:
- `cancel_pending_removal()` was a permanent no-op (`if player_name in self._pending_removals` was always false).
- `cleanup_game_tasks()` iterated an always-empty dict.

Removed: the `_pending_removals` field, the `cancel_pending_removal()` method, its dead loop in `cleanup_game_tasks()`, and all **4** no-op call sites in `ws_handlers.py` (`handle_join` ×3, `handle_reconnect` ×1). Updated the `cleanup_game_tasks` / `async_close_all` docstrings + comments to stop referencing the removed field.

**Kept intact:** the `_admin_disconnect_task` and `_broadcast_debounce_task` cancellation in `cleanup_game_tasks()` / `async_close_all()` (the #1391 unload-teardown path) — those tasks ARE populated and must still be cancelled. Updated `tests/unit/test_unload_teardown.py::test_async_close_all_cancels_pending_tasks` to drop the `_pending_removals` assertions while still covering admin + debounce cancellation.

### 2. `is_authorized_http` async with zero awaits (`server/companion_auth.py`)
The function was declared `async def` but contained no `await` — `hass.auth.async_validate_access_token()` is a synchronous HA method (no await in the original) and `is_companion_trusted_request()` is sync. Dropped the `async` keyword (added a docstring note explaining why it's sync) and removed `await` at all **12** production call sites:
- `game_views.py` ×5, `views.py` ×5, `playlist_views.py` ×2.

Test updates: dropped `await` in the 7 direct calls in `test_companion_auth.py`; swapped the mock patches from `AsyncMock` → `MagicMock` (the helper is no longer awaited) in `test_lights_view.py`, `test_save_playlist_view.py`, `test_playlist_requests_view.py`, `test_start_game_view.py`, and removed the now-unused `AsyncMock` import in `test_lights_view.py`.

## ⚠️ Overlap with open PR #1404 (#1357) — for human sequencing
`companion_auth.py` is the subject of the open, **un-merged** security PR #1404. This B5 PR is built off `origin/main` **without** #1404 and is deliberately scoped to the `async`-keyword cleanup only — it does **not** touch the bypass-trust logic (`is_companion_trusted_request` / `is_companion_trusted_meta`), which is #1404's domain. Still, both PRs edit the same file/function signature, so **whichever lands second will need a trivial rebase** (the `def is_authorized_http(...)` signature line + the `await`/non-`await` call sites). Recommend sequencing: land one, rebase the other.

## Readiness assessment
- [x] Ready to merge (pending #1404 sequencing note above)
- [ ] Borderline — see notes
- [ ] Not ready — needs human review

**Honest summary:** Pure dead-code + async-keyword cleanup, no behaviour change. Full suite green (1018 passed, 2 pre-existing skips), ruff + mypy clean. Only caveat is the file-level overlap with #1404, flagged above for sequencing.

## Test plan
- `python3 -m pytest tests/unit tests/integration` → 1018 passed, 2 skipped.
- `ruff check .` → All checks passed; `ruff format --check .` → 99 files already formatted (ruff==0.15.7).
- `mypy` → Success: no issues found in 15 source files (mypy==1.18.2). Note: server/ modules are not in the scoped mypy file list, so the helper signature change isn't type-gated by CI, but the run is clean.

## Risk assessment
- **Blast radius:** WS handler teardown/reconnect path + the HTTP auth gate shared by game/playlist/lights views.
- **What could go wrong:** if any out-of-tree caller `await`s `is_authorized_http`, it would now break (grep found none in repo). #1404 rebase friction (flagged).
- **What I did NOT test:** live HA runtime (unit/integration only); live Companion-app bypass path.

🤖 Auto-generated by issue-triage routine (B5)