### PR TITLE
fix: #1402 B6 — HA-platform plumbing

### DIFF
--- a/custom_components/beatify/__init__.py
+++ b/custom_components/beatify/__init__.py
@@ -97,8 +97,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Beatify from a config entry."""
     _LOGGER.debug("Setting up Beatify integration")
 
-    # Initialize domain data storage
-    hass.data.setdefault(DOMAIN, {})
+    # hass.data[DOMAIN] is assigned wholesale below once discovery + game
+    # infrastructure are built, so an early setdefault here is redundant (#1402
+    # B6). The only reader before that assignment is _read_manifest_version,
+    # which doesn't touch hass.data.
 
     # Read version from manifest.json once at setup (#784). Done in executor
     # because HA 2026.2+ flags blocking I/O at module level — but doing it

--- a/custom_components/beatify/binary_sensor.py
+++ b/custom_components/beatify/binary_sensor.py
@@ -12,9 +12,11 @@ from typing import Any
 from homeassistant.components.binary_sensor import BinarySensorEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
+from .device import build_device_info
 from .game.state import GamePhase, GameState
 
 _LOGGER = logging.getLogger(__name__)
@@ -27,7 +29,10 @@ async def async_setup_entry(
 ) -> None:
     """Set up Beatify binary sensor entities from a config entry."""
     game_state: GameState = hass.data[DOMAIN]["game"]
-    async_add_entities([BeatifyGameActiveSensor(game_state, entry.entry_id)])
+    device_info = build_device_info(hass, entry.entry_id)
+    async_add_entities(
+        [BeatifyGameActiveSensor(game_state, entry.entry_id, device_info)]
+    )
 
 
 class BeatifyGameActiveSensor(BinarySensorEntity):
@@ -38,9 +43,13 @@ class BeatifyGameActiveSensor(BinarySensorEntity):
     _attr_name = "Beatify game active"
     _attr_icon = "mdi:gamepad-variant"
 
-    def __init__(self, game_state: GameState, entry_id: str) -> None:
+    def __init__(
+        self, game_state: GameState, entry_id: str, device_info: DeviceInfo
+    ) -> None:
         self._game_state = game_state
         self._attr_unique_id = f"{entry_id}_game_active"
+        # #1402 B6: share the single Beatify device with the sensor platform.
+        self._attr_device_info = device_info
 
     async def async_added_to_hass(self) -> None:
         """Register state callback when entity is added."""
@@ -65,11 +74,11 @@ class BeatifyGameActiveSensor(BinarySensorEntity):
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
-        players = self._game_state.players
-        leader_name = None
-        if players:
-            leader = max(players.values(), key=lambda p: p.score)
-            leader_name = leader.name
+        # #1402 B6: reuse GameState.leader instead of recomputing the max() —
+        # the property already owns the leader-selection logic (and its
+        # empty-players guard), so duplicating it here risked divergence.
+        leader = self._game_state.leader
+        leader_name = leader.name if leader else None
 
         return {
             "phase": self._game_state.phase.value,

--- a/custom_components/beatify/config_flow.py
+++ b/custom_components/beatify/config_flow.py
@@ -7,9 +7,9 @@ from typing import Any
 
 import voluptuous as vol
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
-from homeassistant.helpers import entity_registry as er
 
 from .const import DOMAIN
+from .services.media_player import async_get_media_players
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -24,25 +24,29 @@ class BeatifyConfigFlow(ConfigFlow, domain=DOMAIN):
         user_input: dict[str, Any] | None = None,
     ) -> ConfigFlowResult:
         """Handle a flow initialized by the user."""
-        # Prevent multiple instances
-        await self.async_set_unique_id(DOMAIN)
-        self._abort_if_unique_id_configured()
+        # Single-instance enforcement is declared via `single_config_entry` in
+        # manifest.json (#1402 B6); HA aborts a second entry before this step
+        # runs, so no unique-id dance is needed here.
 
-        # Check for available media players
-        media_players = self._get_media_player_entities()
+        # Check for available media players using the SAME discovery that
+        # async_setup_entry runs (#1402 B6). The previous registry-only scan
+        # disagreed with runtime discovery — it counted disabled and
+        # capability-unsupported (raw Cast) players the setup path filters out,
+        # so the wizard could promise "✓ Found N media player(s)" for players
+        # Beatify can't actually use. async_get_media_players reads live states,
+        # skips unsupported platforms, and is async-safe.
+        media_players = await async_get_media_players(self.hass)
         has_media_players = len(media_players) > 0
 
         if user_input is not None:
-            # User confirmed setup - create entry regardless of media player status
-            # Store whether media players were available at setup time
-            return self.async_create_entry(
-                title="Beatify",
-                data={"has_media_players": has_media_players},
-            )
+            # User confirmed setup - create entry regardless of media player
+            # status. No entry data needed (the previously-stored
+            # "has_media_players" flag was never read back — dead field, #1402).
+            return self.async_create_entry(title="Beatify", data={})
 
         # Build description with warning if no media players
         if not has_media_players:
-            _LOGGER.warning("No media_player entities found in Home Assistant")
+            _LOGGER.warning("No compatible media_player entities found")
             warning_msg = (
                 "⚠️ No media players found. Beatify requires at least one "
                 "media_player entity to play music. You can proceed, but "
@@ -64,31 +68,3 @@ class BeatifyConfigFlow(ConfigFlow, domain=DOMAIN):
             data_schema=vol.Schema({}),
             description_placeholders=description_placeholders,
         )
-
-    def _get_media_player_entities(self) -> list[dict[str, str]]:
-        """
-        Get list of available media_player entities with friendly names.
-
-        Returns a list of dicts with entity_id and friendly_name for all
-        media_player entities registered in Home Assistant.
-        """
-        entity_reg = er.async_get(self.hass)
-        media_players = []
-
-        for entry in entity_reg.entities.values():
-            if entry.domain == "media_player":
-                # Get friendly name from entity registry or fall back to entity_id
-                friendly_name = entry.name or entry.original_name or entry.entity_id
-                media_players.append(
-                    {
-                        "entity_id": entry.entity_id,
-                        "friendly_name": friendly_name,
-                    }
-                )
-
-        _LOGGER.debug(
-            "Found %d media_player entities: %s",
-            len(media_players),
-            [p["entity_id"] for p in media_players],
-        )
-        return media_players

--- a/custom_components/beatify/device.py
+++ b/custom_components/beatify/device.py
@@ -1,0 +1,35 @@
+"""Shared HA device descriptor for Beatify entities (#1402 B6).
+
+All Beatify sensor and binary_sensor entities attach to a single logical
+"Beatify" device so they don't float without a device in the entity registry.
+Both platforms build their ``DeviceInfo`` through :func:`build_device_info` to
+keep identifiers, name, manufacturer and sw_version identical.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from homeassistant.helpers.entity import DeviceInfo
+
+from .const import DOMAIN
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+
+
+def build_device_info(hass: HomeAssistant, entry_id: str) -> DeviceInfo:
+    """Build the shared Beatify device descriptor.
+
+    The ``sw_version`` is read from ``hass.data[DOMAIN]["version"]``, which
+    async_setup_entry populates from manifest.json (#784) before forwarding the
+    platforms — so it is always present by the time entities are created. A
+    defensive fallback keeps the helper safe if called out of order.
+    """
+    version = hass.data.get(DOMAIN, {}).get("version", "unknown")
+    return DeviceInfo(
+        identifiers={(DOMAIN, entry_id)},
+        name="Beatify",
+        manufacturer="Beatify",
+        sw_version=version,
+    )

--- a/custom_components/beatify/manifest.json
+++ b/custom_components/beatify/manifest.json
@@ -15,5 +15,6 @@
   "requirements": [
     "num2words==0.5.14"
   ],
+  "single_config_entry": true,
   "version": "4.0.0"
 }

--- a/custom_components/beatify/sensor.py
+++ b/custom_components/beatify/sensor.py
@@ -16,9 +16,11 @@ from typing import Any
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
+from .device import build_device_info
 from .game.state import GamePhase, GameState
 
 _LOGGER = logging.getLogger(__name__)
@@ -31,13 +33,14 @@ async def async_setup_entry(
 ) -> None:
     """Set up Beatify sensor entities from a config entry."""
     game_state: GameState = hass.data[DOMAIN]["game"]
+    device_info = build_device_info(hass, entry.entry_id)
 
     entities = [
-        BeatifyCurrentRoundSensor(game_state, entry.entry_id),
-        BeatifyLeaderSensor(game_state, entry.entry_id),
-        BeatifyTopScoreSensor(game_state, entry.entry_id),
-        BeatifyPlayerCountSensor(game_state, entry.entry_id),
-        BeatifyCurrentSongSensor(game_state, entry.entry_id),
+        BeatifyCurrentRoundSensor(game_state, entry.entry_id, device_info),
+        BeatifyLeaderSensor(game_state, entry.entry_id, device_info),
+        BeatifyTopScoreSensor(game_state, entry.entry_id, device_info),
+        BeatifyPlayerCountSensor(game_state, entry.entry_id, device_info),
+        BeatifyCurrentSongSensor(game_state, entry.entry_id, device_info),
     ]
     async_add_entities(entities)
 
@@ -48,9 +51,14 @@ class BeatifySensorBase(SensorEntity):
     _attr_should_poll = False
     _attr_has_entity_name = True
 
-    def __init__(self, game_state: GameState, entry_id: str) -> None:
+    def __init__(
+        self, game_state: GameState, entry_id: str, device_info: DeviceInfo
+    ) -> None:
         self._game_state = game_state
         self._attr_unique_id = f"{entry_id}_{self._sensor_key}"
+        # #1402 B6: attach every entity to a single Beatify device so the six
+        # sensors don't float without a device in the registry.
+        self._attr_device_info = device_info
 
     @property
     def _sensor_key(self) -> str:
@@ -164,27 +172,38 @@ class BeatifyCurrentSongSensor(BeatifySensorBase):
     _attr_icon = "mdi:music-note"
     _sensor_key = "current_song"
 
-    def __init__(self, game_state: GameState, entry_id: str) -> None:
-        super().__init__(game_state, entry_id)
+    def __init__(
+        self, game_state: GameState, entry_id: str, device_info: DeviceInfo
+    ) -> None:
+        super().__init__(game_state, entry_id, device_info)
         self._last_title: str | None = None
         self._last_artist: str | None = None
         self._last_year: int | None = None
 
-    @property
-    def native_value(self) -> str | None:
+    @callback
+    def _on_state_changed(self) -> None:
+        """Refresh the cached song before writing state (#1402 B6).
+
+        The cache update used to be a side effect of reading ``native_value``,
+        which made an HA property impure — repeated reads (or a read that never
+        happened) could leave the cache out of sync. The cache is now refreshed
+        exactly once per game-state change, here, before ``async_write_ha_state``
+        re-reads the now-pure properties.
+        """
         phase = self._game_state.phase
         song = self._game_state.current_song
-
-        # Update cache when song info is available during non-PLAYING phases
         if song and phase != GamePhase.PLAYING:
             self._last_title = song.get("title")
             self._last_artist = song.get("artist")
             self._last_year = song.get("year")
+        super()._on_state_changed()
 
-        # Hidden during PLAYING phase
-        if phase == GamePhase.PLAYING:
+    @property
+    def native_value(self) -> str | None:
+        # Pure read: caching happens in _on_state_changed (#1402 B6).
+        if self._game_state.phase == GamePhase.PLAYING:
+            # Hidden during PLAYING phase
             return None
-
         return self._last_title
 
     @property

--- a/tests/unit/_ha_stubs.py
+++ b/tests/unit/_ha_stubs.py
@@ -1,0 +1,94 @@
+"""Real HA stubs for B6 platform tests (#1402).
+
+The repo-root conftest.py registers most ``homeassistant.*`` leaf modules as
+bare ``MagicMock`` objects so game logic imports cleanly. That is fine for code
+that only *references* HA symbols, but the B6 platform modules need a few of
+those symbols to behave like real classes/callables for assertions to be
+meaningful:
+
+* ``DeviceInfo`` must build a real (dict-like) mapping so we can assert on
+  identifiers / name / sw_version.
+* ``ConfigFlow`` must be a real base class accepting ``domain=...`` and
+  exposing ``async_create_entry`` / ``async_show_form``.
+* ``SensorEntity`` / ``BinarySensorEntity`` must be real classes to subclass.
+* ``callback`` must be an identity decorator.
+
+:func:`install` force-replaces just those symbols (the MagicMock leaves answer
+``hasattr`` for everything, so we overwrite unconditionally). Call it once at
+the top of a test module, BEFORE importing the beatify module under test.
+"""
+
+from __future__ import annotations
+
+import sys
+from types import ModuleType
+from typing import Any
+
+
+def _module(name: str) -> ModuleType:
+    """Return a real ModuleType for ``name`` (replacing any MagicMock leaf)."""
+    mod = sys.modules.get(name)
+    if not isinstance(mod, ModuleType):
+        mod = ModuleType(name)
+        sys.modules[name] = mod
+    return mod
+
+
+class _DeviceInfo(dict):
+    """Dict-backed stand-in for HA's DeviceInfo TypedDict."""
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+
+
+class _ConfigFlow:
+    """Tiny ConfigFlow stand-in accepting the ``domain=...`` subclass kwarg."""
+
+    hass: Any = None
+
+    def __init_subclass__(cls, **kwargs: Any) -> None:
+        super().__init_subclass__()
+
+    def async_create_entry(self, **kwargs: Any) -> dict[str, Any]:
+        return {"type": "create_entry", **kwargs}
+
+    def async_show_form(self, **kwargs: Any) -> dict[str, Any]:
+        return {"type": "form", **kwargs}
+
+
+def install() -> None:
+    """Force-install real HA stubs needed by the B6 platform modules."""
+    core = _module("homeassistant.core")
+    core.callback = lambda func: func  # type: ignore[attr-defined]
+    if not isinstance(getattr(core, "HomeAssistant", None), type):
+        core.HomeAssistant = object  # type: ignore[attr-defined]
+
+    ce = _module("homeassistant.config_entries")
+    ce.ConfigEntry = object  # type: ignore[attr-defined]
+    ce.ConfigFlowResult = dict  # type: ignore[attr-defined]
+    ce.ConfigFlow = _ConfigFlow  # type: ignore[attr-defined]
+
+    # Base entity classes expose a no-op async_write_ha_state so _on_state_changed
+    # can be invoked directly in tests.
+    _entity_ns = {"async_write_ha_state": lambda self: None}
+    sensor = _module("homeassistant.components.sensor")
+    sensor.SensorEntity = type(  # type: ignore[attr-defined]
+        "SensorEntity", (), dict(_entity_ns)
+    )
+    bsensor = _module("homeassistant.components.binary_sensor")
+    bsensor.BinarySensorEntity = type(  # type: ignore[attr-defined]
+        "BinarySensorEntity", (), dict(_entity_ns)
+    )
+
+    helpers_entity = _module("homeassistant.helpers.entity")
+    helpers_entity.DeviceInfo = _DeviceInfo  # type: ignore[attr-defined]
+    plat = _module("homeassistant.helpers.entity_platform")
+    plat.AddEntitiesCallback = object  # type: ignore[attr-defined]
+
+    # ``config_flow`` does ``import voluptuous as vol`` at module top — but
+    # voluptuous is a Home Assistant runtime dep that is NOT installed in the
+    # minimal CI unit-test env (requirements_test.txt only). Stub it so the
+    # import resolves; config_flow only needs ``vol.Schema({})`` to build an
+    # (empty) data schema, so a passthrough callable is enough.
+    vol = _module("voluptuous")
+    vol.Schema = lambda schema=None, **kwargs: schema  # type: ignore[attr-defined]

--- a/tests/unit/test_config_flow_b6.py
+++ b/tests/unit/test_config_flow_b6.py
@@ -1,0 +1,100 @@
+"""Regression tests for B6 config-flow plumbing (#1402).
+
+Covers:
+* Fix 1 — the wizard's media-player check uses the same async_get_media_players
+  discovery as setup (so the warning matches what setup finds), not the old
+  registry-only scan.
+* Fix 3 — the created entry stores empty data (the dead "has_media_players"
+  flag is gone) and the flow no longer runs the unique-id dance (single-entry
+  is enforced via manifest single_config_entry).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from tests.unit import _ha_stubs
+
+_ha_stubs.install()
+
+from custom_components.beatify.config_flow import BeatifyConfigFlow  # noqa: E402
+
+_MANIFEST = (
+    Path(__file__).resolve().parents[2]
+    / "custom_components"
+    / "beatify"
+    / "manifest.json"
+)
+
+
+def _flow() -> BeatifyConfigFlow:
+    flow = BeatifyConfigFlow()
+    flow.hass = MagicMock()
+    return flow
+
+
+@pytest.mark.asyncio
+async def test_flow_uses_async_get_media_players_discovery():
+    """Fix 1: the form check calls the shared async discovery, not the registry."""
+    flow = _flow()
+    players = [{"entity_id": "media_player.living", "friendly_name": "Living Room"}]
+    with patch(
+        "custom_components.beatify.config_flow.async_get_media_players",
+        new=AsyncMock(return_value=players),
+    ) as mocked:
+        result = await flow.async_step_user(None)
+
+    mocked.assert_awaited_once_with(flow.hass)
+    assert result["type"] == "form"
+    assert "Living Room" in result["description_placeholders"]["warning"]
+
+
+@pytest.mark.asyncio
+async def test_flow_warns_when_no_media_players():
+    flow = _flow()
+    with patch(
+        "custom_components.beatify.config_flow.async_get_media_players",
+        new=AsyncMock(return_value=[]),
+    ):
+        result = await flow.async_step_user(None)
+    assert result["type"] == "form"
+    assert "No media players found" in result["description_placeholders"]["warning"]
+
+
+@pytest.mark.asyncio
+async def test_flow_creates_entry_with_empty_data():
+    """Fix 3: created entry stores empty data (dead has_media_players gone)."""
+    flow = _flow()
+    with patch(
+        "custom_components.beatify.config_flow.async_get_media_players",
+        new=AsyncMock(return_value=[]),
+    ):
+        result = await flow.async_step_user({})
+    assert result["type"] == "create_entry"
+    assert result["title"] == "Beatify"
+    assert result["data"] == {}
+
+
+@pytest.mark.asyncio
+async def test_flow_no_unique_id_dance():
+    """Fix 3: the flow no longer calls async_set_unique_id (single_config_entry)."""
+    flow = _flow()
+    flow.async_set_unique_id = AsyncMock()
+    flow._abort_if_unique_id_configured = MagicMock()
+    with patch(
+        "custom_components.beatify.config_flow.async_get_media_players",
+        new=AsyncMock(return_value=[]),
+    ):
+        await flow.async_step_user(None)
+    flow.async_set_unique_id.assert_not_called()
+    flow._abort_if_unique_id_configured.assert_not_called()
+
+
+def test_manifest_declares_single_config_entry():
+    """Fix 3: manifest opts into HA's single-entry enforcement."""
+    manifest = json.loads(_MANIFEST.read_text(encoding="utf-8"))
+    assert manifest.get("single_config_entry") is True

--- a/tests/unit/test_platform_b6.py
+++ b/tests/unit/test_platform_b6.py
@@ -1,0 +1,148 @@
+"""Regression tests for B6 HA-platform plumbing (#1402).
+
+Covers:
+* Fix 2 — BeatifyCurrentSongSensor.native_value is a pure read; the cache is
+  refreshed in the _on_state_changed callback, not as a property side effect.
+* Fix 4 — every sensor / binary_sensor entity carries a shared Beatify
+  DeviceInfo (identifiers, name, manufacturer, sw_version from manifest).
+* Fix 5 — BeatifyGameActiveSensor reuses GameState.leader instead of
+  recomputing the leaderboard max().
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from tests.conftest import make_game_state, make_player
+from tests.unit import _ha_stubs
+
+_ha_stubs.install()
+
+from custom_components.beatify.binary_sensor import (  # noqa: E402
+    BeatifyGameActiveSensor,
+)
+from custom_components.beatify.const import DOMAIN  # noqa: E402
+from custom_components.beatify.device import build_device_info  # noqa: E402
+from custom_components.beatify.game.state import GamePhase  # noqa: E402
+from custom_components.beatify.sensor import (  # noqa: E402
+    BeatifyCurrentSongSensor,
+    BeatifyLeaderSensor,
+)
+
+
+def _device_info(version: str = "4.0.0"):
+    hass = MagicMock()
+    hass.data = {DOMAIN: {"version": version}}
+    return build_device_info(hass, "entry123")
+
+
+# ---------------------------------------------------------------------------
+# Fix 4 — DeviceInfo
+# ---------------------------------------------------------------------------
+
+
+def test_build_device_info_fields():
+    info = _device_info("4.2.1")
+    assert info["identifiers"] == {(DOMAIN, "entry123")}
+    assert info["name"] == "Beatify"
+    assert info["manufacturer"] == "Beatify"
+    assert info["sw_version"] == "4.2.1"
+
+
+def test_build_device_info_falls_back_when_version_missing():
+    hass = MagicMock()
+    hass.data = {}  # version not yet populated
+    info = build_device_info(hass, "e1")
+    assert info["sw_version"] == "unknown"
+
+
+def test_entities_share_same_device_identifiers():
+    game = make_game_state()
+    info = _device_info()
+    leader_sensor = BeatifyLeaderSensor(game, "entry123", info)
+    binary = BeatifyGameActiveSensor(game, "entry123", info)
+    # Both platforms attach to the SAME device (same identifiers).
+    assert leader_sensor._attr_device_info["identifiers"] == {(DOMAIN, "entry123")}
+    assert (
+        binary._attr_device_info["identifiers"]
+        == leader_sensor._attr_device_info["identifiers"]
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fix 2 — current-song cache is updated in the callback, not in native_value
+# ---------------------------------------------------------------------------
+
+
+def test_current_song_native_value_is_pure_read():
+    game = make_game_state()
+    sensor = BeatifyCurrentSongSensor(game, "e", _device_info())
+
+    # Song available during a non-PLAYING phase, but the callback hasn't fired.
+    game.phase = GamePhase.REVEAL
+    game.current_song = {"title": "Africa", "artist": "Toto", "year": 1982}
+
+    # Pure read: native_value must NOT populate the cache as a side effect.
+    assert sensor.native_value is None
+    assert sensor._last_title is None
+
+    # The callback is what refreshes the cache.
+    sensor._on_state_changed()
+    assert sensor._last_title == "Africa"
+    assert sensor._last_artist == "Toto"
+    assert sensor._last_year == 1982
+    assert sensor.native_value == "Africa"
+
+
+def test_current_song_hidden_during_playing_and_cache_untouched():
+    game = make_game_state()
+    sensor = BeatifyCurrentSongSensor(game, "e", _device_info())
+
+    # Seed the cache via a REVEAL callback.
+    game.phase = GamePhase.REVEAL
+    game.current_song = {"title": "Africa", "artist": "Toto", "year": 1982}
+    sensor._on_state_changed()
+
+    # Now PLAYING — value hidden, and a PLAYING callback must NOT overwrite the
+    # cached last song (so it reappears at the next REVEAL).
+    game.phase = GamePhase.PLAYING
+    game.current_song = {"title": "Secret", "artist": "X", "year": 2000}
+    sensor._on_state_changed()
+    assert sensor.native_value is None
+    assert sensor._last_title == "Africa"
+
+    game.phase = GamePhase.REVEAL
+    sensor._on_state_changed()
+    assert sensor.native_value == "Secret"  # cache refreshed once back in REVEAL
+
+
+def test_current_song_extra_attributes_pure_read():
+    game = make_game_state()
+    sensor = BeatifyCurrentSongSensor(game, "e", _device_info())
+    game.phase = GamePhase.PLAYING
+    assert sensor.extra_state_attributes == {"artist": None, "year": None}
+
+
+# ---------------------------------------------------------------------------
+# Fix 5 — binary sensor reuses GameState.leader
+# ---------------------------------------------------------------------------
+
+
+def test_game_active_leader_attribute_reuses_game_state_leader():
+    game = make_game_state()
+    game.players = {
+        "a": make_player("Alice", score=10),
+        "b": make_player("Bob", score=42),
+        "c": make_player("Cara", score=7),
+    }
+    sensor = BeatifyGameActiveSensor(game, "e", _device_info())
+    attrs = sensor.extra_state_attributes
+    assert attrs["leader"] == "Bob"
+    assert attrs["leader"] == game.leader.name
+
+
+def test_game_active_leader_none_when_no_players():
+    game = make_game_state()
+    game.players = {}
+    sensor = BeatifyGameActiveSensor(game, "e", _device_info())
+    assert sensor.extra_state_attributes["leader"] is None


### PR DESCRIPTION
Bundle **B6 (HA-platform plumbing)** from #1402. One cohesive PR, five findings. References #1402 (does not close it).

## Findings fixed

1. **Config-flow media-player check disagreed with runtime discovery** (`config_flow.py`)
   The wizard scanned the entity registry directly — counting disabled and capability-unsupported (raw Cast) players that `async_setup_entry` filters out — so it could promise "✓ Found N media player(s)" for players Beatify can't actually use. The flow now reuses `await async_get_media_players(self.hass)`, the same async-safe discovery setup runs, so the warning matches what setup finds.

2. **Current-song sensor mutated its cache as a side effect of `native_value`** (`sensor.py`)
   Reading the property refreshed `_last_title/_artist/_year`, making an HA property impure (repeated reads, or a read that never happened, could desync the cache). The cache refresh moved into an overridden `_on_state_changed` callback (runs once per game-state change, before `async_write_ha_state`); both `native_value` and `extra_state_attributes` are now pure reads.

3. **`single_config_entry` manifest flag instead of the unique-id hack; dead entry data** (`manifest.json`, `config_flow.py`, `__init__.py`)
   Added `"single_config_entry": true` to the manifest (HA enforces single-entry at the framework level — standard, safe migration for existing entries that already carry `unique_id=DOMAIN`). Dropped the `async_set_unique_id(DOMAIN)` / `_abort_if_unique_id_configured()` dance. The created entry now stores `data={}` — the previously-stored `has_media_players` flag was never read back anywhere (dead field). Removed the redundant `hass.data.setdefault(DOMAIN, {})` in `async_setup_entry` (the key is assigned wholesale a few lines later). **Unload logic (`async_unload_entry`, #1391/#1392) left untouched.**

4. **Entities had no `device_info` — six entities floated without a device** (`sensor.py`, `binary_sensor.py`, new `device.py`)
   New shared helper `build_device_info(hass, entry_id)` returns `DeviceInfo(identifiers={(DOMAIN, entry_id)}, name="Beatify", manufacturer="Beatify", sw_version=<manifest version from hass.data>)`, used by both platforms so all seven entities attach to one logical Beatify device with identical descriptors.

5. **Binary sensor recomputed the leader instead of reusing `GameState.leader`** (`binary_sensor.py`)
   Replaced the `max(players.values(), key=...)` block with `leader = self._game_state.leader; leader_name = leader.name if leader else None` — the property already owns leader-selection (and its empty-players guard), so the duplicate logic risked divergence.

## Tests
- `tests/unit/test_platform_b6.py` — DeviceInfo fields + fallback + shared identifiers across both platforms (Fix 4); current-song pure-read + cache-in-callback + PLAYING-phase cache preservation (Fix 2); binary-sensor leader reuse + empty-players (Fix 5).
- `tests/unit/test_config_flow_b6.py` — flow uses `async_get_media_players` discovery, warning text, empty entry data, no unique-id dance (Fix 1 + Fix 3); manifest `single_config_entry` assertion.
- `tests/unit/_ha_stubs.py` — real (non-MagicMock) HA stubs for the platform/config-flow modules, layered on the repo-root conftest mock leaves.

## Gates (all green)
- `python3 -m pytest` → 1031 passed, 2 skipped
- `python3 -m ruff check .` → All checks passed
- `python3 -m ruff format --check .` → 103 files already formatted
- `python3 -m mypy` (1.18.2) → no issues in 15 source files

## Risk / caveats
- **Blast radius:** integration setup + config flow + both entity platforms. `single_config_entry` and `device_info` touch HA registration; implemented conservatively. Existing single-instance entries already carry `unique_id=DOMAIN`, which is exactly the state `single_config_entry` expects — no data migration required.
- mypy's scoped `files` list (per pyproject.toml ramp-up) does not include the platform modules or new `device.py`, so they aren't statically gated yet — consistent with the existing baseline.
- Not exercised against a live HA instance (HA is not installed in the test env; the repo stubs it). Logic is unit-tested; manual smoke against a real install is advisable before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)