### PR TITLE
fix: #1402 B4 — media_player/lights batch

### DIFF
--- a/custom_components/beatify/services/lights.py
+++ b/custom_components/beatify/services/lights.py
@@ -136,6 +136,13 @@ class PartyLightsService:
                     "brightness": state.attributes.get("brightness"),
                     "rgb_color": state.attributes.get("rgb_color"),
                     "color_temp_kelvin": state.attributes.get("color_temp_kelvin"),
+                    # #1402: remember which color attribute was actually active.
+                    # A light reports BOTH rgb_color and color_temp_kelvin in its
+                    # attributes (the inactive one lingers), so restore must only
+                    # replay the attribute matching the active color_mode — sending
+                    # both in one turn_on is contradictory and the light picks one
+                    # nondeterministically.
+                    "color_mode": state.attributes.get("color_mode"),
                 }
 
         # Compute base brightness for subtle mode from saved states
@@ -366,10 +373,27 @@ class PartyLightsService:
                     restore_data: dict[str, Any] = {"entity_id": entity_id}
                     if saved.get("brightness") is not None:
                         restore_data["brightness"] = saved["brightness"]
-                    if saved.get("rgb_color") is not None:
-                        restore_data["rgb_color"] = list(saved["rgb_color"])
-                    if saved.get("color_temp_kelvin") is not None:
-                        restore_data["color_temp_kelvin"] = saved["color_temp_kelvin"]
+                    # #1402: restore only the color attribute matching the
+                    # active color_mode. Sending rgb_color AND color_temp_kelvin
+                    # in the same turn_on is contradictory; the light resolves it
+                    # nondeterministically and the original color is not reliably
+                    # restored. color_temp mode → color_temp_kelvin only; any
+                    # rgb/hs/xy mode → rgb_color only. When color_mode is unknown
+                    # (older/partial states), fall back to rgb_color if present,
+                    # else color_temp_kelvin — never both.
+                    color_mode = saved.get("color_mode")
+                    rgb = saved.get("rgb_color")
+                    ct = saved.get("color_temp_kelvin")
+                    if color_mode == "color_temp":
+                        if ct is not None:
+                            restore_data["color_temp_kelvin"] = ct
+                    elif color_mode in ("rgb", "rgbw", "rgbww", "hs", "xy"):
+                        if rgb is not None:
+                            restore_data["rgb_color"] = list(rgb)
+                    elif rgb is not None:
+                        restore_data["rgb_color"] = list(rgb)
+                    elif ct is not None:
+                        restore_data["color_temp_kelvin"] = ct
                     await self._hass.services.async_call(
                         "light",
                         "turn_on",

--- a/custom_components/beatify/services/media_player.py
+++ b/custom_components/beatify/services/media_player.py
@@ -4,15 +4,10 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import sys
+from asyncio import timeout as async_timeout
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any
 from urllib.parse import quote
-
-if sys.version_info >= (3, 11):
-    from asyncio import timeout as async_timeout
-else:
-    from async_timeout import timeout as async_timeout
 
 from homeassistant.exceptions import HomeAssistantError, ServiceNotFound
 from homeassistant.helpers.event import async_track_state_change_event
@@ -388,7 +383,7 @@ class MediaPlayerService:
                 return await self._play_via_alexa(song)
             _LOGGER.error("Unsupported platform: %s", self._platform)
             return False
-        except TimeoutError:
+        except (TimeoutError, asyncio.TimeoutError):
             _LOGGER.error(
                 "Playback timed out after %ss for %s: %s",
                 PLAYBACK_TIMEOUT,
@@ -1004,7 +999,22 @@ class MediaPlayerService:
             content_type = "SPOTIFY"
         elif self._provider == "amazon_music":
             content_type = "AMAZON_MUSIC"
+        elif self._provider == "apple_music":
+            content_type = "APPLE_MUSIC"
         else:
+            # Unknown provider slipped past the wizard gate. Previously every
+            # non-spotify/non-amazon provider was silently mapped to
+            # APPLE_MUSIC, so a deezer/tidal/ytmusic mismatch played the wrong
+            # catalog with no diagnostic — the same silent-fail class as
+            # #768/#808. Surface it (mirrors the #1276 dispatch warning) before
+            # falling back to APPLE_MUSIC. (#1402)
+            _LOGGER.warning(
+                "Alexa dispatch: unexpected provider %r — no Alexa content-type "
+                "mapping; falling back to APPLE_MUSIC for %s - %s (#1402)",
+                self._provider,
+                song.get("artist"),
+                song.get("title"),
+            )
             content_type = "APPLE_MUSIC"
 
         _LOGGER.debug(
@@ -1445,7 +1455,7 @@ class MediaPlayerService:
             _LOGGER.debug("Media player %s is responsive", self._entity_id)
             self._preflight_verified = True
             return True, ""
-        except TimeoutError:
+        except (TimeoutError, asyncio.TimeoutError):
             msg = f"Timeout after {PREFLIGHT_TIMEOUT}s - speaker may be sleeping or offline"
             _LOGGER.warning(
                 "Media player %s not responsive: %s",

--- a/tests/unit/test_lights.py
+++ b/tests/unit/test_lights.py
@@ -231,6 +231,125 @@ class TestStartStop:
         await svc.stop()
         assert svc._active is False
 
+    @pytest.mark.asyncio
+    async def test_start_saves_color_mode(self):
+        """#1402: start() must remember the active color_mode for restore."""
+        hass = _make_hass(
+            {
+                "light.ct": {
+                    "state": "on",
+                    "attributes": {
+                        "supported_color_modes": ["color_temp", "rgb"],
+                        "color_mode": "color_temp",
+                        "brightness": 180,
+                        "rgb_color": [255, 255, 255],
+                        "color_temp_kelvin": 2700,
+                    },
+                }
+            }
+        )
+        svc = PartyLightsService(hass)
+        await svc.start(["light.ct"])
+        assert svc._saved_states["light.ct"]["color_mode"] == "color_temp"
+
+    @pytest.mark.asyncio
+    async def test_stop_color_temp_mode_restores_only_kelvin(self):
+        """#1402: a color_temp light reports BOTH rgb_color and color_temp_kelvin;
+        restore must replay color_temp_kelvin only, never both in one turn_on."""
+        hass = _make_hass(
+            {
+                "light.ct": {
+                    "state": "on",
+                    "attributes": {
+                        "supported_color_modes": ["color_temp", "rgb"],
+                        "color_mode": "color_temp",
+                        "brightness": 180,
+                        "rgb_color": [255, 255, 255],
+                        "color_temp_kelvin": 2700,
+                    },
+                }
+            }
+        )
+        svc = PartyLightsService(hass)
+        await svc.start(["light.ct"])
+        await svc.stop()
+
+        hass.services.async_call.assert_any_call(
+            "light",
+            "turn_on",
+            {
+                "entity_id": "light.ct",
+                "brightness": 180,
+                "color_temp_kelvin": 2700,
+            },
+            blocking=False,
+        )
+
+    @pytest.mark.asyncio
+    async def test_stop_rgb_mode_restores_only_rgb(self):
+        """#1402: an rgb-mode light with a lingering color_temp_kelvin attribute
+        must restore rgb_color only, never both."""
+        hass = _make_hass(
+            {
+                "light.rgb": {
+                    "state": "on",
+                    "attributes": {
+                        "supported_color_modes": ["color_temp", "rgb"],
+                        "color_mode": "rgb",
+                        "brightness": 120,
+                        "rgb_color": [10, 20, 30],
+                        "color_temp_kelvin": 4000,
+                    },
+                }
+            }
+        )
+        svc = PartyLightsService(hass)
+        await svc.start(["light.rgb"])
+        await svc.stop()
+
+        hass.services.async_call.assert_any_call(
+            "light",
+            "turn_on",
+            {
+                "entity_id": "light.rgb",
+                "brightness": 120,
+                "rgb_color": [10, 20, 30],
+            },
+            blocking=False,
+        )
+
+    @pytest.mark.asyncio
+    async def test_stop_unknown_color_mode_prefers_rgb_not_both(self):
+        """#1402: when color_mode is absent (older/partial state) but both color
+        attributes were saved, restore picks rgb_color and never sends both."""
+        hass = _make_hass(
+            {
+                "light.legacy": {
+                    "state": "on",
+                    "attributes": {
+                        "supported_color_modes": ["rgb"],
+                        "brightness": 90,
+                        "rgb_color": [1, 2, 3],
+                        "color_temp_kelvin": 3500,
+                    },
+                }
+            }
+        )
+        svc = PartyLightsService(hass)
+        await svc.start(["light.legacy"])
+        await svc.stop()
+
+        hass.services.async_call.assert_any_call(
+            "light",
+            "turn_on",
+            {
+                "entity_id": "light.legacy",
+                "brightness": 90,
+                "rgb_color": [1, 2, 3],
+            },
+            blocking=False,
+        )
+
 
 # ---------------------------------------------------------------------------
 # set_phase

--- a/tests/unit/test_media_player.py
+++ b/tests/unit/test_media_player.py
@@ -2050,3 +2050,58 @@ class TestWaitForMetadataUpdateCrossProvider:
             result = await task
 
         assert result["album_art"] == "/api/media_player_proxy/x?token=NEW"
+
+
+class TestAlexaContentType:
+    """#1402: Alexa dispatch must map provider -> content_type explicitly and
+    warn on an unexpected provider instead of silently treating everything as
+    Apple Music."""
+
+    @staticmethod
+    def _service(provider: str):
+        hass = _make_hass("playing")
+        svc = MediaPlayerService(
+            hass, "media_player.echo", platform="alexa_media", provider=provider
+        )
+        return svc, hass
+
+    @pytest.mark.asyncio
+    async def test_spotify_maps_to_spotify(self):
+        svc, hass = self._service("spotify")
+        await svc._play_via_alexa(_make_song())
+        call = hass.services.async_call.call_args
+        assert call[0][2]["media_content_type"] == "SPOTIFY"
+
+    @pytest.mark.asyncio
+    async def test_amazon_maps_to_amazon_music(self):
+        svc, hass = self._service("amazon_music")
+        await svc._play_via_alexa(_make_song())
+        call = hass.services.async_call.call_args
+        assert call[0][2]["media_content_type"] == "AMAZON_MUSIC"
+
+    @pytest.mark.asyncio
+    async def test_apple_music_maps_to_apple_music_no_warning(self):
+        svc, hass = self._service("apple_music")
+        with patch(
+            "custom_components.beatify.services.media_player._LOGGER"
+        ) as mock_log:
+            await svc._play_via_alexa(_make_song())
+        call = hass.services.async_call.call_args
+        assert call[0][2]["media_content_type"] == "APPLE_MUSIC"
+        assert not any(
+            "unexpected provider" in str(c) for c in mock_log.warning.call_args_list
+        )
+
+    @pytest.mark.asyncio
+    async def test_unexpected_provider_falls_back_and_warns(self):
+        """A provider with no Alexa mapping (e.g. deezer) falls back to
+        APPLE_MUSIC but logs a warning naming the provider (#1402)."""
+        svc, hass = self._service("deezer")
+        with patch(
+            "custom_components.beatify.services.media_player._LOGGER"
+        ) as mock_log:
+            await svc._play_via_alexa(_make_song())
+        call = hass.services.async_call.call_args
+        assert call[0][2]["media_content_type"] == "APPLE_MUSIC"
+        warnings = [str(c) for c in mock_log.warning.call_args_list]
+        assert any("unexpected provider" in w and "deezer" in w for w in warnings)


### PR DESCRIPTION
Bundle **B4** from #1402 (media_player / lights code-quality batch). References #1402; does **not** close it and does **not** touch the #1402 checklist.

## Findings fixed

### 1. Python 3.10 timeout branch — dead code + wrong exception type
`services/media_player.py`. The `if sys.version_info >= (3, 11)` fork imported `async_timeout` from the `async_timeout` backport on 3.10, whose `timeout()` raises `asyncio.TimeoutError` — which a bare `except TimeoutError` does **not** catch on 3.10. The HACS floor is `2025.1.0` (HA 2025.1 requires Python 3.13), so the 3.10 path can never execute.
- **Fix:** dropped the version branch and the `async_timeout` backport import entirely; `from asyncio import timeout as async_timeout` directly. Removed the now-unused `import sys`.
- Belt-and-braces: the two `except TimeoutError:` sites (`play_song`, `verify_responsive`) are now `except (TimeoutError, asyncio.TimeoutError):` so they stay correct even if a future caller reintroduces a backport. (On 3.11+ these are aliases; explicit is harmless.)

### 2. Alexa dispatch silently maps every unknown provider to APPLE_MUSIC
`services/media_player._play_via_alexa`. The `else: content_type = "APPLE_MUSIC"` branch meant a deezer/tidal/ytmusic mismatch silently played the Apple Music catalog with no diagnostic — the same silent-fail class as #768/#808.
- **Fix:** `apple_music` is now an explicit `elif`; the final `else` logs a warning naming the unexpected provider (mirrors the #1276 dispatch-warning pattern) before falling back to `APPLE_MUSIC`.

### 3. `stop()` restore sends rgb_color AND color_temp_kelvin in one turn_on
`services/lights.py`. A real HA light reports **both** `rgb_color` and `color_temp_kelvin` in its attributes (the inactive one lingers). `stop()` replayed both in a single `light.turn_on`, which is contradictory — the light resolves it nondeterministically and the user's original color is not reliably restored.
- **Fix:** `start()` now saves `state.attributes.get('color_mode')`. `stop()` restores only the matching attribute: `color_temp` mode → `color_temp_kelvin` only; `rgb`/`rgbw`/`rgbww`/`hs`/`xy` → `rgb_color` only. When `color_mode` is absent (older/partial states) it falls back to rgb-if-present-else-ct — **never both**.

## Tests
- `tests/unit/test_lights.py`: `test_start_saves_color_mode`, `test_stop_color_temp_mode_restores_only_kelvin`, `test_stop_rgb_mode_restores_only_rgb`, `test_stop_unknown_color_mode_prefers_rgb_not_both`.
- `tests/unit/test_media_player.py`: new `TestAlexaContentType` (spotify / amazon / apple_music-no-warning / unexpected-provider-warns).

## Gate (Python 3.13, ruff==0.15.7, mypy==1.18.2)
- `pytest`: 1050 passed, 2 skipped
- `ruff check .`: clean
- `ruff format --check .`: clean
- `mypy`: Success, no issues (both touched modules are in the #1275 mypy gate)

## ⚠️ Merge-sequencing flag — lights.py overlap with open PR #1450 (B2)
This branch is built off `origin/main` **without** the open (unmerged) B2 PR #1450, which adds `start(inherited_states=...)` + `snapshot_saved_states` to `lights.py`. Both PRs edit the same `start()` save-block and the `stop()` restore loop, so **they will textually conflict** on `lights.py`. Recommend landing one then rebasing the other. The B4 change here is local to (a) one added `color_mode` key in the saved-state dict and (b) the restore-attribute selection in `stop()` — small, easy to replay on top of #1450 or vice-versa.

## Risk
- **Blast radius:** Alexa playback path, Party Lights restore-on-stop, MA/Sonos/Alexa timeout handling.
- **What could go wrong:** finding #3 changes restore behavior for lights that previously (accidentally) got both attributes — intended, but worth a live smoke-test on a color_temp bulb.
- **Not tested:** live HA hardware (unit-tested only via mocked `hass.services.async_call`).

References #1402.

🤖 Generated with [Claude Code](https://claude.com/claude-code)