### PR TITLE
data: fix dead Apple Music URI for Lamb of God – Ruin (#1456)

### DIFF
--- a/custom_components/beatify/playlists/community/greatest-metal-songs.json
+++ b/custom_components/beatify/playlists/community/greatest-metal-songs.json
@@ -1,6 +1,6 @@
 {
   "name": "Greatest Metal Songs of All Time 🤘",
-  "version": "1.8",
+  "version": "1.9",
   "tags": [
     "metal",
     "rock",
@@ -1541,7 +1541,7 @@
       "fun_fact_de": "Lamb of God sind eine der wichtigsten Metal-Bands der 2000er. Sänger Randy Blythe wurde 2012 in der Tschechischen Republik wegen Totschlagvorwürfen verhaftet — er wurde letztendlich freigesprochen.",
       "fun_fact_es": "Lamb of God es una de las bandas de metal más importantes de los años 2000. El vocalista Randy Blythe fue arrestado en la República Checa en 2012 por cargos de homicidio involuntario relacionados con un incidente en un concierto de 2010 — finalmente fue absuelto.",
       "fun_fact_fr": "Lamb of God est l'un des groupes de metal les plus importants des années 2000. Le chanteur Randy Blythe a été arrêté en République tchèque en 2012 sous des accusations d'homicide involontaire liées à un incident lors d'un concert de 2010 — il a finalement été acquitté.",
-      "uri_apple_music": "applemusic://track/1440904907",
+      "uri_apple_music": "applemusic://track/6777217538",
       "uri_youtube_music": "https://music.youtube.com/watch?v=iFm9v0wvEnw",
       "uri_tidal": "tidal://track/4085761",
       "fun_fact_nl": "Lamb of God is een van de belangrijkste metalbands van de jaren 2000, die samen met Mastodon en Killswitch Engage de New Wave of American Heavy Metal aanvoerde. Zanger Randy Blythe werd in 2012 in Tsjechië gearresteerd op beschuldiging van doodslag naar aanleiding van een incident tijdens een concert in 2010 - hij werd uiteindelijk vrijgesproken. Hun album Ashes of the Wake wordt beschouwd als een moderne metalklassieker.",
@@ -1550,13 +1550,13 @@
       ],
       "isrc": "USRZR0300801",
       "uri_apple_music_by_region": {
-        "us": "applemusic://track/1440904907",
-        "de": "applemusic://track/1440904907",
-        "gb": "applemusic://track/1440904907",
-        "fr": "applemusic://track/1440904907",
-        "es": "applemusic://track/1440904907",
-        "nl": "applemusic://track/1440904907",
-        "it": "applemusic://track/1440904907"
+        "us": "applemusic://track/6777217538",
+        "de": "applemusic://track/6777217538",
+        "gb": "applemusic://track/6777217538",
+        "fr": "applemusic://track/6777217538",
+        "es": "applemusic://track/6777217538",
+        "nl": "applemusic://track/6777217538",
+        "it": "applemusic://track/6777217538"
       }
     },
     {


### PR DESCRIPTION
Closes #1456. Replaced dead Apple Music URI for Lamb of God – Ruin (`1440904907` → `6777217538`, *As The Palaces Burn* 10th Anniversary Deluxe Edition) across all 7 storefronts. Bumped playlist version 1.8→1.9.