### PR TITLE
fix(player): swap submit button row above artist challenge card (#1458)

### DIFF
--- a/custom_components/beatify/www/player.html
+++ b/custom_components/beatify/www/player.html
@@ -488,6 +488,17 @@
                     <div id="ta-input-ack" class="ta-input-ack hidden" aria-live="polite"></div>
                 </section>
 
+                <!-- Actions: bet (compact) + submit (primary) — moved above the challenge cards (#1458) -->
+                <div class="arc-actions">
+                    <button id="bet-toggle" class="bet-arc" type="button">
+                        <span class="bet-icon" aria-hidden="true">🎲</span>
+                        <span class="bet-label" data-i18n="game.betShort">×2</span>
+                    </button>
+                    <button id="submit-btn" class="submit-arc" data-i18n="game.submitGuess">
+                        Submit Guess
+                    </button>
+                </div>
+
                 <!-- Artist Challenge — arcade tiles (Story 20.5) -->
                 <section id="artist-challenge-container" class="arc-tiles artist-challenge hidden">
                     <div class="arc-tiles-header">
@@ -522,17 +533,6 @@
                 <div id="no-bonus-filler" class="bonus-filler hidden">
                     <span aria-hidden="true">🎵</span>
                     <span data-i18n="game.noBonusThisRound">No bonus this round — nail the year</span>
-                </div>
-
-                <!-- Actions: bet (compact) + submit (primary) -->
-                <div class="arc-actions">
-                    <button id="bet-toggle" class="bet-arc" type="button">
-                        <span class="bet-icon" aria-hidden="true">🎲</span>
-                        <span class="bet-label" data-i18n="game.betShort">×2</span>
-                    </button>
-                    <button id="submit-btn" class="submit-arc" data-i18n="game.submitGuess">
-                        Submit Guess
-                    </button>
                 </div>
 
                 <!-- Steal power-up button (full width, only when steal available) -->


### PR DESCRIPTION
## Summary

Closes #1458. On the player game screen, swaps the vertical order so the **Submit button row** sits directly under the year slider, **above** the artist challenge card.

## What moved

Moved the entire `.arc-actions` wrapper `<div>` (the power-up bet dice **and** the `#submit-btn` Submit Guess button — kept grouped exactly as one unit) from below the challenge cards to **directly after the slider / title-artist section**, i.e. above `#artist-challenge-container`.

New top → bottom order:
1. Year slider (`#year-selector-container`) / title-artist input
2. **`.arc-actions` — bet dice + Submit Guess** (moved up)
3. `#artist-challenge-container` (artist multiple-choice)
4. `#movie-challenge-container` / `#no-bonus-filler`
5. Steal button, `#submission-tracker` ("0/2 abgegeben"), leaderboard — unchanged, still at the bottom

## Safety / behaviour

- Pure DOM-order change in `player.html` (raw HTML, not a bundle — no min.js to regenerate).
- All `player-game` JS accesses these elements via `getElementById` (`submit-btn`, `bet-toggle`, `artist-challenge-container`); verified **no** sibling/positional traversal (`nextElementSibling` / `insertBefore` / child-index) and **no** CSS adjacent-sibling (`+`/`~`) selectors depend on the order. Behaviour (submit, artist choice, bet dice, submitted-count) is unchanged.
- Cache-busting is fully server-templated via `{{ASSET_VER}}` in both `player.html` and `sw.js` (`CACHE_VERSION = 'beatify-v{{ASSET_VER}}'`) — nothing to hand-bump.

## Gates

- `npm run build:check` → ✅ all 10 bundles match source (0 drift)
- `npm test` (vitest) → ✅ 320 passed (27 files)

## Test note

No vitest DOM-order assertion added: the suite is entirely JS-module behavioural testing — no test reads/parses `player.html`. A static markup-order snapshot would introduce a non-idiomatic fs-read pattern to pin purely-static HTML with no behavioural surface. Skipped deliberately.

## ⚠️ Needs manual check

Layout should be verified on a **phone-width / portrait viewport** by Markus (acceptance criterion #4) — this PR doesn't include a live device screenshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)