### PR TITLE
feat(worker): Quizify community-pack submission route on shared Cloudflare Worker

### DIFF
--- a/cf-workers/beatify-api.js
+++ b/cf-workers/beatify-api.js
@@ -42,8 +42,173 @@ async function handleReportData(request, env, corsHeaders) {
 }
 
 
+// ===========================================================================
+// Quizify community-pack submission (additive — Beatify logic above/below is
+// untouched). Mounted on any path starting with `/quizify` (e.g.
+// `/quizify/submit-pack`). Self-contained: own secret gate, own GitHub repo,
+// own (no-)CORS policy. Ported from the standalone quizify-api worker so both
+// HA integrations can share one deployed Worker.
+//   Secrets:  SHARED_SECRET        (REQUIRED — fail-closed gate, #292/#316)
+//             QUIZIFY_GITHUB_PAT   (Issues R+W on mholzi/quizify; falls back to
+//                                   GITHUB_PAT if that token also covers quizify)
+// ===========================================================================
+const QUIZIFY_REPO = 'mholzi/quizify';
+const QUIZIFY_ISSUES_API = `https://api.github.com/repos/${QUIZIFY_REPO}/issues`;
+const QZ_MAX_QUESTIONS = 500;
+const QZ_MIN_QUESTIONS = 1;
+const QZ_ANSWERS_PER_QUESTION = 3;
+const QZ_MAX_BYTES = 1_048_576; // 1 MiB
+// No CORS: the Quizify HA integration calls server-side (aiohttp), never from a
+// browser, so we emit no ACAO header (#292).
+const QZ_CORS = {};
+
+function qzJsonError(code, message, status) {
+  return Response.json({ code, message }, { status, headers: QZ_CORS });
+}
+
+/** Constant-time string compare (#292): equal-length UTF-8 buffers via
+ *  crypto.subtle.timingSafeEqual; a length mismatch is an immediate non-match. */
+function qzTimingSafeEqualStr(a, b) {
+  if (typeof a !== 'string' || typeof b !== 'string') return false;
+  const enc = new TextEncoder();
+  const bufA = enc.encode(a);
+  const bufB = enc.encode(b);
+  if (bufA.byteLength !== bufB.byteLength) return false;
+  return crypto.subtle.timingSafeEqual(bufA, bufB);
+}
+
+/** Validate the pack against the #179 schema — mirrors
+ *  server/pack_submission.py::validate_pack exactly. */
+function qzValidatePack(pack) {
+  if (!pack || typeof pack !== 'object' || Array.isArray(pack)) return 'Top-level JSON must be an object.';
+  if (typeof pack.name !== 'string' || !pack.name.trim()) return "Field 'name' is required.";
+  const lang = pack.language === undefined ? 'de' : pack.language;
+  if (typeof lang !== 'string' || !lang.trim()) return "Field 'language' must be a non-empty string.";
+  const qs = pack.questions;
+  if (!Array.isArray(qs) || qs.length < QZ_MIN_QUESTIONS) return "Field 'questions' must be a non-empty list.";
+  if (qs.length > QZ_MAX_QUESTIONS) return `Too many questions (max ${QZ_MAX_QUESTIONS}).`;
+  const seenIds = new Set();
+  for (let i = 0; i < qs.length; i++) {
+    const q = qs[i];
+    const p = `Question ${i + 1}`;
+    if (!q || typeof q !== 'object') return `${p}: must be an object.`;
+    if (typeof q.id !== 'string' || !q.id.trim()) return `${p}: 'id' is required.`;
+    if (seenIds.has(q.id)) return `${p}: duplicate id '${q.id}'.`;
+    seenIds.add(q.id);
+    if (typeof q.question !== 'string' || !q.question.trim()) return `${p}: 'question' is required.`;
+    if (!Array.isArray(q.answers) || q.answers.length !== QZ_ANSWERS_PER_QUESTION) {
+      return `${p}: exactly ${QZ_ANSWERS_PER_QUESTION} answers are required.`;
+    }
+    let correct = 0;
+    for (const a of q.answers) {
+      if (!a || typeof a !== 'object') return `${p}: each answer must be an object.`;
+      if (typeof a.text !== 'string' || !a.text.trim()) return `${p}: every answer needs non-empty 'text'.`;
+      if (a.correct === true) correct += 1;
+    }
+    if (correct !== 1) return `${p}: exactly 1 answer must be marked correct (got ${correct}).`;
+  }
+  return null;
+}
+
+/** Neutralise Markdown / mention injection in user strings going into the issue
+ *  (#305): break @mentions and #refs, escape table/code + link/image controls,
+ *  collapse newlines. Escape backslash-family first, then the link/image set. */
+function qzEsc(s) {
+  return String(s == null ? '' : s)
+    .replace(/[\r\n]+/g, ' ')
+    .replace(/[`|\\]/g, '\\$&')
+    .replace(/[[\]()!]/g, '\\$&')
+    .replace(/@/g, '@​')
+    .replace(/#(?=\d)/g, '#​')
+    .slice(0, 500);
+}
+
+function qzBuildIssue(pack) {
+  const qs = pack.questions || [];
+  const title = `pack: ${qzEsc(pack.name)} (${qzEsc(pack.language || 'de')}) — ${qs.length} questions`;
+  const lines = [
+    '## Community pack submission', '',
+    'A host submitted a community question pack from the in-app composer.', '',
+    '| Field | Value |', '|-------|-------|',
+    `| **Name** | ${qzEsc(pack.name)} |`,
+    `| **Language** | ${qzEsc(pack.language || 'de')} |`,
+    `| **Questions** | ${qs.length} |`,
+    '', '### Questions', '',
+  ];
+  qs.forEach((q, i) => {
+    lines.push(`**${i + 1}. ${qzEsc(q.question)}**`);
+    (q.answers || []).forEach((a) => {
+      lines.push(`- ${a && a.correct === true ? '✅ ' : ''}${qzEsc(a && a.text)}`);
+    });
+    lines.push('');
+  });
+  lines.push('---', '*Auto-filed by the Quizify in-app community-pack submission (#180).*');
+  return { title: title.slice(0, 250), body: lines.join('\n'), labels: ['community-pack'] };
+}
+
+async function handleQuizifySubmit(request, env) {
+  const pat = env.QUIZIFY_GITHUB_PAT || env.GITHUB_PAT;
+  if (!pat) {
+    return qzJsonError('GITHUB_ERROR', 'Worker is missing its GitHub PAT secret.', 500);
+  }
+  // Shared-secret gate — FAIL CLOSED (#292/#316): reject 401 if SHARED_SECRET is
+  // unset OR the X-Quizify-Secret header is missing / doesn't match. The worker
+  // must never be an open, unauthenticated proxy that files issues with the PAT.
+  if (!env.SHARED_SECRET) {
+    return qzJsonError('INVALID_FORMAT', 'Unauthorized.', 401);
+  }
+  const presented = request.headers.get('X-Quizify-Secret');
+  if (!qzTimingSafeEqualStr(presented, env.SHARED_SECRET)) {
+    return qzJsonError('INVALID_FORMAT', 'Unauthorized.', 401);
+  }
+
+  const raw = await request.text();
+  if (raw.length > QZ_MAX_BYTES) return qzJsonError('INVALID_FORMAT', `Pack exceeds ${QZ_MAX_BYTES} bytes.`, 400);
+  let body;
+  try {
+    body = JSON.parse(raw);
+  } catch {
+    return qzJsonError('INVALID_FORMAT', 'Body is not valid JSON.', 400);
+  }
+  const pack = body && typeof body === 'object' ? body.pack : null;
+  const err = qzValidatePack(pack);
+  if (err) return qzJsonError('INVALID_FORMAT', err, 400);
+
+  const issue = qzBuildIssue(pack);
+  const ghRes = await fetch(QUIZIFY_ISSUES_API, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${pat}`,
+      Accept: 'application/vnd.github+json',
+      'Content-Type': 'application/json',
+      'User-Agent': 'Quizify-PackBot',
+    },
+    body: JSON.stringify(issue),
+  });
+  if (!ghRes.ok) {
+    console.error('Quizify GitHub API error:', ghRes.status, await ghRes.text());
+    return qzJsonError('GITHUB_ERROR', `Failed to create issue (HTTP ${ghRes.status}).`, 502);
+  }
+  const created = await ghRes.json();
+  return Response.json({ issue_number: created.number, issue_url: created.html_url }, { headers: QZ_CORS });
+}
+
 export default {
   async fetch(request, env) {
+    // Quizify community-pack route (additive). Fully self-contained — owns its
+    // method guard, secret gate and (no-)CORS — so every non-/quizify request
+    // falls through to the Beatify handling below byte-for-byte as before.
+    const qzUrl = new URL(request.url);
+    if (qzUrl.pathname.startsWith('/quizify')) {
+      if (request.method !== 'POST') return qzJsonError('INVALID_FORMAT', 'POST only.', 405);
+      try {
+        return await handleQuizifySubmit(request, env);
+      } catch (e) {
+        console.error('Quizify worker error:', e);
+        return qzJsonError('GITHUB_ERROR', 'Unexpected worker error.', 500);
+      }
+    }
+
     const corsHeaders = {
       'Access-Control-Allow-Origin': '*',
       'Access-Control-Allow-Methods': 'POST, OPTIONS',


### PR DESCRIPTION
## Quizify community-pack route on the shared Worker

Adds a self-contained `/quizify*` handler to the shared `cf-workers/beatify-api.js` Worker so the Quizify HA integration and Beatify can share one deployed Worker (ported from the standalone `quizify-api` worker).

### Behaviour
- **POST `/quizify/...`** → validates a submitted question pack, builds a GitHub issue, and files it to `mholzi/quizify`.
- **Fail-closed secret gate** — requires `X-Quizify-Secret` matching `SHARED_SECRET` (constant-time compare). 401 if the secret is unset or wrong, so the Worker is never an open PAT-backed proxy (#292/#316).
- **Validation** mirrors `server/pack_submission.py::validate_pack` (#179): required fields, 1–500 questions, exactly 3 answers each, exactly 1 correct, unique ids.
- **Injection hardening** — neutralises Markdown / `@`-mention / `#`-ref injection in the issue body (#305).
- **Limits** — 1 MiB body cap; uses `QUIZIFY_GITHUB_PAT` (falls back to `GITHUB_PAT`); no CORS (server-side caller only).

### Scope safety
Additive only. The `/quizify` branch returns early; **every non-`/quizify` request falls through to the existing Beatify `/report-data` handling byte-for-byte.** `node --check` passes.

### Not included
Worker-only change — no HA integration version bump, CHANGELOG entry, or HACS release. Deploys separately via Cloudflare (no auto-deploy workflow exists in this repo). Requires the `SHARED_SECRET` and `QUIZIFY_GITHUB_PAT` Worker secrets to be set in Cloudflare.

🤖 Generated with [Claude Code](https://claude.com/claude-code)