### PR TITLE
v4.1.0-rc9 chore(release): consolidated release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to Beatify are documented here. For detailed release notes, 
 
 ## [Unreleased]
 
+## [4.1.0-rc9] - 2026-06-13
+
+### Changed
+- **Consolidated the user-facing v4.1.0 release notes.** The release notes now cover the whole 4.1.0 line in one place — the Spotlight Stage / Round-Delta / Podium Stage / Broadcast Lower-Third reveal-and-dashboard redesign (rc1–rc8) alongside the Amazon Music provider, the screen-wake / TV-reconnect / login-loop reliability pass, the storefront-aware Apple Music fix, the Title & Artist polish (including the "Name the Song" start fix), and the security pass. This is the release candidate for stable 4.1.0; no functional code change since rc8.
+
 ## [4.1.0-rc8] - 2026-06-13
 
 ### Changed

--- a/custom_components/beatify/manifest.json
+++ b/custom_components/beatify/manifest.json
@@ -19,5 +19,5 @@
     "num2words==0.5.14"
   ],
   "single_config_entry": true,
-  "version": "4.1.0-rc8"
+  "version": "4.1.0-rc9"
 }


### PR DESCRIPTION
## What

Cuts pre-release **v4.1.0-rc9**. Bumps `manifest.json` to `4.1.0-rc9` and adds the matching CHANGELOG entry.

This rc carries no functional code change since rc8 — it finalizes the **consolidated user-facing v4.1.0 release notes**, which now cover the whole 4.1.0 line in one place:

- The reveal & dashboard redesign shipped across rc1–rc8 (Spotlight Stage reveal, Round-Delta ledger standings, Podium Stage TV game-over, Broadcast Lower-Third TV reveal).
- Amazon Music provider, the screen-wake / TV-reconnect / login-loop reliability pass, the storefront-aware Apple Music fix, Title & Artist polish (incl. the "Name the Song" start fix), and the security pass.

## Why

rc9 is the release candidate for stable 4.1.0. The previous rc1–rc8 pre-releases are being retired in favour of this single consolidated candidate.

## Notes

- No CSS/JS changed, so no `.min` regen and cache-buster fingerprints are unaffected.
- Release notes live in `docs/` (gitignored on main) and are used as the GitHub Release body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)