### PR TITLE
data: fix 1 dead Apple Music URI in world-cup-anthems (#1473)

### DIFF
--- a/custom_components/beatify/playlists/world-cup-anthems.json
+++ b/custom_components/beatify/playlists/world-cup-anthems.json
@@ -1,6 +1,6 @@
 {
   "name": "World Cup Anthems",
-  "version": "1.2",
+  "version": "1.3",
   "tags": [
     "world-cup",
     "fifa",
@@ -317,7 +317,7 @@
       "awards_es": [],
       "awards_fr": [],
       "awards_nl": [],
-      "uri_apple_music": "applemusic://track/471764799",
+      "uri_apple_music": "applemusic://track/1811457658",
       "uri_youtube_music": "https://music.youtube.com/watch?v=aYbwkEX7bko",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3345558141",


### PR DESCRIPTION
Closes #1473. Replaced dead Anastacia Boom Apple Music URI (471764799→1811457658) and bumped playlist version to 1.3.