### PR TITLE
fix(data): Lady Gaga – RUNWAY release year 2021 → 2026

### DIFF
--- a/custom_components/beatify/playlists/community/edm-anthems.json
+++ b/custom_components/beatify/playlists/community/edm-anthems.json
@@ -1,6 +1,6 @@
 {
   "name": "EDM Anthems",
-  "version": "1.2",
+  "version": "1.3",
   "tags": [
     "edm",
     "electronic",
@@ -41,7 +41,7 @@
     {
       "artist": "Lady Gaga",
       "title": "RUNWAY",
-      "year": 2021,
+      "year": 2026,
       "isrc": "USUG12603164",
       "uri": "spotify:track:7BjcYqD0CqXnG45ezWSTYR",
       "uri_apple_music": "applemusic://track/1892523797",


### PR DESCRIPTION
## Wrong-year fix for #1499

A player (Emil) flagged the year for **Lady Gaga – RUNWAY** in `community/edm-anthems.json`.

| | |
|---|---|
| **Playlist value** | 2021 |
| **Correct year** | **2026** |

### Verification
*RUNWAY* is a 2026 single by Lady Gaga & Doechii for *The Devil Wears Prada 2* soundtrack, released **10 Apr 2026** ([Wikipedia](https://en.wikipedia.org/wiki/Runway_(song)), [Apple Music](https://music.apple.com/us/album/runway-single/1891472590)). The track's ISRC `USUG12603164` carries the `26` year-code, consistent with 2026.

### Change
- `year` 2021 → 2026 for Lady Gaga – RUNWAY
- Bumped `EDM Anthems` playlist version 1.2 → 1.3

Closes #1499

🤖 Generated with [Claude Code](https://claude.com/claude-code)