### PR TITLE
data: fix 1 broken URI in trance-classics (#1502)

### DIFF
--- a/custom_components/beatify/playlists/community/trance-classics.json
+++ b/custom_components/beatify/playlists/community/trance-classics.json
@@ -1,6 +1,6 @@
 {
   "name": "Trance Classics",
-  "version": "1.1",
+  "version": "1.2",
   "tags": [
     "trance",
     "hands-up",
@@ -2770,7 +2770,7 @@
       "year": 2006,
       "isrc": "US75Z0700010",
       "uri": "spotify:track:14U7iQtUGumHX4htbIhUL4",
-      "uri_apple_music": "applemusic://track/6762881748",
+      "uri_apple_music": "applemusic://track/6774667760",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1216908995",
         "de": "applemusic://track/1216908995",


### PR DESCRIPTION
Closes #1502. Replaced 1 dead Apple Music URI for Claude VonStroke - The Whistler and bumped playlist version to 1.2.