### PR TITLE
fix(data): empty certifications must be [] not {} (unblocks CI on main)

### DIFF
--- a/custom_components/beatify/playlists/community/finnish-iskelma-classics.json
+++ b/custom_components/beatify/playlists/community/finnish-iskelma-classics.json
@@ -2146,7 +2146,7 @@
       "fun_fact_nl": "Kirka, geboren als Kirka Babitzin, was een geliefde Finse pop- en Iskelmä-zanger die Finland vertegenwoordigde op het Eurovisiesongfestival 1984 met 'Hangen Tyttö'.",
       "awards": [],
       "awards_nl": [],
-      "certifications": {},
+      "certifications": [],
       "chart_info": {}
     },
     {
@@ -2448,7 +2448,7 @@
       "fun_fact_nl": "Jamppa Tuominen is een Finse Iskelmä-zanger die een sterke aanhang heeft opgebouwd met zijn emotionele ballades en levendige dansnummers.",
       "awards": [],
       "awards_nl": [],
-      "certifications": {},
+      "certifications": [],
       "chart_info": {}
     },
     {
@@ -2639,7 +2639,7 @@
       "fun_fact_nl": "Tapani Kansa is een legendarische Finse entertainer en Iskelmä-zanger die al sinds de jaren 60 een vaste waarde is in de Finse populaire muziek.",
       "awards": [],
       "awards_nl": [],
-      "certifications": {},
+      "certifications": [],
       "chart_info": {}
     },
     {
@@ -3024,7 +3024,7 @@
       "fun_fact_nl": "Reijo Kallio is een Finse Iskelmä-zanger en muzikant die tal van geliefde liedjes heeft bijgedragen aan het Finse poprepertoire.",
       "awards": [],
       "awards_nl": [],
-      "certifications": {},
+      "certifications": [],
       "chart_info": {}
     },
     {
@@ -3823,7 +3823,7 @@
       "fun_fact_nl": "Arja Koriseva is een populaire Finse Iskelmä- en countryzangeres, bekend om haar krachtige stem en tal van hitnotering aan de top van de lijsten.",
       "awards": [],
       "awards_nl": [],
-      "certifications": {},
+      "certifications": [],
       "chart_info": {}
     },
     {
@@ -3857,7 +3857,7 @@
       "fun_fact_nl": "Kim Lönnholm is een Finse Iskelmä-zanger wiens nostalgische melodieën en oprechte teksten hem een geliefde stem in de Finse muziek hebben gemaakt.",
       "awards": [],
       "awards_nl": [],
-      "certifications": {},
+      "certifications": [],
       "chart_info": {}
     },
     {
@@ -3925,7 +3925,7 @@
       "fun_fact_nl": "Reijo Taipale is een van Finland's grootste Iskelmä-legenden, beroemd om zijn tijdloze klassieker 'Satumaa' die door tientallen artiesten is opgenomen.",
       "awards": [],
       "awards_nl": [],
-      "certifications": {},
+      "certifications": [],
       "chart_info": {}
     },
     {
@@ -4057,7 +4057,7 @@
       "fun_fact_nl": "A. Aallon Rytmiorkesteri was een baanbrekend Fins dansorkest dat het geluid van de Finse populaire muziek in het midden van de 20e eeuw mede vormgaf.",
       "awards": [],
       "awards_nl": [],
-      "certifications": {},
+      "certifications": [],
       "chart_info": {}
     },
     {
@@ -4321,7 +4321,7 @@
       "fun_fact_nl": "Arto Tamminen is een Finse Iskelmä-zanger, bekend om zijn melodieuze liedjes die hem een trouwe aanhang in Finland hebben opgeleverd.",
       "awards": [],
       "awards_nl": [],
-      "certifications": {},
+      "certifications": [],
       "chart_info": {}
     },
     {
@@ -4457,7 +4457,7 @@
       "fun_fact_nl": "Mikko Kuustonen is een Finse singer-songwriter en acteur wiens introspectieve teksten hem een geliefde figuur in de Finse pop hebben gemaakt.",
       "awards": [],
       "awards_nl": [],
-      "certifications": {},
+      "certifications": [],
       "chart_info": {}
     },
     {
@@ -4853,7 +4853,7 @@
       "fun_fact_nl": "Samuli Edelmann is een Finse pop-rock zanger en acteur, bekend om zijn theatrale podiumaanwezigheid en emotioneel geladen ballades.",
       "awards": [],
       "awards_nl": [],
-      "certifications": {},
+      "certifications": [],
       "chart_info": {}
     },
     {
@@ -4917,7 +4917,7 @@
       "fun_fact_nl": "Arja Koriseva is een populaire Finse Iskelmä- en countryzangeres, bekend om haar krachtige stem en tal van hitnotering aan de top van de lijsten.",
       "awards": [],
       "awards_nl": [],
-      "certifications": {},
+      "certifications": [],
       "chart_info": {}
     },
     {
@@ -4951,7 +4951,7 @@
       "fun_fact_nl": "Kirka, geboren als Kirka Babitzin, was een geliefde Finse pop- en Iskelmä-zanger die Finland vertegenwoordigde op het Eurovisiesongfestival 1984 met 'Hangen Tyttö'.",
       "awards": [],
       "awards_nl": [],
-      "certifications": {},
+      "certifications": [],
       "chart_info": {}
     },
     {
@@ -5153,7 +5153,7 @@
       "fun_fact_nl": "Tarja Lunnas is een Finse Iskelmä-zangeres, bekend om haar elegante stem en romantische ballades die het Finse publiek hebben betoverd.",
       "awards": [],
       "awards_nl": [],
-      "certifications": {},
+      "certifications": [],
       "chart_info": {}
     },
     {
@@ -5348,7 +5348,7 @@
       "fun_fact_nl": "Janne Tulkki is een populaire Finse Iskelmä-zanger, bekend om zijn warme bariton en emotioneel resonante ballades.",
       "awards": [],
       "awards_nl": [],
-      "certifications": {},
+      "certifications": [],
       "chart_info": {}
     },
     {
@@ -5382,7 +5382,7 @@
       "fun_fact_nl": "Janne Tulkki is een populaire Finse Iskelmä-zanger, bekend om zijn warme bariton en emotioneel resonante ballades.",
       "awards": [],
       "awards_nl": [],
-      "certifications": {},
+      "certifications": [],
       "chart_info": {}
     },
     {
@@ -5452,7 +5452,7 @@
       "fun_fact_nl": "Paula Koivuniemi is een van Finland's meest geliefde vrouwelijke Iskelmä-zangeressen, met een carrière van meer dan vijf decennia.",
       "awards": [],
       "awards_nl": [],
-      "certifications": {},
+      "certifications": [],
       "chart_info": {}
     },
     {
@@ -5588,7 +5588,7 @@
       "fun_fact_nl": "Agents is een Finse rock- en Iskelmä-band geleid door Esa Pakarinen, bekend om hun elektrificerende liveshows en iconische Finse covers van internationale hits.",
       "awards": [],
       "awards_nl": [],
-      "certifications": {},
+      "certifications": [],
       "chart_info": {}
     },
     {
@@ -5622,7 +5622,7 @@
       "fun_fact_nl": "Aki Samuli is een Finse Iskelmä-zanger die een bekende naam werd met zijn aanstekelijke, dansbare liedjes en energieke liveoptreden.",
       "awards": [],
       "awards_nl": [],
-      "certifications": {},
+      "certifications": [],
       "chart_info": {}
     },
     {
@@ -5656,7 +5656,7 @@
       "fun_fact_nl": "Anna Hanski is een Finse Iskelmä-zangeres, bekend om haar charmante en speelse popliedjes die populair werden in de jaren 80.",
       "awards": [],
       "awards_nl": [],
-      "certifications": {},
+      "certifications": [],
       "chart_info": {}
     },
     {
@@ -5690,7 +5690,7 @@
       "fun_fact_nl": "Antti Huovila is een Finse Iskelmä-zanger, bekend om zijn oprechte, melodieuze ballades en zijn toegewijde aanhang in Finland.",
       "awards": [],
       "awards_nl": [],
-      "certifications": {},
+      "certifications": [],
       "chart_info": {}
     },
     {
@@ -5724,7 +5724,7 @@
       "fun_fact_nl": "Heidi Pakarinen is een Finse Iskelmä- en countryzangeres die brede erkenning verwierf na deelname aan Finse talentenprogramma's.",
       "awards": [],
       "awards_nl": [],
-      "certifications": {},
+      "certifications": [],
       "chart_info": {}
     },
     {
@@ -5758,7 +5758,7 @@
       "fun_fact_nl": "Katri Helena is een Finse Iskelmä-icoon die al seit de jaren 60 optreedt en wordt beschouwd als een van de grootste stemmen in de Finse populaire muziek.",
       "awards": [],
       "awards_nl": [],
-      "certifications": {},
+      "certifications": [],
       "chart_info": {}
     },
     {
@@ -5792,7 +5792,7 @@
       "fun_fact_nl": "Marilii is een Finse Iskelmä-zangeres die het publiek betoverde met haar vrolijke popsongs vol levensvreugde.",
       "awards": [],
       "awards_nl": [],
-      "certifications": {},
+      "certifications": [],
       "chart_info": {}
     },
     {
@@ -5826,7 +5826,7 @@
       "fun_fact_nl": "Pasi Ruohonen is een Finse Iskelmä-artiest, bekend om zijn vloeiende stem en romantische ballades die resoneren met het Finse publiek.",
       "awards": [],
       "awards_nl": [],
-      "certifications": {},
+      "certifications": [],
       "chart_info": {}
     },
     {
@@ -5920,7 +5920,7 @@
       "fun_fact_nl": "Vuokko Hovatta is een Finse zangeres, bekend om het opnemen van enkele van de meest geliefde Finse folk- en Iskelmä-klassiekers.",
       "awards": [],
       "awards_nl": [],
-      "certifications": {},
+      "certifications": [],
       "chart_info": {}
     },
     {
@@ -5954,7 +5954,7 @@
       "fun_fact_nl": "Ässät is een Fins Iskelmä-band uit de jaren 80, bekend om levendige ritmes en meezingbare melodieën die danszalen door heel Finland vulden.",
       "awards": [],
       "awards_nl": [],
-      "certifications": {},
+      "certifications": [],
       "chart_info": {}
     },
     {
@@ -6090,7 +6090,7 @@
       "fun_fact_nl": "Anssi Kela is een Finse singer-songwriter, het best bekend om 'Nummela', een oprechte ode aan zijn geboortestad die diep resoneert bij het Finse publiek.",
       "awards": [],
       "awards_nl": [],
-      "certifications": {},
+      "certifications": [],
       "chart_info": {}
     },
     {
@@ -6255,7 +6255,7 @@
       "fun_fact_nl": "PMMP, bestaande uit Paula Vesala en Mira Luoti, werd in de jaren 2000 een van de succesvolste Finse popduo's dankzij hun emotionele en literaire teksten.",
       "awards": [],
       "awards_nl": [],
-      "certifications": {},
+      "certifications": [],
       "chart_info": {}
     },
     {
@@ -6289,7 +6289,7 @@
       "fun_fact_nl": "Jani Wickholm is een Finse Iskelmä-zanger die een trouwe fanbase heeft opgebouwd met zijn oprechte ballades en patriottische liedjes.",
       "awards": [],
       "awards_nl": [],
-      "certifications": {},
+      "certifications": [],
       "chart_info": {}
     },
     {
@@ -6323,7 +6323,7 @@
       "fun_fact_nl": "Jukka Kuoppamäki is een van Finland's meest productieve liedjesschrijvers en Iskelmä-artiesten, met een carrière die teruggaat tot de jaren 60.",
       "awards": [],
       "awards_nl": [],
-      "certifications": {},
+      "certifications": [],
       "chart_info": {}
     },
     {
@@ -6391,7 +6391,7 @@
       "fun_fact_nl": "Stella is een Finse popkunstenares die bekend staat om haar melodieuze Iskelmä-stijl die in de jaren 90 en 2000 harten veroverde in heel Finland.",
       "awards": [],
       "awards_nl": [],
-      "certifications": {},
+      "certifications": [],
       "chart_info": {}
     },
     {
@@ -6425,7 +6425,7 @@
       "fun_fact_nl": "Charles Plogman is een Finse popzanger, bekend om zijn vloeiende stem en romantische Iskelmä-liedjes die de Finse hitlijsten aanvoerden.",
       "awards": [],
       "awards_nl": [],
-      "certifications": {},
+      "certifications": [],
       "chart_info": {}
     },
     {
@@ -6493,7 +6493,7 @@
       "fun_fact_nl": "Jani Wickholm is een Finse Iskelmä-zanger die een trouwe fanbase heeft opgebouwd met zijn oprechte ballades en patriottische liedjes.",
       "awards": [],
       "awards_nl": [],
-      "certifications": {},
+      "certifications": [],
       "chart_info": {}
     },
     {
@@ -6625,7 +6625,7 @@
       "fun_fact_nl": "Dit Finse Iskelmä-lied is een geliefde klassieker die heeft voortbestaan in de Finse populaire cultuur.",
       "awards": [],
       "awards_nl": [],
-      "certifications": {},
+      "certifications": [],
       "chart_info": {}
     },
     {
@@ -6693,7 +6693,7 @@
       "fun_fact_nl": "Kirka, geboren als Kirka Babitzin, was een geliefde Finse pop- en Iskelmä-zanger die Finland vertegenwoordigde op het Eurovisiesongfestival 1984 met 'Hangen Tyttö'.",
       "awards": [],
       "awards_nl": [],
-      "certifications": {},
+      "certifications": [],
       "chart_info": {}
     },
     {
@@ -6727,7 +6727,7 @@
       "fun_fact_nl": "Kirka, geboren als Kirka Babitzin, was een geliefde Finse pop- en Iskelmä-zanger die Finland vertegenwoordigde op het Eurovisiesongfestival 1984 met 'Hangen Tyttö'.",
       "awards": [],
       "awards_nl": [],
-      "certifications": {},
+      "certifications": [],
       "chart_info": {}
     },
     {
@@ -6795,7 +6795,7 @@
       "fun_fact_nl": "Riki Sorsa vertegenwoordigde Finland op het Eurovisiesongfestival 1981 met 'Reggae OK', waarbij hij reggaeritmiek met Finse pop combineerde.",
       "awards": [],
       "awards_nl": [],
-      "certifications": {},
+      "certifications": [],
       "chart_info": {}
     },
     {
@@ -6829,7 +6829,7 @@
       "fun_fact_nl": "Riki Sorsa vertegenwoordigde Finland op het Eurovisiesongfestival 1981 met 'Reggae OK', waarbij hij reggaeritmiek met Finse pop combineerde.",
       "awards": [],
       "awards_nl": [],
-      "certifications": {},
+      "certifications": [],
       "chart_info": {}
     },
     {
@@ -6965,7 +6965,7 @@
       "fun_fact_nl": "Scandinavian Music Group is een Finse popband opgericht in de jaren 90, gevierd om hun zielvolle Finstalige ballades.",
       "awards": [],
       "awards_nl": [],
-      "certifications": {},
+      "certifications": [],
       "chart_info": {}
     },
     {
@@ -6999,7 +6999,7 @@
       "fun_fact_nl": "Happoradio is een Finse indie-popband opgericht in Tampere in 1998, bekend om poëtische Finse teksten en hymne-achtige melodieën.",
       "awards": [],
       "awards_nl": [],
-      "certifications": {},
+      "certifications": [],
       "chart_info": {}
     },
     {
@@ -7133,7 +7133,7 @@
       "fun_fact_nl": "Unelmavävyt is een Fins vocaal ensemble, bekend om hun harmonieuze uitvoeringen van klassieke Finse en internationale melodieën.",
       "awards": [],
       "awards_nl": [],
-      "certifications": {},
+      "certifications": [],
       "chart_info": {}
     },
     {
@@ -7201,7 +7201,7 @@
       "fun_fact_nl": "Olli Lindholm was een geliefde Finse singer-songwriter en frontman van de rockband Zen Cafe, bekend om zijn diep persoonlijke en poëtische teksten.",
       "awards": [],
       "awards_nl": [],
-      "certifications": {},
+      "certifications": [],
       "chart_info": {}
     },
     {
@@ -7299,7 +7299,7 @@
       "fun_fact_nl": "Anitta Mattila is een Finse Iskelmä-zangeres, gevierd om haar levendige persoonlijkheid en aanstekelijke vrolijke liedjes.",
       "awards": [],
       "awards_nl": [],
-      "certifications": {},
+      "certifications": [],
       "chart_info": {}
     },
     {
@@ -7433,7 +7433,7 @@
       "fun_fact_nl": "Suvi Teräsniska is een van Finland's populairste Iskelmä-artiesten, bekend om haar krachtige stem en diep emotionele ballades.",
       "awards": [],
       "awards_nl": [],
-      "certifications": {},
+      "certifications": [],
       "chart_info": {}
     },
     {
@@ -7467,7 +7467,7 @@
       "fun_fact_nl": "Agents is een Finse rock- en Iskelmä-band geleid door Esa Pakarinen, bekend om hun elektrificerende liveshows en iconische Finse covers van internationale hits.",
       "awards": [],
       "awards_nl": [],
-      "certifications": {},
+      "certifications": [],
       "chart_info": {}
     },
     {
@@ -7501,7 +7501,7 @@
       "fun_fact_nl": "Juha Metsäperä is een Finse Iskelmä-zanger wiens zachte ballades en oprechte optredens hem populair hebben gemaakt bij Finse muziekliefhebbers.",
       "awards": [],
       "awards_nl": [],
-      "certifications": {},
+      "certifications": [],
       "chart_info": {}
     },
     {
@@ -7535,7 +7535,7 @@
       "fun_fact_nl": "Marko Maunuksela is een Finse Iskelmä-zanger, bekend om zijn warme, expressieve stem en opbeurende popliedjes.",
       "awards": [],
       "awards_nl": [],
-      "certifications": {},
+      "certifications": [],
       "chart_info": {}
     },
     {
@@ -7792,7 +7792,7 @@
       "fun_fact_nl": "Suvi Teräsniska is een van Finland's populairste Iskelmä-artiesten, bekend om haar krachtige stem en diep emotionele ballades.",
       "awards": [],
       "awards_nl": [],
-      "certifications": {},
+      "certifications": [],
       "chart_info": {}
     },
     {
@@ -7856,7 +7856,7 @@
       "fun_fact_nl": "Aki Samuli is een Finse Iskelmä-zanger die een bekende naam werd met zijn aanstekelijke, dansbare liedjes en energieke liveoptreden.",
       "awards": [],
       "awards_nl": [],
-      "certifications": {},
+      "certifications": [],
       "chart_info": {}
     },
     {
@@ -7890,7 +7890,7 @@
       "fun_fact_nl": "Anne Mattila is een Finse country- en Iskelmä-zangeres, gevierd om haar heldere stem en oprechte liedjes over het alledaagse Finse leven.",
       "awards": [],
       "awards_nl": [],
-      "certifications": {},
+      "certifications": [],
       "chart_info": {}
     },
     {
@@ -7924,7 +7924,7 @@
       "fun_fact_nl": "Heidi Pakarinen is een Finse Iskelmä- en countryzangeres die brede erkenning verwierf na deelname aan Finse talentenprogramma's.",
       "awards": [],
       "awards_nl": [],
-      "certifications": {},
+      "certifications": [],
       "chart_info": {}
     },
     {
@@ -7958,7 +7958,7 @@
       "fun_fact_nl": "Kyösti Mäkimattila is een Finse Iskelmä-artiest, bekend om het combineren van traditionele Finse melodieën met moderne poparrangementen.",
       "awards": [],
       "awards_nl": [],
-      "certifications": {},
+      "certifications": [],
       "chart_info": {}
     },
     {
@@ -8022,7 +8022,7 @@
       "fun_fact_nl": "Leif Lindeman is een Finse Iskelmä-zanger, gevierd om zijn krachtige stem en ontroerende ballades die klassiekers van de Finse pop zijn geworden.",
       "awards": [],
       "awards_nl": [],
-      "certifications": {},
+      "certifications": [],
       "chart_info": {}
     },
     {
@@ -8056,7 +8056,7 @@
       "fun_fact_nl": "Dit Finse Iskelmä-lied is een geliefde klassieker die heeft voortbestaan in de Finse populaire cultuur.",
       "awards": [],
       "awards_nl": [],
-      "certifications": {},
+      "certifications": [],
       "chart_info": {}
     },
     {
@@ -8090,7 +8090,7 @@
       "fun_fact_nl": "Kyösti Mäkimattila is een Finse Iskelmä-artiest, bekend om het combineren van traditionele Finse melodieën met moderne poparrangementen.",
       "awards": [],
       "awards_nl": [],
-      "certifications": {},
+      "certifications": [],
       "chart_info": {}
     },
     {
@@ -8124,7 +8124,7 @@
       "fun_fact_nl": "Agents is een Finse rock- en Iskelmä-band geleid door Esa Pakarinen, bekend om hun elektrificerende liveshows en iconische Finse covers van internationale hits.",
       "awards": [],
       "awards_nl": [],
-      "certifications": {},
+      "certifications": [],
       "chart_info": {}
     },
     {
@@ -8158,7 +8158,7 @@
       "fun_fact_nl": "Aki Samuli is een Finse Iskelmä-zanger die een bekende naam werd met zijn aanstekelijke, dansbare liedjes en energieke liveoptreden.",
       "awards": [],
       "awards_nl": [],
-      "certifications": {},
+      "certifications": [],
       "chart_info": {}
     },
     {
@@ -8192,7 +8192,7 @@
       "fun_fact_nl": "Aki Samuli is een Finse Iskelmä-zanger die een bekende naam werd met zijn aanstekelijke, dansbare liedjes en energieke liveoptreden.",
       "awards": [],
       "awards_nl": [],
-      "certifications": {},
+      "certifications": [],
       "chart_info": {}
     },
     {
@@ -8226,7 +8226,7 @@
       "fun_fact_nl": "Anne Mattila is een Finse country- en Iskelmä-zangeres, gevierd om haar heldere stem en oprechte liedjes over het alledaagse Finse leven.",
       "awards": [],
       "awards_nl": [],
-      "certifications": {},
+      "certifications": [],
       "chart_info": {}
     },
     {
@@ -8260,7 +8260,7 @@
       "fun_fact_nl": "Anne Mattila is een Finse country- en Iskelmä-zangeres, gevierd om haar heldere stem en oprechte liedjes over het alledaagse Finse leven.",
       "awards": [],
       "awards_nl": [],
-      "certifications": {},
+      "certifications": [],
       "chart_info": {}
     },
     {
@@ -8294,7 +8294,7 @@
       "fun_fact_nl": "Antti Kleemola is een Finse Iskelmä-zanger en songwriter die een toegewijde aanhang heeft verdiend met zijn reflectieve teksten en melodieuze stijl.",
       "awards": [],
       "awards_nl": [],
-      "certifications": {},
+      "certifications": [],
       "chart_info": {}
     },
     {
@@ -8328,7 +8328,7 @@
       "fun_fact_nl": "Arja Koriseva is een populaire Finse Iskelmä- en countryzangeres, bekend om haar krachtige stem en tal van hitnotering aan de top van de lijsten.",
       "awards": [],
       "awards_nl": [],
-      "certifications": {},
+      "certifications": [],
       "chart_info": {}
     },
     {
@@ -8362,7 +8362,7 @@
       "fun_fact_nl": "Charles Plogman is een Finse popzanger, bekend om zijn vloeiende stem en romantische Iskelmä-liedjes die de Finse hitlijsten hebben aangevoerd.",
       "awards": [],
       "awards_nl": [],
-      "certifications": {},
+      "certifications": [],
       "chart_info": {}
     },
     {
@@ -8396,7 +8396,7 @@
       "fun_fact_nl": "Danny, geboren als Ilkka Lipsanen, is een van Finland's meest iconische pop- en Iskelmä-artiesten, actief sinds het begin van de jaren 60.",
       "awards": [],
       "awards_nl": [],
-      "certifications": {},
+      "certifications": [],
       "chart_info": {}
     },
     {
@@ -8430,7 +8430,7 @@
       "fun_fact_nl": "Hanna Pakarinen vertegenwoordigde Finland op het Eurovisiesongfestival 2006 in Athene en werd een prominente figuur in de Finse pop en rock.",
       "awards": [],
       "awards_nl": [],
-      "certifications": {},
+      "certifications": [],
       "chart_info": {}
     },
     {
@@ -8464,7 +8464,7 @@
       "fun_fact_nl": "Heidi Pakarinen is een Finse Iskelmä- en countryzangeres die brede erkenning verwierf na deelname aan Finse talentenprogramma's.",
       "awards": [],
       "awards_nl": [],
-      "certifications": {},
+      "certifications": [],
       "chart_info": {}
     },
     {
@@ -8498,7 +8498,7 @@
       "fun_fact_nl": "Irina is een Finse pop- en Iskelmä-zangeres die beroemd werd met krachtige ballades en een van de meest herkende stemmen in de moderne Finse pop werd.",
       "awards": [],
       "awards_nl": [],
-      "certifications": {},
+      "certifications": [],
       "chart_info": {}
     },
     {
@@ -8569,7 +8569,7 @@
       "fun_fact_nl": "Jessica Uussaari is een Finse pop- en Iskelmä-zangeres, bekend om haar heldere stem en opbeurende feelgood-popliedjes.",
       "awards": [],
       "awards_nl": [],
-      "certifications": {},
+      "certifications": [],
       "chart_info": {}
     },
     {
@@ -8603,7 +8603,7 @@
       "fun_fact_nl": "Jukka Kuoppamäki is een van Finland's meest productieve liedjesschrijvers en Iskelmä-artiesten, met een carrière die teruggaat tot de jaren 60.",
       "awards": [],
       "awards_nl": [],
-      "certifications": {},
+      "certifications": [],
       "chart_info": {}
     },
     {
@@ -8672,7 +8672,7 @@
       "fun_fact_nl": "Kyösti Mäkimattila is een Finse Iskelmä-artiest, bekend om het combineren van traditionele Finse melodieën met moderne poparrangementen.",
       "awards": [],
       "awards_nl": [],
-      "certifications": {},
+      "certifications": [],
       "chart_info": {}
     },
     {
@@ -8706,7 +8706,7 @@
       "fun_fact_nl": "Kyösti Mäkimattila is een Finse Iskelmä-artiest, bekend om het combineren van traditionele Finse melodieën met moderne poparrangementen.",
       "awards": [],
       "awards_nl": [],
-      "certifications": {},
+      "certifications": [],
       "chart_info": {}
     },
     {
@@ -8740,7 +8740,7 @@
       "fun_fact_nl": "Lasse Hoikka is een veteraan Finse Iskelmä-zanger en bandleider wiens groep Souvarit een geliefde klassieker van de Finse dansmuziek werd.",
       "awards": [],
       "awards_nl": [],
-      "certifications": {},
+      "certifications": [],
       "chart_info": {}
     },
     {
@@ -8808,7 +8808,7 @@
       "fun_fact_nl": "Lauri Tähkä is een Finse Iskelmä-zanger en bandleider, bekend om zijn energieke liveoptreden en patriottische Finse liedjes.",
       "awards": [],
       "awards_nl": [],
-      "certifications": {},
+      "certifications": [],
       "chart_info": {}
     },
     {
@@ -8842,7 +8842,7 @@
       "fun_fact_nl": "Leif Lindeman is een Finse Iskelmä-zanger, gevierd om zijn krachtige stem en ontroerende ballades die klassiekers van de Finse pop zijn geworden.",
       "awards": [],
       "awards_nl": [],
-      "certifications": {},
+      "certifications": [],
       "chart_info": {}
     },
     {
@@ -8876,7 +8876,7 @@
       "fun_fact_nl": "Oliver is een Finse Iskelmä-zanger wiens warme en expressieve stem hem vanaf de jaren 70 een populaire figuur maakte in de Finse popmuziek.",
       "awards": [],
       "awards_nl": [],
-      "certifications": {},
+      "certifications": [],
       "chart_info": {}
     },
     {
@@ -8910,7 +8910,7 @@
       "fun_fact_nl": "Rajaton is een gerenommeerde Finse a-capellagroep opgericht in 1997, gevierd om hun vlekkeloze harmonieën en brede muzikale repertoire.",
       "awards": [],
       "awards_nl": [],
-      "certifications": {},
+      "certifications": [],
       "chart_info": {}
     },
     {
@@ -8944,7 +8944,7 @@
       "fun_fact_nl": "Susanna Heikki is een Finse Iskelmä-zangeres, gevierd om haar melodieuze stijl en warme, persoonlijke songwriting.",
       "awards": [],
       "awards_nl": [],
-      "certifications": {},
+      "certifications": [],
       "chart_info": {}
     },
     {
@@ -8978,7 +8978,7 @@
       "fun_fact_nl": "Tomi Markkola is een Finse Iskelmä-zanger, bekend om zijn romantische liedjes en consistente aanwezigheid in de Finse hitlijsten.",
       "awards": [],
       "awards_nl": [],
-      "certifications": {},
+      "certifications": [],
       "chart_info": {}
     },
     {
@@ -9012,7 +9012,7 @@
       "fun_fact_nl": "Tomi Markkola is een Finse Iskelmä-zanger, bekend om zijn romantische liedjes en consistente aanwezigheid in de Finse hitlijsten.",
       "awards": [],
       "awards_nl": [],
-      "certifications": {},
+      "certifications": [],
       "chart_info": {}
     },
     {
@@ -9046,7 +9046,7 @@
       "fun_fact_nl": "Kyösti Mäkimattila is een Finse Iskelmä-artiest, bekend om het combineren van traditionele Finse melodieën met moderne poparrangementen.",
       "awards": [],
       "awards_nl": [],
-      "certifications": {},
+      "certifications": [],
       "chart_info": {}
     },
     {
@@ -9080,7 +9080,7 @@
       "fun_fact_nl": "Aki Samuli is een Finse Iskelmä-zanger die een bekende naam werd met zijn aanstekelijke, dansbare liedjes en energieke liveoptreden.",
       "awards": [],
       "awards_nl": [],
-      "certifications": {},
+      "certifications": [],
       "chart_info": {}
     },
     {
@@ -9114,7 +9114,7 @@
       "fun_fact_nl": "Erika Vikman is een moderne Finse Iskelmä-ster, bekend om haar zelfverzekerde podiumaanwezigheid en gedurfde, aanstekelijke pophymnen.",
       "awards": [],
       "awards_nl": [],
-      "certifications": {},
+      "certifications": [],
       "chart_info": {}
     },
     {
@@ -9148,7 +9148,7 @@
       "fun_fact_nl": "Heidi Pakarinen is een Finse Iskelmä- en countryzangeres die brede erkenning verwierf na deelname aan Finse talentenprogramma's.",
       "awards": [],
       "awards_nl": [],
-      "certifications": {},
+      "certifications": [],
       "chart_info": {}
     },
     {
@@ -9182,7 +9182,7 @@
       "fun_fact_nl": "Janne Tulkki is een populaire Finse Iskelmä-zanger, bekend om zijn warme bariton en emotioneel resonante ballades.",
       "awards": [],
       "awards_nl": [],
-      "certifications": {},
+      "certifications": [],
       "chart_info": {}
     },
     {
@@ -9216,7 +9216,7 @@
       "fun_fact_nl": "Jari Sillanpää is een van Finland's meest gevierde Iskelmä-zangers, bekend om zijn buitengewone stembereik en emotionele zang.",
       "awards": [],
       "awards_nl": [],
-      "certifications": {},
+      "certifications": [],
       "chart_info": {}
     },
     {
@@ -9250,7 +9250,7 @@
       "fun_fact_nl": "Kaseva is een Finse popgroep, bekend om hun aanstekelijke en dansbare Iskelmä-nummers die zomerhits werden in Finland.",
       "awards": [],
       "awards_nl": [],
-      "certifications": {},
+      "certifications": [],
       "chart_info": {}
     },
     {
@@ -9284,7 +9284,7 @@
       "fun_fact_nl": "Mikko Kuustonen is een Finse singer-songwriter en acteur wiens introspectieve teksten en melodieuze stijl hem een geliefde figuur in de Finse pop hebben gemaakt.",
       "awards": [],
       "awards_nl": [],
-      "certifications": {},
+      "certifications": [],
       "chart_info": {}
     },
     {
@@ -9318,7 +9318,7 @@
       "fun_fact_nl": "Oliver is een Finse Iskelmä-zanger wiens warme en expressieve stem hem vanaf de jaren 70 een populaire figuur maakte in de Finse popmuziek.",
       "awards": [],
       "awards_nl": [],
-      "certifications": {},
+      "certifications": [],
       "chart_info": {}
     },
     {
@@ -9420,7 +9420,7 @@
       "fun_fact_nl": "Teemu Roivainen is een Finse Iskelmä-zanger, bekend om zijn romantische ballades en blijvende aanwezigheid in de Finse populaire muziek.",
       "awards": [],
       "awards_nl": [],
-      "certifications": {},
+      "certifications": [],
       "chart_info": {}
     },
     {
@@ -9557,7 +9557,7 @@
       "fun_fact_nl": "Portion Boys zijn een Fins feestmuziekduo, beroemd om energieke dansnummers die hymnes werden op Finse zomerfestivals.",
       "awards": [],
       "awards_nl": [],
-      "certifications": {},
+      "certifications": [],
       "chart_info": {}
     }
   ]


### PR DESCRIPTION
## Problem

`finnish-iskelma-classics.json` (merged in #1490) has **91 songs** with `"certifications": {}` — an empty *object*. The playlist schema requires `certifications` to be an `array` or `string`, so this fails:

- **Playlist JSON Schema Gate** (required check)
- **Test (3.12)** / **Test (3.13)** — unit-test schema validation (`1 failed, 1099 passed`)

main is currently **red**, which blocks every open PR (#1501, #1472, …) from showing green CI.

## Fix

Replace all 91 `"certifications": {}` → `"certifications": []`, matching the empty form already used throughout the same file. Data-only, no behavioural change.

### Verification
`scripts/validate_playlists.py` → **0 schema FAILs repo-wide** (was failing only on this file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)