### PR TITLE
playlist(100-brasil): Tidal 34→49/66

### DIFF
--- a/custom_components/beatify/playlists/community/hitster-brasil.json
+++ b/custom_components/beatify/playlists/community/hitster-brasil.json
@@ -559,7 +559,7 @@
         "it": "applemusic://track/1361081880"
       },
       "uri_deezer": "deezer://track/35946071",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/15871382",
       "uri_youtube_music": "https://music.youtube.com/watch?v=IElS9cxpImA"
     },
     {
@@ -593,7 +593,7 @@
         "it": "applemusic://track/723973783"
       },
       "uri_deezer": "deezer://track/3137439",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/1574982",
       "uri_youtube_music": "https://music.youtube.com/watch?v=drGewMyo00A"
     },
     {
@@ -627,7 +627,7 @@
         "it": "applemusic://track/1442685903"
       },
       "uri_deezer": "deezer://track/665413102",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/65250029",
       "uri_youtube_music": "https://music.youtube.com/watch?v=6d6fIM54Vkk"
     },
     {
@@ -661,7 +661,7 @@
         "it": "applemusic://track/1121329085"
       },
       "uri_deezer": "deezer://track/721611",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/215985",
       "uri_youtube_music": "https://music.youtube.com/watch?v=A_sY2rjxq6M"
     },
     {
@@ -695,7 +695,7 @@
         "it": "applemusic://track/872638018"
       },
       "uri_deezer": "deezer://track/3919443",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/600489",
       "uri_youtube_music": "https://music.youtube.com/watch?v=Kp9G0zkorio"
     },
     {
@@ -729,7 +729,7 @@
         "it": "applemusic://track/1435824014"
       },
       "uri_deezer": "deezer://track/128702397",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/97270",
       "uri_youtube_music": "https://music.youtube.com/watch?v=KmUe9VYxJYQ"
     },
     {
@@ -763,7 +763,7 @@
         "it": "applemusic://track/1423304868"
       },
       "uri_deezer": "deezer://track/487042412",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/93427523",
       "uri_youtube_music": "https://music.youtube.com/watch?v=r9nWlPtpcJI"
     },
     {
@@ -797,7 +797,7 @@
         "it": "applemusic://track/1440930363"
       },
       "uri_deezer": "deezer://track/3121608",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/1335142",
       "uri_youtube_music": "https://music.youtube.com/watch?v=WGU_4-5RaxU"
     },
     {
@@ -831,7 +831,7 @@
         "it": "applemusic://track/1413454802"
       },
       "uri_deezer": "deezer://track/529390571",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/92154212",
       "uri_youtube_music": "https://music.youtube.com/watch?v=PNr-XhSXAdc"
     },
     {
@@ -865,7 +865,7 @@
         "it": "applemusic://track/1440812153"
       },
       "uri_deezer": "deezer://track/4125592",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/3044148",
       "uri_youtube_music": "https://music.youtube.com/watch?v=SGyOaCXr8Lw"
     },
     {
@@ -899,7 +899,7 @@
         "it": "applemusic://track/1440882897"
       },
       "uri_deezer": "deezer://track/2525864",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/107690648",
       "uri_youtube_music": "https://music.youtube.com/watch?v=OMOGaugKpzs"
     },
     {
@@ -933,7 +933,7 @@
         "it": "applemusic://track/321575685"
       },
       "uri_deezer": "deezer://track/14924893",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/11456255",
       "uri_youtube_music": "https://music.youtube.com/watch?v=BK_X3FvQTdE"
     },
     {
@@ -967,7 +967,7 @@
         "it": "applemusic://track/1442811008"
       },
       "uri_deezer": "deezer://track/52878141",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/80263881",
       "uri_youtube_music": "https://music.youtube.com/watch?v=r6esToXGQJM"
     },
     {
@@ -1001,7 +1001,7 @@
         "it": "applemusic://track/1136942170"
       },
       "uri_deezer": "deezer://track/2133307",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/130345381",
       "uri_youtube_music": "https://music.youtube.com/watch?v=5m_HAtyycD8"
     },
     {
@@ -1035,7 +1035,7 @@
         "it": "applemusic://track/713691790"
       },
       "uri_deezer": "deezer://track/3529945",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/3444994",
       "uri_youtube_music": "https://music.youtube.com/watch?v=rnCTXKqfuGc"
     },
     {


### PR DESCRIPTION
Second-wave Tidal backfill (Odesli recovered, 0 rate-limit skips). Remaining 17 tracks have no Tidal mapping on Odesli — regional BR catalog gaps, intentionally left null.

🤖 Generated with [Claude Code](https://claude.com/claude-code)