### PR TITLE
playlist(100-francais): Tidal 38→55/100

### DIFF
--- a/custom_components/beatify/playlists/community/hitster-100-francais.json
+++ b/custom_components/beatify/playlists/community/hitster-100-francais.json
@@ -1616,7 +1616,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=vGxOs9OrLYk",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/97874385",
       "uri_deezer": "deezer://track/579936282",
       "alt_artists": [],
       "fun_fact": "Sheryfa Luna emerged from TV talent show 'Popstars' as a French R&B singer.",
@@ -2136,7 +2136,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=0qeV8PDBH8E",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/102392944",
       "uri_deezer": "deezer://track/624630922",
       "alt_artists": [],
       "fun_fact": "'Manhattan-Kaboul' paired Renaud and Axelle Red in a 2002 anti-war duet.",
@@ -2162,7 +2162,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=Dkqsh0kkjFw",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/26398130",
       "uri_deezer": "deezer://track/1101590",
       "alt_artists": [],
       "fun_fact": "Claude Nougaro's 'Armstrong' is his jazz-infused homage to Louis Armstrong.",
@@ -2188,7 +2188,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=17vFHKwq8B8",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/14638606",
       "uri_deezer": "deezer://track/254954",
       "alt_artists": [],
       "fun_fact": "'La danse des canards' (the Chicken Dance) became an inescapable French party novelty.",
@@ -2214,7 +2214,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=Kv-37-nXC48",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/567503",
       "uri_deezer": "deezer://track/2149986",
       "alt_artists": [],
       "fun_fact": "Pow woW's a cappella 'Le lion est mort ce soir' reworked 'The Lion Sleeps Tonight' in 1992.",
@@ -2240,7 +2240,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=GwvPQNxlaf4",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/17168859",
       "uri_deezer": "deezer://track/3453418",
       "alt_artists": [],
       "fun_fact": "Enrico Macias's songs of Mediterranean exile made him a French-Algerian icon.",
@@ -2266,7 +2266,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=1R2etg__x1Y",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/198425030",
       "uri_deezer": "deezer://track/1490805692",
       "alt_artists": [],
       "fun_fact": "MC Solaar's 'Nouveau western' samples Serge Gainsbourg over jazzy French hip-hop.",
@@ -2292,7 +2292,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=VftQyYqEMYk",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/240028342",
       "uri_deezer": "deezer://track/1839225277",
       "alt_artists": [],
       "fun_fact": "Stromae's 'Mon amour' (2022) marked the Belgian star's celebrated comeback era.",
@@ -2318,7 +2318,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=jQztFLKaZEU",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/22618",
       "uri_deezer": "deezer://track/604505",
       "alt_artists": [],
       "fun_fact": "Slaï is a French Antillean singer known for zouk-love ballads.",
@@ -2344,7 +2344,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=gzlHucbD76U",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/1229196",
       "uri_deezer": "deezer://track/921886",
       "alt_artists": [],
       "fun_fact": "Khaled's 'Aïcha', written by Jean-Jacques Goldman, became a worldwide raï anthem.",
@@ -2370,7 +2370,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=yJuz9zfygIg",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/87035840",
       "uri_deezer": "deezer://track/482681782",
       "alt_artists": [],
       "fun_fact": "Magic System's 'Premier Gaou' grew from an Ivorian hit to a French summer phenomenon.",
@@ -2396,7 +2396,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=519_pOvP9xs",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/401736048",
       "uri_deezer": "deezer://track/3110786941",
       "alt_artists": [],
       "fun_fact": "Fauve were an anonymous French collective whose spoken-word rock became a cult sensation.",
@@ -2422,7 +2422,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=g-gh2hIRhkc",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/3689478",
       "uri_deezer": "deezer://track/984192",
       "alt_artists": [],
       "fun_fact": "Florent Pagny's 'Savoir aimer' (1997) is one of his most cherished French ballads.",
@@ -2474,7 +2474,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=pX594TK_VIc",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/1471460",
       "uri_deezer": "deezer://track/3435031",
       "alt_artists": [],
       "fun_fact": "De Palmas's 'Sur la route' is a road-trip French pop-rock favourite from 'Marcher dans le sable'.",
@@ -2500,7 +2500,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=Xn5TgdH4GEU",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/492948805",
       "uri_deezer": "deezer://track/3786102562",
       "alt_artists": [],
       "fun_fact": "Sylvie Vartan's 'Comme un garçon' (1967) is a defining record of the French yéyé era.",
@@ -2526,7 +2526,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=Bw0xx9DVHZ4",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/34922641",
       "uri_deezer": "deezer://track/929610",
       "alt_artists": [],
       "fun_fact": "François Feldman's 'Les valses de Vienne' was a chart-topping 1989 French pop hit.",
@@ -2552,7 +2552,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=GGPXjiwlWZc",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/50329329",
       "uri_deezer": "deezer://track/105966812",
       "alt_artists": [],
       "fun_fact": "Kamini's 'Marly-Gomont' (2006) put his tiny Picardy village on the map with witty rap.",


### PR DESCRIPTION
Second-wave Tidal backfill (Odesli recovered, 0 rate-limit skips). Remaining 45 tracks have no Tidal mapping on Odesli — regional FR catalog gaps (incl. recent French rap), intentionally left null.

🤖 Generated with [Claude Code](https://claude.com/claude-code)