### PR TITLE
release: v4.1.1 — Two New Countries (100% Brasil + 100% Français)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,21 @@ All notable changes to Beatify are documented here. For detailed release notes, 
 
 ## [Unreleased]
 
+## [4.1.1] - 2026-06-20
+
+Content release — two new community playlists. See [docs/release-notes-v4.1.1.md](docs/release-notes-v4.1.1.md) for the user-facing notes.
+
 ### Added
-- Added 66 tracks to new community playlist "HITSTER - Brasil 🇧🇷" (#1495).
+- **New community playlist "100% Brasil 🇧🇷" (66 songs).** Brazilian hits across the decades, year-mode ready (verified original release year + ISRC per track) with multi-provider URIs — Apple Music, Deezer, YouTube Music and Tidal alongside Spotify (#1495).
+- **New community playlist "100% Français 🇫🇷" (100 songs).** French hits across the eras (chanson, pop, rap, variété), same enrichment: verified release year + ISRC per track, multi-provider URIs, and fun facts in five languages (#1496).
+
+### Changed
+- Renamed the country playlist packs to the "100% &lt;Country&gt;" scheme — "100% Brasil" and "100% Français" — dropping the previous third-party game name, matching the existing "100% en Español".
+
+### Fixed
+- Corrected the Lady Gaga – "RUNWAY" release year (2021 → 2026) in EDM Anthems (#1499, #1501).
+- Fixed an invalid empty `certifications` value (`{}` → `[]`) in Finnish Schlager Classics that broke the playlist JSON schema gate (#1504).
+- Cleaned up stale/incorrect track URIs in Trance Classics (#1503), Harder Styles (#1494) and Finnish Iskelmä Classics (#1492).
 
 ## [4.1.0] - 2026-06-18
 

--- a/custom_components/beatify/manifest.json
+++ b/custom_components/beatify/manifest.json
@@ -19,5 +19,5 @@
     "num2words==0.5.14"
   ],
   "single_config_entry": true,
-  "version": "4.1.0"
+  "version": "4.1.1"
 }

--- a/docs/release-notes-v4.1.1.md
+++ b/docs/release-notes-v4.1.1.md
@@ -1,0 +1,21 @@
+## v4.1.1 — Two New Countries
+
+Two brand-new community playlists join the lineup, each a decades-spanning tour of a country's biggest hits — and each built year-mode ready, so it plays clean from the very first round.
+
+### 🇧🇷 100% Brasil
+
+66 Brazilian hits across the decades, from timeless classics to modern chart-toppers. Every track carries a verified original release year and ISRC, so year-guess mode runs true, and the list plays through every Music Assistant provider — not just Spotify.
+
+### 🇫🇷 100% Français
+
+100 French hits spanning the eras — chanson, pop and today's rap and variété side by side. Same care under the hood: a verified release year and ISRC on every track, multi-provider playback, and fun facts in five languages for the reveal.
+
+### 🙏 Thank you
+
+To everyone asking for more of their own country on the board — these two lists came straight from the in-app request funnel. Keep them coming.
+
+---
+
+**43 playlists · 4,954 songs · 5 music platforms · 5 languages**
+
+[Report a Bug](https://github.com/mholzi/beatify/issues) · [Discussions](https://github.com/mholzi/beatify/discussions) · [Full Changelog](https://github.com/mholzi/beatify/blob/main/CHANGELOG.md)


### PR DESCRIPTION
Content release for the two new community playlists added since v4.1.0.

**Files only — no `gh release` created** (per request).

### Changes
- `docs/release-notes-v4.1.1.md` — user-facing notes (old narrative format, focused on the two new playlists)
- `CHANGELOG.md` — new `[4.1.1]` section (Added / Changed / Fixed), stale `[Unreleased]` Brasil line removed
- `manifest.json` — version 4.1.0 → 4.1.1

### Covered
- **100% Brasil 🇧🇷** (66 songs) + **100% Français 🇫🇷** (100 songs) — new community playlists
- "100% &lt;Country&gt;" rename (dropped third-party game name)
- Data fixes merged since v4.1.0: Lady Gaga year (#1501), Finnish cert schema (#1504), URI cleanups (#1503/#1494/#1492)

🤖 Generated with [Claude Code](https://claude.com/claude-code)