### PR TITLE
data: fix 1 wrong-track URI in hitster-100-francais (#1510)

### DIFF
--- a/custom_components/beatify/playlists/community/hitster-100-francais.json
+++ b/custom_components/beatify/playlists/community/hitster-100-francais.json
@@ -1,6 +1,6 @@
 {
   "name": "100% Français 🇫🇷",
-  "version": "0.1",
+  "version": "0.2",
   "tags": [
     "french",
     "francais",
@@ -213,7 +213,7 @@
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=1rGW4BMzzPo",
       "uri_tidal": null,
-      "uri_deezer": "deezer://track/3986529121",
+      "uri_deezer": "deezer://track/129674020",
       "alt_artists": [],
       "fun_fact": "Alliage was a late-1990s French boy band featuring a young Steaphan/Steevy-era teen-pop sound.",
       "fun_fact_de": "Alliage war eine französische Boyband der späten 1990er im Teen-Pop-Sound.",


### PR DESCRIPTION
Closes #1510. Replaced 1 wrong-track Deezer URI and bumped playlist version to 0.2.

**Change:** Alliage — Lucy: `deezer://track/3986529121` → `deezer://track/129674020`

The old URI pointed to "All Ages" by artist LUCY (a completely different song). The correct track is "Lucy" by the French 90s boy band Alliage.