### PR TITLE
release: v4.1.2 — Disney auf Deutsch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,12 @@ All notable changes to Beatify are documented here. For detailed release notes, 
 
 ## [Unreleased]
 
+## [4.1.2] - 2026-06-22
+
+Content release — new German Disney playlist with the guess-the-film bonus. See [docs/release-notes-v4.1.2.md](docs/release-notes-v4.1.2.md) for the user-facing notes.
+
 ### Added
-- Added 97 tracks to new community playlist "Disney Hits Deutschland 🇩🇪" (#1505).
+- **New community playlist "Disney Hits Deutschland 🇩🇪" (97 songs).** German-language Disney songs across the decades (Das Dschungelbuch 1967 → Mufasa 2024), year-mode ready with a verified film year per track and multi-provider URIs (Apple Music, Deezer, YouTube Music, Spotify). The guess-the-film bonus is enabled — each track carries its Disney/Pixar film plus two decoy choices, across 40 distinct films. Movie assignments, years and fun-facts were cross-checked by a multi-agent verification pass (#1505).
 
 ## [4.1.1] - 2026-06-20
 

--- a/custom_components/beatify/manifest.json
+++ b/custom_components/beatify/manifest.json
@@ -19,5 +19,5 @@
     "num2words==0.5.14"
   ],
   "single_config_entry": true,
-  "version": "4.1.1"
+  "version": "4.1.2"
 }

--- a/docs/release-notes-v4.1.2.md
+++ b/docs/release-notes-v4.1.2.md
@@ -1,0 +1,19 @@
+## v4.1.2 — Disney auf Deutsch
+
+A new community playlist joins the lineup — and it brings the guess-the-film bonus along for the ride.
+
+### 🇩🇪 Disney Hits Deutschland
+
+97 German-language Disney songs across the decades, from "Probier's mal mit Gemütlichkeit" (Das Dschungelbuch, 1967) all the way to Mufasa (2024). Every track is year-mode ready with a verified film year, and plays on every Music Assistant provider — Apple Music, Deezer, YouTube Music and Spotify.
+
+Best of all: the playlist has the **guess-the-film bonus** switched on. After each song you can name the movie it came from — pick from three deliberately tricky choices — with 40 different Disney and Pixar films in the mix, from Der König der Löwen to Encanto, Vaiana and Die Eiskönigin.
+
+### 🙏 Thank you
+
+Requested straight from the in-app funnel — keep the playlist ideas coming.
+
+---
+
+**44 playlists · 5,051 songs · 5 music platforms · 5 languages**
+
+[Report a Bug](https://github.com/mholzi/beatify/issues) · [Discussions](https://github.com/mholzi/beatify/discussions) · [Full Changelog](https://github.com/mholzi/beatify/blob/main/CHANGELOG.md)


### PR DESCRIPTION
Content release for the new **Disney Hits Deutschland** playlist (#1505, already merged to main).

**Files only:**
- `docs/release-notes-v4.1.2.md` — user-facing notes (old narrative format)
- `CHANGELOG.md` — new `[4.1.2]` block
- `manifest.json` — 4.1.1 → 4.1.2

After merge: tag + gh release v4.1.2 as Latest with these notes as the body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)