### PR TITLE
data: fix 1 wrong YouTube Music URI in disney-hits-deutschland (#1522)

### DIFF
--- a/custom_components/beatify/playlists/community/disney-hits-deutschland.json
+++ b/custom_components/beatify/playlists/community/disney-hits-deutschland.json
@@ -1,6 +1,6 @@
 {
   "name": "Disney Hits Deutschland",
-  "version": "0.1",
+  "version": "0.2",
   "tags": [
     "disney",
     "movies",
@@ -2567,7 +2567,7 @@
         "it": "applemusic://track/1388083877"
       },
       "uri_deezer": "deezer://track/534375692",
-      "uri_youtube_music": "https://music.youtube.com/watch?v=WDMtsanDLIQ",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=V1U5si-Rcss",
       "uri_tidal": null,
       "fun_fact": "\"Dig a Little Deeper\" is Mama Odie's gospel-style song from The Princess and the Frog.",
       "fun_fact_de": "\"Dig a Little Deeper\" ist Mama Odies Gospel-Song aus Küss den Frosch.",


### PR DESCRIPTION
Closes #1522. Replaced 1 wrong YouTube Music URI for Jenifer Lewis 'Dig a Little Deeper' (WDMtsanDLIQ→V1U5si-Rcss; was pointing to Disney Night on American Idol 2024 performance, now points to original Princess and the Frog 2009 recording). Bumped playlist version to 0.2.