### PR TITLE
fix: reset MediaPlayerService on create_game to apply new player sele…

### DIFF
--- a/custom_components/beatify/game/state_setup.py
+++ b/custom_components/beatify/game/state_setup.py
@@ -195,6 +195,15 @@ class GameSetupMixin:
         self.playlists = playlists
         self.songs = songs
         self.media_player = media_player
+        # A new game brings fresh media_player/platform/provider from the wizard.
+        # The lazily-built MediaPlayerService captures these at construction time
+        # (services/media_player.py __init__) — without nulling it here, the next
+        # _ensure_media_player_service() call recycles the previous game's service
+        # because of its `not self._media_player_service` guard. Result: playback
+        # ignores the new selection and routes via the old entity_id/platform/
+        # provider until HA itself restarts. rematch_game() intentionally preserves
+        # these values, so this reset stays scoped to create_game.
+        self._media_player_service = None
         self.join_url = f"{base_url}/beatify/play?game={self.game_id}"
         self.players = {}
 

--- a/tests/unit/test_state_title_artist_window.py
+++ b/tests/unit/test_state_title_artist_window.py
@@ -32,9 +32,6 @@ def _stub_media_service() -> MagicMock:
 
 
 async def _start_round(gs):
-    # Inject a stub service (truthy) so the lazy _ensure_media_player_service
-    # is a no-op and real playback never runs.
-    gs._media_player_service = _stub_media_service()
     gs.create_game(
         playlists=["t.json"],
         songs=_ta_songs(3),
@@ -42,6 +39,11 @@ async def _start_round(gs):
         base_url="http://h",
         title_artist_mode=True,
     )
+    # Inject a stub service (truthy) so the lazy _ensure_media_player_service
+    # is a no-op and real playback never runs. Must come *after* create_game,
+    # which now nulls _media_player_service so a fresh game rebuilds it with the
+    # new selection (#1526) — injecting before would be wiped out by that reset.
+    gs._media_player_service = _stub_media_service()
     gs.platform = "music_assistant"  # skip the verify_responsive branch
     gs.add_player("Alice", MagicMock())
     gs.add_player("Bob", MagicMock())
@@ -496,7 +498,6 @@ class TestVoteWindowFlagReset:
         await self._open_window(gs)
         await gs.end_game()
         # Start a fresh plain year-mode game.
-        gs._media_player_service = _stub_media_service()
         gs.create_game(
             playlists=["t.json"],
             songs=make_songs(3),
@@ -505,6 +506,8 @@ class TestVoteWindowFlagReset:
             title_artist_mode=False,
             reveal_auto_advance=5,
         )
+        # Stub the service after create_game, which nulls it for a fresh game (#1526).
+        gs._media_player_service = _stub_media_service()
         gs.platform = "music_assistant"
         gs.add_player("Alice", MagicMock())
         for p in gs.players.values():

--- a/tests/unit/test_ws_title_artist_guess.py
+++ b/tests/unit/test_ws_title_artist_guess.py
@@ -43,7 +43,6 @@ def _stub_media_service() -> MagicMock:
 def _make_handler_game():
     mock_hass = MagicMock()
     gs = make_game_state()
-    gs._media_player_service = _stub_media_service()
     gs.create_game(
         playlists=["t.json"],
         songs=_ta_songs(3),
@@ -51,6 +50,8 @@ def _make_handler_game():
         base_url="http://h",
         title_artist_mode=True,
     )
+    # After create_game, which nulls _media_player_service for a fresh game (#1526).
+    gs._media_player_service = _stub_media_service()
     gs.platform = "music_assistant"  # skip the verify_responsive branch
     mock_hass.data = {DOMAIN: {"game": gs}}
     handler = BeatifyWebSocketHandler(mock_hass)

--- a/tests/unit/test_ws_title_artist_vote.py
+++ b/tests/unit/test_ws_title_artist_vote.py
@@ -35,9 +35,6 @@ def _stub_media_service() -> MagicMock:
 def _make_handler_game():
     mock_hass = MagicMock()
     gs = make_game_state()
-    # Inject a truthy stub service so the lazy _ensure_media_player_service is a
-    # no-op and real (hass-less) playback never runs during start_round.
-    gs._media_player_service = _stub_media_service()
     gs.create_game(
         playlists=["t.json"],
         songs=_ta_songs(3),
@@ -45,6 +42,10 @@ def _make_handler_game():
         base_url="http://h",
         title_artist_mode=True,
     )
+    # Inject a truthy stub service so the lazy _ensure_media_player_service is a
+    # no-op and real (hass-less) playback never runs during start_round. Must be
+    # after create_game, which nulls _media_player_service for a fresh game (#1526).
+    gs._media_player_service = _stub_media_service()
     gs.platform = "music_assistant"  # skip the verify_responsive branch
     mock_hass.data = {DOMAIN: {"game": gs}}
     handler = BeatifyWebSocketHandler(mock_hass)


### PR DESCRIPTION
## Summary

Choosing a different speaker in the wizard had no effect until Home Assistant itself was restarted — the previous selection kept routing playback.

Repro example: pick *Sonos Flur (Music Assistant, YouTube Music)*, hit *Force reset*, start a new game; playback still goes to *Sonos Wohnzimmer Alexa* with `APPLE_MUSIC`.

## Root cause

`_ensure_media_player_service()` in `game/state_lifecycle.py` only builds a fresh `MediaPlayerService` when `self._media_player_service is None`:

```python
if self.media_player and not self._media_player_service:
    self._media_player_service = MediaPlayerService(
        self._hass, self.media_player,
        platform=self.platform, provider=self.provider,
    )
```

The service captures `entity_id`, `platform` and `provider` at `__init__` time (`services/media_player.py`). Neither `end_game()` nor `_reset_game_internals()` ever nulls `self._media_player_service`, so the next `create_game()` runs with new values on `self.media_player` / `self.platform` / `self.provider`, but the lazy guard reuses the previous game's service — old `entity_id`, old `platform`, old `provider` — until HA itself is restarted (which discards `hass.data[DOMAIN]`).

This explains the symptom split observed in the logs:

```
PlaylistManager: 57/69 songs across 1 playlist(s) for youtube_music [de]    ← new provider, correct
Alexa playback: '...' (APPLE_MUSIC) on media_player.sonos_wohnzimmer_alexa  ← stale service, wrong
```

Provider/songs flow through `self.provider` (fresh) — playback flows through the cached `MediaPlayerService` (stale).

## Fix

Reset `self._media_player_service = None` inside `create_game()`, right where the new `media_player` / `platform` / `provider` arrive from the wizard. The next `_ensure_media_player_service()` then constructs a service aligned with the new selection.

Scope is deliberately limited to `create_game`: `rematch_game()` preserves `media_player` / `platform` / `provider` via its preserved block in `state_setup.py`, so the existing service is still valid there — nulling it would force an unnecessary rebuild.

## Test plan

Reproduced and verified on Home Assistant OS with Beatify 4.1.2:

- Before patch: pick speaker A, force-reset, pick speaker B → playback still on A (until HA restart)
- After patch: pick speaker A, play a round, force-reset, pick speaker B → playback on B, no HA restart needed
- `rematch_game()` continues to play through the same speaker (its preserved block keeps the values; the still-valid service is reused)
```