### PR TITLE
fix: render <html lang> server-side so Android auto-translate stops k…

### DIFF
--- a/custom_components/beatify/server/base.py
+++ b/custom_components/beatify/server/base.py
@@ -162,7 +162,11 @@ def _resolve_page_language(hass: HomeAssistant) -> str:
         lang = getattr(game_state, "language", None)
         if lang:
             return lang
-    cfg_lang = getattr(hass.config, "language", None)
+    # `hass.config` exists on a real HomeAssistant but may be absent on a bare
+    # test/stub hass — guard the attribute access so the helper degrades to "en"
+    # instead of raising while serving a page.
+    cfg = getattr(hass, "config", None)
+    cfg_lang = getattr(cfg, "language", None)
     if cfg_lang:
         return cfg_lang
     return "en"

--- a/custom_components/beatify/server/base.py
+++ b/custom_components/beatify/server/base.py
@@ -139,6 +139,44 @@ def _apply_cache_tokens(text: str, hass: HomeAssistant) -> str:
     return text.replace(_VERSION_TOKEN, version)
 
 
+# #1177 follow-up: PR #1179 set documentElement.lang inside setLanguage(), but
+# on Android Chrome auto-translate runs against the *initial* HTML, before the
+# WebSocket state arrives and triggers setLanguage('de'). The static
+# <html lang="en"> in the page sources then causes the browser to auto-translate
+# the already-correct German strings ("Tipp abgeben" -> "Trinkgeld abgeben",
+# "Fun Facts" -> "Wissenswertes"). Patching the attribute server-side, before
+# the bytes leave the integration, eliminates the race entirely.
+def _resolve_page_language(hass: HomeAssistant) -> str:
+    """Resolve the locale to render into ``<html lang>`` for HTML pages.
+
+    Priority:
+    1. Active game's language (the wizard selection wins for player/dashboard
+       pages, which are the surfaces that show the per-game translated UI).
+    2. Home Assistant's configured UI language (covers admin/launcher visits
+       outside an active game — matches what the wizard would default to).
+    3. ``"en"`` as last resort.
+    """
+    data = hass.data.get(DOMAIN, {})
+    game_state = data.get("game")
+    if game_state is not None:
+        lang = getattr(game_state, "language", None)
+        if lang:
+            return lang
+    cfg_lang = getattr(hass.config, "language", None)
+    if cfg_lang:
+        return cfg_lang
+    return "en"
+
+
+def _apply_html_lang(text: str, hass: HomeAssistant) -> str:
+    """Rewrite ``<html lang="en">`` to the active locale before serving."""
+    lang = _resolve_page_language(hass)
+    # All Beatify HTML files ship with the literal `<html lang="en">`; a plain
+    # string replace stays predictable (no regex-escaping the locale value) and
+    # is a no-op if a future template lands with a different default.
+    return text.replace('<html lang="en">', f'<html lang="{lang}">', 1)
+
+
 _html_cache: dict[str, str] = {}
 
 

--- a/custom_components/beatify/server/stats_views.py
+++ b/custom_components/beatify/server/stats_views.py
@@ -44,7 +44,9 @@ class DashboardView(HomeAssistantView):
             _LOGGER.error("Dashboard page not found: %s", html_path)
             return web.Response(text="Dashboard page not found", status=500)
         return web.Response(
-            text=_apply_html_lang(_apply_cache_tokens(html_content, self.hass), self.hass),
+            text=_apply_html_lang(
+                _apply_cache_tokens(html_content, self.hass), self.hass
+            ),
             content_type="text/html",
         )
 

--- a/custom_components/beatify/server/stats_views.py
+++ b/custom_components/beatify/server/stats_views.py
@@ -14,6 +14,7 @@ from custom_components.beatify.const import DOMAIN
 from custom_components.beatify.server.base import (
     RateLimitMixin,
     _apply_cache_tokens,
+    _apply_html_lang,
     _get_html,
     _json_error,
 )
@@ -43,7 +44,7 @@ class DashboardView(HomeAssistantView):
             _LOGGER.error("Dashboard page not found: %s", html_path)
             return web.Response(text="Dashboard page not found", status=500)
         return web.Response(
-            text=_apply_cache_tokens(html_content, self.hass),
+            text=_apply_html_lang(_apply_cache_tokens(html_content, self.hass), self.hass),
             content_type="text/html",
         )
 
@@ -174,7 +175,7 @@ class AnalyticsPageView(HomeAssistantView):
         if content is None:
             return web.Response(text="Analytics page not found", status=404)
         return web.Response(
-            text=_apply_cache_tokens(content, self.hass),
+            text=_apply_html_lang(_apply_cache_tokens(content, self.hass), self.hass),
             content_type="text/html",
         )
 

--- a/custom_components/beatify/server/views.py
+++ b/custom_components/beatify/server/views.py
@@ -118,7 +118,9 @@ class AdminView(HomeAssistantView):
         if html_content is None:
             _LOGGER.error("Admin page not found: %s", html_path)
             return web.Response(text="Admin page not found", status=500)
-        return _html_response(_apply_html_lang(_apply_cache_tokens(html_content, self.hass), self.hass))
+        return _html_response(
+            _apply_html_lang(_apply_cache_tokens(html_content, self.hass), self.hass)
+        )
 
 
 class LauncherView(HomeAssistantView):
@@ -139,7 +141,9 @@ class LauncherView(HomeAssistantView):
         if html_content is None:
             _LOGGER.error("Launcher page not found: %s", html_path)
             return web.Response(text="Launcher page not found", status=500)
-        return _html_response(_apply_html_lang(_apply_cache_tokens(html_content, self.hass), self.hass))
+        return _html_response(
+            _apply_html_lang(_apply_cache_tokens(html_content, self.hass), self.hass)
+        )
 
 
 class PlayerView(HomeAssistantView):
@@ -160,7 +164,9 @@ class PlayerView(HomeAssistantView):
         if html_content is None:
             _LOGGER.error("Player page not found: %s", html_path)
             return web.Response(text="Player page not found", status=500)
-        return _html_response(_apply_html_lang(_apply_cache_tokens(html_content, self.hass), self.hass))
+        return _html_response(
+            _apply_html_lang(_apply_cache_tokens(html_content, self.hass), self.hass)
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/custom_components/beatify/server/views.py
+++ b/custom_components/beatify/server/views.py
@@ -26,6 +26,7 @@ from custom_components.beatify.game.playlist import async_discover_playlists
 from custom_components.beatify.server.base import (
     RateLimitMixin,
     _apply_cache_tokens,
+    _apply_html_lang,
     _get_html,
     _get_version,
     _json_error,
@@ -117,7 +118,7 @@ class AdminView(HomeAssistantView):
         if html_content is None:
             _LOGGER.error("Admin page not found: %s", html_path)
             return web.Response(text="Admin page not found", status=500)
-        return _html_response(_apply_cache_tokens(html_content, self.hass))
+        return _html_response(_apply_html_lang(_apply_cache_tokens(html_content, self.hass), self.hass))
 
 
 class LauncherView(HomeAssistantView):
@@ -138,7 +139,7 @@ class LauncherView(HomeAssistantView):
         if html_content is None:
             _LOGGER.error("Launcher page not found: %s", html_path)
             return web.Response(text="Launcher page not found", status=500)
-        return _html_response(_apply_cache_tokens(html_content, self.hass))
+        return _html_response(_apply_html_lang(_apply_cache_tokens(html_content, self.hass), self.hass))
 
 
 class PlayerView(HomeAssistantView):
@@ -159,7 +160,7 @@ class PlayerView(HomeAssistantView):
         if html_content is None:
             _LOGGER.error("Player page not found: %s", html_path)
             return web.Response(text="Player page not found", status=500)
-        return _html_response(_apply_cache_tokens(html_content, self.hass))
+        return _html_response(_apply_html_lang(_apply_cache_tokens(html_content, self.hass), self.hass))
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Root cause

PR #1179 set `documentElement.lang` inside `i18n.setLanguage()`, but on Android
Chrome the auto-translate detection runs against the *initial* HTML response.
`setLanguage('de')` only fires after the page boots and the WebSocket state
arrives — by then Chrome has already seen the static `<html lang="en">` in every
Beatify page (`admin.html`, `player.html`, `dashboard.html`, `launcher.html`,
`analytics.html`) and offered to translate.

The result reproduces #1177 verbatim: *"Tipp abgeben"* → *"Trinkgeld abgeben"*,
*"Fun Facts"* → *"Wissenswertes"*.

Reported live on 2026-06-23 with six devices in one game; every device running
Android Chrome saw the auto-translation despite running v4.1.2 (which already
contains the PR #1179 patch).

## Fix

Rewrite the `<html lang>` attribute server-side before the bytes leave the
integration, so the very first paint already matches the rendered locale.

Resolution priority in `_resolve_page_language(hass)`:

1. **Active game's language** — the per-game wizard choice wins on
   player/dashboard surfaces; that's the locale the JS would set anyway, so the
   initial HTML matches.
2. **`hass.config.language`** — covers admin/launcher visits outside an active
   game.
3. **`"en"`** — last resort.

Both helpers (`_resolve_page_language`, `_apply_html_lang`) live in
`server/base.py`. All five HTML-serving views call them after
`_apply_cache_tokens`:

- `server/views.py`: `AdminView`, `LauncherView`, `PlayerView`
- `server/stats_views.py`: `DashboardView`, `AnalyticsPageView`

`<html lang="en">` is the literal in every shipped template, so a plain
`str.replace` keeps the patch predictable (no regex-escape needed on the locale
value) and silently no-ops on any future template that ships a different default.
```