### PR TITLE
data: fix 1 dead Apple Music URI in essential-alternative (#1532)

### DIFF
--- a/custom_components/beatify/playlists/community/essential-alternative.json
+++ b/custom_components/beatify/playlists/community/essential-alternative.json
@@ -1,6 +1,6 @@
 {
   "name": "Essential Alternative 🎸",
-  "version": "0.2",
+  "version": "0.3",
   "tags": [
     "alternative",
     "rock",
@@ -1154,7 +1154,7 @@
       "fun_fact_de": "Gerard Way schrieb 'Teenagers' nach einer Panikattacke in der New Yorker U-Bahn — er satirisiert die Angst Erwachsener vor Jugendlichen, nicht die Jugend selbst.",
       "fun_fact_es": "Gerard Way escribió 'Teenagers' tras un ataque de pánico en el metro de Nueva York — satiriza el miedo adulto a los jóvenes, no a los jóvenes.",
       "fun_fact_fr": "Gerard Way a écrit 'Teenagers' après une crise de panique dans le métro new-yorkais — il satirise la peur adulte des jeunes, pas les jeunes eux-mêmes.",
-      "uri_apple_music": "applemusic://track/1778289278",
+      "uri_apple_music": "applemusic://track/209388998",
       "uri_youtube_music": "https://music.youtube.com/watch?v=jLKOBJR5vHs",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/676590",
@@ -1162,13 +1162,13 @@
       "awards_nl": [],
       "isrc": "USRE10602912",
       "uri_apple_music_by_region": {
-        "us": "applemusic://track/1778289278",
-        "de": "applemusic://track/1778289278",
-        "gb": "applemusic://track/1778289278",
-        "fr": "applemusic://track/1778289278",
-        "es": "applemusic://track/1778289278",
-        "nl": "applemusic://track/1778289278",
-        "it": "applemusic://track/1778289278"
+        "us": "applemusic://track/209388998",
+        "de": "applemusic://track/209388998",
+        "gb": "applemusic://track/209388998",
+        "fr": "applemusic://track/209388998",
+        "es": "applemusic://track/209388998",
+        "nl": "applemusic://track/209388998",
+        "it": "applemusic://track/209388998"
       }
     },
     {


### PR DESCRIPTION
Closes #1532. Replaced dead Apple Music track ID with correct one and bumped playlist version to 0.3.