### PR TITLE
release: v4.1.3 — New Wave Summer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,18 @@ All notable changes to Beatify are documented here. For detailed release notes, 
 
 ## [Unreleased]
 
+## [4.1.3] - 2026-06-24
+
+Content + reliability release — two new German community playlists plus speaker and Android-translate fixes. See [docs/release-notes-v4.1.3.md](docs/release-notes-v4.1.3.md) for the user-facing notes.
+
 ### Added
 - **Speaker volume is restored when the game ends (#1516).** If the host adjusts the speaker volume during a game, Beatify now hands the speaker back at its original pre-game level when the game ends — no more manually resetting the volume after every round. Complements the existing party-lights state restore (#331/#1402).
 - Added 60 tracks to new community playlist "Sommerklassiker ☀️" — international summer hits spanning 1978–2023 (#1519).
 - Added 50 tracks to new community playlist "NDW – Neue Deutsche Welle" — German New Wave hits spanning 1976–1986 (#1517).
+
+### Fixed
+- **Speaker selection now applies immediately (#1526).** Choosing a different speaker in the wizard takes effect right away instead of routing playback through the previous selection until Home Assistant restarts.
+- **Android Chrome no longer auto-translates the UI (#1527).** The page language is rendered server-side so the initial HTML already matches the locale, stopping the browser from re-translating the already-correct German strings.
 
 ## [4.1.2] - 2026-06-22
 

--- a/custom_components/beatify/manifest.json
+++ b/custom_components/beatify/manifest.json
@@ -19,5 +19,5 @@
     "num2words==0.5.14"
   ],
   "single_config_entry": true,
-  "version": "4.1.2"
+  "version": "4.1.3"
 }

--- a/docs/release-notes-v4.1.3.md
+++ b/docs/release-notes-v4.1.3.md
@@ -1,0 +1,22 @@
+# Beatify v4.1.3 — "New Wave Summer"
+
+A summer content drop plus a few reliability fixes that smooth out game setup and playback.
+
+### 🎵 Two new community playlists
+
+- **Sommerklassiker ☀️** — 60 international summer hits spanning 1978–2023, year-mode ready with multi-provider URIs (Apple Music, Deezer, YouTube Music, Spotify) and fun facts in five languages.
+- **NDW – Neue Deutsche Welle** — 50 German New Wave classics from 1976–1986 (Peter Schilling, Falco, Spider Murphy Gang, Münchener Freiheit …), the genre's golden era in one set.
+
+### 🔧 Fixes & polish
+
+- **Speaker selection applies immediately** — picking a different speaker in the wizard now takes effect right away, no Home Assistant restart needed (#1526).
+- **Android auto-translate no longer scrambles the UI** — the page language is set server-side, so Android Chrome stops re-translating the already-correct German strings ("Tipp abgeben" was turning into "Trinkgeld abgeben") (#1527).
+- **Your speaker volume is restored when a game ends** — if the host changes the volume mid-game, Beatify hands the speaker back at its original level afterwards (#1516).
+
+### 🙏 Thank you
+
+Thanks to @Scribblerman for two sharp bug reports and fixes (speaker selection + Android translate), and to everyone requesting playlists.
+
+—
+
+46 playlists · 5161 songs · 5 providers · 5 languages


### PR DESCRIPTION
Release v4.1.3 "New Wave Summer": manifest bump 4.1.2→4.1.3, CHANGELOG [4.1.3] block, release notes.

- 2 new community playlists: Sommerklassiker ☀️ (#1519), NDW – Neue Deutsche Welle (#1517)
- Fixes: speaker selection applies immediately (#1526), Android auto-translate (#1527), speaker volume restore (#1516)

🤖 Generated with [Claude Code](https://claude.com/claude-code)