### PR TITLE
perf(game): pre-warm MediaPlayerService during LOBBY (#1540)

### DIFF
--- a/custom_components/beatify/game/state.py
+++ b/custom_components/beatify/game/state.py
@@ -281,6 +281,10 @@ class GameState(
         # #1012: REVEAL auto-advance (seconds; 0 = manual) + its task handle
         self.reveal_auto_advance: int = 0
         self._auto_advance_task: asyncio.Task | None = None
+        # #1540 review: handle for the LOBBY media-player pre-warm task so a
+        # game reset/recreate can cancel a still-running warm-up (analogous to
+        # _auto_advance_task) instead of orphaning it.
+        self._prewarm_task: asyncio.Task | None = None
         # #1180 Phase 4: title/artist near-miss vote window is open in REVEAL.
         self._title_artist_voting_open: bool = False
         # #1180: server-owned wall-clock deadline (in self._now units) for the

--- a/custom_components/beatify/game/state_lifecycle.py
+++ b/custom_components/beatify/game/state_lifecycle.py
@@ -410,41 +410,64 @@ class RoundLifecycleMixin:
         if not (self._hass and self.media_player):
             return
 
+        # #1540 review: supersede any still-running pre-warm from a prior
+        # create_game before scheduling a new one, so a stale warm-up can't
+        # race the fresh game's first round.
+        self._cancel_prewarm()
+
         async def _runner() -> None:
             try:
                 await self.prewarm_media_player_service()
+            except asyncio.CancelledError:
+                # A game reset/recreate cancelled the warm-up — expected, not a
+                # failure. Re-raise so the task is marked cancelled, not errored.
+                raise
             except Exception as err:  # noqa: BLE001 — pre-warm must never raise
-                _LOGGER.debug("Media player pre-warm failed (best-effort): %s", err)
+                # #1540 review: warn (not debug) so a permanently offline
+                # speaker surfaces in the log instead of being silently masked.
+                _LOGGER.warning("Media player pre-warm failed (best-effort): %s", err)
 
         # Use HA's tracked task helper when available so the warm-up is tied to
         # the integration's lifecycle; fall back to a bare task otherwise (e.g.
-        # the slimmed-down hass stub used in unit tests).
+        # the slimmed-down hass stub used in unit tests). Keep the handle so the
+        # reset path can cancel it.
         creator = getattr(self._hass, "async_create_background_task", None)
         if callable(creator):
-            creator(_runner(), name="beatify_media_player_prewarm")
+            self._prewarm_task = creator(_runner(), name="beatify_media_player_prewarm")
         else:
-            asyncio.create_task(_runner())  # noqa: RUF006 — fire-and-forget warm-up
+            self._prewarm_task = asyncio.create_task(_runner())
+
+    def _cancel_prewarm(self) -> None:
+        """Cancel the pending LOBBY media-player pre-warm task, if any (#1540)."""
+        if self._prewarm_task is not None:
+            self._prewarm_task.cancel()
+            self._prewarm_task = None
 
     async def prewarm_media_player_service(self) -> None:
-        """Construct + lightly probe the MediaPlayerService ahead of Round 1.
+        """Construct + warm the MediaPlayerService ahead of Round 1.
 
         Builds the service via the idempotent :meth:`_ensure_media_player_service`
-        (so a later round-path call recycles this instance), then issues the same
-        cheap, read-only availability probe (``verify_responsive``) the round path
-        would otherwise pay on its first call — caching it so the first real
-        playback isn't the cold one. Any probe failure is swallowed: the round
-        path re-checks availability and surfaces real errors there.
+        (so a later round-path call recycles this instance). For non-Music-
+        Assistant players it then issues ``verify_responsive`` — a *blocking*
+        speaker service call — so the first real playback isn't the cold one,
+        mirroring the round path (``start_round``), which only probes non-MA
+        players. For Music Assistant it deliberately skips the probe: firing a
+        speaker service call in the LOBBY would be a wasted (and potentially
+        wake-on-LAN-triggering) call, and the round path doesn't probe MA
+        either. Any probe failure propagates to the runner, which warns; the
+        round path re-checks availability and surfaces real errors there.
         """
         self._ensure_media_player_service()
         service = self._media_player_service
         if service is None:
             return
+        # #1540 review: match the round path — only non-MA players get the
+        # blocking verify_responsive probe.
+        if self.platform == "music_assistant":
+            return
         probe = getattr(service, "verify_responsive", None)
         if callable(probe):
-            try:
-                await probe()
-            except Exception as err:  # noqa: BLE001 — probe is best-effort only
-                _LOGGER.debug("Media player pre-warm probe failed: %s", err)
+            await probe()
 
     def _prepare_intro_round(self, song: dict) -> bool:
         """Determine if this is an intro round. Delegates to RoundManager."""

--- a/custom_components/beatify/game/state_lifecycle.py
+++ b/custom_components/beatify/game/state_lifecycle.py
@@ -369,7 +369,13 @@ class RoundLifecycleMixin:
         return True
 
     def _ensure_media_player_service(self) -> None:
-        """Create MediaPlayerService lazily on first round."""
+        """Create MediaPlayerService lazily on first round.
+
+        Idempotent: if the service was already built (e.g. by the #1540 LOBBY
+        pre-warm — see :meth:`prewarm_media_player_service`), the
+        ``not self._media_player_service`` guard makes this a no-op, so the
+        round path keeps working unchanged whether or not the pre-warm ran.
+        """
         # Lazy import: only the concrete class for instantiation; type hints
         # use MediaPlayerProtocol (module-level) to keep the import graph acyclic.
         from custom_components.beatify.services.media_player import (  # noqa: PLC0415
@@ -386,6 +392,59 @@ class RoundLifecycleMixin:
             # Connect analytics for error recording (Story 19.1 AC: #2)
             if self._stats_service and hasattr(self._stats_service, "_analytics"):
                 self._media_player_service.set_analytics(self._stats_service._analytics)
+
+    def schedule_media_player_prewarm(self) -> None:
+        """Pre-warm the MediaPlayerService during LOBBY (#1540).
+
+        Follow-up to #803: ``_ensure_media_player_service`` builds the service
+        lazily on the first round, so on a cold Music Assistant start the first
+        round pays the construction + first-call (preflight) latency. This kicks
+        that work off in the background as soon as ``create_game`` has a media
+        player selected, so Round 1 starts without the cold-start lag.
+
+        Best-effort and non-blocking: ``create_game`` MUST NOT wait on this.
+        Requires ``_hass`` (the event loop owner) and a selected media player;
+        otherwise it silently no-ops and the lazy round path stays the fallback.
+        The actual warming runs in :meth:`prewarm_media_player_service`.
+        """
+        if not (self._hass and self.media_player):
+            return
+
+        async def _runner() -> None:
+            try:
+                await self.prewarm_media_player_service()
+            except Exception as err:  # noqa: BLE001 — pre-warm must never raise
+                _LOGGER.debug("Media player pre-warm failed (best-effort): %s", err)
+
+        # Use HA's tracked task helper when available so the warm-up is tied to
+        # the integration's lifecycle; fall back to a bare task otherwise (e.g.
+        # the slimmed-down hass stub used in unit tests).
+        creator = getattr(self._hass, "async_create_background_task", None)
+        if callable(creator):
+            creator(_runner(), name="beatify_media_player_prewarm")
+        else:
+            asyncio.create_task(_runner())  # noqa: RUF006 — fire-and-forget warm-up
+
+    async def prewarm_media_player_service(self) -> None:
+        """Construct + lightly probe the MediaPlayerService ahead of Round 1.
+
+        Builds the service via the idempotent :meth:`_ensure_media_player_service`
+        (so a later round-path call recycles this instance), then issues the same
+        cheap, read-only availability probe (``verify_responsive``) the round path
+        would otherwise pay on its first call — caching it so the first real
+        playback isn't the cold one. Any probe failure is swallowed: the round
+        path re-checks availability and surfaces real errors there.
+        """
+        self._ensure_media_player_service()
+        service = self._media_player_service
+        if service is None:
+            return
+        probe = getattr(service, "verify_responsive", None)
+        if callable(probe):
+            try:
+                await probe()
+            except Exception as err:  # noqa: BLE001 — probe is best-effort only
+                _LOGGER.debug("Media player pre-warm probe failed: %s", err)
 
     def _prepare_intro_round(self, song: dict) -> bool:
         """Determine if this is an intro round. Delegates to RoundManager."""

--- a/custom_components/beatify/game/state_setup.py
+++ b/custom_components/beatify/game/state_setup.py
@@ -292,6 +292,13 @@ class GameSetupMixin:
 
         _LOGGER.info("Game created: %s with %d songs", self.game_id, len(songs))
 
+        # #1540: pre-warm the MediaPlayerService during LOBBY so Round 1 doesn't
+        # pay the construction + cold first-call (preflight) latency that #803
+        # tracked. Fire-and-forget / best-effort — must NOT block create_game.
+        # _ensure_media_player_service() stays the idempotent fallback if this
+        # didn't run (or hasn't finished) by the time the first round starts.
+        self.schedule_media_player_prewarm()
+
         return {
             "game_id": self.game_id,
             "join_url": self.join_url,

--- a/custom_components/beatify/game/state_setup.py
+++ b/custom_components/beatify/game/state_setup.py
@@ -356,6 +356,10 @@ class GameSetupMixin:
         # is still REVEAL there) and trigger the next song after the game ended.
         # advance_to_end() already does this; the HTTP/force-end path lands here.
         self._cancel_auto_advance()
+        # #1540 review: cancel a still-running LOBBY media-player pre-warm so it
+        # can't keep probing the speaker after the game ended (analogous to the
+        # auto-advance cancel above).
+        self._cancel_prewarm()
         # #1358: bump the game-identity epoch synchronously, BEFORE the awaits
         # below (same rationale as the _cancel_auto_advance above). A start_round
         # that's parked in play_song and resumes anytime during this teardown —

--- a/tests/unit/test_media_player_prewarm.py
+++ b/tests/unit/test_media_player_prewarm.py
@@ -1,0 +1,138 @@
+"""Tests for the #1540 LOBBY media-player pre-warm.
+
+Follow-up to #803: ``create_game`` should kick off construction (and a cheap
+availability probe) of the ``MediaPlayerService`` during LOBBY so Round 1 does
+not pay the cold-start construction + first-call latency. The pre-warm must be
+best-effort and non-blocking, and ``_ensure_media_player_service`` must stay the
+idempotent fallback for the round path.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from tests.conftest import make_game_state, make_songs
+
+
+def _closing_background_task(coro, *_args, **_kwargs):
+    """async_create_background_task stub that closes the coro (no event loop)."""
+    coro.close()
+    return MagicMock()
+
+
+def _create_game(state, **kwargs) -> dict:
+    return state.create_game(
+        playlists=["test.json"],
+        songs=make_songs(5),
+        media_player="media_player.test",
+        base_url="http://localhost:8123",
+        **kwargs,
+    )
+
+
+def test_create_game_schedules_prewarm_when_hass_set() -> None:
+    """create_game schedules the pre-warm via hass when a player is selected."""
+    state = make_game_state()
+    hass = MagicMock()
+    hass.async_create_background_task = MagicMock()
+    state.set_hass(hass)
+
+    _create_game(state)
+
+    hass.async_create_background_task.assert_called_once()
+    # The scheduled coroutine is named for the integration lifecycle.
+    _args, kwargs = hass.async_create_background_task.call_args
+    assert kwargs.get("name") == "beatify_media_player_prewarm"
+    # Drain the scheduled coroutine so pytest doesn't warn about it never awaited.
+    coro = hass.async_create_background_task.call_args.args[0]
+    coro.close()
+
+
+def test_create_game_does_not_schedule_without_hass() -> None:
+    """No hass -> no pre-warm scheduled (silent no-op, lazy path remains)."""
+    state = make_game_state()  # _hass is None
+    # Must not raise even though there is no event loop / hass available.
+    result = _create_game(state)
+    assert result["game_id"]
+    assert state._media_player_service is None
+
+
+@pytest.mark.asyncio
+async def test_prewarm_constructs_service_and_probes() -> None:
+    """prewarm_media_player_service builds the service and runs verify_responsive."""
+    state = make_game_state()
+    hass = MagicMock()
+    hass.async_create_background_task = MagicMock(side_effect=_closing_background_task)
+    state.set_hass(hass)
+    _create_game(state)
+    assert state._media_player_service is None  # not yet built
+
+    fake_service = MagicMock()
+    fake_service.verify_responsive = AsyncMock(return_value=(True, ""))
+
+    def _build() -> None:
+        state._media_player_service = fake_service
+
+    state._ensure_media_player_service = MagicMock(side_effect=_build)
+
+    await state.prewarm_media_player_service()
+
+    state._ensure_media_player_service.assert_called_once()
+    fake_service.verify_responsive.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_prewarm_is_idempotent_with_ensure() -> None:
+    """A real round-path _ensure_media_player_service reuses the pre-warmed service."""
+    state = make_game_state()
+    hass = MagicMock()
+    hass.states.get.return_value = None  # verify_responsive bails gracefully
+    hass.async_create_background_task = MagicMock(side_effect=_closing_background_task)
+    state.set_hass(hass)
+    _create_game(state)
+
+    await state.prewarm_media_player_service()
+    warmed = state._media_player_service
+    assert warmed is not None
+
+    # The round path's lazy fallback must NOT rebuild — same instance is kept.
+    state._ensure_media_player_service()
+    assert state._media_player_service is warmed
+
+
+@pytest.mark.asyncio
+async def test_prewarm_swallows_probe_errors() -> None:
+    """A failing probe never propagates out of the pre-warm (best-effort)."""
+    state = make_game_state()
+    hass = MagicMock()
+    hass.async_create_background_task = MagicMock(side_effect=_closing_background_task)
+    state.set_hass(hass)
+    _create_game(state)
+
+    fake_service = MagicMock()
+    fake_service.verify_responsive = AsyncMock(side_effect=RuntimeError("boom"))
+    state._media_player_service = fake_service
+
+    # Should not raise.
+    await state.prewarm_media_player_service()
+    fake_service.verify_responsive.assert_awaited_once()
+
+
+def test_schedule_falls_back_to_create_task_without_helper() -> None:
+    """When hass lacks async_create_background_task, a bare task is used."""
+    state = make_game_state()
+    hass = MagicMock(spec=[])  # no async_create_background_task attr
+    state.set_hass(hass)
+    state.media_player = "media_player.test"
+    state.prewarm_media_player_service = AsyncMock()
+
+    async def _run() -> None:
+        state.schedule_media_player_prewarm()
+        # Let the fire-and-forget task run.
+        await asyncio.sleep(0)
+
+    asyncio.run(_run())
+    state.prewarm_media_player_service.assert_awaited_once()

--- a/tests/unit/test_media_player_prewarm.py
+++ b/tests/unit/test_media_player_prewarm.py
@@ -104,21 +104,112 @@ async def test_prewarm_is_idempotent_with_ensure() -> None:
 
 
 @pytest.mark.asyncio
-async def test_prewarm_swallows_probe_errors() -> None:
-    """A failing probe never propagates out of the pre-warm (best-effort)."""
+async def test_prewarm_runner_swallows_probe_errors_with_warning(caplog) -> None:
+    """#1540 review (Fix 3): a failing probe is caught + warned in the runner.
+
+    The inner best-effort catch was removed; the probe error now propagates out
+    of ``prewarm_media_player_service`` and is swallowed (and logged at WARNING)
+    by the ``_runner`` wrapper in ``schedule_media_player_prewarm``.
+    """
+    state = make_game_state()
+    fake_service = MagicMock()
+    fake_service.verify_responsive = AsyncMock(side_effect=RuntimeError("boom"))
+    state._media_player_service = fake_service
+    state.platform = "sonos"  # non-MA -> probe runs
+
+    # The method itself now propagates (no inner swallow).
+    with pytest.raises(RuntimeError, match="boom"):
+        await state.prewarm_media_player_service()
+
+    # The runner wrapper must swallow it (best-effort) and warn so a permanently
+    # offline speaker is visible.
+    hass = MagicMock(spec=[])  # no async_create_background_task -> bare task path
+    state.set_hass(hass)
+    state.media_player = "media_player.test"
+
+    async def _run() -> None:
+        with caplog.at_level("WARNING"):
+            state.schedule_media_player_prewarm()
+            await asyncio.sleep(0)  # let the fire-and-forget runner execute
+
+    await _run()
+    assert any("pre-warm failed" in r.message for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_prewarm_music_assistant_skips_probe() -> None:
+    """#1540 review (Fix 1): MA players must NOT get the blocking probe.
+
+    verify_responsive is a blocking speaker service call; the round path only
+    issues it for non-MA players. The pre-warm must mirror that so it doesn't
+    fire a speaker service call in the LOBBY for Music Assistant.
+    """
+    state = make_game_state()
+    hass = MagicMock()
+    hass.async_create_background_task = MagicMock(side_effect=_closing_background_task)
+    state.set_hass(hass)
+    _create_game(state, platform="music_assistant")
+
+    fake_service = MagicMock()
+    fake_service.verify_responsive = AsyncMock(return_value=(True, ""))
+    state._media_player_service = fake_service
+
+    await state.prewarm_media_player_service()
+
+    fake_service.verify_responsive.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_prewarm_non_ma_runs_probe() -> None:
+    """#1540 review (Fix 1): non-MA players still get the probe (counterpart)."""
+    state = make_game_state()
+    hass = MagicMock()
+    hass.async_create_background_task = MagicMock(side_effect=_closing_background_task)
+    state.set_hass(hass)
+    _create_game(state, platform="sonos")
+
+    fake_service = MagicMock()
+    fake_service.verify_responsive = AsyncMock(return_value=(True, ""))
+    state._media_player_service = fake_service
+
+    await state.prewarm_media_player_service()
+
+    fake_service.verify_responsive.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_end_game_cancels_running_prewarm() -> None:
+    """#1540 review (Fix 2): end_game cancels a still-running pre-warm task."""
     state = make_game_state()
     hass = MagicMock()
     hass.async_create_background_task = MagicMock(side_effect=_closing_background_task)
     state.set_hass(hass)
     _create_game(state)
 
-    fake_service = MagicMock()
-    fake_service.verify_responsive = AsyncMock(side_effect=RuntimeError("boom"))
-    state._media_player_service = fake_service
+    fake_task = MagicMock()
+    state._prewarm_task = fake_task
 
-    # Should not raise.
-    await state.prewarm_media_player_service()
-    fake_service.verify_responsive.assert_awaited_once()
+    await state.end_game()
+
+    fake_task.cancel.assert_called_once()
+    assert state._prewarm_task is None
+
+
+def test_create_game_cancels_prior_prewarm() -> None:
+    """#1540 review (Fix 2): a new create_game cancels the prior pre-warm task."""
+    state = make_game_state()
+    hass = MagicMock()
+    hass.async_create_background_task = MagicMock(side_effect=_closing_background_task)
+    state.set_hass(hass)
+    _create_game(state)
+
+    stale_task = MagicMock()
+    state._prewarm_task = stale_task
+
+    # A second create_game (e.g. host starts a fresh game) must supersede it.
+    _create_game(state)
+
+    stale_task.cancel.assert_called_once()
 
 
 def test_schedule_falls_back_to_create_task_without_helper() -> None:


### PR DESCRIPTION
Closes #1540

> ⚠️ **AUTO-GENERATED DRAFT** — opened by an automated agent for human review. Do not merge without a maintainer pass.

## Problem
`_ensure_media_player_service()` (in `game/state_lifecycle.py`) builds the `MediaPlayerService` **lazily on the first round**. On a cold Music Assistant start, Round 1 paid the construction + first-call (preflight) latency — the cold-start lag tracked in the now-closed #803.

## Approach
Pre-warm the service during **LOBBY** as soon as `create_game()` has a media player selected (which, after #1526, already nulls the service so the pre-warm rebuilds with the correct selection).

- **`schedule_media_player_prewarm()`** — fire-and-forget, **best-effort, never blocks `create_game`**. No-ops when there's no `_hass` or no selected media player. Uses `hass.async_create_background_task` when available (ties the warm-up to the integration lifecycle), falling back to a bare `asyncio.create_task` otherwise.
- **`prewarm_media_player_service()`** — builds the service via the idempotent `_ensure_media_player_service()` (so the round path recycles the same instance) and issues the same cheap, **read-only** `verify_responsive()` availability probe the round path would otherwise pay cold — caching it so the first real playback isn't the cold one. Any probe error is swallowed.
- **`_ensure_media_player_service()`** stays the idempotent fallback — **no behaviour change** if the pre-warm didn't run (or hasn't finished) by the time the first round starts.

## Tests
New `tests/unit/test_media_player_prewarm.py`:
- `create_game` schedules the pre-warm (named task) when `_hass` + player are set
- no `_hass` → silent no-op, service stays `None`
- pre-warm constructs the service and awaits `verify_responsive`
- pre-warm is idempotent with `_ensure_media_player_service` (same instance reused)
- probe errors are swallowed (best-effort)
- fallback to bare `create_task` when `async_create_background_task` is absent

## Verification
- `pytest tests/unit/` → **1125 passed**
- `ruff@0.15.7 check` → clean; `ruff@0.15.7 format` → no changes

## Caveats / follow-ups
- The issue suggests **measuring** the lag after #1526 before investing — this PR implements the optimization; an actual cold-start timing measurement on real hardware is still worth doing to confirm the win.
- The probe runs once at LOBBY; if the speaker wakes/changes between LOBBY and Round 1 the cached `_preflight_verified` may need re-validation. Current round-path availability checks still run, so correctness is unaffected; revisiting cache invalidation is a possible follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)