### PR TITLE
chore(playlists): tidal backfill wave — +19 uris (2000s Pop, 40s-50s)

### DIFF
--- a/custom_components/beatify/playlists/2000s-pop-anthems.json
+++ b/custom_components/beatify/playlists/2000s-pop-anthems.json
@@ -1,6 +1,6 @@
 {
   "name": "2000s Pop Anthems",
-  "version": "1.12",
+  "version": "1.13",
   "tags": [
     "2000s",
     "pop",
@@ -6938,7 +6938,7 @@
         "it": "applemusic://track/1443760448"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=o_ZBzGlYS6g",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/578434",
       "uri_deezer": "deezer://track/1399345572",
       "fun_fact": "A chart hit by Safri Duo (2021).",
       "fun_fact_de": "Ein Chart-Hit von Safri Duo (2021).",
@@ -6963,7 +6963,7 @@
         "it": "applemusic://track/1584857947"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=w60C081sLtI",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/44814701",
       "uri_deezer": "deezer://track/98981562",
       "fun_fact": "A chart hit by S Club (2015).",
       "fun_fact_de": "Ein Chart-Hit von S Club (2015).",
@@ -6980,7 +6980,7 @@
       "uri_apple_music": null,
       "uri_apple_music_by_region": {},
       "uri_youtube_music": "https://music.youtube.com/watch?v=JhulBGMA7G4",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/1550549",
       "uri_deezer": null,
       "fun_fact": "A chart hit by Daft Punk (2022).",
       "fun_fact_de": "Ein Chart-Hit von Daft Punk (2022).",
@@ -7005,7 +7005,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=QWBMCtIllEM",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/111279010",
       "uri_deezer": "deezer://track/3477676331",
       "fun_fact": "A chart hit by Daddy DJ (2022).",
       "fun_fact_de": "Ein Chart-Hit von Daddy DJ (2022).",
@@ -7030,7 +7030,7 @@
         "it": "applemusic://track/1681137250"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=ogJJoVqfXHY",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/50421567",
       "uri_deezer": "deezer://track/2321097235",
       "fun_fact": "A chart hit by Girls Aloud (2023).",
       "fun_fact_de": "Ein Chart-Hit von Girls Aloud (2023).",
@@ -7055,7 +7055,7 @@
         "it": "applemusic://track/1691419161"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=GEo7W-uJNkc",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/71943313",
       "uri_deezer": "deezer://track/145425722",
       "fun_fact": "A chart hit by Counting Crows (2017).",
       "fun_fact_de": "Ein Chart-Hit von Counting Crows (2017).",
@@ -7080,7 +7080,7 @@
         "it": "applemusic://track/1700327230"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=ey8BvkgO4bk",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/8296025",
       "uri_deezer": "deezer://track/14194027",
       "fun_fact": "A chart hit by Alphabeat (2013).",
       "fun_fact_de": "Ein Chart-Hit von Alphabeat (2013).",
@@ -7105,7 +7105,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=oGDjI40SjrA",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/79783653",
       "uri_deezer": "deezer://track/3305815511",
       "fun_fact": "A chart hit by Alex Gaudino (2025).",
       "fun_fact_de": "Ein Chart-Hit von Alex Gaudino (2025).",
@@ -7130,7 +7130,7 @@
         "it": "applemusic://track/1823040456"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=Kj0wBAtCN5o",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/103536544",
       "uri_deezer": "deezer://track/3432957681",
       "fun_fact": "A chart hit by Akcent (2025).",
       "fun_fact_de": "Ein Chart-Hit von Akcent (2025).",
@@ -7155,7 +7155,7 @@
         "it": "applemusic://track/1269627144"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=WFGhOkCzp2g",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/77267276",
       "uri_deezer": "deezer://track/393003352",
       "fun_fact": "A chart hit by Rednex (2017).",
       "fun_fact_de": "Ein Chart-Hit von Rednex (2017).",
@@ -7180,7 +7180,7 @@
         "it": "applemusic://track/1793821664"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=ChNc3td4YQw",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/415034837",
       "uri_deezer": "deezer://track/3212563591",
       "alt_artists": [
         "BT"

--- a/custom_components/beatify/playlists/40s-50s-classics.json
+++ b/custom_components/beatify/playlists/40s-50s-classics.json
@@ -1,6 +1,6 @@
 {
   "name": "40s & 50s Classics",
-  "version": "1.0",
+  "version": "1.1",
   "tags": [
     "1940s",
     "1950s",
@@ -30,7 +30,7 @@
         "it": "applemusic://track/1434878503"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=pCgyKVxSkuw",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/122089871",
       "uri_deezer": "deezer://track/542807362",
       "fun_fact": "Billie Holiday — one of the most influential jazz singers of all time.",
       "fun_fact_de": "Billie Holiday — eine der einflussreichsten Jazzsängerinnen aller Zeiten.",
@@ -55,7 +55,7 @@
         "it": "applemusic://track/1814188169"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=njCoOSJSDTI",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/122089884",
       "uri_deezer": "deezer://track/593692922",
       "fun_fact": "Billie Holiday — one of the most influential jazz singers of all time.",
       "fun_fact_de": "Billie Holiday — eine der einflussreichsten Jazzsängerinnen aller Zeiten.",
@@ -80,7 +80,7 @@
         "it": "applemusic://track/1837486323"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=KFtI42u88LI",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/99351999",
       "uri_deezer": "deezer://track/541542932",
       "fun_fact": "Billie Holiday — one of the most influential jazz singers of all time.",
       "fun_fact_de": "Billie Holiday — eine der einflussreichsten Jazzsängerinnen aller Zeiten.",
@@ -105,7 +105,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=FArD1hJMmPA",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/99999861",
       "uri_deezer": "deezer://track/62794564",
       "fun_fact": "Billie Holiday — one of the most influential jazz singers of all time.",
       "fun_fact_de": "Billie Holiday — eine der einflussreichsten Jazzsängerinnen aller Zeiten.",
@@ -130,7 +130,7 @@
         "it": "applemusic://track/1760714172"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=nZeyY0NSTW4",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/1308225",
       "uri_deezer": "deezer://track/609537",
       "fun_fact": "A 1940s classic (1949).",
       "fun_fact_de": "Ein 40er-Klassiker (1949).",
@@ -155,7 +155,7 @@
         "it": "applemusic://track/1467439589"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=2kVNTB9dJXQ",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/94445466",
       "uri_deezer": "deezer://track/547739802",
       "fun_fact": "A 1940s classic (1949).",
       "fun_fact_de": "Ein 40er-Klassiker (1949).",
@@ -180,7 +180,7 @@
         "it": "applemusic://track/1467439395"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=Ry_-p-0stx4",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/94445460",
       "uri_deezer": "deezer://track/548862852",
       "fun_fact": "A 1940s classic (1949).",
       "fun_fact_de": "Ein 40er-Klassiker (1949).",
@@ -205,7 +205,7 @@
         "it": "applemusic://track/181567834"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=-91ZKvNiiJc",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/3559045",
       "uri_deezer": "deezer://track/5690691",
       "fun_fact": "A 1940s classic (1949).",
       "fun_fact_de": "Ein 40er-Klassiker (1949).",


### PR DESCRIPTION
Extra Tidal-URI backfill wave (--max 80, on-demand).

## Delta
- **2000s Pop Anthems** — +11 `uri_tidal`, version 1.12 → 1.13
- **40s–50s Classics** — +8 `uri_tidal`, version 1.0 → 1.1

Wave: 19 added · 0 genuine misses · 61 rate-limit skips (Odesli hard-limited today; retried next wave).

🤖 Auto-generated by the tidal-backfill heartbeat job