### PR TITLE
data: fix 3 broken URIs in community/sommerklassiker.json (#1552)

### DIFF
--- a/custom_components/beatify/playlists/community/sommerklassiker.json
+++ b/custom_components/beatify/playlists/community/sommerklassiker.json
@@ -1,6 +1,6 @@
 {
   "name": "Sommerklassiker ☀️",
-  "version": "0.1",
+  "version": "0.2",
   "tags": [
     "summer",
     "pop",
@@ -1258,7 +1258,7 @@
       "certifications": [],
       "awards": [],
       "isrc": "USUM71703825",
-      "uri_apple_music": "applemusic://track/1445038004",
+      "uri_apple_music": "applemusic://track/1447401626",
       "uri_apple_music_by_region": {
         "us": null,
         "de": null,
@@ -1268,7 +1268,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": "https://music.youtube.com/watch?v=kJQP7kiw5Fk",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=72UO0v5ESUo",
       "uri_tidal": null,
       "uri_deezer": "623698182",
       "awards_nl": []
@@ -1748,7 +1748,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": "https://music.youtube.com/watch?v=YRom6y1E8p8",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=vs2PWPgdetc",
       "uri_tidal": null,
       "uri_deezer": "702996922",
       "awards_nl": []


### PR DESCRIPTION
Closes #1552. Replaced 3 wrong URIs and bumped playlist version to 0.2.

## Changes

- **Despacito - Remix (Luis Fonsi, Daddy Yankee, Justin Bieber)**
  - YouTube Music: `kJQP7kiw5Fk` (original without Bieber) → `72UO0v5ESUo` (official audio with Bieber, verified via oEmbed)
  - Apple Music: `1445038004` (Mandarin version ft. JJ Lin, verified via iTunes Lookup) → `1447401626` (Bieber Remix, verified via iTunes Lookup)
- **One Day / Reckoning Song (Wankelmut Remix) [Radio Edit] (Asaf Avidan, The Mojos, Wankelmut)**
  - YouTube Music: `YRom6y1E8p8` (Videoclip Day Version — original) → `vs2PWPgdetc` (Wankelmut Remix Radio Edit, verified via oEmbed)

## Additional note

All 60 Deezer URIs in this playlist are stored as bare numeric IDs (missing `deezer://track/` prefix). This is a pre-existing data quality issue with this playlist — the health checker cannot validate them. Tracked separately; not in scope for this PR.

---
*Automated fix by playlist-health-check — reviewed by AI*