### PR TITLE
chore(playlists): tidal backfill wave — +22 uris (2000s Pop, 40s-50s)

### DIFF
--- a/custom_components/beatify/playlists/2000s-pop-anthems.json
+++ b/custom_components/beatify/playlists/2000s-pop-anthems.json
@@ -1,6 +1,6 @@
 {
   "name": "2000s Pop Anthems",
-  "version": "1.13",
+  "version": "1.14",
   "tags": [
     "2000s",
     "pop",
@@ -6732,7 +6732,7 @@
         "it": "applemusic://track/697335612"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=eKvT8qZ-AyM",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/151842",
       "uri_deezer": "deezer://track/3151534",
       "fun_fact": "A chart hit by Kylie Minogue (2000).",
       "fun_fact_de": "Ein Chart-Hit von Kylie Minogue (2000).",
@@ -6757,7 +6757,7 @@
         "it": "applemusic://track/1646679726"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=hY_LBqmyNrk",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/93614211",
       "uri_deezer": "deezer://track/548876882",
       "alt_artists": [
         "The Original J.B.s"
@@ -6785,7 +6785,7 @@
         "it": "applemusic://track/1440655153"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=pHQvdENN8GM",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/4883270",
       "uri_deezer": "deezer://track/1574660",
       "fun_fact": "A chart hit by Rihanna (2005).",
       "fun_fact_de": "Ein Chart-Hit von Rihanna (2005).",
@@ -6810,7 +6810,7 @@
         "it": "applemusic://track/6768419236"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=mRaQAdynxto",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/37890784",
       "uri_deezer": "deezer://track/2435238",
       "fun_fact": "A chart hit by Black Eyed Peas (2006).",
       "fun_fact_de": "Ein Chart-Hit von Black Eyed Peas (2006).",
@@ -6835,7 +6835,7 @@
         "it": "applemusic://track/1308507633"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=4z-bOdAdias",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/2024984",
       "uri_deezer": "deezer://track/2485118",
       "fun_fact": "A chart hit by Beyoncé (2008).",
       "fun_fact_de": "Ein Chart-Hit von Beyoncé (2008).",
@@ -6860,7 +6860,7 @@
         "it": "applemusic://track/1751609527"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=Qe2pjBYskUU",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/37090641",
       "uri_deezer": "deezer://track/24171441",
       "fun_fact": "A chart hit by Hilary Duff (2005).",
       "fun_fact_de": "Ein Chart-Hit von Hilary Duff (2005).",
@@ -6885,7 +6885,7 @@
         "it": "applemusic://track/1569519431"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=HtGZbWyXhd4",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/566981",
       "uri_deezer": "deezer://track/1161006",
       "alt_artists": [
         "will.i.am"
@@ -6913,7 +6913,7 @@
         "it": "applemusic://track/1250458072"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=lG0nkCy2IrI",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/75330756",
       "uri_deezer": "deezer://track/375141931",
       "fun_fact": "A chart hit by Danzel (2004).",
       "fun_fact_de": "Ein Chart-Hit von Danzel (2004).",

--- a/custom_components/beatify/playlists/40s-50s-classics.json
+++ b/custom_components/beatify/playlists/40s-50s-classics.json
@@ -1,6 +1,6 @@
 {
   "name": "40s & 50s Classics",
-  "version": "1.1",
+  "version": "1.2",
   "tags": [
     "1940s",
     "1950s",
@@ -230,7 +230,7 @@
         "it": "applemusic://track/293997893"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=0nf_bjcYRpI",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/80814490",
       "uri_deezer": "deezer://track/6086891",
       "fun_fact": "A 1950s classic (1950).",
       "fun_fact_de": "Ein 50er-Klassiker (1950).",
@@ -255,7 +255,7 @@
         "it": "applemusic://track/1718643436"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=zbaKVfMIxbk",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/94445479",
       "uri_deezer": "deezer://track/548862752",
       "fun_fact": "A 1950s classic (1951).",
       "fun_fact_de": "Ein 50er-Klassiker (1951).",
@@ -280,7 +280,7 @@
         "it": "applemusic://track/724837720"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=iF7kOq0peAU",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/61134154",
       "uri_deezer": "deezer://track/1444376692",
       "fun_fact": "A 1950s classic (1951).",
       "fun_fact_de": "Ein 50er-Klassiker (1951).",
@@ -305,7 +305,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=l2Q0RsJ5-24",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/640973",
       "uri_deezer": "deezer://track/6084625",
       "fun_fact": "A 1950s classic (1951).",
       "fun_fact_de": "Ein 50er-Klassiker (1951).",
@@ -330,7 +330,7 @@
         "it": "applemusic://track/1872787434"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=HkplpL2P9YM",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/108022897",
       "uri_deezer": "deezer://track/593695402",
       "fun_fact": "Billie Holiday — one of the most influential jazz singers of all time.",
       "fun_fact_de": "Billie Holiday — eine der einflussreichsten Jazzsängerinnen aller Zeiten.",
@@ -355,7 +355,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=96fyS2Wi7tg",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/105363997",
       "uri_deezer": "deezer://track/1557002172",
       "fun_fact": "A 1950s classic (1952).",
       "fun_fact_de": "Ein 50er-Klassiker (1952).",
@@ -380,7 +380,7 @@
         "it": "applemusic://track/1705468065"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=Mc_2sOWVTxI",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/94439290",
       "uri_deezer": "deezer://track/548865992",
       "fun_fact": "A 1950s classic (1952).",
       "fun_fact_de": "Ein 50er-Klassiker (1952).",
@@ -405,7 +405,7 @@
         "it": "applemusic://track/1814189052"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=9t8wwWzbMD0",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/10829232",
       "uri_deezer": "deezer://track/3098857",
       "fun_fact": "A 1950s classic (1952).",
       "fun_fact_de": "Ein 50er-Klassiker (1952).",
@@ -430,7 +430,7 @@
         "it": "applemusic://track/1801287060"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=pam1eUkWfFM",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/138209182",
       "uri_deezer": "deezer://track/427259512",
       "fun_fact": "A 1950s classic (1953).",
       "fun_fact_de": "Ein 50er-Klassiker (1953).",
@@ -455,7 +455,7 @@
         "it": "applemusic://track/1690654597"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=QP2bgZOCDlc",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/35217378",
       "uri_deezer": "deezer://track/3435056",
       "fun_fact": "A 1950s classic (1953).",
       "fun_fact_de": "Ein 50er-Klassiker (1953).",
@@ -480,7 +480,7 @@
         "it": "applemusic://track/1858098728"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=unf2AbrdXh0",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/1383080",
       "uri_deezer": "deezer://track/104622004",
       "fun_fact": "Frank Sinatra — 'Ol' Blue Eyes', the defining voice of the American songbook.",
       "fun_fact_de": "Frank Sinatra — 'Ol' Blue Eyes', die prägende Stimme des American Songbook.",
@@ -1955,7 +1955,7 @@
         "it": "applemusic://track/332735039"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=FD5gE6viJ9g",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/62894578",
       "uri_deezer": "deezer://track/2483163",
       "fun_fact": "A 1950s classic (1957).",
       "fun_fact_de": "Ein 50er-Klassiker (1957).",
@@ -1980,7 +1980,7 @@
         "it": "applemusic://track/217634327"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=A99sV18J0mk",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/515077",
       "uri_deezer": "deezer://track/6596867",
       "fun_fact": "Elvis Presley — the King of Rock'n'Roll, who reshaped popular music in the 50s.",
       "fun_fact_de": "Elvis Presley — der King of Rock'n'Roll, der die Popmusik der 50er neu prägte.",
@@ -2005,7 +2005,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=N9awCYgefCg",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/5119983",
       "uri_deezer": "deezer://track/13210872",
       "fun_fact": "Elvis Presley — the King of Rock'n'Roll, who reshaped popular music in the 50s.",
       "fun_fact_de": "Elvis Presley — der King of Rock'n'Roll, der die Popmusik der 50er neu prägte.",


### PR DESCRIPTION
Scheduled Tidal-URI backfill wave (22:00, --max 80).

## Delta
- **2000s Pop Anthems** — +8 `uri_tidal`, version 1.13 → 1.14
- **40s–50s Classics** — +14 `uri_tidal`, version 1.1 → 1.2

Wave: 22 added · 0 genuine misses · 58 rate-limit skips.

🤖 Auto-generated by the tidal-backfill heartbeat job