### PR TITLE
data(funk-carioca): swap Duelo / Duelo 2 YouTube Music URIs

### DIFF
--- a/custom_components/beatify/playlists/community/funk-carioca.json
+++ b/custom_components/beatify/playlists/community/funk-carioca.json
@@ -1,6 +1,6 @@
 {
   "name": "🌪️ Funk Carioca",
-  "version": "0.1",
+  "version": "0.2",
   "tags": [
     "2000s",
     "funk",
@@ -345,7 +345,7 @@
       },
       "uri_deezer": "deezer://track/1341704242",
       "uri_tidal": null,
-      "uri_youtube_music": "https://music.youtube.com/watch?v=gcOkX_CW1aQ"
+      "uri_youtube_music": "https://music.youtube.com/watch?v=jcrloN9d-UA"
     },
     {
       "year": 2015,
@@ -525,7 +525,7 @@
       },
       "uri_deezer": "deezer://track/1341216712",
       "uri_tidal": null,
-      "uri_youtube_music": "https://music.youtube.com/watch?v=jcrloN9d-UA"
+      "uri_youtube_music": "https://music.youtube.com/watch?v=gcOkX_CW1aQ"
     },
     {
       "year": 2015,


### PR DESCRIPTION
Fixes #1559.

playlist-review found the two Duelo tracks' YouTube Music URIs swapped (each pointing at the other's video). Spotify 20/20 + Deezer 20/20 validated ok, so only the YT URIs were wrong.

- `Duelo - Ao Vivo` → `jcrloN9d-UA` (Duelo videoclipe oficial)
- `Duelo 2 - Ao Vivo` → `gcOkX_CW1aQ` (Duelo 2 Tsunami #24)
- version 0.1 → 0.2

3-line diff, Schema-Gate validates in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)