### PR TITLE
data(iconic-movie-songs): fix Eye of the Tiger + Diamonds release years

### DIFF
--- a/custom_components/beatify/playlists/community/iconic-movie-songs.json
+++ b/custom_components/beatify/playlists/community/iconic-movie-songs.json
@@ -1,6 +1,6 @@
 {
   "name": "ICONIC movie songs 🎬",
-  "version": "0.4",
+  "version": "0.5",
   "tags": [
     "movies",
     "soundtracks",
@@ -94,7 +94,7 @@
       ]
     },
     {
-      "year": 2006,
+      "year": 1982,
       "uri": "spotify:track:2KH16WveTQWT6KOG9Rg6e2",
       "artist": "Survivor",
       "alt_artists": [
@@ -814,7 +814,7 @@
       ]
     },
     {
-      "year": 2010,
+      "year": 1953,
       "uri": "spotify:track:4GKpEXCbrjJRH6K3M5B662",
       "artist": "Marilyn Monroe",
       "alt_artists": [


### PR DESCRIPTION
Closes #1561, closes #1562.

Two in-game year flags (player Moaten) on `community/iconic-movie-songs.json`, both verified as genuine errors (catalogue/reissue dates leaked in):

- **Eye of the Tiger** (Survivor) 2006 → **1982** — single from Rocky III ([Discogs r1253013](https://www.discogs.com/release/1253013), Wikipedia)
- **Diamonds Are a Girl's Best Friend** (Marilyn Monroe) 2010 → **1953** — from Gentlemen Prefer Blondes (1953 film)

Version 0.4 → 0.5. 3-line diff, Schema-Gate validates in CI.

> Note: spot-checking this playlist suggests **more** entries may have too-recent years (e.g. Simple Minds "Don't You Forget About Me" listed 2008 vs 1985; "Pocketful of Sunshine" 2011 vs 2008). A full year-audit of this file is probably warranted — tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)