### PR TITLE
chore(playlists): tidal backfill wave — +19 uris (40s-50s-classics)

### DIFF
--- a/custom_components/beatify/playlists/40s-50s-classics.json
+++ b/custom_components/beatify/playlists/40s-50s-classics.json
@@ -1,6 +1,6 @@
 {
   "name": "40s & 50s Classics",
-  "version": "1.3",
+  "version": "1.4",
   "tags": [
     "1940s",
     "1950s",
@@ -980,7 +980,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=B9j91-18Kb4",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/1323480",
       "uri_deezer": "deezer://track/3982486",
       "fun_fact": "A 1950s classic (1955).",
       "fun_fact_de": "Ein 50er-Klassiker (1955).",
@@ -1005,7 +1005,7 @@
         "it": "applemusic://track/1814190164"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=85-6op3kt_g",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/9216645",
       "uri_deezer": "deezer://track/907897",
       "fun_fact": "A 1950s classic (1955).",
       "fun_fact_de": "Ein 50er-Klassiker (1955).",
@@ -1030,7 +1030,7 @@
         "it": "applemusic://track/394923324"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=boN1TMqmKKk",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/60651680",
       "uri_deezer": "deezer://track/10820776",
       "fun_fact": "A 1950s classic (1956).",
       "fun_fact_de": "Ein 50er-Klassiker (1956).",
@@ -1055,7 +1055,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=mvsYRAc-BWA",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/12319041",
       "uri_deezer": "deezer://track/32959581",
       "fun_fact": "A 1950s classic (1956).",
       "fun_fact_de": "Ein 50er-Klassiker (1956).",
@@ -1080,7 +1080,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=kTZQefSKxKw",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/139954380",
       "uri_deezer": "deezer://track/942970102",
       "fun_fact": "A 1950s classic (1956).",
       "fun_fact_de": "Ein 50er-Klassiker (1956).",
@@ -1105,7 +1105,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=lGfeCe0DHtI",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/74131725",
       "uri_deezer": "deezer://track/1942643",
       "fun_fact": "A 1950s classic (1956).",
       "fun_fact_de": "Ein 50er-Klassiker (1956).",
@@ -1130,7 +1130,7 @@
         "it": "applemusic://track/1757013593"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=WgDzYaVwb_o",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/94445629",
       "uri_deezer": "deezer://track/2268166",
       "fun_fact": "A 1950s classic (1956).",
       "fun_fact_de": "Ein 50er-Klassiker (1956).",
@@ -1155,7 +1155,7 @@
         "it": "applemusic://track/256334189"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=4ZOEfUZzDVE",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/21194636",
       "uri_deezer": "deezer://track/17479889",
       "fun_fact": "Elvis Presley — the King of Rock'n'Roll, who reshaped popular music in the 50s.",
       "fun_fact_de": "Elvis Presley — der King of Rock'n'Roll, der die Popmusik der 50er neu prägte.",
@@ -1180,7 +1180,7 @@
         "it": "applemusic://track/261066721"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=0qz4sTM9XkM",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/21277615",
       "uri_deezer": "deezer://track/6596861",
       "fun_fact": "Elvis Presley — the King of Rock'n'Roll, who reshaped popular music in the 50s.",
       "fun_fact_de": "Elvis Presley — der King of Rock'n'Roll, der die Popmusik der 50er neu prägte.",
@@ -1205,7 +1205,7 @@
         "it": "applemusic://track/217633894"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=LGwO2BaDJQc",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/5119978",
       "uri_deezer": "deezer://track/7675085",
       "fun_fact": "Elvis Presley — the King of Rock'n'Roll, who reshaped popular music in the 50s.",
       "fun_fact_de": "Elvis Presley — der King of Rock'n'Roll, der die Popmusik der 50er neu prägte.",
@@ -1230,7 +1230,7 @@
         "it": "applemusic://track/1443775790"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=IYRJC0_c8Wk",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/63432908",
       "uri_deezer": "deezer://track/3092103",
       "fun_fact": "Fats Domino — a New Orleans piano legend and one of rock'n'roll's first stars.",
       "fun_fact_de": "Fats Domino — eine Piano-Legende aus New Orleans und einer der ersten Rock'n'Roll-Stars.",
@@ -1255,7 +1255,7 @@
         "it": "applemusic://track/1692399749"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=xz5W5bKLj_4",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/1381213",
       "uri_deezer": "deezer://track/3105125",
       "fun_fact": "Frank Sinatra — 'Ol' Blue Eyes', the defining voice of the American songbook.",
       "fun_fact_de": "Frank Sinatra — 'Ol' Blue Eyes', die prägende Stimme des American Songbook.",
@@ -1280,7 +1280,7 @@
         "it": "applemusic://track/1700949009"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=8XuL5xSVL7s",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/1381205",
       "uri_deezer": "deezer://track/3105117",
       "fun_fact": "Frank Sinatra — 'Ol' Blue Eyes', the defining voice of the American songbook.",
       "fun_fact_de": "Frank Sinatra — 'Ol' Blue Eyes', die prägende Stimme des American Songbook.",
@@ -1305,7 +1305,7 @@
         "it": "applemusic://track/1846456726"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=Wi6f5YO6om0",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/1381212",
       "uri_deezer": "deezer://track/3105124",
       "fun_fact": "Frank Sinatra — 'Ol' Blue Eyes', the defining voice of the American songbook.",
       "fun_fact_de": "Frank Sinatra — 'Ol' Blue Eyes', die prägende Stimme des American Songbook.",
@@ -1330,7 +1330,7 @@
         "it": "applemusic://track/689286034"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=KDCSG97anKU",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/84526266",
       "uri_deezer": "deezer://track/3468934",
       "fun_fact": "A 1950s classic (1956).",
       "fun_fact_de": "Ein 50er-Klassiker (1956).",
@@ -1355,7 +1355,7 @@
         "it": "applemusic://track/175547524"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=DYYkJ0kwNss",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/674903",
       "uri_deezer": "deezer://track/546692",
       "fun_fact": "A 1950s classic (1956).",
       "fun_fact_de": "Ein 50er-Klassiker (1956).",
@@ -1380,7 +1380,7 @@
         "it": "applemusic://track/201414524"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=h9xacmsc4Xg",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/1745142",
       "uri_deezer": "deezer://track/585829",
       "fun_fact": "A 1950s classic (1956).",
       "fun_fact_de": "Ein 50er-Klassiker (1956).",
@@ -1405,7 +1405,7 @@
         "it": "applemusic://track/1440936752"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=E68N5E1d0_M",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/80391229",
       "uri_deezer": "deezer://track/422278942",
       "fun_fact": "Little Richard — the flamboyant 'Architect of Rock'n'Roll'.",
       "fun_fact_de": "Little Richard — der extravagante 'Architekt des Rock'n'Roll'.",
@@ -1430,7 +1430,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=g3cp_KqvGI4",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/3049551",
       "uri_deezer": "deezer://track/101753763",
       "fun_fact": "Little Richard — the flamboyant 'Architect of Rock'n'Roll'.",
       "fun_fact_de": "Little Richard — der extravagante 'Architekt des Rock'n'Roll'.",


### PR DESCRIPTION
Automated Tidal-URI backfill wave (18:00).

- **40s-50s-classics** tidal +19, version 1.3→1.4

URI-only change, validated by the Playlist JSON Schema Gate. Wave was Odesli-throttled (script hit the 10-min worker cap); incremental saves captured the 19 hits before cutoff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)