### PR TITLE
ci: run JS vitest suite in CI (#1574)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -114,6 +114,9 @@ jobs:
       - name: Verify min.js bundles match source
         run: npm run build:check
 
+      - name: Run JS unit tests (vitest)
+        run: npm test
+
   # ==========================================================================
   # STAGE 2: TEST
   # ==========================================================================


### PR DESCRIPTION
## Problem
`.github/workflows/test.yml` ran `npm run build:check` in the `frontend-build` job but **never executed the JS test suite**. The 29 Vitest files (346 tests) under `custom_components/beatify/www/js/__tests__/` were never run in CI, so frontend JS regressions could land unblocked.

## What I added
A single step to the existing `frontend-build` job, right after `build:check`:

```yaml
- name: Run JS unit tests (vitest)
  run: npm test
```

It reuses that job's existing Node 22 setup + `npm install`, and runs on PRs to `main`/`develop` like the other checks. `npm test` is `vitest run` (see `package.json`).

## Local verification
- `npm install` + `npm test` → **346 tests passed (29 files)**, all green. The new CI step will not be red.
- `npm run build:check` → still passes (no JS changed).

No version/manifest/docs touched.

Fixes #1574

🤖 Generated with [Claude Code](https://claude.com/claude-code)