### PR TITLE
fix(game): don't strand round when round-end broadcast callback raises (#1575)

### DIFF
--- a/custom_components/beatify/game/state.py
+++ b/custom_components/beatify/game/state.py
@@ -750,6 +750,17 @@ class GameState(
                 _LOGGER.debug("Round_end callback completed successfully")
             except (ConnectionError, OSError, TypeError) as err:
                 _LOGGER.error("Round_end callback failed: %s", err)
+            except Exception:  # noqa: BLE001 — a broadcast error must not strand REVEAL
+                # #1575: any unexpected error in the broadcast callback must not
+                # escape — the round has already transitioned to REVEAL above, so
+                # swallowing it here keeps the game state consistent and avoids a
+                # frozen client. Log with traceback so the failure stays visible.
+                _LOGGER.error(
+                    "Round_end callback raised unexpectedly — REVEAL state may not "
+                    "have been broadcast (round %d)",
+                    self.round,
+                    exc_info=True,
+                )
         else:
             _LOGGER.warning(
                 "No round_end callback set - REVEAL state will not be broadcast!"

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -1503,6 +1503,24 @@ class TestEndRoundResilience:
         assert self.state.phase == GamePhase.REVEAL
         broadcast.assert_awaited_once()
 
+    @pytest.mark.asyncio
+    async def test_end_round_does_not_strand_when_broadcast_raises_arbitrary(self):
+        """#1575: an unexpected exception type from the broadcast callback (one
+        outside the historic ``(ConnectionError, OSError, TypeError)`` tuple)
+        must not escape `_end_round_unlocked`. The round has already
+        transitioned to REVEAL by the time the callback fires, so a raising
+        broadcast must be swallowed + logged rather than stranding the round.
+        """
+        broadcast = AsyncMock(side_effect=RuntimeError("simulated broadcast bug"))
+        self.state.set_round_end_callback(broadcast)
+
+        # Must NOT raise — the arbitrary exception is caught defensively.
+        await self.state.end_round()
+
+        # Phase still transitioned and the callback was actually invoked.
+        assert self.state.phase == GamePhase.REVEAL
+        broadcast.assert_awaited_once()
+
 
 # ---------------------------------------------------------------------------
 # Timer-task self-cancellation (#1029)


### PR DESCRIPTION
## Root cause

`_end_round_unlocked` (in `custom_components/beatify/game/state.py`) invokes the round-end broadcast callback after the round has already transitioned to REVEAL. The callback was wrapped in a narrow `except (ConnectionError, OSError, TypeError)`. Any other exception raised inside the callback escaped `_end_round_unlocked` — and because the REVEAL transition + auto-advance scheduling had already run, the round was left stranded: players saw a frozen state until reconnect, with no broadcast going out.

## Fix

Added a broad `except Exception` (keeping the existing specific connection-error branch) that logs at error level with `exc_info=True` and the round number, so an unexpected error in the broadcast can no longer silently strand the round. Change is minimal and scoped to that one callback. Matches the file's existing `# noqa: BLE001 — <reason>` style used elsewhere in the `game/` package (e.g. `state_auto_advance.py`, `state_lifecycle.py`).

Also added a unit test in `TestEndRoundResilience` proving an arbitrary callback exception (`RuntimeError`, outside the historic tuple) no longer escapes: `end_round()` returns cleanly, phase still reaches REVEAL, and the callback was invoked.

## Tests

- `pytest tests/` — 1150 passed, 2 skipped
- Targeted `-k "state or round or end"` — 339 passed, 1 skipped
- `ruff check` on changed files — clean

Fixes #1575

🤖 Generated with [Claude Code](https://claude.com/claude-code)