### PR TITLE
refactor(game): extract get_playback_uri helper

### DIFF
--- a/custom_components/beatify/game/playlist.py
+++ b/custom_components/beatify/game/playlist.py
@@ -507,6 +507,24 @@ def get_song_uri(
     return None
 
 
+def get_playback_uri(song: dict[str, Any]) -> str | None:
+    """
+    Get the URI a song is currently played back with.
+
+    Prefers the provider-resolved URI (``_resolved_uri``, set once the song
+    has been resolved against the active provider/storefront) and falls back
+    to the song's generic ``uri`` field.
+
+    Args:
+        song: Song dictionary.
+
+    Returns:
+        The resolved playback URI, the generic URI, or None if neither set.
+
+    """
+    return song.get("_resolved_uri") or song.get("uri")
+
+
 def filter_songs_for_provider(
     songs: list[dict[str, Any]],
     provider: str,

--- a/custom_components/beatify/game/serializers.py
+++ b/custom_components/beatify/game/serializers.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any
 
+from .playlist import get_playback_uri
+
 if TYPE_CHECKING:
     from .state import GameState
 
@@ -165,9 +167,7 @@ class GameStateSerializer:
             state["game_performance"] = game_performance
         # Song difficulty rating (Story 15.1 AC1, AC4)
         if gs.current_song:
-            song_uri = gs.current_song.get("_resolved_uri") or gs.current_song.get(
-                "uri"
-            )
+            song_uri = get_playback_uri(gs.current_song)
             if song_uri:
                 difficulty = gs.get_song_difficulty(song_uri)
                 if difficulty:

--- a/custom_components/beatify/game/state.py
+++ b/custom_components/beatify/game/state.py
@@ -43,7 +43,7 @@ from .challenges import (
 from .config import GameStateConfig
 from .highlights import HighlightsTracker
 from .player import PlayerSession
-from .playlist import PlaylistManager
+from .playlist import PlaylistManager, get_playback_uri
 from .player_registry import PlayerRegistry
 from .powerups import PowerUpManager
 from .round_manager import RoundManager
@@ -635,9 +635,7 @@ class GameState(
             # Artist/title are authoritative from playlist data — media player
             # state can report stale/wrong track info (especially Sonos + Spotify).
             if self.current_song:
-                current_uri = self.current_song.get(
-                    "_resolved_uri"
-                ) or self.current_song.get("uri")
+                current_uri = get_playback_uri(self.current_song)
                 if current_uri == uri:
                     self.current_song["album_art"] = metadata.get(
                         "album_art", "/beatify/static/img/no-artwork.svg"

--- a/custom_components/beatify/game/state_lifecycle.py
+++ b/custom_components/beatify/game/state_lifecycle.py
@@ -100,7 +100,7 @@ from custom_components.beatify.const import (
     MIN_PLAYERS,
 )
 
-from .playlist import get_song_uri
+from .playlist import get_playback_uri, get_song_uri
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -241,9 +241,7 @@ class RoundLifecycleMixin:
                 failure_reason = getattr(
                     self._media_player_service, "last_failure_reason", None
                 )
-                self._playlist_manager.mark_played(
-                    song.get("_resolved_uri") or song.get("uri")
-                )
+                self._playlist_manager.mark_played(get_playback_uri(song))
 
                 if failure_reason == "unavailable":
                     _LOGGER.info(

--- a/custom_components/beatify/game/state_scoring.py
+++ b/custom_components/beatify/game/state_scoring.py
@@ -72,6 +72,7 @@ from custom_components.beatify.const import (
     STREAK_MILESTONES,
 )
 
+from .playlist import get_playback_uri
 from .scoring import ScoringService
 
 _LOGGER = logging.getLogger(__name__)
@@ -211,9 +212,7 @@ class RoundScoringMixin:
         # Extended for song statistics (Story 19.7)
         # Wrapped in try/catch to ensure round transition completes even if stats fail
         if self._stats_service and self.current_song:
-            song_uri = self.current_song.get("_resolved_uri") or self.current_song.get(
-                "uri"
-            )
+            song_uri = get_playback_uri(self.current_song)
             if song_uri:
                 try:
                     # Build player results list for song difficulty calculation

--- a/custom_components/beatify/services/media_player.py
+++ b/custom_components/beatify/services/media_player.py
@@ -15,6 +15,8 @@ from urllib.parse import quote
 from homeassistant.exceptions import HomeAssistantError, ServiceNotFound
 from homeassistant.helpers.event import async_track_state_change_event
 
+from custom_components.beatify.game.playlist import get_playback_uri
+
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
 
@@ -432,7 +434,7 @@ class MediaPlayerService:
             True if playback started successfully, False otherwise
 
         """
-        uri = song.get("_resolved_uri") or song.get("uri")
+        uri = get_playback_uri(song)
         if not uri:
             _LOGGER.error(
                 "Song has no URI to play: %s - %s",


### PR DESCRIPTION
Fixes #1591

## What
The expression `song.get("_resolved_uri") or song.get("uri")` was duplicated identically across several modules. This extracts a single helper and replaces every call site — behavior-identical, no logic changes.

## Helper
Added `get_playback_uri(song)` to `custom_components/beatify/game/playlist.py`, right next to the sibling URI helper `get_song_uri`.

**Why there (import-safety):** `playlist.py` is a low-level module that only depends on `const` + stdlib and imports none of the game-state modules. All call sites already sit downstream of it, so importing the helper from `playlist` introduces no circular import. A public name (`get_playback_uri`) matches the module's existing convention (`get_song_uri`, `filter_songs_for_provider`).

## Call sites replaced
- `game/state.py` (~L638) — `current_uri`
- `game/state_lifecycle.py` (~L245) — `mark_played(...)`
- `game/state_scoring.py` (~L214) — `song_uri`
- `game/serializers.py` (~L168) — `song_uri`
- `services/media_player.py` (~L435) — `uri` (5th identical site found by grep; deduped too so zero inline copies remain)

## Verify
- `pytest tests/unit/` → **1149 passed**; targeted run on the touched modules → **342 passed**. Integration tests skip in the local env (require live HA), unchanged.
- `ruff check` clean on all changed files.
- No circular import: full chain imports fine and test collection (which imports every changed module) succeeds.
- `grep '_resolved_uri") or'` → only the helper body remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)