### PR TITLE
feat(playlist): surface rejected songs from validation to the host

### DIFF
--- a/custom_components/beatify/game/playlist.py
+++ b/custom_components/beatify/game/playlist.py
@@ -353,8 +353,29 @@ async def _copy_bundled_playlists(dest_dir: Path) -> None:
             )
 
 
-def validate_playlist(data: dict[str, Any]) -> tuple[bool, list[str]]:
-    """Validate playlist structure. Returns (is_valid, list_of_errors)."""
+def validate_playlist(
+    data: dict[str, Any],
+    *,
+    rejected_songs: list[dict[str, Any]] | None = None,
+) -> tuple[bool, list[str]]:
+    """Validate playlist structure. Returns (is_valid, list_of_errors).
+
+    Args:
+        data: The parsed playlist document.
+        rejected_songs: Optional out-param. When a list is passed, it is
+            populated in place with one structured record per song that has
+            at least one validation problem::
+
+                {"index": 1, "title": "...", "artist": "...",
+                 "reasons": ["year 1500 out of range", "no valid URI"]}
+
+            This lets callers surface *which* tracks dropped and *why* to the
+            host (#1576) instead of the positional ``errors`` strings alone.
+            ``title``/``artist`` are ``None`` when missing. Passing this param
+            never changes which songs/playlists are accepted or rejected — it
+            only makes the existing rejections observable.
+
+    """
     errors: list[str] = []
     max_year = _max_year()
 
@@ -374,22 +395,36 @@ def validate_playlist(data: dict[str, Any]) -> tuple[bool, list[str]]:
     for i, song in enumerate(songs):
         if not isinstance(song, dict):
             errors.append(f"Song {i + 1}: not a valid object")
+            if rejected_songs is not None:
+                rejected_songs.append(
+                    {
+                        "index": i + 1,
+                        "title": None,
+                        "artist": None,
+                        "reasons": ["not a valid object"],
+                    }
+                )
             continue
+
+        # Per-song reasons collected without the "Song N:" prefix so callers
+        # can render them per track. The prefixed variant is appended to the
+        # flat ``errors`` list below to keep the legacy string output identical.
+        song_reasons: list[str] = []
 
         # #697: title and artist are required for gameplay (challenge + reveal).
         title = song.get("title")
         if not isinstance(title, str) or not title.strip():
-            errors.append(f"Song {i + 1}: missing or empty 'title'")
+            song_reasons.append("missing or empty 'title'")
         artist = song.get("artist")
         if not isinstance(artist, str) or not artist.strip():
-            errors.append(f"Song {i + 1}: missing or empty 'artist'")
+            song_reasons.append("missing or empty 'artist'")
 
         # Check year
         year = song.get("year")
         if not isinstance(year, int):
-            errors.append(f"Song {i + 1}: missing or invalid 'year' (must be integer)")
+            song_reasons.append("missing or invalid 'year' (must be integer)")
         elif not (MIN_YEAR <= year <= max_year):
-            errors.append(f"Song {i + 1}: year {year} out of range")
+            song_reasons.append(f"year {year} out of range")
 
         # Check URIs - validate patterns and ensure at least one valid URI exists
         has_valid_uri = False
@@ -399,24 +434,22 @@ def validate_playlist(data: dict[str, Any]) -> tuple[bool, list[str]]:
                 if re.match(pattern, value):
                     has_valid_uri = True
                 else:
-                    errors.append(
-                        f"Song {i + 1}: '{field}' invalid (expected {expected})"
-                    )
+                    song_reasons.append(f"'{field}' invalid (expected {expected})")
 
         # Error if no valid URI found
         if not has_valid_uri:
-            errors.append(f"Song {i + 1}: no valid URI")
+            song_reasons.append("no valid URI")
 
         # Story 20.2: Validate alt_artists if present (optional field)
         alt_artists = song.get("alt_artists")
         if alt_artists is not None:
             if not isinstance(alt_artists, list):
-                errors.append(f"Song {i + 1}: 'alt_artists' must be an array")
+                song_reasons.append("'alt_artists' must be an array")
             else:
                 for j, alt in enumerate(alt_artists):
                     if not isinstance(alt, str) or not alt.strip():
-                        errors.append(
-                            f"Song {i + 1}: 'alt_artists[{j}]' must be non-empty string"
+                        song_reasons.append(
+                            f"'alt_artists[{j}]' must be non-empty string"
                         )
                 # Log warning if fewer than 2 alternatives (weak challenge)
                 valid_alts = [
@@ -429,7 +462,54 @@ def validate_playlist(data: dict[str, Any]) -> tuple[bool, list[str]]:
                         len(valid_alts),
                     )
 
+        # Flush this song's reasons into the flat error list (prefixed, in the
+        # same order as before) and, if requested, into the structured out-param.
+        for reason in song_reasons:
+            errors.append(f"Song {i + 1}: {reason}")
+        if song_reasons and rejected_songs is not None:
+            rejected_songs.append(
+                {
+                    "index": i + 1,
+                    "title": title if isinstance(title, str) else None,
+                    "artist": artist if isinstance(artist, str) else None,
+                    "reasons": song_reasons,
+                }
+            )
+
     return (len(errors) == 0, errors)
+
+
+def summarize_rejected_songs(
+    rejected_songs: list[dict[str, Any]],
+    *,
+    limit: int = 5,
+) -> str:
+    """Render the structured rejections from :func:`validate_playlist`.
+
+    Produces a short, host-readable one-liner such as::
+
+        "Bohemian Rhapsody — Queen (year 1500 out of range); Song #4 (no
+        valid URI); +3 more"
+
+    Used for the INFO load summary (#1576) and the import error response so a
+    host loading a flawed playlist sees *which* tracks dropped and *why*.
+    """
+    parts: list[str] = []
+    for song in rejected_songs[:limit]:
+        title = song.get("title")
+        artist = song.get("artist")
+        if title and artist:
+            label = f"{title} — {artist}"
+        elif title:
+            label = str(title)
+        else:
+            label = f"Song #{song.get('index', '?')}"
+        reasons = ", ".join(song.get("reasons", [])) or "invalid"
+        parts.append(f"{label} ({reasons})")
+    remaining = len(rejected_songs) - limit
+    if remaining > 0:
+        parts.append(f"+{remaining} more")
+    return "; ".join(parts)
 
 
 def get_song_uri(
@@ -593,7 +673,8 @@ async def async_discover_playlists(hass: HomeAssistant) -> list[dict]:
             )
             content = await loop.run_in_executor(None, _read_file, json_file)
             data = json.loads(content)
-            is_valid, errors = validate_playlist(data)
+            rejected_songs: list[dict[str, Any]] = []
+            is_valid, errors = validate_playlist(data, rejected_songs=rejected_songs)
 
             # Count songs per provider (Story 17.1), validating URI patterns (#708).
             songs = data.get("songs", [])
@@ -656,6 +737,10 @@ async def async_discover_playlists(hass: HomeAssistant) -> list[dict]:
                     "amazon_music_count": amazon_music_count,
                     "is_valid": is_valid,
                     "errors": errors,
+                    # #1576: structured per-song rejections so the playlist
+                    # browser can show *which* tracks dropped and why, not just
+                    # the positional "Song N: ..." strings.
+                    "rejected_songs": rejected_songs,
                 }
             )
         except json.JSONDecodeError as e:
@@ -689,6 +774,7 @@ async def async_discover_playlists(hass: HomeAssistant) -> list[dict]:
                     "amazon_music_count": 0,
                     "is_valid": False,
                     "errors": [f"Invalid JSON: {e}"],
+                    "rejected_songs": [],
                 }
             )
 
@@ -718,8 +804,21 @@ async def async_load_and_validate_playlist(
     except json.JSONDecodeError as e:
         return (None, [f"Invalid JSON: {e}"])
 
-    is_valid, errors = validate_playlist(data)
+    rejected_songs: list[dict[str, Any]] = []
+    is_valid, errors = validate_playlist(data, rejected_songs=rejected_songs)
 
     if is_valid:
         return (data, [])
+
+    # #1576: a host loading a flawed playlist used to get zero feedback on
+    # which tracks dropped (per-song problems were DEBUG-only). Log a concise
+    # INFO summary naming the offending songs + reasons so it is visible in
+    # the HA log without flipping the integration to DEBUG.
+    if rejected_songs:
+        _LOGGER.info(
+            "Playlist %s: %d song(s) failed validation: %s",
+            path.name,
+            len(rejected_songs),
+            summarize_rejected_songs(rejected_songs),
+        )
     return (None, errors)

--- a/custom_components/beatify/server/base.py
+++ b/custom_components/beatify/server/base.py
@@ -196,7 +196,13 @@ async def _get_html(hass: HomeAssistant, path: Path) -> str | None:
     return content
 
 
-def _json_error(message: str, status: int, *, code: str = "ERROR") -> web.Response:
+def _json_error(
+    message: str,
+    status: int,
+    *,
+    code: str = "ERROR",
+    details: dict[str, Any] | None = None,
+) -> web.Response:
     """Return a consistent JSON error response.
 
     rc16 (#1097): the body now puts the machine-readable code under
@@ -213,10 +219,16 @@ def _json_error(message: str, status: int, *, code: str = "ERROR") -> web.Respon
 
     The ``error`` key is kept too so anything still reading it from
     older builds doesn't break — drop after a few releases.
+
+    ``details`` (optional) carries extra machine-readable context that the
+    admin UI can render — e.g. the structured per-song rejections from a
+    failed playlist import (#1576). Merged into the body under their own keys
+    so clients ignoring them are unaffected.
     """
-    return web.json_response(
-        {"code": code, "error": code, "message": message}, status=status
-    )
+    body: dict[str, Any] = {"code": code, "error": code, "message": message}
+    if details:
+        body.update(details)
+    return web.json_response(body, status=status)
 
 
 class RateLimitMixin:

--- a/custom_components/beatify/server/playlist_views.py
+++ b/custom_components/beatify/server/playlist_views.py
@@ -9,7 +9,7 @@ import re
 import unicodedata
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from aiohttp import ClientError, web
 from homeassistant.components.http import HomeAssistantView
@@ -17,6 +17,7 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from custom_components.beatify.game.playlist import (
     get_playlist_directory,
+    summarize_rejected_songs,
     validate_playlist,
 )
 from custom_components.beatify.server.base import (
@@ -368,12 +369,25 @@ class SavePlaylistView(RateLimitMixin, HomeAssistantView):
                 f"Too many songs (max {self.MAX_SONGS})", 400, code="TOO_LARGE"
             )
 
-        is_valid, errors = validate_playlist(playlist)
+        rejected_songs: list[dict[str, Any]] = []
+        is_valid, errors = validate_playlist(playlist, rejected_songs=rejected_songs)
         if not is_valid:
+            # #1576: surface *which* tracks dropped and *why* to the host —
+            # both as a human-readable summary in the message and as structured
+            # ``rejected_songs`` the admin UI can render per track.
+            if rejected_songs:
+                _LOGGER.info(
+                    "Playlist import '%s' rejected: %d song(s) failed "
+                    "validation: %s",
+                    playlist.get("name", "?"),
+                    len(rejected_songs),
+                    summarize_rejected_songs(rejected_songs),
+                )
             return _json_error(
                 "Playlist validation failed: " + "; ".join(errors[:5]),
                 400,
                 code="INVALID_PLAYLIST",
+                details={"errors": errors, "rejected_songs": rejected_songs},
             )
 
         slug = _slugify_playlist_name(playlist.get("name", ""))

--- a/custom_components/beatify/server/playlist_views.py
+++ b/custom_components/beatify/server/playlist_views.py
@@ -377,8 +377,7 @@ class SavePlaylistView(RateLimitMixin, HomeAssistantView):
             # ``rejected_songs`` the admin UI can render per track.
             if rejected_songs:
                 _LOGGER.info(
-                    "Playlist import '%s' rejected: %d song(s) failed "
-                    "validation: %s",
+                    "Playlist import '%s' rejected: %d song(s) failed validation: %s",
                     playlist.get("name", "?"),
                     len(rejected_songs),
                     summarize_rejected_songs(rejected_songs),

--- a/tests/unit/test_validate_playlist_rejected_songs.py
+++ b/tests/unit/test_validate_playlist_rejected_songs.py
@@ -1,0 +1,157 @@
+"""Tests for the structured ``rejected_songs`` out-param of ``validate_playlist``
+and the ``summarize_rejected_songs`` renderer (#1576).
+
+The host needs to see *which* tracks dropped and *why* when loading a flawed
+playlist, not just the flat positional ``errors`` strings. These tests pin:
+
+* the structured record shape (``index``/``title``/``artist``/``reasons``),
+* the back-compat guarantee that passing ``rejected_songs`` never changes the
+  ``errors`` list (byte-for-byte identical to the legacy call), and
+* the host-readable one-liner produced by ``summarize_rejected_songs``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from custom_components.beatify.game.playlist import (
+    summarize_rejected_songs,
+    validate_playlist,
+)
+
+VALID_SONG: dict[str, Any] = {
+    "title": "Bohemian Rhapsody",
+    "artist": "Queen",
+    "year": 1975,
+    "uri": "spotify:track:3z8h0TU7ReDPLIbEnYhWZb",
+}
+
+
+def _playlist(*songs: dict[str, Any]) -> dict[str, Any]:
+    return {"name": "Test", "songs": list(songs)}
+
+
+# ---------------------------------------------------------------------------
+# rejected_songs structure
+# ---------------------------------------------------------------------------
+
+
+class TestRejectedSongsStructure:
+    def test_valid_playlist_leaves_rejected_songs_empty(self):
+        rejected: list[dict[str, Any]] = []
+        is_valid, errors = validate_playlist(
+            _playlist(VALID_SONG), rejected_songs=rejected
+        )
+        assert is_valid is True
+        assert errors == []
+        assert rejected == []
+
+    def test_one_record_per_flawed_song_with_index_and_reasons(self):
+        bad = {"title": "X", "artist": "Y", "year": 1500}  # out of range + no URI
+        rejected: list[dict[str, Any]] = []
+        is_valid, _ = validate_playlist(
+            _playlist(VALID_SONG, bad), rejected_songs=rejected
+        )
+        assert is_valid is False
+        assert len(rejected) == 1
+        rec = rejected[0]
+        # 1-based index: the bad song is the 2nd entry.
+        assert rec["index"] == 2
+        assert rec["title"] == "X"
+        assert rec["artist"] == "Y"
+        assert "year 1500 out of range" in rec["reasons"]
+        assert "no valid URI" in rec["reasons"]
+
+    def test_missing_title_and_artist_are_none(self):
+        bad = {"year": 1975, "uri": "spotify:track:3z8h0TU7ReDPLIbEnYhWZb"}
+        rejected: list[dict[str, Any]] = []
+        validate_playlist(_playlist(bad), rejected_songs=rejected)
+        assert len(rejected) == 1
+        assert rejected[0]["title"] is None
+        assert rejected[0]["artist"] is None
+        assert "missing or empty 'title'" in rejected[0]["reasons"]
+        assert "missing or empty 'artist'" in rejected[0]["reasons"]
+
+    def test_non_object_song_records_not_a_valid_object(self):
+        rejected: list[dict[str, Any]] = []
+        validate_playlist(_playlist(VALID_SONG, "oops"), rejected_songs=rejected)
+        assert len(rejected) == 1
+        rec = rejected[0]
+        assert rec["index"] == 2
+        assert rec["title"] is None
+        assert rec["artist"] is None
+        assert rec["reasons"] == ["not a valid object"]
+
+    def test_reasons_omit_the_song_n_prefix(self):
+        bad = {"title": "X", "artist": "Y", "year": 1975}  # no URI only
+        rejected: list[dict[str, Any]] = []
+        validate_playlist(_playlist(bad), rejected_songs=rejected)
+        assert rejected[0]["reasons"] == ["no valid URI"]
+
+
+# ---------------------------------------------------------------------------
+# errors back-compat — the out-param must not change the flat errors list
+# ---------------------------------------------------------------------------
+
+
+class TestErrorsBackCompat:
+    def test_errors_identical_with_and_without_out_param(self):
+        bad = {"title": "X", "year": 1500}  # missing artist + out of range + no URI
+        doc = _playlist(VALID_SONG, bad, "oops")
+
+        _, errors_legacy = validate_playlist(doc)
+        rejected: list[dict[str, Any]] = []
+        _, errors_new = validate_playlist(doc, rejected_songs=rejected)
+
+        # Byte-for-byte identical: passing the out-param only makes the existing
+        # rejections observable, it never alters which strings are produced.
+        assert errors_new == errors_legacy
+        # And the structured view captured the same rejected tracks.
+        assert {r["index"] for r in rejected} == {2, 3}
+
+    def test_validity_verdict_unchanged_by_out_param(self):
+        doc = _playlist(VALID_SONG)
+        assert validate_playlist(doc)[0] == (
+            validate_playlist(doc, rejected_songs=[])[0]
+        )
+
+
+# ---------------------------------------------------------------------------
+# summarize_rejected_songs renderer
+# ---------------------------------------------------------------------------
+
+
+class TestSummarizeRejectedSongs:
+    def test_empty_input_renders_empty_string(self):
+        assert summarize_rejected_songs([]) == ""
+
+    def test_title_artist_label_with_joined_reasons(self):
+        rejected = [
+            {
+                "index": 1,
+                "title": "Bohemian Rhapsody",
+                "artist": "Queen",
+                "reasons": ["year 1500 out of range", "no valid URI"],
+            }
+        ]
+        out = summarize_rejected_songs(rejected)
+        assert out == (
+            "Bohemian Rhapsody — Queen "
+            "(year 1500 out of range, no valid URI)"
+        )
+
+    def test_falls_back_to_song_index_label_when_no_title(self):
+        rejected = [
+            {"index": 4, "title": None, "artist": None, "reasons": ["no valid URI"]}
+        ]
+        assert summarize_rejected_songs(rejected) == "Song #4 (no valid URI)"
+
+    def test_truncates_with_plus_n_more(self):
+        rejected = [
+            {"index": i, "title": f"T{i}", "artist": "A", "reasons": ["no valid URI"]}
+            for i in range(1, 9)  # 8 rejected, default limit 5
+        ]
+        out = summarize_rejected_songs(rejected)
+        assert out.endswith("+3 more")
+        # Only the first `limit` labelled entries appear before the suffix.
+        assert out.count(" — A (") == 5

--- a/tests/unit/test_validate_playlist_rejected_songs.py
+++ b/tests/unit/test_validate_playlist_rejected_songs.py
@@ -111,8 +111,8 @@ class TestErrorsBackCompat:
 
     def test_validity_verdict_unchanged_by_out_param(self):
         doc = _playlist(VALID_SONG)
-        assert validate_playlist(doc)[0] == (
-            validate_playlist(doc, rejected_songs=[])[0]
+        assert (
+            validate_playlist(doc)[0] == (validate_playlist(doc, rejected_songs=[])[0])
         )
 
 
@@ -136,8 +136,7 @@ class TestSummarizeRejectedSongs:
         ]
         out = summarize_rejected_songs(rejected)
         assert out == (
-            "Bohemian Rhapsody — Queen "
-            "(year 1500 out of range, no valid URI)"
+            "Bohemian Rhapsody — Queen (year 1500 out of range, no valid URI)"
         )
 
     def test_falls_back_to_song_index_label_when_no_title(self):


### PR DESCRIPTION
Fixes #1576

## Problem
`validate_playlist` in `game/playlist.py` flagged bad songs (invalid/missing year, missing/invalid URI, etc.) only via positional `Song N: ...` strings, and `async_load_and_validate_playlist` logged nothing above DEBUG. A host loading a flawed playlist got **zero feedback** on which tracks dropped and why.

## What this collects
`validate_playlist` gains an optional **`rejected_songs`** out-param. When a list is passed, it is populated in place with one structured record per problematic song:

```json
{"index": 2, "title": "Bad Year", "artist": "B", "reasons": ["year 1500 out of range"]}
```

Behavior-safe: the flat `errors` strings are **byte-for-byte unchanged**, and which songs/playlists are accepted vs. rejected is unchanged — the param only makes the existing rejections observable. Callers that don't pass it are unaffected (2-tuple return unchanged).

## Where it's surfaced
- **Load boundary** (`async_load_and_validate_playlist`): collects rejections and logs an **INFO** summary — `Playlist X: N song(s) failed validation: <title> — <artist> (reason); +K more`. No more need to flip the integration to DEBUG.
- **Import endpoint** (`server/playlist_views.py`): the `INVALID_PLAYLIST` JSON error now carries `errors` + `rejected_songs` in the body (via a new optional `details` param on `_json_error`, non-breaking), plus an INFO log. This is the host-facing import path.
- **Discovery** (`async_discover_playlists`): each playlist result dict gains a `rejected_songs` key alongside the existing `errors`.
- **`summarize_rejected_songs`**: shared host-readable formatter used by both the load summary and the import response.

## Remaining UI work (for the reviewer)
The backend now exposes structured rejections at both load and import boundaries, but **no admin-UI element renders them yet**. The import endpoint returns `rejected_songs` in the error body and the discovery list includes it per playlist — a follow-up can add a "N songs skipped — reasons" panel in the playlist browser / import dialog consuming `data.rejected_songs`. Kept out of this PR to stay reviewable (PWA/admin JS lives in the HA add-on build path).

## Tests
- `pytest tests/ -q -k "playlist or validate or import"` → **140 passed**, 1012 deselected.
- `tests/unit/test_mix_view.py` + `tests/unit/test_playlist_schema.py` → 68 passed.
- Manual sanity check confirms structured records, identical legacy error strings, and intact 2-tuple back-compat.
- `ruff check` clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)