### PR TITLE
fix(game): truncate guesses at ingest boundary

### DIFF
--- a/custom_components/beatify/server/websocket.py
+++ b/custom_components/beatify/server/websocket.py
@@ -12,6 +12,7 @@ from aiohttp import WSCloseCode, WSMsgType, web
 from custom_components.beatify.const import (
     ERR_GAME_NOT_STARTED,
     LOBBY_DISCONNECT_GRACE_PERIOD,
+    MAX_GUESS_LEN,
 )
 from custom_components.beatify.server.serializers import (
     REDACTED_PLACEHOLDER,
@@ -47,6 +48,13 @@ if TYPE_CHECKING:
     from custom_components.beatify.analytics import AnalyticsStorage
 
 _LOGGER = logging.getLogger(__name__)
+
+# Free-text guess fields that must be length-capped at the ingest boundary
+# (#1581). aiohttp accepts WS frames up to 4 MB; an unbounded guess would feed a
+# multi-megabyte string into the O(n*m) Levenshtein DP and freeze the HA event
+# loop. Truncating here — before the message is dispatched, classified, stored,
+# or re-broadcast — keeps any oversized payload from flowing through the backend.
+_GUESS_TEXT_FIELDS = ("title", "artist", "movie")
 
 
 class BeatifyWebSocketHandler:
@@ -242,6 +250,14 @@ class BeatifyWebSocketHandler:
 
         """
         msg_type = data.get("type")
+
+        # Truncate free-text guesses at the ingest boundary (#1581), before the
+        # message is dispatched to a handler, classified, stored, or rebroadcast.
+        for field in _GUESS_TEXT_FIELDS:
+            value = data.get(field)
+            if isinstance(value, str) and len(value) > MAX_GUESS_LEN:
+                data[field] = value[:MAX_GUESS_LEN]
+
         game_state = get_game_state(self.hass)
 
         # Heartbeat ping: answer before the active-game guard so the client

--- a/custom_components/beatify/server/ws_handlers.py
+++ b/custom_components/beatify/server/ws_handlers.py
@@ -45,7 +45,6 @@ from custom_components.beatify.const import (
     ERR_SESSION_NOT_FOUND,
     ERR_SESSION_TAKEOVER,
     ERR_UNAUTHORIZED,
-    MAX_GUESS_LEN,
     YEAR_MAX,
     YEAR_MIN,
 )
@@ -1601,12 +1600,9 @@ async def handle_title_artist_guess(
         title = ""
     if not isinstance(artist, str):
         artist = ""
-    # Cap guess length before it is matched, stored, and re-broadcast (#1362).
-    # aiohttp accepts WS messages up to 4 MB; an unbounded guess would feed a
-    # multi-megabyte string into the O(n*m) Levenshtein DP and freeze the HA
-    # event loop. A real title/artist never approaches MAX_GUESS_LEN.
-    title = title[:MAX_GUESS_LEN]
-    artist = artist[:MAX_GUESS_LEN]
+    # Guess length is capped at the WS ingest boundary (#1581) before dispatch,
+    # so title/artist already fit MAX_GUESS_LEN here. classify_field truncates
+    # again defensively.
 
     guess_time = game_state.current_time()
     result = game_state.submit_title_artist_guess(

--- a/tests/unit/test_ws_title_artist_guess.py
+++ b/tests/unit/test_ws_title_artist_guess.py
@@ -14,6 +14,7 @@ from unittest.mock import AsyncMock, MagicMock
 from custom_components.beatify.const import (
     ARTIST_POINTS,
     DOMAIN,
+    MAX_GUESS_LEN,
     TITLE_POINTS,
 )
 from custom_components.beatify.game.state import GamePhase
@@ -152,5 +153,60 @@ class TestTitleArtistGuessMarksSubmitted:
         assert gs.players["Alice"].submitted is True
         assert gs.players["Bob"].submitted is True
         assert gs.check_all_guesses_complete() is True
+
+        gs._cancel_auto_advance()
+
+
+class TestGuessTruncatedAtIngest:
+    """#1581: oversized guesses must be capped at the WS ingest boundary,
+    before _handle_message dispatches to any guess handler — so a multi-MB
+    string never flows through classification / storage / rebroadcast.
+    """
+
+    async def test_oversized_title_artist_truncated_before_dispatch(self):
+        handler, gs = _make_handler_game()
+        ws = _ws()
+        gs.add_player("Alice", ws)
+        gs.players["Alice"].connected = True
+        await gs.start_round()
+
+        # Capture what the dispatched handler actually receives.
+        received: dict = {}
+
+        async def _spy(_handler, _ws, data, _gs):
+            received["title"] = data["title"]
+            received["artist"] = data["artist"]
+
+        handler._message_handlers["title_artist_guess"] = _spy
+
+        await handler._handle_message(
+            ws,
+            {
+                "type": "title_artist_guess",
+                "title": "x" * (MAX_GUESS_LEN + 5000),
+                "artist": "y" * (MAX_GUESS_LEN + 5000),
+            },
+        )
+
+        # The handler saw the already-truncated values — capping happened at ingest.
+        assert len(received["title"]) == MAX_GUESS_LEN
+        assert len(received["artist"]) == MAX_GUESS_LEN
+
+        gs._cancel_auto_advance()
+
+    async def test_at_cap_guess_passed_through_unchanged(self):
+        handler, gs = _make_handler_game()
+        ws = _ws()
+        gs.add_player("Alice", ws)
+        gs.players["Alice"].connected = True
+        await gs.start_round()
+
+        exact = "z" * MAX_GUESS_LEN
+        data = {"type": "title_artist_guess", "title": exact, "artist": "short"}
+        await handler._handle_message(ws, data)
+
+        # A guess exactly at the cap (and a short one) are left untouched.
+        assert data["title"] == exact
+        assert data["artist"] == "short"
 
         gs._cancel_auto_advance()


### PR DESCRIPTION
Fixes #1581

Truncate free-text guesses (title/artist/movie) to `MAX_GUESS_LEN` at the WS ingest boundary in `_handle_message`, before dispatch/classification/storage/rebroadcast — instead of after parsing inside individual handlers. Removes the now-redundant in-handler truncation in `handle_title_artist_guess`. Adds a regression test proving the handler receives already-truncated values.