### PR TITLE
test: close core-path test gaps (mixins/integration/mypy)

### DIFF
--- a/custom_components/beatify/game/player_registry.py
+++ b/custom_components/beatify/game/player_registry.py
@@ -16,6 +16,8 @@ from ..const import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from aiohttp import web
 
     from .state import GamePhase
@@ -49,7 +51,7 @@ class PlayerRegistry:
         name: str,
         ws: web.WebSocketResponse,
         phase: GamePhase,
-        average_score_fn: callable,
+        average_score_fn: Callable[[], int],
     ) -> tuple[bool, str | None]:
         """
         Add a player to the game.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ files = [
     "custom_components/beatify/game/protocols.py",
     "custom_components/beatify/game/powerups.py",
     "custom_components/beatify/game/playlist.py",
+    "custom_components/beatify/game/player_registry.py",
     "custom_components/beatify/game/player.py",
     "custom_components/beatify/game/highlights.py",
     "custom_components/beatify/game/config.py",
@@ -80,8 +81,10 @@ files = [
 #   game/scoring.py         (~13 errors: Optional year math, sort/key Optionals)
 #   game/serializers.py     (~3 errors: GameState.language attr, sort key)
 #   game/round_manager.py   (~2 errors: Awaitable vs Coroutine in create_task)
-#   game/player_registry.py (~2 errors: bare `callable` used as a type)
 #   services/stats.py       (~2 errors: Optional dict passed to _format_song)
+#
+# Fixed & promoted into the gate:
+#   game/player_registry.py (#1587 — bare `callable` annotation → Callable[[], int])
 #
 # Next strictness steps once the above are clean:
 #   1. Replace `files` with whole-package check of game/ + services/.

--- a/tests/integration/test_round_flow.py
+++ b/tests/integration/test_round_flow.py
@@ -1,0 +1,183 @@
+"""End-to-end integration: a full scored round through the GameState machine.
+
+Issue #1587: ``tests/integration/`` held only ``test_placeholder.py`` (skipped
+WebSocket stubs from #197). The most load-bearing untested path is the *round
+lifecycle* — the seam where the #1271 mixins cooperate: ``GameSetupMixin``
+(create), ``PlayerLifecycleMixin`` (join), ``RoundLifecycleMixin``
+(start_game), ``RoundScoringMixin`` + ``ScoringService`` (end_round scoring),
+and ``LeaderboardMixin`` (ranking). ``test_state.py`` exercises only the
+*resilience* of ``end_round`` (one player throwing); it never asserts the
+**happy-path scoring outcome** of a real round driven through the public API.
+
+These tests drive ``GameState`` exactly as the WebSocket layer would —
+create → join → start → submit → end_round — and assert the resulting scores,
+phase transition, and leaderboard (including rank movement across rounds). No
+running Home Assistant instance is required: the root ``conftest.py`` HA stubs
+plus the pure ``ScoringService`` make the flow fully deterministic.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.beatify.game.state import GamePhase
+from tests.conftest import make_game_state, make_songs
+
+
+def _create_fresh_game(state) -> None:
+    state.create_game(
+        playlists=["test.json"],
+        songs=make_songs(5),
+        media_player="media_player.test",
+        base_url="http://localhost:8123",
+    )
+
+
+def _begin_round(state, *, year: int) -> None:
+    """Put the machine into a scorable PLAYING round for ``year``.
+
+    Mirrors what ``start_round`` establishes once the media player is up:
+    a ``current_song`` with the correct year, a round-start clock, and the
+    PLAYING phase. We set it directly to keep the test off the HA media path.
+    """
+    state.current_song = {"title": "Test Song", "artist": "Test Artist", "year": year}
+    state.round_start_time = state._now()
+    state.phase = GamePhase.PLAYING
+
+
+def _setup_started_game(*names: str):
+    """Create a game, join ``names``, and start it — returns the GameState."""
+    state = make_game_state()
+    _create_fresh_game(state)
+    for name in names:
+        state.add_player(name, MagicMock())
+    started, _ = state.start_game()
+    assert started is True
+    return state
+
+
+# ---------------------------------------------------------------------------
+# Single scored round — the core happy path
+# ---------------------------------------------------------------------------
+
+
+class TestSingleRoundScoring:
+    @pytest.mark.asyncio
+    async def test_exact_beats_near_beats_miss(self):
+        """A full round: exact guess > near guess > far miss, and the phase
+        transitions to REVEAL with the broadcast callback fired exactly once.
+        """
+        state = _setup_started_game("Alice", "Bob", "Carol")
+        broadcast = MagicMock()
+
+        async def _broadcast() -> None:
+            broadcast()
+
+        state.set_round_end_callback(_broadcast)
+
+        _begin_round(state, year=1990)
+        state.players["Alice"].submit_guess(1990, state._now())  # exact
+        state.players["Bob"].submit_guess(1985, state._now())  # 5 off
+        state.players["Carol"].submit_guess(2010, state._now())  # 20 off
+
+        await state.end_round()
+
+        # Phase transitioned and the UI was notified once.
+        assert state.phase == GamePhase.REVEAL
+        broadcast.assert_called_once()
+
+        # Strict scoring order: exact > near > far.
+        alice = state.players["Alice"]
+        bob = state.players["Bob"]
+        carol = state.players["Carol"]
+        assert alice.years_off == 0
+        assert bob.years_off == 5
+        assert carol.years_off == 20
+        assert alice.score > bob.score >= carol.score
+        assert alice.score > 0
+
+    @pytest.mark.asyncio
+    async def test_non_submitter_scores_zero_and_is_marked_missed(self):
+        """A player who never submits earns nothing and is recorded as a miss
+        in the shareable round_results card (#120)."""
+        state = _setup_started_game("Alice", "Bob")
+        _begin_round(state, year=2000)
+        state.players["Alice"].submit_guess(2000, state._now())
+        # Bob stays silent.
+
+        await state.end_round()
+
+        bob = state.players["Bob"]
+        assert bob.submitted is False
+        assert bob.score == 0
+        assert bob.round_results[-1] == "missed"
+        assert state.players["Alice"].round_results[-1] == "exact"
+
+
+# ---------------------------------------------------------------------------
+# Multi-round flow — score accumulation + leaderboard rank movement
+# ---------------------------------------------------------------------------
+
+
+class TestMultiRoundLeaderboard:
+    @pytest.mark.asyncio
+    async def test_scores_accumulate_and_ranks_move_across_rounds(self):
+        """Two rounds with a lead change: scores accumulate and the leaderboard
+        reports the rank movement (previous_rank -> rank_change) from round 1.
+        """
+        state = _setup_started_game("Alice", "Bob")
+
+        # Round 1: Bob nails it, Alice is far off -> Bob leads.
+        _begin_round(state, year=1990)
+        state._store_previous_ranks()
+        state.players["Bob"].submit_guess(1990, state._now())
+        state.players["Alice"].submit_guess(1950, state._now())
+        await state.end_round()
+
+        round1 = {e["name"]: e for e in state.get_leaderboard()}
+        assert round1["Bob"]["rank"] == 1
+        assert round1["Alice"]["rank"] == 2
+        bob_r1 = state.players["Bob"].score
+
+        # Round 2: Alice nails it (Bob far off). Her exact guess earns the same
+        # as Bob's round-1 exact, so the two pull level on cumulative score.
+        for player in state.players.values():
+            player.reset_round()
+        _begin_round(state, year=2000)
+        state._store_previous_ranks()  # snapshot: Bob 1st, Alice 2nd
+        state.players["Alice"].submit_guess(2000, state._now())
+        state.players["Bob"].submit_guess(1900, state._now())
+        await state.end_round()
+
+        # Cumulative: scores are summed across rounds, not replaced.
+        assert state.players["Bob"].score == bob_r1  # round-2 far miss added 0
+        assert state.players["Alice"].score == bob_r1  # round-2 exact == Bob's r1
+
+        # Movement reflects the round-1 ranks as the baseline snapshot.
+        final = {e["name"]: e for e in state.get_leaderboard()}
+        # Now level on score -> both share rank 1 (tie-break by name keeps order).
+        assert final["Alice"]["rank"] == 1
+        assert final["Bob"]["rank"] == 1
+        # Alice climbed from her round-1 rank 2 into the shared lead (+1).
+        assert final["Alice"]["rank_change"] == 1
+        assert final["Bob"]["rank_change"] == 0
+
+    @pytest.mark.asyncio
+    async def test_final_leaderboard_reflects_played_game(self):
+        """After a played round the final leaderboard carries the end-of-game
+        stat block and ranks players by their accumulated score."""
+        state = _setup_started_game("Alice", "Bob")
+        _begin_round(state, year=1990)
+        state.players["Alice"].submit_guess(1990, state._now())
+        state.players["Bob"].submit_guess(1995, state._now())
+        await state.end_round()
+
+        board = state.get_final_leaderboard()
+
+        assert [e["name"] for e in board] == ["Alice", "Bob"]
+        assert board[0]["rank"] == 1
+        # Final stat block keys are present for every entry.
+        for entry in board:
+            assert {"best_streak", "rounds_played", "bets_won"} <= entry.keys()

--- a/tests/unit/test_state_leaderboard.py
+++ b/tests/unit/test_state_leaderboard.py
@@ -1,0 +1,254 @@
+"""Focused unit tests for the LeaderboardMixin (#1587).
+
+The leaderboard / ranking cluster was extracted into ``LeaderboardMixin``
+(``game/state_leaderboard.py``) by the #1271 mixin refactor. ``test_state.py``
+covers only the ``get_leaderboard`` happy path (sort order + tie ranks). The
+rank-*movement* logic (``previous_rank`` → ``rank_change``), the
+``_store_previous_ranks`` snapshot pass, and ``get_final_leaderboard``'s
+end-of-game stat block (``best_streak`` / ``rounds_played`` / ``bets_won``)
+had no dedicated tests. This module closes that gap.
+
+All tests drive the mixin through a real ``GameState`` instance (the host
+class) so the assertions exercise the actual inheritance wiring, not a
+stand-in.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from tests.conftest import make_game_state
+
+
+def _create_fresh_game(state) -> None:
+    """Create a minimal game so the registry/round subsystems are wired up."""
+    state.create_game(
+        playlists=["test.json"],
+        songs=[
+            {
+                "year": 1990,
+                "title": "Song",
+                "artist": "Artist",
+                "_resolved_uri": "spotify:track:x",
+                "uri": "spotify:track:x",
+            }
+        ],
+        media_player="media_player.test",
+        base_url="http://localhost:8123",
+    )
+
+
+def _add(state, name: str, score: int = 0, **attrs) -> None:
+    """Add a player and force-set leaderboard-relevant attributes."""
+    state.add_player(name, MagicMock())
+    player = state.players[name]
+    player.score = score
+    for key, value in attrs.items():
+        setattr(player, key, value)
+
+
+# ---------------------------------------------------------------------------
+# _store_previous_ranks — snapshot pass before scoring
+# ---------------------------------------------------------------------------
+
+
+class TestStorePreviousRanks:
+    def setup_method(self):
+        self.state = make_game_state()
+        _create_fresh_game(self.state)
+
+    def test_stamps_each_player_with_current_rank(self):
+        _add(self.state, "Alice", score=100)
+        _add(self.state, "Bob", score=50)
+        _add(self.state, "Carol", score=10)
+
+        self.state._store_previous_ranks()
+
+        assert self.state.players["Alice"].previous_rank == 1
+        assert self.state.players["Bob"].previous_rank == 2
+        assert self.state.players["Carol"].previous_rank == 3
+
+    def test_tied_players_share_previous_rank_and_skip(self):
+        # scores [100, 80, 80, 50] -> ranks [1, 2, 2, 4]
+        _add(self.state, "Alice", score=100)
+        _add(self.state, "Bob", score=80)
+        _add(self.state, "Carol", score=80)
+        _add(self.state, "Dave", score=50)
+
+        self.state._store_previous_ranks()
+
+        ranks = {n: p.previous_rank for n, p in self.state.players.items()}
+        assert ranks == {"Alice": 1, "Bob": 2, "Carol": 2, "Dave": 4}
+
+    def test_overwrites_stale_previous_rank(self):
+        _add(self.state, "Alice", score=10, previous_rank=99)
+        _add(self.state, "Bob", score=20, previous_rank=99)
+
+        self.state._store_previous_ranks()
+
+        # Bob leads now; both stale 99s replaced with the fresh snapshot.
+        assert self.state.players["Bob"].previous_rank == 1
+        assert self.state.players["Alice"].previous_rank == 2
+
+
+# ---------------------------------------------------------------------------
+# get_leaderboard — rank_change movement (previous_rank -> rank_change)
+# ---------------------------------------------------------------------------
+
+
+class TestLeaderboardRankChange:
+    def setup_method(self):
+        self.state = make_game_state()
+        _create_fresh_game(self.state)
+
+    def test_no_previous_rank_yields_zero_change(self):
+        # Fresh players have previous_rank=None -> rank_change must stay 0.
+        _add(self.state, "Alice", score=50)
+        _add(self.state, "Bob", score=30)
+
+        lb = {e["name"]: e["rank_change"] for e in self.state.get_leaderboard()}
+
+        assert lb == {"Alice": 0, "Bob": 0}
+
+    def test_positive_change_when_moving_up(self):
+        # Alice was 3rd, now 1st -> rank_change = 3 - 1 = +2 (moved up).
+        _add(self.state, "Alice", score=100, previous_rank=3)
+        _add(self.state, "Bob", score=50, previous_rank=1)
+        _add(self.state, "Carol", score=10, previous_rank=2)
+
+        lb = {e["name"]: e["rank_change"] for e in self.state.get_leaderboard()}
+
+        assert lb["Alice"] == 2  # 3 -> 1
+        assert lb["Bob"] == -1  # 1 -> 2
+        assert lb["Carol"] == -1  # 2 -> 3
+
+    def test_no_movement_yields_zero(self):
+        _add(self.state, "Alice", score=100, previous_rank=1)
+        _add(self.state, "Bob", score=50, previous_rank=2)
+
+        lb = {e["name"]: e["rank_change"] for e in self.state.get_leaderboard()}
+
+        assert lb["Alice"] == 0
+        assert lb["Bob"] == 0
+
+    def test_round_trip_store_then_score_then_change(self):
+        """End-to-end: snapshot ranks, mutate scores, then read movement."""
+        _add(self.state, "Alice", score=10)
+        _add(self.state, "Bob", score=20)
+        _add(self.state, "Carol", score=30)
+
+        # Snapshot: Carol 1st, Bob 2nd, Alice 3rd.
+        self.state._store_previous_ranks()
+
+        # Alice surges to the top, Carol drops to the bottom.
+        self.state.players["Alice"].score = 100
+        self.state.players["Carol"].score = 5
+
+        lb = {e["name"]: e for e in self.state.get_leaderboard()}
+
+        assert lb["Alice"]["rank"] == 1
+        assert lb["Alice"]["rank_change"] == 2  # 3 -> 1
+        assert lb["Bob"]["rank"] == 2
+        assert lb["Bob"]["rank_change"] == 0  # 2 -> 2
+        assert lb["Carol"]["rank"] == 3
+        assert lb["Carol"]["rank_change"] == -2  # 1 -> 3
+
+
+# ---------------------------------------------------------------------------
+# get_leaderboard — payload shape & deterministic tie-break ordering
+# ---------------------------------------------------------------------------
+
+
+class TestLeaderboardPayload:
+    def setup_method(self):
+        self.state = make_game_state()
+        _create_fresh_game(self.state)
+
+    def test_entry_carries_live_fields(self):
+        _add(
+            self.state,
+            "Alice",
+            score=42,
+            streak=3,
+            is_admin=True,
+            connected=False,
+        )
+
+        (entry,) = self.state.get_leaderboard()
+
+        assert entry["name"] == "Alice"
+        assert entry["score"] == 42
+        assert entry["streak"] == 3
+        assert entry["is_admin"] is True
+        assert entry["connected"] is False
+
+    def test_ties_break_by_name_for_stable_display(self):
+        # Equal scores -> alphabetical name order, equal rank.
+        _add(self.state, "Charlie", score=50)
+        _add(self.state, "Alice", score=50)
+        _add(self.state, "Bob", score=50)
+
+        order = [e["name"] for e in self.state.get_leaderboard()]
+        ranks = {e["name"]: e["rank"] for e in self.state.get_leaderboard()}
+
+        assert order == ["Alice", "Bob", "Charlie"]
+        assert ranks == {"Alice": 1, "Bob": 1, "Charlie": 1}
+
+
+# ---------------------------------------------------------------------------
+# get_final_leaderboard — end-of-game stat block (Story 5.6)
+# ---------------------------------------------------------------------------
+
+
+class TestFinalLeaderboard:
+    def setup_method(self):
+        self.state = make_game_state()
+        _create_fresh_game(self.state)
+
+    def test_includes_cumulative_final_stats(self):
+        _add(
+            self.state,
+            "Alice",
+            score=120,
+            best_streak=5,
+            rounds_played=8,
+            bets_won=2,
+            is_admin=True,
+            connected=True,
+        )
+
+        (entry,) = self.state.get_final_leaderboard()
+
+        assert entry["rank"] == 1
+        assert entry["name"] == "Alice"
+        assert entry["score"] == 120
+        assert entry["best_streak"] == 5
+        assert entry["rounds_played"] == 8
+        assert entry["bets_won"] == 2
+        assert entry["is_admin"] is True
+        assert entry["connected"] is True
+
+    def test_final_omits_live_only_fields(self):
+        # streak / rank_change are live-leaderboard concepts; the final board
+        # carries the end-of-game stat block instead.
+        _add(self.state, "Alice", score=10, streak=4)
+
+        (entry,) = self.state.get_final_leaderboard()
+
+        assert "streak" not in entry
+        assert "rank_change" not in entry
+        assert "best_streak" in entry
+
+    def test_sorted_with_tie_rank_skip(self):
+        # scores [90, 90, 40] -> ranks [1, 1, 3]
+        _add(self.state, "Bob", score=90)
+        _add(self.state, "Alice", score=90)
+        _add(self.state, "Carol", score=40)
+
+        board = self.state.get_final_leaderboard()
+
+        assert [e["name"] for e in board] == ["Alice", "Bob", "Carol"]
+        assert [e["rank"] for e in board] == [1, 1, 3]
+
+    def test_empty_game_returns_empty_list(self):
+        assert self.state.get_final_leaderboard() == []


### PR DESCRIPTION
Fixes #1587

**Highest-value slice** of the three named gap buckets (depth over breadth):

**mypy excludes** — fixed the bare `callable` type-hole in `game/player_registry.py` (`average_score_fn: callable` → `Callable[[], int]`, a genuine `[valid-type]`/`[misc]` error pair) and promoted the module into the mypy gate. Gate now type-checks 16 files, green.

**Untested mixin** — new `tests/unit/test_state_leaderboard.py`: focused unit tests for `LeaderboardMixin` (#1271 extraction). `test_state.py` covered only `get_leaderboard` sort/tie basics; these add the untested **rank-movement** logic (`previous_rank` → `rank_change`), the `_store_previous_ranks` snapshot pass, and `get_final_leaderboard`'s end-of-game stat block (`best_streak`/`rounds_played`/`bets_won`).

**Placeholder integration** — new `tests/integration/test_round_flow.py`: drives a real scored round through the `GameState` machine (create → join → start → submit → `end_round`) and asserts the happy-path scoring outcome, REVEAL transition, broadcast, and multi-round leaderboard rank movement. Previously only the `end_round` *resilience* path (one player throwing) was tested — never the happy-path result.

**Results:** 17 new tests, all green. `ruff check .` + `ruff format --check .` + `mypy` clean over the whole repo.

**Intentionally deferred:** the other 5 mypy-excluded modules (`state.py`, `scoring.py`, `serializers.py`, `round_manager.py`, `services/stats.py`) still carry real type errors per the #1275 ramp-up plan; `test_placeholder.py`'s WebSocket-layer stubs (#197) still need a live HA harness; the remaining ~13 mixins beyond Leaderboard are still only covered indirectly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)