### PR TITLE
fix(assets): make the asset-fingerprint cache thread-safe

### DIFF
--- a/custom_components/beatify/server/base.py
+++ b/custom_components/beatify/server/base.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import logging
+import threading
 import time
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -81,6 +82,10 @@ _ASSET_SUBDIRS = ("css", "js", "i18n")
 # burst of player.html loads at game start doesn't re-walk per request.
 _ASSET_FP_TTL_NS = 5 * 1_000_000_000  # 5s
 _ASSET_FP_CACHE: tuple[int, str] | None = None  # (monotonic_ns, fingerprint)
+# Guards _ASSET_FP_CACHE: it's read/written from both the event loop and HA
+# executor threads, so concurrent first-access could otherwise race and recompute
+# the fingerprint twice (#1592). Double-checked inside the lock below.
+_ASSET_FP_LOCK = threading.Lock()
 
 
 def _compute_asset_fingerprint(www_dir: Path) -> str:
@@ -119,11 +124,20 @@ def _get_asset_version(version: str, www_dir: Path) -> str:
     """
     global _ASSET_FP_CACHE  # noqa: PLW0603
     now = time.monotonic_ns()
-    if _ASSET_FP_CACHE is not None and now - _ASSET_FP_CACHE[0] < _ASSET_FP_TTL_NS:
-        fingerprint = _ASSET_FP_CACHE[1]
-    else:
-        fingerprint = _compute_asset_fingerprint(www_dir)
-        _ASSET_FP_CACHE = (now, fingerprint)
+    # Fast path: a fresh cache entry needs no lock (tuple reads are atomic).
+    cache = _ASSET_FP_CACHE
+    if cache is not None and now - cache[0] < _ASSET_FP_TTL_NS:
+        return f"{version}-{cache[1]}"
+    # Slow path: serialize recompute so concurrent first-access (event loop +
+    # executor threads) hashes once, not once-per-thread (#1592). Re-check the
+    # cache inside the lock — another thread may have just populated it.
+    with _ASSET_FP_LOCK:
+        cache = _ASSET_FP_CACHE
+        if cache is not None and now - cache[0] < _ASSET_FP_TTL_NS:
+            fingerprint = cache[1]
+        else:
+            fingerprint = _compute_asset_fingerprint(www_dir)
+            _ASSET_FP_CACHE = (time.monotonic_ns(), fingerprint)
     return f"{version}-{fingerprint}"
 
 

--- a/tests/unit/test_asset_cachebuster.py
+++ b/tests/unit/test_asset_cachebuster.py
@@ -9,6 +9,7 @@ identical, so browsers / the service worker kept serving stale assets.
 from __future__ import annotations
 
 import re
+import threading
 from pathlib import Path
 
 import pytest
@@ -114,6 +115,52 @@ class TestAssetVersion:
     def test_apply_cache_tokens_passthrough_without_tokens(self) -> None:
         hass = _FakeHass("9.9.9")
         assert _apply_cache_tokens("no tokens here", hass) == "no tokens here"
+
+
+class TestAssetVersionThreadSafety:
+    """The fingerprint cache is read/written from the event loop AND HA
+    executor threads, so concurrent first-access must not race (#1592)."""
+
+    def setup_method(self) -> None:
+        base._ASSET_FP_CACHE = None
+
+    def test_concurrent_first_access_yields_one_consistent_fingerprint(
+        self, tmp_path
+    ) -> None:
+        _write(tmp_path, "css", "styles.css", "a {}")
+        _write(tmp_path, "js", "admin.js", "x")
+
+        n = 16
+        barrier = threading.Barrier(n)
+        results: list[str] = []
+        errors: list[BaseException] = []
+        lock = threading.Lock()
+
+        def worker() -> None:
+            try:
+                # Line all threads up so they hit the empty cache together.
+                barrier.wait()
+                av = _get_asset_version("9.9.9", tmp_path)
+            except BaseException as exc:  # noqa: BLE001 — surface any race crash
+                with lock:
+                    errors.append(exc)
+            else:
+                with lock:
+                    results.append(av)
+
+        threads = [threading.Thread(target=worker) for _ in range(n)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors, f"concurrent access raised: {errors}"
+        assert len(results) == n
+        # All threads must observe one identical fingerprint.
+        assert len(set(results)) == 1, results
+        assert results[0].startswith("9.9.9-")
+        # And the cache ends up populated exactly once.
+        assert base._ASSET_FP_CACHE is not None
 
 
 class TestServedPagesHaveNoUnresolvedTokens:


### PR DESCRIPTION
Fixes #1592

Guards the module-global `_ASSET_FP_CACHE` in `server/base.py` with a `threading.Lock` using a double-checked pattern: a lock-free fast path for a fresh entry, and a re-check inside the lock on the slow path so concurrent first-access (event loop + HA executor threads) hashes the fingerprint once, not once-per-thread. Public signature and lazy-compute semantics are unchanged.

Adds a concurrent-access regression test: 16 threads released from a barrier must observe one identical fingerprint with no exceptions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)