### PR TITLE
chore(playlists): tidal backfill wave 2026-06-26 06:13 — +19 uris

### DIFF
--- a/custom_components/beatify/playlists/40s-50s-classics.json
+++ b/custom_components/beatify/playlists/40s-50s-classics.json
@@ -1,6 +1,6 @@
 {
   "name": "40s & 50s Classics",
-  "version": "1.6",
+  "version": "1.7",
   "tags": [
     "1940s",
     "1950s",
@@ -2030,7 +2030,7 @@
         "it": "applemusic://track/724490494"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=PaPYuUMLFIM",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/90457566",
       "uri_deezer": "deezer://track/3092112",
       "fun_fact": "Fats Domino — a New Orleans piano legend and one of rock'n'roll's first stars.",
       "fun_fact_de": "Fats Domino — eine Piano-Legende aus New Orleans und einer der ersten Rock'n'Roll-Stars.",
@@ -2055,7 +2055,7 @@
         "it": "applemusic://track/403806790"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=3lZ2xjoBoXU",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/320689270",
       "uri_deezer": "deezer://track/116857978",
       "fun_fact": "A 1950s classic (1957).",
       "fun_fact_de": "Ein 50er-Klassiker (1957).",
@@ -2080,7 +2080,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=0VJ1NuAbEBI",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/90456508",
       "uri_deezer": "deezer://track/105121570",
       "fun_fact": "Jerry Lee Lewis — 'The Killer', a wild rock'n'roll piano showman.",
       "fun_fact_de": "Jerry Lee Lewis — 'The Killer', ein wilder Rock'n'Roll-Piano-Showman.",
@@ -2105,7 +2105,7 @@
         "it": "applemusic://track/1890307026"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=FAYEjb2Aqu8",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/15662305",
       "uri_deezer": "deezer://track/101566916",
       "fun_fact": "Jerry Lee Lewis — 'The Killer', a wild rock'n'roll piano showman.",
       "fun_fact_de": "Jerry Lee Lewis — 'The Killer', ein wilder Rock'n'Roll-Piano-Showman.",
@@ -2130,7 +2130,7 @@
         "it": "applemusic://track/201414675"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=llqc9LKcDj0",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/51072795",
       "uri_deezer": "deezer://track/585831",
       "fun_fact": "A 1950s classic (1957).",
       "fun_fact_de": "Ein 50er-Klassiker (1957).",
@@ -2155,7 +2155,7 @@
         "it": "applemusic://track/201414349"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=ILfUKbPPGfE",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/1745141",
       "uri_deezer": "deezer://track/585828",
       "fun_fact": "A 1950s classic (1957).",
       "fun_fact_de": "Ein 50er-Klassiker (1957).",
@@ -2180,7 +2180,7 @@
         "it": "applemusic://track/1432874900"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=qYt56i8HCwE",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/69305440",
       "uri_deezer": "deezer://track/544053252",
       "fun_fact": "A 1950s classic (1957).",
       "fun_fact_de": "Ein 50er-Klassiker (1957).",
@@ -2205,7 +2205,7 @@
         "it": "applemusic://track/26088767"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=gRDLTF0djHg",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/93426047",
       "uri_deezer": "deezer://track/5908975",
       "fun_fact": "A 1950s classic (1957).",
       "fun_fact_de": "Ein 50er-Klassiker (1957).",
@@ -2230,7 +2230,7 @@
         "it": "applemusic://track/314000997"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=4xsKpO1qsSQ",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/517191",
       "uri_deezer": "deezer://track/964938",
       "fun_fact": "A 1950s classic (1957).",
       "fun_fact_de": "Ein 50er-Klassiker (1957).",
@@ -2255,7 +2255,7 @@
         "it": "applemusic://track/715509678"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=LJCp7K__8Vo",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/60683639",
       "uri_deezer": null,
       "fun_fact": "Ricky Nelson — a teen idol who became one of the 50s' biggest stars.",
       "fun_fact_de": "Ricky Nelson — ein Teenie-Idol, das zu einem der größten Stars der 50er wurde.",
@@ -2280,7 +2280,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=_YS23MA0Jtg",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/99138546",
       "uri_deezer": "deezer://track/60240231",
       "fun_fact": "A 1950s classic (1957).",
       "fun_fact_de": "Ein 50er-Klassiker (1957).",
@@ -2305,7 +2305,7 @@
         "it": "applemusic://track/941259917"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=4mi2uXATgVw",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/94413908",
       "uri_deezer": "deezer://track/90427389",
       "fun_fact": "A 1950s classic (1957).",
       "fun_fact_de": "Ein 50er-Klassiker (1957).",
@@ -2330,7 +2330,7 @@
         "it": "applemusic://track/1400161658"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=w1AcbP0_SYs",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/25710479",
       "uri_deezer": "deezer://track/691215",
       "fun_fact": "The Everly Brothers — close-harmony pioneers who shaped 50s pop.",
       "fun_fact_de": "The Everly Brothers — Harmoniegesang-Pioniere, die den 50er-Pop prägten.",
@@ -2355,7 +2355,7 @@
         "it": "applemusic://track/358042641"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=oqSNChmm-mY",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/118067999",
       "uri_deezer": "deezer://track/12081837",
       "fun_fact": "A 1950s classic (1957).",
       "fun_fact_de": "Ein 50er-Klassiker (1957).",
@@ -2380,7 +2380,7 @@
         "it": "applemusic://track/358105982"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=mHizexVWcVc",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/8672338",
       "uri_deezer": "deezer://track/12081869",
       "fun_fact": "A 1950s classic (1957).",
       "fun_fact_de": "Ein 50er-Klassiker (1957).",
@@ -2405,7 +2405,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=9xWCy7b8bgg",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/72778919",
       "uri_deezer": "deezer://track/349496981",
       "fun_fact": "A 1950s classic (1957).",
       "fun_fact_de": "Ein 50er-Klassiker (1957).",
@@ -2430,7 +2430,7 @@
         "it": "applemusic://track/1577370946"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=4R53SaiFW9c",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/218263",
       "uri_deezer": "deezer://track/691319",
       "fun_fact": "A 1950s classic (1958).",
       "fun_fact_de": "Ein 50er-Klassiker (1958).",
@@ -2455,7 +2455,7 @@
         "it": "applemusic://track/451058102"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=E6yGhe2gQxw",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/12722459",
       "uri_deezer": "deezer://track/12999373",
       "fun_fact": "A 1950s classic (1958).",
       "fun_fact_de": "Ein 50er-Klassiker (1958).",
@@ -2580,7 +2580,7 @@
         "it": "applemusic://track/324167268"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=yzvlPKozW-A",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/3381656",
       "uri_deezer": "deezer://track/1053695",
       "fun_fact": "A 1950s classic (1958).",
       "fun_fact_de": "Ein 50er-Klassiker (1958).",


### PR DESCRIPTION
Scheduled Tidal URI backfill wave (Odesli). Partial wave — rate-limit-capped at 1 file before the 429 backoff stopped it; the next scheduled wave (12:00) continues the rotation.

### Delta
- **40s-50s-classics**: +19 Tidal URIs (`uri_tidal` null → set), version 1.6 → 1.7

URI-only + version bump. Validated by the Playlist JSON Schema Gate in CI. Draft for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)