### PR TITLE
fix(mixer): make the Mix tab scrollable

### DIFF
--- a/custom_components/beatify/www/js/playlist-hub.js
+++ b/custom_components/beatify/www/js/playlist-hub.js
@@ -554,7 +554,9 @@ function _renderAll() {
             <div class="plh-sheet-host" data-plh-sheet></div>
         </div>
         <div class="playlist-panel plh-mix-view ${state.topTab === 'mix' ? '' : 'hidden'}" data-plh-mix-view role="tabpanel">
-            ${_mixPanelHtml()}
+            <div class="plh-body plh-mix-body">
+                ${_mixPanelHtml()}
+            </div>
         </div>
     `;
     _renderHeader();

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/markusholzhauser/Development/Beatify/node_modules


### PR DESCRIPTION
## Problem
Markus reported the **Mix page still can't scroll** on rc4 (after the #1573 Playlist-Hub scroll fix).

## Root cause
The Playlists tab renders into a `.plh-body` (`overflow-y:auto`) scroll container. The **Mix tab renders `_mixPanelHtml()` directly into `.plh-mix-view` with no such container.** #1573 made `.plh-mix-view` a flex column (`flex:1 1 0; min-height:0`) but without an inner overflow container nothing scrolls, so `.plh-root{overflow:hidden}` clips the chip cloud / preview / actions below the fold. #1573 fixed the Playlists tab; the Mix tab was left unscrollable.

## Fix
Wrap the mix panel in the same `.plh-body` scroll container the Playlists tab uses. No horizontal layout change (the mix view had no horizontal padding before either), no CSS change needed — reuses the existing `.plh-body` rule.

## Verification
- `npm test` → 376/376 pass (incl. playlist-hub-mix-tab + mix-tracklist-preview)
- `npm run build` + `build:check` → 10/10 bundles in sync
- lint → 0 errors

Note: can't browser-verify the live scroll (macOS local-network block on the test Chrome), but the markup/CSS mechanism is identical to the proven Playlists-tab scroll.

🤖 Generated with [Claude Code](https://claude.com/claude-code)