### PR TITLE
chore(playlists): tidal backfill wave 2026-06-26 12:00 — +19 uris

### DIFF
--- a/custom_components/beatify/playlists/40s-50s-classics.json
+++ b/custom_components/beatify/playlists/40s-50s-classics.json
@@ -1,6 +1,6 @@
 {
   "name": "40s & 50s Classics",
-  "version": "1.7",
+  "version": "1.8",
   "tags": [
     "1940s",
     "1950s",
@@ -2605,7 +2605,7 @@
         "it": "applemusic://track/1444122663"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=Wl1-uj1UQuk",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/1482410",
       "uri_deezer": "deezer://track/3089535",
       "fun_fact": "A 1950s classic (1958).",
       "fun_fact_de": "Ein 50er-Klassiker (1958).",
@@ -2630,7 +2630,7 @@
         "it": "applemusic://track/730297255"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=yOzEeJZ92X8",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/1381139",
       "uri_deezer": "deezer://track/3103535",
       "fun_fact": "Frank Sinatra — 'Ol' Blue Eyes', the defining voice of the American songbook.",
       "fun_fact_de": "Frank Sinatra — 'Ol' Blue Eyes', die prägende Stimme des American Songbook.",
@@ -2655,7 +2655,7 @@
         "it": "applemusic://track/403809717"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=J9vG5BhOKaY",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/319131548",
       "uri_deezer": "deezer://track/116857974",
       "fun_fact": "A 1950s classic (1958).",
       "fun_fact_de": "Ein 50er-Klassiker (1958).",
@@ -2680,7 +2680,7 @@
         "it": "applemusic://track/714312494"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=bQLBvHMSBvM",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/1461673",
       "uri_deezer": "deezer://track/4227586",
       "fun_fact": "A 1950s classic (1958).",
       "fun_fact_de": "Ein 50er-Klassiker (1958).",
@@ -2705,7 +2705,7 @@
         "it": "applemusic://track/1763342564"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=QTDhQ2QECqE",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/3049549",
       "uri_deezer": "deezer://track/2203629",
       "fun_fact": "Little Richard — the flamboyant 'Architect of Rock'n'Roll'.",
       "fun_fact_de": "Little Richard — der extravagante 'Architekt des Rock'n'Roll'.",
@@ -2730,7 +2730,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=MzNswqHrd8I",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/36057628",
       "uri_deezer": "deezer://track/1631871972",
       "fun_fact": "A 1950s classic (1958).",
       "fun_fact_de": "Ein 50er-Klassiker (1958).",
@@ -2755,7 +2755,7 @@
         "it": "applemusic://track/1700948227"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=JBANWpzsHts",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/157943",
       "uri_deezer": "deezer://track/3124340",
       "fun_fact": "A 1950s classic (1958).",
       "fun_fact_de": "Ein 50er-Klassiker (1958).",
@@ -2780,7 +2780,7 @@
         "it": "applemusic://track/1443786396"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=LIxHJpmvg7E",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/628494",
       "uri_deezer": "deezer://track/3291529",
       "fun_fact": "Ricky Nelson — a teen idol who became one of the 50s' biggest stars.",
       "fun_fact_de": "Ricky Nelson — ein Teenie-Idol, das zu einem der größten Stars der 50er wurde.",
@@ -2805,7 +2805,7 @@
         "it": "applemusic://track/6767663390"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=tEPefBWlBgk",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/522861631",
       "uri_deezer": "deezer://track/3233830",
       "fun_fact": "Ricky Nelson — a teen idol who became one of the 50s' biggest stars.",
       "fun_fact_de": "Ricky Nelson — ein Teenie-Idol, das zu einem der größten Stars der 50er wurde.",
@@ -2830,7 +2830,7 @@
         "it": "applemusic://track/1828397031"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=BycLmWI97Nc",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/7985177",
       "uri_deezer": "deezer://track/13975941",
       "fun_fact": "A 1950s classic (1958).",
       "fun_fact_de": "Ein 50er-Klassiker (1958).",
@@ -2855,7 +2855,7 @@
         "it": "applemusic://track/29124600"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=0iJCAcKIwdI",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/306884",
       "uri_deezer": "deezer://track/3860014",
       "fun_fact": "A 1950s classic (1958).",
       "fun_fact_de": "Ein 50er-Klassiker (1958).",
@@ -2880,7 +2880,7 @@
         "it": "applemusic://track/1702867914"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=2PRvejWMWl4",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/306883",
       "uri_deezer": "deezer://track/682206",
       "fun_fact": "A 1950s classic (1958).",
       "fun_fact_de": "Ein 50er-Klassiker (1958).",
@@ -2905,7 +2905,7 @@
         "it": "applemusic://track/1700465239"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=FbcVFF0TISM",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/93539847",
       "uri_deezer": "deezer://track/543099772",
       "fun_fact": "A 1950s classic (1958).",
       "fun_fact_de": "Ein 50er-Klassiker (1958).",
@@ -2930,7 +2930,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=8fX4rxe9T3o",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/90132108",
       "uri_deezer": "deezer://track/90174115",
       "fun_fact": "A 1950s classic (1958).",
       "fun_fact_de": "Ein 50er-Klassiker (1958).",
@@ -2955,7 +2955,7 @@
         "it": "applemusic://track/164459848"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=4hswHOEQfj8",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/77412839",
       "uri_deezer": "deezer://track/1201417",
       "fun_fact": "A 1950s classic (1958).",
       "fun_fact_de": "Ein 50er-Klassiker (1958).",
@@ -2980,7 +2980,7 @@
         "it": "applemusic://track/400798830"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=_kXKUSAbvuM",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/22330291",
       "uri_deezer": "deezer://track/3991861",
       "fun_fact": "A 1950s classic (1958).",
       "fun_fact_de": "Ein 50er-Klassiker (1958).",
@@ -3005,7 +3005,7 @@
         "it": "applemusic://track/81979584"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=FSliAkQg68Y",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/12722107",
       "uri_deezer": "deezer://track/2070824",
       "fun_fact": "A 1950s classic (1958).",
       "fun_fact_de": "Ein 50er-Klassiker (1958).",
@@ -3030,7 +3030,7 @@
         "it": "applemusic://track/1473830324"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=Tvq1ZBkG5xM",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/113767928",
       "uri_deezer": "deezer://track/717077602",
       "fun_fact": "A 1950s classic (1958).",
       "fun_fact_de": "Ein 50er-Klassiker (1958).",
@@ -3055,7 +3055,7 @@
         "it": "applemusic://track/1576448302"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=6qtqS9SGlnM",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/16445116",
       "uri_deezer": "deezer://track/2511253",
       "fun_fact": "A 1950s classic (1959).",
       "fun_fact_de": "Ein 50er-Klassiker (1959).",


### PR DESCRIPTION
Scheduled Tidal URI backfill wave (Odesli). Partial — Odesli was rate-limiting hard today (sustained 429 backoffs), so the wave only completed one file before being stopped; the next scheduled wave (18:00) continues the rotation.

### Delta
- **40s-50s-classics**: +19 Tidal URIs (`uri_tidal` null → set), version 1.7 → 1.8 (continues #1614's pass on the same playlist's remaining nulls)

URI-only + version bump. Validated by the Playlist JSON Schema Gate in CI. Draft for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)