### PR TITLE
chore(playlists): tidal backfill wave 2026-06-27 22:00 — +18 uris

### DIFF
--- a/custom_components/beatify/playlists/70s-hits.json
+++ b/custom_components/beatify/playlists/70s-hits.json
@@ -1,6 +1,6 @@
 {
   "name": "70s Hits",
-  "version": "1.2",
+  "version": "1.3",
   "tags": [
     "1970s",
     "classic-rock",
@@ -530,7 +530,7 @@
         "it": "applemusic://track/1440910931"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=BdEe5SpdIuo",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/334634",
       "uri_deezer": "deezer://track/1144863",
       "fun_fact": "Elton John is a British singer-songwriter and one of pop's biggest careers.",
       "fun_fact_de": "Elton John ist ein britischer Singer-Songwriter mit einer der größten Pop-Karrieren.",
@@ -555,7 +555,7 @@
         "it": "applemusic://track/405601026"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=ufQUxoidxkM",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/33924910",
       "uri_deezer": "deezer://track/1037414",
       "fun_fact": "A 70s classic (1976).",
       "fun_fact_de": "Ein 70er-Klassiker (1976).",
@@ -580,7 +580,7 @@
         "it": "applemusic://track/1069036964"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=Ey8gm1W-e1Y",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/55391452",
       "uri_deezer": "deezer://track/116914094",
       "fun_fact": "Pink Floyd were a British band famed for their conceptual, immersive albums.",
       "fun_fact_de": "Pink Floyd waren eine britische Band, berühmt für ihre konzeptuellen, immersiven Alben.",
@@ -605,7 +605,7 @@
         "it": "applemusic://track/594061859"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=MTIkFwMuiTw",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/215115420",
       "uri_deezer": "deezer://track/63480990",
       "fun_fact": "Fleetwood Mac's 'Rumours'-era line-up made them one of the 70s' defining bands.",
       "fun_fact_de": "Fleetwood Mac wurden in der 'Rumours'-Ära zu einer der prägenden Bands der 70er.",
@@ -630,7 +630,7 @@
         "it": "applemusic://track/1578934918"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=iL-jC7XyLeo",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/77820570",
       "uri_deezer": "deezer://track/24949681",
       "fun_fact": "A 70s classic (1974).",
       "fun_fact_de": "Ein 70er-Klassiker (1974).",
@@ -655,7 +655,7 @@
         "it": "applemusic://track/1030801346"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=wuJIqmha2Hk",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/53230853",
       "uri_deezer": "deezer://track/112662184",
       "fun_fact": "Electric Light Orchestra blended rock with lush orchestral pop.",
       "fun_fact_de": "Electric Light Orchestra verband Rock mit üppigem Orchester-Pop.",
@@ -680,7 +680,7 @@
         "it": "applemusic://track/1737859453"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=z4R5crZylQ0",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/40482043",
       "uri_deezer": "deezer://track/75768727",
       "fun_fact": "A 70s classic (1973).",
       "fun_fact_de": "Ein 70er-Klassiker (1973).",
@@ -705,7 +705,7 @@
         "it": "applemusic://track/1891813116"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=iX_TFkut1PM",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/1325625",
       "uri_deezer": "deezer://track/3166505",
       "fun_fact": "A 70s classic (1971).",
       "fun_fact_de": "Ein 70er-Klassiker (1971).",
@@ -730,7 +730,7 @@
         "it": "applemusic://track/1685077864"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=DzXEos0xIQM",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/77139773",
       "uri_deezer": "deezer://track/392284592",
       "fun_fact": "A 70s classic (1973).",
       "fun_fact_de": "Ein 70er-Klassiker (1973).",
@@ -755,7 +755,7 @@
         "it": "applemusic://track/1626467846"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=PbpIyn70t8c",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/26703889",
       "uri_deezer": "deezer://track/27533081",
       "fun_fact": "Earth, Wind & Fire fused funk, soul and disco into era-defining anthems.",
       "fun_fact_de": "Earth, Wind & Fire verschmolzen Funk, Soul und Disco zu epochalen Hymnen.",
@@ -780,7 +780,7 @@
         "it": "applemusic://track/1688434083"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=jwikdkqYw6o",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/68493648",
       "uri_deezer": "deezer://track/350027751",
       "fun_fact": "The Bee Gees were the falsetto-driven heart of the disco era.",
       "fun_fact_de": "Die Bee Gees waren mit ihrem Falsett das Herz der Disco-Ära.",
@@ -805,7 +805,7 @@
         "it": "applemusic://track/779290473"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=f7jkXqzsYzU",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/20750059",
       "uri_deezer": "deezer://track/68116147",
       "fun_fact": "The Eagles are one of the best-selling American rock bands of all time.",
       "fun_fact_de": "Die Eagles zählen zu den meistverkauften amerikanischen Rockbands aller Zeiten.",
@@ -830,7 +830,7 @@
         "it": "applemusic://track/1350497718"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=aBKEt3MhNMM",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/51161410",
       "uri_deezer": "deezer://track/107471926",
       "fun_fact": "David Bowie was a British artist who reinvented rock again and again.",
       "fun_fact_de": "David Bowie war ein britischer Künstler, der Rock immer wieder neu erfand.",
@@ -855,7 +855,7 @@
         "it": "applemusic://track/1685072813"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=QCgeitX5xg0",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/45105672",
       "uri_deezer": "deezer://track/70016835",
       "fun_fact": "A 70s classic (1977).",
       "fun_fact_de": "Ein 70er-Klassiker (1977).",
@@ -880,7 +880,7 @@
         "it": "applemusic://track/575998664"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=NhsK5WExrnE",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/35986171",
       "uri_deezer": "deezer://track/92720006",
       "fun_fact": "AC/DC are an Australian hard-rock band, loud and unmistakable since the 70s.",
       "fun_fact_de": "AC/DC sind eine australische Hard-Rock-Band — laut und unverwechselbar seit den 70ern.",
@@ -905,7 +905,7 @@
         "it": "applemusic://track/1005702295"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=Bid6LmRU1d8",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/11335946",
       "uri_deezer": "deezer://track/72208034",
       "fun_fact": "A 70s classic (1978).",
       "fun_fact_de": "Ein 70er-Klassiker (1978).",
@@ -930,7 +930,7 @@
         "it": "applemusic://track/1440913387"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=VHK5k2ieudc",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/295903",
       "uri_deezer": "deezer://track/1162676",
       "fun_fact": "Elton John is a British singer-songwriter and one of pop's biggest careers.",
       "fun_fact_de": "Elton John ist ein britischer Singer-Songwriter mit einer der größten Pop-Karrieren.",
@@ -955,7 +955,7 @@
         "it": "applemusic://track/1862239887"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=44FId4BpMx0",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/482738028",
       "uri_deezer": "deezer://track/461043312",
       "fun_fact": "David Bowie was a British artist who reinvented rock again and again.",
       "fun_fact_de": "David Bowie war ein britischer Künstler, der Rock immer wieder neu erfand.",


### PR DESCRIPTION
Automated Tidal-URI backfill wave (idea #7).

- **70s-hits**: +18 Tidal URIs, version 1.2 → 1.3

URI-only, Schema-Gate-validated. Heavy 429 rate-limiting; skips retry next wave.

🤖 Generated with [Claude Code](https://claude.com/claude-code)