### PR TITLE
fix(media-player): hide native-platform twins of Music Assistant speakers in the picker (#1627)

### DIFF
--- a/custom_components/beatify/services/media_player.py
+++ b/custom_components/beatify/services/media_player.py
@@ -1559,6 +1559,22 @@ async def async_get_media_players(hass: HomeAssistant) -> list[dict[str, Any]]:
     # Get entity registry to check which platform created each entity
     ent_reg = er.async_get(hass)
 
+    # #1627: A speaker exposed through Music Assistant appears in the registry
+    # twice with the SAME unique_id — once on its native platform (e.g. sonos)
+    # and once on music_assistant. Both are the same physical speaker, but only
+    # the MA twin can stream Beatify's provider URIs (spotify:track:… etc.); the
+    # native twin throws "UPnP Error 800" and the game pauses with
+    # media_player_error. Collect the unique_ids owned by an MA media_player so
+    # we can drop the native twins below (even when the native platform — sonos
+    # — is itself "supported").
+    ma_unique_ids = {
+        entry.unique_id
+        for entry in ent_reg.entities.values()
+        if entry.domain == "media_player"
+        and entry.platform == "music_assistant"
+        and entry.unique_id
+    }
+
     media_players = []
     for state in hass.states.async_all("media_player"):
         entity_entry = ent_reg.async_get(state.entity_id)
@@ -1574,6 +1590,24 @@ async def async_get_media_players(hass: HomeAssistant) -> list[dict[str, Any]]:
                 state.entity_id,
                 platform,
                 capabilities.get("reason", "unknown"),
+            )
+            continue
+
+        # #1627: Skip the native-platform twin of a Music Assistant speaker.
+        # Runs independently of the supported-platform check above so a native
+        # twin is dropped even when its own platform (sonos) is supported —
+        # picking it would route provider URIs to a player that can't resolve
+        # them (UPnP Error 800). The MA twin (same unique_id) is kept.
+        if (
+            platform != "music_assistant"
+            and entity_entry is not None
+            and entity_entry.unique_id in ma_unique_ids
+        ):
+            _LOGGER.debug(
+                "Skipping native twin of MA player: %s (platform=%s, unique_id=%s)",
+                state.entity_id,
+                platform,
+                entity_entry.unique_id,
             )
             continue
 

--- a/tests/unit/test_media_player.py
+++ b/tests/unit/test_media_player.py
@@ -9,6 +9,7 @@ import pytest
 
 from custom_components.beatify.services.media_player import (
     MediaPlayerService,
+    async_get_media_players,
     proxy_album_art,
 )
 
@@ -2173,3 +2174,126 @@ class TestVolumeSaveRestore:
             call.args[:2] != ("media_player", "volume_set")
             for call in hass.services.async_call.await_args_list
         )
+
+
+def _make_registry_entry(
+    entity_id: str, platform: str, unique_id: str | None, domain: str = "media_player"
+) -> MagicMock:
+    """Build a fake entity-registry entry (mirrors HA's RegistryEntry attrs)."""
+    entry = MagicMock()
+    entry.entity_id = entity_id
+    entry.platform = platform
+    entry.unique_id = unique_id
+    entry.domain = domain
+    return entry
+
+
+def _make_player_state(entity_id: str) -> MagicMock:
+    """Build a fake media_player state object for async_all()."""
+    state = MagicMock()
+    state.entity_id = entity_id
+    state.state = "idle"
+    state.attributes = {"friendly_name": entity_id}
+    return state
+
+
+def _make_discovery_hass(entries: list[MagicMock]) -> tuple[MagicMock, MagicMock]:
+    """Wire a hass + fake entity registry from a list of registry entries.
+
+    Returns (hass, registry). `hass.states.async_all` yields a state per entry;
+    the registry resolves entity_id → entry and exposes `.entities.values()`.
+    """
+    by_id = {e.entity_id: e for e in entries}
+
+    hass = MagicMock()
+    hass.states.async_all = MagicMock(
+        return_value=[_make_player_state(e.entity_id) for e in entries]
+    )
+
+    registry = MagicMock()
+    registry.entities.values = MagicMock(return_value=list(entries))
+    registry.async_get = MagicMock(side_effect=lambda eid: by_id.get(eid))
+    return hass, registry
+
+
+class TestNativeTwinFiltering:
+    """async_get_media_players hides native-platform twins of MA speakers (#1627)."""
+
+    @pytest.mark.asyncio
+    async def test_native_sonos_twin_of_ma_player_is_hidden(self):
+        """Same unique_id on sonos + music_assistant → only the MA twin shows."""
+        entries = [
+            _make_registry_entry(
+                "media_player.esszimmer",
+                "music_assistant",
+                "RINCON_C43875ED053801400",
+            ),
+            _make_registry_entry(
+                "media_player.unnamed_room",
+                "sonos",
+                "RINCON_C43875ED053801400",
+            ),
+        ]
+        hass, registry = _make_discovery_hass(entries)
+
+        with patch(
+            "homeassistant.helpers.entity_registry.async_get",
+            return_value=registry,
+        ):
+            result = await async_get_media_players(hass)
+
+        ids = {p["entity_id"] for p in result}
+        assert "media_player.esszimmer" in ids
+        assert "media_player.unnamed_room" not in ids
+
+    @pytest.mark.asyncio
+    async def test_standalone_sonos_without_ma_twin_is_kept(self):
+        """A native sonos player with a unique unique_id must NOT be filtered."""
+        entries = [
+            _make_registry_entry(
+                "media_player.living_ma",
+                "music_assistant",
+                "RINCON_AAAA",
+            ),
+            _make_registry_entry(
+                "media_player.kitchen_sonos",
+                "sonos",
+                "RINCON_BBBB",
+            ),
+        ]
+        hass, registry = _make_discovery_hass(entries)
+
+        with patch(
+            "homeassistant.helpers.entity_registry.async_get",
+            return_value=registry,
+        ):
+            result = await async_get_media_players(hass)
+
+        ids = {p["entity_id"] for p in result}
+        assert ids == {"media_player.living_ma", "media_player.kitchen_sonos"}
+
+    @pytest.mark.asyncio
+    async def test_player_with_none_unique_id_is_unaffected(self):
+        """unique_id=None must not collide with the MA set (None never matches)."""
+        entries = [
+            _make_registry_entry(
+                "media_player.ma_box",
+                "music_assistant",
+                "RINCON_AAAA",
+            ),
+            _make_registry_entry(
+                "media_player.legacy_sonos",
+                "sonos",
+                None,
+            ),
+        ]
+        hass, registry = _make_discovery_hass(entries)
+
+        with patch(
+            "homeassistant.helpers.entity_registry.async_get",
+            return_value=registry,
+        ):
+            result = await async_get_media_players(hass)
+
+        ids = {p["entity_id"] for p in result}
+        assert ids == {"media_player.ma_box", "media_player.legacy_sonos"}


### PR DESCRIPTION
## The footgun

A speaker exposed through Music Assistant appears in HA's entity registry **twice with the same `unique_id`** — once on its native platform (e.g. `sonos`) and once on `music_assistant`. The same physical speaker, two `media_player` entities.

The speaker picker (`async_get_media_players`) listed **both**. Picking the native twin breaks playback: the native platform can't resolve Beatify's provider URIs (`spotify:track:…` → `UPnP Error 800`), and the game then pauses with `media_player_error`.

Verified live: `media_player.esszimmer` (platform `music_assistant`) and `media_player.unnamed_room` (platform `sonos`) share `unique_id` `RINCON_C43875ED053801400` — same Sonos. The MA entity streams fine; the native one throws UPnP 800.

## The fix

`async_get_media_players` now:
1. builds the set of `unique_id`s owned by a `music_assistant` `media_player` entity, then
2. skips any **non-MA** entity whose `unique_id` is in that set (it's the same physical speaker; prefer the MA twin which can stream provider URIs).

The twin-skip runs **independently** of the existing unsupported-platform check, so the native `sonos` twin is dropped even though `sonos` is itself a supported platform. `unique_id=None` never collides (the MA set filters out falsy `unique_id`s, and `None in set` is safely `False`).

## Tests

Added `TestNativeTwinFiltering` in `tests/unit/test_media_player.py`:
- sonos + MA with the **same** `unique_id` → result contains the MA `entity_id`, not the native sonos one;
- standalone sonos with a **unique** `unique_id` → still included (no over-filtering);
- player with `unique_id=None` → unaffected.

## Verification

- `pytest tests/unit tests/integration`: **1186 passed, 2 skipped**
- `ruff check` + `ruff format --check`: clean
- `mypy` (scoped config): `Success: no issues found in 16 source files`
- Pure Python change — no frontend build needed.

Closes #1627