### PR TITLE
chore(playlists): tidal backfill wave 2026-06-28 22:00 — +18 uris

### DIFF
--- a/custom_components/beatify/playlists/70s-hits.json
+++ b/custom_components/beatify/playlists/70s-hits.json
@@ -1,6 +1,6 @@
 {
   "name": "70s Hits",
-  "version": "1.4",
+  "version": "1.5",
   "tags": [
     "1970s",
     "classic-rock",
@@ -1430,7 +1430,7 @@
         "it": "applemusic://track/1786556144"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=cleCtBP0o5Y",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/1554383",
       "uri_deezer": "deezer://track/766109",
       "fun_fact": "A 70s classic (1972).",
       "fun_fact_de": "Ein 70er-Klassiker (1972).",
@@ -1455,7 +1455,7 @@
         "it": "applemusic://track/6762962944"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=BOCe62_vdzY",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/21844148",
       "uri_deezer": "deezer://track/67503800",
       "fun_fact": "Queen were a British rock band fronted by the inimitable Freddie Mercury.",
       "fun_fact_de": "Queen waren eine britische Rockband mit dem unnachahmlichen Freddie Mercury am Mikrofon.",
@@ -1480,7 +1480,7 @@
         "it": "applemusic://track/6762676050"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=DkkQ8dCPiwA",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/1771747",
       "uri_deezer": "deezer://track/884028",
       "fun_fact": "ABBA were a Swedish quartet — one of the best-selling pop acts in history.",
       "fun_fact_de": "ABBA waren ein schwedisches Quartett — einer der meistverkauften Pop-Acts der Geschichte.",
@@ -1505,7 +1505,7 @@
         "it": "applemusic://track/1847684954"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=o1BqHjNafRk",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/3029661",
       "uri_deezer": "deezer://track/4688887",
       "fun_fact": "A 70s classic (1978).",
       "fun_fact_de": "Ein 70er-Klassiker (1978).",
@@ -1530,7 +1530,7 @@
         "it": "applemusic://track/1870541550"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=6F9N-6ITFnA",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/2043322",
       "uri_deezer": "deezer://track/2550736",
       "fun_fact": "A 70s classic (1978).",
       "fun_fact_de": "Ein 70er-Klassiker (1978).",
@@ -1555,7 +1555,7 @@
         "it": "applemusic://track/1695901687"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=CFhFyvk0yS8",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/4350147",
       "uri_deezer": "deezer://track/6917710",
       "fun_fact": "A 70s classic (1972).",
       "fun_fact_de": "Ein 70er-Klassiker (1972).",
@@ -1580,7 +1580,7 @@
         "it": "applemusic://track/779290504"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=zhhET_JZ3z4",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/20664054",
       "uri_deezer": "deezer://track/68094422",
       "fun_fact": "The Eagles are one of the best-selling American rock bands of all time.",
       "fun_fact_de": "Die Eagles zählen zu den meistverkauften amerikanischen Rockbands aller Zeiten.",
@@ -1605,7 +1605,7 @@
         "it": "applemusic://track/1774784848"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=bSnlKl_PoQU",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/21844140",
       "uri_deezer": "deezer://track/9997018",
       "fun_fact": "Queen were a British rock band fronted by the inimitable Freddie Mercury.",
       "fun_fact_de": "Queen waren eine britische Rockband mit dem unnachahmlichen Freddie Mercury am Mikrofon.",
@@ -1630,7 +1630,7 @@
         "it": "applemusic://track/1527283047"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=1w4VEc92Y_4",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/63372063",
       "uri_deezer": "deezer://track/129231818",
       "fun_fact": "A 70s classic (1972).",
       "fun_fact_de": "Ein 70er-Klassiker (1972).",
@@ -1655,7 +1655,7 @@
         "it": "applemusic://track/6767663161"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=tYTgtsCm0DA",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/32589534",
       "uri_deezer": "deezer://track/82159934",
       "fun_fact": "A 70s classic (1973).",
       "fun_fact_de": "Ein 70er-Klassiker (1973).",
@@ -1680,7 +1680,7 @@
         "it": "applemusic://track/1737859507"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=FS8p_F0Stog",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/35191628",
       "uri_deezer": "deezer://track/82692320",
       "fun_fact": "A 70s classic (1976).",
       "fun_fact_de": "Ein 70er-Klassiker (1976).",
@@ -1705,7 +1705,7 @@
         "it": "applemusic://track/1737859386"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=kW0HZy8J0v0",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/7900624",
       "uri_deezer": "deezer://track/13816433",
       "fun_fact": "Electric Light Orchestra blended rock with lush orchestral pop.",
       "fun_fact_de": "Electric Light Orchestra verband Rock mit üppigem Orchester-Pop.",
@@ -1730,7 +1730,7 @@
         "it": "applemusic://track/1706888471"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=W1LsRShUPtY",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/81126290",
       "uri_deezer": "deezer://track/2548061582",
       "fun_fact": "A 70s classic (1978).",
       "fun_fact_de": "Ein 70er-Klassiker (1978).",
@@ -1755,7 +1755,7 @@
         "it": "applemusic://track/6763249217"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=TngViNw2pOo",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/5816049",
       "uri_deezer": "deezer://track/1175612",
       "fun_fact": "A 70s classic (1970).",
       "fun_fact_de": "Ein 70er-Klassiker (1970).",
@@ -1780,7 +1780,7 @@
         "it": "applemusic://track/976362823"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=EKOcfZtKvYQ",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/43697107",
       "uri_deezer": "deezer://track/97095572",
       "fun_fact": "A 70s classic (1971).",
       "fun_fact_de": "Ein 70er-Klassiker (1971).",
@@ -1805,7 +1805,7 @@
         "it": "applemusic://track/1847898800"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=CVsLEI-hCXw",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/273900",
       "uri_deezer": "deezer://track/3616544",
       "fun_fact": "A 70s classic (1973).",
       "fun_fact_de": "Ein 70er-Klassiker (1973).",
@@ -1830,7 +1830,7 @@
         "it": "applemusic://track/1819127168"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=tkGSubR4B6Q",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/2286109",
       "uri_deezer": "deezer://track/2801132",
       "fun_fact": "A 70s classic (1979).",
       "fun_fact_de": "Ein 70er-Klassiker (1979).",
@@ -1855,7 +1855,7 @@
         "it": "applemusic://track/158816065"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=kdxSmoxfl7A",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/1809085",
       "uri_deezer": "deezer://track/988632",
       "fun_fact": "A 70s classic (1977).",
       "fun_fact_de": "Ein 70er-Klassiker (1977).",


### PR DESCRIPTION
Automated Tidal-URI backfill wave (Odesli).

**Delta:** 70s-hits.json — tidal +18, version 1.4 → 1.5

URI-only, no track changes. Playlist JSON Schema Gate validates the changed file in CI. Auto-merge enabled once required checks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)