### PR TITLE
data: fix dead Apple Music URI in 80er-hits (Gianna Nannini)

### DIFF
--- a/custom_components/beatify/playlists/80er-hits.json
+++ b/custom_components/beatify/playlists/80er-hits.json
@@ -1,6 +1,6 @@
 {
   "name": "80s Hits",
-  "version": "2.8",
+  "version": "2.9",
   "tags": [
     "1980s",
     "pop",
@@ -5373,7 +5373,7 @@
       "fun_fact_de": "Gianna Nanninis Durchbruchshit etablierte sie als Italiens führende Rock-Sängerin. Ihre raue Stimme und ihr energiegeladener Stil beeinflussten eine Generation italienischer Künstlerinnen.",
       "fun_fact_es": "El éxito revelación de Gianna Nannini la estableció como la principal cantante de rock femenina de Italia. Su voz ronca y estilo energético influyeron en una generación de artistas italianas.",
       "fun_fact_fr": "Le tube de la consécration de Gianna Nannini l'a établie comme la première rockeuse d'Italie. Sa voix rauque et son énergie scénique ont influencé toute une génération d'artistes féminines italiennes.",
-      "uri_apple_music": "applemusic://track/1048058595",
+      "uri_apple_music": "applemusic://track/6768669296",
       "uri_youtube_music": "https://music.youtube.com/watch?v=xzCO9FenHhc",
       "uri_tidal": "tidal://track/18004852",
       "uri_deezer": "deezer://track/16513318",
@@ -5381,13 +5381,13 @@
       "awards_nl": [],
       "isrc": "ITB001500273",
       "uri_apple_music_by_region": {
-        "us": "applemusic://track/1048058595",
-        "de": "applemusic://track/1048058595",
-        "gb": "applemusic://track/1048058595",
-        "fr": "applemusic://track/1048058595",
-        "es": "applemusic://track/1048058595",
-        "nl": "applemusic://track/1048058595",
-        "it": "applemusic://track/1048058595"
+        "us": "applemusic://track/6768669296",
+        "de": "applemusic://track/6768669296",
+        "gb": "applemusic://track/6768669296",
+        "fr": "applemusic://track/6768669296",
+        "es": "applemusic://track/6768669296",
+        "nl": "applemusic://track/6768669296",
+        "it": "applemusic://track/6768669296"
       }
     },
     {


### PR DESCRIPTION
Replaces a confirmed-dead Apple Music URI in **80er-hits.json**.

**Track:** Gianna Nannini — *Bello e impossibile* (1986)
- old `applemusic://track/1048058595` → iTunes lookup returns **no result** (dead)
- new `applemusic://track/6768669296` → iTunes lookup returns **Gianna Nannini — Bello e impossibile** (album *Profumo*) ✅

Version bumped 2.8 → 2.9. URI-only, schema-gate validated.

_Recovered: this fix was auto-generated by a BeatifyBot triage agent at 04:48 today but stranded on a local branch (committed to the working tree instead of a /tmp worktree) before it could be pushed. Re-verified the replacement URI before opening this PR._

🤖 Generated with [Claude Code](https://claude.com/claude-code)