### PR TITLE
chore(playlists): tidal backfill wave 2026-06-29 18:00 — +19 uris in 70s-hits

### DIFF
--- a/custom_components/beatify/playlists/70s-hits.json
+++ b/custom_components/beatify/playlists/70s-hits.json
@@ -1,6 +1,6 @@
 {
   "name": "70s Hits",
-  "version": "1.8",
+  "version": "1.9",
   "tags": [
     "1970s",
     "classic-rock",
@@ -2780,7 +2780,7 @@
         "it": "applemusic://track/1467440335"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=ZCwWAD6ZuPk",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/54518833",
       "uri_deezer": "deezer://track/114422238",
       "fun_fact": "A 70s classic (1973).",
       "fun_fact_de": "Ein 70er-Klassiker (1973).",
@@ -2805,7 +2805,7 @@
         "it": "applemusic://track/1507830357"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=qznqW8KzMpE",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/4623873",
       "uri_deezer": "deezer://track/7340163",
       "fun_fact": "A 70s classic (1973).",
       "fun_fact_de": "Ein 70er-Klassiker (1973).",
@@ -2830,7 +2830,7 @@
         "it": "applemusic://track/1685075664"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=uw_t_o-LluM",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/42753194",
       "uri_deezer": "deezer://track/563850",
       "fun_fact": "A 70s classic (1973).",
       "fun_fact_de": "Ein 70er-Klassiker (1973).",
@@ -2855,7 +2855,7 @@
         "it": "applemusic://track/1660680959"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=ZR-3r5Z9kqw",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/1747034",
       "uri_deezer": "deezer://track/3248376",
       "fun_fact": "A 70s classic (1979).",
       "fun_fact_de": "Ein 70er-Klassiker (1979).",
@@ -2880,7 +2880,7 @@
         "it": "applemusic://track/1445662813"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=Pu5c4aEg3NM",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/18152390",
       "uri_deezer": "deezer://track/1175626",
       "fun_fact": "A 70s classic (1977).",
       "fun_fact_de": "Ein 70er-Klassiker (1977).",
@@ -2905,7 +2905,7 @@
         "it": "applemusic://track/1842466754"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=A_J2bcNx3Gw",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/77625023",
       "uri_deezer": "deezer://track/781563042",
       "fun_fact": "A 70s classic (1978).",
       "fun_fact_de": "Ein 70er-Klassiker (1978).",
@@ -2930,7 +2930,7 @@
         "it": "applemusic://track/1657881589"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=nYMeJSehCe4",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/93427542",
       "uri_deezer": "deezer://track/538706952",
       "fun_fact": "A 70s classic (1979).",
       "fun_fact_de": "Ein 70er-Klassiker (1979).",
@@ -2955,7 +2955,7 @@
         "it": "applemusic://track/1609685498"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=0eJ7C7-NQJ0",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/63372064",
       "uri_deezer": "deezer://track/129231820",
       "fun_fact": "A 70s classic (1972).",
       "fun_fact_de": "Ein 70er-Klassiker (1972).",
@@ -2980,7 +2980,7 @@
         "it": "applemusic://track/1618775942"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=_zoLVyQZn0Y",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/278460",
       "uri_deezer": "deezer://track/726391",
       "fun_fact": "A 70s classic (1972).",
       "fun_fact_de": "Ein 70er-Klassiker (1972).",
@@ -3005,7 +3005,7 @@
         "it": "applemusic://track/1685073516"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=bs75cGRgVEQ",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/3728808",
       "uri_deezer": "deezer://track/6071038",
       "fun_fact": "A 70s classic (1976).",
       "fun_fact_de": "Ein 70er-Klassiker (1976).",
@@ -3030,7 +3030,7 @@
         "it": "applemusic://track/1737859327"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=Qu6F-mMAQhk",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/43719965",
       "uri_deezer": "deezer://track/97081744",
       "fun_fact": "A 70s classic (1972).",
       "fun_fact_de": "Ein 70er-Klassiker (1972).",
@@ -3055,7 +3055,7 @@
         "it": "applemusic://track/1626933880"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=aNKGUaWb0kE",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/1277161",
       "uri_deezer": "deezer://track/364953",
       "fun_fact": "A 70s classic (1976).",
       "fun_fact_de": "Ein 70er-Klassiker (1976).",
@@ -3080,7 +3080,7 @@
         "it": "applemusic://track/6767662926"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=E9eLz4DrwF8",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/16154848",
       "uri_deezer": "deezer://track/2289262",
       "fun_fact": "A 70s classic (1978).",
       "fun_fact_de": "Ein 70er-Klassiker (1978).",
@@ -3105,7 +3105,7 @@
         "it": "applemusic://track/1608961067"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=ftdZ363R9kQ",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/77683246",
       "uri_deezer": "deezer://track/596034702",
       "fun_fact": "A 70s classic (1972).",
       "fun_fact_de": "Ein 70er-Klassiker (1972).",
@@ -3130,7 +3130,7 @@
         "it": "applemusic://track/206434940"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=f_-_9GGl0_I",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/1287452",
       "uri_deezer": "deezer://track/565312",
       "fun_fact": "A 70s classic (1978).",
       "fun_fact_de": "Ein 70er-Klassiker (1978).",
@@ -3155,7 +3155,7 @@
         "it": "applemusic://track/1196519945"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=BEBHIV9L3uc",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/67328812",
       "uri_deezer": "deezer://track/140302333",
       "fun_fact": "A 70s classic (1971).",
       "fun_fact_de": "Ein 70er-Klassiker (1971).",
@@ -3180,7 +3180,7 @@
         "it": "applemusic://track/318312874"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=Zl9o1QWHXko",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/53230836",
       "uri_deezer": "deezer://track/112660460",
       "fun_fact": "Electric Light Orchestra blended rock with lush orchestral pop.",
       "fun_fact_de": "Electric Light Orchestra verband Rock mit üppigem Orchester-Pop.",
@@ -3205,7 +3205,7 @@
         "it": "applemusic://track/1452666599"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=rIbMbXjbW98",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/3710217",
       "uri_deezer": "deezer://track/2121805",
       "fun_fact": "A 70s classic (1971).",
       "fun_fact_de": "Ein 70er-Klassiker (1971).",
@@ -3230,7 +3230,7 @@
         "it": "applemusic://track/1426968402"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=EOl7dh7a-6g",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/93614147",
       "uri_deezer": "deezer://track/538641872",
       "fun_fact": "A 70s classic (1971).",
       "fun_fact_de": "Ein 70er-Klassiker (1971).",


### PR DESCRIPTION
Automated Tidal-URI backfill wave (18:00 slot).

**Delta:** 70s-hits.json — +19 `uri_tidal`, version 1.8 → 1.9.

URI-only, schema-gate validated. Odesli rate-limited hard (mostly 429-skips, retried next wave).

🤖 Generated with [Claude Code](https://claude.com/claude-code)