### PR TITLE
chore(playlists): tidal backfill wave — +8 uris (anime-openings, salvaged 12:00)

### DIFF
--- a/custom_components/beatify/playlists/community/anime-openings.json
+++ b/custom_components/beatify/playlists/community/anime-openings.json
@@ -1,6 +1,6 @@
 {
   "name": "Anime Openings",
-  "version": "1.11",
+  "version": "1.12",
   "tags": [
     "anime",
     "japanese",
@@ -285,7 +285,7 @@
         "it": "applemusic://track/1702823583"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=r_hJWTufE6w",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/311108517",
       "uri_deezer": "deezer://track/2413426495",
       "fun_fact": "Opening of 'Jujutsu Kaisen' Season 2 (Shibuya Incident arc) by King Gnu.",
       "fun_fact_de": "Opening von 'Jujutsu Kaisen' Staffel 2 (Shibuya-Incident-Arc) von King Gnu.",
@@ -310,7 +310,7 @@
         "it": "applemusic://track/1793489143"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=6gMBmZ28Xg4",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/334541300",
       "uri_deezer": "deezer://track/2580253682",
       "fun_fact": "Opening of 'Mashle' Season 2 (2024) — its dance went massively viral on TikTok.",
       "fun_fact_de": "Opening von 'Mashle' Staffel 2 (2024) — der Tanz dazu ging auf TikTok extrem viral.",
@@ -360,7 +360,7 @@
         "it": "applemusic://track/1535535911"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=mtawrvojDyU",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/145060431",
       "uri_deezer": "deezer://track/975968052",
       "fun_fact": "Opening of 'Tokyo Ghoul' (2014) — one of the most iconic anime openings of the 2010s.",
       "fun_fact_de": "Opening von 'Tokyo Ghoul' (2014) — eines der ikonischsten Anime-Openings der 2010er.",
@@ -385,7 +385,7 @@
         "it": "applemusic://track/1707581765"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=m9SMT5ipbxk",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/285515076",
       "uri_deezer": "deezer://track/2210493097",
       "fun_fact": "Opening of 'Oshi no Ko' (2023) — hit #1 on the Billboard Global chart.",
       "fun_fact_de": "Opening von 'Oshi no Ko' (2023) — erreichte Platz 1 der Billboard-Global-Charts.",
@@ -460,7 +460,7 @@
         "it": "applemusic://track/1537445612"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=0NJCpJZ19n8",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/144438717",
       "uri_deezer": "deezer://track/975952742",
       "fun_fact": "Opening 1 of 'Fullmetal Alchemist: Brotherhood' (2009).",
       "fun_fact_de": "Opening 1 von 'Fullmetal Alchemist: Brotherhood' (2009).",
@@ -485,7 +485,7 @@
         "it": "applemusic://track/1607077118"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=rdryKml2YXI",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/214065166",
       "uri_deezer": "deezer://track/1634748192",
       "alt_artists": [
         "Naeleck"
@@ -513,7 +513,7 @@
         "it": "applemusic://track/1611527058"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=isY3rtuSsK8",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/162359753",
       "uri_deezer": "deezer://track/1143848452",
       "fun_fact": "Opening 1 of 'Jujutsu Kaisen' (2020) by Eve.",
       "fun_fact_de": "Opening 1 von 'Jujutsu Kaisen' (2020) von Eve.",
@@ -563,7 +563,7 @@
         "it": "applemusic://track/1672185103"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=uFUEq5ZadUw",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/277247127",
       "uri_deezer": "deezer://track/2152253197",
       "fun_fact": "Opening of 'Attack on Titan' The Final Season by Japanese reggae-metal band SiM.",
       "fun_fact_de": "Opening der finalen Staffel von 'Attack on Titan' von der Reggae-Metal-Band SiM.",


### PR DESCRIPTION
Recovered the 12:00 tidal-backfill wave from a stranded worktree (session restarted before commit).

- **community/anime-openings.json**: +8 tidal URIs, version 1.11 → 1.12
- URI-only, additive (null → `tidal://track/...`), JSON valid
- Diff verified: only `uri_tidal` + `version` lines changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)