### PR TITLE
docs(readme): YouTube Music also requires a paid plan (#1512)

### DIFF
--- a/README.md
+++ b/README.md
@@ -520,7 +520,7 @@ That's it. No mDNS, no broadcast, no additional ports.
 ### Requirements
 - **Home Assistant** 2024.1+
 - **Supported media player** (see [Supported Speakers](#supported-speakers) above)
-- **A music service** — Spotify, Apple Music, YouTube Music, Tidal or Deezer, each with a **paid plan** (on-demand single-track playback; free/ad-supported tiers don't allow it — Spotify Free is blocked, and Music Assistant's YouTube Music provider [requires Premium too](https://www.music-assistant.io/music-providers/youtube-music/)).
+- **A music service** — Spotify, Apple Music, YouTube Music, Tidal or Deezer, each of which needs a **paid plan** (on-demand single-track playback; free/ad-supported tiers don't allow it — Spotify Free is blocked, and Music Assistant's YouTube Music provider [requires Premium too](https://www.music-assistant.io/music-providers/youtube-music/)).
 - **HACS** (recommended) or manual installation
 
 ### How It Works

--- a/README.md
+++ b/README.md
@@ -520,7 +520,7 @@ That's it. No mDNS, no broadcast, no additional ports.
 ### Requirements
 - **Home Assistant** 2024.1+
 - **Supported media player** (see [Supported Speakers](#supported-speakers) above)
-- **A music service** — Spotify, Apple Music, Tidal or Deezer need a **paid plan** (on-demand single-track playback; free/ad-supported tiers like Spotify Free don't allow it). **YouTube Music is the exception** — it works with a free Google account (with ads).
+- **A music service** — Spotify, Apple Music, YouTube Music, Tidal or Deezer, each with a **paid plan** (on-demand single-track playback; free/ad-supported tiers don't allow it — Spotify Free is blocked, and Music Assistant's YouTube Music provider [requires Premium too](https://www.music-assistant.io/music-providers/youtube-music/)).
 - **HACS** (recommended) or manual installation
 
 ### How It Works
@@ -594,7 +594,7 @@ Spotify, Apple Music, YouTube Music, Tidal, and Deezer. Support depends on your 
 <details>
 <summary><strong>Do I need a paid music subscription? Does Beatify work with free Spotify?</strong></summary>
 <br>
-For most services, yes. Beatify plays a specific song on demand each round, and on Spotify, Apple Music, Tidal and Deezer that requires a <strong>paid</strong> plan—<strong>Spotify Free does not work</strong> (its free tier blocks on-demand single-track playback via Music Assistant / Spotify Connect). This is a streaming-service limitation, not a Beatify one. <strong>The exception is YouTube Music</strong>, which works with a free Google account (you'll just hear the occasional ad). So if you don't want a paid subscription, pick YouTube Music in the setup wizard. The curated playlists carry URIs for all five services.
+Yes. Beatify plays a specific song on demand each round, and on every provider—Spotify, Apple Music, YouTube Music, Tidal and Deezer—that requires a <strong>paid</strong> plan. <strong>Spotify Free does not work</strong> (its free tier blocks on-demand single-track playback via Music Assistant / Spotify Connect), and <strong>a free YouTube Music account does not work either</strong>—playback runs through Music Assistant, whose <a href="https://www.music-assistant.io/music-providers/youtube-music/">YouTube Music provider</a> supports Premium accounts only. This is a streaming-service limitation, not a Beatify one. The curated playlists carry URIs for all five services.
 </details>
 
 <details>


### PR DESCRIPTION
## What

Corrects the README's Requirements + FAQ sections, which wrongly listed **YouTube Music** as the free-account exception (all other providers need a paid plan).

## Why

Beatify's playback runs entirely through **Music Assistant**, and Music Assistant's [YouTube Music provider](https://www.music-assistant.io/music-providers/youtube-music/) supports **Premium accounts only** ("Subscription FREE: No"). So a free Google/YouTube Music account cannot be used — the same as every other provider. The incorrect "free exception" claim was introduced in #912.

Reported in [discussion #1512](https://github.com/mholzi/beatify/discussions/1512) by @fheck (who hit the wall setting it up with a free account) and confirmed by @krotname. Verified against the current Music Assistant provider docs before this change.

## Changes

- **Requirements** — YouTube Music now listed alongside the other paid providers; note that MA's YT Music provider requires Premium.
- **FAQ ("Do I need a paid music subscription?")** — removed the "YouTube Music is the free exception" paragraph; now states every provider needs a paid plan and a free YT Music account does not work.

Docs-only, no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)