### PR TITLE
chore(playlists): tidal backfill wave — +1 uri in anime-openings

### DIFF
--- a/custom_components/beatify/playlists/community/anime-openings.json
+++ b/custom_components/beatify/playlists/community/anime-openings.json
@@ -1,6 +1,6 @@
 {
   "name": "Anime Openings",
-  "version": "1.16",
+  "version": "1.17",
   "tags": [
     "anime",
     "japanese",
@@ -3358,7 +3358,7 @@
         "it": "applemusic://track/1536115701"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=RCbjLfpCbhQ",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/144480268",
       "uri_deezer": "deezer://track/976145962",
       "fun_fact": "J-rock band Long Shot Party's 2010 anime opening/ending theme",
       "fun_fact_de": "2010 Anime-Opening/Ending-Theme der J-Rock-Band Long Shot Party",


### PR DESCRIPTION
Automated Tidal-URI backfill wave (12:00, 2026-07-04).

- **anime-openings** — +1 Tidal URI (Long Shot Party – distance → `tidal://track/144480268`), `version` 1.16 → 1.17.

Wave stats: 1 added, 19 genuine misses (recorded, not re-queried), 60 rate-limit skips (retried next wave). URI-only, schema-gate validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)