### PR TITLE
fix(guessing): one artist guess per player per round (#1660)

### DIFF
--- a/custom_components/beatify/server/ws_handlers/guessing.py
+++ b/custom_components/beatify/server/ws_handlers/guessing.py
@@ -281,6 +281,22 @@ async def handle_artist_guess(
         )
         return
 
+    # One artist attempt per player per round. The artist challenge is
+    # multiple-choice and the options are broadcast, so without this guard a
+    # player could submit each option in turn and is guaranteed to hit the
+    # correct one (brute-force the bonus). Unlike the movie flow,
+    # ``submit_artist_guess`` only dedupes the *global* winner, not per-player
+    # attempts — so the lock has to live here. (#1660)
+    if player.has_artist_guess:
+        await ws.send_json(
+            {
+                "type": "error",
+                "code": ERR_INVALID_ACTION,
+                "message": "Artist already guessed this round",
+            }
+        )
+        return
+
     artist = data.get("artist", "").strip()
     if not artist:
         await ws.send_json(

--- a/tests/unit/test_websocket.py
+++ b/tests/unit/test_websocket.py
@@ -670,6 +670,32 @@ class TestArtistGuess:
         assert ack["correct"] is True
         assert ack["first"] is True
 
+    async def test_artist_guess_already_guessed(self):
+        """A second artist guess in the same round is rejected (#1660).
+
+        The challenge is multiple-choice with broadcast options, so without a
+        one-guess-per-player guard a player could brute-force the bonus. The
+        guard must short-circuit before scoring.
+        """
+        handler, game_state, ws = _make_handler_and_game()
+        game_state.add_player("Alice", ws)
+        game_state.phase = GamePhase.PLAYING
+        game_state.artist_challenge = ArtistChallenge(
+            correct_artist="A", options=["A", "B"]
+        )
+        player = game_state.get_player_by_ws(ws)
+        player.has_artist_guess = True
+        game_state.submit_artist_guess = MagicMock()
+
+        await handler._handle_message(
+            ws, {"type": "artist_guess", "artist": "B"}
+        )
+
+        msg = ws.send_json.call_args[0][0]
+        assert msg["type"] == "error"
+        assert msg["code"] == ERR_INVALID_ACTION
+        game_state.submit_artist_guess.assert_not_called()
+
 
 # ---------------------------------------------------------------------------
 # Movie guess

--- a/tests/unit/test_websocket.py
+++ b/tests/unit/test_websocket.py
@@ -687,9 +687,7 @@ class TestArtistGuess:
         player.has_artist_guess = True
         game_state.submit_artist_guess = MagicMock()
 
-        await handler._handle_message(
-            ws, {"type": "artist_guess", "artist": "B"}
-        )
+        await handler._handle_message(ws, {"type": "artist_guess", "artist": "B"})
 
         msg = ws.send_json.call_args[0][0]
         assert msg["type"] == "error"


### PR DESCRIPTION
Closes #1660.

## Bug
The artist challenge is multiple-choice and its options are broadcast in the round state. `handle_artist_guess` set `player.has_artist_guess = True` only **after** calling `submit_artist_guess` and never guarded on it, and `submit_artist_guess` only dedupes the **global** winner (not per-player attempts). So a player could submit each option in turn and was guaranteed to hit the correct one — brute-forcing `ARTIST_BONUS_POINTS` with zero knowledge.

## Fix
Add an early `if player.has_artist_guess: return` guard at the top of the guess flow (mirrors the movie handler's one-attempt intent).

## Test
`test_artist_guess_already_guessed` asserts a second guess in the same round returns an error and that `submit_artist_guess` is never called (guard short-circuits before scoring).

🤖 Generated with [Claude Code](https://claude.com/claude-code)