### PR TITLE
fix(mix): age-scope transient cleanup so parallel runs don't clobber (#1657)

### DIFF
--- a/custom_components/beatify/server/mix_views.py
+++ b/custom_components/beatify/server/mix_views.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 import json
 import logging
 import random
+import time
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
@@ -76,6 +77,10 @@ MAX_TAGS = 40
 TRANSIENT_MIX_PREFIX = "__mix__"
 # Subdirectory (under the playlist dir) that holds transient mixes.
 TRANSIENT_MIX_SUBDIR = "mix"
+# Transient mixes older than this are removed on the next write. Must comfortably
+# exceed the POST /mix → start-game gap so a concurrent run's fresh file is never
+# cleaned out from under it (#1657).
+TRANSIENT_MIX_MAX_AGE_S = 3600
 
 
 def _is_transient_mix(path: str) -> bool:
@@ -345,15 +350,22 @@ class MixPlaylistView(RateLimitMixin, HomeAssistantView):
             # each other's transient file (#1547). The returned path is what gets
             # fed into start-game, so it always points at THIS run's file.
             target = mix_dir / f"{TRANSIENT_MIX_PREFIX}-{uuid.uuid4().hex[:8]}.json"
-            # Best-effort cleanup of stale transient mixes so the mix/ folder
-            # does not grow unbounded. Never let a cleanup failure block the
-            # write — the freshly-written file below is all start-game needs.
-            try:
-                for old in mix_dir.glob(f"{TRANSIENT_MIX_PREFIX}*.json"):
-                    if old != target:
+            # Best-effort cleanup of STALE transient mixes so the mix/ folder
+            # does not grow unbounded. Only remove files older than
+            # TRANSIENT_MIX_MAX_AGE_S — a sibling run started in parallel has a
+            # freshly-written file, and deleting "everything except my target"
+            # would clobber it in the window between its POST /mix and its
+            # start-game (#1657), defeating the #1547 unique-stem guarantee.
+            # Never let a cleanup failure block the write.
+            cutoff = time.time() - TRANSIENT_MIX_MAX_AGE_S
+            for old in mix_dir.glob(f"{TRANSIENT_MIX_PREFIX}*.json"):
+                if old == target:
+                    continue
+                try:
+                    if old.stat().st_mtime < cutoff:
                         old.unlink()
-            except OSError as cleanup_err:  # pragma: no cover - best-effort I/O
-                _LOGGER.debug("Mix cleanup skipped: %s", cleanup_err)
+                except OSError as cleanup_err:  # pragma: no cover - best-effort I/O
+                    _LOGGER.debug("Mix cleanup skipped %s: %s", old.name, cleanup_err)
             target.write_text(
                 json.dumps(playlist_doc, indent=2, ensure_ascii=False),
                 encoding="utf-8",

--- a/tests/unit/test_mix_view.py
+++ b/tests/unit/test_mix_view.py
@@ -331,6 +331,43 @@ class TestMixPlaylistView:
         assert Path(path1).name.startswith("__mix__-")
         assert Path(path2).name.startswith("__mix__-")
 
+    async def test_transient_mix_cleanup_preserves_fresh_siblings(self, tmp_path):
+        """#1657: a concurrent run's fresh transient file must survive cleanup.
+
+        The old cleanup deleted every ``__mix__*.json`` except the current
+        target, so run A's file vanished the moment run B wrote its own —
+        breaking the #1547 parallel-safety guarantee. Only *stale* files
+        (older than TRANSIENT_MIX_MAX_AGE_S) should be removed.
+        """
+        import os
+        import time as _time
+
+        from custom_components.beatify.server.mix_views import (
+            TRANSIENT_MIX_MAX_AGE_S,
+        )
+
+        view = _view_with_catalogue(tmp_path)
+        body = json.dumps(
+            {"tags": ["pop"], "target_count": 50, "provider": "spotify"}
+        ).encode()
+
+        resp1 = await view.post(_request_with_body(body))
+        path1 = Path(json.loads(resp1.body)["path"])
+
+        # A second (parallel) run must NOT delete run 1's fresh file.
+        resp2 = await view.post(_request_with_body(body))
+        path2 = Path(json.loads(resp2.body)["path"])
+        assert path1.exists(), "fresh sibling transient was clobbered"
+        assert path2.exists()
+
+        # A genuinely stale transient IS cleaned up on the next write.
+        stale = path1.parent / "__mix__-staaaale.json"
+        stale.write_text("{}", encoding="utf-8")
+        old = _time.time() - (TRANSIENT_MIX_MAX_AGE_S + 60)
+        os.utime(stale, (old, old))
+        await view.post(_request_with_body(body))
+        assert not stale.exists(), "stale transient should have been removed"
+
     async def test_save_as_community_writes_to_user_subdir(self, tmp_path):
         view = _view_with_catalogue(tmp_path)
         body = json.dumps(


### PR DESCRIPTION
Closes #1657.

## Bug
`_write_transient()` cleaned up the mix folder by deleting **every** `__mix__*.json` except its own target. Despite the #1547 unique-stem promise ("two games started in parallel never clobber each other's transient file"), this removed a concurrent run's freshly-written file in the window between its `POST /mix` (returns the path) and its `start-game` (reads it) → "playlist not found".

## Fix
Scope the cleanup by **age**: only unlink transients older than `TRANSIENT_MIX_MAX_AGE_S` (1h, new constant). An in-flight sibling run's file is seconds old and is never touched, while crashed-run leftovers still get cleaned so the folder stays bounded.

## Test
`test_transient_mix_cleanup_preserves_fresh_siblings` — asserts run A's fresh file survives run B's write (would fail on the old code), and that a genuinely stale file (mtime pushed past the cutoff) is still removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)