### PR TITLE
fix(guessing): reject late Artist/Movie/Title&Artist guesses past deadline (#1662)

### DIFF
--- a/custom_components/beatify/server/ws_handlers/guessing.py
+++ b/custom_components/beatify/server/ws_handlers/guessing.py
@@ -260,6 +260,19 @@ async def handle_artist_guess(
         )
         return
 
+    # #1662: reject late guesses in the window between deadline expiry and the
+    # end_round phase flip — mirrors the year handler's guard so Artist/Movie/
+    # Title&Artist challenges can't bank points/bonus after time is up.
+    if game_state.is_deadline_passed():
+        await ws.send_json(
+            {
+                "type": "error",
+                "code": ERR_ROUND_EXPIRED,
+                "message": "Time's up!",
+            }
+        )
+        return
+
     player = game_state.get_player_by_ws(ws)
     if not player:
         await ws.send_json(
@@ -357,6 +370,19 @@ async def handle_movie_guess(
         )
         return
 
+    # #1662: reject late guesses in the window between deadline expiry and the
+    # end_round phase flip — mirrors the year handler's guard so Artist/Movie/
+    # Title&Artist challenges can't bank points/bonus after time is up.
+    if game_state.is_deadline_passed():
+        await ws.send_json(
+            {
+                "type": "error",
+                "code": ERR_ROUND_EXPIRED,
+                "message": "Time's up!",
+            }
+        )
+        return
+
     player = game_state.get_player_by_ws(ws)
     if not player:
         await ws.send_json(
@@ -435,6 +461,19 @@ async def handle_title_artist_guess(
                 "type": "error",
                 "code": ERR_INVALID_ACTION,
                 "message": "Can only guess during PLAYING phase",
+            }
+        )
+        return
+
+    # #1662: reject late guesses in the window between deadline expiry and the
+    # end_round phase flip — mirrors the year handler's guard so Artist/Movie/
+    # Title&Artist challenges can't bank points/bonus after time is up.
+    if game_state.is_deadline_passed():
+        await ws.send_json(
+            {
+                "type": "error",
+                "code": ERR_ROUND_EXPIRED,
+                "message": "Time's up!",
             }
         )
         return

--- a/tests/unit/test_ws_late_guess_deadline.py
+++ b/tests/unit/test_ws_late_guess_deadline.py
@@ -1,0 +1,100 @@
+"""Regression tests for #1662 (late-guess gap).
+
+The Artist / Movie / Title&Artist challenge WS handlers must reject guesses
+submitted after the round deadline has passed — mirroring the year handler's
+``is_deadline_passed()`` guard (``ws_handlers/guessing.py``). Without it, in the
+window between deadline expiry and the ``end_round`` phase flip a late guess
+could still bank points/bonus while ``phase`` was still ``PLAYING``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.beatify.const import DOMAIN, ERR_ROUND_EXPIRED
+from custom_components.beatify.game.state import GamePhase
+from tests.conftest import make_game_state, make_songs
+
+from custom_components.beatify.server.websocket import (  # isort: skip
+    BeatifyWebSocketHandler,
+)
+
+
+def _stub_media_service() -> MagicMock:
+    svc = MagicMock()
+    svc.is_available.return_value = True
+    svc.play_song = AsyncMock(return_value=True)
+    svc.verify_responsive = AsyncMock(return_value=(True, None))
+    return svc
+
+
+def _ws() -> AsyncMock:
+    ws = AsyncMock()
+    ws.send_json = AsyncMock()
+    ws.closed = False
+    ws.close = AsyncMock()
+    return ws
+
+
+async def _playing_game_with_player():
+    """A game in PLAYING phase whose deadline has just expired."""
+    mock_hass = MagicMock()
+    gs = make_game_state()
+    gs.create_game(
+        playlists=["t.json"],
+        songs=make_songs(3),
+        media_player="media_player.x",
+        base_url="http://h",
+    )
+    gs._media_player_service = _stub_media_service()
+    gs.platform = "music_assistant"  # skip the verify_responsive branch
+    mock_hass.data = {DOMAIN: {"game": gs}}
+    handler = BeatifyWebSocketHandler(mock_hass)
+    handler.broadcast_state = AsyncMock()
+    handler.broadcast = AsyncMock()
+    handler.debounced_broadcast_state = AsyncMock()
+
+    ws = _ws()
+    gs.add_player("Alice", ws)
+    gs.players["Alice"].connected = True
+    await gs.start_round()
+    assert gs.phase == GamePhase.PLAYING
+    # Round is still PLAYING, but the deadline has elapsed.
+    gs.is_deadline_passed = MagicMock(return_value=True)
+    return handler, gs, ws
+
+
+def _sent_codes(ws: AsyncMock) -> list[str]:
+    return [
+        call.args[0].get("code")
+        for call in ws.send_json.call_args_list
+        if call.args and isinstance(call.args[0], dict)
+    ]
+
+
+class TestLateGuessRejected:
+    @pytest.mark.parametrize(
+        ("message", "flag"),
+        [
+            ({"type": "artist_guess", "artist": "Whoever"}, "has_artist_guess"),
+            ({"type": "movie_guess", "movie": "Whatever"}, "has_movie_guess"),
+            (
+                {"type": "title_artist_guess", "title": "T", "artist": "A"},
+                "has_title_artist_guess",
+            ),
+        ],
+    )
+    async def test_guess_after_deadline_is_rejected(self, message, flag):
+        """A late guess gets ROUND_EXPIRED and is never recorded."""
+        handler, gs, ws = await _playing_game_with_player()
+
+        await handler._handle_message(ws, message)
+
+        # Handler answered with the round-expired error ...
+        assert ERR_ROUND_EXPIRED in _sent_codes(ws)
+        # ... and never marked the guess as submitted (no points/bonus banked).
+        assert getattr(gs.players["Alice"], flag) is False
+
+        gs._cancel_auto_advance()


### PR DESCRIPTION
## What

The year-guess handler (`ws_handlers/guessing.py`) rejects submissions after the round deadline via `is_deadline_passed()`, but the three challenge handlers — `handle_artist_guess`, `handle_movie_guess`, `handle_title_artist_guess` — only gated on `phase == GamePhase.PLAYING`.

In the window between deadline expiry and the `end_round` phase flip, the phase is still `PLAYING`, so a late guess could still bank points/bonus. This is the **late-guess gap** item from #1662 (Fable code review, v4.2.0-rc9).

## Fix

Add the same `is_deadline_passed()` → `ERR_ROUND_EXPIRED` guard to all three handlers, placed immediately after the phase check (before player lookup and per-mode requirements) so a late guess is rejected uniformly.

## Test

New `tests/unit/test_ws_late_guess_deadline.py` — parametrized over all three message types; forces `is_deadline_passed() == True` while `phase == PLAYING`, drives the real handler, asserts the response carries `ROUND_EXPIRED` and the guess flag stays unset.

## Scope

Addresses only the **late-guess-gap** checkbox of #1662; the other items (verbose auth logging, timer clock-skew, reconnect divergence) remain open in that issue. Draft — no auto-merge.

Refs #1662