### PR TITLE
fix(mix): validate provider against the shared whitelist (#1658)

### DIFF
--- a/custom_components/beatify/server/mix_views.py
+++ b/custom_components/beatify/server/mix_views.py
@@ -52,6 +52,7 @@ from custom_components.beatify.server.base import (
     _read_file,
 )
 from custom_components.beatify.server.companion_auth import is_authorized_http
+from custom_components.beatify.server.game_views import _validate_provider
 from custom_components.beatify.server.playlist_views import _slugify_playlist_name
 
 if TYPE_CHECKING:
@@ -256,9 +257,16 @@ class MixPlaylistView(RateLimitMixin, HomeAssistantView):
         if target_count not in ALLOWED_TARGET_COUNTS:
             target_count = DEFAULT_TARGET_COUNT
 
-        provider = body.get("provider") or PROVIDER_DEFAULT
-        if not isinstance(provider, str):
-            provider = PROVIDER_DEFAULT
+        # #1658: validate the provider against the shared whitelist
+        # (game_views._validate_provider is the single source of truth) so an
+        # unknown/hostile provider string can't flow into get_song_uri / mix
+        # assembly unchecked — it coerces to PROVIDER_DEFAULT instead.
+        raw_provider = body.get("provider")
+        provider = _validate_provider(
+            raw_provider
+            if isinstance(raw_provider, str) and raw_provider
+            else PROVIDER_DEFAULT
+        )
         save_as_community = bool(body.get("save_as_community", False))
         # #1586: a "preview" request assembles + de-dupes exactly like a real
         # run but returns the resulting tracklist WITHOUT writing any file, so

--- a/tests/unit/test_mix_view.py
+++ b/tests/unit/test_mix_view.py
@@ -25,6 +25,7 @@ import pytest
 from aiohttp import StreamReader
 from aiohttp.test_utils import make_mocked_request
 
+from custom_components.beatify.const import PROVIDER_DEEZER, PROVIDER_DEFAULT
 from custom_components.beatify.server.base import _read_file
 from custom_components.beatify.server.mix_views import (
     MixPlaylistView,
@@ -453,6 +454,38 @@ class TestMixPlaylistView:
         data = json.loads(resp.body)
         # 4 unique songs available, default cap 50 → all 4 returned, no crash.
         assert data["song_count"] == 4
+
+    @pytest.mark.parametrize(
+        ("sent_provider", "expected"),
+        [
+            ("totally-bogus", PROVIDER_DEFAULT),
+            ("spotify'; DROP TABLE songs;--", PROVIDER_DEFAULT),
+            ("", PROVIDER_DEFAULT),
+            (None, PROVIDER_DEFAULT),
+            (123, PROVIDER_DEFAULT),
+            ({"nested": "obj"}, PROVIDER_DEFAULT),
+            ("deezer", PROVIDER_DEEZER),  # whitelisted → passes through
+        ],
+    )
+    async def test_provider_validated_against_whitelist(
+        self, tmp_path, sent_provider, expected
+    ):
+        """#1658: unknown/non-string providers coerce to the default; a
+        whitelisted provider passes through unchanged — checked *before* the
+        value reaches ``get_song_uri`` / mix assembly."""
+        view = _view_with_catalogue(tmp_path)
+        body = json.dumps(
+            {"tags": ["pop"], "provider": sent_provider, "preview": True}
+        ).encode()
+        spy = MagicMock(return_value=([_song("0001")], 1))
+        with mock.patch(
+            "custom_components.beatify.server.mix_views._assemble_mix_songs",
+            new=spy,
+        ):
+            resp = await view.post(_request_with_body(body))
+        assert resp.status == 200
+        # provider is the 4th positional arg passed to _assemble_mix_songs.
+        assert spy.call_args.args[3] == expected
 
     async def test_unauthorized_returns_401(self, tmp_path):
         view = _view_with_catalogue(tmp_path)


### PR DESCRIPTION
## What

The Mix endpoint (`server/mix_views.py`) accepted **any** provider string — it only checked `isinstance(provider, str)`, then fed it straight into `_assemble_mix_songs` → `get_song_uri`. An unknown provider (typo, stale client, hostile input) wasn't rejected: it just silently produced an empty/degraded mix rather than falling back to the default. (#1658, Fable code review.)

## Fix

Reuse `game_views._validate_provider` — the **single source of truth** for the six supported providers, introduced by #808 precisely so the provider whitelist lives in one place. Unknown or non-string providers now coerce to `PROVIDER_DEFAULT`; whitelisted ones pass through unchanged. No import cycle (`mix_views` → `game_views` only).

## Test

Parametrized case in `tests/unit/test_mix_view.py` spies on `_assemble_mix_songs` and asserts the provider it receives: bogus / SQL-ish / empty / `None` / int / object → `spotify` (default); `deezer` → `deezer` (passes through).

Draft — no auto-merge.

Closes #1658