### PR TITLE
fix(logging): lower per-request auth/WS diagnostics from INFO to DEBUG (#1662)

### DIFF
--- a/custom_components/beatify/server/companion_auth.py
+++ b/custom_components/beatify/server/companion_auth.py
@@ -140,7 +140,7 @@ def is_companion_trusted_request(request: web.Request, hass: HomeAssistant) -> b
     # rc9 diagnostic: log every HTTP trust check so #1131 / #1120 reports can
     # be correlated with the actual UA + remote that reaches the server.
     # Remove once Companion auth lands stable.
-    _LOGGER.info(
+    _LOGGER.debug(
         "[Companion-Debug] HTTP path=%s ua=%r remote=%s ua_match=%s ip_match=%s trusted=%s",
         request.path,
         (ua[:200] if isinstance(ua, str) else ua),
@@ -172,14 +172,14 @@ def is_companion_trusted_meta(meta: dict | None, hass: HomeAssistant) -> bool:
         return False
 
     if not isinstance(meta, dict):
-        _LOGGER.info("[Companion-Debug] WS meta=None (no signature collected)")
+        _LOGGER.debug("[Companion-Debug] WS meta=None (no signature collected)")
         return False
     ua = meta.get("ua")
     remote = meta.get("remote")
     ua_match = is_companion_ua(ua)
     ip_match = is_local_remote(remote)
     trusted = ua_match and ip_match
-    _LOGGER.info(
+    _LOGGER.debug(
         "[Companion-Debug] WS ua=%r remote=%s ua_match=%s ip_match=%s trusted=%s",
         (ua[:200] if isinstance(ua, str) else ua),
         remote,
@@ -214,13 +214,13 @@ def is_authorized_http(request: web.Request, hass: HomeAssistant) -> bool:
             bearer_present = True
             result = hass.auth.async_validate_access_token(token)
             if result is not None:
-                _LOGGER.info(
+                _LOGGER.debug(
                     "[Companion-Debug] HTTP path=%s bearer_valid=True (bypass not consulted)",
                     request.path,
                 )
                 return True
     if bearer_present:
-        _LOGGER.info(
+        _LOGGER.debug(
             "[Companion-Debug] HTTP path=%s bearer_present=True bearer_valid=False (falling back to bypass)",
             request.path,
         )

--- a/custom_components/beatify/server/websocket.py
+++ b/custom_components/beatify/server/websocket.py
@@ -186,7 +186,7 @@ class BeatifyWebSocketHandler:
         # upgrade time so we can confirm whether the WS path sees the same
         # Companion signature the HTTP path does, or whether the upgrade
         # arrives with a different UA / through a different proxy hop.
-        _LOGGER.info(
+        _LOGGER.debug(
             "[WS-Debug] upgrade path=%s remote=%s ua=%r total=%d",
             request.path,
             request.remote,
@@ -199,7 +199,7 @@ class BeatifyWebSocketHandler:
                 if msg.type == WSMsgType.TEXT:
                     try:
                         parsed = msg.json()
-                        _LOGGER.info(
+                        _LOGGER.debug(
                             "[WS-Debug] recv type=%s keys=%s",
                             parsed.get("type") if isinstance(parsed, dict) else "?",
                             list(parsed.keys()) if isinstance(parsed, dict) else None,
@@ -217,7 +217,7 @@ class BeatifyWebSocketHandler:
 
                     self._record_error(ERROR_WEBSOCKET_DISCONNECT, err_msg)
                 else:
-                    _LOGGER.info(
+                    _LOGGER.debug(
                         "[WS-Debug] non-text msg type=%s",
                         msg.type,
                     )
@@ -225,7 +225,7 @@ class BeatifyWebSocketHandler:
         finally:
             self.connections.discard(ws)
             await self._handle_disconnect(ws)
-            _LOGGER.info(
+            _LOGGER.debug(
                 "[WS-Debug] disconnect path=%s remote=%s total=%d ws_closed=%s close_code=%s",
                 request.path,
                 request.remote,

--- a/custom_components/beatify/server/ws_handlers/lifecycle.py
+++ b/custom_components/beatify/server/ws_handlers/lifecycle.py
@@ -50,7 +50,7 @@ async def handle_join(
     # see exactly which path the player-join takes when "Reconnecting"
     # surfaces on the client. Remove once #1131 lands stable.
     meta = getattr(ws, "beatify_request_meta", None)
-    _LOGGER.info(
+    _LOGGER.debug(
         "[WS-Debug] join name=%r is_admin=%s ha_token_present=%s phase=%s meta=%s",
         name,
         is_admin,
@@ -67,7 +67,7 @@ async def handle_join(
     was_existing_player = game_state.get_player(name) is not None
 
     success, error_code = game_state.add_player(name, ws)
-    _LOGGER.info(
+    _LOGGER.debug(
         "[WS-Debug] join add_player name=%r success=%s error_code=%s was_existing=%s",
         name,
         success,
@@ -83,7 +83,7 @@ async def handle_join(
             # Normal players join with no auth — only the admin claim is
             # gated. add_player() already ran, so undo it on rejection.
             authed = _is_ha_authenticated(handler, data, ws)
-            _LOGGER.info(
+            _LOGGER.debug(
                 "[WS-Debug] join is_admin=True _is_ha_authenticated=%s",
                 authed,
             )


### PR DESCRIPTION
Fixes the **verbose-logging** item of #1662: several auth/WS diagnostic paths log User-Agent, remote IP, match flags and token-presence at **INFO** on *every* request / WS message — log flood plus minor privacy/token-presence exposure. These purely diagnostic calls are lowered to **DEBUG**. Log message text and behaviour are otherwise unchanged.

### Changes (12 `_LOGGER.info` → `_LOGGER.debug`)

- **`custom_components/beatify/server/companion_auth.py`** — 5 lowered. All `[Companion-Debug]` per-request trust-check logs (HTTP UA/remote/match/trusted, WS meta=None, WS UA/remote/match/trusted, bearer-valid, bearer-present-fallback). Fire on every protected HTTP request / WS trust evaluation.
- **`custom_components/beatify/server/websocket.py`** — 4 lowered. All `[WS-Debug]` logs: per-connection upgrade, per-message `recv type/keys`, per-message non-text, per-connection disconnect.
- **`custom_components/beatify/server/ws_handlers/lifecycle.py`** — 3 lowered. All `[WS-Debug]` per-join-message logs: join attempt (incl. `ha_token_present`), add_player result, admin-auth result.

### Left as INFO (deliberately — legitimate operational lifecycle, not per-request diagnostics)

- `websocket.py`: "Admin spectator WebSocket disconnected", "Player disconnected", "Game paused due to admin disconnect".
- `lifecycle.py`: admin reconnect / game resumed / player onboarding / session takeover / player reconnected / player left messages.

Validated locally with `python3 -m py_compile` (all three files) and `uvx ruff check` (all checks passed). Python unit tests run in CI.

`Refs #1662` — do not close, #1662 has other open items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)