### PR TITLE
fix(logging): demote verbose WS-Debug/Companion-Debug diagnostics to DEBUG (#1662)

### DIFF
--- a/custom_components/beatify/server/companion_auth.py
+++ b/custom_components/beatify/server/companion_auth.py
@@ -137,10 +137,8 @@ def is_companion_trusted_request(request: web.Request, hass: HomeAssistant) -> b
     ua_match = is_companion_ua(ua)
     ip_match = is_local_remote(remote)
     trusted = ua_match and ip_match
-    # rc9 diagnostic: log every HTTP trust check so #1131 / #1120 reports can
-    # be correlated with the actual UA + remote that reaches the server.
-    # Remove once Companion auth lands stable.
-    _LOGGER.info(
+    # #1662: demoted to DEBUG — these fire on every auth check and flood INFO logs.
+    _LOGGER.debug(
         "[Companion-Debug] HTTP path=%s ua=%r remote=%s ua_match=%s ip_match=%s trusted=%s",
         request.path,
         (ua[:200] if isinstance(ua, str) else ua),
@@ -172,14 +170,14 @@ def is_companion_trusted_meta(meta: dict | None, hass: HomeAssistant) -> bool:
         return False
 
     if not isinstance(meta, dict):
-        _LOGGER.info("[Companion-Debug] WS meta=None (no signature collected)")
+        _LOGGER.debug("[Companion-Debug] WS meta=None (no signature collected)")
         return False
     ua = meta.get("ua")
     remote = meta.get("remote")
     ua_match = is_companion_ua(ua)
     ip_match = is_local_remote(remote)
     trusted = ua_match and ip_match
-    _LOGGER.info(
+    _LOGGER.debug(
         "[Companion-Debug] WS ua=%r remote=%s ua_match=%s ip_match=%s trusted=%s",
         (ua[:200] if isinstance(ua, str) else ua),
         remote,
@@ -214,13 +212,13 @@ def is_authorized_http(request: web.Request, hass: HomeAssistant) -> bool:
             bearer_present = True
             result = hass.auth.async_validate_access_token(token)
             if result is not None:
-                _LOGGER.info(
+                _LOGGER.debug(
                     "[Companion-Debug] HTTP path=%s bearer_valid=True (bypass not consulted)",
                     request.path,
                 )
                 return True
     if bearer_present:
-        _LOGGER.info(
+        _LOGGER.debug(
             "[Companion-Debug] HTTP path=%s bearer_present=True bearer_valid=False (falling back to bypass)",
             request.path,
         )

--- a/custom_components/beatify/server/websocket.py
+++ b/custom_components/beatify/server/websocket.py
@@ -180,13 +180,8 @@ class BeatifyWebSocketHandler:
         await ws.prepare(request)
 
         self.connections.add(ws)
-        # rc11 diagnostic (#1131 follow-up, player-join "Reconnecting" issue):
-        # the HTTP bypass works (admin loads) but the WS player-join fails.
-        # Log every WS upgrade with the *exact* UA + remote the server saw at
-        # upgrade time so we can confirm whether the WS path sees the same
-        # Companion signature the HTTP path does, or whether the upgrade
-        # arrives with a different UA / through a different proxy hop.
-        _LOGGER.info(
+        # #1662: demoted to DEBUG — fires on every WS upgrade and floods INFO logs.
+        _LOGGER.debug(
             "[WS-Debug] upgrade path=%s remote=%s ua=%r total=%d",
             request.path,
             request.remote,
@@ -199,7 +194,7 @@ class BeatifyWebSocketHandler:
                 if msg.type == WSMsgType.TEXT:
                     try:
                         parsed = msg.json()
-                        _LOGGER.info(
+                        _LOGGER.debug(
                             "[WS-Debug] recv type=%s keys=%s",
                             parsed.get("type") if isinstance(parsed, dict) else "?",
                             list(parsed.keys()) if isinstance(parsed, dict) else None,
@@ -217,7 +212,7 @@ class BeatifyWebSocketHandler:
 
                     self._record_error(ERROR_WEBSOCKET_DISCONNECT, err_msg)
                 else:
-                    _LOGGER.info(
+                    _LOGGER.debug(
                         "[WS-Debug] non-text msg type=%s",
                         msg.type,
                     )
@@ -225,7 +220,7 @@ class BeatifyWebSocketHandler:
         finally:
             self.connections.discard(ws)
             await self._handle_disconnect(ws)
-            _LOGGER.info(
+            _LOGGER.debug(
                 "[WS-Debug] disconnect path=%s remote=%s total=%d ws_closed=%s close_code=%s",
                 request.path,
                 request.remote,

--- a/custom_components/beatify/server/ws_handlers/lifecycle.py
+++ b/custom_components/beatify/server/ws_handlers/lifecycle.py
@@ -46,11 +46,9 @@ async def handle_join(
     """Handle player join request."""
     name = data.get("name", "").strip()
     is_admin = data.get("is_admin", False)
-    # rc11 diagnostic (#1131 follow-up): log every join attempt so we can
-    # see exactly which path the player-join takes when "Reconnecting"
-    # surfaces on the client. Remove once #1131 lands stable.
+    # #1662: demoted to DEBUG — fires on every join and floods INFO logs.
     meta = getattr(ws, "beatify_request_meta", None)
-    _LOGGER.info(
+    _LOGGER.debug(
         "[WS-Debug] join name=%r is_admin=%s ha_token_present=%s phase=%s meta=%s",
         name,
         is_admin,
@@ -67,7 +65,7 @@ async def handle_join(
     was_existing_player = game_state.get_player(name) is not None
 
     success, error_code = game_state.add_player(name, ws)
-    _LOGGER.info(
+    _LOGGER.debug(
         "[WS-Debug] join add_player name=%r success=%s error_code=%s was_existing=%s",
         name,
         success,
@@ -83,7 +81,7 @@ async def handle_join(
             # Normal players join with no auth — only the admin claim is
             # gated. add_player() already ran, so undo it on rejection.
             authed = _is_ha_authenticated(handler, data, ws)
-            _LOGGER.info(
+            _LOGGER.debug(
                 "[WS-Debug] join is_admin=True _is_ha_authenticated=%s",
                 authed,
             )


### PR DESCRIPTION
Closes #1662

## Readiness assessment
- [x] Ready to merge
- [ ] Borderline — see notes
- [ ] Not ready — needs human review

**Honest summary:** All 12 diagnostic `[WS-Debug]` / `[Companion-Debug]` log calls that were added as rc9/rc11 temporaries are demoted from `INFO` to `DEBUG`. No operational or alarm-worthy logs were touched. The fix is a purely mechanical level change with zero behavioural impact — the messages remain available at `logger: debug` in HA's logger config.

## Test plan
- Deploy to HA with default logger config; confirm `[WS-Debug]` / `[Companion-Debug]` lines no longer appear in the log during a normal game session
- Set `custom_components.beatify: debug` in HA logger; confirm all messages still appear (no regressions in diagnosability)
- Run `ruff check` + `ruff format --check` on the three touched files ✅ (done locally)

## Risk assessment
- **Blast radius:** 3 backend Python files, 12 log-level changes only
- **What could go wrong:** If someone was relying on these `[WS-Debug]` lines at default INFO level for issue debugging, they'll need to enable DEBUG level going forward — expected and intended behaviour
- **What I did NOT test:** Full game flow end-to-end (logging demotion is a no-op at the game-logic level)

### Scope note
The issue also listed: (1) late-guess guard in challenge handlers → **already fixed in main** (guards present with `#1662` comment); (3) XSS steal-name → **verified false positive** in the issue itself. Items (4) timer clock-skew and (5) reconnect strategy unification involve frontend JS refactoring beyond a minimum fix scope — left for a follow-up issue.

🤖 Auto-generated by issue-triage routine