### PR TITLE
fix(repo): remove tracked circular node_modules symlink

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/Users/markusholzhauser/Development/Beatify/node_modules


### PR DESCRIPTION
## Root cause

A self-referential symlink was tracked in git at HEAD:

```
120000 147ddc6 node_modules -> /Users/markusholzhauser/Development/Beatify/node_modules
```

At the repo root this symlink points at its **own** location — a circular/self-referential symlink. Because the `node_modules` path was **explicitly tracked** (mode `120000`), it **shadowed** the existing `node_modules/` rule in `.gitignore` (line 47). So on a fresh checkout git materialized the broken circular symlink, and `npm install` / local test runs failed (npm has to remove/reconcile the bogus symlink) until manually worked around.

## Fix

- `git rm --cached node_modules` — untrack the symlink. **No real dependencies were removed** (it was only a symlink, not a populated directory).
- No `.gitignore` change needed: `node_modules/` is already ignored (line 47). Once the explicit tracked entry is gone, the ignore rule correctly takes effect and node_modules stays out of the tree.

## Verification

- `git ls-files -s | grep node_modules` → now empty (was `120000 … node_modules`).
- `git check-ignore -v node_modules` → matched by `.gitignore:47`.
- Fresh `npm install` from a clean state resolves **184 packages** with no circular-symlink error.
- `npm test` → **411 tests passed (37 files)**.
- Confirmed no `node_modules/` contents were accidentally staged.

Unblocks local test runs for anyone cloning/checking out the repo.