### PR TITLE
fix(backfill): #1687 skip Odesli on 429 (no data-loss) + bump version on --apply

### DIFF
--- a/.claude/skills/provider-uri-backfill/SKILL.md
+++ b/.claude/skills/provider-uri-backfill/SKILL.md
@@ -55,7 +55,7 @@ catalog (main + community) — expect this to take a long time because of the
 |---|---|---|
 | `--repo-root` | `.` | Beatify repo root |
 | `--playlist` | all | Process one playlist (basename or `community/<name>`) |
-| `--apply` | off | Write filled URIs back to JSON (else dry-run report only) |
+| `--apply` | off | Write filled URIs back to JSON + bump each modified playlist's `version` (minor +1); else dry-run report only |
 | `--output` | `docs/provider-coverage.md` | Coverage report path |
 | `--state` | `skill/.backfill-state.json` | YouTube resume-cursor + daily-budget state |
 | `--odesli-sleep` | `6.0` | Seconds between Odesli calls (free tier ~10/min) |
@@ -81,7 +81,11 @@ a provider, it **skips** that provider for that song (it never guesses a format)
 One `GET https://api.song.link/v1-alpha.1/links?url=<spotify-url>` per track maps
 the Spotify URI to all providers at once. Keyless, free, ~10 req/min — the script
 sleeps `--odesli-sleep` (6 s) between calls and retries HTTP 429 with exponential
-backoff.
+backoff. If the backoff is exhausted (or any other Odesli error), the track is
+**skipped** for this wave (never raised — that would abort the run and lose
+partial progress); the next wave retries it. Under `--apply` progress is flushed
+to disk after every resolved song, so a mid-run 429 wall keeps everything already
+written, and the independent YouTube phase runs regardless of Odesli's state.
 
 **Known limitation:** Odesli's keyless responses frequently omit Apple Music
 entirely (observed live for multiple mainstream tracks, 2026-06). Tidal + Deezer

--- a/.claude/skills/provider-uri-backfill/scripts/backfill_provider_uris.py
+++ b/.claude/skills/provider-uri-backfill/scripts/backfill_provider_uris.py
@@ -267,7 +267,16 @@ def fetch_odesli(
     getter: Callable[[str], dict] = _http_get_json,
     sleeper: Callable[[float], None] = time.sleep,
 ) -> dict | None:
-    """Call Odesli for one Spotify track. Throttles + backs off on HTTP 429."""
+    """Call Odesli for one Spotify track. Throttles + backs off on HTTP 429.
+
+    Returns the parsed JSON on success, or ``None`` when the track can't be
+    resolved right now (429 that exhausts its backoff retries, 404, any other
+    HTTP status, or a transient network/parse error). It **never raises** — a
+    raise here would abort the whole run, discard all partial progress and
+    never reach the independent YouTube phase (#1687). A ``None`` simply skips
+    Odesli for this song; the next wave retries it (idempotent, matching
+    ``scripts/backfill_tidal.py``).
+    """
     spotify_url = f"https://open.spotify.com/track/{spotify_id}"
     api = "https://api.song.link/v1-alpha.1/links?url=" + urllib.parse.quote(
         spotify_url, safe=""
@@ -281,9 +290,12 @@ def fetch_odesli(
                 sleeper(backoff)
                 backoff *= 2
                 continue
-            if e.code == 404:
-                return None
-            raise
+            # 429 with retries exhausted, 404, or any other HTTP status: skip
+            # this provider for this song (do NOT raise / abort the run).
+            return None
+        except (urllib.error.URLError, TimeoutError, json.JSONDecodeError):
+            # Transient network / parse error → skip, retry next wave.
+            return None
     return None
 
 
@@ -338,6 +350,23 @@ def rel_name(root: Path, path: Path) -> str:
     return str(path.relative_to(base))
 
 
+def bump_version(version: Any) -> str:
+    """Bump a playlist ``MAJOR.MINOR`` version (minor +1).
+
+    Catalogue versions are strings like ``"1.8"`` / ``"1.11"`` / ``"0.1"`` — the
+    minor part is an integer, not a decimal, so ``1.9 -> 1.10``. Falls back to
+    appending ``.1`` for odd/missing values so the bump never crashes a run.
+    Identical logic to ``scripts/backfill_tidal.py`` for catalogue consistency.
+    """
+    if not isinstance(version, str) or not version:
+        return "1.1"
+    parts = version.split(".")
+    if len(parts) >= 2 and parts[-1].isdigit():
+        parts[-1] = str(int(parts[-1]) + 1)
+        return ".".join(parts)
+    return f"{version}.1"
+
+
 # ---------------------------------------------------------------------------
 # Orchestration
 # ---------------------------------------------------------------------------
@@ -378,7 +407,7 @@ def run(args: argparse.Namespace) -> int:
         songs = data.get("songs", [])
         cov = coverage_for_playlist(rel_name(root, path), str(path), songs)
         cov.filled_this_run = {p: 0 for p in PROVIDER_FIELDS}
-        dirty = False
+        version_bumped = False
 
         for song in songs:
             this_global_idx = global_idx
@@ -388,28 +417,34 @@ def run(args: argparse.Namespace) -> int:
             if not sid or not gaps:
                 continue
 
+            song_dirty = False
+
             # ---- Odesli (apple/tidal/deezer) ----
             non_yt_gaps = [g for g in gaps if g != "youtube_music"]
             if non_yt_gaps:
+                # payload is None when Odesli is unavailable (429 exhausted /
+                # error) — skip Odesli for this song but keep going so the
+                # independent YouTube phase below still runs (#1687).
                 payload = fetch_odesli(sid, sleep=args.odesli_sleep)
-                resolved = odesli_to_uris(payload or {})
-                for prov in non_yt_gaps:
-                    val = resolved.get(prov)
-                    if val:
-                        song[PROVIDER_FIELDS[prov]] = val
-                        cov.filled_this_run[prov] += 1
-                        dirty = True
-                # Deezer secondary verify via ISRC if Odesli missed it.
-                if (
-                    "deezer" in non_yt_gaps
-                    and not song.get("uri_deezer")
-                    and song.get("isrc")
-                ):
-                    did = fetch_deezer_isrc(song["isrc"])
-                    if did:
-                        song["uri_deezer"] = deezer_uri(did)
-                        cov.filled_this_run["deezer"] += 1
-                        dirty = True
+                if payload is not None:
+                    resolved = odesli_to_uris(payload)
+                    for prov in non_yt_gaps:
+                        val = resolved.get(prov)
+                        if val:
+                            song[PROVIDER_FIELDS[prov]] = val
+                            cov.filled_this_run[prov] += 1
+                            song_dirty = True
+                    # Deezer secondary verify via ISRC if Odesli missed it.
+                    if (
+                        "deezer" in non_yt_gaps
+                        and not song.get("uri_deezer")
+                        and song.get("isrc")
+                    ):
+                        did = fetch_deezer_isrc(song["isrc"])
+                        if did:
+                            song["uri_deezer"] = deezer_uri(did)
+                            cov.filled_this_run["deezer"] += 1
+                            song_dirty = True
                 time.sleep(args.odesli_sleep)
 
             # ---- YouTube Data API (resume-cursor + daily budget) ----
@@ -430,11 +465,20 @@ def run(args: argparse.Namespace) -> int:
                 if vid:
                     song["uri_youtube_music"] = youtube_uri(vid)
                     cov.filled_this_run["youtube_music"] += 1
-                    dirty = True
+                    song_dirty = True
+
+            # Incremental flush: persist after every song that changed
+            # something, so a later crash / 429 wall never discards prior
+            # progress (matching backfill_tidal.py's per-hit save). The
+            # playlist ``version`` is bumped once per file on its first write.
+            if song_dirty and args.apply:
+                if not version_bumped:
+                    old_v = data.get("version")
+                    data["version"] = bump_version(old_v)
+                    version_bumped = True
+                path.write_text(json.dumps(data, ensure_ascii=False, indent=2) + "\n")
 
         coverages.append(cov)
-        if dirty and args.apply:
-            path.write_text(json.dumps(data, ensure_ascii=False, indent=2) + "\n")
 
     if yt_key:
         save_state(state_path, yt_state)

--- a/tests/unit/test_provider_uri_backfill.py
+++ b/tests/unit/test_provider_uri_backfill.py
@@ -219,6 +219,65 @@ def test_fetch_odesli_404_returns_none():
     assert bf.fetch_odesli("x" * 22, sleep=0, getter=getter) is None
 
 
+def test_fetch_odesli_429_exhausted_returns_none_not_raises():
+    # #1687: a 429 that outlasts every backoff retry must SKIP (return None),
+    # never re-raise — a raise aborts the whole run + discards partial progress.
+    import urllib.error
+
+    calls = {"n": 0}
+
+    def getter(url):
+        calls["n"] += 1
+        raise urllib.error.HTTPError(url, 429, "rate", {}, None)
+
+    slept = []
+    out = bf.fetch_odesli(
+        "x" * 22,
+        sleep=0.01,
+        max_retries=2,
+        getter=getter,
+        sleeper=lambda s: slept.append(s),
+    )
+    assert out is None  # skipped, not raised
+    assert calls["n"] == 3  # initial try + 2 retries
+    assert len(slept) == 2  # backed off on each retryable 429
+
+
+def test_fetch_odesli_other_http_error_returns_none():
+    import urllib.error
+
+    def getter(url):
+        raise urllib.error.HTTPError(url, 500, "boom", {}, None)
+
+    assert bf.fetch_odesli("x" * 22, sleep=0, getter=getter) is None
+
+
+def test_fetch_odesli_network_error_returns_none():
+    import urllib.error
+
+    def getter(url):
+        raise urllib.error.URLError("no route")
+
+    assert bf.fetch_odesli("x" * 22, sleep=0, getter=getter) is None
+
+
+# --- version bump (matches backfill_tidal.py) ------------------------------
+@pytest.mark.parametrize(
+    "old,new",
+    [
+        ("1.0", "1.1"),
+        ("0.1", "0.2"),
+        ("1.9", "1.10"),
+        ("1.15", "1.16"),
+        ("2", "2.1"),
+        ("", "1.1"),
+        (None, "1.1"),
+    ],
+)
+def test_bump_version(old, new):
+    assert bf.bump_version(old) == new
+
+
 def test_fetch_deezer_isrc_maps_id():
     out = bf.fetch_deezer_isrc("USRE19901615", getter=lambda u: {"id": 2268878307})
     assert out == "2268878307"
@@ -374,6 +433,113 @@ def test_run_apply_writes_uri(tmp_path, monkeypatch):
         ]
     )
     assert rc == 0
-    song = json.loads(f.read_text())["songs"][0]
+    doc = json.loads(f.read_text())
+    song = doc["songs"][0]
     assert song["uri_tidal"] == "tidal://track/42"
     assert song["uri_deezer"] == "deezer://track/99"
+    # #1687 bug 2: --apply bumps the modified playlist's version (minor +1).
+    assert doc["version"] == "1.1"
+
+
+def _write_playlist(pl_dir: Path, name: str, songs: list[dict], version="1.0") -> Path:
+    doc = {"name": name, "version": version, "tags": [], "songs": songs}
+    f = pl_dir / f"{name}.json"
+    f.write_text(json.dumps(doc))
+    return f
+
+
+def test_run_apply_odesli_429_does_not_block_youtube(tmp_path, monkeypatch):
+    # #1687 bug 1: a persistent Odesli 429 (fetch_odesli -> None) must NOT stop
+    # the independent YouTube phase, which fills uri_youtube_music regardless.
+    pl_dir = tmp_path / "custom_components" / "beatify" / "playlists"
+    pl_dir.mkdir(parents=True)
+    f = _write_playlist(
+        pl_dir,
+        "yt",
+        [
+            {
+                "artist": "Rick Astley",
+                "title": "Never Gonna",
+                "uri": "spotify:track:" + "a" * 22,
+            }
+        ],
+    )
+
+    # Odesli hard-rate-limited: skips every song (returns None), never raises.
+    monkeypatch.setattr(bf, "fetch_odesli", lambda *a, **k: None)
+    monkeypatch.setattr(bf, "youtube_search_id", lambda *a, **k: "dQw4w9WgXcQ")
+    monkeypatch.setattr(bf.time, "sleep", lambda s: None)
+    monkeypatch.setenv("YOUTUBE_API_KEY", "KEY")
+
+    rc = bf.main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "--apply",
+            "--output",
+            str(tmp_path / "coverage.md"),
+            "--state",
+            str(tmp_path / "state.json"),
+            "--odesli-sleep",
+            "0",
+        ]
+    )
+    assert rc == 0
+    doc = json.loads(f.read_text())
+    song = doc["songs"][0]
+    # YouTube filled despite Odesli being down; Odesli providers stay empty.
+    assert song["uri_youtube_music"] == "https://music.youtube.com/watch?v=dQw4w9WgXcQ"
+    assert song.get("uri_tidal") is None
+    assert song.get("uri_deezer") is None
+    assert doc["version"] == "1.1"  # file modified → version bumped
+
+
+def test_run_apply_flushes_partial_progress_on_crash(tmp_path, monkeypatch):
+    # #1687 bug 1: progress is flushed per song, so an abort mid-run keeps every
+    # song resolved BEFORE the crash instead of discarding the whole wave.
+    pl_dir = tmp_path / "custom_components" / "beatify" / "playlists"
+    pl_dir.mkdir(parents=True)
+    f = _write_playlist(
+        pl_dir,
+        "two",
+        [
+            {"artist": "A", "title": "1", "uri": "spotify:track:" + "a" * 22},
+            {"artist": "B", "title": "2", "uri": "spotify:track:" + "b" * 22},
+        ],
+    )
+
+    calls = {"n": 0}
+
+    def flaky_odesli(*a, **k):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return {
+                "linksByPlatform": {"tidal": {"entityUniqueId": "TIDAL_SONG::42"}},
+                "entitiesByUniqueId": {"TIDAL_SONG::42": {"id": "42"}},
+            }
+        raise RuntimeError("simulated mid-run abort")
+
+    monkeypatch.setattr(bf, "fetch_odesli", flaky_odesli)
+    monkeypatch.setattr(bf.time, "sleep", lambda s: None)
+    monkeypatch.delenv("YOUTUBE_API_KEY", raising=False)
+
+    with pytest.raises(RuntimeError):
+        bf.main(
+            [
+                "--repo-root",
+                str(tmp_path),
+                "--apply",
+                "--output",
+                str(tmp_path / "coverage.md"),
+                "--state",
+                str(tmp_path / "state.json"),
+                "--odesli-sleep",
+                "0",
+            ]
+        )
+
+    doc = json.loads(f.read_text())
+    # Song 1 was flushed before the crash on song 2; nothing lost.
+    assert doc["songs"][0]["uri_tidal"] == "tidal://track/42"
+    assert doc["songs"][1].get("uri_tidal") is None
+    assert doc["version"] == "1.1"  # bumped once on the first flush


### PR DESCRIPTION
## Summary

Fixes both bugs in the `provider-uri-backfill` skill script
(`.claude/skills/provider-uri-backfill/scripts/backfill_provider_uris.py`)
reported in #1687, surfaced during a backfill while Odesli was hard-rate-limiting (HTTP 429).

### Bug 1 — crash-on-429 aborted the whole run (data-loss)
`fetch_odesli` re-raised the 429 after exhausting its backoff retries. Since the
Odesli (Apple/Tidal/Deezer) and YouTube resolution shared one per-song loop and the
JSON was only written after the loop completed, a sustained Odesli 429 (a) aborted the
run and discarded all partial progress, and (b) never reached the independent YouTube
phase — writing 0 changes even though YouTube (a separate API) was fully available.

**Fix (matching `scripts/backfill_tidal.py`'s skip-on-429 + per-hit save):**
- `fetch_odesli` now returns `None` (skip this provider for this song, next wave
  retries) on exhausted-429 / 404 / any other HTTP status / transient network+parse
  error. It **never raises** — so it can no longer abort the run.
- The per-song loop treats a `None` payload as "Odesli unavailable, skip" and **keeps
  going**, so the independent YouTube phase always runs regardless of Odesli's state.
- Under `--apply`, progress is now **flushed to disk after every resolved song**, so an
  abort mid-run keeps everything already written instead of discarding the whole wave.

### Bug 2 — `--apply` did not bump the playlist `version`
`--apply` wrote URIs but never bumped `version`, contrary to the SKILL doc and the
catalogue convention (minor +1 per modified file, e.g. 1.15→1.16).

**Fix:** added a `bump_version` helper with logic identical to `backfill_tidal.py`
(`1.9 → 1.10`, safe fallback to `.1`). On `--apply` each modified playlist's `version`
is bumped minor +1 exactly once, on its first flush.

SKILL.md updated to document both behaviours (skip-on-persistent-429, incremental
flush, independent YouTube phase, and the `--apply` version bump).

## Test coverage
Extended `tests/unit/test_provider_uri_backfill.py` (all HTTP mocked, no live requests):
- `fetch_odesli` 429-after-retries returns `None` instead of raising (+ 500 + network-error variants)
- Odesli 429 does **not** block the YouTube phase (YouTube fills `uri_youtube_music` while Odesli is down)
- partial progress is flushed: a simulated mid-run abort after song 1 leaves song 1's URI already on disk
- `--apply` bumps `version` minor +1 per modified file (+ `bump_version` unit matrix)

`python -m pytest tests/unit/test_provider_uri_backfill.py -q` → **39 passed** (standalone, Python 3.9 and 3.13). `ruff format` + `ruff check` clean.

Closes #1687

🤖 Generated with [Claude Code](https://claude.com/claude-code)