### PR TITLE
feat(backfill): #1687-followup raise Apple/Tidal/YT hit-rate (userCountry, iTunes+gate, odesli-YT-first)

### DIFF
--- a/.claude/skills/provider-uri-backfill/scripts/backfill_provider_uris.py
+++ b/.claude/skills/provider-uri-backfill/scripts/backfill_provider_uris.py
@@ -7,18 +7,26 @@ Fills gaps in ``uri_apple_music`` / ``uri_tidal`` / ``uri_deezer`` /
 Resolvers
 ---------
 * **Odesli / song.link** (primary, keyless) — one call per track maps the
-  Spotify URI to Apple Music + Tidal + Deezer in a single response. Free tier
-  is ~10 req/min, so calls are throttled (``--odesli-sleep``, default 6s) and
-  HTTP 429 is retried with exponential backoff.
+  Spotify URI to Apple Music + Tidal + Deezer + YouTube in a single response.
+  Requested with ``userCountry=DE`` so the country-scoped Apple/Tidal links
+  resolve for this DE-centric catalogue. Free tier is ~10 req/min, so calls are
+  throttled (``--odesli-sleep``, default 6s) and HTTP 429 is retried with
+  exponential backoff.
+* **Apple iTunes Search** (secondary for Apple, keyless) — when Odesli returns
+  no Apple id, ``https://itunes.apple.com/search`` is queried (diacritic-folded
+  + suffix-stripped + alt_artists variants). Every hit passes a fuzzy
+  title+artist verify-gate (:func:`titles_match`) before being trusted, so the
+  niche catalogue never collects confident-but-wrong Apple URIs.
 * **Deezer ISRC** (secondary verify for Deezer) — the undocumented public
   ``https://api.deezer.com/track/isrc:<ISRC>`` endpoint maps a song's ISRC to a
   Deezer track id, used when Odesli has no Deezer link but the song has an ISRC.
-* **YouTube Data API** (YouTube only) — Odesli's ``youtube`` field is
-  unreliable for this catalog, so ``uri_youtube_music`` is filled via
-  ``search.list`` (100 quota units each). A resume-cursor in the state file caps
-  each run at a daily budget (``--youtube-budget``, default 90) and resumes
-  across runs/days. Needs ``YOUTUBE_API_KEY``; absent → the phase is skipped
-  with a logged note (never crashes).
+* **YouTube** — Odesli's ``youtube`` link is used as a **0-quota first pass**,
+  verified via the keyless ``youtube.com/oembed`` endpoint (artist+title must
+  appear) to filter covers/live re-uploads. Only when that fails or is absent
+  does the expensive **YouTube Data API ``search.list``** (100 quota units)
+  run. A resume-cursor in the state file caps each run at a daily budget
+  (``--youtube-budget``, default 90) and resumes across runs/days. Needs
+  ``YOUTUBE_API_KEY``; absent → the phase is skipped (never crashes).
 
 Stored URI formats (matched byte-for-byte from existing data — verified live
 against Odesli for tidal/deezer; see scripts/PROVIDER_FORMATS below):
@@ -41,6 +49,7 @@ import os
 import re
 import sys
 import time
+import unicodedata
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -156,6 +165,184 @@ def _id_from_url(url: str | None, pattern: str) -> str | None:
     for g in reversed(m.groups()):
         if g and _NUMERIC.match(g):
             return g
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Fuzzy title/artist matching (pure, unit-tested)
+# ---------------------------------------------------------------------------
+# Ported from ``custom_components/beatify/game/text_match.py`` so the backfill
+# script stays standalone (no HA-runtime import). Used as the verify-gate for
+# the keyless iTunes / YouTube-oembed resolvers below: a fuzzy title+artist
+# match is required before a resolved id is trusted, otherwise the niche
+# (Polish/Eurovision/…) catalogue collects confident-but-wrong URIs.
+
+# NFD does not decompose these to base + combining mark, so fold them first.
+_ASCII_FOLD = str.maketrans(
+    {
+        "ł": "l",
+        "Ł": "l",
+        "ø": "o",
+        "Ø": "o",
+        "đ": "d",
+        "Đ": "d",
+        "ß": "ss",
+        "æ": "ae",
+        "Æ": "ae",
+        "œ": "oe",
+        "Œ": "oe",
+    }
+)
+_FEAT_RE = re.compile(r"\s+(?:feat\.?|ft\.?)\s+.*$", re.IGNORECASE)
+_PARENTHETICAL_RE = re.compile(r"\s*[\(\[][^\)\]]*[\)\]]\s*$")
+_DASH_SUFFIX_RE = re.compile(r"\s+-\s+.*$")
+_PUNCT_RE = re.compile(r"[^\w\s]", re.UNICODE)
+_WHITESPACE_RE = re.compile(r"\s+")
+_LEADING_ARTICLE_RE = re.compile(r"^(?:the|a|an)\s+")
+
+# Keyless resolver endpoints (queried in the network helpers below).
+ITUNES_SEARCH = "https://itunes.apple.com/search"
+YOUTUBE_OEMBED = "https://www.youtube.com/oembed"
+_YT_WATCH_ID_RE = re.compile(r"[?&]v=([A-Za-z0-9_-]{11})")
+_YT_SHORT_ID_RE = re.compile(r"youtu\.be/([A-Za-z0-9_-]{11})")
+
+
+def strip_diacritics(text: str) -> str:
+    """Return ``text`` with diacritics folded to ASCII (ł→l, ż→z, ó→o, é→e)."""
+    folded = (text or "").translate(_ASCII_FOLD)
+    decomposed = unicodedata.normalize("NFD", folded)
+    return "".join(ch for ch in decomposed if not unicodedata.combining(ch))
+
+
+def strip_suffixes(text: str) -> str:
+    """Strip ``feat.``/``ft.``, trailing ``(…)``/``[…]`` and `` - <suffix>``.
+
+    Case-preserving (used to build search queries), so applied before lowercase.
+    """
+    r = _FEAT_RE.sub("", text or "")
+    r = _DASH_SUFFIX_RE.sub("", r)
+    r = _PARENTHETICAL_RE.sub("", r)
+    return _WHITESPACE_RE.sub(" ", r).strip()
+
+
+def normalize_title(text: str) -> str:
+    """Aggressive normalization for equality: fold, strip qualifiers + punct."""
+    if not text:
+        return ""
+    r = strip_diacritics(text.lower())
+    r = _FEAT_RE.sub("", r)
+    r = _DASH_SUFFIX_RE.sub("", r)
+    r = _PARENTHETICAL_RE.sub("", r)
+    r = _PUNCT_RE.sub(" ", r)
+    r = _WHITESPACE_RE.sub(" ", r).strip()
+    return _LEADING_ARTICLE_RE.sub("", r)
+
+
+def _normalize_loose(text: str) -> str:
+    """Light normalization that KEEPS qualifiers (for YouTube oembed titles.
+
+    A YouTube title is usually ``Artist - Title (Official Video)`` — the ``-``
+    and parenthetical carry the real title, so the aggressive ``normalize_title``
+    would wrongly discard it. Loose = lowercase + fold + de-punct + collapse.
+    """
+    if not text:
+        return ""
+    r = strip_diacritics(text.lower())
+    r = _PUNCT_RE.sub(" ", r)
+    return _WHITESPACE_RE.sub(" ", r).strip()
+
+
+def levenshtein(a: str, b: str) -> int:
+    """Levenshtein edit distance (pure two-row DP, no dependencies)."""
+    if a == b:
+        return 0
+    if not a:
+        return len(b)
+    if not b:
+        return len(a)
+    previous = list(range(len(b) + 1))
+    for i, ca in enumerate(a, start=1):
+        current = [i]
+        for j, cb in enumerate(b, start=1):
+            current.append(
+                min(
+                    current[j - 1] + 1,
+                    previous[j] + 1,
+                    previous[j - 1] + (0 if ca == cb else 1),
+                )
+            )
+        previous = current
+    return previous[-1]
+
+
+def titles_match(a: str, b: str) -> bool:
+    """Fuzzy equality of two title/artist strings after ``normalize_title``.
+
+    True when the normalized forms are equal or within a length-scaled edit
+    budget (~1 edit per 5 chars, min 1) — tolerant of a stray remaster tag or
+    typo, strict enough to reject a different song. Empty either side → False.
+    """
+    na, nb = normalize_title(a), normalize_title(b)
+    if not na or not nb:
+        return False
+    if na == nb:
+        return True
+    budget = max(1, min(len(na), len(nb)) // 5)
+    return levenshtein(na, nb) <= budget
+
+
+def _tokens_present(needle: str, hay: str, *, min_len: int = 3) -> bool:
+    """True if every significant token of ``needle`` appears in ``hay`` (loose)."""
+    toks = [t for t in needle.split() if len(t) >= min_len] or needle.split()
+    if not toks:
+        return False
+    hay_set = set(hay.split())
+    return all(t in hay_set for t in toks)
+
+
+def _dedup(items: list[str]) -> list[str]:
+    """Order-preserving de-dup of non-empty strings."""
+    out: list[str] = []
+    for it in items:
+        if it and it not in out:
+            out.append(it)
+    return out
+
+
+def _pick_itunes_match(
+    results: list[dict], title: str, artist: str, alt_artists: list[str]
+) -> str | None:
+    """Verify-gate: first iTunes result whose title AND artist fuzzy-match.
+
+    The artist may match the primary ``artist`` OR any ``alt_artists`` entry
+    (covers writer/original-performer credits). Returns the numeric trackId of
+    the first gate-passing result, else None (never guesses on title alone).
+    """
+    for r in results or []:
+        track_id = _numeric_id(r.get("trackId"))
+        if not track_id:
+            continue
+        r_title = r.get("trackName") or r.get("trackCensoredName") or ""
+        r_artist = r.get("artistName") or ""
+        if not titles_match(r_title, title):
+            continue
+        if titles_match(r_artist, artist) or any(
+            titles_match(r_artist, alt) for alt in (alt_artists or [])
+        ):
+            return track_id
+    return None
+
+
+def odesli_youtube_video_id(payload: dict) -> str | None:
+    """Extract an 11-char YouTube video id from an Odesli response, if any."""
+    links = (payload or {}).get("linksByPlatform", {}) or {}
+    for key in ("youtubeMusic", "youtube"):
+        url = (links.get(key) or {}).get("url")
+        if not url:
+            continue
+        m = _YT_WATCH_ID_RE.search(url) or _YT_SHORT_ID_RE.search(url)
+        if m:
+            return m.group(1)
     return None
 
 
@@ -278,8 +465,12 @@ def fetch_odesli(
     ``scripts/backfill_tidal.py``).
     """
     spotify_url = f"https://open.spotify.com/track/{spotify_id}"
-    api = "https://api.song.link/v1-alpha.1/links?url=" + urllib.parse.quote(
-        spotify_url, safe=""
+    # ``userCountry=DE`` pins Odesli's ``linksByPlatform`` to the German
+    # storefront. Odesli's Apple/Tidal links are country-scoped, so omitting it
+    # made Apple/Tidal resolve worse for this DE-centric catalogue than
+    # ``scripts/backfill_tidal.py`` (which always passes it). See #1687-followup.
+    api = "https://api.song.link/v1-alpha.1/links?" + urllib.parse.urlencode(
+        {"url": spotify_url, "userCountry": "DE"}
     )
     backoff = sleep
     for attempt in range(max_retries + 1):
@@ -333,6 +524,114 @@ def youtube_search_id(
         return None
     vid = (items[0].get("id") or {}).get("videoId")
     return vid if vid and _YT_ID.match(vid) else None
+
+
+def itunes_search(
+    term: str,
+    *,
+    entity: str = "song",
+    limit: int = 5,
+    getter: Callable[[str], dict] = _http_get_json,
+) -> list[dict]:
+    """Call the keyless iTunes Search API. Returns ``results`` or ``[]``.
+
+    Uses ``itunes.apple.com/search`` (public, no key) — NOT the Apple Music
+    Developer API, which is token-gated + blocked in this environment.
+    Never raises: any HTTP/network/parse error → ``[]``.
+    """
+    q = urllib.parse.urlencode({"term": term, "entity": entity, "limit": limit})
+    try:
+        data = getter(f"{ITUNES_SEARCH}?{q}")
+    except (
+        urllib.error.HTTPError,
+        urllib.error.URLError,
+        TimeoutError,
+        json.JSONDecodeError,
+    ):
+        return []
+    return (data or {}).get("results") or []
+
+
+def resolve_apple_via_itunes(
+    song: dict, getter: Callable[[str], dict] = _http_get_json
+) -> str | None:
+    """Resolve an Apple Music track id for ``song`` via iTunes Search + gate.
+
+    Query strategy (most-specific first, deduped, stops at first gate-pass):
+      1. ``<artist> <title>`` and a suffix-stripped title (remaster/feat/…).
+      2. Diacritic-folded artist/title variants (Polish ł/ż/… → ASCII) — some
+         catalogue rows carry accents the storefront index does not.
+      3. ``alt_artists`` as a fallback performer when the primary doesn't match.
+    Only a result that clears :func:`_pick_itunes_match` is returned.
+    """
+    title = (song.get("title") or "").strip()
+    if not title:
+        return None
+    artist = (song.get("artist") or "").strip()
+    alt_artists = song.get("alt_artists") or []
+
+    stripped = strip_suffixes(title)
+    titles = _dedup([title, stripped])
+    artists = _dedup([a for a in (artist, strip_diacritics(artist)) if a])
+    folded_titles = _dedup([strip_diacritics(t) for t in titles])
+
+    terms: list[str] = []
+    for a in artists:
+        for t in titles:
+            terms.append(f"{a} {t}")
+        for t in folded_titles:
+            terms.append(f"{a} {t}")
+    for alt in alt_artists:
+        terms.append(f"{alt} {stripped}")
+
+    seen: set[str] = set()
+    for term in terms:
+        term = _WHITESPACE_RE.sub(" ", term).strip()
+        if not term or term in seen:
+            continue
+        seen.add(term)
+        results = itunes_search(term, getter=getter)
+        aid = _pick_itunes_match(results, title, artist, alt_artists)
+        if aid:
+            return aid
+    return None
+
+
+def youtube_oembed_verify(
+    video_id: str,
+    artist: str,
+    title: str,
+    getter: Callable[[str], dict] = _http_get_json,
+) -> bool:
+    """Verify a YouTube video really is ``artist – title`` via keyless oembed.
+
+    ``youtube.com/oembed`` returns the video ``title`` + channel ``author_name``
+    at 0 quota cost. The gate passes only when the expected title AND artist
+    tokens are present in that metadata — filtering covers / live / lyric
+    re-uploads that Odesli's ``youtube`` link sometimes points at. Any
+    HTTP/network/parse error → False (fall back to the paid search.list path).
+    """
+    watch = f"https://www.youtube.com/watch?v={video_id}"
+    q = urllib.parse.urlencode({"url": watch, "format": "json"})
+    try:
+        data = getter(f"{YOUTUBE_OEMBED}?{q}")
+    except (
+        urllib.error.HTTPError,
+        urllib.error.URLError,
+        TimeoutError,
+        json.JSONDecodeError,
+    ):
+        return False
+    if not data:
+        return False
+    hay = _normalize_loose(f"{data.get('author_name', '')} {data.get('title', '')}")
+    nt = _normalize_loose(title)
+    na = _normalize_loose(artist)
+    if not nt:
+        return False
+    title_ok = nt in hay or _tokens_present(nt, hay)
+    artist_ok = (not na) or na in hay or _tokens_present(na, hay)
+    return title_ok and artist_ok
 
 
 # ---------------------------------------------------------------------------
@@ -418,10 +717,15 @@ def run(args: argparse.Namespace) -> int:
                 continue
 
             song_dirty = False
-
-            # ---- Odesli (apple/tidal/deezer) ----
+            yt_gap = "youtube_music" in gaps
             non_yt_gaps = [g for g in gaps if g != "youtube_music"]
-            if non_yt_gaps:
+
+            # ---- Odesli (apple/tidal/deezer + free YouTube-first pass) ----
+            # Odesli is fetched for the Apple/Tidal/Deezer gaps AND, when a
+            # YouTube key is set, to try its ``youtube`` link as a 0-quota
+            # first pass before spending an expensive search.list call.
+            want_odesli = bool(non_yt_gaps) or (yt_gap and yt_key)
+            if want_odesli:
                 # payload is None when Odesli is unavailable (429 exhausted /
                 # error) — skip Odesli for this song but keep going so the
                 # independent YouTube phase below still runs (#1687).
@@ -445,27 +749,48 @@ def run(args: argparse.Namespace) -> int:
                             song["uri_deezer"] = deezer_uri(did)
                             cov.filled_this_run["deezer"] += 1
                             song_dirty = True
+                    # YouTube free-first: trust Odesli's link only if oembed
+                    # confirms artist+title (filters covers/live re-uploads).
+                    if yt_gap and yt_key and not song.get("uri_youtube_music"):
+                        vid = odesli_youtube_video_id(payload)
+                        if vid and youtube_oembed_verify(
+                            vid, song.get("artist", ""), song.get("title", "")
+                        ):
+                            song["uri_youtube_music"] = youtube_uri(vid)
+                            cov.filled_this_run["youtube_music"] += 1
+                            song_dirty = True
+                # Apple iTunes-Search fallback (keyless, verify-gated) whenever
+                # Odesli produced no Apple id — including when Odesli is down.
+                if "apple_music" in non_yt_gaps and not song.get("uri_apple_music"):
+                    aid = resolve_apple_via_itunes(song)
+                    if aid:
+                        song["uri_apple_music"] = apple_uri(aid)
+                        cov.filled_this_run["apple_music"] += 1
+                        song_dirty = True
                 time.sleep(args.odesli_sleep)
 
-            # ---- YouTube Data API (resume-cursor + daily budget) ----
-            if "youtube_music" in gaps and yt_key:
-                if this_global_idx < yt_state.cursor:
-                    continue  # already passed this index in a prior run
-                if not yt_state.can_spend():
-                    yt_phase_note = (
-                        f"daily budget {yt_state.budget} exhausted; "
-                        f"resume at song #{yt_state.cursor}"
-                    )
-                    continue
-                vid = youtube_search_id(
-                    yt_key, song.get("artist", ""), song.get("title", "")
-                )
-                yt_state.spend()
-                yt_state.cursor = this_global_idx + 1
-                if vid:
-                    song["uri_youtube_music"] = youtube_uri(vid)
-                    cov.filled_this_run["youtube_music"] += 1
-                    song_dirty = True
+            # ---- YouTube Data API search.list (resume-cursor + daily budget) ----
+            # Only reached when the free Odesli/oembed pass above did NOT fill
+            # YouTube — this is the quota-spending fallback (100 units/call).
+            if yt_gap and yt_key and not song.get("uri_youtube_music"):
+                if this_global_idx >= yt_state.cursor:
+                    if yt_state.can_spend():
+                        vid = youtube_search_id(
+                            yt_key, song.get("artist", ""), song.get("title", "")
+                        )
+                        yt_state.spend()
+                        yt_state.cursor = this_global_idx + 1
+                        if vid:
+                            song["uri_youtube_music"] = youtube_uri(vid)
+                            cov.filled_this_run["youtube_music"] += 1
+                            song_dirty = True
+                    else:
+                        yt_phase_note = (
+                            f"daily budget {yt_state.budget} exhausted; "
+                            f"resume at song #{yt_state.cursor}"
+                        )
+                # else: already passed this index in a prior run — leave for the
+                # next cursor window; still fall through to the flush below.
 
             # Incremental flush: persist after every song that changed
             # something, so a later crash / 429 wall never discards prior

--- a/tests/unit/test_provider_uri_backfill.py
+++ b/tests/unit/test_provider_uri_backfill.py
@@ -356,6 +356,8 @@ def test_run_dry_run_no_mutation(tmp_path, monkeypatch):
     )
     monkeypatch.setattr(bf, "fetch_deezer_isrc", lambda *a, **k: None)
     monkeypatch.setattr(bf.time, "sleep", lambda s: None)
+    # Keyless Apple iTunes fallback is network → stub it off in these tests.
+    monkeypatch.setattr(bf, "resolve_apple_via_itunes", lambda *a, **k: None)
     monkeypatch.delenv("YOUTUBE_API_KEY", raising=False)
 
     out = tmp_path / "coverage.md"
@@ -417,6 +419,8 @@ def test_run_apply_writes_uri(tmp_path, monkeypatch):
         },
     )
     monkeypatch.setattr(bf.time, "sleep", lambda s: None)
+    # Keyless Apple iTunes fallback is network → stub it off in these tests.
+    monkeypatch.setattr(bf, "resolve_apple_via_itunes", lambda *a, **k: None)
     monkeypatch.delenv("YOUTUBE_API_KEY", raising=False)
 
     rc = bf.main(
@@ -469,6 +473,8 @@ def test_run_apply_odesli_429_does_not_block_youtube(tmp_path, monkeypatch):
     monkeypatch.setattr(bf, "fetch_odesli", lambda *a, **k: None)
     monkeypatch.setattr(bf, "youtube_search_id", lambda *a, **k: "dQw4w9WgXcQ")
     monkeypatch.setattr(bf.time, "sleep", lambda s: None)
+    # Keyless Apple iTunes fallback is network → stub it off in these tests.
+    monkeypatch.setattr(bf, "resolve_apple_via_itunes", lambda *a, **k: None)
     monkeypatch.setenv("YOUTUBE_API_KEY", "KEY")
 
     rc = bf.main(
@@ -521,6 +527,8 @@ def test_run_apply_flushes_partial_progress_on_crash(tmp_path, monkeypatch):
 
     monkeypatch.setattr(bf, "fetch_odesli", flaky_odesli)
     monkeypatch.setattr(bf.time, "sleep", lambda s: None)
+    # Keyless Apple iTunes fallback is network → stub it off in these tests.
+    monkeypatch.setattr(bf, "resolve_apple_via_itunes", lambda *a, **k: None)
     monkeypatch.delenv("YOUTUBE_API_KEY", raising=False)
 
     with pytest.raises(RuntimeError):
@@ -543,3 +551,381 @@ def test_run_apply_flushes_partial_progress_on_crash(tmp_path, monkeypatch):
     assert doc["songs"][0]["uri_tidal"] == "tidal://track/42"
     assert doc["songs"][1].get("uri_tidal") is None
     assert doc["version"] == "1.1"  # bumped once on the first flush
+
+
+# ===========================================================================
+# #1687-followup: hit-rate levers (userCountry, iTunes+gate, odesli-YT-first)
+# ===========================================================================
+
+
+# --- Lever 1: userCountry=DE reaches Odesli --------------------------------
+def test_fetch_odesli_sends_user_country_de():
+    import urllib.parse
+
+    seen = {}
+
+    def getter(url):
+        seen["url"] = url
+        return {"ok": True}
+
+    bf.fetch_odesli("x" * 22, sleep=0, getter=getter)
+    assert "userCountry=DE" in seen["url"]
+    # Spotify track URL is still the query subject.
+    assert "open.spotify.com/track/" in urllib.parse.unquote(seen["url"])
+
+
+# --- fuzzy title/artist matching (verify-gate primitive) -------------------
+def test_titles_match_equal_and_diacritics():
+    assert bf.titles_match("Świętokrzyskie", "Swietokrzyskie")
+    assert bf.titles_match("Beyoncé", "Beyonce")
+    assert bf.titles_match("Zażółć", "Zazolc")  # ż/ó/ł folded
+
+
+def test_titles_match_strips_qualifiers():
+    assert bf.titles_match("Song (Remastered 2011)", "Song")
+    assert bf.titles_match("Song - Radio Edit", "Song")
+    assert bf.titles_match("Song feat. Other", "Song")
+
+
+def test_titles_match_rejects_different():
+    assert not bf.titles_match("Bohemian Rhapsody", "Stairway to Heaven")
+    assert not bf.titles_match("", "Song")
+
+
+def test_strip_diacritics_polish():
+    # Uppercase folds map to lowercase ASCII (matching lowercases anyway).
+    assert (
+        bf.strip_diacritics("Łódź żółć ćma ń ą ę ś ź ó") == "lodz zolc cma n a e s z o"
+    )
+
+
+# --- Lever 2: Apple iTunes fallback + verify-gate ---------------------------
+def test_itunes_fallback_resolves_apple_id_with_gate():
+    def getter(url):
+        return {
+            "results": [
+                {
+                    "trackId": 555001,
+                    "trackName": "Jolka, Jolka Pamiętasz (Remastered)",
+                    "artistName": "Budka Suflera",
+                }
+            ]
+        }
+
+    # Gate is fuzzy: a stray "(Remastered)" qualifier is stripped before compare,
+    # so title+artist still pass and the numeric trackId is returned.
+    aid = bf.resolve_apple_via_itunes(
+        {"artist": "Budka Suflera", "title": "Jolka, Jolka Pamiętasz"}, getter=getter
+    )
+    assert aid == "555001"
+    assert bf.apple_uri(aid) == "applemusic://track/555001"
+
+
+def test_itunes_gate_rejects_wrong_title():
+    # iTunes returns a *different* song by a same-ish name → gate must reject,
+    # so no Apple URI is set on a niche-catalogue mismatch.
+    def getter(url):
+        return {
+            "results": [
+                {
+                    "trackId": 999,
+                    "trackName": "Completely Different Song",
+                    "artistName": "Some Other Band",
+                }
+            ]
+        }
+
+    aid = bf.resolve_apple_via_itunes(
+        {"artist": "Budka Suflera", "title": "Jolka Jolka"}, getter=getter
+    )
+    assert aid is None
+
+
+def test_itunes_diacritic_variant_matches():
+    # Catalogue row carries accents; the storefront index stores ASCII. The
+    # folded query variant is what actually returns the result.
+    calls = []
+
+    def getter(url):
+        calls.append(url)
+        # Only the diacritic-folded query ("Zeromski ...") returns a hit.
+        if "Zeromski" in url or "zeromski" in url.lower():
+            return {
+                "results": [
+                    {
+                        "trackId": 42042,
+                        "trackName": "Ballada",
+                        "artistName": "Zeromski",
+                    }
+                ]
+            }
+        return {"results": []}
+
+    aid = bf.resolve_apple_via_itunes(
+        {"artist": "Żeromski", "title": "Ballada"}, getter=getter
+    )
+    assert aid == "42042"
+
+
+def test_itunes_alt_artists_fallback():
+    # Primary artist does not match the storefront credit, but an alt_artist
+    # does → gate passes on the alt.
+    def getter(url):
+        return {
+            "results": [
+                {
+                    "trackId": 77,
+                    "trackName": "Eve Of Destruction",
+                    "artistName": "P.F. Sloan",
+                }
+            ]
+        }
+
+    aid = bf.resolve_apple_via_itunes(
+        {
+            "artist": "Barry McGuire",
+            "title": "Eve Of Destruction",
+            "alt_artists": ["P.F. Sloan", "The Turtles"],
+        },
+        getter=getter,
+    )
+    assert aid == "77"
+
+
+def test_itunes_returns_none_on_no_results():
+    assert (
+        bf.resolve_apple_via_itunes(
+            {"artist": "A", "title": "T"}, getter=lambda u: {"results": []}
+        )
+        is None
+    )
+
+
+def test_itunes_search_never_raises_on_http_error():
+    import urllib.error
+
+    def getter(url):
+        raise urllib.error.HTTPError(url, 500, "boom", {}, None)
+
+    assert bf.itunes_search("q", getter=getter) == []
+    assert (
+        bf.resolve_apple_via_itunes({"artist": "A", "title": "T"}, getter=getter)
+        is None
+    )
+
+
+# --- Lever 3: YouTube Odesli-first + oembed verify --------------------------
+def test_odesli_youtube_video_id_extracts():
+    payload = {
+        "linksByPlatform": {
+            "youtube": {"url": "https://www.youtube.com/watch?v=dQw4w9WgXcQ&foo=1"}
+        }
+    }
+    assert bf.odesli_youtube_video_id(payload) == "dQw4w9WgXcQ"
+    # youtu.be short form + youtubeMusic key.
+    assert (
+        bf.odesli_youtube_video_id(
+            {
+                "linksByPlatform": {
+                    "youtubeMusic": {"url": "https://youtu.be/abcDEF12345"}
+                }
+            }
+        )
+        == "abcDEF12345"
+    )
+    assert bf.odesli_youtube_video_id({}) is None
+
+
+def test_youtube_oembed_verify_pass_and_fail():
+    def ok(url):
+        return {
+            "title": "Rick Astley - Never Gonna Give You Up (Official Music Video)",
+            "author_name": "Rick Astley",
+        }
+
+    assert bf.youtube_oembed_verify(
+        "dQw4w9WgXcQ", "Rick Astley", "Never Gonna Give You Up", getter=ok
+    )
+
+    def cover(url):
+        return {
+            "title": "Never Gonna Give You Up (Live Cover)",
+            "author_name": "Some Cover Band",
+        }
+
+    # Wrong artist → gate fails (filters covers/live re-uploads).
+    assert not bf.youtube_oembed_verify(
+        "dQw4w9WgXcQ", "Rick Astley", "Never Gonna Give You Up", getter=cover
+    )
+
+
+def test_youtube_oembed_verify_network_error_false():
+    import urllib.error
+
+    def getter(url):
+        raise urllib.error.HTTPError(url, 404, "nf", {}, None)
+
+    assert not bf.youtube_oembed_verify("x" * 11, "A", "T", getter=getter)
+
+
+def test_run_youtube_odesli_first_pass_skips_search_list(tmp_path, monkeypatch):
+    # Odesli returns a YouTube link that oembed confirms → uri_youtube_music is
+    # filled at 0 quota; the paid search.list must NOT be called.
+    pl_dir = tmp_path / "custom_components" / "beatify" / "playlists"
+    pl_dir.mkdir(parents=True)
+    f = _write_playlist(
+        pl_dir,
+        "ytfirst",
+        [
+            {
+                "artist": "Rick Astley",
+                "title": "Never Gonna Give You Up",
+                "uri": "spotify:track:" + "a" * 22,
+            }
+        ],
+    )
+
+    monkeypatch.setattr(
+        bf,
+        "fetch_odesli",
+        lambda *a, **k: {
+            "linksByPlatform": {
+                "youtube": {"url": "https://www.youtube.com/watch?v=dQw4w9WgXcQ"}
+            }
+        },
+    )
+    monkeypatch.setattr(bf, "resolve_apple_via_itunes", lambda *a, **k: None)
+    monkeypatch.setattr(bf, "youtube_oembed_verify", lambda *a, **k: True)
+
+    search_calls = {"n": 0}
+
+    def boom_search(*a, **k):
+        search_calls["n"] += 1
+        return "SHOULDNOTBE1"
+
+    monkeypatch.setattr(bf, "youtube_search_id", boom_search)
+    monkeypatch.setattr(bf.time, "sleep", lambda s: None)
+    monkeypatch.setenv("YOUTUBE_API_KEY", "KEY")
+
+    rc = bf.main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "--apply",
+            "--output",
+            str(tmp_path / "cov.md"),
+            "--state",
+            str(tmp_path / "state.json"),
+            "--odesli-sleep",
+            "0",
+        ]
+    )
+    assert rc == 0
+    song = json.loads(f.read_text())["songs"][0]
+    assert song["uri_youtube_music"] == "https://music.youtube.com/watch?v=dQw4w9WgXcQ"
+    assert search_calls["n"] == 0  # quota saved — no search.list call
+
+
+def test_run_youtube_oembed_fail_falls_back_to_search_list(tmp_path, monkeypatch):
+    # Odesli has a YouTube link but oembed rejects it (cover) → fall back to the
+    # paid search.list path, which fills the URI.
+    pl_dir = tmp_path / "custom_components" / "beatify" / "playlists"
+    pl_dir.mkdir(parents=True)
+    f = _write_playlist(
+        pl_dir,
+        "ytfallback",
+        [
+            {
+                "artist": "Rick Astley",
+                "title": "Never Gonna Give You Up",
+                "uri": "spotify:track:" + "a" * 22,
+            }
+        ],
+    )
+
+    monkeypatch.setattr(
+        bf,
+        "fetch_odesli",
+        lambda *a, **k: {
+            "linksByPlatform": {
+                "youtube": {"url": "https://www.youtube.com/watch?v=coverVID1234"}
+            }
+        },
+    )
+    monkeypatch.setattr(bf, "resolve_apple_via_itunes", lambda *a, **k: None)
+    monkeypatch.setattr(bf, "youtube_oembed_verify", lambda *a, **k: False)
+
+    search_calls = {"n": 0}
+
+    def real_search(*a, **k):
+        search_calls["n"] += 1
+        return "dQw4w9WgXcQ"
+
+    monkeypatch.setattr(bf, "youtube_search_id", real_search)
+    monkeypatch.setattr(bf.time, "sleep", lambda s: None)
+    monkeypatch.setenv("YOUTUBE_API_KEY", "KEY")
+
+    rc = bf.main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "--apply",
+            "--output",
+            str(tmp_path / "cov.md"),
+            "--state",
+            str(tmp_path / "state.json"),
+            "--odesli-sleep",
+            "0",
+        ]
+    )
+    assert rc == 0
+    song = json.loads(f.read_text())["songs"][0]
+    assert song["uri_youtube_music"] == "https://music.youtube.com/watch?v=dQw4w9WgXcQ"
+    assert search_calls["n"] == 1  # oembed failed → paid path used
+
+
+def test_run_apply_itunes_fills_apple_when_odesli_lacks_it(tmp_path, monkeypatch):
+    # Odesli returns Tidal only (no Apple) → the iTunes fallback fills Apple.
+    pl_dir = tmp_path / "custom_components" / "beatify" / "playlists"
+    pl_dir.mkdir(parents=True)
+    f = _write_playlist(
+        pl_dir,
+        "apple",
+        [
+            {
+                "artist": "Budka Suflera",
+                "title": "Jolka Jolka",
+                "uri": "spotify:track:" + "a" * 22,
+            }
+        ],
+    )
+
+    monkeypatch.setattr(
+        bf,
+        "fetch_odesli",
+        lambda *a, **k: {
+            "linksByPlatform": {"tidal": {"entityUniqueId": "TIDAL_SONG::7"}},
+            "entitiesByUniqueId": {"TIDAL_SONG::7": {"id": "7"}},
+        },
+    )
+    monkeypatch.setattr(bf, "resolve_apple_via_itunes", lambda *a, **k: "808080")
+    monkeypatch.setattr(bf.time, "sleep", lambda s: None)
+    monkeypatch.delenv("YOUTUBE_API_KEY", raising=False)
+
+    rc = bf.main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "--apply",
+            "--output",
+            str(tmp_path / "cov.md"),
+            "--state",
+            str(tmp_path / "state.json"),
+            "--odesli-sleep",
+            "0",
+        ]
+    )
+    assert rc == 0
+    song = json.loads(f.read_text())["songs"][0]
+    assert song["uri_tidal"] == "tidal://track/7"
+    assert song["uri_apple_music"] == "applemusic://track/808080"


### PR DESCRIPTION
## Summary

Follow-up to #1690 (#1687): raises the per-provider hit-rate of the provider-URI backfill allrounder (`.claude/skills/provider-uri-backfill/scripts/backfill_provider_uris.py`) for the three weakest providers — **Apple Music, Tidal, YouTube** — via three coherent, independently-testable levers. Same "ISRC-first / Odesli / fuzzy-fallback" thinking per provider; every keyless resolver is verify-gated so the niche catalogue never collects confident-but-wrong URIs.

> **Stacked on #1690 — merge #1690 first, then rebase onto main.** Both PRs touch the same file (the #1687 429-skip fixes); this branch is cut from `fix/1687-backfill-429-version`.

## The three levers

**1. `userCountry=DE` on the Odesli request** — the allrounder previously sent no `userCountry`, while `scripts/backfill_tidal.py` always does. Odesli's `linksByPlatform` for Apple and Tidal is country-scoped, so this single param lifts **both** Apple and Tidal coverage for this DE-centric catalogue. Smallest change, biggest ratio.

**2. Apple iTunes-Search resolver + verify-gate** — new keyless resolver via `https://itunes.apple.com/search?entity=song` (NOT the token-gated / blocked Apple Music Developer API). Chain: when Odesli yields no Apple id → iTunes fallback. Features:
- Diacritic normalisation (ł→l, ż/ź→z, ó→o, ś→s, ć→c, ń→n, ą→a, ę→e, …) — queries **both** the raw and folded variants (storefront index is often ASCII-only).
- Strips `feat.`/`ft.`/parenthetical/dash suffixes ("(Remastered)", "- Radio Edit") for query building.
- `alt_artists` fallback when the primary performer doesn't match the storefront credit.
- **Mandatory verify-gate**: every iTunes hit must clear a fuzzy `titles_match()` on title AND (primary-or-alt) artist before its `trackId` is trusted. Ported from `custom_components/beatify/game/text_match.py` so the script stays standalone (no HA-runtime import).

**3. YouTube Odesli free-first pass + oembed verify** — the allrounder already fetches Odesli for Apple/Tidal/Deezer, so its `linksByPlatform.youtube` is used as a **0-quota first pass**, verified against artist/title via the keyless `https://www.youtube.com/oembed` endpoint (filters covers / live / lyric re-uploads). Only when oembed rejects it or Odesli has no YT link does the expensive `search.list` (100 quota units) run. Saves YouTube Data API quota + cuts false matches.

## Expected impact
- **Apple: +20–35pp** (iTunes fallback fills the large slice Odesli keyless omits) + userCountry lift.
- **Tidal / Apple: +userCountry** (country-scoped Odesli links now resolve).
- **YouTube: quota savings** (free oembed-verified Odesli link avoids most 100-unit `search.list` calls) + fewer cover/live mismatches.

## Test coverage (`tests/unit/test_provider_uri_backfill.py`, all HTTP mocked — no live network)
- `userCountry=DE` present in the Odesli request URL.
- Apple: Odesli-without-Apple → iTunes fallback fills it; diacritic-folded variant matches; `alt_artists` fallback; verify-gate **rejects** a wrong-title result (no URI set); iTunes never raises on HTTP error.
- YouTube: Odesli-YT-link + oembed-pass → set **without** a `search.list` call (quota saved); oembed-fail → `search.list` fallback used.
- `titles_match()` / `strip_diacritics()` unit coverage (Polish diacritics, qualifier stripping, rejection of different songs).
- All pre-existing tests (incl. the #1690 429-skip tests) stay green: **56 passed**.

Ruff `format` + `check` clean on both changed files.

Context: #1687 (backfill data-loss deep-dive) / #1690 (429-skip + version-bump). No `Closes` — no dedicated hit-rate issue exists.