### PR TITLE
feat(player): expose player_id alias (additive, name-identity refactor PR-1)

### DIFF
--- a/custom_components/beatify/game/player.py
+++ b/custom_components/beatify/game/player.py
@@ -106,6 +106,18 @@ class PlayerSession:
     )  # Per-round: who stole this player's answer
 
     @property
+    def player_id(self) -> str:
+        """Stable identifier for this player (alias of ``session_id``).
+
+        Read-only alias introduced for the name-identity refactor (#1664,
+        PR-1). ``session_id`` is already a server-issued, stable UUID; this
+        property simply exposes it under the ``player_id`` name that will
+        become the primary key in later refactor steps. Purely additive — no
+        behaviour change, no new state.
+        """
+        return self.session_id
+
+    @property
     def is_active(self) -> bool:
         """True only if the player is genuinely still connected.
 

--- a/custom_components/beatify/game/player_registry.py
+++ b/custom_components/beatify/game/player_registry.py
@@ -192,6 +192,8 @@ class PlayerRegistry:
         return [
             {
                 "name": p.name,
+                # #1664 PR-1: stable id alias (== session_id), additive enabler
+                "player_id": p.player_id,
                 "score": p.score,
                 "connected": p.connected,
                 "streak": p.streak,

--- a/custom_components/beatify/game/serializers.py
+++ b/custom_components/beatify/game/serializers.py
@@ -255,6 +255,8 @@ class GameStateSerializer:
         for p in gs.players.values():
             player_data = {
                 "name": p.name,
+                # #1664 PR-1: stable id alias (== session_id), additive enabler
+                "player_id": p.player_id,
                 "score": p.score,
                 "streak": p.streak,
                 "is_admin": p.is_admin,

--- a/tests/unit/test_websocket.py
+++ b/tests/unit/test_websocket.py
@@ -987,6 +987,45 @@ class TestPlayerOnboarded:
         assert alice.onboarded is True, "onboarded must survive reset_round()"
 
 
+class TestPlayerIdAlias:
+    """#1664 PR-1: stable ``player_id`` alias exposed additively.
+
+    ``player_id`` is a read-only alias of the already-existing ``session_id``.
+    PR-1 only exposes it (property + state broadcast) so later refactor steps
+    can migrate the registry primary key off the display name. No behaviour
+    change here.
+    """
+
+    async def test_player_id_property_equals_session_id(self):
+        """PlayerSession.player_id is a read-only alias of session_id."""
+        handler, game_state, ws = _make_handler_and_game()
+        await handler._handle_message(ws, {"type": "join", "name": "Alice"})
+        alice = game_state.get_player("Alice")
+        assert alice is not None
+        assert alice.player_id == alice.session_id
+
+    async def test_players_state_includes_player_id(self):
+        """get_players_state() exposes player_id == session_id per player."""
+        handler, game_state, ws = _make_handler_and_game()
+        await handler._handle_message(ws, {"type": "join", "name": "Alice"})
+        rows = game_state.get_players_state()
+        alice_row = next(r for r in rows if r["name"] == "Alice")
+        alice = game_state.get_player("Alice")
+        assert "player_id" in alice_row
+        assert alice_row["player_id"] == alice.session_id
+
+    async def test_reveal_players_state_includes_player_id(self):
+        """REVEAL-phase serializer also exposes player_id == session_id."""
+        from custom_components.beatify.game.serializers import GameStateSerializer
+
+        handler, game_state, ws = _make_handler_and_game()
+        await handler._handle_message(ws, {"type": "join", "name": "Alice"})
+        rows = GameStateSerializer.get_reveal_players_state(game_state)
+        alice_row = next(r for r in rows if r["name"] == "Alice")
+        alice = game_state.get_player("Alice")
+        assert alice_row["player_id"] == alice.session_id
+
+
 # ---------------------------------------------------------------------------
 # admin_next_round — recovery from PAUSED (#805)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

**Purely additive** first step of the name-identity refactor (**PR-1 of #1664 item 1**). No behaviour change.

- Adds a read-only `PlayerSession.player_id` property that returns the existing `session_id` (alias only — no field rename, no new state).
- Includes `player_id` (== `session_id`) in the player-state dicts sent to the frontend:
  - `PlayerRegistry.get_players_state()` — the main WS `state` player list.
  - `GameStateSerializer.get_reveal_players_state()` — the REVEAL-phase player list (added for consistency so `player_id` is present in every phase's player state).

## Why

`session_id` is already a server-issued, stable UUID, but today the display **name** is the registry primary key and drives the fragile reconnect / admin-reclaim logic. The refactor plan migrates the primary key to the stable id. This PR is the risk-free enabler: it exposes the stable id under the future-primary-key name (`player_id`) on the wire so later PRs can switch the identity logic without another wire change.

- Wire fields are additive; `session_id` is retained as-is.
- No changes to `add_player` / `get_player` / reconnect / admin / name logic. No frontend changes required (backend-only enabler).

## Tests

- New `TestPlayerIdAlias`: `player_id == session_id` (property), `player_id` present and correct in `get_players_state()` and `get_reveal_players_state()`.
- Existing unit tests remain green (`tests/unit/` state/player/registry subset: 397 passed; full `test_websocket.py`: 79 passed). `ruff format` + `ruff check` clean.

Emphasis: **purely additive, no behaviour change.** Does not close #1664.