### PR TITLE
refactor(player): #1664 registry keyed by player_id + name-fallback + F6 (PR-2)

### DIFF
--- a/custom_components/beatify/game/player_registry.py
+++ b/custom_components/beatify/game/player_registry.py
@@ -32,13 +32,49 @@ class PlayerRegistry:
 
     def __init__(self) -> None:
         """Initialize empty registry."""
-        self.players: dict[str, PlayerSession] = {}
-        self._sessions: dict[str, str] = {}  # session_id → player_name
+        # #1664 PR-2: ``players`` is now keyed by ``player_id`` (== session_id),
+        # the stable server-issued identifier — NOT the display name. The name
+        # is a mutable display attribute tracked by ``_name_index`` purely as a
+        # non-authoritative uniqueness / lookup hint.
+        self._players: dict[str, PlayerSession] = {}  # player_id → PlayerSession
+        # name.lower() → player_id (display / uniqueness hint, not authoritative)
+        self._name_index: dict[str, str] = {}
+        # session_id → player_id — reconnect gate (see clear_all_sessions):
+        # clearing this map invalidates session-based reconnect while leaving
+        # the players themselves intact (Story 11.6 leftover-session semantics).
+        self._sessions: dict[str, str] = {}
         self._reactions_this_phase: set[str] = set()
+
+    @property
+    def players(self) -> dict[str, PlayerSession]:
+        """Player dict keyed by ``player_id`` (== session_id)."""
+        return self._players
+
+    @players.setter
+    def players(self, value: dict[str, PlayerSession]) -> None:
+        """Replace the player dict and rebuild the derived indexes.
+
+        Callers assign a fresh dict (typically ``{}`` on teardown). Keeping the
+        ``_name_index`` / ``_sessions`` maps consistent here avoids stale
+        lookups after a wholesale replacement.
+        """
+        self._players = value
+        self._rebuild_indexes()
+
+    def _rebuild_indexes(self) -> None:
+        """Rebuild ``_name_index`` and ``_sessions`` from ``_players``."""
+        self._name_index = {
+            player.name.lower(): player_id
+            for player_id, player in self._players.items()
+        }
+        self._sessions = {
+            player.session_id: player_id for player_id, player in self._players.items()
+        }
 
     def reset(self) -> None:
         """Clear all players, sessions, and reactions."""
-        self.players.clear()
+        self._players.clear()
+        self._name_index.clear()
         self._sessions.clear()
         self._reactions_this_phase.clear()
 
@@ -82,25 +118,36 @@ class PlayerRegistry:
         if phase == GamePhase.END:
             return False, ERR_GAME_ENDED
 
-        # Check for reconnection - case-insensitive match
-        for existing_name, existing_player in self.players.items():
-            if existing_name.lower() == name.lower():
-                if not existing_player.connected:
-                    existing_player.ws = ws
-                    existing_player.connected = True
-                    _LOGGER.info("Player reconnected: %s", existing_name)
-                    return True, None
-                # #646: Check if the old WS is actually dead (race condition
-                # where _handle_disconnect hasn't run yet after browser reload)
-                if existing_player.ws is None or existing_player.ws.closed:
-                    _LOGGER.info(
-                        "Player %s: stale connected flag, old WS closed — allowing rejoin",
-                        existing_name,
-                    )
-                    existing_player.ws = ws
-                    existing_player.connected = True
-                    return True, None
-                return False, ERR_NAME_TAKEN
+        # #1664 PR-2: name-based reconnect FALLBACK (deprecated).
+        # The authoritative reconnect path is session_id-based
+        # (``get_player_by_session_id`` → ``handle_reconnect``). This
+        # case-insensitive name match is kept as an explicit backward-compat
+        # fallback for clients that rejoin by name without a valid session_id
+        # (old cookies, cleared storage). It will be removed in PR-5 once prod
+        # logs confirm it is unused.
+        existing_id = self._name_index.get(name.lower())
+        existing_player = self.players.get(existing_id) if existing_id else None
+        if existing_player is not None:
+            if not existing_player.connected:
+                existing_player.ws = ws
+                existing_player.connected = True
+                _LOGGER.info(
+                    "name-based reconnect fallback (deprecated) for %s",
+                    existing_player.name,
+                )
+                return True, None
+            # #646: Check if the old WS is actually dead (race condition
+            # where _handle_disconnect hasn't run yet after browser reload)
+            if existing_player.ws is None or existing_player.ws.closed:
+                _LOGGER.info(
+                    "name-based reconnect fallback (deprecated) for %s: "
+                    "stale connected flag, old WS closed — allowing rejoin",
+                    existing_player.name,
+                )
+                existing_player.ws = ws
+                existing_player.connected = True
+                return True, None
+            return False, ERR_NAME_TAKEN
 
         # Check player limit
         if len(self.players) >= MAX_PLAYERS:
@@ -116,8 +163,10 @@ class PlayerRegistry:
         player = PlayerSession(
             name=name, ws=ws, score=initial_score, streak=0, joined_late=joined_late
         )
-        self.players[name] = player
-        self._sessions[player.session_id] = name
+        # #1664 PR-2: key by player_id (== session_id), not the display name.
+        self._players[player.player_id] = player
+        self._name_index[name.lower()] = player.player_id
+        self._sessions[player.session_id] = player.player_id
 
         # Log join with score info
         if joined_late and initial_score > 0:
@@ -137,21 +186,19 @@ class PlayerRegistry:
         return True, None
 
     def get_player(self, name: str) -> PlayerSession | None:
-        """Get player by name (case-insensitive to match add_player reconnection)."""
-        player = self.players.get(name)
-        if player is not None:
-            return player
-        # Fallback: case-insensitive lookup (#413)
-        name_lower = name.lower()
-        for existing_name, existing_player in self.players.items():
-            if existing_name.lower() == name_lower:
-                return existing_player
-        return None
+        """Get player by display name (case-insensitive via ``_name_index``).
+
+        #1664 PR-2 / F6: name lookup is now uniformly case-insensitive across
+        ``get_player`` / ``remove_player`` / ``set_admin`` — all resolve through
+        the same ``_name_index`` (name.lower() → player_id).
+        """
+        player_id = self._name_index.get(name.lower())
+        return self.players.get(player_id) if player_id else None
 
     def get_player_by_session_id(self, session_id: str) -> PlayerSession | None:
-        """Get player by session ID."""
-        name = self._sessions.get(session_id)
-        return self.players.get(name) if name else None
+        """Get player by session ID (authoritative reconnect path)."""
+        player_id = self._sessions.get(session_id)
+        return self.players.get(player_id) if player_id else None
 
     def get_player_by_ws(self, ws: web.WebSocketResponse) -> PlayerSession | None:
         """Get player by WebSocket connection."""
@@ -174,12 +221,15 @@ class PlayerRegistry:
         return True
 
     def remove_player(self, name: str) -> None:
-        """Remove player from game."""
-        if name in self.players:
-            player = self.players[name]
-            self._sessions.pop(player.session_id, None)
-            del self.players[name]
-            _LOGGER.info("Player removed: %s", name)
+        """Remove player from game (by display name, case-insensitive — F6)."""
+        player_id = self._name_index.get(name.lower())
+        player = self.players.get(player_id) if player_id else None
+        if player_id is None or player is None:
+            return
+        self._sessions.pop(player.session_id, None)
+        self._name_index.pop(player.name.lower(), None)
+        del self._players[player_id]
+        _LOGGER.info("Player removed: %s", player.name)
 
     def clear_all_sessions(self) -> None:
         """Clear all session mappings for game reset."""
@@ -233,15 +283,15 @@ class PlayerRegistry:
 
     def set_admin(self, name: str) -> bool:
         """
-        Set a player as admin.
+        Set a player as admin (by display name, case-insensitive — F6).
 
         Returns:
             True if admin was set, False if player not found
 
         """
-        player = self.players.get(name)
+        player = self.get_player(name)
         if player:
             player.is_admin = True
-            _LOGGER.info("Admin set: %s", name)
+            _LOGGER.info("Admin set: %s", player.name)
             return True
         return False

--- a/custom_components/beatify/game/powerups.py
+++ b/custom_components/beatify/game/powerups.py
@@ -55,10 +55,12 @@ class PowerUpManager:
             List of player names who have submitted this round, excluding self
 
         """
+        # #1664 PR-2: ``players`` is keyed by player_id now, so match on the
+        # display name attribute rather than the dict key.
         return [
-            name
-            for name, player in players.items()
-            if name != stealer_name and player.submitted
+            player.name
+            for player in players.values()
+            if player.name != stealer_name and player.submitted
         ]
 
     def use_steal(
@@ -84,8 +86,18 @@ class PowerUpManager:
         """
         from .state import GamePhase  # noqa: PLC0415 — avoid circular import
 
-        stealer = players.get(stealer_name)
-        target = players.get(target_name)
+        # #1664 PR-2: ``players`` is keyed by player_id now; steal targeting is
+        # still name-based input (from get_steal_targets), so resolve by the
+        # display name attribute. Name uniqueness is enforced at add_player, so
+        # the first match is the intended player.
+        def _by_name(wanted: str) -> PlayerSession | None:
+            for candidate in players.values():
+                if candidate.name == wanted:
+                    return candidate
+            return None
+
+        stealer = _by_name(stealer_name)
+        target = _by_name(target_name)
 
         # Validations
         if not stealer:

--- a/custom_components/beatify/game/share.py
+++ b/custom_components/beatify/game/share.py
@@ -85,8 +85,9 @@ def build_share_data(game_state: Any) -> dict[str, Any]:
     total_rounds = game_state.round
 
     emoji_grids: dict[str, str] = {}
-    for name, player in game_state.players.items():
-        emoji_grids[name] = build_emoji_grid(player, playlist_name, total_rounds)
+    # #1664 PR-2: players keyed by player_id — key the grid by display name
+    for player in game_state.players.values():
+        emoji_grids[player.name] = build_emoji_grid(player, playlist_name, total_rounds)
 
     return {
         "emoji_grids": emoji_grids,

--- a/custom_components/beatify/game/state_player.py
+++ b/custom_components/beatify/game/state_player.py
@@ -59,7 +59,12 @@ class PlayerLifecycleMixin:
 
     @property
     def players(self) -> dict[str, PlayerSession]:
-        """Player dict — delegated to PlayerRegistry."""
+        """Player dict keyed by player_id (== session_id) — delegated to PlayerRegistry.
+
+        #1664 PR-2: the key is the stable ``player_id`` now, not the display
+        name. Name-based access goes through ``get_player`` / ``remove_player``
+        / ``set_admin`` (case-insensitive via the registry name index).
+        """
         return self._player_registry.players
 
     @players.setter

--- a/custom_components/beatify/server/websocket.py
+++ b/custom_components/beatify/server/websocket.py
@@ -439,15 +439,12 @@ class BeatifyWebSocketHandler:
         if not game_state:
             return
 
-        # Find player by WebSocket
-        player_name = None
-        player = None
-        for name, p in list(game_state.players.items()):
-            if p.ws == ws:
-                player_name = name
-                player = p
-                player.connected = False
-                break
+        # Find player by WebSocket (#1664 PR-2: players keyed by player_id now,
+        # so resolve via the WS lookup and read the display name off the object)
+        player = game_state.get_player_by_ws(ws)
+        player_name = player.name if player else None
+        if player is not None:
+            player.connected = False
 
         # Issue #477: Clear admin spectator WS if it disconnected
         if game_state._admin_ws is ws:
@@ -478,14 +475,14 @@ class BeatifyWebSocketHandler:
 
             async def pause_after_timeout() -> None:
                 await asyncio.sleep(LOBBY_DISCONNECT_GRACE_PERIOD)
-                # Check if admin still disconnected
-                if player_name in game_state.players:
-                    admin = game_state.players[player_name]
-                    if not admin.connected:
-                        # pause_game() is async and handles media stop internally
-                        if await game_state.pause_game("admin_disconnected"):
-                            await self.broadcast_state()
-                            _LOGGER.info("Game paused due to admin disconnect")
+                # Check if admin still present and disconnected (#1664 PR-2:
+                # resolve by stable player_id, not by display name)
+                admin = game_state.get_player_by_session_id(player.player_id)
+                if admin is not None and not admin.connected:
+                    # pause_game() is async and handles media stop internally
+                    if await game_state.pause_game("admin_disconnected"):
+                        await self.broadcast_state()
+                        _LOGGER.info("Game paused due to admin disconnect")
 
             # Store task for cancellation on reconnect
             self._admin_disconnect_task = asyncio.create_task(pause_after_timeout())

--- a/custom_components/beatify/server/ws_handlers/lifecycle.py
+++ b/custom_components/beatify/server/ws_handlers/lifecycle.py
@@ -431,16 +431,11 @@ async def handle_leave(
     game_state: GameState,
 ) -> None:
     """Handle intentional leave game (Story 11.5)."""
-    player = None
-    player_name = None
-    for name, p in list(game_state.players.items()):
-        if p.ws == ws:
-            player = p
-            player_name = name
-            break
-
+    # #1664 PR-2: players keyed by player_id — resolve by WS, use display name
+    player = game_state.get_player_by_ws(ws)
     if not player:
         return
+    player_name = player.name
 
     if player.is_admin:
         await ws.send_json(

--- a/tests/integration/test_round_flow.py
+++ b/tests/integration/test_round_flow.py
@@ -78,9 +78,9 @@ class TestSingleRoundScoring:
         state.set_round_end_callback(_broadcast)
 
         _begin_round(state, year=1990)
-        state.players["Alice"].submit_guess(1990, state._now())  # exact
-        state.players["Bob"].submit_guess(1985, state._now())  # 5 off
-        state.players["Carol"].submit_guess(2010, state._now())  # 20 off
+        state.get_player("Alice").submit_guess(1990, state._now())  # exact
+        state.get_player("Bob").submit_guess(1985, state._now())  # 5 off
+        state.get_player("Carol").submit_guess(2010, state._now())  # 20 off
 
         await state.end_round()
 
@@ -89,9 +89,9 @@ class TestSingleRoundScoring:
         broadcast.assert_called_once()
 
         # Strict scoring order: exact > near > far.
-        alice = state.players["Alice"]
-        bob = state.players["Bob"]
-        carol = state.players["Carol"]
+        alice = state.get_player("Alice")
+        bob = state.get_player("Bob")
+        carol = state.get_player("Carol")
         assert alice.years_off == 0
         assert bob.years_off == 5
         assert carol.years_off == 20
@@ -104,16 +104,16 @@ class TestSingleRoundScoring:
         in the shareable round_results card (#120)."""
         state = _setup_started_game("Alice", "Bob")
         _begin_round(state, year=2000)
-        state.players["Alice"].submit_guess(2000, state._now())
+        state.get_player("Alice").submit_guess(2000, state._now())
         # Bob stays silent.
 
         await state.end_round()
 
-        bob = state.players["Bob"]
+        bob = state.get_player("Bob")
         assert bob.submitted is False
         assert bob.score == 0
         assert bob.round_results[-1] == "missed"
-        assert state.players["Alice"].round_results[-1] == "exact"
+        assert state.get_player("Alice").round_results[-1] == "exact"
 
 
 # ---------------------------------------------------------------------------
@@ -132,14 +132,14 @@ class TestMultiRoundLeaderboard:
         # Round 1: Bob nails it, Alice is far off -> Bob leads.
         _begin_round(state, year=1990)
         state._store_previous_ranks()
-        state.players["Bob"].submit_guess(1990, state._now())
-        state.players["Alice"].submit_guess(1950, state._now())
+        state.get_player("Bob").submit_guess(1990, state._now())
+        state.get_player("Alice").submit_guess(1950, state._now())
         await state.end_round()
 
         round1 = {e["name"]: e for e in state.get_leaderboard()}
         assert round1["Bob"]["rank"] == 1
         assert round1["Alice"]["rank"] == 2
-        bob_r1 = state.players["Bob"].score
+        bob_r1 = state.get_player("Bob").score
 
         # Round 2: Alice nails it (Bob far off). Her exact guess earns the same
         # as Bob's round-1 exact, so the two pull level on cumulative score.
@@ -147,13 +147,13 @@ class TestMultiRoundLeaderboard:
             player.reset_round()
         _begin_round(state, year=2000)
         state._store_previous_ranks()  # snapshot: Bob 1st, Alice 2nd
-        state.players["Alice"].submit_guess(2000, state._now())
-        state.players["Bob"].submit_guess(1900, state._now())
+        state.get_player("Alice").submit_guess(2000, state._now())
+        state.get_player("Bob").submit_guess(1900, state._now())
         await state.end_round()
 
         # Cumulative: scores are summed across rounds, not replaced.
-        assert state.players["Bob"].score == bob_r1  # round-2 far miss added 0
-        assert state.players["Alice"].score == bob_r1  # round-2 exact == Bob's r1
+        assert state.get_player("Bob").score == bob_r1  # round-2 far miss added 0
+        assert state.get_player("Alice").score == bob_r1  # round-2 exact == Bob's r1
 
         # Movement reflects the round-1 ranks as the baseline snapshot.
         final = {e["name"]: e for e in state.get_leaderboard()}
@@ -170,8 +170,8 @@ class TestMultiRoundLeaderboard:
         stat block and ranks players by their accumulated score."""
         state = _setup_started_game("Alice", "Bob")
         _begin_round(state, year=1990)
-        state.players["Alice"].submit_guess(1990, state._now())
-        state.players["Bob"].submit_guess(1995, state._now())
+        state.get_player("Alice").submit_guess(1990, state._now())
+        state.get_player("Bob").submit_guess(1995, state._now())
         await state.end_round()
 
         board = state.get_final_leaderboard()

--- a/tests/unit/test_player_id_registry_1664.py
+++ b/tests/unit/test_player_id_registry_1664.py
@@ -1,0 +1,174 @@
+"""PR-2 tests (#1664): PlayerRegistry keyed by player_id (== session_id).
+
+Covers the registry-key migration from display-name to the stable
+``player_id``, the retained name-based reconnect fallback, the F6 case-fix
+(get_player / remove_player / set_admin share one case-insensitive semantic),
+steal targeting after the key change, and the player_id exposure in the
+state broadcast.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from custom_components.beatify.const import ERR_NAME_TAKEN
+from custom_components.beatify.game.state import GamePhase, GameState
+from tests.conftest import make_game_state, make_songs
+
+
+def _create_fresh_game(state: GameState) -> None:
+    state.create_game(
+        playlists=["test.json"],
+        songs=make_songs(5),
+        media_player="media_player.test",
+        base_url="http://localhost:8123",
+    )
+
+
+def _healthy_ws() -> MagicMock:
+    ws = MagicMock()
+    ws.closed = False
+    return ws
+
+
+class TestRegistryKeyedByPlayerId:
+    def setup_method(self):
+        self.state = make_game_state()
+        _create_fresh_game(self.state)
+
+    def test_players_dict_keyed_by_player_id(self):
+        self.state.add_player("Alice", _healthy_ws())
+        player = self.state.get_player("Alice")
+        assert player is not None
+        # The dict key is the stable player_id (== session_id), not the name.
+        assert player.player_id in self.state.players
+        assert self.state.players[player.player_id] is player
+        assert "Alice" not in self.state.players
+
+    def test_get_players_state_exposes_player_id(self):
+        self.state.add_player("Alice", _healthy_ws())
+        rows = self.state.get_players_state()
+        assert len(rows) == 1
+        row = rows[0]
+        assert row["name"] == "Alice"
+        assert row["player_id"] == self.state.get_player("Alice").player_id
+
+
+class TestSessionIdReconnect:
+    """(b) Reconnect by session_id hits the record despite case / rename."""
+
+    def setup_method(self):
+        self.state = make_game_state()
+        _create_fresh_game(self.state)
+
+    def test_session_id_lookup_is_direct(self):
+        self.state.add_player("Alice", _healthy_ws())
+        player = self.state.get_player("Alice")
+        assert self.state.get_player_by_session_id(player.session_id) is player
+
+    def test_session_id_survives_rename(self):
+        self.state.add_player("Alice", _healthy_ws())
+        player = self.state.get_player("Alice")
+        sid = player.session_id
+        # Display-name change must not detach the record from its session_id.
+        player.name = "Alicia"
+        assert self.state.get_player_by_session_id(sid) is player
+
+    def test_unknown_session_id_returns_none(self):
+        assert self.state.get_player_by_session_id("does-not-exist") is None
+
+
+class TestNameUniquenessAndFallback:
+    """(a) Same-name handling — uniqueness retained + fallback reconnect."""
+
+    def setup_method(self):
+        self.state = make_game_state()
+        _create_fresh_game(self.state)
+
+    def test_duplicate_name_with_live_ws_rejected(self):
+        self.state.add_player("Alice", _healthy_ws())
+        ok, err = self.state.add_player("Alice", _healthy_ws())
+        assert ok is False
+        assert err == ERR_NAME_TAKEN
+
+    def test_name_fallback_reconnect_reactivates_same_record(self):
+        ws1 = _healthy_ws()
+        self.state.add_player("Alice", ws1)
+        original = self.state.get_player("Alice")
+        original_id = original.player_id
+        original.connected = False
+
+        ws2 = _healthy_ws()
+        ok, err = self.state.add_player("Alice", ws2)
+        assert ok is True
+        assert err is None
+        # Same underlying record reactivated — no duplicate, id preserved.
+        reconnected = self.state.get_player("Alice")
+        assert reconnected is original
+        assert reconnected.player_id == original_id
+        assert reconnected.ws is ws2
+        assert reconnected.connected is True
+        assert len(self.state.players) == 1
+
+
+class TestF6CaseConsistency:
+    """(c) get_player / remove_player / set_admin share one case semantic."""
+
+    def setup_method(self):
+        self.state = make_game_state()
+        _create_fresh_game(self.state)
+        self.state.add_player("Alice", _healthy_ws())
+
+    def test_get_player_case_insensitive(self):
+        assert self.state.get_player("alice") is self.state.get_player("Alice")
+        assert self.state.get_player("ALICE") is self.state.get_player("Alice")
+
+    def test_set_admin_case_insensitive(self):
+        assert self.state.set_admin("ALICE") is True
+        assert self.state.get_player("Alice").is_admin is True
+
+    def test_remove_player_case_insensitive(self):
+        assert self.state.get_player("Alice") is not None
+        self.state.remove_player("ALICE")
+        assert self.state.get_player("Alice") is None
+        assert len(self.state.players) == 0
+
+    def test_remove_player_clears_session_and_name_index(self):
+        player = self.state.get_player("Alice")
+        sid = player.session_id
+        self.state.remove_player("alice")
+        assert self.state.get_player_by_session_id(sid) is None
+        # A fresh join under the same name works again (index freed).
+        ok, err = self.state.add_player("Alice", _healthy_ws())
+        assert ok is True
+        assert err is None
+
+
+class TestStealTargetingAfterKeyChange:
+    """(d) Steal targeting still resolves stealer + target by name."""
+
+    def setup_method(self):
+        self.state = make_game_state()
+        _create_fresh_game(self.state)
+        self.state.add_player("Alice", _healthy_ws())
+        self.state.add_player("Bob", _healthy_ws())
+        self.state.phase = GamePhase.PLAYING
+
+    def test_get_steal_targets_returns_submitted_names(self):
+        self.state.get_player("Bob").submitted = True
+        targets = self.state.get_steal_targets("Alice")
+        assert targets == ["Bob"]
+
+    def test_get_steal_targets_excludes_self(self):
+        self.state.get_player("Alice").submitted = True
+        self.state.get_player("Bob").submitted = True
+        assert self.state.get_steal_targets("Alice") == ["Bob"]
+
+    def test_use_steal_resolves_by_name(self):
+        self.state.get_player("Alice").steal_available = True
+        self.state.get_player("Bob").submitted = True
+        self.state.get_player("Bob").current_guess = 1990
+        result = self.state.use_steal("Alice", "Bob")
+        assert result["success"] is True
+        assert result["year"] == 1990
+        assert self.state.get_player("Alice").current_guess == 1990

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -483,7 +483,7 @@ class TestRevealStartedAt:
         state.reveal_started_at = 1_700_000_000_000
         # Mark at least one player as submitted so idle_halt isn't set.
         state.add_player("Alice", MagicMock())
-        state.players["Alice"].submitted = True
+        state.get_player("Alice").submitted = True
 
         payload = GameStateSerializer.serialize(state)
         assert payload["reveal_auto_advance"] == 30
@@ -497,7 +497,7 @@ class TestRevealStartedAt:
         state.phase = GamePhase.REVEAL
         state.reveal_started_at = None
         state.add_player("Alice", MagicMock())
-        state.players["Alice"].submitted = True
+        state.get_player("Alice").submitted = True
 
         payload = GameStateSerializer.serialize(state)
         assert payload["reveal_auto_advance"] == 0
@@ -550,7 +550,7 @@ class TestAddPlayer:
         ok, err = self.state.add_player("Alice", MagicMock())
         assert ok is True
         assert err is None
-        assert "Alice" in self.state.players
+        assert self.state.get_player("Alice") is not None
 
     def test_add_duplicate_name_rejected(self):
         # ws.closed must be explicitly False — bare MagicMock attributes are
@@ -610,18 +610,18 @@ class TestAddPlayer:
         ws2 = MagicMock()
         self.state.add_player("Alice", ws1)
         # Simulate disconnect
-        self.state.players["Alice"].connected = False
+        self.state.get_player("Alice").connected = False
         # Reconnect with same name
         ok, err = self.state.add_player("Alice", ws2)
         assert ok is True
         assert err is None
-        assert self.state.players["Alice"].ws == ws2
-        assert self.state.players["Alice"].connected is True
+        assert self.state.get_player("Alice").ws == ws2
+        assert self.state.get_player("Alice").connected is True
 
     def test_player_name_trimmed(self):
         ok, err = self.state.add_player("  Bob  ", MagicMock())
         assert ok is True
-        assert "Bob" in self.state.players
+        assert self.state.get_player("Bob") is not None
 
 
 # ---------------------------------------------------------------------------
@@ -679,24 +679,24 @@ class TestAllSubmitted:
         assert self.state.all_submitted() is False
 
     def test_partial_submissions_returns_false(self):
-        self.state.players["Alice"].submitted = True
+        self.state.get_player("Alice").submitted = True
         assert self.state.all_submitted() is False
 
     def test_all_submitted_returns_true(self):
-        self.state.players["Alice"].submitted = True
-        self.state.players["Bob"].submitted = True
+        self.state.get_player("Alice").submitted = True
+        self.state.get_player("Bob").submitted = True
         assert self.state.all_submitted() is True
 
     def test_disconnected_player_excluded(self):
-        self.state.players["Bob"].connected = False
-        self.state.players["Alice"].submitted = True
+        self.state.get_player("Bob").connected = False
+        self.state.get_player("Alice").submitted = True
         assert self.state.all_submitted() is True
 
     def test_stale_connected_ghost_excluded(self):
         # #928: a player whose WebSocket is already closed but whose
         # `connected` flag has not been cleared must not block all-submitted.
-        self.state.players["Bob"].ws.closed = True
-        self.state.players["Alice"].submitted = True
+        self.state.get_player("Bob").ws.closed = True
+        self.state.get_player("Alice").submitted = True
         assert self.state.all_submitted() is True
 
     def test_no_players_returns_false(self):
@@ -717,8 +717,8 @@ class TestLeaderboard:
     def test_sorted_by_score_descending(self):
         self.state.add_player("Alice", MagicMock())
         self.state.add_player("Bob", MagicMock())
-        self.state.players["Alice"].score = 50
-        self.state.players["Bob"].score = 80
+        self.state.get_player("Alice").score = 50
+        self.state.get_player("Bob").score = 80
         lb = self.state.get_leaderboard()
         assert lb[0]["name"] == "Bob"
         assert lb[1]["name"] == "Alice"
@@ -726,8 +726,8 @@ class TestLeaderboard:
     def test_tied_scores_same_rank(self):
         self.state.add_player("Alice", MagicMock())
         self.state.add_player("Bob", MagicMock())
-        self.state.players["Alice"].score = 50
-        self.state.players["Bob"].score = 50
+        self.state.get_player("Alice").score = 50
+        self.state.get_player("Bob").score = 50
         lb = self.state.get_leaderboard()
         assert lb[0]["rank"] == 1
         assert lb[1]["rank"] == 1
@@ -736,9 +736,9 @@ class TestLeaderboard:
         self.state.add_player("Alice", MagicMock())
         self.state.add_player("Bob", MagicMock())
         self.state.add_player("Carol", MagicMock())
-        self.state.players["Alice"].score = 100
-        self.state.players["Bob"].score = 50
-        self.state.players["Carol"].score = 50
+        self.state.get_player("Alice").score = 100
+        self.state.get_player("Bob").score = 50
+        self.state.get_player("Carol").score = 50
         lb = self.state.get_leaderboard()
         ranks = {e["name"]: e["rank"] for e in lb}
         assert ranks["Alice"] == 1
@@ -764,27 +764,27 @@ class TestGetAverageScore:
 
     def test_single_player(self):
         self.state.add_player("Alice", MagicMock())
-        self.state.players["Alice"].score = 40
-        self.state.players["Alice"].rounds_played = 1
+        self.state.get_player("Alice").score = 40
+        self.state.get_player("Alice").rounds_played = 1
         assert self.state.get_average_score() == 40
 
     def test_multiple_players(self):
         self.state.add_player("Alice", MagicMock())
         self.state.add_player("Bob", MagicMock())
-        self.state.players["Alice"].score = 40
-        self.state.players["Alice"].rounds_played = 1
-        self.state.players["Bob"].score = 60
-        self.state.players["Bob"].rounds_played = 1
+        self.state.get_player("Alice").score = 40
+        self.state.get_player("Alice").rounds_played = 1
+        self.state.get_player("Bob").score = 60
+        self.state.get_player("Bob").rounds_played = 1
         assert self.state.get_average_score() == 50
 
     def test_excludes_unscored_late_joiners(self):
         self.state.add_player("Alice", MagicMock())
         self.state.add_player("Bob", MagicMock())
-        self.state.players["Alice"].score = 40
-        self.state.players["Alice"].rounds_played = 1
+        self.state.get_player("Alice").score = 40
+        self.state.get_player("Alice").rounds_played = 1
         # Bob is a late joiner with no rounds played
-        self.state.players["Bob"].score = 40
-        self.state.players["Bob"].rounds_played = 0
+        self.state.get_player("Bob").score = 40
+        self.state.get_player("Bob").rounds_played = 0
         assert self.state.get_average_score() == 40
 
 
@@ -807,34 +807,34 @@ class TestUseSteal:
         assert result["error"] == ERR_NO_STEAL_AVAILABLE
 
     def test_target_not_submitted(self):
-        self.state.players["Alice"].steal_available = True
+        self.state.get_player("Alice").steal_available = True
         result = self.state.use_steal("Alice", "Bob")
         assert result["success"] is False
         assert result["error"] == ERR_TARGET_NOT_SUBMITTED
 
     def test_cannot_steal_self(self):
-        self.state.players["Alice"].steal_available = True
+        self.state.get_player("Alice").steal_available = True
         result = self.state.use_steal("Alice", "Alice")
         assert result["success"] is False
         assert result["error"] == ERR_CANNOT_STEAL_SELF
 
     def test_successful_steal(self):
-        self.state.players["Alice"].steal_available = True
-        self.state.players["Bob"].submitted = True
-        self.state.players["Bob"].current_guess = 1990
+        self.state.get_player("Alice").steal_available = True
+        self.state.get_player("Bob").submitted = True
+        self.state.get_player("Bob").current_guess = 1990
         result = self.state.use_steal("Alice", "Bob")
         assert result["success"] is True
         assert result["year"] == 1990
-        assert self.state.players["Alice"].current_guess == 1990
-        assert self.state.players["Alice"].submitted is True
-        assert self.state.players["Alice"].steal_available is False
-        assert self.state.players["Alice"].steal_used is True
+        assert self.state.get_player("Alice").current_guess == 1990
+        assert self.state.get_player("Alice").submitted is True
+        assert self.state.get_player("Alice").steal_available is False
+        assert self.state.get_player("Alice").steal_used is True
 
     def test_steal_wrong_phase(self):
         self.state.phase = GamePhase.REVEAL
-        self.state.players["Alice"].steal_available = True
-        self.state.players["Bob"].submitted = True
-        self.state.players["Bob"].current_guess = 1990
+        self.state.get_player("Alice").steal_available = True
+        self.state.get_player("Bob").submitted = True
+        self.state.get_player("Bob").current_guess = 1990
         result = self.state.use_steal("Alice", "Bob")
         assert result["success"] is False
         assert result["error"] == ERR_INVALID_ACTION
@@ -1004,8 +1004,8 @@ class TestFinalizeGame:
         _create_fresh_game(self.state, songs=make_songs(5))
         self.state.add_player("Alice", MagicMock())
         self.state.add_player("Bob", MagicMock())
-        self.state.players["Alice"].score = 120
-        self.state.players["Bob"].score = 80
+        self.state.get_player("Alice").score = 120
+        self.state.get_player("Bob").score = 80
         self.state.round = 5
 
     def test_winner_is_highest_scorer(self):
@@ -1083,7 +1083,7 @@ class TestGetState:
     def test_end_state_has_winner(self):
         _create_fresh_game(self.state)
         self.state.add_player("Alice", MagicMock())
-        self.state.players["Alice"].score = 100
+        self.state.get_player("Alice").score = 100
         self.state.phase = GamePhase.END
         state = self.state.get_state()
         assert "winner" in state
@@ -1178,11 +1178,11 @@ class TestRematchGame:
         """Players must be preserved across rematch (scores reset)."""
         _create_fresh_game(self.state)
         self.state.add_player("Alice", MagicMock())
-        self.state.players["Alice"].score = 200
+        self.state.get_player("Alice").score = 200
         self.state.phase = GamePhase.END
         self.state.rematch_game()
-        assert "Alice" in self.state.players
-        assert self.state.players["Alice"].score == 0  # reset for new game
+        assert self.state.get_player("Alice") is not None
+        assert self.state.get_player("Alice").score == 0  # reset for new game
 
     def test_rematch_preserves_songs(self):
         """Songs must be restored so gameplay can start immediately."""
@@ -1697,13 +1697,13 @@ class TestTitleArtistMode:
         gs.add_player("Alice", _make_ws_for_state())
         gs.add_player("Bob", _make_ws_for_state())
         # Year guesses in for both (the existing all_submitted gate)
-        gs.players["Alice"].submit_guess(1965, 1.0)
-        gs.players["Bob"].submit_guess(1965, 1.0)
+        gs.get_player("Alice").submit_guess(1965, 1.0)
+        gs.get_player("Bob").submit_guess(1965, 1.0)
         # Only Alice submitted her title/artist guess
-        gs.players["Alice"].has_title_artist_guess = True
+        gs.get_player("Alice").has_title_artist_guess = True
         assert gs.check_all_guesses_complete() is False
         # Now Bob too
-        gs.players["Bob"].has_title_artist_guess = True
+        gs.get_player("Bob").has_title_artist_guess = True
         assert gs.check_all_guesses_complete() is True
 
 
@@ -2153,8 +2153,8 @@ class TestComputeWinners:
         state = make_game_state()
         state.add_player("Alice", MagicMock())
         state.add_player("Bob", MagicMock())
-        state.players["Alice"].score = 120
-        state.players["Bob"].score = 80
+        state.get_player("Alice").score = 120
+        state.get_player("Bob").score = 80
         winners, top = state.compute_winners()
         assert [w.name for w in winners] == ["Alice"]
         assert top == 120
@@ -2163,8 +2163,8 @@ class TestComputeWinners:
         state = make_game_state()
         state.add_player("Alice", MagicMock())
         state.add_player("Bob", MagicMock())
-        state.players["Alice"].score = 100
-        state.players["Bob"].score = 100
+        state.get_player("Alice").score = 100
+        state.get_player("Bob").score = 100
         winners, top = state.compute_winners()
         assert {w.name for w in winners} == {"Alice", "Bob"}
         assert top == 100
@@ -2180,8 +2180,8 @@ class TestComputeWinners:
         state = make_game_state()
         state.add_player("Alice", MagicMock())
         state.add_player("Bob", MagicMock())
-        state.players["Alice"].score = 100
-        state.players["Bob"].score = 100
+        state.get_player("Alice").score = 100
+        state.get_player("Bob").score = 100
         state.round = 3
 
         summary = state.finalize_game()

--- a/tests/unit/test_state_leaderboard.py
+++ b/tests/unit/test_state_leaderboard.py
@@ -41,7 +41,7 @@ def _create_fresh_game(state) -> None:
 def _add(state, name: str, score: int = 0, **attrs) -> None:
     """Add a player and force-set leaderboard-relevant attributes."""
     state.add_player(name, MagicMock())
-    player = state.players[name]
+    player = state.get_player(name)
     player.score = score
     for key, value in attrs.items():
         setattr(player, key, value)
@@ -64,9 +64,9 @@ class TestStorePreviousRanks:
 
         self.state._store_previous_ranks()
 
-        assert self.state.players["Alice"].previous_rank == 1
-        assert self.state.players["Bob"].previous_rank == 2
-        assert self.state.players["Carol"].previous_rank == 3
+        assert self.state.get_player("Alice").previous_rank == 1
+        assert self.state.get_player("Bob").previous_rank == 2
+        assert self.state.get_player("Carol").previous_rank == 3
 
     def test_tied_players_share_previous_rank_and_skip(self):
         # scores [100, 80, 80, 50] -> ranks [1, 2, 2, 4]
@@ -77,7 +77,7 @@ class TestStorePreviousRanks:
 
         self.state._store_previous_ranks()
 
-        ranks = {n: p.previous_rank for n, p in self.state.players.items()}
+        ranks = {p.name: p.previous_rank for p in self.state.players.values()}
         assert ranks == {"Alice": 1, "Bob": 2, "Carol": 2, "Dave": 4}
 
     def test_overwrites_stale_previous_rank(self):
@@ -87,8 +87,8 @@ class TestStorePreviousRanks:
         self.state._store_previous_ranks()
 
         # Bob leads now; both stale 99s replaced with the fresh snapshot.
-        assert self.state.players["Bob"].previous_rank == 1
-        assert self.state.players["Alice"].previous_rank == 2
+        assert self.state.get_player("Bob").previous_rank == 1
+        assert self.state.get_player("Alice").previous_rank == 2
 
 
 # ---------------------------------------------------------------------------
@@ -141,8 +141,8 @@ class TestLeaderboardRankChange:
         self.state._store_previous_ranks()
 
         # Alice surges to the top, Carol drops to the bottom.
-        self.state.players["Alice"].score = 100
-        self.state.players["Carol"].score = 5
+        self.state.get_player("Alice").score = 100
+        self.state.get_player("Carol").score = 5
 
         lb = {e["name"]: e for e in self.state.get_leaderboard()}
 

--- a/tests/unit/test_state_title_artist_window.py
+++ b/tests/unit/test_state_title_artist_window.py
@@ -210,8 +210,8 @@ class TestVoteWindowScoring:
         gs.set_title_artist_override("Alice:title", True)
         await gs.resolve_title_artist_if_pending()
 
-        alice = gs.players["Alice"]
-        bob = gs.players["Bob"]
+        alice = gs.get_player("Alice")
+        bob = gs.get_player("Bob")
         # Alice: accepted near-miss title (partial 5) + exact artist (5) = 10.
         assert alice.score == 10
         assert alice.round_score == 10
@@ -229,7 +229,7 @@ class TestVoteWindowScoring:
         # No vote and no override -> default reject on resolve.
         await gs.resolve_title_artist_if_pending()
 
-        alice = gs.players["Alice"]
+        alice = gs.get_player("Alice")
         # Rejected title (0) + exact artist (5) = 5.
         assert alice.score == 5
         assert alice.round_scores == [5]
@@ -243,7 +243,7 @@ class TestVoteWindowScoring:
         gs.register_title_artist_vote("Bob", "Alice:title", True)
         await gs.resolve_title_artist_if_pending()
 
-        alice = gs.players["Alice"]
+        alice = gs.get_player("Alice")
         assert alice.score == 10
         assert alice.round_scores == [10]
         assert alice.rounds_played == 1
@@ -262,7 +262,7 @@ class TestVoteWindowScoring:
         finally:
             state_mod.TITLE_ARTIST_VOTE_WINDOW_SECONDS = orig
 
-        alice = gs.players["Alice"]
+        alice = gs.get_player("Alice")
         assert alice.score == 10
         assert alice.round_scores == [10]
         assert alice.rounds_played == 1
@@ -300,7 +300,7 @@ class TestVoteWindowScoring:
         await gs.resolve_title_artist_if_pending()
         await gs._finalize_title_artist_window()
 
-        alice = gs.players["Alice"]
+        alice = gs.get_player("Alice")
         assert alice.score == 10
         assert alice.round_scores == [10]
         assert alice.rounds_played == 1
@@ -352,8 +352,8 @@ class TestRoundResultsShareGrid:
             p.submitted = True
         await gs.end_round()
         assert gs.is_title_artist_voting_open() is False
-        assert gs.players["Alice"].round_results == ["scored"]
-        assert gs.players["Bob"].round_results == ["exact"]
+        assert gs.get_player("Alice").round_results == ["scored"]
+        assert gs.get_player("Bob").round_results == ["exact"]
         gs._cancel_auto_advance()
 
     async def test_accepted_near_miss_is_close_deferred_path(self):
@@ -376,13 +376,13 @@ class TestRoundResultsShareGrid:
             p.submitted = True
         await gs.end_round()
         # Deferred — no round_results banked yet while the window is open.
-        assert gs.players["Alice"].round_results == []
+        assert gs.get_player("Alice").round_results == []
         gs.set_title_artist_override("Alice:title", True)
         await gs.resolve_title_artist_if_pending()
         # Alice: accepted near-miss title (partial) + exact artist -> "scored"
         # (artist is exact, which earns full points). Bob exact/exact -> "exact".
-        assert gs.players["Alice"].round_results == ["scored"]
-        assert gs.players["Bob"].round_results == ["exact"]
+        assert gs.get_player("Alice").round_results == ["scored"]
+        assert gs.get_player("Bob").round_results == ["exact"]
 
     async def test_rejected_near_miss_only_is_close(self):
         """A near-miss accepted with no other full-points field -> 'close'."""
@@ -402,7 +402,7 @@ class TestRoundResultsShareGrid:
         await gs.end_round()
         gs.set_title_artist_override("Alice:title", True)
         await gs.resolve_title_artist_if_pending()
-        assert gs.players["Alice"].round_results == ["close"]
+        assert gs.get_player("Alice").round_results == ["close"]
 
     async def test_no_submission_is_missed(self):
         """A player who didn't guess in title/artist mode -> 'missed'."""
@@ -412,12 +412,12 @@ class TestRoundResultsShareGrid:
         gs._challenge_manager.submit_title_artist_guess(
             "Bob", gs.current_song["title"], gs.current_song["artist"], 1.0
         )
-        gs.players["Bob"].submitted = True
+        gs.get_player("Bob").submitted = True
         # Alice never submits.
         await gs.end_round()
         assert gs.is_title_artist_voting_open() is False
-        assert gs.players["Alice"].round_results == ["missed"]
-        assert gs.players["Bob"].round_results == ["exact"]
+        assert gs.get_player("Alice").round_results == ["missed"]
+        assert gs.get_player("Bob").round_results == ["exact"]
         gs._cancel_auto_advance()
 
 

--- a/tests/unit/test_websocket.py
+++ b/tests/unit/test_websocket.py
@@ -120,7 +120,7 @@ class TestJoin:
 
         await handler._handle_message(ws, {"type": "join", "name": "Alice"})
 
-        assert "Alice" in game_state.players
+        assert game_state.get_player("Alice") is not None
         # Should receive join_ack, then state
         calls = ws.send_json.call_args_list
         types = [c[0][0]["type"] for c in calls]
@@ -191,8 +191,8 @@ class TestJoin:
             {"type": "join", "name": "Host", "is_admin": True, "ha_token": "t"},
         )
 
-        assert "Host" in game_state.players
-        assert game_state.players["Host"].is_admin is True
+        assert game_state.get_player("Host") is not None
+        assert game_state.get_player("Host").is_admin is True
 
     async def test_admin_join_without_ha_token_rejected(self):
         """#998: an is_admin claim with no HA token is rejected."""
@@ -205,7 +205,7 @@ class TestJoin:
         msg = ws.send_json.call_args[0][0]
         assert msg["type"] == "error"
         assert msg["code"] == ERR_UNAUTHORIZED
-        assert "Host" not in game_state.players
+        assert game_state.get_player("Host") is None
 
     async def test_second_admin_join_rejected(self):
         handler, game_state, ws = _make_handler_and_game()
@@ -223,7 +223,7 @@ class TestJoin:
         assert msg["type"] == "error"
         assert msg["code"] == ERR_ADMIN_EXISTS
         # Intruder should have been removed
-        assert "Intruder" not in game_state.players
+        assert game_state.get_player("Intruder") is None
 
     async def test_admin_reconnect_during_pause(self):
         handler, game_state, ws = _make_handler_and_game()
@@ -233,7 +233,7 @@ class TestJoin:
         game_state.add_player("Player2", _make_ws())
         game_state.start_game()
         # Simulate admin disconnect and game pause
-        game_state.players["Host"].connected = False
+        game_state.get_player("Host").connected = False
         game_state.phase = GamePhase.PAUSED
         game_state.disconnected_admin_name = "Host"
         game_state._previous_phase = GamePhase.PLAYING
@@ -263,7 +263,7 @@ class TestJoin:
         game_state.set_admin("Ben")
         # Simulate the WS drop that triggers Levtos's flow: connected=False
         # but no pause yet (grace period running or never fired).
-        game_state.players["Ben"].connected = False
+        game_state.get_player("Ben").connected = False
         game_state.phase = GamePhase.REVEAL
         assert not game_state.disconnected_admin_name
 
@@ -274,8 +274,8 @@ class TestJoin:
         )
 
         # Ben should still be admin, still in players, no error sent.
-        assert "Ben" in game_state.players
-        assert game_state.players["Ben"].is_admin is True
+        assert game_state.get_player("Ben") is not None
+        assert game_state.get_player("Ben").is_admin is True
         # Phase stays REVEAL — reclaim doesn't auto-resume from REVEAL
         assert game_state.phase == GamePhase.REVEAL
         # No error was sent on the new ws
@@ -307,7 +307,7 @@ class TestJoin:
         # Either ERR_ADMIN_EXISTS (existing admin found) or ERR_INVALID_ACTION
         # (phase check) is acceptable — both mean "no, you're not admin".
         assert msg["code"] in (ERR_ADMIN_EXISTS, ERR_INVALID_ACTION)
-        assert "Intruder" not in game_state.players
+        assert game_state.get_player("Intruder") is None
 
 
 # ---------------------------------------------------------------------------
@@ -328,8 +328,8 @@ class TestSubmit:
 
         await handler._handle_message(ws, {"type": "submit", "year": 1985})
 
-        assert game_state.players["Alice"].submitted is True
-        assert game_state.players["Alice"].current_guess == 1985
+        assert game_state.get_player("Alice").submitted is True
+        assert game_state.get_player("Alice").current_guess == 1985
         # Should receive submit_ack
         ack = next(
             c[0][0]
@@ -364,7 +364,7 @@ class TestSubmit:
         game_state.add_player("Alice", ws)
         game_state.phase = GamePhase.PLAYING
         game_state.deadline = int(game_state._now() * 1000) + 60_000
-        game_state.players["Alice"].submitted = True
+        game_state.get_player("Alice").submitted = True
 
         await handler._handle_message(ws, {"type": "submit", "year": 1985})
 
@@ -432,7 +432,7 @@ class TestSubmit:
 
         await handler._handle_message(ws, {"type": "submit", "year": 1985, "bet": True})
 
-        assert game_state.players["Alice"].bet is True
+        assert game_state.get_player("Alice").bet is True
 
 
 # ---------------------------------------------------------------------------
@@ -444,8 +444,8 @@ class TestReconnect:
     async def test_successful_reconnect(self):
         handler, game_state, ws = _make_handler_and_game()
         game_state.add_player("Alice", ws)
-        session_id = game_state.players["Alice"].session_id
-        game_state.players["Alice"].connected = False
+        session_id = game_state.get_player("Alice").session_id
+        game_state.get_player("Alice").connected = False
 
         new_ws = _make_ws()
         await handler._handle_message(
@@ -456,8 +456,8 @@ class TestReconnect:
         types = [c[0][0]["type"] for c in new_ws.send_json.call_args_list]
         assert "reconnect_ack" in types
         assert "state" in types
-        assert game_state.players["Alice"].connected is True
-        assert game_state.players["Alice"].ws is new_ws
+        assert game_state.get_player("Alice").connected is True
+        assert game_state.get_player("Alice").ws is new_ws
 
     async def test_reconnect_no_session_id(self):
         handler, game_state, ws = _make_handler_and_game()
@@ -480,7 +480,7 @@ class TestReconnect:
     async def test_reconnect_ended_game(self):
         handler, game_state, ws = _make_handler_and_game()
         game_state.add_player("Alice", ws)
-        session_id = game_state.players["Alice"].session_id
+        session_id = game_state.get_player("Alice").session_id
         game_state.phase = GamePhase.END
 
         new_ws = _make_ws()
@@ -507,7 +507,7 @@ class TestLeave:
         await handler._handle_message(ws, {"type": "leave"})
 
         # Player should be removed
-        assert "Alice" not in game_state.players
+        assert game_state.get_player("Alice") is None
         # Should receive "left" message
         left_msg = next(
             c[0][0] for c in ws.send_json.call_args_list if c[0][0]["type"] == "left"
@@ -525,7 +525,7 @@ class TestLeave:
         assert msg["type"] == "error"
         assert msg["code"] == ERR_ADMIN_CANNOT_LEAVE
         # Admin should still be in game
-        assert "Host" in game_state.players
+        assert game_state.get_player("Host") is not None
 
     async def test_leave_unknown_player_silent(self):
         handler, game_state, ws = _make_handler_and_game()
@@ -569,9 +569,9 @@ class TestSteal:
         game_state.add_player("Alice", ws)
         game_state.add_player("Bob", _make_ws())
         game_state.phase = GamePhase.PLAYING
-        game_state.players["Alice"].steal_available = True
-        game_state.players["Bob"].submitted = True
-        game_state.players["Bob"].current_guess = 1990
+        game_state.get_player("Alice").steal_available = True
+        game_state.get_player("Bob").submitted = True
+        game_state.get_player("Bob").current_guess = 1990
         handler.connections.add(ws)
 
         await handler._handle_message(ws, {"type": "steal", "target": "Bob"})
@@ -1295,7 +1295,7 @@ class TestTitleArtistGuess:
         )
         assert ack["title_status"] == "exact"
         assert ack["artist_status"] == "exact"
-        assert game_state.players["Alice"].has_title_artist_guess is True
+        assert game_state.get_player("Alice").has_title_artist_guess is True
 
     async def test_empty_fields_allowed_as_skipped(self):
         handler, game_state, ws = self._playing_game()

--- a/tests/unit/test_ws_late_guess_deadline.py
+++ b/tests/unit/test_ws_late_guess_deadline.py
@@ -58,7 +58,7 @@ async def _playing_game_with_player():
 
     ws = _ws()
     gs.add_player("Alice", ws)
-    gs.players["Alice"].connected = True
+    gs.get_player("Alice").connected = True
     await gs.start_round()
     assert gs.phase == GamePhase.PLAYING
     # Round is still PLAYING, but the deadline has elapsed.
@@ -95,6 +95,6 @@ class TestLateGuessRejected:
         # Handler answered with the round-expired error ...
         assert ERR_ROUND_EXPIRED in _sent_codes(ws)
         # ... and never marked the guess as submitted (no points/bonus banked).
-        assert getattr(gs.players["Alice"], flag) is False
+        assert getattr(gs.get_player("Alice"), flag) is False
 
         gs._cancel_auto_advance()

--- a/tests/unit/test_ws_title_artist_guess.py
+++ b/tests/unit/test_ws_title_artist_guess.py
@@ -84,7 +84,7 @@ class TestTitleArtistGuessMarksSubmitted:
         handler, gs = _make_handler_game()
         ws = _ws()
         gs.add_player("Alice", ws)
-        gs.players["Alice"].connected = True
+        gs.get_player("Alice").connected = True
         await gs.start_round()
         assert gs.phase == GamePhase.PLAYING
 
@@ -101,7 +101,7 @@ class TestTitleArtistGuessMarksSubmitted:
             },
         )
 
-        player = gs.players["Alice"]
+        player = gs.get_player("Alice")
         assert player.has_title_artist_guess is True
         # The bug: the handler never set these, so scoring + early reveal break.
         assert player.submitted is True
@@ -150,8 +150,8 @@ class TestTitleArtistGuessMarksSubmitted:
                 "artist": truth_artist,
             },
         )
-        assert gs.players["Alice"].submitted is True
-        assert gs.players["Bob"].submitted is True
+        assert gs.get_player("Alice").submitted is True
+        assert gs.get_player("Bob").submitted is True
         assert gs.check_all_guesses_complete() is True
 
         gs._cancel_auto_advance()
@@ -167,7 +167,7 @@ class TestGuessTruncatedAtIngest:
         handler, gs = _make_handler_game()
         ws = _ws()
         gs.add_player("Alice", ws)
-        gs.players["Alice"].connected = True
+        gs.get_player("Alice").connected = True
         await gs.start_round()
 
         # Capture what the dispatched handler actually receives.
@@ -198,7 +198,7 @@ class TestGuessTruncatedAtIngest:
         handler, gs = _make_handler_game()
         ws = _ws()
         gs.add_player("Alice", ws)
-        gs.players["Alice"].connected = True
+        gs.get_player("Alice").connected = True
         await gs.start_round()
 
         exact = "z" * MAX_GUESS_LEN

--- a/tests/unit/test_ws_title_artist_vote.py
+++ b/tests/unit/test_ws_title_artist_vote.py
@@ -113,7 +113,7 @@ class TestVoteHandler:
         handler, gs = _make_handler_game()
         bob_ws = _ws()
         gs.add_player("Bob", bob_ws)
-        gs.players["Bob"].connected = True
+        gs.get_player("Bob").connected = True
         # phase is LOBBY
         await handler._handle_message(
             bob_ws,
@@ -215,4 +215,4 @@ class TestHostAdvanceResolves:
         assert gs.is_title_artist_voting_open() is False
         assert ta.resolved is True
         # Alice's accepted near-miss banked partial title (5) + exact artist (5).
-        assert gs.players["Alice"].score == 10
+        assert gs.get_player("Alice").score == 10


### PR DESCRIPTION
## PR-2 of #1664 item 1 — Player identity refactor

Switches the `PlayerRegistry` primary key from the mutable display **name** to the stable **`player_id`** (`== session_id`). Conservative, incremental step — the name-based path is retained as an explicit deprecation fallback, not removed (that is PR-5).

### What changed
- **Registry key Name → player_id** (`game/player_registry.py`): `players` is now `dict[player_id, PlayerSession]`. Added `_name_index` (`name.lower() → player_id`) as a non-authoritative display/uniqueness hint, and kept `_sessions` (`session_id → player_id`) as the reconnect gate so `clear_all_sessions()` semantics (Story 11.6: invalidate session reconnect while leaving players intact) are preserved exactly.
- **`players` is now a property** with a setter that rebuilds the derived indexes, keeping `_name_index`/`_sessions` consistent after a wholesale `self.players = {}` replacement (teardown path).
- **`get_player_by_session_id`** resolves through the `_sessions` gate (kept deliberately over a raw dict lookup to preserve leftover-session behaviour).
- **Name-based reconnect FALLBACK retained** in `add_player` — the case-insensitive name match still reactivates a disconnected record, now via `_name_index`, and emits a deprecation log (`name-based reconnect fallback (deprecated) for %s`). No big-bang removal.
- **F6 case-fix**: `get_player` / `remove_player` / `set_admin` now share one case-insensitive semantic (all resolve through `_name_index`). Previously `add_player` was case-insensitive while `remove_player`/`set_admin` were case-sensitive.
- **Steal targeting** (`game/powerups.py`): `get_steal_targets` / `use_steal` receive an id-keyed dict now, so they resolve stealer/target by the `player.name` attribute instead of the dict key. Name-based steal input is unchanged.
- **Delegation & callers**: `game/state_player.py` docstring updated; `server/websocket.py` (disconnect + admin-pause task), `server/ws_handlers/lifecycle.py` (`handle_leave`), and `game/share.py` no longer use the dict key as a name — they resolve via `get_player_by_ws` / `player.name` / `get_player_by_session_id(player.player_id)`.

### Tests
- New `tests/unit/test_player_id_registry_1664.py` (14 tests): registry keyed by player_id, `get_players_state` exposes `player_id`, session_id reconnect survives rename/case, name-uniqueness retained + fallback reconnect reactivates the same record, F6 case-consistency across get/remove/set_admin, steal targeting after the key change.
- Existing tests that indexed `players["Name"]` / `"Name" in players` (name-key internals) were mechanically migrated to `get_player("Name")` / `get_player(...) is [not] None` — behaviour preserved, ~135 call sites across 8 files.
- Full suite: **1259 passed, 2 skipped**. `ruff format` + `ruff check` clean. `mypy` gate green (16 files).

### Not in this PR
- PR-3: admin-reclaim on id (`disconnected_admin_id`, F2/F5)
- PR-4: FE persistence on `player_id` + rename call (F3)
- PR-5: remove the name key entirely (after prod logs confirm the fallback is unused)

PR-2 of #1664 item 1 refactor plan; PR-3 (admin-reclaim), PR-4 (FE), PR-5 (remove name-key) follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
