### PR TITLE
fix(i18n): #1730 backfill 133 missing es/fr/nl keys + fix CONTRIBUTING path

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -181,10 +181,12 @@ Notes:
 ## Translations
 
 Config-flow / setup strings live in `custom_components/beatify/translations/`
-(`de`, `en`, `es`, `fr`, `nl`). The in-app UI strings are handled in
-`custom_components/beatify/www/js/i18n.js`. To add or fix a language, update the
-matching JSON / i18n entries and keep keys in sync across all languages. After
-editing `i18n.js`, rebuild (`npm run build`) so `i18n.min.js` stays current.
+(`de`, `en`, `es`, `fr`, `nl`). The in-app UI strings live in
+`custom_components/beatify/www/i18n/<locale>.json` (one file per locale:
+`en.json`, `de.json`, `es.json`, `fr.json`, `nl.json`). `en.json` is the
+canonical source — add new keys there first, then mirror them into every other
+locale, keeping the exact same key structure and nesting across all languages.
+No build step is required for these JSON files; they are loaded at runtime.
 
 ---
 

--- a/custom_components/beatify/www/i18n/es.json
+++ b/custom_components/beatify/www/i18n/es.json
@@ -88,13 +88,13 @@
     "timeRemaining": "{seconds}s restantes",
     "bet": "Triple o nada",
     "betShort": "×3",
+    "betActive": "Apuesta activa!",
     "noBonusThisRound": "Sin bonus esta ronda — acierta el año",
     "lockedIn": "Bloqueado · esperando a los demás",
     "lockedInWaitingCount": "Bloqueado · esperando a {count} más",
     "lockedInAllSubmitted": "Bloqueado · todos enviaron",
     "waitingForOthers": "Esperando a los demás",
     "allSubmitted": "Todos dentro",
-    "betActive": "Apuesta activa!",
     "guessArtist": "Adivina el artista",
     "artistPlaceholder": "Nombre del artista",
     "paused": "Juego pausado",
@@ -324,6 +324,26 @@
     "skipRound": "Saltar",
     "mediaPlayers": "Reproductores",
     "playlists": "Listas de reproduccion",
+    "playlistTabList": "Listas",
+    "playlistTabMix": "Mezcla",
+    "mixTitle": "Mezclador inteligente de listas",
+    "mixSubtitle": "Elige etiquetas — Beatify arma al instante un conjunto sin duplicados a partir de tu catálogo.",
+    "mixTargetCount": "Canciones objetivo",
+    "mixPreviewEmpty": "Selecciona etiquetas para previsualizar tu mezcla.",
+    "mixPreviewNone": "Ninguna lista coincide con estas etiquetas.",
+    "mixPreview": "≈ {songs} canciones de {playlists} listas · duplicados eliminados",
+    "mixPreviewTracks": "Ver lista de canciones",
+    "mixPreviewLoading": "Cargando vista previa…",
+    "mixTracklistHeading": "{count} canciones en esta mezcla",
+    "mixTracklistEmpty": "No hay canciones para previsualizar.",
+    "mixStart": "Iniciar mezcla",
+    "mixAssembling": "Armando…",
+    "mixSaveCommunity": "Guardar como lista de la comunidad",
+    "mixNoTags": "No se encontraron listas etiquetadas para mezclar.",
+    "mixNoTagsSelected": "Selecciona al menos una etiqueta.",
+    "mixNoMediaPlayer": "Selecciona primero un reproductor.",
+    "mixFailed": "No se pudo armar la mezcla.",
+    "mixStartUnavailable": "Mezcla creada, pero no se pudo iniciar el juego.",
     "selectPlaylist": "Seleccionar lista",
     "selectMediaPlayer": "Seleccionar altavoz",
     "selectMediaPlayerHint": "Selecciona un reproductor",
@@ -365,6 +385,8 @@
     "stopSong": "Detener canción",
     "connectionLost": "Conexión perdida — reconectando...",
     "connectionDisrupted": "Conexión interrumpida — recarga la página.",
+    "wsAuthFailed": "Home Assistant rechazó el token de acceso. Volviendo a autenticar…",
+    "companionLocalNetworkRequired": "El administrador de Beatify requiere acceso a la red local desde la app Companion — abre Beatify en un navegador externo o conéctate a tu wifi doméstica.",
     "confirmIntro": "Iniciar ronda",
     "next": "Siguiente",
     "nextRound": "Siguiente ronda",
@@ -599,7 +621,8 @@
     "suddenDeathMode": "Muerte Súbita",
     "suddenDeathModeHint": "El último de cada ronda queda eliminado. Gana el último en pie.",
     "suddenDeathDisabledTooltip": "Muerte Súbita necesita al menos 3 jugadores.",
-    "suddenDeathLive": "Muerte Súbita"  },
+    "suddenDeathLive": "Muerte Súbita"
+  },
   "analyticsDashboard": {
     "title": "Estadisticas de Beatify",
     "subtitle": "Estadisticas",
@@ -849,6 +872,7 @@
     "ADMIN_EXISTS": "El anfitrion ya existe",
     "ALREADY_SUBMITTED": "Ya enviaste tu respuesta",
     "CONNECTION_LOST": "Conexion perdida",
+    "EMPTY_MIX": "Ninguna canción coincide con las etiquetas seleccionadas para este proveedor. Prueba con menos etiquetas o distintas.",
     "GAME_ALREADY_STARTED": "Ya hay una partida en curso. Termínala antes de empezar una nueva.",
     "GAME_ENDED": "El juego ha terminado",
     "GAME_FULL": "El juego esta lleno",
@@ -858,17 +882,21 @@
     "INVALID_ACTION": "Accion invalida",
     "INVALID_FORMAT": "Esa no parece ser una URL valida de playlist de Spotify.",
     "MEDIA_PLAYER_UNAVAILABLE": "Reproductor no disponible",
+    "MIX_INVALID": "La mezcla creada no pasó la validación. Inténtalo de nuevo con otras etiquetas.",
     "NAME_INVALID": "Nombre invalido",
     "NAME_TAKEN": "Nombre ya en uso",
     "NOT_ADMIN": "Se requiere acceso de administrador",
     "NOT_IN_GAME": "No estas en el juego",
     "NO_SONGS_REMAINING": "No quedan canciones",
+    "NO_TAGS": "Elige al menos una etiqueta para crear una mezcla.",
     "PLAYLIST_NOT_FOUND": "Playlist no encontrada. La URL es correcta y la playlist es publica?",
     "RATE_LIMITED": "Demasiadas solicitudes — espera un minuto e intentalo de nuevo.",
     "RECONNECTING": "Reconectando...",
     "ROUND_EXPIRED": "La ronda ha expirado",
+    "SAVE_FAILED": "No se pudo guardar la mezcla. Inténtalo de nuevo.",
     "SESSION_NOT_FOUND": "Sesion expirada",
     "SESSION_TAKEOVER": "Sesion tomada por otra pestana",
+    "UNAUTHORIZED": "No tienes permiso para hacer eso.",
     "UNKNOWN": "Ocurrio un error",
     "askHostNewGame": "Pide al anfitrion que inicie un nuevo juego.",
     "startNotPossible": "No se puede iniciar",
@@ -1065,6 +1093,166 @@
     "titleArtistTitle": "Adivina la canción",
     "titleArtistCaption": "A veces: escribe título y artista",
     "titleArtistHint": "¿Cerca? La sala vota 👍/👎."
+  },
+  "playlistHub": {
+    "title": "Centro de listas",
+    "loading": "Cargando…",
+    "close": "Cerrar",
+    "retry": "Reintentar",
+    "seeAll": "Ver todo",
+    "by": "de",
+    "bundledBy": "Equipo de Beatify",
+    "songs": "canciones",
+    "played": "reproducida",
+    "players": "jugadores",
+    "min": "min",
+    "local": "Local",
+    "search": {
+      "placeholder": "Buscar listas, artistas, años…"
+    },
+    "tabs": {
+      "bundled": "Incluidas",
+      "community": "Comunidad",
+      "mine": "Mías"
+    },
+    "chips": {
+      "all": "Todos los géneros",
+      "pop": "Pop",
+      "rock": "Rock",
+      "hiphop": "Hip-Hop",
+      "metal": "Metal",
+      "jazz": "Jazz",
+      "electronic": "Electrónica",
+      "latin": "Latina",
+      "schlager": "Schlager",
+      "soul": "Soul / R&B",
+      "other": "Otros"
+    },
+    "shelves": {
+      "yourMostPlayed": "Las más reproducidas",
+      "recentlyPlayed": "Reproducidas recientemente",
+      "editorsPicks": "Selección del equipo",
+      "fromCommunity": "De la comunidad",
+      "popularIn": "Populares en",
+      "recentlyAdded": "Añadidas recientemente",
+      "regional": "Regional y especiales",
+      "searchResults": "Resultados"
+    },
+    "community": {
+      "tag": "COMUNIDAD",
+      "banner": {
+        "title": "¿No hay nada para ti? Pide una lista.",
+        "sub": "Describe el género, la época, el ambiente. Un responsable la publica en 24–48 h."
+      }
+    },
+    "mine": {
+      "requests": "PETICIONES",
+      "done": "LISTAS",
+      "inFlight": "EN CURSO",
+      "untitled": "Petición sin título",
+      "submitted": "Enviada",
+      "empty": {
+        "title": "Aún no hay peticiones",
+        "body": "¿Falta un género, una época o una escena regional? Pídelo. Un responsable lo añade en 24–48 h."
+      },
+      "request": {
+        "title": "Pedir una lista",
+        "sub": "Pega la URL de una lista de Spotify y envíala.",
+        "cta": "Iniciar una petición"
+      },
+      "newRequest": {
+        "title": "Pedir otra lista",
+        "sub": "Pega una URL de Spotify, nosotros nos encargamos."
+      },
+      "meanwhile": {
+        "title": "Mientras tanto, explora listas de la comunidad",
+        "sub": "Selecciones de usuarios, instalables con un toque."
+      },
+      "generator": {
+        "title": "O crea la tuya con una IA",
+        "sub": "URL de Spotify → copia el prompt → ejecútalo en tu IA → pégalo de vuelta → valida → envía.",
+        "subShort": "URL de Spotify → prompt → JSON → validar → enviar."
+      },
+      "step": {
+        "submitted": "Enviada",
+        "reviewed": "Revisada",
+        "building": "En construcción",
+        "inBundled": "Incluida"
+      }
+    },
+    "status": {
+      "pending": "Pendiente",
+      "building": "En construcción",
+      "done": "Lista",
+      "declined": "Rechazada"
+    },
+    "detail": {
+      "add": "Añadir a la ronda",
+      "remove": "Quitar de la ronda",
+      "added": "Añadida",
+      "language": "Idioma",
+      "tags": "Etiquetas",
+      "streaming": "Cobertura de streaming"
+    },
+    "sources": {
+      "bundled": "Incluidas",
+      "community": "Comunidad"
+    },
+    "empty": {
+      "noSearch": {
+        "title": "Sin resultados para",
+        "body": "No hay coincidencias. Prueba con otra búsqueda o mira la otra pestaña.",
+        "searchOther": "Buscar",
+        "request": "Pedir esta lista",
+        "clear": "Borrar búsqueda"
+      },
+      "noFilter": {
+        "title": "Ninguna lista coincide",
+        "body": "Prueba a quitar el filtro o a pedir este género.",
+        "clear": "Borrar filtro de género",
+        "request": "Pedir este género"
+      },
+      "communityEmpty": {
+        "title": "No hay listas de la comunidad instaladas",
+        "body": "Las listas de la comunidad vienen con Beatify. Actualiza la integración para obtener las últimas."
+      }
+    },
+    "error": {
+      "title": "No se pudieron cargar las listas"
+    },
+    "time": {
+      "justNow": "ahora mismo",
+      "minutesAgo": "hace {n} min",
+      "hoursAgo": "hace {n} h",
+      "daysAgo": "hace {n} d",
+      "weeksAgo": "hace {n} sem"
+    },
+    "cta": {
+      "start": "Continuar",
+      "pickSome": "Elige algunas →",
+      "back": "Atrás"
+    },
+    "pill": {
+      "add": "Añadir",
+      "added": "Añadida",
+      "ariaAdd": "Añadir a la ronda",
+      "ariaRemove": "Quitar de la ronda"
+    },
+    "sections": {
+      "byCountry": "Por país",
+      "byStyle": "Por estilo",
+      "countries": "países",
+      "styles": "estilos"
+    },
+    "selected": {
+      "title": "Tus listas seleccionadas",
+      "subtitleOne": "1 lista seleccionada",
+      "subtitleN": "{n} listas seleccionadas",
+      "empty": "Aún no hay listas seleccionadas",
+      "remove": "Quitar",
+      "removeAria": "Quitar {name}",
+      "openAria": "Mostrar listas seleccionadas"
+    }
   },
   "playlistGenerator": {
     "title": "Generador de listas",

--- a/custom_components/beatify/www/i18n/fr.json
+++ b/custom_components/beatify/www/i18n/fr.json
@@ -88,13 +88,13 @@
     "timeRemaining": "{seconds}s restantes",
     "bet": "Quitte ou triple",
     "betShort": "×3",
+    "betActive": "Pari actif !",
     "noBonusThisRound": "Pas de bonus ce tour — trouve l'année",
     "lockedIn": "Verrouillé · en attente des autres",
     "lockedInWaitingCount": "Verrouillé · en attente de {count} joueur(s)",
     "lockedInAllSubmitted": "Verrouillé · tout le monde a envoyé",
     "waitingForOthers": "En attente des autres",
     "allSubmitted": "Tous prêts",
-    "betActive": "Pari actif !",
     "guessArtist": "Devine l'artiste",
     "artistPlaceholder": "Nom de l'artiste",
     "paused": "Partie en pause",
@@ -324,6 +324,26 @@
     "skipRound": "Passer",
     "mediaPlayers": "Lecteurs",
     "playlists": "Playlists",
+    "playlistTabList": "Playlists",
+    "playlistTabMix": "Mix",
+    "mixTitle": "Mixeur intelligent de playlists",
+    "mixSubtitle": "Choisis des tags — Beatify compose à la volée un ensemble dédupliqué à partir de ton catalogue.",
+    "mixTargetCount": "Nombre de titres visé",
+    "mixPreviewEmpty": "Sélectionne des tags pour prévisualiser ton mix.",
+    "mixPreviewNone": "Aucune playlist ne correspond à ces tags.",
+    "mixPreview": "≈ {songs} titres de {playlists} playlists · doublons supprimés",
+    "mixPreviewTracks": "Voir la liste des titres",
+    "mixPreviewLoading": "Chargement de l'aperçu…",
+    "mixTracklistHeading": "{count} titres dans ce mix",
+    "mixTracklistEmpty": "Aucun titre à afficher.",
+    "mixStart": "Démarrer le mix",
+    "mixAssembling": "Composition…",
+    "mixSaveCommunity": "Enregistrer comme playlist de la communauté",
+    "mixNoTags": "Aucune playlist taguée à mixer trouvée.",
+    "mixNoTagsSelected": "Sélectionne au moins un tag.",
+    "mixNoMediaPlayer": "Sélectionne d'abord un lecteur multimédia.",
+    "mixFailed": "Impossible de composer le mix.",
+    "mixStartUnavailable": "Mix composé, mais la partie n'a pas pu démarrer.",
     "selectPlaylist": "Choisir une playlist",
     "selectMediaPlayer": "Choisir une enceinte",
     "selectMediaPlayerHint": "Sélectionne un lecteur",
@@ -365,6 +385,8 @@
     "stopSong": "Arrêter chanson",
     "connectionLost": "Connexion perdue — reconnexion...",
     "connectionDisrupted": "Connexion interrompue — veuillez recharger la page.",
+    "wsAuthFailed": "Home Assistant a rejeté le jeton d'accès. Nouvelle authentification…",
+    "companionLocalNetworkRequired": "L'admin Beatify nécessite un accès au réseau local depuis l'app Companion — ouvre Beatify dans un navigateur externe, ou connecte-toi à ton wifi domestique.",
     "confirmIntro": "Lancer la manche",
     "next": "Suivant",
     "nextRound": "Manche suivante",
@@ -599,7 +621,8 @@
     "suddenDeathMode": "Mort Subite",
     "suddenDeathModeHint": "Le dernier de chaque manche est éliminé. Le dernier en lice gagne.",
     "suddenDeathDisabledTooltip": "La Mort Subite nécessite au moins 3 joueurs.",
-    "suddenDeathLive": "Mort Subite"  },
+    "suddenDeathLive": "Mort Subite"
+  },
   "analyticsDashboard": {
     "title": "Statistiques Beatify",
     "subtitle": "Statistiques",
@@ -849,6 +872,7 @@
     "ADMIN_EXISTS": "L'hôte existe déjà",
     "ALREADY_SUBMITTED": "Tu as déjà envoyé ta réponse",
     "CONNECTION_LOST": "Connexion perdue",
+    "EMPTY_MIX": "Aucun titre ne correspond aux tags sélectionnés pour ce fournisseur. Essaie avec moins de tags ou d'autres tags.",
     "GAME_ALREADY_STARTED": "Une partie est déjà en cours. Termine-la avant d'en lancer une nouvelle.",
     "GAME_ENDED": "La partie est terminée",
     "GAME_FULL": "La partie est complète",
@@ -858,17 +882,21 @@
     "INVALID_ACTION": "Action invalide",
     "INVALID_FORMAT": "Cela ne ressemble pas à une URL valide de playlist Spotify.",
     "MEDIA_PLAYER_UNAVAILABLE": "Lecteur indisponible",
+    "MIX_INVALID": "Le mix composé n'a pas passé la validation. Réessaie avec d'autres tags.",
     "NAME_INVALID": "Nom invalide",
     "NAME_TAKEN": "Nom déjà utilisé",
     "NOT_ADMIN": "Accès administrateur requis",
     "NOT_IN_GAME": "Tu n'es pas dans la partie",
     "NO_SONGS_REMAINING": "Plus de chansons restantes",
+    "NO_TAGS": "Choisis au moins un tag pour créer un mix.",
     "PLAYLIST_NOT_FOUND": "Playlist introuvable. L’URL est-elle correcte et la playlist publique ?",
     "RATE_LIMITED": "Trop de requêtes — patiente une minute et réessaye.",
     "RECONNECTING": "Reconnexion...",
     "ROUND_EXPIRED": "La manche a expiré",
+    "SAVE_FAILED": "Impossible d'enregistrer le mix. Réessaie.",
     "SESSION_NOT_FOUND": "Session expirée",
     "SESSION_TAKEOVER": "Session reprise par un autre onglet",
+    "UNAUTHORIZED": "Tu n'es pas autorisé à faire ça.",
     "UNKNOWN": "Une erreur est survenue",
     "askHostNewGame": "Demande à l'hôte de lancer une nouvelle partie.",
     "startNotPossible": "Démarrage impossible",
@@ -1065,6 +1093,166 @@
     "titleArtistTitle": "Trouve le titre",
     "titleArtistCaption": "Parfois : tape le titre & l’artiste",
     "titleArtistHint": "Presque ? La salle vote 👍/👎."
+  },
+  "playlistHub": {
+    "title": "Hub des playlists",
+    "loading": "Chargement…",
+    "close": "Fermer",
+    "retry": "Réessayer",
+    "seeAll": "Tout voir",
+    "by": "par",
+    "bundledBy": "Équipe Beatify",
+    "songs": "titres",
+    "played": "jouée",
+    "players": "joueurs",
+    "min": "min",
+    "local": "Locale",
+    "search": {
+      "placeholder": "Rechercher playlists, artistes, années…"
+    },
+    "tabs": {
+      "bundled": "Incluses",
+      "community": "Communauté",
+      "mine": "Les miennes"
+    },
+    "chips": {
+      "all": "Tous les genres",
+      "pop": "Pop",
+      "rock": "Rock",
+      "hiphop": "Hip-Hop",
+      "metal": "Metal",
+      "jazz": "Jazz",
+      "electronic": "Électronique",
+      "latin": "Latino",
+      "schlager": "Schlager",
+      "soul": "Soul / R&B",
+      "other": "Autres"
+    },
+    "shelves": {
+      "yourMostPlayed": "Tes plus jouées",
+      "recentlyPlayed": "Jouées récemment",
+      "editorsPicks": "Sélection de la rédaction",
+      "fromCommunity": "De la communauté",
+      "popularIn": "Populaires en",
+      "recentlyAdded": "Ajoutées récemment",
+      "regional": "Régional et spécialités",
+      "searchResults": "Résultats"
+    },
+    "community": {
+      "tag": "COMMUNAUTÉ",
+      "banner": {
+        "title": "Rien pour toi ici ? Demande une playlist.",
+        "sub": "Décris le genre, l'époque, l'ambiance. Un mainteneur la livre en 24–48 h."
+      }
+    },
+    "mine": {
+      "requests": "DEMANDES",
+      "done": "TERMINÉ",
+      "inFlight": "EN COURS",
+      "untitled": "Demande sans titre",
+      "submitted": "Envoyée",
+      "empty": {
+        "title": "Pas encore de demandes",
+        "body": "Il manque un genre, une époque ou une scène régionale ? Demande-le. Un mainteneur l'ajoute en 24–48 h."
+      },
+      "request": {
+        "title": "Demander une playlist",
+        "sub": "Colle l'URL d'une playlist Spotify et envoie.",
+        "cta": "Lancer une demande"
+      },
+      "newRequest": {
+        "title": "Demander une autre playlist",
+        "sub": "Colle une URL Spotify, on s'occupe du reste."
+      },
+      "meanwhile": {
+        "title": "En attendant, explore les playlists de la communauté",
+        "sub": "Sélections des utilisateurs, installables en un tap."
+      },
+      "generator": {
+        "title": "Ou crée la tienne avec une IA",
+        "sub": "URL Spotify → copie le prompt → lance-le dans ton IA → recolle → valide → envoie.",
+        "subShort": "URL Spotify → prompt → JSON → valider → envoyer."
+      },
+      "step": {
+        "submitted": "Envoyée",
+        "reviewed": "Examinée",
+        "building": "En cours",
+        "inBundled": "Livrée"
+      }
+    },
+    "status": {
+      "pending": "En attente",
+      "building": "En cours",
+      "done": "Terminée",
+      "declined": "Refusée"
+    },
+    "detail": {
+      "add": "Ajouter à la manche",
+      "remove": "Retirer de la manche",
+      "added": "Ajoutée",
+      "language": "Langue",
+      "tags": "Tags",
+      "streaming": "Couverture streaming"
+    },
+    "sources": {
+      "bundled": "Incluses",
+      "community": "Communauté"
+    },
+    "empty": {
+      "noSearch": {
+        "title": "Aucun résultat pour",
+        "body": "Rien ne correspond ici. Essaie une autre recherche, ou consulte l'autre onglet.",
+        "searchOther": "Rechercher",
+        "request": "Demander cette playlist",
+        "clear": "Effacer la recherche"
+      },
+      "noFilter": {
+        "title": "Aucune playlist ne correspond",
+        "body": "Essaie de retirer le filtre ou de demander ce genre.",
+        "clear": "Effacer le filtre de genre",
+        "request": "Demander ce genre"
+      },
+      "communityEmpty": {
+        "title": "Aucune playlist de la communauté installée",
+        "body": "Les playlists de la communauté sont fournies avec Beatify. Mets à jour l'intégration pour obtenir les dernières."
+      }
+    },
+    "error": {
+      "title": "Impossible de charger les playlists"
+    },
+    "time": {
+      "justNow": "à l'instant",
+      "minutesAgo": "il y a {n} min",
+      "hoursAgo": "il y a {n} h",
+      "daysAgo": "il y a {n} j",
+      "weeksAgo": "il y a {n} sem"
+    },
+    "cta": {
+      "start": "Continuer",
+      "pickSome": "Choisis-en →",
+      "back": "Retour"
+    },
+    "pill": {
+      "add": "Ajouter",
+      "added": "Ajoutée",
+      "ariaAdd": "Ajouter à la manche",
+      "ariaRemove": "Retirer de la manche"
+    },
+    "sections": {
+      "byCountry": "Par pays",
+      "byStyle": "Par style",
+      "countries": "pays",
+      "styles": "styles"
+    },
+    "selected": {
+      "title": "Tes playlists sélectionnées",
+      "subtitleOne": "1 playlist sélectionnée",
+      "subtitleN": "{n} playlists sélectionnées",
+      "empty": "Aucune playlist sélectionnée pour l'instant",
+      "remove": "Retirer",
+      "removeAria": "Retirer {name}",
+      "openAria": "Afficher les playlists sélectionnées"
+    }
   },
   "playlistGenerator": {
     "title": "Générateur de playlists",

--- a/custom_components/beatify/www/i18n/nl.json
+++ b/custom_components/beatify/www/i18n/nl.json
@@ -88,13 +88,13 @@
     "timeRemaining": "{seconds}s over",
     "bet": "Driedubbel of niets",
     "betShort": "×3",
+    "betActive": "Inzet actief!",
     "noBonusThisRound": "Geen bonus deze ronde — raad het jaar",
     "lockedIn": "Vergrendeld · wachten op anderen",
     "lockedInWaitingCount": "Vergrendeld · wachten op {count} meer",
     "lockedInAllSubmitted": "Vergrendeld · iedereen klaar",
     "waitingForOthers": "Wachten op anderen",
     "allSubmitted": "Iedereen klaar",
-    "betActive": "Inzet actief!",
     "guessArtist": "Raad de artiest",
     "artistPlaceholder": "Naam van artiest",
     "paused": "Spel gepauzeerd",
@@ -324,6 +324,26 @@
     "skipRound": "Overslaan",
     "mediaPlayers": "Mediaspelers",
     "playlists": "Afspeellijsten",
+    "playlistTabList": "Playlists",
+    "playlistTabMix": "Mix",
+    "mixTitle": "Slimme playlist-mixer",
+    "mixSubtitle": "Kies tags — Beatify stelt direct een ontdubbelde set samen uit je catalogus.",
+    "mixTargetCount": "Aantal nummers doel",
+    "mixPreviewEmpty": "Selecteer tags om je mix te bekijken.",
+    "mixPreviewNone": "Geen playlists komen overeen met deze tags.",
+    "mixPreview": "≈ {songs} nummers uit {playlists} playlists · duplicaten verwijderd",
+    "mixPreviewTracks": "Tracklist bekijken",
+    "mixPreviewLoading": "Voorbeeld laden…",
+    "mixTracklistHeading": "{count} nummers in deze mix",
+    "mixTracklistEmpty": "Geen nummers om te bekijken.",
+    "mixStart": "Mix starten",
+    "mixAssembling": "Samenstellen…",
+    "mixSaveCommunity": "Opslaan als community-playlist",
+    "mixNoTags": "Geen getagde playlists gevonden om uit te mixen.",
+    "mixNoTagsSelected": "Selecteer minstens één tag.",
+    "mixNoMediaPlayer": "Selecteer eerst een mediaspeler.",
+    "mixFailed": "Kon de mix niet samenstellen.",
+    "mixStartUnavailable": "Mix samengesteld, maar het spel kon niet worden gestart.",
     "selectPlaylist": "Kies afspeellijst",
     "selectMediaPlayer": "Kies speaker",
     "selectMediaPlayerHint": "Kies een mediaspeler",
@@ -365,6 +385,8 @@
     "stopSong": "Stop nummer",
     "connectionLost": "Verbinding verloren — opnieuw verbinden...",
     "connectionDisrupted": "Verbinding verstoord — herlaad de pagina.",
+    "wsAuthFailed": "Home Assistant heeft het toegangstoken geweigerd. Opnieuw authenticeren…",
+    "companionLocalNetworkRequired": "Beatify-admin vereist lokale netwerktoegang vanuit de Companion-app — open Beatify in een externe browser of maak verbinding met je thuis-wifi.",
     "confirmIntro": "Ronde starten",
     "next": "Volgende",
     "nextRound": "Volgende ronde",
@@ -599,7 +621,8 @@
     "suddenDeathMode": "Sudden Death",
     "suddenDeathModeHint": "De laatste van elke ronde valt af. Wie overblijft, wint.",
     "suddenDeathDisabledTooltip": "Sudden Death heeft minstens 3 spelers nodig.",
-    "suddenDeathLive": "Sudden Death"  },
+    "suddenDeathLive": "Sudden Death"
+  },
   "analyticsDashboard": {
     "title": "Beatify Analytics",
     "subtitle": "Analytics",
@@ -849,6 +872,7 @@
     "ADMIN_EXISTS": "Er is al een host",
     "ALREADY_SUBMITTED": "Al verstuurd",
     "CONNECTION_LOST": "Verbinding verbroken",
+    "EMPTY_MIX": "Geen nummers komen overeen met de geselecteerde tags voor deze provider. Probeer minder of andere tags.",
     "GAME_ALREADY_STARTED": "Er is al een spel bezig. Beëindig het voordat je een nieuwe start.",
     "GAME_ENDED": "Het spel is afgelopen",
     "GAME_FULL": "Het spel zit vol",
@@ -858,17 +882,21 @@
     "INVALID_ACTION": "Ongeldige actie",
     "INVALID_FORMAT": "Dat lijkt geen geldige Spotify-playlist-URL te zijn.",
     "MEDIA_PLAYER_UNAVAILABLE": "Mediaspeler niet beschikbaar",
+    "MIX_INVALID": "De samengestelde mix is niet gevalideerd. Probeer het opnieuw met andere tags.",
     "NAME_INVALID": "Ongeldige naam",
     "NAME_TAKEN": "Naam is al in gebruik",
     "NOT_ADMIN": "Beheerrechten vereist",
     "NOT_IN_GAME": "Niet in spel",
     "NO_SONGS_REMAINING": "Geen nummers meer over",
+    "NO_TAGS": "Kies minstens één tag om een mix te maken.",
     "PLAYLIST_NOT_FOUND": "Playlist niet gevonden. Klopt de URL en is de playlist openbaar?",
     "RATE_LIMITED": "Te veel verzoeken — wacht een minuut en probeer opnieuw.",
     "RECONNECTING": "Opnieuw verbinden...",
     "ROUND_EXPIRED": "De ronde is verlopen",
+    "SAVE_FAILED": "Kon de mix niet opslaan. Probeer het opnieuw.",
     "SESSION_NOT_FOUND": "Sessie verlopen",
     "SESSION_TAKEOVER": "Sessie overgenomen door een ander tabblad",
+    "UNAUTHORIZED": "Je hebt daar geen toestemming voor.",
     "UNKNOWN": "Er is een fout opgetreden",
     "askHostNewGame": "Vraag de host om een nieuw spel te starten.",
     "startNotPossible": "Starten niet mogelijk",
@@ -1065,6 +1093,166 @@
     "titleArtistTitle": "Raad het nummer",
     "titleArtistCaption": "Soms: typ de titel & artiest",
     "titleArtistHint": "Bijna? De zaal stemt 👍/👎."
+  },
+  "playlistHub": {
+    "title": "Playlist-hub",
+    "loading": "Laden…",
+    "close": "Sluiten",
+    "retry": "Opnieuw",
+    "seeAll": "Alles bekijken",
+    "by": "van",
+    "bundledBy": "Beatify-team",
+    "songs": "nummers",
+    "played": "gespeeld",
+    "players": "spelers",
+    "min": "min",
+    "local": "Lokaal",
+    "search": {
+      "placeholder": "Zoek playlists, artiesten, jaren…"
+    },
+    "tabs": {
+      "bundled": "Meegeleverd",
+      "community": "Community",
+      "mine": "Mijne"
+    },
+    "chips": {
+      "all": "Alle genres",
+      "pop": "Pop",
+      "rock": "Rock",
+      "hiphop": "Hip-Hop",
+      "metal": "Metal",
+      "jazz": "Jazz",
+      "electronic": "Elektronisch",
+      "latin": "Latin",
+      "schlager": "Schlager",
+      "soul": "Soul / R&B",
+      "other": "Overig"
+    },
+    "shelves": {
+      "yourMostPlayed": "Meest gespeeld",
+      "recentlyPlayed": "Onlangs gespeeld",
+      "editorsPicks": "Redactiekeuze",
+      "fromCommunity": "Uit de community",
+      "popularIn": "Populair in",
+      "recentlyAdded": "Onlangs toegevoegd",
+      "regional": "Regionaal & speciaal",
+      "searchResults": "Resultaten"
+    },
+    "community": {
+      "tag": "COMMUNITY",
+      "banner": {
+        "title": "Niks voor jou hier? Vraag een playlist aan.",
+        "sub": "Beschrijf het genre, tijdperk, de sfeer. Een maintainer levert 'm in 24–48 u."
+      }
+    },
+    "mine": {
+      "requests": "AANVRAGEN",
+      "done": "KLAAR",
+      "inFlight": "ONDERWEG",
+      "untitled": "Naamloze aanvraag",
+      "submitted": "Ingediend",
+      "empty": {
+        "title": "Nog geen aanvragen",
+        "body": "Mis je een genre, tijdperk of regionale scene? Vraag het aan. Een maintainer voegt het toe in 24–48 u."
+      },
+      "request": {
+        "title": "Playlist aanvragen",
+        "sub": "Plak een Spotify-playlist-URL en dien in.",
+        "cta": "Aanvraag starten"
+      },
+      "newRequest": {
+        "title": "Nog een playlist aanvragen",
+        "sub": "Plak een Spotify-URL, wij regelen de rest."
+      },
+      "meanwhile": {
+        "title": "Bekijk ondertussen community-playlists",
+        "sub": "Door gebruikers samengesteld, met één tik te installeren."
+      },
+      "generator": {
+        "title": "Of maak je eigen met een LLM",
+        "sub": "Spotify-URL → prompt kopiëren → in je LLM uitvoeren → terugplakken → valideren → indienen.",
+        "subShort": "Spotify-URL → prompt → JSON → valideren → indienen."
+      },
+      "step": {
+        "submitted": "Ingediend",
+        "reviewed": "Beoordeeld",
+        "building": "In aanbouw",
+        "inBundled": "Geleverd"
+      }
+    },
+    "status": {
+      "pending": "In behandeling",
+      "building": "In aanbouw",
+      "done": "Klaar",
+      "declined": "Afgewezen"
+    },
+    "detail": {
+      "add": "Aan ronde toevoegen",
+      "remove": "Uit ronde verwijderen",
+      "added": "Toegevoegd",
+      "language": "Taal",
+      "tags": "Tags",
+      "streaming": "Streamingdekking"
+    },
+    "sources": {
+      "bundled": "Meegeleverd",
+      "community": "Community"
+    },
+    "empty": {
+      "noSearch": {
+        "title": "Geen resultaten voor",
+        "body": "Niets komt hier overeen. Probeer een andere zoekopdracht of bekijk het andere tabblad.",
+        "searchOther": "Zoeken",
+        "request": "Deze playlist aanvragen",
+        "clear": "Zoekopdracht wissen"
+      },
+      "noFilter": {
+        "title": "Geen playlists komen overeen",
+        "body": "Verwijder het filter of vraag dit genre aan.",
+        "clear": "Genrefilter wissen",
+        "request": "Dit genre aanvragen"
+      },
+      "communityEmpty": {
+        "title": "Geen community-playlists geïnstalleerd",
+        "body": "Community-playlists worden met Beatify meegeleverd. Werk de integratie bij om de nieuwste te krijgen."
+      }
+    },
+    "error": {
+      "title": "Kon playlists niet laden"
+    },
+    "time": {
+      "justNow": "zojuist",
+      "minutesAgo": "{n} min geleden",
+      "hoursAgo": "{n} u geleden",
+      "daysAgo": "{n} d geleden",
+      "weeksAgo": "{n} w geleden"
+    },
+    "cta": {
+      "start": "Doorgaan",
+      "pickSome": "Kies er een paar →",
+      "back": "Terug"
+    },
+    "pill": {
+      "add": "Toevoegen",
+      "added": "Toegevoegd",
+      "ariaAdd": "Aan ronde toevoegen",
+      "ariaRemove": "Uit ronde verwijderen"
+    },
+    "sections": {
+      "byCountry": "Per land",
+      "byStyle": "Per stijl",
+      "countries": "landen",
+      "styles": "stijlen"
+    },
+    "selected": {
+      "title": "Je geselecteerde playlists",
+      "subtitleOne": "1 playlist geselecteerd",
+      "subtitleN": "{n} playlists geselecteerd",
+      "empty": "Nog geen playlists geselecteerd",
+      "remove": "Verwijderen",
+      "removeAria": "{name} verwijderen",
+      "openAria": "Geselecteerde playlists tonen"
+    }
   },
   "playlistGenerator": {
     "title": "Playlist-generator",

--- a/tests/unit/test_i18n_locale_parity.py
+++ b/tests/unit/test_i18n_locale_parity.py
@@ -1,0 +1,74 @@
+"""Key-parity guard for the in-app UI locale files (#1730).
+
+``custom_components/beatify/www/i18n/en.json`` is the canonical source of UI
+strings. Every other locale (``de``, ``es``, ``fr``, ``nl``) must expose the
+*exact same* set of (dotted) keys — no missing keys (which surface as English
+fallbacks for that locale) and no extra keys (dead strings).
+
+Regression context: #1730 — es/fr/nl each drifted 133 keys behind en.json
+(the entire Smart Playlist Mixer UI, ``companionLocalNetworkRequired`` and
+other 4.x strings), so ES/FR/NL hosts silently saw English fallbacks while the
+README promised full support. This test fails loudly the next time a key is
+added to en.json without being mirrored into every locale.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+I18N_DIR = (
+    Path(__file__).resolve().parents[2]
+    / "custom_components"
+    / "beatify"
+    / "www"
+    / "i18n"
+)
+CANONICAL = "en"
+LOCALES = ["de", "es", "fr", "nl"]
+
+
+def _flatten(obj: dict, prefix: str = "") -> set[str]:
+    """Return the set of dotted leaf-key paths in a nested translation dict."""
+    keys: set[str] = set()
+    for key, value in obj.items():
+        dotted = f"{prefix}.{key}" if prefix else key
+        if isinstance(value, dict):
+            keys |= _flatten(value, dotted)
+        else:
+            keys.add(dotted)
+    return keys
+
+
+def _load(locale: str) -> dict:
+    return json.loads((I18N_DIR / f"{locale}.json").read_text(encoding="utf-8"))
+
+
+def test_canonical_locale_exists() -> None:
+    assert (I18N_DIR / f"{CANONICAL}.json").is_file()
+
+
+@pytest.mark.parametrize("locale", LOCALES)
+def test_locale_is_valid_json(locale: str) -> None:
+    # Raises if the file is not valid JSON.
+    _load(locale)
+
+
+@pytest.mark.parametrize("locale", LOCALES)
+def test_locale_key_parity_with_english(locale: str) -> None:
+    en_keys = _flatten(_load(CANONICAL))
+    loc_keys = _flatten(_load(locale))
+
+    missing = sorted(en_keys - loc_keys)
+    extra = sorted(loc_keys - en_keys)
+
+    assert not missing, (
+        f"{locale}.json is missing {len(missing)} key(s) present in "
+        f"{CANONICAL}.json (English fallbacks): {missing}"
+    )
+    assert not extra, (
+        f"{locale}.json has {len(extra)} key(s) not present in "
+        f"{CANONICAL}.json (dead strings): {extra}"
+    )


### PR DESCRIPTION
Fixes #1730

## Problem
`en.json` (canonical) and `de.json` sit at 1098 keys, but `es/fr/nl` each missed the **same 133 keys** — the entire Smart Playlist Mixer UI (`admin.mix*`), `admin.companionLocalNetworkRequired`, the new `errors.*` mix codes, and the full `playlistHub.*` tree. ES/FR/NL hosts saw English fallbacks while the README promised full support. `CONTRIBUTING.md` also pointed contributors at `www/js/i18n.js`, but in-app UI strings actually live in `www/i18n/<locale>.json`.

## Fix
- **Backfill 133 keys** into each of `es.json`, `fr.json`, `nl.json` with real localized translations (not EN placeholders, not machine gibberish). `de.json` used as tone/terminology reference; structure and key order mirrored exactly from `en.json`.
- **Parity confirmed:** all four non-canonical locales now expose the identical key set as `en.json` (1098 keys, 0 missing / 0 extra), valid JSON, all `{placeholder}` tokens preserved.
- **CONTRIBUTING.md:** Translations section now points at `custom_components/beatify/www/i18n/<locale>.json`, names `en.json` as the source of truth, and drops the stale `npm run build` / `i18n.js` guidance (these JSON files load at runtime).
- **New test** `tests/unit/test_i18n_locale_parity.py` guards key parity + JSON validity across all `www/i18n/*.json` so this can't silently regress (9 tests, green).

## Scope
Touches only `www/i18n/{es,fr,nl}.json`, `CONTRIBUTING.md`, and the new test. No README/code changes.