### PR TITLE
docs: sync README + ARCHITECTURE (HA floor, Amazon Music, playlist schema, Mixer, v4.1.x, counts)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 Turn any gathering into an unforgettable music trivia experience.
 Guests scan, songs play, everyone competes. It's that simple.
 
-[![Home Assistant](https://img.shields.io/badge/Home%20Assistant-2024.1+-41BDF5?style=for-the-badge&logo=homeassistant&logoColor=white)](https://www.home-assistant.io/)
+[![Home Assistant](https://img.shields.io/badge/Home%20Assistant-2025.1+-41BDF5?style=for-the-badge&logo=homeassistant&logoColor=white)](https://www.home-assistant.io/)
 [![Version](https://img.shields.io/github/v/release/mholzi/beatify?style=for-the-badge&color=ff00ff&label=Version)](https://github.com/mholzi/beatify/releases)
 [![License](https://img.shields.io/badge/License-MIT-green?style=for-the-badge)](LICENSE)
 
@@ -41,7 +41,7 @@ No apps to download. No accounts to create. Just scan a QR code and play.
 
 **Two Ways to Play** — Guess the release year, or switch to **Title & Artist** mode and type the song title (+10) and artist (+5) in free text, with typo-forgiving partial credit. Close calls go to a live 👍/👎 vote — *Crowd Court* — that the whole room watches on the TV.
 
-**Your Music, Your Vibe** — Spotify, Apple Music, YouTube Music, Tidal, or Deezer playlists. Curated song packs included. Create your own.
+**Your Music, Your Vibe** — Spotify, Apple Music, YouTube Music, Tidal, Deezer, or Amazon Music (Alexa) playlists. Curated song packs included. Create your own.
 
 **Runs Locally** — No cloud, no Beatify account, no data leaves your network. Free and open-source. (You bring your own music-streaming subscription — see [Requirements](#requirements).)
 
@@ -139,7 +139,7 @@ play with zero friction.
 **First time?** Beatify drops you into a 5-step first-run wizard that walks you through the whole setup:
 
 1. **Speakers** — Only [supported speakers](#supported-speakers) appear
-2. **Music service** — Spotify, Apple Music, YouTube Music, Tidal, or Deezer (filtered by speaker)
+2. **Music service** — Spotify, Apple Music, YouTube Music, Tidal, Deezer, or Amazon Music (filtered by speaker; Amazon Music is offered only on Alexa)
 3. **Playlist** — Pick one or more curated packs
 4. **Game mode** — Difficulty, round timer, announcement language, Artist Challenge / Intro Mode / Closest Wins toggles
 5. **Lights & Voice** (optional) — Party Lights mode + WLED presets, TTS announcements (only shown if Home Assistant has the entities)
@@ -354,7 +354,7 @@ Playlists are displayed on the main Beatify admin screen:
 
 ### Included Playlists
 
-Beatify comes with 5,161 songs across 46 curated playlists:
+Beatify comes with 5,381 songs across 49 curated playlists:
 
 - 🎬 **100 Greatest Movie Themes** — 162 iconic film soundtracks
 - ☀️ **100 Summer Anthems** — 112 feel-good tracks from 1957–2020
@@ -385,20 +385,23 @@ Beatify comes with 5,161 songs across 46 curated playlists:
 - 🏆 **Eurovision Winners (1956–2025)** — 72 winning songs
 - 💃 **Fiesta Latina 90s** — 50 Latin party anthems from Shakira, Ricky Martin, Maná
 - 🇫🇮 **Finnish Schlager Classics** — 293 Finnish iskelmä classics
+- 🌪️ **Funk Carioca** — 20 Brazilian baile funk hits spanning 2000–2018
 - 🧃 **Gen Z Anthems** — 30 tracks from TikTok to Good Luck, Babe! spanning 2009–2024
-- 🎯 **Greatest Hits of All Time** — 182 chart-toppers across four decades
+- 🎯 **Greatest Hits of All Time** — 236 chart-toppers across four decades
 - 🤘 **Greatest Metal Songs** — 61 legendary tracks across all major metal subgenres
 - 🔊 **Harder Styles** — 190 hardstyle, hardcore and raw tracks
 - 🎬 **ICONIC Movie Songs** — 72 songs from the movies, with a dedicated movie-quiz mode
 - 🎵 **Motown & Soul Classics** — 100 iconic soul tracks from Diana Ross, Marvin Gaye, The Temptations
 - 🎸 **NDW – Neue Deutsche Welle** — 50 German New Wave classics from 1976–1986
 - 🎤 **One-Hit Wonders** — 98 flash-in-the-pan classics
+- 🇵🇱 **Polski Rock** — 100 Polish rock tracks
+- 🇵🇱 **Polskie przeboje wszech czasów** — 100 all-time Polish hits
 - 💔 **Power Ballads** — 99 epic rock ballads from the 80s and 90s
 - 🎸 **Pure Pop Punk** — 100 essential pop-punk tracks from the 2000s
 - 🇩🇪 **Schlager Classics** — 60 German schlager classics
 - 🇨🇭 **Schweizer Hits** — 97 Swiss tracks
 - ☀️ **Sommerklassiker** — 60 international summer hits from 1978–2023
-- 🇳🇱 **Top 100 Dutch Classics** — 100 Nederlandstalig tracks
+- 🇳🇱 **Top 100 Dutch Classics** — 104 Nederlandstalig tracks
 - 🌀 **Trance Classics** — 120 classic trance anthems
 - 🌍 **World Cup Anthems** — 26 official FIFA World Cup songs, 1962–2026
 - ⛵ **Yacht Rock** — 100 smooth West Coast classics from the 70s and 80s
@@ -409,36 +412,67 @@ Custom playlists are stored in: `config/beatify/playlists/`
 
 See [Creating Playlists](#creating-playlists) for the JSON format.
 
+### Mix Your Own
+
+Don't want to pick whole packs? The **Mix** tab in the playlist picker builds a fresh set on the fly from the tags you care about — no JSON editing required.
+
+1. Open the **Mix** tab in the playlist screen.
+2. Pick any combination of tags across four categories — **decade**, **style**, **region**, and **special** (the same taxonomy as the playlist filter bar).
+3. Choose a target size: **30**, **50**, or **100** songs.
+4. Beatify pulls every track from playlists matching your tags, de-duplicates across packs, and assembles a set at your chosen size.
+
+By default a mix is **transient** — it's built for that one game and isn't saved. Tick **"save as community playlist"** before building and the assembled set is written to `config/beatify/playlists/user/<slug>.json`, where it shows up in the **Community** tab on the next refresh like any other playlist. (Unsaved mixes live in an internal `playlists/mix/` folder and are cleaned up automatically — they never clutter your Community tab.)
+
+You can carry a built mix straight into the setup wizard with **"Weiter → / Continue"**, exactly like selecting a curated pack.
+
 ---
 
 <br>
 
 ## Creating Playlists
 
-Beatify uses simple JSON playlists stored in `config/beatify/playlists/`.
+Beatify uses JSON playlists stored in `config/beatify/playlists/`. The full, authoritative format lives in [`scripts/playlist_schema.json`](scripts/playlist_schema.json) (validated in CI by `scripts/validate_playlists.py`). Here is a schema-accurate example:
 
 ```json
 {
   "name": "80s Classics",
+  "version": "1.0",
+  "tags": ["decade:80s", "style:pop"],
   "songs": [
     {
+      "artist": "Michael Jackson",
+      "title": "Billie Jean",
       "year": 1983,
       "uri": "spotify:track:4cOdK2wGLETKBW3PvgPWqT",
-      "fun_fact": "Spent 8 weeks at #1"
-    },
-    {
-      "year": 1985,
-      "uri": "spotify:track:2374M0fQpWi3dLnB54qaLX",
-      "fun_fact": "Written in just 10 minutes"
+      "uri_apple_music": "https://music.apple.com/us/album/_/269572838?i=269573364",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": null,
+      "alt_artists": ["MJ"],
+      "fun_fact": "Spent 7 weeks at #1 on the Billboard Hot 100.",
+      "fun_fact_de": "Stand 7 Wochen auf Platz 1 der Billboard Hot 100.",
+      "fun_fact_es": "Estuvo 7 semanas en el nº 1 del Billboard Hot 100.",
+      "fun_fact_fr": "7 semaines à la 1re place du Billboard Hot 100.",
+      "fun_fact_nl": "Stond 7 weken op nummer 1 in de Billboard Hot 100."
     }
   ]
 }
 ```
 
+**Required fields**
+- Playlist level: `name`, `version`, `tags`, `songs`.
+- Per song: `artist`, `title` (both mandatory — songs missing either are **silently skipped at load**, #697, so you can't play Title & Artist mode and the track never appears), `year`, `uri`, and the fun-fact set `fun_fact` + `fun_fact_de` / `fun_fact_es` / `fun_fact_fr` / `fun_fact_nl`.
+
+**Optional fields**
+- Extra provider URIs — `uri_apple_music`, `uri_youtube_music`, `uri_tidal`, `uri_deezer` (and `uri_apple_music_by_region` for storefront-specific Apple Music IDs). A song with only a `spotify:` URI plays on Spotify but is skipped on the other services.
+- `alt_artists` (accepted spellings for the Artist Challenge), `isrc`, `chart_info`, `certifications`, `awards` (+ localized `awards_de/es/fr/nl`), and the movie-quiz fields `movie` / `movie_choices` (playlist-level `movie_quiz_enabled: true` to turn the mode on).
+
+> The `uri` must be a Spotify track URI (`spotify:track:<22 chars>`) or `null`. Invalid or incomplete songs are dropped silently rather than failing the whole playlist — check the Home Assistant log if a track doesn't show up.
+
 **Playlist Tips:**
 - Mix decades for variety
 - Include recognizable songs (obscure = frustrating)
-- Add fun facts for the reveal screen
+- Add fun facts for the reveal screen — one per language
 - 10-20 songs per playlist works great
 
 Sample playlists are included to get you started immediately.
@@ -467,13 +501,15 @@ Select during game setup. All players see the chosen language. Fun facts and awa
 
 Beatify works with specific Home Assistant integrations that support music playback:
 
-| Integration | Supported | Spotify | Apple Music | YouTube Music | Tidal | Deezer | How It Works |
-|-------------|-----------|---------|-------------|---------------|-------|--------|--------------|
-| **[Music Assistant](https://music-assistant.io/)** | ✅ Yes | ✅ | ✅ | ✅ | ✅ | ✅ | Direct URI playback to any connected speaker |
-| **Sonos** | ✅ Yes | ✅ | ❌ | ❌ | ❌ | ❌ | Direct Spotify playback via Sonos integration |
-| **Alexa Media Player** | ✅ Yes | ✅ | ✅ | ❌ | ❌ | ❌ | Voice search playback ("Play [song] on Spotify") |
-| **Cast (Chromecast/Nest/Google TV)** | ❌ No | — | — | — | — | — | Use Music Assistant instead |
-| **HomePod** | ❌ No | — | — | — | — | — | Use Music Assistant instead |
+| Integration | Supported | Spotify | Apple Music | YouTube Music | Tidal | Deezer | Amazon Music | How It Works |
+|-------------|-----------|---------|-------------|---------------|-------|--------|--------------|--------------|
+| **[Music Assistant](https://music-assistant.io/)** | ✅ Yes | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | Direct URI playback to any connected speaker |
+| **Sonos** | ✅ Yes | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | Direct Spotify playback via Sonos integration |
+| **Alexa Media Player** | ✅ Yes | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ | Voice-search playback ("Play [song] on [service]") |
+| **Cast (Chromecast/Nest/Google TV)** | ❌ No | — | — | — | — | — | — | Use Music Assistant instead |
+| **HomePod** | ❌ No | — | — | — | — | — | — | Use Music Assistant instead |
+
+> **Amazon Music is Alexa-only and uses text search.** Amazon has no direct-URI playback path, so Beatify asks Alexa to play each track by name (`artist` + `title`) rather than by a fixed track ID. This works well for well-tagged songs but has one caveat: Alexa occasionally picks the wrong version of a track (a live/remaster/cover) when several share a title — the round still plays, it just may not be the exact recording the playlist author intended. For pinpoint accuracy on those tracks, pick a URI-based service (Spotify/Apple Music/etc.) via Music Assistant instead.
 
 ### Why Some Speakers Don't Work Directly
 
@@ -518,9 +554,9 @@ That's it. No mDNS, no broadcast, no additional ports.
 ## Technical Details
 
 ### Requirements
-- **Home Assistant** 2024.1+
+- **Home Assistant** 2025.1+ (matches the `homeassistant` floor declared in `hacs.json`)
 - **Supported media player** (see [Supported Speakers](#supported-speakers) above)
-- **A music service** — Spotify, Apple Music, YouTube Music, Tidal or Deezer, each of which needs a **paid plan** (on-demand single-track playback; free/ad-supported tiers don't allow it — Spotify Free is blocked, and Music Assistant's YouTube Music provider [requires Premium too](https://www.music-assistant.io/music-providers/youtube-music/)).
+- **A music service** — Spotify, Apple Music, YouTube Music, Tidal, Deezer or Amazon Music, each of which needs a **paid plan** (on-demand single-track playback; free/ad-supported tiers don't allow it — Spotify Free is blocked, and Music Assistant's YouTube Music provider [requires Premium too](https://www.music-assistant.io/music-providers/youtube-music/)). Amazon Music playback is Alexa-only (text search — see [Supported Speakers](#supported-speakers)).
 - **HACS** (recommended) or manual installation
 
 ### How It Works
@@ -588,13 +624,13 @@ Game pauses automatically. Reconnect and continue exactly where you left off.
 <details>
 <summary><strong>What music services work?</strong></summary>
 <br>
-Spotify, Apple Music, YouTube Music, Tidal, and Deezer. Support depends on your speaker platform—see the <a href="#supported-speakers">Supported Speakers</a> table for details.
+Spotify, Apple Music, YouTube Music, Tidal, Deezer, and Amazon Music. Support depends on your speaker platform—see the <a href="#supported-speakers">Supported Speakers</a> table for details. Amazon Music is available on Alexa speakers only and plays via voice/text search rather than fixed track URIs.
 </details>
 
 <details>
 <summary><strong>Do I need a paid music subscription? Does Beatify work with free Spotify?</strong></summary>
 <br>
-Yes. Beatify plays a specific song on demand each round, and on every provider—Spotify, Apple Music, YouTube Music, Tidal and Deezer—that requires a <strong>paid</strong> plan. <strong>Spotify Free does not work</strong> (its free tier blocks on-demand single-track playback via Music Assistant / Spotify Connect), and <strong>a free YouTube Music account does not work either</strong>—playback runs through Music Assistant, whose <a href="https://www.music-assistant.io/music-providers/youtube-music/">YouTube Music provider</a> supports Premium accounts only. This is a streaming-service limitation, not a Beatify one. The curated playlists carry URIs for all five services.
+Yes. Beatify plays a specific song on demand each round, and on every provider—Spotify, Apple Music, YouTube Music, Tidal, Deezer and Amazon Music—that requires a <strong>paid</strong> plan. <strong>Spotify Free does not work</strong> (its free tier blocks on-demand single-track playback via Music Assistant / Spotify Connect), and <strong>a free YouTube Music account does not work either</strong>—playback runs through Music Assistant, whose <a href="https://www.music-assistant.io/music-providers/youtube-music/">YouTube Music provider</a> supports Premium accounts only. This is a streaming-service limitation, not a Beatify one. The curated playlists carry URIs for the five URI-based services; Amazon Music (Alexa-only) plays those same tracks by text search (<code>artist</code> + <code>title</code>) rather than a fixed URI.
 </details>
 
 <details>
@@ -620,6 +656,32 @@ The neon dark theme is built-in and looks stunning. Custom theming is on the roa
 <br>
 
 ## What's New
+
+### v4.1.3 — Content & Reliability ☀️
+- **Speaker volume is restored when the game ends (#1516)** — if the host bumps the volume mid-game, Beatify hands the speaker back at its original level, complementing the party-lights state restore
+- **Speaker selection now applies immediately (#1526)** — switching speakers in the wizard takes effect right away instead of routing through the previous pick until a Home Assistant restart
+- **Android Chrome no longer auto-translates the UI (#1527)** — the page language is rendered server-side so the initial HTML already matches the locale
+- **Two new German playlists** — Sommerklassiker ☀️ (60) and NDW – Neue Deutsche Welle (50)
+- 6 music platforms, 5 languages
+
+### v4.1.2 — Disney auf Deutsch 🏰
+- **New community playlist "Disney Hits Deutschland 🇩🇪" (97 songs)** — German-language Disney songs across the decades, year-mode ready with multi-provider URIs and the guess-the-film bonus across 40 films (#1505)
+- 6 music platforms, 5 languages
+
+### v4.1.1 — Around the World 🌍
+- **Two new community playlists** — 100% Brasil 🇧🇷 (66) and 100% Français 🇫🇷 (100), each year-mode ready with verified release years, ISRCs and multi-provider URIs
+- **Country packs renamed to the "100% <Country>" scheme** — matching the existing 100% en Español
+- Data fixes across EDM Anthems, Trance Classics, Harder Styles and Finnish Schlager Classics
+- 6 music platforms, 5 languages
+
+### v4.1.0 — Rock Solid, New Look (Now on Amazon Music) 🛒
+- **Amazon Music is the sixth music provider** — play through Alexa speakers via voice/text search (`artist` + `title`), no fixed track URI needed. Alexa-only; see [Supported Speakers](#supported-speakers) for the text-search caveat
+- **Reveal & dashboard redesigned — Spotlight Stage / Podium Stage** — the round reveal, round-delta standings ledger, TV broadcast lower-third and end-game podium were rebuilt into one cinematic broadcast language, with the guess-the-artist result and Game Highlights reel finally shown on the TV
+- **Party-night reliability pass** — screen-wake, TV auto-reconnect and a fixed admin login-loop keep long parties alive
+- **Storefront-aware Apple Music fix** — per-region Apple Music IDs resolve against your Home Assistant country so the right catalog track plays
+- **Security pass** across the import and request flows
+- **New community playlist "Finnish Schlager Classics 🇫🇮" (293 songs)** — deduplicated iskelmä from 1949–2026, year-mode ready
+- 6 music platforms, 5 languages
 
 ### v4.0.0 — Name That Tune 🎵
 - **A whole new game mode: Title & Artist** — instead of guessing the year, answer in free text: song title (**+10**) and artist (**+5**), each scored on its own. Small typos and near spellings earn partial credit, with forgiveness that scales to the title's length. Movie and Intro bonuses still stack. Built by @jgossen01, from an idea by @Hendrik0123 (#1180)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,240 @@
+# Beatify Architecture
+
+A self-hosted multiplayer music trivia game that runs as a Home Assistant integration. This document is the top-down map of the system. For the why-was-this-decision-made nuance, follow the inline issue references (#NNN) into the GitHub history — every non-trivial path was driven by a specific user-reported bug or feature request.
+
+> Last refreshed: 2026-07-05 against `main` at `b90f947` (the v4.2.0-rc9 line).
+
+---
+
+## 1. System overview
+
+```
+   Guests' phones                    Host's tablet/phone
+   (player.html)                     (admin.html)
+        │                                  │
+        │  WebSocket  /beatify/api/ws      │
+        └───────────────┬──────────────────┘
+                        │
+                ┌───────▼────────┐
+                │ Beatify back-  │   game/state.py (~916 LOC orchestrator) +
+                │ end (HA inte-  │   game/state_*.py (14 mixins)
+                │ gration)       │   server/ws_handlers/ (package, ~40 message types)
+                └───────┬────────┘   services/{media_player,tts,playlist}
+                        │
+                ┌───────▼────────┐
+                │ Music Assistant│   external HA add-on
+                │  (MA)          │   talks to Spotify / Apple Music / YT Music /
+                └───────┬────────┘   Tidal / Deezer
+                        │
+                ┌───────▼────────┐
+                │ Smart speakers │   Sonos / HomePod / Alexa / generic MA target
+                └────────────────┘
+
+   Alexa path (no MA): Amazon Music + Spotify + Apple Music play through the
+   Alexa Media Player integration by text search (artist + title), bypassing
+   Music Assistant entirely — see §4.
+
+   Out-of-band:                            ┌────────────────────────┐
+   "Request playlist" form ──────► CF Worker (beatify-api.mholzi    │
+                                   .workers.dev) ──► GitHub Issue   │
+                                   ───► manual enrichment ─────────►│
+                                   ──► `playlists/community/*.json`│
+                                   ──► next HACS release ──────────►│
+                                                                    └─
+```
+
+## 2. Repo layout
+
+```
+custom_components/beatify/
+├── __init__.py             # Home Assistant integration entry
+├── manifest.json           # version + dependencies + HA constraints (HA 2025.1+)
+├── config_flow.py          # First-run wizard config
+├── const.py                # Constants (6 provider IDs incl. amazon_music, defaults, timeouts)
+├── analytics.py            # Local error/event tracking (HA storage)
+├── sensor.py               # HA sensor entities (live game state)
+├── binary_sensor.py        # HA binary sensor entities
+├── device.py               # HA device registration
+├── game/
+│   ├── state.py            # Core game-state orchestrator (~916 LOC)
+│   ├── state_*.py          # 14 mixins the orchestrator composes (#1560 decomposition):
+│   │                       #   state_lifecycle / state_round_delegation / state_media /
+│   │                       #   state_scoring / state_reveal_transition / state_auto_advance /
+│   │                       #   state_challenge / state_vote_window (Crowd Court) /
+│   │                       #   state_player / state_leaderboard / state_pause /
+│   │                       #   state_setup / state_tts / state_serialization
+│   ├── round_manager.py    # Per-round lifecycle (intro → playing → reveal → next)
+│   ├── scoring.py          # Per-player scoring per round
+│   ├── text_match.py       # Title & Artist fuzzy/near-miss matching (#1180)
+│   ├── challenges.py       # Artist Challenge / Movie Quiz
+│   ├── powerups.py         # Steal power-up
+│   ├── playlist.py         # Playlist loading + filtering + provider URI resolution
+│   ├── player_registry.py  # Player roster + reconnect reclaim
+│   ├── highlights.py       # End-of-game highlights reel (#75)
+│   ├── share.py            # End-game share card
+│   ├── tts_phrases.py      # Localised TTS phrase templates
+│   └── serializers.py, types.py, protocols.py, config.py, service.py
+├── server/
+│   ├── __init__.py         # async_register_static_paths → /beatify/static/
+│   ├── views.py            # HTTP views registry
+│   ├── websocket.py        # WS endpoint plumbing
+│   ├── ws_handlers/        # WS message handlers, split into a package (#1588):
+│   │   ├── __init__.py     #   registration + dispatch (~40 message types)
+│   │   ├── _helpers.py     #   shared helpers
+│   │   ├── admin.py        #   admin/host actions
+│   │   ├── guessing.py     #   submit_guess / vote / challenge answers
+│   │   └── lifecycle.py    #   join / start / pause / resume / end
+│   ├── game_views.py       # start-game + game HTTP endpoints
+│   ├── playlist_views.py   # playlist + playlist-request endpoints, SavePlaylistView
+│   ├── mix_views.py        # Smart Playlist Mixer endpoint (#1538) — see §6
+│   ├── companion_auth.py   # HA Companion app login handoff (#1527 era)
+│   ├── stats_views.py      # analytics dashboard data
+│   ├── setup_state.py      # persisted wizard/setup state
+│   ├── serializers.py, base.py
+├── playlists/              # 49 bundled playlists, 5,381 songs
+│   ├── *.json              # 17 default packs (era / greatest-hits / movie)
+│   ├── community/          # 30 community packs (genre / region), separate browse tab
+│   ├── user/               # host-saved mixes land here as <slug>.json (Community tab)
+│   └── mix/                # transient Mixer output (internal, auto-cleaned)
+├── translations/           # HA-internal (config flow, services)
+└── www/                    # Frontend assets
+    ├── admin.html          # Host UI (the "control panel")
+    ├── player.html         # Guest UI (lobby + gameplay + reveal)
+    ├── dashboard.html      # TV / big-screen spectator view
+    ├── sw.js               # PWA service worker (CACHE_VERSION pattern)
+    ├── i18n/               # 5 locales: en/de/es/fr/nl
+    ├── js/
+    │   ├── admin/          # admin UI modules (constants.js holds TAG_CATEGORIES)
+    │   ├── admin.js        # admin entry + WS hub
+    │   ├── player-*.js     # player core / lobby / game / reveal / end / tour
+    │   ├── dashboard.js    # TV renderers (Spotlight/Podium/Broadcast lower-third)
+    │   ├── playlist-hub.js # 3-tab playlist browser
+    │   ├── playlist-generator.js  # Mix tab UI
+    │   ├── title-artist-bonuses.js, party-lights.js, tts-settings.js, i18n.js, ...
+    └── css/
+        └── styles.min.css
+
+tests/                      # 58 pytest files (unit + integration)
+custom_components/beatify/www/js/__tests__/
+└── *.test.js               # 45 Vitest JS unit tests
+
+scripts/
+├── playlist_schema.json    # authoritative playlist JSON schema (CI-validated)
+├── validate_playlists.py   # schema gate
+└── fix_broken_tracks.py    # periodic URI-health automation
+```
+
+## 3. Game state machine
+
+`game/state.py` is a thin orchestrator (~916 LOC, down from the 2075-LOC monolith) that composes **14 `state_*.py` mixins** (#1560). Each mixin owns one concern; the orchestrator wires them together and holds the shared game object.
+
+**Core subsystems (now mixin-owned):**
+1. **Lifecycle / phase** (`state_lifecycle`) — IDLE / LOBBY / PLAYING / REVEAL / PAUSED, gated transitions.
+2. **Round flow** (`state_round_delegation`, `state_reveal_transition`, `state_auto_advance`) — initialize → confirm intro → play → end (timer or all-submitted) → reveal → next.
+3. **Media** (`state_media`) — playback orchestration against `MediaPlayerService`.
+4. **Scoring** (`state_scoring`, `state_leaderboard`) — per-player per-round, isolated try/except so one player's exception can't freeze the round (#816); closest-wins support.
+5. **Challenges & Crowd Court** (`state_challenge`, `state_vote_window`) — Artist Challenge, Movie Quiz, and the Title & Artist close-call vote window (#1180/#1243).
+6. **Roster** (`state_player`) — admin (host) + 0..N guests, reclaim-by-name on reconnect (#790).
+7. **Pause/resume** (`state_pause`), **setup** (`state_setup`), **TTS** (`state_tts`), **serialization** (`state_serialization`).
+
+**Round-flow defensive coding:** every `asyncio.create_task` in the round flow carries an `add_done_callback` that surfaces unretrieved exceptions with a stack trace (fixed the #816 class of silent freezes).
+
+## 4. Provider URI dispatch (the #768 / #805 / #808 story, plus Amazon Music)
+
+`services/media_player.py` holds the provider dispatch that took three issues to settle:
+
+```python
+_PROVIDER_URI_FIELDS: dict[str, tuple[str, ...]] = {
+    "spotify":       ("uri_spotify", "uri"),
+    "apple_music":   ("uri_apple_music",),
+    "youtube_music": ("uri_youtube_music",),
+    "tidal":         ("uri_tidal",),
+    "deezer":        ("uri_deezer",),
+    "amazon_music":  (),   # no URI — plays via Alexa text search
+}
+```
+
+`_get_ma_uri_candidates(song)` walks ONLY the user-selected provider's fields. The original design (#768) walked all six providers in order and fell through on failure — wrong on Apple-Music-only setups, where each round paid 4×15s of timeouts before reaching the working URI, then force-paused after 3 failures. #805 narrowed the cascade (@Levtos's stress-testing surfaced it).
+
+**#808 storefront dimension:** Apple Music URIs are per-country. A US-storefront ID isn't in the DE catalog, so MA accepts the URI but can't resolve a stream. Fix: a per-region URI map (`uri_apple_music_by_region`), a runtime resolver keyed on `hass.config.country`, and region-locked songs filtered at playlist load.
+
+**#777 strict-detection invariant:** if `media_title` doesn't change after `play_media`, the track never started — fail and try the next URI.
+
+**Amazon Music (v4.1.0):** the sixth provider is **Alexa-only and URI-less** — it maps to `()` above. Playback goes through `_play_via_alexa(song)` with `content_type="AMAZON_MUSIC"`, asking Alexa to search by `artist` + `title` (`_get_alexa_search_text`). Speaker capability tables mark `amazon_music: True` only for the `alexa_media` platform (`method: "text_search"`); Music Assistant and Sonos map it to `False`. Trade-off: no exact-recording guarantee — Alexa may pick a live/remaster/cover when titles collide.
+
+## 5. WebSocket protocol
+
+`server/ws_handlers/` (a **package** since #1588 — previously a single 1300-LOC file) registers ~40 message types across `admin.py`, `guessing.py`, `lifecycle.py`, with `__init__.py` handling registration/dispatch and `_helpers.py` shared logic. Categories:
+
+- **Auth** — `admin_join`, `player_join`, `reconnect` (name-based admin reclaim)
+- **Game lifecycle** — `start_game`, `end_game`, `pause_game`, `resume_game`
+- **Round** — `next_round`, `submit_guess`, `confirm_intro`
+- **Challenges / vote** — artist/movie answers, Crowd Court 👍/👎 votes
+- **State sync** — `state_update` (full serialised state broadcast), `phase_change`
+- **Player management** — `kick_player`, `rename_player`
+- **Playlist requests** — `submit_request`, `poll_requests`
+
+Failure modes: WS dropped during reveal → `reconnect` with same name restores admin role regardless of phase (#790). HA restart → the client retries with a 20s budget (#814) and shows an inline "Connecting…" state.
+
+## 6. Smart Playlist Mixer (#1538)
+
+`server/mix_views.py` powers the **Mix** tab. The host picks tags across four categories — `decade` / `style` / `region` / `special` (the same `TAG_CATEGORIES` that drive the filter bar, `www/js/admin/constants.js`) — and a target size (**30 / 50 / 100**). The view unions all songs from tag-matching playlists, de-duplicates, caps to the target, and returns a path.
+
+- **Transient by default:** the assembled set is written to `playlists/mix/__mix__-<uuid>.json` (unique stem per run, #1547) and treated as `bundled` by discovery, so it never pollutes the Community tab. Stale transient files are best-effort cleaned on each write.
+- **No new game-start path:** the mix path feeds the *existing* `/beatify/api/start-game` flow, reusing all validated provider/platform/dedup logic.
+- **Save as community:** ticking "save as community playlist" persists the set to `playlists/user/<slug>.json` (same place as `SavePlaylistView`), so `async_discover_playlists` surfaces it in the Community tab on refresh.
+
+## 7. Playlist format & validation
+
+Playlists are JSON in `custom_components/beatify/playlists/` (and user `config/beatify/playlists/`), validated in CI by `scripts/validate_playlists.py` against `scripts/playlist_schema.json`.
+
+- **Playlist-level required:** `name`, `version`, `tags`, `songs`.
+- **Per-song required:** `artist`, `title` (both mandatory — #697; songs missing either are **silently skipped at load**), `year`, `uri` (a `spotify:track:` URI or `null`), and the fun-fact set (`fun_fact` + `fun_fact_de/es/fr/nl`).
+- **Optional:** additional provider URIs (`uri_apple_music`, `uri_youtube_music`, `uri_tidal`, `uri_deezer`, `uri_apple_music_by_region`), `alt_artists`, `isrc`, `chart_info`, `certifications`, `awards` (+ localized), and movie-quiz fields (`movie`, `movie_choices`, playlist-level `movie_quiz_enabled`).
+
+## 8. Playlist request flow
+
+End-to-end from the host's "+ Add custom playlist" tap: `playlist-requests.js` POSTs the Spotify URL to a Cloudflare Worker (`beatify-api.mholzi.workers.dev`, Dashboard-deployed, not in this repo), which decrypts the URL, calls the Spotify Web API, and opens a labelled GitHub issue. A maintainer enriches the tracks (years, alt-artists, fun facts, multi-provider URIs) into `playlists/community/<slug>.json`, and the pack ships in the next HACS release. The Worker's structured `error.code` is surfaced in the UI (#835) so failures are legible instead of opaque.
+
+## 9. Frontend asset serving + cache-busting (#824)
+
+`server/__init__.py` registers `/beatify/static/` → `<integration>/www/`. Every HTML page declares `<meta name="beatify-version">`; `i18n.js` reads it and appends `?v=X.Y.Z` to JSON fetches. Each release bumps that meta tag in admin/player/dashboard alongside `manifest.json` and `sw.js` `CACHE_VERSION`. Without it, a service-worker-cached `en.json` from an older rc would mismatch the new bundle and leak raw i18n keys on screen. `make build` runs esbuild to regenerate the `.min.js` bundles.
+
+## 10. TTS announcements
+
+`services/tts.py` calls `tts.speak` with both `entity_id` AND `media_player_entity_id` (pre-#793 only the former was passed, which silently failed on modern engines). Per-game-event toggles live in `tts-settings.js` with Minimal / Standard / Full verbosity presets; each event maps to a localised phrase (`game/tts_phrases.py`) in the active language.
+
+## 11. Test strategy
+
+- **`tests/`** — 58 pytest files (unit + integration): state mixins, scoring, playlist filtering, provider URI dispatch, WS handlers end-to-end via mocked HA.
+- **`www/js/__tests__/`** — 45 Vitest JS unit tests (player tour, wizard, game logic).
+- **Burn-in CI** — flaky-test detection reruns the suite weekly.
+- **HACS validation** — `validate.yml` runs `hacs/action` + `hassfest` on every push; the playlist schema gate runs `validate_playlists.py`.
+
+## 12. Build + ship
+
+```bash
+# Local dev
+PATH=/opt/homebrew/bin:$PATH make build       # regenerates *.min.js bundles
+npm test                                       # Vitest JS suite
+python3 -m pytest -q                           # pytest suite
+
+# Release
+# 1. Bump manifest.json version + sw.js CACHE_VERSION + <meta beatify-version> ×3
+# 2. CHANGELOG.md entry under [<version>]
+# 3. make build (regenerate .min.js)
+# 4. git commit + push + tag
+# 5. gh release create --prerelease (rc) or stable
+```
+
+HACS subscribers see new versions automatically (pre-release subscribers see rcs separately from stable).
+
+## 13. Operational footprint
+
+- **Telemetry:** zero external. `analytics.py` records error events to local HA storage; the dashboard surfaces them. No HTTP calls leave the instance unless the host submits a playlist request.
+- **Persistence:** game history → `GameRecord` entries in HA storage; survives restarts; fuels the "most-played" / "recently played" shelves.
+- **State machine:** in-memory only. A HA restart mid-game ends the game (admin can rejoin; recovery banner offers Resume from PAUSED).
+
+## 14. Known dragons
+
+The wiki at `~/Development/Claude/beatifybot/wiki/` (private to the maintainer, BeatifyBot's knowledge base) holds the long-form synthesis on recurring URI-bug patterns, playback state-sync fragility (FE↔MA↔Speaker), and external feedback that pre-empted GitHub issues (Reddit + Discussions surfaced the provider-mismatch bugs months before #768/#808). If you hit a confusing failure mode, search closed issues by symptom — almost every weird playback case has a documented post-mortem.


### PR DESCRIPTION
Documentation-only sync of README + ARCHITECTURE against current `main`. Touches only `README.md` and (force-added, since `docs/` is gitignored) `docs/ARCHITECTURE.md`. No code, i18n, or CONTRIBUTING changes.

## What changed

- **#1728** — README HA badge + Requirements bumped `2024.1+ → 2025.1+` to match the `homeassistant` floor already declared in `hacs.json` (the runtime truth).
- **#1729** — Amazon Music (shipped v4.1.0) documented everywhere it was missing: intro/"Your Music" copy, wizard step 2, a new **Amazon Music** column in the Supported Speakers matrix (✅ Alexa only, ❌ MA/Sonos), Requirements, and both FAQ entries — plus the voice/text-search wrong-version caveat.
- **#1731** — "Creating Playlists" example rewritten to be schema-accurate: `artist`/`title` required (silently skipped otherwise, #697), multi-provider URIs, `alt_artists`, the fun-fact locale set, required-vs-optional breakdown, and a link to [`scripts/playlist_schema.json`](../scripts/playlist_schema.json).
- **#1732** — new **Mix Your Own** section: Mix tab, the decade/style/region/special tag taxonomy, target sizes (30/50/100), transient vs. saved, and that saved mixes land in `playlists/user/<slug>.json`.
- **#1733** — `docs/ARCHITECTURE.md` refreshed against `main`: `ws_handlers/` package split (#1588), the 14 `game/state_*.py` mixins (state.py 2075 → ~916 LOC), `mix_views.py`/`companion_auth.py`, Amazon Music dispatch, playlist count 24 → 49, Title & Artist / Crowd Court / Mixer sections, and a new Last-refreshed stamp (2026-07-05 @ b90f947).
- **#1735** — "What's New" entries for v4.1.0–4.1.3, added **Funk Carioca**, **Polski Rock** and **Polskie przeboje wszech czasów** to the playlist list, and corrected totals.

## Verified against the repo

Counts were computed from the actual `origin/main` tree, not the issue text:
- **49 playlists / 5,381 songs** (the issues' 47/5,181 predated the two Polish playlists merged since — #1673/#1677).
- Per-list count fixes: Greatest Hits of All Time 182 → 236, Top 100 Dutch Classics 100 → 104.
- Amazon Music = 6th provider confirmed in `const.py` (`PROVIDER_AMAZON_MUSIC`) and `services/media_player.py` (`alexa_media` → `amazon_music: True, method: "text_search"`).
- `hacs.json` already at `2025.1.0` — left unchanged (it is the runtime source of truth); README aligned to it.
- README embedded JSON + `hacs.json` validated with `json.load`.

Fixes #1728, #1729, #1731, #1732, #1733, #1735

🤖 Generated with [Claude Code](https://claude.com/claude-code)