### PR TITLE
perf: #1708/#1709/#1710 stats debounce + single registry walk + precompute playlist URIs

### DIFF
--- a/custom_components/beatify/__init__.py
+++ b/custom_components/beatify/__init__.py
@@ -356,6 +356,10 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             analytics = domain_data.get("analytics")
             if analytics is not None:
                 await analytics.async_shutdown()
+            # Flush any pending debounced per-round stats save before teardown (#1708)
+            stats = domain_data.get("stats")
+            if stats is not None:
+                await stats.async_shutdown()
 
         _LOGGER.info("Beatify integration unloaded")
     else:

--- a/custom_components/beatify/game/playlist.py
+++ b/custom_components/beatify/game/playlist.py
@@ -100,6 +100,12 @@ class PlaylistManager:
             if uri in seen_uris:
                 continue
             seen_uris.add(uri)
+            # #1710: provider + storefront are immutable for this manager, so a
+            # song's resolved URI never changes. Cache it on the song now so
+            # get_next_song/_pick_from_pool filter against a precomputed key each
+            # round instead of re-resolving get_song_uri() for the whole pool.
+            # Only ever set for pooled songs, and always the truthy `uri` above.
+            song["_precomputed_uri"] = uri
             source = song.get("_playlist_source", "__default__")
             buckets.setdefault(source, []).append(song)
 
@@ -135,14 +141,11 @@ class PlaylistManager:
         if not self._multi_playlist:
             return self._pick_from_pool(self._songs)
 
-        # Balanced: pick a random non-exhausted playlist, then a song
+        # Balanced: pick a random non-exhausted playlist, then a song.
+        # #1710: filter against the precomputed URI cached in __init__ instead
+        # of re-resolving get_song_uri() for every song every round.
         active_buckets = {
-            k: [
-                s
-                for s in v
-                if get_song_uri(s, self._provider, self._storefront)
-                not in self._played_uris
-            ]
+            k: [s for s in v if s["_precomputed_uri"] not in self._played_uris]
             for k, v in self._buckets.items()
         }
         active_buckets = {k: v for k, v in active_buckets.items() if v}
@@ -153,26 +156,19 @@ class PlaylistManager:
         chosen_key = random.choice(list(active_buckets.keys()))  # noqa: S311
         song = random.choice(active_buckets[chosen_key])  # noqa: S311
         song_copy = song.copy()
-        song_copy["_resolved_uri"] = get_song_uri(
-            song, self._provider, self._storefront
-        )
+        song_copy["_resolved_uri"] = song["_precomputed_uri"]
         return song_copy
 
     def _pick_from_pool(self, pool: list[dict[str, Any]]) -> dict[str, Any] | None:
         """Pick a random unplayed song from a flat pool."""
-        available = [
-            s
-            for s in pool
-            if get_song_uri(s, self._provider, self._storefront)
-            not in self._played_uris
-        ]
+        # #1710: pool songs carry a precomputed URI (set in __init__); use it
+        # instead of re-resolving get_song_uri() for the whole pool each round.
+        available = [s for s in pool if s["_precomputed_uri"] not in self._played_uris]
         if not available:
             return None
         song = random.choice(available)  # noqa: S311
         song_copy = song.copy()
-        song_copy["_resolved_uri"] = get_song_uri(
-            song, self._provider, self._storefront
-        )
+        song_copy["_resolved_uri"] = song["_precomputed_uri"]
         return song_copy
 
     def mark_played(self, uri: str) -> None:

--- a/custom_components/beatify/services/media_player.py
+++ b/custom_components/beatify/services/media_player.py
@@ -1539,44 +1539,63 @@ class MediaPlayerService:
             return False, msg
 
 
-async def async_get_media_players(hass: HomeAssistant) -> list[dict[str, Any]]:
+def _collect_ma_twin_maps(
+    ent_reg: Any,
+) -> tuple[dict[str, str], dict[str, str]]:
+    """Walk the entity registry ONCE and derive both Music Assistant twin maps.
+
+    #1709: ``async_get_media_players`` and ``async_get_native_twin_remap`` used
+    to iterate ``ent_reg.entities`` 3-4 times per status request to rebuild
+    essentially the same data. This single pass builds them both:
+
+    - ``ma_by_unique_id``: ``{unique_id: ma_entity_id}`` for every
+      music_assistant-owned media_player (its keys are the MA unique-id set used
+      to hide native twins from the picker, #1627/#1628).
+    - ``native_twin_remap``: ``{native_entity_id: ma_entity_id}`` for every
+      native-platform media_player that shares a unique_id with an MA twin
+      (#1627 follow-up — heals stale saved selections).
+
+    A native entity can appear before its MA twin in the registry, so natives
+    are collected in the same pass and resolved against the completed MA map
+    afterwards (no second full registry walk).
     """
-    Get all available media player entities with platform and capability info.
+    ma_by_unique_id: dict[str, str] = {}
+    native_media_players: list[tuple[str, str]] = []  # (entity_id, unique_id)
+    for entry in ent_reg.entities.values():
+        if entry.domain != "media_player" or not entry.unique_id:
+            continue
+        if entry.platform == "music_assistant":
+            ma_by_unique_id[entry.unique_id] = entry.entity_id
+        else:
+            native_media_players.append((entry.entity_id, entry.unique_id))
 
-    Filters out unsupported platforms (raw Cast devices without Music Assistant).
+    native_twin_remap = {
+        entity_id: ma_by_unique_id[unique_id]
+        for entity_id, unique_id in native_media_players
+        if unique_id in ma_by_unique_id
+    }
+    return ma_by_unique_id, native_twin_remap
 
-    Returns:
-        List of media player dicts with entity_id, friendly_name, state,
-        platform, supports_spotify, supports_apple_music, playback_method,
-        warning, caveat fields.
 
+def _build_media_player_list(
+    hass: HomeAssistant, ma_by_unique_id: dict[str, str]
+) -> list[dict[str, Any]]:
+    """Build the compatible-player list from live states + precomputed twin map.
+
+    Factored out of :func:`async_get_media_players` (#1709) so the player list
+    and the native-twin remap can be produced from a single registry walk (see
+    :func:`async_get_media_players_with_remap`). ``ma_by_unique_id`` keys are the
+    MA unique-id set used to drop native twins (#1627/#1628).
     """
-    # Late import: homeassistant.helpers.entity_registry is not available in
-    # the test environment without a full HA setup, so we import it here to
-    # avoid ImportError during unit tests.  (noqa: PLC0415)
+    # Late import mirrors the callers: entity_registry isn't importable in the
+    # unit-test env without a full HA setup. (noqa: PLC0415)
     from homeassistant.helpers import entity_registry as er  # noqa: PLC0415
 
-    # Get entity registry to check which platform created each entity
     ent_reg = er.async_get(hass)
-
-    # #1627: A speaker exposed through Music Assistant appears in the registry
-    # twice with the SAME unique_id — once on its native platform (e.g. sonos)
-    # and once on music_assistant. Both are the same physical speaker, but only
-    # the MA twin can stream Beatify's provider URIs (spotify:track:… etc.); the
-    # native twin throws "UPnP Error 800" and the game pauses with
-    # media_player_error. Collect the unique_ids owned by an MA media_player so
-    # we can drop the native twins below (even when the native platform — sonos
-    # — is itself "supported").
-    ma_unique_ids = {
-        entry.unique_id
-        for entry in ent_reg.entities.values()
-        if entry.domain == "media_player"
-        and entry.platform == "music_assistant"
-        and entry.unique_id
-    }
 
     media_players = []
     for state in hass.states.async_all("media_player"):
+        # async_get is an O(1) dict lookup, not a registry walk.
         entity_entry = ent_reg.async_get(state.entity_id)
         platform = entity_entry.platform if entity_entry else "unknown"
 
@@ -1601,7 +1620,7 @@ async def async_get_media_players(hass: HomeAssistant) -> list[dict[str, Any]]:
         if (
             platform != "music_assistant"
             and entity_entry is not None
-            and entity_entry.unique_id in ma_unique_ids
+            and entity_entry.unique_id in ma_by_unique_id
         ):
             _LOGGER.debug(
                 "Skipping native twin of MA player: %s (platform=%s, unique_id=%s)",
@@ -1632,6 +1651,57 @@ async def async_get_media_players(hass: HomeAssistant) -> list[dict[str, Any]]:
     return media_players
 
 
+async def async_get_media_players(hass: HomeAssistant) -> list[dict[str, Any]]:
+    """
+    Get all available media player entities with platform and capability info.
+
+    Filters out unsupported platforms (raw Cast devices without Music Assistant).
+
+    Returns:
+        List of media player dicts with entity_id, friendly_name, state,
+        platform, supports_spotify, supports_apple_music, playback_method,
+        warning, caveat fields.
+
+    """
+    # Late import: homeassistant.helpers.entity_registry is not available in
+    # the test environment without a full HA setup, so we import it here to
+    # avoid ImportError during unit tests.  (noqa: PLC0415)
+    from homeassistant.helpers import entity_registry as er  # noqa: PLC0415
+
+    # Get entity registry to check which platform created each entity
+    ent_reg = er.async_get(hass)
+
+    # #1627: A speaker exposed through Music Assistant appears in the registry
+    # twice with the SAME unique_id — once on its native platform (e.g. sonos)
+    # and once on music_assistant. Both are the same physical speaker, but only
+    # the MA twin can stream Beatify's provider URIs (spotify:track:… etc.); the
+    # native twin throws "UPnP Error 800" and the game pauses with
+    # media_player_error. Collect the unique_ids owned by an MA media_player so
+    # we can drop the native twins below (even when the native platform — sonos
+    # — is itself "supported"). Single registry walk (#1709).
+    ma_by_unique_id, _ = _collect_ma_twin_maps(ent_reg)
+    return _build_media_player_list(hass, ma_by_unique_id)
+
+
+async def async_get_media_players_with_remap(
+    hass: HomeAssistant,
+) -> tuple[list[dict[str, Any]], dict[str, str]]:
+    """Return the player list AND the native→MA twin remap from ONE walk (#1709).
+
+    Callers that need both (e.g. the status path) should prefer this over
+    calling :func:`async_get_media_players` and
+    :func:`async_get_native_twin_remap` back to back, which repeats the entity
+    registry walk. Behaviour of the two returned values is identical to calling
+    those functions individually.
+    """
+    from homeassistant.helpers import entity_registry as er  # noqa: PLC0415
+
+    ent_reg = er.async_get(hass)
+    ma_by_unique_id, native_twin_remap = _collect_ma_twin_maps(ent_reg)
+    players = _build_media_player_list(hass, ma_by_unique_id)
+    return players, native_twin_remap
+
+
 async def async_get_native_twin_remap(hass: HomeAssistant) -> dict[str, str]:
     """Map each native-platform media_player entity_id to the Music Assistant
     entity_id for the same physical speaker (same unique_id). #1627 follow-up.
@@ -1656,23 +1726,6 @@ async def async_get_native_twin_remap(hass: HomeAssistant) -> dict[str, str]:
 
     ent_reg = er.async_get(hass)
 
-    # unique_id → MA media_player entity_id for every MA-owned media_player.
-    ma_by_unique_id = {
-        entry.unique_id: entry.entity_id
-        for entry in ent_reg.entities.values()
-        if entry.domain == "media_player"
-        and entry.platform == "music_assistant"
-        and entry.unique_id
-    }
-
-    remap: dict[str, str] = {}
-    for entry in ent_reg.entities.values():
-        if (
-            entry.domain == "media_player"
-            and entry.platform != "music_assistant"
-            and entry.unique_id
-            and entry.unique_id in ma_by_unique_id
-        ):
-            remap[entry.entity_id] = ma_by_unique_id[entry.unique_id]
-
+    # Single registry walk (#1709): previously two full passes (MA map + remap).
+    _, remap = _collect_ma_twin_maps(ent_reg)
     return remap

--- a/custom_components/beatify/services/stats.py
+++ b/custom_components/beatify/services/stats.py
@@ -26,6 +26,14 @@ _LOGGER = logging.getLogger(__name__)
 # running weighted sum, so dropping detailed entries does not skew it.
 MAX_DETAILED_GAMES = 500
 
+# Debounce window for per-round stat saves. record_song_result runs once per
+# round (~30s) and each call would otherwise rewrite the entire growing
+# stats.json via json.dumps (#1708). We coalesce rapid saves into a single
+# write scheduled STATS_SAVE_DEBOUNCE_SECONDS in the future; any save requested
+# before the timer fires resets it. Game end and unload flush explicitly so no
+# data is lost. Mirrors AnalyticsStorage's error-save debounce (#1388).
+STATS_SAVE_DEBOUNCE_SECONDS = 30.0
+
 
 class StatsService:
     """Service for tracking game statistics."""
@@ -46,10 +54,14 @@ class StatsService:
         self._all_time_avg_cache: float | None = None
         self._save_task: asyncio.Task | None = None
         self._save_lock = asyncio.Lock()
-        # Dirty flag: set on every schedule_save(); the save's done-callback
-        # re-schedules if it was set again while a save was in flight, so
-        # mutations made during a save are never silently dropped (#1402).
+        # Dirty flag: set on every _schedule_save_now(); the save's
+        # done-callback re-schedules if it was set again while a save was in
+        # flight, so mutations made during a save are never silently dropped
+        # (#1402).
         self._save_dirty = False
+        # Pending debounce timer for schedule_save() (#1708). None when no save
+        # is queued; a call_later handle otherwise.
+        self._save_handle: asyncio.TimerHandle | None = None
 
     def set_analytics(self, analytics: AnalyticsStorage) -> None:
         """
@@ -160,9 +172,31 @@ class StatsService:
 
     def schedule_save(self) -> None:
         """
-        Schedule non-blocking save.
+        Schedule a debounced non-blocking save (#1708).
 
-        Uses fire-and-forget pattern to avoid blocking game operations.
+        record_song_result runs once per round (~30s). Writing the whole
+        (growing) stats.json on every round hammers the disk and runs
+        json.dumps of the full store in the event loop. Instead we coalesce:
+        the save is deferred STATS_SAVE_DEBOUNCE_SECONDS into the future and any
+        call arriving before the timer fires resets it, so a burst of rounds
+        results in a single write. Game end (record_game) and unload
+        (async_shutdown) flush explicitly so nothing is lost.
+        """
+        if self._save_handle is not None:
+            self._save_handle.cancel()
+
+        def _fire() -> None:
+            self._save_handle = None
+            self._schedule_save_now()
+
+        self._save_handle = self._hass.loop.call_later(
+            STATS_SAVE_DEBOUNCE_SECONDS, _fire
+        )
+
+    def _schedule_save_now(self) -> None:
+        """
+        Kick off an immediate non-blocking save (fire-and-forget).
+
         Coalesces rapid calls: if a save is already in flight, the call sets a
         dirty flag and the in-flight save's done-callback re-schedules a fresh
         save. Without this, the save task snapshots ``self._stats`` at the
@@ -177,14 +211,33 @@ class StatsService:
         self._save_task = asyncio.create_task(self.save())
         self._save_task.add_done_callback(self._handle_save_done)
 
+    async def async_flush(self) -> None:
+        """
+        Cancel any pending debounced save and persist immediately (#1708).
+
+        Used on game end and unload so the last coalesced batch of per-round
+        updates is written even though its debounce timer hasn't fired yet.
+        Idempotent: a no-op beyond a harmless extra write if nothing is dirty.
+        """
+        if self._save_handle is not None:
+            self._save_handle.cancel()
+            self._save_handle = None
+        await self.save()
+
+    async def async_shutdown(self) -> None:
+        """Flush pending stats on unload so debounced rounds aren't lost."""
+        await self.async_flush()
+
     def _handle_save_done(self, task: asyncio.Task) -> None:
         """Log save-task errors and re-schedule if mutated mid-save (#1402)."""
         if (exc := task.exception()) is not None:
             _LOGGER.error("Unhandled error in stats save task: %s", exc)
-        # A schedule_save() arrived while this save was in flight — its
-        # mutations may not be on disk yet, so kick off another save.
+        # A _schedule_save_now() arrived while this save was in flight — its
+        # mutations may not be on disk yet, so kick off another immediate save.
+        # (Use the non-debounced path: the data is already committed to being
+        # written; don't restart a fresh debounce window, #1708.)
         if self._save_dirty:
-            self.schedule_save()
+            self._schedule_save_now()
 
     async def record_game(self, game_summary: dict, difficulty: str = "normal") -> dict:
         """
@@ -323,8 +376,10 @@ class StatsService:
         if len(games_list) > MAX_DETAILED_GAMES:
             del games_list[:-MAX_DETAILED_GAMES]
 
-        # Schedule deferred save (non-blocking)
-        self.schedule_save()
+        # Game end is a natural flush point: persist immediately (cancelling any
+        # pending per-round debounce) so a completed game is never lost to a
+        # crash/unload before the debounce timer fires (#1708).
+        await self.async_flush()
 
         _LOGGER.info(
             "Recorded game %s: %.2f avg pts/round, %d players, %d rounds",

--- a/tests/unit/test_media_player.py
+++ b/tests/unit/test_media_player.py
@@ -10,6 +10,7 @@ import pytest
 from custom_components.beatify.services.media_player import (
     MediaPlayerService,
     async_get_media_players,
+    async_get_media_players_with_remap,
     async_get_native_twin_remap,
     proxy_album_art,
 )
@@ -2377,3 +2378,45 @@ class TestNativeTwinRemap:
             remap = await async_get_native_twin_remap(hass)
 
         assert remap == {}
+
+
+class TestSingleWalkEquivalence:
+    """#1709: the single-walk combined path returns the SAME player list and
+    remap as calling async_get_media_players + async_get_native_twin_remap."""
+
+    @pytest.mark.asyncio
+    async def test_combined_matches_individual_functions(self):
+        entries = [
+            _make_registry_entry(
+                "media_player.esszimmer",
+                "music_assistant",
+                "RINCON_C43875ED053801400",
+            ),
+            _make_registry_entry(
+                "media_player.unnamed_room",
+                "sonos",
+                "RINCON_C43875ED053801400",
+            ),
+            _make_registry_entry(
+                "media_player.kitchen_sonos",
+                "sonos",
+                "RINCON_STANDALONE",
+            ),
+        ]
+        hass, registry = _make_discovery_hass(entries)
+
+        with patch(
+            "homeassistant.helpers.entity_registry.async_get",
+            return_value=registry,
+        ):
+            players_indiv = await async_get_media_players(hass)
+            remap_indiv = await async_get_native_twin_remap(hass)
+            players_combined, remap_combined = await async_get_media_players_with_remap(
+                hass
+            )
+
+        assert players_combined == players_indiv
+        assert remap_combined == remap_indiv
+        assert remap_combined == {"media_player.unnamed_room": "media_player.esszimmer"}
+        ids = {p["entity_id"] for p in players_combined}
+        assert ids == {"media_player.esszimmer", "media_player.kitchen_sonos"}

--- a/tests/unit/test_playlist.py
+++ b/tests/unit/test_playlist.py
@@ -354,3 +354,71 @@ class TestPlaylistManagerAmazonMusic:
         ]
         pm = PlaylistManager(songs, provider=PROVIDER_AMAZON_MUSIC)
         assert pm.get_total_count() == 1
+
+
+class TestPrecomputedUriEquivalence:
+    """#1710: the URI cached in __init__ equals the on-the-fly get_song_uri
+    result, and the full play-through behaviour is unchanged."""
+
+    def test_precomputed_uri_matches_on_the_fly_spotify(self):
+        songs = [
+            {"uri_spotify": "spotify:track:aaaaaaaaaaaaaaaaaaaaaa", "title": "A"},
+            {"uri": "spotify:track:bbbbbbbbbbbbbbbbbbbbbb", "title": "B"},
+        ]
+        pm = PlaylistManager(songs, provider=PROVIDER_SPOTIFY)
+        for song in pm._songs:
+            assert song["_precomputed_uri"] == get_song_uri(
+                song, PROVIDER_SPOTIFY, None
+            )
+
+    def test_precomputed_uri_matches_on_the_fly_apple_storefront(self):
+        songs = [
+            {
+                "uri_apple_music": "applemusic://track/legacy",
+                "uri_apple_music_by_region": {"gb": "applemusic://track/gbid"},
+                "title": "A",
+            },
+        ]
+        pm = PlaylistManager(songs, provider=PROVIDER_APPLE_MUSIC, storefront="gb")
+        song = pm._songs[0]
+        assert (
+            song["_precomputed_uri"]
+            == get_song_uri(song, PROVIDER_APPLE_MUSIC, "gb")
+            == "applemusic://track/gbid"
+        )
+
+    def test_resolved_uri_equals_precomputed(self):
+        songs = [
+            {"uri_spotify": "spotify:track:aaaaaaaaaaaaaaaaaaaaaa", "title": "A"},
+        ]
+        pm = PlaylistManager(songs, provider=PROVIDER_SPOTIFY)
+        picked = pm.get_next_song()
+        assert picked is not None
+        assert picked["_resolved_uri"] == "spotify:track:aaaaaaaaaaaaaaaaaaaaaa"
+
+    def test_multi_playlist_play_through_unchanged(self):
+        songs = [
+            {
+                "uri_spotify": "spotify:track:aaaaaaaaaaaaaaaaaaaaaa",
+                "title": "A",
+                "_playlist_source": "p1",
+            },
+            {
+                "uri_spotify": "spotify:track:bbbbbbbbbbbbbbbbbbbbbb",
+                "title": "B",
+                "_playlist_source": "p2",
+            },
+        ]
+        pm = PlaylistManager(songs, provider=PROVIDER_SPOTIFY)
+        assert pm._multi_playlist is True
+        played: list[str] = []
+        for _ in range(2):
+            song = pm.get_next_song()
+            assert song is not None
+            played.append(song["_resolved_uri"])
+            pm.mark_played(song["_resolved_uri"])
+        assert set(played) == {
+            "spotify:track:aaaaaaaaaaaaaaaaaaaaaa",
+            "spotify:track:bbbbbbbbbbbbbbbbbbbbbb",
+        }
+        assert pm.get_next_song() is None

--- a/tests/unit/test_setup_reload_routes.py
+++ b/tests/unit/test_setup_reload_routes.py
@@ -128,6 +128,7 @@ def _patch_heavy_helpers(monkeypatch):
     # carry just the attributes async_setup_entry reads/wires.
     stats = MagicMock()
     stats.load = AsyncMock()
+    stats.async_shutdown = AsyncMock()  # #1708: flushed on unload
     stats.games_played = 0
     monkeypatch.setattr(beatify_init, "StatsService", MagicMock(return_value=stats))
 

--- a/tests/unit/test_stats.py
+++ b/tests/unit/test_stats.py
@@ -743,12 +743,14 @@ class TestScheduleSaveDirtyFlag:
         service._hass.async_add_executor_job = AsyncMock(side_effect=_gated_executor)
 
         service._stats["all_time"]["games_played"] = 1
-        service.schedule_save()  # starts save #1 (gated)
+        # #1708: schedule_save() is now debounced; _schedule_save_now() owns the
+        # immediate fire-and-forget + dirty-flag coalescing this test exercises.
+        service._schedule_save_now()  # starts save #1 (gated)
         await asyncio.sleep(0)  # let the task reach the gate
 
         # Mutate AFTER save #1 snapshotted, and re-schedule.
         service._stats["all_time"]["games_played"] = 2
-        service.schedule_save()  # in flight -> sets dirty flag
+        service._schedule_save_now()  # in flight -> sets dirty flag
         assert service._save_dirty is True
 
         release.set()  # let save #1 finish -> done-callback re-schedules
@@ -761,6 +763,86 @@ class TestScheduleSaveDirtyFlag:
         data = _json.loads(stats_path.read_text())
         assert data["all_time"]["games_played"] == 2
         assert save_count >= 2
+
+
+class TestScheduleSaveDebounce:
+    """#1708: per-round saves are debounced into a single write; game end and
+    unload flush explicitly."""
+
+    @pytest.mark.asyncio
+    async def test_rapid_saves_coalesce_into_single_timer(self):
+        from custom_components.beatify.services.stats import (
+            STATS_SAVE_DEBOUNCE_SECONDS,
+        )
+
+        service = _make_service()
+        service._hass.loop = MagicMock()
+        handles = [MagicMock(name=f"h{i}") for i in range(3)]
+        service._hass.loop.call_later.side_effect = handles
+
+        with patch.object(service, "_schedule_save_now") as now:
+            service.schedule_save()
+            service.schedule_save()
+            service.schedule_save()
+
+            # Each call schedules a fresh timer and cancels the previous one, so
+            # only the most recent timer survives — a burst of rounds ends in a
+            # single pending write, not one per round.
+            assert service._hass.loop.call_later.call_count == 3
+            handles[0].cancel.assert_called_once()
+            handles[1].cancel.assert_called_once()
+            handles[2].cancel.assert_not_called()
+            assert service._save_handle is handles[2]
+            # No actual save has started yet — it is debounced.
+            now.assert_not_called()
+
+        # Firing the debounce callback kicks off exactly one immediate save.
+        delay, fire = service._hass.loop.call_later.call_args.args
+        assert delay == STATS_SAVE_DEBOUNCE_SECONDS
+        with patch.object(service, "_schedule_save_now") as now:
+            fire()
+            now.assert_called_once()
+        assert service._save_handle is None
+
+    @pytest.mark.asyncio
+    async def test_flush_cancels_pending_debounce_and_saves(self):
+        service = _make_service()
+        service._hass.loop = MagicMock()
+        handle = MagicMock()
+        service._hass.loop.call_later.return_value = handle
+
+        with patch.object(service, "save", new_callable=AsyncMock) as save:
+            service.schedule_save()
+            assert service._save_handle is handle
+            await service.async_flush()
+
+        handle.cancel.assert_called_once()
+        save.assert_awaited_once()
+        assert service._save_handle is None
+
+    @pytest.mark.asyncio
+    async def test_shutdown_flushes_pending(self):
+        service = _make_service()
+        service._hass.loop = MagicMock()
+
+        with patch.object(service, "save", new_callable=AsyncMock) as save:
+            service.schedule_save()
+            await service.async_shutdown()
+
+        save.assert_awaited_once()
+        assert service._save_handle is None
+
+    @pytest.mark.asyncio
+    async def test_record_game_flushes_immediately(self):
+        service = _make_service()
+        service._hass.loop = MagicMock()
+
+        with patch.object(service, "save", new_callable=AsyncMock) as save:
+            await service.record_game(_make_game_summary())
+
+        # Game end is a flush point: written now, not left on the debounce timer.
+        save.assert_awaited()
+        assert service._save_handle is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #1708, #1709, #1710

Three isolated backend performance fixes (no behaviour change; existing tests stay green, new tests added).

## #1708 — stats.json debounce (`services/stats.py`)
`record_song_result` fired once per round and rewrote the whole (growing) stats.json via json.dumps every time. `schedule_save()` is now debounced with `loop.call_later(30s)` (mirrors the analytics error-save debounce, #1388): a burst of rounds coalesces into a single write. The immediate fire-and-forget + dirty-flag coalescing moved to `_schedule_save_now`. Game end (`record_game`) and unload (`async_shutdown`, wired in `__init__.py` next to the existing analytics flush) flush explicitly, so no data is lost. Idempotent.

## #1709 — single entity-registry walk (`services/media_player.py`)
`async_get_media_players` + `async_get_native_twin_remap` did 3-4 full registry scans per status request. A shared `_collect_ma_twin_maps` now derives the MA unique-id map and the native→MA twin remap in ONE pass; `async_get_native_twin_remap` drops from 2 walks to 1. New `async_get_media_players_with_remap` returns both from a single walk for callers that need both (status path). Existing function signatures unchanged.

## #1710 — precompute playlist URIs (`game/playlist.py`)
`get_next_song`/`_pick_from_pool` re-resolved `get_song_uri()` for the whole pool every round (~5000 songs × 15-30 rounds). Provider/storefront are immutable per manager, so each song's URI is resolved once in `__init__` (`_precomputed_uri`) and filtered/returned against that cached key thereafter.

## Verification
- `pytest tests/` → 1295 passed, 2 skipped
- `ruff check .` + `ruff format --check .` clean
- gated `mypy` clean (16 files)

New tests: debounce coalescing + flush/shutdown/game-end, twin-remap single-walk equivalence, precomputed-URI == on-the-fly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)