### PR TITLE
fix(round): serialize round-advance (#1697/#1698/#1702/#1703) + broadcast serialize-once (#1711)

### DIFF
--- a/custom_components/beatify/game/state_auto_advance.py
+++ b/custom_components/beatify/game/state_auto_advance.py
@@ -156,6 +156,10 @@ class RevealAutoAdvanceMixin:
                 timer_seconds,
                 elapsed,
             )
+            # #1697: honors the round-start lock transitively — start_round()
+            # acquires _round_start_lock and no-ops (returns True) if a manual
+            # admin_next_round already advanced to PLAYING, so this auto-advance
+            # can't pull a second song / double-increment the round.
             success = await self.start_round()
             # #1360: when the playlist is exhausted, start_round() flips the
             # phase to END and returns False (a bare _set_phase(END), NOT the

--- a/custom_components/beatify/game/state_lifecycle.py
+++ b/custom_components/beatify/game/state_lifecycle.py
@@ -135,8 +135,35 @@ class RoundLifecycleMixin:
         _LOGGER.info("Game started: %d players", len(self.players))
         return True, None
 
+    def _get_round_start_lock(self) -> asyncio.Lock:
+        """Get (lazily creating) the #1697 round-start serialization lock.
+
+        The lock is not created in ``GameState.__init__`` (that file owns the
+        attribute set but the mixin must stay self-contained); it is built on
+        first use instead. Creation is a plain ``getattr``/``setattr`` pair with
+        no ``await`` in between, so two coroutines entering ``start_round`` in the
+        same event-loop tick still share a single lock instance.
+        """
+        lock = getattr(self, "_round_start_lock", None)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._round_start_lock = lock
+        return lock
+
     async def start_round(self, _retry_count: int = 0) -> bool:
         """Start a new round with song playback (#390).
+
+        #1697: serialized behind ``_round_start_lock`` so a manual
+        ``admin_next_round`` and the REVEAL ``_reveal_auto_advance`` (which both
+        call this method) can never drive a round-start concurrently. Before the
+        lock existed, the auto-advance parked in ``start_round``'s long awaits
+        while the phase was still REVEAL, and an admin tapping "Next" passed its
+        own REVEAL check and launched a second concurrent ``start_round`` — two
+        songs pulled/marked played, the round incremented twice, two
+        ``play_media`` calls, an orphaned timer cutting the round short. Holding
+        the lock also serializes the internal skip/retry recursion (it stays a
+        single logical round-start). After acquiring, a phase re-check makes the
+        losing caller a no-op if the winner already reached PLAYING.
 
         Args:
             _retry_count: Internal counter for failed song attempts (max 3)
@@ -144,6 +171,36 @@ class RoundLifecycleMixin:
         Returns:
             True if round started successfully, False otherwise
 
+        """
+        from .state import GamePhase  # noqa: PLC0415 — avoid circular import
+
+        # Snapshot the phase BEFORE we contend for the lock. The double-advance
+        # bug is specifically: this caller entered while the phase was still
+        # REVEAL (or LOBBY for round 1), parked waiting for the lock, and the
+        # race winner flipped it to PLAYING in the meantime. Bailing only when
+        # the phase changed to PLAYING *under us* keeps legitimate PLAYING-phase
+        # entries working (e.g. the Sudden-Death auto-end check runs inside
+        # start_round, and the #1358 ghost-round guard tests drive it directly).
+        entry_phase = self.phase
+        async with self._get_round_start_lock():
+            if (
+                _retry_count == 0
+                and entry_phase != GamePhase.PLAYING
+                and self.phase == GamePhase.PLAYING
+            ):
+                _LOGGER.info(
+                    "start_round: race winner already advanced to PLAYING while "
+                    "we held for the lock — skipping duplicate round-start (#1697)"
+                )
+                return True
+            return await self._start_round_locked(_retry_count)
+
+    async def _start_round_locked(self, _retry_count: int = 0) -> bool:
+        """Round-start orchestration body, run under ``_round_start_lock`` (#1697).
+
+        Carries the exact pre-#1697 ``start_round`` logic. The skip/retry paths
+        recurse into *this* method (not the public ``start_round``) so the
+        non-reentrant lock is acquired once per logical round-start.
         """
         from .state import GamePhase  # noqa: PLC0415 — avoid circular import
 
@@ -201,7 +258,7 @@ class RoundLifecycleMixin:
                 )
                 await self.pause_game("no_songs_available")
                 return False
-            return await self.start_round(_retry_count + 1)
+            return await self._start_round_locked(_retry_count + 1)
 
         self.last_round = self._playlist_manager.get_remaining_count() <= 1
         self._ensure_media_player_service()
@@ -263,7 +320,7 @@ class RoundLifecycleMixin:
                         song.get("title") or song.get("uri"),
                     )
                     await asyncio.sleep(0.2)
-                    return await self.start_round(_retry_count)
+                    return await self._start_round_locked(_retry_count)
 
                 # #949: a systemic playback failure — the speaker stayed idle,
                 # or the Music Assistant provider is unauthenticated — does not

--- a/custom_components/beatify/server/websocket.py
+++ b/custom_components/beatify/server/websocket.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import time
 from typing import TYPE_CHECKING
@@ -78,6 +79,12 @@ class BeatifyWebSocketHandler:
         self.connections: set[web.WebSocketResponse] = set()
         self._admin_disconnect_task: asyncio.Task | None = None
         self._analytics: AnalyticsStorage | None = None
+        # #1702: game_ids whose terminal end sequence (finalize_game +
+        # record_game + advance_to_end) has already been claimed. An admin has
+        # two admin-capable sockets (participant WS + spectator _admin_ws); on
+        # the final round both can pass the REVEAL/last_round checks. The claim
+        # (see _claim_game_end) makes the end run exactly once per game.
+        self._recorded_game_ids: set[str] = set()
         # Debouncing for concurrent player joins (Issue #41)
         self._broadcast_debounce_task: asyncio.Task | None = None
         self._broadcast_debounce_delay = 0.05  # 50ms
@@ -125,6 +132,22 @@ class BeatifyWebSocketHandler:
         """
         if self._analytics:
             self._analytics.record_error(error_type, message)
+
+    def _claim_game_end(self, game_id: str | None) -> bool:
+        """Claim the one-shot game-end for ``game_id`` (#1702).
+
+        Returns ``True`` exactly once per game — for the first admin socket to
+        reach the terminal branch — and ``False`` for any concurrent or repeat
+        caller, so ``record_game`` (double stats) and ``advance_to_end`` (double
+        podium TTS) run at most once per game. The check + insert has no
+        ``await`` between them, so two admin sockets in the same tick can't both
+        win. ``rematch_game`` / ``create_game`` mint a fresh ``game_id``, so a
+        later game is claimable again.
+        """
+        if game_id is None or game_id in self._recorded_game_ids:
+            return False
+        self._recorded_game_ids.add(game_id)
+        return True
 
     # ------------------------------------------------------------------
     # Rate limiting
@@ -313,11 +336,20 @@ class BeatifyWebSocketHandler:
 
         admin_ws = game_state._admin_ws if game_state else None
 
+        # #1711: there are at most two payload variants per broadcast (the
+        # admin/spectator copy and the redacted player copy). Serialize each to a
+        # JSON string ONCE here instead of letting aiohttp's ws.send_json run
+        # json.dumps per connection on the event loop. When no redaction applied
+        # (_redact_for_player returns the same object), both variants are one
+        # string, so we dump only once.
+        player_json = json.dumps(player_message)
+        admin_json = player_json if player_message is message else json.dumps(message)
+
         # Build list of send tasks for all open connections
         tasks = []
         for ws in list(targets):
             if not ws.closed:
-                payload = message if ws is admin_ws else player_message
+                payload = admin_json if ws is admin_ws else player_json
                 tasks.append(self._safe_send(ws, payload))
 
         # Execute all sends in parallel
@@ -352,17 +384,20 @@ class BeatifyWebSocketHandler:
                 return {**message, "song": song}
         return message
 
-    async def _safe_send(self, ws: web.WebSocketResponse, message: dict) -> None:
+    async def _safe_send(self, ws: web.WebSocketResponse, message: str) -> None:
         """
-        Send message to a single WebSocket, catching errors.
+        Send a pre-serialized JSON string to a single WebSocket, catching errors.
+
+        #1711: takes an already-``json.dumps``-ed string and uses ``send_str`` so
+        the same payload isn't re-serialized once per connection.
 
         Args:
             ws: WebSocket connection
-            message: Message to send
+            message: JSON string to send
 
         """
         try:
-            await ws.send_json(message)
+            await ws.send_str(message)
         except (ConnectionError, RuntimeError) as err:
             _LOGGER.warning("Failed to send to WebSocket: %s", err)
 
@@ -472,9 +507,21 @@ class BeatifyWebSocketHandler:
 
         # Admin disconnect: pause game after grace period (Story 7-1)
         if player.is_admin:
+            # #1703: snapshot the game identity so a grace timer that outlives
+            # the game (rematch / new game / dismiss) can't pause an unrelated
+            # later game.
+            armed_game_id = game_state.game_id
 
             async def pause_after_timeout() -> None:
                 await asyncio.sleep(LOBBY_DISCONNECT_GRACE_PERIOD)
+                # #1703: bail if the game changed identity while we waited.
+                if game_state.game_id != armed_game_id:
+                    _LOGGER.debug(
+                        "Admin-disconnect pause skipped — game changed (%s→%s)",
+                        armed_game_id,
+                        game_state.game_id,
+                    )
+                    return
                 # Check if admin still present and disconnected (#1664 PR-2:
                 # resolve by stable player_id, not by display name)
                 admin = game_state.get_player_by_session_id(player.player_id)
@@ -484,6 +531,13 @@ class BeatifyWebSocketHandler:
                         await self.broadcast_state()
                         _LOGGER.info("Game paused due to admin disconnect")
 
+            # #1703: cancel any still-pending disconnect-pause task before
+            # overwriting the handle. Without this, a superseded task keeps
+            # running and its grace timer can fire against a later game — e.g.
+            # after a rematch (which preserves player records with the admin
+            # marked disconnected), pausing the brand-new LOBBY.
+            if self._admin_disconnect_task and not self._admin_disconnect_task.done():
+                self._admin_disconnect_task.cancel()
             # Store task for cancellation on reconnect
             self._admin_disconnect_task = asyncio.create_task(pause_after_timeout())
         # Story 11.3: Regular players persist indefinitely - no removal timeout

--- a/custom_components/beatify/server/ws_handlers/admin.py
+++ b/custom_components/beatify/server/ws_handlers/admin.py
@@ -32,6 +32,31 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 
 
+async def _finalize_and_end(
+    handler: BeatifyWebSocketHandler, game_state: GameState
+) -> None:
+    """Record game stats + run the game-end ceremony exactly once (#1702).
+
+    The final-round terminal path is reachable from two admin-capable sockets
+    (participant WS + spectator ``_admin_ws``) at the same time. Gating on the
+    handler's one-shot claim keyed by ``game_id`` makes ``finalize_game`` /
+    ``record_game`` (double stats) and ``advance_to_end`` (double podium TTS)
+    fire at most once per game. The loser skips straight to the broadcast its
+    caller performs.
+    """
+    if not handler._claim_game_end(game_state.game_id):
+        _LOGGER.debug("Game-end already claimed for %s — skipping", game_state.game_id)
+        return
+
+    stats_service = handler.hass.data.get(DOMAIN, {}).get("stats")
+    if stats_service:
+        game_summary = game_state.finalize_game()
+        await stats_service.record_game(game_summary, difficulty=game_state.difficulty)
+        _LOGGER.debug("Game stats recorded")
+
+    await game_state.advance_to_end()
+
+
 async def handle_admin_connect(
     handler: BeatifyWebSocketHandler,
     ws: web.WebSocketResponse,
@@ -193,16 +218,17 @@ async def admin_next_round(
         # override + majority, rescore) before the round advances or the game
         # ends, so accepted near-misses count toward the leaderboard.
         await game_state.resolve_title_artist_if_pending()
+        # #1702: a second admin-capable socket (participant WS + spectator
+        # _admin_ws) may have advanced/ended the game while we awaited above.
+        # Re-check before driving the round forward; if it already left REVEAL,
+        # just re-broadcast the current state.
+        if game_state.phase != GamePhase.REVEAL:
+            await handler.broadcast_state()
+            return
         if game_state.last_round:
-            stats_service = handler.hass.data.get(DOMAIN, {}).get("stats")
-            if stats_service:
-                game_summary = game_state.finalize_game()
-                await stats_service.record_game(
-                    game_summary, difficulty=game_state.difficulty
-                )
-                _LOGGER.debug("Game stats recorded for natural end")
-
-            await game_state.advance_to_end()
+            # #1702: finalize + record + advance run exactly once per game even
+            # if both admin sockets reach here.
+            await _finalize_and_end(handler, game_state)
             await handler.broadcast_state()
         else:
             success = await game_state.start_round()
@@ -219,15 +245,7 @@ async def admin_next_round(
                 )
                 await handler.broadcast_state()
             else:
-                stats_service = handler.hass.data.get(DOMAIN, {}).get("stats")
-                if stats_service:
-                    game_summary = game_state.finalize_game()
-                    await stats_service.record_game(
-                        game_summary, difficulty=game_state.difficulty
-                    )
-                    _LOGGER.debug("Game stats recorded (no songs remaining)")
-
-                await game_state.advance_to_end()
+                await _finalize_and_end(handler, game_state)
                 await handler.broadcast_state()
     else:
         await ws.send_json(
@@ -335,13 +353,16 @@ async def admin_end_game(
 
     await game_state.stop_media()
 
-    stats_service = handler.hass.data.get(DOMAIN, {}).get("stats")
-    if stats_service:
-        game_summary = game_state.finalize_game()
-        await stats_service.record_game(game_summary, difficulty=game_state.difficulty)
-        _LOGGER.debug("Game stats recorded for early end")
+    # #1698: in title/artist mode, scoring for the current round is deferred
+    # until the vote window is finalized. admin_next_round resolves it first;
+    # admin_end_game must too, otherwise ending during REVEAL with the window
+    # open snapshots totals that miss the entire last round (wrong podium /
+    # winner). No-op outside title/artist mode or when nothing is pending.
+    await game_state.resolve_title_artist_if_pending()
 
-    await game_state.advance_to_end()
+    # #1702: record + end ceremony run once per game (shared claim with the
+    # next_round terminal path).
+    await _finalize_and_end(handler, game_state)
     _LOGGER.info(
         "Admin ended game early at round %d - players preserved for rematch",
         game_state.round,
@@ -428,6 +449,12 @@ async def admin_rematch_game(
             }
         )
         return
+
+    # #1703: cancel any pending admin-disconnect pause task before the rematch.
+    # rematch_game() preserves player records (admin may still be marked
+    # disconnected), so a leftover grace timer would otherwise fire and pause
+    # the brand-new LOBBY. cleanup_game_tasks previously ran only on dismiss.
+    await handler.cleanup_game_tasks()
 
     player_count = len(game_state.players)
     game_state.rematch_game()

--- a/tests/unit/test_redact_answers_1366.py
+++ b/tests/unit/test_redact_answers_1366.py
@@ -10,6 +10,7 @@ connection gets a redacted copy.
 
 from __future__ import annotations
 
+import json
 from unittest.mock import AsyncMock, MagicMock
 
 from custom_components.beatify.const import DOMAIN
@@ -111,8 +112,15 @@ class TestRedactStateForPlayer:
 def _make_ws() -> AsyncMock:
     ws = AsyncMock()
     ws.send_json = AsyncMock()
+    # #1711: broadcast now serializes once and sends via send_str(json_string).
+    ws.send_str = AsyncMock()
     ws.closed = False
     return ws
+
+
+def _sent_payload(ws: AsyncMock) -> dict:
+    """Decode the JSON string the broadcast sent to this WS (#1711)."""
+    return json.loads(ws.send_str.call_args[0][0])
 
 
 class TestBroadcastRedaction:
@@ -133,8 +141,8 @@ class TestBroadcastRedaction:
         msg = build_state_message(gs)
         await handler.broadcast(msg)
 
-        admin_payload = admin_ws.send_json.call_args[0][0]
-        player_payload = player_ws.send_json.call_args[0][0]
+        admin_payload = _sent_payload(admin_ws)
+        player_payload = _sent_payload(player_ws)
 
         # Spectator admin keeps the answers.
         assert admin_payload["admin_song"]["year"] == 1968
@@ -159,8 +167,8 @@ class TestBroadcastRedaction:
             {"artist": "The Beatles", "title": "Hey Jude", "album_art": "/art.png"}
         )
 
-        admin_payload = admin_ws.send_json.call_args[0][0]
-        player_payload = player_ws.send_json.call_args[0][0]
+        admin_payload = _sent_payload(admin_ws)
+        player_payload = _sent_payload(player_ws)
         assert admin_payload["song"]["artist"] == "The Beatles"
         assert player_payload["song"]["artist"] == REDACTED_PLACEHOLDER
         assert player_payload["song"]["title"] == REDACTED_PLACEHOLDER

--- a/tests/unit/test_round_advance_serialization.py
+++ b/tests/unit/test_round_advance_serialization.py
@@ -1,0 +1,214 @@
+"""Round-advance / connection serialization regression tests.
+
+Covers the concurrent round-advance + admin-connection bugs found via Fable
+multi-agent review (2026-07-05):
+
+* #1697 — ``start_round`` is serialized behind ``_round_start_lock`` so a manual
+  ``next_round`` and the REVEAL auto-advance cannot double-advance the round.
+* #1698 — ``admin_end_game`` resolves an open title/artist vote window before
+  finalizing, so the last round's scores aren't lost.
+* #1702 — two admin-capable sockets both driving ``next_round`` on the final
+  round record the game exactly once (idempotent per ``game_id``).
+* #1703 — a pending admin-disconnect pause task is cancelled before being
+  overwritten and on rematch, so it can't pause a fresh lobby.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.beatify.const import DOMAIN
+from custom_components.beatify.game.state import GamePhase
+from custom_components.beatify.server.ws_handlers import (
+    admin_end_game,
+    admin_next_round,
+    admin_rematch_game,
+)
+from tests.conftest import make_game_state
+from tests.unit.test_websocket import _make_handler_and_game, _make_ws
+
+
+# ---------------------------------------------------------------------------
+# #1697 — start_round serialized behind _round_start_lock
+# ---------------------------------------------------------------------------
+
+
+class TestRoundStartLock:
+    async def test_lock_prevents_double_start_round(self):
+        """Two concurrent start_round() calls from REVEAL run the real
+        orchestration once; the race loser no-ops (returns True) instead of
+        pulling a second song / double-incrementing the round."""
+        state = make_game_state()
+        state.phase = GamePhase.REVEAL
+
+        calls: list[int] = []
+
+        async def fake_locked(retry_count: int = 0) -> bool:
+            calls.append(retry_count)
+            # Hold the lock long enough for the second caller to contend.
+            await asyncio.sleep(0.02)
+            state.phase = GamePhase.PLAYING
+            return True
+
+        state._start_round_locked = fake_locked
+
+        results = await asyncio.gather(state.start_round(), state.start_round())
+
+        # Only ONE real round-start ran.
+        assert calls == [0]
+        # Both callers report success (the loser is a benign no-op).
+        assert results == [True, True]
+        assert state.phase == GamePhase.PLAYING
+
+    async def test_single_start_from_reveal_runs(self):
+        """Guard is inert for a lone caller: the real orchestration runs."""
+        state = make_game_state()
+        state.phase = GamePhase.REVEAL
+
+        calls: list[int] = []
+
+        async def fake_locked(retry_count: int = 0) -> bool:
+            calls.append(retry_count)
+            state.phase = GamePhase.PLAYING
+            return True
+
+        state._start_round_locked = fake_locked
+
+        assert await state.start_round() is True
+        assert calls == [0]
+
+
+# ---------------------------------------------------------------------------
+# #1698 — admin_end_game resolves an open title/artist vote window
+# ---------------------------------------------------------------------------
+
+
+class TestEndGameResolvesVoteWindow:
+    async def test_end_game_resolves_before_finalizing(self):
+        handler, game_state, ws = _make_handler_and_game()
+        game_state.phase = GamePhase.REVEAL
+
+        order: list[str] = []
+
+        async def _resolve() -> None:
+            order.append("resolve")
+
+        async def _advance() -> None:
+            order.append("advance")
+
+        game_state.stop_media = AsyncMock()
+        game_state.resolve_title_artist_if_pending = AsyncMock(side_effect=_resolve)
+        game_state.advance_to_end = AsyncMock(side_effect=_advance)
+        game_state.finalize_game = MagicMock(return_value={})
+        handler.broadcast_state = AsyncMock()
+
+        await admin_end_game(handler, ws, {"action": "end_game"}, game_state)
+
+        game_state.resolve_title_artist_if_pending.assert_awaited_once()
+        game_state.advance_to_end.assert_awaited_once()
+        # The vote window is resolved BEFORE the end ceremony snapshots totals.
+        assert order == ["resolve", "advance"]
+
+
+# ---------------------------------------------------------------------------
+# #1702 — concurrent last-round next_round records the game once
+# ---------------------------------------------------------------------------
+
+
+class TestConcurrentLastRoundRecordsOnce:
+    async def test_two_sockets_record_and_advance_once(self):
+        handler, game_state, ws1 = _make_handler_and_game()
+        ws2 = _make_ws()
+        game_state.phase = GamePhase.REVEAL
+        game_state.last_round = True
+        game_state.resolve_title_artist_if_pending = AsyncMock()
+        game_state.advance_to_end = AsyncMock()
+        game_state.finalize_game = MagicMock(return_value={})
+
+        record_game = AsyncMock()
+        stats = MagicMock()
+        stats.record_game = record_game
+        handler.hass.data[DOMAIN]["stats"] = stats
+        handler.broadcast_state = AsyncMock()
+
+        # Participant-admin WS and spectator-admin WS both fire next_round on
+        # the final round at the same time.
+        await asyncio.gather(
+            admin_next_round(handler, ws1, {"action": "next_round"}, game_state),
+            admin_next_round(handler, ws2, {"action": "next_round"}, game_state),
+        )
+
+        record_game.assert_awaited_once()
+        game_state.advance_to_end.assert_awaited_once()
+
+    async def test_repeat_call_after_end_does_not_re_record(self):
+        """Even sequentially, a second terminal call for the same game_id is a
+        no-op (idempotent per game_id)."""
+        handler, game_state, ws = _make_handler_and_game()
+        game_state.phase = GamePhase.REVEAL
+        game_state.last_round = True
+        game_state.resolve_title_artist_if_pending = AsyncMock()
+        game_state.advance_to_end = AsyncMock()
+        game_state.finalize_game = MagicMock(return_value={})
+
+        record_game = AsyncMock()
+        stats = MagicMock()
+        stats.record_game = record_game
+        handler.hass.data[DOMAIN]["stats"] = stats
+        handler.broadcast_state = AsyncMock()
+
+        await admin_next_round(handler, ws, {"action": "next_round"}, game_state)
+        # advance_to_end is mocked so phase stays REVEAL; a second tap must not
+        # re-record the already-claimed game.
+        await admin_next_round(handler, ws, {"action": "next_round"}, game_state)
+
+        record_game.assert_awaited_once()
+        game_state.advance_to_end.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# #1703 — pending admin-disconnect pause task cancelled on re-arm + rematch
+# ---------------------------------------------------------------------------
+
+
+class TestAdminDisconnectTaskCleanup:
+    async def test_disconnect_cancels_prior_pause_task(self):
+        handler, game_state, admin_ws = _make_handler_and_game()
+        game_state.add_player("Host", admin_ws)
+        game_state.set_admin("Host")
+        handler.broadcast_state = AsyncMock()
+
+        async def _never() -> None:
+            await asyncio.sleep(3600)
+
+        old_task = asyncio.create_task(_never())
+        handler._admin_disconnect_task = old_task
+
+        await handler._handle_disconnect(admin_ws)
+
+        # The superseded task is cancelled instead of leaking.
+        with pytest.raises(asyncio.CancelledError):
+            await old_task
+        # A fresh grace task was armed in its place.
+        assert handler._admin_disconnect_task is not None
+        assert handler._admin_disconnect_task is not old_task
+
+        # Cleanup: cancel the freshly-armed task so it doesn't dangle.
+        handler._admin_disconnect_task.cancel()
+
+    async def test_rematch_cleans_up_pending_tasks(self):
+        handler, game_state, ws = _make_handler_and_game()
+        game_state.phase = GamePhase.END
+        handler.cleanup_game_tasks = AsyncMock()
+        game_state.announce_rematch = AsyncMock()
+        handler.broadcast = AsyncMock()
+        handler.broadcast_state = AsyncMock()
+
+        await admin_rematch_game(handler, ws, {"action": "rematch_game"}, game_state)
+
+        # rematch must cancel any pending admin-disconnect pause task so the
+        # grace timer can't pause the brand-new lobby.
+        handler.cleanup_game_tasks.assert_awaited_once()


### PR DESCRIPTION
Backend-only fixes for the concurrent round-advance / connection bugs from the Fable multi-agent review (2026-07-05).

## What changed

- **#1697** `start_round` is serialized behind a lazily-created `asyncio.Lock` (`_round_start_lock`). A manual `admin_next_round` and the REVEAL `_reveal_auto_advance` (both call `start_round`) can no longer drive a round-start concurrently. After acquiring, a phase re-check no-ops the race loser once the winner reached PLAYING (guarded by an entry-phase snapshot so legitimate PLAYING-phase entries — Sudden-Death auto-end, #1358 ghost-round guard — still run). Skip/retry recursion moved into `_start_round_locked` (the lock is non-reentrant).
- **#1698** `admin_end_game` now `await resolve_title_artist_if_pending()` before finalize/record, mirroring `admin_next_round`, so ending during REVEAL with an open title/artist vote window no longer drops the final round's scores. (Only the WS handler path is in scope here; the REST/service `game/service.py` finalize path is out of the touched-file set and still needs the same one-liner.)
- **#1702** `finalize_game` + `record_game` + `advance_to_end` now run exactly once per `game_id` via a handler-level claim (`_claim_game_end`), shared by the `next_round` and `end_game` terminal paths. `admin_next_round` also re-checks the phase after the awaits. Prevents double stats / double podium TTS when the participant-admin WS and spectator `_admin_ws` both fire `next_round` on the final round.
- **#1703** `_handle_disconnect` cancels an existing pending admin-disconnect pause task before overwriting the handle and guards the grace timer by `game_id`; `admin_rematch_game` runs `cleanup_game_tasks`. A leftover grace timer can no longer pause a brand-new lobby after a rematch.
- **#1711** `broadcast()` serializes each variant (admin vs. redacted player) to JSON once and sends via `ws.send_str` in the gather loop, instead of aiohttp running `json.dumps` per connection. The `players`/`leaderboard` payload-overlap reduction was intentionally left out (needs a coordinated frontend change).

## Tests

- New `tests/unit/test_round_advance_serialization.py` (7 tests): lock prevents double `start_round`; `end_game` resolves the vote window before the ceremony; concurrent last-round `next_round` records once; disconnect cancels the prior pause task + rematch cleans up tasks.
- Updated `tests/unit/test_redact_answers_1366.py` to decode the `send_str` JSON string (transport change from #1711).
- Full suite: **1315 passed, 2 skipped**. `ruff format` + `ruff check` clean. `mypy` gate green.

Fixes #1697
Fixes #1711

(#1698, #1702, #1703 to be closed manually after merge — the required-checks gate references two issues in the body.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)