### PR TITLE
perf(status): #1704 cache playlist discovery + fix(pause): #1699 intro-splash resume

### DIFF
--- a/custom_components/beatify/game/playlist.py
+++ b/custom_components/beatify/game/playlist.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from custom_components.beatify.const import (
+    DOMAIN,
     PLAYLIST_DIR,
     PROVIDER_AMAZON_MUSIC,
     PROVIDER_APPLE_MUSIC,
@@ -639,26 +640,58 @@ def filter_songs_for_provider(
     return (filtered, skipped)
 
 
-async def async_discover_playlists(hass: HomeAssistant) -> list[dict]:
-    """Discover all playlist files in the playlist directory."""
-    playlist_dir = get_playlist_directory(hass)
+# hass.data[DOMAIN] key holding the memoised discovery result (#1704).
+_DISCOVERY_CACHE_KEY = "_playlist_discovery_cache"
+
+# Signature entry per playlist file: (absolute path, mtime_ns, size). The whole
+# tuple of these — sorted, over every *.json under the playlist dir — is the
+# cache key. It changes on add / delete (path set changes) AND on in-place edit
+# (mtime_ns / size change), so a save / mix / delete self-invalidates the cache
+# with no explicit hook needed in those write paths (#1704).
+_DiscoverySig = tuple[tuple[str, int, int], ...]
+
+
+def _discover_playlists_sync(
+    playlist_dir: Path, cached_sig: _DiscoverySig | None
+) -> tuple[list[dict], dict[str, list[dict[str, Any]]], _DiscoverySig] | None:
+    """Walk + read + parse + validate + count every playlist, in ONE executor job.
+
+    #1704: previously only the raw file reads ran in the executor while
+    ``json.loads`` + ``validate_playlist`` (~6 regexes/song) + 5 provider-count
+    passes ran on the event loop on every ``/api/status`` request. This does the
+    whole job off-loop and returns finished dicts.
+
+    Returns ``None`` when ``cached_sig`` matches the current on-disk signature
+    (i.e. nothing changed → the caller reuses its cached result). Otherwise
+    returns ``(metas, songs_by_path, signature)`` where ``metas`` is the public
+    discovery payload (unchanged shape) and ``songs_by_path`` maps each playlist
+    path to its parsed song list so callers (the mixer) can reuse the parse
+    instead of re-reading the file.
+    """
+    if not playlist_dir.exists():
+        empty_sig: _DiscoverySig = ()
+        if cached_sig == empty_sig:
+            return None
+        return [], {}, empty_sig
+
+    # Offload blocking glob to executor to avoid scandir in event loop (#516).
+    json_files = sorted(playlist_dir.glob("**/*.json"))
+
+    sig_parts: list[tuple[str, int, int]] = []
+    for f in json_files:
+        try:
+            st = f.stat()
+        except OSError:
+            continue
+        sig_parts.append((str(f), st.st_mtime_ns, st.st_size))
+    signature: _DiscoverySig = tuple(sig_parts)
+
+    # Cache hit: nothing added/removed/edited since the last full parse.
+    if cached_sig is not None and cached_sig == signature:
+        return None
+
     playlists: list[dict] = []
-
-    loop = asyncio.get_running_loop()
-
-    # #1402 B3: `exists()` is a blocking syscall — run it in the executor.
-    if not await loop.run_in_executor(None, playlist_dir.exists):
-        _LOGGER.debug("Playlist directory does not exist: %s", playlist_dir)
-        return playlists
-
-    def _read_file(path: Path) -> str:
-        """Read file contents (runs in executor)."""
-        return path.read_text(encoding="utf-8")
-
-    # Offload blocking glob to executor to avoid scandir in event loop (#516)
-    json_files = await loop.run_in_executor(
-        None, lambda: list(playlist_dir.glob("**/*.json"))
-    )
+    songs_by_path: dict[str, list[dict[str, Any]]] = {}
     for json_file in json_files:
         try:
             rel = json_file.relative_to(playlist_dir)
@@ -667,15 +700,14 @@ async def async_discover_playlists(hass: HomeAssistant) -> list[dict]:
                 if rel.parts and rel.parts[0] in ("community", "user")
                 else "bundled"
             )
-            content = await loop.run_in_executor(None, _read_file, json_file)
-            data = json.loads(content)
+            data = json.loads(json_file.read_text(encoding="utf-8"))
             rejected_songs: list[dict[str, Any]] = []
             is_valid, errors = validate_playlist(data, rejected_songs=rejected_songs)
 
             # Count songs per provider (Story 17.1), validating URI patterns (#708).
             songs = data.get("songs", [])
 
-            def _count(field: str, pattern: str) -> int:
+            def _count(field: str, pattern: str, songs: list = songs) -> int:
                 n = 0
                 for s in songs:
                     v = s.get(field)
@@ -712,9 +744,13 @@ async def async_discover_playlists(hass: HomeAssistant) -> list[dict]:
                 )
                 continue
 
+            path_str = str(json_file)
+            # #1704: retain the parsed songs so the mixer reuses this parse
+            # instead of re-reading + re-parsing every tag file a second time.
+            songs_by_path[path_str] = songs
             playlists.append(
                 {
-                    "path": str(json_file),
+                    "path": path_str,
                     "filename": json_file.name,
                     "name": data.get("name", json_file.stem),
                     "source": source,
@@ -773,9 +809,57 @@ async def async_discover_playlists(hass: HomeAssistant) -> list[dict]:
                     "rejected_songs": [],
                 }
             )
+        except OSError as e:  # pragma: no cover - I/O edge (file vanished mid-walk)
+            _LOGGER.debug("Skipping unreadable playlist %s: %s", json_file, e)
+            continue
 
     _LOGGER.debug("Found %d playlists", len(playlists))
-    return playlists
+    return playlists, songs_by_path, signature
+
+
+async def async_discover_playlists_detailed(
+    hass: HomeAssistant,
+) -> tuple[list[dict], dict[str, list[dict[str, Any]]]]:
+    """Discover playlists, returning both the metas and the parsed songs per path.
+
+    #1704: memoised. The entire walk/read/parse/validate/count runs in ONE
+    executor job (never on the event loop) and the result is cached in
+    ``hass.data[DOMAIN]`` keyed by an on-disk signature (path set + each file's
+    mtime + size). A cache hit re-uses the parsed result; any save / mix / delete
+    changes the signature and transparently invalidates it — no explicit hook in
+    the write paths, and no staleness.
+    """
+    playlist_dir = get_playlist_directory(hass)
+    domain_data = hass.data.setdefault(DOMAIN, {})
+    cache = domain_data.get(_DISCOVERY_CACHE_KEY)
+    cached_sig: _DiscoverySig | None = cache["sig"] if cache else None
+
+    # Offload the whole walk/read/parse/validate/count to the executor (matches
+    # the original discovery, which used loop.run_in_executor(None, …) for its
+    # glob + reads — #516/#1402 B3). Doing it in one job keeps the event loop
+    # free of the ~47 json.loads + validate + 50k regex evals per request.
+    loop = asyncio.get_running_loop()
+    result = await loop.run_in_executor(
+        None, _discover_playlists_sync, playlist_dir, cached_sig
+    )
+
+    if result is None:
+        # Signature unchanged → serve the memoised parse.
+        return cache["metas"], cache["songs_by_path"]
+
+    metas, songs_by_path, signature = result
+    domain_data[_DISCOVERY_CACHE_KEY] = {
+        "sig": signature,
+        "metas": metas,
+        "songs_by_path": songs_by_path,
+    }
+    return metas, songs_by_path
+
+
+async def async_discover_playlists(hass: HomeAssistant) -> list[dict]:
+    """Discover all playlist files in the playlist directory (memoised, #1704)."""
+    metas, _ = await async_discover_playlists_detailed(hass)
+    return metas
 
 
 async def async_load_and_validate_playlist(

--- a/custom_components/beatify/game/round_manager.py
+++ b/custom_components/beatify/game/round_manager.py
@@ -166,6 +166,17 @@ class RoundManager:
 
     def is_deadline_passed(self) -> bool:
         """Return True if the round deadline has passed."""
+        # #1699: while an intro splash is still pending, the deadline stamped by
+        # initialize_round is only a placeholder — the round timer has NOT
+        # started counting down (that is deferred to confirm_intro_splash, which
+        # recomputes the deadline from the moment the deferred song plays). Until
+        # then the round has not really begun, so report the deadline as
+        # not-passed. This closes the same blind spot in the client watchdog
+        # (handle_round_timeout gates on is_deadline_passed): otherwise a splash
+        # left unconfirmed past round_duration would let a client nudge end_round
+        # on a round whose song never even played.
+        if self._intro_splash_pending:
+            return False
         if self.deadline is None:
             return False
         now_ms = int(self._now() * 1000)

--- a/custom_components/beatify/game/state_pause.py
+++ b/custom_components/beatify/game/state_pause.py
@@ -173,6 +173,28 @@ class PauseResumeMixin:
 
         previous = self._previous_phase
 
+        # #1699: a round paused while its intro splash was still pending has NOT
+        # started its round timer or begun playback — initialize_round flips to
+        # PLAYING and stamps a placeholder deadline but defers BOTH the timer and
+        # the play() to confirm_intro_splash. The generic resume path below sees
+        # previous==PLAYING with a truthy deadline and would (a) start the round
+        # timer and (b) call play() — un-pausing whatever was last on the speaker
+        # rather than the deferred song, and counting down a round the host never
+        # confirmed. So short-circuit here: restore the PLAYING phase but leave
+        # the round waiting for confirm_intro_splash to start the timer + play
+        # the deferred song.
+        if self.intro_splash_pending:
+            self._set_phase(previous, restore=True)
+            self.pause_reason = None
+            self.disconnected_admin_name = None
+            self._previous_phase = None
+            _LOGGER.info(
+                "Game resumed to phase %s — intro splash still pending, timer "
+                "and playback deferred to confirm_intro_splash",
+                previous.value,
+            )
+            return True
+
         # Restart timer if resuming to PLAYING and deadline still valid
         if previous == GamePhase.PLAYING and self.deadline:
             now_ms = int(self._now() * 1000)

--- a/custom_components/beatify/server/mix_views.py
+++ b/custom_components/beatify/server/mix_views.py
@@ -41,7 +41,7 @@ from custom_components.beatify.const import PROVIDER_DEFAULT
 from custom_components.beatify.game.playlist import (
     MIN_YEAR,
     _max_year,
-    async_discover_playlists,
+    async_discover_playlists_detailed,
     get_playlist_directory,
     get_song_uri,
     validate_playlist,
@@ -49,7 +49,6 @@ from custom_components.beatify.game.playlist import (
 from custom_components.beatify.server.base import (
     RateLimitMixin,
     _json_error,
-    _read_file,
 )
 from custom_components.beatify.server.companion_auth import is_authorized_http
 from custom_components.beatify.server.game_views import _validate_provider
@@ -105,8 +104,7 @@ def _assemble_mix_songs(
     selected_tags: set[str],
     target_count: int,
     provider: str,
-    read_file,
-    playlist_dir: Path,
+    songs_by_path: dict[str, list[dict[str, Any]]],
 ) -> tuple[list[dict[str, Any]], int]:
     """Collect, de-dupe and cap candidate songs from tag-matching playlists.
 
@@ -115,6 +113,10 @@ def _assemble_mix_songs(
     80s, the 90s OR pop, then dedupe. Songs are de-duplicated by their
     provider-resolved URI (``get_song_uri``) — the same key the in-game
     PlaylistManager uses — then shuffled and capped at ``target_count``.
+
+    #1704: the songs come pre-parsed from discovery (``songs_by_path``) rather
+    than being re-read + re-parsed from disk here — discovery already read and
+    parsed every file, so a second per-file pass was pure waste.
 
     Returns ``(songs, matched_playlist_count)``.
     """
@@ -134,16 +136,13 @@ def _assemble_mix_songs(
         if _is_transient_mix(path):
             continue
 
-        full_path = Path(path)
-        try:
-            data = json.loads(read_file(full_path))
-        except (OSError, ValueError) as err:  # pragma: no cover - I/O edge
-            _LOGGER.debug("Mix: skipping unreadable playlist %s: %s", path, err)
+        songs = songs_by_path.get(path)
+        if not songs:  # pragma: no cover - meta/parse desync edge
             continue
 
         matched += 1
         max_year = _max_year()
-        for song in data.get("songs", []):
+        for song in songs:
             if not isinstance(song, dict):
                 continue
             # Apply the SAME int/range year check as validate_playlist (#1547):
@@ -275,7 +274,11 @@ class MixPlaylistView(RateLimitMixin, HomeAssistantView):
         preview = bool(body.get("preview", False))
 
         # --- Discover + assemble ------------------------------------------
-        playlists_meta = await async_discover_playlists(self.hass)
+        # #1704: reuse discovery's already-parsed songs (songs_by_path) so the
+        # mixer no longer re-reads + re-parses every tag file a second time.
+        playlists_meta, songs_by_path = await async_discover_playlists_detailed(
+            self.hass
+        )
         playlist_dir = get_playlist_directory(self.hass)
 
         songs, matched = await self.hass.async_add_executor_job(
@@ -284,8 +287,7 @@ class MixPlaylistView(RateLimitMixin, HomeAssistantView):
             selected_tags,
             target_count,
             provider,
-            _read_file,
-            playlist_dir,
+            songs_by_path,
         )
 
         if not songs:

--- a/custom_components/beatify/server/views.py
+++ b/custom_components/beatify/server/views.py
@@ -40,8 +40,7 @@ from custom_components.beatify.server.setup_state import read_setup, write_setup
 from custom_components.beatify.services.lights import PartyLightsService
 from custom_components.beatify.services.media_player import (
     album_art_signature_is_valid,
-    async_get_media_players,
-    async_get_native_twin_remap,
+    async_get_media_players_with_remap,
 )
 
 # Re-export game views
@@ -526,14 +525,20 @@ class StatusView(HomeAssistantView):
 
     async def get(self, request: web.Request) -> web.Response:  # noqa: ARG002
         """Return current status as JSON."""
-        # Fetch media players fresh (not cached) - Story 8-2
-        media_players = await async_get_media_players(self.hass)
+        # Fetch media players fresh (not cached) - Story 8-2.
+        # #1704: the player list and the native→MA twin remap (#1627: lets the
+        # admin frontend heal a stale saved selection pointing at a now-hidden
+        # native twin) come from a SINGLE entity-registry walk instead of two
+        # back-to-back walks (async_get_media_players +
+        # async_get_native_twin_remap), via the #1739 combined helper.
+        (
+            media_players,
+            media_player_twin_remap,
+        ) = await async_get_media_players_with_remap(self.hass)
 
-        # #1627 follow-up: native→MA twin map so the admin frontend can heal a
-        # stale saved selection pointing at a now-hidden native twin.
-        media_player_twin_remap = await async_get_native_twin_remap(self.hass)
-
-        # Fetch playlists fresh (not cached) - Issue #135
+        # Discover playlists (#1704: memoised — reuses the parsed corpus unless a
+        # file changed on disk; the heavy json.loads/validate/count now runs in
+        # the executor, not on the event loop, on every /api/status request).
         playlists = await async_discover_playlists(self.hass)
         self.hass.data.setdefault(DOMAIN, {})["playlists"] = playlists
 

--- a/tests/unit/test_mix_view.py
+++ b/tests/unit/test_mix_view.py
@@ -26,11 +26,23 @@ from aiohttp import StreamReader
 from aiohttp.test_utils import make_mocked_request
 
 from custom_components.beatify.const import PROVIDER_DEEZER, PROVIDER_DEFAULT
-from custom_components.beatify.server.base import _read_file
 from custom_components.beatify.server.mix_views import (
     MixPlaylistView,
     _assemble_mix_songs,
 )
+
+
+def _songs_by_path(pdir: Path) -> dict:
+    """Build the ``{path: parsed songs}`` map discovery now hands to the mixer.
+
+    #1704: ``_assemble_mix_songs`` no longer re-reads files — it consumes the
+    songs already parsed by ``async_discover_playlists``. Mirror that here by
+    parsing every catalogue file once.
+    """
+    return {
+        str(f): json.loads(f.read_text(encoding="utf-8")).get("songs", [])
+        for f in pdir.glob("**/*.json")
+    }
 
 
 def _uri(tag: str) -> str:
@@ -158,7 +170,7 @@ class TestAssembleMixSongs:
         # "pop" union: both pop lists match (3 + 2 songs = 5 raw), track0001 is a
         # dup → 4 unique. Rock list has no "pop" tag → excluded.
         songs, matched = _assemble_mix_songs(
-            meta, {"pop"}, 100, "spotify", _read_file, pdir
+            meta, {"pop"}, 100, "spotify", _songs_by_path(pdir)
         )
         assert matched == 2
         uris = {s["uri"] for s in songs}
@@ -176,7 +188,9 @@ class TestAssembleMixSongs:
             self._meta(str(pdir / "80s-pop.json"), ["1980s", "pop"]),
             self._meta(str(pdir / "90s-pop.json"), ["1990s", "pop"]),
         ]
-        songs, _ = _assemble_mix_songs(meta, {"pop"}, 2, "spotify", _read_file, pdir)
+        songs, _ = _assemble_mix_songs(
+            meta, {"pop"}, 2, "spotify", _songs_by_path(pdir)
+        )
         assert len(songs) == 2  # capped below the 4 available
 
     def test_skips_invalid_playlists(self, tmp_path):
@@ -185,7 +199,7 @@ class TestAssembleMixSongs:
             self._meta(str(pdir / "80s-pop.json"), ["1980s", "pop"], valid=False),
         ]
         songs, matched = _assemble_mix_songs(
-            meta, {"pop"}, 100, "spotify", _read_file, pdir
+            meta, {"pop"}, 100, "spotify", _songs_by_path(pdir)
         )
         assert matched == 0
         assert songs == []
@@ -212,7 +226,7 @@ class TestAssembleMixSongs:
         )
         meta = [self._meta(str(pdir / "mixed.json"), ["pop"])]
         songs, matched = _assemble_mix_songs(
-            meta, {"pop"}, 100, "spotify", _read_file, pdir
+            meta, {"pop"}, 100, "spotify", _songs_by_path(pdir)
         )
         assert matched == 1
         uris = {s["uri"] for s in songs}
@@ -237,7 +251,7 @@ class TestAssembleMixSongs:
             self._meta(str(mix_dir / "__mix__-deadbeef.json"), ["pop"]),
         ]
         songs, matched = _assemble_mix_songs(
-            meta, {"pop"}, 100, "spotify", _read_file, pdir
+            meta, {"pop"}, 100, "spotify", _songs_by_path(pdir)
         )
         assert matched == 1  # only the real 80s list, transient excluded
         uris = {s["uri"] for s in songs}

--- a/tests/unit/test_playlist_discovery_cache_1704.py
+++ b/tests/unit/test_playlist_discovery_cache_1704.py
@@ -1,0 +1,148 @@
+"""Tests for the memoised playlist discovery cache (#1704).
+
+The status endpoint used to re-read + re-parse + re-validate the whole playlist
+corpus on the event loop on every ``/api/status`` request. Discovery is now
+memoised in ``hass.data[DOMAIN]`` keyed by an on-disk signature (path set + each
+file's mtime + size): unchanged corpus → cache hit (no re-parse); any
+save / mix / delete changes the signature → transparent invalidation, no
+staleness and no explicit hook in the write paths.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest import mock
+from unittest.mock import MagicMock
+
+from custom_components.beatify.game import playlist as pl
+
+
+def _song(tag: str, year: int = 1985) -> dict:
+    uri = "spotify:track:" + tag.rjust(22, "0")
+    return {"artist": "A " + tag, "title": "T " + tag, "year": year, "uri": uri}
+
+
+def _playlist(name: str, tags: list[str], songs: list[dict]) -> dict:
+    return {
+        "name": name,
+        "version": "1.0",
+        "tags": tags,
+        "language": "en",
+        "author": "Tester",
+        "added_date": "2026-06-24",
+        "songs": songs,
+    }
+
+
+def _write(pdir: Path, filename: str, name: str, tags: list[str], songs) -> None:
+    (pdir / filename).write_text(
+        json.dumps(_playlist(name, tags, songs)), encoding="utf-8"
+    )
+
+
+def _fake_hass(pdir: Path):
+    """Minimal hass double: real dict `.data`, config.path → the playlist dir.
+
+    Discovery offloads its work via ``asyncio.get_running_loop().run_in_executor``
+    (not ``hass.async_add_executor_job``), so a plain object with a real
+    ``data`` dict is enough — the cache must survive across calls, which a
+    MagicMock dict would not.
+    """
+    hass = MagicMock()
+    hass.config.path = MagicMock(return_value=str(pdir))
+    hass.data = {}
+    return hass
+
+
+def _catalogue(tmp_path: Path) -> Path:
+    pdir = tmp_path / "beatify" / "playlists"
+    pdir.mkdir(parents=True)
+    _write(pdir, "80s.json", "80s", ["1980s", "pop"], [_song("0001"), _song("0002")])
+    _write(pdir, "90s.json", "90s", ["1990s", "pop"], [_song("0003", 1995)])
+    return pdir
+
+
+class TestDiscoveryCache:
+    async def test_second_call_is_cache_hit_no_reparse(self, tmp_path):
+        pdir = _catalogue(tmp_path)
+        hass = _fake_hass(pdir)
+
+        with mock.patch.object(
+            pl, "validate_playlist", wraps=pl.validate_playlist
+        ) as spy:
+            metas1, songs1 = await pl.async_discover_playlists_detailed(hass)
+            calls_first = spy.call_count
+            assert calls_first == 2  # both playlists parsed + validated
+
+            # Nothing changed on disk → cache hit → no re-parse, same objects.
+            metas2, songs2 = await pl.async_discover_playlists_detailed(hass)
+            assert spy.call_count == calls_first
+            assert metas2 is metas1
+            assert songs2 is songs1
+
+    async def test_save_new_playlist_invalidates_cache(self, tmp_path):
+        pdir = _catalogue(tmp_path)
+        hass = _fake_hass(pdir)
+
+        metas1 = await pl.async_discover_playlists(hass)
+        names1 = {m["name"] for m in metas1}
+        assert "Fresh" not in names1
+
+        # A save writes a new file (e.g. user/<slug>.json) — the signature
+        # changes, so the very next discovery must see it (no staleness).
+        (pdir / "user").mkdir()
+        _write(pdir / "user", "fresh.json", "Fresh", ["pop"], [_song("0009", 2001)])
+
+        with mock.patch.object(
+            pl, "validate_playlist", wraps=pl.validate_playlist
+        ) as spy:
+            metas2 = await pl.async_discover_playlists(hass)
+            assert spy.call_count > 0  # re-parsed
+        names2 = {m["name"] for m in metas2}
+        assert "Fresh" in names2
+        assert metas2 is not metas1
+
+    async def test_inplace_edit_invalidates_cache(self, tmp_path):
+        """An in-place content edit (mtime/size change) also invalidates —
+        directory mtime alone would miss this, so the signature includes each
+        file's mtime_ns + size."""
+        pdir = _catalogue(tmp_path)
+        hass = _fake_hass(pdir)
+
+        await pl.async_discover_playlists_detailed(hass)
+
+        # Overwrite an existing file with a different song count.
+        _write(
+            pdir,
+            "80s.json",
+            "80s",
+            ["1980s", "pop"],
+            [_song("0001"), _song("0002"), _song("0005")],
+        )
+
+        metas, songs_by_path = await pl.async_discover_playlists_detailed(hass)
+        edited = next(m for m in metas if m["filename"] == "80s.json")
+        assert edited["song_count"] == 3
+
+    async def test_songs_by_path_carries_parsed_songs(self, tmp_path):
+        """The detailed variant returns the parsed songs per path so the mixer
+        reuses the parse instead of re-reading each file (#1704)."""
+        pdir = _catalogue(tmp_path)
+        hass = _fake_hass(pdir)
+
+        metas, songs_by_path = await pl.async_discover_playlists_detailed(hass)
+        for meta in metas:
+            assert meta["path"] in songs_by_path
+            assert len(songs_by_path[meta["path"]]) == meta["song_count"]
+
+    async def test_missing_dir_returns_empty_and_caches(self, tmp_path):
+        pdir = tmp_path / "beatify" / "playlists"  # not created
+        hass = _fake_hass(pdir)
+
+        metas1, songs1 = await pl.async_discover_playlists_detailed(hass)
+        assert metas1 == []
+        assert songs1 == {}
+        # Second call is a cache hit (empty signature unchanged).
+        metas2, _ = await pl.async_discover_playlists_detailed(hass)
+        assert metas2 is metas1

--- a/tests/unit/test_round_manager.py
+++ b/tests/unit/test_round_manager.py
@@ -66,6 +66,21 @@ class TestIsDeadlinePassed:
         rm.deadline = int((now + 30) * 1000)
         assert rm.is_deadline_passed() is False
 
+    def test_pending_intro_splash_never_passed(self):
+        """#1699: while an intro splash is pending the stamped deadline is only a
+        placeholder (the timer starts on confirm_intro_splash). Report it as
+        not-passed so the client watchdog can't end_round a round whose song
+        never played, even if the placeholder deadline has 'elapsed'.
+        """
+        now = 1_000_000.0
+        rm = _make_rm(time_fn=lambda: now)
+        rm.deadline = int((now - 10) * 1000)  # would be 'passed' normally
+        rm._intro_splash_pending = True
+        assert rm.is_deadline_passed() is False
+        # Once the splash is confirmed the deadline is honoured again.
+        rm._intro_splash_pending = False
+        assert rm.is_deadline_passed() is True
+
 
 # ---------------------------------------------------------------------------
 # RoundManager.cancel_timer

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -1456,6 +1456,39 @@ class TestResumeGame:
         mock_media.play.assert_awaited_once_with()
 
     @pytest.mark.asyncio
+    async def test_resume_during_pending_intro_splash_no_timer_no_play(self):
+        """#1699: pause/resume while an intro splash is still pending must NOT
+        start the round timer or call play().
+
+        An intro-splash round flips to PLAYING and stamps a placeholder deadline
+        in initialize_round but defers BOTH the timer and the play() to
+        confirm_intro_splash. Before the fix, resume_game saw previous==PLAYING
+        with a truthy deadline and (a) started the round timer and (b) called
+        play() — un-pausing whatever was last on the speaker (the WRONG media)
+        and counting down a round the host never confirmed. resume_game must
+        instead just restore the PLAYING phase and leave the round waiting.
+        """
+        mock_media = AsyncMock()
+        self.state._media_player_service = mock_media
+        self.state.current_song = {"title": "Test", "uri": "spotify:track:test"}
+        # Simulate an intro-splash round awaiting confirmation.
+        self.state._round_manager._intro_splash_pending = True
+        assert self.state.intro_splash_pending is True
+
+        await self.state.pause_game("admin_disconnected")
+        result = await self.state.resume_game()
+
+        assert result is True
+        # Phase restored, but playback + timer stay deferred to the splash confirm.
+        assert self.state.phase == GamePhase.PLAYING
+        assert self.state.intro_splash_pending is True
+        mock_media.play.assert_not_awaited()
+        assert self.state._round_manager._timer_task is None
+        # Pause bookkeeping still cleared as on any resume.
+        assert self.state.pause_reason is None
+        assert self.state._previous_phase is None
+
+    @pytest.mark.asyncio
     async def test_resume_expired_timer_ends_round(self):
         """When timer expired during pause, round should end immediately."""
         self.state.deadline = int(self.state._now() * 1000) - 1000  # expired


### PR DESCRIPTION
Fixes #1704, #1699

## #1704 — Status endpoint re-parses the whole playlist corpus per request (perf)
`/api/status` re-read + re-parsed + re-validated every playlist on the event loop on every request (~47 json.loads + validate + 50k regex evals, hit on every admin/wizard load, playlist-hub open, and the 3s lobby-poll fallback).

- Move the entire walk/read/parse/validate/count into **one executor job** (previously only file reads were offloaded).
- **Memoise** discovery in `hass.data` keyed by an on-disk signature (path set + each file's `mtime_ns` + size). Unchanged corpus → cache hit; any save / mix / delete changes the signature → transparent invalidation. No staleness, and no explicit hook needed in the write paths (which live outside this PR's file scope).
- `MixPlaylistView` reuses discovery's already-parsed songs (`songs_by_path`) instead of re-reading + re-parsing each tag file a second time.
- `StatusView` gets the player list **and** the native→MA twin remap from a **single** registry walk via `async_get_media_players_with_remap` (#1739), instead of two back-to-back walks.

Status payload shape is **unchanged** — pure perf.

## #1699 — Pause/resume during a pending intro splash (bug)
An intro-splash round flips to PLAYING and stamps a placeholder deadline but defers the timer + `play()` to `confirm_intro_splash`. `resume_game` saw `previous==PLAYING` with a truthy deadline and (a) started the round timer and (b) called `play()` — un-pausing whatever was last on the speaker (the wrong media) and counting down a round the host never confirmed.

- `resume_game` now short-circuits on `intro_splash_pending`: restore the PLAYING phase, **no timer, no play** — leave the round waiting for `confirm_intro_splash`.
- `is_deadline_passed` reports **not-passed** while a splash is pending, closing the same blind spot in the client watchdog (`handle_round_timeout` gates on it) so it can't `end_round` a round whose song never played.

## Tests
- New `test_playlist_discovery_cache_1704.py`: cache hit vs. invalidation after save (new file), in-place edit invalidation, `songs_by_path` reuse, missing-dir caching.
- `test_state.py`: resume during pending intro splash starts no timer and does not call `play()`.
- `test_round_manager.py`: `is_deadline_passed` gated on `intro_splash_pending`.
- Updated `test_mix_view.py` `_assemble_mix_songs` callers to the new signature.
- Full suite green (1311 passed; 4 pre-existing `test_tts_localization` failures are an unrelated missing `num2words` dep on origin/main). `ruff format`/`check` + mypy clean.

Note: #1699 is the second issue and will be closed manually after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)