### PR TITLE
docs+fix: #1734 companion-auth docs + #1698 REST title/artist resolve + i18n new-game keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,28 @@ play with zero friction.
 > Any Home Assistant user account can host — Beatify does not distinguish
 > between HA admin and non-admin users.
 
+### Options (Settings → Devices & Services → Beatify → Configure)
+
+Beatify exposes a single option in its options flow:
+
+**Enable HA Android Companion auth bypass** — OFF by default.
+
+Some setups hit a login loop when opening Beatify from the **Home Assistant
+Companion app on Android**: the host page keeps bouncing back to the login
+screen and never reaches the admin UI, so you can't host from the phone. When
+this toggle is ON, requests coming from the HA Android Companion app on your
+**local network** are treated as the host without a separate login, which
+breaks that loop.
+
+> ⚠️ **Security warning.** This weakens host authentication. Leave it **OFF**
+> unless the Companion app genuinely cannot authenticate. **Do NOT enable it**
+> if Beatify is reachable through **Home Assistant Cloud (Nabu Casa)** or a
+> **reverse proxy that does not forward the real client IP** — in those setups
+> every request can look like it comes from your local network, so an internet
+> visitor could host games, control your speakers/lights, and end games
+> **without any credentials**. Players joining at `/beatify/play` are never
+> affected either way.
+
 ### Starting a Game
 
 **First time?** Beatify drops you into a 5-step first-run wizard that walks you through the whole setup:
@@ -905,6 +927,12 @@ The neon dark theme is built-in and looks stunning. Custom theming is on the roa
 - Improve lighting on the display
 - Try the "Print QR" feature for a physical copy
 - Use a dedicated QR scanner app
+
+**Can't host from the HA Companion app on Android?**
+- Opening Beatify from the Android Companion app can loop back to the login screen and never reach the admin UI
+- First try opening `/beatify/admin` in the phone's browser and logging in there once — the Companion webview often picks up the session afterwards
+- If it still loops, enable **Settings → Devices & Services → Beatify → Configure → Enable HA Android Companion auth bypass** — see [Options](#options-settings--devices--services--beatify--configure) for the full explanation
+- ⚠️ Only enable the bypass on a **local, non-forwarding** setup. Do **NOT** enable it if Beatify is reachable via **Nabu Casa** or a **reverse proxy that doesn't forward the real client IP** — it would let internet visitors host without a login
 
 ---
 

--- a/custom_components/beatify/game/service.py
+++ b/custom_components/beatify/game/service.py
@@ -97,6 +97,14 @@ class GameService:
         where ``finalize_game()`` + ``stats_service.record_game()``
         are called together.
         """
+        # #1698: In title/artist mode scoring is deferred until the vote window
+        # is finalized. The REST/service finalize path (used by REST + service
+        # end-game callers) must resolve an open window *before* finalize_game/
+        # record_game, mirroring admin_end_game / admin_next_round in
+        # server/ws_handlers/admin.py — otherwise ending during REVEAL with the
+        # window still open persists totals missing the entire last round.
+        await self._game_state.resolve_title_artist_if_pending()
+
         stats = self.stats_service
         if stats:
             game_summary = self._game_state.finalize_game()

--- a/custom_components/beatify/www/i18n/de.json
+++ b/custom_components/beatify/www/i18n/de.json
@@ -380,6 +380,8 @@
     "newGame": "Neues Spiel",
     "newGameTitle": "Neues Spiel?",
     "newGameConfirm": "Ein neues Spiel starten?",
+    "newGameConfirmTitle": "Neues Spiel starten?",
+    "newGameConfirmMessage": "Lautsprecher + Playlists verwerfen und neu einrichten?",
     "startNewGame": "Neues Spiel starten",
     "stop": "Stop",
     "stopSong": "Song stoppen",

--- a/custom_components/beatify/www/i18n/en.json
+++ b/custom_components/beatify/www/i18n/en.json
@@ -380,6 +380,8 @@
     "newGame": "New Game",
     "newGameTitle": "New Game?",
     "newGameConfirm": "Start a new game?",
+    "newGameConfirmTitle": "Start New Game?",
+    "newGameConfirmMessage": "Forget your speaker + playlists and start fresh setup?",
     "startNewGame": "Start New Game",
     "stop": "Stop",
     "stopSong": "Stop Song",

--- a/custom_components/beatify/www/i18n/es.json
+++ b/custom_components/beatify/www/i18n/es.json
@@ -380,6 +380,8 @@
     "newGame": "Nuevo juego",
     "newGameTitle": "¿Nuevo juego?",
     "newGameConfirm": "¿Iniciar un nuevo juego?",
+    "newGameConfirmTitle": "¿Iniciar un nuevo juego?",
+    "newGameConfirmMessage": "¿Olvidar tu altavoz + listas y empezar la configuración de cero?",
     "startNewGame": "Iniciar nuevo juego",
     "stop": "Detener",
     "stopSong": "Detener canción",

--- a/custom_components/beatify/www/i18n/fr.json
+++ b/custom_components/beatify/www/i18n/fr.json
@@ -380,6 +380,8 @@
     "newGame": "Nouvelle partie",
     "newGameTitle": "Nouvelle partie ?",
     "newGameConfirm": "Lancer une nouvelle partie ?",
+    "newGameConfirmTitle": "Lancer une nouvelle partie ?",
+    "newGameConfirmMessage": "Oublier votre enceinte + playlists et repartir de zéro ?",
     "startNewGame": "Lancer une nouvelle partie",
     "stop": "Arrêter",
     "stopSong": "Arrêter chanson",

--- a/custom_components/beatify/www/i18n/nl.json
+++ b/custom_components/beatify/www/i18n/nl.json
@@ -380,6 +380,8 @@
     "newGame": "Nieuw spel",
     "newGameTitle": "Nieuw spel?",
     "newGameConfirm": "Een nieuw spel starten?",
+    "newGameConfirmTitle": "Nieuw spel starten?",
+    "newGameConfirmMessage": "Speaker + afspeellijsten vergeten en opnieuw instellen?",
     "startNewGame": "Nieuw spel starten",
     "stop": "Stop",
     "stopSong": "Stop nummer",

--- a/tests/unit/test_game_service.py
+++ b/tests/unit/test_game_service.py
@@ -34,6 +34,7 @@ def game_state():
     gs.end_game = AsyncMock()
     gs.stop_media = AsyncMock()
     gs.trigger_early_reveal_if_complete = AsyncMock()
+    gs.resolve_title_artist_if_pending = AsyncMock()  # #1698
     gs.create_game.return_value = {"game_id": "abc", "phase": "LOBBY"}
     gs.submit_artist_guess.return_value = {"correct": True, "first": True}
     gs.submit_movie_guess.return_value = {"correct": False, "already_guessed": False}
@@ -106,6 +107,8 @@ class TestFinalizeAndRecordStats:
 
         await service.finalize_and_record_stats()
 
+        # #1698: an open title/artist vote window is resolved before finalize.
+        game_state.resolve_title_artist_if_pending.assert_awaited_once()
         game_state.finalize_game.assert_called_once()
         mock_stats.record_game.assert_awaited_once_with(
             {"winner": "Alice", "rounds": 3}, difficulty="normal"
@@ -115,6 +118,8 @@ class TestFinalizeAndRecordStats:
     async def test_skips_when_no_stats_service(self, service, game_state):
         await service.finalize_and_record_stats()
         game_state.finalize_game.assert_not_called()
+        # #1698: resolve runs regardless of stats availability (mirrors admin.py).
+        game_state.resolve_title_artist_if_pending.assert_awaited_once()
 
 
 class TestNextRound:


### PR DESCRIPTION
Small cleanup PR bundling three independent follow-ups from the 2026-07-05 Fable review.

## #1734 — Companion auth bypass undocumented (docs)
The security-relevant `enable_companion_auth_bypass` options toggle (weakens host auth for the HA Android Companion, dangerous behind Nabu Casa / non-forwarding proxy) was only described in the options-flow string. Added:
- a new **Options** section in the README (Settings → Devices & Services → Beatify → Configure) documenting when to use the toggle (Android Companion login loop) and an explicit Nabu Casa / reverse-proxy warning.
- a **Troubleshooting** entry: "Can't host from the HA Companion app on Android?".

Facts verified against `config_flow.py` (`BeatifyOptionsFlow` / `CONF_ENABLE_COMPANION_AUTH_BYPASS`) and `translations/en.json` `options.step.init`.

## #1698 follow-up — REST/service finalize path
`admin_end_game` was fixed in #1742 to `await resolve_title_artist_if_pending()` before finalize, but the REST/service path (`game/service.py`) still omitted it — so ending a game during REVEAL with an open title/artist vote window dropped the final round's scores. Added the single `await self._game_state.resolve_title_artist_if_pending()` call in `GameService.finalize_and_record_stats()` (the shared finalize path behind `next_round`'s terminal branches), mirroring the ws handler. Method is reachable via `VoteWindowMixin` on `GameState`.

## #1740 follow-up — i18n keys
`admin.newGameConfirmTitle` + `admin.newGameConfirmMessage` (introduced by #1740 as `data-i18n` refs in `admin.html`, rendering via English literal fallback) were missing from the locale JSONs. Added real translations to en/de/es/fr/nl. Locale key parity (#1737) stays green.

## Verification
- `pytest tests/ -q` — **1322 passed, 2 skipped** (incl. i18n locale-parity + round-advance + game-service tests; game-service fixture/asserts updated for the new awaited call).
- `ruff format` + `ruff check` + `mypy` clean for `service.py`.
- All five i18n JSON files valid.

Fixes #1734

🤖 Generated with [Claude Code](https://claude.com/claude-code)