### PR TITLE
fix(scoring): #1720 gate intro bonus on correctness + #1721 preserve streak in closest-wins

### DIFF
--- a/custom_components/beatify/game/scoring.py
+++ b/custom_components/beatify/game/scoring.py
@@ -321,26 +321,77 @@ def _score_movie_challenge(
     return player.movie_bonus
 
 
+def _intro_qualified(
+    player: PlayerSession,
+    *,
+    cutoff: float,
+    correct_year: int | None,
+    difficulty: str,
+    title_artist_manager: Any | None,
+) -> bool:
+    """Whether ``player`` qualifies for the intro speed bonus (#1720).
+
+    A submission must be both *in time* (before the 15s cutoff) and
+    *accuracy-positive*. Accuracy is recomputed from stable submit-time inputs
+    (``current_guess`` / the title-artist manager) rather than read off
+    ``player.base_score``: the per-player scoring loop runs sequentially, so a
+    not-yet-scored player's ``base_score`` may still hold a previous round's
+    value. Recomputing keeps the speed ranking order-independent.
+
+    Year mode: accuracy score (== ``base_score``) must be > 0.
+    Title/artist mode: title + artist points (== ``base_score``) must be > 0.
+    """
+    if player.submission_time is None or player.submission_time >= cutoff:
+        return False
+    if title_artist_manager is not None:
+        title_pts, artist_pts = title_artist_manager.title_artist_points(player.name)
+        return (title_pts + artist_pts) > 0
+    if correct_year is None or player.current_guess is None:
+        return False
+    return calculate_accuracy_score(player.current_guess, correct_year, difficulty) > 0
+
+
 def _score_intro_round(
     player: PlayerSession,
     *,
     is_intro_round: bool,
     intro_round_start_time: float | None,
     all_players: list[PlayerSession],
+    correct_year: int | None,
+    difficulty: str,
+    title_artist_manager: Any | None,
 ) -> int:
-    """Return intro bonus points. Mutates player.intro_bonus and player.intro_speed_bonuses."""
+    """Return intro bonus points. Mutates player.intro_bonus and player.intro_speed_bonuses.
+
+    #1720: only accuracy-qualified submitters compete for (and receive) the
+    tiered 5/3/1 intro bonus. A fast-but-wrong tap no longer farms guaranteed
+    points nor displaces a slower-but-correct recognizer in the speed ranking.
+    """
     player.intro_bonus = 0
     if not (is_intro_round and intro_round_start_time and player.submission_time):
         return 0
     cutoff = intro_round_start_time + INTRO_DURATION_SECONDS
-    if player.submission_time >= cutoff:
+    if not _intro_qualified(
+        player,
+        cutoff=cutoff,
+        correct_year=correct_year,
+        difficulty=difficulty,
+        title_artist_manager=title_artist_manager,
+    ):
         return 0
     player.intro_speed_bonuses += 1
     rank = sum(
         1
         for p in all_players
-        if p.submission_time is not None
-        and p.submission_time < cutoff
+        if p is not player
+        and _intro_qualified(
+            p,
+            cutoff=cutoff,
+            correct_year=correct_year,
+            difficulty=difficulty,
+            title_artist_manager=title_artist_manager,
+        )
+        and p.submission_time is not None
         and p.submission_time < player.submission_time
     )
     if rank < len(INTRO_BONUS_TIERS):
@@ -626,7 +677,14 @@ class ScoringService:
                 # set streak=0 and saved the real previous_streak for players
                 # who scored 0 — overwriting previous_streak with the now-0
                 # streak here would wipe their "lost X-streak" reveal display.
-                if lost > 0:
+                # #1721: additionally keep the streak (and its steal/milestone/
+                # best_streak side-effects) alive when the player was ACCURATE
+                # this round (base_score > 0). Closest-Wins still voids their
+                # round POINTS above, but an accurate guess must not break a
+                # streak just because someone else landed closer — otherwise
+                # streaks, the Steal unlock, milestone bonuses and the 🔥
+                # highlight become dead content in this mode.
+                if lost > 0 and p.base_score <= 0:
                     # _apply_streak incremented streak for this scoring round,
                     # so the pre-round streak is (streak - 1). Roll back the
                     # side-effects that the now-voided round produced:
@@ -810,6 +868,9 @@ class ScoringService:
                     is_intro_round=is_intro_round,
                     intro_round_start_time=intro_round_start_time,
                     all_players=all_players,
+                    correct_year=correct_year,
+                    difficulty=difficulty,
+                    title_artist_manager=title_artist_manager,
                 )
                 player.score += player.movie_bonus + player.intro_bonus
             else:
@@ -865,6 +926,9 @@ class ScoringService:
                 is_intro_round=is_intro_round,
                 intro_round_start_time=intro_round_start_time,
                 all_players=all_players,
+                correct_year=correct_year,
+                difficulty=difficulty,
+                title_artist_manager=None,
             )
 
             player.score += (

--- a/tests/unit/test_scoring.py
+++ b/tests/unit/test_scoring.py
@@ -452,6 +452,139 @@ class TestApplyClosestWins:
         # Real previous_streak preserved — NOT clobbered to 0.
         assert p2.previous_streak == 6
 
+    def test_accurate_non_closest_keeps_streak(self):
+        """#1721: an accurate (base_score>0) non-closest player keeps the streak.
+
+        Closest-Wins still voids the round POINTS, but the streak, its milestone
+        counter, the Steal unlock and best_streak survive so streaks/Steal/🔥 are
+        reachable in this mode.
+        """
+        from custom_components.beatify.const import STEAL_UNLOCK_STREAK
+
+        p1 = _make_player("Alice", 2000, 10)  # 0 off — closest
+        # Bob is 2 off (accurate — base_score 5) but not closest.
+        p2 = _make_player(
+            "Bob",
+            1998,
+            8,
+            base_score=5,
+            streak=STEAL_UNLOCK_STREAK,
+            streak_bonus=20,
+            best_streak=STEAL_UNLOCK_STREAK,
+            steal_available=True,
+            steal_used=False,
+            score=8 + 20,
+        )
+        achievements = {f"streak_{STEAL_UNLOCK_STREAK}": 1}
+
+        ScoringService.apply_closest_wins([p1, p2], 2000, achievements)
+
+        # Points voided …
+        assert p2.round_score == 0
+        assert p2.score == 0
+        assert p2.streak_bonus == 0
+        # … but the streak and everything it unlocked survive.
+        assert p2.streak == STEAL_UNLOCK_STREAK
+        assert p2.best_streak == STEAL_UNLOCK_STREAK
+        assert p2.steal_available is True
+        assert achievements[f"streak_{STEAL_UNLOCK_STREAK}"] == 1
+
+    def test_inaccurate_non_closest_breaks_streak(self):
+        """#1721: a wrong (base_score==0) non-closest player still loses streak.
+
+        Mirrors real play where _apply_streak already zeroed a wrong guess; the
+        streak preservation is gated strictly on positive accuracy.
+        """
+        p1 = _make_player("Alice", 2000, 10)
+        p2 = _make_player("Bob", 1990, 5, base_score=0, streak=3, streak_bonus=20)
+        p2.score = 5 + 20
+
+        ScoringService.apply_closest_wins([p1, p2], 2000)
+
+        assert p2.round_score == 0
+        assert p2.streak == 0
+        assert p2.streak_bonus == 0
+        assert p2.previous_streak == 2  # pre-round value (streak - 1)
+
+
+# ---------------------------------------------------------------------------
+# Intro-round speed bonus (Issue #23, correctness gate #1720)
+# ---------------------------------------------------------------------------
+
+
+# Epoch-like base so intro_round_start_time is truthy (0.0 is falsy in the
+# guard, matching real gameplay where these are wall-clock timestamps).
+_INTRO_ROUND_START = 1000.0
+
+
+def _intro_player(name: str, guess: int, offset: float) -> PlayerSession:
+    """A submitted player for intro-round tests; ``offset`` seconds after start."""
+    p = PlayerSession(name=name, ws=MagicMock())
+    p.submitted = True
+    p.current_guess = guess
+    p.submission_time = _INTRO_ROUND_START + offset
+    return p
+
+
+def _score_intro_year(
+    players: list[PlayerSession], correct_year: int = 2000, difficulty: str = "normal"
+) -> None:
+    """Score every player for a year-mode intro round via score_player_round."""
+    achievements: dict[str, int] = {}
+    bets = {"total_bets": 0, "bets_won": 0}
+    for p in players:
+        ScoringService.score_player_round(
+            p,
+            correct_year=correct_year,
+            round_start_time=_INTRO_ROUND_START,
+            round_duration=30.0,
+            difficulty=difficulty,
+            artist_challenge=None,
+            movie_challenge=None,
+            is_intro_round=True,
+            intro_round_start_time=_INTRO_ROUND_START,
+            all_players=players,
+            streak_achievements=achievements,
+            bet_tracking=bets,
+            title_artist_manager=None,
+        )
+
+
+class TestIntroBonusCorrectnessGate:
+    """#1720: the tiered intro speed bonus is gated on answer correctness."""
+
+    def test_fast_wrong_gets_no_bonus_correct_does(self):
+        """A fast-but-wrong tap earns nothing; a slower-but-correct guess does."""
+        wrong_fast = _intro_player("Wrong", 1950, 0.5)  # 50 off → base_score 0
+        right = _intro_player("Right", 2000, 1.0)  # exact
+        _score_intro_year([wrong_fast, right])
+
+        assert wrong_fast.intro_bonus == 0
+        assert wrong_fast.intro_speed_bonuses == 0
+        assert right.intro_bonus == 5
+        assert right.intro_speed_bonuses == 1
+
+    def test_fast_wrong_does_not_displace_correct_ranking(self):
+        """Ranking runs among the qualified only — a faster wrong tap can't push
+        a correct recognizer down a tier."""
+        wrong_fastest = _intro_player("Wrong", 1950, 0.5)
+        alice = _intro_player("Alice", 2000, 1.0)  # exact, fastest correct
+        carol = _intro_player("Carol", 2001, 2.0)  # 1 off → accurate, 2nd correct
+        # Score Alice first to prove order-independence of the rank calc.
+        _score_intro_year([alice, wrong_fastest, carol])
+
+        assert wrong_fastest.intro_bonus == 0
+        assert alice.intro_bonus == 5  # rank 0 among qualified
+        assert carol.intro_bonus == 3  # rank 1 among qualified
+
+    def test_correct_after_cutoff_gets_no_bonus(self):
+        """A correct guess after the 15s intro cutoff earns no intro bonus."""
+        late = _intro_player("Late", 2000, 20.0)  # correct but past 15s cutoff
+        _score_intro_year([late])
+
+        assert late.intro_bonus == 0
+        assert late.intro_speed_bonuses == 0
+
 
 # ---------------------------------------------------------------------------
 # Title & Artist mode scoring (Issue #1180)


### PR DESCRIPTION
## Summary
Two gameplay-scoring fixes found via Fable multi-agent review.

### #1720 — Intro speed bonus was awarded regardless of correctness
`_score_intro_round` handed out the tiered 5/3/1 intro bonus to the first submitters before the 15s cutoff without checking accuracy — a blind tap farmed guaranteed points. Now only **accuracy-qualified** submitters (`base_score > 0`) compete for and receive the bonus. Correctness is recomputed order-independently (from `current_guess`/the title-artist manager, not the per-player `base_score` which the sequential scoring loop may not yet have refreshed), so a fast-but-wrong tap no longer displaces a slower-but-correct recognizer in the speed ranking. Gates title/artist mode on title+artist points too.

### #1721 — Closest-Wins killed streaks / Steal / milestones
`apply_closest_wins` reset the streak for every non-closest scorer, making `STEAL_UNLOCK_STREAK=3`, streak milestones and the fire highlight effectively unreachable. Now the streak (and its Steal unlock, milestone counter and best_streak) survives whenever the player's accuracy was positive (`base_score > 0`); round **points** are still voided. Inaccurate guesses still break the streak (and already did so during scoring).

## Tests
- #1720: fast-but-wrong gets no intro bonus / speed-bonus count; fast-and-correct gets +5; ranking among the qualified only (a faster wrong tap can't push a correct guess down a tier); order-independent; post-cutoff correct gets nothing.
- #1721: accurate non-closest keeps streak + Steal + milestone + best_streak while points are zeroed; inaccurate non-closest still breaks the streak.
- Full suite green (1327 passed, 2 skipped); ruff format/check + configured mypy clean.

Fixes #1720, #1721

🤖 Generated with [Claude Code](https://claude.com/claude-code)