### PR TITLE
fix(stats): #1762 deepcopy snapshot before executor dump (no dict-changed-size race)

### DIFF
--- a/custom_components/beatify/services/stats.py
+++ b/custom_components/beatify/services/stats.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import copy
 import json
 import logging
 import os
@@ -149,15 +150,22 @@ class StatsService:
                     self._stats_file.parent.mkdir, 0o755, True, True
                 )
 
-                # Snapshot the stats dict, then do the (potentially expensive)
-                # json.dumps AND the file write together in the executor thread
-                # so neither blocks the event loop. With unbounded history the
-                # serialization alone could stall the loop on every save
-                # (#1402). The snapshot is a shallow copy taken on the loop
-                # thread so the executor serializes a stable view.
+                # Take a REAL snapshot on the loop thread before dispatching to
+                # the executor. json.dumps runs in the executor while the loop
+                # keeps mutating self._stats (record_song_result mutates
+                # _stats["songs"] in place, record_game appends/deletes games),
+                # so handing over a live reference would let json.dumps iterate
+                # a dict that changes size — raising RuntimeError mid-serialize
+                # and leaving the batch unwritten (#1762, regression from
+                # #1708's debounce which makes the collision more likely). A
+                # deepcopy is bounded (MAX_DETAILED_GAMES games) and costs a few
+                # ms on the loop thread, cheaply buying the executor a stable,
+                # immutable view. The expensive json.dumps AND the file write
+                # still run together in the executor so neither blocks the loop
+                # (#1402).
                 stats_path = self._stats_file
                 temp_path = stats_path.with_suffix(".json.tmp")
-                snapshot = self._stats
+                snapshot = copy.deepcopy(self._stats)
 
                 def _serialize_and_write() -> None:
                     content = json.dumps(snapshot, indent=2)
@@ -169,6 +177,15 @@ class StatsService:
                 _LOGGER.debug("Stats saved to %s", self._stats_file)
             except OSError as err:
                 _LOGGER.error("Failed to save stats: %s", err)
+            except (RuntimeError, ValueError) as err:
+                # Defense-in-depth: the deepcopy above should already prevent a
+                # "dictionary changed size during iteration" RuntimeError (and
+                # any serialization ValueError), but if one still slips through
+                # the batch is not on disk. Flag dirty so the done-callback path
+                # (_handle_save_done) retries rather than silently dropping it
+                # (#1762).
+                _LOGGER.error("Failed to serialize stats, will retry: %s", err)
+                self._save_dirty = True
 
     def schedule_save(self) -> None:
         """

--- a/tests/unit/test_stats.py
+++ b/tests/unit/test_stats.py
@@ -765,6 +765,116 @@ class TestScheduleSaveDirtyFlag:
         assert save_count >= 2
 
 
+# ---------------------------------------------------------------------------
+# TestSaveSnapshotIsolation — save() must serialize a real snapshot, not a live
+# reference, so concurrent loop mutations can't crash json.dumps (#1762)
+# ---------------------------------------------------------------------------
+
+
+class TestSaveSnapshotIsolation:
+    @pytest.mark.asyncio
+    async def test_concurrent_mutation_during_dump_does_not_lose_batch(self, tmp_path):
+        """A mutation of self._stats while json.dumps runs must NOT raise
+        'dictionary changed size during iteration' nor lose the batch — the
+        executor must operate on an immutable deepcopy taken on the loop thread
+        (#1762)."""
+        import json as _json
+
+        stats_path = tmp_path / "beatify" / "stats.json"
+        service = _make_real_fs_service(stats_path)
+
+        # Seed a realistic store with per-song entries (the dict record_song_result
+        # mutates in place) plus a couple of games.
+        for i in range(5):
+            service._stats["songs"][f"song-{i}"] = {
+                "times_played": i,
+                "correct_guesses": i,
+                "total_guesses": i,
+            }
+        service._stats["games"] = [{"id": f"g{i}"} for i in range(3)]
+        service._stats["all_time"]["games_played"] = 3
+
+        real_dumps = _json.dumps
+
+        def _mutating_dumps(obj, *args, **kwargs):
+            # Simulate the event loop mutating the LIVE store while the executor
+            # serializes: record_song_result adds/updates song keys, record_game
+            # appends/pops games. If ``obj`` were a live reference to
+            # self._stats this iteration would raise RuntimeError.
+            service._stats["songs"]["song-late"] = {"times_played": 99}
+            del service._stats["songs"]["song-0"]
+            service._stats["games"].append({"id": "g-late"})
+            return real_dumps(obj, *args, **kwargs)
+
+        with patch(
+            "custom_components.beatify.services.stats.json.dumps",
+            side_effect=_mutating_dumps,
+        ):
+            # Must not raise despite the concurrent mutation.
+            await service.save()
+
+        # The batch was written (not silently dropped) and reflects the snapshot
+        # taken BEFORE the mid-dump mutation.
+        assert stats_path.exists()
+        data = _json.loads(stats_path.read_text())
+        assert "song-late" not in data["songs"]
+        assert "song-0" in data["songs"]
+        assert len(data["games"]) == 3
+        # A clean save leaves no retry pending.
+        assert service._save_dirty is False
+
+    @pytest.mark.asyncio
+    async def test_snapshot_is_deepcopy_not_reference(self, tmp_path):
+        """The object handed to json.dumps must be a distinct deepcopy, so
+        nested containers aren't shared with the live store (#1762)."""
+        import json as _json
+
+        stats_path = tmp_path / "beatify" / "stats.json"
+        service = _make_real_fs_service(stats_path)
+        service._stats["songs"]["s1"] = {"times_played": 1}
+
+        captured: dict = {}
+        real_dumps = _json.dumps
+
+        def _capturing_dumps(obj, *args, **kwargs):
+            captured["obj"] = obj
+            return real_dumps(obj, *args, **kwargs)
+
+        with patch(
+            "custom_components.beatify.services.stats.json.dumps",
+            side_effect=_capturing_dumps,
+        ):
+            await service.save()
+
+        snap = captured["obj"]
+        assert snap is not service._stats
+        assert snap["songs"] is not service._stats["songs"]
+        assert snap["songs"]["s1"] is not service._stats["songs"]["s1"]
+        # Mutating the live store after the snapshot must not touch the copy.
+        service._stats["songs"]["s1"]["times_played"] = 999
+        assert snap["songs"]["s1"]["times_played"] == 1
+
+    @pytest.mark.asyncio
+    async def test_serialize_runtimeerror_sets_dirty_for_retry(self, tmp_path):
+        """Defense-in-depth: if serialization still raises RuntimeError/ValueError,
+        save() must not propagate and must flag _save_dirty so the done-callback
+        retries instead of dropping the batch (#1762)."""
+        stats_path = tmp_path / "beatify" / "stats.json"
+        service = _make_real_fs_service(stats_path)
+
+        def _boom(*_args, **_kwargs):
+            raise RuntimeError("dictionary changed size during iteration")
+
+        with patch(
+            "custom_components.beatify.services.stats.json.dumps",
+            side_effect=_boom,
+        ):
+            # Must swallow the error, not raise.
+            await service.save()
+
+        assert service._save_dirty is True
+
+
 class TestScheduleSaveDebounce:
     """#1708: per-round saves are debounced into a single write; game end and
     unload flush explicitly."""


### PR DESCRIPTION
Fixes #1762

## Problem
`save()` handed a **live reference** to `self._stats` to the executor for `json.dumps` while the event loop kept mutating it — `record_song_result` mutates `_stats["songs"]` in place, `record_game` appends/deletes games. A mutation mid-serialization raises `RuntimeError: dictionary changed size during iteration`, which the `except OSError` never caught, so the batch stayed unwritten. The inline comment claimed a shallow copy, but none was made. The #1708 debounce (write fires ~30s later, near the next round's mutation burst) made the collision more likely. Regression surfaced by Fable re-review after the 2026-07-05 fix wave.

## Fix
- Take a **real snapshot** on the loop thread before dispatch: `snapshot = copy.deepcopy(self._stats)`. Bounded at `MAX_DETAILED_GAMES` (500) games → a few ms on the loop, cheaply buying the executor a stable, immutable view. The expensive `json.dumps` + file write still run together in the executor.
- **Defense-in-depth:** also catch `RuntimeError`/`ValueError` in `save()`, log, and set `_save_dirty = True` so `_handle_save_done` retries instead of silently dropping the batch.
- Corrected the misleading "shallow copy" comment.

## Tests
New `TestSaveSnapshotIsolation`:
- `test_concurrent_mutation_during_dump_does_not_lose_batch` — mutating the live store while `json.dumps` runs no longer raises and the pre-mutation batch is written.
- `test_snapshot_is_deepcopy_not_reference` — object passed to `json.dumps` is a distinct deepcopy (nested containers not shared).
- `test_serialize_runtimeerror_sets_dirty_for_retry` — a serialization `RuntimeError` is swallowed and flags `_save_dirty`.

`python -m pytest tests/ -q` → 1330 passed, 2 skipped. `ruff format`/`check` clean; mypy introduces no new errors (2 pre-existing on `stats.py:889-890`, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)