### PR TITLE
fix(sudden-death): #1749 winner banner matches survival leaderboard

### DIFF
--- a/custom_components/beatify/game/state_serialization.py
+++ b/custom_components/beatify/game/state_serialization.py
@@ -141,15 +141,23 @@ class StateSerializationMixin:
         """
         if not self.players:
             return [], 0
-        # Issue #827: in Sudden Death the winner is the last player standing,
-        # regardless of cumulative score — provided the game actually ran to its
-        # conclusion (at least one elimination and exactly one survivor). Falls
-        # through to the score-based winner when Sudden Death is off or the game
-        # ended without resolving (e.g. force-ended early).
-        if self.sudden_death_mode:
+        # Issue #827 / #1749: once Sudden Death has claimed at least one player,
+        # the finish order is survival-first — exactly the order
+        # ``get_final_leaderboard`` renders. The winner must therefore be the
+        # top-scoring *survivor*, never a late-eliminated high scorer, otherwise
+        # the END-screen banner contradicts the leaderboard below it (#1749: a
+        # game ending by round exhaustion with >=2 survivors previously fell
+        # back to max cumulative score across *all* players, crowning someone
+        # the leaderboard ranks below the cut-line). Falls through to the plain
+        # score winner only when Sudden Death is off or the game ended without
+        # any elimination (e.g. force-ended early) — or, defensively, when no
+        # survivor remains, matching the pre-#1749 fallback.
+        if self.sudden_death_mode and any(p.eliminated for p in self.players.values()):
             survivors = [p for p in self.players.values() if not p.eliminated]
-            if len(survivors) == 1 and any(p.eliminated for p in self.players.values()):
-                return survivors, survivors[0].score
+            if survivors:
+                top_score = max(p.score for p in survivors)
+                winners = [p for p in survivors if p.score == top_score]
+                return winners, top_score
         top_score = max(p.score for p in self.players.values())
         winners = [p for p in self.players.values() if p.score == top_score]
         return winners, top_score

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -2769,3 +2769,42 @@ class TestSuddenDeathWinner:
         state.get_player("Bob").score = 30
         lb = state.get_final_leaderboard()
         assert [e["name"] for e in lb] == ["Bob", "Alice"]
+
+    def test_winner_is_top_survivor_with_multiple_survivors(self):
+        """#1749: SD ends by round exhaustion with >=2 survivors and a
+        late-eliminated high scorer → the winner is the top-scoring *survivor*,
+        matching the leaderboard's #1, NOT the higher-scoring eliminated player.
+        """
+        state = self._game()
+        # Bob was early-dominant but got eliminated last with the highest total.
+        state.get_player("Bob").score = 99
+        state.get_player("Bob").eliminated = True
+        state.get_player("Bob").eliminated_round = 4
+        # Two survivors remain (game ran out of rounds); Alice tops Carol.
+        state.get_player("Alice").score = 40  # survivor, top score among survivors
+        state.get_player("Carol").score = 25  # survivor
+
+        winners, top = state.compute_winners()
+        assert [w.name for w in winners] == ["Alice"]
+        assert top == 40
+        # The banner must agree with the leaderboard's #1 (deckungsgleich).
+        lb = state.get_final_leaderboard()
+        assert lb[0]["name"] == "Alice"
+        assert winners[0].name == lb[0]["name"]
+        # The high-scoring eliminated player is NOT the winner and sits below.
+        assert "Bob" not in {w.name for w in winners}
+        assert lb[-1]["name"] == "Bob"
+
+    def test_winner_ties_among_survivors(self):
+        """#1749: two survivors sharing the top survivor score → both win,
+        the eliminated high scorer is still excluded."""
+        state = self._game()
+        state.get_player("Bob").score = 200
+        state.get_player("Bob").eliminated = True
+        state.get_player("Bob").eliminated_round = 3
+        state.get_player("Alice").score = 30  # survivor
+        state.get_player("Carol").score = 30  # survivor, tie with Alice
+
+        winners, top = state.compute_winners()
+        assert {w.name for w in winners} == {"Alice", "Carol"}
+        assert top == 30


### PR DESCRIPTION
Fixes #1749.

## Problem
`compute_winners` (`game/state_serialization.py`) only applied Sudden-Death survival logic when exactly **one** survivor remained; otherwise it fell back to max cumulative score across **all** players (including eliminated). `get_final_leaderboard` (`game/state_leaderboard.py`), however, switches to survival-first order as soon as **any** elimination happens.

So a SD game ending by round exhaustion with >=2 survivors — where an early-dominant player was eliminated late holding the highest total — showed that eliminated player as "winner" on the END screen while the leaderboard ranked them below the cut-line. Contradictory on one screen.

## Fix
Once Sudden Death has claimed at least one player, restrict `compute_winners` to survivors (max score among non-eliminated), matching the leaderboard's survival-first #1.

- Non-Sudden-Death behavior unchanged.
- SD with no elimination (e.g. force-ended early) still uses the plain score winner.
- Defensively falls back to the plain score winner when no survivor remains.

## Tests
- `test_winner_is_top_survivor_with_multiple_survivors` — SD end with >=2 survivors + late-eliminated high scorer: winner == leaderboard #1 (a survivor), not the eliminated high scorer.
- `test_winner_ties_among_survivors` — two survivors sharing the top survivor score both win; eliminated high scorer excluded.
- Existing SD single-survivor / score-fallback / non-SD tests still green.

Full suite: 1329 passed, 2 skipped. `ruff format`/`check` + project `mypy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)