### PR TITLE
fix(round-end): #1753/#1754 shared game-end gate across all 3 terminal paths + release claim on failure

### DIFF
--- a/custom_components/beatify/__init__.py
+++ b/custom_components/beatify/__init__.py
@@ -7,6 +7,7 @@ to play music guessing games.
 
 from __future__ import annotations
 
+import functools
 import json
 import logging
 from pathlib import Path
@@ -63,6 +64,7 @@ from .server.views import (
     UsageView,
 )
 from .server.websocket import BeatifyWebSocketHandler
+from .server.ws_handlers.admin import _finalize_and_end
 from .services.media_player import async_get_media_players
 from .services.stats import StatsService
 
@@ -155,6 +157,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     # Set up round end callback for timer expiry (Story 4.5)
     game_state.set_round_end_callback(ws_handler.broadcast_state)
+
+    # #1753: wire the terminal game-end one-shot so the unattended REVEAL
+    # auto-advance final round records stats + runs the podium ceremony through
+    # the same claim as the admin sockets (no double record / double podium TTS).
+    game_state.set_game_end_callback(
+        functools.partial(_finalize_and_end, ws_handler, game_state)
+    )
 
     # Set up metadata update callback for fast transitions (Issue #42)
     game_state.set_metadata_update_callback(ws_handler.broadcast_metadata_update)

--- a/custom_components/beatify/game/state.py
+++ b/custom_components/beatify/game/state.py
@@ -330,6 +330,14 @@ class GameState(
         # Callback for round end (Story 4.5)
         self._on_round_end: Callable[[], Awaitable[None]] | None = None
 
+        # #1753: callback for the terminal game-end. Wired by the WS handler to
+        # `_finalize_and_end` so the unattended REVEAL auto-advance final round
+        # runs the SAME one-shot (claim + record_game + advance_to_end) as the
+        # two admin sockets — recording stats + firing the podium TTS exactly
+        # once. When unset (REST/service path or tests) the auto-advance falls
+        # back to `advance_to_end` directly.
+        self._on_game_end: Callable[[], Awaitable[None]] | None = None
+
         # Volume control (Story 6.4)
         self.volume_level: float = 0.5  # Default 50%
 
@@ -554,6 +562,22 @@ class GameState(
 
         """
         self._on_round_end = callback
+
+    def set_game_end_callback(self, callback: Callable[[], Awaitable[None]]) -> None:
+        """Set the terminal game-end callback (#1753).
+
+        The WS handler wires this to ``_finalize_and_end`` so the unattended
+        REVEAL auto-advance final round records stats + runs the podium ceremony
+        through the SAME one-shot claim as the two admin sockets, instead of
+        calling ``advance_to_end`` directly (which skipped ``record_game`` and
+        the game-end claim).
+
+        Args:
+            callback: Async function running the finalize + record + end-ceremony
+                one-shot for the current game.
+
+        """
+        self._on_game_end = callback
 
     def set_metadata_update_callback(
         self, callback: Callable[[dict[str, Any]], Awaitable[None]]

--- a/custom_components/beatify/game/state_auto_advance.py
+++ b/custom_components/beatify/game/state_auto_advance.py
@@ -54,11 +54,18 @@ The mixin relies on attributes / methods the host class owns and that live on
 * ``self.start_round`` — the next-round trigger the auto-advance fires.
 * ``self._on_round_end`` — the async WebSocket broadcast callback mirrored after
   the auto-advance ``start_round`` so the new PLAYING state reaches clients.
+* ``self._on_game_end`` — the terminal game-end callback (#1753), wired by the
+  WS handler to ``_finalize_and_end`` (claim + record_game + advance_to_end).
+  The auto-advance final round routes through it so the unattended end records
+  stats + fires the podium TTS through the SAME one-shot claim as the two admin
+  sockets. Falls back to ``self.advance_to_end`` when unset (REST/service path
+  or tests).
 * ``self.advance_to_end`` — the terminal game-end ceremony (party-light
   celebration + winner/podium TTS + END transition; lives on
   ``RevealTransitionMixin``). Run when the auto-advance carries the final round
-  and ``start_round`` exhausts the playlist (#1360), so the unattended end fires
-  the same ceremony + broadcast as the manual ``admin_next_round`` game-end.
+  and ``start_round`` exhausts the playlist (#1360) and no ``_on_game_end`` is
+  wired, so the unattended end still fires the same ceremony + broadcast as the
+  manual ``admin_next_round`` game-end.
 
 It carries no state of its own. ``GamePhase`` is imported lazily inside the
 methods that need it (``# noqa: PLC0415``) to avoid a top-level circular import
@@ -168,16 +175,28 @@ class RevealAutoAdvanceMixin:
             # without intervention here the game ends with: no party-light
             # celebration, no announce_winner/announce_podium TTS, and — because
             # success is False — no broadcast, leaving every client frozen on
-            # REVEAL. Run the proper terminal ceremony so the unattended end
-            # mirrors the manual end. advance_to_end() re-sets END idempotently
-            # (a same-phase write), celebrates the lights and fires the winner /
-            # podium announcements; the broadcast below then pushes END.
+            # REVEAL.
+            #
+            # #1753: route through the shared game-end gate (_on_game_end =
+            # ws_handler._finalize_and_end) rather than calling advance_to_end()
+            # directly. The old direct call (a) never recorded stats on the
+            # unattended final round and (b) never claimed the game_id, so a
+            # concurrently-parked admin_next_round could still win the claim and
+            # fire a SECOND record_game + advance_to_end (double podium TTS).
+            # The gate claims once, records stats, and runs advance_to_end (which
+            # re-sets END idempotently, celebrates the lights, announces the
+            # winner/podium); whichever terminal path claims first wins. When no
+            # handler is wired (REST/service path or tests) fall back to the bare
+            # ceremony so the unattended end still fires.
             if not success and self.phase == GamePhase.END:
                 _LOGGER.info(
                     "REVEAL auto-advance reached the final round — running "
                     "game-end ceremony"
                 )
-                await self.advance_to_end()
+                if self._on_game_end is not None:
+                    await self._on_game_end()
+                else:
+                    await self.advance_to_end()
                 success = True
             # start_round() only fires sync state-callbacks via
             # _notify_state_callbacks; the async WebSocket broadcast

--- a/custom_components/beatify/server/game_views.py
+++ b/custom_components/beatify/server/game_views.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import functools
 import json
 import logging
 from pathlib import Path
@@ -38,6 +39,7 @@ from custom_components.beatify.server.companion_auth import is_authorized_http
 from custom_components.beatify.server.serializers import (
     build_state_message,
 )
+from custom_components.beatify.server.ws_handlers.admin import _finalize_and_end
 from custom_components.beatify.services.media_player import (
     async_get_native_twin_remap,
     get_platform_capabilities,
@@ -644,6 +646,12 @@ class StartGameplayView(BeatifyAdminView):
         ws_handler = data.get("ws_handler")
         if ws_handler:
             game_state.set_round_end_callback(ws_handler.broadcast_state)
+            # #1753: wire the terminal game-end one-shot so the unattended REVEAL
+            # auto-advance final round records stats + runs the podium ceremony
+            # through the same claim as the admin sockets.
+            game_state.set_game_end_callback(
+                functools.partial(_finalize_and_end, ws_handler, game_state)
+            )
             # Set metadata update callback for fast transitions (Issue #42)
             game_state.set_metadata_update_callback(
                 ws_handler.broadcast_metadata_update

--- a/custom_components/beatify/server/websocket.py
+++ b/custom_components/beatify/server/websocket.py
@@ -136,18 +136,36 @@ class BeatifyWebSocketHandler:
     def _claim_game_end(self, game_id: str | None) -> bool:
         """Claim the one-shot game-end for ``game_id`` (#1702).
 
-        Returns ``True`` exactly once per game — for the first admin socket to
-        reach the terminal branch — and ``False`` for any concurrent or repeat
+        Returns ``True`` exactly once per game — for the first terminal path to
+        reach the game-end (either admin socket or the unattended REVEAL
+        auto-advance, #1753) — and ``False`` for any concurrent or repeat
         caller, so ``record_game`` (double stats) and ``advance_to_end`` (double
         podium TTS) run at most once per game. The check + insert has no
-        ``await`` between them, so two admin sockets in the same tick can't both
-        win. ``rematch_game`` / ``create_game`` mint a fresh ``game_id``, so a
-        later game is claimable again.
+        ``await`` between them, so two callers in the same tick can't both win.
+        ``rematch_game`` / ``create_game`` mint a fresh ``game_id``, so a later
+        game is claimable again.
+
+        #1754: only one game is ever active per handler, so the claim set is
+        pruned to just the current ``game_id`` on each successful claim — it can
+        never grow unbounded across a long-lived handler's many games.
         """
         if game_id is None or game_id in self._recorded_game_ids:
             return False
-        self._recorded_game_ids.add(game_id)
+        # Bound the set: drop any stale predecessor id, keep only this claim.
+        self._recorded_game_ids = {game_id}
         return True
+
+    def _release_game_end(self, game_id: str | None) -> None:
+        """Release a claimed game-end so the terminal sequence can be retried (#1754).
+
+        ``_finalize_and_end`` claims BEFORE its side effects (``record_game``
+        storage I/O + ``advance_to_end``). If either raises, the claim would
+        otherwise be burned: every retry hits "already claimed" and returns
+        without advancing, stranding the game in REVEAL/PAUSED. Discarding the
+        id on failure lets the next tap re-run the end sequence.
+        """
+        if game_id is not None:
+            self._recorded_game_ids.discard(game_id)
 
     # ------------------------------------------------------------------
     # Rate limiting

--- a/custom_components/beatify/server/ws_handlers/admin.py
+++ b/custom_components/beatify/server/ws_handlers/admin.py
@@ -35,26 +35,41 @@ _LOGGER = logging.getLogger(__name__)
 async def _finalize_and_end(
     handler: BeatifyWebSocketHandler, game_state: GameState
 ) -> None:
-    """Record game stats + run the game-end ceremony exactly once (#1702).
+    """Record game stats + run the game-end ceremony exactly once (#1702/#1753).
 
-    The final-round terminal path is reachable from two admin-capable sockets
-    (participant WS + spectator ``_admin_ws``) at the same time. Gating on the
-    handler's one-shot claim keyed by ``game_id`` makes ``finalize_game`` /
-    ``record_game`` (double stats) and ``advance_to_end`` (double podium TTS)
-    fire at most once per game. The loser skips straight to the broadcast its
-    caller performs.
+    The final-round terminal path is reachable from THREE places at the same
+    time: the two admin-capable sockets (participant WS + spectator
+    ``_admin_ws``) driving ``next_round``/``end_game``, and the unattended
+    REVEAL auto-advance carrying the final round (#1753, wired via
+    ``GameState.set_game_end_callback``). Gating on the handler's one-shot claim
+    keyed by ``game_id`` makes ``finalize_game`` / ``record_game`` (double
+    stats) and ``advance_to_end`` (double podium TTS) fire at most once per
+    game. The loser skips straight to the broadcast its caller performs.
+
+    #1754: the claim is taken BEFORE the side effects (``record_game`` storage
+    I/O + ``advance_to_end``). If either raises, the claim is released so a
+    retry can re-run the terminal sequence instead of stranding the game in
+    REVEAL/PAUSED — then the error propagates to the caller.
     """
     if not handler._claim_game_end(game_state.game_id):
         _LOGGER.debug("Game-end already claimed for %s — skipping", game_state.game_id)
         return
 
-    stats_service = handler.hass.data.get(DOMAIN, {}).get("stats")
-    if stats_service:
-        game_summary = game_state.finalize_game()
-        await stats_service.record_game(game_summary, difficulty=game_state.difficulty)
-        _LOGGER.debug("Game stats recorded")
+    try:
+        stats_service = handler.hass.data.get(DOMAIN, {}).get("stats")
+        if stats_service:
+            game_summary = game_state.finalize_game()
+            await stats_service.record_game(
+                game_summary, difficulty=game_state.difficulty
+            )
+            _LOGGER.debug("Game stats recorded")
 
-    await game_state.advance_to_end()
+        await game_state.advance_to_end()
+    except Exception:
+        # #1754: release the claim so a retry re-runs the end sequence rather
+        # than hitting "already claimed" and stranding the game in REVEAL.
+        handler._release_game_end(game_state.game_id)
+        raise
 
 
 async def handle_admin_connect(

--- a/tests/unit/test_round_advance_serialization.py
+++ b/tests/unit/test_round_advance_serialization.py
@@ -16,10 +16,12 @@ multi-agent review (2026-07-05):
 from __future__ import annotations
 
 import asyncio
+import functools
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+import custom_components.beatify.game.state_auto_advance as auto_advance_mod
 from custom_components.beatify.const import DOMAIN
 from custom_components.beatify.game.state import GamePhase
 from custom_components.beatify.server.ws_handlers import (
@@ -27,6 +29,7 @@ from custom_components.beatify.server.ws_handlers import (
     admin_next_round,
     admin_rematch_game,
 )
+from custom_components.beatify.server.ws_handlers.admin import _finalize_and_end
 from tests.conftest import make_game_state
 from tests.unit.test_websocket import _make_handler_and_game, _make_ws
 
@@ -212,3 +215,138 @@ class TestAdminDisconnectTaskCleanup:
         # rematch must cancel any pending admin-disconnect pause task so the
         # grace timer can't pause the brand-new lobby.
         handler.cleanup_game_tasks.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# #1753 — unattended REVEAL auto-advance final round shares the game-end gate
+# ---------------------------------------------------------------------------
+
+
+def _wire_game_end(handler, game_state) -> None:
+    """Wire the terminal game-end callback exactly like setup does."""
+    game_state.set_game_end_callback(
+        functools.partial(_finalize_and_end, handler, game_state)
+    )
+
+
+def _stub_terminal_game(handler, game_state) -> AsyncMock:
+    """Common stubs for the final-round terminal path; returns record_game mock."""
+    game_state.resolve_title_artist_if_pending = AsyncMock()
+    game_state.advance_to_end = AsyncMock()
+    game_state.finalize_game = MagicMock(return_value={})
+    record_game = AsyncMock()
+    stats = MagicMock()
+    stats.record_game = record_game
+    handler.hass.data[DOMAIN]["stats"] = stats
+    handler.broadcast_state = AsyncMock()
+    return record_game
+
+
+class TestAutoAdvanceFinalRoundRecordsOnce:
+    async def test_unattended_final_round_records_stats_exactly_once(self, monkeypatch):
+        """#1753(a): the auto-advance final round (admin walked away) must record
+        stats + run the game-end ceremony — previously it called advance_to_end
+        directly and never recorded."""
+        handler, game_state, _ws = _make_handler_and_game()
+        record_game = _stub_terminal_game(handler, game_state)
+        _wire_game_end(handler, game_state)
+
+        # Skip the poll delays; break out of the wait loop on the first poll.
+        monkeypatch.setattr(auto_advance_mod.asyncio, "sleep", AsyncMock())
+        game_state._song_finished = MagicMock(return_value=True)
+        game_state._on_round_end = AsyncMock()
+
+        async def _exhaust() -> bool:
+            # Playlist exhausted: start_round flips to END and returns False.
+            game_state.phase = GamePhase.END
+            return False
+
+        game_state.start_round = AsyncMock(side_effect=_exhaust)
+        game_state.phase = GamePhase.REVEAL
+
+        await game_state._reveal_auto_advance(0)
+
+        record_game.assert_awaited_once()
+        game_state.advance_to_end.assert_awaited_once()
+        # The game-end was claimed by the auto-advance path.
+        assert game_state.game_id in handler._recorded_game_ids
+
+    async def test_auto_advance_and_parallel_next_round_end_once(self, monkeypatch):
+        """#1753(b): a concurrently-parked admin_next_round and the auto-advance
+        both reaching the final round record + advance exactly once."""
+        handler, game_state, ws = _make_handler_and_game()
+        record_game = _stub_terminal_game(handler, game_state)
+        game_state.last_round = True
+        _wire_game_end(handler, game_state)
+
+        monkeypatch.setattr(auto_advance_mod.asyncio, "sleep", AsyncMock())
+        game_state._song_finished = MagicMock(return_value=True)
+        game_state._on_round_end = AsyncMock()
+
+        async def _exhaust() -> bool:
+            game_state.phase = GamePhase.END
+            return False
+
+        game_state.start_round = AsyncMock(side_effect=_exhaust)
+        game_state.phase = GamePhase.REVEAL
+
+        await asyncio.gather(
+            game_state._reveal_auto_advance(0),
+            admin_next_round(handler, ws, {"action": "next_round"}, game_state),
+        )
+
+        record_game.assert_awaited_once()
+        game_state.advance_to_end.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# #1754 — a record_game failure releases the claim so a retry ends the game
+# ---------------------------------------------------------------------------
+
+
+class TestGameEndClaimReleasedOnFailure:
+    async def test_record_failure_releases_claim_then_retry_ends_game(self):
+        """#1754: if record_game raises, the burned claim would strand the game
+        in REVEAL forever. The claim is released so the next tap re-runs the
+        terminal sequence and the game ends."""
+        handler, game_state, ws = _make_handler_and_game()
+        game_state.phase = GamePhase.REVEAL
+        game_state.last_round = True
+        game_state.resolve_title_artist_if_pending = AsyncMock()
+        game_state.advance_to_end = AsyncMock()
+        game_state.finalize_game = MagicMock(return_value={})
+        handler.broadcast_state = AsyncMock()
+
+        # First record_game raises (storage I/O), second succeeds.
+        record_game = AsyncMock(side_effect=[RuntimeError("storage down"), None])
+        stats = MagicMock()
+        stats.record_game = record_game
+        handler.hass.data[DOMAIN]["stats"] = stats
+
+        # First tap: record_game raises → claim released, error propagates.
+        with pytest.raises(RuntimeError):
+            await admin_next_round(handler, ws, {"action": "next_round"}, game_state)
+
+        # The claim was released — not left burned.
+        assert game_state.game_id not in handler._recorded_game_ids
+        game_state.advance_to_end.assert_not_awaited()
+
+        # Retry: record_game succeeds → the game finally ends.
+        await admin_next_round(handler, ws, {"action": "next_round"}, game_state)
+
+        assert record_game.await_count == 2
+        game_state.advance_to_end.assert_awaited_once()
+        assert game_state.game_id in handler._recorded_game_ids
+
+    async def test_claim_set_stays_bounded_across_games(self):
+        """#1754 minor: the claim set never grows unbounded — a fresh game_id
+        prunes the predecessor's entry."""
+        handler, game_state, _ws = _make_handler_and_game()
+
+        assert handler._claim_game_end("game-1") is True
+        assert handler._claim_game_end("game-2") is True
+        # Only the current claim is retained.
+        assert handler._recorded_game_ids == {"game-2"}
+        # The predecessor is claimable again (it's a different, later game).
+        assert handler._claim_game_end("game-1") is True
+        assert handler._recorded_game_ids == {"game-1"}


### PR DESCRIPTION
Fixes #1753, #1754

Two coupled round-end regressions surfaced by the Fable round-2 re-review of #1742 (#1702). One coherent fix: a single game-end one-shot shared by all three terminal paths, plus claim-release on failure.

## #1753 — auto-advance final round bypassed the claim + never recorded stats
`_reveal_auto_advance` called `advance_to_end()` directly on the unattended final round, so it:
- (a) **never recorded stats** — the exact admin-walked-away scenario, and
- (b) **never claimed the game_id** — a concurrently-parked `admin_next_round` could still win the claim and fire a second `record_game` + `advance_to_end` (double podium/winner TTS).

Fix: new `GameState._on_game_end` async callback (mirrors `_on_round_end`), wired by both handler-setup sites (`__init__.py`, `game_views.py`) to `_finalize_and_end`. The auto-advance terminal branch now routes through it, so **all three terminal paths (2 WS handlers + auto-advance) share one `game_id`-keyed one-shot** — the unattended end records stats + runs the ceremony exactly once. Falls back to `advance_to_end` when unwired (REST/service path or tests).

## #1754 — the claim was consumed before its side effects
`_finalize_and_end` claimed the `game_id` **before** `record_game` (storage I/O) + `advance_to_end`. If either raised, the claim was burned: every retry hit "already claimed" and returned without advancing, stranding the game in REVEAL/PAUSED (only escape: force-reset).

Fix: wrap the body in try/except and **release the claim** (`_release_game_end` → discard) on failure before re-raising, so a retry re-runs the terminal sequence. Also **bound `_recorded_game_ids`** to the current `game_id` (prune on each claim) so it can't grow unbounded.

## Tests
New in `test_round_advance_serialization.py`:
- unattended auto-advance final round records stats exactly once (#1753a)
- auto-advance + parallel `next_round` → one `record_game`/`advance_to_end` (#1753b)
- `record_game` failure releases the claim → retry ends the game (#1754)
- claim set stays bounded across games (#1754 minor)

Existing #1697/#1698/#1702/#1703 serialization tests stay green. Full suite: 1331 passed, 2 skipped. ruff format+check clean, gated mypy clean.

Note: #1754 will be closed manually after merge (GitHub only auto-closes the first "Fixes").

🤖 Generated with [Claude Code](https://claude.com/claude-code)