### PR TITLE
fix(playlists): drop wrong Apple Music URIs on Polish playlists (#1777)

### DIFF
--- a/custom_components/beatify/playlists/community/polish-all-time-hits.json
+++ b/custom_components/beatify/playlists/community/polish-all-time-hits.json
@@ -1,6 +1,6 @@
 {
   "name": "Polskie przeboje wszech czasów",
-  "version": "0.2",
+  "version": "0.3",
   "tags": [
     "polish",
     "pop",
@@ -52,19 +52,19 @@
       "fun_fact_es": "Dziwna Wiosna es un artista polaco, y 'Światła miasta' (2026) aparece en esta seleccion de grandes exitos polacos de todos los tiempos.",
       "fun_fact_fr": "Dziwna Wiosna est un artiste polonais, et 'Światła miasta' (2026) figure dans cette selection de succes polonais de tous les temps.",
       "fun_fact_nl": "Dziwna Wiosna is een Poolse artiest, en 'Światła miasta' (2026) staat in deze verzameling Poolse hits aller tijden.",
-      "uri_apple_music": "applemusic://track/1715321071",
+      "uri_apple_music": null,
       "uri_youtube_music": "https://music.youtube.com/watch?v=op2cyrTP-NE",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/4058537141",
       "isrc": "PLC592600073",
       "uri_apple_music_by_region": {
-        "us": "applemusic://track/1715321071",
-        "de": "applemusic://track/1715321071",
-        "gb": "applemusic://track/1715321071",
-        "fr": "applemusic://track/1715321071",
-        "es": "applemusic://track/1715321071",
-        "nl": "applemusic://track/1715321071",
-        "it": "applemusic://track/1715321071"
+        "us": null,
+        "de": null,
+        "gb": null,
+        "fr": null,
+        "es": null,
+        "nl": null,
+        "it": null
       }
     },
     {
@@ -592,19 +592,19 @@
       "fun_fact_es": "Szymon Wydra es un artista polaco, y 'Wciąż mamy moc' (2026) aparece en esta seleccion de grandes exitos polacos de todos los tiempos.",
       "fun_fact_fr": "Szymon Wydra est un artiste polonais, et 'Wciąż mamy moc' (2026) figure dans cette selection de succes polonais de tous les temps.",
       "fun_fact_nl": "Szymon Wydra is een Poolse artiest, en 'Wciąż mamy moc' (2026) staat in deze verzameling Poolse hits aller tijden.",
-      "uri_apple_music": "applemusic://track/1443770343",
+      "uri_apple_music": null,
       "uri_youtube_music": "https://music.youtube.com/watch?v=SpBWPZN1uCg",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3981328981",
       "isrc": "QZWFP2603209",
       "uri_apple_music_by_region": {
-        "us": "applemusic://track/1443770343",
-        "de": "applemusic://track/1443798438",
-        "gb": "applemusic://track/1443770343",
-        "fr": "applemusic://track/1443798438",
-        "es": "applemusic://track/1443798438",
-        "nl": "applemusic://track/1443798438",
-        "it": "applemusic://track/1443798438"
+        "us": null,
+        "de": null,
+        "gb": null,
+        "fr": null,
+        "es": null,
+        "nl": null,
+        "it": null
       }
     },
     {

--- a/custom_components/beatify/playlists/community/polish-rock.json
+++ b/custom_components/beatify/playlists/community/polish-rock.json
@@ -1,6 +1,6 @@
 {
   "name": "Polski Rock",
-  "version": "0.3",
+  "version": "0.4",
   "tags": [
     "polish",
     "rock"
@@ -43,15 +43,15 @@
       "artist": "Dziwna Wiosna",
       "title": "Światła miasta",
       "isrc": "PLC592600073",
-      "uri_apple_music": "applemusic://track/1715321071",
+      "uri_apple_music": null,
       "uri_apple_music_by_region": {
-        "us": "applemusic://track/1715321071",
-        "de": "applemusic://track/1715321071",
-        "gb": "applemusic://track/1715321071",
-        "fr": "applemusic://track/1715321071",
-        "es": "applemusic://track/1715321071",
-        "nl": "applemusic://track/1715321071",
-        "it": "applemusic://track/1715321071"
+        "us": null,
+        "de": null,
+        "gb": null,
+        "fr": null,
+        "es": null,
+        "nl": null,
+        "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=op2cyrTP-NE",
       "uri_tidal": "tidal://track/529664799",
@@ -563,15 +563,15 @@
       "artist": "Szymon Wydra",
       "title": "Wciąż mamy moc",
       "isrc": "QZWFP2603209",
-      "uri_apple_music": "applemusic://track/1443770343",
+      "uri_apple_music": null,
       "uri_apple_music_by_region": {
-        "us": "applemusic://track/1443770343",
-        "de": "applemusic://track/1443798438",
-        "gb": "applemusic://track/1443770343",
-        "fr": "applemusic://track/1443798438",
-        "es": "applemusic://track/1443798438",
-        "nl": "applemusic://track/1443798438",
-        "it": "applemusic://track/1443798438"
+        "us": null,
+        "de": null,
+        "gb": null,
+        "fr": null,
+        "es": null,
+        "nl": null,
+        "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=SpBWPZN1uCg",
       "uri_tidal": null,


### PR DESCRIPTION
Fixes #1777

Removes fuzzy-backfill `wrong_track` Apple Music URIs from two Polish community songs (present in both `polish-rock.json` and `polish-all-time-hits.json`), verified individually via iTunes lookup:

- **Dziwna Wiosna — "Światła miasta"**: `applemusic://track/1715321071` actually resolves to **"Śnieg"** (album *DUCHY.DISCO*) — right artist, wrong track.
- **Szymon Wydra — "Wciąż mamy moc"**: `applemusic://track/1443770343` actually resolves to **"Jak Ja Jej to Powiem"** (album *Remedium*) — right artist, wrong track. Region ID `1443798438` = empty/invalid lookup.

`uri_apple_music` and every `uri_apple_music_by_region` entry nulled for both songs so the Apple provider falls out cleanly (no guessed replacement — a later backfill wave refills). Spotify/YouTube/Deezer/Tidal untouched. Playlist `version` bumped minor per file (polish-rock 0.3→0.4, polish-all-time-hits 0.2→0.3). Schema gate green.

**False positive (unchanged):** Stanisław Soyka — "Tolerancja / Na Miły Bóg" YouTube URI (`FWZNF4F1r7Y`) is the correct song; oEmbed title "Tolerancja - Stanisław Soyka" matched, the flag was only the medley alt-title + diacritics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)