### PR TITLE
fix(sudden-death): #1747/#1748/#1750/#1751/#1752/#1755 elimination hardening

### DIFF
--- a/custom_components/beatify/const.py
+++ b/custom_components/beatify/const.py
@@ -141,6 +141,7 @@ ERR_NO_ARTIST_CHALLENGE = "NO_ARTIST_CHALLENGE"  # Story 20.3 - no artist challe
 ERR_NO_MOVIE_CHALLENGE = "NO_MOVIE_CHALLENGE"  # Issue #28 - no movie quiz this round
 ERR_NO_TITLE_ARTIST_CHALLENGE = "NO_TITLE_ARTIST_CHALLENGE"  # #1180 - no T&A this round
 ERR_UNAUTHORIZED = "UNAUTHORIZED"  # Issue #477 - invalid admin token
+ERR_ELIMINATED = "ELIMINATED"  # #1748 - Sudden Death: eliminated player may not act
 
 # Song difficulty rating constants (Story 15.1)
 MIN_PLAYS_FOR_DIFFICULTY = 3  # Minimum plays before showing difficulty rating

--- a/custom_components/beatify/game/player.py
+++ b/custom_components/beatify/game/player.py
@@ -77,6 +77,11 @@ class PlayerSession:
     # Sudden Death tracking (Issue #827) - CUMULATIVE, NOT reset in reset_round()
     eliminated: bool = False  # True once eliminated; stays out for the rest of the game
     eliminated_round: int | None = None  # Round number the player was eliminated in
+    # #1752: round number a late joiner entered the game in. None for LOBBY joins
+    # (and after reset_for_new_game). Used to grant a mid-round joiner one grace
+    # round — they are excluded from the Sudden Death elimination candidate pool
+    # for the round they join, since they never played it.
+    joined_round: int | None = None
 
     # Final stats tracking (Story 5.6) - CUMULATIVE, NOT reset in reset_round()
     best_streak: int = 0  # Highest streak achieved during game
@@ -221,6 +226,9 @@ class PlayerSession:
         # Reset Sudden Death state (Issue #827)
         self.eliminated = False
         self.eliminated_round = None
+        # #1752: clear late-join grace tracking so a rematch/new game never
+        # grants a carried-over player Sudden Death grace on a stale round number.
+        self.joined_round = None
 
         # Reset movie bonus cumulative tracking (Issue #28)
         self.movie_bonus_total = 0

--- a/custom_components/beatify/game/player_registry.py
+++ b/custom_components/beatify/game/player_registry.py
@@ -88,6 +88,7 @@ class PlayerRegistry:
         ws: web.WebSocketResponse,
         phase: GamePhase,
         average_score_fn: Callable[[], int],
+        current_round: int = 0,
     ) -> tuple[bool, str | None]:
         """
         Add a player to the game.
@@ -100,6 +101,9 @@ class PlayerRegistry:
             ws: WebSocket connection
             phase: Current game phase
             average_score_fn: Callable returning current average score for late joiners
+            current_round: The round in progress (#1752). Recorded as
+                ``joined_round`` for late joiners so Sudden Death can grant them
+                one grace round (excluded from that round's elimination pool).
 
         Returns:
             (success, error_code) - error_code is None on success
@@ -159,9 +163,16 @@ class PlayerRegistry:
         # Calculate initial score (late joiners get average)
         initial_score = average_score_fn() if joined_late else 0
 
-        # Add new player
+        # Add new player. #1752: record the round a late joiner entered so
+        # Sudden Death excludes them from that round's elimination pool (one
+        # grace round); LOBBY joins leave joined_round None.
         player = PlayerSession(
-            name=name, ws=ws, score=initial_score, streak=0, joined_late=joined_late
+            name=name,
+            ws=ws,
+            score=initial_score,
+            streak=0,
+            joined_late=joined_late,
+            joined_round=current_round if joined_late else None,
         )
         # #1664 PR-2: key by player_id (== session_id), not the display name.
         self._players[player.player_id] = player

--- a/custom_components/beatify/game/powerups.py
+++ b/custom_components/beatify/game/powerups.py
@@ -57,10 +57,14 @@ class PowerUpManager:
         """
         # #1664 PR-2: ``players`` is keyed by player_id now, so match on the
         # display name attribute rather than the dict key.
+        # #1748: an eliminated player (Sudden Death) is out of the game — their
+        # guess must not be a steal target.
         return [
             player.name
             for player in players.values()
-            if player.name != stealer_name and player.submitted
+            if player.name != stealer_name
+            and player.submitted
+            and not player.eliminated
         ]
 
     def use_steal(

--- a/custom_components/beatify/game/scoring.py
+++ b/custom_components/beatify/game/scoring.py
@@ -384,6 +384,9 @@ def _score_intro_round(
         1
         for p in all_players
         if p is not player
+        # #1748: an eliminated player (Sudden Death) is out of the game and must
+        # not occupy a slot in the intro speed ranking that survivors compete for.
+        and not p.eliminated
         and _intro_qualified(
             p,
             cutoff=cutoff,
@@ -648,7 +651,14 @@ class ScoringService:
         milestone counter cannot be decremented (callers that don't track
         achievements may pass ``None``).
         """
-        submitted = [p for p in players if p.submitted and p.current_guess is not None]
+        # #1748: an eliminated player (Sudden Death) must not enter the
+        # closest-distance calculation — a stale-client submission from someone
+        # already OUT could otherwise become "closest" and zero every survivor.
+        submitted = [
+            p
+            for p in players
+            if p.submitted and p.current_guess is not None and not p.eliminated
+        ]
         if not submitted:
             return
 

--- a/custom_components/beatify/game/state.py
+++ b/custom_components/beatify/game/state.py
@@ -612,6 +612,13 @@ class GameState(
             self._challenge_manager if self.title_artist_mode else None
         )
         for player in self.players.values():
+            # #1748: an eliminated player (Sudden Death) is out of the game — do
+            # not accumulate any further score for them. Their frozen totals must
+            # stand, so skip the per-player scoring pass entirely. (The intro
+            # speed-rank pool in _score_intro_round independently excludes
+            # eliminated players so survivors' ranks are unaffected.)
+            if player.eliminated:
+                continue
             try:
                 ScoringService.score_player_round(
                     player,
@@ -754,9 +761,17 @@ class GameState(
         self._score_round(correct_year)
 
         # Issue #827: Sudden Death — after scoring, eliminate the lowest
-        # round-scoring survivor (from round 2 on). Runs before REVEAL so the
+        # round-delta survivor (from round 2 on). Runs before REVEAL so the
         # elimination is part of the reveal broadcast.
-        self._apply_sudden_death_elimination()
+        #
+        # #1747: in the deferred title/artist near-miss path, _score_round has
+        # NOT scored anyone yet (per-player scores depend on the post-vote-window
+        # near-miss resolution). Running elimination now would read stale
+        # round_score / round-delta values and cut the wrong player. Defer it too
+        # — _finalize_title_artist_window runs it once after the deferred scoring
+        # pass. Only the non-deferred path eliminates here.
+        if not self._title_artist_scoring_deferred():
+            self._apply_sudden_death_elimination()
 
         # Phase 3: highlights, round analytics, persisted song-result stats
         await self._record_round_stats(correct_year)
@@ -804,17 +819,85 @@ class GameState(
         """Players still in the game (not yet eliminated). Issue #827."""
         return [p for p in self.players.values() if not p.eliminated]
 
+    def _title_artist_scoring_deferred(self) -> bool:
+        """Whether this round's scoring is deferred past the vote window (#1180).
+
+        In title/artist mode with vote-eligible near-misses, per-player scoring
+        depends on the final near-miss resolution, which only happens after the
+        REVEAL vote window closes — so ``_score_round`` skips the main scoring
+        loop and ``_finalize_title_artist_window`` runs the single post-resolve
+        pass instead. Single source of truth for that predicate so the scoring
+        pass (``_score_round``) and the Sudden Death elimination gate
+        (``_end_round_unlocked``, #1747) can never disagree on whether scores are
+        final yet.
+        """
+        return self.title_artist_mode and self.has_near_misses()
+
+    @staticmethod
+    def _sudden_death_round_delta(player: PlayerSession) -> int:
+        """Full leaderboard delta a player earned this round (#1751).
+
+        The Sudden Death elimination metric. Bare ``round_score`` is only the
+        accuracy×speed×bet component; the round gain the TV actually shows also
+        includes the streak, artist, movie and intro bonuses — exactly the sum
+        ``score_player_round`` adds to ``player.score``. Comparing that same sum
+        here keeps the OUT call consistent with the visible leaderboard delta: a
+        player who scored 0 on the year but won the movie quiz is no longer cut
+        ahead of a survivor whose leaderboard actually moved less.
+        """
+        return (
+            player.round_score
+            + player.streak_bonus
+            + player.artist_bonus
+            + player.movie_bonus
+            + player.intro_bonus
+        )
+
+    @staticmethod
+    def _sudden_death_order_key(
+        player: PlayerSession,
+    ) -> tuple[tuple[bool, int], int, tuple[bool, float]]:
+        """Rank a player from *least* to *most* eliminable (#1750).
+
+        Used with ``max()`` to pick the loser among the players tied for the
+        lowest round delta. Closest-Wins zeros every non-closest submitter's
+        round_score, so from round 2 the tie for last is essentially everyone
+        but the closest — breaking it purely by submission speed would eliminate
+        an accurate-but-deliberate player ahead of a wildly-wrong instant
+        tapper. Mirroring #1721 (accuracy survives Closest-Wins voiding),
+        accuracy decides first. Higher tuple = more eliminable:
+
+          1. accuracy — a non-submitter (``years_off`` is None) is least
+             accurate; otherwise a larger ``years_off`` is worse. (``years_off``
+             is None for everyone in title/artist mode too, so this key ties out
+             there and the next one decides.)
+          2. base_score — the mode-agnostic accuracy signal (year accuracy score
+             or title+artist points); lower is worse, so negate for ``max``.
+          3. submission speed — a non-submitter is slowest of all, then the
+             latest ``submission_time`` loses.
+        """
+        return (
+            (player.years_off is None, player.years_off or 0),
+            -player.base_score,
+            (player.submission_time is None, player.submission_time or 0.0),
+        )
+
     def _apply_sudden_death_elimination(self) -> list[str]:
-        """Eliminate the lowest round-scoring survivor(s). Issue #827.
+        """Eliminate the lowest round-delta survivor. Issue #827.
 
         Runs after scoring, from round 2 onward (round 1 never eliminates).
-        Among non-eliminated players, the one with the lowest *round* score
-        (this round's delta, not cumulative) is eliminated. A tie for last is
-        broken by submission speed: the slowest (latest) submitter is out, and
-        a non-submitter counts as the slowest of all. Returns the names
-        eliminated this round (empty when nothing happens).
+        Among the eligible survivors, the player with the lowest *round delta*
+        (this round's full leaderboard gain, not cumulative — #1751) is
+        eliminated. A tie for last is broken by accuracy first, then submission
+        speed (#1750): the least-accurate / slowest submitter is out, and a
+        non-submitter counts as slowest of all. Mid-round joiners get one grace
+        round (#1752) — they are excluded from the candidate pool for the round
+        they joined. Returns the names eliminated this round (empty when nothing
+        happens).
 
-        Caller holds ``_score_lock`` (invoked from ``_end_round_unlocked``).
+        Caller holds ``_score_lock`` (invoked from ``_end_round_unlocked`` for
+        the normal path, or ``_finalize_title_artist_window`` for the deferred
+        title/artist near-miss path — #1747).
         """
         if not self.sudden_death_mode or self.round < 2:
             return []
@@ -825,22 +908,30 @@ class GameState(
         if len(survivors) <= 1:
             return []
 
-        min_round_score = min(p.round_score for p in survivors)
-        tied_for_last = [p for p in survivors if p.round_score == min_round_score]
+        # #1752: a mid-round joiner never played the round they joined (missed →
+        # round_score 0, submission_time None), which would make them prime
+        # elimination fodder in a round they never saw. Grant one grace round by
+        # excluding them from this round's candidate pool.
+        candidates = [p for p in survivors if p.joined_round != self.round]
+        if not candidates:
+            return []
 
-        # Slowest among the tied: a non-submitter (submission_time is None) is
-        # the slowest of all; otherwise the latest submission_time loses.
-        loser = max(
-            tied_for_last,
-            key=lambda p: (p.submission_time is None, p.submission_time or 0.0),
-        )
+        # #1751: compare the full round delta, not bare round_score.
+        min_delta = min(self._sudden_death_round_delta(p) for p in candidates)
+        tied_for_last = [
+            p for p in candidates if self._sudden_death_round_delta(p) == min_delta
+        ]
+
+        # #1750: among the players tied for last, break by accuracy first, then
+        # submission speed (a non-submitter counts as slowest of all).
+        loser = max(tied_for_last, key=self._sudden_death_order_key)
         loser.eliminated = True
         loser.eliminated_round = self.round
         _LOGGER.info(
-            "Sudden Death: eliminated %s in round %d (round score %d)",
+            "Sudden Death: eliminated %s in round %d (round delta %d)",
             loser.name,
             self.round,
-            loser.round_score,
+            self._sudden_death_round_delta(loser),
         )
         return [loser.name]
 

--- a/custom_components/beatify/game/state_player.py
+++ b/custom_components/beatify/game/state_player.py
@@ -113,7 +113,7 @@ class PlayerLifecycleMixin:
     ) -> tuple[bool, str | None]:
         """Add a player to the game. Delegates to PlayerRegistry."""
         return self._player_registry.add_player(
-            name, ws, self.phase, self.get_average_score
+            name, ws, self.phase, self.get_average_score, self.round
         )
 
     def get_player(self, name: str) -> PlayerSession | None:

--- a/custom_components/beatify/game/state_scoring.py
+++ b/custom_components/beatify/game/state_scoring.py
@@ -110,7 +110,10 @@ class RoundScoringMixin:
         # resolve) so the leaderboard reflects accepted near-misses without the
         # main loop and the rescore double-counting. With no near-misses the
         # challenge resolves immediately, so scoring here is already final.
-        defer_title_artist = self.title_artist_mode and self.has_near_misses()
+        # #1747: shared predicate with the Sudden Death elimination gate in
+        # _end_round_unlocked so the two paths never disagree on whether scores
+        # are final yet.
+        defer_title_artist = self._title_artist_scoring_deferred()
         if not defer_title_artist:
             self._score_all_players(correct_year, all_players)
 

--- a/custom_components/beatify/game/state_vote_window.py
+++ b/custom_components/beatify/game/state_vote_window.py
@@ -136,6 +136,15 @@ class VoteWindowMixin:
                     await self._on_round_end()
                 except (ConnectionError, OSError, TypeError) as err:
                     _LOGGER.error("Vote-window broadcast failed: %s", err)
+            # #1755: opening the vote window took over the _auto_advance_task
+            # slot, so REVEAL is now parked with no song-end advance armed. Re-arm
+            # it so an unattended title/artist near-miss round still advances at
+            # song-end (never-stall invariant #1012) — and a final unattended
+            # round still reaches END — instead of holding on REVEAL until the
+            # host taps Next. Only re-arm while still in REVEAL (a manual advance
+            # or end during the broadcast would have moved the phase on).
+            if self.phase == GamePhase.REVEAL:
+                self._schedule_song_end_auto_advance()
         except asyncio.CancelledError:
             # #1359: defense in depth — when end_game/next_round/pause cancels
             # this task mid-window, clear the vote-window flags so they can't
@@ -164,6 +173,12 @@ class VoteWindowMixin:
         self._challenge_manager.resolve_title_artist()
         async with self._score_lock:
             await self._score_title_artist_round()
+            # #1747: the deferred title/artist scores are now final, so run the
+            # Sudden Death cut that _end_round_unlocked deferred for this path.
+            # Guarded by voting_open above so it runs exactly once per round (the
+            # host-advance and window-expiry races both resolve through here).
+            # Caller-held _score_lock is required by _apply_sudden_death_elimination.
+            self._apply_sudden_death_elimination()
 
     async def _score_title_artist_round(self) -> None:
         """Run the deferred title/artist scoring pass. Caller holds the lock.

--- a/custom_components/beatify/server/ws_handlers/guessing.py
+++ b/custom_components/beatify/server/ws_handlers/guessing.py
@@ -15,6 +15,7 @@ from aiohttp import web
 from custom_components.beatify.const import (
     ARTIST_BONUS_POINTS,
     ERR_ALREADY_SUBMITTED,
+    ERR_ELIMINATED,
     ERR_INVALID_ACTION,
     ERR_NO_ARTIST_CHALLENGE,
     ERR_NO_MOVIE_CHALLENGE,
@@ -52,6 +53,18 @@ async def handle_submit(
                 "type": "error",
                 "code": ERR_NOT_IN_GAME,
                 "message": "Not in game",
+            }
+        )
+        return
+
+    # #1748: a Sudden Death eliminated player is out of the game — reject any
+    # server-side guess so a stale client can't keep banking score.
+    if player.eliminated:
+        await ws.send_json(
+            {
+                "type": "error",
+                "code": ERR_ELIMINATED,
+                "message": "You have been eliminated",
             }
         )
         return
@@ -152,6 +165,17 @@ async def handle_get_steal_targets(
         )
         return
 
+    # #1748: an eliminated player (Sudden Death) may not use a banked steal.
+    if player.eliminated:
+        await ws.send_json(
+            {
+                "type": "error",
+                "code": ERR_ELIMINATED,
+                "message": "You have been eliminated",
+            }
+        )
+        return
+
     if not player.steal_available:
         await ws.send_json(
             {
@@ -190,6 +214,17 @@ async def handle_steal(
                 "type": "error",
                 "code": ERR_NOT_IN_GAME,
                 "message": "Not in game",
+            }
+        )
+        return
+
+    # #1748: an eliminated player (Sudden Death) may not execute a banked steal.
+    if player.eliminated:
+        await ws.send_json(
+            {
+                "type": "error",
+                "code": ERR_ELIMINATED,
+                "message": "You have been eliminated",
             }
         )
         return
@@ -280,6 +315,17 @@ async def handle_artist_guess(
                 "type": "error",
                 "code": ERR_NOT_IN_GAME,
                 "message": "Not in game",
+            }
+        )
+        return
+
+    # #1748: reject guesses from a Sudden Death eliminated player.
+    if player.eliminated:
+        await ws.send_json(
+            {
+                "type": "error",
+                "code": ERR_ELIMINATED,
+                "message": "You have been eliminated",
             }
         )
         return
@@ -394,6 +440,17 @@ async def handle_movie_guess(
         )
         return
 
+    # #1748: reject guesses from a Sudden Death eliminated player.
+    if player.eliminated:
+        await ws.send_json(
+            {
+                "type": "error",
+                "code": ERR_ELIMINATED,
+                "message": "You have been eliminated",
+            }
+        )
+        return
+
     if not game_state.movie_challenge:
         await ws.send_json(
             {
@@ -485,6 +542,17 @@ async def handle_title_artist_guess(
                 "type": "error",
                 "code": ERR_NOT_IN_GAME,
                 "message": "Not in game",
+            }
+        )
+        return
+
+    # #1748: reject guesses from a Sudden Death eliminated player.
+    if player.eliminated:
+        await ws.send_json(
+            {
+                "type": "error",
+                "code": ERR_ELIMINATED,
+                "message": "You have been eliminated",
             }
         )
         return

--- a/tests/unit/test_sudden_death_hardening.py
+++ b/tests/unit/test_sudden_death_hardening.py
@@ -1,0 +1,417 @@
+"""Sudden Death hardening regression tests (#1747/#1748/#1750/#1751/#1752/#1755).
+
+These guard the six elimination-logic findings from the Fable re-review round 2:
+
+* #1747 — deferred title/artist scoring must defer the SD cut too, so the
+  RIGHT (lowest resolved) player is eliminated, not a stale-score victim.
+* #1748 — an eliminated player is gated server-side (no submit / steal) and is
+  never scored, a steal target, or a closest-wins participant.
+* #1750 — round-delta ties break by accuracy first, not raw submission speed.
+* #1751 — the elimination metric is the full round delta (incl. bonuses).
+* #1752 — a mid-round joiner gets one grace round (not eliminable that round).
+* #1755 — an unattended title/artist near-miss round re-arms the song-end
+  auto-advance after the vote window expires (never-stall invariant #1012).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+from custom_components.beatify.const import DOMAIN, ERR_ELIMINATED
+from custom_components.beatify.game.scoring import ScoringService
+from custom_components.beatify.game.state import GamePhase
+from tests.conftest import make_game_state, make_songs
+
+from custom_components.beatify.server.websocket import (  # isort: skip
+    BeatifyWebSocketHandler,
+)
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+def _ta_songs(n: int = 3) -> list[dict]:
+    songs = make_songs(n)
+    for i, s in enumerate(songs):
+        s["title"] = f"Real Title {i}"
+        s["artist"] = f"Real Artist {i}"
+    return songs
+
+
+def _stub_media_service() -> MagicMock:
+    svc = MagicMock()
+    svc.is_available.return_value = True
+    svc.play_song = AsyncMock(return_value=True)
+    svc.verify_responsive = AsyncMock(return_value=(True, None))
+    svc.restore_volume = AsyncMock(return_value=True)
+    return svc
+
+
+def _add_live_player(gs, name: str) -> None:
+    ws = MagicMock()
+    ws.closed = False
+    gs.add_player(name, ws)
+    gs.get_player(name).connected = True
+
+
+async def _start_ta_sd_game(gs, names, *, sudden_death=True):
+    gs.create_game(
+        playlists=["t.json"],
+        songs=_ta_songs(3),
+        media_player="media_player.x",
+        base_url="http://h",
+        title_artist_mode=True,
+        sudden_death_mode=sudden_death,
+    )
+    gs._media_player_service = _stub_media_service()
+    gs.platform = "music_assistant"
+    for n in names:
+        _add_live_player(gs, n)
+    await gs.start_round()
+
+
+# ---------------------------------------------------------------------------
+# #1747 — deferred title/artist scoring must defer the elimination too
+# ---------------------------------------------------------------------------
+
+
+class TestDeferredEliminationTitleArtist:
+    async def _drive_near_miss_round(self, gs):
+        """Alice: rejected near-miss title + wrong artist (resolves to 0).
+
+        Bob + Carol: exact/exact (15 each). Alice submitted FIRST (fastest),
+        Carol submitted LAST (slowest) — so the pre-fix stale-score path (all
+        round_score 0 at end_round) would wrongly eliminate the slowest
+        *submitter* Carol, while the resolved scores make Alice the true lowest.
+        """
+        await _start_ta_sd_game(gs, ("Alice", "Bob", "Carol"))
+        gs.round = 2  # SD only eliminates from round 2 on
+        title = gs.current_song["title"]
+        artist = gs.current_song["artist"]
+        # Alice: near-miss title ("Real Mismatch" shares the stem) + wrong artist.
+        gs._challenge_manager.submit_title_artist_guess(
+            "Alice", "Real Mismatch", "Totally Different Band", 1.0
+        )
+        gs._challenge_manager.submit_title_artist_guess("Bob", title, artist, 2.0)
+        gs._challenge_manager.submit_title_artist_guess("Carol", title, artist, 5.0)
+        for name, t in (("Alice", 1.0), ("Bob", 2.0), ("Carol", 5.0)):
+            p = gs.get_player(name)
+            p.submitted = True
+            p.submission_time = t
+
+    async def test_no_elimination_while_window_open(self):
+        """The cut must NOT happen at end_round while scoring is deferred."""
+        gs = make_game_state()
+        await self._drive_near_miss_round(gs)
+        await gs.end_round()
+        assert gs.is_title_artist_voting_open() is True
+        # Deferred: nobody scored, nobody eliminated yet.
+        assert all(not p.eliminated for p in gs.players.values())
+        gs._cancel_auto_advance()
+
+    async def test_deferred_path_eliminates_correct_player(self):
+        """After the window resolves, the lowest *resolved* scorer is out."""
+        gs = make_game_state()
+        await self._drive_near_miss_round(gs)
+        await gs.end_round()
+        # Host advances -> finalize resolves near-misses, scores, then eliminates.
+        await gs.resolve_title_artist_if_pending()
+
+        alice = gs.get_player("Alice")
+        assert alice.eliminated is True
+        assert alice.eliminated_round == 2
+        # The slowest *submitter* (pre-fix victim) survives — accuracy/score won.
+        assert gs.get_player("Bob").eliminated is False
+        assert gs.get_player("Carol").eliminated is False
+
+    async def test_non_deferred_ta_still_eliminates_inline(self):
+        """With no near-miss the immediate-resolve path eliminates at end_round."""
+        gs = make_game_state()
+        await _start_ta_sd_game(gs, ("Alice", "Bob", "Carol"))
+        gs.round = 2
+        title = gs.current_song["title"]
+        artist = gs.current_song["artist"]
+        gs._challenge_manager.submit_title_artist_guess("Alice", title, artist, 1.0)
+        gs._challenge_manager.submit_title_artist_guess("Bob", title, artist, 1.0)
+        for name in ("Alice", "Bob"):
+            gs.get_player(name).submitted = True
+            gs.get_player(name).submission_time = 1.0
+        # Carol never submits -> lowest, no near-miss -> immediate resolve.
+        await gs.end_round()
+        assert gs.is_title_artist_voting_open() is False
+        assert gs.get_player("Carol").eliminated is True
+        assert gs.get_player("Carol").eliminated_round == 2
+        assert gs.get_player("Alice").eliminated is False
+        gs._cancel_auto_advance()
+
+
+# ---------------------------------------------------------------------------
+# #1748 — eliminated players gated server-side and never scored
+# ---------------------------------------------------------------------------
+
+
+def _make_year_handler_game(sudden_death=True):
+    mock_hass = MagicMock()
+    gs = make_game_state()
+    gs.create_game(
+        playlists=["t.json"],
+        songs=make_songs(3),
+        media_player="media_player.x",
+        base_url="http://h",
+        sudden_death_mode=sudden_death,
+    )
+    gs._media_player_service = _stub_media_service()
+    gs.platform = "music_assistant"
+    mock_hass.data = {DOMAIN: {"game": gs}}
+    handler = BeatifyWebSocketHandler(mock_hass)
+    handler.broadcast_state = AsyncMock()
+    handler.broadcast = AsyncMock()
+    handler.debounced_broadcast_state = AsyncMock()
+    return handler, gs
+
+
+def _ws() -> AsyncMock:
+    ws = AsyncMock()
+    ws.send_json = AsyncMock()
+    ws.closed = False
+    ws.close = AsyncMock()
+    return ws
+
+
+class TestEliminatedGatedServerSide:
+    async def test_eliminated_submit_rejected(self):
+        handler, gs = _make_year_handler_game()
+        ws = _ws()
+        gs.add_player("Alice", ws)
+        gs.get_player("Alice").connected = True
+        await gs.start_round()
+        gs.get_player("Alice").eliminated = True
+
+        await handler._handle_message(ws, {"type": "submit", "year": 1985})
+
+        ws.send_json.assert_awaited()
+        codes = [
+            c.args[0].get("code")
+            for c in ws.send_json.await_args_list
+            if isinstance(c.args[0], dict)
+        ]
+        assert ERR_ELIMINATED in codes
+        # The rejected guess must not have registered.
+        assert gs.get_player("Alice").submitted is False
+
+    async def test_eliminated_steal_rejected(self):
+        handler, gs = _make_year_handler_game()
+        ws = _ws()
+        gs.add_player("Alice", ws)
+        gs.get_player("Alice").connected = True
+        await gs.start_round()
+        gs.get_player("Alice").eliminated = True
+
+        await handler._handle_message(ws, {"type": "steal", "target": "Someone"})
+
+        codes = [
+            c.args[0].get("code")
+            for c in ws.send_json.await_args_list
+            if isinstance(c.args[0], dict)
+        ]
+        assert ERR_ELIMINATED in codes
+
+    def test_eliminated_not_scored(self):
+        gs = make_game_state()
+        gs.create_game(
+            playlists=["t.json"],
+            songs=make_songs(3),
+            media_player="media_player.x",
+            base_url="http://h",
+            sudden_death_mode=True,
+        )
+        _add_live_player(gs, "Alice")
+        _add_live_player(gs, "Bob")
+        alice = gs.get_player("Alice")
+        bob = gs.get_player("Bob")
+        alice.eliminated = True
+        alice.score = 42  # frozen at elimination
+        # Both "submit" a perfect guess for year 1990.
+        for p in (alice, bob):
+            p.submitted = True
+            p.current_guess = 1990
+            p.submission_time = 1.0
+        gs._score_all_players(1990, list(gs.players.values()))
+        # Eliminated Alice's totals are frozen; Bob scored normally.
+        assert alice.score == 42
+        assert alice.round_score == 0
+        assert bob.score > 0
+
+    def test_eliminated_excluded_from_steal_targets(self):
+        gs = make_game_state()
+        gs.create_game(
+            playlists=["t.json"],
+            songs=make_songs(3),
+            media_player="media_player.x",
+            base_url="http://h",
+            sudden_death_mode=True,
+        )
+        _add_live_player(gs, "Alice")
+        _add_live_player(gs, "Bob")
+        _add_live_player(gs, "Carol")
+        for n in ("Bob", "Carol"):
+            gs.get_player(n).submitted = True
+            gs.get_player(n).current_guess = 1985
+        gs.get_player("Carol").eliminated = True
+        targets = gs.get_steal_targets("Alice")
+        assert "Bob" in targets
+        assert "Carol" not in targets
+
+    def test_eliminated_excluded_from_closest_wins(self):
+        gs = make_game_state()
+        _add_live_player(gs, "Alice")
+        _add_live_player(gs, "Bob")
+        alice = gs.get_player("Alice")
+        bob = gs.get_player("Bob")
+        # Eliminated Alice sits exactly on the year; survivor Bob is 5 off.
+        alice.submitted = True
+        alice.current_guess = 1990
+        alice.round_score = 10
+        alice.eliminated = True
+        bob.submitted = True
+        bob.current_guess = 1995
+        bob.round_score = 6
+        ScoringService.apply_closest_wins(list(gs.players.values()), 1990)
+        # Alice is OUT of the closest calc, so Bob (the only live submitter) is
+        # "closest" and keeps his points instead of being zeroed by a ghost.
+        assert bob.round_score == 6
+
+
+# ---------------------------------------------------------------------------
+# Unit-level elimination logic (#1750/#1751/#1752)
+# ---------------------------------------------------------------------------
+
+
+class TestEliminationLogic:
+    def _fresh(self):
+        gs = make_game_state()
+        gs.create_game(
+            playlists=["t.json"],
+            songs=make_songs(5),
+            media_player="media_player.x",
+            base_url="http://h",
+            sudden_death_mode=True,
+        )
+        for n in ("Alice", "Bob", "Carol", "Dave"):
+            _add_live_player(gs, n)
+        return gs
+
+    def test_tie_break_prefers_accuracy_over_speed(self):
+        """#1750: among a round-delta tie, the least accurate player is cut,
+        even if they submitted fastest."""
+        gs = self._fresh()
+        gs.round = 2
+        alice = gs.get_player("Alice")
+        bob = gs.get_player("Bob")
+        # Alice + Bob tie for last at round_score 0; Carol/Dave clearly ahead.
+        for n, sc in (("Alice", 0), ("Bob", 0), ("Carol", 5), ("Dave", 5)):
+            gs.get_player(n).round_score = sc
+        # Alice: 1 year off (accurate), pondered 10s. Bob: 40 off, tapped at 1s.
+        alice.years_off, alice.base_score, alice.submission_time = 1, 9, 10.0
+        bob.years_off, bob.base_score, bob.submission_time = 40, 1, 1.0
+        eliminated = gs._apply_sudden_death_elimination()
+        assert eliminated == ["Bob"]  # accuracy beats raw speed
+        assert alice.eliminated is False
+
+    def test_round_bonus_counts_toward_metric(self):
+        """#1751: a player who scored 0 on the year but won a bonus is safe."""
+        gs = self._fresh()
+        gs.round = 3
+        for n, sc in (("Alice", 1), ("Bob", 0), ("Carol", 3), ("Dave", 4)):
+            gs.get_player(n).round_score = sc
+        # Bob's raw round_score is the lowest (0) — but a +5 movie bonus makes his
+        # true round delta 5, so Alice (delta 1) is the real lowest.
+        gs.get_player("Bob").movie_bonus = 5
+        eliminated = gs._apply_sudden_death_elimination()
+        assert eliminated == ["Alice"]
+        assert gs.get_player("Bob").eliminated is False
+
+    def test_late_joiner_gets_grace_round(self):
+        """#1752: a player who joined THIS round is excluded from the cut."""
+        gs = self._fresh()
+        gs.round = 3
+        alice = gs.get_player("Alice")
+        alice.joined_round = 3  # joined mid-round 3
+        alice.round_score = 0  # missed the round they never played
+        alice.submission_time = None
+        for n, sc in (("Bob", 5), ("Carol", 6), ("Dave", 7)):
+            gs.get_player(n).round_score = sc
+            gs.get_player(n).submission_time = 1.0
+        eliminated = gs._apply_sudden_death_elimination()
+        # Alice would be the lowest, but grace excludes her; Bob is the cut.
+        assert eliminated == ["Bob"]
+        assert alice.eliminated is False
+
+    def test_late_joiner_eliminable_next_round(self):
+        """#1752: grace lasts exactly one round — the joiner is fair game after."""
+        gs = self._fresh()
+        gs.round = 4
+        alice = gs.get_player("Alice")
+        alice.joined_round = 3  # joined last round, now fully played round 4
+        alice.round_score = 0
+        alice.submission_time = None
+        for n, sc in (("Bob", 5), ("Carol", 6), ("Dave", 7)):
+            gs.get_player(n).round_score = sc
+            gs.get_player(n).submission_time = 1.0
+        eliminated = gs._apply_sudden_death_elimination()
+        assert eliminated == ["Alice"]
+
+    def test_all_fresh_joiners_no_elimination(self):
+        """#1752: if every survivor joined this round, nobody is eliminated."""
+        gs = self._fresh()
+        gs.round = 3
+        for n in ("Alice", "Bob", "Carol", "Dave"):
+            gs.get_player(n).joined_round = 3
+            gs.get_player(n).round_score = 0
+        eliminated = gs._apply_sudden_death_elimination()
+        assert eliminated == []
+        assert all(not p.eliminated for p in gs.players.values())
+
+
+# ---------------------------------------------------------------------------
+# #1755 — unattended title/artist near-miss round re-arms auto-advance
+# ---------------------------------------------------------------------------
+
+
+class TestUnattendedTitleArtistAdvance:
+    async def test_natural_expiry_rearms_auto_advance(self):
+        """After the vote window expires unattended, the song-end auto-advance
+        must be re-armed so the round doesn't park on REVEAL forever."""
+        gs = make_game_state()
+        await _start_ta_sd_game(gs, ("Alice", "Bob"), sudden_death=False)
+        title = gs.current_song["title"]
+        artist = gs.current_song["artist"]
+        gs._challenge_manager.submit_title_artist_guess(
+            "Alice", "Real Mismatch", artist, 1.0
+        )
+        gs._challenge_manager.submit_title_artist_guess("Bob", title, artist, 1.0)
+        for p in gs.players.values():
+            p.submitted = True
+            p.submission_time = 1.0
+
+        # Spy on the re-arm so the assertion doesn't depend on the real
+        # song-end poll task's timing.
+        calls: list[bool] = []
+        gs._schedule_song_end_auto_advance = lambda: calls.append(True)  # type: ignore[method-assign]
+
+        import custom_components.beatify.game.state_vote_window as vw_mod
+
+        orig = vw_mod.TITLE_ARTIST_VOTE_WINDOW_SECONDS
+        vw_mod.TITLE_ARTIST_VOTE_WINDOW_SECONDS = 0
+        try:
+            await gs.end_round()
+            assert gs.is_title_artist_voting_open() is True
+            await asyncio.sleep(0.05)  # let the 0s window task expire
+        finally:
+            vw_mod.TITLE_ARTIST_VOTE_WINDOW_SECONDS = orig
+
+        assert gs.phase == GamePhase.REVEAL
+        assert calls, "song-end auto-advance was not re-armed after vote expiry"


### PR DESCRIPTION
Six coherent fixes to the freshly-merged Sudden Death (#1472) elimination path — all rooted in `game/state.py`'s `_apply_sudden_death_elimination`, kept in one PR so the interdependent changes don't block each other.

## What each fix does

- **#1747 (high)** — In the deferred title/artist near-miss path `_score_round` hasn't scored anyone yet, so the inline cut read a stale `round_score` and permanently eliminated the wrong player. Elimination is now deferred to `_finalize_title_artist_window` (after the post-resolve scoring pass) and re-broadcast; the inline call is kept for the non-deferred path. A shared `_title_artist_scoring_deferred()` predicate keeps the scoring pass and the elimination gate from drifting. Runs exactly once per round.
- **#1748 (med)** — Eliminated players are now gated server-side: year/artist/movie/title-artist guesses and steals are rejected with `ERR_ELIMINATED`; eliminated players are skipped in `_score_all_players`, `get_steal_targets`, `apply_closest_wins` and the intro speed-rank pool.
- **#1750 (med)** — Round-delta ties break by accuracy first (`years_off` asc / `base_score` desc), then submission speed, then non-submitter last — so Closest-Wins no longer turns elimination into a raw submission-speed lottery.
- **#1751 (low)** — The elimination metric is now the full round delta (`round_score` + streak/artist/movie/intro bonuses), matching the visible leaderboard gain instead of bare `round_score`.
- **#1752 (med)** — `joined_round` is recorded on `PlayerSession`; a mid-round joiner gets one grace round (excluded from the elimination candidate pool for the round they joined).
- **#1755 (low)** — After the title/artist vote window expires naturally, the song-end auto-advance is re-armed so an unattended near-miss round doesn't stall on REVEAL (never-stall invariant #1012).

## Tests
New `tests/unit/test_sudden_death_hardening.py` (14 tests) covers all six findings; verified the #1747 test fails without the fix. Full suite green (1350 passed, 2 skipped), `ruff format`/`check` + `mypy` clean.

Fixes #1747
Also addresses #1748, #1750, #1751, #1752, #1755 (closed manually after merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)