### PR TITLE
docs: document Sudden Death + fix ARCHITECTURE drift + regen provider-coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to Beatify are documented here. For detailed release notes, 
 
 ## [Unreleased]
 
+### Added
+- **Sudden Death mode (#827, #1472).** An opt-in elimination format: after each round (from round 2 on), the surviving player with the lowest round score is knocked out for the rest of the game — last one standing wins. Ties for last go to the slowest submitter. Requires at least 3 players, and can be armed in the setup wizard or toggled live from the reveal screen. The TV shows an "OUT" takeover for players eliminated that round.
+
 ## [4.2.0-rc9] - 2026-06-28
 
 Pre-release — completes the speaker-twin fix so a previously-saved selection can't strand you on a non-streaming speaker. See [docs/release-notes-v4.2.0-rc9.md](docs/release-notes-v4.2.0-rc9.md) for the user-facing notes.

--- a/README.md
+++ b/README.md
@@ -622,7 +622,7 @@ The AI is the typist. The decisions, the architecture, the bug triage, and the "
 <details>
 <summary><strong>What game modes are there? How do you play Title & Artist?</strong></summary>
 <br>
-Two modes, chosen by the host in the setup wizard. <strong>Year</strong> mode is the classic: a song plays and everyone slides to guess the release year, scored by how close you are. <strong>Title &amp; Artist</strong> mode asks you to type the song title (<strong>+10</strong>) and the artist (<strong>+5</strong>) in free text — you don't have to be letter-perfect, since small typos earn partial credit and the forgiveness scales with title length. Genuinely close guesses go to <em>Crowd Court</em>, a live 30-second 👍/👎 vote the whole room can watch on the TV; plainly wrong answers are marked Wrong and scored zero. Movie Quiz and Intro bonuses stack on top of either mode.
+Two modes, chosen by the host in the setup wizard. <strong>Year</strong> mode is the classic: a song plays and everyone slides to guess the release year, scored by how close you are. <strong>Title &amp; Artist</strong> mode asks you to type the song title (<strong>+10</strong>) and the artist (<strong>+5</strong>) in free text — you don't have to be letter-perfect, since small typos earn partial credit and the forgiveness scales with title length. Genuinely close guesses go to <em>Crowd Court</em>, a live 30-second 👍/👎 vote the whole room can watch on the TV; plainly wrong answers are marked Wrong and scored zero. Movie Quiz and Intro bonuses stack on top of either mode. For a high-stakes twist, turn on <strong>Sudden Death</strong> (needs at least 3 players): from round 2 on, the lowest-scoring player each round is eliminated until one winner is left standing — arm it in the wizard or flip it on live from the reveal screen.
 </details>
 
 <details>
@@ -678,6 +678,10 @@ The neon dark theme is built-in and looks stunning. Custom theming is on the roa
 <br>
 
 ## What's New
+
+### v4.2.0 — Sudden Death 💀
+- **New game mode: Sudden Death** — an elimination format where, from round 2 on, the lowest-scoring player each round is knocked out until only one is left standing. Ties for last go to the slowest submitter, the TV shows an "OUT" takeover for whoever was just eliminated, and the winner earns a "last one standing" highlight. Needs at least 3 players; arm it in the setup wizard or flip it on live from the reveal screen (#827, #1472)
+- 6 music platforms, 5 languages
 
 ### v4.1.3 — Content & Reliability ☀️
 - **Speaker volume is restored when the game ends (#1516)** — if the host bumps the volume mid-game, Beatify hands the speaker back at its original level, complementing the party-lights state restore

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -19,7 +19,7 @@ A self-hosted multiplayer music trivia game that runs as a Home Assistant integr
                 │ Beatify back-  │   game/state.py (~916 LOC orchestrator) +
                 │ end (HA inte-  │   game/state_*.py (14 mixins)
                 │ gration)       │   server/ws_handlers/ (package, ~40 message types)
-                └───────┬────────┘   services/{media_player,tts,playlist}
+                └───────┬────────┘   services/{media_player,tts,lights,stats}
                         │
                 ┌───────▼────────┐
                 │ Music Assistant│   external HA add-on
@@ -69,6 +69,7 @@ custom_components/beatify/
 │   ├── challenges.py       # Artist Challenge / Movie Quiz
 │   ├── powerups.py         # Steal power-up
 │   ├── playlist.py         # Playlist loading + filtering + provider URI resolution
+│   ├── player.py           # PlayerSession (score/streak/elimination state)
 │   ├── player_registry.py  # Player roster + reconnect reclaim
 │   ├── highlights.py       # End-of-game highlights reel (#75)
 │   ├── share.py            # End-game share card
@@ -91,9 +92,14 @@ custom_components/beatify/
 │   ├── stats_views.py      # analytics dashboard data
 │   ├── setup_state.py      # persisted wizard/setup state
 │   ├── serializers.py, base.py
+├── services/               # backend side-effect services (see §4, §10)
+│   ├── media_player.py     # provider URI dispatch + playback (#768/#805/#808)
+│   ├── tts.py              # TTS announcements (tts.speak; #793)
+│   ├── lights.py           # party-lights phase orchestration
+│   └── stats.py            # analytics/stats side-effects
 ├── playlists/              # 49 bundled playlists, 5,381 songs
 │   ├── *.json              # 17 default packs (era / greatest-hits / movie)
-│   ├── community/          # 30 community packs (genre / region), separate browse tab
+│   ├── community/          # 32 community packs (genre / region), separate browse tab
 │   ├── user/               # host-saved mixes land here as <slug>.json (Community tab)
 │   └── mix/                # transient Mixer output (internal, auto-cleaned)
 ├── translations/           # HA-internal (config flow, services)
@@ -114,9 +120,9 @@ custom_components/beatify/
     └── css/
         └── styles.min.css
 
-tests/                      # 58 pytest files (unit + integration)
+tests/                      # ~55 pytest files (unit + integration)
 custom_components/beatify/www/js/__tests__/
-└── *.test.js               # 45 Vitest JS unit tests
+└── *.test.js               # ~45+ Vitest JS unit suites
 
 scripts/
 ├── playlist_schema.json    # authoritative playlist JSON schema (CI-validated)
@@ -136,6 +142,7 @@ scripts/
 5. **Challenges & Crowd Court** (`state_challenge`, `state_vote_window`) — Artist Challenge, Movie Quiz, and the Title & Artist close-call vote window (#1180/#1243).
 6. **Roster** (`state_player`) — admin (host) + 0..N guests, reclaim-by-name on reconnect (#790).
 7. **Pause/resume** (`state_pause`), **setup** (`state_setup`), **TTS** (`state_tts`), **serialization** (`state_serialization`).
+8. **Sudden Death** (`state.py` `_apply_sudden_death_elimination`, #827/#1472) — an opt-in elimination mode: after each round's scoring (from **round 2** onward), the surviving player with the **lowest round score** is eliminated for the rest of the game; a tie for last is broken by submission speed (slowest — or a non-submitter — is out). Never eliminates the last survivor (the game ends with a `last_one_standing` 💀 highlight instead). Requires a **3-player minimum**: the wizard disables the toggle below 3, and the LOBBY→PLAYING transition (`server/game_views.py`) auto-disables it as a server-side backstop. Can be armed at game start or toggled live from the reveal screen (`set_sudden_death`).
 
 **Round-flow defensive coding:** every `asyncio.create_task` in the round flow carries an `add_done_callback` that surfaces unretrieved exceptions with a stack trace (fixed the #816 class of silent freezes).
 
@@ -206,8 +213,8 @@ End-to-end from the host's "+ Add custom playlist" tap: `playlist-requests.js` P
 
 ## 11. Test strategy
 
-- **`tests/`** — 58 pytest files (unit + integration): state mixins, scoring, playlist filtering, provider URI dispatch, WS handlers end-to-end via mocked HA.
-- **`www/js/__tests__/`** — 45 Vitest JS unit tests (player tour, wizard, game logic).
+- **`tests/`** — ~55 pytest files (unit + integration): state mixins, scoring, playlist filtering, provider URI dispatch, WS handlers end-to-end via mocked HA.
+- **`www/js/__tests__/`** — ~45+ Vitest JS unit suites (player tour, wizard, game logic).
 - **Burn-in CI** — flaky-test detection reruns the suite weekly.
 - **HACS validation** — `validate.yml` runs `hacs/action` + `hassfest` on every push; the playlist schema gate runs `validate_playlists.py`.
 

--- a/docs/provider-coverage.md
+++ b/docs/provider-coverage.md
@@ -1,50 +1,59 @@
 # Beatify Provider-URI Coverage
-> Generated: 2026-06-10
+> Generated: 2026-07-05
 > Mode: DRY-RUN (no JSON written)
-> YouTube phase: skipped — sample report generated without network (YOUTUBE_API_KEY not set)
+> YouTube phase: skipped — coverage regenerated offline (existing URIs counted; no network, YOUTUBE_API_KEY not set)
 
 ## Summary
 
 | Provider | Have | Total | Coverage | Filled this run |
 |---|---:|---:|---:|---:|
-| Apple | 4082 | 4495 | 90.8% | 0 |
-| Tidal | 2340 | 4495 | 52.1% | 0 |
-| Deezer | 4035 | 4495 | 89.8% | 0 |
-| YouTube | 4348 | 4495 | 96.7% | 0 |
+| Apple | 4710 | 5381 | 87.5% | 0 |
+| Tidal | 3081 | 5381 | 57.3% | 0 |
+| Deezer | 4905 | 5381 | 91.2% | 0 |
+| YouTube | 5011 | 5381 | 93.1% | 0 |
 
 ## Per-playlist coverage
 
 | Playlist | Songs | Apple | Tidal | Deezer | YouTube | Filled |
 |---|---:|---:|---:|---:|---:|---:|
-| 2000s-pop-anthems.json | 182 | 175 | 144 | 179 | 182 |  |
-| 40s-50s-classics.json | 152 | 115 | 0 | 149 | 152 |  |
-| 70s-hits.json | 163 | 84 | 0 | 163 | 163 |  |
-| 80er-hits.json | 238 | 229 | 186 | 238 | 234 |  |
-| 90er-hits.json | 115 | 99 | 9 | 113 | 115 |  |
+| 2000s-pop-anthems.json | 182 | 175 | 182 | 179 | 182 |  |
+| 40s-50s-classics.json | 152 | 115 | 151 | 149 | 152 |  |
+| 70s-hits.json | 163 | 84 | 162 | 163 | 163 |  |
+| 80er-hits.json | 238 | 229 | 237 | 238 | 234 |  |
+| 90er-hits.json | 115 | 99 | 114 | 113 | 115 |  |
 | community/90s-2000s-hiphop-bangers.json | 40 | 40 | 40 | 40 | 40 |  |
-| community/anime-openings.json | 140 | 140 | 0 | 102 | 139 |  |
-| community/ballermann-party-hits.json | 189 | 178 | 0 | 175 | 189 |  |
+| community/anime-openings.json | 140 | 140 | 63 | 102 | 139 |  |
+| community/ballermann-party-hits.json | 189 | 178 | 11 | 175 | 189 |  |
 | community/best-of-giraffenaffen.json | 26 | 26 | 0 | 25 | 25 |  |
 | community/british-invasion-britpop.json | 100 | 86 | 98 | 100 | 98 |  |
 | community/deutschpop-klassiker.json | 107 | 106 | 1 | 107 | 107 |  |
+| community/disney-hits-deutschland.json | 97 | 63 | 0 | 93 | 97 |  |
 | community/divorced-dad-rock.json | 107 | 56 | 0 | 107 | 107 |  |
 | community/edm-anthems.json | 126 | 103 | 0 | 126 | 126 |  |
 | community/essential-alternative.json | 100 | 100 | 0 | 98 | 100 |  |
 | community/eurodance-90s.json | 100 | 86 | 92 | 91 | 97 |  |
 | community/fiesta-latina-90s.json | 50 | 48 | 50 | 50 | 50 |  |
+| community/finnish-iskelma-classics.json | 293 | 252 | 0 | 289 | 196 |  |
+| community/funk-carioca.json | 20 | 9 | 0 | 20 | 20 |  |
 | community/gen-z-anthems.json | 30 | 30 | 30 | 30 | 30 |  |
 | community/greatest-metal-songs.json | 61 | 61 | 52 | 0 | 61 |  |
-| community/harder-styles.json | 190 | 174 | 0 | 182 | 190 |  |
+| community/harder-styles.json | 190 | 174 | 0 | 181 | 190 |  |
 | community/hitster-100-en-espanol.json | 127 | 127 | 127 | 0 | 127 |  |
+| community/hitster-100-francais.json | 100 | 94 | 55 | 98 | 100 |  |
+| community/hitster-brasil.json | 66 | 66 | 49 | 66 | 66 |  |
 | community/iconic-movie-songs.json | 72 | 72 | 0 | 72 | 71 |  |
 | community/koelner-karneval.json | 290 | 289 | 276 | 288 | 273 |  |
+| community/ndw-neue-deutsche-welle.json | 50 | 31 | 19 | 47 | 43 |  |
+| community/polish-all-time-hits.json | 100 | 30 | 0 | 99 | 37 |  |
+| community/polish-rock.json | 100 | 30 | 37 | 99 | 45 |  |
 | community/pure-pop-punk.json | 100 | 97 | 100 | 100 | 100 |  |
 | community/schlager-klassiker.json | 60 | 58 | 60 | 59 | 60 |  |
-| community/schweizer-hits.json | 97 | 90 | 17 | 97 | 97 |  |
+| community/schweizer-hits.json | 97 | 90 | 17 | 97 | 96 |  |
+| community/sommerklassiker.json | 60 | 54 | 0 | 60 | 60 |  |
 | community/top100-allertijden-nederlandstalig.json | 104 | 96 | 68 | 0 | 100 |  |
 | community/trance-classics.json | 120 | 103 | 0 | 109 | 120 |  |
 | community/yacht-rock.json | 100 | 98 | 100 | 100 | 100 |  |
-| disco-funk-classics.json | 98 | 88 | 73 | 96 | 73 |  |
+| disco-funk-classics.json | 98 | 87 | 73 | 96 | 73 |  |
 | disney-classics.json | 69 | 69 | 0 | 69 | 57 |  |
 | eurovision-winners.json | 72 | 63 | 62 | 71 | 67 |  |
 | greatest-hits-of-all-time.json | 236 | 225 | 196 | 236 | 194 |  |


### PR DESCRIPTION
Fixes documentation-drift issues found in the Fable re-review (round 2). Docs-only — no code/i18n touched. All numbers verified against the repo at branch-point.

- **#1768** — Sudden Death mode (merged in #1472) was undocumented. Added to ARCHITECTURE §3 (elimination rule, round-2 start, tie-break, 3-player minimum, live toggle), a CHANGELOG `[Unreleased]` entry, and a README v4.2.0 What's New bullet + FAQ modes update.
- **#1769** — ARCHITECTURE §2 "30 community packs" → **32** (17 root + 32 = 49 bundled; verified `ls playlists/community/*.json` = 32).
- **#1770** — Fixed the §1 diagram (`services/{media_player,tts,playlist}` → `services/{media_player,tts,lights,stats}`), added a `services/` block to the §2 repo tree (media_player/tts/lights/stats — no `services/playlist.py` exists), and added `game/player.py` to the game listing. Verified via `ls services/` + `ls game/`.
- **#1771** — Replaced hardcoded, already-stale test counts (58 pytest / 45 vitest) with approximations (~55 pytest files, ~45+ Vitest suites). Actual today: 56 pytest / 48 vitest.
- **#1772** — Regenerated `docs/provider-coverage.md` from the backfill script's pure coverage functions (offline, no network — existing URIs counted only). Now 49 playlists / **5,381 songs** (was 4,495, stamped 2026-06-10); anime-openings Tidal 0 → 63.

Fixes #1768, #1769, #1770, #1771, #1772

🤖 Generated with [Claude Code](https://claude.com/claude-code)