### PR TITLE
perf: #1763 debounce in-round broadcasts + #1766 start-game cache + #1765 slim leaderboard payload

### DIFF
--- a/custom_components/beatify/game/state_leaderboard.py
+++ b/custom_components/beatify/game/state_leaderboard.py
@@ -62,17 +62,29 @@ class LeaderboardMixin:
             if player.previous_rank is not None:
                 rank_change = player.previous_rank - current_rank
 
+            # #1765: slim the per-frame (PLAYING/REVEAL) leaderboard entry.
+            # ``is_admin`` and ``eliminated_round`` were duplicated here but no
+            # client reads them off a leaderboard entry — every consumer
+            # (player-utils.renderLeaderboardEntry, dashboard.renderLeaderboard /
+            # renderRevealLeaderboard, admin) takes the host crown and the
+            # "Eliminated · Round N" copy from the ``players`` rows instead — so
+            # they are dropped to shrink each broadcast frame.
+            #
+            # KEPT deliberately (still read directly off leaderboard entries, so
+            # dropping them WOULD break a client — out of scope for a backend-only
+            # change): ``score``/``streak`` (rendered per row), ``connected``
+            # (away badge), ``eliminated`` (dashboard skull prefix + Sudden-Death
+            # survivor filter), plus ``rank``/``name``/``rank_change``.
             entry = {
                 "rank": current_rank,
                 "name": player.name,
                 "score": player.score,
                 "streak": player.streak,
-                "is_admin": player.is_admin,
                 "rank_change": rank_change,
                 "connected": player.connected,
-                # Issue #827: Sudden Death cut-line rendering
+                # Issue #827: Sudden Death cut-line rendering (dashboard reads
+                # entry.eliminated for the 💀 prefix + survivor filter).
                 "eliminated": player.eliminated,
-                "eliminated_round": player.eliminated_round,
             }
             leaderboard.append(entry)
 

--- a/custom_components/beatify/server/game_views.py
+++ b/custom_components/beatify/server/game_views.py
@@ -28,6 +28,9 @@ from custom_components.beatify.const import (
     ROUND_DURATION_MAX,
     ROUND_DURATION_MIN,
 )
+from custom_components.beatify.game.playlist import (
+    async_discover_playlists_detailed,
+)
 from custom_components.beatify.game.state import GamePhase, GameState
 from custom_components.beatify.server.base import (
     BeatifyAdminView,
@@ -49,6 +52,47 @@ if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def _resolve_and_load_playlist(
+    playlist_dir: Path,
+    playlist_path: str,
+    cached_songs: list[dict[str, Any]] | None,
+) -> tuple[list[dict[str, Any]] | None, str | None]:
+    """Resolve, security-check, and load one playlist's songs — off event loop.
+
+    #1766: consolidates the path-traversal ``resolve()``/``is_relative_to``
+    guard, the ``exists()`` stat, and (only on a discovery-cache miss) the file
+    read + ``json.loads`` into a single executor job, keeping these blocking
+    syscalls off the loop at the latency-sensitive Start tap. On a cache hit
+    ``cached_songs`` (already parsed by ``async_discover_playlists_detailed``)
+    is returned without touching disk.
+
+    Returns ``(songs, warning)``; ``songs`` is ``None`` when the path is
+    invalid / missing / unreadable and ``warning`` explains why.
+    """
+    full_path = playlist_dir / playlist_path
+    # Security: prevent path traversal attacks.
+    try:
+        full_path = full_path.resolve()
+        if not full_path.is_relative_to(playlist_dir.resolve()):
+            return None, f"Invalid playlist path: {playlist_path}"
+    except (OSError, ValueError):
+        return None, f"Invalid playlist path: {playlist_path}"
+
+    if not full_path.exists():
+        return None, f"Playlist not found: {playlist_path}"
+
+    if cached_songs is not None:
+        return cached_songs, None
+
+    # Cache miss (discovery hasn't run, or the file changed since the last
+    # discovery signature) → read + parse here in the same executor job.
+    try:
+        data = json.loads(_read_file(full_path))
+    except (OSError, ValueError) as err:
+        return None, f"Failed to load {playlist_path}: {err}"
+    return data.get("songs", []), None
 
 
 def _validate_provider(provider: str) -> str:
@@ -216,52 +260,51 @@ class StartGameView(RateLimitMixin, HomeAssistantView):
         warnings: list[str] = []
         playlist_dir = Path(self.hass.config.path("beatify/playlists"))
 
+        # #1766: reuse the #1704 discovery cache. ``songs_by_path`` already holds
+        # each playlist's parsed song list (built in one off-loop executor job,
+        # memoised by on-disk signature), so a Start tap seconds after discovery
+        # skips re-reading + re-parsing (~600 songs/playlist, several per game)
+        # json.loads on the event loop. Cache misses fall back to an executor
+        # read+parse inside _resolve_and_load_playlist.
+        _, songs_by_path = await async_discover_playlists_detailed(self.hass)
+
         for playlist_path in playlist_paths:
-            try:
-                full_path = playlist_dir / playlist_path
-                # Security: Prevent path traversal attacks
-                try:
-                    full_path = full_path.resolve()
-                    if not full_path.is_relative_to(playlist_dir.resolve()):
-                        warnings.append(f"Invalid playlist path: {playlist_path}")
-                        continue
-                except ValueError:
-                    warnings.append(f"Invalid playlist path: {playlist_path}")
-                    continue
+            # #1766: discovery keys songs_by_path by the un-resolved absolute
+            # path string (str(playlist_dir / <rel>)); match that here.
+            cached_songs = songs_by_path.get(str(playlist_dir / playlist_path))
+            # #1766: resolve()/exists() (and any cache-miss read+parse) run in a
+            # single executor job instead of on the event loop.
+            playlist_songs, warning = await self.hass.async_add_executor_job(
+                _resolve_and_load_playlist,
+                playlist_dir,
+                playlist_path,
+                cached_songs,
+            )
+            if warning is not None:
+                warnings.append(warning)
+            if playlist_songs is None:
+                continue
 
-                if not full_path.exists():
-                    warnings.append(f"Playlist not found: {playlist_path}")
-                    continue
-
-                # Read file in executor to avoid blocking event loop
-                file_content = await self.hass.async_add_executor_job(
-                    _read_file, full_path
-                )
-                playlist_data = json.loads(file_content)
-
-                for song in playlist_data.get("songs", []):
-                    has_uri = any(
-                        song.get(k)
-                        for k in (
-                            "uri",
-                            "uri_spotify",
-                            "uri_youtube_music",
-                            "uri_tidal",
-                            "uri_deezer",
-                            "uri_apple_music",
-                        )
+            for song in playlist_songs:
+                has_uri = any(
+                    song.get(k)
+                    for k in (
+                        "uri",
+                        "uri_spotify",
+                        "uri_youtube_music",
+                        "uri_tidal",
+                        "uri_deezer",
+                        "uri_apple_music",
                     )
-                    if "year" in song and has_uri:
-                        tagged = dict(song)
-                        tagged["_playlist_source"] = playlist_path
-                        songs.append(tagged)
-                    else:
-                        warnings.append(
-                            f"Invalid song in {playlist_path}: missing year or uri"
-                        )
-
-            except (OSError, ValueError) as err:
-                warnings.append(f"Failed to load {playlist_path}: {err}")
+                )
+                if "year" in song and has_uri:
+                    tagged = dict(song)
+                    tagged["_playlist_source"] = playlist_path
+                    songs.append(tagged)
+                else:
+                    warnings.append(
+                        f"Invalid song in {playlist_path}: missing year or uri"
+                    )
 
         if not songs:
             return _json_error(

--- a/custom_components/beatify/server/websocket.py
+++ b/custom_components/beatify/server/websocket.py
@@ -511,8 +511,12 @@ class BeatifyWebSocketHandler:
             "Player disconnected: %s (is_admin: %s)", player_name, player.is_admin
         )
 
-        # Broadcast disconnect state immediately
-        await self.broadcast_state()
+        # #1763: setting connected=False is a non-phase-changing flag update.
+        # A mass Wi-Fi blip disconnects N players back-to-back; routing this
+        # through the 50ms debounce coalesces them into a single broadcast
+        # instead of N full-state fan-outs. Phase transitions triggered below
+        # (early-reveal, admin-disconnect pause) keep their immediate broadcasts.
+        await self.debounced_broadcast_state()
 
         # #928: a mid-round disconnect can itself complete the round. If
         # everyone still active has already submitted, the departing player

--- a/custom_components/beatify/server/ws_handlers/guessing.py
+++ b/custom_components/beatify/server/ws_handlers/guessing.py
@@ -128,7 +128,11 @@ async def handle_submit(
     # transition to REVEAL and broadcast via the round_end callback,
     # avoiding a redundant double broadcast.
     if not game_state.check_all_guesses_complete():
-        await handler.broadcast_state()
+        # #1763: in-round submit-progress is non-phase-changing → coalesce via
+        # the 50ms debounce so an N-player round can't fan out N full-state
+        # broadcasts (O(N^2)). The round-end REVEAL broadcast stays immediate
+        # (round_end callback below).
+        await handler.debounced_broadcast_state()
 
     _LOGGER.debug(
         "Early reveal check: phase=%s, artist_challenge=%s",
@@ -254,7 +258,8 @@ async def handle_steal(
         # Issue #842 Phase 4: announce the steal (use case 23).
         await game_state.announce_steal_used(player.name, result["target"])
         if not game_state.check_all_guesses_complete():
-            await handler.broadcast_state()
+            # #1763: non-phase-changing in-round update → debounce.
+            await handler.debounced_broadcast_state()
         await game_state.trigger_early_reveal_if_complete()
     else:
         await ws.send_json(
@@ -386,7 +391,11 @@ async def handle_artist_guess(
     await ws.send_json(response)
 
     if result.get("first"):
-        await handler.broadcast_state()
+        # #1763: "first correct artist" flag is a non-phase-changing PLAYING
+        # update → debounce. debounced_broadcast_state re-reads state at fire
+        # time, so a subsequent immediate REVEAL broadcast is never overwritten
+        # with stale data.
+        await handler.debounced_broadcast_state()
 
     await game_state.trigger_early_reveal_if_complete()
 
@@ -603,7 +612,8 @@ async def handle_title_artist_guess(
     # when the early-reveal path is about to broadcast via the round_end
     # callback. Only broadcast here when the round is NOT yet complete.
     if not game_state.check_all_guesses_complete():
-        await handler.broadcast_state()
+        # #1763: non-phase-changing in-round update → debounce.
+        await handler.debounced_broadcast_state()
 
     await game_state.trigger_early_reveal_if_complete()
 
@@ -699,7 +709,10 @@ async def handle_title_artist_vote(
     _LOGGER.debug(
         "Title/artist vote by %s on %s -> %s", player.name, nearmiss_id, accept
     )
-    await handler.broadcast_state()
+    # #1763: REVEAL vote tallies are per-player (N voters → N broadcasts) and
+    # non-phase-changing → debounce. The auto-advance out of REVEAL is a
+    # separate immediate path.
+    await handler.debounced_broadcast_state()
 
 
 async def handle_title_artist_override(
@@ -770,4 +783,5 @@ async def handle_title_artist_override(
 
     game_state.set_title_artist_override(nearmiss_id, accept)
     _LOGGER.info("Title/artist override on %s -> %s", nearmiss_id, accept)
-    await handler.broadcast_state()
+    # #1763: non-phase-changing REVEAL update → debounce.
+    await handler.debounced_broadcast_state()

--- a/tests/unit/test_broadcast_debounce_1763.py
+++ b/tests/unit/test_broadcast_debounce_1763.py
@@ -1,0 +1,126 @@
+"""#1763: non-phase-changing in-round broadcasts must be coalesced.
+
+The per-player in-round events (year submit progress, guess/vote tallies,
+disconnect flags) used to call ``broadcast_state()`` directly — one full
+get_state + redact + 2x json.dumps + N send_str per event, i.e. O(N^2) work on
+a busy round. They now route through ``debounced_broadcast_state()`` (50ms
+coalescing window). The *phase transition* out of PLAYING (round end -> REVEAL)
+still broadcasts immediately via the round_end callback, so clients never wait
+for the debounce to see the reveal.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.beatify.const import DOMAIN
+from custom_components.beatify.game.state import GamePhase
+from tests.conftest import make_game_state, make_songs
+
+from custom_components.beatify.server.websocket import (  # isort: skip
+    BeatifyWebSocketHandler,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+def _stub_media_service() -> MagicMock:
+    svc = MagicMock()
+    svc.is_available.return_value = True
+    svc.play_song = AsyncMock(return_value=True)
+    svc.verify_responsive = AsyncMock(return_value=(True, None))
+    return svc
+
+
+def _ws() -> AsyncMock:
+    ws = AsyncMock()
+    ws.send_json = AsyncMock()
+    ws.closed = False
+    ws.close = AsyncMock()
+    return ws
+
+
+async def _playing_game_with_two_players():
+    """A PLAYING game with an admin (Alice) + a regular player (Bob)."""
+    mock_hass = MagicMock()
+    gs = make_game_state()
+    gs.create_game(
+        playlists=["t.json"],
+        songs=make_songs(3),
+        media_player="media_player.x",
+        base_url="http://h",
+    )
+    gs._media_player_service = _stub_media_service()
+    gs.platform = "music_assistant"
+    mock_hass.data = {DOMAIN: {"game": gs}}
+
+    handler = BeatifyWebSocketHandler(mock_hass)
+    handler.broadcast_state = AsyncMock()
+    handler.broadcast = AsyncMock()
+    handler.debounced_broadcast_state = AsyncMock()
+    # Mirror production wiring: the round-end reveal broadcasts immediately.
+    gs.set_round_end_callback(handler.broadcast_state)
+
+    alice_ws, bob_ws = _ws(), _ws()
+    gs.add_player("Alice", alice_ws)
+    gs.add_player("Bob", bob_ws)
+    gs.get_player("Alice").connected = True
+    gs.get_player("Bob").connected = True
+    gs.get_player("Alice").is_admin = True
+    gs.get_player("Bob").is_admin = False
+    handler.connections.update({alice_ws, bob_ws})
+
+    await gs.start_round()
+    assert gs.phase == GamePhase.PLAYING
+    return handler, gs, alice_ws, bob_ws
+
+
+class TestInRoundBroadcastsDebounced:
+    async def test_submit_progress_is_debounced_not_immediate(self):
+        """A submit that does NOT complete the round coalesces via debounce."""
+        handler, gs, alice_ws, bob_ws = await _playing_game_with_two_players()
+
+        # Only Alice submits → Bob still outstanding → round NOT complete.
+        await handler._handle_message(alice_ws, {"type": "submit", "year": 1985})
+
+        handler.debounced_broadcast_state.assert_awaited()
+        # No phase transition happened → no immediate broadcast.
+        handler.broadcast_state.assert_not_awaited()
+
+        gs._cancel_auto_advance()
+
+    async def test_round_end_broadcasts_immediately(self):
+        """The completing submit skips the debounce and reveals immediately."""
+        handler, gs, alice_ws, bob_ws = await _playing_game_with_two_players()
+
+        await handler._handle_message(alice_ws, {"type": "submit", "year": 1985})
+        # Reset so we observe ONLY the completing submit's broadcasts.
+        handler.debounced_broadcast_state.reset_mock()
+        handler.broadcast_state.reset_mock()
+
+        # Bob submits → round complete → early reveal fires the round_end
+        # callback, which is the immediate broadcast_state.
+        await handler._handle_message(bob_ws, {"type": "submit", "year": 1990})
+
+        assert gs.phase == GamePhase.REVEAL
+        # Immediate reveal broadcast, and NOT the debounced in-round path.
+        handler.broadcast_state.assert_awaited()
+        handler.debounced_broadcast_state.assert_not_awaited()
+
+        gs._cancel_auto_advance()
+
+    async def test_disconnect_flag_is_debounced(self):
+        """A mid-round disconnect coalesces the connected=False flag broadcast."""
+        handler, gs, alice_ws, bob_ws = await _playing_game_with_two_players()
+
+        # Regular player Bob drops while the round is still open (Alice has not
+        # submitted) → no reveal, no admin pause → only the flag broadcast.
+        await handler._handle_disconnect(bob_ws)
+
+        assert gs.get_player("Bob").connected is False
+        handler.debounced_broadcast_state.assert_awaited()
+        handler.broadcast_state.assert_not_awaited()
+
+        gs._cancel_auto_advance()

--- a/tests/unit/test_start_game_view.py
+++ b/tests/unit/test_start_game_view.py
@@ -110,6 +110,11 @@ def start_game_env():
 
     # Playlist file read runs in an executor; return the valid content.
     async def _executor(func, *args):
+        # #1766: StartGameView now loads playlist songs off-loop via
+        # _resolve_and_load_playlist, which returns (songs, warning) instead of
+        # raw file content. Other executor calls keep the raw-content contract.
+        if getattr(func, "__name__", "") == "_resolve_and_load_playlist":
+            return json.loads(_VALID_PLAYLIST).get("songs", []), None
         return _VALID_PLAYLIST
 
     hass.async_add_executor_job = AsyncMock(side_effect=_executor)
@@ -212,6 +217,11 @@ def _twin_start_game_env(media_player: str, entries: list[MagicMock]):
     hass.config.path.return_value = "/tmp/beatify/playlists"
 
     async def _executor(func, *args):
+        # #1766: StartGameView now loads playlist songs off-loop via
+        # _resolve_and_load_playlist, which returns (songs, warning) instead of
+        # raw file content. Other executor calls keep the raw-content contract.
+        if getattr(func, "__name__", "") == "_resolve_and_load_playlist":
+            return json.loads(_VALID_PLAYLIST).get("songs", []), None
         return _VALID_PLAYLIST
 
     hass.async_add_executor_job = AsyncMock(side_effect=_executor)
@@ -312,3 +322,87 @@ class TestNativeTwinRemapAtStart:
         assert resp.status == 200
         # A normal (non-twin) MA entity_id is used as-is.
         assert game_state.media_player == "media_player.esszimmer"
+
+
+# ---------------------------------------------------------------------------
+# #1766: start-game reuses the #1704 discovery cache + loads off the loop
+# ---------------------------------------------------------------------------
+
+
+class TestResolveAndLoadPlaylist:
+    """The per-playlist load helper runs resolve/exists (+ any read) off-loop
+    and reuses discovery's already-parsed songs on a cache hit."""
+
+    def test_cache_hit_returns_cached_songs_without_reading(self, tmp_path):
+        # A real file exists, but the cached parse must be returned verbatim
+        # (identity) — proving no re-read/re-parse happened on a cache hit.
+        from custom_components.beatify.server.game_views import (
+            _resolve_and_load_playlist,
+        )
+
+        pl = tmp_path / "p.json"
+        pl.write_text(
+            json.dumps({"songs": [{"year": 1999, "uri": "spotify:track:onfile"}]})
+        )
+        cached = [{"year": 2001, "uri": "spotify:track:fromcache"}]
+
+        songs, warning = _resolve_and_load_playlist(tmp_path, "p.json", cached)
+
+        assert warning is None
+        assert songs is cached  # reused discovery's parse, ignored the file
+
+    def test_cache_miss_falls_back_to_read_and_parse(self, tmp_path):
+        from custom_components.beatify.server.game_views import (
+            _resolve_and_load_playlist,
+        )
+
+        pl = tmp_path / "p.json"
+        pl.write_text(
+            json.dumps({"songs": [{"year": 1999, "uri": "spotify:track:onfile"}]})
+        )
+
+        songs, warning = _resolve_and_load_playlist(tmp_path, "p.json", None)
+
+        assert warning is None
+        assert songs == [{"year": 1999, "uri": "spotify:track:onfile"}]
+
+    def test_missing_file_returns_warning(self, tmp_path):
+        from custom_components.beatify.server.game_views import (
+            _resolve_and_load_playlist,
+        )
+
+        songs, warning = _resolve_and_load_playlist(tmp_path, "nope.json", None)
+
+        assert songs is None
+        assert "not found" in warning.lower()
+
+    def test_path_traversal_is_blocked(self, tmp_path):
+        from custom_components.beatify.server.game_views import (
+            _resolve_and_load_playlist,
+        )
+
+        songs, warning = _resolve_and_load_playlist(tmp_path, "../../etc/passwd", None)
+
+        assert songs is None
+        assert "Invalid playlist path" in warning
+
+
+class TestStartGameUsesDiscoveryCache:
+    """StartGameView routes playlist loading through the memoised #1704
+    discovery entry point rather than re-reading each file itself (#1766)."""
+
+    async def test_start_game_calls_discovery(self, start_game_env):
+        view, hass, body = start_game_env
+
+        discover = AsyncMock(return_value=([], {}))
+        with patch(
+            "custom_components.beatify.server.game_views."
+            "async_discover_playlists_detailed",
+            discover,
+        ):
+            resp = await view.post(_make_request(hass, body))
+
+        assert resp.status == 200
+        # The Start tap went through the shared discovery cache (one off-loop
+        # parse) instead of re-reading/parsing playlists inline on the loop.
+        discover.assert_awaited_once()

--- a/tests/unit/test_state_leaderboard.py
+++ b/tests/unit/test_state_leaderboard.py
@@ -179,8 +179,36 @@ class TestLeaderboardPayload:
         assert entry["name"] == "Alice"
         assert entry["score"] == 42
         assert entry["streak"] == 3
-        assert entry["is_admin"] is True
         assert entry["connected"] is False
+
+    def test_entry_is_slimmed_to_client_read_fields(self):
+        # #1765: the per-frame leaderboard entry drops fields no client reads
+        # off a leaderboard entry (is_admin, eliminated_round — both taken from
+        # the players rows instead) while keeping the ones clients still render
+        # directly (rank/name/score/streak/rank_change/connected/eliminated).
+        _add(
+            self.state,
+            "Alice",
+            score=42,
+            streak=3,
+            is_admin=True,
+            connected=True,
+        )
+
+        (entry,) = self.state.get_leaderboard()
+
+        assert set(entry) == {
+            "rank",
+            "name",
+            "score",
+            "streak",
+            "rank_change",
+            "connected",
+            "eliminated",
+        }
+        # Dropped: duplicated from the players rows, unused off leaderboard.
+        assert "is_admin" not in entry
+        assert "eliminated_round" not in entry
 
     def test_ties_break_by_name_for_stable_display(self):
         # Equal scores -> alphabetical name order, equal rank.

--- a/tests/unit/test_ws_title_artist_vote.py
+++ b/tests/unit/test_ws_title_artist_vote.py
@@ -94,7 +94,8 @@ class TestVoteHandler:
             {"type": "title_artist_vote", "nearmiss_id": "Alice:title", "accept": True},
         )
         assert gs.get_near_misses()[0]["votes_yes"] == 1
-        handler.broadcast_state.assert_awaited()
+        # #1763: vote tallies are coalesced through the debounced broadcast.
+        handler.debounced_broadcast_state.assert_awaited()
         gs._cancel_auto_advance()
 
     async def test_self_vote_rejected(self):
@@ -158,7 +159,8 @@ class TestOverrideHandler:
             gs._challenge_manager.title_artist_challenge.overrides["Alice:title"]
             is True
         )
-        handler.broadcast_state.assert_awaited()
+        # #1763: override updates are coalesced through the debounced broadcast.
+        handler.debounced_broadcast_state.assert_awaited()
         gs._cancel_auto_advance()
 
     async def test_override_rejected_for_non_admin(self):


### PR DESCRIPTION
Fixes #1763, #1766, #1765

Backend-only performance follow-ups from the Fable round-2 re-review. No frontend/docs touched.

## #1763 — in-round full-state broadcasts bypass the debounce (medium)
The per-player in-round events ran the full `broadcast_state()` pipeline (get_state + leaderboard sort + reveal build → redact → 2x `json.dumps` → Nx `send_str`) once per event → O(N^2) on a busy round. Routed the **non-phase-changing** ones through the existing 50ms `debounced_broadcast_state()`:

- `guessing.py`: year submit progress, steal progress, first-correct-artist flag, title-artist guess progress, TA vote tally, TA override.
- `websocket.py` `_handle_disconnect`: the `connected=False` flag broadcast (a mass Wi-Fi blip disconnects N players back-to-back → 1 coalesced broadcast instead of N).

**Kept immediate** (phase transitions): the round-end → REVEAL broadcast (round_end callback, wired to `broadcast_state`) and the admin-disconnect pause broadcast. `debounced_broadcast_state` re-reads state at fire time, so a debounced tick that lands just after an immediate reveal re-broadcasts the current (REVEAL) state — never stale.

## #1766 — start-game re-parses playlists on the loop, ignores the #1704 cache (low)
`StartGameView` now calls `async_discover_playlists_detailed` once (reusing the memoised `songs_by_path`) and loads each playlist via a new `_resolve_and_load_playlist` helper that runs `resolve()`/`is_relative_to`/`exists()` — plus a cache-miss `read`+`json.loads` fallback — in a **single executor job**, off the event loop. Behavior unchanged (same traversal guard, same warnings, same per-song filtering).

## #1765 — players/leaderboard payload overlap (low, payload change)
**Verified every client + Python consumer before slimming.** The per-frame leaderboard entry only dropped the two fields no client reads off a leaderboard entry:

- **Dropped:** `is_admin`, `eliminated_round` — grep confirms both are only ever read off the `players` rows (`p.is_admin` host-crown logic; `me.eliminated_round`/`player.eliminated_round` from `data.players`), never off a `leaderboard[]` entry.
- **Kept (would break a client if dropped — out of scope for a backend-only change):** `score`, `streak` (rendered per row by `player-utils.renderLeaderboardEntry` + `dashboard.renderLeaderboard`/`renderRevealLeaderboard`), `connected` (away badge), `eliminated` (dashboard 💀 prefix + Sudden-Death survivor filter), plus `rank`/`name`/`rank_change`. Fully draining leaderboard down to `{rank,name,rank_change}` as the issue suggested would require a frontend agent to migrate those renderers to join against `players` — deliberately left for a follow-up.

`get_final_leaderboard` (END screen) is untouched.

## Tests
- New `tests/unit/test_broadcast_debounce_1763.py`: in-round submit debounced (not immediate); completing submit reveals immediately via round_end callback (not debounced); disconnect flag debounced.
- `test_start_game_view.py`: `_resolve_and_load_playlist` cache-hit reuse (identity) / cache-miss read / missing-file / traversal-blocked; start-game routes through the discovery cache entry point.
- `test_state_leaderboard.py`: asserts the slimmed entry shape (drops is_admin/eliminated_round, keeps the client-read fields).
- Updated `test_ws_title_artist_vote.py` vote/override assertions to `debounced_broadcast_state`.

Full suite: `1359 passed, 2 skipped` (test_tls_localization deselected). `ruff format` + `ruff check` clean, `mypy` gate green.