### PR TITLE
fix(scoring): speed-multiplier grace window + round-not-truncate (#1722)

### DIFF
--- a/custom_components/beatify/game/scoring.py
+++ b/custom_components/beatify/game/scoring.py
@@ -47,6 +47,12 @@ from custom_components.beatify.game.text_match import (
 POINTS_EXACT = 10
 POINTS_WRONG = 0
 
+# #1722: the speed bonus holds at its maximum for an initial grace window so a
+# player isn't punished for actually listening to the song before committing to
+# a year. After the grace it decays linearly to 1.0x at the deadline.
+SPEED_MULTIPLIER_MAX = 2.0
+SPEED_GRACE_FRACTION = 1.0 / 3.0
+
 # A won bet (exact year) multiplies the round score by this (#1004).
 BET_WIN_MULTIPLIER = 3
 
@@ -95,13 +101,15 @@ def calculate_speed_multiplier(elapsed_time: float, round_duration: float) -> fl
     """
     Calculate speed bonus multiplier based on submission timing.
 
-    Formula: speed_multiplier = 2.0 - (1.0 * submission_time_ratio)
-    - Instant submission (0s): 2.0x multiplier (double points!)
-    - At deadline (30s): 1.0x multiplier (no bonus)
+    #1722: a grace window keeps the multiplier at its maximum for the first
+    third of the round, so listening to recognise the song isn't penalised.
+    - Instant .. grace edge (round_duration / 3): 2.0x (double points!)
+    - Grace edge .. deadline: linear decay 2.0x → 1.0x
+    - At / past the deadline: 1.0x (no bonus)
 
     Args:
         elapsed_time: Seconds elapsed since round started when player submitted
-        round_duration: Total round duration in seconds (default 30)
+        round_duration: Total round duration in seconds
 
     Returns:
         Multiplier between 1.0 and 2.0
@@ -110,14 +118,16 @@ def calculate_speed_multiplier(elapsed_time: float, round_duration: float) -> fl
     if round_duration <= 0:
         return 1.0
 
-    # Calculate ratio (0.0 = instant, 1.0 = at deadline)
-    submission_time_ratio = elapsed_time / round_duration
+    grace = round_duration * SPEED_GRACE_FRACTION
 
-    # Clamp to valid range [0.0, 1.0]
-    submission_time_ratio = max(0.0, min(1.0, submission_time_ratio))
+    # Full multiplier during the grace window (and for any early / negative time).
+    if elapsed_time <= grace:
+        return SPEED_MULTIPLIER_MAX
 
-    # Formula: 2.0x at instant, 1.0x at deadline (linear)
-    return 2.0 - (1.0 * submission_time_ratio)
+    # Linear decay from the max at the grace edge to 1.0x at the deadline.
+    decay_ratio = (elapsed_time - grace) / (round_duration - grace)
+    decay_ratio = max(0.0, min(1.0, decay_ratio))
+    return SPEED_MULTIPLIER_MAX - ((SPEED_MULTIPLIER_MAX - 1.0) * decay_ratio)
 
 
 def calculate_round_score(
@@ -143,7 +153,10 @@ def calculate_round_score(
     """
     base_score = calculate_accuracy_score(guess, actual, difficulty)
     speed_multiplier = calculate_speed_multiplier(elapsed_time, round_duration)
-    final_score = int(base_score * speed_multiplier)
+    # #1722: round rather than truncate — int() dropped the speed bonus entirely
+    # for the 1-point accuracy tier (int(1 * 1.9) == 1) and shaved fractional
+    # bonuses off every other tier.
+    final_score = round(base_score * speed_multiplier)
     return final_score, base_score, speed_multiplier
 
 

--- a/tests/unit/test_scoring.py
+++ b/tests/unit/test_scoring.py
@@ -109,8 +109,17 @@ class TestSpeedMultiplier:
     def test_at_deadline(self):
         assert calculate_speed_multiplier(30.0, 30.0) == pytest.approx(1.0)
 
-    def test_halfway(self):
-        assert calculate_speed_multiplier(15.0, 30.0) == pytest.approx(1.5)
+    def test_grace_window_holds_max(self):
+        # #1722: the first third (10s of a 30s round) stays at the full 2.0x so
+        # listening to recognise the song isn't punished.
+        assert calculate_speed_multiplier(5.0, 30.0) == pytest.approx(2.0)
+        assert calculate_speed_multiplier(10.0, 30.0) == pytest.approx(2.0)
+
+    def test_decays_after_grace(self):
+        # #1722: past the 10s grace edge the multiplier decays linearly over the
+        # remaining 20s; 15s → 2.0 - 0.25 = 1.75, 20s → 1.5.
+        assert calculate_speed_multiplier(15.0, 30.0) == pytest.approx(1.75)
+        assert calculate_speed_multiplier(20.0, 30.0) == pytest.approx(1.5)
 
     def test_over_deadline_clamped(self):
         # More than round_duration → clamped to 1.0
@@ -125,9 +134,11 @@ class TestSpeedMultiplier:
         assert calculate_speed_multiplier(5.0, 0.0) == pytest.approx(1.0)
 
     def test_custom_duration(self):
+        # #1722: grace scales with the round (20s of a 60s round).
         assert calculate_speed_multiplier(0.0, 60.0) == pytest.approx(2.0)
+        assert calculate_speed_multiplier(20.0, 60.0) == pytest.approx(2.0)
         assert calculate_speed_multiplier(60.0, 60.0) == pytest.approx(1.0)
-        assert calculate_speed_multiplier(30.0, 60.0) == pytest.approx(1.5)
+        assert calculate_speed_multiplier(40.0, 60.0) == pytest.approx(1.5)
 
 
 # ---------------------------------------------------------------------------
@@ -154,15 +165,24 @@ class TestRoundScore:
         assert final == 0  # 0 * 2.0 = 0
 
     def test_close_guess_with_speed_bonus(self):
+        # #1722: 15s → 1.75x (post-grace decay); round(5 * 1.75) = round(8.75) = 9.
         final, base, multiplier = calculate_round_score(1983, 1985, 15.0, 30.0)
         assert base == 5
-        assert multiplier == pytest.approx(1.5)
-        assert final == 7  # int(5 * 1.5) = 7
+        assert multiplier == pytest.approx(1.75)
+        assert final == 9
 
     def test_hard_difficulty(self):
         final, base, _ = calculate_round_score(1983, 1985, 0.0, 30.0, "hard")
         assert base == 3  # hard: ±2 → 3pts
         assert final == 6  # 3 * 2.0 = 6
+
+    def test_low_tier_keeps_speed_bonus(self):
+        # #1722 regression: with int() a 1-point accuracy tier was speed-immune
+        # (int(1 * 1.75) == 1). round() now credits the bonus. Normal ±4 = 1pt.
+        final, base, multiplier = calculate_round_score(1981, 1985, 15.0, 30.0)
+        assert base == 1
+        assert multiplier == pytest.approx(1.75)
+        assert final == 2  # round(1 * 1.75) = 2, not 1
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Gameplay-balance fix from the Fable review. Backend-only (scoring). **Ready for review — not auto-merged.**

## Problem
`calculate_speed_multiplier` decayed linearly from t=0: **2.0x** instant → **1.0x** at the deadline. A player who listened a few more seconds to actually pin the year lost ~22% of the bonus, so optimal play was anchoring a fast plausible guess — reflexes over recognition, on a *music* quiz. Separately, `int(base * multiplier)` truncation made the **1-point accuracy tier speed-immune** (`int(1 * 1.9) == 1`) and shaved fractional bonuses off every tier.

## Fix
- **Grace window** — hold the full **2.0x** for the first `round_duration / 3` (e.g. 10s of a 30s round, ~15s of a 45s round), then decay linearly to 1.0x at the deadline. Listening no longer costs points; the grace scales with the round.
- **`round()` instead of `int()`** — the low tier now keeps its speed bonus and fractional bonuses are credited fairly.

## Tests
- `+` grace-window (full 2.0x within grace) and post-grace-decay cases
- `+` low-tier-keeps-bonus regression (`round(1 * 1.75) == 2`, not 1)
- updated the mid-curve assertions (15s → 1.75x) to the new shape
- full unit suite green (**1352**), ruff + mypy clean

Fixes #1722

🤖 Generated with [Claude Code](https://claude.com/claude-code)