### PR TITLE
chore(playlists): tidal backfill wave — +11 uris across 1 playlist

### DIFF
--- a/custom_components/beatify/playlists/community/anime-openings.json
+++ b/custom_components/beatify/playlists/community/anime-openings.json
@@ -1,6 +1,6 @@
 {
   "name": "Anime Openings",
-  "version": "1.18",
+  "version": "1.19",
   "tags": [
     "anime",
     "japanese",
@@ -2583,7 +2583,7 @@
         "it": "applemusic://track/1537790375"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=HxlysqrFjHo",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/170958443",
       "uri_deezer": "deezer://track/1220973532",
       "fun_fact": "Orchestral composer whose 2014 works included dramatic anime scores with cinematic arrangements",
       "fun_fact_de": "Orchesterkomponist, dessen Werke 2014 dramatische Anime-Scores mit filmischen Arrangements umfassten",
@@ -2608,7 +2608,7 @@
         "it": "applemusic://track/1371246458"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=hgFPAJNuVhM",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/518147953",
       "uri_deezer": "deezer://track/2266011437",
       "fun_fact": "Singer known for delivering intense vocal performances in anime opening and ending themes",
       "fun_fact_de": "Sängerin, bekannt für intensive Stimmleistungen bei Anime-Öffnungs- und Abspannthemen",
@@ -2633,7 +2633,7 @@
         "it": "applemusic://track/1536482656"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=G-h_sVWP1SQ",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/144565974",
       "uri_deezer": "deezer://track/976202472",
       "fun_fact": "Opening theme of Code Geass, a dark anime about superpowers used for political manipulation",
       "fun_fact_de": "Anfangsthema von Code Geass, ein dunkler Anime über Superkräfte zur politischen Manipulation",
@@ -2658,7 +2658,7 @@
         "it": "applemusic://track/1422126913"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=P-eNMO8L5Hs",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/93065497",
       "uri_deezer": "deezer://track/537151152",
       "fun_fact": "J-rock band whose music has featured in multiple anime opening sequences and soundtracks",
       "fun_fact_de": "J-Rock-Band, deren Musik in mehreren Anime-Öffnungssequenzen und Soundtracks vertreten ist",
@@ -2683,7 +2683,7 @@
         "it": "applemusic://track/1838917472"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=Hh9yZWeTmVM",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/459692273",
       "uri_deezer": "deezer://track/3620224292",
       "fun_fact": "Japanese rock band that gained fame through anime theme songs and international rock tours",
       "fun_fact_de": "Japanische Rockband, die durch Anime-Themensongs und internationale Rocktourneen berühmt wurde",
@@ -2808,7 +2808,7 @@
         "it": "applemusic://track/1463232194"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=oomE4oltFRo",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/219073826",
       "uri_deezer": "deezer://track/678377952",
       "fun_fact": "Gurenge is the opening theme for Demon Slayer Season 1, achieving platinum certification in Japan.",
       "fun_fact_de": "Gurenge ist das Öffnungsthema für Demon Slayer Staffel 1 und erreichte Platinstatus in Japan.",
@@ -2833,7 +2833,7 @@
         "it": "applemusic://track/1538160328"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=qpi9YXaChHI",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/145213302",
       "uri_deezer": "deezer://track/976146912",
       "fun_fact": "Opening theme for Fullmetal Alchemist: Brotherhood Season 1, an iconic anime adaptation released 2009-2010.",
       "fun_fact_de": "Opening-Thema für Fullmetal Alchemist: Brotherhood Staffel 1, eine ikonische Anime-Adaption von 2009-2010.",
@@ -2908,7 +2908,7 @@
         "it": "applemusic://track/1528877472"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=QwACoXnNcwg",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/487464847",
       "uri_deezer": "deezer://track/1059340662",
       "fun_fact": "Yuki Hayashi's My Hero Academia track, an iconic action theme heard during pivotal battle sequences.",
       "fun_fact_de": "Yuki Hayashis My Hero Academia-Track, ein ikonisches Action-Thema in entscheidenden Kampfszenen.",
@@ -2958,7 +2958,7 @@
         "it": "applemusic://track/6767143828"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=yQEUGxngQN4",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/149317244",
       "uri_deezer": "deezer://track/975929972",
       "fun_fact": "J-rock power duo BURNOUT SYNDROMES known for prolific anime opening/ending releases from 2016-2020",
       "fun_fact_de": "J-Rock-Duo BURNOUT SYNDROMES bekannt für zahlreiche Anime-Opening/Ending-Veröffentlichungen von 2016–2020",
@@ -2983,7 +2983,7 @@
         "it": "applemusic://track/1582348551"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=rUw2-ZqFJbc",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/520657434",
       "uri_deezer": "deezer://track/1471722992",
       "fun_fact": "Vocalist KANKAKU PIERO active in 2010s anime music with diverse emotional theme arrangements",
       "fun_fact_de": "Sänger KANKAKU PIERO in der Anime-Musik der 2010er Jahre mit vielfältigen emotionalen Thema-Arrangements",
@@ -3058,7 +3058,7 @@
         "it": "applemusic://track/1538131047"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=PwZBiq1c6Mc",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/144922190",
       "uri_deezer": "deezer://track/975907272",
       "fun_fact": "BURNOUT SYNDROMES' early anime theme from 2016 showcasing signature high-energy J-rock instrumental style",
       "fun_fact_de": "BURNOUT SYNDROMES' frühes Anime-Thema von 2016 zeigt charakteristischen hochenergetischen J-Rock-Sound",


### PR DESCRIPTION
Automated Tidal-URI backfill wave (catch-up for the missed 12:00 slot).

**Per-playlist delta**
- `community/anime-openings.json` — tidal 63→74 (+11), version 1.18→1.19

**Wave stats**
- 11 URIs added · 1 playlist touched
- 8 genuine "not on Tidal" misses (recorded in state)
- 61 rate-limit (429) skips — retried next wave

URI-only change, Schema-Gate-validated. Auto-merge enabled per standing tidal-backfill rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)