### PR TITLE
chore(playlists): tidal backfill wave — +6 uris across 2 playlists

### DIFF
--- a/custom_components/beatify/playlists/community/anime-openings.json
+++ b/custom_components/beatify/playlists/community/anime-openings.json
@@ -1,6 +1,6 @@
 {
   "name": "Anime Openings",
-  "version": "1.19",
+  "version": "1.20",
   "tags": [
     "anime",
     "japanese",
@@ -3158,7 +3158,7 @@
         "it": "applemusic://track/1420545183"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=M-ROgEvfkqE",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/467129879",
       "uri_deezer": null,
       "fun_fact": "Kumi Koda is a J-pop vocalist featured in multiple anime openings and endings throughout career",
       "fun_fact_de": "Kumi Koda ist eine J-Pop-Sängerin, die in vielen Anime-Openings und Endings auftritt",
@@ -3183,7 +3183,7 @@
         "it": "applemusic://track/1538264260"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=hoxUfOTE5II",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/144888568",
       "uri_deezer": "deezer://track/976001772",
       "fun_fact": "Eir Aoi's emotional rock-pop vocals power many anime openings across shonen and romance genres",
       "fun_fact_de": "Eir Aoi's emotionale Rock-Pop-Stimme treibt viele Anime-Openings in Shonen- und Romance-Genres an",
@@ -3208,7 +3208,7 @@
         "it": "applemusic://track/1551120604"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=c8I4iu7Qvyg",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/170921986",
       "uri_deezer": "deezer://track/1220736152",
       "fun_fact": "Attack on Titan Season 1 opening theme with Sawano Hiroyuki's signature orchestral style",
       "fun_fact_de": "Opening-Thema von Attack on Titan Staffel 1 mit Sawano Hiroyukis charakteristischem Orchestersound",
@@ -3258,7 +3258,7 @@
         "it": "applemusic://track/1147022401"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=zyuvcD7vdy0",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/320017168",
       "uri_deezer": "deezer://track/2191817367",
       "fun_fact": "Chinese anime collaboration featuring pianist Neo Liu and vocalist Tu Hua Bing from 2016",
       "fun_fact_de": "Chinesische Anime-Zusammenarbeit mit Pianist Neo Liu und Sänger Tu Hua Bing aus 2016",

--- a/custom_components/beatify/playlists/community/ballermann-party-hits.json
+++ b/custom_components/beatify/playlists/community/ballermann-party-hits.json
@@ -1,6 +1,6 @@
 {
   "name": "Ballermann Party Hits",
-  "version": "1.5",
+  "version": "1.6",
   "tags": [
     "schlager",
     "party",
@@ -311,7 +311,7 @@
         "it": "applemusic://track/1891364268"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=V1picOnkqJU",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/514696503",
       "uri_deezer": "deezer://track/3952478221",
       "alt_artists": [
         "Justin Flieger"
@@ -339,7 +339,7 @@
         "it": "applemusic://track/1882994210"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=X3WzMDNb6lw",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/506693469",
       "uri_deezer": "deezer://track/3898152331",
       "alt_artists": [
         "bozi"


### PR DESCRIPTION
Scheduled 18:00 tidal-backfill wave (Odesli). URI-only + version bump, Schema-Gate validates.

- anime-openings 1.19→1.20 (+4 uri_tidal)
- ballermann-party-hits 1.5→1.6 (+2 uri_tidal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)