### PR TITLE
data: fix dead Apple Music URI in hitster-100-en-espanol

### DIFF
--- a/custom_components/beatify/playlists/community/hitster-100-en-espanol.json
+++ b/custom_components/beatify/playlists/community/hitster-100-en-espanol.json
@@ -1,6 +1,6 @@
 {
   "name": "100% en Español 🇪🇸",
-  "version": "1.8",
+  "version": "1.9",
   "tags": [
     "spanish",
     "spain",
@@ -2837,7 +2837,7 @@
       "fun_fact_de": "Nach einem Kartenspiel benannt, wurde dieses Madrider Pop-Punk-Trio eine der erfolgreichsten Bands Spaniens. Frontmann Álvaro Benito spielte in Real Madrids Jugend.",
       "fun_fact_es": "Nombrados por un juego de cartas, este trío pop-punk madrileño fue una de las bandas más exitosas de los 2000. Álvaro Benito jugó en la cantera del Real Madrid.",
       "fun_fact_fr": "Nommés d'après un jeu de cartes, ce trio pop-punk madrilène fut l'un des plus grands groupes des années 2000. Álvaro Benito jouait au Real Madrid.",
-      "uri_apple_music": "applemusic://track/151630092",
+      "uri_apple_music": "applemusic://track/1519029259",
       "uri_youtube_music": "https://music.youtube.com/watch?v=b4YVijo8UFA",
       "uri_tidal": "tidal://track/340902",
       "fun_fact_nl": "Dit Madrileense pop-punk trio, vernoemd naar een kaartspel (varkensneus), werd een van de succesvolste Spaanse bands van de jaren 2000. Frontman Álvaro Benito is een voormalig jeugdspeler van Real Madrid.",


### PR DESCRIPTION
Recovered stranded commit `db576c6` (BeatifyBot music-data run 04:39 today — pushed but the agent died before opening the PR; [[reference_stranded_worktree_commit_recovery]]).

**Fix** — replaced dead Apple Music track ID `151630092` → `1519029259` for **Pignoise – Nada que perder**. Playlist version 1.8 → 1.9.

6 `wrong_track` flags were reviewed; the other 5 dismissed as false positives.

URI-only data fix, validated by the Playlist JSON Schema Gate in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)