### PR TITLE
fix(server): prime asset fingerprint off event loop; allow LOBBY->PAUSED

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Beatify are documented here. For detailed release notes, 
 
 ## [Unreleased]
 
+### Fixed
+- **No blocking I/O on the HTML serve path.** The asset cache-buster fingerprint is now primed in an executor instead of being recomputed inline on the event loop, so serving the admin/player/dashboard/analytics pages (or `sw.js`) no longer trips Home Assistant's blocking-call detector (`scandir` inside the event loop) when the fingerprint cache's TTL expires.
+- **Sudden Death no longer logs a spurious phase-transition warning.** When the first round's playback fails (e.g. an unreachable speaker), the game pauses straight from `LOBBY`; that `LOBBY -> PAUSED` edge is now a recognised transition instead of an "Unexpected phase transition" warning (#768/#1627, #1273).
+
 ## [4.2.0-rc11] - 2026-07-06
 
 Pre-release — a gameplay-tension pass on top of the Mix & Match / Sudden Death cycle: four opt-in modes that keep trailing players in the game and reward taking a risk, plus a fairness fix to the side challenges. See the GitHub release for the user-facing notes.

--- a/custom_components/beatify/game/state.py
+++ b/custom_components/beatify/game/state.py
@@ -117,7 +117,11 @@ class GamePhase(Enum):
 # Same-phase forward writes (LOBBY→LOBBY re-init, PLAYING→PLAYING next round)
 # are covered by the same-phase exemption, not by this table.
 _VALID_PHASE_TRANSITIONS: dict[GamePhase, frozenset[GamePhase]] = {
-    GamePhase.LOBBY: frozenset({GamePhase.PLAYING}),
+    # LOBBY -> PAUSED is legitimate: if the very first round's playback fails
+    # (e.g. the speaker is unreachable), the playback-failure handler pauses the
+    # game while it is still in LOBBY (the PLAYING transition never completes).
+    # See state_lifecycle playback-failure path (#768/#1627 speaker fails).
+    GamePhase.LOBBY: frozenset({GamePhase.PLAYING, GamePhase.PAUSED}),
     GamePhase.PLAYING: frozenset({GamePhase.REVEAL, GamePhase.PAUSED}),
     GamePhase.REVEAL: frozenset({GamePhase.PLAYING, GamePhase.PAUSED}),
     GamePhase.PAUSED: frozenset(),

--- a/custom_components/beatify/server/base.py
+++ b/custom_components/beatify/server/base.py
@@ -153,6 +153,42 @@ def _apply_cache_tokens(text: str, hass: HomeAssistant) -> str:
     return text.replace(_VERSION_TOKEN, version)
 
 
+async def _async_prime_asset_fingerprint(hass: HomeAssistant) -> None:
+    """Warm ``_ASSET_FP_CACHE`` via an executor job when it is cold or stale.
+
+    Mirrors the throttle/lock logic in :func:`_get_asset_version`, but performs
+    the actual filesystem sweep (:func:`_compute_asset_fingerprint`, a blocking
+    ``rglob``/``stat`` walk) off the event loop. A no-op when the cache is fresh.
+    """
+    global _ASSET_FP_CACHE  # noqa: PLW0603
+    now = time.monotonic_ns()
+    cache = _ASSET_FP_CACHE
+    if cache is not None and now - cache[0] < _ASSET_FP_TTL_NS:
+        return
+    fingerprint = await hass.async_add_executor_job(
+        _compute_asset_fingerprint, _www_dir()
+    )
+    with _ASSET_FP_LOCK:
+        cache = _ASSET_FP_CACHE
+        if cache is None or time.monotonic_ns() - cache[0] >= _ASSET_FP_TTL_NS:
+            _ASSET_FP_CACHE = (time.monotonic_ns(), fingerprint)
+
+
+async def async_apply_cache_tokens(hass: HomeAssistant, text: str) -> str:
+    """Async form of :func:`_apply_cache_tokens` for the HTTP serve path.
+
+    ``_get_asset_version`` recomputes the asset fingerprint with a blocking
+    ``rglob``/``stat`` sweep on cache miss (once per ``_ASSET_FP_TTL_NS``).
+    Calling the sync form directly from an async view runs that sweep on the
+    event loop, which HA's ``util/loop`` blocking-call detector flags
+    (``scandir``/``read_bytes`` inside the event loop). Priming the fingerprint
+    cache in an executor first keeps the hot serve path non-blocking; the
+    subsequent sync substitution then hits the warm cache.
+    """
+    await _async_prime_asset_fingerprint(hass)
+    return _apply_cache_tokens(text, hass)
+
+
 # #1177 follow-up: PR #1179 set documentElement.lang inside setLanguage(), but
 # on Android Chrome auto-translate runs against the *initial* HTML, before the
 # WebSocket state arrives and triggers setLanguage('de'). The static

--- a/custom_components/beatify/server/stats_views.py
+++ b/custom_components/beatify/server/stats_views.py
@@ -13,10 +13,10 @@ from homeassistant.components.http import HomeAssistantView
 from custom_components.beatify.const import DOMAIN
 from custom_components.beatify.server.base import (
     RateLimitMixin,
-    _apply_cache_tokens,
     _apply_html_lang,
     _get_html,
     _json_error,
+    async_apply_cache_tokens,
 )
 
 if TYPE_CHECKING:
@@ -45,7 +45,7 @@ class DashboardView(HomeAssistantView):
             return web.Response(text="Dashboard page not found", status=500)
         return web.Response(
             text=_apply_html_lang(
-                _apply_cache_tokens(html_content, self.hass), self.hass
+                await async_apply_cache_tokens(self.hass, html_content), self.hass
             ),
             content_type="text/html",
         )
@@ -177,7 +177,9 @@ class AnalyticsPageView(HomeAssistantView):
         if content is None:
             return web.Response(text="Analytics page not found", status=404)
         return web.Response(
-            text=_apply_html_lang(_apply_cache_tokens(content, self.hass), self.hass),
+            text=_apply_html_lang(
+                await async_apply_cache_tokens(self.hass, content), self.hass
+            ),
             content_type="text/html",
         )
 

--- a/custom_components/beatify/server/views.py
+++ b/custom_components/beatify/server/views.py
@@ -25,12 +25,12 @@ from custom_components.beatify.game.state import GamePhase
 from custom_components.beatify.game.playlist import async_discover_playlists
 from custom_components.beatify.server.base import (
     RateLimitMixin,
-    _apply_cache_tokens,
     _apply_html_lang,
     _get_html,
     _get_version,
     _json_error,
     _read_file,
+    async_apply_cache_tokens,
 )
 from custom_components.beatify.server.companion_auth import is_authorized_http
 from custom_components.beatify.server.serializers import (
@@ -126,7 +126,9 @@ class AdminView(HomeAssistantView):
             _LOGGER.error("Admin page not found: %s", html_path)
             return web.Response(text="Admin page not found", status=500)
         return _html_response(
-            _apply_html_lang(_apply_cache_tokens(html_content, self.hass), self.hass)
+            _apply_html_lang(
+                await async_apply_cache_tokens(self.hass, html_content), self.hass
+            )
         )
 
 
@@ -149,7 +151,9 @@ class LauncherView(HomeAssistantView):
             _LOGGER.error("Launcher page not found: %s", html_path)
             return web.Response(text="Launcher page not found", status=500)
         return _html_response(
-            _apply_html_lang(_apply_cache_tokens(html_content, self.hass), self.hass)
+            _apply_html_lang(
+                await async_apply_cache_tokens(self.hass, html_content), self.hass
+            )
         )
 
 
@@ -172,7 +176,9 @@ class PlayerView(HomeAssistantView):
             _LOGGER.error("Player page not found: %s", html_path)
             return web.Response(text="Player page not found", status=500)
         return _html_response(
-            _apply_html_lang(_apply_cache_tokens(html_content, self.hass), self.hass)
+            _apply_html_lang(
+                await async_apply_cache_tokens(self.hass, html_content), self.hass
+            )
         )
 
 
@@ -501,7 +507,7 @@ class SwJsView(HomeAssistantView):
         # waiting for HTTP cache to expire on the SW bootstrap itself. Tokens
         # ({{ASSET_VER}}) are substituted at serve time (#1266).
         return web.Response(
-            text=_apply_cache_tokens(content, self.hass),
+            text=await async_apply_cache_tokens(self.hass, content),
             content_type="application/javascript",
             headers=_NO_CACHE_HEADERS,
         )

--- a/tests/unit/test_asset_cachebuster.py
+++ b/tests/unit/test_asset_cachebuster.py
@@ -260,3 +260,72 @@ class TestNoHardcodedCacheBusters:
             "hardcoded literal, so it busts on any asset change (#1278):\n  "
             + "\n  ".join(offenders)
         )
+
+
+class TestAsyncApplyCacheTokens:
+    """The async serve-path wrapper must prime the fingerprint OFF the event
+    loop: the sync form's blocking ``rglob``/``stat`` sweep tripped HA's
+    ``util/loop`` blocking-call detector when the throttle TTL expired.
+    ``async_apply_cache_tokens`` offloads that sweep to an executor first, then
+    substitutes against the warm cache."""
+
+    def setup_method(self) -> None:
+        base._ASSET_FP_CACHE = None
+
+    async def test_substitutes_like_sync_form(self) -> None:
+        hass = _FakeHass("9.9.9")
+        out = await base.async_apply_cache_tokens(
+            hass, 'v={{VERSION}} a="?v={{ASSET_VER}}"'
+        )
+        assert "{{VERSION}}" not in out
+        assert "{{ASSET_VER}}" not in out
+        assert "v=9.9.9 " in out
+        assert "?v=9.9.9-" in out
+
+    async def test_fingerprint_sweep_runs_in_executor(self) -> None:
+        # The blocking sweep must be offloaded — record what the executor runs.
+        offloaded: list = []
+
+        class _SpyHass(_FakeHass):
+            async def async_add_executor_job(self, func, *args):  # noqa: ANN001
+                offloaded.append(func)
+                return func(*args)
+
+        await base.async_apply_cache_tokens(_SpyHass("9.9.9"), "{{ASSET_VER}}")
+        assert base._compute_asset_fingerprint in offloaded, (
+            "the blocking fingerprint sweep must run via async_add_executor_job, "
+            "not inline on the event loop"
+        )
+
+    async def test_prime_warms_cache_so_sync_form_does_not_recompute(
+        self, monkeypatch
+    ) -> None:
+        # After the async wrapper primes the cache, the sync substitution that
+        # follows must hit the warm cache and NOT re-run the blocking sweep.
+        await base.async_apply_cache_tokens(_FakeHass("9.9.9"), "{{ASSET_VER}}")
+        assert base._ASSET_FP_CACHE is not None
+
+        calls: list = []
+        real = base._compute_asset_fingerprint
+
+        def _spy(www_dir):  # noqa: ANN001
+            calls.append(www_dir)
+            return real(www_dir)
+
+        monkeypatch.setattr(base, "_compute_asset_fingerprint", _spy)
+        base._apply_cache_tokens("{{ASSET_VER}}", _FakeHass("9.9.9"))
+        assert calls == [], "warm cache must not trigger a blocking recompute"
+
+    async def test_fresh_cache_skips_executor_entirely(self) -> None:
+        # A warm cache is a no-op: no executor job, no sweep — the hot path.
+        await base.async_apply_cache_tokens(_FakeHass("9.9.9"), "{{ASSET_VER}}")
+
+        offloaded: list = []
+
+        class _SpyHass(_FakeHass):
+            async def async_add_executor_job(self, func, *args):  # noqa: ANN001
+                offloaded.append(func)
+                return func(*args)
+
+        await base.async_apply_cache_tokens(_SpyHass("9.9.9"), "{{ASSET_VER}}")
+        assert offloaded == [], "a fresh fingerprint cache must skip the executor"

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -1833,6 +1833,9 @@ class TestSetPhaseSSOT:
         [
             # Forward edges from the table.
             (GamePhase.LOBBY, GamePhase.PLAYING),
+            # LOBBY -> PAUSED: first-round playback failure (unreachable speaker)
+            # pauses the game while it is still in LOBBY (#768/#1627).
+            (GamePhase.LOBBY, GamePhase.PAUSED),
             (GamePhase.PLAYING, GamePhase.REVEAL),
             (GamePhase.PLAYING, GamePhase.PAUSED),
             (GamePhase.REVEAL, GamePhase.PLAYING),


### PR DESCRIPTION
## What

Two fixes for warnings that surfaced during a live game (log triage):

### 1. No blocking I/O on the HTML serve path
`_compute_asset_fingerprint` (the asset cache-buster) does a blocking `rglob`/`stat` sweep of `www/{css,js,i18n}`. It was called **inline on the event loop** via `_apply_cache_tokens` on every HTML / `sw.js` serve. The fingerprint is throttled (5s TTL) + lock-guarded (#1592), but when the TTL expires the recompute still ran in the loop and tripped HA's `util/loop` blocking-call detector:

```
Detected blocking call to scandir with args ('.../beatify/www/css/',) inside the event loop
  by custom integration 'beatify' at server/base.py, line 104
```

**Fix:** new `async_apply_cache_tokens(hass, text)` primes the fingerprint cache in an executor (`hass.async_add_executor_job`) first, then does the sync token substitution against the warm cache. All six serve call sites converted (admin / launcher / player HTML, `sw.js`, dashboard, analytics). A fresh cache is a no-op (skips the executor entirely — the hot path).

### 2. `LOBBY -> PAUSED` is a legitimate transition
When the first round's playback fails (e.g. an unreachable speaker), the playback-failure handler pauses the game while it is still in `LOBBY` (the `PLAYING` transition never completes). That edge wasn't in `_VALID_PHASE_TRANSITIONS`, so it logged a spurious observational warning (#1273):

```
Unexpected phase transition LOBBY -> PAUSED (not in transition table); proceeding.
```

**Fix:** add `PAUSED` to `LOBBY`'s allowed set with an explanatory comment.

## Why now
Both fired in a live session (20:34–20:43). Neither is functionally breaking — the fingerprint is throttled and the transition check is observational-only — but they're real log noise and the blocking call can jank the event loop when it fires.

## Tests
- `tests/unit/test_asset_cachebuster.py` — new `TestAsyncApplyCacheTokens`: the wrapper offloads the fingerprint sweep to the executor, warms the cache so the sync form does **not** recompute, and skips the executor when the cache is fresh. Existing end-to-end view tests already exercise the converted serve path.
- `tests/unit/test_state.py` — `LOBBY -> PAUSED` added to the `test_valid_transition_does_not_warn` parametrization.
- Full unit suite green (1447 passed), `ruff check`/`format` clean, `mypy` clean.

Refs #768, #1627, #1273, #1592

🤖 Generated with [Claude Code](https://claude.com/claude-code)
