### PR TITLE
chore(playlists): tidal backfill wave — +1 uri (ballermann-party-hits)

### DIFF
--- a/custom_components/beatify/playlists/community/ballermann-party-hits.json
+++ b/custom_components/beatify/playlists/community/ballermann-party-hits.json
@@ -1,6 +1,6 @@
 {
   "name": "Ballermann Party Hits",
-  "version": "1.7",
+  "version": "1.8",
   "tags": [
     "schlager",
     "party",
@@ -955,7 +955,7 @@
         "it": "applemusic://track/6768697709"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=muanMtynQV0",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/430782930",
       "uri_deezer": "deezer://track/3329770641",
       "alt_artists": [
         "Julian Sommer"


### PR DESCRIPTION
Automated Tidal-URI backfill wave (22:00 CEST).

**Delta:**
- `ballermann-party-hits.json` — Isi Glück – Bax Banni → `tidal://track/430782930` (version 1.7 → 1.8)

19 genuine misses, 60 rate-limit skips (retry next wave). URI-only + version bump; validated by the Playlist JSON Schema Gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)