### PR TITLE
data: fix broken YouTube Music URI in anime-openings (#1802)

### DIFF
--- a/custom_components/beatify/playlists/community/anime-openings.json
+++ b/custom_components/beatify/playlists/community/anime-openings.json
@@ -434,7 +434,7 @@
         "nl": "applemusic://track/1692289314",
         "it": "applemusic://track/1692289314"
       },
-      "uri_youtube_music": "https://music.youtube.com/watch?v=A2jr18ZbkFc",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=zuoVd2QNxJo",
       "uri_tidal": null,
       "uri_deezer": null,
       "fun_fact": "Opening 1 of 'Jujutsu Kaisen' Season 2 by Tatsuya Kitani.",


### PR DESCRIPTION
Closes #1802.

Replaced incorrect Acoustic Version link with the correct original opening theme for Tatsuya Kitani - 青のすみか from Jujutsu Kaisen Season 2.

**Changes:**
- Updated YouTube Music URI from (Acoustic Version) to (original theme)
- 1 URI fixed

**Validation:**
- Confirmed by AI review of 96 flagged URIs (95 were expected false positives due to Japanese title format differences on different platforms)