### PR TITLE
data: fix 2 dead Apple Music URIs in ballermann-party-hits (#1804)

### DIFF
--- a/custom_components/beatify/playlists/community/ballermann-party-hits.json
+++ b/custom_components/beatify/playlists/community/ballermann-party-hits.json
@@ -1,6 +1,6 @@
 {
   "name": "Ballermann Party Hits",
-  "version": "1.8",
+  "version": "1.9",
   "tags": [
     "schlager",
     "party",
@@ -4112,15 +4112,15 @@
       "year": 2012,
       "isrc": "DEC611200301",
       "uri": "spotify:track:49RTrYhydcQGGm4RxUtVhv",
-      "uri_apple_music": "applemusic://track/1784923514",
+      "uri_apple_music": "applemusic://track/1442233430",
       "uri_apple_music_by_region": {
-        "us": "applemusic://track/1784923514",
-        "de": "applemusic://track/1784923514",
-        "gb": "applemusic://track/1784923514",
-        "fr": "applemusic://track/1784923514",
-        "es": "applemusic://track/1784923514",
-        "nl": "applemusic://track/1784923514",
-        "it": "applemusic://track/1784923514"
+        "us": "applemusic://track/1442233430",
+        "de": "applemusic://track/1442233430",
+        "gb": "applemusic://track/1442233430",
+        "fr": "applemusic://track/1442233430",
+        "es": "applemusic://track/1442233430",
+        "nl": "applemusic://track/1442233430",
+        "it": "applemusic://track/1442233430"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=nqraNWUjasA",
       "uri_tidal": null,
@@ -4839,15 +4839,15 @@
       "year": 2002,
       "isrc": "DEC610800451",
       "uri": "spotify:track:11sqYqOdI6Mt8to9w2HuJV",
-      "uri_apple_music": "applemusic://track/1784937256",
+      "uri_apple_music": "applemusic://track/1813909935",
       "uri_apple_music_by_region": {
-        "us": "applemusic://track/1784937256",
-        "de": "applemusic://track/1784937256",
-        "gb": "applemusic://track/1784937256",
-        "fr": "applemusic://track/1784937256",
-        "es": "applemusic://track/1784937256",
-        "nl": "applemusic://track/1784937256",
-        "it": "applemusic://track/1784937256"
+        "us": "applemusic://track/1813909935",
+        "de": "applemusic://track/1813909935",
+        "gb": "applemusic://track/1813909935",
+        "fr": "applemusic://track/1813909935",
+        "es": "applemusic://track/1813909935",
+        "nl": "applemusic://track/1813909935",
+        "it": "applemusic://track/1813909935"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=YGGnS4QQndo",
       "uri_tidal": null,


### PR DESCRIPTION
Closes #1804.

Daily playlist-review found 2 dead Apple Music URIs (HTTP 404) in `ballermann-party-hits.json`. Replacements verified live via iTunes lookup across all 7 regions (us/de/gb/fr/es/nl/it).

| Track | Old (dead) | New (live) |
|---|---|---|
| Nur noch Schuhe an - Party-Version 2013 | 1784923514 | 1442233430 (Luxor-Live 2013) |
| Zehn Nackte Friseusen 2003 | 1784937256 | 1813909935 (Ballermann Mix) |

Each: `uri_apple_music` + all 7 `uri_apple_music_by_region` entries. Version 1.8→1.9. Schema gate passes. Other 12 wrong_track flags reviewed + dismissed (8 artist-strip FPs, 4 same-song-different-mix) — see #1804.