### PR TITLE
data: fix 1 broken URI in finnish-iskelma-classics (#1807)

### DIFF
--- a/custom_components/beatify/playlists/community/finnish-iskelma-classics.json
+++ b/custom_components/beatify/playlists/community/finnish-iskelma-classics.json
@@ -1,6 +1,6 @@
 {
   "name": "Finnish Schlager Classics 🇫🇮",
-  "version": "1.1",
+  "version": "1.2",
   "tags": [
     "finnish",
     "iskelma",
@@ -7453,7 +7453,7 @@
         "it": null
       },
       "uri_deezer": "40489611",
-      "uri_youtube_music": "https://music.youtube.com/watch?v=1jxXiPxyXsQ",
+      "uri_youtube_music": null,
       "uri_tidal": null,
       "alt_artists": [
         "Susanna Heikki",


### PR DESCRIPTION
Closes #1807.

Removed the YouTube Music URI for **Agents - Kello käy - A Wondrous Place** which pointed to the live album version (`On Stage - In Studio`, 2012). No studio version is available on YouTube Music. The song remains playable via Spotify and Deezer.

Bumped playlist version `1.1` → `1.2`.

**AI review outcome:**
- 7 flags dismissed as false positives (3 Apple Music FI-catalog-only tracks; 4 YouTube title-format mismatches)
- 1 confirmed issue fixed (YouTube live version)