### PR TITLE
data: fix 1 broken Apple Music URI in trance-classics (#1809)

### DIFF
--- a/custom_components/beatify/playlists/community/trance-classics.json
+++ b/custom_components/beatify/playlists/community/trance-classics.json
@@ -1,6 +1,6 @@
 {
   "name": "Trance Classics",
-  "version": "1.2",
+  "version": "1.3",
   "tags": [
     "trance",
     "hands-up",
@@ -94,7 +94,7 @@
       "year": 1993,
       "isrc": "DEL020260008",
       "uri": "spotify:track:2w9Yfj0FcyKcPCIkzsRSwD",
-      "uri_apple_music": "applemusic://track/1456244005",
+      "uri_apple_music": "applemusic://track/1703077503",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/785625381",
         "de": "applemusic://track/785392307",


### PR DESCRIPTION
Closes #1809. Replaced dead Apple Music URI for Energy 52 – Café Del Mar with current track ID `applemusic://track/1703077503` (Three 'N One Radio Edit). Bumped playlist version to 1.3.