### PR TITLE
data: fix release year for Norman Greenbaum – Spirit In The Sky (#1812)

### DIFF
--- a/custom_components/beatify/playlists/one-hit-wonders.json
+++ b/custom_components/beatify/playlists/one-hit-wonders.json
@@ -1,6 +1,6 @@
 {
   "name": "One-Hit Wonders",
-  "version": "1.6",
+  "version": "1.7",
   "tags": [
     "one-hit",
     "classics",
@@ -434,7 +434,7 @@
       }
     },
     {
-      "year": 1970,
+      "year": 1969,
       "uri": "spotify:track:0jvN7eQJJt4nxQzgQfZ1SP",
       "artist": "Norman Greenbaum",
       "alt_artists": [


### PR DESCRIPTION
Closes #1812

## What
Corrects the release year of **Norman Greenbaum – Spirit In The Sky** in `custom_components/beatify/playlists/one-hit-wonders.json` from **1970** to **1969**, and bumps the playlist `version` 1.6 → 1.7.

## Why
The reported value 1970 is the chart-peak year, not the original release year. The single was released in **December 1969** by Reprise Records. Beatify's data convention uses the song's original release year.

## Verification (two authoritative sources)
- **Discogs** — 7" single release [r809956](https://discogs.com/release/809956) dated **1969**; album LP [r8145185](https://www.discogs.com/release/8145185-Norman-Greenbaum-Spirit-In-The-Sky) dated **1969**.
- **Wikipedia** — [Spirit in the Sky](https://en.wikipedia.org/wiki/Spirit_in_the_Sky): "released in December 1969 ... by Reprise Records" (charted into 1970).

## Readiness assessment
- [x] Ready to merge
- [ ] Borderline — see notes
- [ ] Not ready — needs human review

**Honest summary:** Data-only, one-field correction plus a playlist version bump. Cross-checked against Discogs (single + album, both 1969) and Wikipedia (December 1969). Low risk.

## Test plan
- `python scripts/validate_playlists.py` → `one-hit-wonders.json` passes the schema gate (the CI `validate-playlists` job).
- No Python source touched → ruff / unit tests not applicable to this change.

## Risk assessment
- **Blast radius:** one field (`year`) + `version` in a single playlist JSON.
- **What could go wrong:** none identified; the value is a well-documented 1969 release.
- **What I did NOT test:** in-game rendering (data-only change, schema-validated).

🤖 Auto-generated by issue-triage routine