### PR TITLE
data: fix 1 broken Apple Music URI in disco-funk-classics (#1814)

### DIFF
--- a/custom_components/beatify/playlists/disco-funk-classics.json
+++ b/custom_components/beatify/playlists/disco-funk-classics.json
@@ -1,6 +1,6 @@
 {
   "name": "Disco & Funk Classics",
-  "version": "1.6",
+  "version": "1.7",
   "tags": [
     "1970s",
     "1980s",
@@ -1089,21 +1089,20 @@
       "fun_fact_de": "Gloria Gaynors Disco-Version des Frankie-Valli-Klassikers von 1967 verwandelte eine Doo-Wop-Ballade in eine pulsierende Dancefloor-Hymne. Das Original von Frankie Valli erreichte Platz 2 der Billboard Hot 100 und wurde von über 200 Künstlern gecovert.",
       "fun_fact_es": "La versión disco de Gloria Gaynor del clásico de Frankie Valli de 1967 transformó una balada doo-wop en un himno pulsante de pista de baile. El original de Frankie Valli llegó al #2 del Billboard Hot 100 y ha sido versionada por más de 200 artistas.",
       "fun_fact_fr": "La version disco de Gloria Gaynor du classique de Frankie Valli de 1967 a transformé une ballade doo-wop en un hymne de piste de danse pulsant. L'original de Frankie Valli avait atteint la 2e place du Billboard Hot 100 et a été repris par plus de 200 artistes.",
-      "uri_apple_music": "applemusic://track/1838865894",
+      "uri_apple_music": "applemusic://track/1650393398",
       "uri_youtube_music": "https://music.youtube.com/watch?v=usccCsOdkM4",
       "uri_tidal": "tidal://track/45751156",
       "uri_deezer": "deezer://track/360910551",
       "fun_fact_nl": "Gloria Gaynors discoversie van Frankie Valli's klassieker uit 1967 transformeerde een doo-wopballade in een pulserende dansklassieker. Het origineel van Frankie Valli bereikte nummer 2 op de Billboard Hot 100 en is gecoverd door meer dan 200 artiesten.",
       "awards_nl": [],
-      "isrc": "ITT4X2400033",
       "uri_apple_music_by_region": {
-        "us": "applemusic://track/1838865894",
-        "de": "applemusic://track/1838865894",
-        "gb": "applemusic://track/1838865894",
-        "fr": "applemusic://track/1838865894",
-        "es": "applemusic://track/1838865894",
-        "nl": "applemusic://track/1838865894",
-        "it": "applemusic://track/1838865894"
+        "us": "applemusic://track/1650393398",
+        "de": "applemusic://track/1650393398",
+        "gb": "applemusic://track/1650393398",
+        "fr": "applemusic://track/1650393398",
+        "es": "applemusic://track/1650393398",
+        "nl": "applemusic://track/1650393398",
+        "it": "applemusic://track/1650393398"
       }
     },
     {


### PR DESCRIPTION
Closes #1814. Replaced 1 wrong Apple Music URI and bumped playlist version to 1.7.

**Fix:** Gloria Gaynor — Can't Take My Eyes Off You Apple Music URI was pointing to a collaborative recording with Joe Mangione (New Edit Version, 2024). Updated to the correct solo version (track/1650393398). Removed the stale ISRC (which belonged to the collaboration); it will be re-resolved on the next Apple Music region refresh run.