### PR TITLE
fix: show Sudden Death gating reason on touch (#1799)

### DIFF
--- a/custom_components/beatify/www/css/styles.css
+++ b/custom_components/beatify/www/css/styles.css
@@ -10698,11 +10698,25 @@ body.home-mode .home-view {
 }
 .wiz-mode-card:hover { background: var(--color-dark-surface-hover); }
 /* Issue #827: a mode card disabled by an unmet requirement (e.g. Sudden Death
-   below the 3-player floor) is dimmed and non-interactive. */
+   below the 3-player floor) is dimmed and non-interactive.
+   Issue #1799: the dimming used to sit on the card itself, which also dimmed
+   the line explaining WHY it is blocked — the one line that has to stay
+   readable. Dim the card's own content instead and leave .wiz-mode-hint.gated
+   at full contrast. */
 .wiz-mode-card.disabled {
-    opacity: 0.45;
     cursor: not-allowed;
     pointer-events: none;
+}
+.wiz-mode-card.disabled .wiz-mode-icon,
+.wiz-mode-card.disabled .wiz-mode-title,
+.wiz-mode-card.disabled .wiz-lvl-toggle {
+    opacity: 0.45;
+}
+/* Issue #1799: the gating requirement, shown in place of the mode hint. It is
+   the only visible explanation on touch (no hover → no title tooltip). */
+.wiz-mode-hint.gated {
+    color: var(--color-warning);
+    font-weight: 600;
 }
 .wiz-mode-card.on {
     background: rgba(255, 45, 106, 0.08);

--- a/custom_components/beatify/www/i18n/de.json
+++ b/custom_components/beatify/www/i18n/de.json
@@ -634,6 +634,7 @@
     "suddenDeathMode": "Sudden Death",
     "suddenDeathModeHint": "Der Letzte jeder Runde scheidet aus. Wer übrig bleibt, gewinnt.",
     "suddenDeathDisabledTooltip": "Sudden Death braucht mindestens 3 Spieler.",
+    "suddenDeathDisabledGate": "Mindestens 3 Spieler nötig",
     "suddenDeathLive": "Sudden Death"  },
   "analyticsDashboard": {
     "title": "Beatify Statistik",

--- a/custom_components/beatify/www/i18n/en.json
+++ b/custom_components/beatify/www/i18n/en.json
@@ -634,6 +634,7 @@
     "suddenDeathMode": "Sudden Death",
     "suddenDeathModeHint": "Last-place player is eliminated each round. Last one standing wins.",
     "suddenDeathDisabledTooltip": "Sudden Death needs at least 3 players.",
+    "suddenDeathDisabledGate": "Needs at least 3 players",
     "suddenDeathLive": "Sudden Death"  },
   "analyticsDashboard": {
     "title": "Beatify Analytics",

--- a/custom_components/beatify/www/i18n/es.json
+++ b/custom_components/beatify/www/i18n/es.json
@@ -634,6 +634,7 @@
     "suddenDeathMode": "Muerte Súbita",
     "suddenDeathModeHint": "El último de cada ronda queda eliminado. Gana el último en pie.",
     "suddenDeathDisabledTooltip": "Muerte Súbita necesita al menos 3 jugadores.",
+    "suddenDeathDisabledGate": "Se necesitan al menos 3 jugadores",
     "suddenDeathLive": "Muerte Súbita"
   },
   "analyticsDashboard": {

--- a/custom_components/beatify/www/i18n/fr.json
+++ b/custom_components/beatify/www/i18n/fr.json
@@ -634,6 +634,7 @@
     "suddenDeathMode": "Mort Subite",
     "suddenDeathModeHint": "Le dernier de chaque manche est éliminé. Le dernier en lice gagne.",
     "suddenDeathDisabledTooltip": "La Mort Subite nécessite au moins 3 joueurs.",
+    "suddenDeathDisabledGate": "Au moins 3 joueurs requis",
     "suddenDeathLive": "Mort Subite"
   },
   "analyticsDashboard": {

--- a/custom_components/beatify/www/i18n/nl.json
+++ b/custom_components/beatify/www/i18n/nl.json
@@ -634,6 +634,7 @@
     "suddenDeathMode": "Sudden Death",
     "suddenDeathModeHint": "De laatste van elke ronde valt af. Wie overblijft, wint.",
     "suddenDeathDisabledTooltip": "Sudden Death heeft minstens 3 spelers nodig.",
+    "suddenDeathDisabledGate": "Minstens 3 spelers nodig",
     "suddenDeathLive": "Sudden Death"
   },
   "analyticsDashboard": {

--- a/custom_components/beatify/www/js/__tests__/wizard.test.js
+++ b/custom_components/beatify/www/js/__tests__/wizard.test.js
@@ -3,7 +3,7 @@
  * These helpers drive the state machine: when to show, where to resume, when to show the pill.
  */
 import { describe, it, expect, beforeEach } from 'vitest';
-import { resumeAtStep, shouldTrigger, shouldShowPill, providerSupportedForPlayer, capabilityBadgeForPlayer, applyGameModeTogglePrecedence, difficultyDisplayFor, buildWizChip, resolveGameLanguageDefault, buildTtsPayload } from '../wizard.js';
+import { resumeAtStep, shouldTrigger, shouldShowPill, providerSupportedForPlayer, capabilityBadgeForPlayer, applyGameModeTogglePrecedence, difficultyDisplayFor, buildWizChip, resolveGameLanguageDefault, buildTtsPayload, modeHintHtml } from '../wizard.js';
 
 function makeLS(initial = {}) {
     const store = { ...initial };
@@ -536,5 +536,29 @@ describe('buildTtsPayload (#1401 — preserve tts_pre_round_delay)', () => {
         });
         expect('tts_pre_round_delay' in out).toBe(false);
         expect(out.preset).toBe('standard');
+    });
+});
+
+// ---------------------------------------------------------------------------
+// modeHintHtml — the gated mode card explains itself without hover (#1799)
+describe('modeHintHtml', () => {
+    it('renders the mode description when the card is not gated', () => {
+        const out = modeHintHtml(false, 'Needs at least 3 players', 'Last one out each round.');
+        expect(out).toBe('<div class="wiz-mode-hint">Last one out each round.</div>');
+        expect(out).not.toContain('gated');
+    });
+
+    it('replaces the description with the requirement when the card is gated', () => {
+        const out = modeHintHtml(true, 'Needs at least 3 players', 'Last one out each round.');
+        expect(out).toContain('wiz-mode-hint gated');
+        expect(out).toContain('Needs at least 3 players');
+        // The requirement must be visible on its own — not hidden behind hover.
+        expect(out).not.toContain('Last one out each round.');
+    });
+
+    it('escapes the gate text', () => {
+        const out = modeHintHtml(true, '<img src=x onerror=alert(1)>', 'hint');
+        expect(out).not.toContain('<img');
+        expect(out).toContain('&lt;img');
     });
 });

--- a/custom_components/beatify/www/js/wizard.js
+++ b/custom_components/beatify/www/js/wizard.js
@@ -121,6 +121,15 @@ export function shouldShowPill(localStorage) {
  * @param {boolean} value - the new value for that toggle.
  * @returns {Object} a new flags object with precedence applied.
  */
+// Issue #1799 — the hint line of a mode card. When the mode is gated by an
+// unmet requirement, the line carries the requirement itself instead of the
+// mode description: on touch there is no hover, so the `title` tooltip that
+// used to be the only explanation never shows.
+export function modeHintHtml(disabled, gateText, hintHtml) {
+    if (!disabled) return `<div class="wiz-mode-hint">${hintHtml}</div>`;
+    return `<div class="wiz-mode-hint gated">🔒 ${escapeText(gateText)}</div>`;
+}
+
 export function applyGameModeTogglePrecedence(flags, key, value) {
     const next = { ...flags };
     switch (key) {
@@ -1025,15 +1034,24 @@ function _renderGameModes() {
         }
         // Issue #827 — disabled Sudden Death card: dimmed, non-interactive, with
         // a tooltip explaining the >=3 player requirement.
+        // Issue #1799 — the tooltip is hover-only, so on touch (the primary way
+        // the wizard is used) the requirement was invisible and the dimmed card
+        // read as broken. Swap the hint line for the requirement itself, and
+        // mark it .gated so the CSS can keep it legible against the dimming.
         const disabled = m.key === 'suddenDeath' && suddenDeathDisabled;
         const titleAttr = disabled
             ? ` title="${escapeAttr(_t('admin.suddenDeathDisabledTooltip', 'Needs at least 3 players'))}"`
             : '';
+        const hint = modeHintHtml(
+            disabled,
+            _t('admin.suddenDeathDisabledGate', 'Needs at least 3 players'),
+            _t(m.hintKey, m.hintFallback),
+        );
         return `<div class="wiz-mode-card ${on ? 'on' : ''}${disabled ? ' disabled' : ''}" data-mode="${m.key}" role="button" tabindex="0" aria-disabled="${disabled}"${titleAttr}>
             <div class="wiz-mode-icon" aria-hidden="true">${m.icon}</div>
             <div class="wiz-mode-body">
                 <div class="wiz-mode-title">${_t(m.titleKey, m.titleFallback)}</div>
-                <div class="wiz-mode-hint">${_t(m.hintKey, m.hintFallback)}</div>
+                ${hint}
             </div>
             <div class="wiz-lvl-toggle"></div>
         </div>`;


### PR DESCRIPTION
Closes #1799. Variant A (hint swap) from the design gate.

## Problem

The Sudden Death card is gated below 3 connected players (#827). The reason lived **only** in a hover `title` tooltip — and the setup wizard is used primarily on touch, where there is no hover. Combined with `pointer-events: none`, tapping the dimmed card did nothing and gave no explanation, so a deliberate gate read as a bug.

## Change

When the card is gated, the `.wiz-mode-hint` line carries the requirement itself (`🔒 Needs at least 3 players`) instead of the mode description. `title=` and `aria-disabled` are untouched, so desktop hover and assistive tech keep what they had.

**One deviation from the mockup, on purpose.** In the rendered variant the card-level `opacity: .45` also dimmed the new line — the single line whose job is to explain the dimming would have been the faintest text on the card, which is exactly the readability problem the issue is about. So the dimming moved from the card to its own content (icon, title, toggle) and `.wiz-mode-hint.gated` renders at full contrast in `--color-warning`. `pointer-events: none` and `cursor: not-allowed` are unchanged, and no other card uses `.wiz-mode-card.disabled`.

The hint logic is extracted into an exported pure helper `modeHintHtml()`, matching the file's existing "pure helpers — exported for vitest" pattern.

## i18n

New key `admin.suddenDeathDisabledGate` next to the existing `admin.suddenDeathDisabledTooltip`, in all 5 languages (de/en/es/fr/nl).

## Verification

- 496/496 JS tests pass (3 new for `modeHintHtml`: ungated description, gated requirement, escaping).
- ESLint: 0 errors.
- Rendered against the real changed `styles.css` + `wizard.js` in a headless browser; computed styles confirm the gated line at `rgb(245, 158, 11)` (undimmed), title still at `opacity: 0.45`, `pointer-events: none` intact.
- No `.min.js` regeneration or cache-buster bump needed: `wizard.js` is loaded as a module (not bundled into `admin.min.js`), and `ASSET_VER` / `sw.js CACHE_VERSION` are templated at serve time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
