### PR TITLE
chore(playlists): tidal backfill salvage — +2 uris (ballermann-party-hits)

### DIFF
--- a/custom_components/beatify/playlists/community/ballermann-party-hits.json
+++ b/custom_components/beatify/playlists/community/ballermann-party-hits.json
@@ -1,6 +1,6 @@
 {
   "name": "Ballermann Party Hits",
-  "version": "1.11",
+  "version": "1.12",
   "tags": [
     "schlager",
     "party",
@@ -1510,7 +1510,7 @@
         "it": "applemusic://track/1733692530"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=cH5lcXQkx2A",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/349692494",
       "uri_deezer": "deezer://track/2694100132",
       "alt_artists": [
         "Knossi"
@@ -1538,7 +1538,7 @@
         "it": "applemusic://track/1729155005"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=o2l7I2O2zeA",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/344504027",
       "uri_deezer": "deezer://track/2655163012",
       "fun_fact": "Julian Sommer is a new-generation Mallorca party star whose \"Dicht im Flieger\" was a huge 2022 hit.",
       "fun_fact_de": "Julian Sommer ist ein Mallorca-Partystar der neuen Generation; sein \"Dicht im Flieger\" war 2022 ein Riesenhit.",


### PR DESCRIPTION
Salvages the stranded **12:00 backfill wave**. That session resolved two Tidal URIs but died before committing, leaving the changes uncommitted in a stale `/tmp` worktree. They were **not** included in #1816 (verified against `origin/main`: both URIs absent, file still at `1.11`).

Re-applied against current `main` by targeted edit — not a file copy — so the +18 URIs merged via #1816 stay intact.

| Track | Tidal URI |
|---|---|
| Lorenz Büffel — Midnight Lady | `tidal://track/349692494` |
| Julian Sommer — Neverland | `tidal://track/344504027` |

`ballermann-party-hits` version `1.11` → `1.12`. Remaining tracks without a Tidal URI in this playlist: 150.

URI-only, additive, covered by the Playlist JSON Schema Gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)