### PR TITLE
chore(playlists): tidal backfill salvage — +14 uris (ballermann-party-hits)

### DIFF
--- a/custom_components/beatify/playlists/community/ballermann-party-hits.json
+++ b/custom_components/beatify/playlists/community/ballermann-party-hits.json
@@ -1,6 +1,6 @@
 {
   "name": "Ballermann Party Hits",
-  "version": "1.12",
+  "version": "1.13",
   "tags": [
     "schlager",
     "party",
@@ -367,7 +367,7 @@
         "it": "applemusic://track/6768696704"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=HrFgfHIBiA8",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/504810496",
       "uri_deezer": "deezer://track/3885416411",
       "fun_fact": "Julian Sommer is a new-generation Mallorca party star whose \"Dicht im Flieger\" was a huge 2022 hit.",
       "fun_fact_de": "Julian Sommer ist ein Mallorca-Partystar der neuen Generation; sein \"Dicht im Flieger\" war 2022 ein Riesenhit.",
@@ -392,7 +392,7 @@
         "it": "applemusic://track/6765750605"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=_oIbocH505E",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/500597855",
       "uri_deezer": "deezer://track/3856158681",
       "alt_artists": [
         "Ikke Hüftgold",
@@ -421,7 +421,7 @@
         "it": "applemusic://track/1708222619"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=gaFQ4Hhl8YE",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/243163118",
       "uri_deezer": "deezer://track/1867701317",
       "alt_artists": [
         "Kings of Günter",
@@ -450,7 +450,7 @@
         "it": "applemusic://track/1839500910"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=H6su3VwkMGA",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/461568904",
       "uri_deezer": "deezer://track/3562765671",
       "alt_artists": [
         "Ingo ohne Flamingo",
@@ -480,7 +480,7 @@
         "it": "applemusic://track/1878166364"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=aEuKqlcohTA",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/492128388",
       "uri_deezer": "deezer://track/3792397922",
       "fun_fact": "A Mallorca / Ballermann party hit (2026).",
       "fun_fact_de": "Ein Mallorca-/Ballermann-Partyhit (2026).",
@@ -505,7 +505,7 @@
         "it": "applemusic://track/1878166755"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=YG6k0EZR8Uo",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/464578463",
       "uri_deezer": null,
       "alt_artists": [
         "Julian Sommer",
@@ -536,7 +536,7 @@
         "it": "applemusic://track/1822359190"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=V6Eaw_WvnsU",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/478479207",
       "uri_deezer": "deezer://track/3696190672",
       "fun_fact": "A Mallorca / Ballermann party hit (2025).",
       "fun_fact_de": "Ein Mallorca-/Ballermann-Partyhit (2025).",
@@ -561,7 +561,7 @@
         "it": "applemusic://track/1823233297"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=YY0krzw0kJ8",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/444688165",
       "uri_deezer": "deezer://track/3434310821",
       "alt_artists": [
         "Timo Scheppert",
@@ -590,7 +590,7 @@
         "it": "applemusic://track/1878166747"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=ZQ2DafYzxyQ",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/451514325",
       "uri_deezer": "deezer://track/3487142851",
       "alt_artists": [
         "Frenzy"
@@ -618,7 +618,7 @@
         "it": "applemusic://track/1827498588"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=IKYqx_B_8Dk",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/450167555",
       "uri_deezer": "deezer://track/3476764771",
       "alt_artists": [
         "Malle Anja",
@@ -648,7 +648,7 @@
         "it": "applemusic://track/1878167016"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=5G6WhC39x3k",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/446945731",
       "alt_artists": [
         "Olaf der Flipper"
       ],
@@ -675,7 +675,7 @@
         "it": "applemusic://track/1823944742"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=FRQxLNtfQvA",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/445505026",
       "uri_deezer": "deezer://track/3439697741",
       "fun_fact": "Mickie Krause is one of Germany's best-known Ballermann entertainers, famous for his sing-along party hits.",
       "fun_fact_de": "Mickie Krause zählt zu den bekanntesten Ballermann-Entertainern Deutschlands, berühmt für seine Mitsing-Partyhits.",
@@ -700,7 +700,7 @@
         "it": "applemusic://track/1878166275"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=ctQtJjiR-vE",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/445992705",
       "uri_deezer": "deezer://track/3444245451",
       "fun_fact": "A Mallorca / Ballermann party hit (2025).",
       "fun_fact_de": "Ein Mallorca-/Ballermann-Partyhit (2025).",
@@ -1386,7 +1386,7 @@
         "it": "applemusic://track/1741012809"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=35Gta9lC_04",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/358213826",
       "uri_deezer": "deezer://track/2757228921",
       "alt_artists": [
         "Marc Eggers"


### PR DESCRIPTION
Recovered from a stranded 12:00 tidal-backfill wave (worktree `beatify-tidal-20260715-1201`) whose session died before commit/PR.

**Delta**
- `ballermann-party-hits` — +14 Tidal URIs (Julian Sommer, Ikke Hüftgold, Kings of Günter, Ingo ohne Flamingo, …), version 1.12 → 1.13

URI-only, no other files touched, JSON valid. Auto-merge on green per the tidal-backfill contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)