### PR TITLE
chore(playlists): tidal backfill wave — +23 uris (ballermann-party-hits)

### DIFF
--- a/custom_components/beatify/playlists/community/ballermann-party-hits.json
+++ b/custom_components/beatify/playlists/community/ballermann-party-hits.json
@@ -1,6 +1,6 @@
 {
   "name": "Ballermann Party Hits",
-  "version": "1.14",
+  "version": "1.15",
   "tags": [
     "schlager",
     "party",
@@ -1969,7 +1969,7 @@
         "it": "applemusic://track/1626938164"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=hV7rPUZa1Bc",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/201548974",
       "uri_deezer": "deezer://track/1524754712",
       "fun_fact": "Wolfgang Petry is a legend of German Schlager, beloved for sing-along anthems like \"Wahnsinn\".",
       "fun_fact_de": "Wolfgang Petry ist eine Legende des deutschen Schlagers, geliebt für Mitsing-Hymnen wie \"Wahnsinn\".",
@@ -1994,7 +1994,7 @@
         "it": "applemusic://track/1695197820"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=xsuHYg5kWqQ",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/294391100",
       "uri_deezer": "deezer://track/2279814117",
       "fun_fact": "Tobee is a Mallorca party-Schlager artist known for catchy party covers and originals.",
       "fun_fact_de": "Tobee ist ein Mallorca-Party-Schlager-Künstler, bekannt für eingängige Party-Cover und Eigenkompositionen.",
@@ -2019,7 +2019,7 @@
         "it": "applemusic://track/1695123243"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=clE-6F_VEBc",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/295990871",
       "uri_deezer": "deezer://track/2291612965",
       "alt_artists": [
         "Deejay Biene",
@@ -2040,7 +2040,7 @@
       "uri_apple_music": null,
       "uri_apple_music_by_region": {},
       "uri_youtube_music": "https://music.youtube.com/watch?v=VnW2FBUnRuc",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/335333730",
       "uri_deezer": null,
       "alt_artists": [
         "Schürze",
@@ -2069,7 +2069,7 @@
         "it": "applemusic://track/1681196511"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=6tsp6Z0toNI",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/289155425",
       "uri_deezer": "deezer://track/2238211297",
       "fun_fact": "DJ Robin is a Ballermann DJ and producer who shot to fame with the 2022 chart-topper \"Layla\".",
       "fun_fact_de": "DJ Robin ist ein Ballermann-DJ und Produzent, der mit dem Nummer-1-Hit \"Layla\" 2022 berühmt wurde.",
@@ -2094,7 +2094,7 @@
         "it": "applemusic://track/1707114391"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=5a_9gngSTsQ",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/291792345",
       "uri_deezer": "deezer://track/2256754637",
       "fun_fact": "Mickie Krause is one of Germany's best-known Ballermann entertainers, famous for his sing-along party hits.",
       "fun_fact_de": "Mickie Krause zählt zu den bekanntesten Ballermann-Entertainern Deutschlands, berühmt für seine Mitsing-Partyhits.",
@@ -2119,7 +2119,7 @@
         "it": "applemusic://track/1721258520"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=nDhzI6hYbms",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/337000336",
       "uri_deezer": null,
       "alt_artists": [
         "DJ Dee"
@@ -2147,7 +2147,7 @@
         "it": "applemusic://track/1687094830"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=b9dRvKj72ws",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/295699445",
       "uri_deezer": "deezer://track/2406223455",
       "alt_artists": [
         "Malle Anja"
@@ -2175,7 +2175,7 @@
         "it": "applemusic://track/1752107890"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=86bdOs8Q33s",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/282385771",
       "uri_deezer": "deezer://track/2195862057",
       "fun_fact": "Peter Wackel is a mainstay of the Mallorca party-Schlager scene and a regular at the Bierkönig.",
       "fun_fact_de": "Peter Wackel ist eine feste Größe der Mallorca-Party-Schlager-Szene und Dauergast im Bierkönig.",
@@ -2200,7 +2200,7 @@
         "it": "applemusic://track/1701685187"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=_0N1VqDP5rk",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/281061881",
       "uri_deezer": "deezer://track/2185020947",
       "alt_artists": [
         "Inki Nici",
@@ -2229,7 +2229,7 @@
         "it": "applemusic://track/930057836"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=xTHtV4NSKwk",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/21992237",
       "uri_deezer": "deezer://track/70082673",
       "fun_fact": "A Mallorca / Ballermann party hit (2013).",
       "fun_fact_de": "Ein Mallorca-/Ballermann-Partyhit (2013).",
@@ -2254,7 +2254,7 @@
         "it": "applemusic://track/1625402009"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=bK1k_nDY0o0",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/266250944",
       "uri_deezer": "deezer://track/2066590617",
       "fun_fact": "Julian Sommer is a new-generation Mallorca party star whose \"Dicht im Flieger\" was a huge 2022 hit.",
       "fun_fact_de": "Julian Sommer ist ein Mallorca-Partystar der neuen Generation; sein \"Dicht im Flieger\" war 2022 ein Riesenhit.",
@@ -2279,7 +2279,7 @@
         "it": "applemusic://track/1688069606"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=9jrBjOZWvmA",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/226390043",
       "uri_deezer": "deezer://track/1732115507",
       "fun_fact": "Lorenz Büffel is a Mallorca party-Schlager star, best known for the anthem \"Johnny Däpp\".",
       "fun_fact_de": "Lorenz Büffel ist ein Mallorca-Party-Schlager-Star, bekannt vor allem durch die Hymne \"Johnny Däpp\".",
@@ -2304,7 +2304,7 @@
         "it": "applemusic://track/1878167480"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=9JLg-oYRp2Q",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/282319333",
       "uri_deezer": "deezer://track/2195310717",
       "alt_artists": [
         "Lorenz Büffel"
@@ -2332,7 +2332,7 @@
         "it": "applemusic://track/1768813119"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=1R8Aq9TdM7c",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/294690957",
       "uri_deezer": "deezer://track/3400429861",
       "fun_fact": "Julian Sommer is a new-generation Mallorca party star whose \"Dicht im Flieger\" was a huge 2022 hit.",
       "fun_fact_de": "Julian Sommer ist ein Mallorca-Partystar der neuen Generation; sein \"Dicht im Flieger\" war 2022 ein Riesenhit.",
@@ -2357,7 +2357,7 @@
         "it": "applemusic://track/880039518"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=5bgL1LMIkvg",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/75042175",
       "uri_deezer": "deezer://track/346173531",
       "fun_fact": "Tobee is a Mallorca party-Schlager artist known for catchy party covers and originals.",
       "fun_fact_de": "Tobee ist ein Mallorca-Party-Schlager-Künstler, bekannt für eingängige Party-Cover und Eigenkompositionen.",
@@ -2382,7 +2382,7 @@
         "it": "applemusic://track/1701685214"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=8DLk2m5srJs",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/250017203",
       "uri_deezer": "deezer://track/1926808767",
       "alt_artists": [
         "Knossi"
@@ -2410,7 +2410,7 @@
         "it": "applemusic://track/1709026570"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=M9CDtiJhzuM",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/201309809",
       "uri_deezer": "deezer://track/1522695572",
       "fun_fact": "Mickie Krause is one of Germany's best-known Ballermann entertainers, famous for his sing-along party hits.",
       "fun_fact_de": "Mickie Krause zählt zu den bekanntesten Ballermann-Entertainern Deutschlands, berühmt für seine Mitsing-Partyhits.",
@@ -2435,7 +2435,7 @@
         "it": "applemusic://track/1701685215"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=HuBR86nnaMA",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/239091105",
       "uri_deezer": "deezer://track/2125898617",
       "alt_artists": [
         "Ikke Hüftgold"
@@ -3895,7 +3895,7 @@
         "it": "applemusic://track/1825576225"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=RCpakXJu_o8",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/84088220",
       "uri_deezer": "deezer://track/456436052",
       "alt_artists": [
         "Specktakel"
@@ -3923,7 +3923,7 @@
         "it": "applemusic://track/1714671423"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=wrrqXZDC9YE",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/46311575",
       "uri_deezer": "deezer://track/2420409535",
       "fun_fact": "Markus Becker is a party-Schlager singer famous for the line-dance hit \"Das rote Pferd\".",
       "fun_fact_de": "Markus Becker ist ein Party-Schlager-Sänger, berühmt für den Line-Dance-Hit \"Das rote Pferd\".",
@@ -3948,7 +3948,7 @@
         "it": "applemusic://track/1445459144"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=Zk-GhIKtLHc",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/337000062",
       "uri_deezer": "deezer://track/2598567692",
       "fun_fact": "A Mallorca / Ballermann party hit (2024).",
       "fun_fact_de": "Ein Mallorca-/Ballermann-Partyhit (2024).",
@@ -3973,7 +3973,7 @@
         "it": "applemusic://track/1276250471"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=GuCSesMFUGU",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/71974548",
       "uri_deezer": "deezer://track/145052236",
       "fun_fact": "Peter Wackel is a mainstay of the Mallorca party-Schlager scene and a regular at the Bierkönig.",
       "fun_fact_de": "Peter Wackel ist eine feste Größe der Mallorca-Party-Schlager-Szene und Dauergast im Bierkönig.",


### PR DESCRIPTION
Automated Tidal-URI backfill wave (22:00 CEST).

**Delta:**
- `ballermann-party-hits`: +23 tidal uris, version 1.14 → 1.15

Wave stats: 23 added · 0 genuine misses · 57 rate-limit skips (retry next wave).

URI-only, Playlist JSON Schema Gate validates in CI. Draft — review/merge at will.

🤖 Generated with [Claude Code](https://claude.com/claude-code)