### PR TITLE
fix(playlists): correct YouTube Music URI for Summer Nights (Grease) (#1841)

### DIFF
--- a/custom_components/beatify/playlists/summer-party-anthems.json
+++ b/custom_components/beatify/playlists/summer-party-anthems.json
@@ -1,6 +1,6 @@
 {
   "name": "100 Summer Anthems ☀️",
-  "version": "1.8",
+  "version": "1.9",
   "tags": [
     "party",
     "classics",
@@ -659,7 +659,7 @@
       "fun_fact_de": "'Summer Nights' aus dem Grease-Soundtrack erreichte Platz eins in Grossbritannien und wurde zu einer der meistverkauften Singles von 1978. Der Song wurde fuer den Film mit anderen Texten als in der Buehnenversion neu aufgenommen.",
       "fun_fact_es": "'Summer Nights' de la banda sonora de Grease llego al numero uno en el Reino Unido y se convirtio en uno de los sencillos mas vendidos de 1978. La cancion fue regrabada para la pelicula con letras diferentes a la version teatral.",
       "uri_apple_music": "applemusic://track/1440844694",
-      "uri_youtube_music": "https://music.youtube.com/watch?v=N8Q-KnMkWS8",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=A_J2bcNx3Gw",
       "uri_tidal": "tidal://track/77625023",
       "fun_fact_fr": "« Summer Nights » de la bande originale de Grease a atteint la première place au Royaume-Uni et est devenu l'un des singles les plus vendus de 1978. La chanson a été réenregistrée pour le film avec des paroles différentes de la version scénique originale.",
       "uri_deezer": "deezer://track/781563042",


### PR DESCRIPTION
Closes #1841.

Replaces the non-official learning-channel re-upload (`N8Q-KnMkWS8`, channel *"GPITRAL2 Music for Learning English with subtitles"*) with the official UMG upload `A_J2bcNx3Gw` (*"John Travolta - Topic"*, verified via oEmbed).

`summer-party-anthems.json` v1.8 → v1.9. URI-only change, no metadata touched.

Daily playlist-review audit (112 songs / 555 URIs): 552 ok, 1 confirmed wrong_track (this), 1 false positive (Despacito, official VEVO), 1 transient 403 (Summer Of '69).