### PR TITLE
docs: add first-game quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,15 @@ Settings → Devices & Services → Add Integration → "Beatify"
 
 That's it. Beatify is now installed.
 
+> [!TIP]
+> ### 🎮 Your First Game in 2 Minutes
+> 1. **Open:** In the Home Assistant sidebar, select **Beatify**, then **Open Beatify**.
+> 2. **Set up:** On your first visit, choose a speaker, music service, and playlist in the guided wizard.
+> 3. **Invite:** On **Ready to host**, show the QR code; guests scan it with any phone and enter their name—no app or account needed.
+> 4. **Play:** When everyone appears in the lobby, select **Start game**.
+>
+> Returning hosts skip the wizard and go straight to **Ready to host**. [See the full hosting guide.](#opening-beatify-admin)
+
 ---
 
 <br>


### PR DESCRIPTION
## Summary
- add a compact "Your First Game in 2 Minutes" callout directly after Home Assistant configuration
- show the exact path from the Beatify sidebar entry to QR-code guest joining
- link to the existing detailed hosting guide without changing application code

## Growth recommendation
Implements `readme-post-config-first-game-quickstart` from the Top-5% growth ledger. The success metric remains the seven-day active HACS-install increase versus the preceding seven days.

## Verification
- [x] GitHub GFM API renders the block as a TIP callout
- [x] all four quickstart steps render as list items
- [x] the detailed-hosting anchor resolves in the rendered HTML
- [x] `git diff --check`

Draft only; merge still requires explicit authorization.