### PR TITLE
chore(playlists): tidal backfill — +19 URIs in 100-greatest-rock-songs

### DIFF
--- a/custom_components/beatify/playlists/community/100-greatest-rock-songs.json
+++ b/custom_components/beatify/playlists/community/100-greatest-rock-songs.json
@@ -1,6 +1,6 @@
 {
   "name": "100 Greatest Rock Songs",
-  "version": "0.5",
+  "version": "0.6",
   "tags": [
     "rock",
     "classic-rock",
@@ -1711,7 +1711,7 @@
       "fun_fact_es": "El videoclip de All the Small Things parodia la estética de las boy bands y las estrellas del pop de la época, con guiños a Britney Spears y a las coreografías de NSYNC y Backstreet Boys.",
       "uri_apple_music": "applemusic://track/1440840510",
       "uri_youtube_music": "https://music.youtube.com/watch?v=9Ht5RZpzPqw",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/173565588",
       "fun_fact_fr": "Le clip d'All the Small Things parodie l'esthétique des boys bands et des popstars de l'époque, avec des clins d'œil à Britney Spears et aux chorégraphies façon NSYNC ou Backstreet Boys.",
       "uri_deezer": "deezer://track/127354207",
       "fun_fact_nl": "De videoclip van All the Small Things parodieert de boyband- en popster-esthetiek van die tijd, met verwijzingen naar Britney Spears en de choreografieën van NSYNC en Backstreet Boys.",
@@ -2956,7 +2956,7 @@
         "it": "applemusic://track/1678339751"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=KXRKoM0misA",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/1211244",
       "uri_deezer": "deezer://track/2680857",
       "fun_fact": "“Slide” by The Goo Goo Dolls was originally released in 1998; the year is based on matched recording and release metadata.",
       "fun_fact_de": "„Slide“ von The Goo Goo Dolls erschien ursprünglich 1998; das Jahr basiert auf abgeglichenen Aufnahme- und Veröffentlichungsdaten.",
@@ -2988,7 +2988,7 @@
       "fun_fact_fr": "« Semi-Charmed Life » de Third Eye Blind est sorti à l’origine en 1997 ; l’année repose sur des métadonnées d’enregistrement et de parution recoupées.",
       "uri_apple_music": "applemusic://track/1747794676",
       "uri_youtube_music": "https://music.youtube.com/watch?v=gjdLAsnR_Ws",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/1584209",
       "uri_deezer": "deezer://track/685709",
       "fun_fact_nl": "“Semi-Charmed Life” van Third Eye Blind verscheen oorspronkelijk in 1997; het jaar is gebaseerd op gecontroleerde opname- en uitgavegegevens.",
       "awards_nl": [],
@@ -3027,7 +3027,7 @@
       "fun_fact_es": "«Backseat» es de Balu Brigada, un grupo neozelandés de indie rock de Auckland liderado por los hermanos multiinstrumentistas Henry y Pierre Beasley.",
       "uri_apple_music": "applemusic://track/1815926074",
       "uri_youtube_music": "https://music.youtube.com/watch?v=Jvv3cC6CamE",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/437387071",
       "fun_fact_fr": "« Backseat » est signé Balu Brigada, un groupe d'indie rock néo-zélandais d'Auckland mené par les frères multi-instrumentistes Henry et Pierre Beasley.",
       "uri_deezer": "deezer://track/3378903331",
       "fun_fact_nl": "'Backseat' is van Balu Brigada, een Nieuw-Zeelandse indierockact uit Auckland rond de multi-instrumentalistische broers Henry en Pierre Beasley.",
@@ -3062,7 +3062,7 @@
       "fun_fact_fr": "Flea (Red Hot Chili Peppers) joue de la basse sur 'You Oughta Know' — la cible présumée de la colère d'Alanis est l'acteur Dave Coulier.",
       "uri_apple_music": "applemusic://track/1798698394",
       "uri_youtube_music": "https://music.youtube.com/watch?v=K_f85Zc6u-U",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/52684790",
       "uri_deezer": "deezer://track/109843288",
       "fun_fact_nl": "Flea (Red Hot Chili Peppers) speelde bas op 'You Oughta Know' — Alanis' woede zou gericht zijn op acteur Dave Coulier.",
       "awards_nl": [],
@@ -3101,7 +3101,7 @@
       "fun_fact_es": "«Get Set» es una canción de 1999 de la banda de Melbourne Taxiride incluida en su álbum debut Imaginate; también apareció en la banda sonora estadounidense de Election.",
       "uri_apple_music": "applemusic://track/345177185",
       "uri_youtube_music": "https://music.youtube.com/watch?v=pzvtPiSeguA",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/3290008",
       "fun_fact_fr": "« Get Set » est une chanson de 1999 du groupe de Melbourne Taxiride, tirée de son premier album Imaginate ; elle figure aussi sur la bande originale américaine d'Election.",
       "uri_deezer": "deezer://track/5195568",
       "fun_fact_nl": "'Get Set' is een nummer uit 1999 van de band Taxiride uit Melbourne, afkomstig van hun debuutalbum Imaginate; het stond ook op de Amerikaanse soundtrack van Election.",
@@ -3238,7 +3238,7 @@
       "fun_fact_es": "«! (The Song Formerly Known As)», de Regurgitator, se publicó originalmente en 1997; el año se basa en datos de grabación y publicación contrastados.",
       "uri_apple_music": "applemusic://track/1812615596",
       "uri_youtube_music": "https://music.youtube.com/watch?v=vnJ97PVnfe8",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/35150991",
       "fun_fact_fr": "« ! (The Song Formerly Known As) » de Regurgitator est sorti à l’origine en 1997 ; l’année repose sur des métadonnées d’enregistrement et de parution recoupées.",
       "uri_deezer": "deezer://track/14684130",
       "fun_fact_nl": "“! (The Song Formerly Known As)” van Regurgitator verscheen oorspronkelijk in 1997; het jaar is gebaseerd op gecontroleerde opname- en uitgavegegevens.",
@@ -3278,7 +3278,7 @@
       "fun_fact_es": "El sonido de guitarra distorsionada de You Really Got Me surgió porque el guitarrista Dave Davies rajó el cono del altavoz de su amplificador con una cuchilla de afeitar, produciendo uno de los sonidos fuzz más tempranos e influyentes del rock.",
       "uri_apple_music": "applemusic://track/1436281753",
       "uri_youtube_music": "https://music.youtube.com/watch?v=fTTsY-oz6Go",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/493118769",
       "fun_fact_fr": "Le son de guitare saturé de You Really Got Me vient du guitariste Dave Davies, qui a entaillé la membrane du haut-parleur de son ampli avec une lame de rasoir, produisant l'un des tout premiers sons fuzz les plus influents du rock.",
       "uri_deezer": "deezer://track/3786490962",
       "fun_fact_nl": "Het vervormde gitaargeluid van You Really Got Me ontstond doordat gitarist Dave Davies het luidsprekermembraan van zijn versterker met een scheermesje insneed, wat een van de vroegste en invloedrijkste fuzz-geluiden in de rockmuziek opleverde.",
@@ -3362,7 +3362,7 @@
       "fun_fact_es": "Howlin' for You pertenece al álbum Brothers, grabado en el histórico Muscle Shoals Sound Studio de Alabama, lo que ayudó a acercar el sonido crudo de blues rock de The Black Keys a un público mucho más masivo.",
       "uri_apple_music": "applemusic://track/1052966898",
       "uri_youtube_music": "https://music.youtube.com/watch?v=Zs3cyuXSFII",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/163704384",
       "fun_fact_fr": "Howlin' for You est extraite de l'album Brothers, enregistré au célèbre Muscle Shoals Sound Studio en Alabama, ce qui a aidé le son brut de blues rock des Black Keys à toucher un public bien plus large.",
       "uri_deezer": "deezer://track/1191627802",
       "fun_fact_nl": "Howlin' for You komt van het album Brothers, opgenomen in de historische Muscle Shoals Sound Studio in Alabama, wat hielp om het rauwe bluesrockgeluid van The Black Keys bij een veel groter mainstreampubliek te brengen.",
@@ -3402,7 +3402,7 @@
       "fun_fact_es": "El videoclip de Hungry Like the Wolf, rodado en Sri Lanka con una temática de aventuras al estilo Indiana Jones, formó parte de una ola de videoclips ambiciosos de los primeros años de MTV que ayudaron a definir la imagen de Duran Duran.",
       "uri_apple_music": "applemusic://track/693610779",
       "uri_youtube_music": "https://music.youtube.com/watch?v=oJL-lCzEXgI",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/3087888",
       "fun_fact_fr": "Le clip de Hungry Like the Wolf, tourné au Sri Lanka sur une thématique d'aventure façon Indiana Jones, faisait partie d'une vague de clips ambitieux du début de MTV qui ont contribué à définir l'image de Duran Duran.",
       "uri_deezer": "deezer://track/3130433",
       "fun_fact_nl": "De videoclip van Hungry Like the Wolf, opgenomen op locatie in Sri Lanka met een Indiana Jones-achtig avonturenthema, maakte deel uit van een golf ambitieuze vroege MTV-clips die het imago van Duran Duran mee bepaalden.",
@@ -3512,7 +3512,7 @@
       "fun_fact_es": "«Feel It Still» se basa en la melodía de «Please Mr. Postman» de The Marvelettes; por ello, los créditos de composición incluyen a los autores de Motown Robert Bateman, Freddie Gorman y Brian Holland.",
       "uri_apple_music": "applemusic://track/1229315050",
       "uri_youtube_music": "https://music.youtube.com/watch?v=pBkHHoOIIn8",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/74886171",
       "fun_fact_fr": "« Feel It Still » reprend la mélodie de « Please Mr. Postman » des Marvelettes ; ses crédits d'écriture incluent donc les auteurs de Motown Robert Bateman, Freddie Gorman et Brian Holland.",
       "uri_deezer": "deezer://track/371593461",
       "fun_fact_nl": "'Feel It Still' gebruikt de melodie van 'Please Mr. Postman' van The Marvelettes; daarom staan ook Motown-schrijvers Robert Bateman, Freddie Gorman en Brian Holland in de credits.",
@@ -3989,7 +3989,7 @@
       "fun_fact_es": "«Hanging Out to Dry» es de Florence Road, una banda de rock irlandesa formada en Bray, condado de Wicklow.",
       "uri_apple_music": "applemusic://track/1884602113",
       "uri_youtube_music": "https://music.youtube.com/watch?v=gjYb0iEcvmg",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/506472752",
       "fun_fact_fr": "« Hanging Out to Dry » est signé Florence Road, un groupe de rock irlandais formé à Bray, dans le comté de Wicklow.",
       "uri_deezer": "deezer://track/3896778251",
       "fun_fact_nl": "'Hanging Out to Dry' is van Florence Road, een Ierse rockband die werd opgericht in Bray, County Wicklow.",
@@ -4066,7 +4066,7 @@
         "it": "applemusic://track/1834660785"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=E4G6XLk8SGE",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/439745417",
       "uri_deezer": "deezer://track/3396908361",
       "alt_artists": [
         "Royel Otis",
@@ -4146,7 +4146,7 @@
         "it": "applemusic://track/1456329240"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=x-uyBbS7ykw",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/108369157",
       "uri_deezer": "deezer://track/676101292",
       "alt_artists": [
         "The Whitlams",
@@ -4338,7 +4338,7 @@
         "it": "applemusic://track/340493091"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=5WXEFwcQ6Vo",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/389991568",
       "uri_deezer": "deezer://track/3019270491",
       "alt_artists": [
         "Jimmy Barnes",
@@ -4420,7 +4420,7 @@
         "it": "applemusic://track/1822507756"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=8oFbRWzVdp4",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/459503857",
       "uri_deezer": "deezer://track/3548243381",
       "alt_artists": [
         "Feeder",
@@ -4498,7 +4498,7 @@
         "it": "applemusic://track/1494504043"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=bAAe3cVFxTM",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/127864510",
       "uri_deezer": "deezer://track/850740592",
       "alt_artists": [
         "Flowers",
@@ -4538,7 +4538,7 @@
         "it": "applemusic://track/1804661912"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=T_fokoU953Y",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/426389618",
       "uri_deezer": "deezer://track/3296189641",
       "alt_artists": [
         "Jet",
@@ -4580,7 +4580,7 @@
       "fun_fact_fr": "Beck a enregistré 'Loser' dans la cuisine d'un ami pour 135 dollars — le slide guitare échantillonne Dr. John, et son rap slacker a marqué l'alt-rap 90s.",
       "uri_apple_music": "applemusic://track/1445666977",
       "uri_youtube_music": "https://music.youtube.com/watch?v=5Z1-5wNjMgs",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/75734800",
       "uri_deezer": "deezer://track/422033092",
       "fun_fact_nl": "Beck nam 'Loser' op in de keuken van een vriend voor 135 dollar — de slideguitaar samplet Dr. John, zijn slacker-rap vormde de jaren-'90 alt-rap.",
       "awards_nl": [],


### PR DESCRIPTION
Odesli backfill wave (`--max 80`), incremental saves, URI-only changes.

| Playlist | Tidal | Version |
|---|---|---|
| `community/100-greatest-rock-songs` | 98 → 117 of 122 | 0.5 → 0.6 |

Wave was capped by the 900s timeout against a hard Odesli 429 wall; the 19 hits were saved incrementally. Remaining misses retry in the next wave.

Verified: 20 insertions / 20 deletions = 19× `null → tidal://` + 1 version line, 0 non-URI changes, JSON valid, 122 tracks intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)