### PR TITLE
fix(perf): stop debug logging from starving the event loop (#1866)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to Beatify are documented here. For detailed release notes, 
 
 ## [Unreleased]
 
+### Fixed
+- **Debug logging no longer cripples the integration (#1866).** Turning on `custom_components.beatify: debug` — the level we ask users for when we need diagnostics — slowed Beatify's own HTTP path by 50–500× (a `/beatify/api/status` call went from 0.03s to 2–15s) and starved the event loop badly enough that the server-side round timer missed its deadline (#1865). The media-player compatibility scan re-emitted its per-entity skip reasons on every status call, and the admin polls that endpoint every ~3s; those reasons are static per entity and are now logged only when they change. Per-request `[Companion-Debug]` and per-frame `[WS-Debug]` records moved to a separate opt-in logger, `custom_components.beatify.debug.wire`, so they are no longer switched on by the documented diagnostics level.
+
 ## [4.2.0-rc14] - 2026-07-21
 
 Pre-release — cut from current `main`, supersedes rc13. Adds the Sabotage power-up plus a week of new playlists, catalogue repairs and a large Tidal backfill.

--- a/custom_components/beatify/server/companion_auth.py
+++ b/custom_components/beatify/server/companion_auth.py
@@ -42,6 +42,7 @@ import re
 from typing import TYPE_CHECKING
 
 from ..const import DOMAIN
+from ..wire_debug import get_wire_logger
 
 if TYPE_CHECKING:
     from aiohttp import web
@@ -49,6 +50,10 @@ if TYPE_CHECKING:
 
 
 _LOGGER = logging.getLogger(__name__)
+# #1866: per-request / per-frame traffic goes to the opt-in wire logger so
+# `custom_components.beatify: debug` stays usable (it used to cost 50-500x on
+# the HTTP path). See custom_components/beatify/wire_debug.py.
+_WIRE_LOGGER = get_wire_logger()
 
 
 # Companion UAs vary by build — order between "Android" and the app name
@@ -138,7 +143,7 @@ def is_companion_trusted_request(request: web.Request, hass: HomeAssistant) -> b
     ip_match = is_local_remote(remote)
     trusted = ua_match and ip_match
     # #1662: demoted to DEBUG — these fire on every auth check and flood INFO logs.
-    _LOGGER.debug(
+    _WIRE_LOGGER.debug(
         "[Companion-Debug] HTTP path=%s ua=%r remote=%s ua_match=%s ip_match=%s trusted=%s",
         request.path,
         (ua[:200] if isinstance(ua, str) else ua),
@@ -170,14 +175,14 @@ def is_companion_trusted_meta(meta: dict | None, hass: HomeAssistant) -> bool:
         return False
 
     if not isinstance(meta, dict):
-        _LOGGER.debug("[Companion-Debug] WS meta=None (no signature collected)")
+        _WIRE_LOGGER.debug("[Companion-Debug] WS meta=None (no signature collected)")
         return False
     ua = meta.get("ua")
     remote = meta.get("remote")
     ua_match = is_companion_ua(ua)
     ip_match = is_local_remote(remote)
     trusted = ua_match and ip_match
-    _LOGGER.debug(
+    _WIRE_LOGGER.debug(
         "[Companion-Debug] WS ua=%r remote=%s ua_match=%s ip_match=%s trusted=%s",
         (ua[:200] if isinstance(ua, str) else ua),
         remote,
@@ -212,13 +217,13 @@ def is_authorized_http(request: web.Request, hass: HomeAssistant) -> bool:
             bearer_present = True
             result = hass.auth.async_validate_access_token(token)
             if result is not None:
-                _LOGGER.debug(
+                _WIRE_LOGGER.debug(
                     "[Companion-Debug] HTTP path=%s bearer_valid=True (bypass not consulted)",
                     request.path,
                 )
                 return True
     if bearer_present:
-        _LOGGER.debug(
+        _WIRE_LOGGER.debug(
             "[Companion-Debug] HTTP path=%s bearer_present=True bearer_valid=False (falling back to bypass)",
             request.path,
         )

--- a/custom_components/beatify/server/websocket.py
+++ b/custom_components/beatify/server/websocket.py
@@ -44,6 +44,7 @@ from custom_components.beatify.server.ws_handlers import (
     handle_title_artist_override,
     handle_title_artist_vote,
 )
+from custom_components.beatify.wire_debug import get_wire_logger
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
@@ -51,6 +52,10 @@ if TYPE_CHECKING:
     from custom_components.beatify.analytics import AnalyticsStorage
 
 _LOGGER = logging.getLogger(__name__)
+# #1866: per-request / per-frame traffic goes to the opt-in wire logger so
+# `custom_components.beatify: debug` stays usable (it used to cost 50-500x on
+# the HTTP path). See custom_components/beatify/wire_debug.py.
+_WIRE_LOGGER = get_wire_logger()
 
 # Free-text guess fields that must be length-capped at the ingest boundary
 # (#1581). aiohttp accepts WS frames up to 4 MB; an unbounded guess would feed a
@@ -226,7 +231,7 @@ class BeatifyWebSocketHandler:
 
         self.connections.add(ws)
         # #1662: demoted to DEBUG — fires on every WS upgrade and floods INFO logs.
-        _LOGGER.debug(
+        _WIRE_LOGGER.debug(
             "[WS-Debug] upgrade path=%s remote=%s ua=%r total=%d",
             request.path,
             request.remote,
@@ -239,7 +244,7 @@ class BeatifyWebSocketHandler:
                 if msg.type == WSMsgType.TEXT:
                     try:
                         parsed = msg.json()
-                        _LOGGER.debug(
+                        _WIRE_LOGGER.debug(
                             "[WS-Debug] recv type=%s keys=%s",
                             parsed.get("type") if isinstance(parsed, dict) else "?",
                             list(parsed.keys()) if isinstance(parsed, dict) else None,
@@ -257,7 +262,7 @@ class BeatifyWebSocketHandler:
 
                     self._record_error(ERROR_WEBSOCKET_DISCONNECT, err_msg)
                 else:
-                    _LOGGER.debug(
+                    _WIRE_LOGGER.debug(
                         "[WS-Debug] non-text msg type=%s",
                         msg.type,
                     )
@@ -265,7 +270,7 @@ class BeatifyWebSocketHandler:
         finally:
             self.connections.discard(ws)
             await self._handle_disconnect(ws)
-            _LOGGER.debug(
+            _WIRE_LOGGER.debug(
                 "[WS-Debug] disconnect path=%s remote=%s total=%d ws_closed=%s close_code=%s",
                 request.path,
                 request.remote,

--- a/custom_components/beatify/services/media_player.py
+++ b/custom_components/beatify/services/media_player.py
@@ -1577,6 +1577,60 @@ def _collect_ma_twin_maps(
     return ma_by_unique_id, native_twin_remap
 
 
+# #1866: the compatibility scan below runs on EVERY /beatify/api/status call,
+# and the admin polls that endpoint roughly every 3 s. Its per-entity skip
+# reasons ("unsupported platform", "native twin of an MA player") are static for
+# the lifetime of an entity, so re-emitting them per request produced ~10 DEBUG
+# records every 3 s from this one code path. HA writes log records synchronously
+# on the event loop, so that is loop time: with `custom_components.beatify:
+# debug` a status call took 2-15 s instead of 0.03 s and the server-side round
+# timer missed its deadline (#1865).
+#
+# We therefore remember the last line emitted per entity and only log again when
+# it actually changes. Bookkeeping happens ONLY while DEBUG is enabled — if we
+# populated the cache while logging was off, enabling debug later would show
+# nothing until something changed, which is exactly when the user needs it.
+_SCAN_LOG_STATE: dict[str, tuple[Any, ...]] = {}
+
+#: Cache key for the "Found N compatible media players" summary line.
+_SCAN_COUNT_KEY = "__scan_count__"
+
+
+def _log_scan_change(
+    key: str, signature: tuple[Any, ...], msg: str, *args: Any
+) -> None:
+    """Emit a compatibility-scan DEBUG line only when it changed (#1866).
+
+    ``key`` identifies the line (an entity_id, or :data:`_SCAN_COUNT_KEY`) and
+    ``signature`` is the tuple of values that would make the line differ.
+    Building the signature is cheap; the message itself is still formatted
+    lazily by the logging module.
+    """
+    if not _LOGGER.isEnabledFor(logging.DEBUG):
+        return
+    if _SCAN_LOG_STATE.get(key) == signature:
+        return
+    _SCAN_LOG_STATE[key] = signature
+    _LOGGER.debug(msg, *args)
+
+
+def _prune_scan_log_state(live_keys: set[str]) -> None:
+    """Forget remembered scan lines for entities that no longer exist (#1866).
+
+    Without this a removed-and-re-added entity would stay silent, and the dict
+    would grow across HA's lifetime.
+    """
+    if not _SCAN_LOG_STATE:
+        return
+    for stale in [k for k in _SCAN_LOG_STATE if k not in live_keys]:
+        del _SCAN_LOG_STATE[stale]
+
+
+def _reset_scan_log_state() -> None:
+    """Drop all remembered scan lines (test seam — module state must not leak)."""
+    _SCAN_LOG_STATE.clear()
+
+
 def _build_media_player_list(
     hass: HomeAssistant, ma_by_unique_id: dict[str, str]
 ) -> list[dict[str, Any]]:
@@ -1594,7 +1648,10 @@ def _build_media_player_list(
     ent_reg = er.async_get(hass)
 
     media_players = []
+    # #1866: entity_ids seen this pass, so stale cache entries can be dropped.
+    scanned_keys: set[str] = {_SCAN_COUNT_KEY}
     for state in hass.states.async_all("media_player"):
+        scanned_keys.add(state.entity_id)
         # async_get is an O(1) dict lookup, not a registry walk.
         entity_entry = ent_reg.async_get(state.entity_id)
         platform = entity_entry.platform if entity_entry else "unknown"
@@ -1604,11 +1661,15 @@ def _build_media_player_list(
 
         # Skip unsupported platforms (Cast without MA)
         if not capabilities.get("supported"):
-            _LOGGER.debug(
+            reason = capabilities.get("reason", "unknown")
+            # #1866: logged once per entity, not once per status request.
+            _log_scan_change(
+                state.entity_id,
+                ("unsupported", platform, reason),
                 "Skipping unsupported player: %s (platform=%s, reason=%s)",
                 state.entity_id,
                 platform,
-                capabilities.get("reason", "unknown"),
+                reason,
             )
             continue
 
@@ -1622,7 +1683,10 @@ def _build_media_player_list(
             and entity_entry is not None
             and entity_entry.unique_id in ma_by_unique_id
         ):
-            _LOGGER.debug(
+            # #1866: logged once per entity, not once per status request.
+            _log_scan_change(
+                state.entity_id,
+                ("native-twin", platform, entity_entry.unique_id),
                 "Skipping native twin of MA player: %s (platform=%s, unique_id=%s)",
                 state.entity_id,
                 platform,
@@ -1647,7 +1711,14 @@ def _build_media_player_list(
             }
         )
 
-    _LOGGER.debug("Found %d compatible media players", len(media_players))
+    # #1866: only when the count actually moves, not on every poll.
+    _log_scan_change(
+        _SCAN_COUNT_KEY,
+        (len(media_players),),
+        "Found %d compatible media players",
+        len(media_players),
+    )
+    _prune_scan_log_state(scanned_keys)
     return media_players
 
 

--- a/custom_components/beatify/wire_debug.py
+++ b/custom_components/beatify/wire_debug.py
@@ -1,0 +1,45 @@
+"""Opt-in per-request / per-frame "wire" logging (#1866).
+
+``custom_components.beatify: debug`` is the level we ask users for when we need
+diagnostics. Two code paths emitted a DEBUG record for *every* HTTP request
+(``[Companion-Debug]``) and *every* WebSocket frame (``[WS-Debug]``), and HA
+writes log records synchronously on the event loop. Together with the
+compatibility scan in :mod:`custom_components.beatify.services.media_player`
+that made the documented diagnostics level slow Beatify's own HTTP path down by
+50-500x and starved the server-side round timer (#1865) — i.e. turning on
+logging changed the behaviour under investigation.
+
+This module hands out a logger for that wire-level traffic which is **not**
+enabled by ``custom_components.beatify: debug``. It carries an explicit level,
+so it does not inherit the effective level of its ``custom_components.beatify``
+ancestor; only naming it directly turns it on::
+
+    logger:
+      logs:
+        custom_components.beatify.debug.wire: debug
+
+Everything that is per-request or per-frame belongs here. Per-*game-event*
+logging (a player joining, playback starting) stays on the normal module logger
+— it is bounded by gameplay, not by poll frequency, and it is what users
+actually need when they report a bug.
+"""
+
+from __future__ import annotations
+
+import logging
+
+#: Logger name users opt into for wire-level traffic.
+WIRE_LOGGER_NAME = "custom_components.beatify.debug.wire"
+
+#: Default level. Setting this explicitly is the whole point: a logger without
+#: its own level inherits the nearest configured ancestor, so
+#: ``custom_components.beatify: debug`` would switch the flood back on.
+WIRE_DEFAULT_LEVEL = logging.INFO
+
+_WIRE_LOGGER = logging.getLogger(WIRE_LOGGER_NAME)
+_WIRE_LOGGER.setLevel(WIRE_DEFAULT_LEVEL)
+
+
+def get_wire_logger() -> logging.Logger:
+    """Return the shared wire-debug logger (see module docstring)."""
+    return _WIRE_LOGGER

--- a/tests/unit/test_debug_logging_perf_1866.py
+++ b/tests/unit/test_debug_logging_perf_1866.py
@@ -1,0 +1,220 @@
+"""#1866 — `custom_components.beatify: debug` must not cost 50-500x.
+
+Two regressions are pinned here:
+
+1. The media-player compatibility scan runs on every ``/beatify/api/status``
+   call (the admin polls it every ~3 s) and used to re-emit a DEBUG line per
+   skipped entity every time. HA writes log records synchronously on the event
+   loop, so that starved the round timer (#1865).
+2. ``[Companion-Debug]`` (per HTTP request) and ``[WS-Debug]`` (per WS frame)
+   must not be reachable via ``custom_components.beatify: debug`` at all — they
+   live on an opt-in wire logger.
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from custom_components.beatify.services.media_player import (
+    _reset_scan_log_state,
+    async_get_media_players,
+)
+from custom_components.beatify.wire_debug import (
+    WIRE_DEFAULT_LEVEL,
+    WIRE_LOGGER_NAME,
+    get_wire_logger,
+)
+
+SCAN_LOGGER = "custom_components.beatify.services.media_player"
+
+
+def _entry(entity_id: str, platform: str, unique_id: str | None) -> MagicMock:
+    entry = MagicMock()
+    entry.entity_id = entity_id
+    entry.platform = platform
+    entry.unique_id = unique_id
+    entry.domain = "media_player"
+    return entry
+
+
+def _state(entity_id: str) -> MagicMock:
+    state = MagicMock()
+    state.entity_id = entity_id
+    state.state = "idle"
+    state.attributes = {"friendly_name": entity_id}
+    return state
+
+
+def _hass_and_registry(entries: list[MagicMock]) -> tuple[MagicMock, MagicMock]:
+    by_id = {e.entity_id: e for e in entries}
+    hass = MagicMock()
+    hass.states.async_all = MagicMock(
+        return_value=[_state(e.entity_id) for e in entries]
+    )
+    registry = MagicMock()
+    registry.entities.values = MagicMock(return_value=list(entries))
+    registry.async_get = MagicMock(side_effect=lambda eid: by_id.get(eid))
+    return hass, registry
+
+
+async def _scan(entries: list[MagicMock]) -> list[dict]:
+    hass, registry = _hass_and_registry(entries)
+    with patch(
+        "homeassistant.helpers.entity_registry.async_get",
+        return_value=registry,
+    ):
+        return await async_get_media_players(hass)
+
+
+def _skip_lines(caplog: pytest.LogCaptureFixture) -> list[str]:
+    return [r.getMessage() for r in caplog.records if r.name == SCAN_LOGGER]
+
+
+@pytest.fixture(autouse=True)
+def _clean_scan_cache():
+    """The dedup cache is module state — never leak it between tests."""
+    _reset_scan_log_state()
+    yield
+    _reset_scan_log_state()
+
+
+# An unsupported platform (raw Cast without MA) and an MA twin pair — the two
+# skip reasons the scan logs.
+UNSUPPORTED = _entry("media_player.tv_cast", "cast", "cast-1")
+MA_TWIN = _entry("media_player.kuche_2", "music_assistant", "RINCON_1")
+NATIVE_TWIN = _entry("media_player.kuche", "sonos", "RINCON_1")
+
+
+class TestCompatScanLogsOncePerEntity:
+    """The static skip reasons are logged on change, not on every poll (#1866)."""
+
+    @pytest.mark.asyncio
+    async def test_repeated_scans_log_skip_reason_once(self, caplog):
+        entries = [UNSUPPORTED, MA_TWIN, NATIVE_TWIN]
+        with caplog.at_level(logging.DEBUG, logger=SCAN_LOGGER):
+            for _ in range(5):
+                result = await _scan(entries)
+
+        # Behaviour is unchanged: only the MA twin survives the scan.
+        assert {p["entity_id"] for p in result} == {"media_player.kuche_2"}
+
+        lines = _skip_lines(caplog)
+        assert sum("Skipping unsupported player" in ln for ln in lines) == 1
+        assert sum("Skipping native twin" in ln for ln in lines) == 1
+        # ...and the summary line likewise, since the count never moved.
+        assert sum("Found 1 compatible media players" in ln for ln in lines) == 1
+
+    @pytest.mark.asyncio
+    async def test_changed_reason_is_logged_again(self, caplog):
+        """A skip reason that actually changes must resurface."""
+        moved = _entry("media_player.tv_cast", "cast", "cast-1")
+        with caplog.at_level(logging.DEBUG, logger=SCAN_LOGGER):
+            await _scan([moved])
+            moved.platform = "androidtv_remote"  # different reason, same entity
+            await _scan([moved])
+
+        skips = [ln for ln in _skip_lines(caplog) if "Skipping unsupported" in ln]
+        assert len(skips) == 2
+        assert "platform=cast" in skips[0]
+        assert "platform=androidtv_remote" in skips[1]
+
+    @pytest.mark.asyncio
+    async def test_count_line_follows_the_count(self, caplog):
+        with caplog.at_level(logging.DEBUG, logger=SCAN_LOGGER):
+            await _scan([MA_TWIN])
+            await _scan([MA_TWIN])
+            await _scan([MA_TWIN, _entry("media_player.bad", "music_assistant", "u2")])
+
+        counts = [ln for ln in _skip_lines(caplog) if "compatible media players" in ln]
+        assert counts == [
+            "Found 1 compatible media players",
+            "Found 2 compatible media players",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_removed_entity_logs_again_when_it_returns(self, caplog):
+        """Stale cache entries are pruned, so a re-added entity is not silent."""
+        with caplog.at_level(logging.DEBUG, logger=SCAN_LOGGER):
+            await _scan([UNSUPPORTED, MA_TWIN])
+            await _scan([MA_TWIN])  # cast player disappears → prune
+            await _scan([UNSUPPORTED, MA_TWIN])  # comes back → log again
+
+        skips = [ln for ln in _skip_lines(caplog) if "Skipping unsupported" in ln]
+        assert len(skips) == 2
+
+    @pytest.mark.asyncio
+    async def test_scans_while_debug_off_do_not_poison_the_cache(self, caplog):
+        """Turning debug ON later must still produce the full picture.
+
+        This is the whole point of the feature: a user enables debug *because*
+        something is wrong. If quiet scans had populated the cache, they would
+        see nothing until an entity changed.
+        """
+        entries = [UNSUPPORTED, MA_TWIN, NATIVE_TWIN]
+        with caplog.at_level(logging.WARNING, logger=SCAN_LOGGER):
+            for _ in range(3):
+                await _scan(entries)
+            assert _skip_lines(caplog) == []
+
+        with caplog.at_level(logging.DEBUG, logger=SCAN_LOGGER):
+            await _scan(entries)
+
+        lines = _skip_lines(caplog)
+        assert any("Skipping unsupported player" in ln for ln in lines)
+        assert any("Skipping native twin" in ln for ln in lines)
+
+
+class TestWireLoggerIsOptIn:
+    """Per-request / per-frame lines are NOT part of `beatify: debug` (#1866)."""
+
+    def test_wire_logger_carries_an_explicit_level(self):
+        """Without its own level it would inherit the parent's DEBUG."""
+        wire = get_wire_logger()
+        assert wire.name == WIRE_LOGGER_NAME
+        assert wire.level == WIRE_DEFAULT_LEVEL
+        assert wire.level > logging.DEBUG
+
+    def test_parent_debug_does_not_enable_the_wire_logger(self):
+        """`custom_components.beatify: debug` must leave wire traffic off."""
+        parent = logging.getLogger("custom_components.beatify")
+        previous = parent.level
+        try:
+            parent.setLevel(logging.DEBUG)
+            assert not get_wire_logger().isEnabledFor(logging.DEBUG)
+        finally:
+            parent.setLevel(previous)
+
+    def test_naming_the_wire_logger_directly_turns_it_on(self):
+        """The documented opt-in must actually work."""
+        wire = get_wire_logger()
+        previous = wire.level
+        try:
+            wire.setLevel(logging.DEBUG)
+            assert wire.isEnabledFor(logging.DEBUG)
+        finally:
+            wire.setLevel(previous)
+
+    def test_companion_and_ws_debug_lines_use_the_wire_logger(self):
+        """Guards against a future edit reattaching them to the module logger."""
+        from custom_components.beatify.server import companion_auth, websocket
+
+        for module in (companion_auth, websocket):
+            source = (
+                __import__("pathlib").Path(module.__file__).read_text(encoding="utf-8")
+            )
+            for tag in ("[Companion-Debug]", "[WS-Debug]"):
+                for idx, line in enumerate(source.splitlines()):
+                    if tag not in line:
+                        continue
+                    # Walk back to the logging call that owns this message.
+                    call = next(
+                        source.splitlines()[i]
+                        for i in range(idx, -1, -1)
+                        if "_LOGGER.debug(" in source.splitlines()[i]
+                    )
+                    assert "_WIRE_LOGGER.debug(" in call, (
+                        f"{module.__name__}: {tag} still logs to the module logger"
+                    )


### PR DESCRIPTION
Closes #1866.

## The problem

`custom_components.beatify: debug` is the level we ask users for when we need diagnostics, and turning it on made Beatify's own HTTP path 50–500× slower. Measured on rc14: `/beatify/api/status` went from 0.03s to 2–15s, Chrome could not load `/beatify/admin` at all, and the server-side round timer missed its deadline (#1865). HA writes log records synchronously on the event loop, so log volume *is* loop time.

The uncomfortable part is that the documented way to collect diagnostics from a user made the bug under investigation worse and added timing bugs that were not in their normal run.

## What changed

**1. The compatibility scan logs on change, not on every poll.**
`_build_media_player_list` runs on every status call and the admin polls that endpoint every ~3s. It re-emitted a DEBUG record per skipped entity each time — about 10 lines every 3s from this one code path. Those skip reasons ("unsupported platform", "native twin of an MA player") are static for the lifetime of an entity, so they are now remembered and only re-logged when they change.

Two properties worth calling out:

- The bookkeeping runs **only while DEBUG is enabled**. If quiet scans populated the cache, a user enabling debug later would see nothing until something changed — exactly when they need the full picture.
- Remembered lines are **pruned** for entities that disappear, so a removed-and-re-added entity is not silent and the dict does not grow across HA's lifetime.

**2. Wire-level records moved to an opt-in logger.**
`[Companion-Debug]` (one record per HTTP request) and `[WS-Debug]` (one per WebSocket frame) now go to `custom_components.beatify.debug.wire`. It carries an explicit level, so it does **not** inherit the effective level of its `custom_components.beatify` ancestor — that inheritance is precisely why a child logger alone would not have fixed anything. Opting in:

```yaml
logger:
  logs:
    custom_components.beatify.debug.wire: debug
```

Per-*game-event* logging (a player joining, playback starting) deliberately stays on the module loggers, including the three `[WS-Debug]`-tagged lines in `ws_handlers/lifecycle.py`: those fire once per join, are bounded by gameplay rather than poll frequency, and are what users actually need when they report a bug.

## What I did not do

The issue also suggests caching the compatible-player list with a short TTL. I left that out on purpose. The issue's own A/B is decisive — same instance, same game, only the logger level differs: 15.3s with `debug` versus 0.03s without. A 500× factor cannot come from iterating a few hundred states, so the cost is the logging, not the computation. A TTL cache would buy little and trade it for a window where a speaker that just came online is missing from the picker. Happy to add it in a follow-up if profiling ever shows the scan itself is hot.

## Verification

- 1487 passed, 2 skipped (full unit + integration suite).
- 9 new tests in `tests/unit/test_debug_logging_perf_1866.py` pin the dedup, the reason-changed path, the count line, the pruning, the do-not-poison-the-cache property, and that the wire logger stays off under `custom_components.beatify: debug`.
- `ruff check` + `ruff format --check` clean.
- Not yet verified on real hardware — the timings in #1866 came from a live game, and re-measuring `/beatify/api/status` under `debug` on Markus' instance is the check that actually closes this out.

## Draft

Left as a draft for review of the wire-logger call: pinning an explicit level on `custom_components.beatify.debug.wire` at import is what makes the opt-in real, but it also means an HA `logger` reload that resets levels could silently re-enable the flood. That tradeoff deserves a second opinion before this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)