### PR TITLE
chore(playlists): tidal backfill wave — +19 uris across 2 playlists

### DIFF
--- a/custom_components/beatify/playlists/community/100-greatest-rock-songs.json
+++ b/custom_components/beatify/playlists/community/100-greatest-rock-songs.json
@@ -1,6 +1,6 @@
 {
   "name": "100 Greatest Rock Songs",
-  "version": "0.6",
+  "version": "0.7",
   "tags": [
     "rock",
     "classic-rock",
@@ -4612,7 +4612,7 @@
         "it": "applemusic://track/1752780530"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=RXbafrTCJds",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/372655582",
       "uri_deezer": "deezer://track/2853455352",
       "alt_artists": [
         "Les Votives",
@@ -4652,7 +4652,7 @@
         "it": "applemusic://track/693800763"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=aAIpSAK_54I",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/2935755",
       "uri_deezer": "deezer://track/3728954",
       "alt_artists": [
         "The Clash",
@@ -4805,7 +4805,7 @@
         "it": "applemusic://track/1537768035"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=JOtfj1phVxo",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/700189",
       "uri_deezer": "deezer://track/71828722",
       "fun_fact": "Nickelback are a Canadian rock band — one of the best-selling acts of the post-grunge era.",
       "fun_fact_de": "Nickelback sind eine kanadische Rockband — einer der meistverkauften Acts der Post-Grunge-Ära.",
@@ -4835,7 +4835,7 @@
         "it": "applemusic://track/270959694"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=l2OvJr0ITTw",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/3514687",
       "uri_deezer": "deezer://track/663984",
       "alt_artists": [
         "Five Finger Death Punch",
@@ -4875,7 +4875,7 @@
         "it": "applemusic://track/1683092200"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=XhjqmAoBKCQ",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/304847",
       "uri_deezer": "deezer://track/139633449",
       "alt_artists": [
         "Foo Fighters",

--- a/custom_components/beatify/playlists/community/ballermann-party-hits.json
+++ b/custom_components/beatify/playlists/community/ballermann-party-hits.json
@@ -1,6 +1,6 @@
 {
   "name": "Ballermann Party Hits",
-  "version": "1.18",
+  "version": "1.19",
   "tags": [
     "schlager",
     "party",
@@ -3547,7 +3547,7 @@
         "it": "applemusic://track/1721524571"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=ADqR7u-rkyI",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/337000445",
       "uri_deezer": "deezer://track/2598585892",
       "fun_fact": "Mia Julia is one of the most popular performers on the Mallorca party scene.",
       "fun_fact_de": "Mia Julia ist eine der beliebtesten Performerinnen der Mallorca-Partyszene.",
@@ -3572,7 +3572,7 @@
         "it": "applemusic://track/1470063962"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=a1Flb6BmEsA",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/336999173",
       "uri_deezer": "deezer://track/2598566852",
       "alt_artists": [
         "DJ Eisbär"
@@ -3600,7 +3600,7 @@
         "it": "applemusic://track/1445698039"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=a7k8ASQWrtE",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/86638639",
       "uri_deezer": "deezer://track/479899102",
       "fun_fact": "Tim Toupet is a party-Schlager singer known for novelty sing-along hits.",
       "fun_fact_de": "Tim Toupet ist ein Party-Schlager-Sänger, bekannt für humorvolle Mitsing-Hits.",
@@ -3625,7 +3625,7 @@
         "it": "applemusic://track/1012884166"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=AHIGlIUGBuw",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/47286002",
       "uri_deezer": "deezer://track/2598567562",
       "alt_artists": [
         "DJ Mico"
@@ -3653,7 +3653,7 @@
         "it": "applemusic://track/1489547857"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=5zfrkyQoePs",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/109058045",
       "uri_deezer": "deezer://track/660214822",
       "fun_fact": "A Mallorca / Ballermann party hit (2019).",
       "fun_fact_de": "Ein Mallorca-/Ballermann-Partyhit (2019).",
@@ -3678,7 +3678,7 @@
         "it": "applemusic://track/1377701856"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=SUrnJYYEbi8",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/87552263",
       "uri_deezer": "deezer://track/482656772",
       "fun_fact": "Peter Wackel is a mainstay of the Mallorca party-Schlager scene and a regular at the Bierkönig.",
       "fun_fact_de": "Peter Wackel ist eine feste Größe der Mallorca-Party-Schlager-Szene und Dauergast im Bierkönig.",
@@ -3703,7 +3703,7 @@
         "it": "applemusic://track/1721517464"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=OmQz5N6x4pE",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/337000440",
       "uri_deezer": "deezer://track/2598565492",
       "fun_fact": "Mia Julia is one of the most popular performers on the Mallorca party scene.",
       "fun_fact_de": "Mia Julia ist eine der beliebtesten Performerinnen der Mallorca-Partyszene.",
@@ -3728,7 +3728,7 @@
         "it": "applemusic://track/1129707127"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=2Yezroz4O7M",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/71128855",
       "uri_deezer": "deezer://track/127667789",
       "fun_fact": "\"Johnny Däpp\" was Lorenz Büffel's breakthrough — the \"Yippie Yippie Yeah\" hook became a Mallorca standard.",
       "fun_fact_de": "\"Johnny Däpp\" war Lorenz Büffels Durchbruch — der \"Yippie Yippie Yeah\"-Hook wurde zum Mallorca-Standard.",
@@ -3753,7 +3753,7 @@
         "it": "applemusic://track/1469514707"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=pU6OZmbO3W0",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/92471771",
       "uri_deezer": "deezer://track/556981552",
       "fun_fact": "Tobee is a Mallorca party-Schlager artist known for catchy party covers and originals.",
       "fun_fact_de": "Tobee ist ein Mallorca-Party-Schlager-Künstler, bekannt für eingängige Party-Cover und Eigenkompositionen.",
@@ -3778,7 +3778,7 @@
         "it": "applemusic://track/1862213079"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=auESWfe2yG0",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/71128856",
       "uri_deezer": "deezer://track/141827711",
       "fun_fact": "Mia Julia is one of the most popular performers on the Mallorca party scene.",
       "fun_fact_de": "Mia Julia ist eine der beliebtesten Performerinnen der Mallorca-Partyszene.",
@@ -3803,7 +3803,7 @@
         "it": "applemusic://track/1235649302"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=VyZ5dM0BU_0",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/73915895",
       "uri_deezer": "deezer://track/361234931",
       "fun_fact": "A Mallorca / Ballermann party hit (2017).",
       "fun_fact_de": "Ein Mallorca-/Ballermann-Partyhit (2017).",
@@ -3828,7 +3828,7 @@
         "it": "applemusic://track/1567235461"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=Sm8LAwKPJuU",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/313607212",
       "uri_deezer": "deezer://track/103871698",
       "fun_fact": "Peter Wackel is a mainstay of the Mallorca party-Schlager scene and a regular at the Bierkönig.",
       "fun_fact_de": "Peter Wackel ist eine feste Größe der Mallorca-Party-Schlager-Szene und Dauergast im Bierkönig.",
@@ -3845,7 +3845,7 @@
       "uri_apple_music": null,
       "uri_apple_music_by_region": {},
       "uri_youtube_music": "https://music.youtube.com/watch?v=PJVqqdbaluE",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/103928543",
       "uri_deezer": null,
       "fun_fact": "Tobee's party cover of \"Cordula Grün\" turned the originally folk-pop tune into a Ballermann smash.",
       "fun_fact_de": "Tobees Party-Coverversion von \"Cordula Grün\" machte aus dem ursprünglichen Folk-Pop-Lied einen Ballermann-Hit.",
@@ -3870,7 +3870,7 @@
         "it": "applemusic://track/1297573291"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=tcDEpbiddU0",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/73754332",
       "uri_deezer": "deezer://track/353122341",
       "fun_fact": "Tobee is a Mallorca party-Schlager artist known for catchy party covers and originals.",
       "fun_fact_de": "Tobee ist ein Mallorca-Party-Schlager-Künstler, bekannt für eingängige Party-Cover und Eigenkompositionen.",


### PR DESCRIPTION
Automated Tidal-URI backfill wave (22:00 slot). URI fields only — no logic, no user-facing change.

## Delta

| Playlist | Tidal | Version |
|---|---|---|
| `community/100-greatest-rock-songs` | 117 → **122 of 122** (complete) | 0.6 → 0.7 |
| `community/ballermann-party-hits` | 138 → **152 of 189** | 1.18 → 1.19 |

**+19 URIs**, 2 files, 2 version bumps. Nothing else in the diff — verified that every changed line is either a `uri_tidal` field or a `version` string, and both files still parse.

## Wave health

Odesli rate-limited hard for most of this wave — 9 tracks ran the full 8s/16s/24s backoff ladder and the run was cut at its 900s cap mid-backoff. The 19 hits above landed before that and were saved incrementally.

Rate-limit skips are deliberately **not** recorded as misses, so they retry on the next wave. The miss-cache grew 277 → 296 entries (genuine "not on Tidal" results only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)