### PR TITLE
chore(playlists): tidal backfill wave — +19 uris (ballermann-party-hits)

### DIFF
--- a/custom_components/beatify/playlists/community/ballermann-party-hits.json
+++ b/custom_components/beatify/playlists/community/ballermann-party-hits.json
@@ -1,6 +1,6 @@
 {
   "name": "Ballermann Party Hits",
-  "version": "1.19",
+  "version": "1.20",
   "tags": [
     "schlager",
     "party",
@@ -3998,7 +3998,7 @@
         "it": "applemusic://track/1430000166"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=gUOltPlrz5E",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/16670929",
       "uri_deezer": "deezer://track/631190652",
       "fun_fact": "Tobee is a Mallorca party-Schlager artist known for catchy party covers and originals.",
       "fun_fact_de": "Tobee ist ein Mallorca-Party-Schlager-Künstler, bekannt für eingängige Party-Cover und Eigenkompositionen.",
@@ -4023,7 +4023,7 @@
         "it": "applemusic://track/1759209462"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=MeZfP-JSJTw",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/335181981",
       "uri_deezer": "deezer://track/2584815622",
       "fun_fact": "Peter Wackel is a mainstay of the Mallorca party-Schlager scene and a regular at the Bierkönig.",
       "fun_fact_de": "Peter Wackel ist eine feste Größe der Mallorca-Party-Schlager-Szene und Dauergast im Bierkönig.",
@@ -4048,7 +4048,7 @@
         "it": "applemusic://track/1713345699"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=FqjGxCtFhDI",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/89527896",
       "uri_deezer": "deezer://track/405520092",
       "fun_fact": "Peter Wackel is a mainstay of the Mallorca party-Schlager scene and a regular at the Bierkönig.",
       "fun_fact_de": "Peter Wackel ist eine feste Größe der Mallorca-Party-Schlager-Szene und Dauergast im Bierkönig.",
@@ -4073,7 +4073,7 @@
         "it": "applemusic://track/967197602"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=vGFNXN4Mm0k",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/336999189",
       "uri_deezer": "deezer://track/2598567202",
       "fun_fact": "Mia Julia is one of the most popular performers on the Mallorca party scene.",
       "fun_fact_de": "Mia Julia ist eine der beliebtesten Performerinnen der Mallorca-Partyszene.",
@@ -4098,7 +4098,7 @@
         "it": "applemusic://track/445944694"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=UEI7txY9dio",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/15352283",
       "uri_deezer": "deezer://track/61721437",
       "fun_fact": "Tobee is a Mallorca party-Schlager artist known for catchy party covers and originals.",
       "fun_fact_de": "Tobee ist ein Mallorca-Party-Schlager-Künstler, bekannt für eingängige Party-Cover und Eigenkompositionen.",
@@ -4123,7 +4123,7 @@
         "it": "applemusic://track/1442233430"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=nqraNWUjasA",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/20663890",
       "uri_deezer": "deezer://track/3136075381",
       "fun_fact": "Mickie Krause is one of Germany's best-known Ballermann entertainers, famous for his sing-along party hits.",
       "fun_fact_de": "Mickie Krause zählt zu den bekanntesten Ballermann-Entertainern Deutschlands, berühmt für seine Mitsing-Partyhits.",
@@ -4148,7 +4148,7 @@
         "it": "applemusic://track/1645636593"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=b8nWIxEODn0",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/83844562",
       "uri_deezer": "deezer://track/453959592",
       "fun_fact": "A Mallorca / Ballermann party hit (2018).",
       "fun_fact_de": "Ein Mallorca-/Ballermann-Partyhit (2018).",
@@ -4173,7 +4173,7 @@
         "it": "applemusic://track/1721339139"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=qFAeK_8cklw",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/337000030",
       "uri_deezer": "deezer://track/2598585822",
       "alt_artists": [
         "Dorfrocker"
@@ -4201,7 +4201,7 @@
         "it": "applemusic://track/1701688010"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=VAJzBz4DtsE",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/67764267",
       "uri_deezer": "deezer://track/139404723",
       "fun_fact": "Mickie Krause is one of Germany's best-known Ballermann entertainers, famous for his sing-along party hits.",
       "fun_fact_de": "Mickie Krause zählt zu den bekanntesten Ballermann-Entertainern Deutschlands, berühmt für seine Mitsing-Partyhits.",
@@ -4226,7 +4226,7 @@
         "it": "applemusic://track/1050694817"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=e_lHA4Fo-bc",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/45274761",
       "uri_deezer": "deezer://track/98831946",
       "alt_artists": [
         "Deejay Biene"
@@ -4254,7 +4254,7 @@
         "it": "applemusic://track/1436883062"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=2JU1mDe7Izg",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/89840237",
       "uri_deezer": "deezer://track/501254962",
       "alt_artists": [
         "Suffgeschwader"
@@ -4282,7 +4282,7 @@
         "it": "applemusic://track/1118343162"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=0gxXe7IUMZA",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/60346496",
       "uri_deezer": "deezer://track/123880402",
       "fun_fact": "Tobee is a Mallorca party-Schlager artist known for catchy party covers and originals.",
       "fun_fact_de": "Tobee ist ein Mallorca-Party-Schlager-Künstler, bekannt für eingängige Party-Cover und Eigenkompositionen.",
@@ -4307,7 +4307,7 @@
         "it": "applemusic://track/1784925586"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=4JfhOtZJtZo",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/404939966",
       "uri_deezer": "deezer://track/3136075321",
       "fun_fact": "\"Schatzi schenk mir ein Foto\" is one of Mickie Krause's most-played sing-along anthems.",
       "fun_fact_de": "\"Schatzi schenk mir ein Foto\" zählt zu Mickie Krauses meistgespielten Mitsing-Hymnen.",
@@ -4332,7 +4332,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=_W7s6d2K1Ps",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/11212805",
       "uri_deezer": "deezer://track/13486846",
       "alt_artists": [
         "Chriss Tuxi"
@@ -4360,7 +4360,7 @@
         "it": "applemusic://track/1259157705"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=A1MGW8bjxtQ",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/72345746",
       "uri_deezer": "deezer://track/145690796",
       "fun_fact": "A Mallorca / Ballermann party hit (2017).",
       "fun_fact_de": "Ein Mallorca-/Ballermann-Partyhit (2017).",
@@ -4377,7 +4377,7 @@
       "uri_apple_music": null,
       "uri_apple_music_by_region": {},
       "uri_youtube_music": "https://music.youtube.com/watch?v=b3CYsa_luYI",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/100116950",
       "uri_deezer": null,
       "fun_fact": "Ikke Hüftgold is a Ballermann artist and label boss — his Summerfield label was behind the 2022 smash \"Layla\".",
       "fun_fact_de": "Ikke Hüftgold ist Ballermann-Künstler und Label-Chef — sein Label Summerfield steckte hinter dem 2022er-Hit \"Layla\".",
@@ -4402,7 +4402,7 @@
         "it": "applemusic://track/1384581799"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=D3OtI4pjbgc",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/89571878",
       "uri_deezer": "deezer://track/489442172",
       "fun_fact": "A Mallorca / Ballermann party hit (2018).",
       "fun_fact_de": "Ein Mallorca-/Ballermann-Partyhit (2018).",
@@ -4427,7 +4427,7 @@
         "it": "applemusic://track/993279864"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=p2djvpbA5e0",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/40043484",
       "uri_deezer": "deezer://track/139077379",
       "fun_fact": "Peter Wackel is a mainstay of the Mallorca party-Schlager scene and a regular at the Bierkönig.",
       "fun_fact_de": "Peter Wackel ist eine feste Größe der Mallorca-Party-Schlager-Szene und Dauergast im Bierkönig.",
@@ -4452,7 +4452,7 @@
         "it": "applemusic://track/1706432499"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=VzFXDaAhqZM",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/59951595",
       "uri_deezer": "deezer://track/124190262",
       "alt_artists": [
         "Chaos Team"


### PR DESCRIPTION
Automated Tidal-URI backfill wave (06:00 slot, `scripts/backfill_tidal.py --max 80`).

## Delta

| Playlist | Tidal-URIs | Version |
|---|---|---|
| `ballermann-party-hits` | +19 (19 `null` → real URIs) | 1.19 → 1.20 |

## Wave notes

- **Heavy 429 wall.** Odesli rate-limited hard for most of the wave; the run was cut at the 15-minute wrapper timeout while still in backoff. The 19 hits above are what landed before that. Skipped tracks are *not* recorded as misses and retry on the next wave.
- Miss-cache grew **296 → 315** entries (19 genuine "not on Tidal" results learned, so they won't be re-queried).
- Only `uri_tidal` fields changed plus the version bump — no track added, removed or reordered.

Draft on purpose — for @mholzi to review and merge.