### PR TITLE
docs: FAQ for the LLM playlist generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to Beatify are documented here. For detailed release notes, 
 
 ## [Unreleased]
 
+### Added
+- **FAQ for the LLM Playlist Generator ([docs/llm-playlist-generator.md](docs/llm-playlist-generator.md)).** The in-app guide already warns that assistants truncate large playlists, but only inside the generator modal — a user who hits the wall and searches the web, or asks in the forum, finds nothing. This page answers the same questions where they can be found and linked. It also gives the number the in-app hint does not: one finished song is ~920 characters (~260 tokens), so 32 songs land near 8 400 tokens — which is why the ceiling sits at ~30 songs and not somewhere arbitrary. Reported on the HA forum (thread 998895) before the in-app guide existed.
+
 ## [4.2.0-rc16] - 2026-07-22
 
 Pre-release — cut from current `main`, supersedes rc15. One admin fix found by the live-test screenshot stage (the API reported the state as healthy), plus a Tidal backfill wave.

--- a/README.md
+++ b/README.md
@@ -508,6 +508,13 @@ Beatify uses JSON playlists stored in `config/beatify/playlists/`. The full, aut
 
 Sample playlists are included to get you started immediately.
 
+**Building one with an AI assistant.** The admin has a Playlist Generator that turns a Spotify
+playlist into this format: it hands you a prompt, you run it in ChatGPT / Claude / a local model,
+and you paste the JSON back. Beatify never calls an LLM itself. Assistants truncate large
+playlists — the wall sits near 30 songs and the reason is response length, not a Beatify limit.
+See [LLM Playlist Generator — FAQ](docs/llm-playlist-generator.md) for the batching workaround
+and the usual paste problems.
+
 ---
 
 <br>

--- a/docs/llm-playlist-generator.md
+++ b/docs/llm-playlist-generator.md
@@ -1,0 +1,93 @@
+# LLM Playlist Generator — FAQ
+
+The Playlist Generator turns a Spotify playlist into a Beatify playlist file. **Beatify never calls an LLM itself** — it hands you a prompt, you run it in whatever assistant you already use, and you paste the JSON back. Everything below is about that middle step, because that is where it goes wrong.
+
+The admin UI carries a short version of this in the guide accordion at the top of the generator modal. This page exists so the same answers are findable *outside* the app — from a search engine, or as a link in a forum reply.
+
+## The flow
+
+1. Paste the Spotify playlist URL, click **Copy prompt**.
+2. Run the prompt in ChatGPT, Claude, or a local model.
+3. Paste the JSON back into Beatify.
+4. Click **Validate** — you get a ✓/✗ per field, per song.
+5. Then either **Save locally** (lands in `<config>/beatify/playlists/user/`, shows up in the Community tab) or **Submit as GitHub issue**.
+
+---
+
+## "It stops after about 30 songs"
+
+**This is the single most common problem, and it is not a bug in Beatify or in your assistant.** It is the response length.
+
+Beatify asks for 15 fields per song, and two of them are expensive: seven regional Apple Music IDs, and the same fun fact translated into five languages. One finished song looks like this — this is the gold-standard example from the prompt itself:
+
+```json
+{
+  "artist": "U96",
+  "title": "Das Boot",
+  "year": 1991,
+  "isrc": "DEPI81403435",
+  "uri": "spotify:track:5A3IdgGphzKS2etiGFB73S",
+  "uri_apple_music": "applemusic://track/965771834",
+  "uri_apple_music_by_region": { "us": "…", "de": "…", "gb": "…", "fr": "…", "es": "…", "nl": "…", "it": "…" },
+  "uri_youtube_music": "https://music.youtube.com/watch?v=0snTYLgg9w0",
+  "uri_tidal": null,
+  "uri_deezer": "deezer://track/94877938",
+  "fun_fact": "A trance and dance-floor classic (1991).",
+  "fun_fact_de": "…", "fun_fact_es": "…", "fun_fact_fr": "…", "fun_fact_nl": "…"
+}
+```
+
+That is **roughly 920 characters, or about 260 tokens, for one song**. Which means:
+
+| Songs | Rough output size |
+|---|---|
+| 30 | ~7 900 tokens |
+| 32 | ~8 400 tokens |
+| 50 | ~13 100 tokens |
+| 100 | ~26 300 tokens |
+
+Many chat assistants cap a single reply at around 8 000 tokens. That is why the wall sits near 30–32 songs and not somewhere random — you are not hitting a Beatify limit, you are hitting the assistant's maximum reply length.
+
+**What it looks like when you hit it**
+
+- The JSON simply stops mid-song, often mid-string. Pasting it back gives a parse error.
+- Some assistants end the reply cleanly but silently short — you get 30 songs out of a 100-song playlist and no warning.
+- ChatGPT sometimes aborts with an error message that does not mention length at all. Length is still almost always the cause.
+
+**The fix: run it in batches**
+
+Split the playlist into **batches of about 30 songs**, run the prompt once per batch, then merge the `songs` arrays into one file. Keep the top-level fields (`name`, `version`, `tags`, `language`, `author`, `added_date`, `description`) from the first batch and drop them from the rest.
+
+If your assistant offers a "continue" button, prefer restarting with a clean batch instead. Continuations tend to re-emit or skip a song at the seam, and a duplicate or a hole is harder to spot afterwards than a clean batch boundary.
+
+---
+
+## "The JSON does not validate even though it looks fine"
+
+A few things travel along with copy-paste that are not part of the JSON. Beatify already strips the common ones automatically and shows you what it changed, so try **Validate** first — but if it still fails, these are the usual suspects:
+
+- **Markdown fences.** Assistants add ```json around the object although the prompt asks them not to. Beatify extracts what is between the fences.
+- **Angle brackets around URLs.** Some chat renderers turn a bare URL into `<https://…>`, and the brackets end up inside the string value. Beatify strips these on the known URI fields only — stripping them everywhere would silently mutate a `fun_fact` that legitimately contains `<…>`.
+- **A preamble or a closing sentence.** Beatify trims everything before the first `{` and after the last `}`.
+
+## "Some IDs are flagged as suspicious"
+
+The validator checks shape, and it also flags values that match patterns typical of a guessed identifier. Shape-valid does not mean correct: an assistant can produce a well-formed Apple Music ID that points at a different recording, or an ISRC that belongs to another release of the same song.
+
+If you cannot verify an identifier against the actual service, leave the field as it is and add `(LLM-generated identifiers — verify with the Beatify URI resolver)` to the playlist `description`. That is what the prompt asks for, and it tells the reviewer what still needs a pass.
+
+## "Which assistant should I use?"
+
+Any of them. The prompt is deliberately plain English and asks for nothing model-specific. The only property that matters in practice is how much the assistant will emit in one reply — which is exactly what the batching advice above is about.
+
+## "Does Beatify send my data anywhere?"
+
+No. The generator builds a prompt string and puts it on your clipboard. What happens after that happens in your assistant, under your account. Beatify sees the JSON only when you paste it back, and it is validated in your browser.
+
+---
+
+## Known limitations
+
+- **No automatic merging of batches.** You merge the `songs` arrays yourself. Beatify validates whatever single JSON object you paste.
+- **`uri_tidal` may be `null`.** It is the one URI field the prompt allows to be empty; Beatify's Tidal backfill fills these in later.
+- **Apple Music identifiers are the weakest link.** Seven regional IDs per song is a lot to ask of a model that cannot query the store. Expect to verify these.


### PR DESCRIPTION
Closes the follow-up left over from HA forum thread 998895 (2026-06-02).

## Why

The generator's in-app guide **already** warns that assistants truncate large playlists and tells you to batch — that shipped on 2026-06-09 as #1286/#1301, a week after the forum report. So the advice is not missing; it is only reachable from inside the generator modal.

A user who hits the wall and searches the web, or asks on the forum, finds nothing. That is the actual gap: discoverability, not knowledge. This page puts the same answers somewhere findable and linkable, and the README now points at it from the *Creating Playlists* section.

## What it adds beyond the in-app hint

**The number.** The in-app warning says "more than ~32 songs?" without saying why 32.

One finished song is **~920 characters / ~260 tokens** — 15 fields, of which seven are regional Apple Music IDs and five are translated fun facts. So 32 songs land near **8 400 tokens**, right at the single-reply ceiling of many chat assistants. The page shows the arithmetic and a small table (30 / 32 / 50 / 100 songs), so a user can reason about their own assistant's limit instead of trusting a rule of thumb.

Measured from the prompt's own gold-standard example (`buildPrompt`, `playlist-generator.js`), not estimated.

It also covers:

- What truncation *looks* like — stops mid-string, or ends cleanly but silently short, or ChatGPT aborts with an error that never mentions length.
- Why "continue" is worse than a clean batch: continuations duplicate or skip a song at the seam, and that is harder to spot than a batch boundary.
- The paste-corruption cases the sanitizer already handles (markdown fences, angle-bracketed URLs, preamble/closing text) — so users know to hit **Validate** before hand-editing.
- What "suspicious ID" means: shape-valid is not correct, and what to write in `description` when you cannot verify.
- That Beatify never calls an LLM itself, and the JSON is validated in the browser.

## A trap worth knowing about

**`docs/` is in `.gitignore` (line 14)**, yet seven files under it are tracked (they predate the rule). A plain `git add -A` therefore staged the CHANGELOG and README but **silently dropped the new doc** — the first version of this commit would have shipped a README link to a file that does not exist in the repo. Caught it on the commit stat; the file is force-added now.

Anyone adding a doc under `docs/` will hit this. Worth either un-ignoring `docs/` or narrowing the rule, but that is a separate change and not one to sneak into a docs PR.

## Scope

Documentation only — no code, no behaviour change. `README.md`, `CHANGELOG.md`, and the new `docs/llm-playlist-generator.md`.

Not done here, deliberately: **the forum reporter still has no answer.** The pause rule forbids autonomous forum replies, so that stays a human action. This page is what a reply would link to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)