### PR TITLE
feat(gameplay): resolve Crowd-Court once everyone has voted (#1667)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable changes to Beatify are documented here. For detailed release notes, 
 ### Added
 - **FAQ for the LLM Playlist Generator ([docs/llm-playlist-generator.md](docs/llm-playlist-generator.md)).** The in-app guide already warns that assistants truncate large playlists, but only inside the generator modal — a user who hits the wall and searches the web, or asks in the forum, finds nothing. This page answers the same questions where they can be found and linked. It also gives the number the in-app hint does not: one finished song is ~920 characters (~260 tokens), so 32 songs land near 8 400 tokens — which is why the ceiling sits at ~30 songs and not somewhere arbitrary. Reported on the HA forum (thread 998895) before the in-app guide existed.
 
+### Changed
+- **Crowd-Court resolves as soon as everyone has voted (#1667).** The near-miss vote window in Title & Artist mode held REVEAL for a fixed 30 seconds even when every eligible player had already tapped 👍/👎 — dead air with nothing left to decide. The window now closes as soon as all votes are in. Eligibility follows the rules the vote handler already enforces: active players only (a stale ghost socket cannot hold the room, #928), eliminated players excluded (#827), and nobody counts as a voter on their own near-miss. When nobody *can* vote — a solo game, or a near-miss whose only other players are gone — the timer runs as before rather than resolving instantly. The 30-second window itself is unchanged and stays fixed.
+
 ## [4.2.0-rc16] - 2026-07-22
 
 Pre-release — cut from current `main`, supersedes rc15. One admin fix found by the live-test screenshot stage (the API reported the state as healthy), plus a Tidal backfill wave.

--- a/custom_components/beatify/game/state_vote_window.py
+++ b/custom_components/beatify/game/state_vote_window.py
@@ -106,6 +106,58 @@ class VoteWindowMixin:
             self._title_artist_voting_open = False
             self._title_artist_vote_deadline = None
 
+    def all_crowd_court_votes_in(self) -> bool:
+        """True when every eligible voter has voted on every near-miss (#1667).
+
+        The vote window's job is to give the room time to weigh in; once the
+        room has, waiting out the rest of the 30 s is dead air. This is the
+        same idea as ``all_submitted`` for guesses, applied to the REVEAL vote.
+
+        Eligibility mirrors the two rules the WS handler already enforces:
+
+        * **Active players only.** Uses ``is_active`` rather than the raw
+          ``connected`` flag, so a stale ghost (closed socket not yet reaped,
+          #928) cannot hold the whole room hostage — and eliminated players
+          (#827) are out, exactly as in ``PlayerRegistry.all_submitted``.
+        * **No self-votes.** ``guessing.py`` rejects a vote on one's own
+          near-miss, so the owner is not counted as an eligible voter for it.
+          Counting them would make early resolve unreachable for any near-miss.
+
+        Returns False when there is nothing to decide (no near-misses, or a
+        near-miss whose only possible voter is its own owner) — the caller then
+        simply lets the timer run, which is the pre-#1667 behaviour and never
+        resolves *earlier* than the host expects.
+        """
+        near_misses = self.get_near_misses()
+        if not near_misses:
+            return False
+        active = [
+            p.name
+            for p in self.players.values()
+            if getattr(p, "is_active", False) and not p.eliminated
+        ]
+        if not active:
+            return False
+        # get_near_misses() already returns [] without an active challenge, so
+        # this cannot be None here — read defensively anyway, because a future
+        # caller reaching this method by another path should not crash REVEAL.
+        challenge = self._challenge_manager.title_artist_challenge
+        if challenge is None:
+            return False
+        votes = challenge.votes
+        for near_miss in near_misses:
+            owner = near_miss["id"].rsplit(":", 1)[0]
+            eligible = [name for name in active if name != owner]
+            if not eligible:
+                # Solo game, or the only other players left. Nobody may vote on
+                # this one, so "everyone has voted" can never become true —
+                # fall back to the timer instead of resolving instantly.
+                return False
+            cast = votes.get(near_miss["id"], {})
+            if any(name not in cast for name in eligible):
+                return False
+        return True
+
     async def _title_artist_vote_window(self, window_seconds: int) -> None:
         """Hold REVEAL open for community voting, then resolve (#1180 P4).
 
@@ -125,8 +177,22 @@ class VoteWindowMixin:
                 elapsed += poll
                 if self.phase != GamePhase.REVEAL:
                     return  # advanced / paused / ended elsewhere
-            # Window expired naturally — clear the handle first so a manual
-            # start_round's _cancel_auto_advance() can't cancel this task.
+                # #1667: everyone eligible has voted — resolve now instead of
+                # staring at a countdown nobody is going to change. Checked in
+                # the existing poll rather than pushed from the vote handler on
+                # purpose: no second task, no new cancellation path, and the
+                # worst case is resolving up to one poll (0.5 s) late.
+                if self.all_crowd_court_votes_in():
+                    _LOGGER.debug(
+                        "Crowd-Court: all votes in after %.1fs of %ss — "
+                        "resolving early (#1667)",
+                        elapsed,
+                        window_seconds,
+                    )
+                    break
+            # Window over — either expired naturally or every vote is in.
+            # Clear the handle first so a manual start_round's
+            # _cancel_auto_advance() can't cancel this task.
             self._auto_advance_task = None
             if self.phase != GamePhase.REVEAL:
                 return

--- a/tests/unit/test_crowd_court_early_resolve_1667.py
+++ b/tests/unit/test_crowd_court_early_resolve_1667.py
@@ -1,0 +1,175 @@
+"""Crowd-Court resolves as soon as every eligible voter has voted (#1667).
+
+The REVEAL vote window exists to give the room 30 s to weigh in on a near-miss.
+Once the room *has* weighed in, the rest of the countdown is dead air. These
+tests pin the predicate that decides "everyone has voted", including the two
+cases where it must deliberately stay False and let the timer run.
+
+Eligibility follows the rules the WS handler already enforces (`guessing.py`):
+active players only, and nobody votes on their own near-miss.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from tests.conftest import make_game_state
+
+
+def _game_with_near_miss(players=("Alice", "Bob", "Carol")):
+    """A game in near-miss state: Alice's title guess is close but not exact."""
+    gs = make_game_state()
+    gs._challenge_manager.configure(
+        artist_challenge_enabled=False,
+        movie_quiz_enabled=False,
+        title_artist_mode=True,
+    )
+    gs._challenge_manager.init_round({"title": "Word Up Now", "artist": "A Word"})
+    gs._challenge_manager.submit_title_artist_guess(
+        "Alice", "Word Up Later", "A Word", 1.0
+    )
+    for name in players:
+        # `is_active` is `connected and ws is not None and not ws.closed`, and a
+        # bare MagicMock's `.closed` is truthy — so an unconfigured mock socket
+        # reads as a stale ghost and every player would be filtered out.
+        ws = MagicMock()
+        ws.closed = False
+        gs.add_player(name, ws)
+    for p in gs.players.values():
+        p.connected = True
+    return gs
+
+
+def _player(gs, name):
+    """Look a player up by name — the registry is keyed by player_id (#1664)."""
+    return next(p for p in gs.players.values() if p.name == name)
+
+
+def _near_miss_id(gs) -> str:
+    return gs.get_near_misses()[0]["id"]
+
+
+class TestAllVotesIn:
+    def test_false_while_a_vote_is_missing(self):
+        gs = _game_with_near_miss()
+        nm = _near_miss_id(gs)
+        gs.register_title_artist_vote("Bob", nm, True)
+        # Carol is active and eligible but has not voted.
+        assert gs.all_crowd_court_votes_in() is False
+
+    def test_true_once_every_eligible_player_voted(self):
+        gs = _game_with_near_miss()
+        nm = _near_miss_id(gs)
+        gs.register_title_artist_vote("Bob", nm, True)
+        gs.register_title_artist_vote("Carol", nm, False)
+        # Alice owns the near-miss and may not vote on it — her silence must
+        # not block the resolve, or early resolve could never fire at all.
+        assert gs.all_crowd_court_votes_in() is True
+
+    def test_disconnected_player_does_not_block(self):
+        # #928: a stale ghost must not hold the room hostage. Same rule as
+        # PlayerRegistry.all_submitted, which is why this reads is_active.
+        gs = _game_with_near_miss()
+        nm = _near_miss_id(gs)
+        _player(gs, "Carol").connected = False
+        gs.register_title_artist_vote("Bob", nm, True)
+        assert gs.all_crowd_court_votes_in() is True
+
+    def test_stale_ghost_does_not_block(self):
+        # The case that actually separates `is_active` from `connected`:
+        # `connected` is still True, but the socket is closed and
+        # `_handle_disconnect` has not run yet (#928). Without this test,
+        # swapping `is_active` for `connected` passes the whole suite — the
+        # disconnect test above clears `connected` and so cannot tell them
+        # apart. Verified by mutation.
+        gs = _game_with_near_miss()
+        nm = _near_miss_id(gs)
+        carol = _player(gs, "Carol")
+        carol.connected = True
+        carol.ws.closed = True
+        gs.register_title_artist_vote("Bob", nm, True)
+        assert gs.all_crowd_court_votes_in() is True
+
+    def test_eliminated_player_does_not_block(self):
+        # #827: eliminated players are out of the round entirely.
+        gs = _game_with_near_miss()
+        nm = _near_miss_id(gs)
+        _player(gs, "Carol").eliminated = True
+        gs.register_title_artist_vote("Bob", nm, True)
+        assert gs.all_crowd_court_votes_in() is True
+
+    def test_every_near_miss_must_be_complete(self):
+        # Two near-misses, one fully voted, one not: still False. Resolving on
+        # the first complete one would cut the vote on the second short.
+        gs = _game_with_near_miss()
+        gs._challenge_manager.submit_title_artist_guess(
+            "Bob", "Word Up Now", "A Word Or Two", 1.0
+        )
+        ids = [nm["id"] for nm in gs.get_near_misses()]
+        assert len(ids) >= 2, ids
+        gs.register_title_artist_vote("Bob", ids[0], True)
+        gs.register_title_artist_vote("Carol", ids[0], True)
+        assert gs.all_crowd_court_votes_in() is False
+
+    def test_solo_game_falls_back_to_the_timer(self):
+        # Only Alice is in the game and the near-miss is hers, so nobody may
+        # vote. "Everyone voted" can never become true — returning True here
+        # would resolve instantly and silently skip the crowd vote.
+        gs = _game_with_near_miss(players=("Alice",))
+        assert gs.all_crowd_court_votes_in() is False
+
+    def test_no_near_misses_is_false(self):
+        # Nothing to decide; the window is not even opened on this path.
+        gs = make_game_state()
+        assert gs.all_crowd_court_votes_in() is False
+
+    def test_no_active_players_is_false(self):
+        gs = _game_with_near_miss()
+        for p in gs.players.values():
+            p.connected = False
+        assert gs.all_crowd_court_votes_in() is False
+
+
+class TestWindowResolvesEarly:
+    """End-to-end: the open window actually closes once the votes are in.
+
+    The predicate above is only half the feature — this drives the real
+    REVEAL window and asserts it stops waiting. The window is the production
+    30 s one, so a run that finishes in ~1 s can only mean it broke out early.
+    """
+
+    async def test_window_closes_without_waiting_out_the_timer(self):
+        import asyncio
+
+        from custom_components.beatify.game.state import GamePhase
+        from tests.unit.test_state_title_artist_window import _start_round
+
+        gs = make_game_state()
+        await _start_round(gs)
+        await gs.start_round()
+        # Alice near-misses the title, Bob is exact -> exactly one near-miss.
+        gs._challenge_manager.submit_title_artist_guess(
+            "Alice", "Real Mismatch", gs.current_song["artist"], 1.0
+        )
+        gs._challenge_manager.submit_title_artist_guess(
+            "Bob", gs.current_song["title"], gs.current_song["artist"], 1.0
+        )
+        for p in gs.players.values():
+            p.submitted = True
+            p.ws.closed = False  # make is_active true (see helper above)
+        await gs.end_round()
+        assert gs.phase == GamePhase.REVEAL
+        assert gs.is_title_artist_voting_open() is True
+
+        nm = gs.get_near_misses()[0]["id"]
+        # Bob is the only eligible voter: Alice owns the near-miss.
+        gs.register_title_artist_vote("Bob", nm, True)
+
+        # Poll interval is 0.5 s; give it two, far short of the 30 s window.
+        await asyncio.sleep(1.5)
+
+        assert gs.is_title_artist_voting_open() is False, (
+            "window still open — early resolve did not fire"
+        )
+        assert gs._challenge_manager.title_artist_challenge.resolved is True
+        gs._cancel_auto_advance()


### PR DESCRIPTION
Part of #1667 — **early resolve only**. The configurable window is deliberately not built; per Markus the 30 seconds stay fixed.

## What changes

The near-miss vote window in Title & Artist mode held REVEAL for the full 30 seconds even when every eligible player had already tapped 👍/👎. Nothing could change in the remaining time — it was dead air. The window now closes as soon as all votes are in.

The check runs inside the **existing poll loop** rather than being pushed from the vote handler. That keeps it to one small predicate plus a `break`: no second task, no new cancellation path, no change to how a manual advance / pause / end tears the window down. The cost is resolving up to one poll (0.5 s) late, which nobody can perceive against a 30 s window.

## Who counts as a voter

Mirrors what `guessing.py` already enforces, rather than inventing a second rule:

- **Active players only** — `is_active`, not the raw `connected` flag, so a stale ghost (closed socket whose `_handle_disconnect` has not run) cannot hold the room hostage. Same reasoning as `PlayerRegistry.all_submitted` (#928).
- **Eliminated players excluded** (#827).
- **No self-votes.** The handler rejects a vote on one's own near-miss, so the owner is not an eligible voter for it. Counting them would make early resolve unreachable for every near-miss.
- **Every** near-miss must be complete, not just one — otherwise a fully-voted first near-miss would cut the vote on the second one short.

## Where it deliberately does nothing

`all_crowd_court_votes_in()` returns False when nobody *can* vote — a solo game, or a near-miss whose only other players have left. "Everyone has voted" can never become true there, and returning True would resolve instantly and silently skip the crowd vote rather than speed it up. The timer runs exactly as before.

## Tests

New `test_crowd_court_early_resolve_1667.py`, 10 tests:

- The predicate: missing vote, all votes in, ghost socket, disconnected, eliminated, two near-misses with one incomplete, solo game, no near-misses, no active players.
- **End-to-end**: opens the real production window, casts the one eligible vote, and asserts it closes within 1.5 s. Against the unmodified 30 s window that can only pass if the loop broke out early.

**Mutation-checked, and it caught a hole in my own suite.** Swapping `is_active` for `connected` passed all tests at first — the disconnect test clears `connected`, so it cannot tell the two apart. The case that separates them is `connected = True` with a closed socket, which is exactly the #928 ghost. Added `test_stale_ghost_does_not_block`; that mutation now fails. Removing the self-vote exclusion fails 3 tests, and disabling the `break` fails the end-to-end test.

## Verification

- **1530 passed / 2 skipped** (up from 1520; +10).
- `ruff check` and `ruff format` clean.
- No frontend change — the window close already broadcasts, so the client needs nothing.
- **Not verified on real hardware.** Title & Artist mode with a near-miss and two players is awkward to stage on the live instance; the end-to-end test drives the real window instead.

## Draft

Draft because the behaviour is a judgement call worth a second look: with three players and one near-miss, a single 👍 from the one eligible voter now ends the vote immediately. That is the intent — but if you would rather have a floor (e.g. never resolve before ~5 s so people can see the tally move), say so and it is a two-line change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)