### PR TITLE
docs(changelog): Polskie-hity-Eintrag an den gemergten Stand angleichen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to Beatify are documented here. For detailed release notes, 
 ## [Unreleased]
 
 ### Added
-- **Polskie hity lat 90' 00' 🇵🇱 — 93 tracks (#1891).** Polish pop and rock hits of the 1990s and 2000s, the third Polish playlist alongside Polskie przeboje wszech czasów and Polski Rock. Seven tracks already curated in those two were dropped as duplicates, so the catalogue gains 93 genuinely new songs rather than 100 with overlap.
+- **Polskie hity radiowe 🇵🇱 — 92 tracks (#1891).** Polish pop and rock radio hits spanning 1972-2016, with the heart of the collection in the 1990s and 2000s (75 of 92 tracks). The third Polish playlist alongside Polskie przeboje wszech czasów and Polski Rock; seven tracks already curated in those two were dropped as duplicates, so the catalogue gains 92 genuinely new songs rather than 100 with overlap.
 
 ## [4.2.0-rc17] - 2026-07-22
 


### PR DESCRIPTION
Der CHANGELOG-Eintrag aus #1894 blieb auf dem Stand des ersten Commits stehen und beschreibt jetzt auf `main` etwas, das es nicht gibt.

| | CHANGELOG (alt) | tatsächlich auf main |
|---|---|---|
| Name | Polskie hity lat 90' 00' 🇵🇱 | **Polskie hity radiowe 🇵🇱** |
| Tracks | 93 | **92** (Krawczyk-Duplikat entfernt, identische ISRC `PLG941201353`) |
| Zeitraum | hits of the 1990s and 2000s | **1972–2016**, Schwerpunkt 75/92 in 1990–2010 |

Nur Text im CHANGELOG, keine Datenänderung an der Playlist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)