### PR TITLE
chore(playlists): tidal backfill wave — +19 uris (deutschpop-klassiker)

### DIFF
--- a/custom_components/beatify/playlists/community/deutschpop-klassiker.json
+++ b/custom_components/beatify/playlists/community/deutschpop-klassiker.json
@@ -1,6 +1,6 @@
 {
   "name": "Deutschpop Klassiker 🇩🇪",
-  "version": "0.10",
+  "version": "0.11",
   "tags": [
     "german",
     "pop",
@@ -2696,7 +2696,7 @@
       },
       "uri_deezer": "deezer://track/352177941",
       "uri_youtube_music": "https://music.youtube.com/watch?v=oas9SCVAfgI",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/73014761",
       "alt_artists": [
         "Bosse",
         "Tim Bendzko",
@@ -2730,7 +2730,7 @@
       },
       "uri_deezer": "deezer://track/522156672",
       "uri_youtube_music": "https://music.youtube.com/watch?v=4Q8iEL-M5Ck",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/77998435",
       "alt_artists": [
         "Helene Fischer",
         "Vanessa Mai",
@@ -2768,7 +2768,7 @@
       },
       "uri_deezer": "deezer://track/142394147",
       "uri_youtube_music": "https://music.youtube.com/watch?v=pV-GGCrRcu0",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/70296776",
       "alt_artists": [
         "Wanda",
         "Faber",
@@ -2804,7 +2804,7 @@
       },
       "uri_deezer": "deezer://track/15539388",
       "uri_youtube_music": "https://music.youtube.com/watch?v=8bNHTgVhdYM",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/11843579",
       "alt_artists": [
         "Juli",
         "Wir sind Helden",
@@ -2840,7 +2840,7 @@
       },
       "uri_deezer": "deezer://track/114918126",
       "uri_youtube_music": "https://music.youtube.com/watch?v=Gwp0bUZGohU",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/60342731",
       "alt_artists": [
         "Glasperlenspiel",
         "Felix Jaehn",
@@ -2879,7 +2879,7 @@
       },
       "uri_deezer": "deezer://track/756918912",
       "uri_youtube_music": "https://music.youtube.com/watch?v=wY_rF_LlZ2c",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/118126092",
       "alt_artists": [
         "Samra",
         "Bausa",
@@ -2917,7 +2917,7 @@
       },
       "uri_deezer": "deezer://track/107604374",
       "uri_youtube_music": "https://music.youtube.com/watch?v=kJ9iywSoLRs",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/51347054",
       "alt_artists": [
         "Stereoact",
         "Felix Jaehn",
@@ -2955,7 +2955,7 @@
       },
       "uri_deezer": "deezer://track/675344152",
       "uri_youtube_music": "https://music.youtube.com/watch?v=fKfRuYV0zfI",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/108798013",
       "alt_artists": [
         "Cro",
         "Mark Forster",
@@ -2989,7 +2989,7 @@
       },
       "uri_deezer": "deezer://track/6347577",
       "uri_youtube_music": "https://music.youtube.com/watch?v=ma3ZbkA3gqY",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/14516038",
       "alt_artists": [
         "Casper",
         "Marteria",
@@ -3023,7 +3023,7 @@
       },
       "uri_deezer": "deezer://track/937031012",
       "uri_youtube_music": "https://music.youtube.com/watch?v=06X89HZmj1Y",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/138362884",
       "alt_artists": [
         "Bosse",
         "Andreas Bourani",
@@ -3057,7 +3057,7 @@
       },
       "uri_deezer": "deezer://track/7718640",
       "uri_youtube_music": "https://music.youtube.com/watch?v=S_Sy5-sOodA",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/3989694",
       "alt_artists": [
         "Echt",
         "Killerpilze",
@@ -3095,7 +3095,7 @@
       },
       "uri_deezer": "deezer://track/396427042",
       "uri_youtube_music": "https://music.youtube.com/watch?v=7dvc9t1su1M",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/77593805",
       "alt_artists": [
         "Helene Fischer",
         "Stereoact",
@@ -3129,7 +3129,7 @@
       },
       "uri_deezer": "deezer://track/66006335",
       "uri_youtube_music": "https://music.youtube.com/watch?v=ETQ4QxYNM8k",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/31888995",
       "alt_artists": [
         "AnnenMayKantereit",
         "Provinz",
@@ -3163,7 +3163,7 @@
       },
       "uri_deezer": "deezer://track/1755753297",
       "uri_youtube_music": "https://music.youtube.com/watch?v=BKGW4MnPXVw",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/199545468",
       "alt_artists": [
         "Bosse",
         "Tim Bendzko",
@@ -3197,7 +3197,7 @@
       },
       "uri_deezer": "deezer://track/654737842",
       "uri_youtube_music": "https://music.youtube.com/watch?v=52mUuzw4SgI",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/106103497",
       "alt_artists": [
         "Capital Bra",
         "Cro",
@@ -3235,7 +3235,7 @@
       },
       "uri_deezer": "deezer://track/122886242",
       "uri_youtube_music": "https://music.youtube.com/watch?v=izHB2EdMngg",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/58814894",
       "alt_artists": [
         "Helene Fischer",
         "Andrea Berg",
@@ -3271,7 +3271,7 @@
       },
       "uri_deezer": "deezer://track/2305261",
       "uri_youtube_music": "https://music.youtube.com/watch?v=yNzyktrWSWM",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/3983182",
       "alt_artists": [
         "Wir sind Helden",
         "Juli",
@@ -3305,7 +3305,7 @@
       },
       "uri_deezer": "deezer://track/133582480",
       "uri_youtube_music": "https://music.youtube.com/watch?v=NQJFPQHX8kA",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/65502905",
       "alt_artists": [
         "Frida Gold",
         "Stefanie Heinzmann",
@@ -3343,7 +3343,7 @@
       },
       "uri_deezer": "deezer://track/3159907",
       "uri_youtube_music": "https://music.youtube.com/watch?v=LKi4BlO_ls8",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/2950975",
       "alt_artists": [
         "Udo Lindenberg",
         "Westernhagen",


### PR DESCRIPTION
Tidal-Welle vom 26.07 12:00.

| Playlist | Tidal vorher | Tidal nachher | version |
|---|---|---|---|
| `deutschpop-klassiker` | 73 / 107 | **92 / 107** | 0.10 → 0.11 |

**Geborgene Welle.** Der Lauf wurde extern abgebrochen, bevor das `--max 80`-Budget ausgeschöpft war. `backfill_tidal.py` speichert pro Treffer inkrementell, die 19 URIs sind also vollständig; `validate_playlists.py` läuft grün (Schema-Gate passed). Geborgen statt verworfen, damit dieselben Odesli-Abfragen nicht erneut fällig werden.

Miss-Cache in derselben Bergung zurückgeschrieben: 482 → **501** Einträge (19 neu als echte „nicht auf Tidal"-Treffer gelernt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)