### PR TITLE
fix(playlists): korrekte Jahre in polish-rock — 40 von 100 Tracks (#1901)

### DIFF
--- a/custom_components/beatify/playlists/community/polish-rock.json
+++ b/custom_components/beatify/playlists/community/polish-rock.json
@@ -1,6 +1,6 @@
 {
   "name": "Polski Rock",
-  "version": "0.4",
+  "version": "0.5",
   "tags": [
     "polish",
     "rock"
@@ -90,7 +90,7 @@
       "fun_fact_nl": "Męskie Granie Orkiestra maakt deel uit van de Poolse rockscene, en 'Tańczę' (2026) staat op deze Poolse rock-playlist."
     },
     {
-      "year": 2005,
+      "year": 2012,
       "uri": "spotify:track:2EEevGBoiKViJmByMzRDfw",
       "artist": "Rezerwat",
       "title": "Zaopiekuj sie mną",
@@ -109,11 +109,11 @@
       "uri_tidal": "tidal://track/458731220",
       "uri_deezer": "deezer://track/18507201",
       "alt_artists": [],
-      "fun_fact": "Rezerwat is part of Poland's rock scene, and 'Zaopiekuj sie mną' (2005) features on this Polish rock playlist.",
-      "fun_fact_de": "Rezerwat gehoert zur polnischen Rockszene, und 'Zaopiekuj sie mną' (2005) ist auf dieser Polish-Rock-Playlist vertreten.",
-      "fun_fact_es": "Rezerwat forma parte de la escena del rock polaco, y 'Zaopiekuj sie mną' (2005) aparece en esta lista de rock polaco.",
-      "fun_fact_fr": "Rezerwat fait partie de la scene rock polonaise, et 'Zaopiekuj sie mną' (2005) figure sur cette playlist de rock polonais.",
-      "fun_fact_nl": "Rezerwat maakt deel uit van de Poolse rockscene, en 'Zaopiekuj sie mną' (2005) staat op deze Poolse rock-playlist."
+      "fun_fact": "Rezerwat is part of Poland's rock scene, and 'Zaopiekuj sie mną' (2012) features on this Polish rock playlist.",
+      "fun_fact_de": "Rezerwat gehoert zur polnischen Rockszene, und 'Zaopiekuj sie mną' (2012) ist auf dieser Polish-Rock-Playlist vertreten.",
+      "fun_fact_es": "Rezerwat forma parte de la escena del rock polaco, y 'Zaopiekuj sie mną' (2012) aparece en esta lista de rock polaco.",
+      "fun_fact_fr": "Rezerwat fait partie de la scene rock polonaise, et 'Zaopiekuj sie mną' (2012) figure sur cette playlist de rock polonais.",
+      "fun_fact_nl": "Rezerwat maakt deel uit van de Poolse rockscene, en 'Zaopiekuj sie mną' (2012) staat op deze Poolse rock-playlist."
     },
     {
       "year": 2020,
@@ -142,7 +142,7 @@
       "fun_fact_nl": "KARAŚ/ROGUCKI maakt deel uit van de Poolse rockscene, en 'Kilka westchnień' (2020) staat op deze Poolse rock-playlist."
     },
     {
-      "year": 2018,
+      "year": 1995,
       "uri": "spotify:track:01FN979nyz1gmdsfWZv5OL",
       "artist": "Robert Gawlinski",
       "title": "O Sobie Samym",
@@ -161,11 +161,11 @@
       "uri_tidal": "tidal://track/89275095",
       "uri_deezer": "deezer://track/503929042",
       "alt_artists": [],
-      "fun_fact": "Robert Gawlinski is part of Poland's rock scene, and 'O Sobie Samym' (2018) features on this Polish rock playlist.",
-      "fun_fact_de": "Robert Gawlinski gehoert zur polnischen Rockszene, und 'O Sobie Samym' (2018) ist auf dieser Polish-Rock-Playlist vertreten.",
-      "fun_fact_es": "Robert Gawlinski forma parte de la escena del rock polaco, y 'O Sobie Samym' (2018) aparece en esta lista de rock polaco.",
-      "fun_fact_fr": "Robert Gawlinski fait partie de la scene rock polonaise, et 'O Sobie Samym' (2018) figure sur cette playlist de rock polonais.",
-      "fun_fact_nl": "Robert Gawlinski maakt deel uit van de Poolse rockscene, en 'O Sobie Samym' (2018) staat op deze Poolse rock-playlist."
+      "fun_fact": "Robert Gawlinski is part of Poland's rock scene, and 'O Sobie Samym' (1995) features on this Polish rock playlist.",
+      "fun_fact_de": "Robert Gawlinski gehoert zur polnischen Rockszene, und 'O Sobie Samym' (1995) ist auf dieser Polish-Rock-Playlist vertreten.",
+      "fun_fact_es": "Robert Gawlinski forma parte de la escena del rock polaco, y 'O Sobie Samym' (1995) aparece en esta lista de rock polaco.",
+      "fun_fact_fr": "Robert Gawlinski fait partie de la scene rock polonaise, et 'O Sobie Samym' (1995) figure sur cette playlist de rock polonais.",
+      "fun_fact_nl": "Robert Gawlinski maakt deel uit van de Poolse rockscene, en 'O Sobie Samym' (1995) staat op deze Poolse rock-playlist."
     },
     {
       "year": 2001,
@@ -194,7 +194,7 @@
       "fun_fact_nl": "Republika is een Poolse new wave- en rockband opgericht in Torun in 1981 en geleid door Grzegorz Ciechowski, en 'Śmierć W Bikini' (2001) staat op deze Poolse rock-playlist."
     },
     {
-      "year": 2005,
+      "year": 1971,
       "uri": "spotify:track:0FGBCrLj15yxjJ1WPRnVMQ",
       "artist": "Breakout",
       "title": "Kiedy byłem małym chłopcem",
@@ -213,14 +213,14 @@
       "uri_tidal": "tidal://track/65537416",
       "uri_deezer": "deezer://track/114010984",
       "alt_artists": [],
-      "fun_fact": "Breakout is a Polish blues-rock band led by Tadeusz Nalepa, active from the late 1960s, and 'Kiedy byłem małym chłopcem' (2005) features on this Polish rock playlist.",
-      "fun_fact_de": "Breakout ist eine polnische Blues-Rock-Band unter Tadeusz Nalepa, aktiv seit den spaeten 1960ern, und 'Kiedy byłem małym chłopcem' (2005) ist auf dieser Polish-Rock-Playlist vertreten.",
-      "fun_fact_es": "Breakout es una banda polaca de blues-rock liderada por Tadeusz Nalepa, activa desde finales de los anos 60, y 'Kiedy byłem małym chłopcem' (2005) aparece en esta lista de rock polaco.",
-      "fun_fact_fr": "Breakout est un groupe de blues-rock polonais mene par Tadeusz Nalepa, actif depuis la fin des annees 1960, et 'Kiedy byłem małym chłopcem' (2005) figure sur cette playlist de rock polonais.",
-      "fun_fact_nl": "Breakout is een Poolse blues-rockband geleid door Tadeusz Nalepa, actief sinds eind jaren 60, en 'Kiedy byłem małym chłopcem' (2005) staat op deze Poolse rock-playlist."
+      "fun_fact": "Breakout is a Polish blues-rock band led by Tadeusz Nalepa, active from the late 1960s, and 'Kiedy byłem małym chłopcem' (1971) features on this Polish rock playlist.",
+      "fun_fact_de": "Breakout ist eine polnische Blues-Rock-Band unter Tadeusz Nalepa, aktiv seit den spaeten 1960ern, und 'Kiedy byłem małym chłopcem' (1971) ist auf dieser Polish-Rock-Playlist vertreten.",
+      "fun_fact_es": "Breakout es una banda polaca de blues-rock liderada por Tadeusz Nalepa, activa desde finales de los anos 60, y 'Kiedy byłem małym chłopcem' (1971) aparece en esta lista de rock polaco.",
+      "fun_fact_fr": "Breakout est un groupe de blues-rock polonais mene par Tadeusz Nalepa, actif depuis la fin des annees 1960, et 'Kiedy byłem małym chłopcem' (1971) figure sur cette playlist de rock polonais.",
+      "fun_fact_nl": "Breakout is een Poolse blues-rockband geleid door Tadeusz Nalepa, actief sinds eind jaren 60, en 'Kiedy byłem małym chłopcem' (1971) staat op deze Poolse rock-playlist."
     },
     {
-      "year": 2016,
+      "year": 2007,
       "uri": "spotify:track:07KPw1ymtT6UKE85E1KVmt",
       "artist": "Happysad",
       "title": "Damy radę",
@@ -239,11 +239,11 @@
       "uri_tidal": "tidal://track/58809796",
       "uri_deezer": "deezer://track/121736770",
       "alt_artists": [],
-      "fun_fact": "Happysad is a Polish rock band formed in Skarzysko-Kamienna, and 'Damy radę' (2016) features on this Polish rock playlist.",
-      "fun_fact_de": "Happysad ist eine polnische Rockband, gegruendet in Skarzysko-Kamienna, und 'Damy radę' (2016) ist auf dieser Polish-Rock-Playlist vertreten.",
-      "fun_fact_es": "Happysad es una banda polaca de rock formada en Skarzysko-Kamienna, y 'Damy radę' (2016) aparece en esta lista de rock polaco.",
-      "fun_fact_fr": "Happysad est un groupe de rock polonais forme a Skarzysko-Kamienna, et 'Damy radę' (2016) figure sur cette playlist de rock polonais.",
-      "fun_fact_nl": "Happysad is een Poolse rockband opgericht in Skarzysko-Kamienna, en 'Damy radę' (2016) staat op deze Poolse rock-playlist."
+      "fun_fact": "Happysad is a Polish rock band formed in Skarzysko-Kamienna, and 'Damy radę' (2007) features on this Polish rock playlist.",
+      "fun_fact_de": "Happysad ist eine polnische Rockband, gegruendet in Skarzysko-Kamienna, und 'Damy radę' (2007) ist auf dieser Polish-Rock-Playlist vertreten.",
+      "fun_fact_es": "Happysad es una banda polaca de rock formada en Skarzysko-Kamienna, y 'Damy radę' (2007) aparece en esta lista de rock polaco.",
+      "fun_fact_fr": "Happysad est un groupe de rock polonais forme a Skarzysko-Kamienna, et 'Damy radę' (2007) figure sur cette playlist de rock polonais.",
+      "fun_fact_nl": "Happysad is een Poolse rockband opgericht in Skarzysko-Kamienna, en 'Damy radę' (2007) staat op deze Poolse rock-playlist."
     },
     {
       "year": 2026,
@@ -298,7 +298,7 @@
       "fun_fact_nl": "Hurt maakt deel uit van de Poolse rockscene, en 'Załoga G' (2005) staat op deze Poolse rock-playlist."
     },
     {
-      "year": 2009,
+      "year": 2026,
       "uri": "spotify:track:5uhKi57yfS7pojet6PTecC",
       "artist": "LemON, Wanda i Banda",
       "title": "Siedem życzeń - Radio Edit",
@@ -317,11 +317,11 @@
       "uri_tidal": "tidal://track/526030278",
       "uri_deezer": "deezer://track/4024261111",
       "alt_artists": [],
-      "fun_fact": "LemON is part of Poland's rock scene, and 'Siedem życzeń' (2009) features on this Polish rock playlist.",
-      "fun_fact_de": "LemON gehoert zur polnischen Rockszene, und 'Siedem życzeń' (2009) ist auf dieser Polish-Rock-Playlist vertreten.",
-      "fun_fact_es": "LemON forma parte de la escena del rock polaco, y 'Siedem życzeń' (2009) aparece en esta lista de rock polaco.",
-      "fun_fact_fr": "LemON fait partie de la scene rock polonaise, et 'Siedem życzeń' (2009) figure sur cette playlist de rock polonais.",
-      "fun_fact_nl": "LemON maakt deel uit van de Poolse rockscene, en 'Siedem życzeń' (2009) staat op deze Poolse rock-playlist."
+      "fun_fact": "LemON is part of Poland's rock scene, and 'Siedem życzeń' (2026) features on this Polish rock playlist.",
+      "fun_fact_de": "LemON gehoert zur polnischen Rockszene, und 'Siedem życzeń' (2026) ist auf dieser Polish-Rock-Playlist vertreten.",
+      "fun_fact_es": "LemON forma parte de la escena del rock polaco, y 'Siedem życzeń' (2026) aparece en esta lista de rock polaco.",
+      "fun_fact_fr": "LemON fait partie de la scene rock polonaise, et 'Siedem życzeń' (2026) figure sur cette playlist de rock polonais.",
+      "fun_fact_nl": "LemON maakt deel uit van de Poolse rockscene, en 'Siedem życzeń' (2026) staat op deze Poolse rock-playlist."
     },
     {
       "year": 2015,
@@ -376,7 +376,7 @@
       "fun_fact_nl": "ZIEMBUL maakt deel uit van de Poolse rockscene, en 'Działam' (2026) staat op deze Poolse rock-playlist."
     },
     {
-      "year": 2005,
+      "year": 1992,
       "uri": "spotify:track:3OdBNP9XFecCwsDteynBBh",
       "artist": "Stanisław Soyka, Janusz Iwanski \"yanina\"",
       "title": "Tolerancja / Na Miły Bóg",
@@ -395,14 +395,14 @@
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3263902",
       "alt_artists": [],
-      "fun_fact": "Stanisław Soyka is part of Poland's rock scene, and 'Tolerancja / Na Miły Bóg' (2005) features on this Polish rock playlist.",
-      "fun_fact_de": "Stanisław Soyka gehoert zur polnischen Rockszene, und 'Tolerancja / Na Miły Bóg' (2005) ist auf dieser Polish-Rock-Playlist vertreten.",
-      "fun_fact_es": "Stanisław Soyka forma parte de la escena del rock polaco, y 'Tolerancja / Na Miły Bóg' (2005) aparece en esta lista de rock polaco.",
-      "fun_fact_fr": "Stanisław Soyka fait partie de la scene rock polonaise, et 'Tolerancja / Na Miły Bóg' (2005) figure sur cette playlist de rock polonais.",
-      "fun_fact_nl": "Stanisław Soyka maakt deel uit van de Poolse rockscene, en 'Tolerancja / Na Miły Bóg' (2005) staat op deze Poolse rock-playlist."
+      "fun_fact": "Stanisław Soyka is part of Poland's rock scene, and 'Tolerancja / Na Miły Bóg' (1992) features on this Polish rock playlist.",
+      "fun_fact_de": "Stanisław Soyka gehoert zur polnischen Rockszene, und 'Tolerancja / Na Miły Bóg' (1992) ist auf dieser Polish-Rock-Playlist vertreten.",
+      "fun_fact_es": "Stanisław Soyka forma parte de la escena del rock polaco, y 'Tolerancja / Na Miły Bóg' (1992) aparece en esta lista de rock polaco.",
+      "fun_fact_fr": "Stanisław Soyka fait partie de la scene rock polonaise, et 'Tolerancja / Na Miły Bóg' (1992) figure sur cette playlist de rock polonais.",
+      "fun_fact_nl": "Stanisław Soyka maakt deel uit van de Poolse rockscene, en 'Tolerancja / Na Miły Bóg' (1992) staat op deze Poolse rock-playlist."
     },
     {
-      "year": 2018,
+      "year": 1992,
       "uri": "spotify:track:4c8ElBFDPpfhE6oq4XdnDm",
       "artist": "Wilki",
       "title": "Son Of The Blue Sky",
@@ -421,11 +421,11 @@
       "uri_tidal": "tidal://track/89024753",
       "uri_deezer": "deezer://track/501721802",
       "alt_artists": [],
-      "fun_fact": "Wilki is a Polish rock band led by Robert Gawlinski, and 'Son Of The Blue Sky' (2018) features on this Polish rock playlist.",
-      "fun_fact_de": "Wilki ist eine polnische Rockband unter der Leitung von Robert Gawlinski, und 'Son Of The Blue Sky' (2018) ist auf dieser Polish-Rock-Playlist vertreten.",
-      "fun_fact_es": "Wilki es una banda polaca de rock liderada por Robert Gawlinski, y 'Son Of The Blue Sky' (2018) aparece en esta lista de rock polaco.",
-      "fun_fact_fr": "Wilki est un groupe de rock polonais mene par Robert Gawlinski, et 'Son Of The Blue Sky' (2018) figure sur cette playlist de rock polonais.",
-      "fun_fact_nl": "Wilki is een Poolse rockband geleid door Robert Gawlinski, en 'Son Of The Blue Sky' (2018) staat op deze Poolse rock-playlist."
+      "fun_fact": "Wilki is a Polish rock band led by Robert Gawlinski, and 'Son Of The Blue Sky' (1992) features on this Polish rock playlist.",
+      "fun_fact_de": "Wilki ist eine polnische Rockband unter der Leitung von Robert Gawlinski, und 'Son Of The Blue Sky' (1992) ist auf dieser Polish-Rock-Playlist vertreten.",
+      "fun_fact_es": "Wilki es una banda polaca de rock liderada por Robert Gawlinski, y 'Son Of The Blue Sky' (1992) aparece en esta lista de rock polaco.",
+      "fun_fact_fr": "Wilki est un groupe de rock polonais mene par Robert Gawlinski, et 'Son Of The Blue Sky' (1992) figure sur cette playlist de rock polonais.",
+      "fun_fact_nl": "Wilki is een Poolse rockband geleid door Robert Gawlinski, en 'Son Of The Blue Sky' (1992) staat op deze Poolse rock-playlist."
     },
     {
       "year": 2018,
@@ -584,7 +584,7 @@
       "fun_fact_nl": "Szymon Wydra maakt deel uit van de Poolse rockscene, en 'Wciąż mamy moc' (2026) staat op deze Poolse rock-playlist."
     },
     {
-      "year": 2018,
+      "year": 1992,
       "uri": "spotify:track:42Pgi2825l5I8XHcXL1BLS",
       "artist": "Wilki",
       "title": "Eli Lama Sabachtani",
@@ -603,11 +603,11 @@
       "uri_tidal": null,
       "uri_deezer": "deezer://track/503929412",
       "alt_artists": [],
-      "fun_fact": "Wilki is a Polish rock band led by Robert Gawlinski, and 'Eli Lama Sabachtani' (2018) features on this Polish rock playlist.",
-      "fun_fact_de": "Wilki ist eine polnische Rockband unter der Leitung von Robert Gawlinski, und 'Eli Lama Sabachtani' (2018) ist auf dieser Polish-Rock-Playlist vertreten.",
-      "fun_fact_es": "Wilki es una banda polaca de rock liderada por Robert Gawlinski, y 'Eli Lama Sabachtani' (2018) aparece en esta lista de rock polaco.",
-      "fun_fact_fr": "Wilki est un groupe de rock polonais mene par Robert Gawlinski, et 'Eli Lama Sabachtani' (2018) figure sur cette playlist de rock polonais.",
-      "fun_fact_nl": "Wilki is een Poolse rockband geleid door Robert Gawlinski, en 'Eli Lama Sabachtani' (2018) staat op deze Poolse rock-playlist."
+      "fun_fact": "Wilki is a Polish rock band led by Robert Gawlinski, and 'Eli Lama Sabachtani' (1992) features on this Polish rock playlist.",
+      "fun_fact_de": "Wilki ist eine polnische Rockband unter der Leitung von Robert Gawlinski, und 'Eli Lama Sabachtani' (1992) ist auf dieser Polish-Rock-Playlist vertreten.",
+      "fun_fact_es": "Wilki es una banda polaca de rock liderada por Robert Gawlinski, y 'Eli Lama Sabachtani' (1992) aparece en esta lista de rock polaco.",
+      "fun_fact_fr": "Wilki est un groupe de rock polonais mene par Robert Gawlinski, et 'Eli Lama Sabachtani' (1992) figure sur cette playlist de rock polonais.",
+      "fun_fact_nl": "Wilki is een Poolse rockband geleid door Robert Gawlinski, en 'Eli Lama Sabachtani' (1992) staat op deze Poolse rock-playlist."
     },
     {
       "year": 2015,
@@ -714,7 +714,7 @@
       "fun_fact_nl": "Stach Bukowski maakt deel uit van de Poolse rockscene, en 'Noc' (2020) staat op deze Poolse rock-playlist."
     },
     {
-      "year": 2019,
+      "year": 2001,
       "uri": "spotify:track:2nyBbMPk3yWE0cLJmJcbzH",
       "artist": "Sztywny Pal Azji",
       "title": "Wieża radości, wieża samotności",
@@ -733,11 +733,11 @@
       "uri_tidal": "tidal://track/120747826",
       "uri_deezer": "deezer://track/782048432",
       "alt_artists": [],
-      "fun_fact": "Sztywny Pal Azji is a Polish rock band active since the 1980s, and 'Wieża radości, wieża samotności' (2019) features on this Polish rock playlist.",
-      "fun_fact_de": "Sztywny Pal Azji ist eine polnische Rockband, aktiv seit den 1980er Jahren, und 'Wieża radości, wieża samotności' (2019) ist auf dieser Polish-Rock-Playlist vertreten.",
-      "fun_fact_es": "Sztywny Pal Azji es una banda polaca de rock activa desde los anos 80, y 'Wieża radości, wieża samotności' (2019) aparece en esta lista de rock polaco.",
-      "fun_fact_fr": "Sztywny Pal Azji est un groupe de rock polonais actif depuis les annees 1980, et 'Wieża radości, wieża samotności' (2019) figure sur cette playlist de rock polonais.",
-      "fun_fact_nl": "Sztywny Pal Azji is een Poolse rockband actief sinds de jaren 80, en 'Wieża radości, wieża samotności' (2019) staat op deze Poolse rock-playlist."
+      "fun_fact": "Sztywny Pal Azji is a Polish rock band active since the 1980s, and 'Wieża radości, wieża samotności' (2001) features on this Polish rock playlist.",
+      "fun_fact_de": "Sztywny Pal Azji ist eine polnische Rockband, aktiv seit den 1980er Jahren, und 'Wieża radości, wieża samotności' (2001) ist auf dieser Polish-Rock-Playlist vertreten.",
+      "fun_fact_es": "Sztywny Pal Azji es una banda polaca de rock activa desde los anos 80, y 'Wieża radości, wieża samotności' (2001) aparece en esta lista de rock polaco.",
+      "fun_fact_fr": "Sztywny Pal Azji est un groupe de rock polonais actif depuis les annees 1980, et 'Wieża radości, wieża samotności' (2001) figure sur cette playlist de rock polonais.",
+      "fun_fact_nl": "Sztywny Pal Azji is een Poolse rockband actief sinds de jaren 80, en 'Wieża radości, wieża samotności' (2001) staat op deze Poolse rock-playlist."
     },
     {
       "year": 2014,
@@ -896,7 +896,7 @@
       "fun_fact_nl": "Pidżama Porno is een Poolse punkrockband geleid door Krzysztof Grabowski, en 'Nikt tak pięknie nie mówił, że się boi miłości' (2016) staat op deze Poolse rock-playlist."
     },
     {
-      "year": 2020,
+      "year": 1999,
       "uri": "spotify:track:1bufVeRDY4rwbM0hMIDZNd",
       "artist": "Myslovitz",
       "title": "Chłopcy",
@@ -915,11 +915,11 @@
       "uri_tidal": "tidal://track/140165671",
       "uri_deezer": "deezer://track/950273412",
       "alt_artists": [],
-      "fun_fact": "Myslovitz is a Polish rock band from the town of Myslowice, and 'Chłopcy' (2020) features on this Polish rock playlist.",
-      "fun_fact_de": "Myslovitz ist eine polnische Rockband aus der Stadt Myslowice, und 'Chłopcy' (2020) ist auf dieser Polish-Rock-Playlist vertreten.",
-      "fun_fact_es": "Myslovitz es una banda polaca de rock de la ciudad de Myslowice, y 'Chłopcy' (2020) aparece en esta lista de rock polaco.",
-      "fun_fact_fr": "Myslovitz est un groupe de rock polonais de la ville de Myslowice, et 'Chłopcy' (2020) figure sur cette playlist de rock polonais.",
-      "fun_fact_nl": "Myslovitz is een Poolse rockband uit de stad Myslowice, en 'Chłopcy' (2020) staat op deze Poolse rock-playlist."
+      "fun_fact": "Myslovitz is a Polish rock band from the town of Myslowice, and 'Chłopcy' (1999) features on this Polish rock playlist.",
+      "fun_fact_de": "Myslovitz ist eine polnische Rockband aus der Stadt Myslowice, und 'Chłopcy' (1999) ist auf dieser Polish-Rock-Playlist vertreten.",
+      "fun_fact_es": "Myslovitz es una banda polaca de rock de la ciudad de Myslowice, y 'Chłopcy' (1999) aparece en esta lista de rock polaco.",
+      "fun_fact_fr": "Myslovitz est un groupe de rock polonais de la ville de Myslowice, et 'Chłopcy' (1999) figure sur cette playlist de rock polonais.",
+      "fun_fact_nl": "Myslovitz is een Poolse rockband uit de stad Myslowice, en 'Chłopcy' (1999) staat op deze Poolse rock-playlist."
     },
     {
       "year": 1993,
@@ -1000,7 +1000,7 @@
       "fun_fact_nl": "Obywatel G.C. maakt deel uit van de Poolse rockscene, en 'Tak ... Tak ... To Ja' (2017) staat op deze Poolse rock-playlist."
     },
     {
-      "year": 2018,
+      "year": 2013,
       "uri": "spotify:track:2ltjC6sARA4cHiJxeMnoah",
       "artist": "Human",
       "title": "Polski",
@@ -1019,11 +1019,11 @@
       "uri_tidal": "tidal://track/89968612",
       "uri_deezer": "deezer://track/509116072",
       "alt_artists": [],
-      "fun_fact": "Human is part of Poland's rock scene, and 'Polski' (2018) features on this Polish rock playlist.",
-      "fun_fact_de": "Human gehoert zur polnischen Rockszene, und 'Polski' (2018) ist auf dieser Polish-Rock-Playlist vertreten.",
-      "fun_fact_es": "Human forma parte de la escena del rock polaco, y 'Polski' (2018) aparece en esta lista de rock polaco.",
-      "fun_fact_fr": "Human fait partie de la scene rock polonaise, et 'Polski' (2018) figure sur cette playlist de rock polonais.",
-      "fun_fact_nl": "Human maakt deel uit van de Poolse rockscene, en 'Polski' (2018) staat op deze Poolse rock-playlist."
+      "fun_fact": "Human is part of Poland's rock scene, and 'Polski' (2013) features on this Polish rock playlist.",
+      "fun_fact_de": "Human gehoert zur polnischen Rockszene, und 'Polski' (2013) ist auf dieser Polish-Rock-Playlist vertreten.",
+      "fun_fact_es": "Human forma parte de la escena del rock polaco, y 'Polski' (2013) aparece en esta lista de rock polaco.",
+      "fun_fact_fr": "Human fait partie de la scene rock polonaise, et 'Polski' (2013) figure sur cette playlist de rock polonais.",
+      "fun_fact_nl": "Human maakt deel uit van de Poolse rockscene, en 'Polski' (2013) staat op deze Poolse rock-playlist."
     },
     {
       "year": 2021,
@@ -1130,7 +1130,7 @@
       "fun_fact_nl": "Kasia Lins maakt deel uit van de Poolse rockscene, en 'Śmierć w bikini' (2025) staat op deze Poolse rock-playlist."
     },
     {
-      "year": 2016,
+      "year": 1988,
       "uri": "spotify:track:3mFRiJ6c2XXkd0Hd9qWP46",
       "artist": "Kult",
       "title": "Arahja",
@@ -1149,11 +1149,11 @@
       "uri_tidal": "tidal://track/58810037",
       "uri_deezer": "deezer://track/121737452",
       "alt_artists": [],
-      "fun_fact": "Kult is a Polish rock band led by Kazik Staszewski, and 'Arahja' (2016) features on this Polish rock playlist.",
-      "fun_fact_de": "Kult ist eine polnische Rockband unter der Leitung von Kazik Staszewski, und 'Arahja' (2016) ist auf dieser Polish-Rock-Playlist vertreten.",
-      "fun_fact_es": "Kult es una banda polaca de rock liderada por Kazik Staszewski, y 'Arahja' (2016) aparece en esta lista de rock polaco.",
-      "fun_fact_fr": "Kult est un groupe de rock polonais mene par Kazik Staszewski, et 'Arahja' (2016) figure sur cette playlist de rock polonais.",
-      "fun_fact_nl": "Kult is een Poolse rockband geleid door Kazik Staszewski, en 'Arahja' (2016) staat op deze Poolse rock-playlist."
+      "fun_fact": "Kult is a Polish rock band led by Kazik Staszewski, and 'Arahja' (1988) features on this Polish rock playlist.",
+      "fun_fact_de": "Kult ist eine polnische Rockband unter der Leitung von Kazik Staszewski, und 'Arahja' (1988) ist auf dieser Polish-Rock-Playlist vertreten.",
+      "fun_fact_es": "Kult es una banda polaca de rock liderada por Kazik Staszewski, y 'Arahja' (1988) aparece en esta lista de rock polaco.",
+      "fun_fact_fr": "Kult est un groupe de rock polonais mene par Kazik Staszewski, et 'Arahja' (1988) figure sur cette playlist de rock polonais.",
+      "fun_fact_nl": "Kult is een Poolse rockband geleid door Kazik Staszewski, en 'Arahja' (1988) staat op deze Poolse rock-playlist."
     },
     {
       "year": 1996,
@@ -1182,7 +1182,7 @@
       "fun_fact_nl": "Myslovitz is een Poolse rockband uit de stad Myslowice, en 'Z twarzą Marilyn Monroe' (1996) staat op deze Poolse rock-playlist."
     },
     {
-      "year": 2011,
+      "year": 1997,
       "uri": "spotify:track:405oT48J84IgtbWVDsCODc",
       "artist": "Maanam",
       "title": "Cykady na Cykladach - 2011 Remaster",
@@ -1201,11 +1201,11 @@
       "uri_tidal": "tidal://track/6039139",
       "uri_deezer": "deezer://track/10246097",
       "alt_artists": [],
-      "fun_fact": "Maanam is a Polish rock band fronted by Kora, one of the defining acts of 1980s Polish rock, and 'Cykady na Cykladach' (2011) features on this Polish rock playlist.",
-      "fun_fact_de": "Maanam ist eine polnische Rockband mit Frontfrau Kora, eine der praegenden Bands des polnischen Rock der 1980er, und 'Cykady na Cykladach' (2011) ist auf dieser Polish-Rock-Playlist vertreten.",
-      "fun_fact_es": "Maanam es una banda polaca de rock liderada por Kora, uno de los grupos definitorios del rock polaco de los anos 80, y 'Cykady na Cykladach' (2011) aparece en esta lista de rock polaco.",
-      "fun_fact_fr": "Maanam est un groupe de rock polonais mene par Kora, l'un des groupes emblematiques du rock polonais des annees 1980, et 'Cykady na Cykladach' (2011) figure sur cette playlist de rock polonais.",
-      "fun_fact_nl": "Maanam is een Poolse rockband met zangeres Kora, een van de bepalende groepen van de Poolse rock uit de jaren 80, en 'Cykady na Cykladach' (2011) staat op deze Poolse rock-playlist."
+      "fun_fact": "Maanam is a Polish rock band fronted by Kora, one of the defining acts of 1980s Polish rock, and 'Cykady na Cykladach' (1997) features on this Polish rock playlist.",
+      "fun_fact_de": "Maanam ist eine polnische Rockband mit Frontfrau Kora, eine der praegenden Bands des polnischen Rock der 1980er, und 'Cykady na Cykladach' (1997) ist auf dieser Polish-Rock-Playlist vertreten.",
+      "fun_fact_es": "Maanam es una banda polaca de rock liderada por Kora, uno de los grupos definitorios del rock polaco de los anos 80, y 'Cykady na Cykladach' (1997) aparece en esta lista de rock polaco.",
+      "fun_fact_fr": "Maanam est un groupe de rock polonais mene par Kora, l'un des groupes emblematiques du rock polonais des annees 1980, et 'Cykady na Cykladach' (1997) figure sur cette playlist de rock polonais.",
+      "fun_fact_nl": "Maanam is een Poolse rockband met zangeres Kora, een van de bepalende groepen van de Poolse rock uit de jaren 80, en 'Cykady na Cykladach' (1997) staat op deze Poolse rock-playlist."
     },
     {
       "year": 2015,
@@ -1234,7 +1234,7 @@
       "fun_fact_nl": "Voo Voo is een Poolse rockband geleid door Wojciech Waglewski, en 'Jak Gdyby Nigdy Nic' (2015) staat op deze Poolse rock-playlist."
     },
     {
-      "year": 2002,
+      "year": 2016,
       "uri": "spotify:track:4FLlgvEWdbAasguGfMKu49",
       "artist": "Lombard",
       "title": "Szklana Pogoda",
@@ -1253,14 +1253,14 @@
       "uri_tidal": null,
       "uri_deezer": "deezer://track/84656155",
       "alt_artists": [],
-      "fun_fact": "Lombard is a Polish rock band formed in Poznan in the early 1980s, and 'Szklana Pogoda' (2002) features on this Polish rock playlist.",
-      "fun_fact_de": "Lombard ist eine polnische Rockband, Anfang der 1980er in Posen gegruendet, und 'Szklana Pogoda' (2002) ist auf dieser Polish-Rock-Playlist vertreten.",
-      "fun_fact_es": "Lombard es una banda polaca de rock formada en Poznan a principios de los anos 80, y 'Szklana Pogoda' (2002) aparece en esta lista de rock polaco.",
-      "fun_fact_fr": "Lombard est un groupe de rock polonais forme a Poznan au debut des annees 1980, et 'Szklana Pogoda' (2002) figure sur cette playlist de rock polonais.",
-      "fun_fact_nl": "Lombard is een Poolse rockband opgericht in Poznan begin jaren 80, en 'Szklana Pogoda' (2002) staat op deze Poolse rock-playlist."
+      "fun_fact": "Lombard is a Polish rock band formed in Poznan in the early 1980s, and 'Szklana Pogoda' (2016) features on this Polish rock playlist.",
+      "fun_fact_de": "Lombard ist eine polnische Rockband, Anfang der 1980er in Posen gegruendet, und 'Szklana Pogoda' (2016) ist auf dieser Polish-Rock-Playlist vertreten.",
+      "fun_fact_es": "Lombard es una banda polaca de rock formada en Poznan a principios de los anos 80, y 'Szklana Pogoda' (2016) aparece en esta lista de rock polaco.",
+      "fun_fact_fr": "Lombard est un groupe de rock polonais forme a Poznan au debut des annees 1980, et 'Szklana Pogoda' (2016) figure sur cette playlist de rock polonais.",
+      "fun_fact_nl": "Lombard is een Poolse rockband opgericht in Poznan begin jaren 80, en 'Szklana Pogoda' (2016) staat op deze Poolse rock-playlist."
     },
     {
-      "year": 2016,
+      "year": 2004,
       "uri": "spotify:track:6LuOCaMHFBfaR1MLKNHhMA",
       "artist": "Happysad",
       "title": "Zanim pójdę",
@@ -1279,11 +1279,11 @@
       "uri_tidal": null,
       "uri_deezer": "deezer://track/121736688",
       "alt_artists": [],
-      "fun_fact": "Happysad is a Polish rock band formed in Skarzysko-Kamienna, and 'Zanim pójdę' (2016) features on this Polish rock playlist.",
-      "fun_fact_de": "Happysad ist eine polnische Rockband, gegruendet in Skarzysko-Kamienna, und 'Zanim pójdę' (2016) ist auf dieser Polish-Rock-Playlist vertreten.",
-      "fun_fact_es": "Happysad es una banda polaca de rock formada en Skarzysko-Kamienna, y 'Zanim pójdę' (2016) aparece en esta lista de rock polaco.",
-      "fun_fact_fr": "Happysad est un groupe de rock polonais forme a Skarzysko-Kamienna, et 'Zanim pójdę' (2016) figure sur cette playlist de rock polonais.",
-      "fun_fact_nl": "Happysad is een Poolse rockband opgericht in Skarzysko-Kamienna, en 'Zanim pójdę' (2016) staat op deze Poolse rock-playlist."
+      "fun_fact": "Happysad is a Polish rock band formed in Skarzysko-Kamienna, and 'Zanim pójdę' (2004) features on this Polish rock playlist.",
+      "fun_fact_de": "Happysad ist eine polnische Rockband, gegruendet in Skarzysko-Kamienna, und 'Zanim pójdę' (2004) ist auf dieser Polish-Rock-Playlist vertreten.",
+      "fun_fact_es": "Happysad es una banda polaca de rock formada en Skarzysko-Kamienna, y 'Zanim pójdę' (2004) aparece en esta lista de rock polaco.",
+      "fun_fact_fr": "Happysad est un groupe de rock polonais forme a Skarzysko-Kamienna, et 'Zanim pójdę' (2004) figure sur cette playlist de rock polonais.",
+      "fun_fact_nl": "Happysad is een Poolse rockband opgericht in Skarzysko-Kamienna, en 'Zanim pójdę' (2004) staat op deze Poolse rock-playlist."
     },
     {
       "year": 2024,
@@ -1416,7 +1416,7 @@
       "fun_fact_nl": "Hey is een Poolse rockband met zangeres Katarzyna Nosowska, en 'Bezruch' (2025) staat op deze Poolse rock-playlist."
     },
     {
-      "year": 2012,
+      "year": 1990,
       "uri": "spotify:track:3QdHnADl1gJHrbGlpWdMax",
       "artist": "Bajm",
       "title": "Biała armia",
@@ -1435,11 +1435,11 @@
       "uri_tidal": null,
       "uri_deezer": "deezer://track/17384386",
       "alt_artists": [],
-      "fun_fact": "Bajm is a Polish pop-rock band fronted by Beata Kozidrak, and 'Biała armia' (2012) features on this Polish rock playlist.",
-      "fun_fact_de": "Bajm ist eine polnische Pop-Rock-Band mit Frontfrau Beata Kozidrak, und 'Biała armia' (2012) ist auf dieser Polish-Rock-Playlist vertreten.",
-      "fun_fact_es": "Bajm es una banda polaca de pop-rock liderada por Beata Kozidrak, y 'Biała armia' (2012) aparece en esta lista de rock polaco.",
-      "fun_fact_fr": "Bajm est un groupe de pop-rock polonais mene par Beata Kozidrak, et 'Biała armia' (2012) figure sur cette playlist de rock polonais.",
-      "fun_fact_nl": "Bajm is een Poolse poprockband met zangeres Beata Kozidrak, en 'Biała armia' (2012) staat op deze Poolse rock-playlist."
+      "fun_fact": "Bajm is a Polish pop-rock band fronted by Beata Kozidrak, and 'Biała armia' (1990) features on this Polish rock playlist.",
+      "fun_fact_de": "Bajm ist eine polnische Pop-Rock-Band mit Frontfrau Beata Kozidrak, und 'Biała armia' (1990) ist auf dieser Polish-Rock-Playlist vertreten.",
+      "fun_fact_es": "Bajm es una banda polaca de pop-rock liderada por Beata Kozidrak, y 'Biała armia' (1990) aparece en esta lista de rock polaco.",
+      "fun_fact_fr": "Bajm est un groupe de pop-rock polonais mene par Beata Kozidrak, et 'Biała armia' (1990) figure sur cette playlist de rock polonais.",
+      "fun_fact_nl": "Bajm is een Poolse poprockband met zangeres Beata Kozidrak, en 'Biała armia' (1990) staat op deze Poolse rock-playlist."
     },
     {
       "year": 2024,
@@ -1468,7 +1468,7 @@
       "fun_fact_nl": "Nosowska maakt deel uit van de Poolse rockscene, en 'Błyszcz' (2024) staat op deze Poolse rock-playlist."
     },
     {
-      "year": 2010,
+      "year": 1997,
       "uri": "spotify:track:23S5Wwh3PudQpnmncsiIBV",
       "artist": "Robert Gawlinski",
       "title": "Nie stało się nic",
@@ -1487,14 +1487,14 @@
       "uri_tidal": null,
       "uri_deezer": "deezer://track/62213305",
       "alt_artists": [],
-      "fun_fact": "Robert Gawlinski is part of Poland's rock scene, and 'Nie stało się nic' (2010) features on this Polish rock playlist.",
-      "fun_fact_de": "Robert Gawlinski gehoert zur polnischen Rockszene, und 'Nie stało się nic' (2010) ist auf dieser Polish-Rock-Playlist vertreten.",
-      "fun_fact_es": "Robert Gawlinski forma parte de la escena del rock polaco, y 'Nie stało się nic' (2010) aparece en esta lista de rock polaco.",
-      "fun_fact_fr": "Robert Gawlinski fait partie de la scene rock polonaise, et 'Nie stało się nic' (2010) figure sur cette playlist de rock polonais.",
-      "fun_fact_nl": "Robert Gawlinski maakt deel uit van de Poolse rockscene, en 'Nie stało się nic' (2010) staat op deze Poolse rock-playlist."
+      "fun_fact": "Robert Gawlinski is part of Poland's rock scene, and 'Nie stało się nic' (1997) features on this Polish rock playlist.",
+      "fun_fact_de": "Robert Gawlinski gehoert zur polnischen Rockszene, und 'Nie stało się nic' (1997) ist auf dieser Polish-Rock-Playlist vertreten.",
+      "fun_fact_es": "Robert Gawlinski forma parte de la escena del rock polaco, y 'Nie stało się nic' (1997) aparece en esta lista de rock polaco.",
+      "fun_fact_fr": "Robert Gawlinski fait partie de la scene rock polonaise, et 'Nie stało się nic' (1997) figure sur cette playlist de rock polonais.",
+      "fun_fact_nl": "Robert Gawlinski maakt deel uit van de Poolse rockscene, en 'Nie stało się nic' (1997) staat op deze Poolse rock-playlist."
     },
     {
-      "year": 2015,
+      "year": 1981,
       "uri": "spotify:track:0yON0VUvFRCULd0BWJlNf4",
       "artist": "Perfect",
       "title": "Chcemy Być Sobą",
@@ -1513,14 +1513,14 @@
       "uri_tidal": null,
       "uri_deezer": "deezer://track/99220048",
       "alt_artists": [],
-      "fun_fact": "Perfect is a Polish rock band that rose to fame in the early 1980s, and 'Chcemy Być Sobą' (2015) features on this Polish rock playlist.",
-      "fun_fact_de": "Perfect ist eine polnische Rockband, die Anfang der 1980er Jahre bekannt wurde, und 'Chcemy Być Sobą' (2015) ist auf dieser Polish-Rock-Playlist vertreten.",
-      "fun_fact_es": "Perfect es una banda polaca de rock que alcanzo la fama a principios de los anos 80, y 'Chcemy Być Sobą' (2015) aparece en esta lista de rock polaco.",
-      "fun_fact_fr": "Perfect est un groupe de rock polonais devenu celebre au debut des annees 1980, et 'Chcemy Być Sobą' (2015) figure sur cette playlist de rock polonais.",
-      "fun_fact_nl": "Perfect is een Poolse rockband die begin jaren 80 bekend werd, en 'Chcemy Być Sobą' (2015) staat op deze Poolse rock-playlist."
+      "fun_fact": "Perfect is a Polish rock band that rose to fame in the early 1980s, and 'Chcemy Być Sobą' (1981) features on this Polish rock playlist.",
+      "fun_fact_de": "Perfect ist eine polnische Rockband, die Anfang der 1980er Jahre bekannt wurde, und 'Chcemy Być Sobą' (1981) ist auf dieser Polish-Rock-Playlist vertreten.",
+      "fun_fact_es": "Perfect es una banda polaca de rock que alcanzo la fama a principios de los anos 80, y 'Chcemy Być Sobą' (1981) aparece en esta lista de rock polaco.",
+      "fun_fact_fr": "Perfect est un groupe de rock polonais devenu celebre au debut des annees 1980, et 'Chcemy Być Sobą' (1981) figure sur cette playlist de rock polonais.",
+      "fun_fact_nl": "Perfect is een Poolse rockband die begin jaren 80 bekend werd, en 'Chcemy Być Sobą' (1981) staat op deze Poolse rock-playlist."
     },
     {
-      "year": 2014,
+      "year": 1992,
       "uri": "spotify:track:1wqbsBYM3yGsIB429f7bsc",
       "artist": "T.Love",
       "title": "King",
@@ -1539,11 +1539,11 @@
       "uri_tidal": null,
       "uri_deezer": "deezer://track/81811430",
       "alt_artists": [],
-      "fun_fact": "T.Love is a Polish rock band led by Muniek Staszczyk, and 'King' (2014) features on this Polish rock playlist.",
-      "fun_fact_de": "T.Love ist eine polnische Rockband unter der Leitung von Muniek Staszczyk, und 'King' (2014) ist auf dieser Polish-Rock-Playlist vertreten.",
-      "fun_fact_es": "T.Love es una banda polaca de rock liderada por Muniek Staszczyk, y 'King' (2014) aparece en esta lista de rock polaco.",
-      "fun_fact_fr": "T.Love est un groupe de rock polonais mene par Muniek Staszczyk, et 'King' (2014) figure sur cette playlist de rock polonais.",
-      "fun_fact_nl": "T.Love is een Poolse rockband geleid door Muniek Staszczyk, en 'King' (2014) staat op deze Poolse rock-playlist."
+      "fun_fact": "T.Love is a Polish rock band led by Muniek Staszczyk, and 'King' (1992) features on this Polish rock playlist.",
+      "fun_fact_de": "T.Love ist eine polnische Rockband unter der Leitung von Muniek Staszczyk, und 'King' (1992) ist auf dieser Polish-Rock-Playlist vertreten.",
+      "fun_fact_es": "T.Love es una banda polaca de rock liderada por Muniek Staszczyk, y 'King' (1992) aparece en esta lista de rock polaco.",
+      "fun_fact_fr": "T.Love est un groupe de rock polonais mene par Muniek Staszczyk, et 'King' (1992) figure sur cette playlist de rock polonais.",
+      "fun_fact_nl": "T.Love is een Poolse rockband geleid door Muniek Staszczyk, en 'King' (1992) staat op deze Poolse rock-playlist."
     },
     {
       "year": 2011,
@@ -1572,7 +1572,7 @@
       "fun_fact_nl": "Luxtorpeda is een Poolse rockband opgericht door Robert Friedrich, en 'AUTYSTYCZNY' (2011) staat op deze Poolse rock-playlist."
     },
     {
-      "year": 2006,
+      "year": 1998,
       "uri": "spotify:track:6oBFFbE8aU6erQXsKJAUyd",
       "artist": "Dżem",
       "title": "Wehikuł Czasu - To Byłby Cud - 2003 Remaster",
@@ -1591,14 +1591,14 @@
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3090202",
       "alt_artists": [],
-      "fun_fact": "Dżem is a Polish blues-rock band from Silesia, and 'Wehikuł Czasu' (2006) features on this Polish rock playlist.",
-      "fun_fact_de": "Dżem ist eine polnische Blues-Rock-Band aus Schlesien, und 'Wehikuł Czasu' (2006) ist auf dieser Polish-Rock-Playlist vertreten.",
-      "fun_fact_es": "Dżem es una banda polaca de blues-rock de Silesia, y 'Wehikuł Czasu' (2006) aparece en esta lista de rock polaco.",
-      "fun_fact_fr": "Dżem est un groupe de blues-rock polonais de Silesie, et 'Wehikuł Czasu' (2006) figure sur cette playlist de rock polonais.",
-      "fun_fact_nl": "Dżem is een Poolse blues-rockband uit Silezie, en 'Wehikuł Czasu' (2006) staat op deze Poolse rock-playlist."
+      "fun_fact": "Dżem is a Polish blues-rock band from Silesia, and 'Wehikuł Czasu' (1998) features on this Polish rock playlist.",
+      "fun_fact_de": "Dżem ist eine polnische Blues-Rock-Band aus Schlesien, und 'Wehikuł Czasu' (1998) ist auf dieser Polish-Rock-Playlist vertreten.",
+      "fun_fact_es": "Dżem es una banda polaca de blues-rock de Silesia, y 'Wehikuł Czasu' (1998) aparece en esta lista de rock polaco.",
+      "fun_fact_fr": "Dżem est un groupe de blues-rock polonais de Silesie, et 'Wehikuł Czasu' (1998) figure sur cette playlist de rock polonais.",
+      "fun_fact_nl": "Dżem is een Poolse blues-rockband uit Silezie, en 'Wehikuł Czasu' (1998) staat op deze Poolse rock-playlist."
     },
     {
-      "year": 2019,
+      "year": 2003,
       "uri": "spotify:track:55dWbx9siuMTNMsIgCtBjl",
       "artist": "Budka Suflera",
       "title": "Za ostatni grosz",
@@ -1617,14 +1617,14 @@
       "uri_tidal": null,
       "uri_deezer": "deezer://track/779754482",
       "alt_artists": [],
-      "fun_fact": "Budka Suflera is a long-running Polish rock band founded in Lublin in 1974, and 'Za ostatni grosz' (2019) features on this Polish rock playlist.",
-      "fun_fact_de": "Budka Suflera ist eine langjaehrige polnische Rockband, 1974 in Lublin gegruendet, und 'Za ostatni grosz' (2019) ist auf dieser Polish-Rock-Playlist vertreten.",
-      "fun_fact_es": "Budka Suflera es una veterana banda polaca de rock fundada en Lublin en 1974, y 'Za ostatni grosz' (2019) aparece en esta lista de rock polaco.",
-      "fun_fact_fr": "Budka Suflera est un groupe de rock polonais de longue date fonde a Lublin en 1974, et 'Za ostatni grosz' (2019) figure sur cette playlist de rock polonais.",
-      "fun_fact_nl": "Budka Suflera is een langlopende Poolse rockband opgericht in Lublin in 1974, en 'Za ostatni grosz' (2019) staat op deze Poolse rock-playlist."
+      "fun_fact": "Budka Suflera is a long-running Polish rock band founded in Lublin in 1974, and 'Za ostatni grosz' (2003) features on this Polish rock playlist.",
+      "fun_fact_de": "Budka Suflera ist eine langjaehrige polnische Rockband, 1974 in Lublin gegruendet, und 'Za ostatni grosz' (2003) ist auf dieser Polish-Rock-Playlist vertreten.",
+      "fun_fact_es": "Budka Suflera es una veterana banda polaca de rock fundada en Lublin en 1974, y 'Za ostatni grosz' (2003) aparece en esta lista de rock polaco.",
+      "fun_fact_fr": "Budka Suflera est un groupe de rock polonais de longue date fonde a Lublin en 1974, et 'Za ostatni grosz' (2003) figure sur cette playlist de rock polonais.",
+      "fun_fact_nl": "Budka Suflera is een langlopende Poolse rockband opgericht in Lublin in 1974, en 'Za ostatni grosz' (2003) staat op deze Poolse rock-playlist."
     },
     {
-      "year": 2013,
+      "year": 1993,
       "uri": "spotify:track:0WhPYKWZD20gRI9EDnVBHY",
       "artist": "Hey",
       "title": "Zazdrosc",
@@ -1643,11 +1643,11 @@
       "uri_tidal": null,
       "uri_deezer": "deezer://track/65120943",
       "alt_artists": [],
-      "fun_fact": "Hey is a Polish rock band fronted by Katarzyna Nosowska, and 'Zazdrosc' (2013) features on this Polish rock playlist.",
-      "fun_fact_de": "Hey ist eine polnische Rockband mit Frontfrau Katarzyna Nosowska, und 'Zazdrosc' (2013) ist auf dieser Polish-Rock-Playlist vertreten.",
-      "fun_fact_es": "Hey es una banda polaca de rock liderada por Katarzyna Nosowska, y 'Zazdrosc' (2013) aparece en esta lista de rock polaco.",
-      "fun_fact_fr": "Hey est un groupe de rock polonais mene par Katarzyna Nosowska, et 'Zazdrosc' (2013) figure sur cette playlist de rock polonais.",
-      "fun_fact_nl": "Hey is een Poolse rockband met zangeres Katarzyna Nosowska, en 'Zazdrosc' (2013) staat op deze Poolse rock-playlist."
+      "fun_fact": "Hey is a Polish rock band fronted by Katarzyna Nosowska, and 'Zazdrosc' (1993) features on this Polish rock playlist.",
+      "fun_fact_de": "Hey ist eine polnische Rockband mit Frontfrau Katarzyna Nosowska, und 'Zazdrosc' (1993) ist auf dieser Polish-Rock-Playlist vertreten.",
+      "fun_fact_es": "Hey es una banda polaca de rock liderada por Katarzyna Nosowska, y 'Zazdrosc' (1993) aparece en esta lista de rock polaco.",
+      "fun_fact_fr": "Hey est un groupe de rock polonais mene par Katarzyna Nosowska, et 'Zazdrosc' (1993) figure sur cette playlist de rock polonais.",
+      "fun_fact_nl": "Hey is een Poolse rockband met zangeres Katarzyna Nosowska, en 'Zazdrosc' (1993) staat op deze Poolse rock-playlist."
     },
     {
       "year": 2009,
@@ -1754,7 +1754,7 @@
       "fun_fact_nl": "Jakub Skorupa maakt deel uit van de Poolse rockscene, en 'Pociągi towarowe' (2022) staat op deze Poolse rock-playlist."
     },
     {
-      "year": 2019,
+      "year": 2005,
       "uri": "spotify:track:1rD0BmlixRov9u1zPGFpZu",
       "artist": "Klaus Mitffoch",
       "title": "Jezu jak się cieszę",
@@ -1773,14 +1773,14 @@
       "uri_tidal": null,
       "uri_deezer": "deezer://track/782776642",
       "alt_artists": [],
-      "fun_fact": "Klaus Mitffoch is part of Poland's rock scene, and 'Jezu jak się cieszę' (2019) features on this Polish rock playlist.",
-      "fun_fact_de": "Klaus Mitffoch gehoert zur polnischen Rockszene, und 'Jezu jak się cieszę' (2019) ist auf dieser Polish-Rock-Playlist vertreten.",
-      "fun_fact_es": "Klaus Mitffoch forma parte de la escena del rock polaco, y 'Jezu jak się cieszę' (2019) aparece en esta lista de rock polaco.",
-      "fun_fact_fr": "Klaus Mitffoch fait partie de la scene rock polonaise, et 'Jezu jak się cieszę' (2019) figure sur cette playlist de rock polonais.",
-      "fun_fact_nl": "Klaus Mitffoch maakt deel uit van de Poolse rockscene, en 'Jezu jak się cieszę' (2019) staat op deze Poolse rock-playlist."
+      "fun_fact": "Klaus Mitffoch is part of Poland's rock scene, and 'Jezu jak się cieszę' (2005) features on this Polish rock playlist.",
+      "fun_fact_de": "Klaus Mitffoch gehoert zur polnischen Rockszene, und 'Jezu jak się cieszę' (2005) ist auf dieser Polish-Rock-Playlist vertreten.",
+      "fun_fact_es": "Klaus Mitffoch forma parte de la escena del rock polaco, y 'Jezu jak się cieszę' (2005) aparece en esta lista de rock polaco.",
+      "fun_fact_fr": "Klaus Mitffoch fait partie de la scene rock polonaise, et 'Jezu jak się cieszę' (2005) figure sur cette playlist de rock polonais.",
+      "fun_fact_nl": "Klaus Mitffoch maakt deel uit van de Poolse rockscene, en 'Jezu jak się cieszę' (2005) staat op deze Poolse rock-playlist."
     },
     {
-      "year": 2016,
+      "year": 2005,
       "uri": "spotify:track:49lCLRbUyr1OBnSx6PDiX2",
       "artist": "Happysad",
       "title": "Łydka",
@@ -1799,11 +1799,11 @@
       "uri_tidal": null,
       "uri_deezer": "deezer://track/125193088",
       "alt_artists": [],
-      "fun_fact": "Happysad is a Polish rock band formed in Skarzysko-Kamienna, and 'Łydka' (2016) features on this Polish rock playlist.",
-      "fun_fact_de": "Happysad ist eine polnische Rockband, gegruendet in Skarzysko-Kamienna, und 'Łydka' (2016) ist auf dieser Polish-Rock-Playlist vertreten.",
-      "fun_fact_es": "Happysad es una banda polaca de rock formada en Skarzysko-Kamienna, y 'Łydka' (2016) aparece en esta lista de rock polaco.",
-      "fun_fact_fr": "Happysad est un groupe de rock polonais forme a Skarzysko-Kamienna, et 'Łydka' (2016) figure sur cette playlist de rock polonais.",
-      "fun_fact_nl": "Happysad is een Poolse rockband opgericht in Skarzysko-Kamienna, en 'Łydka' (2016) staat op deze Poolse rock-playlist."
+      "fun_fact": "Happysad is a Polish rock band formed in Skarzysko-Kamienna, and 'Łydka' (2005) features on this Polish rock playlist.",
+      "fun_fact_de": "Happysad ist eine polnische Rockband, gegruendet in Skarzysko-Kamienna, und 'Łydka' (2005) ist auf dieser Polish-Rock-Playlist vertreten.",
+      "fun_fact_es": "Happysad es una banda polaca de rock formada en Skarzysko-Kamienna, y 'Łydka' (2005) aparece en esta lista de rock polaco.",
+      "fun_fact_fr": "Happysad est un groupe de rock polonais forme a Skarzysko-Kamienna, et 'Łydka' (2005) figure sur cette playlist de rock polonais.",
+      "fun_fact_nl": "Happysad is een Poolse rockband opgericht in Skarzysko-Kamienna, en 'Łydka' (2005) staat op deze Poolse rock-playlist."
     },
     {
       "year": 2023,
@@ -1858,7 +1858,7 @@
       "fun_fact_nl": "Jacko Brango maakt deel uit van de Poolse rockscene, en 'Pod powierzchnią' (2025) staat op deze Poolse rock-playlist."
     },
     {
-      "year": 2005,
+      "year": 1998,
       "uri": "spotify:track:7qboThq6AiQBDDq2wCj578",
       "artist": "Republika",
       "title": "Mamona",
@@ -1877,11 +1877,11 @@
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3295158",
       "alt_artists": [],
-      "fun_fact": "Republika is a Polish new wave and rock band formed in Torun in 1981 and led by Grzegorz Ciechowski, and 'Mamona' (2005) features on this Polish rock playlist.",
-      "fun_fact_de": "Republika ist eine polnische New-Wave- und Rockband, 1981 in Torun gegruendet und von Grzegorz Ciechowski angefuehrt, und 'Mamona' (2005) ist auf dieser Polish-Rock-Playlist vertreten.",
-      "fun_fact_es": "Republika es una banda polaca de new wave y rock formada en Torun en 1981 y liderada por Grzegorz Ciechowski, y 'Mamona' (2005) aparece en esta lista de rock polaco.",
-      "fun_fact_fr": "Republika est un groupe polonais de new wave et de rock forme a Torun en 1981 et mene par Grzegorz Ciechowski, et 'Mamona' (2005) figure sur cette playlist de rock polonais.",
-      "fun_fact_nl": "Republika is een Poolse new wave- en rockband opgericht in Torun in 1981 en geleid door Grzegorz Ciechowski, en 'Mamona' (2005) staat op deze Poolse rock-playlist."
+      "fun_fact": "Republika is a Polish new wave and rock band formed in Torun in 1981 and led by Grzegorz Ciechowski, and 'Mamona' (1998) features on this Polish rock playlist.",
+      "fun_fact_de": "Republika ist eine polnische New-Wave- und Rockband, 1981 in Torun gegruendet und von Grzegorz Ciechowski angefuehrt, und 'Mamona' (1998) ist auf dieser Polish-Rock-Playlist vertreten.",
+      "fun_fact_es": "Republika es una banda polaca de new wave y rock formada en Torun en 1981 y liderada por Grzegorz Ciechowski, y 'Mamona' (1998) aparece en esta lista de rock polaco.",
+      "fun_fact_fr": "Republika est un groupe polonais de new wave et de rock forme a Torun en 1981 et mene par Grzegorz Ciechowski, et 'Mamona' (1998) figure sur cette playlist de rock polonais.",
+      "fun_fact_nl": "Republika is een Poolse new wave- en rockband opgericht in Torun in 1981 en geleid door Grzegorz Ciechowski, en 'Mamona' (1998) staat op deze Poolse rock-playlist."
     },
     {
       "year": 1995,
@@ -1910,7 +1910,7 @@
       "fun_fact_nl": "Maanam is een Poolse rockband met zangeres Kora, een van de bepalende groepen van de Poolse rock uit de jaren 80, en 'Szare miraże' (1995) staat op deze Poolse rock-playlist."
     },
     {
-      "year": 2015,
+      "year": 1981,
       "uri": "spotify:track:5mt0TgOSfDbuUqCTRbEHRI",
       "artist": "Perfect",
       "title": "Ale Wkoło Jest Wesoło",
@@ -1929,14 +1929,14 @@
       "uri_tidal": null,
       "uri_deezer": "deezer://track/99220058",
       "alt_artists": [],
-      "fun_fact": "Perfect is a Polish rock band that rose to fame in the early 1980s, and 'Ale Wkoło Jest Wesoło' (2015) features on this Polish rock playlist.",
-      "fun_fact_de": "Perfect ist eine polnische Rockband, die Anfang der 1980er Jahre bekannt wurde, und 'Ale Wkoło Jest Wesoło' (2015) ist auf dieser Polish-Rock-Playlist vertreten.",
-      "fun_fact_es": "Perfect es una banda polaca de rock que alcanzo la fama a principios de los anos 80, y 'Ale Wkoło Jest Wesoło' (2015) aparece en esta lista de rock polaco.",
-      "fun_fact_fr": "Perfect est un groupe de rock polonais devenu celebre au debut des annees 1980, et 'Ale Wkoło Jest Wesoło' (2015) figure sur cette playlist de rock polonais.",
-      "fun_fact_nl": "Perfect is een Poolse rockband die begin jaren 80 bekend werd, en 'Ale Wkoło Jest Wesoło' (2015) staat op deze Poolse rock-playlist."
+      "fun_fact": "Perfect is a Polish rock band that rose to fame in the early 1980s, and 'Ale Wkoło Jest Wesoło' (1981) features on this Polish rock playlist.",
+      "fun_fact_de": "Perfect ist eine polnische Rockband, die Anfang der 1980er Jahre bekannt wurde, und 'Ale Wkoło Jest Wesoło' (1981) ist auf dieser Polish-Rock-Playlist vertreten.",
+      "fun_fact_es": "Perfect es una banda polaca de rock que alcanzo la fama a principios de los anos 80, y 'Ale Wkoło Jest Wesoło' (1981) aparece en esta lista de rock polaco.",
+      "fun_fact_fr": "Perfect est un groupe de rock polonais devenu celebre au debut des annees 1980, et 'Ale Wkoło Jest Wesoło' (1981) figure sur cette playlist de rock polonais.",
+      "fun_fact_nl": "Perfect is een Poolse rockband die begin jaren 80 bekend werd, en 'Ale Wkoło Jest Wesoło' (1981) staat op deze Poolse rock-playlist."
     },
     {
-      "year": 2019,
+      "year": 2001,
       "uri": "spotify:track:1kAb8sDgCY43mRRw8lskmp",
       "artist": "Sztywny Pal Azji",
       "title": "Spotkanie z...",
@@ -1955,14 +1955,14 @@
       "uri_tidal": null,
       "uri_deezer": "deezer://track/782048332",
       "alt_artists": [],
-      "fun_fact": "Sztywny Pal Azji is a Polish rock band active since the 1980s, and 'Spotkanie z...' (2019) features on this Polish rock playlist.",
-      "fun_fact_de": "Sztywny Pal Azji ist eine polnische Rockband, aktiv seit den 1980er Jahren, und 'Spotkanie z...' (2019) ist auf dieser Polish-Rock-Playlist vertreten.",
-      "fun_fact_es": "Sztywny Pal Azji es una banda polaca de rock activa desde los anos 80, y 'Spotkanie z...' (2019) aparece en esta lista de rock polaco.",
-      "fun_fact_fr": "Sztywny Pal Azji est un groupe de rock polonais actif depuis les annees 1980, et 'Spotkanie z...' (2019) figure sur cette playlist de rock polonais.",
-      "fun_fact_nl": "Sztywny Pal Azji is een Poolse rockband actief sinds de jaren 80, en 'Spotkanie z...' (2019) staat op deze Poolse rock-playlist."
+      "fun_fact": "Sztywny Pal Azji is a Polish rock band active since the 1980s, and 'Spotkanie z...' (2001) features on this Polish rock playlist.",
+      "fun_fact_de": "Sztywny Pal Azji ist eine polnische Rockband, aktiv seit den 1980er Jahren, und 'Spotkanie z...' (2001) ist auf dieser Polish-Rock-Playlist vertreten.",
+      "fun_fact_es": "Sztywny Pal Azji es una banda polaca de rock activa desde los anos 80, y 'Spotkanie z...' (2001) aparece en esta lista de rock polaco.",
+      "fun_fact_fr": "Sztywny Pal Azji est un groupe de rock polonais actif depuis les annees 1980, et 'Spotkanie z...' (2001) figure sur cette playlist de rock polonais.",
+      "fun_fact_nl": "Sztywny Pal Azji is een Poolse rockband actief sinds de jaren 80, en 'Spotkanie z...' (2001) staat op deze Poolse rock-playlist."
     },
     {
-      "year": 2012,
+      "year": 1993,
       "uri": "spotify:track:1yuX7XjM3l9Gz0grQwxDIl",
       "artist": "Hey",
       "title": "Teksanski",
@@ -1981,11 +1981,11 @@
       "uri_tidal": null,
       "uri_deezer": "deezer://track/17466931",
       "alt_artists": [],
-      "fun_fact": "Hey is a Polish rock band fronted by Katarzyna Nosowska, and 'Teksanski' (2012) features on this Polish rock playlist.",
-      "fun_fact_de": "Hey ist eine polnische Rockband mit Frontfrau Katarzyna Nosowska, und 'Teksanski' (2012) ist auf dieser Polish-Rock-Playlist vertreten.",
-      "fun_fact_es": "Hey es una banda polaca de rock liderada por Katarzyna Nosowska, y 'Teksanski' (2012) aparece en esta lista de rock polaco.",
-      "fun_fact_fr": "Hey est un groupe de rock polonais mene par Katarzyna Nosowska, et 'Teksanski' (2012) figure sur cette playlist de rock polonais.",
-      "fun_fact_nl": "Hey is een Poolse rockband met zangeres Katarzyna Nosowska, en 'Teksanski' (2012) staat op deze Poolse rock-playlist."
+      "fun_fact": "Hey is a Polish rock band fronted by Katarzyna Nosowska, and 'Teksanski' (1993) features on this Polish rock playlist.",
+      "fun_fact_de": "Hey ist eine polnische Rockband mit Frontfrau Katarzyna Nosowska, und 'Teksanski' (1993) ist auf dieser Polish-Rock-Playlist vertreten.",
+      "fun_fact_es": "Hey es una banda polaca de rock liderada por Katarzyna Nosowska, y 'Teksanski' (1993) aparece en esta lista de rock polaco.",
+      "fun_fact_fr": "Hey est un groupe de rock polonais mene par Katarzyna Nosowska, et 'Teksanski' (1993) figure sur cette playlist de rock polonais.",
+      "fun_fact_nl": "Hey is een Poolse rockband met zangeres Katarzyna Nosowska, en 'Teksanski' (1993) staat op deze Poolse rock-playlist."
     },
     {
       "year": 2024,
@@ -2040,7 +2040,7 @@
       "fun_fact_nl": "Voo Voo is een Poolse rockband geleid door Wojciech Waglewski, en 'Beztrosko' (2022) staat op deze Poolse rock-playlist."
     },
     {
-      "year": 2019,
+      "year": 2011,
       "uri": "spotify:track:142yjgxYc26ON55Zx2M339",
       "artist": "Mr. Zoob",
       "title": "Mój jest ten kawałek podłogi",
@@ -2059,11 +2059,11 @@
       "uri_tidal": null,
       "uri_deezer": "deezer://track/792031932",
       "alt_artists": [],
-      "fun_fact": "Mr. Zoob is part of Poland's rock scene, and 'Mój jest ten kawałek podłogi' (2019) features on this Polish rock playlist.",
-      "fun_fact_de": "Mr. Zoob gehoert zur polnischen Rockszene, und 'Mój jest ten kawałek podłogi' (2019) ist auf dieser Polish-Rock-Playlist vertreten.",
-      "fun_fact_es": "Mr. Zoob forma parte de la escena del rock polaco, y 'Mój jest ten kawałek podłogi' (2019) aparece en esta lista de rock polaco.",
-      "fun_fact_fr": "Mr. Zoob fait partie de la scene rock polonaise, et 'Mój jest ten kawałek podłogi' (2019) figure sur cette playlist de rock polonais.",
-      "fun_fact_nl": "Mr. Zoob maakt deel uit van de Poolse rockscene, en 'Mój jest ten kawałek podłogi' (2019) staat op deze Poolse rock-playlist."
+      "fun_fact": "Mr. Zoob is part of Poland's rock scene, and 'Mój jest ten kawałek podłogi' (2011) features on this Polish rock playlist.",
+      "fun_fact_de": "Mr. Zoob gehoert zur polnischen Rockszene, und 'Mój jest ten kawałek podłogi' (2011) ist auf dieser Polish-Rock-Playlist vertreten.",
+      "fun_fact_es": "Mr. Zoob forma parte de la escena del rock polaco, y 'Mój jest ten kawałek podłogi' (2011) aparece en esta lista de rock polaco.",
+      "fun_fact_fr": "Mr. Zoob fait partie de la scene rock polonaise, et 'Mój jest ten kawałek podłogi' (2011) figure sur cette playlist de rock polonais.",
+      "fun_fact_nl": "Mr. Zoob maakt deel uit van de Poolse rockscene, en 'Mój jest ten kawałek podłogi' (2011) staat op deze Poolse rock-playlist."
     },
     {
       "year": 2005,
@@ -2118,7 +2118,7 @@
       "fun_fact_nl": "Żurkowski maakt deel uit van de Poolse rockscene, en 'Western' (2022) staat op deze Poolse rock-playlist."
     },
     {
-      "year": 2013,
+      "year": 2003,
       "uri": "spotify:track:0B0DHAefOiMrouhSB6Q9Y5",
       "artist": "Perfect",
       "title": "Idź precz!",
@@ -2137,11 +2137,11 @@
       "uri_tidal": null,
       "uri_deezer": "deezer://track/74895995",
       "alt_artists": [],
-      "fun_fact": "Perfect is a Polish rock band that rose to fame in the early 1980s, and 'Idź precz!' (2013) features on this Polish rock playlist.",
-      "fun_fact_de": "Perfect ist eine polnische Rockband, die Anfang der 1980er Jahre bekannt wurde, und 'Idź precz!' (2013) ist auf dieser Polish-Rock-Playlist vertreten.",
-      "fun_fact_es": "Perfect es una banda polaca de rock que alcanzo la fama a principios de los anos 80, y 'Idź precz!' (2013) aparece en esta lista de rock polaco.",
-      "fun_fact_fr": "Perfect est un groupe de rock polonais devenu celebre au debut des annees 1980, et 'Idź precz!' (2013) figure sur cette playlist de rock polonais.",
-      "fun_fact_nl": "Perfect is een Poolse rockband die begin jaren 80 bekend werd, en 'Idź precz!' (2013) staat op deze Poolse rock-playlist."
+      "fun_fact": "Perfect is a Polish rock band that rose to fame in the early 1980s, and 'Idź precz!' (2003) features on this Polish rock playlist.",
+      "fun_fact_de": "Perfect ist eine polnische Rockband, die Anfang der 1980er Jahre bekannt wurde, und 'Idź precz!' (2003) ist auf dieser Polish-Rock-Playlist vertreten.",
+      "fun_fact_es": "Perfect es una banda polaca de rock que alcanzo la fama a principios de los anos 80, y 'Idź precz!' (2003) aparece en esta lista de rock polaco.",
+      "fun_fact_fr": "Perfect est un groupe de rock polonais devenu celebre au debut des annees 1980, et 'Idź precz!' (2003) figure sur cette playlist de rock polonais.",
+      "fun_fact_nl": "Perfect is een Poolse rockband die begin jaren 80 bekend werd, en 'Idź precz!' (2003) staat op deze Poolse rock-playlist."
     },
     {
       "year": 2016,
@@ -2170,7 +2170,7 @@
       "fun_fact_nl": "Męskie Granie Orkiestra maakt deel uit van de Poolse rockscene, en 'Wataha' (2016) staat op deze Poolse rock-playlist."
     },
     {
-      "year": 2005,
+      "year": 1971,
       "uri": "spotify:track:3pGbNgDouEys2kZZGHl6Rc",
       "artist": "Breakout",
       "title": "Oni zaraz przyjdą tu",
@@ -2189,11 +2189,11 @@
       "uri_tidal": null,
       "uri_deezer": "deezer://track/114010986",
       "alt_artists": [],
-      "fun_fact": "Breakout is a Polish blues-rock band led by Tadeusz Nalepa, active from the late 1960s, and 'Oni zaraz przyjdą tu' (2005) features on this Polish rock playlist.",
-      "fun_fact_de": "Breakout ist eine polnische Blues-Rock-Band unter Tadeusz Nalepa, aktiv seit den spaeten 1960ern, und 'Oni zaraz przyjdą tu' (2005) ist auf dieser Polish-Rock-Playlist vertreten.",
-      "fun_fact_es": "Breakout es una banda polaca de blues-rock liderada por Tadeusz Nalepa, activa desde finales de los anos 60, y 'Oni zaraz przyjdą tu' (2005) aparece en esta lista de rock polaco.",
-      "fun_fact_fr": "Breakout est un groupe de blues-rock polonais mene par Tadeusz Nalepa, actif depuis la fin des annees 1960, et 'Oni zaraz przyjdą tu' (2005) figure sur cette playlist de rock polonais.",
-      "fun_fact_nl": "Breakout is een Poolse blues-rockband geleid door Tadeusz Nalepa, actief sinds eind jaren 60, en 'Oni zaraz przyjdą tu' (2005) staat op deze Poolse rock-playlist."
+      "fun_fact": "Breakout is a Polish blues-rock band led by Tadeusz Nalepa, active from the late 1960s, and 'Oni zaraz przyjdą tu' (1971) features on this Polish rock playlist.",
+      "fun_fact_de": "Breakout ist eine polnische Blues-Rock-Band unter Tadeusz Nalepa, aktiv seit den spaeten 1960ern, und 'Oni zaraz przyjdą tu' (1971) ist auf dieser Polish-Rock-Playlist vertreten.",
+      "fun_fact_es": "Breakout es una banda polaca de blues-rock liderada por Tadeusz Nalepa, activa desde finales de los anos 60, y 'Oni zaraz przyjdą tu' (1971) aparece en esta lista de rock polaco.",
+      "fun_fact_fr": "Breakout est un groupe de blues-rock polonais mene par Tadeusz Nalepa, actif depuis la fin des annees 1960, et 'Oni zaraz przyjdą tu' (1971) figure sur cette playlist de rock polonais.",
+      "fun_fact_nl": "Breakout is een Poolse blues-rockband geleid door Tadeusz Nalepa, actief sinds eind jaren 60, en 'Oni zaraz przyjdą tu' (1971) staat op deze Poolse rock-playlist."
     },
     {
       "year": 2020,
@@ -2222,7 +2222,7 @@
       "fun_fact_nl": "KARAŚ/ROGUCKI maakt deel uit van de Poolse rockscene, en 'Bolesne strzały w serce' (2020) staat op deze Poolse rock-playlist."
     },
     {
-      "year": 2016,
+      "year": 1993,
       "uri": "spotify:track:7ECBfG3O3Sxs3D3TGEU7ag",
       "artist": "Kult",
       "title": "Baranek",
@@ -2241,14 +2241,14 @@
       "uri_tidal": null,
       "uri_deezer": "deezer://track/121736180",
       "alt_artists": [],
-      "fun_fact": "Kult is a Polish rock band led by Kazik Staszewski, and 'Baranek' (2016) features on this Polish rock playlist.",
-      "fun_fact_de": "Kult ist eine polnische Rockband unter der Leitung von Kazik Staszewski, und 'Baranek' (2016) ist auf dieser Polish-Rock-Playlist vertreten.",
-      "fun_fact_es": "Kult es una banda polaca de rock liderada por Kazik Staszewski, y 'Baranek' (2016) aparece en esta lista de rock polaco.",
-      "fun_fact_fr": "Kult est un groupe de rock polonais mene par Kazik Staszewski, et 'Baranek' (2016) figure sur cette playlist de rock polonais.",
-      "fun_fact_nl": "Kult is een Poolse rockband geleid door Kazik Staszewski, en 'Baranek' (2016) staat op deze Poolse rock-playlist."
+      "fun_fact": "Kult is a Polish rock band led by Kazik Staszewski, and 'Baranek' (1993) features on this Polish rock playlist.",
+      "fun_fact_de": "Kult ist eine polnische Rockband unter der Leitung von Kazik Staszewski, und 'Baranek' (1993) ist auf dieser Polish-Rock-Playlist vertreten.",
+      "fun_fact_es": "Kult es una banda polaca de rock liderada por Kazik Staszewski, y 'Baranek' (1993) aparece en esta lista de rock polaco.",
+      "fun_fact_fr": "Kult est un groupe de rock polonais mene par Kazik Staszewski, et 'Baranek' (1993) figure sur cette playlist de rock polonais.",
+      "fun_fact_nl": "Kult is een Poolse rockband geleid door Kazik Staszewski, en 'Baranek' (1993) staat op deze Poolse rock-playlist."
     },
     {
-      "year": 2012,
+      "year": 2003,
       "uri": "spotify:track:4iS4v7NkeyC61OtJYpOjZy",
       "artist": "Dżem",
       "title": "Naiwne pytania - 2003 Remaster",
@@ -2267,14 +2267,14 @@
       "uri_tidal": null,
       "uri_deezer": "deezer://track/79590766",
       "alt_artists": [],
-      "fun_fact": "Dżem is a Polish blues-rock band from Silesia, and 'Naiwne pytania' (2012) features on this Polish rock playlist.",
-      "fun_fact_de": "Dżem ist eine polnische Blues-Rock-Band aus Schlesien, und 'Naiwne pytania' (2012) ist auf dieser Polish-Rock-Playlist vertreten.",
-      "fun_fact_es": "Dżem es una banda polaca de blues-rock de Silesia, y 'Naiwne pytania' (2012) aparece en esta lista de rock polaco.",
-      "fun_fact_fr": "Dżem est un groupe de blues-rock polonais de Silesie, et 'Naiwne pytania' (2012) figure sur cette playlist de rock polonais.",
-      "fun_fact_nl": "Dżem is een Poolse blues-rockband uit Silezie, en 'Naiwne pytania' (2012) staat op deze Poolse rock-playlist."
+      "fun_fact": "Dżem is a Polish blues-rock band from Silesia, and 'Naiwne pytania' (2003) features on this Polish rock playlist.",
+      "fun_fact_de": "Dżem ist eine polnische Blues-Rock-Band aus Schlesien, und 'Naiwne pytania' (2003) ist auf dieser Polish-Rock-Playlist vertreten.",
+      "fun_fact_es": "Dżem es una banda polaca de blues-rock de Silesia, y 'Naiwne pytania' (2003) aparece en esta lista de rock polaco.",
+      "fun_fact_fr": "Dżem est un groupe de blues-rock polonais de Silesie, et 'Naiwne pytania' (2003) figure sur cette playlist de rock polonais.",
+      "fun_fact_nl": "Dżem is een Poolse blues-rockband uit Silezie, en 'Naiwne pytania' (2003) staat op deze Poolse rock-playlist."
     },
     {
-      "year": 2016,
+      "year": 2012,
       "uri": "spotify:track:0m0MNn28t3VYGpzQd3PHuw",
       "artist": "Farben Lehre",
       "title": "Anioły i Demony",
@@ -2293,11 +2293,11 @@
       "uri_tidal": null,
       "uri_deezer": "deezer://track/132429046",
       "alt_artists": [],
-      "fun_fact": "Farben Lehre is part of Poland's rock scene, and 'Anioły i Demony' (2016) features on this Polish rock playlist.",
-      "fun_fact_de": "Farben Lehre gehoert zur polnischen Rockszene, und 'Anioły i Demony' (2016) ist auf dieser Polish-Rock-Playlist vertreten.",
-      "fun_fact_es": "Farben Lehre forma parte de la escena del rock polaco, y 'Anioły i Demony' (2016) aparece en esta lista de rock polaco.",
-      "fun_fact_fr": "Farben Lehre fait partie de la scene rock polonaise, et 'Anioły i Demony' (2016) figure sur cette playlist de rock polonais.",
-      "fun_fact_nl": "Farben Lehre maakt deel uit van de Poolse rockscene, en 'Anioły i Demony' (2016) staat op deze Poolse rock-playlist."
+      "fun_fact": "Farben Lehre is part of Poland's rock scene, and 'Anioły i Demony' (2012) features on this Polish rock playlist.",
+      "fun_fact_de": "Farben Lehre gehoert zur polnischen Rockszene, und 'Anioły i Demony' (2012) ist auf dieser Polish-Rock-Playlist vertreten.",
+      "fun_fact_es": "Farben Lehre forma parte de la escena del rock polaco, y 'Anioły i Demony' (2012) aparece en esta lista de rock polaco.",
+      "fun_fact_fr": "Farben Lehre fait partie de la scene rock polonaise, et 'Anioły i Demony' (2012) figure sur cette playlist de rock polonais.",
+      "fun_fact_nl": "Farben Lehre maakt deel uit van de Poolse rockscene, en 'Anioły i Demony' (2012) staat op deze Poolse rock-playlist."
     },
     {
       "year": 2023,
@@ -2352,7 +2352,7 @@
       "fun_fact_nl": "KULT is een Poolse rockband geleid door Kazik Staszewski, en 'Polska' (2016) staat op deze Poolse rock-playlist."
     },
     {
-      "year": 2016,
+      "year": 1998,
       "uri": "spotify:track:318KZH2O4R003o3hL1aDqS",
       "artist": "Kult",
       "title": "Gdy nie ma dzieci",
@@ -2371,11 +2371,11 @@
       "uri_tidal": null,
       "uri_deezer": "deezer://track/121736510",
       "alt_artists": [],
-      "fun_fact": "Kult is a Polish rock band led by Kazik Staszewski, and 'Gdy nie ma dzieci' (2016) features on this Polish rock playlist.",
-      "fun_fact_de": "Kult ist eine polnische Rockband unter der Leitung von Kazik Staszewski, und 'Gdy nie ma dzieci' (2016) ist auf dieser Polish-Rock-Playlist vertreten.",
-      "fun_fact_es": "Kult es una banda polaca de rock liderada por Kazik Staszewski, y 'Gdy nie ma dzieci' (2016) aparece en esta lista de rock polaco.",
-      "fun_fact_fr": "Kult est un groupe de rock polonais mene par Kazik Staszewski, et 'Gdy nie ma dzieci' (2016) figure sur cette playlist de rock polonais.",
-      "fun_fact_nl": "Kult is een Poolse rockband geleid door Kazik Staszewski, en 'Gdy nie ma dzieci' (2016) staat op deze Poolse rock-playlist."
+      "fun_fact": "Kult is a Polish rock band led by Kazik Staszewski, and 'Gdy nie ma dzieci' (1998) features on this Polish rock playlist.",
+      "fun_fact_de": "Kult ist eine polnische Rockband unter der Leitung von Kazik Staszewski, und 'Gdy nie ma dzieci' (1998) ist auf dieser Polish-Rock-Playlist vertreten.",
+      "fun_fact_es": "Kult es una banda polaca de rock liderada por Kazik Staszewski, y 'Gdy nie ma dzieci' (1998) aparece en esta lista de rock polaco.",
+      "fun_fact_fr": "Kult est un groupe de rock polonais mene par Kazik Staszewski, et 'Gdy nie ma dzieci' (1998) figure sur cette playlist de rock polonais.",
+      "fun_fact_nl": "Kult is een Poolse rockband geleid door Kazik Staszewski, en 'Gdy nie ma dzieci' (1998) staat op deze Poolse rock-playlist."
     },
     {
       "year": 2026,
@@ -2404,7 +2404,7 @@
       "fun_fact_nl": "Spięty maakt deel uit van de Poolse rockscene, en 'Zapalenie Przedrostka' (2026) staat op deze Poolse rock-playlist."
     },
     {
-      "year": 2018,
+      "year": 2000,
       "uri": "spotify:track:7khJGSgc3iD8aRhFTGxBWa",
       "artist": "El Dupa",
       "title": "Natalia w Bruklinie odc. 1",
@@ -2423,14 +2423,14 @@
       "uri_tidal": null,
       "uri_deezer": "deezer://track/606654752",
       "alt_artists": [],
-      "fun_fact": "El Dupa is part of Poland's rock scene, and 'Natalia w Bruklinie odc. 1' (2018) features on this Polish rock playlist.",
-      "fun_fact_de": "El Dupa gehoert zur polnischen Rockszene, und 'Natalia w Bruklinie odc. 1' (2018) ist auf dieser Polish-Rock-Playlist vertreten.",
-      "fun_fact_es": "El Dupa forma parte de la escena del rock polaco, y 'Natalia w Bruklinie odc. 1' (2018) aparece en esta lista de rock polaco.",
-      "fun_fact_fr": "El Dupa fait partie de la scene rock polonaise, et 'Natalia w Bruklinie odc. 1' (2018) figure sur cette playlist de rock polonais.",
-      "fun_fact_nl": "El Dupa maakt deel uit van de Poolse rockscene, en 'Natalia w Bruklinie odc. 1' (2018) staat op deze Poolse rock-playlist."
+      "fun_fact": "El Dupa is part of Poland's rock scene, and 'Natalia w Bruklinie odc. 1' (2000) features on this Polish rock playlist.",
+      "fun_fact_de": "El Dupa gehoert zur polnischen Rockszene, und 'Natalia w Bruklinie odc. 1' (2000) ist auf dieser Polish-Rock-Playlist vertreten.",
+      "fun_fact_es": "El Dupa forma parte de la escena del rock polaco, y 'Natalia w Bruklinie odc. 1' (2000) aparece en esta lista de rock polaco.",
+      "fun_fact_fr": "El Dupa fait partie de la scene rock polonaise, et 'Natalia w Bruklinie odc. 1' (2000) figure sur cette playlist de rock polonais.",
+      "fun_fact_nl": "El Dupa maakt deel uit van de Poolse rockscene, en 'Natalia w Bruklinie odc. 1' (2000) staat op deze Poolse rock-playlist."
     },
     {
-      "year": 2019,
+      "year": 2003,
       "uri": "spotify:track:55IzVZdFOu4gS5U5RDO4g8",
       "artist": "Lady Pank",
       "title": "Kryzysowa narzeczona",
@@ -2449,14 +2449,14 @@
       "uri_tidal": null,
       "uri_deezer": "deezer://track/779745992",
       "alt_artists": [],
-      "fun_fact": "Lady Pank is a Polish rock band formed in 1982, and 'Kryzysowa narzeczona' (2019) features on this Polish rock playlist.",
-      "fun_fact_de": "Lady Pank ist eine polnische Rockband, gegruendet 1982, und 'Kryzysowa narzeczona' (2019) ist auf dieser Polish-Rock-Playlist vertreten.",
-      "fun_fact_es": "Lady Pank es una banda polaca de rock formada en 1982, y 'Kryzysowa narzeczona' (2019) aparece en esta lista de rock polaco.",
-      "fun_fact_fr": "Lady Pank est un groupe de rock polonais forme en 1982, et 'Kryzysowa narzeczona' (2019) figure sur cette playlist de rock polonais.",
-      "fun_fact_nl": "Lady Pank is een Poolse rockband opgericht in 1982, en 'Kryzysowa narzeczona' (2019) staat op deze Poolse rock-playlist."
+      "fun_fact": "Lady Pank is a Polish rock band formed in 1982, and 'Kryzysowa narzeczona' (2003) features on this Polish rock playlist.",
+      "fun_fact_de": "Lady Pank ist eine polnische Rockband, gegruendet 1982, und 'Kryzysowa narzeczona' (2003) ist auf dieser Polish-Rock-Playlist vertreten.",
+      "fun_fact_es": "Lady Pank es una banda polaca de rock formada en 1982, y 'Kryzysowa narzeczona' (2003) aparece en esta lista de rock polaco.",
+      "fun_fact_fr": "Lady Pank est un groupe de rock polonais forme en 1982, et 'Kryzysowa narzeczona' (2003) figure sur cette playlist de rock polonais.",
+      "fun_fact_nl": "Lady Pank is een Poolse rockband opgericht in 1982, en 'Kryzysowa narzeczona' (2003) staat op deze Poolse rock-playlist."
     },
     {
-      "year": 2016,
+      "year": 2007,
       "uri": "spotify:track:6WhXF50byenR5PbqpKanoq",
       "artist": "Pidżama Porno",
       "title": "Ezoteryczny Poznań",
@@ -2475,11 +2475,11 @@
       "uri_tidal": null,
       "uri_deezer": "deezer://track/122778052",
       "alt_artists": [],
-      "fun_fact": "Pidżama Porno is a Polish punk rock band led by Krzysztof Grabowski, and 'Ezoteryczny Poznań' (2016) features on this Polish rock playlist.",
-      "fun_fact_de": "Pidżama Porno ist eine polnische Punkrock-Band unter der Leitung von Krzysztof Grabowski, und 'Ezoteryczny Poznań' (2016) ist auf dieser Polish-Rock-Playlist vertreten.",
-      "fun_fact_es": "Pidżama Porno es una banda polaca de punk rock liderada por Krzysztof Grabowski, y 'Ezoteryczny Poznań' (2016) aparece en esta lista de rock polaco.",
-      "fun_fact_fr": "Pidżama Porno est un groupe de punk rock polonais mene par Krzysztof Grabowski, et 'Ezoteryczny Poznań' (2016) figure sur cette playlist de rock polonais.",
-      "fun_fact_nl": "Pidżama Porno is een Poolse punkrockband geleid door Krzysztof Grabowski, en 'Ezoteryczny Poznań' (2016) staat op deze Poolse rock-playlist."
+      "fun_fact": "Pidżama Porno is a Polish punk rock band led by Krzysztof Grabowski, and 'Ezoteryczny Poznań' (2007) features on this Polish rock playlist.",
+      "fun_fact_de": "Pidżama Porno ist eine polnische Punkrock-Band unter der Leitung von Krzysztof Grabowski, und 'Ezoteryczny Poznań' (2007) ist auf dieser Polish-Rock-Playlist vertreten.",
+      "fun_fact_es": "Pidżama Porno es una banda polaca de punk rock liderada por Krzysztof Grabowski, y 'Ezoteryczny Poznań' (2007) aparece en esta lista de rock polaco.",
+      "fun_fact_fr": "Pidżama Porno est un groupe de punk rock polonais mene par Krzysztof Grabowski, et 'Ezoteryczny Poznań' (2007) figure sur cette playlist de rock polonais.",
+      "fun_fact_nl": "Pidżama Porno is een Poolse punkrockband geleid door Krzysztof Grabowski, en 'Ezoteryczny Poznań' (2007) staat op deze Poolse rock-playlist."
     },
     {
       "year": 2025,
@@ -2534,7 +2534,7 @@
       "fun_fact_nl": "Miro Kepinski maakt deel uit van de Poolse rockscene, en 'Szklana Góra' (2025) staat op deze Poolse rock-playlist."
     },
     {
-      "year": 2019,
+      "year": 2001,
       "uri": "spotify:track:6fNnE4M5eATVZ9O4NK4tPT",
       "artist": "Sztywny Pal Azji",
       "title": "Nieprzemakalni",
@@ -2553,14 +2553,14 @@
       "uri_tidal": null,
       "uri_deezer": "deezer://track/782048382",
       "alt_artists": [],
-      "fun_fact": "Sztywny Pal Azji is a Polish rock band active since the 1980s, and 'Nieprzemakalni' (2019) features on this Polish rock playlist.",
-      "fun_fact_de": "Sztywny Pal Azji ist eine polnische Rockband, aktiv seit den 1980er Jahren, und 'Nieprzemakalni' (2019) ist auf dieser Polish-Rock-Playlist vertreten.",
-      "fun_fact_es": "Sztywny Pal Azji es una banda polaca de rock activa desde los anos 80, y 'Nieprzemakalni' (2019) aparece en esta lista de rock polaco.",
-      "fun_fact_fr": "Sztywny Pal Azji est un groupe de rock polonais actif depuis les annees 1980, et 'Nieprzemakalni' (2019) figure sur cette playlist de rock polonais.",
-      "fun_fact_nl": "Sztywny Pal Azji is een Poolse rockband actief sinds de jaren 80, en 'Nieprzemakalni' (2019) staat op deze Poolse rock-playlist."
+      "fun_fact": "Sztywny Pal Azji is a Polish rock band active since the 1980s, and 'Nieprzemakalni' (2001) features on this Polish rock playlist.",
+      "fun_fact_de": "Sztywny Pal Azji ist eine polnische Rockband, aktiv seit den 1980er Jahren, und 'Nieprzemakalni' (2001) ist auf dieser Polish-Rock-Playlist vertreten.",
+      "fun_fact_es": "Sztywny Pal Azji es una banda polaca de rock activa desde los anos 80, y 'Nieprzemakalni' (2001) aparece en esta lista de rock polaco.",
+      "fun_fact_fr": "Sztywny Pal Azji est un groupe de rock polonais actif depuis les annees 1980, et 'Nieprzemakalni' (2001) figure sur cette playlist de rock polonais.",
+      "fun_fact_nl": "Sztywny Pal Azji is een Poolse rockband actief sinds de jaren 80, en 'Nieprzemakalni' (2001) staat op deze Poolse rock-playlist."
     },
     {
-      "year": 2024,
+      "year": 1994,
       "uri": "spotify:track:0rR6ZI9B8btUNBkD4qZxad",
       "artist": "Edyta Bartosiewicz",
       "title": "Koziorożec - Remastered 2024",
@@ -2579,11 +2579,11 @@
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3017689761",
       "alt_artists": [],
-      "fun_fact": "Edyta Bartosiewicz is a Polish rock singer-songwriter of the 1990s, and 'Koziorożec' (2024) features on this Polish rock playlist.",
-      "fun_fact_de": "Edyta Bartosiewicz ist eine polnische Rock-Singer-Songwriterin der 1990er, und 'Koziorożec' (2024) ist auf dieser Polish-Rock-Playlist vertreten.",
-      "fun_fact_es": "Edyta Bartosiewicz es una cantautora de rock polaca de los anos 90, y 'Koziorożec' (2024) aparece en esta lista de rock polaco.",
-      "fun_fact_fr": "Edyta Bartosiewicz est un auteure-compositrice-interprete de rock polonaise des annees 1990, et 'Koziorożec' (2024) figure sur cette playlist de rock polonais.",
-      "fun_fact_nl": "Edyta Bartosiewicz is een Poolse rock-singer-songwriter uit de jaren 90, en 'Koziorożec' (2024) staat op deze Poolse rock-playlist."
+      "fun_fact": "Edyta Bartosiewicz is a Polish rock singer-songwriter of the 1990s, and 'Koziorożec' (1994) features on this Polish rock playlist.",
+      "fun_fact_de": "Edyta Bartosiewicz ist eine polnische Rock-Singer-Songwriterin der 1990er, und 'Koziorożec' (1994) ist auf dieser Polish-Rock-Playlist vertreten.",
+      "fun_fact_es": "Edyta Bartosiewicz es una cantautora de rock polaca de los anos 90, y 'Koziorożec' (1994) aparece en esta lista de rock polaco.",
+      "fun_fact_fr": "Edyta Bartosiewicz est un auteure-compositrice-interprete de rock polonaise des annees 1990, et 'Koziorożec' (1994) figure sur cette playlist de rock polonais.",
+      "fun_fact_nl": "Edyta Bartosiewicz is een Poolse rock-singer-songwriter uit de jaren 90, en 'Koziorożec' (1994) staat op deze Poolse rock-playlist."
     },
     {
       "year": 2000,


### PR DESCRIPTION
Behebt #1901 für `polish-rock`. `polish-all-time-hits` ist über #1903 bereits neu gebaut und trägt schon korrekte Jahre — dieser PR ist der verbleibende Teil.

## Was geändert wurde

**40 von 100 Tracks** bekommen ein neues `year`, gezogen über `open.spotify.com/embed/track/<id>` → `entity.releaseDate.isoString`, also das Release-Jahr des Tracks, auf den `uri` zeigt — die Konvention des Repos. Alle 100 Tracks liessen sich diesmal auflösen.

Bei jedem geänderten Track wird das Jahr **auch in `fun_fact` und den vier Übersetzungen** nachgezogen, weil es dort ausgeschrieben steht und im Spiel sichtbar ist. Das sind 200 Textfelder. Der Diff ist exakt 40 × (1 Jahr + 5 Texte) + 1 Versions-Zeile = 241 Zeilenpaare, ohne sonstige Umformatierung.

`version` 0.4 → 0.5.

## Wirkung auf die Verteilung

| | 1970er | 1980er | 1990er | 2000er | 2010er | 2020er |
|---|---|---|---|---|---|---|
| vorher | 0 | 0 | 4 | 15 | 46 | 35 |
| nachher | 2 | 3 | 20 | 20 | 21 | 34 |

Vorher hatte die Datei **keinen einzigen** Track vor 1990, obwohl die Beschreibung „from classic 1980s acts like Republika, Maanam and Perfect" verspricht. Jetzt sind es 5. Tracks mit `year >= 2011` gehen von 79 auf 54 zurück.

## Richtung der Korrekturen

37 Tracks bekommen ein **früheres** Jahr, 3 ein **späteres** — die Korrektur geht also nicht durchgängig in eine Richtung. Beispiel für die Gegenrichtung: Rezerwat „Zaopiekuj sie mną" 2005 → 2012.

## Was dieser PR NICHT anfasst

Die offene Grundsatzfrage aus #1844 / #1825: Spotify verlinkt bei einigen Klassikern selbst nur eine Compilation oder ein Remaster (Republika „Śmierć W Bikini" zeigt auf eine 2001er-Veröffentlichung, das Original ist von 1983). Dort stimmt das File mit dem verlinkten Track überein und bleibt unverändert. Wer das anders haben will, muss zuerst die Konvention ändern — das ist eine Produktentscheidung, kein Datenfehler.

Schema-Gate `scripts/validate_playlists.py` grün (54 Dateien).

Closes #1901

## Alle 40 Korrekturen

| Artist | Titel | vorher | nachher | Δ |
|---|---|---|---|---|
| Breakout | Kiedy byłem małym chłopcem | 2005 | 1971 | -34 |
| Perfect | Chcemy Być Sobą | 2015 | 1981 | -34 |
| Perfect | Ale Wkoło Jest Wesoło | 2015 | 1981 | -34 |
| Breakout | Oni zaraz przyjdą tu | 2005 | 1971 | -34 |
| Edyta Bartosiewicz | Koziorożec - Remastered 2024 | 2024 | 1994 | -30 |
| Kult | Arahja | 2016 | 1988 | -28 |
| Wilki | Son Of The Blue Sky | 2018 | 1992 | -26 |
| Wilki | Eli Lama Sabachtani | 2018 | 1992 | -26 |
| Robert Gawlinski | O Sobie Samym | 2018 | 1995 | -23 |
| Kult | Baranek | 2016 | 1993 | -23 |
| Bajm | Biała armia | 2012 | 1990 | -22 |
| T.Love | King | 2014 | 1992 | -22 |
| Myslovitz | Chłopcy | 2020 | 1999 | -21 |
| Hey | Zazdrosc | 2013 | 1993 | -20 |
| Hey | Teksanski | 2012 | 1993 | -19 |
| Sztywny Pal Azji | Wieża radości, wieża samotności | 2019 | 2001 | -18 |
| Sztywny Pal Azji | Spotkanie z... | 2019 | 2001 | -18 |
| Kult | Gdy nie ma dzieci | 2016 | 1998 | -18 |
| El Dupa | Natalia w Bruklinie odc. 1 | 2018 | 2000 | -18 |
| Sztywny Pal Azji | Nieprzemakalni | 2019 | 2001 | -18 |
| Budka Suflera | Za ostatni grosz | 2019 | 2003 | -16 |
| Lady Pank | Kryzysowa narzeczona | 2019 | 2003 | -16 |
| Maanam | Cykady na Cykladach - 2011 Remaster | 2011 | 1997 | -14 |
| Klaus Mitffoch | Jezu jak się cieszę | 2019 | 2005 | -14 |
| Stanisław Soyka, Janusz Iwanski "yanina" | Tolerancja / Na Miły Bóg | 2005 | 1992 | -13 |
| Robert Gawlinski | Nie stało się nic | 2010 | 1997 | -13 |
| Happysad | Zanim pójdę | 2016 | 2004 | -12 |
| Happysad | Łydka | 2016 | 2005 | -11 |
| Perfect | Idź precz! | 2013 | 2003 | -10 |
| Happysad | Damy radę | 2016 | 2007 | -9 |
| Dżem | Naiwne pytania - 2003 Remaster | 2012 | 2003 | -9 |
| Pidżama Porno | Ezoteryczny Poznań | 2016 | 2007 | -9 |
| Dżem | Wehikuł Czasu - To Byłby Cud - 2003 Remaster | 2006 | 1998 | -8 |
| Mr. Zoob | Mój jest ten kawałek podłogi | 2019 | 2011 | -8 |
| Republika | Mamona | 2005 | 1998 | -7 |
| Human | Polski | 2018 | 2013 | -5 |
| Farben Lehre | Anioły i Demony | 2016 | 2012 | -4 |
| Rezerwat | Zaopiekuj sie mną | 2005 | 2012 | +7 |
| Lombard | Szklana Pogoda | 2002 | 2016 | +14 |
| LemON, Wanda i Banda | Siedem życzeń - Radio Edit | 2009 | 2026 | +17 |
