### PR TITLE
chore(playlists): tidal backfill wave — +19 uris (deutschrock-best-of)

### DIFF
--- a/custom_components/beatify/playlists/community/deutschrock-best-of.json
+++ b/custom_components/beatify/playlists/community/deutschrock-best-of.json
@@ -1,6 +1,6 @@
 {
   "name": "Deutschrock - Best Of",
-  "version": "0.2",
+  "version": "0.3",
   "tags": [
     "deutschrock",
     "german rock",
@@ -134,7 +134,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/416292504",
       "uri_deezer": "deezer://track/3187689581",
       "alt_artists": [],
       "fun_fact": "Unantastbar is part of the German rock (Deutschrock) scene; \"Dieser eine Moment\" (2025) features on this Deutschrock best-of.",
@@ -160,7 +160,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/442775007",
       "uri_deezer": "deezer://track/3419570401",
       "alt_artists": [],
       "fun_fact": "Local Bastards is part of the German rock (Deutschrock) scene; \"Symbole des Wahnsinns\" (2025) features on this Deutschrock best-of.",
@@ -186,7 +186,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/73402976",
       "uri_deezer": "deezer://track/357434601",
       "alt_artists": [],
       "fun_fact": "Die Toten Hosen is part of the German rock (Deutschrock) scene; \"Laune der Natur\" (2017) features on this Deutschrock best-of.",
@@ -212,7 +212,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/276999011",
       "uri_deezer": "deezer://track/2147895807",
       "alt_artists": [],
       "fun_fact": "KneipenTerroristen is part of the German rock (Deutschrock) scene; \"Der Alkohol\" (2023) features on this Deutschrock best-of.",
@@ -238,7 +238,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/88858729",
       "uri_deezer": "deezer://track/500165212",
       "alt_artists": [],
       "fun_fact": "Rockwasser is part of the German rock (Deutschrock) scene; \"Herzlich Willkommen\" (2018) features on this Deutschrock best-of.",
@@ -264,7 +264,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/430681773",
       "uri_deezer": "deezer://track/3328976811",
       "alt_artists": [],
       "fun_fact": "Eickenlob is part of the German rock (Deutschrock) scene; \"Blaue Lichter\" (2025) features on this Deutschrock best-of.",
@@ -290,7 +290,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/440113397",
       "uri_deezer": "deezer://track/3395760901",
       "alt_artists": [],
       "fun_fact": "Störte.Priester is part of the German rock (Deutschrock) scene; \"Nie wieder ist jetzt\" (2025) features on this Deutschrock best-of.",
@@ -316,7 +316,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/353847575",
       "uri_deezer": "deezer://track/2724656311",
       "alt_artists": [],
       "fun_fact": "KrawallBrüder is part of the German rock (Deutschrock) scene; \"von anfang an\" (2023) features on this Deutschrock best-of.",
@@ -342,7 +342,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/341534834",
       "uri_deezer": "deezer://track/2476328001",
       "alt_artists": [],
       "fun_fact": "Grenzenlos is part of the German rock (Deutschrock) scene; \"10 Jahre\" (2024) features on this Deutschrock best-of.",
@@ -368,7 +368,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/522727364",
       "uri_deezer": "deezer://track/4009923081",
       "alt_artists": [],
       "fun_fact": "Betontod is part of the German rock (Deutschrock) scene; \"Traum von Freiheit\" (2015) features on this Deutschrock best-of.",
@@ -394,7 +394,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/442482686",
       "uri_deezer": "deezer://track/3417022611",
       "alt_artists": [],
       "fun_fact": "Kärbholz is part of the German rock (Deutschrock) scene; \"Gar nichts\" (2023) features on this Deutschrock best-of.",
@@ -420,7 +420,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/2040261",
       "uri_deezer": "deezer://track/1272451732",
       "alt_artists": [],
       "fun_fact": "Böhse Onkelz is part of the German rock (Deutschrock) scene; \"10 Jahre\" (1990) features on this Deutschrock best-of.",
@@ -446,7 +446,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/279503489",
       "uri_deezer": "deezer://track/2170638557",
       "alt_artists": [],
       "fun_fact": "Frei.Wild is part of the German rock (Deutschrock) scene; \"Allein nach vorne - Still Version\" (2013) features on this Deutschrock best-of.",
@@ -472,7 +472,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/442479985",
       "uri_deezer": "deezer://track/3417021261",
       "alt_artists": [],
       "fun_fact": "Artefuckt is part of the German rock (Deutschrock) scene; \"Lasst uns\" (2023) features on this Deutschrock best-of.",
@@ -498,7 +498,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/203629601",
       "uri_deezer": "deezer://track/1520562962",
       "alt_artists": [],
       "fun_fact": "Toxpack is part of the German rock (Deutschrock) scene; \"Totgeglaubt, doch neugeboren\" (2022) features on this Deutschrock best-of.",
@@ -524,7 +524,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/84765402",
       "uri_deezer": "deezer://track/462439512",
       "alt_artists": [],
       "fun_fact": "Unherz is part of the German rock (Deutschrock) scene; \"Helden von Morgen\" (2017) features on this Deutschrock best-of.",
@@ -550,7 +550,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/438221487",
       "uri_deezer": "deezer://track/3370456051",
       "alt_artists": [],
       "fun_fact": "Neurotox is part of the German rock (Deutschrock) scene; \"Mama hat gesagt\" (2025) features on this Deutschrock best-of.",
@@ -576,7 +576,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/422158122",
       "uri_deezer": "deezer://track/3265960061",
       "alt_artists": [],
       "fun_fact": "BRDIGUNG is part of the German rock (Deutschrock) scene; \"Gib nicht auf\" (2025) features on this Deutschrock best-of.",
@@ -602,7 +602,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/424046632",
       "uri_deezer": "deezer://track/2459899275",
       "alt_artists": [],
       "fun_fact": "Leidbild is part of the German rock (Deutschrock) scene; \"Vollgas\" (2025) features on this Deutschrock best-of.",


### PR DESCRIPTION
Tidal-Welle vom **26.07., 22:00-Slot** — vierte und letzte des Tages.

| Playlist | Tidal vorher | nachher | Δ | version |
|---|---|---|---|---|
| `deutschrock-best-of` | 4 / 100 | **23 / 100** | +19 | 0.2 → 0.3 |

**Die Welle lief ins Timeout** (1500 s, exit 124) und ist nach dem Muster des `tidal-wave-salvage`-Skills **geborgen** statt verworfen worden — `backfill_tidal.py` speichert pro Treffer inkrementell, die 19 URIs lagen also bereits im Worktree. Kein Skript-Fehler.

**Odesli drosselt abends deutlich härter**: 71 429-Backoffs plus ein HTTP 502 in dieser Welle, gegenüber 25 Backoffs in der 18:00-Welle. Die übrigen 77 offenen Tracks sind **Skips, keine Misses** — sie landen nicht im Cache und werden in der 06:00-Welle erneut versucht.

**Miss-Cache** 520 → **539** zurückgemergt (19 neue echte „nicht auf Tidal"-Treffer).

Schema-Gate `scripts/validate_playlists.py` grün (54 Dateien).