### PR TITLE
chore(playlists): tidal backfill wave — +19 uris (deutschrock-best-of)

### DIFF
--- a/custom_components/beatify/playlists/community/deutschrock-best-of.json
+++ b/custom_components/beatify/playlists/community/deutschrock-best-of.json
@@ -1,6 +1,6 @@
 {
   "name": "Deutschrock - Best Of",
-  "version": "0.3",
+  "version": "0.4",
   "tags": [
     "deutschrock",
     "german rock",
@@ -628,7 +628,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/133886894",
       "uri_deezer": "deezer://track/899950322",
       "alt_artists": [],
       "fun_fact": "Themenwexel is part of the German rock (Deutschrock) scene; \"Luft\" (2020) features on this Deutschrock best-of.",
@@ -654,7 +654,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/289132450",
       "uri_deezer": "deezer://track/2237025037",
       "alt_artists": [],
       "fun_fact": "Eizbrand is part of the German rock (Deutschrock) scene; \"Feuer\" (2023) features on this Deutschrock best-of.",
@@ -680,7 +680,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/94431445",
       "uri_deezer": "deezer://track/548387972",
       "alt_artists": [],
       "fun_fact": "ElbRebellen is part of the German rock (Deutschrock) scene; \"Alter Freund\" (2015) features on this Deutschrock best-of.",
@@ -706,7 +706,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/105896551",
       "uri_deezer": "deezer://track/649053902",
       "alt_artists": [],
       "fun_fact": "Hangar-X is part of the German rock (Deutschrock) scene; \"Nur die Zeit\" (2019) features on this Deutschrock best-of.",
@@ -732,7 +732,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/442482758",
       "uri_deezer": "deezer://track/3417042361",
       "alt_artists": [],
       "fun_fact": "Maerzfeld is part of the German rock (Deutschrock) scene; \"Lange nicht\" (2023) features on this Deutschrock best-of.",
@@ -758,7 +758,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/18217419",
       "uri_deezer": "deezer://track/58495591",
       "alt_artists": [],
       "fun_fact": "Haudegen is part of the German rock (Deutschrock) scene; \"Feuer und Flamme\" (2012) features on this Deutschrock best-of.",
@@ -784,7 +784,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/15187667",
       "uri_deezer": "deezer://track/142393405",
       "alt_artists": [],
       "fun_fact": "Die Toten Hosen is part of the German rock (Deutschrock) scene; \"Altes Fieber\" (2012) features on this Deutschrock best-of.",
@@ -810,7 +810,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/292900112",
       "uri_deezer": "deezer://track/2267593717",
       "alt_artists": [],
       "fun_fact": "Frei.Wild is part of the German rock (Deutschrock) scene; \"Auf alles was war\" (2023) features on this Deutschrock best-of.",
@@ -836,7 +836,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/2039802",
       "uri_deezer": "deezer://track/2490361",
       "alt_artists": [],
       "fun_fact": "Böhse Onkelz is part of the German rock (Deutschrock) scene; \"Zu nah an der Wahrheit\" (1996) features on this Deutschrock best-of.",
@@ -862,7 +862,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/63875994",
       "uri_deezer": "deezer://track/112693002",
       "alt_artists": [],
       "fun_fact": "Unantastbar is part of the German rock (Deutschrock) scene; \"Gerader Weg\" (2016) features on this Deutschrock best-of.",
@@ -888,7 +888,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/146668304",
       "uri_deezer": "deezer://track/1004595412",
       "alt_artists": [],
       "fun_fact": "Betontod is part of the German rock (Deutschrock) scene; \"Zusammen\" (2018) features on this Deutschrock best-of.",
@@ -914,7 +914,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/50820652",
       "uri_deezer": "deezer://track/106845220",
       "alt_artists": [],
       "fun_fact": "Wilde Jungs is part of the German rock (Deutschrock) scene; \"Wildes Neues\" (2013) features on this Deutschrock best-of.",
@@ -940,7 +940,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/110204234",
       "uri_deezer": "deezer://track/687374092",
       "alt_artists": [],
       "fun_fact": "KneipenTerroristen is part of the German rock (Deutschrock) scene; \"Kneipenterroristen 2.0\" (2019) features on this Deutschrock best-of.",
@@ -966,7 +966,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/121262580",
       "uri_deezer": "deezer://track/790676042",
       "alt_artists": [],
       "fun_fact": "Goitzsche Front is part of the German rock (Deutschrock) scene; \"Schwarze Raben\" (2020) features on this Deutschrock best-of.",
@@ -992,7 +992,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/95744216",
       "uri_deezer": "deezer://track/560613942",
       "alt_artists": [],
       "fun_fact": "Böhse Onkelz is part of the German rock (Deutschrock) scene; \"Guten Tag (Neuaufnahme 2018)\" (2018) features on this Deutschrock best-of.",
@@ -1018,7 +1018,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/2251069",
       "uri_deezer": "deezer://track/2728350",
       "alt_artists": [],
       "fun_fact": "Dimple Minds is part of the German rock (Deutschrock) scene; \"Sie scheisst Gold\" (2007) features on this Deutschrock best-of.",
@@ -1044,7 +1044,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/408183190",
       "uri_deezer": "deezer://track/3160832981",
       "alt_artists": [],
       "fun_fact": "BRDIGUNG is part of the German rock (Deutschrock) scene; \"Dreh die Musik auf\" (2020) features on this Deutschrock best-of.",
@@ -1070,7 +1070,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/522727395",
       "uri_deezer": "deezer://track/4009919651",
       "alt_artists": [],
       "fun_fact": "Betontod is part of the German rock (Deutschrock) scene; \"Regenbogen\" (2021) features on this Deutschrock best-of.",
@@ -1096,7 +1096,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/210683302",
       "uri_deezer": "deezer://track/1605684792",
       "alt_artists": [],
       "fun_fact": "Rockwasser is part of the German rock (Deutschrock) scene; \"Nicht einer von Millionen\" (2022) features on this Deutschrock best-of.",


### PR DESCRIPTION
Automatische Tidal-URI-Welle (06:00-Slot) via `scripts/backfill_tidal.py --max 80`.

## Delta
| Playlist | Tidal vorher | nachher | version |
|---|---|---|---|
| `deutschrock-best-of` | 23 / 100 | **42 / 100** | 0.3 → 0.4 |

+19 URIs, Diff exakt 1 Datei / +20 −20.

## Hinweise
- Welle lief ins 1500s-Timeout und wurde nach dem `tidal-wave-salvage`-Muster geborgen — `backfill_tidal.py` speichert pro Treffer inkrementell.
- Ende der Welle in einer geschlossenen 429-Wand (die letzten 40 Log-Zeilen sind ausschließlich Odesli-Backoffs). Die verbleibenden 58 offenen Tracks sind **Skips, keine Misses**, und stehen der 12:00-Welle wieder zur Verfügung.
- Miss-Cache 539 → 558 Einträge zurückgemergt.
- `validate_playlists.py` grün (54 Dateien, Schema-Gate bestanden).

Draft — kein Auto-Merge.