### PR TITLE
chore(playlists): tidal backfill wave — +19 uris (deutschrock-best-of)

### DIFF
--- a/custom_components/beatify/playlists/community/deutschrock-best-of.json
+++ b/custom_components/beatify/playlists/community/deutschrock-best-of.json
@@ -1,6 +1,6 @@
 {
   "name": "Deutschrock - Best Of",
-  "version": "0.4",
+  "version": "0.5",
   "tags": [
     "deutschrock",
     "german rock",
@@ -1122,7 +1122,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/279503506",
       "uri_deezer": "deezer://track/2171829957",
       "alt_artists": [],
       "fun_fact": "Frei.Wild is part of the German rock (Deutschrock) scene; \"Immer höher hinaus - Still Version\" (2013) features on this Deutschrock best-of.",
@@ -1148,7 +1148,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/433439330",
       "uri_deezer": "deezer://track/3349286271",
       "alt_artists": [],
       "fun_fact": "Eickenlob is part of the German rock (Deutschrock) scene; \"Heute Nacht\" (2025) features on this Deutschrock best-of.",
@@ -1174,7 +1174,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/108861504",
       "uri_deezer": "deezer://track/644361402",
       "alt_artists": [],
       "fun_fact": "Local Bastards is part of the German rock (Deutschrock) scene; \"Rattenfänger\" (2019) features on this Deutschrock best-of.",
@@ -1200,7 +1200,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/100168656",
       "uri_deezer": "deezer://track/599115062",
       "alt_artists": [],
       "fun_fact": "Artefuckt is part of the German rock (Deutschrock) scene; \"Stigma\" (2019) features on this Deutschrock best-of.",
@@ -1226,7 +1226,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/446944567",
       "uri_deezer": "deezer://track/3417197171",
       "alt_artists": [],
       "fun_fact": "Kärbholz is part of the German rock (Deutschrock) scene; \"Lass mich fliegen\" (2015) features on this Deutschrock best-of.",
@@ -1252,7 +1252,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/73402978",
       "uri_deezer": "deezer://track/357434621",
       "alt_artists": [],
       "fun_fact": "Die Toten Hosen is part of the German rock (Deutschrock) scene; \"Alles passiert\" (2017) features on this Deutschrock best-of.",
@@ -1278,7 +1278,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/353722894",
       "uri_deezer": "deezer://track/2723611402",
       "alt_artists": [],
       "fun_fact": "KrawallBrüder is part of the German rock (Deutschrock) scene; \"Auf der Flucht - Rockversion\" (2016) features on this Deutschrock best-of.",
@@ -1304,7 +1304,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/2040262",
       "uri_deezer": "deezer://track/1272451742",
       "alt_artists": [],
       "fun_fact": "Böhse Onkelz is part of the German rock (Deutschrock) scene; \"Nekrophil\" (1990) features on this Deutschrock best-of.",
@@ -1330,7 +1330,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/115878765",
       "uri_deezer": "deezer://track/731095032",
       "alt_artists": [],
       "fun_fact": "Eizbrand is part of the German rock (Deutschrock) scene; \"So erheben wir das Glas\" (2019) features on this Deutschrock best-of.",
@@ -1356,7 +1356,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/425228467",
       "uri_deezer": "deezer://track/3286817871",
       "alt_artists": [],
       "fun_fact": "Grenzenlos is part of the German rock (Deutschrock) scene; \"Abenteuer Apokalypse\" (2025) features on this Deutschrock best-of.",
@@ -1382,7 +1382,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/146668313",
       "uri_deezer": "deezer://track/1004595452",
       "alt_artists": [],
       "fun_fact": "Betontod is part of the German rock (Deutschrock) scene; \"Es ist vorbei\" (2018) features on this Deutschrock best-of.",
@@ -1408,7 +1408,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/416292498",
       "uri_deezer": "deezer://track/3187689521",
       "alt_artists": [],
       "fun_fact": "Unantastbar is part of the German rock (Deutschrock) scene; \"Beautiful day\" (2025) features on this Deutschrock best-of.",
@@ -1434,7 +1434,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/72144851",
       "uri_deezer": "deezer://track/140221629",
       "alt_artists": [],
       "fun_fact": "Toxpack is part of the German rock (Deutschrock) scene; \"Die Letzten, die sich noch dagegen stellen\" (2017) features on this Deutschrock best-of.",
@@ -1460,7 +1460,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/429412841",
       "uri_deezer": "deezer://track/3319062641",
       "alt_artists": [],
       "fun_fact": "Frei.Wild is part of the German rock (Deutschrock) scene; \"Immer unter Feuer\" (2025) features on this Deutschrock best-of.",
@@ -1486,7 +1486,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/21598352",
       "uri_deezer": "deezer://track/66730108",
       "alt_artists": [],
       "fun_fact": "Störte.Priester is part of the German rock (Deutschrock) scene; \"Im Himmel nur Idioten\" (2008) features on this Deutschrock best-of.",
@@ -1512,7 +1512,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/276999010",
       "uri_deezer": "deezer://track/2150175597",
       "alt_artists": [],
       "fun_fact": "KneipenTerroristen is part of the German rock (Deutschrock) scene; \"Die Zeit ist ein Dieb\" (2023) features on this Deutschrock best-of.",
@@ -1538,7 +1538,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/119304675",
       "uri_deezer": "deezer://track/767767342",
       "alt_artists": [],
       "fun_fact": "Unherz is part of the German rock (Deutschrock) scene; \"Drachenflügel\" (2020) features on this Deutschrock best-of.",
@@ -1564,7 +1564,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/11016863",
       "uri_deezer": "deezer://track/142393491",
       "alt_artists": [],
       "fun_fact": "Die Toten Hosen is part of the German rock (Deutschrock) scene; \"Nur zu Besuch\" (2002) features on this Deutschrock best-of.",
@@ -1590,7 +1590,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/422158126",
       "uri_deezer": "deezer://track/3265960101",
       "alt_artists": [],
       "fun_fact": "BRDIGUNG is part of the German rock (Deutschrock) scene; \"Genug\" (2025) features on this Deutschrock best-of.",


### PR DESCRIPTION
Eine Odesli-Welle des `tidal-backfill`-Jobs (12:00-Slot).

## Delta

| Playlist | Tidal vorher | nachher | version |
|---|---|---|---|
| `deutschrock-best-of` | 42 / 100 | **61 / 100** | 0.4 → 0.5 |

## Verlauf

Die Welle lief in das 1400s-Timeout und wurde nach dem `tidal-wave-salvage`-Muster geborgen — `backfill_tidal.py` speichert pro Treffer inkrementell, die Arbeit lag bereits im Worktree. Das Ende der Welle steckte wie bei den Vorgängerwellen in der Odesli-429-Wand; die 39 offenen Tracks sind Skips, keine Misses, und kommen in der 18:00-Welle wieder.

Miss-Cache 558 → 577 Einträge zurückgemergt.

## Checks

- `validate_playlists.py` grün (54 Dateien, Schema-Gate)
- Diff exakt 1 Datei, +20 −20 — 19 × `uri_tidal` null → Wert plus Version-Bump

Draft, kein Auto-Merge.