### PR TITLE
chore(playlists): tidal backfill wave — +19 uris

### DIFF
--- a/custom_components/beatify/playlists/community/deutschrock-best-of.json
+++ b/custom_components/beatify/playlists/community/deutschrock-best-of.json
@@ -1,6 +1,6 @@
 {
   "name": "Deutschrock - Best Of",
-  "version": "0.5",
+  "version": "0.6",
   "tags": [
     "deutschrock",
     "german rock",
@@ -1616,7 +1616,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/26008097",
       "uri_deezer": "deezer://track/13777652",
       "alt_artists": [],
       "fun_fact": "Böhse Onkelz is part of the German rock (Deutschrock) scene; \"Wir ham' noch lange nicht genug\" (1991) features on this Deutschrock best-of.",
@@ -1642,7 +1642,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/75510995",
       "uri_deezer": "deezer://track/376661241",
       "alt_artists": [],
       "fun_fact": "Haudegen is part of the German rock (Deutschrock) scene; \"Heute für immer\" (2017) features on this Deutschrock best-of.",
@@ -1668,7 +1668,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/425415886",
       "uri_deezer": "deezer://track/3289131851",
       "alt_artists": [],
       "fun_fact": "Themenwexel is part of the German rock (Deutschrock) scene; \"Regieren\" (2025) features on this Deutschrock best-of.",
@@ -1694,7 +1694,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/53648555",
       "uri_deezer": "deezer://track/111482204",
       "alt_artists": [],
       "fun_fact": "Goitzsche Front is part of the German rock (Deutschrock) scene; \"Menschlich\" (2014) features on this Deutschrock best-of.",
@@ -1720,7 +1720,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/522727446",
       "uri_deezer": "deezer://track/4009920941",
       "alt_artists": [],
       "fun_fact": "Betontod is part of the German rock (Deutschrock) scene; \"Nie mehr St. Pauli ohne Dich\" (2023) features on this Deutschrock best-of.",
@@ -1746,7 +1746,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/1926853",
       "uri_deezer": "deezer://track/2145099",
       "alt_artists": [],
       "fun_fact": "Der W is part of the German rock (Deutschrock) scene; \"Geschichtenhasser\" (2008) features on this Deutschrock best-of.",
@@ -1772,7 +1772,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/442482683",
       "uri_deezer": "deezer://track/3417022381",
       "alt_artists": [],
       "fun_fact": "Kärbholz is part of the German rock (Deutschrock) scene; \"Raubtier\" (2023) features on this Deutschrock best-of.",
@@ -1798,7 +1798,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/145592136",
       "uri_deezer": "deezer://track/995812842",
       "alt_artists": [],
       "fun_fact": "Artefuckt is part of the German rock (Deutschrock) scene; \"Diese Tage\" (2020) features on this Deutschrock best-of.",
@@ -1824,7 +1824,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/279327036",
       "uri_deezer": "deezer://track/2170127937",
       "alt_artists": [],
       "fun_fact": "Frei.Wild is part of the German rock (Deutschrock) scene; \"Geile Heimat\" (2020) features on this Deutschrock best-of.",
@@ -1850,7 +1850,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/353847569",
       "uri_deezer": "deezer://track/2724656261",
       "alt_artists": [],
       "fun_fact": "KrawallBrüder is part of the German rock (Deutschrock) scene; \"töte was du liebst\" (2023) features on this Deutschrock best-of.",
@@ -1876,7 +1876,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/47879830",
       "uri_deezer": "deezer://track/101545624",
       "alt_artists": [],
       "fun_fact": "Rockwasser is part of the German rock (Deutschrock) scene; \"Immer noch nicht satt\" (2015) features on this Deutschrock best-of.",
@@ -1902,7 +1902,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/172685142",
       "uri_deezer": "deezer://track/1235498822",
       "alt_artists": [],
       "fun_fact": "ElbRebellen is part of the German rock (Deutschrock) scene; \"Fick das System\" (2021) features on this Deutschrock best-of.",
@@ -1928,7 +1928,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/232831487",
       "uri_deezer": "deezer://track/1785043087",
       "alt_artists": [],
       "fun_fact": "Eickenlob is part of the German rock (Deutschrock) scene; \"Schließ deine Augen\" (2021) features on this Deutschrock best-of.",
@@ -1954,7 +1954,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/26008096",
       "uri_deezer": "deezer://track/2806907",
       "alt_artists": [],
       "fun_fact": "Böhse Onkelz is part of the German rock (Deutschrock) scene; \"Terpentin\" (1998) features on this Deutschrock best-of.",
@@ -1980,7 +1980,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/84762491",
       "uri_deezer": "deezer://track/462436962",
       "alt_artists": [],
       "fun_fact": "Saitenfeuer is part of the German rock (Deutschrock) scene; \"Auf und Davon\" (2016) features on this Deutschrock best-of.",
@@ -2006,7 +2006,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/192675499",
       "uri_deezer": "deezer://track/672579152",
       "alt_artists": [],
       "fun_fact": "Sündflut is part of the German rock (Deutschrock) scene; \"Gewalt der Musik\" (2018) features on this Deutschrock best-of.",
@@ -2032,7 +2032,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/261999503",
       "uri_deezer": "deezer://track/1965894197",
       "alt_artists": [],
       "fun_fact": "Unantastbar is part of the German rock (Deutschrock) scene; \"Wir leben laut\" (2022) features on this Deutschrock best-of.",
@@ -2058,7 +2058,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/408189544",
       "uri_deezer": "deezer://track/3160855431",
       "alt_artists": [],
       "fun_fact": "BRDIGUNG is part of the German rock (Deutschrock) scene; \"Kraft Liebe Hoffnung\" (2018) features on this Deutschrock best-of.",
@@ -2084,7 +2084,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/11016850",
       "uri_deezer": "deezer://track/142393465",
       "alt_artists": [],
       "fun_fact": "Die Toten Hosen is part of the German rock (Deutschrock) scene; \"Hier kommt Alex\" (2011) features on this Deutschrock best-of.",


### PR DESCRIPTION
Tidal-Backfill-Welle 18:00 (geborgen nach Session-Cold-Restart).

| Playlist | Tidal | version |
|---|---|---|
| `deutschrock-best-of` | 61 → **80 / 100** (+19) | 0.5 → 0.6 |

- Rein additiv: 19 × `uri_tidal` + `version`-Bump, keine anderen Felder.
- `validate_playlists.py` grün (54 Dateien, Schema-Gate).
- Die 20 offenen Tracks sind 429-Skips und kommen in der 22:00-Welle wieder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)