### PR TITLE
chore(playlists): tidal backfill wave — +20 uris across 2 playlists

### DIFF
--- a/custom_components/beatify/playlists/community/deutschrock-best-of.json
+++ b/custom_components/beatify/playlists/community/deutschrock-best-of.json
@@ -1,6 +1,6 @@
 {
   "name": "Deutschrock - Best Of",
-  "version": "0.6",
+  "version": "0.7",
   "tags": [
     "deutschrock",
     "german rock",
@@ -2110,7 +2110,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/146668319",
       "uri_deezer": "deezer://track/1004595472",
       "alt_artists": [],
       "fun_fact": "Betontod is part of the German rock (Deutschrock) scene; \"Nie mehr Alkohol\" (2018) features on this Deutschrock best-of.",
@@ -2136,7 +2136,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/38577317",
       "uri_deezer": "deezer://track/91514576",
       "alt_artists": [],
       "fun_fact": "KneipenTerroristen is part of the German rock (Deutschrock) scene; \"Prost!\" (2014) features on this Deutschrock best-of.",
@@ -2162,7 +2162,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/279503505",
       "uri_deezer": "deezer://track/2170638627",
       "alt_artists": [],
       "fun_fact": "Frei.Wild is part of the German rock (Deutschrock) scene; \"Wer weniger schläft, ist länger wach - Still Version\" (2013) features on this Deutschrock best-of.",
@@ -2188,7 +2188,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/190544282",
       "uri_deezer": "deezer://track/1429122832",
       "alt_artists": [],
       "fun_fact": "Eizbrand is part of the German rock (Deutschrock) scene; \"Lasst uns Geschichte schreiben\" (2021) features on this Deutschrock best-of.",
@@ -2214,7 +2214,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/522729538",
       "uri_deezer": "deezer://track/4009919411",
       "alt_artists": [],
       "fun_fact": "Betontod is part of the German rock (Deutschrock) scene; \"Las Vegas\" (2020) features on this Deutschrock best-of.",
@@ -2240,7 +2240,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/7863165",
       "uri_deezer": "deezer://track/13777596",
       "alt_artists": [],
       "fun_fact": "Böhse Onkelz is part of the German rock (Deutschrock) scene; \"Heilige Lieder\" (1992) features on this Deutschrock best-of.",
@@ -2266,7 +2266,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/466149903",
       "uri_deezer": "deezer://track/3596363432",
       "alt_artists": [],
       "fun_fact": "Local Bastards is part of the German rock (Deutschrock) scene; \"Dem Teufel so nah\" (2025) features on this Deutschrock best-of.",
@@ -2292,7 +2292,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/82778242",
       "uri_deezer": "deezer://track/443839702",
       "alt_artists": [],
       "fun_fact": "Goitzsche Front is part of the German rock (Deutschrock) scene; \"Tag des Regens\" (2018) features on this Deutschrock best-of.",
@@ -2318,7 +2318,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/446944573",
       "uri_deezer": "deezer://track/3417197221",
       "alt_artists": [],
       "fun_fact": "Kärbholz is part of the German rock (Deutschrock) scene; \"Es fühlt sich richtig an\" (2015) features on this Deutschrock best-of.",
@@ -2344,7 +2344,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/442507343",
       "uri_deezer": "deezer://track/3417318381",
       "alt_artists": [],
       "fun_fact": "Neurotox is part of the German rock (Deutschrock) scene; \"Dein Problem\" (2018) features on this Deutschrock best-of.",
@@ -2370,7 +2370,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/341534835",
       "uri_deezer": "deezer://track/2594286122",
       "alt_artists": [],
       "fun_fact": "Grenzenlos is part of the German rock (Deutschrock) scene; \"Letzte Generation\" (2024) features on this Deutschrock best-of.",
@@ -2396,7 +2396,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/424046622",
       "uri_deezer": "deezer://track/3278753611",
       "alt_artists": [],
       "fun_fact": "Leidbild is part of the German rock (Deutschrock) scene; \"Alte Brücken\" (2025) features on this Deutschrock best-of.",
@@ -2422,7 +2422,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/353722895",
       "uri_deezer": "deezer://track/2723611412",
       "alt_artists": [],
       "fun_fact": "KrawallBrüder is part of the German rock (Deutschrock) scene; \"Für uns zu spät - 2015 Version\" (2016) features on this Deutschrock best-of.",
@@ -2448,7 +2448,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/203629605",
       "uri_deezer": "deezer://track/1520563002",
       "alt_artists": [],
       "fun_fact": "Toxpack is part of the German rock (Deutschrock) scene; \"Noch einmal so wie früher\" (2022) features on this Deutschrock best-of.",
@@ -2474,7 +2474,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/15187665",
       "uri_deezer": "deezer://track/142393383",
       "alt_artists": [],
       "fun_fact": "Die Toten Hosen is part of the German rock (Deutschrock) scene; \"Tage wie diese\" (2012) features on this Deutschrock best-of.",
@@ -2526,7 +2526,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/453551268",
       "uri_deezer": "deezer://track/3503714961",
       "alt_artists": [],
       "fun_fact": "Frei.Wild is part of the German rock (Deutschrock) scene; \"Für immer untrennbar\" (2025) features on this Deutschrock best-of.",
@@ -2552,7 +2552,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/2040270",
       "uri_deezer": "deezer://track/1272451822",
       "alt_artists": [],
       "fun_fact": "Böhse Onkelz is part of the German rock (Deutschrock) scene; \"Es ist soweit\" (1990) features on this Deutschrock best-of.",
@@ -2578,7 +2578,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/1992589",
       "uri_deezer": "deezer://track/2222140",
       "alt_artists": [],
       "fun_fact": "Dimple Minds is part of the German rock (Deutschrock) scene; \"Durstige Männer\" (1990) features on this Deutschrock best-of.",

--- a/custom_components/beatify/playlists/community/disney-hits-deutschland.json
+++ b/custom_components/beatify/playlists/community/disney-hits-deutschland.json
@@ -1,6 +1,6 @@
 {
   "name": "Disney Hits Deutschland",
-  "version": "0.2",
+  "version": "0.3",
   "tags": [
     "disney",
     "movies",
@@ -1824,7 +1824,7 @@
       },
       "uri_deezer": "deezer://track/138225343",
       "uri_youtube_music": "https://music.youtube.com/watch?v=eoH8Vj7fKXM",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/518749767",
       "fun_fact": "\"Glänzend\" is the German version of \"Shiny,\" the crab Tamatoa's flamboyant villain song from Moana (Vaiana).",
       "fun_fact_de": "\"Glänzend\" ist die deutsche Fassung von \"Shiny\", dem schillernden Bösewicht-Song der Krabbe Tamatoa aus Vaiana.",
       "fun_fact_es": "\"Glänzend\" es la versión alemana de \"Shiny\", la extravagante canción del cangrejo Tamatoa en Vaiana (Moana).",
@@ -1855,7 +1855,7 @@
       },
       "uri_deezer": "deezer://track/595453882",
       "uri_youtube_music": "https://music.youtube.com/watch?v=0X0sLw63KLU",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/34916447",
       "fun_fact": "\"Kingdom Dance\" is an instrumental piece by Alan Menken from Tangled, scoring the lively village dance.",
       "fun_fact_de": "\"Kingdom Dance\" ist ein Instrumentalstück von Alan Menken aus Rapunzel, das den lebhaften Dorftanz untermalt.",
       "fun_fact_es": "\"Kingdom Dance\" es una pieza instrumental de Alan Menken en Enredados, que acompaña el animado baile del pueblo.",


### PR DESCRIPTION
Tidal-Backfill-Welle 22:00 — **erste Welle seit Tagen, die vollständig durchgelaufen ist** (kein Timeout, kein Bergen).

| Playlist | Tidal | version |
|---|---|---|
| `deutschrock-best-of` | 80 → **98 / 100** (+18) | 0.6 → 0.7 |
| `disney-hits-deutschland` | 0 → **2 / 97** (+2) | 0.2 → 0.3 |

Wellen-Bilanz laut Log: **20 Treffer · 1 echter Miss · 59 Rate-Limit-Skips · 177 429-Backoffs**. Die Skips kommen in der 06:00-Welle wieder.

- Rein additiv: 20 × `uri_tidal` + 2 `version`-Bumps, keine anderen Felder.
- `validate_playlists.py` grün (54 Dateien, Schema-Gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)