### PR TITLE
feat(scripts): add --max-minutes wall-clock cap to tidal backfill

### DIFF
--- a/scripts/backfill_tidal.py
+++ b/scripts/backfill_tidal.py
@@ -26,6 +26,7 @@ State file (``scripts/.tidal-backfill-state.json``) maps each Spotify URI to
 Usage:
     python scripts/backfill_tidal.py                 # one wave over all playlists
     python scripts/backfill_tidal.py --max 50        # cap queries this run
+    python scripts/backfill_tidal.py --max-minutes 30  # cap wall-clock this run
     python scripts/backfill_tidal.py PATH.json ...   # only the given playlists
     python scripts/backfill_tidal.py --dry-run       # list what would be queried, no network
     python scripts/backfill_tidal.py --retry-misses  # also re-query recorded misses
@@ -158,6 +159,12 @@ def main() -> int:
         help="cap number of Odesli queries this run (0 = no cap)",
     )
     ap.add_argument(
+        "--max-minutes",
+        type=float,
+        default=0,
+        help="stop the wave after this many minutes of wall-clock (0 = no limit)",
+    )
+    ap.add_argument(
         "--dry-run",
         action="store_true",
         help="list what would be queried, no network/writes",
@@ -213,9 +220,17 @@ def main() -> int:
     hits = misses = skips = 0
     queried = 0
     dirty: set[Path] = set()
+    # Wall-clock deadline. Odesli's 429 backoff makes a wave's *duration* far
+    # less predictable than its query count, and yield is heavily front-loaded:
+    # the tail is mostly backoff with no hits. Stopping on time is safe because
+    # every hit is written out incrementally below.
+    deadline = time.monotonic() + args.max_minutes * 60 if args.max_minutes else None
     for pf, track, sid in todo:
         if args.max and queried >= args.max:
             print(f"reached --max {args.max}, stopping")
+            break
+        if deadline is not None and time.monotonic() >= deadline:
+            print(f"reached --max-minutes {args.max_minutes:g}, stopping")
             break
         queried += 1
         tidal_uri, outcome = query_odesli(sid)


### PR DESCRIPTION
## Warum

Odesli rate-limitet hart. Dadurch ist die **Dauer** einer Backfill-Welle viel schlechter vorhersagbar als ihre Query-Zahl — und der Ertrag ist stark front-lastig.

Die letzten beiden Wellen:

| Welle | Treffer gesamt | davon in den ersten ~25 Min | Restlaufzeit | Backoffs im Rest |
|---|---|---|---|---|
| 2026-07-27 22:00 | 20 | 18 | ~45 Min | ~115 |
| 2026-07-28 06:00 | 18 | 17 | ~40 Min | ~115 |

Der Schwanz der Welle brennt also fast nur noch 429-Backoffs ab, ohne nennenswerte Ausbeute.

## Was

Neuer Flag `--max-minutes` — stoppt die Welle nach Wall-Clock-Zeit, **neben** dem bestehenden `--max`-Query-Deckel; es greift, was zuerst kommt.

- `--max-minutes 0` (default) = altes Verhalten, für Aufrufer die den Flag nicht setzen ändert sich nichts
- Der Abbruch-Check sitzt direkt neben dem `--max`-Check in derselben Schleife

## Warum ein Abbruch mitten in der Welle sicher ist

Jeder Treffer wird **inkrementell** in die Playlist und den Miss-Cache geschrieben, und der `version`-Bump passiert beim ersten Treffer pro Datei. Ein Stopp verliert also nichts.

Das ersetzt zugleich den externen `timeout`-Wrapper, der Wellen per `SIGKILL` beendet hat — samt ihrer Logs. Genau daran sind zwischen dem 26. und 27.07 fünf Wellen in Folge gestorben und mussten von Hand geborgen werden.

## Test

```
$ python3 scripts/backfill_tidal.py --max-minutes 0.02 <eine-playlist>.json
76 track(s) missing Tidal across 1 playlist(s)
  version  disney-hits-deutschland.json: 0.4 -> 0.5
  OK  disney-hits-deutschland.json: Manuel Straube, Pia Allgaier – Endlich sehe ich das Licht -> tidal://track/100106794
reached --max-minutes 0.02, stopping

wave done: 1 added, 0 genuine misses, 0 rate-limit skips (retry next wave). Files updated: 1.
```

Der Treffer aus dem Testlauf wurde verworfen (`git checkout -- custom_components/`) — er wird von der nächsten regulären Welle wieder eingesammelt.

`ruff format --check` sauber. Die zwei `ruff check`-Befunde in dieser Datei (`EXE001`, `SIM113`) bestehen unverändert auch auf `main` und stammen nicht aus diesem PR.

## Folge-Änderung außerhalb dieses Repos

Der Heartbeat-Aufruf in `beatifybot/commands/tidal-backfill/command.md` wird auf `--max 80 --max-minutes 30` umgestellt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)