### PR TITLE
fix(playlists): ersetze 2 tote Apple-Music-URIs in pure-pop-punk

### DIFF
--- a/custom_components/beatify/playlists/community/pure-pop-punk.json
+++ b/custom_components/beatify/playlists/community/pure-pop-punk.json
@@ -1,6 +1,6 @@
 {
   "name": "Pure Pop Punk 🎸",
-  "version": "1.5",
+  "version": "1.6",
   "tags": [
     "2000s",
     "pop-punk",
@@ -1213,7 +1213,7 @@
       "fun_fact_de": "Inspiriert vom PostSecret-Projekt, bei dem Menschen Geheimnisse anonym auf Postkarten teilen. Echte Fan-Postkarten erscheinen im Video.",
       "fun_fact_es": "Inspirada en el proyecto PostSecret donde la gente comparte secretos anónimamente en postales. Postales reales de fans aparecen en el video.",
       "fun_fact_fr": "Inspiré par le projet PostSecret, où des gens partagent leurs secrets de manière anonyme sur des cartes postales. De vraies cartes postales de fans apparaissent dans le clip.",
-      "uri_apple_music": "applemusic://track/1440717129",
+      "uri_apple_music": "applemusic://track/6790495186",
       "uri_youtube_music": "https://music.youtube.com/watch?v=gPDcwjJ8pLg",
       "uri_tidal": "tidal://track/38982811",
       "uri_deezer": "deezer://track/2438121",
@@ -3166,7 +3166,7 @@
       "fun_fact_de": "Die inspirierende Hymne von The All-American Rejects wurde ihr größter Hit und ein Klassiker in Sportarenen und bei Abschlussfeiern.",
       "fun_fact_es": "El himno inspirador de The All-American Rejects se convirtió en su mayor éxito y es esencial en estadios deportivos y ceremonias de graduación.",
       "fun_fact_fr": "L'hymne motivant de The All-American Rejects est devenu leur plus grand hit et un classique des enceintes sportives et des cérémonies de remise de diplômes.",
-      "uri_apple_music": "applemusic://track/1440717253",
+      "uri_apple_music": "applemusic://track/6790495198",
       "uri_youtube_music": "https://music.youtube.com/watch?v=XleOkGsYgO8",
       "uri_tidal": "tidal://track/35711773",
       "uri_deezer": "deezer://track/2438123",


### PR DESCRIPTION
Closes #1914

## Was war kaputt

Der tägliche `playlist-health-check` fand am 28.07 in `community/pure-pop-punk.json` zwei tote Apple-Music-URIs — beide von The All-American Rejects, beide HTTP 404 in US/DE/GB.

Unabhängig gegengeprüft über die iTunes-Lookup-API: beide IDs liefern `resultCount: 0`. Es handelt sich also um echte Katalog-Abgänge, nicht um Validator-Fehlalarme (Remaster-Suffix, Akzent-Abweichung o.ä.).

## Fix

| Track | alt | neu | Album |
|---|---|---|---|
| Dirty Little Secret | `1440717129` | `6790495186` | Move Along (Deluxe Edition) |
| Move Along | `1440717253` | `6790495198` | Move Along (Deluxe Edition) |

Beide Ersatz-IDs **einzeln** in allen drei geprüften Katalogen verifiziert (US, DE, GB je `resultCount: 1`). Bewusst dieselbe Album-Edition für beide, damit die Playlist konsistent bleibt.

## Nicht betroffen

Spotify 100/100 · Deezer 100/100 · Tidal 100/100 · YouTube Music 100/100 — 495 von 497 URIs waren gesund.

`validate_playlists.py` grün (54 Dateien, Schema-Gate bestanden). version 1.5 → 1.6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)