### PR TITLE
fix(health-check): uri_apple_music_by_region pro behaupteter Region prüfen

### DIFF
--- a/.claude/skills/playlist-health-check/scripts/run-health-check.sh
+++ b/.claude/skills/playlist-health-check/scripts/run-health-check.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+set -euo pipefail
+HEALTH_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+STATE="$HEALTH_DIR/rotation-state.json"
+LOG="$HEALTH_DIR/health-check.log"
+REPO_DIR="/tmp/beatify-health-repo"
+
+log() { echo "$(date '+%Y-%m-%d %H:%M:%S') $*" | tee -a "$LOG"; }
+
+[ ! -f "$STATE" ] && echo '{"playlists":[],"last_checked":{},"last_run":null}' > "$STATE"
+
+log "Cloning repo..."
+rm -rf "$REPO_DIR"
+git clone --depth=1 --filter=blob:none --sparse https://github.com/mholzi/beatify.git "$REPO_DIR" -q
+cd "$REPO_DIR" && git sparse-checkout set custom_components/beatify/playlists && git checkout -q
+PLAYLIST_DIR="$REPO_DIR/custom_components/beatify/playlists"
+
+NEXT=$(python3 - "$STATE" "$PLAYLIST_DIR" << 'PYEOF'
+import json, sys
+from pathlib import Path
+with open(sys.argv[1]) as f:
+    state = json.load(f)
+found = sorted([f.name for f in Path(sys.argv[2]).glob("*.json")] +
+               ["community/" + f.name for f in Path(sys.argv[2] + "/community").glob("*.json")])
+for p in found:
+    if p not in state["playlists"]:
+        state["playlists"].append(p)
+with open(sys.argv[1], "w") as f:
+    json.dump(state, f, indent=2)
+checked = state.get("last_checked", {})
+never = [p for p in state["playlists"] if p not in checked]
+print(never[0] if never else sorted(checked.items(), key=lambda x: x[1])[0][0])
+PYEOF
+)
+
+log "Checking: $NEXT"
+
+INPUT="$HEALTH_DIR/validate-input.json"
+OUTPUT="$HEALTH_DIR/validate-output.json"
+
+python3 - "$PLAYLIST_DIR/$NEXT" "$INPUT" << 'PYEOF'
+import json, sys
+with open(sys.argv[1]) as f:
+    data = json.load(f)
+entries = []
+region_maps = []
+for s in data["songs"]:
+    artist, title = s["artist"], s["title"]
+    for field in ["uri", "uri_youtube_music", "uri_tidal", "uri_deezer", "uri_apple_music"]:
+        uri = s.get(field)
+        if uri:
+            entries.append({"uri": uri, "artist": artist, "title": title})
+    # uri_apple_music_by_region is validated separately and in batch — it is
+    # frequently a different id from uri_apple_music, so the per-track pass
+    # above never sees it.
+    regions = s.get("uri_apple_music_by_region")
+    if isinstance(regions, dict) and regions:
+        region_maps.append({"artist": artist, "title": title, "regions": regions})
+with open(sys.argv[2], "w") as f:
+    json.dump({"uris": entries, "region_maps": region_maps}, f)
+claimed = sum(1 for r in region_maps for v in r["regions"].values() if v)
+print(f"  {len(data['songs'])} songs x {len(entries)} URIs total"
+      f" + {claimed} claimed region(s) across {len(region_maps)} track(s)")
+PYEOF
+
+log "Validating URIs (this takes ~7 min for all platforms)..."
+python3 "$HEALTH_DIR/scripts/validate_uris.py" "$INPUT" "$OUTPUT" 2>>"$LOG" || true
+
+SUMMARY=$(python3 -c "
+import json
+with open('$OUTPUT') as f: r = json.load(f)
+s = r['summary']
+print(f\"{s['ok']} ok, {s['dead']} dead, {s.get('wrong_track',0)} wrong track, {s.get('error',0)} error, {s.get('unreachable',0)} unreachable / {s['total']} total\")
+")
+log "Results: $SUMMARY"
+
+REGION_SUMMARY=$(python3 -c "
+import json
+with open('$OUTPUT') as f: r = json.load(f)
+s = r.get('region_summary')
+if not s:
+    print('')
+else:
+    print(f\"{s['ok']} ok, {s['dead']} dead, {s.get('wrong_track',0)} wrong track, {s.get('unfilled',0)} unfilled / {s['total']} claimed — {s.get('tracks_affected',0)} track(s) affected\")
+")
+[ -n "$REGION_SUMMARY" ] && log "Region maps: $REGION_SUMMARY"
+
+TODAY=$(date '+%Y-%m-%d')
+python3 - "$STATE" "$NEXT" "$TODAY" << 'PYEOF'
+import json, sys
+with open(sys.argv[1]) as f:
+    state = json.load(f)
+state["last_checked"][sys.argv[2]] = sys.argv[3]
+state["last_run"] = sys.argv[3]
+with open(sys.argv[1], "w") as f:
+    json.dump(state, f, indent=2)
+PYEOF
+
+ISSUES=$(python3 -c "import json; d=json.load(open('$OUTPUT')); s=d['summary']; print(s['dead'] + s.get('wrong_track',0) + s.get('error',0))")
+if [ "$ISSUES" -gt 0 ]; then
+  log "Found $ISSUES issue(s) — pending AI review before creating GitHub issue."
+else
+  log "All tracks healthy — no issues found."
+fi
+
+log "Done."

--- a/.claude/skills/playlist-health-check/scripts/validate_uris.py
+++ b/.claude/skills/playlist-health-check/scripts/validate_uris.py
@@ -255,6 +255,131 @@ CHECKERS = {
     "apple_music":   check_apple_music,
 }
 
+# ---------------------------------------------------------------------------
+# Region-map validation (uri_apple_music_by_region)
+#
+# check_apple_music above validates the *base* field only, and it accepts a
+# track as healthy as soon as the id resolves in ANY of us/de/gb. Both
+# properties hide a real class of defect:
+#
+#   * 36% of tracks carry a by-region map whose ids differ from the base
+#     field entirely, so the base check never touches them. Aerosmith
+#     "Dream On" had a valid base id while its map pointed at 1885596530,
+#     dead in all nine storefronts checked — and the daily run reported the
+#     playlist as healthy.
+#   * A track present in DE but absent in US/GB passes the base check, so a
+#     map claiming us/gb was never contradicted.
+#
+# This pass resolves every *claimed* region separately. Regions whose map
+# entry is null are not defects — they are simply unfilled (Mode 2 never ran
+# for that track) and are counted apart.
+#
+# Cost is kept low by batching: iTunes' lookup endpoint accepts up to ~40
+# comma-separated ids per call, so a 100-track playlist across 7 regions is
+# ~21 requests rather than 700 sequential ones — cheaper than the per-track
+# pass it complements.
+# ---------------------------------------------------------------------------
+
+REGION_BATCH = 40
+REGION_DELAY = 1.0
+
+
+def _lookup_batch(ids, country):
+    """Resolve a batch of Apple track ids in one storefront.
+
+    Returns (found_map, transient). ``found_map`` maps id -> track dict for
+    everything the storefront knows. ``transient`` is True when the lookup
+    itself failed (throttled/unreachable) — the caller must then not treat
+    any id in the batch as dead.
+    """
+    url = ("https://itunes.apple.com/lookup?id=" + ",".join(ids)
+           + f"&entity=song&country={country}")
+    data, code, is_transient = http_json(url, timeout=25)
+    if data is None:
+        return {}, True if (is_transient or code is None) else False
+    found = {}
+    for t in data.get("results", []):
+        tid = t.get("trackId")
+        if tid is not None:
+            found[str(tid)] = t
+    return found, False
+
+
+def validate_region_maps(entries):
+    """Validate uri_apple_music_by_region entries.
+
+    ``entries`` is a list of dicts:
+        {"artist", "title", "regions": {"us": "applemusic://track/123", ...}}
+
+    Returns {"results": [...], "summary": {...}} where each result is one
+    (track, region) pair that was actually claimed.
+    """
+    results = []
+    summary = {"total": 0, "ok": 0, "dead": 0, "wrong_track": 0,
+               "unfilled": 0, "transient": 0, "tracks_affected": 0}
+
+    # Collect claimed (region -> [(id, entry)]) so each storefront is queried
+    # in as few calls as possible.
+    by_region = {}
+    for e in entries:
+        regions = e.get("regions") or {}
+        for country, uri in regions.items():
+            if not uri:
+                summary["unfilled"] += 1
+                continue
+            provider, tid = detect_provider(uri)
+            if provider != "apple_music":
+                results.append({"artist": e.get("artist"), "title": e.get("title"),
+                                "region": country, "uri": uri, "provider": "apple_music",
+                                "status": "unknown",
+                                "detail": f"Not an Apple Music URI: {uri}"})
+                summary["total"] += 1
+                summary["unknown"] = summary.get("unknown", 0) + 1
+                continue
+            by_region.setdefault(country, []).append((tid, e))
+            summary["total"] += 1
+
+    affected = set()
+    for country in sorted(by_region):
+        pairs = by_region[country]
+        for i in range(0, len(pairs), REGION_BATCH):
+            chunk = pairs[i:i + REGION_BATCH]
+            found, transient = _lookup_batch([tid for tid, _ in chunk], country)
+            for tid, e in chunk:
+                base = {"artist": e.get("artist"), "title": e.get("title"),
+                        "region": country, "uri": f"applemusic://track/{tid}",
+                        "provider": "apple_music"}
+                if transient:
+                    base.update({"status": "unreachable", "transient": True,
+                                 "detail": f"iTunes lookup for storefront {country} "
+                                           f"failed after retries — no verdict"})
+                    summary["transient"] += 1
+                    results.append(base)
+                    continue
+                track = found.get(tid)
+                if track is None:
+                    base.update({"status": "dead", "http_code": 404,
+                                 "detail": f"Claimed for storefront {country}, "
+                                           f"but not in that catalog"})
+                    summary["dead"] += 1
+                    affected.add((e.get("artist"), e.get("title")))
+                elif not titles_match(e.get("title", ""), track.get("trackName", ""),
+                                      e.get("artist", "")):
+                    r = wrong_track(e.get("title", ""), e.get("artist", ""),
+                                    track.get("trackName", ""), track.get("artistName", ""))
+                    base.update(r)
+                    base["detail"] = f"[{country}] " + base.get("detail", "")
+                    summary["wrong_track"] += 1
+                    affected.add((e.get("artist"), e.get("title")))
+                else:
+                    base.update({"status": "ok", "http_code": 200})
+                    summary["ok"] += 1
+                results.append(base)
+            time.sleep(REGION_DELAY)
+
+    summary["tracks_affected"] = len(affected)
+    return {"results": results, "summary": summary}
+
 COOLDOWN = 5.0   # extra pause after a throttled lookup, to let the provider recover
 
 def validate_uris(songs, delay=0.5):
@@ -294,7 +419,17 @@ def validate_uris(songs, delay=0.5):
 if __name__ == "__main__":
     if len(sys.argv) != 3:
         print(f"Usage: {sys.argv[0]} <input.json> <output.json>", file=sys.stderr); sys.exit(1)
-    with open(sys.argv[1]) as f: songs = json.load(f)
+    with open(sys.argv[1]) as f: payload = json.load(f)
+
+    # Input is either the historical flat list of URI entries, or an object
+    # that additionally carries region maps. Both are accepted so an older
+    # runner keeps working against a newer validator.
+    if isinstance(payload, dict):
+        songs = payload.get("uris", [])
+        region_entries = payload.get("region_maps", [])
+    else:
+        songs, region_entries = payload, []
+
     print(f"Validating {len(songs)} URIs (with title matching)...", file=sys.stderr)
     report = validate_uris(songs)
     s = report["summary"]
@@ -305,5 +440,28 @@ if __name__ == "__main__":
         print(f"  WARNING: {s['transient']} lookup(s) were throttled/unavailable even after "
               f"{len(RETRY_BACKOFF) + 1} attempts — those are provider failures, not track "
               f"defects. Re-run to get a verdict on them.", file=sys.stderr)
+
+    rs = {}
+    if region_entries:
+        claimed = sum(1 for e in region_entries
+                      for v in (e.get("regions") or {}).values() if v)
+        print(f"Validating {claimed} claimed region(s) across {len(region_entries)} "
+              f"track(s) (batched)...", file=sys.stderr)
+        region_report = validate_region_maps(region_entries)
+        report["region_results"] = region_report["results"]
+        report["region_summary"] = rs = region_report["summary"]
+        print(f"Region maps: {rs['ok']} ok, {rs['dead']} dead, "
+              f"{rs['wrong_track']} wrong track, {rs['unfilled']} unfilled "
+              f"({rs['tracks_affected']} track(s) affected).", file=sys.stderr)
+        if rs.get("transient"):
+            print(f"  WARNING: {rs['transient']} region lookup(s) had no verdict "
+                  f"(throttled/unreachable) — re-run before acting on them.",
+                  file=sys.stderr)
+
     with open(sys.argv[2], "w") as f: json.dump(report, f, indent=2)
-    sys.exit(1 if (s["dead"] + s["wrong_track"]) > 0 else 0)
+    # Region defects count toward the failure exit code as well — a dead id in
+    # a region map breaks playback for users in that region just as surely as a
+    # dead base URI does.
+    defects = (s["dead"] + s["wrong_track"]
+               + rs.get("dead", 0) + rs.get("wrong_track", 0))
+    sys.exit(1 if defects > 0 else 0)


### PR DESCRIPTION
Closes #1919.

## Problem

Der tägliche URI-Check validierte bei Apple **nur** `uri_apple_music` — und akzeptierte einen Track als gesund, sobald die ID in **irgendeinem** von us/de/gb auflöst. Zwei Folgen, beide an Live-Daten belegt:

- **1733 von 4794 Tracks (36,1 %)** tragen eine Region-Map mit **anderen IDs** als `uri_apple_music`. Der Per-Track-Pass hat sie nie angefasst. **Aerosmith „Dream On"** hatte ein gültiges Basisfeld, während die Map auf `1885596530` zeigte — tot in **allen neun** geprüften Storefronts. Der tägliche Lauf meldete die Playlist trotzdem grün.
- Ein Track, der in DE existiert und in US/GB fehlt, kam durch. Der Lauf vom 29.07. über `polish-all-time-hits` meldete deshalb **2** Defekte, betroffen waren **6** Tracks.

## Änderung

Ein zweiter Pass löst **jede behauptete Region einzeln** auf.

- Regionen, deren Map-Eintrag `null` ist, zählen als **`unfilled`**, nicht als Defekt — dort ist Mode 2 schlicht nie gelaufen (katalogweit 542 Tracks).
- **Gebatcht**: iTunes' `lookup` nimmt ~40 kommagetrennte IDs pro Aufruf. 100 Tracks × 7 Regionen sind damit **~21 Requests statt 700** — billiger als der Per-Track-Pass, den er ergänzt.
- Titel werden auch hier geprüft, ein Regions-Treffer mit falschem Titel wird als `wrong_track` gemeldet.
- Throttling führt zu `unreachable` mit `transient`, **nie** zu `dead` — dieselbe Regel wie im bestehenden Pass.

## Kompatibilität

Das Eingabeformat ist jetzt `{"uris": [...], "region_maps": [...]}`. Eine **flache Liste wird weiterhin akzeptiert**, damit ein älterer Runner gegen einen neueren Validator nicht bricht.

Regions-Defekte zählen in den Exit-Code — eine tote ID in der Region-Map bricht die Wiedergabe für Nutzer dieser Region genauso wie eine tote Basis-URI.

## Verifikation an drei bekannten Tracks

`greatest-hits-of-all-time`, davon einer bewusst als sauberer Kontrollfall:

| Pass | Ergebnis |
|---|---|
| Basisfeld | **3 ok** — blind für den Defekt, wie zuvor |
| Region-Map | **8 ok · 13 dead**, 2 Tracks betroffen |

- **Aerosmith „Dream On"** — tot in allen 7 behaupteten Regionen
- **Queen „Bohemian Rhapsody"** — tot in 6, `us` löst auf
- **ABBA „Dancing Queen"** — sauber in allen Regionen (Kontrolle)

Deckt sich exakt mit der manuellen Messung aus #1919. Alte Eingabeform liefert weiterhin die alte Report-Form und Exit-Code 0.

## Hinweis zum Force-Add

`.claude/` ist per `.gitignore:12` ignoriert; die getrackten Skill-Dateien liegen alle per Force-Add im Index. `run-health-check.sh` war bisher **nicht** getrackt und wird hier mit aufgenommen — ohne die Runner-Änderung bekäme der Validator nie Regions-Daten und die neue Prüfung wäre toter Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)