### PR TITLE
chore(playlists): tidal backfill wave — +19 uris (edm-anthems)

### DIFF
--- a/custom_components/beatify/playlists/community/edm-anthems.json
+++ b/custom_components/beatify/playlists/community/edm-anthems.json
@@ -1,6 +1,6 @@
 {
   "name": "EDM Anthems",
-  "version": "1.5",
+  "version": "1.6",
   "tags": [
     "edm",
     "electronic",
@@ -30,7 +30,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=_mmHxzGjUZQ",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/54504286",
       "uri_deezer": "deezer://track/113876568",
       "fun_fact": "“Lean On” appears on Major Lazer’s release “Peace Is The Mission : Extended”.",
       "fun_fact_de": "„Lean On“ erschien auf der Veröffentlichung „Peace Is The Mission : Extended“ von Major Lazer.",
@@ -60,7 +60,7 @@
         "it": "applemusic://track/6764429254"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=N2pFAltZSGs",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/514601526",
       "uri_deezer": "deezer://track/3951817191",
       "fun_fact": "“RUNWAY” is the title track of Lady Gaga’s release of the same name.",
       "fun_fact_de": "„RUNWAY“ ist der Titelsong der gleichnamigen Veröffentlichung von Lady Gaga.",
@@ -90,7 +90,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=r7zTKRonHXM",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/63232677",
       "uri_deezer": "deezer://track/129310248",
       "fun_fact": "“Closer” appears on The Chainsmokers’s release “Hot Summer Party Mix”.",
       "fun_fact_de": "„Closer“ erschien auf der Veröffentlichung „Hot Summer Party Mix“ von The Chainsmokers.",
@@ -120,7 +120,7 @@
         "it": "applemusic://track/1664553137"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=mVw5KiGwqaQ",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/65931865",
       "uri_deezer": "deezer://track/134527024",
       "fun_fact": "“Rockabye (feat. Sean Paul & Anne-Marie)” appears on Clean Bandit’s release “Maldivas”.",
       "fun_fact_de": "„Rockabye (feat. Sean Paul & Anne-Marie)“ erschien auf der Veröffentlichung „Maldivas“ von Clean Bandit.",
@@ -150,7 +150,7 @@
         "it": "applemusic://track/1108212668"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=inCm3ByI17o",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/59929264",
       "uri_deezer": "deezer://track/123883254",
       "fun_fact": "“This Is What You Came For” is the title track of Calvin Harris’s release of the same name.",
       "fun_fact_de": "„This Is What You Came For“ ist der Titelsong der gleichnamigen Veröffentlichung von Calvin Harris.",
@@ -180,7 +180,7 @@
         "it": "applemusic://track/1115396158"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=OBs1Fb8adGQ",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/189604699",
       "uri_deezer": "deezer://track/125244224",
       "fun_fact": "“Alone” appears on Marshmello’s release “Monstercat - Best of 2016”.",
       "fun_fact_de": "„Alone“ erschien auf der Veröffentlichung „Monstercat - Best of 2016“ von Marshmello.",
@@ -210,7 +210,7 @@
         "it": "applemusic://track/1645408287"
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/22120602",
       "uri_deezer": "deezer://track/3092872331",
       "fun_fact": "“Wake Me Up - Radio Edit” appears on Avicii’s release “Transports en commun”.",
       "fun_fact_de": "„Wake Me Up - Radio Edit“ erschien auf der Veröffentlichung „Transports en commun“ von Avicii.",
@@ -240,7 +240,7 @@
         "it": "applemusic://track/1793441759"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=owTWCbq_nSk",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/70748216",
       "uri_deezer": null,
       "fun_fact": "“Something Just Like This” is the title track of The Chainsmokers’s release of the same name.",
       "fun_fact_de": "„Something Just Like This“ ist der Titelsong der gleichnamigen Veröffentlichung von The Chainsmokers.",
@@ -270,7 +270,7 @@
         "it": "applemusic://track/1692242948"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=DcDbKDAb7go",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/53893676",
       "uri_deezer": "deezer://track/112662364",
       "fun_fact": "“What Do You Mean?” appears on Justin Bieber’s release “Sport Music 2021”.",
       "fun_fact_de": "„What Do You Mean?“ erschien auf der Veröffentlichung „Sport Music 2021“ von Justin Bieber.",
@@ -300,7 +300,7 @@
         "it": "applemusic://track/1805559510"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=LRPGqNeav_M",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/18420572",
       "uri_deezer": "deezer://track/62847142",
       "fun_fact": "“Titanium (feat. Sia)” appears on David Guetta’s release “Nothing but the Beat Ultimate”.",
       "fun_fact_de": "„Titanium (feat. Sia)“ erschien auf der Veröffentlichung „Nothing but the Beat Ultimate“ von David Guetta.",
@@ -330,7 +330,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/275664235",
       "uri_deezer": null,
       "fun_fact": "“Animals” is the title track of Martin Garrix’s release of the same name.",
       "fun_fact_de": "„Animals“ ist der Titelsong der gleichnamigen Veröffentlichung von Martin Garrix.",
@@ -360,7 +360,7 @@
         "it": "applemusic://track/1859073443"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=Ah0srVZq9ac",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/60269439",
       "uri_deezer": "deezer://track/124550860",
       "fun_fact": "“I Took A Pill In Ibiza - Seeb Remix” is the title track of Mike Posner’s release of the same name.",
       "fun_fact_de": "„I Took A Pill In Ibiza - Seeb Remix“ ist der Titelsong der gleichnamigen Veröffentlichung von Mike Posner.",
@@ -390,7 +390,7 @@
         "it": "applemusic://track/1743042654"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=KSgKKSny0Qo",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/37218619",
       "uri_deezer": "deezer://track/88936747",
       "fun_fact": "“Summer” appears on Calvin Harris’s release “Motion”.",
       "fun_fact_de": "„Summer“ erschien auf der Veröffentlichung „Motion“ von Calvin Harris.",
@@ -420,7 +420,7 @@
         "it": "applemusic://track/1614614520"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=Hsz6hL_a69Q",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/37870598",
       "uri_deezer": "deezer://track/90250621",
       "fun_fact": "“Hey Mama (feat. Nicki Minaj, Bebe Rexha & Afrojack)” appears on David Guetta’s release “Listen”.",
       "fun_fact_de": "„Hey Mama (feat. Nicki Minaj, Bebe Rexha & Afrojack)“ erschien auf der Veröffentlichung „Listen“ von David Guetta.",
@@ -450,7 +450,7 @@
         "it": "applemusic://track/1445141168"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=aZwklvDdaVw",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/70040624",
       "uri_deezer": "deezer://track/141822951",
       "fun_fact": "“Alone” is the title track of Alan Walker’s release of the same name.",
       "fun_fact_de": "„Alone“ ist der Titelsong der gleichnamigen Veröffentlichung von Alan Walker.",
@@ -480,7 +480,7 @@
         "it": "applemusic://track/1711849667"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=kfCTO9PPtVo",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/314738807",
       "uri_deezer": "deezer://track/2441318935",
       "fun_fact": "“Happier” is the title track of Marshmello’s release of the same name.",
       "fun_fact_de": "„Happier“ ist der Titelsong der gleichnamigen Veröffentlichung von Marshmello.",
@@ -510,7 +510,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=E2lX1ZovtcA",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/6858003",
       "uri_deezer": "deezer://track/10308117",
       "fun_fact": "“Give Me Everything (feat. Nayer)” appears on Pitbull’s release “Planet Pit (Deluxe Version)”.",
       "fun_fact_de": "„Give Me Everything (feat. Nayer)“ erschien auf der Veröffentlichung „Planet Pit (Deluxe Version)“ von Pitbull.",
@@ -540,7 +540,7 @@
         "it": "applemusic://track/1068554525"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=vkX6yFVFRYY",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/42697180",
       "uri_deezer": "deezer://track/95963378",
       "fun_fact": "“Where Are Ü Now (with Justin Bieber)” appears on Jack Ü’s release “Skrillex and Diplo present Jack Ü”.",
       "fun_fact_de": "„Where Are Ü Now (with Justin Bieber)“ erschien auf der Veröffentlichung „Skrillex and Diplo present Jack Ü“ von Jack Ü.",
@@ -570,7 +570,7 @@
         "it": "applemusic://track/1869661185"
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/233788675",
       "uri_deezer": "deezer://track/2522607221",
       "fun_fact": "“Spectre” appears on Alan Walker’s release “Origins”.",
       "fun_fact_de": "„Spectre“ erschien auf der Veröffentlichung „Origins“ von Alan Walker.",


### PR DESCRIPTION
## Tidal-Backfill-Welle 18:00 (29.07)

**+19 Tidal-URIs**, eine Playlist.

| Playlist | Tidal vorher | Tidal nachher | version |
|---|---|---|---|
| `edm-anthems` | 0/190 | **19/190** | 1.5 → 1.6 |

Erster Tidal-Kontakt dieser Playlist.

**Wellen-Bilanz:** 19 Treffer · **0 echte Misses** · 30 Rate-Limit-Skips · 90 429-Backoffs. Beendet vom `--max-minutes 30`-Deckel — die fünfte gedeckelte Welle in Folge mit 17–19 Treffern.

Miss-Cache 716 → 735. `validate_playlists.py` grün (54 Dateien).

### Warum nicht `divorced-dad-rock`

Schritt 0 der command.md fand keinen offenen **Tidal**-PR, aber ein Trockenlauf zeigte **24 der nächsten 90 Kandidaten in `divorced-dad-rock.json`** — eine der 9 Dateien, die der offene [PR #1924](https://github.com/mholzi/beatify/pull/1924) anfasst. Beide hätten die `version`-Zeile derselben Datei geändert, ein Konflikt wäre sicher gewesen.

Deshalb liefen nur 45 der 54 Playlists als Argumente. Kein Ertragsverlust — die Welle zog stattdessen auf `edm-anthems`. `divorced-dad-rock` kommt nach dem #1924-Merge automatisch wieder dran.

Das verallgemeinert sich: Schritt 0 prüft bisher nur auf offene *Tidal*-PRs, der Grund gilt aber für **jeden** PR, der Playlist-Dateien anfasst.

Provider-Stand von `edm-anthems`: Spotify 190/190 · Deezer 175/190 · Apple 135/190 · YouTube 125/190 · **Tidal 19/190**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)