### PR TITLE
fix(auth): roll the refresh cookie on every successful refresh (#1932)

### DIFF
--- a/custom_components/beatify/server/views.py
+++ b/custom_components/beatify/server/views.py
@@ -216,6 +216,14 @@ _REFRESH_COOKIE = "beatify_refresh"
 # refresh tokens are long-lived. 30 days lines up with HA's own refresh-
 # token rotation window and means a user who hits the admin once a month
 # never has to re-do the full OAuth dance.
+#
+# #1932: this is 30 days of INACTIVITY, not 30 days of existence. The
+# callback sets the cookie and every successful /beatify/auth/refresh
+# re-issues it with a fresh Max-Age, so the clock restarts on each use.
+# Before that, the cookie died 30 days after the FIRST login no matter how
+# often the user came back — which is the opposite of what the paragraph
+# above promises, and put every install on a 30-day fuse back through the
+# full OAuth round trip.
 _REFRESH_COOKIE_MAX_AGE = 30 * 24 * 60 * 60
 
 
@@ -457,10 +465,7 @@ class BeatifyAuthRefreshView(HomeAssistantView):
             return response
 
         # #1369: the fresh access token is returned ONLY in the JSON body —
-        # the frontend caches it in memory, never in a cookie. HA's
-        # refresh-token grant does NOT return a new refresh_token (the
-        # long-lived one stays in the HttpOnly cookie), so no Set-Cookie is
-        # needed here beyond wiping any legacy JS-readable access cookie.
+        # the frontend caches it in memory, never in a cookie.
         response = web.json_response(
             {
                 "access_token": parsed["access_token"],
@@ -471,8 +476,13 @@ class BeatifyAuthRefreshView(HomeAssistantView):
         _set_session_cookies(
             response,
             request,
-            # Don't overwrite the long-lived refresh cookie.
-            refresh_token=None,
+            # #1932: roll the refresh cookie. HA's refresh-token grant does not
+            # mint a new refresh_token, so this re-issues the SAME value the
+            # request arrived with — the point is the fresh Max-Age. Without it
+            # the cookie expired 30 days after the first login however active
+            # the user was, and the next page load fell all the way back to the
+            # /auth/authorize round trip.
+            refresh_token=refresh_token,
         )
         return response
 

--- a/tests/unit/test_auth_refresh_view.py
+++ b/tests/unit/test_auth_refresh_view.py
@@ -108,10 +108,14 @@ class TestBeatifyAuthRefreshView:
         if access is not None:
             assert "refreshed-access" not in access.value
             assert str(access["max-age"]) == "0"
-        # The refresh cookie is NOT touched — HA's refresh grant doesn't
-        # return a new refresh_token, so we leave the existing long-lived
-        # one in place.
-        assert "beatify_refresh" not in resp.cookies
+        # #1932: the refresh cookie IS re-issued — same value (HA's refresh
+        # grant mints no new refresh_token), fresh Max-Age. Before this the
+        # cookie kept the expiry it got at first login, so an active user was
+        # still thrown back into the full OAuth flow on day 30.
+        refresh = resp.cookies.get("beatify_refresh")
+        assert refresh is not None
+        assert refresh.value == "stored-refresh"
+        assert refresh["max-age"] == str(30 * 24 * 60 * 60)
 
     @pytest.mark.asyncio
     async def test_ha_rejects_refresh_token_clears_cookies_returns_401(self):
@@ -156,3 +160,83 @@ class TestBeatifyAuthRefreshView:
         # client_id must match what the frontend used at /auth/authorize —
         # origin + "/beatify/". For this test request, origin is the host.
         assert "client_id=http%3A%2F%2Fha.local%3A8123%2Fbeatify%2F" in body
+
+    @pytest.mark.asyncio
+    async def test_rolled_cookie_keeps_security_attributes(self):
+        """#1932: rolling must not quietly downgrade the cookie.
+
+        The re-issued cookie has to keep HttpOnly, Path=/beatify and
+        SameSite=Lax — the attributes that stop JS from reading it and stop it
+        from riding along on non-Beatify requests.
+        """
+        view = BeatifyAuthRefreshView(_hass())
+        mock_session = MagicMock()
+        mock_session.post = MagicMock(
+            return_value=_MockResponseCtx(
+                status=200, text='{"access_token":"x","expires_in":1800}'
+            )
+        )
+
+        with patch(
+            "custom_components.beatify.server.views.async_get_clientsession",
+            return_value=mock_session,
+        ):
+            resp = await view.get(_request())
+
+        refresh = resp.cookies["beatify_refresh"]
+        assert refresh["httponly"]
+        assert refresh["path"] == "/beatify"
+        assert refresh["samesite"] == "Lax"
+
+    @pytest.mark.asyncio
+    async def test_rolled_cookie_is_secure_only_over_https(self):
+        """#1932: the roll must follow the same Secure rule as the callback —
+        Secure on an HTTPS origin (Nabu Casa), not on plain-HTTP LAN access
+        where the browser would then refuse to store it at all.
+        """
+        view = BeatifyAuthRefreshView(_hass())
+        mock_session = MagicMock()
+        mock_session.post = MagicMock(
+            return_value=_MockResponseCtx(
+                status=200, text='{"access_token":"x","expires_in":1800}'
+            )
+        )
+
+        with patch(
+            "custom_components.beatify.server.views.async_get_clientsession",
+            return_value=mock_session,
+        ):
+            plain = await view.get(_request())
+            tls = await view.get(
+                _request(
+                    headers={
+                        "Host": "abc.ui.nabu.casa",
+                        "X-Forwarded-Proto": "https",
+                        "X-Forwarded-Host": "abc.ui.nabu.casa",
+                    }
+                )
+            )
+
+        assert not plain.cookies["beatify_refresh"]["secure"]
+        assert tls.cookies["beatify_refresh"]["secure"]
+
+    @pytest.mark.asyncio
+    async def test_failed_refresh_still_wipes_instead_of_rolling(self):
+        """A rejected refresh token must be cleared, never re-issued with a
+        fresh 30 days — otherwise a dead session would be kept alive on disk.
+        """
+        view = BeatifyAuthRefreshView(_hass())
+        mock_session = MagicMock()
+        mock_session.post = MagicMock(
+            return_value=_MockResponseCtx(status=400, text='{"error":"invalid_grant"}')
+        )
+
+        with patch(
+            "custom_components.beatify.server.views.async_get_clientsession",
+            return_value=mock_session,
+        ):
+            resp = await view.get(_request())
+
+        assert resp.status == 401
+        assert resp.cookies["beatify_refresh"]["max-age"] == "0"
+        assert resp.cookies["beatify_refresh"].value != "stored-refresh"


### PR DESCRIPTION
Fixes #1932.

## The bug

`beatify_refresh` was written **only** by the OAuth callback, with a fixed 30-day `Max-Age`, and the refresh endpoint explicitly declined to re-issue it:

```python
_set_session_cookies(
    response,
    request,
    # Don't overwrite the long-lived refresh cookie.
    refresh_token=None,
)
```

So the cookie expired 30 days after the **first** login, however active the user was:

- day 0 — callback sets the cookie, `Max-Age=2592000`
- day 20 — user opens the admin, `/beatify/auth/refresh` succeeds, no `Set-Cookie`; the cookie still dies on day 30
- day 31 — `401 no_refresh_token`, full `/auth/authorize` round trip required again

That is the opposite of what the constant's own comment promises ("a user who hits the admin once a month never has to re-do the full OAuth dance").

## The change

The refresh endpoint now re-issues the cookie it was handed. HA's refresh-token grant mints no new refresh token, so the **value is unchanged** — the point of the write is the fresh `Max-Age`. The 30 days now measure inactivity rather than existence.

A rejected refresh still goes through `_clear_session_cookies()`, so a dead session is wiped rather than kept alive for another 30 days.

## Trade-off worth naming

Rolling means a refresh cookie that keeps getting used stays valid indefinitely, instead of forcing a re-auth once a month. That is the intended behaviour (and matches how the underlying HA refresh token already behaves — HA does not expire it either, it prunes tokens that go unused), but it is a real change in exposure window: a stolen cookie now survives as long as it is exercised. Mitigations are unchanged and still in place — `HttpOnly` (JS cannot read it, so an XSS on a /beatify page cannot exfiltrate it), `Path=/beatify` (never rides along on other HA requests), `SameSite=Lax`, and `Secure` on HTTPS origins. Revoking the refresh token in HA still kills the session on the next refresh.

## Not in this PR

Whether an expired or wiped session should surface anything to the user. Today it is silent until the next gated call fails with a raw `Unauthorized` — which is what made #1931 hard to read. Related: #1933.

## Tests

- The existing `test_successful_refresh_returns_json_and_updates_access_cookie` asserted `"beatify_refresh" not in resp.cookies` — it encoded the bug, so it now asserts the roll (same value, fresh `Max-Age`).
- New: security attributes survive the roll (`HttpOnly` / `Path=/beatify` / `SameSite=Lax`).
- New: `Secure` tracks the origin scheme, so plain-HTTP LAN access still stores the cookie while Nabu Casa gets `Secure` — a blanket `Secure` here would have silently broken every LAN install.
- New: a failed refresh wipes instead of rolling.
- Full Python suite: **1550 passed, 2 skipped**, run locally. `ruff check` and `ruff format --check` clean.
