### PR TITLE
fix(auth): translate the terminal auth-error screen (#1933)

### DIFF
--- a/custom_components/beatify/www/i18n/de.json
+++ b/custom_components/beatify/www/i18n/de.json
@@ -1355,5 +1355,10 @@
   "starting": {
     "headline": "Gleich geht's los!",
     "sub": "Wir verbinden den Lautsprecher und laden die erste Runde. Schnappt euch schon mal eure Buzzer."
+  },
+  "auth": {
+    "errorTitle": "Anmeldung fehlgeschlagen",
+    "errorBody": "Beatify konnte keine Verbindung zu Home Assistant herstellen. Bitte prüfe die Beatify-Konfiguration (interne URL / SSL) und versuche es erneut.",
+    "errorRetry": "Erneut versuchen"
   }
 }

--- a/custom_components/beatify/www/i18n/en.json
+++ b/custom_components/beatify/www/i18n/en.json
@@ -1355,5 +1355,10 @@
   "starting": {
     "headline": "Here we go!",
     "sub": "Connecting the speaker and loading round one. Grab your buzzer."
+  },
+  "auth": {
+    "errorTitle": "Sign-in failed",
+    "errorBody": "Beatify could not connect to Home Assistant. Please check the Beatify configuration (internal URL / SSL) and try again.",
+    "errorRetry": "Try again"
   }
 }

--- a/custom_components/beatify/www/i18n/es.json
+++ b/custom_components/beatify/www/i18n/es.json
@@ -1355,5 +1355,10 @@
   "starting": {
     "headline": "¡Ya empezamos!",
     "sub": "Conectando el altavoz y cargando la primera ronda. Preparad vuestros pulsadores."
+  },
+  "auth": {
+    "errorTitle": "Error al iniciar sesión",
+    "errorBody": "Beatify no pudo conectarse a Home Assistant. Comprueba la configuración de Beatify (URL interna / SSL) e inténtalo de nuevo.",
+    "errorRetry": "Inténtalo de nuevo"
   }
 }

--- a/custom_components/beatify/www/i18n/fr.json
+++ b/custom_components/beatify/www/i18n/fr.json
@@ -1355,5 +1355,10 @@
   "starting": {
     "headline": "C'est parti !",
     "sub": "Connexion de l'enceinte et chargement de la première manche. Préparez vos buzzers."
+  },
+  "auth": {
+    "errorTitle": "Échec de la connexion",
+    "errorBody": "Beatify n'a pas pu se connecter à Home Assistant. Vérifie la configuration de Beatify (URL interne / SSL) et réessaie.",
+    "errorRetry": "Réessayer"
   }
 }

--- a/custom_components/beatify/www/i18n/nl.json
+++ b/custom_components/beatify/www/i18n/nl.json
@@ -1355,5 +1355,10 @@
   "starting": {
     "headline": "Daar gaan we!",
     "sub": "We verbinden de speaker en laden ronde één. Pak alvast je buzzer."
+  },
+  "auth": {
+    "errorTitle": "Aanmelden mislukt",
+    "errorBody": "Beatify kon geen verbinding maken met Home Assistant. Controleer de Beatify-configuratie (interne URL / SSL) en probeer het opnieuw.",
+    "errorRetry": "Opnieuw proberen"
   }
 }

--- a/custom_components/beatify/www/js/__tests__/ha-auth.test.js
+++ b/custom_components/beatify/www/js/__tests__/ha-auth.test.js
@@ -57,36 +57,37 @@ function loadHaAuth({
     // Only created when withDomBody is set; otherwise document has no body and
     // _renderAuthError() short-circuits (matching a not-yet-painted page).
     let bodyShim = null;
-    if (withDomBody) {
-        const makeEl = () => {
-            const el = {
-                style: { cssText: '' },
-                children: [],
-                _listeners: {},
-                setAttribute() {},
-                set innerHTML(html) { this._html = html; },
-                get innerHTML() { return this._html || ''; },
-                appendChild(c) { this.children.push(c); return c; },
-                addEventListener(ev, fn) { this._listeners[ev] = fn; },
-                querySelector() { return makeEl(); },
-            };
-            return el;
+    // #1933: the shim now tracks children + textContent so a test can read
+    // what the auth-error card actually renders. Previously createElement()
+    // returned a throwaway whose appendChild() dropped the node, which was
+    // enough to prove "does not crash" but could not see the strings.
+    const makeEl = (tag) => {
+        const el = {
+            tagName: (tag || 'div').toUpperCase(),
+            style: { cssText: '' },
+            children: [],
+            textContent: '',
+            id: '',
+            type: '',
+            _attrs: {},
+            _listeners: {},
+            setAttribute(k, v) { this._attrs[k] = v; },
+            getAttribute(k) { return this._attrs[k]; },
+            set innerHTML(html) { this._html = html; },
+            get innerHTML() { return this._html || ''; },
+            appendChild(c) { this.children.push(c); return c; },
+            addEventListener(ev, fn) { this._listeners[ev] = fn; },
+            querySelector() { return makeEl(); },
         };
+        return el;
+    };
+    if (withDomBody) {
         bodyShim = makeEl();
     }
     const documentShim = {
         title: 'test',
         body: bodyShim,
-        createElement: bodyShim ? () => ({
-            style: { cssText: '' },
-            _listeners: {},
-            id: '',
-            setAttribute() {},
-            set innerHTML(html) { this._html = html; },
-            get innerHTML() { return this._html || ''; },
-            appendChild() {},
-            querySelector() { return { addEventListener: () => {} }; },
-        }) : undefined,
+        createElement: bodyShim ? (tag) => makeEl(tag) : undefined,
         get cookie() { return cookieJar.value; },
         set cookie(v) {
             const name = v.split('=')[0];
@@ -832,5 +833,98 @@ describe('login() OAuth redirect', () => {
         expect(url).toContain(
             'client_id=' + encodeURIComponent('https://ha.example/beatify/')
         );
+    });
+});
+
+describe('auth-error screen is translated, not hardcoded German (#1933)', () => {
+    const K = 'beatify_login_attempts';
+
+    /** Render the terminal auth-error card by exhausting the login budget. */
+    async function renderErrorCard(i18n) {
+        const ctx = loadHaAuth({
+            fetchFn: async () => ({ ok: false, status: 401, json: async () => ({}) }),
+            sessionStorageData: { [K]: '3' }, // budget already spent
+            withDomBody: true,
+        });
+        if (i18n) ctx.sandboxWindow.BeatifyI18n = i18n;
+        await ctx.BeatifyAuth.init({ requireAuth: true });
+        return ctx.bodyShim.children[0];
+    }
+
+    /** Flatten every textContent in the rendered subtree. */
+    function texts(node, out = []) {
+        if (!node) return out;
+        if (node.textContent) out.push(node.textContent);
+        (node.children || []).forEach((c) => texts(c, out));
+        return out;
+    }
+
+    it('falls back to English when i18n is not loaded at all', async () => {
+        // ha-auth.js is deliberately loaded ahead of the rest of the admin
+        // bundle, so the card can render before BeatifyI18n exists.
+        const card = await renderErrorCard(null);
+        const all = texts(card).join(' | ');
+
+        expect(all).toContain('Sign-in failed');
+        expect(all).toContain('Try again');
+        expect(all).not.toContain('Anmeldung fehlgeschlagen');
+        expect(all).not.toContain('Erneut versuchen');
+    });
+
+    it('uses the translations when i18n is available', async () => {
+        const card = await renderErrorCard({
+            t: (key) => ({
+                'auth.errorTitle': 'Aanmelden mislukt',
+                'auth.errorBody': 'Beatify kon geen verbinding maken.',
+                'auth.errorRetry': 'Opnieuw proberen',
+            }[key] || key),
+        });
+        const all = texts(card).join(' | ');
+
+        expect(all).toContain('Aanmelden mislukt');
+        expect(all).toContain('Opnieuw proberen');
+    });
+
+    it('falls back to English when t() echoes the key back (missing entry)', async () => {
+        // BeatifyI18n.t() returns the KEY itself for an unknown key — rendering
+        // that verbatim would put "auth.errorTitle" on a full-screen overlay.
+        const card = await renderErrorCard({ t: (key) => key });
+        const all = texts(card).join(' | ');
+
+        expect(all).toContain('Sign-in failed');
+        expect(all).not.toContain('auth.errorTitle');
+        expect(all).not.toContain('auth.errorRetry');
+    });
+
+    it('never interprets a translation as markup', async () => {
+        // Built with textContent, so a locale string containing tags stays
+        // inert text instead of becoming DOM.
+        const card = await renderErrorCard({
+            t: (key) =>
+                key === 'auth.errorTitle' ? '<img src=x onerror=1>' : key,
+        });
+        const all = texts(card).join(' | ');
+
+        expect(all).toContain('<img src=x onerror=1>');
+        expect(card.innerHTML).toBe('');
+    });
+
+    it('still offers a working retry that clears the attempt counter', async () => {
+        const ctx = loadHaAuth({
+            fetchFn: async () => ({ ok: false, status: 401, json: async () => ({}) }),
+            sessionStorageData: { [K]: '3' },
+            withDomBody: true,
+        });
+        await ctx.BeatifyAuth.init({ requireAuth: true });
+
+        const card = ctx.bodyShim.children[0];
+        const button = card.children[0].children.find((c) => c.tagName === 'BUTTON');
+        expect(button).toBeTruthy();
+        expect(ctx.sessionStorage.getItem(K)).toBe('3');
+
+        button._listeners.click();
+
+        expect(ctx.sessionStorage.getItem(K)).toBeNull();
+        expect(ctx.sandboxWindow.location._lastReplace).toContain('/auth/authorize');
     });
 });

--- a/custom_components/beatify/www/js/ha-auth.js
+++ b/custom_components/beatify/www/js/ha-auth.js
@@ -547,10 +547,36 @@
   }
 
   /**
+   * Translate a key with an English literal as the fallback (#1933).
+   *
+   * `BeatifyI18n.t()` returns the KEY itself when a translation is missing, and
+   * on this screen it may not be loaded at all — the auth error can render
+   * before the locale fetch resolves, and ha-auth.js is deliberately loaded
+   * ahead of the rest of the admin bundle. Both cases must degrade to readable
+   * English, never to a raw key like `auth.errorTitle`.
+   */
+  function _t(key, fallback) {
+    try {
+      if (typeof window === 'undefined' || !window.BeatifyI18n) return fallback;
+      var value = window.BeatifyI18n.t(key);
+      return !value || value === key ? fallback : value;
+    } catch (e) {
+      return fallback;
+    }
+  }
+
+  /**
    * Render a terminal auth-error state into the page instead of redirecting
    * again. Called once the bounded retry budget is exhausted (#1394) so a
    * persistently-failing server-side OAuth exchange stops the redirect loop
    * and shows the user what happened.
+   *
+   * #1933: the strings used to be hardcoded German. This is the one screen a
+   * user in a broken auth state is guaranteed to reach, it covers the whole
+   * viewport, and a reporter who cannot read it describes the symptom in their
+   * own words instead of quoting it — which is exactly what made #1931 hard to
+   * triage. Built with textContent rather than innerHTML so a translation can
+   * never inject markup.
    */
   function _renderAuthError() {
     try {
@@ -570,23 +596,37 @@
         'align-items:center;justify-content:center;padding:24px;' +
         'background:#1c1c1e;color:#fff;font:16px/1.5 system-ui,sans-serif;' +
         'text-align:center;';
-      box.innerHTML =
-        '<div style="max-width:420px">' +
-        '<h2 style="margin:0 0 12px">Anmeldung fehlgeschlagen</h2>' +
-        '<p style="margin:0 0 20px;opacity:.85">Die Verbindung zu Home ' +
-        'Assistant konnte nicht hergestellt werden. Bitte pr&uuml;fe die ' +
-        'Beatify-Konfiguration (interne URL / SSL) und versuche es erneut.</p>' +
-        '<button type="button" style="padding:10px 20px;border:0;' +
-        'border-radius:8px;background:#0a84ff;color:#fff;font-size:16px;' +
-        'cursor:pointer">Erneut versuchen</button>' +
-        '</div>';
-      var btn = box.querySelector('button');
-      if (btn) {
-        btn.addEventListener('click', function () {
-          _clearLoginAttempts();
-          login();
-        });
-      }
+
+      var inner = document.createElement('div');
+      inner.style.cssText = 'max-width:420px';
+
+      var heading = document.createElement('h2');
+      heading.style.cssText = 'margin:0 0 12px';
+      heading.textContent = _t('auth.errorTitle', 'Sign-in failed');
+
+      var body = document.createElement('p');
+      body.style.cssText = 'margin:0 0 20px;opacity:.85';
+      body.textContent = _t(
+        'auth.errorBody',
+        'Beatify could not connect to Home Assistant. Please check the ' +
+          'Beatify configuration (internal URL / SSL) and try again.'
+      );
+
+      var btn = document.createElement('button');
+      btn.type = 'button';
+      btn.style.cssText =
+        'padding:10px 20px;border:0;border-radius:8px;background:#0a84ff;' +
+        'color:#fff;font-size:16px;cursor:pointer';
+      btn.textContent = _t('auth.errorRetry', 'Try again');
+      btn.addEventListener('click', function () {
+        _clearLoginAttempts();
+        login();
+      });
+
+      inner.appendChild(heading);
+      inner.appendChild(body);
+      inner.appendChild(btn);
+      box.appendChild(inner);
       document.body.appendChild(box);
     } catch (e) {
       /* ignore — error UI is best-effort */


### PR DESCRIPTION
Fixes #1933.

## The bug

`_renderAuthError()` — the full-screen card that replaces the login loop once `MAX_LOGIN_ATTEMPTS` is spent — had its three strings hardcoded in German and injected as `innerHTML`:

```js
'<h2 style="margin:0 0 12px">Anmeldung fehlgeschlagen</h2>' +
'<p ...>Die Verbindung zu Home Assistant konnte nicht hergestellt werden. ...</p>' +
'<button ...>Erneut versuchen</button>'
```

The rest of the admin UI is translated into five languages, so this was the odd one out — and it is the one screen a user in a broken auth state is guaranteed to reach, covering the whole viewport with `position:fixed;inset:0`.

## The change

- New `auth.errorTitle` / `auth.errorBody` / `auth.errorRetry` keys in **en / de / nl / es / fr**. English is the fallback, matching the rest of the codebase, instead of German being the de-facto default for this one screen.
- New `_t(key, fallback)` helper that degrades to the English literal in both failure modes that actually apply here:
  - **BeatifyI18n not loaded yet.** `ha-auth.js` is deliberately loaded ahead of the admin bundle, and this card can render before the locale fetch resolves.
  - **`t()` echoes the key back.** That is what `BeatifyI18n.t()` does for a missing entry — and `auth.errorTitle` rendered verbatim on a full-screen overlay would be worse than the German it replaces.
- Built with `createElement` + `textContent` instead of `innerHTML`, so a locale string can never inject markup. This also drops the `&uuml;` entity workaround.

## Test-harness note

The DOM shim in `ha-auth.test.js` previously had `createElement()` return a throwaway whose `appendChild()` dropped the node. That was enough for the existing #1394 tests ("does not crash, does not redirect") but blind to what the card actually renders. It now tracks `children` and `textContent`, which is what makes the assertions below possible. The three existing tests that use `withDomBody` are unaffected.

## Tests

5 new cases:

- English fallback when i18n is absent entirely — and specifically **not** the old German strings.
- Translations are used when `BeatifyI18n` is present.
- English fallback when `t()` echoes the key back, asserting no raw `auth.errorTitle` reaches the screen.
- A translation containing `<img src=x onerror=1>` stays inert text; the container's `innerHTML` is never written.
- The retry button still clears the attempt counter and restarts the OAuth flow — the behaviour that makes this screen recoverable rather than terminal.

Full JS suite **569 passed** (59 files), Python **1550 passed / 2 skipped**, eslint clean, all five locale files parse. `ha-auth.js` is served unminified, so no bundle rebuild is involved.

## Not in this PR

The issue also flags that the body copy ("check the Beatify configuration (internal URL / SSL)") is guidance for a self-hosting admin rather than for a household member who just opened the app. The English text here is a faithful translation of what was there; rewording it is a product decision, not a translation one.
