### PR TITLE
fix(playback): survive a rate-limiting provider instead of pausing the game (#1936)

### DIFF
--- a/custom_components/beatify/const.py
+++ b/custom_components/beatify/const.py
@@ -17,6 +17,14 @@ DEFAULT_ROUND_DURATION = 45  # seconds
 ROUND_DURATION_MIN = 15  # seconds (Story 13.1)
 ROUND_DURATION_MAX = 60  # seconds (Story 13.1)
 
+# #1936: how many playback timeouts IN A ROW count as a systemic failure that
+# pauses the game. Below this, a timeout skips the song and play continues —
+# a rate-limiting provider (Music Assistant's Apple Music backs off ~15.7s,
+# longer than our own deadline) is not a broken one, and pausing on the first
+# timeout ended whole games over it. A genuinely offline speaker still reaches
+# the recovery banner, just a few songs later.
+MAX_CONSECUTIVE_PLAYBACK_FAILURES = 3
+
 # Server-side round backstop (#1865). A periodic tick ends a round whose
 # deadline passed while the phase is still PLAYING, so the game does not depend
 # on the per-round timer task surviving or on a client's countdown nudging it.

--- a/custom_components/beatify/game/state_lifecycle.py
+++ b/custom_components/beatify/game/state_lifecycle.py
@@ -97,6 +97,7 @@ import logging
 from custom_components.beatify.const import (
     ERR_GAME_ALREADY_STARTED,
     ERR_GAME_NOT_STARTED,
+    MAX_CONSECUTIVE_PLAYBACK_FAILURES,
     MIN_PLAYERS,
 )
 
@@ -331,6 +332,48 @@ class RoundLifecycleMixin:
                     await asyncio.sleep(0.2)
                     return await self._start_round_locked(_retry_count)
 
+                # #1936: a timeout is not proof of a broken system. Music
+                # Assistant's Apple Music provider rate-limits and then retries
+                # after its OWN backoff — measured at 15.7s, i.e. longer than
+                # the deadline we just gave it. Pausing the whole game on that
+                # first timeout ended the evening for a provider that was
+                # working, and handed the host a re-authenticate banner for a
+                # problem they did not have.
+                #
+                # So the first failures skip the song, exactly like a
+                # storefront gap; only MAX_CONSECUTIVE_PLAYBACK_FAILURES in a
+                # row still means systemic and pauses. An offline speaker or a
+                # genuinely dead provider therefore still reaches the recovery
+                # banner — a few songs later instead of instantly, which is the
+                # deliberate price for not ending a game over one slow start.
+                self._consecutive_playback_failures = (
+                    getattr(self, "_consecutive_playback_failures", 0) + 1
+                )
+                if (
+                    self._consecutive_playback_failures
+                    < MAX_CONSECUTIVE_PLAYBACK_FAILURES
+                ):
+                    # Stop the speaker BEFORE moving on. MA may still be
+                    # retrying the track we just gave up on; without this it can
+                    # start mid-way through the *next* round and play the wrong
+                    # song under a live question. This does not provably cancel
+                    # MA's internal retry — it is the strongest lever this side
+                    # of the boundary has.
+                    try:
+                        await self._media_player_service.stop()
+                    except Exception as err:  # noqa: BLE001 — must not raise
+                        _LOGGER.warning("Stop before skip failed: %s (#1936)", err)
+                    _LOGGER.warning(
+                        "Playback timed out for %s — skipping this song "
+                        "(failure %d of %d in a row; the provider may be "
+                        "rate-limiting). Trying the next song. (#1936)",
+                        song.get("title") or song.get("uri"),
+                        self._consecutive_playback_failures,
+                        MAX_CONSECUTIVE_PLAYBACK_FAILURES,
+                    )
+                    await asyncio.sleep(0.2)
+                    return await self._start_round_locked(_retry_count)
+
                 # #949: a systemic playback failure — the speaker stayed idle,
                 # or the Music Assistant provider is unauthenticated — does not
                 # fix itself by retrying. play_song already waited a full MA
@@ -361,8 +404,16 @@ class RoundLifecycleMixin:
                     attempted_uri,
                     self.media_player,
                 )
+                # #1936: the budget is spent — reset it so the Resume button
+                # gets a full one rather than pausing again on the next timeout.
+                self._consecutive_playback_failures = 0
                 await self.pause_game("media_player_error")
                 return False
+
+            # #1936: a confirmed start clears the streak. Only CONSECUTIVE
+            # timeouts mean systemic; one bad song between two good ones does
+            # not accumulate toward the pause.
+            self._consecutive_playback_failures = 0
 
             # #1358: play_song just succeeded, but it parks for a full Music
             # Assistant timeout — long enough for the admin to end the game

--- a/custom_components/beatify/services/media_player.py
+++ b/custom_components/beatify/services/media_player.py
@@ -101,6 +101,19 @@ PLAYBACK_TIMEOUT = 8.0
 # advanced before the track had actually swapped on the speaker.
 MA_PLAYBACK_TIMEOUT = 15.0
 
+# #1936: the FIRST play of a game gets a third more time (15.0s → 20.0s). A
+# speaker idle for a while was measured at 10.1s to first audio (Sonos via MA,
+# Apple Music) — close enough to the deadline that a cold start regularly lost
+# the race and the game paused before a single note had played. Later rounds
+# keep the shorter deadline: by then the speaker is warm and a longer wait is
+# just silence in front of the players.
+#
+# Expressed as a FACTOR, not a second absolute constant, so the one existing
+# patch point still governs both budgets — eight tests patch
+# MA_PLAYBACK_TIMEOUT down to keep the suite fast, and a separate absolute
+# constant would have silently made each of them wait the full 20s.
+MA_FIRST_PLAY_TIMEOUT_FACTOR = 4 / 3
+
 # #1381: Fast-path Path 2 (title-advanced-without-exact-match) must not
 # instant-accept an *arbitrary* title change. If a requested URI fails to
 # resolve in MA while the speaker's prior queue naturally auto-advances to its
@@ -325,6 +338,10 @@ class MediaPlayerService:
         # attempt was reported as `spotify:track:…` and every reader was sent
         # hunting in the wrong provider. None until the first attempt.
         self.last_attempted_uri: str | None = None
+
+        # #1936: True until the first playback attempt of this game has been
+        # made. Drives the longer cold-start budget in _try_ma_play.
+        self._first_play_pending: bool = True
 
         # #1363: set when Beatify itself issues a same-song media_stop after a
         # stale-title detect (line ~729). The stop forces the speaker to
@@ -766,7 +783,14 @@ class MediaPlayerService:
         # #1927 follow-up: remember what we are about to play, so a failure is
         # reported with the URI that was really tried.
         self.last_attempted_uri = uri
-        _LOGGER.debug("MA playback: %s on %s", uri, self._entity_id)
+        # #1936: cold-start budget for the very first attempt of a game only.
+        timeout = MA_PLAYBACK_TIMEOUT * (
+            MA_FIRST_PLAY_TIMEOUT_FACTOR if self._first_play_pending else 1
+        )
+        self._first_play_pending = False
+        _LOGGER.debug(
+            "MA playback: %s on %s (budget %.0fs)", uri, self._entity_id, timeout
+        )
 
         # Snapshot speaker state before the call — we need both fields to
         # distinguish #345 slow-buffer (one of them changed during the wait)
@@ -903,7 +927,7 @@ class MediaPlayerService:
                 )
                 return True
 
-            await asyncio.wait_for(confirmed.wait(), timeout=MA_PLAYBACK_TIMEOUT)
+            await asyncio.wait_for(confirmed.wait(), timeout=timeout)
             elapsed = asyncio.get_event_loop().time() - start_time
             final = self._safe_state()
             _LOGGER.debug(
@@ -937,7 +961,7 @@ class MediaPlayerService:
                     "Beatify stopped it after a same-song stale-title detect. "
                     "Treating as a storefront/catalog gap (unavailable), not a "
                     "systemic error — game will skip this song silently. (#1363)",
-                    MA_PLAYBACK_TIMEOUT,
+                    timeout,
                     uri,
                 )
                 self.last_failure_reason = "unavailable"
@@ -946,8 +970,11 @@ class MediaPlayerService:
                 "MA playback failed after %.1fs for %s (state: %s). "
                 "Either the speaker is offline, MA's provider is unauthenticated, "
                 "or the track is not available in your provider's catalog. If this "
-                "happens for many tracks, re-authenticate your music provider in MA.",
-                MA_PLAYBACK_TIMEOUT,
+                "happens for many tracks, re-authenticate your music provider in MA. "
+                "A rate-limiting provider looks the same from here — Music "
+                "Assistant then retries the track after its own backoff, which "
+                "can outlast this budget. (#1936)",
+                timeout,
                 uri,
                 speaker_state,
             )
@@ -997,7 +1024,7 @@ class MediaPlayerService:
                 "not available in your provider's catalog/storefront, OR "
                 "your provider needs re-authentication in MA. Skipping "
                 "this song silently — game will try the next one. (#795)",
-                MA_PLAYBACK_TIMEOUT,
+                timeout,
                 uri,
                 title_before,
                 "advanced — prior track still playing"
@@ -1060,7 +1087,7 @@ class MediaPlayerService:
                 "dispatched. Check that the speaker is exposed to Music "
                 "Assistant and that your provider is authenticated there. "
                 "(#1863)",
-                MA_PLAYBACK_TIMEOUT,
+                timeout,
                 uri,
                 speaker_state,
                 title_before,
@@ -1085,7 +1112,7 @@ class MediaPlayerService:
             "MA playback not confirmed after %.1fs for %s (state: %s). "
             "Title moved %r → %r. Continuing anyway — MA may still be "
             "buffering. (#345)",
-            MA_PLAYBACK_TIMEOUT,
+            timeout,
             uri,
             speaker_state,
             title_before,

--- a/custom_components/beatify/www/i18n/de.json
+++ b/custom_components/beatify/www/i18n/de.json
@@ -589,8 +589,8 @@
     "ttsTestNoSpeaker": "Erst einen Lautsprecher auswählen",
     "pauseRecovery": {
       "title": "Spiel pausiert",
-      "mediaPlayerError": "Die Wiedergabe konnte nicht starten — der Lautsprecher reagiert nicht. Häufige Ursache: {provider} in Music Assistant muss neu authentifiziert werden — Einstellungen → Music Assistant → {provider} → Neu verbinden, dann auf Fortsetzen klicken.",
-      "mediaPlayerErrorGeneric": "Die Wiedergabe konnte nicht starten — der Lautsprecher reagiert nicht. Häufige Ursache: dein Musikanbieter in Music Assistant muss neu authentifiziert werden — Einstellungen → Music Assistant → Anbieter → Neu verbinden, dann auf Fortsetzen klicken.",
+      "mediaPlayerError": "Die Wiedergabe ist mehrmals hintereinander nicht gestartet. Zwei häufige Ursachen: {provider} in Music Assistant muss neu angemeldet werden (Einstellungen → Music Assistant → {provider} → Neu verbinden), oder {provider} drosselt gerade — dann eine Minute warten und auf Fortsetzen tippen.",
+      "mediaPlayerErrorGeneric": "Die Wiedergabe ist mehrmals hintereinander nicht gestartet. Zwei häufige Ursachen: dein Musikanbieter in Music Assistant muss neu angemeldet werden (Einstellungen → Music Assistant → Anbieter → Neu verbinden), oder er drosselt gerade — dann eine Minute warten und auf Fortsetzen tippen.",
       "noSongsAvailable": "Keine spielbaren Songs für diesen Anbieter mehr. Fortsetzen, um es erneut zu versuchen, oder Spiel beenden.",
       "resume": "Fortsetzen",
       "endGame": "Spiel beenden",

--- a/custom_components/beatify/www/i18n/en.json
+++ b/custom_components/beatify/www/i18n/en.json
@@ -589,8 +589,8 @@
     "ttsTestNoSpeaker": "Pick a speaker first",
     "pauseRecovery": {
       "title": "Game paused",
-      "mediaPlayerError": "Playback did not start — the speaker is not responding. This often means {provider} in Music Assistant needs re-authentication — open Settings → Music Assistant → {provider} → Reconnect, then click Resume.",
-      "mediaPlayerErrorGeneric": "Playback did not start — the speaker is not responding. This often means your music provider in Music Assistant needs re-authentication — open Settings → Music Assistant → your provider → Reconnect, then click Resume.",
+      "mediaPlayerError": "Playback did not start for several songs in a row. Two common causes: {provider} in Music Assistant needs re-authentication (Settings → Music Assistant → {provider} → Reconnect), or {provider} is rate-limiting right now — in that case wait a minute and hit Resume.",
+      "mediaPlayerErrorGeneric": "Playback did not start for several songs in a row. Two common causes: your music provider in Music Assistant needs re-authentication (Settings → Music Assistant → your provider → Reconnect), or it is rate-limiting right now — in that case wait a minute and hit Resume.",
       "noSongsAvailable": "No playable songs left for this provider. Resume to retry, or end the game.",
       "resume": "Resume",
       "endGame": "End game",

--- a/custom_components/beatify/www/i18n/es.json
+++ b/custom_components/beatify/www/i18n/es.json
@@ -589,8 +589,8 @@
     "ttsTestNoSpeaker": "Elige primero un altavoz",
     "pauseRecovery": {
       "title": "Partida en pausa",
-      "mediaPlayerError": "La reproducción no se ha iniciado — el altavoz no responde. Causa habitual: {provider} en Music Assistant necesita reautenticarse — Ajustes → Music Assistant → {provider} → Reconectar, y luego pulsa Reanudar.",
-      "mediaPlayerErrorGeneric": "La reproducción no se ha iniciado — el altavoz no responde. Causa habitual: tu proveedor de música en Music Assistant necesita reautenticarse — Ajustes → Music Assistant → tu proveedor → Reconectar, y luego pulsa Reanudar.",
+      "mediaPlayerError": "La reproducción no se ha iniciado en varias canciones seguidas. Dos causas habituales: {provider} en Music Assistant necesita volver a autenticarse (Ajustes → Music Assistant → {provider} → Reconectar), o {provider} está limitando las peticiones ahora mismo — en ese caso espera un minuto y pulsa Reanudar.",
+      "mediaPlayerErrorGeneric": "La reproducción no se ha iniciado en varias canciones seguidas. Dos causas habituales: tu proveedor de música en Music Assistant necesita volver a autenticarse (Ajustes → Music Assistant → proveedor → Reconectar), o está limitando las peticiones ahora mismo — en ese caso espera un minuto y pulsa Reanudar.",
       "noSongsAvailable": "No quedan canciones reproducibles para este proveedor. Reanuda para reintentarlo, o finaliza la partida.",
       "resume": "Reanudar",
       "endGame": "Finalizar partida",

--- a/custom_components/beatify/www/i18n/fr.json
+++ b/custom_components/beatify/www/i18n/fr.json
@@ -589,8 +589,8 @@
     "ttsTestNoSpeaker": "Choisis d'abord une enceinte",
     "pauseRecovery": {
       "title": "Partie en pause",
-      "mediaPlayerError": "La lecture n'a pas démarré — l'enceinte ne répond pas. Cause fréquente : {provider} dans Music Assistant doit être ré-authentifié — Paramètres → Music Assistant → {provider} → Reconnecter, puis clique sur Reprendre.",
-      "mediaPlayerErrorGeneric": "La lecture n'a pas démarré — l'enceinte ne répond pas. Cause fréquente : ton service de musique dans Music Assistant doit être ré-authentifié — Paramètres → Music Assistant → ton service → Reconnecter, puis clique sur Reprendre.",
+      "mediaPlayerError": "La lecture n'a pas démarré sur plusieurs morceaux d'affilée. Deux causes fréquentes : {provider} dans Music Assistant doit être réauthentifié (Paramètres → Music Assistant → {provider} → Reconnecter), ou {provider} limite actuellement les requêtes — dans ce cas, attends une minute puis appuie sur Reprendre.",
+      "mediaPlayerErrorGeneric": "La lecture n'a pas démarré sur plusieurs morceaux d'affilée. Deux causes fréquentes : ton fournisseur de musique dans Music Assistant doit être réauthentifié (Paramètres → Music Assistant → fournisseur → Reconnecter), ou il limite actuellement les requêtes — dans ce cas, attends une minute puis appuie sur Reprendre.",
       "noSongsAvailable": "Plus aucune chanson lisible pour ce service. Reprends pour réessayer, ou termine la partie.",
       "resume": "Reprendre",
       "endGame": "Terminer la partie",

--- a/custom_components/beatify/www/i18n/nl.json
+++ b/custom_components/beatify/www/i18n/nl.json
@@ -589,8 +589,8 @@
     "ttsTestNoSpeaker": "Kies eerst een luidspreker",
     "pauseRecovery": {
       "title": "Spel gepauzeerd",
-      "mediaPlayerError": "Afspelen kon niet starten — de speaker reageert niet. Veelvoorkomende oorzaak: {provider} in Music Assistant moet opnieuw worden geverifieerd — Instellingen → Music Assistant → {provider} → Opnieuw verbinden, en klik dan op Hervatten.",
-      "mediaPlayerErrorGeneric": "Afspelen kon niet starten — de speaker reageert niet. Veelvoorkomende oorzaak: je muziekprovider in Music Assistant moet opnieuw worden geverifieerd — Instellingen → Music Assistant → je provider → Opnieuw verbinden, en klik dan op Hervatten.",
+      "mediaPlayerError": "Afspelen is meerdere nummers achter elkaar niet gestart. Twee veelvoorkomende oorzaken: {provider} in Music Assistant moet opnieuw worden geverifieerd (Instellingen → Music Assistant → {provider} → Opnieuw verbinden), of {provider} beperkt op dit moment het aantal aanvragen — wacht dan een minuut en tik op Hervatten.",
+      "mediaPlayerErrorGeneric": "Afspelen is meerdere nummers achter elkaar niet gestart. Twee veelvoorkomende oorzaken: je muziekprovider in Music Assistant moet opnieuw worden geverifieerd (Instellingen → Music Assistant → provider → Opnieuw verbinden), of hij beperkt op dit moment het aantal aanvragen — wacht dan een minuut en tik op Hervatten.",
       "noSongsAvailable": "Geen afspeelbare nummers meer voor deze provider. Hervat om opnieuw te proberen, of stop het spel.",
       "resume": "Hervatten",
       "endGame": "Spel beëindigen",

--- a/tests/unit/test_media_player.py
+++ b/tests/unit/test_media_player.py
@@ -7,6 +7,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from custom_components.beatify.const import MAX_CONSECUTIVE_PLAYBACK_FAILURES
+
 from custom_components.beatify.services.media_player import (
     MediaPlayerService,
     async_get_media_players,
@@ -1558,12 +1560,17 @@ class TestStartRoundFailureClassification:
         assert mock_service.play_song.await_count >= 2
 
     @pytest.mark.asyncio
-    async def test_error_failure_pauses_immediately(self):
-        """#949: an 'error' failure (speaker idle / provider unauthenticated)
-        is systemic — play_song already waited a full MA timeout. start_round
-        must pause on the FIRST such failure, not grind ~3 silent retries
-        (~2 min) before the recovery banner appears. The banner's Resume
-        button is the manual retry if it really was a transient blip.
+    async def test_error_failure_pauses_within_the_consecutive_budget(self):
+        """#949 + #1936: an 'error' failure still pauses the game — but not on
+        the very first one any more.
+
+        #949 paused immediately, to avoid a ~2 min silent retry grind. #1936
+        showed the cost of that: Music Assistant's Apple Music provider
+        rate-limits and retries after its own backoff (15.7s, longer than our
+        deadline), so a working provider ended the game on its first slow
+        track. The compromise is a bounded streak — skip, skip, then pause —
+        which keeps the recovery banner for genuinely systemic failures while a
+        throttled provider only costs a couple of songs.
         """
         from custom_components.beatify.game.state import GameState  # noqa: PLC0415
         from tests.conftest import (  # noqa: PLC0415
@@ -1594,9 +1601,9 @@ class TestStartRoundFailureClassification:
         ):
             result = await gs.start_round()
 
-        # Pauses on the FIRST failure — no silent retry grind (#949).
+        # Still pauses, and still bounded — not an open-ended retry grind.
         assert result is False
-        assert mock_service.play_song.await_count == 1
+        assert mock_service.play_song.await_count == MAX_CONSECUTIVE_PLAYBACK_FAILURES
         gs.pause_game.assert_awaited_once_with("media_player_error")
 
     @pytest.mark.asyncio
@@ -2623,3 +2630,154 @@ class TestSingleWalkEquivalence:
         assert remap_combined == {"media_player.unnamed_room": "media_player.esszimmer"}
         ids = {p["entity_id"] for p in players_combined}
         assert ids == {"media_player.esszimmer", "media_player.kitchen_sonos"}
+
+
+class TestRateLimitTolerance:
+    """#1936 — a playback timeout is not proof that the system is broken.
+
+    Music Assistant's Apple Music provider rate-limits and then retries after
+    its own backoff (measured at 15.7s, longer than our deadline). Pausing the
+    whole game on the first timeout ended the evening for a provider that was
+    working. Only CONSECUTIVE timeouts now mean systemic.
+    """
+
+    @staticmethod
+    def _game_with_failing_player():
+        from custom_components.beatify.game.state import GameState  # noqa: PLC0415
+        from tests.conftest import make_game_state, make_songs  # noqa: PLC0415
+
+        gs: GameState = make_game_state()
+        gs.create_game(
+            playlists=["test.json"],
+            songs=make_songs(30),
+            media_player="media_player.esszimmer",
+            base_url="http://localhost:8123",
+        )
+        svc = MagicMock()
+        svc.is_available.return_value = True
+        svc.last_failure_reason = "error"
+        svc.last_attempted_uri = "apple_music://track/1122776156"
+        svc.play_song = AsyncMock(return_value=False)
+        svc.stop = AsyncMock()
+        gs._media_player_service = svc
+        gs.media_player = "media_player.esszimmer"
+        gs.platform = "music_assistant"
+        gs.pause_game = AsyncMock()
+        return gs, svc
+
+    @pytest.mark.asyncio
+    async def test_first_timeout_skips_the_song_instead_of_pausing(self):
+        gs, svc = self._game_with_failing_player()
+
+        with patch(
+            "custom_components.beatify.game.state.asyncio.sleep",
+            new_callable=AsyncMock,
+        ):
+            await gs.start_round()
+
+        # It kept trying songs rather than ending the game on the first miss.
+        assert svc.play_song.await_count >= 2
+        assert gs.pause_game.await_count <= 1
+
+    @pytest.mark.asyncio
+    async def test_speaker_is_stopped_before_moving_on(self):
+        """MA may still be retrying the track we gave up on; without a stop it
+        can start mid-way through the NEXT round and play the wrong song under
+        a live question."""
+        gs, svc = self._game_with_failing_player()
+
+        with patch(
+            "custom_components.beatify.game.state.asyncio.sleep",
+            new_callable=AsyncMock,
+        ):
+            await gs.start_round()
+
+        assert svc.stop.await_count >= 1
+
+    @pytest.mark.asyncio
+    async def test_pauses_once_the_consecutive_budget_is_spent(self):
+        """A genuinely offline speaker must still reach the recovery banner."""
+        from custom_components.beatify.const import (  # noqa: PLC0415
+            MAX_CONSECUTIVE_PLAYBACK_FAILURES,
+        )
+
+        gs, svc = self._game_with_failing_player()
+
+        with patch(
+            "custom_components.beatify.game.state.asyncio.sleep",
+            new_callable=AsyncMock,
+        ):
+            await gs.start_round()
+
+        gs.pause_game.assert_awaited_with("media_player_error")
+        assert svc.play_song.await_count == MAX_CONSECUTIVE_PLAYBACK_FAILURES
+
+    @pytest.mark.asyncio
+    async def test_a_success_clears_the_streak(self):
+        """One bad song between two good ones must not accumulate."""
+        gs, svc = self._game_with_failing_player()
+        # fail, fail, then succeed — the streak must be back to zero.
+        svc.play_song = AsyncMock(side_effect=[False, False, True])
+
+        with patch(
+            "custom_components.beatify.game.state.asyncio.sleep",
+            new_callable=AsyncMock,
+        ):
+            await gs.start_round()
+
+        assert gs._consecutive_playback_failures == 0
+        gs.pause_game.assert_not_awaited()
+
+
+class TestFirstPlayBudget:
+    """#1936 — the first play of a game gets a third more time (cold speaker)."""
+
+    def test_factor_is_derived_from_the_base_timeout(self):
+        from custom_components.beatify.services.media_player import (  # noqa: PLC0415
+            MA_FIRST_PLAY_TIMEOUT_FACTOR,
+            MA_PLAYBACK_TIMEOUT,
+        )
+
+        assert MA_PLAYBACK_TIMEOUT * MA_FIRST_PLAY_TIMEOUT_FACTOR == 20.0
+
+    def test_a_fresh_service_is_pending_its_first_play(self):
+        svc = MediaPlayerService(
+            MagicMock(), "media_player.test", platform="music_assistant"
+        )
+        assert svc._first_play_pending is True
+
+    @pytest.mark.asyncio
+    async def test_the_longer_budget_is_used_once_and_then_dropped(self):
+        """The second attempt must fall back to the normal deadline — a warm
+        speaker waiting longer is just silence in front of the players."""
+        hass = MagicMock()
+        hass.services.async_call = AsyncMock()
+        hass.states.get = MagicMock(return_value=_make_state("idle", media_title="Old"))
+        svc = MediaPlayerService(hass, "media_player.test", platform="music_assistant")
+
+        seen = []
+
+        async def capture(awaitable, timeout=None):
+            seen.append(timeout)
+            awaitable.close()  # we never await it — keep the loop warning-free
+            raise asyncio.TimeoutError
+
+        with (
+            patch(
+                "custom_components.beatify.services.media_player.MA_PLAYBACK_TIMEOUT",
+                1.0,
+            ),
+            patch(
+                "custom_components.beatify.services.media_player.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "custom_components.beatify.services.media_player.asyncio.wait_for",
+                capture,
+            ),
+        ):
+            await svc.play_song(_make_song(title="First"))
+            await svc.play_song(_make_song(title="Second"))
+
+        assert seen[0] == pytest.approx(4 / 3)
+        assert seen[-1] == pytest.approx(1.0)


### PR DESCRIPTION
Fixes #1936.

## What was happening

Music Assistant's Apple Music provider rate-limits, then retries after **its own** backoff. From the add-on log, during a live run:

```
18:47:51.453  [beatify] MA playback: apple_music://track/1122776156 on media_player.esszimmer
18:47:51.897  [music_assistant.apple_music] Attempt 1/5 failed: Apple Music Rate Limiter
18:47:51.928  [music_assistant.apple_music] Retrying in 15.7 seconds...
18:48:06.457  [beatify] MA playback failed after 15.0s … (state: idle)   ← we give up
```

We gave up 1.6 s before MA even tried again. The speaker was legitimately `idle` the whole time, the URI was fine, the provider was fine. Beatify then classified it as systemic, paused the game on that first timeout, and told the host to re-authenticate a provider that was working.

MA retries up to 5 times with ~15 s gaps, so no deadline sane for a party game can wait it out. The fix is in the **classification**, not the duration.

## The change

**1. A timeout skips the song; three in a row still pause.** `MAX_CONSECUTIVE_PLAYBACK_FAILURES = 3`. A confirmed start clears the streak, so one bad song between two good ones never accumulates. A pause resets it, so Resume gets a full budget rather than pausing again on the next timeout. An offline speaker or a genuinely dead provider still reaches the recovery banner — a couple of songs later instead of instantly.

**2. The skip stops the speaker first.** MA may still be retrying the track we abandoned; without a stop it can start mid-way through the *next* round and play the wrong song under a live question. Stated honestly in the code: this does not provably cancel MA's internal retry, it is the strongest lever available on our side of the boundary.

**3. The first play of a game gets a third more time** (15 s → 20 s). A cold speaker measured 10.1 s to first audio — close enough to the deadline to lose the race before a single note had played. Later rounds keep 15 s, because a longer wait on a warm speaker is just silence in front of the players.

Written as a factor of `MA_PLAYBACK_TIMEOUT` rather than a second absolute constant, deliberately: eight existing tests patch that constant down to keep the suite fast, and a separate constant would have silently made each of them block for the full 20 s.

**4. The pause banner names rate-limiting** alongside re-authentication, with the concrete advice — wait a minute, hit Resume — in all five locales.

## This softens #949, on purpose

#949 paused on the first failure specifically to avoid a silent retry grind before the banner appeared. That protection is why the grind is still **bounded**: three attempts, not an open-ended loop. Worst case is now up to three timeouts of silence before the banner instead of one — the deliberate price for not ending a game over one slow start. The #949 test is updated rather than deleted, and its docstring carries both rationales so the next reader sees the trade, not just the current rule.

## Tests

7 new cases: first timeout skips instead of pausing · the speaker is stopped before moving on · pause once the consecutive budget is spent · a success clears the streak · the longer budget is used once and then dropped · the factor arithmetic lands on 20 s · a fresh service is pending its first play.

Full Python suite **1557 passed / 2 skipped**, JS **569 passed**, `ruff check` + `ruff format --check` + `eslint` clean, all five locale files parse — run locally.

## Not covered here

Whether MA exposes its rate-limit state in a way Beatify could read at runtime. If it does, a specific "your provider is throttling, songs may be skipped" message would beat the current two-cause banner. Worth a look, not a blocker.
