### PR TITLE
data: fix 1 broken URI in world-cup-anthems (#1938)

### DIFF
--- a/custom_components/beatify/playlists/world-cup-anthems.json
+++ b/custom_components/beatify/playlists/world-cup-anthems.json
@@ -1,6 +1,6 @@
 {
   "name": "World Cup Anthems",
-  "version": "1.3",
+  "version": "1.4",
   "tags": [
     "world-cup",
     "fifa",
@@ -293,7 +293,7 @@
       "awards_fr": [],
       "awards_nl": [],
       "uri_apple_music": "applemusic://track/359615452",
-      "uri_youtube_music": "https://music.youtube.com/watch?v=ewKX3c3CBNw",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=4fAy7F2wuCk",
       "uri_tidal": null,
       "uri_deezer": null,
       "isrc": null,


### PR DESCRIPTION
Closes #1938. Replaced the wrong YouTube Music URI for Youssou N'Dour & Axelle Red — La Cour des Grands (Do You Mind If I Play): the old URI pointed to an unofficial third-party compilation by "Mike'S" instead of the official track. Bumped playlist version to 1.4.

## Changes
- `world-cup-anthems.json` version `1.3` → `1.4`
- YouTube Music URI for Youssou N'Dour & Axelle Red: `ewKX3c3CBNw` → `4fAy7F2wuCk`

## Review notes
5 additional `wrong_track` flags from this run were reviewed by AI and dismissed as false positives (see #1938 for details).