### PR TITLE
fix(server): keep the asset-fingerprint sweep off the event loop (#1945)

### DIFF
--- a/custom_components/beatify/server/base.py
+++ b/custom_components/beatify/server/base.py
@@ -131,9 +131,19 @@ def _get_asset_version(version: str, www_dir: Path) -> str:
     # Slow path: serialize recompute so concurrent first-access (event loop +
     # executor threads) hashes once, not once-per-thread (#1592). Re-check the
     # cache inside the lock — another thread may have just populated it.
+    # #1945: a STALE entry is served as-is rather than recomputed here. This
+    # function can run on the event loop (the sync substitution path), and
+    # recomputing means an rglob/stat sweep over the shipped bundle right there
+    # — which is exactly what HA's blocking-call detector reported. A
+    # cache-buster that is a few seconds old is harmless: the next call through
+    # async_apply_cache_tokens refreshes it in an executor. Only a completely
+    # cold cache still justifies computing inline, because there is nothing to
+    # serve otherwise.
+    if cache is not None:
+        return f"{version}-{cache[1]}"
     with _ASSET_FP_LOCK:
         cache = _ASSET_FP_CACHE
-        if cache is not None and now - cache[0] < _ASSET_FP_TTL_NS:
+        if cache is not None:
             fingerprint = cache[1]
         else:
             fingerprint = _compute_asset_fingerprint(www_dir)
@@ -146,25 +156,39 @@ def _www_dir() -> Path:
     return Path(__file__).parent.parent / "www"
 
 
-def _apply_cache_tokens(text: str, hass: HomeAssistant) -> str:
-    """Substitute {{VERSION}} and {{ASSET_VER}} tokens at serve time (#1266)."""
+def _apply_cache_tokens(
+    text: str, hass: HomeAssistant, *, asset_version: str | None = None
+) -> str:
+    """Substitute {{VERSION}} and {{ASSET_VER}} tokens at serve time (#1266).
+
+    ``asset_version`` (#1945) lets the async serve path pass the value it just
+    warmed in an executor, so this function never has to look the cache up
+    again — and therefore can never trigger the fingerprint sweep itself.
+    """
     version = _get_version(hass)
-    text = text.replace(_ASSET_VER_TOKEN, _get_asset_version(version, _www_dir()))
+    if asset_version is None:
+        asset_version = _get_asset_version(version, _www_dir())
+    text = text.replace(_ASSET_VER_TOKEN, asset_version)
     return text.replace(_VERSION_TOKEN, version)
 
 
-async def _async_prime_asset_fingerprint(hass: HomeAssistant) -> None:
+async def _async_prime_asset_fingerprint(hass: HomeAssistant) -> str:
     """Warm ``_ASSET_FP_CACHE`` via an executor job when it is cold or stale.
 
     Mirrors the throttle/lock logic in :func:`_get_asset_version`, but performs
     the actual filesystem sweep (:func:`_compute_asset_fingerprint`, a blocking
     ``rglob``/``stat`` walk) off the event loop. A no-op when the cache is fresh.
+
+    #1945: returns the fingerprint instead of nothing. The caller hands it
+    straight to the substitution, so the serve path never re-reads the cache —
+    the five-second TTL used to expire between the two steps on a loaded
+    instance, and the sweep then ran on the event loop after all.
     """
     global _ASSET_FP_CACHE  # noqa: PLW0603
     now = time.monotonic_ns()
     cache = _ASSET_FP_CACHE
     if cache is not None and now - cache[0] < _ASSET_FP_TTL_NS:
-        return
+        return cache[1]
     fingerprint = await hass.async_add_executor_job(
         _compute_asset_fingerprint, _www_dir()
     )
@@ -172,6 +196,11 @@ async def _async_prime_asset_fingerprint(hass: HomeAssistant) -> None:
         cache = _ASSET_FP_CACHE
         if cache is None or time.monotonic_ns() - cache[0] >= _ASSET_FP_TTL_NS:
             _ASSET_FP_CACHE = (time.monotonic_ns(), fingerprint)
+        else:
+            # Another thread warmed a fresher value while we were in the
+            # executor — prefer it, so every caller sees the same buster.
+            fingerprint = cache[1]
+    return fingerprint
 
 
 async def async_apply_cache_tokens(hass: HomeAssistant, text: str) -> str:
@@ -185,8 +214,10 @@ async def async_apply_cache_tokens(hass: HomeAssistant, text: str) -> str:
     cache in an executor first keeps the hot serve path non-blocking; the
     subsequent sync substitution then hits the warm cache.
     """
-    await _async_prime_asset_fingerprint(hass)
-    return _apply_cache_tokens(text, hass)
+    fingerprint = await _async_prime_asset_fingerprint(hass)
+    return _apply_cache_tokens(
+        text, hass, asset_version=f"{_get_version(hass)}-{fingerprint}"
+    )
 
 
 # #1177 follow-up: PR #1179 set documentElement.lang inside setLanguage(), but

--- a/tests/unit/test_asset_cachebuster.py
+++ b/tests/unit/test_asset_cachebuster.py
@@ -329,3 +329,91 @@ class TestAsyncApplyCacheTokens:
 
         await base.async_apply_cache_tokens(_SpyHass("9.9.9"), "{{ASSET_VER}}")
         assert offloaded == [], "a fresh fingerprint cache must skip the executor"
+
+
+@pytest.mark.asyncio
+class TestNoBlockingSweepOnTheLoop:
+    """#1945 — the sweep must be unreachable from the event loop, not merely
+    unlikely.
+
+    Reported by a user whose HA logged `Detected blocking call to scandir …
+    inside the event loop by custom integration 'beatify' at base.py line 99`.
+    The async wrapper primed the cache in an executor and then called the sync
+    substitution, which re-read the cache — and the TTL is five seconds. On a
+    loaded instance those two steps are more than five seconds apart, the entry
+    was stale again, and the rglob walk ran on the loop after all.
+    """
+
+    def setup_method(self) -> None:
+        base._ASSET_FP_CACHE = None
+
+    async def test_expiring_between_prime_and_use_does_not_recompute(
+        self, monkeypatch
+    ) -> None:
+        """The reported failure, reproduced: with a TTL of 0 every cache read
+        is stale. The sweep must still run exactly once, in the executor."""
+        monkeypatch.setattr(base, "_ASSET_FP_TTL_NS", 0)
+
+        inline: list = []
+        offloaded: list = []
+        real = base._compute_asset_fingerprint
+
+        def _spy(www_dir):  # noqa: ANN001
+            inline.append(www_dir)
+            return real(www_dir)
+
+        monkeypatch.setattr(base, "_compute_asset_fingerprint", _spy)
+
+        class _SpyHass(_FakeHass):
+            async def async_add_executor_job(self, func, *args):  # noqa: ANN001
+                offloaded.append(func)
+                return func(*args)
+
+        out = await base.async_apply_cache_tokens(_SpyHass("9.9.9"), "{{ASSET_VER}}")
+
+        assert "{{ASSET_VER}}" not in out
+        assert len(offloaded) == 1, "the sweep belongs in the executor, once"
+        assert len(inline) == 1, (
+            "the sweep ran twice — the second one was on the event loop, which "
+            "is exactly the blocking call HA reported"
+        )
+
+    async def test_stale_cache_is_served_rather_than_recomputed(
+        self, monkeypatch
+    ) -> None:
+        """A stale entry is good enough for a cache-buster. Recomputing it on
+        the caller's thread is not worth a disk sweep in the hot path."""
+        await base.async_apply_cache_tokens(_FakeHass("9.9.9"), "{{ASSET_VER}}")
+        warm = base._ASSET_FP_CACHE
+        assert warm is not None
+
+        # Age the entry past the TTL without touching the filesystem.
+        base._ASSET_FP_CACHE = (warm[0] - base._ASSET_FP_TTL_NS * 10, warm[1])
+
+        calls: list = []
+        monkeypatch.setattr(
+            base, "_compute_asset_fingerprint", lambda d: calls.append(d) or "x"
+        )
+        out = _get_asset_version("9.9.9", base._www_dir())
+
+        assert calls == [], "a stale entry must be served, not recomputed inline"
+        assert out == f"9.9.9-{warm[1]}"
+
+    async def test_cold_cache_still_computes_inline_as_a_last_resort(
+        self, monkeypatch
+    ) -> None:
+        """With nothing cached at all there is nothing to serve — computing
+        inline is the only option, and stays allowed."""
+        base._ASSET_FP_CACHE = None
+        calls: list = []
+        real = base._compute_asset_fingerprint
+
+        def _spy(www_dir):  # noqa: ANN001
+            calls.append(www_dir)
+            return real(www_dir)
+
+        monkeypatch.setattr(base, "_compute_asset_fingerprint", _spy)
+        out = _get_asset_version("9.9.9", base._www_dir())
+
+        assert len(calls) == 1
+        assert out.startswith("9.9.9-")


### PR DESCRIPTION
Fixes #1945. Reported by @pwhh20 in #1931.

## The report

Home Assistant's blocking-call detector, on every page Beatify serves:

```
Detected blocking call to scandir with args ('/config/custom_components/beatify/www/css/',)
inside the event loop by custom integration 'beatify' at
custom_components/beatify/server/base.py, line 99: for p in sorted(d.rglob("*"))
```

## Why it happened

`async_apply_cache_tokens()` looks like it keeps the sweep off the loop:

```python
await _async_prime_asset_fingerprint(hass)   # executor
return _apply_cache_tokens(text, hass)       # sync — re-reads the cache
```

The cache TTL is **5 seconds**. If more than five seconds pass between those two lines — a loaded event loop, a slow executor, a busy disk — the entry is stale again and the sync path recomputes it inline: `rglob("*")` over `www/css`, `www/js`, `www/i18n`, on the event loop.

So the guarantee held only while the machine was fast enough to get from one line to the next, and the cost landed precisely on the machines where it hurts. The reporter's install is the case in point: the detector only fires when the loop is already busy.

## The change

- **`_async_prime_asset_fingerprint()` returns the fingerprint it warmed**, and the async path passes it straight into the substitution via a new `asset_version=` argument. The serve path never consults the cache a second time, so there is no timing assumption left to break.
- **`_get_asset_version()` serves a stale entry** rather than recomputing on the caller's thread. A cache-buster a few seconds old is harmless — the next async call refreshes it in the executor. Only a completely cold cache still computes inline, because then there is nothing to serve at all.

Together the blocking walk becomes unreachable from the event loop instead of merely unlikely.

## Tests

3 new cases in `test_asset_cachebuster.py`, and I checked they actually fail without the fix rather than passing by construction:

- **TTL 0 — the reported failure, reproduced.** Every cache read is stale, so the old code swept twice: once in the executor, once on the loop. Without the fix this fails with "the sweep ran twice"; with it, exactly one executor sweep.
- **Stale cache is served, not recomputed.** Without the fix this fails on the inline recompute.
- **Cold cache still computes inline** — the one case that must stay allowed.

Full Python suite **1560 passed / 2 skipped**, `ruff check` + `format --check` clean.

## Scope note

This does **not** claim to explain the `Unauthorised` symptom in #1931. A stalled loop can push the OAuth handshake into timeouts, so it is a plausible contributor — but that link is unproven, and #1931 stays open.
