### PR TITLE
chore(playlists): tidal backfill wave — +19 uris (divorced-dad-rock)

### DIFF
--- a/custom_components/beatify/playlists/community/divorced-dad-rock.json
+++ b/custom_components/beatify/playlists/community/divorced-dad-rock.json
@@ -1,6 +1,6 @@
 {
   "name": "Divorced Dad Rock",
-  "version": "1.2",
+  "version": "1.3",
   "tags": [
     "post-grunge",
     "nu-metal",
@@ -105,7 +105,7 @@
         "it": "applemusic://track/1702094269"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=UjWZGLi-1jM",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/134283108",
       "uri_deezer": "deezer://track/2511224",
       "fun_fact": "3 Doors Down are an American rock band from Mississippi, post-grunge radio mainstays.",
       "fun_fact_de": "3 Doors Down sind eine amerikanische Rockband aus Mississippi — feste Größe im Post-Grunge-Radio.",
@@ -130,7 +130,7 @@
         "it": "applemusic://track/1892522401"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=-mm50mejioI",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/4722264",
       "uri_deezer": "deezer://track/7408923",
       "fun_fact": "Puddle of Mudd are an American rock band from Kansas City.",
       "fun_fact_de": "Puddle of Mudd sind eine amerikanische Rockband aus Kansas City.",
@@ -155,7 +155,7 @@
         "it": "applemusic://track/212581978"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=rKXmAs0nfG4",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/56475876",
       "uri_deezer": "deezer://track/118996424",
       "fun_fact": "Daughtry was launched by Chris Daughtry after his run on American Idol.",
       "fun_fact_de": "Daughtry wurde von Chris Daughtry nach seiner American-Idol-Teilnahme gestartet.",
@@ -180,7 +180,7 @@
         "it": "applemusic://track/1666737320"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=jd_HmLEhVqA",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/477376",
       "uri_deezer": "deezer://track/94613616",
       "fun_fact": "Limp Bizkit were among the most commercially dominant nu-metal acts of the era.",
       "fun_fact_de": "Limp Bizkit zählten zu den kommerziell dominantesten Nu-Metal-Acts ihrer Zeit.",
@@ -205,7 +205,7 @@
         "it": "applemusic://track/1537768035"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=JOtfj1phVxo",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/700189",
       "uri_deezer": "deezer://track/71828722",
       "fun_fact": "Nickelback are a Canadian rock band — one of the best-selling acts of the post-grunge era.",
       "fun_fact_de": "Nickelback sind eine kanadische Rockband — einer der meistverkauften Acts der Post-Grunge-Ära.",
@@ -230,7 +230,7 @@
         "it": "applemusic://track/1889935330"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=tyIKi-dJYtA",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/1643756",
       "uri_deezer": "deezer://track/3356436",
       "fun_fact": "A post-grunge / 2000s-rock track (2008).",
       "fun_fact_de": "Ein Post-Grunge-/2000er-Rock-Track (2008).",
@@ -255,7 +255,7 @@
         "it": "applemusic://track/1805119746"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=KwN_f0fTHoE",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/1225571",
       "uri_deezer": "deezer://track/676162",
       "fun_fact": "Linkin Park fused nu-metal, rap and rock into one of the biggest sounds of the 2000s.",
       "fun_fact_de": "Linkin Park verschmolzen Nu-Metal, Rap und Rock zu einem der größten Sounds der 2000er.",
@@ -280,7 +280,7 @@
         "it": "applemusic://track/1440739980"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=84jK2Rzso7M",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/572144",
       "uri_deezer": "deezer://track/2172900",
       "fun_fact": "3 Doors Down are an American rock band from Mississippi, post-grunge radio mainstays.",
       "fun_fact_de": "3 Doors Down sind eine amerikanische Rockband aus Mississippi — feste Größe im Post-Grunge-Radio.",
@@ -305,7 +305,7 @@
         "it": "applemusic://track/1689138318"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=235sYB1hRxk",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/478049",
       "uri_deezer": "deezer://track/1138329",
       "fun_fact": "A post-grunge / 2000s-rock track (1995).",
       "fun_fact_de": "Ein Post-Grunge-/2000er-Rock-Track (1995).",
@@ -330,7 +330,7 @@
         "it": "applemusic://track/425465318"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=u7T2OR-O2Vk",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/5120024",
       "uri_deezer": "deezer://track/7675129",
       "fun_fact": "Pearl Jam are a Seattle band and one of the cornerstones of the grunge movement.",
       "fun_fact_de": "Pearl Jam sind eine Band aus Seattle und einer der Eckpfeiler der Grunge-Bewegung.",
@@ -355,7 +355,7 @@
         "it": "applemusic://track/263065220"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=RNDWIh3Z_zo",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/348185",
       "uri_deezer": "deezer://track/3611374",
       "fun_fact": "Staind are an American rock band best known for the ballad 'It's Been Awhile'.",
       "fun_fact_de": "Staind sind eine amerikanische Rockband, bekannt vor allem für die Ballade 'It's Been Awhile'.",
@@ -380,7 +380,7 @@
         "it": "applemusic://track/252254603"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=FHOBbtbiugo",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/1308545",
       "uri_deezer": "deezer://track/581935",
       "fun_fact": "A post-grunge / 2000s-rock track (2002).",
       "fun_fact_de": "Ein Post-Grunge-/2000er-Rock-Track (2002).",
@@ -405,7 +405,7 @@
         "it": "applemusic://track/6763248458"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=FLTx18QMXmE",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/32074197",
       "uri_deezer": "deezer://track/80274464",
       "fun_fact": "Creed were one of the defining American post-grunge bands of the late 90s and early 2000s.",
       "fun_fact_de": "Creed waren eine der prägenden amerikanischen Post-Grunge-Bands der späten 90er und frühen 2000er.",
@@ -430,7 +430,7 @@
         "it": "applemusic://track/1077069438"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=P39pSx1NcF8",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/56475878",
       "uri_deezer": "deezer://track/118996428",
       "fun_fact": "Daughtry was launched by Chris Daughtry after his run on American Idol.",
       "fun_fact_de": "Daughtry wurde von Chris Daughtry nach seiner American-Idol-Teilnahme gestartet.",
@@ -455,7 +455,7 @@
         "it": "applemusic://track/1800245375"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=kOFVsn6U9L8",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/5002024",
       "uri_deezer": "deezer://track/3825405",
       "fun_fact": "Shinedown are an American rock band from Jacksonville, Florida.",
       "fun_fact_de": "Shinedown sind eine amerikanische Rockband aus Jacksonville, Florida.",
@@ -480,7 +480,7 @@
         "it": "applemusic://track/1892529820"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=ui-TR4U9WOs",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/35973010",
       "uri_deezer": "deezer://track/623731972",
       "fun_fact": "Puddle of Mudd are an American rock band from Kansas City.",
       "fun_fact_de": "Puddle of Mudd sind eine amerikanische Rockband aus Kansas City.",
@@ -505,7 +505,7 @@
         "it": "applemusic://track/6766813783"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=2j8SyixzzQY",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/348192",
       "uri_deezer": "deezer://track/3611381",
       "fun_fact": "Staind are an American rock band best known for the ballad 'It's Been Awhile'.",
       "fun_fact_de": "Staind sind eine amerikanische Rockband, bekannt vor allem für die Ballade 'It's Been Awhile'.",
@@ -530,7 +530,7 @@
         "it": "applemusic://track/301126021"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=jtpfIwoV3DU",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/10916153",
       "uri_deezer": "deezer://track/4091624",
       "fun_fact": "A post-grunge / 2000s-rock track (2002).",
       "fun_fact_de": "Ein Post-Grunge-/2000er-Rock-Track (2002).",
@@ -555,7 +555,7 @@
         "it": "applemusic://track/1799744763"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=vtuZmShWLGo",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/11343607",
       "uri_deezer": "deezer://track/14876844",
       "fun_fact": "Incubus are a Californian rock band that evolved from funk-metal into alternative rock.",
       "fun_fact_de": "Incubus sind eine kalifornische Rockband, die sich von Funk-Metal zu Alternative Rock entwickelte.",


### PR DESCRIPTION
Automatische Tidal-Welle (06:00-Slot, 02.08.2026).

## Delta

| Playlist | Tidal vorher | nachher | version |
|---|---|---|---|
| `community/divorced-dad-rock` | 3/107 | **22/107** | 1.2 → 1.3 |

## Wellen-Bilanz

- **19 Treffer**, 0 echte Misses, 30 Rate-Limit-Skips (kommen in der 12:00-Welle wieder)
- **90 429-Backoffs** — Odesli drosselte von Anfang an hart
- Ende durch den 30-Minuten-Deckel (`--max-minutes 30`), nicht durch `--max 80`
- Miss-Cache 735 → 753 Einträge
- `validate_playlists.py`: 54/54 gültig, Schema-Gate grün

## Übriger Provider-Stand der Playlist

Spotify 107/107 · Deezer 107/107 · YouTube Music 107/107 · Apple Music 56/107 · **Tidal 22/107** — Tidal bleibt der große Rückstand.

Draft, kein Auto-Merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)