### PR TITLE
fix(playlists): korrekte Apple-Music-Region-Map für „Lotje" (#1949)

### DIFF
--- a/custom_components/beatify/playlists/community/top100-allertijden-nederlandstalig.json
+++ b/custom_components/beatify/playlists/community/top100-allertijden-nederlandstalig.json
@@ -1,6 +1,6 @@
 {
   "name": "Top 100 Dutch Classics 🇳🇱",
-  "version": "1.11",
+  "version": "1.12",
   "tags": [
     "nederlandstalig",
     "dutch",
@@ -3560,10 +3560,10 @@
         "us": "applemusic://track/1807093937",
         "de": "applemusic://track/1807093937",
         "gb": "applemusic://track/1807093937",
-        "fr": "applemusic://track/1294890829",
-        "es": "applemusic://track/1581435584",
-        "nl": "applemusic://track/1294890829",
-        "it": "applemusic://track/1791220442"
+        "fr": "applemusic://track/1807093937",
+        "es": "applemusic://track/1807093937",
+        "nl": "applemusic://track/1807093937",
+        "it": "applemusic://track/1807093937"
       }
     },
     {


### PR DESCRIPTION
`Closes #1949`

## Was war kaputt

Song-Index 102 in `community/top100-allertijden-nederlandstalig.json` — *Lustrum U.V.S.V./N.V.V.S.U., Jopke, Roeland Beelen — „Lotje"*. Vier von sieben Region-Einträgen zeigten auf **drei verschiedene, unverwandte Songs**:

| Region | vorher | lag dort | nachher |
|---|---|---|---|
| `fr` | `1294890829` | H.E.R. — „U" | `1807093937` |
| `nl` | `1294890829` | H.E.R. — „U" | `1807093937` |
| `es` | `1581435584` | zzoilo & Aitana — „Mon Amour (Remix)" | `1807093937` |
| `it` | `1791220442` | Coez — „Faccio un casino" | `1807093937` |

## Warum die Korrektur mechanisch tragfähig ist

Das Basisfeld `uri_apple_music` war **gesund**. Vor der Änderung einzeln per iTunes-Lookup geprüft: `1807093937` löst in **nl, fr, es, it und us** korrekt auf — jedes Mal *Lotje (Kroegenversie)*, richtiger Interpret. Es war also keine Recherche nötig, nur das Zurücksetzen auf die verifizierte Basis-ID.

## Diff

Genau **5 Zeilen**: 4 Region-Einträge plus `version` 1.11 → 1.12. Kein Reformatieren, Datei-Ende unverändert ohne Zeilenumbruch belassen.

`validate_playlists.py`: 54/54 gültig, Schema-Gate grün.

Draft, kein Auto-Merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)