### PR TITLE
chore(playlists): tidal backfill wave — +38 uris (divorced-dad-rock)

### DIFF
--- a/custom_components/beatify/playlists/community/divorced-dad-rock.json
+++ b/custom_components/beatify/playlists/community/divorced-dad-rock.json
@@ -1,6 +1,6 @@
 {
   "name": "Divorced Dad Rock",
-  "version": "1.3",
+  "version": "1.4",
   "tags": [
     "post-grunge",
     "nu-metal",
@@ -580,7 +580,7 @@
         "it": "applemusic://track/1645918297"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=TOwIGbTeCd8",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/76004365",
       "uri_deezer": "deezer://track/2628562",
       "fun_fact": "A post-grunge / 2000s-rock track (2001).",
       "fun_fact_de": "Ein Post-Grunge-/2000er-Rock-Track (2001).",
@@ -605,7 +605,7 @@
         "it": "applemusic://track/1829842080"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=3jDT-oZcSxQ",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/4014892",
       "uri_deezer": "deezer://track/6435665",
       "fun_fact": "Papa Roach broke through with their nu-metal anthem 'Last Resort' in 2000.",
       "fun_fact_de": "Papa Roach gelang mit ihrer Nu-Metal-Hymne 'Last Resort' im Jahr 2000 der Durchbruch.",
@@ -630,7 +630,7 @@
         "it": "applemusic://track/298376639"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=ph9KP2_lT5Q",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/1631925",
       "uri_deezer": "deezer://track/541012",
       "fun_fact": "Three Days Grace are a Canadian rock band, a fixture of 2000s active-rock radio.",
       "fun_fact_de": "Three Days Grace sind eine kanadische Rockband — fester Bestandteil des Active-Rock-Radios der 2000er.",
@@ -655,7 +655,7 @@
         "it": "applemusic://track/302036762"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=Wo7qhT7lBXw",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/2864068",
       "uri_deezer": "deezer://track/866622",
       "fun_fact": "Audioslave paired Soundgarden's Chris Cornell with the musicians of Rage Against the Machine.",
       "fun_fact_de": "Audioslave vereinten Soundgardens Chris Cornell mit den Musikern von Rage Against the Machine.",
@@ -680,7 +680,7 @@
         "it": "applemusic://track/1892530017"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=1hhvxCQOF2Q",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/31849290",
       "uri_deezer": "deezer://track/80274470",
       "fun_fact": "Creed were one of the defining American post-grunge bands of the late 90s and early 2000s.",
       "fun_fact_de": "Creed waren eine der prägenden amerikanischen Post-Grunge-Bands der späten 90er und frühen 2000er.",
@@ -705,7 +705,7 @@
         "it": "applemusic://track/1751829858"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=TC1AvkzjZr8",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/93170558",
       "uri_deezer": "deezer://track/538405542",
       "fun_fact": "A post-grunge / 2000s-rock track (2000).",
       "fun_fact_de": "Ein Post-Grunge-/2000er-Rock-Track (2000).",
@@ -730,7 +730,7 @@
         "it": "applemusic://track/1567216583"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=PHUL9w5-EVM",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/700192",
       "uri_deezer": "deezer://track/2139735",
       "fun_fact": "Nickelback are a Canadian rock band — one of the best-selling acts of the post-grunge era.",
       "fun_fact_de": "Nickelback sind eine kanadische Rockband — einer der meistverkauften Acts der Post-Grunge-Ära.",
@@ -755,7 +755,7 @@
         "it": "applemusic://track/1680620427"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=9VcI-t8rb8c",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/1631834",
       "uri_deezer": "deezer://track/2466008475",
       "fun_fact": "Switchfoot are a Californian alternative-rock band from San Diego.",
       "fun_fact_de": "Switchfoot sind eine kalifornische Alternative-Rock-Band aus San Diego.",
@@ -780,7 +780,7 @@
         "it": "applemusic://track/1770320488"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=5qZQEq_C3vc",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/234806",
       "uri_deezer": "deezer://track/677232",
       "fun_fact": "Linkin Park fused nu-metal, rap and rock into one of the biggest sounds of the 2000s.",
       "fun_fact_de": "Linkin Park verschmolzen Nu-Metal, Rap und Rock zu einem der größten Sounds der 2000er.",
@@ -805,7 +805,7 @@
         "it": "applemusic://track/131299294"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=_jGKB5b50Mk",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/585367",
       "uri_deezer": "deezer://track/978822",
       "fun_fact": "Audioslave paired Soundgarden's Chris Cornell with the musicians of Rage Against the Machine.",
       "fun_fact_de": "Audioslave vereinten Soundgardens Chris Cornell mit den Musikern von Rage Against the Machine.",
@@ -830,7 +830,7 @@
         "it": "applemusic://track/1779537259"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=BLZWkjBXfN8",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/1225577",
       "uri_deezer": "deezer://track/676183",
       "fun_fact": "Linkin Park fused nu-metal, rap and rock into one of the biggest sounds of the 2000s.",
       "fun_fact_de": "Linkin Park verschmolzen Nu-Metal, Rap und Rock zu einem der größten Sounds der 2000er.",
@@ -855,7 +855,7 @@
         "it": "applemusic://track/293236986"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=brj4BGkbOUw",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/1631830",
       "uri_deezer": "deezer://track/2453967",
       "fun_fact": "Switchfoot are a Californian alternative-rock band from San Diego.",
       "fun_fact_de": "Switchfoot sind eine kalifornische Alternative-Rock-Band aus San Diego.",
@@ -880,7 +880,7 @@
         "it": "applemusic://track/1688164546"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=8vMnKrN9FCw",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/3335968",
       "uri_deezer": "deezer://track/740318",
       "fun_fact": "A post-grunge / 2000s-rock track (2001).",
       "fun_fact_de": "Ein Post-Grunge-/2000er-Rock-Track (2001).",
@@ -905,7 +905,7 @@
         "it": "applemusic://track/1749571990"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=7-Ik8Pn0u7A",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/703434",
       "uri_deezer": "deezer://track/660760",
       "fun_fact": "A post-grunge / 2000s-rock track (2006).",
       "fun_fact_de": "Ein Post-Grunge-/2000er-Rock-Track (2006).",
@@ -930,7 +930,7 @@
         "it": "applemusic://track/1892522277"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=7BMyt8Znpkk",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/31849370",
       "uri_deezer": "deezer://track/80274650",
       "fun_fact": "Creed were one of the defining American post-grunge bands of the late 90s and early 2000s.",
       "fun_fact_de": "Creed waren eine der prägenden amerikanischen Post-Grunge-Bands der späten 90er und frühen 2000er.",
@@ -955,7 +955,7 @@
         "it": "applemusic://track/438938124"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=-cid1qHuy_U",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/17825556",
       "uri_deezer": "deezer://track/859699",
       "fun_fact": "System of a Down are an Armenian-American metal band known for their unmistakable sound.",
       "fun_fact_de": "System of a Down sind eine armenisch-amerikanische Metal-Band mit einem unverwechselbaren Sound.",
@@ -980,7 +980,7 @@
         "it": "applemusic://track/208294773"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=t5ANJpUj0hg",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/532961",
       "uri_deezer": "deezer://track/866619",
       "fun_fact": "Audioslave paired Soundgarden's Chris Cornell with the musicians of Rage Against the Machine.",
       "fun_fact_de": "Audioslave vereinten Soundgardens Chris Cornell mit den Musikern von Rage Against the Machine.",
@@ -1005,7 +1005,7 @@
         "it": "applemusic://track/1445669378"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=qQ0zxuWFxrY",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/76773928",
       "uri_deezer": "deezer://track/1103890762",
       "fun_fact": "Hoobastank are a Californian rock band best known for the ballad 'The Reason'.",
       "fun_fact_de": "Hoobastank sind eine kalifornische Rockband, bekannt vor allem für die Ballade 'The Reason'.",
@@ -1030,7 +1030,7 @@
         "it": "applemusic://track/1763046567"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=-YQ8IbVIwPM",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/234796",
       "uri_deezer": "deezer://track/14628995",
       "fun_fact": "Linkin Park fused nu-metal, rap and rock into one of the biggest sounds of the 2000s.",
       "fun_fact_de": "Linkin Park verschmolzen Nu-Metal, Rap und Rock zu einem der größten Sounds der 2000er.",
@@ -1130,7 +1130,7 @@
         "it": "applemusic://track/1892522089"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=weqK155M_4o",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/67367356",
       "uri_deezer": "deezer://track/137234202",
       "fun_fact": "The Offspring are a Californian punk-rock band that crossed firmly into the mainstream.",
       "fun_fact_de": "The Offspring sind eine kalifornische Punk-Rock-Band, die fest in den Mainstream vordrang.",
@@ -1155,7 +1155,7 @@
         "it": "applemusic://track/334812012"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=L6SIgRlijmU",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/3146734",
       "uri_deezer": "deezer://track/4311595",
       "fun_fact": "The Foo Fighters were formed by ex-Nirvana drummer Dave Grohl after Kurt Cobain's death.",
       "fun_fact_de": "Die Foo Fighters wurden von Ex-Nirvana-Drummer Dave Grohl nach Kurt Cobains Tod gegründet.",
@@ -1180,7 +1180,7 @@
         "it": "applemusic://track/1799756618"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=rwj9xcy5Ums",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/5120244",
       "uri_deezer": "deezer://track/7675298",
       "fun_fact": "A post-grunge / 2000s-rock track (1998).",
       "fun_fact_de": "Ein Post-Grunge-/2000er-Rock-Track (1998).",
@@ -1205,7 +1205,7 @@
         "it": "applemusic://track/6767217674"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=8AXoeZW73XY",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/700197",
       "uri_deezer": "deezer://track/1094264072",
       "fun_fact": "Nickelback are a Canadian rock band — one of the best-selling acts of the post-grunge era.",
       "fun_fact_de": "Nickelback sind eine kanadische Rockband — einer der meistverkauften Acts der Post-Grunge-Ära.",
@@ -1230,7 +1230,7 @@
         "it": "applemusic://track/1892483827"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=vbMh38KGZMM",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/35354658",
       "uri_deezer": "deezer://track/7419123",
       "fun_fact": "A post-grunge / 2000s-rock track (2008).",
       "fun_fact_de": "Ein Post-Grunge-/2000er-Rock-Track (2008).",
@@ -1255,7 +1255,7 @@
         "it": "applemusic://track/1748941175"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=VTgMFcFIH9k",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/268226",
       "uri_deezer": "deezer://track/663165",
       "fun_fact": "Matchbox Twenty are an American rock band fronted by Rob Thomas.",
       "fun_fact_de": "Matchbox Twenty sind eine amerikanische Rockband mit Frontmann Rob Thomas.",
@@ -1280,7 +1280,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=iY7LLYCmkpU",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/73879392",
       "uri_deezer": "deezer://track/361116571",
       "fun_fact": "A post-grunge / 2000s-rock track (1996).",
       "fun_fact_de": "Ein Post-Grunge-/2000er-Rock-Track (1996).",
@@ -1305,7 +1305,7 @@
         "it": "applemusic://track/1666737341"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=pcAKbKUBUOQ",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/36766279",
       "uri_deezer": "deezer://track/130132899",
       "fun_fact": "Breaking Benjamin are an American rock band from Pennsylvania.",
       "fun_fact_de": "Breaking Benjamin sind eine amerikanische Rockband aus Pennsylvania.",
@@ -1330,7 +1330,7 @@
         "it": "applemusic://track/1602385479"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=f6z2dS5KHgc",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/477381",
       "uri_deezer": "deezer://track/104011168",
       "fun_fact": "Limp Bizkit were among the most commercially dominant nu-metal acts of the era.",
       "fun_fact_de": "Limp Bizkit zählten zu den kommerziell dominantesten Nu-Metal-Acts ihrer Zeit.",
@@ -1355,7 +1355,7 @@
         "it": "applemusic://track/6763248457"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=ZD3kCxMqjuk",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/32074389",
       "uri_deezer": "deezer://track/80275000",
       "fun_fact": "A post-grunge / 2000s-rock track (2007).",
       "fun_fact_de": "Ein Post-Grunge-/2000er-Rock-Track (2007).",
@@ -1380,7 +1380,7 @@
         "it": "applemusic://track/1551378218"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=-uQi0vJK9lk",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/67367330",
       "uri_deezer": "deezer://track/137233986",
       "fun_fact": "The Offspring are a Californian punk-rock band that crossed firmly into the mainstream.",
       "fun_fact_de": "The Offspring sind eine kalifornische Punk-Rock-Band, die fest in den Mainstream vordrang.",
@@ -1405,7 +1405,7 @@
         "it": "applemusic://track/1706933199"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=Imimigrz7GQ",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/31848571",
       "uri_deezer": "deezer://track/80276126",
       "fun_fact": "Seether are a South African post-grunge band that broke through internationally in the 2000s.",
       "fun_fact_de": "Seether sind eine südafrikanische Post-Grunge-Band, die in den 2000ern international durchbrach.",
@@ -1430,7 +1430,7 @@
         "it": "applemusic://track/1769626227"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=I6NU3kWqnDE",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/1225574",
       "uri_deezer": "deezer://track/676171",
       "fun_fact": "Linkin Park fused nu-metal, rap and rock into one of the biggest sounds of the 2000s.",
       "fun_fact_de": "Linkin Park verschmolzen Nu-Metal, Rap und Rock zu einem der größten Sounds der 2000er.",
@@ -1455,7 +1455,7 @@
         "it": "applemusic://track/396134137"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=zA3pE_cLUdU",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/552725",
       "uri_deezer": "deezer://track/563772",
       "fun_fact": "Audioslave paired Soundgarden's Chris Cornell with the musicians of Rage Against the Machine.",
       "fun_fact_de": "Audioslave vereinten Soundgardens Chris Cornell mit den Musikern von Rage Against the Machine.",
@@ -1480,7 +1480,7 @@
         "it": "applemusic://track/1440635198"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=Ib9swdvt3mA",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/36766280",
       "uri_deezer": "deezer://track/13711281",
       "fun_fact": "Breaking Benjamin are an American rock band from Pennsylvania.",
       "fun_fact_de": "Breaking Benjamin sind eine amerikanische Rockband aus Pennsylvania.",
@@ -1505,7 +1505,7 @@
         "it": "applemusic://track/1678339751"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=KXRKoM0misA",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/1211244",
       "uri_deezer": "deezer://track/2680857",
       "fun_fact": "A post-grunge / 2000s-rock track (1999).",
       "fun_fact_de": "Ein Post-Grunge-/2000er-Rock-Track (1999).",
@@ -1530,7 +1530,7 @@
         "it": "applemusic://track/1701819671"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=gqM8S4geS5w",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/5002023",
       "uri_deezer": "deezer://track/3825404",
       "fun_fact": "Shinedown are an American rock band from Jacksonville, Florida.",
       "fun_fact_de": "Shinedown sind eine amerikanische Rockband aus Jacksonville, Florida.",
@@ -1555,7 +1555,7 @@
         "it": "applemusic://track/1524782384"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=uHUzMb74Z18",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/23267442",
       "uri_deezer": "deezer://track/1094264012",
       "fun_fact": "Nickelback are a Canadian rock band — one of the best-selling acts of the post-grunge era.",
       "fun_fact_de": "Nickelback sind eine kanadische Rockband — einer der meistverkauften Acts der Post-Grunge-Ära.",
@@ -1580,7 +1580,7 @@
         "it": "applemusic://track/1716124943"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=akoYOyky_3c",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/31848768",
       "uri_deezer": "deezer://track/80276490",
       "fun_fact": "Seether are a South African post-grunge band that broke through internationally in the 2000s.",
       "fun_fact_de": "Seether sind eine südafrikanische Post-Grunge-Band, die in den 2000ern international durchbrach.",


### PR DESCRIPTION
## Welle 18:00 (02.08.2026)

**`divorced-dad-rock` 22 → 60 / 107 Tidal-URIs** (+38), version 1.3 → 1.4.

### Bilanz

- 38 Treffer
- 0 echte Misses
- 27 Rate-Limit-Skips (kommen in der 22:00-Welle wieder)
- 83 429-Backoffs
- Miss-Cache 753 → 790 Einträge

Gestoppt hat der **Zeitdeckel `--max-minutes 30`**, nicht `--max 80` — die Welle war noch nicht ausgereizt, die 27 Skips sind offene Kandidaten.

### Provider-Stand der Playlist danach

| Provider | Abdeckung |
|---|---|
| Spotify | 107/107 |
| Deezer | 107/107 |
| YouTube Music | 107/107 |
| Tidal | **60/107** |
| Apple Music | 56/107 |

Tidal und Apple sind der verbleibende Rückstand; die anderen drei sind komplett.

### Gate

`validate_playlists.py` grün — 54 Dateien valide, `divorced-dad-rock.json` ohne Lint-Warnung.

Diff ist 1 Datei / +39 −39 = 38 × `uri_tidal` + `version`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)