### PR TITLE
chore(playlists): tidal backfill wave — +19 uris (divorced-dad-rock)

### DIFF
--- a/custom_components/beatify/playlists/community/divorced-dad-rock.json
+++ b/custom_components/beatify/playlists/community/divorced-dad-rock.json
@@ -1,6 +1,6 @@
 {
   "name": "Divorced Dad Rock",
-  "version": "1.4",
+  "version": "1.5",
   "tags": [
     "post-grunge",
     "nu-metal",
@@ -1055,7 +1055,7 @@
         "it": "applemusic://track/1703143668"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=mjXRapctp6k",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/334653",
       "uri_deezer": "deezer://track/1108061",
       "fun_fact": "A post-grunge / 2000s-rock track (2000).",
       "fun_fact_de": "Ein Post-Grunge-/2000er-Rock-Track (2000).",
@@ -1080,7 +1080,7 @@
         "it": "applemusic://track/255220737"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=pOOItvMnMB0",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/1788214",
       "uri_deezer": "deezer://track/866625",
       "fun_fact": "Audioslave paired Soundgarden's Chris Cornell with the musicians of Rage Against the Machine.",
       "fun_fact_de": "Audioslave vereinten Soundgardens Chris Cornell mit den Musikern von Rage Against the Machine.",
@@ -1105,7 +1105,7 @@
         "it": "applemusic://track/1788999886"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=z1ndFL1v34E",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/1631945",
       "uri_deezer": "deezer://track/541867",
       "fun_fact": "A post-grunge / 2000s-rock track (2002).",
       "fun_fact_de": "Ein Post-Grunge-/2000er-Rock-Track (2002).",
@@ -1605,7 +1605,7 @@
         "it": "applemusic://track/1799745093"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=0TxeLL_0-Vc",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/1308296",
       "uri_deezer": "deezer://track/7675296",
       "fun_fact": "A post-grunge / 2000s-rock track (2000).",
       "fun_fact_de": "Ein Post-Grunge-/2000er-Rock-Track (2000).",
@@ -1630,7 +1630,7 @@
         "it": "applemusic://track/1705329728"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=-wGdGUTBbqQ",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/477379",
       "uri_deezer": "deezer://track/1143493",
       "fun_fact": "Limp Bizkit were among the most commercially dominant nu-metal acts of the era.",
       "fun_fact_de": "Limp Bizkit zählten zu den kommerziell dominantesten Nu-Metal-Acts ihrer Zeit.",
@@ -1655,7 +1655,7 @@
         "it": "applemusic://track/1703143431"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=eEpbE2UJXcU",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/1342021",
       "uri_deezer": "deezer://track/3119156",
       "fun_fact": "A post-grunge / 2000s-rock track (2004).",
       "fun_fact_de": "Ein Post-Grunge-/2000er-Rock-Track (2004).",
@@ -1680,7 +1680,7 @@
         "it": "applemusic://track/1290809"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=vTxFQGb3Op4",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/255737",
       "uri_deezer": "deezer://track/3592362",
       "fun_fact": "Staind are an American rock band best known for the ballad 'It's Been Awhile'.",
       "fun_fact_de": "Staind sind eine amerikanische Rockband, bekannt vor allem für die Ballade 'It's Been Awhile'.",
@@ -1705,7 +1705,7 @@
         "it": "applemusic://track/1788997574"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=BQxs17l4GEQ",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/100897",
       "uri_deezer": "deezer://track/866618",
       "fun_fact": "Audioslave paired Soundgarden's Chris Cornell with the musicians of Rage Against the Machine.",
       "fun_fact_de": "Audioslave vereinten Soundgardens Chris Cornell mit den Musikern von Rage Against the Machine.",
@@ -1730,7 +1730,7 @@
         "it": "applemusic://track/1876962476"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=Dy_eP-mqWow",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/1211254",
       "uri_deezer": "deezer://track/3841257141",
       "fun_fact": "A post-grunge / 2000s-rock track (2004).",
       "fun_fact_de": "Ein Post-Grunge-/2000er-Rock-Track (2004).",
@@ -1755,7 +1755,7 @@
         "it": "applemusic://track/1130011053"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=AxuTd9rwEHQ",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/3146735",
       "uri_deezer": "deezer://track/4762041",
       "fun_fact": "The Foo Fighters were formed by ex-Nirvana drummer Dave Grohl after Kurt Cobain's death.",
       "fun_fact_de": "Die Foo Fighters wurden von Ex-Nirvana-Drummer Dave Grohl nach Kurt Cobains Tod gegründet.",
@@ -1780,7 +1780,7 @@
         "it": "applemusic://track/1849880061"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=sYjXE0mCPzU",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/118552282",
       "uri_deezer": "deezer://track/3098924461",
       "fun_fact": "A post-grunge / 2000s-rock track (2006).",
       "fun_fact_de": "Ein Post-Grunge-/2000er-Rock-Track (2006).",
@@ -1805,7 +1805,7 @@
         "it": "applemusic://track/618713069"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=e-2251_at-k",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/17825564",
       "uri_deezer": "deezer://track/15523799",
       "fun_fact": "System of a Down are an Armenian-American metal band known for their unmistakable sound.",
       "fun_fact_de": "System of a Down sind eine armenisch-amerikanische Metal-Band mit einem unverwechselbaren Sound.",
@@ -1830,7 +1830,7 @@
         "it": "applemusic://track/1794125837"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=hH4wcNRj9PI",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/3015267",
       "uri_deezer": "deezer://track/72189643",
       "fun_fact": "Matchbox Twenty are an American rock band fronted by Rob Thomas.",
       "fun_fact_de": "Matchbox Twenty sind eine amerikanische Rockband mit Frontmann Rob Thomas.",
@@ -1855,7 +1855,7 @@
         "it": "applemusic://track/1892522090"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=nIxxdRaWoBs",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/1393750",
       "uri_deezer": "deezer://track/3090875",
       "fun_fact": "A post-grunge / 2000s-rock track (2005).",
       "fun_fact_de": "Ein Post-Grunge-/2000er-Rock-Track (2005).",
@@ -1880,7 +1880,7 @@
         "it": "applemusic://track/1494718470"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=PIF4So6xcU8",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/392563",
       "uri_deezer": "deezer://track/778452",
       "fun_fact": "A post-grunge / 2000s-rock track (1998).",
       "fun_fact_de": "Ein Post-Grunge-/2000er-Rock-Track (1998).",
@@ -1905,7 +1905,7 @@
         "it": "applemusic://track/1701076383"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=eb3kAUQxinQ",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/417841714",
       "uri_deezer": "deezer://track/407646162",
       "fun_fact": "A post-grunge / 2000s-rock track (1993).",
       "fun_fact_de": "Ein Post-Grunge-/2000er-Rock-Track (1993).",
@@ -1930,7 +1930,7 @@
         "it": "applemusic://track/1799744580"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=FwTQOPZvY3s",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/18012088",
       "uri_deezer": "deezer://track/7410392",
       "fun_fact": "A post-grunge / 2000s-rock track (1999).",
       "fun_fact_de": "Ein Post-Grunge-/2000er-Rock-Track (1999).",
@@ -1955,7 +1955,7 @@
         "it": "applemusic://track/1440751090"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=bzXSBPnvhRI",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/478047",
       "uri_deezer": "deezer://track/1138326",
       "fun_fact": "A post-grunge / 2000s-rock track (2005).",
       "fun_fact_de": "Ein Post-Grunge-/2000er-Rock-Track (2005).",
@@ -1980,7 +1980,7 @@
         "it": "applemusic://track/1517407814"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=bZ6VcOVQpcE",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/3335967",
       "uri_deezer": "deezer://track/740289",
       "fun_fact": "A post-grunge / 2000s-rock track (2001).",
       "fun_fact_de": "Ein Post-Grunge-/2000er-Rock-Track (2001).",


### PR DESCRIPTION
On-demand wave (Markus' Quick-Pill, 20:21) — a follow-up to #1951 aimed at the 27 rate-limit skips that wave left behind.

## Delta

| Playlist | Tidal before | after | version |
|---|---|---|---|
| `divorced-dad-rock` | 60/107 | **79/107** | 1.4 → 1.5 |

## Wave balance

- **19 hits · 0 genuine misses · 28 rate-limit skips · 84 429-backoffs**
- Stopped on the 30-minute wall-clock cap (`--max-minutes 30`), not on `--max 80` — the wave was at 47 of 80 possible queries.
- Miss-cache 790 → 808 entries, merged back into the canonical copy.
- Targeted at this single playlist rather than the whole catalogue, so the Odesli budget went entirely into its open slots.

## Provider state after this wave

Spotify 107/107 · Deezer 107/107 · YouTube Music 107/107 · **Tidal 79/107** · Apple Music 56/107

The remaining 28 Tidal gaps are all rate-limit skips, not confirmed misses — candidates for the next wave.

## Gate

`validate_playlists.py` green, 54 files, no lint warning on the changed file.

Draft — Markus reviews and merges.