### PR TITLE
chore(playlists): tidal backfill wave — +19 uris (divorced-dad-rock)

### DIFF
--- a/custom_components/beatify/playlists/community/divorced-dad-rock.json
+++ b/custom_components/beatify/playlists/community/divorced-dad-rock.json
@@ -1,6 +1,6 @@
 {
   "name": "Divorced Dad Rock",
-  "version": "1.5",
+  "version": "1.6",
   "tags": [
     "post-grunge",
     "nu-metal",
@@ -2005,7 +2005,7 @@
         "it": "applemusic://track/337355453"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=mUEsqQpact0",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/17825562",
       "uri_deezer": "deezer://track/15523793",
       "fun_fact": "System of a Down are an Armenian-American metal band known for their unmistakable sound.",
       "fun_fact_de": "System of a Down sind eine armenisch-amerikanische Metal-Band mit einem unverwechselbaren Sound.",
@@ -2030,7 +2030,7 @@
         "it": "applemusic://track/1549644079"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=4a_yFS0Vuzo",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/11009222",
       "uri_deezer": "deezer://track/4086848",
       "fun_fact": "A post-grunge / 2000s-rock track (1998).",
       "fun_fact_de": "Ein Post-Grunge-/2000er-Rock-Track (1998).",
@@ -2055,7 +2055,7 @@
         "it": "applemusic://track/290303018"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=5xppdO2b2rc",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/1906287",
       "uri_deezer": "deezer://track/2924841",
       "fun_fact": "A post-grunge / 2000s-rock track (2009).",
       "fun_fact_de": "Ein Post-Grunge-/2000er-Rock-Track (2009).",
@@ -2080,7 +2080,7 @@
         "it": "applemusic://track/1741671531"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=7a_YLfSvHCo",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/34793",
       "uri_deezer": "deezer://track/13144808",
       "fun_fact": "A post-grunge / 2000s-rock track (1999).",
       "fun_fact_de": "Ein Post-Grunge-/2000er-Rock-Track (1999).",
@@ -2105,7 +2105,7 @@
         "it": "applemusic://track/483191914"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=-T3jhVhNZKE",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/4949566",
       "uri_deezer": "deezer://track/13167070",
       "fun_fact": "Three Days Grace are a Canadian rock band, a fixture of 2000s active-rock radio.",
       "fun_fact_de": "Three Days Grace sind eine kanadische Rockband — fester Bestandteil des Active-Rock-Radios der 2000er.",
@@ -2130,7 +2130,7 @@
         "it": "applemusic://track/1778714096"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=Jc6-WXt5iKA",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/1795001",
       "uri_deezer": "deezer://track/546578",
       "fun_fact": "System of a Down are an Armenian-American metal band known for their unmistakable sound.",
       "fun_fact_de": "System of a Down sind eine armenisch-amerikanische Metal-Band mit einem unverwechselbaren Sound.",
@@ -2155,7 +2155,7 @@
         "it": "applemusic://track/1440733705"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=OqEZPdmevhc",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/1218907",
       "uri_deezer": "deezer://track/914234",
       "fun_fact": "A post-grunge / 2000s-rock track (2002).",
       "fun_fact_de": "Ein Post-Grunge-/2000er-Rock-Track (2002).",
@@ -2180,7 +2180,7 @@
         "it": "applemusic://track/1645901771"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=-eGM0IJc70Y",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/31849195",
       "uri_deezer": "deezer://track/80274512",
       "fun_fact": "A post-grunge / 2000s-rock track (2003).",
       "fun_fact_de": "Ein Post-Grunge-/2000er-Rock-Track (2003).",
@@ -2205,7 +2205,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=_t1vqLwqbyA",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/392568",
       "uri_deezer": "deezer://track/778493",
       "fun_fact": "A post-grunge / 2000s-rock track (1998).",
       "fun_fact_de": "Ein Post-Grunge-/2000er-Rock-Track (1998).",
@@ -2230,7 +2230,7 @@
         "it": "applemusic://track/1789000053"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=J497TQ6jcHI",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/409692490",
       "uri_deezer": "deezer://track/866620",
       "fun_fact": "Audioslave paired Soundgarden's Chris Cornell with the musicians of Rage Against the Machine.",
       "fun_fact_de": "Audioslave vereinten Soundgardens Chris Cornell mit den Musikern von Rage Against the Machine.",
@@ -2255,7 +2255,7 @@
         "it": "applemusic://track/1440754476"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=2_ANCiQOEfw",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/35749816",
       "uri_deezer": "deezer://track/94613610",
       "fun_fact": "Limp Bizkit were among the most commercially dominant nu-metal acts of the era.",
       "fun_fact_de": "Limp Bizkit zählten zu den kommerziell dominantesten Nu-Metal-Acts ihrer Zeit.",
@@ -2280,7 +2280,7 @@
         "it": "applemusic://track/1799757090"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=Z3hvVzfW1sk",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/33725743",
       "uri_deezer": "deezer://track/15489584",
       "fun_fact": "Incubus are a Californian rock band that evolved from funk-metal into alternative rock.",
       "fun_fact_de": "Incubus sind eine kalifornische Rockband, die sich von Funk-Metal zu Alternative Rock entwickelte.",
@@ -2305,7 +2305,7 @@
         "it": "applemusic://track/1789000068"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=rTFhszubbXE",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/4949567",
       "uri_deezer": "deezer://track/13167071",
       "fun_fact": "Three Days Grace are a Canadian rock band, a fixture of 2000s active-rock radio.",
       "fun_fact_de": "Three Days Grace sind eine kanadische Rockband — fester Bestandteil des Active-Rock-Radios der 2000er.",
@@ -2330,7 +2330,7 @@
         "it": "applemusic://track/1761838896"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=t2rsf8SiMJY",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/3015268",
       "uri_deezer": "deezer://track/72189644",
       "fun_fact": "Matchbox Twenty are an American rock band fronted by Rob Thomas.",
       "fun_fact_de": "Matchbox Twenty sind eine amerikanische Rockband mit Frontmann Rob Thomas.",
@@ -2355,7 +2355,7 @@
         "it": "applemusic://track/571750359"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=XZLnd3uwars",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/11343618",
       "uri_deezer": "deezer://track/14876855",
       "fun_fact": "Incubus are a Californian rock band that evolved from funk-metal into alternative rock.",
       "fun_fact_de": "Incubus sind eine kalifornische Rockband, die sich von Funk-Metal zu Alternative Rock entwickelte.",
@@ -2380,7 +2380,7 @@
         "it": "applemusic://track/1774312003"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=MXBMd-XO0Yo",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/32074193",
       "uri_deezer": "deezer://track/80297284",
       "fun_fact": "Creed were one of the defining American post-grunge bands of the late 90s and early 2000s.",
       "fun_fact_de": "Creed waren eine der prägenden amerikanischen Post-Grunge-Bands der späten 90er und frühen 2000er.",
@@ -2405,7 +2405,7 @@
         "it": "applemusic://track/1032181382"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=EOjm4SEDMu8",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/1906286",
       "uri_deezer": "deezer://track/15531170",
       "fun_fact": "A post-grunge / 2000s-rock track (2008).",
       "fun_fact_de": "Ein Post-Grunge-/2000er-Rock-Track (2008).",
@@ -2430,7 +2430,7 @@
         "it": "applemusic://track/208294962"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=6nxlcQsPE4I",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/111180812",
       "uri_deezer": "deezer://track/866624",
       "fun_fact": "Audioslave paired Soundgarden's Chris Cornell with the musicians of Rage Against the Machine.",
       "fun_fact_de": "Audioslave vereinten Soundgardens Chris Cornell mit den Musikern von Rage Against the Machine.",
@@ -2455,7 +2455,7 @@
         "it": "applemusic://track/1650514030"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=V_DI4mhrY64",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/3146737",
       "uri_deezer": "deezer://track/4311598",
       "fun_fact": "The Foo Fighters were formed by ex-Nirvana drummer Dave Grohl after Kurt Cobain's death.",
       "fun_fact_de": "Die Foo Fighters wurden von Ex-Nirvana-Drummer Dave Grohl nach Kurt Cobains Tod gegründet.",


### PR DESCRIPTION
Scheduled 22:00 wave, invoked **catalogue-wide** (no file argument).

## Delta

| Playlist | Tidal before | after | version |
|---|---|---|---|
| `divorced-dad-rock` | 79/107 | **98/107** | 1.5 → 1.6 |

## Wave balance

- **19 hits · 0 genuine misses · 30 rate-limit skips · 90 429-backoffs**
- Stopped on the 30-minute wall-clock cap.
- Miss-cache 808 → 826 entries, merged back into the canonical copy.

## Worth noting: catalogue-wide did not mean fresh material

`backfill_tidal.py` walks `sorted(PLAYLISTS_DIR.rglob("*.json"))` — a deterministic
alphabetical order. Files already complete are skipped without a query, so every
catalogue-wide wave starts at the *first file that still has gaps*. Today that is
`community/divorced-dad-rock.json`, and the 30-minute cap expired before the walk
got past it.

Consequence: with ~2000 open candidates and 80 queries per wave, the front of the
alphabet is worked repeatedly while the tail is never reached. Targeting a specific
playlist requires passing it explicitly as a positional argument.

## Gate

`validate_playlists.py` green, 54 files, no lint warning on the changed file.

Draft — Markus reviews and merges.