### PR TITLE
chore(playlists): tidal backfill wave — +19 uris across 2 playlists

### DIFF
--- a/custom_components/beatify/playlists/community/divorced-dad-rock.json
+++ b/custom_components/beatify/playlists/community/divorced-dad-rock.json
@@ -1,6 +1,6 @@
 {
   "name": "Divorced Dad Rock",
-  "version": "1.6",
+  "version": "1.7",
   "tags": [
     "post-grunge",
     "nu-metal",
@@ -2480,7 +2480,7 @@
         "it": "applemusic://track/1616083922"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=LMsBHDoC51c",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/49157053",
       "uri_deezer": "deezer://track/1143496",
       "fun_fact": "Limp Bizkit were among the most commercially dominant nu-metal acts of the era.",
       "fun_fact_de": "Limp Bizkit zählten zu den kommerziell dominantesten Nu-Metal-Acts ihrer Zeit.",
@@ -2505,7 +2505,7 @@
         "it": "applemusic://track/1719041513"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=H1i5HaQV9ck",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/33723797",
       "uri_deezer": "deezer://track/15523335",
       "fun_fact": "A post-grunge / 2000s-rock track (1992).",
       "fun_fact_de": "Ein Post-Grunge-/2000er-Rock-Track (1992).",
@@ -2530,7 +2530,7 @@
         "it": "applemusic://track/1706914822"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=iYcbfc_UB6M",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/31849323",
       "uri_deezer": "deezer://track/80274568",
       "fun_fact": "A post-grunge / 2000s-rock track (2000).",
       "fun_fact_de": "Ein Post-Grunge-/2000er-Rock-Track (2000).",
@@ -2555,7 +2555,7 @@
         "it": "applemusic://track/1650514546"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=HJMLLKgknvk",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/3146738",
       "uri_deezer": "deezer://track/4311599",
       "fun_fact": "The Foo Fighters were formed by ex-Nirvana drummer Dave Grohl after Kurt Cobain's death.",
       "fun_fact_de": "Die Foo Fighters wurden von Ex-Nirvana-Drummer Dave Grohl nach Kurt Cobains Tod gegründet.",
@@ -2580,7 +2580,7 @@
         "it": "applemusic://track/1457976257"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=NDdqhnFm0L0",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/23267448",
       "uri_deezer": "deezer://track/795239",
       "fun_fact": "Nickelback are a Canadian rock band — one of the best-selling acts of the post-grunge era.",
       "fun_fact_de": "Nickelback sind eine kanadische Rockband — einer der meistverkauften Acts der Post-Grunge-Ära.",
@@ -2605,7 +2605,7 @@
         "it": "applemusic://track/1695532447"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=kLtdJ1rM8es",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/2914800",
       "uri_deezer": "deezer://track/7675611",
       "fun_fact": "A post-grunge / 2000s-rock track (2002).",
       "fun_fact_de": "Ein Post-Grunge-/2000er-Rock-Track (2002).",
@@ -2630,7 +2630,7 @@
         "it": "applemusic://track/1650409506"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=06HcqK2vvlw",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/225479",
       "uri_deezer": "deezer://track/678053",
       "fun_fact": "Green Day are a Californian punk-rock trio and one of the genre's biggest mainstream successes.",
       "fun_fact_de": "Green Day sind ein kalifornisches Punk-Rock-Trio und einer der größten Mainstream-Erfolge des Genres.",
@@ -2655,7 +2655,7 @@
         "it": "applemusic://track/216661494"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=ZjhkSjb41VQ",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/1108913",
       "uri_deezer": "deezer://track/3866895",
       "fun_fact": "A post-grunge / 2000s-rock track (2002).",
       "fun_fact_de": "Ein Post-Grunge-/2000er-Rock-Track (2002).",
@@ -2680,7 +2680,7 @@
         "it": "applemusic://track/6762674925"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=SB3wAJjJP6c",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/173565587",
       "uri_deezer": "deezer://track/127354209",
       "fun_fact": "blink-182 are a Californian pop-punk band that shaped the sound of an era.",
       "fun_fact_de": "blink-182 sind eine kalifornische Pop-Punk-Band, die den Sound einer Ära prägte.",

--- a/custom_components/beatify/playlists/community/edm-anthems.json
+++ b/custom_components/beatify/playlists/community/edm-anthems.json
@@ -1,6 +1,6 @@
 {
   "name": "EDM Anthems",
-  "version": "1.6",
+  "version": "1.7",
   "tags": [
     "edm",
     "electronic",
@@ -600,7 +600,7 @@
         "it": "applemusic://track/1750578593"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=qpiilPFQtwM",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/18420577",
       "uri_deezer": "deezer://track/62847147",
       "fun_fact": "“Play Hard (feat. Ne-Yo & Akon)” appears on David Guetta’s release “Nothing but the Beat (Ultimate Edition)”.",
       "fun_fact_de": "„Play Hard (feat. Ne-Yo & Akon)“ erschien auf der Veröffentlichung „Nothing but the Beat (Ultimate Edition)“ von David Guetta.",
@@ -630,7 +630,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=1s4-OFCBUGo",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/33531474",
       "uri_deezer": "deezer://track/83844544",
       "fun_fact": "“Break Free” appears on Ariana Grande’s release “My Everything (Deluxe)”.",
       "fun_fact_de": "„Break Free“ erschien auf der Veröffentlichung „My Everything (Deluxe)“ von Ariana Grande.",
@@ -660,7 +660,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=aWkPBCF8rFU",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/15905192",
       "uri_deezer": "deezer://track/37027991",
       "fun_fact": "“Beauty And A Beat” appears on Justin Bieber’s release “Believe (Deluxe Edition)”.",
       "fun_fact_de": "„Beauty And A Beat“ erschien auf der Veröffentlichung „Believe (Deluxe Edition)“ von Justin Bieber.",
@@ -690,7 +690,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=n6N1_sxlBU8",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/10582679",
       "uri_deezer": "deezer://track/14113580",
       "fun_fact": "“We Found Love” appears on Rihanna’s release “Talk That Talk (Deluxe)”.",
       "fun_fact_de": "„We Found Love“ erschien auf der Veröffentlichung „Talk That Talk (Deluxe)“ von Rihanna.",
@@ -720,7 +720,7 @@
         "it": "applemusic://track/1740076913"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=gTQk2mWE0xs",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/355591507",
       "uri_deezer": "deezer://track/2739157311",
       "fun_fact": "“Ring Ring” is the title track of MIRA’s release of the same name.",
       "fun_fact_de": "„Ring Ring“ ist der Titelsong der gleichnamigen Veröffentlichung von MIRA.",
@@ -750,7 +750,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=4tFktcmLl5M",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/27865010",
       "uri_deezer": "deezer://track/76520669",
       "fun_fact": "“Bad (feat. Vassy) - Radio Edit” is the title track of David Guetta’s release of the same name.",
       "fun_fact_de": "„Bad (feat. Vassy) - Radio Edit“ ist der Titelsong der gleichnamigen Veröffentlichung von David Guetta.",
@@ -780,7 +780,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=3mWbRB3Y4R8",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/17271290",
       "uri_deezer": "deezer://track/60842359",
       "fun_fact": "“Don't You Worry Child - Radio Edit” appears on Swedish House Mafia’s release “Don't You Worry Child”.",
       "fun_fact_de": "„Don't You Worry Child - Radio Edit“ erschien auf der Veröffentlichung „Don't You Worry Child“ von Swedish House Mafia.",
@@ -810,7 +810,7 @@
         "it": "applemusic://track/1685074634"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=aDPkAK5s30I",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/38092836",
       "uri_deezer": "deezer://track/90726629",
       "fun_fact": "“Firestone” appears on Kygo’s release “Cloud Nine”.",
       "fun_fact_de": "„Firestone“ erschien auf der Veröffentlichung „Cloud Nine“ von Kygo.",
@@ -840,7 +840,7 @@
         "it": "applemusic://track/1840277744"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=W4C-NEWrnSQ",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/38048363",
       "uri_deezer": "deezer://track/90632837",
       "fun_fact": "“The Nights” appears on Avicii’s release “Stories”.",
       "fun_fact_de": "„The Nights“ erschien auf der Veröffentlichung „Stories“ von Avicii.",
@@ -870,7 +870,7 @@
         "it": "applemusic://track/1137641426"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=4u4d4GWdpo8",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/63337364",
       "uri_deezer": "deezer://track/129313094",
       "fun_fact": "“In the Name of Love” is the title track of Martin Garrix’s release of the same name.",
       "fun_fact_de": "„In the Name of Love“ ist der Titelsong der gleichnamigen Veröffentlichung von Martin Garrix.",


### PR DESCRIPTION
Scheduled 06:00 wave, catalogue-wide.

## Delta

| Playlist | Tidal before | after | version |
|---|---|---|---|
| `divorced-dad-rock` | 98/107 | **107/107** ✅ complete | 1.6 → 1.7 |
| `edm-anthems` | 19/190 | **29/190** | 1.6 → 1.7 |

## Wave balance

- **19 hits · 0 genuine misses · 30 rate-limit skips · 90 429-backoffs**
- Stopped on the 30-minute wall-clock cap.
- Miss-cache 826 → 845 entries, merged back into the canonical copy.

## The alphabetical walk moved on, as predicted

Yesterday's 22:00 wave established that `backfill_tidal.py` walks
`sorted(PLAYLISTS_DIR.rglob("*.json"))` and therefore always starts at the first
file that still has gaps. This wave is the confirmation: it closed the last 9 gaps
in `divorced-dad-rock` (now **107/107**) and then moved to the next file with gaps,
`edm-anthems`, without any intervention.

`divorced-dad-rock` went from 22 → 107 Tidal URIs in four waves across two days.

## Gate

`validate_playlists.py` green, 54 files, no lint warning on either changed file.

Draft — Markus reviews and merges.