### PR TITLE
chore(playlists): tidal backfill wave 2026-08-03 12:00 — +19 URIs

### DIFF
--- a/custom_components/beatify/playlists/community/edm-anthems.json
+++ b/custom_components/beatify/playlists/community/edm-anthems.json
@@ -1,6 +1,6 @@
 {
   "name": "EDM Anthems",
-  "version": "1.7",
+  "version": "1.8",
   "tags": [
     "edm",
     "electronic",
@@ -900,7 +900,7 @@
         "it": "applemusic://track/922876184"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=70BASPcfWVQ",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/33271765",
       "uri_deezer": "deezer://track/83489074",
       "fun_fact": "“Blame (feat. John Newman)” appears on Calvin Harris’s release “Motion”.",
       "fun_fact_de": "„Blame (feat. John Newman)“ erschien auf der Veröffentlichung „Motion“ von Calvin Harris.",
@@ -930,7 +930,7 @@
         "it": "applemusic://track/1828775985"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=RH-Rco7s8v8",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/73359309",
       "uri_deezer": "deezer://track/355724441",
       "fun_fact": "“Mama” appears on Jonas Blue’s release “Blue”.",
       "fun_fact_de": "„Mama“ erschien auf der Veröffentlichung „Blue“ von Jonas Blue.",
@@ -960,7 +960,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=91byJDDV3mU",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/131734338",
       "uri_deezer": "deezer://track/142342967",
       "fun_fact": "“Perfect Strangers” is the title track of Jonas Blue’s release of the same name.",
       "fun_fact_de": "„Perfect Strangers“ ist der Titelsong der gleichnamigen Veröffentlichung von Jonas Blue.",
@@ -990,7 +990,7 @@
         "it": "applemusic://track/1741270964"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=ChEQQ9zl85U",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/357381739",
       "uri_deezer": "deezer://track/2751093881",
       "fun_fact": "“Ladida” is the title track of MIRA’s release of the same name.",
       "fun_fact_de": "„Ladida“ ist der Titelsong der gleichnamigen Veröffentlichung von MIRA.",
@@ -1020,7 +1020,7 @@
         "it": "applemusic://track/1647424714"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=e3atZ1OXfHU",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/17614977",
       "uri_deezer": "deezer://track/61142290",
       "fun_fact": "“I Need Your Love (feat. Ellie Goulding)” appears on Calvin Harris’s release “18 Months”.",
       "fun_fact_de": "„I Need Your Love (feat. Ellie Goulding)“ erschien auf der Veröffentlichung „18 Months“ von Calvin Harris.",
@@ -1050,7 +1050,7 @@
         "it": "applemusic://track/922876187"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=lMQH_xmx1zE",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/37218617",
       "uri_deezer": "deezer://track/88936743",
       "fun_fact": "“Outside (feat. Ellie Goulding)” appears on Calvin Harris’s release “Party Mixtape”.",
       "fun_fact_de": "„Outside (feat. Ellie Goulding)“ erschien auf der Veröffentlichung „Party Mixtape“ von Calvin Harris.",
@@ -1080,7 +1080,7 @@
         "it": "applemusic://track/1626467618"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=CXU7Xlf8wTI",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/92265335",
       "uri_deezer": "deezer://track/530231361",
       "fun_fact": "“Darkside” is the title track of Alan Walker’s release of the same name.",
       "fun_fact_de": "„Darkside“ ist der Titelsong der gleichnamigen Veröffentlichung von Alan Walker.",
@@ -1110,7 +1110,7 @@
         "it": "applemusic://track/1196786344"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=vFFT1iAUNDE",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/69484822",
       "uri_deezer": "deezer://track/140856305",
       "fun_fact": "“Scared to Be Lonely” is the title track of Martin Garrix’s release of the same name.",
       "fun_fact_de": "„Scared to Be Lonely“ ist der Titelsong der gleichnamigen Veröffentlichung von Martin Garrix.",
@@ -1140,7 +1140,7 @@
         "it": "applemusic://track/1440881859"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=Rs1HqzgM-q8",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/74069065",
       "uri_deezer": "deezer://track/362795841",
       "fun_fact": "“More Than You Know” is the title track of Axwell /\\ Ingrosso’s release of the same name.",
       "fun_fact_de": "„More Than You Know“ ist der Titelsong der gleichnamigen Veröffentlichung von Axwell /\\ Ingrosso.",
@@ -1170,7 +1170,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=5Tm_Q1MbODw",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/36511124",
       "uri_deezer": "deezer://track/144534320",
       "fun_fact": "“Get Low” appears on Dillon Francis’s release “Get Low (Remixes)”.",
       "fun_fact_de": "„Get Low“ erschien auf der Veröffentlichung „Get Low (Remixes)“ von Dillon Francis.",
@@ -1200,7 +1200,7 @@
         "it": "applemusic://track/1445141158"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=nWiv728Vc9k",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/69449735",
       "uri_deezer": "deezer://track/140295915",
       "fun_fact": "“Sing Me to Sleep” is the title track of Alan Walker’s release of the same name.",
       "fun_fact_de": "„Sing Me to Sleep“ ist der Titelsong der gleichnamigen Veröffentlichung von Alan Walker.",
@@ -1230,7 +1230,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=rkE_oBe8ABw",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/54688949",
       "uri_deezer": "deezer://track/114396428",
       "fun_fact": "“Fast Car” is the title track of Jonas Blue’s release of the same name.",
       "fun_fact_de": "„Fast Car“ ist der Titelsong der gleichnamigen Veröffentlichung von Jonas Blue.",
@@ -1260,7 +1260,7 @@
         "it": "applemusic://track/1768339965"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=NqLR8IHgEzM",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/372152647",
       "uri_deezer": "deezer://track/2868382762",
       "fun_fact": "“Two Feet” is the title track of TOESUP’s release of the same name.",
       "fun_fact_de": "„Two Feet“ ist der Titelsong der gleichnamigen Veröffentlichung von TOESUP.",
@@ -1290,7 +1290,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/232117824",
       "uri_deezer": null,
       "fun_fact": "“Tremor” is the title track of Dimitri Vegas & Like Mike’s release of the same name.",
       "fun_fact_de": "„Tremor“ ist der Titelsong der gleichnamigen Veröffentlichung von Dimitri Vegas & Like Mike.",
@@ -1320,7 +1320,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=OK848_DSj6k",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/70379767",
       "uri_deezer": "deezer://track/142328215",
       "fun_fact": "“It Ain't Me (with Selena Gomez)” is the title track of Kygo’s release of the same name.",
       "fun_fact_de": "„It Ain't Me (with Selena Gomez)“ ist der Titelsong der gleichnamigen Veröffentlichung von Kygo.",
@@ -1350,7 +1350,7 @@
         "it": "applemusic://track/1870734281"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=RK4Vplud0SM",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/26793943",
       "uri_deezer": "deezer://track/75739907",
       "fun_fact": "“#SELFIE” is the title track of The Chainsmokers’s release of the same name.",
       "fun_fact_de": "„#SELFIE“ ist der Titelsong der gleichnamigen Veröffentlichung von The Chainsmokers.",
@@ -1380,7 +1380,7 @@
         "it": "applemusic://track/1052323327"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=ZL4VBzz5kH4",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/25738281",
       "uri_deezer": "deezer://track/74457141",
       "fun_fact": "“Shot Me Down (feat. Skylar Grey) - Radio Edit” appears on David Guetta’s release “Listen”.",
       "fun_fact_de": "„Shot Me Down (feat. Skylar Grey) - Radio Edit“ erschien auf der Veröffentlichung „Listen“ von David Guetta.",
@@ -1410,7 +1410,7 @@
         "it": "applemusic://track/1669143907"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=3ZJ1PkZt3M8",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/80272672",
       "uri_deezer": "deezer://track/420355352",
       "fun_fact": "“Wolves” is the title track of Selena Gomez’s release of the same name.",
       "fun_fact_de": "„Wolves“ ist der Titelsong der gleichnamigen Veröffentlichung von Selena Gomez.",
@@ -1440,7 +1440,7 @@
         "it": "applemusic://track/1697378782"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=OjpX8ILe2N4",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/22120604",
       "uri_deezer": "deezer://track/70266758",
       "fun_fact": "“Hey Brother” appears on Avicii’s release “True”.",
       "fun_fact_de": "„Hey Brother“ erschien auf der Veröffentlichung „True“ von Avicii.",


### PR DESCRIPTION
Automated Tidal URI backfill wave (Odesli), scheduled 12:00 slot.

## Per-playlist delta

| Playlist | Tidal before | Tidal after | Version |
|---|---|---|---|
| `community/edm-anthems.json` | 29 / 190 | **48 / 190** | 1.7 → 1.8 |

## Wave balance

- 19 hits · 0 genuine misses · 30 rate-limit skips (retried next wave) · 90 429-backoffs
- Stopped by the built-in `--max-minutes 30` cap, not by a query budget
- Miss-cache 845 → 864 entries (written back to the canonical copy)
- Playlist JSON schema gate: 54/54 valid, no new warnings on the changed file

Draft on purpose — review and merge stays with @mholzi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)