### PR TITLE
fix(health-check): script-aware title matching (#1957)

### DIFF
--- a/.claude/skills/playlist-health-check/scripts/validate_uris.py
+++ b/.claude/skills/playlist-health-check/scripts/validate_uris.py
@@ -82,7 +82,10 @@ _NOISE_RE = re.compile(
 )
 
 def normalize(s):
-    s = s.lower()
+    # Fold compatibility forms first: Japanese catalogues mix fullwidth and
+    # halfwidth latin, so "少女Ｓ" and "少女S" are the same title written two
+    # ways. NFKC maps Ｓ→S, ﬁ→fi, ①→1 — none of which changes meaning.
+    s = unicodedata.normalize('NFKC', s).lower()
     # Strip unicode accents (é→e, ü→u, etc.)
     s = ''.join(c for c in unicodedata.normalize('NFD', s)
                 if unicodedata.category(c) != 'Mn')
@@ -109,6 +112,38 @@ def strip_version_suffix(s):
     stripped = _VERSION_SUFFIX_RE.sub('', s).strip()
     return stripped or s
 
+# YouTube auto-generates an "<Artist> - Topic" channel per artist, and labels
+# publish under "<Artist>VEVO". Neither is part of the artist's name.
+_CHANNEL_SUFFIX_RE = re.compile(r'(?i)(?:\s*[\-–—]\s*topic|\s*vevo)\s*$')
+
+def strip_channel_suffix(s):
+    stripped = _CHANNEL_SUFFIX_RE.sub('', s or '').strip()
+    return stripped or s
+
+# Codepoint blocks that carry no Latin transliteration: a title written in one
+# of these cannot be string-compared against a romanised or translated title.
+_CJK_RE = re.compile(
+    r'[぀-ゟ'   # Hiragana
+    r'゠-ヿ'    # Katakana
+    r'㐀-䶿'    # CJK Ext A
+    r'一-鿿'    # CJK Unified
+    r'가-힯'    # Hangul
+    r'ｦ-ﾟ]'   # Halfwidth Katakana
+)
+
+def has_cjk(s):
+    return bool(_CJK_RE.search(s or ''))
+
+def scripts_differ(expected, actual):
+    """True when exactly one side is written in a non-Latin script.
+
+    Providers legitimately return Japanese tracks romanised ("紅蓮華" →
+    "Gurenge") or translated ("百花繚乱" → "In Bloom"). A string comparison
+    across that boundary answers nothing — it always says "mismatch", which is
+    why anime-openings produced 308 flags and 0 real defects (#1957).
+    """
+    return has_cjk(expected) != has_cjk(actual)
+
 def titles_match(expected, actual, artist=None):
     e, a = normalize(expected), normalize(actual)
     if not e or not a: return True
@@ -131,7 +166,30 @@ def titles_match(expected, actual, artist=None):
                 return True
     return SequenceMatcher(None, e, a).ratio() >= 0.75
 
+def title_verdict(expected, actual, artist=None):
+    """'match' | 'unverifiable' | 'mismatch'.
+
+    'unverifiable' means the two titles are written in different scripts, so
+    the comparison cannot decide the question either way. The URI resolved and
+    the track exists — it is simply not checkable by string equality, and is
+    reported as its own status rather than as a defect.
+    """
+    if titles_match(expected, actual, artist):
+        return "match"
+    if scripts_differ(expected, actual):
+        return "unverifiable"
+    return "mismatch"
+
+def unverifiable_title(expected_title, actual_title, actual_artist=None):
+    actual_artist = strip_channel_suffix(actual_artist) if actual_artist else None
+    return {"status": "unverifiable", "http_code": 200,
+            "detail": f"Title written in a different script — expected "
+                      f"'{expected_title}', got '{actual_title}'. Not comparable "
+                      f"by string match; no verdict.",
+            "actual_title": actual_title, "actual_artist": actual_artist}
+
 def wrong_track(expected_title, expected_artist, actual_title, actual_artist=None):
+    actual_artist = strip_channel_suffix(actual_artist) if actual_artist else None
     exp = f"{expected_artist} - {expected_title}"
     act = f"{actual_artist} - {actual_title}" if actual_artist else actual_title
     return {"status": "wrong_track", "http_code": 200,
@@ -155,8 +213,11 @@ def check_spotify(tid, title, artist):
         if code == 403: return {"status": "dead", "http_code": 403, "detail": "Restricted"}
         return {"status": "unreachable", "http_code": code, "detail": f"Spotify HTTP {code}"}
     actual = data.get("title", "")
-    if not titles_match(title, actual, artist):
+    v = title_verdict(title, actual, artist)
+    if v == "mismatch":
         return wrong_track(title, artist, actual)
+    if v == "unverifiable":
+        return unverifiable_title(title, actual)
     return {"status": "ok", "http_code": 200}
 
 def check_youtube(tid, title, artist):
@@ -171,8 +232,11 @@ def check_youtube(tid, title, artist):
             return {"status": "dead", "http_code": code, "detail": "Not found or private"}
         return {"status": "unreachable", "http_code": code, "detail": f"YouTube HTTP {code}"}
     actual = data.get("title", "")
-    if not titles_match(title, actual, artist):
+    v = title_verdict(title, actual, artist)
+    if v == "mismatch":
         return wrong_track(title, artist, actual, data.get("author_name"))
+    if v == "unverifiable":
+        return unverifiable_title(title, actual, data.get("author_name"))
     return {"status": "ok", "http_code": 200}
 
 def check_deezer(tid, title, artist):
@@ -185,8 +249,11 @@ def check_deezer(tid, title, artist):
         return {"status": "dead", "http_code": 200, "detail": data["error"].get("message", "?")}
     actual_title  = data.get("title", "")
     actual_artist = data.get("artist", {}).get("name", "")
-    if not titles_match(title, actual_title, artist):
+    v = title_verdict(title, actual_title, artist)
+    if v == "mismatch":
         return wrong_track(title, artist, actual_title, actual_artist)
+    if v == "unverifiable":
+        return unverifiable_title(title, actual_title, actual_artist)
     return {"status": "ok", "http_code": 200}
 
 def check_tidal(tid, title, artist):
@@ -201,8 +268,12 @@ def check_tidal(tid, title, artist):
         if code == 403: return _check_tidal_embed(tid, title, artist)
         return {"status": "unreachable", "http_code": code, "detail": f"Tidal HTTP {code}"}
     actual = data.get("title", "")
-    if actual and not titles_match(title, actual, artist):
-        return wrong_track(title, artist, actual)
+    if actual:
+        v = title_verdict(title, actual, artist)
+        if v == "mismatch":
+            return wrong_track(title, artist, actual)
+        if v == "unverifiable":
+            return unverifiable_title(title, actual)
     return {"status": "ok", "http_code": 200}
 
 def _check_tidal_embed(tid, title, artist):
@@ -217,8 +288,11 @@ def _check_tidal_embed(tid, title, artist):
             og = re.search(r'<meta[^>]+property="og:title"[^>]+content="([^"]+)"', html)
             if og:
                 actual_title = og.group(1).strip()
-                if not titles_match(title, actual_title, artist):
+                v = title_verdict(title, actual_title, artist)
+                if v == "mismatch":
                     return wrong_track(title, artist, actual_title)
+                if v == "unverifiable":
+                    return unverifiable_title(title, actual_title)
             return {"status": "ok", "http_code": 200}
     except urllib.error.HTTPError as e:
         if e.code == 404: return {"status": "dead", "http_code": e.code, "detail": "Not found"}
@@ -242,8 +316,11 @@ def check_apple_music(tid, title, artist):
         track = data["results"][0]
         actual_title  = track.get("trackName", "")
         actual_artist = track.get("artistName", "")
-        if not titles_match(title, actual_title, artist):
+        v = title_verdict(title, actual_title, artist)
+        if v == "mismatch":
             return wrong_track(title, artist, actual_title, actual_artist)
+        if v == "unverifiable":
+            return unverifiable_title(title, actual_title, actual_artist)
         return {"status": "ok", "http_code": 200}
     return {"status": "dead", "http_code": 404, "detail": "Not found in US/DE/GB catalogs"}
 
@@ -316,7 +393,7 @@ def validate_region_maps(entries):
     """
     results = []
     summary = {"total": 0, "ok": 0, "dead": 0, "wrong_track": 0,
-               "unfilled": 0, "transient": 0, "tracks_affected": 0}
+               "unverifiable": 0, "unfilled": 0, "transient": 0, "tracks_affected": 0}
 
     # Collect claimed (region -> [(id, entry)]) so each storefront is queried
     # in as few calls as possible.
@@ -363,14 +440,23 @@ def validate_region_maps(entries):
                                            f"but not in that catalog"})
                     summary["dead"] += 1
                     affected.add((e.get("artist"), e.get("title")))
-                elif not titles_match(e.get("title", ""), track.get("trackName", ""),
-                                      e.get("artist", "")):
+                elif (v := title_verdict(e.get("title", ""), track.get("trackName", ""),
+                                         e.get("artist", ""))) == "mismatch":
                     r = wrong_track(e.get("title", ""), e.get("artist", ""),
                                     track.get("trackName", ""), track.get("artistName", ""))
                     base.update(r)
                     base["detail"] = f"[{country}] " + base.get("detail", "")
                     summary["wrong_track"] += 1
                     affected.add((e.get("artist"), e.get("title")))
+                elif v == "unverifiable":
+                    # Apple Music localises titles per storefront, so a German
+                    # storefront returns "Inferno" where the catalogue says
+                    # "インフェルノ". Not a defect and not an affected track.
+                    base.update(unverifiable_title(e.get("title", ""),
+                                                   track.get("trackName", ""),
+                                                   track.get("artistName", "")))
+                    base["detail"] = f"[{country}] " + base.get("detail", "")
+                    summary["unverifiable"] = summary.get("unverifiable", 0) + 1
                 else:
                     base.update({"status": "ok", "http_code": 200})
                     summary["ok"] += 1
@@ -384,8 +470,8 @@ COOLDOWN = 5.0   # extra pause after a throttled lookup, to let the provider rec
 
 def validate_uris(songs, delay=0.5):
     results = []
-    summary = {"total":0,"ok":0,"dead":0,"wrong_track":0,"error":0,"unreachable":0,"unknown":0,
-               "transient":0}
+    summary = {"total":0,"ok":0,"dead":0,"wrong_track":0,"unverifiable":0,"error":0,
+               "unreachable":0,"unknown":0,"transient":0}
     for i, song in enumerate(songs):
         uri, artist, title = song.get("uri",""), song.get("artist",""), song.get("title","")
         summary["total"] += 1
@@ -434,6 +520,7 @@ if __name__ == "__main__":
     report = validate_uris(songs)
     s = report["summary"]
     print(f"Done. {s['ok']} ok, {s['dead']} dead, {s['wrong_track']} wrong track, "
+          f"{s.get('unverifiable',0)} unverifiable (different script), "
           f"{s.get('error',0)} error, {s.get('unreachable',0)} unreachable.", file=sys.stderr)
     if s.get("transient"):
         # A degraded run must be visible as degraded, not as a wall of defects.
@@ -451,7 +538,9 @@ if __name__ == "__main__":
         report["region_results"] = region_report["results"]
         report["region_summary"] = rs = region_report["summary"]
         print(f"Region maps: {rs['ok']} ok, {rs['dead']} dead, "
-              f"{rs['wrong_track']} wrong track, {rs['unfilled']} unfilled "
+              f"{rs['wrong_track']} wrong track, "
+              f"{rs.get('unverifiable',0)} unverifiable (different script), "
+              f"{rs['unfilled']} unfilled "
               f"({rs['tracks_affected']} track(s) affected).", file=sys.stderr)
         if rs.get("transient"):
             print(f"  WARNING: {rs['transient']} region lookup(s) had no verdict "

--- a/tests/unit/test_playlist_health_title_matching.py
+++ b/tests/unit/test_playlist_health_title_matching.py
@@ -13,13 +13,16 @@ its reader to ignore it.
 These tests pin the three rules that fixed it, and — just as important — pin
 that a genuinely wrong track is still reported.
 """
+
 import importlib.util
 from pathlib import Path
 
 import pytest
 
-_SCRIPT = (Path(__file__).resolve().parents[2]
-           / ".claude/skills/playlist-health-check/scripts/validate_uris.py")
+_SCRIPT = (
+    Path(__file__).resolve().parents[2]
+    / ".claude/skills/playlist-health-check/scripts/validate_uris.py"
+)
 
 
 @pytest.fixture(scope="module")
@@ -33,12 +36,15 @@ def validator():
 class TestChannelSuffix:
     """YouTube's auto-generated channels are not part of an artist's name."""
 
-    @pytest.mark.parametrize("raw,expected", [
-        ("Ikimonogakari - Topic", "Ikimonogakari"),
-        ("Mrs. GREEN APPLE - Topic", "Mrs. GREEN APPLE"),
-        ("SevenOopsVEVO", "SevenOops"),
-        ("Judy & Mary", "Judy & Mary"),
-    ])
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            ("Ikimonogakari - Topic", "Ikimonogakari"),
+            ("Mrs. GREEN APPLE - Topic", "Mrs. GREEN APPLE"),
+            ("SevenOopsVEVO", "SevenOops"),
+            ("Judy & Mary", "Judy & Mary"),
+        ],
+    )
     def test_strips_topic_and_vevo(self, validator, raw, expected):
         assert validator.strip_channel_suffix(raw) == expected
 
@@ -50,19 +56,24 @@ class TestChannelSuffix:
 class TestScriptMismatch:
     """Different scripts -> the comparison has no verdict to give."""
 
-    @pytest.mark.parametrize("expected,actual", [
-        ("紅蓮華", "Gurenge"),                    # kanji -> romaji
-        ("百花繚乱", "In Bloom"),                  # kanji -> English translation
-        ("インフェルノ", "Inferno"),                # katakana -> English
-        ("Guren no Yumiya", "紅蓮の弓矢"),          # romaji -> kanji (reverse)
-    ])
+    @pytest.mark.parametrize(
+        "expected,actual",
+        [
+            ("紅蓮華", "Gurenge"),  # kanji -> romaji
+            ("百花繚乱", "In Bloom"),  # kanji -> English translation
+            ("インフェルノ", "Inferno"),  # katakana -> English
+            ("Guren no Yumiya", "紅蓮の弓矢"),  # romaji -> kanji (reverse)
+        ],
+    )
     def test_reports_unverifiable_not_mismatch(self, validator, expected, actual):
         assert validator.title_verdict(expected, actual, "LiSA") == "unverifiable"
 
     def test_same_script_still_compared(self, validator):
         """Both sides Latin -> the script rule must not swallow the check."""
-        assert validator.title_verdict("Let It Be", "Se Me Enamora el Alma",
-                                       "The Beatles") == "mismatch"
+        assert (
+            validator.title_verdict("Let It Be", "Se Me Enamora el Alma", "The Beatles")
+            == "mismatch"
+        )
 
     def test_both_sides_cjk_still_compared(self, validator):
         assert validator.title_verdict("紅蓮華", "残響散歌", "LiSA") == "mismatch"
@@ -78,18 +89,25 @@ class TestCompatibilityFolding:
 class TestNoRegressionOnLatinTitles:
     """The rules above must not loosen the ordinary Latin-script path."""
 
-    @pytest.mark.parametrize("expected,actual,artist", [
-        ("Bohemian Rhapsody", "Bohemian Rhapsody - Remastered 2011", "Queen"),
-        ("Blame", "Blame (feat. John Newman)", "Calvin Harris"),
-        ("Dancing Queen", "Dancing Queen", "ABBA"),
-    ])
+    @pytest.mark.parametrize(
+        "expected,actual,artist",
+        [
+            ("Bohemian Rhapsody", "Bohemian Rhapsody - Remastered 2011", "Queen"),
+            ("Blame", "Blame (feat. John Newman)", "Calvin Harris"),
+            ("Dancing Queen", "Dancing Queen", "ABBA"),
+        ],
+    )
     def test_known_good_pairs_still_match(self, validator, expected, actual, artist):
         assert validator.title_verdict(expected, actual, artist) == "match"
 
     def test_a_genuinely_wrong_track_is_still_reported(self, validator):
         """The defect #1943 found — the check must keep catching this."""
-        assert validator.title_verdict("Se Me Enamora el Alma", "Let It Be",
-                                       "Isabel Pantoja") == "mismatch"
+        assert (
+            validator.title_verdict(
+                "Se Me Enamora el Alma", "Let It Be", "Isabel Pantoja"
+            )
+            == "mismatch"
+        )
 
 
 class TestVerdictShape:
@@ -97,7 +115,7 @@ class TestVerdictShape:
         r = validator.unverifiable_title("紅蓮華", "Gurenge", "LiSA - Topic")
         assert r["status"] == "unverifiable"
         assert r["http_code"] == 200
-        assert r["actual_artist"] == "LiSA"      # channel suffix stripped
+        assert r["actual_artist"] == "LiSA"  # channel suffix stripped
         assert "no verdict" in r["detail"]
 
     def test_wrong_track_result_keeps_both_titles(self, validator):

--- a/tests/unit/test_playlist_health_title_matching.py
+++ b/tests/unit/test_playlist_health_title_matching.py
@@ -1,0 +1,107 @@
+"""Title-matching rules of the playlist health-check validator (#1957).
+
+The validator compares the title a provider returns against the title in the
+playlist. That comparison is a string match, which cannot decide anything when
+the two sides are written in different scripts: providers return Japanese
+tracks romanised ("紅蓮華" -> "Gurenge") or translated ("百花繚乱" -> "In Bloom").
+
+Before #1957 every one of those counted as a defect. A single run on
+`community/anime-openings.json` produced 308 flags with zero real defects, which
+is worse than not running the check at all — a report that is 100 % noise trains
+its reader to ignore it.
+
+These tests pin the three rules that fixed it, and — just as important — pin
+that a genuinely wrong track is still reported.
+"""
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = (Path(__file__).resolve().parents[2]
+           / ".claude/skills/playlist-health-check/scripts/validate_uris.py")
+
+
+@pytest.fixture(scope="module")
+def validator():
+    spec = importlib.util.spec_from_file_location("validate_uris", _SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class TestChannelSuffix:
+    """YouTube's auto-generated channels are not part of an artist's name."""
+
+    @pytest.mark.parametrize("raw,expected", [
+        ("Ikimonogakari - Topic", "Ikimonogakari"),
+        ("Mrs. GREEN APPLE - Topic", "Mrs. GREEN APPLE"),
+        ("SevenOopsVEVO", "SevenOops"),
+        ("Judy & Mary", "Judy & Mary"),
+    ])
+    def test_strips_topic_and_vevo(self, validator, raw, expected):
+        assert validator.strip_channel_suffix(raw) == expected
+
+    def test_never_empties_a_name(self, validator):
+        """A band literally called "Topic" must survive the strip."""
+        assert validator.strip_channel_suffix("Topic") == "Topic"
+
+
+class TestScriptMismatch:
+    """Different scripts -> the comparison has no verdict to give."""
+
+    @pytest.mark.parametrize("expected,actual", [
+        ("紅蓮華", "Gurenge"),                    # kanji -> romaji
+        ("百花繚乱", "In Bloom"),                  # kanji -> English translation
+        ("インフェルノ", "Inferno"),                # katakana -> English
+        ("Guren no Yumiya", "紅蓮の弓矢"),          # romaji -> kanji (reverse)
+    ])
+    def test_reports_unverifiable_not_mismatch(self, validator, expected, actual):
+        assert validator.title_verdict(expected, actual, "LiSA") == "unverifiable"
+
+    def test_same_script_still_compared(self, validator):
+        """Both sides Latin -> the script rule must not swallow the check."""
+        assert validator.title_verdict("Let It Be", "Se Me Enamora el Alma",
+                                       "The Beatles") == "mismatch"
+
+    def test_both_sides_cjk_still_compared(self, validator):
+        assert validator.title_verdict("紅蓮華", "残響散歌", "LiSA") == "mismatch"
+
+
+class TestCompatibilityFolding:
+    """Fullwidth and halfwidth latin are the same title written two ways."""
+
+    def test_fullwidth_latin_matches_halfwidth(self, validator):
+        assert validator.title_verdict("少女Ｓ", "少女S", "SCANDAL") == "match"
+
+
+class TestNoRegressionOnLatinTitles:
+    """The rules above must not loosen the ordinary Latin-script path."""
+
+    @pytest.mark.parametrize("expected,actual,artist", [
+        ("Bohemian Rhapsody", "Bohemian Rhapsody - Remastered 2011", "Queen"),
+        ("Blame", "Blame (feat. John Newman)", "Calvin Harris"),
+        ("Dancing Queen", "Dancing Queen", "ABBA"),
+    ])
+    def test_known_good_pairs_still_match(self, validator, expected, actual, artist):
+        assert validator.title_verdict(expected, actual, artist) == "match"
+
+    def test_a_genuinely_wrong_track_is_still_reported(self, validator):
+        """The defect #1943 found — the check must keep catching this."""
+        assert validator.title_verdict("Se Me Enamora el Alma", "Let It Be",
+                                       "Isabel Pantoja") == "mismatch"
+
+
+class TestVerdictShape:
+    def test_unverifiable_result_is_not_a_defect(self, validator):
+        r = validator.unverifiable_title("紅蓮華", "Gurenge", "LiSA - Topic")
+        assert r["status"] == "unverifiable"
+        assert r["http_code"] == 200
+        assert r["actual_artist"] == "LiSA"      # channel suffix stripped
+        assert "no verdict" in r["detail"]
+
+    def test_wrong_track_result_keeps_both_titles(self, validator):
+        r = validator.wrong_track("Africa", "Toto", "Rosanna", "Toto - Topic")
+        assert r["status"] == "wrong_track"
+        assert r["actual_title"] == "Rosanna"
+        assert r["actual_artist"] == "Toto"


### PR DESCRIPTION
Closes #1957.

## Problem

`validate_uris.py` decides `wrong_track` by string-comparing the provider's title against the playlist's. That comparison has no meaning when the two sides are written in different scripts — and providers routinely romanise or translate Japanese titles. Today's scheduled run on `community/anime-openings.json` produced **308 flags and 0 real defects**.

A report that is 100 % noise is worse than no report: it trains its reader to skip `wrong_track`, which is how a real dead URI slips through later.

## Rules added

1. **Strip YouTube's channel suffix** — ` - Topic`, `VEVO` — from the artist a provider reports. Never empties a name (a band called "Topic" survives).
2. **Script mismatch is not a verdict.** When exactly one side contains CJK codepoints, the check returns a new status `unverifiable` instead of `wrong_track`. It stays visible and countable in the summary, but is not a defect and does not affect the exit code.
3. **NFKC folding in `normalize()`** so fullwidth and halfwidth latin compare equal (`少女Ｓ` = `少女S`). This one was not in the issue — it surfaced when replaying the fix against the real data, where 6 flags survived rules 1–2 for this reason alone.

## Verification against real data

Replayed both rule sets over today's `validate-output.json`:

| | before | after |
|---|---|---|
| Track URIs | 94 flags | **3** mismatch · 91 unverifiable |
| Region maps | 214 flags | **9** mismatch · 200 unverifiable |

The 12 remaining flags cover 5 distinct tracks and are deliberately **not** silenced:

- `Sawano Hiroyuki – Attack on Titan` → `ətˈæk 0N tάɪtn` (the real, stylised track name)
- `Yasuharu Takanashi – Kizuna` → `Bonds` (translation, both sides Latin — indistinguishable from a genuine mismatch without a translation table)
- `Miura Jam – Polaris (…)` → a cover upload

Loosening the threshold far enough to absorb these would also absorb real defects. One human dismissal each is the cheaper trade.

## Tests

- New `tests/unit/test_playlist_health_title_matching.py` — 18 cases pinning **both** directions: the new leniency, and that a genuinely wrong track (the defect #1943 found) is still reported.
- Full suite green: **pytest 1578 passed, 2 skipped** · **vitest 571 passed (59 files)**.

## Not covered

Titles translated between two Latin scripts stay flagged — there is no deterministic way to tell `Kizuna`/`Bonds` from a genuine mismatch without a translation source. Deliberate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)