### PR TITLE
chore(playlists): tidal backfill wave 2026-08-03 17:56 — +19 URIs (edm-anthems past halfway)

### DIFF
--- a/custom_components/beatify/playlists/community/edm-anthems.json
+++ b/custom_components/beatify/playlists/community/edm-anthems.json
@@ -1,6 +1,6 @@
 {
   "name": "EDM Anthems",
-  "version": "1.10",
+  "version": "1.11",
   "tags": [
     "edm",
     "electronic",
@@ -2760,7 +2760,7 @@
         "it": "applemusic://track/1819450998"
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/54059868",
       "uri_deezer": "deezer://track/90250609",
       "fun_fact": "“Lovers on the Sun (feat. Sam Martin)” appears on David Guetta’s release “Listen”.",
       "fun_fact_de": "„Lovers on the Sun (feat. Sam Martin)“ erschien auf der Veröffentlichung „Listen“ von David Guetta.",
@@ -2790,7 +2790,7 @@
         "it": "applemusic://track/1576427396"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=tS_LVLMurXI",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/74633163",
       "uri_deezer": "deezer://track/2659206152",
       "fun_fact": "“OK” is the title track of Robin Schulz’s release of the same name.",
       "fun_fact_de": "„OK“ ist der Titelsong der gleichnamigen Veröffentlichung von Robin Schulz.",
@@ -2820,7 +2820,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=7NMrrRQqzN0",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/45183922",
       "uri_deezer": "deezer://track/99554796",
       "fun_fact": "“I Want You To Know” appears on Zedd’s release “True Colors”.",
       "fun_fact_de": "„I Want You To Know“ erschien auf der Veröffentlichung „True Colors“ von Zedd.",
@@ -2850,7 +2850,7 @@
         "it": "applemusic://track/1843374039"
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/83549084",
       "uri_deezer": "deezer://track/468407642",
       "fun_fact": "“Wizard” is the title track of Martin Garrix’s release of the same name.",
       "fun_fact_de": "„Wizard“ ist der Titelsong der gleichnamigen Veröffentlichung von Martin Garrix.",
@@ -2880,7 +2880,7 @@
         "it": "applemusic://track/1733209782"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=fDYtGCrnFiY",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/347764225",
       "uri_deezer": "deezer://track/2679700102",
       "fun_fact": "“Summer's Gone” is the title track of Monoir’s release of the same name.",
       "fun_fact_de": "„Summer's Gone“ ist der Titelsong der gleichnamigen Veröffentlichung von Monoir.",
@@ -2910,7 +2910,7 @@
         "it": "applemusic://track/1219424964"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=8dwSKcSbvAU",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/71983606",
       "uri_deezer": "deezer://track/145432614",
       "fun_fact": "“No Promises (feat. Demi Lovato)” is the title track of Cheat Codes’s release of the same name.",
       "fun_fact_de": "„No Promises (feat. Demi Lovato)“ ist der Titelsong der gleichnamigen Veröffentlichung von Cheat Codes.",
@@ -2940,7 +2940,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=67_ZA1zLlXA",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/45183923",
       "uri_deezer": "deezer://track/99554798",
       "fun_fact": "“Beautiful Now” appears on Zedd’s release “True Colors”.",
       "fun_fact_de": "„Beautiful Now“ erschien auf der Veröffentlichung „True Colors“ von Zedd.",
@@ -2970,7 +2970,7 @@
         "it": "applemusic://track/1850669717"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=JDJGXwZlkb0",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/84395161",
       "uri_deezer": "deezer://track/459401542",
       "fun_fact": "“Forbidden Voices” is the title track of Martin Garrix’s release of the same name.",
       "fun_fact_de": "„Forbidden Voices“ ist der Titelsong der gleichnamigen Veröffentlichung von Martin Garrix.",
@@ -3000,7 +3000,7 @@
         "it": "applemusic://track/1789544127"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=KUmd-GHUu7g",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/410491819",
       "uri_deezer": "deezer://track/3186454911",
       "fun_fact": "“Till It Hurts (feat. Ayden)” is the title track of Yellow Claw’s release of the same name.",
       "fun_fact_de": "„Till It Hurts (feat. Ayden)“ ist der Titelsong der gleichnamigen Veröffentlichung von Yellow Claw.",
@@ -3030,7 +3030,7 @@
         "it": "applemusic://track/1489350662"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=lLwuuLIs-H0",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/113846918",
       "uri_deezer": "deezer://track/717723342",
       "fun_fact": "“Takeaway (feat. Lennon Stella)” appears on The Chainsmokers’s release “World War Joy...Takeaway”.",
       "fun_fact_de": "„Takeaway (feat. Lennon Stella)“ erschien auf der Veröffentlichung „World War Joy...Takeaway“ von The Chainsmokers.",
@@ -3060,7 +3060,7 @@
         "it": "applemusic://track/1686969184"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=nmlzCmic34Y",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/110141837",
       "uri_deezer": "deezer://track/685843722",
       "fun_fact": "“Ritual” is the title track of Tiësto’s release of the same name.",
       "fun_fact_de": "„Ritual“ ist der Titelsong der gleichnamigen Veröffentlichung von Tiësto.",
@@ -3090,7 +3090,7 @@
         "it": "applemusic://track/1820970628"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=HdLZ4UBF73g",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/93964538",
       "uri_deezer": "deezer://track/546834702",
       "fun_fact": "“8 Letters” is the title track of Why Don't We’s release of the same name.",
       "fun_fact_de": "„8 Letters“ ist der Titelsong der gleichnamigen Veröffentlichung von Why Don't We.",
@@ -3120,7 +3120,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/84395148",
       "uri_deezer": null,
       "fun_fact": "“How We Party - Original Mix” appears on R3HAB’s release “How We Party”.",
       "fun_fact_de": "„How We Party - Original Mix“ erschien auf der Veröffentlichung „How We Party“ von R3HAB.",
@@ -3150,7 +3150,7 @@
         "it": "applemusic://track/1741670480"
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/98084041",
       "uri_deezer": "deezer://track/62710229",
       "fun_fact": "“Die Young” appears on Kesha’s release “Warrior (Deluxe Version)”.",
       "fun_fact_de": "„Die Young“ erschien auf der Veröffentlichung „Warrior (Deluxe Version)“ von Kesha.",
@@ -3180,7 +3180,7 @@
         "it": "applemusic://track/1712104159"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=X9PrdEN4uFc",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/322363963",
       "uri_deezer": "deezer://track/2500849271",
       "fun_fact": "“Shades of Blue” is the title track of Féa’s release of the same name.",
       "fun_fact_de": "„Shades of Blue“ ist der Titelsong der gleichnamigen Veröffentlichung von Féa.",
@@ -3210,7 +3210,7 @@
         "it": "applemusic://track/1672128307"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=rFtrb2NzjAk",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/76977108",
       "uri_deezer": "deezer://track/393460712",
       "fun_fact": "“Lonely Together (feat. Rita Ora)” appears on Avicii’s release “AVĪCI (01)”.",
       "fun_fact_de": "„Lonely Together (feat. Rita Ora)“ erschien auf der Veröffentlichung „AVĪCI (01)“ von Avicii.",
@@ -3240,7 +3240,7 @@
         "it": "applemusic://track/1634271997"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=1Gb6MIuWpW8",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/30045827",
       "uri_deezer": "deezer://track/78933237",
       "fun_fact": "“Red Lights” appears on Tiësto’s release “A Town Called Paradise”.",
       "fun_fact_de": "„Red Lights“ erschien auf der Veröffentlichung „A Town Called Paradise“ von Tiësto.",
@@ -3270,7 +3270,7 @@
         "it": "applemusic://track/1692250931"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=Fe9clLVyJEE",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/94090608",
       "uri_deezer": "deezer://track/546232052",
       "fun_fact": "“REMEDY” is the title track of Alesso’s release of the same name.",
       "fun_fact_de": "„REMEDY“ ist der Titelsong der gleichnamigen Veröffentlichung von Alesso.",
@@ -3300,7 +3300,7 @@
         "it": "applemusic://track/1099908241"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=OFiBWFtbH-w",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/59024081",
       "uri_deezer": "deezer://track/122886138",
       "fun_fact": "“The Ocean (feat. Shy Martin)” is the title track of Mike Perry’s release of the same name.",
       "fun_fact_de": "„The Ocean (feat. Shy Martin)“ ist der Titelsong der gleichnamigen Veröffentlichung von Mike Perry.",


### PR DESCRIPTION
Fourth Tidal backfill wave today on `edm-anthems`. Covers the regular 18:00 slot, which was deliberately skipped earlier while PR #1959 was still open (a wave off `main` would have re-queried the same tracks — the 2026-07-28 duplicate-work failure).

## Per-playlist delta

| Playlist | Tidal before | Tidal after | Version |
|---|---|---|---|
| `community/edm-anthems.json` | 86 / 190 | **105 / 190** | 1.10 → 1.11 |

First time this playlist is past halfway on Tidal.

## Wave balance

- 19 hits · 0 genuine misses · 30 rate-limit skips · 91 429-backoffs
- Stopped by the `--max-minutes 30` cap
- Miss-cache 902 → 921 entries
- Playlist JSON schema gate: 54/54 valid

## Four waves, one day

| Wave | Gap | Hits |
|---|---|---|
| 12:00 | 6 h | 19 |
| 13:20 | 40 min | 19 |
| 17:06 | 3 h 46 | 19 |
| 17:56 | 50 min | 19 |

Yield is invariant to spacing across a 40-minute-to-six-hour range. `edm-anthems` moved 29 → 105 today (+76). 85 gaps remain.

Draft on purpose — review and merge stays with @mholzi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)