### PR TITLE
chore(playlists): tidal backfill wave — +19 uris

### DIFF
--- a/custom_components/beatify/playlists/community/edm-anthems.json
+++ b/custom_components/beatify/playlists/community/edm-anthems.json
@@ -1,6 +1,6 @@
 {
   "name": "EDM Anthems",
-  "version": "1.13",
+  "version": "1.14",
   "tags": [
     "edm",
     "electronic",
@@ -4320,7 +4320,7 @@
         "it": "applemusic://track/873131250"
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/30214472",
       "uri_deezer": null,
       "fun_fact": "“Gecko (Overdrive) - Radio Edit” is the title track of Oliver Heldens’s release of the same name.",
       "fun_fact_de": "„Gecko (Overdrive) - Radio Edit“ ist der Titelsong der gleichnamigen Veröffentlichung von Oliver Heldens.",
@@ -4350,7 +4350,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=w15oWDh02K4",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/19020552",
       "uri_deezer": "deezer://track/2076053797",
       "fun_fact": "“L'Amour Toujours” is the title track of GIGI D'AGOSTINO’s release of the same name.",
       "fun_fact_de": "„L'Amour Toujours“ ist der Titelsong der gleichnamigen Veröffentlichung von GIGI D'AGOSTINO.",
@@ -4380,7 +4380,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=GKZgTk1dSJg",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/4169625",
       "uri_deezer": null,
       "fun_fact": "“One - Radio Edit” appears on Swedish House Mafia’s release “One (Your Name)”.",
       "fun_fact_de": "„One - Radio Edit“ erschien auf der Veröffentlichung „One (Your Name)“ von Swedish House Mafia.",
@@ -4410,7 +4410,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/80031865",
       "uri_deezer": null,
       "fun_fact": "“Sun & Moon - Original Mix” appears on Above & Beyond’s release “Group Therapy”.",
       "fun_fact_de": "„Sun & Moon - Original Mix“ erschien auf der Veröffentlichung „Group Therapy“ von Above & Beyond.",
@@ -4440,7 +4440,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=93ASUImTedo",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/17311738",
       "uri_deezer": "deezer://track/67563950",
       "fun_fact": "“Latch” appears on Disclosure’s release “Settle (Deluxe)”.",
       "fun_fact_de": "„Latch“ erschien auf der Veröffentlichung „Settle (Deluxe)“ von Disclosure.",
@@ -4470,7 +4470,7 @@
         "it": "applemusic://track/535279482"
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/15956685",
       "uri_deezer": "deezer://track/38019911",
       "fun_fact": "“Alive” appears on Krewella’s release “Play Hard EP”.",
       "fun_fact_de": "„Alive“ erschien auf der Veröffentlichung „Play Hard EP“ von Krewella.",
@@ -4500,7 +4500,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=llDikI2hTtk",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/7434066",
       "uri_deezer": "deezer://track/13112883",
       "fun_fact": "“Promises” appears on NERO’s release “Welcome Reality +”.",
       "fun_fact_de": "„Promises“ erschien auf der Veröffentlichung „Welcome Reality +“ von NERO.",
@@ -4530,7 +4530,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/39441061",
       "uri_deezer": "deezer://track/92984012",
       "fun_fact": "“Habits (Stay High) - Hippie Sabotage Remix” appears on Tove Lo’s release “Queen Of The Clouds”.",
       "fun_fact_de": "„Habits (Stay High) - Hippie Sabotage Remix“ erschien auf der Veröffentlichung „Queen Of The Clouds“ von Tove Lo.",
@@ -4560,7 +4560,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/237114050",
       "uri_deezer": null,
       "fun_fact": "“Spaceman - Edit” appears on Hardwell’s release “I Am Hardwell (Original Soundtrack)”.",
       "fun_fact_de": "„Spaceman - Edit“ erschien auf der Veröffentlichung „I Am Hardwell (Original Soundtrack)“ von Hardwell.",
@@ -4590,7 +4590,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/85082920",
       "uri_deezer": "deezer://track/479839272",
       "fun_fact": "“Take Over Control (feat. Eva Simons) - Radio Edit” is the title track of AFROJACK’s release of the same name.",
       "fun_fact_de": "„Take Over Control (feat. Eva Simons) - Radio Edit“ ist der Titelsong der gleichnamigen Veröffentlichung von AFROJACK.",
@@ -4620,7 +4620,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=gB5aXPgZ61s",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/17981364",
       "uri_deezer": "deezer://track/62126184",
       "fun_fact": "“Smack My Bitch Up” appears on The Prodigy’s release “The Fat of the Land”.",
       "fun_fact_de": "„Smack My Bitch Up“ erschien auf der Veröffentlichung „The Fat of the Land“ von The Prodigy.",
@@ -4650,7 +4650,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/21435624",
       "uri_deezer": "deezer://track/858979012",
       "fun_fact": "“I Remember” appears on Kaskade’s release “Strobelite Seduction”.",
       "fun_fact_de": "„I Remember“ erschien auf der Veröffentlichung „Strobelite Seduction“ von Kaskade.",
@@ -4680,7 +4680,7 @@
         "it": "applemusic://track/601136935"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=qV0LHCHf-pE",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/79949791",
       "uri_deezer": "deezer://track/64734097",
       "fun_fact": "“Harlem Shake” is the title track of Baauer’s release of the same name.",
       "fun_fact_de": "„Harlem Shake“ ist der Titelsong der gleichnamigen Veröffentlichung von Baauer.",
@@ -4710,7 +4710,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/66399550",
       "uri_deezer": "deezer://track/14708131",
       "fun_fact": "“Seek Bromance (Avicii Vocal Edit)” appears on Tim Berg’s release “Seek Bromance”.",
       "fun_fact_de": "„Seek Bromance (Avicii Vocal Edit)“ erschien auf der Veröffentlichung „Seek Bromance“ von Tim Berg.",
@@ -4740,7 +4740,7 @@
         "it": "applemusic://track/1777119822"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=t-knFuqQdGc",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/397022073",
       "uri_deezer": "deezer://track/3069116671",
       "fun_fact": "“The Days - NOTION Remix” is the title track of Chrystal’s release of the same name.",
       "fun_fact_de": "„The Days - NOTION Remix“ ist der Titelsong der gleichnamigen Veröffentlichung von Chrystal.",
@@ -4770,7 +4770,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/32904099",
       "uri_deezer": "deezer://track/82182346",
       "fun_fact": "“Say My Name” appears on ODESZA’s release “In Return”.",
       "fun_fact_de": "„Say My Name“ erschien auf der Veröffentlichung „In Return“ von ODESZA.",
@@ -4800,7 +4800,7 @@
         "it": "applemusic://track/1058740894"
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/56068951",
       "uri_deezer": "deezer://track/113475002",
       "fun_fact": "“Innerbloom” appears on RÜFÜS DU SOL’s release “Bloom”.",
       "fun_fact_de": "„Innerbloom“ erschien auf der Veröffentlichung „Bloom“ von RÜFÜS DU SOL.",
@@ -4830,7 +4830,7 @@
         "it": "applemusic://track/1804350103"
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/426118752",
       "uri_deezer": "deezer://track/3278706951",
       "fun_fact": "“Mammoth” is the title track of Dimitri Vegas’s release of the same name.",
       "fun_fact_de": "„Mammoth“ ist der Titelsong der gleichnamigen Veröffentlichung von Dimitri Vegas.",
@@ -4860,7 +4860,7 @@
         "it": "applemusic://track/1673828907"
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/278684345",
       "uri_deezer": "deezer://track/2164533907",
       "fun_fact": "“Where You Are” appears on John Summit’s release “Comfort In Chaos”.",
       "fun_fact_de": "„Where You Are“ erschien auf der Veröffentlichung „Comfort In Chaos“ von John Summit.",


### PR DESCRIPTION
Zweite Tidal-Welle des 04.08. (12:00-Slot). Die Welle wurde nach ~14 Minuten **abgebrochen** (nicht durch den 30-Min-Deckel), die Änderungen lagen uncommittet im Worktree und wurden geborgen.

**Delta**

- `edm-anthems` — Tidal **143 → 162/190**, version 1.13 → 1.14

**Bilanz**

19 Treffer · 42 429-Backoffs im sichtbaren Log. Die Endbilanz-Zeile fehlt (Prozess vor dem Schreiben beendet), die `OK`-Zeilen steckten in der stdout-Pufferung — gezählt wurde deshalb am Diff, nicht am Log. Miss-Cache 959 → 978 Einträge.

**Provider-Stand `edm-anthems` (v1.14)**

Spotify 190/190 · Deezer 175/190 · Apple Music 135/190 · YouTube Music 125/190 · Tidal 162/190

Schema-Gate lokal 54/54 grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)