### PR TITLE
data: fix 6 broken URIs in harder-styles (#1967)

### DIFF
--- a/custom_components/beatify/playlists/community/harder-styles.json
+++ b/custom_components/beatify/playlists/community/harder-styles.json
@@ -1,6 +1,6 @@
 {
   "name": "Harder Styles",
-  "version": "1.8",
+  "version": "1.9",
   "tags": [
     "hardstyle",
     "hardcore",
@@ -367,13 +367,13 @@
       "uri": "spotify:track:4T1lTz3KZUsKJPzhef0vVb",
       "uri_apple_music": "applemusic://track/1842432772",
       "uri_apple_music_by_region": {
-        "us": "applemusic://track/6762605997",
-        "de": "applemusic://track/6762605997",
-        "gb": "applemusic://track/6762605997",
-        "fr": "applemusic://track/6762605997",
-        "es": "applemusic://track/6762605997",
-        "nl": "applemusic://track/6762605997",
-        "it": "applemusic://track/6762605997"
+        "us": "applemusic://track/1842432772",
+        "de": "applemusic://track/1842432772",
+        "gb": "applemusic://track/1842432772",
+        "fr": "applemusic://track/1842432772",
+        "es": "applemusic://track/1842432772",
+        "nl": "applemusic://track/1842432772",
+        "it": "applemusic://track/1842432772"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=2UXFA6zfFi8",
       "uri_tidal": null,
@@ -417,13 +417,13 @@
       "uri": "spotify:track:3VChr8qpIsCvdsHnIph7Qb",
       "uri_apple_music": "applemusic://track/923426095",
       "uri_apple_music_by_region": {
-        "us": "applemusic://track/1842608184",
-        "de": "applemusic://track/1842608184",
-        "gb": "applemusic://track/1842608184",
-        "fr": "applemusic://track/1842608184",
-        "es": "applemusic://track/1842608184",
-        "nl": "applemusic://track/1842608184",
-        "it": "applemusic://track/1842608184"
+        "us": "applemusic://track/923426095",
+        "de": "applemusic://track/923426095",
+        "gb": "applemusic://track/923426095",
+        "fr": "applemusic://track/923426095",
+        "es": "applemusic://track/923426095",
+        "nl": "applemusic://track/923426095",
+        "it": "applemusic://track/923426095"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=3M6hB2zo134",
       "uri_tidal": null,
@@ -3022,13 +3022,13 @@
       "uri": "spotify:track:02zAW3DWnWjpiN1PAVD6yz",
       "uri_apple_music": "applemusic://track/1805252710",
       "uri_apple_music_by_region": {
-        "us": "applemusic://track/937886274",
-        "de": "applemusic://track/937886274",
-        "gb": "applemusic://track/937886274",
-        "fr": "applemusic://track/937886274",
-        "es": "applemusic://track/937886274",
-        "nl": "applemusic://track/937886274",
-        "it": "applemusic://track/937886274"
+        "us": "applemusic://track/1805252710",
+        "de": "applemusic://track/1805252710",
+        "gb": "applemusic://track/1805252710",
+        "fr": "applemusic://track/1805252710",
+        "es": "applemusic://track/1805252710",
+        "nl": "applemusic://track/1805252710",
+        "it": "applemusic://track/1805252710"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=Lk2SaW4TeuQ",
       "uri_tidal": null,
@@ -4541,7 +4541,7 @@
         "nl": "applemusic://track/1740386319",
         "it": "applemusic://track/1740386319"
       },
-      "uri_youtube_music": "https://music.youtube.com/watch?v=rHzREJhrX9s",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=qatArIFBIOQ",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2714092902",
       "fun_fact": "Headhunterz is one of the most influential hardstyle artists of all time.",
@@ -4566,7 +4566,7 @@
         "nl": "applemusic://track/1740387192",
         "it": "applemusic://track/1740387192"
       },
-      "uri_youtube_music": "https://music.youtube.com/watch?v=qkz8vv4nprg",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=mrrE0-bMhO8",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2714091742",
       "fun_fact": "Sub Zero Project is a Dutch hardstyle duo known for their raw-edged festival anthems.",
@@ -4666,7 +4666,7 @@
         "nl": "applemusic://track/1728077902",
         "it": "applemusic://track/1728077902"
       },
-      "uri_youtube_music": "https://music.youtube.com/watch?v=sKzLfRKZfy4",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=w_Sb-QFJa1k",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2618543312",
       "fun_fact": "Phuture Noize is a Dutch hardstyle artist known for concept albums and cinematic productions.",


### PR DESCRIPTION
Closes #1967. Replaced 3 wrong YouTube Music URIs and corrected 3 `uri_apple_music_by_region` maps (21 entries) pointing to wrong versions. Bumped playlist version to 1.9.

**YouTube Music fixes:**
- Headhunterz, Vertile, Sian Evans - Lost Without You: `rHzREJhrX9s` (Delta IV) → `qatArIFBIOQ` (Q-dance Music, confirmed correct)
- Sub Zero Project - Path Of The Warrior: `qkz8vv4nprg` (Logarythm GE) → `mrrE0-bMhO8` (Q-dance, confirmed correct)
- Phuture Noize, B-Front - The Singularity: `sKzLfRKZfy4` (Phuture-T) → `w_Sb-QFJa1k` (B-Front official, confirmed correct)

**Apple Music region map fixes (all 7 storefronts):**
- The Prophet - LOUDER: 6762605997 (Live Cut) → 1842432772 (Album Edit, matches main URI)
- Titan - Flip uhm op: 1842608184 (Tha Playah Remix) → 923426095 (Original Mix, matches main URI)
- Jack Of Sound - Das Weite Land: 937886274 (Edit) → 1805252710 (Digital Punk Fragments Remix, matches main URI)

**9 wrong_track flags + 1 region flag dismissed as false positives** (Radio Edit vs Original Mix version variants, Q-dance event prefix format, reordered descriptors, DE title capitalization variant).