### PR TITLE
fix(playlists): tote Apple-Music-URI in divorced-dad-rock

### DIFF
--- a/custom_components/beatify/playlists/community/divorced-dad-rock.json
+++ b/custom_components/beatify/playlists/community/divorced-dad-rock.json
@@ -1,6 +1,6 @@
 {
   "name": "Divorced Dad Rock",
-  "version": "1.7",
+  "version": "1.8",
   "tags": [
     "post-grunge",
     "nu-metal",
@@ -1044,7 +1044,7 @@
       "year": 2000,
       "isrc": "USDW10022224",
       "uri": "spotify:track:5z6xHjCZr7a7AIcy8sPBKy",
-      "uri_apple_music": "applemusic://track/1440762729",
+      "uri_apple_music": "applemusic://track/1703143668",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1703143668",
         "de": "applemusic://track/1703143668",


### PR DESCRIPTION
`Closes #1972`

Vom täglichen `playlist-review` (14:00) gefunden.

## Änderung

Eine URI, ein Version-Bump — Diff 1 Datei / +2 −2.

- `uri_apple_music` **`1440762729` → `1703143668`** (Alien Ant Farm — Smooth Criminal)
- `version` **1.7 → 1.8**

## Warum genau diese Ersatz-ID

Die alte ID liefert `resultCount = 0` in **US, DE und GB** — echter Katalog-Abgang. Die neue ID ist **nicht frei gewählt**: fünf der sieben Einträge in der `uri_apple_music_by_region`-Map desselben Tracks zeigen bereits darauf. Damit stimmt das Basisfeld künftig mit der Regions-Map überein, statt eine achte Variante einzuführen. Einzeln in allen drei Storefronts geprüft.

## Befund des Laufs

- **483 von 484 URIs ok**, 1 dead, 0 wrong_track, 0 error
- **734 behauptete Regionen alle erreichbar**, 0 dead
- 15 Regions-Einträge sind `null` — fehlende Angabe, kein Defekt, bewusst kein Ticket
- Schema-Gate **54/54 valid**

🤖 Generated with [Claude Code](https://claude.com/claude-code)