### PR TITLE
data: fix 3 dead Apple Music URIs in finnish-iskelma-classics (#1974)

### DIFF
--- a/custom_components/beatify/playlists/community/finnish-iskelma-classics.json
+++ b/custom_components/beatify/playlists/community/finnish-iskelma-classics.json
@@ -1,6 +1,6 @@
 {
   "name": "Finnish Schlager Classics 🇫🇮",
-  "version": "1.4",
+  "version": "1.5",
   "tags": [
     "finnish",
     "iskelma",
@@ -1532,7 +1532,7 @@
       "awards": [],
       "awards_nl": [],
       "isrc": "FIPT60900003",
-      "uri_apple_music": "applemusic://track/656130117",
+      "uri_apple_music": "applemusic://track/656128096",
       "uri_apple_music_by_region": {
         "us": null,
         "de": null,
@@ -4505,7 +4505,7 @@
       "awards": [],
       "awards_nl": [],
       "isrc": "FIARA9500005",
-      "uri_apple_music": "applemusic://track/919599316",
+      "uri_apple_music": "applemusic://track/1789334979",
       "uri_apple_music_by_region": {
         "us": null,
         "de": null,
@@ -6208,7 +6208,7 @@
       "chart_info": {},
       "certifications": [],
       "awards": [],
-      "uri_apple_music": "applemusic://track/724627361",
+      "uri_apple_music": "applemusic://track/713821788",
       "uri_youtube_music": "https://music.youtube.com/watch?v=5EeQTOQpO_o",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/8075560",


### PR DESCRIPTION
Closes #1974. Replaced 3 dead Apple Music URIs and bumped playlist version to 1.5.

| Artist | Title | Old URI | New URI | Coverage |
|--------|-------|---------|---------|----------|
| Pasi Kaunisto | Koskaan et muuttua saa | `applemusic://track/656130117` | `applemusic://track/656128096` | US/DE/GB ✓ |
| Arja Havakka | Lokki | `applemusic://track/919599316` | `applemusic://track/1789334979` (live) | US/DE/GB ✓ |
| Sakari Kuosmanen & Riikka Kuosmanen | Pieni Sydän | `applemusic://track/724627361` | `applemusic://track/713821788` | DE/GB/FR/ES/NL/IT ✓ |

Also noted in issue: 7 `wrong_track` flags in `uri_apple_music_by_region` across 5 tracks — stale per-region IDs that need a Mode 2 refresh (not addressed in this PR).