### PR TITLE
fix(scripts): Apple-Matcher vergleicht Klammer-Suffixe, Artists als Mitgliedschaft (#1980)

### DIFF
--- a/scripts/backfill_apple.py
+++ b/scripts/backfill_apple.py
@@ -29,22 +29,45 @@ The gate
 --------
 A search result is only accepted when **all** of these hold:
 
-  1. ``artistName`` equals the track's primary artist after normalisation
-     (casefold, punctuation stripped, ``&``/``and`` unified, ``feat.``-tails cut)
+  1. the track's primary artist is **one of** the artists credited in
+     ``artistName`` after normalisation (casefold, punctuation stripped,
+     ``&``/``and`` unified, ``feat.``-tails cut)
   2. title similarity >= ``--title-threshold`` (default 0.87, difflib ratio on
      normalised titles)
   3. the year in ``releaseDate`` is within ``--year-tolerance`` of ``year``
      (default 1; a release can straddle a year boundary)
+  4. no parenthetical suffix on either side names a different recording
+     (``suffix_conflict``)
 
 Anything else is **rejected, not guessed**. Rejections are recorded separately
 from genuine absences so the two can be told apart later — a rejection may
 become resolvable with a better matcher, a miss will not.
+
+Note on rule 1: this is membership, not equality (changed 2026-08-05, #1980).
+Apple frequently orders a multi-artist credit differently than the catalogue —
+"Tatanka, Zatox & Wild Motherfuckers" for our "Zatox" — and lead-vs-lead
+comparison rejected those correct matches. Only the *primary* catalogue artist
+is required to be present: Apple moves featured guests into the title, so
+demanding the full catalogue set would reject "Harris & Ford, BassWar & CaoX,
+Bobby John" against "Harris & Ford & BassWar & CaoX".
 
 Note on rule 3: for old songs that only exist on remaster/compilation albums,
 ``releaseDate`` is the *reissue* date, so rule 3 will reject some correct
 matches. That is deliberate — precision over recall. ``--probe`` reports the
 rejection breakdown so the thresholds can be calibrated against real data
 before any wave writes anything.
+
+Note on rule 4: rule 2 compares a parenthetical-stripped form as well, so a
+suffix on one side alone costs no similarity at all. That is right for
+"(2000 Remaster)" and wrong for "(Extended Mix)" — both score 1.00, so **no
+threshold can separate them** and the suffix must be inspected directly. Rule 4
+accepts a one-sided suffix only when the other title mentions the same words
+anywhere ("The Afterlife - Radio Edit" vs "The Afterlife (Radio Edit)") or when
+it is recording-neutral per ``_NEUTRAL_SUFFIX_RE``. This costs recall: real
+"(Radio Edit)" and "(Extended Version)" catalogue entries now land in
+``rejected`` rather than ``hit``. That is the intended direction — they stay
+retrievable via ``--retry-rejected``, whereas a wrong URI in the catalogue is
+only found again by the daily playlist-review.
 
 State file (``scripts/.apple-backfill-state.json``) maps each Spotify URI to
 ``{"status": hit|miss|rejected, ...}``:
@@ -101,8 +124,27 @@ REQUEST_TIMEOUT_S = 20
 
 _FEAT_RE = re.compile(r"\s*[\(\[]?\b(feat|ft|featuring|with)\b\.?\s.*$", re.I)
 _PAREN_RE = re.compile(r"\s*[\(\[][^)\]]*[)\]]")
+_PAREN_CONTENT_RE = re.compile(r"[\(\[]([^)\]]*)[)\]]")
 _PUNCT_RE = re.compile(r"[^\w\s]", re.UNICODE)
 _WS_RE = re.compile(r"\s+")
+_ARTIST_SPLIT_RE = re.compile(r"\s*[,;/]\s*|\s+(?:&|feat\.?|ft\.?|x|vs\.?)\s+", re.I)
+
+# Parenthetical suffixes that name the same *recording* — packaging or mastering
+# wording, not a different take. Only these may appear on one side alone.
+# Deliberately a short closed list: every entry here is a licence to accept a
+# title the other side does not carry, so it is reviewed in the diff.
+_NEUTRAL_SUFFIX_RE = re.compile(
+    r"^(?:\d{4}\s+)?(?:digital\s+)?(?:"
+    r"remaster(?:ed)?(?:\s+version)?(?:\s+\d{4})?"
+    r"|deluxe(?:\s+edition)?"
+    r"|album\s+version"
+    r"|single\s+version"
+    r"|original\s+(?:version|mix)"
+    r"|bonus\s+track"
+    r"|explicit|clean"
+    r")$",
+    re.I,
+)
 
 
 def _now_iso() -> str:
@@ -132,14 +174,70 @@ def primary_artist(artist: str) -> str:
     """First credited artist — search results carry the lead artist only."""
     if not artist:
         return ""
-    return re.split(r"\s*[,;/]\s*|\s+(?:&|feat\.?|ft\.?|x)\s+", artist, maxsplit=1)[0]
+    return _ARTIST_SPLIT_RE.split(artist, maxsplit=1)[0]
+
+
+def artist_set(artist: str) -> set[str]:
+    """All credited artists, normalised.
+
+    Split on the raw string, not the normalised one: ``normalise`` turns ``&``
+    into ``and``, which would stop it being a separator.
+    """
+    if not artist:
+        return set()
+    return {n for n in (normalise(p) for p in _ARTIST_SPLIT_RE.split(artist)) if n}
+
+
+def parenthetical_suffixes(text: str) -> list[str]:
+    """Normalised contents of every ``(...)``/``[...]`` group.
+
+    ``feat.``-tails are cut first — ``normalise`` already handles those, and a
+    featured guest is not a different recording.
+    """
+    if not text:
+        return []
+    stripped = _FEAT_RE.sub("", unicodedata.normalize("NFC", text))
+    out = []
+    for raw in _PAREN_CONTENT_RE.findall(stripped):
+        norm = normalise(raw)
+        if norm:
+            out.append(norm)
+    return out
+
+
+def suffix_conflict(a: str, b: str) -> str | None:
+    """The first suffix that one title carries and the other does not account for.
+
+    ``title_similarity`` compares a parenthetical-stripped form too, so a suffix
+    on one side alone costs nothing — which is right for ``(2000 Remaster)`` and
+    wrong for ``(Extended Mix)``. Both reach similarity 1.00, so no threshold can
+    separate them; the suffix has to be looked at directly.
+
+    A suffix is fine when either
+      * the other side mentions it anywhere in its title (``The Afterlife -
+        Radio Edit`` vs ``The Afterlife (Radio Edit)`` — same words, different
+        punctuation), or
+      * it is recording-neutral per ``_NEUTRAL_SUFFIX_RE``.
+
+    Anything else names a different take and is returned for rejection.
+    """
+    for src, other in ((a, b), (b, a)):
+        other_norm = normalise(other)
+        for suffix in parenthetical_suffixes(src):
+            if suffix in other_norm:
+                continue
+            if _NEUTRAL_SUFFIX_RE.match(suffix):
+                continue
+            return suffix
+    return None
 
 
 def title_similarity(a: str, b: str) -> float:
     """Best ratio over the raw and the parenthetical-stripped forms.
 
     ``Kryptonite`` vs ``Kryptonite (2000 Remaster)`` should not be punished for
-    a suffix that says nothing about track identity.
+    a suffix that says nothing about track identity. Suffixes that *do* say
+    something are caught by ``suffix_conflict``, not here.
     """
     best = difflib.SequenceMatcher(None, normalise(a), normalise(b)).ratio()
     bare = difflib.SequenceMatcher(
@@ -159,8 +257,15 @@ def evaluate(track: dict, result: dict, *, title_threshold: float,
              year_tolerance: int) -> tuple[bool, str]:
     """Apply the gate. Returns (accepted, reason)."""
     want_artist = normalise(primary_artist(track.get("artist", "")))
-    got_artist = normalise(primary_artist(result.get("artistName", "")))
-    if not want_artist or want_artist != got_artist:
+    got_artists = artist_set(result.get("artistName", ""))
+    # Membership, not equality: Apple often orders a multi-artist credit
+    # differently ("Tatanka, Zatox & Wild Motherfuckers" for our "Zatox"), and
+    # the lead-artist-only comparison then rejected a correct match. Checking
+    # the *primary* catalogue artist rather than the whole catalogue set is
+    # deliberate — Apple moves featured guests into the title, so requiring the
+    # full set to be present would reject e.g. "Harris & Ford, BassWar & CaoX,
+    # Bobby John" against "Harris & Ford & BassWar & CaoX".
+    if not want_artist or want_artist not in got_artists:
         return False, f"artist {result.get('artistName')!r} != {track.get('artist')!r}"
 
     sim = title_similarity(track.get("title", ""), result.get("trackName", ""))
@@ -168,6 +273,13 @@ def evaluate(track: dict, result: dict, *, title_threshold: float,
         return False, (
             f"title {result.get('trackName')!r} vs {track.get('title')!r} "
             f"(similarity {sim:.2f} < {title_threshold:.2f})"
+        )
+
+    clash = suffix_conflict(track.get("title", ""), result.get("trackName", ""))
+    if clash:
+        return False, (
+            f"suffix {result.get('trackName')!r} vs {track.get('title')!r} "
+            f"(unmatched {clash!r})"
         )
 
     want_year = track.get("year")

--- a/tests/unit/test_backfill_apple_gate_1980.py
+++ b/tests/unit/test_backfill_apple_gate_1980.py
@@ -1,0 +1,158 @@
+"""Gate rules of ``scripts/backfill_apple.py`` (#1980).
+
+These cover the two matcher rules added on 2026-08-05, both of which were found
+against real iTunes responses rather than invented:
+
+* **Suffix comparison.** ``title_similarity`` also compares a
+  parenthetical-stripped form, so a one-sided suffix costs no similarity at all.
+  ``The Night`` and ``The Night (Extended Mix)`` therefore both score 1.00 —
+  no threshold can separate them, so the suffix has to be inspected directly.
+  Without this rule a 20-track sample of ``divorced-dad-rock`` accepted two live
+  recordings and one censored edit as if they were the studio versions.
+
+* **Artist membership.** Apple orders multi-artist credits differently than the
+  catalogue ("Tatanka, Zatox & Wild Motherfuckers" for our "Zatox"), which the
+  old lead-vs-lead equality rejected.
+
+``scripts/`` is not a package, so the module is loaded by path.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "backfill_apple.py"
+_spec = importlib.util.spec_from_file_location("backfill_apple", _SCRIPT)
+backfill_apple = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(backfill_apple)
+
+artist_set = backfill_apple.artist_set
+evaluate = backfill_apple.evaluate
+normalise = backfill_apple.normalise
+primary_artist = backfill_apple.primary_artist
+suffix_conflict = backfill_apple.suffix_conflict
+
+
+@pytest.mark.parametrize(
+    ("catalogue", "apple", "expected"),
+    [
+        # A suffix naming a different take must be caught — both score 1.00.
+        ("The Night", "The Night (Extended Mix)", "extended mix"),
+        (
+            "Strike As A Die Hard (Q-Base Anthem 2017)",
+            "Strike as a Die Hard (Q - Base Anthem 2017) [Pro Mix]",
+            "pro mix",
+        ),
+        ("Smooth Criminal", "Smooth Criminal (Live)", "live"),
+        (
+            "Be Yourself",
+            "Be Yourself (Live from Sessions@AOL Music)",
+            "live from sessions aol music",
+        ),
+        ("Crazy Bitch", "Crazy B*tch (Amended Version)", "amended version"),
+        # Same words, different punctuation — not a conflict.
+        ("The Afterlife - Radio Edit", "The Afterlife (Radio Edit)", None),
+        ("Let Go (Album Edit)", "Let Go (Album Edit)", None),
+        ("Hemorrhage (In My Hands)", "Hemorrhage (In My Hands)", None),
+        # Recording-neutral suffixes stay allowed, which is why the rule exists
+        # as an allowlist rather than a blanket ban.
+        ("Kryptonite", "Kryptonite (2000 Remaster)", None),
+        ("Wonderwall", "Wonderwall (Remastered)", None),
+        ("Last Resort", "Last Resort (Explicit)", None),
+        # A featured guest is not a different recording.
+        ("Teenage Dirtbag", "Teenage Dirtbag (feat. Bobby John)", None),
+        ("Drift Away", "Drift Away", None),
+    ],
+)
+def test_suffix_conflict(catalogue: str, apple: str, expected: str | None) -> None:
+    assert suffix_conflict(catalogue, apple) == expected
+
+
+@pytest.mark.parametrize(
+    ("catalogue", "apple", "accepted"),
+    [
+        # Apple reorders the credit; the artist is present, just not first.
+        ("Zatox", "Tatanka, Zatox & Wild Motherfuckers", True),
+        # Apple moves the featured guest into the title, so only the *primary*
+        # catalogue artist may be required — not the whole catalogue set.
+        (
+            "Harris & Ford, BassWar & CaoX, Bobby John",
+            "Harris & Ford & BassWar & CaoX",
+            True,
+        ),
+        ("Endymion", "Endymion & GLDY LX", True),
+        ("Noisecontrollers", "Noisecontrollers", True),
+        # Genuinely different artists stay rejected.
+        ("Sub Zero Project", "E-Force", False),
+        ("Artifact", "Saif Shraideh", False),
+    ],
+)
+def test_artist_membership(catalogue: str, apple: str, accepted: bool) -> None:
+    assert (normalise(primary_artist(catalogue)) in artist_set(apple)) is accepted
+
+
+def test_evaluate_rejects_extended_mix_with_matching_artist_and_year() -> None:
+    """The regression that motivated #1980: everything else about this match is
+    perfect, so only rule 4 can stop it."""
+    track = {"artist": "Noisecontrollers", "title": "The Night", "year": 2018}
+    result = {
+        "artistName": "Noisecontrollers",
+        "trackName": "The Night (Extended Mix)",
+        "releaseDate": "2018-06-01T00:00:00Z",
+    }
+    accepted, reason = evaluate(track, result, title_threshold=0.87, year_tolerance=1)
+    assert accepted is False
+    assert reason.startswith("suffix ")
+    assert "extended mix" in reason
+
+
+def test_evaluate_accepts_plain_version_of_same_track() -> None:
+    track = {"artist": "Noisecontrollers", "title": "The Night", "year": 2018}
+    result = {
+        "artistName": "Noisecontrollers",
+        "trackName": "The Night",
+        "releaseDate": "2018-06-01T00:00:00Z",
+    }
+    accepted, _ = evaluate(track, result, title_threshold=0.87, year_tolerance=1)
+    assert accepted is True
+
+
+def test_evaluate_accepts_reordered_multi_artist_credit() -> None:
+    track = {"artist": "Zatox", "title": "Hard Bass", "year": 2014}
+    result = {
+        "artistName": "Tatanka, Zatox & Wild Motherfuckers",
+        "trackName": "Hard Bass",
+        "releaseDate": "2014-03-01T00:00:00Z",
+    }
+    accepted, _ = evaluate(track, result, title_threshold=0.87, year_tolerance=1)
+    assert accepted is True
+
+
+def test_evaluate_still_rejects_a_different_artist() -> None:
+    track = {"artist": "Artifact", "title": "Aftermath", "year": 2019}
+    result = {
+        "artistName": "Saif Shraideh",
+        "trackName": "Aftermath",
+        "releaseDate": "2019-01-01T00:00:00Z",
+    }
+    accepted, reason = evaluate(track, result, title_threshold=0.87, year_tolerance=1)
+    assert accepted is False
+    assert reason.startswith("artist ")
+
+
+def test_reject_reason_kinds_stay_parseable() -> None:
+    """The wave counter derives its histogram key from the second word of the
+    reason (``de: suffix ...`` -> ``suffix``). A reason phrased differently
+    would silently produce a junk bucket."""
+    track = {"artist": "Noisecontrollers", "title": "The Night", "year": 2018}
+    result = {
+        "artistName": "Noisecontrollers",
+        "trackName": "The Night (Extended Mix)",
+        "releaseDate": "2018-06-01T00:00:00Z",
+    }
+    _, reason = evaluate(track, result, title_threshold=0.87, year_tolerance=1)
+    detail = f"de: {reason}"
+    assert detail.split(" ", 1)[1].split(" ")[0] == "suffix"


### PR DESCRIPTION
Closes #1980.

Zwei Regeln im Gate von `scripts/backfill_apple.py`, beide an echten iTunes-Antworten gefunden, nicht ausgedacht.

## Regel 4 (neu) — Klammer-Suffixe vergleichen statt strippen

`title_similarity()` vergleicht zusätzlich eine klammer-freie Form, ein einseitiger Suffix kostet also **null** Ähnlichkeit. Richtig für `(2000 Remaster)`, falsch für `(Extended Mix)` — beide erreichen **1.00**, keine Schwelle kann sie trennen.

Neu prüft `suffix_conflict()` die Suffixe direkt. Ein einseitiger Suffix ist nur in Ordnung, wenn

- die andere Seite dieselben Wörter irgendwo im Titel trägt (`The Afterlife - Radio Edit` vs. `The Afterlife (Radio Edit)`), oder
- er aufnahme-neutral ist (`_NEUTRAL_SUFFIX_RE` — Remaster, Deluxe, Album/Single Version, Explicit …).

Sonst: neue Reject-Art `suffix`. Die Allowlist ist die einzige Ermessens-Stelle, kurz und im Diff prüfbar.

## Regel 1 (geändert) — Artist als Mitgliedschaft statt Gleichheit

Vorher `primary_artist(a) == primary_artist(b)`. Apple sortiert Mehr-Artist-Credits anders (`Tatanka, Zatox & Wild Motherfuckers` für unser `Zatox`), das schlug fehl. Jetzt muss der **primäre Katalog-Artist** in der Apple-Artist-Menge enthalten sein.

**Warum nicht die volle Teilmenge Katalog ⊆ Apple**, wie in #1980 zuerst vorgeschlagen: Apple schiebt Feature-Gäste in den Titel. `Harris & Ford, BassWar & CaoX, Bobby John` gegen Apples `Harris & Ford & BassWar & CaoX` würde dann abgelehnt — ein Treffer, der heute korrekt durchgeht. Die umgesetzte Variante ist eine reine Lockerung und kann daher nichts brechen, was bisher lief.

## Gemessen, nicht geschätzt

Beide Versionen als `--probe` über **dieselben 20 Tracks** von `divorced-dad-rock`:

| | alt | neu |
|---|---|---|
| akzeptiert | 17 | 15 |
| abgelehnt | 3 | 5 |

Die zwei „verlorenen" sind der eigentliche Befund — **das alte Gate hat falsche Aufnahmen akzeptiert**:

| Track | alt akzeptierte | neu |
|---|---|---|
| Audioslave – Be Yourself | `1124163673` **(Live from Sessions@AOL Music)** | `1436558550`, die Studio-Fassung |
| The Goo Goo Dolls – Iris | `1109656945` **(Live)** | abgelehnt (nächster Kandidat scheitert am Jahr) |
| Buckcherry – Crazy Bitch | `297744113` **(Amended Version)**, die zensierte Fassung | abgelehnt |
| Thirty Seconds To Mars – The Kill | `715917262` (Bury Me) | `1867087254`, schlichter Eintrag |

Drei von 17 akzeptierten Treffern waren Live- bzw. zensierte Fassungen — **genau die `wrong_track`-Defekte, gegen die das Gate laut Modul-Docstring existiert.** Der Recall-Verlust ist real, aber er ist Präzisionsgewinn, kein Schaden.

Auf `harder-styles` (`--probe --retry-rejected`): `Noisecontrollers – The Night` löst jetzt auf **`1470619481`** auf, die schlichte Fassung — statt wie am 05.08. auf `…483 (Extended Mix)`, die ich damals von Hand zurücknehmen musste. Die Regel blockiert also nicht nur, sie lässt den richtigen Treffer durch.

**Was der PR NICHT löst:** von den 10 offenen Tracks in #1977 kommt genau einer dazu (The Night). `Zatox` passiert jetzt die Artist-Regel, wird aber von Regel 4 gestoppt — Apple führt `Hard Bass [Mixed] (Ran-D Remix)`, und `[Mixed]` bezeichnet die durchmischte DJ-Fassung. Das halte ich für richtig, es ist aber eine Ermessensfrage.

## Tests

`tests/unit/test_backfill_apple_gate_1980.py`, **24 Fälle**, darunter alle oben genannten realen Paare. Ein Test hält fest, dass die Reject-Begründung als zweites Wort `suffix` trägt — daraus leitet der Wellen-Zähler seine Histogramm-Kategorie ab, eine anders formulierte Begründung würde still einen Müll-Eimer erzeugen.

Volle Unit-Suite lokal **1598 passed**, mypy sauber.

🤖 Generated with [Claude Code](https://claude.com/claude-code)