### PR TITLE
chore(playlists): tidal backfill wave — +19 uris (12:00)

### DIFF
--- a/custom_components/beatify/playlists/community/finnish-iskelma-classics.json
+++ b/custom_components/beatify/playlists/community/finnish-iskelma-classics.json
@@ -1,6 +1,6 @@
 {
   "name": "Finnish Schlager Classics 🇫🇮",
-  "version": "1.8",
+  "version": "1.9",
   "tags": [
     "finnish",
     "iskelma",
@@ -1115,7 +1115,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/20534262",
       "uri_deezer": "deezer://track/104155100",
       "fun_fact": "'Isoisän olkihattu' (Grandfather's Straw Hat) is one of Tapio Rautavaara's most enduring songs about rural Finnish nostalgia; its warmth and simplicity made it a staple of Finnish family gatherings for generations.",
       "fun_fact_de": "'Isoisän olkihattu' (Großvaters Strohhut) ist eines von Tapio Rautavaaras beständigsten Liedern über ländliche finnische Nostalgie.",
@@ -1145,7 +1145,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/20507837",
       "uri_deezer": "deezer://track/3597708",
       "fun_fact": "Eija Merilä's 'Yö saaristossa' (Night in the Archipelago) evokes Finland's stunning coastal archipelago — a landscape so central to Finnish identity that it features in countless iskelmä songs as a symbol of both beauty and longing.",
       "fun_fact_de": "Eija Merilläs 'Yö saaristossa' (Nacht im Schärengarten) beschwört Finnlands atemberaubenden Küstenschärengarten.",
@@ -1175,7 +1175,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/20489959",
       "uri_deezer": "deezer://track/3595425",
       "fun_fact": "Esko Rahkonen's 'Syvä kuin meri' (Deep as the Sea) uses oceanic metaphor for profound love; Rahkonen was a respected iskelmä singer throughout the 1960s whose recordings of nature-themed love songs remain cherished.",
       "fun_fact_de": "Esko Rahkonens 'Syvä kuin meri' (Tief wie das Meer) nutzt Ozeansmetaphern für tiefe Liebe.",
@@ -1205,7 +1205,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/403907",
       "uri_deezer": "deezer://track/3608929",
       "fun_fact": "Esko Rahkonen's 'Hiljainen kylätie' (The Quiet Village Road) paints a pastoral picture of rural Finland; such songs of countryside peace and simplicity were deeply popular in an era when Finland was rapidly urbanising.",
       "fun_fact_de": "Esko Rahkonens 'Hiljainen kylätie' (Die stille Dorfstraße) malt ein pastorales Bild des ländlichen Finnlands.",
@@ -1235,7 +1235,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/19192030",
       "uri_deezer": "deezer://track/6627681",
       "fun_fact": "Seppo Hanski's 'Minä soitan sulle illalla' (I'll Play for You This Evening) is a tender serenade from the romantic innocence of 1950s Finnish pop, before rock and roll began reshaping Finnish youth culture.",
       "fun_fact_de": "Seppo Hanskis 'Minä soitan sulle illalla' (Ich spiele heute Abend für dich) ist eine zärtliche Serenade aus der romantischen Unschuld des finnischen Pops der 1950er Jahre.",
@@ -1265,7 +1265,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/1578377",
       "uri_deezer": "deezer://track/6629324",
       "fun_fact": "Eino Grön's 'Sä kuulut päivään jokaiseen' (You Belong to Every Day) is a warm love declaration; Grön's career spanned over six decades, and he remained one of Finland's most active and beloved performers into his eighties.",
       "fun_fact_de": "Eino Gröns 'Sä kuulut päivään jokaiseen' (Du gehörst zu jedem Tag) ist eine warme Liebeserklärung; Gröns Karriere erstreckte sich über sechs Jahrzehnte.",
@@ -1293,7 +1293,7 @@
       "awards": [],
       "uri_apple_music": "applemusic://track/274566076",
       "uri_youtube_music": "https://music.youtube.com/watch?v=leSS06OhXDI",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/179648",
       "uri_deezer": "deezer://track/797328",
       "awards_nl": [],
       "isrc": "FIFMF6600014",
@@ -1329,7 +1329,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/1153629",
       "uri_deezer": "deezer://track/3597819",
       "fun_fact": "Esko Rahkonen's 'Odotin pitkän illan' (I Waited the Long Evening) captures the melancholy of waiting and uncertainty; the long Finnish evening — stretching into darkness in winter — gives this kind of emotional patience a distinctive Nordic quality.",
       "fun_fact_de": "Esko Rahkonens 'Odotin pitkän illan' (Ich wartete den langen Abend) erfasst die Melancholie des Wartens.",
@@ -1359,7 +1359,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/20898148",
       "uri_deezer": "deezer://track/3595920",
       "fun_fact": "Laila Kinnunen's 'Muistojen bulevardi' (Memory Boulevard) evokes the bittersweet revisiting of romantic memories; the boulevard as a metaphor for nostalgia connects Finnish iskelmä to wider European chanson and schlager traditions.",
       "fun_fact_de": "Laila Kinnunens 'Muistojen bulevardi' (Boulevard der Erinnerungen) beschwört das bittersüße Wiedererleben romantischer Erinnerungen.",
@@ -1389,7 +1389,7 @@
         "it": "applemusic://track/209280307"
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/20968678",
       "uri_deezer": "deezer://track/864400242",
       "fun_fact": "Olavi Virta's Finnish version of 'Guarda che luna' showcases his mastery of adapting Italian songs; Virta recorded over 800 songs and was so dominant in Finnish music of the 1940s–60s that he is often called 'Finland's Sinatra'.",
       "fun_fact_de": "Olavi Virtas finnische Version von 'Guarda che luna' zeigt seine Meisterschaft in der Adaption italienischer Lieder; Virta nahm über 800 Songs auf und wird als 'Finnlands Sinatra' bezeichnet.",
@@ -1419,7 +1419,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/7986156",
       "uri_deezer": "deezer://track/10260592",
       "fun_fact": "Carola's Finnish version of the German 'Was Ich Dir Sagen Will' demonstrates the multi-lingual crossover of European schlager; Carola was one of several artists who successfully bridged the Finnish and Swedish-speaking music markets.",
       "fun_fact_de": "Carolas finnische Version des deutschen 'Was Ich Dir Sagen Will' zeigt den mehrsprachigen Crossover des europäischen Schlagers.",
@@ -1447,7 +1447,7 @@
       "awards": [],
       "uri_apple_music": "applemusic://track/209381696",
       "uri_youtube_music": "https://music.youtube.com/watch?v=kxd4xhcW0uE",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/363349",
       "uri_deezer": "deezer://track/3612415",
       "awards_nl": [],
       "isrc": "FIFDP6800600",
@@ -1483,7 +1483,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/13243730",
       "uri_deezer": "deezer://track/10260597",
       "fun_fact": "Markku Aro's Finnish cover of the French 'Les bicyclettes de Belsize' is a charming example of how French chanson influenced Finnish iskelmä; French songs were widely covered in Finnish during the 1960s.",
       "fun_fact_de": "Markku Aros finnischer Cover des französischen 'Les bicyclettes de Belsize' ist ein charmantes Beispiel für den Einfluss des französischen Chansons auf finnische Iskelmä.",
@@ -1513,7 +1513,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/20905889",
       "uri_deezer": "deezer://track/67726861",
       "fun_fact": "Laila Kinnunen's 'Pieni sydän' (Little Heart) is a tender ballad that shows her gift for conveying vulnerability; Kinnunen's clear soprano and emotional directness made her one of the most beloved female voices of her generation.",
       "fun_fact_de": "Laila Kinnunens 'Pieni sydän' (Kleines Herz) ist eine zärtliche Ballade, die ihr Talent zeigt, Verletzlichkeit zu vermitteln.",
@@ -1543,7 +1543,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/20530701",
       "uri_deezer": "deezer://track/94684876",
       "fun_fact": "Pasi Kaunisto's 'Koskaan et muuttua saa' (You Must Never Change) is a timeless love song from the late 1960s; Kaunisto became one of the enduring voices of Finnish romantic pop.",
       "fun_fact_de": "Pasi Kaunistos 'Koskaan et muuttua saa' (Du darfst dich niemals ändern) ist ein zeitloses Liebeslied aus den späten 1960er Jahren.",
@@ -1573,7 +1573,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/20833374",
       "uri_deezer": "deezer://track/1010524882",
       "fun_fact": "Seija Simola's Finnish cover of the Italian 'Ti regalo gli occhi miei' shows how Finnish iskelmä absorbed Italian melodic traditions; Italian music was hugely popular in Finland during the 1960s.",
       "fun_fact_de": "Seija Simolas finnische Version des italienischen 'Ti regalo gli occhi miei' zeigt, wie finnische Iskelmä italienische Melodietraditionen aufnahm.",
@@ -1603,7 +1603,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/20555073",
       "uri_deezer": "deezer://track/117677658",
       "fun_fact": "'Lapin jenkka' is Tapio Rautavaara's joyful celebration of Lapland in the jenkka style — a Finnish dance genre related to the schottische. The song embodies the festive spirit of Finland's north that made Rautavaara a beloved national figure.",
       "fun_fact_de": "'Lapin jenkka' ist Tapio Rautavaaras freudige Feier Lapplands im Jenkka-Stil — einem finnischen Tanzgenre, das mit der Schottischen verwandt ist.",
@@ -1633,7 +1633,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/20984583",
       "uri_deezer": "deezer://track/14956780",
       "fun_fact": "Georg Malmstén's 'Äänisen aallot' (Waves of Lake Onega) became a Finnish wartime anthem of longing for the eastern territories; Malmstén (1902–1981) was the pioneering composer who helped create the Finnish popular music tradition in the 1930s.",
       "fun_fact_de": "Georg Malmsténs 'Äänisen aallot' (Wellen des Onegasees) wurde eine finnische Kriegszeitshymne der Sehnsucht nach östlichen Gebieten; Malmstén war der Pionier der finnischen Popularmusik in den 1930ern.",
@@ -1663,7 +1663,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/397356",
       "uri_deezer": "deezer://track/3879943",
       "fun_fact": "Jörgen Petersen's 'Yli rajojen' (Across the Borders) is a romantic song about love transcending boundaries; Petersen was a popular Finnish artist of the 1970s–80s who bridged the worlds of iskelmä and more contemporary pop styles.",
       "fun_fact_de": "Jörgen Petersens 'Yli rajojen' (Über Grenzen hinweg) ist ein romantisches Lied über grenzenüberschreitende Liebe.",


### PR DESCRIPTION
## Was drin ist

`finnish-iskelma-classics` **36 → 55 / 293** Tidal-URIs, version **1.8 → 1.9**. Ein Datei-Diff, 20 Zeilenpaare (19 × `uri_tidal` + `version`).

## Wellen-Bilanz

- **19 Treffer · 0 echte Misses · 29 Rate-Limit-Skips** (die kommen in der nächsten Welle wieder)
- 36 429-Backoff-Zeilen im Log von 60 Zeilen gesamt
- Miss-Cache **1126 → 1145** Einträge
- Schema-Gate **54/54 valid** (10 non-blocking lint warnings, unverändert)

## Nebenbefund zum 17-Minuten-Abbruch

Diese Welle lief zum **ersten Mal seit Tagen die vollen 30 Minuten** durch und endete regulär mit `reached --max-minutes 30`. Die Wellen vom 05.08. 22:00 und 06.08. 06:00 starben beide nach exakt 17 Minuten, bei 10- bzw. 40-Minuten-Tool-Timeout — der Timeout-Wert war also nachweislich nicht die Ursache.

Der einzige Unterschied heute ist, dass die Welle **detached im Hintergrund** lief statt als blockierender Vordergrund-Aufruf. Das ist **ein** Datenpunkt und noch kein Beweis, aber es legt nahe, dass der Abbruch am Aufrufweg hängt und nicht am Skript — und dass die offene LaunchAgent-Frage womöglich gar nicht entschieden werden muss.

🤖 Generated with [Claude Code](https://claude.com/claude-code)