### PR TITLE
data: Apple-URI für Noisecontrollers – The Night (#1977)

### DIFF
--- a/custom_components/beatify/playlists/community/harder-styles.json
+++ b/custom_components/beatify/playlists/community/harder-styles.json
@@ -1,6 +1,6 @@
 {
   "name": "Harder Styles",
-  "version": "1.10",
+  "version": "1.11",
   "tags": [
     "hardstyle",
     "hardcore",
@@ -2478,7 +2478,7 @@
       "year": 2018,
       "isrc": "NLH2L1800135",
       "uri": "spotify:track:1rLd3cCQBWkXw0prrzBQvB",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/1470619481",
       "uri_apple_music_by_region": {
         "us": null,
         "de": null,


### PR DESCRIPTION
## Was drin ist

`harder-styles` Apple Music **180 → 181 / 190**, version **1.10 → 1.11**. Genau ein Feld plus Version-Bump.

| Artist | Titel | Apple-ID |
|---|---|---|
| Noisecontrollers | The Night | `1470619481` |

## Warum das jetzt geht

Der Track stand in [#1977](https://github.com/mholzi/beatify/issues/1977) unter **Gruppe A — Apple hat einen anderen Mix**. Das alte Gate lieferte `1470619483`, den **(Extended Mix)**, der am 05.08. von Hand auf `null` zurückgesetzt werden musste.

Die in [PR #1981](https://github.com/mholzi/beatify/pull/1981) eingeführte Regel 4 (`suffix_conflict`) blockiert den Extended Mix und lässt stattdessen die schlichte Fassung durch. Der Fund ist also nicht „Schwelle gesenkt", sondern **der richtige Treffer, den das alte Gate übersehen hat**.

## Was NICHT gelöst ist

Der `--retry-rejected`-Lauf hat alle 7 offenen Rejection-Kandidaten neu abgefragt. **6 bleiben abgelehnt, und das ist jeweils korrekt:**

| Track | Apple liefert | Bewertung |
|---|---|---|
| Noisecontrollers – Strike As A Die Hard | `[Pro Mix]` | anderer Mix, korrekt abgelehnt |
| Zatox – Hard Bass - Ran-D Remix | `Hard Bass [Mixed] (Ran-D Remix)` | `[Mixed]` ist die DJ-Mix-Fassung, korrekt abgelehnt |
| Mike NRG – Lost in Dreams (D-Fence Remix) | `(Q-Base Ost 2008) [Weapon X Remix]` | **anderer Remix**, korrekt abgelehnt |
| Sub Zero Project – Stand Strong | Artist `E-Force` | anderer Artist, korrekt |
| Artifact – Aftermath | Artist `Saif Shraideh` | anderer Artist, korrekt |
| Jason Payne – One | Titel `On the Frontline`, Ähnlichkeit 0.32 | korrekt |

Der Zatox-Fall aus #1980 passiert jetzt zwar die Artist-Regel, wird aber von der Suffix-Regel gestoppt — das war dort schon so vorhergesagt.

Die 3 echten Misses der Gruppe C wurden **nicht** angefasst (dafür bräuchte es `--retry-misses`); `null` bleibt dort die korrekte Angabe.

## Hinweis zur CI

**GitHub Actions hat gerade einen `major_outage`** (githubstatus.com). Dieser PR bekommt vermutlich keine Checks, bis das behoben ist. Lokal ist das Playlist-Schema-Gate grün — **54/54 Dateien valid**.

Refs #1977

🤖 Generated with [Claude Code](https://claude.com/claude-code)
