### PR TITLE
data: fix 2 wrong Apple Music region map URIs in 40s-50s-classics (#1991)

### DIFF
--- a/custom_components/beatify/playlists/40s-50s-classics.json
+++ b/custom_components/beatify/playlists/40s-50s-classics.json
@@ -1,6 +1,6 @@
 {
   "name": "40s & 50s Classics",
-  "version": "1.10",
+  "version": "1.11",
   "tags": [
     "1940s",
     "1950s",
@@ -2946,13 +2946,13 @@
       "uri": "spotify:track:14bUqUj1EUnQabWeAqnj39",
       "uri_apple_music": "applemusic://track/164459852",
       "uri_apple_music_by_region": {
-        "us": "applemusic://track/164459848",
-        "de": "applemusic://track/164459848",
-        "gb": "applemusic://track/164459848",
-        "fr": "applemusic://track/164459848",
-        "es": "applemusic://track/164459848",
-        "nl": "applemusic://track/164459848",
-        "it": "applemusic://track/164459848"
+        "us": "applemusic://track/164459852",
+        "de": "applemusic://track/164459852",
+        "gb": "applemusic://track/164459852",
+        "fr": "applemusic://track/164459852",
+        "es": "applemusic://track/164459852",
+        "nl": "applemusic://track/164459852",
+        "it": "applemusic://track/164459852"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=4hswHOEQfj8",
       "uri_tidal": "tidal://track/77412839",
@@ -3196,13 +3196,13 @@
       "uri": "spotify:track:66iKqUazBbTlAEjcZrpDkD",
       "uri_apple_music": "applemusic://track/1434896962",
       "uri_apple_music_by_region": {
-        "us": "applemusic://track/1707041008",
-        "de": "applemusic://track/1707041008",
-        "gb": "applemusic://track/1707041008",
-        "fr": "applemusic://track/1707041008",
-        "es": "applemusic://track/1707041008",
-        "nl": "applemusic://track/1707041008",
-        "it": "applemusic://track/1707041008"
+        "us": "applemusic://track/1434896962",
+        "de": "applemusic://track/1434896962",
+        "gb": "applemusic://track/1434896962",
+        "fr": "applemusic://track/1434896962",
+        "es": "applemusic://track/1434896962",
+        "nl": "applemusic://track/1434896962",
+        "it": "applemusic://track/1434896962"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=3UZmjs20Ms0",
       "uri_tidal": "tidal://track/94441589",


### PR DESCRIPTION
Closes #1991. Replaced 2 wrong Apple Music region map entries and bumped playlist version to 1.11.

**Fixes:**
- The Champs "Tequila (Original)": all 7 region map entries pointed to track/164459848 ("Too Much Tequila") instead of track/164459852 ("Tequila") — fixed
- Dinah Washington "What A Diff'rence A Day Made": all 7 region map entries (track/1707041008) returned 404 in all storefronts — replaced with track/1434896962 (same as main URI, verified live in all 7 regions)

**Dismissed false positive:**
- Johnny Mathis "Wonderful! Wonderful!" YouTube Music: flagged as wrong_track because YTM title says "Single Version" vs playlist's "with Ray Conniff & His Orchestra & Chorus" — same song, version variant, no fix needed