### PR TITLE
chore(playlists): tidal backfill wave — +38 uris

### DIFF
--- a/custom_components/beatify/playlists/community/finnish-iskelma-classics.json
+++ b/custom_components/beatify/playlists/community/finnish-iskelma-classics.json
@@ -1,6 +1,6 @@
 {
   "name": "Finnish Schlager Classics 🇫🇮",
-  "version": "1.17",
+  "version": "1.18",
   "tags": [
     "finnish",
     "iskelma",
@@ -7322,7 +7322,7 @@
       "awards_nl": [],
       "uri_apple_music": "applemusic://track/898852511",
       "uri_youtube_music": "https://music.youtube.com/watch?v=PvHlonCnHh8",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/20906146",
       "uri_deezer": "deezer://track/3598316",
       "isrc": "FIFMF7400300",
       "uri_apple_music_by_region": {
@@ -7355,7 +7355,7 @@
       "awards": [],
       "uri_apple_music": "applemusic://track/466355386",
       "uri_youtube_music": "https://music.youtube.com/watch?v=l-fjVXeVx4s",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/7915447",
       "uri_deezer": "deezer://track/14173054",
       "awards_nl": [],
       "isrc": "FIWMA1100701",
@@ -7389,7 +7389,7 @@
       "awards_nl": [],
       "uri_apple_music": null,
       "uri_youtube_music": "https://music.youtube.com/watch?v=lGN3XB9YXDI",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/1427262",
       "uri_deezer": "deezer://track/1225533152",
       "isrc": "FIEFP8700034",
       "uri_apple_music_by_region": {
@@ -7420,7 +7420,7 @@
       },
       "uri_deezer": "1010289512",
       "uri_youtube_music": "https://music.youtube.com/watch?v=PwxzWkKl8Sk",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/147296992",
       "alt_artists": [
         "Lasse Hoikka",
         "Irina",
@@ -7454,7 +7454,7 @@
       },
       "uri_deezer": "40489611",
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/26719312",
       "alt_artists": [
         "Susanna Heikki",
         "Kirka",
@@ -7488,7 +7488,7 @@
       },
       "uri_deezer": "16663730",
       "uri_youtube_music": "https://music.youtube.com/watch?v=4n_5vRqjh_s",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/14145129",
       "alt_artists": [
         "Suvi Teräsniska",
         "Hanna Pakarinen",
@@ -7522,7 +7522,7 @@
       },
       "uri_deezer": "20539491",
       "uri_youtube_music": "https://music.youtube.com/watch?v=IU3CEP_O3nY",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/15729334",
       "alt_artists": [
         "Janne Tulkki",
         "Oliver",
@@ -7554,7 +7554,7 @@
       "awards": [],
       "uri_apple_music": "applemusic://track/726619797",
       "uri_youtube_music": "https://music.youtube.com/watch?v=N72Gbbq3Esg",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/15210303",
       "uri_deezer": "deezer://track/27464911",
       "awards_nl": [],
       "isrc": "FIWMA1200117",
@@ -7590,7 +7590,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/147305934",
       "uri_deezer": "deezer://track/1010527642",
       "fun_fact": "Juha Eirto's 'Keskiyön tango' (Midnight Tango) captures late-night melancholy at the heart of Finnish tango; Finland hosts the world's largest tango festival in Seinäjoki each summer, drawing tens of thousands of devotees.",
       "fun_fact_de": "Juha Eirtos 'Keskiyön tango' (Mitternachtstango) erfasst die nächtliche Melancholie im Herzen des finnischen Tangos.",
@@ -7620,7 +7620,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/147305936",
       "uri_deezer": "deezer://track/1010527662",
       "fun_fact": "Olavi Virta's 'Sylvia-valssi' (Sylvia Waltz) showcases the elegant waltz-time side of Finland's most recorded popular singer; Virta's 800+ recordings covered an extraordinary range of genres, from tango to jazz to classical-influenced ballads.",
       "fun_fact_de": "Olavi Virtas 'Sylvia-valssi' zeigt die elegante Walzer-Seite von Finnlands meistaufgenommenem Popsänger.",
@@ -7648,7 +7648,7 @@
       "awards_nl": [],
       "uri_apple_music": "applemusic://track/656239587",
       "uri_youtube_music": "https://music.youtube.com/watch?v=HyNYlUQH7LQ",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/20930185",
       "uri_deezer": "deezer://track/65087962",
       "isrc": "FIFMF7600100",
       "uri_apple_music_by_region": {
@@ -7681,7 +7681,7 @@
       "awards_nl": [],
       "uri_apple_music": "applemusic://track/898892266",
       "uri_youtube_music": "https://music.youtube.com/watch?v=oKVW14ORZIU",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/390698",
       "uri_deezer": "deezer://track/65087952",
       "isrc": "FIFMF7302000",
       "uri_apple_music_by_region": {
@@ -7714,7 +7714,7 @@
       "awards_nl": [],
       "uri_apple_music": "applemusic://track/655962005",
       "uri_youtube_music": "https://music.youtube.com/watch?v=aFFep9KVr20",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/1578392",
       "uri_deezer": "deezer://track/14172588",
       "isrc": "FIFMF7200700",
       "uri_apple_music_by_region": {
@@ -7747,7 +7747,7 @@
       "awards": [],
       "uri_apple_music": "applemusic://track/857595588",
       "uri_youtube_music": "https://music.youtube.com/watch?v=73GZKW7dP_E",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/23149972",
       "uri_deezer": null,
       "awards_nl": [],
       "isrc": "FIWMA1300450",
@@ -7779,7 +7779,7 @@
       },
       "uri_deezer": "2566802322",
       "uri_youtube_music": "https://music.youtube.com/watch?v=fjRRU4BrAZg",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/332414298",
       "alt_artists": [
         "Lasse Hoikka",
         "Irina",
@@ -7811,7 +7811,7 @@
       "awards": [],
       "uri_apple_music": "applemusic://track/843388608",
       "uri_youtube_music": "https://music.youtube.com/watch?v=_QhnyJpXadA",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/1511114",
       "uri_deezer": "deezer://track/75684309",
       "awards_nl": [],
       "isrc": "FIUNP0400137",
@@ -7843,7 +7843,7 @@
       },
       "uri_deezer": "110957854",
       "uri_youtube_music": "https://music.youtube.com/watch?v=JaFIH8e3jRI",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/54386814",
       "alt_artists": [
         "Rajaton",
         "Kirka",
@@ -7877,7 +7877,7 @@
       },
       "uri_deezer": "121126658",
       "uri_youtube_music": "https://music.youtube.com/watch?v=4XZxx-8NJr4",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/57985487",
       "alt_artists": [
         "Komiat",
         "Jukka Kuoppamäki",
@@ -7911,7 +7911,7 @@
       },
       "uri_deezer": "145426818",
       "uri_youtube_music": "https://music.youtube.com/watch?v=Zc1dTEYZvvg",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/39188737",
       "alt_artists": [
         "Hanna Pakarinen",
         "Juha Metsäperä",
@@ -7945,7 +7945,7 @@
       },
       "uri_deezer": "135870046",
       "uri_youtube_music": "https://music.youtube.com/watch?v=J-nA_xdBdVU",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/51884808",
       "alt_artists": [
         "Ässät",
         "Mikko Kuustonen",
@@ -7983,7 +7983,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/10810024",
       "uri_deezer": "deezer://track/105382576",
       "fun_fact": "Laila Kinnunen's version of the Italian 'Chell'alla' is a bittersweet duet about evening arrivals and departures; Italian melodies were widely adapted into Finnish during the 1960s, and Kinnunen excelled at giving them an intimate, personal feel.",
       "fun_fact_de": "Laila Kinnunens Version des italienischen 'Chell'alla' ist ein bittersüßes Duett über abendliche Ankünfte und Abschiede.",
@@ -8009,7 +8009,7 @@
       },
       "uri_deezer": "100606176",
       "uri_youtube_music": "https://music.youtube.com/watch?v=IHDOJcX-8qA",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/45088282",
       "alt_artists": [
         "Reijo Taipale",
         "Jari Sillanpää",
@@ -8043,7 +8043,7 @@
       },
       "uri_deezer": "82200870",
       "uri_youtube_music": "https://music.youtube.com/watch?v=kDu7juQ5OSE",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/47553456",
       "alt_artists": [
         "Suvi Teräsniska",
         "Charles Plogman",
@@ -8077,7 +8077,7 @@
       },
       "uri_deezer": "107962726",
       "uri_youtube_music": "https://music.youtube.com/watch?v=u-RuV42TMsg",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/60136844",
       "alt_artists": [
         "Stella",
         "Reijo Kallio",
@@ -8111,7 +8111,7 @@
       },
       "uri_deezer": "125970475",
       "uri_youtube_music": "https://music.youtube.com/watch?v=pzh-NBeieSw",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/64016246",
       "alt_artists": [
         "Susanna Heikki",
         "Kirka",
@@ -8145,7 +8145,7 @@
       },
       "uri_deezer": "131337640",
       "uri_youtube_music": "https://music.youtube.com/watch?v=vHHJljueLQs",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/69223459",
       "alt_artists": [
         "Rajaton",
         "Kirka",
@@ -8179,7 +8179,7 @@
       },
       "uri_deezer": "124601772",
       "uri_youtube_music": "https://music.youtube.com/watch?v=izu9AMOqDss",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/60137459",
       "alt_artists": [
         "Rajaton",
         "Kirka",
@@ -8213,7 +8213,7 @@
       },
       "uri_deezer": "121126662",
       "uri_youtube_music": "https://music.youtube.com/watch?v=0hvexJl8NWY",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/57985489",
       "alt_artists": [
         "Komiat",
         "Jukka Kuoppamäki",
@@ -8247,7 +8247,7 @@
       },
       "uri_deezer": "117728526",
       "uri_youtube_music": "https://music.youtube.com/watch?v=MXPFS8J1bp4",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/56065920",
       "alt_artists": [
         "Komiat",
         "Jukka Kuoppamäki",
@@ -8281,7 +8281,7 @@
       },
       "uri_deezer": "132195254",
       "uri_youtube_music": "https://music.youtube.com/watch?v=9RwvXzD1LPs",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/64624762",
       "alt_artists": [
         "Heidi Pakarinen",
         "Antti Huovila",
@@ -8315,7 +8315,7 @@
       },
       "uri_deezer": "126847847",
       "uri_youtube_music": "https://music.youtube.com/watch?v=l8-RuuqZZqM",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/61927213",
       "alt_artists": [
         "Marion",
         "Hanna Pakarinen",
@@ -8349,7 +8349,7 @@
       },
       "uri_deezer": "117728514",
       "uri_youtube_music": "https://music.youtube.com/watch?v=8Kdw47e6AeE",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/59739862",
       "alt_artists": [
         "Lea Laven",
         "Riki Sorsa",
@@ -8383,7 +8383,7 @@
       },
       "uri_deezer": "132195124",
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/64562178",
       "alt_artists": [
         "Samuli Edelmann",
         "Arto Tamminen",
@@ -8417,7 +8417,7 @@
       },
       "uri_deezer": "129632946",
       "uri_youtube_music": "https://music.youtube.com/watch?v=ri51FQj5y5U",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/64257058",
       "alt_artists": [
         "Tomi Markkola",
         "Yö",
@@ -8451,7 +8451,7 @@
       },
       "uri_deezer": "127246111",
       "uri_youtube_music": "https://music.youtube.com/watch?v=p78pL9PwyE4",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/71567327",
       "alt_artists": [
         "Hanna Pakarinen",
         "Juha Metsäperä",
@@ -8485,7 +8485,7 @@
       },
       "uri_deezer": "341400671",
       "uri_youtube_music": "https://music.youtube.com/watch?v=PI02890Dus8",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/58693517",
       "alt_artists": [
         "Jukka Kuoppamäki",
         "Riki Sorsa",
@@ -8525,7 +8525,7 @@
       "awards_nl": [],
       "uri_apple_music": null,
       "uri_youtube_music": "https://music.youtube.com/watch?v=teFVIKbdls0",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/1225888",
       "uri_deezer": "deezer://track/3612633",
       "isrc": "FIFMF7300022",
       "uri_apple_music_by_region": {
@@ -8556,7 +8556,7 @@
       },
       "uri_deezer": "127247327",
       "uri_youtube_music": "https://music.youtube.com/watch?v=Trd8f8wSw30",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/62037362",
       "alt_artists": [
         "Tomi Markkola",
         "Reijo Taipale",


### PR DESCRIPTION
Eine Odesli-Welle, automatisch gefahren von `com.beatify.tidal-wave`.

- `finnish-iskelma-classics` Tidal 226 → **264**/293, version 1.17 → 1.18

Bilanz: 38 Treffer · 0 echte Misses · 26 Rate-Limit-Skips · 80 429-Zeilen.

**Draft mit Absicht** — Merge nur nach Markus' Freigabe.