### PR TITLE
chore(playlists): tidal backfill wave — +19 uris

### DIFF
--- a/custom_components/beatify/playlists/community/finnish-iskelma-classics.json
+++ b/custom_components/beatify/playlists/community/finnish-iskelma-classics.json
@@ -1,6 +1,6 @@
 {
   "name": "Finnish Schlager Classics 🇫🇮",
-  "version": "1.18",
+  "version": "1.19",
   "tags": [
     "finnish",
     "iskelma",
@@ -8693,7 +8693,7 @@
       },
       "uri_deezer": "128548813",
       "uri_youtube_music": "https://music.youtube.com/watch?v=VNzxf-MDJr0",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/62655806",
       "alt_artists": [
         "Ässät",
         "Mikko Kuustonen",
@@ -8727,7 +8727,7 @@
       },
       "uri_deezer": "125512210",
       "uri_youtube_music": "https://music.youtube.com/watch?v=TP-KRXZvvA8",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/60264672",
       "alt_artists": [
         "Anna Hanski",
         "Happoradio",
@@ -8763,7 +8763,7 @@
       "awards": [],
       "uri_apple_music": "applemusic://track/1565591756",
       "uri_youtube_music": "https://music.youtube.com/watch?v=I5zRPbh1Fas",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/182562984",
       "uri_deezer": "deezer://track/1360702882",
       "awards_nl": [],
       "isrc": "FIK3E1600204",
@@ -8795,7 +8795,7 @@
       },
       "uri_deezer": "541246172",
       "uri_youtube_music": "https://music.youtube.com/watch?v=0a6rpE8btK8",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/64691373",
       "alt_artists": [
         "Marion",
         "Heidi Kyrö",
@@ -8829,7 +8829,7 @@
       },
       "uri_deezer": "128548895",
       "uri_youtube_music": "https://music.youtube.com/watch?v=IUYEJw-s0TM",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/62655735",
       "alt_artists": [
         "Reijo Taipale",
         "Jari Sillanpää",
@@ -8863,7 +8863,7 @@
       },
       "uri_deezer": "496333152",
       "uri_youtube_music": "https://music.youtube.com/watch?v=_VxaYZVXQXo",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/95218451",
       "alt_artists": [
         "Marion",
         "Katri Helena",
@@ -8897,7 +8897,7 @@
       },
       "uri_deezer": "134947754",
       "uri_youtube_music": "https://music.youtube.com/watch?v=_B16yVXuD0M",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/66392221",
       "alt_artists": [
         "Jari Sillanpää",
         "Anne Mattila",
@@ -8931,7 +8931,7 @@
       },
       "uri_deezer": "120305744",
       "uri_youtube_music": "https://music.youtube.com/watch?v=bY139F1enyQ",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/57817888",
       "alt_artists": [
         "Riki Sorsa",
         "Jari Sillanpää",
@@ -8965,7 +8965,7 @@
       },
       "uri_deezer": "138122445",
       "uri_youtube_music": "https://music.youtube.com/watch?v=N10riFBXxjM",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/67844003",
       "alt_artists": [
         "Paula Koivuniemi",
         "Happoradio",
@@ -8999,7 +8999,7 @@
       },
       "uri_deezer": "126847719",
       "uri_youtube_music": "https://music.youtube.com/watch?v=N286cj8W1Sw",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/61539577",
       "alt_artists": [
         "Paula Koivuniemi",
         "Happoradio",
@@ -9033,7 +9033,7 @@
       },
       "uri_deezer": "124185522",
       "uri_youtube_music": "https://music.youtube.com/watch?v=K2I__DH3ZYQ",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/60136847",
       "alt_artists": [
         "Stella",
         "Reijo Kallio",
@@ -9067,7 +9067,7 @@
       },
       "uri_deezer": "141334777",
       "uri_youtube_music": "https://music.youtube.com/watch?v=9hyjMkLSR8k",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/69223462",
       "alt_artists": [
         "Rajaton",
         "Kirka",
@@ -9101,7 +9101,7 @@
       },
       "uri_deezer": "141824435",
       "uri_youtube_music": "https://music.youtube.com/watch?v=gXbkeNkMBLI",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/70199192",
       "alt_artists": [
         "Stella",
         "Portion Boys",
@@ -9135,7 +9135,7 @@
       },
       "uri_deezer": "143778134",
       "uri_youtube_music": "https://music.youtube.com/watch?v=vUMJQvtuXi8",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/71020010",
       "alt_artists": [
         "Hanna Pakarinen",
         "Juha Metsäperä",
@@ -9169,7 +9169,7 @@
       },
       "uri_deezer": "143335430",
       "uri_youtube_music": "https://music.youtube.com/watch?v=qOK_Esun3ec",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/71060841",
       "alt_artists": [
         "Irina",
         "Samuli Edelmann",
@@ -9203,7 +9203,7 @@
       },
       "uri_deezer": "75299345",
       "uri_youtube_music": "https://music.youtube.com/watch?v=jAPElJGDW_I",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/31826456",
       "alt_artists": [
         "Hanna Pakarinen",
         "Reijo Taipale",
@@ -9237,7 +9237,7 @@
       },
       "uri_deezer": "368958001",
       "uri_youtube_music": "https://music.youtube.com/watch?v=lgJhPknSTnA",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/77510658",
       "alt_artists": [
         "Stella",
         "Portion Boys",
@@ -9271,7 +9271,7 @@
       },
       "uri_deezer": "140797957",
       "uri_youtube_music": "https://music.youtube.com/watch?v=RHOOlQweDj8",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/69223310",
       "alt_artists": [
         "Pasi Ruohonen",
         "Irina",
@@ -9305,7 +9305,7 @@
       },
       "uri_deezer": "495980502",
       "uri_youtube_music": "https://music.youtube.com/watch?v=6HzP8Pj1XYI",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/89679558",
       "alt_artists": [
         "Marion",
         "Katri Helena",


### PR DESCRIPTION
Eine Odesli-Welle, automatisch gefahren von `com.beatify.tidal-wave`.

- `finnish-iskelma-classics` Tidal 264 → **283**/293, version 1.18 → 1.19

Bilanz: 19 Treffer · 0 echte Misses · 30 Rate-Limit-Skips · 88 429-Zeilen.

**Draft mit Absicht** — Merge nur nach Markus' Freigabe.