### PR TITLE
chore(playlists): tidal backfill wave — +17 uris

### DIFF
--- a/custom_components/beatify/playlists/community/greatest-metal-songs.json
+++ b/custom_components/beatify/playlists/community/greatest-metal-songs.json
@@ -1,6 +1,6 @@
 {
   "name": "Greatest Metal Songs of All Time 🤘",
-  "version": "1.10",
+  "version": "1.11",
   "tags": [
     "metal",
     "rock",
@@ -2570,7 +2570,7 @@
       "fun_fact_fr": "B.Y.O.B. (« Bring Your Own Bombs »), de l'album Mezmerize (2005), est une chanson de protestation furieuse contre la guerre d'Irak, opposant des couplets frénétiques à un refrain étonnamment mélodique. Elle remporta le Grammy 2006 de la meilleure performance hard rock.",
       "uri_apple_music": "applemusic://track/986888670",
       "uri_youtube_music": "https://music.youtube.com/watch?v=OMtq6JzREcA",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/560272",
       "fun_fact_nl": "B.Y.O.B. ('Bring Your Own Bombs'), van het album Mezmerize (2005), is een woedend protestlied tegen de Irakoorlog, dat razende coupletten contrasteert met een verrassend melodieus refrein. Het won in 2006 de Grammy Award voor Beste Hardrockprestatie.",
       "awards_nl": [
         "Grammy Award voor Beste Hardrockprestatie"

--- a/custom_components/beatify/playlists/community/harder-styles.json
+++ b/custom_components/beatify/playlists/community/harder-styles.json
@@ -1,6 +1,6 @@
 {
   "name": "Harder Styles",
-  "version": "1.11",
+  "version": "1.12",
   "tags": [
     "hardstyle",
     "hardcore",
@@ -84,7 +84,7 @@
         "it": "applemusic://track/415408811"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=ohsyd6rO_1o",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/84983260",
       "uri_deezer": "deezer://track/86472303",
       "alt_artists": [
         "Wildstylez",
@@ -113,7 +113,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=x9V3fWmOXkk",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/94393365",
       "uri_deezer": "deezer://track/86472299",
       "alt_artists": [
         "Wildstylez",
@@ -142,7 +142,7 @@
         "it": "applemusic://track/1805216148"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=9VbCZ65uzBM",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/84983741",
       "uri_deezer": "deezer://track/3287430221",
       "fun_fact": "D-Block & S-te-Fan are a Dutch hardstyle duo known for melodic, euphoric productions and their Scantraxx releases.",
       "fun_fact_de": "D-Block & S-te-Fan sind ein niederländisches Hardstyle-Duo, bekannt für melodische, euphorische Produktionen.",
@@ -167,7 +167,7 @@
         "it": "applemusic://track/415386902"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=6rngScnbaZA",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/84929668",
       "uri_deezer": "deezer://track/62208376",
       "fun_fact": "D-Block & S-te-Fan are a Dutch hardstyle duo known for melodic, euphoric productions and their Scantraxx releases.",
       "fun_fact_de": "D-Block & S-te-Fan sind ein niederländisches Hardstyle-Duo, bekannt für melodische, euphorische Produktionen.",
@@ -192,7 +192,7 @@
         "it": "applemusic://track/415388791"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=LS1XPB8VAVs",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/84983583",
       "uri_deezer": "deezer://track/63046978",
       "fun_fact": "A hardstyle / hardcore track (2009).",
       "fun_fact_de": "Ein Hardstyle-/Hardcore-Track (2009).",
@@ -217,7 +217,7 @@
         "it": "applemusic://track/415271521"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=XV1qQVhFx_g",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/463274189",
       "uri_deezer": "deezer://track/63046892",
       "fun_fact": "A hardstyle / hardcore track (2009).",
       "fun_fact_de": "Ein Hardstyle-/Hardcore-Track (2009).",
@@ -242,7 +242,7 @@
         "it": "applemusic://track/420275831"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=_V-zIp9_EQs",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/16296135",
       "uri_deezer": "deezer://track/9958420",
       "fun_fact": "A hardstyle / hardcore track (2010).",
       "fun_fact_de": "Ein Hardstyle-/Hardcore-Track (2010).",
@@ -267,7 +267,7 @@
         "it": "applemusic://track/489794486"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=U5XmoYxY8ro",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/84932197",
       "uri_deezer": "deezer://track/63046498",
       "alt_artists": [
         "Deepack"
@@ -295,7 +295,7 @@
         "it": "applemusic://track/643877934"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=yqWJb0mW0B8",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/79634272",
       "uri_deezer": "deezer://track/67040237",
       "alt_artists": [
         "Lene Kokai"
@@ -323,7 +323,7 @@
         "it": "applemusic://track/635816578"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=_eZUnt4ff38",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/374546506",
       "uri_deezer": "deezer://track/66554143",
       "fun_fact": "A hardstyle / hardcore track (2013).",
       "fun_fact_de": "Ein Hardstyle-/Hardcore-Track (2013).",
@@ -348,7 +348,7 @@
         "it": "applemusic://track/1679587711"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=y0UK8Or_ABs",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/285799800",
       "uri_deezer": "deezer://track/2212640817",
       "alt_artists": [
         "F8trix"
@@ -376,7 +376,7 @@
         "it": "applemusic://track/1842432772"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=2UXFA6zfFi8",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/463243419",
       "uri_deezer": "deezer://track/76761244",
       "fun_fact": "The Prophet is a Dutch DJ and a pioneering figure of hardstyle and its early hardcore roots.",
       "fun_fact_de": "The Prophet ist ein niederländischer DJ und eine Pionierfigur des Hardstyle und seiner frühen Hardcore-Wurzeln.",
@@ -401,7 +401,7 @@
         "it": "applemusic://track/1278515031"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=AproN5JLHnM",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/29988231",
       "uri_deezer": "deezer://track/399475412",
       "fun_fact": "A hardstyle / hardcore track (2014).",
       "fun_fact_de": "Ein Hardstyle-/Hardcore-Track (2014).",
@@ -426,7 +426,7 @@
         "it": "applemusic://track/923426095"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=3M6hB2zo134",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/463403243",
       "uri_deezer": "deezer://track/86869601",
       "alt_artists": [
         "DV8 Rocks!"
@@ -454,7 +454,7 @@
         "it": "applemusic://track/1556106100"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=_nuF-1kcOdg",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/175466766",
       "uri_deezer": "deezer://track/1260681482",
       "alt_artists": [
         "Ruthless"
@@ -482,7 +482,7 @@
         "it": "applemusic://track/978709565"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=0e_IVwZRF7g",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/55355790",
       "uri_deezer": "deezer://track/98063004",
       "fun_fact": "A hardstyle / hardcore track (2015).",
       "fun_fact_de": "Ein Hardstyle-/Hardcore-Track (2015).",


### PR DESCRIPTION
Eine Odesli-Welle, automatisch gefahren von `com.beatify.tidal-wave`.

- `greatest-metal-songs` Tidal 60 → **61**/61, version 1.10 → 1.11
- `harder-styles` Tidal 0 → **16**/190, version 1.11 → 1.12

Bilanz: 17 Treffer · 2 echte Misses · 29 Rate-Limit-Skips · 87 429-Zeilen.

**Draft mit Absicht** — Merge nur nach Markus' Freigabe.