### PR TITLE
chore(playlists): tidal backfill wave — +17 uris

### DIFF
--- a/custom_components/beatify/playlists/community/harder-styles.json
+++ b/custom_components/beatify/playlists/community/harder-styles.json
@@ -1,6 +1,6 @@
 {
   "name": "Harder Styles",
-  "version": "1.12",
+  "version": "1.13",
   "tags": [
     "hardstyle",
     "hardcore",
@@ -507,7 +507,7 @@
         "it": "applemusic://track/981901908"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=cg_yarNOFCE",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/84984290",
       "uri_deezer": "deezer://track/98098272",
       "fun_fact": "A hardstyle / hardcore track (2015).",
       "fun_fact_de": "Ein Hardstyle-/Hardcore-Track (2015).",
@@ -532,7 +532,7 @@
         "it": "applemusic://track/992883574"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=TTnZIB8hkzY",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/46291693",
       "uri_deezer": "deezer://track/100519446",
       "fun_fact": "A hardstyle / hardcore track (2015).",
       "fun_fact_de": "Ein Hardstyle-/Hardcore-Track (2015).",
@@ -585,7 +585,7 @@
         "it": "applemusic://track/922010485"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=7mKlr6QgMtY",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/462396644",
       "uri_deezer": "deezer://track/100908106",
       "alt_artists": [
         "Abject"
@@ -642,7 +642,7 @@
         "it": "applemusic://track/1011730059"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=qBSVeb1kvEc",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/51131047",
       "uri_deezer": "deezer://track/102957868",
       "fun_fact": "A hardstyle / hardcore track (2014).",
       "fun_fact_de": "Ein Hardstyle-/Hardcore-Track (2014).",
@@ -667,7 +667,7 @@
         "it": "applemusic://track/1077741547"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=XwboqMO_eKU",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/434957096",
       "uri_deezer": "deezer://track/118029228",
       "alt_artists": [
         "John Harris"
@@ -695,7 +695,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=rkgGAa_TdaA",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/60362142",
       "uri_deezer": "deezer://track/2328621965",
       "fun_fact": "A hardstyle / hardcore track (2015).",
       "fun_fact_de": "Ein Hardstyle-/Hardcore-Track (2015).",
@@ -720,7 +720,7 @@
         "it": "applemusic://track/1873488365"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=WMCxlaCh--8",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/498760313",
       "uri_deezer": "deezer://track/3842816301",
       "fun_fact": "Ran-D is a Dutch hardstyle artist, also one half of the duo Gunz For Hire.",
       "fun_fact_de": "Ran-D ist ein niederländischer Hardstyle-Künstler und zugleich eine Hälfte des Duos Gunz For Hire.",
@@ -745,7 +745,7 @@
         "it": "applemusic://track/986427654"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=Q-ycbdf4tho",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/79633641",
       "uri_deezer": "deezer://track/356862911",
       "alt_artists": [
         "Oscar"
@@ -773,7 +773,7 @@
         "it": "applemusic://track/1770708119"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=1iUh3HQToRc",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/389494568",
       "uri_deezer": "deezer://track/3015841471",
       "fun_fact": "Radical Redemption is a Dutch artist at the harder, raw end of the hardstyle spectrum.",
       "fun_fact_de": "Radical Redemption ist ein niederländischer Künstler am härteren, rohen Ende des Hardstyle-Spektrums.",
@@ -798,7 +798,7 @@
         "it": "applemusic://track/1149009130"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=j5KTSicTf-w",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/64487256",
       "uri_deezer": "deezer://track/3015841371",
       "fun_fact": "Radical Redemption is a Dutch artist at the harder, raw end of the hardstyle spectrum.",
       "fun_fact_de": "Radical Redemption ist ein niederländischer Künstler am härteren, rohen Ende des Hardstyle-Spektrums.",
@@ -823,7 +823,7 @@
         "it": "applemusic://track/1740385583"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=kqlRcIf6w0c",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/352185684",
       "uri_deezer": "deezer://track/116994412",
       "fun_fact": "A hardstyle / hardcore track (2015).",
       "fun_fact_de": "Ein Hardstyle-/Hardcore-Track (2015).",
@@ -848,7 +848,7 @@
         "it": "applemusic://track/1102452364"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=AqgAMftI_bc",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/94393364",
       "uri_deezer": "deezer://track/118605368",
       "alt_artists": [
         "The Prophet"
@@ -876,7 +876,7 @@
         "it": "applemusic://track/1450543977"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=dehsumm05eE",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/56601900",
       "uri_deezer": "deezer://track/3842818841",
       "fun_fact": "Gunz For Hire is the hardstyle duo of Ran-D and Adaro, known for dark, raw-edged anthems.",
       "fun_fact_de": "Gunz For Hire ist das Hardstyle-Duo aus Ran-D und Adaro, bekannt für düstere, raue Hymnen.",
@@ -901,7 +901,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=wJHROyBwzyQ",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/352178028",
       "uri_deezer": "deezer://track/126209957",
       "alt_artists": [
         "MC Creature"
@@ -929,7 +929,7 @@
         "it": "applemusic://track/1444297787"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=WuUe99_2fzY",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/64372935",
       "uri_deezer": "deezer://track/131344236",
       "alt_artists": [
         "The Darkraver",
@@ -958,7 +958,7 @@
         "it": "applemusic://track/1197352992"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=zsxtLnAnXQM",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/84929822",
       "uri_deezer": "deezer://track/132282586",
       "alt_artists": [
         "The Prophet"
@@ -986,7 +986,7 @@
         "it": "applemusic://track/1681737060"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=jpGJwjVzBeA",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/237059571",
       "uri_deezer": "deezer://track/1818044977",
       "alt_artists": [
         "Dbstf",


### PR DESCRIPTION
Eine Odesli-Welle, automatisch gefahren von `com.beatify.tidal-wave`.

- `harder-styles` Tidal 16 → **33**/190, version 1.12 → 1.13

Bilanz: 17 Treffer · 2 echte Misses · 29 Rate-Limit-Skips · 87 429-Zeilen.

**Draft mit Absicht** — Merge nur nach Markus' Freigabe.