### PR TITLE
chore(playlists): tidal backfill wave — +19 uris

### DIFF
--- a/custom_components/beatify/playlists/community/harder-styles.json
+++ b/custom_components/beatify/playlists/community/harder-styles.json
@@ -1,6 +1,6 @@
 {
   "name": "Harder Styles",
-  "version": "1.16",
+  "version": "1.17",
   "tags": [
     "hardstyle",
     "hardcore",
@@ -2024,7 +2024,7 @@
         "it": "applemusic://track/1842462057"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=v6KoaP3j5qM",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/442149441",
       "uri_deezer": "deezer://track/3842891621",
       "fun_fact": "Gunz For Hire is the hardstyle duo of Ran-D and Adaro, known for dark, raw-edged anthems.",
       "fun_fact_de": "Gunz For Hire ist das Hardstyle-Duo aus Ran-D und Adaro, bekannt für düstere, raue Hymnen.",
@@ -2514,7 +2514,7 @@
         "it": "applemusic://track/1773268601"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=x_1QLhFWw-8",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/92988576",
       "uri_deezer": "deezer://track/3039390731",
       "fun_fact": "A hardstyle / hardcore track (2024).",
       "fun_fact_de": "Ein Hardstyle-/Hardcore-Track (2024).",
@@ -2539,7 +2539,7 @@
         "it": "applemusic://track/1843189485"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=kWutRKO4K6M",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/98581975",
       "uri_deezer": "deezer://track/617578112",
       "fun_fact": "Ran-D is a Dutch hardstyle artist, also one half of the duo Gunz For Hire.",
       "fun_fact_de": "Ran-D ist ein niederländischer Hardstyle-Künstler und zugleich eine Hälfte des Duos Gunz For Hire.",
@@ -2564,7 +2564,7 @@
         "it": "applemusic://track/1441784259"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=hNI9RqVF4gs",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/352184049",
       "uri_deezer": "deezer://track/583568812",
       "fun_fact": "A hardstyle / hardcore track (2018).",
       "fun_fact_de": "Ein Hardstyle-/Hardcore-Track (2018).",
@@ -2589,7 +2589,7 @@
         "it": "applemusic://track/1246268938"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=ouxoYtOkNcY",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/94393355",
       "uri_deezer": "deezer://track/583569452",
       "fun_fact": "A hardstyle / hardcore track (2018).",
       "fun_fact_de": "Ein Hardstyle-/Hardcore-Track (2018).",
@@ -2614,7 +2614,7 @@
         "it": "applemusic://track/1429745273"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=ZKhHSMywOok",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/93705093",
       "uri_deezer": "deezer://track/542288862",
       "fun_fact": "A hardstyle / hardcore track (2018).",
       "fun_fact_de": "Ein Hardstyle-/Hardcore-Track (2018).",
@@ -2639,7 +2639,7 @@
         "it": "applemusic://track/1594624227"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=AHBoYKEFQfU",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/93148827",
       "uri_deezer": "deezer://track/1548816292",
       "alt_artists": [
         "Technoboy",
@@ -2668,7 +2668,7 @@
         "it": "applemusic://track/1843188539"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=N2RGlesRFKo",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/94393313",
       "uri_deezer": "deezer://track/965474012",
       "fun_fact": "A hardstyle / hardcore track (2018).",
       "fun_fact_de": "Ein Hardstyle-/Hardcore-Track (2018).",
@@ -2685,7 +2685,7 @@
       "uri_apple_music": null,
       "uri_apple_music_by_region": {},
       "uri_youtube_music": "https://music.youtube.com/watch?v=dP_KhSmjFzI",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/94393347",
       "uri_deezer": null,
       "fun_fact": "A hardstyle / hardcore track (2018).",
       "fun_fact_de": "Ein Hardstyle-/Hardcore-Track (2018).",
@@ -2710,7 +2710,7 @@
         "it": "applemusic://track/1438848217"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=1VrGSoNXDQg",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/96606751",
       "uri_deezer": "deezer://track/567314602",
       "fun_fact": "Coone is a Belgian hardstyle DJ and founder of the Dirty Workz label.",
       "fun_fact_de": "Coone ist ein belgischer Hardstyle-DJ und Gründer des Labels Dirty Workz.",
@@ -2735,7 +2735,7 @@
         "it": "applemusic://track/1435525054"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=YbHzgepOPZ4",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/94702701",
       "uri_deezer": "deezer://track/536846792",
       "fun_fact": "A hardstyle / hardcore track (2018).",
       "fun_fact_de": "Ein Hardstyle-/Hardcore-Track (2018).",
@@ -2760,7 +2760,7 @@
         "it": "applemusic://track/1444297681"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=FNDwfrQFeEA",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/95069750",
       "uri_deezer": "deezer://track/554943742",
       "fun_fact": "A hardstyle / hardcore track (2018).",
       "fun_fact_de": "Ein Hardstyle-/Hardcore-Track (2018).",
@@ -2785,7 +2785,7 @@
         "it": "applemusic://track/1439047089"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=JBPngYAC39c",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/352177118",
       "uri_deezer": "deezer://track/965512562",
       "alt_artists": [
         "Villain"
@@ -2813,7 +2813,7 @@
         "it": "applemusic://track/1441296798"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=JcC_aDCRVOI",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/97406877",
       "uri_deezer": "deezer://track/579174902",
       "alt_artists": [
         "D-Sturb"
@@ -2841,7 +2841,7 @@
         "it": "applemusic://track/1483063022"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=315d_c2k-oY",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/104143736",
       "uri_deezer": "deezer://track/579200632",
       "fun_fact": "A hardstyle / hardcore track (2018).",
       "fun_fact_de": "Ein Hardstyle-/Hardcore-Track (2018).",
@@ -2866,7 +2866,7 @@
         "it": "applemusic://track/1440051917"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=BYnZbjS4pYA",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/97282790",
       "uri_deezer": "deezer://track/573782042",
       "fun_fact": "A hardstyle / hardcore track (2018).",
       "fun_fact_de": "Ein Hardstyle-/Hardcore-Track (2018).",
@@ -2891,7 +2891,7 @@
         "it": "applemusic://track/1469274982"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=DJ4tu2_4xic",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/111607032",
       "uri_deezer": "deezer://track/578359072",
       "alt_artists": [
         "Mental Theo"
@@ -2919,7 +2919,7 @@
         "it": "applemusic://track/1443910520"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=6gYA9tcAUbk",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/98656301",
       "uri_deezer": "deezer://track/585350602",
       "alt_artists": [
         "Sefa"
@@ -2947,7 +2947,7 @@
         "it": "applemusic://track/1450545182"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=bCKgg9_8VzE",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/98581977",
       "uri_deezer": "deezer://track/583568962",
       "alt_artists": [
         "B-Front"


### PR DESCRIPTION
Eine Odesli-Welle, automatisch gefahren von `com.beatify.tidal-wave`.

- `harder-styles` Tidal 87 → **106**/190, version 1.16 → 1.17

Bilanz: 19 Treffer · 0 echte Misses · 29 Rate-Limit-Skips · 87 429-Zeilen.

**Draft mit Absicht** — Merge nur nach Markus' Freigabe.