### PR TITLE
fix(scripts): zweistufige Apple-Suche — Klammer-Zusatz nicht mehr im Suchbegriff

### DIFF
--- a/scripts/backfill_apple.py
+++ b/scripts/backfill_apple.py
@@ -25,6 +25,22 @@ Two failure modes were visible in the very first five samples:
 An ungated backfill would therefore manufacture exactly the ``wrong_track``
 defects that the daily playlist-review then has to find and repair. Hence:
 
+Two-stage search (2026-08-08)
+-----------------------------
+The gate can only judge what the search returns, and the search term used to be
+the primary artist plus the **full** title. iTunes ranks on the whole string, so
+a distinctive parenthetical outweighs the song title: ``Sub Zero Project Stand
+Strong (Q-BASE 2017 Hangar OST)`` answers with ``E-Force – Salute (Q-Base 2018
+Hangar Ost)`` in both storefronts — different artist, different song, different
+year — while the correct track never appears at all. Dropping the suffix puts
+``Stand Strong (feat. Meccah Dawn)`` at rank 1 in ``de`` and ``us``.
+
+``search_terms`` therefore yields the historical term first and, only when the
+title actually carries a parenthetical, a second one without it. Stage 1 is
+unchanged and still wins on a tie, so this can only add matches, never move an
+existing one. **The gate is untouched** — stage 2 widens what it gets to see,
+not what it accepts.
+
 The gate
 --------
 A search result is only accepted when **all** of these hold:
@@ -127,6 +143,8 @@ _PAREN_RE = re.compile(r"\s*[\(\[][^)\]]*[)\]]")
 _PAREN_CONTENT_RE = re.compile(r"[\(\[]([^)\]]*)[)\]]")
 _PUNCT_RE = re.compile(r"[^\w\s]", re.UNICODE)
 _WS_RE = re.compile(r"\s+")
+# Separators a stripped parenthetical can leave dangling at the end of a title.
+_TRAILING_SEP_RE = re.compile(r"[\s\-–—/,:;]+$")
 _ARTIST_SPLIT_RE = re.compile(r"\s*[,;/]\s*|\s+(?:&|feat\.?|ft\.?|x|vs\.?)\s+", re.I)
 
 # Parenthetical suffixes that name the same *recording* — packaging or mastering
@@ -230,6 +248,52 @@ def suffix_conflict(a: str, b: str) -> str | None:
                 continue
             return suffix
     return None
+
+
+def strip_parentheticals(text: str) -> str:
+    """Title without its ``(...)``/``[...]`` groups and the debris they leave.
+
+    Only for building a *search* term — the gate keeps comparing full titles.
+    Trailing separators matter: ``Lost in Dreams (Q-BASE 2017 Warehouse OST) -
+    (D-Fence Remix)`` would otherwise become ``Lost in Dreams -`` and carry the
+    dangling dash into the query.
+    """
+    if not text:
+        return ""
+    out = _PAREN_RE.sub(" ", text)
+    out = _WS_RE.sub(" ", out).strip()
+    return _TRAILING_SEP_RE.sub("", out).strip()
+
+
+def search_terms(track: dict) -> list[str]:
+    """Query strings to try, most specific first.
+
+    Stage 1 is the historical term (primary artist + **full** title). Stage 2
+    drops the parenthetical groups, and exists because iTunes ranks on the whole
+    string: a distinctive event suffix outweighs the song title and can return a
+    wholly unrelated track, so the right candidate never reaches the gate.
+
+    The case this was built from — ``Sub Zero Project`` / ``Stand Strong
+    (Q-BASE 2017 Hangar OST)``. With the suffix, Apple answers with two
+    ``E-Force – Salute (Q-Base 2018 Hangar Ost)`` rows in both storefronts:
+    different artist, different song, different year. Without it, the correct
+    ``Stand Strong (feat. Meccah Dawn)`` is rank 1 in ``de`` **and** ``us``.
+
+    Stage 2 is skipped when it would repeat stage 1, so titles without a
+    parenthetical cost no extra request.
+    """
+    artist = primary_artist(track.get("artist", "") or "")
+    title = (track.get("title", "") or "").strip()
+    terms: list[str] = []
+    full = f"{artist} {title}".strip()
+    if full:
+        terms.append(full)
+    bare = strip_parentheticals(title)
+    if bare and bare != title:
+        reduced = f"{artist} {bare}".strip()
+        if reduced and reduced not in terms:
+            terms.append(reduced)
+    return terms
 
 
 def title_similarity(a: str, b: str) -> float:
@@ -363,41 +427,54 @@ def resolve(track: dict, *, title_threshold: float, year_tolerance: int,
     outcome: 'hit' | 'miss' (no results anywhere) | 'rejected' (results, none
     passed the gate) | 'skip' (throttled/transient).
     """
-    term = f"{primary_artist(track.get('artist', ''))} {track.get('title', '')}".strip()
-    if not term:
+    terms = search_terms(track)
+    if not terms:
         return None, "rejected", "no artist/title to search on"
 
     saw_any = False
-    first_reason = ""
-    for storefront in STOREFRONTS:
-        results, outcome = itunes_search(term, storefront, limit)
-        if outcome == "skip":
-            return None, "skip", f"throttled on storefront {storefront}"
-        if not results:
-            continue
-        saw_any = True
-        for result in results:
-            accepted, reason = evaluate(
-                track, result,
-                title_threshold=title_threshold, year_tolerance=year_tolerance,
-            )
-            if accepted:
-                tid = result.get("trackId")
-                if not tid:
-                    continue
-                return (
-                    f"applemusic://track/{tid}",
-                    "hit",
-                    f"{storefront}: {result.get('artistName')} – "
-                    f"{result.get('trackName')} ({reason})",
+    reason_to_report = ""
+    for stage, term in enumerate(terms):
+        # Tag stage-2 candidates so a rejection cannot be mistaken for a verdict
+        # on the full-title query. Kept space-free — main() parses the reason as
+        # "<tag>: <kind> ..." to tally the rejection breakdown.
+        tag_suffix = "" if stage == 0 else "(bare)"
+        stage_reason = ""
+        for storefront in STOREFRONTS:
+            results, outcome = itunes_search(term, storefront, limit)
+            if outcome == "skip":
+                return None, "skip", f"throttled on storefront {storefront}"
+            if not results:
+                continue
+            saw_any = True
+            for result in results:
+                accepted, reason = evaluate(
+                    track, result,
+                    title_threshold=title_threshold, year_tolerance=year_tolerance,
                 )
-            if not first_reason:
-                first_reason = f"{storefront}: {reason}"
-        time.sleep(BASE_DELAY_S)
+                if accepted:
+                    tid = result.get("trackId")
+                    if not tid:
+                        continue
+                    return (
+                        f"applemusic://track/{tid}",
+                        "hit",
+                        f"{storefront}{tag_suffix}: {result.get('artistName')} – "
+                        f"{result.get('trackName')} ({reason})",
+                    )
+                if not stage_reason:
+                    stage_reason = f"{storefront}{tag_suffix}: {reason}"
+            time.sleep(BASE_DELAY_S)
+        # Report the *last* stage that produced candidates. A stage-1 rejection
+        # is often a verdict on an unrelated track the suffix dragged in, and
+        # recording it hid the real situation: "artist 'E-Force' != 'Sub Zero
+        # Project'" read as "Apple credits it differently" when it meant "the
+        # search returned something else entirely".
+        if stage_reason:
+            reason_to_report = stage_reason
 
     if not saw_any:
         return None, "miss", "no results in any storefront"
-    return None, "rejected", first_reason
+    return None, "rejected", reason_to_report
 
 
 def main() -> int:

--- a/tests/unit/test_backfill_apple_search_terms.py
+++ b/tests/unit/test_backfill_apple_search_terms.py
@@ -1,0 +1,99 @@
+"""Two-stage search-term construction in ``scripts/backfill_apple.py``.
+
+The gate can only judge what the search returns. Until 2026-08-08 the query was
+the primary artist plus the **full** title, and iTunes ranks on the whole
+string — so a distinctive parenthetical outweighed the song title.
+
+The case this was built from is real, not invented: searching
+``Sub Zero Project Stand Strong (Q-BASE 2017 Hangar OST)`` returned two
+``E-Force – Salute (Q-Base 2018 Hangar Ost)`` rows in ``de`` and ``us``, and the
+correct recording did not appear at all. It was therefore recorded as
+``artist 'E-Force' != 'Sub Zero Project'`` — a rejection that reads like "Apple
+credits it differently" but means "the search returned something else".
+
+``scripts/`` is not a package, so the module is loaded by path.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "backfill_apple.py"
+_spec = importlib.util.spec_from_file_location("backfill_apple", _SCRIPT)
+backfill_apple = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(backfill_apple)
+
+search_terms = backfill_apple.search_terms
+strip_parentheticals = backfill_apple.strip_parentheticals
+
+
+@pytest.mark.parametrize(
+    ("title", "expected"),
+    [
+        ("Stand Strong (Q-BASE 2017 Hangar OST)", "Stand Strong"),
+        ("Strike As A Die Hard (Q-Base Anthem 2017)", "Strike As A Die Hard"),
+        ("Dragonblood (Defqon.1 Chile Anthem 2016)", "Dragonblood"),
+        # Two groups and a dangling dash between them — the naive strip leaves
+        # "Lost in Dreams -" and carries the dash into the query.
+        (
+            "Lost in Dreams (Q-BASE 2017 Warehouse OST) - (D-Fence Remix)",
+            "Lost in Dreams",
+        ),
+        ("The Night [Extended Mix]", "The Night"),
+        # Nothing to strip — must come back untouched.
+        ("Aftermath", "Aftermath"),
+        ("", ""),
+    ],
+)
+def test_strip_parentheticals(title: str, expected: str) -> None:
+    assert strip_parentheticals(title) == expected
+
+
+def test_second_term_drops_the_parenthetical() -> None:
+    track = {"artist": "Sub Zero Project", "title": "Stand Strong (Q-BASE 2017 Hangar OST)"}
+    assert search_terms(track) == [
+        "Sub Zero Project Stand Strong (Q-BASE 2017 Hangar OST)",
+        "Sub Zero Project Stand Strong",
+    ]
+
+
+def test_stage_one_is_unchanged() -> None:
+    """The historical term stays first, so an existing hit cannot move."""
+    for track in (
+        {"artist": "Zatox", "title": "Hard Bass - Ran-D Remix"},
+        {"artist": "Sub Zero Project", "title": "Stand Strong (Q-BASE 2017 Hangar OST)"},
+        {"artist": "Artifact", "title": "Aftermath"},
+    ):
+        first = search_terms(track)[0]
+        expected = (
+            f"{backfill_apple.primary_artist(track['artist'])} {track['title']}".strip()
+        )
+        assert first == expected
+
+
+def test_no_parenthetical_means_no_second_request() -> None:
+    """Titles without a group must not cost an extra query."""
+    assert search_terms({"artist": "Artifact", "title": "Aftermath"}) == [
+        "Artifact Aftermath"
+    ]
+
+
+def test_only_the_lead_artist_is_searched() -> None:
+    """Unchanged behaviour: search results carry the lead artist only."""
+    track = {"artist": "Tatanka, Zatox & Wild Motherfuckers", "title": "Bassleader (Anthem 2012)"}
+    terms = search_terms(track)
+    assert terms[0].startswith("Tatanka ")
+    assert terms[-1] == "Tatanka Bassleader"
+
+
+def test_a_title_that_is_only_a_parenthetical_yields_one_term() -> None:
+    """Stripping must not produce an artist-only query that matches anything."""
+    track = {"artist": "Frontliner", "title": "(Defqon.1 Chile Anthem 2016)"}
+    assert search_terms(track) == ["Frontliner (Defqon.1 Chile Anthem 2016)"]
+
+
+def test_no_artist_and_no_title_yields_nothing() -> None:
+    assert search_terms({"artist": "", "title": ""}) == []

--- a/tests/unit/test_backfill_apple_search_terms.py
+++ b/tests/unit/test_backfill_apple_search_terms.py
@@ -53,7 +53,10 @@ def test_strip_parentheticals(title: str, expected: str) -> None:
 
 
 def test_second_term_drops_the_parenthetical() -> None:
-    track = {"artist": "Sub Zero Project", "title": "Stand Strong (Q-BASE 2017 Hangar OST)"}
+    track = {
+        "artist": "Sub Zero Project",
+        "title": "Stand Strong (Q-BASE 2017 Hangar OST)",
+    }
     assert search_terms(track) == [
         "Sub Zero Project Stand Strong (Q-BASE 2017 Hangar OST)",
         "Sub Zero Project Stand Strong",
@@ -64,7 +67,10 @@ def test_stage_one_is_unchanged() -> None:
     """The historical term stays first, so an existing hit cannot move."""
     for track in (
         {"artist": "Zatox", "title": "Hard Bass - Ran-D Remix"},
-        {"artist": "Sub Zero Project", "title": "Stand Strong (Q-BASE 2017 Hangar OST)"},
+        {
+            "artist": "Sub Zero Project",
+            "title": "Stand Strong (Q-BASE 2017 Hangar OST)",
+        },
         {"artist": "Artifact", "title": "Aftermath"},
     ):
         first = search_terms(track)[0]
@@ -83,7 +89,10 @@ def test_no_parenthetical_means_no_second_request() -> None:
 
 def test_only_the_lead_artist_is_searched() -> None:
     """Unchanged behaviour: search results carry the lead artist only."""
-    track = {"artist": "Tatanka, Zatox & Wild Motherfuckers", "title": "Bassleader (Anthem 2012)"}
+    track = {
+        "artist": "Tatanka, Zatox & Wild Motherfuckers",
+        "title": "Bassleader (Anthem 2012)",
+    }
     terms = search_terms(track)
     assert terms[0].startswith("Tatanka ")
     assert terms[-1] == "Tatanka Bassleader"


### PR DESCRIPTION
Behebt #2007 — der Klammer-Zusatz stand mit im iTunes-Suchbegriff und hat den richtigen Treffer aus dem Ergebnis verdrängt.

## Was geändert wurde

`search_terms()` liefert die Suchbegriffe jetzt gestaffelt:

1. **Stufe 1** — primärer Artist + **vollständiger** Titel. Unverändert, kommt zuerst und gewinnt bei Gleichstand.
2. **Stufe 2** — derselbe Begriff ohne die `(...)`/`[...]`-Gruppen. Wird nur gebildet, wenn der Titel wirklich eine Klammer trägt.

`strip_parentheticals()` räumt dabei auch die Trennzeichen weg, die eine entfernte Gruppe hinterlässt — sonst wird aus `Lost in Dreams (Q-BASE 2017 Warehouse OST) - (D-Fence Remix)` der Suchbegriff `Lost in Dreams -`.

**Das Gate ist unangetastet.** Alle vier Regeln aus #1980 stehen unverändert; sie bekommen nur mehr Kandidaten vorgelegt.

Zusätzlich nennt die protokollierte Ablehnung jetzt die Stufe (`de(bare):`) und stammt aus der **letzten** Stufe, die überhaupt Kandidaten hatte. Vorher wurde die Ablehnung der ersten Stufe festgehalten, obwohl sie oft ein Urteil über einen Fremdtreffer war, den der Suffix hereingezogen hatte — genau daran ist die Analyse vom 06.08. in #1977 hängengeblieben.

## Gemessenes Ergebnis — ehrlich: null neue URIs

`--probe --retry-rejected --retry-misses` gegen `community/harder-styles`, mit echtem Netz, ohne Schreibzugriff:

```
9 track(s) missing Apple Music across 1 playlist(s) (probe — no writes)
wave done: 0 accepted, 7 rejected by gate, 2 genuine misses, 0 throttle skips
```

**Der Fix holt auf dieser Playlist keinen einzigen Track.** Das war anders vorhergesagt und muss so dastehen: der richtige Sub-Zero-Track wird jetzt gefunden, scheitert dann aber an `suffix_conflict` — Apple führt ihn als `Stand Strong (feat. Meccah Dawn)`, wir als `Stand Strong (Q-BASE 2017 Hangar OST)`.

Was sich stattdessen ändert, ist die **Aussagekraft**:

| Track | vorher | nachher |
|---|---|---|
| Sub Zero Project – Stand Strong | `artist 'E-Force' != 'Sub Zero Project'` | `de(bare): suffix 'Stand Strong (feat. Meccah Dawn)' vs 'Stand Strong (Q-BASE 2017 Hangar OST)'` |
| Mike NRG – Lost in Dreams | Weapon X Remix 2008 | DJ Sequenza Remix, weiterhin nicht der D-Fence Remix 2017 |
| Ransom – The Great Unknown | `miss` | `de(bare): artist 'Cloven Hoof' != 'Ransom'` |

Aus „die Suche hat Müll geliefert und ich weiß nicht warum" wird eine benannte Einzelfall-Entscheidung. Bei Sub Zero ist das jetzt eine Frage, die ein Mensch in zwei Minuten beantwortet: ist der Q-BASE 2017 Hangar OST dieselbe Aufnahme wie die Single mit Meccah Dawn? Wenn ja, gehört die ID `1743980249` von Hand eingetragen.

## Bekannter Nebeneffekt

`Ransom – The Great Unknown` wandert von `miss` nach `rejected`, weil die zweite Stufe unbrauchbare Treffer zurückbekommt. Semantisch ist das ein kleiner Rückschritt — der Track ist eine echte Katalog-Lücke, wird künftig aber von `--retry-rejected` statt `--retry-misses` erfasst. Bewusst nicht wegprogrammiert: jede Heuristik dagegen wäre schwerer zu verstehen als der Effekt selbst.

## Kosten

Eine zusätzliche Anfrage pro Storefront, **nur** bei Titeln mit Klammer und **nur**, wenn Stufe 1 nichts durchs Gate bringt. Titel ohne Klammer und alle bisherigen Treffer kosten unverändert.

## Tests

- Neu `tests/unit/test_backfill_apple_search_terms.py` — 13 Fälle: Suffix-Strippen inkl. hängendem Trennzeichen, Stufe-1-Unveränderlichkeit, kein Zweitbegriff ohne Klammer, nur Lead-Artist, Titel der **nur** aus einer Klammer besteht (darf keine artist-only-Suche erzeugen), leerer Track.
- `tests/unit/test_backfill_apple_gate_1980.py` unverändert grün — Beleg, dass das Gate nicht angefasst wurde.
- **Volle Unit-Suite 1611 passed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
