### PR TITLE
chore(playlists): tidal backfill wave — +17 uris

### DIFF
--- a/custom_components/beatify/playlists/community/harder-styles.json
+++ b/custom_components/beatify/playlists/community/harder-styles.json
@@ -1,6 +1,6 @@
 {
   "name": "Harder Styles",
-  "version": "1.19",
+  "version": "1.20",
   "tags": [
     "hardstyle",
     "hardcore",
@@ -3967,7 +3967,7 @@
         "it": "applemusic://track/1794271543"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=Dl8ejYZXmLw",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/415573332",
       "uri_deezer": "deezer://track/3216181141",
       "fun_fact": "A hardstyle / hardcore track (2017).",
       "fun_fact_de": "Ein Hardstyle-/Hardcore-Track (2017).",
@@ -3992,7 +3992,7 @@
         "it": "applemusic://track/1494161792"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=gIf0Sch5OJk",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/127622472",
       "uri_deezer": "deezer://track/862412192",
       "fun_fact": "Da Tweekaz are a Norwegian hardstyle duo famous for their high-energy, often playful tracks.",
       "fun_fact_de": "Da Tweekaz sind ein norwegisches Hardstyle-Duo, berühmt für energiegeladene, oft verspielte Tracks.",
@@ -4017,7 +4017,7 @@
         "it": "applemusic://track/1469191498"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=NKMfIXG9X6E",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/111595922",
       "uri_deezer": "deezer://track/698823322",
       "fun_fact": "Da Tweekaz are a Norwegian hardstyle duo famous for their high-energy, often playful tracks.",
       "fun_fact_de": "Da Tweekaz sind ein norwegisches Hardstyle-Duo, berühmt für energiegeladene, oft verspielte Tracks.",
@@ -4067,7 +4067,7 @@
         "it": "applemusic://track/1502459479"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=y4cGW0YulmQ",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/134068604",
       "uri_deezer": "deezer://track/901330192",
       "fun_fact": "Da Tweekaz are a Norwegian hardstyle duo famous for their high-energy, often playful tracks.",
       "fun_fact_de": "Da Tweekaz sind ein norwegisches Hardstyle-Duo, berühmt für energiegeladene, oft verspielte Tracks.",
@@ -4092,7 +4092,7 @@
         "it": "applemusic://track/1447117753"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=xPXDIOXUQZ8",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/101241839",
       "uri_deezer": "deezer://track/617578102",
       "fun_fact": "Da Tweekaz are a Norwegian hardstyle duo famous for their high-energy, often playful tracks.",
       "fun_fact_de": "Da Tweekaz sind ein norwegisches Hardstyle-Duo, berühmt für energiegeladene, oft verspielte Tracks.",
@@ -4117,7 +4117,7 @@
         "it": "applemusic://track/1112717349"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=cw6wL9_P6FI",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/60271304",
       "uri_deezer": "deezer://track/124990244",
       "fun_fact": "A hardstyle / hardcore track (2016).",
       "fun_fact_de": "Ein Hardstyle-/Hardcore-Track (2016).",
@@ -4142,7 +4142,7 @@
         "it": "applemusic://track/1759935260"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=0ztuzPUbm_o",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/378177816",
       "uri_deezer": "deezer://track/2923786481",
       "fun_fact": "A hardstyle / hardcore track (2024).",
       "fun_fact_de": "Ein Hardstyle-/Hardcore-Track (2024).",
@@ -4167,7 +4167,7 @@
         "it": "applemusic://track/1506791082"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=pBmnEZ1brCY",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/136369677",
       "uri_deezer": "deezer://track/920218642",
       "fun_fact": "Harris & Ford are an Austrian DJ duo bridging hardstyle, techno and party anthems.",
       "fun_fact_de": "Harris & Ford sind ein österreichisches DJ-Duo zwischen Hardstyle, Techno und Party-Hymnen.",
@@ -4192,7 +4192,7 @@
         "it": "applemusic://track/1749783604"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=t_-G6lJbTew",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/366814891",
       "uri_deezer": "deezer://track/2828734612",
       "fun_fact": "Gunz For Hire is the hardstyle duo of Ran-D and Adaro, known for dark, raw-edged anthems.",
       "fun_fact_de": "Gunz For Hire ist das Hardstyle-Duo aus Ran-D und Adaro, bekannt für düstere, raue Hymnen.",
@@ -4217,7 +4217,7 @@
         "it": "applemusic://track/1804139334"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=Ke1vaxgf-i4",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/13467719",
       "uri_deezer": "deezer://track/3289616621",
       "fun_fact": "Ran-D is a Dutch hardstyle artist, also one half of the duo Gunz For Hire.",
       "fun_fact_de": "Ran-D ist ein niederländischer Hardstyle-Künstler und zugleich eine Hälfte des Duos Gunz For Hire.",
@@ -4242,7 +4242,7 @@
         "it": "applemusic://track/1747485184"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=G2R0AEKJhZA",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/364533123",
       "uri_deezer": "deezer://track/2812228322",
       "fun_fact": "Ran-D is a Dutch hardstyle artist, also one half of the duo Gunz For Hire.",
       "fun_fact_de": "Ran-D ist ein niederländischer Hardstyle-Künstler und zugleich eine Hälfte des Duos Gunz For Hire.",
@@ -4267,7 +4267,7 @@
         "it": "applemusic://track/1724222807"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=FMNvE4wI8os",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/338361966",
       "uri_deezer": "deezer://track/2608552372",
       "fun_fact": "Harris & Ford are an Austrian DJ duo bridging hardstyle, techno and party anthems.",
       "fun_fact_de": "Harris & Ford sind ein österreichisches DJ-Duo zwischen Hardstyle, Techno und Party-Hymnen.",
@@ -4292,7 +4292,7 @@
         "it": "applemusic://track/1705706586"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=6hKrqkp0B70",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/314523345",
       "uri_deezer": "deezer://track/2440721905",
       "fun_fact": "Harris & Ford are an Austrian DJ duo bridging hardstyle, techno and party anthems.",
       "fun_fact_de": "Harris & Ford sind ein österreichisches DJ-Duo zwischen Hardstyle, Techno und Party-Hymnen.",
@@ -4317,7 +4317,7 @@
         "it": "applemusic://track/1688359515"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=Ltpr95L4U0I",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/271096564",
       "uri_deezer": "deezer://track/2106063717",
       "fun_fact": "Coone is a Belgian hardstyle DJ and founder of the Dirty Workz label.",
       "fun_fact_de": "Coone ist ein belgischer Hardstyle-DJ und Gründer des Labels Dirty Workz.",
@@ -4342,7 +4342,7 @@
         "it": "applemusic://track/1646936817"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=8Jw41oS_scU",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/250412451",
       "uri_deezer": null,
       "fun_fact": "A hardstyle / hardcore track (2022).",
       "fun_fact_de": "Ein Hardstyle-/Hardcore-Track (2022).",
@@ -4367,7 +4367,7 @@
         "it": "applemusic://track/1609628247"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=McLt8JUQ-rc",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/216365790",
       "uri_deezer": "deezer://track/1652997052",
       "fun_fact": "A hardstyle / hardcore track (2022).",
       "fun_fact_de": "Ein Hardstyle-/Hardcore-Track (2022).",
@@ -4417,7 +4417,7 @@
         "it": "applemusic://track/1455239880"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=zZW69hkFQvE",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/105261214",
       "uri_deezer": "deezer://track/643926522",
       "fun_fact": "Harris & Ford are an Austrian DJ duo bridging hardstyle, techno and party anthems.",
       "fun_fact_de": "Harris & Ford sind ein österreichisches DJ-Duo zwischen Hardstyle, Techno und Party-Hymnen.",


### PR DESCRIPTION
Eine Odesli-Welle, automatisch gefahren von `com.beatify.tidal-wave`.

- `harder-styles` Tidal 144 → **161**/190, version 1.19 → 1.20

Bilanz: 17 Treffer · 2 echte Misses · 29 Rate-Limit-Skips · 87 429-Zeilen.

**Draft mit Absicht** — Merge nur nach Markus' Freigabe.