### PR TITLE
chore(playlists): tidal backfill wave — +19 uris

### DIFF
--- a/custom_components/beatify/playlists/community/harder-styles.json
+++ b/custom_components/beatify/playlists/community/harder-styles.json
@@ -1,6 +1,6 @@
 {
   "name": "Harder Styles",
-  "version": "1.20",
+  "version": "1.21",
   "tags": [
     "hardstyle",
     "hardcore",
@@ -4442,7 +4442,7 @@
         "it": "applemusic://track/1664197790"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=D94p7WxpmLo",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/154155044",
       "uri_deezer": "deezer://track/1069790362",
       "fun_fact": "Da Tweekaz are a Norwegian hardstyle duo famous for their high-energy, often playful tracks.",
       "fun_fact_de": "Da Tweekaz sind ein norwegisches Hardstyle-Duo, berühmt für energiegeladene, oft verspielte Tracks.",
@@ -4467,7 +4467,7 @@
         "it": "applemusic://track/1607300766"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=U9fsjv5KrkQ",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/196978045",
       "uri_deezer": "deezer://track/3287428361",
       "fun_fact": "A hardstyle / hardcore track (2021).",
       "fun_fact_de": "Ein Hardstyle-/Hardcore-Track (2021).",
@@ -4492,7 +4492,7 @@
         "it": "applemusic://track/1805171154"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=M9n0ETlFlLk",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/98530891",
       "uri_deezer": "deezer://track/3287361441",
       "fun_fact": "The Prophet is a Dutch DJ and a pioneering figure of hardstyle and its early hardcore roots.",
       "fun_fact_de": "The Prophet ist ein niederländischer DJ und eine Pionierfigur des Hardstyle.",
@@ -4517,7 +4517,7 @@
         "it": "applemusic://track/1530852613"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=f_CVpr-Xx5o",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/154693526",
       "uri_deezer": "deezer://track/1074414432",
       "fun_fact": "A hardstyle / hardcore track (2020).",
       "fun_fact_de": "Ein Hardstyle-/Hardcore-Track (2020).",
@@ -4542,7 +4542,7 @@
         "it": "applemusic://track/1740386319"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=qatArIFBIOQ",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/352187428",
       "uri_deezer": "deezer://track/2714092902",
       "fun_fact": "Headhunterz is one of the most influential hardstyle artists of all time.",
       "fun_fact_de": "Headhunterz zählt zu den einflussreichsten Hardstyle-Künstlern überhaupt.",
@@ -4567,7 +4567,7 @@
         "it": "applemusic://track/1740387192"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=mrrE0-bMhO8",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/352186940",
       "uri_deezer": "deezer://track/2714091742",
       "fun_fact": "Sub Zero Project is a Dutch hardstyle duo known for their raw-edged festival anthems.",
       "fun_fact_de": "Sub Zero Project ist ein niederländisches Hardstyle-Duo, bekannt für rohe Festival-Hymnen.",
@@ -4592,7 +4592,7 @@
         "it": "applemusic://track/1704855471"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=_jnqpGHi68A",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/313459832",
       "uri_deezer": "deezer://track/2431155005",
       "fun_fact": "Rebelion is a Dutch act at the raw, hard end of the hardstyle spectrum.",
       "fun_fact_de": "Rebelion ist ein niederländischer Act am rohen, harten Ende des Hardstyle-Spektrums.",
@@ -4617,7 +4617,7 @@
         "it": "applemusic://track/1622831439"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=g6fCJotUAXg",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/227811651",
       "uri_deezer": "deezer://track/1743182497",
       "fun_fact": "Da Tweekaz are a Norwegian hardstyle duo famous for their high-energy, often playful tracks.",
       "fun_fact_de": "Da Tweekaz sind ein norwegisches Hardstyle-Duo, berühmt für energiegeladene, oft verspielte Tracks.",
@@ -4642,7 +4642,7 @@
         "it": "applemusic://track/1531960577"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=8kq2No15Mt0",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/128789999",
       "uri_deezer": "deezer://track/1131497132",
       "fun_fact": "Brennan Heart is a veteran Dutch hardstyle artist and founder of the WE R label.",
       "fun_fact_de": "Brennan Heart ist ein erfahrener niederländischer Hardstyle-Künstler und Gründer des Labels WE R.",
@@ -4667,7 +4667,7 @@
         "it": "applemusic://track/1728077902"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=w_Sb-QFJa1k",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/339703176",
       "uri_deezer": "deezer://track/2618543312",
       "fun_fact": "Phuture Noize is a Dutch hardstyle artist known for concept albums and cinematic productions.",
       "fun_fact_de": "Phuture Noize ist ein niederländischer Hardstyle-Künstler, bekannt für Konzeptalben und cineastische Produktionen.",
@@ -4692,7 +4692,7 @@
         "it": "applemusic://track/1740406698"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=IxaKgYmGjDQ",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/352186374",
       "uri_deezer": "deezer://track/2714087542",
       "fun_fact": "A hardstyle / hardcore track (2022).",
       "fun_fact_de": "Ein Hardstyle-/Hardcore-Track (2022).",
@@ -4717,7 +4717,7 @@
         "it": "applemusic://track/1764374646"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=UFanQiA57RQ",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/382763788",
       "uri_deezer": "deezer://track/2958936031",
       "fun_fact": "Sub Zero Project is a Dutch hardstyle duo known for their raw-edged festival anthems.",
       "fun_fact_de": "Sub Zero Project ist ein niederländisches Hardstyle-Duo, bekannt für rohe Festival-Hymnen.",
@@ -4742,7 +4742,7 @@
         "it": "applemusic://track/1784504277"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=055VRTYrwOo",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/382830231",
       "uri_deezer": "deezer://track/2959339881",
       "fun_fact": "Brennan Heart is a veteran Dutch hardstyle artist and founder of the WE R label.",
       "fun_fact_de": "Brennan Heart ist ein erfahrener niederländischer Hardstyle-Künstler und Gründer des Labels WE R.",
@@ -4767,7 +4767,7 @@
         "it": "applemusic://track/1678969827"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=gY1XIvLQKX0",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/283625589",
       "uri_deezer": "deezer://track/2200054497",
       "fun_fact": "Sub Zero Project is a Dutch hardstyle duo known for their raw-edged festival anthems.",
       "fun_fact_de": "Sub Zero Project ist ein niederländisches Hardstyle-Duo, bekannt für rohe Festival-Hymnen.",
@@ -4792,7 +4792,7 @@
         "it": "applemusic://track/1520407295"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=8rSixk9quSU",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/146548193",
       "uri_deezer": "deezer://track/1003518122",
       "fun_fact": "Sub Zero Project is a Dutch hardstyle duo known for their raw-edged festival anthems.",
       "fun_fact_de": "Sub Zero Project ist ein niederländisches Hardstyle-Duo, bekannt für rohe Festival-Hymnen.",
@@ -4817,7 +4817,7 @@
         "it": "applemusic://track/1609632256"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=rgCngYHUlIQ",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/216338547",
       "uri_deezer": "deezer://track/1652805712",
       "fun_fact": "A hardstyle / hardcore track (2022).",
       "fun_fact_de": "Ein Hardstyle-/Hardcore-Track (2022).",
@@ -4842,7 +4842,7 @@
         "it": "applemusic://track/1596785371"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=hoLDVyIkLEE",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/206198460",
       "uri_deezer": "deezer://track/1562849872",
       "fun_fact": "A hardstyle / hardcore track (2021).",
       "fun_fact_de": "Ein Hardstyle-/Hardcore-Track (2021).",
@@ -4867,7 +4867,7 @@
         "it": "applemusic://track/1495975252"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=nrxuDaIkC3s",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/121267210",
       "uri_deezer": "deezer://track/701889672",
       "fun_fact": "Headhunterz is one of the most influential hardstyle artists of all time.",
       "fun_fact_de": "Headhunterz zählt zu den einflussreichsten Hardstyle-Künstlern überhaupt.",
@@ -4892,7 +4892,7 @@
         "it": "applemusic://track/1718520200"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=ZQxsr5QvZgE",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/310378675",
       "uri_deezer": "deezer://track/2407232155",
       "fun_fact": "Sub Zero Project is a Dutch hardstyle duo known for their raw-edged festival anthems.",
       "fun_fact_de": "Sub Zero Project ist ein niederländisches Hardstyle-Duo, bekannt für rohe Festival-Hymnen.",


### PR DESCRIPTION
Eine Odesli-Welle, automatisch gefahren von `com.beatify.tidal-wave`.

- `harder-styles` Tidal 161 → **180**/190, version 1.20 → 1.21

Bilanz: 19 Treffer · 0 echte Misses · 29 Rate-Limit-Skips · 87 429-Zeilen.

**Draft mit Absicht** — Merge nur nach Markus' Freigabe.