### PR TITLE
chore(playlists): tidal backfill wave — +17 uris

### DIFF
--- a/custom_components/beatify/playlists/community/harder-styles.json
+++ b/custom_components/beatify/playlists/community/harder-styles.json
@@ -1,6 +1,6 @@
 {
   "name": "Harder Styles",
-  "version": "1.21",
+  "version": "1.22",
   "tags": [
     "hardstyle",
     "hardcore",
@@ -4917,7 +4917,7 @@
         "it": "applemusic://track/1511162031"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=COAvbbHIv04",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/132755602",
       "uri_deezer": "deezer://track/889440482",
       "fun_fact": "Da Tweekaz are a Norwegian hardstyle duo famous for their high-energy, often playful tracks.",
       "fun_fact_de": "Da Tweekaz sind ein norwegisches Hardstyle-Duo, berühmt für energiegeladene, oft verspielte Tracks.",

--- a/custom_components/beatify/playlists/community/hitster-100-francais.json
+++ b/custom_components/beatify/playlists/community/hitster-100-francais.json
@@ -1,6 +1,6 @@
 {
   "name": "100% Français 🇫🇷",
-  "version": "0.2",
+  "version": "0.3",
   "tags": [
     "french",
     "francais",
@@ -30,7 +30,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=qUSiJmZ-YyM",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/3244922",
       "uri_deezer": "deezer://track/1386410842",
       "alt_artists": [],
       "fun_fact": "Amel Bent, a 2004 'Nouvelle Star' finalist, became one of France's most enduring R&B-pop voices.",
@@ -56,7 +56,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=qyHmeySM14k",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/1793719",
       "uri_deezer": "deezer://track/895161",
       "alt_artists": [],
       "fun_fact": "Nèg' Marrons emerged from the 1990s French ragga-rap scene around the Secteur Ä collective.",
@@ -82,7 +82,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=y8p0BxMykqg",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/247479816",
       "uri_deezer": "deezer://track/2728101101",
       "alt_artists": [],
       "fun_fact": "Ilona Mitrecey was only 11 when 'Un monde parfait' topped the French chart in 2005.",
@@ -108,7 +108,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=zquFZaHw2TQ",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/140972048",
       "uri_deezer": "deezer://track/943928002",
       "alt_artists": [],
       "fun_fact": "Bosh's 'Djomb' was one of the biggest French rap hits of 2020, its 'bien ou quoi' hook going viral.",
@@ -134,7 +134,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=anrhMwxkxPQ",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/1319424",
       "uri_deezer": "deezer://track/539702",
       "alt_artists": [],
       "fun_fact": "Jacques Dutronc's 1966 'Les cactus' is a sardonic slice of French 1960s yéyé-pop.",
@@ -160,7 +160,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=2_r8KMzeA4o",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/4853681",
       "uri_deezer": "deezer://track/823182022",
       "alt_artists": [],
       "fun_fact": "Nino Ferrer wrote 'La Rua Madureira' inspired by his childhood years in Brazil.",
@@ -186,7 +186,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=km6gUbW8s28",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/44020076",
       "uri_deezer": "deezer://track/13025822",
       "alt_artists": [],
       "fun_fact": "La Compagnie Créole turned Caribbean zouk-pop into French party staples in the 1980s.",
@@ -238,7 +238,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=-ojQYUAvqFo",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/131178380",
       "uri_deezer": "deezer://track/886919302",
       "alt_artists": [],
       "fun_fact": "Teri Moïse's 'Je serai là' was a gentle 1996 hit from the Los Angeles-born French singer.",
@@ -264,7 +264,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=6c1PAeoaJOo",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/164907802",
       "uri_deezer": "deezer://track/4306044",
       "alt_artists": [],
       "fun_fact": "PZK was a French teen-pop duo that scored hits in the late 2000s.",
@@ -290,7 +290,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=Vkw4Dqd43nA",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/61822606",
       "uri_deezer": "deezer://track/126846197",
       "alt_artists": [],
       "fun_fact": "Keen'V is a Normandy-born singer who built huge streaming numbers with feel-good pop-ragga.",
@@ -342,7 +342,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=KAOmC5qT02w",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/49210",
       "uri_deezer": "deezer://track/870090",
       "alt_artists": [],
       "fun_fact": "Indochine's 'J'ai demandé à la lune' (2002) was co-written with Mickael Furnon of Mickey 3D.",
@@ -368,7 +368,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=EelX_LwPHbA",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/30065658",
       "uri_deezer": "deezer://track/78749541",
       "alt_artists": [],
       "fun_fact": "Carla Bruni's 'Quelqu'un m'a dit' (2002) launched the model's parallel career as a chanson singer.",
@@ -394,7 +394,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=AzaTyxMduH4",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/3182912",
       "uri_deezer": "deezer://track/4762933",
       "alt_artists": [],
       "fun_fact": "'Pour que tu m'aimes encore' was written by Jean-Jacques Goldman and became Céline Dion's French signature.",
@@ -420,7 +420,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=JthrO7hn2lQ",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/1749507",
       "uri_deezer": "deezer://track/606908",
       "alt_artists": [],
       "fun_fact": "TRUST's 'Antisocial' (1980) is a landmark of French hard rock, later covered by Anthrax.",
@@ -446,7 +446,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=Iy1gH00vkMw",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/10942498",
       "uri_deezer": "deezer://track/15044236",
       "alt_artists": [],
       "fun_fact": "Sniper were among the most prominent French rap groups of the 2000s.",
@@ -472,7 +472,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=t82VZncQ8e8",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/197797581",
       "uri_deezer": "deezer://track/1495554532",
       "alt_artists": [],
       "fun_fact": "Lââm's 'Chanter' was a major 1998 French-pop hit built on a soaring chorus.",


### PR DESCRIPTION
Eine Odesli-Welle, automatisch gefahren von `com.beatify.tidal-wave`.

- `harder-styles` Tidal 180 → **181**/190, version 1.21 → 1.22
- `hitster-100-francais` Tidal 55 → **71**/100, version 0.2 → 0.3

Bilanz: 17 Treffer · 2 echte Misses · 30 Rate-Limit-Skips · 90 429-Zeilen.

**Draft mit Absicht** — Merge nur nach Markus' Freigabe.