### PR TITLE
chore(playlists): tidal backfill wave — +19 uris

### DIFF
--- a/custom_components/beatify/playlists/community/hitster-100-francais.json
+++ b/custom_components/beatify/playlists/community/hitster-100-francais.json
@@ -1,6 +1,6 @@
 {
   "name": "100% Français 🇫🇷",
-  "version": "0.3",
+  "version": "0.4",
   "tags": [
     "french",
     "francais",
@@ -992,7 +992,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=Rwbm281DTYc",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/81915298",
       "uri_deezer": "deezer://track/3198384621",
       "alt_artists": [],
       "fun_fact": "Superbus, led by Jennifer Ayache, were one of France's biggest 2000s pop-rock bands.",
@@ -1018,7 +1018,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=6qpvDY6PYx4",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/1461304",
       "uri_deezer": "deezer://track/3088341",
       "alt_artists": [],
       "fun_fact": "Jean-Louis Aubert co-founded the legendary rock band Téléphone before his solo career.",
@@ -1044,7 +1044,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=adyT-z0MxGs",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/5156415",
       "uri_deezer": "deezer://track/3466724961",
       "alt_artists": [],
       "fun_fact": "'Le temps de l'amour' is forever tied to Françoise Hardy and the early-1960s yéyé era.",
@@ -1070,7 +1070,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=oJ_x1yRyATA",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/74540806",
       "uri_deezer": "deezer://track/367753611",
       "alt_artists": [],
       "fun_fact": "KOD's 'Chacun sa route' featured on the 1994 soundtrack of the film 'Un indien dans la ville'.",
@@ -1096,7 +1096,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=LEremyjd0bk",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/122841790",
       "uri_deezer": "deezer://track/811201102",
       "alt_artists": [],
       "fun_fact": "Belgian singer Axelle Red is one of francophone pop's most successful soul-pop voices.",
@@ -1122,7 +1122,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=akFZtK0GVU4",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/40838025",
       "uri_deezer": "deezer://track/94400936",
       "alt_artists": [],
       "fun_fact": "La Caution's 'Thé à la menthe' featured in the chase scene of the film 'Ocean's Twelve'.",
@@ -1148,7 +1148,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=KVyZkQTx5xA",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/311623788",
       "uri_deezer": "deezer://track/2417379575",
       "alt_artists": [],
       "fun_fact": "Léopold Nord & Vous's 'C'est l'amour' was a cheeky 1987 Belgian-French pop hit.",
@@ -1174,7 +1174,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=f5IruTV-LGQ",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/77624292",
       "uri_deezer": "deezer://track/350055571",
       "alt_artists": [],
       "fun_fact": "Polo & Pan craft sun-dappled French electronic pop; 'Canopée' became their breakout.",
@@ -1200,7 +1200,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=rtJogxTNa1o",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/3693611",
       "uri_deezer": "deezer://track/2238913",
       "alt_artists": [],
       "fun_fact": "Alain Bashung's 'Vertige de l'amour' (1981) is a cornerstone of arty French rock.",
@@ -1226,7 +1226,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=U556LvysfjI",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/20428164",
       "uri_deezer": null,
       "alt_artists": [],
       "fun_fact": "Colonel Reyel rode a wave of French pop-ragga success in the early 2010s.",
@@ -1252,7 +1252,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=nG1fWSxSqBI",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/491206046",
       "uri_deezer": "deezer://track/3786029842",
       "alt_artists": [],
       "fun_fact": "Mecano's 'Une femme avec une femme' was a Spanish band's francophone-era hit on same-sex love.",
@@ -1278,7 +1278,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=Nlw4jOOEgIo",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/532993",
       "uri_deezer": "deezer://track/5403417",
       "alt_artists": [],
       "fun_fact": "Patrick Bruel's 'Au café des délices' (1999) nods to his Tunisian roots and childhood.",
@@ -1304,7 +1304,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=2XVHXW2u_98",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/191257375",
       "uri_deezer": "deezer://track/1436238632",
       "alt_artists": [],
       "fun_fact": "Ottawan, of 'D.I.S.C.O.' fame, were a French disco act masterminded by the Daniel Vangarde team.",
@@ -1330,7 +1330,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=BvPszccELCA",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/287248955",
       "uri_deezer": "deezer://track/2222984647",
       "alt_artists": [],
       "fun_fact": "PLK is one of the most-streamed French rappers of the early 2020s.",
@@ -1356,7 +1356,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=6GQYdYlwXfw",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/3970663",
       "uri_deezer": "deezer://track/1093562",
       "alt_artists": [],
       "fun_fact": "Brigitte Bardot's 'La madrague' evokes her famous Saint-Tropez retreat.",
@@ -1382,7 +1382,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=x8l43czQAy4",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/3985349",
       "uri_deezer": "deezer://track/2541557",
       "alt_artists": [],
       "fun_fact": "Daniel Guichard's 'Mon vieux' is a tear-jerking chanson tribute to a working father.",
@@ -1408,7 +1408,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=lACT1rmoR3E",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/4092273",
       "uri_deezer": "deezer://track/809639",
       "alt_artists": [],
       "fun_fact": "Louisy Joseph rose from the group L5 before her solo French-pop career.",
@@ -1434,7 +1434,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=tZ1ZsDmeOEc",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/67715127",
       "uri_deezer": "deezer://track/137092518",
       "alt_artists": [],
       "fun_fact": "Thierry Pastor's 'Le coup de folie' was a 1982 French new-wave-pop hit.",
@@ -1460,7 +1460,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=gQUOXqyIkj4",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/14635447",
       "uri_deezer": "deezer://track/2635262",
       "alt_artists": [],
       "fun_fact": "François Valéry is a prolific French pop songwriter and performer since the 1970s.",


### PR DESCRIPTION
Eine Odesli-Welle, automatisch gefahren von `com.beatify.tidal-wave`.

- `hitster-100-francais` Tidal 71 → **90**/100, version 0.3 → 0.4

Bilanz: 19 Treffer · 0 echte Misses · 29 Rate-Limit-Skips · 87 429-Zeilen.

**Draft mit Absicht** — Merge nur nach Markus' Freigabe.