### PR TITLE
chore(playlists): tidal backfill wave — +17 uris

### DIFF
--- a/custom_components/beatify/playlists/community/hitster-100-francais.json
+++ b/custom_components/beatify/playlists/community/hitster-100-francais.json
@@ -1,6 +1,6 @@
 {
   "name": "100% Français 🇫🇷",
-  "version": "0.4",
+  "version": "0.5",
   "tags": [
     "french",
     "francais",
@@ -1486,7 +1486,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=eXF6hDCsPuU",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/136556005",
       "uri_deezer": "deezer://track/3121388",
       "alt_artists": [],
       "fun_fact": "Mike Brant's 'Laisse-moi t'aimer' (1970) made the Israeli-French singer an overnight star.",
@@ -1512,7 +1512,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=YN-nTZmiA0M",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/32853312",
       "uri_deezer": "deezer://track/17426509",
       "alt_artists": [],
       "fun_fact": "Philippe Lafontaine's 'Cœur de loup' (1989) is a much-loved francophone pop earworm.",
@@ -1538,7 +1538,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=OohXkUCtVTI",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/67676138",
       "uri_deezer": "deezer://track/137047046",
       "alt_artists": [],
       "fun_fact": "'Tu veux ou tu veux pas' is jazzman Marcel Zanini's playful, much-sampled signature.",
@@ -1564,7 +1564,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=cmE_aahc448",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/37677691",
       "uri_deezer": "deezer://track/70785260",
       "alt_artists": [],
       "fun_fact": "Julien Doré, a 2007 'Nouvelle Star' winner, became a major French indie-pop figure.",
@@ -1590,7 +1590,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=tVKaN_H35xs",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/81115730",
       "uri_deezer": "deezer://track/429974992",
       "alt_artists": [],
       "fun_fact": "Dadju, brother of Gims, is a leading voice of late-2010s French R&B.",
@@ -2578,7 +2578,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=HXdP15Ubu6M",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/163856865",
       "uri_deezer": "deezer://track/886301",
       "alt_artists": [],
       "fun_fact": "Daniel Balavoine's 'Le chanteur' (1978) is a poignant self-portrait of a singer's dreams.",

--- a/custom_components/beatify/playlists/community/hitster-brasil.json
+++ b/custom_components/beatify/playlists/community/hitster-brasil.json
@@ -1,6 +1,6 @@
 {
   "name": "100% Brasil 🇧🇷",
-  "version": "0.2",
+  "version": "0.3",
   "tags": [
     "brazil",
     "brasil",
@@ -1069,7 +1069,7 @@
         "it": "applemusic://track/1512946315"
       },
       "uri_deezer": "deezer://track/958716372",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/16204463",
       "uri_youtube_music": "https://music.youtube.com/watch?v=X8TOhb_4jU0"
     },
     {
@@ -1103,7 +1103,7 @@
         "it": "applemusic://track/474535913"
       },
       "uri_deezer": "deezer://track/309174",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/24854500",
       "uri_youtube_music": "https://music.youtube.com/watch?v=iyLdoQGBchQ"
     },
     {
@@ -1137,7 +1137,7 @@
         "it": "applemusic://track/268026802"
       },
       "uri_deezer": "deezer://track/14639814",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/34188141",
       "uri_youtube_music": "https://music.youtube.com/watch?v=cddQn1mZRfI"
     },
     {
@@ -1171,7 +1171,7 @@
         "it": "applemusic://track/623041165"
       },
       "uri_deezer": "deezer://track/1522301102",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/7606163",
       "uri_youtube_music": "https://music.youtube.com/watch?v=BXUqiiygC5Y"
     },
     {
@@ -1205,7 +1205,7 @@
         "it": "applemusic://track/509909049"
       },
       "uri_deezer": "deezer://track/86130187",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/4718760",
       "uri_youtube_music": "https://music.youtube.com/watch?v=0zISy9OkZA0"
     },
     {
@@ -1239,7 +1239,7 @@
         "it": "applemusic://track/1715762825"
       },
       "uri_deezer": "deezer://track/789250",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/2123821",
       "uri_youtube_music": "https://music.youtube.com/watch?v=Adu-EfJbuBs"
     },
     {
@@ -1273,7 +1273,7 @@
         "it": "applemusic://track/1802051245"
       },
       "uri_deezer": "deezer://track/4701615",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/2571391",
       "uri_youtube_music": "https://music.youtube.com/watch?v=RYbl88mMMJw"
     },
     {
@@ -1307,7 +1307,7 @@
         "it": "applemusic://track/588335679"
       },
       "uri_deezer": "deezer://track/14897306",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/11457572",
       "uri_youtube_music": "https://music.youtube.com/watch?v=DjPtwYunRq4"
     },
     {
@@ -1341,7 +1341,7 @@
         "it": "applemusic://track/1751829192"
       },
       "uri_deezer": "deezer://track/3008633",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/4909100",
       "uri_youtube_music": "https://music.youtube.com/watch?v=nvGcaTGcN5A"
     },
     {
@@ -1375,7 +1375,7 @@
         "it": null
       },
       "uri_deezer": "deezer://track/4704236",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/93011941",
       "uri_youtube_music": "https://music.youtube.com/watch?v=WvSF1Xi-EVg"
     },
     {
@@ -2055,7 +2055,7 @@
         "it": "applemusic://track/980648501"
       },
       "uri_deezer": "deezer://track/10701732",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/7240144",
       "uri_youtube_music": "https://music.youtube.com/watch?v=hv1Hnmt1GBo"
     },
     {


### PR DESCRIPTION
Eine Odesli-Welle, automatisch gefahren von `com.beatify.tidal-wave`.

- `hitster-100-francais` Tidal 90 → **96**/100, version 0.4 → 0.5
- `hitster-brasil` Tidal 49 → **60**/66, version 0.2 → 0.3

Bilanz: 17 Treffer · 2 echte Misses · 30 Rate-Limit-Skips · 90 429-Zeilen.

**Draft mit Absicht** — Merge nur nach Markus' Freigabe.