### PR TITLE
chore(playlists): tidal backfill wave — +18 uris

### DIFF
--- a/custom_components/beatify/playlists/community/iconic-movie-songs.json
+++ b/custom_components/beatify/playlists/community/iconic-movie-songs.json
@@ -1,6 +1,6 @@
 {
   "name": "ICONIC movie songs 🎬",
-  "version": "0.9",
+  "version": "0.10",
   "tags": [
     "movies",
     "soundtracks",
@@ -2832,7 +2832,7 @@
       "fun_fact_fr": "L'hymne du montage d'entraînement de Mulan (1998) de Disney.",
       "uri_apple_music": "applemusic://track/1440662805",
       "uri_youtube_music": "https://music.youtube.com/watch?v=elBKil5zE2g",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/47940552",
       "uri_deezer": "deezer://track/1377537512",
       "fun_fact_nl": "De trainingsmontage-hymne uit Disneys Mulan (1998).",
       "awards_nl": [],
@@ -2872,7 +2872,7 @@
       "fun_fact_fr": "Le duo révélation de Troy et Gabriella dans High School Musical (2006).",
       "uri_apple_music": "applemusic://track/1440747342",
       "uri_youtube_music": "https://music.youtube.com/watch?v=0qj67KE5VXI",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/34307865",
       "uri_deezer": "deezer://track/4242713",
       "fun_fact_nl": "Troy en Gabriella's doorbraakduet uit High School Musical (2006).",
       "awards_nl": [],

--- a/custom_components/beatify/playlists/community/koelner-karneval.json
+++ b/custom_components/beatify/playlists/community/koelner-karneval.json
@@ -1,6 +1,6 @@
 {
   "name": "Cologne Carnival 🎭",
-  "version": "1.8",
+  "version": "1.9",
   "tags": [
     "german",
     "carnival",
@@ -538,7 +538,8 @@
         "es": "applemusic://track/724060579",
         "nl": "applemusic://track/724060579",
         "it": "applemusic://track/724060579"
-      }
+      },
+      "uri_tidal": "tidal://track/2502619"
     },
     {
       "year": 1980,
@@ -1008,7 +1009,8 @@
         "es": "applemusic://track/205556986",
         "nl": "applemusic://track/205556986",
         "it": "applemusic://track/205556986"
-      }
+      },
+      "uri_tidal": "tidal://track/2104423"
     },
     {
       "year": 2003,
@@ -1726,7 +1728,8 @@
         "es": "applemusic://track/1219254873",
         "nl": "applemusic://track/1219254873",
         "it": "applemusic://track/1219254873"
-      }
+      },
+      "uri_tidal": "tidal://track/20796037"
     },
     {
       "year": 2006,
@@ -2383,7 +2386,8 @@
       },
       "uri_deezer": "deezer://track/3613918972",
       "fun_fact_nl": "Hanaks 'Haifischzahn' (Haaientand) brengt een steviger rock-geluid in de carnavalsmuziek, wat de evolutie van het genre buiten de traditionele klanken toont.",
-      "awards_nl": []
+      "awards_nl": [],
+      "uri_tidal": "tidal://track/11201660"
     },
     {
       "year": 2003,
@@ -2783,7 +2787,8 @@
         "es": "applemusic://track/202229994",
         "nl": "applemusic://track/202229994",
         "it": "applemusic://track/202229994"
-      }
+      },
+      "uri_tidal": "tidal://track/2117520"
     },
     {
       "year": 1957,
@@ -3957,7 +3962,8 @@
         "es": "applemusic://track/933255544",
         "nl": "applemusic://track/933255544",
         "it": "applemusic://track/933255544"
-      }
+      },
+      "uri_tidal": "tidal://track/40869675"
     },
     {
       "year": 2015,
@@ -4086,7 +4092,8 @@
         "es": "applemusic://track/1443009841",
         "nl": "applemusic://track/1443009841",
         "it": "applemusic://track/1443009841"
-      }
+      },
+      "uri_tidal": "tidal://track/52419252"
     },
     {
       "year": 2015,
@@ -4290,7 +4297,8 @@
         "es": "applemusic://track/1208124638",
         "nl": "applemusic://track/1208124638",
         "it": "applemusic://track/1208124638"
-      }
+      },
+      "uri_tidal": "tidal://track/70998871"
     },
     {
       "year": 2016,
@@ -5269,7 +5277,8 @@
         "es": "applemusic://track/1439344305",
         "nl": "applemusic://track/1439344305",
         "it": "applemusic://track/1439344305"
-      }
+      },
+      "uri_tidal": "tidal://track/102830944"
     },
     {
       "year": 2018,
@@ -5467,7 +5476,8 @@
         "es": "applemusic://track/1621280233",
         "nl": "applemusic://track/1621280233",
         "it": "applemusic://track/1621280233"
-      }
+      },
+      "uri_tidal": "tidal://track/96837825"
     },
     {
       "year": 2018,
@@ -6006,7 +6016,8 @@
         "es": "applemusic://track/1482342716",
         "nl": "applemusic://track/1482342716",
         "it": "applemusic://track/1482342716"
-      }
+      },
+      "uri_tidal": "tidal://track/119978974"
     },
     {
       "year": 2019,
@@ -6040,7 +6051,8 @@
         "es": "applemusic://track/1539793742",
         "nl": "applemusic://track/1539793742",
         "it": "applemusic://track/1539793742"
-      }
+      },
+      "uri_tidal": "tidal://track/120159373"
     },
     {
       "year": 2019,
@@ -6598,7 +6610,8 @@
         "es": "applemusic://track/1536059328",
         "nl": "applemusic://track/1536059328",
         "it": "applemusic://track/1536059328"
-      }
+      },
+      "uri_tidal": "tidal://track/159640003"
     },
     {
       "year": 2020,

--- a/custom_components/beatify/playlists/community/ndw-neue-deutsche-welle.json
+++ b/custom_components/beatify/playlists/community/ndw-neue-deutsche-welle.json
@@ -1,6 +1,6 @@
 {
   "name": "NDW – Neue Deutsche Welle",
-  "version": "0.1",
+  "version": "0.2",
   "tags": [
     "ndw",
     "neue deutsche welle",
@@ -726,7 +726,7 @@
       "fun_fact_nl": "'Dschinghis Khan' was West-Duitslands inzending voor het Eurovisie Songfestival 1979, eindigend op de 4e plaats.",
       "uri_apple_music": "applemusic://track/1308712711",
       "uri_youtube_music": "https://www.youtube.com/watch?v=1AXlVZRpweI",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/3609106",
       "uri_deezer": "1104837",
       "isrc": "DEUM70703330",
       "uri_apple_music_by_region": {
@@ -760,7 +760,7 @@
       "fun_fact_nl": "'Flieger, grüß mir die Sonne' van Extrabreit speelde bewust met beelden uit het nazi-tijdperk.",
       "uri_apple_music": "applemusic://track/1442228307",
       "uri_youtube_music": "https://www.youtube.com/watch?v=7e61KF2eH3g",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/13473805",
       "uri_deezer": "1140787",
       "isrc": "DEF088025210",
       "uri_apple_music_by_region": {
@@ -794,7 +794,7 @@
       "fun_fact_nl": "'Blaue Augen' van Ideal is een post-punk NDW klassieker uit Berlijn uit 1980 met zangeres Annette Humpe.",
       "uri_apple_music": "applemusic://track/41255576",
       "uri_youtube_music": "https://www.youtube.com/watch?v=zbaTJDnDRuY",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/222224",
       "uri_deezer": "725925",
       "isrc": "DEA629260600",
       "uri_apple_music_by_region": {


### PR DESCRIPTION
Eine Odesli-Welle, automatisch gefahren von `com.beatify.tidal-wave`.

- `iconic-movie-songs` Tidal 69 → **71**/72, version 0.9 → 0.10
- `koelner-karneval` Tidal 276 → **289**/290, version 1.8 → 1.9
- `ndw-neue-deutsche-welle` Tidal 19 → **22**/50, version 0.1 → 0.2

Bilanz: 18 Treffer · 1 echte Misses · 29 Rate-Limit-Skips · 87 429-Zeilen.

**Draft mit Absicht** — Merge nur nach Markus' Freigabe.