### PR TITLE
chore(playlists): tidal backfill wave — +19 uris

### DIFF
--- a/custom_components/beatify/playlists/community/ndw-neue-deutsche-welle.json
+++ b/custom_components/beatify/playlists/community/ndw-neue-deutsche-welle.json
@@ -1,6 +1,6 @@
 {
   "name": "NDW – Neue Deutsche Welle",
-  "version": "0.3",
+  "version": "0.4",
   "tags": [
     "ndw",
     "neue deutsche welle",
@@ -1488,7 +1488,7 @@
       "fun_fact_nl": "'Eine Königin mit Rädern untendran' van Foyer Des Arts zette de groepstraditie van vrolijke NDW-absurditeit voort.",
       "uri_apple_music": null,
       "uri_youtube_music": "https://www.youtube.com/watch?v=Jt9L777q4p0",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/171654",
       "uri_deezer": "753143",
       "isrc": "DEA629252270",
       "uri_apple_music_by_region": {
@@ -1522,7 +1522,7 @@
       "fun_fact_nl": "'Ich will nicht älter werden' van Bärchen und die Milchbubis verbindt kinderlijke esthetiek met NDW-eigenzinnigheid.",
       "uri_apple_music": "applemusic://track/1634090932",
       "uri_youtube_music": "https://www.youtube.com/watch?v=PsFl4UUCGnY",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/202851992",
       "uri_deezer": null,
       "uri_apple_music_by_region": {
         "us": null,
@@ -1557,7 +1557,7 @@
       "fun_fact_nl": "'Verliebte Jungs' van Purple Schulz is een dromerige synth-pop ballade die de zachtere kant van het NDW liet zien.",
       "uri_apple_music": null,
       "uri_youtube_music": "https://www.youtube.com/watch?v=3sUNZTLL_t4",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/1532265",
       "uri_deezer": "13460740",
       "isrc": "DEA348500348",
       "uri_apple_music_by_region": {
@@ -1595,7 +1595,7 @@
       "fun_fact_nl": "Nena's '99 Luftballons' bereikte nummer 2 in de VS en nummer 1 in het VK, een van de meest succesvolle Duitstalige nummers internationaal.",
       "uri_apple_music": null,
       "uri_youtube_music": "https://www.youtube.com/watch?v=Fpu5a0Bl8eY",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/491245790",
       "uri_deezer": null,
       "uri_apple_music_by_region": {
         "us": null,
@@ -1628,7 +1628,7 @@
       "fun_fact_nl": "'Vor all den Jahren' van Stahlnetz is een melancholische NDW parel uit Hamburg.",
       "uri_apple_music": null,
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/482999776",
       "uri_deezer": "3724778042",
       "isrc": "DEGE92000085",
       "uri_apple_music_by_region": {
@@ -1664,7 +1664,7 @@
       "fun_fact_nl": "'1000 und 1 Nacht' van Klaus Lage werd een van de grootste Duitse hits van 1984.",
       "uri_apple_music": null,
       "uri_youtube_music": "https://www.youtube.com/watch?v=Ug3HFmW8AVA",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/37258467",
       "uri_deezer": "13460739",
       "isrc": "DEA348400330",
       "uri_apple_music_by_region": {
@@ -1698,7 +1698,7 @@
       "fun_fact_nl": "'Carbonara' van Spliff was een vrolijk absurdistische ode aan het Italiaanse pastagerecht, van de band met toekomstig Nena-lid Carlo Karges.",
       "uri_apple_music": null,
       "uri_youtube_music": "https://www.youtube.com/watch?v=A1cMbolFc-A",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/11675426",
       "uri_deezer": "582479",
       "isrc": "DEE868200104",
       "uri_apple_music_by_region": {
@@ -1734,7 +1734,7 @@
       "fun_fact_nl": "'Bruttosozialprodukt' van Geier Sturzflug was een satirische blik op het West-Duitse economische wonder.",
       "uri_apple_music": "applemusic://track/205477661",
       "uri_youtube_music": "https://www.youtube.com/watch?v=7Df3vRcoA50",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/4058435",
       "uri_deezer": "6417948",
       "isrc": "DEA760605107",
       "uri_apple_music_by_region": {
@@ -1770,7 +1770,7 @@
       "fun_fact_nl": "'Irgendwie, irgendwo, irgendwann' van Nena werd geschreven door gitarist Carlo Karges, die ook '99 Luftballons' schreef.",
       "uri_apple_music": "applemusic://track/1446021377",
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/493681444",
       "uri_deezer": "3806147312",
       "isrc": "DEE869901718",
       "uri_apple_music_by_region": {

--- a/custom_components/beatify/playlists/community/polish-all-time-hits.json
+++ b/custom_components/beatify/playlists/community/polish-all-time-hits.json
@@ -1,6 +1,6 @@
 {
   "name": "Polskie przeboje wszech czasów",
-  "version": "0.2",
+  "version": "0.3",
   "tags": [
     "polish",
     "pop",
@@ -33,7 +33,7 @@
         "pl": "applemusic://track/1586028291"
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/55083459",
       "uri_deezer": "deezer://track/114979646",
       "fun_fact": "Edmund Fetting belongs to the Polish popular-music canon; \"Nim wstanie dzień\" (1966) features on this Polskie przeboje wszech czasów selection.",
       "fun_fact_de": "Edmund Fetting gehört zum Kanon der polnischen Popularmusik; „Nim wstanie dzień\" (1966) ist auf dieser Auswahl polnischer Hits aller Zeiten vertreten.",
@@ -61,7 +61,7 @@
         "pl": "applemusic://track/946479213"
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/131882770",
       "uri_deezer": "deezer://track/1677917767",
       "fun_fact": "Kalina Jedrusik belongs to the Polish popular-music canon; \"Mój pierwszy bal\" (1966) features on this Polskie przeboje wszech czasów selection.",
       "fun_fact_de": "Kalina Jedrusik gehört zum Kanon der polnischen Popularmusik; „Mój pierwszy bal\" (1966) ist auf dieser Auswahl polnischer Hits aller Zeiten vertreten.",
@@ -89,7 +89,7 @@
         "pl": "applemusic://track/1513379214"
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/141509561",
       "uri_deezer": "deezer://track/889397062",
       "fun_fact": "Sława Przybylska belongs to the Polish popular-music canon; \"Siedzieliśmy na dachu\" (1966) features on this Polskie przeboje wszech czasów selection.",
       "fun_fact_de": "Sława Przybylska gehört zum Kanon der polnischen Popularmusik; „Siedzieliśmy na dachu\" (1966) ist auf dieser Auswahl polnischer Hits aller Zeiten vertreten.",
@@ -119,7 +119,7 @@
         "pl": "applemusic://track/1451727774"
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/103690904",
       "uri_deezer": "deezer://track/631693162",
       "fun_fact": "Niemen belongs to the Polish popular-music canon; \"Pod Papugami\" (1968) features on this Polskie przeboje wszech czasów selection.",
       "fun_fact_de": "Niemen gehört zum Kanon der polnischen Popularmusik; „Pod Papugami\" (1968) ist auf dieser Auswahl polnischer Hits aller Zeiten vertreten.",
@@ -147,7 +147,7 @@
         "pl": "applemusic://track/1435513576"
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/62033044",
       "uri_deezer": "deezer://track/550519242",
       "fun_fact": "Mieczysław Fogg belongs to the Polish popular-music canon; \"To ostatnia niedziela\" (1969) features on this Polskie przeboje wszech czasów selection.",
       "fun_fact_de": "Mieczysław Fogg gehört zum Kanon der polnischen Popularmusik; „To ostatnia niedziela\" (1969) ist auf dieser Auswahl polnischer Hits aller Zeiten vertreten.",
@@ -175,7 +175,7 @@
         "pl": "applemusic://track/1160877356"
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/65537411",
       "uri_deezer": "deezer://track/282467201",
       "fun_fact": "Skaldowie belongs to the Polish popular-music canon; \"Prześliczna wiolonczelistka\" (1969) features on this Polskie przeboje wszech czasów selection.",
       "fun_fact_de": "Skaldowie gehört zum Kanon der polnischen Popularmusik; „Prześliczna wiolonczelistka\" (1969) ist auf dieser Auswahl polnischer Hits aller Zeiten vertreten.",
@@ -203,7 +203,7 @@
         "pl": "applemusic://track/1439259695"
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/96794255",
       "uri_deezer": "deezer://track/569471922",
       "fun_fact": "Anna Jantar belongs to the Polish popular-music canon; \"Tyle słońca w całym mieście\" (1974) features on this Polskie przeboje wszech czasów selection.",
       "fun_fact_de": "Anna Jantar gehört zum Kanon der polnischen Popularmusik; „Tyle słońca w całym mieście\" (1974) ist auf dieser Auswahl polnischer Hits aller Zeiten vertreten.",
@@ -231,7 +231,7 @@
         "pl": "applemusic://track/1739629557"
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/133924497",
       "uri_deezer": "deezer://track/2737733571",
       "fun_fact": "Maryla Rodowicz belongs to the Polish popular-music canon; \"Sing-Sing\" (1976) features on this Polskie przeboje wszech czasów selection.",
       "fun_fact_de": "Maryla Rodowicz gehört zum Kanon der polnischen Popularmusik; „Sing-Sing\" (1976) ist auf dieser Auswahl polnischer Hits aller Zeiten vertreten.",
@@ -259,7 +259,7 @@
         "pl": "applemusic://track/1737414055"
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/352846174",
       "uri_deezer": "deezer://track/3573033021",
       "fun_fact": "Maryla Rodowicz belongs to the Polish popular-music canon; \"Remedium\" (1978) features on this Polskie przeboje wszech czasów selection.",
       "fun_fact_de": "Maryla Rodowicz gehört zum Kanon der polnischen Popularmusik; „Remedium\" (1978) ist auf dieser Auswahl polnischer Hits aller Zeiten vertreten.",
@@ -289,7 +289,7 @@
         "pl": "applemusic://track/1737414587"
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/352846182",
       "uri_deezer": "deezer://track/3878972081",
       "fun_fact": "Maryla Rodowicz belongs to the Polish popular-music canon; \"Gaj\" (1978) features on this Polskie przeboje wszech czasów selection.",
       "fun_fact_de": "Maryla Rodowicz gehört zum Kanon der polnischen Popularmusik; „Gaj\" (1978) ist auf dieser Auswahl polnischer Hits aller Zeiten vertreten.",


### PR DESCRIPTION
Eine Odesli-Welle, automatisch gefahren von `com.beatify.tidal-wave`.

- `ndw-neue-deutsche-welle` Tidal 41 → **50**/50, version 0.3 → 0.4
- `polish-all-time-hits` Tidal 0 → **10**/59, version 0.2 → 0.3

Bilanz: 19 Treffer · 0 echte Misses · 30 Rate-Limit-Skips · 90 429-Zeilen.

**Draft mit Absicht** — Merge nur nach Markus' Freigabe.