### PR TITLE
chore(playlists): tidal backfill wave — +18 uris

### DIFF
--- a/custom_components/beatify/playlists/community/polish-all-time-hits.json
+++ b/custom_components/beatify/playlists/community/polish-all-time-hits.json
@@ -1,6 +1,6 @@
 {
   "name": "Polskie przeboje wszech czasów",
-  "version": "0.3",
+  "version": "0.4",
   "tags": [
     "polish",
     "pop",
@@ -317,7 +317,7 @@
         "pl": "applemusic://track/1731393585"
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/345847098",
       "uri_deezer": "deezer://track/2665885052",
       "fun_fact": "Anna Jantar belongs to the Polish popular-music canon; \"Nic nie może wiecznie trwać\" (1980) features on this Polskie przeboje wszech czasów selection.",
       "fun_fact_de": "Anna Jantar gehört zum Kanon der polnischen Popularmusik; „Nic nie może wiecznie trwać\" (1980) ist auf dieser Auswahl polnischer Hits aller Zeiten vertreten.",
@@ -345,7 +345,7 @@
         "pl": "applemusic://track/1731393292"
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/345847093",
       "uri_deezer": "deezer://track/2665885002",
       "fun_fact": "Anna Jantar belongs to the Polish popular-music canon; \"Wielka dama tańczy sama\" (1980) features on this Polskie przeboje wszech czasów selection.",
       "fun_fact_de": "Anna Jantar gehört zum Kanon der polnischen Popularmusik; „Wielka dama tańczy sama\" (1980) ist auf dieser Auswahl polnischer Hits aller Zeiten vertreten.",
@@ -375,7 +375,7 @@
         "pl": "applemusic://track/1442653444"
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/14556703",
       "uri_deezer": "deezer://track/17466922",
       "fun_fact": "Hey belongs to the Polish popular-music canon; \"Moja i Twoja Nadzieja\" (1993) features on this Polskie przeboje wszech czasów selection.",
       "fun_fact_de": "Hey gehört zum Kanon der polnischen Popularmusik; „Moja i Twoja Nadzieja\" (1993) ist auf dieser Auswahl polnischer Hits aller Zeiten vertreten.",
@@ -403,7 +403,7 @@
         "pl": "applemusic://track/884097398"
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/31128344",
       "uri_deezer": "deezer://track/79221223",
       "fun_fact": "IRA belongs to the Polish popular-music canon; \"Wiara\" (1993) features on this Polskie przeboje wszech czasów selection.",
       "fun_fact_de": "IRA gehört zum Kanon der polnischen Popularmusik; „Wiara\" (1993) ist auf dieser Auswahl polnischer Hits aller Zeiten vertreten.",
@@ -431,7 +431,7 @@
         "pl": "applemusic://track/688660666"
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/1577336",
       "uri_deezer": "deezer://track/3478012",
       "fun_fact": "Grzegorz Turnau belongs to the Polish popular-music canon; \"Bracka\" (1995) features on this Polskie przeboje wszech czasów selection.",
       "fun_fact_de": "Grzegorz Turnau gehört zum Kanon der polnischen Popularmusik; „Bracka\" (1995) ist auf dieser Auswahl polnischer Hits aller Zeiten vertreten.",
@@ -459,7 +459,7 @@
         "pl": "applemusic://track/1049025548"
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/1558934",
       "uri_deezer": "deezer://track/3117187",
       "fun_fact": "Maanam belongs to the Polish popular-music canon; \"Krakowski spleen\" (1995) features on this Polskie przeboje wszech czasów selection.",
       "fun_fact_de": "Maanam gehört zum Kanon der polnischen Popularmusik; „Krakowski spleen\" (1995) ist auf dieser Auswahl polnischer Hits aller Zeiten vertreten.",
@@ -487,7 +487,7 @@
         "pl": "applemusic://track/1781629501"
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/401748913",
       "uri_deezer": "deezer://track/3110788131",
       "fun_fact": "Robert Chojnacki belongs to the Polish popular-music canon; \"Niecierpliwi\" (1995) features on this Polskie przeboje wszech czasów selection.",
       "fun_fact_de": "Robert Chojnacki gehört zum Kanon der polnischen Popularmusik; „Niecierpliwi\" (1995) ist auf dieser Auswahl polnischer Hits aller Zeiten vertreten.",
@@ -534,7 +534,7 @@
         "pl": "applemusic://track/1813802310"
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/435339165",
       "uri_deezer": "deezer://track/3362497711",
       "fun_fact": "O.N.A. belongs to the Polish popular-music canon; \"Kiedy powiem sobie dość\" (1996) features on this Polskie przeboje wszech czasów selection.",
       "fun_fact_de": "O.N.A. gehört zum Kanon der polnischen Popularmusik; „Kiedy powiem sobie dość\" (1996) ist auf dieser Auswahl polnischer Hits aller Zeiten vertreten.",
@@ -562,7 +562,7 @@
         "pl": "applemusic://track/1454675909"
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/83503150",
       "uri_deezer": "deezer://track/451345312",
       "fun_fact": "Budka Suflera belongs to the Polish popular-music canon; \"Takie tango\" (1997) features on this Polskie przeboje wszech czasów selection.",
       "fun_fact_de": "Budka Suflera gehört zum Kanon der polnischen Popularmusik; „Takie tango\" (1997) ist auf dieser Auswahl polnischer Hits aller Zeiten vertreten.",
@@ -590,7 +590,7 @@
         "pl": "applemusic://track/1443331486"
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/7096528",
       "uri_deezer": "deezer://track/7045758",
       "fun_fact": "Edyta Bartosiewicz belongs to the Polish popular-music canon; \"Ostatni\" (1999) features on this Polskie przeboje wszech czasów selection.",
       "fun_fact_de": "Edyta Bartosiewicz gehört zum Kanon der polnischen Popularmusik; „Ostatni\" (1999) ist auf dieser Auswahl polnischer Hits aller Zeiten vertreten.",
@@ -611,7 +611,7 @@
       "uri_apple_music": null,
       "uri_apple_music_by_region": {},
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/532284628",
       "uri_deezer": "deezer://track/4076981281",
       "fun_fact": "Kayah belongs to the Polish popular-music canon; \"Śpij Kochanie Śpij\" (1999) features on this Polskie przeboje wszech czasów selection.",
       "fun_fact_de": "Kayah gehört zum Kanon der polnischen Popularmusik; „Śpij Kochanie Śpij\" (1999) ist auf dieser Auswahl polnischer Hits aller Zeiten vertreten.",
@@ -639,7 +639,7 @@
         "pl": "applemusic://track/1772966363"
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/140165673",
       "uri_deezer": "deezer://track/950273432",
       "fun_fact": "Myslovitz belongs to the Polish popular-music canon; \"Długość dźwięku samotności\" (1999) features on this Polskie przeboje wszech czasów selection.",
       "fun_fact_de": "Myslovitz gehört zum Kanon der polnischen Popularmusik; „Długość dźwięku samotności\" (1999) ist auf dieser Auswahl polnischer Hits aller Zeiten vertreten.",
@@ -667,7 +667,7 @@
         "pl": "applemusic://track/1462306820"
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/69021693",
       "uri_deezer": "deezer://track/139501895",
       "fun_fact": "Krystyna Prońko belongs to the Polish popular-music canon; \"Jesteś lekiem na całe zło - 1994\" (2000) features on this Polskie przeboje wszech czasów selection.",
       "fun_fact_de": "Krystyna Prońko gehört zum Kanon der polnischen Popularmusik; „Jesteś lekiem na całe zło - 1994\" (2000) ist auf dieser Auswahl polnischer Hits aller Zeiten vertreten.",
@@ -698,7 +698,7 @@
         "pl": "applemusic://track/853114366"
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/27834253",
       "uri_deezer": "deezer://track/143931894",
       "fun_fact": "Jacek Kaczmarski belongs to the Polish popular-music canon; \"Mury\" (2002) features on this Polskie przeboje wszech czasów selection.",
       "fun_fact_de": "Jacek Kaczmarski gehört zum Kanon der polnischen Popularmusik; „Mury\" (2002) ist auf dieser Auswahl polnischer Hits aller Zeiten vertreten.",
@@ -726,7 +726,7 @@
         "pl": "applemusic://track/1485628458"
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/120927360",
       "uri_deezer": "deezer://track/783262572",
       "fun_fact": "Bogusław Mec belongs to the Polish popular-music canon; \"Jej portret\" (2004) features on this Polskie przeboje wszech czasów selection.",
       "fun_fact_de": "Bogusław Mec gehört zum Kanon der polnischen Popularmusik; „Jej portret\" (2004) ist auf dieser Auswahl polnischer Hits aller Zeiten vertreten.",
@@ -754,7 +754,7 @@
         "pl": "applemusic://track/1604203989"
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/121191086",
       "uri_deezer": "deezer://track/1616487652",
       "fun_fact": "Obywatel G.C. belongs to the Polish popular-music canon; \"Nie Pytaj O Polskę\" (2004) features on this Polskie przeboje wszech czasów selection.",
       "fun_fact_de": "Obywatel G.C. gehört zum Kanon der polnischen Popularmusik; „Nie Pytaj O Polskę\" (2004) ist auf dieser Auswahl polnischer Hits aller Zeiten vertreten.",
@@ -782,7 +782,7 @@
         "pl": "applemusic://track/1485484391"
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/121279547",
       "uri_deezer": "deezer://track/791149442",
       "fun_fact": "Zbigniew Wodecki belongs to the Polish popular-music canon; \"Lubię wracać tam gdzie byłem\" (2004) features on this Polskie przeboje wszech czasów selection.",
       "fun_fact_de": "Zbigniew Wodecki gehört zum Kanon der polnischen Popularmusik; „Lubię wracać tam gdzie byłem\" (2004) ist auf dieser Auswahl polnischer Hits aller Zeiten vertreten.",
@@ -810,7 +810,7 @@
         "pl": "applemusic://track/1485484045"
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/21486995",
       "uri_deezer": "deezer://track/791181232",
       "fun_fact": "Zbigniew Wodecki belongs to the Polish popular-music canon; \"Zacznij od Bacha\" (2006) features on this Polskie przeboje wszech czasów selection.",
       "fun_fact_de": "Zbigniew Wodecki gehört zum Kanon der polnischen Popularmusik; „Zacznij od Bacha\" (2006) ist auf dieser Auswahl polnischer Hits aller Zeiten vertreten.",


### PR DESCRIPTION
Eine Odesli-Welle, automatisch gefahren von `com.beatify.tidal-wave`.

- `polish-all-time-hits` Tidal 10 → **28**/59, version 0.3 → 0.4

Bilanz: 18 Treffer · 1 echte Misses · 30 Rate-Limit-Skips · 90 429-Zeilen.

**Draft mit Absicht** — Merge nur nach Markus' Freigabe.