### PR TITLE
chore(playlists): tidal backfill wave — +19 uris

### DIFF
--- a/custom_components/beatify/playlists/community/polish-all-time-hits.json
+++ b/custom_components/beatify/playlists/community/polish-all-time-hits.json
@@ -1,6 +1,6 @@
 {
   "name": "Polskie przeboje wszech czasów",
-  "version": "0.4",
+  "version": "0.5",
   "tags": [
     "polish",
     "pop",
@@ -838,7 +838,7 @@
         "pl": "applemusic://track/536224726"
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/16214286",
       "uri_deezer": "deezer://track/135930332",
       "fun_fact": "Raz Dwa Trzy belongs to the Polish popular-music canon; \"Trudno Nie Wierzyc W Nic\" (2008) features on this Polskie przeboje wszech czasów selection.",
       "fun_fact_de": "Raz Dwa Trzy gehört zum Kanon der polnischen Popularmusik; „Trudno Nie Wierzyc W Nic\" (2008) ist auf dieser Auswahl polnischer Hits aller Zeiten vertreten.",
@@ -868,7 +868,7 @@
         "pl": "applemusic://track/1066493151"
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/55083317",
       "uri_deezer": "deezer://track/190531251",
       "fun_fact": "Marek Grechuta belongs to the Polish popular-music canon; \"Będziesz moją panią\" (2010) features on this Polskie przeboje wszech czasów selection.",
       "fun_fact_de": "Marek Grechuta gehört zum Kanon der polnischen Popularmusik; „Będziesz moją panią\" (2010) ist auf dieser Auswahl polnischer Hits aller Zeiten vertreten.",
@@ -896,7 +896,7 @@
         "pl": "applemusic://track/1442790380"
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/17837673",
       "uri_deezer": "deezer://track/62119203",
       "fun_fact": "Golden Life belongs to the Polish popular-music canon; \"24.11.94 - Wersja Akustyczna\" (2012) features on this Polskie przeboje wszech czasów selection.",
       "fun_fact_de": "Golden Life gehört zum Kanon der polnischen Popularmusik; „24.11.94 - Wersja Akustyczna\" (2012) ist auf dieser Auswahl polnischer Hits aller Zeiten vertreten.",
@@ -924,7 +924,7 @@
         "pl": "applemusic://track/1443210991"
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/14734166",
       "uri_deezer": "deezer://track/17827067",
       "fun_fact": "Stanisław Soyka belongs to the Polish popular-music canon; \"Dziwny Jest Ten Swiat\" (2012) features on this Polskie przeboje wszech czasów selection.",
       "fun_fact_de": "Stanisław Soyka gehört zum Kanon der polnischen Popularmusik; „Dziwny Jest Ten Swiat\" (2012) ist auf dieser Auswahl polnischer Hits aller Zeiten vertreten.",
@@ -952,7 +952,7 @@
         "pl": "applemusic://track/924197036"
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/36274741",
       "uri_deezer": "deezer://track/576227252",
       "fun_fact": "Andrzej Zaucha belongs to the Polish popular-music canon; \"C'est la vie - Paryż z pocztówki\" (2014) features on this Polskie przeboje wszech czasów selection.",
       "fun_fact_de": "Andrzej Zaucha gehört zum Kanon der polnischen Popularmusik; „C'est la vie - Paryż z pocztówki\" (2014) ist auf dieser Auswahl polnischer Hits aller Zeiten vertreten.",
@@ -980,7 +980,7 @@
         "pl": "applemusic://track/1542580817"
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/104494135",
       "uri_deezer": "deezer://track/636177602",
       "fun_fact": "Andrzej Zaucha belongs to the Polish popular-music canon; \"Byłaś serca biciem\" (2014) features on this Polskie przeboje wszech czasów selection.",
       "fun_fact_de": "Andrzej Zaucha gehört zum Kanon der polnischen Popularmusik; „Byłaś serca biciem\" (2014) ist auf dieser Auswahl polnischer Hits aller Zeiten vertreten.",
@@ -1008,7 +1008,7 @@
         "pl": "applemusic://track/1062834858"
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/54604565",
       "uri_deezer": "deezer://track/114013558",
       "fun_fact": "Czerwone Gitary belongs to the Polish popular-music canon; \"Kwiaty we włosach\" (2014) features on this Polskie przeboje wszech czasów selection.",
       "fun_fact_de": "Czerwone Gitary gehört zum Kanon der polnischen Popularmusik; „Kwiaty we włosach\" (2014) ist auf dieser Auswahl polnischer Hits aller Zeiten vertreten.",
@@ -1036,7 +1036,7 @@
         "pl": "applemusic://track/1489740033"
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/36274711",
       "uri_deezer": "deezer://track/823681652",
       "fun_fact": "Dzamble belongs to the Polish popular-music canon; \"Wymyśliłem Ciebie\" (2014) features on this Polskie przeboje wszech czasów selection.",
       "fun_fact_de": "Dzamble gehört zum Kanon der polnischen Popularmusik; „Wymyśliłem Ciebie\" (2014) ist auf dieser Auswahl polnischer Hits aller Zeiten vertreten.",
@@ -1064,7 +1064,7 @@
         "pl": "applemusic://track/1858893141"
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/107479651",
       "uri_deezer": "deezer://track/663031472",
       "fun_fact": "Niemen belongs to the Polish popular-music canon; \"Sen o Warszawie\" (2014) features on this Polskie przeboje wszech czasów selection.",
       "fun_fact_de": "Niemen gehört zum Kanon der polnischen Popularmusik; „Sen o Warszawie\" (2014) ist auf dieser Auswahl polnischer Hits aller Zeiten vertreten.",
@@ -1092,7 +1092,7 @@
         "pl": "applemusic://track/930047859"
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/36829366",
       "uri_deezer": "deezer://track/88250207",
       "fun_fact": "Perfect belongs to the Polish popular-music canon; \"Niepokonani\" (2014) features on this Polskie przeboje wszech czasów selection.",
       "fun_fact_de": "Perfect gehört zum Kanon der polnischen Popularmusik; „Niepokonani\" (2014) ist auf dieser Auswahl polnischer Hits aller Zeiten vertreten.",
@@ -1120,7 +1120,7 @@
         "pl": "applemusic://track/930054893"
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/36829347",
       "uri_deezer": "deezer://track/88413379",
       "fun_fact": "Republika belongs to the Polish popular-music canon; \"Biała Flaga - Live\" (2014) features on this Polskie przeboje wszech czasów selection.",
       "fun_fact_de": "Republika gehört zum Kanon der polnischen Popularmusik; „Biała Flaga - Live\" (2014) ist auf dieser Auswahl polnischer Hits aller Zeiten vertreten.",
@@ -1148,7 +1148,7 @@
         "pl": "applemusic://track/905435677"
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/32782332",
       "uri_deezer": "deezer://track/88413377",
       "fun_fact": "Republika belongs to the Polish popular-music canon; \"Telefony - Live\" (2014) features on this Polskie przeboje wszech czasów selection.",
       "fun_fact_de": "Republika gehört zum Kanon der polnischen Popularmusik; „Telefony - Live\" (2014) ist auf dieser Auswahl polnischer Hits aller Zeiten vertreten.",
@@ -1176,7 +1176,7 @@
         "pl": "applemusic://track/1005024799"
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/47719254",
       "uri_deezer": "deezer://track/102156558",
       "fun_fact": "Tadeusz Wozniak belongs to the Polish popular-music canon; \"Zegarmistrz swiatla\" (2014) features on this Polskie przeboje wszech czasów selection.",
       "fun_fact_de": "Tadeusz Wozniak gehört zum Kanon der polnischen Popularmusik; „Zegarmistrz swiatla\" (2014) ist auf dieser Auswahl polnischer Hits aller Zeiten vertreten.",
@@ -1204,7 +1204,7 @@
         "pl": "applemusic://track/1442357580"
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/29863049",
       "uri_deezer": "deezer://track/78573356",
       "fun_fact": "Urszula belongs to the Polish popular-music canon; \"Dmuchawce, Latawce, Wiatr\" (2014) features on this Polskie przeboje wszech czasów selection.",
       "fun_fact_de": "Urszula gehört zum Kanon der polnischen Popularmusik; „Dmuchawce, Latawce, Wiatr\" (2014) ist auf dieser Auswahl polnischer Hits aller Zeiten vertreten.",
@@ -1232,7 +1232,7 @@
         "pl": "applemusic://track/1435476496"
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/53739065",
       "uri_deezer": "deezer://track/114979652",
       "fun_fact": "Andrzej Dabrowski belongs to the Polish popular-music canon; \"Zielono Mi\" (2015) features on this Polskie przeboje wszech czasów selection.",
       "fun_fact_de": "Andrzej Dabrowski gehört zum Kanon der polnischen Popularmusik; „Zielono Mi\" (2015) ist auf dieser Auswahl polnischer Hits aller Zeiten vertreten.",
@@ -1260,7 +1260,7 @@
         "pl": "applemusic://track/1062834606"
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/65537420",
       "uri_deezer": "deezer://track/114013544",
       "fun_fact": "Czerwone Gitary belongs to the Polish popular-music canon; \"Historia jednej znajomości\" (2015) features on this Polskie przeboje wszech czasów selection.",
       "fun_fact_de": "Czerwone Gitary gehört zum Kanon der polnischen Popularmusik; „Historia jednej znajomości\" (2015) ist auf dieser Auswahl polnischer Hits aller Zeiten vertreten.",
@@ -1288,7 +1288,7 @@
         "pl": "applemusic://track/1855904906"
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/48983963",
       "uri_deezer": "deezer://track/3698341812",
       "fun_fact": "Grażyna Łobaszewska belongs to the Polish popular-music canon; \"Czas Nas Uczy Pogody\" (2015) features on this Polskie przeboje wszech czasów selection.",
       "fun_fact_de": "Grażyna Łobaszewska gehört zum Kanon der polnischen Popularmusik; „Czas Nas Uczy Pogody\" (2015) ist auf dieser Auswahl polnischer Hits aller Zeiten vertreten.",
@@ -1316,7 +1316,7 @@
         "pl": "applemusic://track/1056034155"
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/52864100",
       "uri_deezer": "deezer://track/780120462",
       "fun_fact": "Irena Jarocka belongs to the Polish popular-music canon; \"Odpływają Kawiarenki\" (2015) features on this Polskie przeboje wszech czasów selection.",
       "fun_fact_de": "Irena Jarocka gehört zum Kanon der polnischen Popularmusik; „Odpływają Kawiarenki\" (2015) ist auf dieser Auswahl polnischer Hits aller Zeiten vertreten.",
@@ -1344,7 +1344,7 @@
         "pl": "applemusic://track/1160877464"
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/45218431",
       "uri_deezer": "deezer://track/559507592",
       "fun_fact": "Irena Santor belongs to the Polish popular-music canon; \"Tych Lat Nie Odda Nikt\" (2015) features on this Polskie przeboje wszech czasów selection.",
       "fun_fact_de": "Irena Santor gehört zum Kanon der polnischen Popularmusik; „Tych Lat Nie Odda Nikt\" (2015) ist auf dieser Auswahl polnischer Hits aller Zeiten vertreten.",


### PR DESCRIPTION
Eine Odesli-Welle, automatisch gefahren von `com.beatify.tidal-wave`.

- `polish-all-time-hits` Tidal 28 → **47**/59, version 0.4 → 0.5

Bilanz: 19 Treffer · 0 echte Misses · 30 Rate-Limit-Skips · 90 429-Zeilen.

**Draft mit Absicht** — Merge nur nach Markus' Freigabe.