### PR TITLE
chore(playlists): tidal backfill wave — +16 uris

### DIFF
--- a/custom_components/beatify/playlists/community/polish-all-time-hits.json
+++ b/custom_components/beatify/playlists/community/polish-all-time-hits.json
@@ -1,6 +1,6 @@
 {
   "name": "Polskie przeboje wszech czasów",
-  "version": "0.5",
+  "version": "0.6",
   "tags": [
     "polish",
     "pop",
@@ -1372,7 +1372,7 @@
         "pl": "applemusic://track/1066493162"
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/55083321",
       "uri_deezer": "deezer://track/190533861",
       "fun_fact": "Marek Grechuta belongs to the Polish popular-music canon; \"Ocalić od zapomnienia\" (2015) features on this Polskie przeboje wszech czasów selection.",
       "fun_fact_de": "Marek Grechuta gehört zum Kanon der polnischen Popularmusik; „Ocalić od zapomnienia\" (2015) ist auf dieser Auswahl polnischer Hits aller Zeiten vertreten.",
@@ -1400,7 +1400,7 @@
         "pl": "applemusic://track/1855904909"
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/48983964",
       "uri_deezer": "deezer://track/103795444",
       "fun_fact": "Martyna Jakubowicz belongs to the Polish popular-music canon; \"W Domach z Betonu Nie Ma Wolnej Miłości\" (2015) features on this Polskie przeboje wszech czasów selection.",
       "fun_fact_de": "Martyna Jakubowicz gehört zum Kanon der polnischen Popularmusik; „W Domach z Betonu Nie Ma Wolnej Miłości\" (2015) ist auf dieser Auswahl polnischer Hits aller Zeiten vertreten.",
@@ -1428,7 +1428,7 @@
         "pl": "applemusic://track/1098869915"
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/58809732",
       "uri_deezer": "deezer://track/121736558",
       "fun_fact": "Kazik belongs to the Polish popular-music canon; \"12 Groszy\" (2016) features on this Polskie przeboje wszech czasów selection.",
       "fun_fact_de": "Kazik gehört zum Kanon der polnischen Popularmusik; „12 Groszy\" (2016) ist auf dieser Auswahl polnischer Hits aller Zeiten vertreten.",
@@ -1456,7 +1456,7 @@
         "pl": "applemusic://track/915322223"
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/58381216",
       "uri_deezer": "deezer://track/120994986",
       "fun_fact": "Lombard belongs to the Polish popular-music canon; \"Przeżyj To Sam\" (2016) features on this Polskie przeboje wszech czasów selection.",
       "fun_fact_de": "Lombard gehört zum Kanon der polnischen Popularmusik; „Przeżyj To Sam\" (2016) ist auf dieser Auswahl polnischer Hits aller Zeiten vertreten.",
@@ -1512,7 +1512,7 @@
         "pl": "applemusic://track/1433949584"
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/94003511",
       "uri_deezer": "deezer://track/546835792",
       "fun_fact": "Bajm belongs to the Polish popular-music canon; \"Co mi Panie dasz\" (2018) features on this Polskie przeboje wszech czasów selection.",
       "fun_fact_de": "Bajm gehört zum Kanon der polnischen Popularmusik; „Co mi Panie dasz\" (2018) ist auf dieser Auswahl polnischer Hits aller Zeiten vertreten.",
@@ -1540,7 +1540,7 @@
         "pl": "applemusic://track/1349865949"
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/84813790",
       "uri_deezer": "deezer://track/463474162",
       "fun_fact": "Edyta Bartosiewicz belongs to the Polish popular-music canon; \"Opowieść\" (2018) features on this Polskie przeboje wszech czasów selection.",
       "fun_fact_de": "Edyta Bartosiewicz gehört zum Kanon der polnischen Popularmusik; „Opowieść\" (2018) ist auf dieser Auswahl polnischer Hits aller Zeiten vertreten.",
@@ -1570,7 +1570,7 @@
         "pl": "applemusic://track/1369127678"
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/485977817",
       "uri_deezer": "deezer://track/3747824252",
       "fun_fact": "Varius Manx belongs to the Polish popular-music canon; \"Piosenka księżycowa - Acoustic Version\" (2018) features on this Polskie przeboje wszech czasów selection.",
       "fun_fact_de": "Varius Manx gehört zum Kanon der polnischen Popularmusik; „Piosenka księżycowa - Acoustic Version\" (2018) ist auf dieser Auswahl polnischer Hits aller Zeiten vertreten.",
@@ -1654,7 +1654,7 @@
         "pl": "applemusic://track/1689642097"
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/296851712",
       "uri_deezer": "deezer://track/2301155735",
       "fun_fact": "ŁZY Adam Konkol belongs to the Polish popular-music canon; \"Agnieszka\" (2023) features on this Polskie przeboje wszech czasów selection.",
       "fun_fact_de": "ŁZY Adam Konkol gehört zum Kanon der polnischen Popularmusik; „Agnieszka\" (2023) ist auf dieser Auswahl polnischer Hits aller Zeiten vertreten.",

--- a/custom_components/beatify/playlists/community/polish-hits-90s-00s.json
+++ b/custom_components/beatify/playlists/community/polish-hits-90s-00s.json
@@ -1,6 +1,6 @@
 {
   "name": "Polskie hity radiowe 🇵🇱",
-  "version": "0.4",
+  "version": "0.5",
   "tags": [
     "polish",
     "pop",
@@ -33,7 +33,7 @@
         "pl": "applemusic://track/688248454"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=en7uKP696RE",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/2967321",
       "uri_deezer": "deezer://track/3172279",
       "alt_artists": [],
       "fun_fact": "Marta Moszczynska/Piotr Rubik belongs to the Polish pop and rock canon; \"Most dwojga serc\" (2009) features on this Polskie hity lat 90' 00' selection.",
@@ -60,7 +60,7 @@
         "pl": "applemusic://track/1443594712"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=j0U4lrfzv6U",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/7231794",
       "uri_deezer": "deezer://track/4670975",
       "alt_artists": [],
       "fun_fact": "Ich Troje belongs to the Polish pop and rock canon; \"Powiedz\" (2003) features on this Polskie hity lat 90' 00' selection.",
@@ -87,7 +87,7 @@
         "pl": "applemusic://track/1444111600"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=u2NLmfSJXAI",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/13491952",
       "uri_deezer": "deezer://track/3911792511",
       "alt_artists": [],
       "fun_fact": "Jacek Stachursky belongs to the Polish pop and rock canon; \"Typ Niepokorny\" (2010) features on this Polskie hity lat 90' 00' selection.",
@@ -107,7 +107,7 @@
         "pl": "applemusic://track/1444111735"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=XH__tJ3vuBU",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/13491953",
       "uri_deezer": "deezer://track/115495332",
       "alt_artists": [],
       "fun_fact": "Jacek Stachursky belongs to the Polish pop and rock canon; \"Jedwab\" (2011) features on this Polskie hity lat 90' 00' selection.",
@@ -134,7 +134,7 @@
         "pl": "applemusic://track/288863471"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=y3bmeafP778",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/1895343",
       "uri_deezer": "deezer://track/1277457",
       "alt_artists": [],
       "fun_fact": "Kasia Cerekwicka belongs to the Polish pop and rock canon; \"Na Kolana\" (2006) features on this Polskie hity lat 90' 00' selection.",
@@ -161,7 +161,7 @@
         "pl": "applemusic://track/996187325"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=HPmH_WoWMcw",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/45513786",
       "uri_deezer": "deezer://track/100618300",
       "alt_artists": [],
       "fun_fact": "Kasia Cerekwicka belongs to the Polish pop and rock canon; \"Miedzy Slowami\" (2015) features on this Polskie hity lat 90' 00' selection.",
@@ -188,7 +188,7 @@
         "pl": "applemusic://track/1443543291"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=2P3B2TLbRic",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/3598811",
       "uri_deezer": "deezer://track/932859",
       "alt_artists": [],
       "fun_fact": "Kombii belongs to the Polish pop and rock canon; \"Pokolenie\" (2004) features on this Polskie hity lat 90' 00' selection.",
@@ -215,7 +215,7 @@
         "pl": "applemusic://track/1443803518"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=ZkRKUrtwqLs",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/3681365",
       "uri_deezer": "deezer://track/4154988",
       "alt_artists": [],
       "fun_fact": "Kombii belongs to the Polish pop and rock canon; \"Awinion\" (2007) features on this Polskie hity lat 90' 00' selection.",


### PR DESCRIPTION
Eine Odesli-Welle, automatisch gefahren von `com.beatify.tidal-wave`.

- `polish-all-time-hits` Tidal 47 → **55**/59, version 0.5 → 0.6
- `polish-hits-90s-00s` Tidal 0 → **8**/92, version 0.4 → 0.5

Bilanz: 16 Treffer · 3 echte Misses · 30 Rate-Limit-Skips · 90 429-Zeilen.

**Draft mit Absicht** — Merge nur nach Markus' Freigabe.