### PR TITLE
chore(playlists): tidal backfill wave — +18 uris

### DIFF
--- a/custom_components/beatify/playlists/community/polish-hits-90s-00s.json
+++ b/custom_components/beatify/playlists/community/polish-hits-90s-00s.json
@@ -1,6 +1,6 @@
 {
   "name": "Polskie hity radiowe 🇵🇱",
-  "version": "0.5",
+  "version": "0.6",
   "tags": [
     "polish",
     "pop",
@@ -240,7 +240,7 @@
         "pl": "applemusic://track/1443838310"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=rPCrAVTOqpU",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/7015549",
       "uri_deezer": "deezer://track/6813437",
       "alt_artists": [],
       "fun_fact": "Kombii belongs to the Polish pop and rock canon; \"Gdzie Jestes Dzis\" (2010) features on this Polskie hity lat 90' 00' selection.",
@@ -260,7 +260,7 @@
         "pl": "applemusic://track/494616538"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=GS_9uTJx3-U",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/13098457",
       "uri_deezer": "deezer://track/16186379",
       "alt_artists": [],
       "fun_fact": "Andrzej Piaseczny belongs to the Polish pop and rock canon; \"To Co Dobre, To Co Lepsze\" (2012) features on this Polskie hity lat 90' 00' selection.",
@@ -280,7 +280,7 @@
         "pl": "applemusic://track/689264324"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=4FVknL_DKuo",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/32580311",
       "uri_deezer": "deezer://track/3447763",
       "alt_artists": [],
       "fun_fact": "Edyta Górniak belongs to the Polish pop and rock canon; \"One & One\" (2004) features on this Polskie hity lat 90' 00' selection.",
@@ -300,7 +300,7 @@
         "pl": "applemusic://track/763080971"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=OsFswALdVkg",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/38291592",
       "uri_deezer": "deezer://track/64820601",
       "alt_artists": [],
       "fun_fact": "Natalia Kukulska belongs to the Polish pop and rock canon; \"Wierność jest nudna - Och Karol 2 OST\" (2011) features on this Polskie hity lat 90' 00' selection.",
@@ -320,7 +320,7 @@
         "pl": "applemusic://track/691873971"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=rrXdNRlKdIE",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/2887363",
       "uri_deezer": "deezer://track/3313805",
       "alt_artists": [],
       "fun_fact": "Patrycja Markowska belongs to the Polish pop and rock canon; \"Świat się pomylił\" (2007) features on this Polskie hity lat 90' 00' selection.",
@@ -340,7 +340,7 @@
         "pl": "applemusic://track/904041898"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=9qRbjK4KPFc",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/104494132",
       "uri_deezer": "deezer://track/3355141",
       "alt_artists": [],
       "fun_fact": "Maanam belongs to the Polish pop and rock canon; \"Kocham Cię, Kochanie Moje\" (1995) features on this Polskie hity lat 90' 00' selection.",
@@ -360,7 +360,7 @@
         "pl": "applemusic://track/888840202"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=UNXGNd-Drfc",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/30987730",
       "uri_deezer": "deezer://track/79590780",
       "alt_artists": [],
       "fun_fact": "Dżem belongs to the Polish pop and rock canon; \"Whisky - 2003 Remaster\" (2012) features on this Polskie hity lat 90' 00' selection.",
@@ -380,7 +380,7 @@
         "pl": "applemusic://track/1442951381"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=K_xWAxfdcks",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/34793548",
       "uri_deezer": "deezer://track/85904749",
       "alt_artists": [],
       "fun_fact": "Yugopolis belongs to the Polish pop and rock canon; \"Miasto budzi się (feat. Paweł Kukiz)\" (2012) features on this Polskie hity lat 90' 00' selection.",
@@ -400,7 +400,7 @@
         "pl": "applemusic://track/691441004"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=KluzKnEapkA",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/1522045",
       "uri_deezer": "deezer://track/3219513",
       "alt_artists": [],
       "fun_fact": "Wilki belongs to the Polish pop and rock canon; \"Na zawsze i na wieczność\" (2006) features on this Polskie hity lat 90' 00' selection.",
@@ -420,7 +420,7 @@
         "pl": "applemusic://track/692595390"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=LVTmSbGH-ZA",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/1454396",
       "uri_deezer": "deezer://track/3092477",
       "alt_artists": [],
       "fun_fact": "Wilki belongs to the Polish pop and rock canon; \"Baśka\" (2003) features on this Polskie hity lat 90' 00' selection.",
@@ -440,7 +440,7 @@
         "pl": "applemusic://track/691440950"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=beME8kLQUqA",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/1522043",
       "uri_deezer": "deezer://track/3219511",
       "alt_artists": [],
       "fun_fact": "Wilki belongs to the Polish pop and rock canon; \"Love Story\" (2006) features on this Polskie hity lat 90' 00' selection.",
@@ -460,7 +460,7 @@
         "pl": "applemusic://track/966231718"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=NigotdQPDCA",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/41094414",
       "uri_deezer": "deezer://track/65582813",
       "alt_artists": [],
       "fun_fact": "Bracia belongs to the Polish pop and rock canon; \"Wierze w lepszy swiat\" (2015) features on this Polskie hity lat 90' 00' selection.",
@@ -480,7 +480,7 @@
         "pl": "applemusic://track/560776277"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=11CuQ1DxExU",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/41094415",
       "uri_deezer": "deezer://track/60675301",
       "alt_artists": [],
       "fun_fact": "Bracia belongs to the Polish pop and rock canon; \"Nad Przepascia\" (2015) features on this Polskie hity lat 90' 00' selection.",
@@ -520,7 +520,7 @@
         "pl": "applemusic://track/881449262"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=OtA2dxJNHV4",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/30010365",
       "uri_deezer": "deezer://track/78712217",
       "alt_artists": [],
       "fun_fact": "Elektryczne Gitary belongs to the Polish pop and rock canon; \"Kiler - 2014\" (2014) features on this Polskie hity lat 90' 00' selection.",
@@ -540,7 +540,7 @@
         "pl": "applemusic://track/1388421757"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=IQV12L24EwY",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/89275095",
       "uri_deezer": "deezer://track/503929042",
       "alt_artists": [],
       "fun_fact": "Robert Gawlinski belongs to the Polish pop and rock canon; \"O sobie samym\" (2010) features on this Polskie hity lat 90' 00' selection.",
@@ -560,7 +560,7 @@
         "pl": "applemusic://track/1454676969"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=uY21XYpTKjo",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/83503177",
       "uri_deezer": "deezer://track/451345722",
       "alt_artists": [],
       "fun_fact": "Budka Suflera belongs to the Polish pop and rock canon; \"Bal Wszystkich Świętych\" (2000) features on this Polskie hity lat 90' 00' selection.",
@@ -580,7 +580,7 @@
         "pl": "applemusic://track/1231145180"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=VCuSqzGxBPM",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/1435346",
       "uri_deezer": "deezer://track/3211718",
       "alt_artists": [],
       "fun_fact": "Varius Manx belongs to the Polish pop and rock canon; \"Maj\" (2001) features on this Polskie hity lat 90' 00' selection.",
@@ -600,7 +600,7 @@
         "pl": "applemusic://track/1484084956"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=Xn2osb59lbU",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/120480753",
       "uri_deezer": "deezer://track/779745992",
       "alt_artists": [],
       "fun_fact": "Lady Pank belongs to the Polish pop and rock canon; \"Kryzysowa Narzeczona\" (1983) features on this Polskie hity lat 90' 00' selection.",


### PR DESCRIPTION
Eine Odesli-Welle, automatisch gefahren von `com.beatify.tidal-wave`.

- `polish-hits-90s-00s` Tidal 8 → **26**/92, version 0.5 → 0.6

Bilanz: 18 Treffer · 1 echte Misses · 30 Rate-Limit-Skips · 87 429-Zeilen.

**Draft mit Absicht** — Merge nur nach Markus' Freigabe.