### PR TITLE
chore(playlists): tidal backfill wave — +19 uris

### DIFF
--- a/custom_components/beatify/playlists/community/polish-hits-90s-00s.json
+++ b/custom_components/beatify/playlists/community/polish-hits-90s-00s.json
@@ -1,6 +1,6 @@
 {
   "name": "Polskie hity radiowe 🇵🇱",
-  "version": "0.6",
+  "version": "0.7",
   "tags": [
     "polish",
     "pop",
@@ -620,7 +620,7 @@
         "pl": "applemusic://track/692595394"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=8YKAHgwLEMg",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/32805069",
       "uri_deezer": "deezer://track/3092481",
       "alt_artists": [],
       "fun_fact": "Wilki belongs to the Polish pop and rock canon; \"Urke\" (2003) features on this Polskie hity lat 90' 00' selection.",
@@ -640,7 +640,7 @@
         "pl": "applemusic://track/1066493167"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=tNnzUZSDNf0",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/55083322",
       "uri_deezer": "deezer://track/190531151",
       "alt_artists": [],
       "fun_fact": "Marek Grechuta belongs to the Polish pop and rock canon; \"Dni, których nie znamy\" (2010) features on this Polskie hity lat 90' 00' selection.",
@@ -660,7 +660,7 @@
         "pl": "applemusic://track/692038757"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=dK7yUfCxD-8",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/2913535",
       "uri_deezer": "deezer://track/81811448",
       "alt_artists": [],
       "fun_fact": "T.Love belongs to the Polish pop and rock canon; \"Nie nie nie\" (2001) features on this Polskie hity lat 90' 00' selection.",
@@ -680,7 +680,7 @@
         "pl": "applemusic://track/688327631"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=NOMk4KwgYA8",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/1519534",
       "uri_deezer": "deezer://track/3328482",
       "alt_artists": [],
       "fun_fact": "Myslovitz belongs to the Polish pop and rock canon; \"Mieć czy być\" (2006) features on this Polskie hity lat 90' 00' selection.",
@@ -700,7 +700,7 @@
         "pl": "applemusic://track/1049025566"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=y97vh4CumoY",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/6039139",
       "uri_deezer": "deezer://track/10246097",
       "alt_artists": [],
       "fun_fact": "Maanam belongs to the Polish pop and rock canon; \"Cykady na Cykladach - 2011 Remaster\" (2011) features on this Polskie hity lat 90' 00' selection.",
@@ -720,7 +720,7 @@
         "pl": "applemusic://track/1654687649"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=6HexKILMxTc",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/120476084",
       "uri_deezer": "deezer://track/779749162",
       "alt_artists": [],
       "fun_fact": "Lady Pank belongs to the Polish pop and rock canon; \"Zawsze Tam Gdzie Ty\" (2007) features on this Polskie hity lat 90' 00' selection.",
@@ -740,7 +740,7 @@
         "pl": "applemusic://track/691883772"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=X0lkrxFuGr8",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/1571641",
       "uri_deezer": "deezer://track/3258372",
       "alt_artists": [],
       "fun_fact": "T.Love belongs to the Polish pop and rock canon; \"Chłopaki nie płaczą\" (1997) features on this Polskie hity lat 90' 00' selection.",
@@ -760,7 +760,7 @@
         "pl": "applemusic://track/1485523612"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=fGrSn37vrW4",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/121304957",
       "uri_deezer": "deezer://track/792031932",
       "alt_artists": [],
       "fun_fact": "Mr. Zoob belongs to the Polish pop and rock canon; \"Mój Jest Ten Kawałek Podłogi\" (2011) features on this Polskie hity lat 90' 00' selection.",
@@ -780,7 +780,7 @@
         "pl": "applemusic://track/1484081264"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=_ewr2o0PEzc",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/120480752",
       "uri_deezer": "deezer://track/779745982",
       "alt_artists": [],
       "fun_fact": "Lady Pank belongs to the Polish pop and rock canon; \"Mniej Niż Zero\" (1983) features on this Polskie hity lat 90' 00' selection.",
@@ -800,7 +800,7 @@
         "pl": "applemusic://track/692038724"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=lEuIHj2iSC8",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/2913530",
       "uri_deezer": "deezer://track/3170553",
       "alt_artists": [],
       "fun_fact": "T.Love belongs to the Polish pop and rock canon; \"Ajrisz\" (2001) features on this Polskie hity lat 90' 00' selection.",
@@ -820,7 +820,7 @@
         "pl": "applemusic://track/1481862811"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=l_AS1FWcLYI",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/121029299",
       "uri_deezer": "deezer://track/786028382",
       "alt_artists": [],
       "fun_fact": "Lady Pank belongs to the Polish pop and rock canon; \"Na Co Komu Dziś\" (2007) features on this Polskie hity lat 90' 00' selection.",
@@ -840,7 +840,7 @@
         "pl": "applemusic://track/1098882919"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=-9Pm05VhIVw",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/58810326",
       "uri_deezer": "deezer://track/121737226",
       "alt_artists": [],
       "fun_fact": "Strachy Na Lachy belongs to the Polish pop and rock canon; \"Dzień dobry, kocham Cię\" (2005) features on this Polskie hity lat 90' 00' selection.",
@@ -860,7 +860,7 @@
         "pl": "applemusic://track/733754252"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=bRircB2hwSU",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/23275119",
       "uri_deezer": "deezer://track/71898685",
       "alt_artists": [],
       "fun_fact": "Poparzeni Kawą Trzy belongs to the Polish pop and rock canon; \"Byłaś dla Mnie Wszystkim\" (2013) features on this Polskie hity lat 90' 00' selection.",
@@ -880,7 +880,7 @@
         "pl": "applemusic://track/1654687651"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=3kwXbUuXQqU",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/17175221",
       "uri_deezer": "deezer://track/60742148",
       "alt_artists": [],
       "fun_fact": "Lady Pank belongs to the Polish pop and rock canon; \"Stacja Warszawa\" (2012) features on this Polskie hity lat 90' 00' selection.",
@@ -900,7 +900,7 @@
         "pl": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=b16vSZMJ13k",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/1452807",
       "uri_deezer": "deezer://track/3276513",
       "alt_artists": [],
       "fun_fact": "Sidney Polak, Pezet belongs to the Polish pop and rock canon; \"Otwieram wino (feat. Pezet)\" (2004) features on this Polskie hity lat 90' 00' selection.",
@@ -920,7 +920,7 @@
         "pl": "applemusic://track/1442966661"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=jMh00h367o0",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/14560840",
       "uri_deezer": "deezer://track/17466994",
       "alt_artists": [],
       "fun_fact": "Big Cyc belongs to the Polish pop and rock canon; \"Każdy Facet To Świnia\" (2013) features on this Polskie hity lat 90' 00' selection.",
@@ -940,7 +940,7 @@
         "pl": "applemusic://track/1484081227"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=wEEEknecLA4",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/120411973",
       "uri_deezer": "deezer://track/779301212",
       "alt_artists": [],
       "fun_fact": "Lady Pank belongs to the Polish pop and rock canon; \"Zostawcie Titanica\" (2007) features on this Polskie hity lat 90' 00' selection.",
@@ -960,7 +960,7 @@
         "pl": "applemusic://track/692620174"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=3FP6ROwV1XM",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/14275426",
       "uri_deezer": "deezer://track/17384428",
       "alt_artists": [],
       "fun_fact": "Bajm belongs to the Polish pop and rock canon; \"Myśli i słowa\" (2003) features on this Polskie hity lat 90' 00' selection.",
@@ -980,7 +980,7 @@
         "pl": "applemusic://track/1485460394"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=LPU2rd2pGno",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/120555558",
       "uri_deezer": "deezer://track/780120242",
       "alt_artists": [],
       "fun_fact": "Kombi belongs to the Polish pop and rock canon; \"Słodkiego Miłego Życia\" (2008) features on this Polskie hity lat 90' 00' selection.",


### PR DESCRIPTION
Eine Odesli-Welle, automatisch gefahren von `com.beatify.tidal-wave`.

- `polish-hits-90s-00s` Tidal 26 → **45**/92, version 0.6 → 0.7

Bilanz: 19 Treffer · 0 echte Misses · 30 Rate-Limit-Skips · 90 429-Zeilen.

**Draft mit Absicht** — Merge nur nach Markus' Freigabe.