### PR TITLE
chore(playlists): tidal backfill wave — +19 uris

### DIFF
--- a/custom_components/beatify/playlists/community/polish-hits-90s-00s.json
+++ b/custom_components/beatify/playlists/community/polish-hits-90s-00s.json
@@ -1,6 +1,6 @@
 {
   "name": "Polskie hity radiowe 🇵🇱",
-  "version": "0.7",
+  "version": "0.8",
   "tags": [
     "polish",
     "pop",
@@ -1000,7 +1000,7 @@
         "pl": "applemusic://track/720685699"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=yrJ_lzYGJdg",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/22916013",
       "uri_deezer": "deezer://track/69184465",
       "alt_artists": [],
       "fun_fact": "GOLEC UORKIESTRA belongs to the Polish pop and rock canon; \"Ściernisco\" (2000) features on this Polskie hity lat 90' 00' selection.",
@@ -1020,7 +1020,7 @@
         "pl": "applemusic://track/674019763"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=8VLHittFkSk",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/21375666",
       "uri_deezer": "deezer://track/71304735",
       "alt_artists": [],
       "fun_fact": "GOLEC UORKIESTRA belongs to the Polish pop and rock canon; \"Pędzą Konie\" (2002) features on this Polskie hity lat 90' 00' selection.",
@@ -1040,7 +1040,7 @@
         "pl": "applemusic://track/720685730"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=5EqS8VM5N2A",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/22916017",
       "uri_deezer": "deezer://track/71304715",
       "alt_artists": [],
       "fun_fact": "GOLEC UORKIESTRA belongs to the Polish pop and rock canon; \"Lornetka - 2013\" (2013) features on this Polskie hity lat 90' 00' selection.",
@@ -1060,7 +1060,7 @@
         "pl": "applemusic://track/720685801"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=HMxN0KM8qt0",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/22916026",
       "uri_deezer": "deezer://track/71304724",
       "alt_artists": [],
       "fun_fact": "GOLEC UORKIESTRA belongs to the Polish pop and rock canon; \"Crazy Is My Life - 2013\" (2013) features on this Polskie hity lat 90' 00' selection.",
@@ -1080,7 +1080,7 @@
         "pl": "applemusic://track/340409213"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=kWRhdN2XusA",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/17754197",
       "uri_deezer": "deezer://track/97309332",
       "alt_artists": [],
       "fun_fact": "Brathanki belongs to the Polish pop and rock canon; \"W Kinie W Lublinie - Kochaj Mnie\" (2000) features on this Polskie hity lat 90' 00' selection.",
@@ -1100,7 +1100,7 @@
         "pl": "applemusic://track/456542887"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=SG8B4DT6ud8",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/11460200",
       "uri_deezer": "deezer://track/13343356",
       "alt_artists": [],
       "fun_fact": "Brathanki belongs to the Polish pop and rock canon; \"Czerwone Korale\" (2000) features on this Polskie hity lat 90' 00' selection.",
@@ -1120,7 +1120,7 @@
         "pl": "applemusic://track/893775565"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=v5da1dgos7I",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/19231559",
       "uri_deezer": "deezer://track/62210507",
       "alt_artists": [],
       "fun_fact": "Ivan i Delfin belongs to the Polish pop and rock canon; \"Jej czarne oczy\" (2004) features on this Polskie hity lat 90' 00' selection.",
@@ -1140,7 +1140,7 @@
         "pl": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=Gm5xZOTtprI",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/19250403",
       "uri_deezer": "deezer://track/62222681",
       "alt_artists": [],
       "fun_fact": "Kancelaria belongs to the Polish pop and rock canon; \"Zabiorę cię\" (2012) features on this Polskie hity lat 90' 00' selection.",
@@ -1160,7 +1160,7 @@
         "pl": "applemusic://track/763151909"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=ZwucGN14j28",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/202683854",
       "uri_deezer": "deezer://track/1533644292",
       "alt_artists": [],
       "fun_fact": "Anna Wyszkoni belongs to the Polish pop and rock canon; \"Czy Ten Pan i Pani\" (2010) features on this Polskie hity lat 90' 00' selection.",
@@ -1180,7 +1180,7 @@
         "pl": "applemusic://track/1459344267"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=pnLSRvO8pJY",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/48983959",
       "uri_deezer": "deezer://track/103795434",
       "alt_artists": [],
       "fun_fact": "Dwa plus Jeden belongs to the Polish pop and rock canon; \"Chodź, Pomaluj Mój Świat\" (2015) features on this Polskie hity lat 90' 00' selection.",
@@ -1200,7 +1200,7 @@
         "pl": "applemusic://track/1072498217"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=OY9fYt8kQsM",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/38056271",
       "uri_deezer": "deezer://track/69533216",
       "alt_artists": [],
       "fun_fact": "Jeden Osiem L belongs to the Polish pop and rock canon; \"Jak zapomnieć\" (2014) features on this Polskie hity lat 90' 00' selection.",
@@ -1220,7 +1220,7 @@
         "pl": "applemusic://track/1442845749"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=OUaRbA1fYSg",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/60153753",
       "uri_deezer": "deezer://track/124600670",
       "alt_artists": [],
       "fun_fact": "Video belongs to the Polish pop and rock canon; \"Wszystko Jedno\" (2016) features on this Polskie hity lat 90' 00' selection.",
@@ -1240,7 +1240,7 @@
         "pl": "applemusic://track/1019522665"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=iNxDj-i-yi8",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/49215369",
       "uri_deezer": "deezer://track/104117900",
       "alt_artists": [],
       "fun_fact": "Yugoton, Kazik belongs to the Polish pop and rock canon; \"Malcziki\" (2011) features on this Polskie hity lat 90' 00' selection.",
@@ -1260,7 +1260,7 @@
         "pl": "applemusic://track/692568005"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=j8F1ar8KY5I",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/1561118",
       "uri_deezer": "deezer://track/3500118",
       "alt_artists": [],
       "fun_fact": "Jamal, Jambojet, USPM belongs to the Polish pop and rock canon; \"Policeman (feat. Jambojet, USPM)\" (2005) features on this Polskie hity lat 90' 00' selection.",
@@ -1280,7 +1280,7 @@
         "pl": "applemusic://track/690779955"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=brYLi4x8U7M",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/7195805",
       "uri_deezer": "deezer://track/12644316",
       "alt_artists": [],
       "fun_fact": "Video belongs to the Polish pop and rock canon; \"Środa Czwartek\" (2011) features on this Polskie hity lat 90' 00' selection.",
@@ -1300,7 +1300,7 @@
         "pl": "applemusic://track/648261923"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=BpS6xNrnMVc",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/20566380",
       "uri_deezer": null,
       "alt_artists": [],
       "fun_fact": "Poparzeni Kawą Trzy belongs to the Polish pop and rock canon; \"Kawałek Do Tańca\" (2011) features on this Polskie hity lat 90' 00' selection.",
@@ -1320,7 +1320,7 @@
         "pl": "applemusic://track/904039503"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=an-rlW6pRWo",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/129212550",
       "uri_deezer": "deezer://track/81811428",
       "alt_artists": [],
       "fun_fact": "T.Love belongs to the Polish pop and rock canon; \"Warszawa\" (1991) features on this Polskie hity lat 90' 00' selection.",
@@ -1340,7 +1340,7 @@
         "pl": "applemusic://track/988439227"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=IILOG6AWN_w",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/45211529",
       "uri_deezer": "deezer://track/99220062",
       "alt_artists": [],
       "fun_fact": "Perfect belongs to the Polish pop and rock canon; \"Nie Płacz Ewka\" (1981) features on this Polskie hity lat 90' 00' selection.",
@@ -1360,7 +1360,7 @@
         "pl": "applemusic://track/1481872523"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=nKOk8qHYg38",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/120556492",
       "uri_deezer": "deezer://track/780120082",
       "alt_artists": [],
       "fun_fact": "Felicjan Andrzejczak belongs to the Polish pop and rock canon; \"Jolka, Jolka Pamiętasz\" (2013) features on this Polskie hity lat 90' 00' selection.",


### PR DESCRIPTION
Eine Odesli-Welle, automatisch gefahren von `com.beatify.tidal-wave`.

- `polish-hits-90s-00s` Tidal 45 → **64**/92, version 0.7 → 0.8

Bilanz: 19 Treffer · 0 echte Misses · 30 Rate-Limit-Skips · 90 429-Zeilen.

**Draft mit Absicht** — Merge nur nach Markus' Freigabe.