### PR TITLE
chore(playlists): tidal backfill wave — +18 uris

### DIFF
--- a/custom_components/beatify/playlists/community/polish-hits-90s-00s.json
+++ b/custom_components/beatify/playlists/community/polish-hits-90s-00s.json
@@ -1,6 +1,6 @@
 {
   "name": "Polskie hity radiowe 🇵🇱",
-  "version": "0.8",
+  "version": "0.9",
   "tags": [
     "polish",
     "pop",
@@ -1380,7 +1380,7 @@
         "pl": "applemusic://track/1476307610"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=_21HqYAL_Ns",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/121289052",
       "uri_deezer": "deezer://track/74043625",
       "alt_artists": [],
       "fun_fact": "Skaldowie belongs to the Polish pop and rock canon; \"Wszystko Mi Mówi, Że Mnie Ktoś Pokochał\" (2008) features on this Polskie hity lat 90' 00' selection.",
@@ -1400,7 +1400,7 @@
         "pl": "applemusic://track/1712454081"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=mOMT20jLZ74",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/322472627",
       "uri_deezer": "deezer://track/1741989317",
       "alt_artists": [],
       "fun_fact": "Krzysztof Krawczyk belongs to the Polish pop and rock canon; \"Bo Jestes Ty\" (2016) features on this Polskie hity lat 90' 00' selection.",
@@ -1420,7 +1420,7 @@
         "pl": "applemusic://track/1485634113"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=3RAxJ9CDyWM",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/120557721",
       "uri_deezer": "deezer://track/780124912",
       "alt_artists": [],
       "fun_fact": "Ryszard Rynkowski belongs to the Polish pop and rock canon; \"Wypijmy za Błędy\" (2015) features on this Polskie hity lat 90' 00' selection.",
@@ -1440,7 +1440,7 @@
         "pl": "applemusic://track/1485457169"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=8Hlj0CRdSaY",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/121279794",
       "uri_deezer": "deezer://track/779748772",
       "alt_artists": [],
       "fun_fact": "Perfect belongs to the Polish pop and rock canon; \"Kołysanka dla Nieznajomej\" (1994) features on this Polskie hity lat 90' 00' selection.",
@@ -1480,7 +1480,7 @@
         "pl": "applemusic://track/1433949599"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=KenmwXMel7M",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/14276231",
       "uri_deezer": "deezer://track/17384393",
       "alt_artists": [],
       "fun_fact": "Bajm belongs to the Polish pop and rock canon; \"Ta sama chwila\" (1993) features on this Polskie hity lat 90' 00' selection.",
@@ -1500,7 +1500,7 @@
         "pl": "applemusic://track/1720216739"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=qxnCOXWs2WE",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/30010355",
       "uri_deezer": "deezer://track/78712207",
       "alt_artists": [],
       "fun_fact": "Elektryczne Gitary belongs to the Polish pop and rock canon; \"Dzieci wybiegły - 2014\" (2014) features on this Polskie hity lat 90' 00' selection.",
@@ -1520,7 +1520,7 @@
         "pl": "applemusic://track/1443595104"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=Wp57PXBB7Xg",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/7230139",
       "uri_deezer": "deezer://track/4670985",
       "alt_artists": [],
       "fun_fact": "Ich Troje belongs to the Polish pop and rock canon; \"Zawsze Z Toba Chcialbym Byc... (Przez Miesiac :) )\" (2001) features on this Polskie hity lat 90' 00' selection.",
@@ -1540,7 +1540,7 @@
         "pl": "applemusic://track/1834162140"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=RXM-9haRVl8",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/353918926",
       "uri_deezer": "deezer://track/2725815781",
       "alt_artists": [],
       "fun_fact": "Maryla Rodowicz belongs to the Polish pop and rock canon; \"To Już Było\" (2013) features on this Polskie hity lat 90' 00' selection.",
@@ -1560,7 +1560,7 @@
         "pl": "applemusic://track/1485460403"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=r1DYwBeYyvU",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/120555560",
       "uri_deezer": "deezer://track/791204912",
       "alt_artists": [],
       "fun_fact": "Kombi belongs to the Polish pop and rock canon; \"Nasze Rendez Vous\" (2008) features on this Polskie hity lat 90' 00' selection.",
@@ -1580,7 +1580,7 @@
         "pl": "applemusic://track/1164950994"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=xvFkSFt5_PQ",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/66093838",
       "uri_deezer": "deezer://track/135367470",
       "alt_artists": [],
       "fun_fact": "Krzysztof Krawczyk, Edyta Bartosiewicz belongs to the Polish pop and rock canon; \"Trudno tak (razem byc nam ze soba)\" (2016) features on this Polskie hity lat 90' 00' selection.",
@@ -1600,7 +1600,7 @@
         "pl": "applemusic://track/1484081003"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=7_zrUAn8TGE",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/120411967",
       "uri_deezer": "deezer://track/779301152",
       "alt_artists": [],
       "fun_fact": "Lady Pank belongs to the Polish pop and rock canon; \"Tacy Sami\" (2007) features on this Polskie hity lat 90' 00' selection.",
@@ -1620,7 +1620,7 @@
         "pl": "applemusic://track/692629907"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=C4IP98NDyO0",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/1200544",
       "uri_deezer": "deezer://track/3460007",
       "alt_artists": [],
       "fun_fact": "Feel belongs to the Polish pop and rock canon; \"No pokaż na co cię stać\" (2007) features on this Polskie hity lat 90' 00' selection.",
@@ -1640,7 +1640,7 @@
         "pl": "applemusic://track/1501151870"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=xEGrNHGXPdY",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/132862708",
       "uri_deezer": "deezer://track/3014377871",
       "alt_artists": [],
       "fun_fact": "Krzysztof Kiljański, Kayah belongs to the Polish pop and rock canon; \"Prócz Ciebie, Nic\" (2005) features on this Polskie hity lat 90' 00' selection.",
@@ -1660,7 +1660,7 @@
         "pl": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=UKsOkMNCURs",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/120555559",
       "uri_deezer": null,
       "alt_artists": [],
       "fun_fact": "Kombi belongs to the Polish pop and rock canon; \"Blackand White\" (2008) features on this Polskie hity lat 90' 00' selection.",
@@ -1680,7 +1680,7 @@
         "pl": "applemusic://track/688298093"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=tihDM9Jrc14",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/1459053",
       "uri_deezer": "deezer://track/3090337",
       "alt_artists": [],
       "fun_fact": "Reni Jusis belongs to the Polish pop and rock canon; \"Kiedyś Cię znajdę - Remastered\" (2003) features on this Polskie hity lat 90' 00' selection.",
@@ -1700,7 +1700,7 @@
         "pl": "applemusic://track/1678776177"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=G4FluV0hFgc",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/284668104",
       "uri_deezer": "deezer://track/2206552937",
       "alt_artists": [],
       "fun_fact": "Gabriel Fleszar belongs to the Polish pop and rock canon; \"Kroplą deszczu\" (2015) features on this Polskie hity lat 90' 00' selection.",
@@ -1720,7 +1720,7 @@
         "pl": "applemusic://track/1442614637"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=VG9H8p44tqU",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/60724019",
       "uri_deezer": "deezer://track/125517966",
       "alt_artists": [],
       "fun_fact": "Big Day belongs to the Polish pop and rock canon; \"W Dzień Gorącego Lata\" (1997) features on this Polskie hity lat 90' 00' selection.",
@@ -1740,7 +1740,7 @@
         "pl": "applemusic://track/688291345"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=zUt7iZ32FYU",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/1432735",
       "uri_deezer": "deezer://track/3102058",
       "alt_artists": [],
       "fun_fact": "Ryszard Rynkowski belongs to the Polish pop and rock canon; \"Za młodzi, za starzy\" (2000) features on this Polskie hity lat 90' 00' selection.",


### PR DESCRIPTION
Eine Odesli-Welle, automatisch gefahren von `com.beatify.tidal-wave`.

- `polish-hits-90s-00s` Tidal 64 → **82**/92, version 0.8 → 0.9

Bilanz: 18 Treffer · 1 echte Misses · 30 Rate-Limit-Skips · 90 429-Zeilen.

**Draft mit Absicht** — Merge nur nach Markus' Freigabe.