### PR TITLE
chore(playlists): tidal backfill wave — +18 uris

### DIFF
--- a/custom_components/beatify/playlists/community/polish-hits-90s-00s.json
+++ b/custom_components/beatify/playlists/community/polish-hits-90s-00s.json
@@ -1,6 +1,6 @@
 {
   "name": "Polskie hity radiowe 🇵🇱",
-  "version": "0.9",
+  "version": "0.10",
   "tags": [
     "polish",
     "pop",
@@ -1760,7 +1760,7 @@
         "pl": "applemusic://track/1443717579"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=XLsGlI3Dvzg",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/3675675",
       "uri_deezer": "deezer://track/4673679",
       "alt_artists": [],
       "fun_fact": "Kasia Kowalska belongs to the Polish pop and rock canon; \"To co dobre\" (2004) features on this Polskie hity lat 90' 00' selection.",
@@ -1780,7 +1780,7 @@
         "pl": "applemusic://track/1802946633"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=_ktXGlYGh6w",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/1566643",
       "uri_deezer": "deezer://track/3477537",
       "alt_artists": [],
       "fun_fact": "Goya belongs to the Polish pop and rock canon; \"Smak słów\" (2005) features on this Polskie hity lat 90' 00' selection.",
@@ -1800,7 +1800,7 @@
         "pl": "applemusic://track/285146610"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=Fk4oL5yGVQI",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/1701046",
       "uri_deezer": "deezer://track/1092961",
       "alt_artists": [],
       "fun_fact": "Brodka belongs to the Polish pop and rock canon; \"Znam cie na pamiec\" (2006) features on this Polskie hity lat 90' 00' selection.",
@@ -1820,7 +1820,7 @@
         "pl": "applemusic://track/691284703"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=xJ5z8gFco3o",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/1570765",
       "uri_deezer": "deezer://track/3089295",
       "alt_artists": [],
       "fun_fact": "Blue Cafe belongs to the Polish pop and rock canon; \"Do nieba, do piekła\" (2003) features on this Polskie hity lat 90' 00' selection.",
@@ -1840,7 +1840,7 @@
         "pl": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=ZEtkY59TUwk",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/234485187",
       "uri_deezer": null,
       "alt_artists": [],
       "fun_fact": "Andrzej Piaseczny belongs to the Polish pop and rock canon; \"Sniadanie do lozka\" (2016) features on this Polskie hity lat 90' 00' selection.",
@@ -1860,7 +1860,7 @@
         "pl": "applemusic://track/1443754401"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=LWE6rwKCC80",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/3616245",
       "uri_deezer": "deezer://track/4672745",
       "alt_artists": [],
       "fun_fact": "Kasia Kowalska belongs to the Polish pop and rock canon; \"Spowiedz\" (2008) features on this Polskie hity lat 90' 00' selection.",
@@ -1880,7 +1880,7 @@
         "pl": "applemusic://track/339038396"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=8_icFGaCtsc",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/49156748",
       "uri_deezer": "deezer://track/103885124",
       "alt_artists": [],
       "fun_fact": "Brodka belongs to the Polish pop and rock canon; \"Dziewczyna Mojego Chlopaka\" (2004) features on this Polskie hity lat 90' 00' selection.",
@@ -1900,7 +1900,7 @@
         "pl": "applemusic://track/883323366"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=-ufEXTzM77E",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/30236960",
       "uri_deezer": "deezer://track/78977394",
       "alt_artists": [],
       "fun_fact": "Anita Lipnicka belongs to the Polish pop and rock canon; \"I wszystko się może zdarzyć\" (1996) features on this Polskie hity lat 90' 00' selection.",

--- a/custom_components/beatify/playlists/community/polish-rock.json
+++ b/custom_components/beatify/playlists/community/polish-rock.json
@@ -1,6 +1,6 @@
 {
   "name": "Polski Rock",
-  "version": "0.5",
+  "version": "0.6",
   "tags": [
     "polish",
     "rock"
@@ -522,7 +522,7 @@
         "it": "applemusic://track/767893096"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=tAKHWJTofP0",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/23965388",
       "uri_deezer": "deezer://track/72999262",
       "alt_artists": [],
       "fun_fact": "Małgorzata Ostrowska is part of Poland's rock scene, and 'Szklana pogoda' (2001) features on this Polish rock playlist.",
@@ -548,7 +548,7 @@
         "it": "applemusic://track/6764462264"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=OAxSu8T_07g",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/519279697",
       "uri_deezer": "deezer://track/3986080281",
       "alt_artists": [],
       "fun_fact": "Kuba Kubiak is part of Poland's rock scene, and '1996' (2026) features on this Polish rock playlist.",
@@ -574,7 +574,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=SpBWPZN1uCg",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/518636137",
       "uri_deezer": "deezer://track/3981328981",
       "alt_artists": [],
       "fun_fact": "Szymon Wydra is part of Poland's rock scene, and 'Wciąż mamy moc' (2026) features on this Polish rock playlist.",
@@ -600,7 +600,7 @@
         "it": "applemusic://track/1386254006"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=gOAaBEeUy_I",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/89024759",
       "uri_deezer": "deezer://track/503929412",
       "alt_artists": [],
       "fun_fact": "Wilki is a Polish rock band led by Robert Gawlinski, and 'Eli Lama Sabachtani' (1992) features on this Polish rock playlist.",
@@ -626,7 +626,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=o2JUFe9sND4",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/506470685",
       "uri_deezer": "deezer://track/3896676001",
       "alt_artists": [],
       "fun_fact": "Lao Che is a Polish rock band known for its concept albums, and 'Wojenka' (2015) features on this Polish rock playlist.",
@@ -652,7 +652,7 @@
         "it": "applemusic://track/6764351284"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=JiKSwRgtRrI",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/519490013",
       "uri_deezer": "deezer://track/3987363771",
       "alt_artists": [],
       "fun_fact": "Kindred Sūn is part of Poland's rock scene, and 'Still Overthinking' (2026) features on this Polish rock playlist.",
@@ -678,7 +678,7 @@
         "it": "applemusic://track/1859614486"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=xAJjY0Et9cQ",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/67250719",
       "uri_deezer": "deezer://track/135930350",
       "alt_artists": [],
       "fun_fact": "Męskie Granie Orkiestra is part of Poland's rock scene, and 'Co Mi Panie Dasz' (2016) features on this Polish rock playlist.",
@@ -704,7 +704,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=19FMN7kMh3I",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/132446675",
       "uri_deezer": "deezer://track/887115842",
       "alt_artists": [],
       "fun_fact": "Stach Bukowski is part of Poland's rock scene, and 'Noc' (2020) features on this Polish rock playlist.",
@@ -834,7 +834,7 @@
         "it": "applemusic://track/1481885572"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=4cgSqCyoj1A",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/121024710",
       "uri_deezer": "deezer://track/785903502",
       "alt_artists": [],
       "fun_fact": "Tilt is a Polish rock band co-founded by Tomasz Lipinski, and 'Mówię ci, że' (2000) features on this Polish rock playlist.",
@@ -1250,7 +1250,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/58381215",
       "uri_deezer": "deezer://track/84656155",
       "alt_artists": [],
       "fun_fact": "Lombard is a Polish rock band formed in Poznan in the early 1980s, and 'Szklana Pogoda' (2016) features on this Polish rock playlist.",


### PR DESCRIPTION
Eine Odesli-Welle, automatisch gefahren von `com.beatify.tidal-wave`.

- `polish-hits-90s-00s` Tidal 82 → **90**/92, version 0.9 → 0.10
- `polish-rock` Tidal 37 → **47**/100, version 0.5 → 0.6

Bilanz: 18 Treffer · 1 echte Misses · 29 Rate-Limit-Skips · 87 429-Zeilen.

**Draft mit Absicht** — Merge nur nach Markus' Freigabe.