### PR TITLE
chore(playlists): tidal backfill wave — +19 uris

### DIFF
--- a/custom_components/beatify/playlists/community/polish-rock.json
+++ b/custom_components/beatify/playlists/community/polish-rock.json
@@ -1,6 +1,6 @@
 {
   "name": "Polski Rock",
-  "version": "0.6",
+  "version": "0.7",
   "tags": [
     "polish",
     "rock"
@@ -1276,7 +1276,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/58809820",
       "uri_deezer": "deezer://track/121736688",
       "alt_artists": [],
       "fun_fact": "Happysad is a Polish rock band formed in Skarzysko-Kamienna, and 'Zanim pójdę' (2004) features on this Polish rock playlist.",
@@ -1302,7 +1302,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/380811020",
       "uri_deezer": "deezer://track/2944342101",
       "alt_artists": [],
       "fun_fact": "Krzysztof Zalewski is a Polish rock singer-songwriter, and 'Edith Piaf' (2024) features on this Polish rock playlist.",
@@ -1328,7 +1328,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/451248631",
       "uri_deezer": "deezer://track/3484821611",
       "alt_artists": [],
       "fun_fact": "WaluśKraksaKryzys is part of Poland's rock scene, and 'NAJGORSZE RZECZY' (2021) features on this Polish rock playlist.",
@@ -1354,7 +1354,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/188278636",
       "uri_deezer": "deezer://track/1780668827",
       "alt_artists": [],
       "fun_fact": "KARAŚ/ROGUCKI is part of Poland's rock scene, and 'Jutro Spróbujemy Jeszcze Raz' (2022) features on this Polish rock playlist.",
@@ -1380,7 +1380,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/182000542",
       "uri_deezer": "deezer://track/1355108062",
       "alt_artists": [],
       "fun_fact": "Bluszcz is part of Poland's rock scene, and 'Lamparty' (2020) features on this Polish rock playlist.",
@@ -1406,7 +1406,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/440545776",
       "uri_deezer": "deezer://track/3404758141",
       "alt_artists": [],
       "fun_fact": "Hey is a Polish rock band fronted by Katarzyna Nosowska, and 'Bezruch' (2025) features on this Polish rock playlist.",
@@ -1432,7 +1432,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/14275444",
       "uri_deezer": "deezer://track/17384386",
       "alt_artists": [],
       "fun_fact": "Bajm is a Polish pop-rock band fronted by Beata Kozidrak, and 'Biała armia' (1990) features on this Polish rock playlist.",
@@ -1458,7 +1458,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/371874667",
       "uri_deezer": "deezer://track/2866833622",
       "alt_artists": [],
       "fun_fact": "Nosowska is part of Poland's rock scene, and 'Błyszcz' (2024) features on this Polish rock playlist.",
@@ -1484,7 +1484,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/19235868",
       "uri_deezer": "deezer://track/62213305",
       "alt_artists": [],
       "fun_fact": "Robert Gawlinski is part of Poland's rock scene, and 'Nie stało się nic' (1997) features on this Polish rock playlist.",
@@ -1510,7 +1510,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/45211522",
       "uri_deezer": "deezer://track/99220048",
       "alt_artists": [],
       "fun_fact": "Perfect is a Polish rock band that rose to fame in the early 1980s, and 'Chcemy Być Sobą' (1981) features on this Polish rock playlist.",
@@ -1536,7 +1536,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/129212575",
       "uri_deezer": "deezer://track/81811430",
       "alt_artists": [],
       "fun_fact": "T.Love is a Polish rock band led by Muniek Staszczyk, and 'King' (1992) features on this Polish rock playlist.",
@@ -1562,7 +1562,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/164662285",
       "uri_deezer": "deezer://track/2451841985",
       "alt_artists": [],
       "fun_fact": "Luxtorpeda is a Polish rock band founded by Robert Friedrich, and 'AUTYSTYCZNY' (2011) features on this Polish rock playlist.",
@@ -1588,7 +1588,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/30987731",
       "uri_deezer": "deezer://track/3090202",
       "alt_artists": [],
       "fun_fact": "Dżem is a Polish blues-rock band from Silesia, and 'Wehikuł Czasu' (1998) features on this Polish rock playlist.",
@@ -1614,7 +1614,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/120480224",
       "uri_deezer": "deezer://track/779754482",
       "alt_artists": [],
       "fun_fact": "Budka Suflera is a long-running Polish rock band founded in Lublin in 1974, and 'Za ostatni grosz' (2003) features on this Polish rock playlist.",
@@ -1640,7 +1640,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/14556702",
       "uri_deezer": "deezer://track/65120943",
       "alt_artists": [],
       "fun_fact": "Hey is a Polish rock band fronted by Katarzyna Nosowska, and 'Zazdrosc' (1993) features on this Polish rock playlist.",
@@ -1666,7 +1666,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/18341459",
       "uri_deezer": "deezer://track/859096652",
       "alt_artists": [],
       "fun_fact": "Happysad is a Polish rock band formed in Skarzysko-Kamienna, and 'Mów mi dobrze' (2009) features on this Polish rock playlist.",
@@ -1692,7 +1692,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/31128311",
       "uri_deezer": "deezer://track/79221169",
       "alt_artists": [],
       "fun_fact": "IRA is a Polish rock band formed in Radom in the late 1980s, and 'Nadzieja' (1991) features on this Polish rock playlist.",
@@ -1718,7 +1718,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/368676367",
       "uri_deezer": "deezer://track/2843259882",
       "alt_artists": [],
       "fun_fact": "Wojtek Szumański is part of Poland's rock scene, and 'Kołowrotek' (2024) features on this Polish rock playlist.",
@@ -1744,7 +1744,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/189186088",
       "uri_deezer": "deezer://track/1675175377",
       "alt_artists": [],
       "fun_fact": "Jakub Skorupa is part of Poland's rock scene, and 'Pociągi towarowe' (2022) features on this Polish rock playlist.",


### PR DESCRIPTION
Eine Odesli-Welle, automatisch gefahren von `com.beatify.tidal-wave`.

- `polish-rock` Tidal 47 → **66**/100, version 0.6 → 0.7

Bilanz: 19 Treffer · 0 echte Misses · 29 Rate-Limit-Skips · 87 429-Zeilen.

**Draft mit Absicht** — Merge nur nach Markus' Freigabe.