### PR TITLE
chore(playlists): tidal backfill wave — +19 uris

### DIFF
--- a/custom_components/beatify/playlists/community/polish-rock.json
+++ b/custom_components/beatify/playlists/community/polish-rock.json
@@ -1,6 +1,6 @@
 {
   "name": "Polski Rock",
-  "version": "0.7",
+  "version": "0.8",
   "tags": [
     "polish",
     "rock"
@@ -1770,7 +1770,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/121298389",
       "uri_deezer": "deezer://track/782776642",
       "alt_artists": [],
       "fun_fact": "Klaus Mitffoch is part of Poland's rock scene, and 'Jezu jak się cieszę' (2005) features on this Polish rock playlist.",
@@ -1796,7 +1796,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/60793321",
       "uri_deezer": "deezer://track/125193088",
       "alt_artists": [],
       "fun_fact": "Happysad is a Polish rock band formed in Skarzysko-Kamienna, and 'Łydka' (2005) features on this Polish rock playlist.",
@@ -1822,7 +1822,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/327338484",
       "uri_deezer": "deezer://track/2255981657",
       "alt_artists": [],
       "fun_fact": "Dziwna Wiosna is part of Poland's rock scene, and 'Płonę, płonę' (2023) features on this Polish rock playlist.",
@@ -1848,7 +1848,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/419236038",
       "uri_deezer": "deezer://track/3244730391",
       "alt_artists": [],
       "fun_fact": "Jacko Brango is part of Poland's rock scene, and 'Pod powierzchnią' (2025) features on this Polish rock playlist.",
@@ -1874,7 +1874,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/1448225",
       "uri_deezer": "deezer://track/3295158",
       "alt_artists": [],
       "fun_fact": "Republika is a Polish new wave and rock band formed in Torun in 1981 and led by Grzegorz Ciechowski, and 'Mamona' (1998) features on this Polish rock playlist.",
@@ -1900,7 +1900,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/1514526",
       "uri_deezer": "deezer://track/3355147",
       "alt_artists": [],
       "fun_fact": "Maanam is a Polish rock band fronted by Kora, one of the defining acts of 1980s Polish rock, and 'Szare miraże' (1995) features on this Polish rock playlist.",
@@ -1926,7 +1926,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/45211527",
       "uri_deezer": "deezer://track/99220058",
       "alt_artists": [],
       "fun_fact": "Perfect is a Polish rock band that rose to fame in the early 1980s, and 'Ale Wkoło Jest Wesoło' (1981) features on this Polish rock playlist.",
@@ -1952,7 +1952,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/120747814",
       "uri_deezer": "deezer://track/782048332",
       "alt_artists": [],
       "fun_fact": "Sztywny Pal Azji is a Polish rock band active since the 1980s, and 'Spotkanie z...' (2001) features on this Polish rock playlist.",
@@ -1978,7 +1978,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/14556712",
       "uri_deezer": "deezer://track/17466931",
       "alt_artists": [],
       "fun_fact": "Hey is a Polish rock band fronted by Katarzyna Nosowska, and 'Teksanski' (1993) features on this Polish rock playlist.",
@@ -2004,7 +2004,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/388353851",
       "uri_deezer": "deezer://track/2806912642",
       "alt_artists": [],
       "fun_fact": "Zabłocki Osobiście is part of Poland's rock scene, and 'Ławeczka' (2024) features on this Polish rock playlist.",
@@ -2030,7 +2030,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/253315610",
       "uri_deezer": "deezer://track/1959068947",
       "alt_artists": [],
       "fun_fact": "Voo Voo is a Polish rock band led by Wojciech Waglewski, and 'Beztrosko' (2022) features on this Polish rock playlist.",
@@ -2056,7 +2056,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/121304957",
       "uri_deezer": "deezer://track/792031932",
       "alt_artists": [],
       "fun_fact": "Mr. Zoob is part of Poland's rock scene, and 'Mój jest ten kawałek podłogi' (2011) features on this Polish rock playlist.",
@@ -2082,7 +2082,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/1491662",
       "uri_deezer": "deezer://track/3218727",
       "alt_artists": [],
       "fun_fact": "Wilki is a Polish rock band led by Robert Gawlinski, and 'Bohema' (2005) features on this Polish rock playlist.",
@@ -2108,7 +2108,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/215759828",
       "uri_deezer": "deezer://track/1638003802",
       "alt_artists": [],
       "fun_fact": "Żurkowski is part of Poland's rock scene, and 'Western' (2022) features on this Polish rock playlist.",
@@ -2134,7 +2134,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/121279474",
       "uri_deezer": "deezer://track/74895995",
       "alt_artists": [],
       "fun_fact": "Perfect is a Polish rock band that rose to fame in the early 1980s, and 'Idź precz!' (2003) features on this Polish rock playlist.",
@@ -2160,7 +2160,7 @@
         "it": "applemusic://track/1699412396"
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/307321411",
       "uri_deezer": "deezer://track/2384257145",
       "alt_artists": [],
       "fun_fact": "Męskie Granie Orkiestra is part of Poland's rock scene, and 'Wataha' (2016) features on this Polish rock playlist.",
@@ -2186,7 +2186,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/54604628",
       "uri_deezer": "deezer://track/114010986",
       "alt_artists": [],
       "fun_fact": "Breakout is a Polish blues-rock band led by Tadeusz Nalepa, active from the late 1960s, and 'Oni zaraz przyjdą tu' (1971) features on this Polish rock playlist.",
@@ -2212,7 +2212,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/128624319",
       "uri_deezer": "deezer://track/855275872",
       "alt_artists": [],
       "fun_fact": "KARAŚ/ROGUCKI is part of Poland's rock scene, and 'Bolesne strzały w serce' (2020) features on this Polish rock playlist.",
@@ -2238,7 +2238,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/58810065",
       "uri_deezer": "deezer://track/121736180",
       "alt_artists": [],
       "fun_fact": "Kult is a Polish rock band led by Kazik Staszewski, and 'Baranek' (1993) features on this Polish rock playlist.",


### PR DESCRIPTION
Eine Odesli-Welle, automatisch gefahren von `com.beatify.tidal-wave`.

- `polish-rock` Tidal 66 → **85**/100, version 0.7 → 0.8

Bilanz: 19 Treffer · 0 echte Misses · 29 Rate-Limit-Skips · 87 429-Zeilen.

**Draft mit Absicht** — Merge nur nach Markus' Freigabe.