### PR TITLE
chore(playlists): tidal backfill wave — +18 uris

### DIFF
--- a/custom_components/beatify/playlists/community/polish-rock.json
+++ b/custom_components/beatify/playlists/community/polish-rock.json
@@ -1,6 +1,6 @@
 {
   "name": "Polski Rock",
-  "version": "0.8",
+  "version": "0.9",
   "tags": [
     "polish",
     "rock"
@@ -2264,7 +2264,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/1459397",
       "uri_deezer": "deezer://track/79590766",
       "alt_artists": [],
       "fun_fact": "Dżem is a Polish blues-rock band from Silesia, and 'Naiwne pytania' (2003) features on this Polish rock playlist.",
@@ -2290,7 +2290,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/65051086",
       "uri_deezer": "deezer://track/132429046",
       "alt_artists": [],
       "fun_fact": "Farben Lehre is part of Poland's rock scene, and 'Anioły i Demony' (2012) features on this Polish rock playlist.",
@@ -2316,7 +2316,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/425361261",
       "uri_deezer": "deezer://track/3287068531",
       "alt_artists": [],
       "fun_fact": "Łydka Grubasa is part of Poland's rock scene, and 'Wzięli zamknęli mi klub' (2023) features on this Polish rock playlist.",
@@ -2342,7 +2342,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/58810110",
       "uri_deezer": "deezer://track/121736400",
       "alt_artists": [],
       "fun_fact": "KULT is a Polish rock band led by Kazik Staszewski, and 'Polska' (2016) features on this Polish rock playlist.",
@@ -2368,7 +2368,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/58810129",
       "uri_deezer": "deezer://track/121736510",
       "alt_artists": [],
       "fun_fact": "Kult is a Polish rock band led by Kazik Staszewski, and 'Gdy nie ma dzieci' (1998) features on this Polish rock playlist.",
@@ -2394,7 +2394,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/494852618",
       "uri_deezer": "deezer://track/3815619752",
       "alt_artists": [],
       "fun_fact": "Spięty is part of Poland's rock scene, and 'Zapalenie Przedrostka' (2026) features on this Polish rock playlist.",
@@ -2420,7 +2420,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/101293696",
       "uri_deezer": "deezer://track/606654752",
       "alt_artists": [],
       "fun_fact": "El Dupa is part of Poland's rock scene, and 'Natalia w Bruklinie odc. 1' (2000) features on this Polish rock playlist.",
@@ -2446,7 +2446,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/120480753",
       "uri_deezer": "deezer://track/779745992",
       "alt_artists": [],
       "fun_fact": "Lady Pank is a Polish rock band formed in 1982, and 'Kryzysowa narzeczona' (2003) features on this Polish rock playlist.",
@@ -2472,7 +2472,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/59362143",
       "uri_deezer": "deezer://track/122778052",
       "alt_artists": [],
       "fun_fact": "Pidżama Porno is a Polish punk rock band led by Krzysztof Grabowski, and 'Ezoteryczny Poznań' (2007) features on this Polish rock playlist.",
@@ -2498,7 +2498,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/451340049",
       "uri_deezer": "deezer://track/3487494801",
       "alt_artists": [],
       "fun_fact": "Aleksander Szalonek is part of Poland's rock scene, and 'Płyń' (2025) features on this Polish rock playlist.",
@@ -2524,7 +2524,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/465676763",
       "uri_deezer": "deezer://track/3592565352",
       "alt_artists": [],
       "fun_fact": "Miro Kepinski is part of Poland's rock scene, and 'Szklana Góra' (2025) features on this Polish rock playlist.",
@@ -2550,7 +2550,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/120747819",
       "uri_deezer": "deezer://track/782048382",
       "alt_artists": [],
       "fun_fact": "Sztywny Pal Azji is a Polish rock band active since the 1980s, and 'Nieprzemakalni' (2001) features on this Polish rock playlist.",
@@ -2576,7 +2576,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/389745865",
       "uri_deezer": "deezer://track/3017689761",
       "alt_artists": [],
       "fun_fact": "Edyta Bartosiewicz is a Polish rock singer-songwriter of the 1990s, and 'Koziorożec' (1994) features on this Polish rock playlist.",
@@ -2602,7 +2602,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/121024756",
       "uri_deezer": "deezer://track/785902672",
       "alt_artists": [],
       "fun_fact": "Brygada Kryzys is a Polish punk and new wave band from the early 1980s, and 'To co czujesz, to co wiesz' (2000) features on this Polish rock playlist.",

--- a/custom_components/beatify/playlists/community/quebecois-1990-2020.json
+++ b/custom_components/beatify/playlists/community/quebecois-1990-2020.json
@@ -1,6 +1,6 @@
 {
   "name": "🍁 Québécois 1990-2020",
-  "version": "0.4",
+  "version": "0.5",
   "tags": [
     "quebecois",
     "quebec",
@@ -33,7 +33,7 @@
         "it": "applemusic://track/1589126538"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=sYRp8oP0yiw",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/155500118",
       "uri_deezer": "deezer://track/1082531032",
       "alt_artists": [
         "Charlotte Cardin, CRi",
@@ -63,7 +63,7 @@
         "it": "applemusic://track/1551597580"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=A5KXY5Ssy5E",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/62849800",
       "uri_deezer": "deezer://track/128228065",
       "alt_artists": [
         "Les Colocs",
@@ -93,7 +93,7 @@
         "it": "applemusic://track/1849697499"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=15rawe3WVWw",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/470392782",
       "uri_deezer": "deezer://track/3629522802",
       "alt_artists": [
         "Éric Lapointe",
@@ -123,7 +123,7 @@
         "it": "applemusic://track/1551615128"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=D_GJnIeyukI",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/62851053",
       "uri_deezer": "deezer://track/128237727",
       "alt_artists": [
         "Fred Fortin",


### PR DESCRIPTION
Eine Odesli-Welle, automatisch gefahren von `com.beatify.tidal-wave`.

- `polish-rock` Tidal 85 → **99**/100, version 0.8 → 0.9
- `quebecois-1990-2020` Tidal 18 → **22**/126, version 0.4 → 0.5

Bilanz: 18 Treffer · 1 echte Misses · 30 Rate-Limit-Skips · 88 429-Zeilen.

**Draft mit Absicht** — Merge nur nach Markus' Freigabe.