### PR TITLE
fix(reset): force-reset drops the persisted setup blob (#2036)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to Beatify are documented here. For detailed release notes, 
 
 ## [Unreleased]
 
+### Fixed
+- **Reset on the host screen now really lands on step 1 of the wizard (#2036).** Reported by **@mholzi** from the ready-to-host screen. Both halves of the reset did what their code said: the browser dropped its seven `beatify_*` keys and reloaded, the server ended the running game. Nobody dropped the persisted setup blob, so the reload asked `/beatify/api/status`, got `setup_complete: true` back, and `reconcileSavedSetup()` wrote the saved speaker into the storage that had just been emptied — the "server wins" rule from #1927, applied to a client that had cleared itself on purpose. `shouldTrigger()` saw a configured host, kept the wizard shut, and `BeatifyHome` opened a fresh lobby: the exact screen the host had pressed Reset to leave. `ForceResetView` now deletes the blob as well, so there is nothing left to re-seed from. The reset therefore spans the whole installation rather than one device, which follows from it already ending the game for everyone. Twelve new tests, including that a failed delete still returns a usable response and that a rate-limited or unauthorized call leaves the blob untouched.
+
 ### Added
 - **Polskie hity radiowe 🇵🇱 — 92 tracks (#1891).** Polish pop and rock radio hits spanning 1972-2016, with the heart of the collection in the 1990s and 2000s (75 of 92 tracks). The third Polish playlist alongside Polskie przeboje wszech czasów and Polski Rock; seven tracks already curated in those two were dropped as duplicates, so the catalogue gains 92 genuinely new songs rather than 100 with overlap.
 

--- a/custom_components/beatify/server/game_views.py
+++ b/custom_components/beatify/server/game_views.py
@@ -43,6 +43,7 @@ from custom_components.beatify.server.companion_auth import is_authorized_http
 from custom_components.beatify.server.serializers import (
     build_state_message,
 )
+from custom_components.beatify.server.setup_state import clear_setup
 from custom_components.beatify.server.ws_handlers.admin import _finalize_and_end
 from custom_components.beatify.services.media_player import (
     async_get_native_twin_remap,
@@ -555,6 +556,16 @@ class ForceResetView(RateLimitMixin, HomeAssistantView):
     per-game admin token — any household HA user can unwedge stuck state —
     so the old "you might not have a valid token" rationale no longer
     applies. Still rate-limited per IP to prevent DoS abuse.
+
+    #2036: the reset also drops the persisted setup blob. The client half of
+    the reset clears ``localStorage`` and reloads, but the server kept
+    reporting ``setup_complete: true`` — and ``reconcileSavedSetup()`` wrote
+    the saved speaker straight back into the emptied storage on that same
+    load, so the wizard stayed shut and the host landed on the ready-to-host
+    screen again. The reset therefore spans the whole installation, not just
+    the device that pressed it; that follows from it already ending the
+    running game for everyone, and the confirm dialog plus the 3/hour rate
+    limit sit in front of it.
     """
 
     url = "/beatify/api/force-reset"
@@ -599,7 +610,24 @@ class ForceResetView(RateLimitMixin, HomeAssistantView):
                 except Exception:  # noqa: BLE001
                     _LOGGER.exception("force-reset: WS broadcast raised; continuing")
 
-        return web.json_response({"success": True, "ended_game_id": ended_game_id})
+        # #2036: drop the persisted setup blob so the reloading client really
+        # comes up unconfigured. Failures here must not swallow the rest of the
+        # recovery — the caller is stuck and the game is already ended.
+        cleared_setup = False
+        try:
+            cleared_setup = await self.hass.async_add_executor_job(
+                clear_setup, self.hass
+            )
+        except OSError:
+            _LOGGER.exception("force-reset: clearing the setup blob failed; continuing")
+
+        return web.json_response(
+            {
+                "success": True,
+                "ended_game_id": ended_game_id,
+                "cleared_setup": cleared_setup,
+            }
+        )
 
 
 class RematchGameView(HomeAssistantView):

--- a/custom_components/beatify/server/setup_state.py
+++ b/custom_components/beatify/server/setup_state.py
@@ -55,3 +55,25 @@ def write_setup(hass: HomeAssistant, blob: dict[str, Any]) -> None:
     path = _setup_path(hass)
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(blob, indent=2, ensure_ascii=False), encoding="utf-8")
+
+
+def clear_setup(hass: HomeAssistant) -> bool:
+    """Delete the persisted setup blob (blocking I/O). Returns whether one existed.
+
+    #2036: the force-reset escape hatch clears the host's ``localStorage`` and
+    reloads, but the blob written here survived — and ``reconcileSavedSetup()``
+    then wrote the speaker straight back into the freshly emptied storage on the
+    very next page load (the "server wins" rule from #1927). The wizard's
+    ``shouldTrigger()`` saw a configured host again and stayed shut, so a reset
+    landed back on the ready-to-host screen it was supposed to leave.
+
+    Deleting the file rather than writing ``{}`` keeps a single notion of
+    "nothing saved": ``read_setup`` already returns ``None`` for a missing file,
+    so no caller needs to learn a second empty shape.
+    """
+    path = _setup_path(hass)
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        return False
+    return True

--- a/custom_components/beatify/www/js/admin/sections/force-reset.js
+++ b/custom_components/beatify/www/js/admin/sections/force-reset.js
@@ -49,6 +49,12 @@ async function confirmReset() {
     closeResetModal();
 
     // 1. Hit the server, but don't block local cleanup on its result.
+    //    #2036: this POST is also what makes the wizard reappear. It drops the
+    //    persisted setup blob; without that the reload re-seeds the speaker we
+    //    are about to delete below (reconcileSavedSetup, "server wins" per
+    //    #1927) and the host lands back on the ready-to-host screen. If the
+    //    call fails we still clear + reload, as before — the reset is then
+    //    only as good as it was, not worse.
     try {
         await BeatifyAuth.fetch('/beatify/api/force-reset', { method: 'POST' });
     } catch (err) {

--- a/tests/unit/test_force_reset_setup_clear_2036.py
+++ b/tests/unit/test_force_reset_setup_clear_2036.py
@@ -1,0 +1,231 @@
+"""Force-reset must also drop the persisted setup blob (#2036).
+
+Pressing Reset on the host screen cleared the browser's ``localStorage`` and
+reloaded — but the server kept its setup blob, so ``/beatify/api/status`` still
+reported ``setup_complete: true`` and ``reconcileSavedSetup()`` wrote the saved
+speaker straight back into the emptied storage on the very same load. The
+wizard's ``shouldTrigger()`` then saw a configured host, stayed shut, and
+``BeatifyHome`` opened a fresh lobby — the screen the reset was meant to leave.
+
+These tests pin the server half of the fix: after a force-reset there is no
+blob left for the reload to re-seed from.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from unittest import mock
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from aiohttp.test_utils import make_mocked_request
+
+from custom_components.beatify.const import DOMAIN
+from custom_components.beatify.server.game_views import ForceResetView
+from custom_components.beatify.server.setup_state import (
+    clear_setup,
+    read_setup,
+    write_setup,
+)
+
+
+CONFIGURED_BLOB = {
+    "last_player": "media_player.esszimmer",
+    "game_settings": {"selectedPlaylists": [{"path": "80s.json"}]},
+}
+
+
+def _hass(tmp_path: Path) -> MagicMock:
+    """A hass double whose config dir is `tmp_path` and whose executor is inline."""
+    hass = MagicMock()
+    # _setup_path() resolves to hass.config.path("beatify") / "setup.json".
+    hass.config.path = MagicMock(return_value=str(tmp_path / "beatify"))
+    hass.async_add_executor_job = AsyncMock(side_effect=lambda fn, *args: fn(*args))
+    # No active game — the interesting half of this view is the blob, and a
+    # stuck instance often has no game left to end anyway.
+    hass.data = {DOMAIN: {}}
+    return hass
+
+
+def _authorized():
+    return mock.patch(
+        "custom_components.beatify.server.game_views.is_authorized_http",
+        new=MagicMock(return_value=True),
+    )
+
+
+def _request():
+    return make_mocked_request("POST", "/beatify/api/force-reset")
+
+
+def _post(view: ForceResetView):
+    """Drive the async handler from a sync test."""
+    return asyncio.run(view.post(_request()))
+
+
+# ---------------------------------------------------------------- clear_setup
+
+
+def test_clear_setup_removes_the_blob(tmp_path: Path) -> None:
+    hass = _hass(tmp_path)
+    write_setup(hass, CONFIGURED_BLOB)
+    assert read_setup(hass) == CONFIGURED_BLOB
+
+    assert clear_setup(hass) is True
+    # read_setup already means "nothing saved" by returning None for a missing
+    # file — no second empty shape for callers to special-case.
+    assert read_setup(hass) is None
+
+
+def test_clear_setup_on_pristine_install_is_a_no_op(tmp_path: Path) -> None:
+    """Never configured, or reset twice — neither may raise."""
+    hass = _hass(tmp_path)
+    assert clear_setup(hass) is False
+    assert read_setup(hass) is None
+
+
+def test_clear_setup_is_idempotent(tmp_path: Path) -> None:
+    hass = _hass(tmp_path)
+    write_setup(hass, CONFIGURED_BLOB)
+
+    assert clear_setup(hass) is True
+    assert clear_setup(hass) is False
+
+
+# ------------------------------------------------------------ ForceResetView
+
+
+def test_force_reset_clears_a_configured_setup(tmp_path: Path) -> None:
+    """The regression: after the POST the instance reports unconfigured."""
+    hass = _hass(tmp_path)
+    write_setup(hass, CONFIGURED_BLOB)
+    view = ForceResetView(hass)
+
+    with _authorized():
+        response = _post(view)
+
+    assert response.status == 200
+    assert read_setup(hass) is None
+
+
+def test_force_reset_reports_what_it_cleared(tmp_path: Path) -> None:
+    hass = _hass(tmp_path)
+    write_setup(hass, CONFIGURED_BLOB)
+    view = ForceResetView(hass)
+
+    with _authorized():
+        response = _post(view)
+
+    assert b'"cleared_setup": true' in response.body
+
+
+def test_force_reset_succeeds_without_a_saved_setup(tmp_path: Path) -> None:
+    """Nothing saved is a normal state, not an error."""
+    hass = _hass(tmp_path)
+    view = ForceResetView(hass)
+
+    with _authorized():
+        response = _post(view)
+
+    assert response.status == 200
+    assert b'"success": true' in response.body
+    assert b'"cleared_setup": false' in response.body
+
+
+def test_force_reset_survives_an_unwritable_config_dir(tmp_path: Path) -> None:
+    """A failed delete must not 500 — the caller is stuck and needs the reload.
+
+    The blob then survives, so this reset degrades to its pre-#2036 behaviour
+    instead of leaving the host with no working escape hatch at all.
+    """
+    hass = _hass(tmp_path)
+    write_setup(hass, CONFIGURED_BLOB)
+    view = ForceResetView(hass)
+
+    with (
+        _authorized(),
+        mock.patch(
+            "custom_components.beatify.server.game_views.clear_setup",
+            side_effect=OSError("read-only file system"),
+        ),
+    ):
+        response = _post(view)
+
+    assert response.status == 200
+    assert b'"success": true' in response.body
+    assert b'"cleared_setup": false' in response.body
+
+
+def test_force_reset_still_ends_a_running_game(tmp_path: Path) -> None:
+    """The #777 job stays intact — the blob is an addition, not a replacement."""
+    hass = _hass(tmp_path)
+    write_setup(hass, CONFIGURED_BLOB)
+
+    game_state = MagicMock()
+    game_state.game_id = "GAME-42"
+    game_state.end_game = AsyncMock()
+    ws_handler = MagicMock()
+    ws_handler.broadcast = AsyncMock()
+    ws_handler.broadcast_state = AsyncMock()
+    hass.data = {DOMAIN: {"game": game_state, "ws_handler": ws_handler}}
+
+    view = ForceResetView(hass)
+    with _authorized():
+        response = _post(view)
+
+    game_state.end_game.assert_awaited_once()
+    assert b'"ended_game_id": "GAME-42"' in response.body
+    assert read_setup(hass) is None
+
+
+def test_force_reset_requires_authorization(tmp_path: Path) -> None:
+    """An unauthorized caller must not be able to wipe the household setup."""
+    hass = _hass(tmp_path)
+    write_setup(hass, CONFIGURED_BLOB)
+    view = ForceResetView(hass)
+
+    with mock.patch(
+        "custom_components.beatify.server.game_views.is_authorized_http",
+        new=MagicMock(return_value=False),
+    ):
+        response = _post(view)
+
+    assert response.status == 401
+    assert read_setup(hass) == CONFIGURED_BLOB
+
+
+def test_force_reset_rate_limit_does_not_clear_setup(tmp_path: Path) -> None:
+    """The 4th call in an hour is refused — and must leave the blob alone."""
+    hass = _hass(tmp_path)
+    view = ForceResetView(hass)
+
+    with _authorized():
+        for _ in range(ForceResetView.RATE_LIMIT_REQUESTS):
+            _post(view)
+
+        write_setup(hass, CONFIGURED_BLOB)
+        response = _post(view)
+
+    assert response.status == 429
+    assert read_setup(hass) == CONFIGURED_BLOB
+
+
+@pytest.mark.parametrize("blob", [CONFIGURED_BLOB, {"last_player": None}])
+def test_status_would_report_unconfigured_after_reset(
+    tmp_path: Path, blob: dict
+) -> None:
+    """End-to-end of the actual bug — the reload has nothing to re-seed from.
+
+    ``reconcileSavedSetup()`` only writes back what ``saved_setup`` carries, so
+    a ``None`` blob is exactly what keeps the wizard open on step 1.
+    """
+    hass = _hass(tmp_path)
+    write_setup(hass, blob)
+    view = ForceResetView(hass)
+
+    with _authorized():
+        _post(view)
+
+    assert read_setup(hass) is None


### PR DESCRIPTION
Fixes #2036.

## Was kaputt war

Reset auf dem Host-Screen („Bereit zum Hosten") landete nach dem Reload wieder auf demselben Screen, mit demselben Speaker und denselben Playlists.

Beide Hälften des Resets taten genau das, was in ihrem Code steht — die Lücke lag zwischen ihnen:

1. `confirmReset()` löscht die sieben `beatify_*`-Keys, meldet den Service-Worker ab, lädt neu.
2. `ForceResetView` beendet das laufende Spiel — und nur das. Der Setup-Blob aus `SetupView` (`<config>/beatify/setup.json`) bleibt liegen.
3. Der Reload holt `/beatify/api/status` **vor** der Wizard-Entscheidung (#1941), bekommt `setup_complete: true` und `saved_setup` zurück, und `reconcileSavedSetup()` schreibt den Speaker in den gerade geleerten Speicher — die Regel „für den Speaker gewinnt der Server" aus #1927 kennt keinen Client, der sich absichtlich geleert hat.
4. `shouldTrigger()` (`wizard.js:74`) findet keinen Wizard-State, prüft ersatzweise „ist ein Speaker gesetzt" — wieder ja → Wizard bleibt zu.
5. `BeatifyHome.enter()` sieht `isConfigured() === true` und legt eine neue Lobby an.

## Der Fix

`ForceResetView.post()` löscht zusätzlich den Blob, über einen neuen `clear_setup()`-Helfer in `setup_state.py`. Danach hat der Reload nichts zum Zurückschreiben, `shouldTrigger()` greift, der Wizard startet auf Schritt 1 **ohne** vorbelegte Picks.

Bewusste Entscheidungen im Diff:

- **Datei löschen statt `{}` schreiben.** `read_setup()` liefert für eine fehlende Datei schon `None` — kein Aufrufer muss eine zweite Leer-Form lernen.
- **Ein Fehler beim Löschen wird geloggt und geschluckt.** Wer auf Reset drückt, steckt fest und braucht die Antwort; der Reset fällt dann auf sein altes Verhalten zurück, statt mit 500 gar nichts mehr zu tun.
- **Die Antwort meldet `cleared_setup`**, damit im Log unterscheidbar bleibt, ob es überhaupt etwas zu löschen gab.
- **Der Reset wirkt jetzt auf die Installation, nicht auf ein Gerät.** Das folgt daraus, dass er das laufende Spiel ohnehin für alle beendet; Bestätigungsdialog und Rate-Limit (3/Stunde/IP) stehen davor.

## Verworfene Alternative

Die geräte-lokale Variante — Reload mit Marker, der `BeatifyWizard.show(1)` erzwingt — lässt den Blob stehen. Der Wizard stünde dann mit dem alten Speaker und den alten Playlists vorbelegt da, also genau das, was #1080 schon einmal als „der Reset hat nicht gewirkt" beschrieben hat. Markus hat sich am 09.08. im Chat für die Server-Variante entschieden.

## Tests

12 neue in `tests/unit/test_force_reset_setup_clear_2036.py`:

- `clear_setup` löscht, ist idempotent und läuft auf einer nie konfigurierten Installation ins Leere
- der View löscht den Blob und meldet `cleared_setup`
- ohne gespeicherten Blob bleibt es ein normaler 200er
- ein fehlgeschlagenes Löschen (`OSError`) gibt weiterhin 200 zurück
- ein laufendes Spiel wird weiterhin beendet (#777 unangetastet)
- 401 und 429 lassen den Blob in Ruhe — niemand wischt über einen unautorisierten oder rate-limitierten Call die Haushalts-Konfiguration

Grün: `1623 passed` (pytest), `571 passed` (vitest), `ruff check`/`format` sauber (CI-Pin 0.15.7), `build.mjs --check` meldet alle 10 Bundles deckungsgleich.

## Nicht automatisch testbar

Der eigentliche Beweis ist der Reload im Browser — dass der Wizard auf Schritt 1 aufgeht und Speaker und Playlists leer sind. Bitte einmal am Gerät gegenprüfen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
