### PR TITLE
chore(release): v4.2.0-rc23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,17 @@ All notable changes to Beatify are documented here. For detailed release notes, 
 
 ## [Unreleased]
 
-### Fixed
-- **Reset reloads the page again (#2041).** Reported by **@mholzi** on iOS Safari minutes after rc22 shipped: pressing Reset left the host screen exactly as it was, and only a manual browser reload landed on the wizard. The Home Assistant log showed the server half had run and the wizard appearing after the manual reload showed the localStorage clear had run, which left exactly one suspect between them — `navigator.serviceWorker.getRegistrations()`, awaited without a deadline. A rejected promise was always handled; one that never settles was not, and `await` on it skips every line below, including the reload. Every cleanup step now has a four-second deadline and the navigation moved into a `finally`, so no stall above it can strand the host on the screen they asked to leave. Thirteen new tests, each of the three steps pinned in its never-settles form.
-
 ### Added
 - **Polskie hity radiowe 🇵🇱 — 92 tracks (#1891).** Polish pop and rock radio hits spanning 1972-2016, with the heart of the collection in the 1990s and 2000s (75 of 92 tracks). The third Polish playlist alongside Polskie przeboje wszech czasów and Polski Rock; seven tracks already curated in those two were dropped as duplicates, so the catalogue gains 92 genuinely new songs rather than 100 with overlap.
   - _Entry needs review: the playlist that shipped is `polish-hits-90s-00s.json`, "Polskie hity lat 90' 00'" with 93 tracks, and it went out in rc21 (commit `274463f4`). Name and count here match neither. Left in Unreleased rather than moved into a release section, because moving it would assert something that isn't true._
+
+## [4.2.0-rc23] - 2026-08-09
+
+### Fixed
+- **Reset reloads the page again (#2041).** Reported by **@mholzi** on iOS Safari minutes after rc22 shipped: pressing Reset left the host screen exactly as it was, and only a manual browser reload landed on the wizard. The Home Assistant log showed the server half had run and the wizard appearing after the manual reload showed the localStorage clear had run, which left exactly one suspect between them — `navigator.serviceWorker.getRegistrations()`, awaited without a deadline. A rejected promise was always handled; one that never settles was not, and `await` on it skips every line below, including the reload. Every cleanup step now has a four-second deadline and the navigation moved into a `finally`, so no stall above it can strand the host on the screen they asked to leave. Thirteen new tests, each of the three steps pinned in its never-settles form.
+
+### Changed
+- **Five broken URIs repaired in `hitster-100-francais` (#2040).** Found by the rotating playlist health check. Tidal coverage moves 5,152 → 5,171 URIs (86.5 %) over one backfill wave.
 
 ## [4.2.0-rc22] - 2026-08-09
 

--- a/custom_components/beatify/manifest.json
+++ b/custom_components/beatify/manifest.json
@@ -19,5 +19,5 @@
     "num2words==0.5.14"
   ],
   "single_config_entry": true,
-  "version": "4.2.0-rc22"
+  "version": "4.2.0-rc23"
 }


### PR DESCRIPTION
Manifest `4.2.0-rc22` → `4.2.0-rc23`, CHANGELOG-Abschnitt für rc23.

## Warum am selben Abend wie rc22

rc22 hat die **serverseitige** Hälfte des Reset-Fix ausgeliefert (#2036). Am Gerät blieb der Knopf trotzdem wirkungslos, weil der Reload ausfiel (#2041). Ohne rc23 ist der Fix nicht testbar.

## Inhalt seit rc22

- **Reset lädt die Seite wieder neu (#2041, PR #2042).** Hängender `serviceWorker.getRegistrations()`-Aufruf blockierte alles darunter.
- **5 kaputte URIs in `hitster-100-francais` repariert (#2040, PR #2043).**
- Tidal 5.152 → 5.171 URIs (86,5 %).

## Gates

`1623 passed` (pytest), `ruff check` sauber im CI-Pin, `build.mjs --check` alle 10 Bundles deckungsgleich.

🤖 Generated with [Claude Code](https://claude.com/claude-code)