### PR TITLE
chore(release): v4.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to Beatify are documented here. For detailed release notes, 
 - **Polskie hity radiowe 🇵🇱 — 92 tracks (#1891).** Polish pop and rock radio hits spanning 1972-2016, with the heart of the collection in the 1990s and 2000s (75 of 92 tracks). The third Polish playlist alongside Polskie przeboje wszech czasów and Polski Rock; seven tracks already curated in those two were dropped as duplicates, so the catalogue gains 92 genuinely new songs rather than 100 with overlap.
   - _Entry needs review: the playlist that shipped is `polish-hits-90s-00s.json`, "Polskie hity lat 90' 00'" with 93 tracks, and it went out in rc21 (commit `274463f4`). Name and count here match neither. Left in Unreleased rather than moved into a release section, because moving it would assert something that isn't true._
 
+## [4.2.0] - 2026-08-09
+
+Stable cut of the 4.2.0 line ("Mix & Match") — see [docs/release-notes-v4.2.0.md](docs/release-notes-v4.2.0.md) for the user-facing notes covering the Smart Playlist Mixer and seasonal suggestions, Sudden Death, the six opt-in gameplay switches (Finale ×2, comeback token, ramp-up ordering, difficulty-scaled betting, Sabotage, Streak-Shield), the fairer speed bonus and unified side-challenge scoring, the speaker-twin and playback-recovery pass, cross-device setup reconciliation, the two-part Reset fix, and the catalogue growth from 46 playlists / 5,161 songs to 54 / 5,980 with Tidal coverage from 47.7 % to 86.5 % (detailed per rc below).
+
 ## [4.2.0-rc23] - 2026-08-09
 
 ### Fixed

--- a/custom_components/beatify/manifest.json
+++ b/custom_components/beatify/manifest.json
@@ -19,5 +19,5 @@
     "num2words==0.5.14"
   ],
   "single_config_entry": true,
-  "version": "4.2.0-rc23"
+  "version": "4.2.0"
 }


### PR DESCRIPTION
Stabiler Schnitt der 4.2.0-Linie („Mix & Match") nach 23 Release-Candidates seit v4.1.3.

Manifest `4.2.0-rc23` → `4.2.0`, CHANGELOG-Kopfabschnitt mit Verweis auf `docs/release-notes-v4.2.0.md`.

## Der Zyklus in Zahlen

- Playlists **46 → 54**, Songs **5.161 → 5.980**
- Tidal-Abdeckung **2.463 (47,7 %) → 5.171 (86,5 %)**
- 23 Release-Candidates, davon 20 Tidal-Wellen allein am 09.08.

## Nebenbefund, weiterhin offen

Der `Polskie hity radiowe`-Eintrag bleibt in `[Unreleased]` samt Review-Notiz. Die Playlist ist als `polish-hits-90s-00s.json` mit 93 Tracks bereits in rc21 gegangen; Name und Zahl im Eintrag passen zu keiner Datei im Repo. Ihn unter 4.2.0 einzusortieren hätte behauptet, er komme mit diesem Release.

## Gates

`1623 passed` (pytest), `ruff check` sauber im CI-Pin 0.15.7, `build.mjs --check` alle 10 Bundles deckungsgleich.

🤖 Generated with [Claude Code](https://claude.com/claude-code)