### PR TITLE
docs: align README, architecture map and coverage table with v4.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,9 +316,9 @@ Choose your difficulty—each changes how points are awarded:
 | 🔥 **Hard** | 10 pts | ±2 yrs = 3 pts | — | Punishing |
 
 ### Speed Bonus
-Submit instantly: **2x multiplier**
+Submit early: **2x multiplier**
 Submit at deadline: **1x multiplier**
-Linear scale in between. Hesitation costs points.
+The full multiplier holds through a short grace window at the start of the round, then decays linearly. You get a moment to actually recognise the song before the clock starts costing you points.
 
 ### Streak Milestones
 - **3 in a row:** +20 bonus points
@@ -341,11 +341,29 @@ After the song, it's a race — the **first** player to guess the artist correct
 Alternate names accepted—"Prince" or "The Artist" both count.
 
 ### Movie Quiz Bonus (Optional)
-For soundtrack songs. Guess the movie a song is from for tiered bonus points: **5 / 3 / 1** by submission speed.
+For soundtrack songs. Name the film a song comes from and the **first** correct guess earns **+5 bonus points** — winner-takes-all, like the Artist Challenge.
 Enable in game setup; only triggers on songs with movie metadata.
 
 ### Steal Power-Up
 Build a **3-answer streak** to unlock Steal. Once unlocked, tap a rival mid-round to copy their answer when they submit. One steal per game — spend it wisely.
+
+With the optional **comeback token** switched on, the bottom third of players are handed a Steal after the halfway round even without the streak.
+
+### Optional Twists
+
+All off by default. Each one is a switch in game setup.
+
+| Switch | What it does |
+|---|---|
+| 💀 **Sudden Death** | From round 2 on, the lowest scorer of each round is eliminated. Last one standing wins; a tie for last goes to the slowest submitter. Needs at least 3 players and can also be armed live from the reveal screen. |
+| 🏁 **Finale ×2** | The final round pays double on accuracy, and a tie for first is settled by a one-round playoff instead of a shared win. |
+| 🎁 **Comeback token** | Hands the bottom third of players a Steal after the halfway round. |
+| 📈 **Ramp-up ordering** | Orders the songs into a difficulty arc, easy early and hard at the end, from the per-song stats Beatify already keeps. |
+| 🎲 **Difficulty-scaled betting** | Triple or Nothing pays ×2 on an easy song, ×3 on normal and ×5 on hard, instead of a flat ×3. |
+| 😈 **Sabotage** | Lets a player cut or freeze somebody else's timer. |
+| 🛡️ **Streak-Shield** | Absorbs one wrong answer without breaking the streak, including one caused by a Sabotage. The absorbed round still pays no streak bonus. |
+
+**Crowd Court** resolves as soon as everyone has voted, rather than waiting out the full window.
 
 ---
 
@@ -383,7 +401,7 @@ Playlists are displayed on the main Beatify admin screen:
 
 ### Included Playlists
 
-Beatify comes with 5,929 songs across 53 curated playlists:
+Beatify comes with 5,980 songs across 54 curated playlists:
 
 - 🎬 **100 Greatest Movie Themes** — 162 iconic film soundtracks
 - 🎸 **100 Greatest Rock Songs** — 122 rock essentials spanning 1964–2026
@@ -427,7 +445,8 @@ Beatify comes with 5,929 songs across 53 curated playlists:
 - 🎸 **NDW – Neue Deutsche Welle** — 50 German New Wave classics from 1976–1986
 - 🎤 **One-Hit Wonders** — 98 flash-in-the-pan classics
 - 🇵🇱 **Polski Rock** — 100 Polish rock tracks
-- 🇵🇱 **Polskie przeboje wszech czasów** — 100 all-time Polish hits
+- 🇵🇱 **Polskie hity radiowe** — 92 Polish pop and rock radio hits from 1972–2016
+- 🇵🇱 **Polskie przeboje wszech czasów** — 59 all-time Polish hits
 - 💔 **Power Ballads** — 99 epic rock ballads from the 80s and 90s
 - 🎸 **Pure Pop Punk** — 100 essential pop-punk tracks from the 2000s
 - 🍁 **Québécois 1990–2020** — 126 French-Canadian tracks from three decades of Quebec pop
@@ -438,6 +457,10 @@ Beatify comes with 5,929 songs across 53 curated playlists:
 - 🌀 **Trance Classics** — 120 classic trance anthems
 - 🌍 **World Cup Anthems** — 26 official FIFA World Cup songs, 1962–2026
 - ⛵ **Yacht Rock** — 100 smooth West Coast classics from the 70s and 80s
+
+### Suggestion Of The Season
+
+The setup screen surfaces a dismissible chip when a season is close — Carnival, Eurovision, World Cup, Summer — that adds the matching playlist in one tap. Dismiss it and it stays gone for that occasion.
 
 ### Adding Custom Playlists
 
@@ -680,6 +703,14 @@ Cast devices (Chromecast, Nest Audio, Nest Hub, Google TV) don't support direct 
 </details>
 
 <details>
+<summary><strong>Something is stuck. What does the Reset button do?</strong></summary>
+<br>
+The ↺ button in the admin header is the escape hatch. It ends whatever game is running, clears Beatify's saved setup and its local browser state, drops the cached service worker, and reloads you onto the first step of the setup wizard with nothing pre-selected. It asks before it does any of that, and it is rate-limited to three uses an hour per address.
+<br><br>
+One thing to know before you press it: the saved setup lives on your Home Assistant, not just on the phone in your hand, so a reset clears it for <strong>every</strong> device in the household. It already ends the running game for everyone anyway. If you only want to change speaker or playlists, use <strong>Edit setup</strong> instead.
+</details>
+
+<details>
 <summary><strong>Do players need to be on the same network?</strong></summary>
 <br>
 Yes, players need to access your Home Assistant instance. Works great on home WiFi.
@@ -697,8 +728,16 @@ The neon dark theme is built-in and looks stunning. Custom theming is on the roa
 
 ## What's New
 
-### v4.2.0 — Sudden Death 💀
-- **New game mode: Sudden Death** — an elimination format where, from round 2 on, the lowest-scoring player each round is knocked out until only one is left standing. Ties for last go to the slowest submitter, the TV shows an "OUT" takeover for whoever was just eliminated, and the winner earns a "last one standing" highlight. Needs at least 3 players; arm it in the setup wizard or flip it on live from the reveal screen (#827, #1472)
+### v4.2.0 — Mix & Match 🎛️
+- **Mix tab in the playlist picker** — assemble a de-duplicated set on the fly from any combination of decade, style, region and special tags, at 30, 50 or 100 songs, and save it as a community playlist in one tap (#1538)
+- **Suggestion of the season** in the setup screen, one tap to add the matching playlist (#1539)
+- **New game mode: Sudden Death** — from round 2 on, the lowest-scoring player each round is knocked out until only one is left standing. Ties for last go to the slowest submitter, the TV shows an "OUT" takeover, and the winner earns a "last one standing" highlight. Needs at least 3 players; arm it in the setup wizard or live from the reveal screen (#827, #1472)
+- **Six optional twists** — Finale ×2, comeback token, ramp-up ordering, difficulty-scaled betting, Sabotage and Streak-Shield, all off by default (#1665, #1666, #1724, #1725, #1726, #1727)
+- **Fairer scoring** — the speed multiplier holds through a grace window before decaying (#1722), and the movie quiz became winner-takes-all like the artist challenge (#1723)
+- **Speakers and playback** — the picker hides the native twin of a Music Assistant speaker (#1627), a playback timeout no longer ends the game (#1936), and a round no longer depends on its own timer task or an open browser to finish (#1865)
+- **Setup follows you between devices** — one source of truth for the speaker (#1927), no more forced logout after 30 days (#1932), and the wizard stops opening on a configured device (#1941)
+- **Reset really resets** — it drops the saved setup on the server too and reloads by itself (#2036, #2041)
+- **Eight new playlists**, catalogue 46 → 54 playlists and 5,161 → 5,980 songs, Tidal coverage 47.7% → 86.5%
 - 6 music platforms, 5 languages
 
 ### v4.1.3 — Content & Reliability ☀️

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 A self-hosted multiplayer music trivia game that runs as a Home Assistant integration. This document is the top-down map of the system. For the why-was-this-decision-made nuance, follow the inline issue references (#NNN) into the GitHub history — every non-trivial path was driven by a specific user-reported bug or feature request.
 
-> Last refreshed: 2026-07-05 against `main` at `b90f947` (the v4.2.0-rc9 line).
+> Last refreshed: 2026-08-09 against `main` at `f15285a8` (the v4.2.0 release).
 
 ---
 
@@ -90,14 +90,14 @@ custom_components/beatify/
 │   ├── mix_views.py        # Smart Playlist Mixer endpoint (#1538) — see §6
 │   ├── companion_auth.py   # HA Companion app login handoff (#1527 era)
 │   ├── stats_views.py      # analytics dashboard data
-│   ├── setup_state.py      # persisted wizard/setup state
+│   ├── setup_state.py      # persisted wizard/setup state (read/write/clear; force-reset drops it, #2036)
 │   ├── serializers.py, base.py
 ├── services/               # backend side-effect services (see §4, §10)
 │   ├── media_player.py     # provider URI dispatch + playback (#768/#805/#808)
 │   ├── tts.py              # TTS announcements (tts.speak; #793)
 │   ├── lights.py           # party-lights phase orchestration
 │   └── stats.py            # analytics/stats side-effects
-├── playlists/              # 49 bundled playlists, 5,381 songs
+├── playlists/              # 54 bundled playlists, 5,980 songs
 │   ├── *.json              # 17 default packs (era / greatest-hits / movie)
 │   ├── community/          # 32 community packs (genre / region), separate browse tab
 │   ├── user/               # host-saved mixes land here as <slug>.json (Community tab)

--- a/docs/provider-coverage.md
+++ b/docs/provider-coverage.md
@@ -1,69 +1,78 @@
 # Beatify Provider-URI Coverage
-> Generated: 2026-07-05
-> Mode: DRY-RUN (no JSON written)
-> YouTube phase: skipped — coverage regenerated offline (existing URIs counted; no network, YOUTUBE_API_KEY not set)
+> Generated: 2026-08-09
+> Mode: OFFLINE COUNT (existing URIs counted from the playlist JSON; no network, no writes)
+> Catalogue state: v4.2.0
 
 ## Summary
 
-| Provider | Have | Total | Coverage | Filled this run |
-|---|---:|---:|---:|---:|
-| Apple | 4710 | 5381 | 87.5% | 0 |
-| Tidal | 3081 | 5381 | 57.3% | 0 |
-| Deezer | 4905 | 5381 | 91.2% | 0 |
-| YouTube | 5011 | 5381 | 93.1% | 0 |
+| Provider | Have | Total | Coverage |
+|---|---:|---:|---:|
+| Apple | 5117 | 5980 | 85.6% |
+| Tidal | 5190 | 5980 | 86.8% |
+| Deezer | 5483 | 5980 | 91.7% |
+| YouTube | 5433 | 5980 | 90.9% |
 
 ## Per-playlist coverage
 
-| Playlist | Songs | Apple | Tidal | Deezer | YouTube | Filled |
-|---|---:|---:|---:|---:|---:|---:|
-| 2000s-pop-anthems.json | 182 | 175 | 182 | 179 | 182 |  |
-| 40s-50s-classics.json | 152 | 115 | 151 | 149 | 152 |  |
-| 70s-hits.json | 163 | 84 | 162 | 163 | 163 |  |
-| 80er-hits.json | 238 | 229 | 237 | 238 | 234 |  |
-| 90er-hits.json | 115 | 99 | 114 | 113 | 115 |  |
-| community/90s-2000s-hiphop-bangers.json | 40 | 40 | 40 | 40 | 40 |  |
-| community/anime-openings.json | 140 | 140 | 63 | 102 | 139 |  |
-| community/ballermann-party-hits.json | 189 | 178 | 11 | 175 | 189 |  |
-| community/best-of-giraffenaffen.json | 26 | 26 | 0 | 25 | 25 |  |
-| community/british-invasion-britpop.json | 100 | 86 | 98 | 100 | 98 |  |
-| community/deutschpop-klassiker.json | 107 | 106 | 1 | 107 | 107 |  |
-| community/disney-hits-deutschland.json | 97 | 63 | 0 | 93 | 97 |  |
-| community/divorced-dad-rock.json | 107 | 56 | 0 | 107 | 107 |  |
-| community/edm-anthems.json | 126 | 103 | 0 | 126 | 126 |  |
-| community/essential-alternative.json | 100 | 100 | 0 | 98 | 100 |  |
-| community/eurodance-90s.json | 100 | 86 | 92 | 91 | 97 |  |
-| community/fiesta-latina-90s.json | 50 | 48 | 50 | 50 | 50 |  |
-| community/finnish-iskelma-classics.json | 293 | 252 | 0 | 289 | 196 |  |
-| community/funk-carioca.json | 20 | 9 | 0 | 20 | 20 |  |
-| community/gen-z-anthems.json | 30 | 30 | 30 | 30 | 30 |  |
-| community/greatest-metal-songs.json | 61 | 61 | 52 | 0 | 61 |  |
-| community/harder-styles.json | 190 | 174 | 0 | 181 | 190 |  |
-| community/hitster-100-en-espanol.json | 127 | 127 | 127 | 0 | 127 |  |
-| community/hitster-100-francais.json | 100 | 94 | 55 | 98 | 100 |  |
-| community/hitster-brasil.json | 66 | 66 | 49 | 66 | 66 |  |
-| community/iconic-movie-songs.json | 72 | 72 | 0 | 72 | 71 |  |
-| community/koelner-karneval.json | 290 | 289 | 276 | 288 | 273 |  |
-| community/ndw-neue-deutsche-welle.json | 50 | 31 | 19 | 47 | 43 |  |
-| community/polish-all-time-hits.json | 100 | 30 | 0 | 99 | 37 |  |
-| community/polish-rock.json | 100 | 30 | 37 | 99 | 45 |  |
-| community/pure-pop-punk.json | 100 | 97 | 100 | 100 | 100 |  |
-| community/schlager-klassiker.json | 60 | 58 | 60 | 59 | 60 |  |
-| community/schweizer-hits.json | 97 | 90 | 17 | 97 | 96 |  |
-| community/sommerklassiker.json | 60 | 54 | 0 | 60 | 60 |  |
-| community/top100-allertijden-nederlandstalig.json | 104 | 96 | 68 | 0 | 100 |  |
-| community/trance-classics.json | 120 | 103 | 0 | 109 | 120 |  |
-| community/yacht-rock.json | 100 | 98 | 100 | 100 | 100 |  |
-| disco-funk-classics.json | 98 | 87 | 73 | 96 | 73 |  |
-| disney-classics.json | 69 | 69 | 0 | 69 | 57 |  |
-| eurovision-winners.json | 72 | 63 | 62 | 71 | 67 |  |
-| greatest-hits-of-all-time.json | 236 | 225 | 196 | 236 | 194 |  |
-| hits-2010s-2020s.json | 71 | 67 | 3 | 68 | 71 |  |
-| motown-soul-classics.json | 100 | 98 | 47 | 100 | 98 |  |
-| movies-100-greatest-themes.json | 162 | 122 | 156 | 148 | 139 |  |
-| one-hit-wonders.json | 98 | 94 | 98 | 98 | 94 |  |
-| summer-party-anthems.json | 112 | 109 | 112 | 111 | 111 |  |
-| top-100-power-ballads.json | 99 | 96 | 99 | 95 | 99 |  |
-| top-songs-der-60er.json | 66 | 62 | 44 | 22 | 66 |  |
-| world-cup-anthems.json | 26 | 23 | 0 | 21 | 26 |  |
+| Playlist | Songs | Apple | Tidal | Deezer | YouTube |
+|---|---:|---:|---:|---:|---:|
+| 2000s-pop-anthems.json | 182 | 175 | 182 | 179 | 182 |
+| 40s-50s-classics.json | 152 | 115 | 151 | 149 | 152 |
+| 70s-hits.json | 163 | 84 | 162 | 163 | 163 |
+| 80er-hits.json | 238 | 229 | 237 | 238 | 234 |
+| 90er-hits.json | 115 | 99 | 114 | 113 | 115 |
+| community/100-greatest-rock-songs.json | 122 | 120 | 122 | 122 | 122 |
+| community/90s-2000s-hiphop-bangers.json | 40 | 40 | 40 | 40 | 40 |
+| community/anime-openings.json | 140 | 140 | 87 | 102 | 139 |
+| community/ballermann-party-hits.json | 189 | 177 | 189 | 175 | 189 |
+| community/best-canadian-hits.json | 100 | 97 | 99 | 98 | 92 |
+| community/best-of-giraffenaffen.json | 26 | 26 | 26 | 25 | 25 |
+| community/british-invasion-britpop.json | 100 | 86 | 99 | 100 | 98 |
+| community/deutschpop-klassiker.json | 107 | 106 | 107 | 107 | 107 |
+| community/deutschrock-best-of.json | 100 | 0 | 99 | 100 | 0 |
+| community/disney-hits-deutschland.json | 97 | 63 | 91 | 93 | 97 |
+| community/divorced-dad-rock.json | 107 | 56 | 107 | 107 | 107 |
+| community/edm-anthems.json | 190 | 135 | 190 | 175 | 125 |
+| community/essential-alternative.json | 100 | 100 | 100 | 98 | 100 |
+| community/eurodance-90s.json | 100 | 86 | 97 | 91 | 97 |
+| community/fiesta-latina-90s.json | 50 | 48 | 50 | 50 | 50 |
+| community/finnish-iskelma-classics.json | 293 | 252 | 293 | 289 | 195 |
+| community/funk-carioca.json | 20 | 9 | 20 | 20 | 20 |
+| community/gen-z-anthems.json | 30 | 30 | 30 | 30 | 30 |
+| community/greatest-metal-songs.json | 61 | 61 | 61 | 0 | 61 |
+| community/harder-styles.json | 190 | 181 | 181 | 181 | 190 |
+| community/hitster-100-en-espanol.json | 127 | 127 | 127 | 0 | 127 |
+| community/hitster-100-francais.json | 100 | 92 | 96 | 98 | 100 |
+| community/hitster-brasil.json | 66 | 66 | 66 | 66 | 66 |
+| community/iconic-movie-songs.json | 72 | 72 | 71 | 72 | 71 |
+| community/koelner-karneval.json | 290 | 289 | 289 | 288 | 273 |
+| community/ndw-neue-deutsche-welle.json | 50 | 31 | 50 | 47 | 43 |
+| community/polish-all-time-hits.json | 59 | 57 | 55 | 58 | 0 |
+| community/polish-hits-90s-00s.json | 92 | 8 | 90 | 88 | 92 |
+| community/polish-rock.json | 100 | 30 | 99 | 99 | 45 |
+| community/pure-pop-punk.json | 100 | 97 | 100 | 100 | 100 |
+| community/quebecois-1990-2020.json | 126 | 119 | 60 | 126 | 119 |
+| community/schlager-klassiker.json | 96 | 58 | 60 | 95 | 96 |
+| community/schweizer-hits.json | 97 | 90 | 17 | 97 | 96 |
+| community/sommerklassiker.json | 60 | 54 | 0 | 60 | 60 |
+| community/top100-allertijden-nederlandstalig.json | 104 | 96 | 68 | 0 | 100 |
+| community/trance-classics.json | 120 | 103 | 18 | 109 | 120 |
+| community/yacht-rock.json | 100 | 98 | 100 | 100 | 100 |
+| disco-funk-classics.json | 98 | 87 | 73 | 96 | 73 |
+| disney-classics.json | 69 | 69 | 0 | 69 | 57 |
+| eurovision-winners.json | 72 | 63 | 62 | 71 | 67 |
+| greatest-hits-of-all-time.json | 236 | 225 | 196 | 236 | 194 |
+| hits-2010s-2020s.json | 71 | 67 | 3 | 68 | 71 |
+| motown-soul-classics.json | 100 | 98 | 47 | 100 | 98 |
+| movies-100-greatest-themes.json | 162 | 122 | 156 | 148 | 139 |
+| one-hit-wonders.json | 98 | 94 | 98 | 98 | 94 |
+| summer-party-anthems.json | 112 | 109 | 112 | 111 | 111 |
+| top-100-power-ballads.json | 99 | 96 | 99 | 95 | 99 |
+| top-songs-der-60er.json | 66 | 62 | 44 | 22 | 66 |
+| world-cup-anthems.json | 26 | 23 | 0 | 21 | 26 |
 
-*Coverage = songs with a non-null URI for that provider. “Filled” = URIs this run added (0 in dry-run).*
+---
+
+Spotify is the base provider: every playable song carries a `uri`, so it is not
+listed above. Regenerate this table with the `provider-uri-backfill` skill, or
+recount it offline from the playlist JSON when you only need the numbers.


### PR DESCRIPTION
Doku auf den Stand des Final-Release gebracht. Alle Zahlen **neu aus den Playlist-JSONs gezählt**, alle Verhaltensaussagen gegen den ausgelieferten Code geprüft.

## Was schlicht falsch war

- **Movie-Quiz-Bonus** stand noch mit den Stufen `5 / 3 / 1` nach Tempo im README. Die wurden in #1723 abgeschafft, es gibt nur noch **+5 für den ersten richtigen Tipp**. Wer das README las, spielte nach Regeln, die es nicht mehr gibt.
- **Speed-Bonus** versprach lineares Abschmelzen ab der ersten Sekunde. Seit #1722 hält der volle Multiplikator erst ein Grace-Fenster durch.
- **Polskie przeboje wszech czasów** war mit 100 Tracks gelistet, die Datei hat **59**.
- **Katalog-Zahl** 5.929 Songs / 53 Playlists → **5.980 / 54**.
- **Polskie hity radiowe** (92 Tracks) fehlte in der Playlist-Liste komplett.

## Was undokumentiert ausgeliefert wurde

Sechs der sieben Schalter aus 4.2.0 standen nirgends im README. Neue Tabelle **Optional Twists**: Sudden Death, Finale ×2, Comeback-Token, Ramp-up-Ordering, schwierigkeitsskaliertes Wetten, Sabotage, Streak-Shield — dazu die Crowd-Court-Sofortauflösung und der Saison-Vorschlag im Setup (#1539).

Dazu ein FAQ-Eintrag zum **Reset**-Knopf, inklusive der heute geänderten Konsequenz: er löscht die Konfiguration der ganzen Installation, nicht nur die des Geräts am Knopf.

## Generierte Dateien

`docs/provider-coverage.md` war vom **05.07.** und rechnete mit 5.381 Songs; Tidal stand dort auf 57,3 %, tatsächlich sind es **86,8 %**. Neu erzeugt — aber **offline aus den JSONs gezählt** statt über das Backfill-Skript, das 6 Sekunden pro Track gegen Odesli wartet und für eine reine Zählung Stunden gebraucht hätte. Der Modus steht im Kopf der Datei.

`docs/ARCHITECTURE.md`: Refresh-Stempel auf den v4.2.0-Commit, 49/5.381 → 54/5.980, `setup_state.py` mit dem Hinweis auf das Löschen durch den Force-Reset.

## Gates

`1623 passed` (pytest), `build.mjs --check` alle 10 Bundles deckungsgleich. Kein Code angefasst.

🤖 Generated with [Claude Code](https://claude.com/claude-code)