### PR TITLE
chore(playlists): tidal backfill wave — +19 uris

### DIFF
--- a/custom_components/beatify/playlists/community/quebecois-1990-2020.json
+++ b/custom_components/beatify/playlists/community/quebecois-1990-2020.json
@@ -1,6 +1,6 @@
 {
   "name": "🍁 Québécois 1990-2020",
-  "version": "0.10",
+  "version": "0.11",
   "tags": [
     "quebecois",
     "quebec",
@@ -3333,7 +3333,7 @@
         "it": "applemusic://track/1591238077"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=dfv58moRXKs",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/201876442",
       "uri_deezer": "deezer://track/1527423362",
       "alt_artists": [
         "Martin Roberts",
@@ -3363,7 +3363,7 @@
         "it": "applemusic://track/1274063182"
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/75787055",
       "uri_deezer": "deezer://track/401394412",
       "alt_artists": [
         "Émile Bilodeau",
@@ -3393,7 +3393,7 @@
         "it": "applemusic://track/1551590981"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=N15Nr1dAogM",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/62845155",
       "uri_deezer": "deezer://track/128234353",
       "alt_artists": [
         "Stefie Shock",
@@ -3423,7 +3423,7 @@
         "it": "applemusic://track/1482953124"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=SYXUnY8f2ik",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/119813275",
       "uri_deezer": "deezer://track/773118122",
       "alt_artists": [
         "Mon Doux Saigneur",
@@ -3453,7 +3453,7 @@
         "it": "applemusic://track/1715453100"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=V3AchEdfMak",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/188270524",
       "uri_deezer": "deezer://track/1497900242",
       "alt_artists": [
         "Charlotte Cardin, CRi",
@@ -3483,7 +3483,7 @@
         "it": "applemusic://track/1880482622"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=70czEeZ3_dw",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/8058167",
       "uri_deezer": "deezer://track/3870010921",
       "alt_artists": [
         "Martin Léon",
@@ -3513,7 +3513,7 @@
         "it": "applemusic://track/1795506114"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=dqjsnjc8laQ",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/409008722",
       "uri_deezer": "deezer://track/3168068471",
       "alt_artists": [
         "La Chicane",
@@ -3543,7 +3543,7 @@
         "it": "applemusic://track/1795505648"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=mf7YG8DSRl0",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/409029218",
       "uri_deezer": "deezer://track/3168322551",
       "alt_artists": [
         "Édith Butler",
@@ -3573,7 +3573,7 @@
         "it": "applemusic://track/687812868"
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/21048803",
       "uri_deezer": "deezer://track/1885473517",
       "alt_artists": [
         "Sally Folk",
@@ -3603,7 +3603,7 @@
         "it": "applemusic://track/1551599658"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=s-EL1GmvImM",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/62851044",
       "uri_deezer": "deezer://track/128237709",
       "alt_artists": [
         "Vilain Pingouin",
@@ -3633,7 +3633,7 @@
         "it": "applemusic://track/687813033"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=QATEin9z50E",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/21048804",
       "uri_deezer": "deezer://track/1885473557",
       "alt_artists": [
         "Tomás Jensen",
@@ -3663,7 +3663,7 @@
         "it": "applemusic://track/1048262285"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=rx2pK_XFQPE",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/52437715",
       "uri_deezer": "deezer://track/109374182",
       "alt_artists": [
         "Cœur De Pirate",
@@ -3693,7 +3693,7 @@
         "it": "applemusic://track/1048261793"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=iSHa7Vu4mYU",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/52438083",
       "uri_deezer": "deezer://track/109374134",
       "alt_artists": [
         "Les Trois Accords",
@@ -3723,7 +3723,7 @@
         "it": "applemusic://track/1238762303"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=CcQ8wuM-MMU",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/39641180",
       "uri_deezer": "deezer://track/93081562",
       "alt_artists": [
         "Luce Dufault",
@@ -3753,7 +3753,7 @@
         "it": "applemusic://track/1048262121"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=Lm4FiytDSoU",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/52437706",
       "uri_deezer": "deezer://track/109374164",
       "alt_artists": [
         "Cœur De Pirate",
@@ -3783,7 +3783,7 @@
         "it": "applemusic://track/582181884"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=nUB0PHRJQ3M",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/19337613",
       "uri_deezer": "deezer://track/62577852",
       "alt_artists": [
         "Cœur De Pirate",

--- a/custom_components/beatify/playlists/community/schlager-klassiker.json
+++ b/custom_components/beatify/playlists/community/schlager-klassiker.json
@@ -1,6 +1,6 @@
 {
   "name": "Schlager Classics 🇩🇪",
-  "version": "1.9",
+  "version": "1.10",
   "tags": [
     "german",
     "schlager",
@@ -2419,7 +2419,7 @@
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=h2EdyvFazzk",
       "uri_deezer": "deezer://track/120358324",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/56290526",
       "isrc": "DEC739300115"
     },
     {
@@ -2452,7 +2452,7 @@
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=wCON7JlxuEI",
       "uri_deezer": "deezer://track/1008665",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/2045071",
       "isrc": "DEC710100031"
     },
     {
@@ -2485,7 +2485,7 @@
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=wTIOa9PCxw0",
       "uri_deezer": "deezer://track/3828536231",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/491129755",
       "isrc": "DEZ040400109"
     },
     {


### PR DESCRIPTION
Eine Odesli-Welle, automatisch gefahren von `com.beatify.tidal-wave`.

- `quebecois-1990-2020` Tidal 109 → **125**/126, version 0.10 → 0.11
- `schlager-klassiker` Tidal 60 → **63**/96, version 1.9 → 1.10

Bilanz: 19 Treffer · 0 echte Misses · 29 Rate-Limit-Skips · 87 429-Zeilen.

**Draft mit Absicht** — Merge nur nach Markus' Freigabe.