### PR TITLE
chore(playlists): tidal backfill wave — +19 uris

### DIFF
--- a/custom_components/beatify/playlists/community/sommerklassiker.json
+++ b/custom_components/beatify/playlists/community/sommerklassiker.json
@@ -1,6 +1,6 @@
 {
   "name": "Sommerklassiker ☀️",
-  "version": "0.5",
+  "version": "0.6",
   "tags": [
     "summer",
     "pop",
@@ -1209,7 +1209,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=nPLV7lGbmT4",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/23181621",
       "uri_deezer": "82241406",
       "awards_nl": []
     },
@@ -1239,7 +1239,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=0Gjx-ZQuQ_Y",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/10905053",
       "uri_deezer": "3819653",
       "awards_nl": []
     },
@@ -1269,7 +1269,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=72UO0v5ESUo",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/85666489",
       "uri_deezer": "623698182",
       "awards_nl": []
     },
@@ -1299,7 +1299,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=Nn1IeHL5DHY",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/91676",
       "uri_deezer": "636405",
       "awards_nl": []
     },
@@ -1329,7 +1329,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=jIoEaTN7GGo",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/125328807",
       "uri_deezer": "831917182",
       "awards_nl": []
     },
@@ -1359,7 +1359,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=rClUOdS5Zyw",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/45404354",
       "uri_deezer": "100598482",
       "awards_nl": []
     },
@@ -1389,7 +1389,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=qaZ0oAh4evU",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/186296962",
       "uri_deezer": "1096588622",
       "awards_nl": []
     },
@@ -1419,7 +1419,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=Jvcv8trEuao",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/144618536",
       "uri_deezer": "986939372",
       "awards_nl": []
     },
@@ -1449,7 +1449,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=nskaoVf8PPM",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/11017522",
       "uri_deezer": "14235829",
       "awards_nl": []
     },
@@ -1479,7 +1479,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=9sg-A-eS6Ig",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/197646315",
       "uri_deezer": "142748736",
       "awards_nl": []
     },
@@ -1509,7 +1509,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=31crA53Dgu0",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/56290502",
       "uri_deezer": "118986142",
       "awards_nl": []
     },
@@ -1539,7 +1539,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=NKR2n-G-wdM",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/1287452",
       "uri_deezer": "565312",
       "awards_nl": []
     },
@@ -1569,7 +1569,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=3l9a1uvoIp0",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/293052226",
       "uri_deezer": "2269454607",
       "awards_nl": []
     },
@@ -1599,7 +1599,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=lzkKzZmRZk8",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/113846918",
       "uri_deezer": "717723342",
       "awards_nl": []
     },
@@ -1629,7 +1629,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=R82XGJV_nkU",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/2067495",
       "uri_deezer": "3528853",
       "awards_nl": []
     },
@@ -1659,7 +1659,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=fiore9Z5iUg",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/29600745",
       "uri_deezer": "84908527",
       "awards_nl": []
     },
@@ -1689,7 +1689,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=Eg4LUvUjUWI",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/108784828",
       "uri_deezer": "675340022",
       "awards_nl": []
     },
@@ -1719,7 +1719,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=4fQeaM62mOY",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/60184069",
       "uri_deezer": "124262674",
       "awards_nl": []
     },
@@ -1749,7 +1749,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=vs2PWPgdetc",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/112067941",
       "uri_deezer": "702996922",
       "awards_nl": []
     },


### PR DESCRIPTION
Eine Odesli-Welle, automatisch gefahren von `com.beatify.tidal-wave`.

- `sommerklassiker` Tidal 39 → **58**/60, version 0.5 → 0.6

Bilanz: 19 Treffer · 0 echte Misses · 30 Rate-Limit-Skips · 90 429-Zeilen.

**Draft mit Absicht** — Merge nur nach Markus' Freigabe.