### PR TITLE
chore(playlists): tidal backfill wave — +13 uris

### DIFF
--- a/custom_components/beatify/playlists/community/sommerklassiker.json
+++ b/custom_components/beatify/playlists/community/sommerklassiker.json
@@ -1,6 +1,6 @@
 {
   "name": "Sommerklassiker ☀️",
-  "version": "0.6",
+  "version": "0.7",
   "tags": [
     "summer",
     "pop",
@@ -1779,7 +1779,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=WYX0sjP6Za8",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/38762",
       "uri_deezer": "1073437",
       "awards_nl": []
     },
@@ -1809,7 +1809,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=HMqgVXSvwGo",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/32570155",
       "uri_deezer": "81768004",
       "awards_nl": []
     }

--- a/custom_components/beatify/playlists/community/top100-allertijden-nederlandstalig.json
+++ b/custom_components/beatify/playlists/community/top100-allertijden-nederlandstalig.json
@@ -1,6 +1,6 @@
 {
   "name": "Top 100 Dutch Classics 🇳🇱",
-  "version": "1.12",
+  "version": "1.13",
   "tags": [
     "nederlandstalig",
     "dutch",
@@ -2521,7 +2521,8 @@
         "es": "applemusic://track/1444144375",
         "nl": "applemusic://track/1444144375",
         "it": "applemusic://track/1444144375"
-      }
+      },
+      "uri_tidal": "tidal://track/85371261"
     },
     {
       "year": 2020,
@@ -2546,7 +2547,8 @@
       "fun_fact_fr": "Smoorverliefd est l'un des titres les plus joyeux de Snelle, une célébration du sentiment vertigineux du nouvel amour, sorti en 2020.",
       "fun_fact_nl": "Smoorverliefd is een van Snelle's meest vrolijke tracks, een viering van het duizelingwekkende, alles verterende gevoel van een nieuwe liefde, uitgebracht in 2020. Het werd een streaminghit en een feelgood anthem voor een generatie. Snelle's vermogen om Nederlandstalige pop fris en authentiek te laten aanvoelen, spat er vanaf.",
       "awards_nl": [],
-      "uri_youtube_music": "https://music.youtube.com/watch?v=LDDy4m_TiVk"
+      "uri_youtube_music": "https://music.youtube.com/watch?v=LDDy4m_TiVk",
+      "uri_tidal": "tidal://track/463294300"
     },
     {
       "year": 2023,
@@ -2582,7 +2584,8 @@
         "es": "applemusic://track/1659415213",
         "nl": "applemusic://track/1659415213",
         "it": "applemusic://track/1659415213"
-      }
+      },
+      "uri_tidal": "tidal://track/266265065"
     },
     {
       "year": 1991,
@@ -2689,7 +2692,8 @@
         "es": "applemusic://track/1357036661",
         "nl": "applemusic://track/1357036661",
         "it": "applemusic://track/1357036661"
-      }
+      },
+      "uri_tidal": "tidal://track/85678569"
     },
     {
       "year": 1995,
@@ -2783,7 +2787,8 @@
         "es": "applemusic://track/1525342810",
         "nl": "applemusic://track/1525342810",
         "it": "applemusic://track/1525342810"
-      }
+      },
+      "uri_tidal": "tidal://track/150797412"
     },
     {
       "year": 1971,
@@ -2817,7 +2822,8 @@
         "es": "applemusic://track/1842921739",
         "nl": "applemusic://track/1842921739",
         "it": "applemusic://track/1842921739"
-      }
+      },
+      "uri_tidal": "tidal://track/463394988"
     },
     {
       "year": 2001,
@@ -2852,7 +2858,8 @@
         "es": "applemusic://track/1442289020",
         "nl": "applemusic://track/1442289020",
         "it": "applemusic://track/1442289020"
-      }
+      },
+      "uri_tidal": "tidal://track/29536632"
     },
     {
       "year": 1969,
@@ -2888,7 +2895,8 @@
         "es": "applemusic://track/315688170",
         "nl": "applemusic://track/315688170",
         "it": "applemusic://track/315688170"
-      }
+      },
+      "uri_tidal": "tidal://track/56079927"
     },
     {
       "year": 1998,
@@ -2920,7 +2928,8 @@
         "es": "applemusic://track/268228952",
         "nl": "applemusic://track/1449978485",
         "it": "applemusic://track/268228952"
-      }
+      },
+      "uri_tidal": "tidal://track/14368044"
     },
     {
       "year": 2021,
@@ -2945,7 +2954,8 @@
       "fun_fact_fr": "Zij Wil Mij est un morceau confiant et autonomisant de FLEMMING explorant les thèmes du désir.",
       "fun_fact_nl": "Zij Wil Mij is een zelfverzekerd, krachtig nummer van FLEMMING dat thema's als verlangen en zelfverzekerdheid verkent. Het werd uitgebracht in 2021 en liet zien dat ze in staat is om sfeervolle pop te maken met een sterk standpunt. Het nummer werd een van haar meest gevierde nummers.",
       "awards_nl": [],
-      "uri_youtube_music": "https://music.youtube.com/watch?v=-mABxYPPqYc"
+      "uri_youtube_music": "https://music.youtube.com/watch?v=-mABxYPPqYc",
+      "uri_tidal": "tidal://track/211497323"
     },
     {
       "year": 2004,
@@ -2980,7 +2990,8 @@
         "es": "applemusic://track/359159887",
         "nl": "applemusic://track/359159887",
         "it": "applemusic://track/359159887"
-      }
+      },
+      "uri_tidal": "tidal://track/189932482"
     },
     {
       "year": 2005,


### PR DESCRIPTION
Eine Odesli-Welle, automatisch gefahren von `com.beatify.tidal-wave`.

- `sommerklassiker` Tidal 58 → **60**/60, version 0.6 → 0.7
- `top100-allertijden-nederlandstalig` Tidal 68 → **79**/104, version 1.12 → 1.13

Bilanz: 13 Treffer · 6 echte Misses · 29 Rate-Limit-Skips · 87 429-Zeilen.

**Draft mit Absicht** — Merge nur nach Markus' Freigabe.