### PR TITLE
chore(playlists): tidal backfill wave — +17 uris

### DIFF
--- a/custom_components/beatify/playlists/community/top100-allertijden-nederlandstalig.json
+++ b/custom_components/beatify/playlists/community/top100-allertijden-nederlandstalig.json
@@ -1,6 +1,6 @@
 {
   "name": "Top 100 Dutch Classics 🇳🇱",
-  "version": "1.13",
+  "version": "1.14",
   "tags": [
     "nederlandstalig",
     "dutch",
@@ -3028,7 +3028,8 @@
         "es": "applemusic://track/1442539933",
         "nl": "applemusic://track/1442539933",
         "it": "applemusic://track/1442539933"
-      }
+      },
+      "uri_tidal": "tidal://track/299388876"
     },
     {
       "year": 2023,
@@ -3062,7 +3063,8 @@
         "es": "applemusic://track/1842435015",
         "nl": "applemusic://track/1842435015",
         "it": "applemusic://track/1842435015"
-      }
+      },
+      "uri_tidal": "tidal://track/311940585"
     },
     {
       "year": 1984,
@@ -3132,7 +3134,8 @@
         "es": "applemusic://track/1822269633",
         "nl": "applemusic://track/1822269633",
         "it": "applemusic://track/1822269633"
-      }
+      },
+      "uri_tidal": "tidal://track/444052593"
     },
     {
       "year": 1995,
@@ -3166,7 +3169,8 @@
         "es": "applemusic://track/1585392334",
         "nl": "applemusic://track/1585392334",
         "it": "applemusic://track/1585392334"
-      }
+      },
+      "uri_tidal": "tidal://track/196779565"
     },
     {
       "year": 2011,
@@ -3202,7 +3206,8 @@
         "es": "applemusic://track/1523444661",
         "nl": "applemusic://track/1523444661",
         "it": "applemusic://track/1523444661"
-      }
+      },
+      "uri_tidal": "tidal://track/53318682"
     },
     {
       "year": 2015,
@@ -3226,7 +3231,8 @@
       "fun_fact_nl": "Niemand is een van Ronnie Flex' meest introspectieve tracks, waarin hij gevoelens van isolatie en eenzaamheid onderzoekt die zelfs in een menigte kunnen bestaan. Het werd uitgebracht in 2015 en werd een doorbraak en toonde zijn emotionele diepgang die verder gaat dan upbeat feestnummers. Het nummer sloeg aan bij de Nederlandse jeugd.",
       "awards_nl": [],
       "uri_apple_music": "applemusic://track/1444579291",
-      "uri_youtube_music": "https://music.youtube.com/watch?v=4vZ_SBbeURs"
+      "uri_youtube_music": "https://music.youtube.com/watch?v=4vZ_SBbeURs",
+      "uri_tidal": "tidal://track/51693783"
     },
     {
       "year": 2002,
@@ -3262,7 +3268,8 @@
         "es": "applemusic://track/343666377",
         "nl": "applemusic://track/343666377",
         "it": "applemusic://track/343666377"
-      }
+      },
+      "uri_tidal": "tidal://track/99095634"
     },
     {
       "year": 1965,
@@ -3298,7 +3305,8 @@
         "es": "applemusic://track/1750745021",
         "nl": "applemusic://track/1750745021",
         "it": "applemusic://track/1750745021"
-      }
+      },
+      "uri_tidal": "tidal://track/82651145"
     },
     {
       "year": 1997,
@@ -3334,7 +3342,8 @@
         "es": "applemusic://track/1364474697",
         "nl": "applemusic://track/1364474697",
         "it": "applemusic://track/1364474697"
-      }
+      },
+      "uri_tidal": "tidal://track/86440979"
     },
     {
       "year": 2024,
@@ -3369,7 +3378,8 @@
         "es": "applemusic://track/1723046101",
         "nl": "applemusic://track/1723046101",
         "it": "applemusic://track/1723046101"
-      }
+      },
+      "uri_tidal": "tidal://track/336703585"
     },
     {
       "year": 2022,
@@ -3395,7 +3405,8 @@
       "fun_fact_fr": "Hallo est devenu un énorme hit viral pour Antoon en 2022, dominant les charts néerlandais avec son ode nostalgique et chaleureuse.",
       "fun_fact_nl": "Hallo werd in 2022 een enorme viral hit voor Antoon, die de Nederlandse hitlijsten aanvoerde met zijn warme, nostalgische ode aan iemand uit het verleden. Antoon is een van de meest succesvolle jonge Nederlandse popartiesten, bekend om zijn pakkende melodieën en relativerende teksten. Het nummer werd een van de meest gestreamde Nederlandse tracks van het jaar.",
       "awards_nl": [],
-      "uri_youtube_music": "https://music.youtube.com/watch?v=8EAUAGtTclo"
+      "uri_youtube_music": "https://music.youtube.com/watch?v=8EAUAGtTclo",
+      "uri_tidal": "tidal://track/462805468"
     },
     {
       "year": 1967,
@@ -3452,7 +3463,8 @@
         "es": "applemusic://track/1442951442",
         "nl": "applemusic://track/1442951442",
         "it": "applemusic://track/1442951442"
-      }
+      },
+      "uri_tidal": "tidal://track/15752418"
     },
     {
       "year": 1984,
@@ -3488,7 +3500,8 @@
         "es": "applemusic://track/1705235721",
         "nl": "applemusic://track/1705235721",
         "it": "applemusic://track/1705235721"
-      }
+      },
+      "uri_tidal": "tidal://track/56826819"
     },
     {
       "year": 2025,
@@ -3504,7 +3517,7 @@
       "fun_fact_es": "Yves Berendse es un cantante neerlandés de la tradición feest y schlager en lengua neerlandesa.",
       "uri_apple_music": "applemusic://track/1822743009",
       "uri_youtube_music": "https://music.youtube.com/watch?v=ERSCR2cuqAU",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/444237000",
       "fun_fact_fr": "Yves Berendse est un chanteur néerlandais de la tradition feest et schlager en langue néerlandaise.",
       "fun_fact_nl": "Yves Berendse is een Nederlandse zanger in de Nederlandstalige feest- en schlagertraditie.",
       "awards_nl": [],
@@ -3533,7 +3546,7 @@
       "fun_fact_es": "Snelle es uno de los artistas de pop en neerlandés más populares de los últimos años, aquí con Zoë Livay.",
       "uri_apple_music": "applemusic://track/1801780608",
       "uri_youtube_music": "https://music.youtube.com/watch?v=nbV3wWY-JFk",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/423555096",
       "fun_fact_fr": "Snelle est l'un des artistes pop néerlandophones les plus populaires de ces dernières années, ici avec Zoë Livay.",
       "fun_fact_nl": "Snelle is een van de populairste Nederlandstalige popartiesten van de laatste jaren, hier met Zoë Livay.",
       "awards_nl": [],
@@ -3562,7 +3575,7 @@
       "fun_fact_es": "Una canción en neerlandés arraigada en la tradición estudiantil de Utrecht.",
       "uri_apple_music": "applemusic://track/1807093937",
       "uri_youtube_music": "https://music.youtube.com/watch?v=RhKm8YE_W0M",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/428630429",
       "fun_fact_fr": "Une chanson en néerlandais ancrée dans la tradition étudiante d'Utrecht.",
       "fun_fact_nl": "Een Nederlandstalig lied geworteld in de Utrechtse studententraditie.",
       "awards_nl": [],
@@ -3591,7 +3604,7 @@
       "fun_fact_es": "Jan Smit es una de las grandes estrellas del pop neerlandés; este dúo con el surinamés Damaru fue número uno.",
       "uri_apple_music": "applemusic://track/1219059350",
       "uri_youtube_music": "https://music.youtube.com/watch?v=JGsGAJIYDRo",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/69775530",
       "fun_fact_fr": "Jan Smit est l'une des plus grandes stars de la pop néerlandophone; ce duo avec le Surinamais Damaru fut numéro un.",
       "fun_fact_nl": "Jan Smit is een van de bekendste Nederlandstalige popsterren; dit duet met de Surinaamse artiest Damaru was een nummer 1-hit.",
       "awards_nl": [],


### PR DESCRIPTION
Eine Odesli-Welle, automatisch gefahren von `com.beatify.tidal-wave`.

- `top100-allertijden-nederlandstalig` Tidal 79 → **96**/104, version 1.13 → 1.14

Bilanz: 17 Treffer · 2 echte Misses · 29 Rate-Limit-Skips · 87 429-Zeilen.

**Draft mit Absicht** — Merge nur nach Markus' Freigabe.