### PR TITLE
chore(playlists): tidal backfill wave — +18 uris

### DIFF
--- a/custom_components/beatify/playlists/community/trance-classics.json
+++ b/custom_components/beatify/playlists/community/trance-classics.json
@@ -1,6 +1,6 @@
 {
   "name": "Trance Classics",
-  "version": "1.5",
+  "version": "1.6",
   "tags": [
     "trance",
     "hands-up",
@@ -505,7 +505,7 @@
         "it": "applemusic://track/1247939867"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=qoCoIrWcVMQ",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/70199934",
       "uri_deezer": "deezer://track/372961111",
       "fun_fact": "A trance and dance-floor classic (1997).",
       "fun_fact_de": "Ein Trance- und Dancefloor-Klassiker (1997).",
@@ -530,7 +530,7 @@
         "it": "applemusic://track/1203765916"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=pDeiPbJ2Q28",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/70199927",
       "uri_deezer": "deezer://track/435030182",
       "fun_fact": "A trance and dance-floor classic (1997).",
       "fun_fact_de": "Ein Trance- und Dancefloor-Klassiker (1997).",
@@ -555,7 +555,7 @@
         "it": "applemusic://track/438738791"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=MKrwetR7IPg",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/6874733",
       "uri_deezer": "deezer://track/12254747",
       "fun_fact": "A trance and dance-floor classic (1997).",
       "fun_fact_de": "Ein Trance- und Dancefloor-Klassiker (1997).",
@@ -580,7 +580,7 @@
         "it": "applemusic://track/1647327166"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=hhWf2GuDZZc",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/250952230",
       "uri_deezer": "deezer://track/1936409977",
       "fun_fact": "A trance and dance-floor classic (1997).",
       "fun_fact_de": "Ein Trance- und Dancefloor-Klassiker (1997).",
@@ -605,7 +605,7 @@
         "it": "applemusic://track/1505310416"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=Vxoyvz1na-E",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/19020555",
       "uri_deezer": "deezer://track/916849682",
       "fun_fact": "A trance and dance-floor classic (1997).",
       "fun_fact_de": "Ein Trance- und Dancefloor-Klassiker (1997).",
@@ -630,7 +630,7 @@
         "it": "applemusic://track/1160733023"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=xXahlXQhMF4",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/65545333",
       "uri_deezer": "deezer://track/133204794",
       "fun_fact": "A trance and dance-floor classic (1997).",
       "fun_fact_de": "Ein Trance- und Dancefloor-Klassiker (1997).",
@@ -680,7 +680,7 @@
         "it": "applemusic://track/1383671519"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=s9QS0Zlc_Yk",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/89356374",
       "uri_deezer": "deezer://track/504525632",
       "fun_fact": "A trance and dance-floor classic (1997).",
       "fun_fact_de": "Ein Trance- und Dancefloor-Klassiker (1997).",
@@ -705,7 +705,7 @@
         "it": "applemusic://track/1657448193"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=Y4xYY8uflFI",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/263785106",
       "uri_deezer": "deezer://track/2045342097",
       "fun_fact": "A trance and dance-floor classic (1997).",
       "fun_fact_de": "Ein Trance- und Dancefloor-Klassiker (1997).",
@@ -730,7 +730,7 @@
         "it": "applemusic://track/1703698474"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=89P8b-mIo8A",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/235078660",
       "uri_deezer": null,
       "fun_fact": "A trance and dance-floor classic (1998).",
       "fun_fact_de": "Ein Trance- und Dancefloor-Klassiker (1998).",
@@ -755,7 +755,7 @@
         "it": "applemusic://track/509175791"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=GA0g1hec-Bo",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/14094151",
       "uri_deezer": "deezer://track/604533",
       "fun_fact": "Faithless were a British electronic act behind some of dance music's biggest anthems.",
       "fun_fact_de": "Faithless waren ein britisches Electronic-Projekt hinter einigen der größten Dance-Hymnen.",
@@ -780,7 +780,7 @@
         "it": "applemusic://track/438700730"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=vTfJi_Oj24M",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/6874694",
       "uri_deezer": "deezer://track/12254712",
       "fun_fact": "A trance and dance-floor classic (1998).",
       "fun_fact_de": "Ein Trance- und Dancefloor-Klassiker (1998).",
@@ -805,7 +805,7 @@
         "it": "applemusic://track/1583233643"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=C9MT5NowzCk",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/86133790",
       "uri_deezer": "deezer://track/1541481792",
       "fun_fact": "A trance and dance-floor classic (1998).",
       "fun_fact_de": "Ein Trance- und Dancefloor-Klassiker (1998).",
@@ -830,7 +830,7 @@
         "it": "applemusic://track/1605918726"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=lBKtD9TdVrI",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/483399556",
       "uri_deezer": "deezer://track/1626487942",
       "fun_fact": "Paul van Dyk is a German DJ who became one of trance's first global superstars.",
       "fun_fact_de": "Paul van Dyk ist ein deutscher DJ, der zu einem der ersten globalen Trance-Superstars wurde.",
@@ -880,7 +880,7 @@
         "it": "applemusic://track/1790568085"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=pyPd5VuXzBQ",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/3834240",
       "uri_deezer": "deezer://track/2959691321",
       "fun_fact": "ATB is German producer André Tanneberger, whose 'guitar plucking' sound defined trance.",
       "fun_fact_de": "ATB ist der deutsche Produzent André Tanneberger, dessen 'Gitarren-Zupf'-Sound den Trance prägte.",
@@ -905,7 +905,7 @@
         "it": "applemusic://track/260655284"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=GWtSamzbGOs",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/3381203",
       "uri_deezer": "deezer://track/5363024",
       "fun_fact": "A trance and dance-floor classic (1999).",
       "fun_fact_de": "Ein Trance- und Dancefloor-Klassiker (1999).",
@@ -930,7 +930,7 @@
         "it": "applemusic://track/271969650"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=XjvkxXblpz8",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/7715350",
       "uri_deezer": "deezer://track/11390027",
       "fun_fact": "Darude is a Finnish producer whose 'Sandstorm' became an internet-era dance institution.",
       "fun_fact_de": "Darude ist ein finnischer Produzent, dessen 'Sandstorm' zur Dance-Institution des Internetzeitalters wurde.",
@@ -955,7 +955,7 @@
         "it": "applemusic://track/365527344"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=i-n6CUiFWjA",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/16908071",
       "uri_deezer": "deezer://track/61685880",
       "fun_fact": "A trance and dance-floor classic (1999).",
       "fun_fact_de": "Ein Trance- und Dancefloor-Klassiker (1999).",
@@ -980,7 +980,7 @@
         "it": "applemusic://track/1530897393"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=r9F2FrmnUdk",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/63261261",
       "uri_deezer": "deezer://track/61057255",
       "fun_fact": "Gigi D'Agostino is an Italian DJ and the figurehead of the bouncy 'Lento Violento' sound.",
       "fun_fact_de": "Gigi D'Agostino ist ein italienischer DJ und Galionsfigur des hüpfenden 'Lento Violento'-Sounds.",


### PR DESCRIPTION
Eine Odesli-Welle, automatisch gefahren von `com.beatify.tidal-wave`.

- `trance-classics` Tidal 18 → **36**/120, version 1.5 → 1.6

Bilanz: 18 Treffer · 1 echte Misses · 29 Rate-Limit-Skips · 87 429-Zeilen.

**Draft mit Absicht** — Merge nur nach Markus' Freigabe.