### PR TITLE
fix(health-check): read an iTunes 403 as throttling, not as unreachable

### DIFF
--- a/.claude/skills/playlist-health-check/scripts/validate_uris.py
+++ b/.claude/skills/playlist-health-check/scripts/validate_uris.py
@@ -32,6 +32,11 @@ def detect_provider(uri):
 # backoff before it is allowed to count as a defect. A 404 that survives all
 # retries is treated as genuinely dead.
 TRANSIENT_CODES = {408, 425, 429, 500, 502, 503, 504}
+# 403 is deliberately NOT in here. It means opposite things per provider:
+# iTunes answers 403 when it throttles, Spotify answers 403 for a track that is
+# genuinely restricted. Making it global would turn every restricted Spotify
+# track into a retried non-finding and add ~20s of backoff per one. The iTunes
+# reading is applied locally in check_apple_music instead.
 RETRY_BACKOFF = (1.0, 4.0, 15.0)   # sleep before attempt 2, 3, 4
 
 def http_json(url, headers=None, timeout=10, retry_404=False):
@@ -308,7 +313,9 @@ def check_apple_music(tid, title, artist):
         data, code, is_transient = http_json(url)
         if data is None:
             # iTunes throttles hard (403/429) — never call a track dead on that.
-            if is_transient: return transient(code, "Apple Music")
+            # 403 is not in TRANSIENT_CODES (it is a real defect at Spotify), so
+            # it is recognised here, where it can only mean throttling.
+            if is_transient or code == 403: return transient(code, "Apple Music")
             if code == 404: continue
             return {"status": "unreachable", "http_code": code, "detail": f"iTunes HTTP {code}"}
         if data.get("resultCount", 0) == 0:

--- a/tests/unit/test_playlist_health_itunes_403.py
+++ b/tests/unit/test_playlist_health_itunes_403.py
@@ -1,0 +1,99 @@
+"""iTunes 403 is throttling, Spotify 403 is a restricted track.
+
+The comment above ``check_apple_music`` has always promised "iTunes throttles
+hard (403/429) — never call a track dead on that", but 403 was not in
+``TRANSIENT_CODES``, so an iTunes 403 came back as ``unreachable`` rather than
+as a transient. Harmless on its own, and invisible until a long Apple backfill
+run put iTunes into throttling for hours.
+
+Adding 403 to the shared set would have been the obvious fix and the wrong one:
+Spotify answers 403 for a track that really is restricted, so the same change
+would turn a genuine defect into a retried non-finding and spend ~20 seconds of
+backoff on each one. The iTunes reading therefore lives in
+``check_apple_music``, where 403 can only mean throttling.
+
+These tests pin both halves of that split.
+"""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = (
+    Path(__file__).resolve().parents[2]
+    / ".claude/skills/playlist-health-check/scripts/validate_uris.py"
+)
+
+
+@pytest.fixture()
+def validator():
+    """A fresh module per test — each one swaps out http_json."""
+    spec = importlib.util.spec_from_file_location("validate_uris_403", _SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _answer(code, transient=False, calls=None):
+    """Stand in for http_json and always fail with `code`."""
+
+    def fake(url, headers=None, timeout=10, retry_404=False):
+        if calls is not None:
+            calls.append(url)
+        return None, code, transient
+
+    return fake
+
+
+def test_itunes_403_is_transient_not_a_defect(validator):
+    validator.http_json = _answer(403)
+    result = validator.check_apple_music("1440834619", "American Pie", "Don McLean")
+
+    assert result["status"] == "error"
+    assert result["transient"] is True
+    assert result["status"] != "dead"
+
+
+def test_itunes_403_does_not_walk_all_three_storefronts(validator):
+    """Throttling is about the caller, not the storefront — retrying us/de/gb
+    triples the load on a service that just asked us to slow down."""
+    calls = []
+    validator.http_json = _answer(403, calls=calls)
+    validator.check_apple_music("1440834619", "American Pie", "Don McLean")
+
+    assert len(calls) == 1
+
+
+def test_spotify_403_still_means_restricted(validator):
+    """The reason 403 stays out of TRANSIENT_CODES."""
+    validator.http_json = _answer(403)
+    result = validator.check_spotify("5A3IdgGphzKS2etiGFB73S", "Das Boot", "U96")
+
+    assert result["status"] == "dead"
+    assert result["detail"] == "Restricted"
+
+
+def test_403_stays_out_of_the_shared_transient_set(validator):
+    assert 403 not in validator.TRANSIENT_CODES
+    # The codes that really are provider-side stay in.
+    assert {429, 500, 503}.issubset(validator.TRANSIENT_CODES)
+
+
+def test_itunes_404_still_walks_the_storefronts(validator):
+    """The fallback that #1957-era runs depend on must survive the change."""
+    calls = []
+    validator.http_json = _answer(404, calls=calls)
+    result = validator.check_apple_music("1", "T", "A")
+
+    assert len(calls) == 3
+    assert result["status"] == "dead"
+
+
+@pytest.mark.parametrize("code", [429, 500, 503])
+def test_itunes_other_throttle_codes_unchanged(validator, code):
+    validator.http_json = _answer(code, transient=True)
+    result = validator.check_apple_music("1", "T", "A")
+
+    assert result["status"] == "error"
+    assert result["transient"] is True


### PR DESCRIPTION
## Was der Auftrag war und was daraus wurde

Auftrag war, **403 in `TRANSIENT_CODES` nachzutragen**, damit Kommentar und Code übereinstimmen. Beim Umsetzen zeigte sich, dass genau das etwas kaputt macht:

`TRANSIENT_CODES` gilt für **alle** Provider. Bei Spotify ist 403 aber ein **echter Befund** — `check_spotify` gibt dafür `dead / "Restricted"` zurück. Global gesetzt, würde jeder gesperrte Spotify-Track zu einem wiederholten Nicht-Befund, und jeder davon kostet zusätzlich rund **20 Sekunden Backoff**.

Der Fix sitzt deshalb dort, wo 403 nur eine Bedeutung haben kann: in `check_apple_music`. `TRANSIENT_CODES` bleibt unverändert und trägt jetzt einen Kommentar, **warum** 403 dort fehlt.

## Gegengeprüft statt angenommen

Mit auf 403 gezwungenem `http_json` gegen das echte Modul:

- `check_apple_music` → `error`, `transient: true`
- `check_spotify` → `dead` / `Restricted`

## Warum das gerade aufgefallen ist

Der Messlauf zu #2030 fragt seit heute früh `itunes.apple.com` ab und hat über 840 abgefangene 403er produziert. Dadurch stand die Frage im Raum, was der Health-Check bei laufender Drosselung meldet — und dabei fiel die Lücke zwischen Kommentar und Code auf.

## Tests

6 neue in `tests/unit/test_playlist_health_itunes_403.py`: beide Lesarten von 403, dass ein gedrosselter Lookup **nicht** mehr alle drei Storefronts abklappert (Drosselung betrifft den Aufrufer, nicht das Storefront), und dass der 404-Fallback über us/de/gb unangetastet bleibt.

`1631 passed`, `ruff check` und `format` sauber.

## Nebenbefund

Unter `.agents/skills/playlist-health-check/scripts/validate_uris.py` liegt eine **nicht versionierte, 309 Zeilen alte Kopie** desselben Skripts (aktuell sind 556 Zeilen). Sie ist nicht angefasst — wer sie ausführt, bekommt aber weder diesen Fix noch die Script-übergreifende Titel-Logik aus #1957.

🤖 Generated with [Claude Code](https://claude.com/claude-code)