### PR TITLE
chore(playlists): tidal backfill wave — +19 uris

### DIFF
--- a/custom_components/beatify/playlists/community/trance-classics.json
+++ b/custom_components/beatify/playlists/community/trance-classics.json
@@ -1,6 +1,6 @@
 {
   "name": "Trance Classics",
-  "version": "1.8",
+  "version": "1.9",
   "tags": [
     "trance",
     "hands-up",
@@ -1931,7 +1931,7 @@
         "it": "applemusic://track/1719317849"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=4nL5m74W9_U",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/649280",
       "uri_deezer": "deezer://track/15800611",
       "fun_fact": "A trance and dance-floor classic (2001).",
       "fun_fact_de": "Ein Trance- und Dancefloor-Klassiker (2001).",
@@ -1956,7 +1956,7 @@
         "it": "applemusic://track/67702305"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=hjNYw4x1sWI",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/3834374",
       "uri_deezer": "deezer://track/61676333",
       "fun_fact": "ATB is German producer André Tanneberger, whose 'guitar plucking' sound defined trance.",
       "fun_fact_de": "ATB ist der deutsche Produzent André Tanneberger, dessen 'Gitarren-Zupf'-Sound den Trance prägte.",
@@ -1981,7 +1981,7 @@
         "it": "applemusic://track/1731208758"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=HYVWhwkERcQ",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/122448027",
       "uri_deezer": "deezer://track/804239442",
       "fun_fact": "A trance and dance-floor classic (2002).",
       "fun_fact_de": "Ein Trance- und Dancefloor-Klassiker (2002).",
@@ -2006,7 +2006,7 @@
         "it": "applemusic://track/275599367"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=_-fr5i2dtME",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/15977137",
       "uri_deezer": "deezer://track/1138338122",
       "fun_fact": "A trance and dance-floor classic (2002).",
       "fun_fact_de": "Ein Trance- und Dancefloor-Klassiker (2002).",
@@ -2031,7 +2031,7 @@
         "it": "applemusic://track/454165725"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=rzEnAEI8Qkw",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/15975080",
       "uri_deezer": "deezer://track/727758952",
       "fun_fact": "A trance and dance-floor classic (2002).",
       "fun_fact_de": "Ein Trance- und Dancefloor-Klassiker (2002).",
@@ -2056,7 +2056,7 @@
         "it": "applemusic://track/438738841"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=h4h6EDIgHE8",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/6874737",
       "uri_deezer": "deezer://track/12254751",
       "fun_fact": "A trance and dance-floor classic (2002).",
       "fun_fact_de": "Ein Trance- und Dancefloor-Klassiker (2002).",
@@ -2081,7 +2081,7 @@
         "it": "applemusic://track/578610104"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=R0FDx5P8pWg",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/18199083",
       "uri_deezer": "deezer://track/62544290",
       "fun_fact": "A trance and dance-floor classic (2002).",
       "fun_fact_de": "Ein Trance- und Dancefloor-Klassiker (2002).",
@@ -2106,7 +2106,7 @@
         "it": "applemusic://track/1888467820"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=2Az_Ux2uNmk",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/1453841",
       "uri_deezer": "deezer://track/3925239971",
       "fun_fact": "A trance and dance-floor classic (2002).",
       "fun_fact_de": "Ein Trance- und Dancefloor-Klassiker (2002).",
@@ -2131,7 +2131,7 @@
         "it": "applemusic://track/1000698813"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=FW-8ZV2XRpE",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/46733734",
       "uri_deezer": "deezer://track/101575828",
       "fun_fact": "A trance and dance-floor classic (2002).",
       "fun_fact_de": "Ein Trance- und Dancefloor-Klassiker (2002).",
@@ -2156,7 +2156,7 @@
         "it": "applemusic://track/1000699043"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=wJlCXNBL8Is",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/46733739",
       "uri_deezer": "deezer://track/101575838",
       "fun_fact": "A trance and dance-floor classic (2002).",
       "fun_fact_de": "Ein Trance- und Dancefloor-Klassiker (2002).",
@@ -2181,7 +2181,7 @@
         "it": "applemusic://track/1692345732"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=Tvx1Hehxzko",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/279180985",
       "uri_deezer": "deezer://track/2168791207",
       "fun_fact": "Scooter are a German group famous for H.P. Baxxter's shouted catchphrases and hard dance beats.",
       "fun_fact_de": "Scooter sind eine deutsche Gruppe, berühmt für H.P. Baxxters gebrüllte Catchphrases und harte Dance-Beats.",
@@ -2206,7 +2206,7 @@
         "it": "applemusic://track/1708999657"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=HiuqKbetgXw",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/279180978",
       "uri_deezer": "deezer://track/2482991481",
       "fun_fact": "Scooter are a German group famous for H.P. Baxxter's shouted catchphrases and hard dance beats.",
       "fun_fact_de": "Scooter sind eine deutsche Gruppe, berühmt für H.P. Baxxters gebrüllte Catchphrases und harte Dance-Beats.",
@@ -2231,7 +2231,7 @@
         "it": "applemusic://track/1843365310"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=f-xKKx5eVZg",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/415034823",
       "uri_deezer": "deezer://track/3125016911",
       "fun_fact": "Tiësto is a Dutch DJ who helped take trance from clubs to stadiums worldwide.",
       "fun_fact_de": "Tiësto ist ein niederländischer DJ, der Trance von den Clubs in die Stadien der Welt brachte.",
@@ -2256,7 +2256,7 @@
         "it": "applemusic://track/1668179033"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=9gKTxhYeJCY",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/273603097",
       "uri_deezer": null,
       "fun_fact": "A trance and dance-floor classic (2002).",
       "fun_fact_de": "Ein Trance- und Dancefloor-Klassiker (2002).",
@@ -2281,7 +2281,7 @@
         "it": "applemusic://track/1691685783"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=EhDI2bNR18Y",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/173330",
       "uri_deezer": "deezer://track/762855",
       "fun_fact": "A trance and dance-floor classic (2003).",
       "fun_fact_de": "Ein Trance- und Dancefloor-Klassiker (2003).",
@@ -2306,7 +2306,7 @@
         "it": "applemusic://track/1455468598"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=RqmufRi2KyM",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/105248338",
       "uri_deezer": "deezer://track/643744962",
       "fun_fact": "A trance and dance-floor classic (2003).",
       "fun_fact_de": "Ein Trance- und Dancefloor-Klassiker (2003).",
@@ -2331,7 +2331,7 @@
         "it": "applemusic://track/519216714"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=g6oPaJ1pctk",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/88075110",
       "uri_deezer": "deezer://track/487971832",
       "fun_fact": "A trance and dance-floor classic (2004).",
       "fun_fact_de": "Ein Trance- und Dancefloor-Klassiker (2004).",
@@ -2356,7 +2356,7 @@
         "it": "applemusic://track/1000699030"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=zMpm_CuEI-M",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/46733735",
       "uri_deezer": "deezer://track/101575830",
       "fun_fact": "A trance and dance-floor classic (2004).",
       "fun_fact_de": "Ein Trance- und Dancefloor-Klassiker (2004).",
@@ -2381,7 +2381,7 @@
         "it": "applemusic://track/925659664"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=uDGJ9DyF25I",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/40844686",
       "uri_deezer": "deezer://track/78304463",
       "fun_fact": "A trance and dance-floor classic (2004).",
       "fun_fact_de": "Ein Trance- und Dancefloor-Klassiker (2004).",


### PR DESCRIPTION
Eine Odesli-Welle, automatisch gefahren von `com.beatify.tidal-wave`.

- `trance-classics` Tidal 70 → **89**/120, version 1.8 → 1.9

Bilanz: 19 Treffer · 0 echte Misses · 29 Rate-Limit-Skips · 87 429-Zeilen.

**Draft mit Absicht** — Merge nur nach Markus' Freigabe.