### PR TITLE
chore(playlists): tidal backfill wave — +15 uris

### DIFF
--- a/custom_components/beatify/playlists/community/trance-classics.json
+++ b/custom_components/beatify/playlists/community/trance-classics.json
@@ -1,6 +1,6 @@
 {
   "name": "Trance Classics",
-  "version": "1.9",
+  "version": "1.10",
   "tags": [
     "trance",
     "hands-up",
@@ -2406,7 +2406,7 @@
         "it": "applemusic://track/1809974901"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=Xu2B3TgNwVo",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/64328325",
       "uri_deezer": "deezer://track/3334867981",
       "fun_fact": "A trance and dance-floor classic (2004).",
       "fun_fact_de": "Ein Trance- und Dancefloor-Klassiker (2004).",
@@ -2431,7 +2431,7 @@
         "it": "applemusic://track/1541606763"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=5eOMT6at2FE",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/159123965",
       "uri_deezer": "deezer://track/135335116",
       "fun_fact": "A trance and dance-floor classic (2004).",
       "fun_fact_de": "Ein Trance- und Dancefloor-Klassiker (2004).",
@@ -2456,7 +2456,7 @@
         "it": "applemusic://track/1541606760"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=2pspyVddtkU",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/159123963",
       "uri_deezer": "deezer://track/135335112",
       "fun_fact": "A trance and dance-floor classic (2004).",
       "fun_fact_de": "Ein Trance- und Dancefloor-Klassiker (2004).",
@@ -2506,7 +2506,7 @@
         "it": "applemusic://track/1024495874"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=EiS9isTa82Y",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/65170112",
       "uri_deezer": "deezer://track/3212563611",
       "fun_fact": "Tiësto is a Dutch DJ who helped take trance from clubs to stadiums worldwide.",
       "fun_fact_de": "Tiësto ist ein niederländischer DJ, der Trance von den Clubs in die Stadien der Welt brachte.",
@@ -2531,7 +2531,7 @@
         "it": "applemusic://track/352917828"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=enOtfOGqm-0",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/5731682",
       "uri_deezer": "deezer://track/387719111",
       "fun_fact": "Cascada are a German act that brought hands-up dance-pop to the global charts.",
       "fun_fact_de": "Cascada sind ein deutscher Act, der Hands-Up-Dance-Pop in die weltweiten Charts brachte.",
@@ -2556,7 +2556,7 @@
         "it": "applemusic://track/696479088"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=4qlDWL1kMcQ",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/154511",
       "uri_deezer": null,
       "fun_fact": "A trance and dance-floor classic (2005).",
       "fun_fact_de": "Ein Trance- und Dancefloor-Klassiker (2005).",
@@ -2606,7 +2606,7 @@
         "it": "applemusic://track/82446848"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=Py-foWjaZ2U",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/247632383",
       "uri_deezer": "deezer://track/61662767",
       "fun_fact": "A trance and dance-floor classic (2005).",
       "fun_fact_de": "Ein Trance- und Dancefloor-Klassiker (2005).",
@@ -2631,7 +2631,7 @@
         "it": "applemusic://track/1828435408"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=sUiZwsTqolQ",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/284283184",
       "uri_deezer": "deezer://track/2171027587",
       "fun_fact": "A trance and dance-floor classic (2005).",
       "fun_fact_de": "Ein Trance- und Dancefloor-Klassiker (2005).",
@@ -2656,7 +2656,7 @@
         "it": "applemusic://track/1886746417"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=UG1QPlR4X04",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/2382805",
       "uri_deezer": "deezer://track/3635868902",
       "fun_fact": "A trance and dance-floor classic (2005).",
       "fun_fact_de": "Ein Trance- und Dancefloor-Klassiker (2005).",
@@ -2681,7 +2681,7 @@
         "it": "applemusic://track/963586125"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=IQtlZXsslGw",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/88325807",
       "uri_deezer": "deezer://track/494659282",
       "fun_fact": "A trance and dance-floor classic (2005).",
       "fun_fact_de": "Ein Trance- und Dancefloor-Klassiker (2005).",
@@ -2731,7 +2731,7 @@
         "it": "applemusic://track/279679223"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=XaA6i32f2PY",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/1844969",
       "uri_deezer": "deezer://track/735670",
       "fun_fact": "A trance and dance-floor classic (2006).",
       "fun_fact_de": "Ein Trance- und Dancefloor-Klassiker (2006).",
@@ -2756,7 +2756,7 @@
         "it": "applemusic://track/6769267879"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=WCcj-8d_K2M",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/13843082",
       "uri_deezer": "deezer://track/1755793187",
       "fun_fact": "A trance and dance-floor classic (2006).",
       "fun_fact_de": "Ein Trance- und Dancefloor-Klassiker (2006).",
@@ -2781,7 +2781,7 @@
         "it": "applemusic://track/1216908995"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=1uy7r3ZexLY",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/529049235",
       "uri_deezer": "deezer://track/144527228",
       "fun_fact": "A trance and dance-floor classic (2006).",
       "fun_fact_de": "Ein Trance- und Dancefloor-Klassiker (2006).",
@@ -2806,7 +2806,7 @@
         "it": "applemusic://track/1539215862"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=Aivzwnexylg",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/161301487",
       "uri_deezer": "deezer://track/1134280742",
       "fun_fact": "A trance and dance-floor classic (2006).",
       "fun_fact_de": "Ein Trance- und Dancefloor-Klassiker (2006).",
@@ -2848,7 +2848,7 @@
         "it": "applemusic://track/1120222071"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=hf34GxAzASE",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/61540990",
       "uri_deezer": "deezer://track/126036749",
       "fun_fact": "A trance and dance-floor classic (2006).",
       "fun_fact_de": "Ein Trance- und Dancefloor-Klassiker (2006).",


### PR DESCRIPTION
Eine Odesli-Welle, automatisch gefahren von `com.beatify.tidal-wave`.

- `trance-classics` Tidal 89 → **104**/120, version 1.9 → 1.10

Bilanz: 15 Treffer · 3 echte Misses · 31 Rate-Limit-Skips · 87 429-Zeilen.

**Draft mit Absicht** — Merge nur nach Markus' Freigabe.