### PR TITLE
chore(playlists): tidal backfill wave — +15 uris

### DIFF
--- a/custom_components/beatify/playlists/community/trance-classics.json
+++ b/custom_components/beatify/playlists/community/trance-classics.json
@@ -1,6 +1,6 @@
 {
   "name": "Trance Classics",
-  "version": "1.10",
+  "version": "1.11",
   "tags": [
     "trance",
     "hands-up",
@@ -2873,7 +2873,7 @@
         "it": "applemusic://track/1648265171"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=y4-xi4kH63M",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/15742376",
       "uri_deezer": "deezer://track/1945881057",
       "fun_fact": "A trance and dance-floor classic (2007).",
       "fun_fact_de": "Ein Trance- und Dancefloor-Klassiker (2007).",
@@ -2898,7 +2898,7 @@
         "it": "applemusic://track/1526153479"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=MGmmg2UoVlA",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/150853312",
       "uri_deezer": "deezer://track/1041079272",
       "fun_fact": "A trance and dance-floor classic (2007).",
       "fun_fact_de": "Ein Trance- und Dancefloor-Klassiker (2007).",
@@ -2923,7 +2923,7 @@
         "it": "applemusic://track/304161923"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=gP7QjAQAfVc",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/3436136",
       "uri_deezer": "deezer://track/3377717621",
       "fun_fact": "A trance and dance-floor classic (2008).",
       "fun_fact_de": "Ein Trance- und Dancefloor-Klassiker (2008).",
@@ -2948,7 +2948,7 @@
         "it": "applemusic://track/518488101"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=9T1CCYpddto",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/73486347",
       "uri_deezer": "deezer://track/356709551",
       "fun_fact": "A trance and dance-floor classic (2008).",
       "fun_fact_de": "Ein Trance- und Dancefloor-Klassiker (2008).",
@@ -2973,7 +2973,7 @@
         "it": "applemusic://track/322109282"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=E2Z40L3cWkc",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/3087251",
       "uri_deezer": "deezer://track/4161883",
       "fun_fact": "A trance and dance-floor classic (2009).",
       "fun_fact_de": "Ein Trance- und Dancefloor-Klassiker (2009).",

--- a/custom_components/beatify/playlists/disco-funk-classics.json
+++ b/custom_components/beatify/playlists/disco-funk-classics.json
@@ -1,6 +1,6 @@
 {
   "name": "Disco & Funk Classics",
-  "version": "1.8",
+  "version": "1.9",
   "tags": [
     "1970s",
     "1980s",
@@ -3121,7 +3121,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/2879929",
       "uri_deezer": "deezer://track/3151319",
       "isrc": "GBAYE7600024"
     },
@@ -3156,7 +3156,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/20481133",
       "uri_deezer": "deezer://track/891619",
       "isrc": "USFI87800059"
     },
@@ -3191,7 +3191,7 @@
         "it": "applemusic://track/1590817672"
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/496171943",
       "uri_deezer": "deezer://track/3803021252",
       "isrc": "GBAJE7900087"
     },
@@ -3226,7 +3226,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/1785214",
       "uri_deezer": "deezer://track/846326",
       "isrc": "USAT20102201"
     },
@@ -3261,7 +3261,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/64498756",
       "uri_deezer": "deezer://track/538706962",
       "isrc": "USPR39402398"
     },
@@ -3296,7 +3296,7 @@
         "it": "applemusic://track/1444081381"
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/93614024",
       "uri_deezer": "deezer://track/94556154",
       "isrc": "USDJ20110815"
     },
@@ -3331,7 +3331,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/299130",
       "uri_deezer": "deezer://track/662391362",
       "isrc": "USAT20102506"
     },
@@ -3366,7 +3366,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/506143303",
       "uri_deezer": null,
       "isrc": null
     },
@@ -3401,7 +3401,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/10906574",
       "uri_deezer": "deezer://track/4094693",
       "isrc": "USWB10104850"
     },
@@ -3436,7 +3436,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/355682487",
       "uri_deezer": "deezer://track/3824997371",
       "isrc": "USWB10903605"
     },


### PR DESCRIPTION
Eine Odesli-Welle, automatisch gefahren von `com.beatify.tidal-wave`.

- `trance-classics` Tidal 104 → **109**/120, version 1.10 → 1.11
- `disco-funk-classics` Tidal 73 → **83**/98, version 1.8 → 1.9

Bilanz: 15 Treffer · 3 echte Misses · 31 Rate-Limit-Skips · 90 429-Zeilen.

**Draft mit Absicht** — Merge nur nach Markus' Freigabe.