### PR TITLE
feat(provider-backfill): --max und --max-minutes, Parität zu backfill_tidal.py

### DIFF
--- a/.claude/skills/provider-uri-backfill/scripts/backfill_provider_uris.py
+++ b/.claude/skills/provider-uri-backfill/scripts/backfill_provider_uris.py
@@ -701,7 +701,18 @@ def run(args: argparse.Namespace) -> int:
         f"cursor at song #{yt_state.cursor}"
     )
 
+    # Run caps, same semantics as scripts/backfill_tidal.py. Without them a single
+    # run is unbounded: Odesli's 429 backoff makes duration far less predictable
+    # than query count, so a 100-track playlist can outlast any scheduling window
+    # a caller reserved for it. Stopping early is safe because every filled URI is
+    # flushed to disk per song below.
+    queried = 0
+    deadline = time.monotonic() + args.max_minutes * 60 if args.max_minutes else None
+    stop_reason: str | None = None
+
     for path in playlist_paths:
+        if stop_reason:
+            break
         data = json.loads(path.read_text())
         songs = data.get("songs", [])
         cov = coverage_for_playlist(rel_name(root, path), str(path), songs)
@@ -709,6 +720,12 @@ def run(args: argparse.Namespace) -> int:
         version_bumped = False
 
         for song in songs:
+            if args.max and queried >= args.max:
+                stop_reason = f"reached --max {args.max}"
+                break
+            if deadline is not None and time.monotonic() >= deadline:
+                stop_reason = f"reached --max-minutes {args.max_minutes:g}"
+                break
             this_global_idx = global_idx
             global_idx += 1
             sid = spotify_track_id(song.get("uri"))
@@ -726,6 +743,9 @@ def run(args: argparse.Namespace) -> int:
             # first pass before spending an expensive search.list call.
             want_odesli = bool(non_yt_gaps) or (yt_gap and yt_key)
             if want_odesli:
+                # Counted before the call, so --max caps attempts rather than
+                # successes — a run that only hits 429s must still terminate.
+                queried += 1
                 # payload is None when Odesli is unavailable (429 exhausted /
                 # error) — skip Odesli for this song but keep going so the
                 # independent YouTube phase below still runs (#1687).
@@ -805,11 +825,18 @@ def run(args: argparse.Namespace) -> int:
 
         coverages.append(cov)
 
+    if stop_reason:
+        print(f"{stop_reason}, stopping")
+
     if yt_key:
         save_state(state_path, yt_state)
 
     report = build_report(
-        coverages, today, applied=args.apply, yt_phase_note=yt_phase_note
+        coverages,
+        today,
+        applied=args.apply,
+        yt_phase_note=yt_phase_note,
+        stop_reason=stop_reason,
     )
     out_path = (
         Path(args.output) if args.output else (root / "docs" / "provider-coverage.md")
@@ -823,7 +850,12 @@ def run(args: argparse.Namespace) -> int:
 
 
 def build_report(
-    coverages: list[PlaylistCoverage], today: str, *, applied: bool, yt_phase_note: str
+    coverages: list[PlaylistCoverage],
+    today: str,
+    *,
+    applied: bool,
+    yt_phase_note: str,
+    stop_reason: str | None = None,
 ) -> str:
     label = {
         "apple_music": "Apple",
@@ -842,6 +874,13 @@ def build_report(
         f"> Generated: {today}",
         f"> Mode: {'APPLY' if applied else 'DRY-RUN (no JSON written)'}",
         f"> YouTube phase: {yt_phase_note}",
+        # A capped run covers only part of the catalogue. Saying so in the report
+        # keeps a truncated run from reading like a complete one.
+        *(
+            [f"> Run stopped early: {stop_reason} — coverage below is partial."]
+            if stop_reason
+            else []
+        ),
         "",
         "## Summary",
         "",
@@ -907,6 +946,18 @@ def build_arg_parser() -> argparse.ArgumentParser:
         type=int,
         default=90,
         help="Max YouTube search.list calls per day (default 90)",
+    )
+    p.add_argument(
+        "--max",
+        type=int,
+        default=0,
+        help="cap number of Odesli queries this run (0 = no cap)",
+    )
+    p.add_argument(
+        "--max-minutes",
+        type=float,
+        default=0,
+        help="stop the run after this many minutes of wall-clock (0 = no limit)",
     )
     return p
 

--- a/tests/unit/test_provider_uri_backfill.py
+++ b/tests/unit/test_provider_uri_backfill.py
@@ -929,3 +929,167 @@ def test_run_apply_itunes_fills_apple_when_odesli_lacks_it(tmp_path, monkeypatch
     song = json.loads(f.read_text())["songs"][0]
     assert song["uri_tidal"] == "tidal://track/7"
     assert song["uri_apple_music"] == "applemusic://track/808080"
+
+
+# --------------------------------------------------------------------------
+# Run caps: --max / --max-minutes (parity with scripts/backfill_tidal.py)
+#
+# Motivation: without a cap a single run is unbounded. Odesli's 429 backoff makes
+# duration far less predictable than query count, so one 100-track playlist can
+# outlast the scheduling window a caller reserved for it — which is exactly how
+# the youtube-backfill agent collided with the hourly Tidal wave on 2026-08-10.
+# --------------------------------------------------------------------------
+
+
+def _capped_songs(n: int) -> list[dict]:
+    return [
+        {
+            "artist": f"Artist {i}",
+            "title": f"Title {i}",
+            "uri": "spotify:track:" + f"{i:022d}",
+        }
+        for i in range(n)
+    ]
+
+
+def test_max_caps_odesli_queries(tmp_path, monkeypatch):
+    pl_dir = tmp_path / "custom_components" / "beatify" / "playlists"
+    pl_dir.mkdir(parents=True)
+    _write_playlist(pl_dir, "many", _capped_songs(10))
+
+    calls = []
+    monkeypatch.setattr(bf, "fetch_odesli", lambda sid, **k: calls.append(sid) or None)
+    monkeypatch.setattr(bf, "resolve_apple_via_itunes", lambda *a, **k: None)
+    monkeypatch.setattr(bf.time, "sleep", lambda s: None)
+    monkeypatch.delenv("YOUTUBE_API_KEY", raising=False)
+
+    rc = bf.main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "--apply",
+            "--output",
+            str(tmp_path / "cov.md"),
+            "--state",
+            str(tmp_path / "state.json"),
+            "--odesli-sleep",
+            "0",
+            "--max",
+            "3",
+        ]
+    )
+    assert rc == 0
+    # Exactly three attempts, not ten — and counted per attempt, so a run that
+    # only ever gets 429s (fetch_odesli -> None) still terminates.
+    assert len(calls) == 3
+
+
+def test_max_minutes_stops_run(tmp_path, monkeypatch):
+    pl_dir = tmp_path / "custom_components" / "beatify" / "playlists"
+    pl_dir.mkdir(parents=True)
+    _write_playlist(pl_dir, "many", _capped_songs(10))
+
+    calls = []
+    # Clock jumps past the deadline after the second song's check.
+    ticks = iter([0, 0, 0, 10_000, 10_000, 10_000, 10_000, 10_000, 10_000, 10_000])
+    monkeypatch.setattr(bf.time, "monotonic", lambda: next(ticks, 10_000))
+    monkeypatch.setattr(bf, "fetch_odesli", lambda sid, **k: calls.append(sid) or None)
+    monkeypatch.setattr(bf, "resolve_apple_via_itunes", lambda *a, **k: None)
+    monkeypatch.setattr(bf.time, "sleep", lambda s: None)
+    monkeypatch.delenv("YOUTUBE_API_KEY", raising=False)
+
+    rc = bf.main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "--apply",
+            "--output",
+            str(tmp_path / "cov.md"),
+            "--state",
+            str(tmp_path / "state.json"),
+            "--odesli-sleep",
+            "0",
+            "--max-minutes",
+            "1",
+        ]
+    )
+    assert rc == 0
+    assert len(calls) < 10  # stopped early, did not walk the whole playlist
+
+
+def test_no_cap_by_default_walks_everything(tmp_path, monkeypatch):
+    pl_dir = tmp_path / "custom_components" / "beatify" / "playlists"
+    pl_dir.mkdir(parents=True)
+    _write_playlist(pl_dir, "many", _capped_songs(6))
+
+    calls = []
+    monkeypatch.setattr(bf, "fetch_odesli", lambda sid, **k: calls.append(sid) or None)
+    monkeypatch.setattr(bf, "resolve_apple_via_itunes", lambda *a, **k: None)
+    monkeypatch.setattr(bf.time, "sleep", lambda s: None)
+    monkeypatch.delenv("YOUTUBE_API_KEY", raising=False)
+
+    rc = bf.main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "--apply",
+            "--output",
+            str(tmp_path / "cov.md"),
+            "--state",
+            str(tmp_path / "state.json"),
+            "--odesli-sleep",
+            "0",
+        ]
+    )
+    assert rc == 0
+    assert len(calls) == 6  # defaults stay uncapped — no behaviour change
+
+
+def test_capped_run_marks_report_as_partial(tmp_path, monkeypatch):
+    # A truncated run must not read like a complete one. Same failure mode that
+    # made the youtube-backfill agent report "nochange" on a broken run.
+    pl_dir = tmp_path / "custom_components" / "beatify" / "playlists"
+    pl_dir.mkdir(parents=True)
+    _write_playlist(pl_dir, "many", _capped_songs(5))
+
+    monkeypatch.setattr(bf, "fetch_odesli", lambda sid, **k: None)
+    monkeypatch.setattr(bf, "resolve_apple_via_itunes", lambda *a, **k: None)
+    monkeypatch.setattr(bf.time, "sleep", lambda s: None)
+    monkeypatch.delenv("YOUTUBE_API_KEY", raising=False)
+
+    cov = tmp_path / "cov.md"
+    bf.main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "--apply",
+            "--output",
+            str(cov),
+            "--state",
+            str(tmp_path / "state.json"),
+            "--odesli-sleep",
+            "0",
+            "--max",
+            "2",
+        ]
+    )
+    text = cov.read_text()
+    assert "stopped early" in text
+    assert "reached --max 2" in text
+
+    # And the uncapped run says nothing of the sort.
+    cov2 = tmp_path / "cov2.md"
+    bf.main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "--apply",
+            "--output",
+            str(cov2),
+            "--state",
+            str(tmp_path / "state.json"),
+            "--odesli-sleep",
+            "0",
+        ]
+    )
+    assert "stopped early" not in cov2.read_text()


### PR DESCRIPTION
## Warum

`backfill_provider_uris.py` kennt keine Laufzeitgrenze. Ein Lauf geht über alles, was Lücken hat, und endet, wenn er fertig ist — oder eben nicht.

**Konkret gemessen am 10.08.2026**: ein Lauf über **eine** Playlist mit 100 YouTube-Lücken hing nach **34 Minuten** immer noch. Rechnerisch wären es 10 gewesen (6 Sekunden Odesli-Abstand × 100), der Rest ging in 429-Backoff. In der Zwischenzeit startete die stündliche `com.beatify.tidal-wave` — und beide Läufe hingen gleichzeitig an derselben Odesli-Quote.

`scripts/backfill_tidal.py` hat für genau dieses Problem seit jeher zwei Flags. Dieses Skript hatte keins davon. Deshalb hält die Tidal-Welle ihr 30-Minuten-Fenster verlässlich ein und ein darauf aufgebauter Backfill-Agent nicht.

## Was

| Flag | Bedeutung | Default |
|---|---|---|
| `--max N` | Deckel auf die Zahl der Odesli-Anfragen | `0` = kein Deckel |
| `--max-minutes M` | Abbruch nach Wanduhr-Zeit | `0` = keine Grenze |

Semantik und Hilfetexte sind bewusst wortgleich zu `backfill_tidal.py` gehalten.

**Drei Details, die nicht offensichtlich sind:**

1. **`--max` zählt Versuche, nicht Treffer.** Der Zähler steht vor dem Aufruf. Ein Lauf, der ausschließlich 429er kassiert (`fetch_odesli → None`), muss trotzdem terminieren — sonst wäre der Deckel genau dann wirkungslos, wenn man ihn am dringendsten braucht.
2. **Der Abbruch ist verlustfrei.** Jede gefüllte URI wird bereits pro Song auf die Platte geschrieben (der bestehende Incremental-Flush). Das ist derselbe Grund, aus dem `backfill_tidal.py` auf Zeit abbrechen darf — und der Grund, warum ein externer `timeout`-Wrapper hier falsch wäre.
3. **Der Coverage-Report sagt jetzt, wenn er unvollständig ist.** Ein gedeckelter Lauf schreibt `> Run stopped early: … — coverage below is partial.` Ohne diese Zeile liest sich ein abgebrochener Lauf exakt wie ein vollständiger. Das ist dieselbe Verwechslungsgefahr, die am selben Tag einen Agenten einen mit `rc=2` gescheiterten Lauf als „nochange — 0 Dateien geändert" melden ließ.

## Tests

4 neue, alle mit gemocktem Netz:

- `test_max_caps_odesli_queries` — 10 Songs, `--max 3` → genau 3 Anfragen
- `test_max_minutes_stops_run` — `time.monotonic` springt über die Deadline, der Lauf endet vor dem Ende der Playlist
- `test_no_cap_by_default_walks_everything` — ohne Flags unverändert alle 6 Songs, **kein Verhaltensbruch**
- `test_capped_run_marks_report_as_partial` — gedeckelter Lauf markiert den Report, ungedeckelter nicht

`1636 passed`, `ruff check` und `ruff format --check` grün. Unter Python 3.9 lauffähig geprüft — das ist die Runtime, in der die LaunchAgents das Skript aufrufen.

## Folge

Danach lässt sich der (aktuell stillgelegte) `com.beatify.youtube-backfill` wieder scharfschalten, dann mit `--max-minutes 25`: er endet damit sicher vor der nächsten Welle zur vollen Stunde.

## Hinweis am Rande

Die Datei liegt unter `.claude/`, was in `.gitignore` steht — sie ist aber **trotzdem versioniert** (seinerzeit force-added). `git add` braucht hier `-f`. Die Notiz in `beatifybot/CLAUDE.md`, die Skills dort seien unversioniert, stimmt für dieses Skript und für `playlist-health-check` nicht.