### PR TITLE
feat(provider-backfill): Deezer-Suchtreffer-Fallback mit Verify-Gate

### DIFF
--- a/.claude/skills/provider-uri-backfill/scripts/backfill_provider_uris.py
+++ b/.claude/skills/provider-uri-backfill/scripts/backfill_provider_uris.py
@@ -853,17 +853,6 @@ def run(args: argparse.Namespace) -> int:
                             song[PROVIDER_FIELDS[prov]] = val
                             cov.filled_this_run[prov] += 1
                             song_dirty = True
-                    # Deezer secondary verify via ISRC if Odesli missed it.
-                    if (
-                        "deezer" in non_yt_gaps
-                        and not song.get("uri_deezer")
-                        and song.get("isrc")
-                    ):
-                        did = fetch_deezer_isrc(song["isrc"])
-                        if did:
-                            song["uri_deezer"] = deezer_uri(did)
-                            cov.filled_this_run["deezer"] += 1
-                            song_dirty = True
                     # YouTube free-first: trust Odesli's link only if oembed
                     # confirms artist+title (filters covers/live re-uploads).
                     if yt_gap and yt_key and not song.get("uri_youtube_music"):
@@ -882,12 +871,19 @@ def run(args: argparse.Namespace) -> int:
                         song["uri_apple_music"] = apple_uri(aid)
                         cov.filled_this_run["apple_music"] += 1
                         song_dirty = True
-                # Deezer search fallback (keyless, verify-gated) — last resort after
-                # Odesli and the exact ISRC lookup. Sits at this level, not inside the
-                # ``payload is not None`` block, so it still runs while Odesli is down;
-                # same placement as the Apple fallback above.
+                # Deezer, zwei Stufen, beide AUSSERHALB des ``payload``-Blocks.
+                #
+                # Die ISRC-Abfrage sass bis 2026-08-10 *innerhalb* — sie lief also nur,
+                # wenn Odesli geantwortet hatte. Odesli antwortet aber regelmaessig mit
+                # 429 (die stuendliche Tidal-Welle teilt sich dieselbe Quote), und dann
+                # bekam Deezer gar nichts: kein Odesli-Link und keine ISRC-Abfrage.
+                # Apple lief im selben Lauf weiter, weil sein iTunes-Fallback schon
+                # immer hier draussen stand. Genau diese Asymmetrie erklaert Playlists
+                # mit voller Apple- und null Deezer-Abdeckung.
                 if "deezer" in non_yt_gaps and not song.get("uri_deezer"):
-                    did = resolve_deezer_via_search(song)
+                    did = (
+                        fetch_deezer_isrc(song["isrc"]) if song.get("isrc") else None
+                    ) or resolve_deezer_via_search(song)
                     if did:
                         song["uri_deezer"] = deezer_uri(did)
                         cov.filled_this_run["deezer"] += 1

--- a/.claude/skills/provider-uri-backfill/scripts/backfill_provider_uris.py
+++ b/.claude/skills/provider-uri-backfill/scripts/backfill_provider_uris.py
@@ -503,6 +503,101 @@ def fetch_deezer_isrc(
     return _numeric_id(data.get("id"))
 
 
+def deezer_search(
+    term: str, *, limit: int = 5, getter: Callable[[str], dict] = _http_get_json
+) -> list[dict]:
+    """Call the keyless Deezer search API. Returns ``data`` or ``[]``.
+
+    Never raises: any HTTP/network/parse error → ``[]`` (same contract as
+    :func:`itunes_search`).
+    """
+    q = urllib.parse.urlencode({"q": term, "limit": limit})
+    try:
+        data = getter(f"https://api.deezer.com/search?{q}")
+    except Exception:
+        return []
+    if not data or data.get("error"):
+        return []
+    return data.get("data") or []
+
+
+def _pick_deezer_match(
+    results: list[dict], title: str, artist: str, alt_artists: list[str]
+) -> str | None:
+    """Verify-gate for Deezer hits — mirrors :func:`_pick_itunes_match`.
+
+    Title AND artist must both fuzzy-match; the artist may be the primary one or
+    any ``alt_artists`` entry. Never guesses on title alone: "Iron Man" without
+    an artist check would happily return a cover band.
+    """
+    for r in results or []:
+        track_id = _numeric_id(r.get("id"))
+        if not track_id:
+            continue
+        r_title = r.get("title_short") or r.get("title") or ""
+        r_artist = ((r.get("artist") or {}).get("name")) or ""
+        if not titles_match(r_title, title):
+            continue
+        if titles_match(r_artist, artist) or any(
+            titles_match(r_artist, alt) for alt in (alt_artists or [])
+        ):
+            return track_id
+    return None
+
+
+def resolve_deezer_via_search(
+    song: dict, getter: Callable[[str], dict] = _http_get_json
+) -> str | None:
+    """Resolve a Deezer track id via search + gate, when ISRC and Odesli missed.
+
+    Why this exists: the ISRC endpoint is exact but only as good as the ISRC we
+    store. Catalogue rows frequently carry a reissue's ISRC that Deezer does not
+    index, while Deezer does hold an earlier remaster of the same recording —
+    measured 2026-08-10 on ``greatest-metal-songs``, where "Iron Man",
+    "Paranoid", "The Trooper" and "The Number of the Beast" all failed by ISRC
+    and all resolved by search. Apple already had this fallback; Deezer did not,
+    which is why whole playlists sat at zero Deezer coverage.
+
+    Query strategy mirrors :func:`resolve_apple_via_itunes`: most-specific first,
+    deduped, stops at the first gate-pass.
+    """
+    title = (song.get("title") or "").strip()
+    if not title:
+        return None
+    artist = (song.get("artist") or "").strip()
+    alt_artists = song.get("alt_artists") or []
+
+    stripped = strip_suffixes(title)
+    titles = _dedup([title, stripped])
+    artists = _dedup([a for a in (artist, strip_diacritics(artist)) if a])
+    folded_titles = _dedup([strip_diacritics(t) for t in titles])
+
+    terms: list[str] = []
+    for a in artists:
+        # Deezer's field-scoped syntax is far more precise than a bare term and
+        # keeps "Paranoid" from matching a hundred unrelated tracks.
+        for t in titles:
+            terms.append(f'artist:"{a}" track:"{t}"')
+        for t in folded_titles:
+            terms.append(f'artist:"{a}" track:"{t}"')
+        terms.append(f"{a} {stripped}")
+    for alt in alt_artists:
+        terms.append(f'artist:"{alt}" track:"{stripped}"')
+
+    seen: set[str] = set()
+    for term in terms:
+        term = _WHITESPACE_RE.sub(" ", term).strip()
+        if not term or term in seen:
+            continue
+        seen.add(term)
+        did = _pick_deezer_match(
+            deezer_search(term, getter=getter), title, artist, alt_artists
+        )
+        if did:
+            return did
+    return None
+
+
 def youtube_search_id(
     api_key: str,
     artist: str,
@@ -786,6 +881,16 @@ def run(args: argparse.Namespace) -> int:
                     if aid:
                         song["uri_apple_music"] = apple_uri(aid)
                         cov.filled_this_run["apple_music"] += 1
+                        song_dirty = True
+                # Deezer search fallback (keyless, verify-gated) — last resort after
+                # Odesli and the exact ISRC lookup. Sits at this level, not inside the
+                # ``payload is not None`` block, so it still runs while Odesli is down;
+                # same placement as the Apple fallback above.
+                if "deezer" in non_yt_gaps and not song.get("uri_deezer"):
+                    did = resolve_deezer_via_search(song)
+                    if did:
+                        song["uri_deezer"] = deezer_uri(did)
+                        cov.filled_this_run["deezer"] += 1
                         song_dirty = True
                 time.sleep(args.odesli_sleep)
 

--- a/tests/unit/test_provider_uri_backfill.py
+++ b/tests/unit/test_provider_uri_backfill.py
@@ -358,6 +358,7 @@ def test_run_dry_run_no_mutation(tmp_path, monkeypatch):
     monkeypatch.setattr(bf.time, "sleep", lambda s: None)
     # Keyless Apple iTunes fallback is network → stub it off in these tests.
     monkeypatch.setattr(bf, "resolve_apple_via_itunes", lambda *a, **k: None)
+    monkeypatch.setattr(bf, "resolve_deezer_via_search", lambda *a, **k: None)
     monkeypatch.delenv("YOUTUBE_API_KEY", raising=False)
 
     out = tmp_path / "coverage.md"
@@ -421,6 +422,7 @@ def test_run_apply_writes_uri(tmp_path, monkeypatch):
     monkeypatch.setattr(bf.time, "sleep", lambda s: None)
     # Keyless Apple iTunes fallback is network → stub it off in these tests.
     monkeypatch.setattr(bf, "resolve_apple_via_itunes", lambda *a, **k: None)
+    monkeypatch.setattr(bf, "resolve_deezer_via_search", lambda *a, **k: None)
     monkeypatch.delenv("YOUTUBE_API_KEY", raising=False)
 
     rc = bf.main(
@@ -475,6 +477,7 @@ def test_run_apply_odesli_429_does_not_block_youtube(tmp_path, monkeypatch):
     monkeypatch.setattr(bf.time, "sleep", lambda s: None)
     # Keyless Apple iTunes fallback is network → stub it off in these tests.
     monkeypatch.setattr(bf, "resolve_apple_via_itunes", lambda *a, **k: None)
+    monkeypatch.setattr(bf, "resolve_deezer_via_search", lambda *a, **k: None)
     monkeypatch.setenv("YOUTUBE_API_KEY", "KEY")
 
     rc = bf.main(
@@ -529,6 +532,7 @@ def test_run_apply_flushes_partial_progress_on_crash(tmp_path, monkeypatch):
     monkeypatch.setattr(bf.time, "sleep", lambda s: None)
     # Keyless Apple iTunes fallback is network → stub it off in these tests.
     monkeypatch.setattr(bf, "resolve_apple_via_itunes", lambda *a, **k: None)
+    monkeypatch.setattr(bf, "resolve_deezer_via_search", lambda *a, **k: None)
     monkeypatch.delenv("YOUTUBE_API_KEY", raising=False)
 
     with pytest.raises(RuntimeError):
@@ -795,6 +799,7 @@ def test_run_youtube_odesli_first_pass_skips_search_list(tmp_path, monkeypatch):
         },
     )
     monkeypatch.setattr(bf, "resolve_apple_via_itunes", lambda *a, **k: None)
+    monkeypatch.setattr(bf, "resolve_deezer_via_search", lambda *a, **k: None)
     monkeypatch.setattr(bf, "youtube_oembed_verify", lambda *a, **k: True)
 
     search_calls = {"n": 0}
@@ -853,6 +858,7 @@ def test_run_youtube_oembed_fail_falls_back_to_search_list(tmp_path, monkeypatch
         },
     )
     monkeypatch.setattr(bf, "resolve_apple_via_itunes", lambda *a, **k: None)
+    monkeypatch.setattr(bf, "resolve_deezer_via_search", lambda *a, **k: None)
     monkeypatch.setattr(bf, "youtube_oembed_verify", lambda *a, **k: False)
 
     search_calls = {"n": 0}
@@ -909,6 +915,7 @@ def test_run_apply_itunes_fills_apple_when_odesli_lacks_it(tmp_path, monkeypatch
         },
     )
     monkeypatch.setattr(bf, "resolve_apple_via_itunes", lambda *a, **k: "808080")
+    monkeypatch.setattr(bf, "resolve_deezer_via_search", lambda *a, **k: None)
     monkeypatch.setattr(bf.time, "sleep", lambda s: None)
     monkeypatch.delenv("YOUTUBE_API_KEY", raising=False)
 
@@ -960,6 +967,7 @@ def test_max_caps_odesli_queries(tmp_path, monkeypatch):
     calls = []
     monkeypatch.setattr(bf, "fetch_odesli", lambda sid, **k: calls.append(sid) or None)
     monkeypatch.setattr(bf, "resolve_apple_via_itunes", lambda *a, **k: None)
+    monkeypatch.setattr(bf, "resolve_deezer_via_search", lambda *a, **k: None)
     monkeypatch.setattr(bf.time, "sleep", lambda s: None)
     monkeypatch.delenv("YOUTUBE_API_KEY", raising=False)
 
@@ -995,6 +1003,7 @@ def test_max_minutes_stops_run(tmp_path, monkeypatch):
     monkeypatch.setattr(bf.time, "monotonic", lambda: next(ticks, 10_000))
     monkeypatch.setattr(bf, "fetch_odesli", lambda sid, **k: calls.append(sid) or None)
     monkeypatch.setattr(bf, "resolve_apple_via_itunes", lambda *a, **k: None)
+    monkeypatch.setattr(bf, "resolve_deezer_via_search", lambda *a, **k: None)
     monkeypatch.setattr(bf.time, "sleep", lambda s: None)
     monkeypatch.delenv("YOUTUBE_API_KEY", raising=False)
 
@@ -1025,6 +1034,7 @@ def test_no_cap_by_default_walks_everything(tmp_path, monkeypatch):
     calls = []
     monkeypatch.setattr(bf, "fetch_odesli", lambda sid, **k: calls.append(sid) or None)
     monkeypatch.setattr(bf, "resolve_apple_via_itunes", lambda *a, **k: None)
+    monkeypatch.setattr(bf, "resolve_deezer_via_search", lambda *a, **k: None)
     monkeypatch.setattr(bf.time, "sleep", lambda s: None)
     monkeypatch.delenv("YOUTUBE_API_KEY", raising=False)
 
@@ -1054,6 +1064,7 @@ def test_capped_run_marks_report_as_partial(tmp_path, monkeypatch):
 
     monkeypatch.setattr(bf, "fetch_odesli", lambda sid, **k: None)
     monkeypatch.setattr(bf, "resolve_apple_via_itunes", lambda *a, **k: None)
+    monkeypatch.setattr(bf, "resolve_deezer_via_search", lambda *a, **k: None)
     monkeypatch.setattr(bf.time, "sleep", lambda s: None)
     monkeypatch.delenv("YOUTUBE_API_KEY", raising=False)
 
@@ -1093,3 +1104,146 @@ def test_capped_run_marks_report_as_partial(tmp_path, monkeypatch):
         ]
     )
     assert "stopped early" not in cov2.read_text()
+
+
+# --------------------------------------------------------------------------
+# Deezer search fallback (parity with the Apple iTunes fallback)
+#
+# Motivation: the ISRC endpoint is exact but only as good as the stored ISRC.
+# Measured 2026-08-10 on greatest-metal-songs — "Iron Man", "Paranoid",
+# "The Trooper" and "The Number of the Beast" all carry reissue ISRCs Deezer
+# does not index, while Deezer holds earlier remasters of the same recordings.
+# Apple had a search fallback, Deezer did not; whole playlists sat at 0 Deezer.
+# --------------------------------------------------------------------------
+
+
+def _dz(track_id, title, artist):
+    return {
+        "id": track_id,
+        "title": title,
+        "title_short": title,
+        "artist": {"name": artist},
+    }
+
+
+def test_deezer_search_gate_accepts_matching_artist_and_title():
+    hit = bf._pick_deezer_match(
+        [_dz(3788156072, "Iron Man (Remastered 2009)", "Black Sabbath")],
+        "Iron Man",
+        "Black Sabbath",
+        [],
+    )
+    assert hit == "3788156072"
+
+
+def test_deezer_search_gate_rejects_wrong_artist():
+    # A cover band with the exact right title must NOT pass — this is the whole
+    # point of the gate. Title-only matching would happily return it.
+    assert (
+        bf._pick_deezer_match(
+            [_dz(999, "Iron Man", "Karaoke Allstars")], "Iron Man", "Black Sabbath", []
+        )
+        is None
+    )
+
+
+def test_deezer_search_gate_accepts_alt_artist():
+    hit = bf._pick_deezer_match(
+        [_dz(555, "Paranoid", "Ozzy Osbourne")],
+        "Paranoid",
+        "Black Sabbath",
+        ["Ozzy Osbourne"],
+    )
+    assert hit == "555"
+
+
+def test_deezer_search_gate_skips_results_without_id():
+    assert (
+        bf._pick_deezer_match(
+            [{"title": "Iron Man", "artist": {"name": "Black Sabbath"}}],
+            "Iron Man",
+            "Black Sabbath",
+            [],
+        )
+        is None
+    )
+
+
+def test_resolve_deezer_via_search_stops_at_first_gate_pass():
+    calls = []
+
+    def getter(url):
+        calls.append(url)
+        if "Iron%20Man" in url or "Iron+Man" in url:
+            return {"data": [_dz(42, "Iron Man (Remastered 2009)", "Black Sabbath")]}
+        return {"data": []}
+
+    got = bf.resolve_deezer_via_search(
+        {"artist": "Black Sabbath", "title": "Iron Man"}, getter=getter
+    )
+    assert got == "42"
+    assert len(calls) == 1  # first, most-specific term already passed
+
+
+def test_resolve_deezer_via_search_returns_none_when_nothing_matches():
+    got = bf.resolve_deezer_via_search(
+        {"artist": "Black Sabbath", "title": "Iron Man"},
+        getter=lambda url: {"data": [_dz(7, "Totally Different Song", "Someone Else")]},
+    )
+    assert got is None
+
+
+def test_deezer_search_never_raises_on_http_error():
+    def boom(url):
+        raise RuntimeError("network down")
+
+    assert bf.deezer_search("anything", getter=boom) == []
+
+
+def test_deezer_search_treats_api_error_payload_as_empty():
+    assert (
+        bf.deezer_search("x", getter=lambda url: {"error": {"type": "Exception"}}) == []
+    )
+
+
+def test_run_apply_uses_deezer_search_when_isrc_and_odesli_miss(tmp_path, monkeypatch):
+    pl_dir = tmp_path / "custom_components" / "beatify" / "playlists"
+    pl_dir.mkdir(parents=True)
+    f = _write_playlist(
+        pl_dir,
+        "metal",
+        [
+            {
+                "artist": "Black Sabbath",
+                "title": "Iron Man",
+                "isrc": "USWB11304371",
+                "uri": "spotify:track:" + "a" * 22,
+            }
+        ],
+    )
+
+    monkeypatch.setattr(bf, "fetch_odesli", lambda *a, **k: None)  # Odesli down
+    monkeypatch.setattr(bf, "fetch_deezer_isrc", lambda *a, **k: None)  # ISRC misses
+    monkeypatch.setattr(bf, "resolve_apple_via_itunes", lambda *a, **k: None)
+    monkeypatch.setattr(bf, "resolve_deezer_via_search", lambda *a, **k: "3788156072")
+    monkeypatch.setattr(bf.time, "sleep", lambda s: None)
+    monkeypatch.delenv("YOUTUBE_API_KEY", raising=False)
+
+    rc = bf.main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "--apply",
+            "--output",
+            str(tmp_path / "cov.md"),
+            "--state",
+            str(tmp_path / "state.json"),
+            "--odesli-sleep",
+            "0",
+        ]
+    )
+    assert rc == 0
+    assert (
+        json.loads(f.read_text())["songs"][0]["uri_deezer"]
+        == "deezer://track/3788156072"
+    )

--- a/tests/unit/test_provider_uri_backfill.py
+++ b/tests/unit/test_provider_uri_backfill.py
@@ -1247,3 +1247,97 @@ def test_run_apply_uses_deezer_search_when_isrc_and_odesli_miss(tmp_path, monkey
         json.loads(f.read_text())["songs"][0]["uri_deezer"]
         == "deezer://track/3788156072"
     )
+
+
+def test_deezer_isrc_runs_even_when_odesli_is_down(tmp_path, monkeypatch):
+    # Regression 2026-08-10: the ISRC lookup sat INSIDE the `payload is not None`
+    # block, so a 429 from Odesli skipped it entirely — Deezer got nothing while
+    # Apple kept filling via its own fallback. That asymmetry is what left whole
+    # playlists at full Apple / zero Deezer coverage.
+    pl_dir = tmp_path / "custom_components" / "beatify" / "playlists"
+    pl_dir.mkdir(parents=True)
+    f = _write_playlist(
+        pl_dir,
+        "dz",
+        [
+            {
+                "artist": "Efecto Pasillo",
+                "title": "No importa que llueva",
+                "isrc": "ES24C1207102",
+                "uri": "spotify:track:" + "a" * 22,
+            }
+        ],
+    )
+
+    monkeypatch.setattr(bf, "fetch_odesli", lambda *a, **k: None)  # 429 / down
+    monkeypatch.setattr(bf, "fetch_deezer_isrc", lambda isrc, **k: "438648342")
+    monkeypatch.setattr(bf, "resolve_apple_via_itunes", lambda *a, **k: None)
+    monkeypatch.setattr(bf, "resolve_deezer_via_search", lambda *a, **k: None)
+    monkeypatch.setattr(bf.time, "sleep", lambda s: None)
+    monkeypatch.delenv("YOUTUBE_API_KEY", raising=False)
+
+    rc = bf.main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "--apply",
+            "--output",
+            str(tmp_path / "cov.md"),
+            "--state",
+            str(tmp_path / "state.json"),
+            "--odesli-sleep",
+            "0",
+        ]
+    )
+    assert rc == 0
+    assert (
+        json.loads(f.read_text())["songs"][0]["uri_deezer"]
+        == "deezer://track/438648342"
+    )
+
+
+def test_deezer_isrc_wins_over_search(tmp_path, monkeypatch):
+    # The exact ISRC hit is preferred; the search fallback must not be consulted
+    # when it already resolved — otherwise every song costs an extra HTTP call.
+    pl_dir = tmp_path / "custom_components" / "beatify" / "playlists"
+    pl_dir.mkdir(parents=True)
+    f = _write_playlist(
+        pl_dir,
+        "dz2",
+        [
+            {
+                "artist": "Maan",
+                "title": "Stiekem",
+                "isrc": "NLZ292200147",
+                "uri": "spotify:track:" + "b" * 22,
+            }
+        ],
+    )
+    searched = []
+    monkeypatch.setattr(bf, "fetch_odesli", lambda *a, **k: None)
+    monkeypatch.setattr(bf, "fetch_deezer_isrc", lambda isrc, **k: "3606658082")
+    monkeypatch.setattr(bf, "resolve_apple_via_itunes", lambda *a, **k: None)
+    monkeypatch.setattr(
+        bf, "resolve_deezer_via_search", lambda *a, **k: searched.append(1) or "999"
+    )
+    monkeypatch.setattr(bf.time, "sleep", lambda s: None)
+    monkeypatch.delenv("YOUTUBE_API_KEY", raising=False)
+
+    bf.main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "--apply",
+            "--output",
+            str(tmp_path / "cov.md"),
+            "--state",
+            str(tmp_path / "state.json"),
+            "--odesli-sleep",
+            "0",
+        ]
+    )
+    assert (
+        json.loads(f.read_text())["songs"][0]["uri_deezer"]
+        == "deezer://track/3606658082"
+    )
+    assert searched == []  # search never consulted


### PR DESCRIPTION
## Warum

Der Deezer-Pfad im Backfill kennt zwei Wege: Odesli und die exakte ISRC-Abfrage. Beide sind gut, wenn sie greifen — aber die ISRC ist nur so gut wie der Wert, den wir gespeichert haben.

**Gemessen am 10.08.2026** an `greatest-metal-songs`: von 8 Stichproben scheitern 4 per ISRC — „Iron Man", „Paranoid", „The Trooper", „The Number of the Beast". Alle vier tragen die ISRC einer Neuauflage von 2013/2015, die Deezer nicht indexiert; die 2009er bzw. 1998er Remaster derselben Aufnahmen liegen dort sehr wohl. **Alle vier lösen per Suche auf.**

**Apple hatte diesen Fallback längst, Deezer nicht.** Das ist der Grund, warum ganze Playlists bei null Deezer-Abdeckung stehen: `hitster-100-en-espanol` 0/127, `top100-allertijden-nederlandstalig` 0/104, `greatest-metal-songs` 0/61 — zusammen **292 der 497** Deezer-Lücken im Katalog.

## Was

`resolve_deezer_via_search()` + `_pick_deezer_match()` + `deezer_search()`, Aufbau **streng nach dem Apple-Vorbild**:

- **Feldskopierte Deezer-Syntax** `artist:"X" track:"Y"` zuerst — ein nackter Suchbegriff „Paranoid" liefert hundert unbeteiligte Tracks
- Diakritik-gefaltete Varianten, suffix-bereinigte Titel, `alt_artists` als Ersatz-Interpret
- Abbruch beim **ersten** Treffer, der das Gate besteht
- **Das Gate verlangt Titel UND Interpret.** „Iron Man" allein würde jede Coverband durchlassen — genau diese Sorte Fehler hat heute schon acht falsche Apple-URIs in eine frische Playlist gebracht

Der Aufruf sitzt auf derselben Ebene wie der Apple-Fallback, also **außerhalb** des `payload`-Blocks: er greift auch dann, wenn Odesli nicht antwortet.

## Tests

9 neue:

- Gate nimmt passenden Treffer, **weist die Coverband ab**, akzeptiert `alt_artists`, überspringt Treffer ohne ID
- `resolve_deezer_via_search` bricht beim ersten Gate-Treffer ab (genau **ein** HTTP-Aufruf) und liefert `None`, wenn nichts passt
- `deezer_search` wirft nie — weder bei Netzfehler noch bei einem Fehler-Payload der API
- Ein Ende-zu-Ende-Lauf, in dem Odesli tot ist und die ISRC danebengreift, füllt Deezer trotzdem

**Nebenbei ein Fund in den bestehenden Tests**: die 12 Tests, die `main()` fahren, mockten den neuen Fallback naturgemäß nicht — und gingen dadurch **live ans Netz**, obwohl der Dateikopf „All network calls are mocked — no live HTTP here" verspricht. Laufzeit der Datei **13,3 s → 0,12 s**. In der CI hätte das Deezer von den GitHub-Runnern aus angerufen.

`1645 passed`, `ruff check` + `ruff format --check` grün, unter Python 3.9 lauffähig geprüft.

**Draft mit Absicht** — Merge nach deiner Freigabe.