### PR TITLE
chore(playlists): tidal backfill wave — +18 uris (Bergung der 20:00-Welle)

### DIFF
--- a/custom_components/beatify/playlists/community/wiesn-party-hits.json
+++ b/custom_components/beatify/playlists/community/wiesn-party-hits.json
@@ -1,6 +1,6 @@
 {
   "name": "Wiesn Party Hits 🍻",
-  "version": "0.1",
+  "version": "0.2",
   "tags": [
     "party",
     "schlager",
@@ -44,7 +44,7 @@
       },
       "uri_deezer": "deezer://track/62238193",
       "uri_youtube_music": null,
-      "uri_tidal": null
+      "uri_tidal": "tidal://track/15811933"
     },
     {
       "year": 1981,
@@ -77,7 +77,7 @@
       },
       "uri_deezer": "deezer://track/982516",
       "uri_youtube_music": null,
-      "uri_tidal": null
+      "uri_tidal": "tidal://track/494409690"
     },
     {
       "year": 1981,
@@ -150,7 +150,7 @@
       },
       "uri_deezer": "deezer://track/3123329",
       "uri_youtube_music": null,
-      "uri_tidal": null
+      "uri_tidal": "tidal://track/1501407"
     },
     {
       "year": 1981,
@@ -187,7 +187,7 @@
       },
       "uri_deezer": "deezer://track/3123334",
       "uri_youtube_music": null,
-      "uri_tidal": null
+      "uri_tidal": "tidal://track/1500927"
     },
     {
       "year": 1982,
@@ -220,7 +220,7 @@
       },
       "uri_deezer": "deezer://track/15306741",
       "uri_youtube_music": null,
-      "uri_tidal": null
+      "uri_tidal": "tidal://track/20717379"
     },
     {
       "year": 1983,
@@ -255,7 +255,7 @@
       },
       "uri_deezer": "deezer://track/3390998",
       "uri_youtube_music": null,
-      "uri_tidal": null
+      "uri_tidal": "tidal://track/1528258"
     },
     {
       "year": 1983,
@@ -290,7 +290,7 @@
       },
       "uri_deezer": "deezer://track/120358320",
       "uri_youtube_music": null,
-      "uri_tidal": null
+      "uri_tidal": "tidal://track/56290524"
     },
     {
       "year": 1984,
@@ -329,7 +329,7 @@
       },
       "uri_deezer": "deezer://track/15379465",
       "uri_youtube_music": null,
-      "uri_tidal": null
+      "uri_tidal": "tidal://track/118934675"
     },
     {
       "year": 1984,
@@ -362,7 +362,7 @@
       },
       "uri_deezer": "deezer://track/2500674",
       "uri_youtube_music": null,
-      "uri_tidal": null
+      "uri_tidal": "tidal://track/3603818"
     },
     {
       "year": 1985,

--- a/custom_components/beatify/playlists/community/wiesn-party-hits.json
+++ b/custom_components/beatify/playlists/community/wiesn-party-hits.json
@@ -1,6 +1,6 @@
 {
   "name": "Wiesn Party Hits 🍻",
-  "version": "0.2",
+  "version": "0.3",
   "tags": [
     "party",
     "schlager",
@@ -395,7 +395,7 @@
       },
       "uri_deezer": "deezer://track/630374",
       "uri_youtube_music": null,
-      "uri_tidal": null
+      "uri_tidal": "tidal://track/1880055"
     },
     {
       "year": 1987,
@@ -428,7 +428,7 @@
       },
       "uri_deezer": "deezer://track/3109247",
       "uri_youtube_music": null,
-      "uri_tidal": null
+      "uri_tidal": "tidal://track/137251"
     },
     {
       "year": 1989,
@@ -461,7 +461,7 @@
       },
       "uri_deezer": "deezer://track/417358492",
       "uri_youtube_music": null,
-      "uri_tidal": null
+      "uri_tidal": "tidal://track/93744339"
     },
     {
       "year": 1994,
@@ -499,7 +499,7 @@
       },
       "uri_deezer": "deezer://track/419139102",
       "uri_youtube_music": null,
-      "uri_tidal": null
+      "uri_tidal": "tidal://track/80186819"
     },
     {
       "year": 1997,
@@ -532,7 +532,7 @@
       },
       "uri_deezer": "deezer://track/10092552",
       "uri_youtube_music": null,
-      "uri_tidal": null
+      "uri_tidal": "tidal://track/6150436"
     },
     {
       "year": 1997,
@@ -565,7 +565,7 @@
       },
       "uri_deezer": "deezer://track/120358330",
       "uri_youtube_music": null,
-      "uri_tidal": null
+      "uri_tidal": "tidal://track/56290529"
     },
     {
       "year": 1998,
@@ -598,7 +598,7 @@
       },
       "uri_deezer": "deezer://track/971107",
       "uri_youtube_music": null,
-      "uri_tidal": null
+      "uri_tidal": "tidal://track/16320764"
     },
     {
       "year": 1998,
@@ -635,7 +635,7 @@
       },
       "uri_deezer": "deezer://track/5105781",
       "uri_youtube_music": null,
-      "uri_tidal": null
+      "uri_tidal": "tidal://track/3270203"
     },
     {
       "year": 1999,
@@ -668,7 +668,7 @@
       },
       "uri_deezer": "deezer://track/417358532",
       "uri_youtube_music": null,
-      "uri_tidal": null
+      "uri_tidal": "tidal://track/20829494"
     },
     {
       "year": 1999,
@@ -701,7 +701,7 @@
       },
       "uri_deezer": "deezer://track/713477362",
       "uri_youtube_music": null,
-      "uri_tidal": null
+      "uri_tidal": "tidal://track/113400855"
     },
     {
       "year": 2000,
@@ -738,7 +738,7 @@
       },
       "uri_deezer": "deezer://track/15319250",
       "uri_youtube_music": null,
-      "uri_tidal": null
+      "uri_tidal": "tidal://track/13981564"
     },
     {
       "year": 2001,
@@ -773,7 +773,7 @@
       },
       "uri_deezer": "deezer://track/1008665",
       "uri_youtube_music": null,
-      "uri_tidal": null
+      "uri_tidal": "tidal://track/2045071"
     },
     {
       "year": 2002,
@@ -809,7 +809,7 @@
       },
       "uri_deezer": "deezer://track/1791078487",
       "uri_youtube_music": null,
-      "uri_tidal": null
+      "uri_tidal": "tidal://track/217332803"
     },
     {
       "year": 2003,
@@ -842,7 +842,7 @@
       },
       "uri_deezer": "deezer://track/3156476",
       "uri_youtube_music": null,
-      "uri_tidal": null
+      "uri_tidal": "tidal://track/1394994"
     },
     {
       "year": 2004,
@@ -879,7 +879,7 @@
       },
       "uri_deezer": "deezer://track/111773080",
       "uri_youtube_music": null,
-      "uri_tidal": null
+      "uri_tidal": "tidal://track/63902379"
     },
     {
       "year": 2004,
@@ -912,7 +912,7 @@
       },
       "uri_deezer": "deezer://track/605095502",
       "uri_youtube_music": null,
-      "uri_tidal": null
+      "uri_tidal": "tidal://track/40043487"
     },
     {
       "year": 2005,
@@ -945,7 +945,7 @@
       },
       "uri_deezer": "deezer://track/2455263785",
       "uri_youtube_music": null,
-      "uri_tidal": null
+      "uri_tidal": "tidal://track/316460562"
     },
     {
       "year": 2006,
@@ -978,7 +978,7 @@
       },
       "uri_deezer": "deezer://track/887610",
       "uri_youtube_music": null,
-      "uri_tidal": null
+      "uri_tidal": "tidal://track/3608587"
     },
     {
       "year": 2006,

--- a/custom_components/beatify/playlists/community/wiesn-party-hits.json
+++ b/custom_components/beatify/playlists/community/wiesn-party-hits.json
@@ -1,6 +1,6 @@
 {
   "name": "Wiesn Party Hits 🍻",
-  "version": "0.3",
+  "version": "0.4",
   "tags": [
     "party",
     "schlager",
@@ -1011,7 +1011,7 @@
       },
       "uri_deezer": "deezer://track/2674766112",
       "uri_youtube_music": null,
-      "uri_tidal": null
+      "uri_tidal": "tidal://track/347043297"
     },
     {
       "year": 2007,
@@ -1048,7 +1048,7 @@
       },
       "uri_deezer": "deezer://track/1139093",
       "uri_youtube_music": null,
-      "uri_tidal": null
+      "uri_tidal": "tidal://track/3608585"
     },
     {
       "year": 2007,
@@ -1081,7 +1081,7 @@
       },
       "uri_deezer": "deezer://track/15508216",
       "uri_youtube_music": null,
-      "uri_tidal": null
+      "uri_tidal": "tidal://track/20370397"
     },
     {
       "year": 2007,
@@ -1118,7 +1118,7 @@
       },
       "uri_deezer": "deezer://track/3164083",
       "uri_youtube_music": null,
-      "uri_tidal": null
+      "uri_tidal": "tidal://track/2965824"
     },
     {
       "year": 2007,
@@ -1151,7 +1151,7 @@
       },
       "uri_deezer": "deezer://track/631190652",
       "uri_youtube_music": null,
-      "uri_tidal": null
+      "uri_tidal": "tidal://track/16670929"
     },
     {
       "year": 2008,
@@ -1186,7 +1186,7 @@
       },
       "uri_deezer": "deezer://track/61750163",
       "uri_youtube_music": null,
-      "uri_tidal": null
+      "uri_tidal": "tidal://track/15413835"
     },
     {
       "year": 2008,
@@ -1221,7 +1221,7 @@
       },
       "uri_deezer": "deezer://track/61838244",
       "uri_youtube_music": null,
-      "uri_tidal": null
+      "uri_tidal": "tidal://track/16744593"
     },
     {
       "year": 2008,
@@ -1258,7 +1258,7 @@
       },
       "uri_deezer": "deezer://track/702871922",
       "uri_youtube_music": null,
-      "uri_tidal": null
+      "uri_tidal": "tidal://track/183359642"
     },
     {
       "year": 2008,
@@ -1291,7 +1291,7 @@
       },
       "uri_deezer": "deezer://track/61721437",
       "uri_youtube_music": null,
-      "uri_tidal": null
+      "uri_tidal": "tidal://track/15352283"
     },
     {
       "year": 2009,
@@ -1324,7 +1324,7 @@
       },
       "uri_deezer": "deezer://track/4619466",
       "uri_youtube_music": null,
-      "uri_tidal": null
+      "uri_tidal": "tidal://track/3159850"
     },
     {
       "year": 2009,
@@ -1362,7 +1362,7 @@
       },
       "uri_deezer": "deezer://track/3445820",
       "uri_youtube_music": null,
-      "uri_tidal": null
+      "uri_tidal": "tidal://track/2791729"
     },
     {
       "year": 2009,
@@ -1397,7 +1397,7 @@
       },
       "uri_deezer": "deezer://track/15038934",
       "uri_youtube_music": null,
-      "uri_tidal": null
+      "uri_tidal": "tidal://track/236476831"
     },
     {
       "year": 2009,
@@ -1430,7 +1430,7 @@
       },
       "uri_deezer": "deezer://track/94338552",
       "uri_youtube_music": null,
-      "uri_tidal": null
+      "uri_tidal": "tidal://track/40043558"
     },
     {
       "year": 2009,
@@ -1463,7 +1463,7 @@
       },
       "uri_deezer": "deezer://track/5137423",
       "uri_youtube_music": null,
-      "uri_tidal": null
+      "uri_tidal": "tidal://track/3819886"
     },
     {
       "year": 2009,
@@ -1496,7 +1496,7 @@
       },
       "uri_deezer": "deezer://track/52202001",
       "uri_youtube_music": null,
-      "uri_tidal": null
+      "uri_tidal": "tidal://track/83590227"
     },
     {
       "year": 2006,
@@ -1529,7 +1529,7 @@
       },
       "uri_deezer": "deezer://track/84747905",
       "uri_youtube_music": null,
-      "uri_tidal": null
+      "uri_tidal": "tidal://track/93742469"
     },
     {
       "year": 2010,
@@ -1562,7 +1562,7 @@
       },
       "uri_deezer": "deezer://track/12817700",
       "uri_youtube_music": null,
-      "uri_tidal": null
+      "uri_tidal": "tidal://track/7016576"
     },
     {
       "year": 2011,
@@ -1595,7 +1595,7 @@
       },
       "uri_deezer": "deezer://track/84747831",
       "uri_youtube_music": null,
-      "uri_tidal": null
+      "uri_tidal": "tidal://track/10598816"
     },
     {
       "year": 2010,


### PR DESCRIPTION
## Bergung, keine neue Welle

Diese 18 Tidal-URIs hat die **20:00-Welle** am 10.08. gefunden. Sie liegen seit 20:30 als Commit `4419c498` auf `tidal-backfill/2026-08-10-1900` — einem Branch, dessen PR (#2074) um **20:04 schon gemergt** war. Der Push landete damit auf einem Branch ohne offenen PR, und `com.beatify.tidal-automerge` fasst nur PRs an. Ohne diesen PR wäre die Arbeit verloren.

Ursache ist ein Wettlauf zwischen den beiden Agenten: `tidal-wave.sh` entscheidet zu Beginn (Schritt 0), ob es sich an einen offenen Tidal-PR anhängt, pusht aber erst 30 Minuten später. Merged der Automerge in diesem Fenster, pusht die Welle ins Leere — und meldet trotzdem `ok`, weil `PR_URL` als String zusammengesetzt statt geprüft wird. Das wird separat behoben.

## Inhalt

- `community/wiesn-party-hits` Tidal **9 → 27** von 100

## Gegen `main` verifiziert, nicht bloß auto-gemergt

Der Branch zweigt von `7744f5b7` (#2072, 18:54) ab, also **vor** #2077 — dem Fix der 8 falschen Apple-URIs in genau dieser Datei. Ein Testmerge gegen den aktuellen `main` wurde deshalb inhaltlich geprüft, nicht nur auf „geht durch":

- Apple-URIs, die sich gegenüber `main` ändern — **0**
- Apple-Region-Maps, die sich ändern — **0**
- Neue Tidal-URIs gegenüber `main` — **18**

Die Korrekturen aus #2077 bleiben also unangetastet; der Merge fügt ausschließlich Tidal-URIs hinzu.

## Achtung, zweite Baustelle an derselben Datei

Die 21:00-Welle läuft auf `main` und fasst `wiesn-party-hits` ebenfalls an — sie kennt diese 18 URIs nicht und fragt dieselben Tracks erneut bei Odesli ab. Wer von beiden PRs zuletzt gemergt wird, kann in einen Konflikt laufen. Dieser hier sollte zuerst durch.
