### PR TITLE
chore(playlists): deezer backfill — +11 deezer uris in greatest-metal-songs

### DIFF
--- a/custom_components/beatify/playlists/community/greatest-metal-songs.json
+++ b/custom_components/beatify/playlists/community/greatest-metal-songs.json
@@ -1,6 +1,6 @@
 {
   "name": "Greatest Metal Songs of All Time 🤘",
-  "version": "1.11",
+  "version": "1.12",
   "tags": [
     "metal",
     "rock",
@@ -52,7 +52,8 @@
         "es": null,
         "nl": null,
         "it": null
-      }
+      },
+      "uri_deezer": "deezer://track/3788156072"
     },
     {
       "year": 1970,
@@ -95,7 +96,8 @@
         "es": null,
         "nl": null,
         "it": null
-      }
+      },
+      "uri_deezer": "deezer://track/3788156052"
     },
     {
       "year": 1975,
@@ -138,7 +140,8 @@
         "es": "applemusic://track/978784360",
         "nl": "applemusic://track/978784360",
         "it": "applemusic://track/978784360"
-      }
+      },
+      "uri_deezer": "deezer://track/557633"
     },
     {
       "year": 1980,
@@ -181,7 +184,8 @@
         "es": "applemusic://track/979938033",
         "nl": "applemusic://track/979938033",
         "it": "applemusic://track/979938033"
-      }
+      },
+      "uri_deezer": "deezer://track/3155089"
     },
     {
       "year": 1982,
@@ -224,7 +228,8 @@
         "es": "applemusic://track/979954059",
         "nl": "applemusic://track/979954059",
         "it": "applemusic://track/979954059"
-      }
+      },
+      "uri_deezer": "deezer://track/3158432"
     },
     {
       "year": 1986,
@@ -267,7 +272,8 @@
         "es": "applemusic://track/1632029152",
         "nl": "applemusic://track/1632029152",
         "it": "applemusic://track/1632029152"
-      }
+      },
+      "uri_deezer": "deezer://track/424562692"
     },
     {
       "year": 1991,
@@ -310,7 +316,8 @@
         "es": "applemusic://track/1571983951",
         "nl": "applemusic://track/1571983951",
         "it": "applemusic://track/1571983951"
-      }
+      },
+      "uri_deezer": "deezer://track/1405866722"
     },
     {
       "year": 1988,
@@ -353,7 +360,8 @@
         "es": "applemusic://track/1435400032",
         "nl": "applemusic://track/1435400032",
         "it": "applemusic://track/1435400032"
-      }
+      },
+      "uri_deezer": "deezer://track/575867572"
     },
     {
       "year": 1986,
@@ -396,7 +404,8 @@
         "es": "applemusic://track/1733769810",
         "nl": "applemusic://track/1733769810",
         "it": "applemusic://track/1733769810"
-      }
+      },
+      "uri_deezer": "deezer://track/65690449"
     },
     {
       "year": 1992,
@@ -439,7 +448,8 @@
         "es": "applemusic://track/518549369",
         "nl": "applemusic://track/518549369",
         "it": "applemusic://track/518549369"
-      }
+      },
+      "uri_deezer": "deezer://track/581205342"
     },
     {
       "year": 1994,
@@ -482,7 +492,8 @@
         "es": "applemusic://track/1612260842",
         "nl": "applemusic://track/1612260842",
         "it": "applemusic://track/1612260842"
-      }
+      },
+      "uri_deezer": "deezer://track/14637138"
     },
     {
       "year": 1983,

--- a/custom_components/beatify/playlists/community/hitster-100-en-espanol.json
+++ b/custom_components/beatify/playlists/community/hitster-100-en-espanol.json
@@ -1,6 +1,6 @@
 {
   "name": "100% en Español 🇪🇸",
-  "version": "1.10",
+  "version": "1.11",
   "tags": [
     "spanish",
     "spain",
@@ -47,7 +47,8 @@
         "es": "applemusic://track/1438759692",
         "nl": "applemusic://track/1438759692",
         "it": "applemusic://track/1438759692"
-      }
+      },
+      "uri_deezer": "deezer://track/1075883212"
     },
     {
       "year": 2012,
@@ -84,7 +85,8 @@
         "es": "applemusic://track/1808388180",
         "nl": "applemusic://track/1808388180",
         "it": "applemusic://track/1808388180"
-      }
+      },
+      "uri_deezer": "deezer://track/438648342"
     },
     {
       "year": 2012,
@@ -121,7 +123,8 @@
         "es": "applemusic://track/1824185070",
         "nl": "applemusic://track/1824185070",
         "it": "applemusic://track/1824185070"
-      }
+      },
+      "uri_deezer": "deezer://track/68350527"
     },
     {
       "year": 2017,
@@ -159,7 +162,8 @@
         "es": "applemusic://track/1586664786",
         "nl": "applemusic://track/1586664786",
         "it": "applemusic://track/1586664786"
-      }
+      },
+      "uri_deezer": "deezer://track/623698142"
     },
     {
       "year": 1978,
@@ -197,7 +201,8 @@
         "es": "applemusic://track/958452370",
         "nl": "applemusic://track/958452370",
         "it": "applemusic://track/958452370"
-      }
+      },
+      "uri_deezer": "deezer://track/1289057"
     },
     {
       "year": 1996,
@@ -235,7 +240,8 @@
         "es": "applemusic://track/694098076",
         "nl": "applemusic://track/694098076",
         "it": "applemusic://track/694098076"
-      }
+      },
+      "uri_deezer": "deezer://track/3355299"
     },
     {
       "year": 1978,
@@ -273,7 +279,8 @@
         "es": "applemusic://track/1464957419",
         "nl": "applemusic://track/1464957419",
         "it": "applemusic://track/1464957419"
-      }
+      },
+      "uri_deezer": "deezer://track/686098802"
     },
     {
       "year": 1970,
@@ -311,7 +318,8 @@
         "es": "applemusic://track/930074779",
         "nl": "applemusic://track/168365130",
         "it": "applemusic://track/168365130"
-      }
+      },
+      "uri_deezer": "deezer://track/3915849"
     },
     {
       "year": 2019,
@@ -349,7 +357,8 @@
         "es": "applemusic://track/1804701192",
         "nl": "applemusic://track/1804701192",
         "it": "applemusic://track/1804701192"
-      }
+      },
+      "uri_deezer": "deezer://track/3250706351"
     },
     {
       "year": 1982,
@@ -387,7 +396,8 @@
         "es": "applemusic://track/1726909970",
         "nl": "applemusic://track/1726909970",
         "it": "applemusic://track/1726909970"
-      }
+      },
+      "uri_deezer": "deezer://track/2630207302"
     },
     {
       "year": 1981,
@@ -425,7 +435,8 @@
         "es": "applemusic://track/1591593239",
         "nl": "applemusic://track/1591593239",
         "it": "applemusic://track/1591593239"
-      }
+      },
+      "uri_deezer": "deezer://track/70498562"
     },
     {
       "year": 2002,
@@ -463,7 +474,8 @@
         "es": "applemusic://track/1442884591",
         "nl": "applemusic://track/1711311377",
         "it": "applemusic://track/1711311377"
-      }
+      },
+      "uri_deezer": "deezer://track/84841555"
     },
     {
       "year": 2021,
@@ -501,7 +513,8 @@
         "es": "applemusic://track/1562714028",
         "nl": "applemusic://track/1562714028",
         "it": "applemusic://track/1562714028"
-      }
+      },
+      "uri_deezer": "deezer://track/1324559202"
     },
     {
       "year": 1981,
@@ -538,7 +551,8 @@
         "es": "applemusic://track/353035476",
         "nl": "applemusic://track/353035476",
         "it": "applemusic://track/353035476"
-      }
+      },
+      "uri_deezer": "deezer://track/29672911"
     },
     {
       "year": 2022,
@@ -576,7 +590,8 @@
         "es": "applemusic://track/1624563284",
         "nl": "applemusic://track/1624563284",
         "it": "applemusic://track/1624563284"
-      }
+      },
+      "uri_deezer": "deezer://track/1753549417"
     },
     {
       "year": 2023,
@@ -614,7 +629,8 @@
         "es": "applemusic://track/1831063985",
         "nl": "applemusic://track/1831063985",
         "it": "applemusic://track/1831063985"
-      }
+      },
+      "uri_deezer": "deezer://track/3261131981"
     },
     {
       "year": 2004,
@@ -652,7 +668,8 @@
         "es": "applemusic://track/1698229459",
         "nl": "applemusic://track/1698229459",
         "it": "applemusic://track/1698229459"
-      }
+      },
+      "uri_deezer": "deezer://track/2192572"
     },
     {
       "year": 2003,
@@ -690,7 +707,8 @@
         "es": "applemusic://track/1574359692",
         "nl": "applemusic://track/1574359692",
         "it": "applemusic://track/1574359692"
-      }
+      },
+      "uri_deezer": "deezer://track/4695167"
     },
     {
       "year": 1997,
@@ -728,7 +746,8 @@
         "es": "applemusic://track/1743406074",
         "nl": "applemusic://track/1743406074",
         "it": "applemusic://track/1743406074"
-      }
+      },
+      "uri_deezer": "deezer://track/43815051"
     },
     {
       "year": 1974,
@@ -765,7 +784,8 @@
         "es": "applemusic://track/1049532476",
         "nl": "applemusic://track/1049532476",
         "it": "applemusic://track/1049532476"
-      }
+      },
+      "uri_deezer": "deezer://track/603842"
     },
     {
       "year": 1981,
@@ -802,7 +822,8 @@
         "es": "applemusic://track/1139910002",
         "nl": "applemusic://track/1139910002",
         "it": "applemusic://track/1139910002"
-      }
+      },
+      "uri_deezer": "deezer://track/5151173"
     },
     {
       "year": 1967,
@@ -840,7 +861,8 @@
         "es": "applemusic://track/1712210818",
         "nl": "applemusic://track/1712210818",
         "it": "applemusic://track/1712210818"
-      }
+      },
+      "uri_deezer": "deezer://track/686101102"
     },
     {
       "year": 1947,
@@ -877,7 +899,8 @@
         "es": "applemusic://track/950732841",
         "nl": "applemusic://track/950732841",
         "it": "applemusic://track/950732841"
-      }
+      },
+      "uri_deezer": "deezer://track/92408868"
     },
     {
       "year": 1953,
@@ -915,7 +938,8 @@
         "es": "applemusic://track/288069714",
         "nl": "applemusic://track/288069714",
         "it": "applemusic://track/288069714"
-      }
+      },
+      "uri_deezer": "deezer://track/63630127"
     },
     {
       "year": 1978,
@@ -952,7 +976,8 @@
         "es": "applemusic://track/874164902",
         "nl": "applemusic://track/874164902",
         "it": "applemusic://track/874164902"
-      }
+      },
+      "uri_deezer": "deezer://track/3906928"
     },
     {
       "year": 1977,
@@ -990,7 +1015,8 @@
         "es": "applemusic://track/555735457",
         "nl": "applemusic://track/654758721",
         "it": "applemusic://track/654758721"
-      }
+      },
+      "uri_deezer": "deezer://track/981538"
     },
     {
       "year": 1981,
@@ -1028,7 +1054,8 @@
         "es": "applemusic://track/250996960",
         "nl": "applemusic://track/250996960",
         "it": "applemusic://track/250996960"
-      }
+      },
+      "uri_deezer": "deezer://track/15215536"
     },
     {
       "year": 1986,
@@ -1066,7 +1093,8 @@
         "es": "applemusic://track/131367922",
         "nl": "applemusic://track/131367922",
         "it": "applemusic://track/131367922"
-      }
+      },
+      "uri_deezer": "deezer://track/814667"
     },
     {
       "year": 2007,
@@ -1104,7 +1132,8 @@
         "es": "applemusic://track/1523866781",
         "nl": "applemusic://track/1523866781",
         "it": "applemusic://track/1523866781"
-      }
+      },
+      "uri_deezer": "deezer://track/3228252151"
     },
     {
       "year": 1979,
@@ -1142,7 +1171,8 @@
         "es": "applemusic://track/1784911935",
         "nl": "applemusic://track/1784911935",
         "it": "applemusic://track/1784911935"
-      }
+      },
+      "uri_deezer": "deezer://track/80134632"
     },
     {
       "year": 1984,
@@ -1180,7 +1210,8 @@
         "es": "applemusic://track/873529482",
         "nl": "applemusic://track/873529482",
         "it": "applemusic://track/873529482"
-      }
+      },
+      "uri_deezer": "deezer://track/78163226"
     },
     {
       "year": 2004,
@@ -1218,7 +1249,8 @@
         "es": "applemusic://track/1837698661",
         "nl": "applemusic://track/1837698661",
         "it": "applemusic://track/1837698661"
-      }
+      },
+      "uri_deezer": "deezer://track/3122562"
     },
     {
       "year": 2015,
@@ -1256,7 +1288,8 @@
         "es": "applemusic://track/1708431097",
         "nl": "applemusic://track/1708431097",
         "it": "applemusic://track/1708431097"
-      }
+      },
+      "uri_deezer": "deezer://track/102351900"
     },
     {
       "year": 2022,
@@ -1294,7 +1327,8 @@
         "es": "applemusic://track/1654013499",
         "nl": "applemusic://track/1654013499",
         "it": "applemusic://track/1654013499"
-      }
+      },
+      "uri_deezer": "deezer://track/2010117817"
     },
     {
       "year": 2021,
@@ -1332,7 +1366,8 @@
         "es": "applemusic://track/1554206953",
         "nl": "applemusic://track/1554206953",
         "it": "applemusic://track/1554206953"
-      }
+      },
+      "uri_deezer": "deezer://track/1260566292"
     },
     {
       "year": 2022,
@@ -1370,7 +1405,8 @@
         "es": "applemusic://track/1746808718",
         "nl": "applemusic://track/1746808718",
         "it": "applemusic://track/1746808718"
-      }
+      },
+      "uri_deezer": "deezer://track/2683558882"
     },
     {
       "year": 1975,
@@ -1408,7 +1444,8 @@
         "es": "applemusic://track/286589993",
         "nl": "applemusic://track/286589993",
         "it": "applemusic://track/286589993"
-      }
+      },
+      "uri_deezer": "deezer://track/2311558"
     },
     {
       "year": 1984,
@@ -1446,7 +1483,8 @@
         "es": "applemusic://track/1478351808",
         "nl": "applemusic://track/1478351808",
         "it": "applemusic://track/1478351808"
-      }
+      },
+      "uri_deezer": "deezer://track/1043670"
     },
     {
       "year": 1988,
@@ -1484,7 +1522,8 @@
         "es": "applemusic://track/362776156",
         "nl": "applemusic://track/362776156",
         "it": "applemusic://track/362776156"
-      }
+      },
+      "uri_deezer": "deezer://track/5709146"
     },
     {
       "year": 1992,
@@ -1522,7 +1561,8 @@
         "es": "applemusic://track/1699078486",
         "nl": "applemusic://track/1699078486",
         "it": "applemusic://track/1699078486"
-      }
+      },
+      "uri_deezer": "deezer://track/3359669"
     },
     {
       "year": 1965,
@@ -1559,7 +1599,8 @@
         "es": "applemusic://track/1837691887",
         "nl": "applemusic://track/1837691887",
         "it": "applemusic://track/1837691887"
-      }
+      },
+      "uri_deezer": "deezer://track/3540661741"
     },
     {
       "year": 2006,
@@ -1597,7 +1638,8 @@
         "es": "applemusic://track/1735282442",
         "nl": "applemusic://track/1735282442",
         "it": "applemusic://track/1735282442"
-      }
+      },
+      "uri_deezer": "deezer://track/3159861"
     },
     {
       "year": 1975,
@@ -1635,7 +1677,8 @@
         "es": "applemusic://track/1757835018",
         "nl": "applemusic://track/1757835018",
         "it": "applemusic://track/1757835018"
-      }
+      },
+      "uri_deezer": "deezer://track/93818118"
     },
     {
       "year": 1977,


### PR DESCRIPTION
## Erster Ertrag des Deezer-Such-Fallbacks aus #2078

Ein gedeckelter Lauf (`--apply --max-minutes 18`) über `community/greatest-metal-songs`, gestartet 21:33 nach Freigabe des Tidal-Lockfiles.

- `community/greatest-metal-songs` Deezer **0 → 11** von 61, version 1.11 → 1.12
- Apple/Tidal/YouTube unverändert bei 61/61 — der Lauf hat ausschließlich Deezer ergänzt

## Die vier Belegfälle aus dem PR-Text von #2078 sind dabei

Genau die vier Tracks, an denen die ISRC-Abfrage gemessen scheiterte, lösen jetzt per Suche auf:

| Track | Deezer-URI |
|---|---|
| Black Sabbath — Iron Man | `deezer://track/3788156072` |
| Black Sabbath — Paranoid | `deezer://track/3788156052` |
| Iron Maiden — The Trooper | `deezer://track/3155089` |
| Iron Maiden — The Number of the Beast | `deezer://track/3158432` |

Dazu Judas Priest — Screaming for Vengeance sowie Metallica — Master of Puppets / Enter Sandman / One und drei weitere.

## Der Lauf ist am Deckel gestoppt, nicht fertig geworden

`reached --max-minutes 18, stopping` — nach 18 Minuten waren 11 von 61 Tracks gefüllt. Der Rest der Playlist ist unberührt, das ist keine Kataloglücke. Grund ist der Odesli-Abstand von 6 Sekunden pro Track plus 429-Backoff, den sich der Lauf mit der stündlichen Tidal-Welle teilt.

Belegt statt behauptet: der Coverage-Report unter `/tmp/deezer-coverage-2133.md` schreibt den Abbruch selbst mit („Run stopped early … coverage below is partial").

## Gates

- `scripts/validate_playlists.py` — **55/55 Dateien valide, Schema-Gate bestanden** (10 nicht-blockierende Lint-Warnungen, alle vorbestehend und in anderen Dateien)
- Isolierter Worktree, `main` nicht angefasst

**Draft mit Absicht** — Merge nach deiner Freigabe.
