### PR TITLE
chore(playlists): tidal backfill wave — +18 uris

### DIFF
--- a/custom_components/beatify/playlists/community/wiesn-party-hits.json
+++ b/custom_components/beatify/playlists/community/wiesn-party-hits.json
@@ -1,6 +1,6 @@
 {
   "name": "Wiesn Party Hits 🍻",
-  "version": "0.5",
+  "version": "0.6",
   "tags": [
     "party",
     "schlager",
@@ -2241,7 +2241,7 @@
       },
       "uri_deezer": "deezer://track/453959592",
       "uri_youtube_music": null,
-      "uri_tidal": null
+      "uri_tidal": "tidal://track/83844562"
     },
     {
       "year": 2019,
@@ -2274,7 +2274,7 @@
       },
       "uri_deezer": "deezer://track/767503372",
       "uri_youtube_music": null,
-      "uri_tidal": null
+      "uri_tidal": "tidal://track/114881181"
     },
     {
       "year": 2019,
@@ -2307,7 +2307,7 @@
       },
       "uri_deezer": "deezer://track/701254282",
       "uri_youtube_music": null,
-      "uri_tidal": null
+      "uri_tidal": "tidal://track/111979125"
     },
     {
       "year": 2019,
@@ -2340,7 +2340,7 @@
       },
       "uri_deezer": "deezer://track/767090942",
       "uri_youtube_music": null,
-      "uri_tidal": null
+      "uri_tidal": "tidal://track/119709384"
     },
     {
       "year": 2017,
@@ -2373,7 +2373,7 @@
       },
       "uri_deezer": "deezer://track/616075692",
       "uri_youtube_music": null,
-      "uri_tidal": null
+      "uri_tidal": "tidal://track/89527896"
     },
     {
       "year": 2017,
@@ -2406,7 +2406,7 @@
       },
       "uri_deezer": "deezer://track/405519982",
       "uri_youtube_music": null,
-      "uri_tidal": null
+      "uri_tidal": "tidal://track/82425407"
     },
     {
       "year": 2018,
@@ -2439,7 +2439,7 @@
       },
       "uri_deezer": "deezer://track/456989982",
       "uri_youtube_music": null,
-      "uri_tidal": null
+      "uri_tidal": "tidal://track/94068457"
     },
     {
       "year": 2019,
@@ -2472,7 +2472,7 @@
       },
       "uri_deezer": "deezer://track/664225902",
       "uri_youtube_music": null,
-      "uri_tidal": null
+      "uri_tidal": "tidal://track/108212644"
     },
     {
       "year": 2020,
@@ -2505,7 +2505,7 @@
       },
       "uri_deezer": "deezer://track/1059236202",
       "uri_youtube_music": null,
-      "uri_tidal": null
+      "uri_tidal": "tidal://track/152662649"
     },
     {
       "year": 2022,
@@ -2538,7 +2538,7 @@
       },
       "uri_deezer": "deezer://track/1861024137",
       "uri_youtube_music": null,
-      "uri_tidal": null
+      "uri_tidal": "tidal://track/242399606"
     },
     {
       "year": 2022,
@@ -2575,7 +2575,7 @@
       },
       "uri_deezer": "deezer://track/1777525717",
       "uri_youtube_music": null,
-      "uri_tidal": null
+      "uri_tidal": "tidal://track/232094164"
     },
     {
       "year": 2022,
@@ -2612,7 +2612,7 @@
       },
       "uri_deezer": "deezer://track/1667190232",
       "uri_youtube_music": null,
-      "uri_tidal": null
+      "uri_tidal": "tidal://track/218186683"
     },
     {
       "year": 2022,
@@ -2647,7 +2647,7 @@
       },
       "uri_deezer": "deezer://track/1799764447",
       "uri_youtube_music": null,
-      "uri_tidal": null
+      "uri_tidal": "tidal://track/234777608"
     },
     {
       "year": 2022,
@@ -2680,7 +2680,7 @@
       },
       "uri_deezer": "deezer://track/1833203577",
       "uri_youtube_music": null,
-      "uri_tidal": null
+      "uri_tidal": "tidal://track/199553095"
     },
     {
       "year": 2022,
@@ -2713,7 +2713,7 @@
       },
       "uri_deezer": "deezer://track/1705383417",
       "uri_youtube_music": null,
-      "uri_tidal": null
+      "uri_tidal": "tidal://track/223358599"
     },
     {
       "year": 2023,
@@ -2749,7 +2749,7 @@
       },
       "uri_deezer": "deezer://track/2310194015",
       "uri_youtube_music": null,
-      "uri_tidal": null
+      "uri_tidal": "tidal://track/297943368"
     },
     {
       "year": 2023,
@@ -2782,7 +2782,7 @@
       },
       "uri_deezer": "deezer://track/2078308317",
       "uri_youtube_music": null,
-      "uri_tidal": null
+      "uri_tidal": "tidal://track/267762137"
     },
     {
       "year": 2023,
@@ -2819,7 +2819,7 @@
       },
       "uri_deezer": "deezer://track/2308642345",
       "uri_youtube_music": null,
-      "uri_tidal": null
+      "uri_tidal": "tidal://track/297794802"
     },
     {
       "year": 2023,


### PR DESCRIPTION
Eine Odesli-Welle, automatisch gefahren von `com.beatify.tidal-wave`.

- `wiesn-party-hits` Tidal 63 → **81**/100, version 0.5 → 0.6

Bilanz: 18 Treffer · 0 echte Misses · 30 Rate-Limit-Skips · 87 429-Zeilen.

**Draft mit Absicht** — Merge nur nach Markus' Freigabe.