### PR TITLE
data(world-cup-anthems): notes-Feld entfernt, Doku wandert ins Wiki

### DIFF
--- a/custom_components/beatify/playlists/world-cup-anthems.json
+++ b/custom_components/beatify/playlists/world-cup-anthems.json
@@ -1,6 +1,6 @@
 {
   "name": "World Cup Anthems",
-  "version": "1.5",
+  "version": "1.6",
   "tags": [
     "world-cup",
     "fifa",
@@ -8,7 +8,6 @@
     "international",
     "anthems"
   ],
-  "notes": "7 Songs haben bewusst keine Spotify-URI (`uri`): die offiziellen WM-Hymnen 1962, 1974, 1982, 1986, 1994, 1998 und 2002 sind bei Spotify nicht verfuegbar — am 11.08.2026 einzeln ueber Odesli geprueft, kein Treffer. Sie sind KEIN Datenfehler und sollen nicht entfernt werden: fuer YouTube-, Apple-, Tidal- und Deezer-Nutzer sind sie spielbar, und ohne sie haette die Playlist Luecken in ihrem eigenen Konzept. Fuer Spotify-Nutzer filtert filter_songs_for_provider sie vor der Auswahl aus (game/playlist.py), es entstehen also keine toten Runden. Nebenwirkung: da backfill_provider_uris.py ueber die Spotify-URI einsteigt und Songs ohne sie ueberspringt, erreichen die Backfill-Agenten diese 7 Songs nie — fehlende Provider-URIs muessen hier von Hand nachgetragen werden.",
   "songs": [
     {
       "year": 1962,


### PR DESCRIPTION
## Was

Das Top-Level-Feld `notes` wird aus `world-cup-anthems.json` wieder entfernt. version `1.5` → `1.6`. Nur diese eine Datei, keine URI-Änderung.

## Warum

Das Feld kam mit #2086 hinein und war dort schon als Präzedenz benannt: **keine andere der 55 Playlists hat ein `notes`-Feld**. Der Bestand kennt nur `name`, `version`, `tags`, `songs`, `source`, `language`, `author`, `added_date`, `description` und `movie_quiz_enabled`. Ein neues Feld für einen Einzelfall einzuführen heißt, dass jeder künftige Leser des Schemas rätselt, ob es Konvention ist.

`description` wäre ebenfalls falsch gewesen — die wird in der UI angezeigt (`www/js/playlist-hub.js:1345`).

## Wohin die Doku stattdessen geht

Ins Wiki des Bots, wo Provenance und geprüfte Befunde hingehören: **`wiki/concepts/bewusste-provider-luecken.md`**, verlinkt von `wiki/concepts/playlist-health.md` mit einer Abgrenzung — Playlist Health behandelt **falsche** URIs, die neue Seite **zu Recht fehlende**.

Die Seite hält fest, was hier verloren gehen würde:

- Welche sieben Songs betroffen sind und bei welchen Providern es sie gibt, einzeln über Odesli geprüft
- Dass sie **kein Datenfehler** sind und nicht entfernt werden sollen
- Dass `filter_songs_for_provider` sie für Spotify-Nutzer vor der Auswahl herausfiltert, es also keine toten Runden gibt
- Dass `backfill_provider_uris.py` über die Spotify-URI einsteigt und diese sieben deshalb für **alle drei** Backfill-Agenten dauerhaft unsichtbar sind
- Den Vorbehalt, dass Odesli für dieselbe Eingabe nicht stabil antwortet — ein positiver Treffer ist belastbar, eine Abwesenheit nicht

## Gates

`scripts/validate_playlists.py` — **55/55 valide**, Schema-Gate bestanden. Isolierter Worktree, Push gegen `ls-remote` verifiziert.

**Draft mit Absicht** — Merge nach deiner Freigabe.
