### PR TITLE
fix(backfill_apple): Artist-Varianten + Soundtrack-Herkunft im Gate (#2030)

### DIFF
--- a/scripts/backfill_apple.py
+++ b/scripts/backfill_apple.py
@@ -164,6 +164,19 @@ _NEUTRAL_SUFFIX_RE = re.compile(
     re.I,
 )
 
+# Apple haengt an Filmmusik eine Herkunftsangabe statt eines Take-Merkmals:
+# "Zwei Seelen (aus \"Die Schoene und das Biest\" deutscher Film-Soundtrack)".
+# Das benennt, WO die Aufnahme herkommt, nicht WELCHE Aufnahme es ist — und war
+# im Probe-Lauf vom 09.08.2026 mit vier Faellen (Die Schoene und das Biest,
+# Rapunzel, Hercules, Mulan) der groesste Einzelposten unter den 19
+# Suffix-Ablehnungen. Bewusst eng gefasst: muss mit "aus"/"from" beginnen UND
+# auf "soundtrack" enden, damit ein blosses "(Motion Picture Version)" — das
+# sehr wohl eine andere Einspielung sein kann — weiter abgelehnt wird.
+_SOUNDTRACK_ORIGIN_RE = re.compile(
+    r"^(?:aus|from)\s+.+\ssoundtrack$|^original\s+motion\s+picture\s+soundtrack$",
+    re.I,
+)
+
 
 def _now_iso() -> str:
     return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%MZ")
@@ -206,6 +219,72 @@ def artist_set(artist: str) -> set[str]:
     return {n for n in (normalise(p) for p in _ARTIST_SPLIT_RE.split(artist)) if n}
 
 
+_LEADING_ARTICLE_RE = re.compile(r"^(?:the|der|die|das|los|las|le|la|les)\s+", re.I)
+
+
+def _artist_variants(name: str) -> set[str]:
+    """Comparable spellings of one credited artist.
+
+    All four variants come from real rejections in the 09.08.2026 probe run over
+    861 missing Apple URIs — 38 of 137 rejections were artist mismatches, and
+    every one of them was a spelling difference, not a different act:
+
+    * ``Jackson 5`` vs ``The Jackson 5`` — a leading article.
+    * ``MadHouse`` vs ``Mad'House`` — an apostrophe. ``normalise`` turns
+      punctuation into a space, so the two differ by exactly that space.
+    * ``Run-DMC`` vs ``Run-D.M.C.`` — dots inside an abbreviation, again a
+      space after normalisation.
+    * ``Frozen - Cast`` vs ``Cast - Frozen`` — the same credit, reordered.
+
+    The space-free variant is what folds the apostrophe and the dots; it is
+    computed from the article-stripped form so ``The Jackson 5`` also yields
+    ``jackson5``.
+    """
+    base = normalise(name)
+    if not base:
+        return set()
+    stripped = _LEADING_ARTICLE_RE.sub("", base).strip()
+    out = {base, stripped}
+    out |= {v.replace(" ", "") for v in (base, stripped)}
+    out.add(" ".join(sorted(stripped.split())))
+    return {v for v in out if v}
+
+
+def artist_matches(want: str, got: str) -> bool:
+    """True when ``want`` (our primary artist) is credited in ``got`` (Apple's).
+
+    Two rules, in order of strictness:
+
+    1. Any spelling variant of ``want`` equals a variant of any artist Apple
+       credits. This is the membership check that has always been here, only
+       with the variants from :func:`_artist_variants` on both sides.
+    2. ``want`` appears in Apple's full credit as a **contiguous run of at
+       least two tokens** — ``Jimi Hendrix`` inside ``The Jimi Hendrix
+       Experience``. Deliberately not a substring test and deliberately
+       one-directional: it must be *our* artist that is contained, and a
+       single token is never enough.
+
+    Rule 2 is what keeps the real false positives out. In the same probe run
+    Apple answered ``The Parachute Club`` for our ``Paul Kalkbrenner`` and an
+    ensemble credit for our ``Phil Collins`` — neither shares a token run with
+    ours, so both stay rejected. Loosening this to a plain substring or to
+    single tokens would let exactly those through.
+    """
+    want_variants = _artist_variants(want)
+    if not want_variants:
+        return False
+    for credited in _ARTIST_SPLIT_RE.split(got or ""):
+        if want_variants & _artist_variants(credited):
+            return True
+    want_tokens = _LEADING_ARTICLE_RE.sub("", normalise(want)).split()
+    if len(want_tokens) >= 2:
+        got_tokens = normalise(got or "").split()
+        run = " ".join(want_tokens)
+        if run and run in " ".join(got_tokens):
+            return True
+    return False
+
+
 def parenthetical_suffixes(text: str) -> list[str]:
     """Normalised contents of every ``(...)``/``[...]`` group.
 
@@ -245,6 +324,8 @@ def suffix_conflict(a: str, b: str) -> str | None:
             if suffix in other_norm:
                 continue
             if _NEUTRAL_SUFFIX_RE.match(suffix):
+                continue
+            if _SOUNDTRACK_ORIGIN_RE.match(suffix):
                 continue
             return suffix
     return None
@@ -320,8 +401,8 @@ def release_year(result: dict) -> int | None:
 def evaluate(track: dict, result: dict, *, title_threshold: float,
              year_tolerance: int) -> tuple[bool, str]:
     """Apply the gate. Returns (accepted, reason)."""
-    want_artist = normalise(primary_artist(track.get("artist", "")))
-    got_artists = artist_set(result.get("artistName", ""))
+    want_artist = primary_artist(track.get("artist", "") or "")
+    got_credit = result.get("artistName", "") or ""
     # Membership, not equality: Apple often orders a multi-artist credit
     # differently ("Tatanka, Zatox & Wild Motherfuckers" for our "Zatox"), and
     # the lead-artist-only comparison then rejected a correct match. Checking
@@ -329,7 +410,7 @@ def evaluate(track: dict, result: dict, *, title_threshold: float,
     # deliberate — Apple moves featured guests into the title, so requiring the
     # full set to be present would reject e.g. "Harris & Ford, BassWar & CaoX,
     # Bobby John" against "Harris & Ford & BassWar & CaoX".
-    if not want_artist or want_artist not in got_artists:
+    if not artist_matches(want_artist, got_credit):
         return False, f"artist {result.get('artistName')!r} != {track.get('artist')!r}"
 
     sim = title_similarity(track.get("title", ""), result.get("trackName", ""))

--- a/tests/unit/test_backfill_apple_gate_1980.py
+++ b/tests/unit/test_backfill_apple_gate_1980.py
@@ -91,7 +91,11 @@ def test_suffix_conflict(catalogue: str, apple: str, expected: str | None) -> No
     ],
 )
 def test_artist_membership(catalogue: str, apple: str, accepted: bool) -> None:
-    assert (normalise(primary_artist(catalogue)) in artist_set(apple)) is accepted
+    # Ruft seit #2030 `artist_matches` statt den alten Ausdruck nachzubauen:
+    # das Gate benutzt `artist_set` nicht mehr, und ein Test, der die frühere
+    # Formel prüft, schützt den Produktionspfad nicht. Alle sechs Erwartungen
+    # gelten unter der neuen Regel unverändert.
+    assert backfill_apple.artist_matches(primary_artist(catalogue), apple) is accepted
 
 
 def test_evaluate_rejects_extended_mix_with_matching_artist_and_year() -> None:

--- a/tests/unit/test_backfill_apple_gate_2030.py
+++ b/tests/unit/test_backfill_apple_gate_2030.py
@@ -100,7 +100,7 @@ def test_artist_containment_is_one_directional() -> None:
     "apple_title",
     [
         'Zwei Seelen (aus "Die Schöne und das Biest" deutscher Film-Soundtrack)',
-        'Endlich sehe ich das Licht'
+        "Endlich sehe ich das Licht"
         ' (aus "Rapunzel – Neu verföhnt" deutscher Film-Soundtrack)',
         'Ich kann es kaum erwarten (aus "Hercules" deutscher Film-Soundtrack)',
         'Sei ein Mann (aus "Mulan" deutscher Film-Soundtrack)',

--- a/tests/unit/test_backfill_apple_gate_2030.py
+++ b/tests/unit/test_backfill_apple_gate_2030.py
@@ -1,0 +1,177 @@
+"""Artist-Varianten und Soundtrack-Herkunft im Gate von ``scripts/backfill_apple.py``.
+
+Alle Faelle hier stammen aus dem Probe-Lauf vom 09.08.2026 ueber 861 fehlende
+Apple-URIs in 54 Playlists (``/tmp/beatify-2030-probe.log``), nicht aus der
+Vorstellung. Von 137 Ablehnungen waren:
+
+* 56 Jahr (41 %) — nicht Gegenstand dieser Tests, siehe #2030 und die offene
+  Jahres-Konvention,
+* 38 Artist (28 %) — jede davon eine Schreibweise, keine andere Band,
+* 19 Suffix (14 %), davon 4 dieselbe deutsche Soundtrack-Zuschreibung.
+
+Der zweite Block ist deshalb so wichtig wie der erste: zwei der 38
+Artist-Ablehnungen waren **echte Fehltreffer** von iTunes. Eine Lockerung, die
+die durchlaesst, ist schlechter als die alte Strenge.
+
+``scripts/`` ist kein Package, das Modul wird daher per Pfad geladen.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "backfill_apple.py"
+_spec = importlib.util.spec_from_file_location("backfill_apple", _SCRIPT)
+backfill_apple = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(backfill_apple)
+
+artist_matches = backfill_apple.artist_matches
+suffix_conflict = backfill_apple.suffix_conflict
+evaluate = backfill_apple.evaluate
+
+
+# --------------------------------------------------------------- Artist: JA
+@pytest.mark.parametrize(
+    ("ours", "apple"),
+    [
+        # Fuehrender Artikel — 2x im Probe-Lauf
+        ("The Jackson 5", "Jackson 5"),
+        ("Jackson 5", "The Jackson 5"),
+        # Apostroph
+        ("MadHouse", "Mad'House"),
+        ("Mad'House", "MadHouse"),
+        # Punkte in der Abkuerzung. Der angehaengte Remixer ("& Jason Nevins")
+        # wird schon von `primary_artist` abgeschnitten — der End-to-End-Test
+        # unten belegt diesen Pfad; hier steht deshalb der primaere Kuenstler.
+        ("Run-DMC", "Run–D.M.C."),
+        # Umgestellte Mehrfach-Credits
+        ("Frozen - Cast", "Cast - Frozen"),
+        # Unser Kuenstler steckt als zusammenhaengender Token-Lauf im Apple-Credit
+        ("Jimi Hendrix", "The Jimi Hendrix Experience"),
+        # Bestehendes Verhalten darf nicht kaputtgehen: Membership im Mehrfach-Credit
+        ("Zatox", "Tatanka, Zatox & Wild Motherfuckers"),
+    ],
+)
+def test_artist_variants_accepted(ours: str, apple: str) -> None:
+    assert artist_matches(ours, apple) is True
+
+
+# -------------------------------------------------------------- Artist: NEIN
+@pytest.mark.parametrize(
+    ("ours", "apple"),
+    [
+        # Die zwei echten Fehltreffer aus dem Probe-Lauf. Sie sind der Grund,
+        # warum die Containment-Regel zwei Token verlangt und einseitig ist.
+        ("Paul Kalkbrenner", "The Parachute Club"),
+        (
+            "Phil Collins",
+            "Anton Zetterholm, Elisabeth Hübert & Ensemble Stage Theater Neue Flora",
+        ),
+        # Ein einzelnes Token darf NIE per Containment greifen, sonst passt
+        # "Cast" in jeden zweiten Soundtrack-Credit.
+        ("Cast", "Johnny Cash & The Tennessee Two"),
+        # Diakritika bleiben unterscheidend (Kommentar in `normalise`).
+        ("Böhse Onkelz", "Bohse Onkel"),
+        # Leere Seite
+        ("", "Irgendwer"),
+    ],
+)
+def test_artist_mismatches_still_rejected(ours: str, apple: str) -> None:
+    assert artist_matches(ours, apple) is False
+
+
+def test_artist_containment_is_one_directional() -> None:
+    """Apples Credit darf nicht in unserem stecken, nur umgekehrt.
+
+    Sonst wuerde ein zu knapper Apple-Credit ("Cast") auf einen langen
+    Katalog-Eintrag passen und die Pruefung waere in beide Richtungen weich.
+    """
+    assert (
+        artist_matches("The Jimi Hendrix Experience", "Jimi Hendrix Experience") is True
+    )
+    assert artist_matches("Die Toten Hosen und Freunde", "Freunde") is False
+
+
+# ----------------------------------------------------------- Soundtrack-Suffix
+@pytest.mark.parametrize(
+    "apple_title",
+    [
+        'Zwei Seelen (aus "Die Schöne und das Biest" deutscher Film-Soundtrack)',
+        'Endlich sehe ich das Licht'
+        ' (aus "Rapunzel – Neu verföhnt" deutscher Film-Soundtrack)',
+        'Ich kann es kaum erwarten (aus "Hercules" deutscher Film-Soundtrack)',
+        'Sei ein Mann (aus "Mulan" deutscher Film-Soundtrack)',
+        "Circle of Life (from The Lion King Soundtrack)",
+        "Let It Go (Original Motion Picture Soundtrack)",
+    ],
+)
+def test_soundtrack_origin_is_neutral(apple_title: str) -> None:
+    """Eine Herkunftsangabe sagt WO die Aufnahme herkommt, nicht WELCHE es ist."""
+    bare = apple_title.split(" (")[0]
+    assert suffix_conflict(bare, apple_title) is None
+
+
+@pytest.mark.parametrize(
+    "apple_title",
+    [
+        # Version statt Herkunft — kann sehr wohl eine andere Einspielung sein.
+        "Let It Go (Motion Picture Version)",
+        "One More Time (Short Radio Edit)",
+        "Hard Bass (Extended Mix)",
+        # "soundtrack" allein, ohne "aus"/"from", ist keine Herkunftsangabe.
+        "Some Song (Soundtrack)",
+    ],
+)
+def test_version_suffixes_still_rejected(apple_title: str) -> None:
+    bare = apple_title.split(" (")[0]
+    assert suffix_conflict(bare, apple_title) is not None
+
+
+# ------------------------------------------------------------- Gate insgesamt
+def test_gate_accepts_article_difference_end_to_end() -> None:
+    track = {"artist": "The Jackson 5", "title": "I'll Be There", "year": 1970}
+    result = {
+        "artistName": "Jackson 5",
+        "trackName": "I'll Be There",
+        "releaseDate": "1970-08-28T07:00:00Z",
+    }
+    accepted, reason = evaluate(track, result, title_threshold=0.87, year_tolerance=1)
+    assert accepted is True, reason
+
+
+def test_gate_still_rejects_the_parachute_club_end_to_end() -> None:
+    """Der Fehltreffer bleibt ein Fehltreffer, auch mit den neuen Varianten."""
+    track = {"artist": "Paul Kalkbrenner", "title": "Sky and Sand", "year": 2009}
+    result = {
+        "artistName": "The Parachute Club",
+        "trackName": "Sky and Sand",
+        "releaseDate": "1983-01-01T07:00:00Z",
+    }
+    accepted, reason = evaluate(track, result, title_threshold=0.87, year_tolerance=1)
+    assert accepted is False
+    assert "artist" in reason
+
+
+def test_gate_accepts_dotted_abbreviation_with_appended_remixer() -> None:
+    """Der ganze Pfad, nicht nur der Vergleich.
+
+    Unsere Seite fuehrt ``Run-DMC & Jason Nevins``; ``primary_artist`` schneidet
+    den Remixer ab, die punktfreie Variante faltet Apples ``Run–D.M.C.``. Der
+    Test faehrt bewusst ``evaluate``, weil genau das Zusammenspiel der beiden
+    Schritte im Probe-Lauf gescheitert ist.
+    """
+    track = {
+        "artist": "Run-DMC & Jason Nevins",
+        "title": "It's Like That",
+        "year": 1997,
+    }
+    result = {
+        "artistName": "Run–D.M.C.",
+        "trackName": "It's Like That",
+        "releaseDate": "1997-03-25T08:00:00Z",
+    }
+    accepted, reason = evaluate(track, result, title_threshold=0.87, year_tolerance=1)
+    assert accepted is True, reason


### PR DESCRIPTION
Behebt den Fehlalarm aus #2030 — aber nicht mit einer erweiterten Neutral-Liste, sondern dort, wo die Zahlen hinzeigen.

## Die Messung zuerst

Ausgezählt am Probe-Lauf vom 09.08.2026 über **861 fehlende Apple-URIs in 54 Playlists**, **137 Ablehnungen**:

| Grund | Anzahl | Anteil |
|---|---:|---:|
| Jahr | 56 | 41 % |
| **Artist** | **38** | **28 %** |
| **Suffix** | **19** | **14 %** |
| Titel-Ähnlichkeit | 17 | 12 % |
| sonstige | 7 | 5 % |

Und innerhalb der 19 Suffix-Fälle kommt **jede** unmatched-Kette **genau einmal** vor — `short radio edit`, `single edit`, `amended version`, `mixed`, `zoom` … Das `[Mixed]` aus #2030 ist ein Einzelfall. Eine Erweiterung von `_NEUTRAL_SUFFIX_RE` um dieses Token hätte genau einen Track gerettet. Markus' Vorgabe im Issue — „messen statt Neutral-Liste erweitern" — ist damit bestätigt.

Dieser PR nimmt deshalb die **zweitgrößte** Ursache (Artist, 38) und den **größten Cluster** innerhalb der Suffixe (4 Fälle, siehe unten).

## 1. Artist-Varianten

Neu: `_artist_variants()` und `artist_matches()`. Das Gate vergleicht nicht mehr eine normalisierte Zeichenkette gegen ein Set, sondern Varianten gegen Varianten. Alle vier Varianten stammen aus echten Ablehnungen, keine ist erfunden:

- **Führender Artikel** — `Jackson 5` gegen `The Jackson 5` (2×)
- **Apostroph** — `MadHouse` gegen `Mad'House`. `normalise` macht aus Satzzeichen ein Leerzeichen, die beiden unterscheiden sich also genau darin; die leerzeichenfreie Variante faltet das
- **Punkte in Abkürzungen** — `Run-DMC` gegen `Run–D.M.C.`, dieselbe Mechanik
- **Umgestellte Credits** — `Frozen - Cast` gegen `Cast - Frozen`, über die sortierte Token-Folge

Dazu eine zweite, strengere Regel: unser Künstler darf als **zusammenhängender Lauf von mindestens zwei Token** in Apples Credit stecken — `Jimi Hendrix` in `The Jimi Hendrix Experience`.

**Warum genau zwei Token und nur in dieser Richtung**: im selben Probe-Lauf antwortete iTunes `The Parachute Club` auf unser `Paul Kalkbrenner` und einen Ensemble-Credit auf unser `Phil Collins`. Das sind **echte Fehltreffer**. Ein Substring-Test oder ein einzelnes Token würde sie durchlassen — `Cast` steckt in jedem zweiten Soundtrack-Credit. Beide Fälle sind als Negativ-Tests festgeschrieben.

## 2. Soundtrack-Herkunft als neutraler Suffix

Neu: `_SOUNDTRACK_ORIGIN_RE`. Apple hängt an Filmmusik eine **Herkunftsangabe** statt eines Take-Merkmals: `Zwei Seelen (aus "Die Schöne und das Biest" deutscher Film-Soundtrack)`. Das benennt, **wo** die Aufnahme herkommt, nicht **welche** es ist.

Mit vier Fällen (Die Schöne und das Biest, Rapunzel, Hercules, Mulan) ist das der größte Einzelposten unter den 19 Suffix-Ablehnungen — und der einzige, der ein Muster statt eines Einzelfalls ist.

Bewusst eng: muss mit `aus`/`from` **beginnen** und auf `soundtrack` **enden**. `(Motion Picture Version)` wird weiter abgelehnt, denn eine Filmversion kann sehr wohl eine andere Einspielung sein. `(Soundtrack)` allein ebenfalls.

## Tests

`tests/unit/test_backfill_apple_gate_2030.py`, 20 neue Fälle: 8 Artist-Varianten die greifen müssen, 5 die nicht greifen dürfen (darunter die zwei echten Fehltreffer), die Einseitigkeit der Containment-Regel, 6 Soundtrack-Herkunftsangaben, 4 Versions-Suffixe die weiter abgelehnt werden, und drei Ende-zu-Ende-Läufe durch `evaluate`.

**Ein bestehender Test war stumpf geworden.** `test_artist_membership` in `test_backfill_apple_gate_1980.py` baute den alten Ausdruck (`normalise(primary_artist(x)) in artist_set(y)`) nach, statt das Gate zu fahren. Da `evaluate` `artist_set` nicht mehr benutzt, hätte dieser Test nach der Änderung weiter grün gestanden, ohne den Produktionspfad zu prüfen. Er ruft jetzt `artist_matches`. **Alle sechs historischen Erwartungen gelten unverändert** — einzeln gegengeprüft, bevor der Test umgestellt wurde.

`1674 passed` in `tests/unit/`. Lokal war kein `ruff` verfügbar; Zeilenlängen wurden manuell auf ≤88 gebracht.

## Was dieser PR NICHT anfasst

Die **größte** Ursache, Jahr mit 41 %. Davon liegen 33 Fälle mehr als zehn Jahre auseinander (Dinah Washington 1988 gegen 1954, Edgar Ott 2002 gegen 1967) — das ist der offene Widerspruch der Jahres-Konvention und keine Gate-Frage: unser Katalog trägt teils das Compilation-Jahr, Apple das Original. Die ±1-Toleranz lehnt dort **korrekt** ab.

**Draft mit Absicht** — Merge nach deiner Freigabe.
