### PR TITLE
data(finnish-iskelma-classics): zwei falsche Jahre korrigiert (Kirka 1989, Pave Maijanen 1987)

### DIFF
--- a/custom_components/beatify/playlists/community/finnish-iskelma-classics.json
+++ b/custom_components/beatify/playlists/community/finnish-iskelma-classics.json
@@ -1,6 +1,6 @@
 {
   "name": "Finnish Schlager Classics 🇫🇮",
-  "version": "1.20",
+  "version": "1.21",
   "tags": [
     "finnish",
     "iskelma",
@@ -5386,7 +5386,7 @@
       "chart_info": {}
     },
     {
-      "year": 1999,
+      "year": 1989,
       "artist": "Kirka",
       "title": "Anna käsi",
       "alt_artists": [
@@ -7370,7 +7370,7 @@
       }
     },
     {
-      "year": 2011,
+      "year": 1987,
       "artist": "Pave Maijanen",
       "title": "Elämän Nälkä",
       "alt_artists": [],


### PR DESCRIPTION
Korrigiert zwei belegt falsche Jahreszahlen in `community/finnish-iskelma-classics.json`. version `1.20` → `1.21`.

| Song | vorher | jetzt | Quelle |
|---|---:|---:|---|
| Kirka — Anna käsi | 1999 | **1989** | [Discogs](https://www.discogs.com/release/2275648-Kirka-Anna-K%C3%A4si) (Vinyl-LP 1989) |
| Pave Maijanen — Elämän Nälkä | 2011 | **1987** | [Discogs](https://www.discogs.com/release/2762599-Pave-Maijanen-El%C3%A4m%C3%A4n-N%C3%A4lk%C3%A4) (Vinyl 1987, Album „Maailman Tuulet" 09/1987) |

## Wie sie aufgefallen sind

Beide kamen aus den Jahr-Ablehnungen des Apple-Gates (Probe-Lauf 09.08., 56 von 137 Ablehnungen betrafen das Jahr). Apple nannte für Pave Maijanen 1987 und lag damit **richtig**; bei Kirka nannte Apple 1979 und lag ebenfalls falsch — die Wahrheit ist 1989, unsere 1999 und Apples 1979 sehen beide wie Zifferndreher aus.

## Zweiter, unabhängiger Beleg aus der eigenen Datei

Die gespeicherten ISRCs bestätigen beide Korrekturen, ohne dass man eine externe Quelle braucht — Stelle 6–7 einer ISRC ist das **Referenzjahr**:

- `FIFLF**89**00400` → 1989 ✓
- `FIEFP**87**00034` → 1987 ✓

## Was dieser Befund NICHT hergibt

Ein katalogweiter Vergleich ISRC-Jahr gegen `year` liefert 2213 Abweichungen über ±1 Jahr — **das ist aber keine Fehlerquote.** Für Back-Catalog wird die ISRC beim Digitalisieren zugewiesen, nicht bei der Aufnahme: Enrico Caruso „Rigoletto" trägt korrekt `year: 1908` und eine ISRC von 2010.

Belastbar ist nur **eine Richtung**: eine ISRC kann nicht *vor* der Aufnahme existieren. Fälle, in denen das ISRC-Jahr **früher** liegt als unser `year`, sind daher logisch verdächtig — davon gibt es **350**, verteilt vor allem auf `finnish-iskelma-classics` (60), `hitster-100-francais` (45) und `koelner-karneval` (25). Auch das sind Kandidaten und keine bewiesenen Fehler: die ISRC kann zu einer späteren Aufnahme desselben Titels gehören, und einzelne ISRCs im Bestand sind schlicht malformed (`DEEM94000002` parst als Jahr 1940).

Dieser PR korrigiert deshalb nur die **zwei extern verifizierten** Fälle. Die 350er-Liste ist ein Werkzeug für eine spätere, stichprobengestützte Aufräumaktion — nicht für einen Massen-Rewrite.

## Gates

`scripts/validate_playlists.py` — **55/55 valide**, Schema-Gate bestanden. Isolierter Worktree, Push gegen `ls-remote` verifiziert.

**Draft mit Absicht** — Merge nach deiner Freigabe.
