### PR TITLE
refactor(uri-gate): Verify-Gate in scripts/uri_gate.py, All-rounder nutzt es mit

### DIFF
--- a/.claude/skills/provider-uri-backfill/scripts/backfill_provider_uris.py
+++ b/.claude/skills/provider-uri-backfill/scripts/backfill_provider_uris.py
@@ -45,6 +45,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import importlib.util
 import os
 import re
 import sys
@@ -309,6 +310,76 @@ def _dedup(items: list[str]) -> list[str]:
     return out
 
 
+# ---------------------------------------------------------------------------
+# Shared verify-gate (scripts/uri_gate.py)
+# ---------------------------------------------------------------------------
+# Dieses Skript und scripts/backfill_apple.py entscheiden dieselbe Frage — ist
+# der Suchtreffer wirklich unsere Aufnahme — und taten es in zwei verschiedenen
+# Formen. Am 11.08.2026 gemessen: `normalize_title` entfernt Klammerzusaetze,
+# bevor es vergleicht, also sind "The Night" und "The Night (Extended Mix)" fuer
+# dieses Gate identisch. Genau diese Regression hat #1980 im Apple-Skript
+# behoben — und der Apple-Backfill-Agent faehrt DIESES Skript.
+#
+# Die gemeinsamen Bausteine liegen deshalb in scripts/uri_gate.py und werden hier
+# per Pfad geladen (weder `scripts/` noch dieses Verzeichnis sind ein Package).
+# Der Pfad ist aus der Dateilage abgeleitet, nicht aus --repo-root: der Import
+# passiert vor dem Argument-Parsing.
+_GATE: Any = None
+_GATE_WARNED = False
+
+
+def _gate() -> Any:
+    """Load ``scripts/uri_gate.py`` once; ``None`` when it is unavailable.
+
+    A missing gate must not stop a backfill run — but it must be loud. Silent
+    degradation to the weaker rules is exactly the failure mode this project
+    keeps getting bitten by, so the fallback prints once and says what it means.
+    """
+    global _GATE, _GATE_WARNED
+    if _GATE is not None:
+        return _GATE
+    # Nach oben laufen statt eine Ebenenzahl zu raten: der erste Versuch stand auf
+    # parents[3] und traf .claude/scripts/uri_gate.py — die Warnung unten hat das
+    # sofort gezeigt, was genau ihr Zweck ist. Die Suche ueberlebt auch, wenn das
+    # Skill-Verzeichnis einmal verschoben wird.
+    here = Path(__file__).resolve()
+    path = None
+    for parent in here.parents:
+        candidate = parent / "scripts" / "uri_gate.py"
+        if candidate.is_file():
+            path = candidate
+            break
+    if path is None:
+        if not _GATE_WARNED:
+            print(
+                "WARNUNG: scripts/uri_gate.py oberhalb von "
+                f"{here} nicht gefunden — das Gate faellt auf die schwaechere "
+                "Fuzzy-Regel zurueck und kann einen Remix nicht vom Original "
+                "unterscheiden.",
+                file=sys.stderr,
+            )
+            _GATE_WARNED = True
+        return None
+    try:
+        spec = importlib.util.spec_from_file_location("beatify_uri_gate", path)
+        if spec is None or spec.loader is None:
+            raise ImportError(f"kein Loader fuer {path}")
+        mod = importlib.util.module_from_spec(spec)
+        sys.modules["beatify_uri_gate"] = mod
+        spec.loader.exec_module(mod)
+        _GATE = mod
+    except Exception as exc:  # pragma: no cover - Umgebungsfehler
+        if not _GATE_WARNED:
+            print(
+                f"WARNUNG: {path} nicht ladbar ({exc}) — das Gate faellt auf die "
+                "schwaechere Fuzzy-Regel zurueck und kann einen Remix nicht vom "
+                "Original unterscheiden.",
+                file=sys.stderr,
+            )
+            _GATE_WARNED = True
+    return _GATE
+
+
 def _pick_itunes_match(
     results: list[dict], title: str, artist: str, alt_artists: list[str]
 ) -> str | None:
@@ -318,6 +389,7 @@ def _pick_itunes_match(
     (covers writer/original-performer credits). Returns the numeric trackId of
     the first gate-passing result, else None (never guesses on title alone).
     """
+    gate = _gate()
     for r in results or []:
         track_id = _numeric_id(r.get("trackId"))
         if not track_id:
@@ -326,9 +398,24 @@ def _pick_itunes_match(
         r_artist = r.get("artistName") or ""
         if not titles_match(r_title, title):
             continue
-        if titles_match(r_artist, artist) or any(
+        # Suffix-Pruefung. `titles_match` sieht Klammerzusaetze nicht, weil
+        # `normalize_title` sie entfernt — ohne diese Zeile nimmt das Gate einen
+        # Extended Mix als Original an (gemessen 11.08.2026 an drei Faellen).
+        if gate is not None:
+            clash = gate.suffix_conflict(title, r_title)
+            if clash:
+                continue
+        artist_ok = titles_match(r_artist, artist) or any(
             titles_match(r_artist, alt) for alt in (alt_artists or [])
-        ):
+        )
+        # Schreibweisen-Varianten als ZUSATZ, nicht als Ersatz: punktierte
+        # Abkuerzungen (Run-DMC / Run-D.M.C.) und Uebermengen (Jimi Hendrix in
+        # The Jimi Hendrix Experience) scheitern an der Editierdistanz.
+        if not artist_ok and gate is not None:
+            artist_ok = gate.artist_matches(artist, r_artist) or any(
+                gate.artist_matches(alt, r_artist) for alt in (alt_artists or [])
+            )
+        if artist_ok:
             return track_id
     return None
 

--- a/scripts/backfill_apple.py
+++ b/scripts/backfill_apple.py
@@ -111,10 +111,10 @@ from __future__ import annotations
 import argparse
 import difflib
 import json
+import importlib.util
 import re
 import sys
 import time
-import unicodedata
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -138,197 +138,33 @@ BACKOFF_BASE_S = 10.0
 MAX_THROTTLE_ATTEMPTS = 3
 REQUEST_TIMEOUT_S = 20
 
-_FEAT_RE = re.compile(r"\s*[\(\[]?\b(feat|ft|featuring|with)\b\.?\s.*$", re.I)
-_PAREN_RE = re.compile(r"\s*[\(\[][^)\]]*[)\]]")
-_PAREN_CONTENT_RE = re.compile(r"[\(\[]([^)\]]*)[)\]]")
-_PUNCT_RE = re.compile(r"[^\w\s]", re.UNICODE)
-_WS_RE = re.compile(r"\s+")
 # Separators a stripped parenthetical can leave dangling at the end of a title.
 _TRAILING_SEP_RE = re.compile(r"[\s\-–—/,:;]+$")
-_ARTIST_SPLIT_RE = re.compile(r"\s*[,;/]\s*|\s+(?:&|feat\.?|ft\.?|x|vs\.?)\s+", re.I)
 
-# Parenthetical suffixes that name the same *recording* — packaging or mastering
-# wording, not a different take. Only these may appear on one side alone.
-# Deliberately a short closed list: every entry here is a licence to accept a
-# title the other side does not carry, so it is reviewed in the diff.
-_NEUTRAL_SUFFIX_RE = re.compile(
-    r"^(?:\d{4}\s+)?(?:digital\s+)?(?:"
-    r"remaster(?:ed)?(?:\s+version)?(?:\s+\d{4})?"
-    r"|deluxe(?:\s+edition)?"
-    r"|album\s+version"
-    r"|single\s+version"
-    r"|original\s+(?:version|mix)"
-    r"|bonus\s+track"
-    r"|explicit|clean"
-    r")$",
-    re.I,
-)
+# Die Gate-Bausteine liegen seit 2026-08-11 in scripts/uri_gate.py, damit der
+# All-rounder sie mitbenutzen kann statt sie zu kopieren. `scripts/` ist kein
+# Package, deshalb der Pfad-Import — dieselbe Technik, die auch die Tests nutzen.
+_GATE_PATH = Path(__file__).resolve().parent / "uri_gate.py"
+_gate_spec = importlib.util.spec_from_file_location("beatify_uri_gate", _GATE_PATH)
+uri_gate = importlib.util.module_from_spec(_gate_spec)
+sys.modules["beatify_uri_gate"] = uri_gate
+_gate_spec.loader.exec_module(uri_gate)
 
-# Apple haengt an Filmmusik eine Herkunftsangabe statt eines Take-Merkmals:
-# "Zwei Seelen (aus \"Die Schoene und das Biest\" deutscher Film-Soundtrack)".
-# Das benennt, WO die Aufnahme herkommt, nicht WELCHE Aufnahme es ist — und war
-# im Probe-Lauf vom 09.08.2026 mit vier Faellen (Die Schoene und das Biest,
-# Rapunzel, Hercules, Mulan) der groesste Einzelposten unter den 19
-# Suffix-Ablehnungen. Bewusst eng gefasst: muss mit "aus"/"from" beginnen UND
-# auf "soundtrack" enden, damit ein blosses "(Motion Picture Version)" — das
-# sehr wohl eine andere Einspielung sein kann — weiter abgelehnt wird.
-_SOUNDTRACK_ORIGIN_RE = re.compile(
-    r"^(?:aus|from)\s+.+\ssoundtrack$|^original\s+motion\s+picture\s+soundtrack$",
-    re.I,
-)
+_NEUTRAL_SUFFIX_RE = uri_gate._NEUTRAL_SUFFIX_RE
+_SOUNDTRACK_ORIGIN_RE = uri_gate._SOUNDTRACK_ORIGIN_RE
+_PAREN_RE = uri_gate._PAREN_RE
+_ARTIST_SPLIT_RE = uri_gate._ARTIST_SPLIT_RE
+_WS_RE = uri_gate._WS_RE
+normalise = uri_gate.normalise
+primary_artist = uri_gate.primary_artist
+artist_set = uri_gate.artist_set
+artist_matches = uri_gate.artist_matches
+parenthetical_suffixes = uri_gate.parenthetical_suffixes
+suffix_conflict = uri_gate.suffix_conflict
 
 
 def _now_iso() -> str:
     return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%MZ")
-
-
-def normalise(text: str, *, drop_parens: bool = False) -> str:
-    """Fold a title/artist to a comparable form.
-
-    Deliberately conservative: diacritics are kept (``Böhse`` must not collapse
-    onto ``Bohse`` and start matching unrelated artists), only case, punctuation,
-    ``&``/``and`` and whitespace are unified.
-    """
-    if not text:
-        return ""
-    out = unicodedata.normalize("NFC", text)
-    out = _FEAT_RE.sub("", out)
-    if drop_parens:
-        out = _PAREN_RE.sub("", out)
-    out = out.casefold()
-    out = out.replace("&", " and ")
-    out = _PUNCT_RE.sub(" ", out)
-    return _WS_RE.sub(" ", out).strip()
-
-
-def primary_artist(artist: str) -> str:
-    """First credited artist — search results carry the lead artist only."""
-    if not artist:
-        return ""
-    return _ARTIST_SPLIT_RE.split(artist, maxsplit=1)[0]
-
-
-def artist_set(artist: str) -> set[str]:
-    """All credited artists, normalised.
-
-    Split on the raw string, not the normalised one: ``normalise`` turns ``&``
-    into ``and``, which would stop it being a separator.
-    """
-    if not artist:
-        return set()
-    return {n for n in (normalise(p) for p in _ARTIST_SPLIT_RE.split(artist)) if n}
-
-
-_LEADING_ARTICLE_RE = re.compile(r"^(?:the|der|die|das|los|las|le|la|les)\s+", re.I)
-
-
-def _artist_variants(name: str) -> set[str]:
-    """Comparable spellings of one credited artist.
-
-    All four variants come from real rejections in the 09.08.2026 probe run over
-    861 missing Apple URIs — 38 of 137 rejections were artist mismatches, and
-    every one of them was a spelling difference, not a different act:
-
-    * ``Jackson 5`` vs ``The Jackson 5`` — a leading article.
-    * ``MadHouse`` vs ``Mad'House`` — an apostrophe. ``normalise`` turns
-      punctuation into a space, so the two differ by exactly that space.
-    * ``Run-DMC`` vs ``Run-D.M.C.`` — dots inside an abbreviation, again a
-      space after normalisation.
-    * ``Frozen - Cast`` vs ``Cast - Frozen`` — the same credit, reordered.
-
-    The space-free variant is what folds the apostrophe and the dots; it is
-    computed from the article-stripped form so ``The Jackson 5`` also yields
-    ``jackson5``.
-    """
-    base = normalise(name)
-    if not base:
-        return set()
-    stripped = _LEADING_ARTICLE_RE.sub("", base).strip()
-    out = {base, stripped}
-    out |= {v.replace(" ", "") for v in (base, stripped)}
-    out.add(" ".join(sorted(stripped.split())))
-    return {v for v in out if v}
-
-
-def artist_matches(want: str, got: str) -> bool:
-    """True when ``want`` (our primary artist) is credited in ``got`` (Apple's).
-
-    Two rules, in order of strictness:
-
-    1. Any spelling variant of ``want`` equals a variant of any artist Apple
-       credits. This is the membership check that has always been here, only
-       with the variants from :func:`_artist_variants` on both sides.
-    2. ``want`` appears in Apple's full credit as a **contiguous run of at
-       least two tokens** — ``Jimi Hendrix`` inside ``The Jimi Hendrix
-       Experience``. Deliberately not a substring test and deliberately
-       one-directional: it must be *our* artist that is contained, and a
-       single token is never enough.
-
-    Rule 2 is what keeps the real false positives out. In the same probe run
-    Apple answered ``The Parachute Club`` for our ``Paul Kalkbrenner`` and an
-    ensemble credit for our ``Phil Collins`` — neither shares a token run with
-    ours, so both stay rejected. Loosening this to a plain substring or to
-    single tokens would let exactly those through.
-    """
-    want_variants = _artist_variants(want)
-    if not want_variants:
-        return False
-    for credited in _ARTIST_SPLIT_RE.split(got or ""):
-        if want_variants & _artist_variants(credited):
-            return True
-    want_tokens = _LEADING_ARTICLE_RE.sub("", normalise(want)).split()
-    if len(want_tokens) >= 2:
-        got_tokens = normalise(got or "").split()
-        run = " ".join(want_tokens)
-        if run and run in " ".join(got_tokens):
-            return True
-    return False
-
-
-def parenthetical_suffixes(text: str) -> list[str]:
-    """Normalised contents of every ``(...)``/``[...]`` group.
-
-    ``feat.``-tails are cut first — ``normalise`` already handles those, and a
-    featured guest is not a different recording.
-    """
-    if not text:
-        return []
-    stripped = _FEAT_RE.sub("", unicodedata.normalize("NFC", text))
-    out = []
-    for raw in _PAREN_CONTENT_RE.findall(stripped):
-        norm = normalise(raw)
-        if norm:
-            out.append(norm)
-    return out
-
-
-def suffix_conflict(a: str, b: str) -> str | None:
-    """The first suffix that one title carries and the other does not account for.
-
-    ``title_similarity`` compares a parenthetical-stripped form too, so a suffix
-    on one side alone costs nothing — which is right for ``(2000 Remaster)`` and
-    wrong for ``(Extended Mix)``. Both reach similarity 1.00, so no threshold can
-    separate them; the suffix has to be looked at directly.
-
-    A suffix is fine when either
-      * the other side mentions it anywhere in its title (``The Afterlife -
-        Radio Edit`` vs ``The Afterlife (Radio Edit)`` — same words, different
-        punctuation), or
-      * it is recording-neutral per ``_NEUTRAL_SUFFIX_RE``.
-
-    Anything else names a different take and is returned for rejection.
-    """
-    for src, other in ((a, b), (b, a)):
-        other_norm = normalise(other)
-        for suffix in parenthetical_suffixes(src):
-            if suffix in other_norm:
-                continue
-            if _NEUTRAL_SUFFIX_RE.match(suffix):
-                continue
-            if _SOUNDTRACK_ORIGIN_RE.match(suffix):
-                continue
-            return suffix
-    return None
 
 
 def strip_parentheticals(text: str) -> str:
@@ -398,8 +234,9 @@ def release_year(result: dict) -> int | None:
     return None
 
 
-def evaluate(track: dict, result: dict, *, title_threshold: float,
-             year_tolerance: int) -> tuple[bool, str]:
+def evaluate(
+    track: dict, result: dict, *, title_threshold: float, year_tolerance: int
+) -> tuple[bool, str]:
     """Apply the gate. Returns (accepted, reason)."""
     want_artist = primary_artist(track.get("artist", "") or "")
     got_credit = result.get("artistName", "") or ""
@@ -443,7 +280,9 @@ def load_state() -> dict:
         try:
             return json.loads(STATE_PATH.read_text())
         except (json.JSONDecodeError, OSError):
-            sys.stderr.write(f"warning: unreadable state {STATE_PATH}, starting fresh\n")
+            sys.stderr.write(
+                f"warning: unreadable state {STATE_PATH}, starting fresh\n"
+            )
     return {}
 
 
@@ -474,8 +313,12 @@ def find_playlists(args_files: list[str]) -> list[Path]:
 
 def itunes_search(term: str, storefront: str, limit: int) -> tuple[list[dict], str]:
     """Return (results, outcome) with outcome in 'ok' | 'skip'."""
-    url = ITUNES_SEARCH + "?" + urllib.parse.urlencode(
-        {"term": term, "entity": "song", "limit": limit, "country": storefront}
+    url = (
+        ITUNES_SEARCH
+        + "?"
+        + urllib.parse.urlencode(
+            {"term": term, "entity": "song", "limit": limit, "country": storefront}
+        )
     )
     for attempt in range(1, MAX_THROTTLE_ATTEMPTS + 1):
         try:
@@ -501,8 +344,9 @@ def itunes_search(term: str, storefront: str, limit: int) -> tuple[list[dict], s
     return [], "skip"  # throttled out — retry next wave, NOT a miss
 
 
-def resolve(track: dict, *, title_threshold: float, year_tolerance: int,
-            limit: int) -> tuple[str | None, str, str]:
+def resolve(
+    track: dict, *, title_threshold: float, year_tolerance: int, limit: int
+) -> tuple[str | None, str, str]:
     """Return (apple_uri_or_None, outcome, detail).
 
     outcome: 'hit' | 'miss' (no results anywhere) | 'rejected' (results, none
@@ -529,8 +373,10 @@ def resolve(track: dict, *, title_threshold: float, year_tolerance: int,
             saw_any = True
             for result in results:
                 accepted, reason = evaluate(
-                    track, result,
-                    title_threshold=title_threshold, year_tolerance=year_tolerance,
+                    track,
+                    result,
+                    title_threshold=title_threshold,
+                    year_tolerance=year_tolerance,
                 )
                 if accepted:
                     tid = result.get("trackId")
@@ -562,25 +408,59 @@ def main() -> int:
     ap = argparse.ArgumentParser(
         description="Backfill uri_apple_music via iTunes search (gated, idempotent)."
     )
-    ap.add_argument("files", nargs="*", help="specific playlist JSON files (default: all)")
-    ap.add_argument("--max", type=int, default=0,
-                    help="cap number of tracks resolved this run (0 = no cap)")
-    ap.add_argument("--max-minutes", type=float, default=0,
-                    help="stop the wave after this many minutes of wall-clock (0 = no limit)")
-    ap.add_argument("--dry-run", action="store_true",
-                    help="list what would be queried, no network/writes")
-    ap.add_argument("--probe", action="store_true",
-                    help="query + apply the gate but write NOTHING (threshold calibration)")
-    ap.add_argument("--retry-rejected", action="store_true",
-                    help="also re-query tracks previously rejected by the gate")
-    ap.add_argument("--retry-misses", action="store_true",
-                    help="also re-query tracks recorded as genuine misses")
-    ap.add_argument("--title-threshold", type=float, default=0.87,
-                    help="minimum title similarity to accept a match (default 0.87)")
-    ap.add_argument("--year-tolerance", type=int, default=1,
-                    help="allowed |releaseDate year - track year| (default 1)")
-    ap.add_argument("--limit", type=int, default=5,
-                    help="search results inspected per storefront (default 5)")
+    ap.add_argument(
+        "files", nargs="*", help="specific playlist JSON files (default: all)"
+    )
+    ap.add_argument(
+        "--max",
+        type=int,
+        default=0,
+        help="cap number of tracks resolved this run (0 = no cap)",
+    )
+    ap.add_argument(
+        "--max-minutes",
+        type=float,
+        default=0,
+        help="stop the wave after this many minutes of wall-clock (0 = no limit)",
+    )
+    ap.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="list what would be queried, no network/writes",
+    )
+    ap.add_argument(
+        "--probe",
+        action="store_true",
+        help="query + apply the gate but write NOTHING (threshold calibration)",
+    )
+    ap.add_argument(
+        "--retry-rejected",
+        action="store_true",
+        help="also re-query tracks previously rejected by the gate",
+    )
+    ap.add_argument(
+        "--retry-misses",
+        action="store_true",
+        help="also re-query tracks recorded as genuine misses",
+    )
+    ap.add_argument(
+        "--title-threshold",
+        type=float,
+        default=0.87,
+        help="minimum title similarity to accept a match (default 0.87)",
+    )
+    ap.add_argument(
+        "--year-tolerance",
+        type=int,
+        default=1,
+        help="allowed |releaseDate year - track year| (default 1)",
+    )
+    ap.add_argument(
+        "--limit",
+        type=int,
+        default=5,
+        help="search results inspected per storefront (default 5)",
+    )
     args = ap.parse_args()
 
     state = {} if args.dry_run else load_state()
@@ -610,13 +490,19 @@ def main() -> int:
                 continue
             todo.append((pf, track))
 
-    mode = " (dry-run)" if args.dry_run else " (probe — no writes)" if args.probe else ""
-    print(f"{len(todo)} track(s) missing Apple Music across "
-          f"{len(files_cache)} playlist(s){mode}")
+    mode = (
+        " (dry-run)" if args.dry_run else " (probe — no writes)" if args.probe else ""
+    )
+    print(
+        f"{len(todo)} track(s) missing Apple Music across "
+        f"{len(files_cache)} playlist(s){mode}"
+    )
 
     if args.dry_run:
         for pf, track in todo[: args.max or len(todo)]:
-            print(f"  WOULD QUERY  {pf.name}: {track.get('artist')} – {track.get('title')}")
+            print(
+                f"  WOULD QUERY  {pf.name}: {track.get('artist')} – {track.get('title')}"
+            )
         return 0
 
     hits = misses = rejected = skips = 0
@@ -661,8 +547,11 @@ def main() -> int:
             reject_reasons[kind] = reject_reasons.get(kind, 0) + 1
             print(f"  REJECT    {label}  [{detail}]")
             if not args.probe:
-                state[track["uri"]] = {"status": "rejected", "tried_at": _now_iso(),
-                                       "reason": detail}
+                state[track["uri"]] = {
+                    "status": "rejected",
+                    "tried_at": _now_iso(),
+                    "reason": detail,
+                }
                 save_state(state)
         elif outcome == "miss":
             misses += 1
@@ -674,9 +563,11 @@ def main() -> int:
             skips += 1
         time.sleep(BASE_DELAY_S)
 
-    print(f"\nwave done: {hits} accepted, {rejected} rejected by gate, "
-          f"{misses} genuine misses, {skips} throttle skips (retry next wave). "
-          f"Files updated: {len(dirty)}.")
+    print(
+        f"\nwave done: {hits} accepted, {rejected} rejected by gate, "
+        f"{misses} genuine misses, {skips} throttle skips (retry next wave). "
+        f"Files updated: {len(dirty)}."
+    )
     if reject_reasons:
         print("rejections by kind:")
         for kind, count in sorted(reject_reasons.items(), key=lambda kv: -kv[1]):

--- a/scripts/uri_gate.py
+++ b/scripts/uri_gate.py
@@ -1,0 +1,215 @@
+"""Shared verify-gate primitives for the URI resolvers.
+
+Both resolvers guess: they query a search endpoint with artist + title and have
+to decide whether the first plausible hit is really *our* recording. That
+decision used to live twice, in two different shapes:
+
+* ``scripts/backfill_apple.py`` — iTunes search, four rules (artist membership,
+  title similarity, suffix conflict, year tolerance). Hardened over #1980,
+  #2007 and #2030.
+* ``.claude/skills/provider-uri-backfill/scripts/backfill_provider_uris.py`` —
+  the all-rounder for Apple/Tidal/Deezer/YouTube. Its gate is a Levenshtein
+  match on title and artist.
+
+Measured on 2026-08-11, the second one **cannot tell a remix from the
+original**: its ``normalize_title`` strips parentheticals before comparing, so
+``The Night`` and ``The Night (Extended Mix)`` are equal to it. That is exactly
+the regression #1980 fixed in the Apple script — and the Apple backfill agent
+runs on the all-rounder.
+
+This module holds the pieces both need, so a fix lands in one place. It is
+deliberately dependency-free (only ``re`` and ``unicodedata``) and free of I/O,
+so it can be imported by a script in any directory and unit-tested on its own.
+
+Kept out of here on purpose: ``title_similarity`` and ``release_year``, which
+are specific to the Apple script's thresholds, and ``normalize_title`` /
+``levenshtein`` from the all-rounder, which serve its own fuzzy stage.
+"""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+
+_FEAT_RE = re.compile(r"\s*[\(\[]?\b(feat|ft|featuring|with)\b\.?\s.*$", re.I)
+_PAREN_RE = re.compile(r"\s*[\(\[][^)\]]*[)\]]")
+_PAREN_CONTENT_RE = re.compile(r"[\(\[]([^)\]]*)[)\]]")
+_PUNCT_RE = re.compile(r"[^\w\s]", re.UNICODE)
+_WS_RE = re.compile(r"\s+")
+_ARTIST_SPLIT_RE = re.compile(r"\s*[,;/]\s*|\s+(?:&|feat\.?|ft\.?|x|vs\.?)\s+", re.I)
+_LEADING_ARTICLE_RE = re.compile(r"^(?:the|der|die|das|los|las|le|la|les)\s+", re.I)
+
+# Parenthetical suffixes that name the same *recording* — packaging or mastering
+# wording, not a different take. Only these may appear on one side alone.
+# Deliberately a short closed list: every entry here is a licence to accept a
+# title the other side does not carry, so it is reviewed in the diff.
+_NEUTRAL_SUFFIX_RE = re.compile(
+    r"^(?:\d{4}\s+)?(?:digital\s+)?(?:"
+    r"remaster(?:ed)?(?:\s+version)?(?:\s+\d{4})?"
+    r"|deluxe(?:\s+edition)?"
+    r"|album\s+version"
+    r"|single\s+version"
+    r"|original\s+(?:version|mix)"
+    r"|bonus\s+track"
+    r"|explicit|clean"
+    r")$",
+    re.I,
+)
+
+# Apple appends an origin credit to film music instead of a take marker:
+# "Zwei Seelen (aus \"Die Schoene und das Biest\" deutscher Film-Soundtrack)".
+# That says WHERE the recording comes from, not WHICH recording it is — and in
+# the 2026-08-09 probe run it was the largest single group among the 19 suffix
+# rejections (Beauty and the Beast, Tangled, Hercules, Mulan). Deliberately
+# narrow: must start with "aus"/"from" AND end in "soundtrack", so a bare
+# "(Motion Picture Version)" — which can genuinely be a different take — keeps
+# being rejected.
+_SOUNDTRACK_ORIGIN_RE = re.compile(
+    r"^(?:aus|from)\s+.+\ssoundtrack$|^original\s+motion\s+picture\s+soundtrack$",
+    re.I,
+)
+
+
+def normalise(text: str, *, drop_parens: bool = False) -> str:
+    """Fold a title/artist to a comparable form.
+
+    Deliberately conservative: diacritics are kept (``Böhse`` must not collapse
+    onto ``Bohse`` and start matching unrelated artists), only case, punctuation,
+    ``&``/``and`` and whitespace are unified.
+    """
+    if not text:
+        return ""
+    out = unicodedata.normalize("NFC", text)
+    out = _FEAT_RE.sub("", out)
+    if drop_parens:
+        out = _PAREN_RE.sub("", out)
+    out = out.casefold()
+    out = out.replace("&", " and ")
+    out = _PUNCT_RE.sub(" ", out)
+    return _WS_RE.sub(" ", out).strip()
+
+
+def primary_artist(artist: str) -> str:
+    """First credited artist — search results carry the lead artist only."""
+    if not artist:
+        return ""
+    return _ARTIST_SPLIT_RE.split(artist, maxsplit=1)[0]
+
+
+def artist_set(artist: str) -> set[str]:
+    """All credited artists, normalised.
+
+    Split on the raw string, not the normalised one: ``normalise`` turns ``&``
+    into ``and``, which would stop it being a separator.
+    """
+    if not artist:
+        return set()
+    return {n for n in (normalise(p) for p in _ARTIST_SPLIT_RE.split(artist)) if n}
+
+
+def _artist_variants(name: str) -> set[str]:
+    """Comparable spellings of one credited artist.
+
+    All four variants come from real rejections in the 2026-08-09 probe run over
+    861 missing Apple URIs — 38 of 137 rejections were artist mismatches, and
+    every one of them was a spelling difference, not a different act:
+
+    * ``Jackson 5`` vs ``The Jackson 5`` — a leading article.
+    * ``MadHouse`` vs ``Mad'House`` — an apostrophe. ``normalise`` turns
+      punctuation into a space, so the two differ by exactly that space.
+    * ``Run-DMC`` vs ``Run-D.M.C.`` — dots inside an abbreviation, again a
+      space after normalisation.
+    * ``Frozen - Cast`` vs ``Cast - Frozen`` — the same credit, reordered.
+
+    The space-free variant is what folds the apostrophe and the dots; it is
+    computed from the article-stripped form so ``The Jackson 5`` also yields
+    ``jackson5``.
+    """
+    base = normalise(name)
+    if not base:
+        return set()
+    stripped = _LEADING_ARTICLE_RE.sub("", base).strip()
+    out = {base, stripped}
+    out |= {v.replace(" ", "") for v in (base, stripped)}
+    out.add(" ".join(sorted(stripped.split())))
+    return {v for v in out if v}
+
+
+def artist_matches(want: str, got: str) -> bool:
+    """True when ``want`` (our primary artist) is credited in ``got``.
+
+    Two rules, in order of strictness:
+
+    1. Any spelling variant of ``want`` equals a variant of any artist credited
+       in ``got``.
+    2. ``want`` appears in the full credit as a **contiguous run of at least
+       two tokens** — ``Jimi Hendrix`` inside ``The Jimi Hendrix Experience``.
+       Deliberately not a substring test and deliberately one-directional: it
+       must be *our* artist that is contained, and a single token is never
+       enough.
+
+    Rule 2 is what keeps the real false positives out. In the same probe run
+    iTunes answered ``The Parachute Club`` for our ``Paul Kalkbrenner`` and an
+    ensemble credit for our ``Phil Collins`` — neither shares a token run with
+    ours, so both stay rejected. Loosening this to a plain substring or to
+    single tokens would let exactly those through.
+    """
+    want_variants = _artist_variants(want)
+    if not want_variants:
+        return False
+    for credited in _ARTIST_SPLIT_RE.split(got or ""):
+        if want_variants & _artist_variants(credited):
+            return True
+    want_tokens = _LEADING_ARTICLE_RE.sub("", normalise(want)).split()
+    if len(want_tokens) >= 2:
+        run = " ".join(want_tokens)
+        if run and run in normalise(got or ""):
+            return True
+    return False
+
+
+def parenthetical_suffixes(text: str) -> list[str]:
+    """Normalised contents of every ``(...)``/``[...]`` group.
+
+    ``feat.``-tails are cut first — ``normalise`` already handles those, and a
+    featured guest is not a different recording.
+    """
+    if not text:
+        return []
+    cleaned = _FEAT_RE.sub("", text)
+    out = []
+    for raw in _PAREN_CONTENT_RE.findall(cleaned):
+        norm = normalise(raw)
+        if norm:
+            out.append(norm)
+    return out
+
+
+def suffix_conflict(a: str, b: str) -> str | None:
+    """The first suffix that one title carries and the other does not account for.
+
+    A fuzzy title comparison that ignores parentheticals cannot separate
+    ``(2000 Remaster)`` from ``(Extended Mix)`` — both look like the same title
+    with something appended. So the suffix has to be inspected directly.
+
+    A suffix is fine when either
+
+      * the other side mentions it anywhere in its title (``The Afterlife -
+        Radio Edit`` vs ``The Afterlife (Radio Edit)`` — same words, different
+        punctuation), or
+      * it is recording-neutral per :data:`_NEUTRAL_SUFFIX_RE`, or
+      * it is an origin credit per :data:`_SOUNDTRACK_ORIGIN_RE`.
+
+    Anything else names a different take and is returned for rejection.
+    """
+    for src, other in ((a, b), (b, a)):
+        other_norm = normalise(other)
+        for suffix in parenthetical_suffixes(src):
+            if suffix in other_norm:
+                continue
+            if _NEUTRAL_SUFFIX_RE.match(suffix):
+                continue
+            if _SOUNDTRACK_ORIGIN_RE.match(suffix):
+                continue
+            return suffix
+    return None

--- a/tests/unit/test_uri_gate_shared.py
+++ b/tests/unit/test_uri_gate_shared.py
@@ -1,0 +1,196 @@
+"""Das gemeinsame Verify-Gate (``scripts/uri_gate.py``) und seine zwei Nutzer.
+
+Anlass ist eine Messung vom 11.08.2026: `backfill_provider_uris.py` — das Skript,
+auf dem der **Apple-Backfill-Agent** läuft — konnte einen Remix nicht vom Original
+unterscheiden. Sein `normalize_title` entfernt Klammerzusätze, bevor es
+vergleicht, also sind ``The Night`` und ``The Night (Extended Mix)`` für sein Gate
+identisch. Genau diese Regression hatte #1980 im Apple-Skript behoben, nur eben
+im anderen Skript.
+
+Die Tests hier sichern drei Dinge:
+
+1. Das gemeinsame Modul verhält sich wie die Regeln, die aus `backfill_apple.py`
+   dorthin gewandert sind.
+2. Der All-rounder **benutzt** es und lehnt seitdem ab, was er vorher annahm.
+3. Fehlt das Modul, degradiert er **laut** und arbeitet weiter.
+
+Punkt 3 ist kein Beiwerk: eine stille Verschlechterung auf die schwächere Regel
+ist genau die Fehlerart, die dieses Projekt mehrfach Arbeit gekostet hat.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _load(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+gate = _load("uri_gate_under_test", _ROOT / "scripts" / "uri_gate.py")
+allrounder = _load(
+    "allrounder_under_test",
+    _ROOT
+    / ".claude"
+    / "skills"
+    / "provider-uri-backfill"
+    / "scripts"
+    / "backfill_provider_uris.py",
+)
+
+
+def _itunes_hit(title: str, artist: str, r_title: str, r_artist: str):
+    """Ein einzelner iTunes-Treffer durch das Gate des All-rounders."""
+    return allrounder._pick_itunes_match(
+        [{"trackId": 123, "trackName": r_title, "artistName": r_artist}],
+        title,
+        artist,
+        [],
+    )
+
+
+# --------------------------------------------------------- gemeinsames Modul
+def test_gate_is_importable_from_the_allrounder() -> None:
+    """Der All-rounder findet das Modul über die Verzeichnissuche.
+
+    Der erste Entwurf riet eine Ebenenzahl (`parents[3]`) und landete auf
+    `.claude/scripts/uri_gate.py`. Aufgefallen ist das nur, weil der Fallback
+    eine Warnung schreibt — deshalb ist dieser Test hier.
+    """
+    assert allrounder._gate() is not None
+
+
+@pytest.mark.parametrize(
+    ("ours", "apple", "expected"),
+    [
+        ("Jackson 5", "The Jackson 5", True),
+        ("MadHouse", "Mad'House", True),
+        ("Run-DMC", "Run–D.M.C.", True),
+        ("Jimi Hendrix", "The Jimi Hendrix Experience", True),
+        ("Frozen - Cast", "Cast - Frozen", True),
+        ("Zatox", "Tatanka, Zatox & Wild Motherfuckers", True),
+        # Die zwei echten Fehltreffer aus dem Probe-Lauf vom 09.08.
+        ("Paul Kalkbrenner", "The Parachute Club", False),
+        ("Phil Collins", "Anton Zetterholm & Ensemble Stage Theater", False),
+        ("Cast", "Johnny Cash & The Tennessee Two", False),
+    ],
+)
+def test_artist_matches_unchanged_after_move(
+    ours: str, apple: str, expected: bool
+) -> None:
+    assert gate.artist_matches(ours, apple) is expected
+
+
+@pytest.mark.parametrize(
+    ("bare", "decorated", "accepted"),
+    [
+        ("The Night", "The Night (2000 Remaster)", True),
+        ("The Night", "The Night (Extended Mix)", False),
+        ("One More Time", "One More Time (Short Radio Edit)", False),
+        (
+            "Zwei Seelen",
+            'Zwei Seelen (aus "Die Schöne und das Biest" Film-Soundtrack)',
+            True,
+        ),
+        ("Let It Go", "Let It Go (Motion Picture Version)", False),
+    ],
+)
+def test_suffix_conflict_unchanged_after_move(
+    bare: str, decorated: str, accepted: bool
+) -> None:
+    assert (gate.suffix_conflict(bare, decorated) is None) is accepted
+
+
+# ------------------------------------------------- All-rounder benutzt es auch
+@pytest.mark.parametrize(
+    ("title", "hit_title", "accepted"),
+    [
+        # Was er schon vorher richtig machte
+        ("The Night", "The Night", True),
+        ("The Night", "The Night (2000 Remaster)", True),
+        # Was er vorher FALSCH machte: alle drei wurden angenommen
+        ("The Night", "The Night (Extended Mix)", False),
+        ("One More Time", "One More Time (Short Radio Edit)", False),
+        ("Hard Bass - Ran-D Remix", "Hard Bass (Xtreme Sound Mix)", False),
+        # Herkunftsangabe ist kein Take-Merkmal
+        (
+            "Zwei Seelen",
+            'Zwei Seelen (aus "Die Schöne und das Biest" deutscher Film-Soundtrack)',
+            True,
+        ),
+    ],
+)
+def test_allrounder_itunes_gate_checks_suffixes(
+    title: str, hit_title: str, accepted: bool
+) -> None:
+    got = _itunes_hit(title, "Noisecontrollers", hit_title, "Noisecontrollers")
+    assert (got is not None) is accepted
+
+
+@pytest.mark.parametrize(
+    ("ours", "hit_artist", "accepted"),
+    [
+        # Diese beiden scheitern an der Editierdistanz und gehen erst mit den
+        # Varianten durch — der eigentliche Zugewinn fuer den All-rounder.
+        ("Run-DMC", "Run–D.M.C.", True),
+        ("Jimi Hendrix", "The Jimi Hendrix Experience", True),
+        # Was die Editierdistanz schon konnte, bleibt
+        ("Jackson 5", "The Jackson 5", True),
+        # Und die Fehltreffer bleiben draussen
+        ("Paul Kalkbrenner", "The Parachute Club", False),
+        ("Phil Collins", "Anton Zetterholm & Ensemble Stage Theater", False),
+    ],
+)
+def test_allrounder_itunes_gate_uses_artist_variants(
+    ours: str, hit_artist: str, accepted: bool
+) -> None:
+    got = _itunes_hit("Some Song", ours, "Some Song", hit_artist)
+    assert (got is not None) is accepted
+
+
+def test_allrounder_still_rejects_a_different_song() -> None:
+    """Die Grundregel bleibt: ein anderer Titel wird nicht akzeptiert."""
+    assert (
+        _itunes_hit(
+            "Sky and Sand",
+            "Paul Kalkbrenner",
+            "Völlig anderes Lied",
+            "Paul Kalkbrenner",
+        )
+        is None
+    )
+
+
+# ------------------------------------------------------------ lauter Fallback
+def test_missing_gate_degrades_loudly_and_keeps_working(monkeypatch, capsys) -> None:
+    """Ohne Modul arbeitet der All-rounder weiter — aber sichtbar schwächer.
+
+    Geprüft wird beides: dass eine Warnung auf stderr landet (und *warum* sie
+    dort landet, steht im Text), und dass der Lauf nicht abbricht.
+    """
+    monkeypatch.setattr(allrounder, "_GATE", None, raising=False)
+    monkeypatch.setattr(allrounder, "_GATE_WARNED", False, raising=False)
+    monkeypatch.setattr(
+        allrounder.importlib.util, "spec_from_file_location", lambda *a, **k: None
+    )
+    got = _itunes_hit(
+        "The Night", "Noisecontrollers", "The Night (Extended Mix)", "Noisecontrollers"
+    )
+    err = capsys.readouterr().err
+    assert "WARNUNG" in err
+    assert "Remix" in err
+    # Ohne Gate faellt er auf die alte, schwaechere Regel zurueck — genau das
+    # macht die Warnung noetig.
+    assert got is not None
+    monkeypatch.setattr(allrounder, "_GATE", None, raising=False)


### PR DESCRIPTION
Legt das Verify-Gate in **eine** Datei und lässt den All-rounder es mitbenutzen. Auslöser ist eine Messung, nicht ein Aufräum-Impuls.

## Der Befund

Beide Resolver entscheiden dieselbe Frage — ist der Suchtreffer wirklich unsere Aufnahme — und taten es in zwei verschiedenen Formen. Am 11.08.2026 beide gegen dieselben Fälle laufen lassen:

| Fall | `backfill_apple.py` | `backfill_provider_uris.py` |
|---|---|---|
| `The Night` vs `The Night (2000 Remaster)` | akzeptiert | akzeptiert |
| `The Night` vs `The Night (Extended Mix)` | **abgelehnt** | **akzeptiert** |
| `One More Time` vs `One More Time (Short Radio Edit)` | **abgelehnt** | **akzeptiert** |
| `Hard Bass - Ran-D Remix` vs `Hard Bass (Xtreme Sound Mix)` | **abgelehnt** | **akzeptiert** |

**Der All-rounder kann einen Remix nicht vom Original unterscheiden.** Sein `normalize_title` entfernt Klammerzusätze, *bevor* es vergleicht — für sein Gate sind die beiden Titel identisch. Das ist genau die Regression, die #1980 im Apple-Skript behoben hat, nur eben im anderen Skript.

**Und das ist nicht theoretisch**: der Apple-Backfill-Agent (seit 11.08. aktiv, `com.beatify.apple-backfill`) fährt **diesen** All-rounder. Die 30 URIs aus #2090 sind mit dem ungefixten Gate geschrieben.

Umgekehrt fand die Editierdistanz zwei Dinge nicht, die das Apple-Gate kann: punktierte Abkürzungen (`Run-DMC` / `Run–D.M.C.`) und Übermengen (`Jimi Hendrix` in `The Jimi Hendrix Experience`).

## Die Änderung

**Neu `scripts/uri_gate.py`** — die gemeinsamen Bausteine, dependency-frei (`re`, `unicodedata`) und ohne I/O: `normalise`, `primary_artist`, `artist_set`, `_artist_variants`, `artist_matches`, `parenthetical_suffixes`, `suffix_conflict` sowie `_NEUTRAL_SUFFIX_RE` und `_SOUNDTRACK_ORIGIN_RE`.

**`scripts/backfill_apple.py`** importiert sie und re-exportiert die Namen, damit die bestehenden Tests unverändert weiterlaufen. Netto −109 Zeilen. **Bewusst dort geblieben**: `title_similarity` und `release_year` — die hängen an den Schwellwerten dieses Skripts.

**`backfill_provider_uris.py`** lädt das Modul per Verzeichnissuche und nutzt es in `_pick_itunes_match` an zwei Stellen: die Suffix-Prüfung als **zusätzliche Ablehnung**, die Artist-Varianten als **zusätzliche Annahme**. Die bestehende Fuzzy-Regel bleibt der erste Filter, es wird nichts ersetzt.

## Der Fallback ist laut, mit Absicht

Fehlt das Modul, arbeitet der Lauf weiter — schreibt aber einmal auf stderr, dass das Gate jetzt „einen Remix nicht vom Original unterscheiden" kann. Eine stille Verschlechterung auf die schwächere Regel ist genau die Fehlerart, die dieses Projekt diese Woche mehrfach Arbeit gekostet hat.

Der Nutzen war sofort messbar: der erste Entwurf riet eine Ebenenzahl (`parents[3]`) und landete auf `.claude/scripts/uri_gate.py`. Aufgefallen ist das **nur** durch diese Warnung. Die Pfadsuche läuft jetzt nach oben, bis sie `scripts/uri_gate.py` findet, und ein Test sichert das ab.

## Tests

`tests/unit/test_uri_gate_shared.py`, **28 Fälle** in vier Gruppen: das Modul verhält sich wie vor dem Verschieben (9 Artist- + 5 Suffix-Fälle), der All-rounder lehnt jetzt ab was er vorher annahm (6), er akzeptiert die Varianten die er vorher nicht kannte (5), und der Fallback warnt sichtbar statt still zu degradieren.

`1702 passed` in `tests/unit/` (vorher 1674). `ruff check .` und `ruff format --check .` mit der in `test.yml` gepinnten **0.15.7** grün.

## Zwei Dinge zum Wissen

**`scripts/uri_gate.py` musste mit `git add -f` hinein.** `.gitignore` Zeile 13 ignoriert `scripts/` pauschal, ebenso `.claude/` und `docs/` — und alle drei enthalten trotzdem getrackte Dateien. Das ist die etablierte Konvention dieses Repos, keine Panne; ich nenne es nur, weil die nächste neue Datei dort wieder daran hängen bleibt.

**Die 30 Apple-URIs aus #2090 sind ungeprüft.** Sie entstanden vor diesem PR, also mit dem Gate, das einen Remix durchlässt. Ob darunter ein falscher Mix ist, lässt sich nur mit einem iTunes-Abruf je ID feststellen — 30 Anfragen. Nicht Teil dieses PRs.

**Draft mit Absicht** — Merge nach deiner Freigabe. Solange er offen ist, läuft der 13:00-Apple-Agent noch auf dem alten Gate.
