### PR TITLE
data(deutschrock-best-of): DE-Region-IDs für vier US-only-Songs nachgetragen

### DIFF
--- a/custom_components/beatify/playlists/community/deutschrock-best-of.json
+++ b/custom_components/beatify/playlists/community/deutschrock-best-of.json
@@ -1,6 +1,6 @@
 {
   "name": "Deutschrock - Best Of",
-  "version": "0.10",
+  "version": "0.11",
   "tags": [
     "deutschrock",
     "german rock",
@@ -411,8 +411,8 @@
       "isrc": "DEN490100010",
       "uri_apple_music": "applemusic://track/587107055",
       "uri_apple_music_by_region": {
-        "us": null,
-        "de": null,
+        "us": "applemusic://track/587107055",
+        "de": "applemusic://track/579070965",
         "gb": null,
         "fr": null,
         "es": null,
@@ -489,8 +489,8 @@
       "isrc": "ATN262105506",
       "uri_apple_music": "applemusic://track/1590190387",
       "uri_apple_music_by_region": {
-        "us": null,
-        "de": null,
+        "us": "applemusic://track/1590190387",
+        "de": "applemusic://track/1593383984",
         "gb": null,
         "fr": null,
         "es": null,
@@ -723,8 +723,8 @@
       "isrc": "DEQ022280938",
       "uri_apple_music": "applemusic://track/1771972304",
       "uri_apple_music_by_region": {
-        "us": null,
-        "de": null,
+        "us": "applemusic://track/1771972304",
+        "de": "applemusic://track/1822319032",
         "gb": null,
         "fr": null,
         "es": null,
@@ -827,8 +827,8 @@
       "isrc": "DEG129603005",
       "uri_apple_music": "applemusic://track/587163591",
       "uri_apple_music_by_region": {
-        "us": null,
-        "de": null,
+        "us": "applemusic://track/587163591",
+        "de": "applemusic://track/579066787",
         "gb": null,
         "fr": null,
         "es": null,


### PR DESCRIPTION
Trägt für **vier** der fünf Songs, deren Apple-ID nur im US-Store auflöst, eine im **deutschen** Store verifizierte ID nach. version `0.10` → `0.11`.

| Song | de (neu) | us |
|---|---|---|
| Böhse Onkelz — 10 Jahre | `579070965` | `587107055` |
| Toxpack — Totgeglaubt, doch neugeboren | `1593383984` | `1590190387` |
| Maerzfeld — Lange nicht | `1822319032` | `1771972304` |
| Böhse Onkelz — Zu nah an der Wahrheit | `579066787` | `587163591` |

## Warum das nötig war

Die fünf IDs kamen aus dem Apple-Backfill vom 11.08. (#2090) und liegen alle im Legacy-Feld `uri_apple_music`. Ein Lookup mit `country=de` findet keine davon — sie existieren nur im US-Store. Titel, Interpret und Jahr stimmen dort jeweils, es ist also **keine Fehlzuordnung, sondern Regionsverfügbarkeit**: für einen deutschen Spieler wären genau diese Songs stumm.

Mit einer gefüllten `uri_apple_music_by_region` löst `get_song_uri` storefront-bewusst auf, und das Legacy-Feld wird nach #1379 zugunsten von `_resolved_uri` fallen gelassen.

## Vier, nicht fünf — und warum

**`Unantastbar — Dieser eine Moment` gibt es im deutschen Store nicht.** Eine Suche dort liefert nur einen unbeteiligten Titel eines anderen Interpreten. Eine Region-Map kann Verfügbarkeit nicht herbeizaubern; ein `de`-Eintrag wäre erfunden. Der Song bleibt für deutsche Spieler nicht spielbar, und das ist die richtige Darstellung der Wirklichkeit.

## Jede ID einzeln gegengeprüft

Nicht aus der Suche übernommen, sondern per `lookup?country=de` bestätigt — mit Titel, Interpret, Datum und Spieldauer:

- `579070965` Böhse Onkelz — 10 Jahre · 1990-07-01 · 254 s (unser Jahr 1990 ✓)
- `1593383984` Toxpack — Totgeglaubt, doch neugeboren · 2022-01-12 · 253 s (unser 2022 ✓)
- `1822319032` Maerzfeld — Lange nicht · 2022-04-21 · 203 s (unser 2023, ein Jahr Abstand)
- `579066787` Böhse Onkelz — Zu nah an der Wahrheit · 1996-09-02 · 379 s (unser 1996 ✓)

Die übrigen Regionen (`gb`, `fr`, `es`, `nl`, `it`) bleiben `null`. Der Auftrag war, die Songs für deutsche Spieler hörbar zu machen; sieben Storefronts pro Song wären 35 weitere Abrufe ohne belegten Bedarf.

## Gates

`scripts/validate_playlists.py` — **55/55 valide**. Isolierter Worktree, Push gegen `ls-remote` verifiziert.

## Zeitliche Warnung

Der Apple-Backfill-Agent läuft **13:00** und wählt voraussichtlich wieder `deutschrock-best-of` (68 Apple-Lücken). Sein Draft-PR fasst dieselbe Datei an. Wird dieser PR vorher gemergt, ist alles glatt; sonst braucht einer der beiden ein Rebase.

**Draft mit Absicht** — Merge nach deiner Freigabe.
