### PR TITLE
chore(playlists): tidal backfill wave — +16 uris

### DIFF
--- a/custom_components/beatify/playlists/disco-funk-classics.json
+++ b/custom_components/beatify/playlists/disco-funk-classics.json
@@ -1,6 +1,6 @@
 {
   "name": "Disco & Funk Classics",
-  "version": "1.9",
+  "version": "1.10",
   "tags": [
     "1970s",
     "1980s",
@@ -3471,7 +3471,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/537537",
       "uri_deezer": "deezer://track/364974",
       "isrc": "DED167800004"
     },
@@ -3506,7 +3506,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/71041309",
       "uri_deezer": "deezer://track/143782586",
       "isrc": "GBAKW0201571"
     },
@@ -3541,7 +3541,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/21975507",
       "uri_deezer": "deezer://track/70051871",
       "isrc": "GBCMX0509001"
     },
@@ -3576,7 +3576,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/19378799",
       "uri_deezer": "deezer://track/68515594",
       "isrc": "CAU118200149"
     },
@@ -3646,7 +3646,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/99846227",
       "uri_deezer": "deezer://track/597208142",
       "isrc": "DKMFA0200501"
     },
@@ -3681,7 +3681,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/1507340",
       "uri_deezer": "deezer://track/3100604",
       "isrc": "USCH30100108"
     },
@@ -3716,7 +3716,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/33740664",
       "uri_deezer": "deezer://track/4603402",
       "isrc": "USSM10905824"
     },
@@ -3751,7 +3751,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/128936364",
       "uri_deezer": "deezer://track/858554742",
       "isrc": "AUDCB1701525"
     },
@@ -3786,7 +3786,7 @@
         "it": "applemusic://track/1469850494"
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/113774878",
       "uri_deezer": "deezer://track/716819012",
       "isrc": "GBKQU1961236"
     },
@@ -3821,7 +3821,7 @@
         "it": null
       },
       "uri_youtube_music": null,
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/123982184",
       "uri_deezer": "deezer://track/810601452",
       "isrc": "GBLV61913727"
     },

--- a/custom_components/beatify/playlists/disney-classics.json
+++ b/custom_components/beatify/playlists/disney-classics.json
@@ -1,6 +1,6 @@
 {
   "name": "Disney Classics",
-  "version": "1.2",
+  "version": "1.3",
   "tags": [
     "disney",
     "movies",
@@ -58,7 +58,7 @@
         "Frozen",
         "Tangled"
       ],
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/67177683",
       "uri_deezer": "deezer://track/136349848",
       "isrc": "USWD11677855",
       "uri_apple_music_by_region": {
@@ -101,7 +101,7 @@
         "Tangled",
         "Encanto"
       ],
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/67177686",
       "uri_deezer": "deezer://track/136349854",
       "isrc": "USWD11677860",
       "uri_apple_music_by_region": {
@@ -145,7 +145,7 @@
         "Pocahontas",
         "Brother Bear"
       ],
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/67177682",
       "uri_deezer": "deezer://track/2506660671",
       "isrc": "DEUM72311526",
       "uri_apple_music_by_region": {
@@ -188,7 +188,7 @@
         "Pocahontas",
         "Brother Bear"
       ],
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/401365775",
       "uri_deezer": "deezer://track/136349850",
       "isrc": "USWD11677859",
       "uri_apple_music_by_region": {
@@ -232,7 +232,7 @@
         "The Jungle Book",
         "Tarzan"
       ],
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/112868755",
       "uri_deezer": "deezer://track/81105404",
       "isrc": "USWD10321345",
       "uri_apple_music_by_region": {
@@ -302,7 +302,7 @@
         "Beauty and the Beast",
         "Aladdin"
       ],
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/34186764",
       "uri_deezer": "deezer://track/3117869",
       "isrc": "USWD10220758",
       "uri_apple_music_by_region": {


### PR DESCRIPTION
Eine Odesli-Welle, automatisch gefahren von `com.beatify.tidal-wave`.

- `disco-funk-classics` Tidal 83 → **93**/98, version 1.9 → 1.10
- `disney-classics` Tidal 0 → **6**/69, version 1.2 → 1.3

Bilanz: 16 Treffer · 1 echte Misses · 32 Rate-Limit-Skips · 90 429-Zeilen.

**Draft mit Absicht** — Merge nur nach Markus' Freigabe.