### PR TITLE
chore(playlists): deezer backfill — +48 deezer uris

### DIFF
--- a/custom_components/beatify/playlists/community/hitster-100-en-espanol.json
+++ b/custom_components/beatify/playlists/community/hitster-100-en-espanol.json
@@ -1,6 +1,6 @@
 {
   "name": "100% en Español 🇪🇸",
-  "version": "1.11",
+  "version": "1.12",
   "tags": [
     "spanish",
     "spain",
@@ -1716,7 +1716,8 @@
         "es": "applemusic://track/1838122505",
         "nl": "applemusic://track/1838122505",
         "it": "applemusic://track/1838122505"
-      }
+      },
+      "uri_deezer": "deezer://track/63258456"
     },
     {
       "year": 1989,
@@ -1754,7 +1755,8 @@
         "es": "applemusic://track/1573213551",
         "nl": "applemusic://track/1573213551",
         "it": "applemusic://track/1573213551"
-      }
+      },
+      "uri_deezer": "deezer://track/13557588"
     },
     {
       "year": 2016,
@@ -1792,7 +1794,8 @@
         "es": "applemusic://track/1405563778",
         "nl": "applemusic://track/1405563778",
         "it": "applemusic://track/1405563778"
-      }
+      },
+      "uri_deezer": "deezer://track/465930422"
     },
     {
       "year": 2004,
@@ -1830,7 +1833,8 @@
         "es": "applemusic://track/695590633",
         "nl": "applemusic://track/1821444438",
         "it": "applemusic://track/1821444438"
-      }
+      },
+      "uri_deezer": "deezer://track/3138141"
     },
     {
       "year": 1966,
@@ -1868,7 +1872,8 @@
         "es": "applemusic://track/1268544137",
         "nl": "applemusic://track/1268544137",
         "it": "applemusic://track/1268544137"
-      }
+      },
+      "uri_deezer": "deezer://track/3090777"
     },
     {
       "year": 1978,
@@ -1906,7 +1911,8 @@
         "es": "applemusic://track/1838124095",
         "nl": "applemusic://track/1838124095",
         "it": "applemusic://track/1838124095"
-      }
+      },
+      "uri_deezer": "deezer://track/63128345"
     },
     {
       "year": 2021,
@@ -1944,7 +1950,8 @@
         "es": "applemusic://track/1710031988",
         "nl": "applemusic://track/1710031988",
         "it": "applemusic://track/1710031988"
-      }
+      },
+      "uri_deezer": "deezer://track/1331984152"
     },
     {
       "year": 1987,
@@ -1982,7 +1989,8 @@
         "es": "applemusic://track/1643712664",
         "nl": "applemusic://track/1643712664",
         "it": "applemusic://track/1643712664"
-      }
+      },
+      "uri_deezer": "deezer://track/403845192"
     },
     {
       "year": 1985,
@@ -2020,7 +2028,8 @@
         "es": "applemusic://track/106258156",
         "nl": "applemusic://track/106258156",
         "it": "applemusic://track/106258156"
-      }
+      },
+      "uri_deezer": "deezer://track/1005172"
     },
     {
       "year": 1995,
@@ -2058,7 +2067,8 @@
         "es": "applemusic://track/1537431985",
         "nl": "applemusic://track/1537431985",
         "it": "applemusic://track/1537431985"
-      }
+      },
+      "uri_deezer": "deezer://track/2437627"
     },
     {
       "year": 2008,
@@ -2096,7 +2106,8 @@
         "es": "applemusic://track/1840394612",
         "nl": "applemusic://track/1840394612",
         "it": "applemusic://track/1840394612"
-      }
+      },
+      "uri_deezer": "deezer://track/6098176"
     },
     {
       "year": 1982,
@@ -2134,7 +2145,8 @@
         "es": "applemusic://track/874164908",
         "nl": "applemusic://track/874164908",
         "it": "applemusic://track/874164908"
-      }
+      },
+      "uri_deezer": "deezer://track/3912230"
     },
     {
       "year": 1985,
@@ -2172,7 +2184,8 @@
         "es": "applemusic://track/1236796106",
         "nl": "applemusic://track/1236796106",
         "it": "applemusic://track/1236796106"
-      }
+      },
+      "uri_deezer": "deezer://track/68446549"
     },
     {
       "year": 1992,
@@ -2210,7 +2223,8 @@
         "es": "applemusic://track/1315218782",
         "nl": "applemusic://track/1315218782",
         "it": "applemusic://track/1315218782"
-      }
+      },
+      "uri_deezer": "deezer://track/2071874767"
     },
     {
       "year": 1995,
@@ -2248,7 +2262,8 @@
         "es": "applemusic://track/699670267",
         "nl": "applemusic://track/699670267",
         "it": "applemusic://track/699670267"
-      }
+      },
+      "uri_deezer": "deezer://track/3113253"
     },
     {
       "year": 2023,
@@ -2286,7 +2301,8 @@
         "es": "applemusic://track/1658144918",
         "nl": "applemusic://track/1658144918",
         "it": "applemusic://track/1658144918"
-      }
+      },
+      "uri_deezer": "deezer://track/1566422042"
     },
     {
       "year": 1986,
@@ -2324,7 +2340,8 @@
         "es": "applemusic://track/1643712675",
         "nl": "applemusic://track/1643712675",
         "it": "applemusic://track/1643712675"
-      }
+      },
+      "uri_deezer": "deezer://track/93888296"
     },
     {
       "year": 1935,
@@ -2362,7 +2379,8 @@
         "es": "applemusic://track/689435154",
         "nl": "applemusic://track/689435154",
         "it": "applemusic://track/689435154"
-      }
+      },
+      "uri_deezer": "deezer://track/13307838"
     },
     {
       "year": 1965,
@@ -2400,7 +2418,8 @@
         "es": "applemusic://track/1838218765",
         "nl": "applemusic://track/1838218765",
         "it": "applemusic://track/1838218765"
-      }
+      },
+      "uri_deezer": "deezer://track/63258570"
     },
     {
       "year": 2011,
@@ -2438,7 +2457,8 @@
         "es": "applemusic://track/486086746",
         "nl": "applemusic://track/486086746",
         "it": "applemusic://track/486086746"
-      }
+      },
+      "uri_deezer": "deezer://track/13020165"
     },
     {
       "year": 1984,
@@ -2476,7 +2496,8 @@
         "es": "applemusic://track/1838209598",
         "nl": "applemusic://track/1838209598",
         "it": "applemusic://track/1838209598"
-      }
+      },
+      "uri_deezer": "deezer://track/3540558561"
     },
     {
       "year": 2014,
@@ -2514,7 +2535,8 @@
         "es": "applemusic://track/844380593",
         "nl": "applemusic://track/844380593",
         "it": "applemusic://track/844380593"
-      }
+      },
+      "uri_deezer": "deezer://track/76295709"
     },
     {
       "year": 2014,
@@ -2552,7 +2574,8 @@
         "es": "applemusic://track/1771099307",
         "nl": "applemusic://track/1771099307",
         "it": "applemusic://track/1771099307"
-      }
+      },
+      "uri_deezer": "deezer://track/76066881"
     },
     {
       "year": 1987,
@@ -2590,7 +2613,8 @@
         "es": "applemusic://track/1807146809",
         "nl": "applemusic://track/1807146809",
         "it": "applemusic://track/1807146809"
-      }
+      },
+      "uri_deezer": "deezer://track/1021301"
     },
     {
       "year": 2003,
@@ -2628,7 +2652,8 @@
         "es": "applemusic://track/1317694740",
         "nl": "applemusic://track/1317694740",
         "it": "applemusic://track/1317694740"
-      }
+      },
+      "uri_deezer": "deezer://track/70555283"
     },
     {
       "year": 1993,
@@ -2666,7 +2691,8 @@
         "es": "applemusic://track/792605907",
         "nl": "applemusic://track/196407804",
         "it": "applemusic://track/196407804"
-      }
+      },
+      "uri_deezer": "deezer://track/565097"
     },
     {
       "year": 1996,
@@ -2704,7 +2730,8 @@
         "es": "applemusic://track/1737191374",
         "nl": "applemusic://track/1737191374",
         "it": "applemusic://track/1737191374"
-      }
+      },
+      "uri_deezer": "deezer://track/707777"
     },
     {
       "year": 2013,
@@ -2742,7 +2769,8 @@
         "es": "applemusic://track/1411538212",
         "nl": "applemusic://track/1411538212",
         "it": "applemusic://track/1411538212"
-      }
+      },
+      "uri_deezer": "deezer://track/3221029021"
     },
     {
       "year": 1980,
@@ -2780,7 +2808,8 @@
         "es": "applemusic://track/1279768387",
         "nl": "applemusic://track/1279768387",
         "it": "applemusic://track/1279768387"
-      }
+      },
+      "uri_deezer": "deezer://track/3868133"
     },
     {
       "year": 1988,
@@ -2818,7 +2847,8 @@
         "es": "applemusic://track/1449551728",
         "nl": "applemusic://track/1449551728",
         "it": "applemusic://track/1449551728"
-      }
+      },
+      "uri_deezer": "deezer://track/617765502"
     },
     {
       "year": 1970,
@@ -2856,7 +2886,8 @@
         "es": "applemusic://track/1746172959",
         "nl": "applemusic://track/1746172959",
         "it": "applemusic://track/1746172959"
-      }
+      },
+      "uri_deezer": "deezer://track/2270578"
     },
     {
       "year": 2005,
@@ -2894,7 +2925,8 @@
         "es": "applemusic://track/1519029259",
         "nl": "applemusic://track/1519029259",
         "it": "applemusic://track/1519029259"
-      }
+      },
+      "uri_deezer": "deezer://track/1000398652"
     },
     {
       "year": 1950,
@@ -2932,7 +2964,8 @@
         "es": "applemusic://track/530174656",
         "nl": "applemusic://track/530174656",
         "it": "applemusic://track/530174656"
-      }
+      },
+      "uri_deezer": "deezer://track/99701314"
     },
     {
       "year": 1989,
@@ -2970,7 +3003,8 @@
         "es": "applemusic://track/1443635392",
         "nl": "applemusic://track/1443635392",
         "it": null
-      }
+      },
+      "uri_deezer": "deezer://track/2487187"
     },
     {
       "year": 2021,
@@ -3008,7 +3042,8 @@
         "es": "applemusic://track/1658144922",
         "nl": "applemusic://track/1658144922",
         "it": "applemusic://track/1658144922"
-      }
+      },
+      "uri_deezer": "deezer://track/1507773472"
     },
     {
       "year": 2002,
@@ -3046,7 +3081,8 @@
         "es": "applemusic://track/1705322815",
         "nl": "applemusic://track/1705322815",
         "it": "applemusic://track/1705322815"
-      }
+      },
+      "uri_deezer": "deezer://track/4232762"
     },
     {
       "year": 2000,
@@ -3084,7 +3120,8 @@
         "es": "applemusic://track/276078076",
         "nl": "applemusic://track/276078076",
         "it": "applemusic://track/276078076"
-      }
+      },
+      "uri_deezer": "deezer://track/971022"
     },
     {
       "year": 2021,
@@ -3122,7 +3159,8 @@
         "es": "applemusic://track/1811167390",
         "nl": "applemusic://track/1811167390",
         "it": "applemusic://track/1811167390"
-      }
+      },
+      "uri_deezer": "deezer://track/788448742"
     },
     {
       "year": 1996,
@@ -3160,7 +3198,8 @@
         "es": "applemusic://track/1489854458",
         "nl": "applemusic://track/268499369",
         "it": "applemusic://track/268499369"
-      }
+      },
+      "uri_deezer": "deezer://track/2455309"
     },
     {
       "year": 1958,
@@ -3197,7 +3236,8 @@
         "es": "applemusic://track/437565070",
         "nl": "applemusic://track/437565070",
         "it": "applemusic://track/437565070"
-      }
+      },
+      "uri_deezer": "deezer://track/11543608"
     },
     {
       "year": 1984,
@@ -3235,7 +3275,8 @@
         "es": "applemusic://track/110722294",
         "nl": "applemusic://track/110722294",
         "it": "applemusic://track/110722294"
-      }
+      },
+      "uri_deezer": "deezer://track/3913386"
     },
     {
       "year": 1994,
@@ -3273,7 +3314,8 @@
         "es": "applemusic://track/251442538",
         "nl": "applemusic://track/251442538",
         "it": "applemusic://track/251442538"
-      }
+      },
+      "uri_deezer": "deezer://track/1357116"
     },
     {
       "year": 1988,
@@ -3311,7 +3353,8 @@
         "es": "applemusic://track/1237074598",
         "nl": "applemusic://track/1237074598",
         "it": "applemusic://track/1237074598"
-      }
+      },
+      "uri_deezer": "deezer://track/749947"
     },
     {
       "year": 1977,
@@ -3349,7 +3392,8 @@
         "es": "applemusic://track/299706392",
         "nl": "applemusic://track/299706392",
         "it": "applemusic://track/299706392"
-      }
+      },
+      "uri_deezer": "deezer://track/13144102"
     },
     {
       "year": 1985,
@@ -3387,7 +3431,8 @@
         "es": "applemusic://track/280269117",
         "nl": "applemusic://track/280269117",
         "it": "applemusic://track/280269117"
-      }
+      },
+      "uri_deezer": "deezer://track/987523"
     },
     {
       "year": 2000,
@@ -3425,7 +3470,8 @@
         "es": "applemusic://track/1805834825",
         "nl": "applemusic://track/1805834825",
         "it": "applemusic://track/1805834825"
-      }
+      },
+      "uri_deezer": "deezer://track/694579"
     },
     {
       "year": 1996,
@@ -3463,7 +3509,8 @@
         "es": "applemusic://track/1808370247",
         "nl": "applemusic://track/1808370247",
         "it": "applemusic://track/1808370247"
-      }
+      },
+      "uri_deezer": "deezer://track/3876149"
     },
     {
       "year": 2005,
@@ -3501,7 +3548,8 @@
         "es": "applemusic://track/1454366846",
         "nl": "applemusic://track/1454366846",
         "it": "applemusic://track/1454366846"
-      }
+      },
+      "uri_deezer": "deezer://track/3239831031"
     },
     {
       "year": 1996,


### PR DESCRIPTION
Ein Lauf des `provider-uri-backfill` mit Schwerpunkt Deezer, automatisch gefahren von `com.beatify.deezer-backfill`.

- `hitster-100-en-espanol` Deezer 43 -> **91**/127

**Der Lauf ist am Deckel gestoppt, nicht fertig geworden** (`reached --max-minutes 50`). Die uebrigen Tracks der Playlist sind unberuehrt und keine Katalogluecke.

**Draft mit Absicht** — Merge nur nach Markus' Freigabe. Fuer diesen Agenten gibt es bewusst KEINEN Automerge.