### PR TITLE
chore(playlists): deezer backfill — +46 deezer uris

### DIFF
--- a/custom_components/beatify/playlists/community/top100-allertijden-nederlandstalig.json
+++ b/custom_components/beatify/playlists/community/top100-allertijden-nederlandstalig.json
@@ -1,6 +1,6 @@
 {
   "name": "Top 100 Dutch Classics 🇳🇱",
-  "version": "1.15",
+  "version": "1.16",
   "tags": [
     "nederlandstalig",
     "dutch",
@@ -1653,7 +1653,8 @@
       "uri_tidal": "tidal://track/15755985",
       "fun_fact_fr": "Toen Ik Je Zag est un classique pop romantique néerlandais de 1997 qui a capturé le sentiment du coup de foudre.",
       "fun_fact_nl": "Toen Ik Je Zag is een romantische Nederlandse popklassieker uit 1997 die het gevoel van liefde op het eerste gezicht vastlegde met een eenvoudige, tijdloze melodie. Hero was een van de opvallende Nederlandse popacts van eind jaren negentig. Het nummer is een sentimentele favoriet gebleven op de Nederlandse radio.",
-      "awards_nl": []
+      "awards_nl": [],
+      "uri_deezer": "deezer://track/7588391"
     },
     {
       "year": 1966,
@@ -1800,7 +1801,8 @@
         "es": "applemusic://track/1515258396",
         "nl": "applemusic://track/1515258396",
         "it": "applemusic://track/1515258396"
-      }
+      },
+      "uri_deezer": "deezer://track/107262138"
     },
     {
       "year": 2019,
@@ -1836,7 +1838,8 @@
         "es": "applemusic://track/1463382212",
         "nl": "applemusic://track/1463382212",
         "it": "applemusic://track/1463382212"
-      }
+      },
+      "uri_deezer": "deezer://track/679070322"
     },
     {
       "year": 1977,
@@ -1873,7 +1876,8 @@
         "es": "applemusic://track/1563716072",
         "nl": "applemusic://track/488387973",
         "it": "applemusic://track/1563716072"
-      }
+      },
+      "uri_deezer": "deezer://track/436411682"
     },
     {
       "year": 1997,
@@ -1910,7 +1914,8 @@
         "es": "applemusic://track/1585392337",
         "nl": "applemusic://track/1585392337",
         "it": "applemusic://track/1585392337"
-      }
+      },
+      "uri_deezer": "deezer://track/1486887682"
     },
     {
       "year": 1995,
@@ -1947,7 +1952,8 @@
         "es": "applemusic://track/1548680688",
         "nl": "applemusic://track/1548680688",
         "it": "applemusic://track/1548680688"
-      }
+      },
+      "uri_deezer": "deezer://track/1208931962"
     },
     {
       "year": 2001,
@@ -1984,7 +1990,8 @@
         "es": "applemusic://track/698746471",
         "nl": "applemusic://track/698746471",
         "it": "applemusic://track/698746471"
-      }
+      },
+      "uri_deezer": "deezer://track/115031640"
     },
     {
       "year": 2006,
@@ -2021,7 +2028,8 @@
         "es": "applemusic://track/1303580026",
         "nl": "applemusic://track/1303580026",
         "it": "applemusic://track/1303580026"
-      }
+      },
+      "uri_deezer": "deezer://track/422529862"
     },
     {
       "year": 1995,
@@ -2058,7 +2066,8 @@
         "es": "applemusic://track/1794283425",
         "nl": "applemusic://track/1794283425",
         "it": "applemusic://track/1794283425"
-      }
+      },
+      "uri_deezer": "deezer://track/396080622"
     },
     {
       "year": 2017,
@@ -2083,7 +2092,8 @@
       "uri_tidal": "tidal://track/82158348",
       "fun_fact_fr": "Blijf Bij Mij est devenu un grand succès en 2017, montrant le côté plus doux et romantique de Ronnie Flex.",
       "fun_fact_nl": "Blijf Bij Mij werd een grote hit in 2017 en liet de zachtere, meer romantische kant van Ronnie Flex zien. Als een van de meest succesvolle Nederlandse hiphop/R&B-artiesten hielp Flex het genre naar een mainstream Nederlands publiek te brengen. Het oprechte sentiment van het nummer maakte het een van zijn meest geliefde nummers.",
-      "awards_nl": []
+      "awards_nl": [],
+      "uri_deezer": "deezer://track/438142772"
     },
     {
       "year": 2000,
@@ -2120,7 +2130,8 @@
         "es": "applemusic://track/61185070",
         "nl": "applemusic://track/61185070",
         "it": "applemusic://track/61185070"
-      }
+      },
+      "uri_deezer": "deezer://track/3758347"
     },
     {
       "year": 1997,
@@ -2155,7 +2166,8 @@
         "es": "applemusic://track/1444144379",
         "nl": "applemusic://track/1444144379",
         "it": "applemusic://track/1444144379"
-      }
+      },
+      "uri_deezer": "deezer://track/918676"
     },
     {
       "year": 1995,
@@ -2190,7 +2202,8 @@
         "es": "applemusic://track/1535250660",
         "nl": "applemusic://track/1535250660",
         "it": "applemusic://track/1535250660"
-      }
+      },
+      "uri_deezer": "deezer://track/1176661122"
     },
     {
       "year": 2002,
@@ -2227,7 +2240,8 @@
         "es": "applemusic://track/408756716",
         "nl": "applemusic://track/1790923391",
         "it": "applemusic://track/408756716"
-      }
+      },
+      "uri_deezer": "deezer://track/13250217"
     },
     {
       "year": 1991,
@@ -2264,7 +2278,8 @@
         "es": "applemusic://track/1371756545",
         "nl": "applemusic://track/1557623605",
         "it": "applemusic://track/1371756545"
-      }
+      },
+      "uri_deezer": "deezer://track/25580331"
     },
     {
       "year": 2022,
@@ -2301,7 +2316,8 @@
         "es": "applemusic://track/1612026523",
         "nl": "applemusic://track/1677174948",
         "it": "applemusic://track/1612026523"
-      }
+      },
+      "uri_deezer": "deezer://track/1669976682"
     },
     {
       "year": 1967,
@@ -2338,7 +2354,8 @@
         "es": "applemusic://track/1638372855",
         "nl": "applemusic://track/1638372855",
         "it": "applemusic://track/1638372855"
-      }
+      },
+      "uri_deezer": "deezer://track/1855006257"
     },
     {
       "year": 1998,
@@ -2375,7 +2392,8 @@
         "es": "applemusic://track/1309033441",
         "nl": "applemusic://track/1309033441",
         "it": "applemusic://track/1309033441"
-      }
+      },
+      "uri_deezer": "deezer://track/637597"
     },
     {
       "year": 2019,
@@ -2408,7 +2426,8 @@
         "es": "applemusic://track/1822754446",
         "nl": "applemusic://track/1822754446",
         "it": "applemusic://track/1822754446"
-      }
+      },
+      "uri_deezer": "deezer://track/3606701852"
     },
     {
       "year": 2003,
@@ -2445,7 +2464,8 @@
         "es": "applemusic://track/724338357",
         "nl": "applemusic://track/724338357",
         "it": "applemusic://track/724338357"
-      }
+      },
+      "uri_deezer": "deezer://track/3212428"
     },
     {
       "year": 2008,
@@ -2478,7 +2498,8 @@
         "es": "applemusic://track/1442904624",
         "nl": "applemusic://track/1444290997",
         "it": "applemusic://track/1442904624"
-      }
+      },
+      "uri_deezer": "deezer://track/7274084"
     },
     {
       "year": 2016,
@@ -2513,7 +2534,8 @@
         "es": "applemusic://track/1440899681",
         "nl": "applemusic://track/1440717999",
         "it": "applemusic://track/1440899681"
-      }
+      },
+      "uri_deezer": "deezer://track/377153411"
     },
     {
       "year": 2006,
@@ -2568,7 +2590,8 @@
         "nl": "applemusic://track/1444144375",
         "it": "applemusic://track/1444144375"
       },
-      "uri_tidal": "tidal://track/85371261"
+      "uri_tidal": "tidal://track/85371261",
+      "uri_deezer": "deezer://track/918661"
     },
     {
       "year": 2020,
@@ -2594,7 +2617,9 @@
       "fun_fact_nl": "Smoorverliefd is een van Snelle's meest vrolijke tracks, een viering van het duizelingwekkende, alles verterende gevoel van een nieuwe liefde, uitgebracht in 2020. Het werd een streaminghit en een feelgood anthem voor een generatie. Snelle's vermogen om Nederlandstalige pop fris en authentiek te laten aanvoelen, spat er vanaf.",
       "awards_nl": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=LDDy4m_TiVk",
-      "uri_tidal": "tidal://track/463294300"
+      "uri_tidal": "tidal://track/463294300",
+      "uri_apple_music": "applemusic://track/1842499184",
+      "uri_deezer": "deezer://track/3575624831"
     },
     {
       "year": 2023,
@@ -2631,7 +2656,8 @@
         "nl": "applemusic://track/1659415213",
         "it": "applemusic://track/1659415213"
       },
-      "uri_tidal": "tidal://track/266265065"
+      "uri_tidal": "tidal://track/266265065",
+      "uri_deezer": "deezer://track/2066554477"
     },
     {
       "year": 1991,
@@ -2667,7 +2693,8 @@
         "es": "applemusic://track/151364731",
         "nl": "applemusic://track/151364731",
         "it": "applemusic://track/151364731"
-      }
+      },
+      "uri_deezer": "deezer://track/25553641"
     },
     {
       "year": 1990,
@@ -2702,7 +2729,8 @@
         "es": "applemusic://track/1371915839",
         "nl": "applemusic://track/1371915839",
         "it": "applemusic://track/1371915839"
-      }
+      },
+      "uri_deezer": "deezer://track/485661192"
     },
     {
       "year": 2018,
@@ -2739,7 +2767,8 @@
         "nl": "applemusic://track/1357036661",
         "it": "applemusic://track/1357036661"
       },
-      "uri_tidal": "tidal://track/85678569"
+      "uri_tidal": "tidal://track/85678569",
+      "uri_deezer": "deezer://track/471588142"
     },
     {
       "year": 1995,
@@ -2775,7 +2804,8 @@
         "es": "applemusic://track/485881394",
         "nl": "applemusic://track/485881394",
         "it": "applemusic://track/485881394"
-      }
+      },
+      "uri_deezer": "deezer://track/25573781"
     },
     {
       "year": 1970,
@@ -2799,7 +2829,9 @@
       "fun_fact_es": "Mijn Gebed es una canción pop holandesa con influencia gospel de 1970 que mostró la poderosa voz de D.C. Lewis.",
       "fun_fact_fr": "Mijn Gebed est une chanson pop néerlandaise aux accents gospel de 1970 qui a mis en valeur la voix puissante de D.C. Lewis.",
       "fun_fact_nl": "Mijn Gebed is een gospel-achtig Nederlandstalig popliedje uit 1970 dat de krachtige, soulvolle stem van D.C. Lewis liet horen. Het nummer werd een geliefde klassieker in de Nederlandstalige pop met zijn spirituele thema van gebed en geloof. Het blijft een van de meest kenmerkende Nederlandstalige popopnames van de vroege jaren 1970.",
-      "awards_nl": []
+      "awards_nl": [],
+      "uri_apple_music": "applemusic://track/259313534",
+      "uri_deezer": "deezer://track/134543785"
     },
     {
       "year": 2020,
@@ -2834,7 +2866,8 @@
         "nl": "applemusic://track/1525342810",
         "it": "applemusic://track/1525342810"
       },
-      "uri_tidal": "tidal://track/150797412"
+      "uri_tidal": "tidal://track/150797412",
+      "uri_deezer": "deezer://track/1035446462"
     },
     {
       "year": 1971,
@@ -2869,7 +2902,8 @@
         "nl": "applemusic://track/1842921739",
         "it": "applemusic://track/1842921739"
       },
-      "uri_tidal": "tidal://track/463394988"
+      "uri_tidal": "tidal://track/463394988",
+      "uri_deezer": "deezer://track/33799671"
     },
     {
       "year": 2001,
@@ -2905,7 +2939,8 @@
         "nl": "applemusic://track/1442289020",
         "it": "applemusic://track/1442289020"
       },
-      "uri_tidal": "tidal://track/29536632"
+      "uri_tidal": "tidal://track/29536632",
+      "uri_deezer": "deezer://track/78256158"
     },
     {
       "year": 1969,
@@ -2942,7 +2977,8 @@
         "nl": "applemusic://track/315688170",
         "it": "applemusic://track/315688170"
       },
-      "uri_tidal": "tidal://track/56079927"
+      "uri_tidal": "tidal://track/56079927",
+      "uri_deezer": "deezer://track/111939438"
     },
     {
       "year": 1998,
@@ -2975,7 +3011,8 @@
         "nl": "applemusic://track/1449978485",
         "it": "applemusic://track/268228952"
       },
-      "uri_tidal": "tidal://track/14368044"
+      "uri_tidal": "tidal://track/14368044",
+      "uri_deezer": "deezer://track/637589"
     },
     {
       "year": 2021,
@@ -3001,7 +3038,9 @@
       "fun_fact_nl": "Zij Wil Mij is een zelfverzekerd, krachtig nummer van FLEMMING dat thema's als verlangen en zelfverzekerdheid verkent. Het werd uitgebracht in 2021 en liet zien dat ze in staat is om sfeervolle pop te maken met een sterk standpunt. Het nummer werd een van haar meest gevierde nummers.",
       "awards_nl": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=-mABxYPPqYc",
-      "uri_tidal": "tidal://track/211497323"
+      "uri_tidal": "tidal://track/211497323",
+      "uri_apple_music": "applemusic://track/1603656634",
+      "uri_deezer": "deezer://track/1613100472"
     },
     {
       "year": 2004,
@@ -3037,7 +3076,8 @@
         "nl": "applemusic://track/359159887",
         "it": "applemusic://track/359159887"
       },
-      "uri_tidal": "tidal://track/189932482"
+      "uri_tidal": "tidal://track/189932482",
+      "uri_deezer": "deezer://track/1419102352"
     },
     {
       "year": 2005,
@@ -3075,7 +3115,8 @@
         "nl": "applemusic://track/1442539933",
         "it": "applemusic://track/1442539933"
       },
-      "uri_tidal": "tidal://track/299388876"
+      "uri_tidal": "tidal://track/299388876",
+      "uri_deezer": "deezer://track/982834"
     },
     {
       "year": 2023,
@@ -3110,7 +3151,8 @@
         "nl": "applemusic://track/1842435015",
         "it": "applemusic://track/1842435015"
       },
-      "uri_tidal": "tidal://track/311940585"
+      "uri_tidal": "tidal://track/311940585",
+      "uri_deezer": "deezer://track/2368080695"
     },
     {
       "year": 1984,
@@ -3146,7 +3188,8 @@
         "es": "applemusic://track/145530931",
         "nl": "applemusic://track/145530931",
         "it": "applemusic://track/145530931"
-      }
+      },
+      "uri_deezer": "deezer://track/25555141"
     },
     {
       "year": 1996,
@@ -3181,7 +3224,8 @@
         "nl": "applemusic://track/1822269633",
         "it": "applemusic://track/1822269633"
       },
-      "uri_tidal": "tidal://track/444052593"
+      "uri_tidal": "tidal://track/444052593",
+      "uri_deezer": "deezer://track/3606676562"
     },
     {
       "year": 1995,
@@ -3216,7 +3260,8 @@
         "nl": "applemusic://track/1585392334",
         "it": "applemusic://track/1585392334"
       },
-      "uri_tidal": "tidal://track/196779565"
+      "uri_tidal": "tidal://track/196779565",
+      "uri_deezer": "deezer://track/1486887652"
     },
     {
       "year": 2011,
@@ -3253,7 +3298,8 @@
         "nl": "applemusic://track/1523444661",
         "it": "applemusic://track/1523444661"
       },
-      "uri_tidal": "tidal://track/53318682"
+      "uri_tidal": "tidal://track/53318682",
+      "uri_deezer": "deezer://track/118225294"
     },
     {
       "year": 2015,
@@ -3278,7 +3324,8 @@
       "awards_nl": [],
       "uri_apple_music": "applemusic://track/1444579291",
       "uri_youtube_music": "https://music.youtube.com/watch?v=4vZ_SBbeURs",
-      "uri_tidal": "tidal://track/51693783"
+      "uri_tidal": "tidal://track/51693783",
+      "uri_deezer": "deezer://track/108125620"
     },
     {
       "year": 2002,
@@ -3315,7 +3362,8 @@
         "nl": "applemusic://track/343666377",
         "it": "applemusic://track/343666377"
       },
-      "uri_tidal": "tidal://track/99095634"
+      "uri_tidal": "tidal://track/99095634",
+      "uri_deezer": "deezer://track/4778505"
     },
     {
       "year": 1965,
@@ -3352,7 +3400,8 @@
         "nl": "applemusic://track/1750745021",
         "it": "applemusic://track/1750745021"
       },
-      "uri_tidal": "tidal://track/82651145"
+      "uri_tidal": "tidal://track/82651145",
+      "uri_deezer": "deezer://track/442557842"
     },
     {
       "year": 1997,


### PR DESCRIPTION
Ein Lauf des `provider-uri-backfill` mit Schwerpunkt Deezer, automatisch gefahren von `com.beatify.deezer-backfill`.

- `top100-allertijden-nederlandstalig` Deezer 46 -> **92**/104

Nebenbei mitgefuellt, weil Odesli alle Provider in einer Antwort liefert: apple +3.

**Der Lauf ist am Deckel gestoppt, nicht fertig geworden** (`reached --max-minutes 50`). Die uebrigen Tracks der Playlist sind unberuehrt und keine Katalogluecke.

**Draft mit Absicht** — Merge nur nach Markus' Freigabe. Fuer diesen Agenten gibt es bewusst KEINEN Automerge.