### PR TITLE
chore(playlists): deezer backfill — +48 deezer uris

### DIFF
--- a/custom_components/beatify/playlists/community/greatest-metal-songs.json
+++ b/custom_components/beatify/playlists/community/greatest-metal-songs.json
@@ -1,6 +1,6 @@
 {
   "name": "Greatest Metal Songs of All Time 🤘",
-  "version": "1.12",
+  "version": "1.13",
   "tags": [
     "metal",
     "rock",
@@ -536,7 +536,8 @@
         "es": null,
         "nl": null,
         "it": null
-      }
+      },
+      "uri_deezer": "deezer://track/136332702"
     },
     {
       "year": 1990,
@@ -579,7 +580,8 @@
         "es": "applemusic://track/724649275",
         "nl": "applemusic://track/724649275",
         "it": "applemusic://track/724649275"
-      }
+      },
+      "uri_deezer": "deezer://track/3339544"
     },
     {
       "year": 1990,
@@ -622,7 +624,8 @@
         "es": "applemusic://track/6762964575",
         "nl": "applemusic://track/6762964575",
         "it": "applemusic://track/6762964575"
-      }
+      },
+      "uri_deezer": "deezer://track/3089034"
     },
     {
       "year": 1984,
@@ -665,7 +668,8 @@
         "es": null,
         "nl": null,
         "it": null
-      }
+      },
+      "uri_deezer": "deezer://track/1122938"
     },
     {
       "year": 1980,
@@ -708,7 +712,8 @@
         "es": "applemusic://track/1626431301",
         "nl": "applemusic://track/1626431301",
         "it": "applemusic://track/1626431301"
-      }
+      },
+      "uri_deezer": "deezer://track/1078203362"
     },
     {
       "year": 2001,
@@ -751,7 +756,8 @@
         "es": "applemusic://track/438938124",
         "nl": "applemusic://track/438938124",
         "it": "applemusic://track/438938124"
-      }
+      },
+      "uri_deezer": "deezer://track/859699"
     },
     {
       "year": 2001,
@@ -794,7 +800,8 @@
         "es": "applemusic://track/273714713",
         "nl": "applemusic://track/273714713",
         "it": "applemusic://track/273714713"
-      }
+      },
+      "uri_deezer": "deezer://track/15523793"
     },
     {
       "year": 1997,
@@ -837,7 +844,8 @@
         "es": "applemusic://track/1474185654",
         "nl": "applemusic://track/1474185654",
         "it": "applemusic://track/1474185654"
-      }
+      },
+      "uri_deezer": "deezer://track/722078532"
     },
     {
       "year": 2000,
@@ -880,7 +888,8 @@
         "es": "applemusic://track/1537631475",
         "nl": "applemusic://track/1537631475",
         "it": "applemusic://track/1537631475"
-      }
+      },
+      "uri_deezer": "deezer://track/846705"
     },
     {
       "year": 1994,
@@ -923,7 +932,8 @@
         "es": "applemusic://track/1442404059",
         "nl": "applemusic://track/1442404059",
         "it": "applemusic://track/1442404059"
-      }
+      },
+      "uri_deezer": "deezer://track/78631539"
     },
     {
       "year": 1992,
@@ -966,7 +976,8 @@
         "es": "applemusic://track/261763500",
         "nl": "applemusic://track/261763500",
         "it": "applemusic://track/261763500"
-      }
+      },
+      "uri_deezer": "deezer://track/15178364"
     },
     {
       "year": 1987,
@@ -1009,7 +1020,8 @@
         "es": "applemusic://track/1377826728",
         "nl": "applemusic://track/1377826728",
         "it": "applemusic://track/1377826728"
-      }
+      },
+      "uri_deezer": "deezer://track/518458092"
     },
     {
       "year": 1987,
@@ -1052,7 +1064,8 @@
         "es": "applemusic://track/1377813701",
         "nl": "applemusic://track/1377813701",
         "it": "applemusic://track/1377813701"
-      }
+      },
+      "uri_deezer": "deezer://track/518458172"
     },
     {
       "year": 1979,
@@ -1095,7 +1108,8 @@
         "es": "applemusic://track/574044008",
         "nl": "applemusic://track/574044008",
         "it": "applemusic://track/574044008"
-      }
+      },
+      "uri_deezer": "deezer://track/92719900"
     },
     {
       "year": 1980,
@@ -1138,7 +1152,8 @@
         "es": "applemusic://track/576003082",
         "nl": "applemusic://track/576003082",
         "it": "applemusic://track/576003082"
-      }
+      },
+      "uri_deezer": "deezer://track/92720046"
     },
     {
       "year": 1972,
@@ -1181,7 +1196,8 @@
         "es": null,
         "nl": null,
         "it": null
-      }
+      },
+      "uri_deezer": "deezer://track/60840057"
     },
     {
       "year": 1987,
@@ -1224,7 +1240,8 @@
         "es": "applemusic://track/1568022079",
         "nl": "applemusic://track/1440907033",
         "it": "applemusic://track/1440907033"
-      }
+      },
+      "uri_deezer": "deezer://track/447552822"
     },
     {
       "year": 1984,
@@ -1267,7 +1284,8 @@
         "es": "applemusic://track/977495501",
         "nl": "applemusic://track/977495501",
         "it": "applemusic://track/977495501"
-      }
+      },
+      "uri_deezer": "deezer://track/97098410"
     },
     {
       "year": 1990,
@@ -1310,7 +1328,8 @@
         "es": "applemusic://track/1737564412",
         "nl": "applemusic://track/1737564412",
         "it": "applemusic://track/1737564412"
-      }
+      },
+      "uri_deezer": "deezer://track/62082829"
     },
     {
       "year": 1998,
@@ -1353,7 +1372,8 @@
         "es": "applemusic://track/1704192336",
         "nl": "applemusic://track/1704192336",
         "it": "applemusic://track/1704192336"
-      }
+      },
+      "uri_deezer": "deezer://track/1151624"
     },
     {
       "year": 1994,
@@ -1396,7 +1416,8 @@
         "es": "applemusic://track/1831584743",
         "nl": "applemusic://track/1831584743",
         "it": "applemusic://track/1831584743"
-      }
+      },
+      "uri_deezer": "deezer://track/3172570731"
     },
     {
       "year": 1999,
@@ -1439,7 +1460,8 @@
         "es": "applemusic://track/927736489",
         "nl": "applemusic://track/927736489",
         "it": "applemusic://track/927736489"
-      }
+      },
+      "uri_deezer": "deezer://track/4197811"
     },
     {
       "year": 2001,
@@ -1482,7 +1504,8 @@
         "es": "applemusic://track/927744252",
         "nl": "applemusic://track/927744252",
         "it": "applemusic://track/927744252"
-      }
+      },
+      "uri_deezer": "deezer://track/3819908"
     },
     {
       "year": 2000,
@@ -1525,7 +1548,8 @@
         "es": "applemusic://track/1030601027",
         "nl": "applemusic://track/1030601027",
         "it": "applemusic://track/1030601027"
-      }
+      },
+      "uri_deezer": "deezer://track/663984"
     },
     {
       "year": 2003,
@@ -1568,7 +1592,8 @@
         "es": "applemusic://track/6777217538",
         "nl": "applemusic://track/6777217538",
         "it": "applemusic://track/6777217538"
-      }
+      },
+      "uri_deezer": "deezer://track/2585571202"
     },
     {
       "year": 2004,
@@ -1611,7 +1636,8 @@
         "es": "applemusic://track/65922935",
         "nl": "applemusic://track/65922935",
         "it": "applemusic://track/65922935"
-      }
+      },
+      "uri_deezer": "deezer://track/10969975"
     },
     {
       "year": 2001,
@@ -1654,7 +1680,8 @@
         "es": "applemusic://track/213374170",
         "nl": "applemusic://track/213374170",
         "it": "applemusic://track/213374170"
-      }
+      },
+      "uri_deezer": "deezer://track/288567"
     },
     {
       "year": 2016,
@@ -1697,7 +1724,8 @@
         "es": "applemusic://track/1104432802",
         "nl": "applemusic://track/1104432802",
         "it": "applemusic://track/1104432802"
-      }
+      },
+      "uri_deezer": "deezer://track/126338363"
     },
     {
       "year": 1995,
@@ -1740,7 +1768,8 @@
         "es": "applemusic://track/1823629743",
         "nl": "applemusic://track/1823629743",
         "it": "applemusic://track/1823629743"
-      }
+      },
+      "uri_deezer": "deezer://track/717542"
     },
     {
       "year": 2011,
@@ -1783,7 +1812,8 @@
         "es": "applemusic://track/1650255958",
         "nl": "applemusic://track/1650255958",
         "it": "applemusic://track/1650255958"
-      }
+      },
+      "uri_deezer": "deezer://track/471584512"
     },
     {
       "year": 2019,
@@ -1826,7 +1856,8 @@
         "es": "applemusic://track/1475686698",
         "nl": "applemusic://track/1475686698",
         "it": "applemusic://track/1475686698"
-      }
+      },
+      "uri_deezer": "deezer://track/740969212"
     },
     {
       "year": 1985,
@@ -1869,7 +1900,8 @@
         "es": "applemusic://track/1452532988",
         "nl": "applemusic://track/1452532988",
         "it": "applemusic://track/1452532988"
-      }
+      },
+      "uri_deezer": "deezer://track/5169799"
     },
     {
       "year": 1997,
@@ -1912,7 +1944,8 @@
         "es": "applemusic://track/1882049242",
         "nl": "applemusic://track/1882049242",
         "it": "applemusic://track/1882049242"
-      }
+      },
+      "uri_deezer": "deezer://track/3879020791"
     },
     {
       "year": 1992,
@@ -1955,7 +1988,8 @@
         "es": "applemusic://track/518549047",
         "nl": "applemusic://track/518549047",
         "it": "applemusic://track/518549047"
-      }
+      },
+      "uri_deezer": "deezer://track/26205571"
     },
     {
       "year": 2001,
@@ -1998,7 +2032,8 @@
         "es": "applemusic://track/591534783",
         "nl": "applemusic://track/591534783",
         "it": "applemusic://track/591534783"
-      }
+      },
+      "uri_deezer": "deezer://track/676183"
     },
     {
       "year": 2003,
@@ -2041,7 +2076,8 @@
         "es": "applemusic://track/1585370207",
         "nl": "applemusic://track/1585370207",
         "it": "applemusic://track/1585370207"
-      }
+      },
+      "uri_deezer": "deezer://track/827686"
     },
     {
       "year": 2006,
@@ -2084,7 +2120,8 @@
         "es": "applemusic://track/702469381",
         "nl": "applemusic://track/702469381",
         "it": "applemusic://track/702469381"
-      }
+      },
+      "uri_deezer": "deezer://track/71060593"
     },
     {
       "year": 2014,
@@ -2127,7 +2164,8 @@
         "es": "applemusic://track/922147642",
         "nl": "applemusic://track/922147642",
         "it": "applemusic://track/922147642"
-      }
+      },
+      "uri_deezer": "deezer://track/378385141"
     },
     {
       "year": 2010,
@@ -2170,7 +2208,8 @@
         "es": "applemusic://track/1485045876",
         "nl": "applemusic://track/1485045876",
         "it": "applemusic://track/1485045876"
-      }
+      },
+      "uri_deezer": "deezer://track/378360851"
     },
     {
       "year": 2012,
@@ -2213,7 +2252,8 @@
         "es": "applemusic://track/1485075528",
         "nl": "applemusic://track/1485075528",
         "it": "applemusic://track/1485075528"
-      }
+      },
+      "uri_deezer": "deezer://track/378388361"
     },
     {
       "year": 2020,
@@ -2256,7 +2296,8 @@
         "es": "applemusic://track/1493581631",
         "nl": "applemusic://track/1493581631",
         "it": "applemusic://track/1493581631"
-      }
+      },
+      "uri_deezer": "deezer://track/847861252"
     },
     {
       "year": 1990,
@@ -2293,7 +2334,8 @@
         "es": "applemusic://track/207178166",
         "nl": "applemusic://track/207178166",
         "it": "applemusic://track/207178166"
-      }
+      },
+      "uri_deezer": "deezer://track/864761"
     },
     {
       "year": 1980,
@@ -2330,7 +2372,8 @@
         "es": "applemusic://track/466738322",
         "nl": "applemusic://track/466738322",
         "it": "applemusic://track/466738322"
-      }
+      },
+      "uri_deezer": "deezer://track/557625"
     },
     {
       "year": 1986,
@@ -2367,7 +2410,8 @@
         "es": "applemusic://track/1733769074",
         "nl": "applemusic://track/1733769074",
         "it": "applemusic://track/1733769074"
-      }
+      },
+      "uri_deezer": "deezer://track/65690440"
     },
     {
       "year": 1990,
@@ -2404,7 +2448,8 @@
         "es": "applemusic://track/1568092372",
         "nl": "applemusic://track/1568092372",
         "it": "applemusic://track/1568092372"
-      }
+      },
+      "uri_deezer": "deezer://track/714420"
     },
     {
       "year": 1990,
@@ -2441,7 +2486,8 @@
         "es": "applemusic://track/719004159",
         "nl": "applemusic://track/719004159",
         "it": "applemusic://track/719004159"
-      }
+      },
+      "uri_deezer": "deezer://track/3089049"
     },
     {
       "year": 1976,
@@ -2478,7 +2524,8 @@
         "es": "applemusic://track/1445099013",
         "nl": "applemusic://track/1445099013",
         "it": "applemusic://track/1445099013"
-      }
+      },
+      "uri_deezer": "deezer://track/1161568"
     },
     {
       "year": 1991,
@@ -2517,7 +2564,8 @@
         "es": "applemusic://track/1571969050",
         "nl": "applemusic://track/1571969050",
         "it": "applemusic://track/1571969050"
-      }
+      },
+      "uri_deezer": "deezer://track/1483825282"
     },
     {
       "year": 1988,


### PR DESCRIPTION
Ein Lauf des `provider-uri-backfill` mit Schwerpunkt Deezer, automatisch gefahren von `com.beatify.deezer-backfill`.

- `greatest-metal-songs` Deezer 11 -> **59**/61

**Der Lauf ist am Deckel gestoppt, nicht fertig geworden** (`reached --max-minutes 50`). Die uebrigen Tracks der Playlist sind unberuehrt und keine Katalogluecke.

**Draft mit Absicht** — Merge nur nach Markus' Freigabe. Fuer diesen Agenten gibt es bewusst KEINEN Automerge.