### PR TITLE
data(harder-styles): the Apple URI for Zatox – Hard Bass (Ran-D Remix)

### DIFF
--- a/custom_components/beatify/playlists/community/harder-styles.json
+++ b/custom_components/beatify/playlists/community/harder-styles.json
@@ -1,6 +1,6 @@
 {
   "name": "Harder Styles",
-  "version": "1.22",
+  "version": "1.23",
   "tags": [
     "hardstyle",
     "hardcore",
@@ -3422,10 +3422,10 @@
       "year": 2014,
       "isrc": "NLS241401025",
       "uri": "spotify:track:2QFR0InGwGPZY1wPCrpb6a",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/1459524332",
       "uri_apple_music_by_region": {
         "us": null,
-        "de": null,
+        "de": "applemusic://track/1459524332",
         "gb": null,
         "fr": null,
         "es": null,


### PR DESCRIPTION
Closes #2030 for the concrete track — and the answer is that the gate was right.

## Decided by duration, not by loosening a rule

Apple carries two candidates:

| Track ID | Title | Length | Album |
|---|---|---|---|
| `1459524332` | Hard Bass (Ran D-Remix Edit) | **207.6 s** | HardBase.FM Vol. 11 |
| `1842465524` | Hard Bass **[Mixed]** (Ran-D Remix) | 195.2 s | Hardstyle The Ultimate Collection |

Our reference (`spotify:track:2QFR0InGwGPZY1wPCrpb6a`) runs **207.553 s**. The first matches to within **0.05 s** — same recording. The `[Mixed]` entry the gate rejected is **12.4 s shorter**: the continuous-mix compilation edit, a different recording.

**So `mixed` must not go into `_NEUTRAL_SUFFIX_RE`.** Had it been added, this track would have taken the wrong URI, and a player would have heard a truncated, beat-matched edit mid-game. That is exactly the failure #2030 was written to avoid — and it is now measured rather than assumed.

## Region map

The correct track is available in **DE only** — `us`, `gb`, `fr`, `es`, `nl` and `it` all return no result on lookup. The map carries the single storefront that has it, the rest stay `null`.

## Two notes for the wider issue

- Even with a 0.05 s duration match, this track would **also** have failed the year check: we store `2014`, Apple's release is `2019-04-12` — five years past the ±1 tolerance. The overnight probe shows the year check is the dominant rejection reason overall (53 of the first 98 rejections), so #2030 stays open for that half.
- The duration comparison proposed in the issue works as a discriminator. Whether it is worth wiring into the gate depends on how often the `[Mixed]` case actually occurs — after 458 of 730 tracks it has occurred exactly once.

Schema gate passes; playlist `version` 1.22 → 1.23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)