### PR TITLE
chore(playlists): deezer backfill — +44 deezer uris

### DIFF
--- a/custom_components/beatify/playlists/top-songs-der-60er.json
+++ b/custom_components/beatify/playlists/top-songs-der-60er.json
@@ -1,6 +1,6 @@
 {
   "name": "60s Classics 🎸",
-  "version": "1.7",
+  "version": "1.8",
   "source": "https://open.spotify.com/playlist/6rtsNFUv2UK3j78PRVMpSd",
   "tags": [
     "1960s",
@@ -46,7 +46,8 @@
         "es": "applemusic://track/1443134674",
         "nl": "applemusic://track/1443134674",
         "it": "applemusic://track/1443134674"
-      }
+      },
+      "uri_deezer": "deezer://track/3102931"
     },
     {
       "year": 1966,
@@ -85,7 +86,8 @@
         "es": "applemusic://track/1442865074",
         "nl": "applemusic://track/1442865074",
         "it": "applemusic://track/1442865074"
-      }
+      },
+      "uri_deezer": "deezer://track/3091992"
     },
     {
       "year": 1966,
@@ -124,7 +126,8 @@
         "es": "applemusic://track/1373179773",
         "nl": "applemusic://track/1373179773",
         "it": "applemusic://track/1373179773"
-      }
+      },
+      "uri_deezer": "deezer://track/13549172"
     },
     {
       "year": 1961,
@@ -163,7 +166,8 @@
         "es": "applemusic://track/1815497962",
         "nl": "applemusic://track/1815497962",
         "it": "applemusic://track/1815497962"
-      }
+      },
+      "uri_deezer": "deezer://track/73267973"
     },
     {
       "year": 1967,
@@ -202,7 +206,8 @@
         "es": "applemusic://track/1625648637",
         "nl": "applemusic://track/1625648637",
         "it": "applemusic://track/1625648637"
-      }
+      },
+      "uri_deezer": "deezer://track/5093933"
     },
     {
       "year": 1967,
@@ -241,7 +246,8 @@
         "es": "applemusic://track/1192962303",
         "nl": "applemusic://track/1192962303",
         "it": "applemusic://track/1192962303"
-      }
+      },
+      "uri_deezer": "deezer://track/3614129"
     },
     {
       "year": 1967,
@@ -278,7 +284,8 @@
         "es": "applemusic://track/640047587",
         "nl": "applemusic://track/640047587",
         "it": "applemusic://track/640047587"
-      }
+      },
+      "uri_deezer": "deezer://track/709951042"
     },
     {
       "year": 1963,
@@ -315,7 +322,8 @@
         "es": "applemusic://track/1308624096",
         "nl": "applemusic://track/1308624096",
         "it": "applemusic://track/1308624096"
-      }
+      },
+      "uri_deezer": "deezer://track/71581474"
     },
     {
       "year": 1964,
@@ -352,7 +360,8 @@
         "es": null,
         "nl": null,
         "it": null
-      }
+      },
+      "uri_deezer": "deezer://track/3155135"
     },
     {
       "year": 1966,
@@ -391,7 +400,8 @@
         "es": "applemusic://track/1576574977",
         "nl": "applemusic://track/1576574977",
         "it": "applemusic://track/1576574977"
-      }
+      },
+      "uri_deezer": "deezer://track/1434159652"
     },
     {
       "year": 1967,
@@ -428,7 +438,8 @@
         "es": "applemusic://track/1469579797",
         "nl": "applemusic://track/1469579797",
         "it": "applemusic://track/1469579797"
-      }
+      },
+      "uri_deezer": "deezer://track/1524486232"
     },
     {
       "year": 1971,
@@ -471,7 +482,8 @@
         "es": "applemusic://track/1308611756",
         "nl": "applemusic://track/1308611756",
         "it": "applemusic://track/1308611756"
-      }
+      },
+      "uri_deezer": "deezer://track/2312047"
     },
     {
       "year": 1964,
@@ -514,7 +526,8 @@
         "es": "applemusic://track/1676474357",
         "nl": "applemusic://track/1676474357",
         "it": "applemusic://track/1676474357"
-      }
+      },
+      "uri_deezer": "deezer://track/431577362"
     },
     {
       "year": 1968,
@@ -553,7 +566,8 @@
         "es": "applemusic://track/6763242221",
         "nl": "applemusic://track/6763242221",
         "it": "applemusic://track/6763242221"
-      }
+      },
+      "uri_deezer": "deezer://track/540202122"
     },
     {
       "year": 1965,
@@ -590,7 +604,8 @@
         "es": "applemusic://track/1443341633",
         "nl": "applemusic://track/1443341633",
         "it": "applemusic://track/1443341633"
-      }
+      },
+      "uri_deezer": "deezer://track/1137255"
     },
     {
       "year": 1969,
@@ -631,7 +646,8 @@
         "es": "applemusic://track/1486377720",
         "nl": "applemusic://track/1486377720",
         "it": "applemusic://track/1486377720"
-      }
+      },
+      "uri_deezer": "deezer://track/802719212"
     },
     {
       "year": 1964,
@@ -670,7 +686,8 @@
         "es": "applemusic://track/1463665119",
         "nl": "applemusic://track/1463665119",
         "it": "applemusic://track/1463665119"
-      }
+      },
+      "uri_deezer": "deezer://track/2468570"
     },
     {
       "year": 1969,
@@ -707,7 +724,8 @@
         "es": "applemusic://track/1713156666",
         "nl": "applemusic://track/1713156666",
         "it": "applemusic://track/1713156666"
-      }
+      },
+      "uri_deezer": "deezer://track/116348464"
     },
     {
       "year": 1967,
@@ -744,7 +762,8 @@
         "es": "applemusic://track/79087150",
         "nl": "applemusic://track/79087150",
         "it": "applemusic://track/79087150"
-      }
+      },
+      "uri_deezer": "deezer://track/2043943"
     },
     {
       "year": 1970,
@@ -781,7 +800,8 @@
         "es": "applemusic://track/1463658941",
         "nl": "applemusic://track/1463658941",
         "it": "applemusic://track/1463658941"
-      }
+      },
+      "uri_deezer": "deezer://track/13174766"
     },
     {
       "year": 1968,
@@ -824,7 +844,8 @@
         "es": "applemusic://track/1463665385",
         "nl": "applemusic://track/1463665385",
         "it": "applemusic://track/1463665385"
-      }
+      },
+      "uri_deezer": "deezer://track/618610"
     },
     {
       "year": 1965,
@@ -863,7 +884,8 @@
         "es": "applemusic://track/1706561182",
         "nl": "applemusic://track/1706561182",
         "it": "applemusic://track/1706561182"
-      }
+      },
+      "uri_deezer": "deezer://track/7677778"
     },
     {
       "year": 1965,
@@ -902,7 +924,8 @@
         "es": "applemusic://track/1821337433",
         "nl": "applemusic://track/1821337433",
         "it": "applemusic://track/1821337433"
-      }
+      },
+      "uri_deezer": "deezer://track/2321278"
     },
     {
       "year": 1967,
@@ -941,7 +964,8 @@
         "es": "applemusic://track/348894696",
         "nl": "applemusic://track/348894696",
         "it": "applemusic://track/348894696"
-      }
+      },
+      "uri_deezer": "deezer://track/625869"
     },
     {
       "year": 1971,
@@ -980,7 +1004,8 @@
         "es": "applemusic://track/1886242473",
         "nl": "applemusic://track/1886242473",
         "it": "applemusic://track/1886242473"
-      }
+      },
+      "uri_deezer": "deezer://track/3166505"
     },
     {
       "year": 1964,
@@ -1019,7 +1044,8 @@
         "es": "applemusic://track/1441164417",
         "nl": "applemusic://track/1441164417",
         "it": "applemusic://track/1441164417"
-      }
+      },
+      "uri_deezer": "deezer://track/116348154"
     },
     {
       "year": 1965,
@@ -1058,7 +1084,8 @@
         "es": "applemusic://track/1441164536",
         "nl": "applemusic://track/1441164536",
         "it": "applemusic://track/1441164536"
-      }
+      },
+      "uri_deezer": "deezer://track/116348166"
     },
     {
       "year": 1965,
@@ -1095,7 +1122,8 @@
         "es": "applemusic://track/1441133496",
         "nl": "applemusic://track/1441133496",
         "it": "applemusic://track/1441133496"
-      }
+      },
+      "uri_deezer": "deezer://track/116348164"
     },
     {
       "year": 1967,
@@ -1132,7 +1160,8 @@
         "es": "applemusic://track/1441163777",
         "nl": "applemusic://track/1441163777",
         "it": "applemusic://track/1441163777"
-      }
+      },
+      "uri_deezer": "deezer://track/116348086"
     },
     {
       "year": 1967,
@@ -1171,7 +1200,8 @@
         "es": "applemusic://track/1441133271",
         "nl": "applemusic://track/1441133271",
         "it": "applemusic://track/1441133271"
-      }
+      },
+      "uri_deezer": "deezer://track/116348096"
     },
     {
       "year": 1968,
@@ -1208,7 +1238,8 @@
         "es": "applemusic://track/1441133276",
         "nl": "applemusic://track/1441133276",
         "it": "applemusic://track/1441133276"
-      }
+      },
+      "uri_deezer": "deezer://track/116348106"
     },
     {
       "year": 1968,
@@ -1247,7 +1278,8 @@
         "es": "applemusic://track/1856287169",
         "nl": "applemusic://track/1856287169",
         "it": "applemusic://track/1856287169"
-      }
+      },
+      "uri_deezer": "deezer://track/116348632"
     },
     {
       "year": 1966,
@@ -1284,7 +1316,8 @@
         "es": "applemusic://track/1463652959",
         "nl": "applemusic://track/1463652959",
         "it": "applemusic://track/1463652959"
-      }
+      },
+      "uri_deezer": "deezer://track/71958646"
     },
     {
       "year": 1969,
@@ -1321,7 +1354,8 @@
         "es": "applemusic://track/1568036799",
         "nl": "applemusic://track/1839414248",
         "it": "applemusic://track/1839414248"
-      }
+      },
+      "uri_deezer": "deezer://track/2813004"
     },
     {
       "year": 1969,
@@ -1358,7 +1392,8 @@
         "es": "applemusic://track/1806381586",
         "nl": "applemusic://track/1806381586",
         "it": "applemusic://track/1806381586"
-      }
+      },
+      "uri_deezer": "deezer://track/5250666"
     },
     {
       "year": 1965,
@@ -1384,7 +1419,8 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=MgJ9K7cPRKk",
       "uri_tidal": "tidal://track/77557764",
       "fun_fact_nl": "Roger Daltrey's stotterende zangstijl was Pete Townshend's poging om een pillen slikkende mod na te bootsen. De BBC verbood het aanvankelijk, omdat ze dachten dat het de spot dreef met mensen met een spraakgebrek.",
-      "awards_nl": []
+      "awards_nl": [],
+      "uri_deezer": "deezer://track/136341550"
     },
     {
       "year": 1967,
@@ -1423,7 +1459,8 @@
         "es": "applemusic://track/1688024397",
         "nl": "applemusic://track/1688024397",
         "it": "applemusic://track/1688024397"
-      }
+      },
+      "uri_deezer": "deezer://track/427230152"
     },
     {
       "year": 1967,
@@ -1460,7 +1497,8 @@
         "es": "applemusic://track/1535485171",
         "nl": "applemusic://track/1535485171",
         "it": "applemusic://track/1535485171"
-      }
+      },
+      "uri_deezer": "deezer://track/3586842"
     },
     {
       "year": 1966,
@@ -1497,7 +1535,8 @@
         "es": "applemusic://track/192480540",
         "nl": "applemusic://track/192480540",
         "it": "applemusic://track/192480540"
-      }
+      },
+      "uri_deezer": "deezer://track/2468578"
     },
     {
       "year": 1965,
@@ -1534,7 +1573,8 @@
         "es": "applemusic://track/1441164546",
         "nl": "applemusic://track/1441164546",
         "it": "applemusic://track/1441164546"
-      }
+      },
+      "uri_deezer": "deezer://track/116348168"
     },
     {
       "year": 1966,
@@ -1571,7 +1611,8 @@
         "es": "applemusic://track/1440508809",
         "nl": "applemusic://track/1440508809",
         "it": "applemusic://track/1440508809"
-      }
+      },
+      "uri_deezer": "deezer://track/3803445662"
     },
     {
       "year": 1968,
@@ -1608,7 +1649,8 @@
         "es": "applemusic://track/1439066304",
         "nl": "applemusic://track/1439066304",
         "it": "applemusic://track/1439066304"
-      }
+      },
+      "uri_deezer": "deezer://track/62811114"
     },
     {
       "year": 1966,
@@ -1647,7 +1689,8 @@
         "es": "applemusic://track/1440745782",
         "nl": "applemusic://track/1440745782",
         "it": "applemusic://track/1440745782"
-      }
+      },
+      "uri_deezer": "deezer://track/7818900"
     },
     {
       "year": 1968,
@@ -1684,7 +1727,8 @@
         "es": "applemusic://track/1833249921",
         "nl": "applemusic://track/1833249921",
         "it": "applemusic://track/1833249921"
-      }
+      },
+      "uri_deezer": "deezer://track/3977776"
     },
     {
       "artist": "Small Faces",


### PR DESCRIPTION
Ein Lauf des `provider-uri-backfill` mit Schwerpunkt Deezer, automatisch gefahren von `com.beatify.deezer-backfill`.

- `top-songs-der-60er` Deezer 22 -> **66**/66

**Der Lauf ist am Deckel gestoppt, nicht fertig geworden** (`reached --max-minutes 50`). Die uebrigen Tracks der Playlist sind unberuehrt und keine Katalogluecke.

**Draft mit Absicht** — Merge nur nach Markus' Freigabe. Fuer diesen Agenten gibt es bewusst KEINEN Automerge.