### PR TITLE
chore(playlists): tidal backfill wave — +35 uris

### DIFF
--- a/custom_components/beatify/playlists/disney-classics.json
+++ b/custom_components/beatify/playlists/disney-classics.json
@@ -1,6 +1,6 @@
 {
   "name": "Disney Classics",
-  "version": "1.6",
+  "version": "1.7",
   "tags": [
     "disney",
     "movies",
@@ -2901,7 +2901,7 @@
         "Atlantis: The Lost Empire",
         "Brother Bear"
       ],
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/36735626",
       "uri_deezer": "deezer://track/1762551507",
       "isrc": "USWD10220511",
       "uri_apple_music_by_region": {
@@ -2944,7 +2944,7 @@
         "The Aristocats",
         "Robin Hood"
       ],
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/59075006",
       "uri_deezer": "deezer://track/122886568",
       "isrc": "USWD11676132",
       "uri_apple_music_by_region": {
@@ -3002,7 +3002,7 @@
         "Snow White and the Seven Dwarfs",
         "Cinderella"
       ],
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/37081267",
       "uri_deezer": "deezer://track/3145964",
       "isrc": "USWD10220003",
       "uri_apple_music_by_region": {
@@ -3055,7 +3055,7 @@
         "Bedknobs and Broomsticks",
         "Chitty Chitty Bang Bang"
       ],
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/34186721",
       "uri_deezer": "deezer://track/3118718",
       "isrc": "USWD10320942",
       "uri_apple_music_by_region": {
@@ -3097,7 +3097,7 @@
         "Bedknobs and Broomsticks",
         "Cinderella"
       ],
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/34186718",
       "uri_deezer": "deezer://track/677778572",
       "isrc": "USWD10220406",
       "uri_apple_music_by_region": {
@@ -3154,7 +3154,7 @@
         "Bedknobs and Broomsticks",
         "Chitty Chitty Bang Bang"
       ],
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/34186727",
       "uri_deezer": "deezer://track/462639092",
       "isrc": "FR10S1851773",
       "uri_apple_music_by_region": {
@@ -3197,7 +3197,7 @@
         "Pocahontas",
         "Beauty and the Beast"
       ],
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/47941008",
       "uri_deezer": "deezer://track/3867512211",
       "isrc": "GX8KD2412728",
       "uri_apple_music_by_region": {
@@ -3239,7 +3239,7 @@
         "Pinocchio",
         "Cinderella"
       ],
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/91948711",
       "uri_deezer": "deezer://track/3203549",
       "isrc": "USWD10321898",
       "uri_apple_music_by_region": {
@@ -3282,7 +3282,7 @@
         "The Aristocats",
         "Lady and the Tramp"
       ],
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/37081149",
       "uri_deezer": "deezer://track/119928454",
       "isrc": "USWD10220295",
       "uri_apple_music_by_region": {
@@ -3325,7 +3325,7 @@
         "The Jungle Book",
         "101 Dalmatians"
       ],
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/2502280",
       "uri_deezer": "deezer://track/134519754",
       "isrc": "FRUM71601092",
       "uri_apple_music_by_region": {
@@ -3369,7 +3369,7 @@
         "Pinocchio",
         "Cinderella"
       ],
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/109095717",
       "uri_deezer": "deezer://track/106122128",
       "isrc": "BEDO61509811",
       "uri_apple_music_by_region": {
@@ -3410,7 +3410,7 @@
         "Tarzan",
         "The Lion King"
       ],
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/37080358",
       "uri_deezer": "deezer://track/3191609",
       "isrc": "USWD10322458",
       "uri_apple_music_by_region": {

--- a/custom_components/beatify/playlists/eurovision-winners.json
+++ b/custom_components/beatify/playlists/eurovision-winners.json
@@ -1,6 +1,6 @@
 {
   "name": "Eurovision Winners (1956-2025)",
-  "version": "1.9",
+  "version": "1.10",
   "tags": [
     "eurovision",
     "contest",
@@ -104,7 +104,8 @@
         "es": "applemusic://track/1739553677",
         "nl": "applemusic://track/1739553677",
         "it": "applemusic://track/1739553677"
-      }
+      },
+      "uri_tidal": "tidal://track/18237627"
     },
     {
       "year": 1958,
@@ -153,7 +154,8 @@
         "es": "applemusic://track/794472283",
         "nl": "applemusic://track/794472283",
         "it": "applemusic://track/794472283"
-      }
+      },
+      "uri_tidal": "tidal://track/73263202"
     },
     {
       "year": 1959,
@@ -491,7 +493,8 @@
       "fun_fact_nl": "Poupee de cire, poupee de son werd geschreven door de legendarische Franse songwriter Serge Gainsbourg. France Gall was pas 17 en was naar verluidt niet op de hoogte van de dubbelzinnige betekenis van de tekst. Het werd een klassieker in de ye-ye popstijl.",
       "awards_nl": [
         "Eurovisionwinnaar 1965"
-      ]
+      ],
+      "uri_tidal": "tidal://track/41386583"
     },
     {
       "year": 1966,
@@ -1126,7 +1129,8 @@
       "fun_fact_nl": "Ding-A-Dong bezorgde Nederland de vierde overwinning. Het aanstekelijke popnummer won in een jaar met veel sterke tegenstanders. Teach-In genoot na de winst van een korte internationale carrière.",
       "awards_nl": [
         "Eurovisionwinnaar 1975"
-      ]
+      ],
+      "uri_tidal": "tidal://track/181365005"
     },
     {
       "year": 1976,

--- a/custom_components/beatify/playlists/hits-2010s-2020s.json
+++ b/custom_components/beatify/playlists/hits-2010s-2020s.json
@@ -1,6 +1,6 @@
 {
   "name": "2010s & 2020s Hits",
-  "version": "1.6",
+  "version": "1.7",
   "tags": [
     "pop",
     "charts",
@@ -425,7 +425,7 @@
         "it": "applemusic://track/1835099678"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=N5KEtQlWzEg",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/33346629",
       "uri_deezer": "deezer://track/65735114",
       "alt_artists": [
         "Ella Eyre"
@@ -453,7 +453,7 @@
         "it": "applemusic://track/1761397067"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=NLyKhp-4Y-0",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/184061880",
       "uri_deezer": "deezer://track/1371887182",
       "alt_artists": [
         "Tom Grennan"
@@ -481,7 +481,7 @@
         "it": "applemusic://track/1807709656"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=Hx4nWW9z0ig",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/114833547",
       "uri_deezer": "deezer://track/739870792",
       "fun_fact": "A chart hit by Tones And I (2019).",
       "fun_fact_de": "Ein Chart-Hit von Tones And I (2019).",
@@ -506,7 +506,7 @@
         "it": "applemusic://track/1416740913"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=K2UAIvQ_lNY",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/92489009",
       "uri_deezer": "deezer://track/532182272",
       "alt_artists": [
         "Bonn"
@@ -534,7 +534,7 @@
         "it": "applemusic://track/6767693237"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=SZx4KF6CQFU",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/94730576",
       "uri_deezer": "deezer://track/552345022",
       "fun_fact": "A chart hit by Andreas Gabalier (2018).",
       "fun_fact_de": "Ein Chart-Hit von Andreas Gabalier (2018).",
@@ -559,7 +559,7 @@
         "it": "applemusic://track/1834746991"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=U4CPl7mpxFw",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/141089695",
       "uri_deezer": "deezer://track/68985416",
       "fun_fact": "A chart hit by INNA (2011).",
       "fun_fact_de": "Ein Chart-Hit von INNA (2011).",
@@ -584,7 +584,7 @@
         "it": "applemusic://track/1756057163"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=jVBsM8CM0AE",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/351423643",
       "uri_deezer": "deezer://track/2706736172",
       "fun_fact": "A chart hit by Artemas (2024).",
       "fun_fact_de": "Ein Chart-Hit von Artemas (2024).",
@@ -601,7 +601,7 @@
       "uri_apple_music": null,
       "uri_apple_music_by_region": {},
       "uri_youtube_music": "https://music.youtube.com/watch?v=XWCPbRsMb0Q",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/86980532",
       "uri_deezer": null,
       "alt_artists": [
         "Dua Lipa"
@@ -629,7 +629,7 @@
         "it": "applemusic://track/1699868137"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=gDRL47NzG5o",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/6444630",
       "uri_deezer": "deezer://track/8930372",
       "alt_artists": [
         "Pitbull"
@@ -657,7 +657,7 @@
         "it": "applemusic://track/1598666433"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=_Za1vy3yDUc",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/75613542",
       "uri_deezer": "deezer://track/377718131",
       "alt_artists": [
         "Willy William"
@@ -685,7 +685,7 @@
         "it": "applemusic://track/1888263656"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=xAgv1mAyxr8",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/9184437",
       "uri_deezer": "deezer://track/14383880",
       "fun_fact": "A chart hit by Avicii (2011).",
       "fun_fact_de": "Ein Chart-Hit von Avicii (2011).",
@@ -710,7 +710,7 @@
         "it": "applemusic://track/1442401366"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=b0U-NcIWz1M",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/32542776",
       "uri_deezer": "deezer://track/81609384",
       "alt_artists": [
         "Ariana Grande",
@@ -739,7 +739,7 @@
         "it": "applemusic://track/1790697544"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=KBV_zpMm_0Q",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/385073564",
       "uri_deezer": "deezer://track/3068802261",
       "fun_fact": "A chart hit by Linkin Park (2024).",
       "fun_fact_de": "Ein Chart-Hit von Linkin Park (2024).",
@@ -764,7 +764,7 @@
         "it": null
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=XOsY3W3dlI0",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/296594990",
       "uri_deezer": "deezer://track/2297911845",
       "fun_fact": "A chart hit by Peggy Gou (2023).",
       "fun_fact_de": "Ein Chart-Hit von Peggy Gou (2023).",
@@ -789,7 +789,7 @@
         "it": "applemusic://track/1738363782"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=jSG3uy97VNA",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/353983142",
       "uri_deezer": "deezer://track/2658723742",
       "fun_fact": "A chart hit by Beyoncé (2024).",
       "fun_fact_de": "Ein Chart-Hit von Beyoncé (2024).",
@@ -814,7 +814,7 @@
         "it": "applemusic://track/1445141316"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=pIWaVJPl0-c",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/69449730",
       "uri_deezer": "deezer://track/140295501",
       "fun_fact": "A chart hit by Alan Walker (2015).",
       "fun_fact_de": "Ein Chart-Hit von Alan Walker (2015).",
@@ -839,7 +839,7 @@
         "it": "applemusic://track/1613393848"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=wERbBIdcT4Y",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/490832408",
       "uri_deezer": "deezer://track/3782886122",
       "alt_artists": [
         "Shaggy"
@@ -867,7 +867,7 @@
         "it": "applemusic://track/1653449011"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=l0dwuaAF3VI",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/217351494",
       "uri_deezer": "deezer://track/1661208732",
       "alt_artists": [
         "DNCE"
@@ -895,7 +895,7 @@
         "it": "applemusic://track/1531503560"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=uYN0VbbQTP8",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/59896476",
       "uri_deezer": "deezer://track/1077700822",
       "fun_fact": "A chart hit by Alexandra Stan (2011).",
       "fun_fact_de": "Ein Chart-Hit von Alexandra Stan (2011).",


### PR DESCRIPTION
Eine Odesli-Welle, automatisch gefahren von `com.beatify.tidal-wave`.

- `disney-classics` Tidal 57 → **69**/69, version 1.6 → 1.7
- `eurovision-winners` Tidal 62 → **66**/72, version 1.9 → 1.10
- `hits-2010s-2020s` Tidal 3 → **22**/71, version 1.6 → 1.7

Bilanz: 35 Treffer · 1 echte Misses · 81 Rate-Limit-Skips · 239 429-Zeilen.

**Draft mit Absicht** — Merge nur nach Markus' Freigabe.