### PR TITLE
data(iconic-movie-songs): YouTube-URI zeigt auf die 12"-Version

### DIFF
--- a/custom_components/beatify/playlists/community/iconic-movie-songs.json
+++ b/custom_components/beatify/playlists/community/iconic-movie-songs.json
@@ -1,6 +1,6 @@
 {
   "name": "ICONIC movie songs 🎬",
-  "version": "0.10",
+  "version": "0.11",
   "tags": [
     "movies",
     "soundtracks",
@@ -151,7 +151,7 @@
       "fun_fact_es": "El dúo culminante de Dirty Dancing (1987) ganó un Óscar y un Grammy.",
       "fun_fact_fr": "Le duo final de Dirty Dancing (1987) a remporté un Oscar et un Grammy.",
       "uri_apple_music": "applemusic://track/254938549",
-      "uri_youtube_music": "https://music.youtube.com/watch?v=E7DU70UTI3Q",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=_zScSltbfGo",
       "uri_tidal": "tidal://track/11337404",
       "uri_deezer": "deezer://track/13128250",
       "fun_fact_nl": "Het slotduet uit Dirty Dancing (1987) won zowel een Oscar als een Grammy.",


### PR DESCRIPTION
Closes #2123. Gefunden vom rotierenden Playlist-Health-Check am 12.08.2026.

## Entschieden über die Dauer, nicht über den Titel

| | Dauer |
|---|---|
| Spotify-Referenz | **290,3 s** |
| bisher gespeichert (`E7DU70UTI3Q`, 12"-Version) | **407 s** |
| neu (`_zScSltbfGo`, Original Soundtrack) | **279 s** |

117 Sekunden Unterschied sind keine andere Abmischung, sondern eine andere Aufnahme. Die Credits des alten Ziels nennen **Jennifer Warnes gar nicht**.

**Restunsicherheit offen benannt**: 11 s Abweichung zwischen neuem Ziel und Referenz. Das liegt im Rahmen von Fade-out- und Master-Unterschieden zwischen Plattformen, ist aber kein exakter Treffer.

## Vier von fünf Meldungen waren Fehlalarme

Unverändert bleiben: Céline Dion (alternatives offizielles Video, gleiche Aufnahme), Taylor Swift und The Hanging Tree (`feat.` statt Komma), Audrey Hepburn (**italienisch lokalisierter** Apple-Titel „Colazione da Tiffany").

Der letzte Fall ist strukturell interessant: der Regionen-Check vergleicht gegen den deutschen Titel und stolpert an jeder lokalisierten Fassung. Heute genau einmal bei 455 geprüften Regionen.

Schema-Gate grün, Playlist-Version 0.10 → 0.11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)