### PR TITLE
chore(playlists): apple backfill — +46 apple uris

### DIFF
--- a/custom_components/beatify/playlists/community/divorced-dad-rock.json
+++ b/custom_components/beatify/playlists/community/divorced-dad-rock.json
@@ -1,6 +1,6 @@
 {
   "name": "Divorced Dad Rock",
-  "version": "1.8",
+  "version": "1.9",
   "tags": [
     "post-grunge",
     "nu-metal",
@@ -719,7 +719,7 @@
       "year": 2005,
       "isrc": "NLA320581338",
       "uri": "spotify:track:0ADZ5dmXhlfzjMw6lefoPl",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/214403586",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1567216583",
         "de": "applemusic://track/290641483",
@@ -794,7 +794,7 @@
       "year": 2005,
       "isrc": "USIR10500509",
       "uri": "spotify:track:3zwmW1gM4E8FlHXV5nE16u",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/1440715272",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/131299294",
         "de": "applemusic://track/131299294",
@@ -1419,7 +1419,7 @@
       "year": 2001,
       "isrc": "USWB10002405",
       "uri": "spotify:track:57BrRMwf9LrcmuOsyGilwr",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/590431782",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1769626227",
         "de": "applemusic://track/1730757323",
@@ -1494,7 +1494,7 @@
       "year": 1999,
       "isrc": "USWB10704697",
       "uri": "spotify:track:0nnwn7LWHCAu09jfuH1xTA",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/1109658194",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1678339751",
         "de": "applemusic://track/1678339751",
@@ -1519,7 +1519,7 @@
       "year": 2008,
       "isrc": "USAT20802280",
       "uri": "spotify:track:0W9Xvd4Qx1aZPxEi94vgRY",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/279812223",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1701819671",
         "de": "applemusic://track/1701819671",
@@ -1544,7 +1544,7 @@
       "year": 2005,
       "isrc": "USRH12000110",
       "uri": "spotify:track:2BoWXJfClbDQkZCZsE0Ru7",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/214403584",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1824619483",
         "de": "applemusic://track/1524782384",
@@ -1569,7 +1569,7 @@
       "year": 2007,
       "isrc": "USWU30700132",
       "uri": "spotify:track:4eAwB5pnKFTmsgc3zWoYO0",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/1440772823",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1716124943",
         "de": "applemusic://track/1716124943",
@@ -1594,7 +1594,7 @@
       "year": 2000,
       "isrc": "USSM10011620",
       "uri": "spotify:track:1sjrDQXqAa9V07FjKIlAQ4",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/203911976",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/203911976",
         "de": "applemusic://track/1799745093",
@@ -1619,7 +1619,7 @@
       "year": 2000,
       "isrc": "USIR10000604",
       "uri": "spotify:track:2avKuMN2QXkaG9vvHa2JLt",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/1440843451",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1705329728",
         "de": "applemusic://track/1705329728",
@@ -1644,7 +1644,7 @@
       "year": 2004,
       "isrc": "USVI20600108",
       "uri": "spotify:track:4wzjNqjKAKDU82e8uMhzmr",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/806224710",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1703143431",
         "de": "applemusic://track/1703143431",
@@ -1669,7 +1669,7 @@
       "year": 2003,
       "isrc": "USEE10340188",
       "uri": "spotify:track:6FOpPA0a80RuBqqgDozvja",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/1506599928",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1290809",
         "de": "applemusic://track/1290809",
@@ -1694,7 +1694,7 @@
       "year": 2002,
       "isrc": "USSM10211584",
       "uri": "spotify:track:1TDk2Jmi4dVZhm2dum3Jim",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/208294752",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1788997574",
         "de": "applemusic://track/1788997574",
@@ -1719,7 +1719,7 @@
       "year": 2004,
       "isrc": "USWB12600244",
       "uri": "spotify:track:6Qyc6fS4DsZjB2mRW9DsQs",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/1109658204",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1876962476",
         "de": "applemusic://track/1876962476",
@@ -1744,7 +1744,7 @@
       "year": 1999,
       "isrc": "USRW29600011",
       "uri": "spotify:track:5UWwZ5lm5PKu6eKsHAGxOk",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/362133505",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/362133505",
         "de": "applemusic://track/1130011053",
@@ -1794,7 +1794,7 @@
       "year": 2001,
       "isrc": "USSM10107264",
       "uri": "spotify:track:4e9eGQYsOiBcftrWXwsVco",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/273714765",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1744586146",
         "de": "applemusic://track/618713069",
@@ -1819,7 +1819,7 @@
       "year": 2000,
       "isrc": "USAT29600038",
       "uri": "spotify:track:5vYA1mW9g2Coh1HUFUSmlb",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/580695852",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1794125837",
         "de": "applemusic://track/1794125837",
@@ -1844,7 +1844,7 @@
       "year": 2005,
       "isrc": "USVI20500136",
       "uri": "spotify:track:0lP4HYLmvowOKdsQ7CVkuq",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/1867087254",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1892522090",
         "de": "applemusic://track/1892522090",
@@ -1869,7 +1869,7 @@
       "year": 1997,
       "isrc": "USMV29700142",
       "uri": "spotify:track:1158ckiB5S4cpsdYHDB9IF",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/1099843209",
       "uri_apple_music_by_region": {
         "us": null,
         "de": "applemusic://track/1494718470",
@@ -1894,7 +1894,7 @@
       "year": 1993,
       "isrc": "USAT21701897",
       "uri": "spotify:track:0CkspLl535ZxdwCRs8AdZ4",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/3631541",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1701076383",
         "de": "applemusic://track/1701076383",
@@ -1919,7 +1919,7 @@
       "year": 1999,
       "isrc": "USRC19900048",
       "uri": "spotify:track:4cKGldbhGJniI8BrB3K6tb",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/298554780",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1789172991",
         "de": "applemusic://track/1799744580",
@@ -1944,7 +1944,7 @@
       "year": 2005,
       "isrc": "USUM70503176",
       "uri": "spotify:track:10fddGyyeUquZZ2uPTjD7P",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/1440763695",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1442264670",
         "de": "applemusic://track/1440751090",
@@ -1969,7 +1969,7 @@
       "year": 2001,
       "isrc": "USAT20621523",
       "uri": "spotify:track:5DooySfCD1xCJ49gQm9rx7",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/300206617",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1517407814",
         "de": "applemusic://track/1517407814",
@@ -1994,7 +1994,7 @@
       "year": 2002,
       "isrc": "USSM10107262",
       "uri": "spotify:track:0snQkGI5qnAmohLE7jTsTn",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/273714713",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/273714713",
         "de": "applemusic://track/1778713957",
@@ -2019,7 +2019,7 @@
       "year": 1998,
       "isrc": "USAT29800696",
       "uri": "spotify:track:0f37VQs969vZUL4gVfHRV9",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/1449698942",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1549644079",
         "de": "applemusic://track/1549644079",
@@ -2044,7 +2044,7 @@
       "year": 2009,
       "isrc": "USRC10800301",
       "uri": "spotify:track:5VGlqQANWDKJFl0MBG3sg2",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/290303018",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/290303018",
         "de": "applemusic://track/290303018",
@@ -2069,7 +2069,7 @@
       "year": 1999,
       "isrc": "USSM19911429",
       "uri": "spotify:track:4BggEwLhGfrbrl7JBhC8EC",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/203304621",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1741671531",
         "de": "applemusic://track/1741671531",
@@ -2094,7 +2094,7 @@
       "year": 2006,
       "isrc": "USJI10600117",
       "uri": "spotify:track:56sk7jBpZV0CD31G9hEU3b",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/266221967",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/483191914",
         "de": "applemusic://track/483191914",
@@ -2119,7 +2119,7 @@
       "year": 2005,
       "isrc": "USSM10505340",
       "uri": "spotify:track:1VNWaY3uNfoeWqb5U8x2QX",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/159457722",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/159457722",
         "de": "applemusic://track/1778714096",
@@ -2144,7 +2144,7 @@
       "year": 2002,
       "isrc": "USUM70759247",
       "uri": "spotify:track:6eYUbXmncekAKMYZcsSkyD",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/1440900494",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1440733705",
         "de": "applemusic://track/1440733705",
@@ -2169,7 +2169,7 @@
       "year": 2003,
       "isrc": "USWU30200093",
       "uri": "spotify:track:0COqiPhxzoWICwFCS4eZcp",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/1440666111",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1645901771",
         "de": "applemusic://track/1645901771",
@@ -2194,7 +2194,7 @@
       "year": 1997,
       "isrc": "USMV29700147",
       "uri": "spotify:track:4Uiw0Sl9yskBaC6P4DcdVD",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/1099843334",
       "uri_apple_music_by_region": {
         "us": null,
         "de": null,
@@ -2219,7 +2219,7 @@
       "year": 2002,
       "isrc": "USSM10211593",
       "uri": "spotify:track:33AxY0QUitvte6JV6B6uLE",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/208294820",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1789000053",
         "de": "applemusic://track/1789000053",
@@ -2244,7 +2244,7 @@
       "year": 1999,
       "isrc": "USIR19902308",
       "uri": "spotify:track:1TEZWG1FdjzDdercCguTwj",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/1443925859",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1440754476",
         "de": "applemusic://track/1440754476",
@@ -2269,7 +2269,7 @@
       "year": 2001,
       "isrc": "USSM10107084",
       "uri": "spotify:track:6KtLECDztnah63TNmV4Plw",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/271792734",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/315710893",
         "de": "applemusic://track/1799757090",
@@ -2294,7 +2294,7 @@
       "year": 2006,
       "isrc": "USJI10600166",
       "uri": "spotify:track:3HE50TVRquwXe9yv2HFoNL",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/266221984",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1789000068",
         "de": "applemusic://track/1789000068",
@@ -2319,7 +2319,7 @@
       "year": 1997,
       "isrc": "USAT29600042",
       "uri": "spotify:track:2KVwlelhxKUy8LVV6JypH3",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/580695853",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1761838896",
         "de": "applemusic://track/1761838896",
@@ -2344,7 +2344,7 @@
       "year": 1999,
       "isrc": "USSM19911010",
       "uri": "spotify:track:1Y13csEpu3TK5gQdzGLrd8",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/187454524",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/571750359",
         "de": "applemusic://track/571750359",
@@ -2369,7 +2369,7 @@
       "year": 1998,
       "isrc": "USWU39703049",
       "uri": "spotify:track:5vRPXm59z8ewWO6WiJHg3m",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/1440666233",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1774312003",
         "de": "applemusic://track/1774312003",
@@ -2394,7 +2394,7 @@
       "year": 2008,
       "isrc": "USRC10800300",
       "uri": "spotify:track:0ntQJM78wzOLVeCUAW7Y45",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/290303003",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1032181382",
         "de": "applemusic://track/1032181382",
@@ -2419,7 +2419,7 @@
       "year": 2003,
       "isrc": "USSM10211591",
       "uri": "spotify:track:2uDwRgwGPjXq0oj0hNCuFc",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/208294962",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/208294962",
         "de": "applemusic://track/163301800",
@@ -2444,7 +2444,7 @@
       "year": 1999,
       "isrc": "USRW29600007",
       "uri": "spotify:track:4dVbhS6OiYvFikshyaQaCN",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/362133488",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1650514030",
         "de": "applemusic://track/1650514030",
@@ -2469,7 +2469,7 @@
       "year": 2000,
       "isrc": "USIR10001177",
       "uri": "spotify:track:2gSVKxPDww9Eep5rdvtdem",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/1784372932",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1616083922",
         "de": "applemusic://track/1616083922",
@@ -2519,7 +2519,7 @@
       "year": 2000,
       "isrc": "USWU30006502",
       "uri": "spotify:track:7CpbhqKUedOIrcvc94p60Y",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/1440777727",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1706914822",
         "de": "applemusic://track/1706914822",
@@ -2544,7 +2544,7 @@
       "year": 1999,
       "isrc": "USRW39900002",
       "uri": "spotify:track:5OQsiBsky2k2kDKy2bX2eT",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/278229654",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1650514546",
         "de": "applemusic://track/1650514546",
@@ -2569,7 +2569,7 @@
       "year": 2003,
       "isrc": "NLA320320275",
       "uri": "spotify:track:4PkJ7c9y1CwpuVOiJODnCZ",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/1751339874",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1751339874",
         "de": "applemusic://track/1457976257",
@@ -2594,7 +2594,7 @@
       "year": 2002,
       "isrc": "USSM10209827",
       "uri": "spotify:track:0BRHnOFm6sjxN1i9LJrUDu",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/288051950",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/402052711",
         "de": "applemusic://track/1695532447",


### PR DESCRIPTION
Ein Lauf des `provider-uri-backfill` mit Schwerpunkt Apple Music, automatisch gefahren von `com.beatify.apple-backfill`.

- `divorced-dad-rock` Apple 56 -> **102**/107

**Der Lauf ist am Deckel gestoppt, nicht fertig geworden** (`reached --max-minutes 50`). Die uebrigen Tracks der Playlist sind unberuehrt und keine Katalogluecke.

**Draft mit Absicht** — Merge nur nach Markus' Freigabe. Fuer diesen Agenten gibt es bewusst KEINEN Automerge.