### PR TITLE
chore(playlists): youtube backfill — +0 youtube uris

### DIFF
--- a/custom_components/beatify/playlists/40s-50s-classics.json
+++ b/custom_components/beatify/playlists/40s-50s-classics.json
@@ -1,6 +1,6 @@
 {
   "name": "40s & 50s Classics",
-  "version": "1.12",
+  "version": "1.13",
   "tags": [
     "1940s",
     "1950s",
@@ -1044,7 +1044,7 @@
       "year": 1956,
       "isrc": "USA561143978",
       "uri": "spotify:track:5d6ZRqgbz26Sg4bk1oifQw",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/1890339100",
       "uri_apple_music_by_region": {
         "us": null,
         "de": null,
@@ -1319,7 +1319,7 @@
       "year": 1956,
       "isrc": "USCA28800076",
       "uri": "spotify:track:0TMrV95mP7sDlvbE4iVfKP",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/1801710188",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1763342566",
         "de": "applemusic://track/689286034",
@@ -1419,7 +1419,7 @@
       "year": 1956,
       "isrc": "ZA42A1507181",
       "uri": "spotify:track:5tHFPtV7dT01fxDe2AhKjD",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/1440936763",
       "uri_apple_music_by_region": {
         "us": null,
         "de": null,
@@ -1469,7 +1469,7 @@
       "year": 1956,
       "isrc": "USCA29501047",
       "uri": "spotify:track:4tmy6FB76bR5eLmx0zO1mn",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/726137579",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1764557878",
         "de": "applemusic://track/1764557878",
@@ -1569,7 +1569,7 @@
       "year": 1956,
       "isrc": "USEM38800149",
       "uri": "spotify:track:2ePDfIXoP2HmC1hfsujb2J",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/1572865154",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1705328531",
         "de": "applemusic://track/1705328531",
@@ -1669,7 +1669,7 @@
       "year": 1956,
       "isrc": "QM7281450273",
       "uri": "spotify:track:4IYyGIbMS5ZkxDXGfPIrXr",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/1443811339",
       "uri_apple_music_by_region": {
         "us": null,
         "de": null,
@@ -1694,7 +1694,7 @@
       "year": 1956,
       "isrc": "USPB81011014",
       "uri": "spotify:track:0GVvRmCoiLkhxJvlZy9bLk",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/328128734",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/358042510",
         "de": "applemusic://track/358042510",
@@ -1719,7 +1719,7 @@
       "year": 1956,
       "isrc": "QM7281459419",
       "uri": "spotify:track:1ntGJDSakqsaw1KhptKrB5",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/1440922198",
       "uri_apple_music_by_region": {
         "us": null,
         "de": "applemusic://track/941321163",
@@ -1844,7 +1844,7 @@
       "year": 1957,
       "isrc": "USUM70974702",
       "uri": "spotify:track:7s7Zu78CztOUFUyQ4BijBQ",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/1469585589",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1435973330",
         "de": "applemusic://track/1435973330",
@@ -1869,7 +1869,7 @@
       "year": 1957,
       "isrc": "USMC15707450",
       "uri": "spotify:track:6sBPjgvLZzHHrpxbBDjmdE",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/1605211898",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1605211898",
         "de": "applemusic://track/1605211898",
@@ -1944,7 +1944,7 @@
       "year": 1957,
       "isrc": "USSM19907730",
       "uri": "spotify:track:2HyPrPSANTIPkR6CfiytwY",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/1133368603",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1495270010",
         "de": "applemusic://track/332735039",
@@ -1994,7 +1994,7 @@
       "year": 1957,
       "isrc": "USLIC0600296",
       "uri": "spotify:track:5ueyLj6e6oVaTY0KQ6yLaA",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/388127922",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/350212673",
         "de": null,
@@ -2044,7 +2044,7 @@
       "year": 1957,
       "isrc": "USBWC0110030",
       "uri": "spotify:track:3h4udS0WeWbsur3yfjvnm4",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/111288978",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/403806790",
         "de": "applemusic://track/403806790",
@@ -2119,7 +2119,7 @@
       "year": 1957,
       "isrc": "USSM15700524",
       "uri": "spotify:track:63NmQTtxQLHSRp7li6aAmP",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/1027550721",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/201414675",
         "de": "applemusic://track/201414675",

--- a/custom_components/beatify/playlists/40s-50s-classics.json
+++ b/custom_components/beatify/playlists/40s-50s-classics.json
@@ -1,6 +1,6 @@
 {
   "name": "40s & 50s Classics",
-  "version": "1.13",
+  "version": "1.14",
   "tags": [
     "1940s",
     "1950s",
@@ -2144,7 +2144,7 @@
       "year": 1957,
       "isrc": "USSM10403425",
       "uri": "spotify:track:4g9ZMsnY0xpeG3OR8GRJne",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/818525729",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/201414349",
         "de": "applemusic://track/201414349",
@@ -2219,7 +2219,7 @@
       "year": 1957,
       "isrc": "USRC10000595",
       "uri": "spotify:track:2k6qpHJsrKCCyvsHv2cPqR",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/282219334",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/282219334",
         "de": "applemusic://track/314000997",
@@ -2256,7 +2256,7 @@
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=LJCp7K__8Vo",
       "uri_tidal": "tidal://track/60683639",
-      "uri_deezer": null,
+      "uri_deezer": "deezer://track/3265903131",
       "fun_fact": "Ricky Nelson — a teen idol who became one of the 50s' biggest stars.",
       "fun_fact_de": "Ricky Nelson — ein Teenie-Idol, das zu einem der größten Stars der 50er wurde.",
       "fun_fact_es": "Ricky Nelson, un ídolo adolescente que se convirtió en una de las grandes estrellas de los 50.",
@@ -2319,7 +2319,7 @@
       "year": 1957,
       "isrc": "USWB10603360",
       "uri": "spotify:track:11fNLqDB47gMKj7BHhR2Qr",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/1714917514",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1400161658",
         "de": "applemusic://track/1400161658",
@@ -2394,7 +2394,7 @@
       "year": 1957,
       "isrc": "QM4TX1767965",
       "uri": "spotify:track:2yOXKIU9YtBSWjI3OA8tqj",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/447593241",
       "uri_apple_music_by_region": {
         "us": null,
         "de": null,
@@ -2569,7 +2569,7 @@
       "year": 1958,
       "isrc": "USRC16406272",
       "uri": "spotify:track:4nAJtcmiyoL0ARY5WZY9IN",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/217699850",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/415504223",
         "de": "applemusic://track/324167268",
@@ -2894,7 +2894,7 @@
       "year": 1958,
       "isrc": "USPR35800063",
       "uri": "spotify:track:1f0Wfl3eLCLKv72SdkpviC",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/1437194539",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1700465239",
         "de": "applemusic://track/1700465239",
@@ -2919,7 +2919,7 @@
       "year": 1958,
       "isrc": "QM7281450274",
       "uri": "spotify:track:07GtDOCxmye5KDWsTSACPk",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/541046802",
       "uri_apple_music_by_region": {
         "us": null,
         "de": null,
@@ -3044,7 +3044,7 @@
       "year": 1959,
       "isrc": "USMO15900265",
       "uri": "spotify:track:0jqr2lIlIU09FsuSOibDdA",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/1445297290",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1576448302",
         "de": "applemusic://track/1576448302",
@@ -3156,7 +3156,7 @@
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=uk4ZbUGRKt8",
       "uri_tidal": "tidal://track/1500589",
-      "uri_deezer": null,
+      "uri_deezer": "deezer://track/3124101",
       "fun_fact": "A 1950s classic (1959).",
       "fun_fact_de": "Ein 50er-Klassiker (1959).",
       "fun_fact_es": "Un clásico de los años 50 (1959).",
@@ -3219,7 +3219,7 @@
       "year": 1959,
       "isrc": "USGR19906204",
       "uri": "spotify:track:28HXaQiH5DF10ey7yh9Gdu",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/1434896964",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1765400390",
         "de": "applemusic://track/1765400390",
@@ -3269,7 +3269,7 @@
       "year": 1959,
       "isrc": "USEM38700242",
       "uri": "spotify:track:3Ib94mN8YF3cXZo5x1FpQL",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/1444140158",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1496048261",
         "de": "applemusic://track/724391048",
@@ -3319,7 +3319,7 @@
       "year": 1959,
       "isrc": "USA371099273",
       "uri": "spotify:track:0qDShcc7oY6M8OFaDXHOZG",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/208115171",
       "uri_apple_music_by_region": {
         "us": null,
         "de": null,
@@ -3594,7 +3594,7 @@
       "year": 1959,
       "isrc": "USAT29901950",
       "uri": "spotify:track:047Ip9c6dijAJfuwloV3NF",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/1600072827",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1694329463",
         "de": "applemusic://track/1694329463",
@@ -3619,7 +3619,7 @@
       "year": 1959,
       "isrc": "NLHR52134880",
       "uri": "spotify:track:5WAPUAldIHRM28j5fUl1ak",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/1354794482",
       "uri_apple_music_by_region": {
         "us": null,
         "de": null,
@@ -3656,7 +3656,7 @@
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=VcCV_ALcpss",
       "uri_tidal": "tidal://track/3191789",
-      "uri_deezer": null,
+      "uri_deezer": "deezer://track/3581352",
       "fun_fact": "A 1950s classic (1959).",
       "fun_fact_de": "Ein 50er-Klassiker (1959).",
       "fun_fact_es": "Un clásico de los años 50 (1959).",
@@ -3794,7 +3794,7 @@
       "year": 1962,
       "isrc": "USSM10404750",
       "uri": "spotify:track:5KG2ahk1cONbHvg3dBdTbx",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/192966100",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/192966100",
         "de": "applemusic://track/192966100",

--- a/custom_components/beatify/playlists/70s-hits.json
+++ b/custom_components/beatify/playlists/70s-hits.json
@@ -1,6 +1,6 @@
 {
   "name": "70s Hits",
-  "version": "1.14",
+  "version": "1.15",
   "tags": [
     "1970s",
     "classic-rock",
@@ -3044,7 +3044,7 @@
       "year": 1976,
       "isrc": "DED168000002",
       "uri": "spotify:track:3pf96IFggfQuT6Gafqx2rt",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/220385946",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1626933880",
         "de": "applemusic://track/1626933880",
@@ -3069,7 +3069,7 @@
       "year": 1978,
       "isrc": "USAM17800365",
       "uri": "spotify:track:1CQqupcyMg7176PPmIVmSj",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/1440911577",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/6767662926",
         "de": "applemusic://track/6767662926",
@@ -3144,7 +3144,7 @@
       "year": 1971,
       "isrc": "US2HK1341204",
       "uri": "spotify:track:10vkYRKw6Jjr7try1ir50G",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/1203896571",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1196519945",
         "de": "applemusic://track/1196519945",
@@ -3169,7 +3169,7 @@
       "year": 1976,
       "isrc": "USSM17800853",
       "uri": "spotify:track:2hdNya0b6Cc2YJ8IyaQIWp",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/1054523242",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/894170618",
         "de": "applemusic://track/318312874",
@@ -3219,7 +3219,7 @@
       "year": 1971,
       "isrc": "USIR20000701",
       "uri": "spotify:track:6rovOdp3HgK1DeAMYDzoA7",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/1423302726",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1426968402",
         "de": "applemusic://track/1426968402",
@@ -3269,7 +3269,7 @@
       "year": 1979,
       "isrc": "GBARL1200680",
       "uri": "spotify:track:5jzma6gCzYtKB1DbEwFZKH",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/684811768",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/688795488",
         "de": "applemusic://track/688795488",
@@ -3294,7 +3294,7 @@
       "year": 1971,
       "isrc": "USJT11500131",
       "uri": "spotify:track:3ZE3wv8V3w2T2f7nOCjV0N",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/1039798013",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1593686602",
         "de": "applemusic://track/1593686602",
@@ -3319,7 +3319,7 @@
       "year": 1976,
       "isrc": "GBF087600063",
       "uri": "spotify:track:43DeSV93pJPT4lCZaWZ6b1",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/1443910472",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/6766355695",
         "de": "applemusic://track/6766355695",
@@ -3344,7 +3344,7 @@
       "year": 1979,
       "isrc": "USUM71021480",
       "uri": "spotify:track:6mHOcVtsHLMuesJkswc0GZ",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/1440521625",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1892521978",
         "de": "applemusic://track/1892521978",
@@ -3394,7 +3394,7 @@
       "year": 1979,
       "isrc": "NLF057990026",
       "uri": "spotify:track:6UXXeFqMBGiqjkzQzkMT3E",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/1445664308",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1716610378",
         "de": "applemusic://track/1716610378",
@@ -3444,7 +3444,7 @@
       "year": 1973,
       "isrc": "USAM17300051",
       "uri": "spotify:track:3wM6RTAnF7IQpMFd7b9ZcL",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/1434886946",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1814188181",
         "de": "applemusic://track/1814188181",
@@ -3469,7 +3469,7 @@
       "year": 1970,
       "isrc": "USSM16900181",
       "uri": "spotify:track:6QhXQOpyYvbpdbyjgAqKdY",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/324127936",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1463652199",
         "de": "applemusic://track/1463652199",
@@ -3494,7 +3494,7 @@
       "year": 1977,
       "isrc": "NLF057790024",
       "uri": "spotify:track:2udGjDmpK1dH9VGyw7nrei",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/1440782710",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1388006144",
         "de": "applemusic://track/1388006144",
@@ -3519,7 +3519,7 @@
       "year": 1971,
       "isrc": "USEM38600091",
       "uri": "spotify:track:0VNzEY1G4GLqcNx5qaaTl6",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/1440834638",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/6768427700",
         "de": "applemusic://track/6768427700",


### PR DESCRIPTION
Ein Lauf des `provider-uri-backfill`, automatisch gefahren von `com.beatify.youtube-backfill`.

- `40s-50s-classics` YouTube 152 -> **152**/152

Nebenbei mitgefuellt, weil Odesli alle Provider in einer Antwort liefert: apple +14.

**Draft mit Absicht** — Merge nur nach Markus' Freigabe.