### PR TITLE
chore(playlists): youtube backfill — +11 youtube uris

### DIFF
--- a/custom_components/beatify/playlists/community/deutschrock-best-of.json
+++ b/custom_components/beatify/playlists/community/deutschrock-best-of.json
@@ -1,6 +1,6 @@
 {
   "name": "Deutschrock - Best Of",
-  "version": "0.13",
+  "version": "0.14",
   "tags": [
     "deutschrock",
     "german rock",
@@ -107,7 +107,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=vEjwjC9209U",
       "uri_tidal": "tidal://track/370026570",
       "uri_deezer": "deezer://track/2851839172",
       "alt_artists": [],
@@ -133,7 +133,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=cHmhdsSVvII",
       "uri_tidal": "tidal://track/416292504",
       "uri_deezer": "deezer://track/3187689581",
       "alt_artists": [],
@@ -159,7 +159,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=LnNOJxB3FeQ",
       "uri_tidal": "tidal://track/442775007",
       "uri_deezer": "deezer://track/3419570401",
       "alt_artists": [],
@@ -185,7 +185,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Uh9IDVowR4Q",
       "uri_tidal": "tidal://track/73402976",
       "uri_deezer": "deezer://track/357434601",
       "alt_artists": [],
@@ -211,7 +211,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=z_6T25fLn_s",
       "uri_tidal": "tidal://track/276999011",
       "uri_deezer": "deezer://track/2147895807",
       "alt_artists": [],
@@ -237,7 +237,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=KXwYEVHQOZQ",
       "uri_tidal": "tidal://track/88858729",
       "uri_deezer": "deezer://track/500165212",
       "alt_artists": [],
@@ -263,7 +263,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=h5eK4RGLDOo",
       "uri_tidal": "tidal://track/430681773",
       "uri_deezer": "deezer://track/3328976811",
       "alt_artists": [],
@@ -289,7 +289,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=HVXOl3F38y4",
       "uri_tidal": "tidal://track/440113397",
       "uri_deezer": "deezer://track/3395760901",
       "alt_artists": [],
@@ -315,7 +315,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=ew2COdgevHM",
       "uri_tidal": "tidal://track/353847575",
       "uri_deezer": "deezer://track/2724656311",
       "alt_artists": [],
@@ -341,7 +341,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Ru5nBnnPPeA",
       "uri_tidal": "tidal://track/341534834",
       "uri_deezer": "deezer://track/2476328001",
       "alt_artists": [],
@@ -367,7 +367,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=sl7b1Ung-rc",
       "uri_tidal": "tidal://track/522727364",
       "uri_deezer": "deezer://track/4009923081",
       "alt_artists": [],

--- a/custom_components/beatify/playlists/community/deutschrock-best-of.json
+++ b/custom_components/beatify/playlists/community/deutschrock-best-of.json
@@ -1,6 +1,6 @@
 {
   "name": "Deutschrock - Best Of",
-  "version": "0.14",
+  "version": "0.18",
   "tags": [
     "deutschrock",
     "german rock",
@@ -393,7 +393,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=7XoKvGq7zB0",
       "uri_tidal": "tidal://track/442482686",
       "uri_deezer": "deezer://track/3417022611",
       "alt_artists": [],
@@ -419,7 +419,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=5pjY547qn5k",
       "uri_tidal": "tidal://track/2040261",
       "uri_deezer": "deezer://track/1272451732",
       "alt_artists": [],
@@ -445,7 +445,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=CYxrCtFlXEA",
       "uri_tidal": "tidal://track/279503489",
       "uri_deezer": "deezer://track/2170638557",
       "alt_artists": [],
@@ -471,7 +471,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=vNZLQGL1fwE",
       "uri_tidal": "tidal://track/442479985",
       "uri_deezer": "deezer://track/3417021261",
       "alt_artists": [],
@@ -497,7 +497,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=puVj_142_R4",
       "uri_tidal": "tidal://track/203629601",
       "uri_deezer": "deezer://track/1520562962",
       "alt_artists": [],

--- a/custom_components/beatify/playlists/community/wiesn-party-hits.json
+++ b/custom_components/beatify/playlists/community/wiesn-party-hits.json
@@ -1,6 +1,6 @@
 {
   "name": "Wiesn Party Hits 🍻",
-  "version": "0.9",
+  "version": "0.13",
   "tags": [
     "party",
     "schlager",
@@ -634,7 +634,7 @@
         "it": "applemusic://track/1857765665"
       },
       "uri_deezer": "deezer://track/5105781",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=PJ7E40Ec5ec",
       "uri_tidal": "tidal://track/3270203"
     },
     {
@@ -667,7 +667,7 @@
         "it": "applemusic://track/338654720"
       },
       "uri_deezer": "deezer://track/417358532",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=y8PgHEoUnXI",
       "uri_tidal": "tidal://track/20829494"
     },
     {
@@ -700,7 +700,7 @@
         "it": "applemusic://track/1473155299"
       },
       "uri_deezer": "deezer://track/713477362",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=WW-HDijZR_Y",
       "uri_tidal": "tidal://track/113400855"
     },
     {
@@ -737,7 +737,7 @@
         "it": "applemusic://track/369158926"
       },
       "uri_deezer": "deezer://track/15319250",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=CfHHv7yOYX0",
       "uri_tidal": "tidal://track/13981564"
     },
     {
@@ -772,7 +772,7 @@
         "it": "applemusic://track/256033333"
       },
       "uri_deezer": "deezer://track/1008665",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=wCON7JlxuEI",
       "uri_tidal": "tidal://track/2045071"
     },
     {
@@ -808,7 +808,7 @@
         "it": "applemusic://track/1629643178"
       },
       "uri_deezer": "deezer://track/1791078487",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=C4uXGzFZjqw",
       "uri_tidal": "tidal://track/217332803"
     },
     {
@@ -841,7 +841,7 @@
         "it": "applemusic://track/724964346"
       },
       "uri_deezer": "deezer://track/3156476",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=37RPcWyHxLE",
       "uri_tidal": "tidal://track/1394994"
     },
     {
@@ -878,7 +878,7 @@
         "it": "applemusic://track/1611040987"
       },
       "uri_deezer": "deezer://track/111773080",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=x6q0ciiqyG0",
       "uri_tidal": "tidal://track/63902379"
     },
     {
@@ -911,7 +911,7 @@
         "it": "applemusic://track/712050372"
       },
       "uri_deezer": "deezer://track/605095502",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=jjXckwRbywM",
       "uri_tidal": "tidal://track/40043487"
     },
     {
@@ -944,7 +944,7 @@
         "it": "applemusic://track/1443394725"
       },
       "uri_deezer": "deezer://track/2455263785",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=rsJ9ZKq8eNQ",
       "uri_tidal": "tidal://track/316460562"
     },
     {
@@ -977,7 +977,7 @@
         "it": "applemusic://track/1442492105"
       },
       "uri_deezer": "deezer://track/887610",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=i_-_8SsGlKs",
       "uri_tidal": "tidal://track/3608587"
     },
     {
@@ -1010,7 +1010,7 @@
         "it": "applemusic://track/1730034830"
       },
       "uri_deezer": "deezer://track/2674766112",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=fX9XZAWa65o",
       "uri_tidal": "tidal://track/347043297"
     },
     {
@@ -1047,7 +1047,7 @@
         "it": "applemusic://track/1444443840"
       },
       "uri_deezer": "deezer://track/1139093",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=2Ua9af7xC9c",
       "uri_tidal": "tidal://track/3608585"
     },
     {
@@ -1080,7 +1080,7 @@
         "it": "applemusic://track/268510504"
       },
       "uri_deezer": "deezer://track/15508216",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=_9Qbn7pzmtA",
       "uri_tidal": "tidal://track/20370397"
     },
     {
@@ -1117,7 +1117,7 @@
         "it": "applemusic://track/715645285"
       },
       "uri_deezer": "deezer://track/3164083",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=8zW9trhJ_TQ",
       "uri_tidal": "tidal://track/2965824"
     },
     {
@@ -1150,7 +1150,7 @@
         "it": "applemusic://track/445944549"
       },
       "uri_deezer": "deezer://track/631190652",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=qAGumIM-L2o",
       "uri_tidal": "tidal://track/16670929"
     },
     {
@@ -1185,7 +1185,7 @@
         "it": "applemusic://track/297230133"
       },
       "uri_deezer": "deezer://track/61750163",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=DIpNMWGUiA4",
       "uri_tidal": "tidal://track/15413835"
     },
     {
@@ -1220,7 +1220,7 @@
         "it": "applemusic://track/294519561"
       },
       "uri_deezer": "deezer://track/61838244",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=q8NRgJRmNA0",
       "uri_tidal": "tidal://track/16744593"
     },
     {
@@ -1257,7 +1257,7 @@
         "it": "applemusic://track/1566574065"
       },
       "uri_deezer": "deezer://track/702871922",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=vQqpMukDSP4",
       "uri_tidal": "tidal://track/183359642"
     },
     {
@@ -1290,7 +1290,7 @@
         "it": "applemusic://track/288013821"
       },
       "uri_deezer": "deezer://track/61721437",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=UEI7txY9dio",
       "uri_tidal": "tidal://track/15352283"
     },
     {

--- a/custom_components/beatify/playlists/community/wiesn-party-hits.json
+++ b/custom_components/beatify/playlists/community/wiesn-party-hits.json
@@ -1,6 +1,6 @@
 {
   "name": "Wiesn Party Hits 🍻",
-  "version": "0.7",
+  "version": "0.9",
   "tags": [
     "party",
     "schlager",
@@ -43,7 +43,7 @@
         "it": "applemusic://track/293895098"
       },
       "uri_deezer": "deezer://track/62238193",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=RwHcohP7y3I",
       "uri_tidal": "tidal://track/15811933"
     },
     {
@@ -76,7 +76,7 @@
         "it": "applemusic://track/1443346606"
       },
       "uri_deezer": "deezer://track/982516",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=CjGQLp6t6GU",
       "uri_tidal": "tidal://track/494409690"
     },
     {
@@ -112,7 +112,7 @@
         "it": "applemusic://track/311429581"
       },
       "uri_deezer": "deezer://track/636405",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Nn1IeHL5DHY",
       "uri_tidal": null
     },
     {
@@ -597,7 +597,7 @@
         "it": "applemusic://track/253831824"
       },
       "uri_deezer": "deezer://track/971107",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=wWURPVmV2cg",
       "uri_tidal": "tidal://track/16320764"
     },
     {


### PR DESCRIPTION
Ein Lauf des `provider-uri-backfill`, automatisch gefahren von `com.beatify.youtube-backfill`.

- `deutschrock-best-of` YouTube 3 -> **14**/100

**Draft mit Absicht** — Merge nur nach Markus' Freigabe.