### PR TITLE
chore(playlists): youtube backfill — +19 youtube uris (Rettung des 07:32-Laufs)

### DIFF
--- a/custom_components/beatify/playlists/community/deutschrock-best-of.json
+++ b/custom_components/beatify/playlists/community/deutschrock-best-of.json
@@ -1,6 +1,6 @@
 {
   "name": "Deutschrock - Best Of",
-  "version": "0.18",
+  "version": "0.19",
   "tags": [
     "deutschrock",
     "german rock",
@@ -523,7 +523,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=WGzqZQPa-z0",
       "uri_tidal": "tidal://track/84765402",
       "uri_deezer": "deezer://track/462439512",
       "alt_artists": [],
@@ -549,7 +549,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=hauVRpe0qvA",
       "uri_tidal": "tidal://track/438221487",
       "uri_deezer": "deezer://track/3370456051",
       "alt_artists": [],
@@ -575,7 +575,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=kBnaZg3jQ94",
       "uri_tidal": "tidal://track/422158122",
       "uri_deezer": "deezer://track/3265960061",
       "alt_artists": [],
@@ -601,7 +601,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=U261z8kwDXI",
       "uri_tidal": "tidal://track/424046632",
       "uri_deezer": "deezer://track/2459899275",
       "alt_artists": [],
@@ -627,7 +627,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=7LORRKXTvnA",
       "uri_tidal": "tidal://track/133886894",
       "uri_deezer": "deezer://track/899950322",
       "alt_artists": [],
@@ -653,7 +653,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=_yV2eIhJm9A",
       "uri_tidal": "tidal://track/289132450",
       "uri_deezer": "deezer://track/2237025037",
       "alt_artists": [],
@@ -679,7 +679,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=tP6t7wBJwmY",
       "uri_tidal": "tidal://track/94431445",
       "uri_deezer": "deezer://track/548387972",
       "alt_artists": [],
@@ -705,7 +705,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=leZB-Ywj-5E",
       "uri_tidal": "tidal://track/105896551",
       "uri_deezer": "deezer://track/649053902",
       "alt_artists": [],
@@ -731,7 +731,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=0rjlV2ZzGio",
       "uri_tidal": "tidal://track/442482758",
       "uri_deezer": "deezer://track/3417042361",
       "alt_artists": [],
@@ -757,7 +757,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=r5Zt0iZi76E",
       "uri_tidal": "tidal://track/18217419",
       "uri_deezer": "deezer://track/58495591",
       "alt_artists": [],
@@ -783,7 +783,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=CQYypFMTQcE",
       "uri_tidal": "tidal://track/15187667",
       "uri_deezer": "deezer://track/142393405",
       "alt_artists": [],
@@ -809,7 +809,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=mkTliFEBG1Y",
       "uri_tidal": "tidal://track/292900112",
       "uri_deezer": "deezer://track/2267593717",
       "alt_artists": [],

--- a/custom_components/beatify/playlists/community/finnish-iskelma-classics.json
+++ b/custom_components/beatify/playlists/community/finnish-iskelma-classics.json
@@ -1,6 +1,6 @@
 {
   "name": "Finnish Schlager Classics 🇫🇮",
-  "version": "1.22",
+  "version": "1.24",
   "tags": [
     "finnish",
     "iskelma",
@@ -34,7 +34,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=d7XohORW0zc",
       "uri_tidal": "tidal://track/56442389",
       "uri_deezer": "deezer://track/104154962",
       "fun_fact": "Olavi Virta's 'Sä et kyyneltä nää' (You Won't See a Tear) is a proud song of emotional restraint — a very Finnish sentiment. Virta recorded an extraordinary range of emotional registers, from ecstatic joy to quiet, dignified sorrow.",
@@ -64,7 +64,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=G-2de6ZRBjI",
       "uri_tidal": "tidal://track/2413901",
       "uri_deezer": "deezer://track/70640366",
       "fun_fact": "Olavi Virta's 'Sinun silmiesi tähden' (For the Sake of Your Eyes) is a classic early 1950s romantic ballad that established his status as Finland's premier romantic vocalist of the post-war era.",
@@ -94,7 +94,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=zS_5FvGC8h4",
       "uri_tidal": "tidal://track/364219",
       "uri_deezer": "deezer://track/104154944",
       "fun_fact": "Olavi Virta's 'Täysikuu' (Full Moon) uses lunar imagery to frame a romantic declaration; moon and night-sky imagery runs throughout Finnish poetry and song, connecting the terrestrial longing of iskelmä to cosmic scale.",
@@ -124,7 +124,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=eFjqd9f6G5Y",
       "uri_tidal": "tidal://track/601027",
       "uri_deezer": "deezer://track/3612503",
       "fun_fact": "Georg Ots's 'Saarenmaan valssi' (Saaremaa Waltz) is the most famous Estonian song to be embraced by Finnish audiences; Ots was an Estonian opera baritone whose warm voice transcended the Iron Curtain to win Finnish hearts.",
@@ -154,7 +154,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=OGM6BxQt53A",
       "uri_tidal": "tidal://track/20970320",
       "uri_deezer": "deezer://track/104154956",
       "fun_fact": "Olavi Virta's Finnish version of 'Quién Será' (the mambo standard) demonstrates his range beyond Nordic styles; Virta embraced Latin rhythms and international pop with the same natural ease he brought to Finnish tangos and waltzes.",
@@ -184,7 +184,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=h1Wzp_4KL_8",
       "uri_tidal": "tidal://track/56443076",
       "uri_deezer": "deezer://track/104155096",
       "fun_fact": "Tapio Rautavaara's 'Reissumies ja kissa' (The Traveler and the Cat) is one of his most beloved novelty songs, showcasing the playful side of iskelmä alongside his more serious folk ballads.",
@@ -214,7 +214,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=8jKufAO4H-A",
       "uri_tidal": "tidal://track/1578350",
       "uri_deezer": "deezer://track/14686543",
       "fun_fact": "Tapio Rautavaara's 'Väliaikainen' (Temporary) muses on the transient nature of happiness; such philosophical reflections on impermanence are a recurring thread in Finnish iskelmä, connected to the Lutheran and stoic sensibility of Finnish culture.",


### PR DESCRIPTION
Der YouTube-Backfill-Lauf von 07:32 hat +19 URIs auf `deutschrock-best-of` und `finnish-iskelma-classics` geholt und sie an PR #2136 angehaengt.

**#2136 war zu diesem Zeitpunkt bereits gemergt** (07:53, mit `--delete-branch`). Der Push des Laufs hat den geloeschten Branch wieder angelegt, aber ein gemergter PR nimmt keine neuen Commits mehr auf — die 19 URIs lagen danach auf einem Branch, auf den kein offener PR zeigte. Der Lauf selbst meldete `status: ok` und `pr_url: #2136`, was in dieser Lage irrefuehrend ist.

Dieser PR traegt denselben Inhalt, unveraendert cherry-gepickt aus `e3839e57` und sauber auf den aktuellen `main` aufgesetzt.

Bleibt Draft, wie bei allen Backfill-Laeufen.