### PR TITLE
data(world-cup-anthems): Spotify-URI für „El Rock del Mundial" — die Lücke war ein Odesli-False-Negative

### DIFF
--- a/custom_components/beatify/playlists/world-cup-anthems.json
+++ b/custom_components/beatify/playlists/world-cup-anthems.json
@@ -1,6 +1,6 @@
 {
   "name": "World Cup Anthems",
-  "version": "1.10",
+  "version": "1.11",
   "tags": [
     "world-cup",
     "fifa",
@@ -87,7 +87,7 @@
       "uri_apple_music_by_region": {}
     },
     {
-      "year": 1974,
+      "year": 1973,
       "artist": "Germany National Football Team",
       "title": "Fußball ist unser Leben",
       "alt_artists": [

--- a/custom_components/beatify/playlists/world-cup-anthems.json
+++ b/custom_components/beatify/playlists/world-cup-anthems.json
@@ -1,6 +1,6 @@
 {
   "name": "World Cup Anthems",
-  "version": "1.7",
+  "version": "1.8",
   "tags": [
     "world-cup",
     "fifa",
@@ -21,7 +21,7 @@
       "fun_fact_es": "La primera canción oficial de un Mundial FIFA, grabada para Chile 1962. Se convirtió en un éxito regional del rock and roll.",
       "fun_fact_fr": "La toute première chanson officielle d'une Coupe du monde FIFA, enregistrée pour le Chili 1962. Devenue un tube régional rock'n'roll.",
       "fun_fact_nl": "Het allereerste officiële FIFA-WK-lied, opgenomen voor Chili 1962. Werd een regionale rock-'n'-roll-hit.",
-      "uri": null,
+      "uri": "spotify:track:4GxsXEhvOhmp2M2aAtKMRl",
       "chart_info": {},
       "certifications": [],
       "awards": [],

--- a/custom_components/beatify/playlists/world-cup-anthems.json
+++ b/custom_components/beatify/playlists/world-cup-anthems.json
@@ -1,6 +1,6 @@
 {
   "name": "World Cup Anthems",
-  "version": "1.8",
+  "version": "1.9",
   "tags": [
     "world-cup",
     "fifa",
@@ -157,11 +157,11 @@
       "awards_es": [],
       "awards_fr": [],
       "awards_nl": [],
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/1673292415",
       "uri_youtube_music": "https://music.youtube.com/watch?v=Xp1HKM1WGXU",
       "uri_tidal": null,
-      "uri_deezer": null,
-      "isrc": null,
+      "uri_deezer": "deezer://track/2160233807",
+      "isrc": "USCGJ2341061",
       "uri_apple_music_by_region": {}
     },
     {

--- a/custom_components/beatify/playlists/world-cup-anthems.json
+++ b/custom_components/beatify/playlists/world-cup-anthems.json
@@ -1,6 +1,6 @@
 {
   "name": "World Cup Anthems",
-  "version": "1.9",
+  "version": "1.10",
   "tags": [
     "world-cup",
     "fifa",
@@ -99,7 +99,7 @@
       "fun_fact_es": "La selección de Alemania Occidental grabó este himno antes de ganar el Mundial en casa en 1974.",
       "fun_fact_fr": "L'équipe d'Allemagne de l'Ouest enregistra cet hymne avant de remporter la Coupe du monde 1974 à domicile.",
       "fun_fact_nl": "Het West-Duitse elftal nam dit anthem op en won vervolgens het WK 1974 op eigen bodem.",
-      "uri": null,
+      "uri": "spotify:track:45jKsyqbTncdrq00gMIKUL",
       "chart_info": {},
       "certifications": [],
       "awards": [],
@@ -111,7 +111,7 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=HYDN6yq8nm4",
       "uri_tidal": "tidal://track/13342489",
       "uri_deezer": "deezer://track/7558171",
-      "isrc": null,
+      "isrc": "DEF067312220",
       "uri_apple_music_by_region": {}
     },
     {


### PR DESCRIPTION
Markus hat den Spotify-Link geschickt, damit schließt sich eine der sieben Lücken aus [bewusste-provider-luecken](https://github.com/mholzi/beatify/issues).

## Was sich ändert

`uri` bei **Los Ramblers — El Rock del Mundial (1962)** von `null` auf `spotify:track:4GxsXEhvOhmp2M2aAtKMRl`. Playlist-`version` 1.7 → 1.8.

## Warum es dieselbe Aufnahme ist

Nicht angenommen, sondern gemessen:

| | Spotify | Apple (962309785, schon im Katalog) |
|---|---|---|
| Titel | El Rock del Mundial | El Rock del Mundial |
| Interpret | Ramblers | Ramblers |
| Album | South American Rock Vol. 1 | South American Rock Vol. 1 |
| Spielzeit | **163.723 ms** | **163.723 ms** |

Millisekundengleiche Spielzeit auf derselben Zusammenstellung — kein Cover, kein Re-Recording.

## Warum das Jahr 1962 bleibt

Spotify weist als Release **2015** aus. Das ist das Datum der Zusammenstellung, nicht der Aufnahme. Nach der Beatify-Konvention zählt das Original-Release des Songs, und das ist die WM 1962 in Chile.

## Der eigentliche Befund

Am 11.08. wurde jeder der sieben Songs einzeln über Odesli aufgelöst, Ergebnis „kein Spotify-Treffer". Für diesen Song war das **falsch**. Damit bestätigt sich der bereits dokumentierte Vorbehalt: **ein positiver Odesli-Treffer ist belastbar, eine Abwesenheit nicht.** Ob auch die übrigen sechs False Negatives sind, ist offen — eine Spotify-Suche steht dem Bot mangels Zugangsdaten nicht zur Verfügung.

## Wirkung

Der Song fällt für Spotify-Nutzer nicht mehr aus `filter_songs_for_provider`. Die Playlist geht für sie von 19 auf **20 von 26** Songs.

Schema-Gate lokal grün (55/55 valide).