### PR TITLE
data(greatest-metal-songs): tote YouTube-URI für System of a Down „Toxicity" ersetzt

### DIFF
--- a/custom_components/beatify/playlists/community/greatest-metal-songs.json
+++ b/custom_components/beatify/playlists/community/greatest-metal-songs.json
@@ -1,6 +1,6 @@
 {
   "name": "Greatest Metal Songs of All Time 🤘",
-  "version": "1.13",
+  "version": "1.14",
   "tags": [
     "metal",
     "rock",
@@ -785,7 +785,7 @@
       "fun_fact_es": "Toxicity es el tema comercialmente más exitoso de System of a Down. El álbum homónimo debutó en el número uno en EE.UU. y Reino Unido simultáneamente. La mezcla única de influencias folk armenias, thrash metal y rock alternativo los distinguió de todas las demás bandas de su época.",
       "fun_fact_fr": "Toxicity est le titre commercialement le plus réussi de System of a Down. L'album éponyme a débuté simultanément à la première place aux États-Unis et au Royaume-Uni. Le mélange unique d'influences folk arméniennes, de thrash metal et de rock alternatif les a distingués de tous les autres groupes de leur époque.",
       "uri_apple_music": "applemusic://track/273714713",
-      "uri_youtube_music": "https://music.youtube.com/watch?v=1yw1Tgj9-VU",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=mUEsqQpact0",
       "uri_tidal": "tidal://track/4085527",
       "fun_fact_nl": "Toxicity is het meest commercieel succesvolle nummer van System of a Down, waarvan de titel verwijst naar het giftige milieu van de moderne samenleving. Het gelijknamige album debuteerde gelijktijdig op nummer één in de VS en het VK. De unieke mix van Armeense folk-invloeden, thrash metal en alternatieve rock onderscheidt de band van alle andere bands uit hun tijd.",
       "awards_nl": [


### PR DESCRIPTION
## Was kaputt war

`uri_youtube_music` von **System of a Down — Toxicity** zeigte auf Video `1yw1Tgj9-VU`. Das ist nicht mehr abspielbar.

Geprüft, statt aus einem 403 geschlossen: die Watch-Seite antwortet mit HTTP 200, aber `playabilityStatus: LOGIN_REQUIRED` und dem Grund **„Privates Video"**. Das Video wurde auf privat gestellt. Es ist also kein bloßes Embed-Verbot, sondern für die Wiedergabe tot.

## Der Ersatz

`mUEsqQpact0` vom Kanal **„System of A Down - Topic"** — der automatisch erzeugte offizielle Art-Track von YouTube Music. Dieselbe Herkunftsart, die 52 % der YouTube-URIs im Katalog ohnehin haben, und die haltbarste: ein Topic-Track verschwindet praktisch nie, ein Privat-Upload jederzeit.

## Beleg für dieselbe Aufnahme

| Quelle | Spielzeit |
|---|---|
| YouTube `mUEsqQpact0` | PT3M39S = 219.000 ms |
| Apple `273714713` (schon im Katalog) | 218.933 ms |

Die 67 ms Abweichung sind die Sekundenrundung der YouTube-API.

## Wie es aufgefallen ist

In einer Stichprobe von **250 der 5525** YouTube-URIs war dies der **einzige** tote Treffer. Hochgerechnet stehen damit **rund 20 tote YouTube-URIs** im Katalog, die übrigen sind nicht gesucht worden. Ein vollständiger Durchlauf über alle 5525 wäre die naheliegende Folgearbeit.

Playlist-`version` 1.13 auf 1.14. Schema-Gate lokal grün, 55/55.
