### PR TITLE
feat(backfill): Per-Provider-Miss-Cache für Apple, Deezer und YouTube

### DIFF
--- a/.claude/skills/provider-uri-backfill/scripts/backfill_provider_uris.py
+++ b/.claude/skills/provider-uri-backfill/scripts/backfill_provider_uris.py
@@ -45,6 +45,7 @@ from __future__ import annotations
 
 import argparse
 import json
+from datetime import datetime, timezone
 import importlib.util
 import os
 import re
@@ -525,6 +526,129 @@ def save_state(path: Path, yt: YouTubeBudget) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Per-Provider-Miss-Cache (pure, unit-tested)
+#
+# Bis 2026-08-13 fragten Apple, Deezer und YouTube bei JEDEM Lauf jeden noch
+# offenen Song erneut bei Odesli ab. `backfill_tidal.py` merkt sich seit jeher,
+# welche Tracks der Anbieter nachweislich nicht hat, und ueberspringt sie —
+# hier fehlte das Gegenstueck, und die Laeufe verbrannten ihr Odesli-Kontingent
+# auf Absagen, die schon bekannt waren.
+#
+# Zwei Eigenheiten, die den Cache von backfill_tidal.py unterscheiden:
+#
+#   1. **Pro Provider, nicht pro Track.** Ein Song kann bei Deezer fehlen und
+#      bei Apple existieren. Ein Cache auf Track-Ebene wuerde die noch
+#      offenen Provider desselben Songs mit abwuergen.
+#   2. **Nur eintragen, was wirklich versucht wurde.** Ist Odesli nicht
+#      erreichbar (429, Netzfehler -> ``payload is None``), darf KEIN Miss
+#      geschrieben werden. Sonst wird aus "gerade gesperrt" dauerhaft "gibt es
+#      nicht" — genau der Fehler, den backfill_tidal.py im Kopf seiner Datei
+#      ausdruecklich ausschliesst.
+#
+# Anders als bei Tidal verfaellt ein Miss hier nach ``--miss-ttl-days`` (Vorgabe
+# 90). Ein Anbieter, der einen Song spaeter aufnimmt, wird dadurch von selbst
+# wiedergefunden.
+# ---------------------------------------------------------------------------
+MISS_TTL_DAYS_DEFAULT = 90
+
+
+def load_provider_misses(path: Path) -> dict:
+    """Return the per-provider miss map from the shared state file."""
+    if not path.exists():
+        return {}
+    try:
+        data = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return {}
+    misses = data.get("provider_misses")
+    return misses if isinstance(misses, dict) else {}
+
+
+def save_provider_misses(path: Path, misses: dict) -> None:
+    """Persist the miss map, leaving every other key of the file untouched."""
+    data = {}
+    if path.exists():
+        try:
+            data = json.loads(path.read_text())
+        except (OSError, json.JSONDecodeError):
+            data = {}
+    data["provider_misses"] = misses
+    path.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n")
+
+
+def _miss_is_fresh(stamp: str, now: datetime, ttl_days: int) -> bool:
+    """True if ``stamp`` is a parsable timestamp within ``ttl_days`` of now."""
+    if ttl_days <= 0:
+        return True
+    try:
+        then = datetime.strptime(stamp, "%Y-%m-%dT%H:%MZ")
+    except (TypeError, ValueError):
+        return False  # unparsable -> treat as expired, i.e. query again
+    return (now - then).days < ttl_days
+
+
+def filter_cached_misses(
+    gaps: list[str],
+    uri: str,
+    misses: dict,
+    now: datetime,
+    ttl_days: int = MISS_TTL_DAYS_DEFAULT,
+    retry_misses: bool = False,
+) -> list[str]:
+    """Drop providers already recorded as a fresh miss for ``uri``.
+
+    Returns the gaps still worth querying. ``retry_misses`` disables the cache
+    entirely; an expired or unparsable entry is treated as "ask again".
+    """
+    if retry_misses or not gaps:
+        return list(gaps)
+    entry = misses.get(uri) or {}
+    return [g for g in gaps if not _miss_is_fresh(entry.get(g, ""), now, ttl_days)]
+
+
+# Provider, die auch ohne Odesli einen eigenen Aufloesungsweg haben:
+# Apple ueber die iTunes-Suche, Deezer ueber ISRC bzw. Deezer-Suche.
+# Beide stehen im Code ausserhalb des ``payload``-Blocks.
+ODESLI_INDEPENDENT = ("apple_music", "deezer")
+
+
+def attempted_providers(non_yt_gaps: list[str], odesli_ok: bool) -> list[str]:
+    """Welche Provider wurden in diesem Durchgang wirklich befragt?
+
+    Antwortet Odesli (``odesli_ok``), gilt das fuer alle offenen Provider.
+    Ist Odesli nicht erreichbar, wurden nur die beiden Wege gegangen, die
+    unabhaengig davon laufen — fuer alle anderen darf KEIN Miss entstehen,
+    sonst wird aus einer Sperre eine dauerhafte Absage.
+    """
+    if odesli_ok:
+        return list(non_yt_gaps)
+    return [g for g in non_yt_gaps if g in ODESLI_INDEPENDENT]
+
+
+def record_provider_misses(
+    misses: dict,
+    uri: str,
+    attempted: list[str],
+    song: dict,
+    now: datetime,
+) -> int:
+    """Record a miss for every attempted provider still unfilled. Returns count.
+
+    ``attempted`` must contain only providers that were genuinely queried this
+    run — never ones skipped because the source was unavailable.
+    """
+    stamp = now.strftime("%Y-%m-%dT%H:%MZ")
+    n = 0
+    for prov in attempted:
+        field = PROVIDER_FIELDS.get(prov)
+        if not field or (song.get(field) or "").strip():
+            continue
+        misses.setdefault(uri, {})[prov] = stamp
+        n += 1
+    return n
+
+
+# ---------------------------------------------------------------------------
 # HTTP helpers (network; mocked in tests)
 # ---------------------------------------------------------------------------
 def _http_get_json(url: str, timeout: int = 30) -> dict:
@@ -892,6 +1016,14 @@ def run(args: argparse.Namespace) -> int:
     deadline = time.monotonic() + args.max_minutes * 60 if args.max_minutes else None
     stop_reason: str | None = None
 
+    # Per-Provider-Miss-Cache: einmal je Lauf laden, am Ende einmal schreiben.
+    # ``run_now`` ist der feste Bezugspunkt fuer Ablauf und Zeitstempel, damit
+    # ein langer Lauf nicht mitten drin die TTL-Grenze verschiebt.
+    provider_misses = load_provider_misses(state_path)
+    run_now = datetime.now(timezone.utc).replace(tzinfo=None)
+    miss_skipped = 0
+    miss_recorded = 0
+
     for path in playlist_paths:
         if stop_reason:
             break
@@ -913,6 +1045,21 @@ def run(args: argparse.Namespace) -> int:
             sid = spotify_track_id(song.get("uri"))
             gaps = song_gaps(song)
             if not sid or not gaps:
+                continue
+            # Provider ueberspringen, deren Absage schon bekannt und noch frisch
+            # ist. Bleibt nichts uebrig, ist der Song fuer diesen Lauf erledigt,
+            # ohne einen einzigen Odesli-Aufruf zu kosten.
+            song_uri = (song.get("uri") or "").strip()
+            gaps = filter_cached_misses(
+                gaps,
+                song_uri,
+                provider_misses,
+                run_now,
+                ttl_days=args.miss_ttl_days,
+                retry_misses=args.retry_misses,
+            )
+            if not gaps:
+                miss_skipped += 1
                 continue
 
             song_dirty = False
@@ -975,6 +1122,15 @@ def run(args: argparse.Namespace) -> int:
                         song["uri_deezer"] = deezer_uri(did)
                         cov.filled_this_run["deezer"] += 1
                         song_dirty = True
+                # Miss nur fuer Provider vormerken, die wirklich befragt
+                # wurden. War Odesli nicht erreichbar (``payload is None``),
+                # gilt das ausschliesslich fuer die beiden Wege, die davon
+                # unabhaengig laufen: Apples iTunes-Suche und Deezers
+                # ISRC-/Such-Fallback.
+                attempted = attempted_providers(non_yt_gaps, payload is not None)
+                miss_recorded += record_provider_misses(
+                    provider_misses, song_uri, attempted, song, run_now
+                )
                 time.sleep(args.odesli_sleep)
 
             # ---- YouTube Data API search.list (resume-cursor + daily budget) ----
@@ -1018,6 +1174,16 @@ def run(args: argparse.Namespace) -> int:
 
     if yt_key:
         save_state(state_path, yt_state)
+    # BEWUSST ausserhalb des ``yt_key``-Blocks: Apple und Deezer laufen mit
+    # ``--youtube-budget 0`` und ohne API-Key. Stuende das Schreiben unter der
+    # Bedingung, wuerde der Cache genau fuer die beiden Agenten nie gefuellt,
+    # fuer die er gebaut wurde.
+    save_provider_misses(state_path, provider_misses)
+    if miss_skipped or miss_recorded:
+        print(
+            f"miss cache: {miss_skipped} song(s) skipped entirely, "
+            f"{miss_recorded} provider miss(es) recorded"
+        )
 
     report = build_report(
         coverages,
@@ -1146,6 +1312,20 @@ def build_arg_parser() -> argparse.ArgumentParser:
         type=float,
         default=0,
         help="stop the run after this many minutes of wall-clock (0 = no limit)",
+    )
+    p.add_argument(
+        "--retry-misses",
+        action="store_true",
+        help="ignore the per-provider miss cache and re-query recorded absences",
+    )
+    p.add_argument(
+        "--miss-ttl-days",
+        type=int,
+        default=MISS_TTL_DAYS_DEFAULT,
+        help=(
+            "days a recorded miss stays binding before it is retried "
+            f"(default: {MISS_TTL_DAYS_DEFAULT}; 0 = never expire)"
+        ),
     )
     return p
 

--- a/tests/unit/test_provider_uri_backfill.py
+++ b/tests/unit/test_provider_uri_backfill.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import importlib.util
 import json
 import sys
+from datetime import datetime, timedelta
 from pathlib import Path
 
 import pytest
@@ -1341,3 +1342,127 @@ def test_deezer_isrc_wins_over_search(tmp_path, monkeypatch):
         == "deezer://track/3606658082"
     )
     assert searched == []  # search never consulted
+
+
+# ---------------------------------------------------------------------------
+# Per-Provider-Miss-Cache (13.08.2026)
+#
+# Kernzusage: was einmal nachweislich fehlt, wird nicht erneut abgefragt — aber
+# eine Sperre darf NIE als Absage durchgehen, und ein Miss verfaellt.
+# ---------------------------------------------------------------------------
+_NOW = datetime(2026, 8, 13, 10, 0)
+
+
+def _stamp(days_ago: int) -> str:
+    return (_NOW - timedelta(days=days_ago)).strftime("%Y-%m-%dT%H:%MZ")
+
+
+def test_filter_cached_misses_drops_fresh_miss():
+    misses = {"spotify:track:A": {"deezer": _stamp(1)}}
+    got = bf.filter_cached_misses(
+        ["deezer", "apple_music"], "spotify:track:A", misses, _NOW
+    )
+    assert got == ["apple_music"]
+
+
+def test_filter_cached_misses_keeps_other_providers_of_same_track():
+    """Ein Miss bei Deezer darf Apple desselben Songs nicht mit abwuergen."""
+    misses = {"spotify:track:A": {"deezer": _stamp(1)}}
+    got = bf.filter_cached_misses(
+        ["apple_music", "tidal", "deezer"], "spotify:track:A", misses, _NOW
+    )
+    assert got == ["apple_music", "tidal"]
+
+
+def test_filter_cached_misses_expires_after_ttl():
+    misses = {"spotify:track:A": {"deezer": _stamp(120)}}
+    got = bf.filter_cached_misses(
+        ["deezer"], "spotify:track:A", misses, _NOW, ttl_days=90
+    )
+    assert got == ["deezer"]
+
+
+def test_filter_cached_misses_ttl_zero_never_expires():
+    misses = {"spotify:track:A": {"deezer": _stamp(9999)}}
+    got = bf.filter_cached_misses(
+        ["deezer"], "spotify:track:A", misses, _NOW, ttl_days=0
+    )
+    assert got == []
+
+
+def test_filter_cached_misses_retry_flag_ignores_cache():
+    misses = {"spotify:track:A": {"deezer": _stamp(1)}}
+    got = bf.filter_cached_misses(
+        ["deezer"], "spotify:track:A", misses, _NOW, retry_misses=True
+    )
+    assert got == ["deezer"]
+
+
+def test_filter_cached_misses_unparsable_stamp_is_retried():
+    misses = {"spotify:track:A": {"deezer": "kaputt"}}
+    got = bf.filter_cached_misses(["deezer"], "spotify:track:A", misses, _NOW)
+    assert got == ["deezer"]
+
+
+def test_record_provider_misses_only_for_unfilled():
+    song = {"uri_deezer": "deezer://track/1"}
+    misses = {}
+    n = bf.record_provider_misses(
+        misses, "spotify:track:A", ["deezer", "apple_music"], song, _NOW
+    )
+    assert n == 1
+    assert list(misses["spotify:track:A"]) == ["apple_music"]
+
+
+def test_record_provider_misses_records_nothing_when_all_filled():
+    song = {"uri_deezer": "deezer://track/1", "uri_apple_music": "applemusic://track/2"}
+    misses = {}
+    n = bf.record_provider_misses(
+        misses, "spotify:track:A", ["deezer", "apple_music"], song, _NOW
+    )
+    assert n == 0
+    assert misses == {}
+
+
+def test_record_provider_misses_ignores_empty_string_field():
+    song = {"uri_deezer": "   "}
+    misses = {}
+    bf.record_provider_misses(misses, "spotify:track:A", ["deezer"], song, _NOW)
+    assert "deezer" in misses["spotify:track:A"]
+
+
+def test_miss_cache_roundtrip_preserves_other_state_keys(tmp_path):
+    """save_provider_misses darf den YouTube-Budgetblock nicht zerstoeren."""
+    p = tmp_path / "state.json"
+    p.write_text(json.dumps({"youtube": {"budget": 90, "cursor": 7}}))
+    bf.save_provider_misses(p, {"spotify:track:A": {"deezer": _stamp(0)}})
+    data = json.loads(p.read_text())
+    assert data["youtube"] == {"budget": 90, "cursor": 7}
+    assert bf.load_provider_misses(p) == {"spotify:track:A": {"deezer": _stamp(0)}}
+
+
+def test_load_provider_misses_tolerates_missing_and_broken_file(tmp_path):
+    assert bf.load_provider_misses(tmp_path / "fehlt.json") == {}
+    bad = tmp_path / "kaputt.json"
+    bad.write_text("{nicht json")
+    assert bf.load_provider_misses(bad) == {}
+
+
+def test_attempted_providers_with_odesli_covers_all_gaps():
+    assert bf.attempted_providers(["apple_music", "tidal", "deezer"], True) == [
+        "apple_music",
+        "tidal",
+        "deezer",
+    ]
+
+
+def test_attempted_providers_without_odesli_excludes_tidal():
+    """Die Kernregel: eine Odesli-Sperre darf NIE zu einem Tidal-Miss werden."""
+    assert bf.attempted_providers(["apple_music", "tidal", "deezer"], False) == [
+        "apple_music",
+        "deezer",
+    ]
+
+
+def test_attempted_providers_without_odesli_and_only_tidal_is_empty():
+    assert bf.attempted_providers(["tidal"], False) == []


### PR DESCRIPTION
## Warum

`backfill_tidal.py` merkt sich seit jeher pro Track, welche Songs Tidal nachweislich nicht hat, und fragt sie nicht erneut ab. Für **Apple, Deezer und YouTube** fehlte dieses Gegenstück: `backfill_provider_uris.py` fragte bei **jedem** Lauf jeden noch offenen Song erneut bei Odesli an.

Gemessen am 13.08.2026: Deezer steht bei 98,7 % Abdeckung mit 78 Restlücken, Tidal bei 97,4 % mit 143. Von den Tidal-Restlücken sind **126 bestätigte Odesli-Misses** — genau die Art Absage, die ein Lauf nicht immer wieder neu einholen muss. Odesli ist dabei die knappe Ressource: alle vier Agenten teilen sich dieselbe Quote, und an diesem Vormittag lieferte sie mehrfach `429`.

## Was dazukommt

Ein Miss-Cache im bestehenden State-File, unter dem neuen Schlüssel `provider_misses`:

```json
"provider_misses": {
  "spotify:track:0snQ…": {"deezer": "2026-08-13T10:31Z"}
}
```

Vier reine, unit-getestete Funktionen: `load_provider_misses`, `save_provider_misses`, `filter_cached_misses`, `record_provider_misses`, dazu `attempted_providers`.

## Zwei Unterschiede zu backfill_tidal.py, die nicht offensichtlich sind

**1. Der Cache greift pro Provider, nicht pro Track.** Ein Song kann bei Deezer fehlen und bei Apple existieren. Ein Cache auf Track-Ebene hätte die noch offenen Provider desselben Songs mit abgewürgt. Der Test `test_filter_cached_misses_keeps_other_providers_of_same_track` pinnt das fest.

**2. Ein Miss verfällt.** Vorgabe 90 Tage, einstellbar über `--miss-ttl-days`, `0` schaltet den Verfall ab. Bei Tidal binden Einträge unbefristet — die 50 `anime-openings`-Misses stammen vom 14. Juli und gelten bis heute. Nimmt ein Anbieter einen Song später auf, findet der Backfill ihn so von selbst wieder.

## Die Regel, auf die es ankommt

Ein Miss wird **nur** für Provider geschrieben, die auch wirklich befragt wurden.

Ist Odesli nicht erreichbar (`payload is None` nach 429 oder Netzfehler), gilt das ausschließlich für Apple und Deezer — die beiden haben mit der iTunes-Suche und der ISRC-/Deezer-Suche eigene Wege, die außerhalb des `payload`-Blocks laufen. Für Tidal und YouTube entsteht in diesem Fall **kein** Eintrag.

Ohne diese Trennung würde aus „gerade gesperrt" ein dauerhaftes „gibt es nicht". `backfill_tidal.py` schließt genau das im Kopf seiner Datei aus, und die Regel ist hier über `attempted_providers` festgeschrieben und getestet.

Das ist keine graue Theorie: der End-to-End-Rauchtest während der Entwicklung lief selbst in einen Odesli-`429` und schrieb daraufhin **null** Einträge — der Schutz hat auf Anhieb gegriffen.

## Neue Optionen

- `--retry-misses` ignoriert den Cache vollständig, gleiche Semantik wie in `backfill_tidal.py`
- `--miss-ttl-days N` setzt die Verfallsfrist

## Ein Detail beim Speichern

`save_provider_misses` steht bewusst **außerhalb** des `if yt_key:`-Blocks, unter dem `save_state` sitzt. Apple und Deezer laufen mit `--youtube-budget 0` und ohne API-Key; stünde das Schreiben unter dieser Bedingung, würde der Cache genau für die beiden Agenten nie gefüllt, für die er gebaut wurde.

## Prüfung

- **85 Tests** in `test_provider_uri_backfill.py`, davon **14 neu**; die volle Suite `tests/unit/` läuft mit **1725** grün durch
- `ruff check .` und `ruff format --check .` sauber
