### PR TITLE
chore(playlists): deezer backfill — +8 deezer uris

### DIFF
--- a/custom_components/beatify/playlists/community/eurodance-90s.json
+++ b/custom_components/beatify/playlists/community/eurodance-90s.json
@@ -1,6 +1,6 @@
 {
   "name": "Eurodance 90s 💥",
-  "version": "1.10",
+  "version": "1.11",
   "tags": [
     "1990s",
     "eurodance",
@@ -85,7 +85,8 @@
         "es": "applemusic://track/1673414298",
         "nl": "applemusic://track/1673414298",
         "it": "applemusic://track/1673414298"
-      }
+      },
+      "uri_deezer": "deezer://track/13185277"
     },
     {
       "year": 1994,
@@ -196,7 +197,8 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=NrVqLGQlieA",
       "uri_deezer": "deezer://track/89629717",
       "fun_fact_nl": "Eiffel 65's 'Blue' stond bovenaan de hitlijsten in 17 landen. De zwaar met autotune bewerkte zang en de repetitieve hook maakten het zowel geliefd als bespot, en het werd een bepalend geluid voor de Eurodance van de late jaren '90.",
-      "awards_nl": []
+      "awards_nl": [],
+      "uri_tidal": "tidal://track/539111445"
     },
     {
       "year": 1995,
@@ -436,7 +438,8 @@
         "es": "applemusic://track/1673414696",
         "nl": "applemusic://track/1673414696",
         "it": "applemusic://track/1673414696"
-      }
+      },
+      "uri_deezer": "deezer://track/13185278"
     },
     {
       "year": 1993,
@@ -466,7 +469,8 @@
       "uri_tidal": "tidal://track/14237868",
       "uri_deezer": "deezer://track/17347911",
       "fun_fact_nl": "Culture Beats 'Mr. Vain' stond 4 weken bovenaan de Britse hitlijsten en verkocht wereldwijd meer dan 9 miljoen exemplaren. Het blijft een van de grootste Eurodance-hits van de jaren '90.",
-      "awards_nl": []
+      "awards_nl": [],
+      "uri_apple_music": "applemusic://track/505475126"
     },
     {
       "year": 1998,
@@ -771,7 +775,8 @@
       "uri_deezer": "deezer://track/7537488",
       "fun_fact_nl": "De inzending van Gina G voor het Eurovisie Songfestival namens het VK werd een nummer 1-hit en was een zeldzaam crossover-succes tussen het Songfestival en Eurodance.",
       "awards_nl": [],
-      "uri_tidal": "tidal://track/4343025"
+      "uri_tidal": "tidal://track/4343025",
+      "uri_apple_music": "applemusic://track/401123583"
     },
     {
       "year": 1994,
@@ -1276,7 +1281,8 @@
       "uri_tidal": "tidal://track/281797602",
       "uri_deezer": "deezer://track/91348522",
       "fun_fact_nl": "Robert Miles' 'Children' wordt toegeschreven aan het populair maken van dream trance/dream house. De Italiaanse producent zei dat hij het schreef als protest tegen rijden onder invloed, nadat hij clubbezoekers dronken naar huis had zien rijden.",
-      "awards_nl": []
+      "awards_nl": [],
+      "uri_apple_music": "applemusic://track/1499501875"
     },
     {
       "year": 1995,
@@ -1738,7 +1744,8 @@
       "uri_tidal": "tidal://track/65545333",
       "uri_deezer": "deezer://track/133204794",
       "fun_fact_nl": "De opvolger van Sash! op 'Encore Une Fois' zette hun door trance beïnvloede Eurodance-geluid voort met panfluit-samples die een exotische sfeer creëerden.",
-      "awards_nl": []
+      "awards_nl": [],
+      "uri_apple_music": "applemusic://track/1160359227"
     },
     {
       "year": 1995,
@@ -2350,7 +2357,8 @@
       "uri_tidal": "tidal://track/34588804",
       "uri_deezer": "deezer://track/1538974072",
       "fun_fact_nl": "De virale hit van O-Zone werd een wereldwijd internetfenomeen door de 'Numa Numa'-video. De aanstekelijke Roemeense tekst van de Moldavische popgroep maakte het tot een van de meest herkende nummers ter wereld.",
-      "awards_nl": []
+      "awards_nl": [],
+      "uri_apple_music": "applemusic://track/1593081404"
     },
     {
       "year": 1995,
@@ -2425,7 +2433,8 @@
         "es": "applemusic://track/1874296691",
         "nl": "applemusic://track/1790923405",
         "it": "applemusic://track/1874296691"
-      }
+      },
+      "uri_deezer": "deezer://track/604175"
     },
     {
       "year": 1995,
@@ -2615,7 +2624,8 @@
       "uri_tidal": "tidal://track/181883955",
       "uri_deezer": "deezer://track/6907036",
       "fun_fact_nl": "De debuutsingle van Whigfield stond bovenaan de hitlijsten in 17 landen en veroorzaakte een dansrage. Het nummer werd oorspronkelijk uitgebracht in Italië, waar het een zomerhit werd voordat het zich wereldwijd verspreidde.",
-      "awards_nl": []
+      "awards_nl": [],
+      "uri_apple_music": "applemusic://track/79145702"
     },
     {
       "year": 1995,
@@ -2692,7 +2702,8 @@
         "nl": "applemusic://track/1674650427",
         "it": "applemusic://track/1674650427"
       },
-      "uri_tidal": "tidal://track/279180978"
+      "uri_tidal": "tidal://track/279180978",
+      "uri_deezer": "deezer://track/2168800397"
     },
     {
       "year": 1995,
@@ -2796,7 +2807,8 @@
       "fun_fact_fr": "L'hymne trance de Sash! est devenu l'un des morceaux phares de la musique dance européenne de la fin des années 90, sublimé par des voix françaises envoûtantes.",
       "uri_deezer": "deezer://track/133204792",
       "fun_fact_nl": "Het trance-anthem van Sash! werd een van de bepalende nummers van de Europese dansmuziek van eind jaren 90, met beklijvende Franse vocalen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "uri_apple_music": "applemusic://track/1164431858"
     },
     {
       "year": 1995,
@@ -3155,7 +3167,9 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=G5EEIy9hLyY",
       "uri_tidal": "tidal://track/3551603",
       "fun_fact_nl": "De grootste hit van 2 Unlimited stond bovenaan de hitlijsten in heel Europa en er werden meer dan 2,8 miljoen exemplaren van verkocht. De meedogenloze energie en 'No no limits!'-hook maakten het een typische Eurodance-track.",
-      "awards_nl": []
+      "awards_nl": [],
+      "uri_apple_music": "applemusic://track/1541663058",
+      "uri_deezer": "deezer://track/134706074"
     },
     {
       "year": 1995,
@@ -3335,7 +3349,8 @@
       "uri_tidal": "tidal://track/65545336",
       "uri_deezer": "deezer://track/133204800",
       "fun_fact_nl": "Tina Cousins' samenwerking met Sash! werd een enorme trance-Eurodance crossover hit met haar etherische vocalen en stuwende productie.",
-      "awards_nl": []
+      "awards_nl": [],
+      "uri_apple_music": "applemusic://track/1171882165"
     },
     {
       "year": 1995,
@@ -3401,7 +3416,9 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=R0u7TpMFC2o",
       "uri_tidal": "tidal://track/3551601",
       "fun_fact_nl": "De stadionhymne van 2 Unlimited werd een vaste waarde tijdens sportevenementen en wordt tientallen jaren later nog steeds gedraaid tijdens wedstrijden over de hele wereld. De agressieve energie van het nummer maakte het perfect voor oppepmomenten.",
-      "awards_nl": []
+      "awards_nl": [],
+      "uri_apple_music": "applemusic://track/389498081",
+      "uri_deezer": "deezer://track/1484325492"
     },
     {
       "year": 1995,
@@ -3514,7 +3531,8 @@
         "es": "applemusic://track/395663450",
         "nl": "applemusic://track/395663450",
         "it": "applemusic://track/395663450"
-      }
+      },
+      "uri_deezer": "deezer://track/51734121"
     },
     {
       "year": 1995,
@@ -3734,7 +3752,8 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=TmphqZVyGsI",
       "uri_tidal": "tidal://track/3551604",
       "fun_fact_nl": "2 Unlimited's opvolger van 'No Limit' zette hun energieke Eurodance-formule voort met op tribals geïnspireerde beats.",
-      "awards_nl": []
+      "awards_nl": [],
+      "uri_deezer": "deezer://track/77198154"
     },
     {
       "year": 1995,


### PR DESCRIPTION
Ein Lauf des `provider-uri-backfill` mit Schwerpunkt Deezer, automatisch gefahren von `com.beatify.deezer-backfill`.

- `eurodance-90s` Deezer 91 -> **99**/100

Nebenbei mitgefuellt, weil Odesli alle Provider in einer Antwort liefert: tidal +1, apple +10.

**Draft mit Absicht** — Merge nur nach Markus' Freigabe. Fuer diesen Agenten gibt es bewusst KEINEN Automerge.