### PR TITLE
chore(playlists): youtube backfill — +24 youtube uris

### DIFF
--- a/custom_components/beatify/playlists/community/finnish-iskelma-classics.json
+++ b/custom_components/beatify/playlists/community/finnish-iskelma-classics.json
@@ -1,6 +1,6 @@
 {
   "name": "Finnish Schlager Classics 🇫🇮",
-  "version": "1.24",
+  "version": "1.29",
   "tags": [
     "finnish",
     "iskelma",
@@ -244,7 +244,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=RhDz2PSWd-g",
       "uri_tidal": "tidal://track/388043",
       "uri_deezer": "deezer://track/3597029",
       "fun_fact": "Annikki Tähti's 'Muistatko Monrepos'n' (Do You Remember Monrepos?) refers to the famous Monrepos landscape park in Vyborg, a Finnish city lost to the Soviet Union; the song carries profound Karelian nostalgia for many Finnish listeners.",
@@ -274,7 +274,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=dKuMVJkyVZc",
       "uri_tidal": "tidal://track/1578352",
       "uri_deezer": "deezer://track/67739759",
       "fun_fact": "Brita Koivunen's Finnish cover of 'Mama's Pearls' made her one of Finland's first teenage pop sensations in the mid-1950s; she later represented Finland at Eurovision 1961 with 'Valoa ikkunassa'.",
@@ -304,7 +304,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=bcKmEgLyuj8",
       "uri_tidal": "tidal://track/21018871",
       "uri_deezer": "deezer://track/117675224",
       "fun_fact": "Olavi Virta's 'Hurmio' (Rapture) showcases his ability to convey ecstatic joy — a counterpoint to the melancholic tangos of his era; Virta's range from sorrow to delight made him Finland's most complete popular singer.",
@@ -334,7 +334,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=sPijX9lVUmE",
       "uri_tidal": "tidal://track/147305933",
       "uri_deezer": "deezer://track/1010527632",
       "fun_fact": "Brita Koivunen's 'Sä kaunehin oot' (You Are the Most Beautiful) exemplifies the youthful pop sound she pioneered in 1950s Finland; Koivunen debuted as a teenager and quickly became one of Finland's most adored singing stars.",
@@ -364,7 +364,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=AtNBDBz_Ftk",
       "uri_tidal": "tidal://track/21064094",
       "uri_deezer": "deezer://track/1231017842",
       "fun_fact": "Olavi Virta's 'Sen tuuli häivyttää' (The Wind Will Carry It Away) speaks to a generation of Finns rebuilding after World War II; Virta's recordings of loss and fading memory held particularly deep resonance in post-war Finland.",
@@ -394,7 +394,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=2YEjrD-pamo",
       "uri_tidal": "tidal://track/22989355",
       "uri_deezer": "deezer://track/3596813",
       "fun_fact": "Helena Siltala's 'Tuuli tuo, tuuli vie' (The Wind Brings, the Wind Takes) is a delicate nature metaphor for the passing of love; Siltala was one of the fresh female voices who shaped Finnish popular music in the late 1950s.",
@@ -424,7 +424,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=OwagHwI0jJo",
       "uri_tidal": "tidal://track/1578342",
       "uri_deezer": "deezer://track/3597024",
       "fun_fact": "Olavi Virta's 'Metsäkukkia' (Forest Flowers) is a gentle nature song that shows his more pastoral side; Virta could shift effortlessly between jazz-inflected dance numbers, romantic ballads, and delicate nature songs.",
@@ -454,7 +454,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=wGUQCbrtVZc",
       "uri_tidal": "tidal://track/19170300",
       "uri_deezer": "deezer://track/14956441",
       "fun_fact": "Annikki Tähti's 'Tummat silmät' (Dark Eyes) draws on the Russian romance 'Ochi Chernye', reflecting Finland's complex historical proximity to Russia; Tähti was one of the queens of Finnish iskelmä in the 1950s.",
@@ -484,7 +484,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=WrMrgYKEIEE",
       "uri_tidal": "tidal://track/21045533",
       "uri_deezer": "deezer://track/1010527672",
       "fun_fact": "Brita Koivunen's 'Katinka' shows her versatility in romantic and playful repertoire; she represented Finland at Eurovision 1961 and was one of the first Finnish artists to gain significant international profile through the competition.",
@@ -1024,7 +1024,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=1xgtWNTxAXM",
       "uri_tidal": "tidal://track/20531151",
       "uri_deezer": "deezer://track/3597326",
       "fun_fact": "Katri Helena's 'Puhelinlangat laulaa' (Telephone Wires Sing) became one of her signature hits; she has sold over 3 million records in Finland, making her one of the country's best-selling artists of all time.",
@@ -1054,7 +1054,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=TvhbAh66HZQ",
       "uri_tidal": "tidal://track/1578366",
       "uri_deezer": "deezer://track/67759460",
       "fun_fact": "Markus Allan's 'Liljankukka' (Lily Flower) is a gentle 1960s iskelmä ballad that exemplifies the genre's romantic delicacy; Allan was one of many talented singers who thrived in Finland's rich mid-century popular music scene.",
@@ -1084,7 +1084,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=o74c48Ktw5g",
       "uri_tidal": "tidal://track/20523395",
       "uri_deezer": "deezer://track/67767283",
       "fun_fact": "Tamara Lund's 'Lapin tango' (Lapland Tango) merges two of Finland's most distinctive cultural identities — its tango tradition and the mystical landscape of Lapland; Lund was a respected interpreter of Finnish romantic songs.",
@@ -1114,7 +1114,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Pu_57TlsIOc",
       "uri_tidal": "tidal://track/20534262",
       "uri_deezer": "deezer://track/104155100",
       "fun_fact": "'Isoisän olkihattu' (Grandfather's Straw Hat) is one of Tapio Rautavaara's most enduring songs about rural Finnish nostalgia; its warmth and simplicity made it a staple of Finnish family gatherings for generations.",
@@ -1144,7 +1144,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Uo4SRq-9bco",
       "uri_tidal": "tidal://track/20507837",
       "uri_deezer": "deezer://track/3597708",
       "fun_fact": "Eija Merilä's 'Yö saaristossa' (Night in the Archipelago) evokes Finland's stunning coastal archipelago — a landscape so central to Finnish identity that it features in countless iskelmä songs as a symbol of both beauty and longing.",
@@ -1174,7 +1174,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=5nE2l2iks6Q",
       "uri_tidal": "tidal://track/20489959",
       "uri_deezer": "deezer://track/3595425",
       "fun_fact": "Esko Rahkonen's 'Syvä kuin meri' (Deep as the Sea) uses oceanic metaphor for profound love; Rahkonen was a respected iskelmä singer throughout the 1960s whose recordings of nature-themed love songs remain cherished.",
@@ -1204,7 +1204,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Kc6ptD-rJKc",
       "uri_tidal": "tidal://track/403907",
       "uri_deezer": "deezer://track/3608929",
       "fun_fact": "Esko Rahkonen's 'Hiljainen kylätie' (The Quiet Village Road) paints a pastoral picture of rural Finland; such songs of countryside peace and simplicity were deeply popular in an era when Finland was rapidly urbanising.",
@@ -1224,7 +1224,7 @@
       "awards": [],
       "awards_nl": [],
       "isrc": "FIFMF6500016",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/308006509",
       "uri_apple_music_by_region": {
         "us": null,
         "de": null,
@@ -1234,7 +1234,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=JIng6IYzyqM",
       "uri_tidal": "tidal://track/19192030",
       "uri_deezer": "deezer://track/6627681",
       "fun_fact": "Seppo Hanski's 'Minä soitan sulle illalla' (I'll Play for You This Evening) is a tender serenade from the romantic innocence of 1950s Finnish pop, before rock and roll began reshaping Finnish youth culture.",
@@ -1264,7 +1264,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=RpytOj472UQ",
       "uri_tidal": "tidal://track/1578377",
       "uri_deezer": "deezer://track/6629324",
       "fun_fact": "Eino Grön's 'Sä kuulut päivään jokaiseen' (You Belong to Every Day) is a warm love declaration; Grön's career spanned over six decades, and he remained one of Finland's most active and beloved performers into his eighties.",
@@ -1318,7 +1318,7 @@
       "awards": [],
       "awards_nl": [],
       "isrc": "FIFMF6600006",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/255924581",
       "uri_apple_music_by_region": {
         "us": null,
         "de": null,
@@ -1328,7 +1328,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=mkEoi-ZpYcU",
       "uri_tidal": "tidal://track/1153629",
       "uri_deezer": "deezer://track/3597819",
       "fun_fact": "Esko Rahkonen's 'Odotin pitkän illan' (I Waited the Long Evening) captures the melancholy of waiting and uncertainty; the long Finnish evening — stretching into darkness in winter — gives this kind of emotional patience a distinctive Nordic quality.",
@@ -1348,7 +1348,7 @@
       "awards": [],
       "awards_nl": [],
       "isrc": "FIFSC6600011",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/655700080",
       "uri_apple_music_by_region": {
         "us": null,
         "de": null,
@@ -1358,7 +1358,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=94Q8OoluUqI",
       "uri_tidal": "tidal://track/20898148",
       "uri_deezer": "deezer://track/3595920",
       "fun_fact": "Laila Kinnunen's 'Muistojen bulevardi' (Memory Boulevard) evokes the bittersweet revisiting of romantic memories; the boulevard as a metaphor for nostalgia connects Finnish iskelmä to wider European chanson and schlager traditions.",
@@ -1388,7 +1388,7 @@
         "nl": "applemusic://track/209280307",
         "it": "applemusic://track/209280307"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=4SIqnLmoNS0",
       "uri_tidal": "tidal://track/20968678",
       "uri_deezer": "deezer://track/864400242",
       "fun_fact": "Olavi Virta's Finnish version of 'Guarda che luna' showcases his mastery of adapting Italian songs; Virta recorded over 800 songs and was so dominant in Finnish music of the 1940s–60s that he is often called 'Finland's Sinatra'.",
@@ -1418,7 +1418,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=6nZcwlEIBWM",
       "uri_tidal": "tidal://track/7986156",
       "uri_deezer": "deezer://track/10260592",
       "fun_fact": "Carola's Finnish version of the German 'Was Ich Dir Sagen Will' demonstrates the multi-lingual crossover of European schlager; Carola was one of several artists who successfully bridged the Finnish and Swedish-speaking music markets.",
@@ -1482,7 +1482,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=jL80eK7w2cg",
       "uri_tidal": "tidal://track/13243730",
       "uri_deezer": "deezer://track/10260597",
       "fun_fact": "Markku Aro's Finnish cover of the French 'Les bicyclettes de Belsize' is a charming example of how French chanson influenced Finnish iskelmä; French songs were widely covered in Finnish during the 1960s.",
@@ -1512,7 +1512,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=tlfjc08v9Ks",
       "uri_tidal": "tidal://track/20905889",
       "uri_deezer": "deezer://track/67726861",
       "fun_fact": "Laila Kinnunen's 'Pieni sydän' (Little Heart) is a tender ballad that shows her gift for conveying vulnerability; Kinnunen's clear soprano and emotional directness made her one of the most beloved female voices of her generation.",


### PR DESCRIPTION
Ein Lauf des `provider-uri-backfill`, automatisch gefahren von `com.beatify.youtube-backfill`.

- `finnish-iskelma-classics` YouTube 219 -> **243**/293

Nebenbei mitgefuellt, weil Odesli alle Provider in einer Antwort liefert: apple +3.

**Draft mit Absicht** — Merge nur nach Markus' Freigabe.