### PR TITLE
fix(manifest): music_assistant in after_dependencies aufnehmen

### DIFF
--- a/custom_components/beatify/manifest.json
+++ b/custom_components/beatify/manifest.json
@@ -2,7 +2,8 @@
   "domain": "beatify",
   "name": "Beatify",
   "after_dependencies": [
-    "cloud"
+    "cloud",
+    "music_assistant"
   ],
   "codeowners": [
     "@mholzi"


### PR DESCRIPTION
Closes #2144.

## Die Änderung

```diff
   "after_dependencies": [
-    "cloud"
+    "cloud",
+    "music_assistant"
   ],
```

## Was sie bewirkt — und was nicht

**Auf `main` allein ändert sich fast nichts.** Beatify importiert hier nirgends aus `homeassistant.components.music_assistant`, sondern spricht Music Assistant ausschließlich über `hass.services.async_call` und `hass.config_entries` an. Hassfest beanstandet also heute nichts, und der Eintrag bewirkt vorerst nur eines: ist Music Assistant installiert, richtet Home Assistant es vor Beatify ein. Das ist für eine Integration, die MA-Dienste aufruft, ohnehin die richtige Reihenfolge.

**Der eigentliche Zweck liegt bei #2141.** Dort steht in `library/ma_client.py` ein echter Direktimport:

```python
from homeassistant.components.music_assistant.helpers import get_music_assistant_client
```

Hassfest wertet das als Nutzung einer anderen Komponente und verlangt die Deklaration. Genau daran ist der Validate-Lauf von #2141 heute früh gescheitert.

**Wichtig für die Erwartung:** dieser PR repariert die CI von #2141 nicht von selbst. Dessen Läufe laufen auf seinem Branch, der diese Zeile erst nach einem Rebase oder Merge aus `main` sieht.

## Warum `after_dependencies` und nicht `dependencies`

`dependencies` würde Music Assistant zur **Pflicht** machen: ohne MA lädt Beatify dann gar nicht mehr. Das trifft jeden, der über Sonos (`_play_via_sonos`) oder Alexa (`_play_via_alexa`) spielt — ein Totalausfall als Nebenwirkung einer Deklaration.

`after_dependencies` ist die weiche Variante: MA wird vorher geladen, **falls** es konfiguriert ist, und fehlt es, startet Beatify normal. Die ausführliche Begründung steht in #2144.

Präzedenzfall im selben Feld: `cloud` steht dort seit jeher.
