### PR TITLE
feat(backfill_apple): Dauer als Zweitmeinung zum Jahres-Gate (#2116)

### DIFF
--- a/scripts/backfill_apple.py
+++ b/scripts/backfill_apple.py
@@ -234,8 +234,103 @@ def release_year(result: dict) -> int | None:
     return None
 
 
+# ---------------------------------------------------------------------------
+# Dauer-Abgleich als Zweitmeinung zum Jahr (#2116)
+#
+# Gemessen am 13.08.2026 an 22 der 58 Jahres-Ablehnungen aus dem Probe-Lauf vom
+# 11./12.08.: bei **14 von 20** auswertbaren Faellen weicht die Spieldauer um
+# hoechstens 2 s ab, bei **8** davon um exakt 0 ms — dieselbe Aufnahme, nur mit
+# anderem Release-Jahr in den Metadaten.
+#
+# Entscheidend ist nicht der Anteil, sondern dass das Jahr nicht trennt: die
+# Abweichungen der 14 richtigen Treffer lauten 2, 2, 2, 2, 2, 3, 3, 4, 7, 9, 14,
+# 19, 34, 43 — und die beiden echten Fehltreffer liegen mit 18 und 23 mitten
+# darin. Eine Abweichung von 43 Jahren gehoerte zu einer millisekundengleichen
+# Aufnahme, eine von 23 Jahren zu einer Live-Fassung mit 38 s Unterschied.
+#
+# Die Toleranz von 2 s ist aus den Daten gegriffen: die Treffergruppe endet bei
+# 920 ms, der naechste Fall beginnt bei 2303 ms. In dieser Luecke liegt die
+# Grenze, sie ist nicht geraten.
+#
+# Die Dauer ersetzt das Jahr NICHT, sie ueberstimmt es nur in eine Richtung:
+# ein Kandidat, den das Jahr verwirft, wird bei passender Dauer doch genommen.
+# Umgekehrt wird nie etwas verworfen, das das Jahr akzeptiert haette.
+# ---------------------------------------------------------------------------
+DURATION_TOLERANCE_MS = 2000
+_SPOTIFY_EMBED = "https://open.spotify.com/embed/track/{}"
+_NEXT_DATA_RE = re.compile(r'<script id="__NEXT_DATA__"[^>]*>(.*?)</script>', re.S)
+
+
+def durations_match(
+    ref_ms: object, cand_ms: object, tolerance_ms: int = DURATION_TOLERANCE_MS
+) -> bool:
+    """True if both durations are known and within ``tolerance_ms``.
+
+    Unknown on either side returns False — eine fehlende Dauer ist kein Beleg
+    fuer Gleichheit, und der Kandidat bleibt dann beim Jahres-Urteil.
+    """
+    if not isinstance(ref_ms, int) or not isinstance(cand_ms, int):
+        return False
+    if ref_ms <= 0 or cand_ms <= 0:
+        return False
+    return abs(ref_ms - cand_ms) <= tolerance_ms
+
+
+def spotify_track_id(uri: object) -> str | None:
+    """Extract the bare track id from ``spotify:track:<id>``."""
+    if not isinstance(uri, str):
+        return None
+    m = re.fullmatch(r"spotify:track:([A-Za-z0-9]{10,})", uri.strip())
+    return m.group(1) if m else None
+
+
+def spotify_duration_ms(uri: object, opener=urllib.request.urlopen) -> int | None:
+    """Read the reference duration from Spotify's public embed page.
+
+    Keyless und nur auf dem Ablehnungspfad aufgerufen: die Dauer wird erst
+    geholt, wenn das Jahres-Gate einen Kandidaten sonst verwerfen wuerde. Bei
+    730 Apple-Luecken betraf das im Probe-Lauf 58 Tracks. Jeder Fehler fuehrt
+    zu ``None``, also zum unveraenderten Jahres-Urteil.
+    """
+    tid = spotify_track_id(uri)
+    if not tid:
+        return None
+    req = urllib.request.Request(
+        _SPOTIFY_EMBED.format(tid), headers={"User-Agent": "Mozilla/5.0"}
+    )
+    try:
+        raw = opener(req, timeout=20).read().decode("utf-8", "replace")
+        m = _NEXT_DATA_RE.search(raw)
+        if not m:
+            return None
+        data = json.loads(m.group(1))
+        dur = data["props"]["pageProps"]["state"]["data"]["entity"]["duration"]
+    except Exception:  # noqa: BLE001 — jede Stoerung faellt auf das Jahr zurueck
+        return None
+    return dur if isinstance(dur, int) and dur > 0 else None
+
+
+def _year_would_reject(track: dict, result: dict, year_tolerance: int) -> bool:
+    """True wenn allein das Jahr diesen Kandidaten verwerfen wuerde.
+
+    Vorgeschaltet, damit die Referenzdauer nur dann geholt wird, wenn sie
+    ueberhaupt gebraucht wird.
+    """
+    want_year = track.get("year")
+    got_year = release_year(result)
+    if not isinstance(want_year, int) or got_year is None:
+        return False
+    return abs(got_year - want_year) > year_tolerance
+
+
 def evaluate(
-    track: dict, result: dict, *, title_threshold: float, year_tolerance: int
+    track: dict,
+    result: dict,
+    *,
+    title_threshold: float,
+    year_tolerance: int,
+    ref_duration_ms: int | None = None,
+    duration_tolerance_ms: int = DURATION_TOLERANCE_MS,
 ) -> tuple[bool, str]:
     """Apply the gate. Returns (accepted, reason)."""
     want_artist = primary_artist(track.get("artist", "") or "")
@@ -267,10 +362,19 @@ def evaluate(
     want_year = track.get("year")
     got_year = release_year(result)
     if isinstance(want_year, int) and got_year is not None:
-        if abs(got_year - want_year) > year_tolerance:
+        off = abs(got_year - want_year)
+        if off > year_tolerance:
+            # Zweitmeinung Dauer (#2116). Nur hier, nur in eine Richtung: was das
+            # Jahr durchlaesst, wird nie nachtraeglich verworfen.
+            cand_ms = result.get("trackTimeMillis")
+            if durations_match(ref_duration_ms, cand_ms, duration_tolerance_ms):
+                delta = abs(int(ref_duration_ms) - int(cand_ms))
+                return True, (
+                    f"similarity {sim:.2f}, Jahr {got_year} vs {want_year} "
+                    f"(off by {off}) durch Dauer bestaetigt ({delta} ms Abweichung)"
+                )
             return False, (
-                f"year {got_year} vs {want_year} (off by {abs(got_year - want_year)} "
-                f"> {year_tolerance})"
+                f"year {got_year} vs {want_year} (off by {off} > {year_tolerance})"
             )
     return True, f"similarity {sim:.2f}"
 
@@ -345,7 +449,14 @@ def itunes_search(term: str, storefront: str, limit: int) -> tuple[list[dict], s
 
 
 def resolve(
-    track: dict, *, title_threshold: float, year_tolerance: int, limit: int
+    track: dict,
+    *,
+    title_threshold: float,
+    year_tolerance: int,
+    limit: int,
+    duration_fallback: bool = True,
+    duration_tolerance_ms: int = DURATION_TOLERANCE_MS,
+    duration_getter=spotify_duration_ms,
 ) -> tuple[str | None, str, str]:
     """Return (apple_uri_or_None, outcome, detail).
 
@@ -358,6 +469,19 @@ def resolve(
 
     saw_any = False
     reason_to_report = ""
+    # Referenzdauer hoechstens EINMAL je Track holen, und nur wenn die
+    # Zweitmeinung ueberhaupt gefragt ist. `_ref` bleibt "nicht geholt", bis das
+    # erste Mal ein Jahr danebenliegt — die grosse Mehrheit der Tracks kostet
+    # damit keinen zusaetzlichen Abruf.
+    _ref: list = []  # leer = noch nicht geholt; [None] = geholt, nicht lesbar
+
+    def ref_ms() -> int | None:
+        if not duration_fallback:
+            return None
+        if not _ref:
+            _ref.append(duration_getter(track.get("uri")))
+        return _ref[0]
+
     for stage, term in enumerate(terms):
         # Tag stage-2 candidates so a rejection cannot be mistaken for a verdict
         # on the full-title query. Kept space-free — main() parses the reason as
@@ -377,6 +501,12 @@ def resolve(
                     result,
                     title_threshold=title_threshold,
                     year_tolerance=year_tolerance,
+                    ref_duration_ms=(
+                        ref_ms()
+                        if _year_would_reject(track, result, year_tolerance)
+                        else None
+                    ),
+                    duration_tolerance_ms=duration_tolerance_ms,
                 )
                 if accepted:
                     tid = result.get("trackId")
@@ -461,6 +591,23 @@ def main() -> int:
         default=5,
         help="search results inspected per storefront (default 5)",
     )
+    ap.add_argument(
+        "--no-duration-fallback",
+        action="store_true",
+        help=(
+            "disable the duration second opinion (#2116): a candidate rejected "
+            "by the year gate stays rejected even when its runtime matches"
+        ),
+    )
+    ap.add_argument(
+        "--duration-tolerance-ms",
+        type=int,
+        default=DURATION_TOLERANCE_MS,
+        help=(
+            "max |our duration - candidate duration| that overrides a year "
+            f"mismatch (default {DURATION_TOLERANCE_MS})"
+        ),
+    )
     args = ap.parse_args()
 
     state = {} if args.dry_run else load_state()
@@ -524,6 +671,8 @@ def main() -> int:
             title_threshold=args.title_threshold,
             year_tolerance=args.year_tolerance,
             limit=args.limit,
+            duration_fallback=not args.no_duration_fallback,
+            duration_tolerance_ms=args.duration_tolerance_ms,
         )
         label = f"{track.get('artist')} – {track.get('title')}"
         if outcome == "hit":

--- a/tests/unit/test_backfill_apple_duration_2116.py
+++ b/tests/unit/test_backfill_apple_duration_2116.py
@@ -1,0 +1,194 @@
+"""Dauer-Zweitmeinung zum Jahres-Gate (#2116).
+
+Gemessen am 13.08.2026: von 20 auswertbaren Jahres-Ablehnungen weichen 14 um
+hoechstens 2 s in der Spieldauer ab, 8 davon um exakt 0 ms. Die beiden echten
+Fehltreffer weichen um 10,7 s und 38 s ab. Das Jahr trennt nicht, die Dauer tut es.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+_SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "backfill_apple.py"
+_spec = importlib.util.spec_from_file_location("backfill_apple", _SCRIPT)
+ba = importlib.util.module_from_spec(_spec)
+sys.modules["backfill_apple"] = ba
+_spec.loader.exec_module(ba)
+
+
+# --------------------------------------------------------------------- helper
+def _track(**kw):
+    base = {
+        "artist": "Dinah Washington",
+        "title": "Teach Me Tonight",
+        "year": 1988,
+        "uri": "spotify:track:0004Uy71ku11n3LMpuyf59",
+    }
+    base.update(kw)
+    return base
+
+
+def _result(**kw):
+    base = {
+        "artistName": "Dinah Washington",
+        "trackName": "Teach Me Tonight",
+        "releaseDate": "1954-01-01T12:00:00Z",
+        "trackId": 12345,
+        "trackTimeMillis": 180000,
+    }
+    base.update(kw)
+    return base
+
+
+# --------------------------------------------------------------- durations_match
+def test_durations_match_exact():
+    assert ba.durations_match(180000, 180000) is True
+
+
+def test_durations_match_within_tolerance():
+    assert ba.durations_match(180000, 180920) is True
+
+
+def test_durations_match_outside_tolerance():
+    """2303 ms ist der erste gemessene Fall jenseits der Luecke."""
+    assert ba.durations_match(180000, 182303) is False
+
+
+def test_durations_match_unknown_reference_is_false():
+    assert ba.durations_match(None, 180000) is False
+
+
+def test_durations_match_unknown_candidate_is_false():
+    assert ba.durations_match(180000, None) is False
+
+
+def test_durations_match_zero_is_false():
+    assert ba.durations_match(0, 0) is False
+
+
+def test_durations_match_custom_tolerance():
+    assert ba.durations_match(180000, 184000, tolerance_ms=5000) is True
+
+
+# ------------------------------------------------------------------- evaluate
+def test_year_mismatch_rejected_without_duration():
+    """Ohne Referenzdauer bleibt es beim bisherigen Verhalten."""
+    ok, reason = ba.evaluate(
+        _track(), _result(), title_threshold=0.87, year_tolerance=1
+    )
+    assert ok is False
+    assert "off by 34" in reason
+
+
+def test_year_mismatch_accepted_when_duration_matches():
+    """Der Kern von #2116: 34 Jahre daneben, 0 ms Unterschied -> annehmen."""
+    ok, reason = ba.evaluate(
+        _track(),
+        _result(),
+        title_threshold=0.87,
+        year_tolerance=1,
+        ref_duration_ms=180000,
+    )
+    assert ok is True
+    assert "durch Dauer bestaetigt" in reason
+    assert "0 ms" in reason
+
+
+def test_year_mismatch_still_rejected_when_duration_differs():
+    """Die Live-Fassung mit 38 s Unterschied bleibt abgelehnt."""
+    ok, reason = ba.evaluate(
+        _track(),
+        _result(trackTimeMillis=218000),
+        title_threshold=0.87,
+        year_tolerance=1,
+        ref_duration_ms=180000,
+    )
+    assert ok is False
+    assert "off by 34" in reason
+
+
+def test_duration_never_rejects_what_the_year_accepts():
+    """Die Dauer ueberstimmt nur in EINE Richtung."""
+    ok, _ = ba.evaluate(
+        _track(year=1954),
+        _result(trackTimeMillis=999999),
+        title_threshold=0.87,
+        year_tolerance=1,
+        ref_duration_ms=180000,
+    )
+    assert ok is True
+
+
+def test_duration_does_not_rescue_artist_mismatch():
+    ok, reason = ba.evaluate(
+        _track(),
+        _result(artistName="Ella Fitzgerald"),
+        title_threshold=0.87,
+        year_tolerance=1,
+        ref_duration_ms=180000,
+    )
+    assert ok is False
+    assert "artist" in reason
+
+
+def test_candidate_without_duration_stays_rejected():
+    ok, reason = ba.evaluate(
+        _track(),
+        _result(trackTimeMillis=None),
+        title_threshold=0.87,
+        year_tolerance=1,
+        ref_duration_ms=180000,
+    )
+    assert ok is False
+    assert "off by 34" in reason
+
+
+# -------------------------------------------------------------- spotify_track_id
+def test_spotify_track_id_parses():
+    assert (
+        ba.spotify_track_id("spotify:track:0004Uy71ku11n3LMpuyf59")
+        == "0004Uy71ku11n3LMpuyf59"
+    )
+
+
+def test_spotify_track_id_rejects_other_forms():
+    assert ba.spotify_track_id("deezer://track/123") is None
+    assert ba.spotify_track_id(None) is None
+    assert ba.spotify_track_id("") is None
+
+
+def test_spotify_duration_ms_survives_network_error():
+    def boom(*a, **kw):
+        raise OSError("kein Netz")
+
+    assert (
+        ba.spotify_duration_ms("spotify:track:0004Uy71ku11n3LMpuyf59", opener=boom)
+        is None
+    )
+
+
+def test_spotify_duration_ms_without_uri_makes_no_request():
+    called = []
+
+    def opener(*a, **kw):
+        called.append(1)
+        raise AssertionError("darf nicht aufgerufen werden")
+
+    assert ba.spotify_duration_ms(None, opener=opener) is None
+    assert called == []
+
+
+# ---------------------------------------------------------- _year_would_reject
+def test_year_would_reject_true_on_mismatch():
+    assert ba._year_would_reject(_track(), _result(), 1) is True
+
+
+def test_year_would_reject_false_when_within_tolerance():
+    assert ba._year_would_reject(_track(year=1954), _result(), 1) is False
+
+
+def test_year_would_reject_false_when_year_unknown():
+    assert ba._year_would_reject(_track(year=None), _result(), 1) is False
+    assert ba._year_would_reject(_track(), _result(releaseDate=""), 1) is False


### PR DESCRIPTION
Setzt Punkt 2 aus #2116 um, nachdem Punkt 1 (die Messung) den Befund geliefert hat.

## Was sich ändert

Verwirft das Jahres-Gate einen Kandidaten, wird jetzt die **Spieldauer** als Zweitmeinung gehört. Passt sie auf höchstens 2 Sekunden, wird der Kandidat doch genommen.

```
Jahr passt (±tolerance)         -> annehmen, wie bisher
Jahr passt nicht, Dauer ≤ 2 s   -> annehmen  (neu)
Jahr passt nicht, Dauer > 2 s   -> ablehnen, wie bisher
Dauer unbekannt                 -> ablehnen, wie bisher
```

**Die Dauer überstimmt nur in eine Richtung.** Was das Jahr durchlässt, wird nie nachträglich verworfen — dafür gibt es einen eigenen Test.

## Warum 2 Sekunden

Aus der Messung am 13.08. (22 der 58 Jahres-Ablehnungen, 20 auswertbar):

| Dauer-Abweichung | Fälle |
|---|---|
| ≤ 2 s | 14 (davon 8 bei exakt 0 ms) |
| 2–5 s | 4 |
| > 5 s | 2 |

Die Treffergruppe endet bei **920 ms**, der nächste Fall beginnt bei **2303 ms**. In dieser Lücke liegt die Grenze — sie ist gemessen, nicht gegriffen.

**Das Jahr trennt nicht.** Die Abweichungen der 14 richtigen Treffer lauten `2, 2, 2, 2, 2, 3, 3, 4, 7, 9, 14, 19, 34, 43`, und die beiden echten Fehltreffer liegen mit **18 und 23 mitten darin**. Eine Abweichung von 43 Jahren gehört zu einer millisekundengleichen Aufnahme, eine von 23 Jahren zu einer Live-Fassung mit 38 s Unterschied.

## Woher die Referenzdauer kommt

Der Katalog führt keine Spieldauer, deshalb wird sie aus Spotifys öffentlicher Embed-Seite gelesen — keyless, kein Token.

**Der Abruf ist faul und kostet im Normalfall nichts.** `_year_would_reject()` prüft vorab, ob das Jahr diesen Kandidaten überhaupt verwerfen würde; erst dann wird die Dauer geholt, und höchstens einmal pro Track. Im Probe-Lauf betraf das 58 von 730 Lücken.

Nachgewiesen statt behauptet: bei passendem Jahr **0 Abrufe**, bei einer Jahres-Ablehnung **1 Abruf** — und der Ausgang kippt dabei von `rejected` auf `hit`.

Jeder Fehler beim Abruf führt zu `None` und damit zum unveränderten Jahres-Urteil.

## Neue Optionen

- `--no-duration-fallback` schaltet die Zweitmeinung ab
- `--duration-tolerance-ms N` verschiebt die Grenze

## Prüfung

- **20 neue Tests** in `tests/unit/test_backfill_apple_duration_2116.py`, volle Suite **1745** grün
- `ruff check .` und `ruff format --check .` sauber

## Einordnung

`scripts/backfill_apple.py` wird derzeit von keinem LaunchAgent aufgerufen — der tägliche Apple-Backfill nutzt `backfill_provider_uris.py`, das gar keine Jahresprüfung hat. Diese Änderung wirkt also erst, wenn das Skript wieder gefahren wird, und ändert am laufenden Betrieb nichts. Der Zusammenhang ist im Nachtrag zu #2116 beschrieben.

Bezug #2116
