### PR TITLE
chore(playlists): deezer backfill — +9 deezer uris

### DIFF
--- a/custom_components/beatify/playlists/community/harder-styles.json
+++ b/custom_components/beatify/playlists/community/harder-styles.json
@@ -1,6 +1,6 @@
 {
   "name": "Harder Styles",
-  "version": "1.23",
+  "version": "1.24",
   "tags": [
     "hardstyle",
     "hardcore",
@@ -614,7 +614,7 @@
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=wxwCjA9feZI",
       "uri_tidal": null,
-      "uri_deezer": null,
+      "uri_deezer": "deezer://track/104966962",
       "alt_artists": [
         "TNT",
         "Technoboy"
@@ -1463,7 +1463,7 @@
       "uri_apple_music_by_region": {},
       "uri_youtube_music": "https://music.youtube.com/watch?v=Fp-3jRcqelM",
       "uri_tidal": "tidal://track/168687273",
-      "uri_deezer": null,
+      "uri_deezer": "deezer://track/965494682",
       "alt_artists": [
         "D-Fence"
       ],
@@ -1508,7 +1508,7 @@
       "uri_apple_music_by_region": {},
       "uri_youtube_music": "https://music.youtube.com/watch?v=Y2uKwACXVk4",
       "uri_tidal": "tidal://track/81147474",
-      "uri_deezer": null,
+      "uri_deezer": "deezer://track/413349522",
       "alt_artists": [
         "GLDY LX"
       ],
@@ -1947,7 +1947,7 @@
       "uri_apple_music_by_region": {},
       "uri_youtube_music": "https://music.youtube.com/watch?v=q7ErRTG3ON4",
       "uri_tidal": "tidal://track/86962828",
-      "uri_deezer": null,
+      "uri_deezer": "deezer://track/482707772",
       "alt_artists": [
         "Outbreak"
       ],
@@ -2042,7 +2042,7 @@
       "uri_apple_music_by_region": {},
       "uri_youtube_music": "https://music.youtube.com/watch?v=5u6Hk7sempo",
       "uri_tidal": "tidal://track/86050836",
-      "uri_deezer": null,
+      "uri_deezer": "deezer://track/474295182",
       "fun_fact": "Phuture Noize is a Dutch hardstyle artist known for concept albums and cinematic productions.",
       "fun_fact_de": "Phuture Noize ist ein niederländischer Hardstyle-Künstler, bekannt für Konzeptalben und cineastische Produktionen.",
       "fun_fact_es": "Phuture Noize es un artista neerlandés de hardstyle conocido por álbumes conceptuales y producciones cinematográficas.",
@@ -2686,7 +2686,7 @@
       "uri_apple_music_by_region": {},
       "uri_youtube_music": "https://music.youtube.com/watch?v=dP_KhSmjFzI",
       "uri_tidal": "tidal://track/94393347",
-      "uri_deezer": null,
+      "uri_deezer": "deezer://track/965474842",
       "fun_fact": "A hardstyle / hardcore track (2018).",
       "fun_fact_de": "Ein Hardstyle-/Hardcore-Track (2018).",
       "fun_fact_es": "Un tema de hardstyle / hardcore (2018).",
@@ -3178,7 +3178,7 @@
       "uri_apple_music_by_region": {},
       "uri_youtube_music": "https://music.youtube.com/watch?v=-8KoFD2iRK8",
       "uri_tidal": "tidal://track/101907235",
-      "uri_deezer": null,
+      "uri_deezer": "deezer://track/612412272",
       "fun_fact": "A hardstyle / hardcore track (2019).",
       "fun_fact_de": "Ein Hardstyle-/Hardcore-Track (2019).",
       "fun_fact_es": "Un tema de hardstyle / hardcore (2019).",
@@ -3455,7 +3455,7 @@
       "uri_apple_music_by_region": {},
       "uri_youtube_music": "https://music.youtube.com/watch?v=YhYOey9TGcM",
       "uri_tidal": "tidal://track/104063920",
-      "uri_deezer": null,
+      "uri_deezer": "deezer://track/631923112",
       "fun_fact": "A hardstyle / hardcore track (2019).",
       "fun_fact_de": "Ein Hardstyle-/Hardcore-Track (2019).",
       "fun_fact_es": "Un tema de hardstyle / hardcore (2019).",
@@ -4343,7 +4343,7 @@
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=8Jw41oS_scU",
       "uri_tidal": "tidal://track/250412451",
-      "uri_deezer": null,
+      "uri_deezer": "deezer://track/1951186317",
       "fun_fact": "A hardstyle / hardcore track (2022).",
       "fun_fact_de": "Ein Hardstyle-/Hardcore-Track (2022).",
       "fun_fact_es": "Un tema de hardstyle / hardcore (2022).",


### PR DESCRIPTION
Ein Lauf des `provider-uri-backfill` mit Schwerpunkt Deezer, automatisch gefahren von `com.beatify.deezer-backfill`.

- `harder-styles` Deezer 181 -> **190**/190

**Draft mit Absicht** — Merge nur nach Markus' Freigabe. Fuer diesen Agenten gibt es bewusst KEINEN Automerge.