### PR TITLE
chore(playlists): youtube backfill — +24 youtube uris

### DIFF
--- a/custom_components/beatify/playlists/community/deutschrock-best-of.json
+++ b/custom_components/beatify/playlists/community/deutschrock-best-of.json
@@ -1,6 +1,6 @@
 {
   "name": "Deutschrock - Best Of",
-  "version": "0.19",
+  "version": "0.24",
   "tags": [
     "deutschrock",
     "german rock",
@@ -835,7 +835,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=JMeDE8xz8wY",
       "uri_tidal": "tidal://track/2039802",
       "uri_deezer": "deezer://track/2490361",
       "alt_artists": [],
@@ -861,7 +861,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=SAX-d5R90sU",
       "uri_tidal": "tidal://track/63875994",
       "uri_deezer": "deezer://track/112693002",
       "alt_artists": [],
@@ -887,7 +887,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=2KQeRxaqymA",
       "uri_tidal": "tidal://track/146668304",
       "uri_deezer": "deezer://track/1004595412",
       "alt_artists": [],
@@ -913,7 +913,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Ct3syqlqgNg",
       "uri_tidal": "tidal://track/50820652",
       "uri_deezer": "deezer://track/106845220",
       "alt_artists": [],
@@ -939,7 +939,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=wrSZGoCRjzI",
       "uri_tidal": "tidal://track/110204234",
       "uri_deezer": "deezer://track/687374092",
       "alt_artists": [],
@@ -965,7 +965,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=-dtB666HbRU",
       "uri_tidal": "tidal://track/121262580",
       "uri_deezer": "deezer://track/790676042",
       "alt_artists": [],
@@ -991,7 +991,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=GmTdw2Wu9ho",
       "uri_tidal": "tidal://track/95744216",
       "uri_deezer": "deezer://track/560613942",
       "alt_artists": [],
@@ -1017,7 +1017,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=iFcudReY9ZM",
       "uri_tidal": "tidal://track/2251069",
       "uri_deezer": "deezer://track/2728350",
       "alt_artists": [],
@@ -1043,7 +1043,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=peRjk-zy8Xc",
       "uri_tidal": "tidal://track/408183190",
       "uri_deezer": "deezer://track/3160832981",
       "alt_artists": [],
@@ -1069,7 +1069,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=IVXzM55CocM",
       "uri_tidal": "tidal://track/522727395",
       "uri_deezer": "deezer://track/4009919651",
       "alt_artists": [],
@@ -1095,7 +1095,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=ObqivJT7kWc",
       "uri_tidal": "tidal://track/210683302",
       "uri_deezer": "deezer://track/1605684792",
       "alt_artists": [],
@@ -1121,7 +1121,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=9KMVJ-6l9Fk",
       "uri_tidal": "tidal://track/279503506",
       "uri_deezer": "deezer://track/2171829957",
       "alt_artists": [],
@@ -1147,7 +1147,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=LkECd0CFFdI",
       "uri_tidal": "tidal://track/433439330",
       "uri_deezer": "deezer://track/3349286271",
       "alt_artists": [],
@@ -1173,7 +1173,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=UDII3rdQLXY",
       "uri_tidal": "tidal://track/108861504",
       "uri_deezer": "deezer://track/644361402",
       "alt_artists": [],
@@ -1199,7 +1199,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=1wg0NxH3aiw",
       "uri_tidal": "tidal://track/100168656",
       "uri_deezer": "deezer://track/599115062",
       "alt_artists": [],
@@ -1225,7 +1225,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=8pPEUyruhTc",
       "uri_tidal": "tidal://track/446944567",
       "uri_deezer": "deezer://track/3417197171",
       "alt_artists": [],
@@ -1251,7 +1251,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=cFpN0O0VQkU",
       "uri_tidal": "tidal://track/73402978",
       "uri_deezer": "deezer://track/357434621",
       "alt_artists": [],
@@ -1277,7 +1277,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=uaxTiriqLLE",
       "uri_tidal": "tidal://track/353722894",
       "uri_deezer": "deezer://track/2723611402",
       "alt_artists": [],
@@ -1303,7 +1303,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=cHYXiSdTvL4",
       "uri_tidal": "tidal://track/2040262",
       "uri_deezer": "deezer://track/1272451742",
       "alt_artists": [],
@@ -1329,7 +1329,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=M8EKY0TtMsY",
       "uri_tidal": "tidal://track/115878765",
       "uri_deezer": "deezer://track/731095032",
       "alt_artists": [],
@@ -1355,7 +1355,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=BJtTNnFFLsY",
       "uri_tidal": "tidal://track/425228467",
       "uri_deezer": "deezer://track/3286817871",
       "alt_artists": [],
@@ -1381,7 +1381,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=_jqfydswTqc",
       "uri_tidal": "tidal://track/146668313",
       "uri_deezer": "deezer://track/1004595452",
       "alt_artists": [],
@@ -1407,7 +1407,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=y-E7OBH5RDw",
       "uri_tidal": "tidal://track/416292498",
       "uri_deezer": "deezer://track/3187689521",
       "alt_artists": [],
@@ -1433,7 +1433,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=W0bogDZ08ig",
       "uri_tidal": "tidal://track/72144851",
       "uri_deezer": "deezer://track/140221629",
       "alt_artists": [],


### PR DESCRIPTION
Ein Lauf des `provider-uri-backfill`, automatisch gefahren von `com.beatify.youtube-backfill`.

- `deutschrock-best-of` YouTube 31 -> **55**/100

**Draft mit Absicht** — Merge nur nach Markus' Freigabe.