### PR TITLE
chore(playlists): youtube backfill — +20 youtube uris

### DIFF
--- a/custom_components/beatify/playlists/community/edm-anthems.json
+++ b/custom_components/beatify/playlists/community/edm-anthems.json
@@ -1,6 +1,6 @@
 {
   "name": "EDM Anthems",
-  "version": "1.19",
+  "version": "1.23",
   "tags": [
     "edm",
     "electronic",
@@ -1289,7 +1289,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=9vMh9f41pqE",
       "uri_tidal": "tidal://track/232117824",
       "uri_deezer": "deezer://track/1495060512",
       "fun_fact": "“Tremor” is the title track of Dimitri Vegas & Like Mike’s release of the same name.",
@@ -1469,7 +1469,7 @@
         "nl": "applemusic://track/1824649781",
         "it": "applemusic://track/1824649781"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=0EWbonj7f18",
       "uri_tidal": "tidal://track/84840860",
       "uri_deezer": "deezer://track/463375512",
       "fun_fact": "“Tsunami” appears on DVBBS’s release “Tsunami (Jump) [Remixes] - EP (feat. Tinie Tempah)”.",
@@ -1499,7 +1499,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=r2LpOUwca94",
       "uri_tidal": "tidal://track/54504292",
       "uri_deezer": "deezer://track/569166552",
       "fun_fact": "“Light It Up” appears on Major Lazer’s release “Peace Is The Mission : Extended”.",
@@ -1589,7 +1589,7 @@
         "nl": "applemusic://track/1689617477",
         "it": "applemusic://track/1533115303"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=2Y6Nne8RvaA",
       "uri_tidal": "tidal://track/66538696",
       "uri_deezer": "deezer://track/135373112",
       "fun_fact": "“This Girl (Kungs Vs. Cookin' On 3 Burners)” appears on Kungs’s release “Layers”.",
@@ -1919,7 +1919,7 @@
         "nl": "applemusic://track/971262278",
         "it": "applemusic://track/971262278"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=fDrTbLXHKu8",
       "uri_tidal": "tidal://track/42697178",
       "uri_deezer": "deezer://track/95963374",
       "fun_fact": "“Mind (feat. Kai)” appears on Jack Ü’s release “Skrillex and Diplo present Jack Ü”.",
@@ -2009,7 +2009,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=dzHdo4yxidc",
       "uri_tidal": "tidal://track/83549265",
       "uri_deezer": "deezer://track/463379152",
       "fun_fact": "“Turn Up The Speakers” is the title track of AFROJACK’s release of the same name.",
@@ -2489,7 +2489,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=i-gyZ35074k",
       "uri_tidal": "tidal://track/31338681",
       "uri_deezer": "deezer://track/79942796",
       "fun_fact": "“Stay The Night - Featuring Hayley Williams Of Paramore” appears on Zedd’s release “Clarity (Deluxe)”.",
@@ -2729,7 +2729,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=I-VsisgVkHw",
       "uri_tidal": "tidal://track/402391122",
       "uri_deezer": "deezer://track/143284446",
       "fun_fact": "“Call On Me - Ryan Riback Extended Remix” appears on Starley’s release “Call On Me (Remixes)”.",
@@ -2759,7 +2759,7 @@
         "nl": "applemusic://track/1819450998",
         "it": "applemusic://track/1819450998"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=BPiW0tkWfeg",
       "uri_tidal": "tidal://track/54059868",
       "uri_deezer": "deezer://track/90250609",
       "fun_fact": "“Lovers on the Sun (feat. Sam Martin)” appears on David Guetta’s release “Listen”.",
@@ -2849,7 +2849,7 @@
         "nl": "applemusic://track/1843374039",
         "it": "applemusic://track/1843374039"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=KnL2RJZTdA4",
       "uri_tidal": "tidal://track/83549084",
       "uri_deezer": "deezer://track/468407642",
       "fun_fact": "“Wizard” is the title track of Martin Garrix’s release of the same name.",
@@ -3119,7 +3119,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=TL1ByAIf8Ck",
       "uri_tidal": "tidal://track/84395148",
       "uri_deezer": "deezer://track/459401332",
       "fun_fact": "“How We Party - Original Mix” appears on R3HAB’s release “How We Party”.",
@@ -3149,7 +3149,7 @@
         "nl": "applemusic://track/1741670480",
         "it": "applemusic://track/1741670480"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=NOubzHCUt48",
       "uri_tidal": "tidal://track/98084041",
       "uri_deezer": "deezer://track/62710229",
       "fun_fact": "“Die Young” appears on Kesha’s release “Warrior (Deluxe Version)”.",
@@ -3449,7 +3449,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=QCyIY10KBnk",
       "uri_tidal": "tidal://track/192680454",
       "uri_deezer": "deezer://track/1451459172",
       "fun_fact": "“Booyah” is the title track of Showtek’s release of the same name.",
@@ -3629,7 +3629,7 @@
         "nl": "applemusic://track/1544424865",
         "it": "applemusic://track/1544424865"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=VjHMDlAPMUw",
       "uri_tidal": "tidal://track/65979679",
       "uri_deezer": "deezer://track/81300218",
       "fun_fact": "“Are You With Me” appears on Lost Frequencies’s release “Less Is More”.",
@@ -3809,7 +3809,7 @@
         "nl": "applemusic://track/697195462",
         "it": "applemusic://track/697195462"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=FGBhQbmPwH8",
       "uri_tidal": "tidal://track/1550546",
       "uri_deezer": "deezer://track/3135553",
       "fun_fact": "“One More Time” appears on Daft Punk’s release “Discovery”.",
@@ -3899,7 +3899,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=9G1I16gJBvU",
       "uri_tidal": "tidal://track/13869649",
       "uri_deezer": "deezer://track/16712341",
       "fun_fact": "“Calling (Lose My Mind) - Radio Edit” appears on Sebastian Ingrosso’s release “Calling (Lose My Mind)”.",
@@ -3929,7 +3929,7 @@
         "nl": "applemusic://track/1509360029",
         "it": "applemusic://track/1509360029"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=iD-NBs5kJqI",
       "uri_tidal": "tidal://track/138517828",
       "uri_deezer": "deezer://track/937856142",
       "fun_fact": "“Language” is the title track of Porter Robinson’s release of the same name.",
@@ -3959,7 +3959,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=a0fkNdPiIL4",
       "uri_tidal": "tidal://track/70687052",
       "uri_deezer": "deezer://track/858971282",
       "fun_fact": "“Satisfaction” appears on Benny Benassi’s release “Hypnotica”.",
@@ -3989,7 +3989,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=SU88c0f5-h0",
       "uri_tidal": "tidal://track/88259519",
       "uri_deezer": "deezer://track/494360142",
       "fun_fact": "“Pressure - Alesso Remix” appears on Nadia Ali’s release “Pressure (The Remixes)”.",
@@ -4019,7 +4019,7 @@
         "nl": "applemusic://track/1769016658",
         "it": "applemusic://track/1769016658"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=3Q9rewnLFYw",
       "uri_tidal": "tidal://track/34702583",
       "uri_deezer": "deezer://track/2942220821",
       "fun_fact": "“I Can't Stop” appears on Flux Pavilion’s release “Lines in Wax”.",


### PR DESCRIPTION
Ein Lauf des `provider-uri-backfill`, automatisch gefahren von `com.beatify.youtube-backfill`.

- `edm-anthems` YouTube 128 -> **148**/190

**Draft mit Absicht** — Merge nur nach Markus' Freigabe.