### PR TITLE
chore(playlists): deezer backfill — +4 deezer uris

### DIFF
--- a/custom_components/beatify/playlists/top-100-power-ballads.json
+++ b/custom_components/beatify/playlists/top-100-power-ballads.json
@@ -1,6 +1,6 @@
 {
   "name": "Top 100 Power Ballads",
-  "version": "1.9",
+  "version": "1.10",
   "tags": [
     "1980s",
     "1990s",
@@ -1771,7 +1771,7 @@
       "fun_fact_de": "[DE] Written and produced entirely by Lenny Kravitz in his home studio. It showed a m...",
       "fun_fact_es": "[ES] Written and produced entirely by Lenny Kravitz in his home studio. It showed a m...",
       "fun_fact_fr": "Entièrement écrite et produite par Lenny Kravitz dans son studio personnel. Elle a révélé un côté plus vulnérable de l'artiste et est devenue l'un de ses titres les plus diffusés en radio adult contemporary.",
-      "uri_apple_music": "",
+      "uri_apple_music": "applemusic://track/723338381",
       "uri_youtube_music": "https://music.youtube.com/watch?v=eW2qlKa6oHw",
       "uri_tidal": "tidal://track/77662157",
       "uri_deezer": "deezer://track/3129591",
@@ -2084,7 +2084,8 @@
         "es": "applemusic://track/1443342983",
         "nl": "applemusic://track/1443342983",
         "it": "applemusic://track/1443342983"
-      }
+      },
+      "uri_deezer": "deezer://track/1218599582"
     },
     {
       "year": 2005,
@@ -2315,7 +2316,8 @@
         "es": "applemusic://track/1038338052",
         "nl": "applemusic://track/1038338052",
         "it": "applemusic://track/1038338052"
-      }
+      },
+      "uri_deezer": "deezer://track/97640852"
     },
     {
       "year": 1990,
@@ -2664,7 +2666,8 @@
         "es": "applemusic://track/1631055268",
         "nl": "applemusic://track/1631055268",
         "it": "applemusic://track/1631055268"
-      }
+      },
+      "uri_deezer": "deezer://track/1798659307"
     },
     {
       "year": 1990,
@@ -2860,7 +2863,8 @@
         "es": "applemusic://track/1629185307",
         "nl": "applemusic://track/1629185307",
         "it": "applemusic://track/1629185307"
-      }
+      },
+      "uri_deezer": "deezer://track/1787569267"
     },
     {
       "year": 1985,
@@ -3425,7 +3429,7 @@
       "fun_fact_de": "[DE] Kerry Livgren wrote this after reading a poem about mortality. The acoustic fing...",
       "fun_fact_es": "[ES] Kerry Livgren wrote this after reading a poem about mortality. The acoustic fing...",
       "fun_fact_fr": "Kerry Livgren a écrit ce morceau après avoir lu un poème sur la mortalité. Le motif de fingerpicking acoustique s'inspire du guitariste classique Fernando Sor.",
-      "uri_apple_music": "",
+      "uri_apple_music": "applemusic://track/193730684",
       "uri_youtube_music": "https://music.youtube.com/watch?v=tH2w6Oxx0kQ",
       "uri_tidal": "tidal://track/234636699",
       "uri_deezer": "deezer://track/855863",
@@ -3492,7 +3496,7 @@
       "fun_fact_de": "[DE] Taime Downe wrote this emotional ballad about personal struggles. It showed the ...",
       "fun_fact_es": "[ES] Taime Downe wrote this emotional ballad about personal struggles. It showed the ...",
       "fun_fact_fr": "Taime Downe a écrit cette ballade émouvante sur ses luttes personnelles. Elle a montré que le groupe de glam metal savait aussi écrire des morceaux sensibles, au-delà des chansons de fête.",
-      "uri_apple_music": "",
+      "uri_apple_music": "applemusic://track/298109233",
       "uri_youtube_music": "https://music.youtube.com/watch?v=eunWuKxfAC8",
       "uri_tidal": "tidal://track/1868118",
       "uri_deezer": "deezer://track/4085312",


### PR DESCRIPTION
Ein Lauf des `provider-uri-backfill` mit Schwerpunkt Deezer, automatisch gefahren von `com.beatify.deezer-backfill`.

- `top-100-power-ballads` Deezer 95 -> **99**/99

Nebenbei mitgefuellt, weil Odesli alle Provider in einer Antwort liefert: apple +3.

**Draft mit Absicht** — Merge nur nach Markus' Freigabe. Fuer diesen Agenten gibt es bewusst KEINEN Automerge.