### PR TITLE
data: fix 1 wrong YouTube Music URI in funk-carioca (#2173)

### DIFF
--- a/custom_components/beatify/playlists/community/funk-carioca.json
+++ b/custom_components/beatify/playlists/community/funk-carioca.json
@@ -1,6 +1,6 @@
 {
   "name": "🌪️ Funk Carioca",
-  "version": "0.4",
+  "version": "0.5",
   "tags": [
     "2000s",
     "funk",
@@ -470,7 +470,7 @@
       },
       "uri_deezer": "deezer://track/1341704382",
       "uri_tidal": "tidal://track/180381602",
-      "uri_youtube_music": "https://music.youtube.com/watch?v=MpzQgVr0ODo"
+      "uri_youtube_music": "https://music.youtube.com/watch?v=aivxvYZbavc"
     },
     {
       "year": 2006,


### PR DESCRIPTION
Closes #2173.

Replaced 1 wrong YouTube Music URI for **Furacão 2000 / Anitta — Eu Vou Ficar - Ao Vivo**: the previous URI pointed to a user-uploaded re-upload by channel "Tatiany Morais" instead of the official live recording. Replaced with the official "Ao Vivo Programa Verão Furacão 2000" video (`aivxvYZbavc`).

Bumped playlist version to `0.5`.

5 additional `wrong_track` flags were reviewed and dismissed as false positives (Furacão 2000 YouTube titles with DVD names, track numbers, featured-artist prefixes — all the same songs).