### PR TITLE
chore(playlists): apple backfill — +16 apple uris

### DIFF
--- a/custom_components/beatify/playlists/70s-hits.json
+++ b/custom_components/beatify/playlists/70s-hits.json
@@ -1,6 +1,6 @@
 {
   "name": "70s Hits",
-  "version": "1.15",
+  "version": "1.16",
   "tags": [
     "1970s",
     "classic-rock",
@@ -3544,7 +3544,7 @@
       "year": 1978,
       "isrc": "DED167800006",
       "uri": "spotify:track:78His8pbKjbDQF7aX5asgv",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/250727833",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/570745447",
         "de": "applemusic://track/570745447",
@@ -3569,7 +3569,7 @@
       "year": 1978,
       "isrc": "USSM17800983",
       "uri": "spotify:track:58r4JuwHhXLAkttkaUZfLw",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/410731495",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/410731495",
         "de": "applemusic://track/467627589",
@@ -3594,7 +3594,7 @@
       "year": 1974,
       "isrc": "USJT11600006",
       "uri": "spotify:track:2EC9IJj7g0mN1Q5VrZkiYY",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/1195108771",
       "uri_apple_music_by_region": {
         "us": null,
         "de": null,
@@ -3619,7 +3619,7 @@
       "year": 1976,
       "isrc": "USCRB0101211",
       "uri": "spotify:track:064SVQsmWl5EF0zahmzkQk",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/73988389",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1632384111",
         "de": "applemusic://track/1632384111",
@@ -3644,7 +3644,7 @@
       "year": 1977,
       "isrc": "USSM17700026",
       "uri": "spotify:track:2M2WJ7gBlcKNxdhyfPp9zY",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/882955357",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/338756305",
         "de": "applemusic://track/338756305",
@@ -3669,7 +3669,7 @@
       "year": 1970,
       "isrc": "USSM16900808",
       "uri": "spotify:track:6l8EbYRtQMgKOyc1gcDHF9",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/324127934",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1286118699",
         "de": "applemusic://track/1286118699",
@@ -3694,7 +3694,7 @@
       "year": 1979,
       "isrc": "USAT21500124",
       "uri": "spotify:track:5hhVpGIBlqAU5yJEOmrk5o",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/999609930",
       "uri_apple_music_by_region": {
         "us": null,
         "de": null,
@@ -3719,7 +3719,7 @@
       "year": 1975,
       "isrc": "ES64E2413022",
       "uri": "spotify:track:7bjtTJ4M10kpl2pGJxsg1Q",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/1444131440",
       "uri_apple_music_by_region": {
         "us": null,
         "de": null,
@@ -3744,7 +3744,7 @@
       "year": 1979,
       "isrc": "FR22F7900020",
       "uri": "spotify:track:0SdfUMRHhcjxrMv5d9V1UP",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/1440825665",
       "uri_apple_music_by_region": {
         "us": null,
         "de": "applemusic://track/1872718907",
@@ -3769,7 +3769,7 @@
       "year": 1978,
       "isrc": "USRC10201815",
       "uri": "spotify:track:65lHwG8JFJs67PnOUhCYPq",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/367515038",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/367515038",
         "de": "applemusic://track/367515038",
@@ -3819,7 +3819,7 @@
       "year": 1973,
       "isrc": "USSM11503412",
       "uri": "spotify:track:7whfo8cT6vgHJh1jngqNvt",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/198019840",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1030452490",
         "de": "applemusic://track/1030452490",
@@ -3869,7 +3869,7 @@
       "year": 1974,
       "isrc": "GBBLY2201571",
       "uri": "spotify:track:5J74pF4Nn86qyLQihpkXq4",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/357256973",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1612479580",
         "de": "applemusic://track/1612479580",
@@ -3944,7 +3944,7 @@
       "year": 1973,
       "isrc": "USAR17500148",
       "uri": "spotify:track:78zYiMv9yNTHgmm6kaUPCm",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/271457297",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/262234782",
         "de": "applemusic://track/621292133",
@@ -3994,7 +3994,7 @@
       "year": 1972,
       "isrc": "DEA619351670",
       "uri": "spotify:track:0lLQ5Bgf2hAg8TU33xoiGX",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/1555141495",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/322028877",
         "de": "applemusic://track/322028877",
@@ -4044,7 +4044,7 @@
       "year": 1978,
       "isrc": "GBAYE7800138",
       "uri": "spotify:track:1as0uTeW3VLa9ifg8Gi9Fe",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/695612290",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1676045342",
         "de": "applemusic://track/1577375522",
@@ -4069,7 +4069,7 @@
       "year": 1973,
       "isrc": "DEA017300010",
       "uri": "spotify:track:6JgrTw5Ai42k2NHjrsfxow",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/1442787974",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1438182713",
         "de": "applemusic://track/1438182713",

--- a/custom_components/beatify/playlists/community/finnish-iskelma-classics.json
+++ b/custom_components/beatify/playlists/community/finnish-iskelma-classics.json
@@ -1,6 +1,6 @@
 {
   "name": "Finnish Schlager Classics 🇫🇮",
-  "version": "1.30",
+  "version": "1.31",
   "tags": [
     "finnish",
     "iskelma",
@@ -5597,7 +5597,7 @@
       "year": 2000,
       "isrc": "FIBAR1600507",
       "uri": "spotify:track:4rcWjCsFHGV2XrefhgrL43",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/1194609001",
       "uri_apple_music_by_region": {
         "us": null,
         "de": null,
@@ -5699,7 +5699,7 @@
       "year": 2000,
       "isrc": "FIB2M1700001",
       "uri": "spotify:track:5IoMgg0HE24edNmVQrzzRz",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/1215673119",
       "uri_apple_music_by_region": {
         "us": null,
         "de": null,
@@ -5733,7 +5733,7 @@
       "year": 2000,
       "isrc": "FIBAR0000042",
       "uri": "spotify:track:6xIu4wz5ihfzX5h7D8lTYr",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/257854045",
       "uri_apple_music_by_region": {
         "us": null,
         "de": "applemusic://track/273934655",
@@ -5767,7 +5767,7 @@
       "year": 2000,
       "isrc": "FIERA9900013",
       "uri": "spotify:track:2Z0NJ6fPy63ifOEPeQXVo4",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/1155562489",
       "uri_apple_music_by_region": {
         "us": null,
         "de": null,
@@ -6517,7 +6517,7 @@
       "uri_apple_music": "applemusic://track/73640761",
       "uri_youtube_music": "https://music.youtube.com/watch?v=IlFKEr3g56Y",
       "uri_tidal": "tidal://track/175334",
-      "uri_deezer": null,
+      "uri_deezer": "deezer://track/73132522",
       "awards_nl": [],
       "isrc": "FIWMA0500036",
       "uri_apple_music_by_region": {
@@ -7274,7 +7274,7 @@
       "year": 2011,
       "isrc": "FIBAR1100088",
       "uri": "spotify:track:6npEtOnwvqSAy3GQJb9Iij",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/431640806",
       "uri_apple_music_by_region": {
         "us": null,
         "de": null,
@@ -7387,7 +7387,7 @@
       "awards_es": [],
       "awards_fr": [],
       "awards_nl": [],
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/1551106843",
       "uri_youtube_music": "https://music.youtube.com/watch?v=lGN3XB9YXDI",
       "uri_tidal": "tidal://track/1427262",
       "uri_deezer": "deezer://track/1225533152",
@@ -7442,7 +7442,7 @@
       "year": 2012,
       "isrc": "FIRMX1200072",
       "uri": "spotify:track:6WiKW0kMCgv77fITqAhCYT",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/539486723",
       "uri_apple_music_by_region": {
         "us": null,
         "de": null,
@@ -7748,7 +7748,7 @@
       "uri_apple_music": "applemusic://track/857595588",
       "uri_youtube_music": "https://music.youtube.com/watch?v=73GZKW7dP_E",
       "uri_tidal": "tidal://track/23149972",
-      "uri_deezer": null,
+      "uri_deezer": "deezer://track/70213323",
       "awards_nl": [],
       "isrc": "FIWMA1300450",
       "uri_apple_music_by_region": {
@@ -7899,7 +7899,7 @@
       "year": 2015,
       "isrc": "FIBAR1400723",
       "uri": "spotify:track:4lFEjmaLhebRErxAUSRo4H",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/953646677",
       "uri_apple_music_by_region": {
         "us": null,
         "de": null,
@@ -7997,7 +7997,7 @@
       "year": 2015,
       "isrc": "FIBAR1500176",
       "uri": "spotify:track:2TBkwoGvD6m6G2Jx1rpkbJ",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/995943578",
       "uri_apple_music_by_region": {
         "us": null,
         "de": "applemusic://track/987985489",
@@ -8031,7 +8031,7 @@
       "year": 2015,
       "isrc": "FIBAR1400468",
       "uri": "spotify:track:0Z0CuTjydlR1ob5xYHOr7j",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/1013871039",
       "uri_apple_music_by_region": {
         "us": null,
         "de": "applemusic://track/1013871039",
@@ -8235,7 +8235,7 @@
       "year": 2016,
       "isrc": "FIBAR1600003",
       "uri": "spotify:track:3vXy7HFgi2OdJqS69fEISf",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/1073124984",
       "uri_apple_music_by_region": {
         "us": null,
         "de": null,
@@ -8371,7 +8371,7 @@
       "year": 2016,
       "isrc": "FIB2M1600003",
       "uri": "spotify:track:6NeoKd7r1c2Ht29w6xyacZ",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/1150475307",
       "uri_apple_music_by_region": {
         "us": null,
         "de": null,
@@ -8523,7 +8523,7 @@
       "awards_es": [],
       "awards_fr": [],
       "awards_nl": [],
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/1189401902",
       "uri_youtube_music": "https://music.youtube.com/watch?v=teFVIKbdls0",
       "uri_tidal": "tidal://track/1225888",
       "uri_deezer": "deezer://track/3612633",
@@ -8919,7 +8919,7 @@
       "year": 2016,
       "isrc": "FIBAR1500964",
       "uri": "spotify:track:202EaNVFyqtWmPdF3aIBep",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/1088600888",
       "uri_apple_music_by_region": {
         "us": null,
         "de": "applemusic://track/1088600888",
@@ -9157,7 +9157,7 @@
       "year": 2017,
       "isrc": "FIDC21700001",
       "uri": "spotify:track:6JGX08kXeqhBda1OA2bqUm",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/1211772098",
       "uri_apple_music_by_region": {
         "us": null,
         "de": "applemusic://track/1211772098",
@@ -9293,7 +9293,7 @@
       "year": 2017,
       "isrc": "FIOMB1700001",
       "uri": "spotify:track:6SKsqakHjGxf7pPgiUQGjM",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/1380100901",
       "uri_apple_music_by_region": {
         "us": null,
         "de": "applemusic://track/1380100901",


### PR DESCRIPTION
Ein Lauf des `provider-uri-backfill` mit Schwerpunkt Apple Music, automatisch gefahren von `com.beatify.apple-backfill`.

- `finnish-iskelma-classics` Apple 270 -> **286**/293

Nebenbei mitgefuellt, weil Odesli alle Provider in einer Antwort liefert: deezer +2.

**Draft mit Absicht** — Merge nur nach Markus' Freigabe. Fuer diesen Agenten gibt es bewusst KEINEN Automerge.