### PR TITLE
chore(playlists): youtube backfill — +44 youtube uris across 2 playlists

### DIFF
--- a/custom_components/beatify/playlists/community/deutschrock-best-of.json
+++ b/custom_components/beatify/playlists/community/deutschrock-best-of.json
@@ -1459,7 +1459,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=U5srASoK53Y",
       "uri_tidal": "tidal://track/429412841",
       "uri_deezer": "deezer://track/3319062641",
       "alt_artists": [],
@@ -1485,7 +1485,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Won4R6teR74",
       "uri_tidal": "tidal://track/21598352",
       "uri_deezer": "deezer://track/66730108",
       "alt_artists": [],
@@ -1511,7 +1511,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=m0ghxq9J9kM",
       "uri_tidal": "tidal://track/276999010",
       "uri_deezer": "deezer://track/2150175597",
       "alt_artists": [],
@@ -1537,7 +1537,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=d5KscDyqbAk",
       "uri_tidal": "tidal://track/119304675",
       "uri_deezer": "deezer://track/767767342",
       "alt_artists": [],
@@ -1563,7 +1563,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=c-Dh0BLHQgU",
       "uri_tidal": "tidal://track/11016863",
       "uri_deezer": "deezer://track/142393491",
       "alt_artists": [],
@@ -1589,7 +1589,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=QA6PqZznquA",
       "uri_tidal": "tidal://track/422158126",
       "uri_deezer": "deezer://track/3265960101",
       "alt_artists": [],
@@ -1615,7 +1615,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=xn-dma7LppE",
       "uri_tidal": "tidal://track/26008097",
       "uri_deezer": "deezer://track/13777652",
       "alt_artists": [],
@@ -1641,7 +1641,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=-XP3KsVFe84",
       "uri_tidal": "tidal://track/75510995",
       "uri_deezer": "deezer://track/376661241",
       "alt_artists": [],
@@ -1667,7 +1667,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=cor0t9cDCYk",
       "uri_tidal": "tidal://track/425415886",
       "uri_deezer": "deezer://track/3289131851",
       "alt_artists": [],
@@ -1693,7 +1693,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=dfHXrzWGbFw",
       "uri_tidal": "tidal://track/53648555",
       "uri_deezer": "deezer://track/111482204",
       "alt_artists": [],
@@ -1719,7 +1719,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=U1jUnPAkyo8",
       "uri_tidal": "tidal://track/522727446",
       "uri_deezer": "deezer://track/4009920941",
       "alt_artists": [],
@@ -1745,7 +1745,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=KrFD4KY7mK8",
       "uri_tidal": "tidal://track/1926853",
       "uri_deezer": "deezer://track/2145099",
       "alt_artists": [],
@@ -1771,7 +1771,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=b-uhEwkvBNk",
       "uri_tidal": "tidal://track/442482683",
       "uri_deezer": "deezer://track/3417022381",
       "alt_artists": [],
@@ -1823,7 +1823,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=BbuN9It9-tw",
       "uri_tidal": "tidal://track/279327036",
       "uri_deezer": "deezer://track/2170127937",
       "alt_artists": [],
@@ -1849,7 +1849,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=OjJU7hrT3fE",
       "uri_tidal": "tidal://track/353847569",
       "uri_deezer": "deezer://track/2724656261",
       "alt_artists": [],
@@ -1875,7 +1875,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=g7aOfgl_bu8",
       "uri_tidal": "tidal://track/47879830",
       "uri_deezer": "deezer://track/101545624",
       "alt_artists": [],
@@ -1901,7 +1901,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=w3US_z1e9KE",
       "uri_tidal": "tidal://track/172685142",
       "uri_deezer": "deezer://track/1235498822",
       "alt_artists": [],
@@ -1927,7 +1927,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=h6WhYgLOKK4",
       "uri_tidal": "tidal://track/232831487",
       "uri_deezer": "deezer://track/1785043087",
       "alt_artists": [],
@@ -1953,7 +1953,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Lq6-e8X_c_k",
       "uri_tidal": "tidal://track/26008096",
       "uri_deezer": "deezer://track/2806907",
       "alt_artists": [],
@@ -1979,7 +1979,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=AiVWTFSiJ4o",
       "uri_tidal": "tidal://track/84762491",
       "uri_deezer": "deezer://track/462436962",
       "alt_artists": [],

--- a/custom_components/beatify/playlists/community/finnish-iskelma-classics.json
+++ b/custom_components/beatify/playlists/community/finnish-iskelma-classics.json
@@ -1542,7 +1542,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=pU6bgc2-fzg",
       "uri_tidal": "tidal://track/20530701",
       "uri_deezer": "deezer://track/94684876",
       "fun_fact": "Pasi Kaunisto's 'Koskaan et muuttua saa' (You Must Never Change) is a timeless love song from the late 1960s; Kaunisto became one of the enduring voices of Finnish romantic pop.",
@@ -1572,7 +1572,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=6oP4Gs2Zq6M",
       "uri_tidal": "tidal://track/20833374",
       "uri_deezer": "deezer://track/1010524882",
       "fun_fact": "Seija Simola's Finnish cover of the Italian 'Ti regalo gli occhi miei' shows how Finnish iskelmä absorbed Italian melodic traditions; Italian music was hugely popular in Finland during the 1960s.",
@@ -1602,7 +1602,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=PM2O3AFdwmU",
       "uri_tidal": "tidal://track/20555073",
       "uri_deezer": "deezer://track/117677658",
       "fun_fact": "'Lapin jenkka' is Tapio Rautavaara's joyful celebration of Lapland in the jenkka style — a Finnish dance genre related to the schottische. The song embodies the festive spirit of Finland's north that made Rautavaara a beloved national figure.",
@@ -1632,7 +1632,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=qkbIXLjvICI",
       "uri_tidal": "tidal://track/20984583",
       "uri_deezer": "deezer://track/14956780",
       "fun_fact": "Georg Malmstén's 'Äänisen aallot' (Waves of Lake Onega) became a Finnish wartime anthem of longing for the eastern territories; Malmstén (1902–1981) was the pioneering composer who helped create the Finnish popular music tradition in the 1930s.",
@@ -1662,7 +1662,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=JuMtiX4T6hA",
       "uri_tidal": "tidal://track/397356",
       "uri_deezer": "deezer://track/3879943",
       "fun_fact": "Jörgen Petersen's 'Yli rajojen' (Across the Borders) is a romantic song about love transcending boundaries; Petersen was a popular Finnish artist of the 1970s–80s who bridged the worlds of iskelmä and more contemporary pop styles.",
@@ -1692,7 +1692,7 @@
         "nl": null,
         "it": "applemusic://track/307823429"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=-m0pKz6SCSE",
       "uri_tidal": "tidal://track/20557759",
       "uri_deezer": "deezer://track/3598899",
       "fun_fact": "Markku Aro's Finnish cover of 'You're Such a Good Looking Woman' brought Joe Dolan's 1970 hit to Finnish audiences; Aro's ability to capture the spirit of international pop while keeping a distinctly Finnish feel made him a fan favourite.",
@@ -1722,7 +1722,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=xck8ooTmxmY",
       "uri_tidal": "tidal://track/32520451",
       "uri_deezer": "deezer://track/1002290",
       "fun_fact": "'Tähdet meren yllä' (Stars Above the Sea) by Reijo Taipale showcases the Finnish tradition of nature imagery in iskelmä; the sea and stars are recurring motifs reflecting Finland's vast coastline and long dark nights.",
@@ -1752,7 +1752,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=RAUtaPD65q8",
       "uri_tidal": "tidal://track/364059",
       "uri_deezer": "deezer://track/80368034",
       "fun_fact": "Paula Koivuniemi's 'Perhonen' (Butterfly) became one of her signature songs; Koivuniemi has been a dominant force in Finnish popular music since the 1970s and is one of the country's most successful live performers.",
@@ -1782,7 +1782,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=POuOWRmjl0w",
       "uri_tidal": "tidal://track/10810244",
       "uri_deezer": "deezer://track/14957199",
       "fun_fact": "A. Aimo's 'Kaunis on luoksesi kaipuu' (Beautiful Is the Longing for You) is a tender wartime love song; Aimo was the troubadour of Finland's wartime generation, whose recordings gave voice to soldiers' homesickness and love.",
@@ -1812,7 +1812,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=iaMy7cUHLJk",
       "uri_tidal": "tidal://track/20788125",
       "uri_deezer": "deezer://track/74226373",
       "fun_fact": "Fredi's Finnish rendition of 'Love Is a Many Splendored Thing' illustrates how Hollywood film songs were regularly translated into Finnish during the 1960s and 70s, keeping cinema-inspired romance accessible to Finnish audiences.",
@@ -1876,7 +1876,7 @@
         "nl": "applemusic://track/1741005248",
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=MzheWNd65x4",
       "uri_tidal": "tidal://track/20555117",
       "uri_deezer": "deezer://track/1010525762",
       "fun_fact": "Tapio Rautavaara was not only Finland's most beloved folk singer of his era but also an Olympic javelin thrower who competed in the 1948 London Games; 'Päivänsäde ja menninkäinen' remains one of his most cherished recordings.",
@@ -1975,7 +1975,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=eTElyWaFJ4E",
       "uri_tidal": "tidal://track/20833372",
       "uri_deezer": "deezer://track/3610307",
       "fun_fact": "Seija Simola's 'Kun aika on' (When the Time Comes) is a melancholic reflection on patience and timing in love; Simola was one of the leading female voices of Finnish iskelmä in the late 1960s and early 1970s.",
@@ -2039,7 +2039,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=gXvNbDSArH8",
       "uri_tidal": "tidal://track/20569496",
       "uri_deezer": "deezer://track/4116238",
       "fun_fact": "Erkki Junkkarinen's 'Pieni hetki' (A Small Moment) captures the Finnish appreciation for fleeting precious moments — a philosophical current running through iskelmä that reflects the Lutheran and stoic strands of Finnish culture.",
@@ -2304,7 +2304,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=iPwdhTdR80A",
       "uri_tidal": "tidal://track/1578405",
       "uri_deezer": "deezer://track/10260526",
       "fun_fact": "Mutkattomat's 'Jätkän humppa' (The Lumberjack's Humppa) celebrates humppa, a uniquely Finnish uptempo dance genre descended from the foxtrot; lumberjacks ('jätkät') were iconic figures in Finnish folk culture, embodying rugged independence.",
@@ -2472,7 +2472,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=w_BDZhgpVJ0",
       "uri_tidal": "tidal://track/20898309",
       "uri_deezer": "deezer://track/3608769",
       "fun_fact": "Eino Grön's Finnish version of the Italian 'Torna Piccina' showcases the warm cross-pollination between Italian melody and Finnish sentiment; Grön's deep baritone gave Italian songs a new emotional palette for Finnish listeners.",
@@ -2502,7 +2502,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Z1kqeKgmPmc",
       "uri_tidal": "tidal://track/20788127",
       "uri_deezer": "deezer://track/3608571",
       "fun_fact": "Fredi's Finnish version of the Godfather theme 'Speak Softly Love' became one of his most remembered recordings; the song's cinematic romance translated beautifully into Finnish iskelmä style.",
@@ -2532,7 +2532,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=MxRzgYMnmGs",
       "uri_tidal": "tidal://track/364173",
       "uri_deezer": "deezer://track/3893606",
       "fun_fact": "Hortto Kaalo, a Finnish Roma music group, brought the rich Romani tradition into the iskelmä mainstream with 'Ei kenenkään lähimmäinen', helping give visibility to Finland's Romani community through popular music.",
@@ -2663,7 +2663,7 @@
         "nl": "applemusic://track/250411615",
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=T2EMSBg2ifc",
       "uri_tidal": "tidal://track/36720833",
       "uri_deezer": "deezer://track/3861990",
       "fun_fact": "Vesa-Matti Loiri's 'Lapin kesä' (Lapland Summer) reflects his deep love for Finnish nature; Loiri was a celebrated actor, comedian, and singer who became a true national treasure, known for his extraordinary versatility.",
@@ -2693,7 +2693,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=YNlBrJkvzg0",
       "uri_tidal": "tidal://track/398078",
       "uri_deezer": "deezer://track/3861986",
       "fun_fact": "Vesa-Matti Loiri's 'Nocturne' demonstrates his artistic ambition beyond comedy; Loiri was a serious musician as well as Finland's most beloved comic actor, and his heartfelt musical recordings stand as works of genuine art.",
@@ -2723,7 +2723,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=m5_fiVnuAh4",
       "uri_tidal": "tidal://track/398074",
       "uri_deezer": "deezer://track/3861982",
       "fun_fact": "Vesa-Matti Loiri's 'Elegia' (Elegy) showcases his profound ability to interpret serious, poetic material; Loiri set several Finnish classical poems to music, and his vocal performances of these pieces are considered definitive.",
@@ -2887,7 +2887,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=HTZPqRlvO8o",
       "uri_tidal": "tidal://track/1842252",
       "uri_deezer": "deezer://track/13259045",
       "fun_fact": "Reijo Kallio's 'Yksinäinen' (Lonely) captures the theme of solitude that runs through much of Finnish popular music; loneliness and longing ('ikävä') are perhaps the most defining emotional themes of the iskelmä genre.",
@@ -2951,7 +2951,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=9KpvVepzjtg",
       "uri_tidal": "tidal://track/20905895",
       "uri_deezer": "deezer://track/3595917",
       "fun_fact": "Laila Kinnunen's 'Tiet' (Roads) is a metaphorical song about life's journey; Kinnunen represented Finland at Eurovision 1961 and was one of the first Finnish artists to achieve genuine pan-European recognition.",
@@ -3048,7 +3048,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Ak8P3XNjEvQ",
       "uri_tidal": "tidal://track/20555612",
       "uri_deezer": "deezer://track/117677730",
       "fun_fact": "Tapio Rautavaara's 'En päivääkään vaihtaisi pois' (I Wouldn't Trade a Single Day) is a celebration of life and contentment, reflecting his philosophy that even hardship has value — a theme resonant in post-war Finnish culture.",
@@ -3207,7 +3207,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=bWARUc0oHQ4",
       "uri_tidal": "tidal://track/1902155",
       "uri_deezer": "deezer://track/3595414",
       "fun_fact": "'Uralin pihlaja' (The Rowan Tree of the Urals) is Tapio Rautavaara's moving tribute to the Karelian lands lost to the Soviet Union; the rowan tree is a Finnish national symbol, and the song carries profound historical resonance for Finns.",


### PR DESCRIPTION
Ein Lauf des `provider-uri-backfill`, automatisch gefahren von `com.beatify.youtube-backfill`.

- `finnish-iskelma-classics` YouTube 243 -> **267**/293

**Draft mit Absicht** — Merge nur nach Markus' Freigabe.