### PR TITLE
chore(playlists): apple backfill — +14 apple uris

### DIFF
--- a/custom_components/beatify/playlists/90er-hits.json
+++ b/custom_components/beatify/playlists/90er-hits.json
@@ -1,6 +1,6 @@
 {
   "name": "90s Hits",
-  "version": "1.19",
+  "version": "1.20",
   "tags": [
     "1990s",
     "pop",
@@ -1218,7 +1218,7 @@
       "fun_fact_de": "Sohn von Randy Bachman (Bachman-Turner Overdrive). Dieser One-Hit-Wonder verglich seine Angebetete mit Kleopatra, Jeanne d’Arc und Aphrodite.",
       "fun_fact_es": "Hijo de Randy Bachman (Bachman-Turner Overdrive). Este artista de un solo éxito comparó a su amor platónico con Cleopatra, Juana de Arco y Afrodita.",
       "fun_fact_fr": "Fils de Randy Bachman (Bachman-Turner Overdrive), cet artiste d'un seul tube comparait la femme de ses rêves à Cléopâtre, Jeanne d'Arc et Aphrodite.",
-      "uri_apple_music": "",
+      "uri_apple_music": "applemusic://track/158610105",
       "uri_youtube_music": "https://music.youtube.com/watch?v=_ElORM9O-0U",
       "uri_deezer": "deezer://track/623469",
       "fun_fact_nl": "Zoon van Randy Bachman (Bachman-Turner Overdrive). Deze eenaggers vergeleek zijn crush met Cleopatra, Jeanne d'Arc en Aphrodite.",
@@ -1248,7 +1248,7 @@
       "fun_fact_de": "Geschrieben von Wyclef Jean. Der Titelsong ihres Comeback-Albums zeigte eine reifere, weniger divenhaft Whitney. Der Song handelt von bedingungsloser Liebe.",
       "fun_fact_es": "Escrita por Wyclef Jean. El tema principal de su álbum de regreso mostró una Whitney más madura, menos diva del pop. La canción habla del amor incondicional.",
       "fun_fact_fr": "Écrit par Wyclef Jean, ce titre phare de son album de retour montrait une Whitney plus mature, loin de l'image de pop diva. La chanson parle d'amour inconditionnel.",
-      "uri_apple_music": "",
+      "uri_apple_music": "applemusic://track/251090745",
       "uri_youtube_music": "https://music.youtube.com/watch?v=kxZD0VQvfqU",
       "uri_deezer": "deezer://track/962260",
       "fun_fact_nl": "Geschreven door Wyclef Jean. De titelsong van haar comeback-album toonde een volwassenere, minder popdiva Whitney. Het nummer gaat over onvoorwaardelijke liefde.",
@@ -1614,7 +1614,7 @@
       "year": 1999,
       "isrc": "DEH259900010",
       "uri": "spotify:track:6x4tKaOzfNJpEJHySoiJcs",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/1322068804",
       "uri_apple_music_by_region": {
         "us": null,
         "de": null,
@@ -1639,11 +1639,11 @@
       "year": 1983,
       "isrc": null,
       "uri": "spotify:track:0CtkjgZpkgnW7U6WmHsakD",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/256097956",
       "uri_apple_music_by_region": {},
       "uri_youtube_music": "https://music.youtube.com/watch?v=g6nthFTiPiI",
       "uri_tidal": "tidal://track/38036078",
-      "uri_deezer": null,
+      "uri_deezer": "deezer://track/2170703",
       "alt_artists": [
         "Jason Nevins"
       ],
@@ -2487,7 +2487,7 @@
       "year": 1997,
       "isrc": "GBAAA9700049",
       "uri": "spotify:track:5yEPxDjbbzUzyauGtnmVEC",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/1443258189",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/6763237471",
         "de": "applemusic://track/6763237471",
@@ -2517,7 +2517,7 @@
       "year": 1997,
       "isrc": "USUR19700175",
       "uri": "spotify:track:1HEBjmt2n8wmQvag4VqczV",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/713773457",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1893192107",
         "de": "applemusic://track/1893192107",
@@ -2547,7 +2547,7 @@
       "year": 1996,
       "isrc": "ITA169500003",
       "uri": "spotify:track:3boi65u59Ex9jbhLXcXwre",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/1499501875",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1237756427",
         "de": "applemusic://track/1606222112",
@@ -2637,7 +2637,7 @@
       "year": 1999,
       "isrc": "DEA310001549",
       "uri": "spotify:track:0l3795cAVGOHNdHvooZ25S",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/384919381",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1210811729",
         "de": "applemusic://track/1436144752",
@@ -2667,7 +2667,7 @@
       "year": 1999,
       "isrc": "GBHAD2400076",
       "uri": "spotify:track:4Y8q64VnhD0vFYy9g2WFpi",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/1823912862",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1764524416",
         "de": "applemusic://track/1764524416",
@@ -2697,7 +2697,7 @@
       "year": 1997,
       "isrc": "GBAWV9700657",
       "uri": "spotify:track:1arJHhz6TxMV50SNvSmGnV",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/1171366701",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1160733023",
         "de": "applemusic://track/1160733023",
@@ -2817,7 +2817,7 @@
       "year": 1997,
       "isrc": "USIR19500279",
       "uri": "spotify:track:7H8zey5My6uNdD2TxeCb9F",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/1440845557",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1442266778",
         "de": "applemusic://track/1442266778",
@@ -2877,7 +2877,7 @@
       "year": 1999,
       "isrc": "USIR19902530",
       "uri": "spotify:track:5EYdTPdJD74r9EVZBztqGG",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/1704947040",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1821521803",
         "de": "applemusic://track/1821521803",
@@ -2967,7 +2967,7 @@
       "year": 1996,
       "isrc": "DED169600128",
       "uri": "spotify:track:37tzoWY1ubBQKGXiWdO5Qv",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/217353621",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/217353621",
         "de": "applemusic://track/585659458",
@@ -3125,11 +3125,11 @@
       "year": 1990,
       "isrc": null,
       "uri": "spotify:track:3lcUQs5nyrjoHpQR9Vo2aA",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/1778288336",
       "uri_apple_music_by_region": {},
       "uri_youtube_music": "https://music.youtube.com/watch?v=BlaWhtHmUw4",
-      "uri_tidal": null,
-      "uri_deezer": null,
+      "uri_tidal": "tidal://track/40845268",
+      "uri_deezer": "deezer://track/78304375",
       "fun_fact": "A chart hit by The Adventures Of Stevie V (2013).",
       "fun_fact_de": "Ein Chart-Hit von The Adventures Of Stevie V (2013).",
       "fun_fact_es": "Un éxito de The Adventures Of Stevie V (2013).",


### PR DESCRIPTION
Ein Lauf des `provider-uri-backfill` mit Schwerpunkt Apple Music, automatisch gefahren von `com.beatify.apple-backfill`.

- `90er-hits` Apple 99 -> **113**/115

Nebenbei mitgefuellt, weil Odesli alle Provider in einer Antwort liefert: tidal +1, deezer +2.

**Draft mit Absicht** — Merge nur nach Markus' Freigabe. Fuer diesen Agenten gibt es bewusst KEINEN Automerge.