### PR TITLE
fix(backfill): record a YouTube miss only when the search really came back empty

### DIFF
--- a/.claude/skills/provider-uri-backfill/scripts/backfill_provider_uris.py
+++ b/.claude/skills/provider-uri-backfill/scripts/backfill_provider_uris.py
@@ -809,13 +809,30 @@ def resolve_deezer_via_search(
     return None
 
 
-def youtube_search_id(
+def youtube_search_ex(
     api_key: str,
     artist: str,
     title: str,
     getter: Callable[[str], dict] = _http_get_json,
-) -> str | None:
-    """search.list for ``artist title``; return the top video id (11 chars)."""
+) -> tuple[str | None, str]:
+    """search.list for ``artist title``; return ``(video_id, status)``.
+
+    ``status`` is the reason the caller needs and ``youtube_search_id`` throws
+    away:
+
+    ``hit``    ein verwertbares Video gefunden
+    ``empty``  YouTube hat geantwortet und **nichts** gefunden — eine echte
+               Absage, die in den Miss-Cache gehoert
+    ``error``  HTTP-/Netz-/Parse-Fehler oder eine unbrauchbare Antwort. Hier
+               ist **nichts** ueber den Song gelernt worden; ein Miss waere
+               eine Sperre auf Verdacht.
+
+    Die Unterscheidung ist der ganze Zweck der Funktion. Bis zum 15.08.2026
+    lieferte ``youtube_search_id`` fuer beide Faelle ``None``, weshalb
+    ``record_provider_misses`` YouTube pauschal ausgeschlossen hat — mit der
+    Folge, dass eine erfolglos durchsuchte Luecke jeden Lauf erneut Quote
+    kostete.
+    """
     q = urllib.parse.quote(f"{artist} {title}")
     url = (
         "https://www.googleapis.com/youtube/v3/search"
@@ -823,13 +840,29 @@ def youtube_search_id(
     )
     try:
         data = getter(url)
-    except urllib.error.HTTPError:
-        return None
+    except Exception:
+        # Bewusst breit: HTTPError, URLError, Timeout und JSON-Parsefehler
+        # sind hier dasselbe — die Suche hat nicht stattgefunden.
+        return None, "error"
     items = (data or {}).get("items") or []
     if not items:
-        return None
+        return None, "empty"
     vid = (items[0].get("id") or {}).get("videoId")
-    return vid if vid and _YT_ID.match(vid) else None
+    if vid and _YT_ID.match(vid):
+        return vid, "hit"
+    # Antwort da, aber unbrauchbar (fehlende/kaputte id). Das ist kein Beleg
+    # dafuer, dass es den Song nicht gibt.
+    return None, "error"
+
+
+def youtube_search_id(
+    api_key: str,
+    artist: str,
+    title: str,
+    getter: Callable[[str], dict] = _http_get_json,
+) -> str | None:
+    """search.list for ``artist title``; return the top video id (11 chars)."""
+    return youtube_search_ex(api_key, artist, title, getter)[0]
 
 
 def itunes_search(
@@ -1139,7 +1172,7 @@ def run(args: argparse.Namespace) -> int:
             if yt_gap and yt_key and not song.get("uri_youtube_music"):
                 if this_global_idx >= yt_state.cursor:
                     if yt_state.can_spend():
-                        vid = youtube_search_id(
+                        vid, yt_status = youtube_search_ex(
                             yt_key, song.get("artist", ""), song.get("title", "")
                         )
                         yt_state.spend()
@@ -1148,6 +1181,20 @@ def run(args: argparse.Namespace) -> int:
                             song["uri_youtube_music"] = youtube_uri(vid)
                             cov.filled_this_run["youtube_music"] += 1
                             song_dirty = True
+                        elif yt_status == "empty":
+                            # Gesucht und nichts gefunden: eine Absage wie
+                            # jede andere. NUR dieser Zweig darf einen Miss
+                            # schreiben — der Budget-Zweig unten und der
+                            # Fehlerfall duerfen es nicht, sonst wird aus
+                            # einer Tagesgrenze bzw. einer Stoerung eine
+                            # Sperre auf 90 Tage.
+                            miss_recorded += record_provider_misses(
+                                provider_misses,
+                                song_uri,
+                                ["youtube_music"],
+                                song,
+                                run_now,
+                            )
                     else:
                         yt_phase_note = (
                             f"daily budget {yt_state.budget} exhausted; "

--- a/tests/unit/test_provider_uri_backfill.py
+++ b/tests/unit/test_provider_uri_backfill.py
@@ -510,9 +510,7 @@ def test_run_apply_odesli_429_does_not_block_youtube(tmp_path, monkeypatch):
 
     # Odesli hard-rate-limited: skips every song (returns None), never raises.
     monkeypatch.setattr(bf, "fetch_odesli", lambda *a, **k: None)
-    monkeypatch.setattr(
-        bf, "youtube_search_ex", lambda *a, **k: ("dQw4w9WgXcQ", "hit")
-    )
+    monkeypatch.setattr(bf, "youtube_search_ex", lambda *a, **k: ("dQw4w9WgXcQ", "hit"))
     monkeypatch.setattr(bf.time, "sleep", lambda s: None)
     # Keyless Apple iTunes fallback is network → stub it off in these tests.
     monkeypatch.setattr(bf, "resolve_apple_via_itunes", lambda *a, **k: None)

--- a/tests/unit/test_provider_uri_backfill.py
+++ b/tests/unit/test_provider_uri_backfill.py
@@ -301,6 +301,42 @@ def test_youtube_search_no_items():
     assert bf.youtube_search_id("KEY", "a", "b", getter=lambda u: {"items": []}) is None
 
 
+def test_youtube_search_ex_reports_hit():
+    resp = {"items": [{"id": {"videoId": "dQw4w9WgXcQ"}}]}
+    assert bf.youtube_search_ex("KEY", "a", "b", getter=lambda u: resp) == (
+        "dQw4w9WgXcQ",
+        "hit",
+    )
+
+
+def test_youtube_search_ex_reports_empty_for_no_items():
+    """Gesucht, nichts gefunden — die einzige Lage, die einen Miss rechtfertigt."""
+    assert bf.youtube_search_ex("KEY", "a", "b", getter=lambda u: {"items": []}) == (
+        None,
+        "empty",
+    )
+
+
+def test_youtube_search_ex_reports_error_on_exception():
+    """Eine gescheiterte Anfrage ist KEIN Beleg gegen den Song."""
+    import urllib.error
+
+    def boom(url):
+        raise urllib.error.URLError("no route")
+
+    vid, status = bf.youtube_search_ex("KEY", "a", "b", getter=boom)
+    assert (vid, status) == (None, "error")
+
+
+def test_youtube_search_ex_reports_error_on_unusable_id():
+    """Antwort da, id unbrauchbar — auch das darf keine Absage werden."""
+    resp = {"items": [{"id": {"videoId": "zu-kurz"}}]}
+    assert bf.youtube_search_ex("KEY", "a", "b", getter=lambda u: resp) == (
+        None,
+        "error",
+    )
+
+
 # --- report aggregation ----------------------------------------------------
 def test_build_report_has_summary_and_rows():
     cov = bf.PlaylistCoverage(name="p.json", path="/p.json", total=10)
@@ -474,7 +510,9 @@ def test_run_apply_odesli_429_does_not_block_youtube(tmp_path, monkeypatch):
 
     # Odesli hard-rate-limited: skips every song (returns None), never raises.
     monkeypatch.setattr(bf, "fetch_odesli", lambda *a, **k: None)
-    monkeypatch.setattr(bf, "youtube_search_id", lambda *a, **k: "dQw4w9WgXcQ")
+    monkeypatch.setattr(
+        bf, "youtube_search_ex", lambda *a, **k: ("dQw4w9WgXcQ", "hit")
+    )
     monkeypatch.setattr(bf.time, "sleep", lambda s: None)
     # Keyless Apple iTunes fallback is network → stub it off in these tests.
     monkeypatch.setattr(bf, "resolve_apple_via_itunes", lambda *a, **k: None)
@@ -807,9 +845,9 @@ def test_run_youtube_odesli_first_pass_skips_search_list(tmp_path, monkeypatch):
 
     def boom_search(*a, **k):
         search_calls["n"] += 1
-        return "SHOULDNOTBE1"
+        return "SHOULDNOTBE1", "hit"
 
-    monkeypatch.setattr(bf, "youtube_search_id", boom_search)
+    monkeypatch.setattr(bf, "youtube_search_ex", boom_search)
     monkeypatch.setattr(bf.time, "sleep", lambda s: None)
     monkeypatch.setenv("YOUTUBE_API_KEY", "KEY")
 
@@ -866,9 +904,9 @@ def test_run_youtube_oembed_fail_falls_back_to_search_list(tmp_path, monkeypatch
 
     def real_search(*a, **k):
         search_calls["n"] += 1
-        return "dQw4w9WgXcQ"
+        return "dQw4w9WgXcQ", "hit"
 
-    monkeypatch.setattr(bf, "youtube_search_id", real_search)
+    monkeypatch.setattr(bf, "youtube_search_ex", real_search)
     monkeypatch.setattr(bf.time, "sleep", lambda s: None)
     monkeypatch.setenv("YOUTUBE_API_KEY", "KEY")
 
@@ -889,6 +927,101 @@ def test_run_youtube_oembed_fail_falls_back_to_search_list(tmp_path, monkeypatch
     song = json.loads(f.read_text())["songs"][0]
     assert song["uri_youtube_music"] == "https://music.youtube.com/watch?v=dQw4w9WgXcQ"
     assert search_calls["n"] == 1  # oembed failed → paid path used
+
+
+def _yt_only_playlist(tmp_path):
+    """Ein Song, dem nur die YouTube-URI fehlt."""
+    pl_dir = tmp_path / "custom_components" / "beatify" / "playlists"
+    pl_dir.mkdir(parents=True)
+    return _write_playlist(
+        pl_dir,
+        "ytmiss",
+        [
+            {
+                "artist": "Rick Astley",
+                "title": "Never Gonna Give You Up",
+                "uri": "spotify:track:" + "a" * 22,
+                "uri_apple_music": "applemusic://track/1",
+                "uri_tidal": "tidal://track/1",
+                "uri_deezer": "deezer://track/1",
+            }
+        ],
+    )
+
+
+def _run_yt(tmp_path, extra=()):
+    return bf.main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "--apply",
+            "--output",
+            str(tmp_path / "cov.md"),
+            "--state",
+            str(tmp_path / "state.json"),
+            "--odesli-sleep",
+            "0",
+            *extra,
+        ]
+    )
+
+
+def test_run_records_youtube_miss_when_search_finds_nothing(tmp_path, monkeypatch):
+    """Gesucht und nichts gefunden -> Absage im Cache, damit der naechste Lauf
+    dieselbe Luecke nicht erneut Quote kostet."""
+    _yt_only_playlist(tmp_path)
+    monkeypatch.setattr(bf, "fetch_odesli", lambda *a, **k: {"linksByPlatform": {}})
+    monkeypatch.setattr(bf, "resolve_apple_via_itunes", lambda *a, **k: None)
+    monkeypatch.setattr(bf, "resolve_deezer_via_search", lambda *a, **k: None)
+    monkeypatch.setattr(bf, "youtube_search_ex", lambda *a, **k: (None, "empty"))
+    monkeypatch.setattr(bf.time, "sleep", lambda s: None)
+    monkeypatch.setenv("YOUTUBE_API_KEY", "KEY")
+
+    assert _run_yt(tmp_path) == 0
+    misses = json.loads((tmp_path / "state.json").read_text())["provider_misses"]
+    entry = misses["spotify:track:" + "a" * 22]
+    assert "youtube_music" in entry
+
+
+def test_run_records_no_youtube_miss_on_search_error(tmp_path, monkeypatch):
+    """Eine gescheiterte Anfrage darf keine 90-Tage-Sperre erzeugen."""
+    _yt_only_playlist(tmp_path)
+    monkeypatch.setattr(bf, "fetch_odesli", lambda *a, **k: {"linksByPlatform": {}})
+    monkeypatch.setattr(bf, "resolve_apple_via_itunes", lambda *a, **k: None)
+    monkeypatch.setattr(bf, "resolve_deezer_via_search", lambda *a, **k: None)
+    monkeypatch.setattr(bf, "youtube_search_ex", lambda *a, **k: (None, "error"))
+    monkeypatch.setattr(bf.time, "sleep", lambda s: None)
+    monkeypatch.setenv("YOUTUBE_API_KEY", "KEY")
+
+    assert _run_yt(tmp_path) == 0
+    misses = json.loads((tmp_path / "state.json").read_text()).get(
+        "provider_misses", {}
+    )
+    entry = misses.get("spotify:track:" + "a" * 22, {})
+    assert "youtube_music" not in entry
+
+
+def test_run_records_no_youtube_miss_when_budget_exhausted(tmp_path, monkeypatch):
+    """Der Fall, der die Ausnahme urspruenglich begruendet hat: ohne Aufruf
+    keine Absage."""
+    _yt_only_playlist(tmp_path)
+    monkeypatch.setattr(bf, "fetch_odesli", lambda *a, **k: {"linksByPlatform": {}})
+    monkeypatch.setattr(bf, "resolve_apple_via_itunes", lambda *a, **k: None)
+    monkeypatch.setattr(bf, "resolve_deezer_via_search", lambda *a, **k: None)
+
+    def must_not_run(*a, **k):
+        raise AssertionError("search.list darf bei aufgebrauchtem Budget nicht laufen")
+
+    monkeypatch.setattr(bf, "youtube_search_ex", must_not_run)
+    monkeypatch.setattr(bf.time, "sleep", lambda s: None)
+    monkeypatch.setenv("YOUTUBE_API_KEY", "KEY")
+
+    assert _run_yt(tmp_path, ["--youtube-budget", "0"]) == 0
+    misses = json.loads((tmp_path / "state.json").read_text()).get(
+        "provider_misses", {}
+    )
+    entry = misses.get("spotify:track:" + "a" * 22, {})
+    assert "youtube_music" not in entry
 
 
 def test_run_apply_itunes_fills_apple_when_odesli_lacks_it(tmp_path, monkeypatch):


### PR DESCRIPTION
## What

`youtube_search_ex` returns `(video_id, status)` with `status` in `hit` / `empty` / `error`. Only `empty` records a provider miss. `youtube_search_id` stays as a thin wrapper.

## Why

YouTube was excluded from the miss cache wholesale:

```python
non_yt_gaps = [g for g in gaps if g != "youtube_music"]
```

The reason was sound. `youtube_search_id` returns `None` both for "searched, found nothing" and for any HTTP error, and the Data API runs on a 90-call daily budget. Recording a miss on `None` would turn a daily limit, or a transient 500, into a 90-day block on a song nobody ever looked up.

The cost was that a genuinely unresolvable YouTube gap burns quota on every single run. In the fill report all 415 open YouTube gaps therefore count as "fillable" — the one number there that is systematically too high.

## The three cases, now separated

| Case | Status | Miss recorded |
|---|---|---|
| Video found | `hit` | no |
| Answered, no items | `empty` | **yes** |
| HTTP / network / parse error, unusable id | `error` | no |
| Daily budget exhausted, no call made | — | no (branch untouched) |

## Tests

Seven new, 92 green. Three of them assert the behaviour end to end: empty search records the miss, an error does not, and an exhausted budget neither records nor calls `search.list` at all.

## Follow-up after merge

The note "for YouTube no refusals are ever recorded" in `beatifybot/wiki/skills/provider-fill-report/SKILL.md` needs updating.