### PR TITLE
chore(playlists): youtube backfill — +20 youtube uris

### DIFF
--- a/custom_components/beatify/playlists/community/edm-anthems.json
+++ b/custom_components/beatify/playlists/community/edm-anthems.json
@@ -1,6 +1,6 @@
 {
   "name": "EDM Anthems",
-  "version": "1.23",
+  "version": "1.27",
   "tags": [
     "edm",
     "electronic",
@@ -4079,7 +4079,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=6HhzIn8I4ak",
       "uri_tidal": "tidal://track/14658643",
       "uri_deezer": "deezer://track/18181530",
       "fun_fact": "“Pursuit Of Happiness - Extended Steve Aoki Remix” appears on Kid Cudi’s release “Pursuit Of Happiness [Extended Steve Aoki Remix (Explicit)]”.",
@@ -4109,7 +4109,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Cw0nkxFhpoM",
       "uri_tidal": "tidal://track/21399997",
       "uri_deezer": "deezer://track/69194935",
       "fun_fact": "“Cinema - Skrillex Remix” appears on Benny Benassi’s release “Electroman”.",
@@ -4139,7 +4139,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=9TJGY8_22Kk",
       "uri_tidal": "tidal://track/6649657",
       "uri_deezer": "deezer://track/11234004",
       "fun_fact": "“Save The World” is the title track of Swedish House Mafia’s release of the same name.",
@@ -4169,7 +4169,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=hRxv0EmgEaY",
       "uri_tidal": "tidal://track/109010807",
       "uri_deezer": "deezer://track/676912382",
       "fun_fact": "“Heads Will Roll - A-Trak Remix Radio Edit” appears on Yeah Yeah Yeahs’s release “Heads Will Roll”.",
@@ -4199,7 +4199,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=KXBKxx2b-rE",
       "uri_tidal": "tidal://track/19906571",
       "uri_deezer": "deezer://track/66822689",
       "fun_fact": "“Reload - Radio Edit” appears on Sebastian Ingrosso’s release “Reload (Vocal Version / Radio Edit)”.",
@@ -4229,7 +4229,7 @@
         "nl": "applemusic://track/1483618721",
         "it": "applemusic://track/1483618721"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=irfSOiH1_Ns",
       "uri_tidal": "tidal://track/120241323",
       "uri_deezer": "deezer://track/776083862",
       "fun_fact": "“Epic - Radio Edit” appears on Sandro Silva’s release “Epic”.",
@@ -4289,7 +4289,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=akhmS1D2Ce4",
       "uri_tidal": "tidal://track/227503406",
       "uri_deezer": "deezer://track/69954067",
       "fun_fact": "“Summertime Sadness (Lana Del Rey Vs. Cedric Gervais) - Cedric Gervais Remix” is the title track of Lana Del Rey’s release of the same name.",
@@ -4319,7 +4319,7 @@
         "nl": "applemusic://track/873131250",
         "it": "applemusic://track/873131250"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Rt25H3OqT5g",
       "uri_tidal": "tidal://track/30214472",
       "uri_deezer": "deezer://track/78974349",
       "fun_fact": "“Gecko (Overdrive) - Radio Edit” is the title track of Oliver Heldens’s release of the same name.",
@@ -4409,7 +4409,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=ll5ykbAumD4",
       "uri_tidal": "tidal://track/80031865",
       "uri_deezer": "deezer://track/99374314",
       "fun_fact": "“Sun & Moon - Original Mix” appears on Above & Beyond’s release “Group Therapy”.",
@@ -4469,7 +4469,7 @@
         "nl": "applemusic://track/535279482",
         "it": "applemusic://track/535279482"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=J-gYJBsln-w",
       "uri_tidal": "tidal://track/15956685",
       "uri_deezer": "deezer://track/38019911",
       "fun_fact": "“Alive” appears on Krewella’s release “Play Hard EP”.",
@@ -4529,7 +4529,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=SYM-RJwSGQ8",
       "uri_tidal": "tidal://track/39441061",
       "uri_deezer": "deezer://track/92984012",
       "fun_fact": "“Habits (Stay High) - Hippie Sabotage Remix” appears on Tove Lo’s release “Queen Of The Clouds”.",
@@ -4559,7 +4559,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=lETmskoqh30",
       "uri_tidal": "tidal://track/237114050",
       "uri_deezer": "deezer://track/938184312",
       "fun_fact": "“Spaceman - Edit” appears on Hardwell’s release “I Am Hardwell (Original Soundtrack)”.",
@@ -4589,7 +4589,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=adGVpCsf9N4",
       "uri_tidal": "tidal://track/85082920",
       "uri_deezer": "deezer://track/479839272",
       "fun_fact": "“Take Over Control (feat. Eva Simons) - Radio Edit” is the title track of AFROJACK’s release of the same name.",
@@ -4649,7 +4649,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=zK1mLIeXwsQ",
       "uri_tidal": "tidal://track/21435624",
       "uri_deezer": "deezer://track/858979012",
       "fun_fact": "“I Remember” appears on Kaskade’s release “Strobelite Seduction”.",
@@ -4709,7 +4709,7 @@
         "nl": "applemusic://track/400429622",
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Jrd25gjyDhE",
       "uri_tidal": "tidal://track/66399550",
       "uri_deezer": "deezer://track/14708131",
       "fun_fact": "“Seek Bromance (Avicii Vocal Edit)” appears on Tim Berg’s release “Seek Bromance”.",
@@ -4769,7 +4769,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=HdzI-191xhU",
       "uri_tidal": "tidal://track/32904099",
       "uri_deezer": "deezer://track/82182346",
       "fun_fact": "“Say My Name” appears on ODESZA’s release “In Return”.",
@@ -4799,7 +4799,7 @@
         "nl": "applemusic://track/1058740894",
         "it": "applemusic://track/1058740894"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Tx9zMFodNtA",
       "uri_tidal": "tidal://track/56068951",
       "uri_deezer": "deezer://track/113475002",
       "fun_fact": "“Innerbloom” appears on RÜFÜS DU SOL’s release “Bloom”.",
@@ -4829,7 +4829,7 @@
         "nl": "applemusic://track/1804350103",
         "it": "applemusic://track/1804350103"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=_o-XIryB2gg",
       "uri_tidal": "tidal://track/426118752",
       "uri_deezer": "deezer://track/3278706951",
       "fun_fact": "“Mammoth” is the title track of Dimitri Vegas’s release of the same name.",
@@ -4859,7 +4859,7 @@
         "nl": "applemusic://track/1673828907",
         "it": "applemusic://track/1673828907"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=5BqjhUmldDc",
       "uri_tidal": "tidal://track/278684345",
       "uri_deezer": "deezer://track/2164533907",
       "fun_fact": "“Where You Are” appears on John Summit’s release “Comfort In Chaos”.",
@@ -4889,7 +4889,7 @@
         "nl": "applemusic://track/696886431",
         "it": "applemusic://track/696886431"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=K0HSD_i2DvA",
       "uri_tidal": "tidal://track/161017",
       "uri_deezer": "deezer://track/3129775",
       "fun_fact": "“Around the World” appears on Daft Punk’s release “Homework”.",


### PR DESCRIPTION
Ein Lauf des `provider-uri-backfill`, automatisch gefahren von `com.beatify.youtube-backfill`.

- `edm-anthems` YouTube 148 -> **168**/190

**Draft mit Absicht** — Merge nur nach Markus' Freigabe.