### PR TITLE
chore(playlists): apple backfill — +10 apple uris

### DIFF
--- a/custom_components/beatify/playlists/community/british-invasion-britpop.json
+++ b/custom_components/beatify/playlists/community/british-invasion-britpop.json
@@ -1,6 +1,6 @@
 {
   "name": "British Invasion & Britpop 🇬🇧",
-  "version": "1.5",
+  "version": "1.6",
   "tags": [
     "1960s",
     "1990s",
@@ -81,7 +81,8 @@
       "fun_fact_fr": "C'était le morceau d'ouverture de Definitely Maybe et il est devenu un classique pour ouvrir les concerts. Noel Gallagher a déclaré que la chanson parlait de vouloir être une rock star tout en étant au chômage à Manchester.",
       "uri_deezer": "deezer://track/2785951382",
       "fun_fact_nl": "Dit was het openingsnummer van Definitely Maybe en werd een vast nummer om concerten mee te openen. Noel Gallagher zei dat het nummer ging over het willen zijn van een rockster terwijl hij in de bijstand zat in Manchester.",
-      "awards_nl": []
+      "awards_nl": [],
+      "uri_apple_music": "applemusic://track/1517506686"
     },
     {
       "year": 1966,
@@ -519,7 +520,8 @@
       "fun_fact_fr": "Écrite à l'origine par Doc Pomus et Mort Shuman pour The Drifters, la reprise des Searchers est devenue le premier numéro un d'un groupe de Liverpool qui n'était pas les Beatles. Ils l'ont enregistrée en une seule prise.",
       "uri_deezer": "deezer://track/73488983",
       "fun_fact_nl": "Oorspronkelijk geschreven door Doc Pomus en Mort Shuman voor The Drifters, werd de cover van The Searchers de eerste nummer 1-hit van een band uit Liverpool die niet The Beatles was. Ze namen het in slechts één take op.",
-      "awards_nl": []
+      "awards_nl": [],
+      "uri_apple_music": "applemusic://track/1088613741"
     },
     {
       "year": 1994,
@@ -680,7 +682,8 @@
       "fun_fact_nl": "De iconische, op Bach geïnspireerde orgelintro werd gespeeld door Matthew Fisher, die decennia later een baanbrekende rechtszaak won waardoor hij als medeauteur werd erkend. Het nummer verkocht wereldwijd meer dan 10 miljoen exemplaren.",
       "awards_nl": [
         "Ivor Novello Award voor Meest Uitgevoerd Werk"
-      ]
+      ],
+      "uri_apple_music": "applemusic://track/1469579797"
     },
     {
       "year": 1995,
@@ -711,7 +714,8 @@
       "fun_fact_fr": "Jarvis Cocker a écrit ceci sur une vraie rencontre avec une étudiante en art grecque à Central Saint Martins qui disait vouloir vivre comme les gens ordinaires. Elle est régulièrement élue parmi les plus grandes chansons britanniques de tous les temps.",
       "uri_deezer": "deezer://track/910074",
       "fun_fact_nl": "Jarvis Cocker schreef dit over een echte ontmoeting met een Griekse kunststudent aan Central Saint Martins die zei dat ze als 'gewone mensen' wilde leven. Het wordt regelmatig verkozen tot een van de beste Britse nummers aller tijden.",
-      "awards_nl": []
+      "awards_nl": [],
+      "uri_apple_music": "applemusic://track/1440767243"
     },
     {
       "year": 1969,
@@ -2191,7 +2195,8 @@
       "fun_fact_fr": "Bien que Hendrix soit américain, sa carrière a été lancée depuis Londres après que Chas Chandler de The Animals l'ait amené en Angleterre. « Purple Haze » a d'abord été un hit au Royaume-Uni avant de traverser l'Atlantique.",
       "uri_deezer": "deezer://track/4952885",
       "fun_fact_nl": "Hoewel Hendrix Amerikaans was, werd zijn carrière gelanceerd vanuit Londen nadat Chas Chandler van The Animals hem naar Engeland bracht. 'Purple Haze' was eerst een hit in het VK voordat het de oversteek maakte naar de VS.",
-      "awards_nl": []
+      "awards_nl": [],
+      "uri_apple_music": "applemusic://track/344799464"
     },
     {
       "year": 1996,
@@ -2340,7 +2345,8 @@
       "fun_fact_fr": "The Marbles était un duo produit et composé par Barry et Robin Gibb des Bee Gees. Leur premier single « Only One Woman » a été un plus grand succès, atteignant la 5e place au Royaume-Uni.",
       "uri_deezer": "deezer://track/70928755",
       "fun_fact_nl": "The Marbles was een duo waarvoor Barry en Robin Gibb van de Bee Gees schreven en produceerden. Hun eerste single 'Only One Woman' was een grotere hit en bereikte nummer 5 in het VK.",
-      "awards_nl": []
+      "awards_nl": [],
+      "uri_apple_music": "applemusic://track/1494461041"
     },
     {
       "year": 1997,
@@ -2737,7 +2743,9 @@
       "fun_fact_fr": "Cette chanson a célèbrement empêché le double single A « Strawberry Fields Forever / Penny Lane » des Beatles d'atteindre le numéro un britannique, mettant fin à la série de numéros un consécutifs des Beatles.",
       "uri_deezer": "deezer://track/932731",
       "fun_fact_nl": "Dit nummer zorgde ervoor dat de dubbele A-kant van 'Strawberry Fields Forever / Penny Lane' van The Beatles niet op de eerste plaats belandde in de UK, wat een einde maakte aan de reeks opeenvolgende hitparade-toppers van The Beatles.",
-      "awards_nl": []
+      "awards_nl": [],
+      "uri_tidal": "tidal://track/73871587",
+      "uri_apple_music": "applemusic://track/1440648816"
     },
     {
       "year": 1993,
@@ -2766,7 +2774,8 @@
       "fun_fact_fr": "The Fall, dirigé par le célèbrement irascible Mark E. Smith, a eu plus de 60 membres au cours de leur carrière. Smith a dit un jour que la formule du groupe était « toujours différent, toujours pareil ».",
       "uri_deezer": "deezer://track/1356313962",
       "fun_fact_nl": "The Fall, geleid door de beroemde brombeer Mark E. Smith, heeft tijdens hun carrière meer dan 60 leden gehad. Smith zei ooit dat de formule van de band 'altijd anders, altijd hetzelfde' was.",
-      "awards_nl": []
+      "awards_nl": [],
+      "uri_apple_music": "applemusic://track/956037116"
     },
     {
       "year": 1964,
@@ -3366,7 +3375,8 @@
       "uri_deezer": "deezer://track/1701073217",
       "fun_fact_nl": "Anne Briggs was een enorm invloedrijke figuur in de Britse folk revival die de muziek vaarwel zei om een teruggetrokken leven te gaan leiden in de Schotse Hooglanden. Ze was een belangrijke inspiratie voor Sandy Denny en vele anderen.",
       "awards_nl": [],
-      "uri_tidal": "tidal://track/222867938"
+      "uri_tidal": "tidal://track/222867938",
+      "uri_apple_music": "applemusic://track/1617409983"
     },
     {
       "year": 1996,
@@ -3600,7 +3610,8 @@
       "fun_fact_fr": "Kenny Lynch était l'un des premiers chanteurs pop noirs britanniques à avoir un hit dans les charts britanniques. Il a également été l'un des premiers artistes à reprendre une chanson des Beatles, enregistrant sa propre version de « Misery » en 1963.",
       "uri_deezer": "deezer://track/10015100",
       "fun_fact_nl": "Kenny Lynch was een van de eerste zwarte Britse popzangers met een hit in de Britse hitlijsten. Hij was ook een van de eerste artiesten die een nummer van de Beatles coverde, door zijn eigen versie van 'Misery' op te nemen in 1963.",
-      "awards_nl": []
+      "awards_nl": [],
+      "uri_apple_music": "applemusic://track/1315733747"
     },
     {
       "year": 1983,


### PR DESCRIPTION
Ein Lauf des `provider-uri-backfill` mit Schwerpunkt Apple Music, automatisch gefahren von `com.beatify.apple-backfill`.

- `british-invasion-britpop` Apple 86 -> **96**/100

Nebenbei mitgefuellt, weil Odesli alle Provider in einer Antwort liefert: tidal +1.

**Draft mit Absicht** — Merge nur nach Markus' Freigabe. Fuer diesen Agenten gibt es bewusst KEINEN Automerge.