### PR TITLE
data: drop 8 dead Apple region entries in greatest-hits-of-all-time

### DIFF
--- a/custom_components/beatify/playlists/greatest-hits-of-all-time.json
+++ b/custom_components/beatify/playlists/greatest-hits-of-all-time.json
@@ -1,6 +1,6 @@
 {
   "name": "Greatest Hits of All Time",
-  "version": "2.15",
+  "version": "2.16",
   "tags": [
     "classics",
     "top-hits",
@@ -2796,16 +2796,7 @@
       "awards_nl": [
         "Grammy Hall of Fame (2003)"
       ],
-      "isrc": "USCA20001654",
-      "uri_apple_music_by_region": {
-        "us": "applemusic://track/1698230404",
-        "de": "applemusic://track/1698230404",
-        "gb": "applemusic://track/1698230404",
-        "fr": "applemusic://track/1698230404",
-        "es": "applemusic://track/1698230404",
-        "nl": "applemusic://track/1698230404",
-        "it": "applemusic://track/1698230404"
-      }
+      "isrc": "USCA20001654"
     },
     {
       "year": 1987,
@@ -7324,7 +7315,6 @@
       "isrc": "USPR37609134",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1590952411",
-        "de": "applemusic://track/1442323421",
         "gb": "applemusic://track/1590952411",
         "fr": "applemusic://track/1590952411",
         "es": "applemusic://track/1590952411",


### PR DESCRIPTION
Closes #2185.

Removes the Beach Boys region map (all seven entries pointed at a dead id) and the single dead `de` entry for KISS. Base URIs are intact in both cases, so playback falls back to them.

Deliberately not repointing KISS `de` at the id the other six regions use — that would assert availability in a storefront nobody checked, which is how the broken map got there.

version 2.15 → 2.16, schema gate green.