### PR TITLE
data: remove unofficial YouTube Music URI for John Miles "Music" (#2190)

### DIFF
--- a/custom_components/beatify/playlists/greatest-hits-of-all-time.json
+++ b/custom_components/beatify/playlists/greatest-hits-of-all-time.json
@@ -1,6 +1,6 @@
 {
   "name": "Greatest Hits of All Time",
-  "version": "2.16",
+  "version": "2.17",
   "tags": [
     "classics",
     "top-hits",
@@ -2985,7 +2985,6 @@
       "fun_fact_de": "Music von John Miles baut sich von einer sanften Ballade zu einem symphonischen Rock-Epos mit vollem Orchester auf. Miles schrieb es als Hommage an die Kraft der Musik selbst. Der Song bleibt ein Konzertfavorit und gilt als eine der größten Progressive-Rock-Kompositionen der 1970er.",
       "fun_fact_es": "Music de John Miles se construye desde una balada suave hasta una épica de rock sinfónico con orquesta completa. Miles la escribió como tributo al poder de la música misma. La canción sigue siendo una favorita en conciertos y se considera una de las mejores composiciones de rock progresivo de los años 70.",
       "fun_fact_fr": "Music de John Miles évolue d'une ballade délicate vers une épopée de rock symphonique avec orchestre complet. Miles l'a écrite comme un hommage à la puissance de la musique elle-même. Le morceau reste un favori en concert et est considéré comme l'une des plus grandes compositions de rock progressif des années 70.",
-      "uri_youtube_music": "https://music.youtube.com/watch?v=lAsvjVx-Mg4",
       "uri_apple_music": "applemusic://track/1768738565",
       "uri_tidal": "tidal://track/34823548",
       "uri_deezer": "deezer://track/16143727",


### PR DESCRIPTION
Closes #2190.

The YouTube Music URI for John Miles "Music" (`lAsvjVx-Mg4`) resolves to an unofficial fan channel upload (channel "KATTIVIK62") rather than an official artist track. No official YouTube Music replacement was found for this 1976 UK hit.

Removed `uri_youtube_music` from the song entry. The track remains playable on Spotify, Tidal, Deezer, and Apple Music. Version bumped 2.16 → 2.17.

**Note:** 8 dead Apple Music region-map entries also detected in this health check run (The Beach Boys "Surfin' U.S.A." and KISS "Detroit Rock City") were already addressed in PR #2186, which merged before this PR.