### PR TITLE
data: drop 8 dead Apple region entries in motown-soul-classics

### DIFF
--- a/custom_components/beatify/playlists/motown-soul-classics.json
+++ b/custom_components/beatify/playlists/motown-soul-classics.json
@@ -1,6 +1,6 @@
 {
   "name": "Motown & Soul Classics",
-  "version": "1.12",
+  "version": "1.13",
   "tags": [
     "1960s",
     "1970s",
@@ -659,7 +659,6 @@
       ],
       "isrc": "USMO17500374",
       "uri_apple_music_by_region": {
-        "us": "applemusic://track/1819076170",
         "de": "applemusic://track/1612221191",
         "gb": "applemusic://track/1612221191",
         "fr": "applemusic://track/1612221191",
@@ -1406,15 +1405,6 @@
         "Grammy Award voor Beste R&B Zangprestatie"
       ],
       "isrc": "USMO17600547",
-      "uri_apple_music_by_region": {
-        "us": "applemusic://track/1708519509",
-        "de": "applemusic://track/1708519509",
-        "gb": "applemusic://track/1708519509",
-        "fr": "applemusic://track/1708519509",
-        "es": "applemusic://track/1708519509",
-        "nl": "applemusic://track/1708519509",
-        "it": "applemusic://track/1708519509"
-      },
       "uri_tidal": "tidal://track/98184494"
     },
     {


### PR DESCRIPTION
Closes #2194 (the data half).

Removes the Thelma Houston region map (one dead id in all seven regions) and the single dead `us` entry for Diana Ross. Base URIs are healthy in both cases, so playback falls back to them.

**The second half of #2194 is not in this PR**: the health check's ISSUES gate ignores `region_summary`, which is why this run reported "All tracks healthy" while eight region entries were dead. That is a change to `run-health-check.sh` and deserves its own PR.

version 1.12 → 1.13, schema gate green.