### PR TITLE
data: remove James Brown "Sex Machine" from 2000s-pop-anthems

### DIFF
--- a/custom_components/beatify/playlists/2000s-pop-anthems.json
+++ b/custom_components/beatify/playlists/2000s-pop-anthems.json
@@ -1,6 +1,6 @@
 {
   "name": "2000s Pop Anthems",
-  "version": "1.17",
+  "version": "1.18",
   "tags": [
     "2000s",
     "pop",
@@ -6739,34 +6739,6 @@
       "fun_fact_es": "Un éxito de Kylie Minogue (2000).",
       "fun_fact_fr": "Un tube de Kylie Minogue (2000).",
       "fun_fact_nl": "Een chart-hit van Kylie Minogue (2000)."
-    },
-    {
-      "artist": "James Brown",
-      "title": "Get Up I Feel Like Being Like A Sex Machine, Pts. 1 & 2",
-      "year": 2005,
-      "isrc": "USF067025050",
-      "uri": "spotify:track:6hpmTwgNCz81H2bFEREx29",
-      "uri_apple_music": "applemusic://track/1646679726",
-      "uri_apple_music_by_region": {
-        "us": "applemusic://track/1646679726",
-        "de": "applemusic://track/1646679726",
-        "gb": "applemusic://track/1646679726",
-        "fr": "applemusic://track/1646679726",
-        "es": "applemusic://track/1646679726",
-        "nl": "applemusic://track/1452460238",
-        "it": "applemusic://track/1646679726"
-      },
-      "uri_youtube_music": "https://music.youtube.com/watch?v=hY_LBqmyNrk",
-      "uri_tidal": "tidal://track/93614211",
-      "uri_deezer": "deezer://track/548876882",
-      "alt_artists": [
-        "The Original J.B.s"
-      ],
-      "fun_fact": "A chart hit by James Brown (2005).",
-      "fun_fact_de": "Ein Chart-Hit von James Brown (2005).",
-      "fun_fact_es": "Un éxito de James Brown (2005).",
-      "fun_fact_fr": "Un tube de James Brown (2005).",
-      "fun_fact_nl": "Een chart-hit van James Brown (2005)."
     },
     {
       "artist": "Rihanna",


### PR DESCRIPTION
Closes #2196, closes #2192.

The track is from 1970, the playlist spans 2000-2009. Removing it rather than correcting the year to 1970 and leaving a three-decade outlier in a decade playlist.

182 → 181 songs, range back to a clean 2000-2009. version 1.17 → 1.18, schema gate green.