### PR TITLE
data: add Spotify URI for Youssou N'Dour — La Cour Des Grands

### DIFF
--- a/custom_components/beatify/playlists/world-cup-anthems.json
+++ b/custom_components/beatify/playlists/world-cup-anthems.json
@@ -1,6 +1,6 @@
 {
   "name": "World Cup Anthems",
-  "version": "1.12",
+  "version": "1.13",
   "tags": [
     "world-cup",
     "fifa",
@@ -284,7 +284,7 @@
       "fun_fact_es": "Himno oficial de Francia 98, mezcla de mbalax senegalés y chanson francesa.",
       "fun_fact_fr": "Hymne officiel de France '98, mélange de mbalax sénégalais et de chanson française.",
       "fun_fact_nl": "Officieel anthem van France '98, een mix van Senegalese mbalax en Franse chanson.",
-      "uri": null,
+      "uri": "spotify:track:2echKEeQCNq2AzS8CZZfVl",
       "chart_info": {},
       "certifications": [],
       "awards": [],


### PR DESCRIPTION
Closes #2198.

One field, verified through the keyless Spotify embed endpoint (title, both artists, release 1998-06-08).

Found by web search, not by the backfill — Odesli reports no Spotify link for this track from three different source platforms. See the issue for what that implies for the miss cache.

version 1.12 → 1.13, schema gate green.