### PR TITLE
chore(playlists): youtube backfill — +20 youtube uris

### DIFF
--- a/custom_components/beatify/playlists/community/deutschrock-best-of.json
+++ b/custom_components/beatify/playlists/community/deutschrock-best-of.json
@@ -1,6 +1,6 @@
 {
   "name": "Deutschrock - Best Of",
-  "version": "0.25",
+  "version": "0.29",
   "tags": [
     "deutschrock",
     "german rock",
@@ -2005,7 +2005,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=vfxjYR_Z6qs",
       "uri_tidal": "tidal://track/192675499",
       "uri_deezer": "deezer://track/672579152",
       "alt_artists": [],
@@ -2031,7 +2031,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=P1po25hQQwI",
       "uri_tidal": "tidal://track/261999503",
       "uri_deezer": "deezer://track/1965894197",
       "alt_artists": [],
@@ -2057,7 +2057,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=hgpwl1kt988",
       "uri_tidal": "tidal://track/408189544",
       "uri_deezer": "deezer://track/3160855431",
       "alt_artists": [],
@@ -2083,7 +2083,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=6z8o7qAIlIU",
       "uri_tidal": "tidal://track/11016850",
       "uri_deezer": "deezer://track/142393465",
       "alt_artists": [],
@@ -2109,7 +2109,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=lqjcL1as1bc",
       "uri_tidal": "tidal://track/146668319",
       "uri_deezer": "deezer://track/1004595472",
       "alt_artists": [],
@@ -2135,7 +2135,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Psg0wH76nhM",
       "uri_tidal": "tidal://track/38577317",
       "uri_deezer": "deezer://track/91514576",
       "alt_artists": [],
@@ -2161,7 +2161,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Z_hs0OMlD7k",
       "uri_tidal": "tidal://track/279503505",
       "uri_deezer": "deezer://track/2170638627",
       "alt_artists": [],
@@ -2187,7 +2187,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=EjioLh7Acfs",
       "uri_tidal": "tidal://track/190544282",
       "uri_deezer": "deezer://track/1429122832",
       "alt_artists": [],
@@ -2213,7 +2213,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=anj-IAAROMs",
       "uri_tidal": "tidal://track/522729538",
       "uri_deezer": "deezer://track/4009919411",
       "alt_artists": [],
@@ -2239,7 +2239,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=S-gtW-iPd-g",
       "uri_tidal": "tidal://track/7863165",
       "uri_deezer": "deezer://track/13777596",
       "alt_artists": [],
@@ -2265,7 +2265,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=FxcTiCoPPQc",
       "uri_tidal": "tidal://track/466149903",
       "uri_deezer": "deezer://track/3596363432",
       "alt_artists": [],
@@ -2291,7 +2291,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Ap0HgqZbJmI",
       "uri_tidal": "tidal://track/82778242",
       "uri_deezer": "deezer://track/443839702",
       "alt_artists": [],
@@ -2317,7 +2317,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=49KIFK7VLQY",
       "uri_tidal": "tidal://track/446944573",
       "uri_deezer": "deezer://track/3417197221",
       "alt_artists": [],
@@ -2343,7 +2343,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=ZgbMEtqVkL8",
       "uri_tidal": "tidal://track/442507343",
       "uri_deezer": "deezer://track/3417318381",
       "alt_artists": [],
@@ -2369,7 +2369,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=9zIw4OhFDvY",
       "uri_tidal": "tidal://track/341534835",
       "uri_deezer": "deezer://track/2594286122",
       "alt_artists": [],
@@ -2395,7 +2395,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=0x_E7imrDAw",
       "uri_tidal": "tidal://track/424046622",
       "uri_deezer": "deezer://track/3278753611",
       "alt_artists": [],
@@ -2421,7 +2421,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=AwivRPZev6M",
       "uri_tidal": "tidal://track/353722895",
       "uri_deezer": "deezer://track/2723611412",
       "alt_artists": [],
@@ -2447,7 +2447,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=zf268OA_JMo",
       "uri_tidal": "tidal://track/203629605",
       "uri_deezer": "deezer://track/1520563002",
       "alt_artists": [],
@@ -2473,7 +2473,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=j09hpp3AxIE",
       "uri_tidal": "tidal://track/15187665",
       "uri_deezer": "deezer://track/142393383",
       "alt_artists": [],
@@ -2499,7 +2499,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Aoh209ZfAVs",
       "uri_tidal": "tidal://track/143586611",
       "uri_deezer": "deezer://track/979374112",
       "alt_artists": [],


### PR DESCRIPTION
Ein Lauf des `provider-uri-backfill`, automatisch gefahren von `com.beatify.youtube-backfill`.

- `deutschrock-best-of` YouTube 75 -> **95**/100

**Draft mit Absicht** — Merge nur nach Markus' Freigabe.