### PR TITLE
chore(playlists): youtube backfill — +22 youtube uris

### DIFF
--- a/custom_components/beatify/playlists/disco-funk-classics.json
+++ b/custom_components/beatify/playlists/disco-funk-classics.json
@@ -1,6 +1,6 @@
 {
   "name": "Disco & Funk Classics",
-  "version": "1.11",
+  "version": "1.15",
   "tags": [
     "1970s",
     "1980s",
@@ -2636,7 +2636,7 @@
       "fun_fact_es": "Un medley de canciones de los Beatles con ritmo disco, estuvo una semana en el #1 en EE.UU. Inicialmente creado como bootleg en los Países Bajos, fue rápidamente legitimado. La dirección de los Beatles no estaba contenta pero no pudo detener su éxito.",
       "fun_fact_fr": "Un medley de chansons des Beatles sur un rythme disco, resté une semaine numéro un aux États-Unis. Créé à l'origine comme un bootleg aux Pays-Bas, il a été rapidement officialisé. Le management des Beatles n'était pas ravi mais n'a pas pu empêcher son succès.",
       "uri_apple_music": "applemusic://track/119840744",
-      "uri_youtube_music": "",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=7skQvj-aBV8",
       "uri_tidal": "tidal://track/18787317",
       "uri_deezer": "deezer://track/60703711",
       "fun_fact_nl": "Een medley van Beatles-nummers op een discobeat, stond het één week op nummer 1 in de VS. Aanvankelijk gecreëerd als bootleg in Nederland, werd het snel gelegaliseerd. Het management van The Beatles was niet blij, maar kon het succes niet tegenhouden.",
@@ -2935,7 +2935,7 @@
       "fun_fact_es": "El álbum más controvertido de Elton John — un disco completo producido por Pete Bellotte (productor de Donna Summer) sin participación de su letrista Bernie Taupin. Mal recibido en su momento, hoy se revalora como un audaz experimento artístico.",
       "fun_fact_fr": "L'album le plus controversé d'Elton John — un disque entièrement disco produit par Pete Bellotte (producteur de Donna Summer) sans aucune contribution de son parolier historique Bernie Taupin. Mal reçu à l'époque, il est aujourd'hui réévalué comme une audacieuse expérience artistique.",
       "uri_apple_music": "applemusic://track/1440756580",
-      "uri_youtube_music": "",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=iIjdraKhUuk",
       "uri_tidal": "tidal://track/258413137",
       "uri_deezer": "deezer://track/1107921",
       "fun_fact_nl": "Elton Johns meest controversiële album - een volledig discoalbum geproduceerd door Pete Bellotte (Donna Summers producer) zonder inbreng van zijn vaste tekstschrijver Bernie Taupin. Het werd destijds slecht ontvangen, maar is later herwaardeert als een gedurfd artistiek experiment.",
@@ -3007,7 +3007,7 @@
       "fun_fact_es": "Originalmente escrita por el líder de Mungo Jerry, Ray Dorset, para Elvis Presley, quien murió antes de grabarla. La versión disco de Kelly Marie estuvo dos semanas en el #1 en UK pero nunca se lanzó en EE.UU. Se convirtió en uno de los éxitos euro-disco de 1980.",
       "fun_fact_fr": "Écrite à l'origine par le leader de Mungo Jerry, Ray Dorset, pour Elvis Presley, qui est décédé avant de pouvoir l'enregistrer. La version disco de Kelly Marie est restée deux semaines numéro un au Royaume-Uni mais n'est jamais sortie aux États-Unis. Elle est devenue l'un des tubes euro-disco marquants de 1980.",
       "uri_apple_music": "applemusic://track/1439708131",
-      "uri_youtube_music": "",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Y_suedIaYGY",
       "uri_deezer": "deezer://track/133282708",
       "fun_fact_nl": "Oorspronkelijk geschreven door Mungo Jerry-frontman Ray Dorset voor Elvis Presley, die stierf voordat hij het kon opnemen. Kelly Maries discoversie stond twee weken op nummer 1 in het VK maar werd nooit uitgebracht in de VS. Het werd een van de bepalende euro-discohits van 1980.",
       "awards_nl": []
@@ -3120,7 +3120,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=x8no2UG-oZ0",
       "uri_tidal": "tidal://track/2879929",
       "uri_deezer": "deezer://track/3151319",
       "isrc": "GBAYE7600024"
@@ -3155,7 +3155,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=gD6cPE2BHic",
       "uri_tidal": "tidal://track/20481133",
       "uri_deezer": "deezer://track/891619",
       "isrc": "USFI87800059"
@@ -3190,7 +3190,7 @@
         "nl": "applemusic://track/1590817676",
         "it": "applemusic://track/1590817672"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=pEmX5HR9ZxU",
       "uri_tidal": "tidal://track/496171943",
       "uri_deezer": "deezer://track/3803021252",
       "isrc": "GBAJE7900087"
@@ -3225,7 +3225,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=fLLSwHaYk6k",
       "uri_tidal": "tidal://track/1785214",
       "uri_deezer": "deezer://track/846326",
       "isrc": "USAT20102201"
@@ -3260,7 +3260,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Bucljr7jX3I",
       "uri_tidal": "tidal://track/64498756",
       "uri_deezer": "deezer://track/538706962",
       "isrc": "USPR39402398"
@@ -3295,7 +3295,7 @@
         "nl": "applemusic://track/1444081381",
         "it": "applemusic://track/1444081381"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=qchPLaiKocI",
       "uri_tidal": "tidal://track/93614024",
       "uri_deezer": "deezer://track/94556154",
       "isrc": "USDJ20110815"
@@ -3330,7 +3330,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=o9arN6feODI",
       "uri_tidal": "tidal://track/299130",
       "uri_deezer": "deezer://track/662391362",
       "isrc": "USAT20102506"
@@ -3365,7 +3365,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=hvNdWwsAMzI",
       "uri_tidal": "tidal://track/506143303",
       "uri_deezer": "deezer://track/3894199721",
       "isrc": null
@@ -3400,7 +3400,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=BNirQXe8HOA",
       "uri_tidal": "tidal://track/10906574",
       "uri_deezer": "deezer://track/4094693",
       "isrc": "USWB10104850"
@@ -3435,7 +3435,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=52iW3lcpK5M",
       "uri_tidal": "tidal://track/355682487",
       "uri_deezer": "deezer://track/3824997371",
       "isrc": "USWB10903605"
@@ -3470,7 +3470,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=hBP9txbREWI",
       "uri_tidal": "tidal://track/537537",
       "uri_deezer": "deezer://track/364974",
       "isrc": "DED167800004"
@@ -3505,7 +3505,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=vjD3EVC1-zU",
       "uri_tidal": "tidal://track/71041309",
       "uri_deezer": "deezer://track/143782586",
       "isrc": "GBAKW0201571"
@@ -3540,7 +3540,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=M0quXl_od3g",
       "uri_tidal": "tidal://track/21975507",
       "uri_deezer": "deezer://track/70051871",
       "isrc": "GBCMX0509001"
@@ -3575,7 +3575,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=PeYUTbU_iTw",
       "uri_tidal": "tidal://track/19378799",
       "uri_deezer": "deezer://track/68515594",
       "isrc": "CAU118200149"
@@ -3610,7 +3610,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=uROYHGheSQg",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3155858881",
       "isrc": "GBCPZ1712705"
@@ -3645,7 +3645,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=SPlQpGeTbIE",
       "uri_tidal": "tidal://track/99846227",
       "uri_deezer": "deezer://track/597208142",
       "isrc": "DKMFA0200501"
@@ -3680,7 +3680,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=WGU_4-5RaxU",
       "uri_tidal": "tidal://track/1507340",
       "uri_deezer": "deezer://track/3100604",
       "isrc": "USCH30100108"
@@ -3715,7 +3715,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=kldVOhKe4rg",
       "uri_tidal": "tidal://track/33740664",
       "uri_deezer": "deezer://track/4603402",
       "isrc": "USSM10905824"
@@ -3750,7 +3750,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=6Q_Xse4izH8",
       "uri_tidal": "tidal://track/128936364",
       "uri_deezer": "deezer://track/858554742",
       "isrc": "AUDCB1701525"


### PR DESCRIPTION
Ein Lauf des `provider-uri-backfill`, automatisch gefahren von `com.beatify.youtube-backfill`.

- `disco-funk-classics` YouTube 73 -> **95**/98

**Draft mit Absicht** — Merge nur nach Markus' Freigabe.