### PR TITLE
data: replace dead Apple Music URI for Tanita Tikaram

### DIFF
--- a/custom_components/beatify/playlists/one-hit-wonders.json
+++ b/custom_components/beatify/playlists/one-hit-wonders.json
@@ -1,6 +1,6 @@
 {
   "name": "One-Hit Wonders",
-  "version": "1.9",
+  "version": "1.10",
   "tags": [
     "one-hit",
     "classics",
@@ -1871,7 +1871,7 @@
         "Gold (DE)"
       ],
       "awards": [],
-      "uri_apple_music": "applemusic://track/1718064942",
+      "uri_apple_music": "applemusic://track/1776580033",
       "uri_youtube_music": "https://music.youtube.com/watch?v=7s8glZ-efMg",
       "uri_tidal": "tidal://track/2158292",
       "uri_deezer": "deezer://track/2686266",


### PR DESCRIPTION
Closes #2207.

One field. `applemusic://track/1718064942` returns `resultCount: 0` from the iTunes lookup — removed, not region-restricted.

Adopts **1776580033**, the id this song's own `uri_apple_music_by_region` map already uses for all seven regions; today's health check validated all 622 region entries as ok, and a manual lookup confirms US, DE, GB and FR.

`299554883` (original album *Ancient Heart*, matching the 1988 year) was rejected because it resolves only in DE and would fail the next rotation.

version 1.9 → 1.10, schema gate green.