### PR TITLE
chore(playlists): youtube backfill — +21 youtube uris

### DIFF
--- a/custom_components/beatify/playlists/community/edm-anthems.json
+++ b/custom_components/beatify/playlists/community/edm-anthems.json
@@ -1,6 +1,6 @@
 {
   "name": "EDM Anthems",
-  "version": "1.27",
+  "version": "1.31",
   "tags": [
     "edm",
     "electronic",
@@ -4949,7 +4949,7 @@
         "nl": "applemusic://track/692624266",
         "it": "applemusic://track/692624266"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=mMfxI3r_LyA",
       "uri_tidal": "tidal://track/22023176",
       "uri_deezer": "deezer://track/70179720",
       "fun_fact": "“Lady - Hear Me Tonight” appears on Modjo’s release “Modjo (Remastered)”.",
@@ -4979,7 +4979,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=jzy2dgEUOhY",
       "uri_tidal": "tidal://track/34645181",
       "uri_deezer": "deezer://track/858737222",
       "fun_fact": "“Infinity - Magic Mitch Club Mix” appears on Guru Josh Project’s release “Infinity”.",
@@ -5009,7 +5009,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=h7ArUgxtlJs",
       "uri_tidal": "tidal://track/37953066",
       "uri_deezer": "deezer://track/2524469521",
       "fun_fact": "“Ghosts 'n' Stuff (feat. Rob Swire)” appears on deadmau5’s release “For Lack of a Better Name (The Extended Mixes)”.",
@@ -5039,7 +5039,7 @@
         "nl": "applemusic://track/259751997",
         "it": "applemusic://track/259751997"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=sy1dYFGkPUE",
       "uri_tidal": "tidal://track/43421710",
       "uri_deezer": "deezer://track/10284909",
       "fun_fact": "“D.A.N.C.E.” appears on Justice’s release “Justice”.",
@@ -5069,7 +5069,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=p-Z3YrHJ1sU",
       "uri_tidal": "tidal://track/203338403",
       "uri_deezer": "deezer://track/2138214447",
       "fun_fact": "Edward Maya is a Romanian producer whose 'Stereo Love' became a global summer anthem in 2009.",
@@ -5129,7 +5129,7 @@
         "nl": "applemusic://track/1463775977",
         "it": "applemusic://track/1463775977"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=FQlAEiCb8m0",
       "uri_tidal": "tidal://track/112165986",
       "uri_deezer": "deezer://track/695110942",
       "fun_fact": "“Music Sounds Better With You - Radio Edit” appears on Stardust’s release “Music Sounds Better With You”.",
@@ -5219,7 +5219,7 @@
         "nl": "applemusic://track/1216949850",
         "it": "applemusic://track/1216949850"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=j26esoayz2c",
       "uri_tidal": "tidal://track/40213783",
       "uri_deezer": "deezer://track/15803513",
       "fun_fact": "“Pjanoo - Radio Edit” appears on Eric Prydz’s release “Pjanoo”.",
@@ -5249,7 +5249,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=8x-M7AkTvrQ",
       "uri_tidal": "tidal://track/26646356",
       "uri_deezer": "deezer://track/72363285",
       "fun_fact": "“You & Me - Flume Remix” appears on Disclosure’s release “Settle (The Remixes)”.",
@@ -5279,7 +5279,7 @@
         "nl": "applemusic://track/1444123050",
         "it": "applemusic://track/1444123050"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=0vc8k7r8HzI",
       "uri_tidal": "tidal://track/49817482",
       "uri_deezer": "deezer://track/105353316",
       "fun_fact": "“Push The Feeling On - Mk Dub Revisited Edit” appears on Nightcrawlers’s release “Push The Feeling On”.",
@@ -5309,7 +5309,7 @@
         "nl": "applemusic://track/714174441",
         "it": "applemusic://track/714174441"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=tpKCqp9CALQ",
       "uri_tidal": "tidal://track/130883",
       "uri_deezer": "deezer://track/3135034",
       "fun_fact": "“Hey Boy Hey Girl” appears on The Chemical Brothers’s release “Surrender”.",
@@ -5339,7 +5339,7 @@
         "nl": "applemusic://track/294600655",
         "it": "applemusic://track/294600655"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Sk9XYQMRiLY",
       "uri_tidal": "tidal://track/294979317",
       "uri_deezer": "deezer://track/63266242",
       "fun_fact": "“Finally Moving” appears on Pretty Lights’s release “Taking up Your Precious Time”.",
@@ -5369,7 +5369,7 @@
         "nl": "applemusic://track/1444623538",
         "it": "applemusic://track/1444623538"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=X52tywo1pfg",
       "uri_tidal": "tidal://track/54290313",
       "uri_deezer": "deezer://track/76495953",
       "fun_fact": "“Nobody To Love - Extended Mix” appears on Sigma’s release “Life (Deluxe)”.",
@@ -5399,7 +5399,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=AWpLZtdeBgQ",
       "uri_tidal": "tidal://track/70564299",
       "uri_deezer": "deezer://track/96465722",
       "fun_fact": "“Freaks - Radio Edit” appears on Timmy Trumpet’s release “Freaks”.",
@@ -5429,7 +5429,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=BR_DFMUzX4E",
       "uri_tidal": "tidal://track/20006918",
       "uri_deezer": "deezer://track/66786199",
       "fun_fact": "“This Is What It Feels Like” appears on Armin van Buuren’s release “Intense”.",
@@ -5519,7 +5519,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=FGH8rnraxoE",
       "uri_tidal": "tidal://track/1643031",
       "uri_deezer": "deezer://track/1379046532",
       "fun_fact": "“As The Rush Comes” is the title track of Motorcycle’s release of the same name.",
@@ -5549,7 +5549,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=IJWlBfo5Oj0",
       "uri_tidal": "tidal://track/491190902",
       "uri_deezer": "deezer://track/3786002622",
       "fun_fact": "“Porcelain” appears on Moby’s release “Play & Play: B Sides”.",
@@ -5579,7 +5579,7 @@
         "nl": "applemusic://track/1701889813",
         "it": "applemusic://track/1701889813"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=HQnC1UHBvWA",
       "uri_tidal": "tidal://track/310051385",
       "uri_deezer": "deezer://track/2404408865",
       "fun_fact": "“Shelter” is the title track of Porter Robinson’s release of the same name.",
@@ -5609,7 +5609,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=CVvJp3d8xGQ",
       "uri_tidal": "tidal://track/280239339",
       "uri_deezer": "deezer://track/85330586",
       "fun_fact": "“Faded” appears on ZHU’s release “THE NIGHTDAY”.",
@@ -5640,7 +5640,7 @@
         "it": "applemusic://track/1442959426"
       },
       "uri_deezer": "deezer://track/1560033",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=9ZqqvrWCs3Q",
       "uri_tidal": "tidal://track/567499",
       "fun_fact": "“I Feel Love” appears on Donna Summer’s 1977 concept album “I Remember Yesterday”, where it represents the album’s futuristic final chapter.",
       "fun_fact_de": "„I Feel Love“ erschien auf Donna Summers Konzeptalbum „I Remember Yesterday“ von 1977 und bildet dort das futuristische Schlusskapitel.",
@@ -5670,7 +5670,7 @@
         "it": "applemusic://track/1444322033"
       },
       "uri_deezer": "deezer://track/61046485",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=V8qVV9MPNTs",
       "uri_tidal": "tidal://track/17491028",
       "fun_fact": "“Million Voices - Radio Edit” is the radio edit of Otto Knows’ 2012 single “Million Voices”.",
       "fun_fact_de": "„Million Voices – Radio Edit“ ist die Radiofassung von Otto Knows’ Single „Million Voices“ aus dem Jahr 2012.",
@@ -5700,7 +5700,7 @@
         "it": null
       },
       "uri_deezer": "deezer://track/79435949",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=pUjE9H8QlA4",
       "uri_tidal": "tidal://track/155823558",
       "fun_fact": "“Waves - Robin Schulz Radio Edit” is Robin Schulz’s radio edit of Mr. Probz’s 2014 single “Waves”.",
       "fun_fact_de": "„Waves – Robin Schulz Radio Edit“ ist Robin Schulz’ Radiofassung von Mr. Probz’ Single „Waves“ aus dem Jahr 2014.",


### PR DESCRIPTION
Ein Lauf des `provider-uri-backfill`, automatisch gefahren von `com.beatify.youtube-backfill`.

- `edm-anthems` YouTube 168 -> **189**/190

**Draft mit Absicht** — Merge nur nach Markus' Freigabe.