### PR TITLE
fix(backfill): accept iTunes hits that credit only the lead artist

### DIFF
--- a/.claude/skills/provider-uri-backfill/scripts/backfill_provider_uris.py
+++ b/.claude/skills/provider-uri-backfill/scripts/backfill_provider_uris.py
@@ -201,6 +201,9 @@ _DASH_SUFFIX_RE = re.compile(r"\s+-\s+.*$")
 _PUNCT_RE = re.compile(r"[^\w\s]", re.UNICODE)
 _WHITESPACE_RE = re.compile(r"\s+")
 _LEADING_ARTICLE_RE = re.compile(r"^(?:the|a|an)\s+")
+# Trennt die Namen in einem Katalog-``artist``-Feld. Spotify liefert alle
+# Credits als EINEN String, mal komma-, mal semikolon-getrennt.
+_ARTIST_SPLIT_RE = re.compile(r"\s*[;,]\s*")
 
 # Keyless resolver endpoints (queried in the network helpers below).
 ITUNES_SEARCH = "https://itunes.apple.com/search"
@@ -300,6 +303,61 @@ def _tokens_present(needle: str, hay: str, *, min_len: int = 3) -> bool:
         return False
     hay_set = set(hay.split())
     return all(t in hay_set for t in toks)
+
+
+def split_credited_artists(artist: str) -> list[str]:
+    """Split a catalogue ``artist`` credit string into the individual names.
+
+    The catalogue stores every credited Spotify artist in ONE field, joined by
+    a comma or a semicolon: ``"Justin Bieber, Nicki Minaj"``,
+    ``"Tanel Padar;Dave Benton"``. Nothing else in the pipeline needs the parts,
+    so this is deliberately dumb — it splits, it does not try to understand.
+    """
+    return [p.strip() for p in _ARTIST_SPLIT_RE.split(artist or "") if p.strip()]
+
+
+def _lead_artist_with_features(artist: str, r_artist: str, r_title: str) -> bool:
+    """Accept an iTunes hit that credits only the LEAD of a multi-artist track.
+
+    The mismatch this repairs (#2211): the catalogue names every artist in one
+    joined string, iTunes names only the lead in ``artistName`` and pushes the
+    guests into ``trackName`` — ``"Justin Bieber, Nicki Minaj"`` versus
+    ``"Justin Bieber"`` + ``"Beauty and a Beat (feat. Nicki Minaj)"``. Compared
+    head-on the two artist strings blow the edit budget of :func:`titles_match`,
+    so a plainly correct match was discarded. Measured on 2026-08-17 over a
+    random sample of 25 of the 185 open Apple gaps: 7 rejections came from this
+    comparison, 6 of them on the right recording.
+
+    True only when BOTH halves hold:
+
+    1. the iTunes artist matches the **first** catalogue name, and
+    2. every remaining catalogue name shows up on the iTunes side — in the
+       track title (``feat. …``) or in the artist string (``A & B``).
+
+    Half 2 is what keeps this from being a loosening. Without it the rule would
+    accept a solo re-release of the same title as the featured version. It is
+    also why a band whose own name carries a comma is safe: splitting
+    ``"Earth, Wind & Fire"`` yields a "guest" ``"Wind & Fire"`` that no iTunes
+    row will carry, so the rule simply never fires and the existing checks
+    decide alone.
+
+    The single-name case returns False on purpose. When the catalogue credits
+    one artist and iTunes credits another as lead — Kayah's *Śpij Kochanie Śpij*
+    against ``kk8 — Śpij Kochanie Śpij (feat. Kayah)`` — that is a different
+    recording, and the gate is right to refuse it.
+    """
+    names = split_credited_artists(artist)
+    if len(names) < 2:
+        return False
+    lead, guests = names[0], names[1:]
+    gate = _gate()
+    lead_ok = titles_match(r_artist, lead) or (
+        gate is not None and gate.artist_matches(lead, r_artist)
+    )
+    if not lead_ok:
+        return False
+    hay = _normalize_loose(f"{r_title} {r_artist}")
+    return all(_tokens_present(_normalize_loose(g), hay) for g in guests)
 
 
 def _dedup(items: list[str]) -> list[str]:
@@ -416,6 +474,12 @@ def _pick_itunes_match(
             artist_ok = gate.artist_matches(artist, r_artist) or any(
                 gate.artist_matches(alt, r_artist) for alt in (alt_artists or [])
             )
+        # Feature-Regel als LETZTE Stufe, nicht als Ersatz: greift nur, wenn
+        # `artist` mehrere Namen fuehrt und iTunes bloss den ersten nennt, die
+        # uebrigen aber nachweislich mitfuehrt (#2211). `alt_artists` faengt das
+        # nicht ab — das Feld meint Coverversionen, keine Features.
+        if not artist_ok:
+            artist_ok = _lead_artist_with_features(artist, r_artist, r_title)
         if artist_ok:
             return track_id
     return None

--- a/tests/unit/test_provider_uri_backfill.py
+++ b/tests/unit/test_provider_uri_backfill.py
@@ -755,6 +755,108 @@ def test_itunes_search_never_raises_on_http_error():
     )
 
 
+# --- Feature-Artists im iTunes-Gate (#2211) ---------------------------------
+def _itunes_getter(track_name: str, artist_name: str, track_id: int = 700100):
+    """Every query returns the same single row — the gate is what's under test."""
+
+    def getter(url):
+        return {
+            "results": [
+                {
+                    "trackId": track_id,
+                    "trackName": track_name,
+                    "artistName": artist_name,
+                }
+            ]
+        }
+
+    return getter
+
+
+def test_split_credited_artists_handles_comma_and_semicolon():
+    assert bf.split_credited_artists("Justin Bieber, Nicki Minaj") == [
+        "Justin Bieber",
+        "Nicki Minaj",
+    ]
+    # Spotify is not consistent about the separator.
+    assert bf.split_credited_artists("Tanel Padar;Dave Benton") == [
+        "Tanel Padar",
+        "Dave Benton",
+    ]
+    assert bf.split_credited_artists("") == []
+    assert bf.split_credited_artists("Prince") == ["Prince"]
+
+
+def test_itunes_gate_accepts_guest_named_in_track_title():
+    # The catalogue joins every credit into one string, iTunes names only the
+    # lead and moves the guest into the title. Real case from the 2026-08-17
+    # sample (spotify:track:0KTsmr6JOuhxZuiXUha1xC).
+    aid = bf.resolve_apple_via_itunes(
+        {"artist": "Justin Bieber, Nicki Minaj", "title": "Beauty And A Beat"},
+        getter=_itunes_getter("Beauty and a Beat (feat. Nicki Minaj)", "Justin Bieber"),
+    )
+    assert aid == "700100"
+
+
+def test_itunes_gate_accepts_guest_named_in_artist_string():
+    # Same rule, other side: iTunes carries the guest in ``artistName`` instead
+    # of the title (spotify:track:5bGG1abhVIUm6EAa36ipRX).
+    aid = bf.resolve_apple_via_itunes(
+        {
+            "artist": "Asaf Avidan,The Mojos,Wankelmut",
+            "title": "One Day / Reckoning Song (Wankelmut Remix) [Radio Edit]",
+        },
+        getter=_itunes_getter(
+            "One Day / Reckoning Song (Wankelmut Remix) [Radio Edit]",
+            "Asaf Avidan & The Mojos",
+        ),
+    )
+    assert aid == "700100"
+
+
+def test_itunes_gate_accepts_two_guests_named_with_ampersand():
+    # Three credited names; iTunes keeps the lead and joins the two guests with
+    # "&" instead of a comma (spotify:track:5bTRw958W3Gf95RwXgJ2ql).
+    aid = bf.resolve_apple_via_itunes(
+        {
+            "artist": "Jamal, Jambojet, USPM",
+            "title": "Policeman (feat. Jambojet, USPM)",
+        },
+        getter=_itunes_getter("Policeman (feat. Jambojet & USPM)", "Jamal"),
+    )
+    assert aid == "700100"
+
+
+def test_itunes_gate_still_rejects_solo_version_of_a_featured_track():
+    # The half that keeps the rule from being a loosening: the guest is credited
+    # NOWHERE on the iTunes side, so this is the solo cut, not the feature.
+    aid = bf.resolve_apple_via_itunes(
+        {"artist": "Justin Bieber, Nicki Minaj", "title": "Beauty And A Beat"},
+        getter=_itunes_getter("Beauty and a Beat", "Justin Bieber"),
+    )
+    assert aid is None
+
+
+def test_itunes_gate_still_rejects_when_catalogue_credits_one_artist():
+    # Kayah's Śpij Kochanie Śpij against ``kk8 — … (feat. Kayah)``: the roles are
+    # swapped, so it is a different recording. One catalogue name → rule is off.
+    aid = bf.resolve_apple_via_itunes(
+        {"artist": "Kayah", "title": "Śpij Kochanie Śpij"},
+        getter=_itunes_getter("Śpij Kochanie Śpij (feat. Kayah)", "kk8"),
+    )
+    assert aid is None
+
+
+def test_itunes_gate_band_name_with_its_own_comma_does_not_leak():
+    # "Earth, Wind & Fire" splits into a bogus "guest" that no iTunes row can
+    # carry — the rule must therefore not fire and the hit must stay rejected.
+    aid = bf.resolve_apple_via_itunes(
+        {"artist": "Earth, Wind & Fire", "title": "September"},
+        getter=_itunes_getter("September", "Earth"),
+    )
+    assert aid is None
+
+
 # --- Lever 3: YouTube Odesli-first + oembed verify --------------------------
 def test_odesli_youtube_video_id_extracts():
     payload = {


### PR DESCRIPTION
Closes #2211.

## What changed

\`_pick_itunes_match\` gets one more fallback stage, after the existing exact/fuzzy and \`alt_artists\` checks: \`_lead_artist_with_features\`.

It accepts an iTunes row only when **both** hold:

1. the iTunes \`artistName\` matches the **first** name of the catalogue's joined \`artist\` string, and
2. every remaining catalogue name is credited somewhere on the iTunes side — in \`trackName\` (\`feat. …\`) or in \`artistName\` (\`A & B\`).

Condition 2 is the whole safety argument. Without it the rule would accept a solo cut of a featured track. With it:

- a solo re-release of the same title still fails (covered by a test),
- a single-name catalogue credit never triggers the rule, so Kayah — *Śpij Kochanie Śpij* keeps being rejected against \`kk8 — … (feat. Kayah)\`, which is a different recording (covered by a test),
- a band whose own name carries a comma is unaffected: splitting "Earth, Wind & Fire" produces a "guest" no iTunes row will ever carry, so the rule never fires (covered by a test).

The title half of the gate, including \`suffix_conflict\`, is untouched. Live recordings, karaoke versions, re-recordings and cover orchestras are still rejected exactly as before.

## Measurement

Random sample of 25 of the 185 open Apple gaps (fixed seed, 2026-08-17), resolved through the real \`resolve_apple_via_itunes\` against the live iTunes Search API.

- Before the change: **0 of 25** resolved.
- After: **5 of 25**.
- All five were then verified one by one against \`itunes.apple.com/lookup\` — every one is the right recording:

| catalogue | resolved iTunes row | id |
|---|---|---|
| Justin Bieber, Nicki Minaj — Beauty And A Beat | Justin Bieber — Beauty and a Beat (feat. Nicki Minaj), *Believe* 2012 | 1440805856 |
| Asaf Avidan,The Mojos,Wankelmut — One Day / Reckoning Song (Wankelmut Remix) [Radio Edit] | Asaf Avidan & The Mojos — same title, 2012 | 1470909129 |
| Jamal, Jambojet, USPM — Policeman (feat. Jambojet, USPM) | Jamal — Policeman (feat. Jambojet & USPM), *Rewolucje* 2005 | 692568005 |
| Łydka Grubasa, Kwiat Jabłoni — Wzięli zamknęli mi klub | Łydka Grubasa — same title (feat. Kwiat Jabłoni), *ĘĆ* 2023 | 1803621973 |
| Daddy DJ, Chico & Tonio — Daddy DJ - Chico & Tonio Radio Edit / Remastered 2025 | Daddy DJ — same title, 25th Anniversary edition | 1841918964 |

Extrapolated over all 185 gaps that is roughly **37**. It is an estimate from 25 tracks; the full sweep is cheap and should replace it with a number.

### Correction to the issue text

#2211 lists Kid Cudi — *Pursuit Of Happiness* as a sixth recoverable case. It is not, and the fix does not resolve it. That entry came from reading the top search result rather than the row that actually reached the artist comparison; for this track the only row clearing the title check is a **different song by Miranda Lambert**, which the gate rejects for the right reason. The issue has been corrected.

## Tests

Seven new tests in \`tests/unit/test_provider_uri_backfill.py\` — three that must now pass, three that must still fail, one for the splitter. Full unit suite green locally (1937 passed).