### PR TITLE
chore(playlists): apple backfill — +33 apple uris across 6 playlists

### DIFF
--- a/custom_components/beatify/playlists/community/edm-anthems.json
+++ b/custom_components/beatify/playlists/community/edm-anthems.json
@@ -1,6 +1,6 @@
 {
   "name": "EDM Anthems",
-  "version": "1.31",
+  "version": "1.32",
   "tags": [
     "edm",
     "electronic",
@@ -79,7 +79,7 @@
       "year": 2016,
       "isrc": "USQX91601347",
       "uri": "spotify:track:3oBzTWbiIndAXQbWBcLeHW",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/1170699703",
       "uri_apple_music_by_region": {
         "us": null,
         "de": null,
@@ -499,7 +499,7 @@
       "year": 2011,
       "isrc": "USJAY1100032",
       "uri": "spotify:track:4QNpBfC0zvjKqPJcyqBy9W",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/1307027266",
       "uri_apple_music_by_region": {
         "us": null,
         "de": "applemusic://track/904436696",
@@ -529,7 +529,7 @@
       "year": 2015,
       "isrc": "USAT21500555",
       "uri": "spotify:track:66hayvUbTotekKU3H4ta1f",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/971262282",
       "uri_apple_music_by_region": {
         "us": null,
         "de": "applemusic://track/1068554525",
@@ -619,7 +619,7 @@
       "year": 2014,
       "isrc": "USUM71409719",
       "uri": "spotify:track:12KUFSHFgT0XCoiSlvdQi4",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/1440825208",
       "uri_apple_music_by_region": {
         "us": null,
         "de": null,
@@ -649,7 +649,7 @@
       "year": 2012,
       "isrc": "USUM71205367",
       "uri": "spotify:track:0KTsmr6JOuhxZuiXUha1xC",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/1440805856",
       "uri_apple_music_by_region": {
         "us": null,
         "de": null,
@@ -679,7 +679,7 @@
       "year": 2011,
       "isrc": "USUM71115507",
       "uri": "spotify:track:5uImkHXfTLkNYwemtGH7kB",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/1443102668",
       "uri_apple_music_by_region": {
         "us": null,
         "de": null,
@@ -769,7 +769,7 @@
       "year": 2012,
       "isrc": "GBAAA1200728",
       "uri": "spotify:track:2V65y3PX4DkRhy1djlxd9p",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/1021729332",
       "uri_apple_music_by_region": {
         "us": null,
         "de": null,
@@ -1219,7 +1219,7 @@
       "year": 2015,
       "isrc": "GBUM71507621",
       "uri": "spotify:track:6OZh916QF8XNunWaP97WEZ",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/1437812225",
       "uri_apple_music_by_region": {
         "us": null,
         "de": null,
@@ -1549,7 +1549,7 @@
       "year": 2018,
       "isrc": "GBUM71802109",
       "uri": "spotify:track:3u1S1OmAUhx5DRlLrXqyp3",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/1383852262",
       "uri_apple_music_by_region": {
         "us": null,
         "de": null,
@@ -1639,7 +1639,7 @@
       "year": 2017,
       "isrc": "USRC11701901",
       "uri": "spotify:track:7vGuf3Y35N4wmASOKLUVVU",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/1268152499",
       "uri_apple_music_by_region": {
         "us": null,
         "de": null,
@@ -1939,7 +1939,7 @@
       "year": 2013,
       "isrc": "USUM71210662",
       "uri": "spotify:track:0VGrgE7GbWaINRnh1bR4k9",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/1440818495",
       "uri_apple_music_by_region": {
         "us": null,
         "de": null,
@@ -2239,7 +2239,7 @@
       "year": 2016,
       "isrc": "USUM71606370",
       "uri": "spotify:track:2zDt2TfQbxiSPjTVJTgbwz",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/1444891951",
       "uri_apple_music_by_region": {
         "us": null,
         "de": null,
@@ -2299,7 +2299,7 @@
       "year": 2015,
       "isrc": "USQX91500801",
       "uri": "spotify:track:3vv9phIu6Y1vX3jcqaGz5Z",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/1050203620",
       "uri_apple_music_by_region": {
         "us": null,
         "de": null,
@@ -2449,7 +2449,7 @@
       "year": 2015,
       "isrc": "CYA111500012",
       "uri": "spotify:track:69zxj1EFDfAouZu9JDmQld",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/1443097680",
       "uri_apple_music_by_region": {
         "us": null,
         "de": null,
@@ -2479,7 +2479,7 @@
       "year": 2013,
       "isrc": "USUM71311478",
       "uri": "spotify:track:4bT2zLVv2T4GiK9q9KtI0v",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/1568228498",
       "uri_apple_music_by_region": {
         "us": null,
         "de": null,
@@ -2809,7 +2809,7 @@
       "year": 2012,
       "isrc": "USUM71502344",
       "uri": "spotify:track:4NCYjPP2VAyYi6707SkS30",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/1470706637",
       "uri_apple_music_by_region": {
         "us": null,
         "de": null,
@@ -2929,7 +2929,7 @@
       "year": 2015,
       "isrc": "USUM71505090",
       "uri": "spotify:track:5rePjHvMXWqVt1EenTR1w1",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/1470706638",
       "uri_apple_music_by_region": {
         "us": null,
         "de": null,
@@ -3439,7 +3439,7 @@
       "year": 2013,
       "isrc": "NLDD61300077",
       "uri": "spotify:track:7hahCXrIA6MmEumclFpA5g",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/1729703799",
       "uri_apple_music_by_region": {
         "us": null,
         "de": null,
@@ -3739,7 +3739,7 @@
       "year": 2013,
       "isrc": "USUM71311296",
       "uri": "spotify:track:4jbmgIyjGoXjY01XxatOx6",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/1440871474",
       "uri_apple_music_by_region": {
         "us": null,
         "de": null,
@@ -3979,7 +3979,7 @@
       "year": 2011,
       "isrc": "NLC281110493",
       "uri": "spotify:track:2g136494iEXB1GGPakAFzx",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/1378649078",
       "uri_apple_music_by_region": {
         "us": null,
         "de": null,
@@ -4759,7 +4759,7 @@
       "year": 2014,
       "isrc": "GBCFB1404201",
       "uri": "spotify:track:1LeItUMezKA1HdCHxYICed",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/897564278",
       "uri_apple_music_by_region": {
         "us": null,
         "de": null,
@@ -4999,7 +4999,7 @@
       "year": 2009,
       "isrc": "USUS10900757",
       "uri": "spotify:track:3ezkJgagRPZ39KCTrKcSI7",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/1826175057",
       "uri_apple_music_by_region": {
         "us": null,
         "de": null,
@@ -5149,7 +5149,7 @@
       "year": 2014,
       "isrc": "USUM71313869",
       "uri": "spotify:track:2U0pVx4m1Kdm1Gsjjm6iq8",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/1440850881",
       "uri_apple_music_by_region": {
         "us": null,
         "de": null,
@@ -5419,7 +5419,7 @@
       "year": 2013,
       "isrc": "NLF711303312",
       "uri": "spotify:track:5GjnIpUlLGEIYk052ISOw9",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/626898256",
       "uri_apple_music_by_region": {
         "us": null,
         "de": null,

--- a/custom_components/beatify/playlists/community/eurodance-90s.json
+++ b/custom_components/beatify/playlists/community/eurodance-90s.json
@@ -1,6 +1,6 @@
 {
   "name": "Eurodance 90s 💥",
-  "version": "1.11",
+  "version": "1.12",
   "tags": [
     "1990s",
     "eurodance",
@@ -1087,7 +1087,8 @@
       "uri_tidal": "tidal://track/111279010",
       "uri_deezer": "deezer://track/696667752",
       "fun_fact_nl": "De eigenzinnige Franse Eurodance-track van Daddy DJ werd een hit in heel Europa met zijn speelse teksten en vrolijke beats.",
-      "awards_nl": []
+      "awards_nl": [],
+      "uri_apple_music": "applemusic://track/1841918964"
     },
     {
       "year": 1998,

--- a/custom_components/beatify/playlists/community/polish-hits-90s-00s.json
+++ b/custom_components/beatify/playlists/community/polish-hits-90s-00s.json
@@ -1,6 +1,6 @@
 {
   "name": "Polskie hity radiowe 🇵🇱",
-  "version": "0.12",
+  "version": "0.13",
   "tags": [
     "polish",
     "pop",
@@ -1235,7 +1235,7 @@
       "artist": "Yugoton, Kazik",
       "title": "Malcziki",
       "isrc": "PLA330100621",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/1019522665",
       "uri_apple_music_by_region": {
         "pl": "applemusic://track/1019522665"
       },
@@ -1255,7 +1255,7 @@
       "artist": "Jamal, Jambojet, USPM",
       "title": "Policeman (feat. Jambojet, USPM)",
       "isrc": "PLA550500048",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/692568005",
       "uri_apple_music_by_region": {
         "pl": "applemusic://track/692568005"
       },
@@ -1635,7 +1635,7 @@
       "artist": "Krzysztof Kiljański, Kayah",
       "title": "Prócz Ciebie, Nic",
       "isrc": "PL0282400013",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/1501151870",
       "uri_apple_music_by_region": {
         "pl": "applemusic://track/1501151870"
       },

--- a/custom_components/beatify/playlists/community/polish-rock.json
+++ b/custom_components/beatify/playlists/community/polish-rock.json
@@ -1,6 +1,6 @@
 {
   "name": "Polski Rock",
-  "version": "0.15",
+  "version": "0.16",
   "tags": [
     "polish",
     "rock"
@@ -2097,7 +2097,7 @@
       "artist": "Żurkowski, Organek",
       "title": "Western",
       "isrc": "PLB822100252",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/1607525202",
       "uri_apple_music_by_region": {
         "us": null,
         "de": null,
@@ -2305,7 +2305,7 @@
       "artist": "Łydka Grubasa, Kwiat Jabłoni",
       "title": "Wzięli zamknęli mi klub",
       "isrc": "PL22V2387010",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/1803621973",
       "uri_apple_music_by_region": {
         "us": null,
         "de": null,

--- a/custom_components/beatify/playlists/community/quebecois-1990-2020.json
+++ b/custom_components/beatify/playlists/community/quebecois-1990-2020.json
@@ -1,6 +1,6 @@
 {
   "name": "🍁 Québécois 1990-2020",
-  "version": "0.12",
+  "version": "0.13",
   "tags": [
     "quebecois",
     "quebec",
@@ -652,7 +652,7 @@
       "uri": "spotify:track:0LI89ikl3gcJpFepnrfr38",
       "year": 2021,
       "isrc": "CA06H2100137",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/1572369506",
       "uri_apple_music_by_region": {
         "us": null,
         "de": null,

--- a/custom_components/beatify/playlists/community/sommerklassiker.json
+++ b/custom_components/beatify/playlists/community/sommerklassiker.json
@@ -1,6 +1,6 @@
 {
   "name": "Sommerklassiker ☀️",
-  "version": "0.9",
+  "version": "0.10",
   "tags": [
     "summer",
     "pop",
@@ -1738,7 +1738,7 @@
       "certifications": [],
       "awards": [],
       "isrc": "DEQ321200132",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/1470909129",
       "uri_apple_music_by_region": {
         "us": null,
         "de": null,
@@ -1798,7 +1798,7 @@
       "certifications": [],
       "awards": [],
       "isrc": "USRC11401783",
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/902800356",
       "uri_apple_music_by_region": {
         "us": null,
         "de": null,


### PR DESCRIPTION
The 33 tracks the lead-artist rule from #2212 found, measured over **all 186** open Apple gaps rather than sampled. Refs #2211.

| playlist | added | version |
|---|---|---|
| `edm-anthems` | 24 | 1.31 → 1.32 |
| `polish-hits-90s-00s` | 3 | 0.12 → 0.13 |
| `polish-rock` | 2 | 0.15 → 0.16 |
| `sommerklassiker` | 2 | 0.9 → 0.10 |
| `eurodance-90s` | 1 | 1.11 → 1.12 |
| `quebecois-1990-2020` | 1 | 0.12 → 0.13 |

Apple coverage goes from **5893/6079 (96.9%)** to **5926/6079 (97.5%)**. 24 of the 33 sit in `edm-anthems`, which was the weakest playlist for Apple at 151 of 190 — featured-artist credits cluster in dance music, so the gap and its cause line up.

## How the diff was read

Rather than eyeballing it, the working tree was compared against `HEAD` field by field, index by index:

- **6** files touched, **33** `uri_apple_music` fields changed, **0** other field changes.
- Song count and song order unchanged in every file (asserted, not assumed).
- All 33 were `null` before — except one, `spotify:track:0l2c67gYvWLmYkz8l1gbdn` in `eurodance-90s`, which carried no `uri_apple_music` key at all. That is the single asymmetric line in the diff: adding the key put a trailing comma on the preceding `awards_nl` line, which is why the diff reads 40 insertions against 39 deletions.
- The set of changed Spotify ids is exactly the set of measured ids — no extra track was touched.
- Every written value equals `applemusic://track/<measured id>`.

That last check is the one worth keeping. A catalogue fix on 2026-08-16 hit three songs instead of one because it matched on the artist name; matching on the Spotify id and then asserting the id set is what stops that class of mistake.

## Gate

`scripts/validate_playlists.py` — **all 55 files valid, schema gate passed**. 10 non-blocking lint warnings, identical in count to `main` before this change (verified by stashing and re-running), so none of them come from here.
