### PR TITLE
chore(playlists): youtube backfill — +27 youtube uris

### DIFF
--- a/custom_components/beatify/playlists/community/polish-all-time-hits.json
+++ b/custom_components/beatify/playlists/community/polish-all-time-hits.json
@@ -1,6 +1,6 @@
 {
   "name": "Polskie przeboje wszech czasów",
-  "version": "0.11",
+  "version": "0.13",
   "tags": [
     "polish",
     "pop",
@@ -1371,7 +1371,7 @@
         "it": "applemusic://track/1066493162",
         "pl": "applemusic://track/1066493162"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=RtWD4iWvgqU",
       "uri_tidal": "tidal://track/55083321",
       "uri_deezer": "deezer://track/190533861",
       "fun_fact": "Marek Grechuta belongs to the Polish popular-music canon; \"Ocalić od zapomnienia\" (2015) features on this Polskie przeboje wszech czasów selection.",
@@ -1399,7 +1399,7 @@
         "it": "applemusic://track/1855904909",
         "pl": "applemusic://track/1855904909"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=pwO4y5FN7BA",
       "uri_tidal": "tidal://track/48983964",
       "uri_deezer": "deezer://track/103795444",
       "fun_fact": "Martyna Jakubowicz belongs to the Polish popular-music canon; \"W Domach z Betonu Nie Ma Wolnej Miłości\" (2015) features on this Polskie przeboje wszech czasów selection.",
@@ -1427,7 +1427,7 @@
         "it": "applemusic://track/1098869915",
         "pl": "applemusic://track/1098869915"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=UAaW1BUSPP8",
       "uri_tidal": "tidal://track/58809732",
       "uri_deezer": "deezer://track/121736558",
       "fun_fact": "Kazik belongs to the Polish popular-music canon; \"12 Groszy\" (2016) features on this Polskie przeboje wszech czasów selection.",
@@ -1455,7 +1455,7 @@
         "it": "applemusic://track/915322223",
         "pl": "applemusic://track/915322223"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=BmEP9czgX0c",
       "uri_tidal": "tidal://track/58381216",
       "uri_deezer": "deezer://track/120994986",
       "fun_fact": "Lombard belongs to the Polish popular-music canon; \"Przeżyj To Sam\" (2016) features on this Polskie przeboje wszech czasów selection.",
@@ -1483,7 +1483,7 @@
         "it": null,
         "pl": "applemusic://track/1206451409"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=DxWKCvpoPYI",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/133752250",
       "fun_fact": "Varius Manx belongs to the Polish popular-music canon; \"Zanim Zrozumiesz\" (2016) features on this Polskie przeboje wszech czasów selection.",
@@ -1511,7 +1511,7 @@
         "it": "applemusic://track/1433949584",
         "pl": "applemusic://track/1433949584"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=RrAn5pGqu_w",
       "uri_tidal": "tidal://track/94003511",
       "uri_deezer": "deezer://track/546835792",
       "fun_fact": "Bajm belongs to the Polish popular-music canon; \"Co mi Panie dasz\" (2018) features on this Polskie przeboje wszech czasów selection.",
@@ -1539,7 +1539,7 @@
         "it": "applemusic://track/1349865949",
         "pl": "applemusic://track/1349865949"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=983bLBM_h_0",
       "uri_tidal": "tidal://track/84813790",
       "uri_deezer": "deezer://track/463474162",
       "fun_fact": "Edyta Bartosiewicz belongs to the Polish popular-music canon; \"Opowieść\" (2018) features on this Polskie przeboje wszech czasów selection.",
@@ -1569,7 +1569,7 @@
         "it": "applemusic://track/1369127678",
         "pl": "applemusic://track/1369127678"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=SMWw4ee-YqE",
       "uri_tidal": "tidal://track/485977817",
       "uri_deezer": "deezer://track/3747824252",
       "fun_fact": "Varius Manx belongs to the Polish popular-music canon; \"Piosenka księżycowa - Acoustic Version\" (2018) features on this Polskie przeboje wszech czasów selection.",
@@ -1597,7 +1597,7 @@
         "it": "applemusic://track/1584907323",
         "pl": "applemusic://track/1584907323"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=lSO8lD3e2xU",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1496653472",
       "fun_fact": "Urszula belongs to the Polish popular-music canon; \"Na Sen\" (2021) features on this Polskie przeboje wszech czasów selection.",
@@ -1625,7 +1625,7 @@
         "it": "applemusic://track/1584907550",
         "pl": "applemusic://track/1584907550"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=8sPAIYQiEb4",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1496653532",
       "fun_fact": "Urszula belongs to the Polish popular-music canon; \"Konik Na Biegunach\" (2021) features on this Polskie przeboje wszech czasów selection.",
@@ -1653,7 +1653,7 @@
         "it": "applemusic://track/1689642097",
         "pl": "applemusic://track/1689642097"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=oqHfso2fXF8",
       "uri_tidal": "tidal://track/296851712",
       "uri_deezer": "deezer://track/2301155735",
       "fun_fact": "ŁZY Adam Konkol belongs to the Polish popular-music canon; \"Agnieszka\" (2023) features on this Polskie przeboje wszech czasów selection.",

--- a/custom_components/beatify/playlists/community/polish-rock.json
+++ b/custom_components/beatify/playlists/community/polish-rock.json
@@ -1,6 +1,6 @@
 {
   "name": "Polski Rock",
-  "version": "0.16",
+  "version": "0.18",
   "tags": [
     "polish",
     "rock"
@@ -2341,7 +2341,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=x3kicEsx7g0",
       "uri_tidal": "tidal://track/58810110",
       "uri_deezer": "deezer://track/121736400",
       "alt_artists": [],
@@ -2367,7 +2367,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=I8NcELiIMHg",
       "uri_tidal": "tidal://track/58810129",
       "uri_deezer": "deezer://track/121736510",
       "alt_artists": [],
@@ -2393,7 +2393,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=7PY55W9VCis",
       "uri_tidal": "tidal://track/494852618",
       "uri_deezer": "deezer://track/3815619752",
       "alt_artists": [],
@@ -2497,7 +2497,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Cc8oAPMzqrk",
       "uri_tidal": "tidal://track/451340049",
       "uri_deezer": "deezer://track/3487494801",
       "alt_artists": [],

--- a/custom_components/beatify/playlists/disney-classics.json
+++ b/custom_components/beatify/playlists/disney-classics.json
@@ -1,6 +1,6 @@
 {
   "name": "Disney Classics",
-  "version": "1.7",
+  "version": "1.8",
   "tags": [
     "disney",
     "movies",
@@ -94,7 +94,7 @@
       "awards_fr": [],
       "awards_nl": [],
       "uri_apple_music": "applemusic://track/1440639393",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=79DijItQXMM",
       "movie": "Moana",
       "movie_choices": [
         "Moana",
@@ -1541,7 +1541,7 @@
         "Grammy voor Best Song Written for Visual Media (2001)"
       ],
       "uri_apple_music": "applemusic://track/1437333914",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=w0ZHlp6atUQ",
       "movie": "Tarzan",
       "movie_choices": [
         "Tarzan",
@@ -2592,7 +2592,7 @@
         "Critics' Choice Movie Award voor Beste Song (2022)"
       ],
       "uri_apple_music": "applemusic://track/1594677760",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=bvWRMAU6V-c",
       "movie": "Encanto",
       "movie_choices": [
         "Encanto",
@@ -2795,7 +2795,7 @@
       "awards_fr": [],
       "awards_nl": [],
       "uri_apple_music": "applemusic://track/1664564080",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=FfeFUOjQsVQ",
       "movie": "Anastasia",
       "movie_choices": [
         "Anastasia",
@@ -2848,7 +2848,7 @@
         "Oscar-nominatie voor Beste Originele Song (1998)"
       ],
       "uri_apple_music": "applemusic://track/1664565006",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=mgyKVLUt0no",
       "movie": "Anastasia",
       "movie_choices": [
         "Anastasia",
@@ -2894,7 +2894,7 @@
       "awards_fr": [],
       "awards_nl": [],
       "uri_apple_music": "applemusic://track/1443634546",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=MUZwblurraA",
       "movie": "Treasure Planet",
       "movie_choices": [
         "Treasure Planet",
@@ -2937,7 +2937,7 @@
       "awards_fr": [],
       "awards_nl": [],
       "uri_apple_music": "applemusic://track/1467938153",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=uX2mopyE5Z0",
       "movie": "The Jungle Book",
       "movie_choices": [
         "The Jungle Book",
@@ -3048,7 +3048,7 @@
         "Oscar-nominatie voor Beste Originele Song (1965)"
       ],
       "uri_apple_music": "applemusic://track/1444019946",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=xA_vQZd_9N8",
       "movie": "Mary Poppins",
       "movie_choices": [
         "Mary Poppins",
@@ -3090,7 +3090,7 @@
       "awards_fr": [],
       "awards_nl": [],
       "uri_apple_music": "applemusic://track/1444019703",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=_L4qauTiCY4",
       "movie": "Mary Poppins",
       "movie_choices": [
         "Mary Poppins",
@@ -3165,7 +3165,8 @@
         "es": "applemusic://track/1434821546",
         "nl": "applemusic://track/1434821546",
         "it": "applemusic://track/1434821546"
-      }
+      },
+      "uri_youtube_music": "https://music.youtube.com/watch?v=SPUTFprsG1U"
     },
     {
       "year": 1996,
@@ -3190,7 +3191,7 @@
       "awards_fr": [],
       "awards_nl": [],
       "uri_apple_music": "applemusic://track/1440357115",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Q-FKLdMEehA",
       "movie": "The Hunchback of Notre Dame",
       "movie_choices": [
         "The Hunchback of Notre Dame",
@@ -3318,7 +3319,7 @@
       "awards_fr": [],
       "awards_nl": [],
       "uri_apple_music": "applemusic://track/1440669863",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=nDJockBnjYs",
       "movie": "The Aristocats",
       "movie_choices": [
         "The Aristocats",


### PR DESCRIPTION
Ein Lauf des `provider-uri-backfill`, automatisch gefahren von `com.beatify.youtube-backfill`.

- `polish-all-time-hits` YouTube 48 -> **59**/59
- `polish-rock` YouTube 89 -> **93**/100
- `disney-classics` YouTube 57 -> **69**/69

**Draft mit Absicht** — Merge nur nach Markus' Freigabe.