### PR TITLE
chore(playlists): youtube backfill — +19 youtube uris

### DIFF
--- a/custom_components/beatify/playlists/80er-hits.json
+++ b/custom_components/beatify/playlists/80er-hits.json
@@ -1,6 +1,6 @@
 {
   "name": "80s Hits",
-  "version": "2.14",
+  "version": "2.15",
   "tags": [
     "1980s",
     "pop",
@@ -2485,7 +2485,8 @@
       "fun_fact_nl": "Oorspronkelijk uitgebracht in 1982 en opnieuw opgenomen voor het album 'The Hurting', gaat het nummer over emotionele verwaarlozing in de kindertijd, geïnspireerd door Arthur Janovs primaire therapie.",
       "awards_nl": [],
       "uri_tidal": "tidal://track/22936962",
-      "uri_apple_music": "applemusic://track/1440912610"
+      "uri_apple_music": "applemusic://track/1440912610",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=BUfcT5OoP-8"
     },
     {
       "year": 1983,
@@ -3624,7 +3625,8 @@
         "es": "applemusic://track/1692882667",
         "nl": "applemusic://track/1692882667",
         "it": "applemusic://track/1692882667"
-      }
+      },
+      "uri_youtube_music": "https://music.youtube.com/watch?v=NSRrAYeh5OU"
     },
     {
       "year": 1984,
@@ -3696,7 +3698,8 @@
         "es": "applemusic://track/1127014316",
         "nl": "applemusic://track/1127014316",
         "it": "applemusic://track/1127014316"
-      }
+      },
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Fe93CLbHjxQ"
     },
     {
       "year": 1984,
@@ -5662,7 +5665,8 @@
       "uri_deezer": "deezer://track/540503452",
       "fun_fact_nl": "Oorspronkelijk met Dolly Parton in gedachten voor de vrouwelijke zang, zong Kate Bush uiteindelijk het duet. Het nummer was geïnspireerd op Depressie-era foto's van Dorothea Lange.",
       "awards_nl": [],
-      "uri_apple_music": "applemusic://track/986800861"
+      "uri_apple_music": "applemusic://track/986800861",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=VjEq-r2agqc"
     },
     {
       "year": 1986,

--- a/custom_components/beatify/playlists/community/deutschrock-best-of.json
+++ b/custom_components/beatify/playlists/community/deutschrock-best-of.json
@@ -1,6 +1,6 @@
 {
   "name": "Deutschrock - Best Of",
-  "version": "0.29",
+  "version": "0.31",
   "tags": [
     "deutschrock",
     "german rock",
@@ -2525,7 +2525,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=IqJo2donfMA",
       "uri_tidal": "tidal://track/453551268",
       "uri_deezer": "deezer://track/3503714961",
       "alt_artists": [],
@@ -2551,7 +2551,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=lKvqAKiUW58",
       "uri_tidal": "tidal://track/2040270",
       "uri_deezer": "deezer://track/1272451822",
       "alt_artists": [],
@@ -2577,7 +2577,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=nQXfqSTbRgo",
       "uri_tidal": "tidal://track/1992589",
       "uri_deezer": "deezer://track/2222140",
       "alt_artists": [],
@@ -2603,7 +2603,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=dxMUs1QsEKY",
       "uri_tidal": "tidal://track/119304666",
       "uri_deezer": "deezer://track/767767252",
       "alt_artists": [],

--- a/custom_components/beatify/playlists/community/polish-rock.json
+++ b/custom_components/beatify/playlists/community/polish-rock.json
@@ -1,6 +1,6 @@
 {
   "name": "Polski Rock",
-  "version": "0.18",
+  "version": "0.19",
   "tags": [
     "polish",
     "rock"
@@ -2575,7 +2575,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=UOyXW3hJMqg",
       "uri_tidal": "tidal://track/389745865",
       "uri_deezer": "deezer://track/3017689761",
       "alt_artists": [],
@@ -2601,7 +2601,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=z0EZSFAnD04",
       "uri_tidal": "tidal://track/121024756",
       "uri_deezer": "deezer://track/785902672",
       "alt_artists": [],

--- a/custom_components/beatify/playlists/community/quebecois-1990-2020.json
+++ b/custom_components/beatify/playlists/community/quebecois-1990-2020.json
@@ -1,6 +1,6 @@
 {
   "name": "🍁 Québécois 1990-2020",
-  "version": "0.13",
+  "version": "0.14",
   "tags": [
     "quebecois",
     "quebec",
@@ -1232,7 +1232,7 @@
         "nl": "applemusic://track/1606159319",
         "it": "applemusic://track/1606159319"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=qJPxlP3m4DM",
       "uri_tidal": "tidal://track/332416388",
       "uri_deezer": "deezer://track/77580105",
       "alt_artists": [
@@ -1622,7 +1622,7 @@
         "nl": "applemusic://track/1568305004",
         "it": "applemusic://track/1568305004"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=RrBHlpUIbE0",
       "uri_tidal": "tidal://track/185129248",
       "uri_deezer": "deezer://track/1376976052",
       "alt_artists": [
@@ -1802,7 +1802,7 @@
         "nl": "applemusic://track/627076988",
         "it": "applemusic://track/627076988"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=s9otjryrpYU",
       "uri_tidal": "tidal://track/20526267",
       "uri_deezer": "deezer://track/65802695",
       "alt_artists": [
@@ -2102,7 +2102,7 @@
         "nl": "applemusic://track/1459897036",
         "it": "applemusic://track/1459897036"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=xwNKQbafLQo",
       "uri_tidal": "tidal://track/108016819",
       "uri_deezer": "deezer://track/668926932",
       "alt_artists": [
@@ -2192,7 +2192,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=RkC9HgrRq3Q",
       "uri_tidal": "tidal://track/36289922",
       "uri_deezer": "deezer://track/617423192",
       "alt_artists": [
@@ -3362,7 +3362,7 @@
         "nl": "applemusic://track/1274063182",
         "it": "applemusic://track/1274063182"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=4j8DVTkZdCE",
       "uri_tidal": "tidal://track/75787055",
       "uri_deezer": "deezer://track/401394412",
       "alt_artists": [
@@ -3572,7 +3572,7 @@
         "nl": "applemusic://track/687812868",
         "it": "applemusic://track/687812868"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=RLOQCqGKVt8",
       "uri_tidal": "tidal://track/21048803",
       "uri_deezer": "deezer://track/1885473517",
       "alt_artists": [

--- a/custom_components/beatify/playlists/community/top100-allertijden-nederlandstalig.json
+++ b/custom_components/beatify/playlists/community/top100-allertijden-nederlandstalig.json
@@ -1,6 +1,6 @@
 {
   "name": "Top 100 Dutch Classics 🇳🇱",
-  "version": "1.17",
+  "version": "1.19",
   "tags": [
     "nederlandstalig",
     "dutch",
@@ -2557,7 +2557,8 @@
       "fun_fact_es": "Toppertje! se convirtió en el himno no oficial de los conciertos Toppers holandeses con Gordon, Gerard Joling y Jan Smit.",
       "fun_fact_fr": "Toppertje! est devenu l'hymne non officiel des concerts Toppers néerlandais avec Gordon, Gerard Joling et Jan Smit.",
       "fun_fact_nl": "Toppertje! werd het officieuze volkslied van de Nederlandse Toppers-concerten, razend populaire entertainmentspektakels met Gordon, Gerard Joling en Jan Smit. Het upbeat, campy nummer vatte perfect de over-the-top spirit van het merk Toppers. Het werd een van de meest herkenbare Nederlandse feestnummers van midden jaren 2000.",
-      "awards_nl": []
+      "awards_nl": [],
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Ktk1Lj5e18Y"
     },
     {
       "year": 1994,
@@ -2730,7 +2731,8 @@
         "nl": "applemusic://track/1371915839",
         "it": "applemusic://track/1371915839"
       },
-      "uri_deezer": "deezer://track/485661192"
+      "uri_deezer": "deezer://track/485661192",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=pZpqZq1nNJs"
     },
     {
       "year": 2018,

--- a/custom_components/beatify/playlists/community/wiesn-party-hits.json
+++ b/custom_components/beatify/playlists/community/wiesn-party-hits.json
@@ -1,6 +1,6 @@
 {
   "name": "Wiesn Party Hits 🍻",
-  "version": "0.20",
+  "version": "0.22",
   "tags": [
     "party",
     "schlager",
@@ -3254,7 +3254,7 @@
         "it": "applemusic://track/275486349"
       },
       "uri_deezer": "deezer://track/2911274451",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=ZVz_IJoyO6Y",
       "uri_tidal": "tidal://track/377339098"
     },
     {
@@ -3287,7 +3287,7 @@
         "it": "applemusic://track/1893345560"
       },
       "uri_deezer": "deezer://track/3960003601",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=-Qb9aSyVQU8",
       "uri_tidal": "tidal://track/515839583"
     },
     {
@@ -3320,7 +3320,7 @@
         "it": "applemusic://track/1886784465"
       },
       "uri_deezer": "deezer://track/3924289331",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=je1t5zJRSXE",
       "uri_tidal": "tidal://track/510532089"
     },
     {
@@ -3353,7 +3353,7 @@
         "it": "applemusic://track/1880096511"
       },
       "uri_deezer": "deezer://track/3870271561",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=06ta931Ij4E",
       "uri_tidal": "tidal://track/502686746"
     },
     {
@@ -3386,7 +3386,7 @@
         "it": "applemusic://track/1735706160"
       },
       "uri_deezer": "deezer://track/2816336822",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=eVyoGdXgjY4",
       "uri_tidal": "tidal://track/365133648"
     },
     {
@@ -3419,7 +3419,7 @@
         "it": "applemusic://track/1891323779"
       },
       "uri_deezer": "deezer://track/3946488621",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=sG-8SSi-xzU",
       "uri_tidal": "tidal://track/513809918"
     }
   ]

--- a/custom_components/beatify/playlists/eurovision-winners.json
+++ b/custom_components/beatify/playlists/eurovision-winners.json
@@ -1,6 +1,6 @@
 {
   "name": "Eurovision Winners (1956-2025)",
-  "version": "1.12",
+  "version": "1.13",
   "tags": [
     "eurovision",
     "contest",
@@ -1132,7 +1132,8 @@
         "Eurovisionwinnaar 1975"
       ],
       "uri_tidal": "tidal://track/181365005",
-      "uri_apple_music": "applemusic://track/104581124"
+      "uri_apple_music": "applemusic://track/104581124",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=BPxuq4uQ0OU"
     },
     {
       "year": 1976,
@@ -1524,7 +1525,8 @@
         "es": "applemusic://track/1568840214",
         "nl": "applemusic://track/1568840214",
         "it": "applemusic://track/1568840214"
-      }
+      },
+      "uri_youtube_music": "https://music.youtube.com/watch?v=F8y5xc8UodE"
     },
     {
       "year": 1984,
@@ -2385,7 +2387,8 @@
       "fun_fact_nl": "Everybody was de eerste Estse overwinning en de eerste voor een voormalige Sovjetrepubliek. Dave Benton werd op 50-jarige leeftijd de oudste winnaar en de eerste zwarte artiest die won. Estland werd kampioen in slechts zeven jaar na hun debuut.",
       "awards_nl": [
         "Eurovisionwinnaar 2001"
-      ]
+      ],
+      "uri_youtube_music": "https://music.youtube.com/watch?v=92TSUlqzFi8"
     },
     {
       "year": 2002,
@@ -2434,7 +2437,8 @@
         "nl": "applemusic://track/260662904",
         "it": "applemusic://track/260662904"
       },
-      "uri_tidal": "tidal://track/12486339"
+      "uri_tidal": "tidal://track/12486339",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=_M-w89U8TEU"
     },
     {
       "year": 2003,
@@ -2863,7 +2867,8 @@
       "fun_fact_nl": "Running Scared was de eerste Eurovisie-overwinning voor Azerbeidzjan, dat pas in 2008 debuteerde. Het romantische duet van Ell en Nikki versloeg nipt Italië. De overwinning zorgde ervoor dat Azerbeidzjan Eurovisie 2012 mocht organiseren in hun speciaal gebouwde Crystal Hall.",
       "awards_nl": [
         "Eurovisionwinnaar 2011"
-      ]
+      ],
+      "uri_youtube_music": "https://music.youtube.com/watch?v=_0tlQUW5X0U"
     },
     {
       "year": 2012,

--- a/custom_components/beatify/playlists/movies-100-greatest-themes.json
+++ b/custom_components/beatify/playlists/movies-100-greatest-themes.json
@@ -1,6 +1,6 @@
 {
   "name": "100 Greatest Movie Themes 🎬",
-  "version": "1.19",
+  "version": "1.20",
   "tags": [
     "movies",
     "soundtrack",
@@ -6495,7 +6495,8 @@
       "fun_fact_nl": "The Deer Hunter gebruikt Cavatina van Stanley Myers. Het zachte gitaarstuk staat in schril contrast met het geweld van de film.",
       "awards_nl": [],
       "uri_apple_music": "applemusic://track/1052784975",
-      "uri_deezer": "deezer://track/120866262"
+      "uri_deezer": "deezer://track/120866262",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=gGycDDqBuX8"
     },
     {
       "year": 2001,
@@ -7076,7 +7077,8 @@
       "uri_deezer": "deezer://track/106267650",
       "fun_fact_nl": "John Barry's From Russia with Love vestigde de muzikale stijl van Bond. Het was de eerste Bondfilm met een titelsong.",
       "awards_nl": [],
-      "uri_apple_music": "applemusic://track/1542637867"
+      "uri_apple_music": "applemusic://track/1542637867",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=UDZEZxHdq5k"
     },
     {
       "year": 1946,
@@ -7114,7 +7116,8 @@
         "es": "applemusic://track/1597777326",
         "nl": "applemusic://track/1597777326",
         "it": "applemusic://track/1597777326"
-      }
+      },
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Ncbod0QSLJA"
     },
     {
       "year": 1942,
@@ -7160,7 +7163,8 @@
       "awards_nl": [
         "Oscar voor Beste Originele Lied (1942)"
       ],
-      "uri_apple_music": "applemusic://track/1300642506"
+      "uri_apple_music": "applemusic://track/1300642506",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=v5ryZdpEHqM"
     },
     {
       "year": 1958,
@@ -7187,7 +7191,8 @@
       "uri_tidal": "tidal://track/303511178",
       "uri_deezer": "deezer://track/2357173085",
       "fun_fact_nl": "Het Pearl & Dean-thema speelt al sinds 1958 voor reclames in Britse bioscopen. De fanfare is bekend bij generaties bioscoopbezoekers.",
-      "awards_nl": []
+      "awards_nl": [],
+      "uri_youtube_music": "https://music.youtube.com/watch?v=cxU6LT6DonE"
     }
   ],
   "movie_quiz_enabled": true


### PR DESCRIPTION
Ein Lauf des `provider-uri-backfill`, automatisch gefahren von `com.beatify.youtube-backfill`.

- `deutschrock-best-of` YouTube 95 -> **99**/100
- `polish-rock` YouTube 93 -> **95**/100
- `quebecois-1990-2020` YouTube 119 -> **126**/126
- `wiesn-party-hits` YouTube 94 -> **100**/100

**Draft mit Absicht** — Merge nur nach Markus' Freigabe.