### PR TITLE
fix(pages): landing page still advertised the June catalogue

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,7 +49,7 @@
     "description": "Multiplayer music trivia party game for Home Assistant. Guess the release year or name the title & artist. Guests scan a QR code to join — no app, no account. Works with Sonos, Alexa, and Music Assistant speakers.",
     "url": "https://mholzi.github.io/beatify/",
     "downloadUrl": "https://my.home-assistant.io/redirect/hacs_repository/?owner=mholzi&repository=beatify&category=integration",
-    "softwareVersion": "4.1.3",
+    "softwareVersion": "4.2.0",
     "offers": {
       "@type": "Offer",
       "price": "0",
@@ -94,8 +94,8 @@
           <p class="tagline">Scan a QR code. Hear a song. Guess the year — or name the title and artist. Beats, laughs, rematches — all through your existing smart speakers.</p>
 
           <div class="hero-stats">
-            <span>46 playlists</span>
-            <span>5,161 songs</span>
+            <span>55 playlists</span>
+            <span>6,079 songs</span>
             <span>5 music platforms</span>
             <span>5 languages</span>
           </div>
@@ -131,7 +131,7 @@
             <div class="step">
               <div class="step-number" aria-hidden="true">2</div>
               <h3>Pick Music</h3>
-              <p>Choose from 46 curated playlists or connect Spotify, Apple Music, YouTube Music, Deezer, or Tidal.</p>
+              <p>Choose from 55 curated playlists or connect Spotify, Apple Music, YouTube Music, Deezer, or Tidal.</p>
             </div>
             <div class="step">
               <div class="step-number" aria-hidden="true">3</div>
@@ -160,7 +160,7 @@
             <div class="feature">
               <div class="feature-icon" aria-hidden="true">🎵</div>
               <h3>Your Music</h3>
-              <p>Spotify, Apple Music, YouTube Music, Deezer, Tidal. 46 curated playlists included.</p>
+              <p>Spotify, Apple Music, YouTube Music, Deezer, Tidal. 55 curated playlists included.</p>
             </div>
             <div class="feature">
               <div class="feature-icon" aria-hidden="true">✍️</div>

--- a/index.html
+++ b/index.html
@@ -96,7 +96,7 @@
           <div class="hero-stats">
             <span>55 playlists</span>
             <span>6,079 songs</span>
-            <span>5 music platforms</span>
+            <span>6 music services</span>
             <span>5 languages</span>
           </div>
 
@@ -131,7 +131,7 @@
             <div class="step">
               <div class="step-number" aria-hidden="true">2</div>
               <h3>Pick Music</h3>
-              <p>Choose from 55 curated playlists or connect Spotify, Apple Music, YouTube Music, Deezer, or Tidal.</p>
+              <p>Choose from 55 curated playlists or connect Spotify, Apple Music, YouTube Music, Deezer, Tidal or Amazon Music.</p>
             </div>
             <div class="step">
               <div class="step-number" aria-hidden="true">3</div>
@@ -160,7 +160,7 @@
             <div class="feature">
               <div class="feature-icon" aria-hidden="true">🎵</div>
               <h3>Your Music</h3>
-              <p>Spotify, Apple Music, YouTube Music, Deezer, Tidal. 55 curated playlists included.</p>
+              <p>Spotify, Apple Music, YouTube Music, Deezer, Tidal and Amazon Music. 55 curated playlists included.</p>
             </div>
             <div class="feature">
               <div class="feature-icon" aria-hidden="true">✍️</div>


### PR DESCRIPTION
Base is `gh-pages`. Split out of #2219 so the number corrections can be reviewed on their own.

Every figure counted against `origin/main` today, not carried over from the page.

| where | was | is |
|---|---|---|
| hero | 46 playlists · 5,161 songs | **55 playlists · 6,079 songs** |
| how-it-works, step 2 | 46 curated playlists | 55 |
| features, "Your Music" | 46 curated playlists | 55 |
| JSON-LD | `softwareVersion: 4.1.3` | **4.2.0** |

4.1.3 shipped 2026-06-24. 4.2.0 has been latest stable since 2026-08-09. For most of two months the page told every visitor — and every crawler reading the structured data — that the catalogue is 16 % smaller than it actually is.

## Two more things on this page, left alone on purpose

Neither is a number, so neither belongs in this PR:

1. **The changelog stops at v4.1.3 (Jun 24).** It is missing v4.2.0 "Mix & Match", the largest release since the redesign. That is copy to write, not a figure to correct.
2. **"5 music platforms" in the hero.** The repo description, refreshed on 2026-08-15, lists six by counting Amazon Music via Alexa. The catalogue itself carries five URI fields, so both numbers are defensible depending on what you count — worth one decision, then applied consistently across the page, the repo description and `/de`.

## Conflict note

#2219 also touches `index.html`, in the `<head>` (hreflang) and the nav. Different lines from these, so the two should merge cleanly in either order; whichever goes second may still want a rebase.