### PR TITLE
docs(pages): add v4.2.0 to the changelog

### DIFF
--- a/index.html
+++ b/index.html
@@ -288,6 +288,11 @@
           <h2 class="section-title">Changelog</h2>
           <div class="changelog-list">
             <div class="changelog-entry">
+              <span class="changelog-version">v4.2.0</span>
+              <span class="changelog-date">Aug 9, 2026</span>
+              <p>🎛️ Mix &amp; Match — a new Mix tab builds a playlist on the spot from any combination of decade, style and region, the setup screen suggests a playlist for the season, and an opt-in Sudden Death round eliminates the lowest scorer from round two on</p>
+            </div>
+            <div class="changelog-entry">
               <span class="changelog-version">v4.1.3</span>
               <span class="changelog-date">Jun 24, 2026</span>
               <p>🌊 New Wave Summer — two new German playlists (Sommerklassiker ☀️ &amp; NDW – Neue Deutsche Welle), plus fixes: speaker selection now applies instantly and Android Chrome no longer auto-translates the UI</p>


### PR DESCRIPTION
Base is `gh-pages`. Split out of #2220, which only corrects figures — this one is copy.

The changelog stopped at **v4.1.3 (Jun 24)**. v4.2.0 shipped **2026-08-09** and is the largest release since the redesign, so the page has been two months and one major release behind.

Entry follows the existing format (version, date, one line with a leading emoji) and takes its wording from the release notes rather than inventing a summary — the Mix tab, the seasonal suggestion on the setup screen, and the opt-in Sudden Death round.

## Note

`v4.2.1-rc1` and `-rc2` are deliberately **not** listed. The changelog only carries stable releases, and both are pre-releases; v4.2.0 remains latest stable.

Touches `index.html` in the changelog section only — no overlap with the lines changed in #2219 (head, nav) or #2220 (hero, features, JSON-LD).