### PR TITLE
chore(playlists): youtube backfill — +14 youtube uris

### DIFF
--- a/custom_components/beatify/playlists/community/british-invasion-britpop.json
+++ b/custom_components/beatify/playlists/community/british-invasion-britpop.json
@@ -1,6 +1,6 @@
 {
   "name": "British Invasion & Britpop 🇬🇧",
-  "version": "1.6",
+  "version": "1.8",
   "tags": [
     "1960s",
     "1990s",
@@ -1765,7 +1765,8 @@
         "es": "applemusic://track/1241160162",
         "nl": "applemusic://track/1241160162",
         "it": "applemusic://track/1241160162"
-      }
+      },
+      "uri_youtube_music": "https://music.youtube.com/watch?v=OEDAGNYYa1o"
     },
     {
       "year": 1968,
@@ -3376,7 +3377,8 @@
       "fun_fact_nl": "Anne Briggs was een enorm invloedrijke figuur in de Britse folk revival die de muziek vaarwel zei om een teruggetrokken leven te gaan leiden in de Schotse Hooglanden. Ze was een belangrijke inspiratie voor Sandy Denny en vele anderen.",
       "awards_nl": [],
       "uri_tidal": "tidal://track/222867938",
-      "uri_apple_music": "applemusic://track/1617409983"
+      "uri_apple_music": "applemusic://track/1617409983",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=J194Hr6_FlM"
     },
     {
       "year": 1996,

--- a/custom_components/beatify/playlists/community/eurodance-90s.json
+++ b/custom_components/beatify/playlists/community/eurodance-90s.json
@@ -1,6 +1,6 @@
 {
   "name": "Eurodance 90s 💥",
-  "version": "1.12",
+  "version": "1.13",
   "tags": [
     "1990s",
     "eurodance",
@@ -776,7 +776,8 @@
       "fun_fact_nl": "De inzending van Gina G voor het Eurovisie Songfestival namens het VK werd een nummer 1-hit en was een zeldzaam crossover-succes tussen het Songfestival en Eurodance.",
       "awards_nl": [],
       "uri_tidal": "tidal://track/4343025",
-      "uri_apple_music": "applemusic://track/401123583"
+      "uri_apple_music": "applemusic://track/401123583",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=ge_U6zw0gLo"
     },
     {
       "year": 1994,
@@ -2809,7 +2810,8 @@
       "uri_deezer": "deezer://track/133204792",
       "fun_fact_nl": "Het trance-anthem van Sash! werd een van de bepalende nummers van de Europese dansmuziek van eind jaren 90, met beklijvende Franse vocalen.",
       "awards_nl": [],
-      "uri_apple_music": "applemusic://track/1164431858"
+      "uri_apple_music": "applemusic://track/1164431858",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=frhVSxCxUGE"
     },
     {
       "year": 1995,
@@ -3321,7 +3323,8 @@
         "es": "applemusic://track/345069329",
         "nl": "applemusic://track/345069329",
         "it": "applemusic://track/345069329"
-      }
+      },
+      "uri_youtube_music": "https://music.youtube.com/watch?v=ogMRSwk2LpI"
     },
     {
       "year": 1995,

--- a/custom_components/beatify/playlists/community/ndw-neue-deutsche-welle.json
+++ b/custom_components/beatify/playlists/community/ndw-neue-deutsche-welle.json
@@ -1,6 +1,6 @@
 {
   "name": "NDW – Neue Deutsche Welle",
-  "version": "0.7",
+  "version": "0.9",
   "tags": [
     "ndw",
     "neue deutsche welle",
@@ -1627,7 +1627,7 @@
       "fun_fact_fr": "'Vor all den Jahren' de Stahlnetz est un bijou mélancolique du NDW de Hambourg.",
       "fun_fact_nl": "'Vor all den Jahren' van Stahlnetz is een melancholische NDW parel uit Hamburg.",
       "uri_apple_music": "applemusic://track/1862481651",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=VPHFwH-MJcY",
       "uri_tidal": "tidal://track/482999776",
       "uri_deezer": "3724778042",
       "isrc": "DEGE92000085",
@@ -1769,7 +1769,7 @@
       "fun_fact_fr": "'Irgendwie, irgendwo, irgendwann' de Nena a été écrite par le guitariste Carlo Karges, qui a aussi écrit '99 Luftballons'.",
       "fun_fact_nl": "'Irgendwie, irgendwo, irgendwann' van Nena werd geschreven door gitarist Carlo Karges, die ook '99 Luftballons' schreef.",
       "uri_apple_music": "applemusic://track/1446021377",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=oMHLkcc9I9c",
       "uri_tidal": "tidal://track/493681444",
       "uri_deezer": "3806147312",
       "isrc": "DEE869901718",

--- a/custom_components/beatify/playlists/disco-funk-classics.json
+++ b/custom_components/beatify/playlists/disco-funk-classics.json
@@ -1,6 +1,6 @@
 {
   "name": "Disco & Funk Classics",
-  "version": "1.15",
+  "version": "1.17",
   "tags": [
     "1970s",
     "1980s",
@@ -3785,7 +3785,7 @@
         "nl": null,
         "it": "applemusic://track/1469850494"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=ybt38UnfAU0",
       "uri_tidal": "tidal://track/113774878",
       "uri_deezer": "deezer://track/716819012",
       "isrc": "GBKQU1961236"
@@ -3820,7 +3820,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=oOimgG4DzbM",
       "uri_tidal": "tidal://track/123982184",
       "uri_deezer": "deezer://track/810601452",
       "isrc": "GBLV61913727"
@@ -3855,7 +3855,7 @@
         "nl": null,
         "it": null
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=70ubJKNWE4c",
       "uri_tidal": null,
       "uri_deezer": null,
       "isrc": null

--- a/custom_components/beatify/playlists/one-hit-wonders.json
+++ b/custom_components/beatify/playlists/one-hit-wonders.json
@@ -1,6 +1,6 @@
 {
   "name": "One-Hit Wonders",
-  "version": "1.10",
+  "version": "1.11",
   "tags": [
     "one-hit",
     "classics",
@@ -883,7 +883,8 @@
       "uri_deezer": "deezer://track/558949042",
       "fun_fact_nl": "Robin Scott nam dit op onder alleen de letter 'M'. Het nummer voorspelde de elektronische toekomst van de muziek, maar Scott bleef liever een mysterieus eendagsvlieg.",
       "awards_nl": [],
-      "uri_apple_music": "applemusic://track/1435333807"
+      "uri_apple_music": "applemusic://track/1435333807",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=gPoiv0sZ4s4"
     },
     {
       "year": 1979,
@@ -1400,7 +1401,8 @@
         "es": "applemusic://track/1550643321",
         "nl": "applemusic://track/1550643321",
         "it": "applemusic://track/1550643321"
-      }
+      },
+      "uri_youtube_music": "https://music.youtube.com/watch?v=wO0A0XcWy88"
     },
     {
       "year": 1983,
@@ -1692,7 +1694,8 @@
         "es": "applemusic://track/1695812529",
         "nl": "applemusic://track/1695812529",
         "it": "applemusic://track/1695812529"
-      }
+      },
+      "uri_youtube_music": "https://music.youtube.com/watch?v=w9gOQgfPW4Y"
     },
     {
       "year": 1988,
@@ -3538,7 +3541,8 @@
         "es": "applemusic://track/308198608",
         "nl": "applemusic://track/308198608",
         "it": "applemusic://track/308198608"
-      }
+      },
+      "uri_youtube_music": "https://music.youtube.com/watch?v=wq-S8CIU7VA"
     },
     {
       "year": 2005,


### PR DESCRIPTION
Ein Lauf des `provider-uri-backfill`, automatisch gefahren von `com.beatify.youtube-backfill`.

- `british-invasion-britpop` YouTube 98 -> **100**/100
- `eurodance-90s` YouTube 97 -> **100**/100
- `ndw-neue-deutsche-welle` YouTube 48 -> **50**/50
- `disco-funk-classics` YouTube 95 -> **98**/98
- `one-hit-wonders` YouTube 94 -> **98**/98

**Draft mit Absicht** — Merge nur nach Markus' Freigabe.