### PR TITLE
data: repair the Apple region map for Jimmy Eat World — The Middle

### DIFF
--- a/custom_components/beatify/playlists/2000s-pop-anthems.json
+++ b/custom_components/beatify/playlists/2000s-pop-anthems.json
@@ -1,6 +1,6 @@
 {
   "name": "2000s Pop Anthems",
-  "version": "1.18",
+  "version": "1.19",
   "tags": [
     "2000s",
     "pop",
@@ -3760,13 +3760,13 @@
       "awards_nl": [],
       "isrc": "USDW10110256",
       "uri_apple_music_by_region": {
-        "us": "applemusic://track/1706919742",
-        "de": "applemusic://track/1706919742",
-        "gb": "applemusic://track/1706919742",
-        "fr": "applemusic://track/1706919742",
-        "es": "applemusic://track/1706919742",
-        "nl": "applemusic://track/1706919742",
-        "it": "applemusic://track/1706919742"
+        "us": "applemusic://track/1450030115",
+        "de": "applemusic://track/1450030115",
+        "gb": "applemusic://track/1450030115",
+        "fr": "applemusic://track/1450030115",
+        "es": "applemusic://track/1450030115",
+        "nl": "applemusic://track/1450030115",
+        "it": "applemusic://track/1450030115"
       }
     },
     {


### PR DESCRIPTION
Closes #2223. Found by the 14:00 `playlist-review` run on `2000s-pop-anthems`.

All seven storefront entries in `uri_apple_music_by_region` claimed `applemusic://track/1706919742`. That id returns `resultCount: 0` — the track is **gone**, not regionally restricted, so every one of the seven was dead.

## Why 1450030115 and not a fresh search

The entry already carried the answer in its own base field, `uri_apple_music`. Checking there first is cheaper and safer than searching, and it is what the [katalog-defekt-beheben](https://github.com/mholzi/beatify) routine asks for after the Tanita Tikaram case on 2026-08-17, where the obvious replacement resolved in only one country.

| check | result |
|---|---|
| `lookup?id=1450030115` | Jimmy Eat World — The Middle, *Bleed American*, 2001 |
| release year vs catalogue `year: 2001` | matches |
| `country=` us, de, gb, fr, es, nl, it | resolves in **all seven**, checked one by one |

## Diff

One entry, seven region values, plus the version bump 1.18 → 1.19. Nothing else in the file changes — the base `uri_apple_music` was already correct and is untouched.

`scripts/validate_playlists.py`: all 55 files valid.

## The reporting bug is not fixed here

The same run printed `All tracks healthy — no issues found.` two lines after reporting 7 dead region entries. That is the blind spot #2194 already named on 2026-08-16; #2195 fixed that playlist's data and left the summary line alone. Described in #2223 — it needs a change in the health-check script, not in the catalogue.