### PR TITLE
chore(playlists): youtube backfill — +7 youtube uris

### DIFF
--- a/custom_components/beatify/playlists/community/anime-openings.json
+++ b/custom_components/beatify/playlists/community/anime-openings.json
@@ -1,6 +1,6 @@
 {
   "name": "Anime Openings",
-  "version": "1.24",
+  "version": "1.25",
   "tags": [
     "anime",
     "japanese",
@@ -335,7 +335,7 @@
         "it": "applemusic://track/1529543135"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=TqyfmFaZlqw",
-      "uri_tidal": null,
+      "uri_tidal": "tidal://track/156732851",
       "uri_deezer": "deezer://track/976228172",
       "fun_fact": "Opening 1 of 'Demon Slayer: Kimetsu no Yaiba' (2019) — LiSA's career-defining smash.",
       "fun_fact_de": "Opening 1 von 'Demon Slayer: Kimetsu no Yaiba' (2019) — LiSAs karrieredefinierender Hit.",

--- a/custom_components/beatify/playlists/community/best-of-giraffenaffen.json
+++ b/custom_components/beatify/playlists/community/best-of-giraffenaffen.json
@@ -1,6 +1,6 @@
 {
   "name": "Best of Giraffenaffen",
-  "version": "1.6",
+  "version": "1.7",
   "tags": [
     "kinderlieder",
     "kids",
@@ -529,7 +529,7 @@
         "nl": "applemusic://track/1615368685",
         "it": "applemusic://track/1615368685"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=jmjf7glExbU",
       "uri_tidal": "tidal://track/22288857",
       "uri_deezer": "deezer://track/1363393712",
       "fun_fact": "A German children's song from the popular Giraffenaffen collection (2009).",

--- a/custom_components/beatify/playlists/community/iconic-movie-songs.json
+++ b/custom_components/beatify/playlists/community/iconic-movie-songs.json
@@ -1,6 +1,6 @@
 {
   "name": "ICONIC movie songs 🎬",
-  "version": "0.11",
+  "version": "0.12",
   "tags": [
     "movies",
     "soundtracks",
@@ -2271,7 +2271,7 @@
       "fun_fact_es": "El eufórico final de Grease (1978).",
       "fun_fact_fr": "Le final exubérant de Grease (1978).",
       "uri_apple_music": "applemusic://track/1440844889",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=bkWevngKTcw",
       "uri_tidal": "tidal://track/77625043",
       "uri_deezer": "deezer://track/781563242",
       "fun_fact_nl": "De uitbundige finale van Grease (1978).",

--- a/custom_components/beatify/playlists/community/top100-allertijden-nederlandstalig.json
+++ b/custom_components/beatify/playlists/community/top100-allertijden-nederlandstalig.json
@@ -1,6 +1,6 @@
 {
   "name": "Top 100 Dutch Classics 🇳🇱",
-  "version": "1.19",
+  "version": "1.20",
   "tags": [
     "nederlandstalig",
     "dutch",
@@ -2833,7 +2833,8 @@
       "fun_fact_nl": "Mijn Gebed is een gospel-achtig Nederlandstalig popliedje uit 1970 dat de krachtige, soulvolle stem van D.C. Lewis liet horen. Het nummer werd een geliefde klassieker in de Nederlandstalige pop met zijn spirituele thema van gebed en geloof. Het blijft een van de meest kenmerkende Nederlandstalige popopnames van de vroege jaren 1970.",
       "awards_nl": [],
       "uri_apple_music": "applemusic://track/259313534",
-      "uri_deezer": "deezer://track/134543785"
+      "uri_deezer": "deezer://track/134543785",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=rqg_kNRvWNQ"
     },
     {
       "year": 2020,
@@ -2942,7 +2943,8 @@
         "it": "applemusic://track/1442289020"
       },
       "uri_tidal": "tidal://track/29536632",
-      "uri_deezer": "deezer://track/78256158"
+      "uri_deezer": "deezer://track/78256158",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=fDlUYTysLk8"
     },
     {
       "year": 1969,

--- a/custom_components/beatify/playlists/motown-soul-classics.json
+++ b/custom_components/beatify/playlists/motown-soul-classics.json
@@ -1,6 +1,6 @@
 {
   "name": "Motown & Soul Classics",
-  "version": "1.13",
+  "version": "1.14",
   "tags": [
     "1960s",
     "1970s",
@@ -1144,7 +1144,7 @@
       "fun_fact_es": "Kim Weston fue una de las vocalistas más versátiles de Motown, más conocida por su dueto 'It Takes Two' con Marvin Gaye. Los Doobie Brothers versionaron esta canción en 1975, alcanzando el #11 en Billboard Hot 100.",
       "fun_fact_fr": "Kim Weston était l'une des vocalistes les plus polyvalentes de Motown, surtout connue pour son duo « It Takes Two » avec Marvin Gaye. Les Doobie Brothers ont repris cette chanson en 1975, atteignant la 11e place du Billboard Hot 100.",
       "uri_apple_music": "applemusic://track/1443843981",
-      "uri_youtube_music": "",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=omnLs0npy6g",
       "uri_tidal": "tidal://track/70547017",
       "uri_deezer": "deezer://track/69454992",
       "fun_fact_nl": "Kim Weston was een van de meest veelzijdige zangeressen van Motown, vooral bekend van haar duet 'It Takes Two' met Marvin Gaye. De Doobie Brothers coverden dit nummer later in 1975 en bereikten nummer 11 in de Billboard Hot 100.",
@@ -1517,7 +1517,7 @@
       "fun_fact_es": "Escrita por Burt Bacharach y Hal David, se convirtió en una de las canciones insignia de Dionne Warwick y ganó el Grammy a Mejor Interpretación Vocal Pop Contemporánea. Aunque no es una grabación de Motown, aparece en esta playlist de Spotify junto a los clásicos de Motown.",
       "fun_fact_fr": "Écrite par Burt Bacharach et Hal David, elle est devenue l'une des chansons signatures de Dionne Warwick et a remporté le Grammy de la meilleure prestation vocale pop contemporaine. Bien que ne figurant pas sur Motown, elle apparaît dans cette playlist Spotify aux côtés des classiques du label.",
       "uri_apple_music": "applemusic://track/41688581",
-      "uri_youtube_music": "",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=FZLa-1q-lkw",
       "uri_deezer": "deezer://track/724179",
       "fun_fact_nl": "Dit nummer, geschreven door Burt Bacharach en Hal David, werd een van Dionne Warwick's meest bekende nummers en won de Grammy voor Best Contemporary Pop Vocal Performance. Hoewel het geen Motown-opname is, staat het in deze Spotify-afspeellijst naast de Motown-klassiekers.",
       "awards_nl": [

--- a/custom_components/beatify/playlists/summer-party-anthems.json
+++ b/custom_components/beatify/playlists/summer-party-anthems.json
@@ -1,6 +1,6 @@
 {
   "name": "100 Summer Anthems ☀️",
-  "version": "1.11",
+  "version": "1.12",
   "tags": [
     "party",
     "classics",
@@ -4235,7 +4235,8 @@
         "es": "applemusic://track/82347771",
         "nl": "applemusic://track/82347771",
         "it": "applemusic://track/82347771"
-      }
+      },
+      "uri_youtube_music": "https://music.youtube.com/watch?v=mTUhnIY3oRM"
     },
     {
       "year": 1966,


### PR DESCRIPTION
Ein Lauf des `provider-uri-backfill`, automatisch gefahren von `com.beatify.youtube-backfill`.

- `anime-openings` YouTube 139 -> **139**/140
- `best-of-giraffenaffen` YouTube 25 -> **26**/26
- `iconic-movie-songs` YouTube 71 -> **72**/72
- `top100-allertijden-nederlandstalig` YouTube 102 -> **104**/104
- `motown-soul-classics` YouTube 98 -> **100**/100
- `summer-party-anthems` YouTube 111 -> **112**/112

Nebenbei mitgefuellt, weil Odesli alle Provider in einer Antwort liefert: tidal +1.

**Draft mit Absicht** — Merge nur nach Markus' Freigabe.