### PR TITLE
fix(health-check): count dead region entries before declaring the playlist healthy

### DIFF
--- a/.claude/skills/playlist-health-check/scripts/run-health-check.sh
+++ b/.claude/skills/playlist-health-check/scripts/run-health-check.sh
@@ -96,9 +96,25 @@ with open(sys.argv[1], "w") as f:
     json.dump(state, f, indent=2)
 PYEOF
 
-ISSUES=$(python3 -c "import json; d=json.load(open('$OUTPUT')); s=d['summary']; print(s['dead'] + s.get('wrong_track',0) + s.get('error',0))")
+# Zaehlt Basis-URIs UND Region-Maps. Bis zum 18.08.2026 sah diese Stelle nur
+# `summary` — ein Lauf mit toten Region-Eintraegen endete deshalb auf
+# "All tracks healthy", zwei Zeilen unter der eigenen Meldung "N dead".
+# Aufgefallen an motown-soul-classics (#2194, 8 tote Regionen) und erneut an
+# 2000s-pop-anthems (#2223, 7 tote Regionen auf einem Track). Beim ersten Mal
+# wurden nur die Daten repariert, nicht die Meldung — daher der zweite Fall.
+read -r BASE_ISSUES REGION_ISSUES <<EOF
+$(python3 -c "
+import json
+d = json.load(open('$OUTPUT'))
+s = d['summary']
+r = d.get('region_summary') or {}
+print(s['dead'] + s.get('wrong_track', 0) + s.get('error', 0),
+      r.get('dead', 0) + r.get('wrong_track', 0))
+")
+EOF
+ISSUES=$((BASE_ISSUES + REGION_ISSUES))
 if [ "$ISSUES" -gt 0 ]; then
-  log "Found $ISSUES issue(s) — pending AI review before creating GitHub issue."
+  log "Found $ISSUES issue(s) — $BASE_ISSUES on base URIs, $REGION_ISSUES in region maps — pending AI review before creating GitHub issue."
 else
   log "All tracks healthy — no issues found."
 fi


### PR DESCRIPTION
The closing verdict in `run-health-check.sh` read only `summary` and never `region_summary`:

```bash
ISSUES=$(... print(s["dead"] + s.get("wrong_track",0) + s.get("error",0)))
```

So a run could print its own region line and then contradict it two lines later:

```
Region maps: 1204 ok, 7 dead, 0 wrong track, 21 unfilled / 1211 claimed — 1 track(s) affected
All tracks healthy — no issues found.
```

That is this morning's real output on `2000s-pop-anthems`.

## Twice, not once

- **2026-08-16**, `motown-soul-classics` — 8 dead region entries, #2194. Its title already said *"and the health check called the playlist healthy"*. #2195 fixed the **data**.
- **2026-08-18**, `2000s-pop-anthems` — 7 dead region entries on one track, #2223.

The second happened because the first fix stopped at the catalogue. This is the part that stops it recurring.

## Change

The verdict sums base and region defects and says where they sit:

```
Found 7 issue(s) — 0 on base URIs, 7 in region maps — pending AI review before creating GitHub issue.
```

Region `unfilled` is deliberately **not** counted. An unfilled region is a gap, not a defect — 21 of them showed up in the same run and none is wrong.

## Tested

`bash -n` clean, and the counting exercised against four inputs:

| input | verdict |
|---|---|
| today's real output (903 ok, 7 dead regions) | `Found 7 — 0 base, 7 region` |
| everything clean | `All tracks healthy` |
| base defects only (2 dead, 1 wrong track) | `Found 3 — 3 base, 0 region` |
| no `region_summary` key at all (older output) | `All tracks healthy` |

The last row matters: `.get` keeps an older output file from crashing the run.