### PR TITLE
chore(playlists): apple backfill — +68 apple, +64 deezer uris

### DIFF
--- a/custom_components/beatify/playlists/community/musica-italiana.json
+++ b/custom_components/beatify/playlists/community/musica-italiana.json
@@ -814,7 +814,9 @@
       "fun_fact_de": "Adriano Pappalardo - \"Ricominciamo\" (1979), aus dem italienischen Pop-Kanon.",
       "fun_fact_es": "Adriano Pappalardo - \"Ricominciamo\" (1979), del canon del pop italiano.",
       "fun_fact_fr": "Adriano Pappalardo - \"Ricominciamo\" (1979), du canon de la pop italienne.",
-      "fun_fact_nl": "Adriano Pappalardo - \"Ricominciamo\" (1979), uit de Italiaanse popcanon."
+      "fun_fact_nl": "Adriano Pappalardo - \"Ricominciamo\" (1979), uit de Italiaanse popcanon.",
+      "uri_apple_music": "applemusic://track/1080717875",
+      "uri_deezer": "deezer://track/1009010"
     },
     {
       "year": 1979,
@@ -829,7 +831,9 @@
       "fun_fact_de": "Alan Sorrenti - \"Tu Sei L'Unica Donna Per Me - 2005 Remaster\" (1979), aus dem italienischen Pop-Kanon.",
       "fun_fact_es": "Alan Sorrenti - \"Tu Sei L'Unica Donna Per Me - 2005 Remaster\" (1979), del canon del pop italiano.",
       "fun_fact_fr": "Alan Sorrenti - \"Tu Sei L'Unica Donna Per Me - 2005 Remaster\" (1979), du canon de la pop italienne.",
-      "fun_fact_nl": "Alan Sorrenti - \"Tu Sei L'Unica Donna Per Me - 2005 Remaster\" (1979), uit de Italiaanse popcanon."
+      "fun_fact_nl": "Alan Sorrenti - \"Tu Sei L'Unica Donna Per Me - 2005 Remaster\" (1979), uit de Italiaanse popcanon.",
+      "uri_apple_music": "applemusic://track/1637161394",
+      "uri_deezer": "deezer://track/3370893"
     },
     {
       "year": 1979,
@@ -844,7 +848,9 @@
       "fun_fact_de": "Umberto Tozzi - \"Gloria\" (1979), aus dem italienischen Pop-Kanon. Erschien auf dem Album Gloria. Veroeffentlicht bei CGD nel 1979 nel singolo Gloria/Aria.",
       "fun_fact_es": "Umberto Tozzi - \"Gloria\" (1979), del canon del pop italiano. Aparecio en el album Gloria. Publicada por CGD nel 1979 nel singolo Gloria/Aria.",
       "fun_fact_fr": "Umberto Tozzi - \"Gloria\" (1979), du canon de la pop italienne. Parue sur l album Gloria. Publiee chez CGD nel 1979 nel singolo Gloria/Aria.",
-      "fun_fact_nl": "Umberto Tozzi - \"Gloria\" (1979), uit de Italiaanse popcanon. Verscheen op het album Gloria. Uitgebracht bij CGD nel 1979 nel singolo Gloria/Aria."
+      "fun_fact_nl": "Umberto Tozzi - \"Gloria\" (1979), uit de Italiaanse popcanon. Verscheen op het album Gloria. Uitgebracht bij CGD nel 1979 nel singolo Gloria/Aria.",
+      "uri_apple_music": "applemusic://track/1567867714",
+      "uri_deezer": "deezer://track/84718345"
     },
     {
       "year": 1979,
@@ -859,7 +865,9 @@
       "fun_fact_de": "Umberto Tozzi - \"Stella stai\" (1979), aus dem italienischen Pop-Kanon. Spaeter im Film Spider-Man: Far from Home del 2019 verwendet. Erschien auf dem Album Tozzi.",
       "fun_fact_es": "Umberto Tozzi - \"Stella stai\" (1979), del canon del pop italiano. Usada despues en la pelicula Spider-Man: Far from Home del 2019. Aparecio en el album Tozzi.",
       "fun_fact_fr": "Umberto Tozzi - \"Stella stai\" (1979), du canon de la pop italienne. Reprise ensuite dans le film Spider-Man: Far from Home del 2019. Parue sur l album Tozzi.",
-      "fun_fact_nl": "Umberto Tozzi - \"Stella stai\" (1979), uit de Italiaanse popcanon. Later gebruikt in de film Spider-Man: Far from Home del 2019. Verscheen op het album Tozzi."
+      "fun_fact_nl": "Umberto Tozzi - \"Stella stai\" (1979), uit de Italiaanse popcanon. Later gebruikt in de film Spider-Man: Far from Home del 2019. Verscheen op het album Tozzi.",
+      "uri_apple_music": "applemusic://track/672547109",
+      "uri_deezer": "deezer://track/69028148"
     },
     {
       "year": 1979,
@@ -874,7 +882,9 @@
       "fun_fact_de": "Vasco Rossi - \"Albachiara - Remastered 2019\" (1979), aus dem italienischen Pop-Kanon.",
       "fun_fact_es": "Vasco Rossi - \"Albachiara - Remastered 2019\" (1979), del canon del pop italiano.",
       "fun_fact_fr": "Vasco Rossi - \"Albachiara - Remastered 2019\" (1979), du canon de la pop italienne.",
-      "fun_fact_nl": "Vasco Rossi - \"Albachiara - Remastered 2019\" (1979), uit de Italiaanse popcanon."
+      "fun_fact_nl": "Vasco Rossi - \"Albachiara - Remastered 2019\" (1979), uit de Italiaanse popcanon.",
+      "uri_apple_music": "applemusic://track/1479885373",
+      "uri_deezer": "deezer://track/753892132"
     },
     {
       "year": 1979,
@@ -889,7 +899,9 @@
       "fun_fact_de": "Viola Valentino - \"Comprami\" (1979), aus dem italienischen Pop-Kanon.",
       "fun_fact_es": "Viola Valentino - \"Comprami\" (1979), del canon del pop italiano.",
       "fun_fact_fr": "Viola Valentino - \"Comprami\" (1979), du canon de la pop italienne.",
-      "fun_fact_nl": "Viola Valentino - \"Comprami\" (1979), uit de Italiaanse popcanon."
+      "fun_fact_nl": "Viola Valentino - \"Comprami\" (1979), uit de Italiaanse popcanon.",
+      "uri_apple_music": "applemusic://track/1566314670",
+      "uri_deezer": "deezer://track/1365061732"
     },
     {
       "year": 1980,
@@ -904,7 +916,9 @@
       "fun_fact_de": "Edoardo Bennato - \"L'isola che non c'è\" (1980), aus dem italienischen Pop-Kanon.",
       "fun_fact_es": "Edoardo Bennato - \"L'isola che non c'è\" (1980), del canon del pop italiano.",
       "fun_fact_fr": "Edoardo Bennato - \"L'isola che non c'è\" (1980), du canon de la pop italienne.",
-      "fun_fact_nl": "Edoardo Bennato - \"L'isola che non c'è\" (1980), uit de Italiaanse popcanon."
+      "fun_fact_nl": "Edoardo Bennato - \"L'isola che non c'è\" (1980), uit de Italiaanse popcanon.",
+      "uri_apple_music": "applemusic://track/254250128",
+      "uri_deezer": "deezer://track/563594"
     },
     {
       "year": 1980,
@@ -919,7 +933,9 @@
       "fun_fact_de": "Gianni Togni - \"Luna - Remastered\" (1980), aus dem italienischen Pop-Kanon.",
       "fun_fact_es": "Gianni Togni - \"Luna - Remastered\" (1980), del canon del pop italiano.",
       "fun_fact_fr": "Gianni Togni - \"Luna - Remastered\" (1980), du canon de la pop italienne.",
-      "fun_fact_nl": "Gianni Togni - \"Luna - Remastered\" (1980), uit de Italiaanse popcanon."
+      "fun_fact_nl": "Gianni Togni - \"Luna - Remastered\" (1980), uit de Italiaanse popcanon.",
+      "uri_apple_music": "applemusic://track/802854272",
+      "uri_deezer": "deezer://track/74398004"
     },
     {
       "year": 1980,
@@ -934,7 +950,9 @@
       "fun_fact_de": "Gianni Togni - \"Luna\" (1980), aus dem italienischen Pop-Kanon. Veroeffentlicht bei Durium.",
       "fun_fact_es": "Gianni Togni - \"Luna\" (1980), del canon del pop italiano. Publicada por Durium.",
       "fun_fact_fr": "Gianni Togni - \"Luna\" (1980), du canon de la pop italienne. Publiee chez Durium.",
-      "fun_fact_nl": "Gianni Togni - \"Luna\" (1980), uit de Italiaanse popcanon. Uitgebracht bij Durium."
+      "fun_fact_nl": "Gianni Togni - \"Luna\" (1980), uit de Italiaanse popcanon. Uitgebracht bij Durium.",
+      "uri_apple_music": "applemusic://track/40638155",
+      "uri_deezer": "deezer://track/783591"
     },
     {
       "year": 1980,
@@ -949,7 +967,9 @@
       "fun_fact_de": "Lucio Battisti - \"Con il nastro rosa\" (1980), aus dem italienischen Pop-Kanon.",
       "fun_fact_es": "Lucio Battisti - \"Con il nastro rosa\" (1980), del canon del pop italiano.",
       "fun_fact_fr": "Lucio Battisti - \"Con il nastro rosa\" (1980), du canon de la pop italienne.",
-      "fun_fact_nl": "Lucio Battisti - \"Con il nastro rosa\" (1980), uit de Italiaanse popcanon."
+      "fun_fact_nl": "Lucio Battisti - \"Con il nastro rosa\" (1980), uit de Italiaanse popcanon.",
+      "uri_apple_music": "applemusic://track/1480764203",
+      "uri_deezer": "deezer://track/764164492"
     },
     {
       "year": 1980,
@@ -964,7 +984,9 @@
       "fun_fact_de": "Raffaella Carrà - \"Pedro\" (1980), aus dem italienischen Pop-Kanon.",
       "fun_fact_es": "Raffaella Carrà - \"Pedro\" (1980), del canon del pop italiano.",
       "fun_fact_fr": "Raffaella Carrà - \"Pedro\" (1980), du canon de la pop italienne.",
-      "fun_fact_nl": "Raffaella Carrà - \"Pedro\" (1980), uit de Italiaanse popcanon."
+      "fun_fact_nl": "Raffaella Carrà - \"Pedro\" (1980), uit de Italiaanse popcanon.",
+      "uri_apple_music": "applemusic://track/1692974548",
+      "uri_deezer": "deezer://track/15255911"
     },
     {
       "year": 1980,
@@ -979,7 +1001,9 @@
       "fun_fact_de": "Vasco Rossi - \"Non l'hai mica capito - Remastered 2020\" (1980), aus dem italienischen Pop-Kanon. Veroeffentlicht bei Targa come unici estratti dall'album.",
       "fun_fact_es": "Vasco Rossi - \"Non l'hai mica capito - Remastered 2020\" (1980), del canon del pop italiano. Publicada por Targa come unici estratti dall'album.",
       "fun_fact_fr": "Vasco Rossi - \"Non l'hai mica capito - Remastered 2020\" (1980), du canon de la pop italienne. Publiee chez Targa come unici estratti dall'album.",
-      "fun_fact_nl": "Vasco Rossi - \"Non l'hai mica capito - Remastered 2020\" (1980), uit de Italiaanse popcanon. Uitgebracht bij Targa come unici estratti dall'album."
+      "fun_fact_nl": "Vasco Rossi - \"Non l'hai mica capito - Remastered 2020\" (1980), uit de Italiaanse popcanon. Uitgebracht bij Targa come unici estratti dall'album.",
+      "uri_apple_music": "applemusic://track/1539965277",
+      "uri_deezer": "deezer://track/1139477612"
     },
     {
       "year": 1981,
@@ -994,7 +1018,9 @@
       "fun_fact_de": "Claudio Baglioni - \"Strada facendo\" (1981), aus dem italienischen Pop-Kanon.",
       "fun_fact_es": "Claudio Baglioni - \"Strada facendo\" (1981), del canon del pop italiano.",
       "fun_fact_fr": "Claudio Baglioni - \"Strada facendo\" (1981), du canon de la pop italienne.",
-      "fun_fact_nl": "Claudio Baglioni - \"Strada facendo\" (1981), uit de Italiaanse popcanon."
+      "fun_fact_nl": "Claudio Baglioni - \"Strada facendo\" (1981), uit de Italiaanse popcanon.",
+      "uri_apple_music": "applemusic://track/580231736",
+      "uri_deezer": "deezer://track/576311"
     },
     {
       "year": 1981,
@@ -1009,7 +1035,9 @@
       "fun_fact_de": "Claudio Baglioni - \"Via\" (1981), aus dem italienischen Pop-Kanon. Erschien auf dem Album Strada facendo.",
       "fun_fact_es": "Claudio Baglioni - \"Via\" (1981), del canon del pop italiano. Aparecio en el album Strada facendo.",
       "fun_fact_fr": "Claudio Baglioni - \"Via\" (1981), du canon de la pop italienne. Parue sur l album Strada facendo.",
-      "fun_fact_nl": "Claudio Baglioni - \"Via\" (1981), uit de Italiaanse popcanon. Verscheen op het album Strada facendo."
+      "fun_fact_nl": "Claudio Baglioni - \"Via\" (1981), uit de Italiaanse popcanon. Verscheen op het album Strada facendo.",
+      "uri_apple_music": "applemusic://track/1344888781",
+      "uri_deezer": "deezer://track/461326012"
     },
     {
       "year": 1981,
@@ -1024,7 +1052,9 @@
       "fun_fact_de": "Eduardo De Crescenzo - \"Ancora\" (1981), aus dem italienischen Pop-Kanon. Beim Sanremo-Festival vorgestellt.",
       "fun_fact_es": "Eduardo De Crescenzo - \"Ancora\" (1981), del canon del pop italiano. Presentada en el Festival de Sanremo.",
       "fun_fact_fr": "Eduardo De Crescenzo - \"Ancora\" (1981), du canon de la pop italienne. Presentee au Festival de Sanremo.",
-      "fun_fact_nl": "Eduardo De Crescenzo - \"Ancora\" (1981), uit de Italiaanse popcanon. Gepresenteerd op het Sanremo-festival."
+      "fun_fact_nl": "Eduardo De Crescenzo - \"Ancora\" (1981), uit de Italiaanse popcanon. Gepresenteerd op het Sanremo-festival.",
+      "uri_apple_music": "applemusic://track/471571745",
+      "uri_deezer": "deezer://track/1020054"
     },
     {
       "year": 1981,
@@ -1039,7 +1069,9 @@
       "fun_fact_de": "Franco Battiato - \"Centro Di Gravità Permanente - Remastered 2021\" (1981), aus dem italienischen Pop-Kanon. Geschrieben von Franco Battiato e Giusto Pio.",
       "fun_fact_es": "Franco Battiato - \"Centro Di Gravità Permanente - Remastered 2021\" (1981), del canon del pop italiano. Escrita por Franco Battiato e Giusto Pio.",
       "fun_fact_fr": "Franco Battiato - \"Centro Di Gravità Permanente - Remastered 2021\" (1981), du canon de la pop italienne. Ecrite par Franco Battiato e Giusto Pio.",
-      "fun_fact_nl": "Franco Battiato - \"Centro Di Gravità Permanente - Remastered 2021\" (1981), uit de Italiaanse popcanon. Geschreven door Franco Battiato e Giusto Pio."
+      "fun_fact_nl": "Franco Battiato - \"Centro Di Gravità Permanente - Remastered 2021\" (1981), uit de Italiaanse popcanon. Geschreven door Franco Battiato e Giusto Pio.",
+      "uri_apple_music": "applemusic://track/1568083647",
+      "uri_deezer": "deezer://track/1375685872"
     },
     {
       "year": 1981,
@@ -1054,7 +1086,9 @@
       "fun_fact_de": "Franco Battiato - \"Cuccurucucù - Mix 2015\" (1981), aus dem italienischen Pop-Kanon.",
       "fun_fact_es": "Franco Battiato - \"Cuccurucucù - Mix 2015\" (1981), del canon del pop italiano.",
       "fun_fact_fr": "Franco Battiato - \"Cuccurucucù - Mix 2015\" (1981), du canon de la pop italienne.",
-      "fun_fact_nl": "Franco Battiato - \"Cuccurucucù - Mix 2015\" (1981), uit de Italiaanse popcanon."
+      "fun_fact_nl": "Franco Battiato - \"Cuccurucucù - Mix 2015\" (1981), uit de Italiaanse popcanon.",
+      "uri_apple_music": "applemusic://track/1440850093",
+      "uri_deezer": "deezer://track/112658532"
     },
     {
       "year": 1981,
@@ -1069,7 +1103,9 @@
       "fun_fact_de": "Franco Battiato - \"Cuccurucucù - Remastered\" (1981), aus dem italienischen Pop-Kanon.",
       "fun_fact_es": "Franco Battiato - \"Cuccurucucù - Remastered\" (1981), del canon del pop italiano.",
       "fun_fact_fr": "Franco Battiato - \"Cuccurucucù - Remastered\" (1981), du canon de la pop italienne.",
-      "fun_fact_nl": "Franco Battiato - \"Cuccurucucù - Remastered\" (1981), uit de Italiaanse popcanon."
+      "fun_fact_nl": "Franco Battiato - \"Cuccurucucù - Remastered\" (1981), uit de Italiaanse popcanon.",
+      "uri_apple_music": "applemusic://track/1568083642",
+      "uri_deezer": "deezer://track/1375685852"
     },
     {
       "year": 1981,
@@ -1084,7 +1120,9 @@
       "fun_fact_de": "Loretta Goggi - \"Maledetta primavera\" (1981), aus dem italienischen Pop-Kanon. Geschrieben von Amerigo Cassella. Beim Sanremo-Festival vorgestellt. Erschien auf dem Album Il mio prossimo amore.",
       "fun_fact_es": "Loretta Goggi - \"Maledetta primavera\" (1981), del canon del pop italiano. Escrita por Amerigo Cassella. Presentada en el Festival de Sanremo. Aparecio en el album Il mio prossimo amore.",
       "fun_fact_fr": "Loretta Goggi - \"Maledetta primavera\" (1981), du canon de la pop italienne. Ecrite par Amerigo Cassella. Presentee au Festival de Sanremo. Parue sur l album Il mio prossimo amore.",
-      "fun_fact_nl": "Loretta Goggi - \"Maledetta primavera\" (1981), uit de Italiaanse popcanon. Geschreven door Amerigo Cassella. Gepresenteerd op het Sanremo-festival. Verscheen op het album Il mio prossimo amore."
+      "fun_fact_nl": "Loretta Goggi - \"Maledetta primavera\" (1981), uit de Italiaanse popcanon. Geschreven door Amerigo Cassella. Gepresenteerd op het Sanremo-festival. Verscheen op het album Il mio prossimo amore.",
+      "uri_apple_music": "applemusic://track/698668560",
+      "uri_deezer": "deezer://track/4090061"
     },
     {
       "year": 1981,
@@ -1099,7 +1137,9 @@
       "fun_fact_de": "Marcella Bella - \"Canto Straniero\" (1981), aus dem italienischen Pop-Kanon.",
       "fun_fact_es": "Marcella Bella - \"Canto Straniero\" (1981), del canon del pop italiano.",
       "fun_fact_fr": "Marcella Bella - \"Canto Straniero\" (1981), du canon de la pop italienne.",
-      "fun_fact_nl": "Marcella Bella - \"Canto Straniero\" (1981), uit de Italiaanse popcanon."
+      "fun_fact_nl": "Marcella Bella - \"Canto Straniero\" (1981), uit de Italiaanse popcanon.",
+      "uri_apple_music": "applemusic://track/311418744",
+      "uri_deezer": "deezer://track/3939671"
     },
     {
       "year": 1981,
@@ -1114,7 +1154,9 @@
       "fun_fact_de": "Pooh - \"Chi fermerà la musica\" (1981), aus dem italienischen Pop-Kanon.",
       "fun_fact_es": "Pooh - \"Chi fermerà la musica\" (1981), del canon del pop italiano.",
       "fun_fact_fr": "Pooh - \"Chi fermerà la musica\" (1981), du canon de la pop italienne.",
-      "fun_fact_nl": "Pooh - \"Chi fermerà la musica\" (1981), uit de Italiaanse popcanon."
+      "fun_fact_nl": "Pooh - \"Chi fermerà la musica\" (1981), uit de Italiaanse popcanon.",
+      "uri_apple_music": "applemusic://track/953251717",
+      "uri_deezer": "deezer://track/124637076"
     },
     {
       "year": 1981,
@@ -1129,7 +1171,9 @@
       "fun_fact_de": "Ricchi E Poveri - \"Come vorrei\" (1981), aus dem italienischen Pop-Kanon.",
       "fun_fact_es": "Ricchi E Poveri - \"Come vorrei\" (1981), del canon del pop italiano.",
       "fun_fact_fr": "Ricchi E Poveri - \"Come vorrei\" (1981), du canon de la pop italienne.",
-      "fun_fact_nl": "Ricchi E Poveri - \"Come vorrei\" (1981), uit de Italiaanse popcanon."
+      "fun_fact_nl": "Ricchi E Poveri - \"Come vorrei\" (1981), uit de Italiaanse popcanon.",
+      "uri_apple_music": "applemusic://track/285797622",
+      "uri_deezer": "deezer://track/636412"
     },
     {
       "year": 1982,
@@ -1144,7 +1188,9 @@
       "fun_fact_de": "Al Bano - \"Felicità\" (1982), aus dem italienischen Pop-Kanon.",
       "fun_fact_es": "Al Bano - \"Felicità\" (1982), del canon del pop italiano.",
       "fun_fact_fr": "Al Bano - \"Felicità\" (1982), du canon de la pop italienne.",
-      "fun_fact_nl": "Al Bano - \"Felicità\" (1982), uit de Italiaanse popcanon."
+      "fun_fact_nl": "Al Bano - \"Felicità\" (1982), uit de Italiaanse popcanon.",
+      "uri_apple_music": "applemusic://track/298583321",
+      "uri_deezer": "deezer://track/4033476791"
     },
     {
       "year": 1982,
@@ -1159,7 +1205,8 @@
       "fun_fact_de": "Claudia Mori, Adriano Celentano - \"Non Succederà Più - Remastered 2009\" (1982), aus dem italienischen Pop-Kanon.",
       "fun_fact_es": "Claudia Mori, Adriano Celentano - \"Non Succederà Più - Remastered 2009\" (1982), del canon del pop italiano.",
       "fun_fact_fr": "Claudia Mori, Adriano Celentano - \"Non Succederà Più - Remastered 2009\" (1982), du canon de la pop italienne.",
-      "fun_fact_nl": "Claudia Mori, Adriano Celentano - \"Non Succederà Più - Remastered 2009\" (1982), uit de Italiaanse popcanon."
+      "fun_fact_nl": "Claudia Mori, Adriano Celentano - \"Non Succederà Più - Remastered 2009\" (1982), uit de Italiaanse popcanon.",
+      "uri_apple_music": "applemusic://track/1784627055"
     },
     {
       "year": 1982,
@@ -1174,7 +1221,9 @@
       "fun_fact_de": "Claudio Baglioni - \"Avrai\" (1982), aus dem italienischen Pop-Kanon.",
       "fun_fact_es": "Claudio Baglioni - \"Avrai\" (1982), del canon del pop italiano.",
       "fun_fact_fr": "Claudio Baglioni - \"Avrai\" (1982), du canon de la pop italienne.",
-      "fun_fact_nl": "Claudio Baglioni - \"Avrai\" (1982), uit de Italiaanse popcanon."
+      "fun_fact_nl": "Claudio Baglioni - \"Avrai\" (1982), uit de Italiaanse popcanon.",
+      "uri_apple_music": "applemusic://track/1344888786",
+      "uri_deezer": "deezer://track/461326062"
     },
     {
       "year": 1982,
@@ -1189,7 +1238,9 @@
       "fun_fact_de": "Franco Battiato - \"Voglio Vederti Danzare - Remastered\" (1982), aus dem italienischen Pop-Kanon.",
       "fun_fact_es": "Franco Battiato - \"Voglio Vederti Danzare - Remastered\" (1982), del canon del pop italiano.",
       "fun_fact_fr": "Franco Battiato - \"Voglio Vederti Danzare - Remastered\" (1982), du canon de la pop italienne.",
-      "fun_fact_nl": "Franco Battiato - \"Voglio Vederti Danzare - Remastered\" (1982), uit de Italiaanse popcanon."
+      "fun_fact_nl": "Franco Battiato - \"Voglio Vederti Danzare - Remastered\" (1982), uit de Italiaanse popcanon.",
+      "uri_apple_music": "applemusic://track/713520078",
+      "uri_deezer": "deezer://track/3464233"
     },
     {
       "year": 1982,
@@ -1204,7 +1255,9 @@
       "fun_fact_de": "Loredana Bertè - \"Non sono una signora\" (1982), aus dem italienischen Pop-Kanon.",
       "fun_fact_es": "Loredana Bertè - \"Non sono una signora\" (1982), del canon del pop italiano.",
       "fun_fact_fr": "Loredana Bertè - \"Non sono una signora\" (1982), du canon de la pop italienne.",
-      "fun_fact_nl": "Loredana Bertè - \"Non sono una signora\" (1982), uit de Italiaanse popcanon."
+      "fun_fact_nl": "Loredana Bertè - \"Non sono una signora\" (1982), uit de Italiaanse popcanon.",
+      "uri_apple_music": "applemusic://track/79323055",
+      "uri_deezer": "deezer://track/742432"
     },
     {
       "year": 1982,
@@ -1219,7 +1272,9 @@
       "fun_fact_de": "Loretta Goggi - \"Pieno d'amore\" (1982), aus dem italienischen Pop-Kanon.",
       "fun_fact_es": "Loretta Goggi - \"Pieno d'amore\" (1982), del canon del pop italiano.",
       "fun_fact_fr": "Loretta Goggi - \"Pieno d'amore\" (1982), du canon de la pop italienne.",
-      "fun_fact_nl": "Loretta Goggi - \"Pieno d'amore\" (1982), uit de Italiaanse popcanon."
+      "fun_fact_nl": "Loretta Goggi - \"Pieno d'amore\" (1982), uit de Italiaanse popcanon.",
+      "uri_apple_music": "applemusic://track/698668554",
+      "uri_deezer": "deezer://track/70331701"
     },
     {
       "year": 1982,
@@ -1234,7 +1289,9 @@
       "fun_fact_de": "Mia Martini - \"E non finisce mica il cielo\" (1982), aus dem italienischen Pop-Kanon. Veroeffentlicht bei DDD nel 1982.",
       "fun_fact_es": "Mia Martini - \"E non finisce mica il cielo\" (1982), del canon del pop italiano. Publicada por DDD nel 1982.",
       "fun_fact_fr": "Mia Martini - \"E non finisce mica il cielo\" (1982), du canon de la pop italienne. Publiee chez DDD nel 1982.",
-      "fun_fact_nl": "Mia Martini - \"E non finisce mica il cielo\" (1982), uit de Italiaanse popcanon. Uitgebracht bij DDD nel 1982."
+      "fun_fact_nl": "Mia Martini - \"E non finisce mica il cielo\" (1982), uit de Italiaanse popcanon. Uitgebracht bij DDD nel 1982.",
+      "uri_apple_music": "applemusic://track/408273025",
+      "uri_deezer": "deezer://track/3803029202"
     },
     {
       "year": 1982,
@@ -1249,7 +1306,9 @@
       "fun_fact_de": "Raffaella Carrà - \"Ballo, ballo\" (1982), aus dem italienischen Pop-Kanon.",
       "fun_fact_es": "Raffaella Carrà - \"Ballo, ballo\" (1982), del canon del pop italiano.",
       "fun_fact_fr": "Raffaella Carrà - \"Ballo, ballo\" (1982), du canon de la pop italienne.",
-      "fun_fact_nl": "Raffaella Carrà - \"Ballo, ballo\" (1982), uit de Italiaanse popcanon."
+      "fun_fact_nl": "Raffaella Carrà - \"Ballo, ballo\" (1982), uit de Italiaanse popcanon.",
+      "uri_apple_music": "applemusic://track/1692975052",
+      "uri_deezer": "deezer://track/2842211102"
     },
     {
       "year": 1982,
@@ -1264,7 +1323,9 @@
       "fun_fact_de": "Riccardo Cocciante - \"Celeste nostalgia\" (1982), aus dem italienischen Pop-Kanon.",
       "fun_fact_es": "Riccardo Cocciante - \"Celeste nostalgia\" (1982), del canon del pop italiano.",
       "fun_fact_fr": "Riccardo Cocciante - \"Celeste nostalgia\" (1982), du canon de la pop italienne.",
-      "fun_fact_nl": "Riccardo Cocciante - \"Celeste nostalgia\" (1982), uit de Italiaanse popcanon."
+      "fun_fact_nl": "Riccardo Cocciante - \"Celeste nostalgia\" (1982), uit de Italiaanse popcanon.",
+      "uri_apple_music": "applemusic://track/254296736",
+      "uri_deezer": "deezer://track/13230004"
     },
     {
       "year": 1982,
@@ -1279,7 +1340,9 @@
       "fun_fact_de": "Riccardo Fogli - \"Storie di tutti i giorni\" (1982), aus dem italienischen Pop-Kanon.",
       "fun_fact_es": "Riccardo Fogli - \"Storie di tutti i giorni\" (1982), del canon del pop italiano.",
       "fun_fact_fr": "Riccardo Fogli - \"Storie di tutti i giorni\" (1982), du canon de la pop italienne.",
-      "fun_fact_nl": "Riccardo Fogli - \"Storie di tutti i giorni\" (1982), uit de Italiaanse popcanon."
+      "fun_fact_nl": "Riccardo Fogli - \"Storie di tutti i giorni\" (1982), uit de Italiaanse popcanon.",
+      "uri_apple_music": "applemusic://track/1453582477",
+      "uri_deezer": "deezer://track/755986"
     },
     {
       "year": 1982,
@@ -1294,7 +1357,9 @@
       "fun_fact_de": "Ricchi E Poveri - \"Mamma Maria\" (1982), aus dem italienischen Pop-Kanon.",
       "fun_fact_es": "Ricchi E Poveri - \"Mamma Maria\" (1982), del canon del pop italiano.",
       "fun_fact_fr": "Ricchi E Poveri - \"Mamma Maria\" (1982), du canon de la pop italienne.",
-      "fun_fact_nl": "Ricchi E Poveri - \"Mamma Maria\" (1982), uit de Italiaanse popcanon."
+      "fun_fact_nl": "Ricchi E Poveri - \"Mamma Maria\" (1982), uit de Italiaanse popcanon.",
+      "uri_apple_music": "applemusic://track/252058369",
+      "uri_deezer": "deezer://track/636403"
     },
     {
       "year": 1982,
@@ -1309,7 +1374,9 @@
       "fun_fact_de": "Vasco Rossi - \"Ogni volta\" (1982), aus dem italienischen Pop-Kanon.",
       "fun_fact_es": "Vasco Rossi - \"Ogni volta\" (1982), del canon del pop italiano.",
       "fun_fact_fr": "Vasco Rossi - \"Ogni volta\" (1982), du canon de la pop italienne.",
-      "fun_fact_nl": "Vasco Rossi - \"Ogni volta\" (1982), uit de Italiaanse popcanon."
+      "fun_fact_nl": "Vasco Rossi - \"Ogni volta\" (1982), uit de Italiaanse popcanon.",
+      "uri_apple_music": "applemusic://track/1327847262",
+      "uri_deezer": "deezer://track/104725328"
     },
     {
       "year": 1983,
@@ -1324,7 +1391,9 @@
       "fun_fact_de": "Fiordaliso - \"Non voglio mica la luna\" (1983), aus dem italienischen Pop-Kanon. Veroeffentlicht bei Durium nel 1984.",
       "fun_fact_es": "Fiordaliso - \"Non voglio mica la luna\" (1983), del canon del pop italiano. Publicada por Durium nel 1984.",
       "fun_fact_fr": "Fiordaliso - \"Non voglio mica la luna\" (1983), du canon de la pop italienne. Publiee chez Durium nel 1984.",
-      "fun_fact_nl": "Fiordaliso - \"Non voglio mica la luna\" (1983), uit de Italiaanse popcanon. Uitgebracht bij Durium nel 1984."
+      "fun_fact_nl": "Fiordaliso - \"Non voglio mica la luna\" (1983), uit de Italiaanse popcanon. Uitgebracht bij Durium nel 1984.",
+      "uri_apple_music": "applemusic://track/255738823",
+      "uri_deezer": "deezer://track/1017423"
     },
     {
       "year": 1983,
@@ -1339,7 +1408,9 @@
       "fun_fact_de": "Franco Battiato - \"La Stagione Dell'Amore - Remastered 2008\" (1983), aus dem italienischen Pop-Kanon.",
       "fun_fact_es": "Franco Battiato - \"La Stagione Dell'Amore - Remastered 2008\" (1983), del canon del pop italiano.",
       "fun_fact_fr": "Franco Battiato - \"La Stagione Dell'Amore - Remastered 2008\" (1983), du canon de la pop italienne.",
-      "fun_fact_nl": "Franco Battiato - \"La Stagione Dell'Amore - Remastered 2008\" (1983), uit de Italiaanse popcanon."
+      "fun_fact_nl": "Franco Battiato - \"La Stagione Dell'Amore - Remastered 2008\" (1983), uit de Italiaanse popcanon.",
+      "uri_apple_music": "applemusic://track/1606898557",
+      "uri_deezer": "deezer://track/3464234"
     },
     {
       "year": 1983,
@@ -1354,7 +1425,9 @@
       "fun_fact_de": "Loredana Bertè - \"Il mare d'inverno\" (1983), aus dem italienischen Pop-Kanon.",
       "fun_fact_es": "Loredana Bertè - \"Il mare d'inverno\" (1983), del canon del pop italiano.",
       "fun_fact_fr": "Loredana Bertè - \"Il mare d'inverno\" (1983), du canon de la pop italienne.",
-      "fun_fact_nl": "Loredana Bertè - \"Il mare d'inverno\" (1983), uit de Italiaanse popcanon."
+      "fun_fact_nl": "Loredana Bertè - \"Il mare d'inverno\" (1983), uit de Italiaanse popcanon.",
+      "uri_apple_music": "applemusic://track/671755909",
+      "uri_deezer": "deezer://track/62912666"
     },
     {
       "year": 1983,
@@ -1369,7 +1442,9 @@
       "fun_fact_de": "Lu Colombo - \"Maracaibo\" (1983), aus dem italienischen Pop-Kanon.",
       "fun_fact_es": "Lu Colombo - \"Maracaibo\" (1983), del canon del pop italiano.",
       "fun_fact_fr": "Lu Colombo - \"Maracaibo\" (1983), du canon de la pop italienne.",
-      "fun_fact_nl": "Lu Colombo - \"Maracaibo\" (1983), uit de Italiaanse popcanon."
+      "fun_fact_nl": "Lu Colombo - \"Maracaibo\" (1983), uit de Italiaanse popcanon.",
+      "uri_apple_music": "applemusic://track/405021856",
+      "uri_deezer": "deezer://track/3541677"
     },
     {
       "year": 1983,
@@ -1384,7 +1459,9 @@
       "fun_fact_de": "Nada - \"Amore Disperato - 2004 Remaster\" (1983), aus dem italienischen Pop-Kanon.",
       "fun_fact_es": "Nada - \"Amore Disperato - 2004 Remaster\" (1983), del canon del pop italiano.",
       "fun_fact_fr": "Nada - \"Amore Disperato - 2004 Remaster\" (1983), du canon de la pop italienne.",
-      "fun_fact_nl": "Nada - \"Amore Disperato - 2004 Remaster\" (1983), uit de Italiaanse popcanon."
+      "fun_fact_nl": "Nada - \"Amore Disperato - 2004 Remaster\" (1983), uit de Italiaanse popcanon.",
+      "uri_apple_music": "applemusic://track/1647071573",
+      "uri_deezer": "deezer://track/3327907"
     },
     {
       "year": 1983,
@@ -1399,7 +1476,9 @@
       "fun_fact_de": "Toto Cutugno - \"Solo noi\" (1983), aus dem italienischen Pop-Kanon. Beim Sanremo-Festival vorgestellt.",
       "fun_fact_es": "Toto Cutugno - \"Solo noi\" (1983), del canon del pop italiano. Presentada en el Festival de Sanremo.",
       "fun_fact_fr": "Toto Cutugno - \"Solo noi\" (1983), du canon de la pop italienne. Presentee au Festival de Sanremo.",
-      "fun_fact_nl": "Toto Cutugno - \"Solo noi\" (1983), uit de Italiaanse popcanon. Gepresenteerd op het Sanremo-festival."
+      "fun_fact_nl": "Toto Cutugno - \"Solo noi\" (1983), uit de Italiaanse popcanon. Gepresenteerd op het Sanremo-festival.",
+      "uri_apple_music": "applemusic://track/1329256168",
+      "uri_deezer": "deezer://track/104724380"
     },
     {
       "year": 1984,
@@ -1414,7 +1493,9 @@
       "fun_fact_de": "Eros Ramazzotti - \"Adesso tu\" (1984), aus dem italienischen Pop-Kanon. Beim Sanremo-Festival vorgestellt.",
       "fun_fact_es": "Eros Ramazzotti - \"Adesso tu\" (1984), del canon del pop italiano. Presentada en el Festival de Sanremo.",
       "fun_fact_fr": "Eros Ramazzotti - \"Adesso tu\" (1984), du canon de la pop italienne. Presentee au Festival de Sanremo.",
-      "fun_fact_nl": "Eros Ramazzotti - \"Adesso tu\" (1984), uit de Italiaanse popcanon. Gepresenteerd op het Sanremo-festival."
+      "fun_fact_nl": "Eros Ramazzotti - \"Adesso tu\" (1984), uit de Italiaanse popcanon. Gepresenteerd op het Sanremo-festival.",
+      "uri_apple_music": "applemusic://track/254548552",
+      "uri_deezer": "deezer://track/87677323"
     },
     {
       "year": 1984,
@@ -1429,7 +1510,9 @@
       "fun_fact_de": "Gianni Togni - \"Giulia\" (1984), aus dem italienischen Pop-Kanon.",
       "fun_fact_es": "Gianni Togni - \"Giulia\" (1984), del canon del pop italiano.",
       "fun_fact_fr": "Gianni Togni - \"Giulia\" (1984), du canon de la pop italienne.",
-      "fun_fact_nl": "Gianni Togni - \"Giulia\" (1984), uit de Italiaanse popcanon."
+      "fun_fact_nl": "Gianni Togni - \"Giulia\" (1984), uit de Italiaanse popcanon.",
+      "uri_apple_music": "applemusic://track/79354753",
+      "uri_deezer": "deezer://track/818877"
     },
     {
       "year": 1985,
@@ -1444,7 +1527,9 @@
       "fun_fact_de": "Gianni Morandi - \"Uno su mille\" (1985), aus dem italienischen Pop-Kanon. Veroeffentlicht bei RCA Italiana.",
       "fun_fact_es": "Gianni Morandi - \"Uno su mille\" (1985), del canon del pop italiano. Publicada por RCA Italiana.",
       "fun_fact_fr": "Gianni Morandi - \"Uno su mille\" (1985), du canon de la pop italienne. Publiee chez RCA Italiana.",
-      "fun_fact_nl": "Gianni Morandi - \"Uno su mille\" (1985), uit de Italiaanse popcanon. Uitgebracht bij RCA Italiana."
+      "fun_fact_nl": "Gianni Morandi - \"Uno su mille\" (1985), uit de Italiaanse popcanon. Uitgebracht bij RCA Italiana.",
+      "uri_apple_music": "applemusic://track/796510429",
+      "uri_deezer": "deezer://track/74189254"
     },
     {
       "year": 1985,
@@ -1459,7 +1544,9 @@
       "fun_fact_de": "Vasco Rossi - \"T'immagini\" (1985), aus dem italienischen Pop-Kanon. Erschien auf dem Album del 1985 Cosa succede in città.",
       "fun_fact_es": "Vasco Rossi - \"T'immagini\" (1985), del canon del pop italiano. Aparecio en el album del 1985 Cosa succede in città.",
       "fun_fact_fr": "Vasco Rossi - \"T'immagini\" (1985), du canon de la pop italienne. Parue sur l album del 1985 Cosa succede in città.",
-      "fun_fact_nl": "Vasco Rossi - \"T'immagini\" (1985), uit de Italiaanse popcanon. Verscheen op het album del 1985 Cosa succede in città."
+      "fun_fact_nl": "Vasco Rossi - \"T'immagini\" (1985), uit de Italiaanse popcanon. Verscheen op het album del 1985 Cosa succede in città.",
+      "uri_apple_music": "applemusic://track/1327592526",
+      "uri_deezer": "deezer://track/104726588"
     },
     {
       "year": 1986,
@@ -1474,7 +1561,9 @@
       "fun_fact_de": "Lucio Dalla - \"Caruso\" (1986), aus dem italienischen Pop-Kanon.",
       "fun_fact_es": "Lucio Dalla - \"Caruso\" (1986), del canon del pop italiano.",
       "fun_fact_fr": "Lucio Dalla - \"Caruso\" (1986), du canon de la pop italienne.",
-      "fun_fact_nl": "Lucio Dalla - \"Caruso\" (1986), uit de Italiaanse popcanon."
+      "fun_fact_nl": "Lucio Dalla - \"Caruso\" (1986), uit de Italiaanse popcanon.",
+      "uri_apple_music": "applemusic://track/200934554",
+      "uri_deezer": "deezer://track/972492"
     },
     {
       "year": 1986,
@@ -1489,7 +1578,9 @@
       "fun_fact_de": "Toto Cutugno - \"Serenata\" (1986), aus dem italienischen Pop-Kanon.",
       "fun_fact_es": "Toto Cutugno - \"Serenata\" (1986), del canon del pop italiano.",
       "fun_fact_fr": "Toto Cutugno - \"Serenata\" (1986), du canon de la pop italienne.",
-      "fun_fact_nl": "Toto Cutugno - \"Serenata\" (1986), uit de Italiaanse popcanon."
+      "fun_fact_nl": "Toto Cutugno - \"Serenata\" (1986), uit de Italiaanse popcanon.",
+      "uri_apple_music": "applemusic://track/1329247255",
+      "uri_deezer": "deezer://track/104724382"
     },
     {
       "year": 1987,
@@ -1504,7 +1595,9 @@
       "fun_fact_de": "Gianna Nannini - \"I maschi\" (1987), aus dem italienischen Pop-Kanon.",
       "fun_fact_es": "Gianna Nannini - \"I maschi\" (1987), del canon del pop italiano.",
       "fun_fact_fr": "Gianna Nannini - \"I maschi\" (1987), du canon de la pop italienne.",
-      "fun_fact_nl": "Gianna Nannini - \"I maschi\" (1987), uit de Italiaanse popcanon."
+      "fun_fact_nl": "Gianna Nannini - \"I maschi\" (1987), uit de Italiaanse popcanon.",
+      "uri_apple_music": "applemusic://track/6768669894",
+      "uri_deezer": "deezer://track/88193681"
     },
     {
       "year": 1987,
@@ -1519,7 +1612,9 @@
       "fun_fact_de": "Mango - \"Bella d'estate\" (1987), aus dem italienischen Pop-Kanon.",
       "fun_fact_es": "Mango - \"Bella d'estate\" (1987), del canon del pop italiano.",
       "fun_fact_fr": "Mango - \"Bella d'estate\" (1987), du canon de la pop italienne.",
-      "fun_fact_nl": "Mango - \"Bella d'estate\" (1987), uit de Italiaanse popcanon."
+      "fun_fact_nl": "Mango - \"Bella d'estate\" (1987), uit de Italiaanse popcanon.",
+      "uri_apple_music": "applemusic://track/486352644",
+      "uri_deezer": "deezer://track/69025912"
     },
     {
       "year": 1988,
@@ -1534,7 +1629,9 @@
       "fun_fact_de": "Anna Oxa - \"Quando nasce un amore\" (1988), aus dem italienischen Pop-Kanon. Beim Sanremo-Festival vorgestellt. Erschien auf dem Album della cantante Pensami per te.",
       "fun_fact_es": "Anna Oxa - \"Quando nasce un amore\" (1988), del canon del pop italiano. Presentada en el Festival de Sanremo. Aparecio en el album della cantante Pensami per te.",
       "fun_fact_fr": "Anna Oxa - \"Quando nasce un amore\" (1988), du canon de la pop italienne. Presentee au Festival de Sanremo. Parue sur l album della cantante Pensami per te.",
-      "fun_fact_nl": "Anna Oxa - \"Quando nasce un amore\" (1988), uit de Italiaanse popcanon. Gepresenteerd op het Sanremo-festival. Verscheen op het album della cantante Pensami per te."
+      "fun_fact_nl": "Anna Oxa - \"Quando nasce un amore\" (1988), uit de Italiaanse popcanon. Gepresenteerd op het Sanremo-festival. Verscheen op het album della cantante Pensami per te.",
+      "uri_apple_music": "applemusic://track/819376891",
+      "uri_deezer": "deezer://track/69008453"
     },
     {
       "year": 1988,
@@ -1549,7 +1646,9 @@
       "fun_fact_de": "Antonello Venditti - \"Ricordati di me\" (1988), aus dem italienischen Pop-Kanon.",
       "fun_fact_es": "Antonello Venditti - \"Ricordati di me\" (1988), del canon del pop italiano.",
       "fun_fact_fr": "Antonello Venditti - \"Ricordati di me\" (1988), du canon de la pop italienne.",
-      "fun_fact_nl": "Antonello Venditti - \"Ricordati di me\" (1988), uit de Italiaanse popcanon."
+      "fun_fact_nl": "Antonello Venditti - \"Ricordati di me\" (1988), uit de Italiaanse popcanon.",
+      "uri_apple_music": "applemusic://track/304341668",
+      "uri_deezer": "deezer://track/566798"
     },
     {
       "year": 1988,
@@ -1564,7 +1663,9 @@
       "fun_fact_de": "Massimo Ranieri - \"Perdere l'amore\" (1988), aus dem italienischen Pop-Kanon. Beim Sanremo-Festival vorgestellt.",
       "fun_fact_es": "Massimo Ranieri - \"Perdere l'amore\" (1988), del canon del pop italiano. Presentada en el Festival de Sanremo.",
       "fun_fact_fr": "Massimo Ranieri - \"Perdere l'amore\" (1988), du canon de la pop italienne. Presentee au Festival de Sanremo.",
-      "fun_fact_nl": "Massimo Ranieri - \"Perdere l'amore\" (1988), uit de Italiaanse popcanon. Gepresenteerd op het Sanremo-festival."
+      "fun_fact_nl": "Massimo Ranieri - \"Perdere l'amore\" (1988), uit de Italiaanse popcanon. Gepresenteerd op het Sanremo-festival.",
+      "uri_apple_music": "applemusic://track/79281601",
+      "uri_deezer": "deezer://track/661313"
     },
     {
       "year": 1989,
@@ -1579,7 +1680,8 @@
       "fun_fact_de": "Anna Oxa, Fausto Leali - \"Ti lascerò\" (1989), aus dem italienischen Pop-Kanon.",
       "fun_fact_es": "Anna Oxa, Fausto Leali - \"Ti lascerò\" (1989), del canon del pop italiano.",
       "fun_fact_fr": "Anna Oxa, Fausto Leali - \"Ti lascerò\" (1989), du canon de la pop italienne.",
-      "fun_fact_nl": "Anna Oxa, Fausto Leali - \"Ti lascerò\" (1989), uit de Italiaanse popcanon."
+      "fun_fact_nl": "Anna Oxa, Fausto Leali - \"Ti lascerò\" (1989), uit de Italiaanse popcanon.",
+      "uri_apple_music": "applemusic://track/335971114"
     },
     {
       "year": 1989,
@@ -1594,7 +1696,9 @@
       "fun_fact_de": "Lorella Cuccarini - \"La notte vola\" (1989), aus dem italienischen Pop-Kanon.",
       "fun_fact_es": "Lorella Cuccarini - \"La notte vola\" (1989), del canon del pop italiano.",
       "fun_fact_fr": "Lorella Cuccarini - \"La notte vola\" (1989), du canon de la pop italienne.",
-      "fun_fact_nl": "Lorella Cuccarini - \"La notte vola\" (1989), uit de Italiaanse popcanon."
+      "fun_fact_nl": "Lorella Cuccarini - \"La notte vola\" (1989), uit de Italiaanse popcanon.",
+      "uri_apple_music": "applemusic://track/518297844",
+      "uri_deezer": "deezer://track/18226796"
     },
     {
       "year": 1989,
@@ -1609,7 +1713,9 @@
       "fun_fact_de": "Mia Martini - \"Almeno tu nell'universo\" (1989), aus dem italienischen Pop-Kanon.",
       "fun_fact_es": "Mia Martini - \"Almeno tu nell'universo\" (1989), del canon del pop italiano.",
       "fun_fact_fr": "Mia Martini - \"Almeno tu nell'universo\" (1989), du canon de la pop italienne.",
-      "fun_fact_nl": "Mia Martini - \"Almeno tu nell'universo\" (1989), uit de Italiaanse popcanon."
+      "fun_fact_nl": "Mia Martini - \"Almeno tu nell'universo\" (1989), uit de Italiaanse popcanon.",
+      "uri_apple_music": "applemusic://track/1616014496",
+      "uri_deezer": "deezer://track/1696872787"
     },
     {
       "year": 1992,
@@ -1624,7 +1730,9 @@
       "fun_fact_de": "Mia Martini - \"Gli Uomini Non Cambiano\" (1992), aus dem italienischen Pop-Kanon.",
       "fun_fact_es": "Mia Martini - \"Gli Uomini Non Cambiano\" (1992), del canon del pop italiano.",
       "fun_fact_fr": "Mia Martini - \"Gli Uomini Non Cambiano\" (1992), du canon de la pop italienne.",
-      "fun_fact_nl": "Mia Martini - \"Gli Uomini Non Cambiano\" (1992), uit de Italiaanse popcanon."
+      "fun_fact_nl": "Mia Martini - \"Gli Uomini Non Cambiano\" (1992), uit de Italiaanse popcanon.",
+      "uri_apple_music": "applemusic://track/1616019807",
+      "uri_deezer": "deezer://track/1696905227"
     },
     {
       "year": 1993,
@@ -1639,7 +1747,9 @@
       "fun_fact_de": "883 - \"Come mai\" (1993), aus dem italienischen Pop-Kanon.",
       "fun_fact_es": "883 - \"Come mai\" (1993), del canon del pop italiano.",
       "fun_fact_fr": "883 - \"Come mai\" (1993), du canon de la pop italienne.",
-      "fun_fact_nl": "883 - \"Come mai\" (1993), uit de Italiaanse popcanon."
+      "fun_fact_nl": "883 - \"Come mai\" (1993), uit de Italiaanse popcanon.",
+      "uri_apple_music": "applemusic://track/63831617",
+      "uri_deezer": "deezer://track/766655"
     },
     {
       "year": 1994,
@@ -1654,7 +1764,9 @@
       "fun_fact_de": "Michele Zarrillo - \"Cinque giorni\" (1994), aus dem italienischen Pop-Kanon.",
       "fun_fact_es": "Michele Zarrillo - \"Cinque giorni\" (1994), del canon del pop italiano.",
       "fun_fact_fr": "Michele Zarrillo - \"Cinque giorni\" (1994), du canon de la pop italienne.",
-      "fun_fact_nl": "Michele Zarrillo - \"Cinque giorni\" (1994), uit de Italiaanse popcanon."
+      "fun_fact_nl": "Michele Zarrillo - \"Cinque giorni\" (1994), uit de Italiaanse popcanon.",
+      "uri_apple_music": "applemusic://track/271725260",
+      "uri_deezer": "deezer://track/2455279"
     },
     {
       "year": 1996,
@@ -1669,7 +1781,9 @@
       "fun_fact_de": "Franco Battiato - \"La Cura\" (1996), aus dem italienischen Pop-Kanon. Veroeffentlicht bei Mercury Records come estratto dall'a.",
       "fun_fact_es": "Franco Battiato - \"La Cura\" (1996), del canon del pop italiano. Publicada por Mercury Records come estratto dall'a.",
       "fun_fact_fr": "Franco Battiato - \"La Cura\" (1996), du canon de la pop italienne. Publiee chez Mercury Records come estratto dall'a.",
-      "fun_fact_nl": "Franco Battiato - \"La Cura\" (1996), uit de Italiaanse popcanon. Uitgebracht bij Mercury Records come estratto dall'a."
+      "fun_fact_nl": "Franco Battiato - \"La Cura\" (1996), uit de Italiaanse popcanon. Uitgebracht bij Mercury Records come estratto dall'a.",
+      "uri_apple_music": "applemusic://track/1443744077",
+      "uri_deezer": "deezer://track/2432922"
     },
     {
       "year": 1996,
@@ -1684,7 +1798,9 @@
       "fun_fact_de": "Ornella Vanoni - \"L'appuntamento\" (1996), aus dem italienischen Pop-Kanon.",
       "fun_fact_es": "Ornella Vanoni - \"L'appuntamento\" (1996), del canon del pop italiano.",
       "fun_fact_fr": "Ornella Vanoni - \"L'appuntamento\" (1996), du canon de la pop italienne.",
-      "fun_fact_nl": "Ornella Vanoni - \"L'appuntamento\" (1996), uit de Italiaanse popcanon."
+      "fun_fact_nl": "Ornella Vanoni - \"L'appuntamento\" (1996), uit de Italiaanse popcanon.",
+      "uri_apple_music": "applemusic://track/254168669",
+      "uri_deezer": "deezer://track/564219"
     },
     {
       "year": 1996,
@@ -1699,7 +1815,9 @@
       "fun_fact_de": "Vasco Rossi - \"Sally\" (1996), aus dem italienischen Pop-Kanon. Geschrieben von Vasco Rossi. Erschien auf dem Album Nessun pericolo.",
       "fun_fact_es": "Vasco Rossi - \"Sally\" (1996), del canon del pop italiano. Escrita por Vasco Rossi. Aparecio en el album Nessun pericolo.",
       "fun_fact_fr": "Vasco Rossi - \"Sally\" (1996), du canon de la pop italienne. Ecrite par Vasco Rossi. Parue sur l album Nessun pericolo.",
-      "fun_fact_nl": "Vasco Rossi - \"Sally\" (1996), uit de Italiaanse popcanon. Geschreven door Vasco Rossi. Verscheen op het album Nessun pericolo."
+      "fun_fact_nl": "Vasco Rossi - \"Sally\" (1996), uit de Italiaanse popcanon. Geschreven door Vasco Rossi. Verscheen op het album Nessun pericolo.",
+      "uri_apple_music": "applemusic://track/1443087171",
+      "uri_deezer": "deezer://track/358728991"
     },
     {
       "year": 1998,
@@ -1714,7 +1832,9 @@
       "fun_fact_de": "MINACELENTANO - \"Acqua e sale\" (1998), aus dem italienischen Pop-Kanon.",
       "fun_fact_es": "MINACELENTANO - \"Acqua e sale\" (1998), del canon del pop italiano.",
       "fun_fact_fr": "MINACELENTANO - \"Acqua e sale\" (1998), du canon de la pop italienne.",
-      "fun_fact_nl": "MINACELENTANO - \"Acqua e sale\" (1998), uit de Italiaanse popcanon."
+      "fun_fact_nl": "MINACELENTANO - \"Acqua e sale\" (1998), uit de Italiaanse popcanon.",
+      "uri_apple_music": "applemusic://track/1719308553",
+      "uri_deezer": "deezer://track/2095901487"
     },
     {
       "year": 1998,
@@ -1729,7 +1849,9 @@
       "fun_fact_de": "Vasco Rossi - \"Rewind - Radio Edit\" (1998), aus dem italienischen Pop-Kanon.",
       "fun_fact_es": "Vasco Rossi - \"Rewind - Radio Edit\" (1998), del canon del pop italiano.",
       "fun_fact_fr": "Vasco Rossi - \"Rewind - Radio Edit\" (1998), du canon de la pop italienne.",
-      "fun_fact_nl": "Vasco Rossi - \"Rewind - Radio Edit\" (1998), uit de Italiaanse popcanon."
+      "fun_fact_nl": "Vasco Rossi - \"Rewind - Radio Edit\" (1998), uit de Italiaanse popcanon.",
+      "uri_apple_music": "applemusic://track/1443191612",
+      "uri_deezer": "deezer://track/3211478"
     },
     {
       "year": 1999,
@@ -1744,7 +1866,9 @@
       "fun_fact_de": "Adriano Celentano - \"L'Emozione Non Ha voce (Io Non So Parlar D'Amore)\" (1999), aus dem italienischen Pop-Kanon. Geschrieben von Mogol.",
       "fun_fact_es": "Adriano Celentano - \"L'Emozione Non Ha voce (Io Non So Parlar D'Amore)\" (1999), del canon del pop italiano. Escrita por Mogol.",
       "fun_fact_fr": "Adriano Celentano - \"L'Emozione Non Ha voce (Io Non So Parlar D'Amore)\" (1999), du canon de la pop italienne. Ecrite par Mogol.",
-      "fun_fact_nl": "Adriano Celentano - \"L'Emozione Non Ha voce (Io Non So Parlar D'Amore)\" (1999), uit de Italiaanse popcanon. Geschreven door Mogol."
+      "fun_fact_nl": "Adriano Celentano - \"L'Emozione Non Ha voce (Io Non So Parlar D'Amore)\" (1999), uit de Italiaanse popcanon. Geschreven door Mogol.",
+      "uri_apple_music": "applemusic://track/1702255790",
+      "uri_deezer": "deezer://track/2407440395"
     },
     {
       "year": 2000,
@@ -1759,7 +1883,9 @@
       "fun_fact_de": "Loretta Goggi - \"L'aria del sabato sera\" (2000), aus dem italienischen Pop-Kanon.",
       "fun_fact_es": "Loretta Goggi - \"L'aria del sabato sera\" (2000), del canon del pop italiano.",
       "fun_fact_fr": "Loretta Goggi - \"L'aria del sabato sera\" (2000), du canon de la pop italienne.",
-      "fun_fact_nl": "Loretta Goggi - \"L'aria del sabato sera\" (2000), uit de Italiaanse popcanon."
+      "fun_fact_nl": "Loretta Goggi - \"L'aria del sabato sera\" (2000), uit de Italiaanse popcanon.",
+      "uri_apple_music": "applemusic://track/698668390",
+      "uri_deezer": "deezer://track/4090058"
     },
     {
       "year": 2001,
@@ -1774,7 +1900,9 @@
       "fun_fact_de": "Gigi D'Alessio - \"Mon amour\" (2001), aus dem italienischen Pop-Kanon.",
       "fun_fact_es": "Gigi D'Alessio - \"Mon amour\" (2001), del canon del pop italiano.",
       "fun_fact_fr": "Gigi D'Alessio - \"Mon amour\" (2001), du canon de la pop italienne.",
-      "fun_fact_nl": "Gigi D'Alessio - \"Mon amour\" (2001), uit de Italiaanse popcanon."
+      "fun_fact_nl": "Gigi D'Alessio - \"Mon amour\" (2001), uit de Italiaanse popcanon.",
+      "uri_apple_music": "applemusic://track/265973220",
+      "uri_deezer": "deezer://track/418533452"
     },
     {
       "year": 2002,
@@ -1789,7 +1917,8 @@
       "fun_fact_de": "Gigi D'Alessio, Anna Tatangelo - \"Un nuovo bacio\" (2002), aus dem italienischen Pop-Kanon.",
       "fun_fact_es": "Gigi D'Alessio, Anna Tatangelo - \"Un nuovo bacio\" (2002), del canon del pop italiano.",
       "fun_fact_fr": "Gigi D'Alessio, Anna Tatangelo - \"Un nuovo bacio\" (2002), du canon de la pop italienne.",
-      "fun_fact_nl": "Gigi D'Alessio, Anna Tatangelo - \"Un nuovo bacio\" (2002), uit de Italiaanse popcanon."
+      "fun_fact_nl": "Gigi D'Alessio, Anna Tatangelo - \"Un nuovo bacio\" (2002), uit de Italiaanse popcanon.",
+      "uri_apple_music": "applemusic://track/1308882452"
     },
     {
       "year": 2004,
@@ -1804,7 +1933,9 @@
       "fun_fact_de": "Vasco Rossi - \"Un Senso\" (2004), aus dem italienischen Pop-Kanon.",
       "fun_fact_es": "Vasco Rossi - \"Un Senso\" (2004), del canon del pop italiano.",
       "fun_fact_fr": "Vasco Rossi - \"Un Senso\" (2004), du canon de la pop italienne.",
-      "fun_fact_nl": "Vasco Rossi - \"Un Senso\" (2004), uit de Italiaanse popcanon."
+      "fun_fact_nl": "Vasco Rossi - \"Un Senso\" (2004), uit de Italiaanse popcanon.",
+      "uri_apple_music": "applemusic://track/1443213440",
+      "uri_deezer": "deezer://track/135876550"
     },
     {
       "year": 2007,
@@ -1819,7 +1950,8 @@
       "fun_fact_de": "Gianni Nazzaro - \"Quando L'Amore Diventa Poesía\" (2007), aus dem italienischen Pop-Kanon.",
       "fun_fact_es": "Gianni Nazzaro - \"Quando L'Amore Diventa Poesía\" (2007), del canon del pop italiano.",
       "fun_fact_fr": "Gianni Nazzaro - \"Quando L'Amore Diventa Poesía\" (2007), du canon de la pop italienne.",
-      "fun_fact_nl": "Gianni Nazzaro - \"Quando L'Amore Diventa Poesía\" (2007), uit de Italiaanse popcanon."
+      "fun_fact_nl": "Gianni Nazzaro - \"Quando L'Amore Diventa Poesía\" (2007), uit de Italiaanse popcanon.",
+      "uri_apple_music": "applemusic://track/1780787742"
     }
   ],
   "tags": [


### PR DESCRIPTION
Ein Lauf des `provider-uri-backfill` mit Schwerpunkt Apple Music, automatisch gefahren von `com.beatify.apple-backfill`.

- `musica-italiana` Apple 46 -> **114**/114

Nebenbei mitgefuellt, weil Odesli alle Provider in einer Antwort liefert: deezer +64.

**Draft mit Absicht** — Merge nur nach Markus' Freigabe. Fuer diesen Agenten gibt es bewusst KEINEN Automerge.