### PR TITLE
i18n: make Italian selectable and visible

### DIFF
--- a/custom_components/beatify/playlists/community/musica-italiana.json
+++ b/custom_components/beatify/playlists/community/musica-italiana.json
@@ -1,6 +1,6 @@
 {
-  "name": "Musica Italiana",
-  "description": "Italienische Klassiker von den 60ern bis in die 2000er — Cantautori, Sanremo-Sieger und die Lieder, die auf jeder Feier mitgesungen werden.",
+  "name": "Musica Italiana 🇮🇹",
+  "description": "Italian classics from the 1960s to the 2000s — cantautori, Sanremo winners and the songs every Italian party sings along to. Merged from playlist requests #2228 and #2229.",
   "version": "0.5",
   "songs": [
     {
@@ -1831,5 +1831,6 @@
     "1980s",
     "1990s",
     "2000s"
-  ]
+  ],
+  "language": "it"
 }

--- a/custom_components/beatify/www/js/wizard.js
+++ b/custom_components/beatify/www/js/wizard.js
@@ -899,6 +899,7 @@ const LANGUAGES = [
     { id: 'es', label: 'Español' },
     { id: 'fr', label: 'Français' },
     { id: 'nl', label: 'Nederlands' },
+    { id: 'it', label: 'Italiano' },
 ];
 
 /**


### PR DESCRIPTION
Markus asked whether there is an Italian flag in the UI yet. There isn't, and finding out why turned up three separate gaps that #2235 and #2237 do not close.

## What was missing

**Italian was not selectable at all.** `wizard.js` carries its own `LANGUAGES` list — `en`, `de`, `es`, `fr`, `nl` — and it is the only in-app language picker. #2235 adds `it` to `SUPPORTED_LANGUAGES` in `i18n.js` and to `detectLanguage()`, but that only covers browser auto-detection. On a German browser there would have been no way to switch to Italian by hand.

**The playlist had no flag and no shelf.** `playlist-hub.js` builds the "By Country" shelf by grouping on a playlist's `language` field and renders `LANGUAGE_FLAGS[lang]` next to the name. `LANGUAGE_FLAGS` already has `it: '🇮🇹'`. But `musica-italiana.json` shipped without a `language` field, so it never entered the shelf and never got the flag — the one mechanism that would have shown an Italian flag today was sitting there unused.

**Two smaller things in the same file.** The name had no flag emoji, unlike `Schlager Classics 🇩🇪`, `100% Français 🇫🇷` and `Polskie hity radiowe 🇵🇱`. And the description was written in German, while every other playlist describes itself in English.

## Changes

| File | Change |
|---|---|
| `www/js/wizard.js` | `{ id: 'it', label: 'Italiano' }` added to `LANGUAGES` |
| `playlists/community/musica-italiana.json` | `"language": "it"` added after `tags`, matching the position used by all 21 other language-tagged playlists |
| `playlists/community/musica-italiana.json` | name → `Musica Italiana 🇮🇹` |
| `playlists/community/musica-italiana.json` | description rewritten in English, now naming requests #2228 and #2229 |

## Merge order

This depends on **#2237**. Offering Italiano in the picker before `www/i18n/it.json` exists would make `i18n.js` fetch a 404 and silently fall back to English — a picker entry that appears to do nothing. Merge #2237 first, then #2235, then this.

The playlist half of this PR is independent and correct on its own; only the `wizard.js` line has the ordering constraint.

1938 unit tests pass.