### PR TITLE
data(musica-italiana): backfill ISRCs via Deezer (113/114)

### DIFF
--- a/custom_components/beatify/playlists/community/musica-italiana.json
+++ b/custom_components/beatify/playlists/community/musica-italiana.json
@@ -1,7 +1,7 @@
 {
   "name": "Musica Italiana 🇮🇹",
   "description": "Italian classics from the 1960s to the 2000s — cantautori, Sanremo winners and the songs every Italian party sings along to. Merged from playlist requests #2228 and #2229.",
-  "version": "0.5",
+  "version": "0.6",
   "songs": [
     {
       "year": 1962,
@@ -17,6 +17,7 @@
       "fun_fact_es": "Gianni Morandi - \"Fatti Mandare Dalla Mamma A Prendere Il Latte\" (1962), del canon del pop italiano.",
       "fun_fact_fr": "Gianni Morandi - \"Fatti Mandare Dalla Mamma A Prendere Il Latte\" (1962), du canon de la pop italienne.",
       "fun_fact_nl": "Gianni Morandi - \"Fatti Mandare Dalla Mamma A Prendere Il Latte\" (1962), uit de Italiaanse popcanon.",
+      "isrc": "ITB006200780",
       "uri_apple_music": "applemusic://track/620947772",
       "uri_deezer": "deezer://track/68627294",
       "uri_youtube_music": "https://music.youtube.com/watch?v=7eLBR4xQt_4"
@@ -35,6 +36,7 @@
       "fun_fact_es": "Rita Pavone - \"La partita di pallone\" (1962), del canon del pop italiano.",
       "fun_fact_fr": "Rita Pavone - \"La partita di pallone\" (1962), du canon de la pop italienne.",
       "fun_fact_nl": "Rita Pavone - \"La partita di pallone\" (1962), uit de Italiaanse popcanon.",
+      "isrc": "ITDD81920978",
       "uri_apple_music": "applemusic://track/1732105559",
       "uri_deezer": "deezer://track/844247532",
       "uri_youtube_music": "https://music.youtube.com/watch?v=DERSWPBE0Xc"
@@ -53,6 +55,7 @@
       "fun_fact_es": "Rita Pavone - \"Il Ballo Del Mattone\" (1963), del canon del pop italiano.",
       "fun_fact_fr": "Rita Pavone - \"Il Ballo Del Mattone\" (1963), du canon de la pop italienne.",
       "fun_fact_nl": "Rita Pavone - \"Il Ballo Del Mattone\" (1963), uit de Italiaanse popcanon.",
+      "isrc": "ITB006200897",
       "uri_apple_music": "applemusic://track/1732106292",
       "uri_deezer": "deezer://track/3783877822",
       "uri_youtube_music": "https://music.youtube.com/watch?v=MBHPjlRQKaU"
@@ -71,6 +74,7 @@
       "fun_fact_es": "Rita Pavone - \"Cuore\" (1963), del canon del pop italiano. Escrita por Carlo Rossi.",
       "fun_fact_fr": "Rita Pavone - \"Cuore\" (1963), du canon de la pop italienne. Ecrite par Carlo Rossi.",
       "fun_fact_nl": "Rita Pavone - \"Cuore\" (1963), uit de Italiaanse popcanon. Geschreven door Carlo Rossi.",
+      "isrc": "ES5831600023",
       "uri_apple_music": "applemusic://track/1054017780",
       "uri_deezer": "deezer://track/118813640",
       "uri_youtube_music": "https://music.youtube.com/watch?v=OScp2u69dOc"
@@ -89,6 +93,7 @@
       "fun_fact_es": "Bobby Solo - \"Una Lacrima Sul Viso\" (1964), del canon del pop italiano. Presentada en el Festival de Sanremo.",
       "fun_fact_fr": "Bobby Solo - \"Una Lacrima Sul Viso\" (1964), du canon de la pop italienne. Presentee au Festival de Sanremo.",
       "fun_fact_nl": "Bobby Solo - \"Una Lacrima Sul Viso\" (1964), uit de Italiaanse popcanon. Gepresenteerd op het Sanremo-festival.",
+      "isrc": "USA370534628",
       "uri_apple_music": "applemusic://track/1462939298",
       "uri_deezer": "deezer://track/5066687",
       "uri_youtube_music": "https://music.youtube.com/watch?v=s6qyC4nPoSs"
@@ -107,6 +112,7 @@
       "fun_fact_es": "Rita Pavone - \"Datemi un martello\" (1964), del canon del pop italiano.",
       "fun_fact_fr": "Rita Pavone - \"Datemi un martello\" (1964), du canon de la pop italienne.",
       "fun_fact_nl": "Rita Pavone - \"Datemi un martello\" (1964), uit de Italiaanse popcanon.",
+      "isrc": "ES5831600027",
       "uri_apple_music": "applemusic://track/1082356818",
       "uri_deezer": "deezer://track/118813648",
       "uri_youtube_music": "https://music.youtube.com/watch?v=u1eehe9J5G0"
@@ -125,6 +131,7 @@
       "fun_fact_es": "Jimmy Fontana - \"Il mondo\" (1965), del canon del pop italiano.",
       "fun_fact_fr": "Jimmy Fontana - \"Il mondo\" (1965), du canon de la pop italienne.",
       "fun_fact_nl": "Jimmy Fontana - \"Il mondo\" (1965), uit de Italiaanse popcanon.",
+      "isrc": "ITB006500604",
       "uri_apple_music": "applemusic://track/1410916284",
       "uri_deezer": "deezer://track/957076",
       "uri_youtube_music": "https://music.youtube.com/watch?v=HFyCfFJC0no"
@@ -143,6 +150,7 @@
       "fun_fact_es": "Mina - \"Più di te\" (1965), del canon del pop italiano.",
       "fun_fact_fr": "Mina - \"Più di te\" (1965), du canon de la pop italienne.",
       "fun_fact_nl": "Mina - \"Più di te\" (1965), uit de Italiaanse popcanon.",
+      "isrc": "ITA646500267",
       "uri_apple_music": "applemusic://track/1423224326",
       "uri_deezer": "deezer://track/518977172",
       "uri_youtube_music": "https://music.youtube.com/watch?v=6uDP_TTvhz8"
@@ -161,6 +169,7 @@
       "fun_fact_es": "Caterina Caselli - \"Nessuno Mi Può Giudicare\" (1966), del canon del pop italiano.",
       "fun_fact_fr": "Caterina Caselli - \"Nessuno Mi Può Giudicare\" (1966), du canon de la pop italienne.",
       "fun_fact_nl": "Caterina Caselli - \"Nessuno Mi Può Giudicare\" (1966), uit de Italiaanse popcanon.",
+      "isrc": "ITR006600011",
       "uri_apple_music": "applemusic://track/1583784528",
       "uri_deezer": "deezer://track/1487292572",
       "uri_youtube_music": "https://music.youtube.com/watch?v=VtWLUYFWb7M"
@@ -179,6 +188,7 @@
       "fun_fact_es": "Mina - \"Se telefonando\" (1966), del canon del pop italiano. Aparecio en el album Studio Uno 66.",
       "fun_fact_fr": "Mina - \"Se telefonando\" (1966), du canon de la pop italienne. Parue sur l album Studio Uno 66.",
       "fun_fact_nl": "Mina - \"Se telefonando\" (1966), uit de Italiaanse popcanon. Verscheen op het album Studio Uno 66.",
+      "isrc": "ITA646600111",
       "uri_apple_music": "applemusic://track/1423193119",
       "uri_deezer": "deezer://track/523540742",
       "uri_youtube_music": "https://music.youtube.com/watch?v=x6fpSiE953w"
@@ -197,6 +207,7 @@
       "fun_fact_es": "Nada - \"Ma Che Freddo Fa\" (1969), del canon del pop italiano.",
       "fun_fact_fr": "Nada - \"Ma Che Freddo Fa\" (1969), du canon de la pop italienne.",
       "fun_fact_nl": "Nada - \"Ma Che Freddo Fa\" (1969), uit de Italiaanse popcanon.",
+      "isrc": "ITB006900687",
       "uri_apple_music": "applemusic://track/201304510",
       "uri_deezer": "deezer://track/972240",
       "uri_youtube_music": "https://music.youtube.com/watch?v=DJs-9BnJRPA"
@@ -215,6 +226,7 @@
       "fun_fact_es": "Claudio Baglioni - \"E tu...\" (1970), del canon del pop italiano.",
       "fun_fact_fr": "Claudio Baglioni - \"E tu...\" (1970), du canon de la pop italienne.",
       "fun_fact_nl": "Claudio Baglioni - \"E tu...\" (1970), uit de Italiaanse popcanon.",
+      "isrc": "ITB007401170",
       "uri_apple_music": "applemusic://track/254120593",
       "uri_deezer": "deezer://track/424506002",
       "uri_youtube_music": "https://music.youtube.com/watch?v=4Ajev-GrEWA"
@@ -233,6 +245,7 @@
       "fun_fact_es": "Lucio Battisti - \"Acqua azzurra, acqua chiara\" (1970), del canon del pop italiano.",
       "fun_fact_fr": "Lucio Battisti - \"Acqua azzurra, acqua chiara\" (1970), du canon de la pop italienne.",
       "fun_fact_nl": "Lucio Battisti - \"Acqua azzurra, acqua chiara\" (1970), uit de Italiaanse popcanon.",
+      "isrc": "ITB001701078",
       "uri_apple_music": "applemusic://track/1480766584",
       "uri_deezer": "deezer://track/764314612",
       "uri_youtube_music": "https://music.youtube.com/watch?v=Q6JW3KKeGKQ"
@@ -251,6 +264,7 @@
       "fun_fact_es": "Lucio Battisti - \"Dieci ragazze\" (1970), del canon del pop italiano.",
       "fun_fact_fr": "Lucio Battisti - \"Dieci ragazze\" (1970), du canon de la pop italienne.",
       "fun_fact_nl": "Lucio Battisti - \"Dieci ragazze\" (1970), uit de Italiaanse popcanon.",
+      "isrc": "ITB001701077",
       "uri_apple_music": "applemusic://track/1480766583",
       "uri_deezer": "deezer://track/764314602",
       "uri_youtube_music": "https://music.youtube.com/watch?v=nWEIl80bqok"
@@ -269,6 +283,7 @@
       "fun_fact_es": "Massimo Ranieri - \"Se bruciasse la città\" (1970), del canon del pop italiano.",
       "fun_fact_fr": "Massimo Ranieri - \"Se bruciasse la città\" (1970), du canon de la pop italienne.",
       "fun_fact_nl": "Massimo Ranieri - \"Se bruciasse la città\" (1970), uit de Italiaanse popcanon.",
+      "isrc": "ITR006900011",
       "uri_apple_music": "applemusic://track/1532921385",
       "uri_deezer": "deezer://track/751997",
       "uri_youtube_music": "https://music.youtube.com/watch?v=_zzug4d51eo"
@@ -287,6 +302,7 @@
       "fun_fact_es": "Massimo Ranieri - \"Vent'anni\" (1970), del canon del pop italiano.",
       "fun_fact_fr": "Massimo Ranieri - \"Vent'anni\" (1970), du canon de la pop italienne.",
       "fun_fact_nl": "Massimo Ranieri - \"Vent'anni\" (1970), uit de Italiaanse popcanon.",
+      "isrc": "ITR007000051",
       "uri_apple_music": "applemusic://track/1542206913",
       "uri_deezer": "deezer://track/783929"
     },
@@ -304,6 +320,7 @@
       "fun_fact_es": "Massimo Ranieri - \"Rose rosse\" (1970), del canon del pop italiano.",
       "fun_fact_fr": "Massimo Ranieri - \"Rose rosse\" (1970), du canon de la pop italienne.",
       "fun_fact_nl": "Massimo Ranieri - \"Rose rosse\" (1970), uit de Italiaanse popcanon.",
+      "isrc": "ITR006900021",
       "uri_apple_music": "applemusic://track/1532950592",
       "uri_deezer": "deezer://track/751985"
     },
@@ -321,6 +338,7 @@
       "fun_fact_es": "Lucio Battisti - \"La canzone del sole - Remastered\" (1971), del canon del pop italiano.",
       "fun_fact_fr": "Lucio Battisti - \"La canzone del sole - Remastered\" (1971), du canon de la pop italienne.",
       "fun_fact_nl": "Lucio Battisti - \"La canzone del sole - Remastered\" (1971), uit de Italiaanse popcanon.",
+      "isrc": "ITB001600716",
       "uri_apple_music": "applemusic://track/1480763765",
       "uri_deezer": "deezer://track/764072472",
       "uri_youtube_music": "https://music.youtube.com/watch?v=XcxWKT41A0g"
@@ -339,6 +357,7 @@
       "fun_fact_es": "Lucio Dalla - \"4/3/1943\" (1971), del canon del pop italiano.",
       "fun_fact_fr": "Lucio Dalla - \"4/3/1943\" (1971), du canon de la pop italienne.",
       "fun_fact_nl": "Lucio Dalla - \"4/3/1943\" (1971), uit de Italiaanse popcanon.",
+      "isrc": "ITB007001022",
       "uri_apple_music": "applemusic://track/254149169",
       "uri_deezer": "deezer://track/972768"
     },
@@ -356,6 +375,7 @@
       "fun_fact_es": "Mia Martini - \"Piccolo uomo\" (1971), del canon del pop italiano. Gano el Festivalbar.",
       "fun_fact_fr": "Mia Martini - \"Piccolo uomo\" (1971), du canon de la pop italienne. A gagne le Festivalbar.",
       "fun_fact_nl": "Mia Martini - \"Piccolo uomo\" (1971), uit de Italiaanse popcanon. Won de Festivalbar.",
+      "isrc": "ITDV92500170",
       "uri_apple_music": "applemusic://track/1807966498",
       "uri_deezer": "deezer://track/3731934942"
     },
@@ -373,6 +393,7 @@
       "fun_fact_es": "Ricchi E Poveri - \"Che Sarà\" (1971), del canon del pop italiano. Escrita por Jimmy Fontana. Presentada en el Festival de Sanremo.",
       "fun_fact_fr": "Ricchi E Poveri - \"Che Sarà\" (1971), du canon de la pop italienne. Ecrite par Jimmy Fontana. Presentee au Festival de Sanremo.",
       "fun_fact_nl": "Ricchi E Poveri - \"Che Sarà\" (1971), uit de Italiaanse popcanon. Geschreven door Jimmy Fontana. Gepresenteerd op het Sanremo-festival.",
+      "isrc": "ITD009000010",
       "uri_apple_music": "applemusic://track/998281784",
       "uri_deezer": "deezer://track/3293696"
     },
@@ -390,6 +411,7 @@
       "fun_fact_es": "Claudio Baglioni - \"Porta Portese\" (1972), del canon del pop italiano.",
       "fun_fact_fr": "Claudio Baglioni - \"Porta Portese\" (1972), du canon de la pop italienne.",
       "fun_fact_nl": "Claudio Baglioni - \"Porta Portese\" (1972), uit de Italiaanse popcanon.",
+      "isrc": "ITB007200862",
       "uri_apple_music": "applemusic://track/254225856",
       "uri_deezer": "deezer://track/424505992"
     },
@@ -407,6 +429,7 @@
       "fun_fact_es": "Claudio Baglioni - \"Mia Libertà\" (1972), del canon del pop italiano.",
       "fun_fact_fr": "Claudio Baglioni - \"Mia Libertà\" (1972), du canon de la pop italienne.",
       "fun_fact_nl": "Claudio Baglioni - \"Mia Libertà\" (1972), uit de Italiaanse popcanon.",
+      "isrc": "ITB007200133",
       "uri_apple_music": "applemusic://track/200571073",
       "uri_deezer": "deezer://track/1021893"
     },
@@ -424,6 +447,7 @@
       "fun_fact_es": "Claudio Baglioni - \"Questo piccolo grande amore\" (1972), del canon del pop italiano.",
       "fun_fact_fr": "Claudio Baglioni - \"Questo piccolo grande amore\" (1972), du canon de la pop italienne.",
       "fun_fact_nl": "Claudio Baglioni - \"Questo piccolo grande amore\" (1972), uit de Italiaanse popcanon.",
+      "isrc": "ITB007200861",
       "uri_apple_music": "applemusic://track/200570600",
       "uri_deezer": "deezer://track/576276"
     },
@@ -441,6 +465,7 @@
       "fun_fact_es": "Lucio Battisti - \"Il mio canto libero\" (1972), del canon del pop italiano.",
       "fun_fact_fr": "Lucio Battisti - \"Il mio canto libero\" (1972), du canon de la pop italienne.",
       "fun_fact_nl": "Lucio Battisti - \"Il mio canto libero\" (1972), uit de Italiaanse popcanon.",
+      "isrc": "ITB001701090",
       "uri_apple_music": "applemusic://track/1480766133",
       "uri_deezer": "deezer://track/764304922"
     },
@@ -458,6 +483,7 @@
       "fun_fact_es": "Claudio Baglioni - \"Amore bello\" (1973), del canon del pop italiano.",
       "fun_fact_fr": "Claudio Baglioni - \"Amore bello\" (1973), du canon de la pop italienne.",
       "fun_fact_nl": "Claudio Baglioni - \"Amore bello\" (1973), uit de Italiaanse popcanon.",
+      "isrc": "ITB007301064",
       "uri_apple_music": "applemusic://track/253992888",
       "uri_deezer": "deezer://track/1020156"
     },
@@ -475,6 +501,7 @@
       "fun_fact_es": "Umberto Tozzi - \"Tu\" (1973), del canon del pop italiano. Escrita por Umberto Tozzi and Giancarlo Bigazzi.",
       "fun_fact_fr": "Umberto Tozzi - \"Tu\" (1973), du canon de la pop italienne. Ecrite par Umberto Tozzi and Giancarlo Bigazzi.",
       "fun_fact_nl": "Umberto Tozzi - \"Tu\" (1973), uit de Italiaanse popcanon. Geschreven door Umberto Tozzi and Giancarlo Bigazzi.",
+      "isrc": "ITR007800321",
       "uri_apple_music": "applemusic://track/1564230420",
       "uri_deezer": "deezer://track/1351336652"
     },
@@ -492,6 +519,7 @@
       "fun_fact_es": "Riccardo Cocciante - \"Bella senz'anima\" (1974), del canon del pop italiano.",
       "fun_fact_fr": "Riccardo Cocciante - \"Bella senz'anima\" (1974), du canon de la pop italienne.",
       "fun_fact_nl": "Riccardo Cocciante - \"Bella senz'anima\" (1974), uit de Italiaanse popcanon.",
+      "isrc": "ITB007401175",
       "uri_apple_music": "applemusic://track/255453955",
       "uri_deezer": "deezer://track/985852"
     },
@@ -509,6 +537,7 @@
       "fun_fact_es": "Francesco De Gregori - \"Rimmel\" (1975), del canon del pop italiano.",
       "fun_fact_fr": "Francesco De Gregori - \"Rimmel\" (1975), du canon de la pop italienne.",
       "fun_fact_nl": "Francesco De Gregori - \"Rimmel\" (1975), uit de Italiaanse popcanon.",
+      "isrc": "ITB007401283",
       "uri_apple_music": "applemusic://track/259987956",
       "uri_deezer": "deezer://track/546135"
     },
@@ -526,6 +555,7 @@
       "fun_fact_es": "Rino Gaetano - \"Ma il cielo è sempre più blu\" (1975), del canon del pop italiano.",
       "fun_fact_fr": "Rino Gaetano - \"Ma il cielo è sempre più blu\" (1975), du canon de la pop italienne.",
       "fun_fact_nl": "Rino Gaetano - \"Ma il cielo è sempre più blu\" (1975), uit de Italiaanse popcanon.",
+      "isrc": "ITB008400575",
       "uri_apple_music": "applemusic://track/1571903770",
       "uri_deezer": "deezer://track/1020925"
     },
@@ -543,6 +573,7 @@
       "fun_fact_es": "Loredana Bertè - \"Sei bellissima\" (1976), del canon del pop italiano. Publicada por Sony Music.",
       "fun_fact_fr": "Loredana Bertè - \"Sei bellissima\" (1976), du canon de la pop italienne. Publiee chez Sony Music.",
       "fun_fact_nl": "Loredana Bertè - \"Sei bellissima\" (1976), uit de Italiaanse popcanon. Uitgebracht bij Sony Music.",
+      "isrc": "ITR007500231",
       "uri_apple_music": "applemusic://track/1631382207",
       "uri_deezer": "deezer://track/689319"
     },
@@ -560,6 +591,7 @@
       "fun_fact_es": "Alan Sorrenti - \"Figli Delle Stelle\" (1977), del canon del pop italiano. Publicada por EMI italiana.",
       "fun_fact_fr": "Alan Sorrenti - \"Figli Delle Stelle\" (1977), du canon de la pop italienne. Publiee chez EMI italiana.",
       "fun_fact_nl": "Alan Sorrenti - \"Figli Delle Stelle\" (1977), uit de Italiaanse popcanon. Uitgebracht bij EMI italiana.",
+      "isrc": "ITD000500050",
       "uri_apple_music": "applemusic://track/1442578568",
       "uri_deezer": "deezer://track/3371535"
     },
@@ -577,6 +609,7 @@
       "fun_fact_es": "Donatella Rettore - \"Donatella\" (1977), del canon del pop italiano.",
       "fun_fact_fr": "Donatella Rettore - \"Donatella\" (1977), du canon de la pop italienne.",
       "fun_fact_nl": "Donatella Rettore - \"Donatella\" (1977), uit de Italiaanse popcanon.",
+      "isrc": "ITDV92500071",
       "uri_apple_music": "applemusic://track/1614482579",
       "uri_deezer": "deezer://track/3731929282"
     },
@@ -594,6 +627,7 @@
       "fun_fact_es": "Pooh - \"Dammi solo un minuto - 2014 Remaster\" (1977), del canon del pop italiano.",
       "fun_fact_fr": "Pooh - \"Dammi solo un minuto - 2014 Remaster\" (1977), du canon de la pop italienne.",
       "fun_fact_nl": "Pooh - \"Dammi solo un minuto - 2014 Remaster\" (1977), uit de Italiaanse popcanon.",
+      "isrc": "ITR001400162",
       "uri_apple_music": "applemusic://track/1710443769",
       "uri_deezer": "deezer://track/124637040"
     },
@@ -611,6 +645,7 @@
       "fun_fact_es": "Roberto Vecchioni - \"Samarcanda\" (1977), del canon del pop italiano.",
       "fun_fact_fr": "Roberto Vecchioni - \"Samarcanda\" (1977), du canon de la pop italienne.",
       "fun_fact_nl": "Roberto Vecchioni - \"Samarcanda\" (1977), uit de Italiaanse popcanon.",
+      "isrc": "IT7009506670",
       "uri_apple_music": "applemusic://track/821631862",
       "uri_deezer": "deezer://track/2297038065"
     },
@@ -628,6 +663,7 @@
       "fun_fact_es": "Umberto Tozzi - \"Ti Amo\" (1977), del canon del pop italiano. Usada despues en la pelicula Asterix & Obelix: Mission Cleopatra.",
       "fun_fact_fr": "Umberto Tozzi - \"Ti Amo\" (1977), du canon de la pop italienne. Reprise ensuite dans le film Asterix & Obelix: Mission Cleopatra.",
       "fun_fact_nl": "Umberto Tozzi - \"Ti Amo\" (1977), uit de Italiaanse popcanon. Later gebruikt in de film Asterix & Obelix: Mission Cleopatra.",
+      "isrc": "ITR007700021",
       "uri_apple_music": "applemusic://track/1565179218",
       "uri_deezer": "deezer://track/1357589612"
     },
@@ -645,6 +681,7 @@
       "fun_fact_es": "Anna Oxa - \"Un'emozione da poco\" (1978), del canon del pop italiano. Alcanzo el numero uno en la lista italiana. Aparecio en el album Oxanna.",
       "fun_fact_fr": "Anna Oxa - \"Un'emozione da poco\" (1978), du canon de la pop italienne. Numero un du classement italien. Parue sur l album Oxanna.",
       "fun_fact_nl": "Anna Oxa - \"Un'emozione da poco\" (1978), uit de Italiaanse popcanon. Bereikte nummer een in de Italiaanse hitlijst. Verscheen op het album Oxanna.",
+      "isrc": "ITB007800565",
       "uri_apple_music": "applemusic://track/818784238",
       "uri_deezer": "deezer://track/69008435"
     },
@@ -662,6 +699,7 @@
       "fun_fact_es": "Antonello Venditti - \"Sara\" (1978), del canon del pop italiano.",
       "fun_fact_fr": "Antonello Venditti - \"Sara\" (1978), du canon de la pop italienne.",
       "fun_fact_nl": "Antonello Venditti - \"Sara\" (1978), uit de Italiaanse popcanon.",
+      "isrc": "ITUM71800855",
       "uri_apple_music": "applemusic://track/252352184",
       "uri_deezer": "deezer://track/555658072"
     },
@@ -679,6 +717,7 @@
       "fun_fact_es": "Claudio Baglioni - \"E tu come stai?\" (1978), del canon del pop italiano.",
       "fun_fact_fr": "Claudio Baglioni - \"E tu come stai?\" (1978), du canon de la pop italienne.",
       "fun_fact_nl": "Claudio Baglioni - \"E tu come stai?\" (1978), uit de Italiaanse popcanon.",
+      "isrc": "ITM000102558",
       "uri_apple_music": "applemusic://track/200324416",
       "uri_deezer": "deezer://track/1073047"
     },
@@ -696,6 +735,7 @@
       "fun_fact_es": "Francesco De Gregori - \"Generale\" (1978), del canon del pop italiano.",
       "fun_fact_fr": "Francesco De Gregori - \"Generale\" (1978), du canon de la pop italienne.",
       "fun_fact_nl": "Francesco De Gregori - \"Generale\" (1978), uit de Italiaanse popcanon.",
+      "isrc": "ITB007701007",
       "uri_apple_music": "applemusic://track/254263491",
       "uri_deezer": "deezer://track/1082468"
     },
@@ -713,6 +753,7 @@
       "fun_fact_es": "Loredana Bertè - \"Dedicato - 2016 Remastered\" (1978), del canon del pop italiano.",
       "fun_fact_fr": "Loredana Bertè - \"Dedicato - 2016 Remastered\" (1978), du canon de la pop italienne.",
       "fun_fact_nl": "Loredana Bertè - \"Dedicato - 2016 Remastered\" (1978), uit de Italiaanse popcanon.",
+      "isrc": "ITR007800251",
       "uri_apple_music": "applemusic://track/1679436762",
       "uri_deezer": "deezer://track/3920585"
     },
@@ -730,6 +771,7 @@
       "fun_fact_es": "Patty Pravo - \"Pensiero stupendo\" (1978), del canon del pop italiano. Escrita por Ivano Fossati.",
       "fun_fact_fr": "Patty Pravo - \"Pensiero stupendo\" (1978), du canon de la pop italienne. Ecrite par Ivano Fossati.",
       "fun_fact_nl": "Patty Pravo - \"Pensiero stupendo\" (1978), uit de Italiaanse popcanon. Geschreven door Ivano Fossati.",
+      "isrc": "ITB007701035",
       "uri_apple_music": "applemusic://track/254264774",
       "uri_deezer": "deezer://track/1020587"
     },
@@ -747,6 +789,7 @@
       "fun_fact_es": "Renato Zero - \"Triangolo\" (1978), del canon del pop italiano.",
       "fun_fact_fr": "Renato Zero - \"Triangolo\" (1978), du canon de la pop italienne.",
       "fun_fact_nl": "Renato Zero - \"Triangolo\" (1978), uit de Italiaanse popcanon.",
+      "isrc": "ITB007800748",
       "uri_apple_music": "applemusic://track/275439955",
       "uri_deezer": "deezer://track/64975600"
     },
@@ -764,6 +807,7 @@
       "fun_fact_es": "Rino Gaetano - \"A mano a mano\" (1978), del canon del pop italiano.",
       "fun_fact_fr": "Rino Gaetano - \"A mano a mano\" (1978), du canon de la pop italienne.",
       "fun_fact_nl": "Rino Gaetano - \"A mano a mano\" (1978), uit de Italiaanse popcanon.",
+      "isrc": "ITB000900104",
       "uri_apple_music": "applemusic://track/1536464463",
       "uri_deezer": "deezer://track/101902307"
     },
@@ -781,6 +825,7 @@
       "fun_fact_es": "Rino Gaetano - \"Gianna\" (1978), del canon del pop italiano.",
       "fun_fact_fr": "Rino Gaetano - \"Gianna\" (1978), du canon de la pop italienne.",
       "fun_fact_nl": "Rino Gaetano - \"Gianna\" (1978), uit de Italiaanse popcanon.",
+      "isrc": "ITB008400565",
       "uri_apple_music": "applemusic://track/1299685367",
       "uri_deezer": "deezer://track/634108"
     },
@@ -798,6 +843,7 @@
       "fun_fact_es": "Vasco Rossi - \"E...\" (1978), del canon del pop italiano.",
       "fun_fact_fr": "Vasco Rossi - \"E...\" (1978), du canon de la pop italienne.",
       "fun_fact_nl": "Vasco Rossi - \"E...\" (1978), uit de Italiaanse popcanon.",
+      "isrc": "ITD000400182",
       "uri_apple_music": "applemusic://track/1443213284",
       "uri_deezer": "deezer://track/135876548"
     },
@@ -815,6 +861,7 @@
       "fun_fact_es": "Adriano Pappalardo - \"Ricominciamo\" (1979), del canon del pop italiano.",
       "fun_fact_fr": "Adriano Pappalardo - \"Ricominciamo\" (1979), du canon de la pop italienne.",
       "fun_fact_nl": "Adriano Pappalardo - \"Ricominciamo\" (1979), uit de Italiaanse popcanon.",
+      "isrc": "ITB007900666",
       "uri_apple_music": "applemusic://track/1080717875",
       "uri_deezer": "deezer://track/1009010"
     },
@@ -832,6 +879,7 @@
       "fun_fact_es": "Alan Sorrenti - \"Tu Sei L'Unica Donna Per Me - 2005 Remaster\" (1979), del canon del pop italiano.",
       "fun_fact_fr": "Alan Sorrenti - \"Tu Sei L'Unica Donna Per Me - 2005 Remaster\" (1979), du canon de la pop italienne.",
       "fun_fact_nl": "Alan Sorrenti - \"Tu Sei L'Unica Donna Per Me - 2005 Remaster\" (1979), uit de Italiaanse popcanon.",
+      "isrc": "ITD000500059",
       "uri_apple_music": "applemusic://track/1637161394",
       "uri_deezer": "deezer://track/3370893"
     },
@@ -849,6 +897,7 @@
       "fun_fact_es": "Umberto Tozzi - \"Gloria\" (1979), del canon del pop italiano. Aparecio en el album Gloria. Publicada por CGD nel 1979 nel singolo Gloria/Aria.",
       "fun_fact_fr": "Umberto Tozzi - \"Gloria\" (1979), du canon de la pop italienne. Parue sur l album Gloria. Publiee chez CGD nel 1979 nel singolo Gloria/Aria.",
       "fun_fact_nl": "Umberto Tozzi - \"Gloria\" (1979), uit de Italiaanse popcanon. Verscheen op het album Gloria. Uitgebracht bij CGD nel 1979 nel singolo Gloria/Aria.",
+      "isrc": "ESA031419191",
       "uri_apple_music": "applemusic://track/1567867714",
       "uri_deezer": "deezer://track/84718345"
     },
@@ -866,6 +915,7 @@
       "fun_fact_es": "Umberto Tozzi - \"Stella stai\" (1979), del canon del pop italiano. Usada despues en la pelicula Spider-Man: Far from Home del 2019. Aparecio en el album Tozzi.",
       "fun_fact_fr": "Umberto Tozzi - \"Stella stai\" (1979), du canon de la pop italienne. Reprise ensuite dans le film Spider-Man: Far from Home del 2019. Parue sur l album Tozzi.",
       "fun_fact_nl": "Umberto Tozzi - \"Stella stai\" (1979), uit de Italiaanse popcanon. Later gebruikt in de film Spider-Man: Far from Home del 2019. Verscheen op het album Tozzi.",
+      "isrc": "ITR008000571",
       "uri_apple_music": "applemusic://track/672547109",
       "uri_deezer": "deezer://track/69028148"
     },
@@ -883,6 +933,7 @@
       "fun_fact_es": "Vasco Rossi - \"Albachiara - Remastered 2019\" (1979), del canon del pop italiano.",
       "fun_fact_fr": "Vasco Rossi - \"Albachiara - Remastered 2019\" (1979), du canon de la pop italienne.",
       "fun_fact_nl": "Vasco Rossi - \"Albachiara - Remastered 2019\" (1979), uit de Italiaanse popcanon.",
+      "isrc": "ITB001900323",
       "uri_apple_music": "applemusic://track/1479885373",
       "uri_deezer": "deezer://track/753892132"
     },
@@ -900,6 +951,7 @@
       "fun_fact_es": "Viola Valentino - \"Comprami\" (1979), del canon del pop italiano.",
       "fun_fact_fr": "Viola Valentino - \"Comprami\" (1979), du canon de la pop italienne.",
       "fun_fact_nl": "Viola Valentino - \"Comprami\" (1979), uit de Italiaanse popcanon.",
+      "isrc": "ITR000790051",
       "uri_apple_music": "applemusic://track/1566314670",
       "uri_deezer": "deezer://track/1365061732"
     },
@@ -917,6 +969,7 @@
       "fun_fact_es": "Edoardo Bennato - \"L'isola che non c'è\" (1980), del canon del pop italiano.",
       "fun_fact_fr": "Edoardo Bennato - \"L'isola che non c'è\" (1980), du canon de la pop italienne.",
       "fun_fact_nl": "Edoardo Bennato - \"L'isola che non c'è\" (1980), uit de Italiaanse popcanon.",
+      "isrc": "ITB008070520",
       "uri_apple_music": "applemusic://track/254250128",
       "uri_deezer": "deezer://track/563594"
     },
@@ -934,6 +987,7 @@
       "fun_fact_es": "Gianni Togni - \"Luna - Remastered\" (1980), del canon del pop italiano.",
       "fun_fact_fr": "Gianni Togni - \"Luna - Remastered\" (1980), du canon de la pop italienne.",
       "fun_fact_nl": "Gianni Togni - \"Luna - Remastered\" (1980), uit de Italiaanse popcanon.",
+      "isrc": "ITR001300280",
       "uri_apple_music": "applemusic://track/802854272",
       "uri_deezer": "deezer://track/74398004"
     },
@@ -951,6 +1005,7 @@
       "fun_fact_es": "Gianni Togni - \"Luna\" (1980), del canon del pop italiano. Publicada por Durium.",
       "fun_fact_fr": "Gianni Togni - \"Luna\" (1980), du canon de la pop italienne. Publiee chez Durium.",
       "fun_fact_nl": "Gianni Togni - \"Luna\" (1980), uit de Italiaanse popcanon. Uitgebracht bij Durium.",
+      "isrc": "ITR008000451",
       "uri_apple_music": "applemusic://track/40638155",
       "uri_deezer": "deezer://track/783591"
     },
@@ -968,6 +1023,7 @@
       "fun_fact_es": "Lucio Battisti - \"Con il nastro rosa\" (1980), del canon del pop italiano.",
       "fun_fact_fr": "Lucio Battisti - \"Con il nastro rosa\" (1980), du canon de la pop italienne.",
       "fun_fact_nl": "Lucio Battisti - \"Con il nastro rosa\" (1980), uit de Italiaanse popcanon.",
+      "isrc": "ITB001700471",
       "uri_apple_music": "applemusic://track/1480764203",
       "uri_deezer": "deezer://track/764164492"
     },
@@ -985,6 +1041,7 @@
       "fun_fact_es": "Raffaella Carrà - \"Pedro\" (1980), del canon del pop italiano.",
       "fun_fact_fr": "Raffaella Carrà - \"Pedro\" (1980), du canon de la pop italienne.",
       "fun_fact_nl": "Raffaella Carrà - \"Pedro\" (1980), uit de Italiaanse popcanon.",
+      "isrc": "ITM009900696",
       "uri_apple_music": "applemusic://track/1692974548",
       "uri_deezer": "deezer://track/15255911"
     },
@@ -1002,6 +1059,7 @@
       "fun_fact_es": "Vasco Rossi - \"Non l'hai mica capito - Remastered 2020\" (1980), del canon del pop italiano. Publicada por Targa come unici estratti dall'album.",
       "fun_fact_fr": "Vasco Rossi - \"Non l'hai mica capito - Remastered 2020\" (1980), du canon de la pop italienne. Publiee chez Targa come unici estratti dall'album.",
       "fun_fact_nl": "Vasco Rossi - \"Non l'hai mica capito - Remastered 2020\" (1980), uit de Italiaanse popcanon. Uitgebracht bij Targa come unici estratti dall'album.",
+      "isrc": "ITB002000300",
       "uri_apple_music": "applemusic://track/1539965277",
       "uri_deezer": "deezer://track/1139477612"
     },
@@ -1019,6 +1077,7 @@
       "fun_fact_es": "Claudio Baglioni - \"Strada facendo\" (1981), del canon del pop italiano.",
       "fun_fact_fr": "Claudio Baglioni - \"Strada facendo\" (1981), du canon de la pop italienne.",
       "fun_fact_nl": "Claudio Baglioni - \"Strada facendo\" (1981), uit de Italiaanse popcanon.",
+      "isrc": "ITM000102727",
       "uri_apple_music": "applemusic://track/580231736",
       "uri_deezer": "deezer://track/576311"
     },
@@ -1036,6 +1095,7 @@
       "fun_fact_es": "Claudio Baglioni - \"Via\" (1981), del canon del pop italiano. Aparecio en el album Strada facendo.",
       "fun_fact_fr": "Claudio Baglioni - \"Via\" (1981), du canon de la pop italienne. Parue sur l album Strada facendo.",
       "fun_fact_nl": "Claudio Baglioni - \"Via\" (1981), uit de Italiaanse popcanon. Verscheen op het album Strada facendo.",
+      "isrc": "ITM000102735",
       "uri_apple_music": "applemusic://track/1344888781",
       "uri_deezer": "deezer://track/461326012"
     },
@@ -1053,6 +1113,7 @@
       "fun_fact_es": "Eduardo De Crescenzo - \"Ancora\" (1981), del canon del pop italiano. Presentada en el Festival de Sanremo.",
       "fun_fact_fr": "Eduardo De Crescenzo - \"Ancora\" (1981), du canon de la pop italienne. Presentee au Festival de Sanremo.",
       "fun_fact_nl": "Eduardo De Crescenzo - \"Ancora\" (1981), uit de Italiaanse popcanon. Gepresenteerd op het Sanremo-festival.",
+      "isrc": "ITB008170506",
       "uri_apple_music": "applemusic://track/471571745",
       "uri_deezer": "deezer://track/1020054"
     },
@@ -1070,6 +1131,7 @@
       "fun_fact_es": "Franco Battiato - \"Centro Di Gravità Permanente - Remastered 2021\" (1981), del canon del pop italiano. Escrita por Franco Battiato e Giusto Pio.",
       "fun_fact_fr": "Franco Battiato - \"Centro Di Gravità Permanente - Remastered 2021\" (1981), du canon de la pop italienne. Ecrite par Franco Battiato e Giusto Pio.",
       "fun_fact_nl": "Franco Battiato - \"Centro Di Gravità Permanente - Remastered 2021\" (1981), uit de Italiaanse popcanon. Geschreven door Franco Battiato e Giusto Pio.",
+      "isrc": "ITUM72001391",
       "uri_apple_music": "applemusic://track/1568083647",
       "uri_deezer": "deezer://track/1375685872"
     },
@@ -1087,6 +1149,7 @@
       "fun_fact_es": "Franco Battiato - \"Cuccurucucù - Mix 2015\" (1981), del canon del pop italiano.",
       "fun_fact_fr": "Franco Battiato - \"Cuccurucucù - Mix 2015\" (1981), du canon de la pop italienne.",
       "fun_fact_nl": "Franco Battiato - \"Cuccurucucù - Mix 2015\" (1981), uit de Italiaanse popcanon.",
+      "isrc": "ITUM71501136",
       "uri_apple_music": "applemusic://track/1440850093",
       "uri_deezer": "deezer://track/112658532"
     },
@@ -1104,6 +1167,7 @@
       "fun_fact_es": "Franco Battiato - \"Cuccurucucù - Remastered\" (1981), del canon del pop italiano.",
       "fun_fact_fr": "Franco Battiato - \"Cuccurucucù - Remastered\" (1981), du canon de la pop italienne.",
       "fun_fact_nl": "Franco Battiato - \"Cuccurucucù - Remastered\" (1981), uit de Italiaanse popcanon.",
+      "isrc": "ITUM72001395",
       "uri_apple_music": "applemusic://track/1568083642",
       "uri_deezer": "deezer://track/1375685852"
     },
@@ -1121,6 +1185,7 @@
       "fun_fact_es": "Loretta Goggi - \"Maledetta primavera\" (1981), del canon del pop italiano. Escrita por Amerigo Cassella. Presentada en el Festival de Sanremo. Aparecio en el album Il mio prossimo amore.",
       "fun_fact_fr": "Loretta Goggi - \"Maledetta primavera\" (1981), du canon de la pop italienne. Ecrite par Amerigo Cassella. Presentee au Festival de Sanremo. Parue sur l album Il mio prossimo amore.",
       "fun_fact_nl": "Loretta Goggi - \"Maledetta primavera\" (1981), uit de Italiaanse popcanon. Geschreven door Amerigo Cassella. Gepresenteerd op het Sanremo-festival. Verscheen op het album Il mio prossimo amore.",
+      "isrc": "ITQ008100011",
       "uri_apple_music": "applemusic://track/698668560",
       "uri_deezer": "deezer://track/4090061"
     },
@@ -1138,6 +1203,7 @@
       "fun_fact_es": "Marcella Bella - \"Canto Straniero\" (1981), del canon del pop italiano.",
       "fun_fact_fr": "Marcella Bella - \"Canto Straniero\" (1981), du canon de la pop italienne.",
       "fun_fact_nl": "Marcella Bella - \"Canto Straniero\" (1981), uit de Italiaanse popcanon.",
+      "isrc": "ITD569502113",
       "uri_apple_music": "applemusic://track/311418744",
       "uri_deezer": "deezer://track/3939671"
     },
@@ -1155,6 +1221,7 @@
       "fun_fact_es": "Pooh - \"Chi fermerà la musica\" (1981), del canon del pop italiano.",
       "fun_fact_fr": "Pooh - \"Chi fermerà la musica\" (1981), du canon de la pop italienne.",
       "fun_fact_nl": "Pooh - \"Chi fermerà la musica\" (1981), uit de Italiaanse popcanon.",
+      "isrc": "ITR001400033",
       "uri_apple_music": "applemusic://track/953251717",
       "uri_deezer": "deezer://track/124637076"
     },
@@ -1172,6 +1239,7 @@
       "fun_fact_es": "Ricchi E Poveri - \"Come vorrei\" (1981), del canon del pop italiano.",
       "fun_fact_fr": "Ricchi E Poveri - \"Come vorrei\" (1981), du canon de la pop italienne.",
       "fun_fact_nl": "Ricchi E Poveri - \"Come vorrei\" (1981), uit de Italiaanse popcanon.",
+      "isrc": "DEC719400068",
       "uri_apple_music": "applemusic://track/285797622",
       "uri_deezer": "deezer://track/636412"
     },
@@ -1189,6 +1257,7 @@
       "fun_fact_es": "Al Bano - \"Felicità\" (1982), del canon del pop italiano.",
       "fun_fact_fr": "Al Bano - \"Felicità\" (1982), du canon de la pop italienne.",
       "fun_fact_nl": "Al Bano - \"Felicità\" (1982), uit de Italiaanse popcanon.",
+      "isrc": "ITG830800001",
       "uri_apple_music": "applemusic://track/298583321",
       "uri_deezer": "deezer://track/4033476791"
     },
@@ -1206,6 +1275,7 @@
       "fun_fact_es": "Claudia Mori, Adriano Celentano - \"Non Succederà Più - Remastered 2009\" (1982), del canon del pop italiano.",
       "fun_fact_fr": "Claudia Mori, Adriano Celentano - \"Non Succederà Più - Remastered 2009\" (1982), du canon de la pop italienne.",
       "fun_fact_nl": "Claudia Mori, Adriano Celentano - \"Non Succederà Più - Remastered 2009\" (1982), uit de Italiaanse popcanon.",
+      "isrc": "ITR050900002",
       "uri_apple_music": "applemusic://track/1784627055"
     },
     {
@@ -1222,6 +1292,7 @@
       "fun_fact_es": "Claudio Baglioni - \"Avrai\" (1982), del canon del pop italiano.",
       "fun_fact_fr": "Claudio Baglioni - \"Avrai\" (1982), du canon de la pop italienne.",
       "fun_fact_nl": "Claudio Baglioni - \"Avrai\" (1982), uit de Italiaanse popcanon.",
+      "isrc": "ITB000500792",
       "uri_apple_music": "applemusic://track/1344888786",
       "uri_deezer": "deezer://track/461326062"
     },
@@ -1239,6 +1310,7 @@
       "fun_fact_es": "Franco Battiato - \"Voglio Vederti Danzare - Remastered\" (1982), del canon del pop italiano.",
       "fun_fact_fr": "Franco Battiato - \"Voglio Vederti Danzare - Remastered\" (1982), du canon de la pop italienne.",
       "fun_fact_nl": "Franco Battiato - \"Voglio Vederti Danzare - Remastered\" (1982), uit de Italiaanse popcanon.",
+      "isrc": "ITD000800109",
       "uri_apple_music": "applemusic://track/713520078",
       "uri_deezer": "deezer://track/3464233"
     },
@@ -1256,6 +1328,7 @@
       "fun_fact_es": "Loredana Bertè - \"Non sono una signora\" (1982), del canon del pop italiano.",
       "fun_fact_fr": "Loredana Bertè - \"Non sono una signora\" (1982), du canon de la pop italienne.",
       "fun_fact_nl": "Loredana Bertè - \"Non sono una signora\" (1982), uit de Italiaanse popcanon.",
+      "isrc": "ITR008200751",
       "uri_apple_music": "applemusic://track/79323055",
       "uri_deezer": "deezer://track/742432"
     },
@@ -1273,6 +1346,7 @@
       "fun_fact_es": "Loretta Goggi - \"Pieno d'amore\" (1982), del canon del pop italiano.",
       "fun_fact_fr": "Loretta Goggi - \"Pieno d'amore\" (1982), du canon de la pop italienne.",
       "fun_fact_nl": "Loretta Goggi - \"Pieno d'amore\" (1982), uit de Italiaanse popcanon.",
+      "isrc": "ITQ008200021",
       "uri_apple_music": "applemusic://track/698668554",
       "uri_deezer": "deezer://track/70331701"
     },
@@ -1290,6 +1364,7 @@
       "fun_fact_es": "Mia Martini - \"E non finisce mica il cielo\" (1982), del canon del pop italiano. Publicada por DDD nel 1982.",
       "fun_fact_fr": "Mia Martini - \"E non finisce mica il cielo\" (1982), du canon de la pop italienne. Publiee chez DDD nel 1982.",
       "fun_fact_nl": "Mia Martini - \"E non finisce mica il cielo\" (1982), uit de Italiaanse popcanon. Uitgebracht bij DDD nel 1982.",
+      "isrc": "ITB008200759",
       "uri_apple_music": "applemusic://track/408273025",
       "uri_deezer": "deezer://track/3803029202"
     },
@@ -1307,6 +1382,7 @@
       "fun_fact_es": "Raffaella Carrà - \"Ballo, ballo\" (1982), del canon del pop italiano.",
       "fun_fact_fr": "Raffaella Carrà - \"Ballo, ballo\" (1982), du canon de la pop italienne.",
       "fun_fact_nl": "Raffaella Carrà - \"Ballo, ballo\" (1982), uit de Italiaanse popcanon.",
+      "isrc": "ES5151401337",
       "uri_apple_music": "applemusic://track/1692975052",
       "uri_deezer": "deezer://track/2842211102"
     },
@@ -1324,6 +1400,7 @@
       "fun_fact_es": "Riccardo Cocciante - \"Celeste nostalgia\" (1982), del canon del pop italiano.",
       "fun_fact_fr": "Riccardo Cocciante - \"Celeste nostalgia\" (1982), du canon de la pop italienne.",
       "fun_fact_nl": "Riccardo Cocciante - \"Celeste nostalgia\" (1982), uit de Italiaanse popcanon.",
+      "isrc": "ITB008100768",
       "uri_apple_music": "applemusic://track/254296736",
       "uri_deezer": "deezer://track/13230004"
     },
@@ -1341,6 +1418,7 @@
       "fun_fact_es": "Riccardo Fogli - \"Storie di tutti i giorni\" (1982), del canon del pop italiano.",
       "fun_fact_fr": "Riccardo Fogli - \"Storie di tutti i giorni\" (1982), du canon de la pop italienne.",
       "fun_fact_nl": "Riccardo Fogli - \"Storie di tutti i giorni\" (1982), uit de Italiaanse popcanon.",
+      "isrc": "ITR008200471",
       "uri_apple_music": "applemusic://track/1453582477",
       "uri_deezer": "deezer://track/755986"
     },
@@ -1358,6 +1436,7 @@
       "fun_fact_es": "Ricchi E Poveri - \"Mamma Maria\" (1982), del canon del pop italiano.",
       "fun_fact_fr": "Ricchi E Poveri - \"Mamma Maria\" (1982), du canon de la pop italienne.",
       "fun_fact_nl": "Ricchi E Poveri - \"Mamma Maria\" (1982), uit de Italiaanse popcanon.",
+      "isrc": "DEC719400065",
       "uri_apple_music": "applemusic://track/252058369",
       "uri_deezer": "deezer://track/636403"
     },
@@ -1375,6 +1454,7 @@
       "fun_fact_es": "Vasco Rossi - \"Ogni volta\" (1982), del canon del pop italiano.",
       "fun_fact_fr": "Vasco Rossi - \"Ogni volta\" (1982), du canon de la pop italienne.",
       "fun_fact_nl": "Vasco Rossi - \"Ogni volta\" (1982), uit de Italiaanse popcanon.",
+      "isrc": "ITB260401560",
       "uri_apple_music": "applemusic://track/1327847262",
       "uri_deezer": "deezer://track/104725328"
     },
@@ -1392,6 +1472,7 @@
       "fun_fact_es": "Fiordaliso - \"Non voglio mica la luna\" (1983), del canon del pop italiano. Publicada por Durium nel 1984.",
       "fun_fact_fr": "Fiordaliso - \"Non voglio mica la luna\" (1983), du canon de la pop italienne. Publiee chez Durium nel 1984.",
       "fun_fact_nl": "Fiordaliso - \"Non voglio mica la luna\" (1983), uit de Italiaanse popcanon. Uitgebracht bij Durium nel 1984.",
+      "isrc": "ITB008670575",
       "uri_apple_music": "applemusic://track/255738823",
       "uri_deezer": "deezer://track/1017423"
     },
@@ -1409,6 +1490,7 @@
       "fun_fact_es": "Franco Battiato - \"La Stagione Dell'Amore - Remastered 2008\" (1983), del canon del pop italiano.",
       "fun_fact_fr": "Franco Battiato - \"La Stagione Dell'Amore - Remastered 2008\" (1983), du canon de la pop italienne.",
       "fun_fact_nl": "Franco Battiato - \"La Stagione Dell'Amore - Remastered 2008\" (1983), uit de Italiaanse popcanon.",
+      "isrc": "ITD000800110",
       "uri_apple_music": "applemusic://track/1606898557",
       "uri_deezer": "deezer://track/3464234"
     },
@@ -1426,6 +1508,7 @@
       "fun_fact_es": "Loredana Bertè - \"Il mare d'inverno\" (1983), del canon del pop italiano.",
       "fun_fact_fr": "Loredana Bertè - \"Il mare d'inverno\" (1983), du canon de la pop italienne.",
       "fun_fact_nl": "Loredana Bertè - \"Il mare d'inverno\" (1983), uit de Italiaanse popcanon.",
+      "isrc": "ITM009901369",
       "uri_apple_music": "applemusic://track/671755909",
       "uri_deezer": "deezer://track/62912666"
     },
@@ -1443,6 +1526,7 @@
       "fun_fact_es": "Lu Colombo - \"Maracaibo\" (1983), del canon del pop italiano.",
       "fun_fact_fr": "Lu Colombo - \"Maracaibo\" (1983), du canon de la pop italienne.",
       "fun_fact_nl": "Lu Colombo - \"Maracaibo\" (1983), uit de Italiaanse popcanon.",
+      "isrc": "ITD008400017",
       "uri_apple_music": "applemusic://track/405021856",
       "uri_deezer": "deezer://track/3541677"
     },
@@ -1460,6 +1544,7 @@
       "fun_fact_es": "Nada - \"Amore Disperato - 2004 Remaster\" (1983), del canon del pop italiano.",
       "fun_fact_fr": "Nada - \"Amore Disperato - 2004 Remaster\" (1983), du canon de la pop italienne.",
       "fun_fact_nl": "Nada - \"Amore Disperato - 2004 Remaster\" (1983), uit de Italiaanse popcanon.",
+      "isrc": "ITD000400067",
       "uri_apple_music": "applemusic://track/1647071573",
       "uri_deezer": "deezer://track/3327907"
     },
@@ -1477,6 +1562,7 @@
       "fun_fact_es": "Toto Cutugno - \"Solo noi\" (1983), del canon del pop italiano. Presentada en el Festival de Sanremo.",
       "fun_fact_fr": "Toto Cutugno - \"Solo noi\" (1983), du canon de la pop italienne. Presentee au Festival de Sanremo.",
       "fun_fact_nl": "Toto Cutugno - \"Solo noi\" (1983), uit de Italiaanse popcanon. Gepresenteerd op het Sanremo-festival.",
+      "isrc": "ITB268000030",
       "uri_apple_music": "applemusic://track/1329256168",
       "uri_deezer": "deezer://track/104724380"
     },
@@ -1494,6 +1580,7 @@
       "fun_fact_es": "Eros Ramazzotti - \"Adesso tu\" (1984), del canon del pop italiano. Presentada en el Festival de Sanremo.",
       "fun_fact_fr": "Eros Ramazzotti - \"Adesso tu\" (1984), du canon de la pop italienne. Presentee au Festival de Sanremo.",
       "fun_fact_nl": "Eros Ramazzotti - \"Adesso tu\" (1984), uit de Italiaanse popcanon. Gepresenteerd op het Sanremo-festival.",
+      "isrc": "ITB008671030",
       "uri_apple_music": "applemusic://track/254548552",
       "uri_deezer": "deezer://track/87677323"
     },
@@ -1511,6 +1598,7 @@
       "fun_fact_es": "Gianni Togni - \"Giulia\" (1984), del canon del pop italiano.",
       "fun_fact_fr": "Gianni Togni - \"Giulia\" (1984), du canon de la pop italienne.",
       "fun_fact_nl": "Gianni Togni - \"Giulia\" (1984), uit de Italiaanse popcanon.",
+      "isrc": "ITR008400501",
       "uri_apple_music": "applemusic://track/79354753",
       "uri_deezer": "deezer://track/818877"
     },
@@ -1528,6 +1616,7 @@
       "fun_fact_es": "Gianni Morandi - \"Uno su mille\" (1985), del canon del pop italiano. Publicada por RCA Italiana.",
       "fun_fact_fr": "Gianni Morandi - \"Uno su mille\" (1985), du canon de la pop italienne. Publiee chez RCA Italiana.",
       "fun_fact_nl": "Gianni Morandi - \"Uno su mille\" (1985), uit de Italiaanse popcanon. Uitgebracht bij RCA Italiana.",
+      "isrc": "ITB008500294",
       "uri_apple_music": "applemusic://track/796510429",
       "uri_deezer": "deezer://track/74189254"
     },
@@ -1545,6 +1634,7 @@
       "fun_fact_es": "Vasco Rossi - \"T'immagini\" (1985), del canon del pop italiano. Aparecio en el album del 1985 Cosa succede in città.",
       "fun_fact_fr": "Vasco Rossi - \"T'immagini\" (1985), du canon de la pop italienne. Parue sur l album del 1985 Cosa succede in città.",
       "fun_fact_nl": "Vasco Rossi - \"T'immagini\" (1985), uit de Italiaanse popcanon. Verscheen op het album del 1985 Cosa succede in città.",
+      "isrc": "ITB260401670",
       "uri_apple_music": "applemusic://track/1327592526",
       "uri_deezer": "deezer://track/104726588"
     },
@@ -1562,6 +1652,7 @@
       "fun_fact_es": "Lucio Dalla - \"Caruso\" (1986), del canon del pop italiano.",
       "fun_fact_fr": "Lucio Dalla - \"Caruso\" (1986), du canon de la pop italienne.",
       "fun_fact_nl": "Lucio Dalla - \"Caruso\" (1986), uit de Italiaanse popcanon.",
+      "isrc": "ITB008600207",
       "uri_apple_music": "applemusic://track/200934554",
       "uri_deezer": "deezer://track/972492"
     },
@@ -1579,6 +1670,7 @@
       "fun_fact_es": "Toto Cutugno - \"Serenata\" (1986), del canon del pop italiano.",
       "fun_fact_fr": "Toto Cutugno - \"Serenata\" (1986), du canon de la pop italienne.",
       "fun_fact_nl": "Toto Cutugno - \"Serenata\" (1986), uit de Italiaanse popcanon.",
+      "isrc": "ITB268405760",
       "uri_apple_music": "applemusic://track/1329247255",
       "uri_deezer": "deezer://track/104724382"
     },
@@ -1596,6 +1688,7 @@
       "fun_fact_es": "Gianna Nannini - \"I maschi\" (1987), del canon del pop italiano.",
       "fun_fact_fr": "Gianna Nannini - \"I maschi\" (1987), du canon de la pop italienne.",
       "fun_fact_nl": "Gianna Nannini - \"I maschi\" (1987), uit de Italiaanse popcanon.",
+      "isrc": "ITB000900945",
       "uri_apple_music": "applemusic://track/6768669894",
       "uri_deezer": "deezer://track/88193681"
     },
@@ -1613,6 +1706,7 @@
       "fun_fact_es": "Mango - \"Bella d'estate\" (1987), del canon del pop italiano.",
       "fun_fact_fr": "Mango - \"Bella d'estate\" (1987), du canon de la pop italienne.",
       "fun_fact_nl": "Mango - \"Bella d'estate\" (1987), uit de Italiaanse popcanon.",
+      "isrc": "ITD018700009",
       "uri_apple_music": "applemusic://track/486352644",
       "uri_deezer": "deezer://track/69025912"
     },
@@ -1630,6 +1724,7 @@
       "fun_fact_es": "Anna Oxa - \"Quando nasce un amore\" (1988), del canon del pop italiano. Presentada en el Festival de Sanremo. Aparecio en el album della cantante Pensami per te.",
       "fun_fact_fr": "Anna Oxa - \"Quando nasce un amore\" (1988), du canon de la pop italienne. Presentee au Festival de Sanremo. Parue sur l album della cantante Pensami per te.",
       "fun_fact_nl": "Anna Oxa - \"Quando nasce un amore\" (1988), uit de Italiaanse popcanon. Gepresenteerd op het Sanremo-festival. Verscheen op het album della cantante Pensami per te.",
+      "isrc": "ITM009700600",
       "uri_apple_music": "applemusic://track/819376891",
       "uri_deezer": "deezer://track/69008453"
     },
@@ -1647,6 +1742,7 @@
       "fun_fact_es": "Antonello Venditti - \"Ricordati di me\" (1988), del canon del pop italiano.",
       "fun_fact_fr": "Antonello Venditti - \"Ricordati di me\" (1988), du canon de la pop italienne.",
       "fun_fact_nl": "Antonello Venditti - \"Ricordati di me\" (1988), uit de Italiaanse popcanon.",
+      "isrc": "ITG028800001",
       "uri_apple_music": "applemusic://track/304341668",
       "uri_deezer": "deezer://track/566798"
     },
@@ -1664,6 +1760,7 @@
       "fun_fact_es": "Massimo Ranieri - \"Perdere l'amore\" (1988), del canon del pop italiano. Presentada en el Festival de Sanremo.",
       "fun_fact_fr": "Massimo Ranieri - \"Perdere l'amore\" (1988), du canon de la pop italienne. Presentee au Festival de Sanremo.",
       "fun_fact_nl": "Massimo Ranieri - \"Perdere l'amore\" (1988), uit de Italiaanse popcanon. Gepresenteerd op het Sanremo-festival.",
+      "isrc": "ITQ008800011",
       "uri_apple_music": "applemusic://track/79281601",
       "uri_deezer": "deezer://track/661313"
     },
@@ -1681,6 +1778,7 @@
       "fun_fact_es": "Anna Oxa, Fausto Leali - \"Ti lascerò\" (1989), del canon del pop italiano.",
       "fun_fact_fr": "Anna Oxa, Fausto Leali - \"Ti lascerò\" (1989), du canon de la pop italienne.",
       "fun_fact_nl": "Anna Oxa, Fausto Leali - \"Ti lascerò\" (1989), uit de Italiaanse popcanon.",
+      "isrc": "ITM009700604",
       "uri_apple_music": "applemusic://track/335971114"
     },
     {
@@ -1697,6 +1795,7 @@
       "fun_fact_es": "Lorella Cuccarini - \"La notte vola\" (1989), del canon del pop italiano.",
       "fun_fact_fr": "Lorella Cuccarini - \"La notte vola\" (1989), du canon de la pop italienne.",
       "fun_fact_nl": "Lorella Cuccarini - \"La notte vola\" (1989), uit de Italiaanse popcanon.",
+      "isrc": "ITZ038901253",
       "uri_apple_music": "applemusic://track/518297844",
       "uri_deezer": "deezer://track/18226796"
     },
@@ -1714,6 +1813,7 @@
       "fun_fact_es": "Mia Martini - \"Almeno tu nell'universo\" (1989), del canon del pop italiano.",
       "fun_fact_fr": "Mia Martini - \"Almeno tu nell'universo\" (1989), du canon de la pop italienne.",
       "fun_fact_nl": "Mia Martini - \"Almeno tu nell'universo\" (1989), uit de Italiaanse popcanon.",
+      "isrc": "ITB551110730",
       "uri_apple_music": "applemusic://track/1616014496",
       "uri_deezer": "deezer://track/1696872787"
     },
@@ -1731,6 +1831,7 @@
       "fun_fact_es": "Mia Martini - \"Gli Uomini Non Cambiano\" (1992), del canon del pop italiano.",
       "fun_fact_fr": "Mia Martini - \"Gli Uomini Non Cambiano\" (1992), du canon de la pop italienne.",
       "fun_fact_nl": "Mia Martini - \"Gli Uomini Non Cambiano\" (1992), uit de Italiaanse popcanon.",
+      "isrc": "ITB551110740",
       "uri_apple_music": "applemusic://track/1616019807",
       "uri_deezer": "deezer://track/1696905227"
     },
@@ -1748,6 +1849,7 @@
       "fun_fact_es": "883 - \"Come mai\" (1993), del canon del pop italiano.",
       "fun_fact_fr": "883 - \"Come mai\" (1993), du canon de la pop italienne.",
       "fun_fact_nl": "883 - \"Come mai\" (1993), uit de Italiaanse popcanon.",
+      "isrc": "ITQ000000822",
       "uri_apple_music": "applemusic://track/63831617",
       "uri_deezer": "deezer://track/766655"
     },
@@ -1765,6 +1867,7 @@
       "fun_fact_es": "Michele Zarrillo - \"Cinque giorni\" (1994), del canon del pop italiano.",
       "fun_fact_fr": "Michele Zarrillo - \"Cinque giorni\" (1994), du canon de la pop italienne.",
       "fun_fact_nl": "Michele Zarrillo - \"Cinque giorni\" (1994), uit de Italiaanse popcanon.",
+      "isrc": "ITB219900158",
       "uri_apple_music": "applemusic://track/271725260",
       "uri_deezer": "deezer://track/2455279"
     },
@@ -1782,6 +1885,7 @@
       "fun_fact_es": "Franco Battiato - \"La Cura\" (1996), del canon del pop italiano. Publicada por Mercury Records come estratto dall'a.",
       "fun_fact_fr": "Franco Battiato - \"La Cura\" (1996), du canon de la pop italienne. Publiee chez Mercury Records come estratto dall'a.",
       "fun_fact_nl": "Franco Battiato - \"La Cura\" (1996), uit de Italiaanse popcanon. Uitgebracht bij Mercury Records come estratto dall'a.",
+      "isrc": "IT7009609320",
       "uri_apple_music": "applemusic://track/1443744077",
       "uri_deezer": "deezer://track/2432922"
     },
@@ -1799,6 +1903,7 @@
       "fun_fact_es": "Ornella Vanoni - \"L'appuntamento\" (1996), del canon del pop italiano.",
       "fun_fact_fr": "Ornella Vanoni - \"L'appuntamento\" (1996), du canon de la pop italienne.",
       "fun_fact_nl": "Ornella Vanoni - \"L'appuntamento\" (1996), uit de Italiaanse popcanon.",
+      "isrc": "ITB007071645",
       "uri_apple_music": "applemusic://track/254168669",
       "uri_deezer": "deezer://track/564219"
     },
@@ -1816,6 +1921,7 @@
       "fun_fact_es": "Vasco Rossi - \"Sally\" (1996), del canon del pop italiano. Escrita por Vasco Rossi. Aparecio en el album Nessun pericolo.",
       "fun_fact_fr": "Vasco Rossi - \"Sally\" (1996), du canon de la pop italienne. Ecrite par Vasco Rossi. Parue sur l album Nessun pericolo.",
       "fun_fact_nl": "Vasco Rossi - \"Sally\" (1996), uit de Italiaanse popcanon. Geschreven door Vasco Rossi. Verscheen op het album Nessun pericolo.",
+      "isrc": "ITUM71700273",
       "uri_apple_music": "applemusic://track/1443087171",
       "uri_deezer": "deezer://track/358728991"
     },
@@ -1833,6 +1939,7 @@
       "fun_fact_es": "MINACELENTANO - \"Acqua e sale\" (1998), del canon del pop italiano.",
       "fun_fact_fr": "MINACELENTANO - \"Acqua e sale\" (1998), du canon de la pop italienne.",
       "fun_fact_nl": "MINACELENTANO - \"Acqua e sale\" (1998), uit de Italiaanse popcanon.",
+      "isrc": "CH1439800020",
       "uri_apple_music": "applemusic://track/1719308553",
       "uri_deezer": "deezer://track/2095901487"
     },
@@ -1850,6 +1957,7 @@
       "fun_fact_es": "Vasco Rossi - \"Rewind - Radio Edit\" (1998), del canon del pop italiano.",
       "fun_fact_fr": "Vasco Rossi - \"Rewind - Radio Edit\" (1998), du canon de la pop italienne.",
       "fun_fact_nl": "Vasco Rossi - \"Rewind - Radio Edit\" (1998), uit de Italiaanse popcanon.",
+      "isrc": "ITD009900052",
       "uri_apple_music": "applemusic://track/1443191612",
       "uri_deezer": "deezer://track/3211478"
     },
@@ -1867,6 +1975,7 @@
       "fun_fact_es": "Adriano Celentano - \"L'Emozione Non Ha voce (Io Non So Parlar D'Amore)\" (1999), del canon del pop italiano. Escrita por Mogol.",
       "fun_fact_fr": "Adriano Celentano - \"L'Emozione Non Ha voce (Io Non So Parlar D'Amore)\" (1999), du canon de la pop italienne. Ecrite par Mogol.",
       "fun_fact_nl": "Adriano Celentano - \"L'Emozione Non Ha voce (Io Non So Parlar D'Amore)\" (1999), uit de Italiaanse popcanon. Geschreven door Mogol.",
+      "isrc": "ITR059900002",
       "uri_apple_music": "applemusic://track/1702255790",
       "uri_deezer": "deezer://track/2407440395"
     },
@@ -1884,6 +1993,7 @@
       "fun_fact_es": "Loretta Goggi - \"L'aria del sabato sera\" (2000), del canon del pop italiano.",
       "fun_fact_fr": "Loretta Goggi - \"L'aria del sabato sera\" (2000), du canon de la pop italienne.",
       "fun_fact_nl": "Loretta Goggi - \"L'aria del sabato sera\" (2000), uit de Italiaanse popcanon.",
+      "isrc": "ITQ007900231",
       "uri_apple_music": "applemusic://track/698668390",
       "uri_deezer": "deezer://track/4090058"
     },
@@ -1901,6 +2011,7 @@
       "fun_fact_es": "Gigi D'Alessio - \"Mon amour\" (2001), del canon del pop italiano.",
       "fun_fact_fr": "Gigi D'Alessio - \"Mon amour\" (2001), du canon de la pop italienne.",
       "fun_fact_nl": "Gigi D'Alessio - \"Mon amour\" (2001), uit de Italiaanse popcanon.",
+      "isrc": "ITB000100006",
       "uri_apple_music": "applemusic://track/265973220",
       "uri_deezer": "deezer://track/418533452"
     },
@@ -1918,6 +2029,7 @@
       "fun_fact_es": "Gigi D'Alessio, Anna Tatangelo - \"Un nuovo bacio\" (2002), del canon del pop italiano.",
       "fun_fact_fr": "Gigi D'Alessio, Anna Tatangelo - \"Un nuovo bacio\" (2002), du canon de la pop italienne.",
       "fun_fact_nl": "Gigi D'Alessio, Anna Tatangelo - \"Un nuovo bacio\" (2002), uit de Italiaanse popcanon.",
+      "isrc": "ITB000200156",
       "uri_apple_music": "applemusic://track/1308882452"
     },
     {
@@ -1934,6 +2046,7 @@
       "fun_fact_es": "Vasco Rossi - \"Un Senso\" (2004), del canon del pop italiano.",
       "fun_fact_fr": "Vasco Rossi - \"Un Senso\" (2004), du canon de la pop italienne.",
       "fun_fact_nl": "Vasco Rossi - \"Un Senso\" (2004), uit de Italiaanse popcanon.",
+      "isrc": "ITD000400186",
       "uri_apple_music": "applemusic://track/1443213440",
       "uri_deezer": "deezer://track/135876550"
     },
@@ -1951,6 +2064,7 @@
       "fun_fact_es": "Gianni Nazzaro - \"Quando L'Amore Diventa Poesía\" (2007), del canon del pop italiano.",
       "fun_fact_fr": "Gianni Nazzaro - \"Quando L'Amore Diventa Poesía\" (2007), du canon de la pop italienne.",
       "fun_fact_nl": "Gianni Nazzaro - \"Quando L'Amore Diventa Poesía\" (2007), uit de Italiaanse popcanon.",
+      "isrc": null,
       "uri_apple_music": "applemusic://track/1780787742"
     }
   ],


### PR DESCRIPTION
Fills the `isrc` field on `playlists/community/musica-italiana.json`, which was empty for all 114 songs. `version` 0.5 → 0.6.

**Rebased onto #2236.** That PR raised `uri_deezer` from 46 to 110, so the ISRCs here were re-derived rather than carried over — see "What the rebase changed" below.

## Result

**113 of 114 filled**, from two paths:

- **110 direct** — the song has a `uri_deezer`, so `GET /track/<id>` returns the ISRC of exactly that track. No matching, no room for error.
- **3 via search** — no `uri_deezer`. Each hit was checked against **both** artist and title before being accepted; a hit failing either check was discarded rather than taken as the best available.

Before the rebase the split was 46 direct / 67 searched. No ISRC appears twice in the file.

## What the rebase changed

Exactly one value, and it was a real correction:

**Al Bano — Felicità** had picked up `USBI10000114` from a search hit credited to *Al Bano & Romina Power*. The Deezer track the catalogue actually links carries `ITG830800001`. The direct value wins — the search had landed on a different release of the same song.

The other 112 came out identical, which is the useful part of the result: it says the search path was not quietly wrong at scale, it was wrong in one place, and the direct path found it.

## Two entries that no longer need a caveat

The pre-rebase version of this PR flagged **Franco Battiato — Cuccurucucù** and **Pooh — Chi fermerà la musica** as search hits that had matched a remaster. Both now resolve through the **direct** path to the same ISRCs (`ITUM72001395`, `ITR001400033`). So those values are not a guess about which recording to pick — they are the ISRC of the Deezer track the catalogue already points at.

If the remaster is the wrong recording for the quiz, that is a pre-existing property of the `uri_deezer` link, not something this PR introduces.

## The one that stayed empty

`Gianni Nazzaro — Quando L'Amore Diventa Poesia` has no ISRC. Deezer carries the artist (ten other tracks come back for the name) but not this recording, under this or a corrected spelling. The field is `null`, not a guess.

## The three remaining search-derived values

| Playlist entry | Deezer match | ISRC |
|---|---|---|
| Claudia Mori, Adriano Celentano — Non Succederà Più - Remastered | Claudia Mori — Non Succederà Più (Remastered 2009) | ITR050900002 |
| Anna Oxa, Fausto Leali — Ti lascerò | Anna Oxa — Ti lascerò | ITM009700604 |
| Gigi D'Alessio, Anna Tatangelo — Un nuovo bacio | Gigi D'Alessio — Un nuovo bacio | ITB000200156 |

All three differ only in a featured-artist credit that Deezer does not carry on the track title.

## Validation

- `python3 -m json.tool` — clean
- `scripts/validate_playlists.py` — `ok custom_components/beatify/playlists/community/musica-italiana.json`
- No duplicate ISRC in the file
- Field coverage after this PR: `uri` 114/114 · `uri_apple_music` 114/114 · `isrc` 113/114 · `uri_deezer` 110/114 · `uri_youtube_music` 16/114

🤖 Generated with [Claude Code](https://claude.com/claude-code)
