### PR TITLE
docs(readme): put the three compatibility gates above the fold

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,20 @@ Guests scan, songs play, everyone competes. It's that simple.
 
 <br>
 
+## Will This Work For Me?
+
+Three things decide it — check them before you install.
+
+- **Home Assistant 2025.1 or newer**
+- **A supported speaker** — Music Assistant (any speaker it drives), Sonos, or Alexa. Chromecast, Nest and HomePod work only through Music Assistant. See [Supported Speakers](#supported-speakers).
+- **A paid music plan** — Spotify, Apple Music, YouTube Music, Tidal, Deezer or Amazon Music. Free tiers can't play a chosen track on demand, so Spotify Free won't work.
+
+Beatify itself is free and runs entirely on your own Home Assistant.
+
+---
+
+<br>
+
 ## What Is Beatify?
 
 **Beatify is an open-source music quiz game for Home Assistant** — a multiplayer music trivia party game that turns your smart speakers into a game show.


### PR DESCRIPTION
## What

Adds a six-line **Will This Work For Me?** section directly after the header block — Home Assistant 2025.1+, a supported speaker, a paid music plan — and leaves everything else untouched.

## Why

GitHub traffic for the last 14 days says the README is the whole funnel:

| path | uniques |
|---|---|
| `/mholzi/beatify` | 92 |
| `/issues` | 8 |
| `/releases` | 6 |
| `/discussions` | 4 |

92 of 127 unique visitors never leave the landing page. Inside that page the install button is at line 60, while the hard condition — *every provider needs a paid plan; free/ad-supported tiers can't play a chosen track on demand, so Spotify Free is blocked* — is at line 619 of 1050. A visitor is asked to install 559 lines before learning whether it can work at all.

Conversion matches that shape: 127 unique visitors in 14 days against **+2** active installs in the same window (HA analytics), while the all-time rate is 17.4/week.

## Honest counter-argument

This can **lower** the install count in the short term, because people without a paid plan will not install in the first place. That is the intent. HA analytics counts *running* instances, so an install that is removed ten minutes later does not survive in the number anyway. The metric to watch is conversion — unique visitors against install delta — with a baseline of 127 / +2 on 2026-08-19.

## Notes

- Cast, Nest and HomePod are named explicitly even though the existing Requirements list omits them; they are the second most common reason Beatify does not work for someone.
- The Requirements section under *Technical Details* is unchanged. This pulls the three exclusion criteria forward, it does not replace them.
- Docs only, no code paths touched.