### PR TITLE
test(i18n): cover Italian with the locale parity guards

### DIFF
--- a/custom_components/beatify/www/js/__tests__/dashboard-b8.test.js
+++ b/custom_components/beatify/www/js/__tests__/dashboard-b8.test.js
@@ -26,7 +26,7 @@ global.window = global.window || {};
 await import('../utils.js');
 const utils = global.window.BeatifyUtils;
 
-const LOCALES = ['en', 'de', 'es', 'fr', 'nl'];
+const LOCALES = ['en', 'de', 'es', 'fr', 'nl', 'it'];
 const i18n = {};
 beforeAll(() => {
     for (const l of LOCALES) {

--- a/custom_components/beatify/www/js/__tests__/dashboard-reconnect.test.js
+++ b/custom_components/beatify/www/js/__tests__/dashboard-reconnect.test.js
@@ -93,7 +93,7 @@ describe('reconnect indicator i18n key (#1578)', () => {
     // (onopen). The badge text is supplied via data-i18n="dashboard.reconnecting"
     // resolved by BeatifyI18n at load — guard that EVERY shipped locale defines
     // the key so no display falls back to the raw key string.
-    const LOCALES = ['en', 'de', 'es', 'fr', 'nl'];
+    const LOCALES = ['en', 'de', 'es', 'fr', 'nl', 'it'];
 
     it('dashboard.reconnecting is present and non-empty in every locale', () => {
         for (const l of LOCALES) {

--- a/custom_components/beatify/www/js/__tests__/seasonal-suggestion.test.js
+++ b/custom_components/beatify/www/js/__tests__/seasonal-suggestion.test.js
@@ -193,17 +193,17 @@ describe('#1570 hub-friendly wiring (wireSeasonalSuggestionHub)', () => {
 });
 
 describe('#1585 data-driven occasions + i18n', () => {
-    const LOCALES = ['en', 'de', 'es', 'fr', 'nl'];
+    const LOCALES = ['en', 'de', 'es', 'fr', 'nl', 'it'];
     const here = path.dirname(fileURLToPath(import.meta.url));
     const i18nDir = path.resolve(here, '../../i18n');
     const locale = (code) =>
         JSON.parse(readFileSync(path.join(i18nDir, `${code}.json`), 'utf8'));
 
     // Shared chrome labels (badge / add / dismiss) + every occasion's reason
-    // key must resolve to a non-empty string in ALL five locales — otherwise
+    // key must resolve to a non-empty string in ALL shipped locales — otherwise
     // tr() would silently fall back to English and a "data-driven" entry would
     // ship untranslated.
-    it('resolves every occasion reasonKey in all 5 locales', () => {
+    it('resolves every occasion reasonKey in every shipped locale', () => {
         for (const code of LOCALES) {
             const admin = locale(code).admin || {};
             for (const o of SEASONAL_OCCASIONS) {
@@ -215,7 +215,7 @@ describe('#1585 data-driven occasions + i18n', () => {
         }
     });
 
-    it('resolves the shared chrome labels in all 5 locales', () => {
+    it('resolves the shared chrome labels in every shipped locale', () => {
         for (const code of LOCALES) {
             const admin = locale(code).admin || {};
             for (const key of ['seasonalBadge', 'seasonalAdd', 'seasonalDismiss']) {

--- a/custom_components/beatify/www/js/__tests__/streak-shield-badge-1666.test.js
+++ b/custom_components/beatify/www/js/__tests__/streak-shield-badge-1666.test.js
@@ -4,7 +4,7 @@
  * `renderPersonalResult` is not exported, so this asserts the wiring at the
  * source level instead of rendering: that both reveal paths consult
  * `streak_shield_used`, that the helper exists, and that the i18n key it uses
- * is present in all five locales. The last one matters more than it looks —
+ * is present in every shipped locale. The last one matters more than it looks —
  * a missing key does not throw, it renders the raw key string into the card.
  */
 
@@ -33,8 +33,8 @@ describe('Streak-Shield badge (#1666)', () => {
         expect(REVEAL).toContain("utils.t('reveal.streakShieldUsed', { streak: streak })");
     });
 
-    it('has the string in all five locales', () => {
-        for (const lang of ['en', 'de', 'es', 'fr', 'nl']) {
+    it('has the string in every shipped locale', () => {
+        for (const lang of ['en', 'de', 'es', 'fr', 'nl', 'it']) {
             const dict = JSON.parse(fs.readFileSync(
                 path.join(ROOT, `www/i18n/${lang}.json`), 'utf8'));
             expect(dict.reveal?.streakShieldUsed, `${lang} missing`).toBeTruthy();

--- a/tests/unit/test_i18n_locale_parity.py
+++ b/tests/unit/test_i18n_locale_parity.py
@@ -1,7 +1,7 @@
 """Key-parity guard for the in-app UI locale files (#1730).
 
 ``custom_components/beatify/www/i18n/en.json`` is the canonical source of UI
-strings. Every other locale (``de``, ``es``, ``fr``, ``nl``) must expose the
+strings. Every other locale (``de``, ``es``, ``fr``, ``nl``, ``it``) must expose the
 *exact same* set of (dotted) keys — no missing keys (which surface as English
 fallbacks for that locale) and no extra keys (dead strings).
 
@@ -27,7 +27,10 @@ I18N_DIR = (
     / "i18n"
 )
 CANONICAL = "en"
-LOCALES = ["de", "es", "fr", "nl"]
+# ``it`` joined on 2026-08-19 (#2234). It shipped in #2237/#2238 on 2026-08-18
+# and was the only locale this guard did not cover — exactly the blind spot
+# #1730 was about, one locale later.
+LOCALES = ["de", "es", "fr", "nl", "it"]
 
 
 def _flatten(obj: dict, prefix: str = "") -> set[str]:


### PR DESCRIPTION
Part of #2234.

Italian is already live: #2237 shipped all 1306 UI strings on 2026-08-18 19:18Z, #2238 wired `SUPPORTED_LANGUAGES`, the browser-locale mapping, the wizard language list and the rebuilt `i18n.min.js` five minutes later. `translations/it.json` for the HA config flow is in place too.

What none of that touched is the guard rail. Every check that watches for locale drift still listed four locales:

| Guard | Purpose |
|---|---|
| `tests/unit/test_i18n_locale_parity.py` | key parity against `en.json` (#1730) |
| `streak-shield-badge-1666.test.js` | `reveal.streakShieldUsed` present, placeholder intact |
| `dashboard-reconnect.test.js` | `dashboard.reconnecting` present and non-empty |
| `dashboard-b8.test.js` | dashboard rendering across locale dictionaries |
| `seasonal-suggestion.test.js` | every seasonal `reasonKey` plus the chrome labels |

**This is the exact gap #1730 was filed for.** Back then es/fr/nl had silently fallen 133 keys behind `en.json` — the whole Smart Playlist Mixer UI — while the README promised full support. The guard was added so it could not happen again; the newest locale was the only one shipping outside it.

## Verification

`it.json` is at full parity today, so adding it changes no result — which is why the guards were checked against a deliberate break instead of a green run: deleting `dashboard.reconnecting` and `reveal.streakShieldUsed` from `it.json` fails `test_locale_key_parity_with_english[it]` and both vitest suites. Restored afterwards; the data file is untouched in this PR.

- `pytest tests/unit/test_i18n_locale_parity.py` → 11 passed
- `vitest run` on the four suites → 40 passed

## Also in here

Two comments and test names said "all five locales". That count was already wrong before this change and would be wrong again with the next language, so they now read "every shipped locale".

## Still open on #2234

`fun_fact_it` across the catalogue. Worth settling first: `fun_fact_it` must be **optional** in `scripts/playlist_schema.json`, since the five existing `fun_fact_*` fields are required and adding `it` the same way would block the schema gate until all 6261 songs carry the field.
