### PR TITLE
feat(i18n): accept optional fun_fact_it and ship it to the client

### DIFF
--- a/custom_components/beatify/game/serializers.py
+++ b/custom_components/beatify/game/serializers.py
@@ -177,6 +177,7 @@ class GameStateSerializer:
                 "fun_fact_es": gs.current_song.get("fun_fact_es", ""),
                 "fun_fact_fr": gs.current_song.get("fun_fact_fr", ""),
                 "fun_fact_nl": gs.current_song.get("fun_fact_nl", ""),
+                "fun_fact_it": gs.current_song.get("fun_fact_it", ""),
             }
         # Leaderboard (Story 5.5)
         state["leaderboard"] = gs.get_leaderboard()
@@ -224,6 +225,7 @@ class GameStateSerializer:
                 "fun_fact_es": gs.current_song.get("fun_fact_es", ""),
                 "fun_fact_fr": gs.current_song.get("fun_fact_fr", ""),
                 "fun_fact_nl": gs.current_song.get("fun_fact_nl", ""),
+                "fun_fact_it": gs.current_song.get("fun_fact_it", ""),
             }
         # Include reveal-specific player data (guesses, round_score, missed)
         state["players"] = GameStateSerializer.get_reveal_players_state(gs)

--- a/scripts/playlist_schema.json
+++ b/scripts/playlist_schema.json
@@ -112,6 +112,10 @@
         "fun_fact_es": { "type": "string" },
         "fun_fact_fr": { "type": "string" },
         "fun_fact_nl": { "type": "string" },
+        "fun_fact_it": {
+          "description": "Italian fun fact. OPTIONAL on purpose (#2234): the five older fun_fact_* fields are required, and adding Italian the same way would fail the CI gate for every one of the 6261 songs until the catalogue is fully translated. The client reads `fun_fact_<lang>` generically and falls back to the English `fun_fact`, so a missing entry degrades to the English text rather than to an error.",
+          "type": "string"
+        },
         "chart_info": { "type": ["object", "string"] },
         "certifications": { "type": ["array", "string"] },
         "awards": { "type": ["array", "string"] },

--- a/tests/unit/test_playlist_schema.py
+++ b/tests/unit/test_playlist_schema.py
@@ -130,3 +130,27 @@ def test_region_map_rejects_bare_id_but_accepts_uri_and_null() -> None:
         )
     )
     assert not list(validator.iter_errors(good))
+
+
+def test_fun_fact_it_is_optional_and_typed() -> None:
+    """#2234: Italian fun facts must not gate the catalogue.
+
+    The five older ``fun_fact_*`` fields are required. Adding ``fun_fact_it``
+    the same way would fail this very gate for all 6261 songs until every one
+    carries an Italian fact, turning a catalogue chore into a release blocker.
+    """
+    schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+    song = schema["$defs"]["song"]
+
+    assert "fun_fact_it" not in song["required"], "fun_fact_it must stay optional"
+    assert song["properties"]["fun_fact_it"]["type"] == "string"
+
+    validator = _validator()
+    # Absent: still valid.
+    assert not list(validator.iter_errors(_playlist(_song())))
+    # Present: still valid.
+    assert not list(
+        validator.iter_errors(_playlist(_song(fun_fact_it="Fu il primo brano…")))
+    )
+    # Wrong type: rejected, so a null does not slip in unnoticed.
+    assert list(validator.iter_errors(_playlist(_song(fun_fact_it=None))))


### PR DESCRIPTION
Part of #2234, step 4.

Italian became a UI language on 2026-08-18 (#2237/#2238), but songs still carry facts in five languages. This makes the catalogue side possible without making it a gate.

## The schema decision

`fun_fact_it` is **optional**. The five older `fun_fact_*` fields are `required`, and adding Italian the same way would fail the CI schema gate for **all 6261 songs** until every last one carries an Italian fact — a catalogue chore would become a release blocker.

Nothing breaks while entries are missing: `utils.getLocalizedSongField` builds the key as `fun_fact_<lang>` and falls back to the English `fun_fact`, so an untranslated song shows the English fact rather than an empty box.

## The serializer line that makes it real

Both payload builders in `game/serializers.py` list the five fields by hand. A `fun_fact_it` in a playlist file would have been **dropped on the way to the browser**, and the schema entry alone would have been decorative — the field would exist, validate, and never display. Two lines, both call sites.

## Deliberately not in here

`playlist-generator.js` still asks the LLM for five languages. Asking community contributors for a sixth is a product decision, not a side effect of a schema change — say the word and it is a three-line follow-up.

## Tests

`test_fun_fact_it_is_optional_and_typed` covers all three states: absent is valid, present is valid, and `null` is **rejected**. That last one is deliberate after #2247 — an optional field that silently accepts `null` is how the Apple region maps grew 4866 null entries that looked like answers.

- `pytest tests/unit` → 1955 passed
- `scripts/validate_playlists.py` → all 57 valid
