### PR TITLE
feat(i18n): let the server accept Italian as a game language

### DIFF
--- a/README.md
+++ b/README.md
@@ -567,6 +567,7 @@ Beatify speaks your guests' language.
 - **Español** — Soporte completo
 - **Français** — Support complet
 - **Nederlands** — Volledige ondersteuning
+- **Italiano** — Supporto completo
 
 Select during game setup. All players see the chosen language. Fun facts and awards are also translated!
 

--- a/custom_components/beatify/game/tts_phrases.py
+++ b/custom_components/beatify/game/tts_phrases.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 DEFAULT_LANGUAGE = "en"
 
 # Languages the game accepts (matches the validation in the WS/REST handlers).
-SUPPORTED_LANGUAGES = ("en", "de", "es", "fr", "nl")
+SUPPORTED_LANGUAGES = ("en", "de", "es", "fr", "nl", "it")
 
 # Word joining names in a spoken list ("Marco and Anna"). The English form uses
 # " and ".join(...) verbatim, so two names read "A and B" and the rare 3+ case
@@ -32,6 +32,7 @@ _AND: dict[str, str] = {
     "es": "y",
     "fr": "et",
     "nl": "en",
+    "it": "e",
 }
 
 # Spoken difficulty labels inserted into the game_start template via {difficulty}.
@@ -41,6 +42,7 @@ _DIFFICULTY: dict[str, dict[str, str]] = {
     "es": {"easy": "fácil", "normal": "normal", "hard": "difícil"},
     "fr": {"easy": "facile", "normal": "normale", "hard": "difficile"},
     "nl": {"easy": "makkelijk", "normal": "normaal", "hard": "moeilijk"},
+    "it": {"easy": "facile", "normal": "normale", "hard": "difficile"},
 }
 
 # Podium place labels, used as "{label}: {name}" in the top-3 readout.
@@ -50,6 +52,7 @@ _PLACE: dict[str, dict[int, str]] = {
     "es": {1: "primer puesto", 2: "segundo puesto", 3: "tercer puesto"},
     "fr": {1: "première place", 2: "deuxième place", 3: "troisième place"},
     "nl": {1: "eerste plaats", 2: "tweede plaats", 3: "derde plaats"},
+    "it": {1: "primo posto", 2: "secondo posto", 3: "terzo posto"},
 }
 
 # str.format templates per language. Keys must be identical across languages;
@@ -179,6 +182,31 @@ _PHRASES: dict[str, dict[str, str]] = {
         "steal_unlocked": "{name} heeft jatten vrijgespeeld.",
         "tie_at_top": "Het is gelijkspel aan kop.",
         "leader_change": "{name} neemt de leiding.",
+    },
+    "it": {
+        "game_start": "Si gioca a Beatify! {rounds} round, difficoltà {difficulty}.",
+        "winner_single": "E il vincitore è... {name} con {points} punti!",
+        "winner_tie": "Pareggio tra {names} con {points} punti!",
+        "round_start": "Round {round} — preparatevi!",
+        "countdown": "Tre, due, uno — via!",
+        "time_up": "Tempo scaduto!",
+        "player_join": "{name} è entrato in partita!",
+        "player_reconnect": "Bentornato, {name}!",
+        "last_round": "Questo è l'ultimo round!",
+        "rematch": "Rivincita! Preparatevi!",
+        "intro_round": "Round introduttivo — veloci, sentite solo i primi secondi!",
+        "steal_used": "{stealer} ha rubato la risposta a {target}!",
+        "answer": "La risposta era {year}.",
+        "exact": "{names}: in pieno centro.",
+        "closest": "{name} è andato più vicino.",
+        "nobody": "Questo round non l'ha indovinato nessuno.",
+        "streak_milestone": "{name} è a una serie di {streak} canzoni.",
+        "streak_broken": "La serie di {name} finisce a {previous}.",
+        "bet_won": "{name} ha raddoppiato i punti.",
+        "bet_lost": "{name} perde la scommessa.",
+        "steal_unlocked": "{name} ha sbloccato il furto.",
+        "tie_at_top": "Parità in testa.",
+        "leader_change": "{name} passa in testa!",
     },
 }
 

--- a/custom_components/beatify/server/game_views.py
+++ b/custom_components/beatify/server/game_views.py
@@ -537,7 +537,7 @@ class StartGameView(RateLimitMixin, HomeAssistantView):
             stats_service.record_game_start()
 
         # Set game language (Story 12.4, 16.3)
-        if language in ("en", "de", "es", "fr", "nl"):
+        if language in ("en", "de", "es", "fr", "nl", "it"):
             game_state.language = language
 
         # Issue #331/#517: Configure Party Lights if enabled

--- a/custom_components/beatify/server/ws_handlers/admin.py
+++ b/custom_components/beatify/server/ws_handlers/admin.py
@@ -520,7 +520,7 @@ async def admin_set_language(
         return
 
     language = data.get("language", "en")
-    if language not in ("en", "de", "es", "fr", "nl"):
+    if language not in ("en", "de", "es", "fr", "nl", "it"):
         language = "en"
 
     game_state.language = language

--- a/tests/unit/test_tts_localization.py
+++ b/tests/unit/test_tts_localization.py
@@ -292,3 +292,26 @@ async def test_speak_omits_language_when_not_set():
     hass = _make_hass()
     await TTSService(hass, "tts.x", "media_player.y").speak("hello")
     assert "language" not in _payload(hass)
+
+
+def test_italian_is_accepted_by_the_server_gates() -> None:
+    """#2234 follow-up: the phrase pack is worthless if the handlers drop 'it'.
+
+    Italian shipped as a UI language on 2026-08-18, but both language gates
+    still carried the five-language tuple: the REST gate ignored 'it' and the
+    WebSocket gate rewrote it to 'en'. `game_state.language` therefore never
+    became 'it', and since dashboard.js and player-core.js switch the UI from
+    exactly that value, players were sent back to English one state update
+    after the wizard.
+    """
+    from pathlib import Path
+
+    root = Path(__file__).resolve().parents[2] / "custom_components" / "beatify"
+    rest = (root / "server" / "game_views.py").read_text(encoding="utf-8")
+    ws = (root / "server" / "ws_handlers" / "admin.py").read_text(encoding="utf-8")
+
+    assert '("en", "de", "es", "fr", "nl", "it")' in rest
+    assert '("en", "de", "es", "fr", "nl", "it")' in ws
+    # Guard against a gate drifting back to the five-language tuple.
+    assert '("en", "de", "es", "fr", "nl")' not in rest
+    assert '("en", "de", "es", "fr", "nl")' not in ws


### PR DESCRIPTION
Follow-up to #2234. Italian was reachable in the wizard and fully translated, but **the server refused the value**.

## The chain

| Where | What it did with `it` |
|---|---|
| `server/game_views.py:540` | `if language in ("en","de","es","fr","nl")` — silently ignored |
| `server/ws_handlers/admin.py:523` | `if language not in (…)` → rewritten to `"en"` |

`game_state.language` could therefore never be `it`. That field is broadcast in the state payload, and `dashboard.js:567` / `player-core.js:652` switch the UI from exactly that value — **a host picked Italian in the wizard and every player was put back into English one state update later**, with a complete `it.json` sitting unused next to them. `_resolve_page_language` reads the same field, so `<html lang>` stayed `"en"` and the #1527 auto-translate guard never applied to Italian either.

## What changed

- Both gates accept `it`.
- `game/tts_phrases.py`: Italian pack — 23 templates plus the "and" word, the difficulty labels and the podium places. Without it, `SUPPORTED_LANGUAGES` would list a language with no announcements.
- README's language list names Italian. **The historical release-note lines still say "5 languages"** — v4.2.0 shipped five, and rewriting shipped history would be wrong.

## Why the phrase pack could not land half-finished

`tests/unit/test_tts_localization.py` already asserts that `_PHRASES` covers exactly `SUPPORTED_LANGUAGES`, with identical keys **and identical placeholder sets** per key. Adding `it` to the tuple without a complete, correctly-parameterised pack fails that test.

Added on top: a test pinning both server gates, because a perfect phrase pack is worthless if a handler drops the value on the way in. **Verified by mutation** — reverting either tuple to the five-language form fails it.

## Not in here

- `awards_it` — other playlists carry `awards_de/es/fr/nl`; Italian falls back to English cleanly, so this is cosmetic.
- The LLM prompt in `playlist-generator.js` still asks community contributors for five languages. That is a product call, not a side effect.

## Checks

`pytest tests/unit` → 1958 passed.

**Still unmeasured:** this is read from the code, not from a running game. A live test with the game language set to Italian would be the proof.
