### PR TITLE
data(playlists): Italian award names for all 422 decorated songs

### DIFF
--- a/custom_components/beatify/playlists/2000s-pop-anthems.json
+++ b/custom_components/beatify/playlists/2000s-pop-anthems.json
@@ -1,6 +1,6 @@
 {
   "name": "2000s Pop Anthems",
-  "version": "1.21",
+  "version": "1.22",
   "tags": [
     "2000s",
     "pop",
@@ -89,6 +89,9 @@
       "fun_fact_nl": "In de videoclip is te zien hoe Kelly Rowland op een beroemde manier probeert Nelly te sms'en via een Microsoft Excel-spreadsheet.",
       "awards_nl": [
         "Grammy Award – Beste Rap/Zang-samenwerking"
+      ],
+      "awards_it": [
+        "Grammy per la migliore collaborazione rap/cantata"
       ],
       "isrc": "USUR10200370",
       "uri_apple_music_by_region": {
@@ -181,6 +184,9 @@
       "awards_nl": [
         "Grammy Award – Beste Vrouwelijke Pop Zangprestatie"
       ],
+      "awards_it": [
+        "Grammy per la migliore interpretazione vocale pop femminile"
+      ],
       "isrc": "GBCTA0400231",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1687386491",
@@ -233,6 +239,10 @@
         "Grammy Award – Beste Vrouwelijke R&B Zangprestatie",
         "Grammy Award – Beste R&B-nummer"
       ],
+      "awards_it": [
+        "Grammy per la migliore interpretazione vocale R&B femminile",
+        "Grammy per la migliore canzone R&B"
+      ],
       "isrc": "USIR20500195",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1443208143",
@@ -281,6 +291,9 @@
       "fun_fact_nl": "De Moulin Rouge-versie bevat Christina Aguilera, Lil' Kim, Mýa en Pink — vier van de grootste vrouwelijke artiesten van dat tijdperk die samen optreden.",
       "awards_nl": [
         "Grammy Award – Beste Popsamenwerking met Zang"
+      ],
+      "awards_it": [
+        "Grammy per la migliore collaborazione pop con parti vocali"
       ],
       "isrc": "USIR10110334",
       "uri_apple_music_by_region": {
@@ -413,6 +426,9 @@
       "fun_fact_nl": "De iconische lach aan het begin van het nummer werd ingesproken door de stemacteur van bassist Murdoc Niccals, en de geanimeerde videoclip won een Grammy voor Beste Videoclip.",
       "awards_nl": [
         "Grammy Award – Beste Popsamenwerking met Zang"
+      ],
+      "awards_it": [
+        "Grammy per la migliore collaborazione pop con parti vocali"
       ],
       "isrc": "GBAYE1400422",
       "uri_apple_music_by_region": {
@@ -547,6 +563,9 @@
       "awards_nl": [
         "Grammy Award – Beste Hardrockprestatie"
       ],
+      "awards_it": [
+        "Grammy per la migliore interpretazione hard rock"
+      ],
       "isrc": "USWU30200093",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1645901771",
@@ -637,6 +656,9 @@
       "fun_fact_nl": "De videoclip in stripboekthema parodieert meerdere beroemdheden en toont Eminem als een superheld genaamd 'Rap Boy', een persiflage op Robin uit Batman.",
       "awards_nl": [
         "Grammy Award – Beste Muziekvideo (Korte Vorm)"
+      ],
+      "awards_it": [
+        "Grammy per il miglior video musicale (Short Form)"
       ],
       "isrc": "USIR10211038",
       "uri_apple_music_by_region": {
@@ -814,6 +836,10 @@
       "awards_nl": [
         "Grammy Award – Lied van het Jaar",
         "Grammy Award – Beste Popprestatie door Duo of Groep"
+      ],
+      "awards_it": [
+        "Grammy per la canzone dell'anno",
+        "Grammy per la migliore interpretazione pop di un duo o gruppo"
       ],
       "isrc": "GBAYE1600217",
       "uri_apple_music_by_region": {
@@ -1031,6 +1057,9 @@
       "awards_nl": [
         "ARIA Award – Beste Poprelease"
       ],
+      "awards_it": [
+        "ARIA Award per la migliore pubblicazione pop"
+      ],
       "isrc": "AUEI10800039",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1707435588",
@@ -1121,6 +1150,9 @@
       "fun_fact_nl": "De iconische Bollywood-strijkerssample van het nummer is afkomstig uit 'Tere Mere Beech Mein' uit de Indiase film Ek Duuje Ke Liye uit 1981. Het leverde Britney haar enige Grammy Award op.",
       "awards_nl": [
         "Grammy Award – Beste Dance-opname"
+      ],
+      "awards_it": [
+        "Grammy per la migliore registrazione dance"
       ],
       "isrc": "USJI10301005",
       "uri_apple_music_by_region": {
@@ -1216,6 +1248,10 @@
         "Grammy Award – Beste Rapnummer",
         "Grammy Award – Beste Rap/Zang-samenwerking"
       ],
+      "awards_it": [
+        "Grammy per la migliore canzone rap",
+        "Grammy per la migliore collaborazione rap/cantata"
+      ],
       "isrc": "USJZ10900031",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1440750745",
@@ -1268,6 +1304,10 @@
         "Grammy Award – Beste Vrouwelijke Pop Zangprestatie",
         "Grammy Award – Beste Korte Muziekvideo"
       ],
+      "awards_it": [
+        "Grammy per la migliore interpretazione vocale pop femminile",
+        "Grammy per il miglior video musicale di forma breve"
+      ],
       "isrc": "USUM70918596",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1688497897",
@@ -1316,6 +1356,9 @@
       "fun_fact_nl": "Timbaland produceerde de track met zware elektronische vervorming, en veel dj's dachten aanvankelijk dat het een nieuwe artiest was in plaats van Justin Timberlake vanwege de dramatische verandering in geluid.",
       "awards_nl": [
         "Grammy Award – Beste Dance-opname"
+      ],
+      "awards_it": [
+        "Grammy per la migliore registrazione dance"
       ],
       "isrc": "USJI10600269",
       "uri_apple_music_by_region": {
@@ -1366,6 +1409,9 @@
       "awards_nl": [
         "Grammy Award – Beste Rockprestatie door Duo of Groep met Zang"
       ],
+      "awards_it": [
+        "Grammy per la migliore interpretazione rock di un duo o gruppo con parti vocali"
+      ],
       "isrc": "USRC10800300",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1441530830",
@@ -1414,6 +1460,9 @@
       "fun_fact_nl": "Chris Martin bedacht de pianoriff diep in de nacht en nam hem bijna niet op omdat hij bedoeld was voor een ander bandproject. Het won de Grammy voor Record of the Year in 2004.",
       "awards_nl": [
         "Grammy Award – Opname van het Jaar"
+      ],
+      "awards_it": [
+        "Grammy per il disco dell'anno"
       ],
       "isrc": "GBAYE1600193",
       "uri_apple_music_by_region": {
@@ -1632,6 +1681,9 @@
       "awards_nl": [
         "Grammy Award – Beste Rap Soloprestatie"
       ],
+      "awards_it": [
+        "Grammy per la migliore interpretazione rap solista"
+      ],
       "isrc": "USIR10000448",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1440866926",
@@ -1765,6 +1817,9 @@
       "awards_nl": [
         "Grammy Award – Beste Dance-opname"
       ],
+      "awards_it": [
+        "Grammy per la migliore registrazione dance"
+      ],
       "isrc": "USUM70824409",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1710465533",
@@ -1854,6 +1909,9 @@
       "fun_fact_nl": "Het nummer was oorspronkelijk geschreven voor Britney Spears, die het weigerde. Het stond 10 opeenvolgende weken op nummer 1 in het VK tijdens een van de regenachtigste zomers ooit gemeten.",
       "awards_nl": [
         "Grammy Award – Beste Rap/Zang-samenwerking"
+      ],
+      "awards_it": [
+        "Grammy per la migliore collaborazione rap/cantata"
       ],
       "isrc": "USUM70736771",
       "uri_apple_music_by_region": {
@@ -1987,6 +2045,9 @@
       "awards_nl": [
         "BRIT Award – Beste Britse Rockact (band)"
       ],
+      "awards_it": [
+        "Brit Award per il miglior artista rock britannico (band)"
+      ],
       "isrc": "GBCEL0300192",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/315844084",
@@ -2035,6 +2096,9 @@
       "fun_fact_nl": "Ironisch genoeg namen The Game en 50 Cent deze samenwerking op vlak voor hun beroemde vete die de G-Unit-rapgroep uiteendreef.",
       "awards_nl": [
         "Grammy-nominatie – Beste Rapprestatie door Duo of Groep"
+      ],
+      "awards_it": [
+        "Candidatura al Grammy per la migliore interpretazione rap di un duo o gruppo"
       ],
       "isrc": "USIR10401121",
       "uri_apple_music_by_region": {
@@ -2171,6 +2235,10 @@
         "Grammy Award – Beste Vrouwelijke R&B Zangprestatie",
         "Grammy Award – Beste R&B-nummer"
       ],
+      "awards_it": [
+        "Grammy per la migliore interpretazione vocale R&B femminile",
+        "Grammy per la migliore canzone R&B"
+      ],
       "isrc": "USJAY0300452",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1721921218",
@@ -2261,6 +2329,9 @@
       "fun_fact_nl": "André 3000 speelde alle instrumenten zelf. De tekst 'shake it like a Polaroid picture' zette Polaroid ertoe aan een verklaring af te geven dat het schudden van foto's ze in feite beschadigt.",
       "awards_nl": [
         "Grammy Award – Beste Urban/Alternatieve Prestatie"
+      ],
+      "awards_it": [
+        "Grammy per la migliore interpretazione urban/alternative"
       ]
     },
     {
@@ -2467,6 +2538,9 @@
       "awards_nl": [
         "Grammy Award – Beste Rapprestatie door Duo of Groep"
       ],
+      "awards_it": [
+        "Grammy per la migliore interpretazione rap di un duo o gruppo"
+      ],
       "isrc": "USLF20000357",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1741741469",
@@ -2642,6 +2716,9 @@
       "awards_nl": [
         "Grammy Award – Beste Vrouwelijke R&B Zangprestatie"
       ],
+      "awards_it": [
+        "Grammy per la migliore interpretazione vocale R&B femminile"
+      ],
       "isrc": "USMC10111369",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1691778424",
@@ -2732,6 +2809,9 @@
       "fun_fact_nl": "Het nummer bevat op beroemde wijze een sample van Daft Punk's 'Harder, Better, Faster, Stronger' en de futuristische videoclip was geïnspireerd op de animefilm Akira.",
       "awards_nl": [
         "Grammy Award – Beste Rap Soloprestatie"
+      ],
+      "awards_it": [
+        "Grammy per la migliore interpretazione rap solista"
       ],
       "isrc": "USUM70741299",
       "uri_apple_music_by_region": {
@@ -3203,6 +3283,10 @@
         "Grammy Award – Opname van het Jaar",
         "Grammy Award – Beste Rockprestatie door Duo of Groep"
       ],
+      "awards_it": [
+        "Grammy per il disco dell'anno",
+        "Grammy per la migliore interpretazione rock di un duo o gruppo"
+      ],
       "isrc": "USRC10800301",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1351343570",
@@ -3549,6 +3633,11 @@
         "Oscar – Beste Originele Lied",
         "Grammy Award – Beste Rapnummer",
         "Grammy Award – Beste Rap Soloprestatie"
+      ],
+      "awards_it": [
+        "Oscar per la migliore canzone originale",
+        "Grammy per la migliore canzone rap",
+        "Grammy per la migliore interpretazione rap solista"
       ],
       "isrc": "USIR10211559",
       "uri_apple_music_by_region": {
@@ -4018,6 +4107,10 @@
       "awards_nl": [
         "Grammy Award – Beste Rapnummer",
         "Grammy Award – Beste Rap/Zang-samenwerking"
+      ],
+      "awards_it": [
+        "Grammy per la migliore canzone rap",
+        "Grammy per la migliore collaborazione rap/cantata"
       ],
       "isrc": "USJZ10900010",
       "uri_apple_music_by_region": {

--- a/custom_components/beatify/playlists/80er-hits.json
+++ b/custom_components/beatify/playlists/80er-hits.json
@@ -1,6 +1,6 @@
 {
   "name": "80s Hits",
-  "version": "2.17",
+  "version": "2.18",
   "tags": [
     "1980s",
     "pop",
@@ -940,6 +940,10 @@
         "Grammy Award voor Opname van het Jaar (1984)",
         "Grammy Award voor Beste Mannelijke Rock Zangprestatie (1984)"
       ],
+      "awards_it": [
+        "Grammy per il disco dell'anno (1984)",
+        "Grammy per la migliore interpretazione vocale rock maschile (1984)"
+      ],
       "isrc": "USSM18200197",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/310505615",
@@ -986,6 +990,9 @@
       "fun_fact_nl": "Michael Jackson schreef dit nummer onderweg naar huis, zo verdiept dat hij niet merkte dat zijn auto vlam had gevat. De beroemde baslijn vergde 91 takes om te perfectioneren. Jackson debuteerde de moonwalk tijdens een tv-optreden van dit nummer.",
       "awards_nl": [
         "Grammy Award voor Beste Mannelijke R&B Zangprestatie (1984)"
+      ],
+      "awards_it": [
+        "Grammy per la migliore interpretazione vocale R&B maschile (1984)"
       ],
       "isrc": "USSM19902991",
       "uri_apple_music_by_region": {
@@ -1265,6 +1272,9 @@
       "awards_nl": [
         "Grammy Award voor Beste Rockprestatie door Duo of Groep (1983)"
       ],
+      "awards_it": [
+        "Grammy per la migliore interpretazione rock di un duo o gruppo (1983)"
+      ],
       "isrc": "USVR19300001",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1635636757",
@@ -1463,6 +1473,9 @@
       "fun_fact_nl": "Het nummer werd geschreven over actrice Rosanna Arquette, die een relatie had met Toto-toetsenist Steve Porcaro. Het karakteristieke drumpatroon, het 'Rosanna Shuffle' genaamd, wordt nu wereldwijd onderwezen op muziekscholen.",
       "awards_nl": [
         "Grammy Award voor Opname van het Jaar (1983)"
+      ],
+      "awards_it": [
+        "Grammy per il disco dell'anno (1983)"
       ],
       "isrc": "USSM18200245",
       "uri_apple_music_by_region": {
@@ -2072,6 +2085,10 @@
       "awards_nl": [
         "Oscar voor Beste Originele Lied (1984)",
         "Golden Globe voor Beste Originele Lied (1984)"
+      ],
+      "awards_it": [
+        "Oscar per la migliore canzone originale (1984)",
+        "Golden Globe per la migliore canzone originale (1984)"
       ],
       "isrc": "USA560661522",
       "uri_apple_music_by_region": {
@@ -3551,6 +3568,9 @@
       "awards_nl": [
         "Grammy Award voor Beste Mannelijke Pop Zangprestatie (1985)"
       ],
+      "awards_it": [
+        "Grammy per la migliore interpretazione vocale pop maschile (1985)"
+      ],
       "isrc": "USRH11603951",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1148642452",
@@ -3778,6 +3798,10 @@
       "awards_nl": [
         "Oscar voor Beste Originele Lied (1985)",
         "Golden Globe voor Beste Originele Lied (1985)"
+      ],
+      "awards_it": [
+        "Oscar per la migliore canzone originale (1985)",
+        "Golden Globe per la migliore canzone originale (1985)"
       ],
       "isrc": "USUMG9900476",
       "uri_apple_music_by_region": {
@@ -4039,6 +4063,11 @@
         "Grammy Award voor Opname van het Jaar (1985)",
         "Grammy Award voor Lied van het Jaar (1985)",
         "Grammy Award voor Beste Vrouwelijke Pop Zangprestatie (1985)"
+      ],
+      "awards_it": [
+        "Grammy per il disco dell'anno (1985)",
+        "Grammy per la canzone dell'anno (1985)",
+        "Grammy per la migliore interpretazione vocale pop femminile (1985)"
       ],
       "isrc": "USCA28400002",
       "uri_apple_music_by_region": {
@@ -5635,6 +5664,9 @@
       "awards_nl": [
         "Grammy Award voor Album van het Jaar (1987) – Album"
       ],
+      "awards_it": [
+        "Grammy per l'album dell'anno (1987)"
+      ],
       "isrc": "USSM11002255",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1739846276",
@@ -5770,6 +5802,9 @@
       "fun_fact_nl": "Steve Winwood werkte samen met Chaka Khan voor achtergrondzang op dit nummer. Het won de Grammy voor Record of the Year in 1987 en markeerde Winwoods succesvolle solocarrière na Traffic.",
       "awards_nl": [
         "Grammy Award voor Opname van het Jaar (1987)"
+      ],
+      "awards_it": [
+        "Grammy per il disco dell'anno (1987)"
       ],
       "isrc": "GBAAN0201051",
       "uri_apple_music_by_region": {
@@ -6431,6 +6466,9 @@
       "awards_nl": [
         "Grammy Award voor Beste Vrouwelijke Pop Zangprestatie (1988)"
       ],
+      "awards_it": [
+        "Grammy per la migliore interpretazione vocale pop femminile (1988)"
+      ],
       "isrc": "USAR18700121",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1627099927",
@@ -6669,6 +6707,9 @@
       "fun_fact_nl": "Phil Collins schreef dit samen met Lamont Dozier (van Motowns Holland-Dozier-Holland) voor de film 'Buster'. De samenwerking resulteerde in een modern Motown-geluid dat een Golden Globe won voor Best Original Song.",
       "awards_nl": [
         "Golden Globe voor Beste Originele Lied (1989)"
+      ],
+      "awards_it": [
+        "Golden Globe per la migliore canzone originale (1989)"
       ],
       "isrc": "USWI19600240",
       "uri_apple_music_by_region": {
@@ -7333,6 +7374,9 @@
       "fun_fact_nl": "Phil Collins schreef dit nummer over dakloosheid nadat hij mensen op straat had zien slapen in Washington DC. Het won de Grammy voor Record of the Year in 1991 en wakkerde een debat aan over sociale verantwoordelijkheid in popmuziek.",
       "awards_nl": [
         "Grammy Award voor Opname van het Jaar (1991)"
+      ],
+      "awards_it": [
+        "Grammy per il disco dell'anno (1991)"
       ],
       "isrc": "USRH11602405",
       "uri_apple_music_by_region": {

--- a/custom_components/beatify/playlists/community/100-greatest-rock-songs.json
+++ b/custom_components/beatify/playlists/community/100-greatest-rock-songs.json
@@ -1,6 +1,6 @@
 {
   "name": "100 Greatest Rock Songs",
-  "version": "0.11",
+  "version": "0.12",
   "tags": [
     "rock",
     "classic-rock",
@@ -186,6 +186,9 @@
       },
       "awards_fr": [
         "Grammy Hall of Fame (2014)"
+      ],
+      "awards_it": [
+        "Grammy Hall of Fame (2014)"
       ]
     },
     {
@@ -263,6 +266,9 @@
       "fun_fact_nl": "Eddie Van Halen schreef de synthesizerriff van Jump thuis op een vierspoors-recorder. De rest van de band verzette zich aanvankelijk tegen een door keyboards geleide single, uit angst te ver af te wijken van hun gitaargedreven identiteit.",
       "awards_nl": [
         "Grammy-nominatie"
+      ],
+      "awards_it": [
+        "Candidatura al Grammy"
       ],
       "isrc": "USWB11403680",
       "uri_apple_music_by_region": {
@@ -523,6 +529,10 @@
       "awards_fr": [
         "Grammy - Enregistrement de l'année (1978)",
         "Grammy Hall of Fame (2003)"
+      ],
+      "awards_it": [
+        "Grammy per il disco dell'anno (1978)",
+        "Grammy Hall of Fame (2003)"
       ]
     },
     {
@@ -604,6 +614,9 @@
         "Grammy Hall of Fame (2009)"
       ],
       "awards_nl": [
+        "Grammy Hall of Fame (2009)"
+      ],
+      "awards_it": [
         "Grammy Hall of Fame (2009)"
       ]
     },
@@ -915,6 +928,9 @@
       "awards_nl": [
         "Grammy Hall of Fame (2017)"
       ],
+      "awards_it": [
+        "Grammy Hall of Fame (2017)"
+      ],
       "isrc": "USGF19942501",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1440783625",
@@ -1009,6 +1025,9 @@
       "awards_nl": [
         "Grammy-nominatie – Beste Metalprestatie (1992)"
       ],
+      "awards_it": [
+        "Candidatura al Grammy per la migliore interpretazione metal (1992)"
+      ],
       "isrc": "QMKHM1900001",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1572046436",
@@ -1100,6 +1119,10 @@
         "Grammy Hall of Fame (1998)",
         "Rolling Stone – #2 Beste Nummer Aller Tijden"
       ],
+      "awards_it": [
+        "Grammy Hall of Fame (1998)",
+        "Rolling Stone – n. 2 tra le migliori canzoni di sempre"
+      ],
       "isrc": "USA176510160",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1623247613",
@@ -1149,6 +1172,9 @@
       "uri_deezer": "deezer://track/12206946",
       "fun_fact_nl": "Another One Bites the Dust werd aanvankelijk tegengewerkt door het management van Queen die het te disco vond. Michael Jackson moedigde de band persoonlijk aan om het als single uit te brengen. John Deacons baslijn was geïnspireerd op Chic's 'Good Times' en werd een wereldwijd fenomeen.",
       "awards_nl": [
+        "American Music Award (1981)"
+      ],
+      "awards_it": [
         "American Music Award (1981)"
       ],
       "isrc": "GBUM71029605",
@@ -1883,6 +1909,9 @@
       "awards_nl": [
         "Grammy Hall of Fame"
       ],
+      "awards_it": [
+        "Grammy Hall of Fame"
+      ],
       "isrc": "GBDXG1200006",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1099335223",
@@ -2294,6 +2323,9 @@
       "uri_deezer": "deezer://track/9997018",
       "fun_fact_nl": "Verschillende managers waarschuwden dat het bijna zes minuten durende nummer te lang was voor de radio. Queen nam het in ongeveer drie weken op; Freddie Mercury, Brian May en Roger Taylor legden hun stemmen herhaaldelijk over elkaar, waarbij sommige delen naar verluidt ongeveer 180 overdubs bevatten.",
       "awards_nl": [
+        "Grammy Hall of Fame (2004)"
+      ],
+      "awards_it": [
         "Grammy Hall of Fame (2004)"
       ],
       "isrc": "GBUM71029604",
@@ -2816,6 +2848,9 @@
       "awards_nl": [
         "Grammy Hall of Fame (2009)"
       ],
+      "awards_it": [
+        "Grammy Hall of Fame (2009)"
+      ],
       "isrc": "GBUM71029618",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1834502336",
@@ -3212,6 +3247,9 @@
       },
       "awards_fr": [
         "MTV VMA - Meilleur nouvel artiste (1986)"
+      ],
+      "awards_it": [
+        "MTV VMA per il miglior artista esordiente (1986)"
       ]
     },
     {
@@ -3325,6 +3363,9 @@
       "fun_fact_nl": "“Ace of Spades” van Motörhead verscheen oorspronkelijk in 1980; het jaar is gebaseerd op gecontroleerde opname- en uitgavegegevens.",
       "awards_nl": [
         "Grammy-nominatie"
+      ],
+      "awards_it": [
+        "Candidatura al Grammy"
       ],
       "isrc": "GBAJE8000033",
       "uri_apple_music_by_region": {
@@ -3788,6 +3829,9 @@
       "awards_nl": [
         "Grammy Hall of Fame (2020)"
       ],
+      "awards_it": [
+        "Grammy Hall of Fame (2020)"
+      ],
       "isrc": "AUAP07900028",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/574044008",
@@ -3837,6 +3881,9 @@
       "uri_deezer": "deezer://track/625643",
       "fun_fact_nl": "Don't Stop Believin' werd het best verkopende digitale nummer van de 20e eeuw na het gebruik ervan in de finale van The Sopranos. Journey's Steve Perry schreef het over zijn eigen dorpse afkomst. Drie decennia na de release beleefde het nummer een enorme revival, waardoor het bij nieuwe generaties fans werd geïntroduceerd.",
       "awards_nl": [
+        "Grammy Hall of Fame (2021)"
+      ],
+      "awards_it": [
         "Grammy Hall of Fame (2021)"
       ],
       "isrc": "USSM18100116",
@@ -4035,6 +4082,9 @@
       "uri_tidal": "tidal://track/4085631",
       "fun_fact_nl": "'Back in Black' opent het gelijknamige album van AC/DC, dat na de dood van Bon Scott met Brian Johnson werd opgenomen en aan Scotts nagedachtenis werd opgedragen. Het album verkocht wereldwijd meer dan 50 miljoen exemplaren.",
       "awards_nl": [
+        "Grammy Hall of Fame"
+      ],
+      "awards_it": [
         "Grammy Hall of Fame"
       ],
       "isrc": "AUAP08000046",
@@ -4775,6 +4825,9 @@
       "fun_fact_nl": "'Killing in the Name' bereikte in 2009 de eerste plaats in de Britse kersthitlijst na een grassrootscampagne op Facebook tegen de winnaarsingle van The X Factor.",
       "awards_nl": [
         "Grammy-nominatie"
+      ],
+      "awards_it": [
+        "Candidatura al Grammy"
       ],
       "isrc": "USSM19200317",
       "uri_apple_music_by_region": {

--- a/custom_components/beatify/playlists/community/90s-2000s-hiphop-bangers.json
+++ b/custom_components/beatify/playlists/community/90s-2000s-hiphop-bangers.json
@@ -1,6 +1,6 @@
 {
   "name": "90s & 2000s Hip Hop Bangers",
-  "version": "1.1",
+  "version": "1.2",
   "tags": [
     "90s",
     "2000s",
@@ -296,6 +296,9 @@
       "awards_nl": [
         "Grammy Award – Beste Rap Soloprestatie (genomineerd)"
       ],
+      "awards_it": [
+        "Candidatura al Grammy per la migliore interpretazione rap solista"
+      ],
       "isrc": "USBB40580817",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1801961851",
@@ -344,6 +347,9 @@
       "fun_fact_nl": "Het nummer werd geschreven voor de soundtrack van de film 'Dangerous Minds' met Michelle Pfeiffer, die ook in de videoclip verschijnt. Het was wereldwijd de bestverkochte single van 1995.",
       "awards_nl": [
         "Grammy Award – Beste Rap Soloprestatie"
+      ],
+      "awards_it": [
+        "Grammy per la migliore interpretazione rap solista"
       ],
       "isrc": "USTB10400128",
       "uri_apple_music_by_region": {
@@ -560,6 +566,9 @@
       "awards_nl": [
         "Grammy Award – Beste Vrouwelijke R&B Zangprestatie"
       ],
+      "awards_it": [
+        "Grammy per la migliore interpretazione vocale R&B femminile"
+      ],
       "isrc": "USSM19802337",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1276760748",
@@ -649,6 +658,9 @@
       "fun_fact_nl": "Het nummer bevat op beroemde wijze een sample van het koor van 'It's the Hard Knock Life' uit de musical Annie. Jay-Z vreesde aanvankelijk dat de sample hem 'zacht' zou doen lijken, maar het werd een van zijn grootste hits.",
       "awards_nl": [
         "Grammy Award – Beste Rapalbum (voor Vol. 2... Hard Knock Life)"
+      ],
+      "awards_it": [
+        "Grammy per il miglior album rap (for Vol. 2... Hard Knock Life)"
       ],
       "isrc": "USRL19800899",
       "uri_apple_music_by_region": {
@@ -741,6 +753,9 @@
       "awards_nl": [
         "Grammy Award – Beste Rap Soloprestatie (genomineerd)"
       ],
+      "awards_it": [
+        "Candidatura al Grammy per la migliore interpretazione rap solista"
+      ],
       "isrc": "USDJ20010705",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1700354890",
@@ -796,6 +811,11 @@
         "MTV VMA – Beste Video",
         "MTV VMA – Beste Mannelijke Video"
       ],
+      "awards_it": [
+        "Grammy per la migliore interpretazione rap solista",
+        "MTV VMA per il miglior video",
+        "MTV VMA per il miglior video maschile"
+      ],
       "isrc": "USIR10000448",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1440866926",
@@ -845,6 +865,9 @@
       "awards_nl": [
         "Grammy Award – Beste Rapprestatie door Duo of Groep"
       ],
+      "awards_it": [
+        "Grammy per la migliore interpretazione rap di un duo o gruppo"
+      ],
       "isrc": "USLF20000357",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1741741469",
@@ -893,6 +916,9 @@
       "fun_fact_nl": "Timbaland produceerde de track met een tumbi, een Indiaas instrument, waarmee hij een van de meest kenmerkende beats in de geschiedenis van de hiphop creëerde. Het nummer werd in één sessie opgenomen en Missy improviseerde een groot deel van de tekst.",
       "awards_nl": [
         "Grammy Award – Beste Rap Soloprestatie"
+      ],
+      "awards_it": [
+        "Grammy per la migliore interpretazione rap solista"
       ],
       "isrc": "USEW20100037",
       "uri_apple_music_by_region": {
@@ -1026,6 +1052,9 @@
       "awards_nl": [
         "Grammy Award – Beste Muziekvideo"
       ],
+      "awards_it": [
+        "Grammy per il miglior video musicale"
+      ],
       "isrc": "USIR10211038",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1625004633",
@@ -1081,6 +1110,11 @@
         "Grammy Award – Beste Rapnummer",
         "Grammy Award – Beste Rap Soloprestatie"
       ],
+      "awards_it": [
+        "Oscar per la migliore canzone originale",
+        "Grammy per la migliore canzone rap",
+        "Grammy per la migliore interpretazione rap solista"
+      ],
       "isrc": "USIR10211559",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1444221569",
@@ -1130,6 +1164,9 @@
       "awards_nl": [
         "Grammy Award – Beste Mannelijke Rap Soloprestatie"
       ],
+      "awards_it": [
+        "Grammy per la migliore interpretazione rap solista maschile"
+      ],
       "isrc": "USUR10200252",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1692116505",
@@ -1178,6 +1215,9 @@
       "fun_fact_nl": "Het nummer bevat de beroemde achterstevoren gedraaide tekst 'I put my thing down, flip it and reverse it', die Missy feitelijk eerst vooruit opnam, waarna de audio in de productie werd omgedraaid om de iconische hook te creëren.",
       "awards_nl": [
         "Grammy Award – Beste Vrouwelijke Rap Soloprestatie"
+      ],
+      "awards_it": [
+        "Grammy per la migliore interpretazione rap solista femminile"
       ]
     },
     {
@@ -1220,6 +1260,10 @@
       "awards_nl": [
         "MTV VMA – Beste Rapvideo",
         "MTV VMA – Beste Nieuwe Artiest"
+      ],
+      "awards_it": [
+        "MTV VMA per il miglior video rap",
+        "MTV VMA per il miglior artista esordiente"
       ],
       "isrc": "USIR10300033",
       "uri_apple_music_by_region": {
@@ -1312,6 +1356,9 @@
       "awards_nl": [
         "Grammy Award – Beste Urban/Alternatieve Prestatie"
       ],
+      "awards_it": [
+        "Grammy per la migliore interpretazione urban/alternative"
+      ],
       "isrc": "USAR10301095",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/202883791",
@@ -1360,6 +1407,9 @@
       "fun_fact_nl": "Het nummer gebruikt drie verschillende beats over de drie coupletten, elk geproduceerd door een andere producent. Rick Rubin produceerde de door rock beïnvloede hoofdbeat, die was geïnspireerd op 'The Big Beat' van Billy Squier.",
       "awards_nl": [
         "Grammy Award – Beste Rap Soloprestatie"
+      ],
+      "awards_it": [
+        "Grammy per la migliore interpretazione rap solista"
       ],
       "isrc": "USDJ20301460",
       "uri_apple_music_by_region": {
@@ -1440,6 +1490,9 @@
       "fun_fact_nl": "Het nummer werd geproduceerd door Kanye West voordat hij een grote soloartiest werd. De samenwerking hielp Kanye op de kaart te zetten als een topproducent in de hiphop.",
       "awards_nl": [
         "Grammy Award – Beste Rapnummer (genomineerd)"
+      ],
+      "awards_it": [
+        "Candidatura al Grammy per la migliore canzone rap"
       ],
       "isrc": "USDJ20300765",
       "uri_apple_music_by_region": {
@@ -1574,6 +1627,9 @@
       "awards_nl": [
         "Grammy Award – Beste Rap Soloprestatie"
       ],
+      "awards_it": [
+        "Grammy per la migliore interpretazione rap solista"
+      ],
       "isrc": "USUM70500143",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1443571076",
@@ -1623,6 +1679,9 @@
       "awards_nl": [
         "Grammy Award – Beste Rap Soloprestatie"
       ],
+      "awards_it": [
+        "Grammy per la migliore interpretazione rap solista"
+      ],
       "isrc": "USUM70741299",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1443830216",
@@ -1671,6 +1730,9 @@
       "awards_nl": [
         "Grammy Award – Beste Rap Soloprestatie"
       ],
+      "awards_it": [
+        "Grammy per la migliore interpretazione rap solista"
+      ],
       "isrc": "USCM50800553",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1440737322",
@@ -1718,6 +1780,9 @@
       "fun_fact_nl": "Met de overleden Static Major, die tragisch stierf slechts enkele maanden na het opnemen van de hook, werd het nummer Lil Waynes eerste nummer 1-single in de Billboard Hot 100 en hielp het Tha Carter III om in de eerste week meer dan een miljoen exemplaren te verkopen.",
       "awards_nl": [
         "Grammy Award – Beste Rapnummer"
+      ],
+      "awards_it": [
+        "Grammy per la migliore canzone rap"
       ],
       "isrc": "USCM50800380",
       "uri_apple_music_by_region": {

--- a/custom_components/beatify/playlists/community/british-invasion-britpop.json
+++ b/custom_components/beatify/playlists/community/british-invasion-britpop.json
@@ -1,6 +1,6 @@
 {
   "name": "British Invasion & Britpop 🇬🇧",
-  "version": "1.11",
+  "version": "1.12",
   "tags": [
     "1960s",
     "1990s",
@@ -161,6 +161,9 @@
       "awards_nl": [
         "BRIT Award voor Beste Britse Single (1995)"
       ],
+      "awards_it": [
+        "Brit Award per il miglior singolo britannico (1995)"
+      ],
       "isrc": "GBAYE1200960",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/699606039",
@@ -209,6 +212,9 @@
       "uri_deezer": "deezer://track/7677778",
       "fun_fact_nl": "Keith Richards bedacht de iconische riff in zijn slaap in een hotel in Clearwater, Florida. Hij nam het op met een cassettespeler naast zijn bed en kon het zich de volgende ochtend niet meer herinneren — de rest van de band bevat alleen gesnurk.",
       "awards_nl": [
+        "Grammy Hall of Fame (1998)"
+      ],
+      "awards_it": [
         "Grammy Hall of Fame (1998)"
       ],
       "isrc": "USA176510160",
@@ -682,6 +688,9 @@
       "fun_fact_nl": "De iconische, op Bach geïnspireerde orgelintro werd gespeeld door Matthew Fisher, die decennia later een baanbrekende rechtszaak won waardoor hij als medeauteur werd erkend. Het nummer verkocht wereldwijd meer dan 10 miljoen exemplaren.",
       "awards_nl": [
         "Ivor Novello Award voor Meest Uitgevoerd Werk"
+      ],
+      "awards_it": [
+        "Ivor Novello Award per l'opera piu eseguita"
       ],
       "uri_apple_music": "applemusic://track/1469579797"
     },
@@ -1475,6 +1484,9 @@
       "awards_nl": [
         "Grammy Award voor Beste Rock-'n-Roll-opname (1965)"
       ],
+      "awards_it": [
+        "Grammy per la migliore registrazione rock and roll (1965)"
+      ],
       "isrc": "FRZ196400510",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1676474357",
@@ -1926,6 +1938,9 @@
       "fun_fact_nl": "Richard Ashcroft schreef dit over de strijd van zijn vader tegen een ziekte en de nutteloosheid van medicatie. Het werd de enige Britse nummer 1-hit van The Verve en wordt vaak aangehaald als een van de beste Britse nummers van de jaren '90.",
       "awards_nl": [
         "BRIT Award voor Beste Britse Single (Nomination, 1998)"
+      ],
+      "awards_it": [
+        "Candidatura al Brit Award per il miglior singolo britannico (1998)"
       ],
       "isrc": "GBUM71601819",
       "uri_apple_music_by_region": {

--- a/custom_components/beatify/playlists/community/fiesta-latina-90s.json
+++ b/custom_components/beatify/playlists/community/fiesta-latina-90s.json
@@ -1,6 +1,6 @@
 {
   "name": "Fiesta Latina 90s 🇲🇽",
-  "version": "1.8",
+  "version": "1.9",
   "tags": [
     "1990s",
     "latin",
@@ -172,6 +172,9 @@
       "fun_fact_nl": "Dit nummer wordt gezien als de lancering van de 'Latin Pop Explosion' van de late jaren '90. Het werd tegelijkertijd in het Engels en Spaans opgenomen en was het eerste nummer van een Latin-artiest dat op nummer 1 debuteerde in de Billboard Hot 100. Het bereikte de eerste plaats in meer dan 20 landen.",
       "awards_nl": [
         "Grammy-nominatie voor Opname van het Jaar"
+      ],
+      "awards_it": [
+        "Candidatura al Grammy per il disco dell'anno"
       ]
     },
     {
@@ -371,6 +374,9 @@
       "fun_fact_nl": "De titel verwijst naar bilirubine, een stof in het bloed, hier gebruikt als metafoor voor 'ziek van liefde'. Van het Grammy-winnende album 'Bachata Rosa', dat de Dominicaanse bachata en merengue revolutioneerde en internationaal aanzien gaf.",
       "awards_nl": [
         "Grammy Award voor Beste Tropisch Latijns Album (Bachata Rosa)"
+      ],
+      "awards_it": [
+        "Grammy per il miglior album latino tropicale (Bachata Rosa)"
       ],
       "isrc": "USKP10400046",
       "uri_apple_music_by_region": {
@@ -584,6 +590,9 @@
       "fun_fact_nl": "Werd het meest gedraaide merengue-nummer op de Amerikaanse radio en won de Grammy voor Best Tropical Latin Performance. De Puerto Ricaanse zanger Elvis Crespo was voorheen lid van Grupo Mania voordat hij zijn solocarrière lanceerde met deze enorme debuuthit.",
       "awards_nl": [
         "Grammy Award voor Beste Tropisch Latijnse Prestatie"
+      ],
+      "awards_it": [
+        "Grammy per la migliore interpretazione latina tropicale"
       ],
       "isrc": "USSD19700576",
       "uri_apple_music_by_region": {
@@ -1182,6 +1191,9 @@
       "fun_fact_nl": "De Puerto Ricaanse 'Mujer de Fuego' (Vuurvrouw) Olga Tañón is een van de meest succesvolle vrouwelijke merengue-artiesten in de geschiedenis. Dit krachtige nummer over een liegende partner werd een feministisch volkslied in heel Latijns-Amerika.",
       "awards_nl": [
         "Grammy-nominatie voor Beste Merengue-album"
+      ],
+      "awards_it": [
+        "Candidatura al Grammy per il miglior album merengue"
       ],
       "isrc": "USWL19400004",
       "uri_apple_music_by_region": {
@@ -1911,6 +1923,10 @@
       "awards_nl": [
         "Latin Grammy voor Opname van het Jaar",
         "Latin Grammy voor Album van het Jaar"
+      ],
+      "awards_it": [
+        "Latin Grammy per il disco dell'anno",
+        "Latin Grammy per l'album dell'anno"
       ],
       "isrc": "ES5150306001",
       "uri_apple_music_by_region": {

--- a/custom_components/beatify/playlists/community/gen-z-anthems.json
+++ b/custom_components/beatify/playlists/community/gen-z-anthems.json
@@ -1,6 +1,6 @@
 {
   "name": "Gen Z Anthems",
-  "version": "1.3",
+  "version": "1.4",
   "tags": [
     "2010s",
     "2020s",
@@ -96,6 +96,9 @@
       "awards_nl": [
         "Billboard Music Award - Beste Hot 100 Nummer"
       ],
+      "awards_it": [
+        "Billboard Music Award per la migliore canzone della Hot 100"
+      ],
       "isrc": "USUM71100061",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1851540442",
@@ -148,6 +151,10 @@
       "awards_nl": [
         "Grammy Award - Opname van het Jaar",
         "Grammy Award - Beste Pop Duo/Groepsprestatie"
+      ],
+      "awards_it": [
+        "Grammy per il disco dell'anno",
+        "Grammy per la migliore interpretazione pop di un duo o gruppo"
       ],
       "isrc": "AUZS21100040",
       "uri_apple_music_by_region": {
@@ -244,6 +251,10 @@
       "awards_nl": [
         "Grammy Award - Nummer van het Jaar",
         "Grammy Award - Beste Pop Solo Prestatie"
+      ],
+      "awards_it": [
+        "Grammy per la canzone dell'anno",
+        "Grammy per la migliore interpretazione pop solista"
       ]
     },
     {
@@ -287,6 +298,10 @@
       "awards_nl": [
         "Grammy Award - Beste Muziekvideo",
         "Grammy Award - Beste Pop Solo Prestatie"
+      ],
+      "awards_it": [
+        "Grammy per il miglior video musicale",
+        "Grammy per la migliore interpretazione pop solista"
       ],
       "isrc": "USQ4E1300686",
       "uri_apple_music_by_region": {
@@ -385,6 +400,11 @@
         "Grammy Award - Opname van het Jaar",
         "Grammy Award - Nummer van het Jaar",
         "Grammy Award - Beste Pop Solo Prestatie"
+      ],
+      "awards_it": [
+        "Grammy per il disco dell'anno",
+        "Grammy per la canzone dell'anno",
+        "Grammy per la migliore interpretazione pop solista"
       ]
     },
     {
@@ -471,6 +491,10 @@
       "awards_nl": [
         "Grammy Award - Beste Pop Solo Prestatie",
         "Billboard Music Award - Beste Hot 100 Nummer"
+      ],
+      "awards_it": [
+        "Grammy per la migliore interpretazione pop solista",
+        "Billboard Music Award per la migliore canzone della Hot 100"
       ]
     },
     {
@@ -517,6 +541,11 @@
         "Latin Grammy Award - Opname van het Jaar",
         "Latin Grammy Award - Nummer van het Jaar",
         "Billboard Music Award - Beste Hot 100 Nummer"
+      ],
+      "awards_it": [
+        "Latin Grammy per il disco dell'anno",
+        "Latin Grammy per la canzone dell'anno",
+        "Billboard Music Award per la migliore canzone della Hot 100"
       ],
       "isrc": "USUM71607007",
       "uri_apple_music_by_region": {
@@ -570,6 +599,10 @@
       "awards_nl": [
         "Grammy Award - Beste Rapnummer",
         "Billboard Music Award - Beste Hot 100 Nummer"
+      ],
+      "awards_it": [
+        "Grammy per la migliore canzone rap",
+        "Billboard Music Award per la migliore canzone della Hot 100"
       ]
     },
     {
@@ -659,6 +692,11 @@
         "Grammy Award - Opname van het Jaar",
         "Grammy Award - Nummer van het Jaar",
         "Grammy Award - Beste Pop Solo Prestatie"
+      ],
+      "awards_it": [
+        "Grammy per il disco dell'anno",
+        "Grammy per la canzone dell'anno",
+        "Grammy per la migliore interpretazione pop solista"
       ]
     },
     {
@@ -702,6 +740,10 @@
       "awards_nl": [
         "Grammy Award - Beste Muziekvideo",
         "CMA Award Nominatie - Muzikaal Evenement van het Jaar"
+      ],
+      "awards_it": [
+        "Grammy per il miglior video musicale",
+        "Candidatura al CMA Award per l'evento musicale dell'anno"
       ],
       "isrc": "USSM11902498",
       "uri_apple_music_by_region": {
@@ -752,6 +794,9 @@
       "fun_fact_nl": "Lewis Capaldi's zelfspot op sociale media maakte hem een Gen Z-icoon — hij verscheen ooit op Glastonbury met een Chewbacca-masker nadat zijn neef Peter Capaldi hem zo had genoemd.",
       "awards_nl": [
         "Brit Award - Nummer van het Jaar"
+      ],
+      "awards_it": [
+        "Brit Award per la canzone dell'anno"
       ],
       "isrc": "DEUM71807062",
       "uri_apple_music_by_region": {
@@ -808,6 +853,11 @@
         "Billboard Music Award - Beste Hot 100 Nummer",
         "Juno Award - Single van het Jaar",
         "American Music Award - Favoriete Pop/Rock Nummer"
+      ],
+      "awards_it": [
+        "Billboard Music Award per la migliore canzone della Hot 100",
+        "Juno Award per il singolo dell'anno",
+        "American Music Award per la canzone pop/rock preferita"
       ],
       "isrc": "USUG11904206",
       "uri_apple_music_by_region": {
@@ -891,6 +941,9 @@
       "fun_fact_nl": "De videoclip van Watermelon Sugar werd op een strand gefilmd met een disclaimer dat het 'opgedragen aan aanraking' was — gefilmd net voor de COVID-lockdowns, de timing was bijna poëtisch.",
       "awards_nl": [
         "Grammy Award - Beste Pop Solo Prestatie"
+      ],
+      "awards_it": [
+        "Grammy per la migliore interpretazione pop solista"
       ],
       "isrc": "USSM11912587",
       "uri_apple_music_by_region": {
@@ -985,6 +1038,9 @@
       "awards_nl": [
         "Grammy Award - Beste Pop Duo/Groepsprestatie"
       ],
+      "awards_it": [
+        "Grammy per la migliore interpretazione pop di un duo o gruppo"
+      ],
       "isrc": "USRC12100760",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1577637152",
@@ -1078,6 +1134,9 @@
       "awards_nl": [
         "Grammy Award - Opname van het Jaar"
       ],
+      "awards_it": [
+        "Grammy per il disco dell'anno"
+      ],
       "isrc": "USAT22202139",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1810531325",
@@ -1131,6 +1190,10 @@
         "Grammy Award - Beste Pop Vocaal Album (Harry's House)",
         "Brit Award - Nummer van het Jaar"
       ],
+      "awards_it": [
+        "Grammy per il miglior album vocale pop (Harry's House)",
+        "Brit Award per la canzone dell'anno"
+      ],
       "isrc": "USSM12200612",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1615585008",
@@ -1180,6 +1243,9 @@
       "fun_fact_nl": "Steve Lacy nam een groot deel van Bad Habit op met zijn iPhone via GarageBand — het feit dat een #1-hit deels op een telefoon is gemaakt, is echt het meest Gen Z-achtige ooit.",
       "awards_nl": [
         "Grammy Award - Beste Pop Solo Prestatie"
+      ],
+      "awards_it": [
+        "Grammy per la migliore interpretazione pop solista"
       ]
     },
     {
@@ -1223,6 +1289,10 @@
       "awards_nl": [
         "Grammy Award - Opname van het Jaar",
         "Grammy Award - Beste Pop Solo Prestatie"
+      ],
+      "awards_it": [
+        "Grammy per il disco dell'anno",
+        "Grammy per la migliore interpretazione pop solista"
       ],
       "isrc": "USSM12209777",
       "uri_apple_music_by_region": {

--- a/custom_components/beatify/playlists/community/greatest-metal-songs.json
+++ b/custom_components/beatify/playlists/community/greatest-metal-songs.json
@@ -1,6 +1,6 @@
 {
   "name": "Greatest Metal Songs of All Time 🤘",
-  "version": "1.16",
+  "version": "1.17",
   "tags": [
     "metal",
     "rock",
@@ -41,6 +41,9 @@
       "uri_tidal": "tidal://track/4085428",
       "fun_fact_nl": "Iron Man bevat een van de meest iconische gitaarriffs uit de rockgeschiedenis, gemaakt door Tony Iommi nadat hij de toppen van twee vingers had verloren bij een fabrieksongeval en prothetische vingertoppen had gemaakt van gesmolten plastic flessen. De openingsriff van het nummer imiteert de lompe tred van de tijdreizende ijzeren man die in de tekst wordt beschreven. Het werd later de basis voor het thema van de Marvel film franchise.",
       "awards_nl": [
+        "Grammy Hall of Fame"
+      ],
+      "awards_it": [
         "Grammy Hall of Fame"
       ],
       "isrc": "USWB11304371",
@@ -87,6 +90,9 @@
       "awards_nl": [
         "Grammy Hall of Fame"
       ],
+      "awards_it": [
+        "Grammy Hall of Fame"
+      ],
       "isrc": "USWB11304369",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/787644021",
@@ -130,6 +136,9 @@
       "fun_fact_nl": "Judas Priest pionierde met de leer-en-studs look die synoniem werd met heavy metal, waarbij zanger Rob Halford inspiratie putte uit de homoseksuele ledersubcultuur. De band wordt alom geprezen voor het codificeren van het geluid en imago van heavy metal. Halford kwam in 1998 uit de kast als homo en was daarmee een van de eerste grote rocksterren die dat deed.",
       "awards_nl": [
         "Grammy-nominatie"
+      ],
+      "awards_it": [
+        "Candidatura al Grammy"
       ],
       "isrc": "GBBBN8202006",
       "uri_apple_music_by_region": {
@@ -175,6 +184,9 @@
       "awards_nl": [
         "Grammy-nominatie"
       ],
+      "awards_it": [
+        "Candidatura al Grammy"
+      ],
       "isrc": "GBCHB1500031",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1713861908",
@@ -219,6 +231,9 @@
       "awards_nl": [
         "Grammy-nominatie"
       ],
+      "awards_it": [
+        "Candidatura al Grammy"
+      ],
       "isrc": "GBCHB1500023",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1713862907",
@@ -261,6 +276,9 @@
       "uri_tidal": "tidal://track/179213196",
       "fun_fact_nl": "Master of Puppets wordt algemeen beschouwd als het beste heavy metal album ooit gemaakt, en het titelnummer is een van de meest technisch veeleisende en geliefde metalsongs aller tijden. Het nummer bereikte nieuwe generaties nadat het in 2022 te horen was in het vierde seizoen van Stranger Things, waardoor het wereldwijd op nummer één kwam te staan op Spotify. Bassist Cliff Burton stierf bij een busongeluk slechts enkele maanden na de release van het album.",
       "awards_nl": [
+        "Grammy Hall of Fame"
+      ],
+      "awards_it": [
         "Grammy Hall of Fame"
       ],
       "isrc": "QMKHM1600219",
@@ -307,6 +325,9 @@
       "awards_nl": [
         "Grammy Award voor Beste Metalprestatie"
       ],
+      "awards_it": [
+        "Grammy per la migliore interpretazione metal"
+      ],
       "isrc": "QMKHM1900001",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1572046436",
@@ -350,6 +371,9 @@
       "fun_fact_nl": "One was Metallica's allereerste videoclip, geïnspireerd op de anti-oorlogsfilm Johnny Got His Gun uit 1971. Het nummer begint als een beklemmende ballade voordat het explodeert in een woeste thrashaanval, die de psychologische afdaling weerspiegelt van een soldaat die wordt achtergelaten als een verlamd, gevoelloos torso. Het leverde Metallica hun eerste Grammy Award op.",
       "awards_nl": [
         "Grammy Award voor Beste Metalprestatie"
+      ],
+      "awards_it": [
+        "Grammy per la migliore interpretazione metal"
       ],
       "isrc": "QMKHM1700138",
       "uri_apple_music_by_region": {
@@ -395,6 +419,9 @@
       "awards_nl": [
         "Grammy-nominatie"
       ],
+      "awards_it": [
+        "Candidatura al Grammy"
+      ],
       "isrc": "USSM18600241",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1733769810",
@@ -438,6 +465,9 @@
       "fun_fact_nl": "Walk werd Pantera's signatuurnummer en een van de bepalende nummers van groove metal. De verpletterende riffs van gitarist Dimebag Darrell en de confronterende zang van Phil Anselmo maakten het tot een hymne van agressie. Dimebag Darrell werd in 2004 tragisch doodgeschoten op het podium, waardoor Walk een nog aangrijpender stuk metalgeschiedenis is geworden.",
       "awards_nl": [
         "Grammy-nominatie"
+      ],
+      "awards_it": [
+        "Candidatura al Grammy"
       ],
       "isrc": "USAT21202190",
       "uri_apple_music_by_region": {
@@ -483,6 +513,9 @@
       "awards_nl": [
         "Grammy-nominatie"
       ],
+      "awards_it": [
+        "Candidatura al Grammy"
+      ],
       "isrc": "USAT21001391",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1814306260",
@@ -526,6 +559,9 @@
       "fun_fact_nl": "Seek and Destroy van Metallica's debuutalbum Kill 'Em All is een van de oudste en meest geliefde live-albums van de band en ontbreekt bijna nooit op een setlist. Het album werd oorspronkelijk afgewezen door grote labels en zelf gefinancierd door Megaforce Records, waarmee de Amerikaanse thrash metalscene bijna eigenhandig werd gelanceerd. De call-and-response structuur van het nummer maakt het tot een elektrisch publieksmoment.",
       "awards_nl": [
         "Grammy-nominatie"
+      ],
+      "awards_it": [
+        "Candidatura al Grammy"
       ],
       "isrc": "USEE19900919",
       "uri_apple_music_by_region": {
@@ -571,6 +607,9 @@
       "awards_nl": [
         "Grammy-nominatie"
       ],
+      "awards_it": [
+        "Candidatura al Grammy"
+      ],
       "isrc": "USCA29000003",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/724649275",
@@ -614,6 +653,9 @@
       "fun_fact_nl": "Symphony of Destruction is Megadeth's meest commercieel succesvolle nummer, dat toegankelijkheid combineert met Dave Mustaine's kenmerkende agressie. De memorabele hoofdriff werd geïnspireerd door een simpel akkoordenschema waar Mustaine op stuitte tijdens een soundcheck. Het nummer blijft decennia na de release een van de meest gedraaide nummers op de rockradio.",
       "awards_nl": [
         "Grammy-nominatie"
+      ],
+      "awards_it": [
+        "Candidatura al Grammy"
       ],
       "isrc": "USCA20400616",
       "uri_apple_music_by_region": {
@@ -659,6 +701,9 @@
       "awards_nl": [
         "Grammy-nominatie"
       ],
+      "awards_it": [
+        "Candidatura al Grammy"
+      ],
       "isrc": "USWB11507137",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1048476460",
@@ -701,6 +746,9 @@
       "uri_tidal": "tidal://track/4085511",
       "fun_fact_nl": "Crazy Train bevat een van de meest herkenbare gitaarriffs uit de rockgeschiedenis, gespeeld door wijlen Randy Rhoads - algemeen beschouwd als een van de grootste gitaristen die ooit heeft geleefd. Rhoads kwam in 1982 op 25-jarige leeftijd om het leven bij een vliegtuigongeluk. De openingskreet 'All aboard!' is een van de meest iconische momenten uit de rockgeschiedenis geworden.",
       "awards_nl": [
+        "Grammy Hall of Fame"
+      ],
+      "awards_it": [
         "Grammy Hall of Fame"
       ],
       "isrc": "USSM11002845",
@@ -747,6 +795,9 @@
       "awards_nl": [
         "Grammy-nominatie"
       ],
+      "awards_it": [
+        "Candidatura al Grammy"
+      ],
       "isrc": "USSM10107256",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/273714640",
@@ -790,6 +841,9 @@
       "fun_fact_nl": "Toxicity is het meest commercieel succesvolle nummer van System of a Down, waarvan de titel verwijst naar het giftige milieu van de moderne samenleving. Het gelijknamige album debuteerde gelijktijdig op nummer één in de VS en het VK. De unieke mix van Armeense folk-invloeden, thrash metal en alternatieve rock onderscheidt de band van alle andere bands uit hun tijd.",
       "awards_nl": [
         "Grammy-nominatie"
+      ],
+      "awards_it": [
+        "Candidatura al Grammy"
       ],
       "isrc": "USSM10107262",
       "uri_apple_music_by_region": {
@@ -835,6 +889,9 @@
       "awards_nl": [
         "Grammy Award voor Beste Metalprestatie"
       ],
+      "awards_it": [
+        "Grammy per la migliore interpretazione metal"
+      ],
       "isrc": "USVR10100013",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1474185654",
@@ -878,6 +935,9 @@
       "fun_fact_nl": "Change is een van Deftones' meest hypnotiserende en verontrustende nummers, opgebouwd rond een gefluisterde gitaarloop en Chino Moreno's verschuivende dynamische zang. White Pony wordt algemeen beschouwd als het meesterwerk van de Deftones en als een van de meest innovatieve rockalbums van de jaren 2000. De band wordt gezien als pionier op het gebied van nu-metal en alternatieve metal.",
       "awards_nl": [
         "Grammy-nominatie"
+      ],
+      "awards_it": [
+        "Candidatura al Grammy"
       ],
       "isrc": "USRE11600104",
       "uri_apple_music_by_region": {
@@ -923,6 +983,9 @@
       "awards_nl": [
         "Grammy Award voor Beste Hardrockprestatie"
       ],
+      "awards_it": [
+        "Grammy per la migliore interpretazione hard rock"
+      ],
       "isrc": "USAM19400007",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1436558379",
@@ -966,6 +1029,9 @@
       "fun_fact_nl": "Rooster werd geschreven door gitarist Jerry Cantrell als een eerbetoon aan zijn vader, die diende in de Vietnamoorlog - zijn bijnaam was Rooster. De beklemmende combinatie van drop-D riffs en dubbele vocalistenharmonieën tussen Cantrell en Layne Staley is een van de krachtigste momenten van Alice in Chains. Layne Staley stierf in 2002 aan een overdosis drugs.",
       "awards_nl": [
         "Grammy-nominatie"
+      ],
+      "awards_it": [
+        "Candidatura al Grammy"
       ],
       "isrc": "USSM19200881",
       "uri_apple_music_by_region": {
@@ -1011,6 +1077,9 @@
       "awards_nl": [
         "Grammy-nominatie"
       ],
+      "awards_it": [
+        "Candidatura al Grammy"
+      ],
       "isrc": "USGF18714801",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1377826728",
@@ -1055,6 +1124,9 @@
       "awards_nl": [
         "Grammy-nominatie"
       ],
+      "awards_it": [
+        "Candidatura al Grammy"
+      ],
       "isrc": "USGF18714809",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1377813701",
@@ -1097,6 +1169,9 @@
       "uri_tidal": "tidal://track/4085621",
       "fun_fact_nl": "Highway to Hell was het laatste album dat werd opgenomen met zanger Bon Scott voor zijn tragische dood in 1980. Het titelnummer werd AC/DC's doorbraaknummer in Amerika en is een van de meest iconische rock anthems ooit opgenomen. De titel van het album was bijna Highway to Hell maar het management van de band was bang dat dit radiostations van zich zou vervreemden.",
       "awards_nl": [
+        "Grammy Hall of Fame"
+      ],
+      "awards_it": [
         "Grammy Hall of Fame"
       ],
       "isrc": "AUAP07900028",
@@ -1143,6 +1218,9 @@
       "awards_nl": [
         "Grammy Hall of Fame"
       ],
+      "awards_it": [
+        "Grammy Hall of Fame"
+      ],
       "isrc": "AUAP08000046",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/576003082",
@@ -1185,6 +1263,9 @@
       "uri_tidal": "tidal://track/4085643",
       "fun_fact_nl": "Smoke on the Water bevat misschien wel de beroemdste gitaarriff ooit geschreven - het motief van vier noten dat elke beginnende gitarist als eerste leert. Het nummer beschrijft de echte brand in het Montreux Casino in december 1971 terwijl Frank Zappa optrad, waarvan Deep Purple getuige was vanaf de overkant van het meer van Genève. De band nam vervolgens het album Machine Head op in een mobiele studio geleend van de Rolling Stones.",
       "awards_nl": [
+        "Grammy Hall of Fame"
+      ],
+      "awards_it": [
         "Grammy Hall of Fame"
       ],
       "isrc": "USRH11602140",
@@ -1231,6 +1312,9 @@
       "awards_nl": [
         "Grammy-nominatie"
       ],
+      "awards_it": [
+        "Candidatura al Grammy"
+      ],
       "isrc": "GBUM71701307",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1438626355",
@@ -1274,6 +1358,9 @@
       "fun_fact_nl": "Jump was Van Halen's enige nummer 1 single in de VS en bevatte controversieel een synthesizer lead, die Eddie Van Halen jarenlang voor de band verborgen had gehouden. David Lee Roth had naar verluidt een hekel aan de keyboard-gedreven aanpak, maar zong er toch op. Eddie Van Halen wordt algemeen beschouwd als een van de meest revolutionaire gitaristen in de rockgeschiedenis.",
       "awards_nl": [
         "Grammy-nominatie"
+      ],
+      "awards_it": [
+        "Candidatura al Grammy"
       ],
       "isrc": "USWB11403500",
       "uri_apple_music_by_region": {
@@ -1319,6 +1406,9 @@
       "awards_nl": [
         "Grammy-nominatie"
       ],
+      "awards_it": [
+        "Candidatura al Grammy"
+      ],
       "isrc": "USSM19200317",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1737564412",
@@ -1362,6 +1452,9 @@
       "fun_fact_nl": "The Beautiful People is het meest iconische nummer van Marilyn Manson en een van de bepalende industrial metalnummers van de jaren '90. De gemechaniseerde groove werd samen met producer Trent Reznor van Nine Inch Nails geschreven. Mansons shock-rock theatraliteit maakte hem tot een van de meest controversiële figuren in de rockgeschiedenis en leidde regelmatig tot pogingen tot censuur.",
       "awards_nl": [
         "Grammy-nominatie"
+      ],
+      "awards_it": [
+        "Candidatura al Grammy"
       ],
       "isrc": "USIR19601008",
       "uri_apple_music_by_region": {
@@ -1407,6 +1500,9 @@
       "awards_nl": [
         "Grammy Award voor Beste Korte Muziekvideo"
       ],
+      "awards_it": [
+        "Grammy per il miglior video musicale di forma breve"
+      ],
       "isrc": "USSM19805391",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1831584743",
@@ -1450,6 +1546,9 @@
       "fun_fact_nl": "Slipknot brak in 1999 door in de metalscene met bijpassende ketelpakken en genummerde maskers, en creëerde zo een van de meest visueel opvallende esthetica in de rockgeschiedenis. De band bestaat uit negen leden en is daarmee een van de grootste metalbands uit de geschiedenis. Van hun debuutalbum werden alleen al in de VS meer dan drie miljoen exemplaren verkocht.",
       "awards_nl": [
         "Grammy-nominatie"
+      ],
+      "awards_it": [
+        "Candidatura al Grammy"
       ],
       "isrc": "NLA321400496",
       "uri_apple_music_by_region": {
@@ -1495,6 +1594,9 @@
       "awards_nl": [
         "Grammy-nominatie"
       ],
+      "awards_it": [
+        "Candidatura al Grammy"
+      ],
       "isrc": "NLA321400554",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/927744252",
@@ -1538,6 +1640,9 @@
       "fun_fact_nl": "Down with the Sickness werd een van de bepalende nummers van de hardrock van begin jaren 2000, verankerd door de unieke gutturale introzang van David Draiman en de meedogenloze riff van het nummer. Disturbed's debuut The Sickness debuteerde op nummer 29 en verkocht uiteindelijk meer dan vier miljoen exemplaren in de VS. Het nummer wordt regelmatig verkozen tot een van de beste metalnummers van het millennium.",
       "awards_nl": [
         "Grammy-nominatie"
+      ],
+      "awards_it": [
+        "Candidatura al Grammy"
       ],
       "isrc": "USRE11500333",
       "uri_apple_music_by_region": {
@@ -1583,6 +1688,9 @@
       "awards_nl": [
         "Grammy-nominatie"
       ],
+      "awards_it": [
+        "Candidatura al Grammy"
+      ],
       "isrc": "USRZR0300801",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/6777217538",
@@ -1626,6 +1734,9 @@
       "fun_fact_nl": "Blood and Thunder opent Mastodons doorbraakalbum Leviathan, een conceptuele hervertelling van Moby Dick door middel van progressieve sludgemetal. Het album wordt beschouwd als een van de meest creatieve en ambitieuze metalplaten van de jaren 2000. Mastodon wordt alom geprezen voor het verhogen van de artistieke ambities van metal en het bewijzen dat het genre in staat is tot echte progressieve diepgang.",
       "awards_nl": [
         "Grammy-nominatie"
+      ],
+      "awards_it": [
+        "Candidatura al Grammy"
       ],
       "isrc": "US2640562201",
       "uri_apple_music_by_region": {
@@ -1671,6 +1782,9 @@
       "awards_nl": [
         "Grammy-nominatie"
       ],
+      "awards_it": [
+        "Candidatura al Grammy"
+      ],
       "isrc": "FR6V80520037",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/213374170",
@@ -1714,6 +1828,9 @@
       "fun_fact_nl": "Silvera werd Gojira's meest toegankelijke en commercieel succesvolle nummer, een groove-driven metal anthem dat hen Grammy nominaties opleverde. Het nummer hielp de band om een veel breder publiek te bereiken zonder afbreuk te doen aan hun heavy sound. Magma, het album waarop het staat, werd geïnspireerd door de dood van de moeder van Joe en Mario Duplantier en wordt beschouwd als een van de meest emotioneel diepgaande metalplaten.",
       "awards_nl": [
         "Grammy-nominatie"
+      ],
+      "awards_it": [
+        "Candidatura al Grammy"
       ],
       "isrc": "NLA321600053",
       "uri_apple_music_by_region": {
@@ -1759,6 +1876,9 @@
       "awards_nl": [
         "Grammy-nominatie"
       ],
+      "awards_it": [
+        "Candidatura al Grammy"
+      ],
       "isrc": "NLA329513650",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1630107557",
@@ -1802,6 +1922,9 @@
       "fun_fact_nl": "Square Hammer leverde Ghost in 2017 een Grammy op voor beste metalprestatie en is het nummer dat de Zweedse theatrale metalband wereldwijd onder de aandacht bracht. Ghost's combinatie van arena-rock hooks, satanische beelden en theatrale liveshows - compleet met een pausachtige frontman genaamd Papa Emeritus - maakte hen tot een van de meest visueel spectaculaire acts in de moderne rock.",
       "awards_nl": [
         "Grammy Award voor Beste Metalprestatie"
+      ],
+      "awards_it": [
+        "Grammy per la migliore interpretazione metal"
       ],
       "isrc": "USC4R1601984",
       "uri_apple_music_by_region": {
@@ -1847,6 +1970,9 @@
       "awards_nl": [
         "Grammy Award voor Beste Metalprestatie"
       ],
+      "awards_it": [
+        "Grammy per la migliore interpretazione metal"
+      ],
       "isrc": "USRC11902032",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1475686698",
@@ -1890,6 +2016,9 @@
       "fun_fact_nl": "Ace of Spades is het definitieve volkslied van Motörhead en een van de snelste en meest woeste nummers uit de rockgeschiedenis. Lemmy Kilmister, de iconische bassist en zanger van de band, leefde een legendarisch hedonistische levensstijl, maar bleef toeren en opnemen tot weken voor zijn dood op 70-jarige leeftijd in december 2015. Het nummer is gebruikt in talloze films, tv-shows en videogames.",
       "awards_nl": [
         "Grammy-nominatie"
+      ],
+      "awards_it": [
+        "Candidatura al Grammy"
       ],
       "isrc": "GBAJE8000033",
       "uri_apple_music_by_region": {
@@ -1935,6 +2064,9 @@
       "awards_nl": [
         "Grammy-nominatie"
       ],
+      "awards_it": [
+        "Candidatura al Grammy"
+      ],
       "isrc": "DED830703548",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1882049242",
@@ -1978,6 +2110,9 @@
       "fun_fact_nl": "Vulgar Display of Power is een van de meest invloedrijke metalalbums aller tijden en verstevigde Pantera's plaats in de heavy metal canon. Dimebag Darrell's agressieve, hoekige gitaarwerk op dit album beïnvloedde een generatie metal gitaristen. De albumhoes - een man die in zijn gezicht wordt geslagen - werd gekozen nadat de band letterlijk vrijwilligers had geslagen en de resultaten had gefotografeerd.",
       "awards_nl": [
         "Grammy-nominatie"
+      ],
+      "awards_it": [
+        "Candidatura al Grammy"
       ],
       "isrc": "USAT21202188",
       "uri_apple_music_by_region": {
@@ -2023,6 +2158,9 @@
       "awards_nl": [
         "Grammy-nominatie"
       ],
+      "awards_it": [
+        "Candidatura al Grammy"
+      ],
       "isrc": "USWB11201118",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/591534783",
@@ -2066,6 +2204,9 @@
       "fun_fact_nl": "The End of Heartache is het bepalende nummer van metalcore, een genre dat Killswitch Engage hielp creëren door de agressie van metal samen te voegen met de melodieuze gevoeligheid van hardcorepunk. De dubbele dynamiek van het nummer - brute breakdowns en stijgende cleane refreinen - werd het sjabloon voor honderden bands. Het hielp de New Wave of American Heavy Metal beweging te lanceren.",
       "awards_nl": [
         "Grammy-nominatie"
+      ],
+      "awards_it": [
+        "Candidatura al Grammy"
       ],
       "isrc": "NLA320420753",
       "uri_apple_music_by_region": {
@@ -2111,6 +2252,9 @@
       "awards_nl": [
         "Grammy-nominatie"
       ],
+      "awards_it": [
+        "Candidatura al Grammy"
+      ],
       "isrc": "NLA321392901",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/697728142",
@@ -2154,6 +2298,9 @@
       "fun_fact_nl": "Drown markeerde een enorme evolutie in het geluid van Bring Me the Horizon, weg van metalcore naar atmosferische rock en synth-gedreven anthems. Het nummer werd hun grootste hit en maakte hen bekend bij een mainstream publiek. BMTH is een van de meest succesvolle Britse heavy acts van hun generatie, die zich enorm heeft ontwikkeld na hun brute deathcore begin.",
       "awards_nl": [
         "Grammy-nominatie"
+      ],
+      "awards_it": [
+        "Candidatura al Grammy"
       ],
       "isrc": "GBARL1401189",
       "uri_apple_music_by_region": {
@@ -2199,6 +2346,9 @@
       "awards_nl": [
         "Grammy-nominatie"
       ],
+      "awards_it": [
+        "Candidatura al Grammy"
+      ],
       "isrc": "USEP41014009",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1485045876",
@@ -2243,6 +2393,9 @@
       "awards_nl": [
         "Grammy-nominatie"
       ],
+      "awards_it": [
+        "Candidatura al Grammy"
+      ],
       "isrc": "USEP41604038",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1485075528",
@@ -2286,6 +2439,9 @@
       "fun_fact_nl": "Underneath won Code Orange in 2021 een Grammy voor beste metalprestatie, waardoor ze een van de jongste bands ooit zijn die de prijs wonnen. De hardcore punk- en metalband uit Pittsburgh begon met repeteren op de middelbare school en tekende als tiener bij een groot label. Hun avant-gardistische benadering van heavy muziek - met industriële, elektronische en noise-elementen - vertegenwoordigt het snijvlak van moderne metal.",
       "awards_nl": [
         "Grammy Award voor Beste Metalprestatie"
+      ],
+      "awards_it": [
+        "Grammy per la migliore interpretazione metal"
       ],
       "isrc": "NLA321900283",
       "uri_apple_music_by_region": {
@@ -2634,6 +2790,9 @@
       "fun_fact_nl": "B.Y.O.B. ('Bring Your Own Bombs'), van het album Mezmerize (2005), is een woedend protestlied tegen de Irakoorlog, dat razende coupletten contrasteert met een verrassend melodieus refrein. Het won in 2006 de Grammy Award voor Beste Hardrockprestatie.",
       "awards_nl": [
         "Grammy Award voor Beste Hardrockprestatie"
+      ],
+      "awards_it": [
+        "Grammy per la migliore interpretazione hard rock"
       ],
       "isrc": "USSM10501327",
       "uri_apple_music_by_region": {

--- a/custom_components/beatify/playlists/community/schlager-klassiker.json
+++ b/custom_components/beatify/playlists/community/schlager-klassiker.json
@@ -1,6 +1,6 @@
 {
   "name": "Schlager Classics 🇩🇪",
-  "version": "1.16",
+  "version": "1.17",
   "tags": [
     "german",
     "schlager",
@@ -87,6 +87,9 @@
       "fun_fact_nl": "Vicky Leandros won in 1972 het Eurovisiesongfestival voor Luxemburg met 'Après toi'. Ich liebe das Leben toont haar krachtige stem en positieve kijk op het leven, die haar tot een Schlagerlegende maakten.",
       "awards_nl": [
         "Winnaar Eurovisie Songfestival (1972)"
+      ],
+      "awards_it": [
+        "Vincitore dell'Eurovision Song Contest 1972"
       ]
     },
     {
@@ -168,6 +171,9 @@
       "fun_fact_nl": "Griechischer Wein is Udo Jürgens' eerbetoon aan Griekse gastarbeiders in Duitsland. Het lied werd een onofficiële hymne van de integratie en wordt tot op de dag van vandaag op elk feest meegezongen.",
       "awards_nl": [
         "Gouden Plaat (1974)"
+      ],
+      "awards_it": [
+        "Goldene Schallplatte (1974)"
       ],
       "isrc": "DEA817400019",
       "uri_apple_music_by_region": {
@@ -267,6 +273,10 @@
         "Echo (1991)",
         "Goldene Stimmgabel (1991)"
       ],
+      "awards_it": [
+        "Echo (1991)",
+        "Goldene Stimmgabel (1991)"
+      ],
       "isrc": "DEA651000005",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1611040987",
@@ -316,6 +326,9 @@
       "uri_deezer": "deezer://track/99127316",
       "fun_fact_nl": "Abenteuerland was PUR's grootste hit en werd een hymne voor dromers en avonturiers. De band uit Bietigheim-Bissingen is een van de succesvolste Duitse rockbands aller tijden.",
       "awards_nl": [
+        "Echo (1996)"
+      ],
+      "awards_it": [
         "Echo (1996)"
       ],
       "isrc": "DEA349503010",
@@ -388,6 +401,12 @@
         "Bambi (2014)",
         "Goldene Kamera (2014)"
       ],
+      "awards_it": [
+        "Echo (2014)",
+        "Goldene Henne (2014)",
+        "Bambi (2014)",
+        "Goldene Kamera (2014)"
+      ],
       "isrc": "DEUM71303188",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1709414078",
@@ -440,6 +459,9 @@
       "fun_fact_nl": "Ich war noch niemals in New York is Udo Jürgens' ode aan onvervulde dromen. Het lied werd later bewerkt tot een succesvolle musical die wereldwijd wordt opgevoerd.",
       "awards_nl": [
         "Gouden Plaat (1982)"
+      ],
+      "awards_it": [
+        "Goldene Schallplatte (1982)"
       ],
       "isrc": "DEA818200038",
       "uri_apple_music_by_region": {
@@ -520,6 +542,9 @@
       "awards_nl": [
         "Deutscher Kleinkunstpreis"
       ],
+      "awards_it": [
+        "Deutscher Kleinkunstpreis"
+      ],
       "isrc": "DEC649800506",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/724105106",
@@ -569,6 +594,9 @@
       "uri_deezer": "deezer://track/3489487",
       "fun_fact_nl": "Ti Amo maakte van Howard Carpendale een superster van de Duitse Schlager. De in Zuid-Afrika geboren zanger verkocht meer dan 25 miljoen platen en vulde de grootste zalen.",
       "awards_nl": [
+        "Goldene Stimmgabel (1977)"
+      ],
+      "awards_it": [
         "Goldene Stimmgabel (1977)"
       ]
     },
@@ -685,6 +713,9 @@
       "uri_deezer": "deezer://track/2312569",
       "fun_fact_nl": "Er gehört zu mir van Marianne Rosenberg werd een klassieker en een hymne van zelfbevestiging. Rosenberg wordt beschouwd als de 'Koningin van de Schlager' en heeft het genre gevormd sinds de jaren 1970.",
       "awards_nl": [
+        "Goldene Stimmgabel (1975)"
+      ],
+      "awards_it": [
         "Goldene Stimmgabel (1975)"
       ],
       "isrc": "DEQS92000744",
@@ -916,6 +947,10 @@
         "Echo (2008)",
         "Amadeus Austrian Music Award (2008)"
       ],
+      "awards_it": [
+        "Echo (2008)",
+        "Amadeus Austrian Music Award (2008)"
+      ],
       "isrc": "DEUM70606361",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1612326333",
@@ -1003,6 +1038,9 @@
       "uri_deezer": "deezer://track/2185735",
       "fun_fact_nl": "Jenseits von Eden van Nino de Angelo werd de grootste hit van de zanger. Dit dramatische nummer laat zijn krachtige stem horen en maakte van hem een ster in de jaren 80.",
       "awards_nl": [
+        "Goldene Stimmgabel (1984)"
+      ],
+      "awards_it": [
         "Goldene Stimmgabel (1984)"
       ],
       "isrc": "DEA812000536",
@@ -1271,6 +1309,10 @@
         "Amadeus Austrian Music Award (2015)",
         "Echo (2015)"
       ],
+      "awards_it": [
+        "Amadeus Austrian Music Award (2015)",
+        "Echo (2015)"
+      ],
       "isrc": "DEUM71500645",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1702249934",
@@ -1350,6 +1392,9 @@
       "awards_nl": [
         "Goldene Stimmgabel (1983)"
       ],
+      "awards_it": [
+        "Goldene Stimmgabel (1983)"
+      ],
       "isrc": "DEC739600528",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1658114506",
@@ -1427,6 +1472,9 @@
       "uri_deezer": "deezer://track/66506378",
       "fun_fact_nl": "Santa Maria van Roland Kaiser bracht het Latijnse gevoel naar de Duitse Schlager. Kaiser staat bekend als de 'Keizer van de Schlager' en vult tot op de dag van vandaag de grootste zalen.",
       "awards_nl": [
+        "Goldene Stimmgabel (1980)"
+      ],
+      "awards_it": [
         "Goldene Stimmgabel (1980)"
       ]
     },
@@ -1608,6 +1656,9 @@
       "fun_fact_nl": "Warum hast du nicht nein gesagt van Roland Kaiser en Maite Kelly werd een moderne Schlager duet klassieker. De chemie tussen de twee is voelbaar op het podium.",
       "awards_nl": [
         "Goldene Henne (2015)"
+      ],
+      "awards_it": [
+        "Goldene Henne (2015)"
       ]
     },
     {
@@ -1756,6 +1807,9 @@
       "awards_nl": [
         "Echo (2010)"
       ],
+      "awards_it": [
+        "Echo (2010)"
+      ],
       "isrc": "DEC610900572",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/716328601",
@@ -1840,6 +1894,10 @@
       "fun_fact_nl": "Ein bisschen Frieden van Nicole won in 1982 het Eurovisie Songfestival voor Duitsland. Het was de eerste ESC-overwinning van Duitsland en maakte van Nicole een ster.",
       "awards_nl": [
         "Winnaar Eurovisie Songfestival (1982)",
+        "Goldene Stimmgabel (1982)"
+      ],
+      "awards_it": [
+        "Vincitore dell'Eurovision Song Contest 1982",
         "Goldene Stimmgabel (1982)"
       ],
       "isrc": "DEC718200001",
@@ -2324,6 +2382,9 @@
       "fun_fact_nl": "Du van Peter Maffay was zijn doorbraakhit en maakte van hem een superster. De titel staat in het Guinness Book als de best verkochte single van een Duitse artiest.",
       "awards_nl": [
         "Gouden Plaat (1970)"
+      ],
+      "awards_it": [
+        "Goldene Schallplatte (1970)"
       ],
       "isrc": "DEA818100076",
       "uri_apple_music_by_region": {

--- a/custom_components/beatify/playlists/disco-funk-classics.json
+++ b/custom_components/beatify/playlists/disco-funk-classics.json
@@ -1,6 +1,6 @@
 {
   "name": "Disco & Funk Classics",
-  "version": "1.19",
+  "version": "1.20",
   "tags": [
     "1970s",
     "1980s",
@@ -722,6 +722,9 @@
       "awards_nl": [
         "Grammy Award voor Beste Mannelijke R&B Zangprestatie"
       ],
+      "awards_it": [
+        "Grammy per la migliore interpretazione vocale R&B maschile"
+      ],
       "isrc": "USSM19803028",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1739929127",
@@ -809,6 +812,9 @@
       "fun_fact_nl": "Geschreven door George Merrill en Shannon Rubicam, die ook Whitney's 'How Will I Know' schreven. Het stond twee weken op nummer 1 en won de Grammy voor Best Female Pop Vocal. De biopic uit 2022 over Whitney Houston werd vernoemd naar dit nummer.",
       "awards_nl": [
         "Grammy Award voor Beste Vrouwelijke Pop Zangprestatie"
+      ],
+      "awards_it": [
+        "Grammy per la migliore interpretazione vocale pop femminile"
       ],
       "isrc": "USAR18700121",
       "uri_apple_music_by_region": {
@@ -1256,6 +1262,9 @@
       "awards_nl": [
         "Grammy Award voor Beste Disco-opname"
       ],
+      "awards_it": [
+        "Grammy per la migliore registrazione disco"
+      ],
       "isrc": "USPR37800083",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1443818368",
@@ -1426,6 +1435,9 @@
       "awards_nl": [
         "Oscarnominatie voor Beste Originele Lied"
       ],
+      "awards_it": [
+        "Candidatura all'Oscar per la migliore canzone originale"
+      ],
       "isrc": "USNLR1200531",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1454593961",
@@ -1473,6 +1485,9 @@
       "fun_fact_nl": "Geproduceerd door Quincy Jones en geschreven door Rod Temperton (die ook Michael Jacksons 'Thriller' schreef). Het vermengde jazz-gitaarvirtuositeit met disco-funkgrooves en bewees dat Benson zowel de jazz- als de pophitparade kon domineren.",
       "awards_nl": [
         "Grammy Award voor Beste Mannelijke R&B Zangprestatie"
+      ],
+      "awards_it": [
+        "Grammy per la migliore interpretazione vocale R&B maschile"
       ],
       "isrc": "USWB19900127",
       "uri_apple_music_by_region": {
@@ -1604,6 +1619,9 @@
       "awards_nl": [
         "Grammy Award voor Beste Vrouwelijke Rock Zangprestatie"
       ],
+      "awards_it": [
+        "Grammy per la migliore interpretazione vocale rock femminile"
+      ],
       "isrc": "USPR37907202",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1704761711",
@@ -1653,6 +1671,10 @@
       "fun_fact_nl": "Won de Oscar voor Beste Originele Nummer uit de film 'Thank God It's Friday'. Het begint uniek als een langzame ballade voordat het losbarst in een energiek disco-nummer - een structuur die revolutionair was voor disco op dat moment.",
       "awards_nl": [
         "Oscar voor Beste Originele Lied",
+        "Golden Globe"
+      ],
+      "awards_it": [
+        "Oscar per la migliore canzone originale",
         "Golden Globe"
       ],
       "isrc": "USPR39402394",
@@ -2388,6 +2410,9 @@
       "awards_nl": [
         "Grammy Award voor Beste R&B-nummer"
       ],
+      "awards_it": [
+        "Grammy per la migliore canzone R&B"
+      ],
       "isrc": "USWB19600662",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1807720130",
@@ -2599,6 +2624,9 @@
       "fun_fact_nl": "Geschreven door Marti Sharron, Gary Skardina en Stephen Mitchell. Het won de Grammy voor Best Pop Performance by a Duo or Group. Het nummer kreeg hernieuwde populariteit toen het te zien was in de film 'Love Actually' (2003) en in Hugh Grants beroemde dansscène.",
       "awards_nl": [
         "Grammy Award voor Beste Popprestatie door Duo of Groep"
+      ],
+      "awards_it": [
+        "Grammy per la migliore interpretazione pop di un duo o gruppo"
       ],
       "isrc": "USRC18303288",
       "uri_apple_music_by_region": {

--- a/custom_components/beatify/playlists/disney-classics.json
+++ b/custom_components/beatify/playlists/disney-classics.json
@@ -1,6 +1,6 @@
 {
   "name": "Disney Classics",
-  "version": "1.8",
+  "version": "1.9",
   "tags": [
     "disney",
     "movies",
@@ -49,6 +49,10 @@
       "awards_nl": [
         "Oscar-nominatie voor Beste Originele Song (2017)",
         "Grammy-nominatie voor Best Song Written for Visual Media (2018)"
+      ],
+      "awards_it": [
+        "Candidatura all'Oscar per la migliore canzone originale (2017)",
+        "Candidatura al Grammy per la migliore canzone scritta per media visivi (2018)"
       ],
       "uri_apple_music": "applemusic://track/1440639381",
       "uri_youtube_music": "https://music.youtube.com/watch?v=cPAbx5kgCJo",
@@ -294,6 +298,11 @@
         "Golden Globe voor Beste Originele Song (1995)",
         "Grammy voor Best Male Pop Vocal Performance (1995)"
       ],
+      "awards_it": [
+        "Oscar per la migliore canzone originale (1995)",
+        "Golden Globe per la migliore canzone originale (1995)",
+        "Grammy per la migliore interpretazione vocale pop maschile (1995)"
+      ],
       "uri_apple_music": "applemusic://track/1442813103",
       "uri_youtube_music": "https://music.youtube.com/watch?v=25QyCxVkXwQ",
       "movie": "The Lion King",
@@ -348,6 +357,9 @@
       ],
       "awards_nl": [
         "Oscar-nominatie voor Beste Originele Song (1995)"
+      ],
+      "awards_it": [
+        "Candidatura all'Oscar per la migliore canzone originale (1995)"
       ],
       "uri_apple_music": "applemusic://track/1472083402",
       "uri_youtube_music": "https://music.youtube.com/watch?v=MBIWFTXQbi4",
@@ -630,6 +642,11 @@
         "Grammy voor Best Song Written for Visual Media (1991)",
         "Golden Globe-nominatie voor Beste Originele Song (1990)"
       ],
+      "awards_it": [
+        "Oscar per la migliore canzone originale (1990)",
+        "Grammy per la migliore canzone scritta per media visivi (1991)",
+        "Candidatura al Golden Globe per la migliore canzone originale (1990)"
+      ],
       "uri_apple_music": "applemusic://track/1440661297",
       "uri_youtube_music": "https://music.youtube.com/watch?v=GC_mV1IpjWA",
       "movie": "The Little Mermaid",
@@ -725,6 +742,9 @@
       ],
       "awards_nl": [
         "Oscar-nominatie voor Beste Originele Song (1990)"
+      ],
+      "awards_it": [
+        "Candidatura all'Oscar per la migliore canzone originale (1990)"
       ],
       "uri_apple_music": "applemusic://track/1440661481",
       "uri_youtube_music": "https://music.youtube.com/watch?v=3BNpW7cxzrw",
@@ -840,6 +860,11 @@
         "Oscar voor Beste Originele Song (2014)",
         "Grammy voor Best Song Written for Visual Media (2015)",
         "Golden Globe-nominatie voor Beste Originele Song (2014)"
+      ],
+      "awards_it": [
+        "Oscar per la migliore canzone originale (2014)",
+        "Grammy per la migliore canzone scritta per media visivi (2015)",
+        "Candidatura al Golden Globe per la migliore canzone originale (2014)"
       ],
       "uri_apple_music": "applemusic://track/1440626764",
       "uri_youtube_music": "https://music.youtube.com/watch?v=YVVTZgwYwVo",
@@ -1125,6 +1150,11 @@
         "Grammy voor Lied van het Jaar (1994)",
         "Golden Globe voor Beste Originele Song (1993)"
       ],
+      "awards_it": [
+        "Oscar per la migliore canzone originale (1993)",
+        "Grammy per la canzone dell'anno (1994)",
+        "Golden Globe per la migliore canzone originale (1993)"
+      ],
       "uri_apple_music": "applemusic://track/1440722284",
       "uri_youtube_music": "https://music.youtube.com/watch?v=eitDnP0_83k",
       "movie": "Aladdin",
@@ -1279,6 +1309,11 @@
         "Grammy voor Best Song Written for Visual Media (1997)",
         "Golden Globe voor Beste Originele Song (1996)"
       ],
+      "awards_it": [
+        "Oscar per la migliore canzone originale (1996)",
+        "Grammy per la migliore canzone scritta per media visivi (1997)",
+        "Golden Globe per la migliore canzone originale (1996)"
+      ],
       "uri_apple_music": "applemusic://track/1440720093",
       "uri_youtube_music": "https://music.youtube.com/watch?v=hcmpj5HPue0",
       "movie": "Pocahontas",
@@ -1382,6 +1417,10 @@
       "awards_nl": [
         "Oscar-nominatie voor Beste Originele Song (1998)",
         "Golden Globe-nominatie voor Beste Originele Song (1998)"
+      ],
+      "awards_it": [
+        "Candidatura all'Oscar per la migliore canzone originale (1998)",
+        "Candidatura al Golden Globe per la migliore canzone originale (1998)"
       ],
       "uri_apple_music": "applemusic://track/1412859027",
       "uri_youtube_music": "https://music.youtube.com/watch?v=44LambNZgd4",
@@ -1540,6 +1579,11 @@
         "Golden Globe voor Beste Originele Song (2000)",
         "Grammy voor Best Song Written for Visual Media (2001)"
       ],
+      "awards_it": [
+        "Oscar per la migliore canzone originale (2000)",
+        "Golden Globe per la migliore canzone originale (2000)",
+        "Grammy per la migliore canzone scritta per media visivi (2001)"
+      ],
       "uri_apple_music": "applemusic://track/1437333914",
       "uri_youtube_music": "https://music.youtube.com/watch?v=w0ZHlp6atUQ",
       "movie": "Tarzan",
@@ -1652,6 +1696,11 @@
         "Grammy voor Best Pop Performance by a Duo or Group (1993)",
         "Golden Globe voor Beste Originele Song (1992)"
       ],
+      "awards_it": [
+        "Oscar per la migliore canzone originale (1992)",
+        "Grammy per la migliore interpretazione pop di un duo o gruppo (1993)",
+        "Golden Globe per la migliore canzone originale (1992)"
+      ],
       "uri_apple_music": "applemusic://track/1443431255",
       "uri_youtube_music": "https://music.youtube.com/watch?v=axySrE0Kg6k",
       "movie": "Beauty and the Beast",
@@ -1704,6 +1753,9 @@
       ],
       "awards_nl": [
         "Oscar-nominatie voor Beste Originele Song (1992)"
+      ],
+      "awards_it": [
+        "Candidatura all'Oscar per la migliore canzone originale (1992)"
       ],
       "uri_apple_music": "applemusic://track/1440618901",
       "uri_youtube_music": "https://music.youtube.com/watch?v=afzmwAKUppU",
@@ -1844,6 +1896,9 @@
       "awards_nl": [
         "Oscar-nominatie voor Beste Originele Song (2017)"
       ],
+      "awards_it": [
+        "Candidatura all'Oscar per la migliore canzone originale (2017)"
+      ],
       "uri_apple_music": "applemusic://track/1443431128",
       "uri_youtube_music": "https://music.youtube.com/watch?v=diLa-gpHRKc",
       "movie": "Beauty and the Beast (Live Action)",
@@ -1941,6 +1996,10 @@
       "awards_nl": [
         "Oscar-nominatie voor Beste Originele Song (2011)",
         "Golden Globe-nominatie voor Beste Originele Song (2011)"
+      ],
+      "awards_it": [
+        "Candidatura all'Oscar per la migliore canzone originale (2011)",
+        "Candidatura al Golden Globe per la migliore canzone originale (2011)"
       ],
       "uri_apple_music": "applemusic://track/1440639422",
       "uri_youtube_music": "https://music.youtube.com/watch?v=ILRs2r6lcHY",
@@ -2078,6 +2137,9 @@
       "awards_nl": [
         "Oscar-nominatie voor Beste Originele Song (2010)"
       ],
+      "awards_it": [
+        "Candidatura all'Oscar per la migliore canzone originale (2010)"
+      ],
       "uri_apple_music": "applemusic://track/1417397131",
       "uri_youtube_music": "https://music.youtube.com/watch?v=ThMwHKfzz1I",
       "movie": "The Princess and the Frog",
@@ -2173,6 +2235,9 @@
       "awards_nl": [
         "Oscar-nominatie voor Beste Originele Song (2008)"
       ],
+      "awards_it": [
+        "Candidatura all'Oscar per la migliore canzone originale (2008)"
+      ],
       "uri_apple_music": "applemusic://track/1452871166",
       "uri_youtube_music": "https://music.youtube.com/watch?v=iFiGp2QrsCw",
       "movie": "Enchanted",
@@ -2267,6 +2332,9 @@
       "awards_nl": [
         "Oscar-nominatie voor Beste Originele Song (2000)"
       ],
+      "awards_it": [
+        "Candidatura all'Oscar per la migliore canzone originale (2000)"
+      ],
       "uri_apple_music": "applemusic://track/1463095449",
       "uri_youtube_music": "https://music.youtube.com/watch?v=QApcQh9_kQw",
       "movie": "Toy Story 2",
@@ -2319,6 +2387,9 @@
       ],
       "awards_nl": [
         "Oscar voor Beste Originele Song (2002)"
+      ],
+      "awards_it": [
+        "Oscar per la migliore canzone originale (2002)"
       ],
       "uri_apple_music": "applemusic://track/893108671",
       "uri_youtube_music": "https://music.youtube.com/watch?v=CMJPhCh4ARc",
@@ -2379,6 +2450,9 @@
       "awards_nl": [
         "Grammy-nominatie voor Best Song Written for Visual Media (2017)"
       ],
+      "awards_it": [
+        "Candidatura al Grammy per la migliore canzone scritta per media visivi (2017)"
+      ],
       "uri_apple_music": "applemusic://track/1440667007",
       "uri_youtube_music": "https://music.youtube.com/watch?v=c6rP-YP4c5I",
       "movie": "Zootopia",
@@ -2437,6 +2511,9 @@
       ],
       "awards_nl": [
         "Oscar-nominatie voor Beste Originele Song (2020)"
+      ],
+      "awards_it": [
+        "Candidatura all'Oscar per la migliore canzone originale (2020)"
       ],
       "uri_apple_music": "applemusic://track/1487738283",
       "uri_youtube_music": "https://music.youtube.com/watch?v=gIOyB9ZXn8s",
@@ -2591,6 +2668,10 @@
         "Grammy-nominatie voor Lied van het Jaar (2023)",
         "Critics' Choice Movie Award voor Beste Song (2022)"
       ],
+      "awards_it": [
+        "Candidatura al Grammy per la canzone dell'anno (2023)",
+        "Critics' Choice Movie Award per la migliore canzone (2022)"
+      ],
       "uri_apple_music": "applemusic://track/1594677760",
       "uri_youtube_music": "https://music.youtube.com/watch?v=bvWRMAU6V-c",
       "movie": "Encanto",
@@ -2649,6 +2730,9 @@
       "awards_nl": [
         "Grammy-nominatie voor Best Song Written for Visual Media (2023)"
       ],
+      "awards_it": [
+        "Candidatura al Grammy per la migliore canzone scritta per media visivi (2023)"
+      ],
       "uri_apple_music": "applemusic://track/1594677759",
       "uri_youtube_music": "https://music.youtube.com/watch?v=tQwVKr8rCYw",
       "movie": "Encanto",
@@ -2700,6 +2784,9 @@
       ],
       "awards_nl": [
         "Oscar-nominatie voor Beste Originele Song (2022)"
+      ],
+      "awards_it": [
+        "Candidatura all'Oscar per la migliore canzone originale (2022)"
       ],
       "uri_apple_music": "applemusic://track/1594677763",
       "uri_youtube_music": "https://music.youtube.com/watch?v=DUGtyj5QlEM",
@@ -2846,6 +2933,9 @@
       ],
       "awards_nl": [
         "Oscar-nominatie voor Beste Originele Song (1998)"
+      ],
+      "awards_it": [
+        "Candidatura all'Oscar per la migliore canzone originale (1998)"
       ],
       "uri_apple_music": "applemusic://track/1664565006",
       "uri_youtube_music": "https://music.youtube.com/watch?v=mgyKVLUt0no",
@@ -2994,6 +3084,10 @@
         "Oscar voor Beste Originele Song (1941)",
         "RIAA 'Songs of the Century'-lijst"
       ],
+      "awards_it": [
+        "Oscar per la migliore canzone originale (1941)",
+        "Recording Industry Association of America, «Songs of the Century»"
+      ],
       "uri_apple_music": "applemusic://track/1452851094",
       "uri_youtube_music": "https://music.youtube.com/watch?v=0oyxywZJsIs",
       "movie": "Pinocchio",
@@ -3046,6 +3140,9 @@
       ],
       "awards_nl": [
         "Oscar-nominatie voor Beste Originele Song (1965)"
+      ],
+      "awards_it": [
+        "Candidatura all'Oscar per la migliore canzone originale (1965)"
       ],
       "uri_apple_music": "applemusic://track/1444019946",
       "uri_youtube_music": "https://music.youtube.com/watch?v=xA_vQZd_9N8",
@@ -3146,6 +3243,10 @@
       "awards_nl": [
         "Oscar voor Beste Originele Song (1965)",
         "Grammy-nominatie"
+      ],
+      "awards_it": [
+        "Oscar per la migliore canzone originale (1965)",
+        "Candidatura al Grammy"
       ],
       "uri_apple_music": "applemusic://track/1434821546",
       "movie": "Mary Poppins",

--- a/custom_components/beatify/playlists/eurovision-winners.json
+++ b/custom_components/beatify/playlists/eurovision-winners.json
@@ -1,6 +1,6 @@
 {
   "name": "Eurovision Winners (1956-2025)",
-  "version": "1.14",
+  "version": "1.15",
   "tags": [
     "eurovision",
     "contest",
@@ -45,6 +45,9 @@
       "fun_fact_nl": "Refrain won het allereerste Eurovisie Songfestival, gehouden in Lugano, Zwitserland. Lys Assia was de enige deelnemer uit Zwitserland en won met een eenvoudig, elegant optreden. Het songfestival van 1956 had nog geen publieksstemmen - alleen de stemmen van de jury telden.",
       "awards_nl": [
         "Eurovisionwinnaar 1956"
+      ],
+      "awards_it": [
+        "Vincitore dell'Eurovision Song Contest 1956"
       ],
       "isrc": "US2Y30712375",
       "uri_apple_music_by_region": {
@@ -95,6 +98,9 @@
       "awards_nl": [
         "Eurovisionwinnaar 1957"
       ],
+      "awards_it": [
+        "Vincitore dell'Eurovision Song Contest 1957"
+      ],
       "isrc": "BEK011900098",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1739553677",
@@ -144,6 +150,9 @@
       "fun_fact_nl": "Dors mon amour (Slaap mijn liefste) was een zacht slaapliedje dat Frankrijk de eerste songfestivaltitel bezorgde. Andre Claveau was voor zijn overwinning al een gevestigde Franse chansonnier, bekend om zijn warme stemgeluid.",
       "awards_nl": [
         "Eurovisionwinnaar 1958"
+      ],
+      "awards_it": [
+        "Vincitore dell'Eurovision Song Contest 1958"
       ],
       "isrc": "FR6V82155103",
       "uri_apple_music_by_region": {
@@ -196,6 +205,9 @@
       "awards_nl": [
         "Eurovisionwinnaar 1959"
       ],
+      "awards_it": [
+        "Vincitore dell'Eurovision Song Contest 1959"
+      ],
       "isrc": "NLBH71029195",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/420371297",
@@ -245,6 +257,9 @@
       "fun_fact_nl": "Tom Pillibi vertelt het verhaal van een charmante leugenaar die fantastische verhalen verzint. Jacqueline Boyer was pas 18 jaar oud toen ze won, en haar moeder Lucienne Boyer was ook een beroemde Franse zangeres.",
       "awards_nl": [
         "Eurovisionwinnaar 1960"
+      ],
+      "awards_it": [
+        "Vincitore dell'Eurovision Song Contest 1960"
       ],
       "isrc": "FRZ035903640",
       "uri_apple_music_by_region": {
@@ -296,6 +311,9 @@
       "awards_nl": [
         "Eurovisionwinnaar 1961"
       ],
+      "awards_it": [
+        "Vincitore dell'Eurovision Song Contest 1961"
+      ],
       "isrc": "FRZ116103170",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1752888490",
@@ -345,6 +363,9 @@
       "fun_fact_nl": "Un premier amour (Een eerste liefde) stelde de derde Franse overwinning veilig. Isabelle Aubret overleefde in 1963 een bijna fataal auto-ongeluk, maar maakte een opmerkelijke comeback. Ze vertegenwoordigde Frankrijk opnieuw in 1968 en werd toen derde.",
       "awards_nl": [
         "Eurovisionwinnaar 1962"
+      ],
+      "awards_it": [
+        "Vincitore dell'Eurovision Song Contest 1962"
       ],
       "isrc": "FRZ036203430",
       "uri_apple_music_by_region": {
@@ -396,6 +417,9 @@
       "awards_nl": [
         "Eurovisionwinnaar 1963"
       ],
+      "awards_it": [
+        "Vincitore dell'Eurovision Song Contest 1963"
+      ],
       "isrc": "DKABA1100812",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/693093834",
@@ -446,6 +470,9 @@
       "awards_nl": [
         "Eurovisionwinnaar 1964"
       ],
+      "awards_it": [
+        "Vincitore dell'Eurovision Song Contest 1964"
+      ],
       "isrc": "ITR006400011",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1769611022",
@@ -494,6 +521,9 @@
       "awards_nl": [
         "Eurovisionwinnaar 1965"
       ],
+      "awards_it": [
+        "Vincitore dell'Eurovision Song Contest 1965"
+      ],
       "uri_tidal": "tidal://track/41386583",
       "uri_apple_music": "applemusic://track/1721242740"
     },
@@ -535,6 +565,9 @@
       "fun_fact_nl": "Merci Cherie was de eerste Oostenrijkse overwinning. Udo Jurgens had al twee keer eerder deelgenomen (1964, 1965) voordat hij eindelijk won. Hij groeide uit tot een van de meest succesvolle artiesten van Europa met meer dan 100 miljoen verkochte platen.",
       "awards_nl": [
         "Eurovisionwinnaar 1966"
+      ],
+      "awards_it": [
+        "Vincitore dell'Eurovision Song Contest 1966"
       ],
       "isrc": "DEA810602256",
       "uri_apple_music_by_region": {
@@ -586,6 +619,9 @@
       "awards_nl": [
         "Eurovisionwinnaar 1967"
       ],
+      "awards_it": [
+        "Vincitore dell'Eurovision Song Contest 1967"
+      ],
       "isrc": "GBCXD0400224",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1467380894",
@@ -636,6 +672,9 @@
       "awards_nl": [
         "Eurovisionwinnaar 1968"
       ],
+      "awards_it": [
+        "Vincitore dell'Eurovision Song Contest 1968"
+      ],
       "isrc": "ES5100300048",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1344881200",
@@ -685,6 +724,9 @@
       "fun_fact_nl": "De Troubadour was onderdeel van het enige gelijke spel tussen vier landen in de geschiedenis. Nederland, Frankrijk, Spanje en het VK deelden de eerste plaats met elk 18 punten. Dit leidde tot regels om gelijke standen in de toekomst te voorkomen.",
       "awards_nl": [
         "Eurovisionwinnaar 1969 (4-way tie)"
+      ],
+      "awards_it": [
+        "Vincitore dell'Eurovision Song Contest 1969 (ex aequo a quattro)"
       ]
     },
     {
@@ -725,6 +767,9 @@
       "fun_fact_nl": "Boom Bang a Bang was een van de vier gedeelde winnaars in 1969. De Schotse zangeres Lulu was al beroemd door 'Shout' en 'To Sir with Love'. Het vrolijke, aanstekelijke nummer werd een hit in het VK ondanks de gedeelde winst.",
       "awards_nl": [
         "Eurovisionwinnaar 1969 (4-way tie)"
+      ],
+      "awards_it": [
+        "Vincitore dell'Eurovision Song Contest 1969 (ex aequo a quattro)"
       ],
       "isrc": "GBAYE6900136",
       "uri_apple_music_by_region": {
@@ -776,6 +821,9 @@
       "awards_nl": [
         "Eurovisionwinnaar 1969 (4-way tie)"
       ],
+      "awards_it": [
+        "Vincitore dell'Eurovision Song Contest 1969 (ex aequo a quattro)"
+      ],
       "isrc": "ES5378900013",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1838068722",
@@ -825,6 +873,9 @@
       "fun_fact_nl": "Un jour, un enfant completeerde de historische gedeelde winst van 1969. Frida Boccara werd geboren in Marokko en groeide uit tot een van de meest gerespecteerde Franse zangeressen. Haar emotionele ballade viel op tussen de andere winnaars.",
       "awards_nl": [
         "Eurovisionwinnaar 1969 (4-way tie)"
+      ],
+      "awards_it": [
+        "Vincitore dell'Eurovision Song Contest 1969 (ex aequo a quattro)"
       ],
       "isrc": "CAU111501580",
       "uri_apple_music_by_region": {
@@ -876,6 +927,9 @@
       "awards_nl": [
         "Eurovisionwinnaar 1970"
       ],
+      "awards_it": [
+        "Vincitore dell'Eurovision Song Contest 1970"
+      ],
       "isrc": "USCGH1615055",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1078014787",
@@ -925,6 +979,9 @@
       "fun_fact_nl": "Un Banc, Un Arbre, Une Rue bezorgde Monaco de enige songfestivaloverwinning. Severine was eigenlijk Frans en het nummer werd geschreven door Yves Dessca. De winst kwam op het moment dat er nieuwe stemregels werden geïntroduceerd.",
       "awards_nl": [
         "Eurovisionwinnaar 1971"
+      ],
+      "awards_it": [
+        "Vincitore dell'Eurovision Song Contest 1971"
       ],
       "isrc": "USBKY0518252",
       "uri_apple_music_by_region": {
@@ -976,6 +1033,9 @@
       "awards_nl": [
         "Eurovisionwinnaar 1972"
       ],
+      "awards_it": [
+        "Vincitore dell'Eurovision Song Contest 1972"
+      ],
       "isrc": "FRZ037201700",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1442450412",
@@ -1025,6 +1085,9 @@
       "fun_fact_nl": "Tu te reconnaitras was de vierde Luxemburgse winst in 12 jaar tijd. Anne-Marie David vertegenwoordigde Frankrijk in 1979, wat haar een van de weinige artiesten maakt die voor twee verschillende landen uitkwamen.",
       "awards_nl": [
         "Eurovisionwinnaar 1973"
+      ],
+      "awards_it": [
+        "Vincitore dell'Eurovision Song Contest 1973"
       ],
       "isrc": "FRZ051700133",
       "uri_apple_music_by_region": {
@@ -1084,6 +1147,10 @@
         "Eurovisionwinnaar 1974",
         "Beste Eurovisielied Ooit (2005 peiling)"
       ],
+      "awards_it": [
+        "Vincitore dell'Eurovision Song Contest 1974",
+        "Migliore canzone dell'Eurovision di sempre (sondaggio del 2005)"
+      ],
       "isrc": "SEAYD7415010",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1612497895",
@@ -1131,6 +1198,9 @@
       "awards_nl": [
         "Eurovisionwinnaar 1975"
       ],
+      "awards_it": [
+        "Vincitore dell'Eurovision Song Contest 1975"
+      ],
       "uri_tidal": "tidal://track/181365005",
       "uri_apple_music": "applemusic://track/104581124",
       "uri_youtube_music": "https://music.youtube.com/watch?v=BPxuq4uQ0OU"
@@ -1173,6 +1243,9 @@
       "fun_fact_nl": "Save Your Kisses For Me was de derde Britse overwinning en werd een van de bestverkochte singles van 1976 wereldwijd. Het liedje lijkt over romantische liefde te gaan, maar aan het eind blijkt het over een driejarige dochter te gaan.",
       "awards_nl": [
         "Eurovisionwinnaar 1976"
+      ],
+      "awards_it": [
+        "Vincitore dell'Eurovision Song Contest 1976"
       ],
       "isrc": "NLB127600905",
       "uri_apple_music_by_region": {
@@ -1224,6 +1297,9 @@
       "awards_nl": [
         "Eurovisionwinnaar 1977"
       ],
+      "awards_it": [
+        "Vincitore dell'Eurovision Song Contest 1977"
+      ],
       "isrc": "FRZ988800040",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1222623640",
@@ -1271,6 +1347,9 @@
       "fun_fact_nl": "A-Ba-Ni-Bi was de eerste overwinning voor Israël en bevatte een Hebreeuws kindertaalspelletje in de tekst. Izhar Cohen en de Alphabeta traden op met een energieke choreografie die baanbrekend was voor die tijd.",
       "awards_nl": [
         "Eurovisionwinnaar 1978"
+      ],
+      "awards_it": [
+        "Vincitore dell'Eurovision Song Contest 1978"
       ]
     },
     {
@@ -1310,6 +1389,9 @@
       "fun_fact_nl": "Hallelujah zorgde voor een tweede Israëlische overwinning op rij. Gezongen door Gali Atari met Milk and Honey, sloeg de vredesboodschap van het nummer diep aan tijdens de gespannen tijden in het Midden-Oosten. Israël organiseerde het festival van 1979 in Jeruzalem.",
       "awards_nl": [
         "Eurovisionwinnaar 1979"
+      ],
+      "awards_it": [
+        "Vincitore dell'Eurovision Song Contest 1979"
       ],
       "isrc": "IL1032102005",
       "uri_apple_music_by_region": {
@@ -1362,6 +1444,9 @@
       "awards_nl": [
         "Eurovisionwinnaar 1980"
       ],
+      "awards_it": [
+        "Vincitore dell'Eurovision Song Contest 1980"
+      ],
       "isrc": "GBCWS1310103",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/735689364",
@@ -1413,6 +1498,9 @@
       "fun_fact_nl": "Making Your Mind Up is beroemd om de routine waarbij de mannen de rokken van de vrouwen afscheurden, waarna er kortere rokjes onder vandaan kwamen. Dit werd een van de meest iconische songfestivalmomenten en maakte Bucks Fizz op slag beroemd.",
       "awards_nl": [
         "Eurovisionwinnaar 1981"
+      ],
+      "awards_it": [
+        "Vincitore dell'Eurovision Song Contest 1981"
       ],
       "isrc": "GBARL8100025",
       "uri_apple_music_by_region": {
@@ -1467,6 +1555,9 @@
       "awards_nl": [
         "Eurovisionwinnaar 1982"
       ],
+      "awards_it": [
+        "Vincitore dell'Eurovision Song Contest 1982"
+      ],
       "isrc": "DEC718200001",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/284222244",
@@ -1515,6 +1606,9 @@
       "fun_fact_nl": "Si la vie est cadeau bezorgde Luxemburg de vijfde en laatste overwinning. De powerballade toonde het indrukwekkende stembereik van Corinne Hermes. Luxemburg trok zich in 1994 terug en is pas onlangs weer teruggekeerd.",
       "awards_nl": [
         "Eurovisionwinnaar 1983"
+      ],
+      "awards_it": [
+        "Vincitore dell'Eurovision Song Contest 1983"
       ],
       "isrc": "TCAFO2159766",
       "uri_apple_music_by_region": {
@@ -1567,6 +1661,9 @@
       "awards_nl": [
         "Eurovisionwinnaar 1984"
       ],
+      "awards_it": [
+        "Vincitore dell'Eurovision Song Contest 1984"
+      ],
       "isrc": "SEVNI0201801",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/440309422",
@@ -1617,6 +1714,9 @@
       "awards_nl": [
         "Eurovisionwinnaar 1985"
       ],
+      "awards_it": [
+        "Vincitore dell'Eurovision Song Contest 1985"
+      ],
       "isrc": "NOJLA1005130",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/976265487",
@@ -1666,6 +1766,9 @@
       "fun_fact_nl": "J'aime la vie is tot nu toe de enige Belgische overwinning. Sandra Kim beweerde 15 te zijn, maar was in werkelijkheid pas 13, waarmee ze de jongste winnaar ooit is. De waarheid kwam pas na haar overwinning aan het licht.",
       "awards_nl": [
         "Eurovisionwinnaar 1986"
+      ],
+      "awards_it": [
+        "Vincitore dell'Eurovision Song Contest 1986"
       ],
       "isrc": "BEU761000004",
       "uri_apple_music_by_region": {
@@ -1719,6 +1822,9 @@
       "awards_nl": [
         "Eurovisionwinnaar 1987"
       ],
+      "awards_it": [
+        "Vincitore dell'Eurovision Song Contest 1987"
+      ],
       "isrc": "GBBBM8700004",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/429802667",
@@ -1768,6 +1874,9 @@
       "fun_fact_nl": "Ne partez pas sans moi betekende de Europese doorbraak voor Celine Dion. Ze won met slechts één punt verschil in een zenuwslopende finale. Dion kwam uit voor Zwitserland omdat Canadese artiesten niet voor hun eigen land mochten uitkomen.",
       "awards_nl": [
         "Eurovisionwinnaar 1988"
+      ],
+      "awards_it": [
+        "Vincitore dell'Eurovision Song Contest 1988"
       ],
       "isrc": "FRV628800310",
       "uri_apple_music_by_region": {
@@ -1819,6 +1928,9 @@
       "awards_nl": [
         "Eurovisionwinnaar 1989"
       ],
+      "awards_it": [
+        "Vincitore dell'Eurovision Song Contest 1989"
+      ],
       "isrc": "HRA048918172",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1846157477",
@@ -1869,6 +1981,9 @@
       "awards_nl": [
         "Eurovisionwinnaar 1990"
       ],
+      "awards_it": [
+        "Vincitore dell'Eurovision Song Contest 1990"
+      ],
       "isrc": "ITB261002520",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1329254875",
@@ -1918,6 +2033,9 @@
       "awards_nl": [
         "Eurovisionwinnaar 1991"
       ],
+      "awards_it": [
+        "Vincitore dell'Eurovision Song Contest 1991"
+      ],
       "uri_apple_music": "applemusic://track/586785384"
     },
     {
@@ -1958,6 +2076,9 @@
       "fun_fact_nl": "Why Me? werd geschreven door Johnny Logan, wat hem zijn derde overwinning bezorgde (dit keer als songwriter). Linda Martin had al eerder meegedaan in 1984. Dit was het begin van een reeks van vier Ierse zeges op rij.",
       "awards_nl": [
         "Eurovisionwinnaar 1992"
+      ],
+      "awards_it": [
+        "Vincitore dell'Eurovision Song Contest 1992"
       ],
       "isrc": "GBKRX1600856",
       "uri_apple_music_by_region": {
@@ -2008,6 +2129,9 @@
       "fun_fact_nl": "In Your Eyes zorgde voor de tweede Ierse overwinning op rij. De krachtige stem van Niamh Kavanagh leverde de hoogste puntenscore tot dan toe op. Ze keerde in 2010 terug om Ierland nogmaals te vertegenwoordigen.",
       "awards_nl": [
         "Eurovisionwinnaar 1993"
+      ],
+      "awards_it": [
+        "Vincitore dell'Eurovision Song Contest 1993"
       ],
       "isrc": "GBARK0400010",
       "uri_apple_music_by_region": {
@@ -2061,6 +2185,9 @@
       "awards_nl": [
         "Eurovisionwinnaar 1994"
       ],
+      "awards_it": [
+        "Vincitore dell'Eurovision Song Contest 1994"
+      ],
       "isrc": "US2G40701607",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/212118856",
@@ -2109,6 +2236,9 @@
       "fun_fact_nl": "Nocturne is het enige grotendeels instrumentale nummer dat het songfestival won, met slechts 24 woorden tekst. De meeslepende vioolmelodie van Secret Garden betoverde Europa en bewees dat winnen niet alleen met popliedjes kon.",
       "awards_nl": [
         "Eurovisionwinnaar 1995"
+      ],
+      "awards_it": [
+        "Vincitore dell'Eurovision Song Contest 1995"
       ]
     },
     {
@@ -2151,6 +2281,9 @@
       "fun_fact_nl": "The Voice bezorgde Ierland de recordbrekende zevende overwinning (de vierde in vijf jaar). Het serene Keltische optreden van Eimear Quinn zette de Ierse dominantie voort. Geen enkel land won het festival vaker dan Ierland.",
       "awards_nl": [
         "Eurovisionwinnaar 1996"
+      ],
+      "awards_it": [
+        "Vincitore dell'Eurovision Song Contest 1996"
       ],
       "isrc": "USDP20403422",
       "uri_apple_music_by_region": {
@@ -2202,6 +2335,9 @@
       "awards_nl": [
         "Eurovisionwinnaar 1997"
       ],
+      "awards_it": [
+        "Vincitore dell'Eurovision Song Contest 1997"
+      ],
       "isrc": "GBDNM1010071",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1438441951",
@@ -2250,6 +2386,9 @@
       "fun_fact_nl": "Diva schreef geschiedenis toen Dana International de eerste transgender winnaar van het songfestival werd. Haar winst was in sommige kringen omstreden, maar werd gevierd als een mijlpaal voor LGBTQ+-representatie. Het nummer werd een wereldwijde hit.",
       "awards_nl": [
         "Eurovisionwinnaar 1998"
+      ],
+      "awards_it": [
+        "Vincitore dell'Eurovision Song Contest 1998"
       ]
     },
     {
@@ -2290,6 +2429,9 @@
       "fun_fact_nl": "Take Me to Your Heaven was de vierde Zweedse overwinning. Charlotte Nilsson (later Perrelli) bracht een klassiek Scandinavisch popnummer. Ze keerde in 2008 terug met 'Hero' en werd toen 18e.",
       "awards_nl": [
         "Eurovisionwinnaar 1999"
+      ],
+      "awards_it": [
+        "Vincitore dell'Eurovision Song Contest 1999"
       ],
       "isrc": "SEVFN9908070",
       "uri_apple_music_by_region": {
@@ -2341,6 +2483,9 @@
       "awards_nl": [
         "Eurovisionwinnaar 2000"
       ],
+      "awards_it": [
+        "Vincitore dell'Eurovision Song Contest 2000"
+      ],
       "isrc": "DKABA1100240",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1676954239",
@@ -2388,6 +2533,9 @@
       "awards_nl": [
         "Eurovisionwinnaar 2001"
       ],
+      "awards_it": [
+        "Vincitore dell'Eurovision Song Contest 2001"
+      ],
       "uri_youtube_music": "https://music.youtube.com/watch?v=92TSUlqzFi8"
     },
     {
@@ -2426,6 +2574,9 @@
       "fun_fact_nl": "I Wanna bezorgde Letland de eerste overwinning bij hun pas derde deelname. Het zwoele optreden van Marie N en de kostuumwissels tijdens het nummer zorgden voor een gedenkwaardig spektakel. Letland organiseerde daarna het festival van 2003 in Riga.",
       "awards_nl": [
         "Eurovisionwinnaar 2002"
+      ],
+      "awards_it": [
+        "Vincitore dell'Eurovision Song Contest 2002"
       ],
       "isrc": "USA370580255",
       "uri_apple_music_by_region": {
@@ -2479,6 +2630,9 @@
       "awards_nl": [
         "Eurovisionwinnaar 2003"
       ],
+      "awards_it": [
+        "Vincitore dell'Eurovision Song Contest 2003"
+      ],
       "isrc": "TRA160300427",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/400705407",
@@ -2528,6 +2682,9 @@
       "fun_fact_nl": "Wild Dances was de eerste Oekraïense overwinning en bevatte volksmuziek-elementen uit de Karpaten. Het energieke optreden van Ruslana met vuur en tribale dans was revolutionair. Ze werd later een bekende activiste tijdens de politieke onrust in Oekraïne.",
       "awards_nl": [
         "Eurovisionwinnaar 2004"
+      ],
+      "awards_it": [
+        "Vincitore dell'Eurovision Song Contest 2004"
       ],
       "isrc": "UAAO10400001",
       "uri_apple_music_by_region": {
@@ -2579,6 +2736,9 @@
       "awards_nl": [
         "Eurovisionwinnaar 2005"
       ],
+      "awards_it": [
+        "Vincitore dell'Eurovision Song Contest 2005"
+      ],
       "isrc": "GRS010500065",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1782949200",
@@ -2629,6 +2789,9 @@
       "awards_nl": [
         "Eurovisionwinnaar 2006"
       ],
+      "awards_it": [
+        "Vincitore dell'Eurovision Song Contest 2006"
+      ],
       "isrc": "USGMP0700099",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/389516413",
@@ -2678,6 +2841,9 @@
       "awards_nl": [
         "Eurovisionwinnaar 2007"
       ],
+      "awards_it": [
+        "Vincitore dell'Eurovision Song Contest 2007"
+      ],
       "uri_apple_music": "applemusic://track/1578027079"
     },
     {
@@ -2717,6 +2883,9 @@
       "fun_fact_nl": "Believe bezorgde Rusland hun eerste en enige Eurovisie-overwinning. Dima Bilan trad op met de Hongaarse violist Edvin Marton en een Olympische schaatser op het podium. Hij was tweede geworden in 2006, waardoor 2008 zijn verlossingsjaar werd.",
       "awards_nl": [
         "Eurovisionwinnaar 2008"
+      ],
+      "awards_it": [
+        "Vincitore dell'Eurovision Song Contest 2008"
       ],
       "isrc": "RUB421500013",
       "uri_apple_music_by_region": {
@@ -2767,6 +2936,9 @@
       "fun_fact_nl": "Fairytale won met 387 punten, de hoogste score ooit behaald op dat moment onder het stemsysteem. Alexander Rybak charmeerde heel Europa met zijn folkpopliedjes en vioolspel. De Wit-Russisch-Noorse artiest was net 22 jaar oud.",
       "awards_nl": [
         "Eurovisionwinnaar 2009"
+      ],
+      "awards_it": [
+        "Vincitore dell'Eurovision Song Contest 2009"
       ],
       "isrc": "NO23B0900001",
       "uri_apple_music_by_region": {
@@ -2821,6 +2993,9 @@
       "awards_nl": [
         "Eurovisionwinnaar 2010"
       ],
+      "awards_it": [
+        "Vincitore dell'Eurovision Song Contest 2010"
+      ],
       "isrc": "DEUM71001210",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1667036971",
@@ -2868,6 +3043,9 @@
       "awards_nl": [
         "Eurovisionwinnaar 2011"
       ],
+      "awards_it": [
+        "Vincitore dell'Eurovision Song Contest 2011"
+      ],
       "uri_youtube_music": "https://music.youtube.com/watch?v=_0tlQUW5X0U"
     },
     {
@@ -2911,6 +3089,9 @@
       "fun_fact_nl": "Euphoria wordt beschouwd als een van de beste winnende Eurovisiesongs ooit. Loreen kreeg stemmen voor de eerste plaats uit 18 landen - een record. Het beklijvende dansnummer stond wereldwijd bovenaan de hitlijsten en heeft meer dan 300 miljoen Spotify streams.",
       "awards_nl": [
         "Eurovisionwinnaar 2012"
+      ],
+      "awards_it": [
+        "Vincitore dell'Eurovision Song Contest 2012"
       ],
       "isrc": "SEPQA1200005",
       "uri_apple_music_by_region": {
@@ -2963,6 +3144,9 @@
       "fun_fact_nl": "Only Teardrops bezorgde Denemarken hun derde Eurovisie-overwinning. Emmelie de Forest's etherische folk-pop optreden bevatte dansen op blote voeten en tin whistle. De boodschap van het lied over het loslaten van pijn vond weerklank bij kijkers in heel Europa.",
       "awards_nl": [
         "Eurovisionwinnaar 2013"
+      ],
+      "awards_it": [
+        "Vincitore dell'Eurovision Song Contest 2013"
       ],
       "isrc": "DKADG1200760",
       "uri_apple_music_by_region": {
@@ -3017,6 +3201,9 @@
       "awards_nl": [
         "Eurovisionwinnaar 2014"
       ],
+      "awards_it": [
+        "Vincitore dell'Eurovision Song Contest 2014"
+      ],
       "isrc": "ATE501400401",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/844169216",
@@ -3070,6 +3257,9 @@
       "awards_nl": [
         "Eurovisionwinnaar 2015"
       ],
+      "awards_it": [
+        "Vincitore dell'Eurovision Song Contest 2015"
+      ],
       "isrc": "SEPQA1401135",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1612452449",
@@ -3122,6 +3312,9 @@
       "awards_nl": [
         "Eurovisionwinnaar 2016"
       ],
+      "awards_it": [
+        "Vincitore dell'Eurovision Song Contest 2016"
+      ],
       "isrc": "RUA1H1518948",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1664506710",
@@ -3171,6 +3364,9 @@
       "fun_fact_nl": "Amar Pelos Dois (Liefde voor ons beiden) won met 758 punten - de hoogste score ooit in de Eurovisiegeschiedenis. De intieme jazzballad van Salvador Sobral, geschreven door zijn zus Luisa, brak alle records. Hij trad op in afwachting van een harttransplantatie, die hij maanden later kreeg.",
       "awards_nl": [
         "Eurovisionwinnaar 2017"
+      ],
+      "awards_it": [
+        "Vincitore dell'Eurovision Song Contest 2017"
       ],
       "isrc": "PTNO11700001",
       "uri_apple_music_by_region": {
@@ -3222,6 +3418,9 @@
       "fun_fact_nl": "De kippengeluiden en loop-pedal performance van Toy maakten het onvergetelijk. Netta Barzilai's 'empowerment anthem' met de boodschap 'I'm not your toy' sloot aan bij de #MeToo-beweging. De eigenzinnige elektronische track verdeelde de meningen maar won beslissend.",
       "awards_nl": [
         "Eurovisionwinnaar 2018"
+      ],
+      "awards_it": [
+        "Vincitore dell'Eurovision Song Contest 2018"
       ],
       "isrc": "IL5181100107",
       "uri_apple_music_by_region": {
@@ -3276,6 +3475,9 @@
       "awards_nl": [
         "Eurovisionwinnaar 2019"
       ],
+      "awards_it": [
+        "Vincitore dell'Eurovision Song Contest 2019"
+      ],
       "isrc": "NL1TK1900001",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1748200197",
@@ -3325,6 +3527,9 @@
       "fun_fact_nl": "ZITTI E BUONI (Shut Up and Behave) was het eerste rocknummer dat Eurovisie won sinds Lordi in 2006. Maneskin werd een wereldwijde superster, die wereldwijd hitlijsten aanvoerde en optrad op grote festivals. Frontman Damiano werd geconfronteerd met valse beschuldigingen van drugsgebruik die snel werden weerlegd.",
       "awards_nl": [
         "Eurovisionwinnaar 2021"
+      ],
+      "awards_it": [
+        "Vincitore dell'Eurovision Song Contest 2021"
       ],
       "isrc": "ITB002100112",
       "uri_apple_music_by_region": {
@@ -3379,6 +3584,9 @@
       "awards_nl": [
         "Eurovisionwinnaar 2022"
       ],
+      "awards_it": [
+        "Vincitore dell'Eurovision Song Contest 2022"
+      ],
       "isrc": "DEE862200344",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1614859013",
@@ -3432,6 +3640,9 @@
       "awards_nl": [
         "Eurovisionwinnaar 2023"
       ],
+      "awards_it": [
+        "Vincitore dell'Eurovision Song Contest 2023"
+      ],
       "isrc": "SEUM72201638",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1872510113",
@@ -3482,6 +3693,9 @@
       "awards_nl": [
         "Eurovisionwinnaar 2024"
       ],
+      "awards_it": [
+        "Vincitore dell'Eurovision Song Contest 2024"
+      ],
       "isrc": "DEUM72401182",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1730730673",
@@ -3531,6 +3745,9 @@
       "fun_fact_nl": "Wasted Love liet JJ's buitengewone countertenor operastem horen in een nummer dat opbouwt van orkestrale zweltonen naar een clubfinish. Johannes Pietsch, die optreedt in de Weense Staatsopera, kreeg de steun van de jury van 8 landen, wat hem dubbele punten opleverde. Oostenrijk zal gastheer zijn van Eurovisie 2026.",
       "awards_nl": [
         "Eurovisionwinnaar 2025"
+      ],
+      "awards_it": [
+        "Vincitore dell'Eurovision Song Contest 2025"
       ],
       "isrc": "DEA622500513",
       "uri_apple_music_by_region": {

--- a/custom_components/beatify/playlists/greatest-hits-of-all-time.json
+++ b/custom_components/beatify/playlists/greatest-hits-of-all-time.json
@@ -1,6 +1,6 @@
 {
   "name": "Greatest Hits of All Time",
-  "version": "2.21",
+  "version": "2.22",
   "tags": [
     "classics",
     "top-hits",
@@ -49,6 +49,9 @@
       "uri_deezer": "deezer://track/9997018",
       "fun_fact_nl": "Bohemian Rhapsody werd aanvankelijk afgewezen door platenmaatschappijen die dachten dat een opera-rocknummer van 6 minuten nooit op de radio zou komen. Freddie Mercury spendeerde drie weken aan het opnemen van de complexe vocale harmonieën, met 180 afzonderlijke overdubs. Het werd het kenmerkende nummer van Queen.",
       "awards_nl": [
+        "Grammy Hall of Fame (2004)"
+      ],
+      "awards_it": [
         "Grammy Hall of Fame (2004)"
       ],
       "isrc": "GBUM71029604",
@@ -218,6 +221,9 @@
       "awards_nl": [
         "Grammy – Beste Mannelijke Pop Zangprestatie (1984)"
       ],
+      "awards_it": [
+        "Grammy per la migliore interpretazione vocale pop maschile (1984)"
+      ],
       "isrc": "USSM19902989",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/655262182",
@@ -347,6 +353,9 @@
       "awards_nl": [
         "Grammy Hall of Fame (2001)"
       ],
+      "awards_it": [
+        "Grammy Hall of Fame (2001)"
+      ],
       "isrc": "GBUM71505902",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1856287169",
@@ -441,6 +450,10 @@
         "Grammy Hall of Fame (2004)",
         "Grammy – Beste Originele Filmmuziek (1971)"
       ],
+      "awards_it": [
+        "Grammy Hall of Fame (2004)",
+        "Grammy per la migliore colonna sonora originale (1971)"
+      ],
       "isrc": "GBAYE0601713",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1441164738",
@@ -491,6 +504,9 @@
       "uri_deezer": "deezer://track/92719900",
       "fun_fact_nl": "Highway to Hell was het laatste AC/DC-album met de oorspronkelijke zanger Bon Scott, die zes maanden na de release overleed. De titel verwijst naar het slopende leven van toeren, niet naar satanisme. Producer Mutt Lange duwde de band in de richting van een meer gepolijst geluid dat hun toekomstige werk bepaalde.",
       "awards_nl": [
+        "Grammy Hall of Fame (2020)"
+      ],
+      "awards_it": [
         "Grammy Hall of Fame (2020)"
       ],
       "isrc": "AUAP07900028",
@@ -549,6 +565,10 @@
         "Grammy – Opname van het Jaar (1978)",
         "Grammy Hall of Fame (2003)"
       ],
+      "awards_it": [
+        "Grammy per il disco dell'anno (1978)",
+        "Grammy Hall of Fame (2003)"
+      ],
       "isrc": "USEE11300195",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/635770202",
@@ -598,6 +618,9 @@
       "uri_deezer": "deezer://track/12206946",
       "fun_fact_nl": "Another One Bites the Dust werd aanvankelijk tegengewerkt door het management van Queen die het te disco vond. Michael Jackson moedigde de band persoonlijk aan om het als single uit te brengen. John Deacons baslijn was geïnspireerd op Chic's 'Good Times' en werd een wereldwijd fenomeen.",
       "awards_nl": [
+        "American Music Award (1981)"
+      ],
+      "awards_it": [
         "American Music Award (1981)"
       ],
       "isrc": "GBUM71029605",
@@ -655,6 +678,10 @@
       "awards_nl": [
         "Grammy – Opname van het Jaar (1984)",
         "Grammy – Beste Mannelijke Rock Zangprestatie (1984)"
+      ],
+      "awards_it": [
+        "Grammy per il disco dell'anno (1984)",
+        "Grammy per la migliore interpretazione vocale rock maschile (1984)"
       ],
       "isrc": "USSM19902990",
       "uri_apple_music_by_region": {
@@ -745,6 +772,9 @@
       "awards_nl": [
         "Grammy Hall of Fame (1998)"
       ],
+      "awards_it": [
+        "Grammy Hall of Fame (1998)"
+      ],
       "isrc": "GBUM71700184",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1652668538",
@@ -795,6 +825,9 @@
       "fun_fact_nl": "Eye of the Tiger werd geschreven als antwoord op Sylvester Stallone's verzoek om een themalied voor Rocky III nadat Queen's 'Another One Bites the Dust' niet gelicenseerd kon worden. De band schreef het met beelden uit de eerste twee Rocky-films als inspiratie. Het haalde wereldwijd de hitlijsten.",
       "awards_nl": [
         "Grammy – Beste Rockprestatie (1983)"
+      ],
+      "awards_it": [
+        "Grammy per la migliore interpretazione rock (1983)"
       ],
       "isrc": "USVR19300001",
       "uri_apple_music_by_region": {
@@ -885,6 +918,9 @@
       "awards_nl": [
         "Grammy Hall of Fame (2023)"
       ],
+      "awards_it": [
+        "Grammy Hall of Fame (2023)"
+      ],
       "isrc": "USRH11602140",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1099335223",
@@ -935,6 +971,9 @@
       "fun_fact_nl": "Het tempo van Stayin' Het tempo van 104 BPM komt overeen met het ideale tempo voor het uitvoeren van reanimatie op de borst, waardoor het een aanbevolen nummer is voor medische training. Het nummer werd in slechts een paar uur geschreven tijdens een onderbreking van het filmen van Saturday Night Fever. Het definieerde het discotijdperk.",
       "awards_nl": [
         "Grammy – Beste Pop Zangprestatie (1979)"
+      ],
+      "awards_it": [
+        "Grammy per la migliore interpretazione vocale pop (1979)"
       ],
       "isrc": "NLF057790034",
       "uri_apple_music_by_region": {
@@ -987,6 +1026,9 @@
       "awards_nl": [
         "Grammy Hall of Fame (2009)"
       ],
+      "awards_it": [
+        "Grammy Hall of Fame (2009)"
+      ],
       "isrc": "GBUM71029619",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1440646546",
@@ -1037,6 +1079,9 @@
       "fun_fact_nl": "Take on Me werd drie keer uitgebracht voordat het een hit werd. De innovatieve videoclip, die een potloodschets-animatie met live action combineerde, kostte 100.000 dollar en de productie nam 16 weken in beslag. Het succes van de video bewees dat MTV de populariteit van een nummer kon maken of breken.",
       "awards_nl": [
         "MTV VMA – Beste Nieuwe Artiest (1986)"
+      ],
+      "awards_it": [
+        "MTV VMA per il miglior artista esordiente (1986)"
       ],
       "isrc": "USWB11506543",
       "uri_apple_music_by_region": {
@@ -1133,6 +1178,10 @@
         "Ivor Novello Award (1966)",
         "Grammy Hall of Fame (1997)"
       ],
+      "awards_it": [
+        "Ivor Novello Award (1966)",
+        "Grammy Hall of Fame (1997)"
+      ],
       "isrc": "GBAYE0601477",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1441133496",
@@ -1183,6 +1232,9 @@
       "fun_fact_nl": "Sweet Dreams werd geschreven door Annie Lennox en Dave Stewart tijdens het verbreken van hun romantische relatie. De synthesizerhook van het nummer ontstond per ongeluk toen Stewart apparatuur verkeerd had aangesloten. Het werd het bepalende geluid van synthpop uit de jaren 80 en lanceerde Eurythmics naar de roem.",
       "awards_nl": [
         "MTV VMA – Beste Nieuwe Artiest (1984)"
+      ],
+      "awards_it": [
+        "MTV VMA per il miglior artista esordiente (1984)"
       ],
       "isrc": "GBARL8300004",
       "uri_apple_music_by_region": {
@@ -1309,6 +1361,9 @@
       "uri_deezer": "deezer://track/12206933",
       "fun_fact_nl": "De iconische stomp-stomp-clap beat van We Will Rock You werd ontworpen door Brian May om te worden uitgevoerd door stadionpubliek. May wilde iets creëren dat 'zelfs een stadion vol mensen kon doen'. Het nummer wordt tot op de dag van vandaag bij vrijwel elk sportevenement wereldwijd gespeeld.",
       "awards_nl": [
+        "Grammy Hall of Fame (2009)"
+      ],
+      "awards_it": [
         "Grammy Hall of Fame (2009)"
       ],
       "isrc": "GBUM71029618",
@@ -1516,6 +1571,9 @@
       "awards_nl": [
         "Grammy Hall of Fame (2017)"
       ],
+      "awards_it": [
+        "Grammy Hall of Fame (2017)"
+      ],
       "isrc": "USMC16991138",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1422721989",
@@ -1565,6 +1623,9 @@
       "uri_deezer": "deezer://track/136710424",
       "fun_fact_nl": "Stand By Me werd in slechts 15 minuten geschreven in de kelder van het appartement van Ben E. King in New York. Het nummer was geïnspireerd op een gospelhymne. Het is gebruikt in meer dan 150 films en tv-shows en werd door de Recording Industry Association uitgeroepen tot een van de Songs of the Century.",
       "awards_nl": [
+        "Grammy Hall of Fame (1999)"
+      ],
+      "awards_it": [
         "Grammy Hall of Fame (1999)"
       ],
       "isrc": "USAT21402270",
@@ -1619,6 +1680,9 @@
       "awards_nl": [
         "Grammy Hall of Fame (1999)"
       ],
+      "awards_it": [
+        "Grammy Hall of Fame (1999)"
+      ],
       "isrc": "USMC16758823",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1483870398",
@@ -1668,6 +1732,9 @@
       "uri_deezer": "deezer://track/4188287",
       "fun_fact_nl": "I Want You Back was de debuutsingle van de Jackson 5, met de 11-jarige Michael Jackson als leadzanger. Motown-oprichter Berry Gordy hield persoonlijk toezicht op de productie. Het nummer toonde Michael's ongelooflijke vocale vaardigheden en lanceerde een van de meest legendarische carrières in de muziek.",
       "awards_nl": [
+        "Grammy Hall of Fame (1999)"
+      ],
+      "awards_it": [
         "Grammy Hall of Fame (1999)"
       ],
       "isrc": "USMO19400306",
@@ -1763,6 +1830,10 @@
       "awards_nl": [
         "Grammy – Opname van het Jaar (1986)",
         "Grammy – Lied van het Jaar (1986)"
+      ],
+      "awards_it": [
+        "Grammy per il disco dell'anno (1986)",
+        "Grammy per la canzone dell'anno (1986)"
       ],
       "isrc": "US25T0511671",
       "uri_apple_music_by_region": {
@@ -1937,6 +2008,10 @@
         "Grammy – Opname van het Jaar (1989)",
         "Grammy – Lied van het Jaar (1989)"
       ],
+      "awards_it": [
+        "Grammy per il disco dell'anno (1989)",
+        "Grammy per la canzone dell'anno (1989)"
+      ],
       "isrc": "USEM38800361",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/6762672295",
@@ -1988,6 +2063,9 @@
       "fun_fact_nl": "Waterloo was ABBA's doorbraakhit die het Eurovisiesongfestival van 1974 won. Het lied vergelijkt overgave in de liefde met Napoleons nederlaag bij Waterloo. Het werd uitgebracht in zowel een Engelse als Zweedse versie en lanceerde ABBA's carrière als een van de best verkopende groepen in de geschiedenis.",
       "awards_nl": [
         "Eurovisionwinnaar (1974)"
+      ],
+      "awards_it": [
+        "Vincitore dell'Eurovision Song Contest 1974"
       ],
       "isrc": "SEAYD7415010",
       "uri_apple_music_by_region": {
@@ -2548,6 +2626,11 @@
         "Grammy – Beste R&B Zangprestatie (1968)",
         "Grammy Hall of Fame (1998)"
       ],
+      "awards_it": [
+        "Grammy per la migliore registrazione R&B (1968)",
+        "Grammy per la migliore interpretazione vocale R&B (1968)",
+        "Grammy Hall of Fame (1998)"
+      ],
       "isrc": "USAT21403673",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/933578351",
@@ -2599,6 +2682,9 @@
       "awards_nl": [
         "Grammy – Opname van het Jaar (1983)"
       ],
+      "awards_it": [
+        "Grammy per il disco dell'anno (1983)"
+      ],
       "isrc": "USSM18200245",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/318675271",
@@ -2649,6 +2735,9 @@
       "uri_deezer": "deezer://track/884025",
       "fun_fact_nl": "Dancing Queen blijft ABBA's meest succesvolle single en de enige die nummer één werd in de VS. Het was geïnspireerd door George McCrae's 'Rock Your Baby'. ABBA voerde het voor het eerst uit op de avond voor het huwelijk van de Zweedse koning Carl XVI Gustaf als eerbetoon aan de nieuwe koningin.",
       "awards_nl": [
+        "Grammy Hall of Fame (2015)"
+      ],
+      "awards_it": [
         "Grammy Hall of Fame (2015)"
       ],
       "isrc": "SEAYD7601020",
@@ -2746,6 +2835,10 @@
         "Grammy – Opname van het Jaar (1994)",
         "Grammy – Beste Pop Zangprestatie (1994)"
       ],
+      "awards_it": [
+        "Grammy per il disco dell'anno (1994)",
+        "Grammy per la migliore interpretazione vocale pop (1994)"
+      ],
       "isrc": "USAR19200110",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/650117376",
@@ -2795,6 +2888,9 @@
       "uri_deezer": "deezer://track/3091966",
       "fun_fact_nl": "De melodie van Surfin' U.S.A. werd aangepast van Chuck Berry's 'Sweet Little Sixteen', wat leidde tot een rechtszaak. Brian Wilson van de Beach Boys werd gedwongen om Berry de eer te geven voor zijn songwriting. Ondanks de controverse legde het nummer de Californische surfcultuur vast en is het tot op de dag van vandaag een Amerikaanse klassieker.",
       "awards_nl": [
+        "Grammy Hall of Fame (2003)"
+      ],
+      "awards_it": [
         "Grammy Hall of Fame (2003)"
       ],
       "isrc": "USCA20001654"
@@ -2915,6 +3011,9 @@
       "awards_nl": [
         "Grammy – Beste Pop Zangprestatie (1988)"
       ],
+      "awards_it": [
+        "Grammy per la migliore interpretazione vocale pop (1988)"
+      ],
       "isrc": "USAR18700121",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1627099927",
@@ -3033,6 +3132,9 @@
       "awards_nl": [
         "Grammy Hall of Fame (2021)"
       ],
+      "awards_it": [
+        "Grammy Hall of Fame (2021)"
+      ],
       "isrc": "USSM18100116",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1681227819",
@@ -3122,6 +3224,9 @@
       "fun_fact_nl": "I Will Survive werd oorspronkelijk uitgebracht als B-kant voordat DJ's het begonnen te draaien in clubs. Gloria Gaynor nam het in één take op, ondanks het feit dat ze net hersteld was van een rugoperatie. Het nummer werd een disco-anthem en later een symbool van empowerment voor de LGBTQ+ gemeenschap wereldwijd.",
       "awards_nl": [
         "Grammy – Beste Disco-opname (1980)"
+      ],
+      "awards_it": [
+        "Grammy per la migliore registrazione disco (1980)"
       ],
       "isrc": "USPR37800083",
       "uri_apple_music_by_region": {
@@ -3255,6 +3360,10 @@
       "awards_nl": [
         "Grammy – Beste R&B Zangprestatie (1984)",
         "Grammy – Beste R&B-nummer (1984)"
+      ],
+      "awards_it": [
+        "Grammy per la migliore interpretazione vocale R&B (1984)",
+        "Grammy per la migliore canzone R&B (1984)"
       ],
       "isrc": "USSM19902991",
       "uri_apple_music_by_region": {
@@ -3692,6 +3801,9 @@
       "awards_nl": [
         "Grammy – Beste Rock-'n-Roll-opname (1962)"
       ],
+      "awards_it": [
+        "Grammy per la migliore registrazione rock and roll (1962)"
+      ],
       "isrc": "USA176140170",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1443091056",
@@ -3934,6 +4046,9 @@
       "awards_nl": [
         "Grammy Hall of Fame (2017)"
       ],
+      "awards_it": [
+        "Grammy Hall of Fame (2017)"
+      ],
       "isrc": "USGF19942501",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1440783625",
@@ -4104,6 +4219,10 @@
         "Grammy – Beste Pop Zangprestatie (1984)",
         "Oscar – Beste Originele Lied (1984)"
       ],
+      "awards_it": [
+        "Grammy per la migliore interpretazione vocale pop (1984)",
+        "Oscar per la migliore canzone originale (1984)"
+      ],
       "isrc": "CAU118300354",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/280711410",
@@ -4268,6 +4387,9 @@
       "fun_fact_nl": "De iconische gitaarriff van Sweet Child O' Mine was eigenlijk een opwarmoefening die Slash aan het spelen was. Axl Rose hoorde het en eiste dat ze er een nummer van maakten. Het nummer werd in slechts vijf dagen geschreven. Het werd Guns N' Roses' grootste hit en een van de meest geliefde ballads van de rock.",
       "awards_nl": [
         "American Music Award – Favoriete Pop/Rock Single (1989)"
+      ],
+      "awards_it": [
+        "American Music Award per il singolo pop/rock preferito (1989)"
       ],
       "isrc": "USGF18714809",
       "uri_apple_music_by_region": {
@@ -4528,6 +4650,9 @@
       "awards_nl": [
         "Grammy Hall of Fame (2003)"
       ],
+      "awards_it": [
+        "Grammy Hall of Fame (2003)"
+      ],
       "isrc": "USAT21207031",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/902620521",
@@ -4616,6 +4741,10 @@
       "awards_nl": [
         "Grammy – Beste Rock Zangprestatie (1985)",
         "Oscar – Beste Originele Liedpartituur (1985)"
+      ],
+      "awards_it": [
+        "Grammy per la migliore interpretazione vocale rock (1985)",
+        "Oscar per la migliore colonna sonora con canzoni originali (1985)"
       ]
     },
     {
@@ -4699,6 +4828,9 @@
       "uri_deezer": "deezer://track/3788156052",
       "fun_fact_nl": "Paranoid werd in slechts 20 minuten geschreven als een last-minute filler track toen het album bijna op was. Tony Iommi bedacht de riff ter plekke en Geezer Butler krabbelde snel een tekst over depressie. Ondanks dat het een bijzaak was, werd het Black Sabbaths grootste hitsingle en het nummer dat heavy metal definieerde.",
       "awards_nl": [
+        "Grammy Hall of Fame (2021)"
+      ],
+      "awards_it": [
         "Grammy Hall of Fame (2021)"
       ],
       "isrc": "USWB11304369",
@@ -4829,6 +4961,9 @@
       "awards_nl": [
         "Grammy – Beste Rocknummer (2004)"
       ],
+      "awards_it": [
+        "Grammy per la migliore canzone rock (2004)"
+      ],
       "isrc": "USVT10300001",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1533513537",
@@ -4921,6 +5056,9 @@
       "uri_deezer": "deezer://track/78671026",
       "fun_fact_nl": "Het middelste gedeelte van Whole Lotta Love bevat een psychedelische breakdown gemaakt door Jimmy Page met behulp van een theremin en backwards echo effecten. De tekst van het nummer is gedeeltelijk afgeleid van Willie Dixon's 'You Need Love', wat leidde tot een rechtszaak en een credit voor het songschrijven van Dixon. De riff werd door het tijdschrift Total Guitar uitgeroepen tot de beste gitaarriff aller tijden.",
       "awards_nl": [
+        "Grammy Hall of Fame (2014)"
+      ],
+      "awards_it": [
         "Grammy Hall of Fame (2014)"
       ],
       "isrc": "USAT21207009",
@@ -5017,6 +5155,9 @@
       "awards_nl": [
         "Grammy Hall of Fame (1999)"
       ],
+      "awards_it": [
+        "Grammy Hall of Fame (1999)"
+      ],
       "isrc": "USA176460010",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1440781975",
@@ -5110,6 +5251,9 @@
       "fun_fact_nl": "Nikki Sixx schreef Kickstart My Heart na een bijna fatale overdosis heroïne in 1987. Hij was klinisch dood gedurende twee minuten voordat paramedici hem weer tot leven wekten met twee injecties met adrenaline recht in het hart. De adrenalinestoot die hem weer tot leven bracht, inspireerde de stuwende energie van het nummer. De basintro is opgenomen op 200+ BPM.",
       "awards_nl": [
         "Grammy-nominatie – Beste Hardrockprestatie (1990)"
+      ],
+      "awards_it": [
+        "Candidatura al Grammy per la migliore interpretazione hard rock (1990)"
       ],
       "isrc": "USBY29900215",
       "uri_apple_music_by_region": {
@@ -5289,6 +5433,9 @@
       "fun_fact_nl": "Kirk Hammett bedacht de iconische riff van Enter Sandman om 3 uur 's nachts, toen hij het half slapend in een bandrecorder speelde. Producer Bob Rock pushte de band om een toegankelijker geluid te creëren, wat spanning veroorzaakte maar uiteindelijk hun best verkopende album opleverde. Het nummer gebruikt de melodie van 'Hush, Little Baby' in de brug, verdraaid in een nachtmerrieachtige context over kinderangsten.",
       "awards_nl": [
         "Grammy-nominatie – Beste Metalprestatie (1992)"
+      ],
+      "awards_it": [
+        "Candidatura al Grammy per la migliore interpretazione metal (1992)"
       ],
       "isrc": "QMKHM1900001",
       "uri_apple_music_by_region": {
@@ -5686,6 +5833,10 @@
         "Grammy – Lied van het Jaar (1984)",
         "Grammy – Beste Popprestatie door Duo of Groep (1984)"
       ],
+      "awards_it": [
+        "Grammy per la canzone dell'anno (1984)",
+        "Grammy per la migliore interpretazione pop di un duo o gruppo (1984)"
+      ],
       "isrc": "GBAAM0201110",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1561882481",
@@ -5784,6 +5935,10 @@
       "awards_nl": [
         "Grammy – Beste Korte Muziekvideo (1992)",
         "Grammy – Beste Popprestatie door Duo of Groep (1992)"
+      ],
+      "awards_it": [
+        "Grammy per il miglior video musicale di forma breve (1992)",
+        "Grammy per la migliore interpretazione pop di un duo o gruppo (1992)"
       ],
       "isrc": "USWB10402077",
       "uri_apple_music_by_region": {
@@ -6044,6 +6199,9 @@
       "uri_deezer": "deezer://track/65445466",
       "fun_fact_nl": "Riders on the Storm was het laatste nummer dat The Doors opnamen met Jim Morrison voor zijn dood in Parijs in juli 1971. De regen- en dondergeluiden werden toegevoegd om een sfeervolle omgeving te creëren. De baslijn van het nummer was geïnspireerd op jazz en de tekst verwijst naar een liftende seriemoordenaar. Morrison fluisterde de zangtrack over zijn gewone zang, waardoor het spookachtige dubbelspooreffect ontstond.",
       "awards_nl": [
+        "Grammy Hall of Fame (2009)"
+      ],
+      "awards_it": [
         "Grammy Hall of Fame (2009)"
       ],
       "isrc": "USEE11200581",
@@ -6314,6 +6472,10 @@
         "Grammy Hall of Fame (1998)",
         "Rolling Stone – #2 Beste Nummer Aller Tijden"
       ],
+      "awards_it": [
+        "Grammy Hall of Fame (1998)",
+        "Rolling Stone – n. 2 tra le migliori canzoni di sempre"
+      ],
       "isrc": "USA176510160",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1623247613",
@@ -6408,6 +6570,9 @@
       "fun_fact_nl": "De videoclip van November Rain kostte naar schatting 1,5 miljoen dollar, waarmee het een van de duurste videoclips ooit was. Axl Rose werkte bijna tien jaar aan het nummer voordat hij het opnam. Het orkestrale arrangement bevat een 60-koppig orkest. De video werd de eerste uit de jaren 90 die meer dan 1 miljard keer werd bekeken op YouTube en bereikte deze mijlpaal in 2018.",
       "awards_nl": [
         "MTV VMA – Beste Cinematografie (1992)"
+      ],
+      "awards_it": [
+        "MTV VMA per la migliore fotografia (1992)"
       ]
     },
     {
@@ -6778,6 +6943,9 @@
       "awards_nl": [
         "Grammy Hall of Fame (2016)"
       ],
+      "awards_it": [
+        "Grammy Hall of Fame (2016)"
+      ],
       "isrc": "USEV19900002",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1275600554",
@@ -6913,6 +7081,9 @@
       "fun_fact_nl": "Eric Clapton schreef Layla over zijn onbeantwoorde liefde voor Pattie Boyd, die in die tijd getrouwd was met zijn beste vriend George Harrison. De titel was geïnspireerd op het Perzische liefdesverhaal 'Layla en Majnun'. Het gastgitaarwerk van Duane Allman creëerde een van de beroemdste gitaaruitvoeringen met dubbele lead in de rock. De uitgebreide pianocoda van het nummer werd geschreven door drummer Jim Gordon en werd bijna een apart nummer.",
       "awards_nl": [
         "Grammy Hall of Fame (2000)"
+      ],
+      "awards_it": [
+        "Grammy Hall of Fame (2000)"
       ]
     },
     {
@@ -6956,6 +7127,9 @@
       "fun_fact_nl": "Fly Away werd in één middag geschreven en opgenomen. Lenny Kravitz bedacht de riff tijdens het jammen in zijn thuisstudio en legde alle instrumenten zelf neer. Het nummer werd zijn grootste commerciële hit en werd veel gebruikt in tv-commercials, videospelletjes en soundtracks van films. Het hielp Kravitz' reputatie als moderne classic rock revivalist te verstevigen.",
       "awards_nl": [
         "Grammy – Beste Mannelijke Rock Zangprestatie (2000)"
+      ],
+      "awards_it": [
+        "Grammy per la migliore interpretazione vocale rock maschile (2000)"
       ],
       "isrc": "USVI29800169",
       "uri_apple_music_by_region": {
@@ -7226,6 +7400,10 @@
       "awards_nl": [
         "Grammy – Beste Hardrockprestatie (1995)",
         "Grammy – Beste Metalprestatie (1995)"
+      ],
+      "awards_it": [
+        "Grammy per la migliore interpretazione hard rock (1995)",
+        "Grammy per la migliore interpretazione metal (1995)"
       ],
       "isrc": "USAM19400007",
       "uri_apple_music_by_region": {

--- a/custom_components/beatify/playlists/motown-soul-classics.json
+++ b/custom_components/beatify/playlists/motown-soul-classics.json
@@ -1,6 +1,6 @@
 {
   "name": "Motown & Soul Classics",
-  "version": "1.15",
+  "version": "1.16",
   "tags": [
     "1960s",
     "1970s",
@@ -128,6 +128,9 @@
       "fun_fact_nl": "De volledige albumversie duurt meer dan 12 minuten met zijn iconische baslijn. The Temptations hadden aanvankelijk een hekel aan het nummer omdat het verwees naar een afwezige vader, wat voor sommige leden te dicht bij huis kwam.",
       "awards_nl": [
         "Grammy Award voor Beste R&B Instrumentale Prestatie"
+      ],
+      "awards_it": [
+        "Grammy per la migliore interpretazione strumentale R&B"
       ],
       "isrc": "USMO17200080",
       "uri_apple_music_by_region": {
@@ -657,6 +660,9 @@
       "awards_nl": [
         "Oscarnominatie voor Beste Originele Lied"
       ],
+      "awards_it": [
+        "Candidatura all'Oscar per la migliore canzone originale"
+      ],
       "isrc": "USMO17500374",
       "uri_apple_music_by_region": {
         "de": "applemusic://track/1612221191",
@@ -989,6 +995,9 @@
       "awards_nl": [
         "Grammy Hall of Fame"
       ],
+      "awards_it": [
+        "Grammy Hall of Fame"
+      ],
       "isrc": "USMO17100041",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1472134764",
@@ -1238,6 +1247,9 @@
       "awards_nl": [
         "Grammy Award voor Beste R&B-nummer"
       ],
+      "awards_it": [
+        "Grammy per la migliore canzone R&B"
+      ],
       "isrc": "USMO18400528",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/6762971076",
@@ -1404,6 +1416,9 @@
       "awards_nl": [
         "Grammy Award voor Beste R&B Zangprestatie"
       ],
+      "awards_it": [
+        "Grammy per la migliore interpretazione vocale R&B"
+      ],
       "isrc": "USMO17600547",
       "uri_tidal": "tidal://track/98184494"
     },
@@ -1522,6 +1537,9 @@
       "fun_fact_nl": "Dit nummer, geschreven door Burt Bacharach en Hal David, werd een van Dionne Warwick's meest bekende nummers en won de Grammy voor Best Contemporary Pop Vocal Performance. Hoewel het geen Motown-opname is, staat het in deze Spotify-afspeellijst naast de Motown-klassiekers.",
       "awards_nl": [
         "Grammy Award voor Beste Hedendaagse Pop Zangprestatie"
+      ],
+      "awards_it": [
+        "Grammy per la migliore interpretazione vocale pop contemporanea"
       ],
       "isrc": "USWSP0000033",
       "uri_apple_music_by_region": {
@@ -1977,6 +1995,9 @@
       "awards_nl": [
         "Oscarnominatie voor Beste Originele Lied"
       ],
+      "awards_it": [
+        "Candidatura all'Oscar per la migliore canzone originale"
+      ],
       "isrc": "USMO18190008",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1606057197",
@@ -2024,6 +2045,9 @@
       "fun_fact_nl": "Een liefdesliedje over een rat, uit de horrorfilm 'Ben. Michael was pas 14 toen het zijn eerste nummer 1 solohit werd. Het werd genomineerd voor een Academy Award voor Best Original Song.",
       "awards_nl": [
         "Oscarnominatie voor Beste Originele Lied"
+      ],
+      "awards_it": [
+        "Candidatura all'Oscar per la migliore canzone originale"
       ],
       "isrc": "USMO17282631",
       "uri_apple_music_by_region": {

--- a/custom_components/beatify/playlists/movies-100-greatest-themes.json
+++ b/custom_components/beatify/playlists/movies-100-greatest-themes.json
@@ -1,6 +1,6 @@
 {
   "name": "100 Greatest Movie Themes 🎬",
-  "version": "1.22",
+  "version": "1.23",
   "tags": [
     "movies",
     "soundtrack",
@@ -53,6 +53,10 @@
       "awards_nl": [
         "Oscar voor Beste Originele Filmmuziek (2001)",
         "Grammy Award voor Beste Soundtrackpartituur (2002)"
+      ],
+      "awards_it": [
+        "Oscar per la migliore colonna sonora originale (2001)",
+        "Grammy per la migliore colonna sonora (2002)"
       ],
       "isrc": "USRE10501631",
       "uri_apple_music_by_region": {
@@ -141,6 +145,10 @@
         "Oscar voor Beste Originele Filmmuziek (1997)",
         "Golden Globe voor Beste Originele Filmmuziek (1998)"
       ],
+      "awards_it": [
+        "Oscar per la migliore colonna sonora originale (1997)",
+        "Golden Globe per la migliore colonna sonora originale (1998)"
+      ],
       "isrc": "USSM19702327",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/582727836",
@@ -203,6 +211,10 @@
         "Oscar voor Beste Originele Filmmuziek (1977)",
         "Grammy Award voor Beste Soundtrackpartituur (1978)"
       ],
+      "awards_it": [
+        "Oscar per la migliore colonna sonora originale (1977)",
+        "Grammy per la migliore colonna sonora (1978)"
+      ],
       "isrc": "USWD11785403",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1375814284",
@@ -260,6 +272,9 @@
       "fun_fact_nl": "De soundtrack van Saturday Night Fever stond 24 weken op nummer 1 en verkocht meer dan 40 miljoen exemplaren, waardoor het een van de best verkochte soundtracks ooit is.",
       "awards_nl": [
         "Grammy Award voor Album van het Jaar (1979)"
+      ],
+      "awards_it": [
+        "Grammy per l'album dell'anno (1979)"
       ],
       "isrc": "NLF057790034",
       "uri_apple_music_by_region": {
@@ -356,6 +371,9 @@
       "fun_fact_nl": "De score voor American Beauty van Thomas Newman maakt gebruik van marimba- en gamelaninstrumenten om een etherische, suburbane soundscape te creëren die een Grammy won.",
       "awards_nl": [
         "Grammy Award voor Beste Soundtrackpartituur (2000)"
+      ],
+      "awards_it": [
+        "Grammy per la migliore colonna sonora (2000)"
       ],
       "isrc": "USDW19921001",
       "uri_apple_music_by_region": {
@@ -500,6 +518,10 @@
         "Oscar voor Beste Originele Lied (1971)",
         "Grammy Award voor Beste Instrumentaal (1972)"
       ],
+      "awards_it": [
+        "Oscar per la migliore canzone originale (1971)",
+        "Grammy per la migliore interpretazione strumentale (1972)"
+      ],
       "uri_apple_music": "applemusic://track/1440781096",
       "uri_youtube_music": "https://music.youtube.com/watch?v=fTU_9T5ufzY"
     },
@@ -545,6 +567,9 @@
       "fun_fact_nl": "Henry Mancini's Pink Panther Theme werd geschreven voor de openingscredits, maar werd zo populair dat er een hele animatieserie uit voortkwam.",
       "awards_nl": [
         "Grammy Award voor Beste Instrumentaal (1964)"
+      ],
+      "awards_it": [
+        "Grammy per la migliore interpretazione strumentale (1964)"
       ],
       "isrc": "USRC16302654",
       "uri_apple_music_by_region": {
@@ -689,6 +714,10 @@
         "Oscar voor Beste Originele Lied (1966)",
         "Oscar voor Beste Originele Filmmuziek (1966)"
       ],
+      "awards_it": [
+        "Oscar per la migliore canzone originale (1966)",
+        "Oscar per la migliore colonna sonora originale (1966)"
+      ],
       "isrc": "USSM10028082",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/209447357",
@@ -746,6 +775,9 @@
       "awards_nl": [
         "Golden Globe voor Beste Originele Lied (1995)"
       ],
+      "awards_it": [
+        "Golden Globe per la migliore canzone originale (1995)"
+      ],
       "isrc": "USWD10220440",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1445732924",
@@ -802,6 +834,9 @@
       "fun_fact_nl": "Gonna Fly Now uit Rocky werd in één middag geschreven. De triomfantelijke fanfare werd synoniem voor het overwinnen van onmogelijke kansen.",
       "awards_nl": [
         "Oscarnominatie voor Beste Originele Lied (1976)"
+      ],
+      "awards_it": [
+        "Candidatura all'Oscar per la migliore canzone originale (1976)"
       ],
       "isrc": "USNPD0600582",
       "uri_apple_music_by_region": {
@@ -864,6 +899,10 @@
       "awards_nl": [
         "Oscar voor Beste Originele Filmmuziek (1965)",
         "Golden Globe voor Beste Originele Filmmuziek (1966)"
+      ],
+      "awards_it": [
+        "Oscar per la migliore colonna sonora originale (1965)",
+        "Golden Globe per la migliore colonna sonora originale (1966)"
       ],
       "isrc": "USNLR1200108",
       "uri_apple_music_by_region": {
@@ -1059,6 +1098,9 @@
       "awards_nl": [
         "Grammy-nominatie voor Beste Soundtrackpartituur (2015)"
       ],
+      "awards_it": [
+        "Candidatura al Grammy per la migliore colonna sonora (2015)"
+      ],
       "isrc": "USNLR1400774",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1533984393",
@@ -1149,6 +1191,10 @@
       "awards_nl": [
         "Golden Globe voor Beste Originele Filmmuziek (2016)",
         "BAFTA voor Beste Filmmuziek (2016)"
+      ],
+      "awards_it": [
+        "Golden Globe per la migliore colonna sonora originale (2016)",
+        "BAFTA per la migliore musica da film (2016)"
       ],
       "isrc": "US5941405853",
       "uri_apple_music_by_region": {
@@ -1271,6 +1317,9 @@
       "awards_nl": [
         "Gouden Palm in Cannes (1966)"
       ],
+      "awards_it": [
+        "Palma d'oro a Cannes (1966)"
+      ],
       "isrc": "FRP366600040",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1453739559",
@@ -1372,6 +1421,10 @@
         "Oscar voor Beste Originele Lied (1995)",
         "Golden Globe voor Beste Originele Lied (1995)"
       ],
+      "awards_it": [
+        "Oscar per la migliore canzone originale (1995)",
+        "Golden Globe per la migliore canzone originale (1995)"
+      ],
       "isrc": "USWD10110149",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1440720182",
@@ -1428,6 +1481,9 @@
       "fun_fact_nl": "Raindrops Keep Fallin' on My Head won de Oscar ondanks dat het niet op zijn plaats leek in een western. Het werd het lijflied van B.J. Thomas.",
       "awards_nl": [
         "Oscar voor Beste Originele Lied (1969)"
+      ],
+      "awards_it": [
+        "Oscar per la migliore canzone originale (1969)"
       ],
       "isrc": "USAFM0600725",
       "uri_apple_music_by_region": {
@@ -1566,6 +1622,10 @@
         "Oscar voor Beste Originele Filmmuziek (1975)",
         "Grammy Award voor Beste Soundtrackpartituur (1976)"
       ],
+      "awards_it": [
+        "Oscar per la migliore colonna sonora originale (1975)",
+        "Grammy per la migliore colonna sonora (1976)"
+      ],
       "isrc": "USUM72505990",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1842229145",
@@ -1623,6 +1683,10 @@
       "awards_nl": [
         "Oscar voor Beste Originele Filmmuziek (1978)",
         "Golden Globe voor Beste Originele Filmmuziek (1979)"
+      ],
+      "awards_it": [
+        "Oscar per la migliore colonna sonora originale (1978)",
+        "Golden Globe per la migliore colonna sonora originale (1979)"
       ],
       "isrc": "USPR37900070",
       "uri_apple_music_by_region": {
@@ -1685,6 +1749,10 @@
         "Oscar voor Beste Originele Lied (1987)",
         "Golden Globe voor Beste Originele Lied (1988)"
       ],
+      "awards_it": [
+        "Oscar per la migliore canzone originale (1987)",
+        "Golden Globe per la migliore canzone originale (1988)"
+      ],
       "uri_apple_music": "applemusic://track/254938549"
     },
     {
@@ -1729,6 +1797,9 @@
       "fun_fact_nl": "Randy Newman schreef You've Got a Friend in Me in slechts één dag. Het werd het hart van de hele Toy Story-franchise.",
       "awards_nl": [
         "Oscarnominatie voor Beste Originele Lied (1995)"
+      ],
+      "awards_it": [
+        "Candidatura all'Oscar per la migliore canzone originale (1995)"
       ],
       "isrc": "USWD10110108",
       "uri_apple_music_by_region": {
@@ -2005,6 +2076,9 @@
       "awards_nl": [
         "Oscarnominatie voor Beste Originele Filmmuziek (1990)"
       ],
+      "awards_it": [
+        "Candidatura all'Oscar per la migliore colonna sonora originale (1990)"
+      ],
       "isrc": "USSM19909870",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1712207945",
@@ -2059,6 +2133,9 @@
       "awards_nl": [
         "Oscar voor Beste Originele Lied (1968)"
       ],
+      "awards_it": [
+        "Oscar per la migliore canzone originale (1968)"
+      ],
       "uri_apple_music": "applemusic://track/1206260997"
     },
     {
@@ -2101,6 +2178,9 @@
       "fun_fact_nl": "Het Indiana Jones-thema van John Williams staat bekend als de Raiders March. Het werd geschreven voor het filmen en inspireerde de branie van het personage.",
       "awards_nl": [
         "Oscarnominatie voor Beste Originele Filmmuziek (1981)"
+      ],
+      "awards_it": [
+        "Candidatura all'Oscar per la migliore colonna sonora originale (1981)"
       ],
       "isrc": "USC4R0818847",
       "uri_apple_music_by_region": {
@@ -2226,6 +2306,9 @@
       "fun_fact_nl": "The Sound of Music werd de best verdienende film van 1965. Julie Andrews zong alleen.",
       "awards_nl": [
         "Oscar voor Beste Film (1965)"
+      ],
+      "awards_it": [
+        "Oscar per il miglior film (1965)"
       ],
       "isrc": "USRC16406208",
       "uri_apple_music_by_region": {
@@ -2399,6 +2482,10 @@
       "awards_nl": [
         "Oscar voor Beste Originele Filmmuziek (1970)",
         "Golden Globe voor Beste Originele Filmmuziek (1971)"
+      ],
+      "awards_it": [
+        "Oscar per la migliore colonna sonora originale (1970)",
+        "Golden Globe per la migliore colonna sonora originale (1971)"
       ]
     },
     {
@@ -2450,6 +2537,10 @@
       "awards_nl": [
         "Oscar voor Beste Originele Lied (1961)",
         "Grammy Award voor Opname van het Jaar (1962)"
+      ],
+      "awards_it": [
+        "Oscar per la migliore canzone originale (1961)",
+        "Grammy per il disco dell'anno (1962)"
       ],
       "isrc": "USRC10001122",
       "uri_apple_music_by_region": {
@@ -2503,6 +2594,9 @@
       "fun_fact_nl": "De score voor Shawshank Redemption van Thomas Newman maakt gebruik van harmonica en zachte strijkers om hoop binnen de gevangenismuren over te brengen.",
       "awards_nl": [
         "Oscarnominatie voor Beste Originele Filmmuziek (1994)"
+      ],
+      "awards_it": [
+        "Candidatura all'Oscar per la migliore colonna sonora originale (1994)"
       ],
       "isrc": "USSM10904608",
       "uri_apple_music_by_region": {
@@ -2636,6 +2730,9 @@
       "fun_fact_nl": "Het thema A Summer Place van Max Steiner stond negen weken op nummer één. De weelderige orkestratie werd een symbool voor romantische cinema.",
       "awards_nl": [
         "Grammy Award voor Opname van het Jaar (1960)"
+      ],
+      "awards_it": [
+        "Grammy per il disco dell'anno (1960)"
       ],
       "uri_apple_music": "applemusic://track/1440563265"
     },
@@ -2841,6 +2938,10 @@
       "awards_nl": [
         "Oscar voor Beste Originele Lied (1976)",
         "Golden Globe voor Beste Originele Lied (1977)"
+      ],
+      "awards_it": [
+        "Oscar per la migliore canzone originale (1976)",
+        "Golden Globe per la migliore canzone originale (1977)"
       ],
       "isrc": "USSM10001384",
       "uri_apple_music_by_region": {
@@ -3165,6 +3266,9 @@
       "awards_nl": [
         "BAFTA voor Beste Filmmuziek (1983)"
       ],
+      "awards_it": [
+        "BAFTA per la migliore musica da film (1983)"
+      ],
       "isrc": "US5941405510",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1500818278",
@@ -3217,6 +3321,9 @@
       "fun_fact_nl": "Het Superman-thema van John Williams belichaamt heldendom en hoop. Christopher Reeve zei dat de muziek hem hielp geloven dat hij kon vliegen.",
       "awards_nl": [
         "Grammy Award voor Beste Soundtrackpartituur (1979)"
+      ],
+      "awards_it": [
+        "Grammy per la migliore colonna sonora (1979)"
       ],
       "uri_apple_music": "applemusic://track/50235862"
     },
@@ -3336,6 +3443,9 @@
       "fun_fact_nl": "De Spartacus-score van Alex North was baanbrekend voor die tijd. Stanley Kubrick wees de muziek later af en gaf de voorkeur aan klassieke stukken.",
       "awards_nl": [
         "Golden Globe voor Beste Originele Filmmuziek (1961)"
+      ],
+      "awards_it": [
+        "Golden Globe per la migliore colonna sonora originale (1961)"
       ],
       "uri_apple_music": "applemusic://track/1705329406",
       "uri_youtube_music": "https://music.youtube.com/watch?v=DZ6e8-94JRE"
@@ -3670,6 +3780,10 @@
         "Oscar voor Beste Originele Filmmuziek (1960)",
         "Golden Globe voor Beste Originele Filmmuziek (1961)"
       ],
+      "awards_it": [
+        "Oscar per la migliore colonna sonora originale (1960)",
+        "Golden Globe per la migliore colonna sonora originale (1961)"
+      ],
       "isrc": "USRC10101348",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1719334913",
@@ -3762,6 +3876,9 @@
       "fun_fact_nl": "Max Steiner's Gone with the Wind partituur was in die tijd de langste die ooit geschreven was. Hij componeerde drie uur muziek in slechts drie maanden.",
       "awards_nl": [
         "Oscar voor Beste Originele Filmmuziek (1939)"
+      ],
+      "awards_it": [
+        "Oscar per la migliore colonna sonora originale (1939)"
       ],
       "isrc": "USNLR1300001",
       "uri_apple_music_by_region": {
@@ -3893,6 +4010,9 @@
       "awards_nl": [
         "Oscar voor Beste Originele Filmmuziek (1981)"
       ],
+      "awards_it": [
+        "Oscar per la migliore colonna sonora originale (1981)"
+      ],
       "isrc": "NLA028100010",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1450958727",
@@ -3950,6 +4070,9 @@
       "awards_nl": [
         "Oscarnominatie voor Beste Originele Lied (1984)"
       ],
+      "awards_it": [
+        "Candidatura all'Oscar per la migliore canzone originale (1984)"
+      ],
       "isrc": "USAR18400117",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1692216413",
@@ -4005,6 +4128,9 @@
       "fun_fact_nl": "The Entertainer van Scott Joplin werd nieuw leven ingeblazen voor The Sting. De ragtime-klassieker leverde Marvin Hamlisch een Oscar op voor Beste Score.",
       "awards_nl": [
         "Oscar voor Beste Originele Filmmuziek (1973)"
+      ],
+      "awards_it": [
+        "Oscar per la migliore colonna sonora originale (1973)"
       ],
       "uri_apple_music": "applemusic://track/1684775318"
     },
@@ -4177,6 +4303,10 @@
       "awards_nl": [
         "Oscar voor Beste Originele Filmmuziek (1982)",
         "Grammy Award voor Beste Soundtrackpartituur (1983)"
+      ],
+      "awards_it": [
+        "Oscar per la migliore colonna sonora originale (1982)",
+        "Grammy per la migliore colonna sonora (1983)"
       ],
       "isrc": "USSM19603560",
       "uri_apple_music_by_region": {
@@ -4384,6 +4514,9 @@
       "awards_nl": [
         "Grammy Award voor Beste Soundtrackpartituur (2012)"
       ],
+      "awards_it": [
+        "Grammy per la migliore colonna sonora (2012)"
+      ],
       "uri_youtube_music": "https://music.youtube.com/watch?v=7Ys-t436d1Y"
     },
     {
@@ -4540,6 +4673,9 @@
       "fun_fact_nl": "Over the Rainbow was bijna uit The Wizard of Oz geknipt. Het won de Oscar en werd het lijflied van Judy Garland.",
       "awards_nl": [
         "Oscar voor Beste Originele Lied (1939)"
+      ],
+      "awards_it": [
+        "Oscar per la migliore canzone originale (1939)"
       ],
       "isrc": "USNLR1500393",
       "uri_apple_music_by_region": {
@@ -4731,6 +4867,9 @@
       "awards_nl": [
         "Oscar voor Beste Originele Lied (1955)"
       ],
+      "awards_it": [
+        "Oscar per la migliore canzone originale (1955)"
+      ],
       "uri_apple_music": "applemusic://track/551962523",
       "uri_youtube_music": "https://music.youtube.com/watch?v=xM96O-Yk5YU"
     },
@@ -4773,6 +4912,9 @@
       "fun_fact_nl": "John Williams' Catch Me If You Can score gebruikt jazz om de jaren 60 op te roepen. Het speelse thema past bij het kat-en-muis plot van de film.",
       "awards_nl": [
         "Grammy-nominatie voor Beste Soundtrackpartituur (2003)"
+      ],
+      "awards_it": [
+        "Candidatura al Grammy per la migliore colonna sonora (2003)"
       ],
       "uri_apple_music": "applemusic://track/1443084900"
     },
@@ -4823,6 +4965,9 @@
       "fun_fact_nl": "Mike Oldfield's Tubular Bells werden beroemd door The Exorcist. Het album verkocht miljoenen exemplaren na het gebruik ervan in de horrorklassieker.",
       "awards_nl": [
         "Grammy Award voor Beste Instrumentaal (1975)"
+      ],
+      "awards_it": [
+        "Grammy per la migliore interpretazione strumentale (1975)"
       ],
       "isrc": "GBUM70905030",
       "uri_apple_music_by_region": {
@@ -4875,6 +5020,9 @@
       "fun_fact_nl": "Miklos Rozsa's Ben-Hur score vereiste het grootste orkest ooit bijeengebracht voor een film. Het won de Oscar voor Beste Score.",
       "awards_nl": [
         "Oscar voor Beste Originele Filmmuziek (1959)"
+      ],
+      "awards_it": [
+        "Oscar per la migliore colonna sonora originale (1959)"
       ],
       "isrc": "USNLR1400192",
       "uri_apple_music_by_region": {
@@ -4958,6 +5106,9 @@
       "fun_fact_nl": "Het Lawrence of Arabia-thema van Maurice Jarre roept de uitgestrektheid van de woestijn op. De score won een Oscar en definieerde epische cinema.",
       "awards_nl": [
         "Oscar voor Beste Originele Filmmuziek (1962)"
+      ],
+      "awards_it": [
+        "Oscar per la migliore colonna sonora originale (1962)"
       ],
       "isrc": "FRZ811210002",
       "uri_apple_music_by_region": {
@@ -5170,6 +5321,9 @@
       "awards_nl": [
         "Oscarnominatie voor Beste Originele Filmmuziek (1962)"
       ],
+      "awards_it": [
+        "Candidatura all'Oscar per la migliore colonna sonora originale (1962)"
+      ],
       "isrc": "US3M59904201",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1444004606",
@@ -5271,6 +5425,9 @@
       "fun_fact_nl": "Leonard Bernsteins West Side Story past Romeo en Julia aan in het New York van de jaren 1950. De film won 10 Academy Awards.",
       "awards_nl": [
         "Oscar voor Beste Film (1961)"
+      ],
+      "awards_it": [
+        "Oscar per il miglior film (1961)"
       ]
     },
     {
@@ -5315,6 +5472,9 @@
       "fun_fact_nl": "The Bare Necessities uit The Jungle Book was het laatste nummer dat Walt Disney goedkeurde voor zijn dood in 1966.",
       "awards_nl": [
         "Oscarnominatie voor Beste Originele Lied (1967)"
+      ],
+      "awards_it": [
+        "Candidatura all'Oscar per la migliore canzone originale (1967)"
       ],
       "isrc": "USWD10423008",
       "uri_apple_music_by_region": {
@@ -5449,6 +5609,9 @@
       "awards_nl": [
         "Oscarnominatie voor Beste Originele Filmmuziek (1979)"
       ],
+      "awards_it": [
+        "Candidatura all'Oscar per la migliore colonna sonora originale (1979)"
+      ],
       "isrc": "USUM70759228",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1798286213",
@@ -5550,6 +5713,10 @@
         "Oscar voor Beste Originele Lied (1981)",
         "Golden Globe voor Beste Originele Lied (1982)"
       ],
+      "awards_it": [
+        "Oscar per la migliore canzone originale (1981)",
+        "Golden Globe per la migliore canzone originale (1982)"
+      ],
       "isrc": "USWB10800109",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/273426183",
@@ -5605,6 +5772,10 @@
         "Oscar voor Beste Originele Filmmuziek (2000)",
         "Golden Globe voor Beste Originele Filmmuziek (2001)"
       ],
+      "awards_it": [
+        "Oscar per la migliore colonna sonora originale (2000)",
+        "Golden Globe per la migliore colonna sonora originale (2001)"
+      ],
       "isrc": "USUMC0110060",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1452552843",
@@ -5659,6 +5830,9 @@
       "awards_nl": [
         "Oscar voor Beste Originele Filmmuziek (1995)"
       ],
+      "awards_it": [
+        "Oscar per la migliore colonna sonora originale (1995)"
+      ],
       "isrc": "GBBBA9570201",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1440773543",
@@ -5709,6 +5883,9 @@
       "fun_fact_nl": "Seven Brides for Seven Brothers bevat uitgebreide choreografie voor het optrekken in de schuur. De musical werd gefilmd in 30 dagen.",
       "awards_nl": [
         "Oscar voor Beste Filmmuziek (1954)"
+      ],
+      "awards_it": [
+        "Oscar per la migliore musica da film (1954)"
       ],
       "isrc": "USNLR1701181",
       "uri_apple_music_by_region": {
@@ -5807,6 +5984,9 @@
       "fun_fact_nl": "What's New Pussycat van Burt Bacharach werd genomineerd voor een Oscar. De energieke uitvoering van Tom Jones maakte er een nieuwe hit van.",
       "awards_nl": [
         "Oscarnominatie voor Beste Originele Lied (1965)"
+      ],
+      "awards_it": [
+        "Candidatura all'Oscar per la migliore canzone originale (1965)"
       ],
       "isrc": "GBF076520020",
       "uri_apple_music_by_region": {
@@ -5981,6 +6161,10 @@
         "Oscar voor Beste Originele Filmmuziek (1964)",
         "Oscar voor Beste Originele Lied (1964)"
       ],
+      "awards_it": [
+        "Oscar per la migliore colonna sonora originale (1964)",
+        "Oscar per la migliore canzone originale (1964)"
+      ],
       "isrc": "USWD10423157",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1377468571",
@@ -6125,6 +6309,9 @@
       "awards_nl": [
         "Oscar voor Beste Originele Filmmuziek (1954)"
       ],
+      "awards_it": [
+        "Oscar per la migliore colonna sonora originale (1954)"
+      ],
       "isrc": "US4DG1400204",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1816013634",
@@ -6219,6 +6406,9 @@
       "awards_nl": [
         "Grammy Award voor Beste Instrumentaal (1963)"
       ],
+      "awards_it": [
+        "Grammy per la migliore interpretazione strumentale (1963)"
+      ],
       "isrc": "USBB16101029",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/306820503",
@@ -6311,6 +6501,9 @@
       "fun_fact_nl": "Oklahoma! was de eerste Rodgers en Hammerstein musical die werd verfilmd. Oh, What a Beautiful Morning opent met puur optimisme.",
       "awards_nl": [
         "Oscar voor Beste Filmmuziek (1955)"
+      ],
+      "awards_it": [
+        "Oscar per la migliore musica da film (1955)"
       ],
       "uri_apple_music": "applemusic://track/1440787711"
     },
@@ -6424,6 +6617,9 @@
       "fun_fact_nl": "John Williams' Close Encounters gebruikt een motief van vijf tonen voor buitenaardse communicatie. De sequentie werd popcultuur steno.",
       "awards_nl": [
         "Oscarnominatie voor Beste Originele Filmmuziek (1977)"
+      ],
+      "awards_it": [
+        "Candidatura all'Oscar per la migliore colonna sonora originale (1977)"
       ],
       "isrc": "USAR10201963",
       "uri_apple_music_by_region": {
@@ -6578,6 +6774,9 @@
       "fun_fact_nl": "Het thema Summer of '42 van Michel Legrand won de Oscar. De nostalgische score vangt de eerste liefde tijdens oorlogstijd.",
       "awards_nl": [
         "Oscar voor Beste Originele Filmmuziek (1971)"
+      ],
+      "awards_it": [
+        "Oscar per la migliore colonna sonora originale (1971)"
       ]
     },
     {
@@ -6708,6 +6907,9 @@
       "fun_fact_nl": "Live and Let Die van Wings was het explosieve Bond-thema van Paul McCartney. Het was het eerste rocknummer in de franchise.",
       "awards_nl": [
         "Oscarnominatie voor Beste Originele Lied (1973)"
+      ],
+      "awards_it": [
+        "Candidatura all'Oscar per la migliore canzone originale (1973)"
       ],
       "isrc": "GBCCS7300674",
       "uri_apple_music_by_region": {
@@ -6841,6 +7043,9 @@
       "fun_fact_nl": "Percy Faith's Theme from A Summer Place stond negen weken op nummer één. Het weelderige arrangement definieerde romantische cinema.",
       "awards_nl": [
         "Grammy Award voor Opname van het Jaar (1961)"
+      ],
+      "awards_it": [
+        "Grammy per il disco dell'anno (1961)"
       ]
     },
     {
@@ -6900,6 +7105,11 @@
         "Oscar voor Beste Originele Lied (1997)",
         "Golden Globe voor Beste Originele Lied (1998)",
         "Grammy Award voor Opname van het Jaar (1999)"
+      ],
+      "awards_it": [
+        "Oscar per la migliore canzone originale (1997)",
+        "Golden Globe per la migliore canzone originale (1998)",
+        "Grammy per il disco dell'anno (1999)"
       ],
       "isrc": "CAC229700123",
       "uri_apple_music_by_region": {
@@ -6998,6 +7208,9 @@
       "fun_fact_nl": "Everybody's Talkin' van Harry Nilsson won een Grammy voor Midnight Cowboy. Het weemoedige nummer beschrijft dromen van ontsnapping.",
       "awards_nl": [
         "Grammy Award voor Beste Hedendaags Lied (1970)"
+      ],
+      "awards_it": [
+        "Grammy per la migliore canzone contemporanea (1970)"
       ],
       "isrc": "USEM36900044",
       "uri_apple_music_by_region": {
@@ -7162,6 +7375,9 @@
       "fun_fact_nl": "White Christmas van Bing Crosby uit Holiday Inn werd de best verkochte single ooit. Het won de Oscar voor Beste Lied.",
       "awards_nl": [
         "Oscar voor Beste Originele Lied (1942)"
+      ],
+      "awards_it": [
+        "Oscar per la migliore canzone originale (1942)"
       ],
       "uri_apple_music": "applemusic://track/1300642506",
       "uri_youtube_music": "https://music.youtube.com/watch?v=v5ryZdpEHqM"

--- a/custom_components/beatify/playlists/one-hit-wonders.json
+++ b/custom_components/beatify/playlists/one-hit-wonders.json
@@ -1,6 +1,6 @@
 {
   "name": "One-Hit Wonders",
-  "version": "1.13",
+  "version": "1.14",
   "tags": [
     "one-hit",
     "classics",
@@ -266,6 +266,9 @@
       "uri_deezer": "deezer://track/639597902",
       "fun_fact_nl": "Won de Ivor Novello Award voor Beste Lied. Zijn broers Eden Kane en Clive Sarstedt waren ook zangers, maar Peter had alleen deze ene hit.",
       "awards_nl": [
+        "Ivor Novello Award (1969)"
+      ],
+      "awards_it": [
         "Ivor Novello Award (1969)"
       ],
       "isrc": "GBAYE6900097",
@@ -540,6 +543,9 @@
       "fun_fact_nl": "Dit verhaal over een buitenechtelijke affaire won een Grammy. Paul zei later dat hij wenste dat hij een ander signatuurnummer had om door herinnerd te worden.",
       "awards_nl": [
         "Grammy Award voor Beste Mannelijke R&B Zangprestatie (1973)"
+      ],
+      "awards_it": [
+        "Grammy per la migliore interpretazione vocale R&B maschile (1973)"
       ],
       "isrc": "USSM17200413",
       "uri_apple_music_by_region": {
@@ -1734,6 +1740,10 @@
         "Grammy Award voor Lied van het Jaar (1989)",
         "Grammy Award voor Opname van het Jaar (1989)"
       ],
+      "awards_it": [
+        "Grammy per la canzone dell'anno (1989)",
+        "Grammy per il disco dell'anno (1989)"
+      ],
       "isrc": "USEM38800361",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/6762672295",
@@ -2035,6 +2045,9 @@
       "awards_nl": [
         "Grammy Award voor Beste Rapprestatie (1990)"
       ],
+      "awards_it": [
+        "Grammy per la migliore interpretazione rap (1990)"
+      ],
       "isrc": "USA370507645",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1807406244",
@@ -2156,6 +2169,10 @@
       "awards_nl": [
         "Grammy Award voor Beste Rap Soloprestatie (1991)",
         "Grammy Award voor Beste R&B-nummer (1991)"
+      ],
+      "awards_it": [
+        "Grammy per la migliore interpretazione rap solista (1991)",
+        "Grammy per la migliore canzone R&B (1991)"
       ],
       "isrc": "USCA29000294",
       "uri_apple_music_by_region": {
@@ -3614,6 +3631,9 @@
       "fun_fact_nl": "Eerste nummer dat alleen al door downloads #1 werd in de Britse hitlijsten. Het duo CeeLo Green en Danger Mouse droeg bij elk optreden uitgebreide kostuums.",
       "awards_nl": [
         "Grammy Award voor Opname van het Jaar (2007)"
+      ],
+      "awards_it": [
+        "Grammy per il disco dell'anno (2007)"
       ],
       "isrc": "USAT20611041",
       "uri_apple_music_by_region": {

--- a/custom_components/beatify/playlists/top-songs-der-60er.json
+++ b/custom_components/beatify/playlists/top-songs-der-60er.json
@@ -1,6 +1,6 @@
 {
   "name": "60s Classics 🎸",
-  "version": "1.13",
+  "version": "1.14",
   "source": "https://open.spotify.com/playlist/6rtsNFUv2UK3j78PRVMpSd",
   "tags": [
     "1960s",
@@ -473,6 +473,9 @@
       "awards_nl": [
         "Grammy Award voor Beste R&B-nummer (1972)"
       ],
+      "awards_it": [
+        "Grammy per la migliore canzone R&B (1972)"
+      ],
       "isrc": "USSM17100268",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/391725482",
@@ -516,6 +519,9 @@
       "fun_fact_nl": "Het nummer werd geschreven door Tony Hatch in 30 minuten na een bezoek aan Times Square in New York. Het was de eerste Britse vrouwelijke solohit die #1 bereikte in de VS.",
       "awards_nl": [
         "Grammy Award voor Beste Rock-'n-Roll-opname (1965)"
+      ],
+      "awards_it": [
+        "Grammy per la migliore registrazione rock and roll (1965)"
       ],
       "isrc": "FRZ196400510",
       "uri_apple_music_by_region": {
@@ -636,6 +642,9 @@
       "fun_fact_nl": "Het werd vijf dagen voor de maanlanding van de Apollo 11 uitgebracht door de BBC. Ze vermeden het echter een tijdje daarna uit angst dat het de astronauten zou vervloeken.",
       "awards_nl": [
         "Ivor Novello Award voor Originaliteit (1970)"
+      ],
+      "awards_it": [
+        "Ivor Novello Award per l'originalita (1970)"
       ],
       "isrc": "USJT10900021",
       "uri_apple_music_by_region": {
@@ -834,6 +843,9 @@
       "fun_fact_nl": "Geschreven voor de film The Graduate (1967), de oorspronkelijke titel was 'Mrs. Roosevelt. De 'DiMaggio' regel was niet gepland-Paul Simon improviseerde het.",
       "awards_nl": [
         "Grammy Award voor Opname van het Jaar (1969)"
+      ],
+      "awards_it": [
+        "Grammy per il disco dell'anno (1969)"
       ],
       "isrc": "USSM16800379",
       "uri_apple_music_by_region": {


### PR DESCRIPTION
`utils.getLocalizedSongField(song, 'awards')` resolves `awards_<lang>` exactly the way it resolves fun facts, so Italian players were shown the English award list. This fills `awards_it` for every decorated song: **422 songs across 17 playlists, 380 distinct award strings**.

## How it was built

The same way `de`/`es`/`fr` were: each string is split into award name, category and year, then reassembled in Italian from a table of 24 award names and ~80 categories. **A string that matched no rule was reported, never guessed** — the run ended at 380 of 380 with nothing open.

Conventions were taken from the existing locales rather than invented:

- **"Academy Award" → "Oscar"**, as de/es/fr already do.
- **Nominations use the Italian form throughout** — `Candidatura all'Oscar per la migliore canzone originale (2017)`. The marker is normalised even where the source hid it inside the year bracket (`Brit Award … (Nomination, 1998)` → `Candidatura al Brit Award … (1998)`).
- **German and Austrian prizes stay untranslated** — Echo, Bambi, Goldene Henne, Goldene Stimmgabel, Amadeus, Deutscher Kleinkunstpreis. `de` and `nl` keep them verbatim; there is no established Italian name and inventing one would be worse than the original. (`fr` does translate some of them, e.g. "Prix Echo" — that is the outlier, not the pattern.)
- **Eurovision entries are normalised to one shape**, `Vincitore dell'Eurovision Song Contest <year>`, across the three spellings the source uses (`Eurovision Winner 1956`, `Eurovision Winner (1974)`, `Eurovision Song Contest Winner (1982)`).

## A finding from the measurement

The other locales are themselves incomplete. Of the 422 decorated songs:

| Locale | Coverage |
|---|---|
| nl | 422 / 422 |
| fr | 355 / 422 |
| de | 253 / 422 |
| es | 253 / 422 |
| **it** | **422 / 422** (this PR) |

Not addressed here — closing the de/es/fr gaps is its own job, and doing it silently inside an Italian PR would hide it.

## Scope

`awards_it` on 422 songs plus 17 version bumps. **Nothing else changed** — verified field by field, not by line count. `pytest tests/unit` → 1958 passed, `validate_playlists.py` → all 57 valid.
