### PR TITLE
data(playlists): close the German, Spanish and French award gaps

### DIFF
--- a/custom_components/beatify/playlists/2000s-pop-anthems.json
+++ b/custom_components/beatify/playlists/2000s-pop-anthems.json
@@ -1,6 +1,6 @@
 {
   "name": "2000s Pop Anthems",
-  "version": "1.22",
+  "version": "1.23",
   "tags": [
     "2000s",
     "pop",
@@ -92,6 +92,12 @@
       ],
       "awards_it": [
         "Grammy per la migliore collaborazione rap/cantata"
+      ],
+      "awards_de": [
+        "Grammy - Beste Rap/Gesang-Zusammenarbeit"
+      ],
+      "awards_es": [
+        "Grammy - Mejor Colaboración Rap/Cantada"
       ],
       "isrc": "USUR10200370",
       "uri_apple_music_by_region": {
@@ -187,6 +193,12 @@
       "awards_it": [
         "Grammy per la migliore interpretazione vocale pop femminile"
       ],
+      "awards_de": [
+        "Grammy - Beste weibliche Pop-Gesangsdarbietung"
+      ],
+      "awards_es": [
+        "Grammy - Mejor Interpretación Vocal Pop Femenina"
+      ],
       "isrc": "GBCTA0400231",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1687386491",
@@ -243,6 +255,14 @@
         "Grammy per la migliore interpretazione vocale R&B femminile",
         "Grammy per la migliore canzone R&B"
       ],
+      "awards_de": [
+        "Grammy - Beste weibliche R&B-Gesangsdarbietung",
+        "Grammy - Bester R&B-Song"
+      ],
+      "awards_es": [
+        "Grammy - Mejor Interpretación Vocal R&B Femenina",
+        "Grammy - Mejor Canción R&B"
+      ],
       "isrc": "USIR20500195",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1443208143",
@@ -294,6 +314,12 @@
       ],
       "awards_it": [
         "Grammy per la migliore collaborazione pop con parti vocali"
+      ],
+      "awards_de": [
+        "Grammy - Beste Pop-Zusammenarbeit mit Gesang"
+      ],
+      "awards_es": [
+        "Grammy - Mejor Colaboración Pop con Voces"
       ],
       "isrc": "USIR10110334",
       "uri_apple_music_by_region": {
@@ -429,6 +455,12 @@
       ],
       "awards_it": [
         "Grammy per la migliore collaborazione pop con parti vocali"
+      ],
+      "awards_de": [
+        "Grammy - Beste Pop-Zusammenarbeit mit Gesang"
+      ],
+      "awards_es": [
+        "Grammy - Mejor Colaboración Pop con Voces"
       ],
       "isrc": "GBAYE1400422",
       "uri_apple_music_by_region": {
@@ -566,6 +598,12 @@
       "awards_it": [
         "Grammy per la migliore interpretazione hard rock"
       ],
+      "awards_de": [
+        "Grammy - Beste Hard-Rock-Darbietung"
+      ],
+      "awards_es": [
+        "Grammy - Mejor Interpretación de Hard Rock"
+      ],
       "isrc": "USWU30200093",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1645901771",
@@ -659,6 +697,12 @@
       ],
       "awards_it": [
         "Grammy per il miglior video musicale (Short Form)"
+      ],
+      "awards_de": [
+        "Grammy - Bestes Musikvideo (Short Form)"
+      ],
+      "awards_es": [
+        "Grammy - Mejor Vídeo Musical (Short Form)"
       ],
       "isrc": "USIR10211038",
       "uri_apple_music_by_region": {
@@ -840,6 +884,14 @@
       "awards_it": [
         "Grammy per la canzone dell'anno",
         "Grammy per la migliore interpretazione pop di un duo o gruppo"
+      ],
+      "awards_de": [
+        "Grammy - Song des Jahres",
+        "Grammy - Beste Pop-Darbietung eines Duos oder einer Gruppe"
+      ],
+      "awards_es": [
+        "Grammy - Canción del Año",
+        "Grammy - Mejor Interpretación Pop de Dúo o Grupo"
       ],
       "isrc": "GBAYE1600217",
       "uri_apple_music_by_region": {
@@ -1060,6 +1112,12 @@
       "awards_it": [
         "ARIA Award per la migliore pubblicazione pop"
       ],
+      "awards_de": [
+        "ARIA Award - Beste Pop-Veröffentlichung"
+      ],
+      "awards_es": [
+        "Premio ARIA - Mejor Lanzamiento Pop"
+      ],
       "isrc": "AUEI10800039",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1707435588",
@@ -1153,6 +1211,12 @@
       ],
       "awards_it": [
         "Grammy per la migliore registrazione dance"
+      ],
+      "awards_de": [
+        "Grammy - Beste Dance-Aufnahme"
+      ],
+      "awards_es": [
+        "Grammy - Mejor Grabación Dance"
       ],
       "isrc": "USJI10301005",
       "uri_apple_music_by_region": {
@@ -1252,6 +1316,14 @@
         "Grammy per la migliore canzone rap",
         "Grammy per la migliore collaborazione rap/cantata"
       ],
+      "awards_de": [
+        "Grammy - Bester Rap-Song",
+        "Grammy - Beste Rap/Gesang-Zusammenarbeit"
+      ],
+      "awards_es": [
+        "Grammy - Mejor Canción de Rap",
+        "Grammy - Mejor Colaboración Rap/Cantada"
+      ],
       "isrc": "USJZ10900031",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1440750745",
@@ -1308,6 +1380,14 @@
         "Grammy per la migliore interpretazione vocale pop femminile",
         "Grammy per il miglior video musicale di forma breve"
       ],
+      "awards_de": [
+        "Grammy - Beste weibliche Pop-Gesangsdarbietung",
+        "Grammy - Bestes Kurzform-Musikvideo"
+      ],
+      "awards_es": [
+        "Grammy - Mejor Interpretación Vocal Pop Femenina",
+        "Grammy - Mejor Vídeo Musical de Formato Corto"
+      ],
       "isrc": "USUM70918596",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1688497897",
@@ -1359,6 +1439,12 @@
       ],
       "awards_it": [
         "Grammy per la migliore registrazione dance"
+      ],
+      "awards_de": [
+        "Grammy - Beste Dance-Aufnahme"
+      ],
+      "awards_es": [
+        "Grammy - Mejor Grabación Dance"
       ],
       "isrc": "USJI10600269",
       "uri_apple_music_by_region": {
@@ -1412,6 +1498,12 @@
       "awards_it": [
         "Grammy per la migliore interpretazione rock di un duo o gruppo con parti vocali"
       ],
+      "awards_de": [
+        "Grammy - Beste Rock-Darbietung eines Duos oder einer Gruppe mit Gesang"
+      ],
+      "awards_es": [
+        "Grammy - Mejor Interpretación Rock de Dúo o Grupo con Voz"
+      ],
       "isrc": "USRC10800300",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1441530830",
@@ -1463,6 +1555,12 @@
       ],
       "awards_it": [
         "Grammy per il disco dell'anno"
+      ],
+      "awards_de": [
+        "Grammy - Aufnahme des Jahres"
+      ],
+      "awards_es": [
+        "Grammy - Grabación del Año"
       ],
       "isrc": "GBAYE1600193",
       "uri_apple_music_by_region": {
@@ -1684,6 +1782,12 @@
       "awards_it": [
         "Grammy per la migliore interpretazione rap solista"
       ],
+      "awards_de": [
+        "Grammy - Beste Rap-Solodarbietung"
+      ],
+      "awards_es": [
+        "Grammy - Mejor Interpretación de Rap Solista"
+      ],
       "isrc": "USIR10000448",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1440866926",
@@ -1820,6 +1924,12 @@
       "awards_it": [
         "Grammy per la migliore registrazione dance"
       ],
+      "awards_de": [
+        "Grammy - Beste Dance-Aufnahme"
+      ],
+      "awards_es": [
+        "Grammy - Mejor Grabación Dance"
+      ],
       "isrc": "USUM70824409",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1710465533",
@@ -1912,6 +2022,12 @@
       ],
       "awards_it": [
         "Grammy per la migliore collaborazione rap/cantata"
+      ],
+      "awards_de": [
+        "Grammy - Beste Rap/Gesang-Zusammenarbeit"
+      ],
+      "awards_es": [
+        "Grammy - Mejor Colaboración Rap/Cantada"
       ],
       "isrc": "USUM70736771",
       "uri_apple_music_by_region": {
@@ -2048,6 +2164,12 @@
       "awards_it": [
         "Brit Award per il miglior artista rock britannico (band)"
       ],
+      "awards_de": [
+        "BRIT Award - Bester britischer Rock-Act (band)"
+      ],
+      "awards_es": [
+        "Premio BRIT - Mejor Artista de Rock Británico (band)"
+      ],
       "isrc": "GBCEL0300192",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/315844084",
@@ -2099,6 +2221,12 @@
       ],
       "awards_it": [
         "Candidatura al Grammy per la migliore interpretazione rap di un duo o gruppo"
+      ],
+      "awards_de": [
+        "Grammy-Nominierung - Beste Rap-Darbietung eines Duos oder einer Gruppe"
+      ],
+      "awards_es": [
+        "Nominación al Grammy - Mejor Interpretación de Rap de Dúo o Grupo"
       ],
       "isrc": "USIR10401121",
       "uri_apple_music_by_region": {
@@ -2239,6 +2367,14 @@
         "Grammy per la migliore interpretazione vocale R&B femminile",
         "Grammy per la migliore canzone R&B"
       ],
+      "awards_de": [
+        "Grammy - Beste weibliche R&B-Gesangsdarbietung",
+        "Grammy - Bester R&B-Song"
+      ],
+      "awards_es": [
+        "Grammy - Mejor Interpretación Vocal R&B Femenina",
+        "Grammy - Mejor Canción R&B"
+      ],
       "isrc": "USJAY0300452",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1721921218",
@@ -2332,6 +2468,12 @@
       ],
       "awards_it": [
         "Grammy per la migliore interpretazione urban/alternative"
+      ],
+      "awards_de": [
+        "Grammy - Beste Urban/Alternative-Darbietung"
+      ],
+      "awards_es": [
+        "Grammy - Mejor Interpretación Urbana/Alternativa"
       ]
     },
     {
@@ -2541,6 +2683,12 @@
       "awards_it": [
         "Grammy per la migliore interpretazione rap di un duo o gruppo"
       ],
+      "awards_de": [
+        "Grammy - Beste Rap-Darbietung eines Duos oder einer Gruppe"
+      ],
+      "awards_es": [
+        "Grammy - Mejor Interpretación de Rap de Dúo o Grupo"
+      ],
       "isrc": "USLF20000357",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1741741469",
@@ -2719,6 +2867,12 @@
       "awards_it": [
         "Grammy per la migliore interpretazione vocale R&B femminile"
       ],
+      "awards_de": [
+        "Grammy - Beste weibliche R&B-Gesangsdarbietung"
+      ],
+      "awards_es": [
+        "Grammy - Mejor Interpretación Vocal R&B Femenina"
+      ],
       "isrc": "USMC10111369",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1691778424",
@@ -2812,6 +2966,12 @@
       ],
       "awards_it": [
         "Grammy per la migliore interpretazione rap solista"
+      ],
+      "awards_de": [
+        "Grammy - Beste Rap-Solodarbietung"
+      ],
+      "awards_es": [
+        "Grammy - Mejor Interpretación de Rap Solista"
       ],
       "isrc": "USUM70741299",
       "uri_apple_music_by_region": {
@@ -3287,6 +3447,14 @@
         "Grammy per il disco dell'anno",
         "Grammy per la migliore interpretazione rock di un duo o gruppo"
       ],
+      "awards_de": [
+        "Grammy - Aufnahme des Jahres",
+        "Grammy - Beste Rock-Darbietung eines Duos oder einer Gruppe"
+      ],
+      "awards_es": [
+        "Grammy - Grabación del Año",
+        "Grammy - Mejor Interpretación Rock de Dúo o Grupo"
+      ],
       "isrc": "USRC10800301",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1351343570",
@@ -3638,6 +3806,16 @@
         "Oscar per la migliore canzone originale",
         "Grammy per la migliore canzone rap",
         "Grammy per la migliore interpretazione rap solista"
+      ],
+      "awards_de": [
+        "Oscar - Bester Filmsong",
+        "Grammy - Bester Rap-Song",
+        "Grammy - Beste Rap-Solodarbietung"
+      ],
+      "awards_es": [
+        "Óscar - Mejor Canción Original",
+        "Grammy - Mejor Canción de Rap",
+        "Grammy - Mejor Interpretación de Rap Solista"
       ],
       "isrc": "USIR10211559",
       "uri_apple_music_by_region": {
@@ -4111,6 +4289,14 @@
       "awards_it": [
         "Grammy per la migliore canzone rap",
         "Grammy per la migliore collaborazione rap/cantata"
+      ],
+      "awards_de": [
+        "Grammy - Bester Rap-Song",
+        "Grammy - Beste Rap/Gesang-Zusammenarbeit"
+      ],
+      "awards_es": [
+        "Grammy - Mejor Canción de Rap",
+        "Grammy - Mejor Colaboración Rap/Cantada"
       ],
       "isrc": "USJZ10900010",
       "uri_apple_music_by_region": {

--- a/custom_components/beatify/playlists/80er-hits.json
+++ b/custom_components/beatify/playlists/80er-hits.json
@@ -1,6 +1,6 @@
 {
   "name": "80s Hits",
-  "version": "2.18",
+  "version": "2.19",
   "tags": [
     "1980s",
     "pop",
@@ -944,6 +944,14 @@
         "Grammy per il disco dell'anno (1984)",
         "Grammy per la migliore interpretazione vocale rock maschile (1984)"
       ],
+      "awards_de": [
+        "Grammy - Aufnahme des Jahres (1984)",
+        "Grammy - Beste männliche Rock-Gesangsdarbietung (1984)"
+      ],
+      "awards_es": [
+        "Grammy - Grabación del Año (1984)",
+        "Grammy - Mejor Interpretación Vocal Rock Masculina (1984)"
+      ],
       "isrc": "USSM18200197",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/310505615",
@@ -993,6 +1001,12 @@
       ],
       "awards_it": [
         "Grammy per la migliore interpretazione vocale R&B maschile (1984)"
+      ],
+      "awards_de": [
+        "Grammy - Beste männliche R&B-Gesangsdarbietung (1984)"
+      ],
+      "awards_es": [
+        "Grammy - Mejor Interpretación Vocal R&B Masculina (1984)"
       ],
       "isrc": "USSM19902991",
       "uri_apple_music_by_region": {
@@ -1275,6 +1289,12 @@
       "awards_it": [
         "Grammy per la migliore interpretazione rock di un duo o gruppo (1983)"
       ],
+      "awards_de": [
+        "Grammy - Beste Rock-Darbietung eines Duos oder einer Gruppe (1983)"
+      ],
+      "awards_es": [
+        "Grammy - Mejor Interpretación Rock de Dúo o Grupo (1983)"
+      ],
       "isrc": "USVR19300001",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1635636757",
@@ -1476,6 +1496,12 @@
       ],
       "awards_it": [
         "Grammy per il disco dell'anno (1983)"
+      ],
+      "awards_de": [
+        "Grammy - Aufnahme des Jahres (1983)"
+      ],
+      "awards_es": [
+        "Grammy - Grabación del Año (1983)"
       ],
       "isrc": "USSM18200245",
       "uri_apple_music_by_region": {
@@ -2089,6 +2115,14 @@
       "awards_it": [
         "Oscar per la migliore canzone originale (1984)",
         "Golden Globe per la migliore canzone originale (1984)"
+      ],
+      "awards_de": [
+        "Oscar - Bester Filmsong (1984)",
+        "Golden Globe - Bester Filmsong (1984)"
+      ],
+      "awards_es": [
+        "Óscar - Mejor Canción Original (1984)",
+        "Globo de Oro - Mejor Canción Original (1984)"
       ],
       "isrc": "USA560661522",
       "uri_apple_music_by_region": {
@@ -3571,6 +3605,12 @@
       "awards_it": [
         "Grammy per la migliore interpretazione vocale pop maschile (1985)"
       ],
+      "awards_de": [
+        "Grammy - Beste männliche Pop-Gesangsdarbietung (1985)"
+      ],
+      "awards_es": [
+        "Grammy - Mejor Interpretación Vocal Pop Masculina (1985)"
+      ],
       "isrc": "USRH11603951",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1148642452",
@@ -3802,6 +3842,14 @@
       "awards_it": [
         "Oscar per la migliore canzone originale (1985)",
         "Golden Globe per la migliore canzone originale (1985)"
+      ],
+      "awards_de": [
+        "Oscar - Bester Filmsong (1985)",
+        "Golden Globe - Bester Filmsong (1985)"
+      ],
+      "awards_es": [
+        "Óscar - Mejor Canción Original (1985)",
+        "Globo de Oro - Mejor Canción Original (1985)"
       ],
       "isrc": "USUMG9900476",
       "uri_apple_music_by_region": {
@@ -4068,6 +4116,16 @@
         "Grammy per il disco dell'anno (1985)",
         "Grammy per la canzone dell'anno (1985)",
         "Grammy per la migliore interpretazione vocale pop femminile (1985)"
+      ],
+      "awards_de": [
+        "Grammy - Aufnahme des Jahres (1985)",
+        "Grammy - Song des Jahres (1985)",
+        "Grammy - Beste weibliche Pop-Gesangsdarbietung (1985)"
+      ],
+      "awards_es": [
+        "Grammy - Grabación del Año (1985)",
+        "Grammy - Canción del Año (1985)",
+        "Grammy - Mejor Interpretación Vocal Pop Femenina (1985)"
       ],
       "isrc": "USCA28400002",
       "uri_apple_music_by_region": {
@@ -5667,6 +5725,12 @@
       "awards_it": [
         "Grammy per l'album dell'anno (1987)"
       ],
+      "awards_de": [
+        "Grammy - Album des Jahres (1987)"
+      ],
+      "awards_es": [
+        "Grammy - Álbum del Año (1987)"
+      ],
       "isrc": "USSM11002255",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1739846276",
@@ -5805,6 +5869,12 @@
       ],
       "awards_it": [
         "Grammy per il disco dell'anno (1987)"
+      ],
+      "awards_de": [
+        "Grammy - Aufnahme des Jahres (1987)"
+      ],
+      "awards_es": [
+        "Grammy - Grabación del Año (1987)"
       ],
       "isrc": "GBAAN0201051",
       "uri_apple_music_by_region": {
@@ -6469,6 +6539,12 @@
       "awards_it": [
         "Grammy per la migliore interpretazione vocale pop femminile (1988)"
       ],
+      "awards_de": [
+        "Grammy - Beste weibliche Pop-Gesangsdarbietung (1988)"
+      ],
+      "awards_es": [
+        "Grammy - Mejor Interpretación Vocal Pop Femenina (1988)"
+      ],
       "isrc": "USAR18700121",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1627099927",
@@ -6710,6 +6786,12 @@
       ],
       "awards_it": [
         "Golden Globe per la migliore canzone originale (1989)"
+      ],
+      "awards_de": [
+        "Golden Globe - Bester Filmsong (1989)"
+      ],
+      "awards_es": [
+        "Globo de Oro - Mejor Canción Original (1989)"
       ],
       "isrc": "USWI19600240",
       "uri_apple_music_by_region": {
@@ -7377,6 +7459,12 @@
       ],
       "awards_it": [
         "Grammy per il disco dell'anno (1991)"
+      ],
+      "awards_de": [
+        "Grammy - Aufnahme des Jahres (1991)"
+      ],
+      "awards_es": [
+        "Grammy - Grabación del Año (1991)"
       ],
       "isrc": "USRH11602405",
       "uri_apple_music_by_region": {

--- a/custom_components/beatify/playlists/community/100-greatest-rock-songs.json
+++ b/custom_components/beatify/playlists/community/100-greatest-rock-songs.json
@@ -1,6 +1,6 @@
 {
   "name": "100 Greatest Rock Songs",
-  "version": "0.12",
+  "version": "0.13",
   "tags": [
     "rock",
     "classic-rock",
@@ -253,8 +253,6 @@
       "awards": [
         "Grammy nomination"
       ],
-      "awards_de": [],
-      "awards_es": [],
       "fun_fact": "Eddie Van Halen wrote Jump's synth riff at home on a four-track recorder. The rest of the band initially resisted releasing a keyboard-led single, worried it strayed too far from their guitar-driven identity.",
       "fun_fact_de": "Eddie Van Halen schrieb das Synthesizer-Riff von Jump zu Hause an einem Vierspur-Rekorder. Der Rest der Band sträubte sich zunächst gegen eine von Keyboards geführte Single, aus Angst, sich zu weit von ihrer gitarrenlastigen Identität zu entfernen.",
       "fun_fact_es": "Eddie Van Halen escribió el riff de sintetizador de Jump en casa con una grabadora de cuatro pistas. El resto de la banda se resistió al principio a lanzar un sencillo liderado por teclados, temiendo alejarse demasiado de su identidad guitarrera.",
@@ -269,6 +267,15 @@
       ],
       "awards_it": [
         "Candidatura al Grammy"
+      ],
+      "awards_de": [
+        "Grammy-Nominierung"
+      ],
+      "awards_es": [
+        "Nominación al Grammy"
+      ],
+      "awards_fr": [
+        "Nomination aux Grammy"
       ],
       "isrc": "USWB11403680",
       "uri_apple_music_by_region": {
@@ -1895,8 +1902,6 @@
       "awards": [
         "Grammy Hall of Fame"
       ],
-      "awards_de": [],
-      "awards_es": [],
       "fun_fact": "Smoke on the Water documents a real event: a fire that broke out during a Frank Zappa concert at the Montreux Casino in Switzerland, started by someone firing a flare gun into the ceiling.",
       "fun_fact_de": "Smoke on the Water beschreibt ein reales Ereignis: einen Brand während eines Frank-Zappa-Konzerts im Casino von Montreux in der Schweiz, ausgelöst durch eine ins Dach abgefeuerte Leuchtpistole.",
       "fun_fact_es": "Smoke on the Water relata un hecho real: un incendio que se produjo durante un concierto de Frank Zappa en el Casino de Montreux, en Suiza, provocado por alguien que disparó una bengala hacia el techo.",
@@ -1910,6 +1915,15 @@
         "Grammy Hall of Fame"
       ],
       "awards_it": [
+        "Grammy Hall of Fame"
+      ],
+      "awards_de": [
+        "Grammy - Hall of Fame"
+      ],
+      "awards_es": [
+        "Grammy - Salón de la Fama"
+      ],
+      "awards_fr": [
         "Grammy Hall of Fame"
       ],
       "isrc": "GBDXG1200006",
@@ -3367,6 +3381,15 @@
       "awards_it": [
         "Candidatura al Grammy"
       ],
+      "awards_de": [
+        "Grammy-Nominierung"
+      ],
+      "awards_es": [
+        "Nominación al Grammy"
+      ],
+      "awards_fr": [
+        "Nomination aux Grammy"
+      ],
       "isrc": "GBAJE8000033",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1442217683",
@@ -4085,6 +4108,15 @@
         "Grammy Hall of Fame"
       ],
       "awards_it": [
+        "Grammy Hall of Fame"
+      ],
+      "awards_de": [
+        "Grammy - Hall of Fame"
+      ],
+      "awards_es": [
+        "Grammy - Salón de la Fama"
+      ],
+      "awards_fr": [
         "Grammy Hall of Fame"
       ],
       "isrc": "AUAP08000046",
@@ -4828,6 +4860,15 @@
       ],
       "awards_it": [
         "Candidatura al Grammy"
+      ],
+      "awards_de": [
+        "Grammy-Nominierung"
+      ],
+      "awards_es": [
+        "Nominación al Grammy"
+      ],
+      "awards_fr": [
+        "Nomination aux Grammy"
       ],
       "isrc": "USSM19200317",
       "uri_apple_music_by_region": {

--- a/custom_components/beatify/playlists/community/90s-2000s-hiphop-bangers.json
+++ b/custom_components/beatify/playlists/community/90s-2000s-hiphop-bangers.json
@@ -1,6 +1,6 @@
 {
   "name": "90s & 2000s Hip Hop Bangers",
-  "version": "1.2",
+  "version": "1.3",
   "tags": [
     "90s",
     "2000s",
@@ -299,6 +299,12 @@
       "awards_it": [
         "Candidatura al Grammy per la migliore interpretazione rap solista"
       ],
+      "awards_de": [
+        "Grammy-Nominierung - Beste Rap-Solodarbietung"
+      ],
+      "awards_es": [
+        "Nominación al Grammy - Mejor Interpretación de Rap Solista"
+      ],
       "isrc": "USBB40580817",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1801961851",
@@ -350,6 +356,12 @@
       ],
       "awards_it": [
         "Grammy per la migliore interpretazione rap solista"
+      ],
+      "awards_de": [
+        "Grammy - Beste Rap-Solodarbietung"
+      ],
+      "awards_es": [
+        "Grammy - Mejor Interpretación de Rap Solista"
       ],
       "isrc": "USTB10400128",
       "uri_apple_music_by_region": {
@@ -569,6 +581,12 @@
       "awards_it": [
         "Grammy per la migliore interpretazione vocale R&B femminile"
       ],
+      "awards_de": [
+        "Grammy - Beste weibliche R&B-Gesangsdarbietung"
+      ],
+      "awards_es": [
+        "Grammy - Mejor Interpretación Vocal R&B Femenina"
+      ],
       "isrc": "USSM19802337",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1276760748",
@@ -661,6 +679,12 @@
       ],
       "awards_it": [
         "Grammy per il miglior album rap (for Vol. 2... Hard Knock Life)"
+      ],
+      "awards_de": [
+        "Grammy - Bestes Rap-Album (for Vol. 2... Hard Knock Life)"
+      ],
+      "awards_es": [
+        "Grammy - Mejor Álbum de Rap (for Vol. 2... Hard Knock Life)"
       ],
       "isrc": "USRL19800899",
       "uri_apple_music_by_region": {
@@ -756,6 +780,12 @@
       "awards_it": [
         "Candidatura al Grammy per la migliore interpretazione rap solista"
       ],
+      "awards_de": [
+        "Grammy-Nominierung - Beste Rap-Solodarbietung"
+      ],
+      "awards_es": [
+        "Nominación al Grammy - Mejor Interpretación de Rap Solista"
+      ],
       "isrc": "USDJ20010705",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1700354890",
@@ -816,6 +846,16 @@
         "MTV VMA per il miglior video",
         "MTV VMA per il miglior video maschile"
       ],
+      "awards_de": [
+        "Grammy - Beste Rap-Solodarbietung",
+        "MTV VMA - Bestes Video",
+        "MTV VMA - Bestes männliches Video"
+      ],
+      "awards_es": [
+        "Grammy - Mejor Interpretación de Rap Solista",
+        "MTV VMA - Mejor Vídeo",
+        "MTV VMA - Mejor Vídeo Masculino"
+      ],
       "isrc": "USIR10000448",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1440866926",
@@ -868,6 +908,12 @@
       "awards_it": [
         "Grammy per la migliore interpretazione rap di un duo o gruppo"
       ],
+      "awards_de": [
+        "Grammy - Beste Rap-Darbietung eines Duos oder einer Gruppe"
+      ],
+      "awards_es": [
+        "Grammy - Mejor Interpretación de Rap de Dúo o Grupo"
+      ],
       "isrc": "USLF20000357",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1741741469",
@@ -919,6 +965,12 @@
       ],
       "awards_it": [
         "Grammy per la migliore interpretazione rap solista"
+      ],
+      "awards_de": [
+        "Grammy - Beste Rap-Solodarbietung"
+      ],
+      "awards_es": [
+        "Grammy - Mejor Interpretación de Rap Solista"
       ],
       "isrc": "USEW20100037",
       "uri_apple_music_by_region": {
@@ -1055,6 +1107,12 @@
       "awards_it": [
         "Grammy per il miglior video musicale"
       ],
+      "awards_de": [
+        "Grammy - Bestes Musikvideo"
+      ],
+      "awards_es": [
+        "Grammy - Mejor Vídeo Musical"
+      ],
       "isrc": "USIR10211038",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1625004633",
@@ -1115,6 +1173,16 @@
         "Grammy per la migliore canzone rap",
         "Grammy per la migliore interpretazione rap solista"
       ],
+      "awards_de": [
+        "Oscar - Bester Filmsong",
+        "Grammy - Bester Rap-Song",
+        "Grammy - Beste Rap-Solodarbietung"
+      ],
+      "awards_es": [
+        "Óscar - Mejor Canción Original",
+        "Grammy - Mejor Canción de Rap",
+        "Grammy - Mejor Interpretación de Rap Solista"
+      ],
       "isrc": "USIR10211559",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1444221569",
@@ -1167,6 +1235,12 @@
       "awards_it": [
         "Grammy per la migliore interpretazione rap solista maschile"
       ],
+      "awards_de": [
+        "Grammy - Beste männliche Rap-Solodarbietung"
+      ],
+      "awards_es": [
+        "Grammy - Mejor Interpretación de Rap Solista Masculina"
+      ],
       "isrc": "USUR10200252",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1692116505",
@@ -1218,6 +1292,12 @@
       ],
       "awards_it": [
         "Grammy per la migliore interpretazione rap solista femminile"
+      ],
+      "awards_de": [
+        "Grammy - Beste weibliche Rap-Solodarbietung"
+      ],
+      "awards_es": [
+        "Grammy - Mejor Interpretación de Rap Solista Femenina"
       ]
     },
     {
@@ -1264,6 +1344,14 @@
       "awards_it": [
         "MTV VMA per il miglior video rap",
         "MTV VMA per il miglior artista esordiente"
+      ],
+      "awards_de": [
+        "MTV VMA - Bestes Rap-Video",
+        "MTV VMA - Bester neuer Künstler"
+      ],
+      "awards_es": [
+        "MTV VMA - Mejor Vídeo de Rap",
+        "MTV VMA - Mejor Artista Nuevo"
       ],
       "isrc": "USIR10300033",
       "uri_apple_music_by_region": {
@@ -1359,6 +1447,12 @@
       "awards_it": [
         "Grammy per la migliore interpretazione urban/alternative"
       ],
+      "awards_de": [
+        "Grammy - Beste Urban/Alternative-Darbietung"
+      ],
+      "awards_es": [
+        "Grammy - Mejor Interpretación Urbana/Alternativa"
+      ],
       "isrc": "USAR10301095",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/202883791",
@@ -1410,6 +1504,12 @@
       ],
       "awards_it": [
         "Grammy per la migliore interpretazione rap solista"
+      ],
+      "awards_de": [
+        "Grammy - Beste Rap-Solodarbietung"
+      ],
+      "awards_es": [
+        "Grammy - Mejor Interpretación de Rap Solista"
       ],
       "isrc": "USDJ20301460",
       "uri_apple_music_by_region": {
@@ -1493,6 +1593,12 @@
       ],
       "awards_it": [
         "Candidatura al Grammy per la migliore canzone rap"
+      ],
+      "awards_de": [
+        "Grammy-Nominierung - Bester Rap-Song"
+      ],
+      "awards_es": [
+        "Nominación al Grammy - Mejor Canción de Rap"
       ],
       "isrc": "USDJ20300765",
       "uri_apple_music_by_region": {
@@ -1630,6 +1736,12 @@
       "awards_it": [
         "Grammy per la migliore interpretazione rap solista"
       ],
+      "awards_de": [
+        "Grammy - Beste Rap-Solodarbietung"
+      ],
+      "awards_es": [
+        "Grammy - Mejor Interpretación de Rap Solista"
+      ],
       "isrc": "USUM70500143",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1443571076",
@@ -1682,6 +1794,12 @@
       "awards_it": [
         "Grammy per la migliore interpretazione rap solista"
       ],
+      "awards_de": [
+        "Grammy - Beste Rap-Solodarbietung"
+      ],
+      "awards_es": [
+        "Grammy - Mejor Interpretación de Rap Solista"
+      ],
       "isrc": "USUM70741299",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1443830216",
@@ -1733,6 +1851,12 @@
       "awards_it": [
         "Grammy per la migliore interpretazione rap solista"
       ],
+      "awards_de": [
+        "Grammy - Beste Rap-Solodarbietung"
+      ],
+      "awards_es": [
+        "Grammy - Mejor Interpretación de Rap Solista"
+      ],
       "isrc": "USCM50800553",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1440737322",
@@ -1783,6 +1907,12 @@
       ],
       "awards_it": [
         "Grammy per la migliore canzone rap"
+      ],
+      "awards_de": [
+        "Grammy - Bester Rap-Song"
+      ],
+      "awards_es": [
+        "Grammy - Mejor Canción de Rap"
       ],
       "isrc": "USCM50800380",
       "uri_apple_music_by_region": {

--- a/custom_components/beatify/playlists/community/british-invasion-britpop.json
+++ b/custom_components/beatify/playlists/community/british-invasion-britpop.json
@@ -1,6 +1,6 @@
 {
   "name": "British Invasion & Britpop 🇬🇧",
-  "version": "1.12",
+  "version": "1.13",
   "tags": [
     "1960s",
     "1990s",
@@ -164,6 +164,9 @@
       "awards_it": [
         "Brit Award per il miglior singolo britannico (1995)"
       ],
+      "awards_fr": [
+        "BRIT Award - Meilleur single britannique (1995)"
+      ],
       "isrc": "GBAYE1200960",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/699606039",
@@ -215,6 +218,9 @@
         "Grammy Hall of Fame (1998)"
       ],
       "awards_it": [
+        "Grammy Hall of Fame (1998)"
+      ],
+      "awards_fr": [
         "Grammy Hall of Fame (1998)"
       ],
       "isrc": "USA176510160",
@@ -691,6 +697,9 @@
       ],
       "awards_it": [
         "Ivor Novello Award per l'opera piu eseguita"
+      ],
+      "awards_fr": [
+        "Ivor Novello Award - Œuvre la plus jouée"
       ],
       "uri_apple_music": "applemusic://track/1469579797"
     },
@@ -1487,6 +1496,9 @@
       "awards_it": [
         "Grammy per la migliore registrazione rock and roll (1965)"
       ],
+      "awards_fr": [
+        "Grammy Award - Meilleur enregistrement rock and roll (1965)"
+      ],
       "isrc": "FRZ196400510",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1676474357",
@@ -1941,6 +1953,9 @@
       ],
       "awards_it": [
         "Candidatura al Brit Award per il miglior singolo britannico (1998)"
+      ],
+      "awards_fr": [
+        "Nomination au BRIT Award - Meilleur single britannique (1998)"
       ],
       "isrc": "GBUM71601819",
       "uri_apple_music_by_region": {

--- a/custom_components/beatify/playlists/community/fiesta-latina-90s.json
+++ b/custom_components/beatify/playlists/community/fiesta-latina-90s.json
@@ -1,6 +1,6 @@
 {
   "name": "Fiesta Latina 90s 🇲🇽",
-  "version": "1.9",
+  "version": "1.10",
   "tags": [
     "1990s",
     "latin",
@@ -175,6 +175,12 @@
       ],
       "awards_it": [
         "Candidatura al Grammy per il disco dell'anno"
+      ],
+      "awards_de": [
+        "Grammy-Nominierung - Aufnahme des Jahres"
+      ],
+      "awards_es": [
+        "Nominación al Grammy - Grabación del Año"
       ]
     },
     {
@@ -377,6 +383,12 @@
       ],
       "awards_it": [
         "Grammy per il miglior album latino tropicale (Bachata Rosa)"
+      ],
+      "awards_de": [
+        "Grammy - Bestes tropisches Latin-Album (Bachata Rosa)"
+      ],
+      "awards_es": [
+        "Grammy - Mejor Álbum Tropical Latino (Bachata Rosa)"
       ],
       "isrc": "USKP10400046",
       "uri_apple_music_by_region": {
@@ -593,6 +605,12 @@
       ],
       "awards_it": [
         "Grammy per la migliore interpretazione latina tropicale"
+      ],
+      "awards_de": [
+        "Grammy - Beste tropische Latin-Darbietung"
+      ],
+      "awards_es": [
+        "Grammy - Mejor Interpretación Tropical Latina"
       ],
       "isrc": "USSD19700576",
       "uri_apple_music_by_region": {
@@ -1194,6 +1212,12 @@
       ],
       "awards_it": [
         "Candidatura al Grammy per il miglior album merengue"
+      ],
+      "awards_de": [
+        "Grammy-Nominierung - Bestes Merengue-Album"
+      ],
+      "awards_es": [
+        "Nominación al Grammy - Mejor Álbum de Merengue"
       ],
       "isrc": "USWL19400004",
       "uri_apple_music_by_region": {
@@ -1927,6 +1951,14 @@
       "awards_it": [
         "Latin Grammy per il disco dell'anno",
         "Latin Grammy per l'album dell'anno"
+      ],
+      "awards_de": [
+        "Latin Grammy - Aufnahme des Jahres",
+        "Latin Grammy - Album des Jahres"
+      ],
+      "awards_es": [
+        "Latin Grammy - Grabación del Año",
+        "Latin Grammy - Álbum del Año"
       ],
       "isrc": "ES5150306001",
       "uri_apple_music_by_region": {

--- a/custom_components/beatify/playlists/community/gen-z-anthems.json
+++ b/custom_components/beatify/playlists/community/gen-z-anthems.json
@@ -1,6 +1,6 @@
 {
   "name": "Gen Z Anthems",
-  "version": "1.4",
+  "version": "1.5",
   "tags": [
     "2010s",
     "2020s",
@@ -99,6 +99,12 @@
       "awards_it": [
         "Billboard Music Award per la migliore canzone della Hot 100"
       ],
+      "awards_de": [
+        "Billboard Music Award - Top-Song der Hot 100"
+      ],
+      "awards_es": [
+        "Billboard Music Award - Mejor Canción del Hot 100"
+      ],
       "isrc": "USUM71100061",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1851540442",
@@ -155,6 +161,14 @@
       "awards_it": [
         "Grammy per il disco dell'anno",
         "Grammy per la migliore interpretazione pop di un duo o gruppo"
+      ],
+      "awards_de": [
+        "Grammy - Aufnahme des Jahres",
+        "Grammy - Beste Pop-Darbietung eines Duos oder einer Gruppe"
+      ],
+      "awards_es": [
+        "Grammy - Grabación del Año",
+        "Grammy - Mejor Interpretación Pop de Dúo o Grupo"
       ],
       "isrc": "AUZS21100040",
       "uri_apple_music_by_region": {
@@ -255,6 +269,14 @@
       "awards_it": [
         "Grammy per la canzone dell'anno",
         "Grammy per la migliore interpretazione pop solista"
+      ],
+      "awards_de": [
+        "Grammy - Song des Jahres",
+        "Grammy - Beste Pop-Solodarbietung"
+      ],
+      "awards_es": [
+        "Grammy - Canción del Año",
+        "Grammy - Mejor Interpretación Pop Solista"
       ]
     },
     {
@@ -302,6 +324,14 @@
       "awards_it": [
         "Grammy per il miglior video musicale",
         "Grammy per la migliore interpretazione pop solista"
+      ],
+      "awards_de": [
+        "Grammy - Bestes Musikvideo",
+        "Grammy - Beste Pop-Solodarbietung"
+      ],
+      "awards_es": [
+        "Grammy - Mejor Vídeo Musical",
+        "Grammy - Mejor Interpretación Pop Solista"
       ],
       "isrc": "USQ4E1300686",
       "uri_apple_music_by_region": {
@@ -405,6 +435,16 @@
         "Grammy per il disco dell'anno",
         "Grammy per la canzone dell'anno",
         "Grammy per la migliore interpretazione pop solista"
+      ],
+      "awards_de": [
+        "Grammy - Aufnahme des Jahres",
+        "Grammy - Song des Jahres",
+        "Grammy - Beste Pop-Solodarbietung"
+      ],
+      "awards_es": [
+        "Grammy - Grabación del Año",
+        "Grammy - Canción del Año",
+        "Grammy - Mejor Interpretación Pop Solista"
       ]
     },
     {
@@ -495,6 +535,14 @@
       "awards_it": [
         "Grammy per la migliore interpretazione pop solista",
         "Billboard Music Award per la migliore canzone della Hot 100"
+      ],
+      "awards_de": [
+        "Grammy - Beste Pop-Solodarbietung",
+        "Billboard Music Award - Top-Song der Hot 100"
+      ],
+      "awards_es": [
+        "Grammy - Mejor Interpretación Pop Solista",
+        "Billboard Music Award - Mejor Canción del Hot 100"
       ]
     },
     {
@@ -546,6 +594,16 @@
         "Latin Grammy per il disco dell'anno",
         "Latin Grammy per la canzone dell'anno",
         "Billboard Music Award per la migliore canzone della Hot 100"
+      ],
+      "awards_de": [
+        "Latin Grammy - Aufnahme des Jahres",
+        "Latin Grammy - Song des Jahres",
+        "Billboard Music Award - Top-Song der Hot 100"
+      ],
+      "awards_es": [
+        "Latin Grammy - Grabación del Año",
+        "Latin Grammy - Canción del Año",
+        "Billboard Music Award - Mejor Canción del Hot 100"
       ],
       "isrc": "USUM71607007",
       "uri_apple_music_by_region": {
@@ -603,6 +661,14 @@
       "awards_it": [
         "Grammy per la migliore canzone rap",
         "Billboard Music Award per la migliore canzone della Hot 100"
+      ],
+      "awards_de": [
+        "Grammy - Bester Rap-Song",
+        "Billboard Music Award - Top-Song der Hot 100"
+      ],
+      "awards_es": [
+        "Grammy - Mejor Canción de Rap",
+        "Billboard Music Award - Mejor Canción del Hot 100"
       ]
     },
     {
@@ -697,6 +763,16 @@
         "Grammy per il disco dell'anno",
         "Grammy per la canzone dell'anno",
         "Grammy per la migliore interpretazione pop solista"
+      ],
+      "awards_de": [
+        "Grammy - Aufnahme des Jahres",
+        "Grammy - Song des Jahres",
+        "Grammy - Beste Pop-Solodarbietung"
+      ],
+      "awards_es": [
+        "Grammy - Grabación del Año",
+        "Grammy - Canción del Año",
+        "Grammy - Mejor Interpretación Pop Solista"
       ]
     },
     {
@@ -744,6 +820,14 @@
       "awards_it": [
         "Grammy per il miglior video musicale",
         "Candidatura al CMA Award per l'evento musicale dell'anno"
+      ],
+      "awards_de": [
+        "Grammy - Bestes Musikvideo",
+        "CMA-Award-Nominierung - Musikalisches Ereignis des Jahres"
+      ],
+      "awards_es": [
+        "Grammy - Mejor Vídeo Musical",
+        "Nominación al Premio CMA - Evento Musical del Año"
       ],
       "isrc": "USSM11902498",
       "uri_apple_music_by_region": {
@@ -797,6 +881,12 @@
       ],
       "awards_it": [
         "Brit Award per la canzone dell'anno"
+      ],
+      "awards_de": [
+        "BRIT Award - Song des Jahres"
+      ],
+      "awards_es": [
+        "Premio BRIT - Canción del Año"
       ],
       "isrc": "DEUM71807062",
       "uri_apple_music_by_region": {
@@ -858,6 +948,16 @@
         "Billboard Music Award per la migliore canzone della Hot 100",
         "Juno Award per il singolo dell'anno",
         "American Music Award per la canzone pop/rock preferita"
+      ],
+      "awards_de": [
+        "Billboard Music Award - Top-Song der Hot 100",
+        "Juno Award - Single des Jahres",
+        "American Music Award - Lieblingssong Pop/Rock"
+      ],
+      "awards_es": [
+        "Billboard Music Award - Mejor Canción del Hot 100",
+        "Premio Juno - Sencillo del Año",
+        "American Music Award - Canción Favorita Pop/Rock"
       ],
       "isrc": "USUG11904206",
       "uri_apple_music_by_region": {
@@ -944,6 +1044,12 @@
       ],
       "awards_it": [
         "Grammy per la migliore interpretazione pop solista"
+      ],
+      "awards_de": [
+        "Grammy - Beste Pop-Solodarbietung"
+      ],
+      "awards_es": [
+        "Grammy - Mejor Interpretación Pop Solista"
       ],
       "isrc": "USSM11912587",
       "uri_apple_music_by_region": {
@@ -1041,6 +1147,12 @@
       "awards_it": [
         "Grammy per la migliore interpretazione pop di un duo o gruppo"
       ],
+      "awards_de": [
+        "Grammy - Beste Pop-Darbietung eines Duos oder einer Gruppe"
+      ],
+      "awards_es": [
+        "Grammy - Mejor Interpretación Pop de Dúo o Grupo"
+      ],
       "isrc": "USRC12100760",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1577637152",
@@ -1137,6 +1249,12 @@
       "awards_it": [
         "Grammy per il disco dell'anno"
       ],
+      "awards_de": [
+        "Grammy - Aufnahme des Jahres"
+      ],
+      "awards_es": [
+        "Grammy - Grabación del Año"
+      ],
       "isrc": "USAT22202139",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1810531325",
@@ -1194,6 +1312,14 @@
         "Grammy per il miglior album vocale pop (Harry's House)",
         "Brit Award per la canzone dell'anno"
       ],
+      "awards_de": [
+        "Grammy - Bestes Pop-Gesangsalbum (Harry's House)",
+        "BRIT Award - Song des Jahres"
+      ],
+      "awards_es": [
+        "Grammy - Mejor Álbum Vocal Pop (Harry's House)",
+        "Premio BRIT - Canción del Año"
+      ],
       "isrc": "USSM12200612",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1615585008",
@@ -1246,6 +1372,12 @@
       ],
       "awards_it": [
         "Grammy per la migliore interpretazione pop solista"
+      ],
+      "awards_de": [
+        "Grammy - Beste Pop-Solodarbietung"
+      ],
+      "awards_es": [
+        "Grammy - Mejor Interpretación Pop Solista"
       ]
     },
     {
@@ -1293,6 +1425,14 @@
       "awards_it": [
         "Grammy per il disco dell'anno",
         "Grammy per la migliore interpretazione pop solista"
+      ],
+      "awards_de": [
+        "Grammy - Aufnahme des Jahres",
+        "Grammy - Beste Pop-Solodarbietung"
+      ],
+      "awards_es": [
+        "Grammy - Grabación del Año",
+        "Grammy - Mejor Interpretación Pop Solista"
       ],
       "isrc": "USSM12209777",
       "uri_apple_music_by_region": {

--- a/custom_components/beatify/playlists/community/greatest-metal-songs.json
+++ b/custom_components/beatify/playlists/community/greatest-metal-songs.json
@@ -1,6 +1,6 @@
 {
   "name": "Greatest Metal Songs of All Time 🤘",
-  "version": "1.17",
+  "version": "1.18",
   "tags": [
     "metal",
     "rock",
@@ -44,6 +44,15 @@
         "Grammy Hall of Fame"
       ],
       "awards_it": [
+        "Grammy Hall of Fame"
+      ],
+      "awards_de": [
+        "Grammy - Hall of Fame"
+      ],
+      "awards_es": [
+        "Grammy - Salón de la Fama"
+      ],
+      "awards_fr": [
         "Grammy Hall of Fame"
       ],
       "isrc": "USWB11304371",
@@ -93,6 +102,15 @@
       "awards_it": [
         "Grammy Hall of Fame"
       ],
+      "awards_de": [
+        "Grammy - Hall of Fame"
+      ],
+      "awards_es": [
+        "Grammy - Salón de la Fama"
+      ],
+      "awards_fr": [
+        "Grammy Hall of Fame"
+      ],
       "isrc": "USWB11304369",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/787644021",
@@ -139,6 +157,15 @@
       ],
       "awards_it": [
         "Candidatura al Grammy"
+      ],
+      "awards_de": [
+        "Grammy-Nominierung"
+      ],
+      "awards_es": [
+        "Nominación al Grammy"
+      ],
+      "awards_fr": [
+        "Nomination aux Grammy"
       ],
       "isrc": "GBBBN8202006",
       "uri_apple_music_by_region": {
@@ -187,6 +214,15 @@
       "awards_it": [
         "Candidatura al Grammy"
       ],
+      "awards_de": [
+        "Grammy-Nominierung"
+      ],
+      "awards_es": [
+        "Nominación al Grammy"
+      ],
+      "awards_fr": [
+        "Nomination aux Grammy"
+      ],
       "isrc": "GBCHB1500031",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1713861908",
@@ -234,6 +270,15 @@
       "awards_it": [
         "Candidatura al Grammy"
       ],
+      "awards_de": [
+        "Grammy-Nominierung"
+      ],
+      "awards_es": [
+        "Nominación al Grammy"
+      ],
+      "awards_fr": [
+        "Nomination aux Grammy"
+      ],
       "isrc": "GBCHB1500023",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1713862907",
@@ -279,6 +324,15 @@
         "Grammy Hall of Fame"
       ],
       "awards_it": [
+        "Grammy Hall of Fame"
+      ],
+      "awards_de": [
+        "Grammy - Hall of Fame"
+      ],
+      "awards_es": [
+        "Grammy - Salón de la Fama"
+      ],
+      "awards_fr": [
         "Grammy Hall of Fame"
       ],
       "isrc": "QMKHM1600219",
@@ -328,6 +382,15 @@
       "awards_it": [
         "Grammy per la migliore interpretazione metal"
       ],
+      "awards_de": [
+        "Grammy - Beste Metal-Darbietung"
+      ],
+      "awards_es": [
+        "Grammy - Mejor Interpretación de Metal"
+      ],
+      "awards_fr": [
+        "Grammy Award - Meilleure performance metal"
+      ],
       "isrc": "QMKHM1900001",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1572046436",
@@ -374,6 +437,15 @@
       ],
       "awards_it": [
         "Grammy per la migliore interpretazione metal"
+      ],
+      "awards_de": [
+        "Grammy - Beste Metal-Darbietung"
+      ],
+      "awards_es": [
+        "Grammy - Mejor Interpretación de Metal"
+      ],
+      "awards_fr": [
+        "Grammy Award - Meilleure performance metal"
       ],
       "isrc": "QMKHM1700138",
       "uri_apple_music_by_region": {
@@ -422,6 +494,15 @@
       "awards_it": [
         "Candidatura al Grammy"
       ],
+      "awards_de": [
+        "Grammy-Nominierung"
+      ],
+      "awards_es": [
+        "Nominación al Grammy"
+      ],
+      "awards_fr": [
+        "Nomination aux Grammy"
+      ],
       "isrc": "USSM18600241",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1733769810",
@@ -468,6 +549,15 @@
       ],
       "awards_it": [
         "Candidatura al Grammy"
+      ],
+      "awards_de": [
+        "Grammy-Nominierung"
+      ],
+      "awards_es": [
+        "Nominación al Grammy"
+      ],
+      "awards_fr": [
+        "Nomination aux Grammy"
       ],
       "isrc": "USAT21202190",
       "uri_apple_music_by_region": {
@@ -516,6 +606,15 @@
       "awards_it": [
         "Candidatura al Grammy"
       ],
+      "awards_de": [
+        "Grammy-Nominierung"
+      ],
+      "awards_es": [
+        "Nominación al Grammy"
+      ],
+      "awards_fr": [
+        "Nomination aux Grammy"
+      ],
       "isrc": "USAT21001391",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1814306260",
@@ -562,6 +661,15 @@
       ],
       "awards_it": [
         "Candidatura al Grammy"
+      ],
+      "awards_de": [
+        "Grammy-Nominierung"
+      ],
+      "awards_es": [
+        "Nominación al Grammy"
+      ],
+      "awards_fr": [
+        "Nomination aux Grammy"
       ],
       "isrc": "USEE19900919",
       "uri_apple_music_by_region": {
@@ -610,6 +718,15 @@
       "awards_it": [
         "Candidatura al Grammy"
       ],
+      "awards_de": [
+        "Grammy-Nominierung"
+      ],
+      "awards_es": [
+        "Nominación al Grammy"
+      ],
+      "awards_fr": [
+        "Nomination aux Grammy"
+      ],
       "isrc": "USCA29000003",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/724649275",
@@ -656,6 +773,15 @@
       ],
       "awards_it": [
         "Candidatura al Grammy"
+      ],
+      "awards_de": [
+        "Grammy-Nominierung"
+      ],
+      "awards_es": [
+        "Nominación al Grammy"
+      ],
+      "awards_fr": [
+        "Nomination aux Grammy"
       ],
       "isrc": "USCA20400616",
       "uri_apple_music_by_region": {
@@ -704,6 +830,15 @@
       "awards_it": [
         "Candidatura al Grammy"
       ],
+      "awards_de": [
+        "Grammy-Nominierung"
+      ],
+      "awards_es": [
+        "Nominación al Grammy"
+      ],
+      "awards_fr": [
+        "Nomination aux Grammy"
+      ],
       "isrc": "USWB11507137",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1048476460",
@@ -749,6 +884,15 @@
         "Grammy Hall of Fame"
       ],
       "awards_it": [
+        "Grammy Hall of Fame"
+      ],
+      "awards_de": [
+        "Grammy - Hall of Fame"
+      ],
+      "awards_es": [
+        "Grammy - Salón de la Fama"
+      ],
+      "awards_fr": [
         "Grammy Hall of Fame"
       ],
       "isrc": "USSM11002845",
@@ -798,6 +942,15 @@
       "awards_it": [
         "Candidatura al Grammy"
       ],
+      "awards_de": [
+        "Grammy-Nominierung"
+      ],
+      "awards_es": [
+        "Nominación al Grammy"
+      ],
+      "awards_fr": [
+        "Nomination aux Grammy"
+      ],
       "isrc": "USSM10107256",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/273714640",
@@ -844,6 +997,15 @@
       ],
       "awards_it": [
         "Candidatura al Grammy"
+      ],
+      "awards_de": [
+        "Grammy-Nominierung"
+      ],
+      "awards_es": [
+        "Nominación al Grammy"
+      ],
+      "awards_fr": [
+        "Nomination aux Grammy"
       ],
       "isrc": "USSM10107262",
       "uri_apple_music_by_region": {
@@ -892,6 +1054,15 @@
       "awards_it": [
         "Grammy per la migliore interpretazione metal"
       ],
+      "awards_de": [
+        "Grammy - Beste Metal-Darbietung"
+      ],
+      "awards_es": [
+        "Grammy - Mejor Interpretación de Metal"
+      ],
+      "awards_fr": [
+        "Grammy Award - Meilleure performance metal"
+      ],
       "isrc": "USVR10100013",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1474185654",
@@ -938,6 +1109,15 @@
       ],
       "awards_it": [
         "Candidatura al Grammy"
+      ],
+      "awards_de": [
+        "Grammy-Nominierung"
+      ],
+      "awards_es": [
+        "Nominación al Grammy"
+      ],
+      "awards_fr": [
+        "Nomination aux Grammy"
       ],
       "isrc": "USRE11600104",
       "uri_apple_music_by_region": {
@@ -986,6 +1166,15 @@
       "awards_it": [
         "Grammy per la migliore interpretazione hard rock"
       ],
+      "awards_de": [
+        "Grammy - Beste Hard-Rock-Darbietung"
+      ],
+      "awards_es": [
+        "Grammy - Mejor Interpretación de Hard Rock"
+      ],
+      "awards_fr": [
+        "Grammy Award - Meilleure performance hard rock"
+      ],
       "isrc": "USAM19400007",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1436558379",
@@ -1032,6 +1221,15 @@
       ],
       "awards_it": [
         "Candidatura al Grammy"
+      ],
+      "awards_de": [
+        "Grammy-Nominierung"
+      ],
+      "awards_es": [
+        "Nominación al Grammy"
+      ],
+      "awards_fr": [
+        "Nomination aux Grammy"
       ],
       "isrc": "USSM19200881",
       "uri_apple_music_by_region": {
@@ -1080,6 +1278,15 @@
       "awards_it": [
         "Candidatura al Grammy"
       ],
+      "awards_de": [
+        "Grammy-Nominierung"
+      ],
+      "awards_es": [
+        "Nominación al Grammy"
+      ],
+      "awards_fr": [
+        "Nomination aux Grammy"
+      ],
       "isrc": "USGF18714801",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1377826728",
@@ -1127,6 +1334,15 @@
       "awards_it": [
         "Candidatura al Grammy"
       ],
+      "awards_de": [
+        "Grammy-Nominierung"
+      ],
+      "awards_es": [
+        "Nominación al Grammy"
+      ],
+      "awards_fr": [
+        "Nomination aux Grammy"
+      ],
       "isrc": "USGF18714809",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1377813701",
@@ -1172,6 +1388,15 @@
         "Grammy Hall of Fame"
       ],
       "awards_it": [
+        "Grammy Hall of Fame"
+      ],
+      "awards_de": [
+        "Grammy - Hall of Fame"
+      ],
+      "awards_es": [
+        "Grammy - Salón de la Fama"
+      ],
+      "awards_fr": [
         "Grammy Hall of Fame"
       ],
       "isrc": "AUAP07900028",
@@ -1221,6 +1446,15 @@
       "awards_it": [
         "Grammy Hall of Fame"
       ],
+      "awards_de": [
+        "Grammy - Hall of Fame"
+      ],
+      "awards_es": [
+        "Grammy - Salón de la Fama"
+      ],
+      "awards_fr": [
+        "Grammy Hall of Fame"
+      ],
       "isrc": "AUAP08000046",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/576003082",
@@ -1266,6 +1500,15 @@
         "Grammy Hall of Fame"
       ],
       "awards_it": [
+        "Grammy Hall of Fame"
+      ],
+      "awards_de": [
+        "Grammy - Hall of Fame"
+      ],
+      "awards_es": [
+        "Grammy - Salón de la Fama"
+      ],
+      "awards_fr": [
         "Grammy Hall of Fame"
       ],
       "isrc": "USRH11602140",
@@ -1315,6 +1558,15 @@
       "awards_it": [
         "Candidatura al Grammy"
       ],
+      "awards_de": [
+        "Grammy-Nominierung"
+      ],
+      "awards_es": [
+        "Nominación al Grammy"
+      ],
+      "awards_fr": [
+        "Nomination aux Grammy"
+      ],
       "isrc": "GBUM71701307",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1438626355",
@@ -1361,6 +1613,15 @@
       ],
       "awards_it": [
         "Candidatura al Grammy"
+      ],
+      "awards_de": [
+        "Grammy-Nominierung"
+      ],
+      "awards_es": [
+        "Nominación al Grammy"
+      ],
+      "awards_fr": [
+        "Nomination aux Grammy"
       ],
       "isrc": "USWB11403500",
       "uri_apple_music_by_region": {
@@ -1409,6 +1670,15 @@
       "awards_it": [
         "Candidatura al Grammy"
       ],
+      "awards_de": [
+        "Grammy-Nominierung"
+      ],
+      "awards_es": [
+        "Nominación al Grammy"
+      ],
+      "awards_fr": [
+        "Nomination aux Grammy"
+      ],
       "isrc": "USSM19200317",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1737564412",
@@ -1455,6 +1725,15 @@
       ],
       "awards_it": [
         "Candidatura al Grammy"
+      ],
+      "awards_de": [
+        "Grammy-Nominierung"
+      ],
+      "awards_es": [
+        "Nominación al Grammy"
+      ],
+      "awards_fr": [
+        "Nomination aux Grammy"
       ],
       "isrc": "USIR19601008",
       "uri_apple_music_by_region": {
@@ -1503,6 +1782,15 @@
       "awards_it": [
         "Grammy per il miglior video musicale di forma breve"
       ],
+      "awards_de": [
+        "Grammy - Bestes Kurzform-Musikvideo"
+      ],
+      "awards_es": [
+        "Grammy - Mejor Vídeo Musical de Formato Corto"
+      ],
+      "awards_fr": [
+        "Grammy Award - Meilleur vidéoclip format court"
+      ],
       "isrc": "USSM19805391",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1831584743",
@@ -1549,6 +1837,15 @@
       ],
       "awards_it": [
         "Candidatura al Grammy"
+      ],
+      "awards_de": [
+        "Grammy-Nominierung"
+      ],
+      "awards_es": [
+        "Nominación al Grammy"
+      ],
+      "awards_fr": [
+        "Nomination aux Grammy"
       ],
       "isrc": "NLA321400496",
       "uri_apple_music_by_region": {
@@ -1597,6 +1894,15 @@
       "awards_it": [
         "Candidatura al Grammy"
       ],
+      "awards_de": [
+        "Grammy-Nominierung"
+      ],
+      "awards_es": [
+        "Nominación al Grammy"
+      ],
+      "awards_fr": [
+        "Nomination aux Grammy"
+      ],
       "isrc": "NLA321400554",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/927744252",
@@ -1643,6 +1949,15 @@
       ],
       "awards_it": [
         "Candidatura al Grammy"
+      ],
+      "awards_de": [
+        "Grammy-Nominierung"
+      ],
+      "awards_es": [
+        "Nominación al Grammy"
+      ],
+      "awards_fr": [
+        "Nomination aux Grammy"
       ],
       "isrc": "USRE11500333",
       "uri_apple_music_by_region": {
@@ -1691,6 +2006,15 @@
       "awards_it": [
         "Candidatura al Grammy"
       ],
+      "awards_de": [
+        "Grammy-Nominierung"
+      ],
+      "awards_es": [
+        "Nominación al Grammy"
+      ],
+      "awards_fr": [
+        "Nomination aux Grammy"
+      ],
       "isrc": "USRZR0300801",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/6777217538",
@@ -1737,6 +2061,15 @@
       ],
       "awards_it": [
         "Candidatura al Grammy"
+      ],
+      "awards_de": [
+        "Grammy-Nominierung"
+      ],
+      "awards_es": [
+        "Nominación al Grammy"
+      ],
+      "awards_fr": [
+        "Nomination aux Grammy"
       ],
       "isrc": "US2640562201",
       "uri_apple_music_by_region": {
@@ -1785,6 +2118,15 @@
       "awards_it": [
         "Candidatura al Grammy"
       ],
+      "awards_de": [
+        "Grammy-Nominierung"
+      ],
+      "awards_es": [
+        "Nominación al Grammy"
+      ],
+      "awards_fr": [
+        "Nomination aux Grammy"
+      ],
       "isrc": "FR6V80520037",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/213374170",
@@ -1831,6 +2173,15 @@
       ],
       "awards_it": [
         "Candidatura al Grammy"
+      ],
+      "awards_de": [
+        "Grammy-Nominierung"
+      ],
+      "awards_es": [
+        "Nominación al Grammy"
+      ],
+      "awards_fr": [
+        "Nomination aux Grammy"
       ],
       "isrc": "NLA321600053",
       "uri_apple_music_by_region": {
@@ -1879,6 +2230,15 @@
       "awards_it": [
         "Candidatura al Grammy"
       ],
+      "awards_de": [
+        "Grammy-Nominierung"
+      ],
+      "awards_es": [
+        "Nominación al Grammy"
+      ],
+      "awards_fr": [
+        "Nomination aux Grammy"
+      ],
       "isrc": "NLA329513650",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1630107557",
@@ -1925,6 +2285,15 @@
       ],
       "awards_it": [
         "Grammy per la migliore interpretazione metal"
+      ],
+      "awards_de": [
+        "Grammy - Beste Metal-Darbietung"
+      ],
+      "awards_es": [
+        "Grammy - Mejor Interpretación de Metal"
+      ],
+      "awards_fr": [
+        "Grammy Award - Meilleure performance metal"
       ],
       "isrc": "USC4R1601984",
       "uri_apple_music_by_region": {
@@ -1973,6 +2342,15 @@
       "awards_it": [
         "Grammy per la migliore interpretazione metal"
       ],
+      "awards_de": [
+        "Grammy - Beste Metal-Darbietung"
+      ],
+      "awards_es": [
+        "Grammy - Mejor Interpretación de Metal"
+      ],
+      "awards_fr": [
+        "Grammy Award - Meilleure performance metal"
+      ],
       "isrc": "USRC11902032",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1475686698",
@@ -2019,6 +2397,15 @@
       ],
       "awards_it": [
         "Candidatura al Grammy"
+      ],
+      "awards_de": [
+        "Grammy-Nominierung"
+      ],
+      "awards_es": [
+        "Nominación al Grammy"
+      ],
+      "awards_fr": [
+        "Nomination aux Grammy"
       ],
       "isrc": "GBAJE8000033",
       "uri_apple_music_by_region": {
@@ -2067,6 +2454,15 @@
       "awards_it": [
         "Candidatura al Grammy"
       ],
+      "awards_de": [
+        "Grammy-Nominierung"
+      ],
+      "awards_es": [
+        "Nominación al Grammy"
+      ],
+      "awards_fr": [
+        "Nomination aux Grammy"
+      ],
       "isrc": "DED830703548",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1882049242",
@@ -2113,6 +2509,15 @@
       ],
       "awards_it": [
         "Candidatura al Grammy"
+      ],
+      "awards_de": [
+        "Grammy-Nominierung"
+      ],
+      "awards_es": [
+        "Nominación al Grammy"
+      ],
+      "awards_fr": [
+        "Nomination aux Grammy"
       ],
       "isrc": "USAT21202188",
       "uri_apple_music_by_region": {
@@ -2161,6 +2566,15 @@
       "awards_it": [
         "Candidatura al Grammy"
       ],
+      "awards_de": [
+        "Grammy-Nominierung"
+      ],
+      "awards_es": [
+        "Nominación al Grammy"
+      ],
+      "awards_fr": [
+        "Nomination aux Grammy"
+      ],
       "isrc": "USWB11201118",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/591534783",
@@ -2207,6 +2621,15 @@
       ],
       "awards_it": [
         "Candidatura al Grammy"
+      ],
+      "awards_de": [
+        "Grammy-Nominierung"
+      ],
+      "awards_es": [
+        "Nominación al Grammy"
+      ],
+      "awards_fr": [
+        "Nomination aux Grammy"
       ],
       "isrc": "NLA320420753",
       "uri_apple_music_by_region": {
@@ -2255,6 +2678,15 @@
       "awards_it": [
         "Candidatura al Grammy"
       ],
+      "awards_de": [
+        "Grammy-Nominierung"
+      ],
+      "awards_es": [
+        "Nominación al Grammy"
+      ],
+      "awards_fr": [
+        "Nomination aux Grammy"
+      ],
       "isrc": "NLA321392901",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/697728142",
@@ -2301,6 +2733,15 @@
       ],
       "awards_it": [
         "Candidatura al Grammy"
+      ],
+      "awards_de": [
+        "Grammy-Nominierung"
+      ],
+      "awards_es": [
+        "Nominación al Grammy"
+      ],
+      "awards_fr": [
+        "Nomination aux Grammy"
       ],
       "isrc": "GBARL1401189",
       "uri_apple_music_by_region": {
@@ -2349,6 +2790,15 @@
       "awards_it": [
         "Candidatura al Grammy"
       ],
+      "awards_de": [
+        "Grammy-Nominierung"
+      ],
+      "awards_es": [
+        "Nominación al Grammy"
+      ],
+      "awards_fr": [
+        "Nomination aux Grammy"
+      ],
       "isrc": "USEP41014009",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1485045876",
@@ -2396,6 +2846,15 @@
       "awards_it": [
         "Candidatura al Grammy"
       ],
+      "awards_de": [
+        "Grammy-Nominierung"
+      ],
+      "awards_es": [
+        "Nominación al Grammy"
+      ],
+      "awards_fr": [
+        "Nomination aux Grammy"
+      ],
       "isrc": "USEP41604038",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1485075528",
@@ -2442,6 +2901,15 @@
       ],
       "awards_it": [
         "Grammy per la migliore interpretazione metal"
+      ],
+      "awards_de": [
+        "Grammy - Beste Metal-Darbietung"
+      ],
+      "awards_es": [
+        "Grammy - Mejor Interpretación de Metal"
+      ],
+      "awards_fr": [
+        "Grammy Award - Meilleure performance metal"
       ],
       "isrc": "NLA321900283",
       "uri_apple_music_by_region": {
@@ -2793,6 +3261,15 @@
       ],
       "awards_it": [
         "Grammy per la migliore interpretazione hard rock"
+      ],
+      "awards_de": [
+        "Grammy - Beste Hard-Rock-Darbietung"
+      ],
+      "awards_es": [
+        "Grammy - Mejor Interpretación de Hard Rock"
+      ],
+      "awards_fr": [
+        "Grammy Award - Meilleure performance hard rock"
       ],
       "isrc": "USSM10501327",
       "uri_apple_music_by_region": {

--- a/custom_components/beatify/playlists/disco-funk-classics.json
+++ b/custom_components/beatify/playlists/disco-funk-classics.json
@@ -1,6 +1,6 @@
 {
   "name": "Disco & Funk Classics",
-  "version": "1.20",
+  "version": "1.21",
   "tags": [
     "1970s",
     "1980s",
@@ -725,6 +725,12 @@
       "awards_it": [
         "Grammy per la migliore interpretazione vocale R&B maschile"
       ],
+      "awards_de": [
+        "Grammy - Beste männliche R&B-Gesangsdarbietung"
+      ],
+      "awards_es": [
+        "Grammy - Mejor Interpretación Vocal R&B Masculina"
+      ],
       "isrc": "USSM19803028",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1739929127",
@@ -815,6 +821,12 @@
       ],
       "awards_it": [
         "Grammy per la migliore interpretazione vocale pop femminile"
+      ],
+      "awards_de": [
+        "Grammy - Beste weibliche Pop-Gesangsdarbietung"
+      ],
+      "awards_es": [
+        "Grammy - Mejor Interpretación Vocal Pop Femenina"
       ],
       "isrc": "USAR18700121",
       "uri_apple_music_by_region": {
@@ -1265,6 +1277,12 @@
       "awards_it": [
         "Grammy per la migliore registrazione disco"
       ],
+      "awards_de": [
+        "Grammy - Beste Disco-Aufnahme"
+      ],
+      "awards_es": [
+        "Grammy - Mejor Grabación Disco"
+      ],
       "isrc": "USPR37800083",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1443818368",
@@ -1438,6 +1456,12 @@
       "awards_it": [
         "Candidatura all'Oscar per la migliore canzone originale"
       ],
+      "awards_de": [
+        "Oscar-Nominierung - Bester Filmsong"
+      ],
+      "awards_es": [
+        "Nominación al Óscar - Mejor Canción Original"
+      ],
       "isrc": "USNLR1200531",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1454593961",
@@ -1488,6 +1512,12 @@
       ],
       "awards_it": [
         "Grammy per la migliore interpretazione vocale R&B maschile"
+      ],
+      "awards_de": [
+        "Grammy - Beste männliche R&B-Gesangsdarbietung"
+      ],
+      "awards_es": [
+        "Grammy - Mejor Interpretación Vocal R&B Masculina"
       ],
       "isrc": "USWB19900127",
       "uri_apple_music_by_region": {
@@ -1622,6 +1652,12 @@
       "awards_it": [
         "Grammy per la migliore interpretazione vocale rock femminile"
       ],
+      "awards_de": [
+        "Grammy - Beste weibliche Rock-Gesangsdarbietung"
+      ],
+      "awards_es": [
+        "Grammy - Mejor Interpretación Vocal Rock Femenina"
+      ],
       "isrc": "USPR37907202",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1704761711",
@@ -1676,6 +1712,14 @@
       "awards_it": [
         "Oscar per la migliore canzone originale",
         "Golden Globe"
+      ],
+      "awards_de": [
+        "Oscar - Bester Filmsong",
+        "Golden Globe"
+      ],
+      "awards_es": [
+        "Óscar - Mejor Canción Original",
+        "Globo de Oro"
       ],
       "isrc": "USPR39402394",
       "uri_apple_music_by_region": {
@@ -2413,6 +2457,12 @@
       "awards_it": [
         "Grammy per la migliore canzone R&B"
       ],
+      "awards_de": [
+        "Grammy - Bester R&B-Song"
+      ],
+      "awards_es": [
+        "Grammy - Mejor Canción R&B"
+      ],
       "isrc": "USWB19600662",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1807720130",
@@ -2627,6 +2677,12 @@
       ],
       "awards_it": [
         "Grammy per la migliore interpretazione pop di un duo o gruppo"
+      ],
+      "awards_de": [
+        "Grammy - Beste Pop-Darbietung eines Duos oder einer Gruppe"
+      ],
+      "awards_es": [
+        "Grammy - Mejor Interpretación Pop de Dúo o Grupo"
       ],
       "isrc": "USRC18303288",
       "uri_apple_music_by_region": {

--- a/custom_components/beatify/playlists/motown-soul-classics.json
+++ b/custom_components/beatify/playlists/motown-soul-classics.json
@@ -1,6 +1,6 @@
 {
   "name": "Motown & Soul Classics",
-  "version": "1.16",
+  "version": "1.17",
   "tags": [
     "1960s",
     "1970s",
@@ -131,6 +131,12 @@
       ],
       "awards_it": [
         "Grammy per la migliore interpretazione strumentale R&B"
+      ],
+      "awards_de": [
+        "Grammy - Beste instrumentale R&B-Darbietung"
+      ],
+      "awards_es": [
+        "Grammy - Mejor Interpretación Instrumental R&B"
       ],
       "isrc": "USMO17200080",
       "uri_apple_music_by_region": {
@@ -663,6 +669,12 @@
       "awards_it": [
         "Candidatura all'Oscar per la migliore canzone originale"
       ],
+      "awards_de": [
+        "Oscar-Nominierung - Bester Filmsong"
+      ],
+      "awards_es": [
+        "Nominación al Óscar - Mejor Canción Original"
+      ],
       "isrc": "USMO17500374",
       "uri_apple_music_by_region": {
         "de": "applemusic://track/1612221191",
@@ -998,6 +1010,12 @@
       "awards_it": [
         "Grammy Hall of Fame"
       ],
+      "awards_de": [
+        "Grammy - Hall of Fame"
+      ],
+      "awards_es": [
+        "Grammy - Salón de la Fama"
+      ],
       "isrc": "USMO17100041",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1472134764",
@@ -1250,6 +1268,12 @@
       "awards_it": [
         "Grammy per la migliore canzone R&B"
       ],
+      "awards_de": [
+        "Grammy - Bester R&B-Song"
+      ],
+      "awards_es": [
+        "Grammy - Mejor Canción R&B"
+      ],
       "isrc": "USMO18400528",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/6762971076",
@@ -1419,6 +1443,12 @@
       "awards_it": [
         "Grammy per la migliore interpretazione vocale R&B"
       ],
+      "awards_de": [
+        "Grammy - Beste R&B-Gesangsdarbietung"
+      ],
+      "awards_es": [
+        "Grammy - Mejor Interpretación Vocal R&B"
+      ],
       "isrc": "USMO17600547",
       "uri_tidal": "tidal://track/98184494"
     },
@@ -1540,6 +1570,12 @@
       ],
       "awards_it": [
         "Grammy per la migliore interpretazione vocale pop contemporanea"
+      ],
+      "awards_de": [
+        "Grammy - Beste zeitgenössische Pop-Gesangsdarbietung"
+      ],
+      "awards_es": [
+        "Grammy - Mejor Interpretación Vocal Pop Contemporánea"
       ],
       "isrc": "USWSP0000033",
       "uri_apple_music_by_region": {
@@ -1998,6 +2034,12 @@
       "awards_it": [
         "Candidatura all'Oscar per la migliore canzone originale"
       ],
+      "awards_de": [
+        "Oscar-Nominierung - Bester Filmsong"
+      ],
+      "awards_es": [
+        "Nominación al Óscar - Mejor Canción Original"
+      ],
       "isrc": "USMO18190008",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1606057197",
@@ -2048,6 +2090,12 @@
       ],
       "awards_it": [
         "Candidatura all'Oscar per la migliore canzone originale"
+      ],
+      "awards_de": [
+        "Oscar-Nominierung - Bester Filmsong"
+      ],
+      "awards_es": [
+        "Nominación al Óscar - Mejor Canción Original"
       ],
       "isrc": "USMO17282631",
       "uri_apple_music_by_region": {

--- a/custom_components/beatify/playlists/one-hit-wonders.json
+++ b/custom_components/beatify/playlists/one-hit-wonders.json
@@ -1,6 +1,6 @@
 {
   "name": "One-Hit Wonders",
-  "version": "1.14",
+  "version": "1.15",
   "tags": [
     "one-hit",
     "classics",
@@ -270,6 +270,12 @@
       ],
       "awards_it": [
         "Ivor Novello Award (1969)"
+      ],
+      "awards_de": [
+        "Ivor Novello Award (1969)"
+      ],
+      "awards_es": [
+        "Premio Ivor Novello (1969)"
       ],
       "isrc": "GBAYE6900097",
       "uri_apple_music_by_region": {
@@ -546,6 +552,12 @@
       ],
       "awards_it": [
         "Grammy per la migliore interpretazione vocale R&B maschile (1973)"
+      ],
+      "awards_de": [
+        "Grammy - Beste männliche R&B-Gesangsdarbietung (1973)"
+      ],
+      "awards_es": [
+        "Grammy - Mejor Interpretación Vocal R&B Masculina (1973)"
       ],
       "isrc": "USSM17200413",
       "uri_apple_music_by_region": {
@@ -1744,6 +1756,14 @@
         "Grammy per la canzone dell'anno (1989)",
         "Grammy per il disco dell'anno (1989)"
       ],
+      "awards_de": [
+        "Grammy - Song des Jahres (1989)",
+        "Grammy - Aufnahme des Jahres (1989)"
+      ],
+      "awards_es": [
+        "Grammy - Canción del Año (1989)",
+        "Grammy - Grabación del Año (1989)"
+      ],
       "isrc": "USEM38800361",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/6762672295",
@@ -2048,6 +2068,12 @@
       "awards_it": [
         "Grammy per la migliore interpretazione rap (1990)"
       ],
+      "awards_de": [
+        "Grammy - Beste Rap-Darbietung (1990)"
+      ],
+      "awards_es": [
+        "Grammy - Mejor Interpretación de Rap (1990)"
+      ],
       "isrc": "USA370507645",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1807406244",
@@ -2173,6 +2199,14 @@
       "awards_it": [
         "Grammy per la migliore interpretazione rap solista (1991)",
         "Grammy per la migliore canzone R&B (1991)"
+      ],
+      "awards_de": [
+        "Grammy - Beste Rap-Solodarbietung (1991)",
+        "Grammy - Bester R&B-Song (1991)"
+      ],
+      "awards_es": [
+        "Grammy - Mejor Interpretación de Rap Solista (1991)",
+        "Grammy - Mejor Canción R&B (1991)"
       ],
       "isrc": "USCA29000294",
       "uri_apple_music_by_region": {
@@ -3634,6 +3668,12 @@
       ],
       "awards_it": [
         "Grammy per il disco dell'anno (2007)"
+      ],
+      "awards_de": [
+        "Grammy - Aufnahme des Jahres (2007)"
+      ],
+      "awards_es": [
+        "Grammy - Grabación del Año (2007)"
       ],
       "isrc": "USAT20611041",
       "uri_apple_music_by_region": {

--- a/custom_components/beatify/playlists/top-songs-der-60er.json
+++ b/custom_components/beatify/playlists/top-songs-der-60er.json
@@ -1,6 +1,6 @@
 {
   "name": "60s Classics 🎸",
-  "version": "1.14",
+  "version": "1.15",
   "source": "https://open.spotify.com/playlist/6rtsNFUv2UK3j78PRVMpSd",
   "tags": [
     "1960s",
@@ -476,6 +476,15 @@
       "awards_it": [
         "Grammy per la migliore canzone R&B (1972)"
       ],
+      "awards_de": [
+        "Grammy - Bester R&B-Song (1972)"
+      ],
+      "awards_es": [
+        "Grammy - Mejor Canción R&B (1972)"
+      ],
+      "awards_fr": [
+        "Grammy Award - Meilleure chanson R&B (1972)"
+      ],
       "isrc": "USSM17100268",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/391725482",
@@ -522,6 +531,15 @@
       ],
       "awards_it": [
         "Grammy per la migliore registrazione rock and roll (1965)"
+      ],
+      "awards_de": [
+        "Grammy Award für beste Rock-and-Roll-Aufnahme (1965)"
+      ],
+      "awards_es": [
+        "Premio Grammy a la Mejor Grabación de Rock and Roll (1965)"
+      ],
+      "awards_fr": [
+        "Grammy Award - Meilleur enregistrement rock and roll (1965)"
       ],
       "isrc": "FRZ196400510",
       "uri_apple_music_by_region": {
@@ -645,6 +663,15 @@
       ],
       "awards_it": [
         "Ivor Novello Award per l'originalita (1970)"
+      ],
+      "awards_de": [
+        "Ivor Novello Award - Originalität (1970)"
+      ],
+      "awards_es": [
+        "Premio Ivor Novello - Originalidad (1970)"
+      ],
+      "awards_fr": [
+        "Ivor Novello Award - Originalité (1970)"
       ],
       "isrc": "USJT10900021",
       "uri_apple_music_by_region": {
@@ -846,6 +873,15 @@
       ],
       "awards_it": [
         "Grammy per il disco dell'anno (1969)"
+      ],
+      "awards_de": [
+        "Grammy - Aufnahme des Jahres (1969)"
+      ],
+      "awards_es": [
+        "Grammy - Grabación del Año (1969)"
+      ],
+      "awards_fr": [
+        "Grammy Award - Enregistrement de l'année (1969)"
       ],
       "isrc": "USSM16800379",
       "uri_apple_music_by_region": {


### PR DESCRIPTION
Follows the measurement in #2259. Of the 422 decorated songs, `nl` covered 422, `fr` 355, and `de` and `es` only **253** — so players on three of the five shipped languages saw English award names on 40 % of the decorated catalogue.

| Locale | Before | After |
|---|---|---|
| de | 253 / 422 | **422 / 422** |
| es | 253 / 422 | **422 / 422** |
| fr | 355 / 422 | **422 / 422** |
| nl | 422 / 422 | unchanged |

## Where the wording comes from

Two sources, in this order:

1. **The catalogue itself.** Where the same English string was already translated into that language somewhere, that wording is reused verbatim. The convention comes from the data, not from me.
2. Only where the catalogue is silent does a table apply.

Anything matching neither was **reported, not guessed** — the run ended with nothing open.

The tables follow each language's own house style, read off the entries that were already there:

- German — `Grammy - Aufnahme des Jahres`, `Oscar - Bester Filmsong`, `Grammy-Nominierung - …`
- Spanish — `Grammy - Grabación del Año`, `Nominación al Óscar - …`
- French — `Grammy Award - Meilleure performance metal`, `Nomination au BRIT Award - …`

Nomination markers are normalised the same way in all three, including the ones the source hid inside the year bracket (`Brit Award … (Nomination, 1998)`).

## Scope

Only `awards_de`, `awards_es` and `awards_fr` change, plus 12 version bumps — verified field by field. `pytest tests/unit` → 1958 passed, `validate_playlists.py` → all 57 valid.

## Merge order

#2259 (`awards_it`) edits the same files. Whichever lands second needs a rebase; the two touch different keys, so the resolution is mechanical.
