### PR TITLE
chore(playlists): youtube backfill — +1 youtube uris

### DIFF
--- a/custom_components/beatify/playlists/community/musica-italiana.json
+++ b/custom_components/beatify/playlists/community/musica-italiana.json
@@ -1,7 +1,7 @@
 {
   "name": "Musica Italiana 🇮🇹",
   "description": "Italian classics from the 1960s to the 2000s — cantautori, Sanremo winners and the songs every Italian party sings along to. Merged from playlist requests #2228 and #2229.",
-  "version": "0.8",
+  "version": "0.9",
   "songs": [
     {
       "year": 1962,
@@ -910,7 +910,8 @@
       "fun_fact_it": "Adriano Pappalardo - \"Ricominciamo\" (1979), dal canone del pop italiano.",
       "isrc": "ITB007900666",
       "uri_apple_music": "applemusic://track/1080717875",
-      "uri_deezer": "deezer://track/1009010"
+      "uri_deezer": "deezer://track/1009010",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=1Hcf2TxhhX4"
     },
     {
       "year": 1979,

--- a/custom_components/beatify/playlists/community/sanremo-vincitori.json
+++ b/custom_components/beatify/playlists/community/sanremo-vincitori.json
@@ -1,7 +1,7 @@
 {
   "name": "Sanremo: I Vincitori 🇮🇹",
   "description": "Every winning song of the Sanremo Music Festival, from Nilla Pizzi in 1951 to Sal Da Vinci in 2026. Years verified against the official Albo d'oro. Requested in #2230.",
-  "version": "0.5",
+  "version": "0.6",
   "tags": [
     "italian",
     "sanremo",
@@ -1050,7 +1050,7 @@
       "uri_apple_music": "applemusic://track/1600943637",
       "uri_apple_music_by_region": {},
       "uri_deezer": "deezer://track/1594546561",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=AlVmxmsjGaU",
       "uri_tidal": null
     },
     {


### PR DESCRIPTION
Ein Lauf des `provider-uri-backfill`, automatisch gefahren von `com.beatify.youtube-backfill`.

- `sanremo-vincitori` YouTube 28 -> **29**/68

**Draft mit Absicht** — Merge nur nach Markus' Freigabe.