### PR TITLE
docs(readme): refresh the user-numbers line

### DIFF
--- a/README.md
+++ b/README.md
@@ -665,7 +665,7 @@ Beatify is built with substantial help from AI coding tools (Claude Code). That'
 - **Test coverage**: 69 Python test files, JS tests via Vitest, integration tests for the WebSocket protocol — every regression gets a test before the fix lands.
 - **Architecture is documented in code**: see `custom_components/beatify/services/media_player.py` lines 111–128 — the comment block walks through *why* the provider-URI dispatch was rewritten, names the specific user (Levtos) whose bug report drove the change, and references the original GitHub issues (#768, #805, #808).
 - **890+ closed issues with traceable root causes**, not just "fixed". URI-validation, playback-recovery, and import-flow security got dedicated sweeps in v3.3.x.
-- **Real users, not vanity metrics**: 216 stars, 10 forks (forks = devs reading the code), 419 active HACS installs, top 11% HACS rank, MIT-licensed.
+- **Real users, not vanity metrics**: 218 stars, 12 forks (forks = devs reading the code), 428 active HACS installs, top 11% HACS rank, MIT-licensed.
 
 The AI is the typist. The decisions, the architecture, the bug triage, and the "ship it" call are all human. If something looks off in the code, [open an issue](https://github.com/mholzi/beatify/issues) — that's how the documented bug-fix sweeps started in the first place.
 


### PR DESCRIPTION
The "real users, not vanity metrics" bullet still claimed **216 stars, 10 forks, 419 active HACS installs**. Measured today: **218, 12, 428**. The "top 11%" claim still holds at 11.16 %.

That line sits on the page that **92 of 127 unique visitors in the last 14 days never leave**, so stale figures there are the ones most people see.

## Two more stale numbers, deliberately not folded in

| Claim in the same list | Measured today |
|---|---|
| "69 Python test files" | 84 files matching `test_*.py` |
| "890+ closed issues" | 971 per GitHub search |

Both are **understatements**, so nothing on the page currently oversells the project. They are their own decision rather than a side effect of a one-line refresh — say the word and they go in a follow-up.
