### PR TITLE
fix: clear persisted state when the integration is removed (#2263)

### DIFF
--- a/custom_components/beatify/__init__.py
+++ b/custom_components/beatify/__init__.py
@@ -19,6 +19,7 @@ from homeassistant.components.frontend import (
     async_remove_panel,
 )
 from homeassistant.helpers.event import async_track_time_interval
+from homeassistant.helpers.storage import Store
 
 from .analytics import AnalyticsStorage
 from .const import (
@@ -68,6 +69,9 @@ from .server.views import (
     UsageView,
 )
 from .server.library_views import (
+    LIBRARY_GAME_OUTPUT_STORE_KEY,
+    LIBRARY_SETTINGS_STORE_KEY,
+    LIBRARY_STORE_VERSION,
     LibraryPoolStatusView,
     LibraryPoolBuildView,
     LibraryPoolExportView,
@@ -82,6 +86,7 @@ from .server.library_views import (
     LibraryPlaylistResolveView,
     LibraryPlaylistGenerateView,
 )
+from .server.setup_state import clear_setup
 from .server.websocket import BeatifyWebSocketHandler
 from .server.ws_handlers.admin import _finalize_and_end
 from .services.media_player import async_get_media_players
@@ -455,3 +460,57 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         )
 
     return unload_ok
+
+
+def _remove_persisted_files(hass: HomeAssistant) -> list[str]:
+    """Delete Beatify's files under ``config/beatify`` (blocking I/O).
+
+    Returns the names that existed and were removed, for the log line.
+    """
+    removed: list[str] = []
+    if clear_setup(hass):
+        removed.append("setup.json")
+    reports = Path(hass.config.path("beatify")) / "data_quality_reports.json"
+    try:
+        if reports.exists():
+            reports.unlink()
+            removed.append("data_quality_reports.json")
+    except OSError:
+        _LOGGER.warning("Could not delete %s during removal", reports, exc_info=True)
+    return removed
+
+
+async def async_remove_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Drop everything Beatify persisted outside the config entry (#2263).
+
+    Home Assistant deletes the config entry itself, but anything an integration
+    wrote elsewhere is its own responsibility. Beatify persists in three places:
+
+    * ``config/beatify/setup.json`` — the host's speaker and game-mode picks
+      (#1663), so a second device can re-hydrate a finished setup.
+    * ``config/beatify/data_quality_reports.json`` — player-reported wrong years.
+    * two HA ``Store`` keys holding the Crate Digger library settings.
+
+    None of it was cleaned up before, so removing and re-adding the integration
+    handed the fresh install the old speaker entity ids. @proffalken hit exactly
+    that: speakers he had since deleted were still assigned, the game refused to
+    start, and the in-app reset that clears the blob is unreachable when no game
+    can start. Reported in #2263.
+
+    Deliberately best-effort: a failure here must not leave the entry
+    half-removed, so every step logs and continues.
+    """
+    _LOGGER.info("Removing Beatify integration, clearing persisted state")
+
+    try:
+        removed = await hass.async_add_executor_job(_remove_persisted_files, hass)
+        if removed:
+            _LOGGER.info("Removed persisted files: %s", ", ".join(removed))
+    except Exception:  # noqa: BLE001
+        _LOGGER.warning("Could not clear persisted files on removal", exc_info=True)
+
+    for key in (LIBRARY_SETTINGS_STORE_KEY, LIBRARY_GAME_OUTPUT_STORE_KEY):
+        try:
+            await Store(hass, LIBRARY_STORE_VERSION, key).async_remove()
+        except Exception:  # noqa: BLE001
+            _LOGGER.warning("Could not remove Store %s on removal", key, exc_info=True)

--- a/custom_components/beatify/server/library_views.py
+++ b/custom_components/beatify/server/library_views.py
@@ -231,6 +231,13 @@ class LibraryPoolBuildView(HomeAssistantView):
 
 _GAME_OUTPUT_KEY = "beatify.game_output_settings"
 
+# Public aliases for the removal hook (#2263). The integration has to clear
+# these Stores when it is deleted, and a second copy of the key strings in
+# __init__.py would drift the first time one of them is renamed here.
+LIBRARY_SETTINGS_STORE_KEY = _SETTINGS_STORE_KEY
+LIBRARY_GAME_OUTPUT_STORE_KEY = _GAME_OUTPUT_KEY
+LIBRARY_STORE_VERSION = _SETTINGS_STORE_VERSION
+
 
 async def async_save_game_output_settings(
     hass: HomeAssistant, patch: dict[str, Any]

--- a/tests/unit/test_remove_entry_2263.py
+++ b/tests/unit/test_remove_entry_2263.py
@@ -98,9 +98,12 @@ async def test_a_failing_step_does_not_abort_the_removal(tmp_path: Path) -> None
             if self._key.endswith("library_settings"):
                 raise OSError("disk full")
 
-    with patch("custom_components.beatify.Store", _FakeStore), patch(
-        "custom_components.beatify._remove_persisted_files",
-        side_effect=OSError("permission denied"),
+    with (
+        patch("custom_components.beatify.Store", _FakeStore),
+        patch(
+            "custom_components.beatify._remove_persisted_files",
+            side_effect=OSError("permission denied"),
+        ),
     ):
         await async_remove_entry(hass, MagicMock())
 

--- a/tests/unit/test_remove_entry_2263.py
+++ b/tests/unit/test_remove_entry_2263.py
@@ -1,0 +1,108 @@
+"""Removal cleanup for the config entry (#2263).
+
+@proffalken removed and re-added the integration after deleting some speakers
+from Home Assistant. Beatify still had the old entity ids: `setup.json` had
+survived the removal, the fresh install re-hydrated it, and the game refused to
+start because the assigned speakers no longer existed. Nothing in the UI could
+clear that state — the in-app reset is the only caller of `clear_setup`, and it
+is unreachable when the game will not start.
+
+Home Assistant deletes the config entry itself; anything written elsewhere is
+the integration's own job, and `async_remove_entry` did not exist at all.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.beatify import _remove_persisted_files, async_remove_entry
+
+
+class _Config:
+    def __init__(self, root: Path) -> None:
+        self._root = root
+
+    def path(self, *parts: str) -> str:
+        return str(self._root.joinpath(*parts))
+
+
+class _Hass:
+    def __init__(self, root: Path) -> None:
+        self.config = _Config(root)
+
+    async def async_add_executor_job(self, func, *args):
+        return func(*args)
+
+
+def _write_both(root: Path) -> Path:
+    d = root / "beatify"
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "setup.json").write_text(
+        json.dumps({"last_player": "Markus"}), encoding="utf-8"
+    )
+    (d / "data_quality_reports.json").write_text("[]", encoding="utf-8")
+    return d
+
+
+def test_removes_both_files(tmp_path: Path) -> None:
+    d = _write_both(tmp_path)
+    removed = _remove_persisted_files(_Hass(tmp_path))
+
+    assert sorted(removed) == ["data_quality_reports.json", "setup.json"]
+    assert not (d / "setup.json").exists()
+    assert not (d / "data_quality_reports.json").exists()
+
+
+def test_missing_files_are_not_an_error(tmp_path: Path) -> None:
+    # A host who never finished the wizard has neither file. Removal must still
+    # succeed rather than raise into HA's entry-removal path.
+    assert _remove_persisted_files(_Hass(tmp_path)) == []
+
+
+@pytest.mark.asyncio
+async def test_removes_both_library_stores(tmp_path: Path) -> None:
+    _write_both(tmp_path)
+    hass = _Hass(tmp_path)
+    created: list[str] = []
+
+    class _FakeStore:
+        def __init__(self, _hass, _version, key):
+            created.append(key)
+            self.async_remove = AsyncMock()
+
+    with patch("custom_components.beatify.Store", _FakeStore):
+        await async_remove_entry(hass, MagicMock())
+
+    assert created == [
+        "beatify.library_settings",
+        "beatify.game_output_settings",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_a_failing_step_does_not_abort_the_removal(tmp_path: Path) -> None:
+    """Best-effort by design: HA must not be left with a half-removed entry."""
+    hass = _Hass(tmp_path)
+    seen: list[str] = []
+
+    class _FakeStore:
+        def __init__(self, _hass, _version, key):
+            self._key = key
+
+        async def async_remove(self):
+            seen.append(self._key)
+            if self._key.endswith("library_settings"):
+                raise OSError("disk full")
+
+    with patch("custom_components.beatify.Store", _FakeStore), patch(
+        "custom_components.beatify._remove_persisted_files",
+        side_effect=OSError("permission denied"),
+    ):
+        await async_remove_entry(hass, MagicMock())
+
+    # The second Store is still attempted after the first one raised.
+    assert seen == ["beatify.library_settings", "beatify.game_output_settings"]


### PR DESCRIPTION
Fixes the defect in #2263.

## What was wrong

**Beatify had no `async_remove_entry` at all.** Home Assistant deletes the config entry; everything an integration wrote elsewhere is its own responsibility, and all of it survived:

| Persisted | What it holds |
|---|---|
| `config/beatify/setup.json` | the host's speaker and game-mode picks (#1663) |
| `config/beatify/data_quality_reports.json` | player-reported wrong years |
| `beatify.library_settings` (HA Store) | Crate Digger library settings |
| `beatify.game_output_settings` (HA Store) | output settings |

So removing and re-adding the integration handed the fresh install the **old speaker entity ids**. @proffalken reported the consequence: speakers he had since deleted from Home Assistant were still assigned, and the game refused to start.

There was no way out through the UI either. `clear_setup` has exactly one caller, the in-app reset, and that screen is unreachable when no game can start.

## The fix

`async_remove_entry` clears both files and both Stores.

**Best-effort by design.** A failure while clearing must not leave Home Assistant with a half-removed entry, so every step logs and the next one still runs.

**The Store keys are now exported from `library_views`** instead of being retyped in `__init__.py`. A second copy of `"beatify.library_settings"` would drift silently the first time someone renames the original.

## Tests

Four cases: both files present, neither present (a host who never finished the wizard must not raise into HA's removal path), both Stores removed in the right order, and a failing step that must not stop the ones behind it.

**Verified by mutation** rather than by a green run: renaming the hook fails the suite. `pytest tests/unit` → 1962 passed.

## Not in here

The reporter asked for three things. This PR fixes the defect, number 3 in his list. The other two, picking speakers again from the admin page and re-running the wizard on demand, are genuine convenience gaps and deserve their own issue: today's reset throws the whole setup away rather than just the speaker.
