### PR TITLE
chore(release): v4.2.1-rc3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to Beatify are documented here. For detailed release notes, 
 
 ## [Unreleased]
 
+## [4.2.1-rc3] - 2026-08-20
+
+### Added
+- **Italian, end to end (#2234).** The interface speaks Italian (1306 strings, at full key parity with English), Home Assistant's own config-flow dialog is translated, and the spoken announcements have their own Italian phrase pack rather than falling back to English. Song fun facts and award names appear in Italian too. The gap this closes was visible from outside the project: the catalogue had carried Italian music for weeks while the language picker offered five languages, none of them Italian.
+- **Two Italian playlists.** `musica-italiana` (114 songs, 1960s to 2000s) and `sanremo-vincitori` (68 songs, every festival winner from 1951 to 2026). The Sanremo years come from the official Albo d'oro rather than from streaming metadata, which dates reissues instead of songs — *Grazie dei fiori* (1951) comes back from Deezer as 2021.
+
+### Fixed
+- **Removing the integration now really removes it (#2263).** Reported by **@proffalken**. Beatify had no `async_remove_entry` at all: `config/beatify/setup.json`, `data_quality_reports.json` and two HA `Store` keys survived a delete, so a fresh install was handed the speaker entity ids of the old one. When those speakers no longer existed, the game refused to start, and the in-app reset that would have cleared the blob is unreachable when no game can start. All four are cleared now, best-effort so a failure cannot leave Home Assistant with a half-removed entry.
+- **291 malformed provider URIs across five playlists (#2247).** Bare numeric ids and Apple Music web URLs where the runtime expects `applemusic://track/<id>` and `deezer://track/<id>`. The resolver passes the stored value to Music Assistant unchanged, and per the #1379 guard a track with a region map drops its legacy field entirely, so 19 songs had a broken URI with no fallback behind it in seven storefronts. The CI schema gate now carries a `pattern` for Apple, Deezer, Tidal and every region-map value, so the next one fails the pull request instead of reaching a player.
+
+### Changed
+- **The locale parity guards cover Italian (#2234).** `test_i18n_locale_parity.py` and four vitest suites listed only de/es/fr/nl. That is the gap #1730 was filed for — es/fr/nl had silently fallen 133 keys behind `en.json` — and the newest locale was the only one shipping outside it.
+- **The playlist generator asks contributors for Italian fun facts.** The client-side validator treats `fun_fact_it` as optional, matching the schema, so it never rejects a submission the CI gate would accept.
+
 ## [4.2.1-rc2] - 2026-08-13
 
 ### Added

--- a/custom_components/beatify/manifest.json
+++ b/custom_components/beatify/manifest.json
@@ -20,5 +20,5 @@
     "num2words==0.5.14"
   ],
   "single_config_entry": true,
-  "version": "4.2.1-rc2"
+  "version": "4.2.1-rc3"
 }

--- a/docs/release-notes-v4.2.1-rc3.md
+++ b/docs/release-notes-v4.2.1-rc3.md
@@ -1,0 +1,25 @@
+## 4.2.1-rc3 — Si Gioca in Italiano
+
+Beatify speaks Italian now, from the setup dialog to the voice that announces the winner. And the catalogue has something to say in it: two Italian playlists arrive together, one of them every Sanremo winner since the festival began.
+
+### 🇮🇹 The whole game in Italian
+
+Pick Italian in the setup wizard and everyone gets it — the lobby, the player screens, the scoreboard, the spoken announcements. Home Assistant's own setup dialog is translated too, so it starts in Italian before the game does. Song trivia and award names come through in Italian as well, which is what makes a round feel like it was written for the room rather than translated at it.
+
+### 🔌 Removing the integration really removes it
+
+If you deleted Beatify from Home Assistant and added it back, it used to remember the speakers you had picked the first time. That was fine until those speakers no longer existed: the game refused to start and there was no obvious way to tell it to forget. A fresh install now really is fresh. Thanks to **@proffalken** for reporting it, and for describing it precisely enough to find in one go.
+
+### 🎉 Two Italian playlists
+
+**Musica Italiana** brings 114 songs from the 1960s to the 2000s — the cantautori, the summer hits, the ones every Italian party sings along to. **Sanremo: I Vincitori** holds every winning song of the festival from 1951 to 2026, with the years taken from the official Albo d'oro rather than from streaming metadata, which likes to date a reissue instead of the song.
+
+### 🙏 Thank you
+
+To **@proffalken** for a bug report that arrived with everything needed to fix it. And to everyone who asked for Italian in one way or another — the catalogue had Italian music long before the interface could say a word of it.
+
+---
+
+**57 playlists · 6,261 songs · 6 music platforms · 6 languages**
+
+[Report a Bug](https://github.com/mholzi/beatify/issues) · [Discussions](https://github.com/mholzi/beatify/discussions) · [Full Changelog](https://github.com/mholzi/beatify/blob/main/CHANGELOG.md)


### PR DESCRIPTION
Cuts the pre-release **v4.2.1-rc3 — Si Gioca in Italiano**. Manifest goes to 4.2.1-rc3; **v4.2.0 stays Latest**.

## What this build adds on top of the 4.2.0 stable cut

- **Italian end to end** (#2234) — 1306 UI strings at full key parity, the Home Assistant config-flow dialog, an Italian TTS phrase pack, and Italian fun facts and award names.
- **Two Italian playlists** — `musica-italiana` (114 songs) and `sanremo-vincitori` (68, every festival winner 1951-2026, years from the official Albo d'oro rather than streaming metadata).
- **Removing the integration really removes it** (#2263, reported by @proffalken) — `async_remove_entry` did not exist, so a fresh install inherited the old speaker entity ids.
- **291 malformed provider URIs fixed, with a CI schema gate** (#2247) so the next one fails the pull request instead of reaching a player.
- **The locale parity guards cover Italian** (#2234).

## Notes on the release file

`docs/release-notes-v4.2.1-rc3.md` is added with `git add -f`: `docs/` is gitignored and the file is the body of the GitHub release, so it has to be in the tree. That is the same step that nearly lost rc16 through rc21.

The note deliberately contains no catalogue-cleanup items — 50 of the 80 commits since the last tag are per-song data work, which the release-notes skill excludes from pre-release notes.

`pytest tests/unit` → 1962 passed.