### PR TITLE
data(summer-party-anthems): replace the dead Apple id for Surfin' U.S.A.

### DIFF
--- a/custom_components/beatify/playlists/summer-party-anthems.json
+++ b/custom_components/beatify/playlists/summer-party-anthems.json
@@ -1,6 +1,6 @@
 {
   "name": "100 Summer Anthems ☀️",
-  "version": "1.14",
+  "version": "1.15",
   "tags": [
     "party",
     "classics",
@@ -392,13 +392,13 @@
       "awards_nl": [],
       "isrc": "USCA20001654",
       "uri_apple_music_by_region": {
-        "us": "applemusic://track/1698230404",
-        "de": "applemusic://track/1698230404",
-        "gb": "applemusic://track/1698230404",
-        "fr": "applemusic://track/1698230404",
-        "es": "applemusic://track/1698230404",
-        "nl": "applemusic://track/1698230404",
-        "it": "applemusic://track/1698230404"
+        "us": "applemusic://track/1443101252",
+        "de": "applemusic://track/1443101252",
+        "gb": "applemusic://track/1443101252",
+        "fr": "applemusic://track/1443101252",
+        "es": "applemusic://track/1443101252",
+        "nl": "applemusic://track/1443101252",
+        "it": "applemusic://track/1443101252"
       }
     },
     {


### PR DESCRIPTION
Closes #2267.

All seven storefront entries for **The Beach Boys — "Surfin' U.S.A."** pointed at `applemusic://track/1698230404`, which `itunes.apple.com/lookup` answers with `resultCount: 0` in us, de, gb, fr, es, nl and it.

**The shape matters more than the count.** Per the #1379 guard, a song carrying a region map has its legacy `uri_apple_music` dropped entirely, so the healthy id in that field (`725823658`) was never reached. Every Apple Music host in every supported storefront got a dead URI for this song with nothing behind it.

Replaced with `applemusic://track/1443101252` — The Beach Boys, "Surfin' U.S.A.", 1963-03-04, from the *Surfin' USA* album rather than a later compilation. **Verified in all seven storefronts before writing it**, not just in us.

Version 1.14 → 1.15, one field changed, verified field by field. Schema gate green.