### PR TITLE
playlist(edm-anthems): add 56 tracks from the Tomorrowland Top 1000 (#2255)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to Beatify are documented here. For detailed release notes, 
 
 ## [Unreleased]
 
+### Added
+- Added 56 tracks to EDM Anthems from the Tomorrowland Top 1000 Official Playlist (#2255).
+
 ## [4.2.1-rc3] - 2026-08-20
 
 ### Added

--- a/custom_components/beatify/playlists/community/edm-anthems.json
+++ b/custom_components/beatify/playlists/community/edm-anthems.json
@@ -1,6 +1,6 @@
 {
   "name": "EDM Anthems",
-  "version": "1.38",
+  "version": "1.39",
   "tags": [
     "edm",
     "electronic",
@@ -11,7 +11,7 @@
   "language": "en",
   "author": "Beatify Community",
   "added_date": "2026-05-17",
-  "description": "190 unique, edition-audited EDM recordings. This enrichment incorporates every recording from the current complete 105-position request source that is not already represented elsewhere in the Beatify catalogue, preserves full Spotify artist/title credits, and includes optional provider IDs only when artist, title, edition and duration were verified.",
+  "description": "246 unique, edition-audited EDM recordings. Extended on 2026-08-20 with 56 recordings from the Tomorrowland Top 1000 Official Playlist (#2255) that were not already represented anywhere in the Beatify catalogue; the 44 that were are left where they are.",
   "songs": [
     {
       "artist": "Major Lazer, DJ Snake, MØ",
@@ -5711,6 +5711,1346 @@
         "The Chainsmokers",
         "Clean Bandit, Jess Glynne",
         "Oliver Heldens, Becky Hill"
+      ]
+    },
+    {
+      "artist": "David Guetta, Third Party, John Martin",
+      "title": "Human (Feat. John Martin)",
+      "year": 2026,
+      "isrc": "BE5KW2601205",
+      "uri": "spotify:track:426LH4RVp0WvxX69NQCTGl",
+      "uri_apple_music": "applemusic://track/6784223276",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/6784223276"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/4116004831",
+      "fun_fact": "“Human (Feat. John Martin)” appears on David Guetta’s release “Human”.",
+      "fun_fact_de": "„Human (Feat. John Martin)“ erschien auf der Veröffentlichung „Human“ von David Guetta.",
+      "fun_fact_es": "«Human (Feat. John Martin)» aparece en el lanzamiento «Human» de David Guetta.",
+      "fun_fact_fr": "« Human (Feat. John Martin) » figure sur la publication « Human » de David Guetta.",
+      "fun_fact_nl": "‘Human (Feat. John Martin)’ staat op de release ‘Human’ van David Guetta.",
+      "alt_artists": [
+        "Swedish House Mafia",
+        "Mr. Probz, Robin Schulz",
+        "Adam Port, Stryv, Keinemusik, Orso, Malachiii"
+      ]
+    },
+    {
+      "artist": "Armin van Buuren",
+      "title": "Blah Blah Blah",
+      "year": 2018,
+      "isrc": "NLF711805914",
+      "uri": "spotify:track:2xkrujtSjZz7EKAYGbIIzH",
+      "uri_apple_music": "applemusic://track/1478926053",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1478926053"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/757592622",
+      "fun_fact": "“Blah Blah Blah” appears on Armin van Buuren’s release “Balance”.",
+      "fun_fact_de": "„Blah Blah Blah“ erschien auf der Veröffentlichung „Balance“ von Armin van Buuren.",
+      "fun_fact_es": "«Blah Blah Blah» aparece en el lanzamiento «Balance» de Armin van Buuren.",
+      "fun_fact_fr": "« Blah Blah Blah » figure sur la publication « Balance » de Armin van Buuren.",
+      "fun_fact_nl": "‘Blah Blah Blah’ staat op de release ‘Balance’ van Armin van Buuren.",
+      "alt_artists": [
+        "Chase & Status, Bou, Flowdan, IRAH, Trigga, Takura",
+        "deadmau5",
+        "John Summit, HAYLA"
+      ]
+    },
+    {
+      "artist": "Martin Garrix",
+      "title": "Animals - Radio Edit",
+      "year": 2013,
+      "isrc": "NLZ541300467",
+      "uri": "spotify:track:4g6m1iaAsgdgDqgxGtvY0C",
+      "uri_apple_music": "applemusic://track/1670593168",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1670593168"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2102633427",
+      "fun_fact": "“Animals - Radio Edit” appears on Martin Garrix’s release “Animals”.",
+      "fun_fact_de": "„Animals - Radio Edit“ erschien auf der Veröffentlichung „Animals“ von Martin Garrix.",
+      "fun_fact_es": "«Animals - Radio Edit» aparece en el lanzamiento «Animals» de Martin Garrix.",
+      "fun_fact_fr": "« Animals - Radio Edit » figure sur la publication « Animals » de Martin Garrix.",
+      "fun_fact_nl": "‘Animals - Radio Edit’ staat op de release ‘Animals’ van Martin Garrix.",
+      "alt_artists": [
+        "Eric Prydz",
+        "Porter Robinson, Madeon",
+        "Axwell, Sebastian Ingrosso, Steve Angello, Laidback Luke, Deborah Cox"
+      ]
+    },
+    {
+      "artist": "Age Of Love, Charlotte de Witte, Enrico Sangiuliano",
+      "title": "The Age Of Love (Charlotte de Witte & Enrico Sangiuliano Remix)",
+      "year": 2021,
+      "isrc": "BEN582100782",
+      "uri": "spotify:track:6R84ZlQF7gGkPB6o3GLZXB",
+      "uri_apple_music": "applemusic://track/1643744154",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1643744154"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1902369227",
+      "fun_fact": "“The Age Of Love (Charlotte de Witte & Enrico Sangiuliano Remix)” is the title track of Age Of Love’s release of the same name.",
+      "fun_fact_de": "„The Age Of Love (Charlotte de Witte & Enrico Sangiuliano Remix)“ ist der Titelsong der gleichnamigen Veröffentlichung von Age Of Love.",
+      "fun_fact_es": "«The Age Of Love (Charlotte de Witte & Enrico Sangiuliano Remix)» es la canción que da título al lanzamiento homónimo de Age Of Love.",
+      "fun_fact_fr": "« The Age Of Love (Charlotte de Witte & Enrico Sangiuliano Remix) » est le morceau-titre de la publication éponyme de Age Of Love.",
+      "fun_fact_nl": "‘The Age Of Love (Charlotte de Witte & Enrico Sangiuliano Remix)’ is het titelnummer van de gelijknamige release van Age Of Love.",
+      "alt_artists": [
+        "Pitbull, AFROJACK, Ne-Yo, Nayer",
+        "The Chainsmokers, ROZES",
+        "Jonas Blue, Dakota"
+      ]
+    },
+    {
+      "artist": "Avicii, Nicky Romero",
+      "title": "I Could Be The One (Avicii Vs. Nicky Romero) - Radio Edit",
+      "year": 2012,
+      "isrc": "SEUM71201601",
+      "uri": "spotify:track:1sh6lL6cmlcwhqZKGiKBua",
+      "uri_apple_music": "applemusic://track/1807714128",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1807714128"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/63017512",
+      "fun_fact": "“I Could Be The One (Avicii Vs. Nicky Romero) - Radio Edit” appears on Avicii’s release “I Could Be The One [Avicii vs Nicky Romero]”.",
+      "fun_fact_de": "„I Could Be The One (Avicii Vs. Nicky Romero) - Radio Edit“ erschien auf der Veröffentlichung „I Could Be The One [Avicii vs Nicky Romero]“ von Avicii.",
+      "fun_fact_es": "«I Could Be The One (Avicii Vs. Nicky Romero) - Radio Edit» aparece en el lanzamiento «I Could Be The One [Avicii vs Nicky Romero]» de Avicii.",
+      "fun_fact_fr": "« I Could Be The One (Avicii Vs. Nicky Romero) - Radio Edit » figure sur la publication « I Could Be The One [Avicii vs Nicky Romero] » de Avicii.",
+      "fun_fact_nl": "‘I Could Be The One (Avicii Vs. Nicky Romero) - Radio Edit’ staat op de release ‘I Could Be The One [Avicii vs Nicky Romero]’ van Avicii.",
+      "alt_artists": [
+        "Marshmello, Khalid",
+        "Kesha",
+        "Motorcycle"
+      ]
+    },
+    {
+      "artist": "Eric Prydz",
+      "title": "Opus",
+      "year": 2015,
+      "isrc": "GB6CM1500105",
+      "uri": "spotify:track:3v2oAQomhOcYCPPHafS3KV",
+      "uri_apple_music": "applemusic://track/1440851025",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1440851025"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/118585342",
+      "fun_fact": "“Opus” is the title track of Eric Prydz’s release of the same name.",
+      "fun_fact_de": "„Opus“ ist der Titelsong der gleichnamigen Veröffentlichung von Eric Prydz.",
+      "fun_fact_es": "«Opus» es la canción que da título al lanzamiento homónimo de Eric Prydz.",
+      "fun_fact_fr": "« Opus » est le morceau-titre de la publication éponyme de Eric Prydz.",
+      "fun_fact_nl": "‘Opus’ is het titelnummer van de gelijknamige release van Eric Prydz.",
+      "alt_artists": [
+        "TOESUP, Che Ree",
+        "AFROJACK, Martin Garrix",
+        "Dimitri Vegas & Like Mike, Wolfpack"
+      ]
+    },
+    {
+      "artist": "Swedish House Mafia, Pharrell Williams",
+      "title": "One (Your Name) - Radio Edit",
+      "year": 2010,
+      "isrc": "GBAAA1000165",
+      "uri": "spotify:track:1qZMPmpD1jDcOA7gZ6TCde",
+      "uri_apple_music": "applemusic://track/6798740071",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/6798740071"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/6588199",
+      "fun_fact": "“One (Your Name) - Radio Edit” appears on Swedish House Mafia’s release “One (Your Name)”.",
+      "fun_fact_de": "„One (Your Name) - Radio Edit“ erschien auf der Veröffentlichung „One (Your Name)“ von Swedish House Mafia.",
+      "fun_fact_es": "«One (Your Name) - Radio Edit» aparece en el lanzamiento «One (Your Name)» de Swedish House Mafia.",
+      "fun_fact_fr": "« One (Your Name) - Radio Edit » figure sur la publication « One (Your Name) » de Swedish House Mafia.",
+      "fun_fact_nl": "‘One (Your Name) - Radio Edit’ staat op de release ‘One (Your Name)’ van Swedish House Mafia.",
+      "alt_artists": [
+        "Showtek, We Are Loud, Sonny Wilson",
+        "Guru Josh Project",
+        "MNEK, Zara Larsson"
+      ]
+    },
+    {
+      "artist": "Alesso, Matthew Koma",
+      "title": "Years - Radio Edit",
+      "year": 2012,
+      "isrc": "GBJ4B1200099",
+      "uri": "spotify:track:2KrHwwnKAfSDdOStftigJm",
+      "uri_apple_music": "applemusic://track/1445170865",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1445170865"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/60906179",
+      "fun_fact": "“Years - Radio Edit” appears on Alesso’s release “Years”.",
+      "fun_fact_de": "„Years - Radio Edit“ erschien auf der Veröffentlichung „Years“ von Alesso.",
+      "fun_fact_es": "«Years - Radio Edit» aparece en el lanzamiento «Years» de Alesso.",
+      "fun_fact_fr": "« Years - Radio Edit » figure sur la publication « Years » de Alesso.",
+      "fun_fact_nl": "‘Years - Radio Edit’ staat op de release ‘Years’ van Alesso.",
+      "alt_artists": [
+        "DJ Snake, LAUV",
+        "Martin Garrix, David Guetta, Jamie Scott, Romy Dya",
+        "Seven Lions, Myon, Shane 54, Tove Lo"
+      ]
+    },
+    {
+      "artist": "Paul Kalkbrenner, Fritz Kalkbrenner",
+      "title": "Sky and Sand",
+      "year": 2013,
+      "isrc": "DENZ71300061",
+      "uri": "spotify:track:3ZSqMer9RLSglvi18bWXYV",
+      "uri_apple_music": "applemusic://track/1496030525",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1496030525"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1761983427",
+      "fun_fact": "“Sky and Sand” appears on Paul Kalkbrenner’s release “Berlin Calling (The Soundtrack by Paul Kalkbrenner)”.",
+      "fun_fact_de": "„Sky and Sand“ erschien auf der Veröffentlichung „Berlin Calling (The Soundtrack by Paul Kalkbrenner)“ von Paul Kalkbrenner.",
+      "fun_fact_es": "«Sky and Sand» aparece en el lanzamiento «Berlin Calling (The Soundtrack by Paul Kalkbrenner)» de Paul Kalkbrenner.",
+      "fun_fact_fr": "« Sky and Sand » figure sur la publication « Berlin Calling (The Soundtrack by Paul Kalkbrenner) » de Paul Kalkbrenner.",
+      "fun_fact_nl": "‘Sky and Sand’ staat op de release ‘Berlin Calling (The Soundtrack by Paul Kalkbrenner)’ van Paul Kalkbrenner.",
+      "alt_artists": [
+        "Major Lazer, DJ Snake, MØ",
+        "Chase & Status, Bou, Flowdan, IRAH, Trigga, Takura",
+        "Axwell /\\ Ingrosso"
+      ]
+    },
+    {
+      "artist": "Armin van Buuren, Susana",
+      "title": "Shivers",
+      "year": 2005,
+      "isrc": "NLF711903264",
+      "uri": "spotify:track:1arwrSldUFx3QJsdHdytgI",
+      "uri_apple_music": "applemusic://track/78991465",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/78991465"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/655849042",
+      "fun_fact": "“Shivers” appears on Armin van Buuren’s release “Live at Tomorrowland Winter 2019”.",
+      "fun_fact_de": "„Shivers“ erschien auf der Veröffentlichung „Live at Tomorrowland Winter 2019“ von Armin van Buuren.",
+      "fun_fact_es": "«Shivers» aparece en el lanzamiento «Live at Tomorrowland Winter 2019» de Armin van Buuren.",
+      "fun_fact_fr": "« Shivers » figure sur la publication « Live at Tomorrowland Winter 2019 » de Armin van Buuren.",
+      "fun_fact_nl": "‘Shivers’ staat op de release ‘Live at Tomorrowland Winter 2019’ van Armin van Buuren.",
+      "alt_artists": [
+        "Alan Walker, Au/Ra, Tomine Harket",
+        "Swedish House Mafia",
+        "Ivan Gough, Feenixpawl, Georgi Kay, Axwell"
+      ]
+    },
+    {
+      "artist": "Martin Garrix, DubVision, Shaun Farrugia",
+      "title": "Starlight (Keep Me Afloat)",
+      "year": 2022,
+      "isrc": "NLM5S2201663",
+      "uri": "spotify:track:4UQy41kC5LjzwQuiuWOpwA",
+      "uri_apple_music": "applemusic://track/1621522791",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1621522791"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1717051137",
+      "fun_fact": "“Starlight (Keep Me Afloat)” is the title track of Martin Garrix’s release of the same name.",
+      "fun_fact_de": "„Starlight (Keep Me Afloat)“ ist der Titelsong der gleichnamigen Veröffentlichung von Martin Garrix.",
+      "fun_fact_es": "«Starlight (Keep Me Afloat)» es la canción que da título al lanzamiento homónimo de Martin Garrix.",
+      "fun_fact_fr": "« Starlight (Keep Me Afloat) » est le morceau-titre de la publication éponyme de Martin Garrix.",
+      "fun_fact_nl": "‘Starlight (Keep Me Afloat)’ is het titelnummer van de gelijknamige release van Martin Garrix.",
+      "alt_artists": [
+        "Jonas Blue, Dakota",
+        "Disco Lines, Tinashe",
+        "FISHER"
+      ]
+    },
+    {
+      "artist": "Kevin de Vries, Mau P",
+      "title": "Metro",
+      "year": 2023,
+      "isrc": "DEEC33501145",
+      "uri": "spotify:track:1YWLrDcr0yl0GfeDvuGX1z",
+      "uri_apple_music": "applemusic://track/1719003437",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1719003437"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2563894272",
+      "fun_fact": "“Metro” is the title track of Kevin de Vries’s release of the same name.",
+      "fun_fact_de": "„Metro“ ist der Titelsong der gleichnamigen Veröffentlichung von Kevin de Vries.",
+      "fun_fact_es": "«Metro» es la canción que da título al lanzamiento homónimo de Kevin de Vries.",
+      "fun_fact_fr": "« Metro » est le morceau-titre de la publication éponyme de Kevin de Vries.",
+      "fun_fact_nl": "‘Metro’ is het titelnummer van de gelijknamige release van Kevin de Vries.",
+      "alt_artists": [
+        "Galantis",
+        "Oliver Heldens, Becky Hill",
+        "Zedd, Alessia Cara"
+      ]
+    },
+    {
+      "artist": "Dimitri Vegas & Like Mike, Ummet Ozcan",
+      "title": "The Hum",
+      "year": 2015,
+      "isrc": "BEK011500126",
+      "uri": "spotify:track:6TT3UM1MBSQwQilMAteDvJ",
+      "uri_apple_music": "applemusic://track/1383671386",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1383671386"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2100387047",
+      "fun_fact": "“The Hum” is the title track of Dimitri Vegas & Like Mike’s release of the same name.",
+      "fun_fact_de": "„The Hum“ ist der Titelsong der gleichnamigen Veröffentlichung von Dimitri Vegas & Like Mike.",
+      "fun_fact_es": "«The Hum» es la canción que da título al lanzamiento homónimo de Dimitri Vegas & Like Mike.",
+      "fun_fact_fr": "« The Hum » est le morceau-titre de la publication éponyme de Dimitri Vegas & Like Mike.",
+      "fun_fact_nl": "‘The Hum’ is het titelnummer van de gelijknamige release van Dimitri Vegas & Like Mike.",
+      "alt_artists": [
+        "RÜFÜS DU SOL",
+        "GIGI D'AGOSTINO",
+        "Jack Ü, Skrillex, Diplo, Justin Bieber"
+      ]
+    },
+    {
+      "artist": "Coldplay, Hardwell",
+      "title": "A Sky Full of Stars - Hardwell Remix",
+      "year": 2014,
+      "isrc": "GBAYE1400990",
+      "uri": "spotify:track:0WZVGXO8FYpK8v1IDxlOyE",
+      "uri_apple_music": "applemusic://track/945235020",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/945235020"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/90760041",
+      "fun_fact": "“A Sky Full of Stars - Hardwell Remix” is the title track of Coldplay’s release of the same name.",
+      "fun_fact_de": "„A Sky Full of Stars - Hardwell Remix“ ist der Titelsong der gleichnamigen Veröffentlichung von Coldplay.",
+      "fun_fact_es": "«A Sky Full of Stars - Hardwell Remix» es la canción que da título al lanzamiento homónimo de Coldplay.",
+      "fun_fact_fr": "« A Sky Full of Stars - Hardwell Remix » est le morceau-titre de la publication éponyme de Coldplay.",
+      "fun_fact_nl": "‘A Sky Full of Stars - Hardwell Remix’ is het titelnummer van de gelijknamige release van Coldplay.",
+      "alt_artists": [
+        "Disclosure, Eliza Doolittle, Flume",
+        "Daft Punk",
+        "Guru Josh Project"
+      ]
+    },
+    {
+      "artist": "Argy, Omnya",
+      "title": "Aria",
+      "year": 2023,
+      "isrc": "DEEC31810498",
+      "uri": "spotify:track:1o2WYr42HrIoR38WhMy4p6",
+      "uri_apple_music": "applemusic://track/1719003750",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1719003750"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2563894342",
+      "fun_fact": "“Aria” is the title track of Argy’s release of the same name.",
+      "fun_fact_de": "„Aria“ ist der Titelsong der gleichnamigen Veröffentlichung von Argy.",
+      "fun_fact_es": "«Aria» es la canción que da título al lanzamiento homónimo de Argy.",
+      "fun_fact_fr": "« Aria » est le morceau-titre de la publication éponyme de Argy.",
+      "fun_fact_nl": "‘Aria’ is het titelnummer van de gelijknamige release van Argy.",
+      "alt_artists": [
+        "Disclosure, Sam Smith",
+        "Marshmello, Khalid",
+        "Dimitri Vegas & Like Mike, Wolfpack"
+      ]
+    },
+    {
+      "artist": "Dimitri Vangelis & Wyman, Steve Angello",
+      "title": "Payback",
+      "year": 2015,
+      "isrc": "USYBL1500021",
+      "uri": "spotify:track:34XFgPp7wnmLSE4w8UNC7I",
+      "uri_apple_music": "applemusic://track/968887508",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/968887508"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/95702698",
+      "fun_fact": "“Payback” is the title track of Dimitri Vangelis & Wyman’s release of the same name.",
+      "fun_fact_de": "„Payback“ ist der Titelsong der gleichnamigen Veröffentlichung von Dimitri Vangelis & Wyman.",
+      "fun_fact_es": "«Payback» es la canción que da título al lanzamiento homónimo de Dimitri Vangelis & Wyman.",
+      "fun_fact_fr": "« Payback » est le morceau-titre de la publication éponyme de Dimitri Vangelis & Wyman.",
+      "fun_fact_nl": "‘Payback’ is het titelnummer van de gelijknamige release van Dimitri Vangelis & Wyman.",
+      "alt_artists": [
+        "Hardwell",
+        "David Guetta, Ne-Yo, Akon",
+        "Robin Schulz, James Blunt"
+      ]
+    },
+    {
+      "artist": "The Temper Trap, ARTBAT",
+      "title": "Sweet Disposition - ARTBAT Remix",
+      "year": 2009,
+      "isrc": "US38Y2529365",
+      "uri": "spotify:track:0NInmbZliZg9hCrw5HgDuf",
+      "uri_apple_music": "applemusic://track/1806341361",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1806341361"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3308851591",
+      "fun_fact": "“Sweet Disposition - ARTBAT Remix” is the title track of The Temper Trap’s release of the same name.",
+      "fun_fact_de": "„Sweet Disposition - ARTBAT Remix“ ist der Titelsong der gleichnamigen Veröffentlichung von The Temper Trap.",
+      "fun_fact_es": "«Sweet Disposition - ARTBAT Remix» es la canción que da título al lanzamiento homónimo de The Temper Trap.",
+      "fun_fact_fr": "« Sweet Disposition - ARTBAT Remix » est le morceau-titre de la publication éponyme de The Temper Trap.",
+      "fun_fact_nl": "‘Sweet Disposition - ARTBAT Remix’ is het titelnummer van de gelijknamige release van The Temper Trap.",
+      "alt_artists": [
+        "David Guetta, USHER",
+        "Tiësto, KSHMR, VASSY",
+        "Swedish House Mafia, Pharrell Williams"
+      ]
+    },
+    {
+      "artist": "Adam Port, Stryv, Keinemusik, Orso, Malachiii",
+      "title": "Move",
+      "year": 2024,
+      "isrc": "DEEC33501508",
+      "uri": "spotify:track:1BJJbSX6muJVF2AK7uH1x4",
+      "uri_apple_music": "applemusic://track/1749043132",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1749043132"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2823893032",
+      "fun_fact": "“Move” is the title track of Adam Port’s release of the same name.",
+      "fun_fact_de": "„Move“ ist der Titelsong der gleichnamigen Veröffentlichung von Adam Port.",
+      "fun_fact_es": "«Move» es la canción que da título al lanzamiento homónimo de Adam Port.",
+      "fun_fact_fr": "« Move » est le morceau-titre de la publication éponyme de Adam Port.",
+      "fun_fact_nl": "‘Move’ is het titelnummer van de gelijknamige release van Adam Port.",
+      "alt_artists": [
+        "Martin Garrix, Bebe Rexha",
+        "Alan Walker, Noah Cyrus, Digital Farm Animals, Juliander",
+        "The Chainsmokers, Phoebe Ryan"
+      ]
+    },
+    {
+      "artist": "Dimitri Vegas & Like Mike, Wolfpack",
+      "title": "Ocarina",
+      "year": 2013,
+      "isrc": "BEK011500129",
+      "uri": "spotify:track:52zeJeJrFqKmJBc4FK6767",
+      "uri_apple_music": "applemusic://track/1103179956",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1103179956"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3450137621",
+      "fun_fact": "“Ocarina” is the title track of Dimitri Vegas & Like Mike’s release of the same name.",
+      "fun_fact_de": "„Ocarina“ ist der Titelsong der gleichnamigen Veröffentlichung von Dimitri Vegas & Like Mike.",
+      "fun_fact_es": "«Ocarina» es la canción que da título al lanzamiento homónimo de Dimitri Vegas & Like Mike.",
+      "fun_fact_fr": "« Ocarina » est le morceau-titre de la publication éponyme de Dimitri Vegas & Like Mike.",
+      "fun_fact_nl": "‘Ocarina’ is het titelnummer van de gelijknamige release van Dimitri Vegas & Like Mike.",
+      "alt_artists": [
+        "Lana Del Rey, Cedric Gervais",
+        "Marshmello",
+        "Armin van Buuren, Susana"
+      ]
+    },
+    {
+      "artist": "David Guetta, Kid Cudi",
+      "title": "Memories (feat. Kid Cudi)",
+      "year": 2009,
+      "isrc": "FRZID0900480",
+      "uri": "spotify:track:7fLzbEOBOae9lUnOwr7Tse",
+      "uri_apple_music": "applemusic://track/726149086",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/726149086"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/5400243",
+      "fun_fact": "“Memories (feat. Kid Cudi)” is the title track of David Guetta’s release of the same name.",
+      "fun_fact_de": "„Memories (feat. Kid Cudi)“ ist der Titelsong der gleichnamigen Veröffentlichung von David Guetta.",
+      "fun_fact_es": "«Memories (feat. Kid Cudi)» es la canción que da título al lanzamiento homónimo de David Guetta.",
+      "fun_fact_fr": "« Memories (feat. Kid Cudi) » est le morceau-titre de la publication éponyme de David Guetta.",
+      "fun_fact_nl": "‘Memories (feat. Kid Cudi)’ is het titelnummer van de gelijknamige release van David Guetta.",
+      "alt_artists": [
+        "Deorro",
+        "Calvin Harris, Alesso, Hurts",
+        "Lost Frequencies, Bastille"
+      ]
+    },
+    {
+      "artist": "Anyma, Chris Avantgarde",
+      "title": "Eternity",
+      "year": 2023,
+      "isrc": "DEEC33500935",
+      "uri": "spotify:track:1GBBbKOarAJ38HwIfLcOji",
+      "uri_apple_music": "applemusic://track/1698793878",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1698793878"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2395987895",
+      "fun_fact": "“Eternity” appears on Anyma’s release “Genesys”.",
+      "fun_fact_de": "„Eternity“ erschien auf der Veröffentlichung „Genesys“ von Anyma.",
+      "fun_fact_es": "«Eternity» aparece en el lanzamiento «Genesys» de Anyma.",
+      "fun_fact_fr": "« Eternity » figure sur la publication « Genesys » de Anyma.",
+      "fun_fact_nl": "‘Eternity’ staat op de release ‘Genesys’ van Anyma.",
+      "alt_artists": [
+        "Avicii",
+        "Krewella",
+        "Jonas Blue, Jack & Jack"
+      ]
+    },
+    {
+      "artist": "Ivan Gough, Feenixpawl, Georgi Kay, Axwell",
+      "title": "In My Mind - Axwell Mix",
+      "year": 2012,
+      "isrc": "GBKCF1200198",
+      "uri": "spotify:track:66WnR5Qn3EPZTyBI9pqwlz",
+      "uri_apple_music": "applemusic://track/1628083605",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1628083605"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/18063173",
+      "fun_fact": "“In My Mind - Axwell Mix” appears on Ivan Gough’s release “Club Life: Vol. Two Miami”.",
+      "fun_fact_de": "„In My Mind - Axwell Mix“ erschien auf der Veröffentlichung „Club Life: Vol. Two Miami“ von Ivan Gough.",
+      "fun_fact_es": "«In My Mind - Axwell Mix» aparece en el lanzamiento «Club Life: Vol. Two Miami» de Ivan Gough.",
+      "fun_fact_fr": "« In My Mind - Axwell Mix » figure sur la publication « Club Life: Vol. Two Miami » de Ivan Gough.",
+      "fun_fact_nl": "‘In My Mind - Axwell Mix’ staat op de release ‘Club Life: Vol. Two Miami’ van Ivan Gough.",
+      "alt_artists": [
+        "Oliver Heldens, Becky Hill",
+        "Martin Garrix, DubVision, Shaun Farrugia",
+        "Coldplay, Hardwell"
+      ]
+    },
+    {
+      "artist": "Kölsch",
+      "title": "Grey",
+      "year": 2016,
+      "isrc": "DEU671600219",
+      "uri": "spotify:track:4rjA5kJJWbwU1prXCvg6Fk",
+      "uri_apple_music": "applemusic://track/1145032280",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1145032280"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/132972756",
+      "fun_fact": "“Grey” appears on Kölsch’s release “Speicher 93”.",
+      "fun_fact_de": "„Grey“ erschien auf der Veröffentlichung „Speicher 93“ von Kölsch.",
+      "fun_fact_es": "«Grey» aparece en el lanzamiento «Speicher 93» de Kölsch.",
+      "fun_fact_fr": "« Grey » figure sur la publication « Speicher 93 » de Kölsch.",
+      "fun_fact_nl": "‘Grey’ staat op de release ‘Speicher 93’ van Kölsch.",
+      "alt_artists": [
+        "Daft Punk",
+        "Tiësto, KSHMR, VASSY",
+        "Skrillex"
+      ]
+    },
+    {
+      "artist": "Swedish House Mafia",
+      "title": "Greyhound",
+      "year": 2012,
+      "isrc": "GBAAA1200389",
+      "uri": "spotify:track:0VffaI2jwQknRrxpECYHsF",
+      "uri_apple_music": "applemusic://track/1021729324",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1021729324"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/61427200",
+      "fun_fact": "“Greyhound” appears on Swedish House Mafia’s release “Until Now”.",
+      "fun_fact_de": "„Greyhound“ erschien auf der Veröffentlichung „Until Now“ von Swedish House Mafia.",
+      "fun_fact_es": "«Greyhound» aparece en el lanzamiento «Until Now» de Swedish House Mafia.",
+      "fun_fact_fr": "« Greyhound » figure sur la publication « Until Now » de Swedish House Mafia.",
+      "fun_fact_nl": "‘Greyhound’ staat op de release ‘Until Now’ van Swedish House Mafia.",
+      "alt_artists": [
+        "Alesso",
+        "David Guetta, Sam Martin",
+        "The Chainsmokers, ILLENIUM, Lennon Stella"
+      ]
+    },
+    {
+      "artist": "Hardwell, Amba Shepherd",
+      "title": "Apollo",
+      "year": 2012,
+      "isrc": "NLS241202273",
+      "uri": "spotify:track:7EdxI2Yro4AW2HH3akwqms",
+      "uri_apple_music": "applemusic://track/1649195190",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1649195190"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1818069397",
+      "fun_fact": "“Apollo” is the title track of Hardwell’s release of the same name.",
+      "fun_fact_de": "„Apollo“ ist der Titelsong der gleichnamigen Veröffentlichung von Hardwell.",
+      "fun_fact_es": "«Apollo» es la canción que da título al lanzamiento homónimo de Hardwell.",
+      "fun_fact_fr": "« Apollo » est le morceau-titre de la publication éponyme de Hardwell.",
+      "fun_fact_nl": "‘Apollo’ is het titelnummer van de gelijknamige release van Hardwell.",
+      "alt_artists": [
+        "GIGI D'AGOSTINO",
+        "Féa",
+        "Kaskade, deadmau5"
+      ]
+    },
+    {
+      "artist": "Lost Frequencies, Andromedik, Bonn",
+      "title": "The Feeling - Lost Frequencies & Andromedik Deluxe Mix",
+      "year": 2023,
+      "isrc": "BEHP42300022",
+      "uri": "spotify:track:3rFHJDslBgt9rHu8p22aFN",
+      "uri_apple_music": "applemusic://track/1734865606",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1734865606"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2390031045",
+      "fun_fact": "“The Feeling - Lost Frequencies & Andromedik Deluxe Mix” appears on Lost Frequencies’s release “The Feeling (Remix Pack)”.",
+      "fun_fact_de": "„The Feeling - Lost Frequencies & Andromedik Deluxe Mix“ erschien auf der Veröffentlichung „The Feeling (Remix Pack)“ von Lost Frequencies.",
+      "fun_fact_es": "«The Feeling - Lost Frequencies & Andromedik Deluxe Mix» aparece en el lanzamiento «The Feeling (Remix Pack)» de Lost Frequencies.",
+      "fun_fact_fr": "« The Feeling - Lost Frequencies & Andromedik Deluxe Mix » figure sur la publication « The Feeling (Remix Pack) » de Lost Frequencies.",
+      "fun_fact_nl": "‘The Feeling - Lost Frequencies & Andromedik Deluxe Mix’ staat op de release ‘The Feeling (Remix Pack)’ van Lost Frequencies.",
+      "alt_artists": [
+        "Donna Summer",
+        "Sandro Silva, Quintino",
+        "Dimitri Vegas & Like Mike, Wolfpack"
+      ]
+    },
+    {
+      "artist": "DVBBS, Borgeous, Tinie Tempah",
+      "title": "Tsunami (Jump) [feat. Tinie Tempah] - Radio Edit",
+      "year": 2013,
+      "isrc": "GBCEN1301227",
+      "uri": "spotify:track:2NFrkgZzweWIiC9tUrjDnx",
+      "uri_apple_music": "applemusic://track/1835100450",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1835100450"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/76411968",
+      "fun_fact": "“Tsunami (Jump) [feat. Tinie Tempah] - Radio Edit” appears on DVBBS’s release “Demonstration”.",
+      "fun_fact_de": "„Tsunami (Jump) [feat. Tinie Tempah] - Radio Edit“ erschien auf der Veröffentlichung „Demonstration“ von DVBBS.",
+      "fun_fact_es": "«Tsunami (Jump) [feat. Tinie Tempah] - Radio Edit» aparece en el lanzamiento «Demonstration» de DVBBS.",
+      "fun_fact_fr": "« Tsunami (Jump) [feat. Tinie Tempah] - Radio Edit » figure sur la publication « Demonstration » de DVBBS.",
+      "fun_fact_nl": "‘Tsunami (Jump) [feat. Tinie Tempah] - Radio Edit’ staat op de release ‘Demonstration’ van DVBBS.",
+      "alt_artists": [
+        "Flux Pavilion",
+        "Daft Punk",
+        "MNEK, Zara Larsson"
+      ]
+    },
+    {
+      "artist": "Dada Life",
+      "title": "Kick Out The Epic Motherf**ker - Radio Edit",
+      "year": 2012,
+      "isrc": "SEUM71200334",
+      "uri": "spotify:track:6mt43avikV8g00AXCyOkS1",
+      "uri_apple_music": "applemusic://track/1444332710",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1444332710"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/61037315",
+      "fun_fact": "“Kick Out The Epic Motherf**ker - Radio Edit” appears on Dada Life’s release “The Rules Of Dada”.",
+      "fun_fact_de": "„Kick Out The Epic Motherf**ker - Radio Edit“ erschien auf der Veröffentlichung „The Rules Of Dada“ von Dada Life.",
+      "fun_fact_es": "«Kick Out The Epic Motherf**ker - Radio Edit» aparece en el lanzamiento «The Rules Of Dada» de Dada Life.",
+      "fun_fact_fr": "« Kick Out The Epic Motherf**ker - Radio Edit » figure sur la publication « The Rules Of Dada » de Dada Life.",
+      "fun_fact_nl": "‘Kick Out The Epic Motherf**ker - Radio Edit’ staat op de release ‘The Rules Of Dada’ van Dada Life.",
+      "alt_artists": [
+        "David Guetta, Ne-Yo, Akon",
+        "Sigala, Bryn Christopher",
+        "Kungs, Cookin' On 3 Burners"
+      ]
+    },
+    {
+      "artist": "Axwell, Sebastian Ingrosso, Steve Angello, Laidback Luke, Deborah Cox",
+      "title": "Leave The World Behind - Radio Edit",
+      "year": 2009,
+      "isrc": "GBKCF0900084",
+      "uri": "spotify:track:25ZEYUgCJyf3gRxkqYbkIc",
+      "uri_apple_music": "applemusic://track/626280123",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/626280123"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/73460627",
+      "fun_fact": "“Leave The World Behind - Radio Edit” appears on Axwell’s release “Leave The World Behind”.",
+      "fun_fact_de": "„Leave The World Behind - Radio Edit“ erschien auf der Veröffentlichung „Leave The World Behind“ von Axwell.",
+      "fun_fact_es": "«Leave The World Behind - Radio Edit» aparece en el lanzamiento «Leave The World Behind» de Axwell.",
+      "fun_fact_fr": "« Leave The World Behind - Radio Edit » figure sur la publication « Leave The World Behind » de Axwell.",
+      "fun_fact_nl": "‘Leave The World Behind - Radio Edit’ staat op de release ‘Leave The World Behind’ van Axwell.",
+      "alt_artists": [
+        "ZHU",
+        "Robin Schulz, James Blunt",
+        "DJ Snake, Bipolar Sunshine"
+      ]
+    },
+    {
+      "artist": "Dimitri Vegas & Like Mike, Tiësto, Dido, W&W, Dimitri Vegas, Like Mike",
+      "title": "Thank You (Not So Bad)",
+      "year": 2023,
+      "isrc": "GBARL2301712",
+      "uri": "spotify:track:09CnYHiZ5jGT1wr1TXJ9Zt",
+      "uri_apple_music": "applemusic://track/1782126187",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1782126187"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2545396411",
+      "fun_fact": "“Thank You (Not So Bad)” is the title track of Dimitri Vegas & Like Mike’s release of the same name.",
+      "fun_fact_de": "„Thank You (Not So Bad)“ ist der Titelsong der gleichnamigen Veröffentlichung von Dimitri Vegas & Like Mike.",
+      "fun_fact_es": "«Thank You (Not So Bad)» es la canción que da título al lanzamiento homónimo de Dimitri Vegas & Like Mike.",
+      "fun_fact_fr": "« Thank You (Not So Bad) » est le morceau-titre de la publication éponyme de Dimitri Vegas & Like Mike.",
+      "fun_fact_nl": "‘Thank You (Not So Bad)’ is het titelnummer van de gelijknamige release van Dimitri Vegas & Like Mike.",
+      "alt_artists": [
+        "David Guetta, Kelly Rowland",
+        "Avicii, Rita Ora",
+        "Disco Lines, Tinashe"
+      ]
+    },
+    {
+      "artist": "DubVision",
+      "title": "Turn It Around",
+      "year": 2014,
+      "isrc": "NLZ541400760",
+      "uri": "spotify:track:6VkMHPcFlxyApzWgEYP6IH",
+      "uri_apple_music": "applemusic://track/1411669346",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1411669346"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/468826652",
+      "fun_fact": "“Turn It Around” is the title track of DubVision’s release of the same name.",
+      "fun_fact_de": "„Turn It Around“ ist der Titelsong der gleichnamigen Veröffentlichung von DubVision.",
+      "fun_fact_es": "«Turn It Around» es la canción que da título al lanzamiento homónimo de DubVision.",
+      "fun_fact_fr": "« Turn It Around » est le morceau-titre de la publication éponyme de DubVision.",
+      "fun_fact_nl": "‘Turn It Around’ is het titelnummer van de gelijknamige release van DubVision.",
+      "alt_artists": [
+        "Nightcrawlers, MK",
+        "Dimitri Vangelis & Wyman, Steve Angello",
+        "Zedd, Alessia Cara"
+      ]
+    },
+    {
+      "artist": "Armin van Buuren, Vini Vici, Hilight Tribe",
+      "title": "Great Spirit",
+      "year": 2016,
+      "isrc": "NLF711609190",
+      "uri": "spotify:track:3Nku6gLNqnwUuq8GLkqyhW",
+      "uri_apple_music": "applemusic://track/1182472297",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1182472297"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/137311004",
+      "fun_fact": "“Great Spirit” is the title track of Armin van Buuren’s release of the same name.",
+      "fun_fact_de": "„Great Spirit“ ist der Titelsong der gleichnamigen Veröffentlichung von Armin van Buuren.",
+      "fun_fact_es": "«Great Spirit» es la canción que da título al lanzamiento homónimo de Armin van Buuren.",
+      "fun_fact_fr": "« Great Spirit » est le morceau-titre de la publication éponyme de Armin van Buuren.",
+      "fun_fact_nl": "‘Great Spirit’ is het titelnummer van de gelijknamige release van Armin van Buuren.",
+      "alt_artists": [
+        "John Summit, Sub Focus, Julia Church",
+        "Modjo",
+        "Kygo, Selena Gomez"
+      ]
+    },
+    {
+      "artist": "Martin Garrix, Third Party",
+      "title": "Lions in the Wild",
+      "year": 2016,
+      "isrc": "TCACO1667693",
+      "uri": "spotify:track:6lBQ0SMCrJ7zy1LSCuXqwV",
+      "uri_apple_music": "applemusic://track/1293743671",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1293743671"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/415148682",
+      "fun_fact": "“Lions in the Wild” is the title track of Martin Garrix’s release of the same name.",
+      "fun_fact_de": "„Lions in the Wild“ ist der Titelsong der gleichnamigen Veröffentlichung von Martin Garrix.",
+      "fun_fact_es": "«Lions in the Wild» es la canción que da título al lanzamiento homónimo de Martin Garrix.",
+      "fun_fact_fr": "« Lions in the Wild » est le morceau-titre de la publication éponyme de Martin Garrix.",
+      "fun_fact_nl": "‘Lions in the Wild’ is het titelnummer van de gelijknamige release van Martin Garrix.",
+      "alt_artists": [
+        "Swedish House Mafia",
+        "Avicii, Nicky Romero",
+        "Chase & Status, Bou, Flowdan, IRAH, Trigga, Takura"
+      ]
+    },
+    {
+      "artist": "Calvin Harris, Florence Welch",
+      "title": "Sweet Nothing (feat. Florence Welch)",
+      "year": 2012,
+      "isrc": "GBARL1201392",
+      "uri": "spotify:track:24LS4lQShWyixJ0ZrJXfJ5",
+      "uri_apple_music": "applemusic://track/1713469232",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1713469232"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/60977514",
+      "fun_fact": "“Sweet Nothing (feat. Florence Welch)” is the title track of Calvin Harris’s release of the same name.",
+      "fun_fact_de": "„Sweet Nothing (feat. Florence Welch)“ ist der Titelsong der gleichnamigen Veröffentlichung von Calvin Harris.",
+      "fun_fact_es": "«Sweet Nothing (feat. Florence Welch)» es la canción que da título al lanzamiento homónimo de Calvin Harris.",
+      "fun_fact_fr": "« Sweet Nothing (feat. Florence Welch) » est le morceau-titre de la publication éponyme de Calvin Harris.",
+      "fun_fact_nl": "‘Sweet Nothing (feat. Florence Welch)’ is het titelnummer van de gelijknamige release van Calvin Harris.",
+      "alt_artists": [
+        "OMI",
+        "Axwell /\\ Ingrosso",
+        "AFROJACK, Martin Garrix"
+      ]
+    },
+    {
+      "artist": "Fred again.., Swedish House Mafia, Future",
+      "title": "Turn On The Lights again.. (feat. Future)",
+      "year": 2022,
+      "isrc": "GBAHS2201001",
+      "uri": "spotify:track:6gdDu39yYqPcaTgCwYEW8i",
+      "uri_apple_music": "applemusic://track/1635570436",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1635570436"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1832599647",
+      "fun_fact": "“Turn On The Lights again.. (feat. Future)” is the title track of Fred again..’s release of the same name.",
+      "fun_fact_de": "„Turn On The Lights again.. (feat. Future)“ ist der Titelsong der gleichnamigen Veröffentlichung von Fred again...",
+      "fun_fact_es": "«Turn On The Lights again.. (feat. Future)» es la canción que da título al lanzamiento homónimo de Fred again...",
+      "fun_fact_fr": "« Turn On The Lights again.. (feat. Future) » est le morceau-titre de la publication éponyme de Fred again...",
+      "fun_fact_nl": "‘Turn On The Lights again.. (feat. Future)’ is het titelnummer van de gelijknamige release van Fred again...",
+      "alt_artists": [
+        "Martin Garrix",
+        "Baauer",
+        "Armin van Buuren, Susana"
+      ]
+    },
+    {
+      "artist": "Avicii",
+      "title": "Silhouettes - Original Radio Edit",
+      "year": 2012,
+      "isrc": "SEUM71200477",
+      "uri": "spotify:track:06h3McKzmxS8Bx58USHiMq",
+      "uri_apple_music": "applemusic://track/1589148307",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1589148307"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/24276241",
+      "fun_fact": "“Silhouettes - Original Radio Edit” appears on Avicii’s release “Silhouettes”.",
+      "fun_fact_de": "„Silhouettes - Original Radio Edit“ erschien auf der Veröffentlichung „Silhouettes“ von Avicii.",
+      "fun_fact_es": "«Silhouettes - Original Radio Edit» aparece en el lanzamiento «Silhouettes» de Avicii.",
+      "fun_fact_fr": "« Silhouettes - Original Radio Edit » figure sur la publication « Silhouettes » de Avicii.",
+      "fun_fact_nl": "‘Silhouettes - Original Radio Edit’ staat op de release ‘Silhouettes’ van Avicii.",
+      "alt_artists": [
+        "David Guetta, Ne-Yo, Akon",
+        "BICEP",
+        "Ookay"
+      ]
+    },
+    {
+      "artist": "Anyma, Chris Avantgarde",
+      "title": "Consciousness",
+      "year": 2022,
+      "isrc": "DEEC33500555",
+      "uri": "spotify:track:01X6etmb1Cz8ujgwHKQIDl",
+      "uri_apple_music": "applemusic://track/1698794335",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1698794335"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2395988015",
+      "fun_fact": "“Consciousness” appears on Anyma’s release “Genesys”.",
+      "fun_fact_de": "„Consciousness“ erschien auf der Veröffentlichung „Genesys“ von Anyma.",
+      "fun_fact_es": "«Consciousness» aparece en el lanzamiento «Genesys» de Anyma.",
+      "fun_fact_fr": "« Consciousness » figure sur la publication « Genesys » de Anyma.",
+      "fun_fact_nl": "‘Consciousness’ staat op de release ‘Genesys’ van Anyma.",
+      "alt_artists": [
+        "Zedd, Selena Gomez",
+        "Pretty Lights",
+        "Krewella"
+      ]
+    },
+    {
+      "artist": "Delerium, Sarah McLachlan, Tiësto",
+      "title": "Silence (feat. Sarah McLachlan) - DJ Tiësto's in Search of Sunrise Remix",
+      "year": 1999,
+      "isrc": "CAN110000030",
+      "uri": "spotify:track:7tU5JvCfG0t3PHG7mchPjv",
+      "uri_apple_music": "applemusic://track/1444889769",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1444889769"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/69524336",
+      "fun_fact": "“Silence (feat. Sarah McLachlan) - DJ Tiësto's in Search of Sunrise Remix” appears on Delerium’s release “Magik Six (Live in Amsterdam)”.",
+      "fun_fact_de": "„Silence (feat. Sarah McLachlan) - DJ Tiësto's in Search of Sunrise Remix“ erschien auf der Veröffentlichung „Magik Six (Live in Amsterdam)“ von Delerium.",
+      "fun_fact_es": "«Silence (feat. Sarah McLachlan) - DJ Tiësto's in Search of Sunrise Remix» aparece en el lanzamiento «Magik Six (Live in Amsterdam)» de Delerium.",
+      "fun_fact_fr": "« Silence (feat. Sarah McLachlan) - DJ Tiësto's in Search of Sunrise Remix » figure sur la publication « Magik Six (Live in Amsterdam) » de Delerium.",
+      "fun_fact_nl": "‘Silence (feat. Sarah McLachlan) - DJ Tiësto's in Search of Sunrise Remix’ staat op de release ‘Magik Six (Live in Amsterdam)’ van Delerium.",
+      "alt_artists": [
+        "Monoir",
+        "Avicii, Nicky Romero",
+        "Benny Benassi, Gary Go, Skrillex"
+      ]
+    },
+    {
+      "artist": "John Summit, Sub Focus, Julia Church",
+      "title": "Go Back (feat. Julia Church)",
+      "year": 2024,
+      "isrc": "USUG12402628",
+      "uri": "spotify:track:68R0zVUeMJ2C852Ov6d2Mh",
+      "uri_apple_music": "applemusic://track/1745292770",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1745292770"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2789182992",
+      "fun_fact": "“Go Back (feat. Julia Church)” appears on John Summit’s release “Go Back”.",
+      "fun_fact_de": "„Go Back (feat. Julia Church)“ erschien auf der Veröffentlichung „Go Back“ von John Summit.",
+      "fun_fact_es": "«Go Back (feat. Julia Church)» aparece en el lanzamiento «Go Back» de John Summit.",
+      "fun_fact_fr": "« Go Back (feat. Julia Church) » figure sur la publication « Go Back » de John Summit.",
+      "fun_fact_nl": "‘Go Back (feat. Julia Church)’ staat op de release ‘Go Back’ van John Summit.",
+      "alt_artists": [
+        "Edward Maya, Vika Jigulina",
+        "Chrystal, NOTION",
+        "Skrillex"
+      ]
+    },
+    {
+      "artist": "David Guetta vs The Egg",
+      "title": "Love Don't Let Me Go",
+      "year": 2001,
+      "isrc": "FRZID0100200",
+      "uri": "spotify:track:0anH8SKDvQxRVaBBtRyeCz",
+      "uri_apple_music": "applemusic://track/693179192",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/693179192"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3087828",
+      "fun_fact": "“Love Don't Let Me Go” appears on David Guetta vs The Egg’s release “Just a Little More Love”.",
+      "fun_fact_de": "„Love Don't Let Me Go“ erschien auf der Veröffentlichung „Just a Little More Love“ von David Guetta vs The Egg.",
+      "fun_fact_es": "«Love Don't Let Me Go» aparece en el lanzamiento «Just a Little More Love» de David Guetta vs The Egg.",
+      "fun_fact_fr": "« Love Don't Let Me Go » figure sur la publication « Just a Little More Love » de David Guetta vs The Egg.",
+      "fun_fact_nl": "‘Love Don't Let Me Go’ staat op de release ‘Just a Little More Love’ van David Guetta vs The Egg.",
+      "alt_artists": [
+        "Martin Garrix, Bebe Rexha",
+        "Marshmello",
+        "Major Lazer, Nyla, Fuse ODG"
+      ]
+    },
+    {
+      "artist": "Paul van Dyk",
+      "title": "For an Angel",
+      "year": 1994,
+      "isrc": "DEW760900143",
+      "uri": "spotify:track:3PbDqZ1VMsBTjXCbs6Jv7P",
+      "uri_apple_music": "applemusic://track/1463197973",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1463197973"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/678184162",
+      "fun_fact": "“For an Angel” appears on Paul van Dyk’s release “45 RPM”.",
+      "fun_fact_de": "„For an Angel“ erschien auf der Veröffentlichung „45 RPM“ von Paul van Dyk.",
+      "fun_fact_es": "«For an Angel» aparece en el lanzamiento «45 RPM» de Paul van Dyk.",
+      "fun_fact_fr": "« For an Angel » figure sur la publication « 45 RPM » de Paul van Dyk.",
+      "fun_fact_nl": "‘For an Angel’ staat op de release ‘45 RPM’ van Paul van Dyk.",
+      "alt_artists": [
+        "DubVision",
+        "Calvin Harris, Rihanna",
+        "ODESZA, Zyra"
+      ]
+    },
+    {
+      "artist": "Nicky Romero",
+      "title": "Toulouse - Original Edit",
+      "year": 2011,
+      "isrc": "NLC281112345",
+      "uri": "spotify:track:4Zz6VnbuykOejSpGOahS4E",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/466984412",
+      "fun_fact": "“Toulouse - Original Edit” appears on Nicky Romero’s release “Toulouse”.",
+      "fun_fact_de": "„Toulouse - Original Edit“ erschien auf der Veröffentlichung „Toulouse“ von Nicky Romero.",
+      "fun_fact_es": "«Toulouse - Original Edit» aparece en el lanzamiento «Toulouse» de Nicky Romero.",
+      "fun_fact_fr": "« Toulouse - Original Edit » figure sur la publication « Toulouse » de Nicky Romero.",
+      "fun_fact_nl": "‘Toulouse - Original Edit’ staat op de release ‘Toulouse’ van Nicky Romero.",
+      "alt_artists": [
+        "Calvin Harris, Alesso, Hurts",
+        "Galantis",
+        "Major Lazer, Nyla, Fuse ODG"
+      ]
+    },
+    {
+      "artist": "Martin Garrix",
+      "title": "Pizza",
+      "year": 2017,
+      "isrc": "NLM5S1600106",
+      "uri": "spotify:track:5oAgI7Pzg6vxuKrfapg3Pi",
+      "uri_apple_music": "applemusic://track/1272651891",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1272651891"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/395627872",
+      "fun_fact": "“Pizza” is the title track of Martin Garrix’s release of the same name.",
+      "fun_fact_de": "„Pizza“ ist der Titelsong der gleichnamigen Veröffentlichung von Martin Garrix.",
+      "fun_fact_es": "«Pizza» es la canción que da título al lanzamiento homónimo de Martin Garrix.",
+      "fun_fact_fr": "« Pizza » est le morceau-titre de la publication éponyme de Martin Garrix.",
+      "fun_fact_nl": "‘Pizza’ is het titelnummer van de gelijknamige release van Martin Garrix.",
+      "alt_artists": [
+        "Tiësto",
+        "Alesso",
+        "Why Don't We"
+      ]
+    },
+    {
+      "artist": "FISHER",
+      "title": "Losing It - Radio Edit",
+      "year": 2018,
+      "isrc": "CA5KR1821202",
+      "uri": "spotify:track:2KXwJZv1pRQFQ95Kj60jBN",
+      "uri_apple_music": "applemusic://track/1440264030",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1440264030"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/525334532",
+      "fun_fact": "“Losing It - Radio Edit” appears on FISHER’s release “Losing It”.",
+      "fun_fact_de": "„Losing It - Radio Edit“ erschien auf der Veröffentlichung „Losing It“ von FISHER.",
+      "fun_fact_es": "«Losing It - Radio Edit» aparece en el lanzamiento «Losing It» de FISHER.",
+      "fun_fact_fr": "« Losing It - Radio Edit » figure sur la publication « Losing It » de FISHER.",
+      "fun_fact_nl": "‘Losing It - Radio Edit’ staat op de release ‘Losing It’ van FISHER.",
+      "alt_artists": [
+        "Armin van Buuren, Vini Vici, Hilight Tribe",
+        "DVBBS, Borgeous, Tinie Tempah",
+        "Kesha"
+      ]
+    },
+    {
+      "artist": "Tiësto",
+      "title": "Lethal Industry - Radio Edit",
+      "year": 2002,
+      "isrc": "NLE710280422",
+      "uri": "spotify:track:3NfcNWiWysF7aV5b3Jd9CE",
+      "uri_apple_music": "applemusic://track/300442667",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/300442667"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/72097707",
+      "fun_fact": "“Lethal Industry - Radio Edit” appears on Tiësto’s release “Top 25 Trance DJ's 2013”.",
+      "fun_fact_de": "„Lethal Industry - Radio Edit“ erschien auf der Veröffentlichung „Top 25 Trance DJ's 2013“ von Tiësto.",
+      "fun_fact_es": "«Lethal Industry - Radio Edit» aparece en el lanzamiento «Top 25 Trance DJ's 2013» de Tiësto.",
+      "fun_fact_fr": "« Lethal Industry - Radio Edit » figure sur la publication « Top 25 Trance DJ's 2013 » de Tiësto.",
+      "fun_fact_nl": "‘Lethal Industry - Radio Edit’ staat op de release ‘Top 25 Trance DJ's 2013’ van Tiësto.",
+      "alt_artists": [
+        "Sia, Sean Paul",
+        "Florence + The Machine, Calvin Harris",
+        "Flux Pavilion"
+      ]
+    },
+    {
+      "artist": "Kx5, deadmau5, Kaskade, HAYLA",
+      "title": "Escape (feat. Hayla)",
+      "year": 2022,
+      "isrc": "GBTDG1302438",
+      "uri": "spotify:track:3VpxEo6vMpi4rQ6t2WVVkK",
+      "uri_apple_music": "applemusic://track/1610019678",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1610019678"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1899047597",
+      "fun_fact": "“Escape (feat. Hayla)” appears on Kx5’s release “Escape (Remixes)”.",
+      "fun_fact_de": "„Escape (feat. Hayla)“ erschien auf der Veröffentlichung „Escape (Remixes)“ von Kx5.",
+      "fun_fact_es": "«Escape (feat. Hayla)» aparece en el lanzamiento «Escape (Remixes)» de Kx5.",
+      "fun_fact_fr": "« Escape (feat. Hayla) » figure sur la publication « Escape (Remixes) » de Kx5.",
+      "fun_fact_nl": "‘Escape (feat. Hayla)’ staat op de release ‘Escape (Remixes)’ van Kx5.",
+      "alt_artists": [
+        "Jack Ü, Skrillex, Diplo, kai",
+        "Dimitri Vangelis & Wyman, Steve Angello",
+        "Martin Garrix, Bonn"
+      ]
+    },
+    {
+      "artist": "Lost Frequencies, Bastille",
+      "title": "Head Down",
+      "year": 2023,
+      "isrc": "BEHP42300071",
+      "uri": "spotify:track:7v4lL0VxQV8yTv29Tpf2sH",
+      "uri_apple_music": "applemusic://track/1719178165",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1719178165"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2565379842",
+      "fun_fact": "“Head Down” is the title track of Lost Frequencies’s release of the same name.",
+      "fun_fact_de": "„Head Down“ ist der Titelsong der gleichnamigen Veröffentlichung von Lost Frequencies.",
+      "fun_fact_es": "«Head Down» es la canción que da título al lanzamiento homónimo de Lost Frequencies.",
+      "fun_fact_fr": "« Head Down » est le morceau-titre de la publication éponyme de Lost Frequencies.",
+      "fun_fact_nl": "‘Head Down’ is het titelnummer van de gelijknamige release van Lost Frequencies.",
+      "alt_artists": [
+        "Edward Maya, Vika Jigulina",
+        "Kygo, Conrad Sewell",
+        "Ivan Gough, Feenixpawl, Georgi Kay, Axwell"
+      ]
+    },
+    {
+      "artist": "Dimitri Vegas & Like Mike, W&W",
+      "title": "Crowd Control - Radio Edit",
+      "year": 2017,
+      "isrc": "BEG851700011",
+      "uri": "spotify:track:0kdVIAjTAkAFo7dYdciDU1",
+      "uri_apple_music": "applemusic://track/1300111904",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1300111904"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/415201512",
+      "fun_fact": "“Crowd Control - Radio Edit” appears on Dimitri Vegas & Like Mike’s release “Crowd Control”.",
+      "fun_fact_de": "„Crowd Control - Radio Edit“ erschien auf der Veröffentlichung „Crowd Control“ von Dimitri Vegas & Like Mike.",
+      "fun_fact_es": "«Crowd Control - Radio Edit» aparece en el lanzamiento «Crowd Control» de Dimitri Vegas & Like Mike.",
+      "fun_fact_fr": "« Crowd Control - Radio Edit » figure sur la publication « Crowd Control » de Dimitri Vegas & Like Mike.",
+      "fun_fact_nl": "‘Crowd Control - Radio Edit’ staat op de release ‘Crowd Control’ van Dimitri Vegas & Like Mike.",
+      "alt_artists": [
+        "Seven Lions, Myon, Shane 54, Tove Lo",
+        "David Guetta, Avicii",
+        "Disclosure, Eliza Doolittle, Flume"
+      ]
+    },
+    {
+      "artist": "Deorro",
+      "title": "Five Hours",
+      "year": 2014,
+      "isrc": "CH3131340319",
+      "uri": "spotify:track:6r7FXNO57mlZCBY6PXcZZT",
+      "uri_apple_music": "applemusic://track/929911882",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/929911882"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/88210781",
+      "fun_fact": "“Five Hours” is the title track of Deorro’s release of the same name.",
+      "fun_fact_de": "„Five Hours“ ist der Titelsong der gleichnamigen Veröffentlichung von Deorro.",
+      "fun_fact_es": "«Five Hours» es la canción que da título al lanzamiento homónimo de Deorro.",
+      "fun_fact_fr": "« Five Hours » est le morceau-titre de la publication éponyme de Deorro.",
+      "fun_fact_nl": "‘Five Hours’ is het titelnummer van de gelijknamige release van Deorro.",
+      "alt_artists": [
+        "Kevin de Vries, Mau P",
+        "David Guetta, Third Party, John Martin",
+        "The Chainsmokers, ROZES"
+      ]
+    },
+    {
+      "artist": "BICEP",
+      "title": "Glue",
+      "year": 2017,
+      "isrc": "GBCFB1700229",
+      "uri": "spotify:track:2aJDlirz6v2a4HREki98cP",
+      "uri_apple_music": "applemusic://track/1240586502",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1240586502"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/389034231",
+      "fun_fact": "“Glue” is the title track of BICEP’s release of the same name.",
+      "fun_fact_de": "„Glue“ ist der Titelsong der gleichnamigen Veröffentlichung von BICEP.",
+      "fun_fact_es": "«Glue» es la canción que da título al lanzamiento homónimo de BICEP.",
+      "fun_fact_fr": "« Glue » est le morceau-titre de la publication éponyme de BICEP.",
+      "fun_fact_nl": "‘Glue’ is het titelnummer van de gelijknamige release van BICEP.",
+      "alt_artists": [
+        "David Guetta, Kid Cudi",
+        "David Guetta, Bebe Rexha",
+        "Armin van Buuren, Trevor Guthrie"
+      ]
+    },
+    {
+      "artist": "Chase & Status, Bou, Flowdan, IRAH, Trigga, Takura",
+      "title": "Baddadan",
+      "year": 2023,
+      "isrc": "GBUM72306881",
+      "uri": "spotify:track:1Je2XcRT7277XaAFGjjTuP",
+      "uri_apple_music": "applemusic://track/1698551200",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1698551200"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2376304835",
+      "fun_fact": "“Baddadan” is the title track of Chase & Status’s release of the same name.",
+      "fun_fact_de": "„Baddadan“ ist der Titelsong der gleichnamigen Veröffentlichung von Chase & Status.",
+      "fun_fact_es": "«Baddadan» es la canción que da título al lanzamiento homónimo de Chase & Status.",
+      "fun_fact_fr": "« Baddadan » est le morceau-titre de la publication éponyme de Chase & Status.",
+      "fun_fact_nl": "‘Baddadan’ is het titelnummer van de gelijknamige release van Chase & Status.",
+      "alt_artists": [
+        "Sigala, Bryn Christopher",
+        "Kölsch",
+        "Chris Brown"
+      ]
+    },
+    {
+      "artist": "David Guetta, Avicii",
+      "title": "Sunshine",
+      "year": 2011,
+      "isrc": "GB28K1100047",
+      "uri": "spotify:track:0PCRR19Pf4iiuvSrPxtQ0x",
+      "uri_apple_music": "applemusic://track/726391143",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/726391143"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/62847158",
+      "fun_fact": "“Sunshine” appears on David Guetta’s release “Nothing but the Beat (Ultimate Edition)”.",
+      "fun_fact_de": "„Sunshine“ erschien auf der Veröffentlichung „Nothing but the Beat (Ultimate Edition)“ von David Guetta.",
+      "fun_fact_es": "«Sunshine» aparece en el lanzamiento «Nothing but the Beat (Ultimate Edition)» de David Guetta.",
+      "fun_fact_fr": "« Sunshine » figure sur la publication « Nothing but the Beat (Ultimate Edition) » de David Guetta.",
+      "fun_fact_nl": "‘Sunshine’ staat op de release ‘Nothing but the Beat (Ultimate Edition)’ van David Guetta.",
+      "alt_artists": [
+        "The Chainsmokers",
+        "Tiësto, KSHMR, VASSY",
+        "Coldplay, Hardwell"
+      ]
+    },
+    {
+      "artist": "deadmau5",
+      "title": "Strobe - Radio Edit",
+      "year": 2009,
+      "isrc": "GBTDG0900141",
+      "uri": "spotify:track:6c9EGVj5CaOeoKd9ecMW1U",
+      "uri_apple_music": "applemusic://track/1817426864",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1817426864"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/5150304",
+      "fun_fact": "“Strobe - Radio Edit” appears on deadmau5’s release “Strobe”.",
+      "fun_fact_de": "„Strobe - Radio Edit“ erschien auf der Veröffentlichung „Strobe“ von deadmau5.",
+      "fun_fact_es": "«Strobe - Radio Edit» aparece en el lanzamiento «Strobe» de deadmau5.",
+      "fun_fact_fr": "« Strobe - Radio Edit » figure sur la publication « Strobe » de deadmau5.",
+      "fun_fact_nl": "‘Strobe - Radio Edit’ staat op de release ‘Strobe’ van deadmau5.",
+      "alt_artists": [
+        "Nicky Romero",
+        "Flo Rida, Sia",
+        "David Guetta, Skylar Grey"
+      ]
+    },
+    {
+      "artist": "Florence + The Machine, Calvin Harris",
+      "title": "Spectrum (Say My Name) - Calvin Harris Remix",
+      "year": 2011,
+      "isrc": "GBUM71203723",
+      "uri": "spotify:track:57yeWyaoeTt26p0dlEZukQ",
+      "uri_apple_music": "applemusic://track/1445315084",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1445315084"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/45594361",
+      "fun_fact": "“Spectrum (Say My Name) - Calvin Harris Remix” appears on Florence + The Machine’s release “Ceremonials”.",
+      "fun_fact_de": "„Spectrum (Say My Name) - Calvin Harris Remix“ erschien auf der Veröffentlichung „Ceremonials“ von Florence + The Machine.",
+      "fun_fact_es": "«Spectrum (Say My Name) - Calvin Harris Remix» aparece en el lanzamiento «Ceremonials» de Florence + The Machine.",
+      "fun_fact_fr": "« Spectrum (Say My Name) - Calvin Harris Remix » figure sur la publication « Ceremonials » de Florence + The Machine.",
+      "fun_fact_nl": "‘Spectrum (Say My Name) - Calvin Harris Remix’ staat op de release ‘Ceremonials’ van Florence + The Machine.",
+      "alt_artists": [
+        "Yellow Claw, Ayden",
+        "Otto Knows",
+        "Clean Bandit, Sean Paul, Anne-Marie"
+      ]
+    },
+    {
+      "artist": "Martin Garrix, Bonn",
+      "title": "No Sleep (feat. Bonn)",
+      "year": 2019,
+      "isrc": "NLM5S1900471",
+      "uri": "spotify:track:1ahVFh0ViDZr8LvkEVlq3B",
+      "uri_apple_music": "applemusic://track/1453438470",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1453438470"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/635094532",
+      "fun_fact": "“No Sleep (feat. Bonn)” is the title track of Martin Garrix’s release of the same name.",
+      "fun_fact_de": "„No Sleep (feat. Bonn)“ ist der Titelsong der gleichnamigen Veröffentlichung von Martin Garrix.",
+      "fun_fact_es": "«No Sleep (feat. Bonn)» es la canción que da título al lanzamiento homónimo de Martin Garrix.",
+      "fun_fact_fr": "« No Sleep (feat. Bonn) » est le morceau-titre de la publication éponyme de Martin Garrix.",
+      "fun_fact_nl": "‘No Sleep (feat. Bonn)’ is het titelnummer van de gelijknamige release van Martin Garrix.",
+      "alt_artists": [
+        "Martin Garrix, Dua Lipa",
+        "David Guetta, Skylar Grey",
+        "DVBBS, Borgeous, Tinie Tempah"
+      ]
+    },
+    {
+      "artist": "Paul Kalkbrenner",
+      "title": "Feed Your Head - Radio Edit",
+      "year": 2015,
+      "isrc": "GBARL1500397",
+      "uri": "spotify:track:3BOQSVjlSd0epD8nV5VZ15",
+      "uri_apple_music": "applemusic://track/1025006111",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1025006111"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/104542954",
+      "fun_fact": "“Feed Your Head - Radio Edit” appears on Paul Kalkbrenner’s release “7”.",
+      "fun_fact_de": "„Feed Your Head - Radio Edit“ erschien auf der Veröffentlichung „7“ von Paul Kalkbrenner.",
+      "fun_fact_es": "«Feed Your Head - Radio Edit» aparece en el lanzamiento «7» de Paul Kalkbrenner.",
+      "fun_fact_fr": "« Feed Your Head - Radio Edit » figure sur la publication « 7 » de Paul Kalkbrenner.",
+      "fun_fact_nl": "‘Feed Your Head - Radio Edit’ staat op de release ‘7’ van Paul Kalkbrenner.",
+      "alt_artists": [
+        "Sigala, Bryn Christopher",
+        "Lana Del Rey, Cedric Gervais",
+        "DAWN, Preyah"
       ]
     }
   ],


### PR DESCRIPTION
## Decision — enrich `edm-anthems`, do not create a new playlist

The request ([#2255](https://github.com/mholzi/beatify/issues/2255)) asks for the **Tomorrowland Top 1000 Official Playlist**. The catalogue already covers that theme in `community/edm-anthems.json`, and **44 of the 100 fetched tracks were already in the catalogue** — 33 of them in `edm-anthems` itself. A separate file would have duplicated a third of itself against a playlist we already ship, so the new material is appended instead.

## Source and its limit — 100 of 1000 tracks

`SPOTIFY_CLIENT_ID` / `SPOTIFY_CLIENT_SECRET` are not set in this environment, so the fetch fell back to the `open.spotify.com/embed` route. **That route caps at 100 tracks.** The source playlist holds roughly 1000. This PR therefore covers the **first 100 entries in playlist order** (Avicii — *Levels* through Paul Kalkbrenner — *Feed Your Head*), not the full Top 1000.

That is a real limit, not a rounding error: **900 tracks were never seen.** With credentials the remaining pages can be fetched and appended in a follow-up; without them this is the ceiling.

## Diff

| | Count |
|---|---|
| Tracks fetched from source | 100 |
| Already in the catalogue (ISRC match) | 44 |
| **Added to `edm-anthems`** | **56** |
| Playlist total | 190 → 246 |
| Version | 1.38 → 1.39 |
| Year span of added tracks | 1994–2026 (32 years) |

Duplicates by file: `edm-anthems.json` 33, `hits-2010s-2020s.json` 6, `trance-classics.json` 2, `eurodance-90s.json` 1, `wiesn-party-hits.json` 1, `hitster-brasil.json` 1

## Gate

- **Span** 32 years (1994–2026) — passes (> 5 required)
- **Coherence** single dominant genre (EDM / dance / festival), matching the existing playlist tags — passes
- **Track count** 100 in source — passes (≥ 20 required)

## Per-field completion for the 56 added tracks

| Field | Source | Coverage |
|---|---|---|
| `artist`, `title`, `uri` | Spotify embed | 56/56 |
| `year` | MusicBrainz first-release-date / Deezer `release_date`, minimum of the two | 56/56 |
| `isrc` | Deezer `GET /track/<id>` | 56/56 |
| `uri_deezer` | Deezer track id | 56/56 |
| `uri_apple_music` + `uri_apple_music_by_region.us` | iTunes Search, US storefront only | 55/56 |
| `uri_youtube_music` | left to the backfill agent | 0/56 |
| `uri_tidal` | left `null` | 0/56 |
| `fun_fact` ×5 languages, `alt_artists` | generated from the Deezer release / playlist artist pool | 56/56 |

## Two data findings worth reading

**1. Nine Deezer matches were wrong and were corrected before anything was written.** The first pass searched on a stripped title and accepted the top hit. That produced `Hardwell — Call Me A Spaceman` for *Spaceman*, `Chris Brown — Five More Hours` for Deorro's *Five Hours*, `Ian Asher` for Galantis' *Runaway (U & I)*, and remix editions for *Ocarina*, *Lethal Industry*, *Shivers* and *For an Angel*. Each was re-resolved against the full title including the edition and verified by name before use. A wrong ISRC here is not cosmetic — it is the dedup key, so it decides whether a track is silently dropped as a duplicate.

**2. The ISRC year-code override in the skill has a failure mode, and it fired six times.** The rule says to prefer the ISRC year when it is at least two years earlier than the provider dates. Six tracks carry an ISRC whose year field is a **serial block, not a year**:

| ISRC | Track | ISRC year | MusicBrainz | Deezer | Used |
|---|---|---|---|---|---|
| `DEEC33501145` | Kevin de Vries, Mau P — Metro | 1935 | 2023 | 2023 | **2023** |
| `DEEC31810498` | Argy, Omnya — Aria | 2018 | 2023 | 2023 | **2023** |
| `DEEC33501508` | Adam Port, Stryv, Keinemusik, Orso, Malachiii — Move | 1935 | 2024 | 2024 | **2024** |
| `DEEC33500935` | Anyma, Chris Avantgarde — Eternity | 1935 | 2023 | 2023 | **2023** |
| `DEEC33500555` | Anyma, Chris Avantgarde — Consciousness | 1935 | 2022 | 2023 | **2022** |
| `GBTDG1302438` | Kx5, deadmau5, Kaskade, HAYLA — Escape (feat. Hayla) | 2013 | 2022 | 2022 | **2022** |

Five of the six share the registrant prefix `DEEC3` and would have dated 2023–2024 club tracks to **1935**. Taken at face value the playlist span would have read 1935–2026.

The guard applied here: the ISRC year is rejected when MusicBrainz and Deezer **agree with each other** (within one year) and the ISRC claims five or more years earlier. Two independent sources agreeing outweigh a single registrant field. Where they disagree, the rule is unchanged — the ISRC still wins, which is what it is for.

## Gap balance

Gap balance: YouTube 56 (agent, 90 searches/day, shared across the catalogue) · Apple 1 (agent, Odesli) · Tidal 56 (see note) · region map 56 beyond `us` (no agent — see the skill's step 4)

- **YouTube** is the real cost. 56 new gaps against a shared 90-searches-a-day budget occupies that agent for the better part of a day.
- **Tidal will stay at 0.** Catalogue-wide, 111 of 115 Tidal gaps are confirmed Odesli refusals; the Tidal wave was cut to a single daily slot on 18.08.2026 for exactly that reason. This is a permanent gap, not a pending one.
- **The region map beyond `us` is not coming either.** `apple-backfill` writes only the base field. Non-US storefronts fall through to `uri_apple_music` (verified in `game/playlist.py` — a storefront absent from the map takes the legacy field), so playback is unaffected; the map simply stays partial.
- **One Apple gap by choice**: Nicky Romero — *Toulouse - Original Edit*. Apple's US storefront carries a *2020 Edit*, a *Radio Edit* and remixes, but not the original edit. Writing a different edition would have been worse than leaving it to Odesli.

## Test plan

- `python3 scripts/validate_playlists.py` — 57 files valid, schema gate passed, **0 warnings on `edm-anthems.json`**
- `python3 -m json.tool` on the changed file — parses
- Dedup verified against every file under `custom_components/beatify/playlists/**` by ISRC first, Spotify URI as fallback

Closes #2255

