### PR TITLE
data(playlists): refresh 7 stale Apple Music region IDs in schweizer-hits (#2274)

### DIFF
--- a/custom_components/beatify/playlists/community/schweizer-hits.json
+++ b/custom_components/beatify/playlists/community/schweizer-hits.json
@@ -1,6 +1,6 @@
 {
   "name": "Schweizer Hits 🇨🇭",
-  "version": "0.11",
+  "version": "0.12",
   "tags": [
     "swiss",
     "mundart",
@@ -2436,12 +2436,12 @@
       "isrc": "CHUM72600001",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1867742662",
-        "de": "applemusic://track/1659833475",
-        "gb": "applemusic://track/1757980407",
-        "fr": "applemusic://track/1441539154",
-        "es": "applemusic://track/1065973980",
-        "nl": "applemusic://track/1441539154",
-        "it": "applemusic://track/1441539154"
+        "de": "applemusic://track/1889330591",
+        "gb": "applemusic://track/1889330591",
+        "fr": "applemusic://track/1889330591",
+        "es": "applemusic://track/1889330591",
+        "nl": "applemusic://track/1889330591",
+        "it": "applemusic://track/1889330591"
       }
     },
     {
@@ -2891,7 +2891,7 @@
         "fr": "applemusic://track/1444078299",
         "es": "applemusic://track/1444078299",
         "nl": "applemusic://track/1444078299",
-        "it": "applemusic://track/1840344817"
+        "it": "applemusic://track/1442609564"
       }
     },
     {


### PR DESCRIPTION
Closes #2274. Refreshed 7 stale Apple Music per-region track IDs in `community/schweizer-hits.json` and bumped playlist version to 0.12.

**Tracks fixed:**
- Stress, ZIAN — How To Heal: 6 region IDs (DE/GB/FR/ES/NL/IT) were pointing to unrelated songs; all refreshed via ISRC lookup
- Peter, Sue & Marc — Io senza te: Italian region ID was pointing to "Ultimo - Poesia senza veli"; refreshed