### PR TITLE
data(playlists): four wrong years, and a clean bill for schweizer-hits

### DIFF
--- a/custom_components/beatify/playlists/community/polish-all-time-hits.json
+++ b/custom_components/beatify/playlists/community/polish-all-time-hits.json
@@ -1,6 +1,6 @@
 {
   "name": "Polskie przeboje wszech czasów",
-  "version": "0.14",
+  "version": "0.15",
   "tags": [
     "polish",
     "pop",
@@ -1549,7 +1549,7 @@
       "fun_fact_nl": "Edyta Bartosiewicz hoort tot de Poolse popcanon; \"Opowieść\" (2018) staat op deze selectie Poolse hits aller tijden."
     },
     {
-      "year": 2018,
+      "year": 1994,
       "uri": "spotify:track:05NKgpBkS8YiN1bqNfFwSW",
       "artist": "Varius Manx",
       "alt_artists": [

--- a/custom_components/beatify/playlists/community/schweizer-hits.json
+++ b/custom_components/beatify/playlists/community/schweizer-hits.json
@@ -1,6 +1,6 @@
 {
   "name": "Schweizer Hits 🇨🇭",
-  "version": "0.12",
+  "version": "0.13",
   "tags": [
     "swiss",
     "mundart",
@@ -1455,7 +1455,7 @@
       }
     },
     {
-      "year": 2022,
+      "year": 1991,
       "uri": "spotify:track:2jdKgpF2blCAMdSyS6FXPZ",
       "artist": "Patent Ochsner",
       "alt_artists": [],
@@ -1785,7 +1785,7 @@
       }
     },
     {
-      "year": 2022,
+      "year": 2003,
       "uri": "spotify:track:6YZU9qdssTVIfGwUXiexbn",
       "artist": "Patent Ochsner",
       "alt_artists": [],

--- a/custom_components/beatify/playlists/community/schweizer-hits.json
+++ b/custom_components/beatify/playlists/community/schweizer-hits.json
@@ -1,6 +1,6 @@
 {
   "name": "Schweizer Hits 🇨🇭",
-  "version": "0.13",
+  "version": "0.14",
   "tags": [
     "swiss",
     "mundart",
@@ -105,7 +105,7 @@
       }
     },
     {
-      "year": 1991,
+      "year": 1996,
       "uri": "spotify:track:67hvPNax9b1T4sRbeaUCzC",
       "artist": "Patent Ochsner",
       "alt_artists": [],


### PR DESCRIPTION
## What this fixes

Three catalogue entries carry the year of a **later recording** instead of the year of the song. This is the year convention broken in the direction nobody notices — the entry looks internally consistent, and a player who knows when the song came out is scored wrong.

| Song | Playlist | Was | Now | Evidence |
|---|---|---|---|---|
| Patent Ochsner — *Bälpmoos - MTV Unplugged* | `community/schweizer-hits` | 2022 | **1991** | MusicBrainz earliest release 1991; Deezer studio recording ISRC `CH0019800110`. The 2022 date is the MTV Unplugged session (2022-02-11). |
| Patent Ochsner — *Novämber - MTV Unplugged* | `community/schweizer-hits` | 2022 | **2003** | MusicBrainz first release 2003-01-27; Deezer ISRC `CH0010200138`. Again, 2022 is the Unplugged session. |
| Varius Manx — *Piosenka księżycowa - Acoustic Version* | `community/polish-all-time-hits` | 2018 | **1994** | MusicBrainz first release 1994. The 2018 date belongs to the acoustic re-recording (Deezer ISRC `PLF301700816`). |

## Why these three and not the other 42

Beatify's convention is the song's **original release year**, never that of a re-record, live version or remaster. All 45 catalogue entries carrying a live/unplugged/remaster marker in their title were checked against MusicBrainz and Deezer. The result splits four ways:

- **3 defects** — the three above. Fixed here.
- **38 remasters** — all correctly dated to the original. A remaster is the same performance remixed; it neither sounds like another decade nor implies a different year. Nothing to do.
- **3 correct but audibly mismatched** — Udo Lindenberg/Clueso *Cello* (1973, recording 2011), Cheap Trick *I Want You to Want Me* (1977, Budokan live take), B.J. Thomas *Raindrops Keep Fallin' on My Head - Rerecorded* (1969, later re-recording). The year follows the convention; what a room hears is a later performance. **Deliberately not touched here** — the lever is the linked recording, not the year. See [#2272](https://github.com/mholzi/beatify/issues/2272).
- **1 correct that looks wrong** — Patent Ochsner & Heidi Happy, *Durscht & Hunger - MTV Unplugged / Radio Edit*. MusicBrainz and Deezer know **only** the 2022 Unplugged recording; no earlier version exists, so 2022 *is* the original year. A blanket rule of "unplugged in the title means the year is wrong" would have broken this entry.

That last case is the reason this was done by looking each entry up rather than by pattern-matching the titles.

## Scope this check could not cover

The title marker only finds recordings that announce themselves. A live or re-recorded take whose title says nothing slips through. Catching those needs a comparison of the linked recording's ISRC year against the `year` field across all 6261 songs, which is a separate piece of work.

## Test plan

- `python3 scripts/validate_playlists.py` — 57 files valid, schema gate passed, no warnings on either changed file
- Playlist versions bumped: `schweizer-hits` 0.12 → 0.13, `polish-all-time-hits` 0.14 → 0.15
- Three `year` fields changed, nothing else


---

## Added after a full audit of `schweizer-hits` (20.08, 21:30)

A fourth year is wrong, and it is the one the title-marker sweep above could never have found.

**Patent Ochsner — *W. Nuss vo Bümpliz*: 1991 → 1996.** Nothing about this entry announces itself. The title carries no marker, and the linked recording is not a later take — ISRC `CH0019600071` carries the 1996 year code and points at the original. The `year` field was simply five years early. The single came out at the end of **1996**; the album *Stella Nera* followed in 1997 ([Wikipedia](https://de.wikipedia.org/wiki/W._Nuss_vo_B%C3%BCmpliz), [Discogs single 1996](https://www.discogs.com/release/5638119-Patent-Ochsner-W-Nuss-Vo-B%C3%BCmpliz)). Per the convention — a single before its album wins — 1996 is the answer.

`schweizer-hits` 0.13 → 0.14.

### What the same audit found and did *not* change

**Stephan Eicher — *Campari Soda*, year 1977.** The linked recording is Eicher's **1999 cover**; the song is by the Swiss band Taxi and dates to **1977** ([Wikipedia](https://en.wikipedia.org/wiki/Campari_Soda_(song))). By the convention the year is right. But this is a cover by a *different artist*, not a re-record by the same one, and the room hears 1999 — the same audio-against-answer tension as [#2272](https://github.com/mholzi/beatify/issues/2272). Left alone deliberately; it needs a decision, not an edit.

### The rest of `schweizer-hits` is clean

Checked against the live sources, not just against the schema:

- **750 Apple Music IDs** — 97 base plus 653 per-region entries across all seven storefronts — looked up in their own storefront. **0 dead, 0 pointing at another song.** The seven that were broken this morning were fixed by [#2275](https://github.com/mholzi/beatify/pull/2275).
- **97 Deezer track ids** — all resolve, all to the right artist and title.
- **97 YouTube Music links** — all resolve via oEmbed.
- **Provider URI shapes** — 0 malformed, including every region-map value.
- 22 of the 679 region entries are an explicit `null`, meaning checked and unavailable. That is the correct way to record a genuine no-match.

### Where this audit is blind

The year comparison rests on resolving each ISRC at MusicBrainz, and **61 of the 97 songs have no MusicBrainz entry for their ISRC**. For those the linked recording's date is unknown, so a wrong year there would not have surfaced. The two findings above come from the 36 songs that could be checked. A wider sweep needs a second date source for the ISRCs MusicBrainz does not carry.
