### PR TITLE
data(schweizer-hits): covers take the year of the linked recording

### DIFF
--- a/custom_components/beatify/playlists/community/schweizer-hits.json
+++ b/custom_components/beatify/playlists/community/schweizer-hits.json
@@ -1,6 +1,6 @@
 {
   "name": "Schweizer Hits 🇨🇭",
-  "version": "0.14",
+  "version": "0.15",
   "tags": [
     "swiss",
     "mundart",
@@ -2235,7 +2235,7 @@
       }
     },
     {
-      "year": 1977,
+      "year": 1999,
       "uri": "spotify:track:1myONPDiNfP95dKi85J8Tp",
       "artist": "Stephan Eicher",
       "alt_artists": [],


### PR DESCRIPTION
## A new rule, and the one entry that did not follow it

**Covers under a different artist credit take the year of the linked recording, not the year of the original song.** Decided 2026-08-20 after two reports on the same evening exposed that the catalogue was applying both answers at once.

**Stephan Eicher — *Campari Soda*: 1977 → 1999.** The linked recording is Eicher's own version from *Louanges* (ISRC `CH0199900211`, MusicBrainz first release 1999-06-01). The song was written by Dominique Grandjean and first released by the Swiss band **Taxi in 1977** ([Wikipedia](https://en.wikipedia.org/wiki/Campari_Soda_(song))). The entry is credited to Eicher, so under the new rule it carries 1999.

`community/schweizer-hits` 0.14 → 0.15. One field changed.

## Why the rule exists

The year convention says "the song's original release year" and rules out re-records, live versions and remasters. That wording plainly addresses **a later take by the same artist**. It says nothing about a cover by **someone else** — and the catalogue had drifted into answering that question two opposite ways:

| Entry | Linked recording | Original | Catalogue said |
|---|---|---|---|
| Santana — *Oye Como Va* | Santana 1970 (*Abraxas*) | Tito Puente **1962** | **1970** — the cover |
| Stephan Eicher — *Campari Soda* | Eicher 1999 (*Louanges*) | Taxi **1977** | **1977** — the original |

Both surfaced within hours: [#2277](https://github.com/mholzi/beatify/issues/2277) came in from a player, *Campari Soda* fell out of a full audit of `schweizer-hits`. Neither was visible as an inconsistency on its own.

The rule follows from what the game asks. The room hears the cover, so the answer should match what comes out of the speaker: a player who recognises Santana's *Abraxas* take and says 1970 is right, even though Tito Puente wrote the song in 1962.

## What the rule deliberately does not cover

It applies **only** to covers under a different artist credit. A re-record, live version or remaster by the **same** artist keeps the original's year. Udo Lindenberg's *Cello* stays at 1973 even though the linked recording is the 2011 MTV Unplugged take. **The dividing line is the artist credit, not whether the difference is audible.**

## Test plan

- `python3 scripts/validate_playlists.py` — 57 files valid, schema gate passed, no warnings on the changed file
- One `year` field changed, playlist version bumped
- Santana — *Oye Como Va* already complies at 1970 and needs no change; #2277 closed accordingly
