### PR TITLE
playlist(tomorrowland-top-1000): add 825 tracks from the Tomorrowland Top 1000 (#2255)

### DIFF
--- a/custom_components/beatify/playlists/community/tomorrowland-top-1000.json
+++ b/custom_components/beatify/playlists/community/tomorrowland-top-1000.json
@@ -1,0 +1,18578 @@
+{
+  "name": "Tomorrowland Top 1000",
+  "version": "0.1",
+  "tags": [
+    "edm",
+    "electronic",
+    "dance",
+    "festival",
+    "mainstage"
+  ],
+  "language": "en",
+  "author": "Beatify Community",
+  "added_date": "2026-08-21",
+  "description": "825 tracks from the Tomorrowland Top 1000 Official Playlist that were not already anywhere in the Beatify catalogue. Fetched from the public Spotify web player (1002 entries), de-duplicated by Spotify URI and then by ISRC; 170 were already curated elsewhere and 7 had no resolvable ISRC and were dropped rather than written without one.",
+  "songs": [
+    {
+      "artist": "Timmy Trumpet, Savage",
+      "title": "Freaks",
+      "year": 2014,
+      "isrc": "AUNV01400153",
+      "uri": "spotify:track:44DCjBHfvn5s6ZfLHpKmBi",
+      "uri_apple_music": "applemusic://track/1845909595",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1845909595"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3601122502",
+      "fun_fact": "“Freaks” is the title track of Timmy Trumpet’s release of the same name.",
+      "fun_fact_de": "„Freaks“ ist der Titelsong der gleichnamigen Veröffentlichung von Timmy Trumpet.",
+      "fun_fact_es": "«Freaks» es la canción que da título al lanzamiento homónimo de Timmy Trumpet.",
+      "fun_fact_fr": "« Freaks » est le morceau-titre de la publication éponyme de Timmy Trumpet.",
+      "fun_fact_nl": "‘Freaks’ is het titelnummer van de gelijknamige release van Timmy Trumpet.",
+      "alt_artists": [
+        "Martin Garrix, Matisse & Sadko, BARBZ",
+        "Yves V, AFROJACK, Icona Pop",
+        "Bastille, Audien"
+      ]
+    },
+    {
+      "artist": "Tiësto",
+      "title": "Adagio For Strings - Radio Edit",
+      "year": 2004,
+      "isrc": "NLS241401501",
+      "uri": "spotify:track:76uTbKqlADkTPQ1bXHMBww",
+      "uri_apple_music": "applemusic://track/1793821667",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1793821667"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2874430052",
+      "fun_fact": "“Adagio For Strings - Radio Edit” appears on Tiësto’s release “A State Of Trance Year Mix 2004 (Mixed) (Mixed by Armin van Buuren)”.",
+      "fun_fact_de": "„Adagio For Strings - Radio Edit“ erschien auf der Veröffentlichung „A State Of Trance Year Mix 2004 (Mixed) (Mixed by Armin van Buuren)“ von Tiësto.",
+      "fun_fact_es": "«Adagio For Strings - Radio Edit» aparece en el lanzamiento «A State Of Trance Year Mix 2004 (Mixed) (Mixed by Armin van Buuren)» de Tiësto.",
+      "fun_fact_fr": "« Adagio For Strings - Radio Edit » figure sur la publication « A State Of Trance Year Mix 2004 (Mixed) (Mixed by Armin van Buuren) » de Tiësto.",
+      "fun_fact_nl": "‘Adagio For Strings - Radio Edit’ staat op de release ‘A State Of Trance Year Mix 2004 (Mixed) (Mixed by Armin van Buuren)’ van Tiësto.",
+      "alt_artists": [
+        "MEDUZA, Dermot Kennedy",
+        "Krewella, Hardwell",
+        "Armin van Buuren, Mr. Probz"
+      ]
+    },
+    {
+      "artist": "Otto Knows",
+      "title": "Million Voices",
+      "year": 2012,
+      "isrc": "GBJ4B1200055",
+      "uri": "spotify:track:3EOPARFP0zKLwQjvIFIl7a",
+      "uri_apple_music": "applemusic://track/627546840",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/627546840"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1355491752",
+      "fun_fact": "“Million Voices” appears on Otto Knows’s release “Electrónica Vieja Y Poderosa”.",
+      "fun_fact_de": "„Million Voices“ erschien auf der Veröffentlichung „Electrónica Vieja Y Poderosa“ von Otto Knows.",
+      "fun_fact_es": "«Million Voices» aparece en el lanzamiento «Electrónica Vieja Y Poderosa» de Otto Knows.",
+      "fun_fact_fr": "« Million Voices » figure sur la publication « Electrónica Vieja Y Poderosa » de Otto Knows.",
+      "fun_fact_nl": "‘Million Voices’ staat op de release ‘Electrónica Vieja Y Poderosa’ van Otto Knows.",
+      "alt_artists": [
+        "NERVO",
+        "Cygnus X, Rank 1",
+        "SOFI TUKKER, Öwnboss, Fancy Inc"
+      ]
+    },
+    {
+      "artist": "Daft Punk",
+      "title": "One More Time - Radio Edit",
+      "year": 2000,
+      "isrc": "GBDUW0000050",
+      "uri": "spotify:track:0ijhkvBpA7OBlY4clWSUZw",
+      "uri_apple_music": "applemusic://track/697402070",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/697402070"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3157686",
+      "fun_fact": "“One More Time - Radio Edit” appears on Daft Punk’s release “One More Time”.",
+      "fun_fact_de": "„One More Time - Radio Edit“ erschien auf der Veröffentlichung „One More Time“ von Daft Punk.",
+      "fun_fact_es": "«One More Time - Radio Edit» aparece en el lanzamiento «One More Time» de Daft Punk.",
+      "fun_fact_fr": "« One More Time - Radio Edit » figure sur la publication « One More Time » de Daft Punk.",
+      "fun_fact_nl": "‘One More Time - Radio Edit’ staat op de release ‘One More Time’ van Daft Punk.",
+      "alt_artists": [
+        "Martin Garrix, USHER",
+        "Calvin Harris, Disciples, Chris Lake",
+        "Dizzee Rascal"
+      ]
+    },
+    {
+      "artist": "David Guetta, Nicky Romero, Sia",
+      "title": "Wild One Two (feat. Nicky Romero and Sia)",
+      "year": 2012,
+      "isrc": "USAT21811081",
+      "uri": "spotify:track:3l2xQwzdNcor10Pz49JqeN",
+      "uri_apple_music": "applemusic://track/1436500148",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1436500148"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/555328722",
+      "fun_fact": "“Wild One Two (feat. Nicky Romero and Sia)” appears on David Guetta’s release “Wild One Two (feat. Nicky Romero & Sia) (Remixes)”.",
+      "fun_fact_de": "„Wild One Two (feat. Nicky Romero and Sia)“ erschien auf der Veröffentlichung „Wild One Two (feat. Nicky Romero & Sia) (Remixes)“ von David Guetta.",
+      "fun_fact_es": "«Wild One Two (feat. Nicky Romero and Sia)» aparece en el lanzamiento «Wild One Two (feat. Nicky Romero & Sia) (Remixes)» de David Guetta.",
+      "fun_fact_fr": "« Wild One Two (feat. Nicky Romero and Sia) » figure sur la publication « Wild One Two (feat. Nicky Romero & Sia) (Remixes) » de David Guetta.",
+      "fun_fact_nl": "‘Wild One Two (feat. Nicky Romero and Sia)’ staat op de release ‘Wild One Two (feat. Nicky Romero & Sia) (Remixes)’ van David Guetta.",
+      "alt_artists": [
+        "Yves V, Matthew Hill, Adrian Lux",
+        "Eliza Rose, Interplanetary Criminal",
+        "La Fuente"
+      ]
+    },
+    {
+      "artist": "Martin Garrix, Third Party, Oaks, Declan J Donovan",
+      "title": "Carry You",
+      "year": 2024,
+      "isrc": "NLM5S2402145",
+      "uri": "spotify:track:31ZO9XuKt48Qb2eUTBynd2",
+      "uri_apple_music": "applemusic://track/1727698271",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1727698271"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2635513182",
+      "fun_fact": "“Carry You” is the title track of Martin Garrix’s release of the same name.",
+      "fun_fact_de": "„Carry You“ ist der Titelsong der gleichnamigen Veröffentlichung von Martin Garrix.",
+      "fun_fact_es": "«Carry You» es la canción que da título al lanzamiento homónimo de Martin Garrix.",
+      "fun_fact_fr": "« Carry You » est le morceau-titre de la publication éponyme de Martin Garrix.",
+      "fun_fact_nl": "‘Carry You’ is het titelnummer van de gelijknamige release van Martin Garrix.",
+      "alt_artists": [
+        "Zonderling, Andreas Moss",
+        "Parachute Youth",
+        "Dimitri Vegas & Like Mike, Bassjackers, D'Angello & Francis"
+      ]
+    },
+    {
+      "artist": "Tiësto",
+      "title": "Traffic - Radio Edit",
+      "year": 2003,
+      "isrc": "NLE710480323",
+      "uri": "spotify:track:2LzEuRdNWNiHdGI1m5ALc5",
+      "uri_apple_music": "applemusic://track/1793821643",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1793821643"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3212523691",
+      "fun_fact": "“Traffic - Radio Edit” appears on Tiësto’s release “Traffic”.",
+      "fun_fact_de": "„Traffic - Radio Edit“ erschien auf der Veröffentlichung „Traffic“ von Tiësto.",
+      "fun_fact_es": "«Traffic - Radio Edit» aparece en el lanzamiento «Traffic» de Tiësto.",
+      "fun_fact_fr": "« Traffic - Radio Edit » figure sur la publication « Traffic » de Tiësto.",
+      "fun_fact_nl": "‘Traffic - Radio Edit’ staat op de release ‘Traffic’ van Tiësto.",
+      "alt_artists": [
+        "cassö, RAYE, D-Block Europe",
+        "Yeah Yeah Yeahs, A-Trak",
+        "Laidback Luke, Steve Angello"
+      ]
+    },
+    {
+      "artist": "David Guetta, Chris Willis, Fred Riesterer, Joachim Garraud",
+      "title": "Love Is Gone - Fred Riester & Joachim Garraud Radio Edit Remix",
+      "year": 2007,
+      "isrc": "FRZID0700070",
+      "uri": "spotify:track:2MGRnjJc7C0z3EOEWRqcMw",
+      "uri_apple_music": "applemusic://track/1715396238",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1715396238"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3166816",
+      "fun_fact": "“Love Is Gone - Fred Riester & Joachim Garraud Radio Edit Remix” appears on David Guetta’s release “Love Is Gone”.",
+      "fun_fact_de": "„Love Is Gone - Fred Riester & Joachim Garraud Radio Edit Remix“ erschien auf der Veröffentlichung „Love Is Gone“ von David Guetta.",
+      "fun_fact_es": "«Love Is Gone - Fred Riester & Joachim Garraud Radio Edit Remix» aparece en el lanzamiento «Love Is Gone» de David Guetta.",
+      "fun_fact_fr": "« Love Is Gone - Fred Riester & Joachim Garraud Radio Edit Remix » figure sur la publication « Love Is Gone » de David Guetta.",
+      "fun_fact_nl": "‘Love Is Gone - Fred Riester & Joachim Garraud Radio Edit Remix’ staat op de release ‘Love Is Gone’ van David Guetta.",
+      "alt_artists": [
+        "Dom Dolla, Daya",
+        "Mike Williams, Robin Valo",
+        "David Guetta, MORTEN, RAYE"
+      ]
+    },
+    {
+      "artist": "AFROJACK, WRABEL",
+      "title": "Ten Feet Tall",
+      "year": 2014,
+      "isrc": "CYA221400001",
+      "uri": "spotify:track:2ldAdghnrO34HPcZ0IWfTu",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/77897290",
+      "fun_fact": "“Ten Feet Tall” appears on AFROJACK’s release “Forget The World (Deluxe)”.",
+      "fun_fact_de": "„Ten Feet Tall“ erschien auf der Veröffentlichung „Forget The World (Deluxe)“ von AFROJACK.",
+      "fun_fact_es": "«Ten Feet Tall» aparece en el lanzamiento «Forget The World (Deluxe)» de AFROJACK.",
+      "fun_fact_fr": "« Ten Feet Tall » figure sur la publication « Forget The World (Deluxe) » de AFROJACK.",
+      "fun_fact_nl": "‘Ten Feet Tall’ staat op de release ‘Forget The World (Deluxe)’ van AFROJACK.",
+      "alt_artists": [
+        "Alesso, TINI",
+        "Zerb, The Chainsmokers, Ink",
+        "PAWSA, The Adventures Of Stevie V"
+      ]
+    },
+    {
+      "artist": "Monolink, ARTBAT",
+      "title": "Return to Oz - ARTBAT Remix",
+      "year": 2019,
+      "isrc": "DETO31900005",
+      "uri": "spotify:track:0gwNGHcBRYtF7mvgUczVo1",
+      "uri_apple_music": "applemusic://track/1475125062",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1475125062"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/671044412",
+      "fun_fact": "“Return to Oz - ARTBAT Remix” is the title track of Monolink’s release of the same name.",
+      "fun_fact_de": "„Return to Oz - ARTBAT Remix“ ist der Titelsong der gleichnamigen Veröffentlichung von Monolink.",
+      "fun_fact_es": "«Return to Oz - ARTBAT Remix» es la canción que da título al lanzamiento homónimo de Monolink.",
+      "fun_fact_fr": "« Return to Oz - ARTBAT Remix » est le morceau-titre de la publication éponyme de Monolink.",
+      "fun_fact_nl": "‘Return to Oz - ARTBAT Remix’ is het titelnummer van de gelijknamige release van Monolink.",
+      "alt_artists": [
+        "Cassian",
+        "MoBlack, Salif Keita, Benja (NL), Franc Fala, Cesária Evora",
+        "Martin Garrix, Bonn"
+      ]
+    },
+    {
+      "artist": "&ME, Black Coffee, Keinemusik",
+      "title": "The Rapture Pt.III",
+      "year": 2023,
+      "isrc": "DEEC33501048",
+      "uri": "spotify:track:200DiJQhDi69nkGXOrrJgn",
+      "uri_apple_music": "applemusic://track/1688080970",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1688080970"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2285438237",
+      "fun_fact": "“The Rapture Pt.III” is the title track of &ME’s release of the same name.",
+      "fun_fact_de": "„The Rapture Pt.III“ ist der Titelsong der gleichnamigen Veröffentlichung von &ME.",
+      "fun_fact_es": "«The Rapture Pt.III» es la canción que da título al lanzamiento homónimo de &ME.",
+      "fun_fact_fr": "« The Rapture Pt.III » est le morceau-titre de la publication éponyme de &ME.",
+      "fun_fact_nl": "‘The Rapture Pt.III’ is het titelnummer van de gelijknamige release van &ME.",
+      "alt_artists": [
+        "Dimitri Vegas & Like Mike, Armin van Buuren, W&W",
+        "Adrian Lux",
+        "Salif Keita, Martin Solveig"
+      ]
+    },
+    {
+      "artist": "Dizzee Rascal",
+      "title": "Bonkers",
+      "year": 2009,
+      "isrc": "GBPVV0900240",
+      "uri": "spotify:track:4S9tSGd8sGFv0bPFmmLO41",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/15640851",
+      "fun_fact": "“Bonkers” appears on Dizzee Rascal’s release “Tongue N' Cheek (Dirtee Deluxe Edition)”.",
+      "fun_fact_de": "„Bonkers“ erschien auf der Veröffentlichung „Tongue N' Cheek (Dirtee Deluxe Edition)“ von Dizzee Rascal.",
+      "fun_fact_es": "«Bonkers» aparece en el lanzamiento «Tongue N' Cheek (Dirtee Deluxe Edition)» de Dizzee Rascal.",
+      "fun_fact_fr": "« Bonkers » figure sur la publication « Tongue N' Cheek (Dirtee Deluxe Edition) » de Dizzee Rascal.",
+      "fun_fact_nl": "‘Bonkers’ staat op de release ‘Tongue N' Cheek (Dirtee Deluxe Edition)’ van Dizzee Rascal.",
+      "alt_artists": [
+        "Nadia Ali",
+        "Dirty South, Rudy",
+        "Sasha"
+      ]
+    },
+    {
+      "artist": "4444 OF A KIND, D-Block & S-te-Fan, Sub Zero Project",
+      "title": "WAITING 4",
+      "year": 2026,
+      "isrc": "BE5KW2601174",
+      "uri": "spotify:track:0BUnzynrao4zAwwB0i3sWQ",
+      "uri_apple_music": "applemusic://track/6776704146",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/6776704146"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/4083221771",
+      "fun_fact": "“WAITING 4” is the title track of 4444 OF A KIND’s release of the same name.",
+      "fun_fact_de": "„WAITING 4“ ist der Titelsong der gleichnamigen Veröffentlichung von 4444 OF A KIND.",
+      "fun_fact_es": "«WAITING 4» es la canción que da título al lanzamiento homónimo de 4444 OF A KIND.",
+      "fun_fact_fr": "« WAITING 4 » est le morceau-titre de la publication éponyme de 4444 OF A KIND.",
+      "fun_fact_nl": "‘WAITING 4’ is het titelnummer van de gelijknamige release van 4444 OF A KIND.",
+      "alt_artists": [
+        "David Guetta, Anne-Marie, Coi Leray",
+        "Blasterjaxx, Timmy Trumpet",
+        "FISHER, bbyclose"
+      ]
+    },
+    {
+      "artist": "Armin van Buuren",
+      "title": "Million Voices",
+      "year": 2019,
+      "isrc": "NLF711909589",
+      "uri": "spotify:track:1Pe3Tnahd3nNcKrTvNvNvW",
+      "uri_apple_music": "applemusic://track/1478926110",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1478926110"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/757592732",
+      "fun_fact": "“Million Voices” appears on Armin van Buuren’s release “Balance”.",
+      "fun_fact_de": "„Million Voices“ erschien auf der Veröffentlichung „Balance“ von Armin van Buuren.",
+      "fun_fact_es": "«Million Voices» aparece en el lanzamiento «Balance» de Armin van Buuren.",
+      "fun_fact_fr": "« Million Voices » figure sur la publication « Balance » de Armin van Buuren.",
+      "fun_fact_nl": "‘Million Voices’ staat op de release ‘Balance’ van Armin van Buuren.",
+      "alt_artists": [
+        "Congorock, Lexxus",
+        "HUGEL, Totó La Momposina",
+        "BUNT., Nate Traveller"
+      ]
+    },
+    {
+      "artist": "David Guetta, Alesso, Madison Love",
+      "title": "Never Going Home Tonight (feat. Madison Love)",
+      "year": 2024,
+      "isrc": "UKWLG2400072",
+      "uri": "spotify:track:7K1BLb6MpvKuGEPpHw35mO",
+      "uri_apple_music": "applemusic://track/1764331995",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1764331995"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2958942721",
+      "fun_fact": "“Never Going Home Tonight (feat. Madison Love)” is the title track of David Guetta’s release of the same name.",
+      "fun_fact_de": "„Never Going Home Tonight (feat. Madison Love)“ ist der Titelsong der gleichnamigen Veröffentlichung von David Guetta.",
+      "fun_fact_es": "«Never Going Home Tonight (feat. Madison Love)» es la canción que da título al lanzamiento homónimo de David Guetta.",
+      "fun_fact_fr": "« Never Going Home Tonight (feat. Madison Love) » est le morceau-titre de la publication éponyme de David Guetta.",
+      "fun_fact_nl": "‘Never Going Home Tonight (feat. Madison Love)’ is het titelnummer van de gelijknamige release van David Guetta.",
+      "alt_artists": [
+        "&ME, Rampa, Adam Port, Alan Dixon, Keinemusik, Arabic Piano",
+        "Jessie Ware, Disclosure",
+        "ARTY, NK"
+      ]
+    },
+    {
+      "artist": "Adrian Lux",
+      "title": "Teenage Crime",
+      "year": 2010,
+      "isrc": "GBKCF1000129",
+      "uri": "spotify:track:1L1kWebLmUAlDjZfcEhiQN",
+      "uri_apple_music": "applemusic://track/627421748",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/627421748"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/73460659",
+      "fun_fact": "“Teenage Crime” is the title track of Adrian Lux’s release of the same name.",
+      "fun_fact_de": "„Teenage Crime“ ist der Titelsong der gleichnamigen Veröffentlichung von Adrian Lux.",
+      "fun_fact_es": "«Teenage Crime» es la canción que da título al lanzamiento homónimo de Adrian Lux.",
+      "fun_fact_fr": "« Teenage Crime » est le morceau-titre de la publication éponyme de Adrian Lux.",
+      "fun_fact_nl": "‘Teenage Crime’ is het titelnummer van de gelijknamige release van Adrian Lux.",
+      "alt_artists": [
+        "Tiësto, Sevenn",
+        "Feist, Boys Noize",
+        "Henri PFR, Raphaella"
+      ]
+    },
+    {
+      "artist": "Supermode, MEDUZA",
+      "title": "Tell Me Why - MEDUZA Remix",
+      "year": 2022,
+      "isrc": "GBKCF2201098",
+      "uri": "spotify:track:7jrMFjEq0t09f7m3HnnWXl",
+      "uri_apple_music": "applemusic://track/1637427486",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1637427486"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1847821547",
+      "fun_fact": "“Tell Me Why - MEDUZA Remix” is the title track of Supermode’s release of the same name.",
+      "fun_fact_de": "„Tell Me Why - MEDUZA Remix“ ist der Titelsong der gleichnamigen Veröffentlichung von Supermode.",
+      "fun_fact_es": "«Tell Me Why - MEDUZA Remix» es la canción que da título al lanzamiento homónimo de Supermode.",
+      "fun_fact_fr": "« Tell Me Why - MEDUZA Remix » est le morceau-titre de la publication éponyme de Supermode.",
+      "fun_fact_nl": "‘Tell Me Why - MEDUZA Remix’ is het titelnummer van de gelijknamige release van Supermode.",
+      "alt_artists": [
+        "Red Hot Chili Peppers",
+        "Secondcity",
+        "Boys Noize"
+      ]
+    },
+    {
+      "artist": "KETTAMA",
+      "title": "It Gets Better - Forever Mix",
+      "year": 2025,
+      "isrc": "USZXT2556641",
+      "uri": "spotify:track:1tloWl8X8O5MOLiOogkdEF",
+      "uri_apple_music": "applemusic://track/1830332331",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1830332331"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3486763691",
+      "fun_fact": "“It Gets Better - Forever Mix” is the title track of KETTAMA’s release of the same name.",
+      "fun_fact_de": "„It Gets Better - Forever Mix“ ist der Titelsong der gleichnamigen Veröffentlichung von KETTAMA.",
+      "fun_fact_es": "«It Gets Better - Forever Mix» es la canción que da título al lanzamiento homónimo de KETTAMA.",
+      "fun_fact_fr": "« It Gets Better - Forever Mix » est le morceau-titre de la publication éponyme de KETTAMA.",
+      "fun_fact_nl": "‘It Gets Better - Forever Mix’ is het titelnummer van de gelijknamige release van KETTAMA.",
+      "alt_artists": [
+        "Delerium, Sarah McLachlan, John Summit",
+        "Henri PFR, Raphaella",
+        "Lost Frequencies, The Temper Trap"
+      ]
+    },
+    {
+      "artist": "Coldplay, Swedish House Mafia",
+      "title": "Every Teardrop Is A Waterfall (Coldplay Vs. Swedish House Mafia)",
+      "year": 2012,
+      "isrc": "GBAYE1101046",
+      "uri": "spotify:track:5J8m6w5VmswbMBYUAFf44t",
+      "uri_apple_music": "applemusic://track/6798410343",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/6798410343"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/61427206",
+      "fun_fact": "“Every Teardrop Is A Waterfall (Coldplay Vs. Swedish House Mafia)” appears on Coldplay’s release “Until Now”.",
+      "fun_fact_de": "„Every Teardrop Is A Waterfall (Coldplay Vs. Swedish House Mafia)“ erschien auf der Veröffentlichung „Until Now“ von Coldplay.",
+      "fun_fact_es": "«Every Teardrop Is A Waterfall (Coldplay Vs. Swedish House Mafia)» aparece en el lanzamiento «Until Now» de Coldplay.",
+      "fun_fact_fr": "« Every Teardrop Is A Waterfall (Coldplay Vs. Swedish House Mafia) » figure sur la publication « Until Now » de Coldplay.",
+      "fun_fact_nl": "‘Every Teardrop Is A Waterfall (Coldplay Vs. Swedish House Mafia)’ staat op de release ‘Until Now’ van Coldplay.",
+      "alt_artists": [
+        "John Summit, Echoes",
+        "W&W, Lucas & Steve",
+        "Dom Dolla, Daya"
+      ]
+    },
+    {
+      "artist": "Eric Prydz, Empire Of The Sun",
+      "title": "We Are Mirage",
+      "year": 2012,
+      "isrc": "GB6CM1200061",
+      "uri": "spotify:track:6mTnH6xSYwKohtsO9RFzcc",
+      "uri_apple_music": "applemusic://track/1444998575",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1444998575"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/81075574",
+      "fun_fact": "“We Are Mirage” appears on Eric Prydz’s release “Liberate (Remixes)”.",
+      "fun_fact_de": "„We Are Mirage“ erschien auf der Veröffentlichung „Liberate (Remixes)“ von Eric Prydz.",
+      "fun_fact_es": "«We Are Mirage» aparece en el lanzamiento «Liberate (Remixes)» de Eric Prydz.",
+      "fun_fact_fr": "« We Are Mirage » figure sur la publication « Liberate (Remixes) » de Eric Prydz.",
+      "fun_fact_nl": "‘We Are Mirage’ staat op de release ‘Liberate (Remixes)’ van Eric Prydz.",
+      "alt_artists": [
+        "Double 99",
+        "Kygo, Rita Ora",
+        "Tinlicker, Helsloot"
+      ]
+    },
+    {
+      "artist": "Push",
+      "title": "Universal Nation",
+      "year": 2010,
+      "isrc": "NLF711503949",
+      "uri": "spotify:track:1u8gw65yb6kRCBqNDFSwHj",
+      "uri_apple_music": "applemusic://track/291796182",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/291796182"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/102586228",
+      "fun_fact": "“Universal Nation” appears on Push’s release “Trance Top 1000 - The Best Of”.",
+      "fun_fact_de": "„Universal Nation“ erschien auf der Veröffentlichung „Trance Top 1000 - The Best Of“ von Push.",
+      "fun_fact_es": "«Universal Nation» aparece en el lanzamiento «Trance Top 1000 - The Best Of» de Push.",
+      "fun_fact_fr": "« Universal Nation » figure sur la publication « Trance Top 1000 - The Best Of » de Push.",
+      "fun_fact_nl": "‘Universal Nation’ staat op de release ‘Trance Top 1000 - The Best Of’ van Push.",
+      "alt_artists": [
+        "Overmono",
+        "Breach",
+        "Higher Self, Lauren Mason"
+      ]
+    },
+    {
+      "artist": "Avicii",
+      "title": "Heaven",
+      "year": 2019,
+      "isrc": "SE5R71900203",
+      "uri": "spotify:track:0vrmHPfoBadXVr2n0m1aqZ",
+      "uri_apple_music": "applemusic://track/1462628896",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1462628896"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/675656882",
+      "fun_fact": "“Heaven” appears on Avicii’s release “TIM”.",
+      "fun_fact_de": "„Heaven“ erschien auf der Veröffentlichung „TIM“ von Avicii.",
+      "fun_fact_es": "«Heaven» aparece en el lanzamiento «TIM» de Avicii.",
+      "fun_fact_fr": "« Heaven » figure sur la publication « TIM » de Avicii.",
+      "fun_fact_nl": "‘Heaven’ staat op de release ‘TIM’ van Avicii.",
+      "alt_artists": [
+        "Lost Frequencies, Elley Duhé, X Ambassadors",
+        "Mike Williams, Robin Valo",
+        "Laidback Luke, Steve Aoki, Lil Jon"
+      ]
+    },
+    {
+      "artist": "Lost Frequencies, Calum Scott",
+      "title": "Where Are You Now",
+      "year": 2021,
+      "isrc": "BEHP42100067",
+      "uri": "spotify:track:3uUuGVFu1V7jTQL60S1r8z",
+      "uri_apple_music": "applemusic://track/1576395046",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1576395046"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1432930542",
+      "fun_fact": "“Where Are You Now” is the title track of Lost Frequencies’s release of the same name.",
+      "fun_fact_de": "„Where Are You Now“ ist der Titelsong der gleichnamigen Veröffentlichung von Lost Frequencies.",
+      "fun_fact_es": "«Where Are You Now» es la canción que da título al lanzamiento homónimo de Lost Frequencies.",
+      "fun_fact_fr": "« Where Are You Now » est le morceau-titre de la publication éponyme de Lost Frequencies.",
+      "fun_fact_nl": "‘Where Are You Now’ is het titelnummer van de gelijknamige release van Lost Frequencies.",
+      "alt_artists": [
+        "Overmono",
+        "System F",
+        "Gregor Salto, Florian T"
+      ]
+    },
+    {
+      "artist": "Martin Garrix, Matisse & Sadko, Michel Zitron",
+      "title": "Hold On (feat. Michel Zitron)",
+      "year": 2019,
+      "isrc": "NLM5S1900788",
+      "uri": "spotify:track:22zxLxXlXrBIm7XaazHNrg",
+      "uri_apple_music": "applemusic://track/1491028334",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1491028334"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/829116322",
+      "fun_fact": "“Hold On (feat. Michel Zitron)” is the title track of Martin Garrix’s release of the same name.",
+      "fun_fact_de": "„Hold On (feat. Michel Zitron)“ ist der Titelsong der gleichnamigen Veröffentlichung von Martin Garrix.",
+      "fun_fact_es": "«Hold On (feat. Michel Zitron)» es la canción que da título al lanzamiento homónimo de Martin Garrix.",
+      "fun_fact_fr": "« Hold On (feat. Michel Zitron) » est le morceau-titre de la publication éponyme de Martin Garrix.",
+      "fun_fact_nl": "‘Hold On (feat. Michel Zitron)’ is het titelnummer van de gelijknamige release van Martin Garrix.",
+      "alt_artists": [
+        "New World Sound, Thomas Newson",
+        "Josh Butler, Bontan, Pleasurekraft",
+        "ANOTR, Abel Balder"
+      ]
+    },
+    {
+      "artist": "Gotye, FISHER, Chris Lake, Sante Sansone, Kimbra",
+      "title": "Somebody (2024)",
+      "year": 2024,
+      "isrc": "GBUM72311281",
+      "uri": "spotify:track:124A7neNKBP0Ps8p6PMLy8",
+      "uri_apple_music": "applemusic://track/1718280036",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1718280036"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2645821532",
+      "fun_fact": "“Somebody (2024)” is the title track of Gotye’s release of the same name.",
+      "fun_fact_de": "„Somebody (2024)“ ist der Titelsong der gleichnamigen Veröffentlichung von Gotye.",
+      "fun_fact_es": "«Somebody (2024)» es la canción que da título al lanzamiento homónimo de Gotye.",
+      "fun_fact_fr": "« Somebody (2024) » est le morceau-titre de la publication éponyme de Gotye.",
+      "fun_fact_nl": "‘Somebody (2024)’ is het titelnummer van de gelijknamige release van Gotye.",
+      "alt_artists": [
+        "Anyma, CamelPhat",
+        "Cassian",
+        "Matisse & Sadko"
+      ]
+    },
+    {
+      "artist": "Tiësto, KSHMR, VASSY",
+      "title": "Secrets",
+      "year": 2015,
+      "isrc": "CYA111500019",
+      "uri": "spotify:track:0NIC4unbe5KZOp1d9T7OaF",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/100334216",
+      "fun_fact": "“Secrets” appears on Tiësto’s release “Club Life, Vol. 4 - New York City”.",
+      "fun_fact_de": "„Secrets“ erschien auf der Veröffentlichung „Club Life, Vol. 4 - New York City“ von Tiësto.",
+      "fun_fact_es": "«Secrets» aparece en el lanzamiento «Club Life, Vol. 4 - New York City» de Tiësto.",
+      "fun_fact_fr": "« Secrets » figure sur la publication « Club Life, Vol. 4 - New York City » de Tiësto.",
+      "fun_fact_nl": "‘Secrets’ staat op de release ‘Club Life, Vol. 4 - New York City’ van Tiësto.",
+      "alt_artists": [
+        "Underworld",
+        "Art Of Trance, Ferry Corsten",
+        "Dom Dolla, Clementine Douglas"
+      ]
+    },
+    {
+      "artist": "David Guetta, Akon",
+      "title": "Sexy Bitch (feat. Akon)",
+      "year": 2009,
+      "isrc": "FRZID0900500",
+      "uri": "spotify:track:2dGxjfhFXDIUX9h5ImyKkE",
+      "uri_apple_music": "applemusic://track/1829555731",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1829555731"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/673165762",
+      "fun_fact": "“Sexy Bitch (feat. Akon)” appears on David Guetta’s release “One More Love”.",
+      "fun_fact_de": "„Sexy Bitch (feat. Akon)“ erschien auf der Veröffentlichung „One More Love“ von David Guetta.",
+      "fun_fact_es": "«Sexy Bitch (feat. Akon)» aparece en el lanzamiento «One More Love» de David Guetta.",
+      "fun_fact_fr": "« Sexy Bitch (feat. Akon) » figure sur la publication « One More Love » de David Guetta.",
+      "fun_fact_nl": "‘Sexy Bitch (feat. Akon)’ staat op de release ‘One More Love’ van David Guetta.",
+      "alt_artists": [
+        "Higher Self, Lauren Mason",
+        "Adriatique, Marino Canal, Delhia De France",
+        "Lilly Wood and The Prick, Robin Schulz"
+      ]
+    },
+    {
+      "artist": "Kaskade, MOGUAI, Zip Zip Through The Night",
+      "title": "Something Something Champs (feat. Zip Zip Through The Night) - Radio Edit",
+      "year": 2013,
+      "isrc": "USUS11202754",
+      "uri": "spotify:track:7lCUnSxHqkQdBnR5VTZwO1",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/82230460",
+      "fun_fact": "“Something Something Champs (feat. Zip Zip Through The Night) - Radio Edit” is the title track of Kaskade’s release of the same name.",
+      "fun_fact_de": "„Something Something Champs (feat. Zip Zip Through The Night) - Radio Edit“ ist der Titelsong der gleichnamigen Veröffentlichung von Kaskade.",
+      "fun_fact_es": "«Something Something Champs (feat. Zip Zip Through The Night) - Radio Edit» es la canción que da título al lanzamiento homónimo de Kaskade.",
+      "fun_fact_fr": "« Something Something Champs (feat. Zip Zip Through The Night) - Radio Edit » est le morceau-titre de la publication éponyme de Kaskade.",
+      "fun_fact_nl": "‘Something Something Champs (feat. Zip Zip Through The Night) - Radio Edit’ is het titelnummer van de gelijknamige release van Kaskade.",
+      "alt_artists": [
+        "Cajmere, Dajae, Marco Lys, Green Velvet",
+        "Dimitri Vegas & Like Mike, Marlon Hoffstadt, Dj Konik, Dimitri Vegas, Like Mike",
+        "Calvin Harris, Sam Smith, Jessie Reyez"
+      ]
+    },
+    {
+      "artist": "Amber Broos",
+      "title": "Amok",
+      "year": 2023,
+      "isrc": "BE5KW2300213",
+      "uri": "spotify:track:41fl1aHm371uXzcWVQEBJr",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2300136505",
+      "fun_fact": "“Amok” is the title track of Amber Broos’s release of the same name.",
+      "fun_fact_de": "„Amok“ ist der Titelsong der gleichnamigen Veröffentlichung von Amber Broos.",
+      "fun_fact_es": "«Amok» es la canción que da título al lanzamiento homónimo de Amber Broos.",
+      "fun_fact_fr": "« Amok » est le morceau-titre de la publication éponyme de Amber Broos.",
+      "fun_fact_nl": "‘Amok’ is het titelnummer van de gelijknamige release van Amber Broos.",
+      "alt_artists": [
+        "Tiësto, Oaks",
+        "Purple Disco Machine",
+        "Justice"
+      ]
+    },
+    {
+      "artist": "Eric Prydz",
+      "title": "Call on Me",
+      "year": 2004,
+      "isrc": "GBCEN0400131",
+      "uri": "spotify:track:1As4KC3YYpu89aBt7EqL2m",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/340051261",
+      "fun_fact": "“Call on Me” appears on Eric Prydz’s release “Call On Me (Remixes)”.",
+      "fun_fact_de": "„Call on Me“ erschien auf der Veröffentlichung „Call On Me (Remixes)“ von Eric Prydz.",
+      "fun_fact_es": "«Call on Me» aparece en el lanzamiento «Call On Me (Remixes)» de Eric Prydz.",
+      "fun_fact_fr": "« Call on Me » figure sur la publication « Call On Me (Remixes) » de Eric Prydz.",
+      "fun_fact_nl": "‘Call on Me’ staat op de release ‘Call On Me (Remixes)’ van Eric Prydz.",
+      "alt_artists": [
+        "Kid Cudi, Crookers",
+        "KI/KI, Marlon Hoffstadt",
+        "Higher Self, Lauren Mason"
+      ]
+    },
+    {
+      "artist": "BURNS",
+      "title": "Lies (Otto Knows Remix)",
+      "year": 2012,
+      "isrc": "GBARL1200836",
+      "uri": "spotify:track:2hEwnK3oW1F4NgV4RPp5qV",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/518018572",
+      "fun_fact": "“Lies (Otto Knows Remix)” appears on BURNS’s release “Lies”.",
+      "fun_fact_de": "„Lies (Otto Knows Remix)“ erschien auf der Veröffentlichung „Lies“ von BURNS.",
+      "fun_fact_es": "«Lies (Otto Knows Remix)» aparece en el lanzamiento «Lies» de BURNS.",
+      "fun_fact_fr": "« Lies (Otto Knows Remix) » figure sur la publication « Lies » de BURNS.",
+      "fun_fact_nl": "‘Lies (Otto Knows Remix)’ staat op de release ‘Lies’ van BURNS.",
+      "alt_artists": [
+        "Notre Dame",
+        "felix jaehn, Sandro Cavazza",
+        "Dimitri Vegas & Like Mike, Bassjackers, D'Angello & Francis"
+      ]
+    },
+    {
+      "artist": "CamelPhat, Elderbrook",
+      "title": "Cola",
+      "year": 2017,
+      "isrc": "GBCPZ1711555",
+      "uri": "spotify:track:0aL5jEWqfIwNDB3tdzyzH4",
+      "uri_apple_music": "applemusic://track/1783998383",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1783998383"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3155482291",
+      "fun_fact": "“Cola” appears on CamelPhat’s release “Cola (Tutara Peak Remix)”.",
+      "fun_fact_de": "„Cola“ erschien auf der Veröffentlichung „Cola (Tutara Peak Remix)“ von CamelPhat.",
+      "fun_fact_es": "«Cola» aparece en el lanzamiento «Cola (Tutara Peak Remix)» de CamelPhat.",
+      "fun_fact_fr": "« Cola » figure sur la publication « Cola (Tutara Peak Remix) » de CamelPhat.",
+      "fun_fact_nl": "‘Cola’ staat op de release ‘Cola (Tutara Peak Remix)’ van CamelPhat.",
+      "alt_artists": [
+        "MK, Dom Dolla",
+        "Arno Cost, Arias",
+        "Dom Dolla"
+      ]
+    },
+    {
+      "artist": "Fred again..",
+      "title": "Delilah (Pull Me Out of This)",
+      "year": 2022,
+      "isrc": "GBAHS2201028",
+      "uri": "spotify:track:3YHOVyF4lBX2lL6MMTTHEj",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1924777117",
+      "fun_fact": "“Delilah (Pull Me Out of This)” is the title track of Fred again..’s release of the same name.",
+      "fun_fact_de": "„Delilah (Pull Me Out of This)“ ist der Titelsong der gleichnamigen Veröffentlichung von Fred again...",
+      "fun_fact_es": "«Delilah (Pull Me Out of This)» es la canción que da título al lanzamiento homónimo de Fred again...",
+      "fun_fact_fr": "« Delilah (Pull Me Out of This) » est le morceau-titre de la publication éponyme de Fred again...",
+      "fun_fact_nl": "‘Delilah (Pull Me Out of This)’ is het titelnummer van de gelijknamige release van Fred again...",
+      "alt_artists": [
+        "Eliza Rose, Interplanetary Criminal",
+        "James Hype, Kelli-Leigh",
+        "James Hype"
+      ]
+    },
+    {
+      "artist": "Swedish House Mafia, Tinie Tempah",
+      "title": "Miami 2 Ibiza - Radio Edit",
+      "year": 2010,
+      "isrc": "GBAAA1000281",
+      "uri": "spotify:track:75uAivmbuGRHrOaerbrg9y",
+      "uri_apple_music": "applemusic://track/6798744299",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/6798744299"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/7261457",
+      "fun_fact": "“Miami 2 Ibiza - Radio Edit” appears on Swedish House Mafia’s release “Miami 2 Ibiza”.",
+      "fun_fact_de": "„Miami 2 Ibiza - Radio Edit“ erschien auf der Veröffentlichung „Miami 2 Ibiza“ von Swedish House Mafia.",
+      "fun_fact_es": "«Miami 2 Ibiza - Radio Edit» aparece en el lanzamiento «Miami 2 Ibiza» de Swedish House Mafia.",
+      "fun_fact_fr": "« Miami 2 Ibiza - Radio Edit » figure sur la publication « Miami 2 Ibiza » de Swedish House Mafia.",
+      "fun_fact_nl": "‘Miami 2 Ibiza - Radio Edit’ staat op de release ‘Miami 2 Ibiza’ van Swedish House Mafia.",
+      "alt_artists": [
+        "Martin Garrix, Alesso, Shaun Farrugia",
+        "John Summit, Inéz",
+        "AFROJACK, Martin Garrix, David Guetta, Amél"
+      ]
+    },
+    {
+      "artist": "Marlon Hoffstadt, DJ Daddy Trance",
+      "title": "It's That Time",
+      "year": 2023,
+      "isrc": "QM4TX2371595",
+      "uri": "spotify:track:5fF9T9SMqBKUvT06cn7kBR",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2412136495",
+      "fun_fact": "“It's That Time” is the title track of Marlon Hoffstadt’s release of the same name.",
+      "fun_fact_de": "„It's That Time“ ist der Titelsong der gleichnamigen Veröffentlichung von Marlon Hoffstadt.",
+      "fun_fact_es": "«It's That Time» es la canción que da título al lanzamiento homónimo de Marlon Hoffstadt.",
+      "fun_fact_fr": "« It's That Time » est le morceau-titre de la publication éponyme de Marlon Hoffstadt.",
+      "fun_fact_nl": "‘It's That Time’ is het titelnummer van de gelijknamige release van Marlon Hoffstadt.",
+      "alt_artists": [
+        "Sonique, The Conductor & The Cowboy",
+        "Swedish House Mafia, Niki & The Dove",
+        "Cygnus X, Rank 1"
+      ]
+    },
+    {
+      "artist": "Dimitri Vegas & Like Mike, Regi",
+      "title": "Momentum",
+      "year": 2012,
+      "isrc": "NLC281210093",
+      "uri": "spotify:track:0YfTACQlZDeIQ8SsQTeISu",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3458603891",
+      "fun_fact": "“Momentum” is the title track of Dimitri Vegas & Like Mike’s release of the same name.",
+      "fun_fact_de": "„Momentum“ ist der Titelsong der gleichnamigen Veröffentlichung von Dimitri Vegas & Like Mike.",
+      "fun_fact_es": "«Momentum» es la canción que da título al lanzamiento homónimo de Dimitri Vegas & Like Mike.",
+      "fun_fact_fr": "« Momentum » est le morceau-titre de la publication éponyme de Dimitri Vegas & Like Mike.",
+      "fun_fact_nl": "‘Momentum’ is het titelnummer van de gelijknamige release van Dimitri Vegas & Like Mike.",
+      "alt_artists": [
+        "Bastille, Audien",
+        "Oxia",
+        "Mark Knight"
+      ]
+    },
+    {
+      "artist": "deadmau5",
+      "title": "Ghosts 'n' Stuff",
+      "year": 2009,
+      "isrc": "GBTDG0900131",
+      "uri": "spotify:track:5m4taQjTIjgEBU6mWpv5OC",
+      "uri_apple_music": "applemusic://track/1824106694",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1824106694"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/89844257",
+      "fun_fact": "“Ghosts 'n' Stuff” appears on deadmau5’s release “5 years of mau5”.",
+      "fun_fact_de": "„Ghosts 'n' Stuff“ erschien auf der Veröffentlichung „5 years of mau5“ von deadmau5.",
+      "fun_fact_es": "«Ghosts 'n' Stuff» aparece en el lanzamiento «5 years of mau5» de deadmau5.",
+      "fun_fact_fr": "« Ghosts 'n' Stuff » figure sur la publication « 5 years of mau5 » de deadmau5.",
+      "fun_fact_nl": "‘Ghosts 'n' Stuff’ staat op de release ‘5 years of mau5’ van deadmau5.",
+      "alt_artists": [
+        "Tiga",
+        "NERVO",
+        "Lost Frequencies"
+      ]
+    },
+    {
+      "artist": "Cloonee, Young M.A, InntRaw, HNTR",
+      "title": "Stephanie - HNTR Remix",
+      "year": 2025,
+      "isrc": "GBKQU2506390",
+      "uri": "spotify:track:3flWoQdYrWyqUsHbURIJby",
+      "uri_apple_music": "applemusic://track/1791639249",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1791639249"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3194938041",
+      "fun_fact": "“Stephanie - HNTR Remix” is the title track of Cloonee’s release of the same name.",
+      "fun_fact_de": "„Stephanie - HNTR Remix“ ist der Titelsong der gleichnamigen Veröffentlichung von Cloonee.",
+      "fun_fact_es": "«Stephanie - HNTR Remix» es la canción que da título al lanzamiento homónimo de Cloonee.",
+      "fun_fact_fr": "« Stephanie - HNTR Remix » est le morceau-titre de la publication éponyme de Cloonee.",
+      "fun_fact_nl": "‘Stephanie - HNTR Remix’ is het titelnummer van de gelijknamige release van Cloonee.",
+      "alt_artists": [
+        "MK",
+        "Reflekt, delline bass",
+        "Adriatique, Marino Canal, Delhia De France"
+      ]
+    },
+    {
+      "artist": "Blasterjaxx, Timmy Trumpet",
+      "title": "Narco",
+      "year": 2017,
+      "isrc": "NLZ541701306",
+      "uri": "spotify:track:4TuNI3WEMyLQAKRMJmcQdA",
+      "uri_apple_music": "applemusic://track/1418145097",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1418145097"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/532996072",
+      "fun_fact": "“Narco” is the title track of Blasterjaxx’s release of the same name.",
+      "fun_fact_de": "„Narco“ ist der Titelsong der gleichnamigen Veröffentlichung von Blasterjaxx.",
+      "fun_fact_es": "«Narco» es la canción que da título al lanzamiento homónimo de Blasterjaxx.",
+      "fun_fact_fr": "« Narco » est le morceau-titre de la publication éponyme de Blasterjaxx.",
+      "fun_fact_nl": "‘Narco’ is het titelnummer van de gelijknamige release van Blasterjaxx.",
+      "alt_artists": [
+        "Jaden Bojsen, Sami Brielle",
+        "Amber Broos",
+        "Alok, ILLENIUM"
+      ]
+    },
+    {
+      "artist": "Martin Solveig, Good Times Ahead",
+      "title": "Intoxicated",
+      "year": 2015,
+      "isrc": "UK98Q1400002",
+      "uri": "spotify:track:4ggTLtqmjfUgufdVWRbxmK",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3786434292",
+      "fun_fact": "“Intoxicated” is the title track of Martin Solveig’s release of the same name.",
+      "fun_fact_de": "„Intoxicated“ ist der Titelsong der gleichnamigen Veröffentlichung von Martin Solveig.",
+      "fun_fact_es": "«Intoxicated» es la canción que da título al lanzamiento homónimo de Martin Solveig.",
+      "fun_fact_fr": "« Intoxicated » est le morceau-titre de la publication éponyme de Martin Solveig.",
+      "fun_fact_nl": "‘Intoxicated’ is het titelnummer van de gelijknamige release van Martin Solveig.",
+      "alt_artists": [
+        "Dimitri Vegas & Like Mike, Armin van Buuren, W&W",
+        "Dimitri Vegas & Like Mike",
+        "Bedrock, John Digweed, Nick Muir"
+      ]
+    },
+    {
+      "artist": "cassö, RAYE, D-Block Europe",
+      "title": "Prada",
+      "year": 2023,
+      "isrc": "GBCEN2300147",
+      "uri": "spotify:track:59NraMJsLaMCVtwXTSia8i",
+      "uri_apple_music": "applemusic://track/1722358898",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1722358898"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2403785095",
+      "fun_fact": "“Prada” is the title track of cassö’s release of the same name.",
+      "fun_fact_de": "„Prada“ ist der Titelsong der gleichnamigen Veröffentlichung von cassö.",
+      "fun_fact_es": "«Prada» es la canción que da título al lanzamiento homónimo de cassö.",
+      "fun_fact_fr": "« Prada » est le morceau-titre de la publication éponyme de cassö.",
+      "fun_fact_nl": "‘Prada’ is het titelnummer van de gelijknamige release van cassö.",
+      "alt_artists": [
+        "Kaskade, Punctual, Poppy Baskcomb",
+        "Dimension",
+        "CamelPhat, Yannis, Foals"
+      ]
+    },
+    {
+      "artist": "Sander van Doorn, Martin Garrix, DVBBS, Aleesia",
+      "title": "Gold Skies (feat. Aleesia) - Radio Edit",
+      "year": 2014,
+      "isrc": "NLZ541400459",
+      "uri": "spotify:track:7KC9bnTvAbU3gJTBej0qP3",
+      "uri_apple_music": "applemusic://track/1359863336",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1359863336"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/465809482",
+      "fun_fact": "“Gold Skies (feat. Aleesia) - Radio Edit” is the title track of Sander van Doorn’s release of the same name.",
+      "fun_fact_de": "„Gold Skies (feat. Aleesia) - Radio Edit“ ist der Titelsong der gleichnamigen Veröffentlichung von Sander van Doorn.",
+      "fun_fact_es": "«Gold Skies (feat. Aleesia) - Radio Edit» es la canción que da título al lanzamiento homónimo de Sander van Doorn.",
+      "fun_fact_fr": "« Gold Skies (feat. Aleesia) - Radio Edit » est le morceau-titre de la publication éponyme de Sander van Doorn.",
+      "fun_fact_nl": "‘Gold Skies (feat. Aleesia) - Radio Edit’ is het titelnummer van de gelijknamige release van Sander van Doorn.",
+      "alt_artists": [
+        "Barry Can't Swim",
+        "Art Of Trance, Ferry Corsten",
+        "Calvin Harris, Ne-Yo"
+      ]
+    },
+    {
+      "artist": "Faithless",
+      "title": "God Is a DJ",
+      "year": 1998,
+      "isrc": "USAR19800589",
+      "uri": "spotify:track:1pUFYb9peWkK8m1WCKNRjp",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/560281",
+      "fun_fact": "“God Is a DJ” appears on Faithless’s release “Forever Faithless - The Greatest Hits”.",
+      "fun_fact_de": "„God Is a DJ“ erschien auf der Veröffentlichung „Forever Faithless - The Greatest Hits“ von Faithless.",
+      "fun_fact_es": "«God Is a DJ» aparece en el lanzamiento «Forever Faithless - The Greatest Hits» de Faithless.",
+      "fun_fact_fr": "« God Is a DJ » figure sur la publication « Forever Faithless - The Greatest Hits » de Faithless.",
+      "fun_fact_nl": "‘God Is a DJ’ staat op de release ‘Forever Faithless - The Greatest Hits’ van Faithless.",
+      "alt_artists": [
+        "Shouse, David Guetta",
+        "Fred again.., Obongjayar",
+        "Dimitri Vegas, Like Mike, Dada Life"
+      ]
+    },
+    {
+      "artist": "Sia, Diplo, Labrinth, LSD, Lost Frequencies",
+      "title": "Thunderclouds - Lost Frequencies Remix",
+      "year": 2018,
+      "isrc": "USQX91803039",
+      "uri": "spotify:track:5xQyeo1rXqNAMgZhFXv8z7",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/569832342",
+      "fun_fact": "“Thunderclouds - Lost Frequencies Remix” appears on Sia’s release “Thunderclouds (feat. Sia, Diplo & Labrinth) (Lost Frequencies Remix)”.",
+      "fun_fact_de": "„Thunderclouds - Lost Frequencies Remix“ erschien auf der Veröffentlichung „Thunderclouds (feat. Sia, Diplo & Labrinth) (Lost Frequencies Remix)“ von Sia.",
+      "fun_fact_es": "«Thunderclouds - Lost Frequencies Remix» aparece en el lanzamiento «Thunderclouds (feat. Sia, Diplo & Labrinth) (Lost Frequencies Remix)» de Sia.",
+      "fun_fact_fr": "« Thunderclouds - Lost Frequencies Remix » figure sur la publication « Thunderclouds (feat. Sia, Diplo & Labrinth) (Lost Frequencies Remix) » de Sia.",
+      "fun_fact_nl": "‘Thunderclouds - Lost Frequencies Remix’ staat op de release ‘Thunderclouds (feat. Sia, Diplo & Labrinth) (Lost Frequencies Remix)’ van Sia.",
+      "alt_artists": [
+        "Skrillex, Starrah, Four Tet",
+        "Kaskade",
+        "Becky Hill, Galantis"
+      ]
+    },
+    {
+      "artist": "Cassian, YOTTO, Da Hool",
+      "title": "Love Parade",
+      "year": 2025,
+      "isrc": "USA2P2546024",
+      "uri": "spotify:track:6sx8YefY3PQgfY8TpVg34w",
+      "uri_apple_music": "applemusic://track/1839520457",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1839520457"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3554039341",
+      "fun_fact": "“Love Parade” is the title track of Cassian’s release of the same name.",
+      "fun_fact_de": "„Love Parade“ ist der Titelsong der gleichnamigen Veröffentlichung von Cassian.",
+      "fun_fact_es": "«Love Parade» es la canción que da título al lanzamiento homónimo de Cassian.",
+      "fun_fact_fr": "« Love Parade » est le morceau-titre de la publication éponyme de Cassian.",
+      "fun_fact_nl": "‘Love Parade’ is het titelnummer van de gelijknamige release van Cassian.",
+      "alt_artists": [
+        "Diplo, HUGEL, Julia Church",
+        "Tiësto, Mesto",
+        "Anyma, Argy, MAGNUS"
+      ]
+    },
+    {
+      "artist": "The Bloody Beetroots, Steve Aoki",
+      "title": "Warp 1.9 (feat. Steve Aoki)",
+      "year": 2009,
+      "isrc": "USDM31000170",
+      "uri": "spotify:track:0HIruANJzlQkYwlpvh8cn6",
+      "uri_apple_music": "applemusic://track/1439631915",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1439631915"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2458883615",
+      "fun_fact": "“Warp 1.9 (feat. Steve Aoki)” appears on The Bloody Beetroots’s release “DIM MAK 20th Anniversary”.",
+      "fun_fact_de": "„Warp 1.9 (feat. Steve Aoki)“ erschien auf der Veröffentlichung „DIM MAK 20th Anniversary“ von The Bloody Beetroots.",
+      "fun_fact_es": "«Warp 1.9 (feat. Steve Aoki)» aparece en el lanzamiento «DIM MAK 20th Anniversary» de The Bloody Beetroots.",
+      "fun_fact_fr": "« Warp 1.9 (feat. Steve Aoki) » figure sur la publication « DIM MAK 20th Anniversary » de The Bloody Beetroots.",
+      "fun_fact_nl": "‘Warp 1.9 (feat. Steve Aoki)’ staat op de release ‘DIM MAK 20th Anniversary’ van The Bloody Beetroots.",
+      "alt_artists": [
+        "Cloonee, Young M.A, InntRaw, HNTR",
+        "Chris Lake, Sammy Virji, Nathan Nicholson",
+        "Laidback Luke, Chris Lorenzo"
+      ]
+    },
+    {
+      "artist": "Kölsch, Troels Abrahamsen",
+      "title": "All that matters",
+      "year": 2013,
+      "isrc": "DEU671300130",
+      "uri": "spotify:track:5hGBJKU8aJaZPVSV7NxoTp",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/68788684",
+      "fun_fact": "“All that matters” appears on Kölsch’s release “1977”.",
+      "fun_fact_de": "„All that matters“ erschien auf der Veröffentlichung „1977“ von Kölsch.",
+      "fun_fact_es": "«All that matters» aparece en el lanzamiento «1977» de Kölsch.",
+      "fun_fact_fr": "« All that matters » figure sur la publication « 1977 » de Kölsch.",
+      "fun_fact_nl": "‘All that matters’ staat op de release ‘1977’ van Kölsch.",
+      "alt_artists": [
+        "Swedish House Mafia, Niki & The Dove",
+        "DJ Hyperactive, Len Faki",
+        "Axwell, Dirty South, Rudy"
+      ]
+    },
+    {
+      "artist": "Underworld",
+      "title": "Born Slippy (Nuxx)",
+      "year": 1995,
+      "isrc": "UK7EF9500001",
+      "uri": "spotify:track:7xQYVjs4wZNdCwO0EeAWMC",
+      "uri_apple_music": "applemusic://track/1445884058",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1445884058"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/82265248",
+      "fun_fact": "“Born Slippy (Nuxx)” appears on Underworld’s release “1992 - 2012”.",
+      "fun_fact_de": "„Born Slippy (Nuxx)“ erschien auf der Veröffentlichung „1992 - 2012“ von Underworld.",
+      "fun_fact_es": "«Born Slippy (Nuxx)» aparece en el lanzamiento «1992 - 2012» de Underworld.",
+      "fun_fact_fr": "« Born Slippy (Nuxx) » figure sur la publication « 1992 - 2012 » de Underworld.",
+      "fun_fact_nl": "‘Born Slippy (Nuxx)’ staat op de release ‘1992 - 2012’ van Underworld.",
+      "alt_artists": [
+        "PAWSA, The Adventures Of Stevie V",
+        "Gouryella, Ferry Corsten",
+        "Djuma Soundsystem"
+      ]
+    },
+    {
+      "artist": "Coldplay",
+      "title": "Paradise - Fedde le Grand Remix",
+      "year": 2011,
+      "isrc": "GBAYE1101454",
+      "uri": "spotify:track:7BOSqLjA3lnA3dKh29pOuQ",
+      "uri_apple_music": "applemusic://track/665202776",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/665202776"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/34563951",
+      "fun_fact": "“Paradise - Fedde le Grand Remix” appears on Coldplay’s release “Princess of China”.",
+      "fun_fact_de": "„Paradise - Fedde le Grand Remix“ erschien auf der Veröffentlichung „Princess of China“ von Coldplay.",
+      "fun_fact_es": "«Paradise - Fedde le Grand Remix» aparece en el lanzamiento «Princess of China» de Coldplay.",
+      "fun_fact_fr": "« Paradise - Fedde le Grand Remix » figure sur la publication « Princess of China » de Coldplay.",
+      "fun_fact_nl": "‘Paradise - Fedde le Grand Remix’ staat op de release ‘Princess of China’ van Coldplay.",
+      "alt_artists": [
+        "Dirty South, Evermore",
+        "Fred again.., The Blessed Madonna",
+        "The Weeknd, Swedish House Mafia"
+      ]
+    },
+    {
+      "artist": "Adam Beyer, Bart Skils",
+      "title": "Your Mind",
+      "year": 2018,
+      "isrc": "GBUR61700227",
+      "uri": "spotify:track:5NZdurYcFYOg3s2YyzeVgE",
+      "uri_apple_music": "applemusic://track/1700668296",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1700668296"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2393352885",
+      "fun_fact": "“Your Mind” is the title track of Adam Beyer’s release of the same name.",
+      "fun_fact_de": "„Your Mind“ ist der Titelsong der gleichnamigen Veröffentlichung von Adam Beyer.",
+      "fun_fact_es": "«Your Mind» es la canción que da título al lanzamiento homónimo de Adam Beyer.",
+      "fun_fact_fr": "« Your Mind » est le morceau-titre de la publication éponyme de Adam Beyer.",
+      "fun_fact_nl": "‘Your Mind’ is het titelnummer van de gelijknamige release van Adam Beyer.",
+      "alt_artists": [
+        "ARTY, NK",
+        "Tiësto",
+        "Above & Beyond"
+      ]
+    },
+    {
+      "artist": "Axwell /\\ Ingrosso, Axwell, Sebastian Ingrosso",
+      "title": "On My Way",
+      "year": 2015,
+      "isrc": "USUG11500277",
+      "uri": "spotify:track:5zATs59c3mikRxLK6ODE0p",
+      "uri_apple_music": "applemusic://track/6798409419",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/6798409419"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/437979102",
+      "fun_fact": "“On My Way” appears on Axwell /\\ Ingrosso’s release “More Than You Know”.",
+      "fun_fact_de": "„On My Way“ erschien auf der Veröffentlichung „More Than You Know“ von Axwell /\\ Ingrosso.",
+      "fun_fact_es": "«On My Way» aparece en el lanzamiento «More Than You Know» de Axwell /\\ Ingrosso.",
+      "fun_fact_fr": "« On My Way » figure sur la publication « More Than You Know » de Axwell /\\ Ingrosso.",
+      "fun_fact_nl": "‘On My Way’ staat op de release ‘More Than You Know’ van Axwell /\\ Ingrosso.",
+      "alt_artists": [
+        "Eats Everything, Charlotte de Witte",
+        "Cassian, YOTTO, Da Hool",
+        "The Temper Trap, John Summit, Silver Panda"
+      ]
+    },
+    {
+      "artist": "KI/KI, Marlon Hoffstadt",
+      "title": "Losing Control",
+      "year": 2025,
+      "isrc": "USUG12505959",
+      "uri": "spotify:track:3gJ16QEGGhLFPNLvbXgB1u",
+      "uri_apple_music": "applemusic://track/1829909740",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1829909740"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3487145721",
+      "fun_fact": "“Losing Control” is the title track of KI/KI’s release of the same name.",
+      "fun_fact_de": "„Losing Control“ ist der Titelsong der gleichnamigen Veröffentlichung von KI/KI.",
+      "fun_fact_es": "«Losing Control» es la canción que da título al lanzamiento homónimo de KI/KI.",
+      "fun_fact_fr": "« Losing Control » est le morceau-titre de la publication éponyme de KI/KI.",
+      "fun_fact_nl": "‘Losing Control’ is het titelnummer van de gelijknamige release van KI/KI.",
+      "alt_artists": [
+        "Rusko, Netsky",
+        "Riva",
+        "Martin Solveig, ALMA"
+      ]
+    },
+    {
+      "artist": "Alesso",
+      "title": "Take My Breath Away",
+      "year": 2016,
+      "isrc": "GBUM71605899",
+      "uri": "spotify:track:2U1uiiXgExCpPr4GhLGJMv",
+      "uri_apple_music": "applemusic://track/1444623986",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1444623986"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/134527712",
+      "fun_fact": "“Take My Breath Away” is the title track of Alesso’s release of the same name.",
+      "fun_fact_de": "„Take My Breath Away“ ist der Titelsong der gleichnamigen Veröffentlichung von Alesso.",
+      "fun_fact_es": "«Take My Breath Away» es la canción que da título al lanzamiento homónimo de Alesso.",
+      "fun_fact_fr": "« Take My Breath Away » est le morceau-titre de la publication éponyme de Alesso.",
+      "fun_fact_nl": "‘Take My Breath Away’ is het titelnummer van de gelijknamige release van Alesso.",
+      "alt_artists": [
+        "Dubfire",
+        "Notre Dame",
+        "DJ Hyperactive, Len Faki"
+      ]
+    },
+    {
+      "artist": "The Chainsmokers, Daya",
+      "title": "Don't Let Me Down",
+      "year": 2016,
+      "isrc": "USQX91600011",
+      "uri": "spotify:track:1i1fxkWeaMmKEB4T7zqbzK",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/119302924",
+      "fun_fact": "“Don't Let Me Down” is the title track of The Chainsmokers’s release of the same name.",
+      "fun_fact_de": "„Don't Let Me Down“ ist der Titelsong der gleichnamigen Veröffentlichung von The Chainsmokers.",
+      "fun_fact_es": "«Don't Let Me Down» es la canción que da título al lanzamiento homónimo de The Chainsmokers.",
+      "fun_fact_fr": "« Don't Let Me Down » est le morceau-titre de la publication éponyme de The Chainsmokers.",
+      "fun_fact_nl": "‘Don't Let Me Down’ is het titelnummer van de gelijknamige release van The Chainsmokers.",
+      "alt_artists": [
+        "Format:B",
+        "Red Carpet, Brad Carter",
+        "Marco V"
+      ]
+    },
+    {
+      "artist": "Avicii",
+      "title": "Fade Into Darkness",
+      "year": 2010,
+      "isrc": "CH3131140002",
+      "uri": "spotify:track:4DLwNoXDVKX1R2Xemojfsx",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/12914365",
+      "fun_fact": "“Fade Into Darkness” is the title track of Avicii’s release of the same name.",
+      "fun_fact_de": "„Fade Into Darkness“ ist der Titelsong der gleichnamigen Veröffentlichung von Avicii.",
+      "fun_fact_es": "«Fade Into Darkness» es la canción que da título al lanzamiento homónimo de Avicii.",
+      "fun_fact_fr": "« Fade Into Darkness » est le morceau-titre de la publication éponyme de Avicii.",
+      "fun_fact_nl": "‘Fade Into Darkness’ is het titelnummer van de gelijknamige release van Avicii.",
+      "alt_artists": [
+        "ACRAZE, Cherish",
+        "Veracocha",
+        "Alan Fitzpatrick"
+      ]
+    },
+    {
+      "artist": "Mau P",
+      "title": "Drugs From Amsterdam",
+      "year": 2022,
+      "isrc": "GBK6Y2251421",
+      "uri": "spotify:track:0w7JPlp7eEQI2EKW3ayXrv",
+      "uri_apple_music": "applemusic://track/1645283575",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1645283575"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1914037957",
+      "fun_fact": "“Drugs From Amsterdam” is the title track of Mau P’s release of the same name.",
+      "fun_fact_de": "„Drugs From Amsterdam“ ist der Titelsong der gleichnamigen Veröffentlichung von Mau P.",
+      "fun_fact_es": "«Drugs From Amsterdam» es la canción que da título al lanzamiento homónimo de Mau P.",
+      "fun_fact_fr": "« Drugs From Amsterdam » est le morceau-titre de la publication éponyme de Mau P.",
+      "fun_fact_nl": "‘Drugs From Amsterdam’ is het titelnummer van de gelijknamige release van Mau P.",
+      "alt_artists": [
+        "Mike Williams, Mesto",
+        "The Chainsmokers, Daya, W&W",
+        "Armin van Buuren, Jan Vayne"
+      ]
+    },
+    {
+      "artist": "AFROJACK, Steve Aoki, Miss Palmer",
+      "title": "No Beef (feat. Miss Palmer) - Radio Edit",
+      "year": 2011,
+      "isrc": "NLC281112041",
+      "uri": "spotify:track:5VObsx4Uaz3KxZEO58knf3",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/497189682",
+      "fun_fact": "“No Beef (feat. Miss Palmer) - Radio Edit” appears on AFROJACK’s release “No Beef”.",
+      "fun_fact_de": "„No Beef (feat. Miss Palmer) - Radio Edit“ erschien auf der Veröffentlichung „No Beef“ von AFROJACK.",
+      "fun_fact_es": "«No Beef (feat. Miss Palmer) - Radio Edit» aparece en el lanzamiento «No Beef» de AFROJACK.",
+      "fun_fact_fr": "« No Beef (feat. Miss Palmer) - Radio Edit » figure sur la publication « No Beef » de AFROJACK.",
+      "fun_fact_nl": "‘No Beef (feat. Miss Palmer) - Radio Edit’ staat op de release ‘No Beef’ van AFROJACK.",
+      "alt_artists": [
+        "Zedd, Matthew Koma",
+        "Lucas & Steve, Tungevaag",
+        "Armin van Buuren, Sunnery James & Ryan Marciano"
+      ]
+    },
+    {
+      "artist": "Eelke Kleijn, Joris Voorn",
+      "title": "Transmission - Joris Voorn Remix",
+      "year": 2022,
+      "isrc": "NLF712208018",
+      "uri": "spotify:track:4erTmDzoe6WZBDl0WCo9Xi",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1963312247",
+      "fun_fact": "“Transmission - Joris Voorn Remix” is the title track of Eelke Kleijn’s release of the same name.",
+      "fun_fact_de": "„Transmission - Joris Voorn Remix“ ist der Titelsong der gleichnamigen Veröffentlichung von Eelke Kleijn.",
+      "fun_fact_es": "«Transmission - Joris Voorn Remix» es la canción que da título al lanzamiento homónimo de Eelke Kleijn.",
+      "fun_fact_fr": "« Transmission - Joris Voorn Remix » est le morceau-titre de la publication éponyme de Eelke Kleijn.",
+      "fun_fact_nl": "‘Transmission - Joris Voorn Remix’ is het titelnummer van de gelijknamige release van Eelke Kleijn.",
+      "alt_artists": [
+        "Otto Knows, Avicii",
+        "Gotye, FISHER, Chris Lake, Sante Sansone, Kimbra",
+        "Tiësto, The Chainsmokers"
+      ]
+    },
+    {
+      "artist": "Laidback Luke, Steve Angello",
+      "title": "Be",
+      "year": 2007,
+      "isrc": "NL8FJ2500117",
+      "uri": "spotify:track:3I0UjPySADLVy9Li9fQjDg",
+      "uri_apple_music": "applemusic://track/1703889793",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1703889793"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3455108951",
+      "fun_fact": "“Be” is the title track of Laidback Luke’s release of the same name.",
+      "fun_fact_de": "„Be“ ist der Titelsong der gleichnamigen Veröffentlichung von Laidback Luke.",
+      "fun_fact_es": "«Be» es la canción que da título al lanzamiento homónimo de Laidback Luke.",
+      "fun_fact_fr": "« Be » est le morceau-titre de la publication éponyme de Laidback Luke.",
+      "fun_fact_nl": "‘Be’ is het titelnummer van de gelijknamige release van Laidback Luke.",
+      "alt_artists": [
+        "Dirty South, Rudy",
+        "Adrian Lux",
+        "Martin Garrix, Justin Mylo, Dewain Whitmore"
+      ]
+    },
+    {
+      "artist": "Yeah Yeah Yeahs, A-Trak",
+      "title": "Heads Will Roll - A-Trak Remix",
+      "year": 2009,
+      "isrc": "USUM70906794",
+      "uri": "spotify:track:5bs8OXiOt4BPF2FAnRFP1u",
+      "uri_apple_music": "applemusic://track/1444267020",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1444267020"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/5250944",
+      "fun_fact": "“Heads Will Roll - A-Trak Remix” is the title track of Yeah Yeah Yeahs’s release of the same name.",
+      "fun_fact_de": "„Heads Will Roll - A-Trak Remix“ ist der Titelsong der gleichnamigen Veröffentlichung von Yeah Yeah Yeahs.",
+      "fun_fact_es": "«Heads Will Roll - A-Trak Remix» es la canción que da título al lanzamiento homónimo de Yeah Yeah Yeahs.",
+      "fun_fact_fr": "« Heads Will Roll - A-Trak Remix » est le morceau-titre de la publication éponyme de Yeah Yeah Yeahs.",
+      "fun_fact_nl": "‘Heads Will Roll - A-Trak Remix’ is het titelnummer van de gelijknamige release van Yeah Yeah Yeahs.",
+      "alt_artists": [
+        "Benny Benassi, Gary Go",
+        "Hardwell, Trevor Guthrie, Sunnery James & Ryan Marciano",
+        "Diplo, SIDEPIECE"
+      ]
+    },
+    {
+      "artist": "RÜFÜS DU SOL, Cassian",
+      "title": "On My Knees - Cassian Remix",
+      "year": 2022,
+      "isrc": "USRE12200387",
+      "uri": "spotify:track:6W98FIcVdbIbU3jdhKBuTO",
+      "uri_apple_music": "applemusic://track/1624098054",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1624098054"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1751207817",
+      "fun_fact": "“On My Knees - Cassian Remix” is the title track of RÜFÜS DU SOL’s release of the same name.",
+      "fun_fact_de": "„On My Knees - Cassian Remix“ ist der Titelsong der gleichnamigen Veröffentlichung von RÜFÜS DU SOL.",
+      "fun_fact_es": "«On My Knees - Cassian Remix» es la canción que da título al lanzamiento homónimo de RÜFÜS DU SOL.",
+      "fun_fact_fr": "« On My Knees - Cassian Remix » est le morceau-titre de la publication éponyme de RÜFÜS DU SOL.",
+      "fun_fact_nl": "‘On My Knees - Cassian Remix’ is het titelnummer van de gelijknamige release van RÜFÜS DU SOL.",
+      "alt_artists": [
+        "Julien Jabre, Jerome Sydenham, Sebastian Ingrosso",
+        "Don Diablo",
+        "KI/KI, Marlon Hoffstadt"
+      ]
+    },
+    {
+      "artist": "Axwell /\\ Ingrosso, Axwell, Sebastian Ingrosso",
+      "title": "Dreamer",
+      "year": 2017,
+      "isrc": "GBUM71706224",
+      "uri": "spotify:track:0RTzJVkunbGwuRjXDFHnjf",
+      "uri_apple_music": "applemusic://track/6798405718",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/6798405718"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/435827332",
+      "fun_fact": "“Dreamer” is the title track of Axwell /\\ Ingrosso’s release of the same name.",
+      "fun_fact_de": "„Dreamer“ ist der Titelsong der gleichnamigen Veröffentlichung von Axwell /\\ Ingrosso.",
+      "fun_fact_es": "«Dreamer» es la canción que da título al lanzamiento homónimo de Axwell /\\ Ingrosso.",
+      "fun_fact_fr": "« Dreamer » est le morceau-titre de la publication éponyme de Axwell /\\ Ingrosso.",
+      "fun_fact_nl": "‘Dreamer’ is het titelnummer van de gelijknamige release van Axwell /\\ Ingrosso.",
+      "alt_artists": [
+        "Dj Bountyhunter",
+        "AFROJACK, WRABEL",
+        "Supermode, Axwell, Steve Angello"
+      ]
+    },
+    {
+      "artist": "Jaden Bojsen, Sami Brielle",
+      "title": "LET'S GO",
+      "year": 2024,
+      "isrc": "UKWLG2400097",
+      "uri": "spotify:track:20Y4EAmSXru3foatDg4OqN",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3016411391",
+      "fun_fact": "“LET'S GO” is the title track of Jaden Bojsen’s release of the same name.",
+      "fun_fact_de": "„LET'S GO“ ist der Titelsong der gleichnamigen Veröffentlichung von Jaden Bojsen.",
+      "fun_fact_es": "«LET'S GO» es la canción que da título al lanzamiento homónimo de Jaden Bojsen.",
+      "fun_fact_fr": "« LET'S GO » est le morceau-titre de la publication éponyme de Jaden Bojsen.",
+      "fun_fact_nl": "‘LET'S GO’ is het titelnummer van de gelijknamige release van Jaden Bojsen.",
+      "alt_artists": [
+        "The Chainsmokers, Daya",
+        "CamelPhat, Cristoph, Jem Cooke",
+        "Alesso, Katy Perry"
+      ]
+    },
+    {
+      "artist": "Armin van Buuren, Jan Vayne",
+      "title": "Serenity",
+      "year": 2005,
+      "isrc": "NLF710500373",
+      "uri": "spotify:track:2S8fffwnxwY4F9bdeTLDIv",
+      "uri_apple_music": "applemusic://track/78991531",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/78991531"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/361256851",
+      "fun_fact": "“Serenity” appears on Armin van Buuren’s release “The Best Of Armin Only”.",
+      "fun_fact_de": "„Serenity“ erschien auf der Veröffentlichung „The Best Of Armin Only“ von Armin van Buuren.",
+      "fun_fact_es": "«Serenity» aparece en el lanzamiento «The Best Of Armin Only» de Armin van Buuren.",
+      "fun_fact_fr": "« Serenity » figure sur la publication « The Best Of Armin Only » de Armin van Buuren.",
+      "fun_fact_nl": "‘Serenity’ staat op de release ‘The Best Of Armin Only’ van Armin van Buuren.",
+      "alt_artists": [
+        "Sebastian Ingrosso",
+        "Pleasurekraft",
+        "Niels Van Gogh, Tiësto"
+      ]
+    },
+    {
+      "artist": "Anyma, Cassian, Poppy Baskcomb",
+      "title": "Save Me",
+      "year": 2023,
+      "isrc": "USUG12303926",
+      "uri": "spotify:track:4b2rlKIqyLxpxoIaG7sZ5K",
+      "uri_apple_music": "applemusic://track/1698794080",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1698794080"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2395987955",
+      "fun_fact": "“Save Me” appears on Anyma’s release “Genesys”.",
+      "fun_fact_de": "„Save Me“ erschien auf der Veröffentlichung „Genesys“ von Anyma.",
+      "fun_fact_es": "«Save Me» aparece en el lanzamiento «Genesys» de Anyma.",
+      "fun_fact_fr": "« Save Me » figure sur la publication « Genesys » de Anyma.",
+      "fun_fact_nl": "‘Save Me’ staat op de release ‘Genesys’ van Anyma.",
+      "alt_artists": [
+        "Chris Lake",
+        "Tujamo",
+        "Tiësto"
+      ]
+    },
+    {
+      "artist": "Martin Garrix, Matisse & Sadko, Alex Aris",
+      "title": "Mistaken (feat. Alex Aris)",
+      "year": 2019,
+      "isrc": "NLM5S1900480",
+      "uri": "spotify:track:18KjYhghq6K3ZmfcewWDp6",
+      "uri_apple_music": "applemusic://track/1457833015",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1457833015"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/655766662",
+      "fun_fact": "“Mistaken (feat. Alex Aris)” is the title track of Martin Garrix’s release of the same name.",
+      "fun_fact_de": "„Mistaken (feat. Alex Aris)“ ist der Titelsong der gleichnamigen Veröffentlichung von Martin Garrix.",
+      "fun_fact_es": "«Mistaken (feat. Alex Aris)» es la canción que da título al lanzamiento homónimo de Martin Garrix.",
+      "fun_fact_fr": "« Mistaken (feat. Alex Aris) » est le morceau-titre de la publication éponyme de Martin Garrix.",
+      "fun_fact_nl": "‘Mistaken (feat. Alex Aris)’ is het titelnummer van de gelijknamige release van Martin Garrix.",
+      "alt_artists": [
+        "Chris Lake, Alexis Roberts",
+        "Lost Frequencies, Flynn",
+        "Martin Garrix, Khalid, DubVision"
+      ]
+    },
+    {
+      "artist": "KI/KI",
+      "title": "What’s a Girl to Do in ‘25",
+      "year": 2025,
+      "isrc": "USA2P2544761",
+      "uri": "spotify:track:4XsQ5Iq8VUNAY006J7GQY0",
+      "uri_apple_music": "applemusic://track/1837319642",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1837319642"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3538037341",
+      "fun_fact": "“What’s a Girl to Do in ‘25” is the title track of KI/KI’s release of the same name.",
+      "fun_fact_de": "„What’s a Girl to Do in ‘25“ ist der Titelsong der gleichnamigen Veröffentlichung von KI/KI.",
+      "fun_fact_es": "«What’s a Girl to Do in ‘25» es la canción que da título al lanzamiento homónimo de KI/KI.",
+      "fun_fact_fr": "« What’s a Girl to Do in ‘25 » est le morceau-titre de la publication éponyme de KI/KI.",
+      "fun_fact_nl": "‘What’s a Girl to Do in ‘25’ is het titelnummer van de gelijknamige release van KI/KI.",
+      "alt_artists": [
+        "Dennis Ferrer",
+        "The Bloody Beetroots, Steve Aoki",
+        "The Chainsmokers, Bebe Rexha"
+      ]
+    },
+    {
+      "artist": "Zedd, Matthew Koma",
+      "title": "Spectrum",
+      "year": 2012,
+      "isrc": "USUM71205604",
+      "uri": "spotify:track:1dFkD1JfRMzwO6hwUsE8aS",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/60904698",
+      "fun_fact": "“Spectrum” appears on Zedd’s release “Clarity”.",
+      "fun_fact_de": "„Spectrum“ erschien auf der Veröffentlichung „Clarity“ von Zedd.",
+      "fun_fact_es": "«Spectrum» aparece en el lanzamiento «Clarity» de Zedd.",
+      "fun_fact_fr": "« Spectrum » figure sur la publication « Clarity » de Zedd.",
+      "fun_fact_nl": "‘Spectrum’ staat op de release ‘Clarity’ van Zedd.",
+      "alt_artists": [
+        "Duke Dumont",
+        "Kaskade, Punctual, Poppy Baskcomb",
+        "Black Coffee, David Guetta, Delilah Montagu"
+      ]
+    },
+    {
+      "artist": "Chicane, Moya Brennan",
+      "title": "Saltwater",
+      "year": 1999,
+      "isrc": "NLF711203806",
+      "uri": "spotify:track:05c4AAJKIulqI8vQQ41Rch",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/55074011",
+      "fun_fact": "“Saltwater” is the title track of Chicane’s release of the same name.",
+      "fun_fact_de": "„Saltwater“ ist der Titelsong der gleichnamigen Veröffentlichung von Chicane.",
+      "fun_fact_es": "«Saltwater» es la canción que da título al lanzamiento homónimo de Chicane.",
+      "fun_fact_fr": "« Saltwater » est le morceau-titre de la publication éponyme de Chicane.",
+      "fun_fact_nl": "‘Saltwater’ is het titelnummer van de gelijknamige release van Chicane.",
+      "alt_artists": [
+        "Fatboy Slim, CamelPhat",
+        "Jerome Isma-Ae, Charlotte de Witte",
+        "Maceo Plex, Chromatics"
+      ]
+    },
+    {
+      "artist": "R3HAB, NERVO, Ummet Ozcan",
+      "title": "Revolution - Radio Mix",
+      "year": 2014,
+      "isrc": "NLZ541301064",
+      "uri": "spotify:track:7IXNAZEJT7wOuCerK60pQj",
+      "uri_apple_music": "applemusic://track/1359975221",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1359975221"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/452690842",
+      "fun_fact": "“Revolution - Radio Mix” is the title track of R3HAB’s release of the same name.",
+      "fun_fact_de": "„Revolution - Radio Mix“ ist der Titelsong der gleichnamigen Veröffentlichung von R3HAB.",
+      "fun_fact_es": "«Revolution - Radio Mix» es la canción que da título al lanzamiento homónimo de R3HAB.",
+      "fun_fact_fr": "« Revolution - Radio Mix » est le morceau-titre de la publication éponyme de R3HAB.",
+      "fun_fact_nl": "‘Revolution - Radio Mix’ is het titelnummer van de gelijknamige release van R3HAB.",
+      "alt_artists": [
+        "John Summit, Echoes",
+        "Overmono",
+        "Martin Garrix, Sem Vox, Jaimes"
+      ]
+    },
+    {
+      "artist": "Eric Prydz",
+      "title": "Every Day",
+      "year": 2016,
+      "isrc": "GBUM71507635",
+      "uri": "spotify:track:4j1hJwuawbvpm2q2orbgj7",
+      "uri_apple_music": "applemusic://track/1440850856",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1440850856"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/118585330",
+      "fun_fact": "“Every Day” appears on Eric Prydz’s release “Opus”.",
+      "fun_fact_de": "„Every Day“ erschien auf der Veröffentlichung „Opus“ von Eric Prydz.",
+      "fun_fact_es": "«Every Day» aparece en el lanzamiento «Opus» de Eric Prydz.",
+      "fun_fact_fr": "« Every Day » figure sur la publication « Opus » de Eric Prydz.",
+      "fun_fact_nl": "‘Every Day’ staat op de release ‘Opus’ van Eric Prydz.",
+      "alt_artists": [
+        "Tiga, Kölsch",
+        "Diplo, SIDEPIECE",
+        "David Guetta, Kid Cudi"
+      ]
+    },
+    {
+      "artist": "Tom Hangs, Shermanology",
+      "title": "Blessed Avicii - Original Mix",
+      "year": 2012,
+      "isrc": "NLE711209304",
+      "uri": "spotify:track:27Aaj2wzCod19dAh0tlUim",
+      "uri_apple_music": "applemusic://track/507582432",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/507582432"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/43872461",
+      "fun_fact": "“Blessed Avicii - Original Mix” appears on Tom Hangs’s release “Night & Day”.",
+      "fun_fact_de": "„Blessed Avicii - Original Mix“ erschien auf der Veröffentlichung „Night & Day“ von Tom Hangs.",
+      "fun_fact_es": "«Blessed Avicii - Original Mix» aparece en el lanzamiento «Night & Day» de Tom Hangs.",
+      "fun_fact_fr": "« Blessed Avicii - Original Mix » figure sur la publication « Night & Day » de Tom Hangs.",
+      "fun_fact_nl": "‘Blessed Avicii - Original Mix’ staat op de release ‘Night & Day’ van Tom Hangs.",
+      "alt_artists": [
+        "Camisra",
+        "Hardwell, KSHMR",
+        "Travis Scott, CHASE B"
+      ]
+    },
+    {
+      "artist": "Butch, Kölsch",
+      "title": "Countach - Kölsch Remix",
+      "year": 2018,
+      "isrc": "DEQ201801712",
+      "uri": "spotify:track:2mwptYSUenZkc1EL20HC30",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/465085292",
+      "fun_fact": "“Countach - Kölsch Remix” appears on Butch’s release “Countach”.",
+      "fun_fact_de": "„Countach - Kölsch Remix“ erschien auf der Veröffentlichung „Countach“ von Butch.",
+      "fun_fact_es": "«Countach - Kölsch Remix» aparece en el lanzamiento «Countach» de Butch.",
+      "fun_fact_fr": "« Countach - Kölsch Remix » figure sur la publication « Countach » de Butch.",
+      "fun_fact_nl": "‘Countach - Kölsch Remix’ staat op de release ‘Countach’ van Butch.",
+      "alt_artists": [
+        "Martin Garrix, Khalid, DubVision",
+        "HUGEL, Topic, Arash, Daecolm",
+        "CYRIL"
+      ]
+    },
+    {
+      "artist": "Armin van Buuren, Sharon Den Adel",
+      "title": "In And Out Of Love",
+      "year": 2008,
+      "isrc": "NLF710801024",
+      "uri": "spotify:track:57nKL06bKwjaM5Y0aMtY9v",
+      "uri_apple_music": "applemusic://track/1549278138",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1549278138"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/6180078",
+      "fun_fact": "“In And Out Of Love” is the title track of Armin van Buuren’s release of the same name.",
+      "fun_fact_de": "„In And Out Of Love“ ist der Titelsong der gleichnamigen Veröffentlichung von Armin van Buuren.",
+      "fun_fact_es": "«In And Out Of Love» es la canción que da título al lanzamiento homónimo de Armin van Buuren.",
+      "fun_fact_fr": "« In And Out Of Love » est le morceau-titre de la publication éponyme de Armin van Buuren.",
+      "fun_fact_nl": "‘In And Out Of Love’ is het titelnummer van de gelijknamige release van Armin van Buuren.",
+      "alt_artists": [
+        "Fish Go Deep, Tracey K, Dennis Ferrer",
+        "Calvin Harris, Disciples, Chris Lake",
+        "Matisse & Sadko"
+      ]
+    },
+    {
+      "artist": "Calvin Harris, Example",
+      "title": "We'll Be Coming Back (feat. Example)",
+      "year": 2012,
+      "isrc": "GBARL1200642",
+      "uri": "spotify:track:7B1Dl3tXqySkB8OPEwVvSu",
+      "uri_apple_music": "applemusic://track/1713469227",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1713469227"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/61142287",
+      "fun_fact": "“We'll Be Coming Back (feat. Example)” appears on Calvin Harris’s release “18 Months”.",
+      "fun_fact_de": "„We'll Be Coming Back (feat. Example)“ erschien auf der Veröffentlichung „18 Months“ von Calvin Harris.",
+      "fun_fact_es": "«We'll Be Coming Back (feat. Example)» aparece en el lanzamiento «18 Months» de Calvin Harris.",
+      "fun_fact_fr": "« We'll Be Coming Back (feat. Example) » figure sur la publication « 18 Months » de Calvin Harris.",
+      "fun_fact_nl": "‘We'll Be Coming Back (feat. Example)’ staat op de release ‘18 Months’ van Calvin Harris.",
+      "alt_artists": [
+        "Tiësto, Dzeko, Preme, Post Malone",
+        "Marc Benjamin, Marcus Santoro, David Pietras",
+        "DR. KUCHO!, Gregor Salto, Ane Brun, Oliver Heldens"
+      ]
+    },
+    {
+      "artist": "DJ Hyperactive, Len Faki",
+      "title": "Wide Open - Len Faki DjEdit",
+      "year": 2012,
+      "isrc": "DEDL81201230",
+      "uri": "spotify:track:477I4wif0etzeupmlQzTxl",
+      "uri_apple_music": "applemusic://track/1664887685",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1664887685"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2106407067",
+      "fun_fact": "“Wide Open - Len Faki DjEdit” appears on DJ Hyperactive’s release “Len Faki Dj-Edits Volume I”.",
+      "fun_fact_de": "„Wide Open - Len Faki DjEdit“ erschien auf der Veröffentlichung „Len Faki Dj-Edits Volume I“ von DJ Hyperactive.",
+      "fun_fact_es": "«Wide Open - Len Faki DjEdit» aparece en el lanzamiento «Len Faki Dj-Edits Volume I» de DJ Hyperactive.",
+      "fun_fact_fr": "« Wide Open - Len Faki DjEdit » figure sur la publication « Len Faki Dj-Edits Volume I » de DJ Hyperactive.",
+      "fun_fact_nl": "‘Wide Open - Len Faki DjEdit’ staat op de release ‘Len Faki Dj-Edits Volume I’ van DJ Hyperactive.",
+      "alt_artists": [
+        "Nosi",
+        "Dom Dolla, Anyma, Daya",
+        "Format:B"
+      ]
+    },
+    {
+      "artist": "MEDUZA, Goodboys",
+      "title": "Piece Of Your Heart",
+      "year": 2019,
+      "isrc": "DEUM71807719",
+      "uri": "spotify:track:1DFD5Fotzgn6yYXkYsKiGs",
+      "uri_apple_music": "applemusic://track/1449911564",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1449911564"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/623723282",
+      "fun_fact": "“Piece Of Your Heart” is the title track of MEDUZA’s release of the same name.",
+      "fun_fact_de": "„Piece Of Your Heart“ ist der Titelsong der gleichnamigen Veröffentlichung von MEDUZA.",
+      "fun_fact_es": "«Piece Of Your Heart» es la canción que da título al lanzamiento homónimo de MEDUZA.",
+      "fun_fact_fr": "« Piece Of Your Heart » est le morceau-titre de la publication éponyme de MEDUZA.",
+      "fun_fact_nl": "‘Piece Of Your Heart’ is het titelnummer van de gelijknamige release van MEDUZA.",
+      "alt_artists": [
+        "Ferry Corsten",
+        "RÜFÜS DU SOL, Cassian",
+        "Au/Ra, CamelPhat"
+      ]
+    },
+    {
+      "artist": "Daft Punk",
+      "title": "Around the World / Harder, Better, Faster, Stronger",
+      "year": 2007,
+      "isrc": "GBDUW0700005",
+      "uri": "spotify:track:5RByQFt9Mlo8hDYJ921tCv",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3167843",
+      "fun_fact": "“Around the World / Harder, Better, Faster, Stronger” appears on Daft Punk’s release “Alive 2007”.",
+      "fun_fact_de": "„Around the World / Harder, Better, Faster, Stronger“ erschien auf der Veröffentlichung „Alive 2007“ von Daft Punk.",
+      "fun_fact_es": "«Around the World / Harder, Better, Faster, Stronger» aparece en el lanzamiento «Alive 2007» de Daft Punk.",
+      "fun_fact_fr": "« Around the World / Harder, Better, Faster, Stronger » figure sur la publication « Alive 2007 » de Daft Punk.",
+      "fun_fact_nl": "‘Around the World / Harder, Better, Faster, Stronger’ staat op de release ‘Alive 2007’ van Daft Punk.",
+      "alt_artists": [
+        "Kevin de Vries",
+        "San Holo",
+        "Robin Schulz, Francesco Yates, Stadiumx"
+      ]
+    },
+    {
+      "artist": "John Summit, Echoes",
+      "title": "Human (feat. Echoes)",
+      "year": 2021,
+      "isrc": "GBAYE2101411",
+      "uri": "spotify:track:4G4patpYxsF6ovHZOX9wgR",
+      "uri_apple_music": "applemusic://track/1591302173",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1591302173"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1527789262",
+      "fun_fact": "“Human (feat. Echoes)” is the title track of John Summit’s release of the same name.",
+      "fun_fact_de": "„Human (feat. Echoes)“ ist der Titelsong der gleichnamigen Veröffentlichung von John Summit.",
+      "fun_fact_es": "«Human (feat. Echoes)» es la canción que da título al lanzamiento homónimo de John Summit.",
+      "fun_fact_fr": "« Human (feat. Echoes) » est le morceau-titre de la publication éponyme de John Summit.",
+      "fun_fact_nl": "‘Human (feat. Echoes)’ is het titelnummer van de gelijknamige release van John Summit.",
+      "alt_artists": [
+        "BL3SS, CamrinWatsin, bbyclose",
+        "Dash Berlin",
+        "Cassian, YOTTO, Da Hool"
+      ]
+    },
+    {
+      "artist": "Sebastian Ingrosso, Céline Dion",
+      "title": "A New Day (feat. Celine Dion)",
+      "year": 2025,
+      "isrc": "US38Y2560326",
+      "uri": "spotify:track:0NRIWkmQiSoIaEs3wvoSS7",
+      "uri_apple_music": "applemusic://track/1826684927",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1826684927"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3460217671",
+      "fun_fact": "“A New Day (feat. Celine Dion)” is the title track of Sebastian Ingrosso’s release of the same name.",
+      "fun_fact_de": "„A New Day (feat. Celine Dion)“ ist der Titelsong der gleichnamigen Veröffentlichung von Sebastian Ingrosso.",
+      "fun_fact_es": "«A New Day (feat. Celine Dion)» es la canción que da título al lanzamiento homónimo de Sebastian Ingrosso.",
+      "fun_fact_fr": "« A New Day (feat. Celine Dion) » est le morceau-titre de la publication éponyme de Sebastian Ingrosso.",
+      "fun_fact_nl": "‘A New Day (feat. Celine Dion)’ is het titelnummer van de gelijknamige release van Sebastian Ingrosso.",
+      "alt_artists": [
+        "Notre Dame",
+        "Martin Solveig",
+        "Purple Disco Machine, Sophie and the Giants"
+      ]
+    },
+    {
+      "artist": "Marshmello, Khalid, Tiësto",
+      "title": "Silence - Tiësto's Big Room Remix",
+      "year": 2017,
+      "isrc": "USRC11702627",
+      "uri": "spotify:track:3AUW7mAGx1BICBWqsuFgh4",
+      "uri_apple_music": "applemusic://track/1293887149",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1293887149"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/415278692",
+      "fun_fact": "“Silence - Tiësto's Big Room Remix” is the title track of Marshmello’s release of the same name.",
+      "fun_fact_de": "„Silence - Tiësto's Big Room Remix“ ist der Titelsong der gleichnamigen Veröffentlichung von Marshmello.",
+      "fun_fact_es": "«Silence - Tiësto's Big Room Remix» es la canción que da título al lanzamiento homónimo de Marshmello.",
+      "fun_fact_fr": "« Silence - Tiësto's Big Room Remix » est le morceau-titre de la publication éponyme de Marshmello.",
+      "fun_fact_nl": "‘Silence - Tiësto's Big Room Remix’ is het titelnummer van de gelijknamige release van Marshmello.",
+      "alt_artists": [
+        "San Holo",
+        "Öwnboss, Sevek",
+        "Chris Lake, Alexis Roberts"
+      ]
+    },
+    {
+      "artist": "Sub Focus",
+      "title": "Solar System",
+      "year": 2019,
+      "isrc": "GBUM71903244",
+      "uri": "spotify:track:5cRDn5aGMLvWsldoRmOOz0",
+      "uri_apple_music": "applemusic://track/1473152283",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1473152283"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/716493872",
+      "fun_fact": "“Solar System” appears on Sub Focus’s release “Solar System / Siren”.",
+      "fun_fact_de": "„Solar System“ erschien auf der Veröffentlichung „Solar System / Siren“ von Sub Focus.",
+      "fun_fact_es": "«Solar System» aparece en el lanzamiento «Solar System / Siren» de Sub Focus.",
+      "fun_fact_fr": "« Solar System » figure sur la publication « Solar System / Siren » de Sub Focus.",
+      "fun_fact_nl": "‘Solar System’ staat op de release ‘Solar System / Siren’ van Sub Focus.",
+      "alt_artists": [
+        "Delerium, Sarah McLachlan, John Summit",
+        "CYRIL",
+        "Martin Garrix, Justin Mylo, Dewain Whitmore"
+      ]
+    },
+    {
+      "artist": "Major Lazer, MØ, DJ Snake",
+      "title": "Lean On (feat. MØ & DJ Snake)",
+      "year": 2015,
+      "isrc": "QMUY41500042",
+      "uri": "spotify:track:2e7s0oEzUoJtDSPtYJuVvD",
+      "uri_apple_music": "applemusic://track/1694794890",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1694794890"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/445811862",
+      "fun_fact": "“Lean On (feat. MØ & DJ Snake)” appears on Major Lazer’s release “Lean On (feat. MØ & DJ Snake) [Remixes]”.",
+      "fun_fact_de": "„Lean On (feat. MØ & DJ Snake)“ erschien auf der Veröffentlichung „Lean On (feat. MØ & DJ Snake) [Remixes]“ von Major Lazer.",
+      "fun_fact_es": "«Lean On (feat. MØ & DJ Snake)» aparece en el lanzamiento «Lean On (feat. MØ & DJ Snake) [Remixes]» de Major Lazer.",
+      "fun_fact_fr": "« Lean On (feat. MØ & DJ Snake) » figure sur la publication « Lean On (feat. MØ & DJ Snake) [Remixes] » de Major Lazer.",
+      "fun_fact_nl": "‘Lean On (feat. MØ & DJ Snake)’ staat op de release ‘Lean On (feat. MØ & DJ Snake) [Remixes]’ van Major Lazer.",
+      "alt_artists": [
+        "Martin Garrix, MOTi",
+        "AN21, Max Vangeli",
+        "Jaydee"
+      ]
+    },
+    {
+      "artist": "David Guetta, Sia, MORTEN",
+      "title": "Titanium (feat. Sia) - David Guetta & MORTEN Future Rave Remix",
+      "year": 2021,
+      "isrc": "GB28K2100001",
+      "uri": "spotify:track:5072hCBK3Z15qRnTEzd8fy",
+      "uri_apple_music": "applemusic://track/1581632203",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1581632203"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1461868062",
+      "fun_fact": "“Titanium (feat. Sia) - David Guetta & MORTEN Future Rave Remix” is the title track of David Guetta’s release of the same name.",
+      "fun_fact_de": "„Titanium (feat. Sia) - David Guetta & MORTEN Future Rave Remix“ ist der Titelsong der gleichnamigen Veröffentlichung von David Guetta.",
+      "fun_fact_es": "«Titanium (feat. Sia) - David Guetta & MORTEN Future Rave Remix» es la canción que da título al lanzamiento homónimo de David Guetta.",
+      "fun_fact_fr": "« Titanium (feat. Sia) - David Guetta & MORTEN Future Rave Remix » est le morceau-titre de la publication éponyme de David Guetta.",
+      "fun_fact_nl": "‘Titanium (feat. Sia) - David Guetta & MORTEN Future Rave Remix’ is het titelnummer van de gelijknamige release van David Guetta.",
+      "alt_artists": [
+        "Zonderling, Don Diablo",
+        "Avicii",
+        "Axwell, Sebastian Ingrosso"
+      ]
+    },
+    {
+      "artist": "Zedd, Hayley Williams, Tiësto",
+      "title": "Stay The Night - Tiesto's Club Life Remix",
+      "year": 2013,
+      "isrc": "USUM71314696",
+      "uri": "spotify:track:560bmVbJ73hE75bunZ8SNa",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/79942806",
+      "fun_fact": "“Stay The Night - Tiesto's Club Life Remix” appears on Zedd’s release “Clarity (Deluxe)”.",
+      "fun_fact_de": "„Stay The Night - Tiesto's Club Life Remix“ erschien auf der Veröffentlichung „Clarity (Deluxe)“ von Zedd.",
+      "fun_fact_es": "«Stay The Night - Tiesto's Club Life Remix» aparece en el lanzamiento «Clarity (Deluxe)» de Zedd.",
+      "fun_fact_fr": "« Stay The Night - Tiesto's Club Life Remix » figure sur la publication « Clarity (Deluxe) » de Zedd.",
+      "fun_fact_nl": "‘Stay The Night - Tiesto's Club Life Remix’ staat op de release ‘Clarity (Deluxe)’ van Zedd.",
+      "alt_artists": [
+        "Marc Benjamin, Marcus Santoro, David Pietras",
+        "Wilkinson, Becky Hill",
+        "Rebūke, Konstantin Sibold, ZAC, CARMEE"
+      ]
+    },
+    {
+      "artist": "Axwell /\\ Ingrosso, RØMANS",
+      "title": "Dancing Alone",
+      "year": 2018,
+      "isrc": "USUG11801349",
+      "uri": "spotify:track:5xzzxWj8a1YBbNZhNLqWuQ",
+      "uri_apple_music": "applemusic://track/1418775756",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1418775756"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/534018462",
+      "fun_fact": "“Dancing Alone” is the title track of Axwell /\\ Ingrosso’s release of the same name.",
+      "fun_fact_de": "„Dancing Alone“ ist der Titelsong der gleichnamigen Veröffentlichung von Axwell /\\ Ingrosso.",
+      "fun_fact_es": "«Dancing Alone» es la canción que da título al lanzamiento homónimo de Axwell /\\ Ingrosso.",
+      "fun_fact_fr": "« Dancing Alone » est le morceau-titre de la publication éponyme de Axwell /\\ Ingrosso.",
+      "fun_fact_nl": "‘Dancing Alone’ is het titelnummer van de gelijknamige release van Axwell /\\ Ingrosso.",
+      "alt_artists": [
+        "Sammy Virji",
+        "Diplo, Sonny Fodera",
+        "Miss Monique"
+      ]
+    },
+    {
+      "artist": "Pryda",
+      "title": "Allein",
+      "year": 2012,
+      "isrc": "GB6CM1200011",
+      "uri": "spotify:track:15PdA8p8usmrc4lWbZmm7H",
+      "uri_apple_music": "applemusic://track/720113855",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/720113855"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/28883331",
+      "fun_fact": "“Allein” appears on Pryda’s release “Eric Prydz Presents Pryda”.",
+      "fun_fact_de": "„Allein“ erschien auf der Veröffentlichung „Eric Prydz Presents Pryda“ von Pryda.",
+      "fun_fact_es": "«Allein» aparece en el lanzamiento «Eric Prydz Presents Pryda» de Pryda.",
+      "fun_fact_fr": "« Allein » figure sur la publication « Eric Prydz Presents Pryda » de Pryda.",
+      "fun_fact_nl": "‘Allein’ staat op de release ‘Eric Prydz Presents Pryda’ van Pryda.",
+      "alt_artists": [
+        "London Grammar",
+        "Lost Frequencies, Tom Odell",
+        "Showtek, Justin Prime"
+      ]
+    },
+    {
+      "artist": "Justice, Simian",
+      "title": "We Are Your Friends - Justice Vs Simian",
+      "year": 2006,
+      "isrc": "GBAAA0600209",
+      "uri": "spotify:track:5f5RzlEgheGXEsYAvmYil8",
+      "uri_apple_music": "applemusic://track/1689611140",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1689611140"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2100102627",
+      "fun_fact": "“We Are Your Friends - Justice Vs Simian” appears on Justice’s release “We Are Your Friends”.",
+      "fun_fact_de": "„We Are Your Friends - Justice Vs Simian“ erschien auf der Veröffentlichung „We Are Your Friends“ von Justice.",
+      "fun_fact_es": "«We Are Your Friends - Justice Vs Simian» aparece en el lanzamiento «We Are Your Friends» de Justice.",
+      "fun_fact_fr": "« We Are Your Friends - Justice Vs Simian » figure sur la publication « We Are Your Friends » de Justice.",
+      "fun_fact_nl": "‘We Are Your Friends - Justice Vs Simian’ staat op de release ‘We Are Your Friends’ van Justice.",
+      "alt_artists": [
+        "Yeah Yeah Yeahs, A-Trak",
+        "Rihanna",
+        "Marlon Hoffstadt, FISHER"
+      ]
+    },
+    {
+      "artist": "Martin Garrix, MOTi",
+      "title": "Virus (How About Now) - Radio Edit",
+      "year": 2014,
+      "isrc": "NLZ541400817",
+      "uri": "spotify:track:6GLzN6o2fkOupy8e1vGzwp",
+      "uri_apple_music": "applemusic://track/1350836690",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1350836690"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/463376132",
+      "fun_fact": "“Virus (How About Now) - Radio Edit” is the title track of Martin Garrix’s release of the same name.",
+      "fun_fact_de": "„Virus (How About Now) - Radio Edit“ ist der Titelsong der gleichnamigen Veröffentlichung von Martin Garrix.",
+      "fun_fact_es": "«Virus (How About Now) - Radio Edit» es la canción que da título al lanzamiento homónimo de Martin Garrix.",
+      "fun_fact_fr": "« Virus (How About Now) - Radio Edit » est le morceau-titre de la publication éponyme de Martin Garrix.",
+      "fun_fact_nl": "‘Virus (How About Now) - Radio Edit’ is het titelnummer van de gelijknamige release van Martin Garrix.",
+      "alt_artists": [
+        "Moby",
+        "4444 OF A KIND, D-Block & S-te-Fan, Sub Zero Project",
+        "Tiësto, Dzeko, Preme, Post Malone"
+      ]
+    },
+    {
+      "artist": "David Guetta, MORTEN, Aloe Blacc",
+      "title": "Never Be Alone (feat. Aloe Blacc)",
+      "year": 2019,
+      "isrc": "GB28K1900048",
+      "uri": "spotify:track:3GT2CBmJWIEdCpHiB31WYK",
+      "uri_apple_music": "applemusic://track/1469397683",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1469397683"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/717419402",
+      "fun_fact": "“Never Be Alone (feat. Aloe Blacc)” is the title track of David Guetta’s release of the same name.",
+      "fun_fact_de": "„Never Be Alone (feat. Aloe Blacc)“ ist der Titelsong der gleichnamigen Veröffentlichung von David Guetta.",
+      "fun_fact_es": "«Never Be Alone (feat. Aloe Blacc)» es la canción que da título al lanzamiento homónimo de David Guetta.",
+      "fun_fact_fr": "« Never Be Alone (feat. Aloe Blacc) » est le morceau-titre de la publication éponyme de David Guetta.",
+      "fun_fact_nl": "‘Never Be Alone (feat. Aloe Blacc)’ is het titelnummer van de gelijknamige release van David Guetta.",
+      "alt_artists": [
+        "Mason",
+        "HUGEL, Alleh, Yorghaki",
+        "Massano"
+      ]
+    },
+    {
+      "artist": "Third Party",
+      "title": "Free",
+      "year": 2019,
+      "isrc": "USA2P1835832",
+      "uri": "spotify:track:1tOTq5hXlLeKbqOVn8ddMF",
+      "uri_apple_music": "applemusic://track/1605320590",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1605320590"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1564802172",
+      "fun_fact": "“Free” appears on Third Party’s release “TOGETHER”.",
+      "fun_fact_de": "„Free“ erschien auf der Veröffentlichung „TOGETHER“ von Third Party.",
+      "fun_fact_es": "«Free» aparece en el lanzamiento «TOGETHER» de Third Party.",
+      "fun_fact_fr": "« Free » figure sur la publication « TOGETHER » de Third Party.",
+      "fun_fact_nl": "‘Free’ staat op de release ‘TOGETHER’ van Third Party.",
+      "alt_artists": [
+        "HUGEL, Topic, Arash, Daecolm",
+        "David Guetta, Showtek",
+        "Eric Prydz, Empire Of The Sun"
+      ]
+    },
+    {
+      "artist": "Eli Brown",
+      "title": "Be The One",
+      "year": 2023,
+      "isrc": "GBUM72302199",
+      "uri": "spotify:track:1cQld05IcUDw3RCFt7uymW",
+      "uri_apple_music": "applemusic://track/1677685964",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1677685964"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2206732877",
+      "fun_fact": "“Be The One” is the title track of Eli Brown’s release of the same name.",
+      "fun_fact_de": "„Be The One“ ist der Titelsong der gleichnamigen Veröffentlichung von Eli Brown.",
+      "fun_fact_es": "«Be The One» es la canción que da título al lanzamiento homónimo de Eli Brown.",
+      "fun_fact_fr": "« Be The One » est le morceau-titre de la publication éponyme de Eli Brown.",
+      "fun_fact_nl": "‘Be The One’ is het titelnummer van de gelijknamige release van Eli Brown.",
+      "alt_artists": [
+        "Armin van Buuren, Nicky Romero, Ifimay",
+        "Sub Focus, Dimension",
+        "Topic, Fireboy DML, Nico Santos"
+      ]
+    },
+    {
+      "artist": "Au/Ra, CamelPhat",
+      "title": "Panic Room",
+      "year": 2018,
+      "isrc": "GBARL1702250",
+      "uri": "spotify:track:3MkuFR7t25mu7Iscp6GGiV",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/454539272",
+      "fun_fact": "“Panic Room” is the title track of Au/Ra’s release of the same name.",
+      "fun_fact_de": "„Panic Room“ ist der Titelsong der gleichnamigen Veröffentlichung von Au/Ra.",
+      "fun_fact_es": "«Panic Room» es la canción que da título al lanzamiento homónimo de Au/Ra.",
+      "fun_fact_fr": "« Panic Room » est le morceau-titre de la publication éponyme de Au/Ra.",
+      "fun_fact_nl": "‘Panic Room’ is het titelnummer van de gelijknamige release van Au/Ra.",
+      "alt_artists": [
+        "Alan Walker",
+        "Armin van Buuren, AVIAN GRAYS, Jordan Shaw",
+        "Fragma"
+      ]
+    },
+    {
+      "artist": "Calvin Harris, Clementine Douglas, Cassian",
+      "title": "Blessings - Cassian Remix",
+      "year": 2025,
+      "isrc": "GBARL2500986",
+      "uri": "spotify:track:3GpNIq74pzLjdIKplMvSV2",
+      "uri_apple_music": "applemusic://track/1826812710",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1826812710"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3443845841",
+      "fun_fact": "“Blessings - Cassian Remix” is the title track of Calvin Harris’s release of the same name.",
+      "fun_fact_de": "„Blessings - Cassian Remix“ ist der Titelsong der gleichnamigen Veröffentlichung von Calvin Harris.",
+      "fun_fact_es": "«Blessings - Cassian Remix» es la canción que da título al lanzamiento homónimo de Calvin Harris.",
+      "fun_fact_fr": "« Blessings - Cassian Remix » est le morceau-titre de la publication éponyme de Calvin Harris.",
+      "fun_fact_nl": "‘Blessings - Cassian Remix’ is het titelnummer van de gelijknamige release van Calvin Harris.",
+      "alt_artists": [
+        "Calvin Harris, Disciples, Chris Lake",
+        "Ahmed Spins, Stevo Atambire",
+        "Alan Fitzpatrick"
+      ]
+    },
+    {
+      "artist": "Kaskade, deadmau5",
+      "title": "I Remember",
+      "year": 2009,
+      "isrc": "GBTDG0900063",
+      "uri": "spotify:track:5miifYL53idUsDxGKjICtb",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3582295",
+      "fun_fact": "“I Remember” is the title track of Kaskade’s release of the same name.",
+      "fun_fact_de": "„I Remember“ ist der Titelsong der gleichnamigen Veröffentlichung von Kaskade.",
+      "fun_fact_es": "«I Remember» es la canción que da título al lanzamiento homónimo de Kaskade.",
+      "fun_fact_fr": "« I Remember » est le morceau-titre de la publication éponyme de Kaskade.",
+      "fun_fact_nl": "‘I Remember’ is het titelnummer van de gelijknamige release van Kaskade.",
+      "alt_artists": [
+        "Dubfire",
+        "Miss Monique",
+        "Ummet Ozcan"
+      ]
+    },
+    {
+      "artist": "Swedish House Mafia, Knife Party",
+      "title": "Antidote - Radio Edit",
+      "year": 2011,
+      "isrc": "GBAAA1100772",
+      "uri": "spotify:track:38JE3O2HocFNvtljgtlNKv",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/15666455",
+      "fun_fact": "“Antidote - Radio Edit” appears on Swedish House Mafia’s release “Antidote”.",
+      "fun_fact_de": "„Antidote - Radio Edit“ erschien auf der Veröffentlichung „Antidote“ von Swedish House Mafia.",
+      "fun_fact_es": "«Antidote - Radio Edit» aparece en el lanzamiento «Antidote» de Swedish House Mafia.",
+      "fun_fact_fr": "« Antidote - Radio Edit » figure sur la publication « Antidote » de Swedish House Mafia.",
+      "fun_fact_nl": "‘Antidote - Radio Edit’ staat op de release ‘Antidote’ van Swedish House Mafia.",
+      "alt_artists": [
+        "Pleasurekraft",
+        "Dirty South, Rudy, Axwell",
+        "Peggy Gou"
+      ]
+    },
+    {
+      "artist": "Nari, Milani",
+      "title": "ATOM",
+      "year": 2011,
+      "isrc": "ITD451200067",
+      "uri": "spotify:track:2ollq2JGmUdAeZFWHrc6PH",
+      "uri_apple_music": "applemusic://track/1845364205",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1845364205"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2448991445",
+      "fun_fact": "“ATOM” is the title track of Nari’s release of the same name.",
+      "fun_fact_de": "„ATOM“ ist der Titelsong der gleichnamigen Veröffentlichung von Nari.",
+      "fun_fact_es": "«ATOM» es la canción que da título al lanzamiento homónimo de Nari.",
+      "fun_fact_fr": "« ATOM » est le morceau-titre de la publication éponyme de Nari.",
+      "fun_fact_nl": "‘ATOM’ is het titelnummer van de gelijknamige release van Nari.",
+      "alt_artists": [
+        "Hypaton, David Guetta, La Bouche",
+        "Jaydee",
+        "Eliza Rose, Interplanetary Criminal"
+      ]
+    },
+    {
+      "artist": "Syzz, Taku-Hero, DubVision",
+      "title": "Be My Love - DubVision Remix",
+      "year": 2019,
+      "isrc": "NLQ8D1900301",
+      "uri": "spotify:track:0e73LsaWkvgC2sUVXdZcug",
+      "uri_apple_music": "applemusic://track/1464501310",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1464501310"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1755239527",
+      "fun_fact": "“Be My Love - DubVision Remix” is the title track of Syzz’s release of the same name.",
+      "fun_fact_de": "„Be My Love - DubVision Remix“ ist der Titelsong der gleichnamigen Veröffentlichung von Syzz.",
+      "fun_fact_es": "«Be My Love - DubVision Remix» es la canción que da título al lanzamiento homónimo de Syzz.",
+      "fun_fact_fr": "« Be My Love - DubVision Remix » est le morceau-titre de la publication éponyme de Syzz.",
+      "fun_fact_nl": "‘Be My Love - DubVision Remix’ is het titelnummer van de gelijknamige release van Syzz.",
+      "alt_artists": [
+        "Au/Ra, CamelPhat",
+        "Tiësto, Stargate, Aloe Blacc",
+        "Paul Woolford, Diplo, Kareen Lomax"
+      ]
+    },
+    {
+      "artist": "Fred again.., The Blessed Madonna",
+      "title": "Marea (we’ve lost dancing)",
+      "year": 2021,
+      "isrc": "GBAHS2100041",
+      "uri": "spotify:track:1t0Jmqg1pKVBbxjQFZebeR",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1239694902",
+      "fun_fact": "“Marea (we’ve lost dancing)” is the title track of Fred again..’s release of the same name.",
+      "fun_fact_de": "„Marea (we’ve lost dancing)“ ist der Titelsong der gleichnamigen Veröffentlichung von Fred again...",
+      "fun_fact_es": "«Marea (we’ve lost dancing)» es la canción que da título al lanzamiento homónimo de Fred again...",
+      "fun_fact_fr": "« Marea (we’ve lost dancing) » est le morceau-titre de la publication éponyme de Fred again...",
+      "fun_fact_nl": "‘Marea (we’ve lost dancing)’ is het titelnummer van de gelijknamige release van Fred again...",
+      "alt_artists": [
+        "Tiësto, Sevenn",
+        "Martin Garrix, Tiësto",
+        "Tiësto, Dzeko, Lena Leon"
+      ]
+    },
+    {
+      "artist": "M83, Eric Prydz",
+      "title": "Midnight City - Eric Prydz Private Remix",
+      "year": 2012,
+      "isrc": "GB55H1200001",
+      "uri": "spotify:track:0FoSiffuAmaJ3VyPaebY6I",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/139691215",
+      "fun_fact": "“Midnight City - Eric Prydz Private Remix” is the title track of M83’s release of the same name.",
+      "fun_fact_de": "„Midnight City - Eric Prydz Private Remix“ ist der Titelsong der gleichnamigen Veröffentlichung von M83.",
+      "fun_fact_es": "«Midnight City - Eric Prydz Private Remix» es la canción que da título al lanzamiento homónimo de M83.",
+      "fun_fact_fr": "« Midnight City - Eric Prydz Private Remix » est le morceau-titre de la publication éponyme de M83.",
+      "fun_fact_nl": "‘Midnight City - Eric Prydz Private Remix’ is het titelnummer van de gelijknamige release van M83.",
+      "alt_artists": [
+        "Kölsch, Gregor Schwellenbach",
+        "Ernesto vs. Bastian, Susana",
+        "CYRIL"
+      ]
+    },
+    {
+      "artist": "David Guetta, Nicky Romero",
+      "title": "Metropolis",
+      "year": 2011,
+      "isrc": "GB28K1200006",
+      "uri": "spotify:track:2x6hopxvQkOzZTBdEMyUO2",
+      "uri_apple_music": "applemusic://track/726391227",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/726391227"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/62847161",
+      "fun_fact": "“Metropolis” appears on David Guetta’s release “Nothing but the Beat (Ultimate Edition)”.",
+      "fun_fact_de": "„Metropolis“ erschien auf der Veröffentlichung „Nothing but the Beat (Ultimate Edition)“ von David Guetta.",
+      "fun_fact_es": "«Metropolis» aparece en el lanzamiento «Nothing but the Beat (Ultimate Edition)» de David Guetta.",
+      "fun_fact_fr": "« Metropolis » figure sur la publication « Nothing but the Beat (Ultimate Edition) » de David Guetta.",
+      "fun_fact_nl": "‘Metropolis’ staat op de release ‘Nothing but the Beat (Ultimate Edition)’ van David Guetta.",
+      "alt_artists": [
+        "Tiësto, Sevenn",
+        "Anyma",
+        "Dimitri Vegas & Like Mike, W&W"
+      ]
+    },
+    {
+      "artist": "Lost Frequencies, Zonderling",
+      "title": "Crazy - Tomorrowland Intro Mix",
+      "year": 2018,
+      "isrc": "NLF711812450",
+      "uri": "spotify:track:0t2wPEn8kALwrf79iB2qO2",
+      "uri_apple_music": "applemusic://track/1442749632",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1442749632"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/586878552",
+      "fun_fact": "“Crazy - Tomorrowland Intro Mix” is the title track of Lost Frequencies’s release of the same name.",
+      "fun_fact_de": "„Crazy - Tomorrowland Intro Mix“ ist der Titelsong der gleichnamigen Veröffentlichung von Lost Frequencies.",
+      "fun_fact_es": "«Crazy - Tomorrowland Intro Mix» es la canción que da título al lanzamiento homónimo de Lost Frequencies.",
+      "fun_fact_fr": "« Crazy - Tomorrowland Intro Mix » est le morceau-titre de la publication éponyme de Lost Frequencies.",
+      "fun_fact_nl": "‘Crazy - Tomorrowland Intro Mix’ is het titelnummer van de gelijknamige release van Lost Frequencies.",
+      "alt_artists": [
+        "Dimitri Vegas & Like Mike, Bassjackers, D'Angello & Francis",
+        "Martin Garrix, Macklemore, Fall Out Boy, Tiësto",
+        "Michel Cleis, Totó La Momposina, Paul Kalkbrenner"
+      ]
+    },
+    {
+      "artist": "Michael Calfan, Axwell",
+      "title": "Resurrection - Axwell's Recut Club Version",
+      "year": 2003,
+      "isrc": "FR6V80341796",
+      "uri": "spotify:track:6byaKxMUNVLoODRQfkqalx",
+      "uri_apple_music": "applemusic://track/1733734254",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1733734254"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2683369492",
+      "fun_fact": "“Resurrection - Axwell's Recut Club Version” appears on Michael Calfan’s release “Yellow Productions: 20 Years of Music”.",
+      "fun_fact_de": "„Resurrection - Axwell's Recut Club Version“ erschien auf der Veröffentlichung „Yellow Productions: 20 Years of Music“ von Michael Calfan.",
+      "fun_fact_es": "«Resurrection - Axwell's Recut Club Version» aparece en el lanzamiento «Yellow Productions: 20 Years of Music» de Michael Calfan.",
+      "fun_fact_fr": "« Resurrection - Axwell's Recut Club Version » figure sur la publication « Yellow Productions: 20 Years of Music » de Michael Calfan.",
+      "fun_fact_nl": "‘Resurrection - Axwell's Recut Club Version’ staat op de release ‘Yellow Productions: 20 Years of Music’ van Michael Calfan.",
+      "alt_artists": [
+        "Martin Garrix, Bonn",
+        "Alok, ILLENIUM",
+        "Jessie Ware, Disclosure"
+      ]
+    },
+    {
+      "artist": "Kaskade",
+      "title": "Atmosphere",
+      "year": 2013,
+      "isrc": "USUS11201442",
+      "uri": "spotify:track:5jozNdKPygoaSZhPJMP3eD",
+      "uri_apple_music": "applemusic://track/1712581135",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1712581135"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/67876796",
+      "fun_fact": "“Atmosphere” is the title track of Kaskade’s release of the same name.",
+      "fun_fact_de": "„Atmosphere“ ist der Titelsong der gleichnamigen Veröffentlichung von Kaskade.",
+      "fun_fact_es": "«Atmosphere» es la canción que da título al lanzamiento homónimo de Kaskade.",
+      "fun_fact_fr": "« Atmosphere » est le morceau-titre de la publication éponyme de Kaskade.",
+      "fun_fact_nl": "‘Atmosphere’ is het titelnummer van de gelijknamige release van Kaskade.",
+      "alt_artists": [
+        "Virtual Self",
+        "Friend Within",
+        "Disclosure, AlunaGeorge"
+      ]
+    },
+    {
+      "artist": "Diplo, SIDEPIECE",
+      "title": "On My Mind",
+      "year": 2019,
+      "isrc": "USZ4V1900134",
+      "uri": "spotify:track:54hA0ldJYyT1huGfSeOjdQ",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/896516162",
+      "fun_fact": "“On My Mind” is the title track of Diplo’s release of the same name.",
+      "fun_fact_de": "„On My Mind“ ist der Titelsong der gleichnamigen Veröffentlichung von Diplo.",
+      "fun_fact_es": "«On My Mind» es la canción que da título al lanzamiento homónimo de Diplo.",
+      "fun_fact_fr": "« On My Mind » est le morceau-titre de la publication éponyme de Diplo.",
+      "fun_fact_nl": "‘On My Mind’ is het titelnummer van de gelijknamige release van Diplo.",
+      "alt_artists": [
+        "David Guetta, Showtek",
+        "Knife Party",
+        "C-Mos, Axwell"
+      ]
+    },
+    {
+      "artist": "Avicii, Lenny Kravitz",
+      "title": "Superlove - Radio Edit",
+      "year": 2012,
+      "isrc": "NLA321292385",
+      "uri": "spotify:track:4YiEKrJuoZGGg3nzTJfONS",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/56690851",
+      "fun_fact": "“Superlove - Radio Edit” is the title track of Avicii’s release of the same name.",
+      "fun_fact_de": "„Superlove - Radio Edit“ ist der Titelsong der gleichnamigen Veröffentlichung von Avicii.",
+      "fun_fact_es": "«Superlove - Radio Edit» es la canción que da título al lanzamiento homónimo de Avicii.",
+      "fun_fact_fr": "« Superlove - Radio Edit » est le morceau-titre de la publication éponyme de Avicii.",
+      "fun_fact_nl": "‘Superlove - Radio Edit’ is het titelnummer van de gelijknamige release van Avicii.",
+      "alt_artists": [
+        "San Holo",
+        "CamelPhat, Elderbrook",
+        "Martin Garrix, Third Party, Oaks, Declan J Donovan"
+      ]
+    },
+    {
+      "artist": "Cygnus X, Rank 1",
+      "title": "Superstring - Rank 1 Remix",
+      "year": 2000,
+      "isrc": "NLE800510018",
+      "uri": "spotify:track:7ubtDZozp38SHSqUMXZvi5",
+      "uri_apple_music": "applemusic://track/1801470984",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1801470984"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2874803522",
+      "fun_fact": "“Superstring - Rank 1 Remix” appears on Cygnus X’s release “A State Of Trance Classics, Vol.4”.",
+      "fun_fact_de": "„Superstring - Rank 1 Remix“ erschien auf der Veröffentlichung „A State Of Trance Classics, Vol.4“ von Cygnus X.",
+      "fun_fact_es": "«Superstring - Rank 1 Remix» aparece en el lanzamiento «A State Of Trance Classics, Vol.4» de Cygnus X.",
+      "fun_fact_fr": "« Superstring - Rank 1 Remix » figure sur la publication « A State Of Trance Classics, Vol.4 » de Cygnus X.",
+      "fun_fact_nl": "‘Superstring - Rank 1 Remix’ staat op de release ‘A State Of Trance Classics, Vol.4’ van Cygnus X.",
+      "alt_artists": [
+        "Push",
+        "&ME, Black Coffee, Keinemusik",
+        "Paul Kalkbrenner"
+      ]
+    },
+    {
+      "artist": "Alan Walker",
+      "title": "Spectre",
+      "year": 2017,
+      "isrc": "NOG841713010",
+      "uri": "spotify:track:2kY1bCxkRIPz3qDgKAbQM6",
+      "uri_apple_music": "applemusic://track/1869661185",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1869661185"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/401358872",
+      "fun_fact": "“Spectre” appears on Alan Walker’s release “The Spectre”.",
+      "fun_fact_de": "„Spectre“ erschien auf der Veröffentlichung „The Spectre“ von Alan Walker.",
+      "fun_fact_es": "«Spectre» aparece en el lanzamiento «The Spectre» de Alan Walker.",
+      "fun_fact_fr": "« Spectre » figure sur la publication « The Spectre » de Alan Walker.",
+      "fun_fact_nl": "‘Spectre’ staat op de release ‘The Spectre’ van Alan Walker.",
+      "alt_artists": [
+        "Chris Lake, Marco Lys",
+        "Laidback Luke, Chris Lorenzo",
+        "Tiësto, Oliver Heldens"
+      ]
+    },
+    {
+      "artist": "Skrillex, Boys Noize, Opus III",
+      "title": "Fine Day Anthem",
+      "year": 2023,
+      "isrc": "USAT22306616",
+      "uri": "spotify:track:6tifCCTIVBLC2TmTquYG7G",
+      "uri_apple_music": "applemusic://track/1695245135",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1695245135"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2350357385",
+      "fun_fact": "“Fine Day Anthem” is the title track of Skrillex’s release of the same name.",
+      "fun_fact_de": "„Fine Day Anthem“ ist der Titelsong der gleichnamigen Veröffentlichung von Skrillex.",
+      "fun_fact_es": "«Fine Day Anthem» es la canción que da título al lanzamiento homónimo de Skrillex.",
+      "fun_fact_fr": "« Fine Day Anthem » est le morceau-titre de la publication éponyme de Skrillex.",
+      "fun_fact_nl": "‘Fine Day Anthem’ is het titelnummer van de gelijknamige release van Skrillex.",
+      "alt_artists": [
+        "Boris Brejcha, Ginger",
+        "Major Lazer, MØ, DJ Snake",
+        "Mike Williams, Robin Valo"
+      ]
+    },
+    {
+      "artist": "Sebastian Ingrosso",
+      "title": "Kidsos",
+      "year": 2009,
+      "isrc": "GBJ4B0900001",
+      "uri": "spotify:track:4DaGEoeEIiozRTKzMCMmB3",
+      "uri_apple_music": "applemusic://track/1019172310",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1019172310"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/104051408",
+      "fun_fact": "“Kidsos” is the title track of Sebastian Ingrosso’s release of the same name.",
+      "fun_fact_de": "„Kidsos“ ist der Titelsong der gleichnamigen Veröffentlichung von Sebastian Ingrosso.",
+      "fun_fact_es": "«Kidsos» es la canción que da título al lanzamiento homónimo de Sebastian Ingrosso.",
+      "fun_fact_fr": "« Kidsos » est le morceau-titre de la publication éponyme de Sebastian Ingrosso.",
+      "fun_fact_nl": "‘Kidsos’ is het titelnummer van de gelijknamige release van Sebastian Ingrosso.",
+      "alt_artists": [
+        "Deniz Koyu",
+        "Virtual Self",
+        "Dash Berlin"
+      ]
+    },
+    {
+      "artist": "Alok, Zeeba, Bruno Martini",
+      "title": "Hear Me Now",
+      "year": 2016,
+      "isrc": "NLZ541600800",
+      "uri": "spotify:track:39cmB3ZoTOLwOTq7tMNqKa",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/452769552",
+      "fun_fact": "“Hear Me Now” appears on Alok’s release “Hear Me Now (feat. Zeeba)”.",
+      "fun_fact_de": "„Hear Me Now“ erschien auf der Veröffentlichung „Hear Me Now (feat. Zeeba)“ von Alok.",
+      "fun_fact_es": "«Hear Me Now» aparece en el lanzamiento «Hear Me Now (feat. Zeeba)» de Alok.",
+      "fun_fact_fr": "« Hear Me Now » figure sur la publication « Hear Me Now (feat. Zeeba) » de Alok.",
+      "fun_fact_nl": "‘Hear Me Now’ staat op de release ‘Hear Me Now (feat. Zeeba)’ van Alok.",
+      "alt_artists": [
+        "deadmau5, Chris James",
+        "Fatboy Slim, Riva Starr, Beardyman, Calvin Harris",
+        "BL3SS, CamrinWatsin, bbyclose"
+      ]
+    },
+    {
+      "artist": "Martin Garrix, Matisse & Sadko, BARBZ",
+      "title": "⁠⁠Butterflies",
+      "year": 2025,
+      "isrc": "NLM5S2502669",
+      "uri": "spotify:track:129zR3hX9D2BYXOMtk2jaT",
+      "uri_apple_music": "applemusic://track/1846320275",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1846320275"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3561841201",
+      "fun_fact": "“⁠⁠Butterflies” is the title track of Martin Garrix’s release of the same name.",
+      "fun_fact_de": "„⁠⁠Butterflies“ ist der Titelsong der gleichnamigen Veröffentlichung von Martin Garrix.",
+      "fun_fact_es": "«⁠⁠Butterflies» es la canción que da título al lanzamiento homónimo de Martin Garrix.",
+      "fun_fact_fr": "« ⁠⁠Butterflies » est le morceau-titre de la publication éponyme de Martin Garrix.",
+      "fun_fact_nl": "‘⁠⁠Butterflies’ is het titelnummer van de gelijknamige release van Martin Garrix.",
+      "alt_artists": [
+        "AN21, Max Vangeli",
+        "Martin Solveig, SAM WHITE",
+        "KAAZE, Alina Pozi"
+      ]
+    },
+    {
+      "artist": "Reflekt, delline bass",
+      "title": "Need To Feel Loved - Radio Edit",
+      "year": 2004,
+      "isrc": "GBHPU0400001",
+      "uri": "spotify:track:4b9S5yZpvIVxMEuI0rHzk6",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/133124834",
+      "fun_fact": "“Need To Feel Loved - Radio Edit” appears on Reflekt’s release “Need To Feel Loved”.",
+      "fun_fact_de": "„Need To Feel Loved - Radio Edit“ erschien auf der Veröffentlichung „Need To Feel Loved“ von Reflekt.",
+      "fun_fact_es": "«Need To Feel Loved - Radio Edit» aparece en el lanzamiento «Need To Feel Loved» de Reflekt.",
+      "fun_fact_fr": "« Need To Feel Loved - Radio Edit » figure sur la publication « Need To Feel Loved » de Reflekt.",
+      "fun_fact_nl": "‘Need To Feel Loved - Radio Edit’ staat op de release ‘Need To Feel Loved’ van Reflekt.",
+      "alt_artists": [
+        "PAWSA",
+        "Ahmed Spins, Stevo Atambire",
+        "Kosheen, Tinlicker"
+      ]
+    },
+    {
+      "artist": "Michel Cleis, Totó La Momposina, Paul Kalkbrenner",
+      "title": "La Mezcla - Paul Kalkbrenner Remix",
+      "year": 2009,
+      "isrc": "GBDVG0900131",
+      "uri": "spotify:track:3XETVG4YPmWS9Fk7q6aLlQ",
+      "uri_apple_music": "applemusic://track/1496030516",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1496030516"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1704279827",
+      "fun_fact": "“La Mezcla - Paul Kalkbrenner Remix” appears on Michel Cleis’s release “La Mezcla”.",
+      "fun_fact_de": "„La Mezcla - Paul Kalkbrenner Remix“ erschien auf der Veröffentlichung „La Mezcla“ von Michel Cleis.",
+      "fun_fact_es": "«La Mezcla - Paul Kalkbrenner Remix» aparece en el lanzamiento «La Mezcla» de Michel Cleis.",
+      "fun_fact_fr": "« La Mezcla - Paul Kalkbrenner Remix » figure sur la publication « La Mezcla » de Michel Cleis.",
+      "fun_fact_nl": "‘La Mezcla - Paul Kalkbrenner Remix’ staat op de release ‘La Mezcla’ van Michel Cleis.",
+      "alt_artists": [
+        "PAWSA, The Adventures Of Stevie V",
+        "Anyma, Cassian, Poppy Baskcomb",
+        "Coldplay"
+      ]
+    },
+    {
+      "artist": "Swedish House Mafia, Connie Constance",
+      "title": "Heaven Takes You Home - SHM Remake",
+      "year": 2025,
+      "isrc": "USUG12508976",
+      "uri": "spotify:track:2UFW1gnrEIQqxyK88wIW0X",
+      "uri_apple_music": "applemusic://track/1642778289",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1642778289"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3578730711",
+      "fun_fact": "“Heaven Takes You Home - SHM Remake” is the title track of Swedish House Mafia’s release of the same name.",
+      "fun_fact_de": "„Heaven Takes You Home - SHM Remake“ ist der Titelsong der gleichnamigen Veröffentlichung von Swedish House Mafia.",
+      "fun_fact_es": "«Heaven Takes You Home - SHM Remake» es la canción que da título al lanzamiento homónimo de Swedish House Mafia.",
+      "fun_fact_fr": "« Heaven Takes You Home - SHM Remake » est le morceau-titre de la publication éponyme de Swedish House Mafia.",
+      "fun_fact_nl": "‘Heaven Takes You Home - SHM Remake’ is het titelnummer van de gelijknamige release van Swedish House Mafia.",
+      "alt_artists": [
+        "Young Marco",
+        "Lost Frequencies, Tom Gregory",
+        "Martin Garrix, Clinton Kane"
+      ]
+    },
+    {
+      "artist": "Stardust, Benjamin Diamond, Alan Braxe, Thomas Bangalter",
+      "title": "Music Sounds Better With You",
+      "year": 1998,
+      "isrc": "FR11Q9800000",
+      "uri": "spotify:track:303ccTay2FiDTZ9fZ2AdBt",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/695110932",
+      "fun_fact": "“Music Sounds Better With You” is the title track of Stardust’s release of the same name.",
+      "fun_fact_de": "„Music Sounds Better With You“ ist der Titelsong der gleichnamigen Veröffentlichung von Stardust.",
+      "fun_fact_es": "«Music Sounds Better With You» es la canción que da título al lanzamiento homónimo de Stardust.",
+      "fun_fact_fr": "« Music Sounds Better With You » est le morceau-titre de la publication éponyme de Stardust.",
+      "fun_fact_nl": "‘Music Sounds Better With You’ is het titelnummer van de gelijknamige release van Stardust.",
+      "alt_artists": [
+        "Disciples",
+        "David Guetta, Nicky Romero",
+        "Rebūke, Konstantin Sibold, ZAC, CARMEE"
+      ]
+    },
+    {
+      "artist": "Axwell, Max C",
+      "title": "I Found U - Vocal Remode",
+      "year": 2007,
+      "isrc": "GBKCF0700027",
+      "uri": "spotify:track:3cUSh8az4INATmKt8OJD2P",
+      "uri_apple_music": "applemusic://track/1845780317",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1845780317"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/73460580",
+      "fun_fact": "“I Found U - Vocal Remode” appears on Axwell’s release “I Found U”.",
+      "fun_fact_de": "„I Found U - Vocal Remode“ erschien auf der Veröffentlichung „I Found U“ von Axwell.",
+      "fun_fact_es": "«I Found U - Vocal Remode» aparece en el lanzamiento «I Found U» de Axwell.",
+      "fun_fact_fr": "« I Found U - Vocal Remode » figure sur la publication « I Found U » de Axwell.",
+      "fun_fact_nl": "‘I Found U - Vocal Remode’ staat op de release ‘I Found U’ van Axwell.",
+      "alt_artists": [
+        "Sammy Virji",
+        "Yves V, AFROJACK, Icona Pop",
+        "Calvin Harris, Example"
+      ]
+    },
+    {
+      "artist": "Sub Focus",
+      "title": "Rock It",
+      "year": 2009,
+      "isrc": "GBBZH0991306",
+      "uri": "spotify:track:69PmbaybVYoxErPtJ5v7Th",
+      "uri_apple_music": "applemusic://track/1409828465",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1409828465"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3785948322",
+      "fun_fact": "“Rock It” appears on Sub Focus’s release “Sub Focus”.",
+      "fun_fact_de": "„Rock It“ erschien auf der Veröffentlichung „Sub Focus“ von Sub Focus.",
+      "fun_fact_es": "«Rock It» aparece en el lanzamiento «Sub Focus» de Sub Focus.",
+      "fun_fact_fr": "« Rock It » figure sur la publication « Sub Focus » de Sub Focus.",
+      "fun_fact_nl": "‘Rock It’ staat op de release ‘Sub Focus’ van Sub Focus.",
+      "alt_artists": [
+        "Boys Noize",
+        "deadmau5, Kaskade, Kx5, John Summit, HAYLA",
+        "Tomaz, Filterheadz"
+      ]
+    },
+    {
+      "artist": "CamelPhat, Cristoph, Jem Cooke",
+      "title": "Breathe",
+      "year": 2018,
+      "isrc": "GBCEN1800173",
+      "uri": "spotify:track:6TR0FGw4zhlGbQALN065AI",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/582260512",
+      "fun_fact": "“Breathe” appears on CamelPhat’s release “Breathe (feat. Jem Cooke)”.",
+      "fun_fact_de": "„Breathe“ erschien auf der Veröffentlichung „Breathe (feat. Jem Cooke)“ von CamelPhat.",
+      "fun_fact_es": "«Breathe» aparece en el lanzamiento «Breathe (feat. Jem Cooke)» de CamelPhat.",
+      "fun_fact_fr": "« Breathe » figure sur la publication « Breathe (feat. Jem Cooke) » de CamelPhat.",
+      "fun_fact_nl": "‘Breathe’ staat op de release ‘Breathe (feat. Jem Cooke)’ van CamelPhat.",
+      "alt_artists": [
+        "Lazy Jay",
+        "Tiësto, Vintage Culture",
+        "BURNS"
+      ]
+    },
+    {
+      "artist": "Chris Brown, Benny Benassi",
+      "title": "Beautiful People - Radio Edit",
+      "year": 2011,
+      "isrc": "USUS11100035",
+      "uri": "spotify:track:16whkF55KgWqpNChzOQWB3",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/69295402",
+      "fun_fact": "“Beautiful People - Radio Edit” appears on Chris Brown’s release “Electroman”.",
+      "fun_fact_de": "„Beautiful People - Radio Edit“ erschien auf der Veröffentlichung „Electroman“ von Chris Brown.",
+      "fun_fact_es": "«Beautiful People - Radio Edit» aparece en el lanzamiento «Electroman» de Chris Brown.",
+      "fun_fact_fr": "« Beautiful People - Radio Edit » figure sur la publication « Electroman » de Chris Brown.",
+      "fun_fact_nl": "‘Beautiful People - Radio Edit’ staat op de release ‘Electroman’ van Chris Brown.",
+      "alt_artists": [
+        "Steve Aoki, Wynter Gordon",
+        "Öwnboss, Sevek",
+        "London Grammar"
+      ]
+    },
+    {
+      "artist": "Monolink, Ben Böhmer",
+      "title": "Father Ocean - Ben Böhmer Remix",
+      "year": 2018,
+      "isrc": "DETO31800273",
+      "uri": "spotify:track:3W8KAzaYIKsCSGj8q8ltul",
+      "uri_apple_music": "applemusic://track/1441667873",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1441667873"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/583588002",
+      "fun_fact": "“Father Ocean - Ben Böhmer Remix” appears on Monolink’s release “Father Ocean”.",
+      "fun_fact_de": "„Father Ocean - Ben Böhmer Remix“ erschien auf der Veröffentlichung „Father Ocean“ von Monolink.",
+      "fun_fact_es": "«Father Ocean - Ben Böhmer Remix» aparece en el lanzamiento «Father Ocean» de Monolink.",
+      "fun_fact_fr": "« Father Ocean - Ben Böhmer Remix » figure sur la publication « Father Ocean » de Monolink.",
+      "fun_fact_nl": "‘Father Ocean - Ben Böhmer Remix’ staat op de release ‘Father Ocean’ van Monolink.",
+      "alt_artists": [
+        "KETTAMA",
+        "DubVision, AFROJACK",
+        "Alesso, Zara Larsson"
+      ]
+    },
+    {
+      "artist": "Bob Sinclar, FISHER, Steve Edwards",
+      "title": "World Hold On (Children Of The Sky) - FISHER Rework",
+      "year": 2022,
+      "isrc": "FR4E42227000",
+      "uri": "spotify:track:6kTwzV93qpcovlRPmBOXmn",
+      "uri_apple_music": "applemusic://track/1856647873",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1856647873"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2282495317",
+      "fun_fact": "“World Hold On (Children Of The Sky) - FISHER Rework” appears on Bob Sinclar’s release “Ibiza Fever 2023 by FG (Exclusive Mix By Bob Sinclar)”.",
+      "fun_fact_de": "„World Hold On (Children Of The Sky) - FISHER Rework“ erschien auf der Veröffentlichung „Ibiza Fever 2023 by FG (Exclusive Mix By Bob Sinclar)“ von Bob Sinclar.",
+      "fun_fact_es": "«World Hold On (Children Of The Sky) - FISHER Rework» aparece en el lanzamiento «Ibiza Fever 2023 by FG (Exclusive Mix By Bob Sinclar)» de Bob Sinclar.",
+      "fun_fact_fr": "« World Hold On (Children Of The Sky) - FISHER Rework » figure sur la publication « Ibiza Fever 2023 by FG (Exclusive Mix By Bob Sinclar) » de Bob Sinclar.",
+      "fun_fact_nl": "‘World Hold On (Children Of The Sky) - FISHER Rework’ staat op de release ‘Ibiza Fever 2023 by FG (Exclusive Mix By Bob Sinclar)’ van Bob Sinclar.",
+      "alt_artists": [
+        "Sia, Sander van Doorn",
+        "Martin Garrix, Third Party, Oaks, Declan J Donovan",
+        "Sonique, The Conductor & The Cowboy"
+      ]
+    },
+    {
+      "artist": "Avicii, Sandro Cavazza",
+      "title": "Without You (feat. Sandro Cavazza)",
+      "year": 2017,
+      "isrc": "SE5R71700140",
+      "uri": "spotify:track:6Pgkp4qUoTmJIPn7ReaGxL",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/415561352",
+      "fun_fact": "“Without You (feat. Sandro Cavazza)” appears on Avicii’s release “Without You (Remixes)”.",
+      "fun_fact_de": "„Without You (feat. Sandro Cavazza)“ erschien auf der Veröffentlichung „Without You (Remixes)“ von Avicii.",
+      "fun_fact_es": "«Without You (feat. Sandro Cavazza)» aparece en el lanzamiento «Without You (Remixes)» de Avicii.",
+      "fun_fact_fr": "« Without You (feat. Sandro Cavazza) » figure sur la publication « Without You (Remixes) » de Avicii.",
+      "fun_fact_nl": "‘Without You (feat. Sandro Cavazza)’ staat op de release ‘Without You (Remixes)’ van Avicii.",
+      "alt_artists": [
+        "Michel Cleis, Totó La Momposina, Paul Kalkbrenner",
+        "Moby, Steve Angello",
+        "Pryda"
+      ]
+    },
+    {
+      "artist": "Lilly Wood and The Prick, Robin Schulz",
+      "title": "Prayer in C - Robin Schulz Remix",
+      "year": 2014,
+      "isrc": "DEA621400324",
+      "uri": "spotify:track:3k9FFXVPn3ua8dlpkxlCvZ",
+      "uri_apple_music": "applemusic://track/1819867207",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1819867207"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/91489286",
+      "fun_fact": "“Prayer in C - Robin Schulz Remix” appears on Lilly Wood and The Prick’s release “Extended Prayer”.",
+      "fun_fact_de": "„Prayer in C - Robin Schulz Remix“ erschien auf der Veröffentlichung „Extended Prayer“ von Lilly Wood and The Prick.",
+      "fun_fact_es": "«Prayer in C - Robin Schulz Remix» aparece en el lanzamiento «Extended Prayer» de Lilly Wood and The Prick.",
+      "fun_fact_fr": "« Prayer in C - Robin Schulz Remix » figure sur la publication « Extended Prayer » de Lilly Wood and The Prick.",
+      "fun_fact_nl": "‘Prayer in C - Robin Schulz Remix’ staat op de release ‘Extended Prayer’ van Lilly Wood and The Prick.",
+      "alt_artists": [
+        "TJR, VINAI",
+        "Kaskade, deadmau5",
+        "Sonny Fodera, MK, Clementine Douglas"
+      ]
+    },
+    {
+      "artist": "Shouse, David Guetta",
+      "title": "Love Tonight (David Guetta Remix)",
+      "year": 2021,
+      "isrc": "USA2P2120717",
+      "uri": "spotify:track:5zf8rvPF22Q3dcKKWWUoeA",
+      "uri_apple_music": "applemusic://track/6767141393",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/6767141393"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/4005834101",
+      "fun_fact": "“Love Tonight (David Guetta Remix)” is the title track of Shouse’s release of the same name.",
+      "fun_fact_de": "„Love Tonight (David Guetta Remix)“ ist der Titelsong der gleichnamigen Veröffentlichung von Shouse.",
+      "fun_fact_es": "«Love Tonight (David Guetta Remix)» es la canción que da título al lanzamiento homónimo de Shouse.",
+      "fun_fact_fr": "« Love Tonight (David Guetta Remix) » est le morceau-titre de la publication éponyme de Shouse.",
+      "fun_fact_nl": "‘Love Tonight (David Guetta Remix)’ is het titelnummer van de gelijknamige release van Shouse.",
+      "alt_artists": [
+        "Alesso, Becky Hill",
+        "Lost Frequencies, Calum Scott",
+        "Calvin Harris, Sam Smith"
+      ]
+    },
+    {
+      "artist": "Lost Frequencies",
+      "title": "Rise",
+      "year": 2021,
+      "isrc": "BEHP42100024",
+      "uri": "spotify:track:7HXBG0W8gFJwHUh5mVF9tf",
+      "uri_apple_music": "applemusic://track/1552918352",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1552918352"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1238536892",
+      "fun_fact": "“Rise” is the title track of Lost Frequencies’s release of the same name.",
+      "fun_fact_de": "„Rise“ ist der Titelsong der gleichnamigen Veröffentlichung von Lost Frequencies.",
+      "fun_fact_es": "«Rise» es la canción que da título al lanzamiento homónimo de Lost Frequencies.",
+      "fun_fact_fr": "« Rise » est le morceau-titre de la publication éponyme de Lost Frequencies.",
+      "fun_fact_nl": "‘Rise’ is het titelnummer van de gelijknamige release van Lost Frequencies.",
+      "alt_artists": [
+        "Amine Edge & DANCE, Blaze (Kevin Hedge)",
+        "Tiësto, Don Diablo, Thomas Troelsen",
+        "Calvin Harris, Clementine Douglas, Cassian"
+      ]
+    },
+    {
+      "artist": "Rihanna, Calvin Harris",
+      "title": "We Found Love",
+      "year": 2011,
+      "isrc": "USUM71116799",
+      "uri": "spotify:track:3t4HeVfURZ5DuqMWz0Cmqg",
+      "uri_apple_music": "applemusic://track/1702249021",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1702249021"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/113982292",
+      "fun_fact": "“We Found Love” appears on Rihanna’s release “We Found Love (The Remixes)”.",
+      "fun_fact_de": "„We Found Love“ erschien auf der Veröffentlichung „We Found Love (The Remixes)“ von Rihanna.",
+      "fun_fact_es": "«We Found Love» aparece en el lanzamiento «We Found Love (The Remixes)» de Rihanna.",
+      "fun_fact_fr": "« We Found Love » figure sur la publication « We Found Love (The Remixes) » de Rihanna.",
+      "fun_fact_nl": "‘We Found Love’ staat op de release ‘We Found Love (The Remixes)’ van Rihanna.",
+      "alt_artists": [
+        "Jazzy",
+        "Pleasurekraft",
+        "Chris Lake"
+      ]
+    },
+    {
+      "artist": "Eats Everything, Charlotte de Witte",
+      "title": "Space Raiders - Charlotte de Witte Remix",
+      "year": 2019,
+      "isrc": "GBT9R1900001",
+      "uri": "spotify:track:2myB33H85ywlZasCnWPNds",
+      "uri_apple_music": "applemusic://track/1742773929",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1742773929"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2763260851",
+      "fun_fact": "“Space Raiders - Charlotte de Witte Remix” is the title track of Eats Everything’s release of the same name.",
+      "fun_fact_de": "„Space Raiders - Charlotte de Witte Remix“ ist der Titelsong der gleichnamigen Veröffentlichung von Eats Everything.",
+      "fun_fact_es": "«Space Raiders - Charlotte de Witte Remix» es la canción que da título al lanzamiento homónimo de Eats Everything.",
+      "fun_fact_fr": "« Space Raiders - Charlotte de Witte Remix » est le morceau-titre de la publication éponyme de Eats Everything.",
+      "fun_fact_nl": "‘Space Raiders - Charlotte de Witte Remix’ is het titelnummer van de gelijknamige release van Eats Everything.",
+      "alt_artists": [
+        "Alan Walker, Tiësto",
+        "Storm",
+        "Kungs"
+      ]
+    },
+    {
+      "artist": "Martin Garrix, USHER",
+      "title": "Don't Look Down (feat. Usher)",
+      "year": 2015,
+      "isrc": "NLZ541500175",
+      "uri": "spotify:track:5M9jOReAKGZ2AttVefFjTY",
+      "uri_apple_music": "applemusic://track/976353585",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/976353585"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/96974184",
+      "fun_fact": "“Don't Look Down (feat. Usher)” is the title track of Martin Garrix’s release of the same name.",
+      "fun_fact_de": "„Don't Look Down (feat. Usher)“ ist der Titelsong der gleichnamigen Veröffentlichung von Martin Garrix.",
+      "fun_fact_es": "«Don't Look Down (feat. Usher)» es la canción que da título al lanzamiento homónimo de Martin Garrix.",
+      "fun_fact_fr": "« Don't Look Down (feat. Usher) » est le morceau-titre de la publication éponyme de Martin Garrix.",
+      "fun_fact_nl": "‘Don't Look Down (feat. Usher)’ is het titelnummer van de gelijknamige release van Martin Garrix.",
+      "alt_artists": [
+        "Lost Frequencies, The NGHBRS, Keanu Silva",
+        "Kygo, Rita Ora",
+        "Diplo, SIDEPIECE"
+      ]
+    },
+    {
+      "artist": "Rebūke, Storm, Jam El Mar",
+      "title": "Storm 2022",
+      "year": 2022,
+      "isrc": "DEMW62200011",
+      "uri": "spotify:track:39N9R61hAatOAIjBs2RH6z",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1650021202",
+      "fun_fact": "“Storm 2022” is the title track of Rebūke’s release of the same name.",
+      "fun_fact_de": "„Storm 2022“ ist der Titelsong der gleichnamigen Veröffentlichung von Rebūke.",
+      "fun_fact_es": "«Storm 2022» es la canción que da título al lanzamiento homónimo de Rebūke.",
+      "fun_fact_fr": "« Storm 2022 » est le morceau-titre de la publication éponyme de Rebūke.",
+      "fun_fact_nl": "‘Storm 2022’ is het titelnummer van de gelijknamige release van Rebūke.",
+      "alt_artists": [
+        "Veracocha",
+        "Steve Angello, The Presets",
+        "Estelle, Lost Frequencies, Kanye West"
+      ]
+    },
+    {
+      "artist": "deadmau5, Chris James",
+      "title": "The Veldt - Radio Edit",
+      "year": 2012,
+      "isrc": "GBTDG1200437",
+      "uri": "spotify:track:4ezalcKN0KnYuZiEw2jFgc",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/29183901",
+      "fun_fact": "“The Veldt - Radio Edit” appears on deadmau5’s release “The Veldt”.",
+      "fun_fact_de": "„The Veldt - Radio Edit“ erschien auf der Veröffentlichung „The Veldt“ von deadmau5.",
+      "fun_fact_es": "«The Veldt - Radio Edit» aparece en el lanzamiento «The Veldt» de deadmau5.",
+      "fun_fact_fr": "« The Veldt - Radio Edit » figure sur la publication « The Veldt » de deadmau5.",
+      "fun_fact_nl": "‘The Veldt - Radio Edit’ staat op de release ‘The Veldt’ van deadmau5.",
+      "alt_artists": [
+        "Tommy Trash",
+        "Tiësto, Mesto",
+        "Tiësto, Dzeko, Preme, Post Malone"
+      ]
+    },
+    {
+      "artist": "Armin van Buuren",
+      "title": "Ping Pong",
+      "year": 2014,
+      "isrc": "NLF711400906",
+      "uri": "spotify:track:4GqvWKAq6uKAcivJGnNAhR",
+      "uri_apple_music": "applemusic://track/854518501",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/854518501"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/77403196",
+      "fun_fact": "“Ping Pong” is the title track of Armin van Buuren’s release of the same name.",
+      "fun_fact_de": "„Ping Pong“ ist der Titelsong der gleichnamigen Veröffentlichung von Armin van Buuren.",
+      "fun_fact_es": "«Ping Pong» es la canción que da título al lanzamiento homónimo de Armin van Buuren.",
+      "fun_fact_fr": "« Ping Pong » est le morceau-titre de la publication éponyme de Armin van Buuren.",
+      "fun_fact_nl": "‘Ping Pong’ is het titelnummer van de gelijknamige release van Armin van Buuren.",
+      "alt_artists": [
+        "Knife Party",
+        "DJ MERCER, Tchami",
+        "Nosi"
+      ]
+    },
+    {
+      "artist": "Avicii, MishCatt",
+      "title": "Fades Away - Tribute Concert Version",
+      "year": 2019,
+      "isrc": "SE5R71900309",
+      "uri": "spotify:track:2Aomjzc0qNjk4uc3JYGxgc",
+      "uri_apple_music": "applemusic://track/1489463484",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1489463484"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/822440172",
+      "fun_fact": "“Fades Away - Tribute Concert Version” is the title track of Avicii’s release of the same name.",
+      "fun_fact_de": "„Fades Away - Tribute Concert Version“ ist der Titelsong der gleichnamigen Veröffentlichung von Avicii.",
+      "fun_fact_es": "«Fades Away - Tribute Concert Version» es la canción que da título al lanzamiento homónimo de Avicii.",
+      "fun_fact_fr": "« Fades Away - Tribute Concert Version » est le morceau-titre de la publication éponyme de Avicii.",
+      "fun_fact_nl": "‘Fades Away - Tribute Concert Version’ is het titelnummer van de gelijknamige release van Avicii.",
+      "alt_artists": [
+        "Red Hot Chili Peppers",
+        "Armand Van Helden",
+        "KSHMR, Mike Waters"
+      ]
+    },
+    {
+      "artist": "Stromae, Paul Kalkbrenner",
+      "title": "Te Quiero - Paul Kalkbrenner Remix",
+      "year": 2010,
+      "isrc": "BET671000144",
+      "uri": "spotify:track:0PHSpagf1hG8ESvphplF91",
+      "uri_apple_music": "applemusic://track/1440769957",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1440769957"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/6994173",
+      "fun_fact": "“Te Quiero - Paul Kalkbrenner Remix” appears on Stromae’s release “Te Quiero (German Remixes)”.",
+      "fun_fact_de": "„Te Quiero - Paul Kalkbrenner Remix“ erschien auf der Veröffentlichung „Te Quiero (German Remixes)“ von Stromae.",
+      "fun_fact_es": "«Te Quiero - Paul Kalkbrenner Remix» aparece en el lanzamiento «Te Quiero (German Remixes)» de Stromae.",
+      "fun_fact_fr": "« Te Quiero - Paul Kalkbrenner Remix » figure sur la publication « Te Quiero (German Remixes) » de Stromae.",
+      "fun_fact_nl": "‘Te Quiero - Paul Kalkbrenner Remix’ staat op de release ‘Te Quiero (German Remixes)’ van Stromae.",
+      "alt_artists": [
+        "David Guetta, MORTEN",
+        "D.O.D",
+        "Disclosure, Rivo, Eliza Doolittle"
+      ]
+    },
+    {
+      "artist": "Young Marco",
+      "title": "What You Say?",
+      "year": 2023,
+      "isrc": "GBCEN2200197",
+      "uri": "spotify:track:22quZFeltYbo325rn3ktTe",
+      "uri_apple_music": "applemusic://track/1658061260",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1658061260"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2054381447",
+      "fun_fact": "“What You Say?” is the title track of Young Marco’s release of the same name.",
+      "fun_fact_de": "„What You Say?“ ist der Titelsong der gleichnamigen Veröffentlichung von Young Marco.",
+      "fun_fact_es": "«What You Say?» es la canción que da título al lanzamiento homónimo de Young Marco.",
+      "fun_fact_fr": "« What You Say? » est le morceau-titre de la publication éponyme de Young Marco.",
+      "fun_fact_nl": "‘What You Say?’ is het titelnummer van de gelijknamige release van Young Marco.",
+      "alt_artists": [
+        "Hardwell, Trevor Guthrie, Sunnery James & Ryan Marciano",
+        "David Guetta, Dirty South, Sebastian Ingrosso, Julie McKnight",
+        "Gregor Salto, Florian T"
+      ]
+    },
+    {
+      "artist": "Krewella, Hardwell",
+      "title": "Alive - Hardwell Remix",
+      "year": 2013,
+      "isrc": "USQX91301123",
+      "uri": "spotify:track:4129VnB82LrGkZBDsrijKd",
+      "uri_apple_music": "applemusic://track/646134057",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/646134057"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/67239290",
+      "fun_fact": "“Alive - Hardwell Remix” is the title track of Krewella’s release of the same name.",
+      "fun_fact_de": "„Alive - Hardwell Remix“ ist der Titelsong der gleichnamigen Veröffentlichung von Krewella.",
+      "fun_fact_es": "«Alive - Hardwell Remix» es la canción que da título al lanzamiento homónimo de Krewella.",
+      "fun_fact_fr": "« Alive - Hardwell Remix » est le morceau-titre de la publication éponyme de Krewella.",
+      "fun_fact_nl": "‘Alive - Hardwell Remix’ is het titelnummer van de gelijknamige release van Krewella.",
+      "alt_artists": [
+        "Don Diablo",
+        "Martin Garrix, Sem Vox, Jaimes",
+        "Djuma Soundsystem"
+      ]
+    },
+    {
+      "artist": "Marco V",
+      "title": "Simulated",
+      "year": 2001,
+      "isrc": "NLE800510078",
+      "uri": "spotify:track:57l64z39EOEvAHFqJexIdF",
+      "uri_apple_music": "applemusic://track/407539791",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/407539791"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/61682328",
+      "fun_fact": "“Simulated” is the title track of Marco V’s release of the same name.",
+      "fun_fact_de": "„Simulated“ ist der Titelsong der gleichnamigen Veröffentlichung von Marco V.",
+      "fun_fact_es": "«Simulated» es la canción que da título al lanzamiento homónimo de Marco V.",
+      "fun_fact_fr": "« Simulated » est le morceau-titre de la publication éponyme de Marco V.",
+      "fun_fact_nl": "‘Simulated’ is het titelnummer van de gelijknamige release van Marco V.",
+      "alt_artists": [
+        "Solid Sessions",
+        "Disclosure, AlunaGeorge",
+        "The Magician, Olly Alexander (Years & Years), Watermät"
+      ]
+    },
+    {
+      "artist": "Swedish House Mafia, Alicia Keys",
+      "title": "Finally",
+      "year": 2024,
+      "isrc": "USUG12405837",
+      "uri": "spotify:track:5a2Mb0OPY17zkS8FnciQhg",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2959712811",
+      "fun_fact": "“Finally” is the title track of Swedish House Mafia’s release of the same name.",
+      "fun_fact_de": "„Finally“ ist der Titelsong der gleichnamigen Veröffentlichung von Swedish House Mafia.",
+      "fun_fact_es": "«Finally» es la canción que da título al lanzamiento homónimo de Swedish House Mafia.",
+      "fun_fact_fr": "« Finally » est le morceau-titre de la publication éponyme de Swedish House Mafia.",
+      "fun_fact_nl": "‘Finally’ is het titelnummer van de gelijknamige release van Swedish House Mafia.",
+      "alt_artists": [
+        "Gregor Salto, Florian T",
+        "Kygo, Rita Ora",
+        "Fred again.., Baby Keem"
+      ]
+    },
+    {
+      "artist": "Kölsch",
+      "title": "Loreley",
+      "year": 2013,
+      "isrc": "DEU671300137",
+      "uri": "spotify:track:5plDcIUqvmCsbc1rvJRfk1",
+      "uri_apple_music": "applemusic://track/397347361",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/397347361"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/68788691",
+      "fun_fact": "“Loreley” appears on Kölsch’s release “1977”.",
+      "fun_fact_de": "„Loreley“ erschien auf der Veröffentlichung „1977“ von Kölsch.",
+      "fun_fact_es": "«Loreley» aparece en el lanzamiento «1977» de Kölsch.",
+      "fun_fact_fr": "« Loreley » figure sur la publication « 1977 » de Kölsch.",
+      "fun_fact_nl": "‘Loreley’ staat op de release ‘1977’ van Kölsch.",
+      "alt_artists": [
+        "Swedish House Mafia, Niki & The Dove",
+        "Dimitri Vegas & Like Mike, Brennan Heart, Tony Junior",
+        "Timmy Trumpet, Savage"
+      ]
+    },
+    {
+      "artist": "Dimitri Vegas & Like Mike, W&W",
+      "title": "Arcade - Radio Edit",
+      "year": 2019,
+      "isrc": "NLF711909188",
+      "uri": "spotify:track:6ToupFpZbiTiRGEF2vVuzU",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/738419252",
+      "fun_fact": "“Arcade - Radio Edit” appears on Dimitri Vegas & Like Mike’s release “The Best Of Armin Only (Live from the Johan Cruijff ArenA - Amsterdam, The Netherlands) [Highlights]”.",
+      "fun_fact_de": "„Arcade - Radio Edit“ erschien auf der Veröffentlichung „The Best Of Armin Only (Live from the Johan Cruijff ArenA - Amsterdam, The Netherlands) [Highlights]“ von Dimitri Vegas & Like Mike.",
+      "fun_fact_es": "«Arcade - Radio Edit» aparece en el lanzamiento «The Best Of Armin Only (Live from the Johan Cruijff ArenA - Amsterdam, The Netherlands) [Highlights]» de Dimitri Vegas & Like Mike.",
+      "fun_fact_fr": "« Arcade - Radio Edit » figure sur la publication « The Best Of Armin Only (Live from the Johan Cruijff ArenA - Amsterdam, The Netherlands) [Highlights] » de Dimitri Vegas & Like Mike.",
+      "fun_fact_nl": "‘Arcade - Radio Edit’ staat op de release ‘The Best Of Armin Only (Live from the Johan Cruijff ArenA - Amsterdam, The Netherlands) [Highlights]’ van Dimitri Vegas & Like Mike.",
+      "alt_artists": [
+        "Lost Frequencies, Elley Duhé, X Ambassadors",
+        "Avicii, Lenny Kravitz",
+        "L.P. Rhythm"
+      ]
+    },
+    {
+      "artist": "The Chainsmokers, Coldplay, Alesso",
+      "title": "Something Just Like This - Alesso Remix",
+      "year": 2017,
+      "isrc": "USQX91700865",
+      "uri": "spotify:track:50RJdoxw8iajGNtHQe6QeS",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/353595051",
+      "fun_fact": "“Something Just Like This - Alesso Remix” appears on The Chainsmokers’s release “Something Just Like This (Remixes)”.",
+      "fun_fact_de": "„Something Just Like This - Alesso Remix“ erschien auf der Veröffentlichung „Something Just Like This (Remixes)“ von The Chainsmokers.",
+      "fun_fact_es": "«Something Just Like This - Alesso Remix» aparece en el lanzamiento «Something Just Like This (Remixes)» de The Chainsmokers.",
+      "fun_fact_fr": "« Something Just Like This - Alesso Remix » figure sur la publication « Something Just Like This (Remixes) » de The Chainsmokers.",
+      "fun_fact_nl": "‘Something Just Like This - Alesso Remix’ staat op de release ‘Something Just Like This (Remixes)’ van The Chainsmokers.",
+      "alt_artists": [
+        "Tiësto, Dzeko, Lena Leon",
+        "Lifelike, Kris Menace",
+        "Cassian, YOTTO, Da Hool"
+      ]
+    },
+    {
+      "artist": "Alan Fitzpatrick",
+      "title": "We Do What We Want",
+      "year": 2006,
+      "isrc": "UKGGD0600001",
+      "uri": "spotify:track:45AQPAds44enlvxkLsb8Q1",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2528278871",
+      "fun_fact": "“We Do What We Want” is the title track of Alan Fitzpatrick’s release of the same name.",
+      "fun_fact_de": "„We Do What We Want“ ist der Titelsong der gleichnamigen Veröffentlichung von Alan Fitzpatrick.",
+      "fun_fact_es": "«We Do What We Want» es la canción que da título al lanzamiento homónimo de Alan Fitzpatrick.",
+      "fun_fact_fr": "« We Do What We Want » est le morceau-titre de la publication éponyme de Alan Fitzpatrick.",
+      "fun_fact_nl": "‘We Do What We Want’ is het titelnummer van de gelijknamige release van Alan Fitzpatrick.",
+      "alt_artists": [
+        "Sub Focus, Culture Shock, Fragma",
+        "Jonas Blue, Malive",
+        "Laurent Garnier"
+      ]
+    },
+    {
+      "artist": "Avicii",
+      "title": "You Make Me",
+      "year": 2013,
+      "isrc": "CH3131340083",
+      "uri": "spotify:track:52RK8UVEDgUAgpecOpTQM3",
+      "uri_apple_music": "applemusic://track/1440872944",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1440872944"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/70266757",
+      "fun_fact": "“You Make Me” appears on Avicii’s release “True”.",
+      "fun_fact_de": "„You Make Me“ erschien auf der Veröffentlichung „True“ von Avicii.",
+      "fun_fact_es": "«You Make Me» aparece en el lanzamiento «True» de Avicii.",
+      "fun_fact_fr": "« You Make Me » figure sur la publication « True » de Avicii.",
+      "fun_fact_nl": "‘You Make Me’ staat op de release ‘True’ van Avicii.",
+      "alt_artists": [
+        "Switch",
+        "Reflekt, delline bass",
+        "Dennis Ferrer"
+      ]
+    },
+    {
+      "artist": "Steve Aoki, Chris Lake, Tujamo",
+      "title": "Boneless",
+      "year": 2013,
+      "isrc": "USUS11201499",
+      "uri": "spotify:track:75f4fO9adbAYJqNBKJNrxs",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/70227575",
+      "fun_fact": "“Boneless” appears on Steve Aoki’s release “Boneless (Remixes)”.",
+      "fun_fact_de": "„Boneless“ erschien auf der Veröffentlichung „Boneless (Remixes)“ von Steve Aoki.",
+      "fun_fact_es": "«Boneless» aparece en el lanzamiento «Boneless (Remixes)» de Steve Aoki.",
+      "fun_fact_fr": "« Boneless » figure sur la publication « Boneless (Remixes) » de Steve Aoki.",
+      "fun_fact_nl": "‘Boneless’ staat op de release ‘Boneless (Remixes)’ van Steve Aoki.",
+      "alt_artists": [
+        "Tiësto, BT",
+        "Roger Sanchez",
+        "Vintage Culture, Fancy Inc, The Beach"
+      ]
+    },
+    {
+      "artist": "David Guetta, USHER",
+      "title": "Without You (feat. Usher) - Radio Edit",
+      "year": 2011,
+      "isrc": "GB28K1100136",
+      "uri": "spotify:track:0V6J3G6SyYGQzzLUSAlAKe",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/14243666",
+      "fun_fact": "“Without You (feat. Usher) - Radio Edit” appears on David Guetta’s release “Without You (feat. Usher) (Remixes)”.",
+      "fun_fact_de": "„Without You (feat. Usher) - Radio Edit“ erschien auf der Veröffentlichung „Without You (feat. Usher) (Remixes)“ von David Guetta.",
+      "fun_fact_es": "«Without You (feat. Usher) - Radio Edit» aparece en el lanzamiento «Without You (feat. Usher) (Remixes)» de David Guetta.",
+      "fun_fact_fr": "« Without You (feat. Usher) - Radio Edit » figure sur la publication « Without You (feat. Usher) (Remixes) » de David Guetta.",
+      "fun_fact_nl": "‘Without You (feat. Usher) - Radio Edit’ staat op de release ‘Without You (feat. Usher) (Remixes)’ van David Guetta.",
+      "alt_artists": [
+        "Jax Jones, Martin Solveig, Madison Beer, Europa",
+        "Swedish House Mafia, Connie Constance",
+        "David Guetta, Alesso, Madison Love"
+      ]
+    },
+    {
+      "artist": "Cosmic Gate",
+      "title": "Exploration of Space",
+      "year": 2016,
+      "isrc": "USLZJ1693111",
+      "uri": "spotify:track:0P2sfcfRD0lWw4b8eXegmR",
+      "uri_apple_music": "applemusic://track/669550227",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/669550227"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/129619816",
+      "fun_fact": "“Exploration of Space” appears on Cosmic Gate’s release “DJ Central: Vol. 19”.",
+      "fun_fact_de": "„Exploration of Space“ erschien auf der Veröffentlichung „DJ Central: Vol. 19“ von Cosmic Gate.",
+      "fun_fact_es": "«Exploration of Space» aparece en el lanzamiento «DJ Central: Vol. 19» de Cosmic Gate.",
+      "fun_fact_fr": "« Exploration of Space » figure sur la publication « DJ Central: Vol. 19 » de Cosmic Gate.",
+      "fun_fact_nl": "‘Exploration of Space’ staat op de release ‘DJ Central: Vol. 19’ van Cosmic Gate.",
+      "alt_artists": [
+        "Steve Aoki, Chris Lake, Tujamo",
+        "Tchami",
+        "Joel Corry, Da Hool"
+      ]
+    },
+    {
+      "artist": "Eric Prydz",
+      "title": "Generate - Radio Edit",
+      "year": 2013,
+      "isrc": "GB6CM1300100",
+      "uri": "spotify:track:5LT8hO0Z9Y1nlCJ7nfuSJi",
+      "uri_apple_music": "applemusic://track/1444889719",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1444889719"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/101022014",
+      "fun_fact": "“Generate - Radio Edit” is the title track of Eric Prydz’s release of the same name.",
+      "fun_fact_de": "„Generate - Radio Edit“ ist der Titelsong der gleichnamigen Veröffentlichung von Eric Prydz.",
+      "fun_fact_es": "«Generate - Radio Edit» es la canción que da título al lanzamiento homónimo de Eric Prydz.",
+      "fun_fact_fr": "« Generate - Radio Edit » est le morceau-titre de la publication éponyme de Eric Prydz.",
+      "fun_fact_nl": "‘Generate - Radio Edit’ is het titelnummer van de gelijknamige release van Eric Prydz.",
+      "alt_artists": [
+        "Marlon Hoffstadt, FISHER",
+        "Jax Jones, Martin Solveig, Madison Beer, Europa",
+        "Rank 1"
+      ]
+    },
+    {
+      "artist": "Tiësto, The Chainsmokers",
+      "title": "Split (Only U)",
+      "year": 2015,
+      "isrc": "CYA111500090",
+      "uri": "spotify:track:1Q4jb2UjtWUDUojHsB8mLY",
+      "uri_apple_music": "applemusic://track/1511947026",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1511947026"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/952358062",
+      "fun_fact": "“Split (Only U)” is the title track of Tiësto’s release of the same name.",
+      "fun_fact_de": "„Split (Only U)“ ist der Titelsong der gleichnamigen Veröffentlichung von Tiësto.",
+      "fun_fact_es": "«Split (Only U)» es la canción que da título al lanzamiento homónimo de Tiësto.",
+      "fun_fact_fr": "« Split (Only U) » est le morceau-titre de la publication éponyme de Tiësto.",
+      "fun_fact_nl": "‘Split (Only U)’ is het titelnummer van de gelijknamige release van Tiësto.",
+      "alt_artists": [
+        "Black Coffee, David Guetta, Delilah Montagu",
+        "The Magician, Olly Alexander (Years & Years), Watermät",
+        "Bakermat"
+      ]
+    },
+    {
+      "artist": "HUGEL, Topic, Arash, Daecolm",
+      "title": "I Adore You (feat. Daecolm)",
+      "year": 2024,
+      "isrc": "DECE72402874",
+      "uri": "spotify:track:5nPbKG04fhLkIAjcPFaZq7",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3151230551",
+      "fun_fact": "“I Adore You (feat. Daecolm)” appears on HUGEL’s release “I Adore You (ARTBAT Remix)”.",
+      "fun_fact_de": "„I Adore You (feat. Daecolm)“ erschien auf der Veröffentlichung „I Adore You (ARTBAT Remix)“ von HUGEL.",
+      "fun_fact_es": "«I Adore You (feat. Daecolm)» aparece en el lanzamiento «I Adore You (ARTBAT Remix)» de HUGEL.",
+      "fun_fact_fr": "« I Adore You (feat. Daecolm) » figure sur la publication « I Adore You (ARTBAT Remix) » de HUGEL.",
+      "fun_fact_nl": "‘I Adore You (feat. Daecolm)’ staat op de release ‘I Adore You (ARTBAT Remix)’ van HUGEL.",
+      "alt_artists": [
+        "Tiësto, Poppy Baskcomb",
+        "KI/KI, Marlon Hoffstadt",
+        "Deniz Koyu"
+      ]
+    },
+    {
+      "artist": "Knife Party",
+      "title": "Internet Friends",
+      "year": 2011,
+      "isrc": "GBAHT1200462",
+      "uri": "spotify:track:5qFL2uwfnGU8FccwLMgPNQ",
+      "uri_apple_music": "applemusic://track/1692399425",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1692399425"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/56718321",
+      "fun_fact": "“Internet Friends” appears on Knife Party’s release “100% No Modern Talking”.",
+      "fun_fact_de": "„Internet Friends“ erschien auf der Veröffentlichung „100% No Modern Talking“ von Knife Party.",
+      "fun_fact_es": "«Internet Friends» aparece en el lanzamiento «100% No Modern Talking» de Knife Party.",
+      "fun_fact_fr": "« Internet Friends » figure sur la publication « 100% No Modern Talking » de Knife Party.",
+      "fun_fact_nl": "‘Internet Friends’ staat op de release ‘100% No Modern Talking’ van Knife Party.",
+      "alt_artists": [
+        "Steve Aoki, KAAZE, John Martin",
+        "Kaskade, MOGUAI, Zip Zip Through The Night",
+        "Dom Dolla, Clementine Douglas"
+      ]
+    },
+    {
+      "artist": "Dirty South, Rudy, Axwell",
+      "title": "Let It Go - Axwell Remix",
+      "year": 2007,
+      "isrc": "GBKCF0700056",
+      "uri": "spotify:track:1vg2d0oXaUMNrYrLNdY8Gx",
+      "uri_apple_music": "applemusic://track/626193146",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/626193146"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1806142637",
+      "fun_fact": "“Let It Go - Axwell Remix” appears on Dirty South’s release “Let It Go”.",
+      "fun_fact_de": "„Let It Go - Axwell Remix“ erschien auf der Veröffentlichung „Let It Go“ von Dirty South.",
+      "fun_fact_es": "«Let It Go - Axwell Remix» aparece en el lanzamiento «Let It Go» de Dirty South.",
+      "fun_fact_fr": "« Let It Go - Axwell Remix » figure sur la publication « Let It Go » de Dirty South.",
+      "fun_fact_nl": "‘Let It Go - Axwell Remix’ staat op de release ‘Let It Go’ van Dirty South.",
+      "alt_artists": [
+        "Pegassi",
+        "David Guetta, Alphaville, Hypaton, Ava Max",
+        "Otto Knows, Avicii"
+      ]
+    },
+    {
+      "artist": "Fragma",
+      "title": "Toca's Miracle - Radio Edit",
+      "year": 2022,
+      "isrc": "DEP992200001",
+      "uri": "spotify:track:6oE5yvroDXWNYWpIFz2JJB",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1678490857",
+      "fun_fact": "“Toca's Miracle - Radio Edit” appears on Fragma’s release “Toca (20th Anniversary Edition)”.",
+      "fun_fact_de": "„Toca's Miracle - Radio Edit“ erschien auf der Veröffentlichung „Toca (20th Anniversary Edition)“ von Fragma.",
+      "fun_fact_es": "«Toca's Miracle - Radio Edit» aparece en el lanzamiento «Toca (20th Anniversary Edition)» de Fragma.",
+      "fun_fact_fr": "« Toca's Miracle - Radio Edit » figure sur la publication « Toca (20th Anniversary Edition) » de Fragma.",
+      "fun_fact_nl": "‘Toca's Miracle - Radio Edit’ staat op de release ‘Toca (20th Anniversary Edition)’ van Fragma.",
+      "alt_artists": [
+        "Rank 1",
+        "Sub Focus",
+        "Justice, Soulwax"
+      ]
+    },
+    {
+      "artist": "Calvin Harris",
+      "title": "I'm Not Alone - Radio Edit",
+      "year": 2009,
+      "isrc": "GBARL0900102",
+      "uri": "spotify:track:07POri5O6Xu0aVZzlvOcpy",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/13131862",
+      "fun_fact": "“I'm Not Alone - Radio Edit” appears on Calvin Harris’s release “Ready For The Weekend”.",
+      "fun_fact_de": "„I'm Not Alone - Radio Edit“ erschien auf der Veröffentlichung „Ready For The Weekend“ von Calvin Harris.",
+      "fun_fact_es": "«I'm Not Alone - Radio Edit» aparece en el lanzamiento «Ready For The Weekend» de Calvin Harris.",
+      "fun_fact_fr": "« I'm Not Alone - Radio Edit » figure sur la publication « Ready For The Weekend » de Calvin Harris.",
+      "fun_fact_nl": "‘I'm Not Alone - Radio Edit’ staat op de release ‘Ready For The Weekend’ van Calvin Harris.",
+      "alt_artists": [
+        "Delerium, Sarah McLachlan, John Summit",
+        "ILLENIUM, Valerie Broussard, NURKO",
+        "Skrillex, Damian \"Jr Gong\" Marley"
+      ]
+    },
+    {
+      "artist": "&ME, Rampa, Adam Port, Alan Dixon, Keinemusik, Arabic Piano",
+      "title": "Thandaza",
+      "year": 2024,
+      "isrc": "DEEC33501383",
+      "uri": "spotify:track:4x6jx7AeSyE7PlQTdCjIJs",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2684663852",
+      "fun_fact": "“Thandaza” is the title track of &ME’s release of the same name.",
+      "fun_fact_de": "„Thandaza“ ist der Titelsong der gleichnamigen Veröffentlichung von &ME.",
+      "fun_fact_es": "«Thandaza» es la canción que da título al lanzamiento homónimo de &ME.",
+      "fun_fact_fr": "« Thandaza » est le morceau-titre de la publication éponyme de &ME.",
+      "fun_fact_nl": "‘Thandaza’ is het titelnummer van de gelijknamige release van &ME.",
+      "alt_artists": [
+        "Rebūke, Konstantin Sibold, ZAC, CARMEE",
+        "David Guetta, MORTEN, Aloe Blacc",
+        "Tiësto, Deorro"
+      ]
+    },
+    {
+      "artist": "Martin Garrix, Matisse & Sadko",
+      "title": "Break Through The Silence - Radio Edit",
+      "year": 2015,
+      "isrc": "NLZ541500543",
+      "uri": "spotify:track:2eotSKVADMMV6qaY15qDOd",
+      "uri_apple_music": "applemusic://track/1350851321",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1350851321"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/463377162",
+      "fun_fact": "“Break Through The Silence - Radio Edit” appears on Martin Garrix’s release “Break Through The Silence EP”.",
+      "fun_fact_de": "„Break Through The Silence - Radio Edit“ erschien auf der Veröffentlichung „Break Through The Silence EP“ von Martin Garrix.",
+      "fun_fact_es": "«Break Through The Silence - Radio Edit» aparece en el lanzamiento «Break Through The Silence EP» de Martin Garrix.",
+      "fun_fact_fr": "« Break Through The Silence - Radio Edit » figure sur la publication « Break Through The Silence EP » de Martin Garrix.",
+      "fun_fact_nl": "‘Break Through The Silence - Radio Edit’ staat op de release ‘Break Through The Silence EP’ van Martin Garrix.",
+      "alt_artists": [
+        "Deniz Koyu",
+        "Jack Ü, Skrillex, Diplo, Kiesza, Tchami",
+        "Dim Chris, Sebastien Drums, Avicii"
+      ]
+    },
+    {
+      "artist": "James Hype, Kelli-Leigh",
+      "title": "More Than Friends (feat. Kelli-Leigh) - VIP Mix",
+      "year": 2017,
+      "isrc": "GBAHT1700474",
+      "uri": "spotify:track:5wLJkvV083MxvW47AJnyHt",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/376386131",
+      "fun_fact": "“More Than Friends (feat. Kelli-Leigh) - VIP Mix” appears on James Hype’s release “More Than Friends (feat. Kelli-Leigh)”.",
+      "fun_fact_de": "„More Than Friends (feat. Kelli-Leigh) - VIP Mix“ erschien auf der Veröffentlichung „More Than Friends (feat. Kelli-Leigh)“ von James Hype.",
+      "fun_fact_es": "«More Than Friends (feat. Kelli-Leigh) - VIP Mix» aparece en el lanzamiento «More Than Friends (feat. Kelli-Leigh)» de James Hype.",
+      "fun_fact_fr": "« More Than Friends (feat. Kelli-Leigh) - VIP Mix » figure sur la publication « More Than Friends (feat. Kelli-Leigh) » de James Hype.",
+      "fun_fact_nl": "‘More Than Friends (feat. Kelli-Leigh) - VIP Mix’ staat op de release ‘More Than Friends (feat. Kelli-Leigh)’ van James Hype.",
+      "alt_artists": [
+        "BURNS",
+        "Kaskade, John Dahlbäck, Sansa",
+        "Bodyrox, Luciana, D. Ramirez"
+      ]
+    },
+    {
+      "artist": "Oliver Heldens",
+      "title": "Melody - Radio Edit",
+      "year": 2015,
+      "isrc": "NLZ541500278",
+      "uri": "spotify:track:2g6EknB0CW6e3Q8BkM1oQ9",
+      "uri_apple_music": "applemusic://track/1336612552",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1336612552"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/452697792",
+      "fun_fact": "“Melody - Radio Edit” appears on Oliver Heldens’s release “Melody”.",
+      "fun_fact_de": "„Melody - Radio Edit“ erschien auf der Veröffentlichung „Melody“ von Oliver Heldens.",
+      "fun_fact_es": "«Melody - Radio Edit» aparece en el lanzamiento «Melody» de Oliver Heldens.",
+      "fun_fact_fr": "« Melody - Radio Edit » figure sur la publication « Melody » de Oliver Heldens.",
+      "fun_fact_nl": "‘Melody - Radio Edit’ staat op de release ‘Melody’ van Oliver Heldens.",
+      "alt_artists": [
+        "David Guetta, Sia",
+        "Chris Lake",
+        "cassö, RAYE, D-Block Europe"
+      ]
+    },
+    {
+      "artist": "Madeon",
+      "title": "Icarus",
+      "year": 2012,
+      "isrc": "FR9W11114947",
+      "uri": "spotify:track:1pUsdir2xhSxP0RyBe9lLH",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/16638433",
+      "fun_fact": "“Icarus” is the title track of Madeon’s release of the same name.",
+      "fun_fact_de": "„Icarus“ ist der Titelsong der gleichnamigen Veröffentlichung von Madeon.",
+      "fun_fact_es": "«Icarus» es la canción que da título al lanzamiento homónimo de Madeon.",
+      "fun_fact_fr": "« Icarus » est le morceau-titre de la publication éponyme de Madeon.",
+      "fun_fact_nl": "‘Icarus’ is het titelnummer van de gelijknamige release van Madeon.",
+      "alt_artists": [
+        "Secondcity",
+        "Becky Hill, Galantis",
+        "MOGUAI, Cheat Codes"
+      ]
+    },
+    {
+      "artist": "The Killers, Jacques Lu Cont",
+      "title": "Mr. Brightside - Jacques Lu Cont's Thin White Duke Mix",
+      "year": 2004,
+      "isrc": "USIR20500022",
+      "uri": "spotify:track:2jrJEy61zyESXv9sW8bAx6",
+      "uri_apple_music": "applemusic://track/1440877826",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1440877826"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1103289",
+      "fun_fact": "“Mr. Brightside - Jacques Lu Cont's Thin White Duke Mix” appears on The Killers’s release “Sawdust”.",
+      "fun_fact_de": "„Mr. Brightside - Jacques Lu Cont's Thin White Duke Mix“ erschien auf der Veröffentlichung „Sawdust“ von The Killers.",
+      "fun_fact_es": "«Mr. Brightside - Jacques Lu Cont's Thin White Duke Mix» aparece en el lanzamiento «Sawdust» de The Killers.",
+      "fun_fact_fr": "« Mr. Brightside - Jacques Lu Cont's Thin White Duke Mix » figure sur la publication « Sawdust » de The Killers.",
+      "fun_fact_nl": "‘Mr. Brightside - Jacques Lu Cont's Thin White Duke Mix’ staat op de release ‘Sawdust’ van The Killers.",
+      "alt_artists": [
+        "Tiësto, Don Diablo, Thomas Troelsen",
+        "Jaden Bojsen, Sami Brielle",
+        "Above & Beyond, anamē, Marty Longstaff"
+      ]
+    },
+    {
+      "artist": "Ummet Ozcan",
+      "title": "Raise Your Hands - Radio Edit",
+      "year": 2014,
+      "isrc": "NLZ541400292",
+      "uri": "spotify:track:1j9IdProZpoS0mVqlyfOp1",
+      "uri_apple_music": "applemusic://track/1336548866",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1336548866"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/452689462",
+      "fun_fact": "“Raise Your Hands - Radio Edit” is the title track of Ummet Ozcan’s release of the same name.",
+      "fun_fact_de": "„Raise Your Hands - Radio Edit“ ist der Titelsong der gleichnamigen Veröffentlichung von Ummet Ozcan.",
+      "fun_fact_es": "«Raise Your Hands - Radio Edit» es la canción que da título al lanzamiento homónimo de Ummet Ozcan.",
+      "fun_fact_fr": "« Raise Your Hands - Radio Edit » est le morceau-titre de la publication éponyme de Ummet Ozcan.",
+      "fun_fact_nl": "‘Raise Your Hands - Radio Edit’ is het titelnummer van de gelijknamige release van Ummet Ozcan.",
+      "alt_artists": [
+        "Alesso, Katy Perry",
+        "Martin Garrix, Khalid, DubVision",
+        "Miss Monique"
+      ]
+    },
+    {
+      "artist": "Steve Angello, The Presets",
+      "title": "Remember (feat. The Presets)",
+      "year": 2015,
+      "isrc": "GBXGT1500037",
+      "uri": "spotify:track:3IvgnZ2vUJedikovn6OLmy",
+      "uri_apple_music": "applemusic://track/1054208532",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1054208532"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/111101816",
+      "fun_fact": "“Remember (feat. The Presets)” is the title track of Steve Angello’s release of the same name.",
+      "fun_fact_de": "„Remember (feat. The Presets)“ ist der Titelsong der gleichnamigen Veröffentlichung von Steve Angello.",
+      "fun_fact_es": "«Remember (feat. The Presets)» es la canción que da título al lanzamiento homónimo de Steve Angello.",
+      "fun_fact_fr": "« Remember (feat. The Presets) » est le morceau-titre de la publication éponyme de Steve Angello.",
+      "fun_fact_nl": "‘Remember (feat. The Presets)’ is het titelnummer van de gelijknamige release van Steve Angello.",
+      "alt_artists": [
+        "SOFI TUKKER, Öwnboss, Fancy Inc",
+        "deadmau5, Wolfgang Gartner",
+        "Axwell, Sebastian Ingrosso, Steve Angello, Laidback Luke"
+      ]
+    },
+    {
+      "artist": "Mike Williams, Mesto",
+      "title": "Wait Another Day",
+      "year": 2018,
+      "isrc": "NLZ541801572",
+      "uri": "spotify:track:7qZOnik9K8Mv987ccBjwwj",
+      "uri_apple_music": "applemusic://track/1443846750",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1443846750"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/599043162",
+      "fun_fact": "“Wait Another Day” is the title track of Mike Williams’s release of the same name.",
+      "fun_fact_de": "„Wait Another Day“ ist der Titelsong der gleichnamigen Veröffentlichung von Mike Williams.",
+      "fun_fact_es": "«Wait Another Day» es la canción que da título al lanzamiento homónimo de Mike Williams.",
+      "fun_fact_fr": "« Wait Another Day » est le morceau-titre de la publication éponyme de Mike Williams.",
+      "fun_fact_nl": "‘Wait Another Day’ is het titelnummer van de gelijknamige release van Mike Williams.",
+      "alt_artists": [
+        "Calvin Harris, Clementine Douglas",
+        "Dirty South, Alesso, Ruben Haze",
+        "Alter Ego, Eric Prydz"
+      ]
+    },
+    {
+      "artist": "CHRIS STASSY, S.A.M.",
+      "title": "Breather",
+      "year": 2021,
+      "isrc": "UKACT2130817",
+      "uri": "spotify:track:1e20Z4j3nuQP35vFtyF1JU",
+      "uri_apple_music": "applemusic://track/1872667788",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1872667788"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3808514882",
+      "fun_fact": "“Breather” appears on CHRIS STASSY’s release “Get Together”.",
+      "fun_fact_de": "„Breather“ erschien auf der Veröffentlichung „Get Together“ von CHRIS STASSY.",
+      "fun_fact_es": "«Breather» aparece en el lanzamiento «Get Together» de CHRIS STASSY.",
+      "fun_fact_fr": "« Breather » figure sur la publication « Get Together » de CHRIS STASSY.",
+      "fun_fact_nl": "‘Breather’ staat op de release ‘Get Together’ van CHRIS STASSY.",
+      "alt_artists": [
+        "Tiësto, KSHMR, VASSY",
+        "Martin Garrix, Macklemore, Fall Out Boy, Tiësto",
+        "D*Note, Pete Heller"
+      ]
+    },
+    {
+      "artist": "Avicii, Sebastien Drums",
+      "title": "My Feelings For You - Radio Edit",
+      "year": 2010,
+      "isrc": "AUVC02203910",
+      "uri": "spotify:track:3Yv9CEIOJjpw8tgKJhbOcc",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/4106993181",
+      "fun_fact": "“My Feelings For You - Radio Edit” appears on Avicii’s release “My Feelings For You”.",
+      "fun_fact_de": "„My Feelings For You - Radio Edit“ erschien auf der Veröffentlichung „My Feelings For You“ von Avicii.",
+      "fun_fact_es": "«My Feelings For You - Radio Edit» aparece en el lanzamiento «My Feelings For You» de Avicii.",
+      "fun_fact_fr": "« My Feelings For You - Radio Edit » figure sur la publication « My Feelings For You » de Avicii.",
+      "fun_fact_nl": "‘My Feelings For You - Radio Edit’ staat op de release ‘My Feelings For You’ van Avicii.",
+      "alt_artists": [
+        "BUNT., Nate Traveller",
+        "Madeon",
+        "Bob Sinclar"
+      ]
+    },
+    {
+      "artist": "Bag Raiders",
+      "title": "Shooting Stars",
+      "year": 2009,
+      "isrc": "AUUM70902040",
+      "uri": "spotify:track:7tOcPDj3vyopZ404pY6UuP",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/4231436",
+      "fun_fact": "“Shooting Stars” is the title track of Bag Raiders’s release of the same name.",
+      "fun_fact_de": "„Shooting Stars“ ist der Titelsong der gleichnamigen Veröffentlichung von Bag Raiders.",
+      "fun_fact_es": "«Shooting Stars» es la canción que da título al lanzamiento homónimo de Bag Raiders.",
+      "fun_fact_fr": "« Shooting Stars » est le morceau-titre de la publication éponyme de Bag Raiders.",
+      "fun_fact_nl": "‘Shooting Stars’ is het titelnummer van de gelijknamige release van Bag Raiders.",
+      "alt_artists": [
+        "Mr. Probz, Chris Brown, T.I.",
+        "Dj Bountyhunter",
+        "Martin Garrix, Macklemore, Fall Out Boy, Tiësto"
+      ]
+    },
+    {
+      "artist": "Mr. Probz, Chris Brown, T.I.",
+      "title": "Waves [feat. Chris Brown & T.I.] - Robin Schulz Remix",
+      "year": 2014,
+      "isrc": "NLB8R1400020",
+      "uri": "spotify:track:2HDhsfCmbVjLHYXK32jaCC",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1084862592",
+      "fun_fact": "“Waves [feat. Chris Brown & T.I.] - Robin Schulz Remix” is the title track of Mr. Probz’s release of the same name.",
+      "fun_fact_de": "„Waves [feat. Chris Brown & T.I.] - Robin Schulz Remix“ ist der Titelsong der gleichnamigen Veröffentlichung von Mr. Probz.",
+      "fun_fact_es": "«Waves [feat. Chris Brown & T.I.] - Robin Schulz Remix» es la canción que da título al lanzamiento homónimo de Mr. Probz.",
+      "fun_fact_fr": "« Waves [feat. Chris Brown & T.I.] - Robin Schulz Remix » est le morceau-titre de la publication éponyme de Mr. Probz.",
+      "fun_fact_nl": "‘Waves [feat. Chris Brown & T.I.] - Robin Schulz Remix’ is het titelnummer van de gelijknamige release van Mr. Probz.",
+      "alt_artists": [
+        "Pryda",
+        "Kevin de Vries",
+        "Pleasurekraft"
+      ]
+    },
+    {
+      "artist": "Axwell, Errol Reid",
+      "title": "Nothing But Love - Radio Edit",
+      "year": 2010,
+      "isrc": "GBKCF1000157",
+      "uri": "spotify:track:317BSQk5pe7FyV3VVmS62w",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/73460660",
+      "fun_fact": "“Nothing But Love - Radio Edit” appears on Axwell’s release “Nothing But Love”.",
+      "fun_fact_de": "„Nothing But Love - Radio Edit“ erschien auf der Veröffentlichung „Nothing But Love“ von Axwell.",
+      "fun_fact_es": "«Nothing But Love - Radio Edit» aparece en el lanzamiento «Nothing But Love» de Axwell.",
+      "fun_fact_fr": "« Nothing But Love - Radio Edit » figure sur la publication « Nothing But Love » de Axwell.",
+      "fun_fact_nl": "‘Nothing But Love - Radio Edit’ staat op de release ‘Nothing But Love’ van Axwell.",
+      "alt_artists": [
+        "Double 99",
+        "Justice, Soulwax",
+        "Showtek, Justin Prime"
+      ]
+    },
+    {
+      "artist": "System F",
+      "title": "Out Of The Blue",
+      "year": 1999,
+      "isrc": "NLB770100093",
+      "uri": "spotify:track:7fIfO8fZ55Eq5qtd5vCd6z",
+      "uri_apple_music": "applemusic://track/1565941214",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1565941214"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/937659352",
+      "fun_fact": "“Out Of The Blue” is the title track of System F’s release of the same name.",
+      "fun_fact_de": "„Out Of The Blue“ ist der Titelsong der gleichnamigen Veröffentlichung von System F.",
+      "fun_fact_es": "«Out Of The Blue» es la canción que da título al lanzamiento homónimo de System F.",
+      "fun_fact_fr": "« Out Of The Blue » est le morceau-titre de la publication éponyme de System F.",
+      "fun_fact_nl": "‘Out Of The Blue’ is het titelnummer van de gelijknamige release van System F.",
+      "alt_artists": [
+        "KI/KI, Marlon Hoffstadt",
+        "Alesso, Sentinel",
+        "Afro Medusa"
+      ]
+    },
+    {
+      "artist": "Armin van Buuren, Nicky Romero, Ifimay",
+      "title": "I Need You To Know",
+      "year": 2020,
+      "isrc": "NLF712006881",
+      "uri": "spotify:track:3KFei4ncqdevg1vZaAZgIL",
+      "uri_apple_music": "applemusic://track/1523741361",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1523741361"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/994819972",
+      "fun_fact": "“I Need You To Know” is the title track of Armin van Buuren’s release of the same name.",
+      "fun_fact_de": "„I Need You To Know“ ist der Titelsong der gleichnamigen Veröffentlichung von Armin van Buuren.",
+      "fun_fact_es": "«I Need You To Know» es la canción que da título al lanzamiento homónimo de Armin van Buuren.",
+      "fun_fact_fr": "« I Need You To Know » est le morceau-titre de la publication éponyme de Armin van Buuren.",
+      "fun_fact_nl": "‘I Need You To Know’ is het titelnummer van de gelijknamige release van Armin van Buuren.",
+      "alt_artists": [
+        "Monolink, ARTBAT",
+        "Rampa, Adam Port, &ME, chuala, Keinemusik",
+        "AFROJACK"
+      ]
+    },
+    {
+      "artist": "Tiësto, Sevenn",
+      "title": "BOOM",
+      "year": 2017,
+      "isrc": "CYA111800003",
+      "uri": "spotify:track:1yaISGEoawvX2l6cU7M13n",
+      "uri_apple_music": "applemusic://track/1444887542",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1444887542"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/451666062",
+      "fun_fact": "“BOOM” is the title track of Tiësto’s release of the same name.",
+      "fun_fact_de": "„BOOM“ ist der Titelsong der gleichnamigen Veröffentlichung von Tiësto.",
+      "fun_fact_es": "«BOOM» es la canción que da título al lanzamiento homónimo de Tiësto.",
+      "fun_fact_fr": "« BOOM » est le morceau-titre de la publication éponyme de Tiësto.",
+      "fun_fact_nl": "‘BOOM’ is het titelnummer van de gelijknamige release van Tiësto.",
+      "alt_artists": [
+        "M.A.N.D.Y., Booka Shade",
+        "Justice, Soulwax",
+        "Paul Kalkbrenner"
+      ]
+    },
+    {
+      "artist": "Dimitri Vegas, Like Mike, Dada Life",
+      "title": "Tomorrow - The Tomorrowland Anthem - Give in to the Night",
+      "year": 2010,
+      "isrc": "BEG581000001",
+      "uri": "spotify:track:71DiO15JfaJuQRiNUc6i1J",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/85997699",
+      "fun_fact": "“Tomorrow - The Tomorrowland Anthem - Give in to the Night” appears on Dimitri Vegas’s release “Tomorrow (Give In To The Night / The Tomorrowland Anthem)”.",
+      "fun_fact_de": "„Tomorrow - The Tomorrowland Anthem - Give in to the Night“ erschien auf der Veröffentlichung „Tomorrow (Give In To The Night / The Tomorrowland Anthem)“ von Dimitri Vegas.",
+      "fun_fact_es": "«Tomorrow - The Tomorrowland Anthem - Give in to the Night» aparece en el lanzamiento «Tomorrow (Give In To The Night / The Tomorrowland Anthem)» de Dimitri Vegas.",
+      "fun_fact_fr": "« Tomorrow - The Tomorrowland Anthem - Give in to the Night » figure sur la publication « Tomorrow (Give In To The Night / The Tomorrowland Anthem) » de Dimitri Vegas.",
+      "fun_fact_nl": "‘Tomorrow - The Tomorrowland Anthem - Give in to the Night’ staat op de release ‘Tomorrow (Give In To The Night / The Tomorrowland Anthem)’ van Dimitri Vegas.",
+      "alt_artists": [
+        "ILLENIUM, Valerie Broussard, NURKO",
+        "Ninetoes",
+        "Congorock, Lexxus"
+      ]
+    },
+    {
+      "artist": "Martin Garrix, Bonn",
+      "title": "Home (feat. Bonn)",
+      "year": 2019,
+      "isrc": "NLM5S1900632",
+      "uri": "spotify:track:4aTtHoSBB0CuQGA6vXBNyp",
+      "uri_apple_music": "applemusic://track/1475915894",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1475915894"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/728155102",
+      "fun_fact": "“Home (feat. Bonn)” is the title track of Martin Garrix’s release of the same name.",
+      "fun_fact_de": "„Home (feat. Bonn)“ ist der Titelsong der gleichnamigen Veröffentlichung von Martin Garrix.",
+      "fun_fact_es": "«Home (feat. Bonn)» es la canción que da título al lanzamiento homónimo de Martin Garrix.",
+      "fun_fact_fr": "« Home (feat. Bonn) » est le morceau-titre de la publication éponyme de Martin Garrix.",
+      "fun_fact_nl": "‘Home (feat. Bonn)’ is het titelnummer van de gelijknamige release van Martin Garrix.",
+      "alt_artists": [
+        "Maverick Sabre, Jorja Smith, Vintage Culture, Slow Motion",
+        "Dim Chris, Sebastien Drums, Avicii",
+        "David Guetta, Nicky Romero, Sia"
+      ]
+    },
+    {
+      "artist": "KETTAMA",
+      "title": "Pretty Green Eyes (Sunset Ibiza Mix)",
+      "year": 2024,
+      "isrc": "CBEFB2400006",
+      "uri": "spotify:track:3Q2RZh5dlBuqaeDIxPeieP",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2817234002",
+      "fun_fact": "“Pretty Green Eyes (Sunset Ibiza Mix)” is the title track of KETTAMA’s release of the same name.",
+      "fun_fact_de": "„Pretty Green Eyes (Sunset Ibiza Mix)“ ist der Titelsong der gleichnamigen Veröffentlichung von KETTAMA.",
+      "fun_fact_es": "«Pretty Green Eyes (Sunset Ibiza Mix)» es la canción que da título al lanzamiento homónimo de KETTAMA.",
+      "fun_fact_fr": "« Pretty Green Eyes (Sunset Ibiza Mix) » est le morceau-titre de la publication éponyme de KETTAMA.",
+      "fun_fact_nl": "‘Pretty Green Eyes (Sunset Ibiza Mix)’ is het titelnummer van de gelijknamige release van KETTAMA.",
+      "alt_artists": [
+        "Andain",
+        "Cassian, SCRIPT, Belladonna (ofc)",
+        "Salif Keita, Martin Solveig"
+      ]
+    },
+    {
+      "artist": "Avicii, Aloe Blacc",
+      "title": "SOS (feat. Aloe Blacc)",
+      "year": 2019,
+      "isrc": "SE5R71900301",
+      "uri": "spotify:track:2x0RZdkZcD8QRI53XT4GI5",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/679227012",
+      "fun_fact": "“SOS (feat. Aloe Blacc)” appears on Avicii’s release “SOS (Laidback Luke Tribute Remix)”.",
+      "fun_fact_de": "„SOS (feat. Aloe Blacc)“ erschien auf der Veröffentlichung „SOS (Laidback Luke Tribute Remix)“ von Avicii.",
+      "fun_fact_es": "«SOS (feat. Aloe Blacc)» aparece en el lanzamiento «SOS (Laidback Luke Tribute Remix)» de Avicii.",
+      "fun_fact_fr": "« SOS (feat. Aloe Blacc) » figure sur la publication « SOS (Laidback Luke Tribute Remix) » de Avicii.",
+      "fun_fact_nl": "‘SOS (feat. Aloe Blacc)’ staat op de release ‘SOS (Laidback Luke Tribute Remix)’ van Avicii.",
+      "alt_artists": [
+        "Tiësto, R3HAB",
+        "Diplo, Paul Woolford, Kareen Lomax",
+        "Tiësto, KSHMR, VASSY"
+      ]
+    },
+    {
+      "artist": "Steve Angello, Matisse & Sadko",
+      "title": "SLVR",
+      "year": 2013,
+      "isrc": "USYBL1400353",
+      "uri": "spotify:track:3Qntjzw2xY1VDb6x808BPi",
+      "uri_apple_music": "applemusic://track/948391884",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/948391884"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/93706216",
+      "fun_fact": "“SLVR” is the title track of Steve Angello’s release of the same name.",
+      "fun_fact_de": "„SLVR“ ist der Titelsong der gleichnamigen Veröffentlichung von Steve Angello.",
+      "fun_fact_es": "«SLVR» es la canción que da título al lanzamiento homónimo de Steve Angello.",
+      "fun_fact_fr": "« SLVR » est le morceau-titre de la publication éponyme de Steve Angello.",
+      "fun_fact_nl": "‘SLVR’ is het titelnummer van de gelijknamige release van Steve Angello.",
+      "alt_artists": [
+        "BLOND:ISH, Stevie Appleton",
+        "Tiësto, The Chainsmokers",
+        "Parachute Youth"
+      ]
+    },
+    {
+      "artist": "Otto Knows, Avicii",
+      "title": "Back Where I Belong (feat. Avicii)",
+      "year": 2016,
+      "isrc": "SE4OX1600112",
+      "uri": "spotify:track:78W8wiUIlQ2SnWY9TVowKZ",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/125970763",
+      "fun_fact": "“Back Where I Belong (feat. Avicii)” is the title track of Otto Knows’s release of the same name.",
+      "fun_fact_de": "„Back Where I Belong (feat. Avicii)“ ist der Titelsong der gleichnamigen Veröffentlichung von Otto Knows.",
+      "fun_fact_es": "«Back Where I Belong (feat. Avicii)» es la canción que da título al lanzamiento homónimo de Otto Knows.",
+      "fun_fact_fr": "« Back Where I Belong (feat. Avicii) » est le morceau-titre de la publication éponyme de Otto Knows.",
+      "fun_fact_nl": "‘Back Where I Belong (feat. Avicii)’ is het titelnummer van de gelijknamige release van Otto Knows.",
+      "alt_artists": [
+        "DJ Hyperactive, Len Faki",
+        "Armin van Buuren",
+        "Martin Garrix, John Martin"
+      ]
+    },
+    {
+      "artist": "Armand Van Helden",
+      "title": "I Want Your Soul",
+      "year": 2007,
+      "isrc": "GBEFR0701070",
+      "uri": "spotify:track:1uqnKeoy55KA6LqoOiW4Pm",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/14155727",
+      "fun_fact": "“I Want Your Soul” is the title track of Armand Van Helden’s release of the same name.",
+      "fun_fact_de": "„I Want Your Soul“ ist der Titelsong der gleichnamigen Veröffentlichung von Armand Van Helden.",
+      "fun_fact_es": "«I Want Your Soul» es la canción que da título al lanzamiento homónimo de Armand Van Helden.",
+      "fun_fact_fr": "« I Want Your Soul » est le morceau-titre de la publication éponyme de Armand Van Helden.",
+      "fun_fact_nl": "‘I Want Your Soul’ is het titelnummer van de gelijknamige release van Armand Van Helden.",
+      "alt_artists": [
+        "Martin Garrix, Third Party, Oaks, Declan J Donovan",
+        "David Tort, Gosha",
+        "Maceo Plex, Chromatics"
+      ]
+    },
+    {
+      "artist": "David Guetta, MORTEN, RAYE",
+      "title": "Make It to Heaven (with Raye)",
+      "year": 2019,
+      "isrc": "GB28K1900115",
+      "uri": "spotify:track:5dS2dvXVPe7AR6UwBpnomW",
+      "uri_apple_music": "applemusic://track/1487717291",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1487717291"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/812497162",
+      "fun_fact": "“Make It to Heaven (with Raye)” is the title track of David Guetta’s release of the same name.",
+      "fun_fact_de": "„Make It to Heaven (with Raye)“ ist der Titelsong der gleichnamigen Veröffentlichung von David Guetta.",
+      "fun_fact_es": "«Make It to Heaven (with Raye)» es la canción que da título al lanzamiento homónimo de David Guetta.",
+      "fun_fact_fr": "« Make It to Heaven (with Raye) » est le morceau-titre de la publication éponyme de David Guetta.",
+      "fun_fact_nl": "‘Make It to Heaven (with Raye)’ is het titelnummer van de gelijknamige release van David Guetta.",
+      "alt_artists": [
+        "Grooveyard, Nicky Romero",
+        "Friend Within",
+        "David Guetta, Alesso, Madison Love"
+      ]
+    },
+    {
+      "artist": "Tiësto",
+      "title": "Flight 643 - Radio Edit",
+      "year": 2001,
+      "isrc": "NLE710180155",
+      "uri": "spotify:track:56hewzN2QiJIxtqAEQTAs4",
+      "uri_apple_music": "applemusic://track/1793821451",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1793821451"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3212563541",
+      "fun_fact": "“Flight 643 - Radio Edit” appears on Tiësto’s release “Magikal Journey -The Hits Collection 1998 - 2008”.",
+      "fun_fact_de": "„Flight 643 - Radio Edit“ erschien auf der Veröffentlichung „Magikal Journey -The Hits Collection 1998 - 2008“ von Tiësto.",
+      "fun_fact_es": "«Flight 643 - Radio Edit» aparece en el lanzamiento «Magikal Journey -The Hits Collection 1998 - 2008» de Tiësto.",
+      "fun_fact_fr": "« Flight 643 - Radio Edit » figure sur la publication « Magikal Journey -The Hits Collection 1998 - 2008 » de Tiësto.",
+      "fun_fact_nl": "‘Flight 643 - Radio Edit’ staat op de release ‘Magikal Journey -The Hits Collection 1998 - 2008’ van Tiësto.",
+      "alt_artists": [
+        "DJ MERCER, Tchami",
+        "Steve Angello, The Presets",
+        "Dimitri Vegas & Like Mike, Sander van Doorn"
+      ]
+    },
+    {
+      "artist": "MK",
+      "title": "17",
+      "year": 2017,
+      "isrc": "GBARL1701492",
+      "uri": "spotify:track:15DwFznkBJir7AK9PyMyRR",
+      "uri_apple_music": "applemusic://track/1269598586",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1269598586"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/393116082",
+      "fun_fact": "“17” is the title track of MK’s release of the same name.",
+      "fun_fact_de": "„17“ ist der Titelsong der gleichnamigen Veröffentlichung von MK.",
+      "fun_fact_es": "«17» es la canción que da título al lanzamiento homónimo de MK.",
+      "fun_fact_fr": "« 17 » est le morceau-titre de la publication éponyme de MK.",
+      "fun_fact_nl": "‘17’ is het titelnummer van de gelijknamige release van MK.",
+      "alt_artists": [
+        "Travis Scott, CHASE B",
+        "Armin van Buuren, Tempo Giusto",
+        "Dom Dolla"
+      ]
+    },
+    {
+      "artist": "Hardwell, Blasterjaxx, Mitch Crown",
+      "title": "Bigroom Never Dies",
+      "year": 2018,
+      "isrc": "NLQ8D1700571",
+      "uri": "spotify:track:0g7r4J268kF71T7ChFu8kI",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1755322927",
+      "fun_fact": "“Bigroom Never Dies” is the title track of Hardwell’s release of the same name.",
+      "fun_fact_de": "„Bigroom Never Dies“ ist der Titelsong der gleichnamigen Veröffentlichung von Hardwell.",
+      "fun_fact_es": "«Bigroom Never Dies» es la canción que da título al lanzamiento homónimo de Hardwell.",
+      "fun_fact_fr": "« Bigroom Never Dies » est le morceau-titre de la publication éponyme de Hardwell.",
+      "fun_fact_nl": "‘Bigroom Never Dies’ is het titelnummer van de gelijknamige release van Hardwell.",
+      "alt_artists": [
+        "Calvin Harris, Ellie Goulding",
+        "Marc Benjamin, Marcus Santoro, David Pietras",
+        "Purple Disco Machine, Moss Kena, The Knocks"
+      ]
+    },
+    {
+      "artist": "John Summit, Inéz",
+      "title": "light years (feat. Inéz)",
+      "year": 2025,
+      "isrc": "USUG12404422",
+      "uri": "spotify:track:2wRKES8HKm4EutRHz7JD1x",
+      "uri_apple_music": "applemusic://track/1803490125",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1803490125"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3288051331",
+      "fun_fact": "“light years (feat. Inéz)” appears on John Summit’s release “light years”.",
+      "fun_fact_de": "„light years (feat. Inéz)“ erschien auf der Veröffentlichung „light years“ von John Summit.",
+      "fun_fact_es": "«light years (feat. Inéz)» aparece en el lanzamiento «light years» de John Summit.",
+      "fun_fact_fr": "« light years (feat. Inéz) » figure sur la publication « light years » de John Summit.",
+      "fun_fact_nl": "‘light years (feat. Inéz)’ staat op de release ‘light years’ van John Summit.",
+      "alt_artists": [
+        "HAVEN., Kaitlin Aragon",
+        "deadmau5",
+        "Jax Jones, Martin Solveig, Madison Beer, Europa"
+      ]
+    },
+    {
+      "artist": "Amelie Lens",
+      "title": "Feel It",
+      "year": 2023,
+      "isrc": "BEN582300365",
+      "uri": "spotify:track:46X06WrqGsHB4H3lcUVXx6",
+      "uri_apple_music": "applemusic://track/1833479161",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1833479161"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3510119541",
+      "fun_fact": "“Feel It” appears on Amelie Lens’s release “Radiance”.",
+      "fun_fact_de": "„Feel It“ erschien auf der Veröffentlichung „Radiance“ von Amelie Lens.",
+      "fun_fact_es": "«Feel It» aparece en el lanzamiento «Radiance» de Amelie Lens.",
+      "fun_fact_fr": "« Feel It » figure sur la publication « Radiance » de Amelie Lens.",
+      "fun_fact_nl": "‘Feel It’ staat op de release ‘Radiance’ van Amelie Lens.",
+      "alt_artists": [
+        "Calvin Harris, Example",
+        "Eric Prydz, Empire Of The Sun",
+        "Southside Spinners"
+      ]
+    },
+    {
+      "artist": "Maverick Sabre, Jorja Smith, Vintage Culture, Slow Motion",
+      "title": "Slow Down (feat. Jorja Smith) - Vintage Culture & Slow Motion Remix",
+      "year": 2020,
+      "isrc": "NLZ542000356",
+      "uri": "spotify:track:5PNvgiKSwMdjBsDsgFCFLX",
+      "uri_apple_music": "applemusic://track/1501718057",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1501718057"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/917700862",
+      "fun_fact": "“Slow Down (feat. Jorja Smith) - Vintage Culture & Slow Motion Remix” is the title track of Maverick Sabre’s release of the same name.",
+      "fun_fact_de": "„Slow Down (feat. Jorja Smith) - Vintage Culture & Slow Motion Remix“ ist der Titelsong der gleichnamigen Veröffentlichung von Maverick Sabre.",
+      "fun_fact_es": "«Slow Down (feat. Jorja Smith) - Vintage Culture & Slow Motion Remix» es la canción que da título al lanzamiento homónimo de Maverick Sabre.",
+      "fun_fact_fr": "« Slow Down (feat. Jorja Smith) - Vintage Culture & Slow Motion Remix » est le morceau-titre de la publication éponyme de Maverick Sabre.",
+      "fun_fact_nl": "‘Slow Down (feat. Jorja Smith) - Vintage Culture & Slow Motion Remix’ is het titelnummer van de gelijknamige release van Maverick Sabre.",
+      "alt_artists": [
+        "Fred again.., Obongjayar",
+        "Armin van Buuren, Sunnery James & Ryan Marciano",
+        "Yves V, Matthew Hill, Adrian Lux"
+      ]
+    },
+    {
+      "artist": "Steve Aoki, Wynter Gordon",
+      "title": "Ladi Dadi (feat. Wynter Gordon) - Tommy Trash Remix",
+      "year": 2012,
+      "isrc": "USUS11100812",
+      "uri": "spotify:track:6H4G4c6FfWED02TqsFDPtC",
+      "uri_apple_music": "applemusic://track/1711788460",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1711788460"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/69183334",
+      "fun_fact": "“Ladi Dadi (feat. Wynter Gordon) - Tommy Trash Remix” appears on Steve Aoki’s release “Ladi Dadi (feat. Wynter Gordon)”.",
+      "fun_fact_de": "„Ladi Dadi (feat. Wynter Gordon) - Tommy Trash Remix“ erschien auf der Veröffentlichung „Ladi Dadi (feat. Wynter Gordon)“ von Steve Aoki.",
+      "fun_fact_es": "«Ladi Dadi (feat. Wynter Gordon) - Tommy Trash Remix» aparece en el lanzamiento «Ladi Dadi (feat. Wynter Gordon)» de Steve Aoki.",
+      "fun_fact_fr": "« Ladi Dadi (feat. Wynter Gordon) - Tommy Trash Remix » figure sur la publication « Ladi Dadi (feat. Wynter Gordon) » de Steve Aoki.",
+      "fun_fact_nl": "‘Ladi Dadi (feat. Wynter Gordon) - Tommy Trash Remix’ staat op de release ‘Ladi Dadi (feat. Wynter Gordon)’ van Steve Aoki.",
+      "alt_artists": [
+        "Miss Monique",
+        "AN21, Max Vangeli, Julie McKnight",
+        "Vintage Culture, Fancy Inc, The Beach"
+      ]
+    },
+    {
+      "artist": "Push",
+      "title": "Strange World",
+      "year": 2001,
+      "isrc": "NLF711501671",
+      "uri": "spotify:track:7uIU44vMKlPVIh4Xm6Cgzh",
+      "uri_apple_music": "applemusic://track/292412010",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/292412010"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/97361580",
+      "fun_fact": "“Strange World” appears on Push’s release “Trance Top 1000 - Selection 003”.",
+      "fun_fact_de": "„Strange World“ erschien auf der Veröffentlichung „Trance Top 1000 - Selection 003“ von Push.",
+      "fun_fact_es": "«Strange World» aparece en el lanzamiento «Trance Top 1000 - Selection 003» de Push.",
+      "fun_fact_fr": "« Strange World » figure sur la publication « Trance Top 1000 - Selection 003 » de Push.",
+      "fun_fact_nl": "‘Strange World’ staat op de release ‘Trance Top 1000 - Selection 003’ van Push.",
+      "alt_artists": [
+        "Parachute Youth",
+        "Tiësto, Mathame",
+        "Jones & Stephenson"
+      ]
+    },
+    {
+      "artist": "SOFI TUKKER, John Summit, Vintage Culture",
+      "title": "Drinkee - Vintage Culture & John Summit Remix",
+      "year": 2021,
+      "isrc": "QM37X2100001",
+      "uri": "spotify:track:5XXdHWkkprtfG8DxBARihy",
+      "uri_apple_music": "applemusic://track/1762724674",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1762724674"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2496486291",
+      "fun_fact": "“Drinkee - Vintage Culture & John Summit Remix” is the title track of SOFI TUKKER’s release of the same name.",
+      "fun_fact_de": "„Drinkee - Vintage Culture & John Summit Remix“ ist der Titelsong der gleichnamigen Veröffentlichung von SOFI TUKKER.",
+      "fun_fact_es": "«Drinkee - Vintage Culture & John Summit Remix» es la canción que da título al lanzamiento homónimo de SOFI TUKKER.",
+      "fun_fact_fr": "« Drinkee - Vintage Culture & John Summit Remix » est le morceau-titre de la publication éponyme de SOFI TUKKER.",
+      "fun_fact_nl": "‘Drinkee - Vintage Culture & John Summit Remix’ is het titelnummer van de gelijknamige release van SOFI TUKKER.",
+      "alt_artists": [
+        "Martin Solveig, Good Times Ahead",
+        "Young Marco",
+        "Coldplay, Swedish House Mafia"
+      ]
+    },
+    {
+      "artist": "Martin Garrix, Tiësto",
+      "title": "The Only Way Is Up",
+      "year": 2015,
+      "isrc": "CYA111500021",
+      "uri": "spotify:track:1V0Zy7533bjXFSVtn3crzY",
+      "uri_apple_music": "applemusic://track/1445046707",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1445046707"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/100334220",
+      "fun_fact": "“The Only Way Is Up” appears on Martin Garrix’s release “Club Life, Vol. 4 - New York City”.",
+      "fun_fact_de": "„The Only Way Is Up“ erschien auf der Veröffentlichung „Club Life, Vol. 4 - New York City“ von Martin Garrix.",
+      "fun_fact_es": "«The Only Way Is Up» aparece en el lanzamiento «Club Life, Vol. 4 - New York City» de Martin Garrix.",
+      "fun_fact_fr": "« The Only Way Is Up » figure sur la publication « Club Life, Vol. 4 - New York City » de Martin Garrix.",
+      "fun_fact_nl": "‘The Only Way Is Up’ staat op de release ‘Club Life, Vol. 4 - New York City’ van Martin Garrix.",
+      "alt_artists": [
+        "Zonderling, Andreas Moss",
+        "Higher Self, Lauren Mason",
+        "Martin Garrix, USHER"
+      ]
+    },
+    {
+      "artist": "Above & Beyond, Zoë Johnston",
+      "title": "No One On Earth - Original Mix",
+      "year": 2004,
+      "isrc": "GBEWA0400020",
+      "uri": "spotify:track:4v4Dt0633CJyKmOrVz8Qb0",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/109922601",
+      "fun_fact": "“No One On Earth - Original Mix” appears on Above & Beyond’s release “No One On Earth”.",
+      "fun_fact_de": "„No One On Earth - Original Mix“ erschien auf der Veröffentlichung „No One On Earth“ von Above & Beyond.",
+      "fun_fact_es": "«No One On Earth - Original Mix» aparece en el lanzamiento «No One On Earth» de Above & Beyond.",
+      "fun_fact_fr": "« No One On Earth - Original Mix » figure sur la publication « No One On Earth » de Above & Beyond.",
+      "fun_fact_nl": "‘No One On Earth - Original Mix’ staat op de release ‘No One On Earth’ van Above & Beyond.",
+      "alt_artists": [
+        "Moby, Steve Angello",
+        "Bob Sinclar, FISHER, Steve Edwards",
+        "Nicky Romero, NERVO"
+      ]
+    },
+    {
+      "artist": "Martin Solveig, Dragonette",
+      "title": "Hello",
+      "year": 2011,
+      "isrc": "ARG991012059",
+      "uri": "spotify:track:2Hy89WQAxszEUQAvpja0nx",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/13214666",
+      "fun_fact": "“Hello” appears on Martin Solveig’s release “Hello (Karaoke)”.",
+      "fun_fact_de": "„Hello“ erschien auf der Veröffentlichung „Hello (Karaoke)“ von Martin Solveig.",
+      "fun_fact_es": "«Hello» aparece en el lanzamiento «Hello (Karaoke)» de Martin Solveig.",
+      "fun_fact_fr": "« Hello » figure sur la publication « Hello (Karaoke) » de Martin Solveig.",
+      "fun_fact_nl": "‘Hello’ staat op de release ‘Hello (Karaoke)’ van Martin Solveig.",
+      "alt_artists": [
+        "Alok, Zeeba, Bruno Martini",
+        "BUNT., Nate Traveller",
+        "Alesso, Katy Perry"
+      ]
+    },
+    {
+      "artist": "Robin Schulz, Francesco Yates, Stadiumx",
+      "title": "Sugar (feat. Francesco Yates) - Stadiumx Remix",
+      "year": 2025,
+      "isrc": "DEA622503558",
+      "uri": "spotify:track:33GH1sHrpx85rk0utdzx04",
+      "uri_apple_music": "applemusic://track/1035668453",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1035668453"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3556945721",
+      "fun_fact": "“Sugar (feat. Francesco Yates) - Stadiumx Remix” appears on Robin Schulz’s release “Sugar (feat. Francesco Yates) (ALOK Remix)”.",
+      "fun_fact_de": "„Sugar (feat. Francesco Yates) - Stadiumx Remix“ erschien auf der Veröffentlichung „Sugar (feat. Francesco Yates) (ALOK Remix)“ von Robin Schulz.",
+      "fun_fact_es": "«Sugar (feat. Francesco Yates) - Stadiumx Remix» aparece en el lanzamiento «Sugar (feat. Francesco Yates) (ALOK Remix)» de Robin Schulz.",
+      "fun_fact_fr": "« Sugar (feat. Francesco Yates) - Stadiumx Remix » figure sur la publication « Sugar (feat. Francesco Yates) (ALOK Remix) » de Robin Schulz.",
+      "fun_fact_nl": "‘Sugar (feat. Francesco Yates) - Stadiumx Remix’ staat op de release ‘Sugar (feat. Francesco Yates) (ALOK Remix)’ van Robin Schulz.",
+      "alt_artists": [
+        "Amber Broos",
+        "Sia, Diplo, Labrinth, LSD, Lost Frequencies",
+        "Avicii, Sebastien Drums"
+      ]
+    },
+    {
+      "artist": "Chris Lorenzo",
+      "title": "Appetite",
+      "year": 2025,
+      "isrc": "QT47L2500018",
+      "uri": "spotify:track:6zldvnVMC25b4uliSKO9Lz",
+      "uri_apple_music": "applemusic://track/1811404734",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1811404734"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3345287311",
+      "fun_fact": "“Appetite” is the title track of Chris Lorenzo’s release of the same name.",
+      "fun_fact_de": "„Appetite“ ist der Titelsong der gleichnamigen Veröffentlichung von Chris Lorenzo.",
+      "fun_fact_es": "«Appetite» es la canción que da título al lanzamiento homónimo de Chris Lorenzo.",
+      "fun_fact_fr": "« Appetite » est le morceau-titre de la publication éponyme de Chris Lorenzo.",
+      "fun_fact_nl": "‘Appetite’ is het titelnummer van de gelijknamige release van Chris Lorenzo.",
+      "alt_artists": [
+        "Bag Raiders",
+        "Blasterjaxx, Timmy Trumpet",
+        "Jay Hardway"
+      ]
+    },
+    {
+      "artist": "Anyma, Argy, Son of Son",
+      "title": "Voices In My Head",
+      "year": 2025,
+      "isrc": "USUG12500914",
+      "uri": "spotify:track:05y9EYjVL7lcxesRLAKkvb",
+      "uri_apple_music": "applemusic://track/1814233144",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1814233144"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3380574911",
+      "fun_fact": "“Voices In My Head” appears on Anyma’s release “The End Of Genesys”.",
+      "fun_fact_de": "„Voices In My Head“ erschien auf der Veröffentlichung „The End Of Genesys“ von Anyma.",
+      "fun_fact_es": "«Voices In My Head» aparece en el lanzamiento «The End Of Genesys» de Anyma.",
+      "fun_fact_fr": "« Voices In My Head » figure sur la publication « The End Of Genesys » de Anyma.",
+      "fun_fact_nl": "‘Voices In My Head’ staat op de release ‘The End Of Genesys’ van Anyma.",
+      "alt_artists": [
+        "La Fuente",
+        "Dimitri Vegas & Like Mike, Regi",
+        "Axwell /\\ Ingrosso, Axwell, Sebastian Ingrosso"
+      ]
+    },
+    {
+      "artist": "Hardwell, KSHMR",
+      "title": "Power",
+      "year": 2017,
+      "isrc": "NLZ541700900",
+      "uri": "spotify:track:4CVOUJki8YUWol3jhLphgs",
+      "uri_apple_music": "applemusic://track/1346880700",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1346880700"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/459990712",
+      "fun_fact": "“Power” is the title track of Hardwell’s release of the same name.",
+      "fun_fact_de": "„Power“ ist der Titelsong der gleichnamigen Veröffentlichung von Hardwell.",
+      "fun_fact_es": "«Power» es la canción que da título al lanzamiento homónimo de Hardwell.",
+      "fun_fact_fr": "« Power » est le morceau-titre de la publication éponyme de Hardwell.",
+      "fun_fact_nl": "‘Power’ is het titelnummer van de gelijknamige release van Hardwell.",
+      "alt_artists": [
+        "MoBlack, Salif Keita, Benja (NL), Franc Fala, Cesária Evora",
+        "CHRIS STASSY, S.A.M.",
+        "AFROJACK"
+      ]
+    },
+    {
+      "artist": "Joel Corry, Da Hool",
+      "title": "The Parade",
+      "year": 2022,
+      "isrc": "DES232200070",
+      "uri": "spotify:track:0B3H6se7MYo3D7BmzfvdVN",
+      "uri_apple_music": "applemusic://track/1606352057",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1606352057"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1629864532",
+      "fun_fact": "“The Parade” is the title track of Joel Corry’s release of the same name.",
+      "fun_fact_de": "„The Parade“ ist der Titelsong der gleichnamigen Veröffentlichung von Joel Corry.",
+      "fun_fact_es": "«The Parade» es la canción que da título al lanzamiento homónimo de Joel Corry.",
+      "fun_fact_fr": "« The Parade » est le morceau-titre de la publication éponyme de Joel Corry.",
+      "fun_fact_nl": "‘The Parade’ is het titelnummer van de gelijknamige release van Joel Corry.",
+      "alt_artists": [
+        "Tinlicker, Helsloot",
+        "Konstantin Sibold, Adam Sellouk",
+        "Tiësto, Dzeko, Preme, Post Malone"
+      ]
+    },
+    {
+      "artist": "Fatboy Slim, CamelPhat",
+      "title": "Right Here, Right Now - CamelPhat Remix",
+      "year": 2018,
+      "isrc": "GBJAJ1801883",
+      "uri": "spotify:track:3SzPA7bBOiaF4mvcujTGvy",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/578921802",
+      "fun_fact": "“Right Here, Right Now - CamelPhat Remix” appears on Fatboy Slim’s release “Best Of Toolroom 2018 (Mixed By Illyus & Barrientos)”.",
+      "fun_fact_de": "„Right Here, Right Now - CamelPhat Remix“ erschien auf der Veröffentlichung „Best Of Toolroom 2018 (Mixed By Illyus & Barrientos)“ von Fatboy Slim.",
+      "fun_fact_es": "«Right Here, Right Now - CamelPhat Remix» aparece en el lanzamiento «Best Of Toolroom 2018 (Mixed By Illyus & Barrientos)» de Fatboy Slim.",
+      "fun_fact_fr": "« Right Here, Right Now - CamelPhat Remix » figure sur la publication « Best Of Toolroom 2018 (Mixed By Illyus & Barrientos) » de Fatboy Slim.",
+      "fun_fact_nl": "‘Right Here, Right Now - CamelPhat Remix’ staat op de release ‘Best Of Toolroom 2018 (Mixed By Illyus & Barrientos)’ van Fatboy Slim.",
+      "alt_artists": [
+        "Diplo, SIDEPIECE",
+        "David Guetta, MORTEN",
+        "PAWSA"
+      ]
+    },
+    {
+      "artist": "Matisse & Sadko",
+      "title": "Saga",
+      "year": 2018,
+      "isrc": "NLM5S1800322",
+      "uri": "spotify:track:4CbUxjNBBkRnoo7MzjUFP9",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/539409732",
+      "fun_fact": "“Saga” is the title track of Matisse & Sadko’s release of the same name.",
+      "fun_fact_de": "„Saga“ ist der Titelsong der gleichnamigen Veröffentlichung von Matisse & Sadko.",
+      "fun_fact_es": "«Saga» es la canción que da título al lanzamiento homónimo de Matisse & Sadko.",
+      "fun_fact_fr": "« Saga » est le morceau-titre de la publication éponyme de Matisse & Sadko.",
+      "fun_fact_nl": "‘Saga’ is het titelnummer van de gelijknamige release van Matisse & Sadko.",
+      "alt_artists": [
+        "Martin Garrix, Macklemore, Fall Out Boy, Tiësto",
+        "HUGEL, Topic, Arash, Daecolm",
+        "Sia, Diplo, Labrinth, LSD, Lost Frequencies"
+      ]
+    },
+    {
+      "artist": "James Hype",
+      "title": "Don't Wake Me Up",
+      "year": 2025,
+      "isrc": "GBUM72500069",
+      "uri": "spotify:track:3sU1L9okYWbN61oHZNQTfh",
+      "uri_apple_music": "applemusic://track/1791736475",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1791736475"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3278141651",
+      "fun_fact": "“Don't Wake Me Up” is the title track of James Hype’s release of the same name.",
+      "fun_fact_de": "„Don't Wake Me Up“ ist der Titelsong der gleichnamigen Veröffentlichung von James Hype.",
+      "fun_fact_es": "«Don't Wake Me Up» es la canción que da título al lanzamiento homónimo de James Hype.",
+      "fun_fact_fr": "« Don't Wake Me Up » est le morceau-titre de la publication éponyme de James Hype.",
+      "fun_fact_nl": "‘Don't Wake Me Up’ is het titelnummer van de gelijknamige release van James Hype.",
+      "alt_artists": [
+        "Calvin Harris, Clementine Douglas",
+        "Avicii, Sandro Cavazza",
+        "Freejak"
+      ]
+    },
+    {
+      "artist": "Swedish House Mafia, Anyma, Future, Fred again..",
+      "title": "Turn On The Lights again.. (feat. Future & Fred again..) - Anyma Remix",
+      "year": 2022,
+      "isrc": "GBAHS2300107",
+      "uri": "spotify:track:4ptnQ0kQnN1U1Ig8TSslj6",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2148297997",
+      "fun_fact": "“Turn On The Lights again.. (feat. Future & Fred again..) - Anyma Remix” appears on Swedish House Mafia’s release “Turn On The Lights again.. (feat. Future & Fred again..) (Remixes)”.",
+      "fun_fact_de": "„Turn On The Lights again.. (feat. Future & Fred again..) - Anyma Remix“ erschien auf der Veröffentlichung „Turn On The Lights again.. (feat. Future & Fred again..) (Remixes)“ von Swedish House Mafia.",
+      "fun_fact_es": "«Turn On The Lights again.. (feat. Future & Fred again..) - Anyma Remix» aparece en el lanzamiento «Turn On The Lights again.. (feat. Future & Fred again..) (Remixes)» de Swedish House Mafia.",
+      "fun_fact_fr": "« Turn On The Lights again.. (feat. Future & Fred again..) - Anyma Remix » figure sur la publication « Turn On The Lights again.. (feat. Future & Fred again..) (Remixes) » de Swedish House Mafia.",
+      "fun_fact_nl": "‘Turn On The Lights again.. (feat. Future & Fred again..) - Anyma Remix’ staat op de release ‘Turn On The Lights again.. (feat. Future & Fred again..) (Remixes)’ van Swedish House Mafia.",
+      "alt_artists": [
+        "ARTBAT, Sailor & I",
+        "Kölsch, Troels Abrahamsen, ARTBAT",
+        "Zerb, Sofiya Nzau"
+      ]
+    },
+    {
+      "artist": "Martin Garrix, Alesso, Shaun Farrugia",
+      "title": "Inside Our Hearts",
+      "year": 2025,
+      "isrc": "NLM5S2502615",
+      "uri": "spotify:track:7JxHc4FNqdIzIJyrpqYAdH",
+      "uri_apple_music": "applemusic://track/1826822532",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1826822532"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3460671751",
+      "fun_fact": "“Inside Our Hearts” is the title track of Martin Garrix’s release of the same name.",
+      "fun_fact_de": "„Inside Our Hearts“ ist der Titelsong der gleichnamigen Veröffentlichung von Martin Garrix.",
+      "fun_fact_es": "«Inside Our Hearts» es la canción que da título al lanzamiento homónimo de Martin Garrix.",
+      "fun_fact_fr": "« Inside Our Hearts » est le morceau-titre de la publication éponyme de Martin Garrix.",
+      "fun_fact_nl": "‘Inside Our Hearts’ is het titelnummer van de gelijknamige release van Martin Garrix.",
+      "alt_artists": [
+        "Young Marco",
+        "KSHMR, Mike Waters",
+        "Mason"
+      ]
+    },
+    {
+      "artist": "MEDUZA, James Carter, Elley Duhé, FAST BOY",
+      "title": "Bad Memories",
+      "year": 2022,
+      "isrc": "GBUM72203666",
+      "uri": "spotify:track:5Na0wKS46WV0pOhXzmQ0vz",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1826426337",
+      "fun_fact": "“Bad Memories” is the title track of MEDUZA’s release of the same name.",
+      "fun_fact_de": "„Bad Memories“ ist der Titelsong der gleichnamigen Veröffentlichung von MEDUZA.",
+      "fun_fact_es": "«Bad Memories» es la canción que da título al lanzamiento homónimo de MEDUZA.",
+      "fun_fact_fr": "« Bad Memories » est le morceau-titre de la publication éponyme de MEDUZA.",
+      "fun_fact_nl": "‘Bad Memories’ is het titelnummer van de gelijknamige release van MEDUZA.",
+      "alt_artists": [
+        "Kaskade, deadmau5",
+        "AFROJACK, NERVO, Dimitri Vegas & Like Mike",
+        "Stromae, Paul Kalkbrenner"
+      ]
+    },
+    {
+      "artist": "NERVO",
+      "title": "You're Gonna Love Again",
+      "year": 2012,
+      "isrc": "USCN31200018",
+      "uri": "spotify:track:5ope2MtxN8VUaghZOkoZwk",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/924642512",
+      "fun_fact": "“You're Gonna Love Again” appears on NERVO’s release “House Party”.",
+      "fun_fact_de": "„You're Gonna Love Again“ erschien auf der Veröffentlichung „House Party“ von NERVO.",
+      "fun_fact_es": "«You're Gonna Love Again» aparece en el lanzamiento «House Party» de NERVO.",
+      "fun_fact_fr": "« You're Gonna Love Again » figure sur la publication « House Party » de NERVO.",
+      "fun_fact_nl": "‘You're Gonna Love Again’ staat op de release ‘House Party’ van NERVO.",
+      "alt_artists": [
+        "Gregor Salto, Florian T",
+        "RAFFA GUIDO",
+        "Galantis"
+      ]
+    },
+    {
+      "artist": "Tiësto, Deorro",
+      "title": "Savage",
+      "year": 2022,
+      "isrc": "NLZ542200513",
+      "uri": "spotify:track:76A1RRDEyHKtmV3Vh6PeVN",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1720194137",
+      "fun_fact": "“Savage” is the title track of Tiësto’s release of the same name.",
+      "fun_fact_de": "„Savage“ ist der Titelsong der gleichnamigen Veröffentlichung von Tiësto.",
+      "fun_fact_es": "«Savage» es la canción que da título al lanzamiento homónimo de Tiësto.",
+      "fun_fact_fr": "« Savage » est le morceau-titre de la publication éponyme de Tiësto.",
+      "fun_fact_nl": "‘Savage’ is het titelnummer van de gelijknamige release van Tiësto.",
+      "alt_artists": [
+        "Vintage Culture, Fancy Inc",
+        "Amine Edge & DANCE, Blaze (Kevin Hedge)",
+        "Martin Garrix, Khalid, DubVision"
+      ]
+    },
+    {
+      "artist": "Kaskade, deadmau5",
+      "title": "Move For Me - Radio Edit",
+      "year": 2008,
+      "isrc": "USUS10800150",
+      "uri": "spotify:track:5HNZPGZFyGG4za71FVLkCC",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/69184803",
+      "fun_fact": "“Move For Me - Radio Edit” appears on Kaskade’s release “Ultra Music Festival 2008”.",
+      "fun_fact_de": "„Move For Me - Radio Edit“ erschien auf der Veröffentlichung „Ultra Music Festival 2008“ von Kaskade.",
+      "fun_fact_es": "«Move For Me - Radio Edit» aparece en el lanzamiento «Ultra Music Festival 2008» de Kaskade.",
+      "fun_fact_fr": "« Move For Me - Radio Edit » figure sur la publication « Ultra Music Festival 2008 » de Kaskade.",
+      "fun_fact_nl": "‘Move For Me - Radio Edit’ staat op de release ‘Ultra Music Festival 2008’ van Kaskade.",
+      "alt_artists": [
+        "Cassius",
+        "Florence + The Machine, Swedish House Mafia, Mark Knight",
+        "Hardwell"
+      ]
+    },
+    {
+      "artist": "Avicii",
+      "title": "Addicted To You",
+      "year": 2013,
+      "isrc": "CH3131340085",
+      "uri": "spotify:track:4eDYMhIin1pSLIG96f1aD0",
+      "uri_apple_music": "applemusic://track/1440873120",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1440873120"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/70266759",
+      "fun_fact": "“Addicted To You” appears on Avicii’s release “True”.",
+      "fun_fact_de": "„Addicted To You“ erschien auf der Veröffentlichung „True“ von Avicii.",
+      "fun_fact_es": "«Addicted To You» aparece en el lanzamiento «True» de Avicii.",
+      "fun_fact_fr": "« Addicted To You » figure sur la publication « True » de Avicii.",
+      "fun_fact_nl": "‘Addicted To You’ staat op de release ‘True’ van Avicii.",
+      "alt_artists": [
+        "Eric Prydz",
+        "MEDUZA, Becky Hill, Goodboys",
+        "CamelPhat, Elderbrook"
+      ]
+    },
+    {
+      "artist": "Jauz",
+      "title": "Feel The Volume",
+      "year": 2014,
+      "isrc": "USZ4V1400159",
+      "uri": "spotify:track:03IxJiB8ZOH9hEQZF5mCNY",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/90262929",
+      "fun_fact": "“Feel The Volume” is the title track of Jauz’s release of the same name.",
+      "fun_fact_de": "„Feel The Volume“ ist der Titelsong der gleichnamigen Veröffentlichung von Jauz.",
+      "fun_fact_es": "«Feel The Volume» es la canción que da título al lanzamiento homónimo de Jauz.",
+      "fun_fact_fr": "« Feel The Volume » est le morceau-titre de la publication éponyme de Jauz.",
+      "fun_fact_nl": "‘Feel The Volume’ is het titelnummer van de gelijknamige release van Jauz.",
+      "alt_artists": [
+        "Round Table Knights, Bauchamp",
+        "Benny Benassi, Gary Go",
+        "Double 99"
+      ]
+    },
+    {
+      "artist": "Vintage Culture, Goodboys",
+      "title": "This Feeling",
+      "year": 2022,
+      "isrc": "CA5KR2227116",
+      "uri": "spotify:track:79SrdoXn93tgSzksq73X2y",
+      "uri_apple_music": "applemusic://track/1658872584",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1658872584"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2060732447",
+      "fun_fact": "“This Feeling” appears on Vintage Culture’s release “This Feeling (Remixes)”.",
+      "fun_fact_de": "„This Feeling“ erschien auf der Veröffentlichung „This Feeling (Remixes)“ von Vintage Culture.",
+      "fun_fact_es": "«This Feeling» aparece en el lanzamiento «This Feeling (Remixes)» de Vintage Culture.",
+      "fun_fact_fr": "« This Feeling » figure sur la publication « This Feeling (Remixes) » de Vintage Culture.",
+      "fun_fact_nl": "‘This Feeling’ staat op de release ‘This Feeling (Remixes)’ van Vintage Culture.",
+      "alt_artists": [
+        "Creeds",
+        "Mark Knight",
+        "John Dahlbäck"
+      ]
+    },
+    {
+      "artist": "Storm",
+      "title": "Time To Burn",
+      "year": 2010,
+      "isrc": "DEMW61000110",
+      "uri": "spotify:track:7m3voFyQJ9lhOTAB5JIBAW",
+      "uri_apple_music": "applemusic://track/394874874",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/394874874"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/7395324",
+      "fun_fact": "“Time To Burn” appears on Storm’s release “Stormjunkie”.",
+      "fun_fact_de": "„Time To Burn“ erschien auf der Veröffentlichung „Stormjunkie“ von Storm.",
+      "fun_fact_es": "«Time To Burn» aparece en el lanzamiento «Stormjunkie» de Storm.",
+      "fun_fact_fr": "« Time To Burn » figure sur la publication « Stormjunkie » de Storm.",
+      "fun_fact_nl": "‘Time To Burn’ staat op de release ‘Stormjunkie’ van Storm.",
+      "alt_artists": [
+        "ILLENIUM, Valerie Broussard, NURKO",
+        "Age Of Love",
+        "Becky Hill, Galantis"
+      ]
+    },
+    {
+      "artist": "Don Diablo",
+      "title": "Cutting Shapes",
+      "year": 2016,
+      "isrc": "NLZ541601041",
+      "uri": "spotify:track:3hENlPbIlUZXQ3MiosF87Q",
+      "uri_apple_music": "applemusic://track/1337751485",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1337751485"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/452768722",
+      "fun_fact": "“Cutting Shapes” is the title track of Don Diablo’s release of the same name.",
+      "fun_fact_de": "„Cutting Shapes“ ist der Titelsong der gleichnamigen Veröffentlichung von Don Diablo.",
+      "fun_fact_es": "«Cutting Shapes» es la canción que da título al lanzamiento homónimo de Don Diablo.",
+      "fun_fact_fr": "« Cutting Shapes » est le morceau-titre de la publication éponyme de Don Diablo.",
+      "fun_fact_nl": "‘Cutting Shapes’ is het titelnummer van de gelijknamige release van Don Diablo.",
+      "alt_artists": [
+        "Öwnboss, Sevek",
+        "Mike Williams, Robin Valo",
+        "Breach"
+      ]
+    },
+    {
+      "artist": "Dj Bountyhunter",
+      "title": "Woops",
+      "year": 1993,
+      "isrc": "BEZ451200625",
+      "uri": "spotify:track:2XeqqfeJgtG3mQI5xNeNTy",
+      "uri_apple_music": "applemusic://track/1771820847",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1771820847"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3030924981",
+      "fun_fact": "“Woops” is the title track of Dj Bountyhunter’s release of the same name.",
+      "fun_fact_de": "„Woops“ ist der Titelsong der gleichnamigen Veröffentlichung von Dj Bountyhunter.",
+      "fun_fact_es": "«Woops» es la canción que da título al lanzamiento homónimo de Dj Bountyhunter.",
+      "fun_fact_fr": "« Woops » est le morceau-titre de la publication éponyme de Dj Bountyhunter.",
+      "fun_fact_nl": "‘Woops’ is het titelnummer van de gelijknamige release van Dj Bountyhunter.",
+      "alt_artists": [
+        "MOGUAI, Cheat Codes",
+        "SOFI TUKKER, Öwnboss, Fancy Inc",
+        "KI/KI, Marlon Hoffstadt"
+      ]
+    },
+    {
+      "artist": "PAWSA, The Adventures Of Stevie V",
+      "title": "Dirty Cash (Money Talks)",
+      "year": 2024,
+      "isrc": "NLML62400170",
+      "uri": "spotify:track:2VyvDGdcVY04cNYou9MFVX",
+      "uri_apple_music": "applemusic://track/1778288336",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1778288336"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3076269681",
+      "fun_fact": "“Dirty Cash (Money Talks)” is the title track of PAWSA’s release of the same name.",
+      "fun_fact_de": "„Dirty Cash (Money Talks)“ ist der Titelsong der gleichnamigen Veröffentlichung von PAWSA.",
+      "fun_fact_es": "«Dirty Cash (Money Talks)» es la canción que da título al lanzamiento homónimo de PAWSA.",
+      "fun_fact_fr": "« Dirty Cash (Money Talks) » est le morceau-titre de la publication éponyme de PAWSA.",
+      "fun_fact_nl": "‘Dirty Cash (Money Talks)’ is het titelnummer van de gelijknamige release van PAWSA.",
+      "alt_artists": [
+        "ACRAZE, Cherish",
+        "Above & Beyond",
+        "Martin Garrix, Bonn"
+      ]
+    },
+    {
+      "artist": "Dirty South, Rudy",
+      "title": "Phazing - [Tomorrowland 2019 Streaming Mix]",
+      "year": 2011,
+      "isrc": "GBCPZ1004288",
+      "uri": "spotify:track:0e2wt90jnekKbozAxV5LIX",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/104104834",
+      "fun_fact": "“Phazing - [Tomorrowland 2019 Streaming Mix]” appears on Dirty South’s release “In Bed With Space - Ibiza Club Sounds, Vol. 14 (Compiled By Dabruck & Klein and Kid Chris)”.",
+      "fun_fact_de": "„Phazing - [Tomorrowland 2019 Streaming Mix]“ erschien auf der Veröffentlichung „In Bed With Space - Ibiza Club Sounds, Vol. 14 (Compiled By Dabruck & Klein and Kid Chris)“ von Dirty South.",
+      "fun_fact_es": "«Phazing - [Tomorrowland 2019 Streaming Mix]» aparece en el lanzamiento «In Bed With Space - Ibiza Club Sounds, Vol. 14 (Compiled By Dabruck & Klein and Kid Chris)» de Dirty South.",
+      "fun_fact_fr": "« Phazing - [Tomorrowland 2019 Streaming Mix] » figure sur la publication « In Bed With Space - Ibiza Club Sounds, Vol. 14 (Compiled By Dabruck & Klein and Kid Chris) » de Dirty South.",
+      "fun_fact_nl": "‘Phazing - [Tomorrowland 2019 Streaming Mix]’ staat op de release ‘In Bed With Space - Ibiza Club Sounds, Vol. 14 (Compiled By Dabruck & Klein and Kid Chris)’ van Dirty South.",
+      "alt_artists": [
+        "PAWSA, The Adventures Of Stevie V",
+        "deadmau5",
+        "Rebūke, Storm, Jam El Mar"
+      ]
+    },
+    {
+      "artist": "Martin Garrix, Matisse & Sadko, John Martin",
+      "title": "Won’t Let You Go",
+      "year": 2021,
+      "isrc": "NLM5S2101507",
+      "uri": "spotify:track:5UZA39t4lX42ApegVubl7f",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1558078362",
+      "fun_fact": "“Won’t Let You Go” is the title track of Martin Garrix’s release of the same name.",
+      "fun_fact_de": "„Won’t Let You Go“ ist der Titelsong der gleichnamigen Veröffentlichung von Martin Garrix.",
+      "fun_fact_es": "«Won’t Let You Go» es la canción que da título al lanzamiento homónimo de Martin Garrix.",
+      "fun_fact_fr": "« Won’t Let You Go » est le morceau-titre de la publication éponyme de Martin Garrix.",
+      "fun_fact_nl": "‘Won’t Let You Go’ is het titelnummer van de gelijknamige release van Martin Garrix.",
+      "alt_artists": [
+        "Oden & Fatzo",
+        "Lifelike, Kris Menace",
+        "San Holo"
+      ]
+    },
+    {
+      "artist": "Dom Dolla, Clementine Douglas",
+      "title": "Miracle Maker",
+      "year": 2022,
+      "isrc": "USQX92201881",
+      "uri": "spotify:track:6txvQu0zUbiqG24A8XMLnK",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1793904837",
+      "fun_fact": "“Miracle Maker” is the title track of Dom Dolla’s release of the same name.",
+      "fun_fact_de": "„Miracle Maker“ ist der Titelsong der gleichnamigen Veröffentlichung von Dom Dolla.",
+      "fun_fact_es": "«Miracle Maker» es la canción que da título al lanzamiento homónimo de Dom Dolla.",
+      "fun_fact_fr": "« Miracle Maker » est le morceau-titre de la publication éponyme de Dom Dolla.",
+      "fun_fact_nl": "‘Miracle Maker’ is het titelnummer van de gelijknamige release van Dom Dolla.",
+      "alt_artists": [
+        "Joel Corry, James Hype",
+        "Dimension",
+        "John Summit"
+      ]
+    },
+    {
+      "artist": "Steve Angello",
+      "title": "Knas",
+      "year": 2010,
+      "isrc": "GBXGT1000095",
+      "uri": "spotify:track:6Wqk68h7bjH0ZAsmwaQIWo",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/86001351",
+      "fun_fact": "“Knas” is the title track of Steve Angello’s release of the same name.",
+      "fun_fact_de": "„Knas“ ist der Titelsong der gleichnamigen Veröffentlichung von Steve Angello.",
+      "fun_fact_es": "«Knas» es la canción que da título al lanzamiento homónimo de Steve Angello.",
+      "fun_fact_fr": "« Knas » est le morceau-titre de la publication éponyme de Steve Angello.",
+      "fun_fact_nl": "‘Knas’ is het titelnummer van de gelijknamige release van Steve Angello.",
+      "alt_artists": [
+        "Boris Brejcha, Laura Korinth",
+        "Alan Fitzpatrick",
+        "Dizzee Rascal"
+      ]
+    },
+    {
+      "artist": "Swedish House Mafia",
+      "title": "Ray Of Solar",
+      "year": 2023,
+      "isrc": "USUG12306525",
+      "uri": "spotify:track:5Y2n6pW4Vqr4Mzkd9V4Uk8",
+      "uri_apple_music": "applemusic://track/1699495047",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1699495047"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2386559845",
+      "fun_fact": "“Ray Of Solar” is the title track of Swedish House Mafia’s release of the same name.",
+      "fun_fact_de": "„Ray Of Solar“ ist der Titelsong der gleichnamigen Veröffentlichung von Swedish House Mafia.",
+      "fun_fact_es": "«Ray Of Solar» es la canción que da título al lanzamiento homónimo de Swedish House Mafia.",
+      "fun_fact_fr": "« Ray Of Solar » est le morceau-titre de la publication éponyme de Swedish House Mafia.",
+      "fun_fact_nl": "‘Ray Of Solar’ is het titelnummer van de gelijknamige release van Swedish House Mafia.",
+      "alt_artists": [
+        "Purple Disco Machine, Sophie and the Giants",
+        "Shakedown, Anyma, Layton Giordani",
+        "CamelPhat, ARTBAT, RHODES"
+      ]
+    },
+    {
+      "artist": "Vintage Culture, Fancy Inc",
+      "title": "In The Dark",
+      "year": 2019,
+      "isrc": "NLZ541901628",
+      "uri": "spotify:track:3K16ZsnNjOTY1Esnrx0rQg",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/781731362",
+      "fun_fact": "“In The Dark” is the title track of Vintage Culture’s release of the same name.",
+      "fun_fact_de": "„In The Dark“ ist der Titelsong der gleichnamigen Veröffentlichung von Vintage Culture.",
+      "fun_fact_es": "«In The Dark» es la canción que da título al lanzamiento homónimo de Vintage Culture.",
+      "fun_fact_fr": "« In The Dark » est le morceau-titre de la publication éponyme de Vintage Culture.",
+      "fun_fact_nl": "‘In The Dark’ is het titelnummer van de gelijknamige release van Vintage Culture.",
+      "alt_artists": [
+        "Vintage Culture, Goodboys",
+        "Maverick Sabre, Jorja Smith, Vintage Culture, Slow Motion",
+        "Tiësto, Deorro"
+      ]
+    },
+    {
+      "artist": "Cirez D",
+      "title": "On Off",
+      "year": 2009,
+      "isrc": "GB6CP0900022",
+      "uri": "spotify:track:4scUsV40AYlpiXCb4s7UnN",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1055126352",
+      "fun_fact": "“On Off” appears on Cirez D’s release “On Off / Fast Forward”.",
+      "fun_fact_de": "„On Off“ erschien auf der Veröffentlichung „On Off / Fast Forward“ von Cirez D.",
+      "fun_fact_es": "«On Off» aparece en el lanzamiento «On Off / Fast Forward» de Cirez D.",
+      "fun_fact_fr": "« On Off » figure sur la publication « On Off / Fast Forward » de Cirez D.",
+      "fun_fact_nl": "‘On Off’ staat op de release ‘On Off / Fast Forward’ van Cirez D.",
+      "alt_artists": [
+        "Rebūke, Konstantin Sibold, ZAC, CARMEE",
+        "Soul Central, Danny Krivit",
+        "MK, Chrystal"
+      ]
+    },
+    {
+      "artist": "Deniz Koyu",
+      "title": "Tung!",
+      "year": 2010,
+      "isrc": "NLBV21100013",
+      "uri": "spotify:track:4RIcLrQ7qzUaZuU279xUZK",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2831671892",
+      "fun_fact": "“Tung!” is the title track of Deniz Koyu’s release of the same name.",
+      "fun_fact_de": "„Tung!“ ist der Titelsong der gleichnamigen Veröffentlichung von Deniz Koyu.",
+      "fun_fact_es": "«Tung!» es la canción que da título al lanzamiento homónimo de Deniz Koyu.",
+      "fun_fact_fr": "« Tung! » est le morceau-titre de la publication éponyme de Deniz Koyu.",
+      "fun_fact_nl": "‘Tung!’ is het titelnummer van de gelijknamige release van Deniz Koyu.",
+      "alt_artists": [
+        "Martin Solveig, Ina Wroldsen",
+        "The Chainsmokers, Daya, W&W",
+        "Adriatique, WhoMadeWho"
+      ]
+    },
+    {
+      "artist": "Duke Dumont, Jax Jones",
+      "title": "I Got U",
+      "year": 2014,
+      "isrc": "GBUM71308955",
+      "uri": "spotify:track:023H4I7HJnxRqsc9cqeFKV",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/74085452",
+      "fun_fact": "“I Got U” is the title track of Duke Dumont’s release of the same name.",
+      "fun_fact_de": "„I Got U“ ist der Titelsong der gleichnamigen Veröffentlichung von Duke Dumont.",
+      "fun_fact_es": "«I Got U» es la canción que da título al lanzamiento homónimo de Duke Dumont.",
+      "fun_fact_fr": "« I Got U » est le morceau-titre de la publication éponyme de Duke Dumont.",
+      "fun_fact_nl": "‘I Got U’ is het titelnummer van de gelijknamige release van Duke Dumont.",
+      "alt_artists": [
+        "Above & Beyond, anamē, Marty Longstaff",
+        "Black Coffee, David Guetta, Delilah Montagu",
+        "Justice, Soulwax"
+      ]
+    },
+    {
+      "artist": "Tiësto, R3HAB",
+      "title": "Run Free (Countdown)",
+      "year": 2023,
+      "isrc": "NLZ542301705",
+      "uri": "spotify:track:4KB66xUZWvRDej628vf2J8",
+      "uri_apple_music": "applemusic://track/1712923020",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1712923020"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2507935731",
+      "fun_fact": "“Run Free (Countdown)” is the title track of Tiësto’s release of the same name.",
+      "fun_fact_de": "„Run Free (Countdown)“ ist der Titelsong der gleichnamigen Veröffentlichung von Tiësto.",
+      "fun_fact_es": "«Run Free (Countdown)» es la canción que da título al lanzamiento homónimo de Tiësto.",
+      "fun_fact_fr": "« Run Free (Countdown) » est le morceau-titre de la publication éponyme de Tiësto.",
+      "fun_fact_nl": "‘Run Free (Countdown)’ is het titelnummer van de gelijknamige release van Tiësto.",
+      "alt_artists": [
+        "Armin van Buuren",
+        "Dom Dolla, Daya",
+        "David Guetta, MORTEN, RAYE"
+      ]
+    },
+    {
+      "artist": "FÄIS, AFROJACK, Matisse & Sadko",
+      "title": "Hey - Matisse & Sadko Remix",
+      "year": 2016,
+      "isrc": "CYA221600029",
+      "uri": "spotify:track:7uy7DFEulOcaO7w3fiOZxK",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/128099021",
+      "fun_fact": "“Hey - Matisse & Sadko Remix” appears on FÄIS’s release “Hey (Remixes)”.",
+      "fun_fact_de": "„Hey - Matisse & Sadko Remix“ erschien auf der Veröffentlichung „Hey (Remixes)“ von FÄIS.",
+      "fun_fact_es": "«Hey - Matisse & Sadko Remix» aparece en el lanzamiento «Hey (Remixes)» de FÄIS.",
+      "fun_fact_fr": "« Hey - Matisse & Sadko Remix » figure sur la publication « Hey (Remixes) » de FÄIS.",
+      "fun_fact_nl": "‘Hey - Matisse & Sadko Remix’ staat op de release ‘Hey (Remixes)’ van FÄIS.",
+      "alt_artists": [
+        "R3HAB, Deorro",
+        "Jones & Stephenson",
+        "Double 99"
+      ]
+    },
+    {
+      "artist": "Anyma",
+      "title": "Pictures Of You",
+      "year": 2024,
+      "isrc": "USUG12400708",
+      "uri": "spotify:track:0QQBgAXdLm0hfk9aBJe97f",
+      "uri_apple_music": "applemusic://track/1727256702",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1727256702"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2722493472",
+      "fun_fact": "“Pictures Of You” appears on Anyma’s release “Genesys II”.",
+      "fun_fact_de": "„Pictures Of You“ erschien auf der Veröffentlichung „Genesys II“ von Anyma.",
+      "fun_fact_es": "«Pictures Of You» aparece en el lanzamiento «Genesys II» de Anyma.",
+      "fun_fact_fr": "« Pictures Of You » figure sur la publication « Genesys II » de Anyma.",
+      "fun_fact_nl": "‘Pictures Of You’ staat op de release ‘Genesys II’ van Anyma.",
+      "alt_artists": [
+        "Tiësto, 433",
+        "Solardo, Eli Brown",
+        "Soul Central, Danny Krivit"
+      ]
+    },
+    {
+      "artist": "Michael Calfan",
+      "title": "Treasured Soul - Original Mix",
+      "year": 2014,
+      "isrc": "NLZ541400816",
+      "uri": "spotify:track:6NCqGm4FydIHey3CMa7obx",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3149222951",
+      "fun_fact": "“Treasured Soul - Original Mix” appears on Michael Calfan’s release “Treasured Soul (Club Collection)”.",
+      "fun_fact_de": "„Treasured Soul - Original Mix“ erschien auf der Veröffentlichung „Treasured Soul (Club Collection)“ von Michael Calfan.",
+      "fun_fact_es": "«Treasured Soul - Original Mix» aparece en el lanzamiento «Treasured Soul (Club Collection)» de Michael Calfan.",
+      "fun_fact_fr": "« Treasured Soul - Original Mix » figure sur la publication « Treasured Soul (Club Collection) » de Michael Calfan.",
+      "fun_fact_nl": "‘Treasured Soul - Original Mix’ staat op de release ‘Treasured Soul (Club Collection)’ van Michael Calfan.",
+      "alt_artists": [
+        "Alesso, Katy Perry",
+        "ARTBAT, Pete Tong",
+        "Rune RK, Firebeatz"
+      ]
+    },
+    {
+      "artist": "Sonny Fodera, Jazzy, D.O.D",
+      "title": "Somedays",
+      "year": 2024,
+      "isrc": "US38Y2414974",
+      "uri": "spotify:track:3wo3d0I5H8KjkwGvnz8WbB",
+      "uri_apple_music": "applemusic://track/1753774219",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1753774219"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2862271732",
+      "fun_fact": "“Somedays” is the title track of Sonny Fodera’s release of the same name.",
+      "fun_fact_de": "„Somedays“ ist der Titelsong der gleichnamigen Veröffentlichung von Sonny Fodera.",
+      "fun_fact_es": "«Somedays» es la canción que da título al lanzamiento homónimo de Sonny Fodera.",
+      "fun_fact_fr": "« Somedays » est le morceau-titre de la publication éponyme de Sonny Fodera.",
+      "fun_fact_nl": "‘Somedays’ is het titelnummer van de gelijknamige release van Sonny Fodera.",
+      "alt_artists": [
+        "Showtek, Justin Prime",
+        "Purple Disco Machine, Moss Kena, The Knocks",
+        "Rui Da Silva, Cassandra"
+      ]
+    },
+    {
+      "artist": "Axwell /\\ Ingrosso, Axwell, Sebastian Ingrosso",
+      "title": "Something New",
+      "year": 2014,
+      "isrc": "USUG11401855",
+      "uri": "spotify:track:5C4NMi4fPpdFPnMZVsyG8H",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/437979062",
+      "fun_fact": "“Something New” appears on Axwell /\\ Ingrosso’s release “More Than You Know”.",
+      "fun_fact_de": "„Something New“ erschien auf der Veröffentlichung „More Than You Know“ von Axwell /\\ Ingrosso.",
+      "fun_fact_es": "«Something New» aparece en el lanzamiento «More Than You Know» de Axwell /\\ Ingrosso.",
+      "fun_fact_fr": "« Something New » figure sur la publication « More Than You Know » de Axwell /\\ Ingrosso.",
+      "fun_fact_nl": "‘Something New’ staat op de release ‘More Than You Know’ van Axwell /\\ Ingrosso.",
+      "alt_artists": [
+        "Sub Focus, Dimension",
+        "Showtek",
+        "Dom Dolla, Anyma, Daya"
+      ]
+    },
+    {
+      "artist": "Adriatique, WhoMadeWho",
+      "title": "Miracle",
+      "year": 2023,
+      "isrc": "QM24S2305899",
+      "uri": "spotify:track:0aVrpFRLlrd5zVyPXWP3mS",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2401560475",
+      "fun_fact": "“Miracle” is the title track of Adriatique’s release of the same name.",
+      "fun_fact_de": "„Miracle“ ist der Titelsong der gleichnamigen Veröffentlichung von Adriatique.",
+      "fun_fact_es": "«Miracle» es la canción que da título al lanzamiento homónimo de Adriatique.",
+      "fun_fact_fr": "« Miracle » est le morceau-titre de la publication éponyme de Adriatique.",
+      "fun_fact_nl": "‘Miracle’ is het titelnummer van de gelijknamige release van Adriatique.",
+      "alt_artists": [
+        "Steve Aoki, Chris Lake, Tujamo",
+        "Feist, Boys Noize",
+        "BLOND:ISH, Stevie Appleton"
+      ]
+    },
+    {
+      "artist": "Nadia Ali",
+      "title": "Rapture - Avicii New Generation Mix",
+      "year": 2010,
+      "isrc": "CH3131000315",
+      "uri": "spotify:track:2bcYHFk3XWcPnDXYY3tdJX",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/42569851",
+      "fun_fact": "“Rapture - Avicii New Generation Mix” appears on Nadia Ali’s release “Rapture”.",
+      "fun_fact_de": "„Rapture - Avicii New Generation Mix“ erschien auf der Veröffentlichung „Rapture“ von Nadia Ali.",
+      "fun_fact_es": "«Rapture - Avicii New Generation Mix» aparece en el lanzamiento «Rapture» de Nadia Ali.",
+      "fun_fact_fr": "« Rapture - Avicii New Generation Mix » figure sur la publication « Rapture » de Nadia Ali.",
+      "fun_fact_nl": "‘Rapture - Avicii New Generation Mix’ staat op de release ‘Rapture’ van Nadia Ali.",
+      "alt_artists": [
+        "Massano",
+        "Oliver Heldens",
+        "Alan Fitzpatrick"
+      ]
+    },
+    {
+      "artist": "Massano",
+      "title": "The Feeling",
+      "year": 2020,
+      "isrc": "ITH642005105",
+      "uri": "spotify:track:4vJIXqQKOTGpcp5RGOOxPN",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3208041201",
+      "fun_fact": "“The Feeling” is the title track of Massano’s release of the same name.",
+      "fun_fact_de": "„The Feeling“ ist der Titelsong der gleichnamigen Veröffentlichung von Massano.",
+      "fun_fact_es": "«The Feeling» es la canción que da título al lanzamiento homónimo de Massano.",
+      "fun_fact_fr": "« The Feeling » est le morceau-titre de la publication éponyme de Massano.",
+      "fun_fact_nl": "‘The Feeling’ is het titelnummer van de gelijknamige release van Massano.",
+      "alt_artists": [
+        "Jan Blomqvist, Ben Böhmer",
+        "Pendulum, AN21, Max Vangeli, Steve Angello",
+        "Alesso, Sentinel"
+      ]
+    },
+    {
+      "artist": "Martin Solveig, SAM WHITE",
+      "title": "+1 (feat. Sam White) - Radio Edit",
+      "year": 2015,
+      "isrc": "UK98Q1500201",
+      "uri": "spotify:track:1Lt4t4pHow1DGBY6Mtvy5X",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/468391442",
+      "fun_fact": "“+1 (feat. Sam White) - Radio Edit” is the title track of Martin Solveig’s release of the same name.",
+      "fun_fact_de": "„+1 (feat. Sam White) - Radio Edit“ ist der Titelsong der gleichnamigen Veröffentlichung von Martin Solveig.",
+      "fun_fact_es": "«+1 (feat. Sam White) - Radio Edit» es la canción que da título al lanzamiento homónimo de Martin Solveig.",
+      "fun_fact_fr": "« +1 (feat. Sam White) - Radio Edit » est le morceau-titre de la publication éponyme de Martin Solveig.",
+      "fun_fact_nl": "‘+1 (feat. Sam White) - Radio Edit’ is het titelnummer van de gelijknamige release van Martin Solveig.",
+      "alt_artists": [
+        "Nicky Romero, NERVO",
+        "Filterheadz",
+        "Blasterjaxx, Hardwell"
+      ]
+    },
+    {
+      "artist": "Tchami",
+      "title": "Adieu",
+      "year": 2018,
+      "isrc": "USLD91713606",
+      "uri": "spotify:track:53Us5C3wTQ2zi6ODWhmHMN",
+      "uri_apple_music": "applemusic://track/1694793501",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1694793501"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2347020225",
+      "fun_fact": "“Adieu” appears on Tchami’s release “No Redemption”.",
+      "fun_fact_de": "„Adieu“ erschien auf der Veröffentlichung „No Redemption“ von Tchami.",
+      "fun_fact_es": "«Adieu» aparece en el lanzamiento «No Redemption» de Tchami.",
+      "fun_fact_fr": "« Adieu » figure sur la publication « No Redemption » de Tchami.",
+      "fun_fact_nl": "‘Adieu’ staat op de release ‘No Redemption’ van Tchami.",
+      "alt_artists": [
+        "Tiësto, Poppy Baskcomb",
+        "Dom Dolla, Anyma, Daya",
+        "Knife Party"
+      ]
+    },
+    {
+      "artist": "Delerium, Sarah McLachlan, John Summit",
+      "title": "Silence - John Summit Remix",
+      "year": 2025,
+      "isrc": "BE5KW2500717",
+      "uri": "spotify:track:2OP7UAuQF1OJbjeYXa5fhm",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3355164441",
+      "fun_fact": "“Silence - John Summit Remix” is the title track of Delerium’s release of the same name.",
+      "fun_fact_de": "„Silence - John Summit Remix“ ist der Titelsong der gleichnamigen Veröffentlichung von Delerium.",
+      "fun_fact_es": "«Silence - John Summit Remix» es la canción que da título al lanzamiento homónimo de Delerium.",
+      "fun_fact_fr": "« Silence - John Summit Remix » est le morceau-titre de la publication éponyme de Delerium.",
+      "fun_fact_nl": "‘Silence - John Summit Remix’ is het titelnummer van de gelijknamige release van Delerium.",
+      "alt_artists": [
+        "David Guetta, Anne-Marie, Coi Leray",
+        "Disciples",
+        "Avicii"
+      ]
+    },
+    {
+      "artist": "James Hype, Miggy Dela Rosa",
+      "title": "Ferrari",
+      "year": 2022,
+      "isrc": "GB3CE2200004",
+      "uri": "spotify:track:4zN21mbAuaD0WqtmaTZZeP",
+      "uri_apple_music": "applemusic://track/1617280597",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1617280597"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1705986647",
+      "fun_fact": "“Ferrari” is the title track of James Hype’s release of the same name.",
+      "fun_fact_de": "„Ferrari“ ist der Titelsong der gleichnamigen Veröffentlichung von James Hype.",
+      "fun_fact_es": "«Ferrari» es la canción que da título al lanzamiento homónimo de James Hype.",
+      "fun_fact_fr": "« Ferrari » est le morceau-titre de la publication éponyme de James Hype.",
+      "fun_fact_nl": "‘Ferrari’ is het titelnummer van de gelijknamige release van James Hype.",
+      "alt_artists": [
+        "FISHER",
+        "Netsky",
+        "Kelis, Alex Wann"
+      ]
+    },
+    {
+      "artist": "Nora En Pure",
+      "title": "Come With Me - Radio Mix",
+      "year": 2013,
+      "isrc": "CH3131311287",
+      "uri": "spotify:track:1Ht4NJdY8adMsW540P5vG0",
+      "uri_apple_music": "applemusic://track/736115391",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/736115391"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/64627716",
+      "fun_fact": "“Come With Me - Radio Mix” appears on Nora En Pure’s release “Come with Me”.",
+      "fun_fact_de": "„Come With Me - Radio Mix“ erschien auf der Veröffentlichung „Come with Me“ von Nora En Pure.",
+      "fun_fact_es": "«Come With Me - Radio Mix» aparece en el lanzamiento «Come with Me» de Nora En Pure.",
+      "fun_fact_fr": "« Come With Me - Radio Mix » figure sur la publication « Come with Me » de Nora En Pure.",
+      "fun_fact_nl": "‘Come With Me - Radio Mix’ staat op de release ‘Come with Me’ van Nora En Pure.",
+      "alt_artists": [
+        "Josh Butler, Bontan, Pleasurekraft",
+        "TJR, VINAI",
+        "Friend Within"
+      ]
+    },
+    {
+      "artist": "Martin Garrix, Khalid, DubVision",
+      "title": "Ocean (feat. Khalid) - DubVision Remix",
+      "year": 2018,
+      "isrc": "NLM5S1800255",
+      "uri": "spotify:track:5hxIWOdB3YAwuRMcdYUXNB",
+      "uri_apple_music": "applemusic://track/1412728922",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1412728922"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/528674741",
+      "fun_fact": "“Ocean (feat. Khalid) - DubVision Remix” appears on Martin Garrix’s release “Ocean (feat. Khalid) (Remixes Vol. 1)”.",
+      "fun_fact_de": "„Ocean (feat. Khalid) - DubVision Remix“ erschien auf der Veröffentlichung „Ocean (feat. Khalid) (Remixes Vol. 1)“ von Martin Garrix.",
+      "fun_fact_es": "«Ocean (feat. Khalid) - DubVision Remix» aparece en el lanzamiento «Ocean (feat. Khalid) (Remixes Vol. 1)» de Martin Garrix.",
+      "fun_fact_fr": "« Ocean (feat. Khalid) - DubVision Remix » figure sur la publication « Ocean (feat. Khalid) (Remixes Vol. 1) » de Martin Garrix.",
+      "fun_fact_nl": "‘Ocean (feat. Khalid) - DubVision Remix’ staat op de release ‘Ocean (feat. Khalid) (Remixes Vol. 1)’ van Martin Garrix.",
+      "alt_artists": [
+        "Sub Focus, Wilkinson",
+        "Sub Focus",
+        "Rampa, Adam Port, &ME, chuala, Keinemusik"
+      ]
+    },
+    {
+      "artist": "Kevin de Vries",
+      "title": "Dance With Me",
+      "year": 2022,
+      "isrc": "DEEC33500767",
+      "uri": "spotify:track:0VbexUMmRVxsshn5PPqrfW",
+      "uri_apple_music": "applemusic://track/1716722471",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1716722471"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2543654701",
+      "fun_fact": "“Dance With Me” appears on Kevin de Vries’s release “Dance With Me EP”.",
+      "fun_fact_de": "„Dance With Me“ erschien auf der Veröffentlichung „Dance With Me EP“ von Kevin de Vries.",
+      "fun_fact_es": "«Dance With Me» aparece en el lanzamiento «Dance With Me EP» de Kevin de Vries.",
+      "fun_fact_fr": "« Dance With Me » figure sur la publication « Dance With Me EP » de Kevin de Vries.",
+      "fun_fact_nl": "‘Dance With Me’ staat op de release ‘Dance With Me EP’ van Kevin de Vries.",
+      "alt_artists": [
+        "John Summit, HAYLA",
+        "Axwell, Max C",
+        "4444 OF A KIND, D-Block & S-te-Fan, Sub Zero Project"
+      ]
+    },
+    {
+      "artist": "Netsky",
+      "title": "Come Alive",
+      "year": 2012,
+      "isrc": "GBCJY1200116",
+      "uri": "spotify:track:7JSRgtiKwuyhZBbJ52cFkb",
+      "uri_apple_music": "applemusic://track/516569496",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/516569496"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2280370857",
+      "fun_fact": "“Come Alive” appears on Netsky’s release “2 Deluxe”.",
+      "fun_fact_de": "„Come Alive“ erschien auf der Veröffentlichung „2 Deluxe“ von Netsky.",
+      "fun_fact_es": "«Come Alive» aparece en el lanzamiento «2 Deluxe» de Netsky.",
+      "fun_fact_fr": "« Come Alive » figure sur la publication « 2 Deluxe » de Netsky.",
+      "fun_fact_nl": "‘Come Alive’ staat op de release ‘2 Deluxe’ van Netsky.",
+      "alt_artists": [
+        "Tiësto, Dzeko, Lena Leon",
+        "Knife Party",
+        "Sunnery James & Ryan Marciano, RANI"
+      ]
+    },
+    {
+      "artist": "Sam Feldt, EDX",
+      "title": "Show Me Love - EDX's Indian Summer Remix",
+      "year": 2015,
+      "isrc": "NLZ541500305",
+      "uri": "spotify:track:3uJwLNPpU4isrplyl478Se",
+      "uri_apple_music": "applemusic://track/1817292592",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1817292592"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3389345631",
+      "fun_fact": "“Show Me Love - EDX's Indian Summer Remix” appears on Sam Feldt’s release “Show Me Love (EDX's Indian Summer & Quintino Remix)”.",
+      "fun_fact_de": "„Show Me Love - EDX's Indian Summer Remix“ erschien auf der Veröffentlichung „Show Me Love (EDX's Indian Summer & Quintino Remix)“ von Sam Feldt.",
+      "fun_fact_es": "«Show Me Love - EDX's Indian Summer Remix» aparece en el lanzamiento «Show Me Love (EDX's Indian Summer & Quintino Remix)» de Sam Feldt.",
+      "fun_fact_fr": "« Show Me Love - EDX's Indian Summer Remix » figure sur la publication « Show Me Love (EDX's Indian Summer & Quintino Remix) » de Sam Feldt.",
+      "fun_fact_nl": "‘Show Me Love - EDX's Indian Summer Remix’ staat op de release ‘Show Me Love (EDX's Indian Summer & Quintino Remix)’ van Sam Feldt.",
+      "alt_artists": [
+        "Kölsch, Troels Abrahamsen, ARTBAT",
+        "Jones & Stephenson",
+        "Josh Baker, Omar+"
+      ]
+    },
+    {
+      "artist": "Age Of Love",
+      "title": "The Age Of Love - Radio Edit",
+      "year": 1990,
+      "isrc": "BEE329000040",
+      "uri": "spotify:track:3qKYCAQHCTWQG0uuaMZTHg",
+      "uri_apple_music": "applemusic://track/1643698514",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1643698514"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1902157797",
+      "fun_fact": "“The Age Of Love - Radio Edit” appears on Age Of Love’s release “The Age Of Love (Remixes)”.",
+      "fun_fact_de": "„The Age Of Love - Radio Edit“ erschien auf der Veröffentlichung „The Age Of Love (Remixes)“ von Age Of Love.",
+      "fun_fact_es": "«The Age Of Love - Radio Edit» aparece en el lanzamiento «The Age Of Love (Remixes)» de Age Of Love.",
+      "fun_fact_fr": "« The Age Of Love - Radio Edit » figure sur la publication « The Age Of Love (Remixes) » de Age Of Love.",
+      "fun_fact_nl": "‘The Age Of Love - Radio Edit’ staat op de release ‘The Age Of Love (Remixes)’ van Age Of Love.",
+      "alt_artists": [
+        "Jax Jones, Martin Solveig, Madison Beer, Europa",
+        "David Guetta, Benny Benassi",
+        "Patrick Topping"
+      ]
+    },
+    {
+      "artist": "Marlon Hoffstadt, FISHER",
+      "title": "It's That Time - FISHER Remix",
+      "year": 2024,
+      "isrc": "QZQAY2417164",
+      "uri": "spotify:track:3GiORO0zRwRT3g9CCklzkQ",
+      "uri_apple_music": "applemusic://track/1751742618",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1751742618"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2843812632",
+      "fun_fact": "“It's That Time - FISHER Remix” is the title track of Marlon Hoffstadt’s release of the same name.",
+      "fun_fact_de": "„It's That Time - FISHER Remix“ ist der Titelsong der gleichnamigen Veröffentlichung von Marlon Hoffstadt.",
+      "fun_fact_es": "«It's That Time - FISHER Remix» es la canción que da título al lanzamiento homónimo de Marlon Hoffstadt.",
+      "fun_fact_fr": "« It's That Time - FISHER Remix » est le morceau-titre de la publication éponyme de Marlon Hoffstadt.",
+      "fun_fact_nl": "‘It's That Time - FISHER Remix’ is het titelnummer van de gelijknamige release van Marlon Hoffstadt.",
+      "alt_artists": [
+        "Martin Garrix, Matisse & Sadko, John Martin",
+        "YORK, Mauro Picotto",
+        "Michael Calfan, Axwell"
+      ]
+    },
+    {
+      "artist": "Laurent Garnier",
+      "title": "The Man With the Red Face - Video Edit",
+      "year": 2000,
+      "isrc": "FRV229900078",
+      "uri": "spotify:track:3FwsjsakjJkeLotPOGIr7s",
+      "uri_apple_music": "applemusic://track/1052536593",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1052536593"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3781914",
+      "fun_fact": "“The Man With the Red Face - Video Edit” appears on Laurent Garnier’s release “The Man With The Red Face”.",
+      "fun_fact_de": "„The Man With the Red Face - Video Edit“ erschien auf der Veröffentlichung „The Man With The Red Face“ von Laurent Garnier.",
+      "fun_fact_es": "«The Man With the Red Face - Video Edit» aparece en el lanzamiento «The Man With The Red Face» de Laurent Garnier.",
+      "fun_fact_fr": "« The Man With the Red Face - Video Edit » figure sur la publication « The Man With The Red Face » de Laurent Garnier.",
+      "fun_fact_nl": "‘The Man With the Red Face - Video Edit’ staat op de release ‘The Man With The Red Face’ van Laurent Garnier.",
+      "alt_artists": [
+        "ARTBAT, Pete Tong",
+        "Zerb, Sofiya Nzau",
+        "Faithless"
+      ]
+    },
+    {
+      "artist": "Galantis",
+      "title": "You",
+      "year": 2014,
+      "isrc": "USAT21400542",
+      "uri": "spotify:track:7gUg4GdOA6Y6yRDe36GIjK",
+      "uri_apple_music": "applemusic://track/984746637",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/984746637"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/75069801",
+      "fun_fact": "“You” is the title track of Galantis’s release of the same name.",
+      "fun_fact_de": "„You“ ist der Titelsong der gleichnamigen Veröffentlichung von Galantis.",
+      "fun_fact_es": "«You» es la canción que da título al lanzamiento homónimo de Galantis.",
+      "fun_fact_fr": "« You » est le morceau-titre de la publication éponyme de Galantis.",
+      "fun_fact_nl": "‘You’ is het titelnummer van de gelijknamige release van Galantis.",
+      "alt_artists": [
+        "Martin Garrix, Matisse & Sadko, Michel Zitron",
+        "New World Sound, Thomas Newson",
+        "Alesso, DubVision"
+      ]
+    },
+    {
+      "artist": "Armin van Buuren, Shapov",
+      "title": "Our Origin - Extended Mix",
+      "year": 2018,
+      "isrc": "NLF711808690",
+      "uri": "spotify:track:6N5TNlYhmpuynRBlyXScV4",
+      "uri_apple_music": "applemusic://track/1458852081",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1458852081"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/530117301",
+      "fun_fact": "“Our Origin - Extended Mix” appears on Armin van Buuren’s release “Our Origin”.",
+      "fun_fact_de": "„Our Origin - Extended Mix“ erschien auf der Veröffentlichung „Our Origin“ von Armin van Buuren.",
+      "fun_fact_es": "«Our Origin - Extended Mix» aparece en el lanzamiento «Our Origin» de Armin van Buuren.",
+      "fun_fact_fr": "« Our Origin - Extended Mix » figure sur la publication « Our Origin » de Armin van Buuren.",
+      "fun_fact_nl": "‘Our Origin - Extended Mix’ staat op de release ‘Our Origin’ van Armin van Buuren.",
+      "alt_artists": [
+        "Martin Garrix, Khalid, DubVision",
+        "Jauz",
+        "Tiësto, Mesto"
+      ]
+    },
+    {
+      "artist": "MEDUZA, Becky Hill, Goodboys",
+      "title": "Lose Control",
+      "year": 2019,
+      "isrc": "DEUM71905792",
+      "uri": "spotify:track:7CHi4DtfK4heMlQaudCuHK",
+      "uri_apple_music": "applemusic://track/1481872810",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1481872810"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/769757652",
+      "fun_fact": "“Lose Control” is the title track of MEDUZA’s release of the same name.",
+      "fun_fact_de": "„Lose Control“ ist der Titelsong der gleichnamigen Veröffentlichung von MEDUZA.",
+      "fun_fact_es": "«Lose Control» es la canción que da título al lanzamiento homónimo de MEDUZA.",
+      "fun_fact_fr": "« Lose Control » est le morceau-titre de la publication éponyme de MEDUZA.",
+      "fun_fact_nl": "‘Lose Control’ is het titelnummer van de gelijknamige release van MEDUZA.",
+      "alt_artists": [
+        "Svenson & Gielen",
+        "Sonny Fodera, MK, Clementine Douglas",
+        "AN21, Max Vangeli"
+      ]
+    },
+    {
+      "artist": "Laidback Luke, Chris Lorenzo",
+      "title": "Break The House Down",
+      "year": 2024,
+      "isrc": "USBBR2400022",
+      "uri": "spotify:track:06Spq2VfQFwngHsRyvnUqA",
+      "uri_apple_music": "applemusic://track/1787190407",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1787190407"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3157820001",
+      "fun_fact": "“Break The House Down” is the title track of Laidback Luke’s release of the same name.",
+      "fun_fact_de": "„Break The House Down“ ist der Titelsong der gleichnamigen Veröffentlichung von Laidback Luke.",
+      "fun_fact_es": "«Break The House Down» es la canción que da título al lanzamiento homónimo de Laidback Luke.",
+      "fun_fact_fr": "« Break The House Down » est le morceau-titre de la publication éponyme de Laidback Luke.",
+      "fun_fact_nl": "‘Break The House Down’ is het titelnummer van de gelijknamige release van Laidback Luke.",
+      "alt_artists": [
+        "David Guetta, MORTEN, RAYE",
+        "Above & Beyond",
+        "James Hype, Miggy Dela Rosa"
+      ]
+    },
+    {
+      "artist": "David Guetta, Martin Garrix, Brooks",
+      "title": "Like I Do",
+      "year": 2018,
+      "isrc": "GB28K1820005",
+      "uri": "spotify:track:6RnkFd8Fqqgk1Uni8RgqCQ",
+      "uri_apple_music": "applemusic://track/1432624804",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1432624804"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/459955592",
+      "fun_fact": "“Like I Do” is the title track of David Guetta’s release of the same name.",
+      "fun_fact_de": "„Like I Do“ ist der Titelsong der gleichnamigen Veröffentlichung von David Guetta.",
+      "fun_fact_es": "«Like I Do» es la canción que da título al lanzamiento homónimo de David Guetta.",
+      "fun_fact_fr": "« Like I Do » est le morceau-titre de la publication éponyme de David Guetta.",
+      "fun_fact_nl": "‘Like I Do’ is het titelnummer van de gelijknamige release van David Guetta.",
+      "alt_artists": [
+        "Dom Dolla, Clementine Douglas",
+        "Underworld",
+        "DJ MERCER, Tchami"
+      ]
+    },
+    {
+      "artist": "FISHER",
+      "title": "You Little Beauty",
+      "year": 2019,
+      "isrc": "CA5KR1923939",
+      "uri": "spotify:track:1gRQxbfL4ULWyTosgXSbWT",
+      "uri_apple_music": "applemusic://track/1467425122",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1467425122"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/694844122",
+      "fun_fact": "“You Little Beauty” is the title track of FISHER’s release of the same name.",
+      "fun_fact_de": "„You Little Beauty“ ist der Titelsong der gleichnamigen Veröffentlichung von FISHER.",
+      "fun_fact_es": "«You Little Beauty» es la canción que da título al lanzamiento homónimo de FISHER.",
+      "fun_fact_fr": "« You Little Beauty » est le morceau-titre de la publication éponyme de FISHER.",
+      "fun_fact_nl": "‘You Little Beauty’ is het titelnummer van de gelijknamige release van FISHER.",
+      "alt_artists": [
+        "Gregor Salto, Florian T",
+        "HUGEL, Alleh, Yorghaki",
+        "Rui Da Silva, Cassandra"
+      ]
+    },
+    {
+      "artist": "Tiësto, Hardwell",
+      "title": "Zero 76 - Radio Edit",
+      "year": 2011,
+      "isrc": "CYA111100001",
+      "uri": "spotify:track:5E5uT5ZokaWpXzo7DgL7ms",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/771701712",
+      "fun_fact": "“Zero 76 - Radio Edit” appears on Tiësto’s release “Zero 76”.",
+      "fun_fact_de": "„Zero 76 - Radio Edit“ erschien auf der Veröffentlichung „Zero 76“ von Tiësto.",
+      "fun_fact_es": "«Zero 76 - Radio Edit» aparece en el lanzamiento «Zero 76» de Tiësto.",
+      "fun_fact_fr": "« Zero 76 - Radio Edit » figure sur la publication « Zero 76 » de Tiësto.",
+      "fun_fact_nl": "‘Zero 76 - Radio Edit’ staat op de release ‘Zero 76’ van Tiësto.",
+      "alt_artists": [
+        "Alesso, TINI",
+        "L.P. Rhythm",
+        "Yves V"
+      ]
+    },
+    {
+      "artist": "Rihanna",
+      "title": "Where Have You Been - The Calvin Harris Extended Remix",
+      "year": 2012,
+      "isrc": "USUM71206271",
+      "uri": "spotify:track:0Qv6D0PaNKZHepRct8kbyX",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1762568467",
+      "fun_fact": "“Where Have You Been - The Calvin Harris Extended Remix” is the title track of Rihanna’s release of the same name.",
+      "fun_fact_de": "„Where Have You Been - The Calvin Harris Extended Remix“ ist der Titelsong der gleichnamigen Veröffentlichung von Rihanna.",
+      "fun_fact_es": "«Where Have You Been - The Calvin Harris Extended Remix» es la canción que da título al lanzamiento homónimo de Rihanna.",
+      "fun_fact_fr": "« Where Have You Been - The Calvin Harris Extended Remix » est le morceau-titre de la publication éponyme de Rihanna.",
+      "fun_fact_nl": "‘Where Have You Been - The Calvin Harris Extended Remix’ is het titelnummer van de gelijknamige release van Rihanna.",
+      "alt_artists": [
+        "Paul van Dyk, Hemstock, Jennings",
+        "FISHER, bbyclose",
+        "Dim Chris, Sebastien Drums, Avicii"
+      ]
+    },
+    {
+      "artist": "Dash Berlin",
+      "title": "Till The Sky Falls Down",
+      "year": 2008,
+      "isrc": "NLF710800253",
+      "uri": "spotify:track:1YddMZzakt7WEZ9y1xGQgR",
+      "uri_apple_music": "applemusic://track/1541882774",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1541882774"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/132560814",
+      "fun_fact": "“Till The Sky Falls Down” appears on Dash Berlin’s release “A State Of Trance - 15 Years”.",
+      "fun_fact_de": "„Till The Sky Falls Down“ erschien auf der Veröffentlichung „A State Of Trance - 15 Years“ von Dash Berlin.",
+      "fun_fact_es": "«Till The Sky Falls Down» aparece en el lanzamiento «A State Of Trance - 15 Years» de Dash Berlin.",
+      "fun_fact_fr": "« Till The Sky Falls Down » figure sur la publication « A State Of Trance - 15 Years » de Dash Berlin.",
+      "fun_fact_nl": "‘Till The Sky Falls Down’ staat op de release ‘A State Of Trance - 15 Years’ van Dash Berlin.",
+      "alt_artists": [
+        "Calvin Harris, Clementine Douglas",
+        "C-Mos, Axwell",
+        "Djuma Soundsystem"
+      ]
+    },
+    {
+      "artist": "Tim Mason, Steve Angello",
+      "title": "The Moment - Steve Angello Edit",
+      "year": 2014,
+      "isrc": "USYBL1400317",
+      "uri": "spotify:track:1TZp2bCH2Ld7o8eMkJtFgS",
+      "uri_apple_music": "applemusic://track/945816846",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/945816846"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/91267450",
+      "fun_fact": "“The Moment - Steve Angello Edit” appears on Tim Mason’s release “The Moment”.",
+      "fun_fact_de": "„The Moment - Steve Angello Edit“ erschien auf der Veröffentlichung „The Moment“ von Tim Mason.",
+      "fun_fact_es": "«The Moment - Steve Angello Edit» aparece en el lanzamiento «The Moment» de Tim Mason.",
+      "fun_fact_fr": "« The Moment - Steve Angello Edit » figure sur la publication « The Moment » de Tim Mason.",
+      "fun_fact_nl": "‘The Moment - Steve Angello Edit’ staat op de release ‘The Moment’ van Tim Mason.",
+      "alt_artists": [
+        "KI/KI",
+        "David Guetta, Benny Benassi",
+        "Steve Aoki, Jamis, Bonn"
+      ]
+    },
+    {
+      "artist": "ARTBAT, Sailor & I",
+      "title": "Best of Me - Radio Edit",
+      "year": 2020,
+      "isrc": "DEBE72000267",
+      "uri": "spotify:track:4bJ7hDIjOucR0hGDEaVBOr",
+      "uri_apple_music": "applemusic://track/1645308143",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1645308143"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1914502307",
+      "fun_fact": "“Best of Me - Radio Edit” is the title track of ARTBAT’s release of the same name.",
+      "fun_fact_de": "„Best of Me - Radio Edit“ ist der Titelsong der gleichnamigen Veröffentlichung von ARTBAT.",
+      "fun_fact_es": "«Best of Me - Radio Edit» es la canción que da título al lanzamiento homónimo de ARTBAT.",
+      "fun_fact_fr": "« Best of Me - Radio Edit » est le morceau-titre de la publication éponyme de ARTBAT.",
+      "fun_fact_nl": "‘Best of Me - Radio Edit’ is het titelnummer van de gelijknamige release van ARTBAT.",
+      "alt_artists": [
+        "Kaskade, Punctual, Poppy Baskcomb",
+        "Eliza Rose, Interplanetary Criminal",
+        "Robin Schulz, Jasmine Thompson"
+      ]
+    },
+    {
+      "artist": "Virtual Self",
+      "title": "Ghost Voices",
+      "year": 2017,
+      "isrc": "QMUY41700232",
+      "uri": "spotify:track:3A02f2nXSbpeY9uXHi7oMi",
+      "uri_apple_music": "applemusic://track/1701891628",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1701891628"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2404408815",
+      "fun_fact": "“Ghost Voices” appears on Virtual Self’s release “Virtual Self”.",
+      "fun_fact_de": "„Ghost Voices“ erschien auf der Veröffentlichung „Virtual Self“ von Virtual Self.",
+      "fun_fact_es": "«Ghost Voices» aparece en el lanzamiento «Virtual Self» de Virtual Self.",
+      "fun_fact_fr": "« Ghost Voices » figure sur la publication « Virtual Self » de Virtual Self.",
+      "fun_fact_nl": "‘Ghost Voices’ staat op de release ‘Virtual Self’ van Virtual Self.",
+      "alt_artists": [
+        "Barry Can't Swim",
+        "Martin Solveig, Tkay Maidza",
+        "Galantis"
+      ]
+    },
+    {
+      "artist": "ACRAZE, Cherish",
+      "title": "Do It To It",
+      "year": 2021,
+      "isrc": "QZFPL2100100",
+      "uri": "spotify:track:7cyGxmLnHWlwt41cr2RZzG",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3482503451",
+      "fun_fact": "“Do It To It” appears on ACRAZE’s release “Do It To It (Remixes)”.",
+      "fun_fact_de": "„Do It To It“ erschien auf der Veröffentlichung „Do It To It (Remixes)“ von ACRAZE.",
+      "fun_fact_es": "«Do It To It» aparece en el lanzamiento «Do It To It (Remixes)» de ACRAZE.",
+      "fun_fact_fr": "« Do It To It » figure sur la publication « Do It To It (Remixes) » de ACRAZE.",
+      "fun_fact_nl": "‘Do It To It’ staat op de release ‘Do It To It (Remixes)’ van ACRAZE.",
+      "alt_artists": [
+        "Martin Garrix, Julian Jordan",
+        "Martin Garrix, Justin Mylo, Dewain Whitmore",
+        "Solardo, Eli Brown"
+      ]
+    },
+    {
+      "artist": "Eliza Rose, Interplanetary Criminal",
+      "title": "B.O.T.A. (Baddest Of Them All) - Edit",
+      "year": 2022,
+      "isrc": "QZAKB2166405",
+      "uri": "spotify:track:39JofJHEtg8I4fSyo7Imft",
+      "uri_apple_music": "applemusic://track/1639317826",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1639317826"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1862856447",
+      "fun_fact": "“B.O.T.A. (Baddest Of Them All) - Edit” appears on Eliza Rose’s release “B.O.T.A. (Baddest Of Them All)”.",
+      "fun_fact_de": "„B.O.T.A. (Baddest Of Them All) - Edit“ erschien auf der Veröffentlichung „B.O.T.A. (Baddest Of Them All)“ von Eliza Rose.",
+      "fun_fact_es": "«B.O.T.A. (Baddest Of Them All) - Edit» aparece en el lanzamiento «B.O.T.A. (Baddest Of Them All)» de Eliza Rose.",
+      "fun_fact_fr": "« B.O.T.A. (Baddest Of Them All) - Edit » figure sur la publication « B.O.T.A. (Baddest Of Them All) » de Eliza Rose.",
+      "fun_fact_nl": "‘B.O.T.A. (Baddest Of Them All) - Edit’ staat op de release ‘B.O.T.A. (Baddest Of Them All)’ van Eliza Rose.",
+      "alt_artists": [
+        "Jauz",
+        "AVAION",
+        "Gouryella, Ferry Corsten"
+      ]
+    },
+    {
+      "artist": "Rank 1",
+      "title": "Airwave - Original Mix",
+      "year": 1999,
+      "isrc": "NLE800510002",
+      "uri": "spotify:track:4Q3p9fr4aaSVsiNmUrT2Tu",
+      "uri_apple_music": "applemusic://track/430649596",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/430649596"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/633661602",
+      "fun_fact": "“Airwave - Original Mix” appears on Rank 1’s release “Airwave”.",
+      "fun_fact_de": "„Airwave - Original Mix“ erschien auf der Veröffentlichung „Airwave“ von Rank 1.",
+      "fun_fact_es": "«Airwave - Original Mix» aparece en el lanzamiento «Airwave» de Rank 1.",
+      "fun_fact_fr": "« Airwave - Original Mix » figure sur la publication « Airwave » de Rank 1.",
+      "fun_fact_nl": "‘Airwave - Original Mix’ staat op de release ‘Airwave’ van Rank 1.",
+      "alt_artists": [
+        "Sammy Virji, Skepta",
+        "Lifelike, Kris Menace",
+        "Gregor Salto, Florian T"
+      ]
+    },
+    {
+      "artist": "KAAZE, Alina Pozi",
+      "title": "Papi",
+      "year": 2024,
+      "isrc": "BEIW12400461",
+      "uri": "spotify:track:5nsGwIGBNcwYVAPNdZCYQV",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2845478952",
+      "fun_fact": "“Papi” is the title track of KAAZE’s release of the same name.",
+      "fun_fact_de": "„Papi“ ist der Titelsong der gleichnamigen Veröffentlichung von KAAZE.",
+      "fun_fact_es": "«Papi» es la canción que da título al lanzamiento homónimo de KAAZE.",
+      "fun_fact_fr": "« Papi » est le morceau-titre de la publication éponyme de KAAZE.",
+      "fun_fact_nl": "‘Papi’ is het titelnummer van de gelijknamige release van KAAZE.",
+      "alt_artists": [
+        "KSHMR, Mike Waters",
+        "Hardwell, Blasterjaxx, Mitch Crown",
+        "Fragma"
+      ]
+    },
+    {
+      "artist": "Axwell, Errol Reid",
+      "title": "(Can You) Feel The Vibe - Radio Edit",
+      "year": 2005,
+      "isrc": "GBKCF0500080",
+      "uri": "spotify:track:2Et2nCcAnsl2KDrGZtsO7U",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/73460558",
+      "fun_fact": "“(Can You) Feel The Vibe - Radio Edit” appears on Axwell’s release “Feel The Vibe”.",
+      "fun_fact_de": "„(Can You) Feel The Vibe - Radio Edit“ erschien auf der Veröffentlichung „Feel The Vibe“ von Axwell.",
+      "fun_fact_es": "«(Can You) Feel The Vibe - Radio Edit» aparece en el lanzamiento «Feel The Vibe» de Axwell.",
+      "fun_fact_fr": "« (Can You) Feel The Vibe - Radio Edit » figure sur la publication « Feel The Vibe » de Axwell.",
+      "fun_fact_nl": "‘(Can You) Feel The Vibe - Radio Edit’ staat op de release ‘Feel The Vibe’ van Axwell.",
+      "alt_artists": [
+        "Duck Sauce, A-Trak, Armand Van Helden",
+        "Martin Garrix, Matisse & Sadko, BARBZ",
+        "Solardo, Eli Brown"
+      ]
+    },
+    {
+      "artist": "MEDUZA, Dermot Kennedy",
+      "title": "Paradise",
+      "year": 2020,
+      "isrc": "GBUM72005075",
+      "uri": "spotify:track:40FUdLENDY3sZmHEM25lpE",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1118064072",
+      "fun_fact": "“Paradise” is the title track of MEDUZA’s release of the same name.",
+      "fun_fact_de": "„Paradise“ ist der Titelsong der gleichnamigen Veröffentlichung von MEDUZA.",
+      "fun_fact_es": "«Paradise» es la canción que da título al lanzamiento homónimo de MEDUZA.",
+      "fun_fact_fr": "« Paradise » est le morceau-titre de la publication éponyme de MEDUZA.",
+      "fun_fact_nl": "‘Paradise’ is het titelnummer van de gelijknamige release van MEDUZA.",
+      "alt_artists": [
+        "Dirty South, Evermore",
+        "Secondcity",
+        "Pegassi"
+      ]
+    },
+    {
+      "artist": "Adriatique, Marino Canal, Delhia De France",
+      "title": "Home",
+      "year": 2020,
+      "isrc": "CHC652000057",
+      "uri": "spotify:track:6jYXP1jrYIHkEYglFgeL2Q",
+      "uri_apple_music": "applemusic://track/1513189643",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1513189643"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/960115192",
+      "fun_fact": "“Home” is the title track of Adriatique’s release of the same name.",
+      "fun_fact_de": "„Home“ ist der Titelsong der gleichnamigen Veröffentlichung von Adriatique.",
+      "fun_fact_es": "«Home» es la canción que da título al lanzamiento homónimo de Adriatique.",
+      "fun_fact_fr": "« Home » est le morceau-titre de la publication éponyme de Adriatique.",
+      "fun_fact_nl": "‘Home’ is het titelnummer van de gelijknamige release van Adriatique.",
+      "alt_artists": [
+        "Loofy, Anyma, Layton Giordani",
+        "Jamback",
+        "Alan Walker, Tiësto"
+      ]
+    },
+    {
+      "artist": "Travis Scott, CHASE B",
+      "title": "FE!N - CHASE B REMIX",
+      "year": 2024,
+      "isrc": "USSM12403173",
+      "uri": "spotify:track:6sFriHsWdq31GcaHdgFHoY",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2757385381",
+      "fun_fact": "“FE!N - CHASE B REMIX” is the title track of Travis Scott’s release of the same name.",
+      "fun_fact_de": "„FE!N - CHASE B REMIX“ ist der Titelsong der gleichnamigen Veröffentlichung von Travis Scott.",
+      "fun_fact_es": "«FE!N - CHASE B REMIX» es la canción que da título al lanzamiento homónimo de Travis Scott.",
+      "fun_fact_fr": "« FE!N - CHASE B REMIX » est le morceau-titre de la publication éponyme de Travis Scott.",
+      "fun_fact_nl": "‘FE!N - CHASE B REMIX’ is het titelnummer van de gelijknamige release van Travis Scott.",
+      "alt_artists": [
+        "Wankelmut, Emma Louise, MK",
+        "Martin Garrix, Macklemore, Fall Out Boy, Tiësto",
+        "Oden & Fatzo"
+      ]
+    },
+    {
+      "artist": "Don Diablo",
+      "title": "Momentum",
+      "year": 2017,
+      "isrc": "NLZ541700795",
+      "uri": "spotify:track:6BUhaCvC3VG4HZwyNLRhWm",
+      "uri_apple_music": "applemusic://track/1337757558",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1337757558"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/452769012",
+      "fun_fact": "“Momentum” is the title track of Don Diablo’s release of the same name.",
+      "fun_fact_de": "„Momentum“ ist der Titelsong der gleichnamigen Veröffentlichung von Don Diablo.",
+      "fun_fact_es": "«Momentum» es la canción que da título al lanzamiento homónimo de Don Diablo.",
+      "fun_fact_fr": "« Momentum » est le morceau-titre de la publication éponyme de Don Diablo.",
+      "fun_fact_nl": "‘Momentum’ is het titelnummer van de gelijknamige release van Don Diablo.",
+      "alt_artists": [
+        "David Guetta, MORTEN, Aloe Blacc",
+        "Joel Corry, Da Hool",
+        "Maverick Sabre, Jorja Smith, Vintage Culture, Slow Motion"
+      ]
+    },
+    {
+      "artist": "Cassian, SCRIPT, Belladonna (ofc)",
+      "title": "Where I'm From",
+      "year": 2025,
+      "isrc": "US38Y2509305",
+      "uri": "spotify:track:0JFNTfRWLqQ09z9ZHldX8d",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3245588751",
+      "fun_fact": "“Where I'm From” is the title track of Cassian’s release of the same name.",
+      "fun_fact_de": "„Where I'm From“ ist der Titelsong der gleichnamigen Veröffentlichung von Cassian.",
+      "fun_fact_es": "«Where I'm From» es la canción que da título al lanzamiento homónimo de Cassian.",
+      "fun_fact_fr": "« Where I'm From » est le morceau-titre de la publication éponyme de Cassian.",
+      "fun_fact_nl": "‘Where I'm From’ is het titelnummer van de gelijknamige release van Cassian.",
+      "alt_artists": [
+        "Michael Calfan",
+        "Samm",
+        "Vintage Culture, Fancy Inc"
+      ]
+    },
+    {
+      "artist": "Armin van Buuren, AVIAN GRAYS, Jordan Shaw",
+      "title": "Something Real",
+      "year": 2019,
+      "isrc": "NLF711906508",
+      "uri": "spotify:track:6BwClo5W3VvTzJv8bvZXDD",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/757592592",
+      "fun_fact": "“Something Real” appears on Armin van Buuren’s release “Balance”.",
+      "fun_fact_de": "„Something Real“ erschien auf der Veröffentlichung „Balance“ von Armin van Buuren.",
+      "fun_fact_es": "«Something Real» aparece en el lanzamiento «Balance» de Armin van Buuren.",
+      "fun_fact_fr": "« Something Real » figure sur la publication « Balance » de Armin van Buuren.",
+      "fun_fact_nl": "‘Something Real’ staat op de release ‘Balance’ van Armin van Buuren.",
+      "alt_artists": [
+        "Cristoph, FEMME",
+        "Yves V",
+        "Rui Da Silva, Cassandra"
+      ]
+    },
+    {
+      "artist": "Bruno Mars, Shepard, Sultan",
+      "title": "Locked out of Heaven - Sultan and Ned Shepard Remix",
+      "year": 2013,
+      "isrc": "USAT21207623",
+      "uri": "spotify:track:6AIxmLiDNHFQgZstB4lzDB",
+      "uri_apple_music": "applemusic://track/598054296",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/598054296"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/64327520",
+      "fun_fact": "“Locked out of Heaven - Sultan and Ned Shepard Remix” appears on Bruno Mars’s release “Locked out of Heaven (Remix)”.",
+      "fun_fact_de": "„Locked out of Heaven - Sultan and Ned Shepard Remix“ erschien auf der Veröffentlichung „Locked out of Heaven (Remix)“ von Bruno Mars.",
+      "fun_fact_es": "«Locked out of Heaven - Sultan and Ned Shepard Remix» aparece en el lanzamiento «Locked out of Heaven (Remix)» de Bruno Mars.",
+      "fun_fact_fr": "« Locked out of Heaven - Sultan and Ned Shepard Remix » figure sur la publication « Locked out of Heaven (Remix) » de Bruno Mars.",
+      "fun_fact_nl": "‘Locked out of Heaven - Sultan and Ned Shepard Remix’ staat op de release ‘Locked out of Heaven (Remix)’ van Bruno Mars.",
+      "alt_artists": [
+        "Dirty South, Evermore",
+        "Dimitri Vegas & Like Mike, Armin van Buuren, W&W",
+        "FISHER, bbyclose"
+      ]
+    },
+    {
+      "artist": "Tiësto, Oliver Heldens",
+      "title": "Wombass",
+      "year": 2015,
+      "isrc": "CYA111500099",
+      "uri": "spotify:track:6etVFDSbFabj0tPY10MAXR",
+      "uri_apple_music": "applemusic://track/1444862281",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1444862281"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/113946622",
+      "fun_fact": "“Wombass” is the title track of Tiësto’s release of the same name.",
+      "fun_fact_de": "„Wombass“ ist der Titelsong der gleichnamigen Veröffentlichung von Tiësto.",
+      "fun_fact_es": "«Wombass» es la canción que da título al lanzamiento homónimo de Tiësto.",
+      "fun_fact_fr": "« Wombass » est le morceau-titre de la publication éponyme de Tiësto.",
+      "fun_fact_nl": "‘Wombass’ is het titelnummer van de gelijknamige release van Tiësto.",
+      "alt_artists": [
+        "BUNT., Nate Traveller",
+        "Alesso, Zara Larsson",
+        "David Guetta, Alesso, Madison Love"
+      ]
+    },
+    {
+      "artist": "Congorock, Lexxus",
+      "title": "Babylon",
+      "year": 2010,
+      "isrc": "USYBL1000568",
+      "uri": "spotify:track:4JZKj6yp5EAah53ryDClq4",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3335368191",
+      "fun_fact": "“Babylon” appears on Congorock’s release “Babylon (Remixes)”.",
+      "fun_fact_de": "„Babylon“ erschien auf der Veröffentlichung „Babylon (Remixes)“ von Congorock.",
+      "fun_fact_es": "«Babylon» aparece en el lanzamiento «Babylon (Remixes)» de Congorock.",
+      "fun_fact_fr": "« Babylon » figure sur la publication « Babylon (Remixes) » de Congorock.",
+      "fun_fact_nl": "‘Babylon’ staat op de release ‘Babylon (Remixes)’ van Congorock.",
+      "alt_artists": [
+        "Lost Frequencies, The Temper Trap",
+        "Oxia",
+        "Prospa, RAHH"
+      ]
+    },
+    {
+      "artist": "Disclosure, Rivo, Eliza Doolittle",
+      "title": "You & Me - Rivo Remix",
+      "year": 2023,
+      "isrc": "GBUM72310662",
+      "uri": "spotify:track:0xoYZ45fgTfyQYREZPN7Sa",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2585655882",
+      "fun_fact": "“You & Me - Rivo Remix” is the title track of Disclosure’s release of the same name.",
+      "fun_fact_de": "„You & Me - Rivo Remix“ ist der Titelsong der gleichnamigen Veröffentlichung von Disclosure.",
+      "fun_fact_es": "«You & Me - Rivo Remix» es la canción que da título al lanzamiento homónimo de Disclosure.",
+      "fun_fact_fr": "« You & Me - Rivo Remix » est le morceau-titre de la publication éponyme de Disclosure.",
+      "fun_fact_nl": "‘You & Me - Rivo Remix’ is het titelnummer van de gelijknamige release van Disclosure.",
+      "alt_artists": [
+        "Sam Feldt, EDX",
+        "FISHER, bbyclose",
+        "Marshall Jefferson, Solardo"
+      ]
+    },
+    {
+      "artist": "DJ MERCER, Tchami",
+      "title": "Turn It Up - Tchami Remix",
+      "year": 2014,
+      "isrc": "NLZ541300918",
+      "uri": "spotify:track:6mKIMSbigaRSF7AE43oIsl",
+      "uri_apple_music": "applemusic://track/1346095388",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1346095388"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/459401082",
+      "fun_fact": "“Turn It Up - Tchami Remix” appears on DJ MERCER’s release “Turn It Up (The Remixes)”.",
+      "fun_fact_de": "„Turn It Up - Tchami Remix“ erschien auf der Veröffentlichung „Turn It Up (The Remixes)“ von DJ MERCER.",
+      "fun_fact_es": "«Turn It Up - Tchami Remix» aparece en el lanzamiento «Turn It Up (The Remixes)» de DJ MERCER.",
+      "fun_fact_fr": "« Turn It Up - Tchami Remix » figure sur la publication « Turn It Up (The Remixes) » de DJ MERCER.",
+      "fun_fact_nl": "‘Turn It Up - Tchami Remix’ staat op de release ‘Turn It Up (The Remixes)’ van DJ MERCER.",
+      "alt_artists": [
+        "Timmy Trumpet, Savage",
+        "Lucas & Steve, Tungevaag",
+        "Tujamo, Plastik Funk"
+      ]
+    },
+    {
+      "artist": "Pendulum, AN21, Max Vangeli, Steve Angello",
+      "title": "The Island - Steve Angello, AN21, Max Vangeli Remix",
+      "year": 2010,
+      "isrc": "GBAHT1000244",
+      "uri": "spotify:track:2RS9TJTiHvg0guy8hSmiAF",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/8040814",
+      "fun_fact": "“The Island - Steve Angello, AN21, Max Vangeli Remix” is the title track of Pendulum’s release of the same name.",
+      "fun_fact_de": "„The Island - Steve Angello, AN21, Max Vangeli Remix“ ist der Titelsong der gleichnamigen Veröffentlichung von Pendulum.",
+      "fun_fact_es": "«The Island - Steve Angello, AN21, Max Vangeli Remix» es la canción que da título al lanzamiento homónimo de Pendulum.",
+      "fun_fact_fr": "« The Island - Steve Angello, AN21, Max Vangeli Remix » est le morceau-titre de la publication éponyme de Pendulum.",
+      "fun_fact_nl": "‘The Island - Steve Angello, AN21, Max Vangeli Remix’ is het titelnummer van de gelijknamige release van Pendulum.",
+      "alt_artists": [
+        "4444 OF A KIND, D-Block & S-te-Fan, Sub Zero Project",
+        "The Prodigy",
+        "Art Of Trance, Ferry Corsten"
+      ]
+    },
+    {
+      "artist": "Kelis",
+      "title": "Acapella",
+      "year": 2010,
+      "isrc": "USUM70922471",
+      "uri": "spotify:track:3B3A4mqiRhspnA3VCyfEbb",
+      "uri_apple_music": "applemusic://track/1443146805",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1443146805"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/6057178",
+      "fun_fact": "“Acapella” appears on Kelis’s release “Flesh Tone”.",
+      "fun_fact_de": "„Acapella“ erschien auf der Veröffentlichung „Flesh Tone“ von Kelis.",
+      "fun_fact_es": "«Acapella» aparece en el lanzamiento «Flesh Tone» de Kelis.",
+      "fun_fact_fr": "« Acapella » figure sur la publication « Flesh Tone » de Kelis.",
+      "fun_fact_nl": "‘Acapella’ staat op de release ‘Flesh Tone’ van Kelis.",
+      "alt_artists": [
+        "Tiësto, Sevenn",
+        "Dimitri Vegas & Like Mike, Armin van Buuren, W&W",
+        "Double 99"
+      ]
+    },
+    {
+      "artist": "Red Hot Chili Peppers",
+      "title": "Snow (Hey Oh)",
+      "year": 2006,
+      "isrc": "USWB10601591",
+      "uri": "spotify:track:2aibwv5hGXSgw7Yru8IYTO",
+      "uri_apple_music": "applemusic://track/207928116",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/207928116"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/680518",
+      "fun_fact": "“Snow (Hey Oh)” appears on Red Hot Chili Peppers’s release “Stadium Arcadium”.",
+      "fun_fact_de": "„Snow (Hey Oh)“ erschien auf der Veröffentlichung „Stadium Arcadium“ von Red Hot Chili Peppers.",
+      "fun_fact_es": "«Snow (Hey Oh)» aparece en el lanzamiento «Stadium Arcadium» de Red Hot Chili Peppers.",
+      "fun_fact_fr": "« Snow (Hey Oh) » figure sur la publication « Stadium Arcadium » de Red Hot Chili Peppers.",
+      "fun_fact_nl": "‘Snow (Hey Oh)’ staat op de release ‘Stadium Arcadium’ van Red Hot Chili Peppers.",
+      "alt_artists": [
+        "AZARI, III, Jamie Jones",
+        "R3HAB, NERVO, Ummet Ozcan",
+        "Rebūke, Storm, Jam El Mar"
+      ]
+    },
+    {
+      "artist": "AFROJACK, Martin Garrix, David Guetta, Amél",
+      "title": "Our Time",
+      "year": 2025,
+      "isrc": "NLZ542500378",
+      "uri": "spotify:track:3MUFebos5drIwrUHxUorhP",
+      "uri_apple_music": "applemusic://track/1820146735",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1820146735"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3411361911",
+      "fun_fact": "“Our Time” is the title track of AFROJACK’s release of the same name.",
+      "fun_fact_de": "„Our Time“ ist der Titelsong der gleichnamigen Veröffentlichung von AFROJACK.",
+      "fun_fact_es": "«Our Time» es la canción que da título al lanzamiento homónimo de AFROJACK.",
+      "fun_fact_fr": "« Our Time » est le morceau-titre de la publication éponyme de AFROJACK.",
+      "fun_fact_nl": "‘Our Time’ is het titelnummer van de gelijknamige release van AFROJACK.",
+      "alt_artists": [
+        "Salif Keita, Martin Solveig",
+        "David Guetta, MORTEN",
+        "Armin van Buuren"
+      ]
+    },
+    {
+      "artist": "Jerome Isma-Ae, Charlotte de Witte",
+      "title": "Hold That Sucker Down - Charlotte de Witte Trance Remix Edit",
+      "year": 2020,
+      "isrc": "NLF712003623",
+      "uri": "spotify:track:21jO16ka3N4a65b14e7taN",
+      "uri_apple_music": "applemusic://track/1505589067",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1505589067"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/917189842",
+      "fun_fact": "“Hold That Sucker Down - Charlotte de Witte Trance Remix Edit” appears on Jerome Isma-Ae’s release “Hold That Sucker Down (Charlotte de Witte Remix)”.",
+      "fun_fact_de": "„Hold That Sucker Down - Charlotte de Witte Trance Remix Edit“ erschien auf der Veröffentlichung „Hold That Sucker Down (Charlotte de Witte Remix)“ von Jerome Isma-Ae.",
+      "fun_fact_es": "«Hold That Sucker Down - Charlotte de Witte Trance Remix Edit» aparece en el lanzamiento «Hold That Sucker Down (Charlotte de Witte Remix)» de Jerome Isma-Ae.",
+      "fun_fact_fr": "« Hold That Sucker Down - Charlotte de Witte Trance Remix Edit » figure sur la publication « Hold That Sucker Down (Charlotte de Witte Remix) » de Jerome Isma-Ae.",
+      "fun_fact_nl": "‘Hold That Sucker Down - Charlotte de Witte Trance Remix Edit’ staat op de release ‘Hold That Sucker Down (Charlotte de Witte Remix)’ van Jerome Isma-Ae.",
+      "alt_artists": [
+        "Tristan Garner, Norman Doray",
+        "Sam Feldt, EDX",
+        "Niels Van Gogh, Tiësto"
+      ]
+    },
+    {
+      "artist": "Sasha",
+      "title": "Xpander",
+      "year": 1999,
+      "isrc": "GBARK9900004",
+      "uri": "spotify:track:76mh0rcSJpNhoCCqazptWm",
+      "uri_apple_music": "applemusic://track/1308821701",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1308821701"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/995973",
+      "fun_fact": "“Xpander” appears on Sasha’s release “The Xpander E.P.”.",
+      "fun_fact_de": "„Xpander“ erschien auf der Veröffentlichung „The Xpander E.P.“ von Sasha.",
+      "fun_fact_es": "«Xpander» aparece en el lanzamiento «The Xpander E.P.» de Sasha.",
+      "fun_fact_fr": "« Xpander » figure sur la publication « The Xpander E.P. » de Sasha.",
+      "fun_fact_nl": "‘Xpander’ staat op de release ‘The Xpander E.P.’ van Sasha.",
+      "alt_artists": [
+        "MK, Dom Dolla",
+        "The Chainsmokers, Bebe Rexha",
+        "Martin Solveig, ALMA"
+      ]
+    },
+    {
+      "artist": "Alesso",
+      "title": "PROGRESSO",
+      "year": 2019,
+      "isrc": "USUG11900499",
+      "uri": "spotify:track:2LLXE4cV9Fcusx2WiSIhwC",
+      "uri_apple_music": "applemusic://track/1454069265",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1454069265"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/642705612",
+      "fun_fact": "“PROGRESSO” appears on Alesso’s release “ALESSO MIXTAPE - PROGRESSO VOLUME 1”.",
+      "fun_fact_de": "„PROGRESSO“ erschien auf der Veröffentlichung „ALESSO MIXTAPE - PROGRESSO VOLUME 1“ von Alesso.",
+      "fun_fact_es": "«PROGRESSO» aparece en el lanzamiento «ALESSO MIXTAPE - PROGRESSO VOLUME 1» de Alesso.",
+      "fun_fact_fr": "« PROGRESSO » figure sur la publication « ALESSO MIXTAPE - PROGRESSO VOLUME 1 » de Alesso.",
+      "fun_fact_nl": "‘PROGRESSO’ staat op de release ‘ALESSO MIXTAPE - PROGRESSO VOLUME 1’ van Alesso.",
+      "alt_artists": [
+        "Monolink, Ben Böhmer",
+        "Push",
+        "Butch, Kölsch"
+      ]
+    },
+    {
+      "artist": "Tiësto",
+      "title": "Maximal Crazy - Original Mix",
+      "year": 2011,
+      "isrc": "CYA111100052",
+      "uri": "spotify:track:3cHyzEpemYlq62PWCEFqGR",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/18063177",
+      "fun_fact": "“Maximal Crazy - Original Mix” appears on Tiësto’s release “Club Life: Vol. Two Miami”.",
+      "fun_fact_de": "„Maximal Crazy - Original Mix“ erschien auf der Veröffentlichung „Club Life: Vol. Two Miami“ von Tiësto.",
+      "fun_fact_es": "«Maximal Crazy - Original Mix» aparece en el lanzamiento «Club Life: Vol. Two Miami» de Tiësto.",
+      "fun_fact_fr": "« Maximal Crazy - Original Mix » figure sur la publication « Club Life: Vol. Two Miami » de Tiësto.",
+      "fun_fact_nl": "‘Maximal Crazy - Original Mix’ staat op de release ‘Club Life: Vol. Two Miami’ van Tiësto.",
+      "alt_artists": [
+        "Konstantin Sibold, Adam Sellouk",
+        "MOGUAI, Cheat Codes",
+        "Ernesto vs. Bastian, Susana"
+      ]
+    },
+    {
+      "artist": "CamelPhat, Yannis, Foals",
+      "title": "Hypercolour",
+      "year": 2020,
+      "isrc": "GBARL2000697",
+      "uri": "spotify:track:3CmUXmrh17WIaQOQu9OVha",
+      "uri_apple_music": "applemusic://track/1518217747",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1518217747"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/990358982",
+      "fun_fact": "“Hypercolour” is the title track of CamelPhat’s release of the same name.",
+      "fun_fact_de": "„Hypercolour“ ist der Titelsong der gleichnamigen Veröffentlichung von CamelPhat.",
+      "fun_fact_es": "«Hypercolour» es la canción que da título al lanzamiento homónimo de CamelPhat.",
+      "fun_fact_fr": "« Hypercolour » est le morceau-titre de la publication éponyme de CamelPhat.",
+      "fun_fact_nl": "‘Hypercolour’ is het titelnummer van de gelijknamige release van CamelPhat.",
+      "alt_artists": [
+        "Booka Shade",
+        "Dom Dolla, Anyma, Daya",
+        "Mason"
+      ]
+    },
+    {
+      "artist": "John Summit, HAYLA",
+      "title": "Shiver",
+      "year": 2024,
+      "isrc": "USUG12401003",
+      "uri": "spotify:track:32VIrOsJmwvqRm4rWFBCsi",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2877072812",
+      "fun_fact": "“Shiver” appears on John Summit’s release “Comfort In Chaos”.",
+      "fun_fact_de": "„Shiver“ erschien auf der Veröffentlichung „Comfort In Chaos“ von John Summit.",
+      "fun_fact_es": "«Shiver» aparece en el lanzamiento «Comfort In Chaos» de John Summit.",
+      "fun_fact_fr": "« Shiver » figure sur la publication « Comfort In Chaos » de John Summit.",
+      "fun_fact_nl": "‘Shiver’ staat op de release ‘Comfort In Chaos’ van John Summit.",
+      "alt_artists": [
+        "Armin van Buuren, Jan Vayne",
+        "L.P. Rhythm",
+        "Hypaton, David Guetta, La Bouche"
+      ]
+    },
+    {
+      "artist": "Becky Hill, Galantis",
+      "title": "Run",
+      "year": 2022,
+      "isrc": "GBUM72200712",
+      "uri": "spotify:track:6oYXbji1rn7U6bFuNYekpQ",
+      "uri_apple_music": "applemusic://track/1610154676",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1610154676"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1659968202",
+      "fun_fact": "“Run” is the title track of Becky Hill’s release of the same name.",
+      "fun_fact_de": "„Run“ ist der Titelsong der gleichnamigen Veröffentlichung von Becky Hill.",
+      "fun_fact_es": "«Run» es la canción que da título al lanzamiento homónimo de Becky Hill.",
+      "fun_fact_fr": "« Run » est le morceau-titre de la publication éponyme de Becky Hill.",
+      "fun_fact_nl": "‘Run’ is het titelnummer van de gelijknamige release van Becky Hill.",
+      "alt_artists": [
+        "Boris Brejcha, Ginger",
+        "ARTY, NK",
+        "Oxia"
+      ]
+    },
+    {
+      "artist": "ARTY",
+      "title": "Tim",
+      "year": 2018,
+      "isrc": "NLF711807497",
+      "uri": "spotify:track:4wmrfUPuvK9phVehREZZ1X",
+      "uri_apple_music": "applemusic://track/1408685591",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1408685591"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/524827952",
+      "fun_fact": "“Tim” is the title track of ARTY’s release of the same name.",
+      "fun_fact_de": "„Tim“ ist der Titelsong der gleichnamigen Veröffentlichung von ARTY.",
+      "fun_fact_es": "«Tim» es la canción que da título al lanzamiento homónimo de ARTY.",
+      "fun_fact_fr": "« Tim » est le morceau-titre de la publication éponyme de ARTY.",
+      "fun_fact_nl": "‘Tim’ is het titelnummer van de gelijknamige release van ARTY.",
+      "alt_artists": [
+        "Axwell, Max C",
+        "The Magician, Olly Alexander (Years & Years)",
+        "Dimitri Vegas & Like Mike, Sander van Doorn"
+      ]
+    },
+    {
+      "artist": "Kungs",
+      "title": "Never Going Home",
+      "year": 2021,
+      "isrc": "FR9W12110749",
+      "uri": "spotify:track:0xfMlIW8lS40qvpsUw1l0X",
+      "uri_apple_music": "applemusic://track/1566539919",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1566539919"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1372169352",
+      "fun_fact": "“Never Going Home” is the title track of Kungs’s release of the same name.",
+      "fun_fact_de": "„Never Going Home“ ist der Titelsong der gleichnamigen Veröffentlichung von Kungs.",
+      "fun_fact_es": "«Never Going Home» es la canción que da título al lanzamiento homónimo de Kungs.",
+      "fun_fact_fr": "« Never Going Home » est le morceau-titre de la publication éponyme de Kungs.",
+      "fun_fact_nl": "‘Never Going Home’ is het titelnummer van de gelijknamige release van Kungs.",
+      "alt_artists": [
+        "Tristan Garner, Norman Doray",
+        "Pleasurekraft",
+        "BICEP, Four Tet"
+      ]
+    },
+    {
+      "artist": "R3HAB, Deorro",
+      "title": "Flashlight",
+      "year": 2014,
+      "isrc": "NLZ541301022",
+      "uri": "spotify:track:4soJPaN3etpZC72tHZztw3",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/463375482",
+      "fun_fact": "“Flashlight” is the title track of R3HAB’s release of the same name.",
+      "fun_fact_de": "„Flashlight“ ist der Titelsong der gleichnamigen Veröffentlichung von R3HAB.",
+      "fun_fact_es": "«Flashlight» es la canción que da título al lanzamiento homónimo de R3HAB.",
+      "fun_fact_fr": "« Flashlight » est le morceau-titre de la publication éponyme de R3HAB.",
+      "fun_fact_nl": "‘Flashlight’ is het titelnummer van de gelijknamige release van R3HAB.",
+      "alt_artists": [
+        "Bob Sinclar, Steve Edwards",
+        "Rusko, Netsky",
+        "Armin van Buuren, Agents Of Time, ORKID"
+      ]
+    },
+    {
+      "artist": "Boris Brejcha, Laura Korinth",
+      "title": "Gravity (feat. Laura Korinth)",
+      "year": 2020,
+      "isrc": "USUS11900297",
+      "uri": "spotify:track:6bjHTATKGW2982YBO1gjYH",
+      "uri_apple_music": "applemusic://track/1714741682",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1714741682"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/759015342",
+      "fun_fact": "“Gravity (feat. Laura Korinth)” appears on Boris Brejcha’s release “Space Diver”.",
+      "fun_fact_de": "„Gravity (feat. Laura Korinth)“ erschien auf der Veröffentlichung „Space Diver“ von Boris Brejcha.",
+      "fun_fact_es": "«Gravity (feat. Laura Korinth)» aparece en el lanzamiento «Space Diver» de Boris Brejcha.",
+      "fun_fact_fr": "« Gravity (feat. Laura Korinth) » figure sur la publication « Space Diver » de Boris Brejcha.",
+      "fun_fact_nl": "‘Gravity (feat. Laura Korinth)’ staat op de release ‘Space Diver’ van Boris Brejcha.",
+      "alt_artists": [
+        "KAAZE, Alina Pozi",
+        "Boris Brejcha, Ginger",
+        "Friend Within"
+      ]
+    },
+    {
+      "artist": "Öwnboss, Sevek",
+      "title": "Move Your Body",
+      "year": 2021,
+      "isrc": "NLZ542101576",
+      "uri": "spotify:track:6GomT970rCOkKAyyrwJeZi",
+      "uri_apple_music": "applemusic://track/1589095808",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1589095808"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1514340882",
+      "fun_fact": "“Move Your Body” is the title track of Öwnboss’s release of the same name.",
+      "fun_fact_de": "„Move Your Body“ ist der Titelsong der gleichnamigen Veröffentlichung von Öwnboss.",
+      "fun_fact_es": "«Move Your Body» es la canción que da título al lanzamiento homónimo de Öwnboss.",
+      "fun_fact_fr": "« Move Your Body » est le morceau-titre de la publication éponyme de Öwnboss.",
+      "fun_fact_nl": "‘Move Your Body’ is het titelnummer van de gelijknamige release van Öwnboss.",
+      "alt_artists": [
+        "Swedish House Mafia, Tinie Tempah",
+        "Otto Knows",
+        "Coldplay, Swedish House Mafia"
+      ]
+    },
+    {
+      "artist": "Sub Focus, Dimension",
+      "title": "Ready To Fly",
+      "year": 2022,
+      "isrc": "GBUM72208256",
+      "uri": "spotify:track:7DCdoJx9mCpdxcyk5CtbBM",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2082295697",
+      "fun_fact": "“Ready To Fly” appears on Sub Focus’s release “Ready To Fly (Hardcore Mix)”.",
+      "fun_fact_de": "„Ready To Fly“ erschien auf der Veröffentlichung „Ready To Fly (Hardcore Mix)“ von Sub Focus.",
+      "fun_fact_es": "«Ready To Fly» aparece en el lanzamiento «Ready To Fly (Hardcore Mix)» de Sub Focus.",
+      "fun_fact_fr": "« Ready To Fly » figure sur la publication « Ready To Fly (Hardcore Mix) » de Sub Focus.",
+      "fun_fact_nl": "‘Ready To Fly’ staat op de release ‘Ready To Fly (Hardcore Mix)’ van Sub Focus.",
+      "alt_artists": [
+        "System F",
+        "DubVision, AFROJACK",
+        "Rampa, Adam Port, &ME, chuala, Keinemusik"
+      ]
+    },
+    {
+      "artist": "Bodyrox, Luciana, D. Ramirez",
+      "title": "Yeah Yeah - D Ramirez Vocal Radio Edit",
+      "year": 2006,
+      "isrc": "GBUM70604170",
+      "uri": "spotify:track:4HVGC52IogHANcKFA0QYiT",
+      "uri_apple_music": "applemusic://track/925691346",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/925691346"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/78304458",
+      "fun_fact": "“Yeah Yeah - D Ramirez Vocal Radio Edit” appears on Bodyrox’s release “Yeah Yeah”.",
+      "fun_fact_de": "„Yeah Yeah - D Ramirez Vocal Radio Edit“ erschien auf der Veröffentlichung „Yeah Yeah“ von Bodyrox.",
+      "fun_fact_es": "«Yeah Yeah - D Ramirez Vocal Radio Edit» aparece en el lanzamiento «Yeah Yeah» de Bodyrox.",
+      "fun_fact_fr": "« Yeah Yeah - D Ramirez Vocal Radio Edit » figure sur la publication « Yeah Yeah » de Bodyrox.",
+      "fun_fact_nl": "‘Yeah Yeah - D Ramirez Vocal Radio Edit’ staat op de release ‘Yeah Yeah’ van Bodyrox.",
+      "alt_artists": [
+        "ARTY",
+        "Steve Angello, The Presets",
+        "Dom Dolla, Anyma, Daya"
+      ]
+    },
+    {
+      "artist": "Tiësto",
+      "title": "Grapevine",
+      "year": 2018,
+      "isrc": "CYA111800373",
+      "uri": "spotify:track:3bYLRndI3qoLQqgPalT8CY",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/933168402",
+      "fun_fact": "“Grapevine” is the title track of Tiësto’s release of the same name.",
+      "fun_fact_de": "„Grapevine“ ist der Titelsong der gleichnamigen Veröffentlichung von Tiësto.",
+      "fun_fact_es": "«Grapevine» es la canción que da título al lanzamiento homónimo de Tiësto.",
+      "fun_fact_fr": "« Grapevine » est le morceau-titre de la publication éponyme de Tiësto.",
+      "fun_fact_nl": "‘Grapevine’ is het titelnummer van de gelijknamige release van Tiësto.",
+      "alt_artists": [
+        "Martin Solveig, Ina Wroldsen",
+        "Kelis",
+        "Red Hot Chili Peppers"
+      ]
+    },
+    {
+      "artist": "Alesso, Roy English",
+      "title": "Cool",
+      "year": 2015,
+      "isrc": "USUG11500056",
+      "uri": "spotify:track:2ToIksTPpJ4csKPEOdUEyM",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/100068942",
+      "fun_fact": "“Cool” appears on Alesso’s release “Forever”.",
+      "fun_fact_de": "„Cool“ erschien auf der Veröffentlichung „Forever“ von Alesso.",
+      "fun_fact_es": "«Cool» aparece en el lanzamiento «Forever» de Alesso.",
+      "fun_fact_fr": "« Cool » figure sur la publication « Forever » de Alesso.",
+      "fun_fact_nl": "‘Cool’ staat op de release ‘Forever’ van Alesso.",
+      "alt_artists": [
+        "Issey Cross, Tiësto",
+        "Joel Corry, James Hype",
+        "AFROJACK, NERVO, Dimitri Vegas & Like Mike"
+      ]
+    },
+    {
+      "artist": "Vintage Culture, Adam K, MKLA",
+      "title": "Deep Inside Of Me (feat. MKLA)",
+      "year": 2020,
+      "isrc": "NLZ541901790",
+      "uri": "spotify:track:1ZHT4WSOuZPAl82T4nKWEN",
+      "uri_apple_music": "applemusic://track/1491189215",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1491189215"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/853614092",
+      "fun_fact": "“Deep Inside Of Me (feat. MKLA)” is the title track of Vintage Culture’s release of the same name.",
+      "fun_fact_de": "„Deep Inside Of Me (feat. MKLA)“ ist der Titelsong der gleichnamigen Veröffentlichung von Vintage Culture.",
+      "fun_fact_es": "«Deep Inside Of Me (feat. MKLA)» es la canción que da título al lanzamiento homónimo de Vintage Culture.",
+      "fun_fact_fr": "« Deep Inside Of Me (feat. MKLA) » est le morceau-titre de la publication éponyme de Vintage Culture.",
+      "fun_fact_nl": "‘Deep Inside Of Me (feat. MKLA)’ is het titelnummer van de gelijknamige release van Vintage Culture.",
+      "alt_artists": [
+        "Jack Ü, Skrillex, Diplo, Kiesza, Tchami",
+        "Swedish House Mafia, Anyma, Future, Fred again..",
+        "Martin Solveig, Dragonette"
+      ]
+    },
+    {
+      "artist": "Mau P",
+      "title": "The Less I Know The Better",
+      "year": 2025,
+      "isrc": "USNRS2543977",
+      "uri": "spotify:track:7lDGg8CFySbkKUrjgzcLlY",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3205781411",
+      "fun_fact": "“The Less I Know The Better” is the title track of Mau P’s release of the same name.",
+      "fun_fact_de": "„The Less I Know The Better“ ist der Titelsong der gleichnamigen Veröffentlichung von Mau P.",
+      "fun_fact_es": "«The Less I Know The Better» es la canción que da título al lanzamiento homónimo de Mau P.",
+      "fun_fact_fr": "« The Less I Know The Better » est le morceau-titre de la publication éponyme de Mau P.",
+      "fun_fact_nl": "‘The Less I Know The Better’ is het titelnummer van de gelijknamige release van Mau P.",
+      "alt_artists": [
+        "Martin Garrix, Clinton Kane",
+        "Above & Beyond",
+        "Swedish House Mafia, Alicia Keys"
+      ]
+    },
+    {
+      "artist": "Martin Garrix, Sentinel, Bonn",
+      "title": "Hurricane",
+      "year": 2023,
+      "isrc": "DECE72301698",
+      "uri": "spotify:track:5RfVafaeEEiqC0Z3LsBaZw",
+      "uri_apple_music": "applemusic://track/1688990932",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1688990932"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2300123815",
+      "fun_fact": "“Hurricane” is the title track of Martin Garrix’s release of the same name.",
+      "fun_fact_de": "„Hurricane“ ist der Titelsong der gleichnamigen Veröffentlichung von Martin Garrix.",
+      "fun_fact_es": "«Hurricane» es la canción que da título al lanzamiento homónimo de Martin Garrix.",
+      "fun_fact_fr": "« Hurricane » est le morceau-titre de la publication éponyme de Martin Garrix.",
+      "fun_fact_nl": "‘Hurricane’ is het titelnummer van de gelijknamige release van Martin Garrix.",
+      "alt_artists": [
+        "Yves V, HIDDN",
+        "Nosi",
+        "Duke Dumont"
+      ]
+    },
+    {
+      "artist": "Dom Dolla",
+      "title": "San Frandisco",
+      "year": 2017,
+      "isrc": "AUDCB1701462",
+      "uri": "spotify:track:4KrATQEoEbKAAY7j0kMDBl",
+      "uri_apple_music": "applemusic://track/1479872574",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1479872574"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/753716852",
+      "fun_fact": "“San Frandisco” is the title track of Dom Dolla’s release of the same name.",
+      "fun_fact_de": "„San Frandisco“ ist der Titelsong der gleichnamigen Veröffentlichung von Dom Dolla.",
+      "fun_fact_es": "«San Frandisco» es la canción que da título al lanzamiento homónimo de Dom Dolla.",
+      "fun_fact_fr": "« San Frandisco » est le morceau-titre de la publication éponyme de Dom Dolla.",
+      "fun_fact_nl": "‘San Frandisco’ is het titelnummer van de gelijknamige release van Dom Dolla.",
+      "alt_artists": [
+        "Eric Prydz",
+        "Disciples",
+        "Solardo, Eli Brown"
+      ]
+    },
+    {
+      "artist": "Tchami",
+      "title": "Untrue",
+      "year": 2014,
+      "isrc": "NLZ541400208",
+      "uri": "spotify:track:1oLbINncYZfnAMTgLbrLpF",
+      "uri_apple_music": "applemusic://track/1114633426",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1114633426"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/452697612",
+      "fun_fact": "“Untrue” is the title track of Tchami’s release of the same name.",
+      "fun_fact_de": "„Untrue“ ist der Titelsong der gleichnamigen Veröffentlichung von Tchami.",
+      "fun_fact_es": "«Untrue» es la canción que da título al lanzamiento homónimo de Tchami.",
+      "fun_fact_fr": "« Untrue » est le morceau-titre de la publication éponyme de Tchami.",
+      "fun_fact_nl": "‘Untrue’ is het titelnummer van de gelijknamige release van Tchami.",
+      "alt_artists": [
+        "Coldplay, Swedish House Mafia",
+        "Bruno Mars, Shepard, Sultan",
+        "CHRIS STASSY"
+      ]
+    },
+    {
+      "artist": "Rune RK, Firebeatz",
+      "title": "Calabria - Firebeatz Remix",
+      "year": 2014,
+      "isrc": "DKJM31400201",
+      "uri": "spotify:track:6lYdV7rTtv3dVpQ89htlRU",
+      "uri_apple_music": "applemusic://track/1711642972",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1711642972"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/459401112",
+      "fun_fact": "“Calabria - Firebeatz Remix” is the title track of Rune RK’s release of the same name.",
+      "fun_fact_de": "„Calabria - Firebeatz Remix“ ist der Titelsong der gleichnamigen Veröffentlichung von Rune RK.",
+      "fun_fact_es": "«Calabria - Firebeatz Remix» es la canción que da título al lanzamiento homónimo de Rune RK.",
+      "fun_fact_fr": "« Calabria - Firebeatz Remix » est le morceau-titre de la publication éponyme de Rune RK.",
+      "fun_fact_nl": "‘Calabria - Firebeatz Remix’ is het titelnummer van de gelijknamige release van Rune RK.",
+      "alt_artists": [
+        "Krystal Klear",
+        "Porter Robinson",
+        "Niels Van Gogh, Tiësto"
+      ]
+    },
+    {
+      "artist": "Swedish House Mafia, Niki & The Dove",
+      "title": "Lioness",
+      "year": 2024,
+      "isrc": "USUG12403371",
+      "uri": "spotify:track:73rh3AJNXQl8iMWgWRrQTR",
+      "uri_apple_music": "applemusic://track/1749175517",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1749175517"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2826480192",
+      "fun_fact": "“Lioness” is the title track of Swedish House Mafia’s release of the same name.",
+      "fun_fact_de": "„Lioness“ ist der Titelsong der gleichnamigen Veröffentlichung von Swedish House Mafia.",
+      "fun_fact_es": "«Lioness» es la canción que da título al lanzamiento homónimo de Swedish House Mafia.",
+      "fun_fact_fr": "« Lioness » est le morceau-titre de la publication éponyme de Swedish House Mafia.",
+      "fun_fact_nl": "‘Lioness’ is het titelnummer van de gelijknamige release van Swedish House Mafia.",
+      "alt_artists": [
+        "Armin van Buuren, Sam Gray",
+        "Zedd, Matthew Koma",
+        "Steve Aoki, KAAZE, John Martin"
+      ]
+    },
+    {
+      "artist": "Laidback Luke, Steve Aoki, Lil Jon",
+      "title": "Turbulence",
+      "year": 2011,
+      "isrc": "NLBW51100020",
+      "uri": "spotify:track:6D3TI6EZuPtdJZyejGuesp",
+      "uri_apple_music": "applemusic://track/1714495177",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1714495177"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3424170731",
+      "fun_fact": "“Turbulence” is the title track of Laidback Luke’s release of the same name.",
+      "fun_fact_de": "„Turbulence“ ist der Titelsong der gleichnamigen Veröffentlichung von Laidback Luke.",
+      "fun_fact_es": "«Turbulence» es la canción que da título al lanzamiento homónimo de Laidback Luke.",
+      "fun_fact_fr": "« Turbulence » est le morceau-titre de la publication éponyme de Laidback Luke.",
+      "fun_fact_nl": "‘Turbulence’ is het titelnummer van de gelijknamige release van Laidback Luke.",
+      "alt_artists": [
+        "Overmono",
+        "The Killers, Jacques Lu Cont",
+        "Au/Ra, CamelPhat"
+      ]
+    },
+    {
+      "artist": "Noizu",
+      "title": "Summer 91 (Looking Back)",
+      "year": 2021,
+      "isrc": "GBARL2001582",
+      "uri": "spotify:track:4FEcEwbE2vsqhxbTPtiNTL",
+      "uri_apple_music": "applemusic://track/1543037572",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1543037572"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1163136562",
+      "fun_fact": "“Summer 91 (Looking Back)” is the title track of Noizu’s release of the same name.",
+      "fun_fact_de": "„Summer 91 (Looking Back)“ ist der Titelsong der gleichnamigen Veröffentlichung von Noizu.",
+      "fun_fact_es": "«Summer 91 (Looking Back)» es la canción que da título al lanzamiento homónimo de Noizu.",
+      "fun_fact_fr": "« Summer 91 (Looking Back) » est le morceau-titre de la publication éponyme de Noizu.",
+      "fun_fact_nl": "‘Summer 91 (Looking Back)’ is het titelnummer van de gelijknamige release van Noizu.",
+      "alt_artists": [
+        "Martin Garrix, Julian Jordan",
+        "BLOND:ISH, Stevie Appleton",
+        "Fragma"
+      ]
+    },
+    {
+      "artist": "Steve Angello, Third Party",
+      "title": "Lights",
+      "year": 2012,
+      "isrc": "GBXGT1200233",
+      "uri": "spotify:track:4EoHnRqDHIpRJCiFuL3VJH",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/61427204",
+      "fun_fact": "“Lights” appears on Steve Angello’s release “Until Now”.",
+      "fun_fact_de": "„Lights“ erschien auf der Veröffentlichung „Until Now“ von Steve Angello.",
+      "fun_fact_es": "«Lights» aparece en el lanzamiento «Until Now» de Steve Angello.",
+      "fun_fact_fr": "« Lights » figure sur la publication « Until Now » de Steve Angello.",
+      "fun_fact_nl": "‘Lights’ staat op de release ‘Until Now’ van Steve Angello.",
+      "alt_artists": [
+        "DR. KUCHO!, Gregor Salto, Ane Brun, Oliver Heldens",
+        "Fred again.., The Blessed Madonna",
+        "Mr. Probz, Chris Brown, T.I."
+      ]
+    },
+    {
+      "artist": "Pegassi",
+      "title": "Yoyoyo",
+      "year": 2023,
+      "isrc": "DEUM72302181",
+      "uri": "spotify:track:3mjpUhSiUbEvaPdxikuEZI",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2216994887",
+      "fun_fact": "“Yoyoyo” is the title track of Pegassi’s release of the same name.",
+      "fun_fact_de": "„Yoyoyo“ ist der Titelsong der gleichnamigen Veröffentlichung von Pegassi.",
+      "fun_fact_es": "«Yoyoyo» es la canción que da título al lanzamiento homónimo de Pegassi.",
+      "fun_fact_fr": "« Yoyoyo » est le morceau-titre de la publication éponyme de Pegassi.",
+      "fun_fact_nl": "‘Yoyoyo’ is het titelnummer van de gelijknamige release van Pegassi.",
+      "alt_artists": [
+        "CamelPhat",
+        "Swedish House Mafia, Sting",
+        "Martin Garrix, Justin Mylo, Dewain Whitmore"
+      ]
+    },
+    {
+      "artist": "Paul Kalkbrenner",
+      "title": "No Goodbye",
+      "year": 2019,
+      "isrc": "DEE861902725",
+      "uri": "spotify:track:5gwLIRjGFf3hXuHoKEsWLg",
+      "uri_apple_music": "applemusic://track/1472498511",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1472498511"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/716940982",
+      "fun_fact": "“No Goodbye” is the title track of Paul Kalkbrenner’s release of the same name.",
+      "fun_fact_de": "„No Goodbye“ ist der Titelsong der gleichnamigen Veröffentlichung von Paul Kalkbrenner.",
+      "fun_fact_es": "«No Goodbye» es la canción que da título al lanzamiento homónimo de Paul Kalkbrenner.",
+      "fun_fact_fr": "« No Goodbye » est le morceau-titre de la publication éponyme de Paul Kalkbrenner.",
+      "fun_fact_nl": "‘No Goodbye’ is het titelnummer van de gelijknamige release van Paul Kalkbrenner.",
+      "alt_artists": [
+        "Avicii",
+        "Dirty South, Rudy, Axwell",
+        "Steve Angello, Matisse & Sadko"
+      ]
+    },
+    {
+      "artist": "ODESZA, Cedric Gervais, Zyra",
+      "title": "Say My Name (feat. Zyra) - Remix Edit",
+      "year": 2015,
+      "isrc": "NLZ541500590",
+      "uri": "spotify:track:5nwcPl5fG6Rx1IWPsaUJI9",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1406260312",
+      "fun_fact": "“Say My Name (feat. Zyra) - Remix Edit” appears on ODESZA’s release “Say My Name (feat. Zyra) (Remix)”.",
+      "fun_fact_de": "„Say My Name (feat. Zyra) - Remix Edit“ erschien auf der Veröffentlichung „Say My Name (feat. Zyra) (Remix)“ von ODESZA.",
+      "fun_fact_es": "«Say My Name (feat. Zyra) - Remix Edit» aparece en el lanzamiento «Say My Name (feat. Zyra) (Remix)» de ODESZA.",
+      "fun_fact_fr": "« Say My Name (feat. Zyra) - Remix Edit » figure sur la publication « Say My Name (feat. Zyra) (Remix) » de ODESZA.",
+      "fun_fact_nl": "‘Say My Name (feat. Zyra) - Remix Edit’ staat op de release ‘Say My Name (feat. Zyra) (Remix)’ van ODESZA.",
+      "alt_artists": [
+        "Martin Garrix, Mike Yung, Nicky Romero",
+        "Peggy Gou",
+        "Dj Bountyhunter"
+      ]
+    },
+    {
+      "artist": "Switch",
+      "title": "A Bit Patchy - Eric Prydz Remix",
+      "year": 2007,
+      "isrc": "GBCEN0600071",
+      "uri": "spotify:track:0GUpNPgynHE3YO3epQFZqY",
+      "uri_apple_music": "applemusic://track/1266015035",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1266015035"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2215971117",
+      "fun_fact": "“A Bit Patchy - Eric Prydz Remix” appears on Switch’s release “La Rocca (Club Classics)”.",
+      "fun_fact_de": "„A Bit Patchy - Eric Prydz Remix“ erschien auf der Veröffentlichung „La Rocca (Club Classics)“ von Switch.",
+      "fun_fact_es": "«A Bit Patchy - Eric Prydz Remix» aparece en el lanzamiento «La Rocca (Club Classics)» de Switch.",
+      "fun_fact_fr": "« A Bit Patchy - Eric Prydz Remix » figure sur la publication « La Rocca (Club Classics) » de Switch.",
+      "fun_fact_nl": "‘A Bit Patchy - Eric Prydz Remix’ staat op de release ‘La Rocca (Club Classics)’ van Switch.",
+      "alt_artists": [
+        "Stardust, Benjamin Diamond, Alan Braxe, Thomas Bangalter",
+        "Samm",
+        "Kaskade, Punctual, Poppy Baskcomb"
+      ]
+    },
+    {
+      "artist": "Charlotte de Witte",
+      "title": "Doppler",
+      "year": 2021,
+      "isrc": "BE4JP2000015",
+      "uri": "spotify:track:7J2ZnqSaDNijHboyFFkwpV",
+      "uri_apple_music": "applemusic://track/1678835626",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1678835626"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2206349367",
+      "fun_fact": "“Doppler” appears on Charlotte de Witte’s release “Formula EP”.",
+      "fun_fact_de": "„Doppler“ erschien auf der Veröffentlichung „Formula EP“ von Charlotte de Witte.",
+      "fun_fact_es": "«Doppler» aparece en el lanzamiento «Formula EP» de Charlotte de Witte.",
+      "fun_fact_fr": "« Doppler » figure sur la publication « Formula EP » de Charlotte de Witte.",
+      "fun_fact_nl": "‘Doppler’ staat op de release ‘Formula EP’ van Charlotte de Witte.",
+      "alt_artists": [
+        "Konstantin Sibold, Adam Sellouk",
+        "AVAION, Sofiya Nzau",
+        "Dimitri Vegas & Like Mike, W&W"
+      ]
+    },
+    {
+      "artist": "Alesso",
+      "title": "Nillionaire",
+      "year": 2011,
+      "isrc": "GBJ4B1100034",
+      "uri": "spotify:track:4Bvo4KWHOoAXipiJc1Gc6W",
+      "uri_apple_music": "applemusic://track/947442600",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/947442600"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/91185505",
+      "fun_fact": "“Nillionaire” appears on Alesso’s release “Dynamite”.",
+      "fun_fact_de": "„Nillionaire“ erschien auf der Veröffentlichung „Dynamite“ von Alesso.",
+      "fun_fact_es": "«Nillionaire» aparece en el lanzamiento «Dynamite» de Alesso.",
+      "fun_fact_fr": "« Nillionaire » figure sur la publication « Dynamite » de Alesso.",
+      "fun_fact_nl": "‘Nillionaire’ staat op de release ‘Dynamite’ van Alesso.",
+      "alt_artists": [
+        "Parachute Youth",
+        "Afro Medusa",
+        "Skrillex, Boys Noize, Opus III"
+      ]
+    },
+    {
+      "artist": "Henri PFR, Raphaella",
+      "title": "Until the End (feat. Raphaella)",
+      "year": 2016,
+      "isrc": "BEDX21600001",
+      "uri": "spotify:track:61VEcQZQZUF4o7QgXsOFjB",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/134523166",
+      "fun_fact": "“Until the End (feat. Raphaella)” is the title track of Henri PFR’s release of the same name.",
+      "fun_fact_de": "„Until the End (feat. Raphaella)“ ist der Titelsong der gleichnamigen Veröffentlichung von Henri PFR.",
+      "fun_fact_es": "«Until the End (feat. Raphaella)» es la canción que da título al lanzamiento homónimo de Henri PFR.",
+      "fun_fact_fr": "« Until the End (feat. Raphaella) » est le morceau-titre de la publication éponyme de Henri PFR.",
+      "fun_fact_nl": "‘Until the End (feat. Raphaella)’ is het titelnummer van de gelijknamige release van Henri PFR.",
+      "alt_artists": [
+        "Vintage Culture, Adam K, MKLA",
+        "Niels Van Gogh, Tiësto",
+        "Calvin Harris, Ellie Goulding"
+      ]
+    },
+    {
+      "artist": "Dimitri Vegas & Like Mike, Bassjackers, D'Angello & Francis",
+      "title": "The Flight",
+      "year": 2019,
+      "isrc": "BEG851900083",
+      "uri": "spotify:track:6dwVoXGSsQ1TTL5aw987pi",
+      "uri_apple_music": "applemusic://track/1476924807",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1476924807"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/734273642",
+      "fun_fact": "“The Flight” is the title track of Dimitri Vegas & Like Mike’s release of the same name.",
+      "fun_fact_de": "„The Flight“ ist der Titelsong der gleichnamigen Veröffentlichung von Dimitri Vegas & Like Mike.",
+      "fun_fact_es": "«The Flight» es la canción que da título al lanzamiento homónimo de Dimitri Vegas & Like Mike.",
+      "fun_fact_fr": "« The Flight » est le morceau-titre de la publication éponyme de Dimitri Vegas & Like Mike.",
+      "fun_fact_nl": "‘The Flight’ is het titelnummer van de gelijknamige release van Dimitri Vegas & Like Mike.",
+      "alt_artists": [
+        "felix jaehn, Sandro Cavazza",
+        "Alesso, Becky Hill",
+        "Fred again.., 070 Shake"
+      ]
+    },
+    {
+      "artist": "Dim Chris, Sebastien Drums, Avicii",
+      "title": "Sometimes I Feel - Avicii's Out of Miami Mix",
+      "year": 2009,
+      "isrc": "DELM40900834",
+      "uri": "spotify:track:2zWawHWvesDYHXDyKf0ENx",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3477966851",
+      "fun_fact": "“Sometimes I Feel - Avicii's Out of Miami Mix” appears on Dim Chris’s release “House Is a Feeling, Vol. 4”.",
+      "fun_fact_de": "„Sometimes I Feel - Avicii's Out of Miami Mix“ erschien auf der Veröffentlichung „House Is a Feeling, Vol. 4“ von Dim Chris.",
+      "fun_fact_es": "«Sometimes I Feel - Avicii's Out of Miami Mix» aparece en el lanzamiento «House Is a Feeling, Vol. 4» de Dim Chris.",
+      "fun_fact_fr": "« Sometimes I Feel - Avicii's Out of Miami Mix » figure sur la publication « House Is a Feeling, Vol. 4 » de Dim Chris.",
+      "fun_fact_nl": "‘Sometimes I Feel - Avicii's Out of Miami Mix’ staat op de release ‘House Is a Feeling, Vol. 4’ van Dim Chris.",
+      "alt_artists": [
+        "Porter Robinson",
+        "Mark Knight",
+        "Alesso, TINI"
+      ]
+    },
+    {
+      "artist": "Calvin Harris, Clementine Douglas",
+      "title": "Blessings",
+      "year": 2025,
+      "isrc": "GBARL2500591",
+      "uri": "spotify:track:78nx0HDJIFD5xDq2L5420Z",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3344642921",
+      "fun_fact": "“Blessings” is the title track of Calvin Harris’s release of the same name.",
+      "fun_fact_de": "„Blessings“ ist der Titelsong der gleichnamigen Veröffentlichung von Calvin Harris.",
+      "fun_fact_es": "«Blessings» es la canción que da título al lanzamiento homónimo de Calvin Harris.",
+      "fun_fact_fr": "« Blessings » est le morceau-titre de la publication éponyme de Calvin Harris.",
+      "fun_fact_nl": "‘Blessings’ is het titelnummer van de gelijknamige release van Calvin Harris.",
+      "alt_artists": [
+        "Alan Fitzpatrick",
+        "AVAION, Sofiya Nzau",
+        "Dom Dolla, Anyma, Daya"
+      ]
+    },
+    {
+      "artist": "Rolando",
+      "title": "Knights of the Jaguar",
+      "year": 2009,
+      "isrc": "USGUM0910150",
+      "uri": "spotify:track:3xxARypr8NdEMesYUHSsGK",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/11899030",
+      "fun_fact": "“Knights of the Jaguar” appears on Rolando’s release “Somewhere In Detroit Mix Series Vol.1”.",
+      "fun_fact_de": "„Knights of the Jaguar“ erschien auf der Veröffentlichung „Somewhere In Detroit Mix Series Vol.1“ von Rolando.",
+      "fun_fact_es": "«Knights of the Jaguar» aparece en el lanzamiento «Somewhere In Detroit Mix Series Vol.1» de Rolando.",
+      "fun_fact_fr": "« Knights of the Jaguar » figure sur la publication « Somewhere In Detroit Mix Series Vol.1 » de Rolando.",
+      "fun_fact_nl": "‘Knights of the Jaguar’ staat op de release ‘Somewhere In Detroit Mix Series Vol.1’ van Rolando.",
+      "alt_artists": [
+        "R3HAB, NERVO, Ummet Ozcan",
+        "Mr. Belt & Wezol",
+        "Mike Williams, Mesto"
+      ]
+    },
+    {
+      "artist": "ARTY",
+      "title": "Around The World - Original Mix",
+      "year": 2022,
+      "isrc": "GBEWA2205774",
+      "uri": "spotify:track:5wzagq4OmVPBd53zd7ngLo",
+      "uri_apple_music": "applemusic://track/446739874",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/446739874"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1916682377",
+      "fun_fact": "“Around The World - Original Mix” appears on ARTY’s release “ALPHA 9: The Story So Far”.",
+      "fun_fact_de": "„Around The World - Original Mix“ erschien auf der Veröffentlichung „ALPHA 9: The Story So Far“ von ARTY.",
+      "fun_fact_es": "«Around The World - Original Mix» aparece en el lanzamiento «ALPHA 9: The Story So Far» de ARTY.",
+      "fun_fact_fr": "« Around The World - Original Mix » figure sur la publication « ALPHA 9: The Story So Far » de ARTY.",
+      "fun_fact_nl": "‘Around The World - Original Mix’ staat op de release ‘ALPHA 9: The Story So Far’ van ARTY.",
+      "alt_artists": [
+        "Bob Sinclar, FISHER, Steve Edwards",
+        "Kaskade, deadmau5",
+        "Yves V, AFROJACK, Icona Pop"
+      ]
+    },
+    {
+      "artist": "Bob Sinclar, Steve Edwards",
+      "title": "World Hold On (Children of the Sky) - Radio Edit",
+      "year": 2006,
+      "isrc": "FR4E41811690",
+      "uri": "spotify:track:3HGwI9qwq5XqBDeZBV3zti",
+      "uri_apple_music": "applemusic://track/1727362089",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1727362089"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2633773772",
+      "fun_fact": "“World Hold On (Children of the Sky) - Radio Edit” is the title track of Bob Sinclar’s release of the same name.",
+      "fun_fact_de": "„World Hold On (Children of the Sky) - Radio Edit“ ist der Titelsong der gleichnamigen Veröffentlichung von Bob Sinclar.",
+      "fun_fact_es": "«World Hold On (Children of the Sky) - Radio Edit» es la canción que da título al lanzamiento homónimo de Bob Sinclar.",
+      "fun_fact_fr": "« World Hold On (Children of the Sky) - Radio Edit » est le morceau-titre de la publication éponyme de Bob Sinclar.",
+      "fun_fact_nl": "‘World Hold On (Children of the Sky) - Radio Edit’ is het titelnummer van de gelijknamige release van Bob Sinclar.",
+      "alt_artists": [
+        "CHRIS STASSY",
+        "London Grammar",
+        "Mike Williams, Mesto"
+      ]
+    },
+    {
+      "artist": "Third Party",
+      "title": "Higher",
+      "year": 2019,
+      "isrc": "USA2P1916081",
+      "uri": "spotify:track:6yFr1EttdGjMuqLEkZbVQi",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1564802162",
+      "fun_fact": "“Higher” appears on Third Party’s release “TOGETHER”.",
+      "fun_fact_de": "„Higher“ erschien auf der Veröffentlichung „TOGETHER“ von Third Party.",
+      "fun_fact_es": "«Higher» aparece en el lanzamiento «TOGETHER» de Third Party.",
+      "fun_fact_fr": "« Higher » figure sur la publication « TOGETHER » de Third Party.",
+      "fun_fact_nl": "‘Higher’ staat op de release ‘TOGETHER’ van Third Party.",
+      "alt_artists": [
+        "MOGUAI, Cheat Codes",
+        "BURNS",
+        "AFROJACK, NERVO, Dimitri Vegas & Like Mike"
+      ]
+    },
+    {
+      "artist": "Oden & Fatzo",
+      "title": "Lauren (I Can't Stay Forever)",
+      "year": 2021,
+      "isrc": "DEE862102011",
+      "uri": "spotify:track:33tYADyL2aZctrvR59K1bQ",
+      "uri_apple_music": "applemusic://track/1586652842",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1586652842"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1498985822",
+      "fun_fact": "“Lauren (I Can't Stay Forever)” is the title track of Oden & Fatzo’s release of the same name.",
+      "fun_fact_de": "„Lauren (I Can't Stay Forever)“ ist der Titelsong der gleichnamigen Veröffentlichung von Oden & Fatzo.",
+      "fun_fact_es": "«Lauren (I Can't Stay Forever)» es la canción que da título al lanzamiento homónimo de Oden & Fatzo.",
+      "fun_fact_fr": "« Lauren (I Can't Stay Forever) » est le morceau-titre de la publication éponyme de Oden & Fatzo.",
+      "fun_fact_nl": "‘Lauren (I Can't Stay Forever)’ is het titelnummer van de gelijknamige release van Oden & Fatzo.",
+      "alt_artists": [
+        "Nicky Romero, NERVO",
+        "David Guetta, Chris Willis, Fred Riesterer, Joachim Garraud",
+        "Cassius"
+      ]
+    },
+    {
+      "artist": "Showtek, Justin Prime",
+      "title": "Cannonball - Radio Edit",
+      "year": 2012,
+      "isrc": "NLC281211989",
+      "uri": "spotify:track:2CYXttmf0SMgzJ0lODtnBT",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2463022925",
+      "fun_fact": "“Cannonball - Radio Edit” appears on Showtek’s release “Cannonball”.",
+      "fun_fact_de": "„Cannonball - Radio Edit“ erschien auf der Veröffentlichung „Cannonball“ von Showtek.",
+      "fun_fact_es": "«Cannonball - Radio Edit» aparece en el lanzamiento «Cannonball» de Showtek.",
+      "fun_fact_fr": "« Cannonball - Radio Edit » figure sur la publication « Cannonball » de Showtek.",
+      "fun_fact_nl": "‘Cannonball - Radio Edit’ staat op de release ‘Cannonball’ van Showtek.",
+      "alt_artists": [
+        "David Tort, Gosha",
+        "R3HAB, Deorro",
+        "Calvin Harris"
+      ]
+    },
+    {
+      "artist": "Calvin Harris, Disciples, Chris Lake",
+      "title": "How Deep Is Your Love - Chris Lake Remix",
+      "year": 2015,
+      "isrc": "GBARL1501087",
+      "uri": "spotify:track:7foafyqmJYUdhGBpIusueW",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/105278286",
+      "fun_fact": "“How Deep Is Your Love - Chris Lake Remix” appears on Calvin Harris’s release “How Deep Is Your Love (Remixes)”.",
+      "fun_fact_de": "„How Deep Is Your Love - Chris Lake Remix“ erschien auf der Veröffentlichung „How Deep Is Your Love (Remixes)“ von Calvin Harris.",
+      "fun_fact_es": "«How Deep Is Your Love - Chris Lake Remix» aparece en el lanzamiento «How Deep Is Your Love (Remixes)» de Calvin Harris.",
+      "fun_fact_fr": "« How Deep Is Your Love - Chris Lake Remix » figure sur la publication « How Deep Is Your Love (Remixes) » de Calvin Harris.",
+      "fun_fact_nl": "‘How Deep Is Your Love - Chris Lake Remix’ staat op de release ‘How Deep Is Your Love (Remixes)’ van Calvin Harris.",
+      "alt_artists": [
+        "Alesso, Sentinel",
+        "Marian Hill, Franky Rizardo",
+        "Armin van Buuren, Agents Of Time, ORKID"
+      ]
+    },
+    {
+      "artist": "Tommy Trash",
+      "title": "Cascade - Original Mix",
+      "year": 2012,
+      "isrc": "NLF711204427",
+      "uri": "spotify:track:0wAFfYyVfhtBCnp66GxRJU",
+      "uri_apple_music": "applemusic://track/533804034",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/533804034"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/46678171",
+      "fun_fact": "“Cascade - Original Mix” appears on Tommy Trash’s release “We Are Planet Perfecto, Vol. 2 (Mixed By Paul Oakenfold)”.",
+      "fun_fact_de": "„Cascade - Original Mix“ erschien auf der Veröffentlichung „We Are Planet Perfecto, Vol. 2 (Mixed By Paul Oakenfold)“ von Tommy Trash.",
+      "fun_fact_es": "«Cascade - Original Mix» aparece en el lanzamiento «We Are Planet Perfecto, Vol. 2 (Mixed By Paul Oakenfold)» de Tommy Trash.",
+      "fun_fact_fr": "« Cascade - Original Mix » figure sur la publication « We Are Planet Perfecto, Vol. 2 (Mixed By Paul Oakenfold) » de Tommy Trash.",
+      "fun_fact_nl": "‘Cascade - Original Mix’ staat op de release ‘We Are Planet Perfecto, Vol. 2 (Mixed By Paul Oakenfold)’ van Tommy Trash.",
+      "alt_artists": [
+        "MEDUZA, Goodboys",
+        "Ben Böhmer",
+        "Zedd, Hayley Williams, Tiësto"
+      ]
+    },
+    {
+      "artist": "Rebūke, Konstantin Sibold, ZAC, CARMEE",
+      "title": "Along Came Polly (Konstantin Sibold, ZAC, CARMEE Remix)",
+      "year": 2024,
+      "isrc": "DEEC33501609",
+      "uri": "spotify:track:5EkSIWWEX7zkFTtSO28vT7",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2946079901",
+      "fun_fact": "“Along Came Polly (Konstantin Sibold, ZAC, CARMEE Remix)” is the title track of Rebūke’s release of the same name.",
+      "fun_fact_de": "„Along Came Polly (Konstantin Sibold, ZAC, CARMEE Remix)“ ist der Titelsong der gleichnamigen Veröffentlichung von Rebūke.",
+      "fun_fact_es": "«Along Came Polly (Konstantin Sibold, ZAC, CARMEE Remix)» es la canción que da título al lanzamiento homónimo de Rebūke.",
+      "fun_fact_fr": "« Along Came Polly (Konstantin Sibold, ZAC, CARMEE Remix) » est le morceau-titre de la publication éponyme de Rebūke.",
+      "fun_fact_nl": "‘Along Came Polly (Konstantin Sibold, ZAC, CARMEE Remix)’ is het titelnummer van de gelijknamige release van Rebūke.",
+      "alt_artists": [
+        "M.A.N.D.Y., Booka Shade",
+        "Zonderling, Don Diablo",
+        "Lost Frequencies, Zonderling"
+      ]
+    },
+    {
+      "artist": "Martin Garrix, Matisse & Sadko",
+      "title": "Dragon - Radio Edit",
+      "year": 2015,
+      "isrc": "NLZ541500466",
+      "uri": "spotify:track:13yeSbqDD7JSd7EWMOATV1",
+      "uri_apple_music": "applemusic://track/1350851534",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1350851534"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/463377172",
+      "fun_fact": "“Dragon - Radio Edit” appears on Martin Garrix’s release “Break Through The Silence EP”.",
+      "fun_fact_de": "„Dragon - Radio Edit“ erschien auf der Veröffentlichung „Break Through The Silence EP“ von Martin Garrix.",
+      "fun_fact_es": "«Dragon - Radio Edit» aparece en el lanzamiento «Break Through The Silence EP» de Martin Garrix.",
+      "fun_fact_fr": "« Dragon - Radio Edit » figure sur la publication « Break Through The Silence EP » de Martin Garrix.",
+      "fun_fact_nl": "‘Dragon - Radio Edit’ staat op de release ‘Break Through The Silence EP’ van Martin Garrix.",
+      "alt_artists": [
+        "Armin van Buuren, Sharon Den Adel",
+        "Dimitri Vegas & Like Mike, W&W",
+        "deadmau5"
+      ]
+    },
+    {
+      "artist": "Armand Van Helden, Duane Harden",
+      "title": "You Don't Know Me (feat. Duane Harden) - Radio Edit",
+      "year": 1998,
+      "isrc": "GBANR9800212",
+      "uri": "spotify:track:7BpyfQEmvi0sUmOq29plEE",
+      "uri_apple_music": "applemusic://track/1444240382",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1444240382"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/603415762",
+      "fun_fact": "“You Don't Know Me (feat. Duane Harden) - Radio Edit” appears on Armand Van Helden’s release “You Don't Know Me (feat. Duane Harden)”.",
+      "fun_fact_de": "„You Don't Know Me (feat. Duane Harden) - Radio Edit“ erschien auf der Veröffentlichung „You Don't Know Me (feat. Duane Harden)“ von Armand Van Helden.",
+      "fun_fact_es": "«You Don't Know Me (feat. Duane Harden) - Radio Edit» aparece en el lanzamiento «You Don't Know Me (feat. Duane Harden)» de Armand Van Helden.",
+      "fun_fact_fr": "« You Don't Know Me (feat. Duane Harden) - Radio Edit » figure sur la publication « You Don't Know Me (feat. Duane Harden) » de Armand Van Helden.",
+      "fun_fact_nl": "‘You Don't Know Me (feat. Duane Harden) - Radio Edit’ staat op de release ‘You Don't Know Me (feat. Duane Harden)’ van Armand Van Helden.",
+      "alt_artists": [
+        "Zonderling, Don Diablo",
+        "Fish Go Deep, Tracey K, Dennis Ferrer",
+        "Yves V, Matthew Hill, Adrian Lux"
+      ]
+    },
+    {
+      "artist": "Ahmed Spins, Stevo Atambire",
+      "title": "Anchor Point",
+      "year": 2022,
+      "isrc": "ITFGO2200044",
+      "uri": "spotify:track:6tE5zuD7eC7cV2O1IyjRLX",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2161608047",
+      "fun_fact": "“Anchor Point” appears on Ahmed Spins’s release “Anchor Point EP”.",
+      "fun_fact_de": "„Anchor Point“ erschien auf der Veröffentlichung „Anchor Point EP“ von Ahmed Spins.",
+      "fun_fact_es": "«Anchor Point» aparece en el lanzamiento «Anchor Point EP» de Ahmed Spins.",
+      "fun_fact_fr": "« Anchor Point » figure sur la publication « Anchor Point EP » de Ahmed Spins.",
+      "fun_fact_nl": "‘Anchor Point’ staat op de release ‘Anchor Point EP’ van Ahmed Spins.",
+      "alt_artists": [
+        "Steve Angello, The Presets",
+        "BICEP, Four Tet",
+        "Tchami"
+      ]
+    },
+    {
+      "artist": "Alan Walker, Tiësto",
+      "title": "Faded - Tiesto's Northern Lights Remix",
+      "year": 2016,
+      "isrc": "SEBGA1600374",
+      "uri": "spotify:track:7MDobIiZKLbDDibHDA1fl8",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/140295639",
+      "fun_fact": "“Faded - Tiesto's Northern Lights Remix” appears on Alan Walker’s release “Faded (Remixes)”.",
+      "fun_fact_de": "„Faded - Tiesto's Northern Lights Remix“ erschien auf der Veröffentlichung „Faded (Remixes)“ von Alan Walker.",
+      "fun_fact_es": "«Faded - Tiesto's Northern Lights Remix» aparece en el lanzamiento «Faded (Remixes)» de Alan Walker.",
+      "fun_fact_fr": "« Faded - Tiesto's Northern Lights Remix » figure sur la publication « Faded (Remixes) » de Alan Walker.",
+      "fun_fact_nl": "‘Faded - Tiesto's Northern Lights Remix’ staat op de release ‘Faded (Remixes)’ van Alan Walker.",
+      "alt_artists": [
+        "Martin Garrix, Clinton Kane",
+        "Jay Hardway",
+        "Martin Garrix, DubVision, Jaimes"
+      ]
+    },
+    {
+      "artist": "Justice",
+      "title": "D.A.N.C.E - Radio Edit",
+      "year": 2007,
+      "isrc": "FR0NT0600380",
+      "uri": "spotify:track:3gcmn2CtOE9SjBevmvGVEk",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/10284847",
+      "fun_fact": "“D.A.N.C.E - Radio Edit” appears on Justice’s release “D.A.N.C.E”.",
+      "fun_fact_de": "„D.A.N.C.E - Radio Edit“ erschien auf der Veröffentlichung „D.A.N.C.E“ von Justice.",
+      "fun_fact_es": "«D.A.N.C.E - Radio Edit» aparece en el lanzamiento «D.A.N.C.E» de Justice.",
+      "fun_fact_fr": "« D.A.N.C.E - Radio Edit » figure sur la publication « D.A.N.C.E » de Justice.",
+      "fun_fact_nl": "‘D.A.N.C.E - Radio Edit’ staat op de release ‘D.A.N.C.E’ van Justice.",
+      "alt_artists": [
+        "Dimitri Vegas & Like Mike, W&W",
+        "Alesso, Katy Perry",
+        "Joel Corry, Da Hool"
+      ]
+    },
+    {
+      "artist": "Fred again.., Skrillex, Four Tet",
+      "title": "Baby again..",
+      "year": 2022,
+      "isrc": "GBAHS2300215",
+      "uri": "spotify:track:4zlbKky2yA657Sk5rekZoR",
+      "uri_apple_music": "applemusic://track/1676442470",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1676442470"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2183959307",
+      "fun_fact": "“Baby again..” is the title track of Fred again..’s release of the same name.",
+      "fun_fact_de": "„Baby again..“ ist der Titelsong der gleichnamigen Veröffentlichung von Fred again...",
+      "fun_fact_es": "«Baby again..» es la canción que da título al lanzamiento homónimo de Fred again...",
+      "fun_fact_fr": "« Baby again.. » est le morceau-titre de la publication éponyme de Fred again...",
+      "fun_fact_nl": "‘Baby again..’ is het titelnummer van de gelijknamige release van Fred again...",
+      "alt_artists": [
+        "Ten Walls",
+        "London Grammar",
+        "Swedish House Mafia, Sting"
+      ]
+    },
+    {
+      "artist": "Fatboy Slim, Riva Starr, Beardyman, Calvin Harris",
+      "title": "Eat Sleep Rave Repeat - feat. Beardyman - Calvin Harris Remix",
+      "year": 2013,
+      "isrc": "GBBMQ1300118",
+      "uri": "spotify:track:3D4WLyMljoc05H9GbgEUxR",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3782910842",
+      "fun_fact": "“Eat Sleep Rave Repeat - feat. Beardyman - Calvin Harris Remix” appears on Fatboy Slim’s release “Eat Sleep Rave Repeat”.",
+      "fun_fact_de": "„Eat Sleep Rave Repeat - feat. Beardyman - Calvin Harris Remix“ erschien auf der Veröffentlichung „Eat Sleep Rave Repeat“ von Fatboy Slim.",
+      "fun_fact_es": "«Eat Sleep Rave Repeat - feat. Beardyman - Calvin Harris Remix» aparece en el lanzamiento «Eat Sleep Rave Repeat» de Fatboy Slim.",
+      "fun_fact_fr": "« Eat Sleep Rave Repeat - feat. Beardyman - Calvin Harris Remix » figure sur la publication « Eat Sleep Rave Repeat » de Fatboy Slim.",
+      "fun_fact_nl": "‘Eat Sleep Rave Repeat - feat. Beardyman - Calvin Harris Remix’ staat op de release ‘Eat Sleep Rave Repeat’ van Fatboy Slim.",
+      "alt_artists": [
+        "Disciples",
+        "Tiësto, Poppy Baskcomb",
+        "Joris Voorn"
+      ]
+    },
+    {
+      "artist": "Robin Schulz, Jasmine Thompson",
+      "title": "Sun Goes Down (feat. Jasmine Thompson) - Radio Mix",
+      "year": 2014,
+      "isrc": "DEA621400666",
+      "uri": "spotify:track:4zLBcDtvYNVtF9fnG6lme3",
+      "uri_apple_music": "applemusic://track/907493618",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/907493618"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/84908531",
+      "fun_fact": "“Sun Goes Down (feat. Jasmine Thompson) - Radio Mix” appears on Robin Schulz’s release “Prayer”.",
+      "fun_fact_de": "„Sun Goes Down (feat. Jasmine Thompson) - Radio Mix“ erschien auf der Veröffentlichung „Prayer“ von Robin Schulz.",
+      "fun_fact_es": "«Sun Goes Down (feat. Jasmine Thompson) - Radio Mix» aparece en el lanzamiento «Prayer» de Robin Schulz.",
+      "fun_fact_fr": "« Sun Goes Down (feat. Jasmine Thompson) - Radio Mix » figure sur la publication « Prayer » de Robin Schulz.",
+      "fun_fact_nl": "‘Sun Goes Down (feat. Jasmine Thompson) - Radio Mix’ staat op de release ‘Prayer’ van Robin Schulz.",
+      "alt_artists": [
+        "Kx5, deadmau5, Kaskade",
+        "Tiga",
+        "Dim Chris, Sebastien Drums, Avicii"
+      ]
+    },
+    {
+      "artist": "YORK, Mauro Picotto",
+      "title": "On The Beach - Mauro Picotto's CRW Remix",
+      "year": 2011,
+      "isrc": "DEPN61100029",
+      "uri": "spotify:track:1YsZB1pLIXR0YgiOxUG9cv",
+      "uri_apple_music": "applemusic://track/1884591384",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1884591384"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1157163962",
+      "fun_fact": "“On The Beach - Mauro Picotto's CRW Remix” appears on YORK’s release “On The Beach (Kryder Remix)”.",
+      "fun_fact_de": "„On The Beach - Mauro Picotto's CRW Remix“ erschien auf der Veröffentlichung „On The Beach (Kryder Remix)“ von YORK.",
+      "fun_fact_es": "«On The Beach - Mauro Picotto's CRW Remix» aparece en el lanzamiento «On The Beach (Kryder Remix)» de YORK.",
+      "fun_fact_fr": "« On The Beach - Mauro Picotto's CRW Remix » figure sur la publication « On The Beach (Kryder Remix) » de YORK.",
+      "fun_fact_nl": "‘On The Beach - Mauro Picotto's CRW Remix’ staat op de release ‘On The Beach (Kryder Remix)’ van YORK.",
+      "alt_artists": [
+        "Jones & Stephenson",
+        "Armin van Buuren, Sam Gray",
+        "Axwell, Max C"
+      ]
+    },
+    {
+      "artist": "Kölsch",
+      "title": "Goldfisch",
+      "year": 2013,
+      "isrc": "DEU671300126",
+      "uri": "spotify:track:7gwB872zS8guMxYTyQSwxY",
+      "uri_apple_music": "applemusic://track/657430383",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/657430383"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/68788680",
+      "fun_fact": "“Goldfisch” appears on Kölsch’s release “1977”.",
+      "fun_fact_de": "„Goldfisch“ erschien auf der Veröffentlichung „1977“ von Kölsch.",
+      "fun_fact_es": "«Goldfisch» aparece en el lanzamiento «1977» de Kölsch.",
+      "fun_fact_fr": "« Goldfisch » figure sur la publication « 1977 » de Kölsch.",
+      "fun_fact_nl": "‘Goldfisch’ staat op de release ‘1977’ van Kölsch.",
+      "alt_artists": [
+        "Tiga, Kölsch",
+        "Rune RK, Firebeatz",
+        "David Guetta, Martin Garrix, Brooks"
+      ]
+    },
+    {
+      "artist": "Zerb, Sofiya Nzau",
+      "title": "Mwaki",
+      "year": 2023,
+      "isrc": "NLRD52339318",
+      "uri": "spotify:track:5KTZgG84bKFGm53lhLtTqc",
+      "uri_apple_music": "applemusic://track/1708588826",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1708588826"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2461506635",
+      "fun_fact": "“Mwaki” appears on Zerb’s release “SURRENDER”.",
+      "fun_fact_de": "„Mwaki“ erschien auf der Veröffentlichung „SURRENDER“ von Zerb.",
+      "fun_fact_es": "«Mwaki» aparece en el lanzamiento «SURRENDER» de Zerb.",
+      "fun_fact_fr": "« Mwaki » figure sur la publication « SURRENDER » de Zerb.",
+      "fun_fact_nl": "‘Mwaki’ staat op de release ‘SURRENDER’ van Zerb.",
+      "alt_artists": [
+        "Format:B",
+        "Ayla",
+        "Anyma, Argy, MAGNUS"
+      ]
+    },
+    {
+      "artist": "Lost Frequencies, Zonderling, Kelvin Jones",
+      "title": "Love To Go - Deluxe Mix",
+      "year": 2020,
+      "isrc": "NLF712007197",
+      "uri": "spotify:track:7cVsSkOfZAJstlyFieyOMG",
+      "uri_apple_music": "applemusic://track/1521975290",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1521975290"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1010098372",
+      "fun_fact": "“Love To Go - Deluxe Mix” appears on Lost Frequencies’s release “Love To Go (Remixes)”.",
+      "fun_fact_de": "„Love To Go - Deluxe Mix“ erschien auf der Veröffentlichung „Love To Go (Remixes)“ von Lost Frequencies.",
+      "fun_fact_es": "«Love To Go - Deluxe Mix» aparece en el lanzamiento «Love To Go (Remixes)» de Lost Frequencies.",
+      "fun_fact_fr": "« Love To Go - Deluxe Mix » figure sur la publication « Love To Go (Remixes) » de Lost Frequencies.",
+      "fun_fact_nl": "‘Love To Go - Deluxe Mix’ staat op de release ‘Love To Go (Remixes)’ van Lost Frequencies.",
+      "alt_artists": [
+        "Loofy, Anyma, Layton Giordani",
+        "David Guetta, Nicky Romero, Sia",
+        "Zedd, Matthew Koma"
+      ]
+    },
+    {
+      "artist": "The Magician, Olly Alexander (Years & Years), Watermät",
+      "title": "Sunlight (feat. Years and Years) - Watermät Remix",
+      "year": 2014,
+      "isrc": "GB01A1400005",
+      "uri": "spotify:track:7J67mKTpZvq7mEWP6nWMyP",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2986367971",
+      "fun_fact": "“Sunlight (feat. Years and Years) - Watermät Remix” appears on The Magician’s release “Sunlight (feat. Years and Years) (Remixes)”.",
+      "fun_fact_de": "„Sunlight (feat. Years and Years) - Watermät Remix“ erschien auf der Veröffentlichung „Sunlight (feat. Years and Years) (Remixes)“ von The Magician.",
+      "fun_fact_es": "«Sunlight (feat. Years and Years) - Watermät Remix» aparece en el lanzamiento «Sunlight (feat. Years and Years) (Remixes)» de The Magician.",
+      "fun_fact_fr": "« Sunlight (feat. Years and Years) - Watermät Remix » figure sur la publication « Sunlight (feat. Years and Years) (Remixes) » de The Magician.",
+      "fun_fact_nl": "‘Sunlight (feat. Years and Years) - Watermät Remix’ staat op de release ‘Sunlight (feat. Years and Years) (Remixes)’ van The Magician.",
+      "alt_artists": [
+        "London Grammar",
+        "Rihanna, Calvin Harris",
+        "Lost Frequencies, Zonderling, Kelvin Jones"
+      ]
+    },
+    {
+      "artist": "TJR, VINAI",
+      "title": "Bounce Generation - Radio Edit",
+      "year": 2014,
+      "isrc": "NLZ541400355",
+      "uri": "spotify:track:3kY68hux4UinxEb2hchsMU",
+      "uri_apple_music": "applemusic://track/1444855628",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1444855628"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/468391472",
+      "fun_fact": "“Bounce Generation - Radio Edit” appears on TJR’s release “Bounce Generation”.",
+      "fun_fact_de": "„Bounce Generation - Radio Edit“ erschien auf der Veröffentlichung „Bounce Generation“ von TJR.",
+      "fun_fact_es": "«Bounce Generation - Radio Edit» aparece en el lanzamiento «Bounce Generation» de TJR.",
+      "fun_fact_fr": "« Bounce Generation - Radio Edit » figure sur la publication « Bounce Generation » de TJR.",
+      "fun_fact_nl": "‘Bounce Generation - Radio Edit’ staat op de release ‘Bounce Generation’ van TJR.",
+      "alt_artists": [
+        "Armin van Buuren, Shapov",
+        "London Grammar",
+        "Justice, Soulwax"
+      ]
+    },
+    {
+      "artist": "Dom Dolla",
+      "title": "Take It",
+      "year": 2018,
+      "isrc": "AUDCB1701202",
+      "uri": "spotify:track:3S4baKuEAz2bM8J3M8DdoZ",
+      "uri_apple_music": "applemusic://track/1454818194",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1454818194"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/642028102",
+      "fun_fact": "“Take It” is the title track of Dom Dolla’s release of the same name.",
+      "fun_fact_de": "„Take It“ ist der Titelsong der gleichnamigen Veröffentlichung von Dom Dolla.",
+      "fun_fact_es": "«Take It» es la canción que da título al lanzamiento homónimo de Dom Dolla.",
+      "fun_fact_fr": "« Take It » est le morceau-titre de la publication éponyme de Dom Dolla.",
+      "fun_fact_nl": "‘Take It’ is het titelnummer van de gelijknamige release van Dom Dolla.",
+      "alt_artists": [
+        "Lost Frequencies, Calum Scott",
+        "Tommy Trash",
+        "Eric Prydz, Floyd"
+      ]
+    },
+    {
+      "artist": "Disclosure, AlunaGeorge",
+      "title": "White Noise",
+      "year": 2013,
+      "isrc": "GBUM71302855",
+      "uri": "spotify:track:7ANO3LRdvefIongRYm5Smz",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/75526537",
+      "fun_fact": "“White Noise” appears on Disclosure’s release “Settle (Special Edition)”.",
+      "fun_fact_de": "„White Noise“ erschien auf der Veröffentlichung „Settle (Special Edition)“ von Disclosure.",
+      "fun_fact_es": "«White Noise» aparece en el lanzamiento «Settle (Special Edition)» de Disclosure.",
+      "fun_fact_fr": "« White Noise » figure sur la publication « Settle (Special Edition) » de Disclosure.",
+      "fun_fact_nl": "‘White Noise’ staat op de release ‘Settle (Special Edition)’ van Disclosure.",
+      "alt_artists": [
+        "L.P. Rhythm",
+        "Prospa, RAHH",
+        "Kölsch, Gregor Schwellenbach"
+      ]
+    },
+    {
+      "artist": "Sebastian Ingrosso",
+      "title": "Dark River",
+      "year": 2016,
+      "isrc": "SEUM71600764",
+      "uri": "spotify:track:4GoqbpOhKuCRNBq7fW2B7S",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1091018482",
+      "fun_fact": "“Dark River” appears on Sebastian Ingrosso’s release “Zwift Workout”.",
+      "fun_fact_de": "„Dark River“ erschien auf der Veröffentlichung „Zwift Workout“ von Sebastian Ingrosso.",
+      "fun_fact_es": "«Dark River» aparece en el lanzamiento «Zwift Workout» de Sebastian Ingrosso.",
+      "fun_fact_fr": "« Dark River » figure sur la publication « Zwift Workout » de Sebastian Ingrosso.",
+      "fun_fact_nl": "‘Dark River’ staat op de release ‘Zwift Workout’ van Sebastian Ingrosso.",
+      "alt_artists": [
+        "Yves V, HIDDN",
+        "Cloonee, Young M.A, InntRaw, HNTR",
+        "Vintage Culture, Fancy Inc, The Beach"
+      ]
+    },
+    {
+      "artist": "BURNS",
+      "title": "Talamanca",
+      "year": 2021,
+      "isrc": "GBAYE2100748",
+      "uri": "spotify:track:7dDLAQ1y0qOq3E4DhNh8FS",
+      "uri_apple_music": "applemusic://track/1570848230",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1570848230"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1394988992",
+      "fun_fact": "“Talamanca” is the title track of BURNS’s release of the same name.",
+      "fun_fact_de": "„Talamanca“ ist der Titelsong der gleichnamigen Veröffentlichung von BURNS.",
+      "fun_fact_es": "«Talamanca» es la canción que da título al lanzamiento homónimo de BURNS.",
+      "fun_fact_fr": "« Talamanca » est le morceau-titre de la publication éponyme de BURNS.",
+      "fun_fact_nl": "‘Talamanca’ is het titelnummer van de gelijknamige release van BURNS.",
+      "alt_artists": [
+        "Robin Schulz, Francesco Yates, Stadiumx",
+        "Faithless",
+        "Justice"
+      ]
+    },
+    {
+      "artist": "Martin Garrix, Matisse & Sadko",
+      "title": "Forever",
+      "year": 2017,
+      "isrc": "NLM5S1600120",
+      "uri": "spotify:track:5EwwwdsQfKI8ZnFG93j5Zu",
+      "uri_apple_music": "applemusic://track/1296253944",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1296253944"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/417565092",
+      "fun_fact": "“Forever” is the title track of Martin Garrix’s release of the same name.",
+      "fun_fact_de": "„Forever“ ist der Titelsong der gleichnamigen Veröffentlichung von Martin Garrix.",
+      "fun_fact_es": "«Forever» es la canción que da título al lanzamiento homónimo de Martin Garrix.",
+      "fun_fact_fr": "« Forever » est le morceau-titre de la publication éponyme de Martin Garrix.",
+      "fun_fact_nl": "‘Forever’ is het titelnummer van de gelijknamige release van Martin Garrix.",
+      "alt_artists": [
+        "Sammy Virji",
+        "Jauz, Netsky",
+        "Lost Frequencies, The NGHBRS, Keanu Silva"
+      ]
+    },
+    {
+      "artist": "Parachute Youth",
+      "title": "Can't Get Better Than This - Radio Edit",
+      "year": 2012,
+      "isrc": "AUCN31204395",
+      "uri": "spotify:track:1YgsNnNKumUzrN7miPzQME",
+      "uri_apple_music": "applemusic://track/496764213",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/496764213"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/82668730",
+      "fun_fact": "“Can't Get Better Than This - Radio Edit” appears on Parachute Youth’s release “Can't Get Better Than This”.",
+      "fun_fact_de": "„Can't Get Better Than This - Radio Edit“ erschien auf der Veröffentlichung „Can't Get Better Than This“ von Parachute Youth.",
+      "fun_fact_es": "«Can't Get Better Than This - Radio Edit» aparece en el lanzamiento «Can't Get Better Than This» de Parachute Youth.",
+      "fun_fact_fr": "« Can't Get Better Than This - Radio Edit » figure sur la publication « Can't Get Better Than This » de Parachute Youth.",
+      "fun_fact_nl": "‘Can't Get Better Than This - Radio Edit’ staat op de release ‘Can't Get Better Than This’ van Parachute Youth.",
+      "alt_artists": [
+        "Jaydee",
+        "Kygo, Rita Ora",
+        "Anyma, Cassian, Poppy Baskcomb"
+      ]
+    },
+    {
+      "artist": "Empire Of The Sun, Zedd",
+      "title": "Alive - Zedd Remix",
+      "year": 2013,
+      "isrc": "AUEI11300023",
+      "uri": "spotify:track:3EK8StyL9XUCp90sqgIuI1",
+      "uri_apple_music": "applemusic://track/1443133343",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1443133343"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/124183404",
+      "fun_fact": "“Alive - Zedd Remix” appears on Empire Of The Sun’s release “Body By Jake: Tough, Tight And Toned Workout (BPM 118-128)”.",
+      "fun_fact_de": "„Alive - Zedd Remix“ erschien auf der Veröffentlichung „Body By Jake: Tough, Tight And Toned Workout (BPM 118-128)“ von Empire Of The Sun.",
+      "fun_fact_es": "«Alive - Zedd Remix» aparece en el lanzamiento «Body By Jake: Tough, Tight And Toned Workout (BPM 118-128)» de Empire Of The Sun.",
+      "fun_fact_fr": "« Alive - Zedd Remix » figure sur la publication « Body By Jake: Tough, Tight And Toned Workout (BPM 118-128) » de Empire Of The Sun.",
+      "fun_fact_nl": "‘Alive - Zedd Remix’ staat op de release ‘Body By Jake: Tough, Tight And Toned Workout (BPM 118-128)’ van Empire Of The Sun.",
+      "alt_artists": [
+        "Steve Angello, Matisse & Sadko",
+        "Disciples",
+        "Topic, Fireboy DML, Nico Santos"
+      ]
+    },
+    {
+      "artist": "Jazzy",
+      "title": "Giving Me",
+      "year": 2023,
+      "isrc": "GBUM72206719",
+      "uri": "spotify:track:1ACFweuuvf6MHtptObgreR",
+      "uri_apple_music": "applemusic://track/1674124880",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1674124880"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2174326127",
+      "fun_fact": "“Giving Me” is the title track of Jazzy’s release of the same name.",
+      "fun_fact_de": "„Giving Me“ ist der Titelsong der gleichnamigen Veröffentlichung von Jazzy.",
+      "fun_fact_es": "«Giving Me» es la canción que da título al lanzamiento homónimo de Jazzy.",
+      "fun_fact_fr": "« Giving Me » est le morceau-titre de la publication éponyme de Jazzy.",
+      "fun_fact_nl": "‘Giving Me’ is het titelnummer van de gelijknamige release van Jazzy.",
+      "alt_artists": [
+        "Avicii, Sandro Cavazza",
+        "Lost Frequencies, Calum Scott",
+        "Grooveyard, Nicky Romero"
+      ]
+    },
+    {
+      "artist": "Jaydee",
+      "title": "Plastic Dreams - Radio Edit",
+      "year": 2003,
+      "isrc": "NLC281011778",
+      "uri": "spotify:track:7t020iFDoAjNgc4mjUMBAS",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/461011162",
+      "fun_fact": "“Plastic Dreams - Radio Edit” appears on Jaydee’s release “Plastic Dreams”.",
+      "fun_fact_de": "„Plastic Dreams - Radio Edit“ erschien auf der Veröffentlichung „Plastic Dreams“ von Jaydee.",
+      "fun_fact_es": "«Plastic Dreams - Radio Edit» aparece en el lanzamiento «Plastic Dreams» de Jaydee.",
+      "fun_fact_fr": "« Plastic Dreams - Radio Edit » figure sur la publication « Plastic Dreams » de Jaydee.",
+      "fun_fact_nl": "‘Plastic Dreams - Radio Edit’ staat op de release ‘Plastic Dreams’ van Jaydee.",
+      "alt_artists": [
+        "Lost Frequencies, Elley Duhé, X Ambassadors",
+        "David Guetta, Akon",
+        "Masters At Work"
+      ]
+    },
+    {
+      "artist": "Eric Prydz, Floyd",
+      "title": "Proper Education - Radio Edit",
+      "year": 2006,
+      "isrc": "GBCEN0600491",
+      "uri": "spotify:track:06Vw2ZOhalTwEw4PhoGRSX",
+      "uri_apple_music": "applemusic://track/1506106173",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1506106173"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/920549052",
+      "fun_fact": "“Proper Education - Radio Edit” appears on Eric Prydz’s release “Proper Education - EP”.",
+      "fun_fact_de": "„Proper Education - Radio Edit“ erschien auf der Veröffentlichung „Proper Education - EP“ von Eric Prydz.",
+      "fun_fact_es": "«Proper Education - Radio Edit» aparece en el lanzamiento «Proper Education - EP» de Eric Prydz.",
+      "fun_fact_fr": "« Proper Education - Radio Edit » figure sur la publication « Proper Education - EP » de Eric Prydz.",
+      "fun_fact_nl": "‘Proper Education - Radio Edit’ staat op de release ‘Proper Education - EP’ van Eric Prydz.",
+      "alt_artists": [
+        "David Guetta, MORTEN",
+        "cassö, RAYE, D-Block Europe",
+        "Lost Frequencies, Mathieu Koss"
+      ]
+    },
+    {
+      "artist": "AFROJACK, NERVO, Dimitri Vegas & Like Mike",
+      "title": "The Way We See The World - Tomorrowland Anthem Radio Edit",
+      "year": 2011,
+      "isrc": "NLC281111850",
+      "uri": "spotify:track:7qm96i0k4auLvcIsNQGkWX",
+      "uri_apple_music": "applemusic://track/1743232241",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1743232241"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/468825872",
+      "fun_fact": "“The Way We See The World - Tomorrowland Anthem Radio Edit” appears on AFROJACK’s release “The Way We See The World (Tomorrowland Anthem Instrumental)”.",
+      "fun_fact_de": "„The Way We See The World - Tomorrowland Anthem Radio Edit“ erschien auf der Veröffentlichung „The Way We See The World (Tomorrowland Anthem Instrumental)“ von AFROJACK.",
+      "fun_fact_es": "«The Way We See The World - Tomorrowland Anthem Radio Edit» aparece en el lanzamiento «The Way We See The World (Tomorrowland Anthem Instrumental)» de AFROJACK.",
+      "fun_fact_fr": "« The Way We See The World - Tomorrowland Anthem Radio Edit » figure sur la publication « The Way We See The World (Tomorrowland Anthem Instrumental) » de AFROJACK.",
+      "fun_fact_nl": "‘The Way We See The World - Tomorrowland Anthem Radio Edit’ staat op de release ‘The Way We See The World (Tomorrowland Anthem Instrumental)’ van AFROJACK.",
+      "alt_artists": [
+        "MK, Chrystal",
+        "Steve Aoki, Wynter Gordon",
+        "Gotye, FISHER, Chris Lake, Sante Sansone, Kimbra"
+      ]
+    },
+    {
+      "artist": "Calvin Harris",
+      "title": "Flashback",
+      "year": 2009,
+      "isrc": "GBARL0900843",
+      "uri": "spotify:track:6A8llSO9QFF4djCCmuCrNu",
+      "uri_apple_music": "applemusic://track/1714694295",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1714694295"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/13131863",
+      "fun_fact": "“Flashback” appears on Calvin Harris’s release “Ready For The Weekend”.",
+      "fun_fact_de": "„Flashback“ erschien auf der Veröffentlichung „Ready For The Weekend“ von Calvin Harris.",
+      "fun_fact_es": "«Flashback» aparece en el lanzamiento «Ready For The Weekend» de Calvin Harris.",
+      "fun_fact_fr": "« Flashback » figure sur la publication « Ready For The Weekend » de Calvin Harris.",
+      "fun_fact_nl": "‘Flashback’ staat op de release ‘Ready For The Weekend’ van Calvin Harris.",
+      "alt_artists": [
+        "Swedish House Mafia, Connie Constance",
+        "John Summit",
+        "John Summit, Guz, Stevie Appleton"
+      ]
+    },
+    {
+      "artist": "Fred again.., Baby Keem",
+      "title": "leavemealone",
+      "year": 2022,
+      "isrc": "GBAHS2301465",
+      "uri": "spotify:track:1MVqeIAwhD4T44AKVkIfic",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2573922082",
+      "fun_fact": "“leavemealone” is the title track of Fred again..’s release of the same name.",
+      "fun_fact_de": "„leavemealone“ ist der Titelsong der gleichnamigen Veröffentlichung von Fred again...",
+      "fun_fact_es": "«leavemealone» es la canción que da título al lanzamiento homónimo de Fred again...",
+      "fun_fact_fr": "« leavemealone » est le morceau-titre de la publication éponyme de Fred again...",
+      "fun_fact_nl": "‘leavemealone’ is het titelnummer van de gelijknamige release van Fred again...",
+      "alt_artists": [
+        "Dim Chris, Sebastien Drums, Avicii",
+        "Tube & Berger",
+        "David Guetta, MORTEN"
+      ]
+    },
+    {
+      "artist": "Tiësto, Dzeko, Preme, Post Malone",
+      "title": "Jackie Chan",
+      "year": 2018,
+      "isrc": "CYA111800123",
+      "uri": "spotify:track:4kWO6O1BUXcZmaxitpVUwp",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/499994962",
+      "fun_fact": "“Jackie Chan” is the title track of Tiësto’s release of the same name.",
+      "fun_fact_de": "„Jackie Chan“ ist der Titelsong der gleichnamigen Veröffentlichung von Tiësto.",
+      "fun_fact_es": "«Jackie Chan» es la canción que da título al lanzamiento homónimo de Tiësto.",
+      "fun_fact_fr": "« Jackie Chan » est le morceau-titre de la publication éponyme de Tiësto.",
+      "fun_fact_nl": "‘Jackie Chan’ is het titelnummer van de gelijknamige release van Tiësto.",
+      "alt_artists": [
+        "Ernesto vs. Bastian, Susana",
+        "Parachute Youth",
+        "Double 99"
+      ]
+    },
+    {
+      "artist": "Lost Frequencies, Flynn",
+      "title": "Recognise",
+      "year": 2019,
+      "isrc": "NLF711901802",
+      "uri": "spotify:track:5NdSCcIJJ42G86xrUx34sA",
+      "uri_apple_music": "applemusic://track/1453086323",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1453086323"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/641406892",
+      "fun_fact": "“Recognise” is the title track of Lost Frequencies’s release of the same name.",
+      "fun_fact_de": "„Recognise“ ist der Titelsong der gleichnamigen Veröffentlichung von Lost Frequencies.",
+      "fun_fact_es": "«Recognise» es la canción que da título al lanzamiento homónimo de Lost Frequencies.",
+      "fun_fact_fr": "« Recognise » est le morceau-titre de la publication éponyme de Lost Frequencies.",
+      "fun_fact_nl": "‘Recognise’ is het titelnummer van de gelijknamige release van Lost Frequencies.",
+      "alt_artists": [
+        "Swedish House Mafia, Anyma, Future, Fred again..",
+        "Oden & Fatzo",
+        "Axwell"
+      ]
+    },
+    {
+      "artist": "Junior Jack",
+      "title": "E Samba",
+      "year": 2004,
+      "isrc": "BEP010310083",
+      "uri": "spotify:track:5Wt1AxOij0QzGOf8mwSUlO",
+      "uri_apple_music": "applemusic://track/1538711924",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1538711924"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2115239597",
+      "fun_fact": "“E Samba” appears on Junior Jack’s release “[PIAS] 40”.",
+      "fun_fact_de": "„E Samba“ erschien auf der Veröffentlichung „[PIAS] 40“ von Junior Jack.",
+      "fun_fact_es": "«E Samba» aparece en el lanzamiento «[PIAS] 40» de Junior Jack.",
+      "fun_fact_fr": "« E Samba » figure sur la publication « [PIAS] 40 » de Junior Jack.",
+      "fun_fact_nl": "‘E Samba’ staat op de release ‘[PIAS] 40’ van Junior Jack.",
+      "alt_artists": [
+        "YORK, Mauro Picotto",
+        "DR. KUCHO!, Gregor Salto, Ane Brun, Oliver Heldens",
+        "Dom Dolla, Anyma, Daya"
+      ]
+    },
+    {
+      "artist": "Eric Prydz",
+      "title": "NOPUS",
+      "year": 2020,
+      "isrc": "GBCEN2000132",
+      "uri": "spotify:track:02dPa4nXABwnFzjZosKxsk",
+      "uri_apple_music": "applemusic://track/1535810091",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1535810091"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1108824212",
+      "fun_fact": "“NOPUS” is the title track of Eric Prydz’s release of the same name.",
+      "fun_fact_de": "„NOPUS“ ist der Titelsong der gleichnamigen Veröffentlichung von Eric Prydz.",
+      "fun_fact_es": "«NOPUS» es la canción que da título al lanzamiento homónimo de Eric Prydz.",
+      "fun_fact_fr": "« NOPUS » est le morceau-titre de la publication éponyme de Eric Prydz.",
+      "fun_fact_nl": "‘NOPUS’ is het titelnummer van de gelijknamige release van Eric Prydz.",
+      "alt_artists": [
+        "Skrillex, Boys Noize, Opus III",
+        "Alok, ILLENIUM",
+        "Armin van Buuren"
+      ]
+    },
+    {
+      "artist": "Purple Disco Machine, Sophie and the Giants",
+      "title": "Hypnotized",
+      "year": 2017,
+      "isrc": "AUDCB1701555",
+      "uri": "spotify:track:0vWUhCPxpJOJR5urYbZypB",
+      "uri_apple_music": "applemusic://track/1504484138",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1504484138"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/914108092",
+      "fun_fact": "“Hypnotized” is the title track of Purple Disco Machine’s release of the same name.",
+      "fun_fact_de": "„Hypnotized“ ist der Titelsong der gleichnamigen Veröffentlichung von Purple Disco Machine.",
+      "fun_fact_es": "«Hypnotized» es la canción que da título al lanzamiento homónimo de Purple Disco Machine.",
+      "fun_fact_fr": "« Hypnotized » est le morceau-titre de la publication éponyme de Purple Disco Machine.",
+      "fun_fact_nl": "‘Hypnotized’ is het titelnummer van de gelijknamige release van Purple Disco Machine.",
+      "alt_artists": [
+        "Mr. Belt & Wezol",
+        "Diplo, Paul Woolford, Kareen Lomax",
+        "Anyma, Argy, MAGNUS"
+      ]
+    },
+    {
+      "artist": "Issey Cross, Tiësto",
+      "title": "Bittersweet Goodbye - Tiësto’s Hardcore Remix",
+      "year": 2023,
+      "isrc": "GBAHS2301011",
+      "uri": "spotify:track:4UWDgSvethiugRKFdbaiik",
+      "uri_apple_music": "applemusic://track/1702091217",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1702091217"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2405850825",
+      "fun_fact": "“Bittersweet Goodbye - Tiësto’s Hardcore Remix” is the title track of Issey Cross’s release of the same name.",
+      "fun_fact_de": "„Bittersweet Goodbye - Tiësto’s Hardcore Remix“ ist der Titelsong der gleichnamigen Veröffentlichung von Issey Cross.",
+      "fun_fact_es": "«Bittersweet Goodbye - Tiësto’s Hardcore Remix» es la canción que da título al lanzamiento homónimo de Issey Cross.",
+      "fun_fact_fr": "« Bittersweet Goodbye - Tiësto’s Hardcore Remix » est le morceau-titre de la publication éponyme de Issey Cross.",
+      "fun_fact_nl": "‘Bittersweet Goodbye - Tiësto’s Hardcore Remix’ is het titelnummer van de gelijknamige release van Issey Cross.",
+      "alt_artists": [
+        "Dimension",
+        "Michel Cleis, Totó La Momposina, Paul Kalkbrenner",
+        "Joel Corry, Da Hool"
+      ]
+    },
+    {
+      "artist": "London Grammar",
+      "title": "Hey Now - ARTY Remix",
+      "year": 2014,
+      "isrc": "GBCEN1300930",
+      "uri": "spotify:track:4kaqizkr7cp8YLsWmf5l9b",
+      "uri_apple_music": "applemusic://track/1691761049",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1691761049"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2367722725",
+      "fun_fact": "“Hey Now - ARTY Remix” appears on London Grammar’s release “The Remixes”.",
+      "fun_fact_de": "„Hey Now - ARTY Remix“ erschien auf der Veröffentlichung „The Remixes“ von London Grammar.",
+      "fun_fact_es": "«Hey Now - ARTY Remix» aparece en el lanzamiento «The Remixes» de London Grammar.",
+      "fun_fact_fr": "« Hey Now - ARTY Remix » figure sur la publication « The Remixes » de London Grammar.",
+      "fun_fact_nl": "‘Hey Now - ARTY Remix’ staat op de release ‘The Remixes’ van London Grammar.",
+      "alt_artists": [
+        "Maceo Plex, Chromatics",
+        "Avicii",
+        "Dirty South, Evermore"
+      ]
+    },
+    {
+      "artist": "Armin van Buuren, Mr. Probz",
+      "title": "Another You",
+      "year": 2015,
+      "isrc": "NLF711501933",
+      "uri": "spotify:track:44EbX1Cuwpq3hdnpTHsmfO",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/99827630",
+      "fun_fact": "“Another You” is the title track of Armin van Buuren’s release of the same name.",
+      "fun_fact_de": "„Another You“ ist der Titelsong der gleichnamigen Veröffentlichung von Armin van Buuren.",
+      "fun_fact_es": "«Another You» es la canción que da título al lanzamiento homónimo de Armin van Buuren.",
+      "fun_fact_fr": "« Another You » est le morceau-titre de la publication éponyme de Armin van Buuren.",
+      "fun_fact_nl": "‘Another You’ is het titelnummer van de gelijknamige release van Armin van Buuren.",
+      "alt_artists": [
+        "Vintage Culture, Fancy Inc",
+        "Paul Kalkbrenner",
+        "Rui Da Silva, Cassandra"
+      ]
+    },
+    {
+      "artist": "The Chainsmokers, Bebe Rexha",
+      "title": "Call You Mine",
+      "year": 2019,
+      "isrc": "USQX91901124",
+      "uri": "spotify:track:2oejEp50ZzPuQTQ6v54Evp",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/717723352",
+      "fun_fact": "“Call You Mine” appears on The Chainsmokers’s release “World War Joy...Takeaway”.",
+      "fun_fact_de": "„Call You Mine“ erschien auf der Veröffentlichung „World War Joy...Takeaway“ von The Chainsmokers.",
+      "fun_fact_es": "«Call You Mine» aparece en el lanzamiento «World War Joy...Takeaway» de The Chainsmokers.",
+      "fun_fact_fr": "« Call You Mine » figure sur la publication « World War Joy...Takeaway » de The Chainsmokers.",
+      "fun_fact_nl": "‘Call You Mine’ staat op de release ‘World War Joy...Takeaway’ van The Chainsmokers.",
+      "alt_artists": [
+        "Bag Raiders",
+        "Fred again..",
+        "Maceo Plex, Chromatics"
+      ]
+    },
+    {
+      "artist": "Mike Williams, Robin Valo",
+      "title": "Feels Like Yesterday (feat. Robin Valo)",
+      "year": 2018,
+      "isrc": "NLZ541800374",
+      "uri": "spotify:track:6dzFe2IgWQ5nDrgbf6AHiR",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/472421032",
+      "fun_fact": "“Feels Like Yesterday (feat. Robin Valo)” is the title track of Mike Williams’s release of the same name.",
+      "fun_fact_de": "„Feels Like Yesterday (feat. Robin Valo)“ ist der Titelsong der gleichnamigen Veröffentlichung von Mike Williams.",
+      "fun_fact_es": "«Feels Like Yesterday (feat. Robin Valo)» es la canción que da título al lanzamiento homónimo de Mike Williams.",
+      "fun_fact_fr": "« Feels Like Yesterday (feat. Robin Valo) » est le morceau-titre de la publication éponyme de Mike Williams.",
+      "fun_fact_nl": "‘Feels Like Yesterday (feat. Robin Valo)’ is het titelnummer van de gelijknamige release van Mike Williams.",
+      "alt_artists": [
+        "Felix Da Housecat",
+        "Sub Focus, Culture Shock, Fragma",
+        "Martin Garrix, Matisse & Sadko, BARBZ"
+      ]
+    },
+    {
+      "artist": "Konstantin Sibold, Adam Sellouk",
+      "title": "Day 'N' Night",
+      "year": 2025,
+      "isrc": "NLF712502308",
+      "uri": "spotify:track:1nXJn2Sy4d1fdu1VHeJOnd",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3324116581",
+      "fun_fact": "“Day 'N' Night” is the title track of Konstantin Sibold’s release of the same name.",
+      "fun_fact_de": "„Day 'N' Night“ ist der Titelsong der gleichnamigen Veröffentlichung von Konstantin Sibold.",
+      "fun_fact_es": "«Day 'N' Night» es la canción que da título al lanzamiento homónimo de Konstantin Sibold.",
+      "fun_fact_fr": "« Day 'N' Night » est le morceau-titre de la publication éponyme de Konstantin Sibold.",
+      "fun_fact_nl": "‘Day 'N' Night’ is het titelnummer van de gelijknamige release van Konstantin Sibold.",
+      "alt_artists": [
+        "Sub Focus",
+        "Martin Solveig, Roy Woods",
+        "Lifelike, Kris Menace"
+      ]
+    },
+    {
+      "artist": "David Guetta, Benny Benassi",
+      "title": "Satisfaction",
+      "year": 2022,
+      "isrc": "UKWLG2200052",
+      "uri": "spotify:track:0lwyzp7GppQxv0Eu6wRkUo",
+      "uri_apple_music": "applemusic://track/1638388862",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1638388862"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1850060617",
+      "fun_fact": "“Satisfaction” is the title track of David Guetta’s release of the same name.",
+      "fun_fact_de": "„Satisfaction“ ist der Titelsong der gleichnamigen Veröffentlichung von David Guetta.",
+      "fun_fact_es": "«Satisfaction» es la canción que da título al lanzamiento homónimo de David Guetta.",
+      "fun_fact_fr": "« Satisfaction » est le morceau-titre de la publication éponyme de David Guetta.",
+      "fun_fact_nl": "‘Satisfaction’ is het titelnummer van de gelijknamige release van David Guetta.",
+      "alt_artists": [
+        "Mr. Probz, Chris Brown, T.I.",
+        "Tommy Trash",
+        "Moby"
+      ]
+    },
+    {
+      "artist": "Bastille, Audien",
+      "title": "Pompeii - Audien Remix",
+      "year": 2014,
+      "isrc": "GBUM71401449",
+      "uri": "spotify:track:2Kl1E3NdbzT7vVi93TffoX",
+      "uri_apple_music": "applemusic://track/1445322038",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1445322038"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/855971922",
+      "fun_fact": "“Pompeii - Audien Remix” appears on Bastille’s release “Running Workout”.",
+      "fun_fact_de": "„Pompeii - Audien Remix“ erschien auf der Veröffentlichung „Running Workout“ von Bastille.",
+      "fun_fact_es": "«Pompeii - Audien Remix» aparece en el lanzamiento «Running Workout» de Bastille.",
+      "fun_fact_fr": "« Pompeii - Audien Remix » figure sur la publication « Running Workout » de Bastille.",
+      "fun_fact_nl": "‘Pompeii - Audien Remix’ staat op de release ‘Running Workout’ van Bastille.",
+      "alt_artists": [
+        "Yves V, AFROJACK, Icona Pop",
+        "CHRIS STASSY",
+        "Armin van Buuren, Sunnery James & Ryan Marciano"
+      ]
+    },
+    {
+      "artist": "Mark Knight, Funkagenda",
+      "title": "Man With The Red Face - Radio Edit",
+      "year": 2014,
+      "isrc": "FR6V82390196",
+      "uri": "spotify:track:5FDn1oWUD5BXL2HCfmCk2F",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/77118136",
+      "fun_fact": "“Man With The Red Face - Radio Edit” appears on Mark Knight’s release “Elektika Miami, Vol.1”.",
+      "fun_fact_de": "„Man With The Red Face - Radio Edit“ erschien auf der Veröffentlichung „Elektika Miami, Vol.1“ von Mark Knight.",
+      "fun_fact_es": "«Man With The Red Face - Radio Edit» aparece en el lanzamiento «Elektika Miami, Vol.1» de Mark Knight.",
+      "fun_fact_fr": "« Man With The Red Face - Radio Edit » figure sur la publication « Elektika Miami, Vol.1 » de Mark Knight.",
+      "fun_fact_nl": "‘Man With The Red Face - Radio Edit’ staat op de release ‘Elektika Miami, Vol.1’ van Mark Knight.",
+      "alt_artists": [
+        "AVAION",
+        "Tiësto, KSHMR, VASSY",
+        "Jack Ü, Skrillex, Diplo, Kiesza, Tchami"
+      ]
+    },
+    {
+      "artist": "ANOTR, Abel Balder",
+      "title": "Relax My Eyes",
+      "year": 2023,
+      "isrc": "GBKQU2296427",
+      "uri": "spotify:track:5u4hhtZ7f4rWkMZEZcTKrH",
+      "uri_apple_music": "applemusic://track/1679316677",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1679316677"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2210691877",
+      "fun_fact": "“Relax My Eyes” is the title track of ANOTR’s release of the same name.",
+      "fun_fact_de": "„Relax My Eyes“ ist der Titelsong der gleichnamigen Veröffentlichung von ANOTR.",
+      "fun_fact_es": "«Relax My Eyes» es la canción que da título al lanzamiento homónimo de ANOTR.",
+      "fun_fact_fr": "« Relax My Eyes » est le morceau-titre de la publication éponyme de ANOTR.",
+      "fun_fact_nl": "‘Relax My Eyes’ is het titelnummer van de gelijknamige release van ANOTR.",
+      "alt_artists": [
+        "Anyma",
+        "Kölsch, Troels Abrahamsen",
+        "Shouse, David Guetta"
+      ]
+    },
+    {
+      "artist": "Gareth Emery, Christina Novelli",
+      "title": "Concrete Angel - Radio Edit",
+      "year": 2014,
+      "isrc": "GB2CT1400391",
+      "uri": "spotify:track:2zM1zEjv2JX1qTmSDeB8IL",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/90919855",
+      "fun_fact": "“Concrete Angel - Radio Edit” appears on Gareth Emery’s release “Grotesque Indoor Festival 2014”.",
+      "fun_fact_de": "„Concrete Angel - Radio Edit“ erschien auf der Veröffentlichung „Grotesque Indoor Festival 2014“ von Gareth Emery.",
+      "fun_fact_es": "«Concrete Angel - Radio Edit» aparece en el lanzamiento «Grotesque Indoor Festival 2014» de Gareth Emery.",
+      "fun_fact_fr": "« Concrete Angel - Radio Edit » figure sur la publication « Grotesque Indoor Festival 2014 » de Gareth Emery.",
+      "fun_fact_nl": "‘Concrete Angel - Radio Edit’ staat op de release ‘Grotesque Indoor Festival 2014’ van Gareth Emery.",
+      "alt_artists": [
+        "Tiësto, Kirsty Hawkshaw",
+        "Jewelz & Sparks, AFROJACK, Sunnery James & Ryan Marciano",
+        "Kygo, Rita Ora"
+      ]
+    },
+    {
+      "artist": "Borai & Denham Audio, Franky Rizardo",
+      "title": "Make Me - Franky Rizardo Remix",
+      "year": 2023,
+      "isrc": "GBARL2301826",
+      "uri": "spotify:track:57508shL0obX0KUOUL8CJk",
+      "uri_apple_music": "applemusic://track/1719866219",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1719866219"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2572591112",
+      "fun_fact": "“Make Me - Franky Rizardo Remix” is the title track of Borai & Denham Audio’s release of the same name.",
+      "fun_fact_de": "„Make Me - Franky Rizardo Remix“ ist der Titelsong der gleichnamigen Veröffentlichung von Borai & Denham Audio.",
+      "fun_fact_es": "«Make Me - Franky Rizardo Remix» es la canción que da título al lanzamiento homónimo de Borai & Denham Audio.",
+      "fun_fact_fr": "« Make Me - Franky Rizardo Remix » est le morceau-titre de la publication éponyme de Borai & Denham Audio.",
+      "fun_fact_nl": "‘Make Me - Franky Rizardo Remix’ is het titelnummer van de gelijknamige release van Borai & Denham Audio.",
+      "alt_artists": [
+        "MEDUZA, Becky Hill, Goodboys",
+        "Martin Solveig",
+        "Solid Sessions"
+      ]
+    },
+    {
+      "artist": "Linska, GENESI",
+      "title": "Bad Boy - GENESI Remix",
+      "year": 2025,
+      "isrc": "US38Y2502570",
+      "uri": "spotify:track:4MKqROsy64whz0A1YyCXGE",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3194171421",
+      "fun_fact": "“Bad Boy - GENESI Remix” is the title track of Linska’s release of the same name.",
+      "fun_fact_de": "„Bad Boy - GENESI Remix“ ist der Titelsong der gleichnamigen Veröffentlichung von Linska.",
+      "fun_fact_es": "«Bad Boy - GENESI Remix» es la canción que da título al lanzamiento homónimo de Linska.",
+      "fun_fact_fr": "« Bad Boy - GENESI Remix » est le morceau-titre de la publication éponyme de Linska.",
+      "fun_fact_nl": "‘Bad Boy - GENESI Remix’ is het titelnummer van de gelijknamige release van Linska.",
+      "alt_artists": [
+        "AN21, Max Vangeli, Julie McKnight",
+        "Alesso, TINI",
+        "Watermät"
+      ]
+    },
+    {
+      "artist": "AN21, Max Vangeli",
+      "title": "Swedish Beauty",
+      "year": 2010,
+      "isrc": "GBJ4B1000003",
+      "uri": "spotify:track:5HAbhRwEdlHSJs7D1sbOsU",
+      "uri_apple_music": "applemusic://track/946844829",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/946844829"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/91185507",
+      "fun_fact": "“Swedish Beauty” is the title track of AN21’s release of the same name.",
+      "fun_fact_de": "„Swedish Beauty“ ist der Titelsong der gleichnamigen Veröffentlichung von AN21.",
+      "fun_fact_es": "«Swedish Beauty» es la canción que da título al lanzamiento homónimo de AN21.",
+      "fun_fact_fr": "« Swedish Beauty » est le morceau-titre de la publication éponyme de AN21.",
+      "fun_fact_nl": "‘Swedish Beauty’ is het titelnummer van de gelijknamige release van AN21.",
+      "alt_artists": [
+        "Filterheadz",
+        "Martin Garrix, Alesso, Shaun Farrugia",
+        "SOFI TUKKER, John Summit, Vintage Culture"
+      ]
+    },
+    {
+      "artist": "DubVision, AFROJACK",
+      "title": "Feels Like Home - Official Song F1 Dutch Grand Prix",
+      "year": 2022,
+      "isrc": "CYA222200014",
+      "uri": "spotify:track:70ztDWxwMLHje4L7QUyu5d",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1883583937",
+      "fun_fact": "“Feels Like Home - Official Song F1 Dutch Grand Prix” is the title track of DubVision’s release of the same name.",
+      "fun_fact_de": "„Feels Like Home - Official Song F1 Dutch Grand Prix“ ist der Titelsong der gleichnamigen Veröffentlichung von DubVision.",
+      "fun_fact_es": "«Feels Like Home - Official Song F1 Dutch Grand Prix» es la canción que da título al lanzamiento homónimo de DubVision.",
+      "fun_fact_fr": "« Feels Like Home - Official Song F1 Dutch Grand Prix » est le morceau-titre de la publication éponyme de DubVision.",
+      "fun_fact_nl": "‘Feels Like Home - Official Song F1 Dutch Grand Prix’ is het titelnummer van de gelijknamige release van DubVision.",
+      "alt_artists": [
+        "Swedish House Mafia, Sting",
+        "Breach",
+        "Digitalism"
+      ]
+    },
+    {
+      "artist": "Michael Calfan",
+      "title": "Last Call",
+      "year": 2020,
+      "isrc": "NLZ542001133",
+      "uri": "spotify:track:6EYxiOpZoEa4UMWSMG9klG",
+      "uri_apple_music": "applemusic://track/1524646216",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1524646216"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1035333462",
+      "fun_fact": "“Last Call” is the title track of Michael Calfan’s release of the same name.",
+      "fun_fact_de": "„Last Call“ ist der Titelsong der gleichnamigen Veröffentlichung von Michael Calfan.",
+      "fun_fact_es": "«Last Call» es la canción que da título al lanzamiento homónimo de Michael Calfan.",
+      "fun_fact_fr": "« Last Call » est le morceau-titre de la publication éponyme de Michael Calfan.",
+      "fun_fact_nl": "‘Last Call’ is het titelnummer van de gelijknamige release van Michael Calfan.",
+      "alt_artists": [
+        "Gregory Porter, Claptone",
+        "Andain",
+        "CYRIL"
+      ]
+    },
+    {
+      "artist": "Purple Disco Machine, Moss Kena, The Knocks",
+      "title": "Fireworks (feat. Moss Kena & The Knocks)",
+      "year": 2017,
+      "isrc": "AUDCB1701705",
+      "uri": "spotify:track:5Iv4HuT9pKPi5WuE2ii3vs",
+      "uri_apple_music": "applemusic://track/1552308473",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1552308473"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1228452582",
+      "fun_fact": "“Fireworks (feat. Moss Kena & The Knocks)” is the title track of Purple Disco Machine’s release of the same name.",
+      "fun_fact_de": "„Fireworks (feat. Moss Kena & The Knocks)“ ist der Titelsong der gleichnamigen Veröffentlichung von Purple Disco Machine.",
+      "fun_fact_es": "«Fireworks (feat. Moss Kena & The Knocks)» es la canción que da título al lanzamiento homónimo de Purple Disco Machine.",
+      "fun_fact_fr": "« Fireworks (feat. Moss Kena & The Knocks) » est le morceau-titre de la publication éponyme de Purple Disco Machine.",
+      "fun_fact_nl": "‘Fireworks (feat. Moss Kena & The Knocks)’ is het titelnummer van de gelijknamige release van Purple Disco Machine.",
+      "alt_artists": [
+        "David Guetta, Nicky Romero",
+        "Sunnery James & Ryan Marciano, Kes Kross",
+        "MK"
+      ]
+    },
+    {
+      "artist": "Blasterjaxx, Hardwell",
+      "title": "Fifteen - Hardwell Radio Edit",
+      "year": 2013,
+      "isrc": "NLS241500213",
+      "uri": "spotify:track:75v4Ec37IYtmpiWu5vwdhY",
+      "uri_apple_music": "applemusic://track/1641051946",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1641051946"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1818071467",
+      "fun_fact": "“Fifteen - Hardwell Radio Edit” appears on Blasterjaxx’s release “Fifteen (Hardwell Edit)”.",
+      "fun_fact_de": "„Fifteen - Hardwell Radio Edit“ erschien auf der Veröffentlichung „Fifteen (Hardwell Edit)“ von Blasterjaxx.",
+      "fun_fact_es": "«Fifteen - Hardwell Radio Edit» aparece en el lanzamiento «Fifteen (Hardwell Edit)» de Blasterjaxx.",
+      "fun_fact_fr": "« Fifteen - Hardwell Radio Edit » figure sur la publication « Fifteen (Hardwell Edit) » de Blasterjaxx.",
+      "fun_fact_nl": "‘Fifteen - Hardwell Radio Edit’ staat op de release ‘Fifteen (Hardwell Edit)’ van Blasterjaxx.",
+      "alt_artists": [
+        "Lost Frequencies, Flynn",
+        "Axwell, Sebastian Ingrosso",
+        "Mark Knight, Funkagenda"
+      ]
+    },
+    {
+      "artist": "AN21, Max Vangeli, Julie McKnight",
+      "title": "Bombs Over Capitals",
+      "year": 2012,
+      "isrc": "USYBL1400344",
+      "uri": "spotify:track:5h6Tk8hZNjrTA12XiCNizA",
+      "uri_apple_music": "applemusic://track/557219597",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/557219597"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/119252048",
+      "fun_fact": "“Bombs Over Capitals” appears on AN21’s release “Bombs Over Capitals (feat. Julie McKnight)”.",
+      "fun_fact_de": "„Bombs Over Capitals“ erschien auf der Veröffentlichung „Bombs Over Capitals (feat. Julie McKnight)“ von AN21.",
+      "fun_fact_es": "«Bombs Over Capitals» aparece en el lanzamiento «Bombs Over Capitals (feat. Julie McKnight)» de AN21.",
+      "fun_fact_fr": "« Bombs Over Capitals » figure sur la publication « Bombs Over Capitals (feat. Julie McKnight) » de AN21.",
+      "fun_fact_nl": "‘Bombs Over Capitals’ staat op de release ‘Bombs Over Capitals (feat. Julie McKnight)’ van AN21.",
+      "alt_artists": [
+        "Dim Chris, Sebastien Drums, Avicii",
+        "Riva",
+        "Alesso, Becky Hill"
+      ]
+    },
+    {
+      "artist": "YOTTO, Joris Voorn",
+      "title": "Walls - Joris Voorn Remix",
+      "year": 2019,
+      "isrc": "GBEWA1900550",
+      "uri": "spotify:track:0lgHrv9qcVhwII3aW9aMZJ",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/637266152",
+      "fun_fact": "“Walls - Joris Voorn Remix” is the title track of YOTTO’s release of the same name.",
+      "fun_fact_de": "„Walls - Joris Voorn Remix“ ist der Titelsong der gleichnamigen Veröffentlichung von YOTTO.",
+      "fun_fact_es": "«Walls - Joris Voorn Remix» es la canción que da título al lanzamiento homónimo de YOTTO.",
+      "fun_fact_fr": "« Walls - Joris Voorn Remix » est le morceau-titre de la publication éponyme de YOTTO.",
+      "fun_fact_nl": "‘Walls - Joris Voorn Remix’ is het titelnummer van de gelijknamige release van YOTTO.",
+      "alt_artists": [
+        "Fragma",
+        "Armin van Buuren, The Stickmen Project",
+        "Marshall Jefferson, Solardo"
+      ]
+    },
+    {
+      "artist": "Lost Frequencies, Mathieu Koss",
+      "title": "Don't Leave Me Now",
+      "year": 2020,
+      "isrc": "NLF712007380",
+      "uri": "spotify:track:7JD624kzfc6wCWRpJ8ndTL",
+      "uri_apple_music": "applemusic://track/1555370252",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1555370252"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1235304042",
+      "fun_fact": "“Don't Leave Me Now” appears on Lost Frequencies’s release “Don't Leave Me Now (Remix Pack)”.",
+      "fun_fact_de": "„Don't Leave Me Now“ erschien auf der Veröffentlichung „Don't Leave Me Now (Remix Pack)“ von Lost Frequencies.",
+      "fun_fact_es": "«Don't Leave Me Now» aparece en el lanzamiento «Don't Leave Me Now (Remix Pack)» de Lost Frequencies.",
+      "fun_fact_fr": "« Don't Leave Me Now » figure sur la publication « Don't Leave Me Now (Remix Pack) » de Lost Frequencies.",
+      "fun_fact_nl": "‘Don't Leave Me Now’ staat op de release ‘Don't Leave Me Now (Remix Pack)’ van Lost Frequencies.",
+      "alt_artists": [
+        "Marlon Hoffstadt, DJ Daddy Trance",
+        "Boris Brejcha, Ginger",
+        "Calvin Harris, Rag'n'Bone Man, Robin Schulz"
+      ]
+    },
+    {
+      "artist": "The Chainsmokers, Daya, W&W",
+      "title": "Don't Let Me Down - W&W Remix",
+      "year": 2016,
+      "isrc": "USQX91600502",
+      "uri": "spotify:track:4s2rzq6ZpCfg5ODq0z79QG",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/122885994",
+      "fun_fact": "“Don't Let Me Down - W&W Remix” appears on The Chainsmokers’s release “Don't Let Me Down (Remixes)”.",
+      "fun_fact_de": "„Don't Let Me Down - W&W Remix“ erschien auf der Veröffentlichung „Don't Let Me Down (Remixes)“ von The Chainsmokers.",
+      "fun_fact_es": "«Don't Let Me Down - W&W Remix» aparece en el lanzamiento «Don't Let Me Down (Remixes)» de The Chainsmokers.",
+      "fun_fact_fr": "« Don't Let Me Down - W&W Remix » figure sur la publication « Don't Let Me Down (Remixes) » de The Chainsmokers.",
+      "fun_fact_nl": "‘Don't Let Me Down - W&W Remix’ staat op de release ‘Don't Let Me Down (Remixes)’ van The Chainsmokers.",
+      "alt_artists": [
+        "Topic, Fireboy DML, Nico Santos",
+        "FISHER, Kita Alexander",
+        "Calvin Harris, Disciples, Chris Lake"
+      ]
+    },
+    {
+      "artist": "Dom Dolla, Daya",
+      "title": "Dreamin (feat. Daya)",
+      "year": 2025,
+      "isrc": "USQX92407559",
+      "uri": "spotify:track:6oWmcKVK6atTCoWVYTdSg1",
+      "uri_apple_music": "applemusic://track/1793159120",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1793159120"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3215554981",
+      "fun_fact": "“Dreamin (feat. Daya)” is the title track of Dom Dolla’s release of the same name.",
+      "fun_fact_de": "„Dreamin (feat. Daya)“ ist der Titelsong der gleichnamigen Veröffentlichung von Dom Dolla.",
+      "fun_fact_es": "«Dreamin (feat. Daya)» es la canción que da título al lanzamiento homónimo de Dom Dolla.",
+      "fun_fact_fr": "« Dreamin (feat. Daya) » est le morceau-titre de la publication éponyme de Dom Dolla.",
+      "fun_fact_nl": "‘Dreamin (feat. Daya)’ is het titelnummer van de gelijknamige release van Dom Dolla.",
+      "alt_artists": [
+        "Armin van Buuren, AVIAN GRAYS, Jordan Shaw",
+        "CYRIL",
+        "Disclosure, Rivo, Eliza Doolittle"
+      ]
+    },
+    {
+      "artist": "Duke Dumont",
+      "title": "Ocean Drive",
+      "year": 2015,
+      "isrc": "GBUM71504503",
+      "uri": "spotify:track:0b6wdul3A5sQNpIOv03OxP",
+      "uri_apple_music": "applemusic://track/1445298941",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1445298941"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/104847438",
+      "fun_fact": "“Ocean Drive” is the title track of Duke Dumont’s release of the same name.",
+      "fun_fact_de": "„Ocean Drive“ ist der Titelsong der gleichnamigen Veröffentlichung von Duke Dumont.",
+      "fun_fact_es": "«Ocean Drive» es la canción que da título al lanzamiento homónimo de Duke Dumont.",
+      "fun_fact_fr": "« Ocean Drive » est le morceau-titre de la publication éponyme de Duke Dumont.",
+      "fun_fact_nl": "‘Ocean Drive’ is het titelnummer van de gelijknamige release van Duke Dumont.",
+      "alt_artists": [
+        "YOTTO, Joris Voorn",
+        "Anyma",
+        "Nosi"
+      ]
+    },
+    {
+      "artist": "David Guetta, Sia",
+      "title": "Beautiful People",
+      "year": 2025,
+      "isrc": "UKWLG2500016",
+      "uri": "spotify:track:4TwEdnSiTPDR1vg1QZ5K8W",
+      "uri_apple_music": "applemusic://track/1795765087",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1795765087"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3229131161",
+      "fun_fact": "“Beautiful People” is the title track of David Guetta’s release of the same name.",
+      "fun_fact_de": "„Beautiful People“ ist der Titelsong der gleichnamigen Veröffentlichung von David Guetta.",
+      "fun_fact_es": "«Beautiful People» es la canción que da título al lanzamiento homónimo de David Guetta.",
+      "fun_fact_fr": "« Beautiful People » est le morceau-titre de la publication éponyme de David Guetta.",
+      "fun_fact_nl": "‘Beautiful People’ is het titelnummer van de gelijknamige release van David Guetta.",
+      "alt_artists": [
+        "Cajmere, Dajae, Marco Lys, Green Velvet",
+        "HUGEL, Topic, Arash, Daecolm",
+        "Dustin Zahn, Len Faki"
+      ]
+    },
+    {
+      "artist": "Axwell",
+      "title": "Center Of The Universe - Original Radio Edit",
+      "year": 2013,
+      "isrc": "GBKCF1300243",
+      "uri": "spotify:track:3ScScD92jv68hPaz0GfK8s",
+      "uri_apple_music": "applemusic://track/656951677",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/656951677"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/718335942",
+      "fun_fact": "“Center Of The Universe - Original Radio Edit” appears on Axwell’s release “Center Of The Universe”.",
+      "fun_fact_de": "„Center Of The Universe - Original Radio Edit“ erschien auf der Veröffentlichung „Center Of The Universe“ von Axwell.",
+      "fun_fact_es": "«Center Of The Universe - Original Radio Edit» aparece en el lanzamiento «Center Of The Universe» de Axwell.",
+      "fun_fact_fr": "« Center Of The Universe - Original Radio Edit » figure sur la publication « Center Of The Universe » de Axwell.",
+      "fun_fact_nl": "‘Center Of The Universe - Original Radio Edit’ staat op de release ‘Center Of The Universe’ van Axwell.",
+      "alt_artists": [
+        "Vintage Culture, Goodboys",
+        "Bag Raiders",
+        "Eric Prydz, Floyd"
+      ]
+    },
+    {
+      "artist": "Tiesto v Diplo, Busta Rhymes",
+      "title": "C'Mon (Catch 'Em by Surprise)",
+      "year": 2011,
+      "isrc": "GBENL1000466",
+      "uri": "spotify:track:5iYLNquuwN4VzJROkA6yjY",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/9808783",
+      "fun_fact": "“C'Mon (Catch 'Em by Surprise)” is the title track of Tiesto v Diplo’s release of the same name.",
+      "fun_fact_de": "„C'Mon (Catch 'Em by Surprise)“ ist der Titelsong der gleichnamigen Veröffentlichung von Tiesto v Diplo.",
+      "fun_fact_es": "«C'Mon (Catch 'Em by Surprise)» es la canción que da título al lanzamiento homónimo de Tiesto v Diplo.",
+      "fun_fact_fr": "« C'Mon (Catch 'Em by Surprise) » est le morceau-titre de la publication éponyme de Tiesto v Diplo.",
+      "fun_fact_nl": "‘C'Mon (Catch 'Em by Surprise)’ is het titelnummer van de gelijknamige release van Tiesto v Diplo.",
+      "alt_artists": [
+        "Laidback Luke, Steve Angello",
+        "Loofy, Anyma, Layton Giordani",
+        "&ME, Black Coffee, Keinemusik"
+      ]
+    },
+    {
+      "artist": "Kelis, Alex Wann",
+      "title": "Milkshake 20 - Alex Wann Remix",
+      "year": 2023,
+      "isrc": "QMRSZ2302091",
+      "uri": "spotify:track:49wEdWGkL2CcOrXEKklXtJ",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3804157712",
+      "fun_fact": "“Milkshake 20 - Alex Wann Remix” is the title track of Kelis’s release of the same name.",
+      "fun_fact_de": "„Milkshake 20 - Alex Wann Remix“ ist der Titelsong der gleichnamigen Veröffentlichung von Kelis.",
+      "fun_fact_es": "«Milkshake 20 - Alex Wann Remix» es la canción que da título al lanzamiento homónimo de Kelis.",
+      "fun_fact_fr": "« Milkshake 20 - Alex Wann Remix » est le morceau-titre de la publication éponyme de Kelis.",
+      "fun_fact_nl": "‘Milkshake 20 - Alex Wann Remix’ is het titelnummer van de gelijknamige release van Kelis.",
+      "alt_artists": [
+        "Armin van Buuren, Agents Of Time, ORKID",
+        "ILLENIUM, Valerie Broussard, NURKO",
+        "Martin Solveig, Good Times Ahead"
+      ]
+    },
+    {
+      "artist": "Dimitri Vegas & Like Mike, Armin van Buuren, W&W",
+      "title": "Repeat After Me",
+      "year": 2019,
+      "isrc": "NLF711900044",
+      "uri": "spotify:track:1F9xcExF9W7m5BxTdlJLED",
+      "uri_apple_music": "applemusic://track/1445933331",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1445933331"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/607484382",
+      "fun_fact": "“Repeat After Me” is the title track of Dimitri Vegas & Like Mike’s release of the same name.",
+      "fun_fact_de": "„Repeat After Me“ ist der Titelsong der gleichnamigen Veröffentlichung von Dimitri Vegas & Like Mike.",
+      "fun_fact_es": "«Repeat After Me» es la canción que da título al lanzamiento homónimo de Dimitri Vegas & Like Mike.",
+      "fun_fact_fr": "« Repeat After Me » est le morceau-titre de la publication éponyme de Dimitri Vegas & Like Mike.",
+      "fun_fact_nl": "‘Repeat After Me’ is het titelnummer van de gelijknamige release van Dimitri Vegas & Like Mike.",
+      "alt_artists": [
+        "Zonderling, Andreas Moss",
+        "KETTAMA, Interplanetary Criminal",
+        "Zedd, Foxes"
+      ]
+    },
+    {
+      "artist": "Martin Garrix, Brooks",
+      "title": "Byte",
+      "year": 2017,
+      "isrc": "NLM5S1600054",
+      "uri": "spotify:track:20hsdn8oITBsuWNLhzr5eh",
+      "uri_apple_music": "applemusic://track/1223347695",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1223347695"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/346578511",
+      "fun_fact": "“Byte” is the title track of Martin Garrix’s release of the same name.",
+      "fun_fact_de": "„Byte“ ist der Titelsong der gleichnamigen Veröffentlichung von Martin Garrix.",
+      "fun_fact_es": "«Byte» es la canción que da título al lanzamiento homónimo de Martin Garrix.",
+      "fun_fact_fr": "« Byte » est le morceau-titre de la publication éponyme de Martin Garrix.",
+      "fun_fact_nl": "‘Byte’ is het titelnummer van de gelijknamige release van Martin Garrix.",
+      "alt_artists": [
+        "Armin van Buuren, Shapov",
+        "Grooveyard, Nicky Romero",
+        "Eliza Rose, Interplanetary Criminal"
+      ]
+    },
+    {
+      "artist": "James Hype, Sam Harper, Bobby Harvey",
+      "title": "Waterfalls (feat. Sam Harper & Bobby Harvey)",
+      "year": 2025,
+      "isrc": "GBUM72506154",
+      "uri": "spotify:track:1OcV53oesLQw3VTW9I3uD3",
+      "uri_apple_music": "applemusic://track/1827379987",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1827379987"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3574795411",
+      "fun_fact": "“Waterfalls (feat. Sam Harper & Bobby Harvey)” appears on James Hype’s release “Waterfalls (Samurai Jay Remix)”.",
+      "fun_fact_de": "„Waterfalls (feat. Sam Harper & Bobby Harvey)“ erschien auf der Veröffentlichung „Waterfalls (Samurai Jay Remix)“ von James Hype.",
+      "fun_fact_es": "«Waterfalls (feat. Sam Harper & Bobby Harvey)» aparece en el lanzamiento «Waterfalls (Samurai Jay Remix)» de James Hype.",
+      "fun_fact_fr": "« Waterfalls (feat. Sam Harper & Bobby Harvey) » figure sur la publication « Waterfalls (Samurai Jay Remix) » de James Hype.",
+      "fun_fact_nl": "‘Waterfalls (feat. Sam Harper & Bobby Harvey)’ staat op de release ‘Waterfalls (Samurai Jay Remix)’ van James Hype.",
+      "alt_artists": [
+        "Steve Aoki, Wynter Gordon",
+        "Bob Sinclar, FISHER, Steve Edwards",
+        "Switch"
+      ]
+    },
+    {
+      "artist": "ILLENIUM, Valerie Broussard, NURKO",
+      "title": "Sideways",
+      "year": 2021,
+      "isrc": "ZZOPM2105395",
+      "uri": "spotify:track:5Kpqr7t4KCI8vrnWrQ4H7B",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1355594372",
+      "fun_fact": "“Sideways” is the title track of ILLENIUM’s release of the same name.",
+      "fun_fact_de": "„Sideways“ ist der Titelsong der gleichnamigen Veröffentlichung von ILLENIUM.",
+      "fun_fact_es": "«Sideways» es la canción que da título al lanzamiento homónimo de ILLENIUM.",
+      "fun_fact_fr": "« Sideways » est le morceau-titre de la publication éponyme de ILLENIUM.",
+      "fun_fact_nl": "‘Sideways’ is het titelnummer van de gelijknamige release van ILLENIUM.",
+      "alt_artists": [
+        "Binary Finary, Paul van Dyk",
+        "Kelis",
+        "Butch, Kölsch"
+      ]
+    },
+    {
+      "artist": "Martin Solveig, Madeon",
+      "title": "The Night Out - Madeon Remix",
+      "year": 2011,
+      "isrc": "FR2PA1200040",
+      "uri": "spotify:track:5fTND2n5FN6uO5UljkQRh5",
+      "uri_apple_music": "applemusic://track/513030940",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/513030940"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3803546532",
+      "fun_fact": "“The Night Out - Madeon Remix” appears on Martin Solveig’s release “The Night Out”.",
+      "fun_fact_de": "„The Night Out - Madeon Remix“ erschien auf der Veröffentlichung „The Night Out“ von Martin Solveig.",
+      "fun_fact_es": "«The Night Out - Madeon Remix» aparece en el lanzamiento «The Night Out» de Martin Solveig.",
+      "fun_fact_fr": "« The Night Out - Madeon Remix » figure sur la publication « The Night Out » de Martin Solveig.",
+      "fun_fact_nl": "‘The Night Out - Madeon Remix’ staat op de release ‘The Night Out’ van Martin Solveig.",
+      "alt_artists": [
+        "Tim Mason, Steve Angello",
+        "FISHER, Kita Alexander",
+        "Alesso, TINI"
+      ]
+    },
+    {
+      "artist": "Paul Woolford, Diplo, Kareen Lomax",
+      "title": "Looking For Me",
+      "year": 2020,
+      "isrc": "USZ4V2000222",
+      "uri": "spotify:track:2KYnSFIrSbaKUXWetW7Klt",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/964219992",
+      "fun_fact": "“Looking For Me” is the title track of Paul Woolford’s release of the same name.",
+      "fun_fact_de": "„Looking For Me“ ist der Titelsong der gleichnamigen Veröffentlichung von Paul Woolford.",
+      "fun_fact_es": "«Looking For Me» es la canción que da título al lanzamiento homónimo de Paul Woolford.",
+      "fun_fact_fr": "« Looking For Me » est le morceau-titre de la publication éponyme de Paul Woolford.",
+      "fun_fact_nl": "‘Looking For Me’ is het titelnummer van de gelijknamige release van Paul Woolford.",
+      "alt_artists": [
+        "Empire Of The Sun, Zedd",
+        "Tiësto, Dzeko, Preme, Post Malone",
+        "Don Diablo, Matt Nash"
+      ]
+    },
+    {
+      "artist": "Hardwell",
+      "title": "Three Triangles (Losing My Religion)",
+      "year": 2014,
+      "isrc": "DEL711310217",
+      "uri": "spotify:track:6PJQQcGlhQZV2JzhD9uwta",
+      "uri_apple_music": "applemusic://track/662136067",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/662136067"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/86000229",
+      "fun_fact": "“Three Triangles (Losing My Religion)” is the title track of Hardwell’s release of the same name.",
+      "fun_fact_de": "„Three Triangles (Losing My Religion)“ ist der Titelsong der gleichnamigen Veröffentlichung von Hardwell.",
+      "fun_fact_es": "«Three Triangles (Losing My Religion)» es la canción que da título al lanzamiento homónimo de Hardwell.",
+      "fun_fact_fr": "« Three Triangles (Losing My Religion) » est le morceau-titre de la publication éponyme de Hardwell.",
+      "fun_fact_nl": "‘Three Triangles (Losing My Religion)’ is het titelnummer van de gelijknamige release van Hardwell.",
+      "alt_artists": [
+        "KI/KI, Marlon Hoffstadt",
+        "Martin Garrix, Brooks",
+        "Fred again.., The Blessed Madonna"
+      ]
+    },
+    {
+      "artist": "San Holo",
+      "title": "Light",
+      "year": 2017,
+      "isrc": "NLRD51630379",
+      "uri": "spotify:track:6jq6rcOikCZAmjliAgAmfT",
+      "uri_apple_music": "applemusic://track/1202254004",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1202254004"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/141822553",
+      "fun_fact": "“Light” is the title track of San Holo’s release of the same name.",
+      "fun_fact_de": "„Light“ ist der Titelsong der gleichnamigen Veröffentlichung von San Holo.",
+      "fun_fact_es": "«Light» es la canción que da título al lanzamiento homónimo de San Holo.",
+      "fun_fact_fr": "« Light » est le morceau-titre de la publication éponyme de San Holo.",
+      "fun_fact_nl": "‘Light’ is het titelnummer van de gelijknamige release van San Holo.",
+      "alt_artists": [
+        "Joel Corry, Da Hool",
+        "Cassius",
+        "Matisse & Sadko"
+      ]
+    },
+    {
+      "artist": "Afro Medusa",
+      "title": "Pasilda",
+      "year": 1996,
+      "isrc": "GBCMH9600500",
+      "uri": "spotify:track:6VQDaTTTHeLUhKaHcDe2Bz",
+      "uri_apple_music": "applemusic://track/1080608741",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1080608741"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/118516574",
+      "fun_fact": "“Pasilda” is the title track of Afro Medusa’s release of the same name.",
+      "fun_fact_de": "„Pasilda“ ist der Titelsong der gleichnamigen Veröffentlichung von Afro Medusa.",
+      "fun_fact_es": "«Pasilda» es la canción que da título al lanzamiento homónimo de Afro Medusa.",
+      "fun_fact_fr": "« Pasilda » est le morceau-titre de la publication éponyme de Afro Medusa.",
+      "fun_fact_nl": "‘Pasilda’ is het titelnummer van de gelijknamige release van Afro Medusa.",
+      "alt_artists": [
+        "Rui Da Silva, Cassandra",
+        "Calvin Harris, Sam Smith",
+        "Tiësto, Poppy Baskcomb"
+      ]
+    },
+    {
+      "artist": "Hannah Laing, RoRo",
+      "title": "Good Love",
+      "year": 2023,
+      "isrc": "GBUM72304092",
+      "uri": "spotify:track:0ZVjgfaC2Ptrod9v6p9KFP",
+      "uri_apple_music": "applemusic://track/1683710992",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1683710992"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2269935937",
+      "fun_fact": "“Good Love” is the title track of Hannah Laing’s release of the same name.",
+      "fun_fact_de": "„Good Love“ ist der Titelsong der gleichnamigen Veröffentlichung von Hannah Laing.",
+      "fun_fact_es": "«Good Love» es la canción que da título al lanzamiento homónimo de Hannah Laing.",
+      "fun_fact_fr": "« Good Love » est le morceau-titre de la publication éponyme de Hannah Laing.",
+      "fun_fact_nl": "‘Good Love’ is het titelnummer van de gelijknamige release van Hannah Laing.",
+      "alt_artists": [
+        "Bodyrox, Luciana, D. Ramirez",
+        "Martin Garrix, Matisse & Sadko, Michel Zitron",
+        "Dirty South, Evermore"
+      ]
+    },
+    {
+      "artist": "Tocadisco",
+      "title": "Morumbi",
+      "year": 2021,
+      "isrc": "QMEU32108721",
+      "uri": "spotify:track:5WVf0NhzUJlXASdLgjb6vh",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1360514932",
+      "fun_fact": "“Morumbi” appears on Tocadisco’s release “Legacy Part 1”.",
+      "fun_fact_de": "„Morumbi“ erschien auf der Veröffentlichung „Legacy Part 1“ von Tocadisco.",
+      "fun_fact_es": "«Morumbi» aparece en el lanzamiento «Legacy Part 1» de Tocadisco.",
+      "fun_fact_fr": "« Morumbi » figure sur la publication « Legacy Part 1 » de Tocadisco.",
+      "fun_fact_nl": "‘Morumbi’ staat op de release ‘Legacy Part 1’ van Tocadisco.",
+      "alt_artists": [
+        "Justice",
+        "David Guetta, Akon",
+        "Veracocha"
+      ]
+    },
+    {
+      "artist": "BICEP, Four Tet",
+      "title": "Opal - Four Tet Remix",
+      "year": 2018,
+      "isrc": "GBCFB1800028",
+      "uri": "spotify:track:3VtTuQ6lypMoOBcm6VMzdh",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/470137032",
+      "fun_fact": "“Opal - Four Tet Remix” is the title track of BICEP’s release of the same name.",
+      "fun_fact_de": "„Opal - Four Tet Remix“ ist der Titelsong der gleichnamigen Veröffentlichung von BICEP.",
+      "fun_fact_es": "«Opal - Four Tet Remix» es la canción que da título al lanzamiento homónimo de BICEP.",
+      "fun_fact_fr": "« Opal - Four Tet Remix » est le morceau-titre de la publication éponyme de BICEP.",
+      "fun_fact_nl": "‘Opal - Four Tet Remix’ is het titelnummer van de gelijknamige release van BICEP.",
+      "alt_artists": [
+        "Kelis",
+        "Sebastian Ingrosso, Céline Dion",
+        "Zedd, Matthew Koma"
+      ]
+    },
+    {
+      "artist": "Martin Solveig",
+      "title": "My Love",
+      "year": 2018,
+      "isrc": "FR2PA1800100",
+      "uri": "spotify:track:7pZ00FeIkpuzHskuDWQnU5",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/518483152",
+      "fun_fact": "“My Love” is the title track of Martin Solveig’s release of the same name.",
+      "fun_fact_de": "„My Love“ ist der Titelsong der gleichnamigen Veröffentlichung von Martin Solveig.",
+      "fun_fact_es": "«My Love» es la canción que da título al lanzamiento homónimo de Martin Solveig.",
+      "fun_fact_fr": "« My Love » est le morceau-titre de la publication éponyme de Martin Solveig.",
+      "fun_fact_nl": "‘My Love’ is het titelnummer van de gelijknamige release van Martin Solveig.",
+      "alt_artists": [
+        "Mason",
+        "KI/KI, Marlon Hoffstadt",
+        "Josh Butler, Bontan, Pleasurekraft"
+      ]
+    },
+    {
+      "artist": "Rusko, Netsky",
+      "title": "Everyday - Netsky Remix",
+      "year": 2011,
+      "isrc": "USZ4V1100020",
+      "uri": "spotify:track:76kY7vDRhosNwxcml9LwTR",
+      "uri_apple_music": "applemusic://track/1683405363",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1683405363"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/69000046",
+      "fun_fact": "“Everyday - Netsky Remix” appears on Rusko’s release “Everyday”.",
+      "fun_fact_de": "„Everyday - Netsky Remix“ erschien auf der Veröffentlichung „Everyday“ von Rusko.",
+      "fun_fact_es": "«Everyday - Netsky Remix» aparece en el lanzamiento «Everyday» de Rusko.",
+      "fun_fact_fr": "« Everyday - Netsky Remix » figure sur la publication « Everyday » de Rusko.",
+      "fun_fact_nl": "‘Everyday - Netsky Remix’ staat op de release ‘Everyday’ van Rusko.",
+      "alt_artists": [
+        "Sebastian Ingrosso",
+        "David Guetta, OneRepublic",
+        "Surf Mesa, Emilee, ARTY"
+      ]
+    },
+    {
+      "artist": "Kygo, Rita Ora",
+      "title": "Carry On (from the Original Motion Picture \"POKÉMON Detective Pikachu\")",
+      "year": 2019,
+      "isrc": "USRC11900838",
+      "uri": "spotify:track:3y3brCCecHC3Db18aIOnny",
+      "uri_apple_music": "applemusic://track/1459399470",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1459399470"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/663258512",
+      "fun_fact": "“Carry On (from the Original Motion Picture \"POKÉMON Detective Pikachu\")” is the title track of Kygo’s release of the same name.",
+      "fun_fact_de": "„Carry On (from the Original Motion Picture \"POKÉMON Detective Pikachu\")“ ist der Titelsong der gleichnamigen Veröffentlichung von Kygo.",
+      "fun_fact_es": "«Carry On (from the Original Motion Picture \"POKÉMON Detective Pikachu\")» es la canción que da título al lanzamiento homónimo de Kygo.",
+      "fun_fact_fr": "« Carry On (from the Original Motion Picture \"POKÉMON Detective Pikachu\") » est le morceau-titre de la publication éponyme de Kygo.",
+      "fun_fact_nl": "‘Carry On (from the Original Motion Picture \"POKÉMON Detective Pikachu\")’ is het titelnummer van de gelijknamige release van Kygo.",
+      "alt_artists": [
+        "Dimitri Vegas & Like Mike, Regi",
+        "Dimitri Vegas & Like Mike, Sander van Doorn",
+        "Kings Of Tomorrow"
+      ]
+    },
+    {
+      "artist": "Calvin Harris, Rag'n'Bone Man, Robin Schulz",
+      "title": "Giant (with Rag'n'Bone Man) - Robin Schulz Remix",
+      "year": 2019,
+      "isrc": "GBARL1900161",
+      "uri": "spotify:track:7kLWq3Z9XSs8cHTLB9nl0w",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2436205725",
+      "fun_fact": "“Giant (with Rag'n'Bone Man) - Robin Schulz Remix” appears on Calvin Harris’s release “Giant (Remixes)”.",
+      "fun_fact_de": "„Giant (with Rag'n'Bone Man) - Robin Schulz Remix“ erschien auf der Veröffentlichung „Giant (Remixes)“ von Calvin Harris.",
+      "fun_fact_es": "«Giant (with Rag'n'Bone Man) - Robin Schulz Remix» aparece en el lanzamiento «Giant (Remixes)» de Calvin Harris.",
+      "fun_fact_fr": "« Giant (with Rag'n'Bone Man) - Robin Schulz Remix » figure sur la publication « Giant (Remixes) » de Calvin Harris.",
+      "fun_fact_nl": "‘Giant (with Rag'n'Bone Man) - Robin Schulz Remix’ staat op de release ‘Giant (Remixes)’ van Calvin Harris.",
+      "alt_artists": [
+        "Zonderling, Andreas Moss",
+        "Avicii, Sebastien Drums",
+        "Martin Garrix, MOTi"
+      ]
+    },
+    {
+      "artist": "Boris Brejcha, Ginger",
+      "title": "Happinezz (feat. Ginger)",
+      "year": 2020,
+      "isrc": "USUS11900410",
+      "uri": "spotify:track:3oWWPvrKwFF8gNOv6tOXZd",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/759015352",
+      "fun_fact": "“Happinezz (feat. Ginger)” appears on Boris Brejcha’s release “Space Diver”.",
+      "fun_fact_de": "„Happinezz (feat. Ginger)“ erschien auf der Veröffentlichung „Space Diver“ von Boris Brejcha.",
+      "fun_fact_es": "«Happinezz (feat. Ginger)» aparece en el lanzamiento «Space Diver» de Boris Brejcha.",
+      "fun_fact_fr": "« Happinezz (feat. Ginger) » figure sur la publication « Space Diver » de Boris Brejcha.",
+      "fun_fact_nl": "‘Happinezz (feat. Ginger)’ staat op de release ‘Space Diver’ van Boris Brejcha.",
+      "alt_artists": [
+        "Jessie Ware, Disclosure",
+        "Miss Monique",
+        "MK, Dom Dolla"
+      ]
+    },
+    {
+      "artist": "Chris Lorenzo",
+      "title": "Pump",
+      "year": 2023,
+      "isrc": "CA5KR2350113",
+      "uri": "spotify:track:37Jh3OXqliOxKjtl1aO49y",
+      "uri_apple_music": "applemusic://track/1688025984",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1688025984"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2285549067",
+      "fun_fact": "“Pump” is the title track of Chris Lorenzo’s release of the same name.",
+      "fun_fact_de": "„Pump“ ist der Titelsong der gleichnamigen Veröffentlichung von Chris Lorenzo.",
+      "fun_fact_es": "«Pump» es la canción que da título al lanzamiento homónimo de Chris Lorenzo.",
+      "fun_fact_fr": "« Pump » est le morceau-titre de la publication éponyme de Chris Lorenzo.",
+      "fun_fact_nl": "‘Pump’ is het titelnummer van de gelijknamige release van Chris Lorenzo.",
+      "alt_artists": [
+        "Dimitri Vegas, Vin, Zion",
+        "Rebūke, Storm, Jam El Mar",
+        "Rampa, Adam Port, &ME, chuala, Keinemusik"
+      ]
+    },
+    {
+      "artist": "Hardwell, Trevor Guthrie, Sunnery James & Ryan Marciano",
+      "title": "Summer Air - Sunnery James & Ryan Marciano Remix",
+      "year": 2019,
+      "isrc": "NLQ8D1900466",
+      "uri": "spotify:track:3jq5IrHLNYoWg57xYrqVaU",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1755258847",
+      "fun_fact": "“Summer Air - Sunnery James & Ryan Marciano Remix” appears on Hardwell’s release “Hardwell presents Revealed Vol. 10”.",
+      "fun_fact_de": "„Summer Air - Sunnery James & Ryan Marciano Remix“ erschien auf der Veröffentlichung „Hardwell presents Revealed Vol. 10“ von Hardwell.",
+      "fun_fact_es": "«Summer Air - Sunnery James & Ryan Marciano Remix» aparece en el lanzamiento «Hardwell presents Revealed Vol. 10» de Hardwell.",
+      "fun_fact_fr": "« Summer Air - Sunnery James & Ryan Marciano Remix » figure sur la publication « Hardwell presents Revealed Vol. 10 » de Hardwell.",
+      "fun_fact_nl": "‘Summer Air - Sunnery James & Ryan Marciano Remix’ staat op de release ‘Hardwell presents Revealed Vol. 10’ van Hardwell.",
+      "alt_artists": [
+        "Marlon Hoffstadt, FISHER",
+        "Michael Calfan, Axwell",
+        "Fred again.."
+      ]
+    },
+    {
+      "artist": "Martin Garrix, Sem Vox, Jaimes",
+      "title": "Gravity",
+      "year": 2024,
+      "isrc": "NLM5S2402316",
+      "uri": "spotify:track:1vMMwDCd1Hnb91a3x9MdfX",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3036450081",
+      "fun_fact": "“Gravity” is the title track of Martin Garrix’s release of the same name.",
+      "fun_fact_de": "„Gravity“ ist der Titelsong der gleichnamigen Veröffentlichung von Martin Garrix.",
+      "fun_fact_es": "«Gravity» es la canción que da título al lanzamiento homónimo de Martin Garrix.",
+      "fun_fact_fr": "« Gravity » est le morceau-titre de la publication éponyme de Martin Garrix.",
+      "fun_fact_nl": "‘Gravity’ is het titelnummer van de gelijknamige release van Martin Garrix.",
+      "alt_artists": [
+        "M.A.N.D.Y., Booka Shade",
+        "Alesso, Katy Perry",
+        "Steve Angello"
+      ]
+    },
+    {
+      "artist": "Daft Punk",
+      "title": "Da Funk",
+      "year": 1995,
+      "isrc": "GBDUW0600006",
+      "uri": "spotify:track:0MyY4WcN7DIfbSmp5yej5z",
+      "uri_apple_music": "applemusic://track/696885792",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/696885792"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3129772",
+      "fun_fact": "“Da Funk” appears on Daft Punk’s release “Homework”.",
+      "fun_fact_de": "„Da Funk“ erschien auf der Veröffentlichung „Homework“ von Daft Punk.",
+      "fun_fact_es": "«Da Funk» aparece en el lanzamiento «Homework» de Daft Punk.",
+      "fun_fact_fr": "« Da Funk » figure sur la publication « Homework » de Daft Punk.",
+      "fun_fact_nl": "‘Da Funk’ staat op de release ‘Homework’ van Daft Punk.",
+      "alt_artists": [
+        "Miss Monique",
+        "Dimitri Vegas & Like Mike, Regi",
+        "Axwell /\\ Ingrosso, RØMANS"
+      ]
+    },
+    {
+      "artist": "Gouryella, Ferry Corsten",
+      "title": "Gouryella",
+      "year": 1999,
+      "isrc": "NLQ880800264",
+      "uri": "spotify:track:6xl5vg5rhmbGI7kNML1IP4",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/978167882",
+      "fun_fact": "“Gouryella” appears on Gouryella’s release “A State Of Trance Top 20 - June 2020 (Selected by Armin van Buuren)”.",
+      "fun_fact_de": "„Gouryella“ erschien auf der Veröffentlichung „A State Of Trance Top 20 - June 2020 (Selected by Armin van Buuren)“ von Gouryella.",
+      "fun_fact_es": "«Gouryella» aparece en el lanzamiento «A State Of Trance Top 20 - June 2020 (Selected by Armin van Buuren)» de Gouryella.",
+      "fun_fact_fr": "« Gouryella » figure sur la publication « A State Of Trance Top 20 - June 2020 (Selected by Armin van Buuren) » de Gouryella.",
+      "fun_fact_nl": "‘Gouryella’ staat op de release ‘A State Of Trance Top 20 - June 2020 (Selected by Armin van Buuren)’ van Gouryella.",
+      "alt_artists": [
+        "Max Dean, Luke Dean, Locky",
+        "Sia, Diplo, Labrinth, LSD, Lost Frequencies",
+        "David Guetta, Akon"
+      ]
+    },
+    {
+      "artist": "Fred again.., Romy, HAAi",
+      "title": "Lights Out",
+      "year": 2022,
+      "isrc": "GBAHS2101176",
+      "uri": "spotify:track:5UatawMsGULDVG2h8wE1KS",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1622182282",
+      "fun_fact": "“Lights Out” is the title track of Fred again..’s release of the same name.",
+      "fun_fact_de": "„Lights Out“ ist der Titelsong der gleichnamigen Veröffentlichung von Fred again...",
+      "fun_fact_es": "«Lights Out» es la canción que da título al lanzamiento homónimo de Fred again...",
+      "fun_fact_fr": "« Lights Out » est le morceau-titre de la publication éponyme de Fred again...",
+      "fun_fact_nl": "‘Lights Out’ is het titelnummer van de gelijknamige release van Fred again...",
+      "alt_artists": [
+        "MEDUZA, James Carter, Elley Duhé, FAST BOY",
+        "Josh Butler, Bontan, Pleasurekraft",
+        "deadmau5, Chris James"
+      ]
+    },
+    {
+      "artist": "The Temper Trap, John Summit, Silver Panda",
+      "title": "Sweet Disposition - John Summit & Silver Panda Remix",
+      "year": 2024,
+      "isrc": "GBCPZ2422741",
+      "uri": "spotify:track:7rXke3ttpL2uXel9Nesf4u",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3156150631",
+      "fun_fact": "“Sweet Disposition - John Summit & Silver Panda Remix” is the title track of The Temper Trap’s release of the same name.",
+      "fun_fact_de": "„Sweet Disposition - John Summit & Silver Panda Remix“ ist der Titelsong der gleichnamigen Veröffentlichung von The Temper Trap.",
+      "fun_fact_es": "«Sweet Disposition - John Summit & Silver Panda Remix» es la canción que da título al lanzamiento homónimo de The Temper Trap.",
+      "fun_fact_fr": "« Sweet Disposition - John Summit & Silver Panda Remix » est le morceau-titre de la publication éponyme de The Temper Trap.",
+      "fun_fact_nl": "‘Sweet Disposition - John Summit & Silver Panda Remix’ is het titelnummer van de gelijknamige release van The Temper Trap.",
+      "alt_artists": [
+        "James Hype, Major Lazer",
+        "Sub Focus, Culture Shock, Fragma",
+        "Krystal Klear"
+      ]
+    },
+    {
+      "artist": "Zedd, Foxes",
+      "title": "Clarity (feat. Foxes) - Tiësto Remix",
+      "year": 2013,
+      "isrc": "NLZ541300486",
+      "uri": "spotify:track:4jIQ0wouzKHbi1fYHORIN0",
+      "uri_apple_music": "applemusic://track/1538815598",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1538815598"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3623153202",
+      "fun_fact": "“Clarity (feat. Foxes) - Tiësto Remix” appears on Zedd’s release “Move Mode”.",
+      "fun_fact_de": "„Clarity (feat. Foxes) - Tiësto Remix“ erschien auf der Veröffentlichung „Move Mode“ von Zedd.",
+      "fun_fact_es": "«Clarity (feat. Foxes) - Tiësto Remix» aparece en el lanzamiento «Move Mode» de Zedd.",
+      "fun_fact_fr": "« Clarity (feat. Foxes) - Tiësto Remix » figure sur la publication « Move Mode » de Zedd.",
+      "fun_fact_nl": "‘Clarity (feat. Foxes) - Tiësto Remix’ staat op de release ‘Move Mode’ van Zedd.",
+      "alt_artists": [
+        "The Prodigy",
+        "The Chainsmokers, Bebe Rexha",
+        "Sam Feldt, Zonderling"
+      ]
+    },
+    {
+      "artist": "Loofy, Anyma, Layton Giordani",
+      "title": "Last Night - Anyma x Layton Giordani Remix",
+      "year": 2023,
+      "isrc": "USNRS2443522",
+      "uri": "spotify:track:22hOKPKTAegLoLJKM33K4a",
+      "uri_apple_music": "applemusic://track/1745370712",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1745370712"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2789828922",
+      "fun_fact": "“Last Night - Anyma x Layton Giordani Remix” is the title track of Loofy’s release of the same name.",
+      "fun_fact_de": "„Last Night - Anyma x Layton Giordani Remix“ ist der Titelsong der gleichnamigen Veröffentlichung von Loofy.",
+      "fun_fact_es": "«Last Night - Anyma x Layton Giordani Remix» es la canción que da título al lanzamiento homónimo de Loofy.",
+      "fun_fact_fr": "« Last Night - Anyma x Layton Giordani Remix » est le morceau-titre de la publication éponyme de Loofy.",
+      "fun_fact_nl": "‘Last Night - Anyma x Layton Giordani Remix’ is het titelnummer van de gelijknamige release van Loofy.",
+      "alt_artists": [
+        "Skrillex, Starrah, Four Tet",
+        "Martin Garrix, Brooks",
+        "Martin Garrix, Matisse & Sadko, Alex Aris"
+      ]
+    },
+    {
+      "artist": "Sara Landry, Alt8",
+      "title": "Heaven",
+      "year": 2024,
+      "isrc": "FRX762422912",
+      "uri": "spotify:track:79nRqde4cRssDzkJcu275a",
+      "uri_apple_music": "applemusic://track/1744921732",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1744921732"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2785441732",
+      "fun_fact": "“Heaven” is the title track of Sara Landry’s release of the same name.",
+      "fun_fact_de": "„Heaven“ ist der Titelsong der gleichnamigen Veröffentlichung von Sara Landry.",
+      "fun_fact_es": "«Heaven» es la canción que da título al lanzamiento homónimo de Sara Landry.",
+      "fun_fact_fr": "« Heaven » est le morceau-titre de la publication éponyme de Sara Landry.",
+      "fun_fact_nl": "‘Heaven’ is het titelnummer van de gelijknamige release van Sara Landry.",
+      "alt_artists": [
+        "Shouse, David Guetta",
+        "Mark Knight, Funkagenda",
+        "Marc Benjamin, Marcus Santoro, David Pietras"
+      ]
+    },
+    {
+      "artist": "Round Table Knights, Bauchamp",
+      "title": "Calypso",
+      "year": 2010,
+      "isrc": "GB6NC1000221",
+      "uri": "spotify:track:7cbXhbH8Is98BrDA3Yglck",
+      "uri_apple_music": "applemusic://track/362491548",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/362491548"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1712190177",
+      "fun_fact": "“Calypso” is the title track of Round Table Knights’s release of the same name.",
+      "fun_fact_de": "„Calypso“ ist der Titelsong der gleichnamigen Veröffentlichung von Round Table Knights.",
+      "fun_fact_es": "«Calypso» es la canción que da título al lanzamiento homónimo de Round Table Knights.",
+      "fun_fact_fr": "« Calypso » est le morceau-titre de la publication éponyme de Round Table Knights.",
+      "fun_fact_nl": "‘Calypso’ is het titelnummer van de gelijknamige release van Round Table Knights.",
+      "alt_artists": [
+        "Swedish House Mafia, Niki & The Dove",
+        "David Guetta, MORTEN, Aloe Blacc",
+        "Josh Baker, Omar+"
+      ]
+    },
+    {
+      "artist": "Florence + The Machine, Swedish House Mafia, Mark Knight",
+      "title": "You Got The Love (Mark Knight Remix) / One",
+      "year": 2012,
+      "isrc": "GB01A1201461",
+      "uri": "spotify:track:70m0QxEfeSeeYlqDbZ1e6a",
+      "uri_apple_music": "applemusic://track/1633500612",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1633500612"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1817055667",
+      "fun_fact": "“You Got The Love (Mark Knight Remix) / One” appears on Florence + The Machine’s release “EDM Party”.",
+      "fun_fact_de": "„You Got The Love (Mark Knight Remix) / One“ erschien auf der Veröffentlichung „EDM Party“ von Florence + The Machine.",
+      "fun_fact_es": "«You Got The Love (Mark Knight Remix) / One» aparece en el lanzamiento «EDM Party» de Florence + The Machine.",
+      "fun_fact_fr": "« You Got The Love (Mark Knight Remix) / One » figure sur la publication « EDM Party » de Florence + The Machine.",
+      "fun_fact_nl": "‘You Got The Love (Mark Knight Remix) / One’ staat op de release ‘EDM Party’ van Florence + The Machine.",
+      "alt_artists": [
+        "MEDUZA, HAYLA",
+        "Axwell, Max C",
+        "London Grammar"
+      ]
+    },
+    {
+      "artist": "Sub Focus, Wilkinson",
+      "title": "Illuminate - Sub Focus & Wilkinson",
+      "year": 2019,
+      "isrc": "GB5KW1903248",
+      "uri": "spotify:track:1vO6ncg0fPrxNwV9UEIip6",
+      "uri_apple_music": "applemusic://track/1478353597",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1478353597"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/750113612",
+      "fun_fact": "“Illuminate - Sub Focus & Wilkinson” is the title track of Sub Focus’s release of the same name.",
+      "fun_fact_de": "„Illuminate - Sub Focus & Wilkinson“ ist der Titelsong der gleichnamigen Veröffentlichung von Sub Focus.",
+      "fun_fact_es": "«Illuminate - Sub Focus & Wilkinson» es la canción que da título al lanzamiento homónimo de Sub Focus.",
+      "fun_fact_fr": "« Illuminate - Sub Focus & Wilkinson » est le morceau-titre de la publication éponyme de Sub Focus.",
+      "fun_fact_nl": "‘Illuminate - Sub Focus & Wilkinson’ is het titelnummer van de gelijknamige release van Sub Focus.",
+      "alt_artists": [
+        "Bruno Mars, Shepard, Sultan",
+        "Ferry Corsten",
+        "Dom Dolla, Daya"
+      ]
+    },
+    {
+      "artist": "Becky Hill, David Guetta",
+      "title": "Remember",
+      "year": 2021,
+      "isrc": "GBUM72102420",
+      "uri": "spotify:track:4laAKIq9ZxBCwf99rauPYb",
+      "uri_apple_music": "applemusic://track/1570736952",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1570736952"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1402072202",
+      "fun_fact": "“Remember” is the title track of Becky Hill’s release of the same name.",
+      "fun_fact_de": "„Remember“ ist der Titelsong der gleichnamigen Veröffentlichung von Becky Hill.",
+      "fun_fact_es": "«Remember» es la canción que da título al lanzamiento homónimo de Becky Hill.",
+      "fun_fact_fr": "« Remember » est le morceau-titre de la publication éponyme de Becky Hill.",
+      "fun_fact_nl": "‘Remember’ is het titelnummer van de gelijknamige release van Becky Hill.",
+      "alt_artists": [
+        "AFROJACK, Lucas & Steve, DubVision",
+        "Armin van Buuren, The Stickmen Project",
+        "HUGEL, Alleh, Yorghaki"
+      ]
+    },
+    {
+      "artist": "Porter Robinson",
+      "title": "Unison",
+      "year": 2011,
+      "isrc": "USQY51142734",
+      "uri": "spotify:track:75T1xBaarYAqYdNtFZxUaZ",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/96532734",
+      "fun_fact": "“Unison” appears on Porter Robinson’s release “Spitfire EP”.",
+      "fun_fact_de": "„Unison“ erschien auf der Veröffentlichung „Spitfire EP“ von Porter Robinson.",
+      "fun_fact_es": "«Unison» aparece en el lanzamiento «Spitfire EP» de Porter Robinson.",
+      "fun_fact_fr": "« Unison » figure sur la publication « Spitfire EP » de Porter Robinson.",
+      "fun_fact_nl": "‘Unison’ staat op de release ‘Spitfire EP’ van Porter Robinson.",
+      "alt_artists": [
+        "Feist, Boys Noize",
+        "Rolando",
+        "Switch"
+      ]
+    },
+    {
+      "artist": "Swedish House Mafia, Connie Constance",
+      "title": "Heaven Takes You Home (feat. Connie Constance)",
+      "year": 2022,
+      "isrc": "USUG12206651",
+      "uri": "spotify:track:3nEHrvNNtgLv9rneTAYVr4",
+      "uri_apple_music": "applemusic://track/1842942827",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1842942827"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1883583657",
+      "fun_fact": "“Heaven Takes You Home (feat. Connie Constance)” appears on Swedish House Mafia’s release “Heaven Takes You Home (Alternative Mix)”.",
+      "fun_fact_de": "„Heaven Takes You Home (feat. Connie Constance)“ erschien auf der Veröffentlichung „Heaven Takes You Home (Alternative Mix)“ von Swedish House Mafia.",
+      "fun_fact_es": "«Heaven Takes You Home (feat. Connie Constance)» aparece en el lanzamiento «Heaven Takes You Home (Alternative Mix)» de Swedish House Mafia.",
+      "fun_fact_fr": "« Heaven Takes You Home (feat. Connie Constance) » figure sur la publication « Heaven Takes You Home (Alternative Mix) » de Swedish House Mafia.",
+      "fun_fact_nl": "‘Heaven Takes You Home (feat. Connie Constance)’ staat op de release ‘Heaven Takes You Home (Alternative Mix)’ van Swedish House Mafia.",
+      "alt_artists": [
+        "Djuma Soundsystem",
+        "Jewelz & Sparks, AFROJACK, Sunnery James & Ryan Marciano",
+        "Purple Disco Machine, Kungs, Julian Perretta"
+      ]
+    },
+    {
+      "artist": "Bingo Players",
+      "title": "Rattle - Radio Edit",
+      "year": 2011,
+      "isrc": "NLC281112191",
+      "uri": "spotify:track:0vRtd0t9CP7FjXKUCXUCLo",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/466013612",
+      "fun_fact": "“Rattle - Radio Edit” appears on Bingo Players’s release “Rattle”.",
+      "fun_fact_de": "„Rattle - Radio Edit“ erschien auf der Veröffentlichung „Rattle“ von Bingo Players.",
+      "fun_fact_es": "«Rattle - Radio Edit» aparece en el lanzamiento «Rattle» de Bingo Players.",
+      "fun_fact_fr": "« Rattle - Radio Edit » figure sur la publication « Rattle » de Bingo Players.",
+      "fun_fact_nl": "‘Rattle - Radio Edit’ staat op de release ‘Rattle’ van Bingo Players.",
+      "alt_artists": [
+        "Deniz Koyu",
+        "Armin van Buuren, Jan Vayne",
+        "Sonny Fodera, MK, Clementine Douglas"
+      ]
+    },
+    {
+      "artist": "Lost Frequencies",
+      "title": "Sun Is Shining",
+      "year": 2019,
+      "isrc": "NLF711907649",
+      "uri": "spotify:track:44slXqFpvRojqlppLDcV07",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/714966692",
+      "fun_fact": "“Sun Is Shining” is the title track of Lost Frequencies’s release of the same name.",
+      "fun_fact_de": "„Sun Is Shining“ ist der Titelsong der gleichnamigen Veröffentlichung von Lost Frequencies.",
+      "fun_fact_es": "«Sun Is Shining» es la canción que da título al lanzamiento homónimo de Lost Frequencies.",
+      "fun_fact_fr": "« Sun Is Shining » est le morceau-titre de la publication éponyme de Lost Frequencies.",
+      "fun_fact_nl": "‘Sun Is Shining’ is het titelnummer van de gelijknamige release van Lost Frequencies.",
+      "alt_artists": [
+        "Anyma, CamelPhat",
+        "Mark Knight",
+        "Dimitri Vegas, Like Mike, Dada Life"
+      ]
+    },
+    {
+      "artist": "Armin van Buuren, Perpetuous Dreamer",
+      "title": "The Sound of Goodbye - Armin's Tribal Feel Radio Edit",
+      "year": 2011,
+      "isrc": "NLC731100002",
+      "uri": "spotify:track:2myHNhz3bFcKcUZHuoEh1k",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/475222882",
+      "fun_fact": "“The Sound of Goodbye - Armin's Tribal Feel Radio Edit” appears on Armin van Buuren’s release “Trance Classics - The Best Of”.",
+      "fun_fact_de": "„The Sound of Goodbye - Armin's Tribal Feel Radio Edit“ erschien auf der Veröffentlichung „Trance Classics - The Best Of“ von Armin van Buuren.",
+      "fun_fact_es": "«The Sound of Goodbye - Armin's Tribal Feel Radio Edit» aparece en el lanzamiento «Trance Classics - The Best Of» de Armin van Buuren.",
+      "fun_fact_fr": "« The Sound of Goodbye - Armin's Tribal Feel Radio Edit » figure sur la publication « Trance Classics - The Best Of » de Armin van Buuren.",
+      "fun_fact_nl": "‘The Sound of Goodbye - Armin's Tribal Feel Radio Edit’ staat op de release ‘Trance Classics - The Best Of’ van Armin van Buuren.",
+      "alt_artists": [
+        "The Chainsmokers, Coldplay, Alesso",
+        "Marc Benjamin, Marcus Santoro, David Pietras",
+        "Bastille, Audien"
+      ]
+    },
+    {
+      "artist": "Bakermat",
+      "title": "One Day (Vandaag) - Radio Edit",
+      "year": 2014,
+      "isrc": "DEE861400079",
+      "uri": "spotify:track:0GSU6yLOJqO10ziQuBLWOE",
+      "uri_apple_music": "applemusic://track/835895899",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/835895899"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/75819429",
+      "fun_fact": "“One Day (Vandaag) - Radio Edit” is the title track of Bakermat’s release of the same name.",
+      "fun_fact_de": "„One Day (Vandaag) - Radio Edit“ ist der Titelsong der gleichnamigen Veröffentlichung von Bakermat.",
+      "fun_fact_es": "«One Day (Vandaag) - Radio Edit» es la canción que da título al lanzamiento homónimo de Bakermat.",
+      "fun_fact_fr": "« One Day (Vandaag) - Radio Edit » est le morceau-titre de la publication éponyme de Bakermat.",
+      "fun_fact_nl": "‘One Day (Vandaag) - Radio Edit’ is het titelnummer van de gelijknamige release van Bakermat.",
+      "alt_artists": [
+        "FISHER, Kita Alexander",
+        "Sub Focus, Culture Shock, Fragma",
+        "Sara Landry, Alt8"
+      ]
+    },
+    {
+      "artist": "Tujamo, Plastik Funk",
+      "title": "WHO - Radio Edit",
+      "year": 2012,
+      "isrc": "DEN061200894",
+      "uri": "spotify:track:70SS7M24ugFjOXSHoOsZ5n",
+      "uri_apple_music": "applemusic://track/1820942640",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1820942640"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3689521382",
+      "fun_fact": "“WHO - Radio Edit” appears on Tujamo’s release “WHO (FatSync & R3ckzet Remix)”.",
+      "fun_fact_de": "„WHO - Radio Edit“ erschien auf der Veröffentlichung „WHO (FatSync & R3ckzet Remix)“ von Tujamo.",
+      "fun_fact_es": "«WHO - Radio Edit» aparece en el lanzamiento «WHO (FatSync & R3ckzet Remix)» de Tujamo.",
+      "fun_fact_fr": "« WHO - Radio Edit » figure sur la publication « WHO (FatSync & R3ckzet Remix) » de Tujamo.",
+      "fun_fact_nl": "‘WHO - Radio Edit’ staat op de release ‘WHO (FatSync & R3ckzet Remix)’ van Tujamo.",
+      "alt_artists": [
+        "MEDUZA, HAYLA",
+        "MEDUZA, Goodboys",
+        "Swedish House Mafia, Sting"
+      ]
+    },
+    {
+      "artist": "CamelPhat, ARTBAT, RHODES",
+      "title": "For a Feeling (feat. RHODES)",
+      "year": 2020,
+      "isrc": "GBARL2000333",
+      "uri": "spotify:track:1wjQEAV31X26Za9KRAmqwz",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/931449452",
+      "fun_fact": "“For a Feeling (feat. RHODES)” is the title track of CamelPhat’s release of the same name.",
+      "fun_fact_de": "„For a Feeling (feat. RHODES)“ ist der Titelsong der gleichnamigen Veröffentlichung von CamelPhat.",
+      "fun_fact_es": "«For a Feeling (feat. RHODES)» es la canción que da título al lanzamiento homónimo de CamelPhat.",
+      "fun_fact_fr": "« For a Feeling (feat. RHODES) » est le morceau-titre de la publication éponyme de CamelPhat.",
+      "fun_fact_nl": "‘For a Feeling (feat. RHODES)’ is het titelnummer van de gelijknamige release van CamelPhat.",
+      "alt_artists": [
+        "Svenson & Gielen",
+        "Digitalism",
+        "Bob Sinclar, Steve Edwards"
+      ]
+    },
+    {
+      "artist": "DubVision, AFROJACK",
+      "title": "Back To Life",
+      "year": 2019,
+      "isrc": "NLF711907243",
+      "uri": "spotify:track:3rnBqIIoxOpQ0p9BeW3NT4",
+      "uri_apple_music": "applemusic://track/1473664929",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1473664929"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/716094692",
+      "fun_fact": "“Back To Life” is the title track of DubVision’s release of the same name.",
+      "fun_fact_de": "„Back To Life“ ist der Titelsong der gleichnamigen Veröffentlichung von DubVision.",
+      "fun_fact_es": "«Back To Life» es la canción que da título al lanzamiento homónimo de DubVision.",
+      "fun_fact_fr": "« Back To Life » est le morceau-titre de la publication éponyme de DubVision.",
+      "fun_fact_nl": "‘Back To Life’ is het titelnummer van de gelijknamige release van DubVision.",
+      "alt_artists": [
+        "Sam Feldt, EDX",
+        "Ninetoes",
+        "Adrian Lux"
+      ]
+    },
+    {
+      "artist": "Friend Within",
+      "title": "The Renegade",
+      "year": 2013,
+      "isrc": "GBCEN1300306",
+      "uri": "spotify:track:7dyWwtPsaL3ThtPtkA4oQK",
+      "uri_apple_music": "applemusic://track/1885599347",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1885599347"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3903989971",
+      "fun_fact": "“The Renegade” appears on Friend Within’s release “The Renegade EP”.",
+      "fun_fact_de": "„The Renegade“ erschien auf der Veröffentlichung „The Renegade EP“ von Friend Within.",
+      "fun_fact_es": "«The Renegade» aparece en el lanzamiento «The Renegade EP» de Friend Within.",
+      "fun_fact_fr": "« The Renegade » figure sur la publication « The Renegade EP » de Friend Within.",
+      "fun_fact_nl": "‘The Renegade’ staat op de release ‘The Renegade EP’ van Friend Within.",
+      "alt_artists": [
+        "Estelle, Lost Frequencies, Kanye West",
+        "Swedish House Mafia, Alicia Keys",
+        "Kölsch, Gregor Schwellenbach"
+      ]
+    },
+    {
+      "artist": "Dimitri Vegas & Like Mike, Sander van Doorn",
+      "title": "Project T",
+      "year": 2013,
+      "isrc": "NLZ541300620",
+      "uri": "spotify:track:33saa6gZxyaMNpT9VGuhM2",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3458603571",
+      "fun_fact": "“Project T” is the title track of Dimitri Vegas & Like Mike’s release of the same name.",
+      "fun_fact_de": "„Project T“ ist der Titelsong der gleichnamigen Veröffentlichung von Dimitri Vegas & Like Mike.",
+      "fun_fact_es": "«Project T» es la canción que da título al lanzamiento homónimo de Dimitri Vegas & Like Mike.",
+      "fun_fact_fr": "« Project T » est le morceau-titre de la publication éponyme de Dimitri Vegas & Like Mike.",
+      "fun_fact_nl": "‘Project T’ is het titelnummer van de gelijknamige release van Dimitri Vegas & Like Mike.",
+      "alt_artists": [
+        "Lost Frequencies, Zonderling, Kelvin Jones",
+        "Becky Hill, Galantis",
+        "Above & Beyond"
+      ]
+    },
+    {
+      "artist": "Tiësto, Stargate, Aloe Blacc",
+      "title": "Carry You Home (feat. StarGate & Aloe Blacc)",
+      "year": 2017,
+      "isrc": "CYA111700144",
+      "uri": "spotify:track:6bolfjXj78EIQRB48C6QTc",
+      "uri_apple_music": "applemusic://track/1524619864",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1524619864"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1013432442",
+      "fun_fact": "“Carry You Home (feat. StarGate & Aloe Blacc)” is the title track of Tiësto’s release of the same name.",
+      "fun_fact_de": "„Carry You Home (feat. StarGate & Aloe Blacc)“ ist der Titelsong der gleichnamigen Veröffentlichung von Tiësto.",
+      "fun_fact_es": "«Carry You Home (feat. StarGate & Aloe Blacc)» es la canción que da título al lanzamiento homónimo de Tiësto.",
+      "fun_fact_fr": "« Carry You Home (feat. StarGate & Aloe Blacc) » est le morceau-titre de la publication éponyme de Tiësto.",
+      "fun_fact_nl": "‘Carry You Home (feat. StarGate & Aloe Blacc)’ is het titelnummer van de gelijknamige release van Tiësto.",
+      "alt_artists": [
+        "Vintage Culture, Fancy Inc",
+        "Öwnboss, Sevek",
+        "Martin Garrix, Sentinel, Bonn"
+      ]
+    },
+    {
+      "artist": "David Guetta, Anne-Marie, Coi Leray",
+      "title": "Baby Don't Hurt Me",
+      "year": 2023,
+      "isrc": "UKWLG2300016",
+      "uri": "spotify:track:3BKD1PwArikchz2Zrlp1qi",
+      "uri_apple_music": "applemusic://track/1679958206",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1679958206"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2216207477",
+      "fun_fact": "“Baby Don't Hurt Me” is the title track of David Guetta’s release of the same name.",
+      "fun_fact_de": "„Baby Don't Hurt Me“ ist der Titelsong der gleichnamigen Veröffentlichung von David Guetta.",
+      "fun_fact_es": "«Baby Don't Hurt Me» es la canción que da título al lanzamiento homónimo de David Guetta.",
+      "fun_fact_fr": "« Baby Don't Hurt Me » est le morceau-titre de la publication éponyme de David Guetta.",
+      "fun_fact_nl": "‘Baby Don't Hurt Me’ is het titelnummer van de gelijknamige release van David Guetta.",
+      "alt_artists": [
+        "Felix Da Housecat",
+        "Jax Jones, Martin Solveig, Madison Beer, Europa",
+        "Faithless"
+      ]
+    },
+    {
+      "artist": "James Hype",
+      "title": "Wild",
+      "year": 2024,
+      "isrc": "US38Y2405797",
+      "uri": "spotify:track:6Yimrlg9ndHZUy1hGm6uQ9",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2693901392",
+      "fun_fact": "“Wild” is the title track of James Hype’s release of the same name.",
+      "fun_fact_de": "„Wild“ ist der Titelsong der gleichnamigen Veröffentlichung von James Hype.",
+      "fun_fact_es": "«Wild» es la canción que da título al lanzamiento homónimo de James Hype.",
+      "fun_fact_fr": "« Wild » est le morceau-titre de la publication éponyme de James Hype.",
+      "fun_fact_nl": "‘Wild’ is het titelnummer van de gelijknamige release van James Hype.",
+      "alt_artists": [
+        "Armin van Buuren, Tempo Giusto",
+        "SOFI TUKKER, John Summit, Vintage Culture",
+        "Tiësto, Oaks"
+      ]
+    },
+    {
+      "artist": "LF SYSTEM",
+      "title": "Afraid To Feel",
+      "year": 2022,
+      "isrc": "GBAHT2200492",
+      "uri": "spotify:track:40SBS57su9xLiE1WqkXOVr",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1703521177",
+      "fun_fact": "“Afraid To Feel” is the title track of LF SYSTEM’s release of the same name.",
+      "fun_fact_de": "„Afraid To Feel“ ist der Titelsong der gleichnamigen Veröffentlichung von LF SYSTEM.",
+      "fun_fact_es": "«Afraid To Feel» es la canción que da título al lanzamiento homónimo de LF SYSTEM.",
+      "fun_fact_fr": "« Afraid To Feel » est le morceau-titre de la publication éponyme de LF SYSTEM.",
+      "fun_fact_nl": "‘Afraid To Feel’ is het titelnummer van de gelijknamige release van LF SYSTEM.",
+      "alt_artists": [
+        "Martin Garrix, Matisse & Sadko, Alex Aris",
+        "Calvin Harris, Ellie Goulding",
+        "PAWSA, The Adventures Of Stevie V"
+      ]
+    },
+    {
+      "artist": "Purple Disco Machine",
+      "title": "Body Funk",
+      "year": 2017,
+      "isrc": "AUDCB1701047",
+      "uri": "spotify:track:2Qw4nXX0eCRLRIX8BT19p2",
+      "uri_apple_music": "applemusic://track/1292960937",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1292960937"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/413490782",
+      "fun_fact": "“Body Funk” appears on Purple Disco Machine’s release “Soulmatic”.",
+      "fun_fact_de": "„Body Funk“ erschien auf der Veröffentlichung „Soulmatic“ von Purple Disco Machine.",
+      "fun_fact_es": "«Body Funk» aparece en el lanzamiento «Soulmatic» de Purple Disco Machine.",
+      "fun_fact_fr": "« Body Funk » figure sur la publication « Soulmatic » de Purple Disco Machine.",
+      "fun_fact_nl": "‘Body Funk’ staat op de release ‘Soulmatic’ van Purple Disco Machine.",
+      "alt_artists": [
+        "Fred again.., 070 Shake",
+        "Kaskade, MOGUAI, Zip Zip Through The Night",
+        "Disclosure, Rivo, Eliza Doolittle"
+      ]
+    },
+    {
+      "artist": "Alesso, Katy Perry",
+      "title": "When I'm Gone (with Katy Perry) [VIP Mix]",
+      "year": 2022,
+      "isrc": "USUG12200703",
+      "uri": "spotify:track:53y02rkTgMKgaJihn2Y2jE",
+      "uri_apple_music": "applemusic://track/1608631145",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1608631145"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1645703942",
+      "fun_fact": "“When I'm Gone (with Katy Perry) [VIP Mix]” appears on Alesso’s release “When I'm Gone (VIP Mix)”.",
+      "fun_fact_de": "„When I'm Gone (with Katy Perry) [VIP Mix]“ erschien auf der Veröffentlichung „When I'm Gone (VIP Mix)“ von Alesso.",
+      "fun_fact_es": "«When I'm Gone (with Katy Perry) [VIP Mix]» aparece en el lanzamiento «When I'm Gone (VIP Mix)» de Alesso.",
+      "fun_fact_fr": "« When I'm Gone (with Katy Perry) [VIP Mix] » figure sur la publication « When I'm Gone (VIP Mix) » de Alesso.",
+      "fun_fact_nl": "‘When I'm Gone (with Katy Perry) [VIP Mix]’ staat op de release ‘When I'm Gone (VIP Mix)’ van Alesso.",
+      "alt_artists": [
+        "Josh Baker, Omar+",
+        "Celeda, Danny Tenaglia",
+        "4444 OF A KIND, D-Block & S-te-Fan, Sub Zero Project"
+      ]
+    },
+    {
+      "artist": "Supermode, Axwell, Steve Angello",
+      "title": "Tell Me Why - Radio Edit",
+      "year": 2006,
+      "isrc": "GBKCF2000928",
+      "uri": "spotify:track:4yhGkvdYU5bi4950r80FRo",
+      "uri_apple_music": "applemusic://track/1519480916",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1519480916"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/997537362",
+      "fun_fact": "“Tell Me Why - Radio Edit” appears on Supermode’s release “Tell Me Why”.",
+      "fun_fact_de": "„Tell Me Why - Radio Edit“ erschien auf der Veröffentlichung „Tell Me Why“ von Supermode.",
+      "fun_fact_es": "«Tell Me Why - Radio Edit» aparece en el lanzamiento «Tell Me Why» de Supermode.",
+      "fun_fact_fr": "« Tell Me Why - Radio Edit » figure sur la publication « Tell Me Why » de Supermode.",
+      "fun_fact_nl": "‘Tell Me Why - Radio Edit’ staat op de release ‘Tell Me Why’ van Supermode.",
+      "alt_artists": [
+        "Jax Jones, Martin Solveig, Madison Beer, Europa",
+        "Pleasurekraft",
+        "Tiësto, Stargate, Aloe Blacc"
+      ]
+    },
+    {
+      "artist": "Loud Luxury, Brando",
+      "title": "Body",
+      "year": 2017,
+      "isrc": "NLF711710457",
+      "uri": "spotify:track:21RzyxY3EFaxVy6K4RqaU9",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/417131852",
+      "fun_fact": "“Body” is the title track of Loud Luxury’s release of the same name.",
+      "fun_fact_de": "„Body“ ist der Titelsong der gleichnamigen Veröffentlichung von Loud Luxury.",
+      "fun_fact_es": "«Body» es la canción que da título al lanzamiento homónimo de Loud Luxury.",
+      "fun_fact_fr": "« Body » est le morceau-titre de la publication éponyme de Loud Luxury.",
+      "fun_fact_nl": "‘Body’ is het titelnummer van de gelijknamige release van Loud Luxury.",
+      "alt_artists": [
+        "Chris Lake, Alexis Roberts",
+        "Rebūke",
+        "Duke Dumont, Jax Jones"
+      ]
+    },
+    {
+      "artist": "Calvin Harris, Ne-Yo",
+      "title": "Let's Go (feat. Ne-Yo)",
+      "year": 2012,
+      "isrc": "GBARL1200331",
+      "uri": "spotify:track:4wkQmYpAaMe41Rc3sYZ7Vz",
+      "uri_apple_music": "applemusic://track/1443809112",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1443809112"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/61142295",
+      "fun_fact": "“Let's Go (feat. Ne-Yo)” appears on Calvin Harris’s release “18 Months”.",
+      "fun_fact_de": "„Let's Go (feat. Ne-Yo)“ erschien auf der Veröffentlichung „18 Months“ von Calvin Harris.",
+      "fun_fact_es": "«Let's Go (feat. Ne-Yo)» aparece en el lanzamiento «18 Months» de Calvin Harris.",
+      "fun_fact_fr": "« Let's Go (feat. Ne-Yo) » figure sur la publication « 18 Months » de Calvin Harris.",
+      "fun_fact_nl": "‘Let's Go (feat. Ne-Yo)’ staat op de release ‘18 Months’ van Calvin Harris.",
+      "alt_artists": [
+        "Estelle, Lost Frequencies, Kanye West",
+        "Dirty South, Rudy, Axwell",
+        "R3HAB, NERVO, Ummet Ozcan"
+      ]
+    },
+    {
+      "artist": "Krystal Klear",
+      "title": "Neutron Dance - Edit",
+      "year": 2018,
+      "isrc": "DEVY91800030",
+      "uri": "spotify:track:0h9xxCoXw2LkdJG9pR79RN",
+      "uri_apple_music": "applemusic://track/1375539233",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1375539233"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/490680972",
+      "fun_fact": "“Neutron Dance - Edit” is the title track of Krystal Klear’s release of the same name.",
+      "fun_fact_de": "„Neutron Dance - Edit“ ist der Titelsong der gleichnamigen Veröffentlichung von Krystal Klear.",
+      "fun_fact_es": "«Neutron Dance - Edit» es la canción que da título al lanzamiento homónimo de Krystal Klear.",
+      "fun_fact_fr": "« Neutron Dance - Edit » est le morceau-titre de la publication éponyme de Krystal Klear.",
+      "fun_fact_nl": "‘Neutron Dance - Edit’ is het titelnummer van de gelijknamige release van Krystal Klear.",
+      "alt_artists": [
+        "Armin van Buuren, Mr. Probz",
+        "Sonny Fodera, Jazzy, D.O.D",
+        "Vintage Culture, Adam K, MKLA"
+      ]
+    },
+    {
+      "artist": "Oxia",
+      "title": "Domino",
+      "year": 2006,
+      "isrc": "DEU670600052",
+      "uri": "spotify:track:6VGNzYErt08Rai78mLkIzI",
+      "uri_apple_music": "applemusic://track/1790534561",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1790534561"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/72149970",
+      "fun_fact": "“Domino” appears on Oxia’s release “Cafe Ole Ibiza (Mixed By Rafha Madrid and Rebecca & Fiona)”.",
+      "fun_fact_de": "„Domino“ erschien auf der Veröffentlichung „Cafe Ole Ibiza (Mixed By Rafha Madrid and Rebecca & Fiona)“ von Oxia.",
+      "fun_fact_es": "«Domino» aparece en el lanzamiento «Cafe Ole Ibiza (Mixed By Rafha Madrid and Rebecca & Fiona)» de Oxia.",
+      "fun_fact_fr": "« Domino » figure sur la publication « Cafe Ole Ibiza (Mixed By Rafha Madrid and Rebecca & Fiona) » de Oxia.",
+      "fun_fact_nl": "‘Domino’ staat op de release ‘Cafe Ole Ibiza (Mixed By Rafha Madrid and Rebecca & Fiona)’ van Oxia.",
+      "alt_artists": [
+        "Gareth Emery",
+        "Tiësto, Stargate, Aloe Blacc",
+        "Skrillex, Starrah, Four Tet"
+      ]
+    },
+    {
+      "artist": "Swedish House Mafia",
+      "title": "Wait So Long (Why Do I Have To)",
+      "year": 2025,
+      "isrc": "US38Y2546515",
+      "uri": "spotify:track:1UlkpIKiVchDMB03AN6LmT",
+      "uri_apple_music": "applemusic://track/1818408731",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1818408731"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3413895351",
+      "fun_fact": "“Wait So Long (Why Do I Have To)” is the title track of Swedish House Mafia’s release of the same name.",
+      "fun_fact_de": "„Wait So Long (Why Do I Have To)“ ist der Titelsong der gleichnamigen Veröffentlichung von Swedish House Mafia.",
+      "fun_fact_es": "«Wait So Long (Why Do I Have To)» es la canción que da título al lanzamiento homónimo de Swedish House Mafia.",
+      "fun_fact_fr": "« Wait So Long (Why Do I Have To) » est le morceau-titre de la publication éponyme de Swedish House Mafia.",
+      "fun_fact_nl": "‘Wait So Long (Why Do I Have To)’ is het titelnummer van de gelijknamige release van Swedish House Mafia.",
+      "alt_artists": [
+        "Lifelike, Kris Menace",
+        "Dennis Ferrer",
+        "Avicii, Sandro Cavazza"
+      ]
+    },
+    {
+      "artist": "Kygo, Miguel",
+      "title": "Remind Me to Forget",
+      "year": 2017,
+      "isrc": "SEBGA1800417",
+      "uri": "spotify:track:5sIx4BlfYGuZeSLF40N9GH",
+      "uri_apple_music": "applemusic://track/1712581186",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1712581186"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/470287772",
+      "fun_fact": "“Remind Me to Forget” is the title track of Kygo’s release of the same name.",
+      "fun_fact_de": "„Remind Me to Forget“ ist der Titelsong der gleichnamigen Veröffentlichung von Kygo.",
+      "fun_fact_es": "«Remind Me to Forget» es la canción que da título al lanzamiento homónimo de Kygo.",
+      "fun_fact_fr": "« Remind Me to Forget » est le morceau-titre de la publication éponyme de Kygo.",
+      "fun_fact_nl": "‘Remind Me to Forget’ is het titelnummer van de gelijknamige release van Kygo.",
+      "alt_artists": [
+        "Armin van Buuren, Sharon Den Adel",
+        "Disclosure, AlunaGeorge",
+        "David Guetta, OneRepublic"
+      ]
+    },
+    {
+      "artist": "Mr. Belt & Wezol",
+      "title": "It's Not Right But It's Okay",
+      "year": 2024,
+      "isrc": "NLP762300246",
+      "uri": "spotify:track:5OFVzqSeFxGpvDGyHvVeLj",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2589549242",
+      "fun_fact": "“It's Not Right But It's Okay” is the title track of Mr. Belt & Wezol’s release of the same name.",
+      "fun_fact_de": "„It's Not Right But It's Okay“ ist der Titelsong der gleichnamigen Veröffentlichung von Mr. Belt & Wezol.",
+      "fun_fact_es": "«It's Not Right But It's Okay» es la canción que da título al lanzamiento homónimo de Mr. Belt & Wezol.",
+      "fun_fact_fr": "« It's Not Right But It's Okay » est le morceau-titre de la publication éponyme de Mr. Belt & Wezol.",
+      "fun_fact_nl": "‘It's Not Right But It's Okay’ is het titelnummer van de gelijknamige release van Mr. Belt & Wezol.",
+      "alt_artists": [
+        "Alesso, TINI",
+        "Bodyrox, Luciana, D. Ramirez",
+        "Armand Van Helden, Duane Harden"
+      ]
+    },
+    {
+      "artist": "Watermät",
+      "title": "Bullit",
+      "year": 2014,
+      "isrc": "NLZ541400541",
+      "uri": "spotify:track:2hBzP8r2QkRuyzV6dwgDq9",
+      "uri_apple_music": "applemusic://track/1356606917",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1356606917"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/470076662",
+      "fun_fact": "“Bullit” is the title track of Watermät’s release of the same name.",
+      "fun_fact_de": "„Bullit“ ist der Titelsong der gleichnamigen Veröffentlichung von Watermät.",
+      "fun_fact_es": "«Bullit» es la canción que da título al lanzamiento homónimo de Watermät.",
+      "fun_fact_fr": "« Bullit » est le morceau-titre de la publication éponyme de Watermät.",
+      "fun_fact_nl": "‘Bullit’ is het titelnummer van de gelijknamige release van Watermät.",
+      "alt_artists": [
+        "Double 99",
+        "Galantis",
+        "Janet Jackson"
+      ]
+    },
+    {
+      "artist": "Junior Jack",
+      "title": "Thrill Me",
+      "year": 2002,
+      "isrc": "BEP010310085",
+      "uri": "spotify:track:2unIXIeXCYSVte41IuRHTz",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/57840221",
+      "fun_fact": "“Thrill Me” appears on Junior Jack’s release “Trust It”.",
+      "fun_fact_de": "„Thrill Me“ erschien auf der Veröffentlichung „Trust It“ von Junior Jack.",
+      "fun_fact_es": "«Thrill Me» aparece en el lanzamiento «Trust It» de Junior Jack.",
+      "fun_fact_fr": "« Thrill Me » figure sur la publication « Trust It » de Junior Jack.",
+      "fun_fact_nl": "‘Thrill Me’ staat op de release ‘Trust It’ van Junior Jack.",
+      "alt_artists": [
+        "Tim Mason, Steve Angello",
+        "Red Carpet, Brad Carter",
+        "Mr. Belt & Wezol"
+      ]
+    },
+    {
+      "artist": "Bingo Players",
+      "title": "Cry (Just A Little) - Radio Edit",
+      "year": 2011,
+      "isrc": "NLC281111567",
+      "uri": "spotify:track:3PXamtUEGjrl9vaFxZ318n",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/481407932",
+      "fun_fact": "“Cry (Just A Little) - Radio Edit” is the title track of Bingo Players’s release of the same name.",
+      "fun_fact_de": "„Cry (Just A Little) - Radio Edit“ ist der Titelsong der gleichnamigen Veröffentlichung von Bingo Players.",
+      "fun_fact_es": "«Cry (Just A Little) - Radio Edit» es la canción que da título al lanzamiento homónimo de Bingo Players.",
+      "fun_fact_fr": "« Cry (Just A Little) - Radio Edit » est le morceau-titre de la publication éponyme de Bingo Players.",
+      "fun_fact_nl": "‘Cry (Just A Little) - Radio Edit’ is het titelnummer van de gelijknamige release van Bingo Players.",
+      "alt_artists": [
+        "Vintage Culture, Fancy Inc, The Beach",
+        "Axwell, Sebastian Ingrosso, Steve Angello, Laidback Luke",
+        "Martin Garrix, Khalid, DubVision"
+      ]
+    },
+    {
+      "artist": "deadmau5",
+      "title": "Faxing Berlin - Radio Edit",
+      "year": 2009,
+      "isrc": "CAPA31700076",
+      "uri": "spotify:track:04DkXrnJlKxc1hk2pOXHlo",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/449243492",
+      "fun_fact": "“Faxing Berlin - Radio Edit” appears on deadmau5’s release “Faxing Berlin x4”.",
+      "fun_fact_de": "„Faxing Berlin - Radio Edit“ erschien auf der Veröffentlichung „Faxing Berlin x4“ von deadmau5.",
+      "fun_fact_es": "«Faxing Berlin - Radio Edit» aparece en el lanzamiento «Faxing Berlin x4» de deadmau5.",
+      "fun_fact_fr": "« Faxing Berlin - Radio Edit » figure sur la publication « Faxing Berlin x4 » de deadmau5.",
+      "fun_fact_nl": "‘Faxing Berlin - Radio Edit’ staat op de release ‘Faxing Berlin x4’ van deadmau5.",
+      "alt_artists": [
+        "MOGUAI, Cheat Codes",
+        "Shakedown, Anyma, Layton Giordani",
+        "Bruno Mars, Shepard, Sultan"
+      ]
+    },
+    {
+      "artist": "Julien Jabre, Jerome Sydenham, Sebastian Ingrosso",
+      "title": "Swimming Places - Sebastien Ingrosso Re-Edit",
+      "year": 2006,
+      "isrc": "GBCPZ0501363",
+      "uri": "spotify:track:5rcuVUo0IQu77SY06QdxF9",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3155420471",
+      "fun_fact": "“Swimming Places - Sebastien Ingrosso Re-Edit” appears on Julien Jabre’s release “Swimming Places”.",
+      "fun_fact_de": "„Swimming Places - Sebastien Ingrosso Re-Edit“ erschien auf der Veröffentlichung „Swimming Places“ von Julien Jabre.",
+      "fun_fact_es": "«Swimming Places - Sebastien Ingrosso Re-Edit» aparece en el lanzamiento «Swimming Places» de Julien Jabre.",
+      "fun_fact_fr": "« Swimming Places - Sebastien Ingrosso Re-Edit » figure sur la publication « Swimming Places » de Julien Jabre.",
+      "fun_fact_nl": "‘Swimming Places - Sebastien Ingrosso Re-Edit’ staat op de release ‘Swimming Places’ van Julien Jabre.",
+      "alt_artists": [
+        "DJ MERCER, Tchami",
+        "deadmau5, Kaskade, Kx5, John Summit, HAYLA",
+        "Svenson & Gielen"
+      ]
+    },
+    {
+      "artist": "Dom Dolla",
+      "title": "Saving Up",
+      "year": 2023,
+      "isrc": "USQX92305379",
+      "uri": "spotify:track:787Y2idwCU2Rk60Prv4wpr",
+      "uri_apple_music": "applemusic://track/1709178108",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1709178108"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2472925871",
+      "fun_fact": "“Saving Up” is the title track of Dom Dolla’s release of the same name.",
+      "fun_fact_de": "„Saving Up“ ist der Titelsong der gleichnamigen Veröffentlichung von Dom Dolla.",
+      "fun_fact_es": "«Saving Up» es la canción que da título al lanzamiento homónimo de Dom Dolla.",
+      "fun_fact_fr": "« Saving Up » est le morceau-titre de la publication éponyme de Dom Dolla.",
+      "fun_fact_nl": "‘Saving Up’ is het titelnummer van de gelijknamige release van Dom Dolla.",
+      "alt_artists": [
+        "Martin Garrix, USHER",
+        "Knife Party",
+        "Kx5, deadmau5, Kaskade"
+      ]
+    },
+    {
+      "artist": "Hypaton, David Guetta, La Bouche",
+      "title": "Be My Lover (feat. La Bouche) - 2023 Mix",
+      "year": 2023,
+      "isrc": "DEE862300656",
+      "uri": "spotify:track:2aQpISWUBToaF84DDiTeRV",
+      "uri_apple_music": "applemusic://track/1681863554",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1681863554"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2233622397",
+      "fun_fact": "“Be My Lover (feat. La Bouche) - 2023 Mix” is the title track of Hypaton’s release of the same name.",
+      "fun_fact_de": "„Be My Lover (feat. La Bouche) - 2023 Mix“ ist der Titelsong der gleichnamigen Veröffentlichung von Hypaton.",
+      "fun_fact_es": "«Be My Lover (feat. La Bouche) - 2023 Mix» es la canción que da título al lanzamiento homónimo de Hypaton.",
+      "fun_fact_fr": "« Be My Lover (feat. La Bouche) - 2023 Mix » est le morceau-titre de la publication éponyme de Hypaton.",
+      "fun_fact_nl": "‘Be My Lover (feat. La Bouche) - 2023 Mix’ is het titelnummer van de gelijknamige release van Hypaton.",
+      "alt_artists": [
+        "Martin Garrix, Justin Mylo, Dewain Whitmore",
+        "Round Table Knights, Bauchamp",
+        "Purple Disco Machine, Moss Kena, The Knocks"
+      ]
+    },
+    {
+      "artist": "AZARI, III, Jamie Jones",
+      "title": "Hungry For The Power - Jamie Jones Ridge Street Remix",
+      "year": 2011,
+      "isrc": "GBX8P1100005",
+      "uri": "spotify:track:0pD9kpqznUhnLSLnYcGPGo",
+      "uri_apple_music": "applemusic://track/1125593814",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1125593814"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/127073863",
+      "fun_fact": "“Hungry For The Power - Jamie Jones Ridge Street Remix” appears on AZARI’s release “Azari & III Remixed”.",
+      "fun_fact_de": "„Hungry For The Power - Jamie Jones Ridge Street Remix“ erschien auf der Veröffentlichung „Azari & III Remixed“ von AZARI.",
+      "fun_fact_es": "«Hungry For The Power - Jamie Jones Ridge Street Remix» aparece en el lanzamiento «Azari & III Remixed» de AZARI.",
+      "fun_fact_fr": "« Hungry For The Power - Jamie Jones Ridge Street Remix » figure sur la publication « Azari & III Remixed » de AZARI.",
+      "fun_fact_nl": "‘Hungry For The Power - Jamie Jones Ridge Street Remix’ staat op de release ‘Azari & III Remixed’ van AZARI.",
+      "alt_artists": [
+        "Sonny Fodera, MK, Clementine Douglas",
+        "deadmau5, Wolfgang Gartner",
+        "Dizzee Rascal"
+      ]
+    },
+    {
+      "artist": "Niels Van Gogh, Tiësto",
+      "title": "Pulverturm - Tiësto's Big Room Remix",
+      "year": 2019,
+      "isrc": "CYA111800465",
+      "uri": "spotify:track:5cNLc9PNhzbGC3DKZeWGSL",
+      "uri_apple_music": "applemusic://track/1501525410",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1501525410"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/894555532",
+      "fun_fact": "“Pulverturm - Tiësto's Big Room Remix” is the title track of Niels Van Gogh’s release of the same name.",
+      "fun_fact_de": "„Pulverturm - Tiësto's Big Room Remix“ ist der Titelsong der gleichnamigen Veröffentlichung von Niels Van Gogh.",
+      "fun_fact_es": "«Pulverturm - Tiësto's Big Room Remix» es la canción que da título al lanzamiento homónimo de Niels Van Gogh.",
+      "fun_fact_fr": "« Pulverturm - Tiësto's Big Room Remix » est le morceau-titre de la publication éponyme de Niels Van Gogh.",
+      "fun_fact_nl": "‘Pulverturm - Tiësto's Big Room Remix’ is het titelnummer van de gelijknamige release van Niels Van Gogh.",
+      "alt_artists": [
+        "Martin Garrix, Sentinel, Bonn",
+        "Jewelz & Sparks, AFROJACK, Sunnery James & Ryan Marciano",
+        "RAFFA GUIDO"
+      ]
+    },
+    {
+      "artist": "Fred again..",
+      "title": "Billie (loving arms)",
+      "year": 2021,
+      "isrc": "GBAHS2100379",
+      "uri": "spotify:track:1vW12BfxjOQKYElBm9ttW9",
+      "uri_apple_music": "applemusic://track/1594208607",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1594208607"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1470880972",
+      "fun_fact": "“Billie (loving arms)” is the title track of Fred again..’s release of the same name.",
+      "fun_fact_de": "„Billie (loving arms)“ ist der Titelsong der gleichnamigen Veröffentlichung von Fred again...",
+      "fun_fact_es": "«Billie (loving arms)» es la canción que da título al lanzamiento homónimo de Fred again...",
+      "fun_fact_fr": "« Billie (loving arms) » est le morceau-titre de la publication éponyme de Fred again...",
+      "fun_fact_nl": "‘Billie (loving arms)’ is het titelnummer van de gelijknamige release van Fred again...",
+      "alt_artists": [
+        "Chuckie, Hardwell, Ambush",
+        "Alesso, Katy Perry",
+        "Linska, GENESI"
+      ]
+    },
+    {
+      "artist": "Armin van Buuren, Punctual, Alika",
+      "title": "On & On",
+      "year": 2023,
+      "isrc": "NLF712300352",
+      "uri": "spotify:track:6wLqNGHQIja6xqT0cfrzBB",
+      "uri_apple_music": "applemusic://track/1682128802",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1682128802"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2184237717",
+      "fun_fact": "“On & On” appears on Armin van Buuren’s release “Feel Again”.",
+      "fun_fact_de": "„On & On“ erschien auf der Veröffentlichung „Feel Again“ von Armin van Buuren.",
+      "fun_fact_es": "«On & On» aparece en el lanzamiento «Feel Again» de Armin van Buuren.",
+      "fun_fact_fr": "« On & On » figure sur la publication « Feel Again » de Armin van Buuren.",
+      "fun_fact_nl": "‘On & On’ staat op de release ‘Feel Again’ van Armin van Buuren.",
+      "alt_artists": [
+        "Travis Scott, CHASE B",
+        "Fred again.., Obongjayar",
+        "Salif Keita, Martin Solveig"
+      ]
+    },
+    {
+      "artist": "Cassius",
+      "title": "I <3 U SO",
+      "year": 2010,
+      "isrc": "FR5Y71000008",
+      "uri": "spotify:track:0WWBeDKdXmGbZD1XVOVqot",
+      "uri_apple_music": "applemusic://track/1675895162",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1675895162"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/592771082",
+      "fun_fact": "“I <3 U SO” appears on Cassius’s release “The Rawkers (I <3 U SO Edition)”.",
+      "fun_fact_de": "„I <3 U SO“ erschien auf der Veröffentlichung „The Rawkers (I <3 U SO Edition)“ von Cassius.",
+      "fun_fact_es": "«I <3 U SO» aparece en el lanzamiento «The Rawkers (I <3 U SO Edition)» de Cassius.",
+      "fun_fact_fr": "« I <3 U SO » figure sur la publication « The Rawkers (I <3 U SO Edition) » de Cassius.",
+      "fun_fact_nl": "‘I <3 U SO’ staat op de release ‘The Rawkers (I <3 U SO Edition)’ van Cassius.",
+      "alt_artists": [
+        "Martin Garrix, Macklemore, Fall Out Boy, Tiësto",
+        "Ten Walls",
+        "Overmono"
+      ]
+    },
+    {
+      "artist": "Chris Lake",
+      "title": "I Want You",
+      "year": 2017,
+      "isrc": "USAT21700584",
+      "uri": "spotify:track:7IM73yy9leN8ftZsOVmVTO",
+      "uri_apple_music": "applemusic://track/1214500802",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1214500802"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/144735090",
+      "fun_fact": "“I Want You” is the title track of Chris Lake’s release of the same name.",
+      "fun_fact_de": "„I Want You“ ist der Titelsong der gleichnamigen Veröffentlichung von Chris Lake.",
+      "fun_fact_es": "«I Want You» es la canción que da título al lanzamiento homónimo de Chris Lake.",
+      "fun_fact_fr": "« I Want You » est le morceau-titre de la publication éponyme de Chris Lake.",
+      "fun_fact_nl": "‘I Want You’ is het titelnummer van de gelijknamige release van Chris Lake.",
+      "alt_artists": [
+        "Lost Frequencies, Zonderling, Kelvin Jones",
+        "Patrick Topping",
+        "Zedd, Lucky Date, Ellie Goulding"
+      ]
+    },
+    {
+      "artist": "ARTY",
+      "title": "Sunshine",
+      "year": 2019,
+      "isrc": "NLF711904534",
+      "uri": "spotify:track:1wTgNpgoZ3g36bsy3sTxqz",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/677552282",
+      "fun_fact": "“Sunshine” is the title track of ARTY’s release of the same name.",
+      "fun_fact_de": "„Sunshine“ ist der Titelsong der gleichnamigen Veröffentlichung von ARTY.",
+      "fun_fact_es": "«Sunshine» es la canción que da título al lanzamiento homónimo de ARTY.",
+      "fun_fact_fr": "« Sunshine » est le morceau-titre de la publication éponyme de ARTY.",
+      "fun_fact_nl": "‘Sunshine’ is het titelnummer van de gelijknamige release van ARTY.",
+      "alt_artists": [
+        "Gotye, FISHER, Chris Lake, Sante Sansone, Kimbra",
+        "Chris Lake, Alexis Roberts",
+        "Celeda, Danny Tenaglia"
+      ]
+    },
+    {
+      "artist": "Joris Voorn",
+      "title": "Ringo",
+      "year": 2020,
+      "isrc": "GB5KW2001913",
+      "uri": "spotify:track:5pD0jmWSuoCc7hwJLN3VJF",
+      "uri_apple_music": "applemusic://track/1489676132",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1489676132"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3704877162",
+      "fun_fact": "“Ringo” appears on Joris Voorn’s release “Michiel Borstlap Plays Joris Voorn, Pt. 1”.",
+      "fun_fact_de": "„Ringo“ erschien auf der Veröffentlichung „Michiel Borstlap Plays Joris Voorn, Pt. 1“ von Joris Voorn.",
+      "fun_fact_es": "«Ringo» aparece en el lanzamiento «Michiel Borstlap Plays Joris Voorn, Pt. 1» de Joris Voorn.",
+      "fun_fact_fr": "« Ringo » figure sur la publication « Michiel Borstlap Plays Joris Voorn, Pt. 1 » de Joris Voorn.",
+      "fun_fact_nl": "‘Ringo’ staat op de release ‘Michiel Borstlap Plays Joris Voorn, Pt. 1’ van Joris Voorn.",
+      "alt_artists": [
+        "Tiësto, The Chainsmokers",
+        "Amine Edge & DANCE, Blaze (Kevin Hedge)",
+        "Mark Knight, Funkagenda"
+      ]
+    },
+    {
+      "artist": "Dimitri Vegas & Like Mike, W&W",
+      "title": "Waves (Tomorrowland 2014 Anthem)",
+      "year": 2014,
+      "isrc": "BEK011400214",
+      "uri": "spotify:track:1Olbk1sJPSwnQUt55yAFS6",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2104890137",
+      "fun_fact": "“Waves (Tomorrowland 2014 Anthem)” is the title track of Dimitri Vegas & Like Mike’s release of the same name.",
+      "fun_fact_de": "„Waves (Tomorrowland 2014 Anthem)“ ist der Titelsong der gleichnamigen Veröffentlichung von Dimitri Vegas & Like Mike.",
+      "fun_fact_es": "«Waves (Tomorrowland 2014 Anthem)» es la canción que da título al lanzamiento homónimo de Dimitri Vegas & Like Mike.",
+      "fun_fact_fr": "« Waves (Tomorrowland 2014 Anthem) » est le morceau-titre de la publication éponyme de Dimitri Vegas & Like Mike.",
+      "fun_fact_nl": "‘Waves (Tomorrowland 2014 Anthem)’ is het titelnummer van de gelijknamige release van Dimitri Vegas & Like Mike.",
+      "alt_artists": [
+        "Art Of Trance, Ferry Corsten",
+        "Laurent Garnier",
+        "KI/KI"
+      ]
+    },
+    {
+      "artist": "Chuckie, Hardwell, Ambush",
+      "title": "Move It 2 The Drum",
+      "year": 2010,
+      "isrc": "GB9VV1000020",
+      "uri": "spotify:track:1cozjHl1Rh0877497fMGtn",
+      "uri_apple_music": "applemusic://track/1148608952",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1148608952"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1505157572",
+      "fun_fact": "“Move It 2 The Drum” appears on Chuckie’s release “Destination Ibiza (Deluxe Edition)”.",
+      "fun_fact_de": "„Move It 2 The Drum“ erschien auf der Veröffentlichung „Destination Ibiza (Deluxe Edition)“ von Chuckie.",
+      "fun_fact_es": "«Move It 2 The Drum» aparece en el lanzamiento «Destination Ibiza (Deluxe Edition)» de Chuckie.",
+      "fun_fact_fr": "« Move It 2 The Drum » figure sur la publication « Destination Ibiza (Deluxe Edition) » de Chuckie.",
+      "fun_fact_nl": "‘Move It 2 The Drum’ staat op de release ‘Destination Ibiza (Deluxe Edition)’ van Chuckie.",
+      "alt_artists": [
+        "FISHER, Kita Alexander",
+        "Au/Ra, CamelPhat",
+        "Swedish House Mafia"
+      ]
+    },
+    {
+      "artist": "Rui Da Silva, Cassandra",
+      "title": "Touch Me (Radio Edit) [feat. Cassandra]",
+      "year": 2000,
+      "isrc": "GBEBP0610063",
+      "uri": "spotify:track:6j8nh1kHwezw8pkC2eU87F",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/11663132",
+      "fun_fact": "“Touch Me (Radio Edit) [feat. Cassandra]” appears on Rui Da Silva’s release “Kismet Records Presents Touch Me (feat. Cassandra)”.",
+      "fun_fact_de": "„Touch Me (Radio Edit) [feat. Cassandra]“ erschien auf der Veröffentlichung „Kismet Records Presents Touch Me (feat. Cassandra)“ von Rui Da Silva.",
+      "fun_fact_es": "«Touch Me (Radio Edit) [feat. Cassandra]» aparece en el lanzamiento «Kismet Records Presents Touch Me (feat. Cassandra)» de Rui Da Silva.",
+      "fun_fact_fr": "« Touch Me (Radio Edit) [feat. Cassandra] » figure sur la publication « Kismet Records Presents Touch Me (feat. Cassandra) » de Rui Da Silva.",
+      "fun_fact_nl": "‘Touch Me (Radio Edit) [feat. Cassandra]’ staat op de release ‘Kismet Records Presents Touch Me (feat. Cassandra)’ van Rui Da Silva.",
+      "alt_artists": [
+        "Sonny Fodera, MK, Clementine Douglas",
+        "Marian Hill, Franky Rizardo",
+        "Paul Woolford, Kim English"
+      ]
+    },
+    {
+      "artist": "Enrico Sangiuliano",
+      "title": "Moon Rocks",
+      "year": 2016,
+      "isrc": "GBUR61600097",
+      "uri": "spotify:track:65m32U7ya28Uns99G6B3Oe",
+      "uri_apple_music": "applemusic://track/1684602178",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1684602178"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2255146707",
+      "fun_fact": "“Moon Rocks” is the title track of Enrico Sangiuliano’s release of the same name.",
+      "fun_fact_de": "„Moon Rocks“ ist der Titelsong der gleichnamigen Veröffentlichung von Enrico Sangiuliano.",
+      "fun_fact_es": "«Moon Rocks» es la canción que da título al lanzamiento homónimo de Enrico Sangiuliano.",
+      "fun_fact_fr": "« Moon Rocks » est le morceau-titre de la publication éponyme de Enrico Sangiuliano.",
+      "fun_fact_nl": "‘Moon Rocks’ is het titelnummer van de gelijknamige release van Enrico Sangiuliano.",
+      "alt_artists": [
+        "R3HAB, NERVO, Ummet Ozcan",
+        "Alesso, Zara Larsson",
+        "YORK, Kryder"
+      ]
+    },
+    {
+      "artist": "Wankelmut, Emma Louise, MK",
+      "title": "My head is a Jungle - MK Remix [Radio Edit]",
+      "year": 2013,
+      "isrc": "DEAW11300332",
+      "uri": "spotify:track:67e9Q3gErUnsCaAk7gGLZv",
+      "uri_apple_music": "applemusic://track/1711636194",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1711636194"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/70513547",
+      "fun_fact": "“My head is a Jungle - MK Remix [Radio Edit]” appears on Wankelmut’s release “My Head Is A Jungle (The Remixes)”.",
+      "fun_fact_de": "„My head is a Jungle - MK Remix [Radio Edit]“ erschien auf der Veröffentlichung „My Head Is A Jungle (The Remixes)“ von Wankelmut.",
+      "fun_fact_es": "«My head is a Jungle - MK Remix [Radio Edit]» aparece en el lanzamiento «My Head Is A Jungle (The Remixes)» de Wankelmut.",
+      "fun_fact_fr": "« My head is a Jungle - MK Remix [Radio Edit] » figure sur la publication « My Head Is A Jungle (The Remixes) » de Wankelmut.",
+      "fun_fact_nl": "‘My head is a Jungle - MK Remix [Radio Edit]’ staat op de release ‘My Head Is A Jungle (The Remixes)’ van Wankelmut.",
+      "alt_artists": [
+        "Ahmed Spins, Stevo Atambire",
+        "Round Table Knights, Bauchamp",
+        "Lucas & Steve, Tungevaag"
+      ]
+    },
+    {
+      "artist": "Alesso, DubVision",
+      "title": "One Last Time",
+      "year": 2020,
+      "isrc": "USUG12000675",
+      "uri": "spotify:track:17kleFbwU5STT8AiR1EXOT",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/891177062",
+      "fun_fact": "“One Last Time” is the title track of Alesso’s release of the same name.",
+      "fun_fact_de": "„One Last Time“ ist der Titelsong der gleichnamigen Veröffentlichung von Alesso.",
+      "fun_fact_es": "«One Last Time» es la canción que da título al lanzamiento homónimo de Alesso.",
+      "fun_fact_fr": "« One Last Time » est le morceau-titre de la publication éponyme de Alesso.",
+      "fun_fact_nl": "‘One Last Time’ is het titelnummer van de gelijknamige release van Alesso.",
+      "alt_artists": [
+        "Disclosure, Rivo, Eliza Doolittle",
+        "Armin van Buuren, Perpetuous Dreamer",
+        "Martin Garrix, Brooks"
+      ]
+    },
+    {
+      "artist": "Martin Garrix, John Martin",
+      "title": "Higher Ground (feat. John Martin)",
+      "year": 2020,
+      "isrc": "NLM5S2000861",
+      "uri": "spotify:track:0rohJsT6NWsThpukt0Xxdc",
+      "uri_apple_music": "applemusic://track/1512816626",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1512816626"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/957925932",
+      "fun_fact": "“Higher Ground (feat. John Martin)” is the title track of Martin Garrix’s release of the same name.",
+      "fun_fact_de": "„Higher Ground (feat. John Martin)“ ist der Titelsong der gleichnamigen Veröffentlichung von Martin Garrix.",
+      "fun_fact_es": "«Higher Ground (feat. John Martin)» es la canción que da título al lanzamiento homónimo de Martin Garrix.",
+      "fun_fact_fr": "« Higher Ground (feat. John Martin) » est le morceau-titre de la publication éponyme de Martin Garrix.",
+      "fun_fact_nl": "‘Higher Ground (feat. John Martin)’ is het titelnummer van de gelijknamige release van Martin Garrix.",
+      "alt_artists": [
+        "Martin Garrix, DubVision, Jaimes",
+        "Don Diablo, Matt Nash",
+        "Tiësto, Kirsty Hawkshaw"
+      ]
+    },
+    {
+      "artist": "Don Diablo, Matt Nash",
+      "title": "Starlight (Could You Be Mine) - Radio Edit",
+      "year": 2013,
+      "isrc": "GBKCF1300266",
+      "uri": "spotify:track:47S7hRI0vwAOcruZKrxWHD",
+      "uri_apple_music": "applemusic://track/765477672",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/765477672"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/73092674",
+      "fun_fact": "“Starlight (Could You Be Mine) - Radio Edit” appears on Don Diablo’s release “Starlight (Could You Be Mine)”.",
+      "fun_fact_de": "„Starlight (Could You Be Mine) - Radio Edit“ erschien auf der Veröffentlichung „Starlight (Could You Be Mine)“ von Don Diablo.",
+      "fun_fact_es": "«Starlight (Could You Be Mine) - Radio Edit» aparece en el lanzamiento «Starlight (Could You Be Mine)» de Don Diablo.",
+      "fun_fact_fr": "« Starlight (Could You Be Mine) - Radio Edit » figure sur la publication « Starlight (Could You Be Mine) » de Don Diablo.",
+      "fun_fact_nl": "‘Starlight (Could You Be Mine) - Radio Edit’ staat op de release ‘Starlight (Could You Be Mine)’ van Don Diablo.",
+      "alt_artists": [
+        "CHRIS STASSY",
+        "Calvin Harris, Ellie Goulding",
+        "Öwnboss, Sevek"
+      ]
+    },
+    {
+      "artist": "Eric Prydz, Steve Angello",
+      "title": "Woz Not Woz - Club Mix",
+      "year": 2004,
+      "isrc": "GBHAD0400011",
+      "uri": "spotify:track:4xxCeBazEKiT4CDpnnTJk4",
+      "uri_apple_music": "applemusic://track/282040868",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/282040868"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1506463612",
+      "fun_fact": "“Woz Not Woz - Club Mix” appears on Eric Prydz’s release “Woz Not Woz”.",
+      "fun_fact_de": "„Woz Not Woz - Club Mix“ erschien auf der Veröffentlichung „Woz Not Woz“ von Eric Prydz.",
+      "fun_fact_es": "«Woz Not Woz - Club Mix» aparece en el lanzamiento «Woz Not Woz» de Eric Prydz.",
+      "fun_fact_fr": "« Woz Not Woz - Club Mix » figure sur la publication « Woz Not Woz » de Eric Prydz.",
+      "fun_fact_nl": "‘Woz Not Woz - Club Mix’ staat op de release ‘Woz Not Woz’ van Eric Prydz.",
+      "alt_artists": [
+        "David Guetta, Nicky Romero, Sia",
+        "Kaskade",
+        "Avicii, Sandro Cavazza"
+      ]
+    },
+    {
+      "artist": "Sonny Fodera, MK, Clementine Douglas",
+      "title": "Asking",
+      "year": 2023,
+      "isrc": "US39N2307761",
+      "uri": "spotify:track:4bz8Z7squfs2Yji2DwoujR",
+      "uri_apple_music": "applemusic://track/1693371172",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1693371172"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2333553245",
+      "fun_fact": "“Asking” is the title track of Sonny Fodera’s release of the same name.",
+      "fun_fact_de": "„Asking“ ist der Titelsong der gleichnamigen Veröffentlichung von Sonny Fodera.",
+      "fun_fact_es": "«Asking» es la canción que da título al lanzamiento homónimo de Sonny Fodera.",
+      "fun_fact_fr": "« Asking » est le morceau-titre de la publication éponyme de Sonny Fodera.",
+      "fun_fact_nl": "‘Asking’ is het titelnummer van de gelijknamige release van Sonny Fodera.",
+      "alt_artists": [
+        "Nadia Ali",
+        "Red Carpet, Brad Carter",
+        "Dimitri Vegas & Like Mike, Brennan Heart, Tony Junior"
+      ]
+    },
+    {
+      "artist": "deadmau5",
+      "title": "Not Exactly",
+      "year": 2007,
+      "isrc": "GBTDG0700005",
+      "uri": "spotify:track:7gdJHtnAqy58RV61EpRBLo",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/89844275",
+      "fun_fact": "“Not Exactly” appears on deadmau5’s release “5 years of mau5”.",
+      "fun_fact_de": "„Not Exactly“ erschien auf der Veröffentlichung „5 years of mau5“ von deadmau5.",
+      "fun_fact_es": "«Not Exactly» aparece en el lanzamiento «5 years of mau5» de deadmau5.",
+      "fun_fact_fr": "« Not Exactly » figure sur la publication « 5 years of mau5 » de deadmau5.",
+      "fun_fact_nl": "‘Not Exactly’ staat op de release ‘5 years of mau5’ van deadmau5.",
+      "alt_artists": [
+        "Zerb, Sofiya Nzau",
+        "David Guetta, Benny Benassi",
+        "Pegassi"
+      ]
+    },
+    {
+      "artist": "Peggy Gou, Soulwax",
+      "title": "I Go - Soulwax Remix",
+      "year": 2022,
+      "isrc": "GBJX32275010",
+      "uri": "spotify:track:3PQyUWqndc51vb1JYrqxuC",
+      "uri_apple_music": "applemusic://track/1678047028",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1678047028"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2198145737",
+      "fun_fact": "“I Go - Soulwax Remix” appears on Peggy Gou’s release “I Go (Remixes)”.",
+      "fun_fact_de": "„I Go - Soulwax Remix“ erschien auf der Veröffentlichung „I Go (Remixes)“ von Peggy Gou.",
+      "fun_fact_es": "«I Go - Soulwax Remix» aparece en el lanzamiento «I Go (Remixes)» de Peggy Gou.",
+      "fun_fact_fr": "« I Go - Soulwax Remix » figure sur la publication « I Go (Remixes) » de Peggy Gou.",
+      "fun_fact_nl": "‘I Go - Soulwax Remix’ staat op de release ‘I Go (Remixes)’ van Peggy Gou.",
+      "alt_artists": [
+        "Michel Cleis, Totó La Momposina, Paul Kalkbrenner",
+        "Sonny Fodera, Jazzy, D.O.D",
+        "Mike Williams"
+      ]
+    },
+    {
+      "artist": "Riva",
+      "title": "Stringer",
+      "year": 2026,
+      "isrc": "NL8FJ2600143",
+      "uri": "spotify:track:5YrZ5hbfxPurBSEYunVeBL",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/4035366421",
+      "fun_fact": "“Stringer” is the title track of Riva’s release of the same name.",
+      "fun_fact_de": "„Stringer“ ist der Titelsong der gleichnamigen Veröffentlichung von Riva.",
+      "fun_fact_es": "«Stringer» es la canción que da título al lanzamiento homónimo de Riva.",
+      "fun_fact_fr": "« Stringer » est le morceau-titre de la publication éponyme de Riva.",
+      "fun_fact_nl": "‘Stringer’ is het titelnummer van de gelijknamige release van Riva.",
+      "alt_artists": [
+        "The Chainsmokers, Coldplay, Alesso",
+        "Armin van Buuren, Sunnery James & Ryan Marciano",
+        "NERVO"
+      ]
+    },
+    {
+      "artist": "Ten Walls",
+      "title": "Walking With Elephants",
+      "year": 2014,
+      "isrc": "UK6VQ1400001",
+      "uri": "spotify:track:0k7z2AgvfqnKr240HrPs0T",
+      "uri_apple_music": "applemusic://track/1730209074",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1730209074"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2650103752",
+      "fun_fact": "“Walking With Elephants” is the title track of Ten Walls’s release of the same name.",
+      "fun_fact_de": "„Walking With Elephants“ ist der Titelsong der gleichnamigen Veröffentlichung von Ten Walls.",
+      "fun_fact_es": "«Walking With Elephants» es la canción que da título al lanzamiento homónimo de Ten Walls.",
+      "fun_fact_fr": "« Walking With Elephants » est le morceau-titre de la publication éponyme de Ten Walls.",
+      "fun_fact_nl": "‘Walking With Elephants’ is het titelnummer van de gelijknamige release van Ten Walls.",
+      "alt_artists": [
+        "FISHER, Aatig",
+        "Lucas & Steve, Brandy",
+        "Swedish House Mafia, Tinie Tempah"
+      ]
+    },
+    {
+      "artist": "Tiësto, BT",
+      "title": "Love Comes Again (feat. BT)",
+      "year": 2004,
+      "isrc": "NLE710480322",
+      "uri": "spotify:track:3gBcC4Tdeq6RAa0xxCSxwf",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3212473561",
+      "fun_fact": "“Love Comes Again (feat. BT)” appears on Tiësto’s release “Just Be”.",
+      "fun_fact_de": "„Love Comes Again (feat. BT)“ erschien auf der Veröffentlichung „Just Be“ von Tiësto.",
+      "fun_fact_es": "«Love Comes Again (feat. BT)» aparece en el lanzamiento «Just Be» de Tiësto.",
+      "fun_fact_fr": "« Love Comes Again (feat. BT) » figure sur la publication « Just Be » de Tiësto.",
+      "fun_fact_nl": "‘Love Comes Again (feat. BT)’ staat op de release ‘Just Be’ van Tiësto.",
+      "alt_artists": [
+        "Supermode, Axwell, Steve Angello",
+        "Travis Scott, CHASE B",
+        "Armin van Buuren, Tempo Giusto"
+      ]
+    },
+    {
+      "artist": "Romy, Fred again..",
+      "title": "Strong",
+      "year": 2022,
+      "isrc": "UK7MC2200175",
+      "uri": "spotify:track:5bF00VrMY3FwnQDgoP4Gnk",
+      "uri_apple_music": "applemusic://track/1650658608",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1650658608"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1974590787",
+      "fun_fact": "“Strong” is the title track of Romy’s release of the same name.",
+      "fun_fact_de": "„Strong“ ist der Titelsong der gleichnamigen Veröffentlichung von Romy.",
+      "fun_fact_es": "«Strong» es la canción que da título al lanzamiento homónimo de Romy.",
+      "fun_fact_fr": "« Strong » est le morceau-titre de la publication éponyme de Romy.",
+      "fun_fact_nl": "‘Strong’ is het titelnummer van de gelijknamige release van Romy.",
+      "alt_artists": [
+        "Bakermat",
+        "John Summit, Inéz",
+        "Swedish House Mafia, Alicia Keys"
+      ]
+    },
+    {
+      "artist": "Kölsch",
+      "title": "Opa",
+      "year": 2013,
+      "isrc": "DEU671300127",
+      "uri": "spotify:track:77l6PAo26UOqjzC0MzytIY",
+      "uri_apple_music": "applemusic://track/478341293",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/478341293"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/68788681",
+      "fun_fact": "“Opa” appears on Kölsch’s release “1977”.",
+      "fun_fact_de": "„Opa“ erschien auf der Veröffentlichung „1977“ von Kölsch.",
+      "fun_fact_es": "«Opa» aparece en el lanzamiento «1977» de Kölsch.",
+      "fun_fact_fr": "« Opa » figure sur la publication « 1977 » de Kölsch.",
+      "fun_fact_nl": "‘Opa’ staat op de release ‘1977’ van Kölsch.",
+      "alt_artists": [
+        "YORK",
+        "Armin van Buuren, The Stickmen Project",
+        "The Chainsmokers, Daya"
+      ]
+    },
+    {
+      "artist": "Filterheadz",
+      "title": "Yimanya - Original Mix",
+      "year": 2010,
+      "isrc": "NLF711000916",
+      "uri": "spotify:track:438LS85kXWLIiR1HfKQMq0",
+      "uri_apple_music": "applemusic://track/376643203",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/376643203"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/60827191",
+      "fun_fact": "“Yimanya - Original Mix” appears on Filterheadz’s release “50 Best Trance Hits Ever (Extended Versions)”.",
+      "fun_fact_de": "„Yimanya - Original Mix“ erschien auf der Veröffentlichung „50 Best Trance Hits Ever (Extended Versions)“ von Filterheadz.",
+      "fun_fact_es": "«Yimanya - Original Mix» aparece en el lanzamiento «50 Best Trance Hits Ever (Extended Versions)» de Filterheadz.",
+      "fun_fact_fr": "« Yimanya - Original Mix » figure sur la publication « 50 Best Trance Hits Ever (Extended Versions) » de Filterheadz.",
+      "fun_fact_nl": "‘Yimanya - Original Mix’ staat op de release ‘50 Best Trance Hits Ever (Extended Versions)’ van Filterheadz.",
+      "alt_artists": [
+        "BUNT., Nate Traveller",
+        "The Chainsmokers, Daya",
+        "Becky Hill, Chase & Status"
+      ]
+    },
+    {
+      "artist": "Dustin Zahn, Len Faki",
+      "title": "Strange (To Stability) - Len Faki Remix",
+      "year": 2009,
+      "isrc": "GBLTF0900021",
+      "uri": "spotify:track:7rIsr8YjCdbCftGSrT6d9B",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2804378412",
+      "fun_fact": "“Strange (To Stability) - Len Faki Remix” appears on Dustin Zahn’s release “Stefano Noferini Club Edition Winter Session 2013”.",
+      "fun_fact_de": "„Strange (To Stability) - Len Faki Remix“ erschien auf der Veröffentlichung „Stefano Noferini Club Edition Winter Session 2013“ von Dustin Zahn.",
+      "fun_fact_es": "«Strange (To Stability) - Len Faki Remix» aparece en el lanzamiento «Stefano Noferini Club Edition Winter Session 2013» de Dustin Zahn.",
+      "fun_fact_fr": "« Strange (To Stability) - Len Faki Remix » figure sur la publication « Stefano Noferini Club Edition Winter Session 2013 » de Dustin Zahn.",
+      "fun_fact_nl": "‘Strange (To Stability) - Len Faki Remix’ staat op de release ‘Stefano Noferini Club Edition Winter Session 2013’ van Dustin Zahn.",
+      "alt_artists": [
+        "L.P. Rhythm",
+        "Rusko, Netsky",
+        "Skrillex, Boys Noize, Opus III"
+      ]
+    },
+    {
+      "artist": "PAWSA",
+      "title": "TOO COOL TO BE CARELESS",
+      "year": 2024,
+      "isrc": "GBKQU2462686",
+      "uri": "spotify:track:6KqM3xmPIDonsTjCSGrrr5",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2862125622",
+      "fun_fact": "“TOO COOL TO BE CARELESS” is the title track of PAWSA’s release of the same name.",
+      "fun_fact_de": "„TOO COOL TO BE CARELESS“ ist der Titelsong der gleichnamigen Veröffentlichung von PAWSA.",
+      "fun_fact_es": "«TOO COOL TO BE CARELESS» es la canción que da título al lanzamiento homónimo de PAWSA.",
+      "fun_fact_fr": "« TOO COOL TO BE CARELESS » est le morceau-titre de la publication éponyme de PAWSA.",
+      "fun_fact_nl": "‘TOO COOL TO BE CARELESS’ is het titelnummer van de gelijknamige release van PAWSA.",
+      "alt_artists": [
+        "Josh Baker, Omar+",
+        "Dimitri Vegas & Like Mike",
+        "Shakedown, Anyma, Layton Giordani"
+      ]
+    },
+    {
+      "artist": "Freejak",
+      "title": "Sandstorm",
+      "year": 2022,
+      "isrc": "UK4ZF2200061",
+      "uri": "spotify:track:0ACTjicmzIcZZrG2DVXemO",
+      "uri_apple_music": "applemusic://track/1656100702",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1656100702"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2031868327",
+      "fun_fact": "“Sandstorm” is the title track of Freejak’s release of the same name.",
+      "fun_fact_de": "„Sandstorm“ ist der Titelsong der gleichnamigen Veröffentlichung von Freejak.",
+      "fun_fact_es": "«Sandstorm» es la canción que da título al lanzamiento homónimo de Freejak.",
+      "fun_fact_fr": "« Sandstorm » est le morceau-titre de la publication éponyme de Freejak.",
+      "fun_fact_nl": "‘Sandstorm’ is het titelnummer van de gelijknamige release van Freejak.",
+      "alt_artists": [
+        "Friend Within",
+        "Wankelmut, Emma Louise, MK",
+        "Double 99"
+      ]
+    },
+    {
+      "artist": "Yves V",
+      "title": "Find Your Soul",
+      "year": 2017,
+      "isrc": "NLZ541700107",
+      "uri": "spotify:track:6se3BJKbSo1U8CYppk9S59",
+      "uri_apple_music": "applemusic://track/1346715477",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1346715477"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/459830092",
+      "fun_fact": "“Find Your Soul” is the title track of Yves V’s release of the same name.",
+      "fun_fact_de": "„Find Your Soul“ ist der Titelsong der gleichnamigen Veröffentlichung von Yves V.",
+      "fun_fact_es": "«Find Your Soul» es la canción que da título al lanzamiento homónimo de Yves V.",
+      "fun_fact_fr": "« Find Your Soul » est le morceau-titre de la publication éponyme de Yves V.",
+      "fun_fact_nl": "‘Find Your Soul’ is het titelnummer van de gelijknamige release van Yves V.",
+      "alt_artists": [
+        "Alan Walker, Tiësto",
+        "Loud Luxury, Brando",
+        "Jaden Bojsen, Sami Brielle"
+      ]
+    },
+    {
+      "artist": "Digitalism",
+      "title": "Zdarlight",
+      "year": 2007,
+      "isrc": "GBUM71207141",
+      "uri": "spotify:track:05JHQRBFjhTTH9DGDM8Iwy",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2692037762",
+      "fun_fact": "“Zdarlight” appears on Digitalism’s release “Idealism”.",
+      "fun_fact_de": "„Zdarlight“ erschien auf der Veröffentlichung „Idealism“ von Digitalism.",
+      "fun_fact_es": "«Zdarlight» aparece en el lanzamiento «Idealism» de Digitalism.",
+      "fun_fact_fr": "« Zdarlight » figure sur la publication « Idealism » de Digitalism.",
+      "fun_fact_nl": "‘Zdarlight’ staat op de release ‘Idealism’ van Digitalism.",
+      "alt_artists": [
+        "Alesso, Zara Larsson",
+        "Coldplay, Swedish House Mafia",
+        "Dj Bountyhunter"
+      ]
+    },
+    {
+      "artist": "RAFFA GUIDO",
+      "title": "Famax",
+      "year": 2024,
+      "isrc": "ITFGO2400001",
+      "uri": "spotify:track:2xpeEb2moFy7dRinc7tUnz",
+      "uri_apple_music": "applemusic://track/1728329796",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1728329796"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2642151722",
+      "fun_fact": "“Famax” is the title track of RAFFA GUIDO’s release of the same name.",
+      "fun_fact_de": "„Famax“ ist der Titelsong der gleichnamigen Veröffentlichung von RAFFA GUIDO.",
+      "fun_fact_es": "«Famax» es la canción que da título al lanzamiento homónimo de RAFFA GUIDO.",
+      "fun_fact_fr": "« Famax » est le morceau-titre de la publication éponyme de RAFFA GUIDO.",
+      "fun_fact_nl": "‘Famax’ is het titelnummer van de gelijknamige release van RAFFA GUIDO.",
+      "alt_artists": [
+        "Steve Aoki, Wynter Gordon",
+        "Kings Of Tomorrow",
+        "Fred again.., Romy, HAAi"
+      ]
+    },
+    {
+      "artist": "Barry Can't Swim",
+      "title": "How It Feels",
+      "year": 2023,
+      "isrc": "GBCFB2300335",
+      "uri": "spotify:track:3NZz7DWeVQesSOn6mO39F7",
+      "uri_apple_music": "applemusic://track/1687656897",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1687656897"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2305911755",
+      "fun_fact": "“How It Feels” appears on Barry Can't Swim’s release “When Will We Land?”.",
+      "fun_fact_de": "„How It Feels“ erschien auf der Veröffentlichung „When Will We Land?“ von Barry Can't Swim.",
+      "fun_fact_es": "«How It Feels» aparece en el lanzamiento «When Will We Land?» de Barry Can't Swim.",
+      "fun_fact_fr": "« How It Feels » figure sur la publication « When Will We Land? » de Barry Can't Swim.",
+      "fun_fact_nl": "‘How It Feels’ staat op de release ‘When Will We Land?’ van Barry Can't Swim.",
+      "alt_artists": [
+        "DubVision, AFROJACK",
+        "Dustin Zahn, Len Faki",
+        "Oden & Fatzo"
+      ]
+    },
+    {
+      "artist": "Armin van Buuren",
+      "title": "Blue Fear",
+      "year": 1996,
+      "isrc": "NLF711404995",
+      "uri": "spotify:track:3TltZ4yCDer3I5wS8MzRmX",
+      "uri_apple_music": "applemusic://track/1231948329",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1231948329"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2992147511",
+      "fun_fact": "“Blue Fear” is the title track of Armin van Buuren’s release of the same name.",
+      "fun_fact_de": "„Blue Fear“ ist der Titelsong der gleichnamigen Veröffentlichung von Armin van Buuren.",
+      "fun_fact_es": "«Blue Fear» es la canción que da título al lanzamiento homónimo de Armin van Buuren.",
+      "fun_fact_fr": "« Blue Fear » est le morceau-titre de la publication éponyme de Armin van Buuren.",
+      "fun_fact_nl": "‘Blue Fear’ is het titelnummer van de gelijknamige release van Armin van Buuren.",
+      "alt_artists": [
+        "Adrian Lux",
+        "Martin Garrix, Matisse & Sadko, John Martin",
+        "Breach"
+      ]
+    },
+    {
+      "artist": "Dubfire",
+      "title": "Roadkill - Original Club Mix",
+      "year": 2008,
+      "isrc": "GBJAJ0700378",
+      "uri": "spotify:track:0Nm6ukwBZHAtxgENSu3naG",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/68893339",
+      "fun_fact": "“Roadkill - Original Club Mix” appears on Dubfire’s release “Toolroom Ten”.",
+      "fun_fact_de": "„Roadkill - Original Club Mix“ erschien auf der Veröffentlichung „Toolroom Ten“ von Dubfire.",
+      "fun_fact_es": "«Roadkill - Original Club Mix» aparece en el lanzamiento «Toolroom Ten» de Dubfire.",
+      "fun_fact_fr": "« Roadkill - Original Club Mix » figure sur la publication « Toolroom Ten » de Dubfire.",
+      "fun_fact_nl": "‘Roadkill - Original Club Mix’ staat op de release ‘Toolroom Ten’ van Dubfire.",
+      "alt_artists": [
+        "John Summit",
+        "Rune RK, Firebeatz",
+        "C-Mos, Axwell"
+      ]
+    },
+    {
+      "artist": "Alter Ego, Eric Prydz",
+      "title": "Rocker - Eric Prydz Remix",
+      "year": 2004,
+      "isrc": "DEZ651357700",
+      "uri": "spotify:track:06rySooiZs8Gvm7ArADyLt",
+      "uri_apple_music": "applemusic://track/1712042835",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1712042835"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/488667532",
+      "fun_fact": "“Rocker - Eric Prydz Remix” appears on Alter Ego’s release “Rocker”.",
+      "fun_fact_de": "„Rocker - Eric Prydz Remix“ erschien auf der Veröffentlichung „Rocker“ von Alter Ego.",
+      "fun_fact_es": "«Rocker - Eric Prydz Remix» aparece en el lanzamiento «Rocker» de Alter Ego.",
+      "fun_fact_fr": "« Rocker - Eric Prydz Remix » figure sur la publication « Rocker » de Alter Ego.",
+      "fun_fact_nl": "‘Rocker - Eric Prydz Remix’ staat op de release ‘Rocker’ van Alter Ego.",
+      "alt_artists": [
+        "Delerium, Sarah McLachlan, John Summit",
+        "RAFFA GUIDO",
+        "Charlotte de Witte"
+      ]
+    },
+    {
+      "artist": "Tiësto, Vintage Culture",
+      "title": "Coffee (Give Me Something)",
+      "year": 2020,
+      "isrc": "CYA112000587",
+      "uri": "spotify:track:4DBLAy03Xk88LOVtrOQ1RD",
+      "uri_apple_music": "applemusic://track/1544504688",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1544504688"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1048015732",
+      "fun_fact": "“Coffee (Give Me Something)” is the title track of Tiësto’s release of the same name.",
+      "fun_fact_de": "„Coffee (Give Me Something)“ ist der Titelsong der gleichnamigen Veröffentlichung von Tiësto.",
+      "fun_fact_es": "«Coffee (Give Me Something)» es la canción que da título al lanzamiento homónimo de Tiësto.",
+      "fun_fact_fr": "« Coffee (Give Me Something) » est le morceau-titre de la publication éponyme de Tiësto.",
+      "fun_fact_nl": "‘Coffee (Give Me Something)’ is het titelnummer van de gelijknamige release van Tiësto.",
+      "alt_artists": [
+        "Armin van Buuren, Sharon Den Adel",
+        "Jay Hardway",
+        "Sander van Doorn, Martin Garrix, DVBBS, Aleesia"
+      ]
+    },
+    {
+      "artist": "Ayla",
+      "title": "Ayla - Original 1995 Mix",
+      "year": 1998,
+      "isrc": "NLD681801752",
+      "uri": "spotify:track:0xTySVrQi5Li96Wu7pCp80",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/501067312",
+      "fun_fact": "“Ayla - Original 1995 Mix” appears on Ayla’s release “Magik Three (Far from Earth) mixed by DJ Tiësto”.",
+      "fun_fact_de": "„Ayla - Original 1995 Mix“ erschien auf der Veröffentlichung „Magik Three (Far from Earth) mixed by DJ Tiësto“ von Ayla.",
+      "fun_fact_es": "«Ayla - Original 1995 Mix» aparece en el lanzamiento «Magik Three (Far from Earth) mixed by DJ Tiësto» de Ayla.",
+      "fun_fact_fr": "« Ayla - Original 1995 Mix » figure sur la publication « Magik Three (Far from Earth) mixed by DJ Tiësto » de Ayla.",
+      "fun_fact_nl": "‘Ayla - Original 1995 Mix’ staat op de release ‘Magik Three (Far from Earth) mixed by DJ Tiësto’ van Ayla.",
+      "alt_artists": [
+        "Sebastian Ingrosso, Céline Dion",
+        "Axwell, Dirty South, Rudy",
+        "Format:B"
+      ]
+    },
+    {
+      "artist": "James Hype, Major Lazer",
+      "title": "Number 1",
+      "year": 2023,
+      "isrc": "US39N2308523",
+      "uri": "spotify:track:0oM1DNoFDkf0dXLMBUZlvt",
+      "uri_apple_music": "applemusic://track/1822817275",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1822817275"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3430840701",
+      "fun_fact": "“Number 1” is the title track of James Hype’s release of the same name.",
+      "fun_fact_de": "„Number 1“ ist der Titelsong der gleichnamigen Veröffentlichung von James Hype.",
+      "fun_fact_es": "«Number 1» es la canción que da título al lanzamiento homónimo de James Hype.",
+      "fun_fact_fr": "« Number 1 » est le morceau-titre de la publication éponyme de James Hype.",
+      "fun_fact_nl": "‘Number 1’ is het titelnummer van de gelijknamige release van James Hype.",
+      "alt_artists": [
+        "Porter Robinson",
+        "Armin van Buuren, Agents Of Time, ORKID",
+        "Avicii, Lenny Kravitz"
+      ]
+    },
+    {
+      "artist": "Jax Jones, Martin Solveig, Madison Beer, Europa",
+      "title": "All Day And Night",
+      "year": 2019,
+      "isrc": "GBUM71900522",
+      "uri": "spotify:track:33CfD8UkDEcSdAP9j4QpUY",
+      "uri_apple_music": "applemusic://track/1489203183",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1489203183"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/653689002",
+      "fun_fact": "“All Day And Night” appears on Jax Jones’s release “All Day And Night (Jax Jones & Martin Solveig Present Europa)”.",
+      "fun_fact_de": "„All Day And Night“ erschien auf der Veröffentlichung „All Day And Night (Jax Jones & Martin Solveig Present Europa)“ von Jax Jones.",
+      "fun_fact_es": "«All Day And Night» aparece en el lanzamiento «All Day And Night (Jax Jones & Martin Solveig Present Europa)» de Jax Jones.",
+      "fun_fact_fr": "« All Day And Night » figure sur la publication « All Day And Night (Jax Jones & Martin Solveig Present Europa) » de Jax Jones.",
+      "fun_fact_nl": "‘All Day And Night’ staat op de release ‘All Day And Night (Jax Jones & Martin Solveig Present Europa)’ van Jax Jones.",
+      "alt_artists": [
+        "Chuckie, Hardwell, Ambush",
+        "Yves V, HIDDN",
+        "Otto Knows, Avicii"
+      ]
+    },
+    {
+      "artist": "Rebūke",
+      "title": "Along Came Polly",
+      "year": 2018,
+      "isrc": "GBK6Y1812601",
+      "uri": "spotify:track:6fL2wAZuNKGpze9E3SINnW",
+      "uri_apple_music": "applemusic://track/1678184581",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1678184581"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2201836177",
+      "fun_fact": "“Along Came Polly” is the title track of Rebūke’s release of the same name.",
+      "fun_fact_de": "„Along Came Polly“ ist der Titelsong der gleichnamigen Veröffentlichung von Rebūke.",
+      "fun_fact_es": "«Along Came Polly» es la canción que da título al lanzamiento homónimo de Rebūke.",
+      "fun_fact_fr": "« Along Came Polly » est le morceau-titre de la publication éponyme de Rebūke.",
+      "fun_fact_nl": "‘Along Came Polly’ is het titelnummer van de gelijknamige release van Rebūke.",
+      "alt_artists": [
+        "Sebastian Ingrosso, Céline Dion",
+        "Zedd, Foxes",
+        "David Guetta, OneRepublic"
+      ]
+    },
+    {
+      "artist": "MoBlack, Salif Keita, Benja (NL), Franc Fala, Cesária Evora",
+      "title": "Yamore",
+      "year": 2024,
+      "isrc": "FRUM72400728",
+      "uri": "spotify:track:480j122Gpi252OIfy4SNzm",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2826343892",
+      "fun_fact": "“Yamore” is the title track of MoBlack’s release of the same name.",
+      "fun_fact_de": "„Yamore“ ist der Titelsong der gleichnamigen Veröffentlichung von MoBlack.",
+      "fun_fact_es": "«Yamore» es la canción que da título al lanzamiento homónimo de MoBlack.",
+      "fun_fact_fr": "« Yamore » est le morceau-titre de la publication éponyme de MoBlack.",
+      "fun_fact_nl": "‘Yamore’ is het titelnummer van de gelijknamige release van MoBlack.",
+      "alt_artists": [
+        "Grooveyard, Nicky Romero",
+        "Jan Blomqvist, Ben Böhmer",
+        "Dimitri Vegas & Like Mike, Bassjackers, D'Angello & Francis"
+      ]
+    },
+    {
+      "artist": "David Guetta, Dirty South, Sebastian Ingrosso, Julie McKnight",
+      "title": "How Soon Is Now - Dirty South Remix",
+      "year": 2009,
+      "isrc": "FRZID0901800",
+      "uri": "spotify:track:5NThOInQkmb3j4CiOuFqdJ",
+      "uri_apple_music": "applemusic://track/1715687669",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1715687669"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/673165832",
+      "fun_fact": "“How Soon Is Now - Dirty South Remix” appears on David Guetta’s release “One More Love”.",
+      "fun_fact_de": "„How Soon Is Now - Dirty South Remix“ erschien auf der Veröffentlichung „One More Love“ von David Guetta.",
+      "fun_fact_es": "«How Soon Is Now - Dirty South Remix» aparece en el lanzamiento «One More Love» de David Guetta.",
+      "fun_fact_fr": "« How Soon Is Now - Dirty South Remix » figure sur la publication « One More Love » de David Guetta.",
+      "fun_fact_nl": "‘How Soon Is Now - Dirty South Remix’ staat op de release ‘One More Love’ van David Guetta.",
+      "alt_artists": [
+        "AVAION",
+        "The Weeknd, Swedish House Mafia",
+        "Rune RK, Firebeatz"
+      ]
+    },
+    {
+      "artist": "Daft Punk",
+      "title": "Alive",
+      "year": 1994,
+      "isrc": "GBDUW0600017",
+      "uri": "spotify:track:1PH5Es89c1cENU8WVuWwbp",
+      "uri_apple_music": "applemusic://track/696887206",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/696887206"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3129783",
+      "fun_fact": "“Alive” appears on Daft Punk’s release “Homework”.",
+      "fun_fact_de": "„Alive“ erschien auf der Veröffentlichung „Homework“ von Daft Punk.",
+      "fun_fact_es": "«Alive» aparece en el lanzamiento «Homework» de Daft Punk.",
+      "fun_fact_fr": "« Alive » figure sur la publication « Homework » de Daft Punk.",
+      "fun_fact_nl": "‘Alive’ staat op de release ‘Homework’ van Daft Punk.",
+      "alt_artists": [
+        "Sub Focus, Dimension",
+        "Pryda",
+        "Red Hot Chili Peppers"
+      ]
+    },
+    {
+      "artist": "Calvin Harris, Ellie Goulding",
+      "title": "Miracle (with Ellie Goulding)",
+      "year": 2023,
+      "isrc": "GBARL2300301",
+      "uri": "spotify:track:5eTaQYBE1yrActixMAeLcZ",
+      "uri_apple_music": "applemusic://track/1678593705",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1678593705"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2320684505",
+      "fun_fact": "“Miracle (with Ellie Goulding)” appears on Calvin Harris’s release “Miracle (Remixes)”.",
+      "fun_fact_de": "„Miracle (with Ellie Goulding)“ erschien auf der Veröffentlichung „Miracle (Remixes)“ von Calvin Harris.",
+      "fun_fact_es": "«Miracle (with Ellie Goulding)» aparece en el lanzamiento «Miracle (Remixes)» de Calvin Harris.",
+      "fun_fact_fr": "« Miracle (with Ellie Goulding) » figure sur la publication « Miracle (Remixes) » de Calvin Harris.",
+      "fun_fact_nl": "‘Miracle (with Ellie Goulding)’ staat op de release ‘Miracle (Remixes)’ van Calvin Harris.",
+      "alt_artists": [
+        "Tiësto, Stargate, Aloe Blacc",
+        "MEDUZA, Becky Hill, Goodboys",
+        "Krewella, Hardwell"
+      ]
+    },
+    {
+      "artist": "Amelie Lens",
+      "title": "Exhale - Original Mix",
+      "year": 2016,
+      "isrc": "GB9TP1500674",
+      "uri": "spotify:track:0n88HmRZGQew4UN1QaVY3A",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/118168904",
+      "fun_fact": "“Exhale - Original Mix” appears on Amelie Lens’s release “Exhale”.",
+      "fun_fact_de": "„Exhale - Original Mix“ erschien auf der Veröffentlichung „Exhale“ von Amelie Lens.",
+      "fun_fact_es": "«Exhale - Original Mix» aparece en el lanzamiento «Exhale» de Amelie Lens.",
+      "fun_fact_fr": "« Exhale - Original Mix » figure sur la publication « Exhale » de Amelie Lens.",
+      "fun_fact_nl": "‘Exhale - Original Mix’ staat op de release ‘Exhale’ van Amelie Lens.",
+      "alt_artists": [
+        "ANOTR, Abel Balder",
+        "Armand Van Helden",
+        "Tiësto, BT"
+      ]
+    },
+    {
+      "artist": "Marian Hill, Franky Rizardo",
+      "title": "Down - Franky Rizardo Remix",
+      "year": 2017,
+      "isrc": "USUM71703951",
+      "uri": "spotify:track:0U65qiH70mcfB1wyF0Mal0",
+      "uri_apple_music": "applemusic://track/1445033600",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1445033600"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/353141091",
+      "fun_fact": "“Down - Franky Rizardo Remix” is the title track of Marian Hill’s release of the same name.",
+      "fun_fact_de": "„Down - Franky Rizardo Remix“ ist der Titelsong der gleichnamigen Veröffentlichung von Marian Hill.",
+      "fun_fact_es": "«Down - Franky Rizardo Remix» es la canción que da título al lanzamiento homónimo de Marian Hill.",
+      "fun_fact_fr": "« Down - Franky Rizardo Remix » est le morceau-titre de la publication éponyme de Marian Hill.",
+      "fun_fact_nl": "‘Down - Franky Rizardo Remix’ is het titelnummer van de gelijknamige release van Marian Hill.",
+      "alt_artists": [
+        "Steve Angello",
+        "ILLENIUM, Valerie Broussard, NURKO",
+        "Alan Braxe, Fred Falke"
+      ]
+    },
+    {
+      "artist": "Avicii",
+      "title": "The Days",
+      "year": 2014,
+      "isrc": "CH3131340471",
+      "uri": "spotify:track:5Iy2Jj87Ha0C0IBlNE1I4y",
+      "uri_apple_music": "applemusic://track/1440829541",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1440829541"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/90632835",
+      "fun_fact": "“The Days” appears on Avicii’s release “The Days / Nights (EP)”.",
+      "fun_fact_de": "„The Days“ erschien auf der Veröffentlichung „The Days / Nights (EP)“ von Avicii.",
+      "fun_fact_es": "«The Days» aparece en el lanzamiento «The Days / Nights (EP)» de Avicii.",
+      "fun_fact_fr": "« The Days » figure sur la publication « The Days / Nights (EP) » de Avicii.",
+      "fun_fact_nl": "‘The Days’ staat op de release ‘The Days / Nights (EP)’ van Avicii.",
+      "alt_artists": [
+        "Dirty South, Alesso, Ruben Haze",
+        "southstar",
+        "Timmy Trumpet, Savage"
+      ]
+    },
+    {
+      "artist": "Sammy Virji",
+      "title": "If U Need It",
+      "year": 2023,
+      "isrc": "GBUM72309238",
+      "uri": "spotify:track:5CaUUACiQFEf4zR5WoeIrp",
+      "uri_apple_music": "applemusic://track/1711713806",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1711713806"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2516525761",
+      "fun_fact": "“If U Need It” is the title track of Sammy Virji’s release of the same name.",
+      "fun_fact_de": "„If U Need It“ ist der Titelsong der gleichnamigen Veröffentlichung von Sammy Virji.",
+      "fun_fact_es": "«If U Need It» es la canción que da título al lanzamiento homónimo de Sammy Virji.",
+      "fun_fact_fr": "« If U Need It » est le morceau-titre de la publication éponyme de Sammy Virji.",
+      "fun_fact_nl": "‘If U Need It’ is het titelnummer van de gelijknamige release van Sammy Virji.",
+      "alt_artists": [
+        "Lost Frequencies, The NGHBRS, Keanu Silva",
+        "Topic, Fireboy DML, Nico Santos",
+        "Armin van Buuren, Sam Gray"
+      ]
+    },
+    {
+      "artist": "Mason",
+      "title": "Exceeder",
+      "year": 2006,
+      "isrc": "NLF711312396",
+      "uri": "spotify:track:7KUsZg51ktiV77dhS03IME",
+      "uri_apple_music": "applemusic://track/736759055",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/736759055"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/72164207",
+      "fun_fact": "“Exceeder” is the title track of Mason’s release of the same name.",
+      "fun_fact_de": "„Exceeder“ ist der Titelsong der gleichnamigen Veröffentlichung von Mason.",
+      "fun_fact_es": "«Exceeder» es la canción que da título al lanzamiento homónimo de Mason.",
+      "fun_fact_fr": "« Exceeder » est le morceau-titre de la publication éponyme de Mason.",
+      "fun_fact_nl": "‘Exceeder’ is het titelnummer van de gelijknamige release van Mason.",
+      "alt_artists": [
+        "Calvin Harris, Clementine Douglas",
+        "Pendulum, AN21, Max Vangeli, Steve Angello",
+        "Format:B"
+      ]
+    },
+    {
+      "artist": "Martin Garrix, Macklemore, Fall Out Boy, Tiësto",
+      "title": "Summer Days (feat. Macklemore & Patrick Stump of Fall Out Boy) - Tiësto Remix",
+      "year": 2019,
+      "isrc": "NLM5S1900575",
+      "uri": "spotify:track:55nMnifaQWKe3f9cbwOXwx",
+      "uri_apple_music": "applemusic://track/1470939103",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1470939103"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/705139962",
+      "fun_fact": "“Summer Days (feat. Macklemore & Patrick Stump of Fall Out Boy) - Tiësto Remix” appears on Martin Garrix’s release “Summer Days (feat. Macklemore & Patrick Stump of Fall Out Boy) (Remixes)”.",
+      "fun_fact_de": "„Summer Days (feat. Macklemore & Patrick Stump of Fall Out Boy) - Tiësto Remix“ erschien auf der Veröffentlichung „Summer Days (feat. Macklemore & Patrick Stump of Fall Out Boy) (Remixes)“ von Martin Garrix.",
+      "fun_fact_es": "«Summer Days (feat. Macklemore & Patrick Stump of Fall Out Boy) - Tiësto Remix» aparece en el lanzamiento «Summer Days (feat. Macklemore & Patrick Stump of Fall Out Boy) (Remixes)» de Martin Garrix.",
+      "fun_fact_fr": "« Summer Days (feat. Macklemore & Patrick Stump of Fall Out Boy) - Tiësto Remix » figure sur la publication « Summer Days (feat. Macklemore & Patrick Stump of Fall Out Boy) (Remixes) » de Martin Garrix.",
+      "fun_fact_nl": "‘Summer Days (feat. Macklemore & Patrick Stump of Fall Out Boy) - Tiësto Remix’ staat op de release ‘Summer Days (feat. Macklemore & Patrick Stump of Fall Out Boy) (Remixes)’ van Martin Garrix.",
+      "alt_artists": [
+        "James Hype",
+        "Issey Cross, Tiësto",
+        "Laurent Garnier"
+      ]
+    },
+    {
+      "artist": "D.O.D",
+      "title": "So Much In Love",
+      "year": 2023,
+      "isrc": "NLF712302567",
+      "uri": "spotify:track:7DnI3ktF2vcmzKuCCKseQL",
+      "uri_apple_music": "applemusic://track/1680178523",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1680178523"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2225841857",
+      "fun_fact": "“So Much In Love” is the title track of D.O.D’s release of the same name.",
+      "fun_fact_de": "„So Much In Love“ ist der Titelsong der gleichnamigen Veröffentlichung von D.O.D.",
+      "fun_fact_es": "«So Much In Love» es la canción que da título al lanzamiento homónimo de D.O.D.",
+      "fun_fact_fr": "« So Much In Love » est le morceau-titre de la publication éponyme de D.O.D.",
+      "fun_fact_nl": "‘So Much In Love’ is het titelnummer van de gelijknamige release van D.O.D.",
+      "alt_artists": [
+        "Armin van Buuren, Sunnery James & Ryan Marciano",
+        "BL3SS, CamrinWatsin, bbyclose",
+        "Monolink, ARTBAT"
+      ]
+    },
+    {
+      "artist": "Above & Beyond, anamē, Marty Longstaff",
+      "title": "Gratitude",
+      "year": 2022,
+      "isrc": "GBEWA2201970",
+      "uri": "spotify:track:0KU8W0lHfsNlH7lfV1dz29",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1711594307",
+      "fun_fact": "“Gratitude” is the title track of Above & Beyond’s release of the same name.",
+      "fun_fact_de": "„Gratitude“ ist der Titelsong der gleichnamigen Veröffentlichung von Above & Beyond.",
+      "fun_fact_es": "«Gratitude» es la canción que da título al lanzamiento homónimo de Above & Beyond.",
+      "fun_fact_fr": "« Gratitude » est le morceau-titre de la publication éponyme de Above & Beyond.",
+      "fun_fact_nl": "‘Gratitude’ is het titelnummer van de gelijknamige release van Above & Beyond.",
+      "alt_artists": [
+        "Martin Garrix, Bonn",
+        "David Guetta, Nicky Romero, Sia",
+        "Blasterjaxx, Hardwell"
+      ]
+    },
+    {
+      "artist": "M.A.N.D.Y., Booka Shade",
+      "title": "Body Language",
+      "year": 2006,
+      "isrc": "DEBE71400074",
+      "uri": "spotify:track:0IvBzwnja9ElmpWKYfBz7i",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1914504267",
+      "fun_fact": "“Body Language” appears on M.A.N.D.Y.’s release “Get Physical, Vol II. - 4th Anniversary”.",
+      "fun_fact_de": "„Body Language“ erschien auf der Veröffentlichung „Get Physical, Vol II. - 4th Anniversary“ von M.A.N.D.Y..",
+      "fun_fact_es": "«Body Language» aparece en el lanzamiento «Get Physical, Vol II. - 4th Anniversary» de M.A.N.D.Y..",
+      "fun_fact_fr": "« Body Language » figure sur la publication « Get Physical, Vol II. - 4th Anniversary » de M.A.N.D.Y..",
+      "fun_fact_nl": "‘Body Language’ staat op de release ‘Get Physical, Vol II. - 4th Anniversary’ van M.A.N.D.Y..",
+      "alt_artists": [
+        "CamelPhat, Yannis, Foals",
+        "Tiësto, 433",
+        "Martin Garrix, Matisse & Sadko, Michel Zitron"
+      ]
+    },
+    {
+      "artist": "Sidney Samson",
+      "title": "Riverside",
+      "year": 2009,
+      "isrc": "NLC280810779",
+      "uri": "spotify:track:6FZQH0HlMULVggaqjyQBqT",
+      "uri_apple_music": "applemusic://track/1712042703",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1712042703"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/489393822",
+      "fun_fact": "“Riverside” is the title track of Sidney Samson’s release of the same name.",
+      "fun_fact_de": "„Riverside“ ist der Titelsong der gleichnamigen Veröffentlichung von Sidney Samson.",
+      "fun_fact_es": "«Riverside» es la canción que da título al lanzamiento homónimo de Sidney Samson.",
+      "fun_fact_fr": "« Riverside » est le morceau-titre de la publication éponyme de Sidney Samson.",
+      "fun_fact_nl": "‘Riverside’ is het titelnummer van de gelijknamige release van Sidney Samson.",
+      "alt_artists": [
+        "Martin Garrix, USHER",
+        "Purple Disco Machine, Moss Kena, The Knocks",
+        "Dimitri Vegas & Like Mike, Marlon Hoffstadt, Dj Konik, Dimitri Vegas, Like Mike"
+      ]
+    },
+    {
+      "artist": "Mau P",
+      "title": "On Again",
+      "year": 2024,
+      "isrc": "NL8RL2409745",
+      "uri": "spotify:track:5vASuVQkngtFoCOczem52V",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2713318481",
+      "fun_fact": "“On Again” is the title track of Mau P’s release of the same name.",
+      "fun_fact_de": "„On Again“ ist der Titelsong der gleichnamigen Veröffentlichung von Mau P.",
+      "fun_fact_es": "«On Again» es la canción que da título al lanzamiento homónimo de Mau P.",
+      "fun_fact_fr": "« On Again » est le morceau-titre de la publication éponyme de Mau P.",
+      "fun_fact_nl": "‘On Again’ is het titelnummer van de gelijknamige release van Mau P.",
+      "alt_artists": [
+        "Robin Schulz, Jasmine Thompson",
+        "Mike Williams",
+        "Calvin Harris, Clementine Douglas, Cassian"
+      ]
+    },
+    {
+      "artist": "Jewelz & Sparks, AFROJACK, Sunnery James & Ryan Marciano",
+      "title": "Bring It Back - Afrojack x Sunnery James & Ryan Marciano Edit",
+      "year": 2019,
+      "isrc": "CYA221900072",
+      "uri": "spotify:track:6JieX6GcqcsXtaKK0OewXI",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/648099672",
+      "fun_fact": "“Bring It Back - Afrojack x Sunnery James & Ryan Marciano Edit” is the title track of Jewelz & Sparks’s release of the same name.",
+      "fun_fact_de": "„Bring It Back - Afrojack x Sunnery James & Ryan Marciano Edit“ ist der Titelsong der gleichnamigen Veröffentlichung von Jewelz & Sparks.",
+      "fun_fact_es": "«Bring It Back - Afrojack x Sunnery James & Ryan Marciano Edit» es la canción que da título al lanzamiento homónimo de Jewelz & Sparks.",
+      "fun_fact_fr": "« Bring It Back - Afrojack x Sunnery James & Ryan Marciano Edit » est le morceau-titre de la publication éponyme de Jewelz & Sparks.",
+      "fun_fact_nl": "‘Bring It Back - Afrojack x Sunnery James & Ryan Marciano Edit’ is het titelnummer van de gelijknamige release van Jewelz & Sparks.",
+      "alt_artists": [
+        "Martin Garrix, MOTi",
+        "Binary Finary, Paul van Dyk",
+        "CHRIS STASSY, S.A.M."
+      ]
+    },
+    {
+      "artist": "Tiga",
+      "title": "You Gonna Want Me - Tocadisco Remix",
+      "year": 2007,
+      "isrc": "BEP010700002",
+      "uri": "spotify:track:0tdxwIjvZq1SXuyghptjRO",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3842078",
+      "fun_fact": "“You Gonna Want Me - Tocadisco Remix” appears on Tiga’s release “You Gonna Want Me Remixes”.",
+      "fun_fact_de": "„You Gonna Want Me - Tocadisco Remix“ erschien auf der Veröffentlichung „You Gonna Want Me Remixes“ von Tiga.",
+      "fun_fact_es": "«You Gonna Want Me - Tocadisco Remix» aparece en el lanzamiento «You Gonna Want Me Remixes» de Tiga.",
+      "fun_fact_fr": "« You Gonna Want Me - Tocadisco Remix » figure sur la publication « You Gonna Want Me Remixes » de Tiga.",
+      "fun_fact_nl": "‘You Gonna Want Me - Tocadisco Remix’ staat op de release ‘You Gonna Want Me Remixes’ van Tiga.",
+      "alt_artists": [
+        "Hardwell, Blasterjaxx, Mitch Crown",
+        "Tube & Berger",
+        "Sonique, The Conductor & The Cowboy"
+      ]
+    },
+    {
+      "artist": "Armin van Buuren, Tempo Giusto",
+      "title": "Mr. Navigator",
+      "year": 2019,
+      "isrc": "NLF711909593",
+      "uri": "spotify:track:1Q7FZie2f2sJjfI5svBjGR",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/742337762",
+      "fun_fact": "“Mr. Navigator” is the title track of Armin van Buuren’s release of the same name.",
+      "fun_fact_de": "„Mr. Navigator“ ist der Titelsong der gleichnamigen Veröffentlichung von Armin van Buuren.",
+      "fun_fact_es": "«Mr. Navigator» es la canción que da título al lanzamiento homónimo de Armin van Buuren.",
+      "fun_fact_fr": "« Mr. Navigator » est le morceau-titre de la publication éponyme de Armin van Buuren.",
+      "fun_fact_nl": "‘Mr. Navigator’ is het titelnummer van de gelijknamige release van Armin van Buuren.",
+      "alt_artists": [
+        "Bingo Players",
+        "Armin van Buuren, Sunnery James & Ryan Marciano",
+        "Djuma Soundsystem"
+      ]
+    },
+    {
+      "artist": "Paul Oakenfold, Carla Werner, Tiësto",
+      "title": "Southern Sun - Tiësto Remix",
+      "year": 2019,
+      "isrc": "NLF711814851",
+      "uri": "spotify:track:1ZYi8vxQO8ZKp42fEvXxkC",
+      "uri_apple_music": "applemusic://track/1816495432",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1816495432"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/614229602",
+      "fun_fact": "“Southern Sun - Tiësto Remix” appears on Paul Oakenfold’s release “Trance Top 1000 - The Legends”.",
+      "fun_fact_de": "„Southern Sun - Tiësto Remix“ erschien auf der Veröffentlichung „Trance Top 1000 - The Legends“ von Paul Oakenfold.",
+      "fun_fact_es": "«Southern Sun - Tiësto Remix» aparece en el lanzamiento «Trance Top 1000 - The Legends» de Paul Oakenfold.",
+      "fun_fact_fr": "« Southern Sun - Tiësto Remix » figure sur la publication « Trance Top 1000 - The Legends » de Paul Oakenfold.",
+      "fun_fact_nl": "‘Southern Sun - Tiësto Remix’ staat op de release ‘Trance Top 1000 - The Legends’ van Paul Oakenfold.",
+      "alt_artists": [
+        "Nora En Pure",
+        "Delerium, Sarah McLachlan, John Summit",
+        "Purple Disco Machine, Sophie and the Giants"
+      ]
+    },
+    {
+      "artist": "deadmau5",
+      "title": "Some Chords",
+      "year": 2010,
+      "isrc": "GBTDG1000182",
+      "uri": "spotify:track:7q3aKYrhCbTnxdRZ6xmkC6",
+      "uri_apple_music": "applemusic://track/1824492347",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1824492347"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/7703889",
+      "fun_fact": "“Some Chords” appears on deadmau5’s release “4x4=12”.",
+      "fun_fact_de": "„Some Chords“ erschien auf der Veröffentlichung „4x4=12“ von deadmau5.",
+      "fun_fact_es": "«Some Chords» aparece en el lanzamiento «4x4=12» de deadmau5.",
+      "fun_fact_fr": "« Some Chords » figure sur la publication « 4x4=12 » de deadmau5.",
+      "fun_fact_nl": "‘Some Chords’ staat op de release ‘4x4=12’ van deadmau5.",
+      "alt_artists": [
+        "MOGUAI, Cheat Codes",
+        "Nicky Romero, NERVO",
+        "Armin van Buuren, W&W"
+      ]
+    },
+    {
+      "artist": "MK, Dom Dolla",
+      "title": "Rhyme Dust",
+      "year": 2023,
+      "isrc": "GBARL2300220",
+      "uri": "spotify:track:59QDyqLww2pxyg9ijOPO7f",
+      "uri_apple_music": "applemusic://track/1671893661",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1671893661"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2140510037",
+      "fun_fact": "“Rhyme Dust” is the title track of MK’s release of the same name.",
+      "fun_fact_de": "„Rhyme Dust“ ist der Titelsong der gleichnamigen Veröffentlichung von MK.",
+      "fun_fact_es": "«Rhyme Dust» es la canción que da título al lanzamiento homónimo de MK.",
+      "fun_fact_fr": "« Rhyme Dust » est le morceau-titre de la publication éponyme de MK.",
+      "fun_fact_nl": "‘Rhyme Dust’ is het titelnummer van de gelijknamige release van MK.",
+      "alt_artists": [
+        "Prospa, RAHH",
+        "Sara Landry, Alt8",
+        "Skrillex, The Doors, Zedd"
+      ]
+    },
+    {
+      "artist": "Alan Braxe, Fred Falke",
+      "title": "Intro",
+      "year": 2000,
+      "isrc": "FR08V0000010",
+      "uri": "spotify:track:60hb5H9yL4P4SPz7lrTvUw",
+      "uri_apple_music": "applemusic://track/1616792067",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1616792067"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1702170497",
+      "fun_fact": "“Intro” appears on Alan Braxe’s release “Running”.",
+      "fun_fact_de": "„Intro“ erschien auf der Veröffentlichung „Running“ von Alan Braxe.",
+      "fun_fact_es": "«Intro» aparece en el lanzamiento «Running» de Alan Braxe.",
+      "fun_fact_fr": "« Intro » figure sur la publication « Running » de Alan Braxe.",
+      "fun_fact_nl": "‘Intro’ staat op de release ‘Running’ van Alan Braxe.",
+      "alt_artists": [
+        "Michael Calfan",
+        "Alesso, Zara Larsson",
+        "Madeon"
+      ]
+    },
+    {
+      "artist": "Axwell, Sebastian Ingrosso",
+      "title": "Together - Radio Edit",
+      "year": 2005,
+      "isrc": "GBKCF0500001",
+      "uri": "spotify:track:4PQCrz4sk00dIEmkwmmJCr",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/73460554",
+      "fun_fact": "“Together - Radio Edit” appears on Axwell’s release “Together”.",
+      "fun_fact_de": "„Together - Radio Edit“ erschien auf der Veröffentlichung „Together“ von Axwell.",
+      "fun_fact_es": "«Together - Radio Edit» aparece en el lanzamiento «Together» de Axwell.",
+      "fun_fact_fr": "« Together - Radio Edit » figure sur la publication « Together » de Axwell.",
+      "fun_fact_nl": "‘Together - Radio Edit’ staat op de release ‘Together’ van Axwell.",
+      "alt_artists": [
+        "Martin Garrix, Khalid, DubVision",
+        "Martin Solveig, Roy Woods",
+        "Armand Van Helden"
+      ]
+    },
+    {
+      "artist": "Hardwell",
+      "title": "INTO THE UNKNOWN",
+      "year": 2022,
+      "isrc": "NLQ8D2200576",
+      "uri": "spotify:track:3Y6CWrNdkuaJ5iW2Y829fU",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1754979757",
+      "fun_fact": "“INTO THE UNKNOWN” is the title track of Hardwell’s release of the same name.",
+      "fun_fact_de": "„INTO THE UNKNOWN“ ist der Titelsong der gleichnamigen Veröffentlichung von Hardwell.",
+      "fun_fact_es": "«INTO THE UNKNOWN» es la canción que da título al lanzamiento homónimo de Hardwell.",
+      "fun_fact_fr": "« INTO THE UNKNOWN » est le morceau-titre de la publication éponyme de Hardwell.",
+      "fun_fact_nl": "‘INTO THE UNKNOWN’ is het titelnummer van de gelijknamige release van Hardwell.",
+      "alt_artists": [
+        "Sub Focus, Culture Shock, Fragma",
+        "Martin Solveig, SAM WHITE",
+        "The Temper Trap, John Summit, Silver Panda"
+      ]
+    },
+    {
+      "artist": "Peggy Gou",
+      "title": "It Makes You Forget (Itgehane)",
+      "year": 2018,
+      "isrc": "GBCFB1700575",
+      "uri": "spotify:track:6GRos6Klc30XItsQtGUcak",
+      "uri_apple_music": "applemusic://track/1335982355",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1335982355"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/453070472",
+      "fun_fact": "“It Makes You Forget (Itgehane)” is the title track of Peggy Gou’s release of the same name.",
+      "fun_fact_de": "„It Makes You Forget (Itgehane)“ ist der Titelsong der gleichnamigen Veröffentlichung von Peggy Gou.",
+      "fun_fact_es": "«It Makes You Forget (Itgehane)» es la canción que da título al lanzamiento homónimo de Peggy Gou.",
+      "fun_fact_fr": "« It Makes You Forget (Itgehane) » est le morceau-titre de la publication éponyme de Peggy Gou.",
+      "fun_fact_nl": "‘It Makes You Forget (Itgehane)’ is het titelnummer van de gelijknamige release van Peggy Gou.",
+      "alt_artists": [
+        "deadmau5, Wolfgang Gartner",
+        "Feist, Boys Noize",
+        "MoBlack, Salif Keita, Benja (NL), Franc Fala, Cesária Evora"
+      ]
+    },
+    {
+      "artist": "Paul Kalkbrenner",
+      "title": "Cloud Rider - Radio Edit",
+      "year": 2015,
+      "isrc": "GBARL1500403",
+      "uri": "spotify:track:3le4Vpe3KCkgZxFyPHEXOl",
+      "uri_apple_music": "applemusic://track/1008376256",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1008376256"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/102517920",
+      "fun_fact": "“Cloud Rider - Radio Edit” is the title track of Paul Kalkbrenner’s release of the same name.",
+      "fun_fact_de": "„Cloud Rider - Radio Edit“ ist der Titelsong der gleichnamigen Veröffentlichung von Paul Kalkbrenner.",
+      "fun_fact_es": "«Cloud Rider - Radio Edit» es la canción que da título al lanzamiento homónimo de Paul Kalkbrenner.",
+      "fun_fact_fr": "« Cloud Rider - Radio Edit » est le morceau-titre de la publication éponyme de Paul Kalkbrenner.",
+      "fun_fact_nl": "‘Cloud Rider - Radio Edit’ is het titelnummer van de gelijknamige release van Paul Kalkbrenner.",
+      "alt_artists": [
+        "Eric Prydz",
+        "Martin Garrix, Clinton Kane",
+        "Alesso"
+      ]
+    },
+    {
+      "artist": "Armin van Buuren, W&W",
+      "title": "D# Fat - Original Mix",
+      "year": 2013,
+      "isrc": "NLF711302154",
+      "uri": "spotify:track:1RDSc1VEq75TxyFOMgtWTu",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/73161904",
+      "fun_fact": "“D# Fat - Original Mix” appears on Armin van Buuren’s release “Armin van Buuren's 2013 Top 20”.",
+      "fun_fact_de": "„D# Fat - Original Mix“ erschien auf der Veröffentlichung „Armin van Buuren's 2013 Top 20“ von Armin van Buuren.",
+      "fun_fact_es": "«D# Fat - Original Mix» aparece en el lanzamiento «Armin van Buuren's 2013 Top 20» de Armin van Buuren.",
+      "fun_fact_fr": "« D# Fat - Original Mix » figure sur la publication « Armin van Buuren's 2013 Top 20 » de Armin van Buuren.",
+      "fun_fact_nl": "‘D# Fat - Original Mix’ staat op de release ‘Armin van Buuren's 2013 Top 20’ van Armin van Buuren.",
+      "alt_artists": [
+        "Krewella, Hardwell",
+        "Moby",
+        "ANOTR, Abel Balder"
+      ]
+    },
+    {
+      "artist": "AVAION, Sofiya Nzau",
+      "title": "WACUKA",
+      "year": 2025,
+      "isrc": "DEE862402296",
+      "uri": "spotify:track:75n9WHWZAzhB59xSjIHly4",
+      "uri_apple_music": "applemusic://track/1783796586",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1783796586"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3130053941",
+      "fun_fact": "“WACUKA” is the title track of AVAION’s release of the same name.",
+      "fun_fact_de": "„WACUKA“ ist der Titelsong der gleichnamigen Veröffentlichung von AVAION.",
+      "fun_fact_es": "«WACUKA» es la canción que da título al lanzamiento homónimo de AVAION.",
+      "fun_fact_fr": "« WACUKA » est le morceau-titre de la publication éponyme de AVAION.",
+      "fun_fact_nl": "‘WACUKA’ is het titelnummer van de gelijknamige release van AVAION.",
+      "alt_artists": [
+        "Ahmed Spins, Stevo Atambire",
+        "KI/KI, Marlon Hoffstadt",
+        "Tube & Berger"
+      ]
+    },
+    {
+      "artist": "Tiësto, Don Diablo, Thomas Troelsen",
+      "title": "Chemicals (feat. Thomas Troelsen)",
+      "year": 2015,
+      "isrc": "CYA111500096",
+      "uri": "spotify:track:5hZz0GjweCU7v0u5VU6KlT",
+      "uri_apple_music": "applemusic://track/1522307425",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1522307425"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/459402542",
+      "fun_fact": "“Chemicals (feat. Thomas Troelsen)” is the title track of Tiësto’s release of the same name.",
+      "fun_fact_de": "„Chemicals (feat. Thomas Troelsen)“ ist der Titelsong der gleichnamigen Veröffentlichung von Tiësto.",
+      "fun_fact_es": "«Chemicals (feat. Thomas Troelsen)» es la canción que da título al lanzamiento homónimo de Tiësto.",
+      "fun_fact_fr": "« Chemicals (feat. Thomas Troelsen) » est le morceau-titre de la publication éponyme de Tiësto.",
+      "fun_fact_nl": "‘Chemicals (feat. Thomas Troelsen)’ is het titelnummer van de gelijknamige release van Tiësto.",
+      "alt_artists": [
+        "Wankelmut, Emma Louise, MK",
+        "Galantis",
+        "Push, Charlotte de Witte"
+      ]
+    },
+    {
+      "artist": "Junior Jack",
+      "title": "Stupidisco - Radio Edit",
+      "year": 2004,
+      "isrc": "BEP010400048",
+      "uri": "spotify:track:71Sw32dLcwyiRvp3dCA8ZH",
+      "uri_apple_music": "applemusic://track/27516016",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/27516016"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3752089",
+      "fun_fact": "“Stupidisco - Radio Edit” appears on Junior Jack’s release “Stupidisco”.",
+      "fun_fact_de": "„Stupidisco - Radio Edit“ erschien auf der Veröffentlichung „Stupidisco“ von Junior Jack.",
+      "fun_fact_es": "«Stupidisco - Radio Edit» aparece en el lanzamiento «Stupidisco» de Junior Jack.",
+      "fun_fact_fr": "« Stupidisco - Radio Edit » figure sur la publication « Stupidisco » de Junior Jack.",
+      "fun_fact_nl": "‘Stupidisco - Radio Edit’ staat op de release ‘Stupidisco’ van Junior Jack.",
+      "alt_artists": [
+        "Henri PFR, Raphaella",
+        "Dustin Zahn, Len Faki",
+        "Loofy, Anyma, Layton Giordani"
+      ]
+    },
+    {
+      "artist": "Paul van Dyk, Hemstock, Jennings",
+      "title": "Nothing but You",
+      "year": 2003,
+      "isrc": "DEW760300013",
+      "uri": "spotify:track:5qwtQRNEhvzSEX4hrdDmRT",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/107189498",
+      "fun_fact": "“Nothing but You” appears on Paul van Dyk’s release “Reflections”.",
+      "fun_fact_de": "„Nothing but You“ erschien auf der Veröffentlichung „Reflections“ von Paul van Dyk.",
+      "fun_fact_es": "«Nothing but You» aparece en el lanzamiento «Reflections» de Paul van Dyk.",
+      "fun_fact_fr": "« Nothing but You » figure sur la publication « Reflections » de Paul van Dyk.",
+      "fun_fact_nl": "‘Nothing but You’ staat op de release ‘Reflections’ van Paul van Dyk.",
+      "alt_artists": [
+        "Disciples",
+        "David Guetta, MORTEN, Aloe Blacc",
+        "Marshmello, Khalid, Tiësto"
+      ]
+    },
+    {
+      "artist": "MK, Chrystal",
+      "title": "Dior (feat. Chrystal)",
+      "year": 2025,
+      "isrc": "GBARL2500597",
+      "uri": "spotify:track:6PTgSuFz9JqQ1o0jTYOuvX",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3346153791",
+      "fun_fact": "“Dior (feat. Chrystal)” is the title track of MK’s release of the same name.",
+      "fun_fact_de": "„Dior (feat. Chrystal)“ ist der Titelsong der gleichnamigen Veröffentlichung von MK.",
+      "fun_fact_es": "«Dior (feat. Chrystal)» es la canción que da título al lanzamiento homónimo de MK.",
+      "fun_fact_fr": "« Dior (feat. Chrystal) » est le morceau-titre de la publication éponyme de MK.",
+      "fun_fact_nl": "‘Dior (feat. Chrystal)’ is het titelnummer van de gelijknamige release van MK.",
+      "alt_artists": [
+        "Tommy Trash",
+        "Tim Mason, Steve Angello",
+        "Becky Hill, Galantis"
+      ]
+    },
+    {
+      "artist": "Deorro",
+      "title": "Offspring",
+      "year": 2018,
+      "isrc": "USDM31899701",
+      "uri": "spotify:track:5NPZpywHJWVnesi5XdhAJC",
+      "uri_apple_music": "applemusic://track/1439646399",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1439646399"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2458905765",
+      "fun_fact": "“Offspring” is the title track of Deorro’s release of the same name.",
+      "fun_fact_de": "„Offspring“ ist der Titelsong der gleichnamigen Veröffentlichung von Deorro.",
+      "fun_fact_es": "«Offspring» es la canción que da título al lanzamiento homónimo de Deorro.",
+      "fun_fact_fr": "« Offspring » est le morceau-titre de la publication éponyme de Deorro.",
+      "fun_fact_nl": "‘Offspring’ is het titelnummer van de gelijknamige release van Deorro.",
+      "alt_artists": [
+        "AFROJACK, Steve Aoki, Miss Palmer",
+        "Ten Walls",
+        "Camisra"
+      ]
+    },
+    {
+      "artist": "Fred again.., Obongjayar",
+      "title": "adore u",
+      "year": 2023,
+      "isrc": "GBAHS2300908",
+      "uri": "spotify:track:3YgtkOxZsTuaZdL8McA1FQ",
+      "uri_apple_music": "applemusic://track/1700707219",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1700707219"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2387490225",
+      "fun_fact": "“adore u” is the title track of Fred again..’s release of the same name.",
+      "fun_fact_de": "„adore u“ ist der Titelsong der gleichnamigen Veröffentlichung von Fred again...",
+      "fun_fact_es": "«adore u» es la canción que da título al lanzamiento homónimo de Fred again...",
+      "fun_fact_fr": "« adore u » est le morceau-titre de la publication éponyme de Fred again...",
+      "fun_fact_nl": "‘adore u’ is het titelnummer van de gelijknamige release van Fred again...",
+      "alt_artists": [
+        "Martin Garrix, Tiësto",
+        "NERVO",
+        "Celeda, Danny Tenaglia"
+      ]
+    },
+    {
+      "artist": "David Guetta, MORTEN",
+      "title": "Kill Me Slow",
+      "year": 2020,
+      "isrc": "UKWLG2000011",
+      "uri": "spotify:track:2NZJKUPIGfJqLAzONNr4gv",
+      "uri_apple_music": "applemusic://track/1522568457",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1522568457"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1021141692",
+      "fun_fact": "“Kill Me Slow” appears on David Guetta’s release “New Rave”.",
+      "fun_fact_de": "„Kill Me Slow“ erschien auf der Veröffentlichung „New Rave“ von David Guetta.",
+      "fun_fact_es": "«Kill Me Slow» aparece en el lanzamiento «New Rave» de David Guetta.",
+      "fun_fact_fr": "« Kill Me Slow » figure sur la publication « New Rave » de David Guetta.",
+      "fun_fact_nl": "‘Kill Me Slow’ staat op de release ‘New Rave’ van David Guetta.",
+      "alt_artists": [
+        "Paul van Dyk, Hemstock, Jennings",
+        "Supermode, MEDUZA",
+        "Rank 1"
+      ]
+    },
+    {
+      "artist": "Zonderling, Don Diablo",
+      "title": "No Good",
+      "year": 2018,
+      "isrc": "NLZ541800175",
+      "uri": "spotify:track:5o0eUxrcE7B7htlnRRZoWF",
+      "uri_apple_music": "applemusic://track/1529897576",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1529897576"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/617706652",
+      "fun_fact": "“No Good” is the title track of Zonderling’s release of the same name.",
+      "fun_fact_de": "„No Good“ ist der Titelsong der gleichnamigen Veröffentlichung von Zonderling.",
+      "fun_fact_es": "«No Good» es la canción que da título al lanzamiento homónimo de Zonderling.",
+      "fun_fact_fr": "« No Good » est le morceau-titre de la publication éponyme de Zonderling.",
+      "fun_fact_nl": "‘No Good’ is het titelnummer van de gelijknamige release van Zonderling.",
+      "alt_artists": [
+        "Steve Aoki, Chris Lake, Tujamo",
+        "Cassian, YOTTO, Da Hool",
+        "Bedrock, John Digweed, Nick Muir"
+      ]
+    },
+    {
+      "artist": "YORK, Kryder",
+      "title": "On The Beach - Kryder Remix",
+      "year": 2020,
+      "isrc": "NLF712012932",
+      "uri": "spotify:track:57Y9YzDxXB2sVlhvqK94sK",
+      "uri_apple_music": "applemusic://track/1545486756",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1545486756"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1157163952",
+      "fun_fact": "“On The Beach - Kryder Remix” is the title track of YORK’s release of the same name.",
+      "fun_fact_de": "„On The Beach - Kryder Remix“ ist der Titelsong der gleichnamigen Veröffentlichung von YORK.",
+      "fun_fact_es": "«On The Beach - Kryder Remix» es la canción que da título al lanzamiento homónimo de YORK.",
+      "fun_fact_fr": "« On The Beach - Kryder Remix » est le morceau-titre de la publication éponyme de YORK.",
+      "fun_fact_nl": "‘On The Beach - Kryder Remix’ is het titelnummer van de gelijknamige release van YORK.",
+      "alt_artists": [
+        "Marlon Hoffstadt, DJ Daddy Trance",
+        "Yeah Yeah Yeahs, A-Trak",
+        "Timmy Trumpet, Savage"
+      ]
+    },
+    {
+      "artist": "Kölsch, Gregor Schwellenbach",
+      "title": "Cassiopeia",
+      "year": 2014,
+      "isrc": "DEU671400168",
+      "uri": "spotify:track:15Kj9518XjY106556JirJN",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/114019834",
+      "fun_fact": "“Cassiopeia” appears on Kölsch’s release “Chalet Beat No.3 - The Sound of Kitz Alps @ Maierl (Compiled by DJ Hoody)”.",
+      "fun_fact_de": "„Cassiopeia“ erschien auf der Veröffentlichung „Chalet Beat No.3 - The Sound of Kitz Alps @ Maierl (Compiled by DJ Hoody)“ von Kölsch.",
+      "fun_fact_es": "«Cassiopeia» aparece en el lanzamiento «Chalet Beat No.3 - The Sound of Kitz Alps @ Maierl (Compiled by DJ Hoody)» de Kölsch.",
+      "fun_fact_fr": "« Cassiopeia » figure sur la publication « Chalet Beat No.3 - The Sound of Kitz Alps @ Maierl (Compiled by DJ Hoody) » de Kölsch.",
+      "fun_fact_nl": "‘Cassiopeia’ staat op de release ‘Chalet Beat No.3 - The Sound of Kitz Alps @ Maierl (Compiled by DJ Hoody)’ van Kölsch.",
+      "alt_artists": [
+        "AFROJACK, Martin Garrix, David Guetta, Amél",
+        "AFROJACK, WRABEL",
+        "Moby, Steve Angello"
+      ]
+    },
+    {
+      "artist": "Dimitri Vegas & Like Mike",
+      "title": "Tomorrowland Anthem 2012",
+      "year": 2012,
+      "isrc": "CH3131240004",
+      "uri": "spotify:track:3eo7hnB4mLUfJZRPgo774S",
+      "uri_apple_music": "applemusic://track/1491498703",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1491498703"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1856132307",
+      "fun_fact": "“Tomorrowland Anthem 2012” is the title track of Dimitri Vegas & Like Mike’s release of the same name.",
+      "fun_fact_de": "„Tomorrowland Anthem 2012“ ist der Titelsong der gleichnamigen Veröffentlichung von Dimitri Vegas & Like Mike.",
+      "fun_fact_es": "«Tomorrowland Anthem 2012» es la canción que da título al lanzamiento homónimo de Dimitri Vegas & Like Mike.",
+      "fun_fact_fr": "« Tomorrowland Anthem 2012 » est le morceau-titre de la publication éponyme de Dimitri Vegas & Like Mike.",
+      "fun_fact_nl": "‘Tomorrowland Anthem 2012’ is het titelnummer van de gelijknamige release van Dimitri Vegas & Like Mike.",
+      "alt_artists": [
+        "CamelPhat, Elderbrook",
+        "Dom Dolla",
+        "Kaskade, deadmau5"
+      ]
+    },
+    {
+      "artist": "Janet Jackson",
+      "title": "Go Deep",
+      "year": 1997,
+      "isrc": "USVI29700001",
+      "uri": "spotify:track:1x3S3LYn5wqKHPzfUiqsj1",
+      "uri_apple_music": "applemusic://track/1646563203",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1646563203"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1939641377",
+      "fun_fact": "“Go Deep” appears on Janet Jackson’s release “The Velvet Rope (Deluxe Edition)”.",
+      "fun_fact_de": "„Go Deep“ erschien auf der Veröffentlichung „The Velvet Rope (Deluxe Edition)“ von Janet Jackson.",
+      "fun_fact_es": "«Go Deep» aparece en el lanzamiento «The Velvet Rope (Deluxe Edition)» de Janet Jackson.",
+      "fun_fact_fr": "« Go Deep » figure sur la publication « The Velvet Rope (Deluxe Edition) » de Janet Jackson.",
+      "fun_fact_nl": "‘Go Deep’ staat op de release ‘The Velvet Rope (Deluxe Edition)’ van Janet Jackson.",
+      "alt_artists": [
+        "David Guetta, Kid Cudi",
+        "Gregor Salto, Florian T",
+        "Bingo Players"
+      ]
+    },
+    {
+      "artist": "Swedish House Mafia, The Weeknd",
+      "title": "Moth To A Flame (with The Weeknd)",
+      "year": 2022,
+      "isrc": "USUG12106541",
+      "uri": "spotify:track:7kfOEMJBJwdCYqyJeEnNhr",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1603196842",
+      "fun_fact": "“Moth To A Flame (with The Weeknd)” appears on Swedish House Mafia’s release “Moth To A Flame (Extended Mix)”.",
+      "fun_fact_de": "„Moth To A Flame (with The Weeknd)“ erschien auf der Veröffentlichung „Moth To A Flame (Extended Mix)“ von Swedish House Mafia.",
+      "fun_fact_es": "«Moth To A Flame (with The Weeknd)» aparece en el lanzamiento «Moth To A Flame (Extended Mix)» de Swedish House Mafia.",
+      "fun_fact_fr": "« Moth To A Flame (with The Weeknd) » figure sur la publication « Moth To A Flame (Extended Mix) » de Swedish House Mafia.",
+      "fun_fact_nl": "‘Moth To A Flame (with The Weeknd)’ staat op de release ‘Moth To A Flame (Extended Mix)’ van Swedish House Mafia.",
+      "alt_artists": [
+        "Mark Knight",
+        "Armin van Buuren, Agents Of Time, ORKID",
+        "Alesso, Sentinel"
+      ]
+    },
+    {
+      "artist": "FISHER",
+      "title": "Stop It",
+      "year": 2017,
+      "isrc": "GBLV61708214",
+      "uri": "spotify:track:627JZ3dVd88Xc5IoHOeNT5",
+      "uri_apple_music": "applemusic://track/1714356981",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1714356981"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2423179905",
+      "fun_fact": "“Stop It” appears on FISHER’s release “Oi Oi”.",
+      "fun_fact_de": "„Stop It“ erschien auf der Veröffentlichung „Oi Oi“ von FISHER.",
+      "fun_fact_es": "«Stop It» aparece en el lanzamiento «Oi Oi» de FISHER.",
+      "fun_fact_fr": "« Stop It » figure sur la publication « Oi Oi » de FISHER.",
+      "fun_fact_nl": "‘Stop It’ staat op de release ‘Oi Oi’ van FISHER.",
+      "alt_artists": [
+        "Fatboy Slim, Riva Starr, Beardyman, Calvin Harris",
+        "Rebūke",
+        "YORK"
+      ]
+    },
+    {
+      "artist": "Armin van Buuren, Sam Gray",
+      "title": "Human Touch - Club Mix",
+      "year": 2022,
+      "isrc": "NLF712200216",
+      "uri": "spotify:track:53lsFKdepwIE4bxnkG6GJM",
+      "uri_apple_music": "applemusic://track/1605836514",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1605836514"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1638044832",
+      "fun_fact": "“Human Touch - Club Mix” appears on Armin van Buuren’s release “A State Of Trance Top 20 - 2022, Vol. 1 (Selected by Armin van Buuren)”.",
+      "fun_fact_de": "„Human Touch - Club Mix“ erschien auf der Veröffentlichung „A State Of Trance Top 20 - 2022, Vol. 1 (Selected by Armin van Buuren)“ von Armin van Buuren.",
+      "fun_fact_es": "«Human Touch - Club Mix» aparece en el lanzamiento «A State Of Trance Top 20 - 2022, Vol. 1 (Selected by Armin van Buuren)» de Armin van Buuren.",
+      "fun_fact_fr": "« Human Touch - Club Mix » figure sur la publication « A State Of Trance Top 20 - 2022, Vol. 1 (Selected by Armin van Buuren) » de Armin van Buuren.",
+      "fun_fact_nl": "‘Human Touch - Club Mix’ staat op de release ‘A State Of Trance Top 20 - 2022, Vol. 1 (Selected by Armin van Buuren)’ van Armin van Buuren.",
+      "alt_artists": [
+        "W&W, Lucas & Steve",
+        "Showtek",
+        "Mr. Probz, Chris Brown, T.I."
+      ]
+    },
+    {
+      "artist": "Shakedown, Anyma, Layton Giordani",
+      "title": "At Night - Anyma x Layton Giordani Remix",
+      "year": 2025,
+      "isrc": "GBCPZ2524597",
+      "uri": "spotify:track:01A16AjdJ0dKGixfZa0Ugd",
+      "uri_apple_music": "applemusic://track/1821679624",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1821679624"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3422311161",
+      "fun_fact": "“At Night - Anyma x Layton Giordani Remix” is the title track of Shakedown’s release of the same name.",
+      "fun_fact_de": "„At Night - Anyma x Layton Giordani Remix“ ist der Titelsong der gleichnamigen Veröffentlichung von Shakedown.",
+      "fun_fact_es": "«At Night - Anyma x Layton Giordani Remix» es la canción que da título al lanzamiento homónimo de Shakedown.",
+      "fun_fact_fr": "« At Night - Anyma x Layton Giordani Remix » est le morceau-titre de la publication éponyme de Shakedown.",
+      "fun_fact_nl": "‘At Night - Anyma x Layton Giordani Remix’ is het titelnummer van de gelijknamige release van Shakedown.",
+      "alt_artists": [
+        "R3HAB, NERVO, Ummet Ozcan",
+        "CYRIL",
+        "Dimitri Vegas & Like Mike, W&W"
+      ]
+    },
+    {
+      "artist": "Joel Corry, James Hype",
+      "title": "Sorry - James Hype Remix",
+      "year": 2019,
+      "isrc": "GBAHS1901066",
+      "uri": "spotify:track:3FZLElqztE94YDeTQ8dt5T",
+      "uri_apple_music": "applemusic://track/1540621480",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1540621480"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/730452542",
+      "fun_fact": "“Sorry - James Hype Remix” is the title track of Joel Corry’s release of the same name.",
+      "fun_fact_de": "„Sorry - James Hype Remix“ ist der Titelsong der gleichnamigen Veröffentlichung von Joel Corry.",
+      "fun_fact_es": "«Sorry - James Hype Remix» es la canción que da título al lanzamiento homónimo de Joel Corry.",
+      "fun_fact_fr": "« Sorry - James Hype Remix » est le morceau-titre de la publication éponyme de Joel Corry.",
+      "fun_fact_nl": "‘Sorry - James Hype Remix’ is het titelnummer van de gelijknamige release van Joel Corry.",
+      "alt_artists": [
+        "Monolink, Ben Böhmer",
+        "Alok, Zeeba, Bruno Martini",
+        "Alesso"
+      ]
+    },
+    {
+      "artist": "Zedd, Lucky Date, Ellie Goulding",
+      "title": "Fall Into The Sky",
+      "year": 2012,
+      "isrc": "USUM71210665",
+      "uri": "spotify:track:6xzCQrXrn0uOOKBQZK1zsF",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/60904703",
+      "fun_fact": "“Fall Into The Sky” appears on Zedd’s release “Clarity”.",
+      "fun_fact_de": "„Fall Into The Sky“ erschien auf der Veröffentlichung „Clarity“ von Zedd.",
+      "fun_fact_es": "«Fall Into The Sky» aparece en el lanzamiento «Clarity» de Zedd.",
+      "fun_fact_fr": "« Fall Into The Sky » figure sur la publication « Clarity » de Zedd.",
+      "fun_fact_nl": "‘Fall Into The Sky’ staat op de release ‘Clarity’ van Zedd.",
+      "alt_artists": [
+        "Josh Baker, Omar+",
+        "Martin Solveig, Tkay Maidza",
+        "Art Of Trance, Ferry Corsten"
+      ]
+    },
+    {
+      "artist": "W&W, Lucas & Steve",
+      "title": "Do It For You",
+      "year": 2020,
+      "isrc": "NLZ541902013",
+      "uri": "spotify:track:2uQ0QffmWbSrSXdYmPKcNO",
+      "uri_apple_music": "applemusic://track/1492468715",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1492468715"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/899944182",
+      "fun_fact": "“Do It For You” is the title track of W&W’s release of the same name.",
+      "fun_fact_de": "„Do It For You“ ist der Titelsong der gleichnamigen Veröffentlichung von W&W.",
+      "fun_fact_es": "«Do It For You» es la canción que da título al lanzamiento homónimo de W&W.",
+      "fun_fact_fr": "« Do It For You » est le morceau-titre de la publication éponyme de W&W.",
+      "fun_fact_nl": "‘Do It For You’ is het titelnummer van de gelijknamige release van W&W.",
+      "alt_artists": [
+        "Freejak",
+        "Martin Garrix, Third Party, Oaks, Declan J Donovan",
+        "Ferry Corsten"
+      ]
+    },
+    {
+      "artist": "Tomaz, Filterheadz",
+      "title": "Sunshine - Original Mix",
+      "year": 2012,
+      "isrc": "SIB151200025",
+      "uri": "spotify:track:3SFDUBqnakhMTLs3U8OA4z",
+      "uri_apple_music": "applemusic://track/1611084995",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1611084995"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2489733441",
+      "fun_fact": "“Sunshine - Original Mix” appears on Tomaz’s release “Sunshine (Remixes 2012)”.",
+      "fun_fact_de": "„Sunshine - Original Mix“ erschien auf der Veröffentlichung „Sunshine (Remixes 2012)“ von Tomaz.",
+      "fun_fact_es": "«Sunshine - Original Mix» aparece en el lanzamiento «Sunshine (Remixes 2012)» de Tomaz.",
+      "fun_fact_fr": "« Sunshine - Original Mix » figure sur la publication « Sunshine (Remixes 2012) » de Tomaz.",
+      "fun_fact_nl": "‘Sunshine - Original Mix’ staat op de release ‘Sunshine (Remixes 2012)’ van Tomaz.",
+      "alt_artists": [
+        "Axwell /\\ Ingrosso, Axwell, Sebastian Ingrosso",
+        "Charlotte de Witte",
+        "Bakermat"
+      ]
+    },
+    {
+      "artist": "Jauz, Netsky",
+      "title": "Higher",
+      "year": 2016,
+      "isrc": "GBARL1600332",
+      "uri": "spotify:track:7KDd9F7q1SyI10qqGPugV1",
+      "uri_apple_music": "applemusic://track/1712706732",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1712706732"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/121592908",
+      "fun_fact": "“Higher” is the title track of Jauz’s release of the same name.",
+      "fun_fact_de": "„Higher“ ist der Titelsong der gleichnamigen Veröffentlichung von Jauz.",
+      "fun_fact_es": "«Higher» es la canción que da título al lanzamiento homónimo de Jauz.",
+      "fun_fact_fr": "« Higher » est le morceau-titre de la publication éponyme de Jauz.",
+      "fun_fact_nl": "‘Higher’ is het titelnummer van de gelijknamige release van Jauz.",
+      "alt_artists": [
+        "Lost Frequencies, Janieck",
+        "Martin Garrix, Clinton Kane",
+        "Swedish House Mafia, Tinie Tempah"
+      ]
+    },
+    {
+      "artist": "Tristan Garner, Norman Doray",
+      "title": "Last Forever - Original Vocal Mix",
+      "year": 2009,
+      "isrc": "DEBL60823924",
+      "uri": "spotify:track:2Jq1MiIjBwTmMbSWhTqKGj",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3045641",
+      "fun_fact": "“Last Forever - Original Vocal Mix” appears on Tristan Garner’s release “French Dancefloor, Vol. 1”.",
+      "fun_fact_de": "„Last Forever - Original Vocal Mix“ erschien auf der Veröffentlichung „French Dancefloor, Vol. 1“ von Tristan Garner.",
+      "fun_fact_es": "«Last Forever - Original Vocal Mix» aparece en el lanzamiento «French Dancefloor, Vol. 1» de Tristan Garner.",
+      "fun_fact_fr": "« Last Forever - Original Vocal Mix » figure sur la publication « French Dancefloor, Vol. 1 » de Tristan Garner.",
+      "fun_fact_nl": "‘Last Forever - Original Vocal Mix’ staat op de release ‘French Dancefloor, Vol. 1’ van Tristan Garner.",
+      "alt_artists": [
+        "Fatboy Slim, Riva Starr, Beardyman, Calvin Harris",
+        "David Guetta, OneRepublic",
+        "MALUGI, Paul Sirrell"
+      ]
+    },
+    {
+      "artist": "David Guetta, MORTEN",
+      "title": "Nothing",
+      "year": 2020,
+      "isrc": "UKWLG2000006",
+      "uri": "spotify:track:0eQz4XG64TvYkt1aw5nbzM",
+      "uri_apple_music": "applemusic://track/1522568459",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1522568459"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1021141702",
+      "fun_fact": "“Nothing” appears on David Guetta’s release “New Rave”.",
+      "fun_fact_de": "„Nothing“ erschien auf der Veröffentlichung „New Rave“ von David Guetta.",
+      "fun_fact_es": "«Nothing» aparece en el lanzamiento «New Rave» de David Guetta.",
+      "fun_fact_fr": "« Nothing » figure sur la publication « New Rave » de David Guetta.",
+      "fun_fact_nl": "‘Nothing’ staat op de release ‘New Rave’ van David Guetta.",
+      "alt_artists": [
+        "Eli Brown",
+        "Martin Garrix, R3HAB, Skytech",
+        "Eric Prydz, Floyd"
+      ]
+    },
+    {
+      "artist": "Anyma, Argy, MAGNUS",
+      "title": "Higher Power",
+      "year": 2023,
+      "isrc": "USUG12308415",
+      "uri": "spotify:track:475r8pbikqtqehhc1qUIOf",
+      "uri_apple_music": "applemusic://track/1713313597",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1713313597"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2722493482",
+      "fun_fact": "“Higher Power” appears on Anyma’s release “Genesys II”.",
+      "fun_fact_de": "„Higher Power“ erschien auf der Veröffentlichung „Genesys II“ von Anyma.",
+      "fun_fact_es": "«Higher Power» aparece en el lanzamiento «Genesys II» de Anyma.",
+      "fun_fact_fr": "« Higher Power » figure sur la publication « Genesys II » de Anyma.",
+      "fun_fact_nl": "‘Higher Power’ staat op de release ‘Genesys II’ van Anyma.",
+      "alt_artists": [
+        "Binary Finary, Paul van Dyk",
+        "Double 99",
+        "Janet Jackson"
+      ]
+    },
+    {
+      "artist": "Binary Finary, Paul van Dyk",
+      "title": "1998 - Paul van Dyk Remix",
+      "year": 1998,
+      "isrc": "GBHCD1610347",
+      "uri": "spotify:track:72lRA680a5ZWu0l14phseH",
+      "uri_apple_music": "applemusic://track/1433857703",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1433857703"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3495343691",
+      "fun_fact": "“1998 - Paul van Dyk Remix” appears on Binary Finary’s release “Reactivate 13 (Beats, Chance & Liquid Trance)”.",
+      "fun_fact_de": "„1998 - Paul van Dyk Remix“ erschien auf der Veröffentlichung „Reactivate 13 (Beats, Chance & Liquid Trance)“ von Binary Finary.",
+      "fun_fact_es": "«1998 - Paul van Dyk Remix» aparece en el lanzamiento «Reactivate 13 (Beats, Chance & Liquid Trance)» de Binary Finary.",
+      "fun_fact_fr": "« 1998 - Paul van Dyk Remix » figure sur la publication « Reactivate 13 (Beats, Chance & Liquid Trance) » de Binary Finary.",
+      "fun_fact_nl": "‘1998 - Paul van Dyk Remix’ staat op de release ‘Reactivate 13 (Beats, Chance & Liquid Trance)’ van Binary Finary.",
+      "alt_artists": [
+        "London Grammar",
+        "Salif Keita, Martin Solveig",
+        "Sammy Virji, Skepta"
+      ]
+    },
+    {
+      "artist": "David Guetta, Showtek",
+      "title": "Your Love",
+      "year": 2018,
+      "isrc": "GB28K1800065",
+      "uri": "spotify:track:0tgbSxoFjZ20MjfoKwWevV",
+      "uri_apple_music": "applemusic://track/1394018252",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1394018252"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/508544952",
+      "fun_fact": "“Your Love” is the title track of David Guetta’s release of the same name.",
+      "fun_fact_de": "„Your Love“ ist der Titelsong der gleichnamigen Veröffentlichung von David Guetta.",
+      "fun_fact_es": "«Your Love» es la canción que da título al lanzamiento homónimo de David Guetta.",
+      "fun_fact_fr": "« Your Love » est le morceau-titre de la publication éponyme de David Guetta.",
+      "fun_fact_nl": "‘Your Love’ is het titelnummer van de gelijknamige release van David Guetta.",
+      "alt_artists": [
+        "Jax Jones, Martin Solveig, Madison Beer, Europa",
+        "Marc Benjamin, Marcus Santoro, David Pietras",
+        "YORK, Kryder"
+      ]
+    },
+    {
+      "artist": "Jamback",
+      "title": "Positive",
+      "year": 2025,
+      "isrc": "QMFMF2549064",
+      "uri": "spotify:track:0cZN3g7rtfNE6vsmX0k8OF",
+      "uri_apple_music": "applemusic://track/1846394100",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1846394100"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3604108432",
+      "fun_fact": "“Positive” is the title track of Jamback’s release of the same name.",
+      "fun_fact_de": "„Positive“ ist der Titelsong der gleichnamigen Veröffentlichung von Jamback.",
+      "fun_fact_es": "«Positive» es la canción que da título al lanzamiento homónimo de Jamback.",
+      "fun_fact_fr": "« Positive » est le morceau-titre de la publication éponyme de Jamback.",
+      "fun_fact_nl": "‘Positive’ is het titelnummer van de gelijknamige release van Jamback.",
+      "alt_artists": [
+        "BUNT., Nate Traveller",
+        "Steve Angello, The Presets",
+        "Tristan Garner, Norman Doray"
+      ]
+    },
+    {
+      "artist": "Sonique, The Conductor & The Cowboy",
+      "title": "It Feels So Good - The Conductor & The Cowboy Amnesia Mix",
+      "year": 2025,
+      "isrc": "NLF712506043",
+      "uri": "spotify:track:10CqUpXoP0EK9ElNWtG4yD",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3549735831",
+      "fun_fact": "“It Feels So Good - The Conductor & The Cowboy Amnesia Mix” appears on Sonique’s release “It Feels So Good (The Conductor & The Cowboy Mixes)”.",
+      "fun_fact_de": "„It Feels So Good - The Conductor & The Cowboy Amnesia Mix“ erschien auf der Veröffentlichung „It Feels So Good (The Conductor & The Cowboy Mixes)“ von Sonique.",
+      "fun_fact_es": "«It Feels So Good - The Conductor & The Cowboy Amnesia Mix» aparece en el lanzamiento «It Feels So Good (The Conductor & The Cowboy Mixes)» de Sonique.",
+      "fun_fact_fr": "« It Feels So Good - The Conductor & The Cowboy Amnesia Mix » figure sur la publication « It Feels So Good (The Conductor & The Cowboy Mixes) » de Sonique.",
+      "fun_fact_nl": "‘It Feels So Good - The Conductor & The Cowboy Amnesia Mix’ staat op de release ‘It Feels So Good (The Conductor & The Cowboy Mixes)’ van Sonique.",
+      "alt_artists": [
+        "YORK, Kryder",
+        "Martin Solveig, Roy Woods",
+        "Tiësto, R3HAB"
+      ]
+    },
+    {
+      "artist": "Cassian",
+      "title": "Dun Dun",
+      "year": 2024,
+      "isrc": "USA2P2446612",
+      "uri": "spotify:track:48XuAKxSzr3nJBeU1yf0KM",
+      "uri_apple_music": "applemusic://track/1757932090",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1757932090"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2894989171",
+      "fun_fact": "“Dun Dun” is the title track of Cassian’s release of the same name.",
+      "fun_fact_de": "„Dun Dun“ ist der Titelsong der gleichnamigen Veröffentlichung von Cassian.",
+      "fun_fact_es": "«Dun Dun» es la canción que da título al lanzamiento homónimo de Cassian.",
+      "fun_fact_fr": "« Dun Dun » est le morceau-titre de la publication éponyme de Cassian.",
+      "fun_fact_nl": "‘Dun Dun’ is het titelnummer van de gelijknamige release van Cassian.",
+      "alt_artists": [
+        "The Bloody Beetroots, Steve Aoki",
+        "Armand Van Helden, Duane Harden",
+        "Parachute Youth"
+      ]
+    },
+    {
+      "artist": "Tiësto, Dzeko, Lena Leon",
+      "title": "Halfway There (feat. Lena Leon)",
+      "year": 2019,
+      "isrc": "CYA111900036",
+      "uri": "spotify:track:0pMyrECfSI1yq2NXxZyLmA",
+      "uri_apple_music": "applemusic://track/1495693993",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1495693993"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/857196092",
+      "fun_fact": "“Halfway There (feat. Lena Leon)” appears on Tiësto’s release “Together”.",
+      "fun_fact_de": "„Halfway There (feat. Lena Leon)“ erschien auf der Veröffentlichung „Together“ von Tiësto.",
+      "fun_fact_es": "«Halfway There (feat. Lena Leon)» aparece en el lanzamiento «Together» de Tiësto.",
+      "fun_fact_fr": "« Halfway There (feat. Lena Leon) » figure sur la publication « Together » de Tiësto.",
+      "fun_fact_nl": "‘Halfway There (feat. Lena Leon)’ staat op de release ‘Together’ van Tiësto.",
+      "alt_artists": [
+        "Andain",
+        "Rebūke, Storm, Jam El Mar",
+        "Lost Frequencies, Tom Gregory"
+      ]
+    },
+    {
+      "artist": "BUNT., Nate Traveller",
+      "title": "Clouds",
+      "year": 2023,
+      "isrc": "QZTBB2202743",
+      "uri": "spotify:track:2lWc1iJlz2NVcStV5fbtPG",
+      "uri_apple_music": "applemusic://track/1668459118",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1668459118"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2127304097",
+      "fun_fact": "“Clouds” is the title track of BUNT.’s release of the same name.",
+      "fun_fact_de": "„Clouds“ ist der Titelsong der gleichnamigen Veröffentlichung von BUNT..",
+      "fun_fact_es": "«Clouds» es la canción que da título al lanzamiento homónimo de BUNT..",
+      "fun_fact_fr": "« Clouds » est le morceau-titre de la publication éponyme de BUNT..",
+      "fun_fact_nl": "‘Clouds’ is het titelnummer van de gelijknamige release van BUNT..",
+      "alt_artists": [
+        "Binary Finary, Paul van Dyk",
+        "Martin Garrix, R3HAB, Skytech",
+        "Svenson & Gielen"
+      ]
+    },
+    {
+      "artist": "John Summit, Guz, Stevie Appleton",
+      "title": "What A Life",
+      "year": 2022,
+      "isrc": "GBCPZ2221055",
+      "uri": "spotify:track:1KbLVz3ZcdUOt2wBXqU2cG",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3156144391",
+      "fun_fact": "“What A Life” is the title track of John Summit’s release of the same name.",
+      "fun_fact_de": "„What A Life“ ist der Titelsong der gleichnamigen Veröffentlichung von John Summit.",
+      "fun_fact_es": "«What A Life» es la canción que da título al lanzamiento homónimo de John Summit.",
+      "fun_fact_fr": "« What A Life » est le morceau-titre de la publication éponyme de John Summit.",
+      "fun_fact_nl": "‘What A Life’ is het titelnummer van de gelijknamige release van John Summit.",
+      "alt_artists": [
+        "Travis Scott, CHASE B",
+        "Dash Berlin",
+        "Veracocha"
+      ]
+    },
+    {
+      "artist": "James Hype",
+      "title": "Say Yeah",
+      "year": 2022,
+      "isrc": "ZZOPM2119429",
+      "uri": "spotify:track:6459qZsM6AkW3eYFQW9rTs",
+      "uri_apple_music": "applemusic://track/1756123461",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1756123461"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2881740792",
+      "fun_fact": "“Say Yeah” is the title track of James Hype’s release of the same name.",
+      "fun_fact_de": "„Say Yeah“ ist der Titelsong der gleichnamigen Veröffentlichung von James Hype.",
+      "fun_fact_es": "«Say Yeah» es la canción que da título al lanzamiento homónimo de James Hype.",
+      "fun_fact_fr": "« Say Yeah » est le morceau-titre de la publication éponyme de James Hype.",
+      "fun_fact_nl": "‘Say Yeah’ is het titelnummer van de gelijknamige release van James Hype.",
+      "alt_artists": [
+        "David Guetta, Showtek",
+        "Au/Ra, CamelPhat",
+        "Hardwell"
+      ]
+    },
+    {
+      "artist": "Diplo, HUGEL, Julia Church",
+      "title": "Stay High (feat. Julia Church) - Extended",
+      "year": 2024,
+      "isrc": "USZ4V2300296",
+      "uri": "spotify:track:66K8ybDmccnR9sLlDQuU3g",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3470988611",
+      "fun_fact": "“Stay High (feat. Julia Church) - Extended” appears on Diplo’s release “Stay High (feat. Julia Church) (Remixes)”.",
+      "fun_fact_de": "„Stay High (feat. Julia Church) - Extended“ erschien auf der Veröffentlichung „Stay High (feat. Julia Church) (Remixes)“ von Diplo.",
+      "fun_fact_es": "«Stay High (feat. Julia Church) - Extended» aparece en el lanzamiento «Stay High (feat. Julia Church) (Remixes)» de Diplo.",
+      "fun_fact_fr": "« Stay High (feat. Julia Church) - Extended » figure sur la publication « Stay High (feat. Julia Church) (Remixes) » de Diplo.",
+      "fun_fact_nl": "‘Stay High (feat. Julia Church) - Extended’ staat op de release ‘Stay High (feat. Julia Church) (Remixes)’ van Diplo.",
+      "alt_artists": [
+        "Fred again.., Obongjayar",
+        "Tiësto, Oaks",
+        "Afro Medusa"
+      ]
+    },
+    {
+      "artist": "BLOND:ISH, Stevie Appleton",
+      "title": "Never Walk Alone",
+      "year": 2024,
+      "isrc": "NL8RL2429546",
+      "uri": "spotify:track:1bE98D49uKNetOyLiaB8tG",
+      "uri_apple_music": "applemusic://track/1755071026",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1755071026"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2871918512",
+      "fun_fact": "“Never Walk Alone” is the title track of BLOND:ISH’s release of the same name.",
+      "fun_fact_de": "„Never Walk Alone“ ist der Titelsong der gleichnamigen Veröffentlichung von BLOND:ISH.",
+      "fun_fact_es": "«Never Walk Alone» es la canción que da título al lanzamiento homónimo de BLOND:ISH.",
+      "fun_fact_fr": "« Never Walk Alone » est le morceau-titre de la publication éponyme de BLOND:ISH.",
+      "fun_fact_nl": "‘Never Walk Alone’ is het titelnummer van de gelijknamige release van BLOND:ISH.",
+      "alt_artists": [
+        "MORTEN",
+        "Ninetoes",
+        "Armin van Buuren, Punctual, Alika"
+      ]
+    },
+    {
+      "artist": "Alesso, Zara Larsson",
+      "title": "Words (feat. Zara Larsson)",
+      "year": 2022,
+      "isrc": "USUG12206712",
+      "uri": "spotify:track:1bgKMxPQU7JIZEhNsM1vFs",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1896638567",
+      "fun_fact": "“Words (feat. Zara Larsson)” appears on Alesso’s release “Words (Remixes)”.",
+      "fun_fact_de": "„Words (feat. Zara Larsson)“ erschien auf der Veröffentlichung „Words (Remixes)“ von Alesso.",
+      "fun_fact_es": "«Words (feat. Zara Larsson)» aparece en el lanzamiento «Words (Remixes)» de Alesso.",
+      "fun_fact_fr": "« Words (feat. Zara Larsson) » figure sur la publication « Words (Remixes) » de Alesso.",
+      "fun_fact_nl": "‘Words (feat. Zara Larsson)’ staat op de release ‘Words (Remixes)’ van Alesso.",
+      "alt_artists": [
+        "John Summit, Guz, Stevie Appleton",
+        "Armin van Buuren",
+        "Zonderling, Don Diablo"
+      ]
+    },
+    {
+      "artist": "Vintage Culture, Adam K, MKLA",
+      "title": "Save Me (feat. MKLA)",
+      "year": 2018,
+      "isrc": "NLZ541801677",
+      "uri": "spotify:track:5WxtmHAcrDbghHVGupu18h",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/606882782",
+      "fun_fact": "“Save Me (feat. MKLA)” is the title track of Vintage Culture’s release of the same name.",
+      "fun_fact_de": "„Save Me (feat. MKLA)“ ist der Titelsong der gleichnamigen Veröffentlichung von Vintage Culture.",
+      "fun_fact_es": "«Save Me (feat. MKLA)» es la canción que da título al lanzamiento homónimo de Vintage Culture.",
+      "fun_fact_fr": "« Save Me (feat. MKLA) » est le morceau-titre de la publication éponyme de Vintage Culture.",
+      "fun_fact_nl": "‘Save Me (feat. MKLA)’ is het titelnummer van de gelijknamige release van Vintage Culture.",
+      "alt_artists": [
+        "Eliza Rose, Interplanetary Criminal",
+        "deadmau5, Wolfgang Gartner",
+        "Djuma Soundsystem"
+      ]
+    },
+    {
+      "artist": "Moby",
+      "title": "Go",
+      "year": 1997,
+      "isrc": "GBAJH0602036",
+      "uri": "spotify:track:0e8C9dPERvvARURkNOFrrC",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3806165162",
+      "fun_fact": "“Go” appears on Moby’s release “Go - The Very Best of Moby (Deluxe)”.",
+      "fun_fact_de": "„Go“ erschien auf der Veröffentlichung „Go - The Very Best of Moby (Deluxe)“ von Moby.",
+      "fun_fact_es": "«Go» aparece en el lanzamiento «Go - The Very Best of Moby (Deluxe)» de Moby.",
+      "fun_fact_fr": "« Go » figure sur la publication « Go - The Very Best of Moby (Deluxe) » de Moby.",
+      "fun_fact_nl": "‘Go’ staat op de release ‘Go - The Very Best of Moby (Deluxe)’ van Moby.",
+      "alt_artists": [
+        "Mau P",
+        "Martin Garrix, USHER",
+        "Congorock, Lexxus"
+      ]
+    },
+    {
+      "artist": "La Fuente",
+      "title": "I Want You",
+      "year": 2022,
+      "isrc": "NLQ8D2200237",
+      "uri": "spotify:track:4s8BpmFtxDgeCoPj2XHtVj",
+      "uri_apple_music": "applemusic://track/1637861831",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1637861831"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1851048117",
+      "fun_fact": "“I Want You” is the title track of La Fuente’s release of the same name.",
+      "fun_fact_de": "„I Want You“ ist der Titelsong der gleichnamigen Veröffentlichung von La Fuente.",
+      "fun_fact_es": "«I Want You» es la canción que da título al lanzamiento homónimo de La Fuente.",
+      "fun_fact_fr": "« I Want You » est le morceau-titre de la publication éponyme de La Fuente.",
+      "fun_fact_nl": "‘I Want You’ is het titelnummer van de gelijknamige release van La Fuente.",
+      "alt_artists": [
+        "Martin Solveig, Ina Wroldsen",
+        "Mr. Probz, Chris Brown, T.I.",
+        "Zedd, Matthew Koma"
+      ]
+    },
+    {
+      "artist": "Armin van Buuren",
+      "title": "Communication",
+      "year": 1999,
+      "isrc": "NLF710801523",
+      "uri": "spotify:track:3Xoqg8LNJaGYvnpdsIYmOh",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/88824755",
+      "fun_fact": "“Communication” appears on Armin van Buuren’s release “Armin Anthems (Ultimate Singles Collected)”.",
+      "fun_fact_de": "„Communication“ erschien auf der Veröffentlichung „Armin Anthems (Ultimate Singles Collected)“ von Armin van Buuren.",
+      "fun_fact_es": "«Communication» aparece en el lanzamiento «Armin Anthems (Ultimate Singles Collected)» de Armin van Buuren.",
+      "fun_fact_fr": "« Communication » figure sur la publication « Armin Anthems (Ultimate Singles Collected) » de Armin van Buuren.",
+      "fun_fact_nl": "‘Communication’ staat op de release ‘Armin Anthems (Ultimate Singles Collected)’ van Armin van Buuren.",
+      "alt_artists": [
+        "Tommy Trash",
+        "Calvin Harris, Example",
+        "Don Diablo, Matt Nash"
+      ]
+    },
+    {
+      "artist": "CHRIS STASSY",
+      "title": "Desire",
+      "year": 2024,
+      "isrc": "QM4TW2437510",
+      "uri": "spotify:track:3uahZPFLqwDp0Jje5K60q4",
+      "uri_apple_music": "applemusic://track/1744599886",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1744599886"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2782517712",
+      "fun_fact": "“Desire” is the title track of CHRIS STASSY’s release of the same name.",
+      "fun_fact_de": "„Desire“ ist der Titelsong der gleichnamigen Veröffentlichung von CHRIS STASSY.",
+      "fun_fact_es": "«Desire» es la canción que da título al lanzamiento homónimo de CHRIS STASSY.",
+      "fun_fact_fr": "« Desire » est le morceau-titre de la publication éponyme de CHRIS STASSY.",
+      "fun_fact_nl": "‘Desire’ is het titelnummer van de gelijknamige release van CHRIS STASSY.",
+      "alt_artists": [
+        "Tom Hangs, Shermanology",
+        "Arno Cost, Arias",
+        "Switch"
+      ]
+    },
+    {
+      "artist": "KSHMR, Mike Waters",
+      "title": "My Best Life (feat. Mike Waters)",
+      "year": 2019,
+      "isrc": "NLZ541900920",
+      "uri": "spotify:track:55EiIt05opIWOahPsVMswf",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/708664602",
+      "fun_fact": "“My Best Life (feat. Mike Waters)” is the title track of KSHMR’s release of the same name.",
+      "fun_fact_de": "„My Best Life (feat. Mike Waters)“ ist der Titelsong der gleichnamigen Veröffentlichung von KSHMR.",
+      "fun_fact_es": "«My Best Life (feat. Mike Waters)» es la canción que da título al lanzamiento homónimo de KSHMR.",
+      "fun_fact_fr": "« My Best Life (feat. Mike Waters) » est le morceau-titre de la publication éponyme de KSHMR.",
+      "fun_fact_nl": "‘My Best Life (feat. Mike Waters)’ is het titelnummer van de gelijknamige release van KSHMR.",
+      "alt_artists": [
+        "Calvin Harris, Clementine Douglas",
+        "Disclosure, AlunaGeorge",
+        "Jessie Ware, Disclosure"
+      ]
+    },
+    {
+      "artist": "deadmau5, Kaskade, Kx5, John Summit, HAYLA",
+      "title": "Escape - John Summit Remix",
+      "year": 2013,
+      "isrc": "GBTDG1302507",
+      "uri": "spotify:track:68lTEhMEx4MxDCJypT6bXE",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1951192377",
+      "fun_fact": "“Escape - John Summit Remix” is the title track of deadmau5’s release of the same name.",
+      "fun_fact_de": "„Escape - John Summit Remix“ ist der Titelsong der gleichnamigen Veröffentlichung von deadmau5.",
+      "fun_fact_es": "«Escape - John Summit Remix» es la canción que da título al lanzamiento homónimo de deadmau5.",
+      "fun_fact_fr": "« Escape - John Summit Remix » est le morceau-titre de la publication éponyme de deadmau5.",
+      "fun_fact_nl": "‘Escape - John Summit Remix’ is het titelnummer van de gelijknamige release van deadmau5.",
+      "alt_artists": [
+        "Dirty South, Rudy, Axwell",
+        "Tiësto, Stargate, Aloe Blacc",
+        "James Hype, Miggy Dela Rosa"
+      ]
+    },
+    {
+      "artist": "KETTAMA, Interplanetary Criminal",
+      "title": "Yosemite",
+      "year": 2024,
+      "isrc": "USZXT2456013",
+      "uri": "spotify:track:2bsE8sHNGxofmecroJrxsT",
+      "uri_apple_music": "applemusic://track/1828200670",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1828200670"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3472405361",
+      "fun_fact": "“Yosemite” is the title track of KETTAMA’s release of the same name.",
+      "fun_fact_de": "„Yosemite“ ist der Titelsong der gleichnamigen Veröffentlichung von KETTAMA.",
+      "fun_fact_es": "«Yosemite» es la canción que da título al lanzamiento homónimo de KETTAMA.",
+      "fun_fact_fr": "« Yosemite » est le morceau-titre de la publication éponyme de KETTAMA.",
+      "fun_fact_nl": "‘Yosemite’ is het titelnummer van de gelijknamige release van KETTAMA.",
+      "alt_artists": [
+        "Martin Garrix, Justin Mylo, Dewain Whitmore",
+        "deadmau5, Chris James",
+        "Fred again.."
+      ]
+    },
+    {
+      "artist": "Martin Garrix, Justin Mylo, Dewain Whitmore",
+      "title": "Burn Out (feat. Dewain Whitmore)",
+      "year": 2018,
+      "isrc": "NLM5S1800332",
+      "uri": "spotify:track:7IWTIkiWGWNQyYfOLdMrGD",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/554315042",
+      "fun_fact": "“Burn Out (feat. Dewain Whitmore)” is the title track of Martin Garrix’s release of the same name.",
+      "fun_fact_de": "„Burn Out (feat. Dewain Whitmore)“ ist der Titelsong der gleichnamigen Veröffentlichung von Martin Garrix.",
+      "fun_fact_es": "«Burn Out (feat. Dewain Whitmore)» es la canción que da título al lanzamiento homónimo de Martin Garrix.",
+      "fun_fact_fr": "« Burn Out (feat. Dewain Whitmore) » est le morceau-titre de la publication éponyme de Martin Garrix.",
+      "fun_fact_nl": "‘Burn Out (feat. Dewain Whitmore)’ is het titelnummer van de gelijknamige release van Martin Garrix.",
+      "alt_artists": [
+        "San Holo",
+        "Anyma, Argy, Son of Son",
+        "MEDUZA, Goodboys"
+      ]
+    },
+    {
+      "artist": "David Guetta, OneRepublic",
+      "title": "I Don't Wanna Wait",
+      "year": 2024,
+      "isrc": "UKWLG2400013",
+      "uri": "spotify:track:331l3xABO0HMr1Kkyh2LZq",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2715243342",
+      "fun_fact": "“I Don't Wanna Wait” is the title track of David Guetta’s release of the same name.",
+      "fun_fact_de": "„I Don't Wanna Wait“ ist der Titelsong der gleichnamigen Veröffentlichung von David Guetta.",
+      "fun_fact_es": "«I Don't Wanna Wait» es la canción que da título al lanzamiento homónimo de David Guetta.",
+      "fun_fact_fr": "« I Don't Wanna Wait » est le morceau-titre de la publication éponyme de David Guetta.",
+      "fun_fact_nl": "‘I Don't Wanna Wait’ is het titelnummer van de gelijknamige release van David Guetta.",
+      "alt_artists": [
+        "Nari, Milani",
+        "Skrillex, Damian \"Jr Gong\" Marley",
+        "Krystal Klear"
+      ]
+    },
+    {
+      "artist": "Sia, Sander van Doorn",
+      "title": "The Girl You Lost To Cocaine - Sander van Doorn Remix",
+      "year": 2018,
+      "isrc": "DEW871707759",
+      "uri": "spotify:track:6lVvvT5C3EkSLMfVTfuIy5",
+      "uri_apple_music": "applemusic://track/1711795423",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1711795423"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/454471802",
+      "fun_fact": "“The Girl You Lost To Cocaine - Sander van Doorn Remix” appears on Sia’s release “Big Room Bangers, Vol. 23”.",
+      "fun_fact_de": "„The Girl You Lost To Cocaine - Sander van Doorn Remix“ erschien auf der Veröffentlichung „Big Room Bangers, Vol. 23“ von Sia.",
+      "fun_fact_es": "«The Girl You Lost To Cocaine - Sander van Doorn Remix» aparece en el lanzamiento «Big Room Bangers, Vol. 23» de Sia.",
+      "fun_fact_fr": "« The Girl You Lost To Cocaine - Sander van Doorn Remix » figure sur la publication « Big Room Bangers, Vol. 23 » de Sia.",
+      "fun_fact_nl": "‘The Girl You Lost To Cocaine - Sander van Doorn Remix’ staat op de release ‘Big Room Bangers, Vol. 23’ van Sia.",
+      "alt_artists": [
+        "Congorock, Lexxus",
+        "Dash Berlin",
+        "Armin van Buuren"
+      ]
+    },
+    {
+      "artist": "Tinlicker, Helsloot",
+      "title": "Because You Move Me",
+      "year": 2017,
+      "isrc": "NLF711706976",
+      "uri": "spotify:track:05GvwwTLLID738BbKN1ze0",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/378940811",
+      "fun_fact": "“Because You Move Me” is the title track of Tinlicker’s release of the same name.",
+      "fun_fact_de": "„Because You Move Me“ ist der Titelsong der gleichnamigen Veröffentlichung von Tinlicker.",
+      "fun_fact_es": "«Because You Move Me» es la canción que da título al lanzamiento homónimo de Tinlicker.",
+      "fun_fact_fr": "« Because You Move Me » est le morceau-titre de la publication éponyme de Tinlicker.",
+      "fun_fact_nl": "‘Because You Move Me’ is het titelnummer van de gelijknamige release van Tinlicker.",
+      "alt_artists": [
+        "Rusko, Netsky",
+        "Alok, ILLENIUM",
+        "The Magician, Olly Alexander (Years & Years)"
+      ]
+    },
+    {
+      "artist": "Becky Hill, Chase & Status",
+      "title": "Disconnect",
+      "year": 2023,
+      "isrc": "GBUM72306588",
+      "uri": "spotify:track:602d2gJewoiF1FivuOMMwE",
+      "uri_apple_music": "applemusic://track/1696160175",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1696160175"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2358398035",
+      "fun_fact": "“Disconnect” is the title track of Becky Hill’s release of the same name.",
+      "fun_fact_de": "„Disconnect“ ist der Titelsong der gleichnamigen Veröffentlichung von Becky Hill.",
+      "fun_fact_es": "«Disconnect» es la canción que da título al lanzamiento homónimo de Becky Hill.",
+      "fun_fact_fr": "« Disconnect » est le morceau-titre de la publication éponyme de Becky Hill.",
+      "fun_fact_nl": "‘Disconnect’ is het titelnummer van de gelijknamige release van Becky Hill.",
+      "alt_artists": [
+        "Booka Shade",
+        "Alesso, Katy Perry",
+        "Sunnery James & Ryan Marciano, Kes Kross"
+      ]
+    },
+    {
+      "artist": "Estelle, Lost Frequencies, Kanye West",
+      "title": "American Boy - Lost Frequencies Remix",
+      "year": 2019,
+      "isrc": "SENAA1900201",
+      "uri": "spotify:track:1o8ppmUhxi6d5qZF1NKIub",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/706758732",
+      "fun_fact": "“American Boy - Lost Frequencies Remix” is the title track of Estelle’s release of the same name.",
+      "fun_fact_de": "„American Boy - Lost Frequencies Remix“ ist der Titelsong der gleichnamigen Veröffentlichung von Estelle.",
+      "fun_fact_es": "«American Boy - Lost Frequencies Remix» es la canción que da título al lanzamiento homónimo de Estelle.",
+      "fun_fact_fr": "« American Boy - Lost Frequencies Remix » est le morceau-titre de la publication éponyme de Estelle.",
+      "fun_fact_nl": "‘American Boy - Lost Frequencies Remix’ is het titelnummer van de gelijknamige release van Estelle.",
+      "alt_artists": [
+        "CHRIS STASSY, S.A.M.",
+        "Peggy Gou, Soulwax",
+        "Zedd, Matthew Koma"
+      ]
+    },
+    {
+      "artist": "Paul Kalkbrenner",
+      "title": "Square 1",
+      "year": 2013,
+      "isrc": "DENZ71300062",
+      "uri": "spotify:track:6eIzXu8Wt69bMgRYIcGPZ3",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1761983437",
+      "fun_fact": "“Square 1” appears on Paul Kalkbrenner’s release “Berlin Calling (The Soundtrack by Paul Kalkbrenner)”.",
+      "fun_fact_de": "„Square 1“ erschien auf der Veröffentlichung „Berlin Calling (The Soundtrack by Paul Kalkbrenner)“ von Paul Kalkbrenner.",
+      "fun_fact_es": "«Square 1» aparece en el lanzamiento «Berlin Calling (The Soundtrack by Paul Kalkbrenner)» de Paul Kalkbrenner.",
+      "fun_fact_fr": "« Square 1 » figure sur la publication « Berlin Calling (The Soundtrack by Paul Kalkbrenner) » de Paul Kalkbrenner.",
+      "fun_fact_nl": "‘Square 1’ staat op de release ‘Berlin Calling (The Soundtrack by Paul Kalkbrenner)’ van Paul Kalkbrenner.",
+      "alt_artists": [
+        "Barry Can't Swim",
+        "Martin Garrix, Matisse & Sadko, BARBZ",
+        "Justice, Simian"
+      ]
+    },
+    {
+      "artist": "Don Diablo",
+      "title": "AnyTime",
+      "year": 2014,
+      "isrc": "NLZ541400613",
+      "uri": "spotify:track:0xnBlKwiZlcab4Sjqg6rbl",
+      "uri_apple_music": "applemusic://track/1336611719",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1336611719"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/452699282",
+      "fun_fact": "“AnyTime” is the title track of Don Diablo’s release of the same name.",
+      "fun_fact_de": "„AnyTime“ ist der Titelsong der gleichnamigen Veröffentlichung von Don Diablo.",
+      "fun_fact_es": "«AnyTime» es la canción que da título al lanzamiento homónimo de Don Diablo.",
+      "fun_fact_fr": "« AnyTime » est le morceau-titre de la publication éponyme de Don Diablo.",
+      "fun_fact_nl": "‘AnyTime’ is het titelnummer van de gelijknamige release van Don Diablo.",
+      "alt_artists": [
+        "Jewelz & Sparks, AFROJACK, Sunnery James & Ryan Marciano",
+        "Black Coffee, David Guetta, Delilah Montagu",
+        "Boris Brejcha, Laura Korinth"
+      ]
+    },
+    {
+      "artist": "Alesso",
+      "title": "Without You",
+      "year": 2023,
+      "isrc": "USUG12303579",
+      "uri": "spotify:track:4NH496Sf2JEOvDRxEuIBc4",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2300219515",
+      "fun_fact": "“Without You” is the title track of Alesso’s release of the same name.",
+      "fun_fact_de": "„Without You“ ist der Titelsong der gleichnamigen Veröffentlichung von Alesso.",
+      "fun_fact_es": "«Without You» es la canción que da título al lanzamiento homónimo de Alesso.",
+      "fun_fact_fr": "« Without You » est le morceau-titre de la publication éponyme de Alesso.",
+      "fun_fact_nl": "‘Without You’ is het titelnummer van de gelijknamige release van Alesso.",
+      "alt_artists": [
+        "Chicane, Moya Brennan",
+        "Kölsch, Troels Abrahamsen",
+        "Grooveyard, Nicky Romero"
+      ]
+    },
+    {
+      "artist": "BL3SS, CamrinWatsin, bbyclose",
+      "title": "Kisses (feat. bbyclose)",
+      "year": 2024,
+      "isrc": "GBAHS2400105",
+      "uri": "spotify:track:2A1aS3mwuGuX2yk1bgxOvA",
+      "uri_apple_music": "applemusic://track/1735803279",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1735803279"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2702569332",
+      "fun_fact": "“Kisses (feat. bbyclose)” is the title track of BL3SS’s release of the same name.",
+      "fun_fact_de": "„Kisses (feat. bbyclose)“ ist der Titelsong der gleichnamigen Veröffentlichung von BL3SS.",
+      "fun_fact_es": "«Kisses (feat. bbyclose)» es la canción que da título al lanzamiento homónimo de BL3SS.",
+      "fun_fact_fr": "« Kisses (feat. bbyclose) » est le morceau-titre de la publication éponyme de BL3SS.",
+      "fun_fact_nl": "‘Kisses (feat. bbyclose)’ is het titelnummer van de gelijknamige release van BL3SS.",
+      "alt_artists": [
+        "DJ MERCER, Tchami",
+        "ZHU",
+        "David Guetta, Akon"
+      ]
+    },
+    {
+      "artist": "Cajmere, Dajae, Marco Lys, Green Velvet",
+      "title": "Brighter Days - Marco Lys Remix",
+      "year": 2011,
+      "isrc": "USCEI1142801",
+      "uri": "spotify:track:7IJP1vVnqU5mV2hYUbZrlX",
+      "uri_apple_music": "applemusic://track/1650248631",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1650248631"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2000315707",
+      "fun_fact": "“Brighter Days - Marco Lys Remix” appears on Cajmere’s release “Brighter Days (30 Year Anniversary Remixes)”.",
+      "fun_fact_de": "„Brighter Days - Marco Lys Remix“ erschien auf der Veröffentlichung „Brighter Days (30 Year Anniversary Remixes)“ von Cajmere.",
+      "fun_fact_es": "«Brighter Days - Marco Lys Remix» aparece en el lanzamiento «Brighter Days (30 Year Anniversary Remixes)» de Cajmere.",
+      "fun_fact_fr": "« Brighter Days - Marco Lys Remix » figure sur la publication « Brighter Days (30 Year Anniversary Remixes) » de Cajmere.",
+      "fun_fact_nl": "‘Brighter Days - Marco Lys Remix’ staat op de release ‘Brighter Days (30 Year Anniversary Remixes)’ van Cajmere.",
+      "alt_artists": [
+        "Duck Sauce, A-Trak, Armand Van Helden",
+        "Tiësto, 433",
+        "Red Hot Chili Peppers"
+      ]
+    },
+    {
+      "artist": "Arno Cost, Arias",
+      "title": "Magenta - Radio Edit",
+      "year": 2006,
+      "isrc": "FRV600600021",
+      "uri": "spotify:track:0RTYWO8kheyjmOk0JXi4Yi",
+      "uri_apple_music": "applemusic://track/1856648159",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1856648159"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2346264355",
+      "fun_fact": "“Magenta - Radio Edit” appears on Arno Cost’s release “Magenta”.",
+      "fun_fact_de": "„Magenta - Radio Edit“ erschien auf der Veröffentlichung „Magenta“ von Arno Cost.",
+      "fun_fact_es": "«Magenta - Radio Edit» aparece en el lanzamiento «Magenta» de Arno Cost.",
+      "fun_fact_fr": "« Magenta - Radio Edit » figure sur la publication « Magenta » de Arno Cost.",
+      "fun_fact_nl": "‘Magenta - Radio Edit’ staat op de release ‘Magenta’ van Arno Cost.",
+      "alt_artists": [
+        "Mr. Probz, Chris Brown, T.I.",
+        "Alesso, TINI",
+        "Parachute Youth"
+      ]
+    },
+    {
+      "artist": "Dirty South, Evermore",
+      "title": "It's Too Late - Dirty South Radio Edit",
+      "year": 2006,
+      "isrc": "AUVC00604311",
+      "uri": "spotify:track:2WMur8xCATjMHLgpPHdosc",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1496284002",
+      "fun_fact": "“It's Too Late - Dirty South Radio Edit” appears on Dirty South’s release “It's Too Late”.",
+      "fun_fact_de": "„It's Too Late - Dirty South Radio Edit“ erschien auf der Veröffentlichung „It's Too Late“ von Dirty South.",
+      "fun_fact_es": "«It's Too Late - Dirty South Radio Edit» aparece en el lanzamiento «It's Too Late» de Dirty South.",
+      "fun_fact_fr": "« It's Too Late - Dirty South Radio Edit » figure sur la publication « It's Too Late » de Dirty South.",
+      "fun_fact_nl": "‘It's Too Late - Dirty South Radio Edit’ staat op de release ‘It's Too Late’ van Dirty South.",
+      "alt_artists": [
+        "Madeon",
+        "Fragma",
+        "FISHER, bbyclose"
+      ]
+    },
+    {
+      "artist": "Lucas & Steve, Tungevaag",
+      "title": "Paper Planes",
+      "year": 2021,
+      "isrc": "NLZ542101141",
+      "uri": "spotify:track:4mrAArfFEIqpH6myouJb03",
+      "uri_apple_music": "applemusic://track/1575570551",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1575570551"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1426994352",
+      "fun_fact": "“Paper Planes” is the title track of Lucas & Steve’s release of the same name.",
+      "fun_fact_de": "„Paper Planes“ ist der Titelsong der gleichnamigen Veröffentlichung von Lucas & Steve.",
+      "fun_fact_es": "«Paper Planes» es la canción que da título al lanzamiento homónimo de Lucas & Steve.",
+      "fun_fact_fr": "« Paper Planes » est le morceau-titre de la publication éponyme de Lucas & Steve.",
+      "fun_fact_nl": "‘Paper Planes’ is het titelnummer van de gelijknamige release van Lucas & Steve.",
+      "alt_artists": [
+        "Axwell, Sebastian Ingrosso",
+        "Tommy Trash",
+        "Estelle, Lost Frequencies, Kanye West"
+      ]
+    },
+    {
+      "artist": "Miss Monique",
+      "title": "Concorde",
+      "year": 2023,
+      "isrc": "DGA072254962",
+      "uri": "spotify:track:2IUG5pEgIyvevQI92WB6Vh",
+      "uri_apple_music": "applemusic://track/1834455173",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1834455173"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3517242671",
+      "fun_fact": "“Concorde” is the title track of Miss Monique’s release of the same name.",
+      "fun_fact_de": "„Concorde“ ist der Titelsong der gleichnamigen Veröffentlichung von Miss Monique.",
+      "fun_fact_es": "«Concorde» es la canción que da título al lanzamiento homónimo de Miss Monique.",
+      "fun_fact_fr": "« Concorde » est le morceau-titre de la publication éponyme de Miss Monique.",
+      "fun_fact_nl": "‘Concorde’ is het titelnummer van de gelijknamige release van Miss Monique.",
+      "alt_artists": [
+        "Paul Woolford, Kim English",
+        "Kaskade, deadmau5",
+        "Shouse, David Guetta"
+      ]
+    },
+    {
+      "artist": "Salif Keita, Martin Solveig",
+      "title": "Madan - Remix",
+      "year": 2001,
+      "isrc": "FRZ020182380",
+      "uri": "spotify:track:5h1xmefdnY2Y4zld4jnvoE",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/956264572",
+      "fun_fact": "“Madan - Remix” appears on Salif Keita’s release “Moffou”.",
+      "fun_fact_de": "„Madan - Remix“ erschien auf der Veröffentlichung „Moffou“ von Salif Keita.",
+      "fun_fact_es": "«Madan - Remix» aparece en el lanzamiento «Moffou» de Salif Keita.",
+      "fun_fact_fr": "« Madan - Remix » figure sur la publication « Moffou » de Salif Keita.",
+      "fun_fact_nl": "‘Madan - Remix’ staat op de release ‘Moffou’ van Salif Keita.",
+      "alt_artists": [
+        "Marco V",
+        "Enrico Sangiuliano",
+        "Armand Van Helden"
+      ]
+    },
+    {
+      "artist": "Alesso",
+      "title": "Hypnotize",
+      "year": 2024,
+      "isrc": "USUG12401558",
+      "uri": "spotify:track:4TRR5t5l0MJSqNJSeaOEXn",
+      "uri_apple_music": "applemusic://track/1744030898",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1744030898"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2780960761",
+      "fun_fact": "“Hypnotize” appears on Alesso’s release “Hypnotize EP”.",
+      "fun_fact_de": "„Hypnotize“ erschien auf der Veröffentlichung „Hypnotize EP“ von Alesso.",
+      "fun_fact_es": "«Hypnotize» aparece en el lanzamiento «Hypnotize EP» de Alesso.",
+      "fun_fact_fr": "« Hypnotize » figure sur la publication « Hypnotize EP » de Alesso.",
+      "fun_fact_nl": "‘Hypnotize’ staat op de release ‘Hypnotize EP’ van Alesso.",
+      "alt_artists": [
+        "Higher Self, Lauren Mason",
+        "Steve Angello",
+        "Becky Hill, Chase & Status"
+      ]
+    },
+    {
+      "artist": "Diplo, Paul Woolford, Kareen Lomax",
+      "title": "Promises",
+      "year": 2021,
+      "isrc": "USZ4V2100192",
+      "uri": "spotify:track:50YQaQXog18lS11wGCl77u",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1489483142",
+      "fun_fact": "“Promises” is the title track of Diplo’s release of the same name.",
+      "fun_fact_de": "„Promises“ ist der Titelsong der gleichnamigen Veröffentlichung von Diplo.",
+      "fun_fact_es": "«Promises» es la canción que da título al lanzamiento homónimo de Diplo.",
+      "fun_fact_fr": "« Promises » est le morceau-titre de la publication éponyme de Diplo.",
+      "fun_fact_nl": "‘Promises’ is het titelnummer van de gelijknamige release van Diplo.",
+      "alt_artists": [
+        "Kosheen, Tinlicker",
+        "Lost Frequencies, Zonderling, Kelvin Jones",
+        "John Summit, Echoes"
+      ]
+    },
+    {
+      "artist": "Chris Lake, Sammy Virji, Nathan Nicholson",
+      "title": "Summertime Blues (feat. Nathan Nicholson)",
+      "year": 2024,
+      "isrc": "USUG12402645",
+      "uri": "spotify:track:6q36Cqt2d3O5jqrQR9uXCp",
+      "uri_apple_music": "applemusic://track/1741634639",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1741634639"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2757424031",
+      "fun_fact": "“Summertime Blues (feat. Nathan Nicholson)” appears on Chris Lake’s release “Summertime Blues”.",
+      "fun_fact_de": "„Summertime Blues (feat. Nathan Nicholson)“ erschien auf der Veröffentlichung „Summertime Blues“ von Chris Lake.",
+      "fun_fact_es": "«Summertime Blues (feat. Nathan Nicholson)» aparece en el lanzamiento «Summertime Blues» de Chris Lake.",
+      "fun_fact_fr": "« Summertime Blues (feat. Nathan Nicholson) » figure sur la publication « Summertime Blues » de Chris Lake.",
+      "fun_fact_nl": "‘Summertime Blues (feat. Nathan Nicholson)’ staat op de release ‘Summertime Blues’ van Chris Lake.",
+      "alt_artists": [
+        "Dimitri Vegas & Like Mike, Brennan Heart, Tony Junior",
+        "Kevin de Vries",
+        "Alesso, TINI"
+      ]
+    },
+    {
+      "artist": "Sam Feldt, Zonderling",
+      "title": "Sensational - Zonderling Remix",
+      "year": 2018,
+      "isrc": "NLZ541800151",
+      "uri": "spotify:track:5ZfmcScnfvdBG2o3CuMWPC",
+      "uri_apple_music": "applemusic://track/1349390936",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1349390936"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/462500082",
+      "fun_fact": "“Sensational - Zonderling Remix” appears on Sam Feldt’s release “After The Sunset”.",
+      "fun_fact_de": "„Sensational - Zonderling Remix“ erschien auf der Veröffentlichung „After The Sunset“ von Sam Feldt.",
+      "fun_fact_es": "«Sensational - Zonderling Remix» aparece en el lanzamiento «After The Sunset» de Sam Feldt.",
+      "fun_fact_fr": "« Sensational - Zonderling Remix » figure sur la publication « After The Sunset » de Sam Feldt.",
+      "fun_fact_nl": "‘Sensational - Zonderling Remix’ staat op de release ‘After The Sunset’ van Sam Feldt.",
+      "alt_artists": [
+        "Justice",
+        "Au/Ra, CamelPhat",
+        "Krewella, Hardwell"
+      ]
+    },
+    {
+      "artist": "Ben Böhmer",
+      "title": "Beyond Beliefs",
+      "year": 2021,
+      "isrc": "GBEWA2103551",
+      "uri": "spotify:track:0SbDNXZYqfsMarINcb72X5",
+      "uri_apple_music": "applemusic://track/1572313320",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1572313320"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1496292952",
+      "fun_fact": "“Beyond Beliefs” appears on Ben Böhmer’s release “Begin Again”.",
+      "fun_fact_de": "„Beyond Beliefs“ erschien auf der Veröffentlichung „Begin Again“ von Ben Böhmer.",
+      "fun_fact_es": "«Beyond Beliefs» aparece en el lanzamiento «Begin Again» de Ben Böhmer.",
+      "fun_fact_fr": "« Beyond Beliefs » figure sur la publication « Begin Again » de Ben Böhmer.",
+      "fun_fact_nl": "‘Beyond Beliefs’ staat op de release ‘Begin Again’ van Ben Böhmer.",
+      "alt_artists": [
+        "Deorro",
+        "Creeds",
+        "Soul Central, Danny Krivit"
+      ]
+    },
+    {
+      "artist": "John Summit, Inéz",
+      "title": "crystallized (feat. Inéz)",
+      "year": 2025,
+      "isrc": "CBEFB2501800",
+      "uri": "spotify:track:6YiIWuVXS4AqF1KvUGMwyx",
+      "uri_apple_music": "applemusic://track/1838005011",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1838005011"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3635742072",
+      "fun_fact": "“crystallized (feat. Inéz)” appears on John Summit’s release “crystallized (feat. Inéz) - Subtronics Remix”.",
+      "fun_fact_de": "„crystallized (feat. Inéz)“ erschien auf der Veröffentlichung „crystallized (feat. Inéz) - Subtronics Remix“ von John Summit.",
+      "fun_fact_es": "«crystallized (feat. Inéz)» aparece en el lanzamiento «crystallized (feat. Inéz) - Subtronics Remix» de John Summit.",
+      "fun_fact_fr": "« crystallized (feat. Inéz) » figure sur la publication « crystallized (feat. Inéz) - Subtronics Remix » de John Summit.",
+      "fun_fact_nl": "‘crystallized (feat. Inéz)’ staat op de release ‘crystallized (feat. Inéz) - Subtronics Remix’ van John Summit.",
+      "alt_artists": [
+        "Purple Disco Machine, Sophie and the Giants",
+        "Skrillex, Starrah, Four Tet",
+        "Dimitri Vegas & Like Mike, Bassjackers, D'Angello & Francis"
+      ]
+    },
+    {
+      "artist": "Lost Frequencies, Janieck",
+      "title": "Reality",
+      "year": 2014,
+      "isrc": "NLF711502765",
+      "uri": "spotify:track:1Mys1gf9SkMBAVGGxpkJ7d",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/100654376",
+      "fun_fact": "“Reality” is the title track of Lost Frequencies’s release of the same name.",
+      "fun_fact_de": "„Reality“ ist der Titelsong der gleichnamigen Veröffentlichung von Lost Frequencies.",
+      "fun_fact_es": "«Reality» es la canción que da título al lanzamiento homónimo de Lost Frequencies.",
+      "fun_fact_fr": "« Reality » est le morceau-titre de la publication éponyme de Lost Frequencies.",
+      "fun_fact_nl": "‘Reality’ is het titelnummer van de gelijknamige release van Lost Frequencies.",
+      "alt_artists": [
+        "Gotye, FISHER, Chris Lake, Sante Sansone, Kimbra",
+        "Lucas & Steve, Tungevaag",
+        "Marshmello, Khalid, Tiësto"
+      ]
+    },
+    {
+      "artist": "Dimitri Vegas & Like Mike, Brennan Heart, Tony Junior",
+      "title": "The Scientist",
+      "year": 2024,
+      "isrc": "BEIW12400212",
+      "uri": "spotify:track:3wxbMFOaduop2XFO9gKihO",
+      "uri_apple_music": "applemusic://track/1735975299",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1735975299"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2703793952",
+      "fun_fact": "“The Scientist” is the title track of Dimitri Vegas & Like Mike’s release of the same name.",
+      "fun_fact_de": "„The Scientist“ ist der Titelsong der gleichnamigen Veröffentlichung von Dimitri Vegas & Like Mike.",
+      "fun_fact_es": "«The Scientist» es la canción que da título al lanzamiento homónimo de Dimitri Vegas & Like Mike.",
+      "fun_fact_fr": "« The Scientist » est le morceau-titre de la publication éponyme de Dimitri Vegas & Like Mike.",
+      "fun_fact_nl": "‘The Scientist’ is het titelnummer van de gelijknamige release van Dimitri Vegas & Like Mike.",
+      "alt_artists": [
+        "Barry Can't Swim",
+        "Chris Lake, Sammy Virji, Nathan Nicholson",
+        "Purple Disco Machine, Moss Kena, The Knocks"
+      ]
+    },
+    {
+      "artist": "Steve Aoki, Jamis, Bonn",
+      "title": "Thanks To You (ft. Bonn)",
+      "year": 2025,
+      "isrc": "USA2P2526346",
+      "uri": "spotify:track:07En86a4TKddEKwOUlasjx",
+      "uri_apple_music": "applemusic://track/1888486791",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1888486791"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3925291921",
+      "fun_fact": "“Thanks To You (ft. Bonn)” appears on Steve Aoki’s release “HiROQUEST 3: Paragon”.",
+      "fun_fact_de": "„Thanks To You (ft. Bonn)“ erschien auf der Veröffentlichung „HiROQUEST 3: Paragon“ von Steve Aoki.",
+      "fun_fact_es": "«Thanks To You (ft. Bonn)» aparece en el lanzamiento «HiROQUEST 3: Paragon» de Steve Aoki.",
+      "fun_fact_fr": "« Thanks To You (ft. Bonn) » figure sur la publication « HiROQUEST 3: Paragon » de Steve Aoki.",
+      "fun_fact_nl": "‘Thanks To You (ft. Bonn)’ staat op de release ‘HiROQUEST 3: Paragon’ van Steve Aoki.",
+      "alt_artists": [
+        "Kings Of Tomorrow",
+        "Axwell /\\ Ingrosso, RØMANS",
+        "Dennis Ferrer"
+      ]
+    },
+    {
+      "artist": "DR. KUCHO!, Gregor Salto, Ane Brun, Oliver Heldens",
+      "title": "Can't Stop Playing (Makes Me High) [feat. Ane Brun] - Oliver Heldens & Gregor Salto Vocal Mix Edit",
+      "year": 2015,
+      "isrc": "NLZ541500027",
+      "uri": "spotify:track:0nBfCpqxSsWT4G8jXM0txf",
+      "uri_apple_music": "applemusic://track/1833096250",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1833096250"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/459413432",
+      "fun_fact": "“Can't Stop Playing (Makes Me High) [feat. Ane Brun] - Oliver Heldens & Gregor Salto Vocal Mix Edit” appears on DR. KUCHO!’s release “Can't Stop Playing (Remixes)”.",
+      "fun_fact_de": "„Can't Stop Playing (Makes Me High) [feat. Ane Brun] - Oliver Heldens & Gregor Salto Vocal Mix Edit“ erschien auf der Veröffentlichung „Can't Stop Playing (Remixes)“ von DR. KUCHO!.",
+      "fun_fact_es": "«Can't Stop Playing (Makes Me High) [feat. Ane Brun] - Oliver Heldens & Gregor Salto Vocal Mix Edit» aparece en el lanzamiento «Can't Stop Playing (Remixes)» de DR. KUCHO!.",
+      "fun_fact_fr": "« Can't Stop Playing (Makes Me High) [feat. Ane Brun] - Oliver Heldens & Gregor Salto Vocal Mix Edit » figure sur la publication « Can't Stop Playing (Remixes) » de DR. KUCHO!.",
+      "fun_fact_nl": "‘Can't Stop Playing (Makes Me High) [feat. Ane Brun] - Oliver Heldens & Gregor Salto Vocal Mix Edit’ staat op de release ‘Can't Stop Playing (Remixes)’ van DR. KUCHO!.",
+      "alt_artists": [
+        "Kx5, deadmau5, Kaskade",
+        "The Chainsmokers, Coldplay, Alesso",
+        "Calvin Harris, Example"
+      ]
+    },
+    {
+      "artist": "Krystal Klear",
+      "title": "Piano Banana",
+      "year": 2021,
+      "isrc": "DEVY92100061",
+      "uri": "spotify:track:54sPB30YiFMw2AkvnVfu2f",
+      "uri_apple_music": "applemusic://track/1566331892",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1566331892"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1365164262",
+      "fun_fact": "“Piano Banana” is the title track of Krystal Klear’s release of the same name.",
+      "fun_fact_de": "„Piano Banana“ ist der Titelsong der gleichnamigen Veröffentlichung von Krystal Klear.",
+      "fun_fact_es": "«Piano Banana» es la canción que da título al lanzamiento homónimo de Krystal Klear.",
+      "fun_fact_fr": "« Piano Banana » est le morceau-titre de la publication éponyme de Krystal Klear.",
+      "fun_fact_nl": "‘Piano Banana’ is het titelnummer van de gelijknamige release van Krystal Klear.",
+      "alt_artists": [
+        "Maceo Plex, Chromatics",
+        "Tiësto, Poppy Baskcomb",
+        "Dimitri Vegas & Like Mike, DVBBS, Borgeous"
+      ]
+    },
+    {
+      "artist": "Veracocha",
+      "title": "Carte Blanche - FM Edit",
+      "year": 1999,
+      "isrc": "NLCY30801567",
+      "uri": "spotify:track:1G19nJWN1DoNffL3JvIclk",
+      "uri_apple_music": "applemusic://track/1577507503",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1577507503"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/767730962",
+      "fun_fact": "“Carte Blanche - FM Edit” appears on Veracocha’s release “Carte Blanche”.",
+      "fun_fact_de": "„Carte Blanche - FM Edit“ erschien auf der Veröffentlichung „Carte Blanche“ von Veracocha.",
+      "fun_fact_es": "«Carte Blanche - FM Edit» aparece en el lanzamiento «Carte Blanche» de Veracocha.",
+      "fun_fact_fr": "« Carte Blanche - FM Edit » figure sur la publication « Carte Blanche » de Veracocha.",
+      "fun_fact_nl": "‘Carte Blanche - FM Edit’ staat op de release ‘Carte Blanche’ van Veracocha.",
+      "alt_artists": [
+        "Alesso, Zara Larsson",
+        "Ummet Ozcan",
+        "Tiësto, Hardwell"
+      ]
+    },
+    {
+      "artist": "Mau P",
+      "title": "Like I Like It",
+      "year": 2023,
+      "isrc": "DEDH72300418",
+      "uri": "spotify:track:6vLKVWEuOCQAWEaHv2yknm",
+      "uri_apple_music": "applemusic://track/1810702937",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1810702937"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3340111711",
+      "fun_fact": "“Like I Like It” appears on Mau P’s release “Too Big For B-Side”.",
+      "fun_fact_de": "„Like I Like It“ erschien auf der Veröffentlichung „Too Big For B-Side“ von Mau P.",
+      "fun_fact_es": "«Like I Like It» aparece en el lanzamiento «Too Big For B-Side» de Mau P.",
+      "fun_fact_fr": "« Like I Like It » figure sur la publication « Too Big For B-Side » de Mau P.",
+      "fun_fact_nl": "‘Like I Like It’ staat op de release ‘Too Big For B-Side’ van Mau P.",
+      "alt_artists": [
+        "Paul van Dyk, Hemstock, Jennings",
+        "Felix",
+        "Anyma, CamelPhat"
+      ]
+    },
+    {
+      "artist": "Anyma, CamelPhat",
+      "title": "The Sign (with CamelPhat)",
+      "year": 2022,
+      "isrc": "DEEC33500811",
+      "uri": "spotify:track:58kUEj9sd9Z2XIPh3BhJRR",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2395987995",
+      "fun_fact": "“The Sign (with CamelPhat)” appears on Anyma’s release “Genesys”.",
+      "fun_fact_de": "„The Sign (with CamelPhat)“ erschien auf der Veröffentlichung „Genesys“ von Anyma.",
+      "fun_fact_es": "«The Sign (with CamelPhat)» aparece en el lanzamiento «Genesys» de Anyma.",
+      "fun_fact_fr": "« The Sign (with CamelPhat) » figure sur la publication « Genesys » de Anyma.",
+      "fun_fact_nl": "‘The Sign (with CamelPhat)’ staat op de release ‘Genesys’ van Anyma.",
+      "alt_artists": [
+        "Borai & Denham Audio, Franky Rizardo",
+        "Celeda, Danny Tenaglia",
+        "HAVEN., Kaitlin Aragon"
+      ]
+    },
+    {
+      "artist": "Axwell, Dirty South, Rudy",
+      "title": "Open Your Heart - Vocal Mix",
+      "year": 2008,
+      "isrc": "GBKCF0800068",
+      "uri": "spotify:track:7u0bF5AZ9xgoOpNSR8BnzU",
+      "uri_apple_music": "applemusic://track/626207768",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/626207768"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/61858806",
+      "fun_fact": "“Open Your Heart - Vocal Mix” appears on Axwell’s release “Sirup House Sessions (2009)”.",
+      "fun_fact_de": "„Open Your Heart - Vocal Mix“ erschien auf der Veröffentlichung „Sirup House Sessions (2009)“ von Axwell.",
+      "fun_fact_es": "«Open Your Heart - Vocal Mix» aparece en el lanzamiento «Sirup House Sessions (2009)» de Axwell.",
+      "fun_fact_fr": "« Open Your Heart - Vocal Mix » figure sur la publication « Sirup House Sessions (2009) » de Axwell.",
+      "fun_fact_nl": "‘Open Your Heart - Vocal Mix’ staat op de release ‘Sirup House Sessions (2009)’ van Axwell.",
+      "alt_artists": [
+        "Rolando",
+        "Storm",
+        "Max Dean, Luke Dean, Locky"
+      ]
+    },
+    {
+      "artist": "Marlon Hoffstadt, DJ Daddy Trance",
+      "title": "Call Me",
+      "year": 2023,
+      "isrc": "QZQAY2343225",
+      "uri": "spotify:track:4iqtDvbICWuBERMTz9cz41",
+      "uri_apple_music": "applemusic://track/1684584572",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1684584572"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2255185497",
+      "fun_fact": "“Call Me” is the title track of Marlon Hoffstadt’s release of the same name.",
+      "fun_fact_de": "„Call Me“ ist der Titelsong der gleichnamigen Veröffentlichung von Marlon Hoffstadt.",
+      "fun_fact_es": "«Call Me» es la canción que da título al lanzamiento homónimo de Marlon Hoffstadt.",
+      "fun_fact_fr": "« Call Me » est le morceau-titre de la publication éponyme de Marlon Hoffstadt.",
+      "fun_fact_nl": "‘Call Me’ is het titelnummer van de gelijknamige release van Marlon Hoffstadt.",
+      "alt_artists": [
+        "John Dahlbäck",
+        "Sub Focus, Wilkinson",
+        "Tomaz, Filterheadz"
+      ]
+    },
+    {
+      "artist": "Kölsch, Troels Abrahamsen, ARTBAT",
+      "title": "All That Matters (feat. Troels Abrahamsen) - [ARTBAT Remix] [Mixed]",
+      "year": 2024,
+      "isrc": "GBHFW2400022",
+      "uri": "spotify:track:7dUQj6Ae5jfOHNlb2VE8Im",
+      "uri_apple_music": "applemusic://track/1691565215",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1691565215"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2637478372",
+      "fun_fact": "“All That Matters (feat. Troels Abrahamsen) - [ARTBAT Remix] [Mixed]” appears on Kölsch’s release “Global Underground: Select #9 (Mixed)”.",
+      "fun_fact_de": "„All That Matters (feat. Troels Abrahamsen) - [ARTBAT Remix] [Mixed]“ erschien auf der Veröffentlichung „Global Underground: Select #9 (Mixed)“ von Kölsch.",
+      "fun_fact_es": "«All That Matters (feat. Troels Abrahamsen) - [ARTBAT Remix] [Mixed]» aparece en el lanzamiento «Global Underground: Select #9 (Mixed)» de Kölsch.",
+      "fun_fact_fr": "« All That Matters (feat. Troels Abrahamsen) - [ARTBAT Remix] [Mixed] » figure sur la publication « Global Underground: Select #9 (Mixed) » de Kölsch.",
+      "fun_fact_nl": "‘All That Matters (feat. Troels Abrahamsen) - [ARTBAT Remix] [Mixed]’ staat op de release ‘Global Underground: Select #9 (Mixed)’ van Kölsch.",
+      "alt_artists": [
+        "Martin Solveig, Good Times Ahead",
+        "CamelPhat, Elderbrook",
+        "Supermode, Axwell, Steve Angello"
+      ]
+    },
+    {
+      "artist": "Roger Sanchez",
+      "title": "Another Chance - Radio Edit",
+      "year": 2001,
+      "isrc": "GBCPZ0100340",
+      "uri": "spotify:track:0EoGXXi91KSqAIY7SSgizW",
+      "uri_apple_music": "applemusic://track/1575824358",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1575824358"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/15790351",
+      "fun_fact": "“Another Chance - Radio Edit” appears on Roger Sanchez’s release “Another Chance”.",
+      "fun_fact_de": "„Another Chance - Radio Edit“ erschien auf der Veröffentlichung „Another Chance“ von Roger Sanchez.",
+      "fun_fact_es": "«Another Chance - Radio Edit» aparece en el lanzamiento «Another Chance» de Roger Sanchez.",
+      "fun_fact_fr": "« Another Chance - Radio Edit » figure sur la publication « Another Chance » de Roger Sanchez.",
+      "fun_fact_nl": "‘Another Chance - Radio Edit’ staat op de release ‘Another Chance’ van Roger Sanchez.",
+      "alt_artists": [
+        "Above & Beyond, anamē, Marty Longstaff",
+        "Diplo, Sonny Fodera",
+        "Dada Life, Sebastian Bach"
+      ]
+    },
+    {
+      "artist": "Netsky",
+      "title": "Iron Heart",
+      "year": 2010,
+      "isrc": "GBCJY1016702",
+      "uri": "spotify:track:1KENVP5f9ASBqxEUvBz54d",
+      "uri_apple_music": "applemusic://track/1688696901",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1688696901"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2929252061",
+      "fun_fact": "“Iron Heart” appears on Netsky’s release “Netsky”.",
+      "fun_fact_de": "„Iron Heart“ erschien auf der Veröffentlichung „Netsky“ von Netsky.",
+      "fun_fact_es": "«Iron Heart» aparece en el lanzamiento «Netsky» de Netsky.",
+      "fun_fact_fr": "« Iron Heart » figure sur la publication « Netsky » de Netsky.",
+      "fun_fact_nl": "‘Iron Heart’ staat op de release ‘Netsky’ van Netsky.",
+      "alt_artists": [
+        "Galantis",
+        "Martin Garrix, Mike Yung, Nicky Romero",
+        "Swedish House Mafia, Tinie Tempah"
+      ]
+    },
+    {
+      "artist": "Push, Charlotte de Witte",
+      "title": "Universal Nation - Charlotte de Witte Rework",
+      "year": 2024,
+      "isrc": "BE4JP2400001",
+      "uri": "spotify:track:4OrY514bfwTTtykP7s049a",
+      "uri_apple_music": "applemusic://track/1724268061",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1724268061"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2585146062",
+      "fun_fact": "“Universal Nation - Charlotte de Witte Rework” is the title track of Push’s release of the same name.",
+      "fun_fact_de": "„Universal Nation - Charlotte de Witte Rework“ ist der Titelsong der gleichnamigen Veröffentlichung von Push.",
+      "fun_fact_es": "«Universal Nation - Charlotte de Witte Rework» es la canción que da título al lanzamiento homónimo de Push.",
+      "fun_fact_fr": "« Universal Nation - Charlotte de Witte Rework » est le morceau-titre de la publication éponyme de Push.",
+      "fun_fact_nl": "‘Universal Nation - Charlotte de Witte Rework’ is het titelnummer van de gelijknamige release van Push.",
+      "alt_artists": [
+        "Jan Blomqvist, Ben Böhmer",
+        "Lost Frequencies, Calum Scott",
+        "Cassian, YOTTO, Da Hool"
+      ]
+    },
+    {
+      "artist": "Double 99",
+      "title": "RIP Groove (Radio Edit)",
+      "year": 2008,
+      "isrc": "GBBMQ0800343",
+      "uri": "spotify:track:6CF9qg5FZFERIUzoYejIzH",
+      "uri_apple_music": "applemusic://track/1697465189",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1697465189"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3808858922",
+      "fun_fact": "“RIP Groove (Radio Edit)” appears on Double 99’s release “RIP Groove”.",
+      "fun_fact_de": "„RIP Groove (Radio Edit)“ erschien auf der Veröffentlichung „RIP Groove“ von Double 99.",
+      "fun_fact_es": "«RIP Groove (Radio Edit)» aparece en el lanzamiento «RIP Groove» de Double 99.",
+      "fun_fact_fr": "« RIP Groove (Radio Edit) » figure sur la publication « RIP Groove » de Double 99.",
+      "fun_fact_nl": "‘RIP Groove (Radio Edit)’ staat op de release ‘RIP Groove’ van Double 99.",
+      "alt_artists": [
+        "Don Diablo",
+        "Dirty South, Evermore",
+        "Michel Cleis, Totó La Momposina, Paul Kalkbrenner"
+      ]
+    },
+    {
+      "artist": "Alesso, Armin van Buuren",
+      "title": "Leave A Little Love",
+      "year": 2021,
+      "isrc": "NLF712101358",
+      "uri": "spotify:track:5pmbZWt1lYVMvZ12MSdtqF",
+      "uri_apple_music": "applemusic://track/1552344232",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1552344232"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1233536262",
+      "fun_fact": "“Leave A Little Love” is the title track of Alesso’s release of the same name.",
+      "fun_fact_de": "„Leave A Little Love“ ist der Titelsong der gleichnamigen Veröffentlichung von Alesso.",
+      "fun_fact_es": "«Leave A Little Love» es la canción que da título al lanzamiento homónimo de Alesso.",
+      "fun_fact_fr": "« Leave A Little Love » est le morceau-titre de la publication éponyme de Alesso.",
+      "fun_fact_nl": "‘Leave A Little Love’ is het titelnummer van de gelijknamige release van Alesso.",
+      "alt_artists": [
+        "Djuma Soundsystem",
+        "Mau P",
+        "Above & Beyond"
+      ]
+    },
+    {
+      "artist": "Barry Can't Swim",
+      "title": "Sunsleeper",
+      "year": 2023,
+      "isrc": "GBCFB2200981",
+      "uri": "spotify:track:35lxsi9U65JKT03Voj2Dl5",
+      "uri_apple_music": "applemusic://track/1667381083",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1667381083"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2121748347",
+      "fun_fact": "“Sunsleeper” is the title track of Barry Can't Swim’s release of the same name.",
+      "fun_fact_de": "„Sunsleeper“ ist der Titelsong der gleichnamigen Veröffentlichung von Barry Can't Swim.",
+      "fun_fact_es": "«Sunsleeper» es la canción que da título al lanzamiento homónimo de Barry Can't Swim.",
+      "fun_fact_fr": "« Sunsleeper » est le morceau-titre de la publication éponyme de Barry Can't Swim.",
+      "fun_fact_nl": "‘Sunsleeper’ is het titelnummer van de gelijknamige release van Barry Can't Swim.",
+      "alt_artists": [
+        "Wankelmut, Emma Louise, MK",
+        "Michel Cleis, Totó La Momposina, Paul Kalkbrenner",
+        "DJ MERCER, Tchami"
+      ]
+    },
+    {
+      "artist": "Axwell",
+      "title": "Nobody Else",
+      "year": 2018,
+      "isrc": "GBKCF1800706",
+      "uri": "spotify:track:7g2WfNLkwj6QeYmXleHUvi",
+      "uri_apple_music": "applemusic://track/1716121731",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1716121731"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/585994092",
+      "fun_fact": "“Nobody Else” is the title track of Axwell’s release of the same name.",
+      "fun_fact_de": "„Nobody Else“ ist der Titelsong der gleichnamigen Veröffentlichung von Axwell.",
+      "fun_fact_es": "«Nobody Else» es la canción que da título al lanzamiento homónimo de Axwell.",
+      "fun_fact_fr": "« Nobody Else » est le morceau-titre de la publication éponyme de Axwell.",
+      "fun_fact_nl": "‘Nobody Else’ is het titelnummer van de gelijknamige release van Axwell.",
+      "alt_artists": [
+        "Bodyrox, Luciana, D. Ramirez",
+        "Pryda",
+        "M83, Eric Prydz"
+      ]
+    },
+    {
+      "artist": "Patrick Topping",
+      "title": "Be Sharp Say Nowt - Edit",
+      "year": 2017,
+      "isrc": "GBK6Y1710203",
+      "uri": "spotify:track:0j7O38949INodwi5ppDvFe",
+      "uri_apple_music": "applemusic://track/1698290969",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1698290969"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2200543787",
+      "fun_fact": "“Be Sharp Say Nowt - Edit” appears on Patrick Topping’s release “Be Sharp Say Nowt”.",
+      "fun_fact_de": "„Be Sharp Say Nowt - Edit“ erschien auf der Veröffentlichung „Be Sharp Say Nowt“ von Patrick Topping.",
+      "fun_fact_es": "«Be Sharp Say Nowt - Edit» aparece en el lanzamiento «Be Sharp Say Nowt» de Patrick Topping.",
+      "fun_fact_fr": "« Be Sharp Say Nowt - Edit » figure sur la publication « Be Sharp Say Nowt » de Patrick Topping.",
+      "fun_fact_nl": "‘Be Sharp Say Nowt - Edit’ staat op de release ‘Be Sharp Say Nowt’ van Patrick Topping.",
+      "alt_artists": [
+        "Sam Feldt, EDX",
+        "David Guetta, USHER",
+        "Estelle, Lost Frequencies, Kanye West"
+      ]
+    },
+    {
+      "artist": "Tiga, Kölsch",
+      "title": "Mind Dimension - Kölsch Remix",
+      "year": 2022,
+      "isrc": "GBENL2203380",
+      "uri": "spotify:track:2HWx4iA8e9ynY7LlCyfelO",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1843202567",
+      "fun_fact": "“Mind Dimension - Kölsch Remix” is the title track of Tiga’s release of the same name.",
+      "fun_fact_de": "„Mind Dimension - Kölsch Remix“ ist der Titelsong der gleichnamigen Veröffentlichung von Tiga.",
+      "fun_fact_es": "«Mind Dimension - Kölsch Remix» es la canción que da título al lanzamiento homónimo de Tiga.",
+      "fun_fact_fr": "« Mind Dimension - Kölsch Remix » est le morceau-titre de la publication éponyme de Tiga.",
+      "fun_fact_nl": "‘Mind Dimension - Kölsch Remix’ is het titelnummer van de gelijknamige release van Tiga.",
+      "alt_artists": [
+        "Disclosure, Rivo, Eliza Doolittle",
+        "Dimitri Vegas & Like Mike, Sander van Doorn",
+        "Cygnus X, Rank 1"
+      ]
+    },
+    {
+      "artist": "Lazy Jay",
+      "title": "Float My Boat - Radio Edit",
+      "year": 2009,
+      "isrc": "NLE800900054",
+      "uri": "spotify:track:6IRPB3rtIhHBjHd701QwrO",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/119131488",
+      "fun_fact": "“Float My Boat - Radio Edit” appears on Lazy Jay’s release “Float My Boat”.",
+      "fun_fact_de": "„Float My Boat - Radio Edit“ erschien auf der Veröffentlichung „Float My Boat“ von Lazy Jay.",
+      "fun_fact_es": "«Float My Boat - Radio Edit» aparece en el lanzamiento «Float My Boat» de Lazy Jay.",
+      "fun_fact_fr": "« Float My Boat - Radio Edit » figure sur la publication « Float My Boat » de Lazy Jay.",
+      "fun_fact_nl": "‘Float My Boat - Radio Edit’ staat op de release ‘Float My Boat’ van Lazy Jay.",
+      "alt_artists": [
+        "Sunnery James & Ryan Marciano, Kes Kross",
+        "Sam Feldt, Zonderling",
+        "LF SYSTEM"
+      ]
+    },
+    {
+      "artist": "Alesso, TINI",
+      "title": "Sad Song (feat. TINI) (Alesso Remix)",
+      "year": 2019,
+      "isrc": "USUG11902428",
+      "uri": "spotify:track:2UJQmwF0yShE7pHcjSzX4X",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/712066792",
+      "fun_fact": "“Sad Song (feat. TINI) (Alesso Remix)” appears on Alesso’s release “Sad Song (Alesso Remix)”.",
+      "fun_fact_de": "„Sad Song (feat. TINI) (Alesso Remix)“ erschien auf der Veröffentlichung „Sad Song (Alesso Remix)“ von Alesso.",
+      "fun_fact_es": "«Sad Song (feat. TINI) (Alesso Remix)» aparece en el lanzamiento «Sad Song (Alesso Remix)» de Alesso.",
+      "fun_fact_fr": "« Sad Song (feat. TINI) (Alesso Remix) » figure sur la publication « Sad Song (Alesso Remix) » de Alesso.",
+      "fun_fact_nl": "‘Sad Song (feat. TINI) (Alesso Remix)’ staat op de release ‘Sad Song (Alesso Remix)’ van Alesso.",
+      "alt_artists": [
+        "Netsky",
+        "Axwell /\\ Ingrosso, Axwell, Sebastian Ingrosso",
+        "Sia, Diplo, Labrinth, LSD, Lost Frequencies"
+      ]
+    },
+    {
+      "artist": "Martin Garrix, Matisse & Sadko",
+      "title": "Together",
+      "year": 2016,
+      "isrc": "NLM5S1600013",
+      "uri": "spotify:track:6nLctpnQJiPTxkaSgbPKiw",
+      "uri_apple_music": "applemusic://track/1165345742",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1165345742"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/134440452",
+      "fun_fact": "“Together” is the title track of Martin Garrix’s release of the same name.",
+      "fun_fact_de": "„Together“ ist der Titelsong der gleichnamigen Veröffentlichung von Martin Garrix.",
+      "fun_fact_es": "«Together» es la canción que da título al lanzamiento homónimo de Martin Garrix.",
+      "fun_fact_fr": "« Together » est le morceau-titre de la publication éponyme de Martin Garrix.",
+      "fun_fact_nl": "‘Together’ is het titelnummer van de gelijknamige release van Martin Garrix.",
+      "alt_artists": [
+        "Avicii, Sandro Cavazza",
+        "Moby",
+        "Amine Edge & DANCE, Blaze (Kevin Hedge)"
+      ]
+    },
+    {
+      "artist": "Justice, Soulwax",
+      "title": "Phantom Pt II - Soulwax Remix",
+      "year": 2007,
+      "isrc": "FR0NT0700510",
+      "uri": "spotify:track:1hFy8aVf25oH4Jqri3u09L",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/10284993",
+      "fun_fact": "“Phantom Pt II - Soulwax Remix” appears on Justice’s release “Phantom - EP”.",
+      "fun_fact_de": "„Phantom Pt II - Soulwax Remix“ erschien auf der Veröffentlichung „Phantom - EP“ von Justice.",
+      "fun_fact_es": "«Phantom Pt II - Soulwax Remix» aparece en el lanzamiento «Phantom - EP» de Justice.",
+      "fun_fact_fr": "« Phantom Pt II - Soulwax Remix » figure sur la publication « Phantom - EP » de Justice.",
+      "fun_fact_nl": "‘Phantom Pt II - Soulwax Remix’ staat op de release ‘Phantom - EP’ van Justice.",
+      "alt_artists": [
+        "KSHMR, Mike Waters",
+        "John Summit, Inéz",
+        "Cassian, SCRIPT, Belladonna (ofc)"
+      ]
+    },
+    {
+      "artist": "ARTY",
+      "title": "Avalanche",
+      "year": 2019,
+      "isrc": "NLF711903031",
+      "uri": "spotify:track:7tqA9XeIDo4VEMaqKqs28g",
+      "uri_apple_music": "applemusic://track/1457692164",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1457692164"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/654915792",
+      "fun_fact": "“Avalanche” is the title track of ARTY’s release of the same name.",
+      "fun_fact_de": "„Avalanche“ ist der Titelsong der gleichnamigen Veröffentlichung von ARTY.",
+      "fun_fact_es": "«Avalanche» es la canción que da título al lanzamiento homónimo de ARTY.",
+      "fun_fact_fr": "« Avalanche » est le morceau-titre de la publication éponyme de ARTY.",
+      "fun_fact_nl": "‘Avalanche’ is het titelnummer van de gelijknamige release van ARTY.",
+      "alt_artists": [
+        "Oxia",
+        "AN21, Max Vangeli, Julie McKnight",
+        "Massano"
+      ]
+    },
+    {
+      "artist": "AVAION",
+      "title": "Pieces",
+      "year": 2019,
+      "isrc": "DEA811900592",
+      "uri": "spotify:track:5H95n43z0KFcXGCEc0ewe1",
+      "uri_apple_music": "applemusic://track/1484687356",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1484687356"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/790090972",
+      "fun_fact": "“Pieces” is the title track of AVAION’s release of the same name.",
+      "fun_fact_de": "„Pieces“ ist der Titelsong der gleichnamigen Veröffentlichung von AVAION.",
+      "fun_fact_es": "«Pieces» es la canción que da título al lanzamiento homónimo de AVAION.",
+      "fun_fact_fr": "« Pieces » est le morceau-titre de la publication éponyme de AVAION.",
+      "fun_fact_nl": "‘Pieces’ is het titelnummer van de gelijknamige release van AVAION.",
+      "alt_artists": [
+        "Sub Focus, Culture Shock, Fragma",
+        "YORK",
+        "Tiësto, Sevenn"
+      ]
+    },
+    {
+      "artist": "Moby, Steve Angello",
+      "title": "Raining Again (Steve Angello's Vocal Mix)",
+      "year": 2005,
+      "isrc": "GBAJH0500687",
+      "uri": "spotify:track:3V1NFwrtwYyomqXDMw2uVe",
+      "uri_apple_music": "applemusic://track/1536464803",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1536464803"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3786453872",
+      "fun_fact": "“Raining Again (Steve Angello's Vocal Mix)” appears on Moby’s release “Raining Again”.",
+      "fun_fact_de": "„Raining Again (Steve Angello's Vocal Mix)“ erschien auf der Veröffentlichung „Raining Again“ von Moby.",
+      "fun_fact_es": "«Raining Again (Steve Angello's Vocal Mix)» aparece en el lanzamiento «Raining Again» de Moby.",
+      "fun_fact_fr": "« Raining Again (Steve Angello's Vocal Mix) » figure sur la publication « Raining Again » de Moby.",
+      "fun_fact_nl": "‘Raining Again (Steve Angello's Vocal Mix)’ staat op de release ‘Raining Again’ van Moby.",
+      "alt_artists": [
+        "Lost Frequencies, Tom Gregory",
+        "Benny Benassi, Gary Go",
+        "Tiga, Kölsch"
+      ]
+    },
+    {
+      "artist": "Anyma, Grimes",
+      "title": "Welcome To The Opera (with Grimes)",
+      "year": 2023,
+      "isrc": "USUG12303917",
+      "uri": "spotify:track:7hV8vZMezoQdSdvsi70Ioa",
+      "uri_apple_music": "applemusic://track/1690875583",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1690875583"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2395987905",
+      "fun_fact": "“Welcome To The Opera (with Grimes)” appears on Anyma’s release “Genesys”.",
+      "fun_fact_de": "„Welcome To The Opera (with Grimes)“ erschien auf der Veröffentlichung „Genesys“ von Anyma.",
+      "fun_fact_es": "«Welcome To The Opera (with Grimes)» aparece en el lanzamiento «Genesys» de Anyma.",
+      "fun_fact_fr": "« Welcome To The Opera (with Grimes) » figure sur la publication « Genesys » de Anyma.",
+      "fun_fact_nl": "‘Welcome To The Opera (with Grimes)’ staat op de release ‘Genesys’ van Anyma.",
+      "alt_artists": [
+        "HUGEL, Totó La Momposina",
+        "Dizzee Rascal",
+        "Noizu"
+      ]
+    },
+    {
+      "artist": "Showtek",
+      "title": "We Like to Party - Original Mix",
+      "year": 2013,
+      "isrc": "NLDD61300111",
+      "uri": "spotify:track:4O799OM270z43L7pKzNqrt",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/483374982",
+      "fun_fact": "“We Like to Party - Original Mix” appears on Showtek’s release “We Like to Party”.",
+      "fun_fact_de": "„We Like to Party - Original Mix“ erschien auf der Veröffentlichung „We Like to Party“ von Showtek.",
+      "fun_fact_es": "«We Like to Party - Original Mix» aparece en el lanzamiento «We Like to Party» de Showtek.",
+      "fun_fact_fr": "« We Like to Party - Original Mix » figure sur la publication « We Like to Party » de Showtek.",
+      "fun_fact_nl": "‘We Like to Party - Original Mix’ staat op de release ‘We Like to Party’ van Showtek.",
+      "alt_artists": [
+        "SOFI TUKKER, John Summit, Vintage Culture",
+        "Sonny Fodera, MK, Clementine Douglas",
+        "The Magician, Olly Alexander (Years & Years), Watermät"
+      ]
+    },
+    {
+      "artist": "Sub Focus, Culture Shock, Fragma",
+      "title": "Miracle",
+      "year": 2025,
+      "isrc": "GBUM72503171",
+      "uri": "spotify:track:7cGXx6FiS6fhp0aIBliXFo",
+      "uri_apple_music": "applemusic://track/1818382781",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1818382781"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3412428671",
+      "fun_fact": "“Miracle” is the title track of Sub Focus’s release of the same name.",
+      "fun_fact_de": "„Miracle“ ist der Titelsong der gleichnamigen Veröffentlichung von Sub Focus.",
+      "fun_fact_es": "«Miracle» es la canción que da título al lanzamiento homónimo de Sub Focus.",
+      "fun_fact_fr": "« Miracle » est le morceau-titre de la publication éponyme de Sub Focus.",
+      "fun_fact_nl": "‘Miracle’ is het titelnummer van de gelijknamige release van Sub Focus.",
+      "alt_artists": [
+        "Andain",
+        "AFROJACK, Steve Aoki, Miss Palmer",
+        "Agents Of Time"
+      ]
+    },
+    {
+      "artist": "Tiësto",
+      "title": "WOW",
+      "year": 2018,
+      "isrc": "CYA111800241",
+      "uri": "spotify:track:3qPXWPkEZgUhUgPifbE99z",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/938717382",
+      "fun_fact": "“WOW” is the title track of Tiësto’s release of the same name.",
+      "fun_fact_de": "„WOW“ ist der Titelsong der gleichnamigen Veröffentlichung von Tiësto.",
+      "fun_fact_es": "«WOW» es la canción que da título al lanzamiento homónimo de Tiësto.",
+      "fun_fact_fr": "« WOW » est le morceau-titre de la publication éponyme de Tiësto.",
+      "fun_fact_nl": "‘WOW’ is het titelnummer van de gelijknamige release van Tiësto.",
+      "alt_artists": [
+        "AVAION, Sofiya Nzau",
+        "Eric Prydz, Floyd",
+        "Josh Butler, Bontan, Pleasurekraft"
+      ]
+    },
+    {
+      "artist": "Dimitri Vegas & Like Mike, Marlon Hoffstadt, Dj Konik, Dimitri Vegas, Like Mike",
+      "title": "Makina Time",
+      "year": 2026,
+      "isrc": "BEIW12500926",
+      "uri": "spotify:track:4jSrN7kXdQUmbVxJe5x6Xg",
+      "uri_apple_music": "applemusic://track/6764864571",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/6764864571"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3719324372",
+      "fun_fact": "“Makina Time” is the title track of Dimitri Vegas & Like Mike’s release of the same name.",
+      "fun_fact_de": "„Makina Time“ ist der Titelsong der gleichnamigen Veröffentlichung von Dimitri Vegas & Like Mike.",
+      "fun_fact_es": "«Makina Time» es la canción que da título al lanzamiento homónimo de Dimitri Vegas & Like Mike.",
+      "fun_fact_fr": "« Makina Time » est le morceau-titre de la publication éponyme de Dimitri Vegas & Like Mike.",
+      "fun_fact_nl": "‘Makina Time’ is het titelnummer van de gelijknamige release van Dimitri Vegas & Like Mike.",
+      "alt_artists": [
+        "Sub Focus, Culture Shock, Fragma",
+        "Steve Angello, The Presets",
+        "Above & Beyond, anamē, Marty Longstaff"
+      ]
+    },
+    {
+      "artist": "Bingo Players",
+      "title": "When I Dip",
+      "year": 2011,
+      "isrc": "NLC281112267",
+      "uri": "spotify:track:3Fb65mpLd7OtD6Er5eUjuT",
+      "uri_apple_music": "applemusic://track/1350837076",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1350837076"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1493620222",
+      "fun_fact": "“When I Dip” appears on Bingo Players’s release “When I Dip (feat. J2K & MC Dynamite) (The Remixes)”.",
+      "fun_fact_de": "„When I Dip“ erschien auf der Veröffentlichung „When I Dip (feat. J2K & MC Dynamite) (The Remixes)“ von Bingo Players.",
+      "fun_fact_es": "«When I Dip» aparece en el lanzamiento «When I Dip (feat. J2K & MC Dynamite) (The Remixes)» de Bingo Players.",
+      "fun_fact_fr": "« When I Dip » figure sur la publication « When I Dip (feat. J2K & MC Dynamite) (The Remixes) » de Bingo Players.",
+      "fun_fact_nl": "‘When I Dip’ staat op de release ‘When I Dip (feat. J2K & MC Dynamite) (The Remixes)’ van Bingo Players.",
+      "alt_artists": [
+        "Peggy Gou, Soulwax",
+        "Chris Brown, Benny Benassi",
+        "Rui Da Silva, Cassandra"
+      ]
+    },
+    {
+      "artist": "D.O.D",
+      "title": "Sleepless",
+      "year": 2021,
+      "isrc": "GBKCF2100988",
+      "uri": "spotify:track:0AQ1twwDGVlIVpcHDkGkXD",
+      "uri_apple_music": "applemusic://track/1548999214",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1548999214"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1208434992",
+      "fun_fact": "“Sleepless” is the title track of D.O.D’s release of the same name.",
+      "fun_fact_de": "„Sleepless“ ist der Titelsong der gleichnamigen Veröffentlichung von D.O.D.",
+      "fun_fact_es": "«Sleepless» es la canción que da título al lanzamiento homónimo de D.O.D.",
+      "fun_fact_fr": "« Sleepless » est le morceau-titre de la publication éponyme de D.O.D.",
+      "fun_fact_nl": "‘Sleepless’ is het titelnummer van de gelijknamige release van D.O.D.",
+      "alt_artists": [
+        "Lucas & Steve, Brandy",
+        "Martin Garrix, R3HAB, Skytech",
+        "Dimitri Vegas & Like Mike, Marlon Hoffstadt, Dj Konik, Dimitri Vegas, Like Mike"
+      ]
+    },
+    {
+      "artist": "Paul Kalkbrenner",
+      "title": "Gebrünn Gebrünn",
+      "year": 2005,
+      "isrc": "DEAE60500477",
+      "uri": "spotify:track:47X4O5S1uOHv7crhB7XeEY",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/486432372",
+      "fun_fact": "“Gebrünn Gebrünn” appears on Paul Kalkbrenner’s release “Tatü-Tata”.",
+      "fun_fact_de": "„Gebrünn Gebrünn“ erschien auf der Veröffentlichung „Tatü-Tata“ von Paul Kalkbrenner.",
+      "fun_fact_es": "«Gebrünn Gebrünn» aparece en el lanzamiento «Tatü-Tata» de Paul Kalkbrenner.",
+      "fun_fact_fr": "« Gebrünn Gebrünn » figure sur la publication « Tatü-Tata » de Paul Kalkbrenner.",
+      "fun_fact_nl": "‘Gebrünn Gebrünn’ staat op de release ‘Tatü-Tata’ van Paul Kalkbrenner.",
+      "alt_artists": [
+        "Armin van Buuren, W&W",
+        "Diplo, HUGEL, Julia Church",
+        "Fish Go Deep, Tracey K, Dennis Ferrer"
+      ]
+    },
+    {
+      "artist": "Steve Angello",
+      "title": "Tivoli",
+      "year": 2015,
+      "isrc": "USYBL1400262",
+      "uri": "spotify:track:2vCRVUl5K1CUy11adrA8Ne",
+      "uri_apple_music": "applemusic://track/920536338",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/920536338"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/86611613",
+      "fun_fact": "“Tivoli” is the title track of Steve Angello’s release of the same name.",
+      "fun_fact_de": "„Tivoli“ ist der Titelsong der gleichnamigen Veröffentlichung von Steve Angello.",
+      "fun_fact_es": "«Tivoli» es la canción que da título al lanzamiento homónimo de Steve Angello.",
+      "fun_fact_fr": "« Tivoli » est le morceau-titre de la publication éponyme de Steve Angello.",
+      "fun_fact_nl": "‘Tivoli’ is het titelnummer van de gelijknamige release van Steve Angello.",
+      "alt_artists": [
+        "Dimitri Vegas, Vin, Zion",
+        "Lost Frequencies, Zonderling, Kelvin Jones",
+        "Bastille, Audien"
+      ]
+    },
+    {
+      "artist": "Max Dean, Luke Dean, Locky",
+      "title": "Can't Decide",
+      "year": 2025,
+      "isrc": "GBAHT2500238",
+      "uri": "spotify:track:10pfamFYvg5ftwq6rGJrWx",
+      "uri_apple_music": "applemusic://track/1814833151",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1814833151"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3370485331",
+      "fun_fact": "“Can't Decide” is the title track of Max Dean’s release of the same name.",
+      "fun_fact_de": "„Can't Decide“ ist der Titelsong der gleichnamigen Veröffentlichung von Max Dean.",
+      "fun_fact_es": "«Can't Decide» es la canción que da título al lanzamiento homónimo de Max Dean.",
+      "fun_fact_fr": "« Can't Decide » est le morceau-titre de la publication éponyme de Max Dean.",
+      "fun_fact_nl": "‘Can't Decide’ is het titelnummer van de gelijknamige release van Max Dean.",
+      "alt_artists": [
+        "Avicii, Aloe Blacc",
+        "Duke Dumont, Jax Jones",
+        "Amelie Lens"
+      ]
+    },
+    {
+      "artist": "Above & Beyond",
+      "title": "Can't Sleep - Radio Edit",
+      "year": 2006,
+      "isrc": "GBEWA0600621",
+      "uri": "spotify:track:7imdlxmN8ORoiwbje4KcDy",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/101321498",
+      "fun_fact": "“Can't Sleep - Radio Edit” appears on Above & Beyond’s release “Can't Sleep”.",
+      "fun_fact_de": "„Can't Sleep - Radio Edit“ erschien auf der Veröffentlichung „Can't Sleep“ von Above & Beyond.",
+      "fun_fact_es": "«Can't Sleep - Radio Edit» aparece en el lanzamiento «Can't Sleep» de Above & Beyond.",
+      "fun_fact_fr": "« Can't Sleep - Radio Edit » figure sur la publication « Can't Sleep » de Above & Beyond.",
+      "fun_fact_nl": "‘Can't Sleep - Radio Edit’ staat op de release ‘Can't Sleep’ van Above & Beyond.",
+      "alt_artists": [
+        "Gregory Porter, Claptone",
+        "Hardwell, Blasterjaxx, Mitch Crown",
+        "Galantis"
+      ]
+    },
+    {
+      "artist": "Vintage Culture, Fancy Inc, The Beach",
+      "title": "Cali Dreams (feat. The Beach)",
+      "year": 2021,
+      "isrc": "NLZ542100012",
+      "uri": "spotify:track:4S5uBAB6Jl4IsMzwBpt2Rf",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1222285582",
+      "fun_fact": "“Cali Dreams (feat. The Beach)” is the title track of Vintage Culture’s release of the same name.",
+      "fun_fact_de": "„Cali Dreams (feat. The Beach)“ ist der Titelsong der gleichnamigen Veröffentlichung von Vintage Culture.",
+      "fun_fact_es": "«Cali Dreams (feat. The Beach)» es la canción que da título al lanzamiento homónimo de Vintage Culture.",
+      "fun_fact_fr": "« Cali Dreams (feat. The Beach) » est le morceau-titre de la publication éponyme de Vintage Culture.",
+      "fun_fact_nl": "‘Cali Dreams (feat. The Beach)’ is het titelnummer van de gelijknamige release van Vintage Culture.",
+      "alt_artists": [
+        "Travis Scott, CHASE B",
+        "Diplo, Miguel",
+        "Porter Robinson"
+      ]
+    },
+    {
+      "artist": "Solardo, Eli Brown",
+      "title": "XTC",
+      "year": 2019,
+      "isrc": "USUS11900336",
+      "uri": "spotify:track:7CN6ZYIX338ekn7pb2CpQp",
+      "uri_apple_music": "applemusic://track/1472273911",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1472273911"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/709596432",
+      "fun_fact": "“XTC” is the title track of Solardo’s release of the same name.",
+      "fun_fact_de": "„XTC“ ist der Titelsong der gleichnamigen Veröffentlichung von Solardo.",
+      "fun_fact_es": "«XTC» es la canción que da título al lanzamiento homónimo de Solardo.",
+      "fun_fact_fr": "« XTC » est le morceau-titre de la publication éponyme de Solardo.",
+      "fun_fact_nl": "‘XTC’ is het titelnummer van de gelijknamige release van Solardo.",
+      "alt_artists": [
+        "Calvin Harris, Ellie Goulding",
+        "Tiësto, R3HAB",
+        "Anyma, CamelPhat"
+      ]
+    },
+    {
+      "artist": "The Weeknd, Swedish House Mafia",
+      "title": "Sacrifice (Remix) (feat. Swedish House Mafia)",
+      "year": 2022,
+      "isrc": "USUG12102081",
+      "uri": "spotify:track:4c4qqhFrvOgddweMQS0ptG",
+      "uri_apple_music": "applemusic://track/1641740273",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1641740273"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1881452677",
+      "fun_fact": "“Sacrifice (Remix) (feat. Swedish House Mafia)” appears on The Weeknd’s release “Dawn FM (Alternate World)”.",
+      "fun_fact_de": "„Sacrifice (Remix) (feat. Swedish House Mafia)“ erschien auf der Veröffentlichung „Dawn FM (Alternate World)“ von The Weeknd.",
+      "fun_fact_es": "«Sacrifice (Remix) (feat. Swedish House Mafia)» aparece en el lanzamiento «Dawn FM (Alternate World)» de The Weeknd.",
+      "fun_fact_fr": "« Sacrifice (Remix) (feat. Swedish House Mafia) » figure sur la publication « Dawn FM (Alternate World) » de The Weeknd.",
+      "fun_fact_nl": "‘Sacrifice (Remix) (feat. Swedish House Mafia)’ staat op de release ‘Dawn FM (Alternate World)’ van The Weeknd.",
+      "alt_artists": [
+        "Michael Calfan, Axwell",
+        "Nari, Milani",
+        "Lost Frequencies, Calum Scott"
+      ]
+    },
+    {
+      "artist": "Armin van Buuren, Sunnery James & Ryan Marciano",
+      "title": "You Are",
+      "year": 2017,
+      "isrc": "NLF711706243",
+      "uri": "spotify:track:3d0pwyoTXmomnQXoVLhBQx",
+      "uri_apple_music": "applemusic://track/1258127028",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1258127028"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/382235621",
+      "fun_fact": "“You Are” is the title track of Armin van Buuren’s release of the same name.",
+      "fun_fact_de": "„You Are“ ist der Titelsong der gleichnamigen Veröffentlichung von Armin van Buuren.",
+      "fun_fact_es": "«You Are» es la canción que da título al lanzamiento homónimo de Armin van Buuren.",
+      "fun_fact_fr": "« You Are » est le morceau-titre de la publication éponyme de Armin van Buuren.",
+      "fun_fact_nl": "‘You Are’ is het titelnummer van de gelijknamige release van Armin van Buuren.",
+      "alt_artists": [
+        "Jauz, Netsky",
+        "FISHER, Kita Alexander",
+        "The Magician, Olly Alexander (Years & Years), Watermät"
+      ]
+    },
+    {
+      "artist": "Duck Sauce, A-Trak, Armand Van Helden",
+      "title": "Barbra Streisand - Radio Edit",
+      "year": 2009,
+      "isrc": "GBSXS1000131",
+      "uri": "spotify:track:782lNGn2rEHVn8JomdtRA7",
+      "uri_apple_music": "applemusic://track/1786856061",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1786856061"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3157769181",
+      "fun_fact": "“Barbra Streisand - Radio Edit” appears on Duck Sauce’s release “Barbra Streisand”.",
+      "fun_fact_de": "„Barbra Streisand - Radio Edit“ erschien auf der Veröffentlichung „Barbra Streisand“ von Duck Sauce.",
+      "fun_fact_es": "«Barbra Streisand - Radio Edit» aparece en el lanzamiento «Barbra Streisand» de Duck Sauce.",
+      "fun_fact_fr": "« Barbra Streisand - Radio Edit » figure sur la publication « Barbra Streisand » de Duck Sauce.",
+      "fun_fact_nl": "‘Barbra Streisand - Radio Edit’ staat op de release ‘Barbra Streisand’ van Duck Sauce.",
+      "alt_artists": [
+        "Disciples",
+        "Calvin Harris, Sam Smith, Jessie Reyez",
+        "Axwell, Max C"
+      ]
+    },
+    {
+      "artist": "Wilkinson, Becky Hill",
+      "title": "Afterglow",
+      "year": 2013,
+      "isrc": "GBBZH1391803",
+      "uri": "spotify:track:6LW3Z1GqbL78TIjfDyg4zp",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/88449443",
+      "fun_fact": "“Afterglow” appears on Wilkinson’s release “Lazers Not Included (Extended Edition)”.",
+      "fun_fact_de": "„Afterglow“ erschien auf der Veröffentlichung „Lazers Not Included (Extended Edition)“ von Wilkinson.",
+      "fun_fact_es": "«Afterglow» aparece en el lanzamiento «Lazers Not Included (Extended Edition)» de Wilkinson.",
+      "fun_fact_fr": "« Afterglow » figure sur la publication « Lazers Not Included (Extended Edition) » de Wilkinson.",
+      "fun_fact_nl": "‘Afterglow’ staat op de release ‘Lazers Not Included (Extended Edition)’ van Wilkinson.",
+      "alt_artists": [
+        "Above & Beyond",
+        "felix jaehn, Sandro Cavazza",
+        "Zonderling, Don Diablo"
+      ]
+    },
+    {
+      "artist": "Calvin Harris, Ellie Goulding",
+      "title": "Free (with Ellie Goulding)",
+      "year": 2024,
+      "isrc": "GBARL2401346",
+      "uri": "spotify:track:3NxB1jubUWY6zit9rOk8ZC",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2999128311",
+      "fun_fact": "“Free (with Ellie Goulding)” appears on Calvin Harris’s release “Free (Arielle Free Remix)”.",
+      "fun_fact_de": "„Free (with Ellie Goulding)“ erschien auf der Veröffentlichung „Free (Arielle Free Remix)“ von Calvin Harris.",
+      "fun_fact_es": "«Free (with Ellie Goulding)» aparece en el lanzamiento «Free (Arielle Free Remix)» de Calvin Harris.",
+      "fun_fact_fr": "« Free (with Ellie Goulding) » figure sur la publication « Free (Arielle Free Remix) » de Calvin Harris.",
+      "fun_fact_nl": "‘Free (with Ellie Goulding)’ staat op de release ‘Free (Arielle Free Remix)’ van Calvin Harris.",
+      "alt_artists": [
+        "Matisse & Sadko",
+        "Alesso, DubVision",
+        "Fred again.., The Blessed Madonna"
+      ]
+    },
+    {
+      "artist": "Chris Lake, Alexis Roberts",
+      "title": "Turn off the Lights",
+      "year": 2018,
+      "isrc": "QMDA61831832",
+      "uri": "spotify:track:42CMeHqi0S8sbKvrzLyixS",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3031056271",
+      "fun_fact": "“Turn off the Lights” is the title track of Chris Lake’s release of the same name.",
+      "fun_fact_de": "„Turn off the Lights“ ist der Titelsong der gleichnamigen Veröffentlichung von Chris Lake.",
+      "fun_fact_es": "«Turn off the Lights» es la canción que da título al lanzamiento homónimo de Chris Lake.",
+      "fun_fact_fr": "« Turn off the Lights » est le morceau-titre de la publication éponyme de Chris Lake.",
+      "fun_fact_nl": "‘Turn off the Lights’ is het titelnummer van de gelijknamige release van Chris Lake.",
+      "alt_artists": [
+        "Eli Brown",
+        "Armin van Buuren, The Stickmen Project",
+        "Joel Corry, Da Hool"
+      ]
+    },
+    {
+      "artist": "Southside Spinners",
+      "title": "Luvstruck",
+      "year": 1998,
+      "isrc": "NLNR22000001",
+      "uri": "spotify:track:5kW0BW8B5hjrbpe0OuFUr9",
+      "uri_apple_music": "applemusic://track/1709656884",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1709656884"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2477720371",
+      "fun_fact": "“Luvstruck” is the title track of Southside Spinners’s release of the same name.",
+      "fun_fact_de": "„Luvstruck“ ist der Titelsong der gleichnamigen Veröffentlichung von Southside Spinners.",
+      "fun_fact_es": "«Luvstruck» es la canción que da título al lanzamiento homónimo de Southside Spinners.",
+      "fun_fact_fr": "« Luvstruck » est le morceau-titre de la publication éponyme de Southside Spinners.",
+      "fun_fact_nl": "‘Luvstruck’ is het titelnummer van de gelijknamige release van Southside Spinners.",
+      "alt_artists": [
+        "Calvin Harris, Disciples, Chris Lake",
+        "Jack Ü, Skrillex, Diplo, Kiesza, Tchami",
+        "Anyma, CamelPhat"
+      ]
+    },
+    {
+      "artist": "Jonas Blue, Malive",
+      "title": "Edge of Desire",
+      "year": 2025,
+      "isrc": "GBCPZ2524512",
+      "uri": "spotify:track:4A56h4B9xUuMMXoKuj18HT",
+      "uri_apple_music": "applemusic://track/1821113842",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1821113842"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3410703621",
+      "fun_fact": "“Edge of Desire” is the title track of Jonas Blue’s release of the same name.",
+      "fun_fact_de": "„Edge of Desire“ ist der Titelsong der gleichnamigen Veröffentlichung von Jonas Blue.",
+      "fun_fact_es": "«Edge of Desire» es la canción que da título al lanzamiento homónimo de Jonas Blue.",
+      "fun_fact_fr": "« Edge of Desire » est le morceau-titre de la publication éponyme de Jonas Blue.",
+      "fun_fact_nl": "‘Edge of Desire’ is het titelnummer van de gelijknamige release van Jonas Blue.",
+      "alt_artists": [
+        "Lost Frequencies, Janieck",
+        "San Holo",
+        "Bob Sinclar, FISHER, Steve Edwards"
+      ]
+    },
+    {
+      "artist": "Creeds",
+      "title": "Push Up - Original Mix",
+      "year": 2022,
+      "isrc": "NLCK42223782",
+      "uri": "spotify:track:43OMUa5jouGCZEz9k9vooo",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2190795587",
+      "fun_fact": "“Push Up - Original Mix” is the title track of Creeds’s release of the same name.",
+      "fun_fact_de": "„Push Up - Original Mix“ ist der Titelsong der gleichnamigen Veröffentlichung von Creeds.",
+      "fun_fact_es": "«Push Up - Original Mix» es la canción que da título al lanzamiento homónimo de Creeds.",
+      "fun_fact_fr": "« Push Up - Original Mix » est le morceau-titre de la publication éponyme de Creeds.",
+      "fun_fact_nl": "‘Push Up - Original Mix’ is het titelnummer van de gelijknamige release van Creeds.",
+      "alt_artists": [
+        "Martin Garrix, Matisse & Sadko, Alex Aris",
+        "M83, Eric Prydz",
+        "R3HAB, Deorro"
+      ]
+    },
+    {
+      "artist": "Steve Aoki, KAAZE, John Martin",
+      "title": "Whole Again (feat. John Martin)",
+      "year": 2022,
+      "isrc": "USA2P2226912",
+      "uri": "spotify:track:1OlNRQFvFyg0Hq0dAOju70",
+      "uri_apple_music": "applemusic://track/1724318208",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1724318208"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1926389657",
+      "fun_fact": "“Whole Again (feat. John Martin)” appears on Steve Aoki’s release “HiROQUEST: Genesis”.",
+      "fun_fact_de": "„Whole Again (feat. John Martin)“ erschien auf der Veröffentlichung „HiROQUEST: Genesis“ von Steve Aoki.",
+      "fun_fact_es": "«Whole Again (feat. John Martin)» aparece en el lanzamiento «HiROQUEST: Genesis» de Steve Aoki.",
+      "fun_fact_fr": "« Whole Again (feat. John Martin) » figure sur la publication « HiROQUEST: Genesis » de Steve Aoki.",
+      "fun_fact_nl": "‘Whole Again (feat. John Martin)’ staat op de release ‘HiROQUEST: Genesis’ van Steve Aoki.",
+      "alt_artists": [
+        "Miss Monique",
+        "KETTAMA",
+        "Tiësto, Kirsty Hawkshaw"
+      ]
+    },
+    {
+      "artist": "Kaskade, John Dahlbäck, Sansa",
+      "title": "A Little More (feat. Sansa)",
+      "year": 2014,
+      "isrc": "USWB11508774",
+      "uri": "spotify:track:6SKkN6yuQFnzMEHMQR3sWw",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/107472746",
+      "fun_fact": "“A Little More (feat. Sansa)” appears on Kaskade’s release “Automatic”.",
+      "fun_fact_de": "„A Little More (feat. Sansa)“ erschien auf der Veröffentlichung „Automatic“ von Kaskade.",
+      "fun_fact_es": "«A Little More (feat. Sansa)» aparece en el lanzamiento «Automatic» de Kaskade.",
+      "fun_fact_fr": "« A Little More (feat. Sansa) » figure sur la publication « Automatic » de Kaskade.",
+      "fun_fact_nl": "‘A Little More (feat. Sansa)’ staat op de release ‘Automatic’ van Kaskade.",
+      "alt_artists": [
+        "Kevin de Vries",
+        "David Guetta, Nicky Romero, Sia",
+        "Solid Sessions"
+      ]
+    },
+    {
+      "artist": "Agents Of Time",
+      "title": "Zodiac",
+      "year": 2015,
+      "isrc": "US23A1563640",
+      "uri": "spotify:track:1yZBuUYcA0Ug7Y7ImNdhwt",
+      "uri_apple_music": "applemusic://track/1684480208",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1684480208"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2254329837",
+      "fun_fact": "“Zodiac” is the title track of Agents Of Time’s release of the same name.",
+      "fun_fact_de": "„Zodiac“ ist der Titelsong der gleichnamigen Veröffentlichung von Agents Of Time.",
+      "fun_fact_es": "«Zodiac» es la canción que da título al lanzamiento homónimo de Agents Of Time.",
+      "fun_fact_fr": "« Zodiac » est le morceau-titre de la publication éponyme de Agents Of Time.",
+      "fun_fact_nl": "‘Zodiac’ is het titelnummer van de gelijknamige release van Agents Of Time.",
+      "alt_artists": [
+        "Armin van Buuren, Tempo Giusto",
+        "Stromae, Paul Kalkbrenner",
+        "MK, Chrystal"
+      ]
+    },
+    {
+      "artist": "FISHER",
+      "title": "Wanna Go Dancin'",
+      "year": 2020,
+      "isrc": "QZA742002493",
+      "uri": "spotify:track:2SweUwDKRlXeCDyaJddhWJ",
+      "uri_apple_music": "applemusic://track/1503415448",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1503415448"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/914174522",
+      "fun_fact": "“Wanna Go Dancin'” appears on FISHER’s release “Freaks (EP)”.",
+      "fun_fact_de": "„Wanna Go Dancin'“ erschien auf der Veröffentlichung „Freaks (EP)“ von FISHER.",
+      "fun_fact_es": "«Wanna Go Dancin'» aparece en el lanzamiento «Freaks (EP)» de FISHER.",
+      "fun_fact_fr": "« Wanna Go Dancin' » figure sur la publication « Freaks (EP) » de FISHER.",
+      "fun_fact_nl": "‘Wanna Go Dancin'’ staat op de release ‘Freaks (EP)’ van FISHER.",
+      "alt_artists": [
+        "Justice, Simian",
+        "Lazy Jay",
+        "Alesso, Armin van Buuren"
+      ]
+    },
+    {
+      "artist": "L.P. Rhythm",
+      "title": "Versatile",
+      "year": 2025,
+      "isrc": "USA2P2532235",
+      "uri": "spotify:track:2CX8w6jrSDujqcnkxDMJw0",
+      "uri_apple_music": "applemusic://track/1823646005",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1823646005"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3437335761",
+      "fun_fact": "“Versatile” is the title track of L.P. Rhythm’s release of the same name.",
+      "fun_fact_de": "„Versatile“ ist der Titelsong der gleichnamigen Veröffentlichung von L.P. Rhythm.",
+      "fun_fact_es": "«Versatile» es la canción que da título al lanzamiento homónimo de L.P. Rhythm.",
+      "fun_fact_fr": "« Versatile » est le morceau-titre de la publication éponyme de L.P. Rhythm.",
+      "fun_fact_nl": "‘Versatile’ is het titelnummer van de gelijknamige release van L.P. Rhythm.",
+      "alt_artists": [
+        "Afro Medusa",
+        "Bob Sinclar, Steve Edwards",
+        "Gouryella, Ferry Corsten"
+      ]
+    },
+    {
+      "artist": "David Guetta, Kid Cudi",
+      "title": "Memories (feat. Kid Cudi) - 2021 Remix",
+      "year": 2021,
+      "isrc": "FRZID2000472",
+      "uri": "spotify:track:59o6ojGNGJOYiVJSzC6Lsa",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1197592562",
+      "fun_fact": "“Memories (feat. Kid Cudi) - 2021 Remix” is the title track of David Guetta’s release of the same name.",
+      "fun_fact_de": "„Memories (feat. Kid Cudi) - 2021 Remix“ ist der Titelsong der gleichnamigen Veröffentlichung von David Guetta.",
+      "fun_fact_es": "«Memories (feat. Kid Cudi) - 2021 Remix» es la canción que da título al lanzamiento homónimo de David Guetta.",
+      "fun_fact_fr": "« Memories (feat. Kid Cudi) - 2021 Remix » est le morceau-titre de la publication éponyme de David Guetta.",
+      "fun_fact_nl": "‘Memories (feat. Kid Cudi) - 2021 Remix’ is het titelnummer van de gelijknamige release van David Guetta.",
+      "alt_artists": [
+        "The Bloody Beetroots, Steve Aoki",
+        "Pegassi",
+        "Calvin Harris"
+      ]
+    },
+    {
+      "artist": "Alesso, Sentinel",
+      "title": "Only You",
+      "year": 2022,
+      "isrc": "USUG12201165",
+      "uri": "spotify:track:7mXNYEVh9FW72c12qBaO3p",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1682735327",
+      "fun_fact": "“Only You” is the title track of Alesso’s release of the same name.",
+      "fun_fact_de": "„Only You“ ist der Titelsong der gleichnamigen Veröffentlichung von Alesso.",
+      "fun_fact_es": "«Only You» es la canción que da título al lanzamiento homónimo de Alesso.",
+      "fun_fact_fr": "« Only You » est le morceau-titre de la publication éponyme de Alesso.",
+      "fun_fact_nl": "‘Only You’ is het titelnummer van de gelijknamige release van Alesso.",
+      "alt_artists": [
+        "Sam Feldt, Zonderling",
+        "CamelPhat, Cristoph, Jem Cooke",
+        "Dustin Zahn, Len Faki"
+      ]
+    },
+    {
+      "artist": "Art Of Trance, Ferry Corsten",
+      "title": "Madagascar - Ferry Corsten Remix",
+      "year": 1999,
+      "isrc": "NLF711302724",
+      "uri": "spotify:track:3x55ruWsb6QtuufuCTxymf",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/64760941",
+      "fun_fact": "“Madagascar - Ferry Corsten Remix” appears on Art Of Trance’s release “50 Best Trance Hits Ever, Vol. 2”.",
+      "fun_fact_de": "„Madagascar - Ferry Corsten Remix“ erschien auf der Veröffentlichung „50 Best Trance Hits Ever, Vol. 2“ von Art Of Trance.",
+      "fun_fact_es": "«Madagascar - Ferry Corsten Remix» aparece en el lanzamiento «50 Best Trance Hits Ever, Vol. 2» de Art Of Trance.",
+      "fun_fact_fr": "« Madagascar - Ferry Corsten Remix » figure sur la publication « 50 Best Trance Hits Ever, Vol. 2 » de Art Of Trance.",
+      "fun_fact_nl": "‘Madagascar - Ferry Corsten Remix’ staat op de release ‘50 Best Trance Hits Ever, Vol. 2’ van Art Of Trance.",
+      "alt_artists": [
+        "Niels Van Gogh, Tiësto",
+        "SOFI TUKKER, John Summit, Vintage Culture",
+        "Laidback Luke, Steve Aoki, Lil Jon"
+      ]
+    },
+    {
+      "artist": "Grooveyard, Nicky Romero",
+      "title": "Mary Go Wild - Nicky Romero Remix",
+      "year": 2010,
+      "isrc": "NLC281011060",
+      "uri": "spotify:track:1NXQgcoRONCcxpBlMWuAQc",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/489399542",
+      "fun_fact": "“Mary Go Wild - Nicky Romero Remix” is the title track of Grooveyard’s release of the same name.",
+      "fun_fact_de": "„Mary Go Wild - Nicky Romero Remix“ ist der Titelsong der gleichnamigen Veröffentlichung von Grooveyard.",
+      "fun_fact_es": "«Mary Go Wild - Nicky Romero Remix» es la canción que da título al lanzamiento homónimo de Grooveyard.",
+      "fun_fact_fr": "« Mary Go Wild - Nicky Romero Remix » est le morceau-titre de la publication éponyme de Grooveyard.",
+      "fun_fact_nl": "‘Mary Go Wild - Nicky Romero Remix’ is het titelnummer van de gelijknamige release van Grooveyard.",
+      "alt_artists": [
+        "Diplo, Miguel",
+        "Swedish House Mafia, Connie Constance",
+        "Virtual Self"
+      ]
+    },
+    {
+      "artist": "Disciples",
+      "title": "On My Mind",
+      "year": 2017,
+      "isrc": "GBAYE1700565",
+      "uri": "spotify:track:5Xc74Dn1ZKH6H8XaVGOHXG",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/4157792382",
+      "fun_fact": "“On My Mind” appears on Disciples’s release “Golden Hour House”.",
+      "fun_fact_de": "„On My Mind“ erschien auf der Veröffentlichung „Golden Hour House“ von Disciples.",
+      "fun_fact_es": "«On My Mind» aparece en el lanzamiento «Golden Hour House» de Disciples.",
+      "fun_fact_fr": "« On My Mind » figure sur la publication « Golden Hour House » de Disciples.",
+      "fun_fact_nl": "‘On My Mind’ staat op de release ‘Golden Hour House’ van Disciples.",
+      "alt_artists": [
+        "The Chainsmokers, Bebe Rexha",
+        "Martin Garrix, Sem Vox, Jaimes",
+        "Gotye, FISHER, Chris Lake, Sante Sansone, Kimbra"
+      ]
+    },
+    {
+      "artist": "Dimitri Vegas & Like Mike",
+      "title": "Wakanda",
+      "year": 2013,
+      "isrc": "GBKCF1300228",
+      "uri": "spotify:track:7M2t0mMSjLJSweu8BwrY2R",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/113783762",
+      "fun_fact": "“Wakanda” is the title track of Dimitri Vegas & Like Mike’s release of the same name.",
+      "fun_fact_de": "„Wakanda“ ist der Titelsong der gleichnamigen Veröffentlichung von Dimitri Vegas & Like Mike.",
+      "fun_fact_es": "«Wakanda» es la canción que da título al lanzamiento homónimo de Dimitri Vegas & Like Mike.",
+      "fun_fact_fr": "« Wakanda » est le morceau-titre de la publication éponyme de Dimitri Vegas & Like Mike.",
+      "fun_fact_nl": "‘Wakanda’ is het titelnummer van de gelijknamige release van Dimitri Vegas & Like Mike.",
+      "alt_artists": [
+        "Dimitri Vegas & Like Mike, Bassjackers, D'Angello & Francis",
+        "Tiësto, Oaks",
+        "cassö, RAYE, D-Block Europe"
+      ]
+    },
+    {
+      "artist": "Skrillex, Damian \"Jr Gong\" Marley",
+      "title": "Make It Bun Dem",
+      "year": 2012,
+      "isrc": "USAT21202262",
+      "uri": "spotify:track:6AbVJjzv7thIvmMCuhZrmK",
+      "uri_apple_music": "applemusic://track/555199299",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/555199299"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/25746431",
+      "fun_fact": "“Make It Bun Dem” is the title track of Skrillex’s release of the same name.",
+      "fun_fact_de": "„Make It Bun Dem“ ist der Titelsong der gleichnamigen Veröffentlichung von Skrillex.",
+      "fun_fact_es": "«Make It Bun Dem» es la canción que da título al lanzamiento homónimo de Skrillex.",
+      "fun_fact_fr": "« Make It Bun Dem » est le morceau-titre de la publication éponyme de Skrillex.",
+      "fun_fact_nl": "‘Make It Bun Dem’ is het titelnummer van de gelijknamige release van Skrillex.",
+      "alt_artists": [
+        "Kx5, deadmau5, Kaskade",
+        "Becky Hill, Chase & Status",
+        "Oxia"
+      ]
+    },
+    {
+      "artist": "Tube & Berger",
+      "title": "Imprint of Pleasure",
+      "year": 2014,
+      "isrc": "NL8FJ2600012",
+      "uri": "spotify:track:61fONEULNtnI3qWvhPJjbn",
+      "uri_apple_music": "applemusic://track/992482616",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/992482616"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3762430162",
+      "fun_fact": "“Imprint of Pleasure” is the title track of Tube & Berger’s release of the same name.",
+      "fun_fact_de": "„Imprint of Pleasure“ ist der Titelsong der gleichnamigen Veröffentlichung von Tube & Berger.",
+      "fun_fact_es": "«Imprint of Pleasure» es la canción que da título al lanzamiento homónimo de Tube & Berger.",
+      "fun_fact_fr": "« Imprint of Pleasure » est le morceau-titre de la publication éponyme de Tube & Berger.",
+      "fun_fact_nl": "‘Imprint of Pleasure’ is het titelnummer van de gelijknamige release van Tube & Berger.",
+      "alt_artists": [
+        "Sidney Samson",
+        "Sammy Virji, Skepta",
+        "Pleasurekraft"
+      ]
+    },
+    {
+      "artist": "Gregory Porter, Claptone",
+      "title": "Liquid Spirit - Claptone Remix",
+      "year": 2015,
+      "isrc": "FRUM71500449",
+      "uri": "spotify:track:6wp5tGVNQYpKJPo1s3WUEY",
+      "uri_apple_music": "applemusic://track/1445305132",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1445305132"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/104274582",
+      "fun_fact": "“Liquid Spirit - Claptone Remix” is the title track of Gregory Porter’s release of the same name.",
+      "fun_fact_de": "„Liquid Spirit - Claptone Remix“ ist der Titelsong der gleichnamigen Veröffentlichung von Gregory Porter.",
+      "fun_fact_es": "«Liquid Spirit - Claptone Remix» es la canción que da título al lanzamiento homónimo de Gregory Porter.",
+      "fun_fact_fr": "« Liquid Spirit - Claptone Remix » est le morceau-titre de la publication éponyme de Gregory Porter.",
+      "fun_fact_nl": "‘Liquid Spirit - Claptone Remix’ is het titelnummer van de gelijknamige release van Gregory Porter.",
+      "alt_artists": [
+        "Tiga, Kölsch",
+        "YORK, Kryder",
+        "R3HAB, NERVO, Ummet Ozcan"
+      ]
+    },
+    {
+      "artist": "Martin Garrix, Jay Hardway",
+      "title": "Spotless",
+      "year": 2016,
+      "isrc": "NLM5S1600009",
+      "uri": "spotify:track:3lBoISh2FvtpdQt1lsU9nN",
+      "uri_apple_music": "applemusic://track/1164247047",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1164247047"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/134279760",
+      "fun_fact": "“Spotless” is the title track of Martin Garrix’s release of the same name.",
+      "fun_fact_de": "„Spotless“ ist der Titelsong der gleichnamigen Veröffentlichung von Martin Garrix.",
+      "fun_fact_es": "«Spotless» es la canción que da título al lanzamiento homónimo de Martin Garrix.",
+      "fun_fact_fr": "« Spotless » est le morceau-titre de la publication éponyme de Martin Garrix.",
+      "fun_fact_nl": "‘Spotless’ is het titelnummer van de gelijknamige release van Martin Garrix.",
+      "alt_artists": [
+        "Cloonee, Young M.A, InntRaw, HNTR",
+        "deadmau5, Chris James",
+        "Martin Solveig, Roy Woods"
+      ]
+    },
+    {
+      "artist": "Steve Angello",
+      "title": "Teasing Mr. Charlie - Short Edit",
+      "year": 2006,
+      "isrc": "USYBL1400214",
+      "uri": "spotify:track:7x3g8FPWPinSieU6LlI5wb",
+      "uri_apple_music": "applemusic://track/1052352915",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1052352915"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/81258036",
+      "fun_fact": "“Teasing Mr. Charlie - Short Edit” appears on Steve Angello’s release “Teasing Mr. Charlie / Straight”.",
+      "fun_fact_de": "„Teasing Mr. Charlie - Short Edit“ erschien auf der Veröffentlichung „Teasing Mr. Charlie / Straight“ von Steve Angello.",
+      "fun_fact_es": "«Teasing Mr. Charlie - Short Edit» aparece en el lanzamiento «Teasing Mr. Charlie / Straight» de Steve Angello.",
+      "fun_fact_fr": "« Teasing Mr. Charlie - Short Edit » figure sur la publication « Teasing Mr. Charlie / Straight » de Steve Angello.",
+      "fun_fact_nl": "‘Teasing Mr. Charlie - Short Edit’ staat op de release ‘Teasing Mr. Charlie / Straight’ van Steve Angello.",
+      "alt_artists": [
+        "Robin Schulz, Francesco Yates, Stadiumx",
+        "CYRIL",
+        "Coldplay, Swedish House Mafia"
+      ]
+    },
+    {
+      "artist": "Purple Disco Machine, Kungs, Julian Perretta",
+      "title": "Substitution (feat. Julian Perretta)",
+      "year": 2023,
+      "isrc": "DEE862300093",
+      "uri": "spotify:track:2F2p7b5Xq20mRyEeWYaeUF",
+      "uri_apple_music": "applemusic://track/1676086003",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1676086003"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2180342597",
+      "fun_fact": "“Substitution (feat. Julian Perretta)” is the title track of Purple Disco Machine’s release of the same name.",
+      "fun_fact_de": "„Substitution (feat. Julian Perretta)“ ist der Titelsong der gleichnamigen Veröffentlichung von Purple Disco Machine.",
+      "fun_fact_es": "«Substitution (feat. Julian Perretta)» es la canción que da título al lanzamiento homónimo de Purple Disco Machine.",
+      "fun_fact_fr": "« Substitution (feat. Julian Perretta) » est le morceau-titre de la publication éponyme de Purple Disco Machine.",
+      "fun_fact_nl": "‘Substitution (feat. Julian Perretta)’ is het titelnummer van de gelijknamige release van Purple Disco Machine.",
+      "alt_artists": [
+        "Axwell",
+        "David Guetta, Sia, MORTEN",
+        "Mike Williams"
+      ]
+    },
+    {
+      "artist": "The Prodigy",
+      "title": "No Good (Start the Dance)",
+      "year": 1994,
+      "isrc": "GBBKS9400117",
+      "uri": "spotify:track:2Jb5Qyy37fdGOTJ6iPYq1y",
+      "uri_apple_music": "applemusic://track/1544453964",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1544453964"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/620495822",
+      "fun_fact": "“No Good (Start the Dance)” appears on The Prodigy’s release “Music for the Jilted Generation”.",
+      "fun_fact_de": "„No Good (Start the Dance)“ erschien auf der Veröffentlichung „Music for the Jilted Generation“ von The Prodigy.",
+      "fun_fact_es": "«No Good (Start the Dance)» aparece en el lanzamiento «Music for the Jilted Generation» de The Prodigy.",
+      "fun_fact_fr": "« No Good (Start the Dance) » figure sur la publication « Music for the Jilted Generation » de The Prodigy.",
+      "fun_fact_nl": "‘No Good (Start the Dance)’ staat op de release ‘Music for the Jilted Generation’ van The Prodigy.",
+      "alt_artists": [
+        "Sub Focus, Wilkinson",
+        "Dj Bountyhunter",
+        "Tiga"
+      ]
+    },
+    {
+      "artist": "Tiësto, Mathame",
+      "title": "Everlight",
+      "year": 2025,
+      "isrc": "NLZ542500375",
+      "uri": "spotify:track:4g1gtAETdNfsNT5GBxNW34",
+      "uri_apple_music": "applemusic://track/1819789227",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1819789227"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3422807521",
+      "fun_fact": "“Everlight” is the title track of Tiësto’s release of the same name.",
+      "fun_fact_de": "„Everlight“ ist der Titelsong der gleichnamigen Veröffentlichung von Tiësto.",
+      "fun_fact_es": "«Everlight» es la canción que da título al lanzamiento homónimo de Tiësto.",
+      "fun_fact_fr": "« Everlight » est le morceau-titre de la publication éponyme de Tiësto.",
+      "fun_fact_nl": "‘Everlight’ is het titelnummer van de gelijknamige release van Tiësto.",
+      "alt_artists": [
+        "David Guetta, Kid Cudi",
+        "Tiesto v Diplo, Busta Rhymes",
+        "Eric Prydz, Steve Angello"
+      ]
+    },
+    {
+      "artist": "Nicky Romero, NERVO",
+      "title": "Like Home - Radio Edit",
+      "year": 2012,
+      "isrc": "NLUW21200023",
+      "uri": "spotify:track:5FV75TYvdP3UzXHzE2veFL",
+      "uri_apple_music": "applemusic://track/1019219785",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1019219785"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/73133570",
+      "fun_fact": "“Like Home - Radio Edit” appears on Nicky Romero’s release “Like Home”.",
+      "fun_fact_de": "„Like Home - Radio Edit“ erschien auf der Veröffentlichung „Like Home“ von Nicky Romero.",
+      "fun_fact_es": "«Like Home - Radio Edit» aparece en el lanzamiento «Like Home» de Nicky Romero.",
+      "fun_fact_fr": "« Like Home - Radio Edit » figure sur la publication « Like Home » de Nicky Romero.",
+      "fun_fact_nl": "‘Like Home - Radio Edit’ staat op de release ‘Like Home’ van Nicky Romero.",
+      "alt_artists": [
+        "Vintage Culture, Fancy Inc, The Beach",
+        "Michael Calfan",
+        "Swedish House Mafia, Niki & The Dove"
+      ]
+    },
+    {
+      "artist": "Marc Benjamin, Marcus Santoro, David Pietras",
+      "title": "Losing Focus - Marcus Santoro & David Pietras Mix",
+      "year": 2020,
+      "isrc": "GBKCF2000946",
+      "uri": "spotify:track:01jdO8lv02Qqrejkopan7M",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1111082782",
+      "fun_fact": "“Losing Focus - Marcus Santoro & David Pietras Mix” appears on Marc Benjamin’s release “Losing Focus”.",
+      "fun_fact_de": "„Losing Focus - Marcus Santoro & David Pietras Mix“ erschien auf der Veröffentlichung „Losing Focus“ von Marc Benjamin.",
+      "fun_fact_es": "«Losing Focus - Marcus Santoro & David Pietras Mix» aparece en el lanzamiento «Losing Focus» de Marc Benjamin.",
+      "fun_fact_fr": "« Losing Focus - Marcus Santoro & David Pietras Mix » figure sur la publication « Losing Focus » de Marc Benjamin.",
+      "fun_fact_nl": "‘Losing Focus - Marcus Santoro & David Pietras Mix’ staat op de release ‘Losing Focus’ van Marc Benjamin.",
+      "alt_artists": [
+        "Rebūke, Storm, Jam El Mar",
+        "Tiësto, Oliver Heldens",
+        "Ferry Corsten"
+      ]
+    },
+    {
+      "artist": "David Guetta, Sia, MORTEN",
+      "title": "Let's Love - David Guetta & MORTEN Future Rave Remix",
+      "year": 2020,
+      "isrc": "UKWLH2000009",
+      "uri": "spotify:track:7HXMzmHisLPilu3phwi73h",
+      "uri_apple_music": "applemusic://track/1535686154",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1535686154"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1114694492",
+      "fun_fact": "“Let's Love - David Guetta & MORTEN Future Rave Remix” is the title track of David Guetta’s release of the same name.",
+      "fun_fact_de": "„Let's Love - David Guetta & MORTEN Future Rave Remix“ ist der Titelsong der gleichnamigen Veröffentlichung von David Guetta.",
+      "fun_fact_es": "«Let's Love - David Guetta & MORTEN Future Rave Remix» es la canción que da título al lanzamiento homónimo de David Guetta.",
+      "fun_fact_fr": "« Let's Love - David Guetta & MORTEN Future Rave Remix » est le morceau-titre de la publication éponyme de David Guetta.",
+      "fun_fact_nl": "‘Let's Love - David Guetta & MORTEN Future Rave Remix’ is het titelnummer van de gelijknamige release van David Guetta.",
+      "alt_artists": [
+        "Celeda, Danny Tenaglia",
+        "Arno Cost, Arias",
+        "Jan Blomqvist, Ben Böhmer"
+      ]
+    },
+    {
+      "artist": "Dimension",
+      "title": "Delight",
+      "year": 2011,
+      "isrc": "GB8KE1101935",
+      "uri": "spotify:track:7tv9rZ26Ll3ti8IIbvUjxw",
+      "uri_apple_music": "applemusic://track/493000280",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/493000280"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/16087973",
+      "fun_fact": "“Delight” appears on Dimension’s release “Delight / Death Row”.",
+      "fun_fact_de": "„Delight“ erschien auf der Veröffentlichung „Delight / Death Row“ von Dimension.",
+      "fun_fact_es": "«Delight» aparece en el lanzamiento «Delight / Death Row» de Dimension.",
+      "fun_fact_fr": "« Delight » figure sur la publication « Delight / Death Row » de Dimension.",
+      "fun_fact_nl": "‘Delight’ staat op de release ‘Delight / Death Row’ van Dimension.",
+      "alt_artists": [
+        "Sammy Virji",
+        "Binary Finary, Paul van Dyk",
+        "Young Marco"
+      ]
+    },
+    {
+      "artist": "Camisra",
+      "title": "Let Me Show You - Original Mix",
+      "year": 1998,
+      "isrc": "NLML69800004",
+      "uri": "spotify:track:1V88ZtojKFHgP3YYo5MPps",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2664162732",
+      "fun_fact": "“Let Me Show You - Original Mix” appears on Camisra’s release “Let Me Show You”.",
+      "fun_fact_de": "„Let Me Show You - Original Mix“ erschien auf der Veröffentlichung „Let Me Show You“ von Camisra.",
+      "fun_fact_es": "«Let Me Show You - Original Mix» aparece en el lanzamiento «Let Me Show You» de Camisra.",
+      "fun_fact_fr": "« Let Me Show You - Original Mix » figure sur la publication « Let Me Show You » de Camisra.",
+      "fun_fact_nl": "‘Let Me Show You - Original Mix’ staat op de release ‘Let Me Show You’ van Camisra.",
+      "alt_artists": [
+        "MK, Dom Dolla",
+        "Sonny Fodera, Jazzy, D.O.D",
+        "Calvin Harris, Ne-Yo"
+      ]
+    },
+    {
+      "artist": "Kings Of Tomorrow",
+      "title": "Finally - Original Extended Mix",
+      "year": 2001,
+      "isrc": "GBCPZ0100363",
+      "uri": "spotify:track:5Ec3ROZqvqgwKVgCwzHK7C",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3155445671",
+      "fun_fact": "“Finally - Original Extended Mix” appears on Kings Of Tomorrow’s release “Finally”.",
+      "fun_fact_de": "„Finally - Original Extended Mix“ erschien auf der Veröffentlichung „Finally“ von Kings Of Tomorrow.",
+      "fun_fact_es": "«Finally - Original Extended Mix» aparece en el lanzamiento «Finally» de Kings Of Tomorrow.",
+      "fun_fact_fr": "« Finally - Original Extended Mix » figure sur la publication « Finally » de Kings Of Tomorrow.",
+      "fun_fact_nl": "‘Finally - Original Extended Mix’ staat op de release ‘Finally’ van Kings Of Tomorrow.",
+      "alt_artists": [
+        "Matisse & Sadko",
+        "Chris Lake",
+        "Dimension"
+      ]
+    },
+    {
+      "artist": "AFROJACK",
+      "title": "Never Forget You",
+      "year": 2025,
+      "isrc": "QZTGW2403799",
+      "uri": "spotify:track:5j68TaDRcPBdh27OjKr4l6",
+      "uri_apple_music": "applemusic://track/1798798516",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1798798516"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3282833161",
+      "fun_fact": "“Never Forget You” is the title track of AFROJACK’s release of the same name.",
+      "fun_fact_de": "„Never Forget You“ ist der Titelsong der gleichnamigen Veröffentlichung von AFROJACK.",
+      "fun_fact_es": "«Never Forget You» es la canción que da título al lanzamiento homónimo de AFROJACK.",
+      "fun_fact_fr": "« Never Forget You » est le morceau-titre de la publication éponyme de AFROJACK.",
+      "fun_fact_nl": "‘Never Forget You’ is het titelnummer van de gelijknamige release van AFROJACK.",
+      "alt_artists": [
+        "Armin van Buuren, Sharon Den Adel",
+        "Michael Calfan, Axwell",
+        "Marlon Hoffstadt, FISHER"
+      ]
+    },
+    {
+      "artist": "Notre Dame",
+      "title": "Yumi",
+      "year": 2022,
+      "isrc": "DEDH72200073",
+      "uri": "spotify:track:3AYRPb2JAD4GZ6L6LeHoj5",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2110249107",
+      "fun_fact": "“Yumi” appears on Notre Dame’s release “Yumi EP”.",
+      "fun_fact_de": "„Yumi“ erschien auf der Veröffentlichung „Yumi EP“ von Notre Dame.",
+      "fun_fact_es": "«Yumi» aparece en el lanzamiento «Yumi EP» de Notre Dame.",
+      "fun_fact_fr": "« Yumi » figure sur la publication « Yumi EP » de Notre Dame.",
+      "fun_fact_nl": "‘Yumi’ staat op de release ‘Yumi EP’ van Notre Dame.",
+      "alt_artists": [
+        "Dimitri Vegas & Like Mike, Sander van Doorn",
+        "Martin Garrix, Alesso, Shaun Farrugia",
+        "CamelPhat, Yannis, Foals"
+      ]
+    },
+    {
+      "artist": "C-Mos, Axwell",
+      "title": "2 Million Ways - Axwell Remix",
+      "year": 2004,
+      "isrc": "GBHNV0500005",
+      "uri": "spotify:track:5d0xTYPko4gewEHpJl5ZJy",
+      "uri_apple_music": "applemusic://track/1773621800",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1773621800"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3043878541",
+      "fun_fact": "“2 Million Ways - Axwell Remix” appears on C-Mos’s release “2 Million Ways”.",
+      "fun_fact_de": "„2 Million Ways - Axwell Remix“ erschien auf der Veröffentlichung „2 Million Ways“ von C-Mos.",
+      "fun_fact_es": "«2 Million Ways - Axwell Remix» aparece en el lanzamiento «2 Million Ways» de C-Mos.",
+      "fun_fact_fr": "« 2 Million Ways - Axwell Remix » figure sur la publication « 2 Million Ways » de C-Mos.",
+      "fun_fact_nl": "‘2 Million Ways - Axwell Remix’ staat op de release ‘2 Million Ways’ van C-Mos.",
+      "alt_artists": [
+        "BLOND:ISH, Stevie Appleton",
+        "Solid Sessions",
+        "Purple Disco Machine"
+      ]
+    },
+    {
+      "artist": "Laurent Garnier",
+      "title": "Crispy Bacon",
+      "year": 1996,
+      "isrc": "FRV229700030",
+      "uri": "spotify:track:3PQGdUJ9GTKv0EttfvPlii",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3780534",
+      "fun_fact": "“Crispy Bacon” appears on Laurent Garnier’s release “30”.",
+      "fun_fact_de": "„Crispy Bacon“ erschien auf der Veröffentlichung „30“ von Laurent Garnier.",
+      "fun_fact_es": "«Crispy Bacon» aparece en el lanzamiento «30» de Laurent Garnier.",
+      "fun_fact_fr": "« Crispy Bacon » figure sur la publication « 30 » de Laurent Garnier.",
+      "fun_fact_nl": "‘Crispy Bacon’ staat op de release ‘30’ van Laurent Garnier.",
+      "alt_artists": [
+        "Mr. Probz, Chris Brown, T.I.",
+        "Notre Dame",
+        "Felix"
+      ]
+    },
+    {
+      "artist": "Martin Solveig, Tkay Maidza",
+      "title": "Do It Right",
+      "year": 2016,
+      "isrc": "UK98Q1600001",
+      "uri": "spotify:track:2uMbCJ8lxF7hqpQUaeo42D",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/124992576",
+      "fun_fact": "“Do It Right” is the title track of Martin Solveig’s release of the same name.",
+      "fun_fact_de": "„Do It Right“ ist der Titelsong der gleichnamigen Veröffentlichung von Martin Solveig.",
+      "fun_fact_es": "«Do It Right» es la canción que da título al lanzamiento homónimo de Martin Solveig.",
+      "fun_fact_fr": "« Do It Right » est le morceau-titre de la publication éponyme de Martin Solveig.",
+      "fun_fact_nl": "‘Do It Right’ is het titelnummer van de gelijknamige release van Martin Solveig.",
+      "alt_artists": [
+        "&ME, Rampa, Adam Port, Alan Dixon, Keinemusik, Arabic Piano",
+        "Gareth Emery, Christina Novelli",
+        "Estelle, Lost Frequencies, Kanye West"
+      ]
+    },
+    {
+      "artist": "Tiësto, Kirsty Hawkshaw",
+      "title": "Just Be (feat. Kirsty Hawkshaw)",
+      "year": 2004,
+      "isrc": "NLE710480329",
+      "uri": "spotify:track:2Qe2p6UaFg37XwYEn0PT5T",
+      "uri_apple_music": "applemusic://track/1632332146",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1632332146"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3212473631",
+      "fun_fact": "“Just Be (feat. Kirsty Hawkshaw)” appears on Tiësto’s release “Just Be”.",
+      "fun_fact_de": "„Just Be (feat. Kirsty Hawkshaw)“ erschien auf der Veröffentlichung „Just Be“ von Tiësto.",
+      "fun_fact_es": "«Just Be (feat. Kirsty Hawkshaw)» aparece en el lanzamiento «Just Be» de Tiësto.",
+      "fun_fact_fr": "« Just Be (feat. Kirsty Hawkshaw) » figure sur la publication « Just Be » de Tiësto.",
+      "fun_fact_nl": "‘Just Be (feat. Kirsty Hawkshaw)’ staat op de release ‘Just Be’ van Tiësto.",
+      "alt_artists": [
+        "Martin Garrix, Julian Jordan",
+        "Dom Dolla",
+        "Amber Broos"
+      ]
+    },
+    {
+      "artist": "Jack Ü, Skrillex, Diplo, Kiesza, Tchami",
+      "title": "Take Ü There (feat. Kiesza) - Tchami Remix",
+      "year": 2014,
+      "isrc": "USAT21405322",
+      "uri": "spotify:track:3JLgiop9jcsgYG070rsE9s",
+      "uri_apple_music": "applemusic://track/948362155",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/948362155"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/91579846",
+      "fun_fact": "“Take Ü There (feat. Kiesza) - Tchami Remix” appears on Jack Ü’s release “Take Ü There (feat. Kiesza) (Remixes)”.",
+      "fun_fact_de": "„Take Ü There (feat. Kiesza) - Tchami Remix“ erschien auf der Veröffentlichung „Take Ü There (feat. Kiesza) (Remixes)“ von Jack Ü.",
+      "fun_fact_es": "«Take Ü There (feat. Kiesza) - Tchami Remix» aparece en el lanzamiento «Take Ü There (feat. Kiesza) (Remixes)» de Jack Ü.",
+      "fun_fact_fr": "« Take Ü There (feat. Kiesza) - Tchami Remix » figure sur la publication « Take Ü There (feat. Kiesza) (Remixes) » de Jack Ü.",
+      "fun_fact_nl": "‘Take Ü There (feat. Kiesza) - Tchami Remix’ staat op de release ‘Take Ü There (feat. Kiesza) (Remixes)’ van Jack Ü.",
+      "alt_artists": [
+        "Sub Focus, Wilkinson",
+        "Alesso, Becky Hill",
+        "Axwell /\\ Ingrosso, RØMANS"
+      ]
+    },
+    {
+      "artist": "ARTY",
+      "title": "Save Me Tonight",
+      "year": 2019,
+      "isrc": "NLF711900036",
+      "uri": "spotify:track:1nufXiTCTTAeJfO9hLHvO8",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/617796402",
+      "fun_fact": "“Save Me Tonight” is the title track of ARTY’s release of the same name.",
+      "fun_fact_de": "„Save Me Tonight“ ist der Titelsong der gleichnamigen Veröffentlichung von ARTY.",
+      "fun_fact_es": "«Save Me Tonight» es la canción que da título al lanzamiento homónimo de ARTY.",
+      "fun_fact_fr": "« Save Me Tonight » est le morceau-titre de la publication éponyme de ARTY.",
+      "fun_fact_nl": "‘Save Me Tonight’ is het titelnummer van de gelijknamige release van ARTY.",
+      "alt_artists": [
+        "Hardwell, KSHMR",
+        "The Prodigy",
+        "BLOND:ISH, Stevie Appleton"
+      ]
+    },
+    {
+      "artist": "Bob Sinclar",
+      "title": "Save Our Soul",
+      "year": 2000,
+      "isrc": "FR6V80005137",
+      "uri": "spotify:track:03GHLf15eAt5bSWssIrFbx",
+      "uri_apple_music": "applemusic://track/1732751442",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1732751442"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2676359802",
+      "fun_fact": "“Save Our Soul” appears on Bob Sinclar’s release “Champs Elysées”.",
+      "fun_fact_de": "„Save Our Soul“ erschien auf der Veröffentlichung „Champs Elysées“ von Bob Sinclar.",
+      "fun_fact_es": "«Save Our Soul» aparece en el lanzamiento «Champs Elysées» de Bob Sinclar.",
+      "fun_fact_fr": "« Save Our Soul » figure sur la publication « Champs Elysées » de Bob Sinclar.",
+      "fun_fact_nl": "‘Save Our Soul’ staat op de release ‘Champs Elysées’ van Bob Sinclar.",
+      "alt_artists": [
+        "Kings Of Tomorrow",
+        "Pryda",
+        "Gregor Salto, Florian T"
+      ]
+    },
+    {
+      "artist": "MALUGI, Paul Sirrell",
+      "title": "Be My Lover",
+      "year": 2025,
+      "isrc": "DEE862500269",
+      "uri": "spotify:track:4CMMYnsYsM7gY3Gf7j10yf",
+      "uri_apple_music": "applemusic://track/1796387710",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1796387710"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3234082101",
+      "fun_fact": "“Be My Lover” is the title track of MALUGI’s release of the same name.",
+      "fun_fact_de": "„Be My Lover“ ist der Titelsong der gleichnamigen Veröffentlichung von MALUGI.",
+      "fun_fact_es": "«Be My Lover» es la canción que da título al lanzamiento homónimo de MALUGI.",
+      "fun_fact_fr": "« Be My Lover » est le morceau-titre de la publication éponyme de MALUGI.",
+      "fun_fact_nl": "‘Be My Lover’ is het titelnummer van de gelijknamige release van MALUGI.",
+      "alt_artists": [
+        "Jay Hardway",
+        "ILLENIUM, Valerie Broussard, NURKO",
+        "Bastille, Audien"
+      ]
+    },
+    {
+      "artist": "FISHER, bbyclose",
+      "title": "Blackberries",
+      "year": 2025,
+      "isrc": "QT47L2500031",
+      "uri": "spotify:track:1AS1oLvEr6PNsCLnuEUmCi",
+      "uri_apple_music": "applemusic://track/1824462364",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1824462364"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3443343751",
+      "fun_fact": "“Blackberries” is the title track of FISHER’s release of the same name.",
+      "fun_fact_de": "„Blackberries“ ist der Titelsong der gleichnamigen Veröffentlichung von FISHER.",
+      "fun_fact_es": "«Blackberries» es la canción que da título al lanzamiento homónimo de FISHER.",
+      "fun_fact_fr": "« Blackberries » est le morceau-titre de la publication éponyme de FISHER.",
+      "fun_fact_nl": "‘Blackberries’ is het titelnummer van de gelijknamige release van FISHER.",
+      "alt_artists": [
+        "Eats Everything, Charlotte de Witte",
+        "Marc Benjamin, Marcus Santoro, David Pietras",
+        "MEDUZA, Becky Hill, Goodboys"
+      ]
+    },
+    {
+      "artist": "Gareth Emery",
+      "title": "Long Way Home",
+      "year": 2009,
+      "isrc": "GB2CT0900325",
+      "uri": "spotify:track:5wi8Uqn5zBrtqrEjIecnkg",
+      "uri_apple_music": "applemusic://track/1834540113",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1834540113"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3517854781",
+      "fun_fact": "“Long Way Home” appears on Gareth Emery’s release “Drive”.",
+      "fun_fact_de": "„Long Way Home“ erschien auf der Veröffentlichung „Drive“ von Gareth Emery.",
+      "fun_fact_es": "«Long Way Home» aparece en el lanzamiento «Drive» de Gareth Emery.",
+      "fun_fact_fr": "« Long Way Home » figure sur la publication « Drive » de Gareth Emery.",
+      "fun_fact_nl": "‘Long Way Home’ staat op de release ‘Drive’ van Gareth Emery.",
+      "alt_artists": [
+        "Nicky Romero, NERVO",
+        "Duck Sauce, A-Trak, Armand Van Helden",
+        "Becky Hill, David Guetta"
+      ]
+    },
+    {
+      "artist": "Dom Dolla, Anyma, Daya",
+      "title": "Dreamin (feat. Daya) - Anyma Remix",
+      "year": 2025,
+      "isrc": "USQX92500893",
+      "uri": "spotify:track:7MtmQJPiZiyNbp8Pnjv5e5",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3279213741",
+      "fun_fact": "“Dreamin (feat. Daya) - Anyma Remix” is the title track of Dom Dolla’s release of the same name.",
+      "fun_fact_de": "„Dreamin (feat. Daya) - Anyma Remix“ ist der Titelsong der gleichnamigen Veröffentlichung von Dom Dolla.",
+      "fun_fact_es": "«Dreamin (feat. Daya) - Anyma Remix» es la canción que da título al lanzamiento homónimo de Dom Dolla.",
+      "fun_fact_fr": "« Dreamin (feat. Daya) - Anyma Remix » est le morceau-titre de la publication éponyme de Dom Dolla.",
+      "fun_fact_nl": "‘Dreamin (feat. Daya) - Anyma Remix’ is het titelnummer van de gelijknamige release van Dom Dolla.",
+      "alt_artists": [
+        "Tiësto, The Chainsmokers",
+        "MEDUZA, Goodboys",
+        "Martin Garrix, Clinton Kane"
+      ]
+    },
+    {
+      "artist": "Patrick Topping",
+      "title": "Forget",
+      "year": 2014,
+      "isrc": "GBK6Y1445001",
+      "uri": "spotify:track:7aBOeUzDz8JIhBYYgKZJih",
+      "uri_apple_music": "applemusic://track/1677869070",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1677869070"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2202505457",
+      "fun_fact": "“Forget” appears on Patrick Topping’s release “Boxed Off”.",
+      "fun_fact_de": "„Forget“ erschien auf der Veröffentlichung „Boxed Off“ von Patrick Topping.",
+      "fun_fact_es": "«Forget» aparece en el lanzamiento «Boxed Off» de Patrick Topping.",
+      "fun_fact_fr": "« Forget » figure sur la publication « Boxed Off » de Patrick Topping.",
+      "fun_fact_nl": "‘Forget’ staat op de release ‘Boxed Off’ van Patrick Topping.",
+      "alt_artists": [
+        "HUGEL, Topic, Arash, Daecolm",
+        "Showtek, Justin Prime",
+        "Lost Frequencies"
+      ]
+    },
+    {
+      "artist": "Andain",
+      "title": "Beautiful Things - Radio Edit",
+      "year": 2003,
+      "isrc": "NLE710316553",
+      "uri": "spotify:track:5hcshdvZJcEdipndIXUwzL",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/62397182",
+      "fun_fact": "“Beautiful Things - Radio Edit” appears on Andain’s release “Beautiful Things”.",
+      "fun_fact_de": "„Beautiful Things - Radio Edit“ erschien auf der Veröffentlichung „Beautiful Things“ von Andain.",
+      "fun_fact_es": "«Beautiful Things - Radio Edit» aparece en el lanzamiento «Beautiful Things» de Andain.",
+      "fun_fact_fr": "« Beautiful Things - Radio Edit » figure sur la publication « Beautiful Things » de Andain.",
+      "fun_fact_nl": "‘Beautiful Things - Radio Edit’ staat op de release ‘Beautiful Things’ van Andain.",
+      "alt_artists": [
+        "Yves V, Matthew Hill, Adrian Lux",
+        "Max Dean, Luke Dean, Locky",
+        "Dirty South, Rudy, Axwell"
+      ]
+    },
+    {
+      "artist": "Martin Garrix, R3HAB, Skytech",
+      "title": "Voodoo",
+      "year": 2025,
+      "isrc": "NLM5S2502653",
+      "uri": "spotify:track:7sKCIyN4Sdeo7OBBUeMCfy",
+      "uri_apple_music": "applemusic://track/1838942984",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1838942984"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3549628231",
+      "fun_fact": "“Voodoo” is the title track of Martin Garrix’s release of the same name.",
+      "fun_fact_de": "„Voodoo“ ist der Titelsong der gleichnamigen Veröffentlichung von Martin Garrix.",
+      "fun_fact_es": "«Voodoo» es la canción que da título al lanzamiento homónimo de Martin Garrix.",
+      "fun_fact_fr": "« Voodoo » est le morceau-titre de la publication éponyme de Martin Garrix.",
+      "fun_fact_nl": "‘Voodoo’ is het titelnummer van de gelijknamige release van Martin Garrix.",
+      "alt_artists": [
+        "Joris Voorn",
+        "Dimitri Vegas & Like Mike, Armin van Buuren, W&W",
+        "Moby, Steve Angello"
+      ]
+    },
+    {
+      "artist": "southstar",
+      "title": "Miss You",
+      "year": 2022,
+      "isrc": "DEZC62269331",
+      "uri": "spotify:track:4tRhRLBxIZ34Iw0eCuiC03",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1847938107",
+      "fun_fact": "“Miss You” is the title track of southstar’s release of the same name.",
+      "fun_fact_de": "„Miss You“ ist der Titelsong der gleichnamigen Veröffentlichung von southstar.",
+      "fun_fact_es": "«Miss You» es la canción que da título al lanzamiento homónimo de southstar.",
+      "fun_fact_fr": "« Miss You » est le morceau-titre de la publication éponyme de southstar.",
+      "fun_fact_nl": "‘Miss You’ is het titelnummer van de gelijknamige release van southstar.",
+      "alt_artists": [
+        "Sammy Virji",
+        "Overmono",
+        "Tiësto, BT"
+      ]
+    },
+    {
+      "artist": "Martin Solveig, ALMA",
+      "title": "All Stars",
+      "year": 2017,
+      "isrc": "UK98Q1700100",
+      "uri": "spotify:track:26haJjtanhamtf25RXH0MO",
+      "uri_apple_music": "applemusic://track/1444270836",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1444270836"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/373219601",
+      "fun_fact": "“All Stars” is the title track of Martin Solveig’s release of the same name.",
+      "fun_fact_de": "„All Stars“ ist der Titelsong der gleichnamigen Veröffentlichung von Martin Solveig.",
+      "fun_fact_es": "«All Stars» es la canción que da título al lanzamiento homónimo de Martin Solveig.",
+      "fun_fact_fr": "« All Stars » est le morceau-titre de la publication éponyme de Martin Solveig.",
+      "fun_fact_nl": "‘All Stars’ is het titelnummer van de gelijknamige release van Martin Solveig.",
+      "alt_artists": [
+        "David Guetta, Akon",
+        "R3HAB, Deorro",
+        "Kevin de Vries"
+      ]
+    },
+    {
+      "artist": "Miss Monique",
+      "title": "Magnet",
+      "year": 2025,
+      "isrc": "BE5KW2500684",
+      "uri": "spotify:track:2okNXW6BSeavOvD3aVCyCp",
+      "uri_apple_music": "applemusic://track/1799939402",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1799939402"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3278045671",
+      "fun_fact": "“Magnet” is the title track of Miss Monique’s release of the same name.",
+      "fun_fact_de": "„Magnet“ ist der Titelsong der gleichnamigen Veröffentlichung von Miss Monique.",
+      "fun_fact_es": "«Magnet» es la canción que da título al lanzamiento homónimo de Miss Monique.",
+      "fun_fact_fr": "« Magnet » est le morceau-titre de la publication éponyme de Miss Monique.",
+      "fun_fact_nl": "‘Magnet’ is het titelnummer van de gelijknamige release van Miss Monique.",
+      "alt_artists": [
+        "Alan Fitzpatrick",
+        "John Dahlbäck",
+        "Arno Cost, Arias"
+      ]
+    },
+    {
+      "artist": "Oliver Heldens, Shungudzo",
+      "title": "Fire In My Soul",
+      "year": 2018,
+      "isrc": "USRC11803472",
+      "uri": "spotify:track:0M0FvSNRZmDz0Z769rewlI",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/570030402",
+      "fun_fact": "“Fire In My Soul” appears on Oliver Heldens’s release “Fire In My Soul (feat. Shungudzo)”.",
+      "fun_fact_de": "„Fire In My Soul“ erschien auf der Veröffentlichung „Fire In My Soul (feat. Shungudzo)“ von Oliver Heldens.",
+      "fun_fact_es": "«Fire In My Soul» aparece en el lanzamiento «Fire In My Soul (feat. Shungudzo)» de Oliver Heldens.",
+      "fun_fact_fr": "« Fire In My Soul » figure sur la publication « Fire In My Soul (feat. Shungudzo) » de Oliver Heldens.",
+      "fun_fact_nl": "‘Fire In My Soul’ staat op de release ‘Fire In My Soul (feat. Shungudzo)’ van Oliver Heldens.",
+      "alt_artists": [
+        "AFROJACK, Martin Garrix, David Guetta, Amél",
+        "Calvin Harris, Clementine Douglas, Cassian",
+        "Calvin Harris, Clementine Douglas"
+      ]
+    },
+    {
+      "artist": "Axwell, Sebastian Ingrosso, Steve Angello, Laidback Luke",
+      "title": "Get Dumb - Radio Edit",
+      "year": 2007,
+      "isrc": "GBKCF1800718",
+      "uri": "spotify:track:3Q8lXdOkI6KBlyDLkvwRsS",
+      "uri_apple_music": "applemusic://track/1445850974",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1445850974"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/600991982",
+      "fun_fact": "“Get Dumb - Radio Edit” appears on Axwell’s release “Get Dumb”.",
+      "fun_fact_de": "„Get Dumb - Radio Edit“ erschien auf der Veröffentlichung „Get Dumb“ von Axwell.",
+      "fun_fact_es": "«Get Dumb - Radio Edit» aparece en el lanzamiento «Get Dumb» de Axwell.",
+      "fun_fact_fr": "« Get Dumb - Radio Edit » figure sur la publication « Get Dumb » de Axwell.",
+      "fun_fact_nl": "‘Get Dumb - Radio Edit’ staat op de release ‘Get Dumb’ van Axwell.",
+      "alt_artists": [
+        "Dom Dolla, Daya",
+        "Notre Dame",
+        "Dirty South, Rudy"
+      ]
+    },
+    {
+      "artist": "Armin van Buuren, Agents Of Time, ORKID",
+      "title": "Love Is Eternity",
+      "year": 2024,
+      "isrc": "NLF712407066",
+      "uri": "spotify:track:2U6nirXZWhSFFe1NfFQ7Ly",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2947287451",
+      "fun_fact": "“Love Is Eternity” is the title track of Armin van Buuren’s release of the same name.",
+      "fun_fact_de": "„Love Is Eternity“ ist der Titelsong der gleichnamigen Veröffentlichung von Armin van Buuren.",
+      "fun_fact_es": "«Love Is Eternity» es la canción que da título al lanzamiento homónimo de Armin van Buuren.",
+      "fun_fact_fr": "« Love Is Eternity » est le morceau-titre de la publication éponyme de Armin van Buuren.",
+      "fun_fact_nl": "‘Love Is Eternity’ is het titelnummer van de gelijknamige release van Armin van Buuren.",
+      "alt_artists": [
+        "R3HAB, NERVO, Ummet Ozcan",
+        "Avicii, Aloe Blacc",
+        "Tiësto, The Chainsmokers"
+      ]
+    },
+    {
+      "artist": "Prospa, RAHH",
+      "title": "This Rhythm (feat. RAHH)",
+      "year": 2024,
+      "isrc": "QMDA62467328",
+      "uri": "spotify:track:4NtQwxR7o3ixPVKLyOTS66",
+      "uri_apple_music": "applemusic://track/1796448782",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1796448782"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3234442241",
+      "fun_fact": "“This Rhythm (feat. RAHH)” is the title track of Prospa’s release of the same name.",
+      "fun_fact_de": "„This Rhythm (feat. RAHH)“ ist der Titelsong der gleichnamigen Veröffentlichung von Prospa.",
+      "fun_fact_es": "«This Rhythm (feat. RAHH)» es la canción que da título al lanzamiento homónimo de Prospa.",
+      "fun_fact_fr": "« This Rhythm (feat. RAHH) » est le morceau-titre de la publication éponyme de Prospa.",
+      "fun_fact_nl": "‘This Rhythm (feat. RAHH)’ is het titelnummer van de gelijknamige release van Prospa.",
+      "alt_artists": [
+        "Tomaz, Filterheadz",
+        "Diplo, Paul Woolford, Kareen Lomax",
+        "Eric Prydz"
+      ]
+    },
+    {
+      "artist": "Charlotte de Witte",
+      "title": "Asura",
+      "year": 2021,
+      "isrc": "BE4JP2100005",
+      "uri": "spotify:track:0VuuObMpLGGCMGtPNgG1rp",
+      "uri_apple_music": "applemusic://track/1678403898",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1678403898"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2201976827",
+      "fun_fact": "“Asura” appears on Charlotte de Witte’s release “Asura EP”.",
+      "fun_fact_de": "„Asura“ erschien auf der Veröffentlichung „Asura EP“ von Charlotte de Witte.",
+      "fun_fact_es": "«Asura» aparece en el lanzamiento «Asura EP» de Charlotte de Witte.",
+      "fun_fact_fr": "« Asura » figure sur la publication « Asura EP » de Charlotte de Witte.",
+      "fun_fact_nl": "‘Asura’ staat op de release ‘Asura EP’ van Charlotte de Witte.",
+      "alt_artists": [
+        "Arno Cost, Arias",
+        "Madeon",
+        "Solardo, Eli Brown"
+      ]
+    },
+    {
+      "artist": "Ernesto vs. Bastian, Susana",
+      "title": "Dark Side Of The Moon - Radio Mix",
+      "year": 2005,
+      "isrc": "NLE800500001",
+      "uri": "spotify:track:2qDsgmOlxlmb3MsaKQj4eq",
+      "uri_apple_music": "applemusic://track/1087288641",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1087288641"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/119865260",
+      "fun_fact": "“Dark Side Of The Moon - Radio Mix” appears on Ernesto vs. Bastian’s release “Dark Side Of The Moon”.",
+      "fun_fact_de": "„Dark Side Of The Moon - Radio Mix“ erschien auf der Veröffentlichung „Dark Side Of The Moon“ von Ernesto vs. Bastian.",
+      "fun_fact_es": "«Dark Side Of The Moon - Radio Mix» aparece en el lanzamiento «Dark Side Of The Moon» de Ernesto vs. Bastian.",
+      "fun_fact_fr": "« Dark Side Of The Moon - Radio Mix » figure sur la publication « Dark Side Of The Moon » de Ernesto vs. Bastian.",
+      "fun_fact_nl": "‘Dark Side Of The Moon - Radio Mix’ staat op de release ‘Dark Side Of The Moon’ van Ernesto vs. Bastian.",
+      "alt_artists": [
+        "RAFFA GUIDO",
+        "Armin van Buuren, Mr. Probz",
+        "Cristoph, FEMME"
+      ]
+    },
+    {
+      "artist": "Tiësto, Oaks",
+      "title": "I Follow Rivers",
+      "year": 2025,
+      "isrc": "CYA112400023",
+      "uri": "spotify:track:1aGXmfXBq4koas7v3277P3",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3185112831",
+      "fun_fact": "“I Follow Rivers” appears on Tiësto’s release “Prismatic: Pack One”.",
+      "fun_fact_de": "„I Follow Rivers“ erschien auf der Veröffentlichung „Prismatic: Pack One“ von Tiësto.",
+      "fun_fact_es": "«I Follow Rivers» aparece en el lanzamiento «Prismatic: Pack One» de Tiësto.",
+      "fun_fact_fr": "« I Follow Rivers » figure sur la publication « Prismatic: Pack One » de Tiësto.",
+      "fun_fact_nl": "‘I Follow Rivers’ staat op de release ‘Prismatic: Pack One’ van Tiësto.",
+      "alt_artists": [
+        "The Chainsmokers, Daya, W&W",
+        "Butch, Kölsch",
+        "Kings Of Tomorrow"
+      ]
+    },
+    {
+      "artist": "Dimitri Vegas, Vin, Zion",
+      "title": "Don't Stop (The Music)",
+      "year": 2024,
+      "isrc": "BEIW12400435",
+      "uri": "spotify:track:6x0eMOT5uyCgtmOxzWVATc",
+      "uri_apple_music": "applemusic://track/1750872144",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1750872144"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2836735212",
+      "fun_fact": "“Don't Stop (The Music)” is the title track of Dimitri Vegas’s release of the same name.",
+      "fun_fact_de": "„Don't Stop (The Music)“ ist der Titelsong der gleichnamigen Veröffentlichung von Dimitri Vegas.",
+      "fun_fact_es": "«Don't Stop (The Music)» es la canción que da título al lanzamiento homónimo de Dimitri Vegas.",
+      "fun_fact_fr": "« Don't Stop (The Music) » est le morceau-titre de la publication éponyme de Dimitri Vegas.",
+      "fun_fact_nl": "‘Don't Stop (The Music)’ is het titelnummer van de gelijknamige release van Dimitri Vegas.",
+      "alt_artists": [
+        "Tom Hangs, Shermanology",
+        "Cassian, YOTTO, Da Hool",
+        "Hardwell, KSHMR"
+      ]
+    },
+    {
+      "artist": "Overmono",
+      "title": "So U Kno",
+      "year": 2021,
+      "isrc": "UKLTE2100202",
+      "uri": "spotify:track:1YGxSgWIWqxKuLLocPVxhC",
+      "uri_apple_music": "applemusic://track/1658771254",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1658771254"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2247350867",
+      "fun_fact": "“So U Kno” appears on Overmono’s release “Good Lies”.",
+      "fun_fact_de": "„So U Kno“ erschien auf der Veröffentlichung „Good Lies“ von Overmono.",
+      "fun_fact_es": "«So U Kno» aparece en el lanzamiento «Good Lies» de Overmono.",
+      "fun_fact_fr": "« So U Kno » figure sur la publication « Good Lies » de Overmono.",
+      "fun_fact_nl": "‘So U Kno’ staat op de release ‘Good Lies’ van Overmono.",
+      "alt_artists": [
+        "Noizu",
+        "Zerb, Sofiya Nzau",
+        "Adriatique, WhoMadeWho"
+      ]
+    },
+    {
+      "artist": "Lost Frequencies, The Temper Trap",
+      "title": "Sweet Disposition (a moment, a love)",
+      "year": 2025,
+      "isrc": "BEHP42500007",
+      "uri": "spotify:track:0D57lQnn110jGaup4NguSI",
+      "uri_apple_music": "applemusic://track/1811354631",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1811354631"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3344814521",
+      "fun_fact": "“Sweet Disposition (a moment, a love)” is the title track of Lost Frequencies’s release of the same name.",
+      "fun_fact_de": "„Sweet Disposition (a moment, a love)“ ist der Titelsong der gleichnamigen Veröffentlichung von Lost Frequencies.",
+      "fun_fact_es": "«Sweet Disposition (a moment, a love)» es la canción que da título al lanzamiento homónimo de Lost Frequencies.",
+      "fun_fact_fr": "« Sweet Disposition (a moment, a love) » est le morceau-titre de la publication éponyme de Lost Frequencies.",
+      "fun_fact_nl": "‘Sweet Disposition (a moment, a love)’ is het titelnummer van de gelijknamige release van Lost Frequencies.",
+      "alt_artists": [
+        "Tinlicker, Helsloot",
+        "Dimitri Vegas & Like Mike",
+        "Avicii, Lenny Kravitz"
+      ]
+    },
+    {
+      "artist": "Ninetoes",
+      "title": "Finder - Radio-Edit",
+      "year": 2013,
+      "isrc": "DENC31200194",
+      "uri": "spotify:track:7az0Hd7YKK5UT10M1nG56c",
+      "uri_apple_music": "applemusic://track/1613029099",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1613029099"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1675401917",
+      "fun_fact": "“Finder - Radio-Edit” appears on Ninetoes’s release “Finder”.",
+      "fun_fact_de": "„Finder - Radio-Edit“ erschien auf der Veröffentlichung „Finder“ von Ninetoes.",
+      "fun_fact_es": "«Finder - Radio-Edit» aparece en el lanzamiento «Finder» de Ninetoes.",
+      "fun_fact_fr": "« Finder - Radio-Edit » figure sur la publication « Finder » de Ninetoes.",
+      "fun_fact_nl": "‘Finder - Radio-Edit’ staat op de release ‘Finder’ van Ninetoes.",
+      "alt_artists": [
+        "Maceo Plex, Chromatics",
+        "BLOND:ISH, Stevie Appleton",
+        "Zedd, Matthew Koma"
+      ]
+    },
+    {
+      "artist": "Boys Noize",
+      "title": "Mvinline",
+      "year": 2020,
+      "isrc": "GBCPZ2017509",
+      "uri": "spotify:track:3z1liIZgam8CRi8CaNKyrJ",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3156086611",
+      "fun_fact": "“Mvinline” is the title track of Boys Noize’s release of the same name.",
+      "fun_fact_de": "„Mvinline“ ist der Titelsong der gleichnamigen Veröffentlichung von Boys Noize.",
+      "fun_fact_es": "«Mvinline» es la canción que da título al lanzamiento homónimo de Boys Noize.",
+      "fun_fact_fr": "« Mvinline » est le morceau-titre de la publication éponyme de Boys Noize.",
+      "fun_fact_nl": "‘Mvinline’ is het titelnummer van de gelijknamige release van Boys Noize.",
+      "alt_artists": [
+        "Loofy, Anyma, Layton Giordani",
+        "Netsky",
+        "Tiësto, Hardwell"
+      ]
+    },
+    {
+      "artist": "Djuma Soundsystem",
+      "title": "Les Djinns - Trentemoeller Remix",
+      "year": 2004,
+      "isrc": "FR1HA0407110",
+      "uri": "spotify:track:6M3dYowAaxq2oSPHp1ctwM",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/6556777",
+      "fun_fact": "“Les Djinns - Trentemoeller Remix” appears on Djuma Soundsystem’s release “Kumharas Ibiza vol.2”.",
+      "fun_fact_de": "„Les Djinns - Trentemoeller Remix“ erschien auf der Veröffentlichung „Kumharas Ibiza vol.2“ von Djuma Soundsystem.",
+      "fun_fact_es": "«Les Djinns - Trentemoeller Remix» aparece en el lanzamiento «Kumharas Ibiza vol.2» de Djuma Soundsystem.",
+      "fun_fact_fr": "« Les Djinns - Trentemoeller Remix » figure sur la publication « Kumharas Ibiza vol.2 » de Djuma Soundsystem.",
+      "fun_fact_nl": "‘Les Djinns - Trentemoeller Remix’ staat op de release ‘Kumharas Ibiza vol.2’ van Djuma Soundsystem.",
+      "alt_artists": [
+        "Armin van Buuren, Agents Of Time, ORKID",
+        "AFROJACK, Steve Aoki, Miss Palmer",
+        "Fragma"
+      ]
+    },
+    {
+      "artist": "AlunaGeorge, Tchami",
+      "title": "You Know You Like It - Tchami Remix",
+      "year": 2013,
+      "isrc": "GBUM71504757",
+      "uri": "spotify:track:0OpcI3rARLsNWgVbPdwHD9",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/105355288",
+      "fun_fact": "“You Know You Like It - Tchami Remix” appears on AlunaGeorge’s release “We Are Your Friends (Music From The Original Motion Picture)”.",
+      "fun_fact_de": "„You Know You Like It - Tchami Remix“ erschien auf der Veröffentlichung „We Are Your Friends (Music From The Original Motion Picture)“ von AlunaGeorge.",
+      "fun_fact_es": "«You Know You Like It - Tchami Remix» aparece en el lanzamiento «We Are Your Friends (Music From The Original Motion Picture)» de AlunaGeorge.",
+      "fun_fact_fr": "« You Know You Like It - Tchami Remix » figure sur la publication « We Are Your Friends (Music From The Original Motion Picture) » de AlunaGeorge.",
+      "fun_fact_nl": "‘You Know You Like It - Tchami Remix’ staat op de release ‘We Are Your Friends (Music From The Original Motion Picture)’ van AlunaGeorge.",
+      "alt_artists": [
+        "MEDUZA, James Carter, Elley Duhé, FAST BOY",
+        "Jonas Blue, Malive",
+        "Avicii, Lenny Kravitz"
+      ]
+    },
+    {
+      "artist": "deadmau5",
+      "title": "Avaritia",
+      "year": 2014,
+      "isrc": "GBTDG1300571",
+      "uri": "spotify:track:0yrKF6Fj0dxkltqmBMvcQU",
+      "uri_apple_music": "applemusic://track/1452627120",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1452627120"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/79727550",
+      "fun_fact": "“Avaritia” appears on deadmau5’s release “while(1<2)”.",
+      "fun_fact_de": "„Avaritia“ erschien auf der Veröffentlichung „while(1<2)“ von deadmau5.",
+      "fun_fact_es": "«Avaritia» aparece en el lanzamiento «while(1<2)» de deadmau5.",
+      "fun_fact_fr": "« Avaritia » figure sur la publication « while(1<2) » de deadmau5.",
+      "fun_fact_nl": "‘Avaritia’ staat op de release ‘while(1<2)’ van deadmau5.",
+      "alt_artists": [
+        "Paul Woolford, Diplo, Kareen Lomax",
+        "Martin Garrix, Matisse & Sadko, BARBZ",
+        "Sonny Fodera, MK, Clementine Douglas"
+      ]
+    },
+    {
+      "artist": "Mau P",
+      "title": "TESLA",
+      "year": 2025,
+      "isrc": "NL8RL2530184",
+      "uri": "spotify:track:6qJhrI2BMuA8qHcmycD3fL",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3412358741",
+      "fun_fact": "“TESLA” is the title track of Mau P’s release of the same name.",
+      "fun_fact_de": "„TESLA“ ist der Titelsong der gleichnamigen Veröffentlichung von Mau P.",
+      "fun_fact_es": "«TESLA» es la canción que da título al lanzamiento homónimo de Mau P.",
+      "fun_fact_fr": "« TESLA » est le morceau-titre de la publication éponyme de Mau P.",
+      "fun_fact_nl": "‘TESLA’ is het titelnummer van de gelijknamige release van Mau P.",
+      "alt_artists": [
+        "Charlotte de Witte",
+        "Swedish House Mafia, Alicia Keys",
+        "David Guetta, Chris Willis, Fred Riesterer, Joachim Garraud"
+      ]
+    },
+    {
+      "artist": "Josh Butler, Bontan, Pleasurekraft",
+      "title": "Got A Feeling - Bontan Remix / Pleasurekraft Edit",
+      "year": 2013,
+      "isrc": "GBUM71302832",
+      "uri": "spotify:track:7xnUcBXKvNig0nWojJXXH6",
+      "uri_apple_music": "applemusic://track/720164944",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/720164944"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/71301806",
+      "fun_fact": "“Got A Feeling - Bontan Remix / Pleasurekraft Edit” appears on Josh Butler’s release “Songs for Clubs 2”.",
+      "fun_fact_de": "„Got A Feeling - Bontan Remix / Pleasurekraft Edit“ erschien auf der Veröffentlichung „Songs for Clubs 2“ von Josh Butler.",
+      "fun_fact_es": "«Got A Feeling - Bontan Remix / Pleasurekraft Edit» aparece en el lanzamiento «Songs for Clubs 2» de Josh Butler.",
+      "fun_fact_fr": "« Got A Feeling - Bontan Remix / Pleasurekraft Edit » figure sur la publication « Songs for Clubs 2 » de Josh Butler.",
+      "fun_fact_nl": "‘Got A Feeling - Bontan Remix / Pleasurekraft Edit’ staat op de release ‘Songs for Clubs 2’ van Josh Butler.",
+      "alt_artists": [
+        "Stromae, Paul Kalkbrenner",
+        "Fred again.., Baby Keem",
+        "Dimitri Vegas & Like Mike, Armin van Buuren, W&W"
+      ]
+    },
+    {
+      "artist": "AFROJACK, Lucas & Steve, DubVision",
+      "title": "Anywhere With You - Festival Mix",
+      "year": 2021,
+      "isrc": "CYA222100050",
+      "uri": "spotify:track:76ACIcYIrmgf3ePzLBJRcm",
+      "uri_apple_music": "applemusic://track/1600252153",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1600252153"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1590238412",
+      "fun_fact": "“Anywhere With You - Festival Mix” appears on AFROJACK’s release “Anywhere With You”.",
+      "fun_fact_de": "„Anywhere With You - Festival Mix“ erschien auf der Veröffentlichung „Anywhere With You“ von AFROJACK.",
+      "fun_fact_es": "«Anywhere With You - Festival Mix» aparece en el lanzamiento «Anywhere With You» de AFROJACK.",
+      "fun_fact_fr": "« Anywhere With You - Festival Mix » figure sur la publication « Anywhere With You » de AFROJACK.",
+      "fun_fact_nl": "‘Anywhere With You - Festival Mix’ staat op de release ‘Anywhere With You’ van AFROJACK.",
+      "alt_artists": [
+        "The Chainsmokers, Daya",
+        "Estelle, Lost Frequencies, Kanye West",
+        "Nicky Romero, NERVO"
+      ]
+    },
+    {
+      "artist": "Masters At Work",
+      "title": "Work - Original Mix",
+      "year": 1997,
+      "isrc": "GBCPZ1408130",
+      "uri": "spotify:track:4xZNOqID5j9vu2kjSK95il",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3157347101",
+      "fun_fact": "“Work - Original Mix” appears on Masters At Work’s release “Defected presents House Masters - Masters At Work”.",
+      "fun_fact_de": "„Work - Original Mix“ erschien auf der Veröffentlichung „Defected presents House Masters - Masters At Work“ von Masters At Work.",
+      "fun_fact_es": "«Work - Original Mix» aparece en el lanzamiento «Defected presents House Masters - Masters At Work» de Masters At Work.",
+      "fun_fact_fr": "« Work - Original Mix » figure sur la publication « Defected presents House Masters - Masters At Work » de Masters At Work.",
+      "fun_fact_nl": "‘Work - Original Mix’ staat op de release ‘Defected presents House Masters - Masters At Work’ van Masters At Work.",
+      "alt_artists": [
+        "Yves V, HIDDN",
+        "Calvin Harris, Clementine Douglas, Cassian",
+        "R3HAB, NERVO, Ummet Ozcan"
+      ]
+    },
+    {
+      "artist": "Dennis Ferrer",
+      "title": "Hey Hey - Radio Edit",
+      "year": 2010,
+      "isrc": "GBCPZ1004170",
+      "uri": "spotify:track:3PPbRrWqas3IjoFZTTTPkn",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3155502691",
+      "fun_fact": "“Hey Hey - Radio Edit” appears on Dennis Ferrer’s release “Hey Hey”.",
+      "fun_fact_de": "„Hey Hey - Radio Edit“ erschien auf der Veröffentlichung „Hey Hey“ von Dennis Ferrer.",
+      "fun_fact_es": "«Hey Hey - Radio Edit» aparece en el lanzamiento «Hey Hey» de Dennis Ferrer.",
+      "fun_fact_fr": "« Hey Hey - Radio Edit » figure sur la publication « Hey Hey » de Dennis Ferrer.",
+      "fun_fact_nl": "‘Hey Hey - Radio Edit’ staat op de release ‘Hey Hey’ van Dennis Ferrer.",
+      "alt_artists": [
+        "Pendulum, AN21, Max Vangeli, Steve Angello",
+        "MOGUAI, Cheat Codes",
+        "Nora En Pure"
+      ]
+    },
+    {
+      "artist": "HAVEN., Kaitlin Aragon",
+      "title": "I Run",
+      "year": 2025,
+      "isrc": "CA5KR2603887",
+      "uri": "spotify:track:1WwQ714xuznu44tEnkem2g",
+      "uri_apple_music": "applemusic://track/6767014741",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/6767014741"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3670988772",
+      "fun_fact": "“I Run” is the title track of HAVEN.’s release of the same name.",
+      "fun_fact_de": "„I Run“ ist der Titelsong der gleichnamigen Veröffentlichung von HAVEN..",
+      "fun_fact_es": "«I Run» es la canción que da título al lanzamiento homónimo de HAVEN..",
+      "fun_fact_fr": "« I Run » est le morceau-titre de la publication éponyme de HAVEN..",
+      "fun_fact_nl": "‘I Run’ is het titelnummer van de gelijknamige release van HAVEN..",
+      "alt_artists": [
+        "Digitalism",
+        "Jamback",
+        "Steve Angello, Matisse & Sadko"
+      ]
+    },
+    {
+      "artist": "Solid Sessions",
+      "title": "Janeiro - Original Mix",
+      "year": 2000,
+      "isrc": "NLS240600254",
+      "uri": "spotify:track:3P4WggZjuyThPXzVUHay17",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1584444782",
+      "fun_fact": "“Janeiro - Original Mix” appears on Solid Sessions’s release “Janeiro”.",
+      "fun_fact_de": "„Janeiro - Original Mix“ erschien auf der Veröffentlichung „Janeiro“ von Solid Sessions.",
+      "fun_fact_es": "«Janeiro - Original Mix» aparece en el lanzamiento «Janeiro» de Solid Sessions.",
+      "fun_fact_fr": "« Janeiro - Original Mix » figure sur la publication « Janeiro » de Solid Sessions.",
+      "fun_fact_nl": "‘Janeiro - Original Mix’ staat op de release ‘Janeiro’ van Solid Sessions.",
+      "alt_artists": [
+        "Fred again.., The Blessed Madonna",
+        "David Guetta, Nicky Romero",
+        "CamelPhat, Cristoph, Jem Cooke"
+      ]
+    },
+    {
+      "artist": "John Dahlbäck",
+      "title": "Hustle Up",
+      "year": 2007,
+      "isrc": "DEH740701518",
+      "uri": "spotify:track:4gtPso0YndZufMZohUyHUs",
+      "uri_apple_music": "applemusic://track/1711795897",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1711795897"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/22502021",
+      "fun_fact": "“Hustle Up” appears on John Dahlbäck’s release “Hustle Up / Watch Me”.",
+      "fun_fact_de": "„Hustle Up“ erschien auf der Veröffentlichung „Hustle Up / Watch Me“ von John Dahlbäck.",
+      "fun_fact_es": "«Hustle Up» aparece en el lanzamiento «Hustle Up / Watch Me» de John Dahlbäck.",
+      "fun_fact_fr": "« Hustle Up » figure sur la publication « Hustle Up / Watch Me » de John Dahlbäck.",
+      "fun_fact_nl": "‘Hustle Up’ staat op de release ‘Hustle Up / Watch Me’ van John Dahlbäck.",
+      "alt_artists": [
+        "Ferry Corsten",
+        "Jamback",
+        "AVAION, Sofiya Nzau"
+      ]
+    },
+    {
+      "artist": "SOFI TUKKER, John Summit",
+      "title": "Sun Came Up",
+      "year": 2021,
+      "isrc": "QM37X2100005",
+      "uri": "spotify:track:4OssNR8i2CZHzIBJDxRh2e",
+      "uri_apple_music": "applemusic://track/1762715188",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1762715188"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1665611132",
+      "fun_fact": "“Sun Came Up” appears on SOFI TUKKER’s release “WET TENNIS”.",
+      "fun_fact_de": "„Sun Came Up“ erschien auf der Veröffentlichung „WET TENNIS“ von SOFI TUKKER.",
+      "fun_fact_es": "«Sun Came Up» aparece en el lanzamiento «WET TENNIS» de SOFI TUKKER.",
+      "fun_fact_fr": "« Sun Came Up » figure sur la publication « WET TENNIS » de SOFI TUKKER.",
+      "fun_fact_nl": "‘Sun Came Up’ staat op de release ‘WET TENNIS’ van SOFI TUKKER.",
+      "alt_artists": [
+        "Skrillex, Damian \"Jr Gong\" Marley",
+        "Ernesto vs. Bastian, Susana",
+        "Martin Garrix, Julian Jordan"
+      ]
+    },
+    {
+      "artist": "Rampa, Adam Port, &ME, chuala, Keinemusik",
+      "title": "Say What",
+      "year": 2024,
+      "isrc": "DEEC33501671",
+      "uri": "spotify:track:2GwsSbo6IbNDVvcm9rtmal",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3026091641",
+      "fun_fact": "“Say What” is the title track of Rampa’s release of the same name.",
+      "fun_fact_de": "„Say What“ ist der Titelsong der gleichnamigen Veröffentlichung von Rampa.",
+      "fun_fact_es": "«Say What» es la canción que da título al lanzamiento homónimo de Rampa.",
+      "fun_fact_fr": "« Say What » est le morceau-titre de la publication éponyme de Rampa.",
+      "fun_fact_nl": "‘Say What’ is het titelnummer van de gelijknamige release van Rampa.",
+      "alt_artists": [
+        "Sub Focus",
+        "Martin Garrix, Justin Mylo, Dewain Whitmore",
+        "Alesso, Roy English"
+      ]
+    },
+    {
+      "artist": "Jan Blomqvist, Ben Böhmer",
+      "title": "The Space In Between - Ben Böhmer Remix",
+      "year": 2018,
+      "isrc": "NLF711806853",
+      "uri": "spotify:track:6QcU4iwfLjjsrW7zsqyc1D",
+      "uri_apple_music": "applemusic://track/1400673010",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1400673010"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/515304252",
+      "fun_fact": "“The Space In Between - Ben Böhmer Remix” is the title track of Jan Blomqvist’s release of the same name.",
+      "fun_fact_de": "„The Space In Between - Ben Böhmer Remix“ ist der Titelsong der gleichnamigen Veröffentlichung von Jan Blomqvist.",
+      "fun_fact_es": "«The Space In Between - Ben Böhmer Remix» es la canción que da título al lanzamiento homónimo de Jan Blomqvist.",
+      "fun_fact_fr": "« The Space In Between - Ben Böhmer Remix » est le morceau-titre de la publication éponyme de Jan Blomqvist.",
+      "fun_fact_nl": "‘The Space In Between - Ben Böhmer Remix’ is het titelnummer van de gelijknamige release van Jan Blomqvist.",
+      "alt_artists": [
+        "Daft Punk",
+        "Axwell, Max C",
+        "Dada Life, Sebastian Bach"
+      ]
+    },
+    {
+      "artist": "Tiësto",
+      "title": "The Business",
+      "year": 2020,
+      "isrc": "CYA112000624",
+      "uri": "spotify:track:6f3Slt0GbA2bPZlz0aIFXN",
+      "uri_apple_music": "applemusic://track/1532019310",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1532019310"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1087667882",
+      "fun_fact": "“The Business” is the title track of Tiësto’s release of the same name.",
+      "fun_fact_de": "„The Business“ ist der Titelsong der gleichnamigen Veröffentlichung von Tiësto.",
+      "fun_fact_es": "«The Business» es la canción que da título al lanzamiento homónimo de Tiësto.",
+      "fun_fact_fr": "« The Business » est le morceau-titre de la publication éponyme de Tiësto.",
+      "fun_fact_nl": "‘The Business’ is het titelnummer van de gelijknamige release van Tiësto.",
+      "alt_artists": [
+        "ANOTR, Abel Balder",
+        "Paul Woolford, Kim English",
+        "Chris Lake"
+      ]
+    },
+    {
+      "artist": "Martin Garrix, Mike Yung, Nicky Romero",
+      "title": "Dreamer - Nicky Romero Remix",
+      "year": 2018,
+      "isrc": "NLM5S1800414",
+      "uri": "spotify:track:58ctD8HaEUXJkdv7TTsmG8",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/594373472",
+      "fun_fact": "“Dreamer - Nicky Romero Remix” appears on Martin Garrix’s release “Dreamer (Remixes Vol. 1)”.",
+      "fun_fact_de": "„Dreamer - Nicky Romero Remix“ erschien auf der Veröffentlichung „Dreamer (Remixes Vol. 1)“ von Martin Garrix.",
+      "fun_fact_es": "«Dreamer - Nicky Romero Remix» aparece en el lanzamiento «Dreamer (Remixes Vol. 1)» de Martin Garrix.",
+      "fun_fact_fr": "« Dreamer - Nicky Romero Remix » figure sur la publication « Dreamer (Remixes Vol. 1) » de Martin Garrix.",
+      "fun_fact_nl": "‘Dreamer - Nicky Romero Remix’ staat op de release ‘Dreamer (Remixes Vol. 1)’ van Martin Garrix.",
+      "alt_artists": [
+        "MK, Chrystal",
+        "Ben Böhmer",
+        "Deniz Koyu"
+      ]
+    },
+    {
+      "artist": "Tujamo",
+      "title": "Drop That Low (When I Dip)",
+      "year": 2016,
+      "isrc": "NLZ541501187",
+      "uri": "spotify:track:0WSjVLITbxV6kVXndziQDm",
+      "uri_apple_music": "applemusic://track/1336554980",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1336554980"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/452689552",
+      "fun_fact": "“Drop That Low (When I Dip)” is the title track of Tujamo’s release of the same name.",
+      "fun_fact_de": "„Drop That Low (When I Dip)“ ist der Titelsong der gleichnamigen Veröffentlichung von Tujamo.",
+      "fun_fact_es": "«Drop That Low (When I Dip)» es la canción que da título al lanzamiento homónimo de Tujamo.",
+      "fun_fact_fr": "« Drop That Low (When I Dip) » est le morceau-titre de la publication éponyme de Tujamo.",
+      "fun_fact_nl": "‘Drop That Low (When I Dip)’ is het titelnummer van de gelijknamige release van Tujamo.",
+      "alt_artists": [
+        "Alesso, Katy Perry",
+        "Purple Disco Machine, Kungs, Julian Perretta",
+        "Don Diablo"
+      ]
+    },
+    {
+      "artist": "Topic, Fireboy DML, Nico Santos",
+      "title": "Body",
+      "year": 2025,
+      "isrc": "DECE72502555",
+      "uri": "spotify:track:3hH3ypxqE0JwYq4mfyYmlD",
+      "uri_apple_music": "applemusic://track/1832008809",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1832008809"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3519927181",
+      "fun_fact": "“Body” is the title track of Topic’s release of the same name.",
+      "fun_fact_de": "„Body“ ist der Titelsong der gleichnamigen Veröffentlichung von Topic.",
+      "fun_fact_es": "«Body» es la canción que da título al lanzamiento homónimo de Topic.",
+      "fun_fact_fr": "« Body » est le morceau-titre de la publication éponyme de Topic.",
+      "fun_fact_nl": "‘Body’ is het titelnummer van de gelijknamige release van Topic.",
+      "alt_artists": [
+        "Laidback Luke, Steve Angello",
+        "Martin Solveig, Ina Wroldsen",
+        "Martin Solveig, Roy Woods"
+      ]
+    },
+    {
+      "artist": "Knife Party",
+      "title": "LRAD",
+      "year": 2013,
+      "isrc": "GBAHT1300264",
+      "uri": "spotify:track:4ce29VAx1D8f3HULOHHA3K",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/66890889",
+      "fun_fact": "“LRAD” appears on Knife Party’s release “Haunted House”.",
+      "fun_fact_de": "„LRAD“ erschien auf der Veröffentlichung „Haunted House“ von Knife Party.",
+      "fun_fact_es": "«LRAD» aparece en el lanzamiento «Haunted House» de Knife Party.",
+      "fun_fact_fr": "« LRAD » figure sur la publication « Haunted House » de Knife Party.",
+      "fun_fact_nl": "‘LRAD’ staat op de release ‘Haunted House’ van Knife Party.",
+      "alt_artists": [
+        "Jack Ü, Skrillex, Diplo, Kiesza, Tchami",
+        "Tiësto, Sevenn",
+        "CamelPhat, Cristoph, Jem Cooke"
+      ]
+    },
+    {
+      "artist": "David Guetta, Alphaville, Hypaton, Ava Max",
+      "title": "Forever Young (feat. Ava Max) - Hypaton Remix",
+      "year": 2024,
+      "isrc": "UKWLG2400113",
+      "uri": "spotify:track:2FI0dWAzVHaZtaZv8pWS8s",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3060347951",
+      "fun_fact": "“Forever Young (feat. Ava Max) - Hypaton Remix” appears on David Guetta’s release “Forever Young (Hypaton Remix)”.",
+      "fun_fact_de": "„Forever Young (feat. Ava Max) - Hypaton Remix“ erschien auf der Veröffentlichung „Forever Young (Hypaton Remix)“ von David Guetta.",
+      "fun_fact_es": "«Forever Young (feat. Ava Max) - Hypaton Remix» aparece en el lanzamiento «Forever Young (Hypaton Remix)» de David Guetta.",
+      "fun_fact_fr": "« Forever Young (feat. Ava Max) - Hypaton Remix » figure sur la publication « Forever Young (Hypaton Remix) » de David Guetta.",
+      "fun_fact_nl": "‘Forever Young (feat. Ava Max) - Hypaton Remix’ staat op de release ‘Forever Young (Hypaton Remix)’ van David Guetta.",
+      "alt_artists": [
+        "Sub Focus",
+        "Tom Staar, Eddie Thoneick",
+        "Armand Van Helden"
+      ]
+    },
+    {
+      "artist": "Tchami, Kaleem Taylor",
+      "title": "Promesses - Radio Edit",
+      "year": 2015,
+      "isrc": "GBCEN1401100",
+      "uri": "spotify:track:7BhoFVTlo0gZeG7CNzcbRL",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2347317135",
+      "fun_fact": "“Promesses - Radio Edit” appears on Tchami’s release “Promesses”.",
+      "fun_fact_de": "„Promesses - Radio Edit“ erschien auf der Veröffentlichung „Promesses“ von Tchami.",
+      "fun_fact_es": "«Promesses - Radio Edit» aparece en el lanzamiento «Promesses» de Tchami.",
+      "fun_fact_fr": "« Promesses - Radio Edit » figure sur la publication « Promesses » de Tchami.",
+      "fun_fact_nl": "‘Promesses - Radio Edit’ staat op de release ‘Promesses’ van Tchami.",
+      "alt_artists": [
+        "San Holo",
+        "Öwnboss, Sevek",
+        "Indira Paganotto"
+      ]
+    },
+    {
+      "artist": "HUGEL, Alleh, Yorghaki",
+      "title": "una noche con hugel",
+      "year": 2025,
+      "isrc": "CH7812530335",
+      "uri": "spotify:track:2iamvJ8dFSfapKYEtEYFun",
+      "uri_apple_music": "applemusic://track/1797756367",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1797756367"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3244352251",
+      "fun_fact": "“una noche con hugel” is the title track of HUGEL’s release of the same name.",
+      "fun_fact_de": "„una noche con hugel“ ist der Titelsong der gleichnamigen Veröffentlichung von HUGEL.",
+      "fun_fact_es": "«una noche con hugel» es la canción que da título al lanzamiento homónimo de HUGEL.",
+      "fun_fact_fr": "« una noche con hugel » est le morceau-titre de la publication éponyme de HUGEL.",
+      "fun_fact_nl": "‘una noche con hugel’ is het titelnummer van de gelijknamige release van HUGEL.",
+      "alt_artists": [
+        "Martin Garrix, Tiësto",
+        "Jack Ü, Skrillex, Diplo, Kiesza, Tchami",
+        "Sasha"
+      ]
+    },
+    {
+      "artist": "Skrillex, The Doors, Zedd",
+      "title": "Breakn' a Sweat - Zedd Remix",
+      "year": 2012,
+      "isrc": "USAT21200124",
+      "uri": "spotify:track:3IBMJLY5uN014W1hTzdTRl",
+      "uri_apple_music": "applemusic://track/500886602",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/500886602"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/16501711",
+      "fun_fact": "“Breakn' a Sweat - Zedd Remix” is the title track of Skrillex’s release of the same name.",
+      "fun_fact_de": "„Breakn' a Sweat - Zedd Remix“ ist der Titelsong der gleichnamigen Veröffentlichung von Skrillex.",
+      "fun_fact_es": "«Breakn' a Sweat - Zedd Remix» es la canción que da título al lanzamiento homónimo de Skrillex.",
+      "fun_fact_fr": "« Breakn' a Sweat - Zedd Remix » est le morceau-titre de la publication éponyme de Skrillex.",
+      "fun_fact_nl": "‘Breakn' a Sweat - Zedd Remix’ is het titelnummer van de gelijknamige release van Skrillex.",
+      "alt_artists": [
+        "Jaydee",
+        "BUNT., Nate Traveller",
+        "AVAION, Sofiya Nzau"
+      ]
+    },
+    {
+      "artist": "Secondcity",
+      "title": "I Wanna Feel - Radio Edit",
+      "year": 2014,
+      "isrc": "GBD581400001",
+      "uri": "spotify:track:3PgSGAq2cOat72laH7uKFn",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3806585392",
+      "fun_fact": "“I Wanna Feel - Radio Edit” appears on Secondcity’s release “I Wanna Feel”.",
+      "fun_fact_de": "„I Wanna Feel - Radio Edit“ erschien auf der Veröffentlichung „I Wanna Feel“ von Secondcity.",
+      "fun_fact_es": "«I Wanna Feel - Radio Edit» aparece en el lanzamiento «I Wanna Feel» de Secondcity.",
+      "fun_fact_fr": "« I Wanna Feel - Radio Edit » figure sur la publication « I Wanna Feel » de Secondcity.",
+      "fun_fact_nl": "‘I Wanna Feel - Radio Edit’ staat op de release ‘I Wanna Feel’ van Secondcity.",
+      "alt_artists": [
+        "John Summit, Guz, Stevie Appleton",
+        "Lost Frequencies, Janieck",
+        "Parachute Youth"
+      ]
+    },
+    {
+      "artist": "deadmau5, Wolfgang Gartner",
+      "title": "Animal Rights - Radio Edit",
+      "year": 2010,
+      "isrc": "GBTDG1000190",
+      "uri": "spotify:track:4qty2H7nROmfs2K6aols1I",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/7164536",
+      "fun_fact": "“Animal Rights - Radio Edit” appears on deadmau5’s release “Animal Rights”.",
+      "fun_fact_de": "„Animal Rights - Radio Edit“ erschien auf der Veröffentlichung „Animal Rights“ von deadmau5.",
+      "fun_fact_es": "«Animal Rights - Radio Edit» aparece en el lanzamiento «Animal Rights» de deadmau5.",
+      "fun_fact_fr": "« Animal Rights - Radio Edit » figure sur la publication « Animal Rights » de deadmau5.",
+      "fun_fact_nl": "‘Animal Rights - Radio Edit’ staat op de release ‘Animal Rights’ van deadmau5.",
+      "alt_artists": [
+        "Mike Williams, Mesto",
+        "Lilly Wood and The Prick, Robin Schulz",
+        "Hardwell, KSHMR"
+      ]
+    },
+    {
+      "artist": "Zerb, The Chainsmokers, Ink",
+      "title": "Addicted",
+      "year": 2024,
+      "isrc": "NLRD52350359",
+      "uri": "spotify:track:5ZUIPLoTLJZrPQh2kFZEUM",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2687704402",
+      "fun_fact": "“Addicted” is the title track of Zerb’s release of the same name.",
+      "fun_fact_de": "„Addicted“ ist der Titelsong der gleichnamigen Veröffentlichung von Zerb.",
+      "fun_fact_es": "«Addicted» es la canción que da título al lanzamiento homónimo de Zerb.",
+      "fun_fact_fr": "« Addicted » est le morceau-titre de la publication éponyme de Zerb.",
+      "fun_fact_nl": "‘Addicted’ is het titelnummer van de gelijknamige release van Zerb.",
+      "alt_artists": [
+        "CamelPhat, Elderbrook",
+        "Niels Van Gogh, Tiësto",
+        "Marc Benjamin, Marcus Santoro, David Pietras"
+      ]
+    },
+    {
+      "artist": "Tiësto, 433",
+      "title": "Tomorrow (feat. 433)",
+      "year": 2020,
+      "isrc": "CYA112000447",
+      "uri": "spotify:track:0uH5ORp6Ai5PP0SUofxoc7",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/986669402",
+      "fun_fact": "“Tomorrow (feat. 433)” is the title track of Tiësto’s release of the same name.",
+      "fun_fact_de": "„Tomorrow (feat. 433)“ ist der Titelsong der gleichnamigen Veröffentlichung von Tiësto.",
+      "fun_fact_es": "«Tomorrow (feat. 433)» es la canción que da título al lanzamiento homónimo de Tiësto.",
+      "fun_fact_fr": "« Tomorrow (feat. 433) » est le morceau-titre de la publication éponyme de Tiësto.",
+      "fun_fact_nl": "‘Tomorrow (feat. 433)’ is het titelnummer van de gelijknamige release van Tiësto.",
+      "alt_artists": [
+        "Peggy Gou, Soulwax",
+        "DR. KUCHO!, Gregor Salto, Ane Brun, Oliver Heldens",
+        "David Guetta, Sia, MORTEN"
+      ]
+    },
+    {
+      "artist": "James Hype",
+      "title": "Dancing",
+      "year": 2021,
+      "isrc": "NLZ542101474",
+      "uri": "spotify:track:7xbBNB9bivza5vrYfnZJYg",
+      "uri_apple_music": "applemusic://track/1585687101",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1585687101"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1492935642",
+      "fun_fact": "“Dancing” is the title track of James Hype’s release of the same name.",
+      "fun_fact_de": "„Dancing“ ist der Titelsong der gleichnamigen Veröffentlichung von James Hype.",
+      "fun_fact_es": "«Dancing» es la canción que da título al lanzamiento homónimo de James Hype.",
+      "fun_fact_fr": "« Dancing » est le morceau-titre de la publication éponyme de James Hype.",
+      "fun_fact_nl": "‘Dancing’ is het titelnummer van de gelijknamige release van James Hype.",
+      "alt_artists": [
+        "Eelke Kleijn, Joris Voorn",
+        "ILLENIUM, Valerie Broussard, NURKO",
+        "Tom Staar, Eddie Thoneick"
+      ]
+    },
+    {
+      "artist": "New World Sound, Thomas Newson",
+      "title": "Flute - Radio Mix",
+      "year": 2013,
+      "isrc": "NLZ541300932",
+      "uri": "spotify:track:2HBe1hMofcMQV2n5mhV8zu",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1518476172",
+      "fun_fact": "“Flute - Radio Mix” is the title track of New World Sound’s release of the same name.",
+      "fun_fact_de": "„Flute - Radio Mix“ ist der Titelsong der gleichnamigen Veröffentlichung von New World Sound.",
+      "fun_fact_es": "«Flute - Radio Mix» es la canción que da título al lanzamiento homónimo de New World Sound.",
+      "fun_fact_fr": "« Flute - Radio Mix » est le morceau-titre de la publication éponyme de New World Sound.",
+      "fun_fact_nl": "‘Flute - Radio Mix’ is het titelnummer van de gelijknamige release van New World Sound.",
+      "alt_artists": [
+        "Alesso, Katy Perry",
+        "Axwell, Sebastian Ingrosso",
+        "Dimitri Vegas & Like Mike, Marlon Hoffstadt, Dj Konik, Dimitri Vegas, Like Mike"
+      ]
+    },
+    {
+      "artist": "Soul Central, Danny Krivit",
+      "title": "Strings of Life - Danny Krivit Re-Edit",
+      "year": 2004,
+      "isrc": "GBCPZ0401054",
+      "uri": "spotify:track:5fQpYRySQhXdghsmQesUqe",
+      "uri_apple_music": "applemusic://track/1783935842",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1783935842"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3155417691",
+      "fun_fact": "“Strings of Life - Danny Krivit Re-Edit” appears on Soul Central’s release “Strings Of Life”.",
+      "fun_fact_de": "„Strings of Life - Danny Krivit Re-Edit“ erschien auf der Veröffentlichung „Strings Of Life“ von Soul Central.",
+      "fun_fact_es": "«Strings of Life - Danny Krivit Re-Edit» aparece en el lanzamiento «Strings Of Life» de Soul Central.",
+      "fun_fact_fr": "« Strings of Life - Danny Krivit Re-Edit » figure sur la publication « Strings Of Life » de Soul Central.",
+      "fun_fact_nl": "‘Strings of Life - Danny Krivit Re-Edit’ staat op de release ‘Strings Of Life’ van Soul Central.",
+      "alt_artists": [
+        "David Guetta, Benny Benassi",
+        "Kölsch, Gregor Schwellenbach",
+        "Major Lazer, MØ, DJ Snake"
+      ]
+    },
+    {
+      "artist": "Marshall Jefferson, Solardo",
+      "title": "Move Your Body",
+      "year": 2019,
+      "isrc": "USUS11900546",
+      "uri": "spotify:track:3OrcEhLzxv1YX597jGjEI7",
+      "uri_apple_music": "applemusic://track/1714515537",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1714515537"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/771050902",
+      "fun_fact": "“Move Your Body” is the title track of Marshall Jefferson’s release of the same name.",
+      "fun_fact_de": "„Move Your Body“ ist der Titelsong der gleichnamigen Veröffentlichung von Marshall Jefferson.",
+      "fun_fact_es": "«Move Your Body» es la canción que da título al lanzamiento homónimo de Marshall Jefferson.",
+      "fun_fact_fr": "« Move Your Body » est le morceau-titre de la publication éponyme de Marshall Jefferson.",
+      "fun_fact_nl": "‘Move Your Body’ is het titelnummer van de gelijknamige release van Marshall Jefferson.",
+      "alt_artists": [
+        "Calvin Harris, Clementine Douglas, Cassian",
+        "Alan Walker",
+        "Sebastian Ingrosso, Céline Dion"
+      ]
+    },
+    {
+      "artist": "CYRIL",
+      "title": "Stumblin' In",
+      "year": 2023,
+      "isrc": "NLZ542301810",
+      "uri": "spotify:track:0h3Xy4V4apMraB5NuM8U7Z",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2537448451",
+      "fun_fact": "“Stumblin' In” is the title track of CYRIL’s release of the same name.",
+      "fun_fact_de": "„Stumblin' In“ ist der Titelsong der gleichnamigen Veröffentlichung von CYRIL.",
+      "fun_fact_es": "«Stumblin' In» es la canción que da título al lanzamiento homónimo de CYRIL.",
+      "fun_fact_fr": "« Stumblin' In » est le morceau-titre de la publication éponyme de CYRIL.",
+      "fun_fact_nl": "‘Stumblin' In’ is het titelnummer van de gelijknamige release van CYRIL.",
+      "alt_artists": [
+        "Diplo, Miguel",
+        "PAWSA",
+        "Martin Garrix, Third Party, Oaks, Declan J Donovan"
+      ]
+    },
+    {
+      "artist": "Chris Lake, Marco Lys",
+      "title": "La Tromba",
+      "year": 2010,
+      "isrc": "GBCPZ1004245",
+      "uri": "spotify:track:7fvZVcQBOD6XbIRUew7Ztq",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3155501701",
+      "fun_fact": "“La Tromba” appears on Chris Lake’s release “La Tromba Risin'”.",
+      "fun_fact_de": "„La Tromba“ erschien auf der Veröffentlichung „La Tromba Risin'“ von Chris Lake.",
+      "fun_fact_es": "«La Tromba» aparece en el lanzamiento «La Tromba Risin'» de Chris Lake.",
+      "fun_fact_fr": "« La Tromba » figure sur la publication « La Tromba Risin' » de Chris Lake.",
+      "fun_fact_nl": "‘La Tromba’ staat op de release ‘La Tromba Risin'’ van Chris Lake.",
+      "alt_artists": [
+        "Southside Spinners",
+        "Major Lazer, MØ, DJ Snake",
+        "Dash Berlin"
+      ]
+    },
+    {
+      "artist": "Pryda",
+      "title": "Stay With Me",
+      "year": 2017,
+      "isrc": "GB6CM1700133",
+      "uri": "spotify:track:7twthmMegoAskip42GJocW",
+      "uri_apple_music": "applemusic://track/1318803149",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1318803149"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/435504002",
+      "fun_fact": "“Stay With Me” is the title track of Pryda’s release of the same name.",
+      "fun_fact_de": "„Stay With Me“ ist der Titelsong der gleichnamigen Veröffentlichung von Pryda.",
+      "fun_fact_es": "«Stay With Me» es la canción que da título al lanzamiento homónimo de Pryda.",
+      "fun_fact_fr": "« Stay With Me » est le morceau-titre de la publication éponyme de Pryda.",
+      "fun_fact_nl": "‘Stay With Me’ is het titelnummer van de gelijknamige release van Pryda.",
+      "alt_artists": [
+        "Lost Frequencies, Janieck",
+        "Tiësto, The Chainsmokers",
+        "Hannah Laing, RoRo"
+      ]
+    },
+    {
+      "artist": "Dimitri Vegas & Like Mike, DVBBS, Borgeous",
+      "title": "Stampede",
+      "year": 2012,
+      "isrc": "NLZ541300643",
+      "uri": "spotify:track:6nsP6Cgov9ZV46fZG3AMcw",
+      "uri_apple_music": "applemusic://track/1350837675",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1350837675"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/463375272",
+      "fun_fact": "“Stampede” is the title track of Dimitri Vegas & Like Mike’s release of the same name.",
+      "fun_fact_de": "„Stampede“ ist der Titelsong der gleichnamigen Veröffentlichung von Dimitri Vegas & Like Mike.",
+      "fun_fact_es": "«Stampede» es la canción que da título al lanzamiento homónimo de Dimitri Vegas & Like Mike.",
+      "fun_fact_fr": "« Stampede » est le morceau-titre de la publication éponyme de Dimitri Vegas & Like Mike.",
+      "fun_fact_nl": "‘Stampede’ is het titelnummer van de gelijknamige release van Dimitri Vegas & Like Mike.",
+      "alt_artists": [
+        "Chris Lake, Sammy Virji, Nathan Nicholson",
+        "Prospa, RAHH",
+        "Armin van Buuren, Perpetuous Dreamer"
+      ]
+    },
+    {
+      "artist": "FISHER, Kita Alexander",
+      "title": "Atmosphere",
+      "year": 2023,
+      "isrc": "QZA742318982",
+      "uri": "spotify:track:63HwAAXuSV2tzIUPoHOwZa",
+      "uri_apple_music": "applemusic://track/1754198966",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1754198966"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2400113255",
+      "fun_fact": "“Atmosphere” is the title track of FISHER’s release of the same name.",
+      "fun_fact_de": "„Atmosphere“ ist der Titelsong der gleichnamigen Veröffentlichung von FISHER.",
+      "fun_fact_es": "«Atmosphere» es la canción que da título al lanzamiento homónimo de FISHER.",
+      "fun_fact_fr": "« Atmosphere » est le morceau-titre de la publication éponyme de FISHER.",
+      "fun_fact_nl": "‘Atmosphere’ is het titelnummer van de gelijknamige release van FISHER.",
+      "alt_artists": [
+        "Cloonee, Young M.A, InntRaw, HNTR",
+        "Dimitri Vegas & Like Mike, Brennan Heart, Tony Junior",
+        "David Guetta, Dirty South, Sebastian Ingrosso, Julie McKnight"
+      ]
+    },
+    {
+      "artist": "Bedrock, John Digweed, Nick Muir",
+      "title": "Heaven Scent",
+      "year": 1999,
+      "isrc": "GBEPM0300155",
+      "uri": "spotify:track:1Yqvsi7X3gGOuLRdaOk010",
+      "uri_apple_music": "applemusic://track/1791662127",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1791662127"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2283159247",
+      "fun_fact": "“Heaven Scent” is the title track of Bedrock’s release of the same name.",
+      "fun_fact_de": "„Heaven Scent“ ist der Titelsong der gleichnamigen Veröffentlichung von Bedrock.",
+      "fun_fact_es": "«Heaven Scent» es la canción que da título al lanzamiento homónimo de Bedrock.",
+      "fun_fact_fr": "« Heaven Scent » est le morceau-titre de la publication éponyme de Bedrock.",
+      "fun_fact_nl": "‘Heaven Scent’ is het titelnummer van de gelijknamige release van Bedrock.",
+      "alt_artists": [
+        "Hannah Laing, RoRo",
+        "Chris Lake, Alexis Roberts",
+        "Rolando"
+      ]
+    },
+    {
+      "artist": "Indira Paganotto",
+      "title": "Diabla",
+      "year": 2022,
+      "isrc": "BE4JP2200022",
+      "uri": "spotify:track:7jhnbFPjiETsnctO3eCkVU",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2202189517",
+      "fun_fact": "“Diabla” appears on Indira Paganotto’s release “Lions of God EP”.",
+      "fun_fact_de": "„Diabla“ erschien auf der Veröffentlichung „Lions of God EP“ von Indira Paganotto.",
+      "fun_fact_es": "«Diabla» aparece en el lanzamiento «Lions of God EP» de Indira Paganotto.",
+      "fun_fact_fr": "« Diabla » figure sur la publication « Lions of God EP » de Indira Paganotto.",
+      "fun_fact_nl": "‘Diabla’ staat op de release ‘Lions of God EP’ van Indira Paganotto.",
+      "alt_artists": [
+        "Alan Fitzpatrick",
+        "Diplo, Sonny Fodera",
+        "Tube & Berger"
+      ]
+    },
+    {
+      "artist": "Axwell /\\ Ingrosso, Axwell, Sebastian Ingrosso",
+      "title": "Can't Hold Us Down",
+      "year": 2014,
+      "isrc": "USUG11401849",
+      "uri": "spotify:track:4l6CWRDyGu7mw3UEXXUtls",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/437979132",
+      "fun_fact": "“Can't Hold Us Down” appears on Axwell /\\ Ingrosso’s release “More Than You Know”.",
+      "fun_fact_de": "„Can't Hold Us Down“ erschien auf der Veröffentlichung „More Than You Know“ von Axwell /\\ Ingrosso.",
+      "fun_fact_es": "«Can't Hold Us Down» aparece en el lanzamiento «More Than You Know» de Axwell /\\ Ingrosso.",
+      "fun_fact_fr": "« Can't Hold Us Down » figure sur la publication « More Than You Know » de Axwell /\\ Ingrosso.",
+      "fun_fact_nl": "‘Can't Hold Us Down’ staat op de release ‘More Than You Know’ van Axwell /\\ Ingrosso.",
+      "alt_artists": [
+        "MK, Dom Dolla",
+        "Fatboy Slim, CamelPhat",
+        "Above & Beyond, anamē, Marty Longstaff"
+      ]
+    },
+    {
+      "artist": "Armin van Buuren",
+      "title": "Turn It Up",
+      "year": 2019,
+      "isrc": "NLF711901964",
+      "uri": "spotify:track:0eDI4488gNLeA7pssOZHOD",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/637734852",
+      "fun_fact": "“Turn It Up” is the title track of Armin van Buuren’s release of the same name.",
+      "fun_fact_de": "„Turn It Up“ ist der Titelsong der gleichnamigen Veröffentlichung von Armin van Buuren.",
+      "fun_fact_es": "«Turn It Up» es la canción que da título al lanzamiento homónimo de Armin van Buuren.",
+      "fun_fact_fr": "« Turn It Up » est le morceau-titre de la publication éponyme de Armin van Buuren.",
+      "fun_fact_nl": "‘Turn It Up’ is het titelnummer van de gelijknamige release van Armin van Buuren.",
+      "alt_artists": [
+        "Armin van Buuren, Agents Of Time, ORKID",
+        "Freejak",
+        "Eelke Kleijn, Joris Voorn"
+      ]
+    },
+    {
+      "artist": "Lost Frequencies, The NGHBRS, Keanu Silva",
+      "title": "Like I Love You - Keanu Silva Remix",
+      "year": 2018,
+      "isrc": "NLF711811875",
+      "uri": "spotify:track:73nYqSz1U08iCWfdnG65KV",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/587097462",
+      "fun_fact": "“Like I Love You - Keanu Silva Remix” appears on Lost Frequencies’s release “Like I Love You (Remixes)”.",
+      "fun_fact_de": "„Like I Love You - Keanu Silva Remix“ erschien auf der Veröffentlichung „Like I Love You (Remixes)“ von Lost Frequencies.",
+      "fun_fact_es": "«Like I Love You - Keanu Silva Remix» aparece en el lanzamiento «Like I Love You (Remixes)» de Lost Frequencies.",
+      "fun_fact_fr": "« Like I Love You - Keanu Silva Remix » figure sur la publication « Like I Love You (Remixes) » de Lost Frequencies.",
+      "fun_fact_nl": "‘Like I Love You - Keanu Silva Remix’ staat op de release ‘Like I Love You (Remixes)’ van Lost Frequencies.",
+      "alt_artists": [
+        "Butch, Kölsch",
+        "Diplo, SIDEPIECE",
+        "Tiësto, The Chainsmokers"
+      ]
+    },
+    {
+      "artist": "Svenson & Gielen",
+      "title": "The Beauty Of Silence",
+      "year": 2025,
+      "isrc": "NLE712500650",
+      "uri": "spotify:track:71i8ofnGKFgZFkELusotFs",
+      "uri_apple_music": "applemusic://track/891369990",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/891369990"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3528021801",
+      "fun_fact": "“The Beauty Of Silence” is the title track of Svenson & Gielen’s release of the same name.",
+      "fun_fact_de": "„The Beauty Of Silence“ ist der Titelsong der gleichnamigen Veröffentlichung von Svenson & Gielen.",
+      "fun_fact_es": "«The Beauty Of Silence» es la canción que da título al lanzamiento homónimo de Svenson & Gielen.",
+      "fun_fact_fr": "« The Beauty Of Silence » est le morceau-titre de la publication éponyme de Svenson & Gielen.",
+      "fun_fact_nl": "‘The Beauty Of Silence’ is het titelnummer van de gelijknamige release van Svenson & Gielen.",
+      "alt_artists": [
+        "AN21, Max Vangeli",
+        "Kölsch",
+        "Martin Solveig, Ina Wroldsen"
+      ]
+    },
+    {
+      "artist": "Josh Baker, Omar+",
+      "title": "Back It Up",
+      "year": 2025,
+      "isrc": "US38Y2512970",
+      "uri": "spotify:track:5bdKaYnig6IqBsQQqBUjHm",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3264440221",
+      "fun_fact": "“Back It Up” is the title track of Josh Baker’s release of the same name.",
+      "fun_fact_de": "„Back It Up“ ist der Titelsong der gleichnamigen Veröffentlichung von Josh Baker.",
+      "fun_fact_es": "«Back It Up» es la canción que da título al lanzamiento homónimo de Josh Baker.",
+      "fun_fact_fr": "« Back It Up » est le morceau-titre de la publication éponyme de Josh Baker.",
+      "fun_fact_nl": "‘Back It Up’ is het titelnummer van de gelijknamige release van Josh Baker.",
+      "alt_artists": [
+        "Max Dean, Luke Dean, Locky",
+        "Celeda, Danny Tenaglia",
+        "Eric Prydz, Floyd"
+      ]
+    },
+    {
+      "artist": "Sunnery James & Ryan Marciano, RANI",
+      "title": "Life After You",
+      "year": 2020,
+      "isrc": "NLF712007928",
+      "uri": "spotify:track:2c1BSmrSeBEY9FxhzSiFWh",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1017778342",
+      "fun_fact": "“Life After You” is the title track of Sunnery James & Ryan Marciano’s release of the same name.",
+      "fun_fact_de": "„Life After You“ ist der Titelsong der gleichnamigen Veröffentlichung von Sunnery James & Ryan Marciano.",
+      "fun_fact_es": "«Life After You» es la canción que da título al lanzamiento homónimo de Sunnery James & Ryan Marciano.",
+      "fun_fact_fr": "« Life After You » est le morceau-titre de la publication éponyme de Sunnery James & Ryan Marciano.",
+      "fun_fact_nl": "‘Life After You’ is het titelnummer van de gelijknamige release van Sunnery James & Ryan Marciano.",
+      "alt_artists": [
+        "Filterheadz",
+        "Hypaton, David Guetta, La Bouche",
+        "Steve Angello, Third Party"
+      ]
+    },
+    {
+      "artist": "Booka Shade",
+      "title": "In White Rooms",
+      "year": 2023,
+      "isrc": "DEQ022391024",
+      "uri": "spotify:track:1Hi9I8Qwt1ADYYlzDge3Np",
+      "uri_apple_music": "applemusic://track/6769267879",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/6769267879"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3881255511",
+      "fun_fact": "“In White Rooms” appears on Booka Shade’s release “In White Rooms (2023 Remix)”.",
+      "fun_fact_de": "„In White Rooms“ erschien auf der Veröffentlichung „In White Rooms (2023 Remix)“ von Booka Shade.",
+      "fun_fact_es": "«In White Rooms» aparece en el lanzamiento «In White Rooms (2023 Remix)» de Booka Shade.",
+      "fun_fact_fr": "« In White Rooms » figure sur la publication « In White Rooms (2023 Remix) » de Booka Shade.",
+      "fun_fact_nl": "‘In White Rooms’ staat op de release ‘In White Rooms (2023 Remix)’ van Booka Shade.",
+      "alt_artists": [
+        "Dimitri Vegas, Vin, Zion",
+        "Armin van Buuren, Sunnery James & Ryan Marciano",
+        "Robin Schulz, Jasmine Thompson"
+      ]
+    },
+    {
+      "artist": "Mau P",
+      "title": "MERTHER",
+      "year": 2024,
+      "isrc": "GBCPZ2423810",
+      "uri": "spotify:track:3WBeUXMYcRePMS2DwaNwUD",
+      "uri_apple_music": "applemusic://track/1784012082",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1784012082"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3155552441",
+      "fun_fact": "“MERTHER” is the title track of Mau P’s release of the same name.",
+      "fun_fact_de": "„MERTHER“ ist der Titelsong der gleichnamigen Veröffentlichung von Mau P.",
+      "fun_fact_es": "«MERTHER» es la canción que da título al lanzamiento homónimo de Mau P.",
+      "fun_fact_fr": "« MERTHER » est le morceau-titre de la publication éponyme de Mau P.",
+      "fun_fact_nl": "‘MERTHER’ is het titelnummer van de gelijknamige release van Mau P.",
+      "alt_artists": [
+        "Supermode, MEDUZA",
+        "DubVision, AFROJACK",
+        "deadmau5, Kaskade, Kx5, John Summit, HAYLA"
+      ]
+    },
+    {
+      "artist": "Felix",
+      "title": "Don't You Want Me",
+      "year": 1992,
+      "isrc": "GBARL9200055",
+      "uri": "spotify:track:1pDhEcCl0d2SAQMKljdbys",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/7779520",
+      "fun_fact": "“Don't You Want Me” appears on Felix’s release “Pure... 90s Dance Party”.",
+      "fun_fact_de": "„Don't You Want Me“ erschien auf der Veröffentlichung „Pure... 90s Dance Party“ von Felix.",
+      "fun_fact_es": "«Don't You Want Me» aparece en el lanzamiento «Pure... 90s Dance Party» de Felix.",
+      "fun_fact_fr": "« Don't You Want Me » figure sur la publication « Pure... 90s Dance Party » de Felix.",
+      "fun_fact_nl": "‘Don't You Want Me’ staat op de release ‘Pure... 90s Dance Party’ van Felix.",
+      "alt_artists": [
+        "Tristan Garner, Norman Doray",
+        "Calvin Harris, Sam Smith, Jessie Reyez",
+        "CYRIL"
+      ]
+    },
+    {
+      "artist": "Sammy Virji, Skepta",
+      "title": "Cops & Robbers",
+      "year": 2025,
+      "isrc": "GBUM72501973",
+      "uri": "spotify:track:5pa2ZyJ3dIEmxRDW74msQi",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3380052561",
+      "fun_fact": "“Cops & Robbers” is the title track of Sammy Virji’s release of the same name.",
+      "fun_fact_de": "„Cops & Robbers“ ist der Titelsong der gleichnamigen Veröffentlichung von Sammy Virji.",
+      "fun_fact_es": "«Cops & Robbers» es la canción que da título al lanzamiento homónimo de Sammy Virji.",
+      "fun_fact_fr": "« Cops & Robbers » est le morceau-titre de la publication éponyme de Sammy Virji.",
+      "fun_fact_nl": "‘Cops & Robbers’ is het titelnummer van de gelijknamige release van Sammy Virji.",
+      "alt_artists": [
+        "MK, Dom Dolla",
+        "Black Coffee, David Guetta, Delilah Montagu",
+        "Masters At Work"
+      ]
+    },
+    {
+      "artist": "Cristoph, FEMME",
+      "title": "Alone",
+      "year": 2014,
+      "isrc": "UK74K1400171",
+      "uri": "spotify:track:4Bu5Y6sAxJIIG4vJNdb1kc",
+      "uri_apple_music": "applemusic://track/1173548129",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1173548129"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/135627940",
+      "fun_fact": "“Alone” is the title track of Cristoph’s release of the same name.",
+      "fun_fact_de": "„Alone“ ist der Titelsong der gleichnamigen Veröffentlichung von Cristoph.",
+      "fun_fact_es": "«Alone» es la canción que da título al lanzamiento homónimo de Cristoph.",
+      "fun_fact_fr": "« Alone » est le morceau-titre de la publication éponyme de Cristoph.",
+      "fun_fact_nl": "‘Alone’ is het titelnummer van de gelijknamige release van Cristoph.",
+      "alt_artists": [
+        "Alesso, Zara Larsson",
+        "Dash Berlin",
+        "Henri PFR, Raphaella"
+      ]
+    },
+    {
+      "artist": "ARTBAT, Pete Tong",
+      "title": "Age of Love - ARTBAT Rave Mix",
+      "year": 2022,
+      "isrc": "GBCEN2100224",
+      "uri": "spotify:track:7LHqxlhat0OIf3gCOGnOGr",
+      "uri_apple_music": "applemusic://track/1599726178",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1599726178"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1585938412",
+      "fun_fact": "“Age of Love - ARTBAT Rave Mix” is the title track of ARTBAT’s release of the same name.",
+      "fun_fact_de": "„Age of Love - ARTBAT Rave Mix“ ist der Titelsong der gleichnamigen Veröffentlichung von ARTBAT.",
+      "fun_fact_es": "«Age of Love - ARTBAT Rave Mix» es la canción que da título al lanzamiento homónimo de ARTBAT.",
+      "fun_fact_fr": "« Age of Love - ARTBAT Rave Mix » est le morceau-titre de la publication éponyme de ARTBAT.",
+      "fun_fact_nl": "‘Age of Love - ARTBAT Rave Mix’ is het titelnummer van de gelijknamige release van ARTBAT.",
+      "alt_artists": [
+        "Lost Frequencies, Zonderling, Kelvin Jones",
+        "CamelPhat",
+        "Martin Solveig, Dragonette"
+      ]
+    },
+    {
+      "artist": "Ferry Corsten",
+      "title": "Punk",
+      "year": 2025,
+      "isrc": "NLF712501118",
+      "uri": "spotify:track:74BSVo5XxxlOOWKstr8doF",
+      "uri_apple_music": "applemusic://track/1591326861",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1591326861"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3265468971",
+      "fun_fact": "“Punk” is the title track of Ferry Corsten’s release of the same name.",
+      "fun_fact_de": "„Punk“ ist der Titelsong der gleichnamigen Veröffentlichung von Ferry Corsten.",
+      "fun_fact_es": "«Punk» es la canción que da título al lanzamiento homónimo de Ferry Corsten.",
+      "fun_fact_fr": "« Punk » est le morceau-titre de la publication éponyme de Ferry Corsten.",
+      "fun_fact_nl": "‘Punk’ is het titelnummer van de gelijknamige release van Ferry Corsten.",
+      "alt_artists": [
+        "Monolink, ARTBAT",
+        "Kosheen, Tinlicker",
+        "Sidney Samson"
+      ]
+    },
+    {
+      "artist": "felix jaehn, Sandro Cavazza",
+      "title": "All For Love",
+      "year": 2023,
+      "isrc": "DEUM72305198",
+      "uri": "spotify:track:3ec1mgb7R6yhRvzp3DaTus",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2290906725",
+      "fun_fact": "“All For Love” is the title track of felix jaehn’s release of the same name.",
+      "fun_fact_de": "„All For Love“ ist der Titelsong der gleichnamigen Veröffentlichung von felix jaehn.",
+      "fun_fact_es": "«All For Love» es la canción que da título al lanzamiento homónimo de felix jaehn.",
+      "fun_fact_fr": "« All For Love » est le morceau-titre de la publication éponyme de felix jaehn.",
+      "fun_fact_nl": "‘All For Love’ is het titelnummer van de gelijknamige release van felix jaehn.",
+      "alt_artists": [
+        "Marc Benjamin, Marcus Santoro, David Pietras",
+        "Cajmere, Dajae, Marco Lys, Green Velvet",
+        "Adrian Lux"
+      ]
+    },
+    {
+      "artist": "David Tort, Gosha",
+      "title": "One Look",
+      "year": 2011,
+      "isrc": "GBKCF1100186",
+      "uri": "spotify:track:3khqkr791PuWhlUFCtWtTh",
+      "uri_apple_music": "applemusic://track/627442768",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/627442768"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/73460670",
+      "fun_fact": "“One Look” is the title track of David Tort’s release of the same name.",
+      "fun_fact_de": "„One Look“ ist der Titelsong der gleichnamigen Veröffentlichung von David Tort.",
+      "fun_fact_es": "«One Look» es la canción que da título al lanzamiento homónimo de David Tort.",
+      "fun_fact_fr": "« One Look » est le morceau-titre de la publication éponyme de David Tort.",
+      "fun_fact_nl": "‘One Look’ is het titelnummer van de gelijknamige release van David Tort.",
+      "alt_artists": [
+        "Kölsch",
+        "Junior Jack",
+        "John Dahlbäck"
+      ]
+    },
+    {
+      "artist": "Celeda, Danny Tenaglia",
+      "title": "Music Is the Answer - Original Extended 12-Inch Mix",
+      "year": 2009,
+      "isrc": "USTWR0900003",
+      "uri": "spotify:track:4n8YdXETqQ3NvWs5XNpvar",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/12076558",
+      "fun_fact": "“Music Is the Answer - Original Extended 12-Inch Mix” appears on Celeda’s release “Music Is the Answer (Part 2)”.",
+      "fun_fact_de": "„Music Is the Answer - Original Extended 12-Inch Mix“ erschien auf der Veröffentlichung „Music Is the Answer (Part 2)“ von Celeda.",
+      "fun_fact_es": "«Music Is the Answer - Original Extended 12-Inch Mix» aparece en el lanzamiento «Music Is the Answer (Part 2)» de Celeda.",
+      "fun_fact_fr": "« Music Is the Answer - Original Extended 12-Inch Mix » figure sur la publication « Music Is the Answer (Part 2) » de Celeda.",
+      "fun_fact_nl": "‘Music Is the Answer - Original Extended 12-Inch Mix’ staat op de release ‘Music Is the Answer (Part 2)’ van Celeda.",
+      "alt_artists": [
+        "MK, Dom Dolla",
+        "Armin van Buuren, The Stickmen Project",
+        "Tristan Garner, Norman Doray"
+      ]
+    },
+    {
+      "artist": "Fred again..",
+      "title": "Jungle",
+      "year": 2022,
+      "isrc": "GBAHS2200844",
+      "uri": "spotify:track:31B7wLv4yvtjDoTTmbnxeE",
+      "uri_apple_music": "applemusic://track/1639997595",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1639997595"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1782377777",
+      "fun_fact": "“Jungle” is the title track of Fred again..’s release of the same name.",
+      "fun_fact_de": "„Jungle“ ist der Titelsong der gleichnamigen Veröffentlichung von Fred again...",
+      "fun_fact_es": "«Jungle» es la canción que da título al lanzamiento homónimo de Fred again...",
+      "fun_fact_fr": "« Jungle » est le morceau-titre de la publication éponyme de Fred again...",
+      "fun_fact_nl": "‘Jungle’ is het titelnummer van de gelijknamige release van Fred again...",
+      "alt_artists": [
+        "YORK, Mauro Picotto",
+        "Virtual Self",
+        "Ben Böhmer"
+      ]
+    },
+    {
+      "artist": "Black Coffee, David Guetta, Delilah Montagu",
+      "title": "Drive (feat. Delilah Montagu)",
+      "year": 2018,
+      "isrc": "GB28K1800181",
+      "uri": "spotify:track:33dI106R5aisHtTUVpwGQi",
+      "uri_apple_music": "applemusic://track/1425338283",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1425338283"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/540179602",
+      "fun_fact": "“Drive (feat. Delilah Montagu)” is the title track of Black Coffee’s release of the same name.",
+      "fun_fact_de": "„Drive (feat. Delilah Montagu)“ ist der Titelsong der gleichnamigen Veröffentlichung von Black Coffee.",
+      "fun_fact_es": "«Drive (feat. Delilah Montagu)» es la canción que da título al lanzamiento homónimo de Black Coffee.",
+      "fun_fact_fr": "« Drive (feat. Delilah Montagu) » est le morceau-titre de la publication éponyme de Black Coffee.",
+      "fun_fact_nl": "‘Drive (feat. Delilah Montagu)’ is het titelnummer van de gelijknamige release van Black Coffee.",
+      "alt_artists": [
+        "Diplo, Miguel",
+        "Riva",
+        "Cosmic Gate"
+      ]
+    },
+    {
+      "artist": "Armin van Buuren, Shapov",
+      "title": "La Résistance De L'Amour",
+      "year": 2019,
+      "isrc": "NLF711903188",
+      "uri": "spotify:track:0wNl0JDRupTEnCrfH7KwDs",
+      "uri_apple_music": "applemusic://track/1458852076",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1458852076"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/757592722",
+      "fun_fact": "“La Résistance De L'Amour” appears on Armin van Buuren’s release “Balance”.",
+      "fun_fact_de": "„La Résistance De L'Amour“ erschien auf der Veröffentlichung „Balance“ von Armin van Buuren.",
+      "fun_fact_es": "«La Résistance De L'Amour» aparece en el lanzamiento «Balance» de Armin van Buuren.",
+      "fun_fact_fr": "« La Résistance De L'Amour » figure sur la publication « Balance » de Armin van Buuren.",
+      "fun_fact_nl": "‘La Résistance De L'Amour’ staat op de release ‘Balance’ van Armin van Buuren.",
+      "alt_artists": [
+        "Axwell",
+        "Above & Beyond",
+        "Zedd, Lucky Date, Ellie Goulding"
+      ]
+    },
+    {
+      "artist": "Yves V, Matthew Hill, Adrian Lux",
+      "title": "Teenage Crime",
+      "year": 2019,
+      "isrc": "NLZ541900065",
+      "uri": "spotify:track:22XFmurHz5pbSmM1K8DgIr",
+      "uri_apple_music": "applemusic://track/1449604190",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1449604190"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/624588692",
+      "fun_fact": "“Teenage Crime” is the title track of Yves V’s release of the same name.",
+      "fun_fact_de": "„Teenage Crime“ ist der Titelsong der gleichnamigen Veröffentlichung von Yves V.",
+      "fun_fact_es": "«Teenage Crime» es la canción que da título al lanzamiento homónimo de Yves V.",
+      "fun_fact_fr": "« Teenage Crime » est le morceau-titre de la publication éponyme de Yves V.",
+      "fun_fact_nl": "‘Teenage Crime’ is het titelnummer van de gelijknamige release van Yves V.",
+      "alt_artists": [
+        "Jerome Isma-Ae, Charlotte de Witte",
+        "Oden & Fatzo",
+        "Ahmed Spins, Stevo Atambire"
+      ]
+    },
+    {
+      "artist": "HUGEL, Totó La Momposina",
+      "title": "La Verdolaga",
+      "year": 2024,
+      "isrc": "GBCPZ2423413",
+      "uri": "spotify:track:5PL7k9QH7Kj7B4527dHvon",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3156247951",
+      "fun_fact": "“La Verdolaga” is the title track of HUGEL’s release of the same name.",
+      "fun_fact_de": "„La Verdolaga“ ist der Titelsong der gleichnamigen Veröffentlichung von HUGEL.",
+      "fun_fact_es": "«La Verdolaga» es la canción que da título al lanzamiento homónimo de HUGEL.",
+      "fun_fact_fr": "« La Verdolaga » est le morceau-titre de la publication éponyme de HUGEL.",
+      "fun_fact_nl": "‘La Verdolaga’ is het titelnummer van de gelijknamige release van HUGEL.",
+      "alt_artists": [
+        "Martin Garrix, Tiësto",
+        "Joel Corry, James Hype",
+        "Dubfire"
+      ]
+    },
+    {
+      "artist": "FISHER",
+      "title": "Stay",
+      "year": 2025,
+      "isrc": "QT47L2500008",
+      "uri": "spotify:track:74y1VgzL668hynrvA59WQB",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3245560861",
+      "fun_fact": "“Stay” is the title track of FISHER’s release of the same name.",
+      "fun_fact_de": "„Stay“ ist der Titelsong der gleichnamigen Veröffentlichung von FISHER.",
+      "fun_fact_es": "«Stay» es la canción que da título al lanzamiento homónimo de FISHER.",
+      "fun_fact_fr": "« Stay » est le morceau-titre de la publication éponyme de FISHER.",
+      "fun_fact_nl": "‘Stay’ is het titelnummer van de gelijknamige release van FISHER.",
+      "alt_artists": [
+        "Chris Brown, Benny Benassi",
+        "Josh Baker, Omar+",
+        "The Chainsmokers, Daya"
+      ]
+    },
+    {
+      "artist": "YORK",
+      "title": "The Awakening",
+      "year": 2018,
+      "isrc": "NLF711804848",
+      "uri": "spotify:track:1IDqx3eZIPQ5WzTfLXAzxG",
+      "uri_apple_music": "applemusic://track/1620334184",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1620334184"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/510689692",
+      "fun_fact": "“The Awakening” appears on YORK’s release “The Awakening 2018”.",
+      "fun_fact_de": "„The Awakening“ erschien auf der Veröffentlichung „The Awakening 2018“ von YORK.",
+      "fun_fact_es": "«The Awakening» aparece en el lanzamiento «The Awakening 2018» de YORK.",
+      "fun_fact_fr": "« The Awakening » figure sur la publication « The Awakening 2018 » de YORK.",
+      "fun_fact_nl": "‘The Awakening’ staat op de release ‘The Awakening 2018’ van YORK.",
+      "alt_artists": [
+        "Binary Finary, Paul van Dyk",
+        "Mark Knight, Funkagenda",
+        "Adriatique, Marino Canal, Delhia De France"
+      ]
+    },
+    {
+      "artist": "Martin Garrix, Jex",
+      "title": "Told You So",
+      "year": 2024,
+      "isrc": "NLM5S2402334",
+      "uri": "spotify:track:52dEZA0A4siRTuA4e8w3ll",
+      "uri_apple_music": "applemusic://track/1780514143",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1780514143"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3099615151",
+      "fun_fact": "“Told You So” is the title track of Martin Garrix’s release of the same name.",
+      "fun_fact_de": "„Told You So“ ist der Titelsong der gleichnamigen Veröffentlichung von Martin Garrix.",
+      "fun_fact_es": "«Told You So» es la canción que da título al lanzamiento homónimo de Martin Garrix.",
+      "fun_fact_fr": "« Told You So » est le morceau-titre de la publication éponyme de Martin Garrix.",
+      "fun_fact_nl": "‘Told You So’ is het titelnummer van de gelijknamige release van Martin Garrix.",
+      "alt_artists": [
+        "ODESZA, Cedric Gervais, Zyra",
+        "Black Coffee, David Guetta, Delilah Montagu",
+        "KAAZE, Alina Pozi"
+      ]
+    },
+    {
+      "artist": "Charlotte de Witte",
+      "title": "Apollo",
+      "year": 2022,
+      "isrc": "BE4JP2200018",
+      "uri": "spotify:track:7sNp24ekO02LkwhV7kBh3Z",
+      "uri_apple_music": "applemusic://track/1678181925",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1678181925"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2201970427",
+      "fun_fact": "“Apollo” appears on Charlotte de Witte’s release “Apollo EP”.",
+      "fun_fact_de": "„Apollo“ erschien auf der Veröffentlichung „Apollo EP“ von Charlotte de Witte.",
+      "fun_fact_es": "«Apollo» aparece en el lanzamiento «Apollo EP» de Charlotte de Witte.",
+      "fun_fact_fr": "« Apollo » figure sur la publication « Apollo EP » de Charlotte de Witte.",
+      "fun_fact_nl": "‘Apollo’ staat op de release ‘Apollo EP’ van Charlotte de Witte.",
+      "alt_artists": [
+        "Lucas & Steve, Tungevaag",
+        "London Grammar",
+        "Laidback Luke, Steve Angello"
+      ]
+    },
+    {
+      "artist": "Amine Edge & DANCE, Blaze (Kevin Hedge)",
+      "title": "Lovelee Dae",
+      "year": 2017,
+      "isrc": "GBCPZ1712198",
+      "uri": "spotify:track:4UVg81quFYDRTikOakqV2G",
+      "uri_apple_music": "applemusic://track/1783935433",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1783935433"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3155856791",
+      "fun_fact": "“Lovelee Dae” is the title track of Amine Edge & DANCE’s release of the same name.",
+      "fun_fact_de": "„Lovelee Dae“ ist der Titelsong der gleichnamigen Veröffentlichung von Amine Edge & DANCE.",
+      "fun_fact_es": "«Lovelee Dae» es la canción que da título al lanzamiento homónimo de Amine Edge & DANCE.",
+      "fun_fact_fr": "« Lovelee Dae » est le morceau-titre de la publication éponyme de Amine Edge & DANCE.",
+      "fun_fact_nl": "‘Lovelee Dae’ is het titelnummer van de gelijknamige release van Amine Edge & DANCE.",
+      "alt_artists": [
+        "David Guetta, Sia, MORTEN",
+        "Borai & Denham Audio, Franky Rizardo",
+        "Peggy Gou"
+      ]
+    },
+    {
+      "artist": "Pleasurekraft",
+      "title": "Tarantula",
+      "year": 2017,
+      "isrc": "US7NS1700006",
+      "uri": "spotify:track:4DG3zMviPoLrBfOErhxgcv",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3614894002",
+      "fun_fact": "“Tarantula” is the title track of Pleasurekraft’s release of the same name.",
+      "fun_fact_de": "„Tarantula“ ist der Titelsong der gleichnamigen Veröffentlichung von Pleasurekraft.",
+      "fun_fact_es": "«Tarantula» es la canción que da título al lanzamiento homónimo de Pleasurekraft.",
+      "fun_fact_fr": "« Tarantula » est le morceau-titre de la publication éponyme de Pleasurekraft.",
+      "fun_fact_nl": "‘Tarantula’ is het titelnummer van de gelijknamige release van Pleasurekraft.",
+      "alt_artists": [
+        "Duke Dumont, Jax Jones",
+        "Alan Fitzpatrick",
+        "Breach"
+      ]
+    },
+    {
+      "artist": "Swedish House Mafia, Sting",
+      "title": "Redlight",
+      "year": 2022,
+      "isrc": "USUG12200887",
+      "uri": "spotify:track:48Jf12YHPBCAfAzi255Rvr",
+      "uri_apple_music": "applemusic://track/1610406429",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1610406429"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1713175847",
+      "fun_fact": "“Redlight” appears on Swedish House Mafia’s release “Paradise Again”.",
+      "fun_fact_de": "„Redlight“ erschien auf der Veröffentlichung „Paradise Again“ von Swedish House Mafia.",
+      "fun_fact_es": "«Redlight» aparece en el lanzamiento «Paradise Again» de Swedish House Mafia.",
+      "fun_fact_fr": "« Redlight » figure sur la publication « Paradise Again » de Swedish House Mafia.",
+      "fun_fact_nl": "‘Redlight’ staat op de release ‘Paradise Again’ van Swedish House Mafia.",
+      "alt_artists": [
+        "Jan Blomqvist, Ben Böhmer",
+        "Gregory Porter, Claptone",
+        "Skrillex, Starrah, Four Tet"
+      ]
+    },
+    {
+      "artist": "Higher Self, Lauren Mason",
+      "title": "Ghosts (feat. Lauren Mason) - Radio Edit",
+      "year": 2014,
+      "isrc": "NLZ541400814",
+      "uri": "spotify:track:5gKcbaxdSpI67Q1O3gRyFm",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/463375092",
+      "fun_fact": "“Ghosts (feat. Lauren Mason) - Radio Edit” appears on Higher Self’s release “Ghosts (feat. Lauren Mason)”.",
+      "fun_fact_de": "„Ghosts (feat. Lauren Mason) - Radio Edit“ erschien auf der Veröffentlichung „Ghosts (feat. Lauren Mason)“ von Higher Self.",
+      "fun_fact_es": "«Ghosts (feat. Lauren Mason) - Radio Edit» aparece en el lanzamiento «Ghosts (feat. Lauren Mason)» de Higher Self.",
+      "fun_fact_fr": "« Ghosts (feat. Lauren Mason) - Radio Edit » figure sur la publication « Ghosts (feat. Lauren Mason) » de Higher Self.",
+      "fun_fact_nl": "‘Ghosts (feat. Lauren Mason) - Radio Edit’ staat op de release ‘Ghosts (feat. Lauren Mason)’ van Higher Self.",
+      "alt_artists": [
+        "Above & Beyond, Zoë Johnston",
+        "Armand Van Helden, Duane Harden",
+        "Calvin Harris, Disciples, Chris Lake"
+      ]
+    },
+    {
+      "artist": "Dada Life, Sebastian Bach",
+      "title": "Born To Rage - Radio Edit",
+      "year": 2014,
+      "isrc": "SE22J1300131",
+      "uri": "spotify:track:4Jp3wkHmYKXu6a0EvHLg4n",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/76187768",
+      "fun_fact": "“Born To Rage - Radio Edit” appears on Dada Life’s release “Born To Rage”.",
+      "fun_fact_de": "„Born To Rage - Radio Edit“ erschien auf der Veröffentlichung „Born To Rage“ von Dada Life.",
+      "fun_fact_es": "«Born To Rage - Radio Edit» aparece en el lanzamiento «Born To Rage» de Dada Life.",
+      "fun_fact_fr": "« Born To Rage - Radio Edit » figure sur la publication « Born To Rage » de Dada Life.",
+      "fun_fact_nl": "‘Born To Rage - Radio Edit’ staat op de release ‘Born To Rage’ van Dada Life.",
+      "alt_artists": [
+        "David Tort, Gosha",
+        "Stromae, Paul Kalkbrenner",
+        "David Guetta, Akon"
+      ]
+    },
+    {
+      "artist": "Alok, ILLENIUM",
+      "title": "To The Moon",
+      "year": 2025,
+      "isrc": "DEE862501663",
+      "uri": "spotify:track:1UqrEdmUZallXzeHpUyAkY",
+      "uri_apple_music": "applemusic://track/1840664788",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1840664788"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3561947741",
+      "fun_fact": "“To The Moon” is the title track of Alok’s release of the same name.",
+      "fun_fact_de": "„To The Moon“ ist der Titelsong der gleichnamigen Veröffentlichung von Alok.",
+      "fun_fact_es": "«To The Moon» es la canción que da título al lanzamiento homónimo de Alok.",
+      "fun_fact_fr": "« To The Moon » est le morceau-titre de la publication éponyme de Alok.",
+      "fun_fact_nl": "‘To The Moon’ is het titelnummer van de gelijknamige release van Alok.",
+      "alt_artists": [
+        "Kölsch",
+        "NERVO",
+        "Masters At Work"
+      ]
+    },
+    {
+      "artist": "MEDUZA, HAYLA",
+      "title": "Another World",
+      "year": 2024,
+      "isrc": "US38Y2418589",
+      "uri": "spotify:track:5U0iZCQ9e8PaLYxup0pcnO",
+      "uri_apple_music": "applemusic://track/1766557249",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1766557249"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2981831311",
+      "fun_fact": "“Another World” is the title track of MEDUZA’s release of the same name.",
+      "fun_fact_de": "„Another World“ ist der Titelsong der gleichnamigen Veröffentlichung von MEDUZA.",
+      "fun_fact_es": "«Another World» es la canción que da título al lanzamiento homónimo de MEDUZA.",
+      "fun_fact_fr": "« Another World » est le morceau-titre de la publication éponyme de MEDUZA.",
+      "fun_fact_nl": "‘Another World’ is het titelnummer van de gelijknamige release van MEDUZA.",
+      "alt_artists": [
+        "Eelke Kleijn, Joris Voorn",
+        "DJ Hyperactive, Len Faki",
+        "MEDUZA, Goodboys"
+      ]
+    },
+    {
+      "artist": "Dimitri Vegas & Like Mike",
+      "title": "Salinas - White Island Original",
+      "year": 2010,
+      "isrc": "BEK010901657",
+      "uri": "spotify:track:72qTaNhKoepn3TOOnijb5p",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/123820280",
+      "fun_fact": "“Salinas - White Island Original” appears on Dimitri Vegas & Like Mike’s release “Salinas”.",
+      "fun_fact_de": "„Salinas - White Island Original“ erschien auf der Veröffentlichung „Salinas“ von Dimitri Vegas & Like Mike.",
+      "fun_fact_es": "«Salinas - White Island Original» aparece en el lanzamiento «Salinas» de Dimitri Vegas & Like Mike.",
+      "fun_fact_fr": "« Salinas - White Island Original » figure sur la publication « Salinas » de Dimitri Vegas & Like Mike.",
+      "fun_fact_nl": "‘Salinas - White Island Original’ staat op de release ‘Salinas’ van Dimitri Vegas & Like Mike.",
+      "alt_artists": [
+        "Paul Woolford, Diplo, Kareen Lomax",
+        "Bruno Mars, Shepard, Sultan",
+        "Alesso, Armin van Buuren"
+      ]
+    },
+    {
+      "artist": "Kx5, deadmau5, Kaskade",
+      "title": "Take Me High",
+      "year": 2013,
+      "isrc": "GBTDG1302555",
+      "uri": "spotify:track:0O2C5SEIVOET80kJjHizI5",
+      "uri_apple_music": "applemusic://track/1641184858",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1641184858"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1899431937",
+      "fun_fact": "“Take Me High” is the title track of Kx5’s release of the same name.",
+      "fun_fact_de": "„Take Me High“ ist der Titelsong der gleichnamigen Veröffentlichung von Kx5.",
+      "fun_fact_es": "«Take Me High» es la canción que da título al lanzamiento homónimo de Kx5.",
+      "fun_fact_fr": "« Take Me High » est le morceau-titre de la publication éponyme de Kx5.",
+      "fun_fact_nl": "‘Take Me High’ is het titelnummer van de gelijknamige release van Kx5.",
+      "alt_artists": [
+        "Yeah Yeah Yeahs, A-Trak",
+        "Julien Jabre, Jerome Sydenham, Sebastian Ingrosso",
+        "Anyma"
+      ]
+    },
+    {
+      "artist": "Steve Aoki, KAAZE, John Martin",
+      "title": "Won't Forget This Time ft. John Martin",
+      "year": 2023,
+      "isrc": "USA2P2335301",
+      "uri": "spotify:track:5q8Z8P353nbfsiXz4Jdho9",
+      "uri_apple_music": "applemusic://track/1696578374",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1696578374"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2367685785",
+      "fun_fact": "“Won't Forget This Time ft. John Martin” is the title track of Steve Aoki’s release of the same name.",
+      "fun_fact_de": "„Won't Forget This Time ft. John Martin“ ist der Titelsong der gleichnamigen Veröffentlichung von Steve Aoki.",
+      "fun_fact_es": "«Won't Forget This Time ft. John Martin» es la canción que da título al lanzamiento homónimo de Steve Aoki.",
+      "fun_fact_fr": "« Won't Forget This Time ft. John Martin » est le morceau-titre de la publication éponyme de Steve Aoki.",
+      "fun_fact_nl": "‘Won't Forget This Time ft. John Martin’ is het titelnummer van de gelijknamige release van Steve Aoki.",
+      "alt_artists": [
+        "Dimitri Vegas, Vin, Zion",
+        "Alesso, Roy English",
+        "DJ Hyperactive, Len Faki"
+      ]
+    },
+    {
+      "artist": "Skrillex, Starrah, Four Tet",
+      "title": "Butterflies",
+      "year": 2021,
+      "isrc": "USAT22101807",
+      "uri": "spotify:track:19dObDGedr40x1UcAm15qz",
+      "uri_apple_music": "applemusic://track/1672155116",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1672155116"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1366419422",
+      "fun_fact": "“Butterflies” is the title track of Skrillex’s release of the same name.",
+      "fun_fact_de": "„Butterflies“ ist der Titelsong der gleichnamigen Veröffentlichung von Skrillex.",
+      "fun_fact_es": "«Butterflies» es la canción que da título al lanzamiento homónimo de Skrillex.",
+      "fun_fact_fr": "« Butterflies » est le morceau-titre de la publication éponyme de Skrillex.",
+      "fun_fact_nl": "‘Butterflies’ is het titelnummer van de gelijknamige release van Skrillex.",
+      "alt_artists": [
+        "Pegassi",
+        "Jauz, Netsky",
+        "Sidney Samson"
+      ]
+    },
+    {
+      "artist": "Kaskade, Punctual, Poppy Baskcomb",
+      "title": "Heaven Knows",
+      "year": 2024,
+      "isrc": "CA6D22400691",
+      "uri": "spotify:track:3TnVOV85DaxEMP02xWbQfH",
+      "uri_apple_music": "applemusic://track/1777381999",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1777381999"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3097107781",
+      "fun_fact": "“Heaven Knows” is the title track of Kaskade’s release of the same name.",
+      "fun_fact_de": "„Heaven Knows“ ist der Titelsong der gleichnamigen Veröffentlichung von Kaskade.",
+      "fun_fact_es": "«Heaven Knows» es la canción que da título al lanzamiento homónimo de Kaskade.",
+      "fun_fact_fr": "« Heaven Knows » est le morceau-titre de la publication éponyme de Kaskade.",
+      "fun_fact_nl": "‘Heaven Knows’ is het titelnummer van de gelijknamige release van Kaskade.",
+      "alt_artists": [
+        "Calvin Harris, Example",
+        "Dim Chris, Sebastien Drums, Avicii",
+        "Yves V, AFROJACK, Icona Pop"
+      ]
+    },
+    {
+      "artist": "D*Note, Pete Heller",
+      "title": "Shed My Skin - Pete Hellers Stylus Vocal Mix",
+      "year": 2001,
+      "isrc": "GBERJ0100003",
+      "uri": "spotify:track:3XIdXIXJKGch6eaOLbncQA",
+      "uri_apple_music": "applemusic://track/1599966125",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1599966125"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3387956991",
+      "fun_fact": "“Shed My Skin - Pete Hellers Stylus Vocal Mix” appears on D*Note’s release “Shed My Skin”.",
+      "fun_fact_de": "„Shed My Skin - Pete Hellers Stylus Vocal Mix“ erschien auf der Veröffentlichung „Shed My Skin“ von D*Note.",
+      "fun_fact_es": "«Shed My Skin - Pete Hellers Stylus Vocal Mix» aparece en el lanzamiento «Shed My Skin» de D*Note.",
+      "fun_fact_fr": "« Shed My Skin - Pete Hellers Stylus Vocal Mix » figure sur la publication « Shed My Skin » de D*Note.",
+      "fun_fact_nl": "‘Shed My Skin - Pete Hellers Stylus Vocal Mix’ staat op de release ‘Shed My Skin’ van D*Note.",
+      "alt_artists": [
+        "Mr. Belt & Wezol",
+        "Notre Dame",
+        "David Guetta, Chris Willis, Fred Riesterer, Joachim Garraud"
+      ]
+    },
+    {
+      "artist": "Jones & Stephenson",
+      "title": "The First Rebirth",
+      "year": 2015,
+      "isrc": "NLF711501643",
+      "uri": "spotify:track:5jpUHXhGWvDoJQ27sXWnZC",
+      "uri_apple_music": "applemusic://track/217753235",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/217753235"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/97361280",
+      "fun_fact": "“The First Rebirth” appears on Jones & Stephenson’s release “Trance Top 1000 - Selection 002”.",
+      "fun_fact_de": "„The First Rebirth“ erschien auf der Veröffentlichung „Trance Top 1000 - Selection 002“ von Jones & Stephenson.",
+      "fun_fact_es": "«The First Rebirth» aparece en el lanzamiento «Trance Top 1000 - Selection 002» de Jones & Stephenson.",
+      "fun_fact_fr": "« The First Rebirth » figure sur la publication « Trance Top 1000 - Selection 002 » de Jones & Stephenson.",
+      "fun_fact_nl": "‘The First Rebirth’ staat op de release ‘Trance Top 1000 - Selection 002’ van Jones & Stephenson.",
+      "alt_artists": [
+        "Romy, Fred again..",
+        "ACRAZE, Cherish",
+        "Friend Within"
+      ]
+    },
+    {
+      "artist": "Armin van Buuren",
+      "title": "Es Vedrà",
+      "year": 2024,
+      "isrc": "NLF712406443",
+      "uri": "spotify:track:4Z6W8iMLWY5uuMsAheztBm",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2898245361",
+      "fun_fact": "“Es Vedrà” is the title track of Armin van Buuren’s release of the same name.",
+      "fun_fact_de": "„Es Vedrà“ ist der Titelsong der gleichnamigen Veröffentlichung von Armin van Buuren.",
+      "fun_fact_es": "«Es Vedrà» es la canción que da título al lanzamiento homónimo de Armin van Buuren.",
+      "fun_fact_fr": "« Es Vedrà » est le morceau-titre de la publication éponyme de Armin van Buuren.",
+      "fun_fact_nl": "‘Es Vedrà’ is het titelnummer van de gelijknamige release van Armin van Buuren.",
+      "alt_artists": [
+        "Riva",
+        "New World Sound, Thomas Newson",
+        "David Guetta, Sia, MORTEN"
+      ]
+    },
+    {
+      "artist": "John Summit",
+      "title": "Deep End",
+      "year": 2020,
+      "isrc": "GBCPZ2017641",
+      "uri": "spotify:track:5xdDQFCjgizAurT6Xi5lYT",
+      "uri_apple_music": "applemusic://track/1529496583",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1529496583"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3156117741",
+      "fun_fact": "“Deep End” appears on John Summit’s release “Deep End (Black V Neck Remix)”.",
+      "fun_fact_de": "„Deep End“ erschien auf der Veröffentlichung „Deep End (Black V Neck Remix)“ von John Summit.",
+      "fun_fact_es": "«Deep End» aparece en el lanzamiento «Deep End (Black V Neck Remix)» de John Summit.",
+      "fun_fact_fr": "« Deep End » figure sur la publication « Deep End (Black V Neck Remix) » de John Summit.",
+      "fun_fact_nl": "‘Deep End’ staat op de release ‘Deep End (Black V Neck Remix)’ van John Summit.",
+      "alt_artists": [
+        "&ME, Black Coffee, Keinemusik",
+        "Jamback",
+        "Camisra"
+      ]
+    },
+    {
+      "artist": "Cassius, Narcotic Thrust",
+      "title": "The Sound of Violence (Narcotic Thrust Remix)",
+      "year": 2002,
+      "isrc": "FR01Q0200079",
+      "uri": "spotify:track:2Mtmth523LEPd59UtZiz9M",
+      "uri_apple_music": "applemusic://track/1090983104",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1090983104"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/120536258",
+      "fun_fact": "“The Sound of Violence (Narcotic Thrust Remix)” appears on Cassius’s release “Au Rêve (Deluxe Edition)”.",
+      "fun_fact_de": "„The Sound of Violence (Narcotic Thrust Remix)“ erschien auf der Veröffentlichung „Au Rêve (Deluxe Edition)“ von Cassius.",
+      "fun_fact_es": "«The Sound of Violence (Narcotic Thrust Remix)» aparece en el lanzamiento «Au Rêve (Deluxe Edition)» de Cassius.",
+      "fun_fact_fr": "« The Sound of Violence (Narcotic Thrust Remix) » figure sur la publication « Au Rêve (Deluxe Edition) » de Cassius.",
+      "fun_fact_nl": "‘The Sound of Violence (Narcotic Thrust Remix)’ staat op de release ‘Au Rêve (Deluxe Edition)’ van Cassius.",
+      "alt_artists": [
+        "Mau P",
+        "Laidback Luke, Chris Lorenzo",
+        "Galantis"
+      ]
+    },
+    {
+      "artist": "Alesso, Becky Hill",
+      "title": "Surrender",
+      "year": 2025,
+      "isrc": "USUG12502244",
+      "uri": "spotify:track:2HJu1bxkubHZEXC8r6snXY",
+      "uri_apple_music": "applemusic://track/1804467568",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1804467568"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3302923111",
+      "fun_fact": "“Surrender” is the title track of Alesso’s release of the same name.",
+      "fun_fact_de": "„Surrender“ ist der Titelsong der gleichnamigen Veröffentlichung von Alesso.",
+      "fun_fact_es": "«Surrender» es la canción que da título al lanzamiento homónimo de Alesso.",
+      "fun_fact_fr": "« Surrender » est le morceau-titre de la publication éponyme de Alesso.",
+      "fun_fact_nl": "‘Surrender’ is het titelnummer van de gelijknamige release van Alesso.",
+      "alt_artists": [
+        "Samm",
+        "Hardwell, KSHMR",
+        "Sammy Virji, Skepta"
+      ]
+    },
+    {
+      "artist": "Tom Staar, Eddie Thoneick",
+      "title": "Otherside",
+      "year": 2018,
+      "isrc": "GBKCF1800696",
+      "uri": "spotify:track:3W5yGSGLfyrRDWEFu7lyWo",
+      "uri_apple_music": "applemusic://track/1426605696",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1426605696"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/541200222",
+      "fun_fact": "“Otherside” is the title track of Tom Staar’s release of the same name.",
+      "fun_fact_de": "„Otherside“ ist der Titelsong der gleichnamigen Veröffentlichung von Tom Staar.",
+      "fun_fact_es": "«Otherside» es la canción que da título al lanzamiento homónimo de Tom Staar.",
+      "fun_fact_fr": "« Otherside » est le morceau-titre de la publication éponyme de Tom Staar.",
+      "fun_fact_nl": "‘Otherside’ is het titelnummer van de gelijknamige release van Tom Staar.",
+      "alt_artists": [
+        "Felix Da Housecat",
+        "Armand Van Helden",
+        "Cygnus X, Rank 1"
+      ]
+    },
+    {
+      "artist": "Breach",
+      "title": "Jack - Radio Edit",
+      "year": 2013,
+      "isrc": "GBAHS1300200",
+      "uri": "spotify:track:3kWHCjPkAP5x9ZEs6SlXk9",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3156208691",
+      "fun_fact": "“Jack - Radio Edit” appears on Breach’s release “Jack (DC Jack Track)”.",
+      "fun_fact_de": "„Jack - Radio Edit“ erschien auf der Veröffentlichung „Jack (DC Jack Track)“ von Breach.",
+      "fun_fact_es": "«Jack - Radio Edit» aparece en el lanzamiento «Jack (DC Jack Track)» de Breach.",
+      "fun_fact_fr": "« Jack - Radio Edit » figure sur la publication « Jack (DC Jack Track) » de Breach.",
+      "fun_fact_nl": "‘Jack - Radio Edit’ staat op de release ‘Jack (DC Jack Track)’ van Breach.",
+      "alt_artists": [
+        "MoBlack, Salif Keita, Benja (NL), Franc Fala, Cesária Evora",
+        "Armin van Buuren",
+        "Digitalism"
+      ]
+    },
+    {
+      "artist": "CamelPhat",
+      "title": "Constellations - Radio Edit",
+      "year": 2015,
+      "isrc": "NLZ541500158",
+      "uri": "spotify:track:0l0jMydIAM3fhJzmtum2FW",
+      "uri_apple_music": "applemusic://track/1355051008",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1355051008"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/468392592",
+      "fun_fact": "“Constellations - Radio Edit” is the title track of CamelPhat’s release of the same name.",
+      "fun_fact_de": "„Constellations - Radio Edit“ ist der Titelsong der gleichnamigen Veröffentlichung von CamelPhat.",
+      "fun_fact_es": "«Constellations - Radio Edit» es la canción que da título al lanzamiento homónimo de CamelPhat.",
+      "fun_fact_fr": "« Constellations - Radio Edit » est le morceau-titre de la publication éponyme de CamelPhat.",
+      "fun_fact_nl": "‘Constellations - Radio Edit’ is het titelnummer van de gelijknamige release van CamelPhat.",
+      "alt_artists": [
+        "Freejak",
+        "Martin Garrix, R3HAB, Skytech",
+        "Peggy Gou"
+      ]
+    },
+    {
+      "artist": "Feist, Boys Noize",
+      "title": "My Moon My Man - Boys Noize Remix",
+      "year": 2007,
+      "isrc": "FRUM70700014",
+      "uri": "spotify:track:5SOmPa1x00jAmZLHptSGm6",
+      "uri_apple_music": "applemusic://track/561557579",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/561557579"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/911117",
+      "fun_fact": "“My Moon My Man - Boys Noize Remix” appears on Feist’s release “My Moon My Man”.",
+      "fun_fact_de": "„My Moon My Man - Boys Noize Remix“ erschien auf der Veröffentlichung „My Moon My Man“ von Feist.",
+      "fun_fact_es": "«My Moon My Man - Boys Noize Remix» aparece en el lanzamiento «My Moon My Man» de Feist.",
+      "fun_fact_fr": "« My Moon My Man - Boys Noize Remix » figure sur la publication « My Moon My Man » de Feist.",
+      "fun_fact_nl": "‘My Moon My Man - Boys Noize Remix’ staat op de release ‘My Moon My Man’ van Feist.",
+      "alt_artists": [
+        "Calvin Harris, Rag'n'Bone Man, Robin Schulz",
+        "The Bloody Beetroots, Steve Aoki",
+        "Axwell, Sebastian Ingrosso, Steve Angello, Laidback Luke"
+      ]
+    },
+    {
+      "artist": "Dom Dolla",
+      "title": "girl$",
+      "year": 2024,
+      "isrc": "USQX92401650",
+      "uri": "spotify:track:46N3FCKFABRjNoNBVq4osr",
+      "uri_apple_music": "applemusic://track/1749336837",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1749336837"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2825761562",
+      "fun_fact": "“girl$” is the title track of Dom Dolla’s release of the same name.",
+      "fun_fact_de": "„girl$“ ist der Titelsong der gleichnamigen Veröffentlichung von Dom Dolla.",
+      "fun_fact_es": "«girl$» es la canción que da título al lanzamiento homónimo de Dom Dolla.",
+      "fun_fact_fr": "« girl$ » est le morceau-titre de la publication éponyme de Dom Dolla.",
+      "fun_fact_nl": "‘girl$’ is het titelnummer van de gelijknamige release van Dom Dolla.",
+      "alt_artists": [
+        "Martin Garrix, Matisse & Sadko, Michel Zitron",
+        "Alesso, Katy Perry",
+        "D*Note, Pete Heller"
+      ]
+    },
+    {
+      "artist": "Yves V, HIDDN",
+      "title": "Magnolia",
+      "year": 2018,
+      "isrc": "NLZ541800391",
+      "uri": "spotify:track:13hG6iLebNpuGmuengL3jr",
+      "uri_apple_music": "applemusic://track/1362779131",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1362779131"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/476596932",
+      "fun_fact": "“Magnolia” is the title track of Yves V’s release of the same name.",
+      "fun_fact_de": "„Magnolia“ ist der Titelsong der gleichnamigen Veröffentlichung von Yves V.",
+      "fun_fact_es": "«Magnolia» es la canción que da título al lanzamiento homónimo de Yves V.",
+      "fun_fact_fr": "« Magnolia » est le morceau-titre de la publication éponyme de Yves V.",
+      "fun_fact_nl": "‘Magnolia’ is het titelnummer van de gelijknamige release van Yves V.",
+      "alt_artists": [
+        "Enrico Sangiuliano",
+        "Peggy Gou",
+        "Gotye, FISHER, Chris Lake, Sante Sansone, Kimbra"
+      ]
+    },
+    {
+      "artist": "Martin Garrix, Julian Jordan",
+      "title": "Glitch",
+      "year": 2018,
+      "isrc": "NLM5S1800426",
+      "uri": "spotify:track:47knrBbYhqtrggWYSkU6h1",
+      "uri_apple_music": "applemusic://track/1445870855",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1445870855"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/601054032",
+      "fun_fact": "“Glitch” is the title track of Martin Garrix’s release of the same name.",
+      "fun_fact_de": "„Glitch“ ist der Titelsong der gleichnamigen Veröffentlichung von Martin Garrix.",
+      "fun_fact_es": "«Glitch» es la canción que da título al lanzamiento homónimo de Martin Garrix.",
+      "fun_fact_fr": "« Glitch » est le morceau-titre de la publication éponyme de Martin Garrix.",
+      "fun_fact_nl": "‘Glitch’ is het titelnummer van de gelijknamige release van Martin Garrix.",
+      "alt_artists": [
+        "Sonny Fodera, MK, Clementine Douglas",
+        "Sonique, The Conductor & The Cowboy",
+        "Jaden Bojsen, Sami Brielle"
+      ]
+    },
+    {
+      "artist": "Don Diablo",
+      "title": "You Can't Change Me",
+      "year": 2017,
+      "isrc": "GBWWP1703295",
+      "uri": "spotify:track:7vAVQMCwSKEVmol4wJvqUO",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1952547247",
+      "fun_fact": "“You Can't Change Me” appears on Don Diablo’s release “FUTURE (Deluxe Edition)”.",
+      "fun_fact_de": "„You Can't Change Me“ erschien auf der Veröffentlichung „FUTURE (Deluxe Edition)“ von Don Diablo.",
+      "fun_fact_es": "«You Can't Change Me» aparece en el lanzamiento «FUTURE (Deluxe Edition)» de Don Diablo.",
+      "fun_fact_fr": "« You Can't Change Me » figure sur la publication « FUTURE (Deluxe Edition) » de Don Diablo.",
+      "fun_fact_nl": "‘You Can't Change Me’ staat op de release ‘FUTURE (Deluxe Edition)’ van Don Diablo.",
+      "alt_artists": [
+        "Armand Van Helden, Duane Harden",
+        "Dirty South, Alesso, Ruben Haze",
+        "Armin van Buuren, AVIAN GRAYS, Jordan Shaw"
+      ]
+    },
+    {
+      "artist": "Diplo, Miguel",
+      "title": "Don’t Forget My Love",
+      "year": 2022,
+      "isrc": "USZ4V2200009",
+      "uri": "spotify:track:1kpTK8SWlA1lGkorVaxp3S",
+      "uri_apple_music": "applemusic://track/1607400982",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1607400982"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1641834132",
+      "fun_fact": "“Don’t Forget My Love” is the title track of Diplo’s release of the same name.",
+      "fun_fact_de": "„Don’t Forget My Love“ ist der Titelsong der gleichnamigen Veröffentlichung von Diplo.",
+      "fun_fact_es": "«Don’t Forget My Love» es la canción que da título al lanzamiento homónimo de Diplo.",
+      "fun_fact_fr": "« Don’t Forget My Love » est le morceau-titre de la publication éponyme de Diplo.",
+      "fun_fact_nl": "‘Don’t Forget My Love’ is het titelnummer van de gelijknamige release van Diplo.",
+      "alt_artists": [
+        "Kevin de Vries",
+        "Above & Beyond, Zoë Johnston",
+        "Samm"
+      ]
+    },
+    {
+      "artist": "Nosi",
+      "title": "So Good",
+      "year": 2025,
+      "isrc": "USA2P2467053",
+      "uri": "spotify:track:2S9jqUEI9fiDNtSH707KR4",
+      "uri_apple_music": "applemusic://track/1793494684",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1793494684"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3212122851",
+      "fun_fact": "“So Good” is the title track of Nosi’s release of the same name.",
+      "fun_fact_de": "„So Good“ ist der Titelsong der gleichnamigen Veröffentlichung von Nosi.",
+      "fun_fact_es": "«So Good» es la canción que da título al lanzamiento homónimo de Nosi.",
+      "fun_fact_fr": "« So Good » est le morceau-titre de la publication éponyme de Nosi.",
+      "fun_fact_nl": "‘So Good’ is het titelnummer van de gelijknamige release van Nosi.",
+      "alt_artists": [
+        "Maverick Sabre, Jorja Smith, Vintage Culture, Slow Motion",
+        "SOFI TUKKER, Öwnboss, Fancy Inc",
+        "Skrillex, Boys Noize, Opus III"
+      ]
+    },
+    {
+      "artist": "Martin Solveig, Roy Woods",
+      "title": "Juliet & Romeo",
+      "year": 2019,
+      "isrc": "FR2PA1900100",
+      "uri": "spotify:track:1CRy08G60mS5jvhB27xMpS",
+      "uri_apple_music": "applemusic://track/1488848175",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1488848175"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/822658282",
+      "fun_fact": "“Juliet & Romeo” is the title track of Martin Solveig’s release of the same name.",
+      "fun_fact_de": "„Juliet & Romeo“ ist der Titelsong der gleichnamigen Veröffentlichung von Martin Solveig.",
+      "fun_fact_es": "«Juliet & Romeo» es la canción que da título al lanzamiento homónimo de Martin Solveig.",
+      "fun_fact_fr": "« Juliet & Romeo » est le morceau-titre de la publication éponyme de Martin Solveig.",
+      "fun_fact_nl": "‘Juliet & Romeo’ is het titelnummer van de gelijknamige release van Martin Solveig.",
+      "alt_artists": [
+        "Janet Jackson",
+        "Tiësto, Dzeko, Lena Leon",
+        "David Guetta, Alphaville, Hypaton, Ava Max"
+      ]
+    },
+    {
+      "artist": "Red Carpet, Brad Carter",
+      "title": "Alright - Brad Carter Radio Edit",
+      "year": 2013,
+      "isrc": "NLF711302710",
+      "uri": "spotify:track:4QqaGFXuaMzocCc4M6Ccj0",
+      "uri_apple_music": "applemusic://track/603925210",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/603925210"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/64760930",
+      "fun_fact": "“Alright - Brad Carter Radio Edit” appears on Red Carpet’s release “50 Best Trance Hits Ever, Vol. 2”.",
+      "fun_fact_de": "„Alright - Brad Carter Radio Edit“ erschien auf der Veröffentlichung „50 Best Trance Hits Ever, Vol. 2“ von Red Carpet.",
+      "fun_fact_es": "«Alright - Brad Carter Radio Edit» aparece en el lanzamiento «50 Best Trance Hits Ever, Vol. 2» de Red Carpet.",
+      "fun_fact_fr": "« Alright - Brad Carter Radio Edit » figure sur la publication « 50 Best Trance Hits Ever, Vol. 2 » de Red Carpet.",
+      "fun_fact_nl": "‘Alright - Brad Carter Radio Edit’ staat op de release ‘50 Best Trance Hits Ever, Vol. 2’ van Red Carpet.",
+      "alt_artists": [
+        "Blasterjaxx, Timmy Trumpet",
+        "MEDUZA, HAYLA",
+        "M.A.N.D.Y., Booka Shade"
+      ]
+    },
+    {
+      "artist": "Fred again.., 070 Shake",
+      "title": "Danielle (smile on my face)",
+      "year": 2022,
+      "isrc": "GBAHS2201033",
+      "uri": "spotify:track:09Rv6ctDE0t9z8zk5FINg8",
+      "uri_apple_music": "applemusic://track/1653471645",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1653471645"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1894584167",
+      "fun_fact": "“Danielle (smile on my face)” is the title track of Fred again..’s release of the same name.",
+      "fun_fact_de": "„Danielle (smile on my face)“ ist der Titelsong der gleichnamigen Veröffentlichung von Fred again...",
+      "fun_fact_es": "«Danielle (smile on my face)» es la canción que da título al lanzamiento homónimo de Fred again...",
+      "fun_fact_fr": "« Danielle (smile on my face) » est le morceau-titre de la publication éponyme de Fred again...",
+      "fun_fact_nl": "‘Danielle (smile on my face)’ is het titelnummer van de gelijknamige release van Fred again...",
+      "alt_artists": [
+        "MORTEN",
+        "David Guetta, Sia, MORTEN",
+        "ARTY, NK"
+      ]
+    },
+    {
+      "artist": "Paul Kalkbrenner",
+      "title": "Part Eight",
+      "year": 2018,
+      "isrc": "DEE861800415",
+      "uri": "spotify:track:2yAOaUhMCX7irO3N1ygHs4",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/472782882",
+      "fun_fact": "“Part Eight” appears on Paul Kalkbrenner’s release “Parts of Life”.",
+      "fun_fact_de": "„Part Eight“ erschien auf der Veröffentlichung „Parts of Life“ von Paul Kalkbrenner.",
+      "fun_fact_es": "«Part Eight» aparece en el lanzamiento «Parts of Life» de Paul Kalkbrenner.",
+      "fun_fact_fr": "« Part Eight » figure sur la publication « Parts of Life » de Paul Kalkbrenner.",
+      "fun_fact_nl": "‘Part Eight’ staat op de release ‘Parts of Life’ van Paul Kalkbrenner.",
+      "alt_artists": [
+        "Martin Garrix, Brooks",
+        "Avicii, Aloe Blacc",
+        "Maceo Plex, Chromatics"
+      ]
+    },
+    {
+      "artist": "Chris Lake",
+      "title": "Savana",
+      "year": 2025,
+      "isrc": "GXFCP2500076",
+      "uri": "spotify:track:6qe61hWL08SxLCQTcOulMB",
+      "uri_apple_music": "applemusic://track/1813214930",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1813214930"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3358703801",
+      "fun_fact": "“Savana” is the title track of Chris Lake’s release of the same name.",
+      "fun_fact_de": "„Savana“ ist der Titelsong der gleichnamigen Veröffentlichung von Chris Lake.",
+      "fun_fact_es": "«Savana» es la canción que da título al lanzamiento homónimo de Chris Lake.",
+      "fun_fact_fr": "« Savana » est le morceau-titre de la publication éponyme de Chris Lake.",
+      "fun_fact_nl": "‘Savana’ is het titelnummer van de gelijknamige release van Chris Lake.",
+      "alt_artists": [
+        "Major Lazer, MØ, DJ Snake",
+        "Fred again.., 070 Shake",
+        "Double 99"
+      ]
+    },
+    {
+      "artist": "Dirty South, Alesso, Ruben Haze",
+      "title": "City Of Dreams - Radio Edit",
+      "year": 2013,
+      "isrc": "GBUYR1200032",
+      "uri": "spotify:track:54ZPmGE1uOG9IYoUBSRSp7",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/68601046",
+      "fun_fact": "“City Of Dreams - Radio Edit” appears on Dirty South’s release “City Of Dreams”.",
+      "fun_fact_de": "„City Of Dreams - Radio Edit“ erschien auf der Veröffentlichung „City Of Dreams“ von Dirty South.",
+      "fun_fact_es": "«City Of Dreams - Radio Edit» aparece en el lanzamiento «City Of Dreams» de Dirty South.",
+      "fun_fact_fr": "« City Of Dreams - Radio Edit » figure sur la publication « City Of Dreams » de Dirty South.",
+      "fun_fact_nl": "‘City Of Dreams - Radio Edit’ staat op de release ‘City Of Dreams’ van Dirty South.",
+      "alt_artists": [
+        "MEDUZA, Dermot Kennedy",
+        "FÄIS, AFROJACK, Matisse & Sadko",
+        "Fatboy Slim, Riva Starr, Beardyman, Calvin Harris"
+      ]
+    },
+    {
+      "artist": "MOGUAI, Cheat Codes",
+      "title": "Hold On - Radio Edit",
+      "year": 2023,
+      "isrc": "NLZ542301634",
+      "uri": "spotify:track:6uNmhuEwkqtDcyDYbc2vBo",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2494445261",
+      "fun_fact": "“Hold On - Radio Edit” appears on MOGUAI’s release “Hold On (Mixes)”.",
+      "fun_fact_de": "„Hold On - Radio Edit“ erschien auf der Veröffentlichung „Hold On (Mixes)“ von MOGUAI.",
+      "fun_fact_es": "«Hold On - Radio Edit» aparece en el lanzamiento «Hold On (Mixes)» de MOGUAI.",
+      "fun_fact_fr": "« Hold On - Radio Edit » figure sur la publication « Hold On (Mixes) » de MOGUAI.",
+      "fun_fact_nl": "‘Hold On - Radio Edit’ staat op de release ‘Hold On (Mixes)’ van MOGUAI.",
+      "alt_artists": [
+        "Steve Aoki, Jamis, Bonn",
+        "Axwell, Errol Reid",
+        "Purple Disco Machine, Sophie and the Giants"
+      ]
+    },
+    {
+      "artist": "Tiësto, Mesto",
+      "title": "Can't Get Enough",
+      "year": 2019,
+      "isrc": "CYA111900050",
+      "uri": "spotify:track:4FpsZqiM5vdrCh8QpCKJQd",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/857196102",
+      "fun_fact": "“Can't Get Enough” appears on Tiësto’s release “Together”.",
+      "fun_fact_de": "„Can't Get Enough“ erschien auf der Veröffentlichung „Together“ von Tiësto.",
+      "fun_fact_es": "«Can't Get Enough» aparece en el lanzamiento «Together» de Tiësto.",
+      "fun_fact_fr": "« Can't Get Enough » figure sur la publication « Together » de Tiësto.",
+      "fun_fact_nl": "‘Can't Get Enough’ staat op de release ‘Together’ van Tiësto.",
+      "alt_artists": [
+        "Josh Butler, Bontan, Pleasurekraft",
+        "Calvin Harris, Rag'n'Bone Man, Robin Schulz",
+        "Tiësto, Oliver Heldens"
+      ]
+    },
+    {
+      "artist": "Calvin Harris, Sam Smith",
+      "title": "Desire (with Sam Smith)",
+      "year": 2023,
+      "isrc": "GBARL2301174",
+      "uri": "spotify:track:22dUzMFttcR3uU17NcOAIv",
+      "uri_apple_music": "applemusic://track/1696083506",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1696083506"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2560398052",
+      "fun_fact": "“Desire (with Sam Smith)” appears on Calvin Harris’s release “Desire (Calvin Harris VIP Mix)”.",
+      "fun_fact_de": "„Desire (with Sam Smith)“ erschien auf der Veröffentlichung „Desire (Calvin Harris VIP Mix)“ von Calvin Harris.",
+      "fun_fact_es": "«Desire (with Sam Smith)» aparece en el lanzamiento «Desire (Calvin Harris VIP Mix)» de Calvin Harris.",
+      "fun_fact_fr": "« Desire (with Sam Smith) » figure sur la publication « Desire (Calvin Harris VIP Mix) » de Calvin Harris.",
+      "fun_fact_nl": "‘Desire (with Sam Smith)’ staat op de release ‘Desire (Calvin Harris VIP Mix)’ van Calvin Harris.",
+      "alt_artists": [
+        "Sara Landry, Alt8",
+        "KI/KI, Marlon Hoffstadt",
+        "Sebastian Ingrosso"
+      ]
+    },
+    {
+      "artist": "ZHU",
+      "title": "Faded",
+      "year": 2014,
+      "isrc": "QMALR1400001",
+      "uri": "spotify:track:0zL9dieoCcjBWV01y73Cj1",
+      "uri_apple_music": "applemusic://track/918184083",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/918184083"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/77542036",
+      "fun_fact": "“Faded” appears on ZHU’s release “THE NIGHTDAY”.",
+      "fun_fact_de": "„Faded“ erschien auf der Veröffentlichung „THE NIGHTDAY“ von ZHU.",
+      "fun_fact_es": "«Faded» aparece en el lanzamiento «THE NIGHTDAY» de ZHU.",
+      "fun_fact_fr": "« Faded » figure sur la publication « THE NIGHTDAY » de ZHU.",
+      "fun_fact_nl": "‘Faded’ staat op de release ‘THE NIGHTDAY’ van ZHU.",
+      "alt_artists": [
+        "TJR, VINAI",
+        "The Chainsmokers, Daya, W&W",
+        "AFROJACK, Martin Garrix, David Guetta, Amél"
+      ]
+    },
+    {
+      "artist": "ARTY, NK",
+      "title": "Strings ID",
+      "year": 2020,
+      "isrc": "NLF712009565",
+      "uri": "spotify:track:4WvYQDNRXu1uUXHKzG394v",
+      "uri_apple_music": "applemusic://track/1504640961",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1504640961"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1055848662",
+      "fun_fact": "“Strings ID” appears on ARTY’s release “Our Song (Mix)”.",
+      "fun_fact_de": "„Strings ID“ erschien auf der Veröffentlichung „Our Song (Mix)“ von ARTY.",
+      "fun_fact_es": "«Strings ID» aparece en el lanzamiento «Our Song (Mix)» de ARTY.",
+      "fun_fact_fr": "« Strings ID » figure sur la publication « Our Song (Mix) » de ARTY.",
+      "fun_fact_nl": "‘Strings ID’ staat op de release ‘Our Song (Mix)’ van ARTY.",
+      "alt_artists": [
+        "Cassius, Narcotic Thrust",
+        "CHRIS STASSY, S.A.M.",
+        "Steve Aoki, Chris Lake, Tujamo"
+      ]
+    },
+    {
+      "artist": "Format:B",
+      "title": "Chunky - Radio Edit",
+      "year": 2015,
+      "isrc": "GBCEN1500880",
+      "uri": "spotify:track:6rph5HqB8Ba2wOE6MoFTmW",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3910318211",
+      "fun_fact": "“Chunky - Radio Edit” appears on Format:B’s release “Chunky”.",
+      "fun_fact_de": "„Chunky - Radio Edit“ erschien auf der Veröffentlichung „Chunky“ von Format:B.",
+      "fun_fact_es": "«Chunky - Radio Edit» aparece en el lanzamiento «Chunky» de Format:B.",
+      "fun_fact_fr": "« Chunky - Radio Edit » figure sur la publication « Chunky » de Format:B.",
+      "fun_fact_nl": "‘Chunky - Radio Edit’ staat op de release ‘Chunky’ van Format:B.",
+      "alt_artists": [
+        "Alesso, TINI",
+        "Martin Garrix, Justin Mylo, Dewain Whitmore",
+        "Maceo Plex, Chromatics"
+      ]
+    },
+    {
+      "artist": "Sunnery James & Ryan Marciano, Kes Kross",
+      "title": "Coffee Shop",
+      "year": 2018,
+      "isrc": "NLF711808319",
+      "uri": "spotify:track:1Oskgd4EDEeOLKVEd1jMEL",
+      "uri_apple_music": "applemusic://track/1450992992",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1450992992"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/537682812",
+      "fun_fact": "“Coffee Shop” appears on Sunnery James & Ryan Marciano’s release “Affective EP”.",
+      "fun_fact_de": "„Coffee Shop“ erschien auf der Veröffentlichung „Affective EP“ von Sunnery James & Ryan Marciano.",
+      "fun_fact_es": "«Coffee Shop» aparece en el lanzamiento «Affective EP» de Sunnery James & Ryan Marciano.",
+      "fun_fact_fr": "« Coffee Shop » figure sur la publication « Affective EP » de Sunnery James & Ryan Marciano.",
+      "fun_fact_nl": "‘Coffee Shop’ staat op de release ‘Affective EP’ van Sunnery James & Ryan Marciano.",
+      "alt_artists": [
+        "Armin van Buuren, Perpetuous Dreamer",
+        "Tiësto, Sevenn",
+        "Martin Solveig, Tkay Maidza"
+      ]
+    },
+    {
+      "artist": "Jay Hardway",
+      "title": "Electric Elephants",
+      "year": 2015,
+      "isrc": "NLZ541500723",
+      "uri": "spotify:track:4O2gRMLAIQYHXe25wjeTFj",
+      "uri_apple_music": "applemusic://track/1336552260",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1336552260"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/452692932",
+      "fun_fact": "“Electric Elephants” is the title track of Jay Hardway’s release of the same name.",
+      "fun_fact_de": "„Electric Elephants“ ist der Titelsong der gleichnamigen Veröffentlichung von Jay Hardway.",
+      "fun_fact_es": "«Electric Elephants» es la canción que da título al lanzamiento homónimo de Jay Hardway.",
+      "fun_fact_fr": "« Electric Elephants » est le morceau-titre de la publication éponyme de Jay Hardway.",
+      "fun_fact_nl": "‘Electric Elephants’ is het titelnummer van de gelijknamige release van Jay Hardway.",
+      "alt_artists": [
+        "Lost Frequencies, Tom Gregory",
+        "Mason",
+        "Yves V, AFROJACK, Icona Pop"
+      ]
+    },
+    {
+      "artist": "Lucas & Steve, Brandy",
+      "title": "I Could Be Wrong - Radio Edit",
+      "year": 2018,
+      "isrc": "NLZ541800423",
+      "uri": "spotify:track:7BF5rE2EVDmWNXc0uoP8Bz",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/501725912",
+      "fun_fact": "“I Could Be Wrong - Radio Edit” appears on Lucas & Steve’s release “I Could Be Wrong”.",
+      "fun_fact_de": "„I Could Be Wrong - Radio Edit“ erschien auf der Veröffentlichung „I Could Be Wrong“ von Lucas & Steve.",
+      "fun_fact_es": "«I Could Be Wrong - Radio Edit» aparece en el lanzamiento «I Could Be Wrong» de Lucas & Steve.",
+      "fun_fact_fr": "« I Could Be Wrong - Radio Edit » figure sur la publication « I Could Be Wrong » de Lucas & Steve.",
+      "fun_fact_nl": "‘I Could Be Wrong - Radio Edit’ staat op de release ‘I Could Be Wrong’ van Lucas & Steve.",
+      "alt_artists": [
+        "Gouryella, Ferry Corsten",
+        "L.P. Rhythm",
+        "Purple Disco Machine, Sophie and the Giants"
+      ]
+    },
+    {
+      "artist": "Lost Frequencies, Tom Odell",
+      "title": "Black Friday (pretty like the sun)",
+      "year": 2024,
+      "isrc": "USA2P2439321",
+      "uri": "spotify:track:4MSj19TwYBLgDFj3ddEeco",
+      "uri_apple_music": "applemusic://track/1755039408",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1755039408"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2871900192",
+      "fun_fact": "“Black Friday (pretty like the sun)” is the title track of Lost Frequencies’s release of the same name.",
+      "fun_fact_de": "„Black Friday (pretty like the sun)“ ist der Titelsong der gleichnamigen Veröffentlichung von Lost Frequencies.",
+      "fun_fact_es": "«Black Friday (pretty like the sun)» es la canción que da título al lanzamiento homónimo de Lost Frequencies.",
+      "fun_fact_fr": "« Black Friday (pretty like the sun) » est le morceau-titre de la publication éponyme de Lost Frequencies.",
+      "fun_fact_nl": "‘Black Friday (pretty like the sun)’ is het titelnummer van de gelijknamige release van Lost Frequencies.",
+      "alt_artists": [
+        "deadmau5",
+        "Dirty South, Rudy, Axwell",
+        "Yves V, HIDDN"
+      ]
+    },
+    {
+      "artist": "Paul Woolford, Kim English",
+      "title": "Hang Up Your Hang Ups (The Only One) [feat. Kim English]",
+      "year": 2018,
+      "isrc": "GBAYE1800657",
+      "uri": "spotify:track:3t462saypfWgBlj9cESaQc",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/525035212",
+      "fun_fact": "“Hang Up Your Hang Ups (The Only One) [feat. Kim English]” is the title track of Paul Woolford’s release of the same name.",
+      "fun_fact_de": "„Hang Up Your Hang Ups (The Only One) [feat. Kim English]“ ist der Titelsong der gleichnamigen Veröffentlichung von Paul Woolford.",
+      "fun_fact_es": "«Hang Up Your Hang Ups (The Only One) [feat. Kim English]» es la canción que da título al lanzamiento homónimo de Paul Woolford.",
+      "fun_fact_fr": "« Hang Up Your Hang Ups (The Only One) [feat. Kim English] » est le morceau-titre de la publication éponyme de Paul Woolford.",
+      "fun_fact_nl": "‘Hang Up Your Hang Ups (The Only One) [feat. Kim English]’ is het titelnummer van de gelijknamige release van Paul Woolford.",
+      "alt_artists": [
+        "Axwell, Sebastian Ingrosso, Steve Angello, Laidback Luke",
+        "Watermät",
+        "Kygo, Rita Ora"
+      ]
+    },
+    {
+      "artist": "FISHER, Aatig",
+      "title": "TAKE IT OFF",
+      "year": 2023,
+      "isrc": "QM24S2302791",
+      "uri": "spotify:track:7zp9FOU4cjFdGN1zdWTvcB",
+      "uri_apple_music": "applemusic://track/1698253579",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1698253579"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2310206575",
+      "fun_fact": "“TAKE IT OFF” is the title track of FISHER’s release of the same name.",
+      "fun_fact_de": "„TAKE IT OFF“ ist der Titelsong der gleichnamigen Veröffentlichung von FISHER.",
+      "fun_fact_es": "«TAKE IT OFF» es la canción que da título al lanzamiento homónimo de FISHER.",
+      "fun_fact_fr": "« TAKE IT OFF » est le morceau-titre de la publication éponyme de FISHER.",
+      "fun_fact_nl": "‘TAKE IT OFF’ is het titelnummer van de gelijknamige release van FISHER.",
+      "alt_artists": [
+        "Alesso, Zara Larsson",
+        "Martin Solveig, Ina Wroldsen",
+        "Axwell, Sebastian Ingrosso, Steve Angello, Laidback Luke"
+      ]
+    },
+    {
+      "artist": "Armin van Buuren, The Stickmen Project",
+      "title": "No Fun",
+      "year": 2021,
+      "isrc": "NLF712109048",
+      "uri": "spotify:track:1q3qh7hEJrPmPH7uOteYSr",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1543695242",
+      "fun_fact": "“No Fun” is the title track of Armin van Buuren’s release of the same name.",
+      "fun_fact_de": "„No Fun“ ist der Titelsong der gleichnamigen Veröffentlichung von Armin van Buuren.",
+      "fun_fact_es": "«No Fun» es la canción que da título al lanzamiento homónimo de Armin van Buuren.",
+      "fun_fact_fr": "« No Fun » est le morceau-titre de la publication éponyme de Armin van Buuren.",
+      "fun_fact_nl": "‘No Fun’ is het titelnummer van de gelijknamige release van Armin van Buuren.",
+      "alt_artists": [
+        "Cosmic Gate",
+        "Diplo, Miguel",
+        "Mike Williams, Mesto"
+      ]
+    },
+    {
+      "artist": "Martin Garrix, Clinton Kane",
+      "title": "Drown (feat. Clinton Kane)",
+      "year": 2020,
+      "isrc": "NLM5S2000785",
+      "uri": "spotify:track:4RVtBlHFKj51Ipvpfv5ER4",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/858386482",
+      "fun_fact": "“Drown (feat. Clinton Kane)” is the title track of Martin Garrix’s release of the same name.",
+      "fun_fact_de": "„Drown (feat. Clinton Kane)“ ist der Titelsong der gleichnamigen Veröffentlichung von Martin Garrix.",
+      "fun_fact_es": "«Drown (feat. Clinton Kane)» es la canción que da título al lanzamiento homónimo de Martin Garrix.",
+      "fun_fact_fr": "« Drown (feat. Clinton Kane) » est le morceau-titre de la publication éponyme de Martin Garrix.",
+      "fun_fact_nl": "‘Drown (feat. Clinton Kane)’ is het titelnummer van de gelijknamige release van Martin Garrix.",
+      "alt_artists": [
+        "Paul van Dyk, Hemstock, Jennings",
+        "Michael Calfan",
+        "Duck Sauce, A-Trak, Armand Van Helden"
+      ]
+    },
+    {
+      "artist": "Felix Da Housecat",
+      "title": "Madame Hollywood",
+      "year": 2001,
+      "isrc": "GBJX32716022",
+      "uri": "spotify:track:6yxsaBtCTog7814X7GjDEv",
+      "uri_apple_music": "applemusic://track/1677879718",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1677879718"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2200270587",
+      "fun_fact": "“Madame Hollywood” appears on Felix Da Housecat’s release “Kittenz and Thee Glitz”.",
+      "fun_fact_de": "„Madame Hollywood“ erschien auf der Veröffentlichung „Kittenz and Thee Glitz“ von Felix Da Housecat.",
+      "fun_fact_es": "«Madame Hollywood» aparece en el lanzamiento «Kittenz and Thee Glitz» de Felix Da Housecat.",
+      "fun_fact_fr": "« Madame Hollywood » figure sur la publication « Kittenz and Thee Glitz » de Felix Da Housecat.",
+      "fun_fact_nl": "‘Madame Hollywood’ staat op de release ‘Kittenz and Thee Glitz’ van Felix Da Housecat.",
+      "alt_artists": [
+        "FÄIS, AFROJACK, Matisse & Sadko",
+        "Delerium, Sarah McLachlan, John Summit",
+        "Eric Prydz, Empire Of The Sun"
+      ]
+    },
+    {
+      "artist": "Zonderling, Don Diablo",
+      "title": "Tunnel Vision - Don Diablo Edit",
+      "year": 2017,
+      "isrc": "NLZ541601462",
+      "uri": "spotify:track:7s2fTKrE24gtReCNgnrRBo",
+      "uri_apple_music": "applemusic://track/1346174729",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1346174729"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/459572422",
+      "fun_fact": "“Tunnel Vision - Don Diablo Edit” appears on Zonderling’s release “Cluster EP”.",
+      "fun_fact_de": "„Tunnel Vision - Don Diablo Edit“ erschien auf der Veröffentlichung „Cluster EP“ von Zonderling.",
+      "fun_fact_es": "«Tunnel Vision - Don Diablo Edit» aparece en el lanzamiento «Cluster EP» de Zonderling.",
+      "fun_fact_fr": "« Tunnel Vision - Don Diablo Edit » figure sur la publication « Cluster EP » de Zonderling.",
+      "fun_fact_nl": "‘Tunnel Vision - Don Diablo Edit’ staat op de release ‘Cluster EP’ van Zonderling.",
+      "alt_artists": [
+        "Coldplay",
+        "Rebūke, Storm, Jam El Mar",
+        "RÜFÜS DU SOL, Cassian"
+      ]
+    },
+    {
+      "artist": "Martin Solveig, Ina Wroldsen",
+      "title": "Places",
+      "year": 2016,
+      "isrc": "UK98Q1600200",
+      "uri": "spotify:track:4QcDkuGQx9824a6X9BZF4e",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/136806118",
+      "fun_fact": "“Places” is the title track of Martin Solveig’s release of the same name.",
+      "fun_fact_de": "„Places“ ist der Titelsong der gleichnamigen Veröffentlichung von Martin Solveig.",
+      "fun_fact_es": "«Places» es la canción que da título al lanzamiento homónimo de Martin Solveig.",
+      "fun_fact_fr": "« Places » est le morceau-titre de la publication éponyme de Martin Solveig.",
+      "fun_fact_nl": "‘Places’ is het titelnummer van de gelijknamige release van Martin Solveig.",
+      "alt_artists": [
+        "Knife Party",
+        "Duke Dumont",
+        "Wilkinson, Becky Hill"
+      ]
+    },
+    {
+      "artist": "Fish Go Deep, Tracey K, Dennis Ferrer",
+      "title": "The Cure & The Cause - Dennis Ferrer Remix",
+      "year": 2006,
+      "isrc": "GBCPZ0601429",
+      "uri": "spotify:track:5mIjBU8wTULTmmKolSXylx",
+      "uri_apple_music": "applemusic://track/1783936709",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1783936709"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3155427641",
+      "fun_fact": "“The Cure & The Cause - Dennis Ferrer Remix” appears on Fish Go Deep’s release “Soul Heaven Presents Digital Heaven”.",
+      "fun_fact_de": "„The Cure & The Cause - Dennis Ferrer Remix“ erschien auf der Veröffentlichung „Soul Heaven Presents Digital Heaven“ von Fish Go Deep.",
+      "fun_fact_es": "«The Cure & The Cause - Dennis Ferrer Remix» aparece en el lanzamiento «Soul Heaven Presents Digital Heaven» de Fish Go Deep.",
+      "fun_fact_fr": "« The Cure & The Cause - Dennis Ferrer Remix » figure sur la publication « Soul Heaven Presents Digital Heaven » de Fish Go Deep.",
+      "fun_fact_nl": "‘The Cure & The Cause - Dennis Ferrer Remix’ staat op de release ‘Soul Heaven Presents Digital Heaven’ van Fish Go Deep.",
+      "alt_artists": [
+        "Swedish House Mafia, Niki & The Dove",
+        "Duck Sauce, A-Trak, Armand Van Helden",
+        "Oden & Fatzo"
+      ]
+    },
+    {
+      "artist": "MORTEN",
+      "title": "Me & You",
+      "year": 2019,
+      "isrc": "NLZ541900381",
+      "uri": "spotify:track:1NuZhF7yzwompkadjLjLFB",
+      "uri_apple_music": "applemusic://track/1457559430",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1457559430"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/664224582",
+      "fun_fact": "“Me & You” is the title track of MORTEN’s release of the same name.",
+      "fun_fact_de": "„Me & You“ ist der Titelsong der gleichnamigen Veröffentlichung von MORTEN.",
+      "fun_fact_es": "«Me & You» es la canción que da título al lanzamiento homónimo de MORTEN.",
+      "fun_fact_fr": "« Me & You » est le morceau-titre de la publication éponyme de MORTEN.",
+      "fun_fact_nl": "‘Me & You’ is het titelnummer van de gelijknamige release van MORTEN.",
+      "alt_artists": [
+        "CHRIS STASSY, S.A.M.",
+        "Paul Oakenfold, Carla Werner, Tiësto",
+        "Martin Garrix, USHER"
+      ]
+    },
+    {
+      "artist": "Surf Mesa, Emilee, ARTY",
+      "title": "ily (i love you baby) (ARTY Remix) [feat. Emilee]",
+      "year": 2020,
+      "isrc": "USUG12001572",
+      "uri": "spotify:track:3mCWozLIaOzbYzyshABNwD",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/942217702",
+      "fun_fact": "“ily (i love you baby) (ARTY Remix) [feat. Emilee]” appears on Surf Mesa’s release “ily (i love you baby) (ARTY Remix)”.",
+      "fun_fact_de": "„ily (i love you baby) (ARTY Remix) [feat. Emilee]“ erschien auf der Veröffentlichung „ily (i love you baby) (ARTY Remix)“ von Surf Mesa.",
+      "fun_fact_es": "«ily (i love you baby) (ARTY Remix) [feat. Emilee]» aparece en el lanzamiento «ily (i love you baby) (ARTY Remix)» de Surf Mesa.",
+      "fun_fact_fr": "« ily (i love you baby) (ARTY Remix) [feat. Emilee] » figure sur la publication « ily (i love you baby) (ARTY Remix) » de Surf Mesa.",
+      "fun_fact_nl": "‘ily (i love you baby) (ARTY Remix) [feat. Emilee]’ staat op de release ‘ily (i love you baby) (ARTY Remix)’ van Surf Mesa.",
+      "alt_artists": [
+        "Matisse & Sadko",
+        "Adrian Lux",
+        "Charlotte de Witte"
+      ]
+    },
+    {
+      "artist": "Lost Frequencies, Tom Gregory",
+      "title": "Dive",
+      "year": 2023,
+      "isrc": "BEHP42300028",
+      "uri": "spotify:track:0CVXJyYIQPnZE2kAHdx2DP",
+      "uri_apple_music": "applemusic://track/1700695874",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1700695874"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2393575535",
+      "fun_fact": "“Dive” is the title track of Lost Frequencies’s release of the same name.",
+      "fun_fact_de": "„Dive“ ist der Titelsong der gleichnamigen Veröffentlichung von Lost Frequencies.",
+      "fun_fact_es": "«Dive» es la canción que da título al lanzamiento homónimo de Lost Frequencies.",
+      "fun_fact_fr": "« Dive » est le morceau-titre de la publication éponyme de Lost Frequencies.",
+      "fun_fact_nl": "‘Dive’ is het titelnummer van de gelijknamige release van Lost Frequencies.",
+      "alt_artists": [
+        "Avicii, Aloe Blacc",
+        "Kungs",
+        "Creeds"
+      ]
+    },
+    {
+      "artist": "Mike Williams",
+      "title": "Day Or Night",
+      "year": 2019,
+      "isrc": "CYA111900215",
+      "uri": "spotify:track:2Y3P9IFAeNGH9qTZDp9N6W",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/740582572",
+      "fun_fact": "“Day Or Night” is the title track of Mike Williams’s release of the same name.",
+      "fun_fact_de": "„Day Or Night“ ist der Titelsong der gleichnamigen Veröffentlichung von Mike Williams.",
+      "fun_fact_es": "«Day Or Night» es la canción que da título al lanzamiento homónimo de Mike Williams.",
+      "fun_fact_fr": "« Day Or Night » est le morceau-titre de la publication éponyme de Mike Williams.",
+      "fun_fact_nl": "‘Day Or Night’ is het titelnummer van de gelijknamige release van Mike Williams.",
+      "alt_artists": [
+        "Tom Staar, Eddie Thoneick",
+        "Zedd, Matthew Koma",
+        "London Grammar"
+      ]
+    },
+    {
+      "artist": "Diplo, Sonny Fodera",
+      "title": "Turn Back Time",
+      "year": 2020,
+      "isrc": "USZ4V2000486",
+      "uri": "spotify:track:1J2OlTIPluzOmf3RX8eKhT",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1145132072",
+      "fun_fact": "“Turn Back Time” is the title track of Diplo’s release of the same name.",
+      "fun_fact_de": "„Turn Back Time“ ist der Titelsong der gleichnamigen Veröffentlichung von Diplo.",
+      "fun_fact_es": "«Turn Back Time» es la canción que da título al lanzamiento homónimo de Diplo.",
+      "fun_fact_fr": "« Turn Back Time » est le morceau-titre de la publication éponyme de Diplo.",
+      "fun_fact_nl": "‘Turn Back Time’ is het titelnummer van de gelijknamige release van Diplo.",
+      "alt_artists": [
+        "MEDUZA, Becky Hill, Goodboys",
+        "The Magician, Olly Alexander (Years & Years)",
+        "ARTBAT, Sailor & I"
+      ]
+    },
+    {
+      "artist": "Armand Van Helden",
+      "title": "My My My",
+      "year": 2004,
+      "isrc": "GBEFR0500419",
+      "uri": "spotify:track:653rxW1E7V52QWh6a7oIdS",
+      "uri_apple_music": "applemusic://track/714934373",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/714934373"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/71110252",
+      "fun_fact": "“My My My” appears on Armand Van Helden’s release “The Best of Armand Van Helden”.",
+      "fun_fact_de": "„My My My“ erschien auf der Veröffentlichung „The Best of Armand Van Helden“ von Armand Van Helden.",
+      "fun_fact_es": "«My My My» aparece en el lanzamiento «The Best of Armand Van Helden» de Armand Van Helden.",
+      "fun_fact_fr": "« My My My » figure sur la publication « The Best of Armand Van Helden » de Armand Van Helden.",
+      "fun_fact_nl": "‘My My My’ staat op de release ‘The Best of Armand Van Helden’ van Armand Van Helden.",
+      "alt_artists": [
+        "Thomas Gold",
+        "Kx5, deadmau5, Kaskade",
+        "Tiësto, Don Diablo, Thomas Troelsen"
+      ]
+    },
+    {
+      "artist": "Tiësto, Poppy Baskcomb",
+      "title": "Drifting",
+      "year": 2023,
+      "isrc": "NLZ542300863",
+      "uri": "spotify:track:4EmH2iRucAgCOnhuJRotUi",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2317153225",
+      "fun_fact": "“Drifting” is the title track of Tiësto’s release of the same name.",
+      "fun_fact_de": "„Drifting“ ist der Titelsong der gleichnamigen Veröffentlichung von Tiësto.",
+      "fun_fact_es": "«Drifting» es la canción que da título al lanzamiento homónimo de Tiësto.",
+      "fun_fact_fr": "« Drifting » est le morceau-titre de la publication éponyme de Tiësto.",
+      "fun_fact_nl": "‘Drifting’ is het titelnummer van de gelijknamige release van Tiësto.",
+      "alt_artists": [
+        "Armin van Buuren, W&W",
+        "Armin van Buuren, The Stickmen Project",
+        "AFROJACK, Steve Aoki, Miss Palmer"
+      ]
+    },
+    {
+      "artist": "Samm",
+      "title": "Body Language",
+      "year": 2025,
+      "isrc": "QMBZ92552535",
+      "uri": "spotify:track:31yljlcH1pEm4Dz85D1KGC",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/3413000091",
+      "fun_fact": "“Body Language” is the title track of Samm’s release of the same name.",
+      "fun_fact_de": "„Body Language“ ist der Titelsong der gleichnamigen Veröffentlichung von Samm.",
+      "fun_fact_es": "«Body Language» es la canción que da título al lanzamiento homónimo de Samm.",
+      "fun_fact_fr": "« Body Language » est le morceau-titre de la publication éponyme de Samm.",
+      "fun_fact_nl": "‘Body Language’ is het titelnummer van de gelijknamige release van Samm.",
+      "alt_artists": [
+        "Lifelike, Kris Menace",
+        "Armin van Buuren, Shapov",
+        "Avicii, MishCatt"
+      ]
+    },
+    {
+      "artist": "SOFI TUKKER, Öwnboss, Fancy Inc",
+      "title": "Summer In New York - Öwnboss & Fancy Inc Remix",
+      "year": 2022,
+      "isrc": "QM37X2200049",
+      "uri": "spotify:track:6aFXimZOxnkqIEshd7d4JE",
+      "uri_apple_music": "applemusic://track/1762727380",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1762727380"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1800448457",
+      "fun_fact": "“Summer In New York - Öwnboss & Fancy Inc Remix” is the title track of SOFI TUKKER’s release of the same name.",
+      "fun_fact_de": "„Summer In New York - Öwnboss & Fancy Inc Remix“ ist der Titelsong der gleichnamigen Veröffentlichung von SOFI TUKKER.",
+      "fun_fact_es": "«Summer In New York - Öwnboss & Fancy Inc Remix» es la canción que da título al lanzamiento homónimo de SOFI TUKKER.",
+      "fun_fact_fr": "« Summer In New York - Öwnboss & Fancy Inc Remix » est le morceau-titre de la publication éponyme de SOFI TUKKER.",
+      "fun_fact_nl": "‘Summer In New York - Öwnboss & Fancy Inc Remix’ is het titelnummer van de gelijknamige release van SOFI TUKKER.",
+      "alt_artists": [
+        "Feist, Boys Noize",
+        "Marian Hill, Franky Rizardo",
+        "Lost Frequencies, Flynn"
+      ]
+    },
+    {
+      "artist": "Yves V, AFROJACK, Icona Pop",
+      "title": "We Got That Cool (feat. Afrojack & Icona Pop)",
+      "year": 2019,
+      "isrc": "NLZ541900844",
+      "uri": "spotify:track:2cFK03sObtI6AK3QKeOT5g",
+      "uri_apple_music": "applemusic://track/1467747046",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1467747046"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/701706242",
+      "fun_fact": "“We Got That Cool (feat. Afrojack & Icona Pop)” is the title track of Yves V’s release of the same name.",
+      "fun_fact_de": "„We Got That Cool (feat. Afrojack & Icona Pop)“ ist der Titelsong der gleichnamigen Veröffentlichung von Yves V.",
+      "fun_fact_es": "«We Got That Cool (feat. Afrojack & Icona Pop)» es la canción que da título al lanzamiento homónimo de Yves V.",
+      "fun_fact_fr": "« We Got That Cool (feat. Afrojack & Icona Pop) » est le morceau-titre de la publication éponyme de Yves V.",
+      "fun_fact_nl": "‘We Got That Cool (feat. Afrojack & Icona Pop)’ is het titelnummer van de gelijknamige release van Yves V.",
+      "alt_artists": [
+        "DJ Hyperactive, Len Faki",
+        "Sub Focus, Culture Shock, Fragma",
+        "Boys Noize"
+      ]
+    },
+    {
+      "artist": "Calvin Harris, Sam Smith, Jessie Reyez",
+      "title": "Promises (with Sam Smith)",
+      "year": 2018,
+      "isrc": "GBARL1801466",
+      "uri": "spotify:track:5N5k9nd479b1xpDZ4usjrg",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/567409842",
+      "fun_fact": "“Promises (with Sam Smith)” appears on Calvin Harris’s release “Promises (Remixes)”.",
+      "fun_fact_de": "„Promises (with Sam Smith)“ erschien auf der Veröffentlichung „Promises (Remixes)“ von Calvin Harris.",
+      "fun_fact_es": "«Promises (with Sam Smith)» aparece en el lanzamiento «Promises (Remixes)» de Calvin Harris.",
+      "fun_fact_fr": "« Promises (with Sam Smith) » figure sur la publication « Promises (Remixes) » de Calvin Harris.",
+      "fun_fact_nl": "‘Promises (with Sam Smith)’ staat op de release ‘Promises (Remixes)’ van Calvin Harris.",
+      "alt_artists": [
+        "Martin Garrix, Jay Hardway",
+        "Chris Lake, Marco Lys",
+        "Martin Garrix, Third Party, Oaks, Declan J Donovan"
+      ]
+    },
+    {
+      "artist": "Gregor Salto, Florian T",
+      "title": "Mundocaso",
+      "year": 2010,
+      "isrc": "NLF541000331",
+      "uri": "spotify:track:4QWBcrylXagFizmFkt6X2t",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/10648388",
+      "fun_fact": "“Mundocaso” appears on Gregor Salto’s release “Horizonte ep”.",
+      "fun_fact_de": "„Mundocaso“ erschien auf der Veröffentlichung „Horizonte ep“ von Gregor Salto.",
+      "fun_fact_es": "«Mundocaso» aparece en el lanzamiento «Horizonte ep» de Gregor Salto.",
+      "fun_fact_fr": "« Mundocaso » figure sur la publication « Horizonte ep » de Gregor Salto.",
+      "fun_fact_nl": "‘Mundocaso’ staat op de release ‘Horizonte ep’ van Gregor Salto.",
+      "alt_artists": [
+        "Jack Ü, Skrillex, Diplo, Kiesza, Tchami",
+        "Topic, Fireboy DML, Nico Santos",
+        "Purple Disco Machine"
+      ]
+    },
+    {
+      "artist": "Maceo Plex, Chromatics",
+      "title": "Shadow (Maceo Plex Remix)",
+      "year": 2021,
+      "isrc": "QZAKB2011745",
+      "uri": "spotify:track:5BAJDNTutBFJL27pKunac1",
+      "uri_apple_music": "applemusic://track/1649265022",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1649265022"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1234385992",
+      "fun_fact": "“Shadow (Maceo Plex Remix)” appears on Maceo Plex’s release “Shadow (Remixes)”.",
+      "fun_fact_de": "„Shadow (Maceo Plex Remix)“ erschien auf der Veröffentlichung „Shadow (Remixes)“ von Maceo Plex.",
+      "fun_fact_es": "«Shadow (Maceo Plex Remix)» aparece en el lanzamiento «Shadow (Remixes)» de Maceo Plex.",
+      "fun_fact_fr": "« Shadow (Maceo Plex Remix) » figure sur la publication « Shadow (Remixes) » de Maceo Plex.",
+      "fun_fact_nl": "‘Shadow (Maceo Plex Remix)’ staat op de release ‘Shadow (Remixes)’ van Maceo Plex.",
+      "alt_artists": [
+        "CHRIS STASSY, S.A.M.",
+        "Vintage Culture, Adam K, MKLA",
+        "Julien Jabre, Jerome Sydenham, Sebastian Ingrosso"
+      ]
+    },
+    {
+      "artist": "Lost Frequencies, Elley Duhé, X Ambassadors",
+      "title": "Back To You",
+      "year": 2022,
+      "isrc": "BEHP42200024",
+      "uri": "spotify:track:4PdSICTVRI1xrXZM1sOSCe",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2023253397",
+      "fun_fact": "“Back To You” is the title track of Lost Frequencies’s release of the same name.",
+      "fun_fact_de": "„Back To You“ ist der Titelsong der gleichnamigen Veröffentlichung von Lost Frequencies.",
+      "fun_fact_es": "«Back To You» es la canción que da título al lanzamiento homónimo de Lost Frequencies.",
+      "fun_fact_fr": "« Back To You » est le morceau-titre de la publication éponyme de Lost Frequencies.",
+      "fun_fact_nl": "‘Back To You’ is het titelnummer van de gelijknamige release van Lost Frequencies.",
+      "alt_artists": [
+        "Lost Frequencies, Calum Scott",
+        "Butch, Kölsch",
+        "FISHER"
+      ]
+    },
+    {
+      "artist": "Zonderling, Andreas Moss",
+      "title": "I Do (feat. Andreas Moss)",
+      "year": 2019,
+      "isrc": "NLZ541900143",
+      "uri": "spotify:track:1HezRYlgnmN4umk4l9HIPv",
+      "uri_apple_music": "applemusic://track/1451341736",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1451341736"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/635276472",
+      "fun_fact": "“I Do (feat. Andreas Moss)” is the title track of Zonderling’s release of the same name.",
+      "fun_fact_de": "„I Do (feat. Andreas Moss)“ ist der Titelsong der gleichnamigen Veröffentlichung von Zonderling.",
+      "fun_fact_es": "«I Do (feat. Andreas Moss)» es la canción que da título al lanzamiento homónimo de Zonderling.",
+      "fun_fact_fr": "« I Do (feat. Andreas Moss) » est le morceau-titre de la publication éponyme de Zonderling.",
+      "fun_fact_nl": "‘I Do (feat. Andreas Moss)’ is het titelnummer van de gelijknamige release van Zonderling.",
+      "alt_artists": [
+        "Marshmello, Khalid, Tiësto",
+        "Fatboy Slim, CamelPhat",
+        "Amber Broos"
+      ]
+    },
+    {
+      "artist": "Lifelike, Kris Menace",
+      "title": "Discopolis",
+      "year": 2006,
+      "isrc": "GBCPZ0501380",
+      "uri": "spotify:track:61RlktJeYy38pu1vY70pgU",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/90383245",
+      "fun_fact": "“Discopolis” appears on Lifelike’s release “Deeper Sessions”.",
+      "fun_fact_de": "„Discopolis“ erschien auf der Veröffentlichung „Deeper Sessions“ von Lifelike.",
+      "fun_fact_es": "«Discopolis» aparece en el lanzamiento «Deeper Sessions» de Lifelike.",
+      "fun_fact_fr": "« Discopolis » figure sur la publication « Deeper Sessions » de Lifelike.",
+      "fun_fact_nl": "‘Discopolis’ staat op de release ‘Deeper Sessions’ van Lifelike.",
+      "alt_artists": [
+        "Gregor Salto, Florian T",
+        "Armin van Buuren, Perpetuous Dreamer",
+        "Kevin de Vries"
+      ]
+    },
+    {
+      "artist": "Martin Garrix, DubVision, Jaimes",
+      "title": "Empty",
+      "year": 2024,
+      "isrc": "NLM5S2402172",
+      "uri": "spotify:track:575ViHchpSUjfTLCQPdE49",
+      "uri_apple_music": "applemusic://track/1732966798",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1732966798"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2675407682",
+      "fun_fact": "“Empty” is the title track of Martin Garrix’s release of the same name.",
+      "fun_fact_de": "„Empty“ ist der Titelsong der gleichnamigen Veröffentlichung von Martin Garrix.",
+      "fun_fact_es": "«Empty» es la canción que da título al lanzamiento homónimo de Martin Garrix.",
+      "fun_fact_fr": "« Empty » est le morceau-titre de la publication éponyme de Martin Garrix.",
+      "fun_fact_nl": "‘Empty’ is het titelnummer van de gelijknamige release van Martin Garrix.",
+      "alt_artists": [
+        "CHRIS STASSY, S.A.M.",
+        "Axwell, Dirty South, Rudy",
+        "Öwnboss, Sevek"
+      ]
+    },
+    {
+      "artist": "Jessie Ware, Disclosure",
+      "title": "Running - Disclosure Remix",
+      "year": 2012,
+      "isrc": "GBUM71201185",
+      "uri": "spotify:track:4Pw5pHYFQYxTyBAh6Qc3Dr",
+      "uri_apple_music": "applemusic://track/1848407764",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1848407764"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/66275128",
+      "fun_fact": "“Running - Disclosure Remix” appears on Jessie Ware’s release “Devotion - The Gold Edition”.",
+      "fun_fact_de": "„Running - Disclosure Remix“ erschien auf der Veröffentlichung „Devotion - The Gold Edition“ von Jessie Ware.",
+      "fun_fact_es": "«Running - Disclosure Remix» aparece en el lanzamiento «Devotion - The Gold Edition» de Jessie Ware.",
+      "fun_fact_fr": "« Running - Disclosure Remix » figure sur la publication « Devotion - The Gold Edition » de Jessie Ware.",
+      "fun_fact_nl": "‘Running - Disclosure Remix’ staat op de release ‘Devotion - The Gold Edition’ van Jessie Ware.",
+      "alt_artists": [
+        "Axwell, Max C",
+        "Armin van Buuren, Sunnery James & Ryan Marciano",
+        "Fatboy Slim, Riva Starr, Beardyman, Calvin Harris"
+      ]
+    },
+    {
+      "artist": "Mark Knight",
+      "title": "Yebisah",
+      "year": 2016,
+      "isrc": "GBJAJ1600685",
+      "uri": "spotify:track:5MYzarVq7dyU7G8z8NQKF2",
+      "uri_apple_music": "applemusic://track/1135950694",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1135950694"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/137751079",
+      "fun_fact": "“Yebisah” appears on Mark Knight’s release “It's Julian Jordan”.",
+      "fun_fact_de": "„Yebisah“ erschien auf der Veröffentlichung „It's Julian Jordan“ von Mark Knight.",
+      "fun_fact_es": "«Yebisah» aparece en el lanzamiento «It's Julian Jordan» de Mark Knight.",
+      "fun_fact_fr": "« Yebisah » figure sur la publication « It's Julian Jordan » de Mark Knight.",
+      "fun_fact_nl": "‘Yebisah’ staat op de release ‘It's Julian Jordan’ van Mark Knight.",
+      "alt_artists": [
+        "John Summit",
+        "Eric Prydz, Floyd",
+        "Dimension"
+      ]
+    },
+    {
+      "artist": "Thomas Gold",
+      "title": "Sing2Me",
+      "year": 2012,
+      "isrc": "GBKCF1200202",
+      "uri": "spotify:track:0aeEe0nk4J2n2GiqSFtvHq",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/113475910",
+      "fun_fact": "“Sing2Me” is the title track of Thomas Gold’s release of the same name.",
+      "fun_fact_de": "„Sing2Me“ ist der Titelsong der gleichnamigen Veröffentlichung von Thomas Gold.",
+      "fun_fact_es": "«Sing2Me» es la canción que da título al lanzamiento homónimo de Thomas Gold.",
+      "fun_fact_fr": "« Sing2Me » est le morceau-titre de la publication éponyme de Thomas Gold.",
+      "fun_fact_nl": "‘Sing2Me’ is het titelnummer van de gelijknamige release van Thomas Gold.",
+      "alt_artists": [
+        "Salif Keita, Martin Solveig",
+        "Lost Frequencies",
+        "Axwell, Sebastian Ingrosso"
+      ]
+    },
+    {
+      "artist": "Paul Kalkbrenner",
+      "title": "Parachute",
+      "year": 2020,
+      "isrc": "DEE862001588",
+      "uri": "spotify:track:3NgAAoUZPkxL5mpvUI7Rl5",
+      "uri_apple_music": "applemusic://track/1522734996",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1522734996"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1015901462",
+      "fun_fact": "“Parachute” is the title track of Paul Kalkbrenner’s release of the same name.",
+      "fun_fact_de": "„Parachute“ ist der Titelsong der gleichnamigen Veröffentlichung von Paul Kalkbrenner.",
+      "fun_fact_es": "«Parachute» es la canción que da título al lanzamiento homónimo de Paul Kalkbrenner.",
+      "fun_fact_fr": "« Parachute » est le morceau-titre de la publication éponyme de Paul Kalkbrenner.",
+      "fun_fact_nl": "‘Parachute’ is het titelnummer van de gelijknamige release van Paul Kalkbrenner.",
+      "alt_artists": [
+        "Martin Garrix, Brooks",
+        "RAFFA GUIDO",
+        "Lost Frequencies, Calum Scott"
+      ]
+    },
+    {
+      "artist": "Pryda",
+      "title": "The Beginning",
+      "year": 2019,
+      "isrc": "GB6CM1900165",
+      "uri": "spotify:track:1lSfGZVuLRNQqoEfzv5Iuc",
+      "uri_apple_music": "applemusic://track/1481875702",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1481875702"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/764557362",
+      "fun_fact": "“The Beginning” appears on Pryda’s release “PRYDA 15 VOL III”.",
+      "fun_fact_de": "„The Beginning“ erschien auf der Veröffentlichung „PRYDA 15 VOL III“ von Pryda.",
+      "fun_fact_es": "«The Beginning» aparece en el lanzamiento «PRYDA 15 VOL III» de Pryda.",
+      "fun_fact_fr": "« The Beginning » figure sur la publication « PRYDA 15 VOL III » de Pryda.",
+      "fun_fact_nl": "‘The Beginning’ staat op de release ‘PRYDA 15 VOL III’ van Pryda.",
+      "alt_artists": [
+        "Delerium, Sarah McLachlan, John Summit",
+        "Krewella, Hardwell",
+        "Massano"
+      ]
+    },
+    {
+      "artist": "Eric Prydz",
+      "title": "Generate",
+      "year": 2015,
+      "isrc": "GBUM71507634",
+      "uri": "spotify:track:4Dg0FSovv3n8IBS9QMezTp",
+      "uri_apple_music": "applemusic://track/1440850841",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1440850841"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/118585318",
+      "fun_fact": "“Generate” appears on Eric Prydz’s release “Opus”.",
+      "fun_fact_de": "„Generate“ erschien auf der Veröffentlichung „Opus“ von Eric Prydz.",
+      "fun_fact_es": "«Generate» aparece en el lanzamiento «Opus» de Eric Prydz.",
+      "fun_fact_fr": "« Generate » figure sur la publication « Opus » de Eric Prydz.",
+      "fun_fact_nl": "‘Generate’ staat op de release ‘Opus’ van Eric Prydz.",
+      "alt_artists": [
+        "Jerome Isma-Ae, Charlotte de Witte",
+        "Max Dean, Luke Dean, Locky",
+        "Dimitri Vegas & Like Mike, W&W"
+      ]
+    },
+    {
+      "artist": "Benny Benassi, Gary Go",
+      "title": "Cinema (feat. Gary Go) - Radio Edit",
+      "year": 2011,
+      "isrc": "USUS11000974",
+      "uri": "spotify:track:4IazOWzgfLB8MR5VIY368A",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/69295405",
+      "fun_fact": "“Cinema (feat. Gary Go) - Radio Edit” appears on Benny Benassi’s release “Electroman”.",
+      "fun_fact_de": "„Cinema (feat. Gary Go) - Radio Edit“ erschien auf der Veröffentlichung „Electroman“ von Benny Benassi.",
+      "fun_fact_es": "«Cinema (feat. Gary Go) - Radio Edit» aparece en el lanzamiento «Electroman» de Benny Benassi.",
+      "fun_fact_fr": "« Cinema (feat. Gary Go) - Radio Edit » figure sur la publication « Electroman » de Benny Benassi.",
+      "fun_fact_nl": "‘Cinema (feat. Gary Go) - Radio Edit’ staat op de release ‘Electroman’ van Benny Benassi.",
+      "alt_artists": [
+        "AN21, Max Vangeli",
+        "David Guetta, Showtek",
+        "Bob Sinclar"
+      ]
+    },
+    {
+      "artist": "Supermode, Axwell, Steve Angello",
+      "title": "Tell Me Why - Original Mix",
+      "year": 2006,
+      "isrc": "GBKCF2000929",
+      "uri": "spotify:track:0zxUWZsgb9HX4WGYvUGkYF",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/997537372",
+      "fun_fact": "“Tell Me Why - Original Mix” appears on Supermode’s release “Tell Me Why”.",
+      "fun_fact_de": "„Tell Me Why - Original Mix“ erschien auf der Veröffentlichung „Tell Me Why“ von Supermode.",
+      "fun_fact_es": "«Tell Me Why - Original Mix» aparece en el lanzamiento «Tell Me Why» de Supermode.",
+      "fun_fact_fr": "« Tell Me Why - Original Mix » figure sur la publication « Tell Me Why » de Supermode.",
+      "fun_fact_nl": "‘Tell Me Why - Original Mix’ staat op de release ‘Tell Me Why’ van Supermode.",
+      "alt_artists": [
+        "Hardwell",
+        "Josh Baker, Omar+",
+        "Martin Garrix, Alesso, Shaun Farrugia"
+      ]
+    },
+    {
+      "artist": "Kid Cudi, Crookers",
+      "title": "Day 'N' Nite - Crookers Remix",
+      "year": 2008,
+      "isrc": "USUM70957532",
+      "uri": "spotify:track:34sGnIHB3ZthMvHpNX1i7e",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/4232307",
+      "fun_fact": "“Day 'N' Nite - Crookers Remix” appears on Kid Cudi’s release “Man On The Moon: The End Of Day (Int'l Version)”.",
+      "fun_fact_de": "„Day 'N' Nite - Crookers Remix“ erschien auf der Veröffentlichung „Man On The Moon: The End Of Day (Int'l Version)“ von Kid Cudi.",
+      "fun_fact_es": "«Day 'N' Nite - Crookers Remix» aparece en el lanzamiento «Man On The Moon: The End Of Day (Int'l Version)» de Kid Cudi.",
+      "fun_fact_fr": "« Day 'N' Nite - Crookers Remix » figure sur la publication « Man On The Moon: The End Of Day (Int'l Version) » de Kid Cudi.",
+      "fun_fact_nl": "‘Day 'N' Nite - Crookers Remix’ staat op de release ‘Man On The Moon: The End Of Day (Int'l Version)’ van Kid Cudi.",
+      "alt_artists": [
+        "Fred again.., Skrillex, Four Tet",
+        "Chris Lake, Marco Lys",
+        "Hardwell, KSHMR"
+      ]
+    },
+    {
+      "artist": "The Magician, Olly Alexander (Years & Years)",
+      "title": "Sunlight (feat. Years and Years)",
+      "year": 2014,
+      "isrc": "GB01A1400003",
+      "uri": "spotify:track:7w9W20r1IpCDQQMRcLEsQZ",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/2986368051",
+      "fun_fact": "“Sunlight (feat. Years and Years)” is the title track of The Magician’s release of the same name.",
+      "fun_fact_de": "„Sunlight (feat. Years and Years)“ ist der Titelsong der gleichnamigen Veröffentlichung von The Magician.",
+      "fun_fact_es": "«Sunlight (feat. Years and Years)» es la canción que da título al lanzamiento homónimo de The Magician.",
+      "fun_fact_fr": "« Sunlight (feat. Years and Years) » est le morceau-titre de la publication éponyme de The Magician.",
+      "fun_fact_nl": "‘Sunlight (feat. Years and Years)’ is het titelnummer van de gelijknamige release van The Magician.",
+      "alt_artists": [
+        "Agents Of Time",
+        "Tom Hangs, Shermanology",
+        "Adam Beyer, Bart Skils"
+      ]
+    },
+    {
+      "artist": "deadmau5, Chris James",
+      "title": "The Veldt",
+      "year": 2012,
+      "isrc": "GBTDG1200438",
+      "uri": "spotify:track:5YaqbhEmoxSpIbdBTPG6KQ",
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/60437441",
+      "fun_fact": "“The Veldt” appears on deadmau5’s release “> album title goes here <”.",
+      "fun_fact_de": "„The Veldt“ erschien auf der Veröffentlichung „> album title goes here <“ von deadmau5.",
+      "fun_fact_es": "«The Veldt» aparece en el lanzamiento «> album title goes here <» de deadmau5.",
+      "fun_fact_fr": "« The Veldt » figure sur la publication « > album title goes here < » de deadmau5.",
+      "fun_fact_nl": "‘The Veldt’ staat op de release ‘> album title goes here <’ van deadmau5.",
+      "alt_artists": [
+        "Joel Corry, James Hype",
+        "John Summit, HAYLA",
+        "AFROJACK"
+      ]
+    },
+    {
+      "artist": "Kosheen, Tinlicker",
+      "title": "Hide U - Tinlicker Remix",
+      "year": 2021,
+      "isrc": "NLF712102759",
+      "uri": "spotify:track:5r43Rwy2cBKF6HQYIS41Bw",
+      "uri_apple_music": "applemusic://track/1557873785",
+      "uri_apple_music_by_region": {
+        "us": "applemusic://track/1557873785"
+      },
+      "uri_youtube_music": null,
+      "uri_tidal": null,
+      "uri_deezer": "deezer://track/1272005622",
+      "fun_fact": "“Hide U - Tinlicker Remix” is the title track of Kosheen’s release of the same name.",
+      "fun_fact_de": "„Hide U - Tinlicker Remix“ ist der Titelsong der gleichnamigen Veröffentlichung von Kosheen.",
+      "fun_fact_es": "«Hide U - Tinlicker Remix» es la canción que da título al lanzamiento homónimo de Kosheen.",
+      "fun_fact_fr": "« Hide U - Tinlicker Remix » est le morceau-titre de la publication éponyme de Kosheen.",
+      "fun_fact_nl": "‘Hide U - Tinlicker Remix’ is het titelnummer van de gelijknamige release van Kosheen.",
+      "alt_artists": [
+        "Armin van Buuren",
+        "Vintage Culture, Goodboys",
+        "Sunnery James & Ryan Marciano, RANI"
+      ]
+    }
+  ],
+  "source": "https://open.spotify.com/playlist/1mB0DBalm5cTnkoi8yDFul"
+}


### PR DESCRIPTION
## What this adds

`community/tomorrowland-top-1000.json` — **825 tracks** from the Tomorrowland Top 1000 Official Playlist that were not already anywhere in the Beatify catalogue. Closes [#2255](https://github.com/mholzi/beatify/issues/2255)'s remaining scope.

Year span **1990–2026**: 1990s 29 · 2000s 107 · 2010s 383 · 2020s 306.

## How the 1002 became 825

| Step | Count |
|---|---|
| Entries in the source playlist | 1002 |
| Already curated, matched by Spotify URI | −119 |
| Already curated, matched by ISRC | −51 |
| No resolvable ISRC, dropped | −7 |
| **Added** | **825** |

The 170 duplicates sit mostly in `edm-anthems` (132 of them) — unsurprising, since 56 of that playlist's tracks came from the same source yesterday.

**The 7 dropped tracks are a deliberate omission, not an oversight.** Netsky — *Rio*, Jeremy Olander — *Let Me Feel*, Anyma — *Running*, Basto & Yves V — *CloudBreaker*, Pryda — *Rebel XX*, John Summit — *Tears*, and Storm — *Storm* have no matching Deezer record and therefore no ISRC. The skill makes ISRC mandatory at creation, because it is the dedup key: writing them without one would make every future request blind to them.

## Where the source came from, and its one caveat

`SPOTIFY_CLIENT_ID` / `SPOTIFY_CLIENT_SECRET` are not set, and the embed route caps at 100 tracks. The full list was harvested from the **public Spotify web player** instead — 97 scroll rounds, no login, 1002 valid track ids, all 100 embed-route tracks contained within them.

**The caveat**: the harvest yields id and title, not artist. Artist, release date and everything else were resolved per track afterwards, from Spotify's own track endpoint, Deezer and MusicBrainz. The first pass at that ran into Spotify's rate limiting and returned only 415 of 883; a slower second pass closed the remaining 468.

## Per-field completion

| Field | Source | Coverage |
|---|---|---|
| `artist`, `title`, `uri` | Spotify | 825/825 |
| `isrc`, `uri_deezer` | Deezer | 825/825 |
| `year` | MusicBrainz first-release-date / Deezer, minimum of the two, ISRC override | 825/825 |
| `uri_apple_music` + `uri_apple_music_by_region.us` | iTunes Search, US storefront only | 555/825 |
| `uri_youtube_music`, `uri_tidal` | left to the agents | 0/825 |
| `fun_fact` ×5, `alt_artists` | generated | 825/825 |

MusicBrainz knows a first-release-date for **716** of the ISRCs; the remaining tracks take Deezer's date. That is stated rather than smoothed over — for those the year rests on a single source.

## The ISRC year rule needed a bound, and finding it took two attempts

The skill says to prefer the ISRC year code when it is at least two years earlier than the provider dates. Across 825 tracks that rule fires **33 times correctly** and **7 times on nonsense**: six tracks from registrant `DEEC3` and one from `GBJX3` carry a *serial number* in the year field, which decodes to **1935** and **1927** for club tracks from 2022–2024.

The first guard I wrote rejected the ISRC whenever two other sources agreed and the ISRC claimed five or more years earlier. It killed the 1935s — and also killed **Underworld — *Born Slippy (Nuxx)***, where MusicBrainz and Deezer agree on 2003 (a reissue) and the ISRC's **1995** is the correct answer. That is precisely the case the override exists for.

The rule that ships instead is blunter and right: **an ISRC year more than 40 years before every other source is not a date.** 2023 − 1935 = 88 → rejected. 2003 − 1995 = 8 → the ISRC wins, and *Born Slippy* is dated 1995.

**What this does not fix**: a serial-number ISRC that happens to decode to a plausible year still wins. Michael Calfan's *Resurrection* takes 2003 from its ISRC against a 2012 provider date, and nothing here can tell whether that is a real early pressing or another serial. Nine such tracks sit between 5 and 40 years of gap.

## Gap balance

Gap balance: YouTube 825 (agent, 90 searches/day, shared) · Apple 270 (agent, Odesli) · Tidal 825 (see note) · region map 825 beyond `us` (no agent)

- **This is by far the largest load ever handed to the YouTube agent.** At 90 searches a day, 825 gaps occupy it for **roughly nine days**, during which nothing else gets filled. That is the real cost of this playlist and it should be a conscious decision, not a surprise.
- **Tidal will stay at 0.** Catalogue-wide, 111 of 115 Tidal gaps are confirmed Odesli refusals; the wave was cut to one daily slot on 18.08 for that reason.
- **The region map beyond `us` is not coming either** — `apple-backfill` writes only the base field. Playback is unaffected: a storefront absent from the map falls through to `uri_apple_music` (`game/playlist.py`).

## Test plan

- `python3 scripts/validate_playlists.py` — 58 files valid, schema gate passed, **0 warnings on the new file**
- `python3 -m json.tool` — parses
- De-duplicated against every file under `custom_components/beatify/playlists/**`, ISRC first, Spotify URI as fallback

Closes #2255

