### PR TITLE
chore(release): v4.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,36 @@ All notable changes to Beatify are documented here. For detailed release notes, 
 
 ## [Unreleased]
 
+## [4.3.0] - 2026-08-21
+
+Released as **4.3.0** rather than 4.2.1: the work shipped as the `v4.2.1-rc1`…`rc3` release
+candidates, but a patch number promises bug fixes and this carries three new features, four
+new playlists and 1,162 more songs. Everything in 4.2.1-rc1 through rc3 is included.
+
 ### Added
-- Added 56 tracks to EDM Anthems from the Tomorrowland Top 1000 Official Playlist (#2255).
+- **Play from your own Music Assistant library (#45, #2082).** Contributed by **@DrMagicWolf**. Games can be sampled from the host's own library (Plex, Jellyfin, local files) instead of a streaming provider, with an enriched cached pool verified against MusicBrainz rather than raw local tags.
+- **The host picks how many rounds a game runs (#1475).** Requested by **@Vanman777**. 10 / 20 / 30 / all / a typed number, with a live duration estimate; a rematch replays at the chosen length.
+- **Italian, end to end (#2234).** Interface, config flow, spoken announcements, fun facts and award names, plus the locale parity guards extended to cover it.
+- **Four new playlists.** `tomorrowland-top-1000` (825), `musica-italiana` (114), `sanremo-vincitori` (68) and `wiesn-party-hits` (100); `edm-anthems` grew 190 → 246. The catalogue is now 58 playlists and 7,142 songs.
+- **Sudden Death names the ending it actually had (#2105).** "Best of the Survivors" when the rounds run out with several players alive.
+
+### Fixed
+- **The host gets their own music back after a game (#2143).** Track, position, shuffle and repeat are captured once per game and restored at the end.
+- **A mid-game speaker switch no longer discards the outgoing speaker's volume (#1516 follow-up).**
+- **The speaker start failure has a way out (#2269).** Persistent banner above the start button with a jump to the speaker list, instead of a toast that fades.
+- **Removing the integration now really removes it (#2263).** Reported by **@proffalken**. `async_remove_entry` clears the saved setup and two storage keys.
+- **The reveal standings no longer cut names off (#2130, #2134).** Reported by **@FurtiveD**. The card scrolls, the band is capped, and rows share the card's height so the text fits without a scrollbar.
+- **"Last One Standing" was announced while others were still standing (#2103).**
+- **Minified CSS was outside the drift guard (#2098).** 31 class rules never reached the stylesheet the browser loads.
+- **291 malformed provider URIs across five playlists (#2247)**, plus a CI schema gate so the next one fails the pull request.
+- **Seven stale Apple Music region ids in `schweizer-hits` (#2274)** and **a dead Apple id for *Surfin' U.S.A.* in `summer-party-anthems` (#2267)**.
+- **Five wrong years (#2272, #2277).** Two Patent Ochsner songs, one by Varius Manx and one that was simply five years early; the fifth established the rule that a cover credited to a different artist carries the year of the linked recording.
+
+### Changed
+- **Music Assistant is set up before Beatify (#2144).**
+- **The backfill agents stop re-asking for answers they already have (#2150)**, and pick their target playlist by fillable gaps rather than raw ones.
+- **The Apple backfill hears a second opinion before rejecting on year (#2116).** Track duration within two seconds overrules the year gate.
+- **Dead reveal CSS removed (#2132).**
 
 ## [4.2.1-rc3] - 2026-08-20
 

--- a/custom_components/beatify/manifest.json
+++ b/custom_components/beatify/manifest.json
@@ -20,5 +20,5 @@
     "num2words==0.5.14"
   ],
   "single_config_entry": true,
-  "version": "4.2.1-rc3"
+  "version": "4.3.0"
 }

--- a/docs/release-notes-v4.3.0.md
+++ b/docs/release-notes-v4.3.0.md
@@ -1,0 +1,62 @@
+## Beatify v4.3.0 — "Your Records, Your Language, Your Length"
+
+Play from the music you already own, run the whole game in Italian, and decide for yourself how long the night lasts. The catalogue grew by a fifth while that was being built.
+
+> **Numbered 4.3.0, not 4.2.1.** The work shipped as three release candidates called `v4.2.1-rc1`…`rc3`, but a patch number promises bug fixes. This carries three new features, four new playlists and 1,162 more songs. The release candidates keep their names in the history; the release does not inherit theirs.
+
+### 🎚️ Play from your own record crate
+
+Beatify can now build a game out of the music in your own Music Assistant library — Plex, Jellyfin, local files — instead of a streaming provider. Pick the library as your source in the setup wizard and the game runs on your own collection.
+
+Playback was never the hard part; Music Assistant already plays a library track. The hard part was *metadata good enough to guess against*. Local tags carry the year of the pressing, so a shelf full of greatest-hits rips makes every era look like the nineties. A difficulty setting means nothing if "famous" means famous inside one collection. And Music Assistant's list views return no genres at all. So the mode builds an enriched, cached pool of your library, checked against MusicBrainz, rather than reading the tags and hoping.
+
+Contributed by **@DrMagicWolf** — the largest external contribution the project has had. Six provider-neutral fixes travelled with it and help every user, whether or not they ever switch the mode on.
+
+### ⏱️ The host decides how long a night runs
+
+A game used to play every song of every playlist you picked, so a hundred-song playlist meant a two-hour evening nobody asked for. Step 4 of the setup wizard now offers 10, 20, 30, everything, or a number you type, with a live estimate of how long that takes. A rematch replays at the same length.
+
+Requested by **@Vanman777** on 15 June and open for 57 days — the only external feature request in the tracker.
+
+### 🇮🇹 Si gioca in italiano
+
+Pick Italian in the setup wizard and everyone gets it: the lobby, the player screens, the scoreboard, the spoken announcements, the song trivia and the award names. Home Assistant's own setup dialog is translated too, so it starts in Italian before the game does.
+
+The gap this closes was visible from outside the project — the catalogue had carried Italian music for weeks while the language picker offered five languages, none of them Italian.
+
+### 📺 The television shows all of it
+
+The reveal standings used to cut names off with no scrollbar and no hint that there was more, and the lower band grew without limit in exactly the rounds where the standings matter most. The card scrolls now and the band is capped.
+
+A scrollbar is not operable on a television with no pointer, though, so the rows also share the card's height and the type scales with the row — the standings fit at any player count and any screen height rather than merely being scrollable by someone who cannot scroll.
+
+Reported by **@FurtiveD**.
+
+### 🔊 Speakers, and getting your own music back
+
+- **Your listening survives the game.** Every round is played with `enqueue: "replace"`, which wipes whatever Music Assistant had queued. Nothing was ever remembered, so a game ended with the speaker parked on Beatify's last track. The current track, playback position, shuffle flag and repeat mode are captured once per game and handed back at the end; the track returns paused, at the position it was at.
+- **Switching speakers mid-game keeps its promises.** The switch used to discard the outgoing speaker's pre-game volume and leave it at party level forever. Each speaker is now restored to its own captured level.
+- **A speaker that cannot play is no longer a dead end.** The message used to be a toast that faded on its own, leaving the host in front of an unchanged screen with no hint left. It is a persistent banner above the start button now, and it carries a button that opens the speaker list and jumps to it.
+- **Removing the integration really removes it.** Beatify had no `async_remove_entry` at all, so the saved setup and two Home Assistant storage keys survived a delete and handed a fresh install the speaker entity ids of the old one. Reported by **@proffalken**.
+
+### ☠️ Sudden Death names the ending it actually had
+
+When the rounds run out with two or more players still alive, nobody is the last one standing. The end screen had no words for that and, worse, announced "Last One Standing" while the leaderboard directly below showed several survivors. It now shows **Best of the Survivors** with the count that explains it, and a genuine one-against-one finish keeps the trophy.
+
+This became reachable the moment the round count was selectable: elimination removes one player per round, so a cap of ten rounds leaves eleven players with two survivors.
+
+### 🎧 The catalogue grew by a fifth
+
+**54 playlists and 5,980 songs became 58 and 7,142.**
+
+- **Tomorrowland Top 1000 — 825 songs.** The festival's own ranking, from Faithless in 1995 to this year's mainstage. 170 of the 1,002 entries were already curated elsewhere and are not duplicated here.
+- **Musica Italiana — 114 songs**, 1960s to 2000s, and **Sanremo: I Vincitori — 68 songs**, every festival winner since 1951. The Sanremo years come from the official *Albo d'oro* rather than from streaming metadata, which dates reissues instead of songs.
+- **Wiesn Party Hits — 100 songs**, in time for the season.
+- **EDM Anthems 190 → 246**, with the 56 Tomorrowland tracks that were not already somewhere in the catalogue.
+
+### 🔧 And it was audited while it grew
+
+- **291 malformed provider links across five playlists.** Bare numeric ids and web URLs where the player expects a provider URI. Nineteen songs had a broken link with nothing behind it in seven storefronts, because a song carrying a region map drops its plain link entirely. The build now checks the shape of every provider link, so the next one fails the pull request instead of reaching a player.
+- **Seven Apple ids in Swiss Hits pointed at other songs** — six of them at breathing exercises and a Lewis Capaldi track, one at an Ultimo song.
+- **The Beach Boys are playable again.** *Surfin' U.S.A.* carried the same dead Apple Music id in all seven storefronts, with a healthy id sitting unused beside it.
+- **Five wrong years, and a rule that did not exist before.** Two Patent Ochsner songs and one by Varius Manx were dated to a later unplugged or acoustic recording rather than to the song. A fourth was simply five years early. The fifth exposed a gap: for a *cover by a different artist* the convention said nothing, and the catalogue was quietly answering it two opposite ways. It now takes the year of the linked recording — the room hears the cover, so the answer should match the speaker.


### PR DESCRIPTION
## What this is

The release cut for **v4.3.0** — manifest bump, changelog section, and the release notes under `docs/`.

Everything that shipped as `v4.2.1-rc1` through `rc3` is in here, plus the eleven merges that landed after rc3.

## Why 4.3.0 and not 4.2.1

The release candidates are named `v4.2.1-rc1`…`rc3`, so the obvious cut would be 4.2.1. A patch number promises bug fixes, and this is not that:

- **Three new features** — play from your own Music Assistant library, a selectable round count, and Italian end to end
- **Four new playlists** and one substantially grown, taking the catalogue from **54 playlists / 5,980 songs to 58 / 7,142**
- **195 commits** since v4.2.0

For comparison, v4.1.0 "Rock Solid, New Look" was a minor bump for less. The release candidates keep their names in the git history; the release does not inherit theirs, and both the notes and the changelog say so explicitly so nobody has to guess when they read the tag list.

## What is in the diff

| File | Change |
|---|---|
| `custom_components/beatify/manifest.json` | `4.2.1-rc3` → `4.3.0` |
| `CHANGELOG.md` | new `## [4.3.0]` section covering rc1–rc3 and everything merged since |
| `docs/release-notes-v4.3.0.md` | new — the narrative notes |

**`docs/` is gitignored**, so the notes file needed `git add -f`. This is the same trap that nearly lost rc16 through rc21: without the force-add the file simply is not in the commit, and nothing warns you.

## Merged since rc3, all covered in the changelog

`#2268` dead Apple id for *Surfin' U.S.A.* · `#2270` the speaker failure gets a way out · `#2271` 56 Tomorrowland tracks into EDM Anthems · `#2273` and `#2279` YouTube backfill · `#2275` seven stale Apple region ids in Swiss Hits · `#2276` four wrong years · `#2278` the cover-year rule · `#2280` the Tomorrowland playlist · `#2281` 191 Apple ids for it

## One thing to know before merging

**CI is not running on pull requests in this repository right now.** The last event-triggered workflow run was at 09:13Z; since then no `pull_request` or `push` event has produced a run at all — verified across four separate triggers on [#2282](https://github.com/mholzi/beatify/pull/2282) (creation, ready-for-review, close/reopen, and an empty commit). GitHub reports Actions as operational and the repository's Actions permissions are unchanged.

`Validate` has a `workflow_dispatch` trigger and was run manually against this branch. `Test` has no such trigger and cannot be forced.

So this pull request may well show no checks. The playlist schema gate passed locally (`58 files valid`), and the diff touches no Python or JavaScript — but that is a statement about risk, not a substitute for the test suite.

## After the merge

The tag and the GitHub release are **not** part of this pull request. Once it is on `main`:

```
git tag v4.3.0 <squash-sha> && git push origin v4.3.0
gh release create v4.3.0 --title "v4.3.0 — Your Records, Your Language, Your Length" \
  --notes-file docs/release-notes-v4.3.0.md --latest
```
