### PR TITLE
fix(backfill): a refused request is not an answer about the catalogue

### DIFF
--- a/.claude/skills/provider-uri-backfill/scripts/backfill_provider_uris.py
+++ b/.claude/skills/provider-uri-backfill/scripts/backfill_provider_uris.py
@@ -695,11 +695,16 @@ def record_provider_misses(
     attempted: list[str],
     song: dict,
     now: datetime,
+    http_status: int | None = None,
 ) -> int:
     """Record a miss for every attempted provider still unfilled. Returns count.
 
     ``attempted`` must contain only providers that were genuinely queried this
     run — never ones skipped because the source was unavailable.
+
+    ``http_status`` is the code behind the refusal, or ``None`` when the source
+    answered cleanly and simply had no link. It is stored alongside the
+    timestamp so a later incident can be told apart from a genuine "no".
     """
     stamp = now.strftime("%Y-%m-%dT%H:%MZ")
     n = 0
@@ -707,7 +712,18 @@ def record_provider_misses(
         field = PROVIDER_FIELDS.get(prov)
         if not field or (song.get(field) or "").strip():
             continue
-        misses.setdefault(uri, {})[prov] = stamp
+        # Wert ist ``{"at": <stamp>, "http": <code|None>}`` statt eines nackten
+        # Zeitstempels (21.08.2026). Der Code ist die einzige Spur, an der sich
+        # ein spaeterer Vorfall wieder aufraeumen laesst: als Odesli am 19.08.
+        # begann, jede Anfrage mit 401 zu beantworten, war der Tidal-Speicher
+        # reparierbar, WEIL er den Code fuehrte — 238 vergiftete Eintraege liessen
+        # sich exakt greifen. Dieser Speicher fuehrte nur einen Zeitstempel; ein
+        # gleichartiger Vorfall waere hier unsichtbar geblieben.
+        #
+        # Alte Eintraege sind blosse Strings. Leser duerfen deshalb NICHT davon
+        # ausgehen, einen dict zu bekommen — ``pick_target_playlist.py`` liest
+        # ohnehin nur die Schluessel und ist von der Form unberuehrt.
+        misses.setdefault(uri, {})[prov] = {"at": stamp, "http": http_status}
         n += 1
     return n
 

--- a/scripts/backfill_tidal.py
+++ b/scripts/backfill_tidal.py
@@ -69,6 +69,17 @@ TIDAL_TRACK_RE = re.compile(r"/track/(\d+)")
 BASE_DELAY_S = 6.0  # between successful requests
 BACKOFF_BASE_S = 8.0  # 429 backoff: BACKOFF_BASE * attempt
 MAX_429_ATTEMPTS = 3  # then skip (NOT recorded as a miss)
+
+# Statuscodes, mit denen der Server die *Anfrage verweigert*, statt eine Auskunft
+# ueber den Katalog zu geben. Sie gehoeren zu 429 und 5xx, nicht zu den Misses.
+#
+# Warum das eine eigene Zeile wert ist (21.08.2026): Odesli hat seine oeffentliche
+# API abgeschaltet und antwortet seit dem 19.08. auf jede Anfrage mit
+# ``401 PUBLIC_API_ACCESS_DEPRECATED``. Der 4xx-Zweig unten hielt das fuer eine
+# Auskunft und schrieb ``status: miss`` — in drei Tagen **238 Eintraege**, also
+# 238 Songs, die nie wieder abgefragt worden waeren. Ein 401 oder 403 sagt nichts
+# darueber, ob Tidal den Song hat; er sagt, dass wir nicht fragen durften.
+SERVER_REFUSED = (401, 403)
 REQUEST_TIMEOUT_S = 25
 
 
@@ -122,10 +133,13 @@ def query_odesli(spotify_id: str) -> tuple[str | None, str, int | None]:
 
     * ``hit``   — 200 with a usable Tidal link.
     * ``miss``  — Odesli will not give us a Tidal link for this track. Either a
-      200 without one, or a 4xx other than 429: those describe the *request*,
-      not the server's mood, so repeating it verbatim cannot change the answer.
-    * ``retry`` — 429, 5xx, or a network/parse error. Genuinely transient;
-      deliberately not recorded, so the next wave tries again.
+      200 without one, or a 4xx other than 429/401/403: those describe the
+      *request*, not the server's mood, so repeating it verbatim cannot change
+      the answer.
+    * ``retry`` — 429, 5xx, **401/403**, or a network/parse error. Genuinely
+      transient; deliberately not recorded, so the next wave tries again.
+      401 and 403 belong here because they describe our *access*, not the
+      catalogue: the server refused to answer rather than answering "no".
 
     ``http_status`` is the code behind a ``miss`` or ``retry`` and ``None`` for
     a clean 200. It is stored with the miss so a permanent refusal can later be
@@ -163,7 +177,7 @@ def query_odesli(spotify_id: str) -> tuple[str | None, str, int | None]:
                 sys.stderr.write(f"  429 backoff {wait:.0f}s (attempt {attempt})\n")
                 time.sleep(wait)
                 continue
-            if 500 <= exc.code < 600:
+            if 500 <= exc.code < 600 or exc.code in SERVER_REFUSED:
                 sys.stderr.write(f"  HTTP {exc.code} -> retry next wave\n")
                 return None, "retry", exc.code
             sys.stderr.write(f"  HTTP {exc.code} -> recorded as miss\n")

--- a/tests/unit/test_backfill_tidal.py
+++ b/tests/unit/test_backfill_tidal.py
@@ -92,9 +92,14 @@ def test_200_without_tidal_link_is_a_miss_without_status(monkeypatch, bt):
     assert status is None
 
 
-@pytest.mark.parametrize("code", [400, 403, 404, 422])
+@pytest.mark.parametrize("code", [400, 404, 422])
 def test_non_429_client_errors_are_recorded_as_misses(monkeypatch, bt, code):
-    """The bug in #2200: these were 'skip' and therefore never written down."""
+    """The bug in #2200: these were 'skip' and therefore never written down.
+
+    403 was in this list until 2026-08-21 and has moved to the retryable set —
+    see ``test_auth_refusal_is_retryable``. A 400, 404 or 422 describes the
+    request we sent; a 401 or 403 describes whether we were allowed to send it.
+    """
     calls = _patch_urlopen(monkeypatch, bt, lambda _n: _http_error(code))
 
     uri, outcome, status = bt.query_odesli("abc")
@@ -102,6 +107,24 @@ def test_non_429_client_errors_are_recorded_as_misses(monkeypatch, bt, code):
     assert (uri, outcome, status) == (None, "miss", code)
     # One shot only — retrying a 4xx verbatim cannot change the answer.
     assert calls["n"] == 1
+
+
+@pytest.mark.parametrize("code", [401, 403])
+def test_auth_refusal_is_retryable(monkeypatch, bt, code):
+    """A refused request is not an answer about the catalogue (2026-08-21).
+
+    Odesli shut its public API down and answered every request with
+    ``401 PUBLIC_API_ACCESS_DEPRECATED`` from 19 August. The 4xx branch read
+    that as "Tidal does not have this track" and wrote 238 songs into the miss
+    cache over three days — 238 songs that would never have been asked about
+    again. A 401 or 403 says nothing about the catalogue; it says we were not
+    allowed to ask.
+    """
+    _patch_urlopen(monkeypatch, bt, lambda _n: _http_error(code))
+
+    uri, outcome, status = bt.query_odesli("abc")
+
+    assert (uri, outcome, status) == (None, "retry", code)
 
 
 @pytest.mark.parametrize("code", [500, 502, 503])


### PR DESCRIPTION
## What this changes

`scripts/backfill_tidal.py` treated **every 4xx except 429 as an answer about the catalogue**. It is not. A `401` or `403` says the server refused the request; it says nothing about whether Tidal carries the track.

401 and 403 now join 429 and 5xx in the retryable set, so the next wave asks again instead of writing the song off.

## What it cost before the fix

Odesli shut down its public API. Since **19 August** every request returns `401 PUBLIC_API_ACCESS_DEPRECATED`, and the 4xx branch recorded each one as `status: miss`:

| Date | HTTP 401 in the wave log | written to the cache as a confirmed refusal |
|---|---|---|
| 17–18 Aug | 0 | 0 |
| **19 Aug** | 228 | **114** |
| **20 Aug** | 134 | **67** |
| **21 Aug** | 114 | **57** |

**238 songs** were marked as "Tidal demonstrably does not have this" without a single answer from Tidal.

**The damage spread beyond Tidal.** Since 14 August the Apple, Deezer and YouTube agents pick their target playlist by *fillable* gaps — gaps minus confirmed refusals. That change was right and well argued, and it makes those agents entirely dependent on a refusal being real. On the morning of 21 August both Apple and Deezer reported `nochange` with "no fillable gaps in the catalogue". The backfill had been dead for three days and was reporting it as success.

The 238 entries were cleaned out separately; this pull request stops them coming back.

## Only one of the four scripts was affected — and it is worth saying why

The task as I framed it was "harden all four backfill scripts". Reading them, that turned out to be wrong: `apple-backfill.sh`, `deezer-backfill.sh` and `youtube-backfill.sh` all run `backfill_provider_uris.py`, which **already** guards this correctly. Its `attempted_providers()` records a miss only for providers genuinely queried, and when Odesli fails to answer it counts only the two paths that run independently of it. The docstring even names the failure mode: *"sonst wird aus einer Sperre eine dauerhafte Absage."*

The evidence agrees. That store holds **184 refusals, of which only 4 fall inside the 401 window** — and those four came from the iTunes fallback, which really did run. The Tidal store holds 238 from the same three days.

So the fix belongs in one file, not four.

## The second change: the shared store now records the HTTP code

`record_provider_misses()` wrote a bare timestamp. It now writes `{"at": <stamp>, "http": <code|None>}`.

This is not fixing a bug — it is making the next one recoverable. The Tidal incident was repairable **only because that store carried the code**: `http == 401` picked the 238 poisoned rows out of 3,049 exactly. The shared store had no such field, so an identical incident there would have been indistinguishable from genuine refusals and unrecoverable.

Old entries are plain strings. `pick_target_playlist.py` reads only the keys of that mapping and is unaffected by the value's shape; the comment in the code says so, so the next reader does not have to rediscover it.

## Tests

- `test_auth_refusal_is_retryable` — new, parametrised over 401 and 403, with the incident in the docstring so the reason survives the next refactor
- `test_non_429_client_errors_are_recorded_as_misses` — **403 removed from its parameters**. It was asserting the old behaviour and failed on the first run, which is exactly what it is for. The docstring now says where 403 went and why 400/404/422 stay: those describe the request we sent, 401/403 describe whether we were allowed to send it.

`pytest tests/unit/test_backfill_tidal.py` 14 passed · `pytest tests/unit/test_provider_uri_backfill.py` 99 passed.

## What this does not do

Odesli is still unreachable. This change stops the outage from poisoning the cache; it does not restore the backfill. The YouTube path works regardless — it uses Odesli only as a free first look and falls through to the YouTube Data API — but Tidal, Apple and Deezer resolution needs Odesli replaced or licensed.
