### PR TITLE
data(sanremo-vincitori): Messaggio d'Amore linked a live recording

### DIFF
--- a/custom_components/beatify/playlists/community/sanremo-vincitori.json
+++ b/custom_components/beatify/playlists/community/sanremo-vincitori.json
@@ -1,7 +1,7 @@
 {
   "name": "Sanremo: I Vincitori 🇮🇹",
   "description": "Every winning song of the Sanremo Music Festival, from Nilla Pizzi in 1951 to Sal Da Vinci in 2026. Years verified against the official Albo d'oro. Requested in #2230.",
-  "version": "0.6",
+  "version": "0.7",
   "tags": [
     "italian",
     "sanremo",
@@ -1005,7 +1005,7 @@
       "isrc": "ITC220200001",
       "uri_apple_music": "applemusic://track/1623153240",
       "uri_apple_music_by_region": {},
-      "uri_deezer": "deezer://track/596448882",
+      "uri_deezer": "deezer://track/1745225757",
       "uri_youtube_music": null,
       "uri_tidal": null
     },


### PR DESCRIPTION
## The check, and its mostly-negative result

`tomorrowland-top-1000` was built by a Deezer matcher with no edition guard and ended up with **17 wrong recordings out of 825** ([#2284](https://github.com/mholzi/beatify/issues/2284)). `musica-italiana` and `sanremo-vincitori` came from the same matcher, so every Deezer link in both was re-checked against the live Deezer record.

**182 links checked. Two genuine findings, and one of them stays as it is.**

The defect is far rarer here, and the reason is worth writing down: edition ambiguity is an EDM problem. Tomorrowland is full of tracks that exist as a radio edit, an extended mix, four remixes and a continuous-mix cut. Sanremo winners from 1951 to 2026 mostly exist once.

## Fixed

**Matia Bazar — *Messaggio D'Amore*** pointed at `596448882`, which Deezer labels **(Live)**. A studio recording exists under `1745225757` and is now linked. A live take has audience noise and a different arrangement; in a guessing game it is a different recording even though the song is right.

`community/sanremo-vincitori` 0.6 → 0.7.

## Found and deliberately left alone

**Francesco Gabbani — *Occidentali's Karma*** points at a **(Radio Edit)**. Deezer carries no unmarked version of this recording — the alternatives it offers are a *Eurovision Version*, a *Live* take and six remixes, all from the same 2026 reissue package. A radio edit is the same performance, shortened; a Eurovision version is not. Swapping one edition marker for a worse one would be motion without improvement, so the link stays.

## Dismissed as false positives

- **Domenico Modugno — *Ciao Ciao Bambina - Piove*** against Deezer's *Piove (Ciao ciao bambina)*. Same song, the two halves of the title swapped.
- **Al Bano & Romina Power — *Ci Sarà (There Will Be)*** against *Ci sarà*. Same song; the catalogue entry carries an English gloss that Deezer does not.

Both would have been "wrong artist or title" to a similarity threshold. Neither is wrong.

## No issue opened for this one

The playlist-review routine files an issue before the fix. One changed link did not seem worth it, and the reasoning that would have gone in the issue is above. Said explicitly so the deviation is visible rather than silent.

## Test plan

- `python3 scripts/validate_playlists.py` — 58 files valid, schema gate passed, no warnings on the changed file
- One `uri_deezer` field changed, playlist version bumped
- `musica-italiana` needed no change: 114 links, zero findings
