### PR TITLE
data(tomorrowland-top-1000): correct Coldplay ISRC, fill its Deezer gap

### DIFF
--- a/custom_components/beatify/playlists/community/tomorrowland-top-1000.json
+++ b/custom_components/beatify/playlists/community/tomorrowland-top-1000.json
@@ -1,6 +1,6 @@
 {
   "name": "Tomorrowland Top 1000",
-  "version": "0.4",
+  "version": "0.5",
   "tags": [
     "edm",
     "electronic",
@@ -1145,7 +1145,7 @@
       "artist": "Coldplay",
       "title": "Paradise - Fedde le Grand Remix",
       "year": 2011,
-      "isrc": "GBAYE1101454",
+      "isrc": "GBAYE1101369",
       "uri": "spotify:track:7BOSqLjA3lnA3dKh29pOuQ",
       "uri_apple_music": "applemusic://track/665202776",
       "uri_apple_music_by_region": {
@@ -1153,6 +1153,7 @@
       },
       "uri_youtube_music": null,
       "uri_tidal": null,
+      "uri_deezer": "deezer://track/75815486",
       "fun_fact": "“Paradise - Fedde le Grand Remix” appears on Coldplay’s release “Princess of China”.",
       "fun_fact_de": "„Paradise - Fedde le Grand Remix“ erschien auf der Veröffentlichung „Princess of China“ von Coldplay.",
       "fun_fact_es": "«Paradise - Fedde le Grand Remix» aparece en el lanzamiento «Princess of China» de Coldplay.",


### PR DESCRIPTION
## What

One row in `tomorrowland-top-1000`: **Coldplay — Paradise - Fedde le Grand Remix**.

- `isrc` **GBAYE1101454 → GBAYE1101369**
- `uri_deezer` **absent → deezer://track/75815486**
- playlist `version` 0.4 → 0.5

## Why the old ISRC was wrong

GBAYE1101454 is the **Tiësto** remix, not the Fedde le Grand one. Two independent checks say so:

- `GET api.deezer.com/track/34563951` — the Tiësto remix — reports `isrc: GBAYE1101454` on its own record.
- `GET api.deezer.com/2.0/track/isrc:GBAYE1101454` returns *Paradise (Tiësto Remix)*.

The Apple link on the entry (`665202776`) is correct — an iTunes lookup on that id returns *Paradise (Fedde le Grand Remix)*, album *Toolroom Ten*. So the link was right and only the ISRC field was wrong; this is not a mis-matched track.

## Why GBAYE1101369 is right

- Two MusicBrainz recordings of *Paradise (Fedde Le Grand remix)* carry `GBAYE1101369`.
- `GET api.deezer.com/2.0/track/isrc:GBAYE1101369` returns *Paradise (Fedde le Grand Remix)* by Coldplay, track **75815486**.

Same registrant (GBAYE, Parlophone) and same year block (11) as the wrong value — the two remixes differ only in the designation code, which is how the mix-up happened in the first place.

## Why it is worth a PR for one row

The ISRC is the **dedup key**. A later import of the Tiësto remix would have matched this entry's ISRC and been dropped as a duplicate — silently, and of a different recording. A wrong ISRC does not misplay anything today; it removes a future track.

## Side effect

The same lookup produced the Deezer link the entry was missing, so the gap turned out to be fillable rather than a confirmed refusal. Deezer's `search` endpoint does not surface this track for `Coldplay Paradise Fedde le Grand` (0 results) — only the ISRC lookup finds it, which is the argument for using ISRC resolution over title search wherever an ISRC exists.

## Scope

This is the only defect of its kind found in the playlist. All 819 entries with a Deezer link were checked against what Deezer reports for that exact track id: 8 differ, but in all 8 the Deezer title matches ours — those are other pressings of the same recording, not wrong links, and they are left alone.