### PR TITLE
Give every error response a log line

### DIFF
--- a/custom_components/beatify/server/base.py
+++ b/custom_components/beatify/server/base.py
@@ -305,10 +305,31 @@ def _json_error(
     admin UI can render — e.g. the structured per-song rejections from a
     failed playlist import (#1576). Merged into the body under their own keys
     so clients ignoring them are unaffected.
+
+    Every call also emits one WARNING carrying the status, code and message
+    (#2294), so a rejected request is findable in ``system_log`` afterwards.
     """
     body: dict[str, Any] = {"code": code, "error": code, "message": message}
     if details:
         body.update(details)
+    # #2294: every error response leaves a trace. Until now none of them did —
+    # the 33 call sites all return silently, so a failed request produced
+    # nothing in the log at all. On 2026-08-21 a host could not start a game
+    # for an evening; the screen said "this request was invalid, check your
+    # setup" (one generic string shared by twelve different rejections) and
+    # `system_log` held zero Beatify entries. The actual cause, "Media player
+    # is unavailable" after Music Assistant had been down for five days, was
+    # known right here and written nowhere.
+    #
+    # WARNING rather than INFO on purpose: Home Assistant's `system_log` — the
+    # list behind Settings > System > Logs and the one an assistant queries
+    # first — only collects WARNING and above. An INFO line would have been
+    # just as invisible during that evening's search as no line at all.
+    #
+    # One line per response, code and message both, no request context: adding
+    # the path would mean threading `request` through all 33 call sites for a
+    # detail the code already implies.
+    _LOGGER.warning("HTTP %s %s: %s", status, code, message)
     return web.json_response(body, status=status)
 
 

--- a/tests/unit/test_json_error.py
+++ b/tests/unit/test_json_error.py
@@ -9,6 +9,7 @@ i18n-by-code lookup were both silently dead.
 from __future__ import annotations
 
 import json
+import logging
 
 import pytest
 
@@ -59,3 +60,55 @@ class TestJsonError:
         body = json.loads(resp.body)
         assert body["code"] == "GAME_IN_LOBBY"
         assert body["message"].startswith("A game is already in the lobby")
+
+
+class TestJsonErrorLogging:
+    """#2294 — every error response must leave a trace.
+
+    Before this, all 33 call sites returned silently. On 2026-08-21 a host
+    could not start a game for an evening: the banner showed the one generic
+    string that twelve different rejections share, and ``system_log`` held
+    zero Beatify entries. The reason — "Media player is unavailable" — was
+    known inside this helper and written nowhere.
+    """
+
+    @pytest.mark.asyncio
+    async def test_logs_status_code_and_message(self, caplog):
+        with caplog.at_level(logging.WARNING, logger="custom_components.beatify.server.base"):
+            _json_error("Media player is unavailable", 400, code="INVALID_REQUEST")
+        assert "400" in caplog.text
+        assert "INVALID_REQUEST" in caplog.text
+        # The message is the whole point: the code alone cannot distinguish
+        # this from "No playlists selected".
+        assert "Media player is unavailable" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_logs_at_warning_so_system_log_collects_it(self, caplog):
+        # Home Assistant's system_log — Settings > System > Logs, and the
+        # first place anyone looks — only collects WARNING and above. An INFO
+        # line would have been exactly as invisible as no line at all.
+        with caplog.at_level(logging.DEBUG, logger="custom_components.beatify.server.base"):
+            _json_error("Media player is unavailable", 400, code="INVALID_REQUEST")
+        records = [r for r in caplog.records if "INVALID_REQUEST" in r.getMessage()]
+        assert records, "the error response produced no log record at all"
+        assert all(r.levelno >= logging.WARNING for r in records)
+
+    @pytest.mark.asyncio
+    async def test_two_rejections_sharing_a_code_are_distinguishable_in_the_log(self, caplog):
+        with caplog.at_level(logging.WARNING, logger="custom_components.beatify.server.base"):
+            _json_error("Media player is unavailable", 400, code="INVALID_REQUEST")
+            _json_error("No playlists selected", 400, code="INVALID_REQUEST")
+        assert "Media player is unavailable" in caplog.text
+        assert "No playlists selected" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_logging_does_not_change_the_response_body(self, caplog):
+        resp = _json_error("Test message", 409, code="TEST_CODE", details={"extra": 1})
+        body = json.loads(resp.body)
+        assert body == {
+            "code": "TEST_CODE",
+            "error": "TEST_CODE",
+            "message": "Test message",
+            "extra": 1,
+        }
+        assert resp.status == 409

--- a/tests/unit/test_json_error.py
+++ b/tests/unit/test_json_error.py
@@ -74,7 +74,9 @@ class TestJsonErrorLogging:
 
     @pytest.mark.asyncio
     async def test_logs_status_code_and_message(self, caplog):
-        with caplog.at_level(logging.WARNING, logger="custom_components.beatify.server.base"):
+        with caplog.at_level(
+            logging.WARNING, logger="custom_components.beatify.server.base"
+        ):
             _json_error("Media player is unavailable", 400, code="INVALID_REQUEST")
         assert "400" in caplog.text
         assert "INVALID_REQUEST" in caplog.text
@@ -87,15 +89,21 @@ class TestJsonErrorLogging:
         # Home Assistant's system_log — Settings > System > Logs, and the
         # first place anyone looks — only collects WARNING and above. An INFO
         # line would have been exactly as invisible as no line at all.
-        with caplog.at_level(logging.DEBUG, logger="custom_components.beatify.server.base"):
+        with caplog.at_level(
+            logging.DEBUG, logger="custom_components.beatify.server.base"
+        ):
             _json_error("Media player is unavailable", 400, code="INVALID_REQUEST")
         records = [r for r in caplog.records if "INVALID_REQUEST" in r.getMessage()]
         assert records, "the error response produced no log record at all"
         assert all(r.levelno >= logging.WARNING for r in records)
 
     @pytest.mark.asyncio
-    async def test_two_rejections_sharing_a_code_are_distinguishable_in_the_log(self, caplog):
-        with caplog.at_level(logging.WARNING, logger="custom_components.beatify.server.base"):
+    async def test_two_rejections_sharing_a_code_are_distinguishable_in_the_log(
+        self, caplog
+    ):
+        with caplog.at_level(
+            logging.WARNING, logger="custom_components.beatify.server.base"
+        ):
             _json_error("Media player is unavailable", 400, code="INVALID_REQUEST")
             _json_error("No playlists selected", 400, code="INVALID_REQUEST")
         assert "Media player is unavailable" in caplog.text


### PR DESCRIPTION
The second half of #2294. #2295 fixed what the host sees; this fixes what the log holds.

## The problem

All **33** `_json_error` call sites return silently — `server/views.py` 2, `game_views.py` 12, `library_views.py` 10, `playlist_views.py` 5, `mix_views.py` 4. A rejected request leaves no trace anywhere.

On 2026-08-21 that cost a host an evening. Game start failed again and again with the one generic sentence that twelve different rejections share, and `system_log` returned **zero** Beatify entries. The actual reason — `Media player is unavailable`, after Music Assistant had been down for five days — was known inside this helper and written nowhere. The same pattern is already recorded in `_validate_provider`'s docstring for #808: *"400 with no log line"*.

## The change

One line in `_json_error`:

```python
_LOGGER.warning("HTTP %s %s: %s", status, code, message)
```

It covers all 33 sites and every future one. Adding it at the call sites would not.

**WARNING rather than INFO, deliberately.** Home Assistant's `system_log` — the list behind Settings › System › Logs, and the first place anyone looks — only collects WARNING and above. An INFO line would have been exactly as invisible during that evening's search as no line at all. That is the whole reason the level matters here, so it is worth disagreeing with if you see it differently.

**No request context in the line.** Adding the path would mean threading `request` through all 33 call sites for a detail the code already implies.

## Noise

Every 4xx now logs, including `UNAUTHORIZED` (401) and `RATE_LIMITED` (429). On a healthy instance those are rare, and when they are not rare that is itself worth seeing. If they turn out to be chatty in practice, the fix is a per-code level map in this one function rather than a retreat to silence.

## Tests

Four cases in `tests/unit/test_json_error.py`:

- status, code and message all reach the log
- the record is at WARNING or above, so `system_log` collects it — the assertion that encodes *why* this PR exists
- two rejections sharing `INVALID_REQUEST` are distinguishable in the log
- the response body and status are unchanged by the logging

1976 unit tests pass; ruff and mypy are clean on the touched files.

## Verification

Unit tests only — I did not re-stage a live outage to watch the line appear in `system_log`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R32KN7vVDQHUid42ry54za