### PR TITLE
Name the game people are actually searching for

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Beatify — Multiplayer Music Trivia for Home Assistant</title>
-  <meta name="description" content="Turn your smart speakers into a party game. Guests scan a QR code, a song plays — guess the year, or name the title and artist. No app, no account. Free and open source.">
+  <meta name="description" content="A self-hosted, open-source alternative to Hitster-style music party games. Guests scan a QR code, a song plays — guess the release year, or name the title and artist. Runs on the smart speakers you already own. No cards, no app, no account.">
   <meta name="keywords" content="Home Assistant, music quiz, party game, HACS, smart home, music trivia, Sonos, Alexa, Music Assistant, self-hosted">
   <meta name="author" content="Markus Holzhäuser">
 
@@ -251,6 +251,59 @@
             </div>
           </div>
           <p class="speakers-note">Using Chromecast, Nest, or HomePod? Install Music Assistant — they'll appear in Beatify automatically.</p>
+        </div>
+      </section>
+
+      <!-- ===== HOW IT COMPARES ===== -->
+      <section class="speakers" id="compare">
+        <div class="container">
+          <h2 class="section-title">Looking for a Hitster Alternative?</h2>
+          <p class="speakers-note" style="margin-bottom:1.5rem">Beatify plays the same core game — a song starts, you place its release year — without the cards, the box, or the app. Here is what is genuinely different, including where Beatify falls short.</p>
+          <div class="speakers-grid">
+            <div class="speaker-card">
+              <span class="speaker-check" aria-hidden="true">✅</span>
+              <div>
+                <strong>Nothing to buy or reprint</strong>
+                <p>The card decks are playlists. 55 of them ship with Beatify, and you can build your own from any music service or your own library.</p>
+              </div>
+            </div>
+            <div class="speaker-card">
+              <span class="speaker-check" aria-hidden="true">✅</span>
+              <div>
+                <strong>Your speakers, your music</strong>
+                <p>Plays through the Sonos, Alexa or Music Assistant speakers already in the house — at party volume, not through a phone.</p>
+              </div>
+            </div>
+            <div class="speaker-card">
+              <span class="speaker-check" aria-hidden="true">✅</span>
+              <div>
+                <strong>No subscription needed</strong>
+                <p>Since v4.3.0 a game can be sampled from your own library — Plex, Jellyfin or local files. A streaming plan is one option, not a requirement.</p>
+              </div>
+            </div>
+            <div class="speaker-card">
+              <span class="speaker-check" aria-hidden="true">✅</span>
+              <div>
+                <strong>A second way to play</strong>
+                <p>Beyond guessing the year, a Title &amp; Artist mode scores naming the track — with bonus rounds, streaks and a podium.</p>
+              </div>
+            </div>
+            <div class="speaker-card">
+              <span class="speaker-check" aria-hidden="true">⚠️</span>
+              <div>
+                <strong>No timeline placement yet</strong>
+                <p>The board-game mechanic of slotting a card between two you already hold does not exist in Beatify. Rounds score a year guess instead. It is the most requested difference and it is on the list.</p>
+              </div>
+            </div>
+            <div class="speaker-card">
+              <span class="speaker-check" aria-hidden="true">⚠️</span>
+              <div>
+                <strong>It needs a Home Assistant</strong>
+                <p>A board game needs a table. Beatify needs Home Assistant 2025.1+ and a supported speaker. If you do not run one, the box wins.</p>
+              </div>
+            </div>
+          </div>
+          <p class="speakers-note">Hitster is a trademark of its respective owner. Beatify is an independent open-source project and is not affiliated with, endorsed by, or connected to it — the name appears here only to describe the kind of game.</p>
         </div>
       </section>
 


### PR DESCRIPTION
M4 from the growth review, landing-page half. The README half follows once #2303 is in (both touch the same file, so they queue rather than conflict).

## Why

`grep -i hitster` over the landing page and the README returns **0** on both. A web search for *"Hitster alternative open source self-hosted"* returns Webster (Codeberg) and directory sites — **Beatify does not appear**.

Google is already the joint-largest referrer to the repository (24 unique visitors in 14 days, level with GitHub). The channel works. It just does not know the word under which this genre gets searched — and the competitor analysis has listed Hitster as the genre-defining brand since May.

Since v4.3.0 the comparison is also true without a footnote: Hitster needs no subscription, and now neither does Beatify.

## What it says

A new **"Looking for a Hitster Alternative?"** section before Installation, reusing the existing `speakers-grid` markup so it needs no new CSS.

Four things Beatify does differently — no cards to buy, plays on the speakers already in the house, no subscription required since v4.3.0, and a second game mode.

And **two things it does worse**, marked with ⚠️ rather than buried:

- **No timeline placement.** The board-game mechanic of slotting a card between two you already hold does not exist here. It is the most requested difference, and a visitor will find out within one game anyway.
- **It needs a Home Assistant.** *"A board game needs a table. Beatify needs Home Assistant 2025.1+ and a supported speaker. If you do not run one, the box wins."*

A comparison that only flatters is worth nothing to someone choosing between a box on the shelf and an integration.

## Trademark

The name is used descriptively, with an explicit note that Beatify is independent and not affiliated with or endorsed by it.

## Not in here

- The **German landing page** (`/de/index.html`) is untouched — the same section there is a separate translation pass.
- The **README** half of M4 waits for #2303.
- **The measurement is weak and worth saying so:** the landing page has no analytics, so the effect is only visible through the repository's Google referrer, which is a proxy. The review's stop rule: if Google uniques are not clearly above the 24 baseline after four weeks, keep the section (it costs nothing) but stop investing in SEO.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R32KN7vVDQHUid42ry54za