### PR TITLE
Say the word people search for, and where the box wins

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,11 @@ A song plays through your Sonos, Alexa, or Music Assistant speakers. Everyone ra
 
 No apps to download. No accounts to create. Just scan a QR code and play.
 
+If you have played **Hitster** or a similar card-based music party game, the core is familiar: a song
+starts, and you place its release year. Beatify does that without the cards, on the speakers already
+in the house — see [How Beatify compares](#how-beatify-compares) for what it does differently, and
+what it does not do at all.
+
 ---
 
 <br>
@@ -624,6 +629,33 @@ That's it. No mDNS, no broadcast, no additional ports.
 - If using HTTPS with a self-signed cert, guests may need to accept it once
 
 > **⚠️ Fritzbox users:** The Fritzbox guest WiFi fully isolates clients from your home network — this cannot be overridden with firewall rules. Players must join the main WiFi, or use a separate VLAN-capable router/access point to create a guest network with selective LAN access.
+
+---
+
+<br>
+
+## How Beatify Compares
+
+People usually find Beatify while looking for a **Hitster alternative**, so here is the honest
+comparison — including where the card game wins.
+
+| | Card-based music party game | Beatify |
+|---|---|---|
+| **What you buy** | A box, and a new box or expansion for more music | Nothing. 55 playlists ship with it, ~6,000 songs |
+| **Where the music comes from** | A fixed printed deck | Spotify, Apple Music, YouTube Music, Tidal, Deezer, Amazon Music — **or your own Plex / Jellyfin / local library** |
+| **Subscription** | None | None required since v4.3.0 (streaming is one option, your own library is another) |
+| **Playback** | A phone speaker on the table | The Sonos, Alexa or Music Assistant speakers you already own |
+| **How you answer** | Physically place a card on your timeline | Guess the year — or name the title and artist in a second mode |
+| **Timeline placement** | ✅ The core mechanic | ❌ **Not implemented.** Rounds score a year guess instead |
+| **Setup** | Open the box | Home Assistant 2025.1+, a supported speaker, HACS install |
+| **Players** | Limited by the components | 20+ on their own phones, no app |
+
+Two rows deserve more than a checkmark. Beatify has **no timeline-placement mechanic** — the most
+requested difference, and not a small feature. And it needs a **running Home Assistant**: a board game
+needs a table, this needs a server. If you do not have one, the box wins.
+
+> *Hitster is a trademark of its respective owner. Beatify is an independent open-source project,
+> not affiliated with or endorsed by it; the name appears here only to describe the kind of game.*
 
 ---
 


### PR DESCRIPTION
M4 from the growth review, README half. The landing-page half is #2304.

## Why

`grep -i hitster README.md` returned **0**. A web search for *"Hitster alternative open source self-hosted"* returns Webster (Codeberg) and directory sites — Beatify does not appear.

Google is already the joint-largest referrer to this repository (24 unique visitors in 14 days, level with GitHub). The channel works. It does not know the term under which this genre gets searched, and the competitor analysis has listed Hitster as the genre-defining brand since May.

## What it adds

**One sentence** under *What Is Beatify?* placing the genre, linking to the new section.

**A "How Beatify Compares" table** before Technical Details: what you buy, where the music comes from, subscription, playback, how you answer, timeline placement, setup, players.

## The two rows that are not flattering

- **Timeline placement — ❌ Not implemented.** The core mechanic of the card game. Marked with a cross in the table rather than left out, and called out again in the paragraph below it as the most requested difference.
- **Setup — needs a running Home Assistant.** *"A board game needs a table, this needs a server. If you do not have one, the box wins."*

Someone weighing a box on the shelf against an integration is making a real decision. A comparison that only flatters is worth nothing to them: they find out within one game anyway, and then it reads as a bait-and-switch instead of a trade-off they accepted going in.

## Trademark

Used descriptively, with an explicit note that Beatify is independent and not affiliated or endorsed.

## Measurement

Weak, and worth stating: the effect is only visible through this repository's Google referrer, which `rank.py --record` already logs daily — the 24-unique baseline exists. The review's stop rule: if Google uniques are not clearly above it after four weeks, keep the section (it costs nothing) and stop investing in SEO.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R32KN7vVDQHUid42ry54za