### PR TITLE
chore(playlists): apple backfill — +2 apple uris

### DIFF
--- a/custom_components/beatify/playlists/community/tomorrowland-top-1000.json
+++ b/custom_components/beatify/playlists/community/tomorrowland-top-1000.json
@@ -1,6 +1,6 @@
 {
   "name": "Tomorrowland Top 1000",
-  "version": "0.6",
+  "version": "0.7",
   "tags": [
     "edm",
     "electronic",
@@ -10264,7 +10264,8 @@
         "Tim Mason, Steve Angello",
         "Red Carpet, Brad Carter",
         "Mr. Belt & Wezol"
-      ]
+      ],
+      "uri_apple_music": "applemusic://track/1704317411"
     },
     {
       "artist": "Bingo Players",
@@ -10284,7 +10285,8 @@
         "Vintage Culture, Fancy Inc, The Beach",
         "Axwell, Sebastian Ingrosso, Steve Angello, Laidback Luke",
         "Martin Garrix, Khalid, DubVision"
-      ]
+      ],
+      "uri_apple_music": "applemusic://track/466851778"
     },
     {
       "artist": "deadmau5",
@@ -10327,7 +10329,8 @@
         "DJ MERCER, Tchami",
         "deadmau5, Kaskade, Kx5, John Summit, HAYLA",
         "Svenson & Gielen"
-      ]
+      ],
+      "uri_deezer": "deezer://track/3155420471"
     },
     {
       "artist": "Dom Dolla",


### PR DESCRIPTION
A `provider-uri-backfill` run focused on Apple Music, driven automatically by `com.beatify.apple-backfill`.

- `tomorrowland-top-1000` Apple 738 -> **740**/825

Filled in along the way, because Odesli answers with every provider at once: deezer +1.

**The run stopped at its cap rather than finishing** (`reached --max-minutes 50`). The remaining tracks of the playlist are untouched and are not a catalogue gap.

**Draft on purpose** — merged only once the maintainer approves. This agent has deliberately NO auto-merge.