### PR TITLE
Open on the room, not the category

### DIFF
--- a/index.html
+++ b/index.html
@@ -94,8 +94,8 @@
       <!-- ===== HERO ===== -->
       <section class="hero" id="hero">
         <div class="container">
-          <h1>The Music Quiz Party Game Your Smart Home Was Made For</h1>
-          <p class="tagline">Scan a QR code. Hear a song. Guess the year — or name the title and artist. Beats, laughs, rematches — all through your existing smart speakers.</p>
+          <h1>A Song Starts. Everyone Shouts a Year.</h1>
+          <p class="tagline">Beatify is the music party game for the speakers you already own. Guests scan a QR code to join — no app, no accounts — and race to name the release year, or the title and the artist. Beats, laughs, rematches, and one friend who insists it was 1987.</p>
 
           <div class="hero-stats">
             <span>55 playlists</span>


### PR DESCRIPTION
Landing-page half of the same change as #2307.

## The problem

The hero named the **category** rather than the **moment**:

> The Music Quiz Party Game Your Smart Home Was Made For

That tells a visitor which shelf this sits on. It does not put them in the room. The tagline then listed mechanics — scan, hear, guess.

## The change

> **A Song Starts. Everyone Shouts a Year.**
>
> Beatify is the music party game for the speakers you already own. Guests scan a QR code to join — no app, no accounts — and race to name the release year, or the title and the artist. Beats, laughs, rematches, and one friend who insists it was 1987.

Everything the old tagline promised is still there: QR code, no app, no accounts, year mode, title-and-artist mode, existing speakers. The headline now carries the scene and the tagline carries the mechanics, rather than both carrying mechanics.

## Evidence

The only article that ever moved the install curve — ifun.de, **+190 installs in eight days** — led with the game and the speakers, not the architecture.

## No CI here

`test.yml` and `validate.yml` only run for PRs against `main`/`develop`, so a `gh-pages` PR reports no checks — same as #2219–#2221 and #2304. Checked by hand instead: 10 sections open and close, the HTML parser finishes with no unclosed tags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R32KN7vVDQHUid42ry54za