### PR TITLE
Give the three actionable start failures their own codes

### DIFF
--- a/custom_components/beatify/const.py
+++ b/custom_components/beatify/const.py
@@ -142,6 +142,11 @@ ERR_ROUND_EXPIRED = "ROUND_EXPIRED"
 ERR_ALREADY_SUBMITTED = "ALREADY_SUBMITTED"
 ERR_NOT_IN_GAME = "NOT_IN_GAME"
 ERR_MEDIA_PLAYER_UNAVAILABLE = "MEDIA_PLAYER_UNAVAILABLE"
+# #2294: the two create-game rejections a host can actually act on. They used to
+# share INVALID_REQUEST with ten unrelated ones, which the client renders as a
+# single generic sentence — "this request was invalid, check your setup".
+ERR_NO_PLAYLISTS_SELECTED = "NO_PLAYLISTS_SELECTED"
+ERR_NO_PLAYABLE_SONGS = "NO_PLAYABLE_SONGS"
 ERR_INVALID_ACTION = "INVALID_ACTION"
 ERR_GAME_FULL = "GAME_FULL"
 ERR_NO_SONGS_REMAINING = "NO_SONGS_REMAINING"

--- a/custom_components/beatify/server/game_views.py
+++ b/custom_components/beatify/server/game_views.py
@@ -20,6 +20,9 @@ from custom_components.beatify.const import (
     DIFFICULTY_HARD,
     DIFFICULTY_NORMAL,
     DOMAIN,
+    ERR_MEDIA_PLAYER_UNAVAILABLE,
+    ERR_NO_PLAYABLE_SONGS,
+    ERR_NO_PLAYLISTS_SELECTED,
     PROVIDER_AMAZON_MUSIC,
     PROVIDER_APPLE_MUSIC,
     PROVIDER_DEEZER,
@@ -224,7 +227,12 @@ class StartGameView(RateLimitMixin, HomeAssistantView):
         # arrives with no playlist paths. Every other provider must select at
         # least one — a game with no source cannot be played.
         if not playlist_paths and provider != PROVIDER_MA_LIBRARY:
-            return _json_error("No playlists selected", 400, code="INVALID_REQUEST")
+            # #2294: own code so the client can say WHICH rejection fired. Twelve
+            # create-game rejections used to share INVALID_REQUEST, which the
+            # frontend renders as one generic sentence.
+            return _json_error(
+                "No playlists selected", 400, code=ERR_NO_PLAYLISTS_SELECTED
+            )
 
         if not media_player:
             return _json_error("No media player selected", 400, code="INVALID_REQUEST")
@@ -253,7 +261,10 @@ class StartGameView(RateLimitMixin, HomeAssistantView):
             return _json_error("Media player not found", 400, code="INVALID_REQUEST")
         if media_player_state.state == "unavailable":
             return _json_error(
-                "Media player is unavailable", 400, code="INVALID_REQUEST"
+                "Media player is unavailable",
+                400,
+                code=ERR_MEDIA_PLAYER_UNAVAILABLE,  # #2294: same code the WS path uses
+                details={"entity_id": media_player},
             )
 
         # Load and validate playlists -- or, for the library provider, sample a
@@ -346,7 +357,7 @@ class StartGameView(RateLimitMixin, HomeAssistantView):
             return _json_error(
                 "No valid songs found in selected playlists",
                 400,
-                code="INVALID_REQUEST",
+                code=ERR_NO_PLAYABLE_SONGS,  # #2294
             )
 
         # Get base URL for join URL construction (from request URL)

--- a/custom_components/beatify/www/i18n/de.json
+++ b/custom_components/beatify/www/i18n/de.json
@@ -1071,7 +1071,9 @@
     "PROVIDER_NOT_SUPPORTED": "{speaker} kann {provider} nicht abspielen. Wechsle zu einem Music-Assistant-Lautsprecher.",
     "UNSUPPORTED_PLAYER": "{speaker} ist kein unterstützter Lautsprecher-Typ. Nutze Music Assistant.",
     "joinTimeout": "Verbindung fehlgeschlagen. Bitte versuche es erneut.",
-    "INVALID_REQUEST": "Diese Anfrage war ungültig. Prüfe deine Einrichtung und versuche es erneut."
+    "INVALID_REQUEST": "Diese Anfrage war ungültig. Prüfe deine Einrichtung und versuche es erneut.",
+    "NO_PLAYLISTS_SELECTED": "Wähle mindestens eine Playlist aus, bevor du ein Spiel startest.",
+    "NO_PLAYABLE_SONGS": "Keiner der Songs in den gewählten Playlists lässt sich mit diesem Musikdienst abspielen. Versuche eine andere Playlist oder einen anderen Dienst."
   },
   "highlights": {
     "highlight_exact_match": "{player} hat '{song}' genagelt — {year}!",

--- a/custom_components/beatify/www/i18n/en.json
+++ b/custom_components/beatify/www/i18n/en.json
@@ -1071,7 +1071,9 @@
     "PROVIDER_NOT_SUPPORTED": "{speaker} can't play {provider}. Switch to a Music Assistant speaker.",
     "UNSUPPORTED_PLAYER": "{speaker} isn't a supported speaker type. Use Music Assistant.",
     "joinTimeout": "Couldn't connect. Please try again.",
-    "INVALID_REQUEST": "That request wasn't valid. Check your setup and try again."
+    "INVALID_REQUEST": "That request wasn't valid. Check your setup and try again.",
+    "NO_PLAYLISTS_SELECTED": "Pick at least one playlist before starting a game.",
+    "NO_PLAYABLE_SONGS": "None of the songs in the selected playlists can be played with this music service. Try another playlist or another service."
   },
   "highlights": {
     "highlight_exact_match": "{player} nailed '{song}' — {year}!",

--- a/custom_components/beatify/www/i18n/es.json
+++ b/custom_components/beatify/www/i18n/es.json
@@ -1071,7 +1071,9 @@
     "PROVIDER_NOT_SUPPORTED": "{speaker} no puede reproducir {provider}. Cambia a un altavoz de Music Assistant.",
     "UNSUPPORTED_PLAYER": "{speaker} no es un tipo de altavoz compatible. Usa Music Assistant.",
     "joinTimeout": "No se pudo conectar. Intentalo de nuevo.",
-    "INVALID_REQUEST": "La solicitud no era válida. Revisa tu configuración e inténtalo de nuevo."
+    "INVALID_REQUEST": "La solicitud no era válida. Revisa tu configuración e inténtalo de nuevo.",
+    "NO_PLAYLISTS_SELECTED": "Elige al menos una lista de reproducción antes de empezar una partida.",
+    "NO_PLAYABLE_SONGS": "Ninguna de las canciones de las listas seleccionadas se puede reproducir con este servicio de música. Prueba otra lista u otro servicio."
   },
   "highlights": {
     "highlight_exact_match": "¡{player} clavó '{song}' — {year}!",

--- a/custom_components/beatify/www/i18n/fr.json
+++ b/custom_components/beatify/www/i18n/fr.json
@@ -1071,7 +1071,9 @@
     "PROVIDER_NOT_SUPPORTED": "{speaker} ne peut pas lire {provider}. Passe a une enceinte Music Assistant.",
     "UNSUPPORTED_PLAYER": "{speaker} n'est pas un type d'enceinte pris en charge. Utilise Music Assistant.",
     "joinTimeout": "Connexion impossible. Reessaie.",
-    "INVALID_REQUEST": "Requête invalide. Vérifiez votre configuration et réessayez."
+    "INVALID_REQUEST": "Requête invalide. Vérifiez votre configuration et réessayez.",
+    "NO_PLAYLISTS_SELECTED": "Choisissez au moins une playlist avant de lancer une partie.",
+    "NO_PLAYABLE_SONGS": "Aucun des titres des playlists sélectionnées ne peut être lu avec ce service musical. Essayez une autre playlist ou un autre service."
   },
   "highlights": {
     "highlight_exact_match": "{player} a trouvé '{song}' pile — {year} !",

--- a/custom_components/beatify/www/i18n/it.json
+++ b/custom_components/beatify/www/i18n/it.json
@@ -1071,7 +1071,9 @@
     "PROVIDER_NOT_SUPPORTED": "{speaker} non può riprodurre {provider}. Passa a un altoparlante Music Assistant.",
     "UNSUPPORTED_PLAYER": "{speaker} non è un tipo di altoparlante supportato. Usa Music Assistant.",
     "joinTimeout": "Connessione non riuscita. Riprova.",
-    "INVALID_REQUEST": "La richiesta non era valida. Controlla la configurazione e riprova."
+    "INVALID_REQUEST": "La richiesta non era valida. Controlla la configurazione e riprova.",
+    "NO_PLAYLISTS_SELECTED": "Scegli almeno una playlist prima di iniziare una partita.",
+    "NO_PLAYABLE_SONGS": "Nessuno dei brani nelle playlist selezionate può essere riprodotto con questo servizio musicale. Prova un’altra playlist o un altro servizio."
   },
   "highlights": {
     "highlight_exact_match": "{player} ha centrato '{song}' — {year}!",

--- a/custom_components/beatify/www/i18n/nl.json
+++ b/custom_components/beatify/www/i18n/nl.json
@@ -1071,7 +1071,9 @@
     "PROVIDER_NOT_SUPPORTED": "{speaker} kan {provider} niet afspelen. Schakel over naar een Music Assistant-speaker.",
     "UNSUPPORTED_PLAYER": "{speaker} is geen ondersteund speakertype. Gebruik Music Assistant.",
     "joinTimeout": "Verbinden mislukt. Probeer het opnieuw.",
-    "INVALID_REQUEST": "Dit verzoek was ongeldig. Controleer je instellingen en probeer het opnieuw."
+    "INVALID_REQUEST": "Dit verzoek was ongeldig. Controleer je instellingen en probeer het opnieuw.",
+    "NO_PLAYLISTS_SELECTED": "Kies minstens één afspeellijst voordat je een spel start.",
+    "NO_PLAYABLE_SONGS": "Geen van de nummers in de gekozen afspeellijsten kan met deze muziekdienst worden afgespeeld. Probeer een andere lijst of een andere dienst."
   },
   "highlights": {
     "highlight_exact_match": "{player} had '{song}' perfect — {year}!",

--- a/tests/unit/test_error_codes_2294.py
+++ b/tests/unit/test_error_codes_2294.py
@@ -1,0 +1,80 @@
+"""#2294 — the create-game rejections a host can act on carry their own code.
+
+Twelve rejections used to share ``INVALID_REQUEST``, which the client renders as
+one generic sentence ("this request was invalid, check your setup"). On
+2026-08-21 that cost an evening: Music Assistant had been down for five days, so
+every speaker was unavailable, and the screen never said so.
+
+Three of the twelve are things a host can actually fix. They now have codes.
+"""
+
+from __future__ import annotations
+
+from custom_components.beatify.const import (
+    ERR_MEDIA_PLAYER_UNAVAILABLE,
+    ERR_NO_PLAYABLE_SONGS,
+    ERR_NO_PLAYLISTS_SELECTED,
+)
+
+
+class TestDistinctErrorCodes:
+    def test_codes_are_distinct_from_each_other(self):
+        codes = {
+            ERR_MEDIA_PLAYER_UNAVAILABLE,
+            ERR_NO_PLAYLISTS_SELECTED,
+            ERR_NO_PLAYABLE_SONGS,
+        }
+        assert len(codes) == 3
+
+    def test_none_of_them_is_the_generic_code(self):
+        # The whole point: these three must never collapse back into the code
+        # that made them indistinguishable.
+        for code in (
+            ERR_MEDIA_PLAYER_UNAVAILABLE,
+            ERR_NO_PLAYLISTS_SELECTED,
+            ERR_NO_PLAYABLE_SONGS,
+        ):
+            assert code != "INVALID_REQUEST"
+
+    def test_media_player_code_is_the_one_the_websocket_path_already_used(self):
+        # ws_handlers/admin.py has emitted this code since #949, and admin/api.js
+        # routes it to the speaker banner with a "Select Speaker" action (#2269).
+        # Reusing it means the REST path inherits that affordance instead of
+        # growing a second, parallel code for the same situation.
+        assert ERR_MEDIA_PLAYER_UNAVAILABLE == "MEDIA_PLAYER_UNAVAILABLE"
+
+    def test_create_game_emits_the_new_codes(self):
+        # Structural guard: the three call sites in the create path must use the
+        # constants. A literal "INVALID_REQUEST" creeping back would be invisible
+        # to a behavioural test that only checks the constants themselves.
+        from pathlib import Path
+
+        src = Path("custom_components/beatify/server/game_views.py").read_text()
+        assert "code=ERR_NO_PLAYLISTS_SELECTED" in src
+        assert "code=ERR_MEDIA_PLAYER_UNAVAILABLE" in src
+        assert "code=ERR_NO_PLAYABLE_SONGS" in src
+
+
+class TestTranslations:
+    def test_every_locale_has_a_string_for_each_new_code(self):
+        import json
+        from pathlib import Path
+
+        for path in sorted(Path("custom_components/beatify/www/i18n").glob("*.json")):
+            errors = json.loads(path.read_text())["errors"]
+            for code in (ERR_NO_PLAYLISTS_SELECTED, ERR_NO_PLAYABLE_SONGS):
+                assert code in errors, f"{path.name} is missing errors.{code}"
+                assert errors[code].strip(), f"{path.name} has an empty errors.{code}"
+
+    def test_new_strings_carry_no_unfilled_placeholders(self):
+        # getErrorMessage rejects a translation still holding {placeholder} and
+        # falls back to the English backend message — which would silently undo
+        # the translation work.
+        import json
+        import re
+        from pathlib import Path
+
+        for path in sorted(Path("custom_components/beatify/www/i18n").glob("*.json")):
+            errors = json.loads(path.read_text())["errors"]
+            for code in (ERR_NO_PLAYLISTS_SELECTED, ERR_NO_PLAYABLE_SONGS):
+                assert not re.search(r"\{[a-z_]+\}", errors[code], re.I)


### PR DESCRIPTION
Closes the remaining part of #2294. #2295 and #2302 made the server's own message visible under the generic headline; this fixes the cause for the three cases a host can act on.

| Code | Means |
|---|---|
| `NO_PLAYLISTS_SELECTED` | Pick a playlist before starting |
| `NO_PLAYABLE_SONGS` | This playlist has nothing the selected service can play |
| `MEDIA_PLAYER_UNAVAILABLE` | The speaker is gone |

## The third one already existed — and that changes the size of the fix

`ERR_MEDIA_PLAYER_UNAVAILABLE` has been in `const.py` since #949. The **WebSocket** path emits it (`ws_handlers/admin.py:205`), and `admin/api.js:454` routes it to the **speaker banner with a "Select Speaker" button** (#2269).

The REST create-game path was the odd one out: same situation, generic code. Reusing the existing constant instead of inventing a parallel one means the REST path now inherits that banner and its action. **The diff is three lines; the behaviour change is a dead-end message becoming a button that fixes the problem.**

I only found this because the string was already present in all six locale files when I went to add it.

## What I deliberately did not change

The existing translations for `MEDIA_PLAYER_UNAVAILABLE` (*"Media player unavailable"* / *"Mediaplayer nicht verfügbar"*) stay exactly as they were. I had rewritten them to a longer version naming Music Assistant as the likely cause, then reverted: they are not broken, an existing path relies on them, and the banner they render in already offers the way out. Rewriting a working string to make a new path read better is a change nobody asked for.

## Translations

The two genuinely new codes are translated in **all six locales** (en, de, es, fr, nl, it) — not machine-passed, each written for its own language.

Worth noting for review: this was safe to ship untranslated. `errorHeadlineAndDetail` falls back to the backend message for a code with no string, so new codes never produce a broken screen. The translations are here because they should be, not because they had to be.

## Tests

`tests/unit/test_error_codes_2294.py` — six cases:

- the three codes are distinct, and **none of them equals `INVALID_REQUEST`** — the assertion that encodes why this PR exists
- `MEDIA_PLAYER_UNAVAILABLE` is still the code the WebSocket path uses, so the two paths cannot drift apart
- a structural guard that reads `game_views.py` and pins the three call sites, because a literal creeping back would be invisible to a test that only checks the constants
- every locale has a non-empty string for both new codes
- no new string carries an unfilled `{placeholder}` — that would make `getErrorMessage` fall back to English and silently undo the translation work

1982 unit tests and 641 frontend tests pass; ruff, ruff format and mypy clean.

## Verification

Unit tests only. I did not stage a live failure to watch the banner appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R32KN7vVDQHUid42ry54za