### PR TITLE
Skip the ground the YouTube cursor already covered

### DIFF
--- a/.claude/skills/provider-uri-backfill/scripts/backfill_provider_uris.py
+++ b/.claude/skills/provider-uri-backfill/scripts/backfill_provider_uris.py
@@ -1179,6 +1179,25 @@ def run(args: argparse.Namespace) -> int:
             yt_gap = "youtube_music" in gaps
             non_yt_gaps = [g for g in gaps if g != "youtube_music"]
 
+            # ---- Fast-forward to the YouTube cursor (#2301) -----------------
+            # Songs before the cursor were already offered to the YouTube phase
+            # in an earlier run. The loop still walked them, paying one Odesli
+            # call each — and Odesli is throttled to ``--odesli-sleep`` (6s by
+            # default), so a 5-minute slice buys about 50 songs of walking.
+            #
+            # On 2026-08-22 that ate the window whole. Two runs, seven and five
+            # slices, `spent_today` unchanged at 0/90: the YouTube phase had
+            # twelve calls available and made none, because the loop never got
+            # past the cursor before the deadline. Cursors are not small —
+            # edm-anthems sits at 234, 80er-hits at 153.
+            #
+            # Under ``--youtube-first`` those songs are skipped outright. The
+            # non-YouTube gaps they may still carry are not lost: Apple, Deezer
+            # and Tidal have their own agents and their own windows. This flag
+            # says which job this run is doing.
+            if args.youtube_first and yt_gap and this_global_idx < yt_state.cursor:
+                continue
+
             # ---- Odesli (apple/tidal/deezer + free YouTube-first pass) ----
             # Odesli is fetched for the Apple/Tidal/Deezer gaps AND, when a
             # YouTube key is set, to try its ``youtube`` link as a 0-quota
@@ -1427,6 +1446,16 @@ def build_arg_parser() -> argparse.ArgumentParser:
         type=int,
         default=90,
         help="Max YouTube search.list calls per day (default 90)",
+    )
+    p.add_argument(
+        "--youtube-first",
+        action="store_true",
+        help=(
+            "Skip songs the YouTube resume cursor has already passed instead of "
+            "paying an Odesli call for them. For runs whose purpose is YouTube "
+            "(#2301) — without it a short window is spent walking ground the "
+            "YouTube phase already covered."
+        ),
     )
     p.add_argument(
         "--max",

--- a/tests/unit/test_backfill_youtube_first_2301.py
+++ b/tests/unit/test_backfill_youtube_first_2301.py
@@ -1,0 +1,96 @@
+"""``--youtube-first``: nicht noch einmal ueber Boden laufen, der schon abgesucht ist (#2301).
+
+Der YouTube-Backfill meldete taeglich „0 URIs" und sah damit aus wie ein
+konvergierter Katalog. Zwei Laeufe am 22.08.2026 zeigen etwas anderes: sieben
+bzw. fuenf Scheiben, ``spent_today`` vor und nach dem Lauf **0/90** — die
+YouTube-Phase hatte zwoelf Aufrufe frei und machte keinen.
+
+Die Ursache ist der Resume-Cursor. Songs davor hat die YouTube-Phase in einem
+frueheren Lauf schon gesehen, aber die Schleife lief trotzdem ueber sie und
+zahlte je einen Odesli-Aufruf. Odesli ist auf ``--odesli-sleep`` gedrosselt
+(6 s), eine Fuenf-Minuten-Scheibe kauft also rund 50 Songs Anlauf. Bei
+Cursor-Staenden wie edm-anthems 234 oder 80er-hits 153 endet das Fenster,
+bevor je neuer Boden erreicht wird.
+
+Diese Tests halten die Bedingung fest, unter der ein Song uebersprungen wird —
+und ebenso die drei Faelle, in denen er es NICHT werden darf.
+
+``scripts/`` ist kein Package, das Modul wird daher per Pfad geladen.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+# Das Skript wird NICHT importiert: es zieht beim Import Netz-Abhaengigkeiten
+# und argparse-Aufbau nach sich, und die Bedingung, um die es hier geht, ist
+# eine Zeile. Geprueft wird sie einmal als nachgebildetes Praedikat und einmal
+# als Textprobe am echten Quelltext, damit ein Umbau nicht stillschweigend an
+# den Tests vorbeigeht.
+_SCRIPT = (
+    Path(__file__).resolve().parents[2]
+    / ".claude"
+    / "skills"
+    / "provider-uri-backfill"
+    / "scripts"
+    / "backfill_provider_uris.py"
+)
+
+
+def skips(youtube_first: bool, yt_gap: bool, idx: int, cursor: int) -> bool:
+    """Die Bedingung aus dem Song-Loop, isoliert nachgebildet."""
+    return youtube_first and yt_gap and idx < cursor
+
+
+class TestFastForward:
+    def test_skips_a_song_the_cursor_has_already_passed(self):
+        # Der eigentliche Fall: tomorrowland stand auf Cursor 46, die Schleife
+        # begann bei 0 und verbrannte das Fenster auf dem Weg dorthin.
+        assert skips(True, yt_gap=True, idx=0, cursor=46) is True
+        assert skips(True, yt_gap=True, idx=45, cursor=46) is True
+
+    def test_does_not_skip_at_or_after_the_cursor(self):
+        # Genau hier faengt die Arbeit an, fuer die der Lauf existiert.
+        assert skips(True, yt_gap=True, idx=46, cursor=46) is False
+        assert skips(True, yt_gap=True, idx=47, cursor=46) is False
+
+    def test_does_not_skip_a_song_without_a_youtube_gap(self):
+        # Ein Song ohne YouTube-Luecke hat mit dem Cursor nichts zu tun; seine
+        # Apple/Deezer/Tidal-Luecken bleiben normal erreichbar.
+        assert skips(True, yt_gap=False, idx=0, cursor=46) is False
+
+    def test_does_nothing_when_the_flag_is_off(self):
+        # Die anderen Agenten (Apple, Deezer, Tidal) rufen dasselbe Skript ohne
+        # das Flag auf. Fuer sie darf sich nichts aendern.
+        assert skips(False, yt_gap=True, idx=0, cursor=46) is False
+        assert skips(False, yt_gap=True, idx=45, cursor=999) is False
+
+    def test_a_fresh_playlist_is_untouched(self):
+        # Cursor 0 heisst: noch nie angesehen. Dann wird nichts uebersprungen.
+        assert skips(True, yt_gap=True, idx=0, cursor=0) is False
+
+
+class TestOptionExists:
+    def test_the_flag_exists_and_is_opt_in(self):
+        src = _SCRIPT.read_text()
+        assert '"--youtube-first"' in src
+        # store_true heisst: ohne das Flag bleibt alles, wie es war. Genau
+        # darauf verlassen sich die Apple-, Deezer- und Tidal-Agenten.
+        idx = src.index('"--youtube-first"')
+        assert 'action="store_true"' in src[idx : idx + 400]
+
+    def test_the_condition_is_wired_into_the_song_loop(self):
+        src = _SCRIPT.read_text()
+        assert (
+            "if args.youtube_first and yt_gap and this_global_idx < yt_state.cursor:"
+            in src
+        )
+
+    def test_odesli_still_runs_before_the_youtube_search(self):
+        # Bewusst NICHT umgedreht: der Odesli-Aufruf liefert den YouTube-Link
+        # gratis mit (0 Quota). Liefe die Suche zuerst, wuerde jeder Treffer
+        # 100 Quota-Einheiten kosten, die Odesli verschenkt haette.
+        src = _SCRIPT.read_text()
+        odesli_at = src.index("---- Odesli (apple/tidal/deezer")
+        youtube_at = src.index("---- YouTube Data API search.list")
+        assert odesli_at < youtube_at


### PR DESCRIPTION
First half of #2301. The daily YouTube backfill has been reporting *"0 URIs"*, which reads as a converged catalogue. It was not searching at all.

## The measurement

Two runs on 22 August — seven slices and five — both ended with `spent_today` **unchanged at 0/90**. The YouTube phase had twelve calls available and made **none**. The first slices end in the log with `reached --max-minutes 5`, and the cursor moved from song #46 to #47 in five minutes of work.

## Why

The resume cursor. Songs before it were already offered to the YouTube phase in an earlier run — but the loop still walked them, paying **one Odesli call each**. Odesli is throttled to `--odesli-sleep` (6s by default), so a five-minute slice buys roughly **fifty songs of walking**.

Cursors are not small: `edm-anthems` sits at 234, `80er-hits` at 153. On those playlists the window ends long before the run reaches new ground, every single time.

## The change

`--youtube-first` skips those songs outright:

```python
if args.youtube_first and yt_gap and this_global_idx < yt_state.cursor:
    continue
```

Their non-YouTube gaps are not lost — Apple, Deezer and Tidal have their own agents and their own windows. The flag states which job this run is doing.

**Opt-in via `store_true`**, so the three other agents calling this same script are untouched.

## What I did not do, and why

The instruction was *"let the YouTube phase run first"*. Reordering the two blocks would be worse, so I did not:

**Odesli hands over a YouTube link for free** (0 quota) — it is used as a first pass before the search is spent. `search.list` costs **100 quota units**. Running the search first would buy links Odesli was about to give away, on a budget of 90 calls a day.

A test pins the current order (`odesli_at < youtube_at` in the source) so a later refactor cannot quietly invert it.

## Tests

`tests/unit/test_backfill_youtube_first_2301.py` — eight cases. The skip fires before the cursor and stops at it; a song **without** a YouTube gap is never skipped; a fresh playlist (cursor 0) is untouched; and with the flag off nothing changes at all, which is what the other three agents depend on.

The tests read the script as text rather than importing it — importing pulls in argparse construction and network helpers for a condition that is one line.

1984 unit tests pass. `ruff check .` (the CI command) is clean; the three `BLE001` findings visible when pointing ruff directly at this file are pre-existing and outside CI's discovery, verified against `HEAD`.

## Still open in #2301

This makes the run reach its work. Whether the slice geometry itself (5 min, 25 min cap, `MISS_LIMIT`) is right is a separate question — the counter from the other half of #2301 will now say so out loud if it is not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R32KN7vVDQHUid42ry54za