### PR TITLE
November Rain is 1991, not 1992

### DIFF
--- a/custom_components/beatify/playlists/top-100-power-ballads.json
+++ b/custom_components/beatify/playlists/top-100-power-ballads.json
@@ -1,6 +1,6 @@
 {
   "name": "Top 100 Power Ballads",
-  "version": "1.12",
+  "version": "1.13",
   "tags": [
     "1980s",
     "1990s",
@@ -50,7 +50,7 @@
       }
     },
     {
-      "year": 1992,
+      "year": 1991,
       "uri": "spotify:track:53968oKecrFxkErocab2Al",
       "artist": "Guns N' Roses",
       "alt_artists": [


### PR DESCRIPTION
Closes #2311 — flagged in-game by a player, and **this one is real**. It is the first of five year reports in two days that was not a false alarm (the Kansas and Matthew Wilder pairs were both correct as filed).

## The evidence

`top-100-power-ballads.json` carried **1992**. Three independent things say 1991, and nothing says otherwise:

| Source | Says |
|---|---|
| *Use Your Illusion I*, Geffen | released **1991-09-17** |
| The entry's own ISRC `USGF19141510` | year code **91** |
| `greatest-hits-of-all-time.json` | has carried **1991** all along |

The single came out on 24 February 1992. Beatify's convention is the original release year of the recording, and a single only wins when it *precedes* the album — here the album was first, so 1991.

## The part worth pausing on

**The catalogue was answering the same question two different ways.** The same song, in two bundled playlists, with two different years — so the "right" answer depended on which playlist the round was drawn from. A player who learned it in one game would have been marked wrong in the other.

Nothing checks for that today. A cross-playlist consistency check (same ISRC or same artist+title, differing `year`) would have caught this without a player having to notice, and would likely surface more. Worth its own issue if you want it — I have not opened one.

Version 1.12 → 1.13. Schema gate passes on all 58 playlists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R32KN7vVDQHUid42ry54za