### PR TITLE
Settle 16 of the 58 one-year year conflicts

### DIFF
--- a/custom_components/beatify/playlists/2000s-pop-anthems.json
+++ b/custom_components/beatify/playlists/2000s-pop-anthems.json
@@ -1,6 +1,6 @@
 {
   "name": "2000s Pop Anthems",
-  "version": "1.23",
+  "version": "1.24",
   "tags": [
     "2000s",
     "pop",
@@ -5146,7 +5146,7 @@
       }
     },
     {
-      "year": 2000,
+      "year": 1999,
       "uri": "spotify:track:4BggEwLhGfrbrl7JBhC8EC",
       "artist": "Crazy Town",
       "alt_artists": [

--- a/custom_components/beatify/playlists/90er-hits.json
+++ b/custom_components/beatify/playlists/90er-hits.json
@@ -1,6 +1,6 @@
 {
   "name": "90s Hits",
-  "version": "1.23",
+  "version": "1.24",
   "tags": [
     "1990s",
     "pop",
@@ -1914,7 +1914,7 @@
     {
       "artist": "Liquido",
       "title": "Narcotic",
-      "year": 1999,
+      "year": 1998,
       "isrc": "DEG129800581",
       "uri": "spotify:track:1H5VQuShs4qfwBXyHF0PeH",
       "uri_apple_music": "applemusic://track/1857765665",

--- a/custom_components/beatify/playlists/community/ballermann-party-hits.json
+++ b/custom_components/beatify/playlists/community/ballermann-party-hits.json
@@ -1,6 +1,6 @@
 {
   "name": "Ballermann Party Hits",
-  "version": "1.27",
+  "version": "1.28",
   "tags": [
     "schlager",
     "party",
@@ -66,7 +66,7 @@
     {
       "artist": "Almklausi",
       "title": "Die Pure Lust am Leben",
-      "year": 2009,
+      "year": 2008,
       "isrc": "DEEQ80800058",
       "uri": "spotify:track:3ACzWKB7R56sGDzEa3ZQH8",
       "uri_apple_music": "applemusic://track/323511421",

--- a/custom_components/beatify/playlists/community/divorced-dad-rock.json
+++ b/custom_components/beatify/playlists/community/divorced-dad-rock.json
@@ -1,6 +1,6 @@
 {
   "name": "Divorced Dad Rock",
-  "version": "1.11",
+  "version": "1.12",
   "tags": [
     "post-grunge",
     "nu-metal",
@@ -1366,7 +1366,7 @@
     {
       "artist": "The Offspring",
       "title": "The Kids Aren't Alright",
-      "year": 1999,
+      "year": 1998,
       "isrc": "USSM19804363",
       "uri": "spotify:track:4EchqUKQ3qAQuRNKmeIpnf",
       "uri_apple_music": "applemusic://track/1440881625",
@@ -1991,7 +1991,7 @@
     {
       "artist": "System Of A Down",
       "title": "Toxicity",
-      "year": 2002,
+      "year": 2001,
       "isrc": "USSM10107262",
       "uri": "spotify:track:0snQkGI5qnAmohLE7jTsTn",
       "uri_apple_music": "applemusic://track/273714713",
@@ -2041,7 +2041,7 @@
     {
       "artist": "Kings of Leon",
       "title": "Use Somebody",
-      "year": 2009,
+      "year": 2008,
       "isrc": "USRC10800301",
       "uri": "spotify:track:5VGlqQANWDKJFl0MBG3sg2",
       "uri_apple_music": "applemusic://track/290303018",

--- a/custom_components/beatify/playlists/community/essential-alternative.json
+++ b/custom_components/beatify/playlists/community/essential-alternative.json
@@ -1,6 +1,6 @@
 {
   "name": "Essential Alternative 🎸",
-  "version": "0.11",
+  "version": "0.12",
   "tags": [
     "alternative",
     "rock",
@@ -2498,7 +2498,7 @@
       }
     },
     {
-      "year": 2001,
+      "year": 2000,
       "uri": "spotify:track:5z6xHjCZr7a7AIcy8sPBKy",
       "artist": "Alien Ant Farm",
       "alt_artists": [

--- a/custom_components/beatify/playlists/community/eurodance-90s.json
+++ b/custom_components/beatify/playlists/community/eurodance-90s.json
@@ -1,6 +1,6 @@
 {
   "name": "Eurodance 90s 💥",
-  "version": "1.16",
+  "version": "1.17",
   "tags": [
     "1990s",
     "eurodance",
@@ -2599,7 +2599,7 @@
       }
     },
     {
-      "year": 1995,
+      "year": 1994,
       "uri": "spotify:track:3wtPKPHAi8xi6P4bCN0eGi",
       "artist": "Whigfield",
       "alt_artists": [

--- a/custom_components/beatify/playlists/community/gen-z-anthems.json
+++ b/custom_components/beatify/playlists/community/gen-z-anthems.json
@@ -1,6 +1,6 @@
 {
   "name": "Gen Z Anthems",
-  "version": "1.5",
+  "version": "1.6",
   "tags": [
     "2010s",
     "2020s",
@@ -1004,7 +1004,7 @@
       "awards_nl": []
     },
     {
-      "year": 2020,
+      "year": 2019,
       "uri": "spotify:track:6UelLqGlWMcVH1E5c4H7lY",
       "artist": "Harry Styles",
       "alt_artists": [

--- a/custom_components/beatify/playlists/community/yacht-rock.json
+++ b/custom_components/beatify/playlists/community/yacht-rock.json
@@ -1,6 +1,6 @@
 {
   "name": "Yacht Rock ⛵",
-  "version": "1.10",
+  "version": "1.11",
   "tags": [
     "1970s",
     "1980s",
@@ -412,7 +412,7 @@
       }
     },
     {
-      "year": 1974,
+      "year": 1973,
       "uri": "spotify:track:0OCgcMy6fvOYL3PIugXjYl",
       "artist": "Redbone",
       "alt_artists": [

--- a/custom_components/beatify/playlists/motown-soul-classics.json
+++ b/custom_components/beatify/playlists/motown-soul-classics.json
@@ -1,6 +1,6 @@
 {
   "name": "Motown & Soul Classics",
-  "version": "1.17",
+  "version": "1.18",
   "tags": [
     "1960s",
     "1970s",
@@ -431,7 +431,7 @@
       }
     },
     {
-      "year": 1984,
+      "year": 1983,
       "uri": "spotify:track:6HMvJcdw6qLsyV1b5x29sa",
       "artist": "Lionel Richie",
       "alt_artists": [

--- a/custom_components/beatify/playlists/one-hit-wonders.json
+++ b/custom_components/beatify/playlists/one-hit-wonders.json
@@ -1,6 +1,6 @@
 {
   "name": "One-Hit Wonders",
-  "version": "1.15",
+  "version": "1.16",
   "tags": [
     "one-hit",
     "classics",
@@ -2488,7 +2488,7 @@
       }
     },
     {
-      "year": 1993,
+      "year": 1992,
       "uri": "spotify:track:0jWgAnTrNZmOGmqgvHhZEm",
       "artist": "4 Non Blondes",
       "alt_artists": [
@@ -3426,7 +3426,7 @@
       }
     },
     {
-      "year": 2000,
+      "year": 1999,
       "uri": "spotify:track:6GQ3WTaNHMFlVmN4burGat",
       "artist": "Crazy Town",
       "alt_artists": [

--- a/custom_components/beatify/playlists/summer-party-anthems.json
+++ b/custom_components/beatify/playlists/summer-party-anthems.json
@@ -1,6 +1,6 @@
 {
   "name": "100 Summer Anthems ☀️",
-  "version": "1.15",
+  "version": "1.16",
   "tags": [
     "party",
     "classics",
@@ -679,7 +679,7 @@
       }
     },
     {
-      "year": 1985,
+      "year": 1984,
       "uri": "spotify:track:0GONea6G2XdnHWjNZd6zt3",
       "artist": "Bryan Adams",
       "alt_artists": [
@@ -4117,7 +4117,7 @@
       }
     },
     {
-      "year": 1973,
+      "year": 1972,
       "uri": "spotify:track:3Vby4nGmtbDo7HDJamOWkT",
       "artist": "Stealers Wheel",
       "alt_artists": [

--- a/custom_components/beatify/playlists/top-100-power-ballads.json
+++ b/custom_components/beatify/playlists/top-100-power-ballads.json
@@ -1,6 +1,6 @@
 {
   "name": "Top 100 Power Ballads",
-  "version": "1.13",
+  "version": "1.14",
   "tags": [
     "1980s",
     "1990s",
@@ -1079,7 +1079,7 @@
       }
     },
     {
-      "year": 2004,
+      "year": 2003,
       "uri": "spotify:track:7afSN5zhUhkbpRFpYKYztK",
       "artist": "Hoobastank",
       "alt_artists": [
@@ -2867,7 +2867,7 @@
       "uri_deezer": "deezer://track/1787569267"
     },
     {
-      "year": 1985,
+      "year": 1984,
       "uri": "spotify:track:5WwqdeavrQrbeAMDxGawse",
       "artist": "REO Speedwagon",
       "alt_artists": [


### PR DESCRIPTION
Follow-up to #2311. That report turned out to be one of **104** cases where the catalogue answers the same question two ways.

## What the check found

461 songs appear in more than one bundled playlist. **104 of them carry different years** depending on which playlist the round was drawn from — a player who learns the answer in one game is marked wrong in the next.

| Gap | Cases | Nature |
|---|---|---|
| **1 year** | 58 | Album versus single. The November Rain question. |
| 2–25 years | 46 | Not a convention question — a compilation or remix year in one of the two |

This PR settles **16 of the 58**.

## The rule, and why it is this narrow

A year changes only when **MusicBrainz's earliest recording date AND the entry's own ISRC year code both point at the lower of the two values already present**. Never a third value, never one source alone.

That is not caution for its own sake. **MusicBrainz alone gets this exact class wrong** — three spot checks while building this:

| Song | MusicBrainz | Actually |
|---|---|---|
| Iron Man | 1971 | *Paranoid*, 1970 |
| Better Off Alone | 1999 | original release 1998 |
| Nothing Else Matters | 1992 | the Black Album, August 1991 |

And the convention itself warns off the ISRC alone: a code is often assigned the year *before* release, which is exactly why #2069 only lets it override at a distance of **two years or more**. For a one-year dispute it is the weakest possible discriminator.

Neither source can carry this alone. Where both agree, and agree on a value the catalogue already holds, that is as much confirmation as this data affords.

## What changed

17 entries across 12 playlist files, each file's `version` bumped. Conflicts drop from **104 → 88**, one-year cases from **58 → 42**. Schema gate passes on all 58 playlists.

## Left open, deliberately

- **42 one-year cases** where the two sources disagree, or where the ISRC is missing or ambiguous
- **46 wider conflicts** — those need a look each, not a rule

## One to check first

**Alien Ant Farm — Smooth Criminal.** Both sources say 2000; *ANThology* came out in March 2001. The rule accepted it because two independent sources agree on a value already in the catalogue, and I would rather not override that with a recollection — but it is the one line here I would look at first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R32KN7vVDQHUid42ry54za