### PR TITLE
Replace three YouTube links that do not play the record

### DIFF
--- a/custom_components/beatify/playlists/80er-hits.json
+++ b/custom_components/beatify/playlists/80er-hits.json
@@ -1,6 +1,6 @@
 {
   "name": "80s Hits",
-  "version": "2.19",
+  "version": "2.20",
   "tags": [
     "1980s",
     "pop",
@@ -27,7 +27,7 @@
       "fun_fact_es": "El éxito Schlager de Marianne Rosenberg de 1975 experimentó un gran renacimiento en los 80 y sigue siendo un clásico alemán. Su poderosa voz la convirtió en una de las cantantes más queridas de Alemania.",
       "fun_fact_fr": "Le tube Schlager de Marianne Rosenberg, sorti en 1975, a connu un formidable regain de popularité dans les années 80 et reste un classique incontournable en Allemagne. Sa voix puissante et son interprétation pleine d'émotion ont fait d'elle l'une des chanteuses les plus adorées du pays.",
       "uri_apple_music": "applemusic://track/253845195",
-      "uri_youtube_music": "https://music.youtube.com/watch?v=s3EMTAr-UBY",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=AwP7w54esDQ",
       "uri_tidal": "tidal://track/22371988",
       "uri_deezer": "deezer://track/2312569",
       "fun_fact_nl": "Marianne Rosenbergs Schlager-hit uit 1975 beleefde een grote revival in de jaren 80 en is een Duits klassiek nummer gebleven. Haar krachtige stem en emotionele zang maakten haar een van Duitslands meest geliefde zangeressen.",
@@ -3595,7 +3595,7 @@
         "Grammy Award de la meilleure interprétation vocale pop masculine (1985)"
       ],
       "uri_apple_music": "applemusic://track/1148701808",
-      "uri_youtube_music": "https://music.youtube.com/watch?v=slPsoYWhZAk",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=wuvtoyVi7vY",
       "uri_tidal": "tidal://track/65556726",
       "uri_deezer": "deezer://track/134036230",
       "fun_fact_nl": "Phil Collins schreef dit voor de gelijknamige film in slechts één nacht. Ondanks het enorme succes van het nummer werd Collins niet uitgenodigd om het op te voeren bij de Oscars - de producers kozen Ann Reinking.",
@@ -3686,7 +3686,7 @@
         "nl": "applemusic://track/1692882667",
         "it": "applemusic://track/1692882667"
       },
-      "uri_youtube_music": "https://music.youtube.com/watch?v=NSRrAYeh5OU"
+      "uri_youtube_music": "https://music.youtube.com/watch?v=yq-lgYe0Pz4"
     },
     {
       "year": 1984,


### PR DESCRIPTION
From the daily rotation check on `80er-hits.json` — see #2314.

## What changed

All three replacements sit on **official channels** and were verified through the YouTube Data API before being written: the id resolves, and `embeddable` is true.

| Track | Was | Now |
|---|---|---|
| Marianne Rosenberg — Er gehört zu mir | a **ZDF Disco performance from 05.07.1975** | the audio entry on the artist's Topic channel |
| Phil Collins — Against All Odds | a re-upload on a channel called **"Marcos Gr"** | the official Phil Collins channel |
| Purple Schulz — Sehnsucht | a **LIVE 1989** recording | the studio audio on the Topic channel |

## One correction to the issue

#2314 lists Purple Schulz as **dead** on an HTTP 401. It is not deleted — it is **`embeddable: false`**. A browser opens it fine; Music Assistant cannot play it.

The validator reports both cases as "dead", which reads as *the link is gone* when the truth is *the link works and the player is not allowed to use it*. Those want different fixes — one needs a new URI, the other might only need a different upload of the same recording. Worth separating in the checker at some point.

## Left out, deliberately

**Central Line — Walking Into Sunshine.** All three providers point at the Larry Levan 12" mix while the entry is titled "- Edit". Three independent providers agreeing makes the **title** the outlier, not the links. That is a decision about what the song should be, and it belongs to whoever owns the catalogue, not to a lookup.

**The Apple per-region maps** for Simply Red, Cyndi Lauper and Peter Schilling. `fetch_apple_music_regions.py` stalls during setup — it prints its region list, then nothing, with essentially no CPU use, never reaching the per-playlist header. Two attempts, ~13 minutes each. Nothing was rebuilt rather than half-rebuilt, so the region maps are exactly as they were.

That leaves the most user-visible half of #2314 open: Simply Red and Cyndi Lauper resolve to nothing in **every** Apple storefront, so those rounds fail silently for anyone off the default one. The issue stays open for it.

Version 2.19 → 2.20. Schema gate passes on all 58 playlists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R32KN7vVDQHUid42ry54za