### PR TITLE
chore(playlists): youtube backfill — +24 youtube uris

### DIFF
--- a/custom_components/beatify/playlists/community/musica-italiana.json
+++ b/custom_components/beatify/playlists/community/musica-italiana.json
@@ -1,7 +1,7 @@
 {
   "name": "Musica Italiana 🇮🇹",
   "description": "Italian classics from the 1960s to the 2000s — cantautori, Sanremo winners and the songs every Italian party sings along to. Merged from playlist requests #2228 and #2229.",
-  "version": "0.9",
+  "version": "0.11",
   "songs": [
     {
       "year": 1962,
@@ -930,7 +930,8 @@
       "fun_fact_it": "Alan Sorrenti - \"Tu Sei L'Unica Donna Per Me - 2005 Remaster\" (1979), dal canone del pop italiano.",
       "isrc": "ITD000500059",
       "uri_apple_music": "applemusic://track/1637161394",
-      "uri_deezer": "deezer://track/3370893"
+      "uri_deezer": "deezer://track/3370893",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=v3CgLAnCooo"
     },
     {
       "year": 1979,
@@ -949,7 +950,8 @@
       "fun_fact_it": "Umberto Tozzi - \"Gloria\" (1979), dal canone del pop italiano. Contenuta nell'album Gloria. Pubblicata da CGD nel 1979 nel singolo Gloria/Aria.",
       "isrc": "ESA031419191",
       "uri_apple_music": "applemusic://track/1567867714",
-      "uri_deezer": "deezer://track/84718345"
+      "uri_deezer": "deezer://track/84718345",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=8Zs7VWqNGHg"
     },
     {
       "year": 1979,
@@ -968,7 +970,8 @@
       "fun_fact_it": "Umberto Tozzi - \"Stella stai\" (1979), dal canone del pop italiano. Usata in seguito nel film Spider-Man: Far from Home del 2019. Contenuta nell'album Tozzi.",
       "isrc": "ITR008000571",
       "uri_apple_music": "applemusic://track/672547109",
-      "uri_deezer": "deezer://track/69028148"
+      "uri_deezer": "deezer://track/69028148",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=fMY-o4BLfJw"
     },
     {
       "year": 1979,
@@ -987,7 +990,8 @@
       "fun_fact_it": "Vasco Rossi - \"Albachiara - Remastered 2019\" (1979), dal canone del pop italiano.",
       "isrc": "ITB001900323",
       "uri_apple_music": "applemusic://track/1479885373",
-      "uri_deezer": "deezer://track/753892132"
+      "uri_deezer": "deezer://track/753892132",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=lN5BVFYjraw"
     },
     {
       "year": 1979,
@@ -1006,7 +1010,8 @@
       "fun_fact_it": "Viola Valentino - \"Comprami\" (1979), dal canone del pop italiano.",
       "isrc": "ITR000790051",
       "uri_apple_music": "applemusic://track/1566314670",
-      "uri_deezer": "deezer://track/1365061732"
+      "uri_deezer": "deezer://track/1365061732",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=5Nzg8Rl4HHE"
     },
     {
       "year": 1980,
@@ -1025,7 +1030,8 @@
       "fun_fact_it": "Edoardo Bennato - \"L'isola che non c'è\" (1980), dal canone del pop italiano.",
       "isrc": "ITB008070520",
       "uri_apple_music": "applemusic://track/254250128",
-      "uri_deezer": "deezer://track/563594"
+      "uri_deezer": "deezer://track/563594",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=hhgoCgUg6Cc"
     },
     {
       "year": 1980,
@@ -1044,7 +1050,8 @@
       "fun_fact_it": "Gianni Togni - \"Luna - Remastered\" (1980), dal canone del pop italiano.",
       "isrc": "ITR001300280",
       "uri_apple_music": "applemusic://track/802854272",
-      "uri_deezer": "deezer://track/74398004"
+      "uri_deezer": "deezer://track/74398004",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=BOkF3F4RFKQ"
     },
     {
       "year": 1980,
@@ -1063,7 +1070,8 @@
       "fun_fact_it": "Gianni Togni - \"Luna\" (1980), dal canone del pop italiano. Pubblicata da Durium.",
       "isrc": "ITR008000451",
       "uri_apple_music": "applemusic://track/40638155",
-      "uri_deezer": "deezer://track/783591"
+      "uri_deezer": "deezer://track/783591",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=xo75gy9E3nE"
     },
     {
       "year": 1980,
@@ -1082,7 +1090,8 @@
       "fun_fact_it": "Lucio Battisti - \"Con il nastro rosa\" (1980), dal canone del pop italiano.",
       "isrc": "ITB001700471",
       "uri_apple_music": "applemusic://track/1480764203",
-      "uri_deezer": "deezer://track/764164492"
+      "uri_deezer": "deezer://track/764164492",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=j6-1zCMvwuw"
     },
     {
       "year": 1980,
@@ -1101,7 +1110,8 @@
       "fun_fact_it": "Raffaella Carrà - \"Pedro\" (1980), dal canone del pop italiano.",
       "isrc": "ITM009900696",
       "uri_apple_music": "applemusic://track/1692974548",
-      "uri_deezer": "deezer://track/15255911"
+      "uri_deezer": "deezer://track/15255911",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=iMZOrEbS7cU"
     },
     {
       "year": 1980,
@@ -1120,7 +1130,8 @@
       "fun_fact_it": "Vasco Rossi - \"Non l'hai mica capito - Remastered 2020\" (1980), dal canone del pop italiano. Pubblicata da Targa.",
       "isrc": "ITB002000300",
       "uri_apple_music": "applemusic://track/1539965277",
-      "uri_deezer": "deezer://track/1139477612"
+      "uri_deezer": "deezer://track/1139477612",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=rzrGWktg6v4"
     },
     {
       "year": 1981,
@@ -1139,7 +1150,8 @@
       "fun_fact_it": "Claudio Baglioni - \"Strada facendo\" (1981), dal canone del pop italiano.",
       "isrc": "ITM000102727",
       "uri_apple_music": "applemusic://track/580231736",
-      "uri_deezer": "deezer://track/576311"
+      "uri_deezer": "deezer://track/576311",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=en2CSm20cjQ"
     },
     {
       "year": 1981,
@@ -1158,7 +1170,8 @@
       "fun_fact_it": "Claudio Baglioni - \"Via\" (1981), dal canone del pop italiano. Contenuta nell'album Strada facendo.",
       "isrc": "ITM000102735",
       "uri_apple_music": "applemusic://track/1344888781",
-      "uri_deezer": "deezer://track/461326012"
+      "uri_deezer": "deezer://track/461326012",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=SW74vHivXDA"
     },
     {
       "year": 1981,
@@ -1177,7 +1190,8 @@
       "fun_fact_it": "Eduardo De Crescenzo - \"Ancora\" (1981), dal canone del pop italiano. Presentata al Festival di Sanremo.",
       "isrc": "ITB008170506",
       "uri_apple_music": "applemusic://track/471571745",
-      "uri_deezer": "deezer://track/1020054"
+      "uri_deezer": "deezer://track/1020054",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=wtQEN9M8Dl0"
     },
     {
       "year": 1981,
@@ -1196,7 +1210,8 @@
       "fun_fact_it": "Franco Battiato - \"Centro Di Gravità Permanente - Remastered 2021\" (1981), dal canone del pop italiano. Scritta da Franco Battiato e Giusto Pio.",
       "isrc": "ITUM72001391",
       "uri_apple_music": "applemusic://track/1568083647",
-      "uri_deezer": "deezer://track/1375685872"
+      "uri_deezer": "deezer://track/1375685872",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=YVML2z4OpEE"
     },
     {
       "year": 1981,
@@ -1215,7 +1230,8 @@
       "fun_fact_it": "Franco Battiato - \"Cuccurucucù - Mix 2015\" (1981), dal canone del pop italiano.",
       "isrc": "ITUM71501136",
       "uri_apple_music": "applemusic://track/1440850093",
-      "uri_deezer": "deezer://track/112658532"
+      "uri_deezer": "deezer://track/112658532",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=6Au59P_obak"
     },
     {
       "year": 1981,
@@ -1234,7 +1250,8 @@
       "fun_fact_it": "Franco Battiato - \"Cuccurucucù - Remastered\" (1981), dal canone del pop italiano.",
       "isrc": "ITUM72001395",
       "uri_apple_music": "applemusic://track/1568083642",
-      "uri_deezer": "deezer://track/1375685852"
+      "uri_deezer": "deezer://track/1375685852",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=43e0Bv4P_3k"
     },
     {
       "year": 1981,
@@ -1253,7 +1270,8 @@
       "fun_fact_it": "Loretta Goggi - \"Maledetta primavera\" (1981), dal canone del pop italiano. Scritta da Amerigo Cassella. Presentata al Festival di Sanremo. Contenuta nell'album Il mio prossimo amore.",
       "isrc": "ITQ008100011",
       "uri_apple_music": "applemusic://track/698668560",
-      "uri_deezer": "deezer://track/4090061"
+      "uri_deezer": "deezer://track/4090061",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=0tdp4nrEBAg"
     },
     {
       "year": 1981,
@@ -1272,7 +1290,8 @@
       "fun_fact_it": "Marcella Bella - \"Canto Straniero\" (1981), dal canone del pop italiano.",
       "isrc": "ITD569502113",
       "uri_apple_music": "applemusic://track/311418744",
-      "uri_deezer": "deezer://track/3939671"
+      "uri_deezer": "deezer://track/3939671",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=iPbqsH6ZHVA"
     },
     {
       "year": 1981,
@@ -1291,7 +1310,8 @@
       "fun_fact_it": "Pooh - \"Chi fermerà la musica\" (1981), dal canone del pop italiano.",
       "isrc": "ITR001400033",
       "uri_apple_music": "applemusic://track/953251717",
-      "uri_deezer": "deezer://track/124637076"
+      "uri_deezer": "deezer://track/124637076",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=1shjAdYxaA0"
     },
     {
       "year": 1981,
@@ -1310,7 +1330,8 @@
       "fun_fact_it": "Ricchi E Poveri - \"Come vorrei\" (1981), dal canone del pop italiano.",
       "isrc": "DEC719400068",
       "uri_apple_music": "applemusic://track/285797622",
-      "uri_deezer": "deezer://track/636412"
+      "uri_deezer": "deezer://track/636412",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=4TCxXahkSyE"
     },
     {
       "year": 1982,
@@ -1329,7 +1350,8 @@
       "fun_fact_it": "Al Bano - \"Felicità\" (1982), dal canone del pop italiano.",
       "isrc": "ITG830800001",
       "uri_apple_music": "applemusic://track/298583321",
-      "uri_deezer": "deezer://track/4033476791"
+      "uri_deezer": "deezer://track/4033476791",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=xUj-lfx6vbo"
     },
     {
       "year": 1982,
@@ -1347,7 +1369,9 @@
       "fun_fact_nl": "Claudia Mori, Adriano Celentano - \"Non Succederà Più - Remastered 2009\" (1982), uit de Italiaanse popcanon.",
       "fun_fact_it": "Claudia Mori, Adriano Celentano - \"Non Succederà Più - Remastered 2009\" (1982), dal canone del pop italiano.",
       "isrc": "ITR050900002",
-      "uri_apple_music": "applemusic://track/1784627055"
+      "uri_apple_music": "applemusic://track/1784627055",
+      "uri_deezer": "deezer://track/3137686981",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=0ch7vL2SVl4"
     },
     {
       "year": 1982,
@@ -1366,7 +1390,8 @@
       "fun_fact_it": "Claudio Baglioni - \"Avrai\" (1982), dal canone del pop italiano.",
       "isrc": "ITB000500792",
       "uri_apple_music": "applemusic://track/1344888786",
-      "uri_deezer": "deezer://track/461326062"
+      "uri_deezer": "deezer://track/461326062",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=F6gamOoBakw"
     },
     {
       "year": 1982,


### PR DESCRIPTION
A `provider-uri-backfill` run, driven automatically by `com.beatify.youtube-backfill`.

- `musica-italiana` YouTube 17 -> **41**/114

Filled in along the way, because Odesli answers with every provider at once: deezer +1.

**Draft on purpose** — merged only once the maintainer approves.