### PR TITLE
Stop paying for a free lookup that costs the whole window

### DIFF
--- a/.claude/skills/provider-uri-backfill/scripts/backfill_provider_uris.py
+++ b/.claude/skills/provider-uri-backfill/scripts/backfill_provider_uris.py
@@ -1202,7 +1202,24 @@ def run(args: argparse.Namespace) -> int:
             # Odesli is fetched for the Apple/Tidal/Deezer gaps AND, when a
             # YouTube key is set, to try its ``youtube`` link as a 0-quota
             # first pass before spending an expensive search.list call.
-            want_odesli = bool(non_yt_gaps) or (yt_gap and yt_key)
+            #
+            # That free pass is not free under ``--youtube-first`` (#2301).
+            # It costs ``--odesli-sleep`` seconds per song, and the YouTube
+            # search sits behind it in the same iteration, so the deadline
+            # takes the search first. Measured on 2026-08-22, 15:32: five
+            # five-minute slices, three of them reached search.list zero
+            # times and the run ended at its 25-minute cap having spent
+            # 24 of 90 permitted searches.
+            #
+            # So when this run exists to fill YouTube and YouTube is the
+            # song's only gap, skip Odesli and pay the search directly.
+            # The trade is quota for time: 100 units against a wait that
+            # currently buys about 50 songs per slice. The other agents
+            # (Apple, Deezer, Tidal) run without the flag and keep the
+            # free pass unchanged.
+            want_odesli = bool(non_yt_gaps) or (
+                yt_gap and yt_key and not args.youtube_first
+            )
             if want_odesli:
                 # Counted before the call, so --max caps attempts rather than
                 # successes — a run that only hits 429s must still terminate.

--- a/tests/unit/test_backfill_youtube_first_2301.py
+++ b/tests/unit/test_backfill_youtube_first_2301.py
@@ -87,10 +87,60 @@ class TestOptionExists:
         )
 
     def test_odesli_still_runs_before_the_youtube_search(self):
-        # Bewusst NICHT umgedreht: der Odesli-Aufruf liefert den YouTube-Link
-        # gratis mit (0 Quota). Liefe die Suche zuerst, wuerde jeder Treffer
-        # 100 Quota-Einheiten kosten, die Odesli verschenkt haette.
+        # Die Reihenfolge im Quelltext bleibt, wie sie war — geaendert wurde
+        # nur, WANN Odesli ueberhaupt gefragt wird (siehe TestOdesliSkip).
+        # Fuer jeden Lauf ohne ``--youtube-first`` gilt unveraendert: Odesli
+        # liefert den YouTube-Link gratis mit (0 Quota), und der Aufruf steht
+        # deshalb vor der Suche, die 100 Einheiten kostet.
         src = _SCRIPT.read_text()
         odesli_at = src.index("---- Odesli (apple/tidal/deezer")
         youtube_at = src.index("---- YouTube Data API search.list")
         assert odesli_at < youtube_at
+
+
+def wants_odesli(
+    non_yt_gaps: list[str], yt_gap: bool, yt_key: bool, youtube_first: bool
+) -> bool:
+    """Die ``want_odesli``-Bedingung aus dem Song-Loop, isoliert nachgebildet."""
+    return bool(non_yt_gaps) or (yt_gap and yt_key and not youtube_first)
+
+
+class TestOdesliSkip:
+    """Der Gratis-Vorabtreffer ist unter ``--youtube-first`` nicht gratis (#2301).
+
+    Er kostet ``--odesli-sleep`` Sekunden pro Song, und die YouTube-Suche steht
+    im selben Schleifendurchgang dahinter. Der Zeitdeckel nimmt also zuerst die
+    Suche. Gemessen am 22.08.2026 um 15:32: fuenf Scheiben, drei davon erreichten
+    ``search.list`` kein einziges Mal, der Lauf endete am 25-Minuten-Deckel mit
+    24 von 90 erlaubten Suchen.
+    """
+
+    def test_youtube_only_gap_skips_odesli_under_the_flag(self):
+        # Der Fall, um den es geht: nichts ausser YouTube fehlt, also gibt es
+        # nichts, wofuer sich die Wartezeit noch lohnen wuerde.
+        assert wants_odesli([], yt_gap=True, yt_key=True, youtube_first=True) is False
+
+    def test_youtube_only_gap_still_asks_odesli_without_the_flag(self):
+        # Apple-, Deezer- und Tidal-Agenten rufen dasselbe Skript ohne das Flag
+        # auf. Fuer sie bleibt der Gratis-Vorabtreffer unveraendert erhalten.
+        assert wants_odesli([], yt_gap=True, yt_key=True, youtube_first=False) is True
+
+    def test_a_second_gap_still_needs_odesli_even_under_the_flag(self):
+        # Apple/Deezer/Tidal kommen NUR ueber Odesli. Fehlt einer davon mit,
+        # muss der Aufruf stattfinden — sonst repariert der YouTube-Lauf eine
+        # Luecke und reisst eine andere auf.
+        for extra in (["apple_music"], ["deezer"], ["tidal"]):
+            assert (
+                wants_odesli(extra, yt_gap=True, yt_key=True, youtube_first=True)
+                is True
+            )
+
+    def test_without_a_youtube_key_nothing_changes(self):
+        # Ohne Key gibt es keine Suche, die man vorziehen koennte. Dann haengt
+        # alles allein an den Nicht-YouTube-Luecken — mit Flag wie ohne.
+        assert wants_odesli([], yt_gap=True, yt_key=False, youtube_first=True) is False
+        assert wants_odesli([], yt_gap=True, yt_key=False, youtube_first=False) is False
+
+    def test_the_condition_is_wired_into_the_song_loop(self):
+        src = _SCRIPT.read_text()
+        assert "yt_gap and yt_key and not args.youtube_first" in src


### PR DESCRIPTION
Closes #2301.

## What changes

One condition in the song loop of `backfill_provider_uris.py`:

```python
want_odesli = bool(non_yt_gaps) or (yt_gap and yt_key and not args.youtube_first)
```

Under `--youtube-first`, a song whose **only** gap is YouTube no longer asks Odesli first — it goes straight to `search.list`. A song that is also missing Apple, Deezer or Tidal still calls Odesli, because those providers have no other route.

Nothing changes for the Apple, Deezer and Tidal agents. They invoke the same script without the flag, and `--youtube-first` is `store_true`.

## Why the earlier fix was not enough

`--youtube-first` shipped this morning and skips songs *before* the resume cursor. It helped where there was something to skip and did nothing where there was not.

The 15:32 run shows both halves in one log:

| Slice | Playlist | Searches | URIs |
|---|---|---|---|
| 1 | tomorrowland-top-1000 (779 gaps) | 0 | 0 |
| 2 | tomorrowland-top-1000 | 0 | 0 |
| 3 | musica-italiana (cursor 46) | 12 | +12 |
| 4 | musica-italiana | 12 | +12 |
| 5 | musica-italiana | 0 | 0 |

The run ended on its 25-minute cap, not on the daily budget: `Zeitdeckel erreicht (25 min)`, `spent 24/90`. The script diagnoses itself in the same log — `ACHTUNG: 3 Scheibe(n) endeten ohne eine einzige YouTube-Suche — der Zeitdeckel fiel in der Odesli-Phase (#2301)`.

The reason is structural. There is no separate YouTube phase; `yt_phase_note` is only a closing line. The `search.list` call lives **inside** the per-song loop, **behind** the Odesli call and its 6-second throttle. A five-minute slice therefore buys about 50 songs of walking, and the search is the last thing in every iteration — so it is the first thing the deadline removes.

## The trade, stated plainly

The Odesli pass can return a YouTube link for 0 quota against 100 units for a search. Giving it up spends quota where Odesli would sometimes have delivered for free.

Two things make that trade worth taking for this agent, and only this agent:

- **Quota is not the binding constraint.** 90 searches is 9,000 of the 10,000 daily units. The agent currently spends 0.
- **Precision is not the concern.** All 24 searches in the 15:32 run returned a usable video. Searching works; most slices never get to do any.

`test_odesli_still_runs_before_the_youtube_search` is kept and still passes — the source order is unchanged. Only its comment is updated, because the rationale is now conditional on the flag rather than universal.

## Tests

`tests/unit/test_backfill_youtube_first_2301.py`, new class `TestOdesliSkip`, 5 cases:

- YouTube-only gap skips Odesli **under** the flag
- YouTube-only gap still asks Odesli **without** the flag (Apple/Deezer/Tidal agents)
- a second gap (`apple_music` / `deezer` / `tidal`) still forces the Odesli call even under the flag
- no YouTube key → behaviour identical with and without the flag
- the condition is actually wired into the song loop

13 tests in the file, **1987 unit tests green** locally.

## How to tell whether it worked

The 19:32 slice. If it reports more than 24 searches for the day, the window is reaching `search.list`. If `spent_today` sticks near 24 again, the cause is elsewhere and this issue should be reopened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LYnmkDxHC2drccP1XFpJN4