### PR TITLE
Point both dead Apple tracks at a release that exists everywhere

### DIFF
--- a/custom_components/beatify/playlists/80er-hits.json
+++ b/custom_components/beatify/playlists/80er-hits.json
@@ -1,6 +1,6 @@
 {
   "name": "80s Hits",
-  "version": "2.20",
+  "version": "2.21",
   "tags": [
     "1980s",
     "pop",
@@ -4877,7 +4877,7 @@
       "fun_fact_fr": "Mick Hucknall a écrit cette chanson à seulement 17 ans, inspiré par sa mère absente partie quand il avait trois ans. Elle a atteint le #1 aux États-Unis en 1986.",
       "chart_info": {},
       "awards": [],
-      "uri_apple_music": "applemusic://track/294361564",
+      "uri_apple_music": "applemusic://track/274034224",
       "uri_youtube_music": "https://music.youtube.com/watch?v=yG07WSu7Q9w",
       "uri_tidal": "tidal://track/2060790",
       "uri_deezer": "deezer://track/2477001",
@@ -4885,13 +4885,13 @@
       "awards_nl": [],
       "isrc": "GBCRL0800119",
       "uri_apple_music_by_region": {
-        "us": "applemusic://track/294361564",
-        "de": "applemusic://track/1802225094",
-        "gb": "applemusic://track/1802225094",
-        "fr": "applemusic://track/1802225094",
-        "es": "applemusic://track/1802225094",
-        "nl": "applemusic://track/1802225094",
-        "it": "applemusic://track/1802225094"
+        "us": "applemusic://track/274034224",
+        "de": "applemusic://track/274034224",
+        "gb": "applemusic://track/274034224",
+        "fr": "applemusic://track/274034224",
+        "es": "applemusic://track/274034224",
+        "nl": "applemusic://track/274034224",
+        "it": "applemusic://track/274034224"
       }
     },
     {
@@ -5312,13 +5312,13 @@
       "awards_nl": [],
       "isrc": "USSM18600632",
       "uri_apple_music_by_region": {
-        "us": "applemusic://track/1452434657",
-        "de": "applemusic://track/1452434657",
-        "gb": "applemusic://track/1452434657",
-        "fr": "applemusic://track/1452434657",
-        "es": "applemusic://track/1452434657",
-        "nl": "applemusic://track/1452434657",
-        "it": "applemusic://track/1452434657"
+        "us": "applemusic://track/193521054",
+        "de": "applemusic://track/193521054",
+        "gb": "applemusic://track/193521054",
+        "fr": "applemusic://track/193521054",
+        "es": "applemusic://track/193521054",
+        "nl": "applemusic://track/193521054",
+        "it": "applemusic://track/193521054"
       }
     },
     {


### PR DESCRIPTION
Fixes the Apple Music half of #2314. The YouTube half shipped in #2315.

## What was broken

Two entries in `80er-hits` had Apple Music region maps that resolved to nothing in every storefront checked:

| Track | Old id | Storefronts affected |
|---|---|---|
| Simply Red — Holding Back the Years | `1802225094` | de, gb, fr, es, nl, it |
| Cyndi Lauper — True Colors | `1452434657` | us, de, gb, fr, es, nl, it |

Verified against `itunes.apple.com/lookup` per storefront: `resultCount: 0` for all fourteen combinations.

## What they point at now

| Track | New id | Album | Verified in |
|---|---|---|---|
| Holding Back the Years | `274034224` | *Picture Book* (1985) | us, de, gb, fr, es, nl, it |
| True Colors | `193521054` | *True Colors* (1986-09-16) | us, de, gb, fr, es, nl, it |

Both were confirmed through the lookup endpoint in each of the seven storefronts before being written, not just found through search.

## Two things worth flagging

**Simply Red's base `uri_apple_music` was broken too, and the issue did not report it.** It held `294361564` (*Picture Book (Expanded Version)*) — alive in six storefronts and dead in **gb**. That is the harder failure to notice: six storefronts answer normally, so nothing looks wrong unless someone happens to be on the seventh. It is corrected in the same commit, and the base field now matches the region map.

**For True Colors the search ranking preferred a compilation.** `187488934` from *The Essential Cyndi Lauper* also resolves in all seven storefronts, and a rule that simply takes the first working result would have chosen it. It was not chosen. Compilations are where this catalogue keeps acquiring wrong release years — 104 cross-playlist year conflicts were counted this morning, 46 of them traceable to compilation or remix entries. The studio album is the safer anchor, and it is already what the entry's base field points at.

## Still open on #2314

This PR does not close the issue. Two items remain, and both are decisions rather than lookups:

- **Peter Schilling — Major Tom** and **Central Line — Walking Into Sunshine**, both flagged `wrong_track` rather than dead. For Central Line all three providers agree on the 12" mix while the entry is titled "- Edit", so the outlier may well be the title.
- **The Farm — All Together Now** answered HTTP 403, which says the checker could not look — not that the link is broken. Left for the next rotation.

Version 2.20 → 2.21. Schema gate green across all 58 playlists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LYnmkDxHC2drccP1XFpJN4