### PR TITLE
chore(playlists): youtube backfill — +4 youtube uris

### DIFF
--- a/custom_components/beatify/playlists/community/musica-italiana.json
+++ b/custom_components/beatify/playlists/community/musica-italiana.json
@@ -1,7 +1,7 @@
 {
   "name": "Musica Italiana 🇮🇹",
   "description": "Italian classics from the 1960s to the 2000s — cantautori, Sanremo winners and the songs every Italian party sings along to. Merged from playlist requests #2228 and #2229.",
-  "version": "0.11",
+  "version": "0.12",
   "songs": [
     {
       "year": 1962,
@@ -1410,7 +1410,8 @@
       "fun_fact_it": "Franco Battiato - \"Voglio Vederti Danzare - Remastered\" (1982), dal canone del pop italiano.",
       "isrc": "ITD000800109",
       "uri_apple_music": "applemusic://track/713520078",
-      "uri_deezer": "deezer://track/3464233"
+      "uri_deezer": "deezer://track/3464233",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=3nxXrHZ2HL4"
     },
     {
       "year": 1982,
@@ -1429,7 +1430,8 @@
       "fun_fact_it": "Loredana Bertè - \"Non sono una signora\" (1982), dal canone del pop italiano.",
       "isrc": "ITR008200751",
       "uri_apple_music": "applemusic://track/79323055",
-      "uri_deezer": "deezer://track/742432"
+      "uri_deezer": "deezer://track/742432",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=oXh2eveEhFI"
     },
     {
       "year": 1982,
@@ -1448,7 +1450,8 @@
       "fun_fact_it": "Loretta Goggi - \"Pieno d'amore\" (1982), dal canone del pop italiano.",
       "isrc": "ITQ008200021",
       "uri_apple_music": "applemusic://track/698668554",
-      "uri_deezer": "deezer://track/70331701"
+      "uri_deezer": "deezer://track/70331701",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=M_81gxRaio8"
     },
     {
       "year": 1982,
@@ -1467,7 +1470,8 @@
       "fun_fact_it": "Mia Martini - \"E non finisce mica il cielo\" (1982), dal canone del pop italiano. Pubblicata da DDD nel 1982.",
       "isrc": "ITB008200759",
       "uri_apple_music": "applemusic://track/408273025",
-      "uri_deezer": "deezer://track/3803029202"
+      "uri_deezer": "deezer://track/3803029202",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=1BqITMZofwM"
     },
     {
       "year": 1982,

--- a/custom_components/beatify/playlists/community/sanremo-vincitori.json
+++ b/custom_components/beatify/playlists/community/sanremo-vincitori.json
@@ -1,7 +1,7 @@
 {
   "name": "Sanremo: I Vincitori 🇮🇹",
   "description": "Every winning song of the Sanremo Music Festival, from Nilla Pizzi in 1951 to Sal Da Vinci in 2026. Years verified against the official Albo d'oro. Requested in #2230.",
-  "version": "0.7",
+  "version": "0.8",
   "tags": [
     "italian",
     "sanremo",
@@ -1072,7 +1072,7 @@
       "uri_apple_music": "applemusic://track/1450934916",
       "uri_apple_music_by_region": {},
       "uri_deezer": "deezer://track/2175872",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=vCE6KYMh6yk",
       "uri_tidal": null
     },
     {
@@ -1096,7 +1096,7 @@
         "us": "applemusic://track/1519834045"
       },
       "uri_deezer": "deezer://track/999720362",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=X_dPtwAVF8w",
       "uri_tidal": null
     },
     {
@@ -1122,7 +1122,7 @@
         "it": "applemusic://track/217831136"
       },
       "uri_deezer": "deezer://track/2170433",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=x8RiA5ZRKMs",
       "uri_tidal": null
     },
     {
@@ -1149,7 +1149,7 @@
         "it": "applemusic://track/1444749282"
       },
       "uri_deezer": "deezer://track/594809612",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=MGAHrzJRBnY",
       "uri_tidal": null
     },
     {
@@ -1171,7 +1171,7 @@
       "uri_apple_music": "applemusic://track/305208085",
       "uri_apple_music_by_region": {},
       "uri_deezer": "deezer://track/2913698",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=-msSyWcO8Ys",
       "uri_tidal": null
     },
     {
@@ -1195,7 +1195,7 @@
         "fr": "applemusic://track/712877672"
       },
       "uri_deezer": "deezer://track/5522920",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=9PRT5NSpPCA",
       "uri_tidal": null
     },
     {


### PR DESCRIPTION
A `provider-uri-backfill` run, driven automatically by `com.beatify.youtube-backfill`.

- `musica-italiana` YouTube 41 -> **45**/114

**Draft on purpose** — merged only once the maintainer approves.