### PR TITLE
Skip Odesli for every YouTube gap, not only the lonely ones

### DIFF
--- a/.claude/skills/provider-uri-backfill/scripts/backfill_provider_uris.py
+++ b/.claude/skills/provider-uri-backfill/scripts/backfill_provider_uris.py
@@ -1211,14 +1211,24 @@ def run(args: argparse.Namespace) -> int:
             # times and the run ended at its 25-minute cap having spent
             # 24 of 90 permitted searches.
             #
-            # So when this run exists to fill YouTube and YouTube is the
-            # song's only gap, skip Odesli and pay the search directly.
+            # So when this run exists to fill YouTube, a song with a YouTube
+            # gap skips Odesli entirely and pays the search directly.
+            #
+            # The first attempt narrowed that to songs whose *only* gap was
+            # YouTube, and on this catalogue that condition never holds:
+            # tomorrowland-top-1000 has 779 YouTube gaps and all 779 are also
+            # missing Tidal, musica-italiana 73 of 73. The 04:00 Tidal wave
+            # counts 1063 tracks missing Tidal across 58 playlists, so a
+            # sole-gap test is close to unreachable and the 19:32 run spent
+            # four searches where the 15:32 run spent twenty-four.
+            #
             # The trade is quota for time: 100 units against a wait that
-            # currently buys about 50 songs per slice. The other agents
-            # (Apple, Deezer, Tidal) run without the flag and keep the
-            # free pass unchanged.
-            want_odesli = bool(non_yt_gaps) or (
-                yt_gap and yt_key and not args.youtube_first
+            # buys about 50 songs per slice. The other gaps on these songs
+            # are not lost — Apple, Deezer and Tidal have their own agents
+            # and their own windows, and they call this script without the
+            # flag, so their free pass is unchanged.
+            want_odesli = not (args.youtube_first and yt_gap) and (
+                bool(non_yt_gaps) or (yt_gap and yt_key)
             )
             if want_odesli:
                 # Counted before the call, so --max caps attempts rather than

--- a/tests/unit/test_backfill_youtube_first_2301.py
+++ b/tests/unit/test_backfill_youtube_first_2301.py
@@ -102,9 +102,7 @@ def wants_odesli(
     non_yt_gaps: list[str], yt_gap: bool, yt_key: bool, youtube_first: bool
 ) -> bool:
     """Die ``want_odesli``-Bedingung aus dem Song-Loop, isoliert nachgebildet."""
-    return not (youtube_first and yt_gap) and (
-        bool(non_yt_gaps) or (yt_gap and yt_key)
-    )
+    return not (youtube_first and yt_gap) and (bool(non_yt_gaps) or (yt_gap and yt_key))
 
 
 class TestOdesliSkip:
@@ -128,8 +126,12 @@ class TestOdesliSkip:
         # Der Normalfall im Katalog: YouTube fehlt, Tidal fehlt mit. Frueher
         # zwang das den 6-Sekunden-Aufruf, jetzt nicht mehr.
         assert wants_odesli([], yt_gap=True, yt_key=True, youtube_first=True) is False
-        for extra in (["tidal"], ["apple_music"], ["deezer"],
-                      ["apple_music", "deezer", "tidal"]):
+        for extra in (
+            ["tidal"],
+            ["apple_music"],
+            ["deezer"],
+            ["apple_music", "deezer", "tidal"],
+        ):
             assert (
                 wants_odesli(extra, yt_gap=True, yt_key=True, youtube_first=True)
                 is False
@@ -139,28 +141,31 @@ class TestOdesliSkip:
         # Ohne API-Key gibt es zwar keine Suche, aber auch keinen Grund, in
         # einem YouTube-Lauf auf Odesli zu warten. Die Entscheidung haengt
         # allein an Flag und Luecke.
-        assert wants_odesli(["tidal"], yt_gap=True, yt_key=False,
-                            youtube_first=True) is False
+        assert (
+            wants_odesli(["tidal"], yt_gap=True, yt_key=False, youtube_first=True)
+            is False
+        )
 
     def test_a_song_without_a_youtube_gap_is_untouched(self):
         # Das Flag sagt nur, welchen Job dieser Lauf macht. Songs ohne
         # YouTube-Luecke gehen ihren gewohnten Weg — sonst wuerde ein
         # YouTube-Lauf fremde Luecken stillschweigend ueberspringen.
-        assert wants_odesli(["tidal"], yt_gap=False, yt_key=True,
-                            youtube_first=True) is True
-        assert wants_odesli([], yt_gap=False, yt_key=True,
-                            youtube_first=True) is False
+        assert (
+            wants_odesli(["tidal"], yt_gap=False, yt_key=True, youtube_first=True)
+            is True
+        )
+        assert wants_odesli([], yt_gap=False, yt_key=True, youtube_first=True) is False
 
     def test_without_the_flag_everything_is_as_before(self):
         # Apple-, Deezer- und Tidal-Agenten rufen dasselbe Skript ohne das
         # Flag auf. Fuer sie darf sich nichts aendern.
         assert wants_odesli([], yt_gap=True, yt_key=True, youtube_first=False) is True
-        assert wants_odesli(["tidal"], yt_gap=True, yt_key=True,
-                            youtube_first=False) is True
-        assert wants_odesli([], yt_gap=True, yt_key=False,
-                            youtube_first=False) is False
-        assert wants_odesli([], yt_gap=False, yt_key=True,
-                            youtube_first=False) is False
+        assert (
+            wants_odesli(["tidal"], yt_gap=True, yt_key=True, youtube_first=False)
+            is True
+        )
+        assert wants_odesli([], yt_gap=True, yt_key=False, youtube_first=False) is False
+        assert wants_odesli([], yt_gap=False, yt_key=True, youtube_first=False) is False
 
     def test_the_narrow_first_attempt_is_gone(self):
         # Die alte Bedingung darf nicht zurueckkommen: sie war syntaktisch

--- a/tests/unit/test_backfill_youtube_first_2301.py
+++ b/tests/unit/test_backfill_youtube_first_2301.py
@@ -102,7 +102,9 @@ def wants_odesli(
     non_yt_gaps: list[str], yt_gap: bool, yt_key: bool, youtube_first: bool
 ) -> bool:
     """Die ``want_odesli``-Bedingung aus dem Song-Loop, isoliert nachgebildet."""
-    return bool(non_yt_gaps) or (yt_gap and yt_key and not youtube_first)
+    return not (youtube_first and yt_gap) and (
+        bool(non_yt_gaps) or (yt_gap and yt_key)
+    )
 
 
 class TestOdesliSkip:
@@ -110,37 +112,62 @@ class TestOdesliSkip:
 
     Er kostet ``--odesli-sleep`` Sekunden pro Song, und die YouTube-Suche steht
     im selben Schleifendurchgang dahinter. Der Zeitdeckel nimmt also zuerst die
-    Suche. Gemessen am 22.08.2026 um 15:32: fuenf Scheiben, drei davon erreichten
-    ``search.list`` kein einziges Mal, der Lauf endete am 25-Minuten-Deckel mit
-    24 von 90 erlaubten Suchen.
+    Suche.
+
+    **Der erste Anlauf war zu eng.** Er sprang nur, wenn YouTube die *einzige*
+    Luecke war — und diese Bedingung ist auf diesem Katalog praktisch nie wahr:
+    tomorrowland-top-1000 hat 779 YouTube-Luecken, allen 779 fehlt auch Tidal;
+    musica-italiana 73 von 73. Die 04:00-Welle zaehlt **1063** Tracks ohne Tidal
+    ueber 58 Playlists. Gemessen: 15:32-Lauf 24 Suchen, 19:32-Lauf mit dem engen
+    Fix **4** Suchen und vier von fuenf Scheiben ohne eine einzige.
+
+    Deshalb faellt Odesli jetzt fuer **jeden** Song mit YouTube-Luecke weg.
     """
 
-    def test_youtube_only_gap_skips_odesli_under_the_flag(self):
-        # Der Fall, um den es geht: nichts ausser YouTube fehlt, also gibt es
-        # nichts, wofuer sich die Wartezeit noch lohnen wuerde.
+    def test_a_youtube_gap_alone_skips_odesli_under_the_flag(self):
+        # Der Normalfall im Katalog: YouTube fehlt, Tidal fehlt mit. Frueher
+        # zwang das den 6-Sekunden-Aufruf, jetzt nicht mehr.
         assert wants_odesli([], yt_gap=True, yt_key=True, youtube_first=True) is False
-
-    def test_youtube_only_gap_still_asks_odesli_without_the_flag(self):
-        # Apple-, Deezer- und Tidal-Agenten rufen dasselbe Skript ohne das Flag
-        # auf. Fuer sie bleibt der Gratis-Vorabtreffer unveraendert erhalten.
-        assert wants_odesli([], yt_gap=True, yt_key=True, youtube_first=False) is True
-
-    def test_a_second_gap_still_needs_odesli_even_under_the_flag(self):
-        # Apple/Deezer/Tidal kommen NUR ueber Odesli. Fehlt einer davon mit,
-        # muss der Aufruf stattfinden — sonst repariert der YouTube-Lauf eine
-        # Luecke und reisst eine andere auf.
-        for extra in (["apple_music"], ["deezer"], ["tidal"]):
+        for extra in (["tidal"], ["apple_music"], ["deezer"],
+                      ["apple_music", "deezer", "tidal"]):
             assert (
                 wants_odesli(extra, yt_gap=True, yt_key=True, youtube_first=True)
-                is True
-            )
+                is False
+            ), extra
 
-    def test_without_a_youtube_key_nothing_changes(self):
-        # Ohne Key gibt es keine Suche, die man vorziehen koennte. Dann haengt
-        # alles allein an den Nicht-YouTube-Luecken — mit Flag wie ohne.
-        assert wants_odesli([], yt_gap=True, yt_key=False, youtube_first=True) is False
-        assert wants_odesli([], yt_gap=True, yt_key=False, youtube_first=False) is False
+    def test_the_key_does_not_matter_under_the_flag(self):
+        # Ohne API-Key gibt es zwar keine Suche, aber auch keinen Grund, in
+        # einem YouTube-Lauf auf Odesli zu warten. Die Entscheidung haengt
+        # allein an Flag und Luecke.
+        assert wants_odesli(["tidal"], yt_gap=True, yt_key=False,
+                            youtube_first=True) is False
+
+    def test_a_song_without_a_youtube_gap_is_untouched(self):
+        # Das Flag sagt nur, welchen Job dieser Lauf macht. Songs ohne
+        # YouTube-Luecke gehen ihren gewohnten Weg — sonst wuerde ein
+        # YouTube-Lauf fremde Luecken stillschweigend ueberspringen.
+        assert wants_odesli(["tidal"], yt_gap=False, yt_key=True,
+                            youtube_first=True) is True
+        assert wants_odesli([], yt_gap=False, yt_key=True,
+                            youtube_first=True) is False
+
+    def test_without_the_flag_everything_is_as_before(self):
+        # Apple-, Deezer- und Tidal-Agenten rufen dasselbe Skript ohne das
+        # Flag auf. Fuer sie darf sich nichts aendern.
+        assert wants_odesli([], yt_gap=True, yt_key=True, youtube_first=False) is True
+        assert wants_odesli(["tidal"], yt_gap=True, yt_key=True,
+                            youtube_first=False) is True
+        assert wants_odesli([], yt_gap=True, yt_key=False,
+                            youtube_first=False) is False
+        assert wants_odesli([], yt_gap=False, yt_key=True,
+                            youtube_first=False) is False
+
+    def test_the_narrow_first_attempt_is_gone(self):
+        # Die alte Bedingung darf nicht zurueckkommen: sie war syntaktisch
+        # gueltig, gruen getestet — und feuerte auf echten Daten nie.
+        src = _SCRIPT.read_text()
+        assert "yt_gap and yt_key and not args.youtube_first" not in src
 
     def test_the_condition_is_wired_into_the_song_loop(self):
         src = _SCRIPT.read_text()
-        assert "yt_gap and yt_key and not args.youtube_first" in src
+        assert "want_odesli = not (args.youtube_first and yt_gap) and (" in src


### PR DESCRIPTION
Closes #2301. Supersedes the narrower attempt in #2317.

## What #2317 got wrong

It skipped Odesli when YouTube was a song's **only** gap. That condition never holds on this catalogue, so the change shipped green and did nothing.

Counted after the fact:

| Playlist | YouTube gaps | Also missing Tidal |
|---|---|---|
| `tomorrowland-top-1000` | 779 | **779** |
| `musica-italiana` | 73 | **73** |

The 04:00 Tidal wave gives the shape in one line: **1063 tracks are missing Tidal across 58 playlists**. With a gap that widespread, `non_yt_gaps` is essentially never empty, so the 6-second `--odesli-sleep` applied exactly as before.

Measured on the two runs either side of #2317 — same script, same queue, same playlists:

| Run | Slices | Searches | URIs | Slices with zero searches |
|---|---|---|---|---|
| 15:32 (before) | 5 | 24 | +24 | 3 |
| 19:32 (after) | 5 | 4 | +4 | **4** |

The 19:32 worktree was cut from `0e1dbf6`, well after #2317 merged, so the new code was running.

**The drop from 24 to 4 is not attributed to #2317.** Odesli's 429 backoff varies through the day, and code that never executes cannot slow anything down. What the numbers establish is only that nothing improved.

## What this changes

```python
want_odesli = not (args.youtube_first and yt_gap) and (
    bool(non_yt_gaps) or (yt_gap and yt_key)
)
```

Under `--youtube-first`, a song with a YouTube gap goes straight to `search.list`. Songs **without** a YouTube gap keep their old path, so a YouTube run does not silently skip work it was never asked about. Every agent that calls this script without the flag is untouched — the flag is `store_true`.

## What this gives up

During a YouTube run, the Apple, Deezer and Tidal gaps riding along on those songs no longer get filled as a side effect. Each provider has its own agent and its own window.

Tidal deserves naming, because it is the gap doing the blocking and it is currently unfillable regardless: the 04:00 wave answered **HTTP 401 on 200 of 200 attempts** and added nothing. Waiting six seconds per song for it is the worst of both.

Quota is not the constraint. 90 searches is 9,000 of the 10,000 daily units, and the agent spent 4 today.

## Tests

`tests/unit/test_backfill_youtube_first_2301.py`, 14 cases. `TestOdesliSkip` rewritten for the wider condition:

- a YouTube gap skips Odesli under the flag — alone, with Tidal, with Apple, with Deezer, with all three
- the API key does not change that decision under the flag
- a song **without** a YouTube gap is untouched
- without the flag, all four combinations behave exactly as before
- **a regression test pinning the narrow condition as gone** — its failure mode was invisible (valid syntax, green tests, zero effect on real data), so absence is asserted explicitly rather than assumed

`test_odesli_still_runs_before_the_youtube_search` is kept: the source order is unchanged, only the entry condition moved.

1988 unit tests green. Schema gate green across all 58 playlists.

## How to tell whether it worked

The 23:32 slice, then 03:32. If `spent_today` climbs well past 4 and the run's closing line stops reporting slices with zero searches, the window is reaching `search.list`. If it does not, this issue should be reopened a second time rather than closed on hope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LYnmkDxHC2drccP1XFpJN4