### PR TITLE
Settle 23 of the 46 wide year conflicts

### DIFF
--- a/custom_components/beatify/playlists/80er-hits.json
+++ b/custom_components/beatify/playlists/80er-hits.json
@@ -1,6 +1,6 @@
 {
   "name": "80s Hits",
-  "version": "2.21",
+  "version": "2.22",
   "tags": [
     "1980s",
     "pop",
@@ -3966,7 +3966,7 @@
       }
     },
     {
-      "year": 1984,
+      "year": 1982,
       "uri": "spotify:track:2u8MGAiS2hBVE7GZzTZLQI",
       "artist": "The Pointer Sisters",
       "alt_artists": [

--- a/custom_components/beatify/playlists/90er-hits.json
+++ b/custom_components/beatify/playlists/90er-hits.json
@@ -1,6 +1,6 @@
 {
   "name": "90s Hits",
-  "version": "1.24",
+  "version": "1.25",
   "tags": [
     "1990s",
     "pop",
@@ -1731,7 +1731,7 @@
     {
       "artist": "KC",
       "title": "Shake Your Booty - Live",
-      "year": 1990,
+      "year": 1976,
       "isrc": "GBAYE7600024",
       "uri": "spotify:track:4gcxYHlffrCstGw7EPWB88",
       "uri_apple_music": "applemusic://track/1580630968",

--- a/custom_components/beatify/playlists/community/anime-openings.json
+++ b/custom_components/beatify/playlists/community/anime-openings.json
@@ -1,6 +1,6 @@
 {
   "name": "Anime Openings",
-  "version": "1.26",
+  "version": "1.27",
   "tags": [
     "anime",
     "japanese",
@@ -2719,7 +2719,7 @@
     {
       "artist": "Yasuharu Takanashi",
       "title": "FAIRY TAIL Main Theme",
-      "year": 2017,
+      "year": 2010,
       "isrc": "JPPC01000884",
       "uri": "spotify:track:7JoZiEMrwjpD18krCV8Czo",
       "uri_apple_music": "applemusic://track/1612105965",

--- a/custom_components/beatify/playlists/community/ballermann-party-hits.json
+++ b/custom_components/beatify/playlists/community/ballermann-party-hits.json
@@ -1,6 +1,6 @@
 {
   "name": "Ballermann Party Hits",
-  "version": "1.28",
+  "version": "1.29",
   "tags": [
     "schlager",
     "party",
@@ -634,7 +634,7 @@
     {
       "artist": "Lorenz Büffel",
       "title": "Mallorca Mallorca",
-      "year": 2025,
+      "year": 2016,
       "isrc": "DEEQ81600063",
       "uri": "spotify:track:4RNfIYpaiDSb5dPT3KNdsv",
       "uri_apple_music": "applemusic://track/1825593929",
@@ -1711,7 +1711,7 @@
     {
       "artist": "Die Flippers",
       "title": "Wir sagen danke schön - DAS ORIGINAL",
-      "year": 2011,
+      "year": 2009,
       "isrc": "DEA810900727",
       "uri": "spotify:track:5oCCVPPduu3KNtf9wRo1eV",
       "uri_apple_music": "applemusic://track/1786346039",

--- a/custom_components/beatify/playlists/community/divorced-dad-rock.json
+++ b/custom_components/beatify/playlists/community/divorced-dad-rock.json
@@ -1,6 +1,6 @@
 {
   "name": "Divorced Dad Rock",
-  "version": "1.12",
+  "version": "1.13",
   "tags": [
     "post-grunge",
     "nu-metal",
@@ -316,7 +316,7 @@
     {
       "artist": "Pearl Jam",
       "title": "Even Flow",
-      "year": 2001,
+      "year": 1991,
       "isrc": "USSM19100673",
       "uri": "spotify:track:6QewNVIDKdSl8Y3ycuHIei",
       "uri_apple_music": "applemusic://track/1440902613",
@@ -541,7 +541,7 @@
     {
       "artist": "Incubus",
       "title": "Drive",
-      "year": 2001,
+      "year": 1999,
       "isrc": "USSM19911007",
       "uri": "spotify:track:73fzhVcs7n1wZz84eoE2vs",
       "uri_apple_music": "applemusic://track/187454421",
@@ -1641,7 +1641,7 @@
     {
       "artist": "The Red Jumpsuit Apparatus",
       "title": "Face Down",
-      "year": 2004,
+      "year": 2006,
       "isrc": "USVI20600108",
       "uri": "spotify:track:4wzjNqjKAKDU82e8uMhzmr",
       "uri_apple_music": "applemusic://track/806224710",

--- a/custom_components/beatify/playlists/community/essential-alternative.json
+++ b/custom_components/beatify/playlists/community/essential-alternative.json
@@ -1,6 +1,6 @@
 {
   "name": "Essential Alternative 🎸",
-  "version": "0.12",
+  "version": "0.13",
   "tags": [
     "alternative",
     "rock",
@@ -866,7 +866,7 @@
       }
     },
     {
-      "year": 2004,
+      "year": 1999,
       "uri": "spotify:track:64BbK9SFKH2jk86U3dGj2P",
       "artist": "Red Hot Chili Peppers",
       "alt_artists": [
@@ -1580,7 +1580,7 @@
       }
     },
     {
-      "year": 1992,
+      "year": 1991,
       "uri": "spotify:track:6QewNVIDKdSl8Y3ycuHIei",
       "artist": "Pearl Jam",
       "alt_artists": [
@@ -1614,7 +1614,7 @@
       }
     },
     {
-      "year": 2004,
+      "year": 1999,
       "uri": "spotify:track:1G391cbiT3v3Cywg8T7DM1",
       "artist": "Red Hot Chili Peppers",
       "alt_artists": [
@@ -1886,7 +1886,7 @@
       }
     },
     {
-      "year": 2009,
+      "year": 2007,
       "uri": "spotify:track:7x8dCjCr0x6x2lXKujYD34",
       "artist": "Foo Fighters",
       "alt_artists": [
@@ -2260,7 +2260,7 @@
       }
     },
     {
-      "year": 2013,
+      "year": 2008,
       "uri": "spotify:track:1sTsuZTdANkiFd7T34H3nb",
       "artist": "The Killers",
       "alt_artists": [
@@ -2396,7 +2396,7 @@
       }
     },
     {
-      "year": 2009,
+      "year": 2005,
       "uri": "spotify:track:5FZxsHWIvUsmSK1IAvm2pp",
       "artist": "Foo Fighters",
       "alt_artists": [
@@ -2532,7 +2532,7 @@
       }
     },
     {
-      "year": 2010,
+      "year": 2002,
       "uri": "spotify:track:0BRHnOFm6sjxN1i9LJrUDu",
       "artist": "Good Charlotte",
       "alt_artists": [

--- a/custom_components/beatify/playlists/community/eurodance-90s.json
+++ b/custom_components/beatify/playlists/community/eurodance-90s.json
@@ -1,6 +1,6 @@
 {
   "name": "Eurodance 90s 💥",
-  "version": "1.17",
+  "version": "1.18",
   "tags": [
     "1990s",
     "eurodance",
@@ -3463,7 +3463,7 @@
       }
     },
     {
-      "year": 1995,
+      "year": 2000,
       "uri": "spotify:track:4oNGIP8ivrEI9rGzfJp8eQ",
       "artist": "Brooklyn Bounce",
       "alt_artists": [

--- a/custom_components/beatify/playlists/community/greatest-metal-songs.json
+++ b/custom_components/beatify/playlists/community/greatest-metal-songs.json
@@ -1,6 +1,6 @@
 {
   "name": "Greatest Metal Songs of All Time 🤘",
-  "version": "1.18",
+  "version": "1.19",
   "tags": [
     "metal",
     "rock",
@@ -1636,7 +1636,7 @@
       "uri_deezer": "deezer://track/97098410"
     },
     {
-      "year": 1990,
+      "year": 1992,
       "uri": "spotify:track:59WN2psjkt1tyaxjspN8fp",
       "artist": "Rage Against the Machine",
       "title": "Killing in the Name",
@@ -2364,7 +2364,7 @@
       "uri_deezer": "deezer://track/740969212"
     },
     {
-      "year": 1985,
+      "year": 1980,
       "uri": "spotify:track:6EPRKhUOdiFSQwGBRBbvsZ",
       "artist": "Motörhead",
       "title": "Ace of Spades",

--- a/custom_components/beatify/playlists/community/hitster-100-francais.json
+++ b/custom_components/beatify/playlists/community/hitster-100-francais.json
@@ -1,6 +1,6 @@
 {
   "name": "100% Français 🇫🇷",
-  "version": "0.14",
+  "version": "0.15",
   "tags": [
     "french",
     "francais",
@@ -381,7 +381,7 @@
       "artist": "Céline Dion",
       "title": "Pour que tu m'aimes encore",
       "uri": "spotify:track:6qlpXtA29VcxCNgLWR5IWx",
-      "year": 2009,
+      "year": 1995,
       "isrc": "CAC229500002",
       "uri_apple_music": "applemusic://track/203133177",
       "uri_apple_music_by_region": {

--- a/custom_components/beatify/playlists/community/musica-italiana.json
+++ b/custom_components/beatify/playlists/community/musica-italiana.json
@@ -1,7 +1,7 @@
 {
   "name": "Musica Italiana 🇮🇹",
   "description": "Italian classics from the 1960s to the 2000s — cantautori, Sanremo winners and the songs every Italian party sings along to. Merged from playlist requests #2228 and #2229.",
-  "version": "0.11",
+  "version": "0.12",
   "songs": [
     {
       "year": 1962,
@@ -1679,7 +1679,7 @@
       "uri_deezer": "deezer://track/104724380"
     },
     {
-      "year": 1984,
+      "year": 1986,
       "uri": "spotify:track:07CPBe6hvgHgn749mxR0EJ",
       "artist": "Eros Ramazzotti",
       "alt_artists": [],

--- a/custom_components/beatify/playlists/community/pure-pop-punk.json
+++ b/custom_components/beatify/playlists/community/pure-pop-punk.json
@@ -1,6 +1,6 @@
 {
   "name": "Pure Pop Punk 🎸",
-  "version": "1.12",
+  "version": "1.13",
   "tags": [
     "2000s",
     "pop-punk",
@@ -2830,7 +2830,7 @@
       }
     },
     {
-      "year": 2013,
+      "year": 2008,
       "uri": "spotify:track:3yZQk5PC52CCmT4ZaTIKvv",
       "artist": "Panic! At The Disco",
       "alt_artists": [
@@ -3028,7 +3028,7 @@
       }
     },
     {
-      "year": 2004,
+      "year": 2011,
       "uri": "spotify:track:0SUClY63fA1awioMFtMYeE",
       "artist": "Jimmy Eat World",
       "alt_artists": [
@@ -3396,7 +3396,7 @@
       }
     },
     {
-      "year": 2000,
+      "year": 2006,
       "uri": "spotify:track:3KLkRy9l3us98SIp6mmxkk",
       "artist": "Millencolin",
       "alt_artists": [

--- a/custom_components/beatify/playlists/disco-funk-classics.json
+++ b/custom_components/beatify/playlists/disco-funk-classics.json
@@ -1,6 +1,6 @@
 {
   "name": "Disco & Funk Classics",
-  "version": "1.21",
+  "version": "1.22",
   "tags": [
     "1970s",
     "1980s",
@@ -340,7 +340,7 @@
       }
     },
     {
-      "year": 1984,
+      "year": 1982,
       "uri": "spotify:track:2u8MGAiS2hBVE7GZzTZLQI",
       "artist": "The Pointer Sisters",
       "alt_artists": [

--- a/custom_components/beatify/playlists/disney-classics.json
+++ b/custom_components/beatify/playlists/disney-classics.json
@@ -1,6 +1,6 @@
 {
   "name": "Disney Classics",
-  "version": "1.9",
+  "version": "1.10",
   "tags": [
     "disney",
     "movies",
@@ -2260,7 +2260,7 @@
       }
     },
     {
-      "year": 2002,
+      "year": 2025,
       "artist": "Iam Tongi, Kamehameha Schools Children's Chorus & Disney",
       "title": "Hawaiian Roller Coaster Ride",
       "uri": "spotify:track:5coZgMb9D2sypM21bwEOAq",


### PR DESCRIPTION
Settles 23 of the 46 cross-playlist year conflicts that are more than one year apart.

## The problem

A song in two playlists with two different years gives the same question two answers, depending on which playlist the round was drawn from. A player who learns it one way is wrong the next time.

81 songs sit in more than one playlist with a differing year. 46 of them differ by **two years or more** — too far for the album-versus-single question to explain, so the later year is almost always a compilation or a re-release. Those 46 are this PR's scope.

## How each was decided

The year convention: `min(MusicBrainz first-release-date, Deezer release_date)`, overridden by the ISRC year code only when it is at least two years earlier. For a cover credited to the covering artist, the year of the linked recording wins.

Two guards on top, because the formula alone is not enough:

1. **The computed year must already be one of the two in the catalogue.** Where the sources produced a third value, nothing was written. Settling a conflict and introducing a new year are different jobs.
2. **At least two of the three sources must name it.** One source agreeing with itself is not corroboration, and MusicBrainz alone gets this class wrong often enough to matter — three spot checks yesterday had it a year late each time.

## Settled (23)

| Song | was | now | sources agreeing |
|---|---|---|---|
| AFI — Miss Murder | 2000 | **2006** | 3/3 |
| Brooklyn Bounce — Bass, Beats & Melody | 1995 | **2000** | 2/3 |
| Céline Dion — Pour que tu m'aimes encore | 2009 | **1995** | 3/3 |
| Die Flippers — Wir sagen danke schön - DAS ORIGINAL | 2011 | **2009** | 3/3 |
| Eros Ramazzotti — Adesso tu | 1984 | **1986** | 2/3 |
| Foo Fighters — Best of You | 2009 | **2005** | 2/3 |
| Foo Fighters — The Pretender | 2009 | **2007** | 2/3 |
| Good Charlotte — The Anthem | 2010 | **2002** | 2/3 |
| Iam Tongi, Kamehameha Schools Children's Chorus, Disney — Hawaiian Roller Coaster Ride | 2002 | **2025** | 3/3 |
| Incubus — Drive | 2001 | **1999** | 2/3 |
| KC — Shake Your Booty - Live | 1990 | **1976** | 2/3 |
| Lorenz Büffel — Mallorca Mallorca | 2025 | **2016** | 3/3 |
| Motörhead — Ace of Spades | 1985 | **1980** | 2/3 |
| Pearl Jam — Even Flow | 1992, 2001 | **1991** | 2/3 |
| Rage Against the Machine — Killing in the Name | 1990 | **1992** | 3/3 |
| Red Hot Chili Peppers — Scar Tissue | 2004 | **1999** | 2/3 |
| Red Hot Chili Peppers — Otherside | 2004 | **1999** | 2/3 |
| Rise Against — Savior | 2013 | **2008** | 3/3 |
| Simple Plan, Natasha Bedingfield — Jet Lag (feat. Natasha Bedingfield) | 2004 | **2011** | 3/3 |
| The Killers — Human | 2013 | **2008** | 3/3 |
| The Pointer Sisters — I'm So Excited | 1984 | **1982** | 2/3 |
| The Red Jumpsuit Apparatus — Face Down | 2004 | **2006** | 3/3 |
| Yasuharu Takanashi — FAIRY TAIL Main Theme | 2017 | **2010** | 2/3 |

## Pulled back out by hand (2)

The rule accepted these two and they were removed anyway. Both raise the year, and a targeted MusicBrainz query over every recording under that artist and title found nothing supporting either the old value or the new one:

| Song | catalogue | rule wanted | why not |
|---|---|---|---|
| SID — 嘘 | 2009 / 2015 | 2015 | MusicBrainz knows only 2022 and 2024 for this recording; nothing corroborates 2009 or 2015 |
| Andrea Berg — Du hast mich tausendmal belogen | 1996 / 2001 | 2001 | MusicBrainz returns nothing at all; 2001 rests on ISRC and Deezer, which can both be reading the same re-release |

A rule that keeps its own doubts is worth more than two extra lines.

## Left open (21)

| Song | catalogue | mb | deezer | isrc | why not |
|---|---|---|---|---|---|
| Pur — Party Mix I | 1999, 2024 | — | 2019 | 1998 | third value 1998 |
| Mr. Zoob — Mój Jest Ten Kawałek Podłogi | 1986, 2011 | — | 2019 | 2011 | only one source names 2011 |
| T.Love — Warszawa | 1991, 2014 | 2008 | 2014 | 2008 | third value 2008 |
| Lady Pank — Kryzysowa Narzeczona | 1983, 2003 | — | 2019 | 2007 | third value 2007 |
| Maanam — Cykady na Cykladach - 2011 Remaster | 1981, 1997 | — | 2011 | 2011 | third value 2011 |
| Robert Gawlinski — O sobie samym | 1995, 2010 | — | 2018 | 2004 | third value 2004 |
| Foo Fighters — Everlong | 1997, 1999, 2009 | 1997 | 2009 | 1996 | only one source names 1997 |
| Green Day — Basket Case | 1994, 2003 | 1994 | 2003 | 1999 | only one source names 1994 |
| Third Eye Blind — Semi-Charmed Life | 1997, 2006 | 1997 | 2006 | 2006 | only one source names 1997 |
| Green Day — When I Come Around | 1994, 2003 | 1994 | 2003 | 1999 | only one source names 1994 |
| Stefan Stürmer — Mallorca ich komm heim - Wellerman | 2014, 2022 | 2021 | 2021 | 2021 | third value 2021 |
| SID — 嘘 | 2009, 2015 | 2015 | 2015 | 2015 | only one source names 2015 |
| Andrea Berg — Du hast mich tausendmal belogen | 1996, 2001 | 2001 | 2001 | 2001 | only one source names 2001 |
| Fats Domino — Ain't That A Shame | 1955, 1956, 1957, 1959 | 2014 | 2014 | 2014 | third value 2014 |
| Bomfunk MC's — Freestyler | 1995, 1999 | 1998 | 2000 | 1999 | third value 1998 |
| Matchbox Twenty — 3AM | 1996, 2000 | 1994 | 1996 | 1996 | third value 1994 |
| Panic! At The Disco — The Ballad of Mona Lisa | 2007, 2011 | 2008 | 2008 | 2008 | third value 2008 |
| Joachim Witt — Goldener Reiter | 1980, 1983 | 1989 | 1998 | 1992 | third value 1989 |
| Audioslave — Like a Stone | 2000, 2003 | 2002 | 2003 | 2002 | third value 2002 |
| Audioslave — Show Me How to Live | 2000, 2003 | 2002 | 2000 | 2002 | only one source names 2000 |
| Laid Back — Sunshine Reggae | 1981, 1983 | 1982 | 2008 | 2000 | third value 1982 |
| Magic Affair — Omen III | 1993, 1995 | 1993 | 2008 | 1940 | third value 1940 |
| The Darkness — I Believe in a Thing Called Love | 2003, 2005 | 2002 | 2005 | 2003 | third value 2002 |

Three of those deserve naming, because they are not close calls:

- **Magic Affair — Omen III** — the ISRC `DEEM94000002` decodes to year code `40`. That is either 1940 or 2040 and the track is from 1993. A legacy or malformed ISRC, and the reason ISRC evidence is never taken alone here.
- **Fats Domino — Ain't That A Shame** — four different years in the catalogue (1955, 1956, 1957, 1959) and every source answers 2014, which is a reissue. The original is 1955, but nothing in the sources says so.
- **Maanam — Cykady na Cykladach - 2011 Remaster** — the entry's own title says remaster, and the convention excludes remaster years. The original is 1981; the sources only know the remaster.

## Numbers

23 conflicts settled, 25 entries changed, 13 files. Wide conflicts fall **46 → 23**, all conflicts **81 → 58**. Schema gate green across all 58 playlists.

## The part worth doing next

None of this stops the count from growing again. A consistency check in the schema gate — same ISRC in two playlists, different `year` → fail — would have caught all 81 without a player reporting one, and would hold the number at zero afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LYnmkDxHC2drccP1XFpJN4
