### PR TITLE
Skip the songs this run has no business with

### DIFF
--- a/.claude/skills/provider-uri-backfill/scripts/backfill_provider_uris.py
+++ b/.claude/skills/provider-uri-backfill/scripts/backfill_provider_uris.py
@@ -1179,6 +1179,28 @@ def run(args: argparse.Namespace) -> int:
             yt_gap = "youtube_music" in gaps
             non_yt_gaps = [g for g in gaps if g != "youtube_music"]
 
+            # ---- Songs this run has no business with (#2301) ----------------
+            # Under ``--youtube-first`` the run exists to fill YouTube and
+            # nothing else. A song that already HAS its YouTube URI has
+            # nothing here to do — but its other gaps still drag the loop
+            # through a full Odesli call at ``--odesli-sleep`` seconds.
+            #
+            # That is the toll booth two earlier fixes drove straight past.
+            # Measured on 2026-08-23 in tomorrowland-top-1000: the 46 songs
+            # that already carry a YouTube URI sit at indices 0 through 45,
+            # and the first real gap is at 46. All 46 are missing Tidal, so
+            # `yt_gap` is false for every one of them and each costs the
+            # full 6 seconds — 276 of a 300-second slice, spent before the
+            # first gap is even reached. The next slice restarts at 0 and
+            # pays it again, which is why two slices in a row report zero.
+            #
+            # Both previous attempts were gated on `yt_gap` (#2310's cursor
+            # skip, #2320's Odesli skip), so neither could ever see these
+            # songs. Their Apple, Deezer and Tidal gaps are not abandoned —
+            # those providers have their own agents and their own windows.
+            if args.youtube_first and not yt_gap:
+                continue
+
             # ---- Fast-forward to the YouTube cursor (#2301) -----------------
             # Songs before the cursor were already offered to the YouTube phase
             # in an earlier run. The loop still walked them, paying one Odesli

--- a/tests/unit/test_backfill_youtube_first_2301.py
+++ b/tests/unit/test_backfill_youtube_first_2301.py
@@ -176,3 +176,57 @@ class TestOdesliSkip:
     def test_the_condition_is_wired_into_the_song_loop(self):
         src = _SCRIPT.read_text()
         assert "want_odesli = not (args.youtube_first and yt_gap) and (" in src
+
+
+def is_skipped_outright(yt_gap: bool, youtube_first: bool) -> bool:
+    """Die #2301-Vorab-Bedingung aus dem Song-Loop, isoliert nachgebildet."""
+    return youtube_first and not yt_gap
+
+
+class TestSkipSongsWithoutAYouTubeGap:
+    """Die Mautstelle, an der zwei Fixes vorbeigefahren sind (#2301).
+
+    Gemessen am 23.08.2026 in ``tomorrowland-top-1000``: die **46** Songs, die
+    bereits eine YouTube-URI tragen, stehen auf den Indizes **0 bis 45**; die
+    erste echte Luecke sitzt auf **46**. Allen 46 fehlt Tidal, also ist
+    ``yt_gap`` fuer jeden von ihnen **falsch** und jeder kostet die vollen
+    6 Sekunden ``--odesli-sleep`` — **276 von 300 Sekunden** einer Scheibe,
+    verbraucht bevor die erste Luecke ueberhaupt erreicht ist. Die naechste
+    Scheibe faengt bei 0 an und zahlt denselben Zoll; daher zwei leere
+    Scheiben hintereinander, jedes Mal.
+
+    Beide frueheren Anlaeufe haengen an ``yt_gap`` (#2310 Cursor-Sprung,
+    #2320 Odesli-Verzicht) und konnten diese Songs **per Konstruktion** nie
+    sehen.
+    """
+
+    def test_a_song_with_its_youtube_uri_is_skipped_under_the_flag(self):
+        # Der Fall, um den es geht: nichts zu tun fuer diesen Lauf.
+        assert is_skipped_outright(yt_gap=False, youtube_first=True) is True
+
+    def test_a_song_with_a_youtube_gap_is_never_skipped(self):
+        # Das ist die Arbeit, fuer die der Lauf existiert.
+        assert is_skipped_outright(yt_gap=True, youtube_first=True) is False
+
+    def test_without_the_flag_nothing_is_skipped(self):
+        # Apple-, Deezer- und Tidal-Agenten rufen dasselbe Skript ohne das
+        # Flag auf und muessen weiterhin JEDEN Song sehen.
+        assert is_skipped_outright(yt_gap=False, youtube_first=False) is False
+        assert is_skipped_outright(yt_gap=True, youtube_first=False) is False
+
+    def test_the_skip_sits_before_the_cursor_fast_forward(self):
+        # Reihenfolge ist wesentlich: der Cursor-Sprung fragt ``yt_gap`` ab
+        # und kann diese Songs nicht abfangen. Stuende der neue Sprung
+        # dahinter, aendert das nichts — stuende er hinter dem Odesli-Block,
+        # waere der Zoll schon gezahlt.
+        src = _SCRIPT.read_text()
+        new_skip = src.index("if args.youtube_first and not yt_gap:")
+        cursor_skip = src.index(
+            "if args.youtube_first and yt_gap and this_global_idx < yt_state.cursor:"
+        )
+        odesli = src.index("---- Odesli (apple/tidal/deezer")
+        assert new_skip < cursor_skip < odesli
+
+    def test_the_condition_is_wired_into_the_song_loop(self):
+        src = _SCRIPT.read_text()
+        assert "if args.youtube_first and not yt_gap:" in src


### PR DESCRIPTION
Closes #2301. Third attempt, and the first grounded in a measurement rather than a reading of the code.

## The toll booth

Measured on 2026-08-23 in `tomorrowland-top-1000`:

| | |
|---|---|
| Songs that already have a YouTube URI | **46** |
| Their positions in the file | indices **0–45** |
| First actual YouTube gap | index **46** |
| Of those 46, missing Tidal | **46** |

Because they have no YouTube gap, `yt_gap` is false for every one of them, `want_odesli` stays true, and each costs the full 6-second `--odesli-sleep`.

**46 × 6s = 276 seconds. The slice is 300.**

The run spends 4.6 of its 5 minutes walking songs that need nothing from it, and reaches the first real gap with about 24 seconds left — where the deadline check at the top of the iteration ends the slice. The next slice restarts at index 0 and pays the identical toll.

That is why two consecutive slices report zero, every single run, and why the closing line keeps reading `ACHTUNG: N Scheibe(n) endeten ohne eine einzige YouTube-Suche`.

## Why two correct fixes both missed it

Both were gated on `yt_gap`:

- **#2310** cursor skip — `args.youtube_first and yt_gap and this_global_idx < yt_state.cursor`
- **#2320** Odesli skip — `not (args.youtube_first and yt_gap)`

A song **without** a YouTube gap is excluded from both **by construction**. Neither fix was wrong; both were blind in the same spot, and each was written from the code rather than from the data.

## What changes

```python
if args.youtube_first and not yt_gap:
    continue
```

Placed before the cursor fast-forward, so it runs before anything can cost time. Under `--youtube-first` the run then does only what it exists to do.

The Apple, Deezer and Tidal gaps on the skipped songs are not abandoned — those providers have their own agents and their own windows, and they invoke this script without the flag, so nothing changes for them.

## One alternative explanation, tested and discarded

Cached YouTube misses would also make `yt_gap` false and produce an identical symptom. Checked before concluding: **zero** of tomorrowland's 779 YouTube gaps appear in the miss cache (165 entries in total, mostly `apple_music`). Not the cause.

## Tests

`tests/unit/test_backfill_youtube_first_2301.py`, now 19 cases. New class `TestSkipSongsWithoutAYouTubeGap`:

- a song with its YouTube URI is skipped under the flag
- a song with a YouTube gap is never skipped
- without the flag nothing is skipped, in either direction
- **the skip sits before the cursor fast-forward and before the Odesli block** — order is the whole point here; placed after Odesli it would arrive once the toll was already paid

1993 unit tests green. Schema gate green across all 58 playlists.

## How to tell whether it worked

The 07:32 slice, then 11:32. `spent_today` should climb well past the 34 of 2026-08-22, and the closing line should stop reporting slices with zero searches.

If it does not, this issue should be reopened a third time rather than closed on hope. The two previous attempts both looked right and both did nothing, so the bar for calling this fixed is the log, not the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LYnmkDxHC2drccP1XFpJN4