### PR TITLE
Take the answer out of the status endpoint, not the endpoint away

### DIFF
--- a/custom_components/beatify/server/serializers.py
+++ b/custom_components/beatify/server/serializers.py
@@ -107,6 +107,7 @@ def build_status_response(
     playlists: list[dict[str, Any]],
     media_player_twin_remap: dict[str, str] | None = None,
     saved_setup: dict[str, Any] | None = None,
+    redact_answers: bool = False,
 ) -> dict[str, Any]:
     """Build the admin ``/api/status`` JSON payload.
 
@@ -123,6 +124,14 @@ def build_status_response(
     settings) or ``None``. It drives ``setup_complete`` — the server-side
     replacement for the localStorage-only "is configured?" check that made a
     configured instance look unconfigured on a new device.
+
+    ``redact_answers`` (#2332) strips the round's answers out of
+    ``active_game`` for a caller who has not proved they are the host. The
+    #1366 redaction existed but was wired only into the WebSocket path, so an
+    unauthenticated HTTP GET returned ``admin_song.year`` — the answer — to
+    anyone who could reach the port. Players are unauthenticated by design and
+    on the same network, so that is one browser tab, silently, with nothing in
+    the log.
     """
     data = hass.data.get(DOMAIN, {})
     game_state: GameState | None = data.get("game")
@@ -130,6 +139,13 @@ def build_status_response(
     active_game = None
     if game_state and game_state.game_id:
         active_game = game_state.get_state()
+        # #2332: same treatment the WebSocket broadcast already gets. The
+        # endpoint stays open — the wizard (``wizard.js``) and the playlist
+        # hub fetch it without a token and would break under a hard auth
+        # gate, which is why ``requires_auth`` is False in the first place.
+        # Only the answers come out.
+        if redact_answers and isinstance(active_game, dict):
+            active_game = redact_state_for_player(active_game)
 
     has_music_assistant = any(
         entry.domain == "music_assistant"

--- a/custom_components/beatify/server/views.py
+++ b/custom_components/beatify/server/views.py
@@ -555,7 +555,7 @@ class StatusView(HomeAssistantView):
         """Initialize the status view."""
         self.hass = hass
 
-    async def get(self, request: web.Request) -> web.Response:  # noqa: ARG002
+    async def get(self, request: web.Request) -> web.Response:
         """Return current status as JSON."""
         # Fetch media players fresh (not cached) - Story 8-2.
         # #1704: the player list and the native→MA twin remap (#1627: lets the
@@ -579,6 +579,15 @@ class StatusView(HomeAssistantView):
         # to the executor (blocking I/O off the event loop).
         saved_setup = await self.hass.async_add_executor_job(read_setup, self.hass)
 
+        # #2332: this view stays unauthenticated on purpose — the wizard
+        # (`wizard.js`) and the playlist hub fetch it with a bare `fetch` and
+        # no token, so a hard `is_authorized_http` gate here would break setup
+        # and the playlist picker. What must not stay open is the answer:
+        # `active_game` carried `admin_song.year` to anyone who could reach
+        # the port, because the #1366 redaction was only ever wired into the
+        # WebSocket path. Players are unauthenticated by design and on the
+        # same network, so reading it was one browser tab away and left no
+        # trace. Authorized callers (the admin screen) get the full payload.
         status = build_status_response(
             self.hass,
             version=_get_version(self.hass),
@@ -586,6 +595,7 @@ class StatusView(HomeAssistantView):
             playlists=playlists,
             media_player_twin_remap=media_player_twin_remap,
             saved_setup=saved_setup,
+            redact_answers=not is_authorized_http(request, self.hass),
         )
 
         return web.json_response(status)

--- a/tests/unit/test_status_endpoint_redaction_2332.py
+++ b/tests/unit/test_status_endpoint_redaction_2332.py
@@ -1,0 +1,106 @@
+"""`/beatify/api/status` darf die Antwort der Runde nicht herausgeben (#2332).
+
+`StatusView` steht bewusst auf ``requires_auth = False``: `wizard.js` und
+`playlist-hub.js` holen den Endpunkt mit einem nackten ``fetch`` ohne Token,
+ein harter Auth-Gate wuerde Einrichtung und Playlist-Picker lahmlegen.
+
+Was daran aber offen stand, war der Inhalt. ``build_status_response`` legte
+``game_state.get_state()`` **ungefiltert** unter ``active_game`` ab, und darin
+sitzt ``admin_song.year`` — das gesuchte Jahr. Die Schwaerzung aus #1366
+existierte, war aber ausschliesslich in den WebSocket-Pfad verdrahtet
+(``websocket.py``, ``ws_handlers/_helpers.py``); ein HTTP-GET ging daran vorbei.
+
+Spieler sind per Design unauthentifiziert und im selben Netz. Ein zweiter Tab
+genuegte, und im Log stand nichts.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from custom_components.beatify.const import DOMAIN
+from custom_components.beatify.game.state import GamePhase
+from custom_components.beatify.server.serializers import build_status_response
+from tests.conftest import make_game_state, make_songs
+
+
+def _hass_with_game(*, title_artist_mode: bool = False):
+    gs = make_game_state()
+    gs.create_game(
+        playlists=["test.json"],
+        songs=make_songs(3),
+        media_player="media_player.test",
+        base_url="http://localhost:8123",
+        title_artist_mode=title_artist_mode,
+    )
+    gs.phase = GamePhase.PLAYING
+    gs.current_song = {
+        "year": 1984,
+        "title": "Geheim",
+        "artist": "Unbekannt",
+        "album_art": "/art.png",
+    }
+    hass = MagicMock()
+    hass.data = {DOMAIN: {"game": gs}}
+    hass.config_entries.async_entries.return_value = []
+    return hass, gs
+
+
+def _status(hass, *, redact: bool):
+    return build_status_response(
+        hass,
+        version="0.0.0-test",
+        media_players=[],
+        playlists=[],
+        redact_answers=redact,
+    )
+
+
+class TestUnauthorizedCaller:
+    def test_the_year_is_gone(self):
+        # Der Kern: das gesuchte Jahr darf nicht in der Antwort stehen.
+        hass, _ = _hass_with_game()
+        assert "admin_song" not in _status(hass, redact=True)["active_game"]
+
+    def test_title_and_artist_are_hidden_in_title_artist_mode(self):
+        # Im Title-&-Artist-Modus SIND Titel und Interpret die Antwort.
+        hass, _ = _hass_with_game(title_artist_mode=True)
+        song = _status(hass, redact=True)["active_game"]["song"]
+        assert song["title"] != "Geheim"
+        assert song["artist"] != "Unbekannt"
+
+    def test_the_rest_of_the_payload_survives(self):
+        # Der Endpunkt bleibt brauchbar — das ist der Grund, ihn zu schwaerzen
+        # statt zu sperren. Wizard und Playlist-Hub holen ihn ohne Token.
+        s = _status(_hass_with_game()[0], redact=True)
+        assert "playlists" in s
+        assert "media_players" in s
+        assert s["active_game"] is not None
+        assert s["active_game"]["phase"] == GamePhase.PLAYING.value
+
+
+class TestAuthorizedCaller:
+    def test_the_admin_screen_still_gets_the_answer(self):
+        # Ohne diesen Fall waere die Reparatur ein neuer Fehler: der
+        # Spielleiter-Bildschirm zeigt Jahr und Fun Facts.
+        ag = _status(_hass_with_game()[0], redact=False)["active_game"]
+        assert ag["admin_song"]["year"] == 1984
+
+    def test_default_is_unredacted_for_existing_callers(self):
+        # ``redact_answers`` ist opt-in. Jeder bestehende Aufrufer, der den
+        # Parameter nicht kennt, verhaelt sich wie vorher.
+        hass, _ = _hass_with_game()
+        s = build_status_response(
+            hass, version="0.0.0-test", media_players=[], playlists=[]
+        )
+        assert s["active_game"]["admin_song"]["year"] == 1984
+
+
+class TestNoGameRunning:
+    def test_redaction_is_harmless_without_a_game(self):
+        # Kein Spiel -> ``active_game`` ist None, und die Schwaerzung darf
+        # daran nicht scheitern.
+        hass = MagicMock()
+        hass.data = {DOMAIN: {}}
+        hass.config_entries.async_entries.return_value = []
+        assert _status(hass, redact=True)["active_game"] is None


### PR DESCRIPTION
Closes #2332.

## What was open

`/beatify/api/status` returned the running round's answer to anyone who could reach the Home Assistant port.

`build_status_response` put `game_state.get_state()` into `active_game` unfiltered, and that carries `admin_song.year` — plus `song.artist` and `song.title` in Title & Artist mode, where those *are* the answers being guessed.

**The redaction for this already existed.** #1366 added `redact_state_for_player`, and wired it into exactly two places, both WebSocket:

- `server/websocket.py:397`
- `server/ws_handlers/_helpers.py:41`

An HTTP GET walked past it. Players are unauthenticated by design and on the same network, so reading the answer was one browser tab away and left nothing in the log — a player exploiting it is indistinguishable from a good guesser.

## Why not the fix the issue proposed

The issue suggested adding the in-handler `is_authorized_http` check that `CapabilitiesView` and its neighbours carry. Checking the callers first showed that breaks the host:

| Caller | How it fetches |
|---|---|
| `www/js/wizard.js:298` | `await fetch('/beatify/api/status')` — no token |
| `www/js/playlist-hub.js:21` | same endpoint, same way |

A hard gate here takes down first-time setup and the playlist picker. That is why `requires_auth = False` is there in the first place, and removing the symptom would have removed the feature with it.

## What this does instead

The endpoint stays open and the **answer** comes out of it.

An unauthorized caller gets `active_game` through the same redaction the WebSocket broadcast already applies. `playlists`, `media_players`, `setup_complete` and the rest are untouched, so the wizard and the playlist hub keep working unchanged. An authorized caller — the admin screen — still gets the full payload including `admin_song`.

`redact_answers` defaults to `False`, so any existing caller that does not know the parameter behaves exactly as before.

## Tests

`tests/unit/test_status_endpoint_redaction_2332.py`, 6 cases in three groups:

**Unauthorized** — the year is gone; title and artist are hidden in Title & Artist mode; **the rest of the payload survives**, which is the whole reason for redacting rather than gating.

**Authorized** — the admin screen still gets the year, because a fix that blinds the host is a new bug; and the default stays unredacted for callers that pass no flag.

**No game running** — `active_game` is `None` and the redaction does not trip over it.

2009 unit tests green.

## Note for review

No JS changed, so no bundle rebuild was needed here. Worth stating explicitly because the guard from #1263 caught exactly that omission on #2347 earlier today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LYnmkDxHC2drccP1XFpJN4