### PR TITLE
Path 1 has to see the track actually change

### DIFF
--- a/custom_components/beatify/services/media_player.py
+++ b/custom_components/beatify/services/media_player.py
@@ -1162,9 +1162,35 @@ class MediaPlayerService:
                 if not position_fresh:
                     return False
 
+                # #2333: the track has to have actually changed. The
+                # docstring above promised this of BOTH paths, and Path 2
+                # honoured it while Path 1 did not — it accepted a substring
+                # match against whatever was playing, including the song from
+                # the previous round still running.
+                #
+                # `position_fresh` above is no help: a track that simply keeps
+                # playing keeps advancing its own position.
+                #
+                # The failure it allowed: round N plays "Stay With Me", round
+                # N+1 draws "Stay" whose URI is missing from the household's
+                # storefront, MA never switches, and `"stay" in "stay with
+                # me"` confirms success within a second. The room then guesses
+                # a song they already heard.
+                #
+                # Substring containment makes that reachable well beyond one
+                # example — covers, "One", "Hurt", remaster suffixes.
+                #
+                # An empty `title_before` (nothing was playing) still passes,
+                # which is the cold-start case and genuinely a change.
+                title_changed = current_title != title_before
+
                 # Path 1: exact-ish title match (substring) — strongest signal,
                 # the only path strong enough to learn a preferred URI field.
-                if expected_lower and expected_lower in current_title.lower():
+                if (
+                    title_changed
+                    and expected_lower
+                    and expected_lower in current_title.lower()
+                ):
                     self._last_confirm_path = 1
                     return True
                 # If no expected title was supplied, position-fresh alone is
@@ -1177,7 +1203,7 @@ class MediaPlayerService:
                 # title is plausibly our track (shared token / prefix) OR the
                 # artist matches. A bare "any different title" no longer
                 # qualifies — that is the prior-queue auto-advance trap.
-                if current_title and current_title != title_before:
+                if current_title and title_changed:
                     if _titles_plausibly_match(
                         expected_title, current_title
                     ) or _artist_matches(expected_artist, current_artist):

--- a/tests/unit/test_ma_path1_requires_title_change_2333.py
+++ b/tests/unit/test_ma_path1_requires_title_change_2333.py
@@ -1,0 +1,149 @@
+"""Weg 1 darf nicht bestaetigen, solange der Titel derselbe ist (#2333).
+
+``_check_state`` in ``_try_ma_play`` bestaetigt den Playback-Start ueber zwei
+Wege. Weg 2 verlangte seit #1381 ausdruecklich ``current_title != title_before``.
+Weg 1 verlangte es **nicht** — er nahm einen Teilzeichenketten-Treffer gegen
+das, was gerade lief, und das schliesst den Song der **vorigen Runde** ein, der
+einfach weiterspielt. Die Docstring darueber versprach die Invariante fuer
+*beide* Wege.
+
+``position_fresh`` faengt das nicht ab: ein Track, der weiterlaeuft, schiebt
+seine eigene Position ohnehin vor.
+
+**Warum das schwerer wiegt als ein Fehlalarm**: nur eine Bestaetigung ueber
+Weg 1 ist stark genug, ein URI-Feld als ``_ma_preferred_uri_field`` zu lernen.
+Eine falsche Bestaetigung merkt sich also genau das Feld, das gerade nichts
+abgespielt hat, und probiert es fuer den Rest der Sitzung zuerst — der Fehler
+macht sich selbst wahrscheinlicher.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from custom_components.beatify.services.media_player import MediaPlayerService
+from tests.unit.test_media_player import _make_hass, _make_state
+
+
+async def _instant_timeout(awaitable=None, *_a, **_k):
+    if awaitable is not None and asyncio.iscoroutine(awaitable):
+        awaitable.close()
+    raise asyncio.TimeoutError
+
+
+class TestSubstringOfTheStillPlayingTrack:
+    @pytest.mark.asyncio
+    async def test_stay_does_not_confirm_against_stay_with_me(self):
+        """Der Fall aus dem Issue: Runde N spielt „Stay With Me", Runde N+1
+        zieht „Stay", dessen URI im Storefront fehlt. MA wechselt nie."""
+        unchanged = _make_state(
+            "playing",
+            media_title="Stay With Me",
+            media_position=120,
+            media_position_updated_at="2020-01-01T00:00:00+00:00",
+        )
+        # Derselbe Track laeuft weiter — nur die Position tickt.
+        still_playing = _make_state(
+            "playing",
+            media_title="Stay With Me",
+            media_position=126,
+            media_position_updated_at="2020-01-01T00:00:06+00:00",
+        )
+        hass = _make_hass("playing", media_title="Stay With Me")
+        svc = MediaPlayerService(hass, "media_player.test", platform="music_assistant")
+        hass.states.get = MagicMock(side_effect=[unchanged, still_playing])
+
+        with patch(
+            "custom_components.beatify.services.media_player.asyncio.wait_for",
+            new=_instant_timeout,
+        ):
+            await svc._try_ma_play("spotify:track:x", "Stay", "Rihanna")
+
+        assert svc._last_confirm_path != 1, (
+            "Weg 1 hat den weiterlaufenden Vorgaenger bestaetigt"
+        )
+
+    @pytest.mark.asyncio
+    async def test_the_failing_uri_field_is_not_learned(self):
+        """Die Folge, die schwerer wiegt als die falsche Runde: das Feld, das
+        gerade nichts abgespielt hat, darf nicht als bevorzugt gelernt werden.
+        Das Lernen haengt an ``_last_confirm_path == 1``."""
+        unchanged = _make_state(
+            "playing",
+            media_title="One More Time",
+            media_position=90,
+            media_position_updated_at="2020-01-01T00:00:00+00:00",
+        )
+        still_playing = _make_state(
+            "playing",
+            media_title="One More Time",
+            media_position=96,
+            media_position_updated_at="2020-01-01T00:00:06+00:00",
+        )
+        hass = _make_hass("playing", media_title="One More Time")
+        svc = MediaPlayerService(hass, "media_player.test", platform="music_assistant")
+        hass.states.get = MagicMock(side_effect=[unchanged, still_playing])
+
+        with patch(
+            "custom_components.beatify.services.media_player.asyncio.wait_for",
+            new=_instant_timeout,
+        ):
+            await svc._try_ma_play("spotify:track:x", "One", "Metallica")
+
+        assert svc._last_confirm_path != 1
+
+
+class TestWhatMustKeepWorking:
+    @pytest.mark.asyncio
+    async def test_a_real_track_change_still_confirms_via_path_1(self):
+        """Der Normalfall darf nicht mit repariert werden: der Titel wechselt
+        wirklich und enthaelt den erwarteten — Weg 1 bestaetigt weiterhin."""
+        before = _make_state(
+            "playing",
+            media_title="Old Track",
+            media_position=120,
+            media_position_updated_at="2020-01-01T00:00:00+00:00",
+        )
+        current = _make_state(
+            "playing",
+            media_title="Stay (Radio Edit)",
+            media_position=2,
+            media_position_updated_at="2020-01-01T00:00:01+00:00",
+        )
+        hass = _make_hass("playing", media_title="Old Track")
+        svc = MediaPlayerService(hass, "media_player.test", platform="music_assistant")
+        hass.states.get = MagicMock(side_effect=[before, current])
+
+        confirmed = await svc._try_ma_play("spotify:track:x", "Stay", "Rihanna")
+
+        assert confirmed is True
+        assert svc._last_confirm_path == 1
+
+    @pytest.mark.asyncio
+    async def test_the_cold_start_still_confirms(self):
+        """Nichts lief vorher: ``title_before`` ist leer, der neue Titel ist
+        gegenueber „nichts" ein echter Wechsel. Ohne diesen Fall wuerde die
+        erste Runde jedes Spiels nicht mehr bestaetigen."""
+        before = _make_state(
+            "idle",
+            media_title="",
+            media_position=0,
+            media_position_updated_at=None,
+        )
+        current = _make_state(
+            "playing",
+            media_title="Stay",
+            media_position=2,
+            media_position_updated_at="2020-01-01T00:00:01+00:00",
+        )
+        hass = _make_hass("idle", media_title="")
+        svc = MediaPlayerService(hass, "media_player.test", platform="music_assistant")
+        hass.states.get = MagicMock(side_effect=[before, current])
+
+        confirmed = await svc._try_ma_play("spotify:track:x", "Stay", "Rihanna")
+
+        assert confirmed is True
+        assert svc._last_confirm_path == 1


### PR DESCRIPTION
Closes #2333.

## The asymmetry

`_check_state` inside `_try_ma_play` confirms a playback start over two paths.

Path 2 has required a real title change since #1381:

```python
if current_title and current_title != title_before:
```

Path 1 did not:

```python
if expected_lower and expected_lower in current_title.lower():
    self._last_confirm_path = 1
    return True
```

The docstring three lines above promises the invariant for **both**:

> #795 invariant still holds: if the title is unchanged from before the call (`title_before`), **neither path fires**

`position_fresh` above them is no safety net — a track that simply keeps playing keeps advancing its own position, so freshness is satisfied by the *old* song.

## What it allowed

1. Round N plays **"Stay With Me"**.
2. Round N+1 draws **"Stay"**, whose URI is missing from the household's storefront — the recurring provider-mismatch case behind #795 and #808.
3. Music Assistant never switches tracks.
4. `"stay" in "stay with me"` → Path 1 confirms success within about a second.

The room guesses a song they already heard two minutes ago, and the screen says the round started normally.

Substring containment makes this reachable well beyond that example: covers, `"One"`, `"Hurt"`, remaster suffixes — any pair where one title contains the other.

## The part that outlasts the round

Only a Path 1 confirmation is strong enough to learn a preferred URI field:

```python
if field and field != self._ma_preferred_uri_field and self._last_confirm_path == 1:
    self._ma_preferred_uri_field = field
```

So a false confirmation memorises **exactly the field that just played nothing** and tries it first for the rest of the session. The bug makes itself more likely, which is what separates it from an ordinary false positive.

## What must keep working

Two of the four tests exist for that, not for the bug:

- **A real track change still confirms via Path 1** — the normal case must not be repaired along with the broken one.
- **The cold start still confirms.** `title_before` is empty when nothing was playing, and "" → "Stay" is a genuine change. Breaking the first round of every game would be a worse bug than the one being fixed.

Both fast-path callers go through this helper, so the immediate check before the wait is covered by the same change.

## Deliberately not done here

Matching on `media_content_id` would be stronger than comparing titles, because it does not depend on how a provider formats them. That belongs in its own change: repairing a safety net and replacing it at the same time makes the cause indistinguishable afterwards.

## Tests

`tests/unit/test_ma_path1_requires_title_change_2333.py`, 4 cases — and **verified to fail against the unfixed code**:

```
FAILED ...::test_stay_does_not_confirm_against_stay_with_me
FAILED ...::test_the_failing_uri_field_is_not_learned
2 failed, 2 passed
```

The two that already passed are the must-keep-working pair, which is exactly what one wants: the regression tests fail, the guard tests hold.

2013 unit tests green. No JS changed, so no bundle rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LYnmkDxHC2drccP1XFpJN4