### PR TITLE
Ask for the attribute that exists

### DIFF
--- a/custom_components/beatify/game/state_lifecycle.py
+++ b/custom_components/beatify/game/state_lifecycle.py
@@ -346,7 +346,7 @@ class RoundLifecycleMixin:
                 _LOGGER.info(
                     "Round %s: waiting %.1fs for the speaker to finish announcing "
                     "before starting playback",
-                    getattr(self, "current_round", "?"),
+                    getattr(self, "round", "?"),
                     busy,
                 )
                 await asyncio.sleep(busy)

--- a/custom_components/beatify/game/state_tts.py
+++ b/custom_components/beatify/game/state_tts.py
@@ -273,7 +273,13 @@ class TtsAnnouncerMixin:
         # PLAYING -> REVEAL, so they were always "stale" by the time they
         # reached the front of the queue. A phase change within the same
         # round is normal; only a NEW ROUND makes a pending phrase wrong.
-        round_at_enqueue = getattr(self, "current_round", None)
+        # #2334: `self.round`, not `current_round`. GameState has no attribute
+        # by that name — it has the `round` property from
+        # RoundManagerDelegationMixin, and GameState composes both mixins, so
+        # it was on this object all along. With the wrong name both sides of
+        # the comparison below resolved to None, `None != None` was never
+        # true, and this guard has never dropped a single announcement.
+        round_at_enqueue = self.round
 
         # RESERVE the speaker window NOW, at enqueue — not when this phrase
         # reaches the front of the queue. Everything that asks "is the speaker
@@ -293,7 +299,7 @@ class TtsAnnouncerMixin:
                 delay = start_at - time.monotonic()
                 if delay > 0:
                     await asyncio.sleep(delay)
-                round_now = getattr(self, "current_round", None)
+                round_now = self.round
                 if round_now != round_at_enqueue:
                     _LOGGER.info(
                         "TTS: dropping stale announcement (queued in round %s, "

--- a/tests/unit/test_tts_stale_guard_2334.py
+++ b/tests/unit/test_tts_stale_guard_2334.py
@@ -1,0 +1,90 @@
+"""Der Waechter gegen veraltete Ansagen hat nie gegriffen (#2334).
+
+``_tts_announce`` merkt sich beim Einreihen die laufende Runde und vergleicht
+sie erneut, wenn die Ansage vorne in der Warteschlange ankommt. Der Kommentar
+darueber beschreibt genau, wozu: eine in Runde N eingereihte Phrase, die erst
+in Runde N+1 gesprochen wuerde, ist falsch und gehoert verworfen.
+
+Gefragt wurde nach ``self.current_round``. **Das Attribut existiert auf
+GameState nicht** — es heisst ``round`` und kommt aus
+``RoundManagerDelegationMixin``, das GameState ohnehin mitkomponiert. Beide
+Seiten des Vergleichs lieferten damit ``None``, ``None != None`` war nie wahr,
+und der Verwerfen-Zweig war unerreichbar.
+
+Sichtbar war das nur an einer Stelle: die Log-Zeile in ``state_lifecycle.py``,
+die dieselbe falsche Abfrage benutzte, druckte statt der Rundennummer immer
+``?`` — waehrend die Zeile ein paar Zeilen weiter unten den richtigen Namen
+verwendet. Eine Umbenennung, die drei Aufrufstellen uebersehen hat.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from tests.conftest import make_game_state
+
+
+def _state_with_speaker():
+    s = make_game_state()
+    s._tts_service = MagicMock()
+    s._tts_service.speak = AsyncMock()
+    s._lang = lambda: "de"
+    s._bg_tasks = set()
+    return s
+
+
+async def _drain(state):
+    """Alle Hintergrund-Tasks der Ansage-Warteschlange zu Ende laufen lassen."""
+    for _ in range(10):
+        await asyncio.sleep(0)
+    if state._bg_tasks:
+        await asyncio.gather(*list(state._bg_tasks), return_exceptions=True)
+
+
+class TestTheGuardActuallyFires:
+    @pytest.mark.asyncio
+    async def test_an_announcement_from_the_previous_round_is_dropped(self):
+        s = _state_with_speaker()
+        s.round = 4
+        await s._tts_announce("Die Zeit ist um")
+        # Die Runde dreht weiter, bevor die Phrase gesprochen wird.
+        s.round = 5
+        await _drain(s)
+        s._tts_service.speak.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_the_round_is_read_from_the_attribute_that_exists(self):
+        # Der eigentliche Fehler war ein Name. Wenn `round` gelesen wird,
+        # unterscheiden sich die beiden Seiten ueberhaupt erst.
+        s = _state_with_speaker()
+        s.round = 1
+        assert getattr(s, "current_round", None) is None
+        assert s.round == 1
+
+
+class TestWhatMustKeepWorking:
+    @pytest.mark.asyncio
+    async def test_an_announcement_in_the_same_round_is_spoken(self):
+        # Der Normalfall. Ohne diesen Test koennte ein zu scharfer Waechter
+        # jede Ansage verschlucken und der obere Test waere trotzdem gruen.
+        s = _state_with_speaker()
+        s.round = 4
+        await s._tts_announce("Die Antwort war 1984")
+        await _drain(s)
+        s._tts_service.speak.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_a_phase_change_within_the_round_does_not_drop_it(self):
+        # Ausdruecklich im Kommentar am Waechter: die Ansagen zum Rundenende
+        # werden GENAU beim Phasenwechsel PLAYING -> REVEAL gefeuert. Wuerde
+        # der Waechter auf die Phase schauen, waeren sie samt und sonders
+        # "veraltet" — das war der Grund, nur auf die Runde zu schauen.
+        s = _state_with_speaker()
+        s.round = 7
+        await s._tts_announce("Niemand hatte es")
+        s.phase = "REVEAL"
+        await _drain(s)
+        s._tts_service.speak.assert_awaited_once()


### PR DESCRIPTION
Closes #2334.

## What was wrong

The TTS queue's staleness guard asked for `self.current_round`:

```python
round_at_enqueue = getattr(self, "current_round", None)
...
round_now = getattr(self, "current_round", None)
if round_now != round_at_enqueue:
    # drop
```

`GameState` has no attribute by that name. It has the `round` property from `RoundManagerDelegationMixin` (`state_round_delegation.py:66`), and `GameState` (`state.py:142`) composes both that mixin and `TtsAnnouncerMixin` — so the right attribute was on this object the whole time.

With the wrong name, both sides resolved to `None`, `None != None` was never true, and **this guard has never dropped a single announcement**.

## What it was supposed to prevent

Its own comment says it: a phrase queued in round N that only reaches the front of the queue in round N+1. In practice, "Time's up!" for the previous round speaking into the start of the next one — which reads to the room as a sluggish announcement rather than a bug.

The queue reported success while doing it. The drop branch is the only thing that logs, so there was no missing log line to notice either.

## Why this is a rename, not a design mistake

The same wrong name sat in a log call in `state_lifecycle.py:349`, printing `?` instead of a round number — while another call at `:509` uses `round` correctly.

That pair is the evidence. The fix needs no new decision, because the neighbouring line already shows which name was meant. All three call sites are updated.

## Tests

`tests/unit/test_tts_stale_guard_2334.py`, 4 cases. The one that matters was **verified to fail against the unfixed code**:

```
FAILED test_an_announcement_from_the_previous_round_is_dropped
1 failed, 3 passed
```

Two of the remaining three exist to stop the repair from overshooting:

- **An announcement in the same round is still spoken.** Without it, a guard that swallowed everything would make the first test pass too.
- **A phase change within the round does not drop it.** This one is explicitly in the guard's comment: end-of-round announcements fire exactly as PLAYING flips to REVEAL, so keying on the phase would swallow all of them. That was the reason for keying on the round alone, and it should stay that way.

2017 unit tests green. No JS changed, so no bundle rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LYnmkDxHC2drccP1XFpJN4