### PR TITLE
The deadline applies to power-ups too

### DIFF
--- a/custom_components/beatify/server/ws_handlers/guessing.py
+++ b/custom_components/beatify/server/ws_handlers/guessing.py
@@ -269,6 +269,26 @@ async def handle_steal(
         )
         return
 
+    # #2335: the same guard the four guessing handlers have carried since
+    # #1662. `use_steal` only checks phase == PLAYING, and there is a window
+    # where the deadline has passed but end_round has not flipped the phase
+    # yet — the "Time's up" announcement, the overdue grace, a timer task
+    # firing late. In that window every honest submission is refused while a
+    # banked steal still goes through, and a steal IS a submission: it writes
+    # current_guess, sets submitted = True and stamps submission_time.
+    #
+    # A power-up that quietly hands one player extra time is a different
+    # thing from one that copies an answer.
+    if game_state.is_deadline_passed():
+        await ws.send_json(
+            {
+                "type": "error",
+                "code": ERR_ROUND_EXPIRED,
+                "message": "Time's up!",
+            }
+        )
+        return
+
     target_name = data.get("target")
     if not target_name:
         await ws.send_json(
@@ -387,6 +407,24 @@ async def handle_sabotage(
                 "type": "error",
                 "code": ERR_ELIMINATED,
                 "message": "You have been eliminated",
+            }
+        )
+        return
+
+    # #2335: same guard, opposite harm. All three sabotage effects act on the
+    # victim's submit path (timer cut, freeze, forced bet), and after the
+    # deadline that path is closed anyway — so a late sabotage cannot hurt the
+    # target. What it does do is run consume_sabotage() and burn the
+    # saboteur's own token for nothing.
+    #
+    # Worth guarding for the attacker's sake rather than the victim's, which
+    # is why it is stated here instead of left to look like a copy-paste.
+    if game_state.is_deadline_passed():
+        await ws.send_json(
+            {
+                "type": "error",
+                "code": ERR_ROUND_EXPIRED,
+                "message": "Time's up!",
             }
         )
         return

--- a/tests/unit/test_ws_powerup_deadline_2335.py
+++ b/tests/unit/test_ws_powerup_deadline_2335.py
@@ -24,8 +24,6 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock
 
-import pytest
-
 from custom_components.beatify.const import DOMAIN, ERR_ROUND_EXPIRED
 from custom_components.beatify.game.state import GamePhase
 from tests.conftest import make_game_state, make_songs

--- a/tests/unit/test_ws_powerup_deadline_2335.py
+++ b/tests/unit/test_ws_powerup_deadline_2335.py
@@ -1,0 +1,174 @@
+"""Steal und Sabotage muessen nach dem Rundenende ebenso abgewiesen werden (#2335).
+
+#1662 hat die drei Challenge-Handler nachgezogen, weil sie nur `phase ==
+PLAYING` prueften und im Fenster zwischen Deadline-Ablauf und dem
+Phasenwechsel durch `end_round` noch Punkte buchten. Der Commit dazu heisst
+`fix(guessing): reject late Artist/Movie/Title&Artist guesses past deadline`.
+
+`handle_steal` und `handle_sabotage` blieben dabei aussen vor — dieselbe
+Ursache, dieselbe Datei, nur nicht auf der Liste.
+
+**Der Schaden zeigt in zwei verschiedene Richtungen**, und das ist der Grund
+fuer zwei getrennte Testklassen statt einer parametrisierten:
+
+* Ein **Steal** ist eine vollwertige Abgabe — er schreibt `current_guess`,
+  setzt `submitted = True` und stempelt `submission_time`. Nach Ablauf
+  ausgefuehrt schenkt er **einem Spieler Zeit**, die alle anderen nicht haben.
+* Eine **Sabotage** trifft das Opfer nicht mehr: alle drei Effekte wirken auf
+  dessen Abgabe-Weg, und der ist nach der Deadline ohnehin zu. Sie verbrennt
+  aber ueber `consume_sabotage` den **Token des Angreifers** — der Schaden
+  faellt auf den, der sie einsetzt.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.beatify.const import DOMAIN, ERR_ROUND_EXPIRED
+from custom_components.beatify.game.state import GamePhase
+from tests.conftest import make_game_state, make_songs
+
+from custom_components.beatify.server.websocket import (  # isort: skip
+    BeatifyWebSocketHandler,
+)
+
+
+def _stub_media_service() -> MagicMock:
+    svc = MagicMock()
+    svc.is_available.return_value = True
+    svc.play_song = AsyncMock(return_value=True)
+    svc.verify_responsive = AsyncMock(return_value=(True, None))
+    return svc
+
+
+def _ws() -> AsyncMock:
+    ws = AsyncMock()
+    ws.send_json = AsyncMock()
+    ws.closed = False
+    ws.close = AsyncMock()
+    return ws
+
+
+async def _playing_game(*, deadline_passed: bool):
+    """Zwei Spieler in PLAYING; Bob hat abgegeben, Alice noch nicht."""
+    mock_hass = MagicMock()
+    gs = make_game_state()
+    gs.create_game(
+        playlists=["t.json"],
+        songs=make_songs(3),
+        media_player="media_player.x",
+        base_url="http://h",
+    )
+    gs._media_player_service = _stub_media_service()
+    gs.platform = "music_assistant"
+    mock_hass.data = {DOMAIN: {"game": gs}}
+    handler = BeatifyWebSocketHandler(mock_hass)
+    handler.broadcast_state = AsyncMock()
+    handler.broadcast = AsyncMock()
+    handler.debounced_broadcast_state = AsyncMock()
+
+    ws_a, ws_b = _ws(), _ws()
+    gs.add_player("Alice", ws_a)
+    gs.add_player("Bob", ws_b)
+    gs.get_player("Alice").connected = True
+    gs.get_player("Bob").connected = True
+    await gs.start_round()
+    assert gs.phase == GamePhase.PLAYING
+
+    bob = gs.get_player("Bob")
+    bob.current_guess = 1984
+    bob.submitted = True
+
+    alice = gs.get_player("Alice")
+    alice.steal_available = True
+    alice.sabotage_available = True
+
+    gs.is_deadline_passed = MagicMock(return_value=deadline_passed)
+    return handler, gs, ws_a
+
+
+def _codes(ws: AsyncMock) -> list[str]:
+    return [
+        c.args[0].get("code")
+        for c in ws.send_json.call_args_list
+        if c.args and isinstance(c.args[0], dict)
+    ]
+
+
+class TestStealAfterTheDeadline:
+    async def test_it_is_rejected(self):
+        handler, gs, ws = await _playing_game(deadline_passed=True)
+        await handler._handle_message(ws, {"type": "steal", "target": "Bob"})
+        assert ERR_ROUND_EXPIRED in _codes(ws)
+        gs._cancel_auto_advance()
+
+    async def test_no_submission_is_banked(self):
+        # Der eigentliche Schaden: ohne den Guard stuende Alice hier mit
+        # submitted=True und einem frischen submission_time da.
+        handler, gs, ws = await _playing_game(deadline_passed=True)
+        await handler._handle_message(ws, {"type": "steal", "target": "Bob"})
+        alice = gs.get_player("Alice")
+        assert alice.submitted is False
+        assert alice.current_guess is None
+        gs._cancel_auto_advance()
+
+    async def test_the_steal_token_is_not_consumed(self):
+        # Eine abgewiesene Aktion darf nichts kosten.
+        handler, gs, ws = await _playing_game(deadline_passed=True)
+        await handler._handle_message(ws, {"type": "steal", "target": "Bob"})
+        assert gs.get_player("Alice").steal_available is True
+        gs._cancel_auto_advance()
+
+
+class TestSabotageAfterTheDeadline:
+    """Ziel ist hier **Charlie**, nicht Bob — und das ist kein Detail.
+
+    Bob hat abgegeben, und `use_sabotage` weist ein Ziel mit `submitted`
+    ohnehin ab. Ein Test gegen Bob waere auch ohne den neuen Guard gruen
+    gewesen und haette nichts gezeigt. Charlie hat nicht abgegeben, also ist
+    der Deadline-Guard das Einzige, was die Aktion noch aufhaelt.
+    """
+
+    async def test_it_is_rejected(self):
+        handler, gs, ws = await _playing_game(deadline_passed=True)
+        gs.add_player("Charlie", _ws())
+        gs.get_player("Charlie").connected = True
+        await handler._handle_message(ws, {"type": "sabotage", "target": "Charlie"})
+        assert ERR_ROUND_EXPIRED in _codes(ws)
+        gs._cancel_auto_advance()
+
+    async def test_the_saboteurs_token_is_not_burned(self):
+        # Hier liegt der Schaden — nicht beim Opfer. Ohne den Guard laeuft
+        # consume_sabotage() fuer einen Effekt, den niemand mehr spuert.
+        handler, gs, ws = await _playing_game(deadline_passed=True)
+        gs.add_player("Charlie", _ws())
+        gs.get_player("Charlie").connected = True
+        await handler._handle_message(ws, {"type": "sabotage", "target": "Charlie"})
+        assert gs.get_player("Alice").sabotage_available is True
+        assert gs.get_player("Charlie").sabotaged_by is None
+        gs._cancel_auto_advance()
+
+
+class TestBeforeTheDeadlineNothingChanges:
+    async def test_a_steal_still_works(self):
+        # Ohne diesen Test waere ein Guard, der immer abweist, ebenfalls gruen.
+        handler, gs, ws = await _playing_game(deadline_passed=False)
+        await handler._handle_message(ws, {"type": "steal", "target": "Bob"})
+        alice = gs.get_player("Alice")
+        assert ERR_ROUND_EXPIRED not in _codes(ws)
+        assert alice.submitted is True
+        assert alice.current_guess == 1984
+        gs._cancel_auto_advance()
+
+    async def test_a_sabotage_still_works(self):
+        handler, gs, ws = await _playing_game(deadline_passed=False)
+        # Bob hat schon abgegeben und ist damit kein gueltiges Ziel — Charlie
+        # ist es. Das trennt „Guard weist ab" von „Regel weist ab".
+        gs.add_player("Charlie", _ws())
+        gs.get_player("Charlie").connected = True
+        await handler._handle_message(ws, {"type": "sabotage", "target": "Charlie"})
+        assert ERR_ROUND_EXPIRED not in _codes(ws)
+        assert gs.get_player("Charlie").sabotaged_by == "Alice"
+        gs._cancel_auto_advance()


### PR DESCRIPTION
Closes #2335.

## The gap

`handle_steal` and `handle_sabotage` were the only two handlers in `ws_handlers/guessing.py` without a deadline guard. The four guessing handlers have carried one since #1662:

| Handler | line | guard |
|---|---|---|
| `handle_submit` | 97 | ✅ |
| `handle_artist_guess` | 476 | ✅ |
| `handle_movie_guess` | 598 | ✅ |
| `handle_title_artist_guess` | 704 | ✅ |
| `handle_steal` | 238 | ❌ |
| `handle_sabotage` | 365 | ❌ |

Both relied on `use_steal` / `use_sabotage` checking `phase == PLAYING` — which is exactly the check #1662 found insufficient. That commit's own message describes today's situation word for word:

> only checked `phase == PLAYING`. In the window between deadline expiry and the `end_round` phase flip, late guesses still banked points/bonus.

## Two guards, opposite reasons

The comments in the code say this too, so the second one does not read as copy-paste.

**A steal *is* a submission.** `use_steal` writes `current_guess`, sets `submitted = True` and stamps `submission_time` with `now`. Executed after the deadline it hands one player time that everyone else was refused — in the same window, the server answers honest submitters with `ROUND_EXPIRED`.

**A sabotage cannot hurt its target after the deadline.** All three effects — timer cut, freeze, forced bet — act on the victim's submit path, and that path is already closed. What it *does* do is run `consume_sabotage()` and burn the **saboteur's own token** for an effect nobody will feel.

The harm points at the attacker rather than the victim. That is a reason to guard it, not a reason to skip it.

## Tests

`tests/unit/test_ws_powerup_deadline_2335.py`, 7 cases. Five fail against the unfixed code:

```
FAILED TestStealAfterTheDeadline::test_it_is_rejected
FAILED TestStealAfterTheDeadline::test_no_submission_is_banked
FAILED TestStealAfterTheDeadline::test_the_steal_token_is_not_consumed
FAILED TestSabotageAfterTheDeadline::test_it_is_rejected
FAILED TestSabotageAfterTheDeadline::test_the_saboteurs_token_is_not_burned
5 failed, 2 passed
```

The two that pass are the guards in the other direction: before the deadline, a steal and a sabotage both still work. Without them, a guard that rejected everything would look just as green.

**One of the five only became meaningful on the second attempt.** The sabotage tests first targeted a player who had already submitted — and `use_sabotage` rejects that regardless, so they passed without the fix and demonstrated nothing. Retargeted at an unsubmitted player, where the deadline guard is the only thing left to stop the action. That is visible in the diff of the test file's docstring, and it is why running new tests against the unfixed code is worth the extra minute.

2024 unit tests green. No JS changed, so no bundle rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LYnmkDxHC2drccP1XFpJN4