### PR TITLE
chore(playlists): youtube backfill — +86 youtube uris

### DIFF
--- a/custom_components/beatify/playlists/community/tomorrowland-top-1000.json
+++ b/custom_components/beatify/playlists/community/tomorrowland-top-1000.json
@@ -1,6 +1,6 @@
 {
   "name": "Tomorrowland Top 1000",
-  "version": "0.7",
+  "version": "0.15",
   "tags": [
     "edm",
     "electronic",
@@ -1107,7 +1107,7 @@
       "year": 2013,
       "isrc": "DEU671300130",
       "uri": "spotify:track:5hGBJKU8aJaZPVSV7NxoTp",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=IrvRK9UW_Vk",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/68788684",
       "fun_fact": "“All that matters” appears on Kölsch’s release “1977”.",
@@ -1132,7 +1132,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1445884058"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=XiMrrleH_hI",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/82265248",
       "fun_fact": "“Born Slippy (Nuxx)” appears on Underworld’s release “1992 - 2012”.",
@@ -1156,7 +1156,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/665202776"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=gQA5gQQNkIo",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/75815486",
       "fun_fact": "“Paradise - Fedde le Grand Remix” appears on Coldplay’s release “Princess of China”.",
@@ -1180,7 +1180,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1700668296"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=aU6z-pPEmY0",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2393352885",
       "fun_fact": "“Your Mind” is the title track of Adam Beyer’s release of the same name.",
@@ -1204,7 +1204,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/6798409419"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=opxhEVjNvdk",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/437979102",
       "fun_fact": "“On My Way” appears on Axwell /\\ Ingrosso’s release “More Than You Know”.",
@@ -1228,7 +1228,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1829909740"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=YHIwJ7IblQU",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3487145721",
       "fun_fact": "“Losing Control” is the title track of KI/KI’s release of the same name.",
@@ -1252,7 +1252,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1444623986"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=o10EV4PG40U",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/134527712",
       "fun_fact": "“Take My Breath Away” is the title track of Alesso’s release of the same name.",
@@ -1272,7 +1272,7 @@
       "year": 2016,
       "isrc": "USQX91600011",
       "uri": "spotify:track:1i1fxkWeaMmKEB4T7zqbzK",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Io0fBr1XBUA",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/119302924",
       "fun_fact": "“Don't Let Me Down” is the title track of The Chainsmokers’s release of the same name.",
@@ -1296,7 +1296,7 @@
       "year": 2010,
       "isrc": "CH3131140002",
       "uri": "spotify:track:4DLwNoXDVKX1R2Xemojfsx",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=t7WRkPbTjsk",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/12914365",
       "fun_fact": "“Fade Into Darkness” is the title track of Avicii’s release of the same name.",
@@ -1324,7 +1324,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1645283575"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=juuIhW8V1Xw",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1914037957",
       "fun_fact": "“Drugs From Amsterdam” is the title track of Mau P’s release of the same name.",
@@ -1344,7 +1344,7 @@
       "year": 2011,
       "isrc": "NLC281112041",
       "uri": "spotify:track:5VObsx4Uaz3KxZEO58knf3",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=LWlmVW3xWM4",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/497189682",
       "fun_fact": "“No Beef (feat. Miss Palmer) - Radio Edit” appears on AFROJACK’s release “No Beef”.",
@@ -1365,7 +1365,7 @@
       "year": 2022,
       "isrc": "NLF712208018",
       "uri": "spotify:track:4erTmDzoe6WZBDl0WCo9Xi",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=0uw52kgpwkE",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1963312247",
       "fun_fact": "“Transmission - Joris Voorn Remix” is the title track of Eelke Kleijn’s release of the same name.",
@@ -1393,7 +1393,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1703889793"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=NtnRR_6Dd5Q",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3455108951",
       "fun_fact": "“Be” is the title track of Laidback Luke’s release of the same name.",
@@ -1417,7 +1417,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1444267020"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=TDyG4YNUXcI",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/5250944",
       "fun_fact": "“Heads Will Roll - A-Trak Remix” is the title track of Yeah Yeah Yeahs’s release of the same name.",
@@ -1441,7 +1441,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1624098054"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=ui_hIe80h5E",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1751207817",
       "fun_fact": "“On My Knees - Cassian Remix” is the title track of RÜFÜS DU SOL’s release of the same name.",
@@ -1465,7 +1465,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/6798405718"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=yl2GaxVGUaI",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/435827332",
       "fun_fact": "“Dreamer” is the title track of Axwell /\\ Ingrosso’s release of the same name.",
@@ -1485,7 +1485,7 @@
       "year": 2024,
       "isrc": "UKWLG2400097",
       "uri": "spotify:track:20Y4EAmSXru3foatDg4OqN",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=0485blukCq0",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3016411391",
       "fun_fact": "“LET'S GO” is the title track of Jaden Bojsen’s release of the same name.",
@@ -1509,7 +1509,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/78991531"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=YoLJ4CWSLSI",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/361256851",
       "fun_fact": "“Serenity” appears on Armin van Buuren’s release “The Best Of Armin Only”.",
@@ -1533,7 +1533,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1698794080"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=yLQvcRM17Es",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2395987955",
       "fun_fact": "“Save Me” appears on Anyma’s release “Genesys”.",
@@ -1557,7 +1557,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1457833015"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=9-klJ6EQfe8",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/655766662",
       "fun_fact": "“Mistaken (feat. Alex Aris)” is the title track of Martin Garrix’s release of the same name.",
@@ -1581,7 +1581,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1837319642"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=KSYj9a24LI8",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3538037341",
       "fun_fact": "“What’s a Girl to Do in ‘25” is the title track of KI/KI’s release of the same name.",
@@ -1601,7 +1601,7 @@
       "year": 2012,
       "isrc": "USUM71205604",
       "uri": "spotify:track:1dFkD1JfRMzwO6hwUsE8aS",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=IsuVMdnF8A0",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/60904698",
       "fun_fact": "“Spectrum” appears on Zedd’s release “Clarity”.",
@@ -1622,7 +1622,7 @@
       "year": 1999,
       "isrc": "NLF711203806",
       "uri": "spotify:track:05c4AAJKIulqI8vQQ41Rch",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=S7MNvol83_0",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/55074011",
       "fun_fact": "“Saltwater” is the title track of Chicane’s release of the same name.",
@@ -1647,7 +1647,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1359975221"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=S6FEEGcMTpw",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/452690842",
       "fun_fact": "“Revolution - Radio Mix” is the title track of R3HAB’s release of the same name.",
@@ -1671,7 +1671,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1440850856"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=yOLd4jl0uQ8",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/118585330",
       "fun_fact": "“Every Day” appears on Eric Prydz’s release “Opus”.",
@@ -1691,7 +1691,7 @@
       "year": 2012,
       "isrc": "NLE711209304",
       "uri": "spotify:track:27Aaj2wzCod19dAh0tlUim",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=IHR-LJmwOh4",
       "uri_tidal": null,
       "fun_fact": "“Blessed Avicii - Original Mix” appears on Tom Hangs’s release “Night & Day”.",
       "fun_fact_de": "„Blessed Avicii - Original Mix“ erschien auf der Veröffentlichung „Night & Day“ von Tom Hangs.",
@@ -1711,7 +1711,7 @@
       "year": 2018,
       "isrc": "DEQ201801712",
       "uri": "spotify:track:2mwptYSUenZkc1EL20HC30",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=rKbjo0u8X-Y",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/465085292",
       "fun_fact": "“Countach - Kölsch Remix” appears on Butch’s release “Countach”.",
@@ -1739,7 +1739,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1549278138"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=TxvpctgU_s8",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/6180078",
       "fun_fact": "“In And Out Of Love” is the title track of Armin van Buuren’s release of the same name.",
@@ -1763,7 +1763,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1713469227"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=cGi4hNgyhik",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/61142287",
       "fun_fact": "“We'll Be Coming Back (feat. Example)” appears on Calvin Harris’s release “18 Months”.",
@@ -1787,7 +1787,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1664887685"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=lD8NxEVtfj4",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2106407067",
       "fun_fact": "“Wide Open - Len Faki DjEdit” appears on DJ Hyperactive’s release “Len Faki Dj-Edits Volume I”.",
@@ -1811,7 +1811,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1449911564"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=KE2SSftvFU4",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/623723282",
       "fun_fact": "“Piece Of Your Heart” is the title track of MEDUZA’s release of the same name.",
@@ -1831,7 +1831,7 @@
       "year": 2007,
       "isrc": "GBDUW0700005",
       "uri": "spotify:track:5RByQFt9Mlo8hDYJ921tCv",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=x84m3YyO2oU",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3167843",
       "fun_fact": "“Around the World / Harder, Better, Faster, Stronger” appears on Daft Punk’s release “Alive 2007”.",
@@ -1859,7 +1859,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1591302173"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=6mn7OonJfk4",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1527789262",
       "fun_fact": "“Human (feat. Echoes)” is the title track of John Summit’s release of the same name.",
@@ -1883,7 +1883,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1826684927"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=0rWBzZoQMP0",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3460217671",
       "fun_fact": "“A New Day (feat. Celine Dion)” is the title track of Sebastian Ingrosso’s release of the same name.",
@@ -1907,7 +1907,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1293887149"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=UWkvmq2euFE",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/415278692",
       "fun_fact": "“Silence - Tiësto's Big Room Remix” is the title track of Marshmello’s release of the same name.",
@@ -1931,7 +1931,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1473152283"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=hRgcgcTP7nM",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/716493872",
       "fun_fact": "“Solar System” appears on Sub Focus’s release “Solar System / Siren”.",
@@ -1955,7 +1955,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1694794890"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=rn9AQoI7mYU",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/445811862",
       "fun_fact": "“Lean On (feat. MØ & DJ Snake)” appears on Major Lazer’s release “Lean On (feat. MØ & DJ Snake) [Remixes]”.",
@@ -1979,7 +1979,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1581632203"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=S69w0zMW-A0",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1461868062",
       "fun_fact": "“Titanium (feat. Sia) - David Guetta & MORTEN Future Rave Remix” is the title track of David Guetta’s release of the same name.",
@@ -1999,7 +1999,7 @@
       "year": 2013,
       "isrc": "USUM71314696",
       "uri": "spotify:track:560bmVbJ73hE75bunZ8SNa",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=80kr8IgD0qo",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/79942806",
       "fun_fact": "“Stay The Night - Tiesto's Club Life Remix” appears on Zedd’s release “Clarity (Deluxe)”.",
@@ -2023,7 +2023,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1418775756"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=K4LfaSNod1E",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/534018462",
       "fun_fact": "“Dancing Alone” is the title track of Axwell /\\ Ingrosso’s release of the same name.",
@@ -2047,7 +2047,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/720113855"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=H6quPnsTnA8",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/28883331",
       "fun_fact": "“Allein” appears on Pryda’s release “Eric Prydz Presents Pryda”.",
@@ -2071,7 +2071,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1689611140"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=L0TvnWRSyr4",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2100102627",
       "fun_fact": "“We Are Your Friends - Justice Vs Simian” appears on Justice’s release “We Are Your Friends”.",
@@ -2095,7 +2095,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1350836690"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=LiflmgfHsHQ",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/463376132",
       "fun_fact": "“Virus (How About Now) - Radio Edit” is the title track of Martin Garrix’s release of the same name.",
@@ -2119,7 +2119,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1469397683"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=vAYFMqSoObk",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/717419402",
       "fun_fact": "“Never Be Alone (feat. Aloe Blacc)” is the title track of David Guetta’s release of the same name.",
@@ -2143,7 +2143,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1605320590"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=hUduPG3UuDc",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1564802172",
       "fun_fact": "“Free” appears on Third Party’s release “TOGETHER”.",
@@ -2167,7 +2167,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1677685964"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=L6fh2joR3Ws",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2206732877",
       "fun_fact": "“Be The One” is the title track of Eli Brown’s release of the same name.",
@@ -2187,7 +2187,7 @@
       "year": 2018,
       "isrc": "GBARL1702250",
       "uri": "spotify:track:3MkuFR7t25mu7Iscp6GGiV",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=pYwXhXuA3Hc",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/454539272",
       "fun_fact": "“Panic Room” is the title track of Au/Ra’s release of the same name.",
@@ -2215,7 +2215,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1826812710"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=JEmbyx8NLxA",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3443845841",
       "fun_fact": "“Blessings - Cassian Remix” is the title track of Calvin Harris’s release of the same name.",
@@ -2235,7 +2235,7 @@
       "year": 2009,
       "isrc": "GBTDG0900063",
       "uri": "spotify:track:5miifYL53idUsDxGKjICtb",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=zK1mLIeXwsQ",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3582295",
       "fun_fact": "“I Remember” is the title track of Kaskade’s release of the same name.",
@@ -2259,7 +2259,7 @@
       "year": 2011,
       "isrc": "GBAAA1100772",
       "uri": "spotify:track:38JE3O2HocFNvtljgtlNKv",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=fbafd6UV3w4",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/15666455",
       "fun_fact": "“Antidote - Radio Edit” appears on Swedish House Mafia’s release “Antidote”.",
@@ -2287,7 +2287,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1845364205"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=MVpVRAbfFsk",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2448991445",
       "fun_fact": "“ATOM” is the title track of Nari’s release of the same name.",
@@ -2311,7 +2311,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1464501310"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=zze_KSpeqTA",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1755239527",
       "fun_fact": "“Be My Love - DubVision Remix” is the title track of Syzz’s release of the same name.",
@@ -2331,7 +2331,7 @@
       "year": 2021,
       "isrc": "GBAHS2100041",
       "uri": "spotify:track:1t0Jmqg1pKVBbxjQFZebeR",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=yMJswjcD8Fg",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1239694902",
       "fun_fact": "“Marea (we’ve lost dancing)” is the title track of Fred again..’s release of the same name.",
@@ -2355,7 +2355,7 @@
       "year": 2012,
       "isrc": "GB55H1200001",
       "uri": "spotify:track:0FoSiffuAmaJ3VyPaebY6I",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=VnPTK6idYg4",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/139691215",
       "fun_fact": "“Midnight City - Eric Prydz Private Remix” is the title track of M83’s release of the same name.",
@@ -2383,7 +2383,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/726391227"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=YeLc_odK58s",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/62847161",
       "fun_fact": "“Metropolis” appears on David Guetta’s release “Nothing but the Beat (Ultimate Edition)”.",
@@ -2407,7 +2407,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1442749632"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=uZCm-MDZNYs",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/586878552",
       "fun_fact": "“Crazy - Tomorrowland Intro Mix” is the title track of Lost Frequencies’s release of the same name.",
@@ -2431,7 +2431,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1733734254"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=2FgdOaeIhOY",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2683369492",
       "fun_fact": "“Resurrection - Axwell's Recut Club Version” appears on Michael Calfan’s release “Yellow Productions: 20 Years of Music”.",
@@ -2455,7 +2455,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1712581135"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=sXQVicNodMw",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/67876796",
       "fun_fact": "“Atmosphere” is the title track of Kaskade’s release of the same name.",
@@ -2475,7 +2475,7 @@
       "year": 2019,
       "isrc": "USZ4V1900134",
       "uri": "spotify:track:54hA0ldJYyT1huGfSeOjdQ",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=018o0enjGOs",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/896516162",
       "fun_fact": "“On My Mind” is the title track of Diplo’s release of the same name.",
@@ -2499,7 +2499,7 @@
       "year": 2012,
       "isrc": "NLA321292385",
       "uri": "spotify:track:4YiEKrJuoZGGg3nzTJfONS",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=_M4YOS01r0I",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/56690851",
       "fun_fact": "“Superlove - Radio Edit” is the title track of Avicii’s release of the same name.",
@@ -2523,7 +2523,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1801470984"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=8JppHhLYEvM",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2874803522",
       "fun_fact": "“Superstring - Rank 1 Remix” appears on Cygnus X’s release “A State Of Trance Classics, Vol.4”.",
@@ -2547,7 +2547,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1869661185"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=wJnBTPUQS5A",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/401358872",
       "fun_fact": "“Spectre” appears on Alan Walker’s release “The Spectre”.",
@@ -2571,7 +2571,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1695245135"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=wTR-ScwmOXI",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2350357385",
       "fun_fact": "“Fine Day Anthem” is the title track of Skrillex’s release of the same name.",
@@ -2595,7 +2595,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1019172310"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=jrrYd1XPMy8",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/104051408",
       "fun_fact": "“Kidsos” is the title track of Sebastian Ingrosso’s release of the same name.",
@@ -2615,7 +2615,7 @@
       "year": 2016,
       "isrc": "NLZ541600800",
       "uri": "spotify:track:39cmB3ZoTOLwOTq7tMNqKa",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=JVpTp8IHdEg",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/452769552",
       "fun_fact": "“Hear Me Now” appears on Alok’s release “Hear Me Now (feat. Zeeba)”.",
@@ -2643,7 +2643,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1846320275"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=ka4WTFKkfH0",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3561841201",
       "fun_fact": "“⁠⁠Butterflies” is the title track of Martin Garrix’s release of the same name.",
@@ -2663,7 +2663,7 @@
       "year": 2004,
       "isrc": "GBHPU0400001",
       "uri": "spotify:track:4b9S5yZpvIVxMEuI0rHzk6",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=H6Sp0u7exPA",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/133124834",
       "fun_fact": "“Need To Feel Loved - Radio Edit” appears on Reflekt’s release “Need To Feel Loved”.",
@@ -2687,7 +2687,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1496030516"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=N7eIKwVd1jQ",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1704279827",
       "fun_fact": "“La Mezcla - Paul Kalkbrenner Remix” appears on Michel Cleis’s release “La Mezcla”.",
@@ -2711,7 +2711,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1642778289"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=xArAvLBveGU",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3578730711",
       "fun_fact": "“Heaven Takes You Home - SHM Remake” is the title track of Swedish House Mafia’s release of the same name.",
@@ -2731,7 +2731,7 @@
       "year": 1998,
       "isrc": "FR11Q9800000",
       "uri": "spotify:track:303ccTay2FiDTZ9fZ2AdBt",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Hf244LCkkLc",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/695110932",
       "fun_fact": "“Music Sounds Better With You” is the title track of Stardust’s release of the same name.",
@@ -2755,7 +2755,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1845780317"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=ox-htOfAEcc",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/73460580",
       "fun_fact": "“I Found U - Vocal Remode” appears on Axwell’s release “I Found U”.",
@@ -2779,7 +2779,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1409828465"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=BdJgwf-_HGY",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3785948322",
       "fun_fact": "“Rock It” appears on Sub Focus’s release “Sub Focus”.",
@@ -2799,7 +2799,7 @@
       "year": 2018,
       "isrc": "GBCEN1800173",
       "uri": "spotify:track:6TR0FGw4zhlGbQALN065AI",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=DKRcqtNSP-4",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/582260512",
       "fun_fact": "“Breathe” appears on CamelPhat’s release “Breathe (feat. Jem Cooke)”.",
@@ -2820,7 +2820,7 @@
       "year": 2011,
       "isrc": "USUS11100035",
       "uri": "spotify:track:16whkF55KgWqpNChzOQWB3",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=qHxlzcAPbBE",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/69295402",
       "fun_fact": "“Beautiful People - Radio Edit” appears on Chris Brown’s release “Electroman”.",
@@ -2845,7 +2845,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1441667873"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=UzPRso975PM",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/583588002",
       "fun_fact": "“Father Ocean - Ben Böhmer Remix” appears on Monolink’s release “Father Ocean”.",
@@ -2869,7 +2869,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1856647873"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=IZ36b3q1elI",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2282495317",
       "fun_fact": "“World Hold On (Children Of The Sky) - FISHER Rework” appears on Bob Sinclar’s release “Ibiza Fever 2023 by FG (Exclusive Mix By Bob Sinclar)”.",
@@ -2889,7 +2889,7 @@
       "year": 2017,
       "isrc": "SE5R71700140",
       "uri": "spotify:track:6Pgkp4qUoTmJIPn7ReaGxL",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=WRz2MxhAdJo",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/415561352",
       "fun_fact": "“Without You (feat. Sandro Cavazza)” appears on Avicii’s release “Without You (Remixes)”.",
@@ -2914,7 +2914,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1819867207"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=fiore9Z5iUg",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/91489286",
       "fun_fact": "“Prayer in C - Robin Schulz Remix” appears on Lilly Wood and The Prick’s release “Extended Prayer”.",
@@ -2938,7 +2938,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/6767141393"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=MveDLwDIZiI",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/4005834101",
       "fun_fact": "“Love Tonight (David Guetta Remix)” is the title track of Shouse’s release of the same name.",
@@ -2962,7 +2962,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1552918352"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=ORoAb5NPi8I",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1238536892",
       "fun_fact": "“Rise” is the title track of Lost Frequencies’s release of the same name.",
@@ -2986,7 +2986,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1702249021"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=tg00YEETFzg",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/113982292",
       "fun_fact": "“We Found Love” appears on Rihanna’s release “We Found Love (The Remixes)”.",
@@ -3010,7 +3010,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1742773929"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=HOs_atFaGJo",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2763260851",
       "fun_fact": "“Space Raiders - Charlotte de Witte Remix” is the title track of Eats Everything’s release of the same name.",
@@ -3034,7 +3034,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/976353585"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=nJSdYlAFKqA",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/96974184",
       "fun_fact": "“Don't Look Down (feat. Usher)” is the title track of Martin Garrix’s release of the same name.",
@@ -3054,7 +3054,7 @@
       "year": 2022,
       "isrc": "DEMW62200011",
       "uri": "spotify:track:39N9R61hAatOAIjBs2RH6z",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=A8AnzskwT-w",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1650021202",
       "fun_fact": "“Storm 2022” is the title track of Rebūke’s release of the same name.",
@@ -3078,7 +3078,7 @@
       "year": 2012,
       "isrc": "GBTDG1200437",
       "uri": "spotify:track:4ezalcKN0KnYuZiEw2jFgc",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=xvtNS6hbVy4",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/29183901",
       "fun_fact": "“The Veldt - Radio Edit” appears on deadmau5’s release “The Veldt”.",
@@ -3102,7 +3102,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/854518501"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Z8V5GfFeUDs",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/77403196",
       "fun_fact": "“Ping Pong” is the title track of Armin van Buuren’s release of the same name.",


### PR DESCRIPTION
A `provider-uri-backfill` run, driven automatically by `com.beatify.youtube-backfill`.

- `tomorrowland-top-1000` YouTube 46 -> **132**/825

**Draft on purpose** — merged only once the maintainer approves.