### PR TITLE
chore(release): v4.3.1-rc1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to Beatify are documented here. For detailed release notes, 
 
 ## [Unreleased]
 
+## [4.3.1-rc1] - 2026-08-23
+
+### Added
+- **Decade marks under the year slider (#2358).** Seventy-odd years of blank rail now carry labelled ticks, so the first drag lands near the target instead of somewhere to correct.
+- **The slider ends where the playlist ends (#2347).** Bounds follow the songs actually shipped in the selected playlist rather than a fixed range.
+- **The reason a game refuses to start reaches the host (#2295, #2309, #2302).** Twelve rejections collapsed into one generic message; each actionable failure now carries its own code, the admin screen shows which one fired, and the Mix tab keeps the server's reason instead of failing silently.
+
+### Fixed
+- **Only a genuinely lost session sends a player back to the join screen (#2353).** A brief network wobble used to force a mid-round rejoin.
+- **The submit button no longer stays greyed out when an answer does not get through (#2354).** It re-enables and says so, with time still on the clock.
+- **After a page reload the client believes the server about its own submission (#2355).**
+- **The round deadline applies to steal and sabotage (#2352).** Power-ups were slipping through after the clock ran out.
+- **The current answer is no longer readable from the status endpoint before the reveal (#2348).**
+- **Playback confirmation waits for the speaker to actually change tracks (#2349).** A round could otherwise run against a song nobody heard.
+
 ## [4.3.0] - 2026-08-21
 
 Released as **4.3.0** rather than 4.2.1: the work shipped as the `v4.2.1-rc1`…`rc3` release

--- a/custom_components/beatify/manifest.json
+++ b/custom_components/beatify/manifest.json
@@ -20,5 +20,5 @@
     "num2words==0.5.14"
   ],
   "single_config_entry": true,
-  "version": "4.3.0"
+  "version": "4.3.1-rc1"
 }

--- a/docs/release-notes-v4.3.1-rc1.md
+++ b/docs/release-notes-v4.3.1-rc1.md
@@ -1,0 +1,33 @@
+## 4.3.1-rc1 — Know Where You Are
+
+The year slider has been a blank rail since the first release: seventy-odd years with nothing to aim at, and no way to tell where 1985 was without dragging and reading the number. That changes here. Alongside it, the moments a round used to slip away from you — a lost connection, a button that stopped answering, a page that reloaded at the wrong second — and a clearer answer when the game refuses to start at all.
+
+### 🎚️ A slider you can actually read
+
+Decade marks now sit under the year slider, so your first movement lands near the right place instead of somewhere you then have to correct. The ends of the slider follow the music too: play a playlist that stops in 1995 and the slider stops there, instead of leaving you to drag across decades the playlist never reaches.
+
+### 📱 A hiccup no longer costs you the round
+
+A brief network wobble used to throw you back to the join screen mid-round, which meant rejoining while everyone waited. Now only a genuinely lost session does that — everything else keeps you where you are. The submit button no longer stays greyed out if your answer does not get through: it comes back and tells you, so you can try again with time still on the clock. And if your phone reloads the page, the game now shows you whether your guess actually landed rather than leaving you guessing about your own guess.
+
+### ⏱️ Nobody gets a free pass
+
+Steal and sabotage now respect the round deadline the same way an ordinary answer does — they were slipping through after the clock ran out. And the answer to the current song is no longer readable from the game's status page before the reveal.
+
+### 🚦 When the game will not start, you now find out why
+
+Twelve different reasons a game could refuse to start all arrived on the host screen as the same generic rejection, with the actual explanation thrown away on the way. The reason now reaches you — no playlist picked, or a playlist with nothing your music service can play — and the Mix tab does the same instead of failing silently.
+
+### 🔊 A song that did not start no longer counts as started
+
+Playback was sometimes taken as confirmed while the speaker was still on the previous track, which is how a round could run against a song nobody heard. Confirmation now waits for the speaker to genuinely change tracks.
+
+### 🙏 Thank you
+
+To everyone who plays Beatify and says when something feels wrong. Most of what is in this build came from watching a real round go sideways — a dim room, twelve seconds on the clock, one hand on the phone — which is the only place these things show up.
+
+---
+
+**58 playlists · 7,142 songs · 6 music platforms · 6 languages**
+
+[Report a Bug](https://github.com/mholzi/beatify/issues) · [Discussions](https://github.com/mholzi/beatify/discussions) · [Full Changelog](https://github.com/mholzi/beatify/blob/main/CHANGELOG.md)


### PR DESCRIPTION
Manifest 4.3.0 -> 4.3.1-rc1, a `[4.3.1-rc1]` changelog section, and the user-facing notes in `docs/release-notes-v4.3.1-rc1.md`.

## What players get

- **Decade marks under the year slider (#2358)** and slider ends that follow the selected playlist (#2347).
- **A hiccup no longer costs the round.** Only a genuinely lost session sends a player back to the join screen (#2353); the submit button re-enables when an answer does not get through (#2354); after a reload the client believes the server about its own submission (#2355).
- **The round deadline applies to steal and sabotage (#2352)**, and the current answer is no longer readable from the status endpoint before the reveal (#2348).
- **The reason a game refuses to start reaches the host (#2295, #2309, #2302).** Twelve rejections used to collapse into one generic message; the Mix tab keeps the server's reason too.
- **Playback confirmation waits for the speaker to actually change tracks (#2349).**

## Scope

41 commits landed since v4.3.0. Nine are player-facing and are listed above; the rest is catalog maintenance, backfill tooling and README work, which the pre-release notes rule excludes.

`docs/` is gitignored, so the notes file is force-added — the same trap that nearly lost earlier release candidates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016FybsxoKwCGDToatP3h5u9