### PR TITLE
chore(playlists): youtube backfill — +6 youtube uris

### DIFF
--- a/custom_components/beatify/playlists/community/musica-italiana.json
+++ b/custom_components/beatify/playlists/community/musica-italiana.json
@@ -1,7 +1,7 @@
 {
   "name": "Musica Italiana 🇮🇹",
   "description": "Italian classics from the 1960s to the 2000s — cantautori, Sanremo winners and the songs every Italian party sings along to. Merged from playlist requests #2228 and #2229.",
-  "version": "0.12",
+  "version": "0.13",
   "songs": [
     {
       "year": 1962,
@@ -1490,7 +1490,8 @@
       "fun_fact_it": "Raffaella Carrà - \"Ballo, ballo\" (1982), dal canone del pop italiano.",
       "isrc": "ES5151401337",
       "uri_apple_music": "applemusic://track/1692975052",
-      "uri_deezer": "deezer://track/2842211102"
+      "uri_deezer": "deezer://track/2842211102",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=zy5HBtuODGc"
     },
     {
       "year": 1982,
@@ -1509,7 +1510,8 @@
       "fun_fact_it": "Riccardo Cocciante - \"Celeste nostalgia\" (1982), dal canone del pop italiano.",
       "isrc": "ITB008100768",
       "uri_apple_music": "applemusic://track/254296736",
-      "uri_deezer": "deezer://track/13230004"
+      "uri_deezer": "deezer://track/13230004",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=irenHpLMNls"
     },
     {
       "year": 1982,
@@ -1547,7 +1549,8 @@
       "fun_fact_it": "Ricchi E Poveri - \"Mamma Maria\" (1982), dal canone del pop italiano.",
       "isrc": "DEC719400065",
       "uri_apple_music": "applemusic://track/252058369",
-      "uri_deezer": "deezer://track/636403"
+      "uri_deezer": "deezer://track/636403",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=X3nqLQoewB0"
     },
     {
       "year": 1982,

--- a/custom_components/beatify/playlists/community/tomorrowland-top-1000.json
+++ b/custom_components/beatify/playlists/community/tomorrowland-top-1000.json
@@ -1,6 +1,6 @@
 {
   "name": "Tomorrowland Top 1000",
-  "version": "0.16",
+  "version": "0.20",
   "tags": [
     "edm",
     "electronic",
@@ -3270,7 +3270,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/397347361"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=FspennuvEoY",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/68788691",
       "fun_fact": "“Loreley” appears on Kölsch’s release “1977”.",
@@ -3290,7 +3290,7 @@
       "year": 2019,
       "isrc": "NLF711909188",
       "uri": "spotify:track:6ToupFpZbiTiRGEF2vVuzU",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=juk-DPtSY4M",
       "uri_tidal": null,
       "fun_fact": "“Arcade - Radio Edit” appears on Dimitri Vegas & Like Mike’s release “The Best Of Armin Only (Live from the Johan Cruijff ArenA - Amsterdam, The Netherlands) [Highlights]”.",
       "fun_fact_de": "„Arcade - Radio Edit“ erschien auf der Veröffentlichung „The Best Of Armin Only (Live from the Johan Cruijff ArenA - Amsterdam, The Netherlands) [Highlights]“ von Dimitri Vegas & Like Mike.",
@@ -3311,7 +3311,7 @@
       "year": 2017,
       "isrc": "USQX91700865",
       "uri": "spotify:track:50RJdoxw8iajGNtHQe6QeS",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=5MenFU9qCzs",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/353595051",
       "fun_fact": "“Something Just Like This - Alesso Remix” appears on The Chainsmokers’s release “Something Just Like This (Remixes)”.",
@@ -3335,7 +3335,7 @@
       "year": 2006,
       "isrc": "UKGGD0600001",
       "uri": "spotify:track:45AQPAds44enlvxkLsb8Q1",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=PgxAz3kzEb0",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2528278871",
       "fun_fact": "“We Do What We Want” is the title track of Alan Fitzpatrick’s release of the same name.",
@@ -3363,7 +3363,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1440872944"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=2GADx4Hy-Gg",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/70266757",
       "fun_fact": "“You Make Me” appears on Avicii’s release “True”.",
@@ -3383,7 +3383,7 @@
       "year": 2013,
       "isrc": "USUS11201499",
       "uri": "spotify:track:75f4fO9adbAYJqNBKJNrxs",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=gl2p4G3CUrI",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/70227575",
       "fun_fact": "“Boneless” appears on Steve Aoki’s release “Boneless (Remixes)”.",
@@ -3407,7 +3407,7 @@
       "year": 2011,
       "isrc": "GB28K1100136",
       "uri": "spotify:track:0V6J3G6SyYGQzzLUSAlAKe",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=jUe8uoKdHao",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/14243670",
       "fun_fact": "“Without You (feat. Usher) - Radio Edit” appears on David Guetta’s release “Without You (feat. Usher) (Remixes)”.",
@@ -3432,7 +3432,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/669550227"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=NE2AvbROl5k",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/129619816",
       "fun_fact": "“Exploration of Space” appears on Cosmic Gate’s release “DJ Central: Vol. 19”.",
@@ -3500,7 +3500,7 @@
       "year": 2024,
       "isrc": "DECE72402874",
       "uri": "spotify:track:5nPbKG04fhLkIAjcPFaZq7",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Mf_pvNkNJjk",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3151230551",
       "fun_fact": "“I Adore You (feat. Daecolm)” appears on HUGEL’s release “I Adore You (ARTBAT Remix)”.",
@@ -3552,7 +3552,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/626193146"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=wOgbvXwmIvU",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1806142637",
       "fun_fact": "“Let It Go - Axwell Remix” appears on Dirty South’s release “Let It Go”.",
@@ -3668,7 +3668,7 @@
       "year": 2017,
       "isrc": "GBAHT1700474",
       "uri": "spotify:track:5wLJkvV083MxvW47AJnyHt",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=KN13RV_HmQw",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/376386131",
       "fun_fact": "“More Than Friends (feat. Kelli-Leigh) - VIP Mix” appears on James Hype’s release “More Than Friends (feat. Kelli-Leigh)”.",
@@ -3744,7 +3744,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1440877826"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=R6DyPsCXxIk",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1103289",
       "fun_fact": "“Mr. Brightside - Jacques Lu Cont's Thin White Duke Mix” appears on The Killers’s release “Sawdust”.",
@@ -3768,7 +3768,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1336548866"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=gc0SJozzt9U",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/452689462",
       "fun_fact": "“Raise Your Hands - Radio Edit” is the title track of Ummet Ozcan’s release of the same name.",
@@ -3816,7 +3816,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1443846750"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=n18g4bRJDCY",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/599043162",
       "fun_fact": "“Wait Another Day” is the title track of Mike Williams’s release of the same name.",
@@ -3840,7 +3840,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1872667788"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=xsgH2jUTuyY",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3808514882",
       "fun_fact": "“Breather” appears on CHRIS STASSY’s release “Get Together”.",
@@ -4116,7 +4116,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/948391884"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=fC8o2GcXgqo",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/93706216",
       "fun_fact": "“SLVR” is the title track of Steve Angello’s release of the same name.",
@@ -4256,7 +4256,7 @@
       "year": 2018,
       "isrc": "NLQ8D1700571",
       "uri": "spotify:track:0g7r4J268kF71T7ChFu8kI",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=4IHDZ4_8oN0",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1755322927",
       "fun_fact": "“Bigroom Never Dies” is the title track of Hardwell’s release of the same name.",
@@ -4377,7 +4377,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/292412010"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=KgSJyw8nNhs",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/97361580",
       "fun_fact": "“Strange World” appears on Push’s release “Trance Top 1000 - Selection 003”.",

--- a/custom_components/beatify/playlists/community/tomorrowland-top-1000.json
+++ b/custom_components/beatify/playlists/community/tomorrowland-top-1000.json
@@ -1,6 +1,6 @@
 {
   "name": "Tomorrowland Top 1000",
-  "version": "0.15",
+  "version": "0.16",
   "tags": [
     "edm",
     "electronic",
@@ -3126,7 +3126,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1489463484"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=WeUCoSaE2Yk",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/822440172",
       "fun_fact": "“Fades Away - Tribute Concert Version” is the title track of Avicii’s release of the same name.",
@@ -3150,7 +3150,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1440769957"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=s1MOYA6mOsU",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/6994173",
       "fun_fact": "“Te Quiero - Paul Kalkbrenner Remix” appears on Stromae’s release “Te Quiero (German Remixes)”.",
@@ -3174,7 +3174,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1658061260"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=psSIJig_xnY",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2054381447",
       "fun_fact": "“What You Say?” is the title track of Young Marco’s release of the same name.",
@@ -3198,7 +3198,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/646134057"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=wNRXFqh36oo",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/67239290",
       "fun_fact": "“Alive - Hardwell Remix” is the title track of Krewella’s release of the same name.",
@@ -3222,7 +3222,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/407539791"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=m0z7MkHIR0c",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/61682328",
       "fun_fact": "“Simulated” is the title track of Marco V’s release of the same name.",
@@ -3242,7 +3242,7 @@
       "year": 2024,
       "isrc": "USUG12405837",
       "uri": "spotify:track:5a2Mb0OPY17zkS8FnciQhg",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=OuMHgqXjM7E",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2959712811",
       "fun_fact": "“Finally” is the title track of Swedish House Mafia’s release of the same name.",


### PR DESCRIPTION
A `provider-uri-backfill` run, driven automatically by `com.beatify.youtube-backfill`.

- `tomorrowland-top-1000` YouTube 132 -> **138**/825

**Draft on purpose** — merged only once the maintainer approves.