### PR TITLE
data: fix 2 dead YouTube Music URIs in 100-greatest-rock-songs (#2362)

### DIFF
--- a/custom_components/beatify/playlists/community/100-greatest-rock-songs.json
+++ b/custom_components/beatify/playlists/community/100-greatest-rock-songs.json
@@ -1,6 +1,6 @@
 {
   "name": "100 Greatest Rock Songs",
-  "version": "0.13",
+  "version": "0.14",
   "tags": [
     "rock",
     "classic-rock",
@@ -514,7 +514,7 @@
       "fun_fact_de": "Die Bedeutung von Hotel California wird seit Jahrzehnten diskutiert. Bandmitglieder haben es weniger als konkreten Ort beschrieben, sondern eher als Metapher für den Exzess der südkalifornischen Musikindustrie der 1970er Jahre.",
       "fun_fact_es": "El significado de Hotel California se ha debatido durante décadas. Los miembros de la banda la han descrito menos como un lugar literal y más como una metáfora del exceso de la industria musical del sur de California en los años setenta.",
       "uri_apple_music": "applemusic://track/635770202",
-      "uri_youtube_music": "https://music.youtube.com/watch?v=AIRikU5K1cQ",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=dLl4PZtxia8",
       "uri_tidal": "tidal://track/20767339",
       "fun_fact_fr": "Le sens de Hotel California est débattu depuis des décennies. Les membres du groupe l'ont décrite non pas comme un lieu réel, mais plutôt comme une métaphore des excès de l'industrie musicale du sud de la Californie dans les années 1970.",
       "uri_deezer": "deezer://track/426703682",
@@ -3372,7 +3372,7 @@
       "fun_fact_es": "«Ace of Spades», de Motörhead, se publicó originalmente en 1980; el año se basa en datos de grabación y publicación contrastados.",
       "fun_fact_fr": "« Ace of Spades » de Motörhead est sorti à l’origine en 1980 ; l’année repose sur des métadonnées d’enregistrement et de parution recoupées.",
       "uri_apple_music": "applemusic://track/1439443121",
-      "uri_youtube_music": "https://music.youtube.com/watch?v=pWB5JZRGl0U",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=PMavhk16FJU",
       "uri_tidal": "tidal://track/4085852",
       "fun_fact_nl": "“Ace of Spades” van Motörhead verscheen oorspronkelijk in 1980; het jaar is gebaseerd op gecontroleerde opname- en uitgavegegevens.",
       "awards_nl": [


### PR DESCRIPTION
Closes #2362. Replaced 2 dead YouTube Music URIs and bumped playlist version to 0.14.

- Eagles "Hotel California": replaced removed video with Official Audio (`dLl4PZtxia8`)
- Motörhead "Ace of Spades": replaced 403-private video with Official Audio (`PMavhk16FJU`)