### PR TITLE
Let Music Assistant resolve Tidal tracks by name when no URI works

### DIFF
--- a/custom_components/beatify/services/media_player.py
+++ b/custom_components/beatify/services/media_player.py
@@ -6,6 +6,7 @@ import asyncio
 import hashlib
 import hmac
 import logging
+import re
 import secrets
 from asyncio import timeout as async_timeout
 from datetime import datetime, timezone
@@ -135,6 +136,59 @@ MA_QUEUE_RESTORE_POLL = 0.25
 # appearing in the speaker's media_artist. The unbounded "any new title"
 # acceptance is reserved for the post-timeout #345 branch, where it is logged.
 _TITLE_TOKEN_MIN_LEN = 3
+
+# Providers whose missing/failed URI may be retried by asking Music Assistant to
+# resolve the track from name + artist. `ma_library` has done this since the
+# Crate Digger work; `tidal` joins because its URIs can no longer be refreshed —
+# Odesli's public API, the only source they ever came from, was retired on
+# 2026-07-31 and now answers 401.
+_NAME_FALLBACK_PROVIDERS = frozenset({"ma_library", "tidal"})
+
+# Words that mark a *different recording of the same song*. A name search is
+# free to return any of them, which is exactly the risk this fallback carries:
+# measured against ~2000 catalogue tracks with a known Deezer id, a plain
+# "artist title" search returned the wrong edition for 2 % of mainstream tracks
+# but 19 % of EDM ones ("Satisfaction" → "Satisfaction (Uk Radio Edit)",
+# "Scary Monsters and Nice Sprites" → "… (Zedd Remix)").
+#
+# `_titles_plausibly_match` does NOT catch these: it accepts a normalized
+# prefix, and the expected title is always a prefix of its own remix. That
+# leniency is deliberate and load-bearing for #1381 ("Das Modell" vs "The
+# Model"), so it stays — the stricter check below is applied only on the name
+# fallback path, where the extra risk actually lives.
+_EDITION_MARKERS = re.compile(
+    r"\b("
+    r"radio edit|extended|club mix|original mix|dub mix|"
+    r"remix|re-?edit|mixed|karaoke|instrumental|acapella|a cappella|"
+    r"acoustic|unplugged|live|demo|cover|tribute|playback|"
+    r"edit|mix|version"
+    r")\b",
+    re.IGNORECASE,
+)
+
+
+def _edition_markers(text: str) -> set[str]:
+    """Edition words present in a title, lower-cased."""
+    return {m.group(0).lower() for m in _EDITION_MARKERS.finditer(text or "")}
+
+
+def _edition_matches(expected_title: str, played_title: str) -> bool:
+    """False when the played title carries an edition the expected title lacks.
+
+    Deliberately one-directional. A catalogue entry named "Waves - Robin Schulz
+    Radio Edit" may legitimately play back as plain "Waves" (the provider drops
+    the suffix), so markers the *expected* side has are not required on the
+    played side. The reverse is the failure we are guarding against: plain
+    "Burn" must not be satisfied by "Burn (Aybsent Mynded Remix)".
+
+    This matters more for Beatify than it would for a music player. The game
+    asks players to guess the release *year*; a 2014 remix standing in for a
+    1998 original does not merely sound different, it makes the round's correct
+    answer wrong — and nothing on screen reveals that.
+    """
+    if not expected_title or not played_title:
+        return True
+    return not (_edition_markers(played_title) - _edition_markers(expected_title))
 
 
 def _normalize_for_match(text: str) -> str:
@@ -949,7 +1003,18 @@ class MediaPlayerService:
         self._stopped_for_cascade = False
 
         candidates = self._get_ma_uri_candidates(song)
-        if not candidates:
+        expected_title = song.get("title") or ""
+        expected_artist = song.get("artist") or ""
+
+        # The name fallback below needs both fields; without them there is
+        # nothing to search for and nothing to verify the result against.
+        name_fallback = bool(
+            self._provider in _NAME_FALLBACK_PROVIDERS
+            and expected_title
+            and expected_artist
+        )
+
+        if not candidates and not name_fallback:
             # #1276: surface the provider so a missing-URI miss is debuggable
             # (which provider was selected vs. which fields the song carries).
             _LOGGER.warning(
@@ -961,8 +1026,6 @@ class MediaPlayerService:
             self.last_failure_reason = "unavailable"
             return False
 
-        expected_title = song.get("title") or ""
-        expected_artist = song.get("artist") or ""
         if not expected_title:
             _LOGGER.warning(
                 "MA playback: no expected title — skipping title verification"
@@ -995,13 +1058,19 @@ class MediaPlayerService:
                 self.last_failure_reason = None
                 return True
 
-        # Library provider: the stored URI is normally exact, but the item may
-        # have moved/changed since the pool was built. Before giving up, let MA
-        # resolve by name+artist -- the confirmation machinery in _try_ma_play
-        # (expected-title matching) still guards against a wrong-track match.
-        if self._provider == "ma_library" and expected_title and expected_artist:
+        # Last resort: let MA resolve the track from name + artist.
+        #
+        # `ma_library`: the stored URI is normally exact, but the item may have
+        # moved or changed since the pool was built.
+        # `tidal`: the URI may be absent entirely and can no longer be obtained
+        # — Odesli, the only source Beatify ever had for Tidal ids, retired its
+        # public API on 2026-07-31. This path is a safety net *behind* the
+        # stored URIs, never a replacement for them: the loop above has already
+        # run, so a song that carries a working `uri_tidal` never reaches here.
+        if name_fallback:
             _LOGGER.info(
-                "MA library fallback: resolving by name -- %s - %s",
+                "MA name fallback (%s): resolving by name -- %s - %s",
+                self._provider,
                 expected_artist,
                 expected_title,
             )
@@ -1011,6 +1080,24 @@ class MediaPlayerService:
                 expected_artist,
                 artist_filter=expected_artist,
             ):
+                # A name search can land on a remix, a live take or a karaoke
+                # version of the right song. `_try_ma_play` will happily accept
+                # those (its title gate is a prefix/token check by design), so
+                # the edition is checked here instead.
+                state = self._safe_state()
+                played_title = (
+                    state.attributes.get("media_title", "") if state else ""
+                ) or ""
+                if not _edition_matches(expected_title, played_title):
+                    _LOGGER.warning(
+                        "MA name fallback: rejecting wrong edition — wanted %r, "
+                        "got %r (%s)",
+                        expected_title,
+                        played_title,
+                        expected_artist,
+                    )
+                    self.last_failure_reason = "wrong_track"
+                    return False
                 self.last_failure_reason = None
                 return True
 

--- a/tests/unit/test_library_regressions.py
+++ b/tests/unit/test_library_regressions.py
@@ -180,8 +180,17 @@ class TestPlaybackWiring:
         assert '"ma_library"' in src("services/media_player.py")
 
     def test_stale_uris_fall_back_to_a_name_lookup(self):
-        """Library item ids change when a library is rebuilt."""
-        assert "MA library fallback" in src("services/media_player.py")
+        """Library item ids change when a library is rebuilt.
+
+        The log line used to read "MA library fallback". It now reads
+        "MA name fallback (<provider>)" because Tidal shares the path, so this
+        asserts on the guard that actually decides whether the fallback runs
+        instead of on the wording of a log message.
+        """
+        code = src("services/media_player.py")
+        assert "_NAME_FALLBACK_PROVIDERS" in code
+        assert '"ma_library"' in code
+        assert "MA name fallback" in code
 
 
 class TestWizardIntegration:

--- a/tests/unit/test_tidal_name_fallback.py
+++ b/tests/unit/test_tidal_name_fallback.py
@@ -1,0 +1,199 @@
+"""Tidal name fallback: a safety net behind the stored URIs, not a replacement.
+
+Odesli retired its public API on 2026-07-31 — it was the only source Beatify
+ever had for Tidal ids, so a missing ``uri_tidal`` can no longer be filled. This
+lets Music Assistant resolve such a track from name + artist instead.
+
+The risk that buys is a *wrong edition*, and it is not hypothetical: measured
+against ~2000 catalogue tracks with a known Deezer id, a plain "artist title"
+search returned a different recording for 2 % of mainstream tracks and 19 % of
+the EDM ones. The cases in ``test_edition_gate_rejects_measured_failures`` are
+verbatim from that measurement.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.beatify.services.media_player import (
+    MediaPlayerService,
+    _edition_matches,
+)
+
+
+def _make_hass() -> MagicMock:
+    hass = MagicMock()
+    hass.services.async_call = AsyncMock()
+    hass.states.get = MagicMock(return_value=None)
+    return hass
+
+
+def _svc(provider: str) -> MediaPlayerService:
+    return MediaPlayerService(
+        _make_hass(),
+        "media_player.test",
+        platform="music_assistant",
+        provider=provider,
+    )
+
+
+def _playing(title: str, artist: str = "Artist") -> MagicMock:
+    state = MagicMock()
+    state.state = "playing"
+    state.attributes = {"media_title": title, "media_artist": artist}
+    return state
+
+
+# --------------------------------------------------------------- edition gate
+
+
+class TestEditionGate:
+    @pytest.mark.parametrize(
+        ("expected", "played"),
+        [
+            ("Satisfaction", "Satisfaction (Uk Radio Edit)"),
+            ("Booyah", "Booyah (Radio Edit)"),
+            (
+                "Scary Monsters and Nice Sprites",
+                "Scary Monsters and Nice Sprites (Zedd Remix)",
+            ),
+            ("Without You (feat. Usher)", "Without You (feat. Usher) (Extended)"),
+            ("Burn", "Burn [Ellie Goulding vs. Aybsent Mynded] (Aybsent Mynded Remix)"),
+            ("No Broke Boys", "No Broke Boys (Lee Foss Remix)"),
+            ("A-Ba-Ni-Bi", "A Ba Ni Bi (1978) - Karaoke Playback Avec Choeurs"),
+            ("Hotel California", "Hotel California - Live"),
+        ],
+    )
+    def test_edition_gate_rejects_measured_failures(self, expected, played):
+        """Every one of these came back from a real "artist title" search."""
+        assert _edition_matches(expected, played) is False
+
+    @pytest.mark.parametrize(
+        ("expected", "played"),
+        [
+            # The provider dropping a suffix we carry is fine — the gate is
+            # deliberately one-directional.
+            ("Waves - Robin Schulz Radio Edit", "Waves"),
+            ("Waves - Robin Schulz Radio Edit", "Waves (Robin Schulz Radio Edit)"),
+            ("Ghosts 'n' Stuff (feat. Rob Swire)", "Ghosts 'n' Stuff"),
+            # #1381 must keep working: a translated title shares no tokens and
+            # carries no edition marker.
+            ("Das Modell", "The Model"),
+            # A remaster is the same recording, not a different edition.
+            ("Bohemian Rhapsody", "Bohemian Rhapsody - Remastered 2011"),
+            ("Satisfaction", "Satisfaction"),
+        ],
+    )
+    def test_edition_gate_passes_legitimate_titles(self, expected, played):
+        assert _edition_matches(expected, played) is True
+
+    def test_missing_titles_do_not_reject(self):
+        """Nothing to compare is not evidence of a wrong edition."""
+        assert _edition_matches("", "anything") is True
+        assert _edition_matches("Satisfaction", "") is True
+
+
+# ------------------------------------------------------------- fallback wiring
+
+
+class TestTidalNameFallback:
+    @pytest.mark.asyncio
+    async def test_stored_uri_wins_and_fallback_never_runs(self):
+        """The whole point: this is a net *behind* the URIs, not instead of them."""
+        svc = _svc("tidal")
+        song = {
+            "title": "Song",
+            "artist": "Artist",
+            "uri_tidal": "tidal://track/12345",
+        }
+        calls: list[str] = []
+
+        async def fake_try(uri, expected_title, expected_artist="", artist_filter=None):
+            calls.append(uri)
+            return True
+
+        with patch.object(svc, "_try_ma_play", side_effect=fake_try):
+            assert await svc._play_via_music_assistant(song) is True
+
+        # The stored id is normalised to a browse URL on the way out; what
+        # matters is that exactly one call happened and it was not the name.
+        assert len(calls) == 1
+        assert "999" not in calls[0] and calls[0] != "Song"
+        assert "12345" in calls[0]
+
+    @pytest.mark.asyncio
+    async def test_missing_uri_reaches_the_fallback(self):
+        """Without the fallback this returned False before trying anything."""
+        svc = _svc("tidal")
+        svc._hass.states.get = MagicMock(return_value=_playing("Song"))
+        song = {"title": "Song", "artist": "Artist"}
+        calls: list[str] = []
+
+        async def fake_try(uri, expected_title, expected_artist="", artist_filter=None):
+            calls.append(uri)
+            return True
+
+        with patch.object(svc, "_try_ma_play", side_effect=fake_try):
+            assert await svc._play_via_music_assistant(song) is True
+
+        assert calls == ["Song"]
+
+    @pytest.mark.asyncio
+    async def test_fallback_runs_after_a_dead_uri(self):
+        svc = _svc("tidal")
+        svc._hass.states.get = MagicMock(return_value=_playing("Song"))
+        song = {"title": "Song", "artist": "Artist", "uri_tidal": "tidal://track/999"}
+        calls: list[str] = []
+
+        async def fake_try(uri, expected_title, expected_artist="", artist_filter=None):
+            calls.append(uri)
+            return uri == "Song"  # the stored URI is dead, the name works
+
+        with patch.object(svc, "_try_ma_play", side_effect=fake_try):
+            assert await svc._play_via_music_assistant(song) is True
+
+        assert len(calls) == 2
+        assert "999" in calls[0]  # stored URI first, normalised to a browse URL
+        assert calls[1] == "Song"  # then, and only then, the name
+
+    @pytest.mark.asyncio
+    async def test_wrong_edition_is_rejected_even_though_ma_accepted_it(self):
+        """`_try_ma_play` says yes — its title gate accepts a prefix. We say no."""
+        svc = _svc("tidal")
+        svc._hass.states.get = MagicMock(
+            return_value=_playing("Satisfaction (Uk Radio Edit)")
+        )
+        song = {"title": "Satisfaction", "artist": "Benny Benassi"}
+
+        with patch.object(svc, "_try_ma_play", AsyncMock(return_value=True)):
+            assert await svc._play_via_music_assistant(song) is False
+
+        assert svc.last_failure_reason == "wrong_track"
+
+    @pytest.mark.asyncio
+    async def test_other_providers_keep_the_old_hard_failure(self):
+        """Only ma_library and tidal opt in; Spotify must not start guessing."""
+        svc = _svc("spotify")
+        song = {"title": "Song", "artist": "Artist"}
+        try_ma = AsyncMock(return_value=True)
+
+        with patch.object(svc, "_try_ma_play", try_ma):
+            assert await svc._play_via_music_assistant(song) is False
+
+        try_ma.assert_not_called()
+        assert svc.last_failure_reason == "unavailable"
+
+    @pytest.mark.asyncio
+    async def test_no_artist_means_no_fallback(self):
+        """A name search needs both halves, and so does verifying its answer."""
+        svc = _svc("tidal")
+        song = {"title": "Song"}
+        try_ma = AsyncMock(return_value=True)
+
+        with patch.object(svc, "_try_ma_play", try_ma):
+            assert await svc._play_via_music_assistant(song) is False
+
+        try_ma.assert_not_called()
+        assert svc.last_failure_reason == "unavailable"


### PR DESCRIPTION
## Why

Odesli retired its public API on **2026-07-31** — `api.song.link` now answers `401 PUBLIC_API_ACCESS_DEPRECATED`, and the docs confirm keys are no longer handed out. It was the only source Beatify ever had for Tidal ids, so a missing `uri_tidal` can no longer be filled by the backfill. **1063 catalogue gaps are permanently unreachable that way.**

Music Assistant can resolve a track from name + artist, and already does for `ma_library`. This extends that path to `tidal`.

## What this is, and what it is not

It is a net **behind** the stored URIs. The candidate loop runs first, so a song with a working `uri_tidal` never reaches the fallback — the existing 5942 Tidal URIs keep their precedence, because they are more precise than any search. Only `ma_library` and `tidal` opt in; every other provider keeps today's hard failure.

## The non-obvious part

The early return for an empty candidate list had to yield to the fallback. Without that change the new path could **never fire**: a Tidal song without a URI has no candidates at all and returned before reaching it.

## The risk, measured rather than assumed

A name search can land on a remix, a live take or a karaoke version. `_titles_plausibly_match` does not catch that — it accepts a normalized prefix, and a title is always a prefix of its own remix. That leniency is load-bearing for #1381 (`Das Modell` vs `The Model`), so it stays; a stricter, one-directional edition check runs on the fallback path only.

How big the risk actually is was measured against ~2000 catalogue tracks with a known Deezer id — same question, and Deezer can be searched without a key:

| sample (60 each) | right recording | wrong title | not found |
|---|---|---|---|
| across the main playlists | **98.3 %** | 1 | 0 |
| `community/edm-anthems` | **81.0 %** | 11 | 2 |

**The risk is a function of genre, not a single number** — roughly 2 % for pop and rock, 19 % for EDM. Every rejection case in the new tests is verbatim from that measurement: `Satisfaction` → `Satisfaction (Uk Radio Edit)`, `Scary Monsters and Nice Sprites` → `… (Zedd Remix)`, `Without You (feat. Usher)` → `… (Extended)`.

This matters more here than it would in a music player. The game asks players to guess the release **year**, so a 2014 remix standing in for a 1998 original does not merely sound different — it makes the round's correct answer wrong, and nothing on screen reveals that.

## Tests

21 new tests in `tests/unit/test_tidal_name_fallback.py`. Per the house rule they were run against the **unpatched** code first: the three behaviour tests fail on `origin/main` and pass here; the three guard tests pass on both, which is what they are for. The 134 existing media-player tests stay green.

## Known gap, deliberately left

`ma_library` has the same wrong-edition exposure and does **not** get the new check — changing its behaviour is out of scope for this PR. Worth a follow-up.

## Why draft

The measurement above says the fallback will occasionally hand a player the wrong edition of the right song. That trade — a round that plays *something* instead of failing outright — is a product decision, not a technical one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012W9Pj7vqs7Yv31j19B4vRt
