### PR TITLE
chore(release): v4.3.1-rc2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to Beatify are documented here. For detailed release notes, 
 
 ## [Unreleased]
 
+## [4.3.1-rc2] - 2026-08-23
+
+### Added
+- **Music Assistant resolves a Tidal track by name when no URI works (#2364).** Odesli's public API was retired on 2026-07-31 and was the only source Beatify had for Tidal ids, so a missing `uri_tidal` can no longer be filled. The name lookup runs strictly *behind* the stored URIs, with an edition check that rejects a remix, live take or karaoke version standing in for the recording asked for.
+
+### Fixed
+- **The start-failure banner docks above the footer instead of inside it (#2365).** Anchoring on the Start button put the banner into `.home-cta-bar`, a flex row, where it was squeezed to its min-content width and wrapped one character per line on a phone.
+
 ## [4.3.1-rc1] - 2026-08-23
 
 ### Added

--- a/custom_components/beatify/manifest.json
+++ b/custom_components/beatify/manifest.json
@@ -20,5 +20,5 @@
     "num2words==0.5.14"
   ],
   "single_config_entry": true,
-  "version": "4.3.1-rc1"
+  "version": "4.3.1-rc2"
 }

--- a/docs/release-notes-v4.3.1-rc2.md
+++ b/docs/release-notes-v4.3.1-rc2.md
@@ -1,0 +1,37 @@
+## 4.3.1-rc2 — Know Where You Are
+
+The year slider has been a blank rail since the first release: seventy-odd years with nothing to aim at, and no way to tell where 1985 was without dragging and reading the number. That changes here. Alongside it, the moments a round used to slip away from you — a lost connection, a button that stopped answering, a page that reloaded at the wrong second — and a clearer answer when the game refuses to start at all.
+
+### 🎚️ A slider you can actually read
+
+Decade marks now sit under the year slider, so your first movement lands near the right place instead of somewhere you then have to correct. The ends of the slider follow the music too: play a playlist that stops in 1995 and the slider stops there, instead of leaving you to drag across decades the playlist never reaches.
+
+### 📱 A hiccup no longer costs you the round
+
+A brief network wobble used to throw you back to the join screen mid-round, which meant rejoining while everyone waited. Now only a genuinely lost session does that — everything else keeps you where you are. The submit button no longer stays greyed out if your answer does not get through: it comes back and tells you, so you can try again with time still on the clock. And if your phone reloads the page, the game now shows you whether your guess actually landed rather than leaving you guessing about your own guess.
+
+### ⏱️ Nobody gets a free pass
+
+Steal and sabotage now respect the round deadline the same way an ordinary answer does — they were slipping through after the clock ran out. And the answer to the current song is no longer readable from the game's status page before the reveal.
+
+### 🚦 When the game will not start, you now find out why
+
+Twelve different reasons a game could refuse to start all arrived on the host screen as the same generic rejection, with the actual explanation thrown away on the way. The reason now reaches you — no playlist picked, or a playlist with nothing your music service can play — and the Mix tab does the same instead of failing silently. On a phone that message is now laid out properly above the buttons, rather than squeezed into the row beside them where it broke apart mid-word.
+
+### 🎧 Fewer songs quietly skipped on Tidal
+
+If a song in the catalogue has no stored Tidal link, Beatify now asks Music Assistant to find it by name before giving up. Rounds that used to be skipped outright have a second chance to play.
+
+### 🔊 A song that did not start no longer counts as started
+
+Playback was sometimes taken as confirmed while the speaker was still on the previous track, which is how a round could run against a song nobody heard. Confirmation now waits for the speaker to genuinely change tracks.
+
+### 🙏 Thank you
+
+To everyone who plays Beatify and says when something feels wrong. Most of what is in this build came from watching a real round go sideways — a dim room, twelve seconds on the clock, one hand on the phone — which is the only place these things show up.
+
+---
+
+**58 playlists · 7,142 songs · 6 music platforms · 6 languages**
+
+[Report a Bug](https://github.com/mholzi/beatify/issues) · [Discussions](https://github.com/mholzi/beatify/discussions) · [Full Changelog](https://github.com/mholzi/beatify/blob/main/CHANGELOG.md)


### PR DESCRIPTION
Cuts **v4.3.1-rc2**.

- `manifest.json` → `4.3.1-rc2`
- `CHANGELOG.md` gets the entry for what landed since the previous build
- `docs/release-notes-v4.3.1-rc2.md` — the pre-release notes

## What is in this build that was not in the last tag

- **Music Assistant resolves a Tidal track by name when no URI works** (#2364)
- **The start-failure banner docks above the footer instead of inside it** (#2365 / #2366)

The two dead YouTube links repaired in #2362 are catalogue maintenance and stay out of the user-facing notes, as pre-release notes always do.

## Note for the reviewer

The notes file is **force-added**: `docs/` is in `.gitignore`, and every previous release-notes file is tracked the same way. Without `-f` the release would have shipped with no notes in the repo and nothing would have complained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012W9Pj7vqs7Yv31j19B4vRt
